### PR TITLE
fr: Format /web/css using Prettier (part 1)

### DIFF
--- a/files/fr/web/css/-moz-float-edge/index.md
+++ b/files/fr/web/css/-moz-float-edge/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-float-edge'
+title: "-moz-float-edge"
 slug: Web/CSS/-moz-float-edge
 translation_of: Web/CSS/-moz-float-edge
 ---

--- a/files/fr/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/fr/web/css/-moz-force-broken-image-icon/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-force-broken-image-icon'
+title: "-moz-force-broken-image-icon"
 slug: Web/CSS/-moz-force-broken-image-icon
 translation_of: Web/CSS/-moz-force-broken-image-icon
 ---

--- a/files/fr/web/css/-moz-image-rect/index.md
+++ b/files/fr/web/css/-moz-image-rect/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-image-rect'
+title: "-moz-image-rect"
 slug: Web/CSS/-moz-image-rect
 translation_of: Web/CSS/-moz-image-rect
 ---

--- a/files/fr/web/css/-moz-image-region/index.md
+++ b/files/fr/web/css/-moz-image-region/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-image-region'
+title: "-moz-image-region"
 slug: Web/CSS/-moz-image-region
 translation_of: Web/CSS/-moz-image-region
 ---

--- a/files/fr/web/css/-moz-orient/index.md
+++ b/files/fr/web/css/-moz-orient/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-orient'
+title: "-moz-orient"
 slug: Web/CSS/-moz-orient
 translation_of: Web/CSS/-moz-orient
 ---

--- a/files/fr/web/css/-moz-user-focus/index.md
+++ b/files/fr/web/css/-moz-user-focus/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-user-focus'
+title: "-moz-user-focus"
 slug: Web/CSS/-moz-user-focus
 translation_of: Web/CSS/-moz-user-focus
 ---

--- a/files/fr/web/css/-moz-user-input/index.md
+++ b/files/fr/web/css/-moz-user-input/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-user-input'
+title: "-moz-user-input"
 slug: Web/CSS/-moz-user-input
 translation_of: Web/CSS/-moz-user-input
 ---

--- a/files/fr/web/css/-webkit-border-before/index.md
+++ b/files/fr/web/css/-webkit-border-before/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-border-before'
+title: "-webkit-border-before"
 slug: Web/CSS/-webkit-border-before
 translation_of: Web/CSS/-webkit-border-before
 ---

--- a/files/fr/web/css/-webkit-box-reflect/index.md
+++ b/files/fr/web/css/-webkit-box-reflect/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-box-reflect'
+title: "-webkit-box-reflect"
 slug: Web/CSS/-webkit-box-reflect
 translation_of: Web/CSS/-webkit-box-reflect
 ---

--- a/files/fr/web/css/-webkit-line-clamp/index.md
+++ b/files/fr/web/css/-webkit-line-clamp/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-line-clamp'
+title: "-webkit-line-clamp"
 slug: Web/CSS/-webkit-line-clamp
 translation_of: Web/CSS/-webkit-line-clamp
 ---

--- a/files/fr/web/css/-webkit-mask-attachment/index.md
+++ b/files/fr/web/css/-webkit-mask-attachment/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-attachment'
+title: "-webkit-mask-attachment"
 slug: Web/CSS/-webkit-mask-attachment
 translation_of: Web/CSS/-webkit-mask-attachment
 ---

--- a/files/fr/web/css/-webkit-mask-box-image/index.md
+++ b/files/fr/web/css/-webkit-mask-box-image/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-box-image'
+title: "-webkit-mask-box-image"
 slug: Web/CSS/-webkit-mask-box-image
 translation_of: Web/CSS/-webkit-mask-box-image
 ---

--- a/files/fr/web/css/-webkit-mask-composite/index.md
+++ b/files/fr/web/css/-webkit-mask-composite/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-composite'
+title: "-webkit-mask-composite"
 slug: Web/CSS/-webkit-mask-composite
 translation_of: Web/CSS/-webkit-mask-composite
 ---

--- a/files/fr/web/css/-webkit-mask-position-x/index.md
+++ b/files/fr/web/css/-webkit-mask-position-x/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-position-x'
+title: "-webkit-mask-position-x"
 slug: Web/CSS/-webkit-mask-position-x
 translation_of: Web/CSS/-webkit-mask-position-x
 ---

--- a/files/fr/web/css/-webkit-mask-position-y/index.md
+++ b/files/fr/web/css/-webkit-mask-position-y/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-position-y'
+title: "-webkit-mask-position-y"
 slug: Web/CSS/-webkit-mask-position-y
 translation_of: Web/CSS/-webkit-mask-position-y
 ---

--- a/files/fr/web/css/-webkit-mask-repeat-x/index.md
+++ b/files/fr/web/css/-webkit-mask-repeat-x/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-repeat-x'
+title: "-webkit-mask-repeat-x"
 slug: Web/CSS/-webkit-mask-repeat-x
 translation_of: Web/CSS/-webkit-mask-repeat-x
 ---

--- a/files/fr/web/css/-webkit-mask-repeat-y/index.md
+++ b/files/fr/web/css/-webkit-mask-repeat-y/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-repeat-y'
+title: "-webkit-mask-repeat-y"
 slug: Web/CSS/-webkit-mask-repeat-y
 translation_of: Web/CSS/-webkit-mask-repeat-y
 ---

--- a/files/fr/web/css/-webkit-overflow-scrolling/index.md
+++ b/files/fr/web/css/-webkit-overflow-scrolling/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-overflow-scrolling'
+title: "-webkit-overflow-scrolling"
 slug: Web/CSS/-webkit-overflow-scrolling
 translation_of: Web/CSS/-webkit-overflow-scrolling
 ---

