### PR TITLE
fr: Format /web/html using Prettier (part 1)

### DIFF
--- a/files/fr/web/html/attributes/accept/index.md
+++ b/files/fr/web/html/attributes/accept/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : accept'
+title: "Attribut HTML : accept"
 slug: Web/HTML/Attributes/accept
 translation_of: Web/HTML/Attributes/accept
 ---

--- a/files/fr/web/html/attributes/autocomplete/index.md
+++ b/files/fr/web/html/attributes/autocomplete/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : autocomplete'
+title: "Attribut HTML : autocomplete"
 slug: Web/HTML/Attributes/autocomplete
 translation_of: Web/HTML/Attributes/autocomplete
 ---

--- a/files/fr/web/html/attributes/capture/index.md
+++ b/files/fr/web/html/attributes/capture/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : capture'
+title: "Attribut HTML : capture"
 slug: Web/HTML/Attributes/capture
 translation_of: Web/HTML/Attributes/capture
 ---

--- a/files/fr/web/html/attributes/crossorigin/index.md
+++ b/files/fr/web/html/attributes/crossorigin/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : crossorigin'
+title: "Attribut HTML : crossorigin"
 slug: Web/HTML/Attributes/crossorigin
 translation_of: Web/HTML/Attributes/crossorigin
 ---

--- a/files/fr/web/html/attributes/disabled/index.md
+++ b/files/fr/web/html/attributes/disabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : disabled'
+title: "Attribut HTML : disabled"
 slug: Web/HTML/Attributes/disabled
 translation_of: Web/HTML/Attributes/disabled
 ---

--- a/files/fr/web/html/attributes/elementtiming/index.md
+++ b/files/fr/web/html/attributes/elementtiming/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : elementtiming'
+title: "Attribut HTML : elementtiming"
 slug: Web/HTML/Attributes/elementtiming
 translation_of: Web/HTML/Attributes/elementtiming
 ---

--- a/files/fr/web/html/attributes/for/index.md
+++ b/files/fr/web/html/attributes/for/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : for'
+title: "Attribut HTML : for"
 slug: Web/HTML/Attributes/for
 translation_of: Web/HTML/Attributes/for
 ---

--- a/files/fr/web/html/attributes/max/index.md
+++ b/files/fr/web/html/attributes/max/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : max'
+title: "Attribut HTML : max"
 slug: Web/HTML/Attributes/max
 translation_of: Web/HTML/Attributes/max
 ---

--- a/files/fr/web/html/attributes/maxlength/index.md
+++ b/files/fr/web/html/attributes/maxlength/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : maxlength'
+title: "Attribut HTML : maxlength"
 slug: Web/HTML/Attributes/maxlength
 translation_of: Web/HTML/Attributes/maxlength
 ---

--- a/files/fr/web/html/attributes/min/index.md
+++ b/files/fr/web/html/attributes/min/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : min'
+title: "Attribut HTML : min"
 slug: Web/HTML/Attributes/min
 translation_of: Web/HTML/Attributes/min
 ---

--- a/files/fr/web/html/attributes/minlength/index.md
+++ b/files/fr/web/html/attributes/minlength/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : minlength'
+title: "Attribut HTML : minlength"
 slug: Web/HTML/Attributes/minlength
 translation_of: Web/HTML/Attributes/minlength
 ---

--- a/files/fr/web/html/attributes/multiple/index.md
+++ b/files/fr/web/html/attributes/multiple/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : multiple'
+title: "Attribut HTML : multiple"
 slug: Web/HTML/Attributes/multiple
 translation_of: Web/HTML/Attributes/multiple
 ---

--- a/files/fr/web/html/attributes/pattern/index.md
+++ b/files/fr/web/html/attributes/pattern/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : pattern'
+title: "Attribut HTML : pattern"
 slug: Web/HTML/Attributes/pattern
 translation_of: Web/HTML/Attributes/pattern
 ---

--- a/files/fr/web/html/attributes/readonly/index.md
+++ b/files/fr/web/html/attributes/readonly/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : readonly'
+title: "Attribut HTML : readonly"
 slug: Web/HTML/Attributes/readonly
 translation_of: Web/HTML/Attributes/readonly
 ---

--- a/files/fr/web/html/attributes/rel/dns-prefetch/index.md
+++ b/files/fr/web/html/attributes/rel/dns-prefetch/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Types de liens : dns-prefetch'
+title: "Types de liens : dns-prefetch"
 slug: Web/HTML/Attributes/rel/dns-prefetch
 translation_of: Web/HTML/Link_types/dns-prefetch
 ---

