### PR TITLE
ko: Format /web/api using Prettier (part 4)

### DIFF
--- a/files/ko/web/api/mediadevices/index.md
+++ b/files/ko/web/api/mediadevices/index.md
@@ -2,6 +2,7 @@
 title: MediaDevices
 slug: Web/API/MediaDevices
 ---
+
 {{APIRef("Media Capture and Streams")}}
 
 **`MediaDevices`** 인터페이스는 카메라, 마이크, 공유 화면 등 현재 연결된 미디어 입력 장치로의 접근 방법을 제공하는 인터페이스입니다. 다르게 말하자면, 미디어 데이터를 제공하는 모든 하드웨어로 접근할 수 있는 방법입니다.
@@ -25,42 +26,50 @@ slug: Web/API/MediaDevices
 ## 예제
 
 ```js
-'use strict';
+"use strict";
 
 // Put variables in global scope to make them available to the browser console.
-var video = document.querySelector('video');
-var constraints = window.constraints = {
+var video = document.querySelector("video");
+var constraints = (window.constraints = {
   audio: false,
-  video: true
-};
-var errorElement = document.querySelector('#errorMsg');
-
-navigator.mediaDevices.getUserMedia(constraints)
-.then(function(stream) {
-  var videoTracks = stream.getVideoTracks();
-  console.log('Got stream with constraints:', constraints);
-  console.log('Using video device: ' + videoTracks[0].label);
-  stream.onremovetrack = function() {
-    console.log('Stream ended');
-  };
-  window.stream = stream; // make variable available to browser console
-  video.srcObject = stream;
-})
-.catch(function(error) {
-  if (error.name === 'ConstraintNotSatisfiedError') {
-    errorMsg('The resolution ' + constraints.video.width.exact + 'x' +
-        constraints.video.width.exact + ' px is not supported by your device.');
-  } else if (error.name === 'PermissionDeniedError') {
-    errorMsg('Permissions have not been granted to use your camera and ' +
-      'microphone, you need to allow the page access to your devices in ' +
-      'order for the demo to work.');
-  }
-  errorMsg('getUserMedia error: ' + error.name, error);
+  video: true,
 });
+var errorElement = document.querySelector("#errorMsg");
+
+navigator.mediaDevices
+  .getUserMedia(constraints)
+  .then(function (stream) {
+    var videoTracks = stream.getVideoTracks();
+    console.log("Got stream with constraints:", constraints);
+    console.log("Using video device: " + videoTracks[0].label);
+    stream.onremovetrack = function () {
+      console.log("Stream ended");
+    };
+    window.stream = stream; // make variable available to browser console
+    video.srcObject = stream;
+  })
+  .catch(function (error) {
+    if (error.name === "ConstraintNotSatisfiedError") {
+      errorMsg(
+        "The resolution " +
+          constraints.video.width.exact +
+          "x" +
+          constraints.video.width.exact +
+          " px is not supported by your device.",
+      );
+    } else if (error.name === "PermissionDeniedError") {
+      errorMsg(
+        "Permissions have not been granted to use your camera and " +
+          "microphone, you need to allow the page access to your devices in " +
+          "order for the demo to work.",
+      );
+    }
+    errorMsg("getUserMedia error: " + error.name, error);
+  });
 
 function errorMsg(msg, error) {
-  errorElement.innerHTML += '<p>' + msg + '</p>';
-  if (typeof error !== 'undefined') {
+  errorElement.innerHTML += "<p>" + msg + "</p>";
+  if (typeof error !== "undefined") {
     console.error(error);
   }
 }

--- a/files/ko/web/api/mediastream_image_capture_api/index.md
+++ b/files/ko/web/api/mediastream_image_capture_api/index.md
@@ -2,6 +2,7 @@
 title: MediaStream Image Capture API
 slug: Web/API/MediaStream_Image_Capture_API
 ---
+
 {{DefaultAPISidebar("Image Capture API")}}
 
 **MediaStream Image Capture API**는 촬영 장치를 사용해 이미지와 비디오를 캡처하기 위한 API입니다. 그러나 데이터 캡처 외에도 이미지 해상도, 적목 현상 감소 기능, 플래시 존재 유무와 현재 사용 여부 등 장치 사양에 대한 정보를 가져올 때에도 사용할 수 있습니다. 거꾸로, Image Capture API를 사용하면 현재 장치의 허용 범위 안에서 해당 기능을 조정할 수도 있습니다.
@@ -13,10 +14,9 @@ slug: Web/API/MediaStream_Image_Capture_API
 우선, {{domxref("MediaDevices.getUserMedia()")}}를 사용해 장치를 가리키는 참조를 가져옵니다. 아래 코드는 단순히 사용 가능한 비디오 장치를 아무거나 요청하는 것이지만, `getUserMedia()` 메서드는더 상세한 장치 기능 요청도 허용합니다. 반환 값은 {{domxref("MediaStream")}} 객체로 이행하는 {{jsxref("Promise")}}입니다.
 
 ```js
-navigator.mediaDevices.getUserMedia({ video: true })
-  .then(mediaStream => {
-    // Do something with the stream.
-  })
+navigator.mediaDevices.getUserMedia({ video: true }).then((mediaStream) => {
+  // Do something with the stream.
+});
 ```
 
 그 후, {{domxref("MediaStream.getVideoTracks()")}}를 호출해 미디어 스트림에서 시각적인 부분을 분리합니다. `getVideoTracks()`의 반환 값은 {{domxref("MediaStreamTrack")}} 객체의 배열로, 여기서는 사용해야 할 객체를 배열의 첫 번째 요소라고 가정합니다. 실제 사용 시에는 `MediaStreamTrack` 객체의 속성을 사용해 원하는 객체를 찾을 수 있습니다.
@@ -28,13 +28,13 @@ const track = mediaStream.getVideoTracks()[0];
 이미지를 캡처하기 전에 우선 장치의 기능을 설정하고 싶을 것입니다. 다른 작업을 수행하기 전에, 트랙 객체의 {{domxref("MediaStreamTrack.applyConstraints","applyConstraints()")}} 메서드를 사용하면 됩니다.
 
 ```js
-let zoom = document.querySelector('#zoom');
+let zoom = document.querySelector("#zoom");
 const capabilities = track.getCapabilities();
 // 확대 지원 여부 판별