--- a/files/fr/web/css/-webkit-tap-highlight-color/index.md
+++ b/files/fr/web/css/-webkit-tap-highlight-color/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-tap-highlight-color'
+title: "-webkit-tap-highlight-color"
 slug: Web/CSS/-webkit-tap-highlight-color
 translation_of: Web/CSS/-webkit-tap-highlight-color
 ---

--- a/files/fr/web/css/-webkit-text-fill-color/index.md
+++ b/files/fr/web/css/-webkit-text-fill-color/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-text-fill-color'
+title: "-webkit-text-fill-color"
 slug: Web/CSS/-webkit-text-fill-color
 translation_of: Web/CSS/-webkit-text-fill-color
 ---

--- a/files/fr/web/css/-webkit-text-security/index.md
+++ b/files/fr/web/css/-webkit-text-security/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-text-security'
+title: "-webkit-text-security"
 slug: Web/CSS/-webkit-text-security
 translation_of: Web/CSS/-webkit-text-security
 ---

--- a/files/fr/web/css/-webkit-text-stroke-color/index.md
+++ b/files/fr/web/css/-webkit-text-stroke-color/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-text-stroke-color'
+title: "-webkit-text-stroke-color"
 slug: Web/CSS/-webkit-text-stroke-color
 translation_of: Web/CSS/-webkit-text-stroke-color
 ---

--- a/files/fr/web/css/-webkit-text-stroke-width/index.md
+++ b/files/fr/web/css/-webkit-text-stroke-width/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-text-stroke-width'
+title: "-webkit-text-stroke-width"
 slug: Web/CSS/-webkit-text-stroke-width
 translation_of: Web/CSS/-webkit-text-stroke-width
 ---

--- a/files/fr/web/css/-webkit-text-stroke/index.md
+++ b/files/fr/web/css/-webkit-text-stroke/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-text-stroke'
+title: "-webkit-text-stroke"
 slug: Web/CSS/-webkit-text-stroke
 translation_of: Web/CSS/-webkit-text-stroke
 ---

--- a/files/fr/web/css/-webkit-touch-callout/index.md
+++ b/files/fr/web/css/-webkit-touch-callout/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-touch-callout'
+title: "-webkit-touch-callout"
 slug: Web/CSS/-webkit-touch-callout
 translation_of: Web/CSS/-webkit-touch-callout
 ---

--- a/files/fr/web/css/@charset/index.md
+++ b/files/fr/web/css/@charset/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@charset'
+title: "@charset"
 slug: Web/CSS/@charset
 translation_of: Web/CSS/@charset
 ---

--- a/files/fr/web/css/@color-profile/index.md
+++ b/files/fr/web/css/@color-profile/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@color-profile'
+title: "@color-profile"
 slug: Web/CSS/@color-profile
 translation_of: Web/CSS/@color-profile
 ---

--- a/files/fr/web/css/@counter-style/index.md
+++ b/files/fr/web/css/@counter-style/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@counter-style'
+title: "@counter-style"
 slug: Web/CSS/@counter-style
 translation_of: Web/CSS/@counter-style
 ---

--- a/files/fr/web/css/@document/index.md
+++ b/files/fr/web/css/@document/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@document'
+title: "@document"
 slug: Web/CSS/@document
 translation_of: Web/CSS/@document
 ---

--- a/files/fr/web/css/@font-face/index.md
+++ b/files/fr/web/css/@font-face/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@font-face'
+title: "@font-face"
 slug: Web/CSS/@font-face
 l10n:
   sourceCommit: ccafad98826d97da19728626047a7020000fd639

--- a/files/fr/web/css/@font-feature-values/index.md
+++ b/files/fr/web/css/@font-feature-values/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@font-feature-values'
+title: "@font-feature-values"
 slug: Web/CSS/@font-feature-values
 translation_of: Web/CSS/@font-feature-values
 ---

--- a/files/fr/web/css/@import/index.md
+++ b/files/fr/web/css/@import/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@import'
+title: "@import"
 slug: Web/CSS/@import
 translation_of: Web/CSS/@import
 ---

--- a/files/fr/web/css/@keyframes/index.md
+++ b/files/fr/web/css/@keyframes/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@keyframes'
+title: "@keyframes"
 slug: Web/CSS/@keyframes
 translation_of: Web/CSS/@keyframes
 ---

--- a/files/fr/web/css/@layer/index.md
+++ b/files/fr/web/css/@layer/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@layer'
+title: "@layer"
 slug: Web/CSS/@layer
 translation_of: Web/CSS/@layer
 ---

--- a/files/fr/web/css/@media/-moz-device-pixel-ratio/index.md
+++ b/files/fr/web/css/@media/-moz-device-pixel-ratio/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-device-pixel-ratio'
+title: "-moz-device-pixel-ratio"
 slug: Web/CSS/@media/-moz-device-pixel-ratio
 translation_of: Web/CSS/@media/-moz-device-pixel-ratio
 ---

--- a/files/fr/web/css/@media/-webkit-animation/index.md
+++ b/files/fr/web/css/@media/-webkit-animation/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-animation'
+title: "-webkit-animation"
 slug: Web/CSS/@media/-webkit-animation
 translation_of: Web/CSS/@media/-webkit-animation
 ---

--- a/files/fr/web/css/@media/-webkit-device-pixel-ratio/index.md
+++ b/files/fr/web/css/@media/-webkit-device-pixel-ratio/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-device-pixel-ratio'
+title: "-webkit-device-pixel-ratio"
 slug: Web/CSS/@media/-webkit-device-pixel-ratio
 translation_of: Web/CSS/@media/-webkit-device-pixel-ratio
 ---

