### PR TITLE
fr: Fix StyleSheet API code examples

### DIFF
--- a/files/fr/web/api/stylesheet/disabled/index.md
+++ b/files/fr/web/api/stylesheet/disabled/index.md
@@ -11,7 +11,7 @@ La **`StyleSheet.disabled`** propriété indique si la feuille de style est emp�
 ## Syntaxe
 
 ```js
-bool = stylesheet.disabled
+bool = stylesheet.disabled;
 ```
 
 ## Exemple

--- a/files/fr/web/api/stylesheet/href/index.md
+++ b/files/fr/web/api/stylesheet/href/index.md
@@ -1,17 +1,17 @@
 ---
-title: Stylesheet.href
+title: StyleSheet.href
 slug: Web/API/StyleSheet/href
 translation_of: Web/API/StyleSheet/href
 ---
 
-{{APIRef ("CSSOM")}}
+{{APIRef("CSSOM")}}
 
 Renvoie l'emplacement de la feuille de style.
 
 ## Syntaxe
 
 ```js
-Uri = stylesheet.href
+uri = stylesheet.href;
 ```
 
 ### Paramètres
@@ -21,21 +21,21 @@ Uri = stylesheet.href
 ## Exemple
 
 ```html
- // sur une machine locale:
- <Html>
-  <Head>
-   <Link rel = "StyleSheet" href = "example.css" type = "text / css" />
-   <Script>
-    Function sref () {
-     Alerte (document.styleSheets [0] .href);
-    }
-   </ Script>
-  </ Head>
-  <Body>
-   <Div class = "tonnerre"> Thunder </ div>
-   <Button onclick = "sref ()"> ss </ button>
-  </ Body>
- </ Html>
+// sur une machine locale:
+<html>
+  <head>
+    <link rel="stylesheet" href="example.css" type="text/css" />
+    <script>
+      function sref() {
+        alert(document.styleSheets[0].href);
+      }
+    </script>
+  </head>
+  <body>
+    <div class="tonnerre">Thunder</div>
+    <button onclick="sref()">ss</button>
+  </body>
+</html>
 // retourne "fichier: //// C: /Windows/Desktop/example.css
 ```
 

--- a/files/fr/web/api/stylesheet/media/index.md
+++ b/files/fr/web/api/stylesheet/media/index.md
@@ -11,18 +11,18 @@ translation_of: Web/API/StyleSheet/media
 ## Syntaxe
 
 ```js
-Medium = stylesheet.media
-Stylesheet.media = medium
+media = stylesheet.media;
+stylesheet.media = media;
 ```
 
 ## Paramètres
 
-- `medium` Est une chaîne décrivant un seul moyen ou une liste séparée par des virgules.
+- `media` Est une chaîne décrivant un seul moyen ou une liste séparée par des virgules.
 
 ## Exemple
 
 ```html
-<Link rel = "StyleSheet" href="document.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="document.css" type="text/css" media="screen" />
 ```
 
 ## Remarques

--- a/files/fr/web/api/stylesheet/ownernode/index.md
+++ b/files/fr/web/api/stylesheet/ownernode/index.md
@@ -11,25 +11,25 @@ translation_of: Web/API/StyleSheet/ownerNode
 ## Syntaxe
 
 ```js
-ObjRef = stylesheet.ownerNode
+objref = stylesheet.ownerNode;
 ```
 
 ## Exemple
 
 ```html
-<Html>
- <Head>
-  <Link rel = "StyleSheet" href = "example.css" type = "text / css" />
-  <Script>
-   Function stilo () {
-    Alerte (document.styleSheets [0] .ownerNode);
-   }
-  </ Script>
- </ Head>
- <Body>
-   <Button onclick = "stilo ()"> ss </ button>
- </ Body>
-</ Html>
+<html>
+  <head>
+    <link rel="stylesheet" href="example.css" type="text/css" />
+    <script>
+      function stilo() {
+       alert(document.styleSheets[0].ownerNode);
+      }
+    </script>
+  </head>
+  <body>
+    <button onclick="stilo()">ss</button>
+  </body>
+</html>
 // affiche "objet HTMLLinkElement"
 ```
 

--- a/files/fr/web/api/stylesheet/parentstylesheet/index.md
+++ b/files/fr/web/api/stylesheet/parentstylesheet/index.md
@@ -4,25 +4,21 @@ slug: Web/API/StyleSheet/parentStyleSheet
 translation_of: Web/API/StyleSheet/parentStyleSheet
 ---
 
-{{APIRef ("CSSOM")}}
+{{APIRef("CSSOM")}}
 
 Renvoie la feuille de style qui inclut celle-ci, le cas échéant.
 
 ## Syntaxe
 
 ```js
-ObjRef = stylesheet.parentStyleSheet
+objref = stylesheet.parentStyleSheet;
 ```
 
 ## Exemple
 
 ```js
 // trouve la feuille de style de niveau supérieur
-If (stylesheet.parentStyleSheet) {
-    Feuille = stylesheet.parentStyleSheet;
-} autre {
-    Feuille = feuille de style;
-}
+const sheet = stylesheet.parentStyleSheet ?? stylesheet;
 ```
 
 ## Remarques

--- a/files/fr/web/api/stylesheet/type/index.md
+++ b/files/fr/web/api/stylesheet/type/index.md
@@ -11,13 +11,13 @@ Type spécifie la langue de la feuille de style pour cette feuille de style.
 ## Syntaxe
 
 ```js
-String = stylesheet.type
+string = stylesheet.type;
 ```
 
 ## Exemple
 
 ```
-Ss.type = "text / css";
+stylesheet.type = "text/css";
 ```
 
 ## Spécification

--- a/files/fr/web/api/stylesheetlist/index.md
+++ b/files/fr/web/api/stylesheetlist/index.md
@@ -14,16 +14,18 @@ Il s'agit d'un objet de type array, mais qui ne peut pas être itéré à l'aide
 
 ```js
 // Récupère toutes les règles CSS du document en cours en utilisant les méthodes de Array
-var allCSS = [].slice.call(document.styleSheets)
-                     .reduce(function (prev, styleSheet) {
-        if (styleSheet.cssRules) {
-            return prev +
-                [].slice.call(styleSheet.cssRules)
-                        .reduce(function (prev, cssRule) {
-                    return prev + cssRule.cssText;
-                });
-        } else {
-            return prev;
-        }
-    });
+var allCSS = [].slice
+  .call(document.styleSheets)
+  .reduce(function (prev, styleSheet) {
+    if (styleSheet.cssRules) {
+      return (
+        prev +
+        [].slice.call(styleSheet.cssRules).reduce(function (prev, cssRule) {
+          return prev + cssRule.cssText;
+        })
+      );
+    } else {
+      return prev;
+    }
+  });
 ```


### PR DESCRIPTION
This PR fixes the code examples for the StyleSheet API.  These code examples were over-translated in the wiki era.