--- a/files/fr/web/html/attributes/rel/index.md
+++ b/files/fr/web/html/attributes/rel/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : rel'
+title: "Attribut HTML : rel"
 slug: Web/HTML/Attributes/rel
 translation_of: Web/HTML/Attributes/rel
 ---

--- a/files/fr/web/html/attributes/rel/manifest/index.md
+++ b/files/fr/web/html/attributes/rel/manifest/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Types de liens : manifest'
+title: "Types de liens : manifest"
 slug: Web/HTML/Attributes/rel/manifest
 translation_of: Web/HTML/Link_types/manifest
 ---

--- a/files/fr/web/html/attributes/rel/me/index.md
+++ b/files/fr/web/html/attributes/rel/me/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Types de lien : me'
+title: "Types de lien : me"
 slug: Web/HTML/Attributes/rel/me
 translation_of: Web/HTML/Link_types/me
 ---

--- a/files/fr/web/html/attributes/rel/modulepreload/index.md
+++ b/files/fr/web/html/attributes/rel/modulepreload/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Link types: modulepreload'
+title: "Link types: modulepreload"
 slug: Web/HTML/Attributes/rel/modulepreload
 translation_of: Web/HTML/Link_types/modulepreload
 ---

--- a/files/fr/web/html/attributes/rel/noopener/index.md
+++ b/files/fr/web/html/attributes/rel/noopener/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Types de liens : noopener'
+title: "Types de liens : noopener"
 slug: Web/HTML/Attributes/rel/noopener
 translation_of: Web/HTML/Link_types/noopener
 ---

--- a/files/fr/web/html/attributes/rel/noreferrer/index.md
+++ b/files/fr/web/html/attributes/rel/noreferrer/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Types de liens : noreferrer'
+title: "Types de liens : noreferrer"
 slug: Web/HTML/Attributes/rel/noreferrer
 translation_of: Web/HTML/Link_types/noreferrer
 ---

--- a/files/fr/web/html/attributes/rel/preconnect/index.md
+++ b/files/fr/web/html/attributes/rel/preconnect/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Types de liens : preconnect'
+title: "Types de liens : preconnect"
 slug: Web/HTML/Attributes/rel/preconnect
 translation_of: Web/HTML/Link_types/preconnect
 ---

--- a/files/fr/web/html/attributes/rel/prefetch/index.md
+++ b/files/fr/web/html/attributes/rel/prefetch/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Types de liens : prefetch'
+title: "Types de liens : prefetch"
 slug: Web/HTML/Attributes/rel/prefetch
 translation_of: Web/HTML/Link_types/prefetch
 ---

--- a/files/fr/web/html/attributes/rel/preload/index.md
+++ b/files/fr/web/html/attributes/rel/preload/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Types de liens : preload'
+title: "Types de liens : preload"
 slug: Web/HTML/Attributes/rel/preload
 translation_of: Web/HTML/Link_types/preload
 ---

--- a/files/fr/web/html/attributes/rel/prerender/index.md
+++ b/files/fr/web/html/attributes/rel/prerender/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Types de liens : prerender'
+title: "Types de liens : prerender"
 slug: Web/HTML/Attributes/rel/prerender
 translation_of: Web/HTML/Link_types/prerender
 ---

--- a/files/fr/web/html/attributes/required/index.md
+++ b/files/fr/web/html/attributes/required/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : required'
+title: "Attribut HTML : required"
 slug: Web/HTML/Attributes/required
 translation_of: Web/HTML/Attributes/required
 ---

--- a/files/fr/web/html/attributes/size/index.md
+++ b/files/fr/web/html/attributes/size/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : size'
+title: "Attribut HTML : size"
 slug: Web/HTML/Attributes/size
 translation_of: Web/HTML/Attributes/size
 ---

--- a/files/fr/web/html/attributes/step/index.md
+++ b/files/fr/web/html/attributes/step/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Attribut HTML : step'
+title: "Attribut HTML : step"
 slug: Web/HTML/Attributes/step
 translation_of: Web/HTML/Attributes/step
 ---

--- a/files/fr/web/html/element/a/index.md
+++ b/files/fr/web/html/element/a/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<a> : l''élément d''ancre'
+title: "<a> : l'élément d'ancre"
 slug: Web/HTML/Element/a
 translation_of: Web/HTML/Element/a
 ---

--- a/files/fr/web/html/element/abbr/index.md
+++ b/files/fr/web/html/element/abbr/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<abbr> : l''élément d''abréviation'
+title: "<abbr> : l'élément d'abréviation"
 slug: Web/HTML/Element/abbr
 translation_of: Web/HTML/Element/abbr
 ---

