### PR TITLE
es: Format /web/javascript using Prettier (part 4)

### DIFF
--- a/files/es/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -24,11 +24,11 @@ class CustomReplacer {
     this.value = value;
   }
   [Symbol.replace](string) {
-    return string.replace(this.value, '#!@?');
+    return string.replace(this.value, "#!@?");
   }
 }
 
-console.log('football'.replace(new CustomReplacer('foo')));
+console.log("football".replace(new CustomReplacer("foo")));
 // salida esperada: "#!@?tball"
 ```
 

--- a/files/es/web/javascript/reference/global_objects/symbol/search/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/search/index.md
@@ -28,7 +28,7 @@ class caseInsensitiveSearch {
   }
 }
 
-console.log('foobar'.search(new caseInsensitiveSearch('BaR')));
+console.log("foobar".search(new caseInsensitiveSearch("BaR")));
 // resultado esperado: 3
 ```
 

--- a/files/es/web/javascript/reference/global_objects/symbol/species/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/species/index.md
@@ -27,13 +27,15 @@ Es posible que quieras devolver objetos {{jsxref("Array")}} en tu clase array de
 ```js
 class MyArray extends Array {
   // Sobrescribir especies al constructor de la matriz Array
-  static get [Symbol.species]() { return Array; }
+  static get [Symbol.species]() {
+    return Array;
+  }
 }
-let a = new MyArray(1,2,3);
+let a = new MyArray(1, 2, 3);
 let mapped = a.map((x) => x * x);
 
 console.log(mapped instanceof MyArray); // false
-console.log(mapped instanceof Array);   // true
+console.log(mapped instanceof Array); // true
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/symbol/split/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/split/index.md
@@ -21,12 +21,12 @@ Para más información, véase {{jsxref("RegExp.@@split", "RegExp.prototype[@@sp
 ```js
 class ReverseSplit {
   [Symbol.split](string) {
-    const array = string.split(' ');
+    const array = string.split(" ");
     return array.reverse();
   }
 }
 
-console.log('Another one bites the dust'.split(new ReverseSplit()));
+console.log("Another one bites the dust".split(new ReverseSplit()));
 // resultado esperado: [ "dust", "the", "bites", "one", "Another" ]
 ```
 

--- a/files/es/web/javascript/reference/global_objects/symbol/symbol/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/symbol/index.md
@@ -15,8 +15,8 @@ El constructor `Symbol()` devuelve un valor de tipo **symbol**, pero está incom
 ## Sintaxis
 
 ```js
-Symbol()
-Symbol(description)
+Symbol();
+Symbol(description);
 ```
 
 ### Parámetros
@@ -31,15 +31,15 @@ Symbol(description)
 Para crear un nuevo símbolo primitivo, se escribe `Symbol()` con una cadena opcional como descripción:
 
 ```js
-let sym1 = Symbol()
-let sym2 = Symbol('foo')
-let sym3 = Symbol('foo')
+let sym1 = Symbol();
+let sym2 = Symbol("foo");
+let sym3 = Symbol("foo");
 ```
 
 El código anterior crea tres nuevos símbolos. Tenga en cuenta que `Symbol("foo")` no coacciona la cadena `"foo"` en un símbolo. Cada vez crea un nuevo símbolo:
 
 ```js
-Symbol('foo') === Symbol('foo')  // false
+Symbol("foo") === Symbol("foo"); // false
 ```
 
 ### new Symbol()
@@ -47,7 +47,7 @@ Symbol('foo') === Symbol('foo')  // false
 La siguiente sintaxis con el operador {{jsxref("Operators/new", "new")}} lanzará un {{jsxref("TypeError")}}:
 
 ```js
-let sym = new Symbol()  // TypeError
+let sym = new Symbol(); // TypeError
 ```
 
 Esto evita que los autores creen un objeto envolvente explícito `Symbol` en lugar de un nuevo valor de símbolo y podría ser sorprendente ya que la creación de objetos envolventes explícitos alrededor de tipos de datos primitivos es generalmente posible (por ejemplo, `new Boolean`, `new String` y `new Number`).
@@ -55,10 +55,10 @@ Esto evita que los autores creen un objeto envolvente explícito `Symbol` en lug
 Si realmente quieres crear un objeto envolvente `Symbol`, puedes utilizar la función `Object()`:
 
 ```js
-let sym    = Symbol('foo');
+let sym = Symbol("foo");
 let symObj = Object(sym);
-typeof sym    // => "symbol"
-typeof symObj // => "object"
+typeof sym; // => "symbol"
+typeof symObj; // => "object"
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/symbol/toprimitive/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/toprimitive/index.md
@@ -27,25 +27,25 @@ El siguiente ejemplo describe cómo la propiedad `Symbol.toPrimitive` puede modi
 ```js
 // Un objeto sin la propiedad Symbol.toPrimitive.
 const obj1 = {};
-console.log(+obj1);     // NaN
+console.log(+obj1); // NaN
 console.log(`${obj1}`); // "[object Object]"
-console.log(obj1 + ''); // "[object Object]"
+console.log(obj1 + ""); // "[object Object]"
 
 // Un objeto con la propiedad Symbol.toPrimitive.
 const obj2 = {
   [Symbol.toPrimitive](hint) {
-    if (hint === 'number') {
+    if (hint === "number") {
       return 10;
     }
-    if (hint === 'string') {
-      return 'hello';
+    if (hint === "string") {
+      return "hello";
     }
     return true;
-  }
+  },
 };
-console.log(+obj2);     // 10        — hint es "number"
+console.log(+obj2); // 10        — hint es "number"
 console.log(`${obj2}`); // "hello"   — hint es "string"
-console.log(obj2 + ''); // "true"    — hint es "default"
+console.log(obj2 + ""); // "true"    — hint es "default"
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/symbol/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/tostring/index.md
@@ -15,7 +15,7 @@ El método **`toString()`** devuelve una cadena que representa el objeto {{jsxre
 ## Sintaxis
 
 ```js
-toString()
+toString();
 ```
 
 ### Valor de retorno
@@ -31,7 +31,7 @@ El objeto {{jsxref("Symbol")}} reemplaza el método `toString` del objeto {{jsxr
 Aunque se puede llamar a `toString()` en los símbolos, no se puede utilizar la concatenación de cadenas con ellos:
 
 ```js
-Symbol('foo') + 'bar'        // TypeError: No se puede convertir el símbolo en cadena
+Symbol("foo") + "bar"; // TypeError: No se puede convertir el símbolo en cadena
 ```
 
 ## Ejemplos
@@ -39,13 +39,13 @@ Symbol('foo') + 'bar'        // TypeError: No se puede convertir el símbolo en 
 ### Usando toString()
 
 ```js
-Symbol('desc').toString()    // "Symbol(desc)"
+Symbol("desc").toString(); // "Symbol(desc)"
 
 // símbolos conocidos
-Symbol.iterator.toString()   // "Symbol(Symbol.iterator)
+Symbol.iterator.toString(); // "Symbol(Symbol.iterator)
 
 // símbolos globales
-Symbol.for('foo').toString() // "Symbol(foo)"
+Symbol.for("foo").toString(); // "Symbol(foo)"
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/symbol/tostringtag/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/tostringtag/index.md
@@ -17,19 +17,19 @@ El símbolo conocido como **`Symbol.toStringTag`** es una propiedad con valor de
 ### Etiquetas por defecto
 
 ```js
-Object.prototype.toString.call('foo');     // "[object String]"
-Object.prototype.toString.call([1, 2]);    // "[object Array]"
-Object.prototype.toString.call(3);         // "[object Number]"
-Object.prototype.toString.call(true);      // "[object Boolean]"
+Object.prototype.toString.call("foo"); // "[object String]"
+Object.prototype.toString.call([1, 2]); // "[object Array]"
+Object.prototype.toString.call(3); // "[object Number]"
+Object.prototype.toString.call(true); // "[object Boolean]"
 Object.prototype.toString.call(undefined); // "[object Undefined]"
-Object.prototype.toString.call(null);      // "[object Null]"
+Object.prototype.toString.call(null); // "[object Null]"
 // ... and more
 ```
 
 ### Símbolos toStringTag integrados
 
 ```js
-Object.prototype.toString.call(new Map());       // "[object Map]"
+Object.prototype.toString.call(new Map()); // "[object Map]"
 Object.prototype.toString.call(function* () {}); // "[object GeneratorFunction]"
 Object.prototype.toString.call(Promise.resolve()); // "[object Promise]"
 // ... and more
@@ -52,7 +52,7 @@ Ahora, con la ayuda de `toStringTag`, puede establecer su propia etiqueta person
 ```js
 class ValidatorClass {
   get [Symbol.toStringTag]() {
-    return 'Validator';
+    return "Validator";
   }
 }
 
