### PR TITLE
ja: Format /web/css using Prettier (part 1)

### DIFF
--- a/files/ja/web/css/--_star_/index.md
+++ b/files/ja/web/css/--_star_/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'カスタムプロパティ (--*): CSS 変数'
+title: "カスタムプロパティ (--*): CSS 変数"
 slug: Web/CSS/--*
 l10n:
   sourceCommit: 8318078e0cf65cd4d56e80376c03019dcb292dc1

--- a/files/ja/web/css/-moz-float-edge/index.md
+++ b/files/ja/web/css/-moz-float-edge/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-float-edge'
+title: "-moz-float-edge"
 slug: Web/CSS/-moz-float-edge
 ---
 

--- a/files/ja/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/ja/web/css/-moz-force-broken-image-icon/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-force-broken-image-icon'
+title: "-moz-force-broken-image-icon"
 slug: Web/CSS/-moz-force-broken-image-icon
 ---
 

--- a/files/ja/web/css/-moz-image-rect/index.md
+++ b/files/ja/web/css/-moz-image-rect/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-image-rect'
+title: "-moz-image-rect"
 slug: Web/CSS/-moz-image-rect
 ---
 

--- a/files/ja/web/css/-moz-image-region/index.md
+++ b/files/ja/web/css/-moz-image-region/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-image-region'
+title: "-moz-image-region"
 slug: Web/CSS/-moz-image-region
 ---
 

--- a/files/ja/web/css/-moz-orient/index.md
+++ b/files/ja/web/css/-moz-orient/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-orient'
+title: "-moz-orient"
 slug: Web/CSS/-moz-orient
 ---
 

--- a/files/ja/web/css/-moz-user-focus/index.md
+++ b/files/ja/web/css/-moz-user-focus/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-user-focus'
+title: "-moz-user-focus"
 slug: Web/CSS/-moz-user-focus
 ---
 

--- a/files/ja/web/css/-moz-user-input/index.md
+++ b/files/ja/web/css/-moz-user-input/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-user-input'
+title: "-moz-user-input"
 slug: Web/CSS/-moz-user-input
 ---
 

--- a/files/ja/web/css/-webkit-border-before/index.md
+++ b/files/ja/web/css/-webkit-border-before/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-border-before'
+title: "-webkit-border-before"
 slug: Web/CSS/-webkit-border-before
 ---
 

--- a/files/ja/web/css/-webkit-box-reflect/index.md
+++ b/files/ja/web/css/-webkit-box-reflect/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-box-reflect'
+title: "-webkit-box-reflect"
 slug: Web/CSS/-webkit-box-reflect
 ---
 

--- a/files/ja/web/css/-webkit-line-clamp/index.md
+++ b/files/ja/web/css/-webkit-line-clamp/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-line-clamp'
+title: "-webkit-line-clamp"
 slug: Web/CSS/-webkit-line-clamp
 ---
 

--- a/files/ja/web/css/-webkit-mask-attachment/index.md
+++ b/files/ja/web/css/-webkit-mask-attachment/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-attachment'
+title: "-webkit-mask-attachment"
 slug: Web/CSS/-webkit-mask-attachment
 ---
 

--- a/files/ja/web/css/-webkit-mask-box-image/index.md
+++ b/files/ja/web/css/-webkit-mask-box-image/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-box-image'
+title: "-webkit-mask-box-image"
 slug: Web/CSS/-webkit-mask-box-image
 ---
 

--- a/files/ja/web/css/-webkit-mask-composite/index.md
+++ b/files/ja/web/css/-webkit-mask-composite/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-composite'
+title: "-webkit-mask-composite"
 slug: Web/CSS/-webkit-mask-composite
 ---
 

--- a/files/ja/web/css/-webkit-mask-position-x/index.md
+++ b/files/ja/web/css/-webkit-mask-position-x/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-position-x'
+title: "-webkit-mask-position-x"
 slug: Web/CSS/-webkit-mask-position-x
 ---
 