--- a/files/fr/web/css/@media/-webkit-transform-2d/index.md
+++ b/files/fr/web/css/@media/-webkit-transform-2d/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-transform-2d'
+title: "-webkit-transform-2d"
 slug: Web/CSS/@media/-webkit-transform-2d
 translation_of: Web/CSS/@media/-webkit-transform-2d
 ---

--- a/files/fr/web/css/@media/-webkit-transform-3d/index.md
+++ b/files/fr/web/css/@media/-webkit-transform-3d/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-transform-3d'
+title: "-webkit-transform-3d"
 slug: Web/CSS/@media/-webkit-transform-3d
 translation_of: Web/CSS/@media/-webkit-transform-3d
 ---

--- a/files/fr/web/css/@media/-webkit-transition/index.md
+++ b/files/fr/web/css/@media/-webkit-transition/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-transition'
+title: "-webkit-transition"
 slug: Web/CSS/@media/-webkit-transition
 translation_of: Web/CSS/@media/-webkit-transition
 ---

--- a/files/fr/web/css/@media/index.md
+++ b/files/fr/web/css/@media/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@media'
+title: "@media"
 slug: Web/CSS/@media
 translation_of: Web/CSS/@media
 ---

--- a/files/fr/web/css/@namespace/index.md
+++ b/files/fr/web/css/@namespace/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@namespace'
+title: "@namespace"
 slug: Web/CSS/@namespace
 translation_of: Web/CSS/@namespace
 ---

--- a/files/fr/web/css/@page/index.md
+++ b/files/fr/web/css/@page/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@page'
+title: "@page"
 slug: Web/CSS/@page
 translation_of: Web/CSS/@page
 ---

--- a/files/fr/web/css/@property/index.md
+++ b/files/fr/web/css/@property/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@property'
+title: "@property"
 slug: Web/CSS/@property
 translation_of: Web/CSS/@property
 ---

--- a/files/fr/web/css/@supports/index.md
+++ b/files/fr/web/css/@supports/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@supports'
+title: "@supports"
 slug: Web/CSS/@supports
 translation_of: Web/CSS/@supports
 ---

--- a/files/fr/web/css/_colon_-moz-broken/index.md
+++ b/files/fr/web/css/_colon_-moz-broken/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-broken'
+title: ":-moz-broken"
 slug: Web/CSS/:-moz-broken
 translation_of: Web/CSS/:-moz-broken
 ---

--- a/files/fr/web/css/_colon_-moz-drag-over/index.md
+++ b/files/fr/web/css/_colon_-moz-drag-over/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-drag-over'
+title: ":-moz-drag-over"
 slug: Web/CSS/:-moz-drag-over
 translation_of: Web/CSS/:-moz-drag-over
 ---

--- a/files/fr/web/css/_colon_-moz-first-node/index.md
+++ b/files/fr/web/css/_colon_-moz-first-node/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-first-node'
+title: ":-moz-first-node"
 slug: Web/CSS/:-moz-first-node
 translation_of: Web/CSS/:-moz-first-node
 ---

--- a/files/fr/web/css/_colon_-moz-handler-blocked/index.md
+++ b/files/fr/web/css/_colon_-moz-handler-blocked/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-handler-blocked'
+title: ":-moz-handler-blocked"
 slug: Web/CSS/:-moz-handler-blocked
 translation_of: Web/CSS/:-moz-handler-blocked
 ---

--- a/files/fr/web/css/_colon_-moz-handler-crashed/index.md
+++ b/files/fr/web/css/_colon_-moz-handler-crashed/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-handler-crashed'
+title: ":-moz-handler-crashed"
 slug: Web/CSS/:-moz-handler-crashed
 translation_of: Web/CSS/:-moz-handler-crashed
 ---

--- a/files/fr/web/css/_colon_-moz-handler-disabled/index.md
+++ b/files/fr/web/css/_colon_-moz-handler-disabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-handler-disabled'
+title: ":-moz-handler-disabled"
 slug: Web/CSS/:-moz-handler-disabled
 translation_of: Web/CSS/:-moz-handler-disabled
 ---

--- a/files/fr/web/css/_colon_-moz-last-node/index.md
+++ b/files/fr/web/css/_colon_-moz-last-node/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-last-node'
+title: ":-moz-last-node"
 slug: Web/CSS/:-moz-last-node
 translation_of: Web/CSS/:-moz-last-node
 ---

--- a/files/fr/web/css/_colon_-moz-loading/index.md
+++ b/files/fr/web/css/_colon_-moz-loading/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-loading'
+title: ":-moz-loading"
 slug: Web/CSS/:-moz-loading
 translation_of: Web/CSS/:-moz-loading
 ---

--- a/files/fr/web/css/_colon_-moz-locale-dir_ltr/index.md
+++ b/files/fr/web/css/_colon_-moz-locale-dir_ltr/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-locale-dir(ltr)'
+title: ":-moz-locale-dir(ltr)"
 slug: Web/CSS/:-moz-locale-dir_ltr
 translation_of: Web/CSS/:-moz-locale-dir(ltr)
 ---

--- a/files/fr/web/css/_colon_-moz-locale-dir_rtl/index.md
+++ b/files/fr/web/css/_colon_-moz-locale-dir_rtl/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-locale-dir(rtl)'
+title: ":-moz-locale-dir(rtl)"
 slug: Web/CSS/:-moz-locale-dir_rtl
 translation_of: Web/CSS/:-moz-locale-dir(rtl)
 ---

--- a/files/fr/web/css/_colon_-moz-only-whitespace/index.md
+++ b/files/fr/web/css/_colon_-moz-only-whitespace/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-only-whitespace'
+title: ":-moz-only-whitespace"
 slug: Web/CSS/:-moz-only-whitespace
 translation_of: Web/CSS/:-moz-only-whitespace
 ---

