### PR TITLE
pt-br: Format /web/javascript using Prettier (part 5)

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/string/trimend/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/trimend/index.md
@@ -39,19 +39,19 @@ String.prototype.trimRight.name === "trimEnd";
 O exemplo a seguir mostra a _string_ em caixa baixa `' foo'`:
 
 ```js
-var str = '   foo  ';
+var str = "   foo  ";
 
 console.log(str.length); // retorna 8
 
 str = str.trimEnd();
 console.log(str.length); // retorna 6
-console.log(str);        // retorna '   foo'
+console.log(str); // retorna '   foo'
 ```
 
 ## Especificações
 
-| Especificação                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                        |
+| ------------------------------------------------------------------------------------ |
 | {{SpecName('ESDraft', '#sec-string.prototype.trimend', 'String.prototype.trimEnd')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/string/trimstart/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/trimstart/index.md
@@ -37,20 +37,21 @@ String.prototype.trimLeft.name === "trimStart";
 ```js
 //https://github.com/FabioVergani/js-Polyfill_String-trimStart
 
-(function(w){
-    var String=w.String, Proto=String.prototype;
+(function (w) {
+  var String = w.String,
+    Proto = String.prototype;
 
-    (function(o,p){
-        if(p in o?o[p]?false:true:true){
-            var r=/^\s+/;
-            o[p]=o.trimLeft||function(){
-                return this.replace(r,'')
-            }
-        }
-    })(Proto,'trimStart');
-
+  (function (o, p) {
+    if (p in o ? (o[p] ? false : true) : true) {
+      var r = /^\s+/;
+      o[p] =
+        o.trimLeft ||
+        function () {
+          return this.replace(r, "");
+        };
+    }
+  })(Proto, "trimStart");
 })(window);
-
 
 /*
 ES6:
@@ -77,19 +78,19 @@ ES6:
 O seguinte exemplo mostra uma _string_ em caixa baixa `'foo '`:
 
 ```js
-var str = '   foo  ';
+var str = "   foo  ";
 
 console.log(str.length); // retorna 8
 
 str = str.trimStart();
 console.log(str.length); // retorna 5
-console.log(str);        // retorna 'foo  '
+console.log(str); // retorna 'foo  '
 ```
 
 ## Especificações
 
-| Especificação                                                                                                            |
-| ------------------------------------------------------------------------------------------------------------------------ |
+| Especificação                                                                             |
+| ----------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-string.prototype.trimstart', ' String.prototype.trimStart')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/string/valueof/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/valueof/index.md
@@ -30,17 +30,17 @@ Esse método é normalmente chamado internamente pelo JavaScript e não fica exp
 ### Usando `valueOf()`
 
 ```js
-var x = new String('Olá, mundo');
+var x = new String("Olá, mundo");
 console.log(x.valueOf()); // retorna 'Olá, mundo'
 ```
 
 ## Especificações
 
-| Especificação                                                                                                    | Status                       | Comentário                                        |
-| ---------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                         | {{Spec2('ES1')}}         | Definição inicial implementada no JavaScript 1.1. |
-| {{SpecName('ES5.1', '#sec-15.5.4.3', 'String.prototype.valueOf')}}                         | {{Spec2('ES5.1')}}     |                                                   |
-| {{SpecName('ES6', '#sec-string.prototype.valueof', 'String.prototype.valueOf')}}     | {{Spec2('ES6')}}         |                                                   |
+| Especificação                                                                        | Status               | Comentário                                        |
+| ------------------------------------------------------------------------------------ | -------------------- | ------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                  | {{Spec2('ES1')}}     | Definição inicial implementada no JavaScript 1.1. |
+| {{SpecName('ES5.1', '#sec-15.5.4.3', 'String.prototype.valueOf')}}                   | {{Spec2('ES5.1')}}   |                                                   |
+| {{SpecName('ES6', '#sec-string.prototype.valueof', 'String.prototype.valueOf')}}     | {{Spec2('ES6')}}     |                                                   |
 | {{SpecName('ESDraft', '#sec-string.prototype.valueof', 'String.prototype.valueOf')}} | {{Spec2('ESDraft')}} |                                                   |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/asynciterator/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/asynciterator/index.md
@@ -21,21 +21,21 @@ Você consegue definir seu próprio iterável assíncrono configurando a proprie
 
 ```js
 const myAsyncIterable = {
-    async* [Symbol.asyncIterator]() {
-        yield "hello";
-        yield "async";
-        yield "iteration!";
-    }
+  async *[Symbol.asyncIterator]() {
+    yield "hello";
+    yield "async";
+    yield "iteration!";
+  },
 };
 
 (async () => {
-    for await (const x of myAsyncIterable) {
-        console.log(x);
-        // resultado esperado:
-        //    "hello"
-        //    "async"
-        //    "iteration!"
-    }
+  for await (const x of myAsyncIterable) {
+    console.log(x);
+    // resultado esperado:
+    //    "hello"
+    //    "async"
+    //    "iteration!"
+  }
 })();
 ```
 
@@ -47,8 +47,8 @@ Não há atualmente objetos Javascript built-in que tenha a chave `[Symbol.async
 
 ## Especificações
 
-| Especificação                                                                                        |
-| ---------------------------------------------------------------------------------------------------- |
+| Especificação                                                                |
+| ---------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-symbol.asynciterator', 'Symbol.asyncIterator')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/description/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/description/index.md
@@ -18,24 +18,24 @@ A propriedade leitura somente **`description`** é uma string que retorna a desc
 ### Usando descrição
 
 ```js
-Symbol('desc').toString();   // "Symbol(desc)"
-Symbol('desc').description;  // "desc"
-Symbol('').description;      // ""
-Symbol().description;        // undefined
+Symbol("desc").toString(); // "Symbol(desc)"
+Symbol("desc").description; // "desc"
+Symbol("").description; // ""
+Symbol().description; // undefined
 
 // símbolos conhecidos
-Symbol.iterator.toString();  // "Symbol(Symbol.iterator)"
+Symbol.iterator.toString(); // "Symbol(Symbol.iterator)"
 Symbol.iterator.description; // "Symbol.iterator"
 
 // símbolos globais
-Symbol.for('foo').toString();  // "Symbol(foo)"
-Symbol.for('foo').description; // "foo"
+Symbol.for("foo").toString(); // "Symbol(foo)"
+Symbol.for("foo").description; // "foo"
 ```
 
 ## Especificações
 
-| Especificação                                                                                                                    |
-| -------------------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                                    |
+| ------------------------------------------------------------------------------------------------ |
 | {{SpecName("ESDraft", "#sec-symbol.prototype.description", "get Symbol.prototype.description")}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/hasinstance/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/hasinstance/index.md
@@ -16,26 +16,25 @@ Você pode implementar o comportamento customizado do seu `instanceof` deste jei
 ```js
 class MyArray {
   static [Symbol.hasInstance](instance) {
-    return this.prototype.isPrototypeOf(instance) ||
-           Array.isArray(instance);
+    return this.prototype.isPrototypeOf(instance) || Array.isArray(instance);
   }
 }
 
 console.log([] instanceof MyArray); // true
-console.log(new MyArray instanceof MyArray); // true
-console.log(new Image instanceof MyArray); // false
+console.log(new MyArray() instanceof MyArray); // true
+console.log(new Image() instanceof MyArray); // false
 
 class MySubArray extends MyArray {}
-console.log(new MySubArray instanceof MySubArray); // true
-console.log(new MySubArray instanceof MyArray); // true
-console.log(new MyArray instanceof MySubArray); // false
+console.log(new MySubArray() instanceof MySubArray); // true
+console.log(new MySubArray() instanceof MyArray); // true
+console.log(new MyArray() instanceof MySubArray); // false
 ```
 
 ## Especificações
 
-| Specification                                                                                    | Status                       | Comment             |
-| ------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-symbol.hasinstance', 'Symbol.hasInstance')}}     | {{Spec2('ES6')}}         | Initial definition. |
+| Specification                                                            | Status               | Comment             |
+| ------------------------------------------------------------------------ | -------------------- | ------------------- |
+| {{SpecName('ES6', '#sec-symbol.hasinstance', 'Symbol.hasInstance')}}     | {{Spec2('ES6')}}     | Initial definition. |
 | {{SpecName('ESDraft', '#sec-symbol.hasinstance', 'Symbol.hasInstance')}} | {{Spec2('ESDraft')}} |                     |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/index.md
@@ -52,9 +52,9 @@ Se você realmente quiser criar um objeto empacotador de `Symbol`, você pode us
 
 ```js
 var sym = Symbol("foo");
-typeof sym;     // "symbol"
+typeof sym; // "symbol"
 var symObj = Object(sym);
-typeof symObj;  // "object"
+typeof symObj; // "object"
 ```
 
 ### Símbolos compartilhados no registro global de símbolo
@@ -117,9 +117,9 @@ Todos os símbolos herdados de {{jsxref("Symbol.prototype")}}.
 O operador {{jsxref("Operators/typeof", "typeof")}} pode ajudar a identificar os símbolos.
 
 ```js
-typeof Symbol() === 'symbol'
-typeof Symbol('foo') === 'symbol'
-typeof Symbol.iterator === 'symbol'
+typeof Symbol() === "symbol";
+typeof Symbol("foo") === "symbol";
+typeof Symbol.iterator === "symbol";
 ```
 
 ### Conversões de tipos de símbolos
@@ -145,7 +145,7 @@ obj["c"] = "c";
 obj.d = "d";
 
 for (var i in obj) {
-   console.log(i); // logs "c" and "d"
+  console.log(i); // logs "c" and "d"
 }
 ```
 
@@ -154,7 +154,7 @@ for (var i in obj) {
 Propriedade com chave de símbolo vão ser completamente ignoradas quando usando `JSON.stringify()`:
 
 ```js
-JSON.stringify({[Symbol("foo")]: "foo"});
+JSON.stringify({ [Symbol("foo")]: "foo" });
 // '{}'
 ```
 
@@ -166,15 +166,15 @@ Quando um objeto wrapper de um símbolo é usado como uma chave de propriedade, 
 
 ```js
 var sym = Symbol("foo");
-var obj = {[sym]: 1};
-obj[sym];            // 1
-obj[Object(sym)];    // still 1
+var obj = { [sym]: 1 };
+obj[sym]; // 1
+obj[Object(sym)]; // still 1
 ```
 
 ## Especificações
 
-| Specification                                                            | Status                   | Comment            |
-| ------------------------------------------------------------------------ | ------------------------ | ------------------ |
+| Specification                                           | Status              | Comment            |
+| ------------------------------------------------------- | ------------------- | ------------------ |
 | {{SpecName('ES2015', '#sec-symbol-objects', 'Symbol')}} | {{Spec2('ES2015')}} | Definição inicial. |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
@@ -50,24 +50,24 @@ console.log(alphaNumeric)  // Resultado: ['a', 'b', 'c', [1, 2, 3] ]
 Para objetos de array semelhantes, o padrão não é espalhado. `Symbol.isConcatSpreadable`precisa ser configurado para `true` para poder conseguir um a array alinhada:
 
 ```js
-let x = [1, 2, 3]
+let x = [1, 2, 3];
 
 let fakeArray = {
   [Symbol.isConcatSpreadable]: true,
   length: 2,
-  0: 'hello',
-  1: 'world'
-}
+  0: "hello",
+  1: "world",
+};
 
-x.concat(fakeArray)  // [1, 2, 3, "hello", "world"]
+x.concat(fakeArray); // [1, 2, 3, "hello", "world"]
 ```
 
 > **Nota:** A propriedade `length` é usada para controlar o número de propriedade dos objetos para ser adicionado. No exemplo acima, `length:2` indica que duas propriedades tem de ser adicionado.
 
 ## Especificações
 
-| Especificação                                                                                                        |
-| -------------------------------------------------------------------------------------------------------------------- |
+| Especificação                                                                          |
+| -------------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-symbol.isconcatspreadable', 'Symbol.isconcatspreadable')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/iterator/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/iterator/index.md
@@ -32,13 +32,13 @@ Veja também [Iteration protocols](/pt-BR/docs/Web/JavaScript/Reference/Iteratio
 Podemos fazer nosso próprio iterável dessa forma:
 
 ```js
-var myIterable = {}
+var myIterable = {};
 myIterable[Symbol.iterator] = function* () {
-    yield 1;
-    yield 2;
-    yield 3;
+  yield 1;
+  yield 2;
+  yield 3;
 };
-[...myIterable] // [1, 2, 3]
+[...myIterable]; // [1, 2, 3]
 ```
 
 Ou iteráveis podem ser definidos diretamente dentro de uma classe ou um objeto usando [computed property](/pt-BR/docs/Web/JavaScript/Reference/Operators/Object_initializer#Computed_property_names):
@@ -75,8 +75,8 @@ nonWellFormedIterable[Symbol.iterator] = () => 1
 
 ## Especificações
 
-| Especificação                                                                            |
-| ---------------------------------------------------------------------------------------- |
+| Especificação                                                      |
+| ------------------------------------------------------------------ |
 | {{SpecName('ESDraft', '#sec-symbol.iterator', 'Symbol.iterator')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/match/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/match/index.md
@@ -22,7 +22,7 @@ Essa função também é usada para identificar se um objeto tem o comportamento
 O seguinte código vai lançar um {{jsxref("TypeError")}}:
 
 ```js
-'/bar/'.startsWith(/bar/);
+"/bar/".startsWith(/bar/);
 
 // Lança um TypeError, como /bar/ é uma expressão regular
 // não Symbol.match não é modificado.
@@ -33,14 +33,14 @@ Entretanto, se você configurar `Symbol.match` para `false`, a verificação `is
 ```js
 var re = /foo/;
 re[Symbol.match] = false;
-'/foo/'.startsWith(re); // true
-'/baz/'.endsWith(re);   // false
+"/foo/".startsWith(re); // true
+"/baz/".endsWith(re); // false
 ```
 
 ## Especificações
 
-| Especificação                                                                    |
-| -------------------------------------------------------------------------------- |
+| Especificação                                                |
+| ------------------------------------------------------------ |
 | {{SpecName('ESDraft', '#sec-symbol.match', 'Symbol.match')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/matchall/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/matchall/index.md
@@ -2,6 +2,7 @@
 title: Symbol.matchAll
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/matchAll
 ---
+
 {{JSRef}}
 
 O símbolo **`Symbol.matchAll`** é conhecido por retornar um iterador, que produz conrrespondências de uma expressão regular com uma string. Essa função é usada pelo método {{jsxref("String.prototype.matchAll()")}}.
@@ -13,9 +14,9 @@ O símbolo **`Symbol.matchAll`** é conhecido por retornar um iterador, que prod
 Esse símbolo é usado pelo {{jsxref("String.prototype.matchAll()")}} e especificado no {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]()")}}. Os próximos dois exemplos retornam o mesmo resultado:
 
 ```js
-'abc'.matchAll(/a/);
+"abc".matchAll(/a/);
 
-/a/[Symbol.matchAll]('abc');
+/a/[Symbol.matchAll]("abc");
 ```
 
 Esse método existe para costumizar o comportamento conrrespondente com as subclasses {{jsxref("RegExp")}}.
@@ -28,13 +29,12 @@ Esse método existe para costumizar o comportamento conrrespondente com as subcl
 
 ```js
 let re = /[0-9]+/g;
-let str = '2016-01-02|2019-03-07';
+let str = "2016-01-02|2019-03-07";
 
 const numbers = {
-  *[Symbol.matchAll] (str) {
-    for (const n of str.matchAll(/[0-9]+/g))
-      yield n[0];
-  }
+  *[Symbol.matchAll](str) {
+    for (const n of str.matchAll(/[0-9]+/g)) yield n[0];
+  },
 };
 
 console.log(Array.from(str.matchAll(numbers)));
@@ -45,8 +45,8 @@ Veja {{jsxref("String.prototype.matchAll()")}} e {{jsxref("RegExp.@@matchAll", "
 
 ## Especificações
 
-| Especificação                                                                            |
-| ---------------------------------------------------------------------------------------- |
+| Especificação                                                      |
+| ------------------------------------------------------------------ |
 | {{SpecName('ESDraft', '#sec-symbol.matchall', 'Symbol.matchAll')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -21,18 +21,18 @@ class CustomReplacer {
     this.value = value;
   }
   [Symbol.replace](string) {
-    return string.replace(this.value, '#!@?');
+    return string.replace(this.value, "#!@?");
   }
 }
 
-console.log('football'.replace(new CustomReplacer('foo')));
+console.log("football".replace(new CustomReplacer("foo")));
 // resultado esperado: "#!@?tball"
 ```
 
 ## Especificações
 
-| Especificação                                                                        |
-| ------------------------------------------------------------------------------------ |
+| Especificação                                                    |
+| ---------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-symbol.replace', 'Symbol.replace')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/search/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/search/index.md
@@ -25,14 +25,14 @@ class caseInsensitiveSearch {
   }
 }
 
-console.log('foobar'.search(new caseInsensitiveSearch('BaR')));
+console.log("foobar".search(new caseInsensitiveSearch("BaR")));
 // resultado esperado: 3
 ```
 
 ## Especificações
 
-| Especificação                                                                        |
-| ------------------------------------------------------------------------------------ |
+| Especificação                                                  |
+| -------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-symbol.search', 'Symbol.search')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/species/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/species/index.md
@@ -24,19 +24,21 @@ Você pode querer que retorne objetos {{jsxref("Array")}} em sua class derivada 
 ```js
 class MyArray extends Array {
   // Substitui espécies para a Array pai construtora
-  static get [Symbol.species]() { return Array; }
+  static get [Symbol.species]() {
+    return Array;
+  }
 }
-let a = new MyArray(1,2,3);
-let mapped = a.map(x => x * x);
+let a = new MyArray(1, 2, 3);
+let mapped = a.map((x) => x * x);
 
 console.log(mapped instanceof MyArray); // false
-console.log(mapped instanceof Array);   // true
+console.log(mapped instanceof Array); // true
 ```
 
 ## Especificações
 
-| Especificação                                                                        |
-| ------------------------------------------------------------------------------------ |
+| Especificação                                                    |
+| ---------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-symbol.species', 'Symbol.species')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/split/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/split/index.md
@@ -18,19 +18,19 @@ Para mais informações, veja {{jsxref("RegExp.@@split", "RegExp.prototype[@@spl
 ```js
 class ReverseSplit {
   [Symbol.split](string) {
-    const array = string.split(' ');
+    const array = string.split(" ");
     return array.reverse();
   }
 }
 
-console.log('Another one bites the dust'.split(new ReverseSplit()));
+console.log("Another one bites the dust".split(new ReverseSplit()));
 // resultado esperado: [ "dust", "the", "bites", "one", "Another" ]
 ```
 
 ## Especificações
 
-| Especificação                                                                    |
-| -------------------------------------------------------------------------------- |
+| Especificação                                                |
+| ------------------------------------------------------------ |
 | {{SpecName('ESDraft', '#sec-symbol.split', 'Symbol.split')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/toprimitive/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/toprimitive/index.md
@@ -24,31 +24,31 @@ O exemplo a seguir descreve que a propriedade **`Symbol.toPrimitive`** pode ser 
 ```js
 // Um objeto sem propriedade Symbol.toPrimitive.
 var obj1 = {};
-console.log(+obj1);     // NaN
+console.log(+obj1); // NaN
 console.log(`${obj1}`); // "[object Object]"
-console.log(obj1 + ''); // "[object Object]"
+console.log(obj1 + ""); // "[object Object]"
 
 // Um objeto com propriedade Symbol.toPrimitive
 var obj2 = {
   [Symbol.toPrimitive](hint) {
-    if (hint == 'number') {
+    if (hint == "number") {
       return 10;
     }
-    if (hint == 'string') {
-      return 'hello';
+    if (hint == "string") {
+      return "hello";
     }
     return true;
-  }
+  },
 };
-console.log(+obj2);     // 10        -- dica é "number"
+console.log(+obj2); // 10        -- dica é "number"
 console.log(`${obj2}`); // "hello"   -- dica é "string"
-console.log(obj2 + ''); // "true"    -- dica é "default"
+console.log(obj2 + ""); // "true"    -- dica é "default"
 ```
 
 ## Especificações
 
-| Especificação                                                                                    |
-| ------------------------------------------------------------------------------------------------ |
+| Especificação                                                            |
+| ------------------------------------------------------------------------ |
 | {{SpecName('ESDraft', '#sec-symbol.toprimitive', 'Symbol.toPrimitive')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/tostringtag/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/tostringtag/index.md
@@ -14,19 +14,19 @@ O símbolo **`Symbol.toStringTag`** é uma propriedade com valor string que é u
 ### Tags padrões
 
 ```js
-Object.prototype.toString.call('foo');     // "[object String]"
-Object.prototype.toString.call([1, 2]);    // "[object Array]"
-Object.prototype.toString.call(3);         // "[object Number]"
-Object.prototype.toString.call(true);      // "[object Boolean]"
+Object.prototype.toString.call("foo"); // "[object String]"
+Object.prototype.toString.call([1, 2]); // "[object Array]"
+Object.prototype.toString.call(3); // "[object Number]"
+Object.prototype.toString.call(true); // "[object Boolean]"
 Object.prototype.toString.call(undefined); // "[object Undefined]"
-Object.prototype.toString.call(null);      // "[object Null]"
+Object.prototype.toString.call(null); // "[object Null]"
 // ... e mais
 ```
 
 ### Símbolos built-in toStringTag
 
 ```js
-Object.prototype.toString.call(new Map());       // "[object Map]"
+Object.prototype.toString.call(new Map()); // "[object Map]"
 Object.prototype.toString.call(function* () {}); // "[object GeneratorFunction]"
 Object.prototype.toString.call(Promise.resolve()); // "[object Promise]"
 // ... e mais
@@ -49,7 +49,7 @@ Agora, com a ajuda do `toStringTag`, você é capaz de costumizar sua própria t
 ```js
 class ValidatorClass {
   get [Symbol.toStringTag]() {
-    return 'Validator';
+    return "Validator";
   }
 }
 
@@ -61,15 +61,15 @@ Object.prototype.toString.call(new ValidatorClass()); // "[object Validator]"
 Devido a uma mudança nas especificações [WebIDL spec change](https://github.com/heycam/webidl/pull/357) em meados de 2020, navegadores estão adicionando uma propriedade `Symbol.toStringTag` para todos os objetos protótipos da DOM . Por exemplo, para acessar a propriedade `Symbol.toStringTag` no {{domxref("HTMLButtonElement")}}:
 
 ```js
-let test = document.createElement('button');
+let test = document.createElement("button");
 test.toString(); // Retorna [object HTMLButtonElement]
-test[Symbol.toStringTag];  // Retona HTMLButtonElement
+test[Symbol.toStringTag]; // Retona HTMLButtonElement
 ```
 
 ## Especificações
 
-| Especificação                                                                                    |
-| ------------------------------------------------------------------------------------------------ |
+| Especificação                                                            |
+| ------------------------------------------------------------------------ |
 | {{SpecName('ESDraft', '#sec-symbol.tostringtag', 'Symbol.toStringTag')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/symbol/unscopables/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/symbol/unscopables/index.md
@@ -27,7 +27,7 @@ O seguinte código funciona normalmente no ES5 e anteriores. Entretanto, no ECMA
 var keys = [];
 
 with (Array.prototype) {
-  keys.push('something');
+  keys.push("something");
 }
 
 Object.keys(Array.prototype[Symbol.unscopables]);
@@ -42,12 +42,12 @@ Você também pode configurar `unscopables` para seu próprio objeot.
 ```js
 var obj = {
   foo: 1,
-  bar: 2
+  bar: 2,
 };
 
 obj[Symbol.unscopables] = {
   foo: false,
-  bar: true
+  bar: true,
 };
 
 with (obj) {
@@ -58,8 +58,8 @@ with (obj) {
 
 ## Especificações
 
-| Especificação                                                                                    |
-| ------------------------------------------------------------------------------------------------ |
+| Especificação                                                            |
+| ------------------------------------------------------------------------ |
 | {{SpecName('ESDraft', '#sec-symbol.unscopables', 'Symbol.unscopables')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/typedarray/index.md
@@ -41,7 +41,7 @@ Float64Array();
 
 ## Description
 
-ECMAScript 2015 defines a _TypedArray_ constructor that serves as the `[[Prototype]]` of all _TypedArray_ constructors. This constructor is not directly exposed: there is no global `%TypedArray%` or `TypedArray` property. It is only directly accessible through `Object.getPrototypeOf(Int8Array)` and similar. All _TypedArray_s constructors inherit common properties from the `%TypedArray%` constructor function. Additionally, all typed array prototypes (`TypedArray.prototype`) have `%TypedArray%.prototype` as their `[[Prototype]]`.
+ECMAScript 2015 defines a _TypedArray_ constructor that serves as the `[[Prototype]]` of all _TypedArray_ constructors. This constructor is not directly exposed: there is no global `%TypedArray%` or `TypedArray` property. It is only directly accessible through `Object.getPrototypeOf(Int8Array)` and similar. All `TypedArray`s constructors inherit common properties from the `%TypedArray%` constructor function. Additionally, all typed array prototypes (`TypedArray.prototype`) have `%TypedArray%.prototype` as their `[[Prototype]]`.
 
 The `%TypedArray%` constructor on its own is not particularly useful. Calling it or using it in a `new` expression will throw a `TypeError`, except when used during object creation in JS engines that support subclassing. There are at present no such engines, so `%TypedArray%` is only useful to polyfill functions or properties onto all _TypedArray_ constructors.
 
@@ -58,33 +58,33 @@ int16[0] = 42;
 console.log(int16[0]); // 42
 
 // Indexed properties on prototypes are not consulted (Fx 25)
-Int8Array.prototype[20] = 'foo';
-(new Int8Array(32))[20]; // 0
+Int8Array.prototype[20] = "foo";
+new Int8Array(32)[20]; // 0
 // even when out of bound
-Int8Array.prototype[20] = 'foo';
-(new Int8Array(8))[20]; // undefined
+Int8Array.prototype[20] = "foo";
+new Int8Array(8)[20]; // undefined
 // or with negative integers
-Int8Array.prototype[-1] = 'foo';
-(new Int8Array(8))[-1]; // undefined
+Int8Array.prototype[-1] = "foo";
+new Int8Array(8)[-1]; // undefined
 
 // Named properties are allowed, though (Fx 30)
-Int8Array.prototype.foo = 'bar';
-(new Int8Array(32)).foo; // "bar"
+Int8Array.prototype.foo = "bar";
+new Int8Array(32).foo; // "bar"
 ```
 
 ## TypedArray objects
 
-| Type                                     | Size in bytes | Description                            | Web IDL type          | Equivalent C type |
-| ---------------------------------------- | ------------- | -------------------------------------- | --------------------- | ----------------- |
+| Type                            | Size in bytes | Description                            | Web IDL type          | Equivalent C type |
+| ------------------------------- | ------------- | -------------------------------------- | --------------------- | ----------------- |
 | {{jsxref("Int8Array")}}         | 1             | 8-bit two's complement signed integer  | `byte`                | `int8_t`          |
-| {{jsxref("Uint8Array")}}         | 1             | 8-bit unsigned integer                 | `octet`               | `uint8_t`         |
+| {{jsxref("Uint8Array")}}        | 1             | 8-bit unsigned integer                 | `octet`               | `uint8_t`         |
 | {{jsxref("Uint8ClampedArray")}} | 1             | 8-bit unsigned integer (clamped)       | `octet`               | `uint8_t`         |
-| {{jsxref("Int16Array")}}         | 2             | 16-bit two's complement signed integer | `short`               | `int16_t`         |
-| {{jsxref("Uint16Array")}}         | 2             | 16-bit unsigned integer                | `unsigned short`      | `uint16_t`        |
-| {{jsxref("Int32Array")}}         | 4             | 32-bit two's complement signed integer | `long`                | `int32_t`         |
-| {{jsxref("Uint32Array")}}         | 4             | 32-bit unsigned integer                | `unsigned long`       | `uint32_t`        |
-| {{jsxref("Float32Array")}}     | 4             | 32-bit IEEE floating point number      | `unrestricted float`  | `float`           |
-| {{jsxref("Float64Array")}}     | 8             | 64-bit IEEE floating point number      | `unrestricted double` | `double`          |
+| {{jsxref("Int16Array")}}        | 2             | 16-bit two's complement signed integer | `short`               | `int16_t`         |
+| {{jsxref("Uint16Array")}}       | 2             | 16-bit unsigned integer                | `unsigned short`      | `uint16_t`        |
+| {{jsxref("Int32Array")}}        | 4             | 32-bit two's complement signed integer | `long`                | `int32_t`         |
+| {{jsxref("Uint32Array")}}       | 4             | 32-bit unsigned integer                | `unsigned long`       | `uint32_t`        |
+| {{jsxref("Float32Array")}}      | 4             | 32-bit IEEE floating point number      | `unrestricted float`  | `float`           |
+| {{jsxref("Float64Array")}}      | 8             | 64-bit IEEE floating point number      | `unrestricted double` | `double`          |
 
 ## Properties
 
@@ -120,10 +120,10 @@ All _TypedArrays_ inherit from {{jsxref("TypedArray.prototype")}}.
 
 ## Specifications
 
-| Specification                                                                                    | Status                           | Comment                                                                                                                         |
-| ------------------------------------------------------------------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('Typed Array')}}                                                             | {{Spec2('Typed Array')}} | Defined as `TypedArray` and `ArrayBufferView` interface with typed array view types. Superseded by ECMAScript 2015.             |
-| {{SpecName('ES6', '#sec-typedarray-objects', 'TypedArray Objects')}}     | {{Spec2('ES6')}}             | Initial definition in an ECMA standard. Specified behaviour for indexed and named properties. Specified that `new` is required. |
+| Specification                                                            | Status                   | Comment                                                                                                                         |
+| ------------------------------------------------------------------------ | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| {{SpecName('Typed Array')}}                                              | {{Spec2('Typed Array')}} | Defined as `TypedArray` and `ArrayBufferView` interface with typed array view types. Superseded by ECMAScript 2015.             |
+| {{SpecName('ES6', '#sec-typedarray-objects', 'TypedArray Objects')}}     | {{Spec2('ES6')}}         | Initial definition in an ECMA standard. Specified behaviour for indexed and named properties. Specified that `new` is required. |
 | {{SpecName('ESDraft', '#sec-typedarray-objects', 'TypedArray Objects')}} | {{Spec2('ESDraft')}}     |                                                                                                                                 |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/typedarray/sort/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/typedarray/sort/index.md
@@ -48,9 +48,9 @@ numbers.sort(compareNumbers);
 
 ## Especificações
 
-| Especificações                                                                                                       | Status                       | Comentários        |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('ES2015', '#sec-%typedarray%.prototype.sort', 'TypedArray.prototype.sort')}} | {{Spec2('ES2015')}}     | Definição inicial. |
+| Especificações                                                                           | Status               | Comentários        |
+| ---------------------------------------------------------------------------------------- | -------------------- | ------------------ |
+| {{SpecName('ES2015', '#sec-%typedarray%.prototype.sort', 'TypedArray.prototype.sort')}}  | {{Spec2('ES2015')}}  | Definição inicial. |
 | {{SpecName('ESDraft', '#sec-%typedarray%.prototype.sort', 'TypedArray.prototype.sort')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/typeerror/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/typeerror/index.md
@@ -54,12 +54,12 @@ try {
   null.f();
 } catch (e) {
   console.log(e instanceof TypeError); // true
-  console.log(e.message);              // "null has no properties"
-  console.log(e.name);                 // "TypeError"
-  console.log(e.fileName);             // "Scratchpad/1"
-  console.log(e.lineNumber);           // 2
-  console.log(e.columnNumber);         // 2
-  console.log(e.stack);                // "@Scratchpad/2:2:3\n"
+  console.log(e.message); // "null has no properties"
+  console.log(e.name); // "TypeError"
+  console.log(e.fileName); // "Scratchpad/1"
+  console.log(e.lineNumber); // 2
+  console.log(e.columnNumber); // 2
+  console.log(e.stack); // "@Scratchpad/2:2:3\n"
 }
 ```
 
@@ -67,25 +67,25 @@ try {
 
 ```js
 try {
-  throw new TypeError('Hello', "someFile.js", 10);
+  throw new TypeError("Hello", "someFile.js", 10);
 } catch (e) {
   console.log(e instanceof TypeError); // true
-  console.log(e.message);              // "Hello"
-  console.log(e.name);                 // "TypeError"
-  console.log(e.fileName);             // "someFile.js"
-  console.log(e.lineNumber);           // 10
-  console.log(e.columnNumber);         // 0
-  console.log(e.stack);                // "@Scratchpad/2:2:9\n"
+  console.log(e.message); // "Hello"
+  console.log(e.name); // "TypeError"
+  console.log(e.fileName); // "someFile.js"
+  console.log(e.lineNumber); // 10
+  console.log(e.columnNumber); // 0
+  console.log(e.stack); // "@Scratchpad/2:2:9\n"
 }
 ```
 
 ## Especificações
 
-| Specification                                                                                                            | Status                   | Comment            |
-| ------------------------------------------------------------------------------------------------------------------------ | ------------------------ | ------------------ |
-| {{SpecName('ES6', '#sec-native-error-types-used-in-this-standard-typeerror', 'TypeError')}} | {{Spec2('ES6')}}     |                    |
-| {{SpecName('ES5.1', '#sec-15.11.6.5', 'TypeError')}}                                                     | {{Spec2('ES5.1')}} |                    |
-| {{SpecName('ES3', '#sec-15.11.6.5', 'TypeError')}}                                                     | {{Spec2('ES3')}}     | Initial definition |
+| Specification                                                                               | Status             | Comment            |
+| ------------------------------------------------------------------------------------------- | ------------------ | ------------------ |
+| {{SpecName('ES6', '#sec-native-error-types-used-in-this-standard-typeerror', 'TypeError')}} | {{Spec2('ES6')}}   |                    |
+| {{SpecName('ES5.1', '#sec-15.11.6.5', 'TypeError')}}                                        | {{Spec2('ES5.1')}} |                    |
+| {{SpecName('ES3', '#sec-15.11.6.5', 'TypeError')}}                                          | {{Spec2('ES3')}}   | Initial definition |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/undefined/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/undefined/index.md
@@ -29,10 +29,15 @@ Uma vez que undefined não é uma {{jsxref("Reserved_Words", "palavra reservada"
 
 ```js
 // escreve no console "foo string"
-(function(){ var undefined = 'foo'; console.log(undefined, typeof undefined); })();
+(function () {
+  var undefined = "foo";
+  console.log(undefined, typeof undefined);
+})();
 
 // escreve no console "foo string"
-(function(undefined){ console.log(undefined, typeof undefined); })('foo');
+(function (undefined) {
+  console.log(undefined, typeof undefined);
+})("foo");
 ```
 
 ## Exemplos
@@ -44,10 +49,9 @@ Voce pode utilizar `undefined` com os operadores de igualdade e desigualdade est
 ```js
 var x;
 if (x === undefined) {
-   // sentenças aqui são executadas
-}
-else {
-   // o código aqui não é executado
+  // sentenças aqui são executadas
+} else {
+  // o código aqui não é executado
 }
 ```
 
@@ -59,8 +63,8 @@ Alternativamente, {{jsxref("Operators/typeof", "typeof")}} pode ser usado:
 
 ```js
 var x;
-if (typeof x === 'undefined') {
-   // esse código é executado
+if (typeof x === "undefined") {
+  // esse código é executado
 }
 ```
 
@@ -68,12 +72,13 @@ Uma das principais razões para usar o {{jsxref("Operators/typeof", "typeof")}} 
 
 ```js
 // x não foi atribuída anteriormente
-if (typeof x === 'undefined') { // retorna verdadeiro sem lançar erros
-   // esse código executa
+if (typeof x === "undefined") {
+  // retorna verdadeiro sem lançar erros
+  // esse código executa
 }
 
-if(x === undefined){ // lança um ReferenceError para x
-
+if (x === undefined) {
+  // lança um ReferenceError para x
 }
 ```
 
@@ -86,22 +91,22 @@ O operador {{jsxref("Operators/void", "void")}} é a terceira alternativa.
 ```js
 var x;
 if (x === void 0) {
-   // esse código executa
+  // esse código executa
 }
 
 // y não foi definido antes
 if (y === void 0) {
-   // lança uma ReferenceError (ao contrário de `typeof`)
+  // lança uma ReferenceError (ao contrário de `typeof`)
 }
 ```
 
 ## Especificação
 
-| Especificação                                                        | Status                   | Comentários                                       |
-| -------------------------------------------------------------------- | ------------------------ | ------------------------------------------------- |
-| ECMAScript 1st Edition.                                              | Standard                 | Definição inicial. Implementado no JavaScript 1.3 |
+| Especificação                                       | Status             | Comentários                                       |
+| --------------------------------------------------- | ------------------ | ------------------------------------------------- |
+| ECMAScript 1st Edition.                             | Standard           | Definição inicial. Implementado no JavaScript 1.3 |
 | {{SpecName('ES5.1', '#sec-15.1.1.3', 'undefined')}} | {{Spec2('ES5.1')}} |                                                   |
-| {{SpecName('ES6', '#sec-undefined', 'undefined')}} | {{Spec2('ES6')}}     |                                                   |
+| {{SpecName('ES6', '#sec-undefined', 'undefined')}}  | {{Spec2('ES6')}}   |                                                   |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/global_objects/unescape/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/unescape/index.md
@@ -29,18 +29,18 @@ A função `unescape` é uma propriedade do objeto global.
 ## Exemplos
 
 ```js
-unescape('abc123');     // "abc123"
-unescape('%E4%F6%FC');  // "äöü"
-unescape('%u0107');     // "ć"
+unescape("abc123"); // "abc123"
+unescape("%E4%F6%FC"); // "äöü"
+unescape("%u0107"); // "ć"
 ```
 
 ## Specifications
 
-| Specification                                                                    | Status                       | Comment                                                                               |
-| -------------------------------------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------- |
-| {{SpecName('ES1', '#sec-15.1.2.5', 'unescape')}}                 | {{Spec2('ES1')}}         | Definição Inicial.                                                                    |
-| {{SpecName('ES5.1', '#sec-B.2.2', 'unescape')}}                 | {{Spec2('ES5.1')}}     | Definido na compatibilidade Annex B                                                   |
-| {{SpecName('ES6', '#sec-unescape-string', 'unescape')}}         | {{Spec2('ES6')}}         | Difinito na (normativa) Annex B Para novidades adicionais do ECMAScript para browsers |
+| Specification                                               | Status               | Comment                                                                               |
+| ----------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------- |
+| {{SpecName('ES1', '#sec-15.1.2.5', 'unescape')}}            | {{Spec2('ES1')}}     | Definição Inicial.                                                                    |
+| {{SpecName('ES5.1', '#sec-B.2.2', 'unescape')}}             | {{Spec2('ES5.1')}}   | Definido na compatibilidade Annex B                                                   |
+| {{SpecName('ES6', '#sec-unescape-string', 'unescape')}}     | {{Spec2('ES6')}}     | Difinito na (normativa) Annex B Para novidades adicionais do ECMAScript para browsers |
 | {{SpecName('ESDraft', '#sec-unescape-string', 'unescape')}} | {{Spec2('ESDraft')}} | Difinito na (normativa) Annex B Para novidades adicionais do ECMAScript para browsers |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/weakmap/delete/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/weakmap/delete/index.md
@@ -30,18 +30,18 @@ wm.delete(key);
 
 ```js
 var wm = new WeakMap();
-wm.set(window, 'foo');
+wm.set(window, "foo");
 
 console.log(wm.delete(window)); // Retorna true. Removido com sucesso.
 
-wm.has(window);    // Retorna false. O objeto window não é mais pertecente ao WeakMap.
+wm.has(window); // Retorna false. O objeto window não é mais pertecente ao WeakMap.
 ```
 
 ## Especificações
 
-| Especificação                                                                                                    | Status                       | Comentário        |
-| ---------------------------------------------------------------------------------------------------------------- | ---------------------------- | ----------------- |
-| {{SpecName('ES2015', '#sec-weakmap.prototype.delete', 'WeakMap.prototype.delete')}} | {{Spec2('ES2015')}}     | Definição inicial |
+| Especificação                                                                        | Status               | Comentário        |
+| ------------------------------------------------------------------------------------ | -------------------- | ----------------- |
+| {{SpecName('ES2015', '#sec-weakmap.prototype.delete', 'WeakMap.prototype.delete')}}  | {{Spec2('ES2015')}}  | Definição inicial |
 | {{SpecName('ESDraft', '#sec-weakmap.prototype.delete', 'WeakMap.prototype.delete')}} | {{Spec2('ESDraft')}} |                   |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/weakmap/get/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/weakmap/get/index.md
@@ -30,17 +30,17 @@ O elemento associado à chave especificada no objeto `WeakMap`. Se a chave não 
 
 ```js
 var wm = new WeakMap();
-wm.set(window, 'foo');
+wm.set(window, "foo");
 
 wm.get(window); // Retorna "foo".
-wm.get('baz');  // Retorna undefined.
+wm.get("baz"); // Retorna undefined.
 ```
 
 ## Especificações
 
-| Specification                                                                                            | Status                       | Comment             |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES2015', '#sec-weakmap.prototype.get', 'WeakMap.prototype.get')}} | {{Spec2('ES2015')}}     | Initial definition. |
+| Specification                                                                  | Status               | Comment             |
+| ------------------------------------------------------------------------------ | -------------------- | ------------------- |
+| {{SpecName('ES2015', '#sec-weakmap.prototype.get', 'WeakMap.prototype.get')}}  | {{Spec2('ES2015')}}  | Initial definition. |
 | {{SpecName('ESDraft', '#sec-weakmap.prototype.get', 'WeakMap.prototype.get')}} | {{Spec2('ESDraft')}} |                     |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/weakmap/has/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/weakmap/has/index.md
@@ -31,17 +31,17 @@ wm.has(chave);
 
 ```js
 var wm = new WeakMap();
-wm.set(window, 'foo');
+wm.set(window, "foo");
 
 wm.has(window); // retorna true
-wm.has('baz');  // retorna false
+wm.has("baz"); // retorna false
 ```
 
 ## Especificações
 
-| Specification                                                                                            | Status                       | Comment             |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES2015', '#sec-weakmap.prototype.has', 'WeakMap.prototype.has')}} | {{Spec2('ES2015')}}     | Initial definition. |
+| Specification                                                                  | Status               | Comment             |
+| ------------------------------------------------------------------------------ | -------------------- | ------------------- |
+| {{SpecName('ES2015', '#sec-weakmap.prototype.has', 'WeakMap.prototype.has')}}  | {{Spec2('ES2015')}}  | Initial definition. |
 | {{SpecName('ESDraft', '#sec-weakmap.prototype.has', 'WeakMap.prototype.has')}} | {{Spec2('ESDraft')}} |                     |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/weakmap/index.md
@@ -53,11 +53,11 @@ Por conta das referências serem fracas, chaves de `WeakMap` não são enumeráv
 
 ```js
 var wm1 = new WeakMap(),
-    wm2 = new WeakMap(),
-    wm3 = new WeakMap();
+  wm2 = new WeakMap(),
+  wm3 = new WeakMap();
 var o1 = {},
-    o2 = function(){},
-    o3 = window;
+  o2 = function () {},
+  o3 = window;
 
 wm1.set(o1, 37);
 wm1.set(o2, "azerty");
@@ -78,16 +78,16 @@ wm3.get(o1); // 37
 wm3.clear();
 wm3.get(o1); // undefined, pois wm3 foi 'limpado' e não há mais valor para o1.
 
-wm1.has(o1);   // true
+wm1.has(o1); // true
 wm1.delete(o1);
-wm1.has(o1);   // false
+wm1.has(o1); // false
 ```
 
 ## Especificações
 
-| Especificações                                                               | Status                       | Comentário         |
-| ---------------------------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('ES2015', '#sec-weakmap-objects', 'WeakMap')}} | {{Spec2('ES2015')}}     | Definição inicial. |
+| Especificações                                             | Status               | Comentário         |
+| ---------------------------------------------------------- | -------------------- | ------------------ |
+| {{SpecName('ES2015', '#sec-weakmap-objects', 'WeakMap')}}  | {{Spec2('ES2015')}}  | Definição inicial. |
 | {{SpecName('ESDraft', '#sec-weakmap-objects', 'WeakMap')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/weakmap/set/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/weakmap/set/index.md
@@ -35,17 +35,17 @@ var wm = new WeakMap();
 var obj = {};
 
 // Adicionar novos elementos ao WeakMap
-wm.set(obj, 'foo').set(window, 'bar'); // encadeável
+wm.set(obj, "foo").set(window, "bar"); // encadeável
 
 // Atualizar um elemento no WeakMap
-wm.set(obj, 'baz');
+wm.set(obj, "baz");
 ```
 
 ## Especificações
 
-| Specification                                                                                            | Status                       | Comment             |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES2015', '#sec-weakmap.prototype.set', 'WeakMap.prototype.set')}} | {{Spec2('ES2015')}}     | Initial definition. |
+| Specification                                                                  | Status               | Comment             |
+| ------------------------------------------------------------------------------ | -------------------- | ------------------- |
+| {{SpecName('ES2015', '#sec-weakmap.prototype.set', 'WeakMap.prototype.set')}}  | {{Spec2('ES2015')}}  | Initial definition. |
 | {{SpecName('ESDraft', '#sec-weakmap.prototype.set', 'WeakMap.prototype.set')}} | {{Spec2('ESDraft')}} |                     |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/global_objects/weakset/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/weakset/index.md
@@ -57,17 +57,17 @@ ws.add(window);
 ws.add(obj);
 
 ws.has(window); // true
-ws.has(foo);    // false, foo não foi adicionado ao set
+ws.has(foo); // false, foo não foi adicionado ao set
 
 ws.delete(window); // remove window do set
-ws.has(window);    // false, window foi removido
+ws.has(window); // false, window foi removido
 ```
 
 ## Especificações
 
-| Especificação                                                                | Status                       | Comentário        |
-| ---------------------------------------------------------------------------- | ---------------------------- | ----------------- |
-| {{SpecName('ES6', '#sec-weakset-objects', 'WeakSet')}}     | {{Spec2('ES6')}}         | Definição inicial |
+| Especificação                                              | Status               | Comentário        |
+| ---------------------------------------------------------- | -------------------- | ----------------- |
+| {{SpecName('ES6', '#sec-weakset-objects', 'WeakSet')}}     | {{Spec2('ES6')}}     | Definição inicial |
 | {{SpecName('ESDraft', '#sec-weakset-objects', 'WeakSet')}} | {{Spec2('ESDraft')}} |                   |
 
 ## Compatilidade de Browser

--- a/files/pt-br/web/javascript/reference/iteration_protocols/index.md
+++ b/files/pt-br/web/javascript/reference/iteration_protocols/index.md
@@ -75,10 +75,12 @@ Um objeto é um iterador quando implementa um método **`next()`** com a semânt
 >
 > ```js
 > var myIterator = {
->     next: function() {
->         // ...
->     },
->     [Symbol.iterator]: function() { return this }
+>   next: function () {
+>     // ...
+>   },
+>   [Symbol.iterator]: function () {
+>     return this;
+>   },
 > };
 > ```
 
@@ -87,25 +89,25 @@ Um objeto é um iterador quando implementa um método **`next()`** com a semânt
 Uma {{jsxref("String")}} é um exemplo de um objeto iterable built-in:
 
 ```js
-var someString = 'hi';
-typeof someString[Symbol.iterator];          // "function"
+var someString = "hi";
+typeof someString[Symbol.iterator]; // "function"
 ```
 
 [O iterador padrão](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/String/@@iterator) de uma string retorna as posições dos caracteres de uma string um por um:
 
 ```js
 var iterator = someString[Symbol.iterator]();
-iterator + '';                               // "[object String Iterator]"
+iterator + ""; // "[object String Iterator]"
 
-iterator.next();                             // { value: "h", done: false }
-iterator.next();                             // { value: "i", done: false }
-iterator.next();                             // { value: undefined, done: true }
+iterator.next(); // { value: "h", done: false }
+iterator.next(); // { value: "i", done: false }
+iterator.next(); // { value: undefined, done: true }
 ```
 
 Alguns construtores built-in, como _[spread syntax](/pt-BR/docs/Web/JavaScript/Reference/Operators/Spread_syntax)_, usam o mesmo protocolo de iteração interiormente:
 
 ```js
-[...someString]                              // ["h", "i"]
+[...someString]; // ["h", "i"]
 ```
 
 Podemos redefinir o comportamento de iteração fornecendo nosso próprio `@@iterator`:
@@ -131,8 +133,8 @@ someString[Symbol.iterator] = function() {
 Observe como redefinir `@@iterator` afeta o comportamento built-in que faz uso do protocolo de iteração:
 
 ```js
-[...someString];                             // ["bye"]
-someString + '';                             // "hi"
+[...someString]; // ["bye"]
+someString + ""; // "hi"
 ```
 
 ## Exemplos de Iteráveis
@@ -338,9 +340,9 @@ aGeneratorObject[Symbol.iterator]() === aGeneratorObject;
 
 ## Especificações
 
-| Especificação                                                            | Status                       | Comentário         |
-| ------------------------------------------------------------------------ | ---------------------------- | ------------------ |
-| {{SpecName('ES2015', '#sec-iteration', 'Iteration')}} | {{Spec2('ES2015')}}     | Definição inicial. |
+| Especificação                                          | Status               | Comentário         |
+| ------------------------------------------------------ | -------------------- | ------------------ |
+| {{SpecName('ES2015', '#sec-iteration', 'Iteration')}}  | {{Spec2('ES2015')}}  | Definição inicial. |
 | {{SpecName('ESDraft', '#sec-iteration', 'Iteration')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Veja também

--- a/files/pt-br/web/javascript/reference/lexical_grammar/index.md
+++ b/files/pt-br/web/javascript/reference/lexical_grammar/index.md
@@ -54,7 +54,7 @@ O primeiro é com o uso de duas barras `//`; isso faz com que qualquer coisa esc
 ```js
 function comment() {
   // Isto é um comentário de uma linha em JavaScript
-  console.log('Hello world!');
+  console.log("Hello world!");
 }
 comment();
 ```
@@ -66,7 +66,7 @@ Por exemplo, você pode usá-lo em uma única linha:
 ```js
 function comment() {
   /* Isto é um comentário de uma linha em JavaScript */
-  console.log('Hello world!');
+  console.log("Hello world!");
 }
 comment();
 ```
@@ -77,7 +77,7 @@ Ou pode fazer um comentário de várias linhas, desta forma:
 function comment() {
   /* Este é um comentário de várias linhas. Observe que
  não precisamos encerrar o comentário até terminar. */
-  console.log('Hello world!');
+  console.log("Hello world!");
 }
 comment();
 ```
@@ -86,9 +86,9 @@ Você também pode usá-lo no meio de uma linha, se quiser, porém isto pode tor
 
 ```js
 function comment(x) {
-  console.log('Hello ' + x /* insira o valor de x */ + ' !');
+  console.log("Hello " + x /* insira o valor de x */ + " !");
 }
-comment('world');
+comment("world");
 ```
 
 Além disso, você pode usá-lo para desativar algum código para evitar que seja executado, envolvendo o código em um comentário, assim:
@@ -209,7 +209,7 @@ function import() {} // Proibido.
 Veja também [`null`](/pt-BR/docs/Web/JavaScript/Reference/Operators/null) para mais informações.
 
 ```js
-null
+null;
 ```
 
 ### Booleanos
@@ -217,8 +217,8 @@ null
 Veja também [`Boolean`](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Boolean) para mais informações.
 
 ```js
-true
-false
+true;
+false;
 ```
 
 ### Números
@@ -226,12 +226,12 @@ false
 #### Decimal
 
 ```js
-1234567890
-42
+1234567890;
+42;
 
 // Cuidado com o uso precedido de zero:
-0888 // 888 convertido como decimal
-0777 // Convertido como octal, 511 em decimal
+0888; // 888 convertido como decimal
+0777; // Convertido como octal, 511 em decimal
 ```
 
 Veja que números decimais podem começar com zero (`0`) seguido de outro dígito decimal, porém se todos dígitos após o zero inicial forem menores que 8, o número é interpretado como um número octal. Isso não vai disparar um erro em JavaScript, veja [Erro do Firefox 957513](https://bugzil.la/957513). Veja também esta página sobre conversão de tipo [`parseInt()`](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/parseInt#octal_interpretations_with_no_radix).
@@ -241,9 +241,9 @@ Veja que números decimais podem começar com zero (`0`) seguido de outro dígit
 Números binários em JavaScript são iniciados em zero seguido da letra "B" em maiúsculo ou minúsculo (`0b` ou `0B`). Esta sintaxe é nova no ECMAScript 2015, por isso verifique a compatibilidade do navegador. Se o dígito seguinte ao `0b` não for 0 ou 1, o seguinte [erro de sintaxe](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError) é disparado: "Missing binary digits after 0b".
 
 ```js
-var FLT_SIGNBIT  = 0b10000000000000000000000000000000; // 2147483648
+var FLT_SIGNBIT = 0b10000000000000000000000000000000; // 2147483648
 var FLT_EXPONENT = 0b01111111100000000000000000000000; // 2139095040
-var FLT_MANTISSA = 0B00000000011111111111111111111111; // 8388607
+var FLT_MANTISSA = 0b00000000011111111111111111111111; // 8388607
 ```
 
 #### Octal
@@ -251,12 +251,12 @@ var FLT_MANTISSA = 0B00000000011111111111111111111111; // 8388607
 Números octais em JavaScript são escritos com zero inicial seguido da letra "O" em maiúsculo ou minúsculo (`0o` ou `0O)`. Esta sintaxe é nova no ECMAScript 2015, por isso verifique a compatibilidade do navegador. Se os dígitos após o `0o não forem octais válidos` (01234567), o seguinte [erro de sintaxe](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError) será disparado: "Missing octal digits after 0o".
 
 ```js
-var n = 0O755; // 493
+var n = 0o755; // 493
 var m = 0o644; // 420
 
 // Também é possível com apenas um zero no início (veja sobre decimais acima)
-0755
-0644
+0755;
+0644;
 ```
 
 #### Hexadecimal
@@ -264,9 +264,9 @@ var m = 0o644; // 420
 Números hexadecimais em JavaScript são iniciados com zero seguido da letra "X" em maiúsculo ou minúsculo (`0x` ou `0X)`. Se os dígitos após o 0x não forem hexadecimais válidos (0123456789ABCDEF), o seguinte [erro de sintaxe](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError) será disparado: "Identifier starts immediately after numeric literal".
 
 ```js
-0xFFFFFFFFFFFFFFFFF // 295147905179352830000
-0x123456789ABCDEF   // 81985529216486900
-0XA                 // 10
+0xfffffffffffffffff; // 295147905179352830000
+0x123456789abcdef; // 81985529216486900
+0xa; // 10
 ```
 
 ### Objetos
@@ -274,11 +274,13 @@ Números hexadecimais em JavaScript são iniciados com zero seguido da letra "X"
 Veja também {{jsxref("Object")}} e [Object initializer](/pt-BR/docs/Web/JavaScript/Reference/Operators/Object_initializer) para mais informações.
 
 ```js
-var o = { a: 'foo', b: 'bar', c: 42 };
+var o = { a: "foo", b: "bar", c: 42 };
 
 // Notação curta. Novidade no ES2015
-var a = 'foo', b = 'bar', c = 42;
-var o = {a, b, c};
+var a = "foo",
+  b = "bar",
+  c = 42;
+var o = { a, b, c };
 
 // instead of
 var o = { a: a, b: b, c: c };
@@ -289,20 +291,20 @@ var o = { a: a, b: b, c: c };
 Veja também {{jsxref("Array")}} para mais informações.
 
 ```js
-[1954, 1974, 1990, 2014]
+[1954, 1974, 1990, 2014];
 ```
 
 ### Strings
 
-```js
-'foo'
-"bar"
+```js-nolint
+'foo';
+"bar";
 ```
 
 #### Caracteres de escape em hexadecimal
 
 ```js
-'\xA9' // "©"
+"\xA9"; // "©"
 ```
 
 #### Caracteres de escape em Unicode
@@ -310,7 +312,7 @@ Veja também {{jsxref("Array")}} para mais informações.
 A representação de caracteres de escape em Unicode requer ao menos quatro caracteres após o `\u`.
 
 ```js
-'\u00A9' // "©"
+"\u00A9"; // "©"
 ```
 
 #### Codificação de caracteres Unicode
@@ -320,10 +322,10 @@ Novidade no ECMAScript 2015. Com a codificação de caracteres Unicode qualquer 
 Veja também {{jsxref("String.fromCodePoint()")}} ou {{jsxref("String.prototype.codePointAt()")}}.
 
 ```js
-'\u{2F804}'
+"\u{2F804}";
 
 // O mesmo usando apenas Unicode
-'\uD87E\uDC04'
+"\uD87E\uDC04";
 ```
 
 ### Expressões regulares
@@ -344,14 +346,14 @@ Veja também [`RegExp`](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/RegE
 Veja também [template strings](/pt-BR/docs/Web/JavaScript/Reference/Template_literals) para mais informações .
 
 ```js
-`texto`
+`texto`;
 
 `linha de texto 1
- linha de texto 2`
+ linha de texto 2`;
 
-`texto ${expressão} texto`
+`texto ${expressão} texto`;
 
-tag `texto ${expressão} texto`
+tag `texto ${expressão} texto`;
 ```
 
 ## Inserção automática de ponto e vírgula
@@ -382,7 +384,7 @@ A especificação ECMAScript menciona [três regras para inserção de ponto e v
 
 Aqui o `++ não é interpretado como operador de incremento aplicado à variável b por que há um finalizador de linha entre o b e ++` .
 
-```js
+```js-nolint
 a = b
 ++c
 
@@ -401,7 +403,7 @@ a = b;
 - `yield`, `yield*`
 - `module`
 
-```js
+```js-nolint
 return
 a + b
 
@@ -413,11 +415,11 @@ a + b;
 
 ## Especificações
 
-| Specification                                                                                                        | Status                       | Comment                                                              |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                             | {{Spec2("ES1")}}         | Definição inicial.                                                   |
-| {{SpecName('ES5.1', '#sec-7', 'Lexical Conventions')}}                                             | {{Spec2('ES5.1')}}     |                                                                      |
-| {{SpecName('ES6', '#sec-ecmascript-language-lexical-grammar', 'Lexical Grammar')}}         | {{Spec2('ES6')}}         | Adicionado: números Binarios e Octais, Unicode code point, Templates |
+| Specification                                                                          | Status               | Comment                                                              |
+| -------------------------------------------------------------------------------------- | -------------------- | -------------------------------------------------------------------- |
+| {{SpecName('ES1')}}                                                                    | {{Spec2("ES1")}}     | Definição inicial.                                                   |
+| {{SpecName('ES5.1', '#sec-7', 'Lexical Conventions')}}                                 | {{Spec2('ES5.1')}}   |                                                                      |
+| {{SpecName('ES6', '#sec-ecmascript-language-lexical-grammar', 'Lexical Grammar')}}     | {{Spec2('ES6')}}     | Adicionado: números Binarios e Octais, Unicode code point, Templates |
 | {{SpecName('ESDraft', '#sec-ecmascript-language-lexical-grammar', 'Lexical Grammar')}} | {{Spec2('ESDraft')}} |                                                                      |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/operators/addition/index.md
+++ b/files/pt-br/web/javascript/reference/operators/addition/index.md
@@ -40,22 +40,22 @@ Você é aconselhado a não usar "" + x para executar a [coerção de string](/p
 
 ```js
 // Number + Number -> adição
-1 + 2 // 3
+1 + 2; // 3
 // Boolean + Number -> adição
-true + 1 // 2
+true + 1; // 2
 // Boolean + Boolean -> adição
-false + false // 0
+false + false; // 0
 ```
 
 ### Concatenação de String
 
 ```js
 // String + String -> concatenação
-'foo' + 'bar' // "foobar"
+"foo" + "bar"; // "foobar"
 // Number + String -> concatenação
-5 + 'foo' // "5foo"
+5 + "foo"; // "5foo"
 // String + Boolean -> concatenação
-'foo' + false // "foofalse"
+"foo" + false; // "foofalse"
 ```
 
 ## Especificações

--- a/files/pt-br/web/javascript/reference/operators/async_function/index.md
+++ b/files/pt-br/web/javascript/reference/operators/async_function/index.md
@@ -34,36 +34,38 @@ Uma expressão `async function` é muito similar, e tem quase a mesma sintaxe de
 
 ```js
 function resolveAfter2Seconds(x) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(() => {
       resolve(x);
     }, 2000);
   });
-};
+}
 
-(async function(x) { // async function expression usada como uma IIFE
+(async function (x) {
+  // async function expression usada como uma IIFE
   var a = resolveAfter2Seconds(20);
   var b = resolveAfter2Seconds(30);
-  return x + await a + await b;
-})(10).then(v => {
-  console.log(v);  // imprime 60 após 2 segundo.
+  return x + (await a) + (await b);
+})(10).then((v) => {
+  console.log(v); // imprime 60 após 2 segundo.
 });
 
-var add = async function(x) { // async function expression atribuída a uma variável
+var add = async function (x) {
+  // async function expression atribuída a uma variável
   var a = await resolveAfter2Seconds(20);
   var b = await resolveAfter2Seconds(30);
   return x + a + b;
 };
 
-add(10).then(v => {
-  console.log(v);  // imprime 60 após 4 segundos.
+add(10).then((v) => {
+  console.log(v); // imprime 60 após 4 segundos.
 });
 ```
 
 ## Especificações
 
-| Especificação                                                                                        | Status                       | Comentário                   |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------- | ---------------------------- |
+| Especificação                                                                | Status               | Comentário                   |
+| ---------------------------------------------------------------------------- | -------------------- | ---------------------------- |
 | {{SpecName('ESDraft', '#sec-async-function-definitions', 'async function')}} | {{Spec2('ESDraft')}} | Definição inicial no ES2017. |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/operators/await/index.md
+++ b/files/pt-br/web/javascript/reference/operators/await/index.md
@@ -30,7 +30,7 @@ Se uma `Promise` é passada para uma expressão `await`, ele espera pela sefinal
 
 ```js
 function resolveAfter2Seconds(x) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(() => {
       resolve(x);
     }, 2000);
@@ -60,7 +60,7 @@ Se a `Promise` for rejeitada, o valor rejeitado é invocado em uma Exception.
 async function f3() {
   try {
     var z = await Promise.reject(30);
-  } catch(e) {
+  } catch (e) {
     console.log(e); // 30
   }
 }
@@ -69,8 +69,8 @@ f3();
 
 ## Especificações
 
-| Especificação                                                                                            | Status                       | Comentário                   |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------- | ---------------------------- |
+| Especificação                                                                 | Status               | Comentário                   |
+| ----------------------------------------------------------------------------- | -------------------- | ---------------------------- |
 | {{SpecName('ESDraft', '#sec-async-function-definitions', 'async functions')}} | {{Spec2('ESDraft')}} | Definição inicial no ES2017. |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/operators/bitwise_and/index.md
+++ b/files/pt-br/web/javascript/reference/operators/bitwise_and/index.md
@@ -53,7 +53,7 @@ A operação AND bit a bit (Bitwase) de qualquer número `x` com `0` produz
 
 ### Usando bitwase AND
 
-``` js
+```js
 //  5: 00000000000000000000000000000101
 //  2: 00000000000000000000000000000010
 5  e  2 ; // 0

--- a/files/pt-br/web/javascript/reference/operators/bitwise_xor/index.md
+++ b/files/pt-br/web/javascript/reference/operators/bitwise_xor/index.md
@@ -19,7 +19,7 @@ a ^ b
 
 Os operandos são convertidos em números inteiros de 32 bits e expressados por uma série de bits (zeros e uns). Numeros com mais de 32 bits descartam seus bits mais significativos. Por exemplo, o número inteiro a seguir com mais de 32 bits será convertido em um número inteiro de 32 bits:
 
-```js
+```plain
 Antes: 11100110111110100000000000000110000000000001
 Depois:            10100000000000000110000000000001
 ```
@@ -60,8 +60,8 @@ Bitwise XORing any number `x` with `0` yields `x`.
 
 ## Especificações
 
-| Specification                                                                                            |
-| -------------------------------------------------------------------------------------------------------- |
+| Specification                                                                   |
+| ------------------------------------------------------------------------------- |
 | {{SpecName('ESDraft', '#prod-BitwiseXORExpression', 'Bitwise XOR expression')}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/operators/class/index.md
+++ b/files/pt-br/web/javascript/reference/operators/class/index.md
@@ -22,7 +22,7 @@ Uma expressão de classe tem uma sintaxe similar a uma [declaração de classe](
 Assim como declarações de classes, o corpo das expressões de classe são executados em [strict mode](/pt-BR/docs/Web/JavaScript/Reference/Strict_mode).
 
 ```js
-'use strict';
+"use strict";
 var Foo = class {}; // propriedade de construtor é opcional
 var Foo = class {}; // Re-declaração é permitida
 
@@ -31,7 +31,7 @@ typeof class {}; //retorna "function"
 
 Foo instanceof Object; // true
 Foo instanceof Function; // true
-class Foo {}; // Throws TypeError, não permite re-declaração
+class Foo {} // Throws TypeError, não permite re-declaração
 ```
 
 ## Exemplos
@@ -44,7 +44,7 @@ Isso é apenas uma simples classe anônima que você pode referir usando a vari�
 var Foo = class {
   constructor() {}
   bar() {
-    return 'Olá mundo!';
+    return "Olá mundo!";
   }
 };
 
@@ -63,7 +63,7 @@ var Foo = class NamedFoo {
   whoIsThere() {
     return NamedFoo.name;
   }
-}
+};
 var bar = new Foo();
 bar.whoIsThere(); // "NamedFoo"
 NamedFoo.name; // ReferenceError: NamedFoo is not defined
@@ -72,11 +72,11 @@ Foo.name; // "NamedFoo"
 
 ## Especificações
 
-| Especificação                                                                                | Situação                     | Comentário         |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('ES2015', '#sec-class-definitions', 'Class definitions')}} | {{Spec2('ES2015')}}     | Definição inicial. |
-| {{SpecName('ES2016', '#sec-class-definitions', 'Class definitions')}} | {{Spec2('ES2016')}}     |                    |
-| {{SpecName('ES2017', '#sec-class-definitions', 'Class definitions')}} | {{Spec2('ES2017')}}     |                    |
+| Especificação                                                          | Situação             | Comentário         |
+| ---------------------------------------------------------------------- | -------------------- | ------------------ |
+| {{SpecName('ES2015', '#sec-class-definitions', 'Class definitions')}}  | {{Spec2('ES2015')}}  | Definição inicial. |
+| {{SpecName('ES2016', '#sec-class-definitions', 'Class definitions')}}  | {{Spec2('ES2016')}}  |                    |
+| {{SpecName('ES2017', '#sec-class-definitions', 'Class definitions')}}  | {{Spec2('ES2017')}}  |                    |
 | {{SpecName('ESDraft', '#sec-class-definitions', 'Class definitions')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/operators/comma_operator/index.md
+++ b/files/pt-br/web/javascript/reference/operators/comma_operator/index.md
@@ -36,11 +36,11 @@ for (var i = 0, j = 9; i <= 9; i++, j--)
 
 ## Especificações
 
-| Specification                                                                    | Status                   | Comment            |
-| -------------------------------------------------------------------------------- | ------------------------ | ------------------ |
-| 1ª Edição ECMAScript.                                                            | Padrão                   | Definição inicial. |
-| {{SpecName('ES5.1', '#sec-11.14', 'Comma operator')}}         | {{Spec2('ES5.1')}} |                    |
-| {{SpecName('ES6', '#sec-comma-operator', 'Comma operator')}} | {{Spec2('ES6')}}     |                    |
+| Specification                                                | Status             | Comment            |
+| ------------------------------------------------------------ | ------------------ | ------------------ |
+| 1ª Edição ECMAScript.                                        | Padrão             | Definição inicial. |
+| {{SpecName('ES5.1', '#sec-11.14', 'Comma operator')}}        | {{Spec2('ES5.1')}} |                    |
+| {{SpecName('ES6', '#sec-comma-operator', 'Comma operator')}} | {{Spec2('ES6')}}   |                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/operators/conditional_operator/index.md
+++ b/files/pt-br/web/javascript/reference/operators/conditional_operator/index.md
@@ -28,7 +28,7 @@ condition ? expr1 : expr2
 Se `condition` é `true`, o operador retornará o valor de `expr1`; se não, ele retorna o valor de `exp2`. Por exemplo, para exibir uma mensagem diferente baseada no valor da variável `isMember`, você poderá utilizar o código (statement) seguinte:
 
 ```js
-"The fee is " + (isMember ? "$2.00" : "$10.00")
+"The fee is " + (isMember ? "$2.00" : "$10.00");
 ```
 
 Conforme o resultado da operação, você também poderá atribuir a variáveis:
@@ -41,32 +41,34 @@ Também são possíveis múltiplas avaliaçãoes ternárias (nota: o operador co
 
 ```js
 var firstCheck = false,
-    secondCheck = false,
-    access = firstCheck ? "Access denied" : secondCheck ? "Access denied" : "Access granted";
+  secondCheck = false,
+  access = firstCheck
+    ? "Access denied"
+    : secondCheck
+    ? "Access denied"
+    : "Access granted";
 
-console.log( access ); // logs "Access granted"
+console.log(access); // logs "Access granted"
 ```
 
 Você também pode usar avaliações ternárias no espaço livre de modo a fazer diferentes operações:
 
 ```js
-var stop = false, age = 16;
+var stop = false,
+  age = 16;
 
-age > 18 ? location.assign("continue.html") : stop = true;
+age > 18 ? location.assign("continue.html") : (stop = true);
 ```
 
 Você também pode fazer mais do que uma única operação em cada caso, separando-os por vírgula:
 
 ```js
-var stop = false, age = 23;
+var stop = false,
+  age = 23;
 
-age > 18 ? (
-    alert("OK, you can go."),
-    location.assign("continue.html")
-) : (
-    stop = true,
-    alert("Sorry, you are much too young!")
-);
+age > 18
+  ? (alert("OK, you can go."), location.assign("continue.html"))
+  : ((stop = true), alert("Sorry, you are much too young!"));
 ```
 
 Você também pode fazer mais de uma operação durante a atribuição de um valor. Neste caso, **o último valor separado por vírgula dentro** dos parênteses **será o valor a ser atribuído**.
@@ -74,28 +76,27 @@ Você também pode fazer mais de uma operação durante a atribuição de um val
 ```js
 var age = 16;
 
-var url = age > 18 ? (
-    alert("OK, you can go."),
- // alert returns "undefined", but it will be ignored because
- // isn't the last comma-separated value of the parenthesis
-    "continue.html" // the value to be assigned if age > 18
-) : (
-    alert("You are much too young!"),
-    alert("Sorry :-("),
- // etc. etc.
-    "stop.html" // the value to be assigned if !(age > 18)
-);
+var url =
+  age > 18
+    ? (alert("OK, you can go."),
+      // alert returns "undefined", but it will be ignored because
+      // isn't the last comma-separated value of the parenthesis
+      "continue.html") // the value to be assigned if age > 18
+    : (alert("You are much too young!"),
+      alert("Sorry :-("),
+      // etc. etc.
+      "stop.html"); // the value to be assigned if !(age > 18)
 
 location.assign(url); // "stop.html"
 ```
 
 ## Especificações
 
-| Especificações                                                                                   | Status                   | Comentários                                       |
-| ------------------------------------------------------------------------------------------------ | ------------------------ | ------------------------------------------------- |
-| ECMAScript 1st Edition.                                                                          | Standard                 | Definição inicial. Implementado em JavaScript 1.0 |
-| {{SpecName('ES5.1', '#sec-11.12', 'The conditional operator')}}             | {{Spec2('ES5.1')}} |                                                   |
-| {{SpecName('ES6', '#sec-conditional-operator', 'Conditional Operator')}} | {{Spec2('ES6')}}     |                                                   |
+| Especificações                                                           | Status             | Comentários                                       |
+| ------------------------------------------------------------------------ | ------------------ | ------------------------------------------------- |
+| ECMAScript 1st Edition.                                                  | Standard           | Definição inicial. Implementado em JavaScript 1.0 |
+| {{SpecName('ES5.1', '#sec-11.12', 'The conditional operator')}}          | {{Spec2('ES5.1')}} |                                                   |
+| {{SpecName('ES6', '#sec-conditional-operator', 'Conditional Operator')}} | {{Spec2('ES6')}}   |                                                   |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/pt-br/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -21,12 +21,12 @@ console.log(a); // 1
 console.log(b); // 2
 console.log(rest); // [3, 4, 5]
 
-({a, b} = {a:1, b:2});
+({ a, b } = { a: 1, b: 2 });
 console.log(a); // 1
 console.log(b); // 2
 
 // ES2016 - não implementado em Firefox 47a01
-({a, b, ...rest} = {a:1, b:2, c:3, d:4});
+({ a, b, ...rest } = { a: 1, b: 2, c: 3, d: 4 });
 ```
 
 ## Descrição
@@ -80,7 +80,7 @@ Uma variável pode ser atribuída de um padrão, no caso em que o valor retirado
 ```js
 var a, b;
 
-[a=5, b=7] = [1];
+[a = 5, b = 7] = [1];
 console.log(a); // 1
 console.log(b); // 7
 ```
@@ -134,7 +134,7 @@ console.log(b); // 3
 Você também pode ignorar todos os valores retornados:
 
 ```js
-[,,] = f();
+[, ,] = f();
 ```
 
 ### Atribuindo o resto de um array para uma variável
@@ -167,8 +167,8 @@ console.log(protocol); // "https"
 ### Atribuição básica
 
 ```js
-var o = {p: 42, q: true};
-var {p, q} = o;
+var o = { p: 42, q: true };
+var { p, q } = o;
 
 console.log(p); // 42
 console.log(q); // true
@@ -181,7 +181,7 @@ Uma variável pode ter seu valor atribuído via desestruturação separadamente 
 ```js
 var a, b;
 
-({a, b} = {a:1, b:2});
+({ a, b } = { a: 1, b: 2 });
 ```
 
 > **Nota:** Os parênteses `( ... )` ao redor da declaração de atribuição é uma sintaxe necessária quando se utiliza a atribuição via desestruturação de objeto literal sem uma declaração.
@@ -195,8 +195,8 @@ var a, b;
 Uma variável pode ser extraída de um objeto e atribuída a uma variável com um nome diferente da propriedade do objeto.
 
 ```js
-var o = {p: 42, q: true};
-var {p: foo, q: bar} = o;
+var o = { p: 42, q: true };
+var { p: foo, q: bar } = o;
 
 console.log(foo); // 42
 console.log(bar); // true
@@ -207,7 +207,7 @@ console.log(bar); // true
 Uma variável pode ser atribuída de um padrão, no caso em que o valor retirado do objeto é undefined.
 
 ```js
-var {a=10, b=5} = {a: 3};
+var { a = 10, b = 5 } = { a: 3 };
 
 console.log(a); // 3
 console.log(b); // 5
@@ -220,7 +220,7 @@ console.log(b); // 5
 ```js
 function drawES5Chart(options) {
   options = options === undefined ? {} : options;
-  var size = options.size === undefined ? 'big' : options.size;
+  var size = options.size === undefined ? "big" : options.size;
   var cords = options.cords === undefined ? { x: 0, y: 0 } : options.cords;
   var radius = options.radius === undefined ? 25 : options.radius;
   console.log(size, cords, radius);
@@ -229,21 +229,25 @@ function drawES5Chart(options) {
 
 drawES5Chart({
   cords: { x: 18, y: 30 },
-  radius: 30
+  radius: 30,
 });
 ```
 
 #### Versão ES2015
 
 ```js
-function drawES2015Chart({size = 'big', cords = { x: 0, y: 0 }, radius = 25} = {}) {
+function drawES2015Chart({
+  size = "big",
+  cords = { x: 0, y: 0 },
+  radius = 25,
+} = {}) {
   console.log(size, cords, radius);
   // do some chart drawing
 }
 
 drawES2015Chart({
   cords: { x: 18, y: 30 },
-  radius: 30
+  radius: 30,
 });
 ```
 
@@ -251,23 +255,26 @@ drawES2015Chart({
 
 ```js
 var metadata = {
-    title: "Scratchpad",
-    translations: [
-       {
-        locale: "de",
-        localization_tags: [ ],
-        last_edit: "2014-04-14T08:43:37",
-        url: "/de/docs/Tools/Scratchpad",
-        title: "JavaScript-Umgebung"
-       }
-    ],
-    url: "/pt-BR/docs/Tools/Scratchpad"
+  title: "Scratchpad",
+  translations: [
+    {
+      locale: "de",
+      localization_tags: [],
+      last_edit: "2014-04-14T08:43:37",
+      url: "/de/docs/Tools/Scratchpad",
+      title: "JavaScript-Umgebung",
+    },
+  ],
+  url: "/pt-BR/docs/Tools/Scratchpad",
 };
 
-var { title: englishTitle, translations: [{ title: localeTitle }] } = metadata;
+var {
+  title: englishTitle,
+  translations: [{ title: localeTitle }],
+} = metadata;
 
 console.log(englishTitle); // "Scratchpad"
-console.log(localeTitle);  // "JavaScript-Umgebung"
+console.log(localeTitle); // "JavaScript-Umgebung"
 ```
 
 ### For de iteração e desestruturação
@@ -279,22 +286,25 @@ var people = [
     family: {
       mother: "Jane Smith",
       father: "Harry Smith",
-      sister: "Samantha Smith"
+      sister: "Samantha Smith",
     },
-    age: 35
+    age: 35,
   },
   {
     name: "Tom Jones",
     family: {
       mother: "Norah Jones",
       father: "Richard Jones",
-      brother: "Howard Jones"
+      brother: "Howard Jones",
     },
-    age: 25
-  }
+    age: 25,
+  },
 ];
 
-for (var {name: n, family: { father: f } } of people) {
+for (var {
+  name: n,
+  family: { father: f },
+} of people) {
   console.log("Name: " + n + ", Father: " + f);
 }
 
@@ -305,11 +315,11 @@ for (var {name: n, family: { father: f } } of people) {
 ### Extraindo campos de objetos passados como parâmetro de função
 
 ```js
-function userId({id}) {
+function userId({ id }) {
   return id;
 }
 
-function whois({displayName: displayName, fullName: {firstName: name}}){
+function whois({ displayName: displayName, fullName: { firstName: name } }) {
   console.log(displayName + " is " + name);
 }
 
@@ -317,9 +327,9 @@ var user = {
   id: 42,
   displayName: "jdoe",
   fullName: {
-      firstName: "John",
-      lastName: "Doe"
-  }
+    firstName: "John",
+    lastName: "Doe",
+  },
 };
 
 console.log("userId: " + userId(user)); // "userId: 42"
@@ -341,9 +351,9 @@ console.log(foo); // "bar"
 
 ## Especificações
 
-| Espeficiação                                                                                                     | Situação                     | Comentário         |
-| ---------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('ES2015', '#sec-destructuring-assignment', 'Destructuring assignment')}} | {{Spec2('ES2015')}}     | Definição inicial. |
+| Espeficiação                                                                         | Situação             | Comentário         |
+| ------------------------------------------------------------------------------------ | -------------------- | ------------------ |
+| {{SpecName('ES2015', '#sec-destructuring-assignment', 'Destructuring assignment')}}  | {{Spec2('ES2015')}}  | Definição inicial. |
 | {{SpecName('ESDraft', '#sec-destructuring-assignment', 'Destructuring assignment')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/operators/division/index.md
+++ b/files/pt-br/web/javascript/reference/operators/division/index.md
@@ -20,21 +20,21 @@ x / y
 ### Divisão básica
 
 ```js
-1 / 2              // 0.5
+1 / 2; // 0.5
 
-Math.floor(3 / 2) // 1
+Math.floor(3 / 2); // 1
 
-1.0 / 2.0         // 0.5
+1.0 / 2.0; // 0.5
 ```
 
 ### Divisão por zero
 
 ```js
-2.0 / 0     // Infinito
+2.0 / 0; // Infinito
 
-2.0 / 0.0   // Infinito, porque 0.0 === 0
+2.0 / 0.0; // Infinito, porque 0.0 === 0
 
-2.0 / -0.0  // -Infinito
+2.0 / -0.0; // -Infinito
 ```
 
 ## Especificações

--- a/files/pt-br/web/javascript/reference/operators/exponentiation/index.md
+++ b/files/pt-br/web/javascript/reference/operators/exponentiation/index.md
@@ -17,7 +17,7 @@ como operandos.
 ## Sintaxe
 
 ```js
-    x ** y;
+x ** y;
 ```
 
 ## Descrição
@@ -50,19 +50,19 @@ mas o JavaScript usa esse símbolo para o operador `XOR lógico bit a bit`.
 ### Exponenciação básica
 
 ```js
-    2 ** 3   // 8
-    3 ** 2   // 9
-    3 ** 2.5 // 15.588457268119896
-    10 ** -1 // 0.1
-    NaN ** 2 // NaN
+2 ** 3; // 8
+3 ** 2; // 9
+3 ** 2.5; // 15.588457268119896
+10 ** -1; // 0.1
+NaN ** 2; // NaN
 ```
 
 ### Associatividade
 
 ```js
-    2 ** 3 ** 2   // 512
-    2 ** (3 ** 2) // 512
-    (2 ** 3) ** 2 // 64
+2 ** 3 ** 2; // 512
+2 ** (3 ** 2); // 512
+(2 ** 3) ** 2; // 64
 ```
 
 ### Uso com operadores unários
@@ -70,13 +70,13 @@ mas o JavaScript usa esse símbolo para o operador `XOR lógico bit a bit`.
 Para inverter o sinal do resultado de uma expressão de exponenciação:
 
 ```js
-    -(2 ** 2) // -4
+-(2 ** 2); // -4
 ```
 
 Para forçar a base de uma expressão de exponenciação a ser um número negativo:
 
 ```js
-    (-2) ** 2 // 4
+(-2) ** 2; // 4
 ```
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/operators/function/index.md
+++ b/files/pt-br/web/javascript/reference/operators/function/index.md
@@ -33,8 +33,8 @@ Uma expressão de função (_function expression_) é muito similar e tem quase 
 O exemplo a seguir define uma função sem nome e a atribui a x. A função retorna o quadrado de seu argumento:
 
 ```js
-var x = function(y) {
-   return y * y;
+var x = function (y) {
+  return y * y;
 };
 ```
 
@@ -44,22 +44,21 @@ Se você quer se referir à função atual dentro do corpo da função, você te
 
 ```js
 var math = {
-  'factorial': function factorial(n) {
-    if (n <= 1)
-      return 1;
+  factorial: function factorial(n) {
+    if (n <= 1) return 1;
     return n * factorial(n - 1);
-  }
+  },
 };
 ```
 
 ## Especificações
 
-| Especificação                                                                                        | Status                       | Comentários                                        |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
+| Especificação                                                                | Status               | Comentários                                        |
+| ---------------------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-function-definitions', 'Function definitions')}} | {{Spec2('ESDraft')}} |                                                    |
-| {{SpecName('ES6', '#sec-function-definitions', 'Function definitions')}}     | {{Spec2('ES6')}}         |                                                    |
-| {{SpecName('ES5.1', '#sec-13', 'Function definition')}}                             | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES3', '#sec-13', 'Function definition')}}                             | {{Spec2('ES3')}}         | Initial definition. Implemented in JavaScript 1.5. |
+| {{SpecName('ES6', '#sec-function-definitions', 'Function definitions')}}     | {{Spec2('ES6')}}     |                                                    |
+| {{SpecName('ES5.1', '#sec-13', 'Function definition')}}                      | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES3', '#sec-13', 'Function definition')}}                        | {{Spec2('ES3')}}     | Initial definition. Implemented in JavaScript 1.5. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/operators/function_star_/index.md
+++ b/files/pt-br/web/javascript/reference/operators/function_star_/index.md
@@ -31,16 +31,16 @@ Uma expressão `function*` é muito similar e tem quase a mesma sintaxe que a {{
 O exemplo a seguir define uma função generator e atribui à variável `x`. A função faz um yield do quadrado do seu argumento:
 
 ```js
-var x = function*(y) {
-   yield y * y;
+var x = function* (y) {
+  yield y * y;
 };
 ```
 
 ## Especificações
 
-| Especificação                                            | Situação                     | Comentário         |
-| -------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('ES2015', '#', 'function*')}}     | {{Spec2('ES2015')}}     | Definição inicial. |
+| Especificação                             | Situação             | Comentário         |
+| ----------------------------------------- | -------------------- | ------------------ |
+| {{SpecName('ES2015', '#', 'function*')}}  | {{Spec2('ES2015')}}  | Definição inicial. |
 | {{SpecName('ESDraft', '#', 'function*')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/operators/grouping/index.md
+++ b/files/pt-br/web/javascript/reference/operators/grouping/index.md
@@ -29,25 +29,25 @@ var b = 2;
 var c = 3;
 
 // default precedence
-a + b * c     // 7
+a + b * c; // 7
 // evaluated by default like this
-a + (b * c)   // 7
+a + (b * c); // 7
 
 // now overriding precedence
 // addition before multiplication
-(a + b) * c   // 9
+(a + b) * c; // 9
 
 // which is equivalent to
-a * c + b * c // 9
+a * c + b * c; // 9
 ```
 
 ## Especificações
 
-| Specification                                                                                | Status                   | Comment                                            |
-| -------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| ECMAScript 1st Edition.                                                                      | Standard                 | Primeira definição. Implementado no JavaScript 1.0 |
-| {{SpecName('ES5.1', '#sec-11.1.6', 'The Grouping Operator')}}             | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-grouping-operator', 'The Grouping Operator')}} | {{Spec2('ES6')}}     |                                                    |
+| Specification                                                          | Status             | Comment                                            |
+| ---------------------------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| ECMAScript 1st Edition.                                                | Standard           | Primeira definição. Implementado no JavaScript 1.0 |
+| {{SpecName('ES5.1', '#sec-11.1.6', 'The Grouping Operator')}}          | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-grouping-operator', 'The Grouping Operator')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade
 

--- a/files/pt-br/web/javascript/reference/operators/import.meta/index.md
+++ b/files/pt-br/web/javascript/reference/operators/import.meta/index.md
@@ -44,7 +44,7 @@ Por exemplo, seguindo esse HTML:
 
 ```html
 <script type="module">
-import './index.mjs?someURLInfo=5';
+  import "./index.mjs?someURLInfo=5";
 </script>
 ```
 
@@ -52,17 +52,17 @@ O arquivo JavaScript a seguir vai registrar o parâmetro `someURLInfo`:
 
 ```js
 // index.mjs
-new URL(import.meta.url).searchParams.get('someURLInfo'); // 5
+new URL(import.meta.url).searchParams.get("someURLInfo"); // 5
 ```
 
 O mesmo se aplica quando um arquivo importa outro:
 
 ```js
 // index.mjs
-import './index2.mjs?someURLInfo=5';
+import "./index2.mjs?someURLInfo=5";
 
 // index2.mjs
-new URL(import.meta.url).searchParams.get('someURLInfo'); // 5
+new URL(import.meta.url).searchParams.get("someURLInfo"); // 5
 ```
 
 Note que enquanto o Node.js vai passar nos parâmetros query (ou na cerquilha) como no exemplo passsado, a partir do Node 14.1.0, a URL com parâmetro query vai dar erro quando carregar no formulário `node --experimental-modules index.mjs?someURLInfo=5` (é tratado como um arquivo ao invés de uma URL nesse contexto).
@@ -71,9 +71,9 @@ Nesse arquivo específico, o argumento passado pode ser complementar para ser us
 
 ## Especifícações
 
-| Especifícação                                                                                                            |
-| ------------------------------------------------------------------------------------------------------------------------ |
-| [`import.meta`](https://tc39.es/proposal-import-meta/#prod-ImportMeta)                                                   |
+| Especifícação                                                                             |
+| ----------------------------------------------------------------------------------------- |
+| [`import.meta`](https://tc39.es/proposal-import-meta/#prod-ImportMeta)                    |
 | {{SpecName("HTML WHATWG", "webappapis.html#hostgetimportmetaproperties", "import.meta")}} |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/operators/in/index.md
+++ b/files/pt-br/web/javascript/reference/operators/in/index.md
@@ -26,33 +26,33 @@ Os exemplos a seguir mostram alguns usos do operador `in`.
 
 ```js
 // Arrays
-var trees = ['redwood', 'bay', 'cedar', 'oak', 'maple'];
-0 in trees        // retorna true
-3 in trees        // retorna true
-6 in trees        // retorna false
-'bay' in trees    // retorna false (você precisa especificar o
-                  // número do índice, não o valor naquele índice)
-'length' in trees // retorna true (length é uma propridade do Array)
-Symbol.iterator in trees // retorna true (arrays são iteráveis, funciona apenas na ES2015+)
+var trees = ["redwood", "bay", "cedar", "oak", "maple"];
+0 in trees; // retorna true
+3 in trees; // retorna true
+6 in trees; // retorna false
+"bay" in trees; // retorna false (você precisa especificar o
+// número do índice, não o valor naquele índice)
+"length" in trees; // retorna true (length é uma propridade do Array)
+Symbol.iterator in trees; // retorna true (arrays são iteráveis, funciona apenas na ES2015+)
 
 // Objetos predefinidos
-'PI' in Math          // retorna true
+"PI" in Math; // retorna true
 
 // Objetos personalizados
-var mycar = {make: 'Honda', model: 'Accord', year: 1998};
-'make' in mycar  // retorna true
-'model' in mycar // retorna true
+var mycar = { make: "Honda", model: "Accord", year: 1998 };
+"make" in mycar; // retorna true
+"model" in mycar; // retorna true
 ```
 
 Você precisa especificar um objeto no lado direito do operador `in`. Por exemplo, você pode especifica um string criado com o construtor `String`, mas você não pode especificar um string literal.
 
 ```js
-var color1 = new String('green');
-'length' in color1 // retorna true
+var color1 = new String("green");
+"length" in color1; // retorna true
 
-var color2 = 'coral';
+var color2 = "coral";
 // gera um erro (color2 não é um objeto String)
-'length' in color2
+"length" in color2;
 ```
 
 ### Usando `in` com propriedade removida ou undefined
@@ -60,11 +60,11 @@ var color2 = 'coral';
 Se você remover uma propriedade com o operador [`delete`](/pt-BR/docs/Web/JavaScript/Reference/Operators/delete) , o operador `in` retorna `false` para essa propriedade.
 
 ```js
-var mycar = {make: 'Honda', model: 'Accord', year: 1998};
+var mycar = { make: "Honda", model: "Accord", year: 1998 };
 delete mycar.make;
-'make' in mycar;  // retorna false
+"make" in mycar; // retorna false
 
-var trees = new Array('redwood', 'bay', 'cedar', 'oak', 'maple');
+var trees = new Array("redwood", "bay", "cedar", "oak", "maple");
 delete trees[3];
 3 in trees; // retorna false
 ```
@@ -72,13 +72,13 @@ delete trees[3];
 Se você definir uma propriedade como {{jsxref("Global_Objects/undefined", "undefined")}}, mas não a remover, o operador `in` retorna `true` para essa propriedade.
 
 ```js
-var mycar = {make: 'Honda', model: 'Accord', year: 1998};
+var mycar = { make: "Honda", model: "Accord", year: 1998 };
 mycar.make = undefined;
-'make' in mycar;  // retorna true
+"make" in mycar; // retorna true
 ```
 
 ```js
-var trees = new Array('redwood', 'bay', 'cedar', 'oak', 'maple');
+var trees = new Array("redwood", "bay", "cedar", "oak", "maple");
 trees[3] = undefined;
 3 in trees; // retorna true
 ```
@@ -88,17 +88,17 @@ trees[3] = undefined;
 O operador `in` retorna `true` para propriedades que estão na cadeida de protótipo (prototype chain).
 
 ```js
-'toString' in {}; // retorna true
+"toString" in {}; // retorna true
 ```
 
 ## Especificações
 
-| Especificação                                                                                        | Situação                     | Comentário                                         |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
+| Especificação                                                                | Situação             | Comentário                                         |
+| ---------------------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-relational-operators', 'Relational Operators')}} | {{Spec2('ESDraft')}} |                                                    |
-| {{SpecName('ES2015', '#sec-relational-operators', 'Relational Operators')}} | {{Spec2('ES2015')}}     |                                                    |
-| {{SpecName('ES5.1', '#sec-11.8.7', 'The in Operator')}}                             | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES3', '#sec-11.8.7', 'The in Operator')}}                             | {{Spec2('ES3')}}         | Definição inicial. Implementado no JavaScript 1.4. |
+| {{SpecName('ES2015', '#sec-relational-operators', 'Relational Operators')}}  | {{Spec2('ES2015')}}  |                                                    |
+| {{SpecName('ES5.1', '#sec-11.8.7', 'The in Operator')}}                      | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES3', '#sec-11.8.7', 'The in Operator')}}                        | {{Spec2('ES3')}}     | Definição inicial. Implementado no JavaScript 1.4. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/operators/index.md
+++ b/files/pt-br/web/javascript/reference/operators/index.md
@@ -213,11 +213,11 @@ An assignment operator assigns a value to its left operand based on the value of
 
 ## Specifications
 
-| Specification                                                                                                                    | Status                   | Comment                                                                                                          |
-| -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| ECMAScript 1st Edition.                                                                                                          | Standard                 | Definição inicial.                                                                                               |
-| {{SpecName('ES5.1', '#sec-11', 'Expressions')}}                                                                 | {{Spec2('ES5.1')}} |                                                                                                                  |
-| {{SpecName('ES6', '#sec-ecmascript-language-expressions', 'ECMAScript Language: Expressions')}} | {{Spec2('ES6')}}     | Novo: Spread operator, destructuring assignment, `super` keyword, Array comprehensions, Generator comprehensions |
+| Specification                                                                                   | Status             | Comment                                                                                                          |
+| ----------------------------------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| ECMAScript 1st Edition.                                                                         | Standard           | Definição inicial.                                                                                               |
+| {{SpecName('ES5.1', '#sec-11', 'Expressions')}}                                                 | {{Spec2('ES5.1')}} |                                                                                                                  |
+| {{SpecName('ES6', '#sec-ecmascript-language-expressions', 'ECMAScript Language: Expressions')}} | {{Spec2('ES6')}}   | Novo: Spread operator, destructuring assignment, `super` keyword, Array comprehensions, Generator comprehensions |
 
 ## Veja também
 

--- a/files/pt-br/web/javascript/reference/operators/instanceof/index.md
+++ b/files/pt-br/web/javascript/reference/operators/instanceof/index.md
@@ -26,8 +26,8 @@ O operador instanceof testa a presença da função construtora no prototype do 
 
 ```js
 // definindo construtores
-function C(){}
-function D(){}
+function C() {}
+function D() {}
 
 var o = new C();
 
@@ -38,7 +38,7 @@ o instanceof C;
 o instanceof D;
 
 o instanceof Object; // true, porque:
-C.prototype instanceof Object // true
+C.prototype instanceof Object; // true
 
 C.prototype = {};
 var o2 = new C();
@@ -73,24 +73,24 @@ However, objects created with the object literal notation are an exception here:
 
 ```js
 var simpleStr = "This is a simple string";
-var myString  = new String();
-var newStr    = new String("String created with constructor");
-var myDate    = new Date();
-var myObj     = {};
+var myString = new String();
+var newStr = new String("String created with constructor");
+var myDate = new Date();
+var myObj = {};
 
 simpleStr instanceof String; // returns false, checks the prototype chain, finds undefined
-myString  instanceof String; // returns true
-newStr    instanceof String; // returns true
-myString  instanceof Object; // returns true
+myString instanceof String; // returns true
+newStr instanceof String; // returns true
+myString instanceof Object; // returns true
 
-myObj instanceof Object;    // returns true, despite an undefined prototype
-({})  instanceof Object;    // returns true, same case as above
+myObj instanceof Object; // returns true, despite an undefined prototype
+({}) instanceof Object; // returns true, same case as above
 
-myString instanceof Date;   // returns false
+myString instanceof Date; // returns false
 
-myDate instanceof Date;     // returns true
-myDate instanceof Object;   // returns true
-myDate instanceof String;   // returns false
+myDate instanceof Date; // returns true
+myDate instanceof Object; // returns true
+myDate instanceof String; // returns false
 ```
 
 ### Demonstrating that `mycar` is of type `Car` and type `Object`
@@ -104,17 +104,17 @@ function Car(make, model, year) {
   this.year = year;
 }
 var mycar = new Car("Honda", "Accord", 1998);
-var a = mycar instanceof Car;    // retorna true
+var a = mycar instanceof Car; // retorna true
 var b = mycar instanceof Object; // retorna true
 ```
 
 ## Especificações
 
-| Especificação                                                                                    | Status                   | Comentário                                        |
-| ------------------------------------------------------------------------------------------------ | ------------------------ | ------------------------------------------------- |
-| ECMAScript 1st Edition.                                                                          | Standard                 | Definição inicial. Implementada no JavaScript 1.4 |
-| {{SpecName('ES5.1', '#sec-11.8.6', 'The instanceof operator')}}             | {{Spec2('ES5.1')}} |                                                   |
-| {{SpecName('ES6', '#sec-relational-operators', 'Relational Operators')}} | {{Spec2('ES6')}}     |                                                   |
+| Especificação                                                            | Status             | Comentário                                        |
+| ------------------------------------------------------------------------ | ------------------ | ------------------------------------------------- |
+| ECMAScript 1st Edition.                                                  | Standard           | Definição inicial. Implementada no JavaScript 1.4 |
+| {{SpecName('ES5.1', '#sec-11.8.6', 'The instanceof operator')}}          | {{Spec2('ES5.1')}} |                                                   |
+| {{SpecName('ES6', '#sec-relational-operators', 'Relational Operators')}} | {{Spec2('ES6')}}   |                                                   |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/operators/new.target/index.md
+++ b/files/pt-br/web/javascript/reference/operators/new.target/index.md
@@ -27,8 +27,8 @@ Em chamadas normais de função (diferente de chamadas a funções do tipo const
 
 ```js
 function Foo() {
-  if (!new.target) throw 'Foo() must be called with new';
-  console.log('Foo instanciado com new');
+  if (!new.target) throw "Foo() must be called with new";
+  console.log("Foo instanciado com new");
 }
 
 Foo(); // throws "Foo() must be called with new"
@@ -46,13 +46,25 @@ class A {
   }
 }
 
-class B extends A { constructor() { super(); } }
+class B extends A {
+  constructor() {
+    super();
+  }
+}
 
 var a = new A(); // logs "A"
 var b = new B(); // logs "B"
 
-class C { constructor() { console.log(new.target); } }
-class D extends C { constructor() { super(); } }
+class C {
+  constructor() {
+    console.log(new.target);
+  }
+}
+class D extends C {
+  constructor() {
+    super();
+  }
+}
 
 var c = new C(); // logs class C{constructor(){console.log(new.target);}}
 var d = new D(); // logs class D extends C{constructor(){super();}}
@@ -62,9 +74,9 @@ A partir do exemplo acima das classes C e D, mostra que new\.target aponta para 
 
 ## Especificações
 
-| Specification                                                                                                        | Status                       | Comment            |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('ES2015', '#sec-built-in-function-objects', 'Built-in Function Objects')}}     | {{Spec2('ES2015')}}     | Definição inicial. |
+| Specification                                                                          | Status               | Comment            |
+| -------------------------------------------------------------------------------------- | -------------------- | ------------------ |
+| {{SpecName('ES2015', '#sec-built-in-function-objects', 'Built-in Function Objects')}}  | {{Spec2('ES2015')}}  | Definição inicial. |
 | {{SpecName('ESDraft', '#sec-built-in-function-objects', 'Built-in Function Objects')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/operators/new/index.md
+++ b/files/pt-br/web/javascript/reference/operators/new/index.md
@@ -45,13 +45,13 @@ Você pode adicionar uma propriedade compartilhada à um tipo de objeto definido
 function Carro() {}
 carro1 = new Carro();
 
-console.log(carro1.cor);    // undefined
+console.log(carro1.cor); // undefined
 
 Carro.prototype.cor = null;
-console.log(carro1.cor);    // null
+console.log(carro1.cor); // null
 
 carro1.cor = "preta";
-console.log(carro1.cor);   // preta
+console.log(carro1.cor); // preta
 ```
 
 ## Exemplos
@@ -122,18 +122,18 @@ var carro2 = new Carro("Nissan", "300ZX", 1992, ken);
 Ao invés de passar uma string ou valor inteiro quando criar os novos objetos, as definições acima passam objetos `rand` e `ken` como os parâmetros para os donos. Para descobrir o nome do dono do `carro2`, você pode acessar a seguinte propriedade:
 
 ```js
-carro2.dono.nome
+carro2.dono.nome;
 ```
 
 ## Especificações
 
-| Specification                                                                        | Status                       | Comment                                            |
-| ------------------------------------------------------------------------------------ | ---------------------------- | -------------------------------------------------- |
+| Specification                                                    | Status               | Comment                                            |
+| ---------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-new-operator', 'The new Operator')}} | {{Spec2('ESDraft')}} |                                                    |
-| {{SpecName('ES6', '#sec-new-operator', 'The new Operator')}}     | {{Spec2('ES6')}}         |                                                    |
-| {{SpecName('ES5.1', '#sec-11.2.2', 'The new Operator')}}         | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES3', '#sec-11.2.2', 'The new Operator')}}             | {{Spec2('ES3')}}         |                                                    |
-| {{SpecName('ES1', '#sec-11.2.2', 'The new Operator')}}             | {{Spec2('ES1')}}         | Definição inicial. Implementado no JavaScript 1.0. |
+| {{SpecName('ES6', '#sec-new-operator', 'The new Operator')}}     | {{Spec2('ES6')}}     |                                                    |
+| {{SpecName('ES5.1', '#sec-11.2.2', 'The new Operator')}}         | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES3', '#sec-11.2.2', 'The new Operator')}}           | {{Spec2('ES3')}}     |                                                    |
+| {{SpecName('ES1', '#sec-11.2.2', 'The new Operator')}}           | {{Spec2('ES1')}}     | Definição inicial. Implementado no JavaScript 1.0. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/operators/null/index.md
+++ b/files/pt-br/web/javascript/reference/operators/null/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'null'
+title: "null"
 slug: Web/JavaScript/Reference/Operators/null
 original_slug: Web/JavaScript/Reference/Global_Objects/null
 ---
@@ -33,19 +33,19 @@ O valor `null` é um literal, e não uma propriedade do objeto global (como o [`
 ### Diferenças entre `null` e `undefined`
 
 ```js
-typeof null        // object (bug no ECMAScript, deveria ser null - http://2ality.com/2013/10/typeof-null.html)
-typeof undefined   // undefined
-null === undefined // falso
-null  == undefined // verdadeiro
+typeof null; // object (bug no ECMAScript, deveria ser null - http://2ality.com/2013/10/typeof-null.html)
+typeof undefined; // undefined
+null === undefined; // falso
+null == undefined; // verdadeiro
 ```
 
 ## Especificações
 
-| Especificação                                                        | Status                   | Comentários       |
-| -------------------------------------------------------------------- | ------------------------ | ----------------- |
-| ECMAScript 1st Edition.                                              | Standard                 | Definição inicial |
-| {{SpecName('ES5.1', '#sec-4.3.11', 'null value')}} | {{Spec2('ES5.1')}} |                   |
-| {{SpecName('ES6', '#sec-null-value', 'null value')}} | {{Spec2('ES6')}}     |                   |
+| Especificação                                        | Status             | Comentários       |
+| ---------------------------------------------------- | ------------------ | ----------------- |
+| ECMAScript 1st Edition.                              | Standard           | Definição inicial |
+| {{SpecName('ES5.1', '#sec-4.3.11', 'null value')}}   | {{Spec2('ES5.1')}} |                   |
+| {{SpecName('ES6', '#sec-null-value', 'null value')}} | {{Spec2('ES6')}}   |                   |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/operators/nullish_coalescing/index.md
+++ b/files/pt-br/web/javascript/reference/operators/nullish_coalescing/index.md
@@ -30,7 +30,7 @@ Inicialmente, quando se deseja endereçar um valor padrão à variável, um padr
 let foo;
 
 //  foo nunca é endereçado a nenhum valor, portanto, ainda está indefinido
-let someDummyText = foo || 'Hello!';
+let someDummyText = foo || "Hello!";
 ```
 
 Entretanto, devido ao `||` ser um operador lógico booleano, o operando do lado esquerdo é coagido para um valor booleano para sua avaliação e qualquer valor _falseável_ (`0`, `''`, `NaN`, `null`, `undefined`) não é retornado. Este comportamento pode causar consequencias inesperadas se você considerar `0`, `''`, ou `NaN` como valores válidos.
@@ -41,19 +41,19 @@ let text = "";
 
 let qty = count || 42;
 let message = text || "Olá!";
-console.log(qty);     // 42 e não 0
+console.log(qty); // 42 e não 0
 console.log(message); // "Olá!" e não ""
 ```
 
 O operador de coalescência nula evita esta cilada pois retorna o segundo operando apenas quando o primeiro é avaliado entre os valores `null` ou `undefined` (mas nehum outro valor falseável):
 
 ```js
-let myText = ''; // Uma string vazia (que também é um valor falseável)
+let myText = ""; // Uma string vazia (que também é um valor falseável)
 
-let notFalsyText = myText || 'Olá mundo';
+let notFalsyText = myText || "Olá mundo";
 console.log(notFalsyText); // Olá mundo
 
-let preservingFalsy = myText ?? 'Olá vizinhança';
+let preservingFalsy = myText ?? "Olá vizinhança";
 console.log(preservingFalsy); // '' (Pois myText não é undefined e nem null)
 ```
 
@@ -62,15 +62,24 @@ console.log(preservingFalsy); // '' (Pois myText não é undefined e nem null)
 Assim como os operadores lógicos OR e AND, a expressão do lado direito não é avaliada se o lado esquerdo não for avaliado entre `null` e nem `undefined`.
 
 ```js
-function A() { console.log('A foi chamado'); return undefined;}
-function B() { console.log('B foi chamado'); return false;}
-function C() { console.log('C foi chamado'); return "foo";}
+function A() {
+  console.log("A foi chamado");
+  return undefined;
+}
+function B() {
+  console.log("B foi chamado");
+  return false;
+}
+function C() {
+  console.log("C foi chamado");
+  return "foo";
+}
 
-console.log( A() ?? C() );
+console.log(A() ?? C());
 // Imprime "A foi chamado" então "C foi chamado" e por fim "foo"
 // Como A() retornou undefined então ambas expressões foram avaliadas
 
-console.log( B() ?? C() );
+console.log(B() ?? C());
 // Imprime "B foi chamado" então "false"
 // Como B() retornou false (e não null ou undefined), a expressão
 // do lado direito não foi avaliada.
@@ -98,7 +107,7 @@ O operador de coalescêcia nula trata `undefined` e `null` como valores específ
 ```js
 let foo = { someFooProp: "oi" };
 
-console.log(foo.someFooProp?.toUpperCase());  // "OI"
+console.log(foo.someFooProp?.toUpperCase()); // "OI"
 console.log(foo.someBarProp?.toUpperCase()); // undefined
 ```
 

--- a/files/pt-br/web/javascript/reference/operators/object_initializer/index.md
+++ b/files/pt-br/web/javascript/reference/operators/object_initializer/index.md
@@ -14,7 +14,9 @@ Objetos podem ser inicializados utilizando [`new Object()`](/pt-BR/docs/Web/Java
 var o = {};
 var o = { a: "foo", b: 42, c: {} };
 
-var a = "foo", b = 42, c = {};
+var a = "foo",
+  b = 42,
+  c = {};
 var o = { a: a, b: b, c: c };
 
 var o = {
@@ -30,7 +32,9 @@ Por favor, verifique o suporte das anotações na tabela de compatibilidade. Em 
 
 ```js
 // // Abreviação em nomes de propriedades (ES2015)
-var a = "foo", b = 42, c = {};
+var a = "foo",
+  b = 42,
+  c = {};
 var o = { a, b, c };
 
 // // Abreviação em nomes de métodos (ES2015)
@@ -67,7 +71,7 @@ var object = {
   foo: "bar",
   age: 42,
   baz: { myProp: 12 },
-}
+};
 ```
 
 ### Acessando propriedades
@@ -87,13 +91,13 @@ Nós temos aprendido como descrever propriedades utilizando a sintaxe _inicializ
 
 ```js
 var a = "foo",
-    b = 42,
-    c = {};
+  b = 42,
+  c = {};
 
 var o = {
   a: a,
   b: b,
-  c: c
+  c: c,
 };
 ```
 
@@ -101,14 +105,14 @@ Com ECMAScript 2015, há uma notação mais curta que possibilita atingir o mesm
 
 ```js
 var a = "foo",
-    b = 42,
-    c = {};
+  b = 42,
+  c = {};
 
 // Abreviação em nomes de propriedades (ES2015)
 var o = { a, b, c };
 
 // Em outras palavras,
-console.log((o.a === { a }.a)); // true
+console.log(o.a === { a }.a); // true
 ```
 
 #### Duplicação em nomes de propriedades
@@ -116,14 +120,14 @@ console.log((o.a === { a }.a)); // true
 Quando se está utilizando o mesmo nome para suas propriedades, a última sobrescreverá as anteriores.
 
 ```js
-var a = {x: 1, x: 2};
+var a = { x: 1, x: 2 };
 console.log(a); // { x: 2}
 ```
 
 Em códigos ECMAScript 5 no modo estrito, duplicação em nomes de propriedades serão consideradas {{jsxref("SyntaxError")}}. Porém, com a introdução de "nomes de propriedades computadas", tornou-se possível a duplicação das propriedades em tempo de execução. Assim, ECMAScript 2015 removeu a restrição.
 
 ```js
-function haveES2015DuplicatePropertySemantics(){
+function haveES2015DuplicatePropertySemantics() {
   "use strict";
   try {
     ({ prop: 1, prop: 2 });
@@ -157,7 +161,7 @@ var o = {
   propriedade([parâmetros]) {},
   get propriedade() {},
   set propriedade(valor) {},
-  * gerador() {}
+  *gerador() {},
 };
 ```
 
@@ -193,17 +197,17 @@ var i = 0;
 var a = {
   ["foo" + ++i]: i,
   ["foo" + ++i]: i,
-  ["foo" + ++i]: i
+  ["foo" + ++i]: i,
 };
 
 console.log(a.foo1); // 1
 console.log(a.foo2); // 2
 console.log(a.foo3); // 3
 
-var param = 'size';
+var param = "size";
 var config = {
   [param]: 12,
-  ["mobile" + param.charAt(0).toUpperCase() + param.slice(1)]: 4
+  ["mobile" + param.charAt(0).toUpperCase() + param.slice(1)]: 4,
 };
 
 console.log(config); // { size: 12, mobileSize: 4 }
@@ -221,7 +225,7 @@ var obj2 = { __proto__: null };
 assert(Object.getPrototypeOf(obj2) === null);
 
 var protoObj = {};
-var obj3 = { "__proto__": protoObj };
+var obj3 = { __proto__: protoObj };
 assert(Object.getPrototypeOf(obj3) === protoObj);
 
 var obj4 = { __proto__: "not an object or null" };
@@ -241,7 +245,11 @@ assert(Object.getPrototypeOf(obj1) === Object.prototype);
 assert(obj1.hasOwnProperty("__proto__"));
 assert(obj1.__proto__ === "variable");
 
-var obj2 = { __proto__() { return "hello"; } };
+var obj2 = {
+  __proto__() {
+    return "hello";
+  },
+};
 assert(obj2.__proto__() === "hello");
 
 var obj3 = { ["__prot" + "o__"]: 17 };
@@ -260,11 +268,11 @@ A notação de objeto literal não é a mesma de **J**ava**S**cript **O**bject *
 
 ## Especificações
 
-| Specification                                                                                    | Status                       | Comment                                                                                                                                  |
-| ------------------------------------------------------------------------------------------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                         | {{Spec2('ES1')}}         | Definição inicial.                                                                                                                       |
-| {{SpecName('ES5.1', '#sec-11.1.5', 'Object Initializer')}}                     | {{Spec2('ES5.1')}}     | [getter](/pt-BR/docs/Web/JavaScript/Reference/Functions/get) e [setter](/pt-BR/docs/Web/JavaScript/Reference/Functions/set) adicionados. |
-| {{SpecName('ES6', '#sec-object-initializer', 'Object Initializer')}}     | {{Spec2('ES6')}}         | Abreviações de nomes em propriedades/métodos e nomes de propriedados computados foram adicionados.                                       |
+| Specification                                                            | Status               | Comment                                                                                                                                  |
+| ------------------------------------------------------------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| {{SpecName('ES1')}}                                                      | {{Spec2('ES1')}}     | Definição inicial.                                                                                                                       |
+| {{SpecName('ES5.1', '#sec-11.1.5', 'Object Initializer')}}               | {{Spec2('ES5.1')}}   | [getter](/pt-BR/docs/Web/JavaScript/Reference/Functions/get) e [setter](/pt-BR/docs/Web/JavaScript/Reference/Functions/set) adicionados. |
+| {{SpecName('ES6', '#sec-object-initializer', 'Object Initializer')}}     | {{Spec2('ES6')}}     | Abreviações de nomes em propriedades/métodos e nomes de propriedados computados foram adicionados.                                       |
 | {{SpecName('ESDraft', '#sec-object-initializer', 'Object Initializer')}} | {{Spec2('ESDraft')}} |                                                                                                                                          |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/pt-br/web/javascript/reference/operators/optional_chaining/index.md
@@ -46,7 +46,7 @@ Isso é equivalente ao seguinte, exceto que a variável temporária, de fato, n�
 
 ```js
 let temp = obj.first;
-let nestedProp = ((temp === null || temp === undefined) ? undefined : temp.second);
+let nestedProp = temp === null || temp === undefined ? undefined : temp.second;
 ```
 
 ### Encadeamento opcional com chamadas de funções
@@ -70,9 +70,9 @@ Se você usa callbacks ou consulta métodos de objetos com [atribuição via des
 function doSomething(onContent, onError) {
   try {
     // ... faz algo com os dados
-  }
-  catch (err) {
-    if (onError) { // teste se onError realmente existe
+  } catch (err) {
+    if (onError) {
+      // teste se onError realmente existe
       onError(err.message);
     }
   }
@@ -83,9 +83,8 @@ function doSomething(onContent, onError) {
 // Usando encadeamento opcional com chamadas de função
 function doSomething(onContent, onError) {
   try {
-   // ... faz algo com os dados
-  }
-  catch (err) {
+    // ... faz algo com os dados
+  } catch (err) {
     onError?.(err.message); // Nenhuma exceção se onError for undefined
   }
 }
@@ -96,7 +95,7 @@ function doSomething(onContent, onError) {
 Você também pode usar o operador de encadeamento opcional ao acessar propriedades com uma expressão usando [assessores de propriedade](/pt-BR/docs/Web/JavaScript/Reference/Operators/Property_Accessors#Bracket_notation):
 
 ```js
-let nestedProp = obj?.['prop' + 'Name'];
+let nestedProp = obj?.["prop" + "Name"];
 ```
 
 ### Encadeamento opcional não válido no lado esquerdo de uma atribuição
@@ -120,7 +119,7 @@ Esse exemplo busca plo valor da propriedade `name` para o membro `bar` em um map
 
 ```js
 let myMap = new Map();
-myMap.set("foo", {name: "baz", desc: "inga"});
+myMap.set("foo", { name: "baz", desc: "inga" });
 
 let nameBar = myMap.get("bar")?.name;
 ```
@@ -146,8 +145,8 @@ let customer = {
   name: "Carl",
   details: {
     age: 82,
-    location: "Paradise Falls" // endereço detalhado é desconhecido
-  }
+    location: "Paradise Falls", // endereço detalhado é desconhecido
+  },
 };
 let customerCity = customer.details?.address?.city;
 
@@ -162,7 +161,7 @@ O {{JSxRef("Operators/Nullish_Coalescing_Operator", "operador de coalescência n
 ```js
 let customer = {
   name: "Carl",
-  details: { age: 82 }
+  details: { age: 82 },
 };
 const customerCity = customer?.city ?? "Cidade desconhecida";
 console.log(customerCity); // Cidade desconhecida

--- a/files/pt-br/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/pt-br/web/javascript/reference/operators/property_accessors/index.md
@@ -32,7 +32,7 @@ object.property = set;
 Neste código, a propriedade deve ser um identificador válido, i.e. uma sequência de carácteres alfanuméricos, incluíndo também o underline ("`_`") e o cifrão ("`$`"), não pode começar com um número. Por exemplo, `object.$1` é valido, enquanto `object.1` não é.
 
 ```js
-document.createElement('pre');
+document.createElement("pre");
 ```
 
 Aqui, o método chamado "createElement" é recuperado do documento e é chamado.
@@ -40,16 +40,15 @@ Aqui, o método chamado "createElement" é recuperado do documento e é chamado.
 Se você usar um método para um literal numérico e o literal numérico não tem expoente e nenhum ponto decimal, deixar de espaço em branco antes do ponto que precede a chamada de método para evitar que o ponto seja interpretado como um ponto decimal.
 
 ```js
-77 .toExponential();
-// ou
-77
-.toExponential();
+(77).toExponential();
 // ou
 (77).toExponential();
 // ou
-77..toExponential();
+(77).toExponential();
 // ou
-77.0.toExponential();
+(77).toExponential();
+// ou
+(77.0).toExponential();
 // porque 77. === 77.0, sem ambiguidade :p
 ```
 
@@ -63,7 +62,7 @@ object[property_name] = set;
 `property_name` é uma string. A string não precisa ser um identificador válido; pode ser qualquer valor, e.g. "1foo", "!bar!", ou até " " (um espaço).
 
 ```js
-document['createElement']('pre');
+document["createElement"]("pre");
 ```
 
 Isto faz exatamente a mesma coisa que o exemplo anterior.
@@ -71,7 +70,7 @@ Isto faz exatamente a mesma coisa que o exemplo anterior.
 Um espaço antes da notação de colchete é permitido.
 
 ```js
-document ['createElement']('pre');
+document["createElement"]("pre");
 ```
 
 ### Nomes de propriedades
@@ -80,15 +79,17 @@ Nomes de propriedades devem ser strings. Isto significa que objetos não-string 
 
 ```js
 var object = {};
-object['1'] = 'value';
+object["1"] = "value";
 console.log(object[1]);
 ```
 
 A saída é "value", desde 1 é estereotipado como '1'.
 
 ```js
-var foo = {unique_prop: 1}, bar = {unique_prop: 2}, object = {};
-object[foo] = 'value';
+var foo = { unique_prop: 1 },
+  bar = { unique_prop: 2 },
+  object = {};
+object[foo] = "value";
 console.log(object[bar]);
 ```
 
@@ -103,7 +104,7 @@ Um método não é limitado ao objeto de quem é metodo. Especificamente, `this`
 Novatos em JavaScript comentem muitas vezes o erro de usar [eval](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/eval) onde a notação de colchete pode ser usada no lugar. Por exemplo, a sintaxe a seguir é muitas vezes vista em muitos scripts.
 
 ```js
-x = eval('document.forms.form_name.elements.' + strFormControl + '.value');
+x = eval("document.forms.form_name.elements." + strFormControl + ".value");
 ```
 
 `eval` é lento e deve ser evitado sempre que possível. Também, `strFormControl` would have to hold an identifier, which is not required for names and IDs of form controls. It is better to use bracket notation instead:
@@ -114,12 +115,12 @@ x = document.forms["form_name"].elements[strFormControl].value;
 
 ## Especificações
 
-| Specification                                                                                    | Status                       | Comment                                            |
-| ------------------------------------------------------------------------------------------------ | ---------------------------- | -------------------------------------------------- |
+| Specification                                                            | Status               | Comment                                            |
+| ------------------------------------------------------------------------ | -------------------- | -------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-property-accessors', 'Property Accessors')}} | {{Spec2('ESDraft')}} |                                                    |
-| {{SpecName('ES6', '#sec-property-accessors', 'Property Accessors')}}     | {{Spec2('ES6')}}         |                                                    |
-| {{SpecName('ES5.1', '#sec-11.2.1', 'Property Accessors')}}                     | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES1', '#sec-11.2.1', 'Property Accessors')}}                     | {{Spec2('ES1')}}         | Initial definition. Implemented in JavaScript 1.0. |
+| {{SpecName('ES6', '#sec-property-accessors', 'Property Accessors')}}     | {{Spec2('ES6')}}     |                                                    |
+| {{SpecName('ES5.1', '#sec-11.2.1', 'Property Accessors')}}               | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES1', '#sec-11.2.1', 'Property Accessors')}}                 | {{Spec2('ES1')}}     | Initial definition. Implemented in JavaScript 1.0. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/pt-br/web/javascript/reference/operators/spread_syntax/index.md
@@ -34,7 +34,7 @@ let objClone = { ...obj };
 É comum usar {{jsxref( "Function.prototype.apply")}} em casos onde você quer usar os elementos de um array como argumentos para uma função.
 
 ```js
-function myFunction(x, y, z) { }
+function myFunction(x, y, z) {}
 var args = [0, 1, 2];
 myFunction.apply(null, args);
 ```
@@ -42,7 +42,7 @@ myFunction.apply(null, args);
 Com a sintaxe de espalhamento, o código acima pode ser escrito assim:
 
 ```js
-function myFunction(x, y, z) { }
+function myFunction(x, y, z) {}
 var args = [0, 1, 2];
 myFunction(...args);
 ```
@@ -50,7 +50,7 @@ myFunction(...args);
 Qualquer argumento numa lista de argumentos pode usar a sintaxe de espalhamento e pode ser usado mais de uma vez.
 
 ```js
-function myFunction(v, w, x, y, z) { }
+function myFunction(v, w, x, y, z) {}
 var args = [0, 1];
 myFunction(-1, ...args, 2, ...[3]);
 ```
@@ -60,7 +60,7 @@ myFunction(-1, ...args, 2, ...[3]);
 Quando um construtor é chamado com `new`, não é possivel usar diretamente um array e `apply` (`apply` executa o `[[Call]]` e não o `[[Construct]]`). No entanto, um array pode facilmente ser usado com `new` graças ao operador de espalhamento:
 
 ```js
-var dateFields = [1970, 0, 1];  // 1 Jan 1970
+var dateFields = [1970, 0, 1]; // 1 Jan 1970
 var d = new Date(...dateFields);
 ```
 
@@ -68,27 +68,26 @@ Para usar o `new` com array de parâmetros sem a sintaxa de espalhamento, você 
 
 ```js
 function applyAndNew(constructor, args) {
-   function partial () {
-      return constructor.apply(this, args);
-   };
-   if (typeof constructor.prototype === "object") {
-      partial.prototype = Object.create(constructor.prototype);
-   }
-   return partial;
+  function partial() {
+    return constructor.apply(this, args);
+  }
+  if (typeof constructor.prototype === "object") {
+    partial.prototype = Object.create(constructor.prototype);
+  }
+  return partial;
 }
 
-
-function myConstructor () {
-   console.log("arguments.length: " + arguments.length);
-   console.log(arguments);
-   this.prop1="val1";
-   this.prop2="val2";
-};
+function myConstructor() {
+  console.log("arguments.length: " + arguments.length);
+  console.log(arguments);
+  this.prop1 = "val1";
+  this.prop2 = "val2";
+}
 
 var myArguments = ["hi", "how", "are", "you", "mr", null];
 var myConstructorWithArguments = applyAndNew(myConstructor, myArguments);
 
-console.log(new myConstructorWithArguments);
+console.log(new myConstructorWithArguments());
 // (internal log of myConstructor):           arguments.length: 6
 // (internal log of myConstructor):           ["hi", "how", "are", "you", "mr", null]
 // (log of "new myConstructorWithArguments"): {prop1: "val1", prop2: "val2"}
@@ -101,8 +100,8 @@ console.log(new myConstructorWithArguments);
 Criar um novo array usando um array existente como parte dele, não é possível utilizando apenas a sintaxe de array literal. O código imperativo deve ser usado ao invés da combinação de `push`, `splice`, `concat`, etc. Com a sintaxe de espalhamento isso se torna muito mais sucinto:
 
 ```js
-var parts = ['shoulders', 'knees'];
-var lyrics = ['head', ...parts, 'and', 'toes'];
+var parts = ["shoulders", "knees"];
+var lyrics = ["head", ...parts, "and", "toes"];
 // ["head", "shoulders", "knees", "and", "toes"]
 ```
 
@@ -153,7 +152,7 @@ arr1 = [...arr1, ...arr2];
 var arr1 = [0, 1, 2];
 var arr2 = [3, 4, 5];
 // Prepend all items from arr2 onto arr1
-Array.prototype.unshift.apply(arr1, arr2) // arr1 is now [3, 4, 5, 0, 1, 2]
+Array.prototype.unshift.apply(arr1, arr2); // arr1 is now [3, 4, 5, 0, 1, 2]
 ```
 
 Com a _sintaxe de espalhamento_ isso se torna _\[Note, no entanto, que isso cria um novo `arr1` array. Ao contrário de {{jsxref("Array.unshift")}}, isso não modifica o array original `arr1` array]_:
@@ -171,8 +170,8 @@ A proposta [Rest/Spread Properties for ECMAScript](https://github.com/tc39/propo
 **Cópia-rasa (Shallow-cloning)** (excluindo o protótipo) ou fusão (**merge**) de objetos agora é possivel usando uma sintaxe mais curta que {{jsxref("Object.assign()")}}.
 
 ```js
-var obj1 = { foo: 'bar', x: 42 };
-var obj2 = { foo: 'baz', y: 13 };
+var obj1 = { foo: "bar", x: 42 };
+var obj2 = { foo: "baz", y: 13 };
 
 var clonedObj = { ...obj1 };
 // Object { foo: "bar", x: 42 }
@@ -188,7 +187,7 @@ Note que {{jsxref("Object.assign()")}} chamada os [setters](/pt-BR/docs/Web/Java
 A sintaxe de espalhamento (diferente de propriedades espalhadas) só pode ser utilizada com objetos iteráveis.
 
 ```js
-var obj = {'key1': 'value1'};
+var obj = { key1: "value1" };
 var array = [...obj]; // TypeError: obj is not iterable
 ```
 
@@ -202,11 +201,11 @@ A _sintaxe rest_ se parece exatamente como a _sintaxe de espalhamento_, mas esta
 
 ## Especificações
 
-| Specification                                                                                | Status                       | Comment                                                                                                                                                                                                                            |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('ES2015', '#sec-array-initializer')}}                             | {{Spec2('ES2015')}}     | Defined in several sections of the specification: [Array Initializer](http://www.ecma-international.org/ecma-262/6.0/#sec-array-initializer), [Argument Lists](http://www.ecma-international.org/ecma-262/6.0/#sec-argument-lists) |
-| {{SpecName('ESDraft', '#sec-array-initializer')}}                             | {{Spec2('ESDraft')}} | No changes.                                                                                                                                                                                                                        |
-| [Rest/Spread Properties for ECMAScript](https://github.com/tc39/proposal-object-rest-spread) | Draft                        | Stage 3 draft.                                                                                                                                                                                                                     |
+| Specification                                                                                | Status               | Comment                                                                                                                                                                                                                            |
+| -------------------------------------------------------------------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| {{SpecName('ES2015', '#sec-array-initializer')}}                                             | {{Spec2('ES2015')}}  | Defined in several sections of the specification: [Array Initializer](http://www.ecma-international.org/ecma-262/6.0/#sec-array-initializer), [Argument Lists](http://www.ecma-international.org/ecma-262/6.0/#sec-argument-lists) |
+| {{SpecName('ESDraft', '#sec-array-initializer')}}                                            | {{Spec2('ESDraft')}} | No changes.                                                                                                                                                                                                                        |
+| [Rest/Spread Properties for ECMAScript](https://github.com/tc39/proposal-object-rest-spread) | Draft                | Stage 3 draft.                                                                                                                                                                                                                     |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/operators/subtraction/index.md
+++ b/files/pt-br/web/javascript/reference/operators/subtraction/index.md
@@ -20,8 +20,8 @@ x - y
 ### Subtração com números
 
 ```js
-5 - 3     // 2
-3 - 5     // -2
+5 - 3; // 2
+3 - 5; // -2
 ```
 
 ### Subtração com strings
@@ -29,9 +29,9 @@ x - y
 > **Warning:** Note que o JavaScript sempre tentará converter uma String em numero número
 
 ```js
-'foo' - 3 // NaN
-'5' - 1   // 4
-'10' - 5  // 5 
+"foo" - 3; // NaN
+"5" - 1; // 4
+"10" - 5; // 5
 ```
 
 ## Especificações

--- a/files/pt-br/web/javascript/reference/operators/super/index.md
+++ b/files/pt-br/web/javascript/reference/operators/super/index.md
@@ -29,12 +29,12 @@ Esse trecho de código foi obtido através de [classes sample](https://github.co
 ```js
 class Polygon {
   constructor(height, width) {
-    this.name = 'Polygon';
+    this.name = "Polygon";
     this.height = height;
     this.width = width;
   }
   sayName() {
-    console.log('Hi, I am a ', this.name + '.');
+    console.log("Hi, I am a ", this.name + ".");
   }
 }
 
@@ -48,7 +48,7 @@ class Square extends Polygon {
 
     // Nota: Em classes derivadas, super() deve ser chamado antes de
     // usar this. Deixar isso de fora vai causar um ReferenceError.
-    this.name = 'Square';
+    this.name = "Square";
   }
 
   get area() {
@@ -69,14 +69,14 @@ Você também pode chamar o super em métodos [estáticos](/pt-BR/docs/Web/JavaS
 class Human {
   constructor() {}
   static ping() {
-    return 'ping';
+    return "ping";
   }
 }
 
 class Computer extends Human {
   constructor() {}
   static pingpong() {
-    return super.ping() + ' pong';
+    return super.ping() + " pong";
   }
 }
 Computer.pingpong(); // 'ping pong'
@@ -111,7 +111,7 @@ class X {
     Object.defineProperty(this, "prop", {
       configurable: true,
       writable: false,
-      value: 1
+      value: 1,
     });
   }
   f() {
@@ -132,14 +132,14 @@ console.log(x.prop); // 1
 var obj1 = {
   method1() {
     console.log("method 1");
-  }
-}
+  },
+};
 
 var obj2 = {
   method2() {
-   super.method1();
-  }
-}
+    super.method1();
+  },
+};
 
 Object.setPrototypeOf(obj2, obj1);
 obj2.method2(); // retorna "method 1"
@@ -147,9 +147,9 @@ obj2.method2(); // retorna "method 1"
 
 ## Especificações
 
-| Specification                                                            | Status                       | Comment            |
-| ------------------------------------------------------------------------ | ---------------------------- | ------------------ |
-| {{SpecName('ES6', '#sec-super-keyword', 'super')}}     | {{Spec2('ES6')}}         | Definição inicial. |
+| Specification                                          | Status               | Comment            |
+| ------------------------------------------------------ | -------------------- | ------------------ |
+| {{SpecName('ES6', '#sec-super-keyword', 'super')}}     | {{Spec2('ES6')}}     | Definição inicial. |
 | {{SpecName('ESDraft', '#sec-super-keyword', 'super')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/operators/this/index.md
+++ b/files/pt-br/web/javascript/reference/operators/this/index.md
@@ -38,7 +38,7 @@ Dentro de uma função, o valor de `this` depende de como a função é chamada.
 Como o código a seguir não está no modo estrito, o valor de `this` não é definido pela chamada. Por padrão, `this` será o objeto global que no navegador é o `window`.
 
 ```js
-function f1(){
+function f1() {
   return this;
 }
 
@@ -49,7 +49,7 @@ f1() === window; // true
 Em modo estrito, o valor de `this` permanece seja qual for o definido ao entrar no contexto de execução, assim, no caso a seguir, `this` por padrão será indefinido (`undefined`):
 
 ```js
-function f2(){
+function f2() {
   "use strict"; // assume modo estrito
   return this;
 }
@@ -67,7 +67,7 @@ Nas [arrow functions](/pt-BR/docs/Web/JavaScript/Reference/Functions/Arrow_funct
 
 ```js
 var globalObject = this;
-var foo = (() => this);
+var foo = () => this;
 console.log(foo() === globalObject); // true
 ```
 
@@ -75,7 +75,7 @@ Não importa como `foo` é chamado, o `this` continuará como o objeto global. I
 
 ```js
 // Chama como um método de um objeto
-var obj = {foo: foo};
+var obj = { foo: foo };
 console.log(obj.foo() === globalObject); // true
 
 // Tentativa de definir this usando call
@@ -94,11 +94,12 @@ Não importa como for, o this do foo mantém o valor que recebeu quando foi cria
 // uma função arrow, para que seu this esteja permanentemente
 // ligado ao this da função que a envolve. O valor de bar pode ser // definido na chamada, que por sua vez define o valor da função
 // retornada.
-var obj = { bar : function() {
-                    var x = (() => this);
-                    return x;
-                  }
-          };
+var obj = {
+  bar: function () {
+    var x = () => this;
+    return x;
+  },
+};
 
 // Chama bar como método de obj, configurando seu this como obj
 // Assina à variável fn uma referência para a função retornada
@@ -120,9 +121,9 @@ No exemplo a seguir, quando `o.f()` é invocado, o this dentro da função é vi
 ```js
 var o = {
   prop: 37,
-  f: function() {
+  f: function () {
     return this.prop;
-  }
+  },
 };
 
 console.log(o.f()); // logs 37
@@ -131,7 +132,7 @@ console.log(o.f()); // logs 37
 Observe que esse comportamento não é afetado mesmo pela forma como (ou onde) a função foi definida. No exemplo anterior, nós definimos a função in-line (em linha) como o membro f durante a definição de o. No entanto, poderíamos ter apenas facilmente definido a função primeiro e depois anexado a o.f. Fazendo isso resulta no mesmo comportamento:
 
 ```js
-var o = {prop: 37};
+var o = { prop: 37 };
 
 function independent() {
   return this.prop;
@@ -147,7 +148,7 @@ Isto demonstra que é importante apenas que a função foi chamada a partir do m
 Da mesma forma, a vinculação de this só é afetada pela referência do membro mais imediato. No exemplo a seguir, quando invocamos a função, podemos chamá-la como um método g do objeto o.b. Desta vez, durante a execução, o this dentro da função irá se referir a o.b. O fato do objeto ser um membro de o não tem qualquer consequência; a referência mais imediata é tudo que importa.
 
 ```js
-o.b = {g: independent, prop: 42};
+o.b = { g: independent, prop: 42 };
 console.log(o.b.g()); // registra 42
 ```
 
@@ -156,7 +157,11 @@ console.log(o.b.g()); // registra 42
 A mesma noção vale para métodos definidos em algum lugar da cadeia de protótipos do objeto. Se o método está na cadeia de protótipo de um objeto, this refere-se ao objeto que é proprietário do método chamado, como se o método estivesse no objeto.
 
 ```js
-var o = {f:function(){ return this.a + this.b; }};
+var o = {
+  f: function () {
+    return this.a + this.b;
+  },
+};
 var p = Object.create(o);
 p.a = 1;
 p.b = 4;
@@ -171,20 +176,23 @@ Neste exemplo, o objeto atribuído à variável p não tem sua própria propried
 Mais uma vez, a mesma noção se aplica quando uma função é chamada a partir de um getter ou setter. A função usada como getter ou setter tem seu this ligado ao objeto do qual a propriedade está sendo modificada ou selecionada.
 
 ```js
-function modulus(){
+function modulus() {
   return Math.sqrt(this.re * this.re + this.im * this.im);
 }
 
 var o = {
   re: 1,
   im: -1,
-  get phase(){
+  get phase() {
     return Math.atan2(this.im, this.re);
-  }
+  },
 };
 
-Object.defineProperty(o, 'modulus', {
-    get: modulus, enumerable:true, configurable:true});
+Object.defineProperty(o, "modulus", {
+  get: modulus,
+  enumerable: true,
+  configurable: true,
+});
 
 console.log(o.phase, o.modulus); // logs -0.78 1.4142
 ```
@@ -215,17 +223,16 @@ Nota: enquanto o padrão para um construtor é retornar o objeto referenciado po
  * }
  */
 
-function C(){
+function C() {
   this.a = 37;
 }
 
 var o = new C();
 console.log(o.a); // logs 37
 
-
-function C2(){
+function C2() {
   this.a = 37;
-  return {a:38};
+  return { a: 38 };
 }
 
 o = new C2();
@@ -239,11 +246,11 @@ No último exemplo (C2), porque um objeto foi retornado durante a construção, 
 Quando uma função usa a palavra-chave this em seu corpo, o seu valor pode ser vinculado a um determinado objeto na chamada utilizando os métodos [`call`](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Function/call) or [`apply`](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Function/apply) que todas as funções herdam de Function.prototype.
 
 ```js
-function add(c, d){
+function add(c, d) {
   return this.a + this.b + c + d;
 }
 
-var o = {a:1, b:3};
+var o = { a: 1, b: 3 };
 
 // O primeiro parâmetro é o objeto a usar como
 // 'this'; subsequentes parâmetros são passados como
@@ -292,21 +299,21 @@ Quando uma função é usada como um manipulador de eventos, seu this está defi
 ```js
 // Quando chamado como listener, transforma o elemento blue
 // relacionado
-function bluify(e){
+function bluify(e) {
   // sempre true
   console.log(this === e.currentTarget);
   // true quando currentTarget e target são o mesmo objeto
   console.log(this === e.target);
-  this.style.backgroundColor = '#A5D9F3';
+  this.style.backgroundColor = "#A5D9F3";
 }
 
 // Obtém uma lista de todo elemento no documento
-var elements = document.getElementsByTagName('*');
+var elements = document.getElementsByTagName("*");
 
 // Adiciona bluify com um click listener (escutador de click)
 // para que quando o elemento seja clicado se torne azul
-for(var i=0 ; i<elements.length ; i++){
-  elements[i].addEventListener('click', bluify, false);
+for (var i = 0; i < elements.length; i++) {
+  elements[i].addEventListener("click", bluify, false);
 }
 ```
 
@@ -315,30 +322,26 @@ for(var i=0 ; i<elements.length ; i++){
 Quando o código é chamado de um manipulador de evento in-line, seu this está definido para o elemento DOM em que o listener é colocado:
 
 ```js
-<button onclick="alert(this.tagName.toLowerCase());">
-  Show this
-</button>
+<button onclick="alert(this.tagName.toLowerCase());">Show this</button>
 ```
 
 O alerta acima mostra button. Note, porém, que apenas o código exterior tem um this definido desta maneira:
 
 ```js
-<button onclick="alert((function(){return this}()));">
-  Show inner this
-</button>
+<button onclick="alert((function(){return this}()));">Show inner this</button>
 ```
 
 Neste caso, o this da função interior não está definido, portanto ele retorna o objeto global/objeto window (ou seja, o objeto padrão no modo não-estrito onde this não está definido pela chamada).
 
 ## Especificações
 
-| Especificação                                                                        | Estado                       | Comentário                                         |
-| ------------------------------------------------------------------------------------ | ---------------------------- | -------------------------------------------------- |
+| Especificação                                                    | Estado               | Comentário                                         |
+| ---------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-this-keyword', 'The this keyword')}} | {{Spec2('ESDraft')}} |                                                    |
-| {{SpecName('ES6', '#sec-this-keyword', 'The this keyword')}}     | {{Spec2('ES6')}}         |                                                    |
-| {{SpecName('ES5.1', '#sec-11.1.1', 'The this keyword')}}         | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES3', '#sec-11.1.1', 'The this keyword')}}             | {{Spec2('ES3')}}         |                                                    |
-| {{SpecName('ES1', '#sec-11.1.1', 'The this keyword')}}             | {{Spec2('ES1')}}         | Initial definition. Implemented in JavaScript 1.0. |
+| {{SpecName('ES6', '#sec-this-keyword', 'The this keyword')}}     | {{Spec2('ES6')}}     |                                                    |
+| {{SpecName('ES5.1', '#sec-11.1.1', 'The this keyword')}}         | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES3', '#sec-11.1.1', 'The this keyword')}}           | {{Spec2('ES3')}}     |                                                    |
+| {{SpecName('ES1', '#sec-11.1.1', 'The this keyword')}}           | {{Spec2('ES1')}}     | Initial definition. Implemented in JavaScript 1.0. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/operators/typeof/index.md
+++ b/files/pt-br/web/javascript/reference/operators/typeof/index.md
@@ -44,47 +44,47 @@ Esta tabela resume os possíveis valores que são retornados pelo `typeof`:
 
 ```js
 // Números - Numéricos
-typeof 37 === 'number';
-typeof 3.14 === 'number';
-typeof Math.LN2 === 'number';
-typeof Infinity === 'number';
-typeof NaN === 'number'; // Apesar de ser "Não-Numérico"
-typeof Number(1) === 'number'; // mas nunca utilize desta forma!
+typeof 37 === "number";
+typeof 3.14 === "number";
+typeof Math.LN2 === "number";
+typeof Infinity === "number";
+typeof NaN === "number"; // Apesar de ser "Não-Numérico"
+typeof Number(1) === "number"; // mas nunca utilize desta forma!
 
 // Strings - Seqüências de caracteres
-typeof "" === 'string';
-typeof "bla" === 'string';
-typeof (typeof 1) === 'string'; // typeof sempre retorna uma string
-typeof String("abc") === 'string'; // mas nunca utilize desta forma!
+typeof "" === "string";
+typeof "bla" === "string";
+typeof typeof 1 === "string"; // typeof sempre retorna uma string
+typeof String("abc") === "string"; // mas nunca utilize desta forma!
 
 // Booleans - Lógicos booleanos
-typeof true === 'boolean';
-typeof false === 'boolean';
-typeof Boolean(true) === 'boolean'; // mas nunca utilize desta forma!
+typeof true === "boolean";
+typeof false === "boolean";
+typeof Boolean(true) === "boolean"; // mas nunca utilize desta forma!
 
 // Undefined - Indefinidos
-typeof undefined === 'undefined';
-typeof blabla === 'undefined'; // uma variável indefinida
+typeof undefined === "undefined";
+typeof blabla === "undefined"; // uma variável indefinida
 
 // Objetos
-typeof {a:1} === 'object';
-typeof [1, 2, 4] === 'object'; // use Array.isArray ou Object.prototype.toString.call para diferenciar os objetos das arrays
-typeof new Date() === 'object';
+typeof { a: 1 } === "object";
+typeof [1, 2, 4] === "object"; // use Array.isArray ou Object.prototype.toString.call para diferenciar os objetos das arrays
+typeof new Date() === "object";
 
-typeof new Boolean(true) === 'object'; // isto é confuso, portanto não use desta forma!
-typeof new Number(1) === 'object'; // isto é confuso, portanto não use desta forma!
-typeof new String("abc") === 'object';  // isso também é confuso, assim evite usar esta construção!
+typeof new Boolean(true) === "object"; // isto é confuso, portanto não use desta forma!
+typeof new Number(1) === "object"; // isto é confuso, portanto não use desta forma!
+typeof new String("abc") === "object"; // isso também é confuso, assim evite usar esta construção!
 
 // Funções
-typeof function(){} === 'function';
-typeof Math.sin === 'function';
+typeof function () {} === "function";
+typeof Math.sin === "function";
 ```
 
 ### `null`
 
 ```js
 // Desde os primóridos do JavaScript
-typeof null === 'object';
+typeof null === "object";
 ```
 
 Na primeira implementação do JavaScript, valores em JavaScript foram representados com uma tag (etiqueta) de tipo e um valor. A tag de tipo para objetos foi 0. `null` foi representada com o ponteiro NULL (0x00 na maioria das plataformas). Consequentemente, null teve 0 como sua tag de tipo, portanto o `typeof` retorna esse valor. (necessário referência)
@@ -96,8 +96,8 @@ Está previsto [para ser corrigido na próxima versão do ECMAScript](http://wik
 Expressões regulares que podem ser chamadas foram uma adição não-padrão em alguns browsers (necessidade de referência para dizer qual).
 
 ```js
-typeof /s/ === 'function'; // Chrome 1-12 ... // Não-conforme no ECMAScript 5.1
-typeof /s/ === 'object'; // Firefox 5+ ...    // Conforme no ECMAScript 5.1
+typeof /s/ === "function"; // Chrome 1-12 ... // Não-conforme no ECMAScript 5.1
+typeof /s/ === "object"; // Firefox 5+ ...    // Conforme no ECMAScript 5.1
 ```
 
 ### Outras peculiaridades

--- a/files/pt-br/web/javascript/reference/operators/void/index.md
+++ b/files/pt-br/web/javascript/reference/operators/void/index.md
@@ -24,18 +24,18 @@ O operador `void` é muitas vezes utilizado apenas para obter o valor primitivo 
 Quando usamos uma [Chamada imediata das expressões da função](/pt-BR/docs/Glossary/IIFE), valores nulos podem ser usado para forçar a palavra-chave da função a ser tratada como uma expressão em vez de uma declaração.
 
 ```js
-void function iife() {
-    var bar = function () {};
-    var baz = function () {};
-    var foo = function () {
-        bar();
-        baz();
-     };
-    var biz = function () {};
+void (function iife() {
+  var bar = function () {};
+  var baz = function () {};
+  var foo = function () {
+    bar();
+    baz();
+  };
+  var biz = function () {};
 
-    foo();
-    biz();
-}();
+  foo();
+  biz();
+})();
 ```
 
 ## JavaScript URIs
@@ -43,9 +43,7 @@ void function iife() {
 Quando o navegador segue uma URI `javascript`, ele avalia o código na URI e então troca o conteúdo da página pelo valor retornado por este, a não ser que o valor retornado seja {{jsxref("Global_Objects/undefined", "undefined")}}. O operador `void` pode ser usado para retornar {{jsxref("Global_Objects/undefined", "undefined")}}. Por exemplo:
 
 ```html
-<a href="javascript:void(0);">
-  Clique aqui para não fazer nada
-</a>
+<a href="javascript:void(0);">Clique aqui para não fazer nada</a>
 
 <a href="javascript:void(document.body.style.backgroundColor='green');">
   Clique aqui para o papel de parede ser verde
@@ -56,11 +54,11 @@ Note que no entanto o pseudo protocolo `javascript:` tem seu uso desencorajado p
 
 ## Specificações
 
-| Specificação                                                                         | Status                   | Comentário                                        |
-| ------------------------------------------------------------------------------------ | ------------------------ | ------------------------------------------------- |
-| ECMAScript 1                                                                         | Standard                 | Initial definition. Implemented in JavaScript 1.1 |
-| {{SpecName('ES5.1', '#sec-11.4.2', 'The void Operator')}}         | {{Spec2('ES5.1')}} |                                                   |
-| {{SpecName('ES6', '#sec-void-operator', 'The void Operator')}} | {{Spec2('ES6')}}     |                                                   |
+| Specificação                                                   | Status             | Comentário                                        |
+| -------------------------------------------------------------- | ------------------ | ------------------------------------------------- |
+| ECMAScript 1                                                   | Standard           | Initial definition. Implemented in JavaScript 1.1 |
+| {{SpecName('ES5.1', '#sec-11.4.2', 'The void Operator')}}      | {{Spec2('ES5.1')}} |                                                   |
+| {{SpecName('ES6', '#sec-void-operator', 'The void Operator')}} | {{Spec2('ES6')}}   |                                                   |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/operators/yield/index.md
+++ b/files/pt-br/web/javascript/reference/operators/yield/index.md
@@ -42,8 +42,7 @@ O código seguinte é a declaração de um exemplo de uma generator function.
 ```js
 function* foo() {
   var index = 0;
-  while (index <= 2)
-    yield index++;
+  while (index <= 2) yield index++;
 }
 ```
 
@@ -59,9 +58,9 @@ console.log(iterator.next()); // { value: undefined, done: true }
 
 ## Especificações
 
-| Especificação                                    | Situação                     | Comentário         |
-| ------------------------------------------------ | ---------------------------- | ------------------ |
-| {{SpecName('ES2015', '#', 'Yield')}} | {{Spec2('ES2015')}}     | Definição inicial. |
+| Especificação                         | Situação             | Comentário         |
+| ------------------------------------- | -------------------- | ------------------ |
+| {{SpecName('ES2015', '#', 'Yield')}}  | {{Spec2('ES2015')}}  | Definição inicial. |
 | {{SpecName('ESDraft', '#', 'Yield')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/operators/yield_star_/index.md
+++ b/files/pt-br/web/javascript/reference/operators/yield_star_/index.md
@@ -58,7 +58,7 @@ Além de objetos generator, `yield*` também podem `yield` outros tipos de objet
 ```js
 function* g3() {
   yield* [1, 2];
-  yield* '34';
+  yield* "34";
   yield* Array.from(arguments);
 }
 
@@ -80,7 +80,7 @@ console.log(iterator.next()); // {value: undefined, done: true}
 ```js
 function* g4() {
   yield* [1, 2, 3];
-  return 'foo';
+  return "foo";
 }
 
 var result;
@@ -95,16 +95,16 @@ console.log(iterator.next()); // {value: 1, done: false}
 console.log(iterator.next()); // {value: 2, done: false}
 console.log(iterator.next()); // {value: 3, done: false}
 console.log(iterator.next()); // {value: undefined, done: true},
-                              // g4() returned {value: 'foo', done: true} nesse ponto
+// g4() returned {value: 'foo', done: true} nesse ponto
 
-console.log(result);          // "foo"
+console.log(result); // "foo"
 ```
 
 ## Especificações
 
-| Especificação                                    | Situação                     | Comentário         |
-| ------------------------------------------------ | ---------------------------- | ------------------ |
-| {{SpecName('ES2015', '#', 'Yield')}} | {{Spec2('ES2015')}}     | Definição inicial. |
+| Especificação                         | Situação             | Comentário         |
+| ------------------------------------- | -------------------- | ------------------ |
+| {{SpecName('ES2015', '#', 'Yield')}}  | {{Spec2('ES2015')}}  | Definição inicial. |
 | {{SpecName('ESDraft', '#', 'Yield')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/statements/async_function/index.md
+++ b/files/pt-br/web/javascript/reference/statements/async_function/index.md
@@ -39,7 +39,7 @@ Uma função assíncrona pode conter uma expressão {{jsxref("Operators/await", 
 
 ```js
 function resolverDepoisDe2Segundos(x) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(() => {
       resolve(x);
     }, 2000);
@@ -49,11 +49,11 @@ function resolverDepoisDe2Segundos(x) {
 async function adicionar1(x) {
   var a = resolverDepoisDe2Segundos(20);
   var b = resolverDepoisDe2Segundos(30);
-  return x + await a + await b;
+  return x + (await a) + (await b);
 }
 
-adicionar1(10).then(v => {
-  console.log(v);  // exibe 60 depois de 2 segundos.
+adicionar1(10).then((v) => {
+  console.log(v); // exibe 60 depois de 2 segundos.
 });
 
 async function adicionar2(x) {
@@ -62,8 +62,8 @@ async function adicionar2(x) {
   return x + a + b;
 }
 
-adicionar2(10).then(v => {
-  console.log(v);  // exibe 60 depois de 4 segundos.
+adicionar2(10).then((v) => {
+  console.log(v); // exibe 60 depois de 4 segundos.
 });
 ```
 
@@ -74,10 +74,10 @@ Uma API que retorna uma {{jsxref("Promise")}} vai resultar em uma cadeia de `Pro
 ```js
 function pegarDadosProcessados(url) {
   return baixarDados(url) // retorna uma Promise
-    .catch(e => {
-      return baixarDadosReservas(url) // retorna uma Promise
+    .catch((e) => {
+      return baixarDadosReservas(url); // retorna uma Promise
     })
-    .then(v => {
+    .then((v) => {
       return processarDadosNoWorker(v); // retorna uma Promise
     });
 }
@@ -90,7 +90,7 @@ async function pegarDadosProcessados(url) {
   let v;
   try {
     v = await baixarDados(url);
-  } catch(e) {
+  } catch (e) {
     v = await baixarDadosReservas(url);
   }
   return processarDadosNoWorker(v);
@@ -101,8 +101,8 @@ Note que no exemplo acima não tem a instrução `await` na instrução do `retu
 
 ## Especificações
 
-| Especificação                                                                                        | Situação                     | Comentário                   |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------- | ---------------------------- |
+| Especificação                                                                | Situação             | Comentário                   |
+| ---------------------------------------------------------------------------- | -------------------- | ---------------------------- |
 | {{SpecName('ESDraft', '#sec-async-function-definitions', 'async function')}} | {{Spec2('ESDraft')}} | Definição inicial no ES2017. |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/statements/block/index.md
+++ b/files/pt-br/web/javascript/reference/statements/block/index.md
@@ -78,13 +78,13 @@ Note que o escope bloqueado de `const c = 2` _não invoca uma_ `SyntaxError: Ide
 
 ## Especificações
 
-| Especificação                                                                | Situação                     | Comentário                                         |
-| ---------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
+| Especificação                                            | Situação             | Comentário                                         |
+| -------------------------------------------------------- | -------------------- | -------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-block', 'Block statement')}} | {{Spec2('ESDraft')}} |                                                    |
-| {{SpecName('ES6', '#sec-block', 'Block statement')}}         | {{Spec2('ES6')}}         |                                                    |
-| {{SpecName('ES5.1', '#sec-12.1', 'Block statement')}}     | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES3', '#sec-12.1', 'Block statement')}}         | {{Spec2('ES3')}}         |                                                    |
-| {{SpecName('ES1', '#sec-12.1', 'Block statement')}}         | {{Spec2('ES1')}}         | Definição inicial. Implementada no JavaScript 1.0. |
+| {{SpecName('ES6', '#sec-block', 'Block statement')}}     | {{Spec2('ES6')}}     |                                                    |
+| {{SpecName('ES5.1', '#sec-12.1', 'Block statement')}}    | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES3', '#sec-12.1', 'Block statement')}}      | {{Spec2('ES3')}}     |                                                    |
+| {{SpecName('ES1', '#sec-12.1', 'Block statement')}}      | {{Spec2('ES1')}}     | Definição inicial. Implementada no JavaScript 1.0. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/statements/break/index.md
+++ b/files/pt-br/web/javascript/reference/statements/break/index.md
@@ -28,30 +28,29 @@ A função a seguir possui um comando `break` que encerra o loop {{jsxref("State
 
 ```js
 function testaBreak(x) {
-   var i = 0;
+  var i = 0;
 
-   while (i < 6) {
-      if (i == 3) {
-         break;
-      }
-      i += 1;
-   }
-   return i * x;
+  while (i < 6) {
+    if (i == 3) {
+      break;
+    }
+    i += 1;
+  }
+  return i * x;
 }
 ```
 
 O código a seguir possui o comando break dentro de uma estrutura nomeada. O comando `break` deverá estar dentro da estrutura na qual o label se refere. Veja que `inner_block` está dentro de `outer_block`.
 
 ```js
-bloco_externo:{
-
-  bloco_interno:{
-    console.log ('1');
-    break bloco_externo;      // encerra bloco_interno e bloco_externok
-    console.log (':-(');    // não é executado
+bloco_externo: {
+  bloco_interno: {
+    console.log("1");
+    break bloco_externo; // encerra bloco_interno e bloco_externok
+    console.log(":-("); // não é executado
   }
 
-  console.log ('2');        // não é executado
+  console.log("2"); // não é executado
 }
 ```
 
@@ -70,12 +69,12 @@ bloco_2:{
 
 ## Especificações
 
-| Especificação                                                                        | Status                   | Comentário                                    |
-| ------------------------------------------------------------------------------------ | ------------------------ | --------------------------------------------- |
-| ECMAScript 1st Edition                                                               | Standard                 | Definição inicial. Versão sem o uso do label. |
-| ECMAScript 3rd Edition                                                               | Standard                 | Versão com label adicionada.                  |
-| {{SpecName('ES5.1', '#sec-12.8', 'Break statement')}}             | {{Spec2('ES5.1')}} |                                               |
-| {{SpecName('ES6', '#sec-break-statement', 'Break statement')}} | {{Spec2('ES6')}}     |                                               |
+| Especificação                                                  | Status             | Comentário                                    |
+| -------------------------------------------------------------- | ------------------ | --------------------------------------------- |
+| ECMAScript 1st Edition                                         | Standard           | Definição inicial. Versão sem o uso do label. |
+| ECMAScript 3rd Edition                                         | Standard           | Versão com label adicionada.                  |
+| {{SpecName('ES5.1', '#sec-12.8', 'Break statement')}}          | {{Spec2('ES5.1')}} |                                               |
+| {{SpecName('ES6', '#sec-break-statement', 'Break statement')}} | {{Spec2('ES6')}}   |                                               |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/statements/class/index.md
+++ b/files/pt-br/web/javascript/reference/statements/class/index.md
@@ -30,7 +30,7 @@ No exemplo a seguir, primeiro definimos uma classe chamada _Polygon_, então ext
 ```js
 class Poligono {
   constructor(altura, largura) {
-    this.nome = 'Polígono';
+    this.nome = "Polígono";
     this.altura = altura;
     this.largura = largura;
   }
@@ -39,15 +39,15 @@ class Poligono {
 class Quadrado extends Poligono {
   constructor(altura) {
     super(altura, altura);
-    this.nome = 'Quadrado';
+    this.nome = "Quadrado";
   }
 }
 ```
 
 ## Especificações
 
-| Especificação                                                                            | Status               | Comentário         |
-| ---------------------------------------------------------------------------------------- | -------------------- | ------------------ |
+| Especificação                                                      | Status           | Comentário         |
+| ------------------------------------------------------------------ | ---------------- | ------------------ |
 | {{SpecName('ES6', '#sec-class-definitions', 'Class definitions')}} | {{Spec2('ES6')}} | definição inicial. |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/statements/const/index.md
+++ b/files/pt-br/web/javascript/reference/statements/const/index.md
@@ -101,9 +101,9 @@ MY_ARRAY = ['B'];
 
 ## Especificações
 
-| Especificação                                                                                                        | Status                       | Comentário         |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('ES6', '#sec-let-and-const-declarations', 'Let and Const Declarations')}}     | {{Spec2('ES6')}}         | Nenhuma mudança.   |
+| Especificação                                                                            | Status               | Comentário         |
+| ---------------------------------------------------------------------------------------- | -------------------- | ------------------ |
+| {{SpecName('ES6', '#sec-let-and-const-declarations', 'Let and Const Declarations')}}     | {{Spec2('ES6')}}     | Nenhuma mudança.   |
 | {{SpecName('ESDraft', '#sec-let-and-const-declarations', 'Let and Const Declarations')}} | {{Spec2('ESDraft')}} | Definição inicial. |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/statements/continue/index.md
+++ b/files/pt-br/web/javascript/reference/statements/continue/index.md
@@ -63,11 +63,10 @@ checkiandj: while (i < 4) {
   i += 1;
 
   checkj: while (j > 4) {
-    console.log("j: "+ j);
+    console.log("j: " + j);
     j -= 1;
 
-    if ((j % 2) == 0)
-      continue checkj;
+    if (j % 2 == 0) continue checkj;
     console.log(j + " is odd.");
   }
   console.log("i = " + i);
@@ -78,41 +77,41 @@ checkiandj: while (i < 4) {
 Output:
 
 ```js
-"i: 0"
+"i: 0";
 
 // start checkj
-"j: 8"
-"7 is odd."
-"j: 7"
-"j: 6"
-"5 is odd."
-"j: 5"
+"j: 8";
+"7 is odd.";
+"j: 7";
+"j: 6";
+"5 is odd.";
+"j: 5";
 // end checkj
 
-"i = 1"
-"j = 4"
+"i = 1";
+"j = 4";
 
-"i: 1"
-"i = 2"
-"j = 4"
+"i: 1";
+"i = 2";
+"j = 4";
 
-"i: 2"
-"i = 3"
-"j = 4"
+"i: 2";
+"i = 3";
+"j = 4";
 
-"i: 3"
-"i = 4"
-"j = 4"
+"i: 3";
+"i = 4";
+"j = 4";
 ```
 
 ## Especificações
 
-| Especificação                                                                                    | Status                       | Comentários                           |
-| ------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------------------------- |
-| {{SpecName('ES1')}}                                                                         | {{Spec2('ES1')}}         | Definição inicial. Versão sem rótulo. |
-| {{SpecName('ES3')}}                                                                         | {{Spec2('ES3')}}         | Versão rotulada adicionada.           |
-| {{SpecName('ES5.1', '#sec-12.7', 'Continue statement')}}                     | {{Spec2('ES5.1')}}     |                                       |
-| {{SpecName('ES6', '#sec-continue-statement', 'Continue statement')}}     | {{Spec2('ES6')}}         |                                       |
+| Especificação                                                            | Status               | Comentários                           |
+| ------------------------------------------------------------------------ | -------------------- | ------------------------------------- |
+| {{SpecName('ES1')}}                                                      | {{Spec2('ES1')}}     | Definição inicial. Versão sem rótulo. |
+| {{SpecName('ES3')}}                                                      | {{Spec2('ES3')}}     | Versão rotulada adicionada.           |
+| {{SpecName('ES5.1', '#sec-12.7', 'Continue statement')}}                 | {{Spec2('ES5.1')}}   |                                       |
+| {{SpecName('ES6', '#sec-continue-statement', 'Continue statement')}}     | {{Spec2('ES6')}}     |                                       |
 | {{SpecName('ESDraft', '#sec-continue-statement', 'Continue statement')}} | {{Spec2('ESDraft')}} |                                       |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/statements/debugger/index.md
+++ b/files/pt-br/web/javascript/reference/statements/debugger/index.md
@@ -19,23 +19,23 @@ O exemplo a seguir mostra o código onde uma declaração debugger foi inserida 
 
 ```js
 function codigoPotencialmenteBugado() {
-    debugger;
-    // faça atividades de depuração como examinar, pular um passo etc.
+  debugger;
+  // faça atividades de depuração como examinar, pular um passo etc.
 }
 ```
 
 Quando o depurador é invocado, a execução é parada na declaração debugger. É como um breakpoint no código-fonte.
 
-[![Paused at a debugger statement.](screen_shot_2014-02-07_at_9.14.35_am.png)](<screen_shot_2014-02-07_at_9.14.35_am.png>)
+[![Paused at a debugger statement.](screen_shot_2014-02-07_at_9.14.35_am.png)](screen_shot_2014-02-07_at_9.14.35_am.png)
 
 ## Especificações
 
-| Especificação                                                                                | Status                   | Comentário                                   |
-| -------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| {{SpecName('ES6', '#sec-debugger-statement', 'Debugger statement')}} | {{Spec2('ES6')}}     |                                              |
-| {{SpecName('ES5.1', '#sec-12.15', 'Debugger statement')}}                 | {{Spec2('ES5.1')}} | Definição Inicial                            |
-| {{SpecName('ES3', '#sec-7.5.3', 'Debugger statement')}}                     | {{Spec2('ES3')}}     |                                              |
-| {{SpecName('ES1', '#sec-7.4.3', 'Debugger statement')}}                     | {{Spec2('ES1')}}     | Apenas mencioado como uma palavra reservada. |
+| Especificação                                                        | Status             | Comentário                                   |
+| -------------------------------------------------------------------- | ------------------ | -------------------------------------------- |
+| {{SpecName('ES6', '#sec-debugger-statement', 'Debugger statement')}} | {{Spec2('ES6')}}   |                                              |
+| {{SpecName('ES5.1', '#sec-12.15', 'Debugger statement')}}            | {{Spec2('ES5.1')}} | Definição Inicial                            |
+| {{SpecName('ES3', '#sec-7.5.3', 'Debugger statement')}}              | {{Spec2('ES3')}}   |                                              |
+| {{SpecName('ES1', '#sec-7.4.3', 'Debugger statement')}}              | {{Spec2('ES1')}}   | Apenas mencioado como uma palavra reservada. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/statements/do...while/index.md
+++ b/files/pt-br/web/javascript/reference/statements/do...while/index.md
@@ -35,13 +35,13 @@ No exemplo seguinte, o laço **do...while** soma pelo menos uma vez e executa no
 ### Conteúdo JavaScript
 
 ```js
-var resultado = '';
+var resultado = "";
 var i = 0;
 do {
-   i += 1;
-   resultado += i + ' ';
+  i += 1;
+  resultado += i + " ";
 } while (i < 5);
-document.getElementById('exemplo').innerHTML = resultado;
+document.getElementById("exemplo").innerHTML = resultado;
 ```
 
 ### Resultado
@@ -50,11 +50,11 @@ document.getElementById('exemplo').innerHTML = resultado;
 
 ## Especificações
 
-| Specification                                                                                | Status                   | Comment                                           |
-| -------------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------- |
-| ECMAScript 3rd Edition.                                                                      | Standard                 | Initial definition. Implemented in JavaScript 1.2 |
-| {{SpecName('ES5.1', '#sec-12.6.1', 'do-while statement')}}                 | {{Spec2('ES5.1')}} |                                                   |
-| {{SpecName('ES6', '#sec-do-while-statement', 'do-while statement')}} | {{Spec2('ES6')}}     | Trailing ; is now optional.                       |
+| Specification                                                        | Status             | Comment                                           |
+| -------------------------------------------------------------------- | ------------------ | ------------------------------------------------- |
+| ECMAScript 3rd Edition.                                              | Standard           | Initial definition. Implemented in JavaScript 1.2 |
+| {{SpecName('ES5.1', '#sec-12.6.1', 'do-while statement')}}           | {{Spec2('ES5.1')}} |                                                   |
+| {{SpecName('ES6', '#sec-do-while-statement', 'do-while statement')}} | {{Spec2('ES6')}}   | Trailing ; is now optional.                       |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/statements/empty/index.md
+++ b/files/pt-br/web/javascript/reference/statements/empty/index.md
@@ -29,38 +29,33 @@ A instrução vazia às vezes é usada com instruções de loop. Veja o exemplo 
 var arr = [1, 2, 3];
 
 // Assign all array values to 0
-for (i = 0; i < arr.length; arr[i++] = 0) /* empty statement */ ;
+for (i = 0; i < arr.length; arr[i++] = 0 /* empty statement */);
 
-console.log(arr)
+console.log(arr);
 // [0, 0, 0]
 ```
 
 **Nota:** É uma boa ideia comentar o uso intencional da declaração vazia, pois não é realmente óbvio distinguir entre um ponto e vírgula normal. No exemplo a seguir, o uso provavelmente não é intencional:
 
-```js
-if (condition);       // Caution, this "if" does nothing!
-   killTheUniverse()  // So this gets always executed!!!
+```js-nolint
+if (condition) // Caution, this "if" does nothing!
+  killTheUniverse(); // So this gets always executed!!!
 ```
 
 Outro Exemplo: Uma declaração [`if...else`](/pt-BR/docs/Web/JavaScript/Reference/Statements/if...else) declaração sem chaves ({ }). Se três for verdadeiro, nada acontecerá, quatro não importa e também a função launchRocket ( ) no caso contrário não será executada.
 
 ```js
-if (one)
-  doOne();
-else if (two)
-  doTwo();
-else if (three)
-  ; // nothing here
-else if (four)
-  doFour();
-else
-  launchRocket();
+if (one) doOne();
+else if (two) doTwo();
+else if (three) // nothing here
+else if (four) doFour();
+else launchRocket();
 ```
 
 ## Especificações
 
-| Especificações                                                                           |
-| ---------------------------------------------------------------------------------------- |
+| Especificações                                                     |
+| ------------------------------------------------------------------ |
 | {{SpecName('ESDraft', '#sec-empty-statement', 'Empty statement')}} |
 
 ## Browsers compatíveis

--- a/files/pt-br/web/javascript/reference/statements/export/index.md
+++ b/files/pt-br/web/javascript/reference/statements/export/index.md
@@ -82,20 +82,20 @@ Mas a exportação padrão pode ser importada com qualquer nome, por exemplo:
 
 ```js
 // arquivo test.js
-let k; export default k = 12;
+let k;
+export default k = 12;
 ```
 
 ```js
 // algum outro arquivo
-import m from './test'; // note que temos a liberdade de usar import m ao invés de import k, porque k era uma exportaçào padrão
-console.log(m);        // vai retornar log 12
+import m from "./test"; // note que temos a liberdade de usar import m ao invés de import k, porque k era uma exportaçào padrão
+console.log(m); // vai retornar log 12
 ```
 
 Você também pode renomear exportações explícitas para evitar conflitos e nome:
 
 ```js
-export { myFunction as function1,
-         myVariable as variable };
+export { myFunction as function1, myVariable as variable };
 ```
 
 ### Re-exportando / Agregando
@@ -105,15 +105,13 @@ export { myFunction as function1,
 Isto pode ser feito com a sintaxe "export from":
 
 ```js
-export { default as function1,
-         function2 } from 'bar.js';
+export { default as function1, function2 } from "bar.js";
 ```
 
 O que é comparável com um combinação de import e export:
 
 ```js
-import { default as function1,
-         function2 } from 'bar.js';
+import { default as function1, function2 } from "bar.js";
 export { function1, function2 };
 ```
 
@@ -122,17 +120,17 @@ Mas onde `function1` e `function2` não ficam disponíveis dentro do módulo atu
 > **Nota:** Os exemplos a seguir são sintaticamente inválidos apesar de sua equivalência com o import:
 
 ```js
-import DefaultExport from 'bar.js'; // Válido
+import DefaultExport from "bar.js"; // Válido
 ```
 
 ```js
-export DefaultExport from 'bar.js'; // Inválido
+export DefaultExport from "bar.js"; // Inválido
 ```
 
 O modo correto de fazer isso e renomeando o export:
 
 ```js
-export { default as DefaultExport } from 'bar.js';
+export { default as DefaultExport } from "bar.js";
 ```
 
 ## Exemplos
@@ -151,13 +149,13 @@ const foo = Math.PI + Math.SQRT2;
 
 var graph = {
   options: {
-      color:'white',
-      thickness:'2px'
+    color: "white",
+    thickness: "2px",
   },
-  draw: function() {
-      console.log('Da função draw de graph');
-  }
-}
+  draw: function () {
+    console.log("Da função draw de graph");
+  },
+};
 
 export { cube, foo, graph };
 ```
@@ -165,16 +163,16 @@ export { cube, foo, graph };
 Então, no módulo principal incluído sem sua página HTML, poderíamos ter:
 
 ```js
-import { cube, foo, graph } from './my-module.js';
+import { cube, foo, graph } from "./my-module.js";
 
 graph.options = {
-    color:'blue',
-    thickness:'3px'
+  color: "blue",
+  thickness: "3px",
 };
 
 graph.draw();
 console.log(cube(3)); // 27
-console.log(foo);    // 4.555806215962888
+console.log(foo); // 4.555806215962888
 ```
 
 É importante notar o seguinte:
@@ -196,15 +194,15 @@ export default function cube(x) {
 Daí em outro script podemos usar:
 
 ```js
-import cube from 'my-module';
+import cube from "my-module";
 console.log(cube(3)); // 27
 ```
 
 ## Especificações
 
-| Especificação                                                        | Estado                       | Comentário          |
-| -------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-exports', 'Exports')}}         | {{Spec2('ES6')}}         | Initial definition. |
+| Especificação                                      | Estado               | Comentário          |
+| -------------------------------------------------- | -------------------- | ------------------- |
+| {{SpecName('ES6', '#sec-exports', 'Exports')}}     | {{Spec2('ES6')}}     | Initial definition. |
 | {{SpecName('ESDraft', '#sec-exports', 'Exports')}} | {{Spec2('ESDraft')}} |                     |
 
 ## Compatibilidade

--- a/files/pt-br/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/pt-br/web/javascript/reference/statements/for-await...of/index.md
@@ -35,15 +35,15 @@ var asyncIterable = {
         }
 
         return Promise.resolve({ done: true });
-      }
+      },
     };
-  }
+  },
 };
 
-(async function() {
-   for await (let num of asyncIterable) {
-     console.log(num);
-   }
+(async function () {
+  for await (let num of asyncIterable) {
+    console.log(num);
+  }
 })();
 
 // 0
@@ -63,7 +63,7 @@ async function* asyncGenerator() {
   }
 }
 
-(async function() {
+(async function () {
   for await (let num of asyncGenerator()) {
     console.log(num);
   }
@@ -105,13 +105,13 @@ async function getResponseSize(url) {
   // output esperado:"Response Size: 1071472"
   return responseSize;
 }
-getResponseSize('https://jsonplaceholder.typicode.com/photos');
+getResponseSize("https://jsonplaceholder.typicode.com/photos");
 ```
 
 ## Especificações
 
-| Specification                                                                                                                                                                    | Status                       | Comment |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------- |
+| Specification                                                                                                                        | Status               | Comment |
+| ------------------------------------------------------------------------------------------------------------------------------------ | -------------------- | ------- |
 | {{SpecName('ESDraft', '#sec-for-in-and-for-of-statements', 'ECMAScript Language: The for-in, for-of, and for-await-of Statements')}} | {{Spec2('ESDraft')}} |         |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/statements/for...in/index.md
+++ b/files/pt-br/web/javascript/reference/statements/for...in/index.md
@@ -43,7 +43,7 @@ A função seguinte toma como argumento um objeto. O laço for...in iterage sobr
 
 ```js
 //Objeto
-var obj = {a:1, b:2, c:3};
+var obj = { a: 1, b: 2, c: 3 };
 
 //Para prop (propriedade) in obj (objeto) faça
 for (var prop in obj) {
@@ -60,7 +60,7 @@ for (var prop in obj) {
 A função seguinte ilustra o uso de {{jsxref("Object.prototype.hasOwnProperty", "hasOwnProperty()")}}: as propriedades herdadas não são exibidas.
 
 ```js
-var triangle = {a:1, b:2, c:3};
+var triangle = { a: 1, b: 2, c: 3 };
 
 function ColoredTriangle() {
   this.color = "red";
@@ -71,7 +71,7 @@ ColoredTriangle.prototype = triangle;
 var obj = new ColoredTriangle();
 
 for (var prop in obj) {
-  if( obj.hasOwnProperty( prop ) ) {
+  if (obj.hasOwnProperty(prop)) {
     console.log("obj." + prop + " = " + obj[prop]);
   }
 }
@@ -82,13 +82,13 @@ for (var prop in obj) {
 
 ## Specificações
 
-| Specificação                                                                                                 | Status                       | Comentário        |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------- | ----------------- |
+| Specificação                                                                       | Status               | Comentário        |
+| ---------------------------------------------------------------------------------- | -------------------- | ----------------- |
 | {{SpecName('ESDraft', '#sec-for-in-and-for-of-statements', 'for...in statement')}} | {{Spec2('ESDraft')}} |                   |
-| {{SpecName('ES6', '#sec-for-in-and-for-of-statements', 'for...in statement')}}     | {{Spec2('ES6')}}         |                   |
-| {{SpecName('ES5.1', '#sec-12.6.4', 'for...in statement')}}                                 | {{Spec2('ES5.1')}}     |                   |
-| {{SpecName('ES3', '#sec-12.6.4', 'for...in statement')}}                                 | {{Spec2('ES3')}}         |                   |
-| {{SpecName('ES1', '#sec-12.6.3', 'for...in statement')}}                                 | {{Spec2('ES1')}}         | Definição inicial |
+| {{SpecName('ES6', '#sec-for-in-and-for-of-statements', 'for...in statement')}}     | {{Spec2('ES6')}}     |                   |
+| {{SpecName('ES5.1', '#sec-12.6.4', 'for...in statement')}}                         | {{Spec2('ES5.1')}}   |                   |
+| {{SpecName('ES3', '#sec-12.6.4', 'for...in statement')}}                           | {{Spec2('ES3')}}     |                   |
+| {{SpecName('ES1', '#sec-12.6.3', 'for...in statement')}}                           | {{Spec2('ES1')}}     | Definição inicial |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/statements/for...of/index.md
+++ b/files/pt-br/web/javascript/reference/statements/for...of/index.md
@@ -231,9 +231,9 @@ for (let i of iterable) {
 
 ### Especificações
 
-| Especificação                                                                                                | Status                       | Comentário          |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-for-in-and-for-of-statements', 'for...of statement')}}     | {{Spec2('ES6')}}         | Definition Inicial. |
+| Especificação                                                                      | Status               | Comentário          |
+| ---------------------------------------------------------------------------------- | -------------------- | ------------------- |
+| {{SpecName('ES6', '#sec-for-in-and-for-of-statements', 'for...of statement')}}     | {{Spec2('ES6')}}     | Definition Inicial. |
 | {{SpecName('ESDraft', '#sec-for-in-and-for-of-statements', 'for...of statement')}} | {{Spec2('ESDraft')}} |                     |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/statements/for/index.md
+++ b/files/pt-br/web/javascript/reference/statements/for/index.md
@@ -37,8 +37,8 @@ A declaração `for` começa declarando a variável `i` e inicializando-a como `
 
 ```js
 for (var i = 0; i < 9; i++) {
-   console.log(i);
-   // more statements
+  console.log(i);
+  // more statements
 }
 ```
 
@@ -51,18 +51,18 @@ Por exemplo, no bloco de _inicialização_, não é necessário inicializar vari
 ```js
 var i = 0;
 for (; i < 9; i++) {
-    console.log(i);
-    // more statements
+  console.log(i);
+  // more statements
 }
 ```
 
 Assim como ocorre no bloco de _inicialização_, a _condição_ também é opcional. Se você está omitindo essa expressão, você deve certificar-se de quebrar o loop no corpo para não criar um loop infinito.
 
 ```js
-for (var i = 0;; i++) {
-   console.log(i);
-   if (i > 3) break;
-   // more statements
+for (var i = 0; ; i++) {
+  console.log(i);
+  if (i > 3) break;
+  // more statements
 }
 ```
 
@@ -83,15 +83,28 @@ for (;;) {
 O ciclo `for` a seguir calcula a posição de deslocamento de um nó na seção \[expressão final] e, portanto, não requer o uso de uma declaração ou de um bloco de declaração, e no seu lugar é usado um ponto-vírgula - `;`.
 
 ```js
-function showOffsetPos (sId) {
-  var nLeft = 0, nTop = 0;
+function showOffsetPos(sId) {
+  var nLeft = 0,
+    nTop = 0;
 
-  for (var oItNode = document.getElementById(sId); // inicialização
-       oItNode; // condition
-       nLeft += oItNode.offsetLeft, nTop += oItNode.offsetTop, oItNode = oItNode.offsetParent) // expressão final
-       /* empty statement */ ;
+  for (
+    var oItNode = document.getElementById(sId); // inicialização
+    oItNode; // condition
+    nLeft += oItNode.offsetLeft,
+      nTop += oItNode.offsetTop,
+      oItNode = oItNode.offsetParent // expressão final
+    /* empty statement */
+  );
 
-  console.log("Offset position of \"" + sId + "\" element:\n left: " + nLeft + "px;\n top: " + nTop + "px;");
+  console.log(
+    'Offset position of "' +
+      sId +
+      '" element:\n left: ' +
+      nLeft +
+      "px;\n top: " +
+      nTop +
+      "px;",
+  );
 }
 
 // Exemplo de call:
@@ -108,11 +121,11 @@ showOffsetPos("content");
 
 ## Especificações
 
-| Especificação                                                                | Status                   | Comentário         |
-| ---------------------------------------------------------------------------- | ------------------------ | ------------------ |
-| ECMAScript 1st Edition.                                                      | Padrão                   | Definição inicial. |
-| {{SpecName('ES5.1', '#sec-12.6.3', 'for statement')}}     | {{Spec2('ES5.1')}} |                    |
-| {{SpecName('ES6', '#sec-for-statement', 'for statement')}} | {{Spec2('ES6')}}     |                    |
+| Especificação                                              | Status             | Comentário         |
+| ---------------------------------------------------------- | ------------------ | ------------------ |
+| ECMAScript 1st Edition.                                    | Padrão             | Definição inicial. |
+| {{SpecName('ES5.1', '#sec-12.6.3', 'for statement')}}      | {{Spec2('ES5.1')}} |                    |
+| {{SpecName('ES6', '#sec-for-statement', 'for statement')}} | {{Spec2('ES6')}}   |                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/statements/function/index.md
+++ b/files/pt-br/web/javascript/reference/statements/function/index.md
@@ -2,6 +2,7 @@
 title: Declaração de função
 slug: Web/JavaScript/Reference/Statements/function
 ---
+
 {{jsSidebar("Statements")}}
 
 A **declaração function** define uma função com os especificados parâmetros.
@@ -52,8 +53,8 @@ Note que {{jsxref("Operators/function", "function expressions")}} não são hois
 ```js
 notHoisted(); // TypeError: notHoisted is not a function
 
-var notHoisted = function() {
-   console.log("bar");
+var notHoisted = function () {
+  console.log("bar");
 };
 ```
 
@@ -65,19 +66,19 @@ O seguinte código declara uma função que retorna a quantidade total das venda
 
 ```js
 function calc_sales(units_a, units_b, units_c) {
-   return units_a * 79 + units_b * 129 + units_c * 699;
+  return units_a * 79 + units_b * 129 + units_c * 699;
 }
 ```
 
 ## Especificações
 
-| Specification                                                                                        | Status                       | Comment                                            |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
+| Specification                                                                | Status               | Comment                                            |
+| ---------------------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
 | {{SpecName('ESDraft', '#sec-function-definitions', 'Function definitions')}} | {{Spec2('ESDraft')}} |                                                    |
-| {{SpecName('ES6', '#sec-function-definitions', 'Function definitions')}}     | {{Spec2('ES6')}}         |                                                    |
-| {{SpecName('ES5.1', '#sec-13', 'Function definition')}}                             | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES3', '#sec-13', 'Function definition')}}                             | {{Spec2('ES3')}}         |                                                    |
-| {{SpecName('ES1', '#sec-13', 'Function definition')}}                             | {{Spec2('ES1')}}         | Definição inicial. Implementado em JavaScript 1.0. |
+| {{SpecName('ES6', '#sec-function-definitions', 'Function definitions')}}     | {{Spec2('ES6')}}     |                                                    |
+| {{SpecName('ES5.1', '#sec-13', 'Function definition')}}                      | {{Spec2('ES5.1')}}   |                                                    |
+| {{SpecName('ES3', '#sec-13', 'Function definition')}}                        | {{Spec2('ES3')}}     |                                                    |
+| {{SpecName('ES1', '#sec-13', 'Function definition')}}                        | {{Spec2('ES1')}}     | Definição inicial. Implementado em JavaScript 1.0. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/statements/function_star_/index.md
+++ b/files/pt-br/web/javascript/reference/statements/function_star_/index.md
@@ -41,10 +41,9 @@ Uma expressão `return` em um gerador, quando executada, fará com que o gerador
 ### Exemplo simples
 
 ```js
-function* idMaker(){
-    var index = 0;
-    while(true)
-        yield index++;
+function* idMaker() {
+  var index = 0;
+  while (true) yield index++;
 }
 
 var gen = idMaker();
@@ -65,7 +64,7 @@ function* outroGerador(i) {
   yield i + 3;
 }
 
-function* gerador(i){
+function* gerador(i) {
   yield i;
   yield* outroGerador(i);
   yield i + 10;
@@ -136,10 +135,10 @@ console.log(bar.next()); // {value: 10, done: false}
 
 ## Especificações
 
-| Especificação                                                                                        | Status                       | Comentário                                                                                                            |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('ES2015', '#sec-generator-function-definitions', 'function*')}} | {{Spec2('ES2015')}}     | Definição inicial.                                                                                                    |
-| {{SpecName('ES2016', '#sec-generator-function-definitions', 'function*')}} | {{Spec2('ES2016')}}     | Mudou para que _generators_ não tenham a armadilha de \[\[Construct]] e irão lançar um erro, quando usados com `new`. |
+| Especificação                                                               | Status               | Comentário                                                                                                            |
+| --------------------------------------------------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| {{SpecName('ES2015', '#sec-generator-function-definitions', 'function*')}}  | {{Spec2('ES2015')}}  | Definição inicial.                                                                                                    |
+| {{SpecName('ES2016', '#sec-generator-function-definitions', 'function*')}}  | {{Spec2('ES2016')}}  | Mudou para que _generators_ não tenham a armadilha de \[\[Construct]] e irão lançar um erro, quando usados com `new`. |
 | {{SpecName('ESDraft', '#sec-generator-function-definitions', 'function*')}} | {{Spec2('ESDraft')}} |                                                                                                                       |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/statements/if...else/index.md
+++ b/files/pt-br/web/javascript/reference/statements/if...else/index.md
@@ -72,10 +72,10 @@ if (b) // essa condição é avaliada como true
 
 ```js
 if (cipher_char === from_char) {
-   result = result + to_char;
-   x++;
+  result = result + to_char;
+  x++;
 } else {
-   result = result + clear_char;
+  result = result + clear_char;
 }
 ```
 
@@ -85,11 +85,8 @@ Perceba que não existe sintaxe de `elseif` em JavaScript. Entretanto, você pod
 
 ```js
 if (x > 5) {
-
 } else if (x > 50) {
-
 } else {
-
 }
 ```
 
@@ -97,9 +94,9 @@ if (x > 5) {
 
 É recomendado não utilizar atribuições simples junto de uma expressão condicional, visto que atribuições podem ser confundidas com igualdade ao olhar o código. Por exemplo, não use o código abaixo:
 
-```js
+```js-nolint
 if (x = y) {
-   /* faça a coisa certa */
+  /* faça a coisa certa */
 }
 ```
 
@@ -107,19 +104,19 @@ Caso você precise utilizar uma atribuição em uma expressão condicional, uma 
 
 ```js
 if ((x = y)) {
-   /* faça a coisa certa */
+  /* faça a coisa certa */
 }
 ```
 
 ## Especificações
 
-| Especificação                                                                    | Status                       | Comentário        |
-| -------------------------------------------------------------------------------- | ---------------------------- | ----------------- |
+| Especificação                                                | Status               | Comentário        |
+| ------------------------------------------------------------ | -------------------- | ----------------- |
 | {{SpecName('ESDraft', '#sec-if-statement', 'if statement')}} | {{Spec2('ESDraft')}} |                   |
-| {{SpecName('ES6', '#sec-if-statement', 'if statement')}}     | {{Spec2('ES6')}}         |                   |
-| {{SpecName('ES5.1', '#sec-12.5', 'if statement')}}             | {{Spec2('ES5.1')}}     |                   |
-| {{SpecName('ES3', '#sec-12.5', 'if statement')}}                 | {{Spec2('ES3')}}         |                   |
-| {{SpecName('ES1', '#sec-12.5', 'if statement')}}                 | {{Spec2('ES1')}}         | Definição Inicial |
+| {{SpecName('ES6', '#sec-if-statement', 'if statement')}}     | {{Spec2('ES6')}}     |                   |
+| {{SpecName('ES5.1', '#sec-12.5', 'if statement')}}           | {{Spec2('ES5.1')}}   |                   |
+| {{SpecName('ES3', '#sec-12.5', 'if statement')}}             | {{Spec2('ES3')}}     |                   |
+| {{SpecName('ES1', '#sec-12.5', 'if statement')}}             | {{Spec2('ES1')}}     | Definição Inicial |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/statements/import/index.md
+++ b/files/pt-br/web/javascript/reference/statements/import/index.md
@@ -164,10 +164,11 @@ export function getUsefulContents(url, callback) {
 **O programa principal: main.js**
 
 ```js
-import { getUsefulContents } from '/modules/file.js';
+import { getUsefulContents } from "/modules/file.js";
 
-getUsefulContents('http://www.example.com',
-    data => { doSomethingUseful(data); });
+getUsefulContents("http://www.example.com", (data) => {
+  doSomethingUseful(data);
+});
 ```
 
 ### Dynamic Import
@@ -177,14 +178,14 @@ Este exemplo mostra como carregar a funcionalidade em uma página com base em um
 ```js
 const main = document.querySelector("main");
 for (const link of document.querySelectorAll("nav > a")) {
-  link.addEventListener("click", e => {
+  link.addEventListener("click", (e) => {
     e.preventDefault();
 
-    import('/modules/my-module.js')
-      .then(module => {
+    import("/modules/my-module.js")
+      .then((module) => {
         module.loadPageInto(main);
       })
-      .catch(err => {
+      .catch((err) => {
         main.textContent = err.message;
       });
   });
@@ -193,14 +194,14 @@ for (const link of document.querySelectorAll("nav > a")) {
 
 ## Especificações
 
-| Especificação                                                                                          | Estado                       | Comentário         |
-| ------------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------ |
-| ["function-like" dynamic `import()` proposal](https://github.com/tc39/proposal-dynamic-import/#import) | Stage 3                      |                    |
-| {{SpecName("ESDraft", "#sec-imports", "Imports")}}                                   | {{Spec2("ESDraft")}} |                    |
-| {{SpecName("ES2018", "#sec-imports", "Imports")}}                                       | {{Spec2("ES2018")}}     |                    |
-| {{SpecName("ES2017", "#sec-imports", "Imports")}}                                       | {{Spec2("ES2017")}}     |                    |
-| {{SpecName("ES2016", "#sec-imports", "Imports")}}                                       | {{Spec2("ES2016")}}     |                    |
-| {{SpecName("ES2015", "#sec-imports", "Imports")}}                                       | {{Spec2("ES2015")}}     | Definição inicial. |
+| Especificação                                                                                          | Estado               | Comentário         |
+| ------------------------------------------------------------------------------------------------------ | -------------------- | ------------------ |
+| ["function-like" dynamic `import()` proposal](https://github.com/tc39/proposal-dynamic-import/#import) | Stage 3              |                    |
+| {{SpecName("ESDraft", "#sec-imports", "Imports")}}                                                     | {{Spec2("ESDraft")}} |                    |
+| {{SpecName("ES2018", "#sec-imports", "Imports")}}                                                      | {{Spec2("ES2018")}}  |                    |
+| {{SpecName("ES2017", "#sec-imports", "Imports")}}                                                      | {{Spec2("ES2017")}}  |                    |
+| {{SpecName("ES2016", "#sec-imports", "Imports")}}                                                      | {{Spec2("ES2016")}}  |                    |
+| {{SpecName("ES2015", "#sec-imports", "Imports")}}                                                      | {{Spec2("ES2015")}}  | Definição inicial. |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/statements/index.md
+++ b/files/pt-br/web/javascript/reference/statements/index.md
@@ -80,11 +80,11 @@ Para visualizar em ordem alfabética use a barra de rolagem à esquerda.
 
 ## Especificações
 
-| Specification                                                                                                                                                            | Status                   | Comment                                      |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ | -------------------------------------------- |
-| ECMAScript 1st Edition.                                                                                                                                                  | Standard                 | Initial definition.                          |
-| {{SpecName('ES5.1', '#sec-12', 'Statements')}}                                                                                                             | {{Spec2('ES5.1')}} |                                              |
-| {{SpecName('ES6', '#sec-ecmascript-language-statements-and-declarations', 'ECMAScript Language: Statements and Declarations')}} | {{Spec2('ES6')}}     | New: function\*, let, for...of, yield, class |
+| Specification                                                                                                                   | Status             | Comment                                      |
+| ------------------------------------------------------------------------------------------------------------------------------- | ------------------ | -------------------------------------------- |
+| ECMAScript 1st Edition.                                                                                                         | Standard           | Initial definition.                          |
+| {{SpecName('ES5.1', '#sec-12', 'Statements')}}                                                                                  | {{Spec2('ES5.1')}} |                                              |
+| {{SpecName('ES6', '#sec-ecmascript-language-statements-and-declarations', 'ECMAScript Language: Statements and Declarations')}} | {{Spec2('ES6')}}   | New: function\*, let, for...of, yield, class |
 
 ## Veja também
 

--- a/files/pt-br/web/javascript/reference/statements/label/index.md
+++ b/files/pt-br/web/javascript/reference/statements/label/index.md
@@ -32,16 +32,16 @@ label :
 ```js
 var i, j;
 
-loop1:
-for (i = 0; i < 3; i++) {      //O primeiro 'for' é etiquetado com "loop1"
-   loop2:
-   for (j = 0; j < 3; j++) {   //O segundo é etiquetado com "loop2"
-      if (i == 1 && j == 1) {
-         continue loop1;
-      } else {
-         console.log("i = " + i + ", j = " + j);
-      }
-   }
+loop1: for (i = 0; i < 3; i++) {
+  //O primeiro 'for' é etiquetado com "loop1"
+  loop2: for (j = 0; j < 3; j++) {
+    //O segundo é etiquetado com "loop2"
+    if (i == 1 && j == 1) {
+      continue loop1;
+    } else {
+      console.log("i = " + i + ", j = " + j);
+    }
+  }
 }
 
 // Sua saída é:
@@ -63,11 +63,8 @@ Dado uma lista de itens e outra de testes, este exemplo conta o número de íten
 var itemsPassed = 0;
 var i, j;
 
-top:
-for (i = 0; i < items.length; i++){
-  for (j = 0; j < tests.length; j++)
-    if (!tests[j].pass(items[i]))
-      continue top;
+top: for (i = 0; i < items.length; i++) {
+  for (j = 0; j < tests.length; j++) if (!tests[j].pass(items[i])) continue top;
   itemsPassed++;
 }
 ```
@@ -80,10 +77,9 @@ Dado uma lista de ítens e uma lista de testes, neste exemplo determina-se se to
 var allPass = true;
 var i, j;
 
-top:
-for (i = 0; items.length; i++)
+top: for (i = 0; items.length; i++)
   for (j = 0; j < tests.length; i++)
-    if (!tests[j].pass(items[i])){
+    if (!tests[j].pass(items[i])) {
       allPass = false;
       break top;
     }

--- a/files/pt-br/web/javascript/reference/statements/let/index.md
+++ b/files/pt-br/web/javascript/reference/statements/let/index.md
@@ -29,12 +29,12 @@ let (var1 [= value1] [, var2 [= value2]] [, ..., varN [= valueN]]) statement;
 
 ### Parâmetros
 
-| Parameter                       | Description                                                                                                                                               |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `var1`, `var2`, …, `varN`       | Nome da variável. Pode ser qualquer identificador válido.                                                                                                 |
-| `value1`, `value2`, …, `valueN` | Valor inicial da variável. Pode ser qualquer expressão válida.                                                                                            |
+| Parameter                       | Description                                                                                      |
+| ------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `var1`, `var2`, …, `varN`       | Nome da variável. Pode ser qualquer identificador válido.                                        |
+| `value1`, `value2`, …, `valueN` | Valor inicial da variável. Pode ser qualquer expressão válida.                                   |
 | `expression`                    | Qualquer [expressão](/pt-BR/docs/JavaScript/Guide/Expressions_and_Operators#Expressions) válida. |
-| `statement`                     | Qualquer [instrução](/pt-BR/docs/JavaScript/Reference/Statements) válida.                                               |
+| `statement`                     | Qualquer [instrução](/pt-BR/docs/JavaScript/Reference/Statements) válida.                        |
 
 ## Descrição
 
@@ -100,8 +100,8 @@ if (a === 5) {
   let a = 4; // O escopo é dentro do bloco if
   var b = 1; // O escopo é dentro da função
 
-  console.log(a);  // 4
-  console.log(b);  // 1
+  console.log(a); // 4
+  console.log(b); // 1
 }
 
 console.log(a); // 5
@@ -111,7 +111,7 @@ console.log(b); // 1
 É possível usar a keyword _let_ para vincular variáveis localmente no escopo de loops em vez de usar uma variável global (definida usando _var_) para isso.
 
 ```js
-for (let i = 0; i<10; i++) {
+for (let i = 0; i < 10; i++) {
   alert(i); // 1, 2, 3, 4 ... 9
 }
 

--- a/files/pt-br/web/javascript/reference/statements/return/index.md
+++ b/files/pt-br/web/javascript/reference/statements/return/index.md
@@ -32,7 +32,7 @@ return x + y / 3;
 
 A declaração `return` é afetada pela [inserção automática de ponto e vírgula (ASI)](/pt-BR/docs/Web/JavaScript/Reference/Lexical_grammar#Automatic_semicolon_insertion). Nenhum terminador de linha é permitido entre a palavra-chave `return` e a expressão.
 
-```js
+```js-nolint
 return
 a + b;
 ```
@@ -56,7 +56,7 @@ A função a seguir retorna o quadro do seu argumento, `x`, quando `x` é um nú
 
 ```js
 function square(x) {
-   return x * x;
+  return x * x;
 }
 ```
 
@@ -66,14 +66,15 @@ Uma função para imediatamente no ponto em que `return` é chamado.
 
 ```js
 function counter() {
-  for (var count = 1; ; count++) {  // loop infinito
-    console.log(count + 'A'); // até 5
-      if (count === 5) {
-        return;
-      }
-      console.log(count + 'B');  // até 4
+  for (var count = 1; ; count++) {
+    // loop infinito
+    console.log(count + "A"); // até 5
+    if (count === 5) {
+      return;
     }
-  console.log(count + 'C');  // nunca aparece
+    console.log(count + "B"); // até 4
+  }
+  console.log(count + "C"); // nunca aparece
 }
 
 counter();
@@ -96,7 +97,9 @@ Veja também o artigo sobre [Closures](/pt-BR/docs/Web/JavaScript/Closures).
 
 ```js
 function magic(x) {
-  return function calc(x) { return x * 42; };
+  return function calc(x) {
+    return x * 42;
+  };
 }
 
 var answer = magic();
@@ -105,11 +108,11 @@ answer(1337); // 56154
 
 ## Especificações
 
-| Especificação                                                                                | Situação                     | Comentário         |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('ES1')}}                                                                     | {{Spec2('ES1')}}         | Definição inicial. |
-| {{SpecName('ES5.1', '#sec-12.9', 'Return statement')}}                     | {{Spec2('ES5.1')}}     |                    |
-| {{SpecName('ES6', '#sec-return-statement', 'Return statement')}}         | {{Spec2('ES6')}}         |                    |
+| Especificação                                                        | Situação             | Comentário         |
+| -------------------------------------------------------------------- | -------------------- | ------------------ |
+| {{SpecName('ES1')}}                                                  | {{Spec2('ES1')}}     | Definição inicial. |
+| {{SpecName('ES5.1', '#sec-12.9', 'Return statement')}}               | {{Spec2('ES5.1')}}   |                    |
+| {{SpecName('ES6', '#sec-return-statement', 'Return statement')}}     | {{Spec2('ES6')}}     |                    |
 | {{SpecName('ESDraft', '#sec-return-statement', 'Return statement')}} | {{Spec2('ESDraft')}} |                    |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/statements/switch/index.md
+++ b/files/pt-br/web/javascript/reference/statements/switch/index.md
@@ -78,20 +78,20 @@ Se você esquecer um break então o script irá rodar a partir do caso onde o cr
 ```js
 var foo = 0;
 switch (foo) {
-    case -1:
-        console.log('1 negativo');
-        break;
-    case 0: // foo é 0 então aqui o critério foi correspondido, então esse bloco vai rodar
-        console.log(0)
-        // NOTA: o break esquecido deveria estar aqui
-    case 1: // nenhuma instrução break em 'case 0:' então essa instrução vai rodar também
-        console.log(1);
-        break; // o programa encontra esse break então não vai continuar para o 'case 2:'
-    case 2:
-        console.log(2);
-        break;
-    default:
-        console.log('default');
+  case -1:
+    console.log("1 negativo");
+    break;
+  case 0: // foo é 0 então aqui o critério foi correspondido, então esse bloco vai rodar
+    console.log(0);
+  // NOTA: o break esquecido deveria estar aqui
+  case 1: // nenhuma instrução break em 'case 0:' então essa instrução vai rodar também
+    console.log(1);
+    break; // o programa encontra esse break então não vai continuar para o 'case 2:'
+  case 2:
+    console.log(2);
+    break;
+  default:
+    console.log("default");
 }
 ```
 
@@ -108,17 +108,17 @@ Esse método toma vantagem do fato de não existir um break após um case e irá
 Esse é um exemplo de uma operação sequencial simples com a instrução switch, onde quatro valores diferentes fazem a mesma coisa..
 
 ```js
-var Animal = 'Girafa';
+var Animal = "Girafa";
 switch (Animal) {
-    case 'Vaca':
-    case 'Girafa':
-    case 'Cachorro':
-    case 'Porco':
-        alert('Esse animal irá para Arca de Noé');
-        break;
-    case 'Dinossauro':
-    default:
-        alert('Esse animal não vai.');
+  case "Vaca":
+  case "Girafa":
+  case "Cachorro":
+  case "Porco":
+    alert("Esse animal irá para Arca de Noé");
+    break;
+  case "Dinossauro":
+  default:
+    alert("Esse animal não vai.");
 }
 ```
 
@@ -130,27 +130,27 @@ This is an example of a multiple-operation sequential switch statement, where, d
 
 ```js
 var foo = 1;
-var output = 'Output: ';
+var output = "Output: ";
 switch (foo) {
-    case 10:
-        output += 'Então ';
-    case 1:
-        output += 'Qual ';
-        output += 'É ';
-    case 2:
-        output += 'O Seu ';
-    case 3:
-        output += 'Nome';
-    case 4:
-        output += '?';
-        alert(output);
-        break;
-    case 5:
-        output += '!';
-        alert(output);
-        break;
-    default:
-        alert('Favor escolher um número de 0 à 6!');
+  case 10:
+    output += "Então ";
+  case 1:
+    output += "Qual ";
+    output += "É ";
+  case 2:
+    output += "O Seu ";
+  case 3:
+    output += "Nome";
+  case 4:
+    output += "?";
+    alert(output);
+    break;
+  case 5:
+    output += "!";
+    alert(output);
+    break;
+  default:
+    alert("Favor escolher um número de 0 à 6!");
 }
 ```
 
@@ -168,11 +168,11 @@ Output para esse exemplo:
 
 ## Especificações
 
-| Especificação                                                                        | Status                   | Comentário                                        |
-| ------------------------------------------------------------------------------------ | ------------------------ | ------------------------------------------------- |
-| ECMAScript 3ª Edição                                                                 | Standard                 | Definição inicial. Implementado no JavaScript 1.2 |
-| {{SpecName('ES5.1', '#sec-12.11', 'switch statement')}}             | {{Spec2('ES5.1')}} |                                                   |
-| {{SpecName('ES6', '#sec-switch-statement', 'switch statement')}} | {{Spec2('ES6')}}     |                                                   |
+| Especificação                                                    | Status             | Comentário                                        |
+| ---------------------------------------------------------------- | ------------------ | ------------------------------------------------- |
+| ECMAScript 3ª Edição                                             | Standard           | Definição inicial. Implementado no JavaScript 1.2 |
+| {{SpecName('ES5.1', '#sec-12.11', 'switch statement')}}          | {{Spec2('ES5.1')}} |                                                   |
+| {{SpecName('ES6', '#sec-switch-statement', 'switch statement')}} | {{Spec2('ES6')}}   |                                                   |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/statements/throw/index.md
+++ b/files/pt-br/web/javascript/reference/statements/throw/index.md
@@ -22,8 +22,8 @@ Use a instrução `throw` para lançar uma exceção. Quando você lança uma ex
 
 ```js
 throw "Erro2"; // gera uma exceção com um valor string
-throw 42;      // gera uma exceção com o valor 42
-throw true;    // gera uma exceção com o valor true
+throw 42; // gera uma exceção com o valor 42
+throw true; // gera uma exceção com o valor true
 ```
 
 Note também que a instrução `throw` é afetada pela [inserção automática de ponto-e-vírgula (ASI)](/pt-BR/docs/Web/JavaScript/Reference/Lexical_grammar#Automatic_semicolon_insertion) como nenhum terminador de linha entre a palavra `throw` e a expressão é permitido.
@@ -36,27 +36,39 @@ Você pode especificar um objeto quando você lança uma exceção. Você pode e
 
 ```js
 function UserException(message) {
-   this.message = message;
-   this.name = "UserException";
+  this.message = message;
+  this.name = "UserException";
 }
 function getMonthName(mo) {
-   mo = mo-1; // Ajusta o número do mês para index de array (1=Jan, 12=Dec)
-   var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
-      "Aug", "Sep", "Oct", "Nov", "Dec"];
-   if (months[mo] !== undefined) {
-      return months[mo];
-   } else {
-      throw new UserException("InvalidMonthNo");
-   }
+  mo = mo - 1; // Ajusta o número do mês para index de array (1=Jan, 12=Dec)
+  var months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+  if (months[mo] !== undefined) {
+    return months[mo];
+  } else {
+    throw new UserException("InvalidMonthNo");
+  }
 }
 
 try {
-   // statements to try
-   var myMonth = 15; // 15 is out of bound to raise the exception
-   monthName = getMonthName(myMonth);
+  // statements to try
+  var myMonth = 15; // 15 is out of bound to raise the exception
+  monthName = getMonthName(myMonth);
 } catch (e) {
-   monthName = "unknown";
-   logMyErrors(e.message, e.name); // pass exception object to err handler
+  monthName = "unknown";
+  logMyErrors(e.message, e.name); // pass exception object to err handler
 }
 ```
 
@@ -79,28 +91,28 @@ O exemplo a seguir testa uma string de entrada para um cep dos Estados Unidos. S
  */
 
 function ZipCode(zip) {
-   zip = new String(zip);
-   pattern = /[0-9]{5}([- ]?[0-9]{4})?/;
-   if (pattern.test(zip)) {
-      // o valor do CEP será a primeira combinação na string
-      this.value = zip.match(pattern)[0];
-      this.valueOf = function() {
-         return this.value
-      };
-      this.toString = function() {
-         return String(this.value)
-      };
-   } else {
-      throw new ZipCodeFormatException(zip);
-   }
+  zip = new String(zip);
+  pattern = /[0-9]{5}([- ]?[0-9]{4})?/;
+  if (pattern.test(zip)) {
+    // o valor do CEP será a primeira combinação na string
+    this.value = zip.match(pattern)[0];
+    this.valueOf = function () {
+      return this.value;
+    };
+    this.toString = function () {
+      return String(this.value);
+    };
+  } else {
+    throw new ZipCodeFormatException(zip);
+  }
 }
 
 function ZipCodeFormatException(value) {
-   this.value = value;
-   this.message = "does not conform to the expected format for a zip code";
-   this.toString = function() {
-      return this.value + this.message;
-   };
+  this.value = value;
+  this.message = "does not conform to the expected format for a zip code";
+  this.toString = function () {
+    return this.value + this.message;
+  };
 }
 
 /*
@@ -112,23 +124,23 @@ const ZIPCODE_INVALID = -1;
 const ZIPCODE_UNKNOWN_ERROR = -2;
 
 function verifyZipCode(z) {
-   try {
-      z = new ZipCode(z);
-   } catch (e) {
-      if (e instanceof ZipCodeFormatException) {
-         return ZIPCODE_INVALID;
-      } else {
-         return ZIPCODE_UNKNOWN_ERROR;
-      }
-   }
-   return z;
+  try {
+    z = new ZipCode(z);
+  } catch (e) {
+    if (e instanceof ZipCodeFormatException) {
+      return ZIPCODE_INVALID;
+    } else {
+      return ZIPCODE_UNKNOWN_ERROR;
+    }
+  }
+  return z;
 }
 
-a = verifyZipCode(95060);         // retorna 95060
-b = verifyZipCode(9560);          // retorna -1
-c = verifyZipCode("a");           // retorna -1
-d = verifyZipCode("95060");       // retorna 95060
-e = verifyZipCode("95060 1234");  // retorna 95060 1234
+a = verifyZipCode(95060); // retorna 95060
+b = verifyZipCode(9560); // retorna -1
+c = verifyZipCode("a"); // retorna -1
+d = verifyZipCode("95060"); // retorna 95060
+e = verifyZipCode("95060 1234"); // retorna 95060 1234
 ```
 
 ### Relançando uma exceção
@@ -137,24 +149,24 @@ Você pode usar `throw` para relançar uma exceção após você pegá-la. O exe
 
 ```js
 try {
-   throw n; // lança uma exceção com um valor numérico
+  throw n; // lança uma exceção com um valor numérico
 } catch (e) {
-   if (e <= 50) {
-      // instruções para tratar exceções 1-50
-   } else {
-      // não pode tratar esta exceção então relança
-      throw e;
-   }
+  if (e <= 50) {
+    // instruções para tratar exceções 1-50
+  } else {
+    // não pode tratar esta exceção então relança
+    throw e;
+  }
 }
 ```
 
 ## Specifications
 
-| Specification                                                                            | Status                       | Comment                                           |
-| ---------------------------------------------------------------------------------------- | ---------------------------- | ------------------------------------------------- |
-| {{SpecName('ES3')}}                                                                 | {{Spec2('ES3')}}         | Definição inicial. Implementada no JavaScript 1.4 |
-| {{SpecName('ES5.1', '#sec-12.13', 'throw statement')}}                 | {{Spec2('ES5.1')}}     |                                                   |
-| {{SpecName('ES6', '#sec-throw-statement', 'throw statement')}}     | {{Spec2('ES6')}}         |                                                   |
+| Specification                                                      | Status               | Comment                                           |
+| ------------------------------------------------------------------ | -------------------- | ------------------------------------------------- |
+| {{SpecName('ES3')}}                                                | {{Spec2('ES3')}}     | Definição inicial. Implementada no JavaScript 1.4 |
+| {{SpecName('ES5.1', '#sec-12.13', 'throw statement')}}             | {{Spec2('ES5.1')}}   |                                                   |
+| {{SpecName('ES6', '#sec-throw-statement', 'throw statement')}}     | {{Spec2('ES6')}}     |                                                   |
 | {{SpecName('ESDraft', '#sec-throw-statement', 'throw statement')}} | {{Spec2('ESDraft')}} |                                                   |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/javascript/reference/statements/try...catch/index.md
+++ b/files/pt-br/web/javascript/reference/statements/try...catch/index.md
@@ -58,11 +58,10 @@ Quando uma única, incondicional cláusula `catch` é utilizada, o bloco `catch`
 
 ```js
 try {
-   throw "myException"; // gera uma exceção
-}
-catch (e) {
-   // declarações para manipular quaisquer exceções
-   logMyErrors(e); // passa o objeto de exceção para o manipulador de erro
+  throw "myException"; // gera uma exceção
+} catch (e) {
+  // declarações para manipular quaisquer exceções
+  logMyErrors(e); // passa o objeto de exceção para o manipulador de erro
 }
 ```
 
@@ -125,13 +124,12 @@ A cláusula `finally` contém declarações para executarem após a execução d
 Você pode utilizar a cláusula `finally` para fazer seu script falhar graciosamente quando uma exceção ocorrer; por exemplo, você pode precisar liberar um recurso que seu script possui vinculado. O exemplo seguinte abre um aquivo e então executa declarações que utilizam o arquivo (server-side JavaScript permite que você acesse arquivos). Se uma exceção for lançada enquanto o arquivo estiver aberto, a cláusula `finally` fecha o arquivo antes que o script falhe.
 
 ```js
-openMyFile()
+openMyFile();
 try {
-   // vincula o recurso
-   writeMyFile(theData);
-}
-finally {
-   closeMyFile(); // sempre fecha o recurso
+  // vincula o recurso
+  writeMyFile(theData);
+} finally {
+  closeMyFile(); // sempre fecha o recurso
 }
 ```
 

--- a/files/pt-br/web/javascript/reference/statements/var/index.md
+++ b/files/pt-br/web/javascript/reference/statements/var/index.md
@@ -30,7 +30,7 @@ Atribuir um valor a uma variável não declarada anteriormente implica em criar 
 
 ```js
 function x() {
-  y = 1;   // Lança a exceção ReferenceError em modo restrito (strict mode)
+  y = 1; // Lança a exceção ReferenceError em modo restrito (strict mode)
   var z = 2;
 }
 
@@ -43,14 +43,14 @@ console.log(z); // Lança a exceção ReferenceError: z não foi definida fora d
 2\. Variáveis declaradas são criadas antes de qualquer código ser executado. As variáveis não declaradas não existem até quando o código atribuir um valor a ela.
 
 ```js
-console.log(a);                // Lança a exceção ReferenceError.
-console.log('still going...'); // Nunca será executado.
+console.log(a); // Lança a exceção ReferenceError.
+console.log("still going..."); // Nunca será executado.
 ```
 
 ```js
 var a;
-console.log(a);                // mostra "undefined" ou "" dependendo do naveador.
-console.log('still going...'); // mostra "still going...".
+console.log(a); // mostra "undefined" ou "" dependendo do naveador.
+console.log("still going..."); // mostra "still going...".
 ```
 
 3\. Variáveis declaradas são propriedades não configuráveis no contexto de execução (função ou global). Variaveis não declaradas são configuráveis (por exemplo, podem ser excluídas).
@@ -73,7 +73,7 @@ Por conta dessas três diferenças, falha para declarar variáveis, muito provav
 Como as declarações de variáveis (e declarações em geral) são processadas antes de qualquer código seja executado, declarar uma variável em qualquer lugar no código é equivalente a declarar no inicio. Isso também significa que uma variável pode aparecer para ser usada antes dela ser declarada. Esse comportamento é chamado de "hoisting", a variável é movida para o inicio da função ou do código global.
 
 ```js
-bla = 2
+bla = 2;
 var bla;
 // ...
 
@@ -90,7 +90,8 @@ Por essa razão, recomenda-se sempre declarar variáveis na parte superior do se
 ### Declarando e inicializando duas variáveis
 
 ```js
-var a = 0, b = 0;
+var a = 0,
+  b = 0;
 ```
 
 ### Atribuindo duas variáveis com uma única expressão
@@ -101,13 +102,15 @@ var b = a;
 
 // Equivalente a:
 
-var a, b = a = "A";
+var a,
+  b = (a = "A");
 ```
 
 É sempre importante lembrar da ordem da declaração das variáveis:
 
 ```js
-var x = y, y = 'A';
+var x = y,
+  y = "A";
 console.log(x + y); // undefinedA
 ```
 
@@ -118,8 +121,8 @@ Então, x e y são declarados antes de qualquer código seja executado, a atribu
 ```js
 var x = 0;
 
-function f(){
-  var x = y = 1; // x é declarado localmente,y não é!
+function f() {
+  var x = (y = 1); // x é declarado localmente,y não é!
 }
 f();
 
@@ -133,37 +136,39 @@ console.log(x, y); // 0, 1
 Variáveis que aparecem como variáveis globais implicitas podem ser referenciadas como variáveis fora do escopo da função:
 
 ```js
-var x = 0;  // x é declarada como global e é igual a 0
+var x = 0; // x é declarada como global e é igual a 0
 
 console.log(typeof z); // undefined, desde que z não tenha sido criada anteriormente
 
-function a() { // quando a for chamada,
-  var y = 2;   // y é declarada como local desta função, e o valor 2 é atribuido
+function a() {
+  // quando a for chamada,
+  var y = 2; // y é declarada como local desta função, e o valor 2 é atribuido
 
-  console.log(x, y);   // 0 2
+  console.log(x, y); // 0 2
 
-  function b() {       // quando b for chamado,
-    x = 3;  // atribui o valor 3 a variável global existente, ele não cria uma nova variável global
-    y = 4;  // atribui o valor 4 a uma variável fora, ele não cria uma nova variável
-    z = 5;  // cria uma nova variável global e atribui o valor 5.
-  }         // (Lança a exceção ReferenceError em modo restrito.)
+  function b() {
+    // quando b for chamado,
+    x = 3; // atribui o valor 3 a variável global existente, ele não cria uma nova variável global
+    y = 4; // atribui o valor 4 a uma variável fora, ele não cria uma nova variável
+    z = 5; // cria uma nova variável global e atribui o valor 5.
+  } // (Lança a exceção ReferenceError em modo restrito.)
 
-  b();     // chamando b, o código irá criar z como variável global
-  console.log(x, y, z);  // 3 4 5
+  b(); // chamando b, o código irá criar z como variável global
+  console.log(x, y, z); // 3 4 5
 }
 
-a();                   // chamando a, também irá chamar b
-console.log(x, z);     // 3 5
+a(); // chamando a, também irá chamar b
+console.log(x, z); // 3 5
 console.log(typeof y); // indefinido já que y é uma variável local da função a
 ```
 
 ## Especificação
 
-| Specification                                                                                | Status                   | Comment                                            |
-| -------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| ECMAScript 1st Edition                                                                       | Standard                 | Primeira definição. Implementada no JavaScript 1.0 |
-| {{SpecName('ES5.1', '#sec-12.2', 'var statement')}}                         | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-variable-statement', 'variable statement')}} | {{Spec2('ES6')}}     |                                                    |
+| Specification                                                        | Status             | Comment                                            |
+| -------------------------------------------------------------------- | ------------------ | -------------------------------------------------- |
+| ECMAScript 1st Edition                                               | Standard           | Primeira definição. Implementada no JavaScript 1.0 |
+| {{SpecName('ES5.1', '#sec-12.2', 'var statement')}}                  | {{Spec2('ES5.1')}} |                                                    |
+| {{SpecName('ES6', '#sec-variable-statement', 'variable statement')}} | {{Spec2('ES6')}}   |                                                    |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/statements/while/index.md
+++ b/files/pt-br/web/javascript/reference/statements/while/index.md
@@ -44,13 +44,13 @@ Depois de completar a terceira passagem, a condição n < 3 não é mais verdade
 
 ## Especificações
 
-| Specification                                                                            | Status                       | Comment           |
-| ---------------------------------------------------------------------------------------- | ---------------------------- | ----------------- |
+| Specification                                                      | Status               | Comment           |
+| ------------------------------------------------------------------ | -------------------- | ----------------- |
 | {{SpecName('ESDraft', '#sec-while-statement', 'while statement')}} | {{Spec2('ESDraft')}} |                   |
-| {{SpecName('ES6', '#sec-while-statement', 'while statement')}}     | {{Spec2('ES6')}}         |                   |
-| {{SpecName('ES5.1', '#sec-12.6.2', 'while statement')}}                 | {{Spec2('ES5.1')}}     |                   |
-| {{SpecName('ES3', '#sec-12.6.2', 'while statement')}}                 | {{Spec2('ES3')}}         |                   |
-| {{SpecName('ES1', '#sec-12.6.1', 'while statement')}}                 | {{Spec2('ES1')}}         | Definição inicial |
+| {{SpecName('ES6', '#sec-while-statement', 'while statement')}}     | {{Spec2('ES6')}}     |                   |
+| {{SpecName('ES5.1', '#sec-12.6.2', 'while statement')}}            | {{Spec2('ES5.1')}}   |                   |
+| {{SpecName('ES3', '#sec-12.6.2', 'while statement')}}              | {{Spec2('ES3')}}     |                   |
+| {{SpecName('ES1', '#sec-12.6.1', 'while statement')}}              | {{Spec2('ES1')}}     | Definição inicial |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/statements/with/index.md
+++ b/files/pt-br/web/javascript/reference/statements/with/index.md
@@ -78,13 +78,13 @@ with (Math) {
 
 ## Especificações
 
-| Especificação                                                                        | Situação                     | Comentário                      |
-| ------------------------------------------------------------------------------------ | ---------------------------- | ------------------------------- |
+| Especificação                                                    | Situação             | Comentário                      |
+| ---------------------------------------------------------------- | -------------------- | ------------------------------- |
 | {{SpecName('ESDraft', '#sec-with-statement', 'with statement')}} | {{Spec2('ESDraft')}} |                                 |
-| {{SpecName('ES6', '#sec-with-statement', 'with statement')}}     | {{Spec2('ES6')}}         |                                 |
-| {{SpecName('ES5.1', '#sec-12.10', 'with statement')}}             | {{Spec2('ES5.1')}}     | Agora proibido no modo estrito. |
-| {{SpecName('ES3', '#sec-12.10', 'with statement')}}                 | {{Spec2('ES3')}}         |                                 |
-| {{SpecName('ES1', '#sec-12.10', 'with statement')}}                 | {{Spec2('ES1')}}         | Definição inicial               |
+| {{SpecName('ES6', '#sec-with-statement', 'with statement')}}     | {{Spec2('ES6')}}     |                                 |
+| {{SpecName('ES5.1', '#sec-12.10', 'with statement')}}            | {{Spec2('ES5.1')}}   | Agora proibido no modo estrito. |
+| {{SpecName('ES3', '#sec-12.10', 'with statement')}}              | {{Spec2('ES3')}}     |                                 |
+| {{SpecName('ES1', '#sec-12.10', 'with statement')}}              | {{Spec2('ES1')}}     | Definição inicial               |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/javascript/reference/strict_mode/index.md
+++ b/files/pt-br/web/javascript/reference/strict_mode/index.md
@@ -34,13 +34,17 @@ Você também pode usar a abordagem de embrulhar o conteúdo inteiro de um scrip
 Da mesma forma, para invocar strict mode para uma função, coloque _exatamente_ a declaração `"use strict";` (ou `'use strict';`) no corpo da função antes de qualquer outra declaração.
 
 ```js
-function strict(){
+function strict() {
   // Sintaxe strict mode a nível de função
-  'use strict';
-  function nested() { return "E eu também!"; }
+  "use strict";
+  function nested() {
+    return "E eu também!";
+  }
   return "Oi! Eu sou uma função strict mode!  " + nested();
 }
-function notStrict() { return "Eu não sou strict."; }
+function notStrict() {
+  return "Eu não sou strict.";
+}
 ```
 
 ## Mudanças no strict mode
@@ -55,9 +59,9 @@ Primeiro, o strict mode impossibilita criar variáveis globais acidentalmente. E
 
 ```js
 "use strict";
-                     // Assumindo que uma variável global variavelErrada existe
+// Assumindo que uma variável global variavelErrada existe
 variavellErrada = 17; // esta linha lança ReferenceError por conta do
-                     // erro de digitação da variável
+// erro de digitação da variável
 ```
 
 Segundo, strict mode faz com que atribuições que outrora falhariam silenciosamente lançar uma exceção. Por exemplo, `NaN` é uma variável global não-atribuível. Em código normal, atribuir a `NaN` não faz nada; o desenvolvedor não recebe qualquer resposta de falha. No strict mode, atribuir a `NaN` lança uma exceção. Qualquer atribuição que falha silenciosamente em código normal (atribuir a uma propriedade não-atribuível, atribuir a uma propriedade getter-only, atribuir a uma propriedade de um objeto [não-extensível](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions)) lançarão exceções em strict mode:
@@ -71,7 +75,11 @@ Object.defineProperty(obj1, "x", { value: 42, writable: false });
 obj1.x = 9; // lança TypeError
 
 // Atribuir a uma propriedade getter-only
-var obj2 = { get x() { return 17; } };
+var obj2 = {
+  get x() {
+    return 17;
+  },
+};
 obj2.x = 5; // lança TypeError
 
 // Atribuir a uma nova propriedade de um objeto não-extensível
@@ -99,7 +107,8 @@ var o = { p: 1, p: 2 }; // !!! erro de sintaxe
 Quinto, strict mode exige que nomes de parâmetros de função sejam únicos. Em código normal, o último argumento duplicado esconde argumentos anteriores com nome semelhante. Estes argumentos anteriores continuam disponíveis através de `arguments[i]`**,** portanto não são completamente inacessíveis. Entretanto, esta ocultação faz pouco sentido e provavelmente é indesejável (pode esconder um erro de digitação, por exemplo), então em strict mode nomes de argumentos duplicados são erro de sintaxe:
 
 ```js
-function sum(a, a, c){ // !!! erro de sintaxe
+function sum(a, a, c) {
+  // !!! erro de sintaxe
   "use strict";
   return a + b + c; // errado se este código executasse
 }
@@ -115,21 +124,21 @@ Novos desenvolvedores algumas vezes acham que um prefixo zero não tem significa
 
 ```js
 "use strict";
-var sum = 015 + // !!! erro de sintaxe
-          197 +
-          142;
+var sum =
+  015 + // !!! erro de sintaxe
+  197 +
+  142;
 ```
 
 Sétimo, strict mode em ECMAScript 6 proíbe definir propriedades em valores {{Glossary("Primitive", "primitivos")}}. Sem strict mode, definir uma propriedade é simplesmente ignorado; com strict mode, no entanto, um {{jsxref("TypeError")}} é lançado.
 
 ```js
-(function() {
-"use strict";
+(function () {
+  "use strict";
 
-false.true = "";             // TypeError
-(14).navegandoPara = "casa"; // TypeError
-"com".voce = "distante";     // TypeError
-
+  false.true = ""; // TypeError
+  (14).navegandoPara = "casa"; // TypeError
+  "com".voce = "distante"; // TypeError
 })();
 ```
 
@@ -142,8 +151,7 @@ Primeiro, strict mode proíbe `with`. O problema com `with` é que qualquer nome
 ```js
 "use strict";
 var x = 17;
-with (obj) // !!! erro de sintaxe
-{
+with (obj) { // !!! erro de sintaxe
   // Se isto não fosse strict mode, isso seria var x ou obj.x?
   // No geral, é impossível saber sem executar o código, então
   // o nome não pode ser otimizado.
@@ -165,18 +173,18 @@ console.assert(evalX === 42);
 Relacionadamente, se a função `eval` for invocada por uma expressão da forma `eval(...)` em código strict mode, o código será avaliado como código strict mode. O código pode invocar strict code explicitamente, mas não é necessário.
 
 ```js
-function strict1(str){
+function strict1(str) {
   "use strict";
   return eval(str); // str será tratado como código strict mode
 }
-function strict2(f, str){
+function strict2(f, str) {
   "use strict";
   return f(str); // não é eval(...): str é strict se e
-                 // somente se invocar strict mode
+  // somente se invocar strict mode
 }
-function nonstrict(str){
+function nonstrict(str) {
   return eval(str); // str é strict se e somente se
-                    // invocar strict mode
+  // invocar strict mode
 }
 
 strict1("'Código strict mode!'");
@@ -211,19 +219,20 @@ Primeiro, os nomes `eval` e `arguments` não podem ser vinculados ou atribuídos
 eval = 17;
 arguments++;
 ++eval;
-var obj = { set p(arguments) { } };
+var obj = { set p(arguments) {} };
 var eval;
-try { } catch (arguments) { }
-function x(eval) { }
-function arguments() { }
-var y = function eval() { };
+try {
+} catch (arguments) {}
+function x(eval) {}
+function arguments() {}
+var y = function eval() {};
 var f = new Function("arguments", "'use strict'; return 17;");
 ```
 
 Segundo, código strict mode não faz _alias_ para propriedades de objetos `arguments` criados dentro de si. Em código normal dentro de uma função cujo primeiro argumento é `arg`, definir `arg` também define `arguments[0]`, e vice-versa (a menos que nenhum argumento seja fornecido ou `arguments[0]` seja deletado). Objetos `arguments` para funções strict mode armazenam os argumentos originais quando a função é invocada. `arguments[i]` não rastreia o valor do argumento nomeado correspondente, nem um argumento nomeado rastreia o valor do `arguments[i]` correspondente.
 
 ```js
-function f(a){
+function f(a) {
   "use strict";
   a = 42;
   return [a, arguments[0]];
@@ -237,7 +246,9 @@ Terceiro, `arguments.callee` não é mais suportado. Em código normal, `argumen
 
 ```js
 "use strict";
-var f = function() { return arguments.callee; };
+var f = function () {
+  return arguments.callee;
+};
 f(); // lança TypeError
 ```
 
@@ -249,7 +260,9 @@ Primeiro, o valor passado como `this` para uma função em strict mode não é f
 
 ```js
 "use strict";
-function fun() { return this; }
+function fun() {
+  return this;
+}
 console.assert(fun() === undefined);
 console.assert(fun.call(2) === 2);
 console.assert(fun.apply(null) === null);
@@ -262,14 +275,12 @@ Isso significa, além de outras coisas, que em navegadores não é mais possíve
 Segundo, em strict mode não é mais possível "caminhar" a pilha JavaScript via extensões do ECMAScript comumente implementadas. Em código normal com essas extensões, quando uma funçao `fun` está no meio de ser chamada, `fun.caller` é a função que chamou `fun` mais recentemente, e `fun.arguments` é o `arguments` para aquela invocação de `fun`. Ambas as extensões são problemáticas para JavaScript "seguro" porque permitem que código "seguro" acesse funções "privilegiadas" e seus argumentos (potencialmente inseguros). Se `fun` estiver em strict mode, tanto `fun.caller` quando `fun.arguments` são propriedades não-deletáveis que lançam exceção quando definidas ou recuperadas:
 
 ```js
-function restrita()
-{
+function restrita() {
   "use strict";
-  restrita.caller;    // lança TypeError
+  restrita.caller; // lança TypeError
   restrita.arguments; // lança TypeError
 }
-function invocadorPrivilegiado()
-{
+function invocadorPrivilegiado() {
   return restrita();
 }
 invocadorPrivilegiado();
@@ -279,8 +290,7 @@ Terceiro, `arguments` para funções strict mode não oferecem mais acesso às v
 
 ```js
 "use strict";
-function fun(a, b)
-{
+function fun(a, b) {
   "use strict";
   var v = 12;
   return arguments.caller; // lança TypeError
@@ -295,18 +305,21 @@ Versões futuras do ECMAScript provavelmente introduzirão nova sintaxe, e o str
 Primeiro, no strict mode, uma pequena lista de identificadores tornam-se palavras-chave reservadas. Estas palavras são `implements`, `interface`, `let`, `package`, `private`, `protected`, `public`, `static` e `yield`. Em strict mode, portanto, você não pode nomear ou usar variáveis ou argumentos com esses nomes.
 
 ```js
-function package(protected){ // !!!
+function package(protected) {
+  // !!!
   "use strict";
   var implements; // !!!
 
-  interface: // !!!
-  while (true){
+  // !!!
+  interface: while (true) {
     break interface; // !!!
   }
 
-  function private() { } // !!!
+  function private() {} // !!!
 }
-function fun(static) { 'use strict'; } // !!!
+function fun(static) {
+  "use strict";
+} // !!!
 ```
 
 Duas ressalvas específicas à Mozilla: primeiro, se seu código for JavaScript 1.7 ou superior (por exemplo em código chrome ou usando o `<script type="">` correto) e for strict mode, `let` e `yield` têm a funcionaldade que eles tiveram desde que essas palavras-chave foram introduzidas pela primeira vez. Mas código strict mode na web, carregado com `<script src="">` ou `<script>...</script>`, não serão capazes de usar `let`/`yield` como identificadores. Segundo, enquanto o ES5 reserva incondicionalmente as palavras `class`, `enum`, `export`, `extends`, `import` e `super`, a Mozilla reservava-as apenas em strict mode antes do Firefox 5.
@@ -315,18 +328,19 @@ Segundo, [strict mode proíbe declaração de funções fora do nível superior 
 
 ```js
 "use strict";
-if (true){
-  function f() { } // !!! erro de sintaxe
+if (true) {
+  function f() {} // !!! erro de sintaxe
   f();
 }
 
-for (var i = 0; i < 5; i++){
-  function f2() { } // !!! erro de sintaxe
+for (var i = 0; i < 5; i++) {
+  function f2() {} // !!! erro de sintaxe
   f2();
 }
 
-function baz(){ // correto
-  function eit() { } // erro de sintaxe
+function baz() {
+  // correto
+  function eit() {} // erro de sintaxe
 }
 ```
 
@@ -338,11 +352,11 @@ Os principais navegadores agora implementam strict mode. Entretanto, não depend
 
 ## Especificações
 
-| Especificação                                                                                | Status                       | Comentário                                                                                                                      |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-10.1.1', 'Strict Mode Code')}}                 | {{Spec2('ES5.1')}}     | Definição inicial. Veja também: [Strict mode restriction and exceptions](https://www.ecma-international.org/ecma-262/5.1/#sec-C) |
-| {{SpecName('ES6', '#sec-strict-mode-code', 'Strict Mode Code')}}         | {{Spec2('ES6')}}         | [Strict mode restriction and exceptions](https://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-of-ecmascript)         |
-| {{SpecName('ESDraft', '#sec-strict-mode-code', 'Strict Mode Code')}} | {{Spec2('ESDraft')}} | [Strict mode restriction and exceptions](https://tc39.github.io/ecma262/#sec-strict-mode-of-ecmascript)                         |
+| Especificação                                                        | Status               | Comentário                                                                                                                       |
+| -------------------------------------------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| {{SpecName('ES5.1', '#sec-10.1.1', 'Strict Mode Code')}}             | {{Spec2('ES5.1')}}   | Definição inicial. Veja também: [Strict mode restriction and exceptions](https://www.ecma-international.org/ecma-262/5.1/#sec-C) |
+| {{SpecName('ES6', '#sec-strict-mode-code', 'Strict Mode Code')}}     | {{Spec2('ES6')}}     | [Strict mode restriction and exceptions](https://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-of-ecmascript)         |
+| {{SpecName('ESDraft', '#sec-strict-mode-code', 'Strict Mode Code')}} | {{Spec2('ESDraft')}} | [Strict mode restriction and exceptions](https://tc39.github.io/ecma262/#sec-strict-mode-of-ecmascript)                          |
 
 ## Veja também
 

--- a/files/pt-br/web/javascript/reference/template_literals/index.md
+++ b/files/pt-br/web/javascript/reference/template_literals/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/template_strings
 
 {{JsSidebar("More")}}
 
-_Template_ Strings são _string_s que permitem expressões embutidas. Você pode _utilizar string_ multi-linhas e interpolação de _string_ com elas.
+_Template_ Strings são *string*s que permitem expressões embutidas. Você pode _utilizar string_ multi-linhas e interpolação de _string_ com elas.
 
 Basicamente é uma nova forma de criar strings e tornar o seu código um pouco mais legível.
 
@@ -28,7 +28,7 @@ tag `texto string ${expression} texto string`
 _Template strings_ são envolvidas por ([acentos graves](https://pt.wikipedia.org/wiki/Acento_grave)) (\` \`) em vez de aspas simples ou duplas. _Template strings_ podem possuir _placeholders_. Estes são indicados por um cifrão seguido de chaves (`${expression}`). As expressões nos _placeholders_, bem como o texto em volta delas são passados a uma função. A função padrão apenas concatena as partes em uma _string_ única. Se existir uma expressão precedendo a _template string_ (função `tag` exemplo), a _template string_ é definida como "_tagged template string_". No caso, a expressão _tag_ (geralmente uma função) é chamada pela _template string_ processada, que você pode manipular antes de produzir o resultado.
 
 ```js
-`\`` === '`' // --> true
+`\`` === "`"; // --> true
 ```
 
 ### Strings multi-linhas
@@ -36,8 +36,7 @@ _Template strings_ são envolvidas por ([acentos graves](https://pt.wikipedia.or
 Qualquer caracter de nova linha inserido no código é parte da _template string_. Utilizando _strings_ normais, você teria de usar a síntaxe a seguir para obter strings multi-linhas:
 
 ```js
-console.log('texto string linha 1\n' +
-'texto string linha 2');
+console.log("texto string linha 1\n" + "texto string linha 2");
 // "texto string linha 1
 // texto string linha 2"
 ```
@@ -58,7 +57,7 @@ Para encapsular expressões dentro de strings, você precisava utilizar a seguin
 ```js
 var a = 5;
 var b = 10;
-console.log('Quinze é ' + (a + b) + ' e\nnão ' + (2 * a + b) + '.');
+console.log("Quinze é " + (a + b) + " e\nnão " + (2 * a + b) + ".");
 // "Quinze é 15 e
 // não 20."
 ```
@@ -85,13 +84,13 @@ var b = 10;
 function tag(strings, ...values) {
   console.log(strings[0]); // "Hello "
   console.log(strings[1]); // " world "
-  console.log(values[0]);  // 15
-  console.log(values[1]);  // 50
+  console.log(values[0]); // 15
+  console.log(values[1]); // 50
 
   return "Bazinga!";
 }
 
-tag`Hello ${ a + b } world ${ a * b}`;
+tag`Hello ${a + b} world ${a * b}`;
 // "Bazinga!"
 ```
 
@@ -111,7 +110,7 @@ tag`string text line 1 \n string text line 2`;
 Adicionalmente, o método {{jsxref("String.raw()")}} permite a criação de strings cruas, exatamente como as _template functions_ e as concatenações deveram criar.
 
 ```js
-String.raw`Hi\n${2+3}!`; // "Hi\\n5!"
+String.raw`Hi\n${2 + 3}!`; // "Hi\\n5!"
 ```
 
 ## Especificações


### PR DESCRIPTION
This PR formats the `/web/javascript` folder of the Brazilian Portuguese locale using Prettier.  This is the fifth part.