--- a/files/ja/web/css/-webkit-mask-position-y/index.md
+++ b/files/ja/web/css/-webkit-mask-position-y/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-position-y'
+title: "-webkit-mask-position-y"
 slug: Web/CSS/-webkit-mask-position-y
 ---
 

--- a/files/ja/web/css/-webkit-mask-repeat-x/index.md
+++ b/files/ja/web/css/-webkit-mask-repeat-x/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-repeat-x'
+title: "-webkit-mask-repeat-x"
 slug: Web/CSS/-webkit-mask-repeat-x
 ---
 

--- a/files/ja/web/css/-webkit-mask-repeat-y/index.md
+++ b/files/ja/web/css/-webkit-mask-repeat-y/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-mask-repeat-y'
+title: "-webkit-mask-repeat-y"
 slug: Web/CSS/-webkit-mask-repeat-y
 ---
 

--- a/files/ja/web/css/-webkit-overflow-scrolling/index.md
+++ b/files/ja/web/css/-webkit-overflow-scrolling/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-overflow-scrolling'
+title: "-webkit-overflow-scrolling"
 slug: Web/CSS/-webkit-overflow-scrolling
 ---
 

--- a/files/ja/web/css/-webkit-tap-highlight-color/index.md
+++ b/files/ja/web/css/-webkit-tap-highlight-color/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-tap-highlight-color'
+title: "-webkit-tap-highlight-color"
 slug: Web/CSS/-webkit-tap-highlight-color
 ---
 

--- a/files/ja/web/css/-webkit-text-fill-color/index.md
+++ b/files/ja/web/css/-webkit-text-fill-color/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-text-fill-color'
+title: "-webkit-text-fill-color"
 slug: Web/CSS/-webkit-text-fill-color
 ---
 

--- a/files/ja/web/css/-webkit-text-stroke-color/index.md
+++ b/files/ja/web/css/-webkit-text-stroke-color/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-text-stroke-color'
+title: "-webkit-text-stroke-color"
 slug: Web/CSS/-webkit-text-stroke-color
 ---
 

--- a/files/ja/web/css/-webkit-text-stroke-width/index.md
+++ b/files/ja/web/css/-webkit-text-stroke-width/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-text-stroke-width'
+title: "-webkit-text-stroke-width"
 slug: Web/CSS/-webkit-text-stroke-width
 ---
 

--- a/files/ja/web/css/-webkit-text-stroke/index.md
+++ b/files/ja/web/css/-webkit-text-stroke/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-text-stroke'
+title: "-webkit-text-stroke"
 slug: Web/CSS/-webkit-text-stroke
 page-type: css-shorthand-property
 browser-compat: css.properties.-webkit-text-stroke

--- a/files/ja/web/css/-webkit-touch-callout/index.md
+++ b/files/ja/web/css/-webkit-touch-callout/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-touch-callout'
+title: "-webkit-touch-callout"
 slug: Web/CSS/-webkit-touch-callout
 ---
 

--- a/files/ja/web/css/@charset/index.md
+++ b/files/ja/web/css/@charset/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@charset'
+title: "@charset"
 slug: Web/CSS/@charset
 ---
 

--- a/files/ja/web/css/@color-profile/index.md
+++ b/files/ja/web/css/@color-profile/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@color-profile'
+title: "@color-profile"
 slug: Web/CSS/@color-profile
 ---
 

--- a/files/ja/web/css/@counter-style/index.md
+++ b/files/ja/web/css/@counter-style/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@counter-style'
+title: "@counter-style"
 slug: Web/CSS/@counter-style
 ---
 

--- a/files/ja/web/css/@font-face/index.md
+++ b/files/ja/web/css/@font-face/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@font-face'
+title: "@font-face"
 slug: Web/CSS/@font-face
 ---
 

--- a/files/ja/web/css/@font-feature-values/index.md
+++ b/files/ja/web/css/@font-feature-values/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@font-feature-values'
+title: "@font-feature-values"
 slug: Web/CSS/@font-feature-values
 ---
 

--- a/files/ja/web/css/@import/index.md
+++ b/files/ja/web/css/@import/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@import'
+title: "@import"
 slug: Web/CSS/@import
 ---
 