--- a/files/fr/web/html/element/acronym/index.md
+++ b/files/fr/web/html/element/acronym/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<acronym> : l''élément d''acronyme'
+title: "<acronym> : l'élément d'acronyme"
 slug: Web/HTML/Element/acronym
 translation_of: Web/HTML/Element/acronym
 ---

--- a/files/fr/web/html/element/address/index.md
+++ b/files/fr/web/html/element/address/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<address> : l''élément d''adresse de contact'
+title: "<address> : l'élément d'adresse de contact"
 slug: Web/HTML/Element/address
 translation_of: Web/HTML/Element/address
 ---

--- a/files/fr/web/html/element/area/index.md
+++ b/files/fr/web/html/element/area/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<area> : l''élément de zone'
+title: "<area> : l'élément de zone"
 slug: Web/HTML/Element/area
 translation_of: Web/HTML/Element/area
 ---

--- a/files/fr/web/html/element/article/index.md
+++ b/files/fr/web/html/element/article/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<article> : l''élément de contenu d''un article'
+title: "<article> : l'élément de contenu d'un article"
 slug: Web/HTML/Element/article
 translation_of: Web/HTML/Element/article
 ---

--- a/files/fr/web/html/element/aside/index.md
+++ b/files/fr/web/html/element/aside/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<aside> : l''élément aparté'
+title: "<aside> : l'élément aparté"
 slug: Web/HTML/Element/aside
 translation_of: Web/HTML/Element/aside
 ---

--- a/files/fr/web/html/element/audio/index.md
+++ b/files/fr/web/html/element/audio/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<audio> : l''élément audio embarqué'
+title: "<audio> : l'élément audio embarqué"
 slug: Web/HTML/Element/audio
 translation_of: Web/HTML/Element/audio
 ---

--- a/files/fr/web/html/element/b/index.md
+++ b/files/fr/web/html/element/b/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<b> : l''élément portant à l''attention'
+title: "<b> : l'élément portant à l'attention"
 slug: Web/HTML/Element/b
 translation_of: Web/HTML/Element/b
 ---

--- a/files/fr/web/html/element/base/index.md
+++ b/files/fr/web/html/element/base/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<base> : l''élément pour l''URL de base du document'
+title: "<base> : l'élément pour l'URL de base du document"
 slug: Web/HTML/Element/base
 translation_of: Web/HTML/Element/base
 ---

--- a/files/fr/web/html/element/bdi/index.md
+++ b/files/fr/web/html/element/bdi/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<bdi> : l''élément d''isolation bidirectionnelle'
+title: "<bdi> : l'élément d'isolation bidirectionnelle"
 slug: Web/HTML/Element/bdi
 translation_of: Web/HTML/Element/bdi
 ---

--- a/files/fr/web/html/element/bdo/index.md
+++ b/files/fr/web/html/element/bdo/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<bdo> : l''élément de remplacement bidirectionnelle'
+title: "<bdo> : l'élément de remplacement bidirectionnelle"
 slug: Web/HTML/Element/bdo
 translation_of: Web/HTML/Element/bdo
 ---

--- a/files/fr/web/html/element/big/index.md
+++ b/files/fr/web/html/element/big/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<big> : l''élément d''agrandissement de texte'
+title: "<big> : l'élément d'agrandissement de texte"
 slug: Web/HTML/Element/big
 translation_of: Web/HTML/Element/big
 ---

--- a/files/fr/web/html/element/blockquote/index.md
+++ b/files/fr/web/html/element/blockquote/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<blockquote> : l''élément de bloc de citation'
+title: "<blockquote> : l'élément de bloc de citation"
 slug: Web/HTML/Element/blockquote
 translation_of: Web/HTML/Element/blockquote
 ---

--- a/files/fr/web/html/element/body/index.md
+++ b/files/fr/web/html/element/body/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<body> : l''élément pour le corps du document'
+title: "<body> : l'élément pour le corps du document"
 slug: Web/HTML/Element/body
 translation_of: Web/HTML/Element/body
 ---

--- a/files/fr/web/html/element/br/index.md
+++ b/files/fr/web/html/element/br/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<br> : l''élément de saut de ligne'
+title: "<br> : l'élément de saut de ligne"
 slug: Web/HTML/Element/br
 translation_of: Web/HTML/Element/br
 ---

--- a/files/fr/web/html/element/button/index.md
+++ b/files/fr/web/html/element/button/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<button> : l''élément représentant un bouton'
+title: "<button> : l'élément représentant un bouton"
 slug: Web/HTML/Element/button
 translation_of: Web/HTML/Element/button
 ---

--- a/files/fr/web/html/element/canvas/index.md
+++ b/files/fr/web/html/element/canvas/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<canvas> : l''élément de canevas graphique'
+title: "<canvas> : l'élément de canevas graphique"
 slug: Web/HTML/Element/canvas
 translation_of: Web/HTML/Element/canvas
 ---