--- a/files/fr/web/css/_colon_-moz-submit-invalid/index.md
+++ b/files/fr/web/css/_colon_-moz-submit-invalid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-submit-invalid'
+title: ":-moz-submit-invalid"
 slug: Web/CSS/:-moz-submit-invalid
 translation_of: Web/CSS/:-moz-submit-invalid
 ---

--- a/files/fr/web/css/_colon_-moz-suppressed/index.md
+++ b/files/fr/web/css/_colon_-moz-suppressed/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-suppressed'
+title: ":-moz-suppressed"
 slug: Web/CSS/:-moz-suppressed
 translation_of: Web/CSS/:-moz-suppressed
 ---

--- a/files/fr/web/css/_colon_-moz-user-disabled/index.md
+++ b/files/fr/web/css/_colon_-moz-user-disabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-user-disabled'
+title: ":-moz-user-disabled"
 slug: Web/CSS/:-moz-user-disabled
 translation_of: Web/CSS/:-moz-user-disabled
 ---

--- a/files/fr/web/css/_colon_-moz-window-inactive/index.md
+++ b/files/fr/web/css/_colon_-moz-window-inactive/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-window-inactive'
+title: ":-moz-window-inactive"
 slug: Web/CSS/:-moz-window-inactive
 translation_of: Web/CSS/:-moz-window-inactive
 ---

--- a/files/fr/web/css/_colon_active/index.md
+++ b/files/fr/web/css/_colon_active/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':active'
+title: ":active"
 slug: Web/CSS/:active
 translation_of: Web/CSS/:active
 ---

--- a/files/fr/web/css/_colon_any-link/index.md
+++ b/files/fr/web/css/_colon_any-link/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':any-link'
+title: ":any-link"
 slug: Web/CSS/:any-link
 translation_of: Web/CSS/:any-link
 ---

--- a/files/fr/web/css/_colon_autofill/index.md
+++ b/files/fr/web/css/_colon_autofill/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-webkit-autofill'
+title: ":-webkit-autofill"
 slug: Web/CSS/:autofill
 translation_of: Web/CSS/:-webkit-autofill
 ---

--- a/files/fr/web/css/_colon_blank/index.md
+++ b/files/fr/web/css/_colon_blank/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':blank'
+title: ":blank"
 slug: Web/CSS/:blank
 translation_of: Web/CSS/:blank
 ---

--- a/files/fr/web/css/_colon_checked/index.md
+++ b/files/fr/web/css/_colon_checked/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':checked'
+title: ":checked"
 slug: Web/CSS/:checked
 translation_of: Web/CSS/:checked
 ---

--- a/files/fr/web/css/_colon_default/index.md
+++ b/files/fr/web/css/_colon_default/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':default'
+title: ":default"
 slug: Web/CSS/:default
 translation_of: Web/CSS/:default
 ---

--- a/files/fr/web/css/_colon_defined/index.md
+++ b/files/fr/web/css/_colon_defined/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':defined'
+title: ":defined"
 slug: Web/CSS/:defined
 translation_of: Web/CSS/:defined
 ---

--- a/files/fr/web/css/_colon_dir/index.md
+++ b/files/fr/web/css/_colon_dir/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':dir'
+title: ":dir"
 slug: Web/CSS/:dir
 translation_of: Web/CSS/:dir
 ---

--- a/files/fr/web/css/_colon_disabled/index.md
+++ b/files/fr/web/css/_colon_disabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':disabled'
+title: ":disabled"
 slug: Web/CSS/:disabled
 translation_of: Web/CSS/:disabled
 ---

--- a/files/fr/web/css/_colon_empty/index.md
+++ b/files/fr/web/css/_colon_empty/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':empty'
+title: ":empty"
 slug: Web/CSS/:empty
 translation_of: Web/CSS/:empty
 ---

--- a/files/fr/web/css/_colon_enabled/index.md
+++ b/files/fr/web/css/_colon_enabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':enabled'
+title: ":enabled"
 slug: Web/CSS/:enabled
 translation_of: Web/CSS/:enabled
 ---

--- a/files/fr/web/css/_colon_first-child/index.md
+++ b/files/fr/web/css/_colon_first-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':first-child'
+title: ":first-child"
 slug: Web/CSS/:first-child
 translation_of: Web/CSS/:first-child
 ---

--- a/files/fr/web/css/_colon_first-of-type/index.md
+++ b/files/fr/web/css/_colon_first-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':first-of-type'
+title: ":first-of-type"
 slug: Web/CSS/:first-of-type
 translation_of: Web/CSS/:first-of-type
 ---

--- a/files/fr/web/css/_colon_first/index.md
+++ b/files/fr/web/css/_colon_first/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':first'
+title: ":first"
 slug: Web/CSS/:first
 translation_of: Web/CSS/:first
 ---

--- a/files/fr/web/css/_colon_focus-visible/index.md
+++ b/files/fr/web/css/_colon_focus-visible/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':focus-visible'
+title: ":focus-visible"
 slug: Web/CSS/:focus-visible
 translation_of: Web/CSS/:focus-visible
 ---

--- a/files/fr/web/css/_colon_focus-within/index.md
+++ b/files/fr/web/css/_colon_focus-within/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':focus-within'
+title: ":focus-within"
 slug: Web/CSS/:focus-within
 translation_of: Web/CSS/:focus-within
 ---

--- a/files/fr/web/css/_colon_focus/index.md
+++ b/files/fr/web/css/_colon_focus/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':focus'
+title: ":focus"
 slug: Web/CSS/:focus
 translation_of: Web/CSS/:focus
 ---

--- a/files/fr/web/css/_colon_fullscreen/index.md
+++ b/files/fr/web/css/_colon_fullscreen/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':fullscreen'
+title: ":fullscreen"
 slug: Web/CSS/:fullscreen
 translation_of: Web/CSS/:fullscreen
 ---

