### PR TITLE
fr: Format /web/css using Prettier (part 2)

### DIFF
--- a/files/fr/web/css/--_star_/index.md
+++ b/files/fr/web/css/--_star_/index.md
@@ -32,8 +32,12 @@ La portée des propriétés personnalisées est celle des éléments sur lesquel
 ### HTML
 
 ```html
-<p id="premierParagraphe">Ce paragraphe devrait être sur fond bleu avec un texte jaune.</p>
-<p id="secondParagraphe">Ce paragraphe devrait être sur fond jaune avec un texte bleu.</p>
+<p id="premierParagraphe">
+  Ce paragraphe devrait être sur fond bleu avec un texte jaune.
+</p>
+<p id="secondParagraphe">
+  Ce paragraphe devrait être sur fond jaune avec un texte bleu.
+</p>
 ```
 
 ### CSS

--- a/files/fr/web/css/-moz-float-edge/index.md
+++ b/files/fr/web/css/-moz-float-edge/index.md
@@ -60,10 +60,7 @@ La propriété **`-moz-float-edge`** définit si les propriétés de hauteur et 
 
 ```html
 <div class="box">
-   <p>
-      Lorem ipsum dolor sit amet,
-      consectetur adipiscing elit.
-   </p>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 </div>
 ```
 