--- a/files/fr/web/html/element/caption/index.md
+++ b/files/fr/web/html/element/caption/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<caption> : l''élément de légende d''un tableau'
+title: "<caption> : l'élément de légende d'un tableau"
 slug: Web/HTML/Element/caption
 translation_of: Web/HTML/Element/caption
 ---

--- a/files/fr/web/html/element/center/index.md
+++ b/files/fr/web/html/element/center/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<center> : l''élément de texte centré'
+title: "<center> : l'élément de texte centré"
 slug: Web/HTML/Element/center
 translation_of: Web/HTML/Element/center
 ---

--- a/files/fr/web/html/element/cite/index.md
+++ b/files/fr/web/html/element/cite/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<cite> : l''élément de citation'
+title: "<cite> : l'élément de citation"
 slug: Web/HTML/Element/cite
 translation_of: Web/HTML/Element/cite
 ---

--- a/files/fr/web/html/element/code/index.md
+++ b/files/fr/web/html/element/code/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<code> : l''élément de code en ligne'
+title: "<code> : l'élément de code en ligne"
 slug: Web/HTML/Element/code
 translation_of: Web/HTML/Element/code
 ---

--- a/files/fr/web/html/element/col/index.md
+++ b/files/fr/web/html/element/col/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<col> : l''élément représentant une colonne'
+title: "<col> : l'élément représentant une colonne"
 slug: Web/HTML/Element/col
 translation_of: Web/HTML/Element/col
 ---

--- a/files/fr/web/html/element/colgroup/index.md
+++ b/files/fr/web/html/element/colgroup/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<colgroup> : l''élément regroupant des colonnes'
+title: "<colgroup> : l'élément regroupant des colonnes"
 slug: Web/HTML/Element/colgroup
 translation_of: Web/HTML/Element/colgroup
 ---

--- a/files/fr/web/html/element/data/index.md
+++ b/files/fr/web/html/element/data/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<data> : l''élément de données'
+title: "<data> : l'élément de données"
 slug: Web/HTML/Element/data
 translation_of: Web/HTML/Element/data
 ---

--- a/files/fr/web/html/element/datalist/index.md
+++ b/files/fr/web/html/element/datalist/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<datalist> : l''élément de liste des données'
+title: "<datalist> : l'élément de liste des données"
 slug: Web/HTML/Element/datalist
 translation_of: Web/HTML/Element/datalist
 ---

--- a/files/fr/web/html/element/dd/index.md
+++ b/files/fr/web/html/element/dd/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<dd> : l''élément de détail d''une description'
+title: "<dd> : l'élément de détail d'une description"
 slug: Web/HTML/Element/dd
 translation_of: Web/HTML/Element/dd
 ---

--- a/files/fr/web/html/element/del/index.md
+++ b/files/fr/web/html/element/del/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<del> : l''élément de texte supprimé'
+title: "<del> : l'élément de texte supprimé"
 slug: Web/HTML/Element/del
 translation_of: Web/HTML/Element/del
 ---

--- a/files/fr/web/html/element/details/index.md
+++ b/files/fr/web/html/element/details/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<details> : l''élément de divulgation des détails'
+title: "<details> : l'élément de divulgation des détails"
 slug: Web/HTML/Element/details
 translation_of: Web/HTML/Element/details
 ---

--- a/files/fr/web/html/element/dfn/index.md
+++ b/files/fr/web/html/element/dfn/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<dfn> : l''élément de définition'
+title: "<dfn> : l'élément de définition"
 slug: Web/HTML/Element/dfn
 translation_of: Web/HTML/Element/dfn
 ---

--- a/files/fr/web/html/element/dialog/index.md
+++ b/files/fr/web/html/element/dialog/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<dialog> : l''élément de boîte de dialogue'
+title: "<dialog> : l'élément de boîte de dialogue"
 slug: Web/HTML/Element/dialog
 translation_of: Web/HTML/Element/dialog
 ---

--- a/files/fr/web/html/element/dir/index.md
+++ b/files/fr/web/html/element/dir/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<dir> : l''élément de répertoire'
+title: "<dir> : l'élément de répertoire"
 slug: Web/HTML/Element/dir
 translation_of: Web/HTML/Element/dir
 ---

--- a/files/fr/web/html/element/div/index.md
+++ b/files/fr/web/html/element/div/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<div> : l''élément de division du contenu'
+title: "<div> : l'élément de division du contenu"
 slug: Web/HTML/Element/div
 translation_of: Web/HTML/Element/div
 ---