--- a/files/ja/web/css/@keyframes/index.md
+++ b/files/ja/web/css/@keyframes/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@keyframes'
+title: "@keyframes"
 slug: Web/CSS/@keyframes
 ---
 

--- a/files/ja/web/css/@layer/index.md
+++ b/files/ja/web/css/@layer/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@layer'
+title: "@layer"
 slug: Web/CSS/@layer
 ---
 

--- a/files/ja/web/css/@media/-moz-device-pixel-ratio/index.md
+++ b/files/ja/web/css/@media/-moz-device-pixel-ratio/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-device-pixel-ratio'
+title: "-moz-device-pixel-ratio"
 slug: Web/CSS/@media/-moz-device-pixel-ratio
 ---
 

--- a/files/ja/web/css/@media/-webkit-animation/index.md
+++ b/files/ja/web/css/@media/-webkit-animation/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-animation'
+title: "-webkit-animation"
 slug: Web/CSS/@media/-webkit-animation
 ---
 

--- a/files/ja/web/css/@media/-webkit-device-pixel-ratio/index.md
+++ b/files/ja/web/css/@media/-webkit-device-pixel-ratio/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-device-pixel-ratio'
+title: "-webkit-device-pixel-ratio"
 slug: Web/CSS/@media/-webkit-device-pixel-ratio
 ---
 

--- a/files/ja/web/css/@media/-webkit-transform-2d/index.md
+++ b/files/ja/web/css/@media/-webkit-transform-2d/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-transform-2d'
+title: "-webkit-transform-2d"
 slug: Web/CSS/@media/-webkit-transform-2d
 ---
 

--- a/files/ja/web/css/@media/-webkit-transform-3d/index.md
+++ b/files/ja/web/css/@media/-webkit-transform-3d/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-transform-3d'
+title: "-webkit-transform-3d"
 slug: Web/CSS/@media/-webkit-transform-3d
 ---
 

--- a/files/ja/web/css/@media/-webkit-transition/index.md
+++ b/files/ja/web/css/@media/-webkit-transition/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-transition'
+title: "-webkit-transition"
 slug: Web/CSS/@media/-webkit-transition
 ---
 

--- a/files/ja/web/css/@media/index.md
+++ b/files/ja/web/css/@media/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@media'
+title: "@media"
 slug: Web/CSS/@media
 ---
 

--- a/files/ja/web/css/@namespace/index.md
+++ b/files/ja/web/css/@namespace/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@namespace'
+title: "@namespace"
 slug: Web/CSS/@namespace
 ---
 

--- a/files/ja/web/css/@page/index.md
+++ b/files/ja/web/css/@page/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@page'
+title: "@page"
 slug: Web/CSS/@page
 ---
 

--- a/files/ja/web/css/@property/index.md
+++ b/files/ja/web/css/@property/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@property'
+title: "@property"
 slug: Web/CSS/@property
 ---
 

--- a/files/ja/web/css/@supports/index.md
+++ b/files/ja/web/css/@supports/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@supports'
+title: "@supports"
 slug: Web/CSS/@supports
 ---
 

--- a/files/ja/web/css/_colon_-moz-broken/index.md
+++ b/files/ja/web/css/_colon_-moz-broken/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-broken'
+title: ":-moz-broken"
 slug: Web/CSS/:-moz-broken
 ---
 

--- a/files/ja/web/css/_colon_-moz-drag-over/index.md
+++ b/files/ja/web/css/_colon_-moz-drag-over/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-drag-over'
+title: ":-moz-drag-over"
 slug: Web/CSS/:-moz-drag-over
 ---
 

--- a/files/ja/web/css/_colon_-moz-first-node/index.md
+++ b/files/ja/web/css/_colon_-moz-first-node/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-first-node'
+title: ":-moz-first-node"
 slug: Web/CSS/:-moz-first-node
 ---
 

--- a/files/ja/web/css/_colon_-moz-last-node/index.md
+++ b/files/ja/web/css/_colon_-moz-last-node/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-last-node'
+title: ":-moz-last-node"
 slug: Web/CSS/:-moz-last-node
 ---
 