@@ -64,9 +64,9 @@ Object.prototype.toString.call(new ValidatorClass()); // "[object Validator]"
 Debido a un [cambio en las especificaciones de WebIDL](https://github.com/whatwg/webidl/pull/357) a mediados de 2020, los navegadores están añadiendo una propiedad `Symbol.toStringTag` a todos los objetos prototipo del DOM. Por ejemplo, para acceder a la propiedad `Symbol.toStringTag` de {{domxref("HTMLButtonElement")}}:
 
 ```js
-let test = document.createElement('button');
+let test = document.createElement("button");
 test.toString(); // Devuelve [object HTMLButtonElement]
-test[Symbol.toStringTag];  // Devuelve HTMLButtonElement
+test[Symbol.toStringTag]; // Devuelve HTMLButtonElement
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/symbol/unscopables/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/unscopables/index.md
@@ -30,7 +30,7 @@ El siguiente código funciona bien en ES5 y posteriores. Sin embargo, en ECMAScr
 const keys = [];
 
 with (Array.prototype) {
-  keys.push('something');
+  keys.push("something");
 }
 
 Object.keys(Array.prototype[Symbol.unscopables]);
@@ -45,12 +45,12 @@ También puede establecer `unscopables` para sus propios objetos.
 ```js
 const obj = {
   foo: 1,
-  bar: 2
+  bar: 2,
 };
 
 obj[Symbol.unscopables] = {
   foo: false,
-  bar: true
+  bar: true,
 };
 
 with (obj) {

--- a/files/es/web/javascript/reference/global_objects/symbol/valueof/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/valueof/index.md
@@ -13,7 +13,7 @@ El método **`valueOf()`** devuelve el valor primitivo de un objeto Symbol.
 ## Sintaxis
 
 ```js
-valueOf()
+valueOf();
 ```
 
 ### Valor de retorno

--- a/files/es/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/es/web/javascript/reference/global_objects/typedarray/index.md
@@ -22,19 +22,19 @@ Al crear una instancia de `TypedArray` (p. ej., `Int8Array`), se crea un arreglo
 
 ### Objetos TypedArray
 
-| Tipo                                     | Intervalo de valores           | Tamaño en bytes | Descripción                                                                               | Tipo de IDL web           | Tipo C equivalente               |
-| ---------------------------------------- | ------------------------------ | --------------- | ----------------------------------------------------------------------------------------- | ------------------------- | -------------------------------- |
-| {{jsxref("Int8Array")}}         | `-128` a `127`                 | 1               | Dos enteros complementarios de 8 bits con signo                                           | `byte`                    | `int8_t`                         |
-| {{jsxref("Uint8Array")}}         | `0` a `255`                    | 1               | Entero de 8-bit sin signo                                                                 | `octet`                   | `uint8_t`                        |
-| {{jsxref("Uint8ClampedArray")}} | `0` a `255`                    | 1               | Entero de 8 bits sin signo (sujeto)                                                       | `octet`                   | `uint8_t`                        |
-| {{jsxref("Int16Array")}}         | `-32768` a `32767`             | 2               | Dos enteros complementarios de 16 bits con signo                                          | `short`                   | `int16_t`                        |
-| {{jsxref("Uint16Array")}}         | `0` a `65535`                  | 2               | Entero de 16 bits sin signo                                                               | `Short sin signo`         | `uint16_t`                       |
-| {{jsxref("Int32Array")}}         | `-2147483648` a `2147483647`   | 4               | dos enteros complementarios de 32 bits con signo                                          | `long`                    | `int32_t`                        |
-| {{jsxref("Uint32Array")}}         | `0` a `4294967295`             | 4               | Enteros de 32 bits sin signo                                                              | `long sin signo`          | `uint32_t`                       |
-| {{jsxref("Float32Array")}}     | `1.2`×`10^-38` a `3.4`×`10^38`   | 4               | Número de coma flotante IEEE de 32 bits (7 dígitos significativos, p. ej., `1.1234567`)   | `float sin restricciones` | `float`                          |
-| {{jsxref("Float64Array")}}     | `5.0`×`10^-324` a `1.8`×`10^308` | 8               | Número de coma flotante IEEE de 64 bits (16 dígitos significativos, p. Ej., `1.123...15`) | `doble sin restricciones` | `double`                         |
+| Tipo                            | Intervalo de valores             | Tamaño en bytes | Descripción                                                                               | Tipo de IDL web           | Tipo C equivalente               |
+| ------------------------------- | -------------------------------- | --------------- | ----------------------------------------------------------------------------------------- | ------------------------- | -------------------------------- |
+| {{jsxref("Int8Array")}}         | `-128` a `127`                   | 1               | Dos enteros complementarios de 8 bits con signo                                           | `byte`                    | `int8_t`                         |
+| {{jsxref("Uint8Array")}}        | `0` a `255`                      | 1               | Entero de 8-bit sin signo                                                                 | `octet`                   | `uint8_t`                        |
+| {{jsxref("Uint8ClampedArray")}} | `0` a `255`                      | 1               | Entero de 8 bits sin signo (sujeto)                                                       | `octet`                   | `uint8_t`                        |
+| {{jsxref("Int16Array")}}        | `-32768` a `32767`               | 2               | Dos enteros complementarios de 16 bits con signo                                          | `short`                   | `int16_t`                        |
+| {{jsxref("Uint16Array")}}       | `0` a `65535`                    | 2               | Entero de 16 bits sin signo                                                               | `Short sin signo`         | `uint16_t`                       |
+| {{jsxref("Int32Array")}}        | `-2147483648` a `2147483647`     | 4               | dos enteros complementarios de 32 bits con signo                                          | `long`                    | `int32_t`                        |
+| {{jsxref("Uint32Array")}}       | `0` a `4294967295`               | 4               | Enteros de 32 bits sin signo                                                              | `long sin signo`          | `uint32_t`                       |
+| {{jsxref("Float32Array")}}      | `1.2`×`10^-38` a `3.4`×`10^38`   | 4               | Número de coma flotante IEEE de 32 bits (7 dígitos significativos, p. ej., `1.1234567`)   | `float sin restricciones` | `float`                          |
+| {{jsxref("Float64Array")}}      | `5.0`×`10^-324` a `1.8`×`10^308` | 8               | Número de coma flotante IEEE de 64 bits (16 dígitos significativos, p. Ej., `1.123...15`) | `doble sin restricciones` | `double`                         |
 | {{jsxref("BigInt64Array")}}     | `-2^63` a `2^63-1`               | 8               | Dos enteros complementarios de 64 bits con signo                                          | `bigint`                  | `int64_t (long long con signo)`  |
-| {{jsxref("BigUint64Array")}}     | `0` a `2^64-1`                  | 8               | Entero de 64 bits sin signo                                                               | `bigint`                  | `uint64_t (long long sin signo)` |
+| {{jsxref("BigUint64Array")}}    | `0` a `2^64-1`                   | 8               | Entero de 64 bits sin signo                                                               | `bigint`                  | `uint64_t (long long sin signo)` |
 
 ## Constructor
 

--- a/files/es/web/javascript/reference/global_objects/typeerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/typeerror/index.md
@@ -41,15 +41,15 @@ Un `TypeError` puede ser lanzado cuando:
 
 ```js
 try {
-  null.f()
+  null.f();
 } catch (e) {
-  console.log(e instanceof TypeError)  // Respuesta: true
-  console.log(e.message)               // Respuesta: "null has no properties"
-  console.log(e.name)                  // Respuesta: "TypeError"
-  console.log(e.fileName)              // Respuesta: "Scratchpad/1"
-  console.log(e.lineNumber)            // Respuesta: 2
-  console.log(e.columnNumber)          // Respuesta: 2
-  console.log(e.stack)                 // Respuesta: "@Scratchpad/2:2:3\n"
+  console.log(e instanceof TypeError); // Respuesta: true
+  console.log(e.message); // Respuesta: "null has no properties"
+  console.log(e.name); // Respuesta: "TypeError"
+  console.log(e.fileName); // Respuesta: "Scratchpad/1"
+  console.log(e.lineNumber); // Respuesta: 2
+  console.log(e.columnNumber); // Respuesta: 2
+  console.log(e.stack); // Respuesta: "@Scratchpad/2:2:3\n"
 }
 ```
 
@@ -57,15 +57,15 @@ try {
 
 ```js
 try {
-  throw new TypeError('Hello', "someFile.js", 10)
+  throw new TypeError("Hello", "someFile.js", 10);
 } catch (e) {
-  console.log(e instanceof TypeError)  // Respuesta: true
-  console.log(e.message)               // Respuesta: "Hello"
-  console.log(e.name)                  // Respuesta: "TypeError"
-  console.log(e.fileName)              // Respuesta: "someFile.js"
-  console.log(e.lineNumber)            // Respuesta: 10
-  console.log(e.columnNumber)          // Respuesta: 0
-  console.log(e.stack)                 // Respuesta: "@Scratchpad/2:2:9\n"
+  console.log(e instanceof TypeError); // Respuesta: true
+  console.log(e.message); // Respuesta: "Hello"
+  console.log(e.name); // Respuesta: "TypeError"
+  console.log(e.fileName); // Respuesta: "someFile.js"
+  console.log(e.lineNumber); // Respuesta: 10
+  console.log(e.columnNumber); // Respuesta: 0
+  console.log(e.stack); // Respuesta: "@Scratchpad/2:2:9\n"
 }
 ```
 

--- a/files/es/web/javascript/reference/global_objects/typeerror/typeerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/typeerror/typeerror/index.md
@@ -10,10 +10,10 @@ El constructor **`TypeError()`** crea un nuevo error cuando una operación no pu
 ## Sintaxis
 
 ```js
-new TypeError()
-new TypeError(message)
-new TypeError(message, fileName)
-new TypeError(message, fileName, lineNumber)
+new TypeError();
+new TypeError(message);
+new TypeError(message, fileName);
+new TypeError(message, fileName, lineNumber);
 ```
 
 ### Parámetros
@@ -24,7 +24,7 @@ new TypeError(message, fileName, lineNumber)
   - : Un objeto con las siguientes propiedades:
     - `cause` {{optional_inline}}
       - : Una propiedad que indica la causa específica del error.
-      Cuando se atrapa y relanza un error con un mensaje de error más especifico o útil, esta propiedad debe ser usada para pasar el error original.
+        Cuando se atrapa y relanza un error con un mensaje de error más especifico o útil, esta propiedad debe ser usada para pasar el error original.
 - `fileName` {{optional_inline}} {{non-standard_inline}}
   - : El nombre del archivo contenedor del código que causa el error.
 - `lineNumber` {{optional_inline}} {{non-standard_inline}}
@@ -36,15 +36,15 @@ new TypeError(message, fileName, lineNumber)
 
 ```js
 try {
-  null.f()
+  null.f();
 } catch (e) {
-  console.log(e instanceof TypeError)  // Respuesta: true
-  console.log(e.message)               // Respuesta: "null has no properties"
-  console.log(e.name)                  // Respuesta: "TypeError"
-  console.log(e.fileName)              // Respuesta: "Scratchpad/1"
-  console.log(e.lineNumber)            // Respuesta: 2
-  console.log(e.columnNumber)          // Respuesta: 2
-  console.log(e.stack)                 // Respuesta: "@Scratchpad/2:2:3\n"
+  console.log(e instanceof TypeError); // Respuesta: true
+  console.log(e.message); // Respuesta: "null has no properties"
+  console.log(e.name); // Respuesta: "TypeError"
+  console.log(e.fileName); // Respuesta: "Scratchpad/1"
+  console.log(e.lineNumber); // Respuesta: 2
+  console.log(e.columnNumber); // Respuesta: 2
+  console.log(e.stack); // Respuesta: "@Scratchpad/2:2:3\n"
 }
 ```
 
@@ -52,15 +52,15 @@ try {
 
 ```js
 try {
-  throw new TypeError('Hello', "someFile.js", 10)
+  throw new TypeError("Hello", "someFile.js", 10);
 } catch (e) {
-  console.log(e instanceof TypeError)  // Respuesta: true
-  console.log(e.message)               // Respuesta: "Hello"
-  console.log(e.name)                  // Respuesta: "TypeError"
-  console.log(e.fileName)              // Respuesta: "someFile.js"
-  console.log(e.lineNumber)            // Respuesta: 10
-  console.log(e.columnNumber)          // Respuesta: 0
-  console.log(e.stack)                 // Respuesta: "@Scratchpad/2:2:9\n"
+  console.log(e instanceof TypeError); // Respuesta: true
+  console.log(e.message); // Respuesta: "Hello"
+  console.log(e.name); // Respuesta: "TypeError"
+  console.log(e.fileName); // Respuesta: "someFile.js"
+  console.log(e.lineNumber); // Respuesta: 10
+  console.log(e.columnNumber); // Respuesta: 0
+  console.log(e.stack); // Respuesta: "@Scratchpad/2:2:9\n"
 }
 ```
 

--- a/files/es/web/javascript/reference/global_objects/uint8array/index.md
+++ b/files/es/web/javascript/reference/global_objects/uint8array/index.md
@@ -122,7 +122,7 @@ console.log(uint8.length); // 2
 console.log(uint8.BYTES_PER_ELEMENT); // 1
 
 // Desde un array
-var arr = new Uint8Array([21,31]);
+var arr = new Uint8Array([21, 31]);
 console.log(arr[1]); // 31
 
 // Desde otro TypedArray

--- a/files/es/web/javascript/reference/global_objects/undefined/index.md
+++ b/files/es/web/javascript/reference/global_objects/undefined/index.md
@@ -31,14 +31,17 @@ Una variable a la que no se le ha asignado valor es de tipo `undefined`. Un mét
 > ```js example-bad
 > //NO HAGAS ESTO
 >
-> (() => { 
->   const undefined = 'foo'; 
->   console.log(undefined, typeof undefined); })() // foo string
+> (() => {
+>   const undefined = "foo";
+>   console.log(undefined, typeof undefined);
+> })()(
+>   // foo string
 >
-> // registra "foo string"
-> ((undefined) => {
->   console.log(undefined, typeof undefined); // foo string
-> })('foo');
+>   // registra "foo string"
+>   (undefined) => {
+>     console.log(undefined, typeof undefined); // foo string
+>   },
+> )("foo");
 > ```
 
 ## Ejemplos
@@ -50,10 +53,9 @@ Puedes usar `undefined` y los operadores de igualdad y desigualdad estricta para
 ```js
 let x;
 if (x === undefined) {
-   // se ejecutan estas instrucciones
-}
-else {
-   // estas instrucciones no se ejecutan
+  // se ejecutan estas instrucciones
+} else {
+  // estas instrucciones no se ejecutan
 }
 ```
 
@@ -65,8 +67,8 @@ Alternativamente se puede usar {{jsxref("Operadores/typeof","typeof")}}. Recuerd
 
 ```js
 let x;
-if (typeof x === 'undefined') {
-   // se ejecutan estas instrucciones
+if (typeof x === "undefined") {
+  // se ejecutan estas instrucciones
 }
 ```
 
@@ -74,12 +76,13 @@ Una razón para usar {{jsxref("Operadores/typeof","typeof")}} es que no devuelve
 
 ```js
 // x no fue declarada antes
-if (typeof x === 'undefined') { // devuelve true
-   //se ejecutan estas instrucciones
+if (typeof x === "undefined") {
+  // devuelve true
+  //se ejecutan estas instrucciones
 }
 
-if (x === undefined) { // lanza un ReferenceError
-
+if (x === undefined) {
+  // lanza un ReferenceError
 }
 ```
 
@@ -100,12 +103,12 @@ El operador {{jsxref("Operadores/void", "void")}} es una tercer alternativa.
 ```js
 let x;
 if (x === void 0) {
-   // se ejecutan estas instrucciones
+  // se ejecutan estas instrucciones
 }
 
 // y no fue declarada antes
 if (y === void 0) {
-   // lanza un ReferenceError (a diferencia de  `typeof`)
+  // lanza un ReferenceError (a diferencia de  `typeof`)
 }
 ```
 

--- a/files/es/web/javascript/reference/global_objects/urierror/index.md
+++ b/files/es/web/javascript/reference/global_objects/urierror/index.md
@@ -36,7 +36,7 @@ global se usó de manera incorrecta.
 
 ```js
 try {
-  decodeURIComponent('%');
+  decodeURIComponent("%");
 } catch (e) {
   console.log(e instanceof URIError); // true
   console.log(e.message); // "malformed URI sequence"
@@ -52,7 +52,7 @@ try {
 
 ```js
 try {
-  throw new URIError('Hello', 'someFile.js', 10);
+  throw new URIError("Hello", "someFile.js", 10);
 } catch (e) {
   console.log(e instanceof URIError); // true
   console.log(e.message); // "Hello"

--- a/files/es/web/javascript/reference/global_objects/weakmap/get/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakmap/get/index.md
@@ -31,10 +31,10 @@ El elemento asociado con la llave específica en el objeto WeakMap. Si la llave 
 
 ```js
 var wm = new WeakMap();
-wm.set(window, 'foo');
+wm.set(window, "foo");
 
 wm.get(window); // Devuelve "foo".
-wm.get('baz');  // Devuelve undefined.
+wm.get("baz"); // Devuelve undefined.
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/weakmap/has/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakmap/has/index.md
@@ -32,10 +32,10 @@ wm.has(key);
 
 ```js
 var wm = new WeakMap();
-wm.set(window, 'foo');
+wm.set(window, "foo");
 
 wm.has(window); // Devuelve true
-wm.has('baz');  // Devuelve false
+wm.has("baz"); // Devuelve false
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakmap/index.md
@@ -74,11 +74,11 @@ Pero debido a que un `WeakMap` no permite observar la vida de sus llaves, sus ll
 
 ```js
 const wm1 = new WeakMap(),
-      wm2 = new WeakMap(),
-      wm3 = new WeakMap();
+  wm2 = new WeakMap(),
+  wm3 = new WeakMap();
 const o1 = {},
-      o2 = function () {},
-      o3 = window;
+  o2 = function () {},
+  o3 = window;
 
 wm1.set(o1, 37);
 wm1.set(o2, "azerty");

--- a/files/es/web/javascript/reference/global_objects/weakmap/set/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakmap/set/index.md
@@ -36,9 +36,9 @@ var wm = new WeakMap();
 var obj = {};
 
 // Agregando nuevos elementos a WeakMap
-wm.set(obj, 'foo').set(window, 'bar'); // encadenamiento
+wm.set(obj, "foo").set(window, "bar"); // encadenamiento
 // Actualiza el un elemento en el objeto WeakMap
-wm.set(obj, 'baz');
+wm.set(obj, "baz");
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/iteration_protocols/index.md
+++ b/files/es/web/javascript/reference/iteration_protocols/index.md
@@ -44,8 +44,8 @@ Algunos iteradores son a su vez iterables:
 var someArray = [1, 5, 7];
 var someArrayEntries = someArray.entries();
 
-someArrayEntries.toString();           // "[object Array Iterator]"
-someArrayEntries === someArrayEntries[Symbol.iterator]();    // true
+someArrayEntries.toString(); // "[object Array Iterator]"
+someArrayEntries === someArrayEntries[Symbol.iterator](); // true
 ```
 
 ## Ejemplos de protocolos de iteración
@@ -54,24 +54,24 @@ Un {{jsxref("String")}} es un ejemplo de un objeto iterable nativo:
 
 ```js
 var someString = "hi";
-typeof someString[Symbol.iterator];          // "function"
+typeof someString[Symbol.iterator]; // "function"
 ```
 
 Para objetos `String` su iterador por defecto retorna cada uno de sus caracteres, uno a la vez:
 
 ```js
 var iterator = someString[Symbol.iterator]();
-iterator + "";                               // "[object String Iterator]"
+iterator + ""; // "[object String Iterator]"
 
-iterator.next();                             // { value: "h", done: false }
-iterator.next();                             // { value: "i", done: false }
-iterator.next();                             // { value: undefined, done: true }
+iterator.next(); // { value: "h", done: false }
+iterator.next(); // { value: "i", done: false }
+iterator.next(); // { value: undefined, done: true }
 ```
 
 En algunas estructuras nativas del lenguaje como en el caso del [operador de propagación _spread operator_](/es/docs/Web/JavaScript/Reference/Operators/Spread_operator), el mismo protocolo de iteración está presente en su parte interna:
 
 ```js
-[...someString]                              // ["h", "i"]
+[...someString]; // ["h", "i"]
 ```
 
 Podemos redefinir el comportamiento de iteración creando nuestro propio `@@iterator`:
@@ -83,9 +83,10 @@ Podemos redefinir el comportamiento de iteración creando nuestro propio `@@iter
 
 var someString = new String("hi");
 
-someString[Symbol.iterator] = function() {
-  return { // este es el objeto iterador que retorna un único elemento, la cadena string "bye"
-    next: function() {
+someString[Symbol.iterator] = function () {
+  return {
+    // este es el objeto iterador que retorna un único elemento, la cadena string "bye"
+    next: function () {
       if (this._first) {
         this._first = false;
         return { value: "bye", done: false };
@@ -93,7 +94,7 @@ someString[Symbol.iterator] = function() {
         return { done: true };
       }
     },
-    _first: true
+    _first: true,
   };
 };
 ```
@@ -101,8 +102,8 @@ someString[Symbol.iterator] = function() {
 Nótese que al redefinir un `@@iterator` se puede afectar el comportamiento de construcciones nativas que usan el protocolo de iteración:
 
 ```js
-[...someString];                              // ["bye"]
-someString + "";                              // "hi"
+[...someString]; // ["bye"]
+someString + ""; // "hi"
 ```
 
 ## Ejemplos de iterables
@@ -118,9 +119,9 @@ Podemos crear nuestros propios iterables de la siguiente manera:
 ```js
 var myIterable = {};
 myIterable[Symbol.iterator] = function* () {
-    yield 1;
-    yield 2;
-    yield 3;
+  yield 1;
+  yield 2;
+  yield 3;
 };
 [...myIterable]; // [1, 2, 3]
 ```
@@ -131,15 +132,30 @@ Existen varios APIs que aceptan iterables, como en el caso de: {{jsxref("Map", "
 
 ```js
 var myObj = {};
-new Map([[1,"a"],[2,"b"],[3,"c"]]).get(2);               // "b"
-new WeakMap([[{},"a"],[myObj,"b"],[{},"c"]]).get(myObj); // "b"
-new Set([1, 2, 3]).has(3);                               // true
-new Set("123").has("2");                                 // true
-new WeakSet(function*() {
+
+new Map([
+  [1, "a"],
+  [2, "b"],
+  [3, "c"],
+]).get(2); // "b"
+
+new WeakMap([
+  [{}, "a"],
+  [myObj, "b"],
+  [{}, "c"],
+]).get(myObj); // "b"
+
+new Set([1, 2, 3]).has(3); // true
+
+new Set("123").has("2"); // true
+
+new WeakSet(
+  (function* () {
     yield {};
     yield myObj;
     yield {};
-}()).has(myObj);                                         // true
+  })(),
+).has(myObj); // true
 ```
 
 De igual manera {{jsxref("Promise.all", "Promise.all(iterable)")}}, {{jsxref("Promise.race", "Promise.race(iterable)")}}, y {{jsxref("Array.from", "Array.from()")}}.
@@ -149,8 +165,8 @@ De igual manera {{jsxref("Promise.all", "Promise.all(iterable)")}}, {{jsxref("Pr
 Algunas declaraciones y expresiones esperan iterables, por ejemplo el bucle [`for-of`](/es/docs/Web/JavaScript/Reference/Statements/for...of), el[operador de propagación _spread operator_](/es/docs/Web/JavaScript/Reference/Operators/Spread_operator), la expresión [`Yield*`](/es/docs/Web/JavaScript/Reference/Operators/yield*), y la [asignación desestructurada _destructuring assignment_](/es/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment).
 
 ```js
-for(let value of ["a", "b", "c"]){
-    console.log(value);
+for (let value of ["a", "b", "c"]) {
+  console.log(value);
 }
 // "a"
 // "b"
@@ -158,14 +174,14 @@ for(let value of ["a", "b", "c"]){
 
 [..."abc"]; // ["a", "b", "c"]
 
-function* gen(){
+function* gen() {
   yield* ["a", "b", "c"];
 }
 
 gen().next(); // { value:"a", done:false }
 
 [a, b, c] = new Set(["a", "b", "c"]);
-a // "a"
+a; // "a"
 ```
 
 ### Iterables mal definidos
@@ -183,36 +199,36 @@ nonWellFormedIterable[Symbol.iterator] = () => 1
 ### Iterador simple
 
 ```js
-function makeIterator(array){
-    var nextIndex = 0;
+function makeIterator(array) {
+  var nextIndex = 0;
 
-    return {
-       next: function(){
-           return nextIndex < array.length ?
-               {value: array[nextIndex++], done: false} :
-               {done: true};
-       }
-    };
+  return {
+    next: function () {
+      return nextIndex < array.length
+        ? { value: array[nextIndex++], done: false }
+        : { done: true };
+    },
+  };
 }
 
-var it = makeIterator(['yo', 'ya']);
+var it = makeIterator(["yo", "ya"]);
 
 console.log(it.next().value); // 'yo'
 console.log(it.next().value); // 'ya'
-console.log(it.next().done);  // true
+console.log(it.next().done); // true
 ```
 
 ### Iterador infinito
 
 ```js
-function idMaker(){
-    var index = 0;
+function idMaker() {
+  var index = 0;
 
-    return {
-       next: function(){
-           return {value: index++, done: false};
-       }
-    };
+  return {
+    next: function () {
+      return { value: index++, done: false };
+    },
+  };
 }
 
 var it = idMaker();
@@ -226,26 +242,23 @@ console.log(it.next().value); // '2'
 ### Con un generador
 
 ```js
-function* makeSimpleGenerator(array){
-    var nextIndex = 0;
+function* makeSimpleGenerator(array) {
+  var nextIndex = 0;
 
-    while(nextIndex < array.length){
-        yield array[nextIndex++];
-    }
+  while (nextIndex < array.length) {
+    yield array[nextIndex++];
+  }
 }
 
-var gen = makeSimpleGenerator(['yo', 'ya']);
+var gen = makeSimpleGenerator(["yo", "ya"]);
 
 console.log(gen.next().value); // 'yo'
 console.log(gen.next().value); // 'ya'
-console.log(gen.next().done);  // true
+console.log(gen.next().done); // true
 
-
-
-function* idMaker(){
-    var index = 0;
-    while(true)
-        yield index++;
+function* idMaker() {
+  var index = 0;
+  while (true) yield index++;
 }
 
 var gen = idMaker();
@@ -261,11 +274,11 @@ console.log(gen.next().value); // '2'
 Un [objeto iterador](/es/docs/Web/JavaScript/Reference/Global_Objects/Generator) es tanto un iterador como un iterable:
 
 ```js
-var aGeneratorObject = function*(){
-    yield 1;
-    yield 2;
-    yield 3;
-}();
+var aGeneratorObject = (function* () {
+  yield 1;
+  yield 2;
+  yield 3;
+})();
 typeof aGeneratorObject.next;
 // "function", ya que tiene un método next, por lo tanto es un iterador
 typeof aGeneratorObject[Symbol.iterator];

--- a/files/es/web/javascript/reference/lexical_grammar/index.md
+++ b/files/es/web/javascript/reference/lexical_grammar/index.md
@@ -14,9 +14,9 @@ Los caracteres de control no tienen representación visual, pero se utilizan par
 
 | Punto de código | Nombre                  | Abreviatura | Descripción                                                                                                                                                                                                               |
 | --------------- | ----------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `U+200C`        | Separador de ancho cero | `<ZWNJ>`      | Colocado entre caracteres para evitar que se conecten a ligaduras en ciertos idiomas ([Wikipedia](https://en.wikipedia.org/wiki/Zero-width_non-joiner)).                                                                  |
-| `U+200D`        | Conector de ancho cero  | `<ZWJ>`       | Colocado entre caracteres que normalmente no estarían conectados para hacer que los caracteres se rendericen usando su forma conectada en ciertos idiomas ([Wikipedia](https://en.wikipedia.org/wiki/Zero-width_joiner)). |
-| `U+FEFF`        | Marca de orden de bytes | `<BOM>`       | Se usa al comienzo del script para marcarlo como Unicode y el orden de bytes del texto ([Wikipedia](https://en.wikipedia.org/wiki/Marca_de_orden_de_bytes)).                                                              |
+| `U+200C`        | Separador de ancho cero | `<ZWNJ>`    | Colocado entre caracteres para evitar que se conecten a ligaduras en ciertos idiomas ([Wikipedia](https://en.wikipedia.org/wiki/Zero-width_non-joiner)).                                                                  |
+| `U+200D`        | Conector de ancho cero  | `<ZWJ>`     | Colocado entre caracteres que normalmente no estarían conectados para hacer que los caracteres se rendericen usando su forma conectada en ciertos idiomas ([Wikipedia](https://en.wikipedia.org/wiki/Zero-width_joiner)). |
+| `U+FEFF`        | Marca de orden de bytes | `<BOM>`     | Se usa al comienzo del script para marcarlo como Unicode y el orden de bytes del texto ([Wikipedia](https://en.wikipedia.org/wiki/Marca_de_orden_de_bytes)).                                                              |
 
 ## Espacio en blanco
 
@@ -24,12 +24,12 @@ Los caracteres de {{Glossary("Espacio_en_blanco")}} mejoran la legibilidad del t
 
 | Punto de código | Nombre                              | Abreviatura | Descripción                                                                                               | Secuencia de escape |
 | --------------- | ----------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------- | ------------------- |
-| U+0009          | Caracter de tabulación              | `<HT>`        | Tabulación horizontal                                                                                     | \t                  |
-| U+000B          | Tabulación de línea                 | `<VT>`        | Tabulación vertical                                                                                       | \v                  |
-| U+000C          | Avance de Página                    | `<FF>`        | Carácter de control de salto de página ([Wikipedia](https://en.wikipedia.org/wiki/Page_break#Form_feed)). | \f                  |
-| U+0020          | Espacio                             | `<SP>`        | Espacio normal                                                                                            |                     |
-| U+00A0          | Espacio irrompible                  | `<NBSP>`      | Espacio normal, pero ningún punto en el que una línea se pueda romper                                     |                     |
-| Otros           | Otros caracteres de espacio Unicode | `<USP>`       | [Espacios Unicode en Wikipedia](<https://es.wikipedia.org/wiki/Espacio_(puntuaci%C3%B3n)>)                |                     |
+| U+0009          | Caracter de tabulación              | `<HT>`      | Tabulación horizontal                                                                                     | \t                  |
+| U+000B          | Tabulación de línea                 | `<VT>`      | Tabulación vertical                                                                                       | \v                  |
+| U+000C          | Avance de Página                    | `<FF>`      | Carácter de control de salto de página ([Wikipedia](https://en.wikipedia.org/wiki/Page_break#Form_feed)). | \f                  |
+| U+0020          | Espacio                             | `<SP>`      | Espacio normal                                                                                            |                     |
+| U+00A0          | Espacio irrompible                  | `<NBSP>`    | Espacio normal, pero ningún punto en el que una línea se pueda romper                                     |                     |
+| Otros           | Otros caracteres de espacio Unicode | `<USP>`     | [Espacios Unicode en Wikipedia](<https://es.wikipedia.org/wiki/Espacio_(puntuaci%C3%B3n)>)                |                     |
 
 ## Terminadores de línea
 
@@ -39,10 +39,10 @@ Solo los siguientes puntos de código Unicode se tratan como terminadores de lí
 
 | Punto de código | Nombre                | Abreviatura | Descripción                                                       | Secuencia de escape |
 | --------------- | --------------------- | ----------- | ----------------------------------------------------------------- | ------------------- |
-| U+000A          | Alimentación de linea | `<LF>`        | Caracter de nueva línea en sistemas UNIX.                         | \n                  |
-| U+000D          | Retorno de carro      | `<CR>`        | Caracter de nueva línea en Commodore y los primeros sistemas Mac. | \r                  |
-| U+2028          | Separador de línea    | `<LS>`        | [Wikipedia](https://es.wikipedia.org/wiki/Nueva_l%C3%ADnea)       |                     |
-| U+2029          | Separador de párrafos | `<PS>`        | [Wikipedia](https://es.wikipedia.org/wiki/Nueva_l%C3%ADnea)       |                     |
+| U+000A          | Alimentación de linea | `<LF>`      | Caracter de nueva línea en sistemas UNIX.                         | \n                  |
+| U+000D          | Retorno de carro      | `<CR>`      | Caracter de nueva línea en Commodore y los primeros sistemas Mac. | \r                  |
+| U+2028          | Separador de línea    | `<LS>`      | [Wikipedia](https://es.wikipedia.org/wiki/Nueva_l%C3%ADnea)       |                     |
+| U+2029          | Separador de párrafos | `<PS>`      | [Wikipedia](https://es.wikipedia.org/wiki/Nueva_l%C3%ADnea)       |                     |
 
 ## Comentarios
 
@@ -55,7 +55,7 @@ La primera forma son las dobles barras inclinadas `//` comentario**;** esta conv
 ```js
 function comment() {
   // Este es un comentario JavaScript de una línea
-  console.log('¡Hola mundo!');
+  console.log("¡Hola mundo!");
 }
 comment();
 ```
@@ -67,7 +67,7 @@ Por ejemplo, lo puedes usar en una sola línea:
 ```js
 function comment() {
   /* Este es un comentario JavaScript de una línea */
-  console.log('¡Hola mundo!');
+  console.log("¡Hola mundo!");
 }
 comment();
 ```
@@ -78,7 +78,7 @@ También puedes hacer comentarios de varias líneas, como este:
 function comment() {
   /* Este comentario abarca varias líneas. Aviso
      No necesitamos cerrar el comentario hasta que terminemos. */
-  console.log('¡Hola mundo!');
+  console.log("¡Hola mundo!");
 }
 comment();
 ```
@@ -87,9 +87,9 @@ También lo puedes usar en medio de una línea, si lo deseas, aunque esto puede 
 
 ```js
 function comment(x) {
-  console.log('¡Hola' + x /* inserta el valor de x */ + ' !');
+  console.log("¡Hola" + x /* inserta el valor de x */ + " !");
 }
-comment('mundo');
+comment("mundo");
 ```
 
 Además, lo puedes usar para deshabilitar el código y evitar que se ejecute, envolviendo el código en un comentario, como este:
@@ -239,7 +239,7 @@ Algunos identificadores tienen un significado especial en algunos contextos sin 
 Consulta también {{jsxref("null")}} para obtener más información.
 
 ```js
-null
+null;
 ```
 
 ### Booleanos literales
@@ -247,8 +247,8 @@ null
 Consulta también {{jsxref("Boolean", "Booleano")}} para obtener más información.
 
 ```js
-true
-false
+true;
+false;
 ```
 
 ### Literales numéricos
@@ -258,12 +258,12 @@ Los tipos {{jsxref("Number")}} y {{jsxref("BigInt")}} usan literales numéricos.
 #### Decimal
 
 ```js
-1234567890
-42
+1234567890;
+42;
 
 // Precaución al usar con un cero a la izquierda:
-0888 // 888 procesado como decimal
-0777 // procesado como octal, 511 en decimal
+0888; // 888 procesado como decimal
+0777; // procesado como octal, 511 en decimal
 ```
 
 Ten en cuenta que los decimales literales pueden comenzar con un cero (`0`) seguido de otro dígito decimal, pero si todos los dígitos después del `0` inicial son menores que 8, el número se interpreta como un número octal. Esto no arrojará JavaScript, consulta [error 957513](https://bugzilla.mozilla.org/show_bug.cgi?id=957513). Consulta también la página sobre {{jsxref("parseInt", "parseInt()")}}
@@ -273,12 +273,12 @@ Ten en cuenta que los decimales literales pueden comenzar con un cero (`0`) segu
 El literal exponencial decimal se especifica mediante el siguiente formato: `beN`; donde `b` es un número base (entero o flotante), seguido del caracter `e` (que sirve como separador o _indicador de exponente_) y `N`, que es un número _exponente_ o _potencia_: un entero con signo (según las especificaciones ECMA-262 de 2019):
 
 ```js
-0e-5   // => 0
-0e+5   // => 0
-5e1    // => 50
-175e-2 // => 1.75
-1e3    // => 1000
-1e-3   // => 0.001
+0e-5; // => 0
+0e5; // => 0
+5e1; // => 50
+175e-2; // => 1.75
+1e3; // => 1000
+1e-3; // => 0.001
 ```
 
 #### Binario
@@ -286,9 +286,9 @@ El literal exponencial decimal se especifica mediante el siguiente formato: `beN
 La sintaxis de números binarios utiliza un cero inicial seguido de una letra "B" latina en minúscula o mayúscula (`0b` o `0B`). Debido a que esta sintaxis es nueva en ECMAScript 2015, consulta la tabla de compatibilidad del navegador a continuación. Si los dígitos después de `0b` no son 0 o 1, se muestra el siguiente {{jsxref("SyntaxError")}}: "Faltan dígitos binarios después de 0b".
 
 ```js
-var FLT_SIGNBIT  = 0b10000000000000000000000000000000; // 2147483648
+var FLT_SIGNBIT = 0b10000000000000000000000000000000; // 2147483648
 var FLT_EXPONENT = 0b01111111100000000000000000000000; // 2139095040
-var FLT_MANTISSA = 0B00000000011111111111111111111111; // 8388607
+var FLT_MANTISSA = 0b00000000011111111111111111111111; // 8388607
 ```
 
 #### Octal
@@ -296,12 +296,12 @@ var FLT_MANTISSA = 0B00000000011111111111111111111111; // 8388607
 La sintaxis de números octales utiliza un cero inicial seguido de una letra "O" latina en minúscula o mayúscula (`0o` o `0O`). Debido a que esta sintaxis es nueva en ECMAScript 2015, consulta la tabla de compatibilidad del navegador a continuación. Si los dígitos después del `0o` están fuera del rango (01234567), se lanza el siguiente {{jsxref("SyntaxError")}}: "Dígitos octales faltantes después del 0o".
 
 ```js
-var n = 0O755; // 493
+var n = 0o755; // 493
 var m = 0o644; // 420
 
 // También es posible con solo un cero inicial (ve la nota sobre los decimales arriba)
-0755
-0644
+0755;
+0644;
 ```
 
 #### Hexadecimal
@@ -309,9 +309,9 @@ var m = 0o644; // 420
 La sintaxis de números hexadecimales utiliza un cero inicial seguido de una letra "X" latina en minúscula o mayúscula (`0x` o `0X`). Si los dígitos después de 0x están fuera del rango (0123456789ABCDEF), se lanza el siguiente {{jsxref("SyntaxError")}}: "El identificador comienza inmediatamente después del literal numérico".
 
 ```js
-0xFFFFFFFFFFFFFFFFF // 295147905179352830000
-0x123456789ABCDEF   // 81985529216486900
-0XA                 // 10
+0xfffffffffffffffff; // 295147905179352830000
+0x123456789abcdef; // 81985529216486900
+0xa; // 10
 ```
 
 #### BigInt literal
@@ -319,10 +319,10 @@ La sintaxis de números hexadecimales utiliza un cero inicial seguido de una let
 El tipo {{jsxref("BigInt")}} es una primitiva numérica en JavaScript que puede representar números enteros con precisión arbitraria. Los BigInt literales se crean agregando `n` al final de un número entero.
 
 ```js
-123456789123456789n     // 123456789123456789
-0o777777777777n         // 68719476735
-0x123456789ABCDEFn      // 81985529216486895‬
-0b11101001010101010101n // 955733
+123456789123456789n; // 123456789123456789
+0o777777777777n; // 68719476735
+0x123456789abcdefn; // 81985529216486895‬
+0b11101001010101010101n; // 955733
 ```
 
 Ten en cuenta que los números octales heredados con solo un cero a la izquierda no funcionarán para `BigInt`:
@@ -335,7 +335,7 @@ Ten en cuenta que los números octales heredados con solo un cero a la izquierda
 Para números `BigInt` octales, siempre utiliza cero seguido de la letra "o" (mayúscula o minúscula):
 
 ```js example-good
-0o755n
+0o755n;
 ```
 
 Para obtener más información sobre `BigInt`, consulta también [estructuras de datos JavaScript](/es/docs/Web/JavaScript/Data_structures#BigInt_type).
@@ -346,20 +346,20 @@ Para mejorar la legibilidad de literales numéricos, se pueden usar guiones bajo
 
 ```js
 // separadores en números decimales
-1_000_000_000_000
-1_050.95
+1_000_000_000_000;
+1_050.95;
 
 // separadores en números binarios
-0b1010_0001_1000_0101
+0b1010_0001_1000_0101;
 
 // separadores en números octales
-0o2_2_5_6
+0o2_2_5_6;
 
 // separadores en números hexadecimales
-0xA0_B0_C0
+0xa0_b0_c0;
 
 // separadores en BigInts
-1_000_000_000_000_000_000_000n
+1_000_000_000_000_000_000_000n;
 ```
 
 Ten en cuenta estas limitaciones:
@@ -380,11 +380,13 @@ Ten en cuenta estas limitaciones:
 Consulta también {{jsxref("Object")}} e [Iniciador de objeto](/es/docs/Web/JavaScript/Reference/Operators/Object_initializer) para obtener más información.
 
 ```js
-var o = { a: 'foo', b: 'bar', c: 42 };
+var o = { a: "foo", b: "bar", c: 42 };
 
 // notación abreviada. Nueva en ES2015
-var a = 'foo', b = 'bar', c = 42;
-var o = {a, b, c};
+var a = "foo",
+  b = "bar",
+  c = 42;
+var o = { a, b, c };
 
 // en vez de
 var o = { a: a, b: b, c: c };
@@ -395,7 +397,7 @@ var o = { a: a, b: b, c: c };
 Consulta también {{jsxref("Array")}} para obtener más información.
 
 ```js
-[1954, 1974, 1990, 2014]
+[1954, 1974, 1990, 2014];
 ```
 
 ### Cadenas literales
@@ -410,9 +412,9 @@ Antes de la [propuesta para hacer que todo el texto JSON sea ECMA-262 válido](h
 
 Cualquier punto de código puede aparecer en forma de secuencia de escape. Las cadenas literales se evalúan como valores de cadena de ECMAScript. Al generar estos valores de cadena, los puntos de código Unicode están codificados en UTF-16.
 
-```js
-'foo'
-"bar"
+```js-nolint
+'foo';
+"bar";
 ```
 
 #### Secuencias de escape hexadecimales
@@ -420,7 +422,7 @@ Cualquier punto de código puede aparecer en forma de secuencia de escape. Las c
 Las secuencias de escape hexadecimales constan de `\x` seguido de exactamente dos dígitos hexadecimales que representan una unidad de código o un punto de código en el rango de 0x0000 a 0x00FF.
 
 ```js
-'\xA9' // "©"
+"\xA9"; // "©"
 ```
 
 #### Secuencias de escape Unicode
@@ -430,7 +432,7 @@ Una secuencia de escape Unicode consta exactamente de cuatro dígitos hexadecima
 Consulta también {{jsxref("String.fromCharCode()")}} y {{jsxref("String.prototype.charCodeAt()")}}.
 
 ```js
-'\u00A9' // "©" (U+A9)
+"\u00A9"; // "©" (U+A9)
 ```
 
 #### Puntos de escape de código Unicode
@@ -440,10 +442,10 @@ Un punto de código de escape Unicode consta de `\u{`, seguido de un punto de c�
 Consulta también {{jsxref("String.fromCodePoint()")}} y {{jsxref("String.prototype.codePointAt()")}}.
 
 ```js
-'\u{2F804}' // CJK COMPATIBILIDAD IDEOGRÁFICA-2F804 (U+2F804)
+"\u{2F804}"; // CJK COMPATIBILIDAD IDEOGRÁFICA-2F804 (U+2F804)
 
 // el mismo caracter representado como un par suplente
-'\uD87E\uDC04'
+"\uD87E\uDC04";
 ```
 
 ### Expresión regular literal
@@ -463,7 +465,7 @@ Consulta también {{jsxref("RegExp")}} para obtener más información.
 
 Consulta también [cadenas de plantilla](/es/docs/Web/JavaScript/Reference/template_strings) para obtener más información.
 
-```js
+```js-nolint
 `string text`
 
 `string text line 1
@@ -471,7 +473,7 @@ Consulta también [cadenas de plantilla](/es/docs/Web/JavaScript/Reference/templ
 
 `string text ${expression} string text`
 
-tag `string text ${expression} string text`
+tag`string text ${expression} string text`
 ```
 
 ## Inserción automática de punto y coma
@@ -503,8 +505,8 @@ La especificación ECMAScript menciona [tres reglas de inserción de punto y com
 Aquí `++` no se trata como un [operador sufijo](/es/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Increment) que se aplica a la variable `b`, porque se produce un terminador de línea entre `b` y `++`.
 
 ```js
-a = b
-++c
+a = b;
+++c;
 
 // IAPC lo transforma en
 
@@ -522,8 +524,8 @@ a = b;
 - `module`
 
 ```js
-return
-a + b
+return;
+a + b;
 
 // La IAPC lo transforma en
 

--- a/files/es/web/javascript/reference/operators/addition/index.md
+++ b/files/es/web/javascript/reference/operators/addition/index.md
@@ -24,26 +24,26 @@ Operator: x + y
 
 ```js
 // Número + Número -> adición
-1 + 2 // 3
+1 + 2; // 3
 
 // Booleano + Número -> adición
-true + 1 // 2
+true + 1; // 2
 
 // Booleano + Booleano -> adición
-false + false // 0
+false + false; // 0
 ```
 
 ### Concatenación de (cadenas) String
 
 ```js
 // String + String -> concatenación
-'fut' + 'bol' // "futbol"
+"fut" + "bol"; // "futbol"
 
 // Número + String -> concatenación
-5 + 'oh' // "5oh"
+5 + "oh"; // "5oh"
 
 // String + Booleano -> concatenación
-'fut' + false // "futfalse"
+"fut" + false; // "futfalse"
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/operators/assignment/index.md
+++ b/files/es/web/javascript/reference/operators/assignment/index.md
@@ -26,8 +26,8 @@ Operador: x = y
 //  n = 10
 //  z = 25
 
-x = n     // La variable x contiene el valor 10
-x = n = z // x = n (es decir 10) y z pisa el valor total remplazandolo por 25
+x = n; // La variable x contiene el valor 10
+x = n = z; // x = n (es decir 10) y z pisa el valor total remplazandolo por 25
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/operators/async_function/index.md
+++ b/files/es/web/javascript/reference/operators/async_function/index.md
@@ -39,31 +39,31 @@ Una expresión `async function` es muy similar, y casi tiene la misma sintaxis q
 
 ```js
 function resuelve2SegundosDespues(x) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(() => {
       resolve(x);
     }, 2000);
   });
-};
+}
 
-
-const agregar= async function(x) { // Expresión de una función asíncrona asignada a una variable
+const agregar = async function (x) {
+  // Expresión de una función asíncrona asignada a una variable
   let a = await resuelve2SegundosDespues(20);
   let b = await resuelve2SegundosDespues(30);
   return x + a + b;
 };
 
-agregar(10).then(v => {
-  console.log(v);  // imprime 60 después de 4 segundos.
+agregar(10).then((v) => {
+  console.log(v); // imprime 60 después de 4 segundos.
 });
 
-
-(async function(x) { // expresión de una función asíncrona utilizada como una IIFE
+(async function (x) {
+  // expresión de una función asíncrona utilizada como una IIFE
   let p_a = resuelve2SegundosDespues(20);
   let p_b = resuelve2SegundosDespues(30);
-  return x + await p_a + await p_b;
-})(10).then(v => {
-  console.log(v);  // imprime 60 después de 2 segundos.
+  return x + (await p_a) + (await p_b);
+})(10).then((v) => {
+  console.log(v); // imprime 60 después de 2 segundos.
 });
 ```
 

--- a/files/es/web/javascript/reference/operators/await/index.md
+++ b/files/es/web/javascript/reference/operators/await/index.md
@@ -31,7 +31,7 @@ Si una `Promise` se pasa a una expresión `await`, espera a que la `Promise` se 
 
 ```js
 function resolveAfter2Seconds(x) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(() => {
       resolve(x);
     }, 2000);
@@ -61,7 +61,7 @@ Si la `Promise` es rechazada, se lanza una excepción con dicho el valor.
 async function f3() {
   try {
     var z = await Promise.reject(30);
-  } catch(e) {
+  } catch (e) {
     console.log(e); // 30
   }
 }

--- a/files/es/web/javascript/reference/operators/class/index.md
+++ b/files/es/web/javascript/reference/operators/class/index.md
@@ -23,7 +23,7 @@ Una expresión de clase tiene una sintaxis similar a la [declaración de una cla
 Tal y como en la declaración de clases, el cuerpo de la expresión de clase se ejecuta en [modo estricto](/es/docs/Web/JavaScript/Referencia/Modo_estricto).
 
 ```js
-'use strict';
+"use strict";
 var Foo = class {}; // la propiedad constructor es opcional
 var Foo = class {}; // Se permite repetir declaraciones
 
@@ -32,7 +32,7 @@ typeof class {}; // devuelve "function"
 
 Foo instanceof Object; // true
 Foo instanceof Function; // true
-class Foo {}; // Lanza TypeError, no permite volver a declararla
+class Foo {} // Lanza TypeError, no permite volver a declararla
 ```
 
 ## Ejemplo
@@ -64,7 +64,7 @@ var Foo = class NamedFoo {
   whoIsThere() {
     return NamedFoo.name;
   }
-}
+};
 var bar = new Foo();
 bar.whoIsThere(); // "NamedFoo"
 NamedFoo.name; // ReferenceError: NamedFoo no está definido

--- a/files/es/web/javascript/reference/operators/comma_operator/index.md
+++ b/files/es/web/javascript/reference/operators/comma_operator/index.md
@@ -37,10 +37,10 @@ for (var i = 0, j = 9; i <= 9; i++, j--)
 Otro ejemplo de lo que se puede hacer con el operador coma es procesar antes de retornar. Como se mencionó, solo el último elemento será retornado pero todos los otros también van a ser evaluados. Así, se puede hacer:
 
 ```js
-function myFunc () {
+function myFunc() {
   var x = 0;
 
-  return (x += 1, x); // the same as return ++x;
+  return (x += 1), x; // the same as return ++x;
 }
 ```
 

--- a/files/es/web/javascript/reference/operators/conditional_operator/index.md
+++ b/files/es/web/javascript/reference/operators/conditional_operator/index.md
@@ -24,7 +24,7 @@ condición ? expr1 : expr2
 Si la `condición` es `true`, el operador retorna el valor de la `expr1`; de lo contrario, devuelve el valor de `expr2`. Por ejemplo, para mostrar un mensaje diferente en función del valor de la variable _`isMember,`_ se puede usar esta declaración:
 
 ```js
-"La Cuota es de:  " + (isMember ? "$2.00" : "$10.00")
+"La Cuota es de:  " + (isMember ? "$2.00" : "$10.00");
 ```
 
 También puedes asignar variables dependiendo del resultado de la condición ternaria:
@@ -37,32 +37,34 @@ También es posible realizar evaluaciones ternarias múltiples (Nota: El operado
 
 ```js
 var firstCheck = false,
-    secondCheck = false,
-    access = firstCheck ? "Acceso Denegado" : secondCheck ? "Acceso Denegado" : "Acceso Permitido";
+  secondCheck = false,
+  access = firstCheck
+    ? "Acceso Denegado"
+    : secondCheck
+    ? "Acceso Denegado"
+    : "Acceso Permitido";
 
-console.log( access ); // muestra "Acceso Permitido"
+console.log(access); // muestra "Acceso Permitido"
 ```
 
 También puede usar operaciones ternarias en espacio vacío con el propósito de realizar diferentes operaciones:
 
 ```js
-var stop = false, age = 16;
+var stop = false,
+  age = 16;
 
-age > 18 ? location.assign("continue.html") : stop = true;
+age > 18 ? location.assign("continue.html") : (stop = true);
 ```
 
 También puede realizar más de una operación por caso, separándolas con una coma:
 
 ```js
-var stop = false, age = 23;
+var stop = false,
+  age = 23;
 
-age > 18 ? (
-    alert("OK, puedes continuar."),
-    location.assign("continue.html")
-) : (
-    stop = true,
-    alert("Disculpa, eres menor de edad!")
-);
+age > 18
+  ? (alert("OK, puedes continuar."), location.assign("continue.html"))
+  : ((stop = true), alert("Disculpa, eres menor de edad!"));
 ```
 
 También puede realizar más de una operación durante la asignación de un valor. En este caso, **_el último valor separado por una coma del paréntesis_ será el valor asignado**.
@@ -70,17 +72,16 @@ También puede realizar más de una operación durante la asignación de un valo
 ```js
 var age = 16;
 
-var url = age > 18 ? (
-    alert("OK, puedes continuar."),
-    // alert devuelve "undefined", pero será ignorado porque
-    // no es el último valor separado por comas del paréntesis
-    "continue.html" // el valor a ser asignado si age > 18
-) : (
-    alert("Eres menor de edad!"),
-    alert("Disculpa :-("),
-    // etc. etc.
-    "stop.html" // el valor a ser asignado si !(age > 18)
-);
+var url =
+  age > 18
+    ? (alert("OK, puedes continuar."),
+      // alert devuelve "undefined", pero será ignorado porque
+      // no es el último valor separado por comas del paréntesis
+      "continue.html") // el valor a ser asignado si age > 18
+    : (alert("Eres menor de edad!"),
+      alert("Disculpa :-("),
+      // etc. etc.
+      "stop.html"); // el valor a ser asignado si !(age > 18)
 
 location.assign(url); // "stop.html"
 ```

--- a/files/es/web/javascript/reference/operators/delete/index.md
+++ b/files/es/web/javascript/reference/operators/delete/index.md
@@ -13,14 +13,14 @@ mantienen más referencias a la misma propiedad, eventualmente se libera automá
 ## Sintaxis
 
 ```js
-delete expresion
+delete expresion;
 ```
 
 Donde `expresion` debe evaluarse como una referencia a la [propiedad](/es/docs/Glossary/property/JavaScript), por ejemplo:
 
 ```js
-delete object.property
-delete object['property']
+delete object.property;
+delete object["property"];
 ```
 
 ### Parámetros
@@ -74,12 +74,12 @@ El siguiente bloque de código muestra un ejemplo simple:
 ```js
 var Employee = {
   age: 28,
-  name: 'abc',
-  designation: 'desarrollador'
-}
+  name: "abc",
+  designation: "desarrollador",
+};
 
-console.log(delete Employee.name);   // retorna true
-console.log(delete Employee.age);    // retorna true
+console.log(delete Employee.name); // retorna true
+console.log(delete Employee.age); // retorna true
 
 // Cuando se trata de eliminar una propiedad
 // que no existe, retorna true
@@ -94,9 +94,9 @@ arrojará un `TypeError`.
 
 ```js
 var Employee = {};
-Object.defineProperty(Employee, 'name', {configurable: false});
+Object.defineProperty(Employee, "name", { configurable: false });
 
-console.log(delete Employee.name);  // retorna false
+console.log(delete Employee.name); // retorna false
 ```
 
 {{jsxref("Statements/var","var")}}, {{jsxref("Statements/let","let")}}, y
@@ -104,10 +104,10 @@ console.log(delete Employee.name);  // retorna false
 que no pueden ser eliminadas con el operador `delete`:
 
 ```js
-var nameOther = 'XYZ';
+var nameOther = "XYZ";
 
 // Podemos acceder a esta propiedad global usando:
-Object.getOwnPropertyDescriptor(window, 'nameOther');
+Object.getOwnPropertyDescriptor(window, "nameOther");
 
 // salida: Object {value: "XYZ",
 //                  writable: true,
@@ -117,7 +117,7 @@ Object.getOwnPropertyDescriptor(window, 'nameOther');
 // Debido a que "nameOther" es añadido usando la palabra
 // reservada var, es marcada como "no configurable"
 
-delete nameOther;   // retorna false
+delete nameOther; // retorna false
 ```
 
 En modo estricto, esto hubiese arrojado una excepción.
@@ -131,8 +131,14 @@ en modo estricto, debe usar el operador `delete` en la forma de
 `delete object.property` o `delete object['property']`.
 
 ```js
-Object.defineProperty(globalThis, 'variable1', { value: 10, configurable: true, });
-Object.defineProperty(globalThis, 'variable2', { value: 10, configurable: false, });
+Object.defineProperty(globalThis, "variable1", {
+  value: 10,
+  configurable: true,
+});
+Object.defineProperty(globalThis, "variable2", {
+  value: 10,
+  configurable: false,
+});
 
 // SyntaxError en modo estricto.
 console.log(delete variable1); // true
@@ -174,7 +180,7 @@ un arreglo de objetos con una única propiedad, etc.
 
 ```js
 // Crea la propiedad adminName en el ámbito global.
-adminName = 'xyz';
+adminName = "xyz";
 
 // Crea la propiedad empCount en el ábmti global.
 // Como se usa var, es marcada como no configurable.
@@ -182,19 +188,19 @@ adminName = 'xyz';
 var empCount = 43;
 
 EmployeeDetails = {
-  name: 'xyz',
+  name: "xyz",
   age: 5,
-  designation: 'Developer'
+  designation: "Developer",
 };
 
 // adminName es una propiedad del ámbito global.
 // Puede ser eliminada debido a que es declarada sin usar var,
 // y por lo tanto es configurable.
-delete adminName;       // retorna true
+delete adminName; // retorna true
 
 // Por el contrario, empCount no es configurable
 // debido a que fue usado var al declararla.
-delete empCount;       // retorna false
+delete empCount; // retorna false
 
 // delete puede ser usado para eliminar propiedades de objetos.
 delete EmployeeDetails.name; // retona true
@@ -207,13 +213,13 @@ delete Math.PI; // retorna false
 
 // EmployeeDetails es una propiedad del ámbito global.
 // Debido a que fue definida sin "var", se marca como configurable.
-delete EmployeeDetails;   // retorna true
+delete EmployeeDetails; // retorna true
 
 function f() {
   var z = 44;
 
   // delete no afecta nombres de variables locales
-  delete z;     // retorna false
+  delete z; // retorna false
 }
 ```
 
@@ -263,10 +269,10 @@ no se encuentra más en el mismo. En el siguiente ejemplo, `trees[3]` es
 eliminado con el uso de `delete`.
 
 ```js
-var trees = ['redwood', 'bay', 'cedar', 'oak', 'maple'];
+var trees = ["redwood", "bay", "cedar", "oak", "maple"];
 delete trees[3];
 if (3 in trees) {
-    // esto no se ejecuta
+  // esto no se ejecuta
 }
 ```
 
@@ -276,10 +282,10 @@ siguiente ejmeplo, `trees[3]` recibe el valor `undefined`, pero el elemento
 del arreglo aún existe:
 
 ```js
-var trees = ['redwood', 'bay', 'cedar', 'oak', 'maple'];
+var trees = ["redwood", "bay", "cedar", "oak", "maple"];
 trees[3] = undefined;
 if (3 in trees) {
-    // esto sí se ejecuta
+  // esto sí se ejecuta
 }
 ```
 
@@ -290,8 +296,8 @@ se elimina completamente `trees[3]` del arreglo usando
 {{jsxref("Array.splice()", "splice()")}}:
 
 ```js
-var trees = ['redwood', 'bay', 'cedar', 'oak', 'maple'];
-trees.splice(3,1);
+var trees = ["redwood", "bay", "cedar", "oak", "maple"];
+trees.splice(3, 1);
 console.log(trees); // ["redwood", "bay", "cedar", "maple"]
 ```
 

--- a/files/es/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/es/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -27,9 +27,8 @@ console.log(rest); // [30, 40, 50]
 console.log(a); // 10
 console.log(b); // 20
 
-
 // Propuesta de etapa 4 (terminada)
-({a, b, ...rest} = {a: 10, b: 20, c: 30, d: 40});
+({ a, b, ...rest } = { a: 10, b: 20, c: 30, d: 40 });
 console.log(a); // 10
 console.log(b); // 20
 console.log(rest); // {c: 30, d: 40}
@@ -61,7 +60,7 @@ Esta capacidad es similar a las características presentes en lenguajes como Per
 #### Asignación básica de variables
 
 ```js
-const foo = ['one', 'two', 'three'];
+const foo = ["one", "two", "three"];
 
 const [red, yellow, green] = foo;
 console.log(red); // "one"
@@ -88,7 +87,7 @@ A una variable se le puede asignar un valor predeterminado, en el caso de que el
 ```js
 let a, b;
 
-[a=5, b=7] = [1];
+[a = 5, b = 7] = [1];
 console.log(a); // 1
 console.log(b); // 7
 ```
@@ -107,7 +106,7 @@ let b = 3;
 console.log(a); // 3
 console.log(b); // 1
 
-const arr = [1,2,3];
+const arr = [1, 2, 3];
 [arr[2], arr[1]] = [arr[1], arr[2]];
 console.log(arr); // [1,3,2]
 ```
@@ -149,7 +148,7 @@ console.log(c); // 1
 También puedes ignorar todos los valores devueltos:
 
 ```js
-[,,] = f();
+[, ,] = f();
 ```
 
 #### Asignar el resto de un arreglo a una variable
@@ -165,7 +164,7 @@ console.log(b); // [2, 3]
 Ten en cuenta que se lanzará un {{jsxref("SyntaxError")}} si se usa una coma final en el lado derecho con un elemento `rest` o:
 
 ```js example-bad
-const [a, ...b,] = [1, 2, 3];
+const [a, ...b] = [1, 2, 3];
 
 // SyntaxError: el elemento rest no puede tener una coma al final
 // Siempre considera usar el operador rest como último elemento
@@ -199,11 +198,11 @@ console.log(parseProtocol('https://developer.mozilla.org/es/Web/JavaScript'));
 
 ```js
 const user = {
-    id: 42,
-    is_verified: true
+  id: 42,
+  is_verified: true,
 };
 
-const {id, is_verified} = user;
+const { id, is_verified } = user;
 
 console.log(id); // 42
 console.log(is_verified); // true
@@ -216,7 +215,7 @@ A una variable se le puede asignar su valor con desestructuración separada de s
 ```js
 let a, b;
 
-({a, b} = {a: 1, b: 2});
+({ a, b } = { a: 1, b: 2 });
 ```
 
 > **Nota:** Los paréntesis `(...)` alrededor de la declaración de asignación son obligatorios cuando se usa la desestructuración de un objeto literal sin una declaración.
@@ -232,8 +231,8 @@ let a, b;
 Una propiedad se puede desempacar de un objeto y asignar a una variable con un nombre diferente al de la propiedad del objeto.
 
 ```js
-const o = {p: 42, q: true};
-const {p: foo, q: bar} = o;
+const o = { p: 42, q: true };
+const { p: foo, q: bar } = o;
 
 console.log(foo); // 42
 console.log(bar); // true
@@ -246,7 +245,7 @@ Aquí, por ejemplo, `const {p: foo} = o` toma del objeto `o` la propiedad llamad
 A una variable se le puede asignar un valor predeterminado, en el caso de que el valor desempacado del objeto sea `undefined`.
 
 ```js
-const {a = 10, b = 5} = {a: 3};
+const { a = 10, b = 5 } = { a: 3 };
 
 console.log(a); // 3
 console.log(b); // 5
@@ -260,7 +259,7 @@ Una propiedad puede ser ambas
 - Se le asigna un valor predeterminado en caso de que el valor desempacado sea `undefined`.
 
 ```js
-const {a: aa = 10, b: bb = 5} = {a: 3};
+const { a: aa = 10, b: bb = 5 } = { a: 3 };
 
 console.log(aa); // 3
 console.log(bb); // 5
@@ -271,23 +270,23 @@ console.log(bb); // 5
 ```js
 const user = {
   id: 42,
-  displayName: 'jdoe',
+  displayName: "jdoe",
   fullName: {
-    firstName: 'John',
-    lastName: 'Doe'
-  }
+    firstName: "John",
+    lastName: "Doe",
+  },
 };
 
-function userId({id}) {
+function userId({ id }) {
   return id;
 }
 
-function whois({displayName, fullName: {firstName: name}}) {
+function whois({ displayName, fullName: { firstName: name } }) {
   return `${displayName} es ${name}`;
 }
 
 console.log(userId(user)); // 42
-console.log(whois(user));  // "jdoe es John"
+console.log(whois(user)); // "jdoe es John"
 ```
 
 Esto desempaca el `id`, `displayName` y `firstName` del objeto `user` y los imprime.
@@ -295,14 +294,18 @@ Esto desempaca el `id`, `displayName` y `firstName` del objeto `user` y los impr
 #### Establecer el valor predeterminado de un parámetro de función
 
 ```js
-function drawChart({size = 'big', coords = {x: 0, y: 0}, radius = 25} = {}) {
+function drawChart({
+  size = "big",
+  coords = { x: 0, y: 0 },
+  radius = 25,
+} = {}) {
   console.log(size, coords, radius);
   // haz un dibujo de gráfico
 }
 
 drawChart({
-  coords: {x: 18, y: 30},
-  radius: 30
+  coords: { x: 18, y: 30 },
+  radius: 30,
 });
 ```
 
@@ -312,30 +315,30 @@ drawChart({
 
 ```js
 const metadata = {
-  title: 'Scratchpad',
+  title: "Scratchpad",
   translations: [
     {
-      locale: 'de',
+      locale: "de",
       localization_tags: [],
-      last_edit: '2020-08-29T08:43:37',
-      url: '/de/docs/Tools/Scratchpad',
-      title: 'JavaScript-Umgebung'
-    }
+      last_edit: "2020-08-29T08:43:37",
+      url: "/de/docs/Tools/Scratchpad",
+      title: "JavaScript-Umgebung",
+    },
   ],
-  url: '/es/docs/Tools/Scratchpad'
+  url: "/es/docs/Tools/Scratchpad",
 };
 
 let {
   title: englishTitle, // renombrar
   translations: [
     {
-       title: localeTitle, // renombrar
+      title: localeTitle, // renombrar
     },
   ],
 } = metadata;
 
 console.log(englishTitle); // "Scratchpad"
-console.log(localeTitle);  // "JavaScript-Umgebung"
+console.log(localeTitle); // "JavaScript-Umgebung"
 ```
 
 #### Iteración "`for...of`" y desestructuración
@@ -343,27 +346,30 @@ console.log(localeTitle);  // "JavaScript-Umgebung"
 ```js
 const people = [
   {
-    name: 'Mike Smith',
+    name: "Mike Smith",
     family: {
-      mother: 'Jane Smith',
-      father: 'Harry Smith',
-      sister: 'Samantha Smith'
+      mother: "Jane Smith",
+      father: "Harry Smith",
+      sister: "Samantha Smith",
     },
-    age: 35
+    age: 35,
   },
   {
-    name: 'Tom Jones',
+    name: "Tom Jones",
     family: {
-      mother: 'Norah Jones',
-      father: 'Richard Jones',
-      brother: 'Howard Jones'
+      mother: "Norah Jones",
+      father: "Richard Jones",
+      brother: "Howard Jones",
     },
-    age: 25
-  }
+    age: 25,
+  },
 ];
 
-for (const {name: n, family: {father: f}} of people) {
-  console.log('Nombre: ' + n + ', Padre: ' + f);
+for (const {
+  name: n,
+  family: { father: f },
+} of people) {
+  console.log("Nombre: " + n + ", Padre: " + f);
 }
 
 // "Nombre: Mike Smith, Padre: Harry Smith"
@@ -375,8 +381,8 @@ for (const {name: n, family: {father: f}} of people) {
 Los nombres de propiedad calculados, como en un {{jsxref("Operators/Object_initializer", "Objeto literal", "#Computed_property_names", 1)}}, se pueden usar con la desestructuración.
 
 ```js
-let key = 'z';
-let {[key]: foo} = {z: 'bar'};
+let key = "z";
+let { [key]: foo } = { z: "bar" };
 
 console.log(foo); // "bar"
 ```
@@ -386,7 +392,7 @@ console.log(foo); // "bar"
 La propuesta [Propiedades `rest`/propagación para ECMAScript](https://github.com/tc39/proposal-object-rest-spread) (etapa 4) agrega la sintaxis {{jsxref("Functions/rest_parameters", "rest", "", 1)}} para desestructurar. Las propiedades de `rest` recopilan las claves de propiedades enumerables restantes que aún no han sido seleccionadas por el patrón de desestructuración.
 
 ```js
-let {a, b, ...rest} = {a: 10, b: 20, c: 30, d: 40}
+let { a, b, ...rest } = { a: 10, b: 20, c: 30, d: 40 };
 a; // 10
 b; // 20
 rest; // { c: 30, d: 40 }
@@ -397,8 +403,8 @@ rest; // { c: 30, d: 40 }
 La desestructuración se puede utilizar con nombres de propiedad que no son {{Glossary("Identifier", "identificadores")}} válidos en JavaScript proporcionando un identificador alternativo que sea válido.
 
 ```js
-const foo = { 'fizz-buzz': true };
-const { 'fizz-buzz': fizzBuzz } = foo;
+const foo = { "fizz-buzz": true };
+const { "fizz-buzz": fizzBuzz } = foo;
 
 console.log(fizzBuzz); // "true"
 ```
@@ -409,12 +415,12 @@ La desestructuración de arreglos y objetos se puede combinar. Supongamos que de
 
 ```js
 const props = [
-  { id: 1, name: 'Fizz'},
-  { id: 2, name: 'Buzz'},
-  { id: 3, name: 'FizzBuzz'}
+  { id: 1, name: "Fizz" },
+  { id: 2, name: "Buzz" },
+  { id: 3, name: "FizzBuzz" },
 ];
 
-const [,, { name }] = props;
+const [, , { name }] = props;
 
 console.log(name); // "FizzBuzz"
 ```
@@ -424,9 +430,9 @@ console.log(name); // "FizzBuzz"
 Al deconstruir un objeto, si no se accede a una propiedad en sí misma, continuará buscando a lo largo de la cadena de prototipos.
 
 ```js
-let obj = {self: '123'};
-obj.__proto__.prot = '456';
-const {self, prot} = obj;
+let obj = { self: "123" };
+obj.__proto__.prot = "456";
+const { self, prot } = obj;
 // self "123"
 // prot "456" (Acceso a la cadena de prototipos)
 ```

--- a/files/es/web/javascript/reference/operators/division/index.md
+++ b/files/es/web/javascript/reference/operators/division/index.md
@@ -21,21 +21,21 @@ Operador: x / y
 ### Division basica
 
 ```js
-1 / 2              // 0.5
+1 / 2; // 0.5
 
-Math.floor(3 / 2) // 1
+Math.floor(3 / 2); // 1
 
-1.0 / 2.0         // 0.5
+1.0 / 2.0; // 0.5
 ```
 
 ### Division por cero
 
 ```js
-2.0 / 0     // Retorna Infinity
+2.0 / 0; // Retorna Infinity
 
-2.0 / 0.0   // Retorna Infinity, Dado que 0.0 === 0
+2.0 / 0.0; // Retorna Infinity, Dado que 0.0 === 0
 
-2.0 / -0.0  // Retorna -Infinity
+2.0 / -0.0; // Retorna -Infinity
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/operators/equality/index.md
+++ b/files/es/web/javascript/reference/operators/equality/index.md
@@ -41,36 +41,36 @@ La diferencia más notable entre este operador y el operador de igualdad estrict
 ### Comparación sin conversión de tipo
 
 ```js
-1 == 1;              // true
-"Hola" == "Hola";  // true
+1 == 1; // true
+"Hola" == "Hola"; // true
 ```
 
 ### Comparación con conversión de tipos
 
 ```js
-"1" ==  1;            // true
-1 == "1";             // true
-0 == false;           // true
-0 == null;            // false
-0 == undefined;       // false
-0 == !!null;          // true, Operador Logico NOT
-0 == !!undefined;     // true, Operador Logico NOT
-null == undefined;    // true
+"1" == 1; // true
+1 == "1"; // true
+0 == false; // true
+0 == null; // false
+0 == undefined; // false
+0 == !!null; // true, Operador Logico NOT
+0 == !!undefined; // true, Operador Logico NOT
+null == undefined; // true
 
 const number1 = new Number(3);
 const number2 = new Number(3);
-number1 == 3;         // true
-number1 == number2;   // false
+number1 == 3; // true
+number1 == number2; // false
 ```
 
 ### Comparación de objetos
 
 ```js
-const object1 = {"key": "value"}
-const object2 = {"key": "value"};
+const object1 = { key: "value" };
+const object2 = { key: "value" };
 
-object1 == object2 // false
-object2 == object2 // true
+object1 == object2; // false
+object2 == object2; // true
 ```
 
 ### Comparar String y objetos String
@@ -93,9 +93,9 @@ console.log(string4 == string4); // true
 ### Comparación de fechas y cadenas
 
 ```js
-const d = new Date('December 17, 1995 03:24:00');
+const d = new Date("December 17, 1995 03:24:00");
 const s = d.toString(); // Por ejemplo: "Sun Dec 17 1995 03:24:00 GMT-0800 (Hora estándar del Pacífico)"
-console.log(d == s);    //true
+console.log(d == s); //true
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/operators/function/index.md
+++ b/files/es/web/javascript/reference/operators/function/index.md
@@ -21,9 +21,11 @@ function [name]([param1, param2, ..., paramN]) {
 ## Parámetros
 
 - `name`
+
   - : El nombre de la función. Puede ser omitido, en cuyo caso la función es _anonymous_. El nombre sólo es local para el cuerpo de la función.
 
 - `paramN`
+
   - : El nombre de un argumento que será pasado a la función. Una función puede tener hasta 255 argumentos.
 
 - `statements`
@@ -38,8 +40,8 @@ La expresión de una función es muy similar y tiene casi la misma sintaxis que 
 El siguiente ejemplo define una función sin nombre y se le asigna a la variable x. La función devuelve como resultado el cuadrado de su argumento:
 
 ```js
-var x = function(y) {
-   return y * y;
+var x = function (y) {
+  return y * y;
 };
 ```
 
@@ -49,11 +51,10 @@ Si quiere referirse a la función actual dentro del cuerpo de la función, debe 
 
 ```js
 var math = {
-  'factorial': function factorial(n) {
-    if (n <= 1)
-      return 1;
+  factorial: function factorial(n) {
+    if (n <= 1) return 1;
     return n * factorial(n - 1);
-  }
+  },
 };
 ```
 

--- a/files/es/web/javascript/reference/operators/function_star_/index.md
+++ b/files/es/web/javascript/reference/operators/function_star_/index.md
@@ -38,8 +38,8 @@ Una expresión `function*` es muy similar y tiene casi la misma sintaxis que una
 El siguiente ejemplo define una función generadora sin nombre y la asigna a `x`. La función produce el cuadrado de su argumento:
 
 ```js
-var x = function*(y) {
-   yield y * y;
+var x = function* (y) {
+  yield y * y;
 };
 ```
 

--- a/files/es/web/javascript/reference/operators/grouping/index.md
+++ b/files/es/web/javascript/reference/operators/grouping/index.md
@@ -22,22 +22,22 @@ El operador de agrupación consiste en un par de paréntesis alrededor de la exp
 
 Sobrescribir la precedencia de operadores aritméticos por defecto para que se evalúe primero la adición y luego la multiplicación.
 
-```js
+```js-nolint
 var a = 1;
 var b = 2;
 var c = 3;
 
 // precedencia por defecto
-a + b * c     // 7
+a + b * c; // 7
 // es evaluada por defecto como:
-a + (b * c)   // 7
+a + (b * c); // 7
 
 // ahora se sobrescribe la precedencia
 // para que la adición se evalúe antes que la multiplicación
-(a + b) * c   // 9
+(a + b) * c; // 9
 
 // que es equivalente a:
-a * c + b * c // 9
+a * c + b * c; // 9
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/operators/import.meta/index.md
+++ b/files/es/web/javascript/reference/operators/import.meta/index.md
@@ -44,7 +44,7 @@ Por ejemplo, con el siguiente HTML:
 
 ```html
 <script type="module">
-import './index.mjs?someURLInfo=5';
+  import "./index.mjs?someURLInfo=5";
 </script>
 ```
 
@@ -52,17 +52,17 @@ import './index.mjs?someURLInfo=5';
 
 ```js
 // index.mjs
-new URL(import.meta.url).searchParams.get('someURLInfo'); // 5
+new URL(import.meta.url).searchParams.get("someURLInfo"); // 5
 ```
 
 Lo mismo aplica cuando un archivo importa otro:
 
 ```js
 // index.mjs
-import './index2.mjs?someURLInfo=5';
+import "./index2.mjs?someURLInfo=5";
 
 // index2.mjs
-new URL(import.meta.url).searchParams.get('someURLInfo'); // 5
+new URL(import.meta.url).searchParams.get("someURLInfo"); // 5
 ```
 
 Nota que mientras Node.js pasa en la consulta los parámetros (o el hash ) como en el último ejemplo, a partir de Node 14.1.0, una URL con parametros en la consulta fallará cuando se carguen en el formato `node --experimental-modules index.mjs?someURLInfo=5` (es tratado como un archivo en lugar de una URL en este contexto).

--- a/files/es/web/javascript/reference/operators/in/index.md
+++ b/files/es/web/javascript/reference/operators/in/index.md
@@ -15,6 +15,7 @@ prop in object
 ### Parámetros
 
 - `prop`
+
   - : Una cadena o expresión númerica que representa el nombre de una propiedad o el índice de un array (lo que no sea un símbolo se forzará a string).
 
 - `object`
@@ -27,30 +28,30 @@ Los siguientes ejemplos muestran algunos de los usos del operador `in`.
 ```js
 // Arrays
 var arboles = new Array("secoya", "pino", "cedro", "roble", "arce");
-0 in arboles        // devuelve true
-3 in arboles        // devuelve true
-6 in arboles        // devuelve false
-"pino" in arboles   // devuelve false (debe especificar el número de índice,
-                    // no el valor del índice)
-"length" in arboles // devuelve true (length es una propiedad de Array)
+0 in arboles; // devuelve true
+3 in arboles; // devuelve true
+6 in arboles; // devuelve false
+"pino" in arboles; // devuelve false (debe especificar el número de índice,
+// no el valor del índice)
+"length" in arboles; // devuelve true (length es una propiedad de Array)
 
 // Objetos predefinidos
-"PI" in Math        // devuelve true
+"PI" in Math; // devuelve true
 
 // Objetos personalizados
-var micoche = {marca: "Honda", modelo: "Accord", año: 1998};
-"marca" in micoche  // devuelve true
-"modelo" in micoche // devuelve true
+var micoche = { marca: "Honda", modelo: "Accord", año: 1998 };
+"marca" in micoche; // devuelve true
+"modelo" in micoche; // devuelve true
 ```
 
 Debe especificar un objeto en el lado derecho del operador `in`. Por ejemplo, puede especificar una cadena creada con el constructor `String` , pero no puede especificar una cadena literal.
 
 ```js
 var color1 = new String("verde");
-"length" in color1 // devuelve true
+"length" in color1; // devuelve true
 
 var color2 = "coral";
-"length" in color2 // genera un error (color2 no es un objeto String)
+"length" in color2; // genera un error (color2 no es un objeto String)
 ```
 
 ### Usando `in` con propiedades eliminadas o no definidas
@@ -58,9 +59,9 @@ var color2 = "coral";
 Si se elimina una propiedad con el operador {{jsxref("Operadores/delete", "delete")}}, el operador `in` devuelve `false` para esa propiedad.
 
 ```js
-var micoche= {marca: "Honda", modelo: "Accord", año: 1998};
+var micoche = { marca: "Honda", modelo: "Accord", año: 1998 };
 delete micoche.marca;
-"marca" in micoche;  // devuelve false
+"marca" in micoche; // devuelve false
 
 var arboles = new Array("secoya", "pino", "cedro", "roble", "arce");
 delete arboles[3];
@@ -70,9 +71,9 @@ delete arboles[3];
 Si se cambia una propiedad a {{jsxref("Objetos_globales/undefined", "undefined")}} pero no se elimina, el operador `in` devuelve true para esa propiedad.
 
 ```js
-var micoche = {marca: "Honda", modelo: "Accord", año: 1998};
+var micoche = { marca: "Honda", modelo: "Accord", año: 1998 };
 micoche.marca = undefined;
-"marca" in micoche;  // devuelve true
+"marca" in micoche; // devuelve true
 ```
 
 ```js

--- a/files/es/web/javascript/reference/operators/instanceof/index.md
+++ b/files/es/web/javascript/reference/operators/instanceof/index.md
@@ -19,6 +19,7 @@ objeto instanceof constructor
 ### Parámetros
 
 - `objeto`
+
   - : Objeto a verificar.
 
 - `constructor`
@@ -31,10 +32,10 @@ Utilice `instanceof` cuando necesite confirmar el tipo de un objeto en tiempo de
 Debe especificar un objeto en el lado derecho del operador `instanceof`. Por ejemplo, puede especificar una cadena creada con el constructor `String`, pero no puede especificar un literal de cadena.
 
 ```js
-color1 = new String("verde")
-color1 instanceof String // devuelve verdadero (true)
-color2 = "coral"
-color2 instanceof String // devuelve falso (color2 no es un objeto String)
+color1 = new String("verde");
+color1 instanceof String; // devuelve verdadero (true)
+color2 = "coral";
+color2 instanceof String; // devuelve falso (color2 no es un objeto String)
 ```
 
 ### Ejemplos
@@ -46,7 +47,7 @@ También vea los ejemplos de {{jsxref("Sentencias/throw", "throw")}}.
 El siguiente código utiliza `instanceof` para determinar si `elDia` es un objeto `Date`. Debido a que `elDia` es un objeto `Date`, las instrucciones de la sentencia if se ejecutan.
 
 ```js
-elDia = new Date(1995, 12, 17)
+elDia = new Date(1995, 12, 17);
 if (elDia instanceof Date) {
   // instrucciones a ejecutar
 }
@@ -57,16 +58,16 @@ if (elDia instanceof Date) {
 El siguiente código utiliza `instanceof` para demostrar que los objetos `String` y `Date` son también del tipo `Object` (éstos se derivan de `Object`).
 
 ```js
-miCadena = new String()
-miFecha = new Date()
+miCadena = new String();
+miFecha = new Date();
 
-miCadena instanceof String // devuelve true
-miCadena instanceof Object // devuelve true
-miCadena instanceof Date   // devuelve false
+miCadena instanceof String; // devuelve true
+miCadena instanceof Object; // devuelve true
+miCadena instanceof Date; // devuelve false
 
-miFecha instanceof Date     // devuelve true
-miFecha instanceof Object   // devuelve true
-miFecha instanceof String   // devuelve false
+miFecha instanceof Date; // devuelve true
+miFecha instanceof Object; // devuelve true
+miFecha instanceof String; // devuelve false
 ```
 
 #### Ejemplo: Demostrando que `miCoche` es del tipo `Coche` y del tipo `Object`
@@ -75,11 +76,11 @@ El siguiente código crea un objeto del tipo `Coche` y una instancia de ese tipo
 
 ```js
 function Coche(fabricante, modelo, ejercicio) {
-  this.fabricante = fabricante
-  this.modelo = modelo
-  this.ejercicio= ejercicio
+  this.fabricante = fabricante;
+  this.modelo = modelo;
+  this.ejercicio = ejercicio;
 }
-miCoche = new Coche("Honda", "Accord", 1998)
-a = miCoche instanceof Coche // devuelve verdadero (true)
-b = miCoche instanceof Object // devuelve verdadero (true)
+miCoche = new Coche("Honda", "Accord", 1998);
+a = miCoche instanceof Coche; // devuelve verdadero (true)
+b = miCoche instanceof Object; // devuelve verdadero (true)
 ```

--- a/files/es/web/javascript/reference/operators/new.target/index.md
+++ b/files/es/web/javascript/reference/operators/new.target/index.md
@@ -28,8 +28,8 @@ En llamadas a funciones normales (en contraposición a llamadas a constructores)
 
 ```js
 function Foo() {
-  if (!new.target) throw 'Foo() debe ser llamado con new';
-  console.log('Foo instanciado con new');
+  if (!new.target) throw "Foo() debe ser llamado con new";
+  console.log("Foo instanciado con new");
 }
 
 Foo(); // Lanza "Foo() debe ser llamado con new"
@@ -47,7 +47,11 @@ class A {
   }
 }
 
-class B extends A { constructor() { super(); } }
+class B extends A {
+  constructor() {
+    super();
+  }
+}
 
 var a = new A(); // escribe en el log "A"
 var b = new B(); // escribe en el log "B"

--- a/files/es/web/javascript/reference/operators/new/index.md
+++ b/files/es/web/javascript/reference/operators/new/index.md
@@ -19,6 +19,7 @@ new constructor[([arguments])]
 ### Parámetros
 
 - `constructor`
+
   - : Una clase o función que especifica el tipo de instancia del objeto.
 
 - `arguments`
@@ -55,18 +56,18 @@ function Car() {}
 car1 = new Car();
 car2 = new Car();
 
-console.log(car1.color);    // undefined
+console.log(car1.color); // undefined
 
-Car.prototype.color = 'color original';
-console.log(car1.color);    // 'color original'
+Car.prototype.color = "color original";
+console.log(car1.color); // 'color original'
 
-car1.color = 'black';
-console.log(car1.color);    // 'black'
+car1.color = "black";
+console.log(car1.color); // 'black'
 
 console.log(Object.getPrototypeOf(car1).color); // 'color original'
 console.log(Object.getPrototypeOf(car2).color); // 'color original'
-console.log(car1.color);   // 'black'
-console.log(car2.color);   // 'color original'
+console.log(car1.color); // 'black'
+console.log(car2.color); // 'color original'
 ```
 
 > **Nota:** Si no escribiste el operador `new`, **la función `constructor` se invocará como cualquier función normal**, _sin crear un objeto._ En este caso, el valor de `this` también es diferente.
@@ -88,7 +89,7 @@ function Car(make, model, year) {
 Ahora puedes crear un objeto llamado `myCar` de la siguiente manera:
 
 ```js
-var myCar = new Car('Eagle', 'Talon TSi', 1993);
+var myCar = new Car("Eagle", "Talon TSi", 1993);
 ```
 
 Esta declaración crea `myCar` y le asigna los valores especificados para sus propiedades. Entonces el valor de `myCar.make` es la cadena "Eagle", `myCar.year` es el entero 1993, y así sucesivamente.
@@ -96,7 +97,7 @@ Esta declaración crea `myCar` y le asigna los valores especificados para sus pr
 Puedes crear cualquier número de objetos `car` mediante llamadas a `new`. Por ejemplo:
 
 ```js
-var kensCar = new Car('Nissan', '300ZX', 1992);
+var kensCar = new Car("Nissan", "300ZX", 1992);
 ```
 
 ### Propiedad del objeto que en sí mismo es otro objeto
@@ -114,8 +115,8 @@ function Person(name, age, sex) {
 Y luego creas una instancia de dos nuevos objetos `Person` de la siguiente manera:
 
 ```js
-var rand = new Person('Rand McNally', 33, 'M');
-var ken = new Person('Ken Jones', 39, 'M');
+var rand = new Person("Rand McNally", 33, "M");
+var ken = new Person("Ken Jones", 39, "M");
 ```
 
 Luego, puedes reescribir la definición de `Car` para incluir una propiedad para `owner` (propietario en español) que tome un objeto `Person`, de la siguiente manera:
@@ -132,14 +133,14 @@ function Car(make, model, year, owner) {
 Para crear instancias de los nuevos objetos, utiliza lo siguiente:
 
 ```js
-var car1 = new Car('Eagle', 'Talon TSi', 1993, rand);
-var car2 = new Car('Nissan', '300ZX', 1992, ken);
+var car1 = new Car("Eagle", "Talon TSi", 1993, rand);
+var car2 = new Car("Nissan", "300ZX", 1992, ken);
 ```
 
 En lugar de pasar una cadena literal o un valor entero al crear los nuevos objetos, las declaraciones anteriores pasan los objetos `rand` y `ken` como parámetros para los propietarios. Para conocer el nombre del propietario de `car2`, puedes acceder a la siguiente propiedad:
 
 ```js
-car2.owner.name
+car2.owner.name;
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/operators/null/index.md
+++ b/files/es/web/javascript/reference/operators/null/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'null'
+title: "null"
 slug: Web/JavaScript/Reference/Operators/null
 original_slug: Web/JavaScript/Reference/Global_Objects/null
 ---
@@ -35,10 +35,10 @@ El valor `null` es un literal (no una propiedad del objeto global como podría s
 ### Diferencias entre `null` y `undefined`
 
 ```js
-typeof null        // object (bug en ECMAScript, debería ser null)
-typeof undefined   // undefined
-null === undefined // false
-null  == undefined // true
+typeof null; // object (bug en ECMAScript, debería ser null)
+typeof undefined; // undefined
+null === undefined; // false
+null == undefined; // true
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/es/web/javascript/reference/operators/operator_precedence/index.md
@@ -22,8 +22,8 @@ con la precedencia más alta va primero y la asociatividad no importa. Observe c
 tiene mayor precedencia que la suma y se ejecuta primero, a pesar de que la suma se escribe primero en el código.
 
 ```js
-console.log(3 + 10 * 2);   // muestra 23
-console.log(3 + (10 * 2)); // muestra 23 porque los paréntesis son superfluos
+console.log(3 + 10 * 2); // muestra 23
+console.log(3 + 10 * 2); // muestra 23 porque los paréntesis son superfluos
 console.log((3 + 10) * 2); // muestra 26 porque los paréntesis cambian el orden
 ```
 
@@ -198,20 +198,20 @@ paréntesis. Se podría decir que el operador de conjunción lógica ("&&") est�
 son la disyunción lógica ("||"), la coalescencia nula ("??"), el encadenamiento opcional ("?."),
 y el operador condicional ternario. A continuación, algunos ejemplos.
 
-```js
-a || (b * c);  // evalúa primero `a`, luego produce `a` si `a` es "truthy"
-a && (b < c);  // evalúa primero `a`, luego produce `a` si `a` es "falsy"
+```js-nolint
+a || (b * c); // evalúa primero `a`, luego produce `a` si `a` es "truthy"
+a && (b < c); // evalúa primero `a`, luego produce `a` si `a` es "falsy"
 a ?? (b || c); // evalúa primero `a`, luego produce `a` si `a` no es `null` ni `undefined`
-a?.b.c;        // evalúa primero `a`, luego produce `undefined` si `a` es `null` ó `undefined`
+a?.b.c; // evalúa primero `a`, luego produce `undefined` si `a` es `null` ó `undefined`
 ```
 
 ## Ejemplos
 
 ```js
-3 > 2 && 2 > 1
+3 > 2 && 2 > 1;
 // Retorna `true`
 
-3 > 2 > 1
+3 > 2 > 1;
 // Retorna `false` porque 3 > 2 es `true`, luego `true` es convertido a 1
 // por coerción de tipos, luego `true` > 1 se convierte en 1 > 1, que es
 // `false`. Agregar paréntesis hace que las cosas se vean claras: (3 > 2) > 1.

--- a/files/es/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/es/web/javascript/reference/operators/optional_chaining/index.md
@@ -43,7 +43,7 @@ Al usar el operador `?.` en lugar de solo el `.`, JavaScript sabe verificar impl
 
 Esto es equivalente a lo siguiente, excepto que la variable temporal es de hecho no creada:
 
-```js
+```js-nolint
 let temp = obj.first;
 let nestedProp = ((temp === null || temp === undefined) ? undefined : temp.second);
 ```
@@ -69,9 +69,9 @@ Si utiliza callbacks o métodos de recuperación de un objeto con[una asignació
 function doSomething(onContent, onError) {
   try {
     // ... hacer algo con los datos
-  }
-  catch (err) {
-    if (onError) { // Probando si onError realmente existe
+  } catch (err) {
+    if (onError) {
+      // Probando si onError realmente existe
       onError(err.message);
     }
   }
@@ -82,9 +82,8 @@ function doSomething(onContent, onError) {
 // Usando encadenamiento opcional con llamado de funciones
 function doSomething(onContent, onError) {
   try {
-   // ... hacer algo con los datos
-  }
-  catch (err) {
+    // ... hacer algo con los datos
+  } catch (err) {
     onError?.(err.message); // Sin excepción si onError esta undefined
   }
 }
@@ -95,7 +94,7 @@ function doSomething(onContent, onError) {
 También puede usar el operador de encadenamiento opcional al acceder a propiedades con una expresión usando [la notación de corchetes](/es/docs/Web/JavaScript/Reference/Operators/Property_Accessors#Bracket_notation):
 
 ```js
-let nestedProp = obj?.['prop' + 'Name'];
+let nestedProp = obj?.["prop" + "Name"];
 ```
 
 ### El encadenamiento opcional no es válido al lado izquierdo de una asignación
@@ -119,7 +118,7 @@ Este ejemplo busca el valor de la propiedad `name` para el miembro `bar` en un m
 
 ```js
 let myMap = new Map();
-myMap.set("foo", {name: "baz", desc: "inga"});
+myMap.set("foo", { name: "baz", desc: "inga" });
 
 let nameBar = myMap.get("bar")?.name;
 ```
@@ -145,8 +144,8 @@ let customer = {
   name: "Carl",
   details: {
     age: 82,
-    location: "Paradise Falls" // "detailed address" es desconocida
-  }
+    location: "Paradise Falls", // "detailed address" es desconocida
+  },
 };
 let customerCity = customer.details?.address?.city;
 
@@ -161,7 +160,7 @@ El {{JSxRef("Operators/Nullish_Coalescing_Operator", "operador de fusión nulo",
 ```js
 let customer = {
   name: "Carl",
-  details: { age: 82 }
+  details: { age: 82 },
 };
 const customerCity = customer?.city ?? "Unknown city";
 console.log(customerCity); // Unknown city

--- a/files/es/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/es/web/javascript/reference/operators/property_accessors/index.md
@@ -26,7 +26,7 @@ objeto.propiedad = set;
 Ejemplo:
 
 ```js
-document.createElement('pre');
+document.createElement("pre");
 ```
 
 Aquí, el método llamado "createElement" se recupera de `document` y se le llama.
@@ -43,7 +43,7 @@ objeto[nombre_propiedad] = set;
 Ejemplo:
 
 ```js
-document['createElement']('pre');
+document["createElement"]("pre");
 ```
 
 Esto hace exactamente lo mismo que el ejemplo anterior.
@@ -56,15 +56,17 @@ Ejemplos:
 
 ```js
 var objeto = {};
-objeto['1'] = 'valor';
+objeto["1"] = "valor";
 alert(objeto[1]);
 ```
 
 Ésto tendrá como resultado "valor", ya que 1 se convertirá por tipo a '1'.
 
 ```js
-var foo = {propiedad_unica: 1}, bar = {propiedad_unica: 2}, objeto = {};
-objeto[foo] = 'valor';
+var foo = { propiedad_unica: 1 },
+  bar = { propiedad_unica: 2 },
+  objeto = {};
+objeto[foo] = "valor";
 alert(objeto[bar]);
 ```
 
@@ -81,7 +83,7 @@ Vea [enlace a métodos](/es/docs/Web/JavaScript/Referencia/Operadores/this#Funci
 Los principiantes en JavaScript a menudo tienen el error de usar {{jsxref("eval")}} cuando la notación por corchetes puede usarse a cambio. Por ejemplo, la siguiente sintaxis se ve a menudo en muchos scripts.
 
 ```js
-x = eval('document.nombre_formulario.' + cadenaControlFormulario + '.value');
+x = eval("document.nombre_formulario." + cadenaControlFormulario + ".value");
 ```
 
 `eval` es lenta y se debería evitar en la medida de lo posible. Es mejor usar la notación por corchetes a cambio:

--- a/files/es/web/javascript/reference/operators/remainder/index.md
+++ b/files/es/web/javascript/reference/operators/remainder/index.md
@@ -25,33 +25,33 @@ Operador: var1 % var2
 ### Resto con dividendo positivo
 
 ```js
- 12 % 5  //  2
- 1 % -2 //  1
- 1 % 2  //  1
- 2 % 3  //  2
-5.5 % 2 // 1.5
+12 % 5; //  2
+1 % -2; //  1
+1 % 2; //  1
+2 % 3; //  2
+5.5 % 2; // 1.5
 ```
 
 ### Resto con dividendo negativo
 
 ```js
--12 % 5 // -2
--1 % 2  // -1
--4 % 2  // -0
+(-12 % 5) - // -2
+  (1 % 2) - // -1
+  (4 % 2); // -0
 ```
 
 ### Resto con NaN
 
 ```js
-NaN % 2 // NaN
+NaN % 2; // NaN
 ```
 
 ### Resto con Infinity
 
 ```js
-Infinity % 2 // NaN
-Infinity % 0 // NaN
-Infinity % Infinity // NaN
+Infinity % 2; // NaN
+Infinity % 0; // NaN
+Infinity % Infinity; // NaN
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/es/web/javascript/reference/operators/spread_syntax/index.md
@@ -37,7 +37,7 @@ let objClone = { ...obj };
 Es frecuente usar {{jsxref( "Function.prototype.apply")}} en casos donde quieres usar los elementos de un arreglo como argumentos de una función.
 
 ```js
-function myFunction(x, y, z) { }
+function myFunction(x, y, z) {}
 var args = [0, 1, 2];
 myFunction.apply(null, args);
 ```
@@ -45,7 +45,7 @@ myFunction.apply(null, args);
 Con la sintaxis expandida (spread syntax), el código anterior puede ser escrito como:
 
 ```js
-function myFunction(x, y, z) { }
+function myFunction(x, y, z) {}
 var args = [0, 1, 2];
 myFunction(...args);
 ```
@@ -53,7 +53,7 @@ myFunction(...args);
 Cualquier argumento en la lista de argumentos puede usar la sintáxis expandida y esto puede ser usado varias veces.
 
 ```js
-function myFunction(v, w, x, y, z) { }
+function myFunction(v, w, x, y, z) {}
 var args = [0, 1];
 myFunction(-1, ...args, 2, ...[3]);
 ```
@@ -63,7 +63,7 @@ myFunction(-1, ...args, 2, ...[3]);
 Cuando se llama un constructor con `new`, no es posible usar **directamente** un arreglo y `apply` (`apply` hace un `[[Call]]` y no un `[[Construct]]`). Sin embargo, un arreglo puede ser fácilmente usado con un new gracias a la sintáxis expandida:
 
 ```js
-var dateFields = [1970, 0, 1];  // 1 Jan 1970
+var dateFields = [1970, 0, 1]; // 1 Jan 1970
 var d = new Date(...dateFields);
 ```
 
@@ -71,27 +71,26 @@ Para usar **new** con un arreglo de parámetros sin la sintáxis expandida, podr
 
 ```js
 function applyAndNew(constructor, args) {
-   function partial () {
-      return constructor.apply(this, args);
-   };
-   if (typeof constructor.prototype === "object") {
-      partial.prototype = Object.create(constructor.prototype);
-   }
-   return partial;
+  function partial() {
+    return constructor.apply(this, args);
+  }
+  if (typeof constructor.prototype === "object") {
+    partial.prototype = Object.create(constructor.prototype);
+  }
+  return partial;
 }
 
-
-function myConstructor () {
-   console.log("arguments.length: " + arguments.length);
-   console.log(arguments);
-   this.prop1="val1";
-   this.prop2="val2";
-};
+function myConstructor() {
+  console.log("arguments.length: " + arguments.length);
+  console.log(arguments);
+  this.prop1 = "val1";
+  this.prop2 = "val2";
+}
 
 var myArguments = ["hi", "how", "are", "you", "mr", null];
 var myConstructorWithArguments = applyAndNew(myConstructor, myArguments);
 
-console.log(new myConstructorWithArguments);
+console.log(new myConstructorWithArguments());
 // (internal log of myConstructor):           arguments.length: 6
 // (internal log of myConstructor):           ["hi", "how", "are", "you", "mr", null]
 // (log of "new myConstructorWithArguments"): {prop1: "val1", prop2: "val2"}
@@ -104,8 +103,8 @@ console.log(new myConstructorWithArguments);
 Sin **`sintaxis expandida (spread syntax)`**, para crear un nuevo arreglo usando un arreglo existente como parte de él,no es suficiente la sintaxis de Array literal y en su lugar se debe usar código imperativo con una combinación de `push`, `splice`, `concat`, etc. Con la sintaxis expandida, esto se vuelve mucho mas práctico:
 
 ```js
-var parts = ['shoulders', 'knees'];
-var lyrics = ['head', ...parts, 'and', 'toes'];
+var parts = ["shoulders", "knees"];
+var lyrics = ["head", ...parts, "and", "toes"];
 // ["head", "shoulders", "knees", "and", "toes"]
 ```
 
@@ -156,7 +155,7 @@ arr1 = [...arr1, ...arr2];
 var arr1 = [0, 1, 2];
 var arr2 = [3, 4, 5];
 // Prepend all items from arr2 onto arr1
-Array.prototype.unshift.apply(arr1, arr2) // arr1 is now [3, 4, 5, 0, 1, 2]
+Array.prototype.unshift.apply(arr1, arr2); // arr1 is now [3, 4, 5, 0, 1, 2]
 ```
 
 Con la sintaxis spread se convierte en \[Observa, sin embargo, que esto crea un nuevo arreglo `arr1`. Diferente a {{jsxref("Array.unshift")}}, esto no modifica el arreglo original en sitio `arr1`]:
@@ -174,8 +173,8 @@ La propuesta [Propiedades Rest/Spread para ECMAScript](https://github.com/tc39/p
 Shallow-cloning (excluyendo prototype) o la combinación de objetos es ahora posible usando una sintaxis más corta que {{jsxref("Object.assign()")}}.
 
 ```js
-var obj1 = { foo: 'bar', x: 42 };
-var obj2 = { foo: 'baz', y: 13 };
+var obj1 = { foo: "bar", x: 42 };
+var obj2 = { foo: "baz", y: 13 };
 
 var clonedObj = { ...obj1 };
 // Object { foo: "bar", x: 42 }
@@ -189,14 +188,14 @@ Observa que {{jsxref("Object.assign()")}} desencadena [setters](/es/docs/Web/Jav
 Observa que tú no puedes reemplazar o replicar la función {{jsxref("Object.assign()")}}:
 
 ```js
-var obj1 = { foo: 'bar', x: 42 };
-var obj2 = { foo: 'baz', y: 13 };
-const merge = ( ...objects ) => ( { ...objects } );
+var obj1 = { foo: "bar", x: 42 };
+var obj2 = { foo: "baz", y: 13 };
+const merge = (...objects) => ({ ...objects });
 
-var mergedObj = merge ( obj1, obj2);
+var mergedObj = merge(obj1, obj2);
 // Object { 0: { foo: 'bar', x: 42 }, 1: { foo: 'baz', y: 13 } }
 
-var mergedObj = merge ( {}, obj1, obj2);
+var mergedObj = merge({}, obj1, obj2);
 // Object { 0: {}, 1: { foo: 'bar', x: 42 }, 2: { foo: 'baz', y: 13 } }
 ```
 
@@ -207,7 +206,7 @@ En el ejemplo de arriba, el operador spread no trabaja como uno podría esperar:
 La sintaxis Spread (otra que en el caso de las propiedades spread) puede ser aplicada sólo a los objetos [iterables](/es/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator):
 
 ```js
-var obj = {'key1': 'value1'};
+var obj = { key1: "value1" };
 var array = [...obj]; // TypeError: obj is not iterable
 ```
 

--- a/files/es/web/javascript/reference/operators/strict_equality/index.md
+++ b/files/es/web/javascript/reference/operators/strict_equality/index.md
@@ -37,41 +37,41 @@ La diferencia más notable entre este operador y el operador de [igualdad](/es/d
 ### Comparando operandos del mismo tipo
 
 ```js
-console.log("hello" === "hello");   // true
-console.log("hello" === "hola");    // false
+console.log("hello" === "hello"); // true
+console.log("hello" === "hola"); // false
 
-console.log(3 === 3);               // true
-console.log(3 === 4);               // false
+console.log(3 === 3); // true
+console.log(3 === 4); // false
 
-console.log(true === true);         // true
-console.log(true === false);        // false
+console.log(true === true); // true
+console.log(true === false); // false
 
-console.log(null === null);         // true
+console.log(null === null); // true
 ```
 
 ### Comparando operandos de distinto tipo
 
 ```js
-console.log("3" === 3);           // false
+console.log("3" === 3); // false
 
-console.log(true === 1);          // false
+console.log(true === 1); // false
 
-console.log(null === undefined);  // false
+console.log(null === undefined); // false
 ```
 
 ### Comparando objetos
 
 ```js
 const object1 = {
-  name: "hello"
-}
+  name: "hello",
+};
 
 const object2 = {
-  name: "hello"
-}
+  name: "hello",
+};
 
-console.log(object1 === object2);  // false
-console.log(object1 === object1);  // true
+console.log(object1 === object2); // false
+console.log(object1 === object1); // true
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/operators/subtraction/index.md
+++ b/files/es/web/javascript/reference/operators/subtraction/index.md
@@ -21,14 +21,14 @@ Operator: x - y
 ### Sustracción con números
 
 ```js
-5 - 3     // 2
-3 - 5     // -2
+5 - 3; // 2
+3 - 5; // -2
 ```
 
 ### Sustracción de no numéricos
 
 ```js
-'foo' - 3 // NaN
+"foo" - 3; // NaN
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/operators/super/index.md
+++ b/files/es/web/javascript/reference/operators/super/index.md
@@ -33,12 +33,12 @@ Este fragmento de código se toma del [ejemplo de clases](https://github.com/Goo
 ```js
 class Rectangle {
   constructor(height, width) {
-    this.name = 'Rectangle';
+    this.name = "Rectangle";
     this.height = height;
     this.width = width;
   }
   sayName() {
-    console.log('Hi, I am a ', this.name + '.');
+    console.log("Hi, I am a ", this.name + ".");
   }
   get area() {
     return this.height * this.width;
@@ -58,7 +58,7 @@ class Square extends Rectangle {
 
     // Nota: En las clases derivadas, se debe llamar a super() antes de
     // poder usar 'this'. Salir de esto provocará un error de referencia.
-    this.name = 'Square';
+    this.name = "Square";
   }
 }
 ```
@@ -71,14 +71,14 @@ También puede llamar a super en métodos estáticos.
 class Rectangle {
   constructor() {}
   static logNbSides() {
-    return 'Tengo 4 lados';
+    return "Tengo 4 lados";
   }
 }
 
 class Square extends Rectangle {
   constructor() {}
   static logDescription() {
-    return super.logNbSides() + ' que son todos iguales';
+    return super.logNbSides() + " que son todos iguales";
   }
 }
 Square.logDescription(); // 'Tengo 4 lados que son todos iguales'
@@ -110,10 +110,10 @@ Al definir propiedades que no se pueden escribir, p. Ej. {{jsxref("Object.define
 ```js
 class X {
   constructor() {
-    Object.defineProperty(this, 'prop', {
+    Object.defineProperty(this, "prop", {
       configurable: true,
       writable: false,
-      value: 1
+      value: 1,
     });
   }
   f() {
@@ -133,15 +133,15 @@ Super también se puede usar en el [inicializador de objetos / notación literal
 ```js
 var obj1 = {
   method1() {
-    console.log('method 1');
-  }
-}
+    console.log("method 1");
+  },
+};
 
 var obj2 = {
   method2() {
-   super.method1();
-  }
-}
+    super.method1();
+  },
+};
 
 Object.setPrototypeOf(obj2, obj1);
 obj2.method2(); // logs "method 1"

--- a/files/es/web/javascript/reference/operators/this/index.md
+++ b/files/es/web/javascript/reference/operators/this/index.md
@@ -47,7 +47,7 @@ Dentro de una función, el valor de this depende de cómo la función es llamada
 ### Llamada simple
 
 ```js
-function f1(){
+function f1() {
   return this;
 }
 
@@ -57,7 +57,7 @@ f1() === window; // objeto global
 En este caso, el valor de **this** no está establecido por la llamada. Dado que el código no está en modo estricto, el valor de this debe ser siempre un objeto por lo que por defecto es el objeto global.
 
 ```js
-function f2(){
+function f2() {
   "use strict"; // consultar modo estricto
   return this;
 }
@@ -78,9 +78,9 @@ En el siguiente ejemplo, cuando **`o.f()`** es invocado, dentro de la función *
 ```js
 var o = {
   prop: 37,
-  f: function() {
+  f: function () {
     return this.prop;
-  }
+  },
 };
 
 console.log(o.f()); // logs 37
@@ -89,7 +89,7 @@ console.log(o.f()); // logs 37
 Note que el comportamiento no es del todo afectado por cómo o dónde la función fue definida. En el ejemplo anterior, nosotros definimos la función en línea como el elemento `f` durante la definición de `o`. Sin embargo, podriamos haber definido con la misma facilidad la primera función y luego adjuntarlo a `o.f`. Hacerlo da como resultado el mismo comportamiento.
 
 ```js
-var o = {prop: 37};
+var o = { prop: 37 };
 
 function independent() {
   return this.prop;
@@ -105,7 +105,7 @@ Esto demuestra que sólo importa que la función fue invocada del elemento `f` d
 Asimismo, el enlace `this` sólo se ve afectado por la referencia del miembro más inmediata. En el siguiente ejemplo, cuando invocamos a la función, lo llamamos como metodo `g` del objeto `o.b`. Esta vez durante la ejecución, `this` dentro de la función se referirá a `o.b`. El hecho de que el objeto es en sí mismo un elemento de `o` no tiene ninguna consecuencia, la referencia más inmediata es todo lo que importa.
 
 ```js
-o.b = {g: independent, prop: 42};
+o.b = { g: independent, prop: 42 };
 console.log(o.b.g()); // logs 42
 ```
 
@@ -114,7 +114,11 @@ console.log(o.b.g()); // logs 42
 El mismo concepto es válido para los métodos definidos en alguna parte de la cadena de prototipo del objeto. Si el método esta sobre una cadena de prototipo del objeto, `this` se referirá al objeto donde está el método de donde fue llamado. Como si ese método estuviera dentro del objeto.
 
 ```js
-var o = {f:function(){ return this.a + this.b; }};
+var o = {
+  f: function () {
+    return this.a + this.b;
+  },
+};
 var p = Object.create(o);
 p.a = 1;
 p.b = 4;
@@ -129,19 +133,23 @@ En este ejemplo, el objeto asignado a la variable `p` no tiene su propia propied
 Nuevamente, el mismo concepto es válido cuando una función es invocada de un getter o un setter. Una función usado como getter o setter tiene su enlace `this` al objeto desde el cual la propiedad esta siendo establecida u obtenida.
 
 ```js
-function modulus(){
+function modulus() {
   return Math.sqrt(this.re * this.re + this.im * this.im);
 }
 
 var o = {
   re: 1,
   im: -1,
-  get phase(){
+  get phase() {
     return Math.atan2(this.im, this.re);
-  }
+  },
 };
 
-Object.defineProperty(o, 'modulus', {get: modulus, enumerable:true, configurable:true});
+Object.defineProperty(o, "modulus", {
+  get: modulus,
+  enumerable: true,
+  configurable: true,
+});
 
 console.log(o.phase, o.modulus); // logs -0.78 1.4142
 ```
@@ -167,17 +175,16 @@ Cuando una función es usada como un constructor (con la palabra clave {{jsxref(
  * }
  */
 
-function C(){
+function C() {
   this.a = 37;
 }
 
 var o = new C();
 console.log(o.a); // logs 37
 
-
-function C2(){
+function C2() {
   this.a = 37;
-  return {a:38};
+  return { a: 38 };
 }
 
 o = new C2();
@@ -191,11 +198,11 @@ En el último ejemplo (`C2`), debido a que un objeto fue devuelto durante la con
 Cuando una función usa la plabra clave `this` en su cuerpo, su valor puede ser enlazado a un objeto particular durante la ejecución del método {{jsxref("Function.call()", "call()")}} or {{jsxref("Function.apply()", "apply()")}} que todas las funciones hereden de `Function.prototype`.
 
 ```js
-function add(c, d){
+function add(c, d) {
   return this.a + this.b + c + d;
 }
 
-var o = {a:1, b:3};
+var o = { a: 1, b: 3 };
 
 // El primer parámetro es el objeto a usar como 'this', parámetros posteriores se pasan como argumentos
 // en la llamada a la función
@@ -211,14 +218,14 @@ add.apply(o, [10, 20]); // 1 + 3 + 10 + 20 = 34
 ECMAScript 5 introduce {{jsxref("Function.prototype.bind()")}}. Llamando a `f.bind(someObject)` crea una nueva función con el mismo cuerpo y alcance de `f`, pero donde `this` se produce en la función original, en la nueva función esto esta permanentemente ligado al primer argumento de `bind`, independientemente de cómo la función está siendo utilizada.
 
 ```js
-function f(){
+function f() {
   return this.a;
 }
 
-var g = f.bind({a:"azerty"});
+var g = f.bind({ a: "azerty" });
 console.log(g()); // azerty
 
-var o = {a:37, f:f, g:g};
+var o = { a: 37, f: f, g: g };
 console.log(o.f(), o.g()); // 37, azerty
 ```
 
@@ -229,18 +236,18 @@ Cuando una función es usada como un controlador de eventos, su `this` es cambia
 ```js
 // Cuando se llama como un listener, convierte en azul el elemento
 // relacionado
-function bluify(e){
+function bluify(e) {
   console.log(this === e.currentTarget); // Siempre true
-  console.log(this === e.target);        // true cuando currentTarget y target son el mismo objeto
-  this.style.backgroundColor = '#A5D9F3';
+  console.log(this === e.target); // true cuando currentTarget y target son el mismo objeto
+  this.style.backgroundColor = "#A5D9F3";
 }
 
 // Consigue una lista de cada elemento en un documento
-var elements = document.getElementsByTagName('*');
+var elements = document.getElementsByTagName("*");
 
 // Añade bluify como un click listener asi cuando se hace click sobre el elemento,
 // este cambia a azul
-for(var i=0 ; i<elements.length ; i++){
-  elements[i].addEventListener('click', bluify, false);
+for (var i = 0; i < elements.length; i++) {
+  elements[i].addEventListener("click", bluify, false);
 }
 ```

--- a/files/es/web/javascript/reference/operators/typeof/index.md
+++ b/files/es/web/javascript/reference/operators/typeof/index.md
@@ -18,59 +18,59 @@ El operador `typeof` devuelve una cadena que indica el tipo del operando sin eva
 Suponga que define las siguientes variables:
 
 ```js
-var miFuncion = new Function("5+2")
-var forma = "redonda"
-var tamano = 1
-var hoy = new Date()
+var miFuncion = new Function("5+2");
+var forma = "redonda";
+var tamano = 1;
+var hoy = new Date();
 ```
 
 El operador `typeof` devuelve los siguientes resultados para estas variables
 
 ```js
-typeof miFuncion === 'function'
-typeof forma === 'string'
-typeof tamano === 'number'
-typeof hoy === 'object'
-typeof noExiste === 'undefined'
+typeof miFuncion === "function";
+typeof forma === "string";
+typeof tamano === "number";
+typeof hoy === "object";
+typeof noExiste === "undefined";
 ```
 
 Para las palabras clave `true` y `null`, el operador `typeof` devuelve los siguientes resultados:
 
 ```js
-typeof true === 'boolean'
-typeof null === 'object'
+typeof true === "boolean";
+typeof null === "object";
 ```
 
 Para un número o una cadena, el operador `typeof` devuelve los siguientes resultados:
 
 ```js
-typeof 62 === 'number'
-typeof 'Hola mundo' === 'string'
+typeof 62 === "number";
+typeof "Hola mundo" === "string";
 ```
 
 Para valores de propiedades, el operador `typeof` devuelve el tipo del valor que contiene la propiedad:
 
 ```js
-typeof document.lastModified === 'string'
-typeof window.length === 'number'
-typeof Math.LN2 === 'number'
+typeof document.lastModified === "string";
+typeof window.length === "number";
+typeof Math.LN2 === "number";
 ```
 
 Para métodos y funciones, el operador `typeof` devuelve los resultados siguientes:
 
 ```js
-typeof blur === 'function'
-typeof eval === 'function'
-typeof parseInt === 'function'
-typeof shape.split === 'function'
+typeof blur === "function";
+typeof eval === "function";
+typeof parseInt === "function";
+typeof shape.split === "function";
 ```
 
 Para objetos predefinidos, el operador `typeof` devuelve los siguientes resultados:
 
 ```js
-typeof Date === 'function'
-typeof Function === 'function'
-typeof Math === 'object'
-typeof Object === 'function'
-typeof String === 'function'
+typeof Date === "function";
+typeof Function === "function";
+typeof Math === "object";
+typeof Object === "function";
+typeof String === "function";
 ```

--- a/files/es/web/javascript/reference/operators/yield/index.md
+++ b/files/es/web/javascript/reference/operators/yield/index.md
@@ -49,10 +49,10 @@ Entre la ruta del código del generador, sus operadores `yield` y la capacidad d
 El siguiente código es la declaración de una función generadora de ejemplo.
 
 ```js
-function* countAppleSales () {
-  let saleList = [3, 7, 5]
+function* countAppleSales() {
+  let saleList = [3, 7, 5];
   for (let i = 0; i < saleList.length; i++) {
-    yield saleList[i]
+    yield saleList[i];
   }
 }
 ```
@@ -60,34 +60,34 @@ function* countAppleSales () {
 Una vez que se define una función generadora, se puede usar construyendo un iterador como el siguiente.
 
 ```js
-let appleStore = countAppleSales()  // Generator { }
-console.log(appleStore.next())      // { value: 3, done: false }
-console.log(appleStore.next())      // { value: 7, done: false }
-console.log(appleStore.next())      // { value: 5, done: false }
-console.log(appleStore.next())      // { value: undefined, done: true }
+let appleStore = countAppleSales(); // Generator { }
+console.log(appleStore.next()); // { value: 3, done: false }
+console.log(appleStore.next()); // { value: 7, done: false }
+console.log(appleStore.next()); // { value: 5, done: false }
+console.log(appleStore.next()); // { value: undefined, done: true }
 ```
 
 También puedes enviar un valor con `next(value)` al generador. '`step`' se evalúa como un valor de retorno en esta sintaxis \[_rv_] = **yield** \[_expression_]
 
 ```js
 function* counter(value) {
- let step;
+  let step;
 
- while (true) {
-   step = yield ++value;
+  while (true) {
+    step = yield ++value;
 
-   if (step) {
-     value += step;
-   }
- }
+    if (step) {
+      value += step;
+    }
+  }
 }
 
 const generatorFunc = counter(0);
-console.log(generatorFunc.next().value);   // 1
-console.log(generatorFunc.next().value);   // 2
-console.log(generatorFunc.next().value);   // 3
+console.log(generatorFunc.next().value); // 1
+console.log(generatorFunc.next().value); // 2
+console.log(generatorFunc.next().value); // 3
 console.log(generatorFunc.next(10).value); // 14
-console.log(generatorFunc.next().value);   // 15
+console.log(generatorFunc.next().value); // 15
 console.log(generatorFunc.next(10).value); // 26
 ```
 

--- a/files/es/web/javascript/reference/operators/yield_star_/index.md
+++ b/files/es/web/javascript/reference/operators/yield_star_/index.md
@@ -96,9 +96,9 @@ console.log(iterator.next()); // { value: 1, done: false }
 console.log(iterator.next()); // { value: 2, done: false }
 console.log(iterator.next()); // { value: 3, done: false }
 console.log(iterator.next()); // { value: undefined, done: true },
-                              // g4() returned { value: "foo", done: true } at this point
+// g4() returned { value: "foo", done: true } at this point
 
-console.log(result);          // "foo"
+console.log(result); // "foo"
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/statements/async_function/index.md
+++ b/files/es/web/javascript/reference/statements/async_function/index.md
@@ -55,13 +55,12 @@ Una función `async` puede contener una expresión {{jsxref("Operators/await", "
 
 ```js
 function resolveAfter2Seconds(x) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(() => {
       resolve(x);
     }, 2000);
   });
 }
-
 
 async function add1(x) {
   const a = await resolveAfter2Seconds(20);
@@ -69,19 +68,18 @@ async function add1(x) {
   return x + a + b;
 }
 
-add1(10).then(v => {
-  console.log(v);  // prints 60 after 4 seconds.
+add1(10).then((v) => {
+  console.log(v); // prints 60 after 4 seconds.
 });
-
 
 async function add2(x) {
   const p_a = resolveAfter2Seconds(20);
   const p_b = resolveAfter2Seconds(30);
-  return x + await p_a + await p_b;
+  return x + (await p_a) + (await p_b);
 }
 
-add2(10).then(v => {
-  console.log(v);  // prints 60 after 2 seconds.
+add2(10).then((v) => {
+  console.log(v); // prints 60 after 2 seconds.
 });
 ```
 
@@ -94,10 +92,10 @@ Una API que devuelva una {{jsxref("Promise")}} tendrá como resultado una cadena
 ```js
 function getProcessedData(url) {
   return downloadData(url) // returns a promise
-    .catch(e => {
-      return downloadFallbackData(url)  // returns a promise
+    .catch((e) => {
+      return downloadFallbackData(url); // returns a promise
     })
-    .then(v => {
+    .then((v) => {
       return processDataInWorker(v); // returns a promise
     });
 }
@@ -110,7 +108,7 @@ async function getProcessedData(url) {
   let v;
   try {
     v = await downloadData(url);
-  } catch(e) {
+  } catch (e) {
     v = await downloadFallbackData(url);
   }
   return processDataInWorker(v);

--- a/files/es/web/javascript/reference/statements/block/index.md
+++ b/files/es/web/javascript/reference/statements/block/index.md
@@ -25,7 +25,7 @@ Esta sentencia se utiliza comúnmente para controlar sentencias de flujo (es dec
 
 ```js
 while (x < 10) {
-   x++;
+  x++;
 }
 ```
 
@@ -34,7 +34,7 @@ Las variables declaradas con `var` **no** tienen alcance de bloque(block scope).
 ```js
 var x = 1;
 {
-   var x = 2;
+  var x = 2;
 }
 alert(x); // resultado 2
 ```
@@ -72,12 +72,12 @@ Tenga en cuenta que la variable `const c = 2 con alcance de bloque`, **_no_ lanz
 La [declaración de una función](/es/docs/Web/JavaScript/Reference/Statements/function) también tiene un alcance limitado dentro del bloque donde se produce la declaración:
 
 ```js
-nacion('frances');  // TypeError: nacion no es una función
+nacion("frances"); // TypeError: nacion no es una función
 {
   function nacion(nacionalidad) {
-   console.log('Yo soy ' + nacionalidad);
+    console.log("Yo soy " + nacionalidad);
   }
-nacion('español'); // correcto. logs Yo soy español
+  nacion("español"); // correcto. logs Yo soy español
 }
 ```
 

--- a/files/es/web/javascript/reference/statements/break/index.md
+++ b/files/es/web/javascript/reference/statements/break/index.md
@@ -31,13 +31,12 @@ La siguiente función tiene una sentencia que termina el bucle {{jsxref("Sentenc
 
 ```js
 function comprobarBreak(x) {
-   var i = 0;
-   while (i < 6) {
-      if (i == 3)
-         break;
-      i++;
-   }
-   return i * x;
+  var i = 0;
+  while (i < 6) {
+    if (i == 3) break;
+    i++;
+  }
+  return i * x;
 }
 ```
 

--- a/files/es/web/javascript/reference/statements/class/index.md
+++ b/files/es/web/javascript/reference/statements/class/index.md
@@ -33,7 +33,7 @@ En el siguiente ejemplo, primero definimos la clase `Polygon`, luego extendemos 
 ```js
 class Polygon {
   constructor(height, width) {
-    this.name = 'Polygon';
+    this.name = "Polygon";
     this.height = height;
     this.width = width;
   }
@@ -42,7 +42,7 @@ class Polygon {
 class Square extends Polygon {
   constructor(length) {
     super(length, length);
-    this.name = 'Square';
+    this.name = "Square";
   }
 }
 ```

--- a/files/es/web/javascript/reference/statements/const/index.md
+++ b/files/es/web/javascript/reference/statements/const/index.md
@@ -19,6 +19,7 @@ const varname1 = value1 [, varname2 = value2 [, varname3 = value3 [, ... [, varn
 ```
 
 - `varnameN`
+
   - : Nombre de la constante. Puede ser un identificador legal.
 
 - `valueN`

--- a/files/es/web/javascript/reference/statements/continue/index.md
+++ b/files/es/web/javascript/reference/statements/continue/index.md
@@ -39,10 +39,11 @@ El siguiente ejemplo muestra un bucle {{jsxref("Sentencias/while", "while")}} qu
 i = 0;
 n = 0;
 while (i < 5) {
-   i++;
-   if (i == 3)
-      continue;
-   n += i;
+  i++;
+  if (i == 3) {
+    continue;
+  }
+  n += i;
 }
 ```
 
@@ -53,17 +54,14 @@ En el siguiente ejemplo, una sentencia etiquetada `checkiandj` contiene una sent
 Si `continue` tuviese una etiqueta `checkiandj`, el programa continuaría hasta encima de la sentencia `checkiandj`.
 
 ```js
-checkiandj:
-while (i < 4) {
+checkiandj: while (i < 4) {
   document.write(i + "<br>");
   i += 1;
 
-  checkj:
-  while (j > 4) {
+  checkj: while (j > 4) {
     document.write(j + "<br>");
     j -= 1;
-    if ((j % 2) == 0)
-      continue checkj;
+    if (j % 2 == 0) continue checkj;
     document.write(j + " is odd.<br>");
   }
   document.write("i = " + i + "<br>");

--- a/files/es/web/javascript/reference/statements/debugger/index.md
+++ b/files/es/web/javascript/reference/statements/debugger/index.md
@@ -20,15 +20,15 @@ El siguiente ejemplo muestra un bloque de código donde ha sido insertada una se
 
 ```js
 function codigoPotencialmenteDefectuoso() {
-    debugger;
-    // realizar paso a paso o examinar código que contiene
-    // potenciales errores
+  debugger;
+  // realizar paso a paso o examinar código que contiene
+  // potenciales errores
 }
 ```
 
 Cuando el depurador es invocado, la ejecución se detiene en la sentencia debugger. Es como un punto de interrupción en el script.
 
-[![Paused at a debugger statement.](screen_shot_2014-02-07_at_9.14.35_am.png)](<screen_shot_2014-02-07_at_9.14.35_am.png>)
+[![Paused at a debugger statement.](screen_shot_2014-02-07_at_9.14.35_am.png)](screen_shot_2014-02-07_at_9.14.35_am.png)
 
 ## Especificaciones
 

--- a/files/es/web/javascript/reference/statements/do...while/index.md
+++ b/files/es/web/javascript/reference/statements/do...while/index.md
@@ -19,6 +19,7 @@ while (condición);
 ```
 
 - `sentencia`
+
   - : Una sentencia que se ejecuta al menos una vez y es reejecutada cada vez que la condición se evalúa a verdadera. Para ejecutar múltiples sentencias dentro de un bucle, utilice la sentencia {{jsxref("Statements/block", "block")}} (`{ ... }`) para agrupar aquellas sentencias.
 
 - `condición`
@@ -32,8 +33,8 @@ En el siguiente ejemplo, el bucle hacer mientras itera al menos una vez y se rei
 
 ```js
 do {
-   i += 1;
-   document.write(i);
+  i += 1;
+  document.write(i);
 } while (i < 5);
 ```
 

--- a/files/es/web/javascript/reference/statements/empty/index.md
+++ b/files/es/web/javascript/reference/statements/empty/index.md
@@ -26,7 +26,9 @@ La sentencia vacía es comúnmente usada en bucles. Por ejemplo, un bucle for si
 var arr = [1, 2, 3];
 
 // Asignar el valor 0 a todos los elementos del array
-for (i = 0; i < arr.length; arr[i++] = 0) /* sentencia vacía */ ;
+for (i = 0; i < arr.length; arr[i++] = 0) {
+  /* sentencia vacía */
+}
 
 console.log(arr);
 // [0, 0, 0]
@@ -34,16 +36,17 @@ console.log(arr);
 
 **Nota:** Es una buena práctica comentar el uso intencional de la sentencia vacía, ya que no es fácilmente distinguible de un punto y coma normal. Un ejemplo de uso probablemente no intencional:
 
-```js
-if (condicion);  // Esta condición no ejerce ningún control!
-   borrarTodo()  // Por lo cual esta sentencia será ejecutada siempre!!!
+```js-nolint
+if (condicion); // Esta condición no ejerce ningún control!
+  borrarTodo(); // Por lo cual esta sentencia será ejecutada siempre!!!
 ```
 
 Otro ejemplo de uso:
 
 ```js
-var a = 1, b = 1;
-if((a == 0) || (b = 0)); // Asigna a 'b' el valor cero si 'a' no es cero.
+var a = 1,
+  b = 1;
+if (a == 0 || (b = 0)); // Asigna a 'b' el valor cero si 'a' no es cero.
 console.log(b); // 0
 ```
 

--- a/files/es/web/javascript/reference/statements/export/index.md
+++ b/files/es/web/javascript/reference/statements/export/index.md
@@ -51,7 +51,7 @@ Existen dos tipos diferentes de exportación , **nombrada** y **por defecto**. S
 - Exports por defecto (function):
 
   ```js
-  export default function() {}
+  export default function () {}
   ```
 
 - Exports por defecto (class):
@@ -67,7 +67,7 @@ Pero un export por defecto puede ser importado con cualquier nombre, por ejemplo
 ```js
 export default k = 12; // en el archivo test.js
 
-import m from './test' // notese que tenemos la libertad de usar import m en lugar de import k, porque k era el export por defecto
+import m from "./test"; // notese que tenemos la libertad de usar import m en lugar de import k, porque k era el export por defecto
 
 console.log(m); // escribirá 12
 ```
@@ -83,7 +83,7 @@ export * from …;
 Si necesita exportar por defecto, escriba lo siguiente en su lugar:
 
 ```js
-import mod from 'mod';
+import mod from "mod";
 export default mod;
 ```
 
@@ -100,14 +100,14 @@ function cube(x) {
 }
 const foo = Math.PI + Math.SQRT2;
 var graph = {
-    options:{
-        color:'white',
-        thickness:'2px'
-    },
-    draw: function(){
-        console.log('From graph draw function');
-    }
-}
+  options: {
+    color: "white",
+    thickness: "2px",
+  },
+  draw: function () {
+    console.log("From graph draw function");
+  },
+};
 export { cube, foo, graph };
 ```
 
@@ -119,14 +119,14 @@ De esta forma, en otro script, podemos tener:
 //open the page in a httpserver,otherwise there will be a CORS policy error.
 //script demo.js
 
-import { cube, foo, graph } from 'my-module';
+import { cube, foo, graph } from "my-module";
 graph.options = {
-    color:'blue',
-    thickness:'3px'
+  color: "blue",
+  thickness: "3px",
 };
 graph.draw();
 console.log(cube(3)); // 27
-console.log(foo);    // 4.555806215962888
+console.log(foo); // 4.555806215962888
 ```
 
 ### Usando el export por defecto
@@ -143,7 +143,7 @@ export default function cube(x) {
 De esta forma la importación de un export default será sumamemte sencilla:
 
 ```js
-import cube from 'my-module';
+import cube from "my-module";
 console.log(cube(3)); // 27
 ```
 

--- a/files/es/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/es/web/javascript/reference/statements/for-await...of/index.md
@@ -38,15 +38,15 @@ var asyncIterable = {
         }
 
         return Promise.resolve({ done: true });
-      }
+      },
     };
-  }
+  },
 };
 
-(async function() {
-   for await (let num of asyncIterable) {
-     console.log(num);
-   }
+(async function () {
+  for await (let num of asyncIterable) {
+    console.log(num);
+  }
 })();
 
 // 0
@@ -66,7 +66,7 @@ async function* asyncGenerator() {
   }
 }
 
-(async function() {
+(async function () {
   for await (let num of asyncGenerator()) {
     console.log(num);
   }
@@ -108,7 +108,7 @@ async function getResponseSize(url) {
   // salida esperada: "Tamaño de la respuesta: 1071472"
   return responseSize;
 }
-getResponseSize('https://jsonplaceholder.typicode.com/photos');
+getResponseSize("https://jsonplaceholder.typicode.com/photos");
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/statements/for...in/index.md
+++ b/files/es/web/javascript/reference/statements/for...in/index.md
@@ -61,7 +61,7 @@ Es posible que se utilice de forma más práctica con fines de depuración, ya q
 El siguiente bucle `for...in` itera sobre todas las propiedades enumerables que no son símbolos del objeto y registra una cadena de los nombres de propiedad y sus valores.
 
 ```js
-var obj = {a: 1, b: 2, c: 3};
+var obj = { a: 1, b: 2, c: 3 };
 
 for (const prop in obj) {
   console.log(`obj.${prop} = ${obj[prop]}`);
@@ -78,10 +78,10 @@ for (const prop in obj) {
 La siguiente función ilustra el uso de {{JSxRef("Object.prototype.hasOwnProperty", "hasOwnProperty()")}} — las propiedades heredadas no se muestran.
 
 ```js
-var triangle = {a: 1, b: 2, c: 3};
+var triangle = { a: 1, b: 2, c: 3 };
 
 function ColoredTriangle() {
-  this.color = 'red';
+  this.color = "red";
 }
 
 ColoredTriangle.prototype = triangle;

--- a/files/es/web/javascript/reference/statements/for...of/index.md
+++ b/files/es/web/javascript/reference/statements/for...of/index.md
@@ -78,7 +78,11 @@ for (let value of iterable) {
 ### Iterando un {{jsxref("Map")}}
 
 ```js
-let iterable = new Map([["a", 1], ["b", 2], ["c", 3]]);
+let iterable = new Map([
+  ["a", 1],
+  ["b", 2],
+  ["c", 3],
+]);
 
 for (let entry of iterable) {
   console.log(entry);
@@ -111,7 +115,7 @@ for (let value of iterable) {
 ### Iterando un objeto arguments
 
 ```js
-(function() {
+(function () {
   for (let argument of arguments) {
     console.log(argument);
   }
@@ -141,11 +145,11 @@ for (let paragraph of articleParagraphs) {
 En los bucles `for...of`, se puede causar que la iteración termine de un modo brusco usando: `break`, `continue[4]`, `throw` or `return[5]`. En estos casos la iteración se cierra.
 
 ```js
-function* foo(){
+function* foo() {
   yield 1;
   yield 2;
   yield 3;
-};
+}
 
 for (let o of foo()) {
   console.log(o);
@@ -158,7 +162,8 @@ for (let o of foo()) {
 También es posible iterar las nuevas funciones **[generator](/es/docs/Web/JavaScript/Reference/Statements/function*)**:
 
 ```js
-function* fibonacci() { // una función generador
+function* fibonacci() {
+  // una función generador
   let [prev, curr] = [0, 1];
   while (true) {
     [prev, curr] = [curr, prev + curr];
@@ -178,14 +183,14 @@ for (let n of fibonacci()) {
 > **Nota:** **No se deben reutilizar los generadores.** Los generadores no deben ser reutilizados, incluso si el bucle **`for...of`** se ha terminado antes de tiempo con la sentencia [break](/es/docs/Web/JavaScript/Referencia/Sentencias/break). Una vez abandonado el bucle, el generador está cerrado y tratar de iterar sobre él de nuevo no dará más resultados. Firefox no ha implementado aún este comportamiento y el generador puede ser reutilizado en contra de lo escrito en el estándar ES6 ([13.7.5.13, step 5m](https://www.ecma-international.org/ecma-262/6.0/#sec-13.7.5.13)), pero esto cambiará una vez que el bug [Error 1147371 en Firefox](https://bugzil.la/1147371) haya sido corregido.
 
 ```js example-bad
-var gen = (function *(){
+var gen = (function* () {
   yield 1;
   yield 2;
   yield 3;
 })();
 for (let o of gen) {
   console.log(o);
-  break;  // Finaliza la iteración
+  break; // Finaliza la iteración
 }
 
 // El generador no debe ser reutilizado, lo siguiente no tiene sentido
@@ -208,9 +213,9 @@ var iterable = {
           return { value: this.i++, done: false };
         }
         return { value: undefined, done: true };
-      }
+      },
     };
-  }
+  },
 };
 
 for (var value of iterable) {
@@ -234,11 +239,11 @@ let arr = [3, 5, 7];
 arr.foo = "hola";
 
 for (let i in arr) {
-   console.log(i); // logs "0", "1", "2", "foo"
+  console.log(i); // logs "0", "1", "2", "foo"
 }
 
 for (let i of arr) {
-   console.log(i); // logs "3", "5", "7"
+  console.log(i); // logs "3", "5", "7"
 }
 ```
 

--- a/files/es/web/javascript/reference/statements/for/index.md
+++ b/files/es/web/javascript/reference/statements/for/index.md
@@ -17,12 +17,15 @@ for ([expresion-inicial]; [condicion]; [expresion-final])sentencia
 ```
 
 - `expresion-inicial`
+
   - : Una expresión (incluyendo las expresiones de asignación) o la declaración de variable. Típicamente se utiliza para usarse como variable contador. Esta expresión puede opcionalmente declarar nuevas variables con la palabra clave `var`. Estas variables no son locales del bucle, es decir, están en el mismo alcance en el que está el bucle `for`. El resultado de esta expresión es descartado.
 
 - `condicion`
+
   - : Una expresión para ser evaluada antes de cada iteración del bucle. Si esta expresión se evalúa como verdadera, se ejecuta `sentencia`. Esta comprobación condicional es opcional. Si se omite, la condición siempre se evalúa como verdadera. Si la expresión se evalúa como falsa, la ejecución salta a la primera expresión que sigue al constructor de `for`.
 
 - `expresion-final`
+
   - : Una expresión para ser evaluada al final de cada iteración del bucle. Esto ocurre antes de la siguiente evaluación de la `condicion`. Generalmente se usa para actualizar o incrementar la variable contador.
 
 - `sentencia`

--- a/files/es/web/javascript/reference/statements/function/index.md
+++ b/files/es/web/javascript/reference/statements/function/index.md
@@ -19,9 +19,11 @@ function nombre([parametro1] [,parametro2] [..., parametroN]) {sentencias}
 ```
 
 - `nombre`
+
   - : El nombre de la función.
 
 - `parametroN`
+
   - : El nombre de un argumento que se pasa a la función. Una función puede tener hasta 255 argumentos.
 
 - `sentencias`
@@ -45,7 +47,7 @@ El siguiente código declara una función que devuelve la cantidad total de vent
 
 ```js
 function calcular_ventas(unidades_a, unidades_b, unidades_c) {
-   return unidades_a*79 + unidades_b * 129 + unidades_c * 699;
+  return unidades_a * 79 + unidades_b * 129 + unidades_c * 699;
 }
 ```
 

--- a/files/es/web/javascript/reference/statements/function_star_/index.md
+++ b/files/es/web/javascript/reference/statements/function_star_/index.md
@@ -19,9 +19,11 @@ function* nombre([param[, param[, ... param]]]) {
 ```
 
 - `nombre`
+
   - : El nombre de la función.
 
 - `param`
+
   - : El nombre de los argumentos que se le van a pasar a la función. Una función puede tener hasta 255 argumentos.
 
 - `instrucciones`
@@ -38,10 +40,9 @@ La llamada a una función generadora no ejecuta su cuerpo inmediatamente; se dev
 ### Ejemplo simple
 
 ```js
-function* idMaker(){
+function* idMaker() {
   var index = 0;
-  while(index < 3)
-    yield index++;
+  while (index < 3) yield index++;
 }
 
 var gen = idMaker();
@@ -62,7 +63,7 @@ function* anotherGenerator(i) {
   yield i + 3;
 }
 
-function* generator(i){
+function* generator(i) {
   yield i;
   yield* anotherGenerator(i);
   yield i + 10;

--- a/files/es/web/javascript/reference/statements/if...else/index.md
+++ b/files/es/web/javascript/reference/statements/if...else/index.md
@@ -17,9 +17,11 @@ if (condición) sentencia1 [else sentencia2]
 ```
 
 - `condición`
+
   - : Una expresión que puede ser evaluada como verdadera o falsa.
 
 - `sentencia1`
+
   - : Sentencia que se ejecutará si `condición` es evaluada como verdadera. Puede ser cualquier sentencia, incluyendo otras sentenccias `if` anidadas. Para ejecutar múltiples sentencias, use una sentencia {{jsxref("Sentencias/block", "block")}} ({ ... }) para agruparlas.
 
 - `sentencia2`
@@ -58,9 +60,9 @@ Para ejecutar varias sentencias en una cláusula, use una sentencia block (`{ ..
 
 ```js
 if (condición) {
-   sentencia1
+  sentencia1;
 } else {
-   sentencia2
+  sentencia2;
 }
 ```
 
@@ -77,10 +79,9 @@ if (b) // Esta condición se evalúa como verdadera
 
 ```js
 if (cipher_char == from_char) {
-   result = result + to_char;
-   x++;
-} else
-   result = result + clear_char;
+  result = result + to_char;
+  x++;
+} else result = result + clear_char;
 ```
 
 ### Ejemplo: Asignación en una expresión condicional
@@ -88,8 +89,8 @@ if (cipher_char == from_char) {
 Es aconsejable no usar asignaciones simples en una expresión condicional, porque la asignación puede ser confundida con igualdad (operador relacional) cuando se lee el código. Por ejemplo, no use el siguiente código:
 
 ```js
-if (x = y) {
-   /* sentencia */
+if ((x = y)) {
+  /* sentencia */
 }
 ```
 
@@ -97,7 +98,7 @@ Si realmente necesita una asignación dentro de una exprsión condicional, una p
 
 ```js
 if ((x = y)) {
-   /* sentencia */
+  /* sentencia */
 }
 ```
 

--- a/files/es/web/javascript/reference/statements/import/index.md
+++ b/files/es/web/javascript/reference/statements/import/index.md
@@ -44,7 +44,7 @@ El parámetro `name` es el nombre del objeto que recibirá los miembros exportad
 Esto inserta `myModule` en el ámbito actual, que contiene todos los elementos exportados en el archivo ubicado en `/modules/my-module.js`.
 
 ```js
-import * as myModule from '/modules/my-module.js';
+import * as myModule from "/modules/my-module.js";
 ```
 
 Aquí, para acceder a los miembros exportados habrá que usar el alias del módulo ("myModule" en este caso) como namespace. Por ejemplo, si el módulo importado arriba incluye un miembre exportado llamado `doAllTheAmazingThings()`, habría que invocarlo de la siguiente manera:
@@ -58,7 +58,7 @@ myModule.doAllTheAmazingThings();
 Dado un objeto o valor llamado `myExport` que ha sido exportado del módulo `my-module` ya sea implícitamente (porque todo el módulo ha sido exportado) o explícitamente (usando la sentencia {{jsxref("Sentencias/export", "export")}} ), esto inserta `myExport` en el ámbito actual.
 
 ```js
-import {myExport} from '/modules/my-module.js';
+import { myExport } from "/modules/my-module.js";
 ```
 
 ### Importa multiples miembros de un módulo
@@ -66,7 +66,7 @@ import {myExport} from '/modules/my-module.js';
 Esto inserta `foo` y `bar` en el ámbito actual.
 
 ```js
-import {foo, bar} from "my-module.js";
+import { foo, bar } from "my-module.js";
 ```
 
 ### Importa un miembre con un alias mas conveniente
@@ -74,8 +74,7 @@ import {foo, bar} from "my-module.js";
 Se puede renombrar un miembro exportado cuando se importa. Por ejemplo, esto inserta `shortName` en el ámbito actual.
 
 ```js
-import {reallyReallyLongModuleExportName as shortName}
-  from '/modules/my-module.js';
+import { reallyReallyLongModuleExportName as shortName } from "/modules/my-module.js";
 ```
 
 ### Renombra multiples miembros durante la importación
@@ -85,8 +84,8 @@ Importa múltiples miembros exportados de un módulo con un alias conveniente.
 ```js
 import {
   reallyReallyLongModuleExportName as shortName,
-  anotherLongModuleName as short
-} from '/modules/my-module.js';
+  anotherLongModuleName as short,
+} from "/modules/my-module.js";
 ```
 
 ### Importa un módulo entero para efectos secundarios sólamente
@@ -94,7 +93,7 @@ import {
 Importa un módulo entero para efectos secundarios sólamente, sin importar ningun elemento. Esto ejecuta el código global del módulo, pero no importa ningún valor.
 
 ```js
-import '/modules/my-module.js';
+import "/modules/my-module.js";
 ```
 
 ### Importación de elementos por defecto
@@ -104,20 +103,20 @@ Es posible tener una exportación por defecto (tanto si se trata de un objeto, f
 La versión más sencilla de importar un elemento por defecto es:
 
 ```js
-import myDefault from '/modules/my-module.js';
+import myDefault from "/modules/my-module.js";
 ```
 
 También es posible usar la sintaxis por defecto con lo que hemos visto anteriormente (importación de espacios de nombres o importaciones con nombre. En esos casos, la importación por defecto se deberá realizar en primer lugar. Por ejemplo:
 
 ```js
-import myDefault, * as myModule from '/modules/my-module.js';
+import myDefault, * as myModule from "/modules/my-module.js";
 // myModule used as a namespace
 ```
 
 o
 
 ```js
-import myDefault, {foo, bar} from '/modules/my-module.js';
+import myDefault, { foo, bar } from "/modules/my-module.js";
 // specific, named imports
 ```
 
@@ -131,24 +130,25 @@ Importar un archivo secundario para asistir en un procesamiento de una petición
 function getJSON(url, callback) {
   let xhr = new XMLHttpRequest();
   xhr.onload = function () {
-    callback(this.responseText)
+    callback(this.responseText);
   };
-  xhr.open('GET', url, true);
+  xhr.open("GET", url, true);
   xhr.send();
 }
 
 export function getUsefulContents(url, callback) {
-  getJSON(url, data => callback(JSON.parse(data)));
+  getJSON(url, (data) => callback(JSON.parse(data)));
 }
 ```
 
 ### El programa principal: main.js
 
 ```js
-import { getUsefulContents } from '/modules/file.js';
+import { getUsefulContents } from "/modules/file.js";
 
-getUsefulContents('http://www.example.com',
-    data => { doSomethingUseful(data); });
+getUsefulContents("http://www.example.com", (data) => {
+  doSomethingUseful(data);
+});
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/statements/index.md
+++ b/files/es/web/javascript/reference/statements/index.md
@@ -77,6 +77,7 @@ Puedes encontrarlas por orden alfabético en la columna de la izquierda .
 - {{jsxref("Sentencias/import", "import")}}
   - : Usada para permitir a un escript importar propiedades, funciones y objetos desde otro script firmado que ha exportado su información. Esta antigua funcionalidad de Netscape ha sido removida y será redefinida por los modulos de ECMAScript 6.
 - {{jsxref("Sentencias/label", "label")}}
+
   - : Provee una instrucción con un identificador que puedes referir usando una instrucción `break` o `continue` .
 
 - {{deprecated_inline()}} {{jsxref("Sentencias/with", "with")}}

--- a/files/es/web/javascript/reference/statements/label/index.md
+++ b/files/es/web/javascript/reference/statements/label/index.md
@@ -19,6 +19,7 @@ etiqueta :sentencia
 ```
 
 - `etiqueta`
+
   - : Cualquier identificador JavaScript que no sea una palabra reservada.
 
 - `sentencia`

--- a/files/es/web/javascript/reference/statements/let/index.md
+++ b/files/es/web/javascript/reference/statements/let/index.md
@@ -43,7 +43,8 @@ if (x > y) {
 Es posible usar definiciones `let` para asociar código en extensiones con un pseudo-espacio-de-nombre (pseudo-namespace). (Ver [Mejores prácticas de seguridad en extensiones](/es/docs/Security_best_practices_in_extensions).)
 
 ```js
-let Cc = Components.classes, Ci = Components.interfaces;
+let Cc = Components.classes,
+  Ci = Components.interfaces;
 ```
 
 `let` puede ser útil para escribir código más limpio cuando usamos funciones internas.
@@ -73,19 +74,19 @@ Variables declaradas por `let` tienen por alcance el bloque en el que se han def
 function varTest() {
   var x = 31;
   if (true) {
-    var x = 71;  // ¡misma variable!
-    console.log(x);  // 71
+    var x = 71; // ¡misma variable!
+    console.log(x); // 71
   }
-  console.log(x);  // 71
+  console.log(x); // 71
 }
 
 function letTest() {
   let x = 31;
   if (true) {
-    let x = 71;  // variable diferente
-    console.log(x);  // 71
+    let x = 71; // variable diferente
+    console.log(x); // 71
   }
-  console.log(x);  // 31
+  console.log(x); // 31
 }
 // llamamos a las funciones
 varTest();
@@ -95,8 +96,8 @@ letTest();
 En el nivel superior de un programa y funciones, `let` , a diferencia de `var`, **no crea** una propiedad en el objeto global, por ejemplo:
 
 ```js
-var x = 'global';
-let y = 'global';
+var x = "global";
+let y = "global";
 console.log(this.x); // "global"
 console.log(this.y); // undefined
 ```
@@ -139,7 +140,7 @@ switch (x) {
 
   case 1:
     let foo; // Terminamos con un error de tipo SyntaxError.
-             // esto debido a la redeclaracion
+    // esto debido a la redeclaracion
     break;
 }
 ```
@@ -151,11 +152,11 @@ Debido al [ámbito léxico](https://www.ecma-international.org/ecma-262/6.0/#sec
 En esa misma línea, el `num` del bloque `if` ya se ha creado en el ámbito léxico, pero aún no ha alcanzado (y **terminado**) su inicialización (que es parte de la propia declaración): todavía está en la zona muerta temporal.
 
 ```js
-function prueba(){
-   var num = 33;
-   if (true) {
-      let num = (num + 55);//ReferenceError: no se puede acceder a la declaración léxica `num'antes de la inicialización
-   }
+function prueba() {
+  var num = 33;
+  if (true) {
+    let num = num + 55; //ReferenceError: no se puede acceder a la declaración léxica `num'antes de la inicialización
+  }
 }
 prueba();
 ```
@@ -174,8 +175,8 @@ if (a === 5) {
   let a = 4; // El alcance es dentro del bloque if
   var b = 1; // El alcance es global
 
-  console.log(a);  // 4
-  console.log(b);  // 1
+  console.log(a); // 4
+  console.log(b); // 1
 }
 
 console.log(a); // 5
@@ -187,7 +188,7 @@ console.log(b); // 1
 Es posible usar la palabra reservada `let` para enlazar variables con alcance local dentro del alcance de un bucle en lugar de usar una variable global (definida usando `var`) para dicho propósito.
 
 ```js
-for (let i = 0; i<10; i++) {
+for (let i = 0; i < 10; i++) {
   console.log(i); // 0, 1, 2, 3, 4 ... 9
 }
 

--- a/files/es/web/javascript/reference/statements/return/index.md
+++ b/files/es/web/javascript/reference/statements/return/index.md
@@ -36,15 +36,14 @@ return x + y / 3;
 La instrucción de retorno se ve afectada por la inserción automática de punto y coma (ASI). No se permite el terminador de línea entre la palabra clave de retorno y la expresión.
 
 ```js
-return
+return;
 a + b;
 ```
 
 se transforma por ASI en:
 
 ```html
-return;
-a + b;
+return; a + b;
 ```
 
 La consola le advertirá "código inalcanzable después de la declaración de retorno".
@@ -59,7 +58,7 @@ La siguiente función devuelve el cuadrado de su argumento, `x`, donde `x` es un
 
 ```js
 function cuadrado(x) {
-   return x * x;
+  return x * x;
 }
 ```
 

--- a/files/es/web/javascript/reference/statements/switch/index.md
+++ b/files/es/web/javascript/reference/statements/switch/index.md
@@ -31,6 +31,7 @@ switch (expresión) {
 - `expresión`
   - : Es una expresión que es comparada con el valor de cada instancia `case`.
 - `case valorN`
+
   - : Una instancia `case valorN` es usada para ser comparada con la `expresión`. Si la `expresión` coincide con el `valorN`, las declaraciones dentro de la instancia `case` se ejecutan hasta que se encuentre el final de la declaración `switch` o hasta encontrar una interrupción `break`.
 
 - `default`
@@ -52,24 +53,24 @@ En el siguiente ejemplo, si `expresión` se resuelve a "Platanos", el algoritmo 
 
 ```js
 switch (expr) {
-  case 'Naranjas':
-    console.log('El kilogramo de naranjas cuesta $0.59.');
+  case "Naranjas":
+    console.log("El kilogramo de naranjas cuesta $0.59.");
     break;
-  case 'Manzanas':
-    console.log('El kilogramo de manzanas cuesta $0.32.');
+  case "Manzanas":
+    console.log("El kilogramo de manzanas cuesta $0.32.");
     break;
-  case 'Platanos':
-    console.log('El kilogramo de platanos cuesta $0.48.');
+  case "Platanos":
+    console.log("El kilogramo de platanos cuesta $0.48.");
     break;
-  case 'Cerezas':
-    console.log('El kilogramo de cerezas cuesta $3.00.');
+  case "Cerezas":
+    console.log("El kilogramo de cerezas cuesta $3.00.");
     break;
-  case 'Mangos':
-  case 'Papayas':
-    console.log('El kilogramo de mangos y papayas cuesta $2.79.');
+  case "Mangos":
+  case "Papayas":
+    console.log("El kilogramo de mangos y papayas cuesta $2.79.");
     break;
   default:
-    console.log('Lo lamentamos, por el momento no disponemos de ' + expr + '.');
+    console.log("Lo lamentamos, por el momento no disponemos de " + expr + ".");
 }
 
 console.log("¿Hay algo más que te quisiera consultar?");
@@ -83,11 +84,11 @@ Si olvidas un `break`, el script se ejecutará desde donde se cumple la condici�
 var foo = 0;
 switch (foo) {
   case -1:
-    console.log('1 negativo');
+    console.log("1 negativo");
     break;
   case 0: // foo es 0, por lo tanto se cumple la condición y se ejecutara el siguiente bloque
-    console.log(0)
-    // NOTA: el "break" olvidado debería estar aquí
+    console.log(0);
+  // NOTA: el "break" olvidado debería estar aquí
   case 1: // No hay sentencia "break" en el 'case 0:', por lo tanto este caso también será ejecutado
     console.log(1);
     break; // Al encontrar un "break", no será ejecutado el 'case 2:'
@@ -95,7 +96,7 @@ switch (foo) {
     console.log(2);
     break;
   default:
-    console.log('default');
+    console.log("default");
 }
 ```
 
@@ -110,10 +111,10 @@ switch (foo) {
     console.log(2);
     break; // al encontrar este 'break' no se continuará con el siguiente 'default:'
   default:
-    console.log('default')
-    // fall-through
+    console.log("default");
+  // fall-through
   case 1:
-    console.log('1');
+    console.log("1");
 }
 ```
 
@@ -132,17 +133,17 @@ Este método toma ventaja del hecho de que, si no hay un `break` debajo de una d
 Este es un ejemplo de operación única con sentencia `switch` secuencial, donde cuatro valores diferentes se comportan exactamente de la misma manera:
 
 ```js
-var Animal = 'Jirafa';
+var Animal = "Jirafa";
 switch (Animal) {
-  case 'Vaca':
-  case 'Jirafa':
-  case 'Perro':
-  case 'Cerdo':
-    console.log('Este animal subirá al Arca de Noé.');
+  case "Vaca":
+  case "Jirafa":
+  case "Perro":
+  case "Cerdo":
+    console.log("Este animal subirá al Arca de Noé.");
     break;
-  case 'Dinosaurio':
+  case "Dinosaurio":
   default:
-    console.log('Este animal no lo hará.');
+    console.log("Este animal no lo hará.");
 }
 ```
 
@@ -152,27 +153,27 @@ Este es un ejemplo de una sentencia `switch` secuencial con múltiples operacion
 
 ```js
 var foo = 1;
-var output = 'Salida: ';
+var output = "Salida: ";
 switch (foo) {
   case 10:
-    output += '¿Y ';
+    output += "¿Y ";
   case 1:
-    output += 'Cuál ';
-    output += 'Es ';
+    output += "Cuál ";
+    output += "Es ";
   case 2:
-    output += 'Tu ';
+    output += "Tu ";
   case 3:
-    output += 'Nombre';
+    output += "Nombre";
   case 4:
-    output += '?';
+    output += "?";
     console.log(output);
     break;
   case 5:
-    output += '!';
+    output += "!";
     console.log(output);
     break;
   default:
-    console.log('Por favor, selecciona un valor del 1 al 6.');
+    console.log("Por favor, selecciona un valor del 1 al 6.");
 }
 ```
 

--- a/files/es/web/javascript/reference/statements/throw/index.md
+++ b/files/es/web/javascript/reference/statements/throw/index.md
@@ -37,28 +37,40 @@ Puede especificar un objeto cuando lanza una excepción. Puede entonces referenc
 
 ```js
 function ExceptionUsuario(mensaje) {
-   this.mensaje = mensaje;
-   this.nombre = "ExceptionUsuario";
+  this.mensaje = mensaje;
+  this.nombre = "ExceptionUsuario";
 }
 
 function getNombreMes(mes) {
-   mes = mes - 1; // Ajustar el número de mes al índice del arreglo (1 = Ene, 12 = Dic)
-   var meses = new Array("Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul",
-      "Ago", "Sep", "Oct", "Nov", "Dic");
-   if (meses[mes] != null) {
-      return meses[mes];
-   } else {
-      miExcepcionUsuario = new ExceptionUsuario("NumeroMesNoValido");
-      throw miExcepcionUsuario;
-   }
+  mes = mes - 1; // Ajustar el número de mes al índice del arreglo (1 = Ene, 12 = Dic)
+  var meses = new Array(
+    "Ene",
+    "Feb",
+    "Mar",
+    "Abr",
+    "May",
+    "Jun",
+    "Jul",
+    "Ago",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dic",
+  );
+  if (meses[mes] != null) {
+    return meses[mes];
+  } else {
+    miExcepcionUsuario = new ExceptionUsuario("NumeroMesNoValido");
+    throw miExcepcionUsuario;
+  }
 }
 
 try {
-   // sentencias para try
-   nombreMes = getNombreMes(miMes);
+  // sentencias para try
+  nombreMes = getNombreMes(miMes);
 } catch (excepcion) {
-   nombreMes = "desconocido";
-   registrarMisErrores(excepcion.mensaje, excepcion.nombre); // pasa el objeto exception al manejador de errores
+  nombreMes = "desconocido";
+  registrarMisErrores(excepcion.mensaje, excepcion.nombre); // pasa el objeto exception al manejador de errores
 }
 ```
 

--- a/files/es/web/javascript/reference/statements/try...catch/index.md
+++ b/files/es/web/javascript/reference/statements/try...catch/index.md
@@ -29,15 +29,19 @@ try {
 ```
 
 - `try_statements`
+
   - : Las sentencias que serán ejecutadas.
 
 - `catch_statements_1`, `catch_statements_2`
+
   - : Sentencias que se ejecutan si una excepción es lanzada en el bloque `try`.
 
 - `exception_var_1`, `exception_var_2`
+
   - : Identificador que contiene un objeto de excepcion asociado a la cláusula `catch`.
 
 - `condition_1`
+
   - : Una expresión condicional.
 
 - `finally_statements`
@@ -65,11 +69,10 @@ Cuando solo se utiliza un bloque `catch`, el bloque `catch` es ejecutado cuando 
 
 ```js
 try {
-   throw "myException"; // genera una excepción
-}
-catch (e) {
-   // sentencias para manejar cualquier excepción
-   logMyErrors(e); // pasa el objeto de la excepción al manejador de errores
+  throw "myException"; // genera una excepción
+} catch (e) {
+  // sentencias para manejar cualquier excepción
+  logMyErrors(e); // pasa el objeto de la excepción al manejador de errores
 }
 ```
 
@@ -127,13 +130,12 @@ Ahora, si esa rutina de limpieza debiera ser hecha ya sea que el código del `tr
 El siguiente ejemplo abre un archivo y despues ejecuta sentencias que usan el archivo (JavaScript del lado del servidor permite acceder a archivos). Si una excepción es lanzada mientras el archivo está abierto, la cláusula `finally` cierra el archivo antes de que el script falle. El código en `finally` también se ejecuta después de un retorno explícito de los bloques `try` o `catch`.
 
 ```js
-openMyFile()
+openMyFile();
 try {
-   // retiene un recurso
-   writeMyFile(theData);
-}
-finally {
-   closeMyFile(); // siempre cierra el recurso
+  // retiene un recurso
+  writeMyFile(theData);
+} finally {
+  closeMyFile(); // siempre cierra el recurso
 }
 ```
 
@@ -146,14 +148,12 @@ Primero, veamos que pasa con esto:
 ```js
 try {
   try {
-    throw new Error('oops');
+    throw new Error("oops");
+  } finally {
+    console.log("finally");
   }
-  finally {
-    console.log('finally');
-  }
-}
-catch (ex) {
-  console.error('outer', ex.message);
+} catch (ex) {
+  console.error("outer", ex.message);
 }
 
 // Output:
@@ -166,17 +166,14 @@ Ahora, si nosotros ya capturamos la excepción en una declaración try interna a
 ```js
 try {
   try {
-    throw new Error('oops');
+    throw new Error("oops");
+  } catch (ex) {
+    console.error("inner", ex.message);
+  } finally {
+    console.log("finally");
   }
-  catch (ex) {
-    console.error('inner', ex.message);
-  }
-  finally {
-    console.log('finally');
-  }
-}
-catch (ex) {
-  console.error('outer', ex.message);
+} catch (ex) {
+  console.error("outer", ex.message);
 }
 
 // Output:
@@ -189,18 +186,15 @@ Y ahora vamos a relanzar el error.
 ```js
 try {
   try {
-    throw new Error('oops');
-  }
-  catch (ex) {
-    console.error('inner', ex.message);
+    throw new Error("oops");
+  } catch (ex) {
+    console.error("inner", ex.message);
     throw ex;
+  } finally {
+    console.log("finally");
   }
-  finally {
-    console.log('finally');
-  }
-}
-catch (ex) {
-  console.error('outer', ex.message);
+} catch (ex) {
+  console.error("outer", ex.message);
 }
 
 // Output:
@@ -216,22 +210,19 @@ Cualquier excepción dada será capturada solo una vez por el bloque catch más 
 Si el bloque `finally` retorna un valor, este valor se convierte en el valor de retorno de toda la producción `try-catch-finally`, a pesar de cualquier sentencia `return` en los bloques `try` y `catch`. Esto incluye excepciones lanzadas dentro del bloque catch.
 
 ```js
-(function() {
+(function () {
   try {
     try {
-      throw new Error('oops');
-    }
-    catch (ex) {
-      console.error('inner', ex.message);
+      throw new Error("oops");
+    } catch (ex) {
+      console.error("inner", ex.message);
       throw ex;
-    }
-    finally {
-      console.log('finally');
+    } finally {
+      console.log("finally");
       return;
     }
-  }
-  catch (ex) {
-    console.error('outer', ex.message);
+  } catch (ex) {
+    console.error("outer", ex.message);
   }
 })();
 

--- a/files/es/web/javascript/reference/statements/var/index.md
+++ b/files/es/web/javascript/reference/statements/var/index.md
@@ -17,6 +17,7 @@ var nombreDeVariable1 [= valor1] [, nombreDeVariable2 [= valor2] ... [, nombreDe
 ```
 
 - `nombreDeVariableN`
+
   - : Representa el nombre que el programador da a la variable. Puede ser cualquier identificador legal.
 
 - `valorN`
@@ -32,7 +33,7 @@ Asignar un valor a una variable no declarada implica crearla como variable globa
 
 ```js
 function x() {
-  y = 1;   // Lanza un error de tipo "ReferenceError" en modo estricto ('use strict')
+  y = 1; // Lanza un error de tipo "ReferenceError" en modo estricto ('use strict')
   var z = 2;
 }
 
@@ -45,14 +46,14 @@ console.log(z); // Lanza un error de tipo "ReferenceError": z no está definida 
 2\. Las variables declaradas son creadas antes de ejecutar cualquier otro código. Las variables sin declarar no existen hasta que el código que las asigna es ejecutado.
 
 ```js
-console.log(a);                // Lanza un error de tipo "ReferenceError".
-console.log('trabajando...'); // Nunca se ejecuta.
+console.log(a); // Lanza un error de tipo "ReferenceError".
+console.log("trabajando..."); // Nunca se ejecuta.
 ```
 
 ```js
 var a;
-console.log(a);                // Imprime "undefined" o "" dependiendo del navegador.
-console.log('trabajando...'); // Imprime "trabajando...".
+console.log(a); // Imprime "undefined" o "" dependiendo del navegador.
+console.log("trabajando..."); // Imprime "trabajando...".
 ```
 
 3\. Las variables declaradas son una propiedad no-configurable de su contexto de ejecución (de función o global). Las variables sin declarar son configurables (p. ej. pueden borrarse).
@@ -110,24 +111,27 @@ function haz_algo() {
 ### Declarando e inicializando dos variables
 
 ```js
-var a = 0, b = 0;
+var a = 0,
+  b = 0;
 ```
 
 ### Asignando dos variables con un solo valor de cadena
 
 ```js
-var a = 'A';
+var a = "A";
 var b = a;
 
 // Equivalente a:
 
-var a, b = a = 'A';
+var a,
+  b = (a = "A");
 ```
 
 Sé consciente del orden:
 
 ```js
-var x = y, y = 'A';
+var x = y,
+  y = "A";
 console.log(x + y); // Imprimirá "undefinedA"
 ```
 
@@ -139,7 +143,7 @@ Aquí, '`x`' & '`y`' son declaradas antes de ejecutarse cualquier código, y la 
 var x = 0;
 
 function f() {
-  var x = y = 1; // 'x' es declarada localmente, ¡'y' no lo es!
+  var x = (y = 1); // 'x' es declarada localmente, ¡'y' no lo es!
 }
 f();
 
@@ -154,26 +158,28 @@ console.log(x, y); // Lanza un error de tipo "ReferenceError" en modo estricto (
 Las variables que parecen ser globales implícitas pueden ser referencias a variables en un ámbito externo a la función:
 
 ```js
-var x = 0;  // 'x' es declarada globalmente, luego se le asigna el valor 0.
+var x = 0; // 'x' es declarada globalmente, luego se le asigna el valor 0.
 
 console.log(typeof z); // Imprime "undefined", pues 'z' aún no existe.
 
-function a() { // Cuando 'a()' es invocada,
-  var y = 2;   // 'y' es declarada localmente en la function 'a()', después se le asigna el valor 2.
+function a() {
+  // Cuando 'a()' es invocada,
+  var y = 2; // 'y' es declarada localmente en la function 'a()', después se le asigna el valor 2.
 
-  console.log(x, y);   // Imprime "0, 2".
+  console.log(x, y); // Imprime "0, 2".
 
-  function b() {       // Cuando 'b()' es invocada,
-    x = 3;  // Asigna el valor 3 a la global 'x' ya existente, no crea una nueva variable global.
-    y = 4;  // Asigna 4 a la externa existente 'y', no crea una nueva variable global.
-    z = 5;  // Crea una nueva variable global 'z' y le asigna un valor de 5.
-  }         // (Lanza un error de tipo "ReferenceError" en modo estricto.)
+  function b() {
+    // Cuando 'b()' es invocada,
+    x = 3; // Asigna el valor 3 a la global 'x' ya existente, no crea una nueva variable global.
+    y = 4; // Asigna 4 a la externa existente 'y', no crea una nueva variable global.
+    z = 5; // Crea una nueva variable global 'z' y le asigna un valor de 5.
+  } // (Lanza un error de tipo "ReferenceError" en modo estricto.)
 
-  b();     // Invocar 'b()' crea 'z' como variable global.
-  console.log(x, y, z);  // Imprime "3, 4, 5".
+  b(); // Invocar 'b()' crea 'z' como variable global.
+  console.log(x, y, z); // Imprime "3, 4, 5".
 }
 
-a();                   // Invocar 'a()' también llama a 'b()'.
-console.log(x, z);     // Imprime "3, 5", porque 'z' ya es una global.
+a(); // Invocar 'a()' también llama a 'b()'.
+console.log(x, z); // Imprime "3, 5", porque 'z' ya es una global.
 console.log(typeof y); // Imprime 'undefined' porque 'y' es local en la función 'a()'
 ```

--- a/files/es/web/javascript/reference/statements/while/index.md
+++ b/files/es/web/javascript/reference/statements/while/index.md
@@ -18,6 +18,7 @@ while (condicion)
 ```
 
 - `condicion`
+
   - : Una expresión que se evalúa antes de cada paso del bucle. Si esta condición se evalúa como verdadera, se ejecuta `sentencia`. Cuando la condición se evalúa como false, la ejecución continúa con la `sentencia` posterior al bucle `while`.
 
 - `sentencia`
@@ -31,7 +32,7 @@ El siguiente bucle `while` itera mientras `n` es menor que tres.
 n = 0;
 x = 0;
 while (n < 3) {
-  n ++;
+  n++;
   x += n;
 }
 ```

--- a/files/es/web/javascript/reference/strict_mode/index.md
+++ b/files/es/web/javascript/reference/strict_mode/index.md
@@ -26,7 +26,7 @@ Para invocar el modo estricto en todo un script, escribe _exactamente_ `"use str
 
 ```js
 // Sintaxis del modo estricto para todo el script
-'use strict';
+"use strict";
 var v = "¡Hola! ¡Estoy en modo estricto para script!";
 ```
 
@@ -41,11 +41,15 @@ De igual forma, para invocar el modo estricto para una función, escribe _exacta
 ```js
 function strict() {
   // Sintaxis del modo estricto a nivel de función
-  'use strict';
-  function nested() { return "¡Y yo también!"; }
+  "use strict";
+  function nested() {
+    return "¡Y yo también!";
+  }
   return "¡Hola!  ¡Soy una función en modo estricto!  " + nested();
 }
-function notStrict() { return "Yo no soy estricto."; }
+function notStrict() {
+  return "Yo no soy estricto.";
+}
 ```
 
 ### Modo estricto para módulos
@@ -54,7 +58,7 @@ ECMAScript 2015 introdujo módulos y por tanto una tercera manera de entrar en e
 
 ```js
 function strict() {
-    // debido a que este es un módulo, soy estricto por omisión
+  // debido a que este es un módulo, soy estricto por omisión
 }
 export default strict;
 ```
@@ -70,16 +74,16 @@ El modo estricto cambia algunos errores de sintaxis tolerados en modo no estrict
 En primer lugar, el modo estricto hace imposible crear variables globales por accidente. En JavaScript no estricto, si se escribe mal una variable en una asignación, se creará una nueva propiedad en el objeto global y el código continuará "trabajando" como si nada (aunque es posible que el código así escrito falle en el futuro, en concreto, en JavaScript moderno). En modo estricto, cualquier asignación que produzca variables globales por accidente lanzará un error:
 
 ```js
-'use strict';
-                       // Asumiendo que exista una variable global llamada mistypedVariable
-mistypeVariable = 17;  // esta línea lanza un ReferenceError debido a
-                       // una errata en el nombre de la variable
+"use strict";
+// Asumiendo que exista una variable global llamada mistypedVariable
+mistypeVariable = 17; // esta línea lanza un ReferenceError debido a
+// una errata en el nombre de la variable
 ```
 
 En segundo lugar, el modo estricto lanza una excepción en asignaciones que de otro modo fallarían silenciosamente. Por ejemplo, `NaN` es una variable global que no puede ser asignada. En un código normal, asignar a `NaN` no tiene efecto; el programador no recibe ningún mensaje de error. En cambio, en modo estricto, si se intenta asignar un valor a `NaN`, el programador recibirá una excepción. Cualquier asignación que falle silenciosamente en código normal (asignaciones a una propiedad de no escritura, asignaciones a una propiedad captadora, asignaciones a una nueva propiedad o a un objecto {{jsxref("Global_Objects/Object/preventExtensions", "no extensible")}}) lanzará una excepción en modo estricto:
 
 ```js
-'use strict';
+"use strict";
 
 // Asignación a una no-escritura global
 var undefined = 5; // lanza un TypeError
@@ -91,7 +95,11 @@ Object.defineProperty(obj1, "x", { value: 42, writable: false });
 obj1.x = 9; // lanza un TypeError
 
 // Asignación a una propiedad de tipo getter
-var obj2 = { get x() { return 17; } };
+var obj2 = {
+  get x() {
+    return 17;
+  },
+};
 obj2.x = 5; // lanza un TypeError
 
 // Asignación a una nueva propiedad en un objeto no extensible
@@ -103,7 +111,7 @@ fixed.newProp = "ohai"; // lanza un TypeError
 En tercer lugar, el modo estricto lanza una excepción al intentar eliminar propiedades no eliminables (mientra que en código normal el intento no tendría ningún efecto):
 
 ```js
-'use strict';
+"use strict";
 delete Object.prototype; // lanza un TypeError
 ```
 
@@ -112,15 +120,16 @@ En cuarto lugar, la versión de modo estricto anterior a Gecko 34 requiere que t
 > **Nota:** Este ya no es el caso en ECMAScript 2015 ([error 1041128](https://bugzilla.mozilla.org/show_bug.cgi?id=1041128)).
 
 ```js
-'use strict';
+"use strict";
 var o = { p: 1, p: 2 }; // !!! error de sintaxis
 ```
 
 En quinto lugar, el modo estricto requiere que los nombres de los parámetros de una función sean únicos. En código normal, el último argumento repetido oculta argumentos anteriores con el mismo nombre. Estos argumentos permanecen disponibles a través de `arguments[i]`, de modo que no son completamente inaccesibles. Aun así, esta ocultación tiene poco sentido y es probablemente indeseable (pues puede ocultar, por ejemplo, un error al teclear una letra). Por lo tanto, en modo estricto, duplicar nombres de argumentos es un error de sintaxis:
 
 ```js
-function sum(a, a, c) { // !!! error de sintaxis
-  'use strict';
+function sum(a, a, c) {
+  // !!! error de sintaxis
+  "use strict";
   return a + a + c; // incorrecto si este código se ejecutó
 }
 ```
@@ -134,10 +143,11 @@ var a = 0o10; // ES2015: Octal
 Los programadores novatos a veces creen que un prefijo cero inicial no tiene un significado semántico, por lo que lo usan como dispositivo de alineación, ¡pero esto cambia el significado del número! Una sintaxis de cero a la izquierda para los octales rara vez es útil y se puede usar por error, por lo que el modo estricto lo convierte en un error de sintaxis:
 
 ```js
-'use strict';
-var sum = 015 + // !!! error de sintaxis
-          197 +
-          142;
+"use strict";
+var sum =
+  015 + // !!! error de sintaxis
+  197 +
+  142;
 
 var sumWithOctal = 0o10 + 8;
 console.log(sumWithOctal); // 16
@@ -146,13 +156,12 @@ console.log(sumWithOctal); // 16
 Séptimo, el modo estricto en ECMAScript 2015 prohíbe establecer propiedades en valores {{Glossary("Primitive", "primitivos")}}. La sintaxis octal rara vez es útil y se puede usar equivocadamente, de modo que en modo estricto, utilizar notación octal lanza un {{jsxref("TypeError")}}:
 
 ```js
-(function() {
-'use strict';
+(function () {
+  "use strict";
 
-false.true = '';         // TypeError
-(14).sailing = 'home';   // TypeError
-'with'.you = 'far away'; // TypeError
-
+  false.true = ""; // TypeError
+  (14).sailing = "home"; // TypeError
+  "with".you = "far away"; // TypeError
 })();
 ```
 
@@ -163,9 +172,10 @@ El modo estricto simplifica el modo en que el nombre de una variable es asignado
 Primero, el modo estricto prohíbe el uso de `with`. El problema con `with` es que cualquier nombre dentro del bloque pude ser asignado a una propiedad del objecto pasado como argumento, o a una variable en su ámbito circundante (o incluso global), en tiempo de ejecución: es imposible saber de antemano cuál será. El modo estricto hace que el uso de `with` sea un error de sintaxis, de modo que no hay oportunidad de que una variable dentro de un `with` se refiera a una dirección desconocida en tiempo de ejecución:
 
 ```js
-'use strict';
+"use strict";
 var x = 17;
-with (obj) { // !!! error de sintaxis
+with (obj) {
+  // !!! error de sintaxis
   // Si este no estuviera un modo estricto, ¿sería var x?, o
   // ¿sería obj.x en su lugar?  Es imposible en general
   // decirlo sin ejecutar el código, por lo que el nombre no
@@ -189,17 +199,17 @@ En el ejemplo anterior, si la función `eval` es invocada por una expresión de 
 
 ```js
 function strict1(str) {
-  'use strict';
+  "use strict";
   return eval(str); // str será tratado como código de modo estricto
 }
 function strict2(f, str) {
-  'use strict';
+  "use strict";
   return f(str); // no eval(...): str es estricto si y solo
-                 // si invoca el modo estricto
+  // si invoca el modo estricto
 }
 function nonstrict(str) {
   return eval(str); // str es estricto si y solo
-                    // si invoca el modo estricto
+  // si invoca el modo estricto
 }
 
 strict1("'¡Código en modo estricto!'");
@@ -215,7 +225,7 @@ Así los nombres en modo estricto usando `eval` se comportan idénticamente a lo
 Tercero, el modo estricto prohíbe eliminar nombres planos. De este modo, `delete name` produce un error de sintaxis.
 
 ```js
-'use strict';
+"use strict";
 
 var x;
 delete x; // !!! error de sintaxis
@@ -230,16 +240,17 @@ El modo estricto hace que el uso de `arguments` y `eval` sea más intuitivo. Amb
 Primero, las palabras `eval` y `arguments` no se pueden ligar o asignar en la sintaxis del lenguaje. Cualquier intento producirá un error de sintaxis:
 
 ```js
-'use strict';
+"use strict";
 eval = 17;
 arguments++;
 ++eval;
-var obj = { set p(arguments) { } };
+var obj = { set p(arguments) {} };
 var eval;
-try { } catch (arguments) { }
-function x(eval) { }
-function arguments() { }
-var y = function eval() { };
+try {
+} catch (arguments) {}
+function x(eval) {}
+function arguments() {}
+var y = function eval() {};
 var f = new Function("arguments", "'use strict'; return 17;");
 ```
 
@@ -247,7 +258,7 @@ Segundo, el modo estricto no permite usar alias en elementos del objecto `argume
 
 ```js
 function f(a) {
-  'use strict';
+  "use strict";
   a = 42;
   return [a, arguments[0]];
 }
@@ -259,8 +270,10 @@ console.assert(pair[1] === 17);
 Tercero, `arguments.callee` no está soportado. En código normal, `arguments.callee` se refiere a la función envolvente. Este caso de uso es débil: ¡simplemente nombra la función envolvente!. Además `arguments.callee` merma el desempeño de funciones en línea pues debe ser posible proveer la referencia de la función que llamó a la función original cada vez que se usa `arguments.callee`. `arguments.callee` en modo estricto es una propiedad no eliminable y lanza una excepción cuando se le asigna un valor o se intenta regresar su valor.
 
 ```js
-'use strict';
-var f = function() { return arguments.callee; };
+"use strict";
+var f = function () {
+  return arguments.callee;
+};
 f(); // lanza un TypeError
 ```
 
@@ -271,8 +284,10 @@ El modo estricto hace más fácil el escribir código "seguro" en JavaScript. Al
 Primero, el valor `this` pasado a una función en modo estricto no forzosamente debe ser un objeto (es decir, "empaquetado"). Para una función normal, `this` siempre es un objeto: o el objeto proporcionado si se llama con un `this` con valor de objeto; el valor, empaquetado, si se llama con un booleano, una cadena o un número `this`; o el objeto global si se llama con un `undefined` o `null` `this`. (Usar {{jsxref("Global_Objects/Function/call", "call")}}, {{jsxref("Global_Objects/Function/apply", "apply")}}, o {{jsxref("Global_Objects/Function/bind", "bind")}} para especificar un valor del `this` particular). Este empaquetado automático al pasar valores a una función tiene un costo en el rendimiento; no solo eso, si no que al exponer el objeto global en los navegadores es un riesgo de seguridad, debido a que el objeto global provee acceso a una funcionalidad que el código de JavaScript "seguro" debe restringir. Así, en una función en modo estricto , el valor de `this` no está empaquetado dentro de un objecto, y si no se especifica, `this` toma el valor de `undefined`.
 
 ```js
-'use strict';
-function fun() { return this; }
+"use strict";
+function fun() {
+  return this;
+}
 console.assert(fun() === undefined);
 console.assert(fun.call(2) === 2);
 console.assert(fun.apply(null) === null);
@@ -286,8 +301,8 @@ Segundo, en modo estricto ya no es posible "recorrer" la pila de JavaScript a tr
 
 ```js
 function restricted() {
-  'use strict';
-  restricted.caller;    // lanza un TypeError
+  "use strict";
+  restricted.caller; // lanza un TypeError
   restricted.arguments; // lanza un TypeError
 }
 function privilegedInvoker() {
@@ -299,9 +314,9 @@ privilegedInvoker();
 Tercero, en funciones de modo estricto, el objeto `arguments` no provee acceso a las variables usadas al llamar a la función. En algunas implementaciones antiguas de ECMAScript, `arguments.caller` era un objeto cuyas propiedades apuntaban a las variables en la función. Esto es una [amenaza de seguridad](http://stuff.mit.edu/iap/2008/facebook/) por que rompe la habilidad de ocultar valores privilegiados a través de la abstracción de la función; además, frena algunas optimizaciones. Por estas razones los navegadores modernos no la implementan. Por su funcionalidad a lo largo de los años, `arguments.caller` en una función de modo estricto es una propiedad que lanza una excepción cuando se usa.
 
 ```js
-'use strict';
+"use strict";
 function fun(a, b) {
-  'use strict';
+  "use strict";
   var v = 12;
   return arguments.caller; // lanza un TypeError
 }
@@ -315,18 +330,21 @@ Las futuras versiones de ECMAScript introducirán nuevos cambios, y el modo estr
 Primero, en modo estricto una lista de identificadores se convierte en palabras reservadas. Estas palabras son `implements`, `interface`, `let`, `package`, `private`, `protected`, `public`, `static`, y `yield`. De modo que en modo estricto, no se pueden usar estas palabras para nombrar variables o argumentos.
 
 ```js
-function package(protected) { // !!!
-  'use strict';
+function package(protected) {
+  // !!!
+  "use strict";
   var implements; // !!!
 
-  interface: // !!!
-  while (true) {
+  // !!!
+  interface: while (true) {
     break interface; // !!!
   }
 
-  function private() { } // !!!
+  function private() {} // !!!
 }
-function fun(static) { 'use strict'; } // !!!
+function fun(static) {
+  "use strict";
+} // !!!
 ```
 
 _Dos advertencias específicas de Mozilla_: Primero, si tu código esta escrito en JavaScript 1.7 o mayor (por ejemplo en código chrome o cuando se usa bien `<script type="">`) y el código esta en modo estricto, `let` y `yield` tienen la funcionalidad que han tenido desde que esas palabras clave se introdujeron por primera vez. Pero el código en modo estricto en la web, cargado con `<script src="">` o `<script>...</script>`, no podrá usar `let`/`yield` como identificadores. _Segundo, mientras que ES5 incondicionalmente reserva las palabras `class`, `enum`, `export`, `extends`, `import` y `super`, Mozilla Firefox 5 solo las reserva en modo estricto_.
@@ -334,19 +352,20 @@ _Dos advertencias específicas de Mozilla_: Primero, si tu código esta escrito 
 En segundo lugar, [el modo estricto prohíbe las declaraciones de función, no en el nivel superior de un script o función](http://whereswalden.com/2011/01/24/new-es5-strict-mode-requirement-function-statements-not-at-top-level-of-a-program-or-function-are-prohibited/). En el modo normal de los navegadores, las declaraciones de función se permiten "en todas partes". _¡Esto no es parte de ES5 (ni siquiera de ES3)!_ Es una extensión con semántica incompatible en diferentes navegadores. Ten en cuenta que en ES2015 se permiten declaraciones de función fuera del nivel superior.
 
 ```js
-'use strict';
+"use strict";
 if (true) {
-  function f() { } // !!! error de sintaxis
+  function f() {} // !!! error de sintaxis
   f();
 }
 
 for (var i = 0; i < 5; i++) {
-  function f2() { } // !!! error de sintaxis
+  function f2() {} // !!! error de sintaxis
   f2();
 }
 
-function baz() {   // legal
-  function eit() { } // también legal
+function baz() {
+  // legal
+  function eit() {} // también legal
 }
 ```
 

--- a/files/es/web/javascript/reference/template_literals/index.md
+++ b/files/es/web/javascript/reference/template_literals/index.md
@@ -34,7 +34,7 @@ La función por defecto sencillamente concatena las partes para formar una únic
 En caso de querer escapar una comilla o tilde invertida en una plantilla literal, se debe poner una barra invertida (`\`) antes de la comilla o tilde invertida.
 
 ```js
-`\`` === '`' // --> true (cierto)
+`\`` === "`"; // --> true (cierto)
 ```
 
 ### Cadenas de más de una línea
@@ -44,8 +44,7 @@ Los caracteres de fin de línea encontrados forman parte de la plantilla literal
 Utilizando cadenas de caracteres normales, sería necesario utilizar la siguiente sintaxes para producir cadenas de más de una línea:
 
 ```js
-console.log('línea 1 de cadena de texto\n' +
-'\línea 2 de cadena de texto');
+console.log("línea 1 de cadena de texto\n" + "línea 2 de cadena de texto");
 // "línea 1 de cadena de texto
 // línea 2 de cadena de texto"
 ```
@@ -66,7 +65,7 @@ Para insertar expresiones dentro de cadenas de caracteres normales, se utilizar�
 ```js
 let a = 5;
 let b = 10;
-console.log('Quince es ' + (a + b) + ' y\nno ' + (2 * a + b) + '.');
+console.log("Quince es " + (a + b) + " y\nno " + (2 * a + b) + ".");
 // "Quince es 15 y
 // no 20."
 ```
@@ -91,24 +90,28 @@ Por ejemplo, si la condición a es `true` (cierta): entonces `return` (devuelva)
 En ES5:
 
 ```js
-let classes = 'header'
-classes += (isLargeScreen() ?
-   '' : item.isCollapsed ?
-     ' icon-expander' : ' icon-collapser');
+let classes = "header";
+classes += isLargeScreen()
+  ? ""
+  : item.isCollapsed
+  ? " icon-expander"
+  : " icon-collapser";
 ```
 
 En ES2015 con plantillas literales y sin anidamiento:
 
 ```js
-const classes = `header ${ isLargeScreen() ? '' :
-    (item.isCollapsed ? 'icon-expander' : 'icon-collapser') }`;
+const classes = `header ${
+  isLargeScreen() ? "" : item.isCollapsed ? "icon-expander" : "icon-collapser"
+}`;
 ```
 
 En ES5 con plantillas literales anidadas:
 
 ```js
-const classes = `header ${ isLargeScreen() ? '' :
- `icon-${item.isCollapsed ? 'expander' : 'collapser'}` }`;
+const classes = `header ${
+  isLargeScreen() ? "" : `icon-${item.isCollapsed ? "expander" : "collapser"}`
+}`;
 ```
 
 ### Plantillas etiquetadas
@@ -122,11 +125,10 @@ La función de etiqueta puede ejecutar cualesquiera operaciones deseadas con est
 El nombre de la función utilizada con la etiqueta no es nada especial, se puede utilizar cualquier nombre de función en su lugar.
 
 ```js
-let persona = 'Mike';
+let persona = "Mike";
 let edad = 28;
 
-function myTag(strings, expPersona, expEdad)
-{
+function myTag(strings, expPersona, expEdad) {
   let str0 = strings[0]; // "Ese "
   let str1 = strings[1]; // " es un "
 
@@ -137,13 +139,10 @@ function myTag(strings, expPersona, expEdad)
   // let str2 = strings[2];
 
   let strEdad;
-  if (expEdad > 99)
-  {
-    strEdad = 'viejo';
-  }
-  else
-  {
-    strEdad = 'joven';
+  if (expEdad > 99) {
+    strEdad = "viejo";
+  } else {
+    strEdad = "joven";
   }
 
   // Podemos incluso retornar una cadena de
@@ -151,7 +150,7 @@ function myTag(strings, expPersona, expEdad)
   return `${str0}${expPersona}${str1}${strEdad}`;
 }
 
-var salida = myTag`Ese ${ persona } es un ${ edad }`;
+var salida = myTag`Ese ${persona} es un ${edad}`;
 
 console.log(salida);
 // Ese Mike es un joven
@@ -161,29 +160,29 @@ Las funciones de etiqueta incluso pueden devolver valores que no sean cadenas de
 
 ```js
 function plantilla(cadenas, ...claves) {
-  return (function(...valores) {
+  return function (...valores) {
     let diccio = valores[valores.length - 1] || {};
     let resultado = [cadenas[0]];
-    claves.forEach(function(clave, i) {
+    claves.forEach(function (clave, i) {
       let valor = Number.isInteger(clave) ? valores[clave] : diccio[clave];
       resultado.push(valor, cadenas[i + 1]);
     });
-    return resultado.join('');
-  });
+    return resultado.join("");
+  };
 }
 
 let t1Closure = plantilla`¡${0}${1}${2}${2}${3}!`;
 //let t1Closure = plantilla(["¡","","","","","","!"],0,1,2,3);
-t1Closure('H', 'U', 'R', 'A');              // "¡HURRA!"
+t1Closure("H", "U", "R", "A"); // "¡HURRA!"
 
-let t2Closure = plantilla`${0} ${'foo'}!`;
+let t2Closure = plantilla`${0} ${"foo"}!`;
 //let t2Closure = plantilla(["¡",""," ","!"],0,"foo");
-t2Closure('Hola', {foo: 'Mundo'}); // "¡Hola Mundo!"
+t2Closure("Hola", { foo: "Mundo" }); // "¡Hola Mundo!"
 
-let t3Closure = plantilla`Me llamo ${'nombre'}. Tengo casi ${'edad'} años.`;
+let t3Closure = plantilla`Me llamo ${"nombre"}. Tengo casi ${"edad"} años.`;
 //let t3Closure = plantilla(["Me llamo ", ". Tengo casi ", " años."], "nombre", "edad");
-t3Closure('foo', {nombre: 'MDN', edad: 30}); //"Me llamo MDN. Tengo casi 30 años."
-t3Closure({nombre: 'MDN', edad: 30}); //"Me llamo MDN. Tengo casi 30 años."
+t3Closure("foo", { nombre: "MDN", edad: 30 }); //"Me llamo MDN. Tengo casi 30 años."
+t3Closure({ nombre: "MDN", edad: 30 }); //"Me llamo MDN. Tengo casi 30 años."
 ```
 
 ### Cadenas en crudo (raw)
@@ -203,13 +202,13 @@ etiqueta`texto de cadena de caracteres 1 \n texto de cadena de caracteres 2`;
 Adicionalmente, el método {{jsxref("String.raw()")}} permite crear cadenas de caracteres en crudo tal como serían generadas por la función por defecto de plantilla, concatenando sus partes.
 
 ```js
-let cadena = String.raw`¡Hola\n${2+3}!`;
+let cadena = String.raw`¡Hola\n${2 + 3}!`;
 // "¡Hola\n5!"
 
 cadena.length;
 // 9
 
-Array.from(cadena).join(',');
+Array.from(cadena).join(",");
 // "¡,H,o,l,a,\,n,5,!"
 ```
 
@@ -227,7 +226,7 @@ Comenzando con ECMAScript 2016, las plantillas etiquetadas se comportan de acuer
 Esto significa que una plantilla etiquetada como la siguiente podría causar problemas, dado que, de acuerdo con la gramática de ECMAScript, un analizador buscará secuencias de escape de formato Unicode válidas pero encontrará sintaxis equivocado:
 
 ```js
-latex`\unicode`
+latex`\unicode`;
 // En ECMAScript 2016 y versiones anteriores, lanza
 // SyntaxError: malformed Unicode character escape sequence
 ```
@@ -240,10 +239,10 @@ Aún así, las secuencias de escape no permitidas deben ser representadas en la 
 
 ```js
 function latex(str) {
-  return { "cocinado": str[0], "en crudo": str.raw[0] }
+  return { cocinado: str[0], "en crudo": str.raw[0] };
 }
 
-latex`\unicode`
+latex`\unicode`;
 
 // { cocinado: undefined, en crudo: "\\unicode" }
 ```


### PR DESCRIPTION
This PR formats the `/web/javascript` folder of the Spanish locale using Prettier.  This is the fourth part.