--- a/files/fr/web/html/element/dl/index.md
+++ b/files/fr/web/html/element/dl/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<dl> : l''élément de liste de descriptions'
+title: "<dl> : l'élément de liste de descriptions"
 slug: Web/HTML/Element/dl
 translation_of: Web/HTML/Element/dl
 ---

--- a/files/fr/web/html/element/dt/index.md
+++ b/files/fr/web/html/element/dt/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<dt> : l''élément pour le terme d''une description'
+title: "<dt> : l'élément pour le terme d'une description"
 slug: Web/HTML/Element/dt
 translation_of: Web/HTML/Element/dt
 ---

--- a/files/fr/web/html/element/em/index.md
+++ b/files/fr/web/html/element/em/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<em> : l''élément d''emphase'
+title: "<em> : l'élément d'emphase"
 slug: Web/HTML/Element/em
 translation_of: Web/HTML/Element/em
 ---

--- a/files/fr/web/html/element/embed/index.md
+++ b/files/fr/web/html/element/embed/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<embed> : l''élément de contenu externe embarqué'
+title: "<embed> : l'élément de contenu externe embarqué"
 slug: Web/HTML/Element/embed
 translation_of: Web/HTML/Element/embed
 ---

--- a/files/fr/web/html/element/fieldset/index.md
+++ b/files/fr/web/html/element/fieldset/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<fieldset> : l''élément pour les ensembles de champs'
+title: "<fieldset> : l'élément pour les ensembles de champs"
 slug: Web/HTML/Element/fieldset
 translation_of: Web/HTML/Element/fieldset
 ---

--- a/files/fr/web/html/element/figcaption/index.md
+++ b/files/fr/web/html/element/figcaption/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<figcaption> : l''élément de légende d''une figure'
+title: "<figcaption> : l'élément de légende d'une figure"
 slug: Web/HTML/Element/figcaption
 translation_of: Web/HTML/Element/figcaption
 ---

--- a/files/fr/web/html/element/figure/index.md
+++ b/files/fr/web/html/element/figure/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<figure> : l''élément de figure avec légende facultative'
+title: "<figure> : l'élément de figure avec légende facultative"
 slug: Web/HTML/Element/figure
 translation_of: Web/HTML/Element/figure
 ---

--- a/files/fr/web/html/element/font/index.md
+++ b/files/fr/web/html/element/font/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<font> : l''élément de police'
+title: "<font> : l'élément de police"
 slug: Web/HTML/Element/font
 translation_of: Web/HTML/Element/font
 ---

--- a/files/fr/web/html/element/footer/index.md
+++ b/files/fr/web/html/element/footer/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<footer> : l''élément de pied de page ou de section'
+title: "<footer> : l'élément de pied de page ou de section"
 slug: Web/HTML/Element/footer
 translation_of: Web/HTML/Element/footer
 ---

--- a/files/fr/web/html/element/form/index.md
+++ b/files/fr/web/html/element/form/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<form> : l''élément représentant un formulaire'
+title: "<form> : l'élément représentant un formulaire"
 slug: Web/HTML/Element/form
 translation_of: Web/HTML/Element/form
 ---

--- a/files/fr/web/html/element/frame/index.md
+++ b/files/fr/web/html/element/frame/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<frame>'
+title: "<frame>"
 slug: Web/HTML/Element/frame
 translation_of: Web/HTML/Element/frame
 ---

--- a/files/fr/web/html/element/frameset/index.md
+++ b/files/fr/web/html/element/frameset/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<frameset> : l''élément contenant des frames'
+title: "<frameset> : l'élément contenant des frames"
 slug: Web/HTML/Element/frameset
 translation_of: Web/HTML/Element/frameset
 ---

--- a/files/fr/web/html/element/head/index.md
+++ b/files/fr/web/html/element/head/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<head> : l''élément de métadonnées (en-tête) du document'
+title: "<head> : l'élément de métadonnées (en-tête) du document"
 slug: Web/HTML/Element/head
 translation_of: Web/HTML/Element/head
 ---

--- a/files/fr/web/html/element/heading_elements/index.md
+++ b/files/fr/web/html/element/heading_elements/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<h1>-<h6> : les éléments de titre de section'
+title: "<h1>-<h6> : les éléments de titre de section"
 slug: Web/HTML/Element/Heading_Elements
 l10n:
   sourceCommit: d9026c37acaf22da682206c381686fe8a4666f16

--- a/files/fr/web/html/element/hr/index.md
+++ b/files/fr/web/html/element/hr/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<hr> : l''élément de rupture thématique (règle horizontale)'
+title: "<hr> : l'élément de rupture thématique (règle horizontale)"
 slug: Web/HTML/Element/hr
 translation_of: Web/HTML/Element/hr
 ---