--- a/files/fr/web/css/_colon_future/index.md
+++ b/files/fr/web/css/_colon_future/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':future'
+title: ":future"
 slug: Web/CSS/:future
 translation_of: Web/CSS/:future
 ---

--- a/files/fr/web/css/_colon_has/index.md
+++ b/files/fr/web/css/_colon_has/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':has'
+title: ":has"
 slug: Web/CSS/:has
 translation_of: Web/CSS/:has
 ---

--- a/files/fr/web/css/_colon_host-context/index.md
+++ b/files/fr/web/css/_colon_host-context/index.md
@@ -1,7 +1,7 @@
 ---
-title: ':host-context()'
+title: ":host-context()"
 slug: Web/CSS/:host-context
-translation_of: 
+translation_of:
 l10n:
   sourceCommit: 257486f64b2472dda4996a4ea7b6b5305e46f863
 ---

--- a/files/fr/web/css/_colon_host/index.md
+++ b/files/fr/web/css/_colon_host/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':host'
+title: ":host"
 slug: Web/CSS/:host
 translation_of: Web/CSS/:host
 ---

--- a/files/fr/web/css/_colon_host_function/index.md
+++ b/files/fr/web/css/_colon_host_function/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':host()'
+title: ":host()"
 slug: Web/CSS/:host_function
 translation_of: Web/CSS/:host()
 ---

--- a/files/fr/web/css/_colon_hover/index.md
+++ b/files/fr/web/css/_colon_hover/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':hover'
+title: ":hover"
 slug: Web/CSS/:hover
 translation_of: Web/CSS/:hover
 ---

--- a/files/fr/web/css/_colon_in-range/index.md
+++ b/files/fr/web/css/_colon_in-range/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':in-range'
+title: ":in-range"
 slug: Web/CSS/:in-range
 translation_of: Web/CSS/:in-range
 ---

--- a/files/fr/web/css/_colon_indeterminate/index.md
+++ b/files/fr/web/css/_colon_indeterminate/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':indeterminate'
+title: ":indeterminate"
 slug: Web/CSS/:indeterminate
 translation_of: Web/CSS/:indeterminate
 ---

--- a/files/fr/web/css/_colon_invalid/index.md
+++ b/files/fr/web/css/_colon_invalid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':invalid'
+title: ":invalid"
 slug: Web/CSS/:invalid
 translation_of: Web/CSS/:invalid
 ---

--- a/files/fr/web/css/_colon_is/index.md
+++ b/files/fr/web/css/_colon_is/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':is() (:matches(), :any())'
+title: ":is() (:matches(), :any())"
 slug: Web/CSS/:is
 translation_of: Web/CSS/:is
 ---

--- a/files/fr/web/css/_colon_lang/index.md
+++ b/files/fr/web/css/_colon_lang/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':lang'
+title: ":lang"
 slug: Web/CSS/:lang
 translation_of: Web/CSS/:lang
 ---

--- a/files/fr/web/css/_colon_last-child/index.md
+++ b/files/fr/web/css/_colon_last-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':last-child'
+title: ":last-child"
 slug: Web/CSS/:last-child
 translation_of: Web/CSS/:last-child
 ---

--- a/files/fr/web/css/_colon_last-of-type/index.md
+++ b/files/fr/web/css/_colon_last-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':last-of-type'
+title: ":last-of-type"
 slug: Web/CSS/:last-of-type
 translation_of: Web/CSS/:last-of-type
 ---

--- a/files/fr/web/css/_colon_left/index.md
+++ b/files/fr/web/css/_colon_left/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':left'
+title: ":left"
 slug: Web/CSS/:left
 translation_of: Web/CSS/:left
 ---

--- a/files/fr/web/css/_colon_link/index.md
+++ b/files/fr/web/css/_colon_link/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':link'
+title: ":link"
 slug: Web/CSS/:link
 translation_of: Web/CSS/:link
 ---

--- a/files/fr/web/css/_colon_local-link/index.md
+++ b/files/fr/web/css/_colon_local-link/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':local-link'
+title: ":local-link"
 slug: Web/CSS/:local-link
 translation_of: Web/CSS/:local-link
 ---

--- a/files/fr/web/css/_colon_modal/index.md
+++ b/files/fr/web/css/_colon_modal/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':modal'
+title: ":modal"
 slug: Web/CSS/:modal
 l10n:
   sourceCommit: 96f68b50c1eac0af56f185d82c17c9ccaf212b67

--- a/files/fr/web/css/_colon_not/index.md
+++ b/files/fr/web/css/_colon_not/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':not'
+title: ":not"
 slug: Web/CSS/:not
 translation_of: Web/CSS/:not
 ---

--- a/files/fr/web/css/_colon_nth-child/index.md
+++ b/files/fr/web/css/_colon_nth-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-child'
+title: ":nth-child"
 slug: Web/CSS/:nth-child
 translation_of: Web/CSS/:nth-child
 ---

--- a/files/fr/web/css/_colon_nth-col/index.md
+++ b/files/fr/web/css/_colon_nth-col/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-col'
+title: ":nth-col"
 slug: Web/CSS/:nth-col
 translation_of: Web/CSS/:nth-col
 ---

--- a/files/fr/web/css/_colon_nth-last-child/index.md
+++ b/files/fr/web/css/_colon_nth-last-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-last-child'
+title: ":nth-last-child"
 slug: Web/CSS/:nth-last-child
 translation_of: Web/CSS/:nth-last-child
 ---

--- a/files/fr/web/css/_colon_nth-last-col/index.md
+++ b/files/fr/web/css/_colon_nth-last-col/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-last-col'
+title: ":nth-last-col"
 slug: Web/CSS/:nth-last-col
 translation_of: Web/CSS/:nth-last-col
 ---