--- a/files/ja/web/css/_colon_-moz-loading/index.md
+++ b/files/ja/web/css/_colon_-moz-loading/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-loading'
+title: ":-moz-loading"
 slug: Web/CSS/:-moz-loading
 ---
 

--- a/files/ja/web/css/_colon_-moz-locale-dir_ltr/index.md
+++ b/files/ja/web/css/_colon_-moz-locale-dir_ltr/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-locale-dir(ltr)'
+title: ":-moz-locale-dir(ltr)"
 slug: Web/CSS/:-moz-locale-dir_ltr
 original_slug: Web/CSS/:-moz-locale-dir(ltr)
 ---

--- a/files/ja/web/css/_colon_-moz-locale-dir_rtl/index.md
+++ b/files/ja/web/css/_colon_-moz-locale-dir_rtl/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-locale-dir(rtl)'
+title: ":-moz-locale-dir(rtl)"
 slug: Web/CSS/:-moz-locale-dir_rtl
 original_slug: Web/CSS/:-moz-locale-dir(rtl)
 ---

--- a/files/ja/web/css/_colon_-moz-submit-invalid/index.md
+++ b/files/ja/web/css/_colon_-moz-submit-invalid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':-moz-submit-invalid'
+title: ":-moz-submit-invalid"
 slug: Web/CSS/:-moz-submit-invalid
 ---
 

--- a/files/ja/web/css/_colon_active/index.md
+++ b/files/ja/web/css/_colon_active/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':active'
+title: ":active"
 slug: Web/CSS/:active
 ---
 

--- a/files/ja/web/css/_colon_any-link/index.md
+++ b/files/ja/web/css/_colon_any-link/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':any-link'
+title: ":any-link"
 slug: Web/CSS/:any-link
 ---
 

--- a/files/ja/web/css/_colon_autofill/index.md
+++ b/files/ja/web/css/_colon_autofill/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':autofill'
+title: ":autofill"
 slug: Web/CSS/:autofill
 original_slug: Web/CSS/:-webkit-autofill
 ---

--- a/files/ja/web/css/_colon_blank/index.md
+++ b/files/ja/web/css/_colon_blank/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':blank'
+title: ":blank"
 slug: Web/CSS/:blank
 ---
 

--- a/files/ja/web/css/_colon_checked/index.md
+++ b/files/ja/web/css/_colon_checked/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':checked'
+title: ":checked"
 slug: Web/CSS/:checked
 ---
 

--- a/files/ja/web/css/_colon_default/index.md
+++ b/files/ja/web/css/_colon_default/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':default'
+title: ":default"
 slug: Web/CSS/:default
 ---
 

--- a/files/ja/web/css/_colon_defined/index.md
+++ b/files/ja/web/css/_colon_defined/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':defined'
+title: ":defined"
 slug: Web/CSS/:defined
 ---
 

--- a/files/ja/web/css/_colon_dir/index.md
+++ b/files/ja/web/css/_colon_dir/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':dir()'
+title: ":dir()"
 slug: Web/CSS/:dir
 ---
 

--- a/files/ja/web/css/_colon_disabled/index.md
+++ b/files/ja/web/css/_colon_disabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':disabled'
+title: ":disabled"
 slug: Web/CSS/:disabled
 ---
 

--- a/files/ja/web/css/_colon_enabled/index.md
+++ b/files/ja/web/css/_colon_enabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':enabled'
+title: ":enabled"
 slug: Web/CSS/:enabled
 ---
 

--- a/files/ja/web/css/_colon_first-child/index.md
+++ b/files/ja/web/css/_colon_first-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':first-child'
+title: ":first-child"
 slug: Web/CSS/:first-child
 ---
 

--- a/files/ja/web/css/_colon_first-of-type/index.md
+++ b/files/ja/web/css/_colon_first-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':first-of-type'
+title: ":first-of-type"
 slug: Web/CSS/:first-of-type
 ---
 

--- a/files/ja/web/css/_colon_first/index.md
+++ b/files/ja/web/css/_colon_first/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':first'
+title: ":first"
 slug: Web/CSS/:first
 ---
 