--- a/files/fr/web/html/element/html/index.md
+++ b/files/fr/web/html/element/html/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<html> : l''élément de racine du document HTML'
+title: "<html> : l'élément de racine du document HTML"
 slug: Web/HTML/Element/html
 translation_of: Web/HTML/Element/html
 ---

--- a/files/fr/web/html/element/iframe/index.md
+++ b/files/fr/web/html/element/iframe/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<iframe> : l''élément de cadre intégré'
+title: "<iframe> : l'élément de cadre intégré"
 slug: Web/HTML/Element/iframe
 translation_of: Web/HTML/Element/iframe
 ---

--- a/files/fr/web/html/element/img/index.md
+++ b/files/fr/web/html/element/img/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<img> : l''élément d''image embarquée'
+title: "<img> : l'élément d'image embarquée"
 slug: Web/HTML/Element/img
 translation_of: Web/HTML/Element/img
 ---

--- a/files/fr/web/html/element/kbd/index.md
+++ b/files/fr/web/html/element/kbd/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<kbd> : l''élément de saisie clavier'
+title: "<kbd> : l'élément de saisie clavier"
 slug: Web/HTML/Element/kbd
 translation_of: Web/HTML/Element/kbd
 ---

--- a/files/fr/web/html/element/link/index.md
+++ b/files/fr/web/html/element/link/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<link> : l''élément de lien vers des ressources externes'
+title: "<link> : l'élément de lien vers des ressources externes"
 slug: Web/HTML/Element/link
 translation_of: Web/HTML/Element/link
 ---

--- a/files/fr/web/html/element/mark/index.md
+++ b/files/fr/web/html/element/mark/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<mark> : l''élément de marquage du texte'
+title: "<mark> : l'élément de marquage du texte"
 slug: Web/HTML/Element/mark
 translation_of: Web/HTML/Element/mark
 ---

--- a/files/fr/web/html/element/marquee/index.md
+++ b/files/fr/web/html/element/marquee/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<marquee> : l''élément de fronton (obsolète)'
+title: "<marquee> : l'élément de fronton (obsolète)"
 slug: Web/HTML/Element/marquee
 translation_of: Web/HTML/Element/marquee
 ---

--- a/files/fr/web/html/element/meta/index.md
+++ b/files/fr/web/html/element/meta/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<meta> : l''élément de métadonnées du document'
+title: "<meta> : l'élément de métadonnées du document"
 slug: Web/HTML/Element/meta
 translation_of: Web/HTML/Element/meta
 ---

--- a/files/fr/web/html/element/nav/index.md
+++ b/files/fr/web/html/element/nav/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<nav> : l''élément de section de navigation'
+title: "<nav> : l'élément de section de navigation"
 slug: Web/HTML/Element/nav
 translation_of: Web/HTML/Element/nav
 ---

--- a/files/fr/web/html/element/nobr/index.md
+++ b/files/fr/web/html/element/nobr/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<nobr> : l''élément de non-rupture de texte (obsolète)'
+title: "<nobr> : l'élément de non-rupture de texte (obsolète)"
 slug: Web/HTML/Element/nobr
 translation_of: Web/HTML/Element/nobr
 ---

--- a/files/fr/web/html/element/noembed/index.md
+++ b/files/fr/web/html/element/noembed/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<noembed> : l''élément alternatif au contenu embarqué (obsolète)'
+title: "<noembed> : l'élément alternatif au contenu embarqué (obsolète)"
 slug: Web/HTML/Element/noembed
 translation_of: Web/HTML/Element/noembed
 ---

--- a/files/fr/web/html/element/noframes/index.md
+++ b/files/fr/web/html/element/noframes/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<noframes> : l''élément alternatif aux frames (obsolete)'
+title: "<noframes> : l'élément alternatif aux frames (obsolete)"
 slug: Web/HTML/Element/noframes
 translation_of: Web/HTML/Element/noframes
 ---

--- a/files/fr/web/html/element/ol/index.md
+++ b/files/fr/web/html/element/ol/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<ol> : l''élément de liste ordonnée'
+title: "<ol> : l'élément de liste ordonnée"
 slug: Web/HTML/Element/ol
 translation_of: Web/HTML/Element/ol
 ---

--- a/files/fr/web/html/element/output/index.md
+++ b/files/fr/web/html/element/output/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<output> : l''élément de sortie'
+title: "<output> : l'élément de sortie"
 slug: Web/HTML/Element/output
 translation_of: Web/HTML/Element/output
 ---

--- a/files/fr/web/html/element/p/index.md
+++ b/files/fr/web/html/element/p/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<p> : l''élément paragraphe'
+title: "<p> : l'élément paragraphe"
 slug: Web/HTML/Element/p
 translation_of: Web/HTML/Element/p
 ---