--- a/files/fr/web/css/_colon_nth-last-of-type/index.md
+++ b/files/fr/web/css/_colon_nth-last-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-last-of-type'
+title: ":nth-last-of-type"
 slug: Web/CSS/:nth-last-of-type
 translation_of: Web/CSS/:nth-last-of-type
 ---

--- a/files/fr/web/css/_colon_nth-of-type/index.md
+++ b/files/fr/web/css/_colon_nth-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-of-type'
+title: ":nth-of-type"
 slug: Web/CSS/:nth-of-type
 translation_of: Web/CSS/:nth-of-type
 ---

--- a/files/fr/web/css/_colon_only-child/index.md
+++ b/files/fr/web/css/_colon_only-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':only-child'
+title: ":only-child"
 slug: Web/CSS/:only-child
 translation_of: Web/CSS/:only-child
 ---

--- a/files/fr/web/css/_colon_only-of-type/index.md
+++ b/files/fr/web/css/_colon_only-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':only-of-type'
+title: ":only-of-type"
 slug: Web/CSS/:only-of-type
 translation_of: Web/CSS/:only-of-type
 ---

--- a/files/fr/web/css/_colon_optional/index.md
+++ b/files/fr/web/css/_colon_optional/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':optional'
+title: ":optional"
 slug: Web/CSS/:optional
 translation_of: Web/CSS/:optional
 ---

--- a/files/fr/web/css/_colon_out-of-range/index.md
+++ b/files/fr/web/css/_colon_out-of-range/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':out-of-range'
+title: ":out-of-range"
 slug: Web/CSS/:out-of-range
 translation_of: Web/CSS/:out-of-range
 ---

--- a/files/fr/web/css/_colon_past/index.md
+++ b/files/fr/web/css/_colon_past/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':past'
+title: ":past"
 slug: Web/CSS/:past
 translation_of: Web/CSS/:past
 ---

--- a/files/fr/web/css/_colon_paused/index.md
+++ b/files/fr/web/css/_colon_paused/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':paused'
+title: ":paused"
 slug: Web/CSS/:paused
 translation_of: Web/CSS/:paused
 ---

--- a/files/fr/web/css/_colon_picture-in-picture/index.md
+++ b/files/fr/web/css/_colon_picture-in-picture/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':picture-in-picture'
+title: ":picture-in-picture"
 slug: Web/CSS/:picture-in-picture
 translation_of: Web/CSS/:picture-in-picture
 l10n:

--- a/files/fr/web/css/_colon_placeholder-shown/index.md
+++ b/files/fr/web/css/_colon_placeholder-shown/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':placeholder-shown'
+title: ":placeholder-shown"
 slug: Web/CSS/:placeholder-shown
 translation_of: Web/CSS/:placeholder-shown
 ---

--- a/files/fr/web/css/_colon_playing/index.md
+++ b/files/fr/web/css/_colon_playing/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':playing'
+title: ":playing"
 slug: Web/CSS/:playing
 translation_of: Web/CSS/:playing
 ---

--- a/files/fr/web/css/_colon_read-only/index.md
+++ b/files/fr/web/css/_colon_read-only/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':read-only'
+title: ":read-only"
 slug: Web/CSS/:read-only
 translation_of: Web/CSS/:read-only
 ---

--- a/files/fr/web/css/_colon_read-write/index.md
+++ b/files/fr/web/css/_colon_read-write/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':read-write'
+title: ":read-write"
 slug: Web/CSS/:read-write
 translation_of: Web/CSS/:read-write
 ---

--- a/files/fr/web/css/_colon_required/index.md
+++ b/files/fr/web/css/_colon_required/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':required'
+title: ":required"
 slug: Web/CSS/:required
 translation_of: Web/CSS/:required
 ---

--- a/files/fr/web/css/_colon_right/index.md
+++ b/files/fr/web/css/_colon_right/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':right'
+title: ":right"
 slug: Web/CSS/:right
 translation_of: Web/CSS/:right
 ---

--- a/files/fr/web/css/_colon_root/index.md
+++ b/files/fr/web/css/_colon_root/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':root'
+title: ":root"
 slug: Web/CSS/:root
 translation_of: Web/CSS/:root
 ---

--- a/files/fr/web/css/_colon_scope/index.md
+++ b/files/fr/web/css/_colon_scope/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':scope'
+title: ":scope"
 slug: Web/CSS/:scope
 translation_of: Web/CSS/:scope
 ---

--- a/files/fr/web/css/_colon_target-within/index.md
+++ b/files/fr/web/css/_colon_target-within/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':target-within'
+title: ":target-within"
 slug: Web/CSS/:target-within
 translation_of: Web/CSS/:target-within
 ---

--- a/files/fr/web/css/_colon_target/index.md
+++ b/files/fr/web/css/_colon_target/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':target'
+title: ":target"
 slug: Web/CSS/:target
 translation_of: Web/CSS/:target
 ---

--- a/files/fr/web/css/_colon_user-invalid/index.md
+++ b/files/fr/web/css/_colon_user-invalid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-ui-invalid'
+title: ":-moz-ui-invalid"
 slug: Web/CSS/:user-invalid
 translation_of: Web/CSS/:user-invalid
 ---

--- a/files/fr/web/css/_colon_user-valid/index.md
+++ b/files/fr/web/css/_colon_user-valid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':user-valid (:-moz-ui-valid)'
+title: ":user-valid (:-moz-ui-valid)"
 slug: Web/CSS/:user-valid
 translation_of: Web/CSS/:user-valid
 l10n:

--- a/files/fr/web/css/_colon_valid/index.md
+++ b/files/fr/web/css/_colon_valid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':valid'
+title: ":valid"
 slug: Web/CSS/:valid
 translation_of: Web/CSS/:valid
 ---