--- a/files/ja/web/css/_colon_focus-visible/index.md
+++ b/files/ja/web/css/_colon_focus-visible/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':focus-visible'
+title: ":focus-visible"
 slug: Web/CSS/:focus-visible
 ---
 

--- a/files/ja/web/css/_colon_focus-within/index.md
+++ b/files/ja/web/css/_colon_focus-within/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':focus-within'
+title: ":focus-within"
 slug: Web/CSS/:focus-within
 ---
 

--- a/files/ja/web/css/_colon_focus/index.md
+++ b/files/ja/web/css/_colon_focus/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':focus'
+title: ":focus"
 slug: Web/CSS/:focus
 ---
 

--- a/files/ja/web/css/_colon_fullscreen/index.md
+++ b/files/ja/web/css/_colon_fullscreen/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':fullscreen'
+title: ":fullscreen"
 slug: Web/CSS/:fullscreen
 ---
 

--- a/files/ja/web/css/_colon_has/index.md
+++ b/files/ja/web/css/_colon_has/index.md
@@ -1,8 +1,8 @@
 ---
-title: ':has()'
+title: ":has()"
 slug: Web/CSS/:has
 l10n:
-  sourceCommit:　e1608631832f2608632569d0bd4061372adc5199
+  sourceCommit: e1608631832f2608632569d0bd4061372adc5199
 ---
 
 {{CSSRef}}

--- a/files/ja/web/css/_colon_host/index.md
+++ b/files/ja/web/css/_colon_host/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':host'
+title: ":host"
 slug: Web/CSS/:host
 ---
 

--- a/files/ja/web/css/_colon_host_function/index.md
+++ b/files/ja/web/css/_colon_host_function/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':host()'
+title: ":host()"
 slug: Web/CSS/:host_function
 original_slug: Web/CSS/:host()
 ---

--- a/files/ja/web/css/_colon_hover/index.md
+++ b/files/ja/web/css/_colon_hover/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':hover'
+title: ":hover"
 slug: Web/CSS/:hover
 ---
 

--- a/files/ja/web/css/_colon_in-range/index.md
+++ b/files/ja/web/css/_colon_in-range/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':in-range'
+title: ":in-range"
 slug: Web/CSS/:in-range
 ---
 

--- a/files/ja/web/css/_colon_indeterminate/index.md
+++ b/files/ja/web/css/_colon_indeterminate/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':indeterminate'
+title: ":indeterminate"
 slug: Web/CSS/:indeterminate
 ---
 

--- a/files/ja/web/css/_colon_invalid/index.md
+++ b/files/ja/web/css/_colon_invalid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':invalid'
+title: ":invalid"
 slug: Web/CSS/:invalid
 ---
 

--- a/files/ja/web/css/_colon_is/index.md
+++ b/files/ja/web/css/_colon_is/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':is() (:matches(), :any())'
+title: ":is() (:matches(), :any())"
 slug: Web/CSS/:is
 ---
 

--- a/files/ja/web/css/_colon_lang/index.md
+++ b/files/ja/web/css/_colon_lang/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':lang()'
+title: ":lang()"
 slug: Web/CSS/:lang
 ---
 

--- a/files/ja/web/css/_colon_last-child/index.md
+++ b/files/ja/web/css/_colon_last-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':last-child'
+title: ":last-child"
 slug: Web/CSS/:last-child
 ---
 

--- a/files/ja/web/css/_colon_last-of-type/index.md
+++ b/files/ja/web/css/_colon_last-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':last-of-type'
+title: ":last-of-type"
 slug: Web/CSS/:last-of-type
 ---
 

--- a/files/ja/web/css/_colon_left/index.md
+++ b/files/ja/web/css/_colon_left/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':left'
+title: ":left"
 slug: Web/CSS/:left
 ---
 

--- a/files/ja/web/css/_colon_link/index.md
+++ b/files/ja/web/css/_colon_link/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':link'
+title: ":link"
 slug: Web/CSS/:link
 ---
 