--- a/files/fr/web/html/element/param/index.md
+++ b/files/fr/web/html/element/param/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<param> : l''élément paramètre d''un objet'
+title: "<param> : l'élément paramètre d'un objet"
 slug: Web/HTML/Element/param
 translation_of: Web/HTML/Element/param
 ---

--- a/files/fr/web/html/element/picture/index.md
+++ b/files/fr/web/html/element/picture/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<picture> : l''élément d''image adaptative'
+title: "<picture> : l'élément d'image adaptative"
 slug: Web/HTML/Element/picture
 translation_of: Web/HTML/Element/picture
 ---

--- a/files/fr/web/html/element/plaintext/index.md
+++ b/files/fr/web/html/element/plaintext/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<plaintext> : l''élément de texte brut (déprécié)'
+title: "<plaintext> : l'élément de texte brut (déprécié)"
 slug: Web/HTML/Element/plaintext
 translation_of: Web/HTML/Element/plaintext
 ---

--- a/files/fr/web/html/element/pre/index.md
+++ b/files/fr/web/html/element/pre/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<pre> : l''élément de texte préformaté'
+title: "<pre> : l'élément de texte préformaté"
 slug: Web/HTML/Element/pre
 l10n:
   sourceCommit: 6aa2d63aef51ada47960f4754b601af66a99d63c

--- a/files/fr/web/html/element/progress/index.md
+++ b/files/fr/web/html/element/progress/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<progress> : l''élément d''indicateur de progression'
+title: "<progress> : l'élément d'indicateur de progression"
 slug: Web/HTML/Element/progress
 translation_of: Web/HTML/Element/progress
 ---

--- a/files/fr/web/html/element/q/index.md
+++ b/files/fr/web/html/element/q/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<q> : l''élément de citation en incise'
+title: "<q> : l'élément de citation en incise"
 slug: Web/HTML/Element/q
 translation_of: Web/HTML/Element/q
 ---

--- a/files/fr/web/html/element/rb/index.md
+++ b/files/fr/web/html/element/rb/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<rb> : l''élément de base ruby'
+title: "<rb> : l'élément de base ruby"
 slug: Web/HTML/Element/rb
 translation_of: Web/HTML/Element/rb
 ---

--- a/files/fr/web/html/element/rp/index.md
+++ b/files/fr/web/html/element/rp/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<rp> : l''élément de parenthèses alternatif aux annotations Ruby'
+title: "<rp> : l'élément de parenthèses alternatif aux annotations Ruby"
 slug: Web/HTML/Element/rp
 translation_of: Web/HTML/Element/rp
 ---

--- a/files/fr/web/html/element/rt/index.md
+++ b/files/fr/web/html/element/rt/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<rt> : l''élément de texte Ruby'
+title: "<rt> : l'élément de texte Ruby"
 slug: Web/HTML/Element/rt
 translation_of: Web/HTML/Element/rt
 ---

--- a/files/fr/web/html/element/rtc/index.md
+++ b/files/fr/web/html/element/rtc/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<rtc> : l''élément de conteneur de texte Ruby'
+title: "<rtc> : l'élément de conteneur de texte Ruby"
 slug: Web/HTML/Element/rtc
 translation_of: Web/HTML/Element/rtc
 ---

--- a/files/fr/web/html/element/samp/index.md
+++ b/files/fr/web/html/element/samp/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<samp> : l''élément d''échantillon en sortie'
+title: "<samp> : l'élément d'échantillon en sortie"
 slug: Web/HTML/Element/samp
 l10n:
   sourceCommit: 20f58e36e34d79bac99aa527865a754e9c29c81b

--- a/files/fr/web/html/element/script/index.md
+++ b/files/fr/web/html/element/script/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<script> : l''élément de script'
+title: "<script> : l'élément de script"
 slug: Web/HTML/Element/script
 translation_of: Web/HTML/Element/script
 ---

--- a/files/fr/web/html/element/section/index.md
+++ b/files/fr/web/html/element/section/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<section> : l''élément de section générique'
+title: "<section> : l'élément de section générique"
 slug: Web/HTML/Element/section
 translation_of: Web/HTML/Element/section
 ---

--- a/files/fr/web/html/element/strong/index.md
+++ b/files/fr/web/html/element/strong/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<strong> : l''élément de haute importance'
+title: "<strong> : l'élément de haute importance"
 slug: Web/HTML/Element/strong
 translation_of: Web/HTML/Element/strong
 ---