-if(!capabilities.zoom) {
+if (!capabilities.zoom) {
   return;
 }
-track.applyConstraints({ advanced : [{ zoom: zoom.value }] });
+track.applyConstraints({ advanced: [{ zoom: zoom.value }] });
 ```
 
 마지막으로, `MediaStreamTrack` 객체를 {{domxref("ImageCapture.ImageCapture()", "ImageCapture()")}} 생성자에 제공합니다. `MediaStream`은 여러 종류의 트랙을 담고 있으며 적절한 트랙을 가져올 때 사용할 수 있는 메서드를 소유하지만, `ImageCapture` 생성자는 {{domxref("MediaStreamTrack.kind")}}가 `"video"` 값이 아닌 경우 `NotSupportedError` {{domxref("DOMException")}}을 던집니다.

--- a/files/ko/web/api/mediastreamtrack/applyconstraints/index.md
+++ b/files/ko/web/api/mediastreamtrack/applyconstraints/index.md
@@ -2,6 +2,7 @@
 title: MediaStreamTrack.applyConstraints()
 slug: Web/API/MediaStreamTrack/applyConstraints
 ---
+
 {{APIRef("Media Capture and Streams")}}
 
 {{domxref("MediaStreamTrack")}} 인터페이스의 **`applyConstraints()`** 메서드는 트랙에 제약을 적용합니다. 제약을 통해 웹 사이트와 앱은 프레임 레이트, 해상도, 플래시 여부 등, 제약 가능한 속성을 자신이 바라는 이상적인 값과 허용 가능한 범위로 제한할 수 있습니다.
@@ -11,7 +12,7 @@ slug: Web/API/MediaStreamTrack/applyConstraints
 ## 구문
 
 ```js
-const appliedPromise = track.applyConstraints([constraints])
+const appliedPromise = track.applyConstraints([constraints]);
 ```
 
 ### 매개변수
@@ -29,24 +30,21 @@ const appliedPromise = track.applyConstraints([constraints])
 
 ```js
 const constraints = {
-  width: {min: 640, ideal: 1280},
-  height: {min: 480, ideal: 720},
-  advanced: [
-    {width: 1920, height: 1280},
-    {aspectRatio: 1.333}
-  ]
+  width: { min: 640, ideal: 1280 },
+  height: { min: 480, ideal: 720 },
+  advanced: [{ width: 1920, height: 1280 }, { aspectRatio: 1.333 }],
 };
 
-navigator.mediaDevices.getUserMedia({ video: true })
-.then(mediaStream => {
+navigator.mediaDevices.getUserMedia({ video: true }).then((mediaStream) => {
   const track = mediaStream.getVideoTracks()[0];
-  track.applyConstraints(constraints)
-  .then(() => {
-    // Do something with the track such as using the Image Capture API.
-  })
-  .catch(e => {
-    // The constraints could not be satisfied by the available devices.
-  });
+  track
+    .applyConstraints(constraints)
+    .then(() => {
+      // Do something with the track such as using the Image Capture API.
+    })
+    .catch((e) => {
+      // The constraints could not be satisfied by the available devices.
+    });
 });
 ```
 

--- a/files/ko/web/api/mediastreamtrack/clone/index.md
+++ b/files/ko/web/api/mediastreamtrack/clone/index.md
@@ -10,7 +10,7 @@ slug: Web/API/MediaStreamTrack/clone
 ## 구문
 
 ```js
-const newTrack = track.clone()
+const newTrack = track.clone();
 ```
 
 ### 반환 값

--- a/files/ko/web/api/mediastreamtrack/enabled/index.md
+++ b/files/ko/web/api/mediastreamtrack/enabled/index.md
@@ -2,6 +2,7 @@
 title: MediaStreamTrack.enabled
 slug: Web/API/MediaStreamTrack/enabled
 ---
+
 {{APIRef("Media Capture and Streams")}}
 
 {{domxref("MediaStreamTrack")}} 인터페이스의 **`enabled`** 속성은 트랙이 소스 스트림을 렌더링 할 수 있으면 `true`, 아니면 `false`를 반환합니다. `enabled` 속성을 사용해 음소거 기능을 구현할 수 있습니다. 활성화된 경우 트랙의 데이터는 입력에서 목적지로 출력됩니다. 비활성 상태에서는 빈 프레임만 출력합니다.
@@ -15,8 +16,8 @@ slug: Web/API/MediaStreamTrack/enabled
 ## 구문
 
 ```js
-const enabledFlag = track.enabled
-track.enabled = [true | false]
+const enabledFlag = track.enabled;
+track.enabled = [true | false];
 ```
 
 ### 값
@@ -34,12 +35,12 @@ track.enabled = [true | false]
 다음 코드는 [`click`](/ko/docs/Web/API/Element/click_event) 이벤트 처리기를 사용해 일시정지를 구현합니다.
 
 ```js
-pauseButton.onclick = function(evt) {
+pauseButton.onclick = function (evt) {
   const newState = !myAudioTrack.enabled;
 
   pauseButton.innerHTML = newState ? "&#x25B6;&#xFE0F;" : "&#x23F8;&#xFE0F;";
   myAudioTrack.enabled = newState;
-}
+};
 ```
 
 ## 명세

--- a/files/ko/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/ko/web/api/mediastreamtrack/getcapabilities/index.md
@@ -12,7 +12,7 @@ slug: Web/API/MediaStreamTrack/getCapabilities
 ## 구문
 
 ```js
-const capabilities = track.getCapabilities()
+const capabilities = track.getCapabilities();
 ```
 
 ### 반환 값

--- a/files/ko/web/api/mediastreamtrack/getconstraints/index.md
+++ b/files/ko/web/api/mediastreamtrack/getconstraints/index.md
@@ -12,7 +12,7 @@ slug: Web/API/MediaStreamTrack/getConstraints
 ## 구문
 
 ```js
-const constraints = track.getConstraints()
+const constraints = track.getConstraints();
 ```
 
 ### 반환 값

--- a/files/ko/web/api/mediastreamtrack/getsettings/index.md
+++ b/files/ko/web/api/mediastreamtrack/getsettings/index.md
@@ -10,7 +10,7 @@ slug: Web/API/MediaStreamTrack/getSettings
 ## 구문
 
 ```js
-const settings = track.getSettings()
+const settings = track.getSettings();
 ```
 
 ### 반환 값

--- a/files/ko/web/api/mediastreamtrack/id/index.md
+++ b/files/ko/web/api/mediastreamtrack/id/index.md
@@ -2,6 +2,7 @@
 title: MediaStreamTrack.id
 slug: Web/API/MediaStreamTrack/id
 ---
+
 {{APIRef("Media Capture and Streams")}}
 
 **`MediaStreamTrack.id`** 읽기 전용 속성은 {{glossary("user agent", "사용자 에이전트")}}가 생성하는, 트랙의 전역 고유 식별자(GUID)를 담은 {{domxref("DOMString")}}을 반환합니다.
@@ -9,7 +10,7 @@ slug: Web/API/MediaStreamTrack/id
 ## 구문
 
 ```js
-const id = track.id
+const id = track.id;
 ```
 
 ## 명세

--- a/files/ko/web/api/mediastreamtrack/index.md
+++ b/files/ko/web/api/mediastreamtrack/index.md
@@ -2,6 +2,7 @@
 title: MediaStreamTrack
 slug: Web/API/MediaStreamTrack
 ---
+
 {{APIRef("Media Capture and Streams")}}
 
 **`MediaStreamTrack`** 인터페이스는 스트림 내의 단일 미디어 트랙을 나타냅니다. 보통 오디오와 비디오 트랙이지만, 다른 종류도 존재할 수 있습니다.

--- a/files/ko/web/api/mediastreamtrack/kind/index.md
+++ b/files/ko/web/api/mediastreamtrack/kind/index.md
@@ -10,7 +10,7 @@ slug: Web/API/MediaStreamTrack/kind
 ## 구문
 
 ```js
-const type = track.kind
+const type = track.kind;
 ```
 
 ### 값

--- a/files/ko/web/api/mediastreamtrack/label/index.md
+++ b/files/ko/web/api/mediastreamtrack/label/index.md
@@ -2,6 +2,7 @@
 title: MediaStreamTrack.label
 slug: Web/API/MediaStreamTrack/label
 ---
+
 {{APIRef("Media Capture and Streams")}}
 
 **`MediaStreamTrack.label`** 읽기 전용 속성은 {{glossary("user agent", "사용자 에이전트")}}가 트랙 소스를 식별하기 위해 지정한 레이블을 담은 {{domxref("DOMString")}}을 반환합니다. 소스가 연결되지 않은 경우 빈 문자열이며, 연결됐던 트랙이 소스에서 분리되더라도 레이블은 바뀌지 않습니다.
@@ -9,7 +10,7 @@ slug: Web/API/MediaStreamTrack/label
 ## 구문
 
 ```js
-const label = track.label
+const label = track.label;
 ```
 
 ### 값

--- a/files/ko/web/api/mediastreamtrack/muted/index.md
+++ b/files/ko/web/api/mediastreamtrack/muted/index.md
@@ -12,7 +12,7 @@ slug: Web/API/MediaStreamTrack/muted
 ## 구문
 
 ```js
-const mutedFlag = track.muted
+const mutedFlag = track.muted;
 ```
 
 ### 값

--- a/files/ko/web/api/mediastreamtrack/readystate/index.md
+++ b/files/ko/web/api/mediastreamtrack/readystate/index.md
@@ -10,7 +10,7 @@ slug: Web/API/MediaStreamTrack/readyState
 ## 구문
 
 ```js
-const state = track.readyState
+const state = track.readyState;
 ```
 
 ### 값

--- a/files/ko/web/api/mediastreamtrack/stop/index.md
+++ b/files/ko/web/api/mediastreamtrack/stop/index.md
@@ -10,7 +10,7 @@ slug: Web/API/MediaStreamTrack/stop
 ## 구문
 
 ```js
-track.stop()
+track.stop();
 ```
 
 ## 설명
@@ -30,7 +30,7 @@ function stopStreamedVideo(videoElem) {
   const stream = videoElem.srcObject;
   const tracks = stream.getTracks();
 
-  tracks.forEach(function(track) {
+  tracks.forEach(function (track) {
     track.stop();
   });
 

--- a/files/ko/web/api/messageevent/index.md
+++ b/files/ko/web/api/messageevent/index.md
@@ -2,6 +2,7 @@
 title: MessageEvent
 slug: Web/API/MessageEvent
 ---
+
 {{APIRef("HTML DOM")}}
 
 **`MessageEvent`** 는 {{domxref("WebSocket")}} 또는 WebRTC {{domxref("RTCDataChannel")}} 으로 된 타겟으로 부터 전달받은 메시지를 보여주는 interface 입니다.

--- a/files/ko/web/api/mouseevent/clientx/index.md
+++ b/files/ko/web/api/mouseevent/clientx/index.md
@@ -2,6 +2,7 @@
 title: MouseEvent.clientX
 slug: Web/API/MouseEvent/clientX
 ---
+
 {{{APIRef("DOM 이벤트")}}
 {{domxref("MouseEvent")}}} 인터페이스의 clientX 읽기 전용 속성은 이벤트가 발생한 애플리케이션 {{glossary("viewport")}}}} 내에 수평 좌표를 제공한다(페이지 내의 좌표와는 반대).
 
@@ -10,7 +11,7 @@ slug: Web/API/MouseEvent/clientX
 ## Syntax
 
 ```js
-var x = instanceOfMouseEvent.clientX
+var x = instanceOfMouseEvent.clientX;
 ```
 
 ### Return value
@@ -31,8 +32,8 @@ CSSOM 뷰 모듈에 의해 재정의된 이중 부동 소수점 값. 원래 이 
 ### JavaScript
 
 ```js
-let screenLog = document.querySelector('#screen-log');
-document.addEventListener('mousemove', logKey);
+let screenLog = document.querySelector("#screen-log");
+document.addEventListener("mousemove", logKey);
 
 function logKey(e) {
   screenLog.innerText = `

--- a/files/ko/web/api/mutationobserver/observe/index.md
+++ b/files/ko/web/api/mutationobserver/observe/index.md
@@ -93,7 +93,7 @@ const observer = new MutationObserver(() => {
   console.log("callback that runs when observer is triggered");
 });
 
-// 
+//
 // 위 MutationObserver 인스턴스의 observe() 메서드를 호출
 // 주시할 요소와 옵션 객체 전달
 observer.observe(elementToObserve, { subtree: true, childList: true });

--- a/files/ko/web/api/navigator/connection/index.md
+++ b/files/ko/web/api/navigator/connection/index.md
@@ -3,6 +3,7 @@ title: window.navigator.connection
 slug: Web/API/Navigator/connection
 original_slug: Web/API/NetworkInformation/connection
 ---
+
 {{ Apiref() }}
 
 {{ SeeCompatTable() }}

--- a/files/ko/web/api/navigator/geolocation/index.md
+++ b/files/ko/web/api/navigator/geolocation/index.md
@@ -5,6 +5,7 @@ slug: Web/API/Navigator/geolocation
 l10n:
   sourceCommit: ef75c1741b450c2331204be5563ee964ad5f4c48
 ---
+
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 
 **`Navigator.geolocation`** 읽기 전용 속성은 웹에서 장치의 위치를 알아낼 때 사용할 수 있는 {{domxref("Geolocation")}} 객체를 반환합니다. 웹 사이트나 웹 앱은 위치정보를 사용해 결과 화면을 맞춤 설정할 수 있습니다.

--- a/files/ko/web/api/navigator/getbattery/index.md
+++ b/files/ko/web/api/navigator/getbattery/index.md
@@ -3,6 +3,7 @@ title: window.navigator.battery
 slug: Web/API/Navigator/getBattery
 original_slug: Web/API/Navigator/battery
 ---
+
 {{ Apiref() }}
 
 `battery` 객체는 시스템의 배터리 충전 상태에 대한 정보를 제공합니다. 배터리의 충전 상태가 변화할때 발생하는 이벤트에 대한 처리도 가능 합니다. 이 객체는 [Battery Status API](/ko/docs/Web/API/Battery_Status_API) 의 구현입니다. 보다 자세한 내용, API, 샘플 코드 등은 문서를 참고 해 주세요.

--- a/files/ko/web/api/navigator/language/index.md
+++ b/files/ko/web/api/navigator/language/index.md
@@ -10,7 +10,7 @@ slug: Web/API/Navigator/language
 ## 구문
 
 ```js
-const lang = navigator.language
+const lang = navigator.language;
 ```
 
 ### 값

--- a/files/ko/web/api/navigator/mediadevices/index.md
+++ b/files/ko/web/api/navigator/mediadevices/index.md
@@ -2,6 +2,7 @@
 title: Navigator.mediaDevices
 slug: Web/API/Navigator/mediaDevices
 ---
+
 {{APIRef("Media Capture and Streams")}}
 
 **`Navigator.mediaDevices`** 읽기 전용 속성은 카메라, 마이크, 화면 공유와 같이 현재 연결된 미디어 입력 장치에 접근할 수 있는 {{domxref("MediaDevices")}} 객체를 반환합니다.

--- a/files/ko/web/api/navigator/online/index.md
+++ b/files/ko/web/api/navigator/online/index.md
@@ -18,7 +18,7 @@ In progress [Firefox 3](/ko/Firefox_3_for_developers)는 [WHATWG 웹 애플리�
 여러분의 웹 애플리케이션은 특정 문서가 오프라인 자원 캐시에 보관되는 것을 확실하게 할 필요도 있습니다. 이를 위해서는 다음과 같이 `HEAD` 섹션에 `LINK` 요소를 포함합니다.
 
 ```html
-<link rel="offline-resource" href="myresource">
+<link rel="offline-resource" href="myresource" />
 ```
 
 이는 Firefox 3 및 이후 버전에서 HTML을 처리할 때, 참조하는 자원을 오프라인에서 사용할 수 있도록 특별한 오프라인 자원 캐시에 저장하도록 합니다.
@@ -54,33 +54,47 @@ Firefox 2는 윈도우와 리눅스에서 브라우저의 온라인/오프라인
 ```html
 <!doctype html>
 <html>
-<head>
-  <script>
-    function updateOnlineStatus(msg) {
-      var status = document.getElementById("status");
-      var condition = navigator.onLine ? "ONLINE" : "OFFLINE";
-      status.setAttribute("class", condition);
-      var state = document.getElementById("state");
-      state.innerHTML = condition;
-      var log = document.getElementById("log");
-      log.appendChild(document.createTextNode("Event: " + msg + "; status=" + condition + "\n"));
-    }
-    function loaded() {
-      updateOnlineStatus("load");
-      document.body.addEventListener("offline", function () {
-        updateOnlineStatus("offline")
-      }, false);
-      document.body.addEventListener("online", function () {
-        updateOnlineStatus("online")
-      }, false);
-    }
-  </script>
-  <style>...</style>
-</head>
-<body onload="loaded()">
-  <div id="status"><p id="state"></p></div>
-  <div id="log"></div>
-</body>
+  <head>
+    <script>
+      function updateOnlineStatus(msg) {
+        var status = document.getElementById("status");
+        var condition = navigator.onLine ? "ONLINE" : "OFFLINE";
+        status.setAttribute("class", condition);
+        var state = document.getElementById("state");
+        state.innerHTML = condition;
+        var log = document.getElementById("log");
+        log.appendChild(
+          document.createTextNode(
+            "Event: " + msg + "; status=" + condition + "\n",
+          ),
+        );
+      }
+      function loaded() {
+        updateOnlineStatus("load");
+        document.body.addEventListener(
+          "offline",
+          function () {
+            updateOnlineStatus("offline");
+          },
+          false,
+        );
+        document.body.addEventListener(
+          "online",
+          function () {
+            updateOnlineStatus("online");
+          },
+          false,
+        );
+      }
+    </script>
+    <style>
+      ...
+    </style>
+  </head>
+  <body onload="loaded()">
+    <div id="status"><p id="state"></p></div>
+    <div id="log"></div>
+  </body>
 </html>
 ```
 

--- a/files/ko/web/api/navigator/registerprotocolhandler/index.md
+++ b/files/ko/web/api/navigator/registerprotocolhandler/index.md
@@ -72,9 +72,11 @@ navigator.registerProtocolHandler(protocol, url, title);
 사이트 주소가 `burgers.example.com`인 경우, 아래 코드로 `web+burger:` 스킴에 대한 처리기를 등록할 수 있습니다.
 
 ```js
-navigator.registerProtocolHandler("web+burger",
-                                  "https://burgers.example.com/?burger=%s",
-                                  "Burger handler");
+navigator.registerProtocolHandler(
+  "web+burger",
+  "https://burgers.example.com/?burger=%s",
+  "Burger handler",
+);
 ```
 
 이제, `web+burger:` 링크는 사용자를 `burgers.example.com`로 보내고, 자신의 URL을 `%s` 위치에 삽입합니다.

--- a/files/ko/web/api/navigator/share/index.md
+++ b/files/ko/web/api/navigator/share/index.md
@@ -32,8 +32,8 @@ var sharePromise = window.navigator.share(data);
 ```js
 navigator.share({
   title: document.title,
-  text: 'Hello World',
-  url: 'https://developer.mozilla.org',
+  text: "Hello World",
+  url: "https://developer.mozilla.org",
 }); // share the URL of MDN
 ```
 

--- a/files/ko/web/api/network_information_api/index.md
+++ b/files/ko/web/api/network_information_api/index.md
@@ -12,7 +12,8 @@ slug: Web/API/Network_Information_API
 이 예제는 사용자의 연결상태 변화를 감시합니다. 사용자가 비싼 망에서 싼 망으로 이동할 때 사용자가 추가적인 비용을 지불하지 않게 하기 위해서 전송량을 감소시키는 등과 같은 행동을 할 수 있게 앱이 경고를 하는 일과 비슷합니다.
 
 ```js
-var connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+var connection =
+  navigator.connection || navigator.mozConnection || navigator.webkitConnection;
 
 function updateConnectionStatus() {
   alert("Connection bandwidth: " + connection.bandwidth + " MB/s");

--- a/files/ko/web/api/node/appendchild/index.md
+++ b/files/ko/web/api/node/appendchild/index.md
@@ -2,6 +2,7 @@
 title: Node.appendChild()
 slug: Web/API/Node/appendChild
 ---
+
 {{APIRef("DOM")}}
 
 **`Node.appendChild()`** 메소드는 한 노드를 특정 부모 노드의 자식 노드 리스트 중 마지막 자식으로 붙입니다. 만약 주어진 노드가 이미 문서에 존재하는 노드를 참조하고 있다면 `appendChild()` 메소드는 노드를 현재 위치에서 새로운 위치로 이동시킵니다. (문서에 존재하는 노드를 다른 곳으로 붙이기 전에 부모 노드로 부터 지워버릴 필요는 없습니다.)

--- a/files/ko/web/api/node/childnodes/index.md
+++ b/files/ko/web/api/node/childnodes/index.md
@@ -25,24 +25,21 @@ var ndList = elementNodeReference.childNodes;
 
 ```js
 // parg는 <p> 요소 개체 참조
-if (parg.hasChildNodes())
-// 그래서, 먼저 개체가 찼는 지(자식 노드가 있는 지) 검사
-  {
-    var children = parg.childNodes;
-    for (var i = 0; i < children.length; i++)
-    {
+if (parg.hasChildNodes()) {
+  // 그래서, 먼저 개체가 찼는 지(자식 노드가 있는 지) 검사
+  var children = parg.childNodes;
+  for (var i = 0; i < children.length; i++) {
     // children[i]로 각 자식에 무언가를 함
     // 주의: 목록은 유효해(live), 자식 추가나 제거는 목록을 바꿈
-    };
-  };
+  }
+}
 
 // This는 노드에서 모든 자식을 제거하는 한 방법
 // box는 자식 있는 요소 개체 참조
-while (box.firstChild)
-  {
-    //목록은 유효해서(LIVE) 호출마다 재배열(re-index)함
-    box.removeChild(box.firstChild);
-  };
+while (box.firstChild) {
+  //목록은 유효해서(LIVE) 호출마다 재배열(re-index)함
+  box.removeChild(box.firstChild);
+}
 ```
 
 ## 명세

--- a/files/ko/web/api/node/contains/index.md
+++ b/files/ko/web/api/node/contains/index.md
@@ -10,7 +10,7 @@ slug: Web/API/Node/contains
 ## Syntax
 
 ```js
-node.contains( otherNode )
+node.contains(otherNode);
 ```
 
 ## Example
@@ -19,7 +19,7 @@ node.contains( otherNode )
 
 ```js
 function isInPage(node) {
-  return (node === document.body) ? false : document.body.contains(node);
+  return node === document.body ? false : document.body.contains(node);
 }
 ```
 

--- a/files/ko/web/api/node/firstchild/index.md
+++ b/files/ko/web/api/node/firstchild/index.md
@@ -27,8 +27,8 @@ childNode = node.firstChild;
 </p>
 
 <script type="text/javascript">
-  var p01 = document.getElementById('para-01');
-  alert(p01.firstChild.nodeName)
+  var p01 = document.getElementById("para-01");
+  alert(p01.firstChild.nodeName);
 </script>
 ```
 
@@ -42,8 +42,8 @@ childNode = node.firstChild;
 <p id="para-01"><span>First span</span></p>
 
 <script type="text/javascript">
-  var p01 = document.getElementById('para-01');
-  alert(p01.firstChild.nodeName)
+  var p01 = document.getElementById("para-01");
+  alert(p01.firstChild.nodeName);
 </script>
 ```
 

--- a/files/ko/web/api/node/haschildnodes/index.md
+++ b/files/ko/web/api/node/haschildnodes/index.md
@@ -10,7 +10,7 @@ slug: Web/API/Node/hasChildNodes
 ## 구문
 
 ```js
-node.hasChildNodes()
+node.hasChildNodes();
 ```
 
 ## 예시
@@ -20,8 +20,8 @@ node.hasChildNodes()
 ```js
 var foo = document.getElementById("foo");
 
-if ( foo.hasChildNodes() ) {
-  foo.removeChild( foo.childNodes[0] );
+if (foo.hasChildNodes()) {
+  foo.removeChild(foo.childNodes[0]);
 }
 ```
 

--- a/files/ko/web/api/node/index.md
+++ b/files/ko/web/api/node/index.md
@@ -2,6 +2,7 @@
 title: Node
 slug: Web/API/Node
 ---
+
 {{APIRef("DOM")}}
 
 **`Node`** 는 여러 가지 DOM 타입들이 상속하는 인터페이스이며 그 다양한 타입들을 비슷하게 처리할 수 있게 한다. 예를들어, 똑같은 메소드를 상속하거나 똑같은 방식으로 테스트를 할수있다
@@ -40,17 +41,17 @@ _부모인 {{domxref("EventTarget")}}으로부터 프라퍼티를 상속한다_.
   - | : Returns an `unsigned short` representing the type of the node. Possible values are: | Name | Value |
     | ------------------------------------------------------------------------------------- | ---- | ----- |
     | `ELEMENT_NODE`                                                                        | `1`  |
-    | `ATTRIBUTE_NODE` {{deprecated_inline()}}                                     | `2`  |
+    | `ATTRIBUTE_NODE` {{deprecated_inline()}}                                              | `2`  |
     | `TEXT_NODE`                                                                           | `3`  |
-    | `CDATA_SECTION_NODE` {{deprecated_inline()}}                                 | `4`  |
-    | `ENTITY_REFERENCE_NODE` {{deprecated_inline()}}                              | `5`  |
-    | `ENTITY_NODE` {{deprecated_inline()}}                                        | `6`  |
+    | `CDATA_SECTION_NODE` {{deprecated_inline()}}                                          | `4`  |
+    | `ENTITY_REFERENCE_NODE` {{deprecated_inline()}}                                       | `5`  |
+    | `ENTITY_NODE` {{deprecated_inline()}}                                                 | `6`  |
     | `PROCESSING_INSTRUCTION_NODE`                                                         | `7`  |
     | `COMMENT_NODE`                                                                        | `8`  |
     | `DOCUMENT_NODE`                                                                       | `9`  |
     | `DOCUMENT_TYPE_NODE`                                                                  | `10` |
     | `DOCUMENT_FRAGMENT_NODE`                                                              | `11` |
-    | `NOTATION_NODE` {{deprecated_inline()}}                                      | `12` |
+    | `NOTATION_NODE` {{deprecated_inline()}}                                               | `12` |
 - {{domxref("Node.nodeValue")}}
   - : Is a {{domxref("DOMString")}} representing the value of an object. For most `Node` type, this returns `null` and any set operation is ignored. For nodes of type `TEXT_NODE` ({{domxref("Text")}} objects), `COMMENT_NODE` ({{domxref("Comment")}} objects), and `PROCESSING_INSTRUCTION_NODE` ({{domxref("ProcessingInstruction")}} objects), the value corresponds to the text data contained in the object.
 - {{domxref("Node.ownerDocument")}} {{readonlyInline}}
@@ -128,7 +129,7 @@ _부모인 {{domxref("EventTarget")}}으로부터 메소드를 상속한다_.\[1
 The following function recursively cycles all child nodes of a node and executes a callback function upon them (and upon the parent node itself).
 
 ```js
-function DOMComb (oParent, oCallback) {
+function DOMComb(oParent, oCallback) {
   if (oParent.hasChildNodes()) {
     for (var oNode = oParent.firstChild; oNode; oNode = oNode.nextSibling) {
       DOMComb(oNode, oCallback);
@@ -160,8 +161,10 @@ Recursively cycle all child nodes of `parentNode` and `parentNode` itself and ex
 The following example send to the `console.log` the text content of the body:
 
 ```js
-function printContent () {
-  if (this.nodeValue) { console.log(this.nodeValue); }
+function printContent() {
+  if (this.nodeValue) {
+    console.log(this.nodeValue);
+  }
 }
 
 onload = function () {
@@ -173,7 +176,9 @@ onload = function () {
 
 ```js
 Element.prototype.removeAll = function () {
-  while (this.firstChild) { this.removeChild(this.firstChild); }
+  while (this.firstChild) {
+    this.removeChild(this.firstChild);
+  }
   return this;
 };
 ```

--- a/files/ko/web/api/node/insertbefore/index.md
+++ b/files/ko/web/api/node/insertbefore/index.md
@@ -2,6 +2,7 @@
 title: Node.insertBefore()
 slug: Web/API/Node/insertBefore
 ---
+
 {{APIRef("DOM")}}
 
 **`Node.insertBefore()`** 메소드는 참조된 노드 앞에 특정 부모 노드의 자식 노드를 삽입합니다. 만약 주어진 자식 노드가 document에 존재하는 노드를 참조한다면, `insertBefore()` 가 자식 노드를 현재 위치에서 새로운 위치로 옮깁니다. (노드를 다른 노드에 추가하기 전에 상위 노드에서 제거할 필요가 없습니다)
@@ -30,30 +31,30 @@ var insertedNode = parentNode.insertBefore(newNode, referenceNode);
 
 ```html
 <div id="parentElement">
-   <span id="childElement">foo bar</span>
+  <span id="childElement">foo bar</span>
 </div>
 
 <script>
-// Create the new node to insert
-var newNode = document.createElement("span");
+  // Create the new node to insert
+  var newNode = document.createElement("span");
 
-// Get a reference to the parent node
-var parentDiv = document.getElementById("childElement").parentNode;
+  // Get a reference to the parent node
+  var parentDiv = document.getElementById("childElement").parentNode;
 
-// Begin test case [ 1 ] : Exist a childElement --> All working correctly
-var sp2 = document.getElementById("childElement");
-parentDiv.insertBefore(newNode, sp2);
-// End test case [ 1 ]
+  // Begin test case [ 1 ] : Exist a childElement --> All working correctly
+  var sp2 = document.getElementById("childElement");
+  parentDiv.insertBefore(newNode, sp2);
+  // End test case [ 1 ]
 
-// Begin test case [ 2 ] : childElement is of Type undefined
-var sp2 = undefined; // Not exist a node of id "childElement"
-parentDiv.insertBefore(newNode, sp2); // Implicit dynamic cast to type Node
-// End test case [ 2 ]
+  // Begin test case [ 2 ] : childElement is of Type undefined
+  var sp2 = undefined; // Not exist a node of id "childElement"
+  parentDiv.insertBefore(newNode, sp2); // Implicit dynamic cast to type Node
+  // End test case [ 2 ]
 
-// Begin test case [ 3 ] : childElement is of Type "undefined" ( string )
-var sp2 = "undefined"; // Not exist a node of id "childElement"
-parentDiv.insertBefore(newNode, sp2); // Generate "Type Error: Invalid Argument"
-// End test case [ 3 ]
+  // Begin test case [ 3 ] : childElement is of Type "undefined" ( string )
+  var sp2 = "undefined"; // Not exist a node of id "childElement"
+  parentDiv.insertBefore(newNode, sp2); // Generate "Type Error: Invalid Argument"
+  // End test case [ 3 ]
 </script>
 ```
 
@@ -70,16 +71,16 @@ parentDiv.insertBefore(newNode, sp2); // Generate "Type Error: Invalid Argument"
 </div>
 
 <script>
-// Create a new, plain <span> element
-var sp1 = document.createElement("span");
+  // Create a new, plain <span> element
+  var sp1 = document.createElement("span");
 
-// Get a reference to the element, before we want to insert the element
-var sp2 = document.getElementById("childElement");
-// Get a reference to the parent element
-var parentDiv = sp2.parentNode;
+  // Get a reference to the element, before we want to insert the element
+  var sp2 = document.getElementById("childElement");
+  // Get a reference to the parent element
+  var parentDiv = sp2.parentNode;
 
-// Insert the new element into the DOM before sp2
-parentDiv.insertBefore(sp1, sp2);
+  // Insert the new element into the DOM before sp2
+  parentDiv.insertBefore(sp1, sp2);
 </script>
 ```
 
@@ -99,7 +100,7 @@ Insert an element before the first child element, using the [firstChild](/ko/doc
 
 ```js
 // Get a reference to the element in which we want to insert a new node
-var parentElement = document.getElementById('parentElement');
+var parentElement = document.getElementById("parentElement");
 // Get a reference to the first child
 var theFirstChild = parentElement.firstChild;
 

--- a/files/ko/web/api/node/lastchild/index.md
+++ b/files/ko/web/api/node/lastchild/index.md
@@ -12,7 +12,7 @@ slug: Web/API/Node/lastChild
 ## 구문과 값
 
 ```js
-last_child = element.lastChild
+last_child = element.lastChild;
 ```
 
 반환되는 `last_child`는 노드입니다. 노드의 부모가 요소이면, 자식은 보통 요소 노드, 텍스트 노드, 주석 노드입니다.

--- a/files/ko/web/api/node/nextsibling/index.md
+++ b/files/ko/web/api/node/nextsibling/index.md
@@ -2,6 +2,7 @@
 title: Node.nextSibling
 slug: Web/API/Node/nextSibling
 ---
+
 {{APIRef("DOM")}}
 
 읽기 전용 속성인 **`Node.nextSibling`** 은 부모의 {{domxref("Node.childNodes","childNodes")}} 목록에서 지정된 노드 바로 다음에 있는 노드를 반환하거나 지정된 노드가 해당 목록의 마지막 노드이면 `null` 값을 반환합니다.
@@ -9,7 +10,7 @@ slug: Web/API/Node/nextSibling
 ## Syntax
 
 ```js
-nextNode = node.nextSibling
+nextNode = node.nextSibling;
 ```
 
 ## Notes
@@ -28,29 +29,20 @@ Gecko 기반 브라우저는 소스 마크업에서 공백을 나타내기 위�
 <div id="div-02">Here is div-02</div>
 
 <script type="text/javascript">
-var el = document.getElementById('div-01').nextSibling,
+  var el = document.getElementById("div-01").nextSibling,
     i = 1;
 
-console.log('Siblings of div-01:');
+  console.log("Siblings of div-01:");
 
-while (el) {
-  console.log(i + '. ' + el.nodeName);
-  el = el.nextSibling;
-  i++;
-}
-
+  while (el) {
+    console.log(i + ". " + el.nodeName);
+    el = el.nextSibling;
+    i++;
+  }
 </script>
 
-/**************************************************
-   로드될 때 다음과 같이 콘솔에 기록됩니다. :
-
-     Siblings of div-01
-
-      1. #text
-      2. DIV
-      3. #text
-      4. SCRIPT
-
+/************************************************** 로드될 때 다음과 같이 콘솔에
+기록됩니다. : Siblings of div-01 1. #text 2. DIV 3. #text 4. SCRIPT
 **************************************************/
 ```
 

--- a/files/ko/web/api/node/normalize/index.md
+++ b/files/ko/web/api/node/normalize/index.md
@@ -2,6 +2,7 @@
 title: Node.normalize()
 slug: Web/API/Node/normalize
 ---
+
 {{APIRef("DOM")}}
 
 **`Node.normalize()`** 메소드는 지정된 노드와 하위 트리의 모든 노드를 "정규화된" 형태로 놓습니다. 정규화된 하위 트리의 텍스트 노드는 비어있지 않으며 인접한 텍스트 노드도 존재하지 않습니다.
@@ -17,8 +18,8 @@ element.normalize();
 ```js
 var wrapper = document.createElement("div");
 
-wrapper.appendChild( document.createTextNode("Part 1 ") );
-wrapper.appendChild( document.createTextNode("Part 2 ") );
+wrapper.appendChild(document.createTextNode("Part 1 "));
+wrapper.appendChild(document.createTextNode("Part 2 "));
 
 // 이 때, wrapper.childNodes.length === 2
 // wrapper.childNodes[0].textContent === "Part 1 "

--- a/files/ko/web/api/node/ownerdocument/index.md
+++ b/files/ko/web/api/node/ownerdocument/index.md
@@ -10,7 +10,7 @@ slug: Web/API/Node/ownerDocument
 ## Syntax
 
 ```js
-document = element.ownerDocument
+document = element.ownerDocument;
 ```
 
 - `document` 는 element 의 부모 [`document`](/ko/docs/DOM/document) 객체입니다.

--- a/files/ko/web/api/node/replacechild/index.md
+++ b/files/ko/web/api/node/replacechild/index.md
@@ -2,6 +2,7 @@
 title: Node.replaceChild()
 slug: Web/API/Node/replaceChild
 ---
+
 {{APIRef("DOM")}}
 
 **`Node.replaceChild()`** 메소드는 특정 부모 노드의 한 자식 노드를 다른 노드로 교체합니다.

--- a/files/ko/web/api/node/textcontent/index.md
+++ b/files/ko/web/api/node/textcontent/index.md
@@ -2,6 +2,7 @@
 title: Node.textContent
 slug: Web/API/Node/textContent
 ---
+
 {{APIRef("DOM")}}
 
 {{domxref("Node")}} 인터페이스의 **`textContent`** 속성은 노드와 그 자손의 텍스트 콘텐츠를 표현합니다.
@@ -11,8 +12,8 @@ slug: Web/API/Node/textContent
 ## 구문
 
 ```js
-let text = someNode.textContent
-someOtherNode.textContent = string
+let text = someNode.textContent;
+someOtherNode.textContent = string;
 ```
 
 ### 값
@@ -60,14 +61,14 @@ someOtherNode.textContent = string
 `textContent`를 사용해 요소의 텍스트 콘텐츠를 가져오거나...
 
 ```js
-let text = document.getElementById('divA').textContent;
+let text = document.getElementById("divA").textContent;
 // The text variable is now: 'This is some text!'
 ```
 
 텍스트 내용을 설정할 수 있습니다.
 
 ```js
-document.getElementById('divA').textContent = 'This text is different!';
+document.getElementById("divA").textContent = "This text is different!";
 // The HTML for divA is now:
 // <div id="divA">This text is different!</div>
 ```

--- a/files/ko/web/api/nodelist/entries/index.md
+++ b/files/ko/web/api/nodelist/entries/index.md
@@ -31,7 +31,7 @@ node.appendChild(kid3);
 var list = node.childNodes;
 
 // Using for..of
-for(var entry of list.entries()) {
+for (var entry of list.entries()) {
   console.log(entry);
 }
 ```

--- a/files/ko/web/api/nodelist/foreach/index.md
+++ b/files/ko/web/api/nodelist/foreach/index.md
@@ -47,12 +47,9 @@ node.appendChild(kid3);
 
 var list = node.childNodes;
 
-list.forEach(
-  function(currentValue, currentIndex, listObj) {
-    console.log(currentValue + ', ' + currentIndex + ', ' + this);
-  },
-  'myThisArg'
-);
+list.forEach(function (currentValue, currentIndex, listObj) {
+  console.log(currentValue + ", " + currentIndex + ", " + this);
+}, "myThisArg");
 ```
 
 결과는 다음과 같습니다.
@@ -69,12 +66,12 @@ list.forEach(
 
 ```js
 if (window.NodeList && !NodeList.prototype.forEach) {
-    NodeList.prototype.forEach = function (callback, thisArg) {
-        thisArg = thisArg || window;
-        for (var i = 0; i < this.length; i++) {
-            callback.call(thisArg, this[i], i, this);
-        }
-    };
+  NodeList.prototype.forEach = function (callback, thisArg) {
+    thisArg = thisArg || window;
+    for (var i = 0; i < this.length; i++) {
+      callback.call(thisArg, this[i], i, this);
+    }
+  };
 }
 ```
 
@@ -82,7 +79,7 @@ if (window.NodeList && !NodeList.prototype.forEach) {
 
 ```js
 if (window.NodeList && !NodeList.prototype.forEach) {
-    NodeList.prototype.forEach = Array.prototype.forEach;
+  NodeList.prototype.forEach = Array.prototype.forEach;
 }
 ```
 

--- a/files/ko/web/api/nodelist/index.md
+++ b/files/ko/web/api/nodelist/index.md
@@ -12,10 +12,10 @@ slug: Web/API/NodeList
 경우에 따라, `NodeList`는 라이브 콜렉션으로, DOM의 변경 사항을 실시간으로 콜렉션에 반영합니다. 예를 들어, {{domxref("Node.childNodes")}} 는 실시간입니다:
 
 ```js
-var parent = document.getElementById('parent');
+var parent = document.getElementById("parent");
 var child_nodes = parent.childNodes;
 console.log(child_nodes.length); // let's assume "2"
-parent.appendChild(document.createElement('div'));
+parent.appendChild(document.createElement("div"));
 console.log(child_nodes.length); // should output "3"
 ```
 
@@ -38,7 +38,7 @@ for 루프를 사용하여 `NodeList`의 항목을 반복할 수 있습니다.
 
 ```js
 for (var i = 0; i < myNodeList.length; ++i) {
-  var item = myNodeList[i];  // Calling myNodeList.item(i) isn't necessary in JavaScript
+  var item = myNodeList[i]; // Calling myNodeList.item(i) isn't necessary in JavaScript
 }
 ```
 
@@ -47,7 +47,7 @@ for (var i = 0; i < myNodeList.length; ++i) {
 [`for...of`](/en-US/docs/JavaScript/Reference/Statements/for...of) 루프는 `NodeList` 객체를 올바르게 반복합니다.
 
 ```js
-var list = document.querySelectorAll( 'input[type=checkbox]' );
+var list = document.querySelectorAll("input[type=checkbox]");
 for (var item of list) {
   item.checked = true;
 }
@@ -58,7 +58,7 @@ for (var item of list) {
 인터넷 익스플로러의 호환을 위해서는 {{jsxref("Array.forEach()", "Array.prototype.forEach")}} 를 사용하는 방법도 있습니다.
 
 ```js
-var list = document.querySelectorAll( 'input[type=checkbox]' );
+var list = document.querySelectorAll("input[type=checkbox]");
 Array.prototype.forEach.call(list, function (item) {
   item.checked = true;
 });
@@ -69,7 +69,7 @@ Array.prototype.forEach.call(list, function (item) {
 NodeList의 컨텐츠를 Array의 메소드를 통해 다루는 것이 더 쉬울 때도 있다. 아래는 NodeList 객체를 Array로 변환하는 기법이다.
 
 ```js
-var div_list = document.querySelectorAll('div'); // returns NodeList
+var div_list = document.querySelectorAll("div"); // returns NodeList
 var div_array = Array.prototype.slice.call(div_list); // converts NodeList to Array
 ```
 
@@ -80,20 +80,20 @@ NodeList에 프로토타입을 추가할 수도 있다.
 ```js
 var elements = document.querySelectorAll(".suggestions");
 
-NodeList.prototype.addEventListener = function(event, func) {
-    this.forEach(function(content, item) {
-       content.addEventListener(event, func);
-    });
-}
+NodeList.prototype.addEventListener = function (event, func) {
+  this.forEach(function (content, item) {
+    content.addEventListener(event, func);
+  });
+};
 
 function log() {
-    console.log(this, " was clicked");
+  console.log(this, " was clicked");
 }
 
 elements.addEventListener("click", log);
 //or
-elements.addEventListener("click", function() {
-    console.log(this, "  awas clicked");
+elements.addEventListener("click", function () {
+  console.log(this, "  awas clicked");
 });
 // 클릭된 요소로부터 출력될 요소는 둘 모두 HTML 요소가 된다.
 ```

--- a/files/ko/web/api/nodelist/item/index.md
+++ b/files/ko/web/api/nodelist/item/index.md
@@ -10,7 +10,7 @@ slug: Web/API/NodeList/item
 ## Syntax
 
 ```js
-nodeItem = nodeList.item(index)
+nodeItem = nodeList.item(index);
 ```
 
 - `nodeList` 는 `NodeList` 입니다. 일반적으로 [childNodes](/ko/docs/Web/API/Node/childNodes) 와 같은 다른 DOM 속성(property) 또는 메서드에서 가져옵니다.
@@ -22,7 +22,7 @@ nodeItem = nodeList.item(index)
 자바스크립트는 NodeList 에서 index를 얻기 위한, 배열과 같은 브라켓 문법(\[])을 제공합니다 :
 
 ```js
-nodeItem = nodeList[index]
+nodeItem = nodeList[index];
 ```
 
 ## Example

--- a/files/ko/web/api/nodelist/keys/index.md
+++ b/files/ko/web/api/nodelist/keys/index.md
@@ -32,8 +32,8 @@ node.appendChild(kid3);
 var list = node.childNodes;
 
 // Using for..of
-for(var key of list.keys()) {
-   console.log(key);
+for (var key of list.keys()) {
+  console.log(key);
 }
 ```
 

--- a/files/ko/web/api/nodelist/length/index.md
+++ b/files/ko/web/api/nodelist/length/index.md
@@ -12,7 +12,7 @@ slug: Web/API/NodeList/length
 ## 구문
 
 ```js
-numItems =nodeList.length
+numItems = nodeList.length;
 ```
 
 - `numItems`은 `NodeList`의 항목수를 나타내는 정수값입니다.

--- a/files/ko/web/api/nodelist/values/index.md
+++ b/files/ko/web/api/nodelist/values/index.md
@@ -32,7 +32,7 @@ node.appendChild(kid3);
 var list = node.childNodes;
 
 // Using for..of
-for(var value of list.values()) {
+for (var value of list.values()) {
   console.log(value);
 }
 ```

--- a/files/ko/web/api/notification/index.md
+++ b/files/ko/web/api/notification/index.md
@@ -125,7 +125,7 @@ function notifyMe() {
   }
 
   // Otherwise, we need to ask the user for permission
-  else if (Notification.permission !== 'denied') {
+  else if (Notification.permission !== "denied") {
     Notification.requestPermission(function (permission) {
       // If the user accepts, let's create a notification
       if (permission === "granted") {
@@ -144,7 +144,7 @@ function notifyMe() {
 많은 경우에 이렇게 장황할 필요는 없습니다. 예를 들어 [Emogotchi 데모](http://mdn.github.io/emogotchi/)([소스코드](https://github.com/mdn/emogotchi))에서는 단순히 알림을 보내기 위해서 권한을 얻을 수 있는지와 상관없이 {{domxref("Notification.requestPermission")}}를 실행합니다(이 경우는 새로운 프로미스 기반 메서드 문법을 사용):
 
 ```js
-Notification.requestPermission().then(function(result) {
+Notification.requestPermission().then(function (result) {
   console.log(result);
 });
 ```
@@ -152,12 +152,12 @@ Notification.requestPermission().then(function(result) {
 그 다음에 알림이 필요한 때에 단순히 `spawnNotification()` 함수를 실행합니다. 본문과 아이콘, 제목을 인자로 넘기면 필요한 `options` 객체를 만들고 {{domxref("Notification.Notification","Notification()")}} 생성자를 사용해서 알림을 발생시킵니다.
 
 ```js
-function spawnNotification(theBody,theIcon,theTitle) {
+function spawnNotification(theBody, theIcon, theTitle) {
   var options = {
-      body: theBody,
-      icon: theIcon
-  }
-  var n = new Notification(theTitle,options);
+    body: theBody,
+    icon: theIcon,
+  };
+  var n = new Notification(theTitle, options);
 }
 ```
 

--- a/files/ko/web/api/notifications_api/index.md
+++ b/files/ko/web/api/notifications_api/index.md
@@ -2,6 +2,7 @@
 title: Notifications API
 slug: Web/API/Notifications_API
 ---
+
 {{DefaultAPISidebar("Web Notifications")}}
 
 Notifications API 는 웹 페이지가 일반 사용자에게 시스템 알림 표시를 제어할 수 있게 해줍니다. 이러한 알람은 최상단 브라우징 컨텍스트 뷰포트의 바깥에 위치하므로 사용자가 탭을 변경하거나 다른 앱으로 이동했을때에도 표시할 수 있습니다. 이 API 는 다양한 플랫폼에 존재하는 알림 시스템과 호환되도록 디자인되었습니다.

--- a/files/ko/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/ko/web/api/notifications_api/using_the_notifications_api/index.md
@@ -44,7 +44,7 @@ original_slug: WebAPI/Using_Web_Notifications
 아직 알림 표시 권한이 허용되지 않았다면 애플리케이션은 {{domxref("Notification.requestPermission()")}} 메서드를 사용하여 사용자에게 권한을 요청할 필요가 있습니다. 간단하게는 아래와 같이 넣습니다.
 
 ```js
-Notification.requestPermission().then(function(result) {
+Notification.requestPermission().then(function (result) {
   console.log(result);
 });
 ```
@@ -72,29 +72,31 @@ function askNotificationPermission() {
   // 권한을 실제로 요구하는 함수
   function handlePermission(permission) {
     // 사용자의 응답에 관계 없이 크롬이 정보를 저장할 수 있도록 함
-    if(!('permission' in Notification)) {
+    if (!("permission" in Notification)) {
       Notification.permission = permission;
     }
 
     // 사용자 응답에 따라 단추를 보이거나 숨기도록 설정
-    if(Notification.permission === 'denied' || Notification.permission === 'default') {
-      notificationBtn.style.display = 'block';
+    if (
+      Notification.permission === "denied" ||
+      Notification.permission === "default"
+    ) {
+      notificationBtn.style.display = "block";
     } else {
-      notificationBtn.style.display = 'none';
+      notificationBtn.style.display = "none";
     }
   }
 
   // 브라우저가 알림을 지원하는지 확인
-  if (!('Notification' in window)) {
+  if (!("Notification" in window)) {
     console.log("이 브라우저는 알림을 지원하지 않습니다.");
   } else {
-    if(checkNotificationPromise()) {
-      Notification.requestPermission()
-      .then((permission) => {
+    if (checkNotificationPromise()) {
+      Notification.requestPermission().then((permission) => {
         handlePermission(permission);
-      })
+      });
     } else {
-      Notification.requestPermission(function(permission) {
+      Notification.requestPermission(function (permission) {
         handlePermission(permission);
       });
     }
@@ -114,14 +116,14 @@ function askNotificationPermission() {
 
 ```js
 function checkNotificationPromise() {
-    try {
-      Notification.requestPermission().then();
-    } catch(e) {
-      return false;
-    }
-
-    return true;
+  try {
+    Notification.requestPermission().then();
+  } catch (e) {
+    return false;
   }
+
+  return true;
+}
 ```
 
 기본적으로 `requestPermission()`에 `.then()` 메서드가 있는지 알아보는 것입니다. 맞다면 계속 진행하고 `true`를 반환합니다. 실패라면 `catch() {}` 블록에서 `false`를 반환합니다.
@@ -133,9 +135,9 @@ function checkNotificationPromise() {
 예를 들어 할일 목록 예시에서 아래 코드로 필요시 알림을 만듭니다(`createNotification()` 함수에서 찾을 수 있음).
 
 ```js
-var img = '/to-do-notifications/img/icon-128.png';
+var img = "/to-do-notifications/img/icon-128.png";
 var text = '아! "' + title + '" 작업 기한이 만료됐습니다.';
-var notification = new Notification('할 일 목록', { body: text, icon: img });
+var notification = new Notification("할 일 목록", { body: text, icon: img });
 ```
 
 ## 알림 닫기
@@ -180,7 +182,7 @@ setTimeout(notification.close.bind(notification), 4000);
 다수의 알림을 아래 방법으로 처리할 수 있습니다.
 
 ```js
-window.addEventListener('load', function () {
+window.addEventListener("load", function () {
   // 처음에는 알림 권한이 있는지 확인함
   // 없으면 권한 요구
   if (Notification && Notification.permission !== "granted") {
@@ -191,9 +193,9 @@ window.addEventListener('load', function () {
     });
   }
 
-  var button = document.getElementsByTagName('button')[0];
+  var button = document.getElementsByTagName("button")[0];
 
-  button.addEventListener('click', function () {
+  button.addEventListener("click", function () {
     // 사용자가 알림을 받는 데 동의한 경우
     // 알림 10개를 보내본다
     if (Notification && Notification.permission === "granted") {
@@ -201,7 +203,7 @@ window.addEventListener('load', function () {
       // 어떤 브라우저(파이어폭스 등)는 일정 시간 동안 알림이 너무 많은 경우 차단하기 때문에 인터벌 사용.
       var interval = window.setInterval(function () {
         // 태그 덕분에 "안녕! 9" 알림만 보여야 함
-        var n = new Notification("안녕! " + i, {tag: '알림너무많음'});
+        var n = new Notification("안녕! " + i, { tag: "알림너무많음" });
         if (i++ == 9) {
           window.clearInterval(interval);
         }
@@ -219,7 +221,7 @@ window.addEventListener('load', function () {
           // 어떤 브라우저(파이어폭스 등)는 일정 시간 동안 알림이 너무 많은 경우 차단하기 때문에 인터벌 사용.
           var interval = window.setInterval(function () {
             // 태그 덕분에 "안녕! 9" 알림만 보여야 함
-            var n = new Notification("안녕! " + i, {tag: '알림너무많음'});
+            var n = new Notification("안녕! " + i, { tag: "알림너무많음" });
             if (i++ == 9) {
               window.clearInterval(interval);
             }

--- a/files/ko/web/api/offlineaudiocontext/index.md
+++ b/files/ko/web/api/offlineaudiocontext/index.md
@@ -2,6 +2,7 @@
 title: OfflineAudioContext
 slug: Web/API/OfflineAudioContext
 ---
+
 {{APIRef("Web Audio API")}}
 
 `OfflineAudioContext` 인터페이스는 함께 연결된 {{domxref("AudioNode")}}들로부터 만들어진 오디오 프로세싱 그래프를 나타내는 {{domxref("AudioContext")}} 인터페이스입니다. 표준 {{domxref("AudioContext")}}와는 대조적으로, `OfflineAudioContext`는 오디오를 장치 하드웨어로 렌더링하지 않습니다; 대신, 이것은 가능한 한 빨리 오디오를 생성하고, 그 결과를 {{domxref("AudioBuffer")}}에 출력합니다.
@@ -63,7 +64,7 @@ _또한 부모 인터페이스인 {{domxref("BaseAudioContext")}}로부터 메�
 // 온라인과 오프라인 오디오 컨텍스트를 정의합니다
 
 var audioCtx = new AudioContext();
-var offlineCtx = new OfflineAudioContext(2,44100*40,44100);
+var offlineCtx = new OfflineAudioContext(2, 44100 * 40, 44100);
 
 source = offlineCtx.createBufferSource();
 
@@ -73,35 +74,38 @@ source = offlineCtx.createBufferSource();
 function getData() {
   request = new XMLHttpRequest();
 
-  request.open('GET', 'viper.ogg', true);
+  request.open("GET", "viper.ogg", true);
 
-  request.responseType = 'arraybuffer';
+  request.responseType = "arraybuffer";
 
-  request.onload = function() {
+  request.onload = function () {
     var audioData = request.response;
 
-    audioCtx.decodeAudioData(audioData, function(buffer) {
+    audioCtx.decodeAudioData(audioData, function (buffer) {
       myBuffer = buffer;
       source.buffer = myBuffer;
       source.connect(offlineCtx.destination);
       source.start();
       //source.loop = true;
-      offlineCtx.startRendering().then(function(renderedBuffer) {
-        console.log('Rendering completed successfully');
-        var song = audioCtx.createBufferSource();
-        song.buffer = renderedBuffer;
+      offlineCtx
+        .startRendering()
+        .then(function (renderedBuffer) {
+          console.log("Rendering completed successfully");
+          var song = audioCtx.createBufferSource();
+          song.buffer = renderedBuffer;
 
-        song.connect(audioCtx.destination);
+          song.connect(audioCtx.destination);
 
-        play.onclick = function() {
-          song.start();
-        }
-      }).catch(function(err) {
-          console.log('Rendering failed: ' + err);
+          play.onclick = function () {
+            song.start();
+          };
+        })
+        .catch(function (err) {
+          console.log("Rendering failed: " + err);
           // 참고: 이 프로미스는 OfflineAudioContext에서 startRendering이 두 번째로 호출되었을 때 거부되어야만 합니다
-      });
+        });
     });
-  }
+  };
 
   request.send();
 }

--- a/files/ko/web/api/offscreencanvas/getcontext/index.md
+++ b/files/ko/web/api/offscreencanvas/getcontext/index.md
@@ -2,6 +2,7 @@
 title: OffscreenCanvas.getContext()
 slug: Web/API/OffscreenCanvas/getContext
 ---
+
 {{APIRef("Canvas API")}} {{SeeCompatTable}}
 
 **`OffscreenCanvas.getContext()`** 메소드는 offscreen 캔버스를 위한 드로잉 컨텍스트 반환합니다. 컨텍스트 식별자가 지원되는 상황이 아닐 경우 {{jsxref("null")}}를 반환합니다.
@@ -17,24 +18,25 @@ offscreen.getContext(contextType, contextAttributes);
 ### 매개 변수
 
 - `contextType`
+
   - : 캔버스의 드로잉 컨텍스트를 정의하는 컨텍스트 식별자가 포함된 {{domxref("DOMString")}}입니다:\* **`"2d"`** 는 2차원 렌더링 컨텍스트를 표현하는 {{domxref("CanvasRenderingContext2D")}} 객체를 생성합니다.
+
     - **`"webgl"`** 는 3차원 렌더링 컨텍스트를 표현하는 {{domxref("WebGLRenderingContext")}} 객체를 생성합니다. 이 컨텍스트는 [WebGL](/ko/docs/Web/WebGL) 버전 1(OpenGL ES 2.0)을 지원하는 브라우저에서만 사용 가능합니다.
     - **`"webgl2"`** 는 3차원 렌더링 컨텍스트를 표현하는 {{domxref("WebGL2RenderingContext")}} 객체를 생성합니다. 이 컨텍스트는 [WebGL](/ko/docs/Web/WebGL) 버전 2 (OpenGL ES 3.0)를 지원하는 브라우저에서만 사용 가능합니다. {{experimental_inline}}
     - **`"bitmaprenderer"`** 는 주어진 {{domxref("ImageBitmap")}}을 캔버스의 내용 대신 전환하는 함수를 제공하는 {{domxref("ImageBitmapRenderingContext")}}를 생성합니다
 
-    > **참고:** `"experimental-webgl"`**과 **`"experimental-webgl2"`** 식별자는 WebGL에서도 사용됩니다.
+    > **참고:** `"experimental-webgl"`**과 **`"experimental-webgl2"`\*\* 식별자는 WebGL에서도 사용됩니다.
     >
     > 그러나 아직 테스트 적합성을 통과하지 못했거나 플랫폼별 그래픽 드라이버 지원이 안정적이진 않습니다.
     > [Khronos Group](https://www.khronos.org/)은 특정한 [정합성 규칙](https://www.khronos.org/registry/webgl/sdk/tests/CONFORMANCE_RULES.txt)에 WebGL 구현을 인증하고 있습니다.
+
 - `contextAttributes`
 
   - : You can use several context attributes when creating your rendering context, for
     example:
 
     ```js
-    offscreen.getContext("webgl",
-                     { antialias: false,
-                       depth: false });
+    offscreen.getContext("webgl", { antialias: false, depth: false });
     ```
 
     2d context attributes:

--- a/files/ko/web/api/offscreencanvas/index.md
+++ b/files/ko/web/api/offscreencanvas/index.md
@@ -22,9 +22,11 @@ slug: Web/API/OffscreenCanvas
 ## 메소드
 
 - {{domxref("OffscreenCanvas.getContext()")}}
+
   - : 렌더링된 캔버스 컨텍스트 객체를 반환합니다.
 
 - {{domxref("OffscreenCanvas.convertToBlob()")}}
+
   - : 캔버스에 들어있는 이미지에 대한 {{domxref("Blob")}} 객체를 생성합니다.
 
 - {{domxref("OffscreenCanvas.transferToImageBitmap()")}}
@@ -41,8 +43,7 @@ slug: Web/API/OffscreenCanvas
 아래에 두 개의 {{HTMLElement("canvas")}} 요소가 있습니다.
 
 ```html
-<canvas id="one"></canvas>
-<canvas id="two"></canvas>
+<canvas id="one"></canvas> <canvas id="two"></canvas>
 ```
 
 다음의 코드는 위에서 설명한 것처럼 `OffscreenCanvas`를 이용해 렌더링합니다.
@@ -52,7 +53,7 @@ var one = document.getElementById("one").getContext("bitmaprenderer");
 var two = document.getElementById("two").getContext("bitmaprenderer");
 
 var offscreen = new OffscreenCanvas(256, 256);
-var gl = offscreen.getContext('webgl');
+var gl = offscreen.getContext("webgl");
 
 // ... gl 컨텍스트를 이용해 첫 번째 캔버스에 무언가를 그립니다 ...
 
@@ -78,13 +79,13 @@ var htmlCanvas = document.getElementById("canvas");
 var offscreen = htmlCanvas.transferControlToOffscreen();
 
 var worker = new Worker("offscreencanvas.js");
-worker.postMessage({canvas: offscreen}, [offscreen]);
+worker.postMessage({ canvas: offscreen }, [offscreen]);
 ```
 
 offscreencanvas.js (worker 코드):
 
 ```js
-onmessage = function(evt) {
+onmessage = function (evt) {
   var canvas = evt.data.canvas;
   var gl = canvas.getContext("webgl");
 
@@ -95,7 +96,7 @@ onmessage = function(evt) {
 worker 내에서 requestAnimationFrame 또한 사용할 수 있습니다.
 
 ```js
-onmessage = function(evt) {
+onmessage = function (evt) {
   const canvas = evt.data.canvas;
   const gl = canvas.getContext("webgl");
 

--- a/files/ko/web/api/offscreencanvas/offscreencanvas/index.md
+++ b/files/ko/web/api/offscreencanvas/offscreencanvas/index.md
@@ -26,7 +26,7 @@ new OffscreenCanvas(width, height);
 
 ```js
 let offscreen = new OffscreenCanvas(256, 256);
-let gl = offscreen.getContext('webgl');
+let gl = offscreen.getContext("webgl");
 ```
 
 ## 명세서

--- a/files/ko/web/api/offscreencanvas/width/index.md
+++ b/files/ko/web/api/offscreencanvas/width/index.md
@@ -2,6 +2,7 @@
 title: OffscreenCanvas.width
 slug: Web/API/OffscreenCanvas/width
 ---
+
 {{APIRef("Canvas API")}} {{SeeCompatTable}}
 
 **`width`** 프로퍼티는 {{domxref("OffscreenCanvas")}} 객체에 할당된 너비를 반환합니다.

--- a/files/ko/web/api/page_visibility_api/index.md
+++ b/files/ko/web/api/page_visibility_api/index.md
@@ -2,6 +2,7 @@
 title: Page Visibility API
 slug: Web/API/Page_Visibility_API
 ---
+
 {{DefaultAPISidebar("Page Visibility API")}}
 
 **Page Visibility API**는 웹페이지가 visible 또는 focus 상태인지 당신이 알도록 한다. 탭 브라우징 사용시에, background 에 어떤 웹페이지가 존재하면서 유저에게 보이지 않을 가능성이 있다. 사용자가 웹페이지를 최소화하거나 다른 탭으로 이동했을 때, 이 API 는 페이지의 visibility 를 관찰하는 {{event("visibilitychange")}} 이벤트를 전달한다. 당신은 이벤트를 감지할 수 있고, 어떠한 action 을 수행하거나 다르게 반응할 수 있다. 예를 들어, 당신의 웹 앱이 video 를 재생한다면, 사용자가 다른 브라우저를 보고 있을 때 video 를 pause 하고, 탭으로 돌아왔을 때 다시 재생할 수 있다. 사용자는 video 에서 자신의 위치를 잃지 않고 계속 시청할 수 있다.
@@ -28,7 +29,8 @@ Visibility states of an {{HTMLElement("iframe")}} 의 visibility 상태는 부�
 ```js
 // Set the name of the hidden property and the change event for visibility
 var hidden, visibilityChange;
-if (typeof document.hidden !== "undefined") { // Opera 12.10 and Firefox 18 and later support
+if (typeof document.hidden !== "undefined") {
+  // Opera 12.10 and Firefox 18 and later support
   hidden = "hidden";
   visibilityChange = "visibilitychange";
 } else if (typeof document.msHidden !== "undefined") {
@@ -52,23 +54,35 @@ function handleVisibilityChange() {
 }
 
 // Warn if the browser doesn't support addEventListener or the Page Visibility API
-if (typeof document.addEventListener === "undefined" || typeof document[hidden] === "undefined") {
-  console.log("This demo requires a browser, such as Google Chrome or Firefox, that supports the Page Visibility API.");
+if (
+  typeof document.addEventListener === "undefined" ||
+  typeof document[hidden] === "undefined"
+) {
+  console.log(
+    "This demo requires a browser, such as Google Chrome or Firefox, that supports the Page Visibility API.",
+  );
 } else {
   // Handle page visibility change
   document.addEventListener(visibilityChange, handleVisibilityChange, false);
 
   // When the video pauses, set the title.
   // This shows the paused
-  videoElement.addEventListener("pause", function(){
-    document.title = 'Paused';
-  }, false);
+  videoElement.addEventListener(
+    "pause",
+    function () {
+      document.title = "Paused";
+    },
+    false,
+  );
 
   // When the video plays, set the title.
-  videoElement.addEventListener("play", function(){
-    document.title = 'Playing';
-  }, false);
-
+  videoElement.addEventListener(
+    "play",
+    function () {
+      document.title = "Playing";
+    },
+    false,
+  );
 }
 ```
 
@@ -92,7 +106,7 @@ if (typeof document.addEventListener === "undefined" || typeof document[hidden] 
 function handleVisibilityChange() {
   if (document.hidden) {
     pauseSimulation();
-  } else  {
+  } else {
     startSimulation();
   }
 }

--- a/files/ko/web/api/performance/now/index.md
+++ b/files/ko/web/api/performance/now/index.md
@@ -50,7 +50,6 @@ performance.now();
 // 8782206
 // ...
 
-
 // reduced time precision with `privacy.resistFingerprinting` enabled
 performance.now();
 // 8865400

--- a/files/ko/web/api/performance_api/navigation_timing/index.md
+++ b/files/ko/web/api/performance_api/navigation_timing/index.md
@@ -10,9 +10,9 @@ original_slug: Web/API/Navigation_timing_API
 
 ```js
 function onLoad() {
-    var now = new Date().getTime();
-    var page_load_time = now - performance.timing.navigationStart;
-    console.log("User-perceived page loading time: " + page_load_time);
+  var now = new Date().getTime();
+  var page_load_time = now - performance.timing.navigationStart;
+  console.log("User-perceived page loading time: " + page_load_time);
 }
 ```
 

--- a/files/ko/web/api/performanceentry/index.md
+++ b/files/ko/web/api/performanceentry/index.md
@@ -2,6 +2,7 @@
 title: PerformanceEntry
 slug: Web/API/PerformanceEntry
 ---
+
 {{APIRef("Performance Timeline API")}}
 
 **`PerformanceEntry`** 객체는 _performance timeline_ 상의 단일 성능 수치를 캡슐화 합니다. *performance entry*는 응용프로그램의 특정 지점에서 performance *{{domxref("PerformanceMark","mark")}}*나 *{{domxref("PerformanceMeasure","measure")}}*를 생성함으로써 (예를 들면 {{domxref("Performance.mark","mark()")}}를 호출하는 방법으로) 직접적으로 만들어질 수 있습니다. 또는 (이미지와 같은) 리소스를 로딩하는 등의 간접적인 방법으로 생성되기도 합니다.
@@ -41,18 +42,15 @@ The following example checks all `PerformanceEntry` properties to see if the bro
 function print_PerformanceEntries() {
   // Use getEntries() to get a list of all performance entries
   var p = performance.getEntries();
-  for (var i=0; i < p.length; i++) {
+  for (var i = 0; i < p.length; i++) {
     console.log("PerformanceEntry[" + i + "]");
     print_PerformanceEntry(p[i]);
   }
 }
 function print_PerformanceEntry(perfEntry) {
-  var properties = ["name",
-                    "entryType",
-                    "startTime",
-                    "duration"];
+  var properties = ["name", "entryType", "startTime", "duration"];
 
-  for (var i=0; i < properties.length; i++) {
+  for (var i = 0; i < properties.length; i++) {
     // Check each property
     var supported = properties[i] in perfEntry;
     if (supported) {

--- a/files/ko/web/api/periodicwave/periodicwave/index.md
+++ b/files/ko/web/api/periodicwave/periodicwave/index.md
@@ -41,10 +41,10 @@ real[1] = 1;
 imag[1] = 0;
 
 var options = {
-  real : real,
-  imag : imag,
-  disableNormalization : false
-}
+  real: real,
+  imag: imag,
+  disableNormalization: false,
+};
 
 var wave = new PeriodicWave(ac, options);
 ```

--- a/files/ko/web/api/plugin/index.md
+++ b/files/ko/web/api/plugin/index.md
@@ -2,6 +2,7 @@
 title: Plugin
 slug: Web/API/Plugin
 ---
+
 {{ApiRef("HTML DOM")}}
 
 플러그 인 인터페이스는 브라우저 플러그 인에 대한 정보를 제공합니다.
@@ -10,11 +11,11 @@ slug: Web/API/Plugin
 
 ## 특성
 
-| 이름                                         | 설명                                                    | Return Type                      | 유용성                           |
-| -------------------------------------------- | ------------------------------------------------------- | -------------------------------- | -------------------------------- |
+| 이름                              | 설명                                                    | Return Type              | 유용성                           |
+| --------------------------------- | ------------------------------------------------------- | ------------------------ | -------------------------------- |
 | {{domxref("Plugin.description")}} | 플러그 인에 대한 읽기 쉬운 설명입니다. 읽기 전용입니다. | {{domxref("DOMString")}} | DOM 0                            |
-| {{domxref("Plugin.filename")}}     | 플러그 인 파일의 파일 이름. 읽기 전용입니다.            | {{domxref("DOMString")}} | DOM 0                            |
-| {{domxref("Plugin.name")}}         | 플러그 인의 이름. 읽기 전용입니다.                      | {{domxref("DOMString")}} | DOM 0                            |
+| {{domxref("Plugin.filename")}}    | 플러그 인 파일의 파일 이름. 읽기 전용입니다.            | {{domxref("DOMString")}} | DOM 0                            |
+| {{domxref("Plugin.name")}}        | 플러그 인의 이름. 읽기 전용입니다.                      | {{domxref("DOMString")}} | DOM 0                            |
 | {{domxref("Plugin.version")}}     | 플러그 인의 버전 번호 문자열. 읽기 전용입니다.          | {{domxref("DOMString")}} | Gecko browsers only (Firefox 4+) |
 
 ## 방법

--- a/files/ko/web/api/push_api/index.md
+++ b/files/ko/web/api/push_api/index.md
@@ -2,6 +2,7 @@
 title: Push API
 slug: Web/API/Push_API
 ---
+
 {{DefaultAPISidebar("Push API")}}
 
 **Push API**는 웹 애플리케이션이 현재 로딩이 되어 있지 않더라도 서버로부터 메시지를 받을 수 있도록 하는 기능이다. 이는 개발자들이 비동기적으로 사용자에게 새로운 내용을 시기적절하게 전달할 수 있도록 만들어 준다.

--- a/files/ko/web/api/pushmanager/index.md
+++ b/files/ko/web/api/pushmanager/index.md
@@ -37,27 +37,29 @@ slug: Web/API/PushManager
 ## 예제
 
 ```js
-this.onpush = function(event) {
+this.onpush = function (event) {
   console.log(event.data);
   // From here we can write the data to IndexedDB, send it to any open
   // windows, display a notification, etc.
-}
+};
 
-navigator.serviceWorker.register('serviceworker.js').then(
-  function(serviceWorkerRegistration) {
+navigator.serviceWorker
+  .register("serviceworker.js")
+  .then(function (serviceWorkerRegistration) {
     serviceWorkerRegistration.pushManager.subscribe().then(
-      function(pushSubscription) {
+      function (pushSubscription) {
         console.log(pushSubscription.endpoint);
         // The push subscription details needed by the application
         // server are now available, and can be sent to it using,
         // for example, an XMLHttpRequest.
-      }, function(error) {
+      },
+      function (error) {
         // During development it often helps to log errors to the
         // console. In a production environment it might make sense to
         // also report information about errors back to the
         // application server.
         console.log(error);
-      }
+      },
     );
   });
 ```

--- a/files/ko/web/api/pushmessagedata/index.md
+++ b/files/ko/web/api/pushmessagedata/index.md
@@ -29,13 +29,13 @@ None.
 ## Examples
 
 ```js
-self.addEventListener('push', function(event) {
+self.addEventListener("push", function (event) {
   var obj = event.data.json();
 
-  if(obj.action === 'subscribe' || obj.action === 'unsubscribe') {
+  if (obj.action === "subscribe" || obj.action === "unsubscribe") {
     fireNotification(obj, event);
     port.postMessage(obj);
-  } else if(obj.action === 'init' || obj.action === 'chatMsg') {
+  } else if (obj.action === "init" || obj.action === "chatMsg") {
     port.postMessage(obj);
   }
 });

--- a/files/ko/web/api/queuemicrotask/index.md
+++ b/files/ko/web/api/queuemicrotask/index.md
@@ -2,6 +2,7 @@
 title: queueMicrotask()
 slug: Web/API/queueMicrotask
 ---
+
 {{APIRef("HTML DOM")}}
 
 {{domxref("Window")}} 또는 {{domxref("Worker")}} 인터페이스의 **`queueMicrotask()`** 메서드는 브라우저의 이벤트 루프로 통제권이 넘어가기 전, 안전한 시점에 실행할 마이크로태스크를 큐에 추가합니다.
@@ -34,7 +35,7 @@ queueMicrotask(function);
 ```js
 queueMicrotask(() => {
   // 함수 내용
-})
+});
 ```
 
 다음은 [queueMicrotask 명세](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#microtask-queuing)에서 가져온 예제 코드입니다.
@@ -47,11 +48,13 @@ MyElement.prototype.loadData = function (url) {
       this.dispatchEvent(new Event("load"));
     });
   } else {
-    fetch(url).then(res => res.arrayBuffer()).then(data => {
-      this._cache[url] = data;
-      this._setData(data);
-      this.dispatchEvent(new Event("load"));
-    });
+    fetch(url)
+      .then((res) => res.arrayBuffer())
+      .then((data) => {
+        this._cache[url] = data;
+        this._setData(data);
+        this.dispatchEvent(new Event("load"));
+      });
   }
 };
 ```

--- a/files/ko/web/api/range/index.md
+++ b/files/ko/web/api/range/index.md
@@ -2,6 +2,7 @@
 title: range
 slug: Web/API/Range
 ---
+
 {{ APIRef("DOM") }}
 
 **`Range`** 객체는 주어진 document 내의 텍스트 노드들의 부분들(parts)과 document의 단편화에 포함된 노드들을 나타내고 있다.

--- a/files/ko/web/api/readablestream/index.md
+++ b/files/ko/web/api/readablestream/index.md
@@ -54,10 +54,10 @@ fetch("https://www.example.org/").then((response) => {
           controller.enqueue(value);
           push();
         });
-      };
+      }
 
       push();
-    }
+    },
   });
 
   return new Response(stream, { headers: { "Content-Type": "text/html" } });

--- a/files/ko/web/api/request/credentials/index.md
+++ b/files/ko/web/api/request/credentials/index.md
@@ -26,7 +26,7 @@ var myCred = request.credentials;
 다음의 snippet 에서, 우리는 {{domxref("Request.Request()")}} constructor 를 사용하여 (스크립트와 동일한 디렉토리의 이미지 파일을 위한) 새로운 요청(request)를 생성하고, 변수에 요청(request) credentials 을 저장한다.
 
 ```js
-var myRequest = new Request('flowers.jpg');
+var myRequest = new Request("flowers.jpg");
 var myCred = myRequest.credentials; // returns "same-origin" by default
 ```
 

--- a/files/ko/web/api/request/request/index.md
+++ b/files/ko/web/api/request/request/index.md
@@ -31,8 +31,8 @@ var myRequest = new Request(input, init);
 
 ## 에러
 
-| **타입**    | **내용**                                                                                                                                                          |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **타입**    | **내용**                                                                                                                                                             |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `TypeError` | [Firefox 43](/ko/docs/Mozilla/Firefox/Releases/43)부터, `http://user:password@example.com` 와 같인 credential을 포함하는 경우 `Request()` 는 타입 에러를 반환합니다. |
 
 ## 예시
@@ -40,16 +40,18 @@ var myRequest = new Request(input, init);
 [Fetch Request example](https://github.com/mdn/fetch-examples/tree/gh-pages/fetch-request)에서는, 생성자를 사용해 새로운 Requst 객체를 생성하고 나서 {{domxref("GlobalFetch.fetch")}}인터페이스를 이용해 Request로 읽어온 결과를 취득하고 있습니다. 특정 사진을 가져와서 사용할 수 있게 만들기 위해서 MIME타입을 설정하고, Response의 {{domxref("Body.blob")}}를 반환합니다. 그 후로 오브젝트 URL을 생성해 {{htmlelement("img")}}요소를 표시하도록 합니다. [Fetch Request live](http://mdn.github.io/fetch-examples/fetch-request/)를 참고해주시기 바랍니다.
 
 ```js
-var myImage = document.querySelector('img');
+var myImage = document.querySelector("img");
 
-var myRequest = new Request('flowers.jpg');
+var myRequest = new Request("flowers.jpg");
 
-fetch(myRequest).then(function(response) {
-  return response.blob();
-}).then(function(response) {
-  var objectURL = URL.createObjectURL(response);
-  myImage.src = objectURL;
-});
+fetch(myRequest)
+  .then(function (response) {
+    return response.blob();
+  })
+  .then(function (response) {
+    var objectURL = URL.createObjectURL(response);
+    myImage.src = objectURL;
+  });
 ```
 
 [Fetch Request with init example](https://github.com/mdn/fetch-examples/tree/gh-pages/fetch-request-with-init)에서는 fetch()를 실행할 때 마다, init객체를 전달하는 것 이외에는 거의 동일한 기능을 수행합니다. [Fetch Request init live](http://mdn.github.io/fetch-examples/fetch-request-with-init/) 를 참조해주시기 바랍니다.

--- a/files/ko/web/api/rtcdatachannelevent/channel/index.md
+++ b/files/ko/web/api/rtcdatachannelevent/channel/index.md
@@ -10,7 +10,7 @@ slug: Web/API/RTCDataChannelEvent/channel
 ## Syntax
 
 ```js
- var channel = RTCDataChannelEvent.channel;
+var channel = RTCDataChannelEvent.channel;
 ```
 
 ### 값
@@ -22,12 +22,12 @@ slug: Web/API/RTCDataChannelEvent/channel
 {{event("datachannel")}} 이벤트 핸들러 안 코드의 첫 줄에서 이벤트 객체의 채널을 가져오고, 이를 데이터 트래픽을 관리하는 코드에 사용 될 수 있도록 지역 변수로 저장합니다.
 
 ```js
-pc.ondatachannel = function(event) {
+pc.ondatachannel = function (event) {
   inboundDataChannel = event.channel;
   inboundDataChannel.onmessage = handleIncomingMessage;
   inboundDataChannel.onopen = handleChannelOpen;
   inboundDataChannel.onclose = handleChannelClose;
-}
+};
 ```
 
 ## 명세

--- a/files/ko/web/api/rtcdatachannelevent/index.md
+++ b/files/ko/web/api/rtcdatachannelevent/index.md
@@ -2,6 +2,7 @@
 title: RTCDataChannelEvent
 slug: Web/API/RTCDataChannelEvent
 ---
+
 {{APIRef("WebRTC")}}{{SeeCompatTable}}
 
 **`RTCDataChannelEvent()`** 생성자는 {{domxref("datachannel")}}을 나타내는 신규 {{domxref("RTCDataChannelEvent")}} 객체를 반환합니다. 이 이벤트는 두 피어 사이에서 원격 피어가 {{domxref("RTCDataChannel")}}을 개통하도록 요청되었을때, {{domxref("RTCPeerConnection")}} 에 전달됩니다.
@@ -29,12 +30,12 @@ _[`Event`](/ko/docs/Web/API/Event)의 속성을 상속합니다._
 아래의 예제에서는 `datachannel` 이벤트 핸들러를 설정해서 데이터 채널의 참조된 정보를 저장하고, 모니터링 할 이벤트들에 대한 핸들러를 새로 설정합니다. {{domxref("RTCDataChannelEvent.channel", "channel")}} 속성은 다른 피어와의 연결을 나타내는 {{domxref("RTCDataChannel")}}을 제공합니다.
 
 ```js
-pc.ondatachannel = function(event) {
+pc.ondatachannel = function (event) {
   inboundDataChannel = event.channel;
   inboundDataChannel.onmessage = handleIncomingMessage;
   inboundDataChannel.onopen = handleChannelOpen;
   inboundDataChannel.onclose = handleChannelClose;
-}
+};
 ```
 
 데이터 채널을 어떤 방식으로 사용하는지에 대한 더 좋은 예제는 [A simple RTCDataChannel sample](/ko/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample)를 확인하십시오.

--- a/files/ko/web/api/rtcdatachannelevent/rtcdatachannelevent/index.md
+++ b/files/ko/web/api/rtcdatachannelevent/rtcdatachannelevent/index.md
@@ -33,7 +33,7 @@ var event = new RTCDataChannelEvent(type, RtcDataChannelEventInit);
 아래 예제는 신규 {{event("datachannel")}}를 생성합니다. `dc`는 이미 존재하는 데이터 채널을 뜻합니다.
 
 ```js
-var event = new RTCDataChannelEvent("datachannel", {"channel": dc});
+var event = new RTCDataChannelEvent("datachannel", { channel: dc });
 ```
 
 ## 명세

--- a/files/ko/web/api/rtcicecandidate/candidate/index.md
+++ b/files/ko/web/api/rtcicecandidate/candidate/index.md
@@ -23,7 +23,7 @@ var candidate = RTCIceCandidate.candidate;
 
 candidate 문자열에 대한 구문은 {{RFC(5245, "", 15.1)}}에 설명되어있습니다.
 
-``` plain
+```plain
 a=candidate:4234997325 1 udp 2043278322 192.168.0.56 44323 typ host
 ```
 
@@ -60,7 +60,7 @@ function handleNewIceCandidate(candidateSDP) {
 위 예제는 더 간단하게 표현 될 수 있습니다. ECMAScript 2016의 고급 기능들을 사용해서 아래와 같이 나타낼 수 있습니다:
 
 ```js
-let handleNewIceCandidate = candidateSDP =>
+let handleNewIceCandidate = (candidateSDP) =>
   myPeerConnection.addIceCandidate(new RTCIceCandidate(candidateSDP));
 ```
 

--- a/files/ko/web/api/rtcicecandidate/tojson/index.md
+++ b/files/ko/web/api/rtcicecandidate/tojson/index.md
@@ -2,6 +2,7 @@
 title: RTCIceCandidate. toJSON()
 slug: Web/API/RTCIceCandidate/toJSON
 ---
+
 {{APIRef("WebRTC")}}
 
 {{domxref("RTCIceCandidate")}} 메소드인 **`toJSON()`**은 JSON 형식으로 호출된 RTCIceCandidate를 {{domxref("RTCIceCandidateInit")}} 객체 형식으로 변환합니다. .

--- a/files/ko/web/api/rtcpeerconnection/addicecandidate/index.md
+++ b/files/ko/web/api/rtcpeerconnection/addicecandidate/index.md
@@ -71,7 +71,7 @@ ICE candidate 추가 시도 중 에러가 발생하면, 이 메소드에서 반�
 //   }
 // }
 
-signalingChannel.onmessage = receivedString => {
+signalingChannel.onmessage = (receivedString) => {
   const message = JSON.parse(receivedString);
   if (message.ice) {
     // A typical value of ice here might look something like this:
@@ -80,19 +80,19 @@ signalingChannel.onmessage = receivedString => {
     //
     // Pass the whole thing to addIceCandidate:
 
-    pc.addIceCandidate(message.ice).catch(e => {
+    pc.addIceCandidate(message.ice).catch((e) => {
       console.log("Failure during addIceCandidate(): " + e.name);
     });
   } else {
     // handle other things you might be signaling, like sdp
   }
-}
+};
 ```
 
 원격 유저에 의해 이러한 방식으로 신호를 전달한 마지막 candiate는 "candidate 종료"를 나타내는 특수한 candidate가 됩니다. "candidate 종료"를 수동으로 설정하려면 다음과 같이 하면 됩니다:
 
 ```js
-pc.addIceCandidate({candidate:''});
+pc.addIceCandidate({ candidate: "" });
 ```
 
 하지만, 대부분의 경우 {{domxref("RTCPeerConnection")}}가 적절한 이벤트를 보내서 처리해주기 때문에 이를 수동으로 확인해야 할 필요는 없습니다.

--- a/files/ko/web/api/rtcpeerconnection/addtrack/index.md
+++ b/files/ko/web/api/rtcpeerconnection/addtrack/index.md
@@ -2,6 +2,7 @@
 title: RTCPeerConnection.addTrack()
 slug: Web/API/RTCPeerConnection/addTrack
 ---
+
 {{APIRef("WebRTC")}}
 
 {{domxref("RTCPeerConnection")}}의 메소드인 **`addTrack()`**은 다른 유저에게 전송될 트랙들의 묶음에 신규 미디어 트랙을 추가합니다.
@@ -66,7 +67,7 @@ async openCall(pc) {
 ```js
 let inboundStream = null;
 
-pc.ontrack = ev => {
+pc.ontrack = (ev) => {
   if (ev.streams && ev.streams[0]) {
     videoElem.srcObject = ev.streams[0];
   } else {
@@ -76,7 +77,7 @@ pc.ontrack = ev => {
     }
     inboundStream.addTrack(ev.track);
   }
-}
+};
 ```
 
 여기서 `track` 이벤트 핸들러는 스트림을 명시한 경우, 이 이벤트에서 명시한 첫 번째 스트림에 트랙을 추가합니다. 그렇지 않은 경우에는 `ontrack`이 처음 호출되는 순간에 신규 스트림이 생성되고 비디오 엘리먼트에 부착된 다음에서야 트랙이 신규 스트림에 추가됩니다. 이때부터 신규 랙이 해당 스트림에 추가됩니다.
@@ -84,14 +85,14 @@ pc.ontrack = ev => {
 또한, 각각의 트랙을 받을 때 마다, 신규 스트림을 만들 수 있습니다:
 
 ```js
-pc.ontrack = ev => {
+pc.ontrack = (ev) => {
   if (ev.streams && ev.streams[0]) {
     videoElem.srcObject = ev.streams[0];
   } else {
     let inboundStream = new MediaStream(track);
     videoElem.srcObject = inboundStream;
   }
-}
+};
 ```
 
 #### 특정 스트림에 트랙 연동하기
@@ -149,20 +150,21 @@ pc.ontrack = ({streams: [stream]} => videoElem.srcObject = stream;
 
 ```js
 var mediaConstraints = {
-  audio: true,            // We want an audio track
-  video: true             // ...and we want a video track
+  audio: true, // We want an audio track
+  video: true, // ...and we want a video track
 };
 
 var desc = new RTCSessionDescription(sdp);
 
-pc.setRemoteDescription(desc).then(function () {
-  return navigator.mediaDevices.getUserMedia(mediaConstraints);
-})
-.then(function(stream) {
-  previewElement.srcObject = stream;
+pc.setRemoteDescription(desc)
+  .then(function () {
+    return navigator.mediaDevices.getUserMedia(mediaConstraints);
+  })
+  .then(function (stream) {
+    previewElement.srcObject = stream;
 
-  stream.getTracks().forEach(track => pc.addTrack(track, stream));
-})
+    stream.getTracks().forEach((track) => pc.addTrack(track, stream));
+  });
 ```
 
 위의 코드는 SDP를 원격 유저로부터 수신 받아서 신규 {{domxref("RTCSessionDescription")}}를 만들고 {{domxref("RTCPeerConnection.setRemoteDescription", "setRemoteDescription()")}}로 전달합니다. `pc.setRemoteDescription(desc)`의 실행이 성공하게되면, {{domxref("MediaDevices.getUserMedia()")}}를 사용해서 로컬 유저의 웹캠과 마이크에 대한접근 권한을 얻습니다. 앞의 과정이 성공하게되면, 스트림은 {{HTMLElement("video")}} 엘리먼트를 위한 소스로 지정됩니다. 이 스트림은 `previewElement`변수를 통해 참조가 가능해집니다.

--- a/files/ko/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
+++ b/files/ko/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
@@ -14,7 +14,7 @@ slug: Web/API/RTCPeerConnection/canTrickleIceCandidates
 ## Syntax
 
 ```js
- var canTrickle = RTCPeerConnection.canTrickleIceCandidates;
+var canTrickle = RTCPeerConnection.canTrickleIceCandidates;
 ```
 
 ### 값

--- a/files/ko/web/api/rtcpeerconnection/connectionstate/index.md
+++ b/files/ko/web/api/rtcpeerconnection/connectionstate/index.md
@@ -2,6 +2,7 @@
 title: RTCPeerConnection.connectionState
 slug: Web/API/RTCPeerConnection/connectionState
 ---
+
 {{APIRef("WebRTC")}}
 
 {{domxref("RTCPeerConnection")}} 인터페이스의 읽기 속성인 **`connectionState`** 는 피어 연결의 현재 상태를 알려줍니다. 이 속성은 [`RTCPeerConnectionState`](#RTCPeerConnectionState_enum) `enum` 값 중 하나를 문자열로 반환해줍니다.
@@ -22,13 +23,13 @@ var connectionState = RTCPeerConnection.connectionState;
 
 `RTCPeerConnectionState` enum은 `RTCPeerConnection`이 존재 할 수 도있는 상태에 대해 알려주는 문자열 상수를 정의합니다. 이 값들은 {domxref("RTCPeerConnection.connectionState", "connectionState")}} 속성에 의해 반홥됩니다. 근본적으로 이 상태는 연결에 의해 사용되는 모든 ICE 전송 ({{domxref("RTCIceTransport")}} 혹은 {{domxref("RTCDtlsTransport")}}의 타입)의 상태 집합을 나타냅니다.
 
-| 상수명  | 설명  |
-| --- | --- |
-| `"new"`          | 연결의 ICE 전송 중 적어도 한 개가 새로 만들어진 `"new"` 상태이고, 그 외의 나머지는 다음의 상태 중 하나가 아니여야 합니다: `"connecting"`, `"checking"`, `"failed"`, 혹은 `"disconnected"`, 혹은 모든 연결의 전송이 끝났다는 `"closed"`상태.                                                                                |
-| `"connecting"`   | 하나 혹은 여러개의 ICE 전송이 현재 연결을 구성하는 중에 있음을 알려주는 값. 이는 `RTCIceConnectionState`가 `"checking"` 혹은 `"connected"`이며, 그 어떤 전송도 `"failed"`상태가 아니여야합니다. **<<< Make this a link once I know where that will be documented**                                                         |
-| `"connected"`    | 연결에 의해 사용되는 모든 ICE 전송이 사용 중 (`"connected"` 혹은 `"completed"`)이거나, 종료된 상태입니다. 추가적으로 최소 하나의 전송이 `"connected"` 혹은 `"completed"`입니다.                                                                                                                                            |
-| `"disconnected"` | 연결에 대한 최소 한 개의 ICE 전송이 `"disconnected"`상태이고, 그 외의 다른 전송 상태는 `"failed"`, `"connecting"`, 혹은 `"checking"`이 아님을 알려주는 값.                                                                                                                                                                 |
-| `"failed"`       | 연결에 대한 하나 혹은 여러개의 ICE 전송이 `"failed"`상태임을 알려주는 값.                                                                                                                                                                                                                                                  |
+| 상수명           | 설명                                                                                                                                                                                                                                                                                                |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"new"`          | 연결의 ICE 전송 중 적어도 한 개가 새로 만들어진 `"new"` 상태이고, 그 외의 나머지는 다음의 상태 중 하나가 아니여야 합니다: `"connecting"`, `"checking"`, `"failed"`, 혹은 `"disconnected"`, 혹은 모든 연결의 전송이 끝났다는 `"closed"`상태.                                                         |
+| `"connecting"`   | 하나 혹은 여러개의 ICE 전송이 현재 연결을 구성하는 중에 있음을 알려주는 값. 이는 `RTCIceConnectionState`가 `"checking"` 혹은 `"connected"`이며, 그 어떤 전송도 `"failed"`상태가 아니여야합니다. **<<< Make this a link once I know where that will be documented**                                  |
+| `"connected"`    | 연결에 의해 사용되는 모든 ICE 전송이 사용 중 (`"connected"` 혹은 `"completed"`)이거나, 종료된 상태입니다. 추가적으로 최소 하나의 전송이 `"connected"` 혹은 `"completed"`입니다.                                                                                                                     |
+| `"disconnected"` | 연결에 대한 최소 한 개의 ICE 전송이 `"disconnected"`상태이고, 그 외의 다른 전송 상태는 `"failed"`, `"connecting"`, 혹은 `"checking"`이 아님을 알려주는 값.                                                                                                                                          |
+| `"failed"`       | 연결에 대한 하나 혹은 여러개의 ICE 전송이 `"failed"`상태임을 알려주는 값.                                                                                                                                                                                                                           |
 | `"closed"`       | `RTCPeerConnection` 개통되지 않음을 알려주는 값.2016년 5월 13일에 작성된 명세서의 초안에 따르면, 이 값은 [`RTCPeerConnectionState` enum](#RTCPeerConnectionState_enum) 안에 존재했었습니다. 따라서, {{domxref("RTCPeerConnection.signalingState", "signalingState")}}의 값을 통해 찾을 수 있습니다. |
 
 ## 예시

--- a/files/ko/web/api/rtcpeerconnection/connectionstatechange_event/index.md
+++ b/files/ko/web/api/rtcpeerconnection/connectionstatechange_event/index.md
@@ -21,8 +21,8 @@ RTCPeerConnection.onconnectionstatechange = eventHandler;
 ## 예시
 
 ```js
-pc.onconnectionstatechange = function(event) {
-  switch(pc.connectionState) {
+pc.onconnectionstatechange = function (event) {
+  switch (pc.connectionState) {
     case "connected":
       // The connection has become fully connected
       break;
@@ -34,7 +34,7 @@ pc.onconnectionstatechange = function(event) {
       // The connection has been closed
       break;
   }
-}
+};
 ```
 
 ## 명세

--- a/files/ko/web/api/rtcpeerconnection/createanswer/index.md
+++ b/files/ko/web/api/rtcpeerconnection/createanswer/index.md
@@ -2,6 +2,7 @@
 title: RTCPeerConnection.createAnswer()
 slug: Web/API/RTCPeerConnection/createAnswer
 ---
+
 {{APIRef("WebRTC")}}
 
 {{domxref("RTCPeerConnection")}} 인터페이스의 **`createAnswer()`** 메소드는 WebRTC 연결 중 발생하는 offer/answer 네고시에이션에서 원격 유저로부터 받은 offer에 대한 {{Glossary("SDP")}} answer를 생성합니다. 이 answer는 세션이 이미 부착된 미디어, 브라우저에서 지원하는 코덱 및 옵션, 그리고 이미 수집된 {{Glossary("ICE")}} candidate에 대한 정보를 담고 잇습니다. Answer는 반환 된 {{jsxref("Promise")}}에 전달되고, 그 다음에는 네고시에이션 과정을 계속 진행하기 위해서 offer의 소스에게 전달되야합니다.
@@ -48,13 +49,14 @@ RTCPeerConnection.createAnswer(successCallback, failureCallback[, options]);
 > **참고:** 주의 할 점은 이것이 시그널링 과정의 일부이며, 전송계층 구현에 대한 세부사항은 전적으로 개발자에게 달려있다는 것 입니다. 여기서는 [WebSocket](/ko/docs/Web/API/WebSocket_API) 연결을 사용해서 다른 유저에게 "video-answer" 값이 있는 `type` 필드 및 offer를 보낸 장치에게 전달 할 answer를 담은 {{Glossary("JSON")}} 메세지를 보냅니다. 프로미스 fulfillment 핸들러의 다른 모든 항목들과 함께 `sendToServer()`함수로 전달되는 객체의 내용을 어떻게 할 지는 개발자의 디자인에 달려잇습니다.
 
 ```js
-pc.createAnswer().then(function(answer) {
-  return pc.setLocalDescription(answer);
-})
-.then(function() {
-  // Send the answer to the remote peer through the signaling server.
-})
-.catch(handleGetUserMediaError);
+pc.createAnswer()
+  .then(function (answer) {
+    return pc.setLocalDescription(answer);
+  })
+  .then(function () {
+    // Send the answer to the remote peer through the signaling server.
+  })
+  .catch(handleGetUserMediaError);
 ```
 
 위의 예제는 {{domxref("RTCPeerConnection")}}가 신규 answer를 만들고 반환하도록 요청합니다. 프로미스 핸들러에 반환된 answer는 {{domxref("RTCPeerConnection.setLocalDescription", "setLocalDescription()")}} 호출에 의해 연결의 로컬 엔드에 대한 description으로 설정됩니다.

--- a/files/ko/web/api/rtcpeerconnection/createdatachannel/index.md
+++ b/files/ko/web/api/rtcpeerconnection/createdatachannel/index.md
@@ -2,6 +2,7 @@
 title: RTCPeerConnection.createDataChannel()
 slug: Web/API/RTCPeerConnection/createDataChannel
 ---
+
 {{APIRef("WebRTC")}}
 
 {{domxref("RTCPeerConnection")}} 인터페이스의 **`createDataChannel()`** 메소드는 어떤 형식의 데이터든 송신 할 수 있도록 원격 유저와 연결하는 신규 채널을 생성합니다.이 방법은 이미지, 파일 전송, 문자 채팅, 게임 패킷 업데이트 등과 같은 백채널 컨텐츠에 유용하게 사용 가능합니다.
@@ -67,27 +68,27 @@ dataChannel = RTCPeerConnection.createDataChannel(label[, options]);
 
 var pc = new RTCPeerConnection(options);
 var channel = pc.createDataChannel("chat");
-channel.onopen = function(event) {
-  channel.send('Hi you!');
-}
-channel.onmessage = function(event) {
+channel.onopen = function (event) {
+  channel.send("Hi you!");
+};
+channel.onmessage = function (event) {
   console.log(event.data);
-}
+};
 ```
 
 ```js
 // Answerer side
 
 var pc = new RTCPeerConnection(options);
-pc.ondatachannel = function(event) {
+pc.ondatachannel = function (event) {
   var channel = event.channel;
-﻿  channel.onopen = function(event) {
-    channel.send('Hi back!');
-  }
-  channel.onmessage = function(event) {
+  channel.onopen = function (event) {
+    channel.send("Hi back!");
+  };
+  channel.onmessage = function (event) {
     console.log(event.data);
-  }
-}
+  };
+};
 ```
 
 다른 방법으로는 양쪽에서 합의한 id를 사용하여 보다 대칭적인 대역 밴드 외 협상이 가능합니다. (id는 0입니다):
@@ -96,13 +97,13 @@ pc.ondatachannel = function(event) {
 // Both sides
 
 var pc = new RTCPeerConnection(options);
-var channel = pc.createDataChannel("chat", {negotiated: true, id: 0});
-channel.onopen = function(event) {
-  channel.send('Hi!');
-}
-channel.onmessage = function(event) {
+var channel = pc.createDataChannel("chat", { negotiated: true, id: 0 });
+channel.onopen = function (event) {
+  channel.send("Hi!");
+};
+channel.onmessage = function (event) {
   console.log(event.data);
-}
+};
 ```
 
 연결 및 채널이 구성되는 예를 더 자세히 알고 싶다면, [A simple RTCDataChannel sample](/ko/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample)를 참조하십시오.

--- a/files/ko/web/api/rtcpeerconnection/currentremotedescription/index.md
+++ b/files/ko/web/api/rtcpeerconnection/currentremotedescription/index.md
@@ -31,8 +31,7 @@ const pc = new RTCPeerConnection();
 const sd = pc.currentRemoteDescription;
 if (sd) {
   alert(`Local session: type='${sd.type}'; sdp description='${sd.sdp}'`);
-}
-else {
+} else {
   alert("No local session yet.");
 }
 ```

--- a/files/ko/web/api/rtcpeerconnection/datachannel_event/index.md
+++ b/files/ko/web/api/rtcpeerconnection/datachannel_event/index.md
@@ -3,6 +3,7 @@ title: RTCPeerConnection.ondatachannel
 slug: Web/API/RTCPeerConnection/datachannel_event
 original_slug: Web/API/RTCPeerConnection/ondatachannel
 ---
+
 {{APIRef("WebRTC")}}{{SeeCompatTable}}
 
 **`RTCPeerConnection.ondatachannel`** 속성은 {{domxref("RTCPeerConnection")}}에서 발생하는 {{event("datachannel")}} 이벤트에 의해 호출되는 {{event("Event_handlers", "event handler")}}입니다. 이 속성에는 함수를 정의하게됩니다. {{domxref("RTCDataChannelEvent")}}의 한 종류인 이 이벤트는 원격 유저가 {{domxref("RTCPeerConnection.createDataChannel", "createDataChannel()")}}를 호출해서 연결에 {{domxref("RTCDataChannel")}}가 추가되었을 때, 전달됩니다.
@@ -22,10 +23,10 @@ RTCPeerConnection.ondatachannel = function;
 ## 예시
 
 ```js
-pc.ondatachannel = function(ev) {
-  console.log('Data channel is created!');
-  ev.channel.onopen = function() {
-    console.log('Data channel is open and ready to be used.');
+pc.ondatachannel = function (ev) {
+  console.log("Data channel is created!");
+  ev.channel.onopen = function () {
+    console.log("Data channel is open and ready to be used.");
   };
 };
 ```

--- a/files/ko/web/api/rtcpeerconnection/generatecertificate_static/index.md
+++ b/files/ko/web/api/rtcpeerconnection/generatecertificate_static/index.md
@@ -11,7 +11,7 @@ original_slug: Web/API/RTCPeerConnection/generateCertificate
 ## Syntax
 
 ```js
-var cert = RTCPeerConnection.generateCertificate(keygenAlgorithm)
+var cert = RTCPeerConnection.generateCertificate(keygenAlgorithm);
 ```
 
 ### 매개변수
@@ -29,12 +29,12 @@ var cert = RTCPeerConnection.generateCertificate(keygenAlgorithm)
 
 ```js
 RTCPeerConnection.generateCertificate({
-    name: 'RSASSA-PKCS1-v1_5',
-    hash: 'SHA-256',
-    modulusLength: 2048,
-    publicExponent: new Uint8Array([1, 0, 1])
-}).then(function(cert) {
-  var pc = new RTCPeerConnection({certificates: [cert]});
+  name: "RSASSA-PKCS1-v1_5",
+  hash: "SHA-256",
+  modulusLength: 2048,
+  publicExponent: new Uint8Array([1, 0, 1]),
+}).then(function (cert) {
+  var pc = new RTCPeerConnection({ certificates: [cert] });
 });
 ```
 

--- a/files/ko/web/api/rtcpeerconnection/getconfiguration/index.md
+++ b/files/ko/web/api/rtcpeerconnection/getconfiguration/index.md
@@ -30,13 +30,16 @@ var configuration = RTCPeerConnection.getConfiguration();
 ```js
 let configuration = myPeerConnection.getConfiguration();
 
-if ((configuration.certificates != undefined) && (!configuration.certificates.length)) {
-   RTCPeerConnection.generateCertificate({
-      name: 'RSASSA-PKCS1-v1_5',
-      hash: 'SHA-256',
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1])
-  }).then(function(cert) {
+if (
+  configuration.certificates != undefined &&
+  !configuration.certificates.length
+) {
+  RTCPeerConnection.generateCertificate({
+    name: "RSASSA-PKCS1-v1_5",
+    hash: "SHA-256",
+    modulusLength: 2048,
+    publicExponent: new Uint8Array([1, 0, 1]),
+  }).then(function (cert) {
     configuration.certificates = [cert];
     myPeerConnection.setConfiguration(configuration);
   });

--- a/files/ko/web/api/rtcpeerconnection/getidentityassertion/index.md
+++ b/files/ko/web/api/rtcpeerconnection/getidentityassertion/index.md
@@ -2,6 +2,7 @@
 title: RTCPeerConnection.getIdentityAssertion()
 slug: Web/API/RTCPeerConnection/getIdentityAssertion
 ---
+
 {{APIRef("WebRTC")}}{{SeeCompatTable}}
 
 **`RTCPeerConnection.getIdentityAssertion()`** 메소드는 식별 주장의 수집을 시작합니다. 이 메소드는 {{domxref("RTCPeerConnection.signalingState", "signalingState")}}가 `"closed"` 상태가 아닐 때에만 유효합니다.

--- a/files/ko/web/api/rtcpeerconnection/gettransceivers/index.md
+++ b/files/ko/web/api/rtcpeerconnection/gettransceivers/index.md
@@ -2,6 +2,7 @@
 title: RTCPeerConnection.getTransceivers()
 slug: Web/API/RTCPeerConnection/getTransceivers
 ---
+
 {{APIRef("WebRTC")}}
 
 {{domxref("RTCPeerConnection")}} 인터페이스의 **`getTransceivers()`** 메소드는 연결에서 데이터 전송 및 수신에 사용되는 {{domxref("RTCRtpTransceiver")}} 객체의 리스트를 반환합니다.
@@ -25,7 +26,7 @@ transceiverList = RTCPeerConnection.getTransceivers();
 아래 코드는 `RTCPeerConnection`와 연관된 모든 트랜시버를 중지시킵니다.
 
 ```js
-pc.getTransceivers.forEach(transceiver => {
+pc.getTransceivers.forEach((transceiver) => {
   transceiver.stop();
 });
 ```

--- a/files/ko/web/api/rtcpeerconnection/icecandidate_event/index.md
+++ b/files/ko/web/api/rtcpeerconnection/icecandidate_event/index.md
@@ -23,14 +23,14 @@ RTCPeerConnection.onicecandidate = eventHandler;
 아래는 [Signaling and video calling](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling) 문서의 코드를 기반으로 원격 피어에게 ICE candidate를 전달하는 {{event("icecandidate")}} 이벤트에 대한 핸들러를 설정합니다.
 
 ```js
-pc.onicecandidate = function(event) {
+pc.onicecandidate = function (event) {
   if (event.candidate) {
     // event.candidate가 존재하면 원격 유저에게 candidate를 전달합니다.
   } else {
     // 모든 ICE candidate가 원격 유저에게 전달된 조건에서 실행됩니다.
     // candidate = null
   }
-}
+};
 ```
 
 위에서 알 수 있듯이, 이벤트의 {{domxref("RTCPeerConnectionIceEvent.candidate", "candidate")}} 속성이 `null`이면 네고시에이션의 종료가 감지됩니다.

--- a/files/ko/web/api/rtcpeerconnection/icegatheringstate/index.md
+++ b/files/ko/web/api/rtcpeerconnection/icegatheringstate/index.md
@@ -23,8 +23,8 @@ var state = RTCPeerConnection.iceGatheringState;
 
 [`RTCPeerConnection.iceGatheringState`](/ko/docs/Web/API/RTCPeerConnection/iceGatheringState) 속성을 사용하게되면 반환되는 `RTCIceGatheringState` enum은 현재의 ICE 수집 상태를 반영하여 알려주는 문자열 상수입니다. {{DOMxRef("RTCPeerConnection/icegatheringstatechange_event", "icegatheringstatechange")}} 타입의 이벤트를 감시해서 이 값이 언제 변하는지 확인 할 수 있습니다.
 
-| 상수명 | 설명 |
-| --- | --- |
+| 상수명        | 설명                                                                                                                                                                                                         |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `"new"`       | 피어 연결이 새로 생성되었지만, 아직 네트워킹은 시작되지 않은 상태                                                                                                                                            |
 | `"gathering"` | ICE 에이전트가 연결을 위한 ICE candidate를 수집하는 과정에 있음을 알려주는 상태                                                                                                                              |
 | `"complete"`  | ICE 에이전트가 candidate 수집을 완료한 상태. 새로운 인터페이스가 추가되거나, 신규 ICE 서버가 추가와 같이 신규 ICE candidate를 수집해야하는 상황이 오면, 상태가 `complete`에서 `gathering`으로 다시 바뀝니다. |

--- a/files/ko/web/api/rtcpeerconnection/icegatheringstatechange_event/index.md
+++ b/files/ko/web/api/rtcpeerconnection/icegatheringstatechange_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'RTCPeerConnection: icegatheringstatechange event'
+title: "RTCPeerConnection: icegatheringstatechange event"
 slug: Web/API/RTCPeerConnection/icegatheringstatechange_event
 ---
 
@@ -9,10 +9,10 @@ slug: Web/API/RTCPeerConnection/icegatheringstatechange_event
 
 ICE가 처음 연결 candidate들을 수집하게되면 값이 `new`에서 `gathering`으로 바뀌게 되고, 이는 연결에 대한 candidate 설정들을 수집하는 과정 중에 있다는 뜻입니다. 값이 complete가 되면, RTCPeerConnection을 구성하는 모든 트랜스포트들이 ICE candidate 수집을 완료한 상태입니다.
 
-| Bubbles       | No                                                                                                                   |
-| ------------- | -------------------------------------------------------------------------------------------------------------------- |
-| 취소가능여부  | No                                                                                                                   |
-| 인터페이스    | {{domxref("Event")}}                                                                                         |
+| Bubbles       | No                                                                                      |
+| ------------- | --------------------------------------------------------------------------------------- |
+| 취소가능여부  | No                                                                                      |
+| 인터페이스    | {{domxref("Event")}}                                                                    |
 | 이벤트 핸들러 | {{domxref("RTCPeerConnection.onicegatheringstatechange", "onicegatheringstatechange")}} |
 
 > **참고:** ICE candidate 수집 과정이 완료되었는지는 `icegatheringstatechange`이벤트와 {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}}의 값이 `complete`로 바뀌는 것을 확인하면 알 수 있습니다. 하지만, 더 쉬운 방법으로는 {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} 이벤트에 대한 핸들러가 {{domxref("RTCPeerConnectionIceEvent.candidate", "candidate")}} 속성의 값이 null로 변하는 시점을 체크하도록 할 수 있습니다. 이 속성이 `null` 값으로 바뀌었다는 것은 즉 모든 candidate 수집이 완료되었다는 뜻입니다.
@@ -22,10 +22,10 @@ ICE가 처음 연결 candidate들을 수집하게되면 값이 `new`에서 `gath
 아래 예제는 `icegatheringstatechange` 이벤트에대한 핸들러를 생성합니다.
 
 ```js
-pc.onicegatheringstatechange = ev => {
+pc.onicegatheringstatechange = (ev) => {
   let connection = ev.target;
 
-  switch(connection.iceGatheringState) {
+  switch (connection.iceGatheringState) {
     case "gathering":
       /* candidate 수집 과정 시작 */
       break;
@@ -33,24 +33,28 @@ pc.onicegatheringstatechange = ev => {
       /* candidate 수집 완료 */
       break;
   }
-}
+};
 ```
 
 아래처럼 {{domxref("EventTarget.addEventListener", "addEventListener()")}}을 사용해서 `icegatheringstatechange` 이벤트에 대한 변경을 감지하는 리스너를 추가 할 수 있습니다.
 
 ```js
-pc.addEventListener("icegatheringstatechange", ev => {
-  let connection = ev.target;
+pc.addEventListener(
+  "icegatheringstatechange",
+  (ev) => {
+    let connection = ev.target;
 
-  switch(connection.iceGatheringState) {
-    case "gathering":
-      /* candidate 수집 과정 시작 */
-      break;
-    case "complete":
-      /* candidate 수집 완료 */
-      break;
-  }
-}, false);
+    switch (connection.iceGatheringState) {
+      case "gathering":
+        /* candidate 수집 과정 시작 */
+        break;
+      case "complete":
+        /* candidate 수집 완료 */
+        break;
+    }
+  },
+  false,
+);
 ```
 
 ## 명세

--- a/files/ko/web/api/rtcpeerconnection/index.md
+++ b/files/ko/web/api/rtcpeerconnection/index.md
@@ -2,6 +2,7 @@
 title: RTCPeerConnection
 slug: Web/API/RTCPeerConnection
 ---
+
 {{APIRef('WebRTC')}}
 
 **`RTCPeerConnection`** 인터페이스는 로컬 컴퓨터와 원격 피어 간의 WebRTC 연결을 담당하며 원격 피어에 연결하기 위한 메서드들을 제공하고, 연결을 유지하고 연결 상태를 모니터링하며 더 이상 연결이 필요하지 않을 경우 연결을 종료합니다.
@@ -28,11 +29,13 @@ slug: Web/API/RTCPeerConnection
 - {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}}
   - : ICE candidate를 수집하는 과정에서 에러가 발생하면 연결에 {{domxref("RTCPeerConnectionIceErrorEvent")}} 에러 타입을 보냅니다. 이는 또한, {{domxref("RTCPeerConnection.onicecandidateerror", "onicecandidateerror")}} 이벤트 핸들러 속성을 통해 사용이 가능합니다.
 - {{domxref("RTCPeerConnection.iceconnectionstatechange_event", "iceconnectionstatechange")}}
+
   - : 연결이 끊기는 상황과 같이 ICE 연결의 상태가 변하게되면 `RTCPeerConnection`에 전달합니다. 이는 또한, {{domxref("RTCPeerConnection.oniceconnectionstatechange", "oniceconnectionstatechange")}} 이벤트 핸들러 속성을 통해 사용이 가능합니다.
 
 - {{domxref("RTCPeerConnection.icegatheringstatechange_event", "icegatheringstatechange")}}
   - : {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}}에 의해 반영되는 ICE 계층의 수집 상태가 변하면, `RTCPeerConnection`에 전달합니다. 계층의 수집 상태는 ICE 네고시에이션이 아직 시작을 안했거나 (`new`), 시작하고 candidate를 수집하는 중이거나 (`gathering`), 혹은 수집이 완료 (`complete`)된 상태로 나눠집니다. 이는 또한, {{domxref("RTCPeerConnection.onicegatheringstatechange", "onicegatheringstatechange")}} 이벤트 핸들러 속성을 통해 사용이 가능합니다.
 - {{domxref("RTCPeerConnection.isolationchange_event", "isolationchange")}}
+
   - : 연결과 관련이 있는 하나의 {{domxref("MediaStreamTrack")}} 객체가 있는 {{domxref("MediaStreamTrack.isolated", "isolated")}} 속성의 값이 변하면, `RTCPeerConnection`에 전달합니다. 만약 미디어 컨텐츠가 인증이 되어있지 않거나, 트랙이 cross-origin source (CORS)에서 오는 것이라면 트랙의 상태는 {{domxref("MediaStreamTrack.isolated", "isolated")}}이 됩니다. 이는 또한, {{domxref("RTCPeerConnection.onisolationchange", "onisolationchange")}} 이벤트 핸들러 속성을 통해 사용이 가능합니다.
 
 - {{domxref("RTCPeerConnection.negotiationneeded_event", "negotiationneeded")}}
@@ -40,11 +43,13 @@ slug: Web/API/RTCPeerConnection
 - {{domxref("RTCPeerConnection.signalingstatechange_event", "signalingstatechange")}}
   - : 연결의 ICE 신호 상태가 변경되면 `signalingstatechange`이벤트를 `RTCPeerConnection`에 전달합니다. 이는 또한, {{domxref("RTCPeerConnection.onsignalingstatechange", "onsignalingstatechange")}} 이벤트 핸들러 속성을 통해 사용이 가능합니다.
 - {{domxref("RTCPeerConnection.statsended_event", "statsended")}}
+
   - : 모니터링이 되던 statistics 객체가 삭제되면, `statsended`이벤트를 전달합니다. {{domxref("RTCStatsEvent")}}는 삭제된 객체의 마지막 리포트를 포함합니다. 마지막 리포트를 전달받고나서 여러개의 객체가 삭제되었다면, 여러 객체에 대한 마지막 리포트를 포함합니다. 예를 들어 연결이 종료되거나 삭제되면, statistics 객체는 삭제됩니다.
 
     The `statsended` event is sent when a statistics object being monitored is deleted. The {{domxref("RTCStatsEvent")}} includes the final report on the deleted object (or objects, if multiple objects have been deleted since the last report was delivered). A statistics object is deleted, for example, when the connection is closed and deleted.
 
     Available as the {{domxref("RTCPeerConnection.onstatsended", "onstatsended")}} event handler property.
+
 - {{domxref("RTCPeerConnection.track_event", "track")}}
   - : 연결을 구성하고 있는 {{domxref("RTCRtpReceiver")}} 인스턴스들 중 하나에 신규 트랙이 추가된 후에, `track`이벤트를 보냅니다. 이는 또한, {{domxref("RTCPeerConnection.ontrack", "ontrack")}} 이벤트 핸들러 속성을 통해 사용이 가능합니다.
 
@@ -86,13 +91,13 @@ The `RTCBundlePolicy` enum defines string constants which are used to request a 
 
 The `RTCIceConnectionState` enum defines the string constants used to describe the current state of the ICE agent and its connection to the ICE server (that is, the {{Glossary("STUN")}} or {{Glossary("TURN")}} server).
 
-| 상수명           | 설명                                                                                                                                                                                                                                                                                                                                                                                                       |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"new"`          | The ICE agent is gathering addresses or is waiting to be given remote candidates through calls to {{domxref("RTCPeerConnection.addIceCandidate()")}} (or both).                                                                                                                                                                                                                          |
-| `"checking"`     | The ICE agent has been given one or more remote candidates and is checking pairs of local and remote candidates against one another to try to find a compatible match, but has not yet found a pair which will allow the peer connection to be made. It's possible that gathering of candidates is also still underway.                                                                                    |
-| `"connected"`    | A usable pairing of local and remote candidates has been found for all components of the connection, and the connection has been established. It's possible that gathering is still underway, and it's also possible that the ICE agent is still checking candidates against one another looking for a better connection to use.                                                                           |
-| `"completed"`    | The ICE agent has finished gathering candidates, has checked all pairs against one another, and has found a connection for all components.                                                                                                                                                                                                                                                                 |
-| `"failed"`       | The ICE candidate has checked all candidates pairs against one another and has failed to find compatible matches for all components of the connection. It is, however, possible that the ICE agent did find compatible connections for some components.                                                                                                                                                    |
+| 상수명           | 설명                                                                                                                                                                                                                                                                                                                                                                                           |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"new"`          | The ICE agent is gathering addresses or is waiting to be given remote candidates through calls to {{domxref("RTCPeerConnection.addIceCandidate()")}} (or both).                                                                                                                                                                                                                                |
+| `"checking"`     | The ICE agent has been given one or more remote candidates and is checking pairs of local and remote candidates against one another to try to find a compatible match, but has not yet found a pair which will allow the peer connection to be made. It's possible that gathering of candidates is also still underway.                                                                        |
+| `"connected"`    | A usable pairing of local and remote candidates has been found for all components of the connection, and the connection has been established. It's possible that gathering is still underway, and it's also possible that the ICE agent is still checking candidates against one another looking for a better connection to use.                                                               |
+| `"completed"`    | The ICE agent has finished gathering candidates, has checked all pairs against one another, and has found a connection for all components.                                                                                                                                                                                                                                                     |
+| `"failed"`       | The ICE candidate has checked all candidates pairs against one another and has failed to find compatible matches for all components of the connection. It is, however, possible that the ICE agent did find compatible connections for some components.                                                                                                                                        |
 | `"disconnected"` | Checks to ensure that components are still connected failed for at least one component of the {{domxref("RTCPeerConnection")}}. This is a less stringent test than `"failed"` and may trigger intermittently and resolve just as spontaneously on less reliable networks, or during temporary disconnections. When the problem resolves, the connection may return to the `"connected"` state. |
 | `"closed"`       | The ICE agent for this {{domxref("RTCPeerConnection")}} has shut down and is no longer handling requests.                                                                                                                                                                                                                                                                                      |
 
@@ -110,33 +115,33 @@ The `RTCIceConnectionState` enum defines the string constants used to describe t
 
 The `RTCIceTransportPolicy` enum defines string constants which can be used to limit the transport policies of the ICE candidates to be considered during the connection process.
 
-| 상수명                                  | 설명                                                                                                                            |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `"all"`                                 | All ICE candidates will be considered.                                                                                          |
+| 상수명                           | 설명                                                                                                                            |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `"all"`                          | All ICE candidates will be considered.                                                                                          |
 | `"public"` {{deprecated_inline}} | Only ICE candidates with public IP addresses will be considered. _Removed from the specification's May 13, 2016 working draft._ |
-| `"relay"`                               | Only ICE candidates whose IP addresses are being relayed, such as those being passed through a TURN server, will be considered. |
+| `"relay"`                        | Only ICE candidates whose IP addresses are being relayed, such as those being passed through a TURN server, will be considered. |
 
 ### RTCPeerConnectionState enum
 
 `RTCPeerConnectionState` enum은 `RTCPeerConnection`이 존재 할 수 도있는 상태에 대해 알려주는 문자열 상수를 정의합니다. 이 값들은 {domxref("RTCPeerConnection.connectionState", "connectionState")}} 속성에 의해 반홥됩니다. 근본적으로 이 상태는 연결에 의해 사용되는 모든 ICE 전송 ({{domxref("RTCIceTransport")}} 혹은 {{domxref("RTCDtlsTransport")}}의 타입)의 상태 집합을 나타냅니다.
 
-| 상수명           | 설명                                                                                                                                                                                                                                                                                                                       |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"new"`          | 연결의 ICE 전송 중 적어도 한 개가 새로 만들어진 `"new"` 상태이고, 그 외의 나머지는 다음의 상태 중 하나가 아니여야 합니다: `"connecting"`, `"checking"`, `"failed"`, 혹은 `"disconnected"`, 혹은 모든 연결의 전송이 끝났다는 `"closed"`상태.                                                                                |
-| `"connecting"`   | 하나 혹은 여러개의 ICE 전송이 현재 연결을 구성하는 중에 있음을 알려주는 값. 이는 `RTCIceConnectionState`가 `"checking"` 혹은 `"connected"`이며, 그 어떤 전송도 `"failed"`상태가 아니여야합니다. **<<< Make this a link once I know where that will be documented**                                                         |
-| `"connected"`    | 연결에 의해 사용되는 모든 ICE 전송이 사용 중 (`"connected"` 혹은 `"completed"`)이거나, 종료된 상태입니다. 추가적으로 최소 하나의 전송이 `"connected"` 혹은 `"completed"`입니다.                                                                                                                                            |
-| `"disconnected"` | 연결에 대한 최소 한 개의 ICE 전송이 `"disconnected"`상태이고, 그 외의 다른 전송 상태는 `"failed"`, `"connecting"`, 혹은 `"checking"`이 아님을 알려주는 값.                                                                                                                                                                 |
-| `"failed"`       | 연결에 대한 하나 혹은 여러개의 ICE 전송이 `"failed"`상태임을 알려주는 값.                                                                                                                                                                                                                                                  |
+| 상수명           | 설명                                                                                                                                                                                                                                                                                                |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"new"`          | 연결의 ICE 전송 중 적어도 한 개가 새로 만들어진 `"new"` 상태이고, 그 외의 나머지는 다음의 상태 중 하나가 아니여야 합니다: `"connecting"`, `"checking"`, `"failed"`, 혹은 `"disconnected"`, 혹은 모든 연결의 전송이 끝났다는 `"closed"`상태.                                                         |
+| `"connecting"`   | 하나 혹은 여러개의 ICE 전송이 현재 연결을 구성하는 중에 있음을 알려주는 값. 이는 `RTCIceConnectionState`가 `"checking"` 혹은 `"connected"`이며, 그 어떤 전송도 `"failed"`상태가 아니여야합니다. **<<< Make this a link once I know where that will be documented**                                  |
+| `"connected"`    | 연결에 의해 사용되는 모든 ICE 전송이 사용 중 (`"connected"` 혹은 `"completed"`)이거나, 종료된 상태입니다. 추가적으로 최소 하나의 전송이 `"connected"` 혹은 `"completed"`입니다.                                                                                                                     |
+| `"disconnected"` | 연결에 대한 최소 한 개의 ICE 전송이 `"disconnected"`상태이고, 그 외의 다른 전송 상태는 `"failed"`, `"connecting"`, 혹은 `"checking"`이 아님을 알려주는 값.                                                                                                                                          |
+| `"failed"`       | 연결에 대한 하나 혹은 여러개의 ICE 전송이 `"failed"`상태임을 알려주는 값.                                                                                                                                                                                                                           |
 | `"closed"`       | `RTCPeerConnection` 개통되지 않음을 알려주는 값.2016년 5월 13일에 작성된 명세서의 초안에 따르면, 이 값은 [`RTCPeerConnectionState` enum](#RTCPeerConnectionState_enum) 안에 존재했었습니다. 따라서, {{domxref("RTCPeerConnection.signalingState", "signalingState")}}의 값을 통해 찾을 수 있습니다. |
 
 ### RTCRtcpMuxPolicy enum
 
 The `RTCRtcpMuxPolicy` enum defines string constants which specify what ICE candidates are gathered to support non-multiplexed RTCP. **<<\<add a link to info about multiplexed RTCP.**
 
-| 상수명        | 설명                                                                                                                                                                                                                                                                                                  |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 상수명        | 설명                                                                                                                                                                                                                                                                                     |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `"negotiate"` | Instructs the ICE agent to gather both {{Glossary("RTP")}} and {{Glossary("RTCP")}} candidates. If the remote peer can multiplex RTCP, then RTCP candidates are multiplexed atop the corresponding RTP candidates. Otherwise, both the RTP and RTCP candidates are returned, separately. |
-| `"require"`   | Tells the ICE agent to gather ICE candidates for only RTP, and to multiplex RTCP atop them. If the remote peer doesn't support RTCP multiplexing, then session negotiation fails.                                                                                                                     |
+| `"require"`   | Tells the ICE agent to gather ICE candidates for only RTP, and to multiplex RTCP atop them. If the remote peer doesn't support RTCP multiplexing, then session negotiation fails.                                                                                                        |
 
 ### RTCSignalingState enum
 

--- a/files/ko/web/api/rtcpeerconnection/localdescription/index.md
+++ b/files/ko/web/api/rtcpeerconnection/localdescription/index.md
@@ -27,8 +27,7 @@ const pc = new RTCPeerConnection();
 const sd = pc.localDescription;
 if (sd) {
   alert(`Local session: type='${sd.type}'; sdp description='${sd.sdp}'`);
-}
-else {
+} else {
   alert("No local session yet.");
 }
 ```

--- a/files/ko/web/api/rtcpeerconnection/removetrack/index.md
+++ b/files/ko/web/api/rtcpeerconnection/removetrack/index.md
@@ -35,16 +35,20 @@ pc.removeTrack(sender);
 
 ```js
 var pc, sender;
-navigator.getUserMedia({video: true}, function(stream) {
+navigator.getUserMedia({ video: true }, function (stream) {
   pc = new RTCPeerConnection();
   var track = stream.getVideoTracks()[0];
   sender = pc.addTrack(track, stream);
 });
 
-document.getElementById("closeButton").addEventListener("click", function(event) {
-  pc.removeTrack(sender);
-  pc.close();
-}, false);
+document.getElementById("closeButton").addEventListener(
+  "click",
+  function (event) {
+    pc.removeTrack(sender);
+    pc.close();
+  },
+  false,
+);
 ```
 
 ## 사양서

--- a/files/ko/web/api/rtcpeerconnection/restartice/index.md
+++ b/files/ko/web/api/rtcpeerconnection/restartice/index.md
@@ -36,7 +36,7 @@ ICE 재시작의 작동원리를 좀 더 자세히 알고 싶다면, [ICE restar
 아래의 예제는 {{domxref("RTCPeerConnection.iceconnectionstatechange_event", "iceconnectionstatechange")}} 이벤트에 대한 핸들러입니다. 이 핸들러는 ICE를 재시작하여 `failed` 상태로의 전환을 관리합니다.
 
 ```js
-pc.addEventListener("iceconnectionstatechange", event => {
+pc.addEventListener("iceconnectionstatechange", (event) => {
   if (pc.iceConnectionState === "failed") {
     /* possibly reconfigure the connection in some way here */
     /* then request ICE restart */

--- a/files/ko/web/api/rtcpeerconnection/rtcpeerconnection/index.md
+++ b/files/ko/web/api/rtcpeerconnection/rtcpeerconnection/index.md
@@ -16,11 +16,15 @@ pc = new RTCPeerConnection([configuration]);
 ### 매개변수
 
 - `configuration` {{optional_inline}}
+
   - : 새로운 연결을 설정하는 옵션 객체입니다.
+
     - `bundlePolicy` {{optional_inline}}
+
       - : 원격 피어가 [SDP BUNDLE 표준](https://webrtcstandards.info/sdp-bundle/)과 호환되지 않을 때 어떻게 candidate의 네고시에이션을 처리 할 것인지를 정의합니다.
 
         가능한 값은 다음 열거형 값 중 하나로, 기본 값은 `balanced`입니다.
+
         - `balanced`
           - : The ICE agent initially creates one {{domxref("RTCDtlsTransport")}}
             for each type of content added: audio, video, and data channels.
@@ -36,14 +40,19 @@ pc = new RTCPeerConnection([configuration]);
             to carry all of the {{DOMxRef("RTCPeerConnection")}}'s data.
             If the remote endpoint is not BUNDLE-aware,
             then only a single track will be negotiated and the rest ignored.
+
     - `certificates` {{optional_inline}}
+
       - : 연결 인증에 사용할 {{domxref("RTCCertificate")}}를 담은 {{jsxref("Array")}}입니다. 지정하지 않을 경우 {{domxref("RTCPeerConnection")}} 인스턴스 각각에 대해 인증서가 자동으로 생성됩니다. 주어진 연결에 대해 하나의 인증서만 사용되지만, 다양한 알고리즘을 사용하는 여러 인증서를 제공하면 특정 상황에서의 연결 성공률을 높일 수 있습니다. 아래의 [인증서 사용하기](#인증서_사용하기)에서 더 많은 정보를 확인하세요.
 
         > **참고:** 이 옵션은 처음 지정한 이후 변경할 수 없습니다. 인증서를 설정한 후엔 모든 {{domxref("RTCPeerConnection.setConfiguration()")}}이 무시됩니다.
+
     - `iceCandidatePoolSize` {{optional_inline}}
+
       - : ICE candidate 풀의 크기를 지정하는 부호 없는 16비트 정수 값입니다. 기본 값은 0으로 candidate 를 미리 가져오지 않을 것임을 나타냅니다. 연결 시도 전부터 ICE 에이전트가 ICE candidate를 가져올 수 있도록 허용하면 {{domxref("RTCPeerConnection.setLocalDescription()")}} 호출 시점에 이미 candidate를 조사할 수 있으므로 특정 상황에서 연결 속도가 빨라질 수 있습니다.
 
         > **참고:** ICE candidate 풀의 크기를 변경하면 ICE 수집이 시작할 수 있습니다.
+
     - `iceServers` {{optional_inline}}
       - : ICE 에이전트가 사용할 수 있는 서버(보통 STUN/TURN)를 설명하는 {{domxref("RTCIceServer")}} 객체의 배열입니다. 지정하지 않을 경우 STUN/TURN 서버를 사용하지 않고 연결 시도를 하므로 연결이 로컬 피어로 제한됩니다.
     - `iceTransportPolicy` {{optional_inline}}

--- a/files/ko/web/api/rtcpeerconnection/setconfiguration/index.md
+++ b/files/ko/web/api/rtcpeerconnection/setconfiguration/index.md
@@ -2,6 +2,7 @@
 title: RTCPeerConnection.setConfiguration()
 slug: Web/API/RTCPeerConnection/setConfiguration
 ---
+
 {{APIRef("WebRTC")}}{{SeeCompatTable}}
 
 **`RTCPeerConnection.setConfiguration()`** 메소드는 {{domxref("RTCConfiguration")}}객체에 명시한 값을 가지고 {{domxref("RTCPeerConnection")}}의 현재 설정을 지정합니다. 이 메소드를 사용해서 연결에서 사용되는 ICE 서버와 전송 정책을 변경 할 수 있습니다.
@@ -40,22 +41,27 @@ RTCPeerConnection.setConfiguration(configuration);
 아래의 예시에서는 ICE 재시작이 필요한 것을 확인하고, 다른 ICE 서버를 사용해서 협상이 이루어지도록 합니다.
 
 ```js
-var restartConfig = { iceServers: [{
-                          urls: "turn:asia.myturnserver.net",
-                          username: "allie@oopcode.com",
-                          credential: "topsecretpassword"
-                      }]
+var restartConfig = {
+  iceServers: [
+    {
+      urls: "turn:asia.myturnserver.net",
+      username: "allie@oopcode.com",
+      credential: "topsecretpassword",
+    },
+  ],
 };
 
 myPeerConnection.setConfiguration(restartConfig);
 
-myPeerConnection.createOffer({"iceRestart": true}).then(function(offer) {
-  return myPeerConnection.setLocalDescription(offer);
-})
-.then(function() {
-  // send the offer to the other peer using the signaling server
-})
-.catch(reportError);
+myPeerConnection
+  .createOffer({ iceRestart: true })
+  .then(function (offer) {
+    return myPeerConnection.setLocalDescription(offer);
+  })
+  .then(function () {
+    // send the offer to the other peer using the signaling server
+  })
+  .catch(reportError);
 ```
 
 먼저, 신규 {{domxref("RTCConfiguration")}}가 신규 ICE 서버와 인증 정보를 명시한 `restartConfig`를 가지도록 생성됩니다. 그리고 설정한 {{domxref("RTCConfiguration")}}가 `setConfiguration()`에 전달됩니다. `iceRestart` 옵션의 값을 `true`로 지정하고, {{domxref("RTCPeerConnection.createOffer()", "createOffer()")}}을 호출해서 ICE 협상이 재시작됩니다. 이후에, 반환받은 offer를 local description으로 설정하고, 다른 피어에게 offer를 전달하는 것과 같이 일반적으로 진행되도록 처리합니다.

--- a/files/ko/web/api/rtcpeerconnection/setidentityprovider/index.md
+++ b/files/ko/web/api/rtcpeerconnection/setidentityprovider/index.md
@@ -2,6 +2,7 @@
 title: RTCPeerConnection.setIdentityProvider()
 slug: Web/API/RTCPeerConnection/setIdentityProvider
 ---
+
 {{APIRef("WebRTC")}}{{SeeCompatTable}}
 
 **`RTCPeerConnection.setIdentityProvider()`** 메소드는 이름, 통신에 사용된 프로토콜 (옵션), 유저 이름 (옵션)으로 구성된 세 가지 매개변수에 식별 제공자 (Identity Provider, IdP)를 지정합니다. IdP는 주장 (assertion)이 필요한 순간에만 사용 될 것입니다.

--- a/files/ko/web/api/rtcpeerconnection/setlocaldescription/index.md
+++ b/files/ko/web/api/rtcpeerconnection/setlocaldescription/index.md
@@ -29,7 +29,7 @@ pc.setLocalDescription(sessionDescription, successCallback, errorCallback);
 `sessionDescription` 매개 변수는 일단 기술적으로는 `RTCSessionDescriptionInit`의 타입입니다. 하지만, {{domxref("RTCSessionDescription")}}가 `RTCSessionDescriptionInit`와 구별이 불가능하도록 직렬화 (serialize)하기 때문에, `RTCSessionDescription`를 전달 할 수도 있습니다. 이 말은 코드가 다음과 같이 간단해질 수 있다는 뜻입니다:
 
 ```js
-myPeerConnection.createOffer().then(function(offer) {
+myPeerConnection.createOffer().then(function (offer) {
   return myPeerConnection.setLocalDescription(new RTCSessionDescription(offer));
 });
 ```
@@ -74,13 +74,14 @@ myPeerConnection.createOffer().then(myPeerConnection.setLocalDescription);
 
 ```js
 function handleNegotiationNeededEvent() {
-  pc.createOffer().then(function(offer) {
-    return pc.setLocalDescription(offer);
-  })
-  .then(function() {
-    // Send the offer to the remote peer using the signaling server
-  })
-  .catch(reportError);
+  pc.createOffer()
+    .then(function (offer) {
+      return pc.setLocalDescription(offer);
+    })
+    .then(function () {
+      // Send the offer to the remote peer using the signaling server
+    })
+    .catch(reportError);
 }
 ```
 

--- a/files/ko/web/api/rtcpeerconnection/track_event/index.md
+++ b/files/ko/web/api/rtcpeerconnection/track_event/index.md
@@ -25,7 +25,7 @@ RTCPeerConnection.ontrack = eventHandler;
 아래의 예시는 [Signaling and video calling](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling) 문서에 나온 코드의 일부입니다. 이 코드는 들어오는 트랙을 {{HTMLElement("video")}}에 연결해서 해당 비디오를 보여줄 수 있도록 합니다.
 
 ```js
-pc.ontrack = function(event) {
+pc.ontrack = function (event) {
   document.getElementById("received_video").srcObject = event.streams[0];
   document.getElementById("hangup-button").disabled = false;
 };

--- a/files/ko/web/api/rtcpeerconnectioniceevent/candidate/index.md
+++ b/files/ko/web/api/rtcpeerconnectioniceevent/candidate/index.md
@@ -2,6 +2,7 @@
 title: RTCPeerConnectionIceEvent.candidate
 slug: Web/API/RTCPeerConnectionIceEvent/candidate
 ---
+
 {{APIRef("WebRTC")}}
 
 {{domxref("RTCPeerConnectionIceEvent")}} 인터페이스의 candidate 속성은 읽기 전용입니다. 이 속성은 {{domxref("RTCIceCandidate")}}와 관련된 이벤트를 반환합니다.
@@ -9,7 +10,7 @@ slug: Web/API/RTCPeerConnectionIceEvent/candidate
 ## Syntax
 
 ```js
- var candidate = event.candidate;
+var candidate = event.candidate;
 ```
 
 ### 값
@@ -19,11 +20,13 @@ ICE candidate를 나타내는 {{domxref("RTCIceCandidate")}} 객체. 해당 네�
 ## 예시
 
 ```js
-pc.onicecandidate = function( ev ) {
-  alert("The ICE candidate (transport address: '" +
-    ev.candidate.candidate +
-    "') has been added to this connection.");
-}
+pc.onicecandidate = function (ev) {
+  alert(
+    "The ICE candidate (transport address: '" +
+      ev.candidate.candidate +
+      "') has been added to this connection.",
+  );
+};
 ```
 
 ## 명세


### PR DESCRIPTION
This PR formats the `/web/api` folder of the Korean locale using Prettier.  This is the fourth part.