--- a/files/fr/web/css/_colon_visited/index.md
+++ b/files/fr/web/css/_colon_visited/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':visited'
+title: ":visited"
 slug: Web/CSS/:visited
 translation_of: Web/CSS/:visited
 ---

--- a/files/fr/web/css/_colon_where/index.md
+++ b/files/fr/web/css/_colon_where/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':where()'
+title: ":where()"
 slug: Web/CSS/:where
 translation_of: Web/CSS/:where
 ---

--- a/files/fr/web/css/_doublecolon_-moz-color-swatch/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-color-swatch/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-moz-color-swatch'
+title: "::-moz-color-swatch"
 slug: Web/CSS/::-moz-color-swatch
 translation_of: Web/CSS/::-moz-color-swatch
 ---

--- a/files/fr/web/css/_doublecolon_-moz-focus-inner/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-focus-inner/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-moz-focus-inner'
+title: "::-moz-focus-inner"
 slug: Web/CSS/::-moz-focus-inner
 translation_of: Web/CSS/::-moz-focus-inner
 l10n:

--- a/files/fr/web/css/_doublecolon_-moz-list-bullet/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-list-bullet/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-moz-list-bullet'
+title: "::-moz-list-bullet"
 slug: Web/CSS/::-moz-list-bullet
 translation_of: Web/CSS/:-moz-list-bullet
 ---

--- a/files/fr/web/css/_doublecolon_-moz-list-number/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-list-number/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-moz-list-number'
+title: "::-moz-list-number"
 slug: Web/CSS/::-moz-list-number
 translation_of: Web/CSS/:-moz-list-number
 ---

--- a/files/fr/web/css/_doublecolon_-moz-page-sequence/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-page-sequence/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-moz-page-sequence'
+title: "::-moz-page-sequence"
 slug: Web/CSS/::-moz-page-sequence
 translation_of: Web/CSS/::-moz-page-sequence
 ---

--- a/files/fr/web/css/_doublecolon_-moz-page/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-page/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-moz-page'
+title: "::-moz-page"
 slug: Web/CSS/::-moz-page
 translation_of: Web/CSS/::-moz-page
 ---

--- a/files/fr/web/css/_doublecolon_-moz-progress-bar/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-progress-bar/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-moz-progress-bar'
+title: "::-moz-progress-bar"
 slug: Web/CSS/::-moz-progress-bar
 translation_of: Web/CSS/::-moz-progress-bar
 ---

--- a/files/fr/web/css/_doublecolon_-moz-range-progress/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-range-progress/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-moz-range-progress'
+title: "::-moz-range-progress"
 slug: Web/CSS/::-moz-range-progress
 translation_of: Web/CSS/::-moz-range-progress
 ---

--- a/files/fr/web/css/_doublecolon_-moz-range-thumb/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-range-thumb/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-moz-range-thumb'
+title: "::-moz-range-thumb"
 slug: Web/CSS/::-moz-range-thumb
 translation_of: Web/CSS/::-moz-range-thumb
 ---

--- a/files/fr/web/css/_doublecolon_-moz-range-track/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-range-track/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-moz-range-track'
+title: "::-moz-range-track"
 slug: Web/CSS/::-moz-range-track
 translation_of: Web/CSS/::-moz-range-track
 ---

--- a/files/fr/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-moz-scrolled-page-sequence'
+title: "::-moz-scrolled-page-sequence"
 slug: Web/CSS/::-moz-scrolled-page-sequence
 translation_of: Web/CSS/::-moz-scrolled-page-sequence
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-inner-spin-button/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-inner-spin-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-inner-spin-button'
+title: "::-webkit-inner-spin-button"
 slug: Web/CSS/::-webkit-inner-spin-button
 translation_of: Web/CSS/::-webkit-inner-spin-button
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-meter-bar/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-bar/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-meter-bar'
+title: "::-webkit-meter-bar"
 slug: Web/CSS/::-webkit-meter-bar
 translation_of: Web/CSS/::-webkit-meter-bar
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-meter-even-less-good-value'
+title: "::-webkit-meter-even-less-good-value"
 slug: Web/CSS/::-webkit-meter-even-less-good-value
 translation_of: Web/CSS/::-webkit-meter-even-less-good-value
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-inner-element/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-meter-inner-element'
+title: "::-webkit-meter-inner-element"
 slug: Web/CSS/::-webkit-meter-inner-element
 translation_of: Web/CSS/::-webkit-meter-inner-element
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-meter-optimum-value'
+title: "::-webkit-meter-optimum-value"
 slug: Web/CSS/::-webkit-meter-optimum-value
 translation_of: Web/CSS/::-webkit-meter-optimum-value
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-meter-suboptimum-value'
+title: "::-webkit-meter-suboptimum-value"
 slug: Web/CSS/::-webkit-meter-suboptimum-value
 translation_of: Web/CSS/::-webkit-meter-suboptimum-value
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-outer-spin-button/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-outer-spin-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-outer-spin-button'
+title: "::-webkit-outer-spin-button"
 slug: Web/CSS/::-webkit-outer-spin-button
 translation_of: Web/CSS/::-webkit-outer-spin-button
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-progress-bar/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-progress-bar'
+title: "::-webkit-progress-bar"
 slug: Web/CSS/::-webkit-progress-bar
 translation_of: Web/CSS/::-webkit-progress-bar
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-progress-inner-element/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-progress-inner-element'
+title: "::-webkit-progress-inner-element"
 slug: Web/CSS/::-webkit-progress-inner-element
 translation_of: Web/CSS/::-webkit-progress-inner-element
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-progress-value/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-progress-value/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-progress-value'
+title: "::-webkit-progress-value"
 slug: Web/CSS/::-webkit-progress-value
 translation_of: Web/CSS/::-webkit-progress-value
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-scrollbar'
+title: "::-webkit-scrollbar"
 slug: Web/CSS/::-webkit-scrollbar
 translation_of: Web/CSS/::-webkit-scrollbar
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-search-cancel-button/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-search-cancel-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-search-cancel-button'
+title: "::-webkit-search-cancel-button"
 slug: Web/CSS/::-webkit-search-cancel-button
 translation_of: Web/CSS/::-webkit-search-cancel-button
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-search-results-button/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-search-results-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-search-results-button'
+title: "::-webkit-search-results-button"
 slug: Web/CSS/::-webkit-search-results-button
 translation_of: Web/CSS/::-webkit-search-results-button
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-slider-runnable-track'
+title: "::-webkit-slider-runnable-track"
 slug: Web/CSS/::-webkit-slider-runnable-track
 translation_of: Web/CSS/::-webkit-slider-runnable-track
 ---