--- a/files/fr/web/html/element/style/index.md
+++ b/files/fr/web/html/element/style/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<style> : l''élément d''information de style'
+title: "<style> : l'élément d'information de style"
 slug: Web/HTML/Element/style
 translation_of: Web/HTML/Element/style
 ---

--- a/files/fr/web/html/element/sub/index.md
+++ b/files/fr/web/html/element/sub/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<sub> : l''élément de mise en indice'
+title: "<sub> : l'élément de mise en indice"
 slug: Web/HTML/Element/sub
 l10n:
   sourceCommit: ca8d6889ade7fc6121aaf4d59158fa6a795f1a1b

--- a/files/fr/web/html/element/summary/index.md
+++ b/files/fr/web/html/element/summary/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<summary> : l''élément de révélation d''un résumé'
+title: "<summary> : l'élément de révélation d'un résumé"
 slug: Web/HTML/Element/summary
 translation_of: Web/HTML/Element/summary
 ---

--- a/files/fr/web/html/element/sup/index.md
+++ b/files/fr/web/html/element/sup/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<sup> : l''élément de mise en exposant'
+title: "<sup> : l'élément de mise en exposant"
 slug: Web/HTML/Element/sup
 translation_of: Web/HTML/Element/sup
 ---

--- a/files/fr/web/html/element/table/index.md
+++ b/files/fr/web/html/element/table/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<table> : l''élément de tableau'
+title: "<table> : l'élément de tableau"
 slug: Web/HTML/Element/table
 translation_of: Web/HTML/Element/table
 ---

--- a/files/fr/web/html/element/tbody/index.md
+++ b/files/fr/web/html/element/tbody/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<tbody> : l''élément de corps d''un tableau'
+title: "<tbody> : l'élément de corps d'un tableau"
 slug: Web/HTML/Element/tbody
 translation_of: Web/HTML/Element/tbody
 ---

--- a/files/fr/web/html/element/td/index.md
+++ b/files/fr/web/html/element/td/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<td> : l''élément de cellule de tableau'
+title: "<td> : l'élément de cellule de tableau"
 slug: Web/HTML/Element/td
 translation_of: Web/HTML/Element/td
 ---

--- a/files/fr/web/html/element/tfoot/index.md
+++ b/files/fr/web/html/element/tfoot/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<tfoot> : l''élément de pied de tableau'
+title: "<tfoot> : l'élément de pied de tableau"
 slug: Web/HTML/Element/tfoot
 translation_of: Web/HTML/Element/tfoot
 ---

--- a/files/fr/web/html/element/th/index.md
+++ b/files/fr/web/html/element/th/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<th> : l''élément d''en-tête de tableau'
+title: "<th> : l'élément d'en-tête de tableau"
 slug: Web/HTML/Element/th
 translation_of: Web/HTML/Element/th
 ---

--- a/files/fr/web/html/element/title/index.md
+++ b/files/fr/web/html/element/title/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<title> : l''élément de titre du document'
+title: "<title> : l'élément de titre du document"
 slug: Web/HTML/Element/title
 translation_of: Web/HTML/Element/title
 ---

--- a/files/fr/web/html/element/tr/index.md
+++ b/files/fr/web/html/element/tr/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<tr> : l''élément de ligne d''un tableau'
+title: "<tr> : l'élément de ligne d'un tableau"
 slug: Web/HTML/Element/tr
 translation_of: Web/HTML/Element/tr
 ---

--- a/files/fr/web/html/element/track/index.md
+++ b/files/fr/web/html/element/track/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<track> : l''élément de piste texte embarquée'
+title: "<track> : l'élément de piste texte embarquée"
 slug: Web/HTML/Element/track
 translation_of: Web/HTML/Element/track
 ---

--- a/files/fr/web/html/element/tt/index.md
+++ b/files/fr/web/html/element/tt/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<tt> : l''élément de texte de téléscripteur (obsolète)'
+title: "<tt> : l'élément de texte de téléscripteur (obsolète)"
 slug: Web/HTML/Element/tt
 translation_of: Web/HTML/Element/tt
 ---

--- a/files/fr/web/html/element/u/index.md
+++ b/files/fr/web/html/element/u/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<u> : l''élément d''annotation non textuelle'
+title: "<u> : l'élément d'annotation non textuelle"
 slug: Web/HTML/Element/u
 translation_of: Web/HTML/Element/u
 ---

--- a/files/fr/web/html/element/var/index.md
+++ b/files/fr/web/html/element/var/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<var> : l''élément de variable'
+title: "<var> : l'élément de variable"
 slug: Web/HTML/Element/var
 translation_of: Web/HTML/Element/var
 ---


### PR DESCRIPTION
This PR formats the `/web/html` folder of the French locale using Prettier.  This is the first part.
