### PR TITLE
fr: Format /web/css using Prettier (part 8)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -39,7 +39,6 @@ build/
 /files/es/web/javascript/reference/**/*.md
 
 # fr
-/files/fr/web/css/**/*.md
 /files/fr/web/javascript/**/*.md
 
 # ja

--- a/files/fr/web/css/_colon_-moz-broken/index.md
+++ b/files/fr/web/css/_colon_-moz-broken/index.md
@@ -13,7 +13,8 @@ Ce sélecteur est principalement destiné à être utilisé par les développeur
 ## Syntaxe
 
 ```css
-:-moz-broken {}
+:-moz-broken {
+}
 ```
 
 ## Exemples

--- a/files/fr/web/css/_colon_-moz-loading/index.md
+++ b/files/fr/web/css/_colon_-moz-loading/index.md
@@ -13,7 +13,8 @@ Cette pseudo-classe est principalement destinée aux développeurs de thèmes.
 ## Syntaxe
 
 ```css
-:-moz-loading {}
+:-moz-loading {
+}
 ```
 
 ## Exemples

--- a/files/fr/web/css/_colon_-moz-submit-invalid/index.md
+++ b/files/fr/web/css/_colon_-moz-submit-invalid/index.md
@@ -13,7 +13,8 @@ Par défaut, aucun style n'est appliqué. Vous pouvez utiliser cette pseudo-clas
 ## Syntaxe
 
 ```css
-:-moz-submit-invalid {}
+:-moz-submit-invalid {
+}
 ```
 
 ## Spécifications

--- a/files/fr/web/css/_colon_-moz-suppressed/index.md
+++ b/files/fr/web/css/_colon_-moz-suppressed/index.md
@@ -13,7 +13,8 @@ Ce sélecteur est principalement destiné aux développeurs de thèmes.
 ## Syntaxe
 
 ```css
-:-moz-suppressed {}
+:-moz-suppressed {
+}
 ```
 
 ## Exemple

--- a/files/fr/web/css/_colon_-moz-user-disabled/index.md
+++ b/files/fr/web/css/_colon_-moz-user-disabled/index.md
@@ -13,7 +13,8 @@ Ce sélecteur est destiné principalement à une utilisation par les développeu
 ## Syntaxe
 
 ```css
-:-moz-user-disabled {}
+:-moz-user-disabled {
+}
 ```
 
 ## Exemples

--- a/files/fr/web/css/_colon_focus-visible/index.md
+++ b/files/fr/web/css/_colon_focus-visible/index.md
@@ -15,7 +15,8 @@ On notera que Firefox prend en charge cette fonctionnalité via une ancienne pse
 ## Syntaxe
 
 ```css
-:focus-visible {}
+:focus-visible {
+}
 ```
 
 ## Exemples

--- a/files/fr/web/css/_colon_has/index.md
+++ b/files/fr/web/css/_colon_has/index.md
@@ -34,13 +34,15 @@ var test = document.querySelector("a:has(> img)");
 Dans l'exemple suivant, le sélecteur permet de cibler uniquement les éléments {{HTMLElement("a")}} qui contiennent un fils direct {{HTMLElement("img")}} :
 
 ```css
-a:has(> img) {}
+a:has(> img) {
+}
 ```
 
 Le sélecteur qui suit correspond aux éléments {{HTMLElement("h1")}} qui précèdent directement un élément {{HTMLElement("p")}} :
 
 ```css
-h1:has(+ p) {}
+h1:has(+ p) {
+}
 ```
 
 ## Spécifications

--- a/files/fr/web/css/_colon_host-context/index.md
+++ b/files/fr/web/css/_colon_host-context/index.md
@@ -41,8 +41,9 @@ p {
 
 ## Syntaxe
 
-```css
-:host-context( <selecteur-composite> ) {}
+```css-nolint
+:host-context(<selecteur-composite>) {
+}
 ```
 
 ## Exemples

--- a/files/fr/web/css/_colon_is/index.md
+++ b/files/fr/web/css/_colon_is/index.md
@@ -317,7 +317,8 @@ L'exemple ci-dessus ne sera pas appliqué par les navigateurs qui ne prennent pa
 Ainsi :
 
 ```css
-.a > :-moz-any(.b, .c) {}
+.a > :-moz-any(.b, .c) {
+}
 ```
 
 sera plus lent que

--- a/files/fr/web/css/_colon_not/index.md
+++ b/files/fr/web/css/_colon_not/index.md
@@ -64,9 +64,7 @@ body :not(.classy, p) {
 ```html
 <p>Un peu de texte.</p>
 <p class="classy">Encore du texte.</p>
-<span>
-  Et toujours du texte.
-</span>
+<span> Et toujours du texte. </span>
 ```
 
 ### Résultat

--- a/files/fr/web/css/_doublecolon_grammar-error/index.md
+++ b/files/fr/web/css/_doublecolon_grammar-error/index.md
@@ -30,7 +30,8 @@ Seul un sous-ensemble restreint de propriétés CSS peut être utilisé dans une
 ## Syntaxe
 
 ```css
-::grammar-error {}
+::grammar-error {
+}
 ```
 
 ## Exemples

--- a/files/fr/web/css/_doublecolon_spelling-error/index.md
+++ b/files/fr/web/css/_doublecolon_spelling-error/index.md
@@ -30,7 +30,8 @@ Seul un sous-ensemble restreint de propriétés CSS peut être utilisé dans une
 ## Syntaxe
 
 ```css
-::spelling-error {}
+::spelling-error {
+}
 ```
 
 ## Exemples

--- a/files/fr/web/css/counter/index.md
+++ b/files/fr/web/css/counter/index.md
@@ -61,7 +61,8 @@ li {
   counter-increment: listCounter;
 }
 li::after {
-  content: "[" counter(listCounter) "] == [" counter(listCounter, upper-roman) "]";
+  content: "[" counter(listCounter) "] == [" counter(listCounter, upper-roman)
+    "]";
 }
 ```
 

--- a/files/fr/web/css/pointer-events/index.md
+++ b/files/fr/web/css/pointer-events/index.md
@@ -106,7 +106,8 @@ Dans l'exemple qui suit, on désactive les événements de pointeur pour le lien
 #### CSS
 
 ```css
-a[href="http://example.com"] {
+a[href="http://example.com"]
+{
   pointer-events: none;
 }
 ```


### PR DESCRIPTION
This PR formats the `/web/css` folder of the French locale using Prettier.  This is the eighth part.