--- a/files/fr/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/fr/web/css/-moz-force-broken-image-icon/index.md
@@ -37,7 +37,7 @@ img {
 ### HTML
 
 ```html
-<img src='/lien/vers/image/cassée.png' alt='Un lien vers une image cassée'>
+<img src="/lien/vers/image/cassée.png" alt="Un lien vers une image cassée" />
 ```
 
 ### Résultat

--- a/files/fr/web/css/-moz-image-rect/index.md
+++ b/files/fr/web/css/-moz-image-rect/index.md
@@ -16,7 +16,7 @@ La propriété **`-moz-image-rect`** permet d'utiliser une seule partie d'une im
 
 ### Valeurs
 
-- [`url()`](/fr/docs/Web/CSS/url())
+- [`url()`](</fr/docs/Web/CSS/url()>)
   - : L'URI de l'image dont on veut obtenir une portion.
 - `top`
   - : La coordonnée du bord haut de l'image, définie comme un entier ([`<integer>`](/fr/docs/Web/CSS/integer)) ou un pourcentage ([`<percentage>`](/fr/docs/Web/CSS/percentage)) à partir du coin supérieur gauche.
@@ -95,15 +95,19 @@ Dans cet exemple, on charge une image qu'on découpe en quatre zones pour dessin
 
 ```js
 function rotate() {
-  var prevStyle = window.getComputedStyle(document.getElementById("box4"), null).getPropertyValue("background-image");
+  var prevStyle = window
+    .getComputedStyle(document.getElementById("box4"), null)
+    .getPropertyValue("background-image");
 
   // Récupérer le style du dernier élément, puis faire tourner les images
 
-  for (var i=1; i<=4; i++) {
+  for (var i = 1; i <= 4; i++) {
     var curId = "box" + i;
 
     // Décaler les images d'arrière-plan
-    var curStyle = window.getComputedStyle(document.getElementById(curId), null).getPropertyValue("background-image");
+    var curStyle = window
+      .getComputedStyle(document.getElementById(curId), null)
+      .getPropertyValue("background-image");
     document.getElementById(curId).style.backgroundImage = prevStyle;
     prevStyle = curStyle;
   }

--- a/files/fr/web/css/-moz-orient/index.md
+++ b/files/fr/web/css/-moz-orient/index.md
@@ -33,15 +33,12 @@ La propriété `moz-orient` est définie avec un mot-clé parmi ceux de la liste
 
 ```html
 <p>
-  La barre de progression suivante est
-  horizontale (le comportement par défaut) :
+  La barre de progression suivante est horizontale (le comportement par défaut)
+  :
 </p>
 <progress max="100" value="75"></progress>
 
-<p>
-  La barre de progression suivante
-  est verticale :
-</p>
+<p>La barre de progression suivante est verticale :</p>
 <progress class="vert" max="100" value="75"></progress>
 ```
 

--- a/files/fr/web/css/-moz-user-focus/index.md
+++ b/files/fr/web/css/-moz-user-focus/index.md
@@ -41,7 +41,9 @@ En utilisant la valeur `ignore`, on peut désactiver la prise de focus sur l'él
 ### HTML
 
 ```html
-<input class="ignored" value="L'utilisateur ne peut pas placer le focus sur cet élément.">
+<input
+  class="ignored"
+  value="L'utilisateur ne peut pas placer le focus sur cet élément." />
 ```
 
 ### CSS

--- a/files/fr/web/css/-webkit-line-clamp/index.md
+++ b/files/fr/web/css/-webkit-line-clamp/index.md
@@ -52,8 +52,9 @@ Lorsqu'on applique ce style à une ancre, la troncature pourra intervenir au mil
 
 ```html
 <p>
-  Dans cet exemple <code>-webkit-line-clamp</code> vaut <code>3</code>, ce qui signifie que le texte sera rogné après trois lignes.
-  Une ellipse sera affichée au n ellipsis will be shown at the point where the text is clamped.
+  Dans cet exemple <code>-webkit-line-clamp</code> vaut <code>3</code>, ce qui
+  signifie que le texte sera rogné après trois lignes. Une ellipse sera affichée
+  au n ellipsis will be shown at the point where the text is clamped.
 </p>
 ```
 

--- a/files/fr/web/css/-webkit-mask-attachment/index.md
+++ b/files/fr/web/css/-webkit-mask-attachment/index.md
@@ -41,7 +41,7 @@ Si la propriété {{cssxref("-webkit-mask-image")}} est définie, **`-webkit-mas
 
 ```css
 body {
-  -webkit-mask-image: url('images/mask.png');
+  -webkit-mask-image: url("images/mask.png");
   -webkit-mask-attachment: fixed;
 }
 ```

--- a/files/fr/web/css/-webkit-mask-box-image/index.md
+++ b/files/fr/web/css/-webkit-mask-box-image/index.md
@@ -55,11 +55,11 @@ Où :
 
 ```css
 .exempleUn {
-  -webkit-mask-box-image: url('mask.png');
+  -webkit-mask-box-image: url("mask.png");
 }
 
 .exempleDeux {
-  -webkit-mask-box-image: url('logo.png') 100 100 0 0 round round;
+  -webkit-mask-box-image: url("logo.png") 100 100 0 0 round round;
 }
 ```
 

--- a/files/fr/web/css/-webkit-mask-composite/index.md
+++ b/files/fr/web/css/-webkit-mask-composite/index.md
@@ -65,7 +65,7 @@ La propriété **`-webkit-mask-composite`** définit la façon dont plusieurs im
 
 ```css
 .exemple {
-  -webkit-mask-image: url(mask1.png), url('mask2.png');
+  -webkit-mask-image: url(mask1.png), url("mask2.png");
   -webkit-mask-composite: xor, source-over;
 }
 ```

--- a/files/fr/web/css/-webkit-mask-position-x/index.md
+++ b/files/fr/web/css/-webkit-mask-position-x/index.md
@@ -25,7 +25,10 @@ La propriété **`-webkit-mask-position-x`** permet de définir la position hori
 -webkit-mask-position-x: -1cm;
 
 /* Gestion de plusieurs valeurs */
--webkit-mask-position-x: 50px, 25%, -3em;
+-webkit-mask-position-x:
+  50px,
+  25%,
+  -3em;
 
 /* Valeurs globales */
 -webkit-mask-position-x: inherit;

--- a/files/fr/web/css/-webkit-mask-position-y/index.md
+++ b/files/fr/web/css/-webkit-mask-position-y/index.md
@@ -25,7 +25,10 @@ La propriété **`-webkit-mask-position-y`** permet de définir la position vert
 -webkit-mask-position-y: -1cm;
 
 /* Gestion de plusieurs valeurs */
--webkit-mask-position-y: 50px, 25%, -3em;
+-webkit-mask-position-y:
+  50px,
+  25%,
+  -3em;
 
 /* Valeurs globales */
 -webkit-mask-position-y: inherit;

--- a/files/fr/web/css/-webkit-mask-repeat-x/index.md
+++ b/files/fr/web/css/-webkit-mask-repeat-x/index.md
@@ -45,12 +45,12 @@ La propriété **`-webkit-mask-repeat-x`** définit la façon dont une image de 
 
 ```css
 .exempleun {
-  -webkit-mask-image: url('mask.png');
+  -webkit-mask-image: url("mask.png");
   -webkit-mask-repeat-x: repeat;
 }
 
 .exempledeux {
-  -webkit-mask-image: url('mask.png');
+  -webkit-mask-image: url("mask.png");
   -webkit-mask-repeat-x: no-repeat;
 }
 ```
@@ -61,7 +61,7 @@ On peut définir un style de répétition (`<repeat-style>`) différent pour cha
 
 ```css
 .exempletrois {
-  -webkit-mask-image: url('mask1.png'), url('mask2.png');
+  -webkit-mask-image: url("mask1.png"), url("mask2.png");
   -webkit-mask-repeat-x: repeat, space;
 }
 ```

--- a/files/fr/web/css/-webkit-mask-repeat-y/index.md
+++ b/files/fr/web/css/-webkit-mask-repeat-y/index.md
@@ -45,12 +45,12 @@ La propriété **`-webkit-mask-repeat-y`** définit la façon dont une image de 
 
 ```css
 .exempleun {
-  -webkit-mask-image: url('mask.png');
+  -webkit-mask-image: url("mask.png");
   -webkit-mask-repeat-y: repeat;
 }
 
 .exempledeux {
-  -webkit-mask-image: url('mask.png');
+  -webkit-mask-image: url("mask.png");
   -webkit-mask-repeat-y: no-repeat;
 }
 ```
@@ -61,7 +61,7 @@ On peut définir un style de répétition (`<repeat-style>`) différent pour cha
 
 ```css
 .exempletrois {
-  -webkit-mask-image: url('mask1.png'), url('mask2.png');
+  -webkit-mask-image: url("mask1.png"), url("mask2.png");
   -webkit-mask-repeat-y: repeat, space;
 }
 ```

--- a/files/fr/web/css/-webkit-overflow-scrolling/index.md
+++ b/files/fr/web/css/-webkit-overflow-scrolling/index.md
@@ -49,14 +49,10 @@ p {
 
 ```html
 <div class="scroll-touch">
-  <p>
-    Ce paragraphe a un défilement inertiel.
-  </p>
+  <p>Ce paragraphe a un défilement inertiel.</p>
 </div>
 <div class="scroll-auto">
-  <p>
-     Pas celui-ci.
-  </p>
+  <p>Pas celui-ci.</p>
 </div>
 ```
 

--- a/files/fr/web/css/-webkit-text-security/index.md
+++ b/files/fr/web/css/-webkit-text-security/index.md
@@ -24,8 +24,7 @@ En utilisant un navigateur qui prend en charge cette propriété et en saisissan
 ### HTML
 
 ```html
-<label for="name">Nom :</label>
-<input type="text" name="name" id="name" />
+<label for="name">Nom :</label> <input type="text" name="name" id="name" />
 ```
 
 ### CSS

--- a/files/fr/web/css/-webkit-text-stroke-color/index.md
+++ b/files/fr/web/css/-webkit-text-stroke-color/index.md
@@ -40,7 +40,7 @@ La propriété **`-webkit-text-stroke-color`** permet de définir la couleur de 
 
 ```html
 <p>Texte avec un contour</p>
-<input type="color" value="#ff0000">
+<input type="color" value="#ff0000" />
 ```
 
 ### CSS
@@ -57,7 +57,7 @@ p {
 
 ```js hidden
 var colorPicker = document.querySelector("input");
-colorPicker.addEventListener("change", function(evt) {
+colorPicker.addEventListener("change", function (evt) {
   document.querySelector("p").style.webkitTextStrokeColor = evt.target.value;
 });
 ```

--- a/files/fr/web/css/@charset/index.md
+++ b/files/fr/web/css/@charset/index.md
@@ -31,7 +31,7 @@ Le moteur dispose de différentes méthodes pour déterminer l'encodage d'une fe
 où
 
 - `charset`
-  - : Est une chaîne de caractères (une valeur CSS de type {{cssxref("&lt;string&gt;")}}) indiquant l'encodage qui doit être utilisé. Cette valeur doit correspondre à un nom d'encodage valide pour le Web tel que défini dans [le registre IANA](https://www.iana.org/assignments/character-sets/character-sets.xhtml) et doit être délimitée par des doubles quotes, précédée d'un blanc (U+0020) et suivie d'un point-virgule. Si plusieurs noms sont associés avec l'encodage, seul celui marqué avec *préféré* (_preferred_) doit être utilisé.
+  - : Est une chaîne de caractères (une valeur CSS de type {{cssxref("&lt;string&gt;")}}) indiquant l'encodage qui doit être utilisé. Cette valeur doit correspondre à un nom d'encodage valide pour le Web tel que défini dans [le registre IANA](https://www.iana.org/assignments/character-sets/character-sets.xhtml) et doit être délimitée par des doubles quotes, précédée d'un blanc (U+0020) et suivie d'un point-virgule. Si plusieurs noms sont associés avec l'encodage, seul celui marqué avec _préféré_ (_preferred_) doit être utilisé.
 
 ### Syntaxe formelle
 
@@ -42,15 +42,15 @@ où
 ### Exemples valides
 
 ```css
-@charset "UTF-8";      /* Valide, la feuille de style est encodée en Unicode UTF-8 */
+@charset "UTF-8"; /* Valide, la feuille de style est encodée en Unicode UTF-8 */
 @charset "iso-8859-15"; /* Valide, la feuille de style est encodée en Latin-9 (langues d'Europe occidentale avec le symbole €) */
 ```
 
 ### Exemples invalides
 
-```css example-bad
- @charset "UTF-8";      /* Invalide, il y a un caractère (un espace) avant la règle @ */
-@charset UTF-8;         /* Invalide, sans ' ou ", le jeu de caractères n'est pas une chaîne CSS ({{cssxref("&lt;string&gt;")}}) */
+```css-nolint example-bad
+ @charset "UTF-8"; /* Invalide, il y a un caractère (un espace) avant la règle @ */
+@charset UTF-8; /* Invalide, sans ' ou ", le jeu de caractères n'est pas une chaîne CSS ({{cssxref("&lt;string&gt;")}}) */
 ```
 
 ## Spécifications

--- a/files/fr/web/css/@color-profile/index.md
+++ b/files/fr/web/css/@color-profile/index.md
@@ -12,7 +12,7 @@ La [règle @](/fr/docs/Web/CSS/At-rule) [CSS](/fr/docs/Web/CSS) **`@color-profil
 
 ```css
 @color-profile --swop5c {
-  src: url('https://example.org/SWOP2006_Coated5v2.icc');
+  src: url("https://example.org/SWOP2006_Coated5v2.icc");
 }
 ```
 
@@ -39,7 +39,7 @@ La [règle @](/fr/docs/Web/CSS/At-rule) [CSS](/fr/docs/Web/CSS) **`@color-profil
 
 ```css
 @color-profile --swop5c {
-  src: url('https://example.org/SWOP2006_Coated5v2.icc');
+  src: url("https://example.org/SWOP2006_Coated5v2.icc");
 }
 
 .header {

--- a/files/fr/web/css/@counter-style/additive-symbols/index.md
+++ b/files/fr/web/css/@counter-style/additive-symbols/index.md
@@ -10,8 +10,12 @@ Le descripteur **`additive-symbols`**, utilisé pour la règle @ {{cssxref("@cou
 
 ```css
 additive-symbols: 3 "0";
-additive-symbols: 3 "0", 2 "\2E\20";
-additive-symbols: 3 "0", 2 url(symbol.png);
+additive-symbols:
+  3 "0",
+  2 "\2E\20";
+additive-symbols:
+  3 "0",
+  2 url(symbol.png);
 ```
 
 Lorsque la valeur du descripteur `system` est `cyclic`, `numeric`, `alphabetic`, `symbolic` ou `fixed`, c'est le descripteur `symbols` qui est utilisé à la place de `additive-symbols` afin de définir les symboles utilisés pour le compteur.
@@ -31,7 +35,10 @@ Lorsque la valeur du descripteur `system` est `cyclic`, `numeric`, `alphabetic`,
 ```css
 @counter-style additive-symbols-example {
   system: additive;
-  additive-symbols: V 5, IV 4, I 1;
+  additive-symbols:
+    V 5,
+    IV 4,
+    I 1;
 }
 .exemple {
   list-style: additive-symbols-example;

--- a/files/fr/web/css/@counter-style/fallback/index.md
+++ b/files/fr/web/css/@counter-style/fallback/index.md
@@ -33,7 +33,8 @@ fallback: custom-gangnam-style;
 
 ```css
 @counter-style fallback-example {
-  system: fixed; symbols: "\24B6" "\24B7" "\24B8";
+  system: fixed;
+  symbols: "\24B6" "\24B7" "\24B8";
   fallback: upper-alpha;
 }
 .exemple {

--- a/files/fr/web/css/@counter-style/index.md
+++ b/files/fr/web/css/@counter-style/index.md
@@ -29,24 +29,31 @@ La version initiale de CSS définit un ensemble de compteurs qui peuvent être u
 Chaque `@counter-style` est identifié par un nom et possède un ensemble de descripteurs.
 
 - [`system`](/fr/docs/Web/CSS/@counter-style/system)
+
   - : Ce descripteur indique l'algorithme à utiliser pour convertir les valeurs entières du compteur en des chaînes de caractères correspondantes.
 
 - [`negative`](/fr/docs/Web/CSS/@counter-style/negative)
+
   - : Ce descripteur permet d'indiquer si le symbole du compteur doit être préfixé ou suffixé si la valeur est négative.
 
 - [`prefix`](/fr/docs/Web/CSS/@counter-style/prefix)
+
   - : Ce descripteur indique un symbole qui doit être utilisé comme préfixe pour le compteur. Les préfixes sont ajoutés à la fin de la représentation et apparaissent avant le signe négatif.
 
 - [`suffix`](/fr/docs/Web/CSS/@counter-style/suffix)
+
   - : Ce descripteur indique un symbole qui doit être utilisé comme suffixe pour le compteur. Comme pour les préfixes, les suffixes sont ajoutés à la fin de la représentation.
 
 - [`range`](/fr/docs/Web/CSS/@counter-style/range)
+
   - : Ce descripteur indique l'intervalle de valeur pour lequel le style du compteur peut s'appliquer. Pour les valeurs du compteur en dehors de cet intervalle, le style utilisé sera le style de secours.
 
 - [`pad`](/fr/docs/Web/CSS/@counter-style/pad)
+
   - : Ce descripteur est utilisé lorsqu'il faut que la représentation du marqueur ait une longueur minimale. Ainsi, s'il faut que le compteur mesure deux caractères (ex. 01, 02, 03, 04 etc), on utilisera ce descripteur. Pour les valeurs dont la taille est plus grande que celle indiquée dans ce descripteur, le marqueur est construit normalement.
 
 - [`fallback`](/fr/docs/Web/CSS/@counter-style/fallback)
+
   - : Ce descripteur définit le système en cas de secours (si le système définit via la règle @ ne permet pas de construire le marqueur ou si la valeur du compteur est en dehors de l'intervalle défini). Si le système indiqué en secours échoue également, ce sera alors le système de secours de secours qui sera utilisé et ainsi de suite si nécessaire. Si besoin, le style décimal sera utilisé en fin de chaîne.
 
 - [`symbols`](/fr/docs/Web/CSS/@counter-style/symbols)
@@ -64,6 +71,7 @@ Chaque `@counter-style` est identifié par un nom et possède un ensemble de des
     ```
 
 - [`additive-symbols`](/fr/docs/Web/CSS/@counter-style/additive-symbols)
+
   - : Certains symboles définis via le descripteur `symbols` sont utilisés par la plupart des algorithmes. Certains systèmes dits «&nbsp;additifs&nbsp;» s'appuient sur des _tuples additifs_ décrit avec ce descripteur. Chaque tuple additif se compose d'un symbole de compteur et d'un poids entier positif. Les tuples additifs doivent être définis dans l'ordre décroissant de leurs poids.
 
 - [`speak-as`](/fr/docs/Web/CSS/@counter-style/speak-as)
@@ -98,7 +106,7 @@ Chaque `@counter-style` est identifié par un nom et possède un ensemble de des
 }
 
 .exemple {
-   list-style: circled-alpha;
+  list-style: circled-alpha;
 }
 ```
 
@@ -119,6 +127,6 @@ Chaque `@counter-style` est identifié par un nom et possède un ensemble de des
 ## Voir aussi
 
 - [`list-style`](/fr/docs/Web/CSS/list-style), [`list-style-image`](/fr/docs/Web/CSS/list-style-image), [`list-style-position`](/fr/docs/Web/CSS/list-style-position), [`list-style-type`](/fr/docs/Web/CSS/list-style-type)
-- [`symbols()`](/fr/docs/Web/CSS/symbols())&nbsp;: la notation fonctionnelle qui permet de créer des styles de compteur anonymes
-- Les fonctions CSS [`counter()`](/fr/docs/Web/CSS/counter()) et [`counters()`](/fr/docs/Web/CSS/counters())
+- [`symbols()`](</fr/docs/Web/CSS/symbols()>)&nbsp;: la notation fonctionnelle qui permet de créer des styles de compteur anonymes
+- Les fonctions CSS [`counter()`](</fr/docs/Web/CSS/counter()>) et [`counters()`](</fr/docs/Web/CSS/counters()>)
 - [Démonstration pour les styles de compteur](https://mdn.github.io/css-examples/counter-style-demo/) ([code](https://github.com/mdn/css-examples/tree/master/counter-style-demo))

--- a/files/fr/web/css/@counter-style/negative/index.md
+++ b/files/fr/web/css/@counter-style/negative/index.md
@@ -10,8 +10,8 @@ Le descripteur **`negative`**, associé à la règle @ {{cssxref("@counter-style
 
 ```css
 /* Valeurs représentant les symboles */
-negative: "-";       /* Préfixe '-' si la valeur est négative */
-negative: "(" ")";   /* Entoure la valeur avec '(' et ')' si elle est négative */
+negative: "-"; /* Préfixe '-' si la valeur est négative */
+negative: "(" ")"; /* Entoure la valeur avec '(' et ')' si elle est négative */
 ```
 
 Si la valeur du compteur est négative, le symbole fourni par le descripteur sera utilisé comme préfixe à la représentation du compteur. Un deuxième symbole peut être indiqué et est alors utilisé comme suffixe. Le descripteur `negative` n'a d'effet que si la valeur du descripteur `system` est `symbolic`, `alphabetic`, `numeric`, `additive` ou `extends` et si le compteur personnalisé utilise des indices négatifs. Dans les autres cas, si le descripteur `negative` est fourni, il est ignoré.

--- a/files/fr/web/css/@counter-style/prefix/index.md
+++ b/files/fr/web/css/@counter-style/prefix/index.md
@@ -37,7 +37,7 @@ prefix: "Page";
 @counter-style chapitres {
   system: numeric;
   symbols: "0" "1" "2" "3" "4" "5" "6" "7" "8" "9";
-  prefix: 'Chapitre ';
+  prefix: "Chapitre ";
 }
 
 .exemple {

--- a/files/fr/web/css/@counter-style/range/index.md
+++ b/files/fr/web/css/@counter-style/range/index.md
@@ -32,8 +32,12 @@ range: 6 infinite;
 range: infinite infinite;
 
 /* Valeurs indiquant plusieurs intervalles */
-range: 2 5, 8 10;
-range: infinite 6, 10 infinite;
+range:
+  2 5,
+  8 10;
+range:
+  infinite 6,
+  10 infinite;
 ```
 
 ### Values
@@ -55,7 +59,9 @@ range: infinite 6, 10 infinite;
 @counter-style range-multi-example {
   system: cyclic;
   symbols: "\25A0" "\25A1";
-  range: 2 4, 7 9;
+  range:
+    2 4,
+    7 9;
 }
 
 .exemple {

--- a/files/fr/web/css/@counter-style/speak-as/index.md
+++ b/files/fr/web/css/@counter-style/speak-as/index.md
@@ -66,7 +66,6 @@ speak-as: <counter-style-name>;
   speak-as: numbers;
 }
 
-
 .exemple {
   list-style: speak-as-exemple;
 }

--- a/files/fr/web/css/@counter-style/symbols/index.md
+++ b/files/fr/web/css/@counter-style/symbols/index.md
@@ -12,7 +12,7 @@ Le descripteur **`symbols`**, rattaché à la règle @ {{cssxref("@counter-style
 symbols: A B C D E;
 symbols: "\24B6" "\24B7" "\24B8" D E;
 symbols: "0" "1" "2" "4" "5" "6" "7" "8" "9";
-symbols: url('premier.svg') url('deuxieme.svg') url('troisieme.svg');
+symbols: url("premier.svg") url("deuxieme.svg") url("troisieme.svg");
 symbols: indic-numbers;
 ```
 

--- a/files/fr/web/css/@counter-style/system/index.md
+++ b/files/fr/web/css/@counter-style/system/index.md
@@ -72,7 +72,7 @@ Ce descripteur peut prendre l'une de ces trois formes :
 }
 
 .list {
-    list-style: fisheye;
+  list-style: fisheye;
 }
 ```
 
@@ -100,7 +100,7 @@ Ce descripteur peut prendre l'une de ces trois formes :
 @counter-style circled-digits {
   system: fixed;
   symbols: ➀ ➁ ➂;
-  suffix: ' ';
+  suffix: " ";
 }
 
 .list {
@@ -258,7 +258,20 @@ Ce descripteur peut prendre l'une de ces trois formes :
 @counter-style upper-roman {
   system: additive;
   range: 1 3999;
-  additive-symbols: 1000 M, 900 CM, 500 D, 400 CD, 100 C, 90 XC, 50 L, 40 XL, 10 X, 9 IX, 5 V, 4 IV, 1 I;
+  additive-symbols:
+    1000 M,
+    900 CM,
+    500 D,
+    400 CD,
+    100 C,
+    90 XC,
+    50 L,
+    40 XL,
+    10 X,
+    9 IX,
+    5 V,
+    4 IV,
+    1 I;
 }
 
 .list {

--- a/files/fr/web/css/@document/index.md
+++ b/files/fr/web/css/@document/index.md
@@ -9,7 +9,8 @@ translation_of: Web/CSS/@document
 La [règle @ CSS](/fr/docs/Web/CSS/Règles_@) **`@document`** restreint les règles qu'elle contient en fonction de l'URL du document. Elle est principalement conçue pour les feuilles de style utilisateur, bien qu'elle puisse être également utilisée pour les feuilles de style d'auteur.
 
 ```css
-@document url("https://www.example.com/") {
+@document url("https://www.example.com/")
+{
   h1 {
     color: green;
   }
@@ -43,8 +44,7 @@ Les valeurs échappées fournies à la fonction `regexp()` doivent être en outr
                url-prefix("http://www.w3.org/Style/"),
                domain("mozilla.org"),
                media-document("video"),
-               regexp("https:.*")
-{
+               regexp("https:.*") {
   /* Ces règles CSS s'appliquent à :
      - la page "http://www.w3.org/"
      - toute page dont l'URL commence par "http://www.w3.org/Style/"

--- a/files/fr/web/css/@font-face/font-display/index.md
+++ b/files/fr/web/css/@font-face/font-display/index.md
@@ -54,8 +54,9 @@ font-display: optional;
 ```css
 @font-face {
   font-family: FonteExemple;
-  src: url(/chemin/vers/fonts/examplefont.woff) format('woff'),
-       url(/chemin/vers/fonts/examplefont.eot) format('eot');
+  src:
+    url(/chemin/vers/fonts/examplefont.woff) format("woff"),
+    url(/chemin/vers/fonts/examplefont.eot) format("eot");
   font-weight: 400;
   font-style: normal;
   font-display: fallback;

--- a/files/fr/web/css/@font-face/font-family/index.md
+++ b/files/fr/web/css/@font-face/font-family/index.md
@@ -14,7 +14,7 @@ Le descripteur **`font-family`** permet aux auteurs d'un document de définir la
 /* Valeurs de chaînes de caractères */
 /* Type <string>                    */
 font-family: "police de caractères a";
-font-family: 'une autre police';
+font-family: "une autre police";
 
 /* Valeur de type <custom-ident> */
 font-family: exemplepolice;
@@ -38,7 +38,7 @@ font-family: exemplepolice;
 ```css
 @font-face {
   font-family: exemplepolice;
-  src: url('exemplepolice.ttf');
+  src: url("exemplepolice.ttf");
 }
 ```
 

--- a/files/fr/web/css/@font-face/font-stretch/index.md
+++ b/files/fr/web/css/@font-face/font-stretch/index.md
@@ -31,7 +31,7 @@ font-stretch: 200%;
 
 /* Valeurs multiples */
 font-stretch: 75% 125%;
-font-stretch: condensed ultra-condensed;;
+font-stretch: condensed ultra-condensed;
 ```
 
 ### Valeurs
@@ -119,8 +119,9 @@ Dans l'exemple suivant, on charge une police Open Sans locale et on l'importe en
 ```css
 @font-face {
   font-family: "Open Sans";
-  src: local("Open Sans") format("woff2"),
-       url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
+  src:
+    local("Open Sans") format("woff2"),
+    url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
   font-stretch: 87.5% 112.5%;
 }
 ```

--- a/files/fr/web/css/@font-face/font-style/index.md
+++ b/files/fr/web/css/@font-face/font-style/index.md
@@ -48,7 +48,7 @@ Dans les exemples qui suivent, on utilisera les différentes formes liées à la
 ```css
 @font-face {
   font-family: garamond;
-  src: url('garamond.ttf');
+  src: url("garamond.ttf");
 }
 ```
 
@@ -63,7 +63,7 @@ En revanche, si on dispose d'une vraie version italique, on peut l'indiquer via 
 ```css
 @font-face {
   font-family: garamond;
-  src: url('garamond-italic.ttf');
+  src: url("garamond-italic.ttf");
   /* On indique ici que la police est italique */
   font-style: italic;
 }

--- a/files/fr/web/css/@font-face/font-variation-settings/index.md
+++ b/files/fr/web/css/@font-face/font-variation-settings/index.md
@@ -37,11 +37,13 @@ font-variation-settings: "xhgt" 0.7;
 
 ```css
 @font-face {
-  font-family: 'OpenTypeFont';
-  src: url('open_type_font.woff2') format('woff2');
+  font-family: "OpenTypeFont";
+  src: url("open_type_font.woff2") format("woff2");
   font-weight: normal;
   font-style: normal;
-  font-variation-settings: 'wght' 400, 'wdth' 300;
+  font-variation-settings:
+    "wght" 400,
+    "wdth" 300;
 }
 ```
 

--- a/files/fr/web/css/@font-face/font-weight/index.md
+++ b/files/fr/web/css/@font-face/font-weight/index.md
@@ -73,8 +73,9 @@ Dans l'exemple suivant, on récupère une police Open Sans et on l'importe en ut
 ```css
 @font-face {
   font-family: "Open Sans";
-  src: local("Open Sans") format("woff2"),
-        url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
+  src:
+    local("Open Sans") format("woff2"),
+    url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
   font-weight: 400;
 }
 ```

--- a/files/fr/web/css/@font-face/index.md
+++ b/files/fr/web/css/@font-face/index.md
@@ -14,9 +14,11 @@ La [règle @](/fr/docs/Web/CSS/At-rule) [CSS](/fr/docs/Web/CSS) **`@font-face`**
 ```css
 @font-face {
   font-family: "Trickster";
-  src: local("Trickster"),
-    url("trickster-COLRv1.otf") format("opentype") tech(color-COLRv1), url("trickster-outline.otf")
-      format("opentype"), url("trickster-outline.woff") format("woff");
+  src:
+    local("Trickster"),
+    url("trickster-COLRv1.otf") format("opentype") tech(color-COLRv1),
+    url("trickster-outline.otf") format("opentype"),
+    url("trickster-outline.woff") format("woff");
 }
 ```
 
@@ -46,6 +48,7 @@ La [règle @](/fr/docs/Web/CSS/At-rule) [CSS](/fr/docs/Web/CSS) **`@font-face`**
 - [`size-adjust`](/fr/docs/Web/CSS/@font-face/size-adjust)
   - : Définit un multiplicateur pour les contours des glyphes et les métriques associées à cette police. Cela permet de simplifier l'harmonisation de différentes polices lorsqu'elles sont affichées avec le même corps.
 - [`src`](/fr/docs/Web/CSS/@font-face/src)
+
   - : Indique les ressources à utiliser pour la police. La valeur est une liste de valeurs indiquant les ressources à tenter les unes après les autres. Chaque ressource est indiquée avec `url()` ou `local()`. C'est la première ressource de la liste qui est chargée correctement qui est utilisée. Les éléments situés après sont ignorés. Si plusieurs descripteurs `src` sont définis, seule la dernière règle déclarée capable de charger une ressource est appliquée.
 
     > **Note :** Les éléments que le navigateur considère comme invalides sont ignorés. Certains navigateurs pourront ignorer l'ensemble du descripteur si même un seul des éléments est invalide. Cela pourra avoir un impact sur la gestion des alternatives.
@@ -53,9 +56,11 @@ La [règle @](/fr/docs/Web/CSS/At-rule) [CSS](/fr/docs/Web/CSS) **`@font-face`**
     Une notation `url()` peut être suivie des notations fonctionnelles `format()` et `tech()`, comme ceci&nbsp;:
 
     ```css
-    src: local("Trickster"),
-      url("trickster-COLRv1.otf") format("opentype") tech(color-COLRv1), url("trickster-outline.otf")
-        format("opentype"), url("trickster-outline.woff") format("woff");
+    src:
+      local("Trickster"),
+      url("trickster-COLRv1.otf") format("opentype") tech(color-COLRv1),
+      url("trickster-outline.otf") format("opentype"),
+      url("trickster-outline.woff") format("woff");
     ```
 
     `url()` indique l'URL d'un fichier de police et fonctionne comme la notation fonctionnelle `url()` qu'on utilise par ailleurs en CSS. Si le fichier de la police contient plusieurs polices, un fragment d'identifiant doit être utilisé pour indiquer la police à utiliser. Par exemple&nbsp;:
@@ -97,6 +102,7 @@ La [règle @](/fr/docs/Web/CSS/At-rule) [CSS](/fr/docs/Web/CSS) **`@font-face`**
     | `format("truetype-variations")` | `format(truetype) tech(variations)` |
 
     > **Note :** `format(svg)` correspond aux [polices SVG](/fr/docs/Web/SVG/Tutorial/SVG_fonts), tandis que `tech(color-SVG)` correspond aux [polices OpenType avec un tableau SVG](https://learn.microsoft.com/en-us/typography/opentype/spec/svg) (également appelées polices de couleur OpenType-SVG)&nbsp;: il s'agit de deux types de polices complètement différents.
+
 - [`unicode-range`](/fr/docs/Web/CSS/@font-face/unicode-range)
   - : L'intervalle des points de code Unicode pour lesquels la règle `@font-face` s'applique.
 
@@ -150,7 +156,7 @@ Dans cet exemple, on indique une police téléchargeable à utiliser et on l'app
 #### HTML
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
   <head>
     <meta charset="utf-8" />
@@ -199,7 +205,9 @@ Cela signifie généralement que les fichiers locaux doivent apparaître avant l
 ```css
 @font-face {
   font-family: "MgOpenModernaBold";
-  src: url("MgOpenModernaBoldIncr.otf") format("opentype") tech(incremental), url("MgOpenModernaBold.otf") format(opentype);
+  src:
+    url("MgOpenModernaBoldIncr.otf") format("opentype") tech(incremental),
+    url("MgOpenModernaBold.otf") format(opentype);
 }
 ```
 
@@ -214,7 +222,9 @@ On notera dans ce cas que les descripteurs `src` sont essayés dans l'ordre inve
   font-family: "MgOpenModernaBold";
   src: url("MgOpenModernaBold.otf") format(opentype);
   src: url("MgOpenModernaBoldIncr.otf") format("opentype") tech(incremental);
-  src: url("MgOpenModernaBoldIncr.otf") format("opentype") tech(incremental), url("MgOpenModernaBold.otf") format(opentype);
+  src:
+    url("MgOpenModernaBoldIncr.otf") format("opentype") tech(incremental),
+    url("MgOpenModernaBold.otf") format(opentype);
 }
 ```
 

--- a/files/fr/web/css/@font-face/src/index.md
+++ b/files/fr/web/css/@font-face/src/index.md
@@ -16,23 +16,25 @@ Là aussi, les URL utilisées peuvent être relatives. Dans le cas où une URL r
 
 ## Syntaxe
 
-```css
+```css-nolint
 /* <url> */
 src: url(https://unsiteweb.com/chemin/vers/police.woff); /* URL absolue */
-src: url(chemin/vers/police.woff);                       /* URL relative */
-src: url(chemin/vers/police.woff) format("woff");        /* format explicite */
-src: url('chemin/vers/police.woff');                     /* URL entre quotes */
-src: url(chemin/vers/policesvg.svg#exemple);             /* fragment identifiant une police */
+src: url(chemin/vers/police.woff); /* URL relative */
+src: url(chemin/vers/police.woff) format("woff"); /* format explicite */
+src: url('chemin/vers/police.woff'); /* URL entre quotes */
+src: url(chemin/vers/policesvg.svg#exemple); /* fragment identifiant une police */
 
 /* Valeurs de type <font-face-name> */
-src: local(police);      /* nom sans double quote */
+src: local(police); /* nom sans double quote */
 src: local(une police); /* nom avec espace */
-src: local("police");    /* nom entre double quotes */
+src: local("police"); /* nom entre double quotes */
 
 /* Liste avec plusieurs éléments */
-src: local(police), url(chemin/vers/police.svg) format("svg"),
-    url(chemin/vers/police.woff) format("woff"),
-    url(chemin/vers/police.otf) format("opentype");
+src:
+  local(police),
+  url(chemin/vers/police.svg) format("svg"),
+  url(chemin/vers/police.woff) format("woff"),
+  url(chemin/vers/police.otf) format("opentype");
 ```
 
 ### Valeurs
@@ -51,8 +53,10 @@ src: local(police), url(chemin/vers/police.svg) format("svg"),
 ```css
 @font-face {
   font-family: policeexemple;
-  src: local(Police Exemple), url('policeexemple.woff') format("woff"),
-      url('policeexemple.otf') format("opentype");
+  src:
+    local(Police Exemple),
+    url("policeexemple.woff") format("woff"),
+    url("policeexemple.otf") format("opentype");
 }
 ```
 

--- a/files/fr/web/css/@font-face/unicode-range/index.md
+++ b/files/fr/web/css/@font-face/unicode-range/index.md
@@ -12,11 +12,11 @@ Le descripteur **`unicode-range`**, associé à la règle @ [`@font-face`](/fr/d
 
 ```css
 /* Valeurs <unicode-range> */
-unicode-range: U+26;                 /* un seul point de code         */
+unicode-range: U+26; /* un seul point de code         */
 unicode-range: U+0-7F;
-unicode-range: U+0025-00FF;          /* un intervalle spécifique      */
-unicode-range: U+4??;                /* un intervalle de substitution */
-unicode-range: U+0025-00FF, U+4??;   /* plusieurs valeurs             */
+unicode-range: U+0025-00FF; /* un intervalle spécifique      */
+unicode-range: U+4??; /* un intervalle de substitution */
+unicode-range: U+0025-00FF, U+4??; /* plusieurs valeurs             */
 ```
 
 ### Valeurs
@@ -63,8 +63,8 @@ Dans la feuille de style CSS, on définit une règle [`@font-face`](/fr/docs/Web
 
 ```css
 @font-face {
-  font-family: 'Ampersand';
-  src: local('Times New Roman');
+  font-family: "Ampersand";
+  src: local("Times New Roman");
   unicode-range: U+26;
 }
 

--- a/files/fr/web/css/@font-feature-values/index.md
+++ b/files/fr/web/css/@font-feature-values/index.md
@@ -10,7 +10,7 @@ La [règle @](/fr/docs/Web/CSS/At-rule) **`@font-feature-values`** permet aux au
 
 ```css
 @font-feature-values Font One {
-/* On active la caractéristique nice-style
+  /* On active la caractéristique nice-style
    sur Font One */
   @styleset {
     nice-style: 12;
@@ -18,7 +18,7 @@ La [règle @](/fr/docs/Web/CSS/At-rule) **`@font-feature-values`** permet aux au
 }
 
 @font-feature-values Font Two {
-/* On active la caractéristique nice-style
+  /* On active la caractéristique nice-style
    sur Font Two */
   @styleset {
     nice-style: 4;
@@ -49,7 +49,7 @@ La règle @ `@font-feature-values` peut être utilisée au plus haut niveau d'un
 - `@styleset`
   - : Indique le nom d'une caractéristique qui fonctionnera avec la notation fonctionnelle {{cssxref("font-variant-alternates", "styleset()", "#styleset()")}}. Plusieurs valeurs peuvent être utilisées pour cette caractéristique : `ident1: 2 4 12 1` correspondra aux valeurs OpenType `ss02`, `ss04`, `ss12`, `ss01`. Les valeurs supérieures à `99` sont valides mais ne correspondent à aucune valeur OpenType et sont donc ignorées.
 - `@character-variant`
-  - : Indique le nom d'une caractéristique qui fonctionnera avec la notation fonctionnelle {{cssxref("font-variant-alternates", "character-variant()", "#character-variant()")}}. Pour cette définition, on peut utiliser une ou deux valeurs : `ident1: 2`  correspond à `cv02=1` et `ident2: 2 4` correspond à `cv02)4`, en revanche `ident2: 2 4 5` est invalide.
+  - : Indique le nom d'une caractéristique qui fonctionnera avec la notation fonctionnelle {{cssxref("font-variant-alternates", "character-variant()", "#character-variant()")}}. Pour cette définition, on peut utiliser une ou deux valeurs : `ident1: 2` correspond à `cv02=1` et `ident2: 2 4` correspond à `cv02)4`, en revanche `ident2: 2 4 5` est invalide.
 
 ### Syntaxe formelle
 

--- a/files/fr/web/css/@import/index.md
+++ b/files/fr/web/css/@import/index.md
@@ -11,10 +11,10 @@ La [règle @](/fr/docs/Web/CSS/Règles_@) **`@import`** est utilisée afin d'imp
 ```css
 @import url("fineprint.css") print;
 @import url("bluish.css") speech;
-@import 'custom.css';
+@import "custom.css";
 @import url("chrome://communicator/skin/");
 @import "common.css" screen;
-@import url('landscape.css') screen and (orientation:landscape);
+@import url("landscape.css") screen and (orientation: landscape);
 ```
 
 Afin que les agents utilisateurs évitent de récupérer des ressources pour des types de média qui ne sont pas pris en charge, les auteurs peuvent définir des règles `@import` spécifiques à chaque média. Ces imports conditionnels comportent une liste de [requête média](/fr/docs/Web/CSS/Media_queries) séparées par des virgules, situées après l'URL. Si aucune requête média n'est indiquée, l'import est inconditionnel. Cela aura le même effet que d'utiliser la requête média `all`.

--- a/files/fr/web/css/@keyframes/index.md
+++ b/files/fr/web/css/@keyframes/index.md
@@ -46,10 +46,21 @@ Si des propriétés ne sont pas définies à chaque étape, elles sont interpol�
 
 ```css
 @keyframes identifier {
-  0% { top: 0; left: 0; }
-  30% { top: 50px; }
-  68%, 72% { left: 50px; }
-  100% { top: 100px; left: 100%; }
+  0% {
+    top: 0;
+    left: 0;
+  }
+  30% {
+    top: 50px;
+  }
+  68%,
+  72% {
+    left: 50px;
+  }
+  100% {
+    top: 100px;
+    left: 100%;
+  }
 }
 ```
 
@@ -63,16 +74,26 @@ Les déclarations qui utilisent `!important` dans une description d'étape sont 
 
 ```css
 @keyframes important1 {
-  from { margin-top: 50px; }
-  50%  { margin-top: 150px !important; } /* ignorée */
-  to   { margin-top: 100px; }
+  from {
+    margin-top: 50px;
+  }
+  50% {
+    margin-top: 150px !important;
+  } /* ignorée */
+  to {
+    margin-top: 100px;
+  }
 }
 
 @keyframes important2 {
-  from { margin-top: 50px;
-         margin-bottom: 100px; }
-                         to { margin-top: 150px !important; /* ignorée */
-         margin-bottom: 50px; }
+  from {
+    margin-top: 50px;
+    margin-bottom: 100px;
+  }
+  to {
+    margin-top: 150px !important; /* ignorée */
+    margin-bottom: 50px;
+  }
 }
 ```
 
@@ -125,11 +146,9 @@ p {
 
 ```html
 <p>
-  Le Chat grimaça en apercevant Alice. Elle trouva qu’il
-  avait l’air bon enfant, et cependant il avait de
-  très longues griffes et une grande rangée de dents ;
-  aussi comprit-elle qu’il fallait le traiter avec
-  respect.
+  Le Chat grimaça en apercevant Alice. Elle trouva qu’il avait l’air bon enfant,
+  et cependant il avait de très longues griffes et une grande rangée de dents ;
+  aussi comprit-elle qu’il fallait le traiter avec respect.
 </p>
 ```
 

--- a/files/fr/web/css/@layer/index.md
+++ b/files/fr/web/css/@layer/index.md
@@ -35,11 +35,11 @@ La première façon consiste à créer une couche de cascade nommée et qui cont
 ```css
 @layer utilities {
   .padding-sm {
-    padding: .5rem;
+    padding: 0.5rem;
   }
 
   .padding-lg {
-    padding: .8rem;
+    padding: 0.8rem;
   }
 }
 ```
@@ -79,7 +79,7 @@ Une autre façon pour créer une couche de cascade consiste à utiliser [`@impor
 > **Attention :** La règle @ `@import` doit précéder tous les autres types de règles, à l'exception des règles `@charset`.
 
 ```css
-@import 'theme.css' layer(utilities);
+@import "theme.css" layer(utilities);
 ```
 
 ### Couches imbriquées
@@ -89,7 +89,6 @@ Les couches peuvent être imbriquées, on peut par exemple avoir&nbsp;:
 ```css
 @layer framework {
   @layer layout {
-
   }
 }
 ```
@@ -159,9 +158,10 @@ Dans l'exemple qui suit, on crée deux couches sans leur affecter de règle puis
 ```html
 <div class="item">
   Je m'affiche avec <code>color: rebeccapurple</code> car la couche
-  <code>special</code> arrive après <code>base</code> dans les déclarations.
-  Ma bordure verte, la taille du texte et le remplissage viennent de la
-  couche <code>base</code>.</div>
+  <code>special</code> arrive après <code>base</code> dans les déclarations. Ma
+  bordure verte, la taille du texte et le remplissage viennent de la couche
+  <code>base</code>.
+</div>
 ```
 
 #### CSS
@@ -180,7 +180,7 @@ Dans l'exemple qui suit, on crée deux couches sans leur affecter de règle puis
     color: green;
     border: 5px solid green;
     font-size: 1.3em;
-    padding: .5em;
+    padding: 0.5em;
   }
 }
 ```

--- a/files/fr/web/css/@media/-moz-device-pixel-ratio/index.md
+++ b/files/fr/web/css/@media/-moz-device-pixel-ratio/index.md
@@ -12,11 +12,11 @@ La [caractéristique média](/fr/docs/Web/CSS/Media_Queries/Using_media_queries#
 >
 > `-moz-device-pixel-ratio` peut être utilisée si besoin d'être compatible avec des versions de Firefox antérieures à la version 16 et `-webkit-device-pixel-ratio` peut être utilisée avec les navigateurs WebKit qui ne prennent pas en charge `dppx`. Par exemple :
 >
-> ```css
+> ```css-nolint
 > @media (-webkit-min-device-pixel-ratio: 2), /* Navigateurs basés sur Webkit */
->        (min--moz-device-pixel-ratio: 2),    /* Anciens Firefox (avant Firefox 16) */
->        (min-resolution: 2dppx),             /* La méthode standard */
->        (min-resolution: 192dpi)             /* Utilisée si dppx n'est pas gérée */
+>        (min--moz-device-pixel-ratio: 2), /* Anciens Firefox (avant Firefox 16) */
+>        (min-resolution: 2dppx), /* La méthode standard */
+>        (min-resolution: 192dpi) /* Utilisée si dppx n'est pas gérée */
 > ```
 >
 > Voir [cet article du CSSWG](https://www.w3.org/blog/CSS/2012/06/14/unprefix-webkit-device-pixel-ratio/) pour les bonnes pratiques quant à la compatibilité de `resolution` et `dppx`.

--- a/files/fr/web/css/@media/-webkit-transition/index.md
+++ b/files/fr/web/css/@media/-webkit-transition/index.md
@@ -15,7 +15,7 @@ translation_of: Web/CSS/@media/-webkit-transition
 S'il vous faut déterminer si les transitions CSS sont prises en charges, évitez d'utiliser `-webkit-transition`. En lieu et place, on utilisera la règle @ {{cssxref("@supports")}} :
 
 ```css
-@supports(transition: initial) {
+@supports (transition: initial) {
   /* Les règles CSS à utiliser si   */
   /* les transitions sont prises en */
   /* charge. */

--- a/files/fr/web/css/@media/any-pointer/index.md
+++ b/files/fr/web/css/@media/any-pointer/index.md
@@ -30,8 +30,7 @@ Dans cet exemple, on crée une petite case à cocher pour les utilisateurs qui d
 ### HTML
 
 ```html
-<input id="test" type="checkbox" />
-<label for="test">Coucou !</label>
+<input id="test" type="checkbox" /> <label for="test">Coucou !</label>
 ```
 
 ### CSS

--- a/files/fr/web/css/@media/aspect-ratio/index.md
+++ b/files/fr/web/css/@media/aspect-ratio/index.md
@@ -28,7 +28,14 @@ Les navigateurs ont ajouté une propriété `aspect-ratio` interne qui s'appliqu
 Pour Firefox, la feuille de style interne ressemble à :
 
 ```css
-img, input[type="image"], video, embed, iframe, marquee, object, table {
+img,
+input[type="image"],
+video,
+embed,
+iframe,
+marquee,
+object,
+table {
   aspect-ratio: attr(width) / attr(height);
 }
 ```

--- a/files/fr/web/css/@media/color-index/index.md
+++ b/files/fr/web/css/@media/color-index/index.md
@@ -52,7 +52,10 @@ Ce fragment HTML permet d'appliquer une feuille de style spécifique pour les ap
 
 ```html
 <link rel="stylesheet" href="http://toto.truc.com/base.css" />
-<link rel="stylesheet" media="all and (min-color-index: 256)" href="http://toto.truc.com/feuille_style_couleurs.css" />
+<link
+  rel="stylesheet"
+  media="all and (min-color-index: 256)"
+  href="http://toto.truc.com/feuille_style_couleurs.css" />
 ```
 
 ## Spécifications

--- a/files/fr/web/css/@media/color/index.md
+++ b/files/fr/web/css/@media/color/index.md
@@ -20,9 +20,8 @@ La caractéristique `color` est définie avec un entier (type CSS {{cssxref("&lt
 
 ```html
 <p>
-   Ce texte sera noir pour les appareils qui ne prennent en charge
-   aucune couleur, rouge pour ceux qui prennent peu de couleurs en
-   charge et vert sinon.
+  Ce texte sera noir pour les appareils qui ne prennent en charge aucune
+  couleur, rouge pour ceux qui prennent peu de couleurs en charge et vert sinon.
 </p>
 ```
 

--- a/files/fr/web/css/@media/device-height/index.md
+++ b/files/fr/web/css/@media/device-height/index.md
@@ -17,7 +17,10 @@ La caractéristique `device-height` est définie comme une longueur (type {{cssx
 Ce fragment HTML applique une feuille de style spécifique pour les appareils dont la hauteur est inférieure à 800 pixels.
 
 ```html
-<link rel="stylesheet" media="screen and (max-device-height: 799px)" href="http://toto.truc.com/short-styles.css" />
+<link
+  rel="stylesheet"
+  media="screen and (max-device-height: 799px)"
+  href="http://toto.truc.com/short-styles.css" />
 ```
 
 ## Spécifications

--- a/files/fr/web/css/@media/device-width/index.md
+++ b/files/fr/web/css/@media/device-width/index.md
@@ -17,7 +17,10 @@ translation_of: Web/CSS/@media/device-width
 Ce code HTML applique une feuille de style pour pour les appareils plus étroits que 800 pixels.
 
 ```html
-<link rel="stylesheet" media="screen and (max-device-width: 799px)" href="http://toto.truc.com/narrow-styles.css" />
+<link
+  rel="stylesheet"
+  media="screen and (max-device-width: 799px)"
+  href="http://toto.truc.com/narrow-styles.css" />
 ```
 
 ## Spécifications

--- a/files/fr/web/css/@media/grid/index.md
+++ b/files/fr/web/css/@media/grid/index.md
@@ -19,7 +19,9 @@ La caractéristique `grid` est une valeur booléenne (`0` ou `1`) (type {{cssxre
 ### HTML
 
 ```html
-<p class="unknown">Impossible de savoir si l'affichage fonctionne sur une grille. :-(</p>
+<p class="unknown">
+  Impossible de savoir si l'affichage fonctionne sur une grille. :-(
+</p>
 <p class="bitmap">L'appareil dispose d'un affichage matriciel.</p>
 <p class="grid">L'appareil utilise une grille pour l'affichage !</p>
 ```

--- a/files/fr/web/css/@media/height/index.md
+++ b/files/fr/web/css/@media/height/index.md
@@ -18,8 +18,7 @@ La caractéristique `height` est définie comme une longueur (type {{cssxref("&l
 
 ```html
 <div>
-  Surveillez cet élément lors du
-  redimensionnement de la zone d'affichage.
+  Surveillez cet élément lors du redimensionnement de la zone d'affichage.
 </div>
 ```
 

--- a/files/fr/web/css/@media/index.md
+++ b/files/fr/web/css/@media/index.md
@@ -121,9 +121,11 @@ Il est aussi possible de combiner plusieurs requêtes média en une seule règle
 - `and`
   - : Cet opérateur permet de combiner plusieurs tests de caractéristiques afin que le résultat du test vaille `true` si chacun des tests individuels vaut `true`. Il permet également de joindre des tests de caractéristiques média et des tests de type de média.
 - `not`
+
   - : Cet opérateur donne la négation d'une requête média, renvoyant `true` si la requête devait renvoyer `false`. Si cet opérateur est présent dans une liste de requêtes séparées par des virgules, la négation portera uniquement sur la requête sur laquelle l'opérateur est appliqué. Si l'opérateur `not` est utilisé, il _est nécessaire_ d'indiquer un type de média.
 
     > **Note :** Dans la spécification de niveau 3, le mot-clé `not` permet uniquement de prendre la négation d'une requête média entière (et pas d'une caractéristique seule).
+
 - `only`
   - : Applique la mise en forme uniquement si toute la requête correspond. Ce mot-clé est utile pour empêcher les anciens navigateurs d'appliquer les styles en question. Sans utiliser `only`, les anciens navigateurs interpréteraient la requête `screen and (max-width: 500px)` comme `screen`, en ignorant le reste et en appliquant donc le style à tous les écrans. Si l'opérateur `only` est utilisé, il _est nécessaire_ d'indiquer un type de média.
 - `,` (virgule)
@@ -151,20 +153,25 @@ Pour ces raisons, un navigateur peut choisir de mentir sur les valeurs renvoyée
 
 ```css
 @media print {
-  body { font-size: 10pt }
+  body {
+    font-size: 10pt;
+  }
 }
 @media screen {
-  body { font-size: 13px }
+  body {
+    font-size: 13px;
+  }
 }
 @media screen, print {
-  body { line-height: 1.2 }
+  body {
+    line-height: 1.2;
+  }
 }
 
-@media only screen
-  and (min-width: 320px)
-  and (max-width: 480px)
-  and (-webkit-min-device-pixel-ratio: 2) {
-    body { line-height: 1.4 }
+@media only screen and (min-width: 320px) and (max-width: 480px) and (-webkit-min-device-pixel-ratio: 2) {
+  body {
+    line-height: 1.4;
+  }
 }
 ```
 
@@ -172,11 +179,15 @@ Avec la mise à jour de la spécification pour les requêtes média, une nouvell
 
 ```css
 @media (height > 600px) {
-  body { line-height: 1.4; }
+  body {
+    line-height: 1.4;
+  }
 }
 
 @media (400px <= width <= 700px) {
-  body { line-height: 1.4; }
+  body {
+    line-height: 1.4;
+  }
 }
 ```
 

--- a/files/fr/web/css/@media/inverted-colors/index.md
+++ b/files/fr/web/css/@media/inverted-colors/index.md
@@ -23,14 +23,12 @@ Cette caractéristique est définie avec un des mots-clés parmi ceux qui suiven
 
 ```html
 <p>
-  Si vous utilisez les couleurs inversées, ce texte devrait
-  être bleu sur blanc (l'inverse de jaune sur noir). Sinon,
-  il devrait être rouge sur gris clair.
+  Si vous utilisez les couleurs inversées, ce texte devrait être bleu sur blanc
+  (l'inverse de jaune sur noir). Sinon, il devrait être rouge sur gris clair.
 </p>
 <p>
-  Si le texte est gris, cela indique que votre navigateur
-  ne prend pas en charge la caractéristique média
-  `inverted-colors`.
+  Si le texte est gris, cela indique que votre navigateur ne prend pas en charge
+  la caractéristique média `inverted-colors`.
 </p>
 ```
 

--- a/files/fr/web/css/@media/monochrome/index.md
+++ b/files/fr/web/css/@media/monochrome/index.md
@@ -17,13 +17,9 @@ La caractéristique `monochrome` est un entier (type {{cssxref("&lt;integer&gt;"
 ### HTML
 
 ```html
-<p class="mono">
-  Votre appareil prend en charge les
-  pixels monochrome !
-</p>
+<p class="mono">Votre appareil prend en charge les pixels monochrome !</p>
 <p class="no-mono">
-  Votre appareil ne prend pas en charge
-  les pixels monochromes.
+  Votre appareil ne prend pas en charge les pixels monochromes.
 </p>
 ```
 

--- a/files/fr/web/css/@media/overflow-block/index.md
+++ b/files/fr/web/css/@media/overflow-block/index.md
@@ -26,7 +26,16 @@ La caractéristique `overflow-block` est définie avec un mot-clé de la liste s
 ### HTML
 
 ```html
-<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ac turpis eleifend, fringilla velit ac, aliquam tellus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nunc velit erat, tempus id rutrum sed, dapibus ut urna. Integer vehicula nibh a justo imperdiet rutrum. Nam faucibus pretium orci imperdiet sollicitudin. Nunc id facilisis dui. Proin elementum et massa et feugiat. Integer rutrum ullamcorper eleifend. Proin sit amet tincidunt risus. Sed nec augue congue eros accumsan tincidunt sed eget ex.</p>
+<p>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ac turpis
+  eleifend, fringilla velit ac, aliquam tellus. Vestibulum ante ipsum primis in
+  faucibus orci luctus et ultrices posuere cubilia Curae; Nunc velit erat,
+  tempus id rutrum sed, dapibus ut urna. Integer vehicula nibh a justo imperdiet
+  rutrum. Nam faucibus pretium orci imperdiet sollicitudin. Nunc id facilisis
+  dui. Proin elementum et massa et feugiat. Integer rutrum ullamcorper eleifend.
+  Proin sit amet tincidunt risus. Sed nec augue congue eros accumsan tincidunt
+  sed eget ex.
+</p>
 ```
 
 ### CSS

--- a/files/fr/web/css/@media/overflow-inline/index.md
+++ b/files/fr/web/css/@media/overflow-inline/index.md
@@ -23,16 +23,14 @@ La caractéristique `overflow-inline` est définit avec un mot-clé parmi ceux d
 
 ```html
 <p>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  Nullam ac turpis eleifend, fringilla velit ac, aliquam tellus.
-  Vestibulum ante ipsum primis in faucibus orci luctus et
-  ultrices posuere cubilia Curae; Nunc velit erat, tempus id
-  rutrum sed, dapibus ut urna. Integer vehicula nibh a justo
-  imperdiet rutrum. Nam faucibus pretium orci imperdiet
-  sollicitudin. Nunc id facilisis dui. Proin elementum et
-  massa et feugiat. Integer rutrum ullamcorper eleifend.
-  Proin sit amet tincidunt risus. Sed nec augue congue eros
-  accumsan tincidunt sed eget ex.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ac turpis
+  eleifend, fringilla velit ac, aliquam tellus. Vestibulum ante ipsum primis in
+  faucibus orci luctus et ultrices posuere cubilia Curae; Nunc velit erat,
+  tempus id rutrum sed, dapibus ut urna. Integer vehicula nibh a justo imperdiet
+  rutrum. Nam faucibus pretium orci imperdiet sollicitudin. Nunc id facilisis
+  dui. Proin elementum et massa et feugiat. Integer rutrum ullamcorper eleifend.
+  Proin sit amet tincidunt risus. Sed nec augue congue eros accumsan tincidunt
+  sed eget ex.
 </p>
 ```
 

--- a/files/fr/web/css/@media/pointer/index.md
+++ b/files/fr/web/css/@media/pointer/index.md
@@ -28,8 +28,7 @@ Dans cet exemple, on crée une petite case à cocher pour les utilisateurs qui d
 ### HTML
 
 ```html
-<input id="test" type="checkbox" />
-<label for="test">Coucou !</label>
+<input id="test" type="checkbox" /> <label for="test">Coucou !</label>
 ```
 
 ### CSS

--- a/files/fr/web/css/@media/prefers-color-scheme/index.md
+++ b/files/fr/web/css/@media/prefers-color-scheme/index.md
@@ -23,20 +23,39 @@ La caractéristique média **`prefers-color-scheme`** permet de détecter les pr
 ### CSS
 
 ```css
-.day   { background: #eee; color: black; }
-.night { background: #333; color: white; }
+.day {
+  background: #eee;
+  color: black;
+}
+.night {
+  background: #333;
+  color: white;
+}
 
 @media (prefers-color-scheme: dark) {
-  .day.dark-scheme   { background:  #333; color: white; }
-  .night.dark-scheme { background: black; color:  #ddd; }
+  .day.dark-scheme {
+    background: #333;
+    color: white;
+  }
+  .night.dark-scheme {
+    background: black;
+    color: #ddd;
+  }
 }
 
 @media (prefers-color-scheme: light) {
-  .day.light-scheme   { background: white; color:  #555; }
-  .night.light-scheme { background:  #eee; color: black; }
+  .day.light-scheme {
+    background: white;
+    color: #555;
+  }
+  .night.light-scheme {
+    background: #eee;
+    color: black;
+  }
 }
 
-.day, .night {
+.day,
+.night {
   display: inline-block;
   padding: 1em;
   width: 7em;
@@ -49,12 +68,21 @@ La caractéristique média **`prefers-color-scheme`** permet de détecter les pr
 
 ```html
 <div class="day">Jour (initial)</div>
-<div class="day light-scheme">Jour (modifié si utilisation d'un thème clair)</div>
-<div class="day dark-scheme">Jour (modifié si utilisation d'un thème sombre)</div> <br>
+<div class="day light-scheme">
+  Jour (modifié si utilisation d'un thème clair)
+</div>
+<div class="day dark-scheme">
+  Jour (modifié si utilisation d'un thème sombre)
+</div>
+<br />
 
 <div class="night">Nuit (initial)</div>
-<div class="night light-scheme">Nuit (modifié si utilisation d'un thème clair)</div>
-<div class="night dark-scheme">Nuit (modifié si utilisation d'un thème sombre)</div>
+<div class="night light-scheme">
+  Nuit (modifié si utilisation d'un thème clair)
+</div>
+<div class="night dark-scheme">
+  Nuit (modifié si utilisation d'un thème sombre)
+</div>
 ```
 
 ### Résultat

--- a/files/fr/web/css/@media/prefers-contrast/index.md
+++ b/files/fr/web/css/@media/prefers-contrast/index.md
@@ -61,7 +61,7 @@ Par défaut, cet exemple présente un contraste trop faible pour la lisibilité.
 
 ## Voir aussi
 
-- La caractéristique média spécifique à Microsoft [`-ms-high-contrast`](https://docs.microsoft.com/fr-fr/previous-versions/hh771830(v=vs.85))
+- La caractéristique média spécifique à Microsoft [`-ms-high-contrast`](<https://docs.microsoft.com/fr-fr/previous-versions/hh771830(v=vs.85)>)
 - La caractéristique média [`forced-colors`](/fr/docs/Web/CSS/@media/forced-colors)
 
 {{QuickLinksWithSubpages("/fr/docs/Web/CSS/@media/")}}

--- a/files/fr/web/css/@media/prefers-reduced-motion/index.md
+++ b/files/fr/web/css/@media/prefers-reduced-motion/index.md
@@ -47,7 +47,7 @@ Cet exemple possède une animation désagréable qui sera exécutée à moins d'
 
 @media (prefers-reduced-motion: reduce) {
   .animation {
-  animation: none;
+    animation: none;
   }
 }
 ```
@@ -56,7 +56,10 @@ Cet exemple possède une animation désagréable qui sera exécutée à moins d'
 .animation {
   background-color: rebeccapurple;
   color: #fff;
-  font: 1.2em Helvetica, arial, sans-serif;
+  font:
+    1.2em Helvetica,
+    arial,
+    sans-serif;
   width: 200px;
   padding: 1em;
   border-radius: 1em;
@@ -76,22 +79,22 @@ Cet exemple possède une animation désagréable qui sera exécutée à moins d'
 
 @keyframes vibrate {
   0% {
-      transform: translate(0);
+    transform: translate(0);
   }
   20% {
-      transform: translate(-2px, 2px);
+    transform: translate(-2px, 2px);
   }
   40% {
-      transform: translate(-2px, -2px);
+    transform: translate(-2px, -2px);
   }
   60% {
-      transform: translate(2px, 2px);
+    transform: translate(2px, 2px);
   }
   80% {
-      transform: translate(2px, -2px);
+    transform: translate(2px, -2px);
   }
   100% {
-      transform: translate(0);
+    transform: translate(0);
   }
 }
 ```

--- a/files/fr/web/css/@media/scripting/index.md
+++ b/files/fr/web/css/@media/scripting/index.md
@@ -25,7 +25,9 @@ La caractéristique `scripting` est définie avec un mot-clé parmi les suivants
 
 ```html
 <p class="script-none">Les outils de script ne sont pas disponibles. :-(</p>
-<p class="script-initial-only">Les outils de script sont uniquement disponibles au chargement initial.</p>
+<p class="script-initial-only">
+  Les outils de script sont uniquement disponibles au chargement initial.
+</p>
 <p class="script-enabled">Les outils de script sont activés ! :-)</p>
 ```
 
@@ -38,7 +40,7 @@ p {
 
 @media (scripting: none) {
   .script-none {
-     color: red;
+    color: red;
   }
 }
 

--- a/files/fr/web/css/@media/shape/index.md
+++ b/files/fr/web/css/@media/shape/index.md
@@ -59,9 +59,12 @@ Ce fragment de code HTML permettra d'appliquer une feuille de style particulièr
 
 ```html
 <head>
-    <link rel="stylesheet" href="default.css" />
-    <link media="screen and (shape: rect)" rel="stylesheet" href="rectangle.css" />
-    <link media="screen and (shape: round)" rel="stylesheet" href="round.css" />
+  <link rel="stylesheet" href="default.css" />
+  <link
+    media="screen and (shape: rect)"
+    rel="stylesheet"
+    href="rectangle.css" />
+  <link media="screen and (shape: round)" rel="stylesheet" href="round.css" />
 </head>
 ```
 

--- a/files/fr/web/css/@media/update/index.md
+++ b/files/fr/web/css/@media/update/index.md
@@ -25,8 +25,8 @@ La caractéristique `update` est définie avec un mot-clé parmi ceux de la list
 
 ```html
 <p>
-  Si ce texte est animé, cela signifie que vous utilisez
-  un appareil avec un affichage qui évolue rapidement.
+  Si ce texte est animé, cela signifie que vous utilisez un appareil avec un
+  affichage qui évolue rapidement.
 </p>
 ```
 

--- a/files/fr/web/css/@media/width/index.md
+++ b/files/fr/web/css/@media/width/index.md
@@ -14,13 +14,16 @@ translation_of: Web/CSS/@media/width
 
 ```css
 /* Largeur exacte */
-@media (width: 300px) {}
+@media (width: 300px) {
+}
 
 /* Un viewport avec une largeur minimale */
-@media (min-width: 50em) {}
+@media (min-width: 50em) {
+}
 
 /* Un viewport avec une largeur maximale */
-@media (max-width: 1000px) {}
+@media (max-width: 1000px) {
+}
 ```
 
 ## Exemples
@@ -28,7 +31,9 @@ translation_of: Web/CSS/@media/width
 ### HTML
 
 ```html
-<div>Observez cet élément lorsque vous redimensionnez la largeur du viewport.</div>
+<div>
+  Observez cet élément lorsque vous redimensionnez la largeur du viewport.
+</div>
 ```
 
 ### CSS

--- a/files/fr/web/css/@namespace/index.md
+++ b/files/fr/web/css/@namespace/index.md
@@ -15,13 +15,16 @@ translation_of: Web/CSS/@namespace
 /* Cela correspond à tous les éléments XHTML <a>
   car XHTML est l'espace de nom par défaut, sans
   préfixe. */
-a {}
+a {
+}
 
 /* Cela correspond à tous les éléments SVG <a> */
-svg|a {}
+svg|a {
+}
 
 /* Cela correspond aux éléments <a> XHTML et SVG */
-*|a {}
+*|a {
+}
 ```
 
 Les règles `@namespace` doivent suivre les règles @ {{cssxref("@charset")}} et {{cssxref("@import")}} et précéder les autres règles @ ainsi que les déclarations de style contenus dans la feuille de style.

--- a/files/fr/web/css/@property/index.md
+++ b/files/fr/web/css/@property/index.md
@@ -14,7 +14,7 @@ La règle `@property` permet l'enregistrement d'une propriété personnalisée d
 
 ```css
 @property --property-name {
-  syntax: '<color>';
+  syntax: "<color>";
   inherits: false;
   initial-value: #c0ffee;
 }
@@ -43,7 +43,7 @@ Utilisation de la règle [CSS](/fr/docs/Web/CSS) [at-rule](/fr/docs/Web/CSS/At-r
 
 ```css
 @property --my-color {
-  syntax: '<color>';
+  syntax: "<color>";
   inherits: false;
   initial-value: #c0ffee;
 }
@@ -53,10 +53,10 @@ Utilisation de la règle [CSS](/fr/docs/Web/CSS) [at-rule](/fr/docs/Web/CSS/At-r
 
 ```js
 window.CSS.registerProperty({
-  name: '--my-color',
-  syntax: '<color>',
+  name: "--my-color",
+  syntax: "<color>",
   inherits: false,
-  initialValue: '#c0ffee',
+  initialValue: "#c0ffee",
 });
 ```
 

--- a/files/fr/web/css/@supports/index.md
+++ b/files/fr/web/css/@supports/index.md
@@ -37,7 +37,8 @@ Une condition de prise en charge se compose d'une ou plusieurs déclarations com
 La plus simple expression est une déclaration CSS, c'est-à-dire un nom de propriété CSS suivi par deux points (:) puis une valeur. Ainsi, l'expression suivante :
 
 ```css
-@supports ( transform-origin: 5% 5% ) { }
+@supports (transform-origin: 5% 5%) {
+}
 ```
 
 renvoie le booléen vrai si la propriété {{cssxref("transform-origin")}} du navigateur considère que la valeur `5% 5%` est valide.
@@ -53,7 +54,8 @@ La deuxième syntaxe permet d'utiliser une fonction. Cette syntaxe est prise en 
 Dans l'exemple qui suit, on teste si le navigateur prend en charge la syntaxe du sélecteur passé en argument. Ici, le code renvoie VRAI si le navigateur prend en charge les [sélecteurs enfants](/fr/docs/Web/CSS/Sélecteurs_enfant)
 
 ```css
-@supports selector(A > B) { }
+@supports selector(A > B) {
+}
 ```
 
 ### L'opérateur `not`
@@ -61,7 +63,8 @@ Dans l'exemple qui suit, on teste si le navigateur prend en charge la syntaxe du
 L'opérateur `not` peut être utilisée avant une expression afin de créer un expression dont le résultat logique est la négation du résultat de l'expression originale. Ainsi, l'expression suivante :
 
 ```css
-@supports not ( transform-origin: 10em 10em 10em ) { }
+@supports not (transform-origin: 10em 10em 10em) {
+}
 ```
 
 renvoie VRAI si la propriété {{cssxref("transform-origin")}} du navigateur ne considère pas la valeur `10em 10em 10em` comme valide.
@@ -69,8 +72,10 @@ renvoie VRAI si la propriété {{cssxref("transform-origin")}} du navigateur ne 
 Comme pour les autres opérateurs, on peut appliquer l'opérateur `not` à une déclaration, quelle que soit sa complexité. Les exemples qui suivent sont donc des expressions valides :
 
 ```css
-@supports not ( not ( transform-origin: 2px ) ) { }
-@supports (display: grid) and ( not (display: inline-grid) ) { }
+@supports not (not (transform-origin: 2px)) {
+}
+@supports (display: grid) and (not (display: inline-grid)) {
+}
 ```
 
 > **Note :** Au niveau le plus haut, il n'est pas nécessaire d'encadrer l'opérateur `not` entre parenthèses. Si on souhaite le combiner avec d'autres opérateurs comme `and` ou `or`, il faudra utiliser des parenthèses.
@@ -80,19 +85,22 @@ Comme pour les autres opérateurs, on peut appliquer l'opérateur `not` à une d
 L'opérateur `and` peut être utilisé pour former une nouvelle expression à partir de deux expressions. L'expression résultante sera la conjonction des deux expressions originelles. Autrement dit, le résultat de cette nouvelle expression sera VRAI si et seulement si les deux expressions de départ sont vraies et FAUX sinon. Dans l'exemple suivant, l'expression complète ne sera vérifiée que si les deux expressions sont vérifiées :
 
 ```css
-@supports (display: table-cell) and (display: list-item) { }
+@supports (display: table-cell) and (display: list-item) {
+}
 ```
 
 On peut enchaîner plusieurs conjonctions sans avoir à ajouter de parenthèses (l'opérateur est commutatif).
 
 ```css
-@supports (display: table-cell) and (display: list-item) and (display:run-in) { }
+@supports (display: table-cell) and (display: list-item) and (display: run-in) {
+}
 ```
 
 sera équivalente à :
 
 ```css
-@supports (display: table-cell) and ((display: list-item) and (display:run-in)) { }
+@supports (display: table-cell) and ((display: list-item) and (display: run-in)) {
+}
 ```
 
 ### L'opérateur `or`
@@ -100,21 +108,30 @@ sera équivalente à :
 L'opérateur `or` peut être utilisé pour former une nouvelle expression à partir de deux expressions. L'expression résultante sera la disjonction des deux expressions originelles. Autrement dit, le résultat de cette nouvelle expression sera VRAI si au moins une des deux expressions est vraie. Dans l'exemple qui suit, l'expression complète est vérifiée si au moins une des deux (ce peuvent être les deux) expressions est vérifiée :
 
 ```css
-@supports ( transform-style: preserve ) or ( -moz-transform-style: preserve ) { }
+@supports (transform-style: preserve) or (-moz-transform-style: preserve) {
+}
 ```
 
 On peut enchaîner plusieurs disjonctions sans qu'il soit nécessaire d'ajouter des parenthèses.
 
 ```css
-@supports ( transform-style: preserve ) or ( -moz-transform-style: preserve ) or
-          ( -o-transform-style: preserve ) or ( -webkit-transform-style: preserve  ) { }
+@supports (transform-style: preserve) or (-moz-transform-style: preserve) or
+  (-o-transform-style: preserve) or (-webkit-transform-style: preserve) {
+}
 ```
 
 sera ainsi équivalente à :
 
 ```css
-@supports ( transform-style: preserve-3d ) or (( -moz-transform-style: preserve-3d ) or
-          (( -o-transform-style: preserve-3d ) or ( -webkit-transform-style: preserve-3d  ))) { }
+@supports (transform-style: preserve-3d) or
+  (
+    (-moz-transform-style: preserve-3d) or
+      (
+        (-o-transform-style: preserve-3d) or
+          (-webkit-transform-style: preserve-3d)
+      )
+  ) {
+}
 ```
 
 > **Note :** Lorsqu'on utilise à la fois l'opérateur `and` et l'opérateur `or`, il devient nécessaire d'utiliser des parenthèses pour que l'ordre d'application des opérateurs soit défini. Si on n'utilise pas de parenthèses, la condition sera considérée comme invalide et l'ensemble de la règle @ sera ignorée.

--- a/files/fr/web/css/_colon_-moz-broken/index.md
+++ b/files/fr/web/css/_colon_-moz-broken/index.md
@@ -13,7 +13,7 @@ Ce sélecteur est principalement destiné à être utilisé par les développeur
 ## Syntaxe
 
 ```css
-:-moz-broken
+:-moz-broken {}
 ```
 
 ## Exemples
@@ -21,7 +21,7 @@ Ce sélecteur est principalement destiné à être utilisé par les développeur
 ### HTML
 
 ```html
-<img src="broken.jpg" alt="Cette image ne fonctionne pas. :-(">
+<img src="broken.jpg" alt="Cette image ne fonctionne pas. :-(" />
 ```
 
 ### CSS

--- a/files/fr/web/css/_colon_-moz-loading/index.md
+++ b/files/fr/web/css/_colon_-moz-loading/index.md
@@ -13,7 +13,7 @@ Cette pseudo-classe est principalement destinée aux développeurs de thèmes.
 ## Syntaxe
 
 ```css
-:-moz-loading
+:-moz-loading {}
 ```
 
 ## Exemples

--- a/files/fr/web/css/_colon_-moz-only-whitespace/index.md
+++ b/files/fr/web/css/_colon_-moz-only-whitespace/index.md
@@ -19,7 +19,7 @@ La [pseudo-classe](/fr/docs/Web/CSS/Pseudo-classes) **`:-moz-only-whitespace`** 
 ### HTML
 
 ```html
-<div> </div>
+<div></div>
 ```
 
 ### CSS

--- a/files/fr/web/css/_colon_-moz-submit-invalid/index.md
+++ b/files/fr/web/css/_colon_-moz-submit-invalid/index.md
@@ -13,7 +13,7 @@ Par défaut, aucun style n'est appliqué. Vous pouvez utiliser cette pseudo-clas
 ## Syntaxe
 
 ```css
-:-moz-submit-invalid
+:-moz-submit-invalid {}
 ```
 
 ## Spécifications

--- a/files/fr/web/css/_colon_-moz-suppressed/index.md
+++ b/files/fr/web/css/_colon_-moz-suppressed/index.md
@@ -13,7 +13,7 @@ Ce sélecteur est principalement destiné aux développeurs de thèmes.
 ## Syntaxe
 
 ```css
-:-moz-suppressed
+:-moz-suppressed {}
 ```
 
 ## Exemple

--- a/files/fr/web/css/_colon_-moz-user-disabled/index.md
+++ b/files/fr/web/css/_colon_-moz-user-disabled/index.md
@@ -13,7 +13,7 @@ Ce sélecteur est destiné principalement à une utilisation par les développeu
 ## Syntaxe
 
 ```css
-:-moz-user-disabled
+:-moz-user-disabled {}
 ```
 
 ## Exemples

--- a/files/fr/web/css/_colon_active/index.md
+++ b/files/fr/web/css/_colon_active/index.md
@@ -33,21 +33,32 @@ La mise en forme associée peut être surchargée par les autres pseudo-classes 
 #### CSS
 
 ```css
-a:link { color: blue; }          /* Liens non visités */
-a:visited { color: purple; }     /* Liens visités */
-a:hover { background: yellow; }  /* Liens survolés */
-a:active { color: red; }         /* Liens actifs */
+a:link {
+  color: blue;
+} /* Liens non visités */
+a:visited {
+  color: purple;
+} /* Liens visités */
+a:hover {
+  background: yellow;
+} /* Liens survolés */
+a:active {
+  color: red;
+} /* Liens actifs */
 
-p:active { background: #eee; }   /* Paragraphes actifs */
+p:active {
+  background: #eee;
+} /* Paragraphes actifs */
 ```
 
 #### HTML
 
 ```html
-<p>Ce paragraphe contient un lien :
+<p>
+  Ce paragraphe contient un lien :
   <a href="#">Ce lien devient rouge quand vous cliquez dessus.</a>
-  Le paragraphe sera sur un fond gris quand vous cliquerez dessus
-  ou sur le lien.
+  Le paragraphe sera sur un fond gris quand vous cliquerez dessus ou sur le
+  lien.
 </p>
 ```
 
@@ -74,7 +85,9 @@ form button {
 ```html
 <form>
   <label for="mon-button">Un bouton :</label>
-  <button id="mon-button" type="button">Cliquez sur moi ou sur mon libellé !</button>
+  <button id="mon-button" type="button">
+    Cliquez sur moi ou sur mon libellé !
+  </button>
 </form>
 ```
 

--- a/files/fr/web/css/_colon_any-link/index.md
+++ b/files/fr/web/css/_colon_any-link/index.md
@@ -41,8 +41,8 @@ La pseudo-classe **`:any-link`** permet de représenter un élément qui agit co
 ### HTML
 
 ```html
-<a href="https://mozilla.org">Une page différente</a><br>
-<a href="#">Une ancre</a><br>
+<a href="https://mozilla.org">Une page différente</a><br />
+<a href="#">Une ancre</a><br />
 <a>Un lien sans cible (n'est pas mis en forme)</a>
 ```
 

--- a/files/fr/web/css/_colon_checked/index.md
+++ b/files/fr/web/css/_colon_checked/index.md
@@ -31,15 +31,15 @@ input:checked {
 
 ```html
 <div>
-  <input type="radio" name="my-input" id="yes">
+  <input type="radio" name="my-input" id="yes" />
   <label for="yes">Oui</label>
 
-  <input type="radio" name="my-input" id="no">
+  <input type="radio" name="my-input" id="no" />
   <label for="no">Non</label>
 </div>
 
 <div>
-  <input type="checkbox" name="my-checkbox" id="opt-in">
+  <input type="checkbox" name="my-checkbox" id="opt-in" />
   <label for="opt-in">Cochez-moi !</label>
 </div>
 

--- a/files/fr/web/css/_colon_default/index.md
+++ b/files/fr/web/css/_colon_default/index.md
@@ -51,16 +51,16 @@ input:default + label {
 <fieldset>
   <legend>Saison préférée</legend>
 
-  <input type="radio" name="season" id="spring">
+  <input type="radio" name="season" id="spring" />
   <label for="spring">Printemps</label>
 
-  <input type="radio" name="season" id="summer" checked>
+  <input type="radio" name="season" id="summer" checked />
   <label for="summer">Eté</label>
 
-  <input type="radio" name="season" id="fall">
+  <input type="radio" name="season" id="fall" />
   <label for="fall">Automne</label>
 
-  <input type="radio" name="season" id="winter">
+  <input type="radio" name="season" id="winter" />
   <label for="winter">Hiver</label>
 </fieldset>
 ```

--- a/files/fr/web/css/_colon_defined/index.md
+++ b/files/fr/web/css/_colon_defined/index.md
@@ -31,18 +31,19 @@ Les fragments de code qui suivent sont tirés [du dépôt `defined-pseudo-class`
 Pour cette démonstration on définit un élément personnalisé trivial :
 
 ```js
-customElements.define('simple-custom',
+customElements.define(
+  "simple-custom",
   class extends HTMLElement {
     constructor() {
       super();
 
-      let divElem = document.createElement('div');
-      divElem.textContent = this.getAttribute('text');
+      let divElem = document.createElement("div");
+      divElem.textContent = this.getAttribute("text");
 
-      let shadowRoot = this.attachShadow({mode: 'open'})
-        .appendChild(divElem);
-  }
-})
+      let shadowRoot = this.attachShadow({ mode: "open" }).appendChild(divElem);
+    }
+  },
+);
 ```
 
 On insère ensuite une copie de cet élément dans le document, à côté d'un paragraphe classique `<p>` :

--- a/files/fr/web/css/_colon_dir/index.md
+++ b/files/fr/web/css/_colon_dir/index.md
@@ -60,7 +60,8 @@ La pseudo-classe `:dir()` nécessite un paramètre qui indique la direction du t
 ```html
 <div dir="rtl">
   <span>test1</span>
-  <div dir="ltr">test2
+  <div dir="ltr">
+    test2
     <div dir="auto">עִבְרִית</div>
   </div>
 </div>

--- a/files/fr/web/css/_colon_disabled/index.md
+++ b/files/fr/web/css/_colon_disabled/index.md
@@ -25,7 +25,9 @@ input[type="text"]:disabled {
 ### CSS
 
 ```css
-input[type="text"]:disabled { background: #ccc; }
+input[type="text"]:disabled {
+  background: #ccc;
+}
 ```
 
 ### HTML
@@ -34,18 +36,24 @@ input[type="text"]:disabled { background: #ccc; }
 <form action="#">
   <fieldset>
     <legend>Adresse de livraison</legend>
-    <input type="text" placeholder="Nom">
-    <input type="text" placeholder="Adresse">
-    <input type="text" placeholder="Code postal">
+    <input type="text" placeholder="Nom" />
+    <input type="text" placeholder="Adresse" />
+    <input type="text" placeholder="Code postal" />
   </fieldset>
   <fieldset id="facturation">
     <legend>Adresse de facturation</legend>
-    <label for="facturation_livraison">Identique à l'adresse de livraison</label>
-    <input type="checkbox" id="facturation_livraison" onchange="javascript:toggleBilling()" checked>
+    <label for="facturation_livraison"
+      >Identique à l'adresse de livraison</label
+    >
+    <input
+      type="checkbox"
+      id="facturation_livraison"
+      onchange="javascript:toggleBilling()"
+      checked />
     <br />
-    <input type="text" placeholder="Nom" disabled>
-    <input type="text" placeholder="Adresse" disabled>
-    <input type="text" placeholder="Code postal" disabled>
+    <input type="text" placeholder="Nom" disabled />
+    <input type="text" placeholder="Adresse" disabled />
+    <input type="text" placeholder="Code postal" disabled />
   </fieldset>
 </form>
 ```
@@ -54,7 +62,9 @@ input[type="text"]:disabled { background: #ccc; }
 
 ```js
 function toggleBilling() {
-  var billingItems = document.querySelectorAll('#facturation input[type="text"]');
+  var billingItems = document.querySelectorAll(
+    '#facturation input[type="text"]',
+  );
   for (var i = 0; i < billingItems.length; i++) {
     billingItems[i].disabled = !billingItems[i].disabled;
   }

--- a/files/fr/web/css/_colon_empty/index.md
+++ b/files/fr/web/css/_colon_empty/index.md
@@ -49,7 +49,7 @@ body {
 <div class="box"><!-- Je serai bleu. --></div>
 <div class="box">Je serai rouge.</div>
 <div class="box">
-    <!-- Je serai rouge à cause des espaces autour du commentaire -->
+  <!-- Je serai rouge à cause des espaces autour du commentaire -->
 </div>
 ```
 

--- a/files/fr/web/css/_colon_enabled/index.md
+++ b/files/fr/web/css/_colon_enabled/index.md
@@ -11,7 +11,7 @@ La [pseudo-classe](/fr/docs/Web/CSS/Pseudo-classes) **`:enabled`** permet de cib
 ```css
 /* Cible n'importe quel élément <input> actif */
 input:enabled {
-  color: #22AA22;
+  color: #22aa22;
 }
 ```
 
@@ -28,12 +28,16 @@ Dans cet exemple, les textes des éléments activés seront verts alors que ceux
 ```html
 <form action="url_of_form">
   <label for="PremierChamp">Premier champ (activé) :</label>
-  <input type="text" id="PremierChamp" value="Titi"><br />
+  <input type="text" id="PremierChamp" value="Titi" /><br />
 
   <label for="DeuxiemeChamp">Deuxième champ (désactivé) :</label>
-  <input type="text" id="DeuxiemeChamp" value="Toto" disabled="disabled"><br />
+  <input
+    type="text"
+    id="DeuxiemeChamp"
+    value="Toto"
+    disabled="disabled" /><br />
 
-  <input type="button" value="Envoyer"/>
+  <input type="button" value="Envoyer" />
 </form>
 ```
 
@@ -41,13 +45,12 @@ Dans cet exemple, les textes des éléments activés seront verts alors que ceux
 
 ```css
 input:enabled {
-  color: #22AA22;
+  color: #22aa22;
 }
 
 input:disabled {
-  color: #D9D9D9;
+  color: #d9d9d9;
 }
-
 ```
 
 ### Résultat

--- a/files/fr/web/css/_colon_first-child/index.md
+++ b/files/fr/web/css/_colon_first-child/index.md
@@ -41,17 +41,21 @@ p:first-child {
 
 ```html
 <div>
-  <p>Ce paragraphe est mis en forme car c'est un élément
-     p ET que c'est le premier fils de l'élément div.</p>
-  <p>En revanche, ce paragraphe n'est pas mis en forme
-     car ce n'est pas le premier !</p>
+  <p>
+    Ce paragraphe est mis en forme car c'est un élément p ET que c'est le
+    premier fils de l'élément div.
+  </p>
+  <p>
+    En revanche, ce paragraphe n'est pas mis en forme car ce n'est pas le
+    premier !
+  </p>
 </div>
 
 <div>
-  <h2>Ce titre h2 n'est pas mis en forme car ce n'est pas
-      un paragraphe.</h2>
-  <p>Et ce paragraphe n'est pas mis en forme car ce n'est pas
-     le premier fils !</p>
+  <h2>Ce titre h2 n'est pas mis en forme car ce n'est pas un paragraphe.</h2>
+  <p>
+    Et ce paragraphe n'est pas mis en forme car ce n'est pas le premier fils !
+  </p>
 </div>
 ```
 
@@ -64,12 +68,12 @@ p:first-child {
 #### CSS
 
 ```css
-li{
-  color:blue;
+li {
+  color: blue;
 }
 
-li:first-child{
-  color:green;
+li:first-child {
+  color: green;
 }
 ```
 

--- a/files/fr/web/css/_colon_first/index.md
+++ b/files/fr/web/css/_colon_first/index.md
@@ -55,7 +55,7 @@ p {
 ### JavaScript
 
 ```js
-document.querySelector("button").addEventListener('click', () => {
+document.querySelector("button").addEventListener("click", () => {
   window.print();
 });
 ```

--- a/files/fr/web/css/_colon_focus-visible/index.md
+++ b/files/fr/web/css/_colon_focus-visible/index.md
@@ -15,7 +15,7 @@ On notera que Firefox prend en charge cette fonctionnalité via une ancienne pse
 ## Syntaxe
 
 ```css
-:focus-visible
+:focus-visible {}
 ```
 
 ## Exemples
@@ -27,18 +27,19 @@ Dans cet exemple, le sélecteur `:focus-visible` utilise le comportement de l'ag
 #### HTML
 
 ```html
-<input value="Styles par défaut"><br>
-<button>Styles par défaut</button><br>
-<input class="focus-only" value=":focus only"><br>
-<button class="focus-only">:focus only</button><br>
-<input class="focus-visible-only" value=":focus-visible only"><br>
+<input value="Styles par défaut" /><br />
+<button>Styles par défaut</button><br />
+<input class="focus-only" value=":focus only" /><br />
+<button class="focus-only">:focus only</button><br />
+<input class="focus-visible-only" value=":focus-visible only" /><br />
 <button class="focus-visible-only">:focus-visible only</button>
 ```
 
 #### CSS
 
 ```css
-input, button {
+input,
+button {
   margin: 10px;
 }
 

--- a/files/fr/web/css/_colon_focus-within/index.md
+++ b/files/fr/web/css/_colon_focus-within/index.md
@@ -46,17 +46,17 @@ input {
 
 ```html
 <p>
-  L'élément div ci-après aura un fond jaune
-  si l'un des deux champs de saisie a le focus.
+  L'élément div ci-après aura un fond jaune si l'un des deux champs de saisie a
+  le focus.
 </p>
 <div class="name-container">
   <label for="prenom">
     Prénom :
-    <input id="prenom" placeholder="Prénom" type="text">
+    <input id="prenom" placeholder="Prénom" type="text" />
   </label>
   <label for="nom">
     Nom :
-    <input id="nom" placeholder="Nom" type="text">
+    <input id="nom" placeholder="Nom" type="text" />
   </label>
 </div>
 ```

--- a/files/fr/web/css/_colon_focus/index.md
+++ b/files/fr/web/css/_colon_focus/index.md
@@ -41,8 +41,8 @@ Cette pseudo-classe ne s'applique qu'aux éléments avec le focus, elle ne s'app
 ### HTML
 
 ```html
-<input class="prenom" value="Rouge si focus">
-<input class="nom" value="Vert si focus">
+<input class="prenom" value="Rouge si focus" />
+<input class="nom" value="Vert si focus" />
 ```
 
 ### Résultat

--- a/files/fr/web/css/_colon_fullscreen/index.md
+++ b/files/fr/web/css/_colon_fullscreen/index.md
@@ -43,9 +43,11 @@ Lorsque le document est en mode plein écran, on utilise cette fois-ci la pseudo
 ```html
 <h1>MDN Web Docs Demo: :fullscreen pseudo-class</h1>
 
-<p>This demo uses the <code>:fullscreen</code> pseudo-class to automatically
+<p>
+  This demo uses the <code>:fullscreen</code> pseudo-class to automatically
   change the style of a button used to toggle full-screen mode on and off,
-  entirely using CSS.</p>
+  entirely using CSS.
+</p>
 
 <button id="fs-toggle">Toggle Fullscreen</button>
 ```

--- a/files/fr/web/css/_colon_future/index.md
+++ b/files/fr/web/css/_colon_future/index.md
@@ -34,7 +34,12 @@ Le sélecteur de [pseudo-classe](/fr/docs/Web/CSS/Pseudo-classes) [CSS](/fr/docs
 <video controls preload="metadata">
   <source src="video.mp4" type="video/mp4" />
   <source src="video.webm" type="video/webm" />
-  <track label="Français" kind="subtitles" srclang="fr" src="subtitles.vtt" default>
+  <track
+    label="Français"
+    kind="subtitles"
+    srclang="fr"
+    src="subtitles.vtt"
+    default />
 </video>
 ```
 

--- a/files/fr/web/css/_colon_has/index.md
+++ b/files/fr/web/css/_colon_has/index.md
@@ -20,7 +20,7 @@ Cette pseudo-classe `:has()` prend en paramètre une liste de sélecteurs.
 /* pas prise en charge par les navigateurs et   */
 /* n'est pas conçue pour fonctionner dans les   */
 /* feuilles de style */
-var test = document.querySelector('a:has(> img)');
+var test = document.querySelector("a:has(> img)");
 ```
 
 ## Syntaxe
@@ -34,13 +34,13 @@ var test = document.querySelector('a:has(> img)');
 Dans l'exemple suivant, le sélecteur permet de cibler uniquement les éléments {{HTMLElement("a")}} qui contiennent un fils direct {{HTMLElement("img")}} :
 
 ```css
-a:has(> img)
+a:has(> img) {}
 ```
 
 Le sélecteur qui suit correspond aux éléments {{HTMLElement("h1")}} qui précèdent directement un élément {{HTMLElement("p")}} :
 
 ```css
-h1:has(+ p)
+h1:has(+ p) {}
 ```
 
 ## Spécifications

--- a/files/fr/web/css/_colon_host-context/index.md
+++ b/files/fr/web/css/_colon_host-context/index.md
@@ -42,7 +42,7 @@ p {
 ## Syntaxe
 
 ```css
-:host-context( <selecteur-composite> )
+:host-context( <selecteur-composite> ) {}
 ```
 
 ## Exemples
@@ -55,27 +55,29 @@ Dans cet exemple, on a un élément personnalisé, `<context-span>`, dans lequel
 
 ```html
 <h1>
-  <a href="#"><context-span>Exemple</context-span></a> pour les sélecteurs d'hôte
+  <a href="#"><context-span>Exemple</context-span></a> pour les sélecteurs
+  d'hôte
 </h1>
 ```
 
 Dans le constructeur de l'élément, on crée des éléments `<style>` et `<span>`, et on remplit l'élément `<span>` avec le contenu de l'élément personnalisé, puis on remplit l'élément `<style>` avec quelques règles CSS&nbsp;:
 
 ```js
-let style = document.createElement('style');
-let span = document.createElement('span');
+let style = document.createElement("style");
+let span = document.createElement("span");
 span.textContent = this.textContent;
 
-const shadowRoot = this.attachShadow({mode: 'open'});
+const shadowRoot = this.attachShadow({ mode: "open" });
 shadowRoot.appendChild(style);
 shadowRoot.appendChild(span);
 
-style.textContent = 'span:hover { text-decoration: underline; }' +
-                    ':host-context(h1) { font-style: italic; }' +
-                    ':host-context(h1):after { content: " - pas de lien dans les titres !" }' +
-                    ':host-context(article, aside) { color: gray; }' +
-                    ':host(.footer) { color : red; }' +
-                    ':host { background: rgba(0,0,0,0.1); padding: 2px 5px; }';
+style.textContent =
+  "span:hover { text-decoration: underline; }" +
+  ":host-context(h1) { font-style: italic; }" +
+  ':host-context(h1):after { content: " - pas de lien dans les titres !" }' +
+  ":host-context(article, aside) { color: gray; }" +
+  ":host(.footer) { color : red; }" +
+  ":host { background: rgba(0,0,0,0.1); padding: 2px 5px; }";
 ```
 
 Les règles `:host-context(h1) { font-style: italic; }` et `:host-context(h1):after { content: " - pas de lien dans les titres !" }` mettent en forme les instances de l'élément `<context-span>` (ici l'hôte sombre) contenus dans des éléments `<h1>`. Dans notre exemple, nous avons utilisé ces règles pour afficher clairement que cet élément personnalisé ne devrait pas apparaître dans un élément `<h1>`.

--- a/files/fr/web/css/_colon_host/index.md
+++ b/files/fr/web/css/_colon_host/index.md
@@ -25,29 +25,32 @@ La [pseudo-classe](/fr/docs/Web/CSS/Pseudo-classes) **`:host`** permet de cibler
 
 Les fragments de code qui suivent sont extraits du dépôt d'exemple [_host-selectors_](https://github.com/mdn/web-components-examples/tree/master/host-selectors) ([voir le résultat _live_](https://mdn.github.io/web-components-examples/host-selectors/)).
 
-Dans cet exemple, on dispose d'un élément personnalisé `<context-span>`  qui peut contenir du texte :
+Dans cet exemple, on dispose d'un élément personnalisé `<context-span>` qui peut contenir du texte :
 
 ```html
-<h1>Host selectors <a href="#"><context-span>example</context-span></a></h1>
+<h1>
+  Host selectors <a href="#"><context-span>example</context-span></a>
+</h1>
 ```
 
 Pour le constructeur de cet élément, on crée des éléments `style` et `span` : l'élément `span` recevra le contenu de l'élément personnalisé et `style` recevra quelques règles CSS :
 
 ```js
-let style = document.createElement('style');
-let span = document.createElement('span');
+let style = document.createElement("style");
+let span = document.createElement("span");
 span.textContent = this.textContent;
 
-const shadowRoot = this.attachShadow({mode: 'open'});
+const shadowRoot = this.attachShadow({ mode: "open" });
 shadowRoot.appendChild(style);
 shadowRoot.appendChild(span);
 
-style.textContent = 'span:hover { text-decoration: underline; }' +
-                    ':host-context(h1) { font-style: italic; }' +
-                    ':host-context(h1):after { content: " - no links in headers!" }' +
-                    ':host-context(article, aside) { color: gray; }' +
-                    ':host(.footer) { color : red; }' +
-                    ':host { background: rgba(0,0,0,0.1); padding: 2px 5px; }';
+style.textContent =
+  "span:hover { text-decoration: underline; }" +
+  ":host-context(h1) { font-style: italic; }" +
+  ':host-context(h1):after { content: " - no links in headers!" }' +
+  ":host-context(article, aside) { color: gray; }" +
+  ":host(.footer) { color : red; }" +
+  ":host { background: rgba(0,0,0,0.1); padding: 2px 5px; }";
 ```
 
 La règle `:host { background: rgba(0,0,0,0.1); padding: 2px 5px; }` permet de cibler l'ensemble des instances de `<context-span>` (qui est l'hôte ici) dans le document.

--- a/files/fr/web/css/_colon_host_function/index.md
+++ b/files/fr/web/css/_colon_host_function/index.md
@@ -31,26 +31,29 @@ Les fragments de code suivants sont extraits du dépôt d'exemple [_host-selecto
 Dans cet exemple, on dispose d'un élément personnalisé, `<context-span>`, qui peut contenir du texte :
 
 ```html
-<h1>Host selectors <a href="#"><context-span>example</context-span></a></h1>
+<h1>
+  Host selectors <a href="#"><context-span>example</context-span></a>
+</h1>
 ```
 
 Dans le constructeur de l'élément, on crée un élément `style` et un élément `span`. Ce dernier recevra le contenu textuel de l'élément personnalisé et l'élément `style` recevra quelques règles CSS :
 
 ```js
-let style = document.createElement('style');
-let span = document.createElement('span');
+let style = document.createElement("style");
+let span = document.createElement("span");
 span.textContent = this.textContent;
 
-const shadowRoot = this.attachShadow({mode: 'open'});
+const shadowRoot = this.attachShadow({ mode: "open" });
 shadowRoot.appendChild(style);
 shadowRoot.appendChild(span);
 
-style.textContent = 'span:hover { text-decoration: underline; }' +
-                    ':host-context(h1) { font-style: italic; }' +
-                    ':host-context(h1):after { content: " - no links in headers!" }' +
-                    ':host-context(article, aside) { color: gray; }' +
-                    ':host(.footer) { color : red; }' +
-                    ':host { background: rgba(0,0,0,0.1); padding: 2px 5px; }';
+style.textContent =
+  "span:hover { text-decoration: underline; }" +
+  ":host-context(h1) { font-style: italic; }" +
+  ':host-context(h1):after { content: " - no links in headers!" }' +
+  ":host-context(article, aside) { color: gray; }" +
+  ":host(.footer) { color : red; }" +
+  ":host { background: rgba(0,0,0,0.1); padding: 2px 5px; }";
 ```
 
 La règle `:host(.footer) { color : red; }` s'applique à toutes les instances de l'élément `<context-span>` (il s'agit ici de l'hôte) du document qui possèdent la classe `footer`. Ici, pour ces éléments donnés, on utilise une couleur spécifique.

--- a/files/fr/web/css/_colon_in-range/index.md
+++ b/files/fr/web/css/_colon_in-range/index.md
@@ -45,10 +45,10 @@ input:out-of-range {
   border: 2px solid red;
 }
 input:in-range + label::after {
-  content:' OK';
+  content: " OK";
 }
 input:out-of-range + label::after {
-  content:' non autorisée !';
+  content: " non autorisée !";
 }
 ```
 
@@ -56,9 +56,17 @@ input:out-of-range + label::after {
 
 ```html
 <form action="" id="form1">
-  <ul>Les valeurs entre 1 et 10 sont valides.
+  <ul>
+    Les valeurs entre 1 et 10 sont valides.
     <li>
-      <input id="valeur1" name="valeur1" type="number" placeholder="de 1 à 10" min="1" max="10" value="12">
+      <input
+        id="valeur1"
+        name="valeur1"
+        type="number"
+        placeholder="de 1 à 10"
+        min="1"
+        max="10"
+        value="12" />
       <label for="valeur1">Votre valeur est </label>
     </li>
   </ul>

--- a/files/fr/web/css/_colon_indeterminate/index.md
+++ b/files/fr/web/css/_colon_indeterminate/index.md
@@ -33,11 +33,13 @@ Cela inclut :
 #### CSS
 
 ```css
-input, span {
+input,
+span {
   background: red;
 }
 
-:indeterminate, :indeterminate + label {
+:indeterminate,
+:indeterminate + label {
   background: lime;
 }
 ```
@@ -46,11 +48,11 @@ input, span {
 
 ```html
 <div>
-  <input type="checkbox" id="checkbox">
+  <input type="checkbox" id="checkbox" />
   <label for="checkbox">L'arrière-plan devrait être vert.</label>
 </div>
 <div>
-  <input type="radio" id="radio">
+  <input type="radio" id="radio" />
   <label for="radio">L'arrière-plan devrait être vert.</label>
 </div>
 ```
@@ -59,7 +61,7 @@ input, span {
 
 ```js
 var inputs = document.getElementsByTagName("input");
-for(var i = 0; i < inputs.length; i++) {
+for (var i = 0; i < inputs.length; i++) {
   inputs[i].indeterminate = true;
 }
 ```
@@ -82,7 +84,7 @@ progress:indeterminate {
 #### HTML
 
 ```html
-<progress/>
+<progress />
 ```
 
 #### Résultat

--- a/files/fr/web/css/_colon_invalid/index.md
+++ b/files/fr/web/css/_colon_invalid/index.md
@@ -71,12 +71,12 @@ input:required:invalid {
 <form>
   <div class="field">
     <label for="url_input">Veuillez saisir une URL :</label>
-    <input type="url" id="url_input">
+    <input type="url" id="url_input" />
   </div>
 
   <div class="field">
     <label for="email_input">Veuillez saisir une adresse électronique :</label>
-    <input type="email" id="email_input" required>
+    <input type="email" id="email_input" required />
   </div>
 </form>
 ```

--- a/files/fr/web/css/_colon_is/index.md
+++ b/files/fr/web/css/_colon_is/index.md
@@ -29,13 +29,12 @@ footer p:hover {
   cursor: pointer;
 }
 
-
 /* La version rétro-compatible avec :-*-any()  */
 :-moz-any(header, main, footer) p:hover {
   color: red;
   cursor: pointer;
 }
-:-webkit-any(header, main, footer) p:hover{
+:-webkit-any(header, main, footer) p:hover {
   color: red;
   cursor: pointer;
 }
@@ -62,8 +61,14 @@ footer p:hover {
 
 <main>
   <ul>
-    <li><p>Mon premier élément de</p><p>liste</p></li>
-    <li><p>Mon deuxième élément de</p><p>liste</p></li>
+    <li>
+      <p>Mon premier élément de</p>
+      <p>liste</p>
+    </li>
+    <li>
+      <p>Mon deuxième élément de</p>
+      <p>liste</p>
+    </li>
   </ul>
 </main>
 
@@ -96,30 +101,41 @@ footer p:hover {
 let matchedItems;
 
 try {
-  matchedItems = document.querySelectorAll(':is(header, main, footer) p');
-} catch(e) {
+  matchedItems = document.querySelectorAll(":is(header, main, footer) p");
+} catch (e) {
   try {
-    matchedItems = document.querySelectorAll(':matches(header, main, footer) p');
-  } catch(e) {
+    matchedItems = document.querySelectorAll(
+      ":matches(header, main, footer) p",
+    );
+  } catch (e) {
     try {
-      matchedItems = document.querySelectorAll(':-webkit-any(header, main, footer) p');
-    } catch(e) {
+      matchedItems = document.querySelectorAll(
+        ":-webkit-any(header, main, footer) p",
+      );
+    } catch (e) {
       try {
-        matchedItems = document.querySelectorAll(':-moz-any(header, main, footer) p');
-      } catch(e) {
-        console.log('Votre navigateur ne prend pas en charge :is(), :matches() ou :any()');
+        matchedItems = document.querySelectorAll(
+          ":-moz-any(header, main, footer) p",
+        );
+      } catch (e) {
+        console.log(
+          "Votre navigateur ne prend pas en charge :is(), :matches() ou :any()",
+        );
       }
     }
   }
 }
 
-for(let i = 0; i < matchedItems.length; i++) {
+for (let i = 0; i < matchedItems.length; i++) {
   applyHandler(matchedItems[i]);
 }
 
 function applyHandler(elem) {
-  elem.addEventListener('click', function(e) {
-    alert('Ce paragraphe est à l\'intérieur d\'un élément ' + e.target.parentNode.nodeName);
+  elem.addEventListener("click", function (e) {
+    alert(
+      "Ce paragraphe est à l'intérieur d'un élément " +
+        e.target.parentNode.nodeName,
+    );
   });
 }
 ```
@@ -133,18 +149,54 @@ La pseudo-classe `:matches()` permet de simplifier largement les sélecteurs CSS
 ```css
 /* les listes non ordonnées sur 3 niveaux ou plus */
 /* utilisent un carré comme puce */
-ol ol ul,     ol ul ul,     ol menu ul,     ol dir ul,
-ol ol menu,   ol ul menu,   ol menu menu,   ol dir menu,
-ol ol dir,    ol ul dir,    ol menu dir,    ol dir dir,
-ul ol ul,     ul ul ul,     ul menu ul,     ul dir ul,
-ul ol menu,   ul ul menu,   ul menu menu,   ul dir menu,
-ul ol dir,    ul ul dir,    ul menu dir,    ul dir dir,
-menu ol ul,   menu ul ul,   menu menu ul,   menu dir ul,
-menu ol menu, menu ul menu, menu menu menu, menu dir menu,
-menu ol dir,  menu ul dir,  menu menu dir,  menu dir dir,
-dir ol ul,    dir ul ul,    dir menu ul,    dir dir ul,
-dir ol menu,  dir ul menu,  dir menu menu,  dir dir menu,
-dir ol dir,   dir ul dir,   dir menu dir,   dir dir dir {
+ol ol ul,
+ol ul ul,
+ol menu ul,
+ol dir ul,
+ol ol menu,
+ol ul menu,
+ol menu menu,
+ol dir menu,
+ol ol dir,
+ol ul dir,
+ol menu dir,
+ol dir dir,
+ul ol ul,
+ul ul ul,
+ul menu ul,
+ul dir ul,
+ul ol menu,
+ul ul menu,
+ul menu menu,
+ul dir menu,
+ul ol dir,
+ul ul dir,
+ul menu dir,
+ul dir dir,
+menu ol ul,
+menu ul ul,
+menu menu ul,
+menu dir ul,
+menu ol menu,
+menu ul menu,
+menu menu menu,
+menu dir menu,
+menu ol dir,
+menu ul dir,
+menu menu dir,
+menu dir dir,
+dir ol ul,
+dir ul ul,
+dir menu ul,
+dir dir ul,
+dir ol menu,
+dir ul menu,
+dir menu menu,
+dir dir menu,
+dir ol dir,
+dir ul dir,
+dir menu dir,
+dir dir dir {
   list-style-type: square;
 }
 ```
@@ -164,7 +216,9 @@ pourra être remplacée par :
 En revanche, le modèle d'usage suivant n'est pas recommandée (cf. [la section qui suit sur les performances](#issues_with_performance_and_specificity)) :
 
 ```css
-:matches(ol, ul, menu, dir) :matches(ol, ul, menu, dir) :matches(ul, menu, dir) {
+:matches(ol, ul, menu, dir)
+  :matches(ol, ul, menu, dir)
+  :matches(ul, menu, dir) {
   list-style-type: square;
 }
 ```
@@ -181,14 +235,29 @@ h1 {
   font-size: 30px;
 }
 /* Niveau 1 */
-section h1, article h1, aside h1, nav h1 {
+section h1,
+article h1,
+aside h1,
+nav h1 {
   font-size: 25px;
 }
 /* Niveau 2 */
-section section h1, section article h1, section aside h1, section nav h1,
-article section h1, article article h1, article aside h1, article nav h1,
-aside section h1, aside article h1, aside aside h1, aside nav h1,
-nav section h1, nav article h1, nav aside h1, nav nav h1 {
+section section h1,
+section article h1,
+section aside h1,
+section nav h1,
+article section h1,
+article article h1,
+article aside h1,
+article nav h1,
+aside section h1,
+aside article h1,
+aside aside h1,
+aside nav h1,
+nav section h1,
+nav article h1,
+nav aside h1,
+nav nav h1 {
   font-size: 20px;
 }
 /* Niveau 3 */
@@ -207,14 +276,14 @@ h1 {
   font-size: 25px;
 }
 /* Niveau 2 */
-:is(section, article, aside, nav)
-:is(section, article, aside, nav) h1 {
+:is(section, article, aside, nav) :is(section, article, aside, nav) h1 {
   font-size: 20px;
 }
 /* Niveau 3 */
 :is(section, article, aside, nav)
-:is(section, article, aside, nav)
-:is(section, article, aside, nav) h1 {
+  :is(section, article, aside, nav)
+  :is(section, article, aside, nav)
+  h1 {
   font-size: 15px;
 }
 ```
@@ -248,7 +317,7 @@ L'exemple ci-dessus ne sera pas appliqué par les navigateurs qui ne prennent pa
 Ainsi :
 
 ```css
-.a > :-moz-any(.b, .c)
+.a > :-moz-any(.b, .c) {}
 ```
 
 sera plus lent que

--- a/files/fr/web/css/_colon_lang/index.md
+++ b/files/fr/web/css/_colon_lang/index.md
@@ -12,7 +12,7 @@ La [pseudo-classe](/fr/docs/Web/CSS/Pseudo-classes) **`:lang`** permet de défin
 /* Correspond aux paragraphes, uniquement si ceux-ci */
 /* sont indiqués comme étant en anglais (en) */
 p:lang(en) {
-  quotes: '\201C' '\201D' '\2018' '\2019';
+  quotes: "\201C" "\201D" "\2018" "\2019";
 }
 ```
 
@@ -39,15 +39,15 @@ Dans cet exemple, la pseudo-classe `:lang` est utilisée pour faire correspondre
 
 ```css
 :lang(fr) > Q {
-  quotes: '« ' ' »';
+  quotes: "« " " »";
 }
 
 :lang(de) > Q {
-  quotes: '»' '«' '\2039' '\203A';
+  quotes: "»" "«" "\2039" "\203A";
 }
 
 :lang(en) > Q {
-  quotes: '\201C' '\201D' '\2018' '\2019';
+  quotes: "\201C" "\201D" "\2018" "\2019";
 }
 ```
 
@@ -57,7 +57,7 @@ Dans cet exemple, la pseudo-classe `:lang` est utilisée pour faire correspondre
 <div lang="fr">
   <q>
     Cette citation française a
-      <q>une citation</q>
+    <q>une citation</q>
     imbriquée.
   </q>
 </div>
@@ -65,7 +65,7 @@ Dans cet exemple, la pseudo-classe `:lang` est utilisée pour faire correspondre
 <div lang="de">
   <q>
     Cette citation allemande a
-      <q>une citation</q>
+    <q>une citation</q>
     imbriquée.
   </q>
 </div>
@@ -73,7 +73,7 @@ Dans cet exemple, la pseudo-classe `:lang` est utilisée pour faire correspondre
 <div lang="en">
   <q>
     Cette citation anglaise a
-      <q>une citation</q>
+    <q>une citation</q>
     imbriquée.
   </q>
 </div>

--- a/files/fr/web/css/_colon_last-child/index.md
+++ b/files/fr/web/css/_colon_last-child/index.md
@@ -37,8 +37,8 @@ li:last-child {
 
 ```html
 <ul>
-   <li>Cet élément n'est pas vert !</li>
-   <li>Celui-ci est vert.</li>
+  <li>Cet élément n'est pas vert !</li>
+  <li>Celui-ci est vert.</li>
 </ul>
 ```
 


### PR DESCRIPTION
This PR formats the `/web/css` folder of the French locale using Prettier.  This is the second part.
