### PR TITLE
pt-br: Format /web/javascript using Prettier (part 2)

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/array/reduceright/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/reduceright/index.md
@@ -40,7 +40,7 @@ arr.reduceRight(callback[, initialValue])
 A chamada ao callback reduceRight irá parecer com uma chamada assim:
 
 ```js
-array.reduceRight(function(previousValue, currentValue, index, array) {
+array.reduceRight(function (previousValue, currentValue, index, array) {
   // ...
 });
 ```
@@ -52,9 +52,11 @@ Se o array é vazio e nenhum `initialValue` foi recebido, {{jsxref("Global_Objec
 Alguns exemplos de execuções da função e como será parecida a chamada:
 
 ```js
-[0, 1, 2, 3, 4].reduceRight(function(previousValue, currentValue, index, array) {
-  return previousValue + currentValue;
-});
+[0, 1, 2, 3, 4].reduceRight(
+  function (previousValue, currentValue, index, array) {
+    return previousValue + currentValue;
+  },
+);
 ```
 
 O callback será invocado quatro vezes, com os argumentos e valores de retornos em cada chamada será como o seguinte:
@@ -71,7 +73,12 @@ O valor retornado pelo `reduceRight` será o valor retornado pela ultima chamada
 E se você também passou um `initialValue`, o resultado irá ser como a seguir:
 
 ```js
-[0, 1, 2, 3, 4].reduceRight(function(previousValue, currentValue, index, array) {
+[0, 1, 2, 3, 4].reduceRight(function (
+  previousValue,
+  currentValue,
+  index,
+  array,
+) {
   return previousValue + currentValue;
 }, 10);
 ```
@@ -91,7 +98,7 @@ O valor retornado pelo `reduceRight` desta vez será, obviamente, `20`.
 ### Exemplo: Somando todos os valores presente em um array
 
 ```js
-var total = [0, 1, 2, 3].reduceRight(function(a, b) {
+var total = [0, 1, 2, 3].reduceRight(function (a, b) {
   return a + b;
 });
 // total == 6
@@ -100,8 +107,12 @@ var total = [0, 1, 2, 3].reduceRight(function(a, b) {
 ### Exemplo: Juntando um array de arrays
 
 ```js
-var flattened = [[0, 1], [2, 3], [4, 5]].reduceRight(function(a, b) {
-    return a.concat(b);
+var flattened = [
+  [0, 1],
+  [2, 3],
+  [4, 5],
+].reduceRight(function (a, b) {
+  return a.concat(b);
 }, []);
 // flattened is [4, 5, 2, 3, 0, 1]
 ```
@@ -113,16 +124,19 @@ var flattened = [[0, 1], [2, 3], [4, 5]].reduceRight(function(a, b) {
 ```js
 // Production steps of ECMA-262, Edition 5, 15.4.4.22
 // Reference: http://es5.github.io/#x15.4.4.22
-if ('function' !== typeof Array.prototype.reduceRight) {
-  Array.prototype.reduceRight = function(callback /*, initialValue*/) {
-    'use strict';
-    if (null === this || 'undefined' === typeof this) {
-      throw new TypeError('Array.prototype.reduce called on null or undefined' );
+if ("function" !== typeof Array.prototype.reduceRight) {
+  Array.prototype.reduceRight = function (callback /*, initialValue*/) {
+    "use strict";
+    if (null === this || "undefined" === typeof this) {
+      throw new TypeError("Array.prototype.reduce called on null or undefined");
     }
-    if ('function' !== typeof callback) {
-      throw new TypeError(callback + ' is not a function');
+    if ("function" !== typeof callback) {
+      throw new TypeError(callback + " is not a function");
     }
-    var t = Object(this), len = t.length >>> 0, k = len - 1, value;
+    var t = Object(this),
+      len = t.length >>> 0,
+      k = len - 1,
+      value;
     if (arguments.length >= 2) {
       value = arguments[1];
     } else {
@@ -130,7 +144,7 @@ if ('function' !== typeof Array.prototype.reduceRight) {
         k--;
       }
       if (k < 0) {
-        throw new TypeError('Reduce of empty array with no initial value');
+        throw new TypeError("Reduce of empty array with no initial value");
       }
       value = t[k--];
     }
@@ -146,10 +160,10 @@ if ('function' !== typeof Array.prototype.reduceRight) {
 
 ## Especificações
 
-| Especificação                                                                                                        | Status                   | Comentário                                         |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.4.4.22', 'Array.prototype.reduceRight')}}                         | {{Spec2('ES5.1')}} | Definição inicial. Implementado em JavaScript 1.8. |
-| {{SpecName('ES6', '#sec-array.prototype.reduceright', 'Array.prototype.reduceRight')}} | {{Spec2('ES6')}}     |                                                    |
+| Especificação                                                                          | Status             | Comentário                                         |
+| -------------------------------------------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| {{SpecName('ES5.1', '#sec-15.4.4.22', 'Array.prototype.reduceRight')}}                 | {{Spec2('ES5.1')}} | Definição inicial. Implementado em JavaScript 1.8. |
+| {{SpecName('ES6', '#sec-array.prototype.reduceright', 'Array.prototype.reduceRight')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com os navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/array/reverse/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/reverse/index.md
@@ -30,19 +30,19 @@ O método `reverse` transpõe os elementos do objeto array no mesmo lugar, mutan
 O seguinte exemplo cria um array `myArray`, contendo três elementos, em seguida inverte-o.
 
 ```js
-var myArray = ['one', 'two', 'three'];
+var myArray = ["one", "two", "three"];
 myArray.reverse();
 
-console.log(myArray) // ['three', 'two', 'one']
+console.log(myArray); // ['three', 'two', 'one']
 ```
 
 ## Especificações
 
-| Especificação                                                                                            | Status                   | Comentário                                         |
-| -------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| ECMAScript 1ª Edição                                                                                     | Padrão                   | Definição inicial. Implementado no JavaScript 1.1. |
-| {{SpecName('ES5.1', '#sec-15.4.4.8', 'Array.prototype.reverse')}}                 | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-array.prototype.reverse', 'Array.prototype.reverse')}} | {{Spec2('ES6')}}     |                                                    |
+| Especificação                                                                  | Status             | Comentário                                         |
+| ------------------------------------------------------------------------------ | ------------------ | -------------------------------------------------- |
+| ECMAScript 1ª Edição                                                           | Padrão             | Definição inicial. Implementado no JavaScript 1.1. |
+| {{SpecName('ES5.1', '#sec-15.4.4.8', 'Array.prototype.reverse')}}              | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-array.prototype.reverse', 'Array.prototype.reverse')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegador
 

--- a/files/pt-br/web/javascript/reference/global_objects/array/shift/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/shift/index.md
@@ -34,15 +34,15 @@ O método shift remove o elemento de índice zero, diminui em 1 os indices dos d
 O código a seguir mostra o array `minhaLista` antes e depois de remover seu primeiro elemento. Ele também mostra o elemento removido.
 
 ```js
-var minhaLista = ['anjo', 'casa', 'mandarim', 'medico'];
+var minhaLista = ["anjo", "casa", "mandarim", "medico"];
 
-console.log('minhaLista antes: ' + minhaLista);
+console.log("minhaLista antes: " + minhaLista);
 // minhaList antes: ['anjo', 'casa', 'mandarim', 'medico']
 var shifted = minhaLista.shift();
 
-console.log('minhaLista depois: ' + minhaLista);
+console.log("minhaLista depois: " + minhaLista);
 // minhaList depois: ['casa', 'mandarim', 'medico']
-console.log('Elemento removido: ' + shifted);
+console.log("Elemento removido: " + shifted);
 // Elemento removido: anjo
 ```
 
@@ -52,19 +52,19 @@ O médodo `shift()` é frequentemente usado como condição dentro de um loop de
 
 ```js
 var nomes = ["André", "Eduardo", "Paulo", "Cris", "João"];
-while( (i = nomes.shift()) !== undefined ) {
-    console.log(i);
+while ((i = nomes.shift()) !== undefined) {
+  console.log(i);
 }
 // André Eduardo Paulo Cris João
 ```
 
 ## Especificações
 
-| Especificação                                                                                        | Estado                   | Comentário                                             |
-| ---------------------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------ |
-| ECMAScript 3rd Edition                                                                               | Standard                 | Implementação inicial. Implementado no JavaScript 1.2. |
-| {{SpecName('ES5.1', '#sec-15.4.4.9', 'Array.prototype.shift')}}                 | {{Spec2('ES5.1')}} |                                                        |
-| {{SpecName('ES6', '#sec-array.prototype.shift', 'Array.prototype.shift')}} | {{Spec2('ES6')}}     |                                                        |
+| Especificação                                                              | Estado             | Comentário                                             |
+| -------------------------------------------------------------------------- | ------------------ | ------------------------------------------------------ |
+| ECMAScript 3rd Edition                                                     | Standard           | Implementação inicial. Implementado no JavaScript 1.2. |
+| {{SpecName('ES5.1', '#sec-15.4.4.9', 'Array.prototype.shift')}}            | {{Spec2('ES5.1')}} |                                                        |
+| {{SpecName('ES6', '#sec-array.prototype.shift', 'Array.prototype.shift')}} | {{Spec2('ES6')}}   |                                                        |
 
 ## Compatibilidade de Browser
 

--- a/files/pt-br/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/slice/index.md
@@ -56,7 +56,7 @@ Se um novo elemento é adicionado a qualquer array, o outro não é afetado.
 
 ```js
 // Exemplo para extrair 'Laranja' e 'Limao' do array frutas
-var frutas = ['Banana', 'Laranja', 'Limao', 'Maçã', 'Manga'];
+var frutas = ["Banana", "Laranja", "Limao", "Maçã", "Manga"];
 var citricos = frutas.slice(1, 3);
 
 // citricos contem ['Laranja','Limao']
@@ -68,24 +68,28 @@ No exemplo seguinte, `slice` cria um novo array, `novoCarro`, do original `meuCa
 
 ```js
 // Usando slice para criar novoCarro a partir de meuCarro.
-var meuHonda = { cor: 'vermelho', rodas: 4, motor: { cilindros: 4, tamanho: 2.2 } };
-var meuCarro = [meuHonda, 2, 'perfeitas condições', 'comprado em 1997'];
+var meuHonda = {
+  cor: "vermelho",
+  rodas: 4,
+  motor: { cilindros: 4, tamanho: 2.2 },
+};
+var meuCarro = [meuHonda, 2, "perfeitas condições", "comprado em 1997"];
 var novoCarro = meuCarro.slice(0, 2);
 
 // Exibe os valores de meuCarro, novoCarro, e a cor de meuHonda
 //  referenciado de ambos arrays.
-console.log('meuCarro = ' + meuCarro.toSource());
-console.log('novoCarro = ' + novoCarro.toSource());
-console.log('meuCarro[0].cor = ' + meuCarro[0].cor);
-console.log('novoCarro[0].cor = ' + novoCarro[0].cor);
+console.log("meuCarro = " + meuCarro.toSource());
+console.log("novoCarro = " + novoCarro.toSource());
+console.log("meuCarro[0].cor = " + meuCarro[0].cor);
+console.log("novoCarro[0].cor = " + novoCarro[0].cor);
 
 // Altera a cor de meuHonda.
-meuHonda.cor= 'roxo';
-console.log('A nova cor do meu Honda é ' + meuHonda.cor);
+meuHonda.cor = "roxo";
+console.log("A nova cor do meu Honda é " + meuHonda.cor);
 
 // Exibe a cor de meuHonda referenciado de ambos arrays.
-console.log('meuCarro[0].cor = ' + meuCarro[0].cor);
-console.log('novoCarro[0].cor = ' + novoCarro[0].cor);
+console.log("meuCarro[0].cor = " + meuCarro[0].cor);
+console.log("novoCarro[0].cor = " + novoCarro[0].cor);
 ```
 
 Esse script escreve:
@@ -131,7 +135,7 @@ Embora os objetos de host (como objetos DOM) não sejam obrigados pela especific
 
 ```js
 (function () {
-  'use strict';
+  "use strict";
   var _slice = Array.prototype.slice;
 
   try {
@@ -142,24 +146,26 @@ Embora os objetos de host (como objetos DOM) não sejam obrigados pela especific
     // NamedNodeMap (atributos, entidades, notações),
     // NodeList (por exemplo, getElementsByTagName), HTMLCollection (por exemplo, childNodes),
     // e não vai falhar em outros objetos do DOM (como falham no IE < 9)
-    Array.prototype.slice = function(begin, end) {
-      end = (typeof end !== 'undefined') ? end : this.length;
+    Array.prototype.slice = function (begin, end) {
+      end = typeof end !== "undefined" ? end : this.length;
 
       // Para arrays, chamamos o método nativo
-      if (Object.prototype.toString.call(this) === '[object Array]'){
+      if (Object.prototype.toString.call(this) === "[object Array]") {
         return _slice.call(this, begin, end);
       }
 
       // Para array-like, o processo é manual.
-      var i, cloned = [],
-        size, len = this.length;
+      var i,
+        cloned = [],
+        size,
+        len = this.length;
 
       // Lidando com valor negativo para "begin"
       var start = begin || 0;
-      start = (start >= 0) ? start : Math.max(0, len + start);
+      start = start >= 0 ? start : Math.max(0, len + start);
 
       // Lidando com valor negativo para "end"
-      var upTo = (typeof end == 'number') ? Math.min(end, len) : len;
+      var upTo = typeof end == "number" ? Math.min(end, len) : len;
       if (end < 0) {
         upTo = len + end;
       }
@@ -183,17 +189,17 @@ Embora os objetos de host (como objetos DOM) não sejam obrigados pela especific
       return cloned;
     };
   }
-}());
+})();
 ```
 
 ## Especificações
 
-| Especificação                                                                                            | Status                       | Comentário                                         |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
+| Especificação                                                                  | Status               | Comentário                                         |
+| ------------------------------------------------------------------------------ | -------------------- | -------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-array.prototype.slice', 'Array.prototype.slice')}} | {{Spec2('ESDraft')}} |                                                    |
-| {{SpecName('ES6', '#sec-array.prototype.slice', 'Array.prototype.slice')}}     | {{Spec2('ES6')}}         |                                                    |
-| {{SpecName('ES5.1', '#sec-15.4.4.10', 'Array.prototype.slice')}}                     | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES3')}}                                                                                 | {{Spec2('ES3')}}         | Definição inicial. Implementada no JavaScript 1.2. |
+| {{SpecName('ES6', '#sec-array.prototype.slice', 'Array.prototype.slice')}}     | {{Spec2('ES6')}}     |                                                    |
+| {{SpecName('ES5.1', '#sec-15.4.4.10', 'Array.prototype.slice')}}               | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES3')}}                                                            | {{Spec2('ES3')}}     | Definição inicial. Implementada no JavaScript 1.2. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/some/index.md
@@ -57,7 +57,7 @@ O exemplo a seguir testa se algum elemento de um array é maior que 10.
 function isBiggerThan10(element, index, array) {
   return element > 10;
 }
-[2, 5, 8, 1, 4].some(isBiggerThan10);  // false
+[2, 5, 8, 1, 4].some(isBiggerThan10); // false
 [12, 5, 8, 1, 4].some(isBiggerThan10); // true
 ```
 
@@ -66,8 +66,8 @@ function isBiggerThan10(element, index, array) {
 [Arrow functions](/pt-BR/docs/Web/JavaScript/Reference/Functions/Arrow_functions) fornece uma sintaxe mais curta para o mesmo teste.
 
 ```js
-[2, 5, 8, 1, 4].some(elem => elem > 10);  // false
-[12, 5, 8, 1, 4].some(elem => elem > 10); // true
+[2, 5, 8, 1, 4].some((elem) => elem > 10); // false
+[12, 5, 8, 1, 4].some((elem) => elem > 10); // true
 ```
 
 ## Polyfill
@@ -78,14 +78,14 @@ function isBiggerThan10(element, index, array) {
 // Production steps of ECMA-262, Edition 5, 15.4.4.17
 // Reference: http://es5.github.io/#x15.4.4.17
 if (!Array.prototype.some) {
-  Array.prototype.some = function(fun/*, thisArg*/) {
-    'use strict';
+  Array.prototype.some = function (fun /*, thisArg*/) {
+    "use strict";
 
     if (this == null) {
-      throw new TypeError('Array.prototype.some called on null or undefined');
+      throw new TypeError("Array.prototype.some called on null or undefined");
     }
 
-    if (typeof fun !== 'function') {
+    if (typeof fun !== "function") {
       throw new TypeError();
     }
 
@@ -106,10 +106,10 @@ if (!Array.prototype.some) {
 
 ## Especificações
 
-| Specification                                                                                    | Status                   | Comment                                            |
-| ------------------------------------------------------------------------------------------------ | ------------------------ | -------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.4.4.17', 'Array.prototype.some')}}             | {{Spec2('ES5.1')}} | Definição inicial. Implementada em JavaScript 1.6. |
-| {{SpecName('ES6', '#sec-array.prototype.some', 'Array.prototype.some')}} | {{Spec2('ES6')}}     |                                                    |
+| Specification                                                            | Status             | Comment                                            |
+| ------------------------------------------------------------------------ | ------------------ | -------------------------------------------------- |
+| {{SpecName('ES5.1', '#sec-15.4.4.17', 'Array.prototype.some')}}          | {{Spec2('ES5.1')}} | Definição inicial. Implementada em JavaScript 1.6. |
+| {{SpecName('ES6', '#sec-array.prototype.some', 'Array.prototype.some')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/sort/index.md
@@ -33,7 +33,7 @@ O array ordenado. Note que o array é ordenado de acordo com a pontuação de c�
 Se **`funcaoDeComparacao`** não for informado, os elementos serão ordenados de acordo com a sua conversão para texto e o texto comparado na pontuação unicode do texto convertido. Por exemplo, "banana" vem antes de "cherry". Em uma ordenação numérica, 9 vem antes de 80, mas porque os números são convertidos para texto e, "80" vem antes de "9" na ordenação Unicode.
 
 ```js
-var fruit = ['cherries', 'apples', 'bananas'];
+var fruit = ["cherries", "apples", "bananas"];
 fruit.sort(); // ['apples', 'bananas', 'cherries']
 
 var scores = [1, 10, 2, 21];
@@ -41,7 +41,7 @@ scores.sort(); // [1, 10, 2, 21]
 // Observe que 10 vem antes do 2,
 // porque '10' vem antes de '2' em ponto de código Unicode.
 
-var things = ['word', 'Word', '1 Word', '2 Words'];
+var things = ["word", "Word", "1 Word", "2 Words"];
 things.sort(); // ['1 Word', '2 Words', 'Word', 'word']
 // Em Unicode, números vêem antes de letras maiúsculas,
 // as quais vêem antes das minúsculas.
@@ -81,7 +81,7 @@ O método de ordenação pode convenientemente ser usada com {{jsxref("Operators
 
 ```js
 var numbers = [4, 2, 5, 1, 3];
-numbers.sort(function(a, b) {
+numbers.sort(function (a, b) {
   return a - b;
 });
 console.log(numbers);
@@ -91,12 +91,12 @@ Objetos podem ser ordenados de acordo com o valor de uma de suas propriedades.
 
 ```js
 var items = [
-  { name: 'Edward', value: 21 },
-  { name: 'Sharpe', value: 37 },
-  { name: 'And', value: 45 },
-  { name: 'The', value: -12 },
-  { name: 'Magnetic' },
-  { name: 'Zeros', value: 37 }
+  { name: "Edward", value: 21 },
+  { name: "Sharpe", value: 37 },
+  { name: "And", value: 45 },
+  { name: "The", value: -12 },
+  { name: "Magnetic" },
+  { name: "Zeros", value: 37 },
 ];
 items.sort(function (a, b) {
   if (a.name > b.name) {
@@ -117,29 +117,35 @@ items.sort(function (a, b) {
 O exemplo abaixo cria quatro arrays e mostra seu conteúdo original, então o conteúdo dos arrays ordenado. Os arrays numéricos são ordenados sem a função de comparação, e então, com a função.
 
 ```js
-var stringArray = ['Blue', 'Humpback', 'Beluga'];
-var numericStringArray = ['80', '9', '700'];
+var stringArray = ["Blue", "Humpback", "Beluga"];
+var numericStringArray = ["80", "9", "700"];
 var numberArray = [40, 1, 5, 200];
-var mixedNumericArray = ['80', '9', '700', 40, 1, 5, 200];
+var mixedNumericArray = ["80", "9", "700", 40, 1, 5, 200];
 
 function compararNumeros(a, b) {
   return a - b;
 }
 
-console.log('stringArray:', stringArray.join());
-console.log('Ordenada:', stringArray.sort());
+console.log("stringArray:", stringArray.join());
+console.log("Ordenada:", stringArray.sort());
 
-console.log('numberArray:', numberArray.join());
-console.log('Ordenada sem função de comparação:', numberArray.sort());
-console.log('Ordenada com compararNumeros:', numberArray.sort(compararNumeros));
+console.log("numberArray:", numberArray.join());
+console.log("Ordenada sem função de comparação:", numberArray.sort());
+console.log("Ordenada com compararNumeros:", numberArray.sort(compararNumeros));
 
-console.log('numericStringArray:', numericStringArray.join());
-console.log('Ordenada sem função de comparação:', numericStringArray.sort());
-console.log('Ordenada com compararNumeros:', numericStringArray.sort(compararNumeros));
+console.log("numericStringArray:", numericStringArray.join());
+console.log("Ordenada sem função de comparação:", numericStringArray.sort());
+console.log(
+  "Ordenada com compararNumeros:",
+  numericStringArray.sort(compararNumeros),
+);
 
-console.log('mixedNumericArray:', mixedNumericArray.join());
-console.log('Ordenada sem função de comparação:', mixedNumericArray.sort());
-console.log('Ordenada com compararNumeros:', mixedNumericArray.sort(compararNumeros));
+console.log("mixedNumericArray:", mixedNumericArray.join());
+console.log("Ordenada sem função de comparação:", mixedNumericArray.sort());
+console.log(
+  "Ordenada com compararNumeros:",
+  mixedNumericArray.sort(compararNumeros),
+);
 ```
 
 Este exemplo gera a saída abaixo. Como as saídas mostram, quando a função de comparação é usada, os números são ordenados corretamente, sejam eles números ou strings numéricas.
@@ -166,7 +172,7 @@ Ordenada com compararNumeros: 1,5,9,40,80,200,700
 Para ordenar strings com caracteres não-ASCII, i.e. strings com caracteres acentuados (e, é, è, a, ä, etc.), strings de línguas diferentes do Inglês: use {{jsxref("String.localeCompare")}}. Esta função pode comparar estes caracteres, então eles aparecerão na ordem correta.
 
 ```js
-var items = ['réservé', 'premier', 'cliché', 'communiqué', 'café', 'adieu'];
+var items = ["réservé", "premier", "cliché", "communiqué", "café", "adieu"];
 items.sort(function (a, b) {
   return a.localeCompare(b);
 });
@@ -180,31 +186,31 @@ A `funcaoDeComparacao` pode ser invocada múltiplas vezes por elemento do array.
 
 ```js
 // o array a ser ordenado
-var list = ['Delta', 'alpha', 'CHARLIE', 'bravo'];
+var list = ["Delta", "alpha", "CHARLIE", "bravo"];
 
 // array temporário que armazena os objetos com o índice e o valor para ordenação
-var mapped = list.map(function(el, i) {
+var mapped = list.map(function (el, i) {
   return { index: i, value: el.toLowerCase() };
-})
+});
 
 // ordenando o array mapeado contendo os dados resumidos
-mapped.sort(function(a, b) {
+mapped.sort(function (a, b) {
   return +(a.value > b.value) || +(a.value === b.value) - 1;
 });
 
 // container para o resultado ordenado
-var result = mapped.map(function(el){
+var result = mapped.map(function (el) {
   return list[el.index];
 });
 ```
 
 ## Especificações
 
-| Especificação                                                                                    | Status                   | Comentário         |
-| ------------------------------------------------------------------------------------------------ | ------------------------ | ------------------ |
-| {{SpecName('ES1')}}                                                                         | {{Spec2('ES1')}}     | Definição Inicial. |
-| {{SpecName('ES5.1', '#sec-15.4.4.11', 'Array.prototype.sort')}}             | {{Spec2('ES5.1')}} |                    |
-| {{SpecName('ES6', '#sec-array.prototype.sort', 'Array.prototype.sort')}} | {{Spec2('ES6')}}     |                    |
+| Especificação                                                            | Status             | Comentário         |
+| ------------------------------------------------------------------------ | ------------------ | ------------------ |
+| {{SpecName('ES1')}}                                                      | {{Spec2('ES1')}}   | Definição Inicial. |
+| {{SpecName('ES5.1', '#sec-15.4.4.11', 'Array.prototype.sort')}}          | {{Spec2('ES5.1')}} |                    |
+| {{SpecName('ES6', '#sec-array.prototype.sort', 'Array.prototype.sort')}} | {{Spec2('ES6')}}   |                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/splice/index.md
@@ -79,11 +79,11 @@ removed = myFish.splice(3, Number.MAX_VALUE);
 
 ## Especificações
 
-| Especificação                                                                                        | Status                   | Comentário                                        |
-| ---------------------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------- |
-| ECMAScript 3rd Edition                                                                               | Padrão                   | Definição inicial. Implementado no JavaScript 1.2 |
-| {{SpecName('ES5.1', '#sec-15.4.4.12', 'Array.prototype.splice')}}             | {{Spec2('ES5.1')}} |                                                   |
-| {{SpecName('ES6', '#sec-array.prototype.splice', 'Array.prototype.splice')}} | {{Spec2('ES6')}}     |                                                   |
+| Especificação                                                                | Status             | Comentário                                        |
+| ---------------------------------------------------------------------------- | ------------------ | ------------------------------------------------- |
+| ECMAScript 3rd Edition                                                       | Padrão             | Definição inicial. Implementado no JavaScript 1.2 |
+| {{SpecName('ES5.1', '#sec-15.4.4.12', 'Array.prototype.splice')}}            | {{Spec2('ES5.1')}} |                                                   |
+| {{SpecName('ES6', '#sec-array.prototype.splice', 'Array.prototype.splice')}} | {{Spec2('ES6')}}   |                                                   |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/array/tolocalestring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/tolocalestring/index.md
@@ -35,7 +35,7 @@ Os elementos de um array são convertidos para strings usando seus respectivos m
 ```js
 var numero = 1337;
 var data = new Date();
-var meuArray = [numero, data, 'foo'];
+var meuArray = [numero, data, "foo"];
 
 var resultado = meuArray.toLocaleString();
 
@@ -48,11 +48,11 @@ Para mais exemplos, veja as páginas {{jsxref("Intl")}}, {{jsxref("NumberFormat"
 
 ## Especificações
 
-| Especificação                                                                                                                | Status                   | Comentários        |
-| ---------------------------------------------------------------------------------------------------------------------------- | ------------------------ | ------------------ |
-| {{SpecName('ES3')}}                                                                                                     | {{Spec2('ES3')}}     | Definição inicial. |
-| {{SpecName('ES5.1', '#sec-15.2.4.3', 'Array.prototype.toLocaleString')}}                             | {{Spec2('ES5.1')}} |                    |
-| {{SpecName('ES6', '#sec-array.prototype.tolocalestring', 'Array.prototype.toLocaleString')}} | {{Spec2('ES6')}}     |                    |
+| Especificação                                                                                | Status             | Comentários        |
+| -------------------------------------------------------------------------------------------- | ------------------ | ------------------ |
+| {{SpecName('ES3')}}                                                                          | {{Spec2('ES3')}}   | Definição inicial. |
+| {{SpecName('ES5.1', '#sec-15.2.4.3', 'Array.prototype.toLocaleString')}}                     | {{Spec2('ES5.1')}} |                    |
+| {{SpecName('ES6', '#sec-array.prototype.tolocalestring', 'Array.prototype.toLocaleString')}} | {{Spec2('ES6')}}   |                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/array/tostring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/tostring/index.md
@@ -22,7 +22,7 @@ Nenhum.
 O objeto {{jsxref("Array")}} substitui o método toString() de {{jsxref("Object")}}. Para objetos do tipo Array, o método toString() concatena todos os valores em apenas uma string. Segue exemplo abaixo, de como ele se comporta.
 
 ```js
-var monthNames = ['Jan', 'Feb', 'Mar', 'Apr'];
+var monthNames = ["Jan", "Feb", "Mar", "Apr"];
 var myVar = monthNames.toString(); // atribui 'Jan,Feb,Mar,Apr' para myVar.
 ```
 
@@ -34,11 +34,11 @@ Implementado no JavaScript 1.8.5 (Firefox 4), e compatível com a 5ª versão do
 
 ## Especificações
 
-| Especificação                                                                                                | Status                   | Comentários                                        |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------ | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                     | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.1. |
-| {{SpecName('ES5.1', '#sec-15.4.4.2', 'Array.prototype.toString')}}                     | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-array.prototype.tostring', 'Array.prototype.toString')}} | {{Spec2('ES6')}}     |                                                    |
+| Especificação                                                                    | Status             | Comentários                                        |
+| -------------------------------------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                              | {{Spec2('ES1')}}   | Definição inicial. Implementado no JavaScript 1.1. |
+| {{SpecName('ES5.1', '#sec-15.4.4.2', 'Array.prototype.toString')}}               | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-array.prototype.tostring', 'Array.prototype.toString')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Browsers compatíveis
 

--- a/files/pt-br/web/javascript/reference/global_objects/array/unshift/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/unshift/index.md
@@ -47,11 +47,11 @@ arr.unshift([-3]);
 
 ## Especificações
 
-| Especificação                                                                                            | Status                   | Comentário                                         |
-| -------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| ECMAScript 3ª Edição                                                                                     | Padrão                   | Definição inicial. Implementado no JavaScript 1.2. |
-| {{SpecName('ES5.1', '#sec-15.4.4.13', 'Array.prototype.unshift')}}                 | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-array.prototype.unshift', 'Array.prototype.unshift')}} | {{Spec2('ES6')}}     |                                                    |
+| Especificação                                                                  | Status             | Comentário                                         |
+| ------------------------------------------------------------------------------ | ------------------ | -------------------------------------------------- |
+| ECMAScript 3ª Edição                                                           | Padrão             | Definição inicial. Implementado no JavaScript 1.2. |
+| {{SpecName('ES5.1', '#sec-15.4.4.13', 'Array.prototype.unshift')}}             | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-array.prototype.unshift', 'Array.prototype.unshift')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade entre browsers
 

--- a/files/pt-br/web/javascript/reference/global_objects/array/values/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/values/index.md
@@ -18,7 +18,7 @@ arr.values()
 ### Iteração usando `for...of` loop
 
 ```js
-var arr = ['w', 'y', 'k', 'o', 'p'];
+var arr = ["w", "y", "k", "o", "p"];
 var eArr = arr.values();
 // seu navegador deve suportar for..of loop
 // e deixar variáveis let-scoped no for loops
@@ -30,7 +30,7 @@ for (let letter of eArr) {
 ### Iteração alternativa
 
 ```js
-var arr = ['w', 'y', 'k', 'o', 'p'];
+var arr = ["w", "y", "k", "o", "p"];
 var eArr = arr.values();
 console.log(eArr.next().value); // w
 console.log(eArr.next().value); // y
@@ -41,8 +41,8 @@ console.log(eArr.next().value); // p
 
 ## Especificações
 
-| Especificação                                                                                        | Status               | Comentário         |
-| ---------------------------------------------------------------------------------------------------- | -------------------- | ------------------ |
+| Especificação                                                                | Status           | Comentário         |
+| ---------------------------------------------------------------------------- | ---------------- | ------------------ |
 | {{SpecName('ES6', '#sec-array.prototype.values', 'Array.prototype.values')}} | {{Spec2('ES6')}} | Definição inicial. |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/arraybuffer/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/arraybuffer/index.md
@@ -79,10 +79,10 @@ var view   = new Int32Array(buffer);
 
 ## Especificações
 
-| Especificação                                                                                | Status                           | Comentário                                                            |
-| -------------------------------------------------------------------------------------------- | -------------------------------- | --------------------------------------------------------------------- |
-| {{SpecName('Typed Array')}}                                                         | {{Spec2('Typed Array')}} | Substituído pelo ECMAScript 6                                         |
-| {{SpecName('ES6', '#sec-arraybuffer-constructor', 'ArrayBuffer')}}     | {{Spec2('ES6')}}             | Definição inicial no ECMA standard. Specified that `new` is required. |
+| Especificação                                                          | Status                   | Comentário                                                            |
+| ---------------------------------------------------------------------- | ------------------------ | --------------------------------------------------------------------- |
+| {{SpecName('Typed Array')}}                                            | {{Spec2('Typed Array')}} | Substituído pelo ECMAScript 6                                         |
+| {{SpecName('ES6', '#sec-arraybuffer-constructor', 'ArrayBuffer')}}     | {{Spec2('ES6')}}         | Definição inicial no ECMA standard. Specified that `new` is required. |
 | {{SpecName('ESDraft', '#sec-arraybuffer-constructor', 'ArrayBuffer')}} | {{Spec2('ESDraft')}}     |                                                                       |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/asyncfunction/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/asyncfunction/index.md
@@ -10,7 +10,7 @@ O **construtor `AsyncFunction`** cria um novo objeto {{jsxref("Statements/async_
 Note que`AsyncFunction` não é um objeto global. Ele poderia ser obtido analisando o seguinte código:
 
 ```js
-Object.getPrototypeOf(async function(){}).constructor
+Object.getPrototypeOf(async function () {}).constructor;
 ```
 
 ## Sintaxe
@@ -59,28 +59,30 @@ Instância `AsyncFunction` herdam métodos e propriedades do {{jsxref("AsyncFunc
 
 ```js
 function resolveAfter2Seconds(x) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(() => {
       resolve(x);
     }, 2000);
   });
 }
 
-var AsyncFunction = Object.getPrototypeOf(async function(){}).constructor
+var AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
 
-var a = new AsyncFunction('a',
-                          'b',
-                          'return await resolveAfter2Seconds(a) + await resolveAfter2Seconds(b);');
+var a = new AsyncFunction(
+  "a",
+  "b",
+  "return await resolveAfter2Seconds(a) + await resolveAfter2Seconds(b);",
+);
 
-a(10, 20).then(v => {
+a(10, 20).then((v) => {
   console.log(v); // imprime 30 após 4 seconds
 });
 ```
 
 ## Especificações
 
-| Especificação                                                                                            | Situação                     | Comentário                   |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------- | ---------------------------- |
+| Especificação                                                                  | Situação             | Comentário                   |
+| ------------------------------------------------------------------------------ | -------------------- | ---------------------------- |
 | {{SpecName('ESDraft', '#sec-async-function-objects', 'AsyncFunction object')}} | {{Spec2('ESDraft')}} | Definição inicial no ES2017. |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/atomics/add/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/atomics/add/index.md
@@ -44,8 +44,8 @@ Atomics.load(ta, 0); // 12
 
 ## Especificações
 
-| Especificação                                                                | Status                       | Comentário                   |
-| ---------------------------------------------------------------------------- | ---------------------------- | ---------------------------- |
+| Especificação                                              | Status               | Comentário                   |
+| ---------------------------------------------------------- | -------------------- | ---------------------------- |
 | {{SpecName('ESDraft', '#sec-atomics.add', 'Atomics.add')}} | {{Spec2('ESDraft')}} | Definição inicial no ES2017. |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/atomics/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/atomics/index.md
@@ -47,8 +47,8 @@ Os métodos `wait()` e `wake()` são modelados no Linux futexes ("fast user-spac
 
 ## Especificações
 
-| Especificações                                                               | Status                               | Comentário         |
-| ---------------------------------------------------------------------------- | ------------------------------------ | ------------------ |
+| Especificações                                             | Status                     | Comentário         |
+| ---------------------------------------------------------- | -------------------------- | ------------------ |
 | {{SpecName('Shared Memory', '#AtomicsObject', 'Atomics')}} | {{Spec2('Shared Memory')}} | Definição inicial. |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/bigint/index.md
@@ -36,7 +36,9 @@ const hugeString = BigInt("9007199254740991");
 const hugeHex = BigInt("0x1fffffffffffff");
 // ↪ 9007199254740991n
 
-const hugeBin = BigInt("0b11111111111111111111111111111111111111111111111111111");
+const hugeBin = BigInt(
+  "0b11111111111111111111111111111111111111111111111111111",
+);
 // ↪ 9007199254740991n
 ```
 
@@ -51,14 +53,14 @@ Isso é parecido com um {{jsxref("Number")}} em algumas partes, mas difere-se em
 Quando testado com `typeof` , um `BigInt` vai devolver "bigint":
 
 ```js
-typeof 1n === 'bigint'; // true
-typeof BigInt('1') === 'bigint'; // true
+typeof 1n === "bigint"; // true
+typeof BigInt("1") === "bigint"; // true
 ```
 
 Quando envolvido em um `Object`, um `BigInt` vai ser considerado como um tipo normal de "object".
 
 ```js
-typeof Object(1n) === 'object'; // true
+typeof Object(1n) === "object"; // true
 ```
 
 ### Operadores
@@ -108,29 +110,29 @@ const rounded = 5n / 2n;
 Um `BigInt` não é estritamente igual a um {{jsxref("Global_Objects/Number", "Number")}}, mas é mais ou menos assim.
 
 ```js
-0n === 0
+0n === 0;
 // ↪ false
 
-0n == 0
+0n == 0;
 // ↪ true
 ```
 
 Um {{jsxref("Global_Objects/Number", "Number")}} e um `BigInt` podem ser comparado normalmente.
 
 ```js
-1n < 2
+1n < 2;
 // ↪ true
 
-2n > 1
+2n > 1;
 // ↪ true
 
-2 > 2
+2 > 2;
 // ↪ false
 
-2n > 2
+2n > 2;
 // ↪ false
 
-2n >= 2
+2n >= 2;
 // ↪ true
 ```
 
@@ -151,7 +153,7 @@ Observe que comparações com `BigInt`s envolvidos em `Object` atuam com outros 
 Object(0n) === Object(0n); // false
 
 const o = Object(0n);
-o === o // true
+o === o; // true
 ```
 
 ### Condicionais
@@ -160,29 +162,29 @@ A `BigInt` comporta-se como {{jsxref("Global_Objects/Number", "Number")}} nos ca
 
 ```js
 if (0n) {
-  console.log('Olá de um if!');
+  console.log("Olá de um if!");
 } else {
-  console.log('Olá de um else!');
+  console.log("Olá de um else!");
 }
 
 // ↪ "Olá de um else!"
 
-0n || 12n
+0n || 12n;
 // ↪ 12n
 
-0n && 12n
+0n && 12n;
 // ↪ 0n
 
-Boolean(0n)
+Boolean(0n);
 // ↪ false
 
-Boolean(12n)
+Boolean(12n);
 // ↪ true
 
-!12n
+!12n;
 // ↪ false
 
-!0n
+!0n;
 // ↪ true
 ```
 
@@ -234,6 +236,6 @@ function nthPrime(nth) {
   return prime;
 }
 
-nthPrime(20n)
+nthPrime(20n);
 // ↪ 73n
 ```

--- a/files/pt-br/web/javascript/reference/global_objects/boolean/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/boolean/index.md
@@ -45,17 +45,17 @@ if (x) {
 Não use um objeto `Boolean` para converter um valor não-boleano para um valor boleano. Ao invés disso use `Boolean` como uma função para executar essa tarefa:
 
 ```js
-var x = Boolean(expression);     // preferido
+var x = Boolean(expression); // preferido
 var x = new Boolean(expression); // não use
 ```
 
 Se você especificar qualquer objeto, incluindo um objeto `Boolean` cujo valor é `false`, como valor inicial de um objeto `Boolean`, o novo objeto `Boolean` terá o valor de `true`.
 
 ```js
-var myFalse = new Boolean(false);   // valor inicial false
-var g = new Boolean(myFalse);       // valor inicial true
-var myString = new String('Hello'); // objeto String
-var s = new Boolean(myString);      // valor inicial true
+var myFalse = new Boolean(false); // valor inicial false
+var g = new Boolean(myFalse); // valor inicial true
+var myString = new String("Hello"); // objeto String
+var s = new Boolean(myString); // valor inicial true
 ```
 
 Não use um um objeto `Boolean` no lugar de um primitivo B`oolean`.
@@ -91,7 +91,7 @@ Todas instâncias `Boolean` herdam de {{jsxref("Boolean.prototype")}}. Assim com
 var bNoParam = new Boolean();
 var bZero = new Boolean(0);
 var bNull = new Boolean(null);
-var bEmptyString = new Boolean('');
+var bEmptyString = new Boolean("");
 var bfalse = new Boolean(false);
 ```
 
@@ -99,20 +99,20 @@ var bfalse = new Boolean(false);
 
 ```js
 var btrue = new Boolean(true);
-var btrueString = new Boolean('true');
-var bfalseString = new Boolean('false');
-var bSuLin = new Boolean('Su Lin');
+var btrueString = new Boolean("true");
+var bfalseString = new Boolean("false");
+var bSuLin = new Boolean("Su Lin");
 var bArrayProto = new Boolean([]);
 var bObjProto = new Boolean({});
 ```
 
 ## Especificações
 
-| Especificação                                                            | Status                   | Comentário                                          |
-| ------------------------------------------------------------------------ | ------------------------ | --------------------------------------------------- |
-| {{SpecName('ES1')}}                                                 | {{Spec2('ES1')}}     | Definição inicial. Implementado no Java Script 1.0. |
-| {{SpecName('ES5.1', '#sec-15.6', 'Boolean')}}             | {{Spec2('ES5.1')}} |                                                     |
-| {{SpecName('ES6', '#sec-boolean-objects', 'Boolean')}} | {{Spec2('ES6')}}     |                                                     |
+| Especificação                                          | Status             | Comentário                                          |
+| ------------------------------------------------------ | ------------------ | --------------------------------------------------- |
+| {{SpecName('ES1')}}                                    | {{Spec2('ES1')}}   | Definição inicial. Implementado no Java Script 1.0. |
+| {{SpecName('ES5.1', '#sec-15.6', 'Boolean')}}          | {{Spec2('ES5.1')}} |                                                     |
+| {{SpecName('ES6', '#sec-boolean-objects', 'Boolean')}} | {{Spec2('ES6')}}   |                                                     |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/boolean/tostring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/boolean/tostring/index.md
@@ -38,11 +38,11 @@ var myVar = flag.toString();
 
 ## Especificações
 
-| Especificação                                                                                                        | Status                       | Comentário         |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('ES1')}}                                                                                             | {{Spec2('ES1')}}         | Definição inicial. |
-| {{SpecName('ES5.1', '#sec-15.6.4.2', 'Boolean.prototype.toString')}}                         | {{Spec2('ES5.1')}}     |                    |
-| {{SpecName('ES6', '#sec-boolean.prototype.tostring', 'Boolean.prototype.toString')}}     | {{Spec2('ES6')}}         |                    |
+| Especificação                                                                            | Status               | Comentário         |
+| ---------------------------------------------------------------------------------------- | -------------------- | ------------------ |
+| {{SpecName('ES1')}}                                                                      | {{Spec2('ES1')}}     | Definição inicial. |
+| {{SpecName('ES5.1', '#sec-15.6.4.2', 'Boolean.prototype.toString')}}                     | {{Spec2('ES5.1')}}   |                    |
+| {{SpecName('ES6', '#sec-boolean.prototype.tostring', 'Boolean.prototype.toString')}}     | {{Spec2('ES6')}}     |                    |
 | {{SpecName('ESDraft', '#sec-boolean.prototype.tostring', 'Boolean.prototype.toString')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/boolean/valueof/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/boolean/valueof/index.md
@@ -34,11 +34,11 @@ myVar = x.valueOf(); // atribui o valor false à variável myVar
 
 ## Especificações
 
-| Especificação                                                                                                | Condição                 | Comentário                                         |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------ | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                     | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.1. |
-| {{SpecName('ES5.1', '#sec-15.6.4.3', 'Boolean.prototype.valueOf')}}                     | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-boolean.prototype.valueof', 'Boolean.prototype.valueOf')}} | {{Spec2('ES6')}}     |                                                    |
+| Especificação                                                                      | Condição           | Comentário                                         |
+| ---------------------------------------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                | {{Spec2('ES1')}}   | Definição inicial. Implementado no JavaScript 1.1. |
+| {{SpecName('ES5.1', '#sec-15.6.4.3', 'Boolean.prototype.valueOf')}}                | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-boolean.prototype.valueof', 'Boolean.prototype.valueOf')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/dataview/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/dataview/index.md
@@ -45,7 +45,7 @@ Você pode pensar nesse objeto retornado como um "intérprete" de um array buffe
 Formatos de números _Multi-byte_ são representados de maneira diferente na memória, dependendo da arquitetura da máquina, veja {{Glossary("Endianness")}} para mais informações. Assessores de `DataView` fornecem controle explícito de como o dado será acessado, independente do _endianness_ da arquitetura em execução.
 
 ```js
-var littleEndian = (function() {
+var littleEndian = (function () {
   var buffer = new ArrayBuffer(2);
   new DataView(buffer).setInt16(0, 256, true /* littleEndian */);
   // Int16Array uses the platform's endianness.
@@ -61,14 +61,16 @@ Como JavaScript atualmente não inclui suporte padrão para valores inteiros de 
 ```js
 function getUint64(dataview, byteOffset, littleEndian) {
   // split 64-bit number into two 32-bit (4-byte) parts
-  const left =  dataview.getUint32(byteOffset, littleEndian);
-  const right = dataview.getUint32(byteOffset+4, littleEndian);
+  const left = dataview.getUint32(byteOffset, littleEndian);
+  const right = dataview.getUint32(byteOffset + 4, littleEndian);
 
   // combine the two 32-bit values
-  const combined = littleEndian? left + 2**32*right : 2**32*left + right;
+  const combined = littleEndian
+    ? left + 2 ** 32 * right
+    : 2 ** 32 * left + right;
 
   if (!Number.isSafeInteger(combined))
-    console.warn(combined, 'exceeds MAX_SAFE_INTEGER. Precision may be lost');
+    console.warn(combined, "exceeds MAX_SAFE_INTEGER. Precision may be lost");
 
   return combined;
 }
@@ -83,9 +85,9 @@ function getUint64BigInt(dataview, byteOffset, littleEndian) {
   const right = dataview.getUint32(byteOffset + 4, littleEndian);
 
   // combine the two 32-bit values as their hex string representations
-  const combined = littleEndian ?
-    right.toString(16) + left.toString(16).padStart(8, '0') :
-    left.toString(16) + right.toString(16).padStart(8, '0');
+  const combined = littleEndian
+    ? right.toString(16) + left.toString(16).padStart(8, "0")
+    : left.toString(16) + right.toString(16).padStart(8, "0");
 
   return BigInt(`0x${combined}`);
 }
@@ -113,10 +115,10 @@ dv.getInt16(1); //42
 
 ## Especificações
 
-| Especificação                                                                        | Status                           | Comentário                         |
-| ------------------------------------------------------------------------------------ | -------------------------------- | ---------------------------------- |
-| {{SpecName('Typed Array')}}                                                 | {{Spec2('Typed Array')}} | Substituído pelo ECMAScript 6      |
-| {{SpecName('ES6', '#sec-dataview-constructor', 'DataView')}}     | {{Spec2('ES6')}}             | Definição inicial no ECMA standard |
+| Especificação                                                    | Status                   | Comentário                         |
+| ---------------------------------------------------------------- | ------------------------ | ---------------------------------- |
+| {{SpecName('Typed Array')}}                                      | {{Spec2('Typed Array')}} | Substituído pelo ECMAScript 6      |
+| {{SpecName('ES6', '#sec-dataview-constructor', 'DataView')}}     | {{Spec2('ES6')}}         | Definição inicial no ECMA standard |
 | {{SpecName('ESDraft', '#sec-dataview-constructor', 'DataView')}} | {{Spec2('ESDraft')}}     |                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/@@toprimitive/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/@@toprimitive/index.md
@@ -35,20 +35,20 @@ O JavaScript chama o método `[@@toPrimitive]()` para converter um objeto para u
 const testDate = new Date(1590757517834);
 // "Date Fri May 29 2020 14:05:17 GMT+0100 (British Summer Time)"
 
-testDate[Symbol.toPrimitive]('string');
+testDate[Symbol.toPrimitive]("string");
 // Returns "Date Fri May 29 2020 14:05:17 GMT+0100 (British Summer Time)"
 
-testDate[Symbol.toPrimitive]('number');
+testDate[Symbol.toPrimitive]("number");
 // Returns "1590757517834"
 
-testDate[Symbol.toPrimitive]('default');
+testDate[Symbol.toPrimitive]("default");
 // Returns "Date Fri May 29 2020 14:05:17 GMT+0100 (British Summer Time)"
 ```
 
 ## Especificações
 
-| Especificação                                                                                                                |
-| ---------------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                                |
+| -------------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype-@@toprimitive', 'Date.prototype.@@toPrimitive')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/getdate/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getdate/index.md
@@ -30,7 +30,7 @@ O valor retornado por `getDate()` é um inteiro entre 1 e 31.
 O segundo statement abaixo atribui o valor 25 à variável day, baseado no valor do objeto {{jsxref("Global_Objects/Date", "Date")}} `Xmas95`.
 
 ```js
-var Xmas95 = new Date('December 25, 1995 23:15:30');
+var Xmas95 = new Date("December 25, 1995 23:15:30");
 var day = Xmas95.getDate();
 
 console.log(day); // 25
@@ -38,11 +38,11 @@ console.log(day); // 25
 
 ## Especificações
 
-| Especificação                                                                                        | Status                   | Comentário                                         |
-| ---------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| ECMAScript 1st Edition.                                                                              | Standard                 | Definição inicial. Implementado em JavaScript 1.1. |
-| {{SpecName('ES5.1', '#sec-15.9.5.14', 'Date.prototype.getDate')}}             | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.getdate', 'Date.prototype.getDate')}} | {{Spec2('ES6')}}     |                                                    |
+| Especificação                                                                | Status             | Comentário                                         |
+| ---------------------------------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| ECMAScript 1st Edition.                                                      | Standard           | Definição inicial. Implementado em JavaScript 1.1. |
+| {{SpecName('ES5.1', '#sec-15.9.5.14', 'Date.prototype.getDate')}}            | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.getdate', 'Date.prototype.getDate')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/getday/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getday/index.md
@@ -30,7 +30,7 @@ O valor retornado por `getDay()` é um inteiro que corresponde com o dia da sema
 O segundo statement abaixo atribui o valor 1 à variável weekday (dia da semana), baseado no valor do objeto {{jsxref("Global_Objects/Date", "Date")}} `Xmas95`. A data 25 de Dezembro de 1995 é uma Segunda-Feira.
 
 ```js
-var Xmas95 = new Date('December 25, 1995 23:15:30');
+var Xmas95 = new Date("December 25, 1995 23:15:30");
 var weekday = Xmas95.getDay();
 
 console.log(weekday); // 1
@@ -38,11 +38,11 @@ console.log(weekday); // 1
 
 ## Especificações
 
-| **Especificação**                                                                                    | Status                   | **Comentário**                                     |
-| ---------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| ECMAScript 1st Edition.                                                                              | Standard                 | Definição inicial. Implementado em JavaScript 1.0. |
-| {{SpecName('ES5.1', '#sec-15.9.5.16', 'Date.prototype.getDay')}}                 | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.getday', 'Date.prototype.getDay')}} | {{Spec2('ES6')}}     |                                                    |
+| **Especificação**                                                          | Status             | **Comentário**                                     |
+| -------------------------------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| ECMAScript 1st Edition.                                                    | Standard           | Definição inicial. Implementado em JavaScript 1.0. |
+| {{SpecName('ES5.1', '#sec-15.9.5.16', 'Date.prototype.getDay')}}           | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.getday', 'Date.prototype.getDay')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/getfullyear/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getfullyear/index.md
@@ -38,11 +38,11 @@ var year = today.getFullYear();
 
 ## Especificações
 
-| **Especificação**                                                                                                | Status                   | **Comentário**                                     |
-| ---------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| ECMAScript 1st Edition.                                                                                          | Standard                 | Definição inicial. Implementado em JavaScript 1.3. |
-| {{SpecName('ES5.1', '#sec-15.9.5.10', 'Date.prototype.getFullYear')}}                     | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.getfullyear', 'Date.prototype.getFullYear')}} | {{Spec2('ES6')}}     |                                                    |
+| **Especificação**                                                                    | Status             | **Comentário**                                     |
+| ------------------------------------------------------------------------------------ | ------------------ | -------------------------------------------------- |
+| ECMAScript 1st Edition.                                                              | Standard           | Definição inicial. Implementado em JavaScript 1.3. |
+| {{SpecName('ES5.1', '#sec-15.9.5.10', 'Date.prototype.getFullYear')}}                | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.getfullyear', 'Date.prototype.getFullYear')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/gethours/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/gethours/index.md
@@ -30,7 +30,7 @@ O valor retornado por `getHours()` é um inteiro entre 0 e 23.
 O segundo statement abaixo atribui o valor 23 à variável `hours`, baseado no valor do objeto {{jsxref("Global_Objects/Date", "Date")}} `Xmas95`.
 
 ```js
-var Xmas95 = new Date('December 25, 1995 23:15:30');
+var Xmas95 = new Date("December 25, 1995 23:15:30");
 var hours = Xmas95.getHours();
 
 console.log(hours); // 23
@@ -38,11 +38,11 @@ console.log(hours); // 23
 
 ## Especificações
 
-| **Especificação**                                                                                        | Status                   | **Comentário**                                     |
-| -------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| ECMAScript 1st Edition.                                                                                  | Standard                 | Definição inicial. Implementado em JavaScript 1.0. |
-| {{SpecName('ES5.1', '#sec-15.9.5.18', 'Date.prototype.getHours')}}                 | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.gethours', 'Date.prototype.getHours')}} | {{Spec2('ES6')}}     |                                                    |
+| **Especificação**                                                              | Status             | **Comentário**                                     |
+| ------------------------------------------------------------------------------ | ------------------ | -------------------------------------------------- |
+| ECMAScript 1st Edition.                                                        | Standard           | Definição inicial. Implementado em JavaScript 1.0. |
+| {{SpecName('ES5.1', '#sec-15.9.5.18', 'Date.prototype.getHours')}}             | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.gethours', 'Date.prototype.getHours')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/getmilliseconds/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getmilliseconds/index.md
@@ -30,11 +30,11 @@ var milliseconds = today.getMilliseconds();
 
 ## Especificações
 
-| Specification                                                                                                                    | Status                       | Comment                                            |
-| -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                                         | {{Spec2('ES1')}}         | Definição inicial. Implementado no JavaScript 1.3. |
-| {{SpecName('ES5.1', '#sec-15.9.5.24', 'Date.prototype.getMilliseconds')}}                                 | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.getmilliseconds', 'Date.prototype.getMilliseconds')}}     | {{Spec2('ES6')}}         |                                                    |
+| Specification                                                                                    | Status               | Comment                                            |
+| ------------------------------------------------------------------------------------------------ | -------------------- | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                              | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.3. |
+| {{SpecName('ES5.1', '#sec-15.9.5.24', 'Date.prototype.getMilliseconds')}}                        | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.getmilliseconds', 'Date.prototype.getMilliseconds')}}     | {{Spec2('ES6')}}     |                                                    |
 | {{SpecName('ESDraft', '#sec-date.prototype.getmilliseconds', 'Date.prototype.getMilliseconds')}} | {{Spec2('ESDraft')}} |                                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/getminutes/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getminutes/index.md
@@ -26,7 +26,7 @@ The second statement below assigns the value 15 to the variable `minutes`, based
 No exemplo abaixo, a segunda linha atribui o valor 15 à variável `minutes`, baseado no valor de objeto {{jsxref("Global_Objects/Date")}} `Xmas95`.
 
 ```js
-var Xmas95 = new Date('December 25, 1995 23:15:30');
+var Xmas95 = new Date("December 25, 1995 23:15:30");
 var minutes = Xmas95.getMinutes();
 
 console.log(minutes); // 15
@@ -34,11 +34,11 @@ console.log(minutes); // 15
 
 ## Especificações
 
-| Specification                                                                                                        | Status                       | Comment                                            |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                             | {{Spec2('ES1')}}         | Definição inicial. Implementado no JavaScript 1.0. |
-| {{SpecName('ES5.1', '#sec-15.9.5.20', 'Date.prototype.getMinutes')}}                         | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.getminutes', 'Date.prototype.getMinutes')}}         | {{Spec2('ES6')}}         |                                                    |
+| Specification                                                                          | Status               | Comment                                            |
+| -------------------------------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                    | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.0. |
+| {{SpecName('ES5.1', '#sec-15.9.5.20', 'Date.prototype.getMinutes')}}                   | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.getminutes', 'Date.prototype.getMinutes')}}     | {{Spec2('ES6')}}     |                                                    |
 | {{SpecName('ESDraft', '#sec-date.prototype.getminutes', 'Date.prototype.getMinutes')}} | {{Spec2('ESDraft')}} |                                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/getmonth/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getmonth/index.md
@@ -28,7 +28,7 @@ O valor retornado pelo método `getMonth()` é um inteiro entre 0 e 11. 0 corres
 A segunda declaração abaixo atribui o valor 11 à variavel `month`, baseado no valor do objeto {{jsxref("Date")}} `Xmas95`.
 
 ```js
-var Xmas95 = new Date('December 25, 1995 23:15:30');
+var Xmas95 = new Date("December 25, 1995 23:15:30");
 var month = Xmas95.getMonth();
 
 console.log(month); // 11
@@ -36,11 +36,11 @@ console.log(month); // 11
 
 ## Especificações
 
-| Especificação                                                                                            | Status                   | Comentário                                         |
-| -------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                 | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.0. |
-| {{SpecName('ES5.1', '#sec-15.9.5.12', 'Date.prototype.getMonth')}}                 | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.getmonth', 'Date.prototype.getMonth')}} | {{Spec2('ES6')}}     |                                                    |
+| Especificação                                                                  | Status             | Comentário                                         |
+| ------------------------------------------------------------------------------ | ------------------ | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                            | {{Spec2('ES1')}}   | Definição inicial. Implementado no JavaScript 1.0. |
+| {{SpecName('ES5.1', '#sec-15.9.5.12', 'Date.prototype.getMonth')}}             | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.getmonth', 'Date.prototype.getMonth')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/getseconds/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getseconds/index.md
@@ -26,7 +26,7 @@ The second statement below assigns the value 30 to the variable `seconds`, based
 No exemplo a seguir, a segunda linha atribui o valor 30 à variável `seconds`, baseado no valor do objeto {{jsxref("Global_Objects/Date", "Date")}} `Xmas95`.
 
 ```js
-var Xmas95 = new Date('December 25, 1995 23:15:30');
+var Xmas95 = new Date("December 25, 1995 23:15:30");
 var seconds = Xmas95.getSeconds();
 
 console.log(seconds); // 30
@@ -34,11 +34,11 @@ console.log(seconds); // 30
 
 ## Espeficicações
 
-| Specification                                                                                                        | Status                       | Comment                                            |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                             | {{Spec2('ES1')}}         | Definição inicial. Implementado no JavaScript 1.0. |
-| {{SpecName('ES5.1', '#sec-15.9.5.22', 'Date.prototype.getSeconds')}}                         | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.getseconds', 'Date.prototype.getSeconds')}}         | {{Spec2('ES6')}}         |                                                    |
+| Specification                                                                          | Status               | Comment                                            |
+| -------------------------------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                    | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.0. |
+| {{SpecName('ES5.1', '#sec-15.9.5.22', 'Date.prototype.getSeconds')}}                   | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.getseconds', 'Date.prototype.getSeconds')}}     | {{Spec2('ES6')}}     |                                                    |
 | {{SpecName('ESDraft', '#sec-date.prototype.getseconds', 'Date.prototype.getSeconds')}} | {{Spec2('ESDraft')}} |                                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/gettime/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/gettime/index.md
@@ -45,16 +45,16 @@ for (var i = 0; i < 1000; i++) {
 }
 end = new Date();
 
-console.log('Operation took ' + (end.getTime() - start.getTime()) + ' msec');
+console.log("Operation took " + (end.getTime() - start.getTime()) + " msec");
 ```
 
 ## Especificações
 
-| Specification                                                                                                | Status                       | Comment                                            |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------- | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                     | {{Spec2('ES1')}}         | Definição inicial. Implementado em JavaScript 1.0. |
-| {{SpecName('ES5.1', '#sec-15.9.5.9', 'Date.prototype.getTime')}}                         | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.gettime', 'Date.prototype.getTime')}}         | {{Spec2('ES6')}}         |                                                    |
+| Specification                                                                    | Status               | Comment                                            |
+| -------------------------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                              | {{Spec2('ES1')}}     | Definição inicial. Implementado em JavaScript 1.0. |
+| {{SpecName('ES5.1', '#sec-15.9.5.9', 'Date.prototype.getTime')}}                 | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.gettime', 'Date.prototype.getTime')}}     | {{Spec2('ES6')}}     |                                                    |
 | {{SpecName('ESDraft', '#sec-date.prototype.gettime', 'Date.prototype.getTime')}} | {{Spec2('ESDraft')}} |                                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/gettimezoneoffset/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/gettimezoneoffset/index.md
@@ -32,11 +32,11 @@ var currentTimeZoneOffsetInHours = x.getTimezoneOffset() / 60;
 
 ## Especificações
 
-| Especificação                                                                                                                    | Situação                 | comentário                                         |
-| -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                                         | {{Spec2('ES1')}}     | Initial definition. Implemented in JavaScript 1.0. |
-| {{SpecName('ES5.1', '#sec-15.9.5.26', 'Date.prototype.getTimezoneOffset')}}                             | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.gettimezoneoffset', 'Date.prototype.getTimezoneOffset')}} | {{Spec2('ES6')}}     |                                                    |
+| Especificação                                                                                    | Situação           | comentário                                         |
+| ------------------------------------------------------------------------------------------------ | ------------------ | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                              | {{Spec2('ES1')}}   | Initial definition. Implemented in JavaScript 1.0. |
+| {{SpecName('ES5.1', '#sec-15.9.5.26', 'Date.prototype.getTimezoneOffset')}}                      | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.gettimezoneoffset', 'Date.prototype.getTimezoneOffset')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/getutcdate/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getutcdate/index.md
@@ -30,11 +30,11 @@ var day = today.getUTCDate();
 
 ## Especificações
 
-| Specification                                                                                                        | Status                       | Comment                                            |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                             | {{Spec2('ES1')}}         | Definição inicial. Implementado no JavaScript 1.3. |
-| {{SpecName('ES5.1', '#sec-15.9.5.15', 'Date.prototype.getUTCDate')}}                         | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.getutcdate', 'Date.prototype.getUTCDate')}}         | {{Spec2('ES6')}}         |                                                    |
+| Specification                                                                          | Status               | Comment                                            |
+| -------------------------------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                    | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.3. |
+| {{SpecName('ES5.1', '#sec-15.9.5.15', 'Date.prototype.getUTCDate')}}                   | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.getutcdate', 'Date.prototype.getUTCDate')}}     | {{Spec2('ES6')}}     |                                                    |
 | {{SpecName('ESDraft', '#sec-date.prototype.getutcdate', 'Date.prototype.getUTCDate')}} | {{Spec2('ESDraft')}} |                                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/getutcday/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getutcday/index.md
@@ -34,11 +34,11 @@ var diaDaSemana = hoje.getUTCDay();
 
 ## Especificações
 
-| Especificação                                                                                                | Situação                 | Comentário                                         |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------ | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                     | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.3. |
-| {{SpecName('ES5.1', '#sec-15.9.5.17', 'Date.prototype.getUTCDay')}}                     | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.getutcday', 'Date.prototype.getUTCDay')}} | {{Spec2('ES6')}}     |                                                    |
+| Especificação                                                                    | Situação           | Comentário                                         |
+| -------------------------------------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                              | {{Spec2('ES1')}}   | Definição inicial. Implementado no JavaScript 1.3. |
+| {{SpecName('ES5.1', '#sec-15.9.5.17', 'Date.prototype.getUTCDay')}}              | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.getutcday', 'Date.prototype.getUTCDay')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/getutcfullyear/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getutcfullyear/index.md
@@ -36,11 +36,11 @@ var year = today.getUTCFullYear();
 
 ## Especificações
 
-| Especificação                                                                                                                | Status                       | Comentário                                         |
-| ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                                     | {{Spec2('ES1')}}         | Definição inicial. Implementado no JavaScript 1.3. |
-| {{SpecName('ES5.1', '#sec-15.9.5.11', 'Date.prototype.getUTCFullYear')}}                             | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.getutcfullyear', 'Date.prototype.getUTCFullYear')}}     | {{Spec2('ES6')}}         |                                                    |
+| Especificação                                                                                  | Status               | Comentário                                         |
+| ---------------------------------------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                            | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.3. |
+| {{SpecName('ES5.1', '#sec-15.9.5.11', 'Date.prototype.getUTCFullYear')}}                       | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.getutcfullyear', 'Date.prototype.getUTCFullYear')}}     | {{Spec2('ES6')}}     |                                                    |
 | {{SpecName('ESDraft', '#sec-date.prototype.getutcfullyear', 'Date.prototype.getUTCFullYear')}} | {{Spec2('ESDraft')}} |                                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/getutchours/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getutchours/index.md
@@ -30,8 +30,8 @@ var hours = today.getUTCHours();
 
 ## Especificações
 
-| Especificação                                                                                                        |
-| -------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                            |
+| ---------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.getutchours', 'Date.prototype.getUTCHours')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/getutcmilliseconds/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getutcmilliseconds/index.md
@@ -30,11 +30,11 @@ var milissegundos = today.getUTCMilliseconds();
 
 ## Especificações
 
-| Especificação                                                                                                                            | Status                       | Comentário                                         |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                                                 | {{Spec2('ES1')}}         | definição inicial. Implementado no JavaScript 1.3. |
-| {{SpecName('ES5.1', '#sec-15.9.5.25', 'Date.prototype.getUTCMilliseconds')}}                                     | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.getutcmilliseconds', 'Date.prototype.getUTCMilliseconds')}}     | {{Spec2('ES6')}}         |                                                    |
+| Especificação                                                                                          | Status               | Comentário                                         |
+| ------------------------------------------------------------------------------------------------------ | -------------------- | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                                    | {{Spec2('ES1')}}     | definição inicial. Implementado no JavaScript 1.3. |
+| {{SpecName('ES5.1', '#sec-15.9.5.25', 'Date.prototype.getUTCMilliseconds')}}                           | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.getutcmilliseconds', 'Date.prototype.getUTCMilliseconds')}}     | {{Spec2('ES6')}}     |                                                    |
 | {{SpecName('ESDraft', '#sec-date.prototype.getutcmilliseconds', 'Date.prototype.getUTCMilliseconds')}} | {{Spec2('ESDraft')}} |                                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/getutcminutes/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getutcminutes/index.md
@@ -32,8 +32,8 @@ var minutes = today.getUTCMinutes();
 
 ## Especificações
 
-| Especificação                                                                                                                |
-| ---------------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                                |
+| -------------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.getutcminutes', 'Date.prototype.getUTCMinutes')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/getutcmonth/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getutcmonth/index.md
@@ -30,11 +30,11 @@ var month = today.getUTCMonth();
 
 ## Especificações
 
-| Specification                                                                                                        | Status                       | Comment                                            |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                             | {{Spec2('ES1')}}         | Initial definition. Implemented in JavaScript 1.3. |
-| {{SpecName('ES5.1', '#sec-15.9.5.13', 'Date.prototype.getUTCMonth')}}                         | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.getutcmonth', 'Date.prototype.getUTCMonth')}}     | {{Spec2('ES6')}}         |                                                    |
+| Specification                                                                            | Status               | Comment                                            |
+| ---------------------------------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                      | {{Spec2('ES1')}}     | Initial definition. Implemented in JavaScript 1.3. |
+| {{SpecName('ES5.1', '#sec-15.9.5.13', 'Date.prototype.getUTCMonth')}}                    | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.getutcmonth', 'Date.prototype.getUTCMonth')}}     | {{Spec2('ES6')}}     |                                                    |
 | {{SpecName('ESDraft', '#sec-date.prototype.getutcmonth', 'Date.prototype.getUTCMonth')}} | {{Spec2('ESDraft')}} |                                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/getutcseconds/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getutcseconds/index.md
@@ -34,11 +34,11 @@ var seconds = today.getUTCSeconds();
 
 ## Especificações
 
-| Especificação                                                                                                                | Estado                       | Comentário                                         |
-| ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                                     | {{Spec2('ES1')}}         | Definição inicial. Implementado no JavaScript 1.3. |
-| {{SpecName('ES5.1', '#sec-15.9.5.23', 'Date.prototype.getUTCSeconds')}}                             | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.getutcseconds', 'Date.prototype.getUTCSeconds')}}         | {{Spec2('ES6')}}         |                                                    |
+| Especificação                                                                                | Estado               | Comentário                                         |
+| -------------------------------------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                          | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.3. |
+| {{SpecName('ES5.1', '#sec-15.9.5.23', 'Date.prototype.getUTCSeconds')}}                      | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.getutcseconds', 'Date.prototype.getUTCSeconds')}}     | {{Spec2('ES6')}}     |                                                    |
 | {{SpecName('ESDraft', '#sec-date.prototype.getutcseconds', 'Date.prototype.getUTCSeconds')}} | {{Spec2('ESDraft')}} |                                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/getyear/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getyear/index.md
@@ -45,7 +45,7 @@ O método `getYear()` retorna um ano de 2 ou 4 dígitos:
 O segundo statement atribui o valor 95 à variável `year`.
 
 ```js
-var Xmas = new Date('December 25, 1995 23:15:00');
+var Xmas = new Date("December 25, 1995 23:15:00");
 var year = Xmas.getYear(); // returns 95
 ```
 
@@ -54,7 +54,7 @@ var year = Xmas.getYear(); // returns 95
 O segundo statement atribui o valor 100 à variável `year`.
 
 ```js
-var Xmas = new Date('December 25, 2000 23:15:00');
+var Xmas = new Date("December 25, 2000 23:15:00");
 var year = Xmas.getYear(); // returns 100
 ```
 
@@ -63,7 +63,7 @@ var year = Xmas.getYear(); // returns 100
 O segundo statement atribui o valor -100 à variável `year`.
 
 ```js
-var Xmas = new Date('December 25, 1800 23:15:00');
+var Xmas = new Date("December 25, 1800 23:15:00");
 var year = Xmas.getYear(); // returns -100
 ```
 
@@ -78,11 +78,11 @@ var year = Xmas.getYear(); // returns 95
 
 ## Especificações
 
-| **Especificação**                                                                                    | Status                   | **Comentário**                                                                           |
-| ---------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------- |
-| ECMAScript 1st Edition.                                                                              | Standard                 | Definição inicial. Implementado em JavaScript 1.3.                                       |
-| {{SpecName('ES5.1', '#sec-B.2.4', 'Date.prototype.getYear')}}                     | {{Spec2('ES5.1')}} | Definido em (informativo) compatibilidade annex.                                         |
-| {{SpecName('ES6', '#sec-date.prototype.getyear', 'Date.prototype.getYear')}} | {{Spec2('ES6')}}     | Definido em (normativo) annex para funcionalidades adicionais para futuros browsers web. |
+| **Especificação**                                                            | Status             | **Comentário**                                                                           |
+| ---------------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------- |
+| ECMAScript 1st Edition.                                                      | Standard           | Definição inicial. Implementado em JavaScript 1.3.                                       |
+| {{SpecName('ES5.1', '#sec-B.2.4', 'Date.prototype.getYear')}}                | {{Spec2('ES5.1')}} | Definido em (informativo) compatibilidade annex.                                         |
+| {{SpecName('ES6', '#sec-date.prototype.getyear', 'Date.prototype.getYear')}} | {{Spec2('ES6')}}   | Definido em (normativo) annex para funcionalidades adicionais para futuros browsers web. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/index.md
@@ -25,27 +25,35 @@ new Date(ano, mês, dia, hora, minuto, segundo, milissegundo);
 Nota: Quando Date for chamado como um construtor com mais de um argumento, se os valores forem maiores do que seu limite lógico (e.g. se 13 for fornecido como um valor para mês ou 70 for o valor para minuto), o valor adjacente será ajustado. E.g. new Date(2013, 13, 1) é equivalente a new Date(2014, 1, 1), ambos criam uma data para 2014-02-01 (note que o mês começa em 0). Similarmente para outros valores: new Date(2013, 2, 1, 0, 70) é equivalente a new Date(2013, 2, 1, 1, 10), pois ambos criam uma data para 2013-03-01T01:10:00.
 
 - _`value`_
+
   - : Um valor inteiro representando o número de milisegundos desde 1 de Janeiro de 1970 00:00:00 UTC (Era Unix ou Marco Zero).
 
 - _`dataString`_
+
   - : Um valor do tipo String que representa uma data. A string deverá estar uma formato reconhecido pelo método {{jsxref("Date.parse()")}} ([IETF-compliant RFC 2822 timestamps](http://tools.ietf.org/html/rfc2822#page-14) e também uma [versão da ISO8601](http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15)).
 
 - _`year`_
+
   - : Um valor inteiro que representa o ano. Valores de 0 a 99 correspondem aos anos de 1900 a 1999. Veja o [exemplo abaixo](<#Two digit years>).
 
 - _`month`_
+
   - : Um valor inteiro que representa o mês, começando com 0 para Janeiro até 11 para Dezembro.
 
 - _`day`_
+
   - : Um valor inteiro que representa o dia do mês.
 
 - _`hour`_
+
   - : Um valor inteiro que representa a hora do dia.
 
 - _`minute`_
+
   - : Um valor inteiro que representa o segmento de um minuto de tempo.
 
 - _`second`_
+
   - : Um valor inteiro que representa o segmento de segundo do tempo.
 
 - _`millisecond`_
@@ -96,8 +104,8 @@ Os seguintes exemplos mostram várias formas de se criar datas em JavaScript:
 var today = new Date();
 var birthday = new Date("December 17, 1995 03:24:00");
 var birthday = new Date("1995-12-17T03:24:00");
-var birthday = new Date(1995,11,17);
-var birthday = new Date(1995,11,17,3,24,0);
+var birthday = new Date(1995, 11, 17);
+var birthday = new Date(1995, 11, 17, 3, 24, 0);
 ```
 
 ### Anos com dois dígitos mapeados para 1900 - 1999
@@ -108,9 +116,9 @@ Para criar e obter datas entre os anos 0 e 99 os métodos {{jsxref("Date.prototy
 var data = new Date(98, 1); // Dom Fev 01 1998 00:00:00 GMT+0000 (GMT)
 
 // Métodos em desuso, 98 mapeia para 1998 aqui também
-data.setYear(98);           // Dom Fev 01 1998 00:00:00 GMT+0000 (GMT)
+data.setYear(98); // Dom Fev 01 1998 00:00:00 GMT+0000 (GMT)
 
-data.setFullYear(98);       // Sab Fev 01 0098 00:00:00 GMT+0000 (BST)
+data.setFullYear(98); // Sab Fev 01 0098 00:00:00 GMT+0000 (BST)
 ```
 
 ### Calculando o tempo decorrido
@@ -143,10 +151,12 @@ var decorrido = fim.getTime() - inicio.getTime(); // tempo decorrido em milisegu
 // para testar uma função e obter o seu retorno
 function imprimirTempoDecorrido(fTeste) {
   var nHoraInicial = Date.now(),
-      vRetorno = fTeste(),
-      nHoraFinal = Date.now();
+    vRetorno = fTeste(),
+    nHoraFinal = Date.now();
 
-  alert("Tempo decorrido: " + String(nHoraFinal - nHoraInicial) + " milisegundos");
+  alert(
+    "Tempo decorrido: " + String(nHoraFinal - nHoraInicial) + " milisegundos",
+  );
   return vRetorno;
 }
 
@@ -157,12 +167,12 @@ retornoDaSuaFuncao = imprimirTempoDecorrido(suaFuncao);
 
 ## Especificações
 
-| Especificação                                                        | Estado                       | Comentário                                         |
-| -------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
+| Especificação                                        | Estado               | Comentário                                         |
+| ---------------------------------------------------- | -------------------- | -------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date-objects', 'Date')}} | {{Spec2('ESDraft')}} |                                                    |
-| {{SpecName('ES6', '#sec-date-objects', 'Date')}}     | {{Spec2('ES6')}}         |                                                    |
-| {{SpecName('ES5.1', '#sec-15.9', 'Date')}}             | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES1')}}                                             | {{Spec2('ES1')}}         | Definição inicial. Implementado no JavaScript 1.1. |
+| {{SpecName('ES6', '#sec-date-objects', 'Date')}}     | {{Spec2('ES6')}}     |                                                    |
+| {{SpecName('ES5.1', '#sec-15.9', 'Date')}}           | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES1')}}                                  | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.1. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/now/index.md
@@ -39,10 +39,10 @@ if (!Date.now) {
 
 ## Especificações
 
-| Especificação                                                        | Status                   | Comentário                                        |
-| -------------------------------------------------------------------- | ------------------------ | ------------------------------------------------- |
+| Especificação                                      | Status             | Comentário                                        |
+| -------------------------------------------------- | ------------------ | ------------------------------------------------- |
 | {{SpecName('ES5.1', '#sec-15.9.4.4', 'Date.now')}} | {{Spec2('ES5.1')}} | Definição inicial. Implementado no JavaScript 1.5 |
-| {{SpecName('ES6', '#sec-date.now', 'Date.now')}}     | {{Spec2('ES6')}}     |                                                   |
+| {{SpecName('ES6', '#sec-date.now', 'Date.now')}}   | {{Spec2('ES6')}}   |                                                   |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/parse/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/parse/index.md
@@ -56,30 +56,30 @@ However, invalid values in date strings not recognized as ISO format as defined 
 
 ```js
 // Non-ISO string with invalid date values
-new Date('23/25/2014');
+new Date("23/25/2014");
 ```
 
 will be treated as a local date of 25 November, 2015 in Firefox 30 and an invalid date in Safari 7. However, if the string is recognized as an ISO format string and it contains invalid values, it will return {{jsxref("Global_Objects/NaN", "NaN")}} in all browsers compliant with ES5:
 
 ```js
 // ISO string with invalid values
-new Date('2014-25-23').toISOString();
+new Date("2014-25-23").toISOString();
 // returns "RangeError: invalid date" in all es5 compliant browsers
 ```
 
 SpiderMonkey's implementation-specific heuristic can be found in [`jsdate.cpp`](http://mxr.mozilla.org/mozilla-central/source/js/src/jsdate.cpp?rev=64553c483cd1#889). The string `"10 06 2014"` is an example of a non–conforming ISO format and thus falls back to a custom routine. See also this [rough outline](https://bugzilla.mozilla.org/show_bug.cgi?id=1023155#c6) on how the parsing works.
 
 ```js
-new Date('10 06 2014');
+new Date("10 06 2014");
 ```
 
 will be treated as a local date of 6 October, 2014 and not 10 June, 2014. Other examples:
 
 ```js
-new Date('foo-bar 2014').toString();
+new Date("foo-bar 2014").toString();
 // returns: "Invalid Date"
 
-Date.parse('foo-bar 2014');
+Date.parse("foo-bar 2014");
 // returns: NaN
 ```
 
@@ -90,54 +90,54 @@ Date.parse('foo-bar 2014');
 If `IPOdate` is an existing {{jsxref("Global_Objects/Date", "Date")}} object, it can be set to August 9, 1995 (local time) as follows:
 
 ```js
-IPOdate.setTime(Date.parse('Aug 9, 1995'));
+IPOdate.setTime(Date.parse("Aug 9, 1995"));
 ```
 
 Some other examples of parsing non–standard date strings:
 
 ```js
-Date.parse('Aug 9, 1995');
+Date.parse("Aug 9, 1995");
 ```
 
 Returns `807937200000` in time zone GMT-0300, and other values in other time zones, since the string does not specify a time zone and is not ISO format, therefore the time zone defaults to local.
 
 ```js
-Date.parse('Wed, 09 Aug 1995 00:00:00 GMT');
+Date.parse("Wed, 09 Aug 1995 00:00:00 GMT");
 ```
 
 Returns `807926400000` no matter the local time zone as GMT (UTC) is provided.
 
 ```js
-Date.parse('Wed, 09 Aug 1995 00:00:00');
+Date.parse("Wed, 09 Aug 1995 00:00:00");
 ```
 
 Returns `807937200000` in time zone GMT-0300, and other values in other time zones, since there is no time zone specifier in the argument and it is not ISO format, so is treated as local.
 
 ```js
-Date.parse('Thu, 01 Jan 1970 00:00:00 GMT');
+Date.parse("Thu, 01 Jan 1970 00:00:00 GMT");
 ```
 
 Returns `0` no matter the local time zone as a time zone GMT (UTC) is provided.
 
 ```js
-Date.parse('Thu, 01 Jan 1970 00:00:00');
+Date.parse("Thu, 01 Jan 1970 00:00:00");
 ```
 
 Returns `14400000` in time zone GMT-0400, and other values in other time zones, since no time zone is provided and the string is not in ISO format, therfore the local time zone is used.
 
 ```js
-Date.parse('Thu, 01 Jan 1970 00:00:00 GMT-0400');
+Date.parse("Thu, 01 Jan 1970 00:00:00 GMT-0400");
 ```
 
 Returns `14400000` no matter the local time zone as a time zone GMT (UTC) is provided.
 
 ## Specifications
 
-| Specification                                                        | Status                   | Comment                                            |
-| -------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| ECMAScript 1st Edition.                                              | Standard                 | Initial definition. Implemented in JavaScript 1.0. |
+| Specification                                        | Status             | Comment                                            |
+| ---------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| ECMAScript 1st Edition.                              | Standard           | Initial definition. Implemented in JavaScript 1.0. |
 | {{SpecName('ES5.1', '#sec-15.9.4.2', 'Date.parse')}} | {{Spec2('ES5.1')}} | ISO 8601 format added.                             |
-| {{SpecName('ES6', '#sec-date.parse', 'Date.parse')}} | {{Spec2('ES6')}}     |                                                    |
+| {{SpecName('ES6', '#sec-date.parse', 'Date.parse')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/setdate/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setdate/index.md
@@ -38,18 +38,18 @@ Se um número negativo for fornecido para `dayValue`, a data será configurada c
 
 ```js
 var theBigDay = new Date(1962, 6, 7); // 1962-07-07 (7th of July 1962)
-theBigDay.setDate(24);  // 1962-07-24 (24th of July 1962)
-theBigDay.setDate(32);  // 1962-08-01 (1st of August 1962)
-theBigDay.setDate(22);  // 1962-08-22 (22th of August 1962)
-theBigDay.setDate(0);   // 1962-07-31 (31th of July 1962)
-theBigDay.setDate(98);  // 1962-10-06 (6th of October 1962)
+theBigDay.setDate(24); // 1962-07-24 (24th of July 1962)
+theBigDay.setDate(32); // 1962-08-01 (1st of August 1962)
+theBigDay.setDate(22); // 1962-08-22 (22th of August 1962)
+theBigDay.setDate(0); // 1962-07-31 (31th of July 1962)
+theBigDay.setDate(98); // 1962-10-06 (6th of October 1962)
 theBigDay.setDate(-50); // 1962-08-11 (11th of August 1962)
 ```
 
 ## Especificações
 
-| Especificação                                                                                                |
-| ------------------------------------------------------------------------------------------------------------ |
+| Especificação                                                                    |
+| -------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.setdate', 'Date.prototype.setDate')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/setfullyear/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setfullyear/index.md
@@ -45,8 +45,8 @@ theBigDay.setFullYear(1997);
 
 ## Especificações
 
-| Especificação                                                                                                        |
-| -------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                            |
+| ---------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.setfullyear', 'Date.prototype.setFullYear')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/sethours/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/sethours/index.md
@@ -53,8 +53,8 @@ theBigDay.setHours(7);
 
 ## Especificações
 
-| Especificação                                                                                                |
-| ------------------------------------------------------------------------------------------------------------ |
+| Especificação                                                                      |
+| ---------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.sethours', 'Date.prototype.setHours')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/setmilliseconds/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setmilliseconds/index.md
@@ -39,8 +39,8 @@ theBigDay.setMilliseconds(100);
 
 ## Especificações
 
-| Especificação                                                                                                                    |
-| -------------------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                                    |
+| ------------------------------------------------------------------------------------------------ |
 | {{SpecName('ESDraft', '#sec-date.prototype.setmilliseconds', 'Date.prototype.setMilliseconds')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/setminutes/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setminutes/index.md
@@ -51,8 +51,8 @@ theBigDay.setMinutes(45);
 
 ## Especificações
 
-| Especificação                                                                                                        |
-| -------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                          |
+| -------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.setminutes', 'Date.prototype.setMinutes')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/setmonth/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setmonth/index.md
@@ -56,8 +56,8 @@ console.log(endOfMonth); //Wed Mar 02 2016 00:00:00
 
 ## Especificações
 
-| Especificação                                                                                                |
-| ------------------------------------------------------------------------------------------------------------ |
+| Especificação                                                                      |
+| ---------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.setmonth', 'Date.prototype.setMonth')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/setseconds/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setseconds/index.md
@@ -49,8 +49,8 @@ theBigDay.setSeconds(30);
 
 ## Especificações
 
-| Especificação                                                                                                        |
-| -------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                          |
+| -------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.setseconds', 'Date.prototype.setSeconds')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/settime/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/settime/index.md
@@ -29,18 +29,18 @@ Use o método `setTime()` para ajudar a atribuir data e hora para outro objeto {
 ### Usando `setTime()`
 
 ```js
-var theBigDay = new Date('July 1, 1999');
+var theBigDay = new Date("July 1, 1999");
 var sameAsBigDay = new Date();
 sameAsBigDay.setTime(theBigDay.getTime());
 ```
 
 ## Especificações
 
-| Especificação                                                                                                | Status                       | Comentário                                         |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------- | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                     | {{Spec2('ES1')}}         | Definição inicial. Implementado no JavaScript 1.0. |
-| {{SpecName('ES5.1', '#sec-15.9.5.27', 'Date.prototype.setTime')}}                     | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.settime', 'Date.prototype.setTime')}}         | {{Spec2('ES6')}}         |                                                    |
+| Especificação                                                                    | Status               | Comentário                                         |
+| -------------------------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                              | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.0. |
+| {{SpecName('ES5.1', '#sec-15.9.5.27', 'Date.prototype.setTime')}}                | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.settime', 'Date.prototype.setTime')}}     | {{Spec2('ES6')}}     |                                                    |
 | {{SpecName('ESDraft', '#sec-date.prototype.settime', 'Date.prototype.setTime')}} | {{Spec2('ESDraft')}} |                                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/setutcdate/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setutcdate/index.md
@@ -39,8 +39,8 @@ theBigDay.setUTCDate(20);
 
 ## Especificações
 
-| Especificação                                                                                                        |
-| -------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                          |
+| -------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.setutcdate', 'Date.prototype.setUTCDate')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/setutcfullyear/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setutcfullyear/index.md
@@ -45,8 +45,8 @@ theBigDay.setUTCFullYear(1997);
 
 ## Especificações
 
-| Especificação                                                                                                                |
-| ---------------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                                  |
+| ---------------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.setutcfullyear', 'Date.prototype.setUTCFullYear')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/setutchours/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setutchours/index.md
@@ -47,8 +47,8 @@ theBigDay.setUTCHours(8);
 
 ## Especificações
 
-| Especificação                                                                                                        |
-| -------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                            |
+| ---------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.setutchours', 'Date.prototype.setUTCHours')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/setutcmilliseconds/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setutcmilliseconds/index.md
@@ -39,8 +39,8 @@ theBigDay.setUTCMilliseconds(500);
 
 ## Especificações
 
-| Especificação                                                                                                                            |
-| ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                                          |
+| ------------------------------------------------------------------------------------------------------ |
 | {{SpecName('ESDraft', '#sec-date.prototype.setutcmilliseconds', 'Date.prototype.setUTCMilliseconds')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/setutcminutes/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setutcminutes/index.md
@@ -45,8 +45,8 @@ theBigDay.setUTCMinutes(43);
 
 ## Especificações
 
-| Especificação                                                                                                                |
-| ---------------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                                |
+| -------------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.setutcminutes', 'Date.prototype.setUTCMinutes')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/setutcmonth/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setutcmonth/index.md
@@ -43,8 +43,8 @@ theBigDay.setUTCMonth(11);
 
 ## Especificações
 
-| Especificação                                                                                                        |
-| -------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                            |
+| ---------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.setutcmonth', 'Date.prototype.setUTCMonth')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/setutcseconds/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setutcseconds/index.md
@@ -43,8 +43,8 @@ theBigDay.setUTCSeconds(20);
 
 ## Especificações
 
-| Especificação                                                                                                                |
-| ---------------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                                |
+| -------------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.setutcseconds', 'Date.prototype.setUTCSeconds')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/setyear/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setyear/index.md
@@ -42,8 +42,8 @@ theBigDay.setYear(2000);
 
 ## Especificações
 
-| Especificação                                                                                                |
-| ------------------------------------------------------------------------------------------------------------ |
+| Especificação                                                                    |
+| -------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.setyear', 'Date.prototype.setYear')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/todatestring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/todatestring/index.md
@@ -26,17 +26,17 @@ Exemplares de {{jsxref("Date")}} referem-se a um ponto específico no tempo. Cha
 ```js
 var d = new Date(1993, 6, 28, 14, 39, 7);
 
-console.log(d.toString());     // exibe Wed Jul 28 1993 14:39:07 GMT-0600 (PDT) no log
+console.log(d.toString()); // exibe Wed Jul 28 1993 14:39:07 GMT-0600 (PDT) no log
 console.log(d.toDateString()); // exibe Wed Jul 28 1993 no log
 ```
 
 ## Especificações
 
-| Especificação                                                                                                            | Situação                     | Comentário         |
-| ------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------ |
-| {{SpecName('ES3')}}                                                                                                 | {{Spec2('ES3')}}         | Definição inicial. |
-| {{SpecName('ES5.1', '#sec-15.9.5.3', 'Date.prototype.toDateString')}}                             | {{Spec2('ES5.1')}}     |                    |
-| {{SpecName('ES6', '#sec-date.prototype.todatestring', 'Date.prototype.toDateString')}}     | {{Spec2('ES6')}}         |                    |
+| Especificação                                                                              | Situação             | Comentário         |
+| ------------------------------------------------------------------------------------------ | -------------------- | ------------------ |
+| {{SpecName('ES3')}}                                                                        | {{Spec2('ES3')}}     | Definição inicial. |
+| {{SpecName('ES5.1', '#sec-15.9.5.3', 'Date.prototype.toDateString')}}                      | {{Spec2('ES5.1')}}   |                    |
+| {{SpecName('ES6', '#sec-date.prototype.todatestring', 'Date.prototype.toDateString')}}     | {{Spec2('ES6')}}     |                    |
 | {{SpecName('ESDraft', '#sec-date.prototype.todatestring', 'Date.prototype.toDateString')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/toisostring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/toisostring/index.md
@@ -25,26 +25,32 @@ Este método foi padronizado na quinta edição da ECMA-262. Motores que não fo
 
 ```js
 if (!Date.prototype.toISOString) {
-  (function() {
-
+  (function () {
     function pad(number) {
       if (number < 10) {
-        return '0' + number;
+        return "0" + number;
       }
       return number;
     }
 
-    Date.prototype.toISOString = function() {
-      return this.getUTCFullYear() +
-        '-' + pad(this.getUTCMonth() + 1) +
-        '-' + pad(this.getUTCDate()) +
-        'T' + pad(this.getUTCHours()) +
-        ':' + pad(this.getUTCMinutes()) +
-        ':' + pad(this.getUTCSeconds()) +
-        '.' + (this.getUTCMilliseconds() / 1000).toFixed(3).slice(2, 5) +
-        'Z';
+    Date.prototype.toISOString = function () {
+      return (
+        this.getUTCFullYear() +
+        "-" +
+        pad(this.getUTCMonth() + 1) +
+        "-" +
+        pad(this.getUTCDate()) +
+        "T" +
+        pad(this.getUTCHours()) +
+        ":" +
+        pad(this.getUTCMinutes()) +
+        ":" +
+        pad(this.getUTCSeconds()) +
+        "." +
+        (this.getUTCMilliseconds() / 1000).toFixed(3).slice(2, 5) +
+        "Z"
+      );
     };
-
   })();
 }
 ```
@@ -54,17 +60,17 @@ if (!Date.prototype.toISOString) {
 ### Usando `toISOString()`
 
 ```js
-let today = new Date('05 October 2011 14:48 UTC')
+let today = new Date("05 October 2011 14:48 UTC");
 
-console.log(today.toISOString())  // Retorna 2011-10-05T14:48:00.000Z
+console.log(today.toISOString()); // Retorna 2011-10-05T14:48:00.000Z
 ```
 
 O exemplo acima usa uma conversão de uma _string_ não-padrão que pode não ser convertida corretamente em navegadores que não sejam da Mozilla..
 
 ## Especificações
 
-| Especificação                                                                                                        |
-| -------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                            |
+| ---------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.toisostring', 'Date.prototype.toISOString')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/tojson/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/tojson/index.md
@@ -28,7 +28,7 @@ Instâncias de {{jsxref("Date")}} referem-se a um específico ponto no tempo. In
 ### Usando `toJSON()`
 
 ```js
-var jsonDate = (new Date()).toJSON();
+var jsonDate = new Date().toJSON();
 var backToDate = new Date(jsonDate);
 
 console.log(jsonDate); //2015-10-26T07:46:36.611Z
@@ -36,10 +36,10 @@ console.log(jsonDate); //2015-10-26T07:46:36.611Z
 
 ## Especificações
 
-| Especificação                                                                                            | Status                       | Comentários                                          |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------- | ---------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.9.5.44', 'Date.prototype.toJSON')}}                     | {{Spec2('ES5.1')}}     | Definição inicial. Implementado no JavaScript 1.8.5. |
-| {{SpecName('ES6', '#sec-date.prototype.tojson', 'Date.prototype.toJSON')}}     | {{Spec2('ES6')}}         |                                                      |
+| Especificação                                                                  | Status               | Comentários                                          |
+| ------------------------------------------------------------------------------ | -------------------- | ---------------------------------------------------- |
+| {{SpecName('ES5.1', '#sec-15.9.5.44', 'Date.prototype.toJSON')}}               | {{Spec2('ES5.1')}}   | Definição inicial. Implementado no JavaScript 1.8.5. |
+| {{SpecName('ES6', '#sec-date.prototype.tojson', 'Date.prototype.toJSON')}}     | {{Spec2('ES6')}}     |                                                      |
 | {{SpecName('ESDraft', '#sec-date.prototype.tojson', 'Date.prototype.toJSON')}} | {{Spec2('ESDraft')}} |                                                      |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
@@ -45,9 +45,9 @@ Os argumentos `locales` e `options` não são suportados em todos os browser ain
 ```js
 function toLocaleDateStringSupportsLocales() {
   try {
-    new Date().toLocaleDateString('i');
+    new Date().toLocaleDateString("i");
   } catch (e) {
-    return e.name === 'RangeError';
+    return e.name === "RangeError";
   }
   return false;
 }
@@ -64,29 +64,29 @@ var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
 // America/Los_Angeles for the US
 
 // Inglês americano usa a ordem mês-dia-ano
-console.log(date.toLocaleDateString('en-US'));
+console.log(date.toLocaleDateString("en-US"));
 // → "12/19/2012"
 
 // Inglês Britânico usa a ordem dia-mês-ano
-console.log(date.toLocaleDateString('en-GB'));
+console.log(date.toLocaleDateString("en-GB"));
 // → "20/12/2012"
 
 // Coreano usa a ordem ano-mês-dia
-console.log(date.toLocaleDateString('ko-KR'));
+console.log(date.toLocaleDateString("ko-KR"));
 // → "2012. 12. 20."
 
 // Árabe na maioria dos países de língua árabe usa dígitos árabes reais
-console.log(date.toLocaleDateString('ar-EG'));
+console.log(date.toLocaleDateString("ar-EG"));
 // → "٢٠‏/١٢‏/٢٠١٢"
 
 // para Japonês, aplicações podem querer usar o calendário japonês,
 // onde 2012 foi o ano 24 da era Heisei
-console.log(date.toLocaleDateString('ja-JP-u-ca-japanese'));
+console.log(date.toLocaleDateString("ja-JP-u-ca-japanese"));
 // → "24/12/20"
 
 // quando um idioma que pode não ser suportado é requerido, tal como
 // Balinês, inclua um idioma de reserva, nesse caso Indonésio
-console.log(date.toLocaleDateString(['ban', 'id']));
+console.log(date.toLocaleDateString(["ban", "id"]));
 // → "20/12/2012"
 ```
 
@@ -98,14 +98,19 @@ O resultados gerados por `toLocaleDateString()` podem ser customizado usando o a
 var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
 
 // requer um dia da semana jutamente com uma data longa
-var options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-console.log(date.toLocaleDateString('de-DE', options));
+var options = {
+  weekday: "long",
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+};
+console.log(date.toLocaleDateString("de-DE", options));
 // → "Donnerstag, 20. Dezember 2012"
 
 // uma aplicação pode querer usar UTC e fazê-lo visível
-options.timeZone = 'UTC';
-options.timeZoneName = 'short';
-console.log(date.toLocaleDateString('en-US', options));
+options.timeZone = "UTC";
+options.timeZoneName = "short";
+console.log(date.toLocaleDateString("en-US", options));
 // → "Thursday, December 20, 2012, GMT"
 ```
 
@@ -115,14 +120,14 @@ Ao formatar um grande número de datas, é melhor criar um objeto {{jsxref("Glob
 
 ## Especificações
 
-| Specification                                                                                                                                    | Status                           | Comment                                            |
-| ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | -------------------------------------------------- |
-| {{SpecName('ES3')}}                                                                                                                         | {{Spec2('ES3')}}             | Definição inicial. Implementada no JavaScript 1.0. |
-| {{SpecName('ES5.1', 'sec-15.9.5.6', 'Date.prototype.toLocaleDateString')}}                                             | {{Spec2('ES5.1')}}         |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.tolocaledatestring', 'Date.prototype.toLocaleDateString')}}             | {{Spec2('ES6')}}             |                                                    |
-| {{SpecName('ESDraft', '#sec-date.prototype.tolocaledatestring', 'Date.prototype.toLocaleDateString')}}         | {{Spec2('ESDraft')}}     |                                                    |
-| {{SpecName('ES Int 1.0', '#sec-13.3.2', 'Date.prototype.toLocaleDateString')}}                                         | {{Spec2('ES Int 1.0')}} | Define os argumentos `locales` e `options`.        |
-| {{SpecName('ES Int 2.0', '#sec-13.3.2', 'Date.prototype.toLocaleDateString')}}                                         | {{Spec2('ES Int 2.0')}} |                                                    |
+| Specification                                                                                               | Status                    | Comment                                            |
+| ----------------------------------------------------------------------------------------------------------- | ------------------------- | -------------------------------------------------- |
+| {{SpecName('ES3')}}                                                                                         | {{Spec2('ES3')}}          | Definição inicial. Implementada no JavaScript 1.0. |
+| {{SpecName('ES5.1', 'sec-15.9.5.6', 'Date.prototype.toLocaleDateString')}}                                  | {{Spec2('ES5.1')}}        |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.tolocaledatestring', 'Date.prototype.toLocaleDateString')}}          | {{Spec2('ES6')}}          |                                                    |
+| {{SpecName('ESDraft', '#sec-date.prototype.tolocaledatestring', 'Date.prototype.toLocaleDateString')}}      | {{Spec2('ESDraft')}}      |                                                    |
+| {{SpecName('ES Int 1.0', '#sec-13.3.2', 'Date.prototype.toLocaleDateString')}}                              | {{Spec2('ES Int 1.0')}}   | Define os argumentos `locales` e `options`.        |
+| {{SpecName('ES Int 2.0', '#sec-13.3.2', 'Date.prototype.toLocaleDateString')}}                              | {{Spec2('ES Int 2.0')}}   |                                                    |
 | {{SpecName('ES Int Draft', '#sec-Date.prototype.toLocaleDateString', 'Date.prototype.toLocaleDateString')}} | {{Spec2('ES Int Draft')}} |                                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/tolocalestring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/tolocalestring/index.md
@@ -49,7 +49,7 @@ The `locales` and `options` arguments are not supported in all browsers yet. To 
 ```js
 function toLocaleStringSupportsLocales() {
   try {
-    new Date().toLocaleString('i');
+    new Date().toLocaleString("i");
   } catch (e) {
     return e instanceof RangeError;
   }
@@ -68,29 +68,29 @@ var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
 // America/Los_Angeles for the US
 
 // US English uses month-day-year order and 12-hour time with AM/PM
-console.log(date.toLocaleString('en-US'));
+console.log(date.toLocaleString("en-US"));
 // → "12/19/2012, 7:00:00 PM"
 
 // British English uses day-month-year order and 24-hour time without AM/PM
-console.log(date.toLocaleString('en-GB'));
+console.log(date.toLocaleString("en-GB"));
 // → "20/12/2012 03:00:00"
 
 // Korean uses year-month-day order and 12-hour time with AM/PM
-console.log(date.toLocaleString('ko-KR'));
+console.log(date.toLocaleString("ko-KR"));
 // → "2012. 12. 20. 오후 12:00:00"
 
 // Arabic in most Arabic speaking countries uses real Arabic digits
-console.log(date.toLocaleString('ar-EG'));
+console.log(date.toLocaleString("ar-EG"));
 // → "٢٠‏/١٢‏/٢٠١٢ ٥:٠٠:٠٠ ص"
 
 // for Japanese, applications may want to use the Japanese calendar,
 // where 2012 was the year 24 of the Heisei era
-console.log(date.toLocaleString('ja-JP-u-ca-japanese'));
+console.log(date.toLocaleString("ja-JP-u-ca-japanese"));
 // → "24/12/20 12:00:00"
 
 // when requesting a language that may not be supported, such as
 // Balinese, include a fallback language, in this case Indonesian
-console.log(date.toLocaleString(['ban', 'id']));
+console.log(date.toLocaleString(["ban", "id"]));
 // → "20/12/2012 11.00.00"
 ```
 
@@ -102,18 +102,23 @@ The results provided by `toLocaleString()` can be customized using the `options`
 var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
 
 // request a weekday along with a long date
-var options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-console.log(date.toLocaleString('de-DE', options));
+var options = {
+  weekday: "long",
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+};
+console.log(date.toLocaleString("de-DE", options));
 // → "Donnerstag, 20. Dezember 2012"
 
 // an application may want to use UTC and make that visible
-options.timeZone = 'UTC';
-options.timeZoneName = 'short';
-console.log(date.toLocaleString('en-US', options));
+options.timeZone = "UTC";
+options.timeZoneName = "short";
+console.log(date.toLocaleString("en-US", options));
 // → "Thursday, December 20, 2012, GMT"
 
 // sometimes even the US needs 24-hour time
-console.log(date.toLocaleString('en-US', { hour12: false }));
+console.log(date.toLocaleString("en-US", { hour12: false }));
 // → "12/19/2012, 19:00:00"
 ```
 
@@ -124,7 +129,8 @@ Most of the time, the formatting returned by `toLocaleString()` is consistent. H
 For this reason you cannot expect to be able to compare the results of `toLocaleString()` to a static value:
 
 ```js example-bad
-"1.1.2019, 01:00:00" === new Date("2019-01-01T00:00:00.000000Z").toLocaleString();
+"1.1.2019, 01:00:00" ===
+  new Date("2019-01-01T00:00:00.000000Z").toLocaleString();
 // true in Firefox and others
 // false in IE and Edge
 ```
@@ -137,14 +143,14 @@ When formatting large numbers of dates, it is better to create an {{jsxref("Glob
 
 ## Specifications
 
-| Specification                                                                                                                        | Status                           | Comment                                            |
-| ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                                             | {{Spec2('ES1')}}             | Initial definition. Implemented in JavaScript 1.0. |
-| {{SpecName('ES5.1', '#sec-15.9.5.5', 'Date.prototype.toLocaleString')}}                                     | {{Spec2('ES5.1')}}         |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.tolocalestring', 'Date.prototype.toLocaleString')}}             | {{Spec2('ES6')}}             |                                                    |
-| {{SpecName('ESDraft', '#sec-date.prototype.tolocalestring', 'Date.prototype.toLocaleString')}}         | {{Spec2('ESDraft')}}     |                                                    |
-| {{SpecName('ES Int 1.0', '#sec-13.3.1', 'Date.prototype.toLocaleString')}}                                 | {{Spec2('ES Int 1.0')}} | Defines `locales` and `options` arguments.         |
-| {{SpecName('ES Int 2.0', '#sec-13.3.1', 'Date.prototype.toLocaleString')}}                                 | {{Spec2('ES Int 2.0')}} |                                                    |
+| Specification                                                                                       | Status                    | Comment                                            |
+| --------------------------------------------------------------------------------------------------- | ------------------------- | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                                 | {{Spec2('ES1')}}          | Initial definition. Implemented in JavaScript 1.0. |
+| {{SpecName('ES5.1', '#sec-15.9.5.5', 'Date.prototype.toLocaleString')}}                             | {{Spec2('ES5.1')}}        |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.tolocalestring', 'Date.prototype.toLocaleString')}}          | {{Spec2('ES6')}}          |                                                    |
+| {{SpecName('ESDraft', '#sec-date.prototype.tolocalestring', 'Date.prototype.toLocaleString')}}      | {{Spec2('ESDraft')}}      |                                                    |
+| {{SpecName('ES Int 1.0', '#sec-13.3.1', 'Date.prototype.toLocaleString')}}                          | {{Spec2('ES Int 1.0')}}   | Defines `locales` and `options` arguments.         |
+| {{SpecName('ES Int 2.0', '#sec-13.3.1', 'Date.prototype.toLocaleString')}}                          | {{Spec2('ES Int 2.0')}}   |                                                    |
 | {{SpecName('ES Int Draft', '#sec-Date.prototype.toLocaleString', 'Date.prototype.toLocaleString')}} | {{Spec2('ES Int Draft')}} |                                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
@@ -45,9 +45,9 @@ Os argumentos `locales` e `options` não são suportados em todos os browsers ai
 ```js
 function toLocaleTimeStringSupportsLocales() {
   try {
-    new Date().toLocaleTimeString('i');
+    new Date().toLocaleTimeString("i");
   } catch (e) {
-    return e.name === 'RangeError';
+    return e.name === "RangeError";
   }
   return false;
 }
@@ -64,24 +64,24 @@ var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
 // America/Los_Angeles for the US
 
 // US English usa o formato 12 horas com AM/PM
-console.log(date.toLocaleTimeString('en-US'));
+console.log(date.toLocaleTimeString("en-US"));
 // → "7:00:00 PM"
 
 // British English usa o formato 24 horas sem AM/PM
-console.log(date.toLocaleTimeString('en-GB'));
+console.log(date.toLocaleTimeString("en-GB"));
 // → "03:00:00"
 
 // Korean usa o formato 12 horas com AM/PM
-console.log(date.toLocaleTimeString('ko-KR'));
+console.log(date.toLocaleTimeString("ko-KR"));
 // → "오후 12:00:00"
 
 // Arabic na maiorias dos países que falam árabe usa-se os dígitos arábicos reais
-console.log(date.toLocaleTimeString('ar-EG'));
+console.log(date.toLocaleTimeString("ar-EG"));
 // → "٧:٠٠:٠٠ م"
 
 // quando solicitar um idioma que talvez não seja suportado, como o
 // Balinese, inclua um idioma de fallback, nesse caso Indonesian
-console.log(date.toLocaleTimeString(['ban', 'id']));
+console.log(date.toLocaleTimeString(["ban", "id"]));
 // → "11.00.00"
 ```
 
@@ -93,12 +93,12 @@ Os resultados fornecidos por `toLocaleTimeString()` podem ser customizados usand
 var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
 
 // uma aplicação pode querer usar UTC e tornar isso visível
-var options = { timeZone: 'UTC', timeZoneName: 'short' };
-console.log(date.toLocaleTimeString('en-US', options));
+var options = { timeZone: "UTC", timeZoneName: "short" };
+console.log(date.toLocaleTimeString("en-US", options));
 // → "3:00:00 AM GMT"
 
 // ás vezes, até em US precise usar o formato 24 horas
-console.log(date.toLocaleTimeString('en-US', { hour12: false }));
+console.log(date.toLocaleTimeString("en-US", { hour12: false }));
 // → "19:00:00"
 ```
 
@@ -108,14 +108,14 @@ Quando se formata um grande número de datas, é aconselhável criar um objeto {
 
 ## Especificações
 
-| Especificação                                                                                                                                    | Status                           | Comentário                                         |
-| ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | -------------------------------------------------- |
-| {{SpecName('ES3')}}                                                                                                                         | {{Spec2('ES3')}}             | Definição inicial, Implementado no JavaScript 1.0. |
-| {{SpecName('ES5.1', '#sec-15.9.5.7', 'Date.prototype.toLocaleTimeString')}}                                             | {{Spec2('ES5.1')}}         |                                                    |
-| {{SpecName('ES6', '#sec-date.prototype.tolocalestring', 'Date.prototype.toLocaleTimeString')}}                     | {{Spec2('ES6')}}             |                                                    |
-| {{SpecName('ESDraft', '#sec-date.prototype.tolocalestring', 'Date.prototype.toLocaleTimeString')}}             | {{Spec2('ESDraft')}}     |                                                    |
-| {{SpecName('ES Int 1.0', '#sec-13.3.3', 'Date.prototype.toLocaleTimeString')}}                                         | {{Spec2('ES Int 1.0')}} | Define os argumentos `locales` e `options`.        |
-| {{SpecName('ES Int 2.0', '#sec-13.3.3', 'Date.prototype.toLocaleTimeString')}}                                         | {{Spec2('ES Int 2.0')}} |                                                    |
+| Especificação                                                                                               | Status                    | Comentário                                         |
+| ----------------------------------------------------------------------------------------------------------- | ------------------------- | -------------------------------------------------- |
+| {{SpecName('ES3')}}                                                                                         | {{Spec2('ES3')}}          | Definição inicial, Implementado no JavaScript 1.0. |
+| {{SpecName('ES5.1', '#sec-15.9.5.7', 'Date.prototype.toLocaleTimeString')}}                                 | {{Spec2('ES5.1')}}        |                                                    |
+| {{SpecName('ES6', '#sec-date.prototype.tolocalestring', 'Date.prototype.toLocaleTimeString')}}              | {{Spec2('ES6')}}          |                                                    |
+| {{SpecName('ESDraft', '#sec-date.prototype.tolocalestring', 'Date.prototype.toLocaleTimeString')}}          | {{Spec2('ESDraft')}}      |                                                    |
+| {{SpecName('ES Int 1.0', '#sec-13.3.3', 'Date.prototype.toLocaleTimeString')}}                              | {{Spec2('ES Int 1.0')}}   | Define os argumentos `locales` e `options`.        |
+| {{SpecName('ES Int 2.0', '#sec-13.3.3', 'Date.prototype.toLocaleTimeString')}}                              | {{Spec2('ES Int 2.0')}}   |                                                    |
 | {{SpecName('ES Int Draft', '#sec-Date.prototype.toLocaleTimeString', 'Date.prototype.toLocaleTimeString')}} | {{Spec2('ES Int Draft')}} |                                                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/tostring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/tostring/index.md
@@ -69,13 +69,13 @@ O exemplo asseguir atribui o valor de `toString()` de um objeto {{jsxref("Date")
 ```js
 var x = new Date();
 var myVar = x.toString(); // atribui uma string em myVar no mesmo formato que este:
-                          // Mon Sep 08 1998 14:36:22 GMT-0700 (PDT)
+// Mon Sep 08 1998 14:36:22 GMT-0700 (PDT)
 ```
 
 ## Especificações
 
-| Especificação                                                                                                |
-| ------------------------------------------------------------------------------------------------------------ |
+| Especificação                                                                      |
+| ---------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.tostring', 'Date.prototype.toString')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/totimestring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/totimestring/index.md
@@ -32,14 +32,14 @@ O `toTimeString()` método é especialmente útil por que motores parecidos que 
 ```js
 var d = new Date(1993, 6, 28, 14, 39, 7);
 
-console.log(d.toString());     // Wed Jul 28 1993 14:39:07 GMT-0600 (PDT)
+console.log(d.toString()); // Wed Jul 28 1993 14:39:07 GMT-0600 (PDT)
 console.log(d.toTimeString()); // 14:39:07 GMT-0600 (PDT)
 ```
 
 ## Especificações
 
-| Especificação                                                                                                            |
-| ------------------------------------------------------------------------------------------------------------------------ |
+| Especificação                                                                              |
+| ------------------------------------------------------------------------------------------ |
 | {{SpecName('ESDraft', '#sec-date.prototype.totimestring', 'Date.prototype.toTimeString')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/toutcstring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/toutcstring/index.md
@@ -42,14 +42,14 @@ Antes do ECMAScript 2018, o formato do valor de retorno variava de acordo com a 
 ### Usando `toUTCString()`
 
 ```js
-let today = new Date('Wed, 14 Jun 2017 00:00:00 PDT');
+let today = new Date("Wed, 14 Jun 2017 00:00:00 PDT");
 let UTCstring = today.toUTCString(); // Wed, 14 Jun 2017 07:00:00 GMT
 ```
 
 ## Especificações
 
-| Especificação                                                                                                        |
-| -------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                            |
+| ---------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.toutcstring', 'Date.prototype.toUTCString')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/date/utc/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/utc/index.md
@@ -57,11 +57,11 @@ var dataUniversal = new Date(Date.UTC(96, 11, 1, 0, 0, 0));
 
 ## Especificações
 
-| Especificação                                                        | Status                   | Comentário                                         |
-| -------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| {{SpecName('ES6', '#sec-date.utc', 'Date.UTC')}}     | {{Spec2('ES6')}}     |                                                    |
+| Especificação                                      | Status             | Comentário                                         |
+| -------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| {{SpecName('ES6', '#sec-date.utc', 'Date.UTC')}}   | {{Spec2('ES6')}}   |                                                    |
 | {{SpecName('ES5.1', '#sec-15.9.4.3', 'Date.UTC')}} | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES1')}}                                             | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.0. |
+| {{SpecName('ES1')}}                                | {{Spec2('ES1')}}   | Definição inicial. Implementado no JavaScript 1.0. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/valueof/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/valueof/index.md
@@ -33,13 +33,13 @@ Este método é geralmente chamado internamente pelo JavaScript e não explícit
 
 ```js
 var x = new Date(56, 6, 17);
-var myVar = x.valueOf();      // atribui -424713600000 to myVar
+var myVar = x.valueOf(); // atribui -424713600000 to myVar
 ```
 
 ## Especificações
 
-| Especificação                                                                                                |
-| ------------------------------------------------------------------------------------------------------------ |
+| Especificação                                                                    |
+| -------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-date.prototype.valueof', 'Date.prototype.valueOf')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/decodeuri/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/decodeuri/index.md
@@ -37,7 +37,9 @@ Substitui cada sequência de escape no URI codificado pelo caractere que ele rep
 ### Decodificando uma URL Cyrillic
 
 ```js
-decodeURI('https://developer.mozilla.org/ru/docs/JavaScript_%D1%88%D0%B5%D0%BB%D0%BB%D1%8B');
+decodeURI(
+  "https://developer.mozilla.org/ru/docs/JavaScript_%D1%88%D0%B5%D0%BB%D0%BB%D1%8B",
+);
 // "https://developer.mozilla.org/ru/docs/JavaScript_шеллы"
 ```
 
@@ -55,11 +57,11 @@ try {
 
 ## Especificações
 
-| Specification                                                                            | Status                       | Comment            |
-| ---------------------------------------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('ES3')}}                                                                 | {{Spec2('ES3')}}         | Definição inicial. |
-| {{SpecName('ES5.1', '#sec-15.1.3.1', 'decodeURI')}}                     | {{Spec2('ES5.1')}}     |                    |
-| {{SpecName('ES6', '#sec-decodeuri-encodeduri', 'decodeURI')}}         | {{Spec2('ES6')}}         |                    |
+| Specification                                                     | Status               | Comment            |
+| ----------------------------------------------------------------- | -------------------- | ------------------ |
+| {{SpecName('ES3')}}                                               | {{Spec2('ES3')}}     | Definição inicial. |
+| {{SpecName('ES5.1', '#sec-15.1.3.1', 'decodeURI')}}               | {{Spec2('ES5.1')}}   |                    |
+| {{SpecName('ES6', '#sec-decodeuri-encodeduri', 'decodeURI')}}     | {{Spec2('ES6')}}     |                    |
 | {{SpecName('ESDraft', '#sec-decodeuri-encodeduri', 'decodeURI')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/decodeuricomponent/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/decodeuricomponent/index.md
@@ -33,11 +33,11 @@ decodeURIComponent("JavaScript_%D1%88%D0%B5%D0%BB%D0%BB%D1%8B");
 
 ## Especificações
 
-| Especificação                                                                                                        | Status                   | Comentário        |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | ----------------- |
-| {{SpecName('ES3')}}                                                                                             | {{Spec2('ES3')}}     | Definição inicial |
-| {{SpecName('ES5.1', '#sec-15.1.3.2', 'decodeURIComponent')}}                                     | {{Spec2('ES5.1')}} |                   |
-| {{SpecName('ES6', '#sec-decodeuricomponent-encodeduricomponent', 'decodeURIComponent')}} | {{Spec2('ES6')}}     |                   |
+| Especificação                                                                            | Status             | Comentário        |
+| ---------------------------------------------------------------------------------------- | ------------------ | ----------------- |
+| {{SpecName('ES3')}}                                                                      | {{Spec2('ES3')}}   | Definição inicial |
+| {{SpecName('ES5.1', '#sec-15.1.3.2', 'decodeURIComponent')}}                             | {{Spec2('ES5.1')}} |                   |
+| {{SpecName('ES6', '#sec-decodeuricomponent-encodeduricomponent', 'decodeURIComponent')}} | {{Spec2('ES6')}}   |                   |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/encodeuri/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/encodeuri/index.md
@@ -50,7 +50,7 @@ Não escapado:
 
 ```js
 var set1 = ";,/?:@&=+$#"; // Caracteres reservados
-var set2 = "-_.!~*'()";   // Marcas não reservadas
+var set2 = "-_.!~*'()"; // Marcas não reservadas
 var set3 = "ABC abc 123"; // Caracteres alfanuméricos + Espaço
 
 console.log(encodeURI(set1)); // ;,/?:@&=+$#
@@ -70,13 +70,13 @@ Um {{jsxref("URIError")}} será jogado se uma tentativa de codificar um substitu
 
 ```js
 // par alto-baixo ok
-console.log(encodeURI('\uD800\uDFFF'));
+console.log(encodeURI("\uD800\uDFFF"));
 
 // substituto alto solitário joga "URIError: malformed URI sequence"
-console.log(encodeURI('\uD800'));
+console.log(encodeURI("\uD800"));
 
 // substituto baixo solitário joga "URIError: malformed URI sequence"
-console.log(encodeURI('\uDFFF'));
+console.log(encodeURI("\uDFFF"));
 ```
 
 ### Codificando para IPv6
@@ -85,14 +85,14 @@ Se você deseja seguir a [RFC3986](http://tools.ietf.org/html/rfc3986) mais rece
 
 ```js
 function fixedEncodeURI(str) {
-    return encodeURI(str).replace(/%5B/g, '[').replace(/%5D/g, ']');
+  return encodeURI(str).replace(/%5B/g, "[").replace(/%5D/g, "]");
 }
 ```
 
 ## Especificações
 
-| Especificação                                                                |
-| ---------------------------------------------------------------------------- |
+| Especificação                                              |
+| ---------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-encodeuri-uri', 'encodeURI')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -26,13 +26,13 @@ Note-se que um{{jsxref("URIError")}} será gerada se uma tentativas para codific
 
 ```js
 // high-low par ok
-console.log(encodeURIComponent('\uD800\uDFFF'));
+console.log(encodeURIComponent("\uD800\uDFFF"));
 
 // lone high surrogate throws "URIError: malformed URI sequence"
-console.log(encodeURIComponent('\uD800'));
+console.log(encodeURIComponent("\uD800"));
 
 // lone low surrogate throws "URIError: malformed URI sequence"
-console.log(encodeURIComponent('\uDFFF'));
+console.log(encodeURIComponent("\uDFFF"));
 ```
 
 Para previnir requisões inesperadas ao servidor, deve-se chamar `encodeURIComponent` ou qualquer parâmetro fornecido pelo usuário que será passado como parte da URI. Por exemplo, um usuário poderia digitar "`Thyme &time=again`" para uma variável `commentario`. Ao não usar `encodeURIComponent` nessa variável irá ser obetido `commentario=Thyme%20&time=again`. Note que o ampersa e o sinal de igual marcam um novo par de chave e valor. Então ao invés de ter um POST com a chave `commentario` igual a "`Thyme &time=again`", tem-se chaves em POST, uma igual a "`Thyme`" e outra (`time`) igual a `again`.
@@ -42,9 +42,9 @@ Para [`application/x-www-form-urlencoded`](http://www.whatwg.org/specs/web-apps/
 Para ser mais rigoroso à aderência da [RFC 3986](http://tools.ietf.org/html/rfc3986) (qual reserva !, ', (, ), e \*), mesmo que esses caracteres não tenham usos formalizados de delimitação de URI, o seguinte pode ser usado com segurança:
 
 ```js
-function ajustadoEncodeURIComponent (str) {
-  return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
-    return '%' + c.charCodeAt(0).toString(16);
+function ajustadoEncodeURIComponent(str) {
+  return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
+    return "%" + c.charCodeAt(0).toString(16);
   });
 }
 ```
@@ -54,33 +54,35 @@ function ajustadoEncodeURIComponent (str) {
 O exemplo seguinte provê o encoding especial requerido pelo UTF-8 nos parâmetros `Content-Disposition` e `Link` no cabeçalho de uma Response (e.g., UTF-8 filenames):
 
 ```js
-var fileName = 'my file(2).txt';
-var header = "Content-Disposition: attachment; filename*=UTF-8''"
-             + encodeRFC5987ValueChars(fileName);
+var fileName = "my file(2).txt";
+var header =
+  "Content-Disposition: attachment; filename*=UTF-8''" +
+  encodeRFC5987ValueChars(fileName);
 
 console.log(header);
 // logs "Content-Disposition: attachment; filename*=UTF-8''my%20file%282%29.txt"
 
-
-function encodeRFC5987ValueChars (str) {
-    return encodeURIComponent(str).
-        // Note that although RFC3986 reserves "!", RFC5987 does not,
-        // so we do not need to escape it
-        replace(/['()]/g, escape). // i.e., %27 %28 %29
-        replace(/\*/g, '%2A').
-            // The following are not required for percent-encoding per RFC5987,
-            // so we can allow for a little better readability over the wire: |`^
-            replace(/%(?:7C|60|5E)/g, unescape);
+function encodeRFC5987ValueChars(str) {
+  return (
+    encodeURIComponent(str)
+      // Note that although RFC3986 reserves "!", RFC5987 does not,
+      // so we do not need to escape it
+      .replace(/['()]/g, escape) // i.e., %27 %28 %29
+      .replace(/\*/g, "%2A")
+      // The following are not required for percent-encoding per RFC5987,
+      // so we can allow for a little better readability over the wire: |`^
+      .replace(/%(?:7C|60|5E)/g, unescape)
+  );
 }
 ```
 
 ## Especificações
 
-| Especificação                                                                                                | Status                   | Comentario         |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------ | ------------------ |
-| {{SpecName('ES3')}}                                                                                     | {{Spec2('ES3')}}     | Definição Inicial. |
-| {{SpecName('ES5.1', '#sec-15.1.3.4', 'encodeURIComponent')}}                             | {{Spec2('ES5.1')}} |                    |
-| {{SpecName('ES6', '#sec-encodeuricomponent-uricomponent', 'encodeURIComponent')}} | {{Spec2('ES6')}}     |                    |
+| Especificação                                                                     | Status             | Comentario         |
+| --------------------------------------------------------------------------------- | ------------------ | ------------------ |
+| {{SpecName('ES3')}}                                                               | {{Spec2('ES3')}}   | Definição Inicial. |
+| {{SpecName('ES5.1', '#sec-15.1.3.4', 'encodeURIComponent')}}                      | {{Spec2('ES5.1')}} |                    |
+| {{SpecName('ES6', '#sec-encodeuricomponent-uricomponent', 'encodeURIComponent')}} | {{Spec2('ES6')}}   |                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/error/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/error/index.md
@@ -76,9 +76,9 @@ Geralmente você cria um objeto `Error` com a intenção de lançá-lo usando a 
 
 ```js
 try {
-  throw new Error('Oooops!');
+  throw new Error("Oooops!");
 } catch (e) {
-  alert(e.name + ': ' + e.message);
+  alert(e.name + ": " + e.message);
 }
 ```
 
@@ -91,9 +91,9 @@ try {
   Objeto.Metodo();
 } catch (e) {
   if (e instanceof EvalError) {
-    alert(e.name + ': ' + e.message);
+    alert(e.name + ": " + e.message);
   } else if (e instanceof RangeError) {
-    alert(e.name + ': ' + e.message);
+    alert(e.name + ": " + e.message);
   }
   // ... etc
 }
@@ -110,9 +110,9 @@ Veja também ["esta discussão no Stackoverflow (em inglês): What's a good way 
 ```js
 // Cria um novo objeto que herda o construtor de Error através do prototype.
 function MeuErro(message) {
-  this.name = 'MeuErro';
-  this.message = message || 'Mensagem de erro padrão';
-  this.stack = (new Error()).stack;
+  this.name = "MeuErro";
+  this.message = message || "Mensagem de erro padrão";
+  this.stack = new Error().stack;
 }
 MeuErro.prototype = Object.create(MeuErro.prototype);
 MeuErro.prototype.constructor = MeuErro;
@@ -120,25 +120,25 @@ MeuErro.prototype.constructor = MeuErro;
 try {
   throw new MeuErro();
 } catch (e) {
-  console.log(e.name);     // 'MeuErro'
-  console.log(e.message);  // 'Mensagem de erro padrão'
+  console.log(e.name); // 'MeuErro'
+  console.log(e.message); // 'Mensagem de erro padrão'
 }
 
 try {
-  throw new MeuErro('Mensagem customizada');
+  throw new MeuErro("Mensagem customizada");
 } catch (e) {
-  console.log(e.name);     // 'MeuErro'
-  console.log(e.message);  // 'Mensagem customizada'
+  console.log(e.name); // 'MeuErro'
+  console.log(e.message); // 'Mensagem customizada'
 }
 ```
 
 ## Especificações
 
-| Especificação                                                        | Status                   | Comentário                                         |
-| -------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                             | {{Spec2('ES1')}}     | Definição inicial. Implementada no JavaScript 1.1. |
-| {{SpecName('ES5.1', '#sec-15.11', 'Error')}}         | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-error-objects', 'Error')}} | {{Spec2('ES6')}}     |                                                    |
+| Especificação                                      | Status             | Comentário                                         |
+| -------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                | {{Spec2('ES1')}}   | Definição inicial. Implementada no JavaScript 1.1. |
+| {{SpecName('ES5.1', '#sec-15.11', 'Error')}}       | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-error-objects', 'Error')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/error/tostring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/error/tostring/index.md
@@ -22,8 +22,8 @@ A string representando o objeto {{jsxref("Error")}} especificado.
 O objeto {{jsxref("Error")}} sobrescreve o método {{jsxref("Object.prototype.toString()")}} herdado por todos os objetos. Sua semântica é a seguinte (assumindo que {{jsxref("Object")}} e {{jsxref("String")}} tem seus valores originais):
 
 ```js
-Error.prototype.toString = function() {
-  'use strict';
+Error.prototype.toString = function () {
+  "use strict";
 
   var obj = Object(this);
   if (obj !== this) {
@@ -31,19 +31,19 @@ Error.prototype.toString = function() {
   }
 
   var name = this.name;
-  name = (name === undefined) ? 'Error' : String(name);
+  name = name === undefined ? "Error" : String(name);
 
   var msg = this.message;
-  msg = (msg === undefined) ? '' : String(msg);
+  msg = msg === undefined ? "" : String(msg);
 
-  if (name === '') {
+  if (name === "") {
     return msg;
   }
-  if (msg === '') {
+  if (msg === "") {
     return name;
   }
 
-  return name + ': ' + msg;
+  return name + ": " + msg;
 };
 ```
 
@@ -52,26 +52,26 @@ Error.prototype.toString = function() {
 ### Usando toString()
 
 ```js
-var e = new Error('fatal error');
+var e = new Error("fatal error");
 console.log(e.toString()); // 'Error: fatal error'
 
 e.name = undefined;
 console.log(e.toString()); // 'Error: fatal error'
 
-e.name = '';
+e.name = "";
 console.log(e.toString()); // 'fatal error'
 
 e.message = undefined;
 console.log(e.toString()); // ''
 
-e.name = 'hello';
+e.name = "hello";
 console.log(e.toString()); // 'hello'
 ```
 
 ## Especificações
 
-| Especificação                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                        |
+| ------------------------------------------------------------------------------------ |
 | {{SpecName('ESDraft', '#sec-error.prototype.tostring', 'Error.prototype.toString')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/escape/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/escape/index.md
@@ -2,6 +2,7 @@
 title: escape()
 slug: Web/JavaScript/Reference/Global_Objects/escape
 ---
+
 {{jsSidebar("Objects")}}A função obsoleta `escape() retorna uma nova string com` certos caracteres substituídos por sua sequência hexadecial. Use {{jsxref("encodeURI")}} ou {{jsxref("encodeURIComponent")}} em seu lugar.
 
 ## Sintaxe
@@ -24,21 +25,21 @@ O formato hexadecimal de caracteres, que o valor unitário do código é **0xFF 
 ## Exemplos
 
 ```js
-escape("abc123");     // "abc123"
-escape("äöü");        // "%E4%F6%FC"
-escape("ć");          // "%u0107"
+escape("abc123"); // "abc123"
+escape("äöü"); // "%E4%F6%FC"
+escape("ć"); // "%u0107"
 
 // Caracteres Especiais
-escape("@*_+-./");    // "@*_+-./"
+escape("@*_+-./"); // "@*_+-./"
 ```
 
 ## Especificações
 
-| Especificação                                                            | Status                       | Comentário                                                                                     |
-| ------------------------------------------------------------------------ | ---------------------------- | ---------------------------------------------------------------------------------------------- |
-| {{SpecName('ES1')}}                                                 | {{Spec2('ES1')}}         | Definição inicial.                                                                             |
-| {{SpecName('ES5.1', '#sec-B.2.1', 'escape')}}             | {{Spec2('ES5.1')}}     | Definido no (informativo) de compatibilidade Anexo B                                           |
-| {{SpecName('ES6', '#sec-escape-string', 'escape')}}     | {{Spec2('ES6')}}         | Definido no (normativo) Anexo B para recursos adicionais do ECMAScript para navegadores da web |
+| Especificação                                           | Status               | Comentário                                                                                     |
+| ------------------------------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------- |
+| {{SpecName('ES1')}}                                     | {{Spec2('ES1')}}     | Definição inicial.                                                                             |
+| {{SpecName('ES5.1', '#sec-B.2.1', 'escape')}}           | {{Spec2('ES5.1')}}   | Definido no (informativo) de compatibilidade Anexo B                                           |
+| {{SpecName('ES6', '#sec-escape-string', 'escape')}}     | {{Spec2('ES6')}}     | Definido no (normativo) Anexo B para recursos adicionais do ECMAScript para navegadores da web |
 | {{SpecName('ESDraft', '#sec-escape-string', 'escape')}} | {{Spec2('ESDraft')}} | Definido no (normativa) Anexo B para recursos adicionais do ECMAScript para navegadores da web |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/eval/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/eval/index.md
@@ -12,7 +12,7 @@ A função **`eval()`** computa um código JavaScript representado como uma stri
 ## Sintaxe
 
 ```js
-eval(string)
+eval(string);
 ```
 
 ### Parâmetros
@@ -36,7 +36,7 @@ Se o argumento de `eval()` não é uma string, `eval()` retorna o argumento inal
 
 ```js
 eval(new String("2 + 2")); // retorna um objeto String contendo "2 + 2"
-eval("2 + 2");             // retorna 4
+eval("2 + 2"); // retorna 4
 ```
 
 Você pode contornar esta limitação de forma genérica usando `toString()`.
@@ -50,11 +50,12 @@ Se você usar a função `eval` _indiretamente_, invocando-a por outra referênc
 
 ```js
 function test() {
-  var x = 2, y = 4;
-  console.log(eval('x + y'));  // Chamada direta, usa o escopo local, resulta em 6
+  var x = 2,
+    y = 4;
+  console.log(eval("x + y")); // Chamada direta, usa o escopo local, resulta em 6
   var geval = eval; // equivalente a chamar eval no escopo global
-  console.log(geval('x + y')); // Chamada indireta, usa o escopo global, lança uma exceção ReferenceError porque `x` não foi declarado
-  (0, eval)('x + y'); // outro exemplo de chamada indireta
+  console.log(geval("x + y")); // Chamada indireta, usa o escopo global, lança uma exceção ReferenceError porque `x` não foi declarado
+  (0, eval)("x + y"); // outro exemplo de chamada indireta
 }
 ```
 
@@ -72,17 +73,17 @@ Você não deve utilizar `eval()` para converter nomes de propriedades em propri
 
 ```js
 var obj = { a: 20, b: 30 };
-var propname = getPropName();  //retorna "a" ou "b"
+var propname = getPropName(); //retorna "a" ou "b"
 
-eval( "var result = obj." + propname );
+eval("var result = obj." + propname);
 ```
 
 No entanto, `eval()` não é necessário aqui. De fato, sua utilização não é recomendada. Ao invés disso, utilize os [operadores de acesso](/pt-BR/docs/Web/JavaScript/Reference/Operators/Member_Operators), que são mais rápidos e seguros:
 
 ```js
 var obj = { a: 20, b: 30 };
-var propname = getPropName();  //retorna "a" ou "b"
-var result = obj[ propname ];  //  obj[ "a" ] é o mesmo como obj.a
+var propname = getPropName(); //retorna "a" ou "b"
+var result = obj[propname]; //  obj[ "a" ] é o mesmo como obj.a
 ```
 
 ### Utilize funções ao invés de avaliar snippets de código
@@ -126,7 +127,7 @@ var x = 2;
 var y = 39;
 var z = "42";
 eval("x + y + 1"); // returns 42
-eval(z);           // returns 42
+eval(z); // returns 42
 ```
 
 ### Exemplo: Using `eval` to evaluate a string of JavaScript statements
@@ -147,12 +148,12 @@ document.write("<P>z is ", eval(str));
 ```js
 var str = "if ( a ) { 1+1; } else { 1+2; }";
 var a = true;
-var b = eval(str);  // returns 2
+var b = eval(str); // returns 2
 
 alert("b is : " + b);
 
 a = false;
-b = eval(str);  // returns 3
+b = eval(str); // returns 3
 
 alert("b is : " + b);
 ```
@@ -160,19 +161,19 @@ alert("b is : " + b);
 ### Exemplo: avaliar uma string definindo a função necessária "(" and ")" como prefixo e sufixo
 
 ```js
-var fctStr1 = "function a() {}"
-var fctStr2 = "(function a() {})"
-var fct1 = eval(fctStr1)  // return undefined
-var fct2 = eval(fctStr2)  // return a function
+var fctStr1 = "function a() {}";
+var fctStr2 = "(function a() {})";
+var fct1 = eval(fctStr1); // return undefined
+var fct2 = eval(fctStr2); // return a function
 ```
 
 ## Especificações
 
-| Especificação                                                | Status                   | Comentário        |
-| ------------------------------------------------------------ | ------------------------ | ----------------- |
-| ECMAScript 1st Edition.                                      | Standard                 | Definição inicial |
+| Especificação                                  | Status             | Comentário        |
+| ---------------------------------------------- | ------------------ | ----------------- |
+| ECMAScript 1st Edition.                        | Standard           | Definição inicial |
 | {{SpecName('ES5.1', '#sec-15.1.2.1', 'eval')}} | {{Spec2('ES5.1')}} |                   |
-| {{SpecName('ES6', '#sec-eval-x', 'eval')}}     | {{Spec2('ES6')}}     |                   |
+| {{SpecName('ES6', '#sec-eval-x', 'eval')}}     | {{Spec2('ES6')}}   |                   |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/evalerror/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/evalerror/index.md
@@ -49,25 +49,25 @@ O global `EvalError` não contém métodos próprios, no entando, ele irá herda
 
 ```js
 try {
-  throw new EvalError('Hello', 'someFile.js', 10);
+  throw new EvalError("Hello", "someFile.js", 10);
 } catch (e) {
   console.log(e instanceof EvalError); // true
-  console.log(e.message);              // "Hello"
-  console.log(e.name);                 // "EvalError"
-  console.log(e.fileName);             // "someFile.js"
-  console.log(e.lineNumber);           // 10
-  console.log(e.columnNumber);         // 0
-  console.log(e.stack);                // "@Scratchpad/2:2:9\n"
+  console.log(e.message); // "Hello"
+  console.log(e.name); // "EvalError"
+  console.log(e.fileName); // "someFile.js"
+  console.log(e.lineNumber); // 10
+  console.log(e.columnNumber); // 0
+  console.log(e.stack); // "@Scratchpad/2:2:9\n"
 }
 ```
 
 ## Especificações
 
-| Especificação                                                                                                                    | Status                       | Comentário                                                                        |
-| -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | --------------------------------------------------------------------------------- |
-| {{SpecName('ES3')}}                                                                                                         | {{Spec2('ES3')}}         | Definição inicial.                                                                |
-| {{SpecName('ES5.1', '#sec-15.11.6.1', 'EvalError')}}                                                             | {{Spec2('ES5.1')}}     | Não utilizada na especificação. Presente para compatibilidade com outras versões. |
-| {{SpecName('ES6', '#sec-native-error-types-used-in-this-standard-evalerror', 'EvalError')}}         | {{Spec2('ES6')}}         | Não utilizada na especificação. Presente para compatibilidade com outras versões. |
+| Especificação                                                                                   | Status               | Comentário                                                                        |
+| ----------------------------------------------------------------------------------------------- | -------------------- | --------------------------------------------------------------------------------- |
+| {{SpecName('ES3')}}                                                                             | {{Spec2('ES3')}}     | Definição inicial.                                                                |
+| {{SpecName('ES5.1', '#sec-15.11.6.1', 'EvalError')}}                                            | {{Spec2('ES5.1')}}   | Não utilizada na especificação. Presente para compatibilidade com outras versões. |
+| {{SpecName('ES6', '#sec-native-error-types-used-in-this-standard-evalerror', 'EvalError')}}     | {{Spec2('ES6')}}     | Não utilizada na especificação. Presente para compatibilidade com outras versões. |
 | {{SpecName('ESDraft', '#sec-native-error-types-used-in-this-standard-evalerror', 'EvalError')}} | {{Spec2('ESDraft')}} |                                                                                   |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/float32array/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/float32array/index.md
@@ -124,7 +124,7 @@ console.log(float32.length); // 2
 console.log(float32.BYTES_PER_ELEMENT); // 4
 
 // Por uma array
-var arr = new Float32Array([21,31]);
+var arr = new Float32Array([21, 31]);
 console.log(arr[1]); // 31
 
 // Por uma outra TypedArray
@@ -137,17 +137,19 @@ var buffer = new ArrayBuffer(16);
 var z = new Float32Array(buffer, 0, 4);
 
 // Por um iterável
-var iterable = function*(){ yield* [1,2,3]; }();
+var iterable = (function* () {
+  yield* [1, 2, 3];
+})();
 var float32 = new Float32Array(iterable);
 // Float32Array[1, 2, 3]
 ```
 
 ## Especificações
 
-| Especificação                                                                        | Status                           | Comment                                                                                                                              |
-| ------------------------------------------------------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| {{SpecName('Typed Array')}}                                                 | {{Spec2('Typed Array')}} | Suplantada pelo ECMAScript 2015.                                                                                                     |
-| {{SpecName('ES6', '#table-49', 'TypedArray constructors')}}     | {{Spec2('ES6')}}             | Definição inicial no padrão ECMA. Especificado que o `new` é requerido.                                                              |
+| Especificação                                                   | Status                   | Comment                                                                                                                              |
+| --------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| {{SpecName('Typed Array')}}                                     | {{Spec2('Typed Array')}} | Suplantada pelo ECMAScript 2015.                                                                                                     |
+| {{SpecName('ES6', '#table-49', 'TypedArray constructors')}}     | {{Spec2('ES6')}}         | Definição inicial no padrão ECMA. Especificado que o `new` é requerido.                                                              |
 | {{SpecName('ESDraft', '#table-49', 'TypedArray constructors')}} | {{Spec2('ESDraft')}}     | O ECMAScript 7 mudou o construtor da Array `Array32Float` para o uso da operação `ToIndex` e ajudar nos construtores sem argumentos. |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/float64array/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/float64array/index.md
@@ -105,7 +105,7 @@ console.log(float64.length); // 2
 console.log(float64.BYTES_PER_ELEMENT); // 8
 
 // From an array
-var arr = new Float64Array([21,31]);
+var arr = new Float64Array([21, 31]);
 console.log(arr[1]); // 31
 
 // From another TypedArray
@@ -118,15 +118,17 @@ var buffer = new ArrayBuffer(32);
 var z = new Float64Array(buffer, 0, 4);
 
 // From an iterable
-var iterable = function*(){ yield* [1,2,3]; }();
+var iterable = (function* () {
+  yield* [1, 2, 3];
+})();
 var float64 = new Float64Array(iterable);
 // Float64Array[1, 2, 3]
 ```
 
 ## Specifications
 
-| Specification                                                                        |
-| ------------------------------------------------------------------------------------ |
+| Specification                                                   |
+| --------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#table-49', 'TypedArray constructors')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/function/apply/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/function/apply/index.md
@@ -51,8 +51,11 @@ Function.prototype.construct = function (aArgs) {
 > **Nota:** O método `Object.create()` usado acima é relativamente novo. Para um método alternativo utilizando closures, por favor considere a seguinte alternativa.
 >
 > ```js
-> Function.prototype.construct = function(aArgs) {
->   var fConstructor = this, fNewConstr = function() { fConstructor.apply(this, aArgs); };
+> Function.prototype.construct = function (aArgs) {
+>   var fConstructor = this,
+>     fNewConstr = function () {
+>       fConstructor.apply(this, aArgs);
+>     };
 >   fNewConstr.prototype = fConstructor.prototype;
 >   return new fNewConstr();
 > };
@@ -63,16 +66,16 @@ Exemplo de uso:
 ```js
 function MyConstructor() {
   for (var nProp = 0; nProp < arguments.length; nProp++) {
-    this['property' + nProp] = arguments[nProp];
+    this["property" + nProp] = arguments[nProp];
   }
 }
 
-var myArray = [4, 'Hello world!', false];
+var myArray = [4, "Hello world!", false];
 var myInstance = MyConstructor.construct(myArray);
 
-console.log(myInstance.property1);                // logs 'Hello world!'
+console.log(myInstance.property1); // logs 'Hello world!'
 console.log(myInstance instanceof MyConstructor); // logs 'true'
-console.log(myInstance.constructor);              // logs 'MyConstructor'
+console.log(myInstance.constructor); // logs 'MyConstructor'
 ```
 
 > **Nota:** Este método não nativo `Function.construct` não irá funcionar com alguns construtores nativos (como {{jsxref("Date")}}, por exemplo). Nestes casos você tem que usar o método {{jsxref("Function.prototype.bind")}} (por exemplo, imagine ter um array como o seguinte, para ser usado com o construtor {{jsxref("Global_Objects/Date", "Date")}}: `[2012, 11, 4]`; Neste caso você tem que escrever algom como: `new (Function.prototype.bind.apply(Date, [null].concat([2012, 11, 4])))()` - de qualquer maneira essa não é a melhor forma de fazer as coisas e provavelmente não deve ser utilizado em qualquer ambiente de produção.
@@ -86,12 +89,15 @@ A forma inteligente com que `apply` é utilizado permite à você usar funções
 var numbers = [5, 6, 2, 3, 7];
 
 /* utilizando Math.min/Math.max apply */
-var max = Math.max.apply(null, numbers); /* Isso está prestes a ser igual a Math.max(numbers[0], ...)
+var max = Math.max.apply(
+  null,
+  numbers,
+); /* Isso está prestes a ser igual a Math.max(numbers[0], ...)
                                             ou Math.max(5, 6, ...) */
 var min = Math.min.apply(null, numbers);
 
 /* vs. algoritmo simples baseado em loop */
-max = -Infinity, min = +Infinity;
+(max = -Infinity), (min = +Infinity);
 
 for (var i = 0; i < numbers.length; i++) {
   if (numbers[i] > max) {
@@ -127,24 +133,24 @@ Apply pode ser a melhor forma de monkey-patch uma função nativa do Firefox, ou
 
 ```js
 var originalfoo = someobject.foo;
-someobject.foo = function() {
+someobject.foo = function () {
   // Faça coisas antes de chamar a função
   console.log(arguments);
   // Chama a função como se ela estivesse sido chamada normalmente:
   originalfoo.apply(this, arguments);
   // Rode as coisas que vem depois, aqui.
-}
+};
 ```
 
 Esse método é especialmente útil quando você quer fazer debug de eventos, ou interagir com algo que não tem nenhuma API como os diversos eventos `.on([event]...` events, por exemplo aqueles utilizáveis no [Devtools Inspector](/pt-BR/docs/Tools/Page_Inspector#Developer_API)).
 
 ## Especificações
 
-| Especificação                                                                                                | Status                   | Comentário                                         |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------ | -------------------------------------------------- |
-| ECMAScript 3º Edição.                                                                                        | Padrão                   | Definição inicial, implementado no JavaScript 1.3. |
-| {{SpecName('ES5.1', '#sec-15.3.4.3', 'Function.prototype.apply')}}                     | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-function.prototype.apply', 'Function.prototype.apply')}} | {{Spec2('ES6')}}     |                                                    |
+| Especificação                                                                    | Status             | Comentário                                         |
+| -------------------------------------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| ECMAScript 3º Edição.                                                            | Padrão             | Definição inicial, implementado no JavaScript 1.3. |
+| {{SpecName('ES5.1', '#sec-15.3.4.3', 'Function.prototype.apply')}}               | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-function.prototype.apply', 'Function.prototype.apply')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/function/arguments/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/function/arguments/index.md
@@ -18,17 +18,21 @@ O valor da propriedade arguments é normalmente nulo (`null`) se não houver nen
 ## Exemplos
 
 ```js
-function f(n) { g(n - 1); }
+function f(n) {
+  g(n - 1);
+}
 
 function g(n) {
-  console.log('before: ' + g.arguments[0]);
-  if (n > 0) { f(n); }
-  console.log('after: ' + g.arguments[0]);
+  console.log("before: " + g.arguments[0]);
+  if (n > 0) {
+    f(n);
+  }
+  console.log("after: " + g.arguments[0]);
 }
 
 f(2);
 
-console.log('returned: ' + g.arguments);
+console.log("returned: " + g.arguments);
 
 // Output
 
@@ -41,11 +45,11 @@ console.log('returned: ' + g.arguments);
 
 ## Especificações
 
-| Especificação                                                                                | Status                       | Comentário                                                                                                                                   |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                     | {{Spec2('ES1')}}         | Definiçao inicial. Implementado em JavaScript 1.0. Obsoleto em favor de {{jsxref("Functions/arguments", "arguments")}} em ES3. |
-| {{SpecName('ES5.1', '#sec-10.6', 'arguments object')}}                     | {{Spec2('ES5.1')}}     | {{jsxref("Functions/arguments", "arguments")}} object                                                                          |
-| {{SpecName('ES6', '#sec-arguments-object', 'arguments object')}}         | {{Spec2('ES6')}}         | {{jsxref("Functions/arguments", "arguments")}} object                                                                          |
+| Especificação                                                        | Status               | Comentário                                                                                                                     |
+| -------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| {{SpecName('ES1')}}                                                  | {{Spec2('ES1')}}     | Definiçao inicial. Implementado em JavaScript 1.0. Obsoleto em favor de {{jsxref("Functions/arguments", "arguments")}} em ES3. |
+| {{SpecName('ES5.1', '#sec-10.6', 'arguments object')}}               | {{Spec2('ES5.1')}}   | {{jsxref("Functions/arguments", "arguments")}} object                                                                          |
+| {{SpecName('ES6', '#sec-arguments-object', 'arguments object')}}     | {{Spec2('ES6')}}     | {{jsxref("Functions/arguments", "arguments")}} object                                                                          |
 | {{SpecName('ESDraft', '#sec-arguments-object', 'arguments object')}} | {{Spec2('ESDraft')}} | {{jsxref("Functions/arguments", "arguments")}} object                                                                          |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/function/bind/index.md
@@ -51,7 +51,9 @@ O uso mais simples de `bind()` é fazer com que uma função que, independenteme
 this.x = 9; //this aqui se refere ao objeto global "window" do navegador
 var module = {
   x: 81,
-  getX: function() { return this.x; }
+  getX: function () {
+    return this.x;
+  },
 };
 
 module.getX(); // 81
@@ -98,13 +100,12 @@ function LateBloomer() {
 }
 
 // Declarar bloom depois de um intervalo de 1 segundo
-LateBloomer.prototype.bloom = function() {
+LateBloomer.prototype.bloom = function () {
   window.setTimeout(this.declare.bind(this), 1000);
 };
 
-LateBloomer.prototype.declare = function() {
-  console.log('I am a beautiful flower with ' +
-    this.petalCount + ' petals!');
+LateBloomer.prototype.declare = function () {
+  console.log("I am a beautiful flower with " + this.petalCount + " petals!");
 };
 
 var flower = new LateBloomer();
@@ -124,8 +125,8 @@ function Point(x, y) {
   this.y = y;
 }
 
-Point.prototype.toString = function() {
-  return this.x + ',' + this.y;
+Point.prototype.toString = function () {
+  return this.x + "," + this.y;
 };
 
 var p = new Point(1, 2);
@@ -134,10 +135,10 @@ p.toString(); // '1,2'
 // não suportado no polyfill abaixo,
 // funciona bem com o bind nativo:
 
-var YAxisPoint = Point.bind(null, 0/*x*/);
+var YAxisPoint = Point.bind(null, 0 /*x*/);
 
 var emptyObj = {};
-var YAxisPoint = Point.bind(emptyObj, 0/*x*/);
+var YAxisPoint = Point.bind(emptyObj, 0 /*x*/);
 
 var axisPoint = new YAxisPoint(5);
 axisPoint.toString(); // '0,5'
@@ -157,7 +158,7 @@ Note que você não precisa fazer nada de especial para criar uma função vincu
 // (apesar de que isso geralmente não é desejado)
 YAxisPoint(13);
 
-emptyObj.x + ',' + emptyObj.y;
+emptyObj.x + "," + emptyObj.y;
 // >  '0,13'
 ```
 
@@ -195,22 +196,24 @@ A função `bind` é uma adição à ECMA-262, 5ª. edição; como tal, pode nã
 
 ```js
 if (!Function.prototype.bind) {
-  Function.prototype.bind = function(oThis) {
-    if (typeof this !== 'function') {
+  Function.prototype.bind = function (oThis) {
+    if (typeof this !== "function") {
       // mais próximo possível da função interna
       // IsCallable da ECMAScript 5
-      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+      throw new TypeError(
+        "Function.prototype.bind - what is trying to be bound is not callable",
+      );
     }
 
-    var aArgs   = Array.prototype.slice.call(arguments, 1),
-        fToBind = this,
-        fNOP    = function() {},
-        fBound  = function() {
-          return fToBind.apply(this instanceof fNOP
-                 ? this
-                 : oThis,
-                 aArgs.concat(Array.prototype.slice.call(arguments)));
-        };
+    var aArgs = Array.prototype.slice.call(arguments, 1),
+      fToBind = this,
+      fNOP = function () {},
+      fBound = function () {
+        return fToBind.apply(
+          this instanceof fNOP ? this : oThis,
+          aArgs.concat(Array.prototype.slice.call(arguments)),
+        );
+      };
 
     fNOP.prototype = this.prototype;
     fBound.prototype = new fNOP();
@@ -231,10 +234,10 @@ Se você escolher utilizar esta implementação parcial, **você não deve confi
 
 ## Especificações
 
-| Especificação                                                                                            | Status                   | Comentário                                           |
-| -------------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.3.4.5', 'Function.prototype.bind')}}                 | {{Spec2('ES5.1')}} | Definição inicial. Implementada no JavaScript 1.8.5. |
-| {{SpecName('ES6', '#sec-function.prototype.bind', 'Function.prototype.bind')}} | {{Spec2('ES6')}}     |                                                      |
+| Especificação                                                                  | Status             | Comentário                                           |
+| ------------------------------------------------------------------------------ | ------------------ | ---------------------------------------------------- |
+| {{SpecName('ES5.1', '#sec-15.3.4.5', 'Function.prototype.bind')}}              | {{Spec2('ES5.1')}} | Definição inicial. Implementada no JavaScript 1.8.5. |
+| {{SpecName('ES6', '#sec-function.prototype.bind', 'Function.prototype.bind')}} | {{Spec2('ES6')}}   |                                                      |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/function/call/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/function/call/index.md
@@ -40,8 +40,9 @@ function Product(name, price) {
   this.price = price;
 
   if (price < 0) {
-    throw RangeError('Cannot create product ' +
-                      this.name + ' with a negative price');
+    throw RangeError(
+      "Cannot create product " + this.name + " with a negative price",
+    );
   }
 
   return this;
@@ -49,20 +50,20 @@ function Product(name, price) {
 
 function Food(name, price) {
   Product.call(this, name, price);
-  this.category = 'food';
+  this.category = "food";
 }
 
 Food.prototype = Object.create(Product.prototype);
 
 function Toy(name, price) {
   Product.call(this, name, price);
-  this.category = 'toy';
+  this.category = "toy";
 }
 
 Toy.prototype = Object.create(Product.prototype);
 
-var cheese = new Food('feta', 5);
-var fun = new Toy('robot', 40);
+var cheese = new Food("feta", 5);
+var fun = new Toy("robot", 40);
 ```
 
 ### Exemplo: Usando o `call` para chamar funções anônimas
@@ -71,16 +72,15 @@ Neste exemplo, criamos uma função anônima que usa o `call` para executá-lo e
 
 ```js
 var animais = [
-  { especie: 'Lion', nome: 'King' },
-  { especie: 'Whale', nome: 'Fail' }
+  { especie: "Lion", nome: "King" },
+  { especie: "Whale", nome: "Fail" },
 ];
 
 for (var i = 0; i < animais.length; i++) {
-  (function(i) {
-    this.print = function() {
-      console.log('#' + i + ' ' + this.especie
-                  + ': ' + this.nome);
-    }
+  (function (i) {
+    this.print = function () {
+      console.log("#" + i + " " + this.especie + ": " + this.nome);
+    };
     this.print();
   }).call(animais[i], i);
 }
@@ -105,11 +105,11 @@ apresentacao.call(i); // Douglas Crockford é um excelente Desenvolvedor Javascr
 
 ## Especificações
 
-| Especificações                                                                                           | Status                   | Comentário                                         |
-| -------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                 | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.3. |
-| {{SpecName('ES5.1', '#sec-15.3.4.4', 'Function.prototype.call')}}                 | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-function.prototype.call', 'Function.prototype.call')}} | {{Spec2('ES6')}}     |                                                    |
+| Especificações                                                                 | Status             | Comentário                                         |
+| ------------------------------------------------------------------------------ | ------------------ | -------------------------------------------------- |
+| {{SpecName('ES1')}}                                                            | {{Spec2('ES1')}}   | Definição inicial. Implementado no JavaScript 1.3. |
+| {{SpecName('ES5.1', '#sec-15.3.4.4', 'Function.prototype.call')}}              | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-function.prototype.call', 'Function.prototype.call')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/function/caller/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/function/caller/index.md
@@ -20,8 +20,16 @@ A propriedade especial `__caller__`, a qual retornou o objeto de ativação do c
 Note que no caso de recurção, você não pode reconstruir o stack de chamadas usando esta propriedade. Considere:
 
 ```js
-function f(n) { g(n - 1); }
-function g(n) { if (n > 0) { f(n); } else { stop(); } }
+function f(n) {
+  g(n - 1);
+}
+function g(n) {
+  if (n > 0) {
+    f(n);
+  } else {
+    stop();
+  }
+}
 f(2);
 ```
 
@@ -34,16 +42,16 @@ f(2) -> g(1) -> f(1) -> g(0) -> stop()
 O seguinte é true:
 
 ```js
-stop.caller === g && f.caller === g && g.caller === f
+stop.caller === g && f.caller === g && g.caller === f;
 ```
 
 então se você tentou recuperar o stack trace na função `stop()` assim:
 
 ```js
 var f = stop;
-var stack = 'Stack trace:';
+var stack = "Stack trace:";
 while (f) {
-  stack += '\n' + f.name;
+  stack += "\n" + f.name;
   f = f.caller;
 }
 ```
@@ -59,9 +67,9 @@ O código a seguir verifica o valor da propriedade `caller` de uma função.
 ```js
 function myFunc() {
   if (myFunc.caller == null) {
-    return 'The function was called from the top!';
+    return "The function was called from the top!";
   } else {
-    return 'This function\'s caller was ' + myFunc.caller;
+    return "This function's caller was " + myFunc.caller;
   }
 }
 ```

--- a/files/pt-br/web/javascript/reference/global_objects/function/displayname/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/function/displayname/index.md
@@ -16,9 +16,11 @@ function doSomething() {}
 
 console.log(doSomething.displayName); // "undefined"
 
-var popup = function(content) { console.log(content); };
+var popup = function (content) {
+  console.log(content);
+};
 
-popup.displayName = 'Show Popup';
+popup.displayName = "Show Popup";
 
 console.log(popup.displayName); // "Show Popup"
 ```
@@ -27,14 +29,18 @@ Você pode definir uma função com uma nome de exibição em um {{jsxref("Funct
 
 ```js
 var object = {
-  someMethod: function() {}
+  someMethod: function () {},
 };
 
-object.someMethod.displayName = 'someMethod';
+object.someMethod.displayName = "someMethod";
 
 console.log(object.someMethod.displayName); // logs "someMethod"
 
-try { someMethod } catch(e) { console.log(e); }
+try {
+  someMethod;
+} catch (e) {
+  console.log(e);
+}
 // ReferenceError: someMethod is not defined
 ```
 
@@ -43,14 +49,14 @@ Você pode mudar dinamicamente o`displayName` de uma função:
 ```js
 var object = {
   // anonymous
-  someMethod: function(value) {
-    arguments.callee.displayName = 'someMethod (' + value + ')';
-  }
+  someMethod: function (value) {
+    arguments.callee.displayName = "someMethod (" + value + ")";
+  },
 };
 
 console.log(object.someMethod.displayName); // "undefined"
 
-object.someMethod('123')
+object.someMethod("123");
 console.log(object.someMethod.displayName); // "someMethod (123)"
 ```
 
@@ -61,8 +67,8 @@ Geralmente, é preferida por consoles e perfis em vez de {{jsxref("Function.name
 Entrando com o seguinte em um console, isso deverá mostrar algo como "`function My Function()`":
 
 ```js
-var a = function() {};
-a.displayName = 'My Function';
+var a = function () {};
+a.displayName = "My Function";
 
 a; // "function My Function()"
 ```

--- a/files/pt-br/web/javascript/reference/global_objects/function/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/function/index.md
@@ -60,7 +60,7 @@ O código a seguir cria um objeto `Function` que recebe dois argumentos.
 // O exemplo pode ser executado direto no seu console JavaScript
 
 // Cria uma função que recebe 2 argumentos e retorna a soma entre os dois:
-var adder = new Function('a', 'b', 'return a + b');
+var adder = new Function("a", "b", "return a + b");
 
 // Chamada da função
 adder(2, 6);
@@ -76,77 +76,98 @@ Creating functions with the `Function` constructor is one of the ways to dynamic
 ```html
 <!doctype html>
 <html>
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<title>MDN Example - a recursive shortcut to massively modify the DOM</title>
-<script type="text/javascript">
-var domQuery = (function() {
-  var aDOMFunc = [
-    Element.prototype.removeAttribute,
-    Element.prototype.setAttribute,
-    CSSStyleDeclaration.prototype.removeProperty,
-    CSSStyleDeclaration.prototype.setProperty
-  ];
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>
+      MDN Example - a recursive shortcut to massively modify the DOM
+    </title>
+    <script type="text/javascript">
+      var domQuery = (function () {
+        var aDOMFunc = [
+          Element.prototype.removeAttribute,
+          Element.prototype.setAttribute,
+          CSSStyleDeclaration.prototype.removeProperty,
+          CSSStyleDeclaration.prototype.setProperty,
+        ];
 
-  function setSomething(bStyle, sProp, sVal) {
-    var bSet = Boolean(sVal), fAction = aDOMFunc[bSet | bStyle << 1],
-        aArgs = Array.prototype.slice.call(arguments, 1, bSet ? 3 : 2),
-        aNodeList = bStyle ? this.cssNodes : this.nodes;
+        function setSomething(bStyle, sProp, sVal) {
+          var bSet = Boolean(sVal),
+            fAction = aDOMFunc[bSet | (bStyle << 1)],
+            aArgs = Array.prototype.slice.call(arguments, 1, bSet ? 3 : 2),
+            aNodeList = bStyle ? this.cssNodes : this.nodes;
 
-    if (bSet && bStyle) { aArgs.push(''); }
-    for (
-      var nItem = 0, nLen = this.nodes.length;
-      nItem < nLen;
-      fAction.apply(aNodeList[nItem++], aArgs)
-    );
-    this.follow = setSomething.caller;
-    return this;
-  }
+          if (bSet && bStyle) {
+            aArgs.push("");
+          }
+          for (
+            var nItem = 0, nLen = this.nodes.length;
+            nItem < nLen;
+            fAction.apply(aNodeList[nItem++], aArgs)
+          );
+          this.follow = setSomething.caller;
+          return this;
+        }
 
-  function setStyles(sProp, sVal) { return setSomething.call(this, true, sProp, sVal); }
-  function setAttribs(sProp, sVal) { return setSomething.call(this, false, sProp, sVal); }
-  function getSelectors() { return this.selectors; };
-  function getNodes() { return this.nodes; };
+        function setStyles(sProp, sVal) {
+          return setSomething.call(this, true, sProp, sVal);
+        }
+        function setAttribs(sProp, sVal) {
+          return setSomething.call(this, false, sProp, sVal);
+        }
+        function getSelectors() {
+          return this.selectors;
+        }
+        function getNodes() {
+          return this.nodes;
+        }
 
-  return (function(sSelectors) {
-    var oQuery = new Function('return arguments.callee.follow.apply(arguments.callee, arguments);');
-    oQuery.selectors = sSelectors;
-    oQuery.nodes = document.querySelectorAll(sSelectors);
-    oQuery.cssNodes = Array.prototype.map.call(oQuery.nodes, function(oInlineCSS) { return oInlineCSS.style; });
-    oQuery.attributes = setAttribs;
-    oQuery.inlineStyle = setStyles;
-    oQuery.follow = getNodes;
-    oQuery.toString = getSelectors;
-    oQuery.valueOf = getNodes;
-    return oQuery;
-  });
-})();
-</script>
-</head>
+        return function (sSelectors) {
+          var oQuery = new Function(
+            "return arguments.callee.follow.apply(arguments.callee, arguments);",
+          );
+          oQuery.selectors = sSelectors;
+          oQuery.nodes = document.querySelectorAll(sSelectors);
+          oQuery.cssNodes = Array.prototype.map.call(
+            oQuery.nodes,
+            function (oInlineCSS) {
+              return oInlineCSS.style;
+            },
+          );
+          oQuery.attributes = setAttribs;
+          oQuery.inlineStyle = setStyles;
+          oQuery.follow = getNodes;
+          oQuery.toString = getSelectors;
+          oQuery.valueOf = getNodes;
+          return oQuery;
+        };
+      })();
+    </script>
+  </head>
 
-<body>
+  <body>
+    <div class="testClass">Lorem ipsum</div>
+    <p>Some text</p>
+    <div class="testClass">dolor sit amet</div>
 
-<div class="testClass">Lorem ipsum</div>
-<p>Some text</p>
-<div class="testClass">dolor sit amet</div>
-
-<script type="text/javascript">
-domQuery('.testClass')
-  .attributes('lang', 'en')('title', 'Risus abundat in ore stultorum')
-  .inlineStyle('background-color', 'black')('color', 'white')('width', '100px')('height', '50px');
-</script>
-</body>
-
+    <script type="text/javascript">
+      domQuery(".testClass")
+        .attributes("lang", "en")("title", "Risus abundat in ore stultorum")
+        .inlineStyle("background-color", "black")("color", "white")(
+        "width",
+        "100px",
+      )("height", "50px");
+    </script>
+  </body>
 </html>
 ```
 
 ## Especificação
 
-| Especificação                                                                | Status                   | Comentário                                         |
-| ---------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| ECMAScript 1st Edition.                                                      | Standard                 | Definição inicial. Implementado no JavaScript 1.0. |
-| {{SpecName('ES5.1', '#sec-15.3', 'Function')}}                 | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-function-objects', 'Function')}} | {{Spec2('ES6')}}     |                                                    |
+| Especificação                                            | Status             | Comentário                                         |
+| -------------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| ECMAScript 1st Edition.                                  | Standard           | Definição inicial. Implementado no JavaScript 1.0. |
+| {{SpecName('ES5.1', '#sec-15.3', 'Function')}}           | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-function-objects', 'Function')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade
 

--- a/files/pt-br/web/javascript/reference/global_objects/function/length/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/function/length/index.md
@@ -26,19 +26,21 @@ A propriedade length do objeto prototype {{jsxref("Function")}} tem o valor de 0
 ```js
 console.log(Function.length); /* 1 */
 
-console.log((function()        {}).length); /* 0 */
-console.log((function(a)       {}).length); /* 1 */
-console.log((function(a, b)    {}).length); /* 2 etc. */
-console.log((function(...args) {}).length); /* 0, rest parameter is not counted */
+console.log(function () {}.length); /* 0 */
+console.log(function (a) {}.length); /* 1 */
+console.log(function (a, b) {}.length); /* 2 etc. */
+console.log(
+  function (...args) {}.length,
+); /* 0, rest parameter is not counted */
 ```
 
 ## Especificações
 
-| Specification                                                                                    | Status                   | Comment                                                      |
-| ------------------------------------------------------------------------------------------------ | ------------------------ | ------------------------------------------------------------ |
-| {{SpecName('ES1')}}                                                                         | {{Spec2('ES1')}}     | Initial definition. Implemented in JavaScript 1.1.           |
-| {{SpecName('ES5.1', '#sec-15.3.5.1', 'Function.length')}}                     | {{Spec2('ES5.1')}} |                                                              |
-| {{SpecName('ES6', '#sec-function-instances-length', 'Function.length')}} | {{Spec2('ES6')}}     | The `configurable` attribute of this property is now `true`. |
+| Specification                                                            | Status             | Comment                                                      |
+| ------------------------------------------------------------------------ | ------------------ | ------------------------------------------------------------ |
+| {{SpecName('ES1')}}                                                      | {{Spec2('ES1')}}   | Initial definition. Implemented in JavaScript 1.1.           |
+| {{SpecName('ES5.1', '#sec-15.3.5.1', 'Function.length')}}                | {{Spec2('ES5.1')}} |                                                              |
+| {{SpecName('ES6', '#sec-function-instances-length', 'Function.length')}} | {{Spec2('ES6')}}   | The `configurable` attribute of this property is now `true`. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/function/name/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/function/name/index.md
@@ -35,9 +35,9 @@ Funções criadas com a sintaxe `new Function(...)` ou somente `Function(...)` c
 Variáveis e métodos podem inferir o nome de uma função anônima a partir de sua posição sintática (novo na ECMAScript 2015).
 
 ```js
-var f = function() {};
+var f = function () {};
 var object = {
-  someMethod: function() {}
+  someMethod: function () {},
 };
 
 console.log(f.name); // "f"
@@ -48,11 +48,15 @@ Você pode definir uma função com um nome numa {{jsxref("Operators/Function", 
 
 ```js
 var object = {
-  someMethod: function object_someMethod() {}
+  someMethod: function object_someMethod() {},
 };
 console.log(object.someMethod.name); // grava o log "object_someMethod"
 
-try { object_someMethod } catch(e) { console.log(e); }
+try {
+  object_someMethod;
+} catch (e) {
+  console.log(e);
+}
 // ReferenceError: object_someMethod is not defined
 ```
 
@@ -61,10 +65,10 @@ Você não pode mudar o nome de uma função, pois a propriedade é somente-leit
 ```js
 var object = {
   // anonymous
-  someMethod: function() {}
+  someMethod: function () {},
 };
 
-object.someMethod.name = 'otherMethod';
+object.someMethod.name = "otherMethod";
 console.log(object.someMethod.name); // someMethod
 ```
 
@@ -74,7 +78,7 @@ Para mudá-lo, você poderia no entanto usar {{jsxref("Object.defineProperty()")
 
 ```js
 var o = {
-  foo(){}
+  foo() {},
 };
 o.foo.name; // "foo";
 ```
@@ -84,7 +88,7 @@ o.foo.name; // "foo";
 {{jsxref("Function.bind()")}} produz uma função cujo nome é "bound " seguido do nome da função.
 
 ```js
-function foo() {};
+function foo() {}
 foo.bind({}).name; // "bound foo"
 ```
 
@@ -94,8 +98,8 @@ Ao usar propriedades acessórias [`get`](/pt-BR/docs/Web/JavaScript/Reference/Fu
 
 ```js
 var o = {
-  get foo(){},
-  set foo(x){}
+  get foo() {},
+  set foo(x) {},
 };
 
 var descriptor = Object.getOwnPropertyDescriptor(o, "foo");
@@ -108,7 +112,7 @@ descriptor.set.name; // "set foo";
 Você pode usar `obj.constructor.name` para checar a "classe" de um objeto (porém leia com atenção os avisos abaixo):
 
 ```js
-function Foo() {}  // Sintaxe ES2015: class Foo {}
+function Foo() {} // Sintaxe ES2015: class Foo {}
 
 var fooInstance = new Foo();
 console.log(fooInstance.constructor.name); // grava o log "Foo"
@@ -129,8 +133,8 @@ Com um método `static name()`, `Foo.name` não guarda mais o nome verdadeiro da
 
 ```js
 function Foo() {}
-Object.defineProperty(Foo, 'name', { writable: true });
-Foo.name = function() {};
+Object.defineProperty(Foo, "name", { writable: true });
+Foo.name = function () {};
 ```
 
 Tentar obter a classe de `fooInstance` via `fooInstance.constructor.name` não nos dará de maneira alguma o nome da classe, mas sim uma referência ao método estático da classe. Exemplo:
@@ -143,7 +147,7 @@ console.log(fooInstance.constructor.name); // grava o name() da função no log
 Você pode ver também, a partir do exemplo de sintaxe ES5, que, no Chrome ou no Firefox, a nossa definição estática de `Foo.name` se torna _writable_. A predefinição interna na ausência de uma definição estática customizada é somente-leitura:
 
 ```js
-Foo.name = 'Hello';
+Foo.name = "Hello";
 console.log(Foo.name); // logs "Hello" if class Foo has a static name() property but "Foo" if not.
 ```
 
@@ -172,25 +176,25 @@ o[sym2].name; // ""
 Código fonte do tipo:
 
 ```js
-function Foo() {};
+function Foo() {}
 var foo = new Foo();
 
-if (foo.constructor.name === 'Foo') {
+if (foo.constructor.name === "Foo") {
   console.log("'foo' is an instance of 'Foo'");
 } else {
-  console.log('Oops!');
+  console.log("Oops!");
 }
 ```
 
 pode ser comprimido e se tornar:
 
 ```js
-function a() {};
+function a() {}
 var b = new a();
-if (b.constructor.name === 'Foo') {
+if (b.constructor.name === "Foo") {
   console.log("'foo' is an instance of 'Foo'");
 } else {
-  console.log('Oops!');
+  console.log("Oops!");
 }
 ```
 
@@ -198,9 +202,9 @@ Na versão descomprimida, o programa cai no bloco-verdade e grava o log _'foo' i
 
 ## Especificações
 
-| Specification                                                                        | Status                       | Comment            |
-| ------------------------------------------------------------------------------------ | ---------------------------- | ------------------ |
-| {{SpecName('ES2015', '#sec-name', 'name')}}                             | {{Spec2('ES2015')}}     | Definição inicial. |
+| Specification                                                   | Status               | Comment            |
+| --------------------------------------------------------------- | -------------------- | ------------------ |
+| {{SpecName('ES2015', '#sec-name', 'name')}}                     | {{Spec2('ES2015')}}  | Definição inicial. |
 | {{SpecName('ESDraft', '#sec-function-instances-name', 'name')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/function/tostring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/function/tostring/index.md
@@ -28,13 +28,13 @@ O JavaScript chama o método `toString` automaticamente quando uma {{jsxref("Fun
 O método `toString()` lançará uma exceção do tipo {{jsxref("TypeError")}} ("Function.prototype.toString called on incompatible object") se o valor `this` do objeto não é um objeto do tipo `Function.`
 
 ```js example-bad
-Function.prototype.toString.call('foo'); // TypeError
+Function.prototype.toString.call("foo"); // TypeError
 ```
 
 Se o método `toString()` é chamado por objetos de funções embutidas ou por uma função criada por `Function.prototype.bind`, `toString()` retorna uma string de uma função nativa que parece
 
 ```js
-"function () {\n    [native code]\n}"
+"function () {\n    [native code]\n}";
 ```
 
 Se o método `toString()` é chamado por uma função criada pelo contrutor de `Function`, `toString()` retorna o código fonte de uma declaração de função sintetizada chamada "anonymous" usando os parâmetros passados e o corpo da função.
@@ -116,12 +116,12 @@ Object.getOwnPropertyDescriptor({
 
 ## Especificações
 
-| Especificação                                                                                                                     | Status                       | Comentário                                                                |
-| --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                                          | {{Spec2('ES1')}}         | Definição inicial. Implementado no JavaScript 1.1.                        |
-| {{SpecName('ES6', '#sec-function.prototype.tostring', 'Function.prototype.toString')}}              | {{Spec2('ES6')}}         | Mais requisitos específicos foram incluídos para representação de string. |
-| [`Function.prototype.toString` revisions proposal](https://tc39.github.io/Function-prototype-toString-revision/#sec-introduction) | Rascunho                     | Padroniza a função de string navida e fins de linha.                      |
-| {{SpecName('ESDraft', '#sec-function.prototype.tostring', 'Function.prototype.toString')}}          | {{Spec2('ESDraft')}} |                                                                           |
+| Especificação                                                                                                                     | Status               | Comentário                                                                |
+| --------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                                                               | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.1.                        |
+| {{SpecName('ES6', '#sec-function.prototype.tostring', 'Function.prototype.toString')}}                                            | {{Spec2('ES6')}}     | Mais requisitos específicos foram incluídos para representação de string. |
+| [`Function.prototype.toString` revisions proposal](https://tc39.github.io/Function-prototype-toString-revision/#sec-introduction) | Rascunho             | Padroniza a função de string navida e fins de linha.                      |
+| {{SpecName('ESDraft', '#sec-function.prototype.tostring', 'Function.prototype.toString')}}                                        | {{Spec2('ESDraft')}} |                                                                           |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/generator/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/generator/index.md
@@ -33,10 +33,9 @@ var g = gen(); // "Generator { }"
 ### An infinite iterator
 
 ```js
-function* idMaker(){
-    var index = 0;
-    while(true)
-        yield index++;
+function* idMaker() {
+  var index = 0;
+  while (true) yield index++;
 }
 
 var gen = idMaker(); // "Generator { }"
@@ -71,18 +70,18 @@ function* fibonacci() {
 }
 
 var it = fibonacci();
-console.log(it);          // "Generator {  }"
-console.log(it.next());   // 1
+console.log(it); // "Generator {  }"
+console.log(it.next()); // 1
 console.log(it.send(10)); // 20
-console.log(it.close());  // undefined
-console.log(it.next());   // throws StopIteration (Como o generator está fechado)
+console.log(it.close()); // undefined
+console.log(it.next()); // throws StopIteration (Como o generator está fechado)
 ```
 
 ## Especificações
 
-| Especificações                                                                               | Status                       | Comentário        |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | ----------------- |
-| {{SpecName('ES6', '#sec-generator-objects', 'Generator objects')}}     | {{Spec2('ES6')}}         | Definição Inicial |
+| Especificações                                                         | Status               | Comentário        |
+| ---------------------------------------------------------------------- | -------------------- | ----------------- |
+| {{SpecName('ES6', '#sec-generator-objects', 'Generator objects')}}     | {{Spec2('ES6')}}     | Definição Inicial |
 | {{SpecName('ESDraft', '#sec-generator-objects', 'Generator objects')}} | {{Spec2('ESDraft')}} |                   |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/globalthis/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/globalthis/index.md
@@ -34,15 +34,21 @@ Antes de `globalThis`, a única maneira confiável de obter o objeto global para
 
 ```js
 var getGlobal = function () {
-  if (typeof self !== 'undefined') { return self; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof global !== 'undefined') { return global; }
-  throw new Error('unable to locate global object');
+  if (typeof self !== "undefined") {
+    return self;
+  }
+  if (typeof window !== "undefined") {
+    return window;
+  }
+  if (typeof global !== "undefined") {
+    return global;
+  }
+  throw new Error("unable to locate global object");
 };
 
 var globals = getGlobal();
 
-if (typeof globals.setTimeout !== 'function') {
+if (typeof globals.setTimeout !== "function") {
   // sem setTimeout neste ambiente!
 }
 ```
@@ -50,7 +56,7 @@ if (typeof globals.setTimeout !== 'function') {
 Com `globalThis` disponível, a busca global adicional entre ambientes não é mais necessária:
 
 ```js
-if (typeof globalThis.setTimeout !== 'function') {
+if (typeof globalThis.setTimeout !== "function") {
   // sem setTimeout neste ambiente!
 }
 ```

--- a/files/pt-br/web/javascript/reference/global_objects/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/index.md
@@ -2,6 +2,7 @@
 title: Objetos Globais
 slug: Web/JavaScript/Reference/Global_Objects
 ---
+
 {{jsSidebar("Objects")}}
 
 ## Resumo

--- a/files/pt-br/web/javascript/reference/global_objects/infinity/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/infinity/index.md
@@ -27,11 +27,11 @@ Pela especificação ECMAScript 5, `Infinity` é somente leitura (implementado n
 
 ## Especificações
 
-| Especificação                                                                                                        | Status                   | Comentário                                        |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------- |
-| ECMAScript 1ª Edição.                                                                                                | Padrão                   | Definição inicial. Implementado no JavaScript 1.3 |
-| {{SpecName('ES5.1', '#sec-15.1.1.2', 'Infinity')}}                                                 | {{Spec2('ES5.1')}} |                                                   |
-| {{SpecName('ES6', '#sec-value-properties-of-the-global-object-infinity', 'Infinity')}} | {{Spec2('ES6')}}     |                                                   |
+| Especificação                                                                          | Status             | Comentário                                        |
+| -------------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------- |
+| ECMAScript 1ª Edição.                                                                  | Padrão             | Definição inicial. Implementado no JavaScript 1.3 |
+| {{SpecName('ES5.1', '#sec-15.1.1.2', 'Infinity')}}                                     | {{Spec2('ES5.1')}} |                                                   |
+| {{SpecName('ES6', '#sec-value-properties-of-the-global-object-infinity', 'Infinity')}} | {{Spec2('ES6')}}   |                                                   |
 
 ## Compatibilidade
 

--- a/files/pt-br/web/javascript/reference/global_objects/int16array/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/int16array/index.md
@@ -124,7 +124,7 @@ console.log(int16.length); // 2
 console.log(int16.BYTES_PER_ELEMENT); // 2
 
 // De uma array
-var arr = new Int16Array([21,31]);
+var arr = new Int16Array([21, 31]);
 console.log(arr[1]); // 31
 
 // De um outro TypedArray
@@ -137,17 +137,19 @@ var buffer = new ArrayBuffer(8);
 var z = new Int16Array(buffer, 0, 4);
 
 // De um interável
-var iterable = function*(){ yield* [1,2,3]; }();
+var iterable = (function* () {
+  yield* [1, 2, 3];
+})();
 var int16 = new Int16Array(iterable);
 // Int16Array[1, 2, 3]
 ```
 
 ## Especificações
 
-| Especificação                                                                        | Status                           | Comentário                                                                                                             |
-| ------------------------------------------------------------------------------------ | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('Typed Array')}}                                                 | {{Spec2('Typed Array')}} | Substituído pelo ECMAScript 2015.                                                                                      |
-| {{SpecName('ES2015', '#table-49', 'TypedArray constructors')}} | {{Spec2('ES2015')}}         | Definição inicial em um padrão ECMA. Especificado `new` como requerido.                                                |
+| Especificação                                                   | Status                   | Comentário                                                                                                             |
+| --------------------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| {{SpecName('Typed Array')}}                                     | {{Spec2('Typed Array')}} | Substituído pelo ECMAScript 2015.                                                                                      |
+| {{SpecName('ES2015', '#table-49', 'TypedArray constructors')}}  | {{Spec2('ES2015')}}      | Definição inicial em um padrão ECMA. Especificado `new` como requerido.                                                |
 | {{SpecName('ESDraft', '#table-49', 'TypedArray constructors')}} | {{Spec2('ESDraft')}}     | ECMAScript 2017 mudou o construtor `Int16Array` para usar a operação `ToIndex` e permitir construtores sem argumentos. |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/internalerror/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/internalerror/index.md
@@ -42,8 +42,10 @@ This recursive function runs 10 times, as per the exit condition.
 
 ```js
 function loop(x) {
-  if (x >= 10) // "x >= 10" is the exit condition
+  if (x >= 10) {
+    // "x >= 10" is the exit condition
     return;
+  }
   // do stuff
   loop(x + 1); // the recursive call
 }
@@ -54,8 +56,7 @@ Setting this condition to an extremely high value, won't work:
 
 ```js example-bad
 function loop(x) {
-  if (x >= 1000000000000)
-    return;
+  if (x >= 1000000000000) return;
   // do stuff
   loop(x + 1);
 }

--- a/files/pt-br/web/javascript/reference/global_objects/intl/datetimeformat/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/intl/datetimeformat/index.md
@@ -57,29 +57,29 @@ var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
 // Results below use the time zone of America/Los_Angeles (UTC-0800, Pacific Standard Time)
 
 // US English uses month-day-year order
-console.log(new Intl.DateTimeFormat('en-US').format(date));
+console.log(new Intl.DateTimeFormat("en-US").format(date));
 // → "12/19/2012"
 
 // British English uses day-month-year order
-console.log(new Intl.DateTimeFormat('en-GB').format(date));
+console.log(new Intl.DateTimeFormat("en-GB").format(date));
 // → "19/12/2012"
 
 // Korean uses year-month-day order
-console.log(new Intl.DateTimeFormat('ko-KR').format(date));
+console.log(new Intl.DateTimeFormat("ko-KR").format(date));
 // → "2012. 12. 19."
 
 // Arabic in most Arabic speaking countries uses real Arabic digits
-console.log(new Intl.DateTimeFormat('ar-EG').format(date));
+console.log(new Intl.DateTimeFormat("ar-EG").format(date));
 // → "١٩‏/١٢‏/٢٠١٢"
 
 // for Japanese, applications may want to use the Japanese calendar,
 // where 2012 was the year 24 of the Heisei era
-console.log(new Intl.DateTimeFormat('ja-JP-u-ca-japanese').format(date));
+console.log(new Intl.DateTimeFormat("ja-JP-u-ca-japanese").format(date));
 // → "24/12/19"
 
 // when requesting a language that may not be supported, such as
 // Balinese, include a fallback language, in this case Indonesian
-console.log(new Intl.DateTimeFormat(['ban', 'id']).format(date));
+console.log(new Intl.DateTimeFormat(["ban", "id"]).format(date));
 // → "19/12/2012"
 ```
 
@@ -91,57 +91,66 @@ The date and time formats can be customized using the `options` argument:
 var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0, 200));
 
 // request a weekday along with a long date
-var options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-console.log(new Intl.DateTimeFormat('de-DE', options).format(date));
+var options = {
+  weekday: "long",
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+};
+console.log(new Intl.DateTimeFormat("de-DE", options).format(date));
 // → "Donnerstag, 20. Dezember 2012"
 
 // an application may want to use UTC and make that visible
-options.timeZone = 'UTC';
-options.timeZoneName = 'short';
-console.log(new Intl.DateTimeFormat('en-US', options).format(date));
+options.timeZone = "UTC";
+options.timeZoneName = "short";
+console.log(new Intl.DateTimeFormat("en-US", options).format(date));
 // → "Thursday, December 20, 2012, GMT"
 
 // sometimes you want to be more precise
 options = {
-  hour: 'numeric', minute: 'numeric', second: 'numeric',
-  timeZone: 'Australia/Sydney',
-  timeZoneName: 'short'
+  hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
+  timeZone: "Australia/Sydney",
+  timeZoneName: "short",
 };
-console.log(new Intl.DateTimeFormat('en-AU', options).format(date));
+console.log(new Intl.DateTimeFormat("en-AU", options).format(date));
 // → "2:00:00 pm AEDT"
 
 // sometimes you want to be very precise
 options.fractionalSecondDigits = 3;
-console.log(new Intl.DateTimeFormat('en-AU', options).format(date));
+console.log(new Intl.DateTimeFormat("en-AU", options).format(date));
 // → "2:00:00.200 pm AEDT"
-
 
 // sometimes even the US needs 24-hour time
 options = {
-  year: 'numeric', month: 'numeric', day: 'numeric',
-  hour: 'numeric', minute: 'numeric', second: 'numeric',
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
   hour12: false,
-  timeZone: 'America/Los_Angeles'
+  timeZone: "America/Los_Angeles",
 };
-console.log(new Intl.DateTimeFormat('en-US', options).format(date));
+console.log(new Intl.DateTimeFormat("en-US", options).format(date));
 // → "12/19/2012, 19:00:00"
 
-
 // to specify options but use the browser's default locale, use 'default'
-console.log(new Intl.DateTimeFormat('default', options).format(date));
+console.log(new Intl.DateTimeFormat("default", options).format(date));
 // → "12/19/2012, 19:00:00"
 
 // sometimes it's helpful to include the period of the day
-options = {hour: "numeric", dayPeriod: "short"};
-console.log(new Intl.DateTimeFormat('en-US', options).format(date));
+options = { hour: "numeric", dayPeriod: "short" };
+console.log(new Intl.DateTimeFormat("en-US", options).format(date));
 // → 10 at night
 ```
 
 The used calendar and numbering formats can also be set independently via `options` arguments:
 
 ```js
-var options = {calendar: 'chinese', numberingSystem: 'arab'};
-var dateFormat = new Intl.DateTimeFormat('default', options);
+var options = { calendar: "chinese", numberingSystem: "arab" };
+var dateFormat = new Intl.DateTimeFormat("default", options);
 var usedOptions = dateFormat.resolvedOptions();
 
 console.log(usedOptions.calendar);
@@ -156,8 +165,8 @@ console.log(usedOptions.timeZone);
 
 ## Specifications
 
-| Specification                                                                                            |
-| -------------------------------------------------------------------------------------------------------- |
+| Specification                                                                  |
+| ------------------------------------------------------------------------------ |
 | {{SpecName('ES Int Draft', '#datetimeformat-objects', 'Intl.DateTimeFormat')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/intl/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/intl/index.md
@@ -57,10 +57,10 @@ One property is supported by all language sensitive constructors and functions: 
 
 ## Specifications
 
-| Specification                                                        | Status                           | Comment                                            |
-| -------------------------------------------------------------------- | -------------------------------- | -------------------------------------------------- |
-| {{SpecName('ES Int 1.0', '#sec-8', 'Intl')}}         | {{Spec2('ES Int 1.0')}} | Initial definition.                                |
-| {{SpecName('ES Int 2.0', '#sec-8', 'Intl')}}         | {{Spec2('ES Int 2.0')}} |                                                    |
+| Specification                                        | Status                    | Comment                                            |
+| ---------------------------------------------------- | ------------------------- | -------------------------------------------------- |
+| {{SpecName('ES Int 1.0', '#sec-8', 'Intl')}}         | {{Spec2('ES Int 1.0')}}   | Initial definition.                                |
+| {{SpecName('ES Int 2.0', '#sec-8', 'Intl')}}         | {{Spec2('ES Int 2.0')}}   |                                                    |
 | {{SpecName('ES Int Draft', '#intl-object', 'Intl')}} | {{Spec2('ES Int Draft')}} | Added Intl.getCanonicalLocales in the 4th edition. |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/intl/listformat/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/intl/listformat/index.md
@@ -39,20 +39,20 @@ const list = ["Moto", "Ônibus", "Carro"];
 
 console.log(
   new Intl.ListFormat("pt-BR", { style: "long", type: "conjunction" }).format(
-    list
-  )
+    list,
+  ),
 );
 // > Moto, Ônibus e Carro
 
 console.log(
   new Intl.ListFormat("pt-BR", { style: "short", type: "disjunction" }).format(
-    list
-  )
+    list,
+  ),
 );
 // > Moto, Ônibus ou Carro
 
 console.log(
-  new Intl.ListFormat("pt-BR", { style: "narrow", type: "unit" }).format(list)
+  new Intl.ListFormat("pt-BR", { style: "narrow", type: "unit" }).format(list),
 );
 // > Moto Ônibus Carro
 ```
@@ -67,7 +67,7 @@ console.log(
   new Intl.ListFormat("pt-BR", {
     style: "long",
     type: "conjunction",
-  }).formatToParts(list)
+  }).formatToParts(list),
 );
 
 // [ { "type": "element", "value": "Moto" },


### PR DESCRIPTION
This PR formats the `/web/javascript` folder of the Brazilian Portuguese locale using Prettier.  This is the second part.