--- a/files/ja/web/css/_colon_nth-child/index.md
+++ b/files/ja/web/css/_colon_nth-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-child()'
+title: ":nth-child()"
 slug: Web/CSS/:nth-child
 ---
 

--- a/files/ja/web/css/_colon_nth-last-child/index.md
+++ b/files/ja/web/css/_colon_nth-last-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-last-child()'
+title: ":nth-last-child()"
 slug: Web/CSS/:nth-last-child
 ---
 

--- a/files/ja/web/css/_colon_nth-last-of-type/index.md
+++ b/files/ja/web/css/_colon_nth-last-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-last-of-type()'
+title: ":nth-last-of-type()"
 slug: Web/CSS/:nth-last-of-type
 ---
 

--- a/files/ja/web/css/_colon_nth-of-type/index.md
+++ b/files/ja/web/css/_colon_nth-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-of-type()'
+title: ":nth-of-type()"
 slug: Web/CSS/:nth-of-type
 ---
 

--- a/files/ja/web/css/_colon_only-child/index.md
+++ b/files/ja/web/css/_colon_only-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':only-child'
+title: ":only-child"
 slug: Web/CSS/:only-child
 ---
 

--- a/files/ja/web/css/_colon_only-of-type/index.md
+++ b/files/ja/web/css/_colon_only-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':only-of-type'
+title: ":only-of-type"
 slug: Web/CSS/:only-of-type
 ---
 

--- a/files/ja/web/css/_colon_optional/index.md
+++ b/files/ja/web/css/_colon_optional/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':optional'
+title: ":optional"
 slug: Web/CSS/:optional
 ---
 

--- a/files/ja/web/css/_colon_out-of-range/index.md
+++ b/files/ja/web/css/_colon_out-of-range/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':out-of-range'
+title: ":out-of-range"
 slug: Web/CSS/:out-of-range
 ---
 

--- a/files/ja/web/css/_colon_paused/index.md
+++ b/files/ja/web/css/_colon_paused/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':paused'
+title: ":paused"
 slug: Web/CSS/:paused
 ---
 

--- a/files/ja/web/css/_colon_picture-in-picture/index.md
+++ b/files/ja/web/css/_colon_picture-in-picture/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':picture-in-picture'
+title: ":picture-in-picture"
 slug: Web/CSS/:picture-in-picture
 ---
 

--- a/files/ja/web/css/_colon_placeholder-shown/index.md
+++ b/files/ja/web/css/_colon_placeholder-shown/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':placeholder-shown'
+title: ":placeholder-shown"
 slug: Web/CSS/:placeholder-shown
 ---
 

--- a/files/ja/web/css/_colon_playing/index.md
+++ b/files/ja/web/css/_colon_playing/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':playing'
+title: ":playing"
 slug: Web/CSS/:playing
 ---
 

--- a/files/ja/web/css/_colon_read-only/index.md
+++ b/files/ja/web/css/_colon_read-only/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':read-only'
+title: ":read-only"
 slug: Web/CSS/:read-only
 ---
 

--- a/files/ja/web/css/_colon_read-write/index.md
+++ b/files/ja/web/css/_colon_read-write/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':read-write'
+title: ":read-write"
 slug: Web/CSS/:read-write
 ---
 

--- a/files/ja/web/css/_colon_required/index.md
+++ b/files/ja/web/css/_colon_required/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':required'
+title: ":required"
 slug: Web/CSS/:required
 ---
 

--- a/files/ja/web/css/_colon_right/index.md
+++ b/files/ja/web/css/_colon_right/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':right'
+title: ":right"
 slug: Web/CSS/:right
 ---
 

--- a/files/ja/web/css/_colon_root/index.md
+++ b/files/ja/web/css/_colon_root/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':root'
+title: ":root"
 slug: Web/CSS/:root
 ---
 

--- a/files/ja/web/css/_colon_scope/index.md
+++ b/files/ja/web/css/_colon_scope/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':scope'
+title: ":scope"
 slug: Web/CSS/:scope
 ---
 


### PR DESCRIPTION
This PR formats the `/web/css` folder of the Japanese locale using Prettier.  This is the first part.