--- a/files/fr/web/css/_doublecolon_-webkit-slider-thumb/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-slider-thumb/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-slider-thumb'
+title: "::-webkit-slider-thumb"
 slug: Web/CSS/::-webkit-slider-thumb
 translation_of: Web/CSS/::-webkit-slider-thumb
 ---

--- a/files/fr/web/css/_doublecolon_after/index.md
+++ b/files/fr/web/css/_doublecolon_after/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::after (:after)'
+title: "::after (:after)"
 slug: Web/CSS/::after
 translation_of: Web/CSS/::after
 ---

--- a/files/fr/web/css/_doublecolon_backdrop/index.md
+++ b/files/fr/web/css/_doublecolon_backdrop/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::backdrop'
+title: "::backdrop"
 slug: Web/CSS/::backdrop
 translation_of: Web/CSS/::backdrop
 ---

--- a/files/fr/web/css/_doublecolon_before/index.md
+++ b/files/fr/web/css/_doublecolon_before/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::before (:before)'
+title: "::before (:before)"
 slug: Web/CSS/::before
 translation_of: Web/CSS/::before
 ---

--- a/files/fr/web/css/_doublecolon_cue-region/index.md
+++ b/files/fr/web/css/_doublecolon_cue-region/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::cue-region'
+title: "::cue-region"
 slug: Web/CSS/::cue-region
 translation_of: Web/CSS/::cue-region
 ---

--- a/files/fr/web/css/_doublecolon_cue/index.md
+++ b/files/fr/web/css/_doublecolon_cue/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::cue'
+title: "::cue"
 slug: Web/CSS/::cue
 translation_of: Web/CSS/::cue
 ---

--- a/files/fr/web/css/_doublecolon_file-selector-button/index.md
+++ b/files/fr/web/css/_doublecolon_file-selector-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-file-upload-button'
+title: "::-webkit-file-upload-button"
 slug: Web/CSS/::file-selector-button
 translation_of: Web/CSS/::file-selector-button
 ---

--- a/files/fr/web/css/_doublecolon_first-letter/index.md
+++ b/files/fr/web/css/_doublecolon_first-letter/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::first-letter'
+title: "::first-letter"
 slug: Web/CSS/::first-letter
 translation_of: Web/CSS/::first-letter
 ---

--- a/files/fr/web/css/_doublecolon_first-line/index.md
+++ b/files/fr/web/css/_doublecolon_first-line/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::first-line (:first-line)'
+title: "::first-line (:first-line)"
 slug: Web/CSS/::first-line
 translation_of: Web/CSS/::first-line
 ---

--- a/files/fr/web/css/_doublecolon_grammar-error/index.md
+++ b/files/fr/web/css/_doublecolon_grammar-error/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::grammar-error'
+title: "::grammar-error"
 slug: Web/CSS/::grammar-error
 translation_of: Web/CSS/::grammar-error
 ---

--- a/files/fr/web/css/_doublecolon_marker/index.md
+++ b/files/fr/web/css/_doublecolon_marker/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::marker'
+title: "::marker"
 slug: Web/CSS/::marker
 translation_of: Web/CSS/::marker
 ---

--- a/files/fr/web/css/_doublecolon_part/index.md
+++ b/files/fr/web/css/_doublecolon_part/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::part()'
+title: "::part()"
 slug: Web/CSS/::part
 translation_of: Web/CSS/::part
 ---

--- a/files/fr/web/css/_doublecolon_placeholder/index.md
+++ b/files/fr/web/css/_doublecolon_placeholder/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::placeholder'
+title: "::placeholder"
 slug: Web/CSS/::placeholder
 translation_of: Web/CSS/::placeholder
 ---

--- a/files/fr/web/css/_doublecolon_selection/index.md
+++ b/files/fr/web/css/_doublecolon_selection/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::selection'
+title: "::selection"
 slug: Web/CSS/::selection
 translation_of: Web/CSS/::selection
 ---

--- a/files/fr/web/css/_doublecolon_slotted/index.md
+++ b/files/fr/web/css/_doublecolon_slotted/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::slotted()'
+title: "::slotted()"
 slug: Web/CSS/::slotted
 translation_of: Web/CSS/::slotted
 ---

--- a/files/fr/web/css/_doublecolon_spelling-error/index.md
+++ b/files/fr/web/css/_doublecolon_spelling-error/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::spelling-error'
+title: "::spelling-error"
 slug: Web/CSS/::spelling-error
 translation_of: Web/CSS/::spelling-error
 ---

--- a/files/fr/web/css/_doublecolon_target-text/index.md
+++ b/files/fr/web/css/_doublecolon_target-text/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::target-text'
+title: "::target-text"
 slug: Web/CSS/::target-text
 translation_of: Web/CSS/::target-text
 ---


### PR DESCRIPTION
This PR formats the `/web/css` folder of the French locale using Prettier.  This is the first part, which focuses solely on formatting the frontmatter.
