### PR TITLE
[ko] iterate 용어 수정

### DIFF
--- a/docs/ko/guides/glossary-guide.md
+++ b/docs/ko/guides/glossary-guide.md
@@ -174,7 +174,7 @@
 | Fulfilled               | 이행(함)        |               |                                                                                          |
 | Handler                 | 처리기          | 이벤트 처리기 |                                                                                          |
 | Interface               | 인터페이스      |               |                                                                                          |
-| Iterate                 | 순회            |               |                                                                                          |
+| Iterate                 | 반복            |               |                                                                                          |
 | Listener                | 수신기          | 이벤트 수신기 |                                                                                          |
 | Mixin                   | 믹스인          |               |                                                                                          |
 | Non-blocking operation  | 논블로킹 연산   |               |                                                                                          |


### PR DESCRIPTION
#14044 에 따라 iterate 용어를 수정하였습니다.

iterate - 반복
iterable - 반복가능
iterator - 반복자 

등으로 번역할 수 있습니다.