### PR TITLE
zh-cn: Lint front matter keys (part 2)

### DIFF
--- a/files/zh-cn/web/css/counter/index.md
+++ b/files/zh-cn/web/css/counter/index.md
@@ -1,7 +1,6 @@
 ---
 title: counter()
 slug: Web/CSS/counter
-original_slug: Web/CSS/counter()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/counters/index.md
+++ b/files/zh-cn/web/css/counters/index.md
@@ -1,7 +1,6 @@
 ---
 title: counters()
 slug: Web/CSS/counters
-original_slug: Web/CSS/counters()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/css_backgrounds_and_borders/border-image_generator/index.md
+++ b/files/zh-cn/web/css/css_backgrounds_and_borders/border-image_generator/index.md
@@ -1,7 +1,6 @@
 ---
 title: Border-image 生成器
 slug: Web/CSS/CSS_backgrounds_and_borders/Border-image_generator
-original_slug: Web/CSS/CSS_Background_and_Borders/Border-image_generator
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/css_colors/applying_color/index.md
+++ b/files/zh-cn/web/css/css_colors/applying_color/index.md
@@ -204,7 +204,7 @@ th {
 </table>
 ```
 
-{{EmbedLiveSample("HSL 函数表示法s", 300, 260)}}
+{{EmbedLiveSample("HSL 函数表示法", 300, 260)}}
 
 > **备注：** Note that when you omit the hue's unit, it's assumed to be in degrees (`deg`).
 

--- a/files/zh-cn/web/css/css_colors/applying_color/index.md
+++ b/files/zh-cn/web/css/css_colors/applying_color/index.md
@@ -1,7 +1,6 @@
 ---
 title: 使用 CSS 为 HTML 元素应用颜色
 slug: Web/CSS/CSS_colors/Applying_color
-original_slug: Web/HTML/Applying_color
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/css_colors/index.md
+++ b/files/zh-cn/web/css/css_colors/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS Color
 slug: Web/CSS/CSS_colors
-original_slug: Web/CSS/CSS_Color
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/css_flexible_box_layout/backwards_compatibility_of_flexbox/index.md
+++ b/files/zh-cn/web/css/css_flexible_box_layout/backwards_compatibility_of_flexbox/index.md
@@ -1,7 +1,6 @@
 ---
 title: Flexbox 的向下支持
 slug: Web/CSS/CSS_flexible_box_layout/Backwards_compatibility_of_flexbox
-original_slug: Web/CSS/CSS_Flexible_Box_Layout/Flexbox_的_向下_支持
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_axis/index.md
+++ b/files/zh-cn/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_axis/index.md
@@ -1,9 +1,6 @@
 ---
 title: 控制弹性元素在主轴上的比例
-slug: >-
-  Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the_main_axis
-original_slug: >-
-  Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax
+slug: Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the_main_axis
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
+++ b/files/zh-cn/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
@@ -1,8 +1,6 @@
 ---
 title: 弹性盒子与其他布局方法的联系
-slug: >-
-  Web/CSS/CSS_flexible_box_layout/Relationship_of_flexbox_to_other_layout_methods
-original_slug: Web/CSS/CSS_Flexible_Box_Layout/弹性盒子与其他布局方法的联系
+slug: Web/CSS/CSS_flexible_box_layout/Relationship_of_flexbox_to_other_layout_methods
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
+++ b/files/zh-cn/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
@@ -1,7 +1,6 @@
 ---
 title: Flexbox 典型用例
 slug: Web/CSS/CSS_flexible_box_layout/Typical_use_cases_of_flexbox
-original_slug: Web/CSS/CSS_Flexible_Box_Layout/典型_用例_的_Flexbox
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/css_fragmentation/index.md
+++ b/files/zh-cn/web/css/css_fragmentation/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS 分片
 slug: Web/CSS/CSS_fragmentation
-original_slug: Web/CSS/CSS_分片
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/css_images/implementing_image_sprites_in_css/index.md
+++ b/files/zh-cn/web/css/css_images/implementing_image_sprites_in_css/index.md
@@ -1,7 +1,6 @@
 ---
 title: 在 CSS 中实现图像合并
 slug: Web/CSS/CSS_images/Implementing_image_sprites_in_CSS
-original_slug: Web/Guide/CSS/CSS_Image_Sprites
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/css_images/using_css_gradients/index.md
+++ b/files/zh-cn/web/css/css_images/using_css_gradients/index.md
@@ -1,7 +1,6 @@
 ---
 title: 使用 CSS 渐变
 slug: Web/CSS/CSS_images/Using_CSS_gradients
-original_slug: Web/Guide/CSS/Using_CSS_gradients
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.md
+++ b/files/zh-cn/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.md
@@ -1,7 +1,6 @@
 ---
 title: 在选择器中使用 :target 伪类
 slug: Web/CSS/CSS_selectors/Using_the_:target_pseudo-class_in_selectors
-original_slug: Web/Guide/CSS/Using_the_:target_selector
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/element/index.md
+++ b/files/zh-cn/web/css/element/index.md
@@ -1,7 +1,6 @@
 ---
 title: element
 slug: Web/CSS/element
-original_slug: Web/CSS/element()
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/zh-cn/web/css/env/index.md
+++ b/files/zh-cn/web/css/env/index.md
@@ -1,7 +1,6 @@
 ---
 title: env()
 slug: Web/CSS/env
-original_slug: Web/CSS/env()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/filter-function/blur/index.md
+++ b/files/zh-cn/web/css/filter-function/blur/index.md
@@ -1,7 +1,6 @@
 ---
 title: blur()
 slug: Web/CSS/filter-function/blur
-original_slug: Web/CSS/filter-function/blur()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/filter-function/brightness/index.md
+++ b/files/zh-cn/web/css/filter-function/brightness/index.md
@@ -1,7 +1,6 @@
 ---
 title: brightness()
 slug: Web/CSS/filter-function/brightness
-original_slug: Web/CSS/filter-function/brightness()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/filter-function/contrast/index.md
+++ b/files/zh-cn/web/css/filter-function/contrast/index.md
@@ -1,7 +1,6 @@
 ---
 title: contrast()
 slug: Web/CSS/filter-function/contrast
-original_slug: Web/CSS/filter-function/contrast()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/filter-function/drop-shadow/index.md
+++ b/files/zh-cn/web/css/filter-function/drop-shadow/index.md
@@ -1,7 +1,6 @@
 ---
 title: drop-shadow()
 slug: Web/CSS/filter-function/drop-shadow
-original_slug: Web/CSS/filter-function/drop-shadow()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/filter-function/grayscale/index.md
+++ b/files/zh-cn/web/css/filter-function/grayscale/index.md
@@ -1,7 +1,6 @@
 ---
 title: grayscale()
 slug: Web/CSS/filter-function/grayscale
-original_slug: Web/CSS/filter-function/grayscale()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/filter-function/opacity/index.md
+++ b/files/zh-cn/web/css/filter-function/opacity/index.md
@@ -1,7 +1,6 @@
 ---
 title: opacity()
 slug: Web/CSS/filter-function/opacity
-original_slug: Web/CSS/filter-function/opacity()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/float/index.md
+++ b/files/zh-cn/web/css/float/index.md
@@ -1,7 +1,6 @@
 ---
 title: float
 slug: Web/CSS/float
-original_slug: CSS/float
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/gradient/linear-gradient/index.md
+++ b/files/zh-cn/web/css/gradient/linear-gradient/index.md
@@ -1,7 +1,6 @@
 ---
 title: linear-gradient()
 slug: Web/CSS/gradient/linear-gradient
-original_slug: Web/CSS/gradient/linear-gradient()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/gradient/repeating-linear-gradient/index.md
+++ b/files/zh-cn/web/css/gradient/repeating-linear-gradient/index.md
@@ -1,7 +1,6 @@
 ---
 title: repeating-linear-gradient()
 slug: Web/CSS/gradient/repeating-linear-gradient
-original_slug: Web/CSS/gradient/repeating-linear-gradient()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/gradient/repeating-radial-gradient/index.md
+++ b/files/zh-cn/web/css/gradient/repeating-radial-gradient/index.md
@@ -1,7 +1,6 @@
 ---
 title: repeating-radial-gradient()
 slug: Web/CSS/gradient/repeating-radial-gradient
-original_slug: Web/CSS/gradient/repeating-radial-gradient()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/grid-template-rows/index.md
+++ b/files/zh-cn/web/css/grid-template-rows/index.md
@@ -1,7 +1,6 @@
 ---
 title: grid-template-rows
 slug: Web/CSS/grid-template-rows
-original_slug: Web/CSS/网格-模板-列
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/layout_cookbook/media_objects/index.md
+++ b/files/zh-cn/web/css/layout_cookbook/media_objects/index.md
@@ -1,7 +1,6 @@
 ---
 title: 指南：媒体对象
 slug: Web/CSS/Layout_cookbook/Media_objects
-original_slug: Web/CSS/Layout_cookbook/媒体对象
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/max/index.md
+++ b/files/zh-cn/web/css/max/index.md
@@ -1,7 +1,6 @@
 ---
 title: max()
 slug: Web/CSS/max
-original_slug: Web/CSS/max()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/min/index.md
+++ b/files/zh-cn/web/css/min/index.md
@@ -1,7 +1,6 @@
 ---
 title: min()
 slug: Web/CSS/min
-original_slug: Web/CSS/min()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/repeat/index.md
+++ b/files/zh-cn/web/css/repeat/index.md
@@ -1,7 +1,6 @@
 ---
 title: repeat()
 slug: Web/CSS/repeat
-original_slug: Web/CSS/repeat()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/text-decoration-thickness/index.md
+++ b/files/zh-cn/web/css/text-decoration-thickness/index.md
@@ -1,7 +1,6 @@
 ---
 title: 文本装饰线厚度 (粗细)
 slug: Web/CSS/text-decoration-thickness
-original_slug: Web/CSS/文本装饰线厚度 (粗细)
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/matrix/index.md
+++ b/files/zh-cn/web/css/transform-function/matrix/index.md
@@ -1,7 +1,6 @@
 ---
 title: matrix()
 slug: Web/CSS/transform-function/matrix
-original_slug: Web/CSS/transform-function/matrix()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/matrix3d/index.md
+++ b/files/zh-cn/web/css/transform-function/matrix3d/index.md
@@ -1,7 +1,6 @@
 ---
 title: matrix3d()
 slug: Web/CSS/transform-function/matrix3d
-original_slug: Web/CSS/transform-function/matrix3d()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/perspective/index.md
+++ b/files/zh-cn/web/css/transform-function/perspective/index.md
@@ -1,7 +1,6 @@
 ---
 title: perspective()
 slug: Web/CSS/transform-function/perspective
-original_slug: Web/CSS/transform-function/perspective()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/rotate/index.md
+++ b/files/zh-cn/web/css/transform-function/rotate/index.md
@@ -1,7 +1,6 @@
 ---
 title: rotate()
 slug: Web/CSS/transform-function/rotate
-original_slug: Web/CSS/transform-function/rotate()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/rotate3d/index.md
+++ b/files/zh-cn/web/css/transform-function/rotate3d/index.md
@@ -1,7 +1,6 @@
 ---
 title: rotate3d()
 slug: Web/CSS/transform-function/rotate3d
-original_slug: Web/CSS/transform-function/rotate3d()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/rotatex/index.md
+++ b/files/zh-cn/web/css/transform-function/rotatex/index.md
@@ -1,7 +1,6 @@
 ---
 title: rotateX()
 slug: Web/CSS/transform-function/rotateX
-original_slug: Web/CSS/transform-function/rotateX()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/rotatey/index.md
+++ b/files/zh-cn/web/css/transform-function/rotatey/index.md
@@ -1,7 +1,6 @@
 ---
 title: rotateY()
 slug: Web/CSS/transform-function/rotateY
-original_slug: Web/CSS/transform-function/rotateY()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/rotatez/index.md
+++ b/files/zh-cn/web/css/transform-function/rotatez/index.md
@@ -1,7 +1,6 @@
 ---
 title: rotateZ()
 slug: Web/CSS/transform-function/rotateZ
-original_slug: Web/CSS/transform-function/rotateZ()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/scale/index.md
+++ b/files/zh-cn/web/css/transform-function/scale/index.md
@@ -1,7 +1,6 @@
 ---
 title: scale()
 slug: Web/CSS/transform-function/scale
-original_slug: Web/CSS/transform-function/scale()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/scalex/index.md
+++ b/files/zh-cn/web/css/transform-function/scalex/index.md
@@ -1,7 +1,6 @@
 ---
 title: scaleX()
 slug: Web/CSS/transform-function/scaleX
-original_slug: Web/CSS/transform-function/scaleX()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/scaley/index.md
+++ b/files/zh-cn/web/css/transform-function/scaley/index.md
@@ -1,7 +1,6 @@
 ---
 title: scaleY()
 slug: Web/CSS/transform-function/scaleY
-original_slug: Web/CSS/transform-function/scaleY()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/skew/index.md
+++ b/files/zh-cn/web/css/transform-function/skew/index.md
@@ -1,7 +1,6 @@
 ---
 title: skew()
 slug: Web/CSS/transform-function/skew
-original_slug: Web/CSS/transform-function/skew()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/skewx/index.md
+++ b/files/zh-cn/web/css/transform-function/skewx/index.md
@@ -1,7 +1,6 @@
 ---
 title: skewX()
 slug: Web/CSS/transform-function/skewX
-original_slug: Web/CSS/transform-function/skewX()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/translate/index.md
+++ b/files/zh-cn/web/css/transform-function/translate/index.md
@@ -1,7 +1,6 @@
 ---
 title: translate()
 slug: Web/CSS/transform-function/translate
-original_slug: Web/CSS/transform-function/translate()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/translate3d/index.md
+++ b/files/zh-cn/web/css/transform-function/translate3d/index.md
@@ -1,7 +1,6 @@
 ---
 title: translate3d()
 slug: Web/CSS/transform-function/translate3d
-original_slug: Web/CSS/transform-function/translate3d()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/translatex/index.md
+++ b/files/zh-cn/web/css/transform-function/translatex/index.md
@@ -1,7 +1,6 @@
 ---
 title: translateX()
 slug: Web/CSS/transform-function/translateX
-original_slug: Web/CSS/transform-function/translateX()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/transform-function/translatey/index.md
+++ b/files/zh-cn/web/css/transform-function/translatey/index.md
@@ -1,7 +1,6 @@
 ---
 title: translateY()
 slug: Web/CSS/transform-function/translateY
-original_slug: Web/CSS/transform-function/translateY()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/url/index.md
+++ b/files/zh-cn/web/css/url/index.md
@@ -1,7 +1,6 @@
 ---
 title: <url>
 slug: Web/CSS/url
-original_slug: Web/CSS/url()
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/css/visual_formatting_model/index.md
+++ b/files/zh-cn/web/css/visual_formatting_model/index.md
@@ -1,7 +1,6 @@
 ---
 title: 视觉格式化模型
 slug: Web/CSS/Visual_formatting_model
-original_slug: Web/Guide/CSS/Visual_formatting_model
 ---
 
 {{CSSRef}}

--- a/files/zh-cn/web/demos/index.md
+++ b/files/zh-cn/web/demos/index.md
@@ -1,7 +1,6 @@
 ---
 title: 开源 Web 技术示例
 slug: Web/Demos
-original_slug: Web/Demos_of_open_web_technologies
 ---
 
 Mozilla 支持各种令人兴奋的开源 Web 技术，我们鼓励大家使用它们。此页面提供了有关这些技术的一些有趣演示链接。

--- a/files/zh-cn/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/zh-cn/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -1,7 +1,6 @@
 ---
 title: 向 HTML 视频中添加字幕
-slug: >-
-  Web/Guide/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video
+slug: Web/Guide/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video
 ---
 
 {{QuickLinksWithSubPages("/zh-CN/docs/Web/Guide/Audio_and_video_delivery")}}

--- a/files/zh-cn/web/guide/houdini/index.md
+++ b/files/zh-cn/web/guide/houdini/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS Houdini
 slug: Web/Guide/Houdini
-original_slug: Web/Houdini
 ---
 
 Houdini 是一组底层 API，它们公开了 CSS 引擎的各个部分，从而使开发人员能够通过加入浏览器渲染引擎的样式和布局过程来扩展 CSS。Houdini 是一组 API，它们使开发人员可以直接访问[CSS 对象模型](/zh-CN/docs/Web/API/CSS_Object_Model) （CSSOM），使开发人员可以编写浏览器可以解析为 CSS 的代码，从而创建新的 CSS 功能，而无需等待它们在浏览器中本地实现。

--- a/files/zh-cn/web/html/attributes/crossorigin/index.md
+++ b/files/zh-cn/web/html/attributes/crossorigin/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTML 属性：crossorigin
 slug: Web/HTML/Attributes/crossorigin
-original_slug: Web/HTML/CORS_settings_attributes
 ---
 
 {{HTMLSidebar}}

--- a/files/zh-cn/web/html/attributes/rel/prefetch/index.md
+++ b/files/zh-cn/web/html/attributes/rel/prefetch/index.md
@@ -1,7 +1,6 @@
 ---
 title: 链接类型：prefetch
 slug: Web/HTML/Attributes/rel/prefetch
-original_slug: Web/HTML/Link_types/prefetch
 ---
 
 {{HTMLSidebar}}

--- a/files/zh-cn/web/html/attributes/rel/preload/index.md
+++ b/files/zh-cn/web/html/attributes/rel/preload/index.md
@@ -1,7 +1,6 @@
 ---
 title: 链接类型：preload
 slug: Web/HTML/Attributes/rel/preload
-original_slug: Web/HTML/Link_types/preload
 ---
 
 {{HTMLSidebar}}

--- a/files/zh-cn/web/html/constraint_validation/index.md
+++ b/files/zh-cn/web/html/constraint_validation/index.md
@@ -1,7 +1,6 @@
 ---
 title: 约束验证
 slug: Web/HTML/Constraint_validation
-original_slug: Web/Guide/HTML/Constraint_validation
 ---
 
 {{HTMLSidebar}}

--- a/files/zh-cn/web/html/content_categories/index.md
+++ b/files/zh-cn/web/html/content_categories/index.md
@@ -1,7 +1,6 @@
 ---
 title: 内容分类
 slug: Web/HTML/Content_categories
-original_slug: Web/Guide/HTML/Content_categories
 ---
 
 {{HTMLSidebar}}

--- a/files/zh-cn/web/html/element/dialog/index.md
+++ b/files/zh-cn/web/html/element/dialog/index.md
@@ -1,5 +1,5 @@
 ---
-title: "<dialog>：对话框元素"
+title: <dialog>：对话框元素
 slug: Web/HTML/Element/dialog
 ---
 

--- a/files/zh-cn/web/http/content_negotiation/list_of_default_accept_values/index.md
+++ b/files/zh-cn/web/http/content_negotiation/list_of_default_accept_values/index.md
@@ -1,7 +1,6 @@
 ---
 title: Accept 默认值
 slug: Web/HTTP/Content_negotiation/List_of_default_Accept_values
-original_slug: Web/HTTP/Content_negotiation/Accept_默认值
 ---
 
 {{HTTPSidebar}}

--- a/files/zh-cn/web/http/cors/errors/corsmissingallowheaderfrompreflight/index.md
+++ b/files/zh-cn/web/http/cors/errors/corsmissingallowheaderfrompreflight/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  原因：missing token 'xyz' in CORS header 'Access-Control-Allow-Headers' from
-  CORS preflight channel
+title: 原因：missing token 'xyz' in CORS header 'Access-Control-Allow-Headers' from CORS preflight channel
 slug: Web/HTTP/CORS/Errors/CORSMissingAllowHeaderFromPreflight
 ---
 

--- a/files/zh-cn/web/http/cors/errors/corsnotsupportingcredentials/index.md
+++ b/files/zh-cn/web/http/cors/errors/corsnotsupportingcredentials/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  原因：Credential is not supported if the CORS header
-  'Access-Control-Allow-Origin' is '*'
+title: 原因：Credential is not supported if the CORS header 'Access-Control-Allow-Origin' is '*'
 slug: Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
 ---
 

--- a/files/zh-cn/web/http/headers/permissions-policy/camera/index.md
+++ b/files/zh-cn/web/http/headers/permissions-policy/camera/index.md
@@ -1,7 +1,6 @@
 ---
 title: "Permissions-Policy: camera"
 slug: Web/HTTP/Headers/Permissions-Policy/camera
-original_slug: Web/HTTP/Headers/Feature-Policy/camera
 ---
 
 {{HTTPSidebar}}

--- a/files/zh-cn/web/http/headers/x-dns-prefetch-control/index.md
+++ b/files/zh-cn/web/http/headers/x-dns-prefetch-control/index.md
@@ -1,7 +1,6 @@
 ---
 title: X-DNS-Prefetch-Control
 slug: Web/HTTP/Headers/X-DNS-Prefetch-Control
-original_slug: Controlling_DNS_prefetching
 ---
 
 {{HTTPSidebar}}

--- a/files/zh-cn/web/http/headers/x-frame-options/index.md
+++ b/files/zh-cn/web/http/headers/x-frame-options/index.md
@@ -1,7 +1,6 @@
 ---
 title: X-Frame-Options
 slug: Web/HTTP/Headers/X-Frame-Options
-original_slug: Web/HTTP/X-Frame-Options
 ---
 
 {{HTTPSidebar}}

--- a/files/zh-cn/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
+++ b/files/zh-cn/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
@@ -1,7 +1,6 @@
 ---
 title: 代理自动配置文件（PAC）文件
 slug: Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file
-original_slug: Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_(PAC)_file
 ---
 
 {{HTTPSidebar}}

--- a/files/zh-cn/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/zh-cn/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -1,7 +1,6 @@
 ---
 title: Groups and ranges
 slug: Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences
-original_slug: Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges
 ---
 
 {{jsSidebar("JavaScript Guide")}}

--- a/files/zh-cn/web/javascript/guide/regular_expressions/quantifiers/index.md
+++ b/files/zh-cn/web/javascript/guide/regular_expressions/quantifiers/index.md
@@ -1,7 +1,6 @@
 ---
 title: 量词
 slug: Web/JavaScript/Guide/Regular_expressions/Quantifiers
-original_slug: Web/JavaScript/Guide/Regular_Expressions/量词
 ---
 
 {{jsSidebar("JavaScript Guide")}}

--- a/files/zh-cn/web/javascript/guide/typed_arrays/index.md
+++ b/files/zh-cn/web/javascript/guide/typed_arrays/index.md
@@ -1,7 +1,6 @@
 ---
 title: JavaScript 类型化数组
 slug: Web/JavaScript/Guide/Typed_arrays
-original_slug: Web/JavaScript/Typed_arrays
 ---
 
 {{JsSidebar("Advanced")}}

--- a/files/zh-cn/web/javascript/language_overview/index.md
+++ b/files/zh-cn/web/javascript/language_overview/index.md
@@ -1,7 +1,6 @@
 ---
 title: 重新介绍 JavaScript（JS 教程）
 slug: Web/JavaScript/Language_overview
-original_slug: Web/JavaScript/A_re-introduction_to_JavaScript
 ---
 
 {{jsSidebar}}

--- a/files/zh-cn/web/javascript/reference/errors/bad_return/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/bad_return/index.md
@@ -1,7 +1,6 @@
 ---
 title: "SyntaxError: return not in function"
 slug: Web/JavaScript/Reference/Errors/Bad_return
-original_slug: Web/JavaScript/Reference/Errors/Bad_return_or_yield
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/zh-cn/web/javascript/reference/errors/cant_assign_to_property/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/cant_assign_to_property/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'TypeError: can''t assign to property "x" on "y": not an object'
 slug: Web/JavaScript/Reference/Errors/Cant_assign_to_property
-original_slug: Web/JavaScript/Reference/Errors/不能添加属性
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/zh-cn/web/javascript/reference/errors/delete_in_strict_mode/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/delete_in_strict_mode/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  SyntaxError: applying the 'delete' operator to an unqualified name is
-  deprecated
+title: "SyntaxError: applying the 'delete' operator to an unqualified name is deprecated"
 slug: Web/JavaScript/Reference/Errors/Delete_in_strict_mode
 ---
 

--- a/files/zh-cn/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //#
-  instead
+title: "SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //# instead"
 slug: Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma
 ---
 

--- a/files/zh-cn/web/javascript/reference/errors/invalid_for-of_initializer/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/invalid_for-of_initializer/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  SyntaxError: a declaration in the head of a for-of loop can't have an
-  initializer
+title: "SyntaxError: a declaration in the head of a for-of loop can't have an initializer"
 slug: Web/JavaScript/Reference/Errors/Invalid_for-of_initializer
 ---
 

--- a/files/zh-cn/web/javascript/reference/global_objects/map/@@iterator/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/map/@@iterator/index.md
@@ -1,7 +1,6 @@
 ---
 title: Map.prototype[@@iterator]()
 slug: Web/JavaScript/Reference/Global_Objects/Map/@@iterator
-original_slug: Web/JavaScript/Reference/Global_Objects/Map/@@iterator
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/map/@@species/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/map/@@species/index.md
@@ -1,7 +1,6 @@
 ---
 title: get Map[@@species]
 slug: Web/JavaScript/Reference/Global_Objects/Map/@@species
-original_slug: Web/JavaScript/Reference/Global_Objects/Map/@@species
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/math/acosh/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/acosh/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.acosh()
 slug: Web/JavaScript/Reference/Global_Objects/Math/acosh
-original_slug: Web/JavaScript/Reference/Global_Objects/Math/反双曲余弦值
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/apply/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/apply/index.md
@@ -1,7 +1,6 @@
 ---
 title: handler.apply()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/apply
-original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/apply
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
@@ -1,7 +1,6 @@
 ---
 title: handler.construct()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/construct
-original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/construct
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
@@ -1,7 +1,6 @@
 ---
 title: handler.defineProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/defineProperty
-original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/defineProperty
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.md
@@ -1,7 +1,6 @@
 ---
 title: handler.deleteProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/deleteProperty
-original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/deleteProperty
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/get/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/get/index.md
@@ -1,7 +1,6 @@
 ---
 title: handler.get()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/get
-original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/get
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
@@ -1,7 +1,6 @@
 ---
 title: handler.getOwnPropertyDescriptor()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getOwnPropertyDescriptor
-original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/getOwnPropertyDescriptor
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
@@ -1,7 +1,6 @@
 ---
 title: handler.getPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getPrototypeOf
-original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/getPrototypeOf
 ---
 
 {{JSRef("Global_Objects", "Proxy")}}

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/has/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/has/index.md
@@ -1,7 +1,6 @@
 ---
 title: handler.has()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/has
-original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/has
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
@@ -1,7 +1,6 @@
 ---
 title: handler.isExtensible()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/isExtensible
-original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/isExtensible
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.md
@@ -1,7 +1,6 @@
 ---
 title: handler.ownKeys()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/ownKeys
-original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.md
@@ -1,7 +1,6 @@
 ---
 title: handler.preventExtensions()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/preventExtensions
-original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/preventExtensions
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/set/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/set/index.md
@@ -1,7 +1,6 @@
 ---
 title: handler.set()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set
-original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/set
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.md
@@ -1,7 +1,6 @@
 ---
 title: handler.setPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/setPrototypeOf
-original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/setPrototypeOf
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/operators/async_function/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/async_function/index.md
@@ -1,7 +1,6 @@
 ---
 title: 异步函数（async function）表达式
 slug: Web/JavaScript/Reference/Operators/async_function
-original_slug: Web/JavaScript/Reference/Operators/async
 ---
 
 {{jsSidebar("Operators")}}

--- a/files/zh-cn/web/javascript/reference/operators/bitwise_and/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/bitwise_and/index.md
@@ -1,7 +1,6 @@
 ---
 title: 按位与（&）
 slug: Web/JavaScript/Reference/Operators/Bitwise_AND
-original_slug: Web/JavaScript/Reference/Operators/按位与
 ---
 
 {{jsSidebar("Operators")}}

--- a/files/zh-cn/web/javascript/reference/operators/import.meta/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/import.meta/index.md
@@ -1,7 +1,6 @@
 ---
 title: import.meta
 slug: Web/JavaScript/Reference/Operators/import.meta
-original_slug: Web/JavaScript/Reference/Statements/import.meta
 ---
 
 {{JSSidebar("Statements")}}

--- a/files/zh-cn/web/javascript/reference/operators/null/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/null/index.md
@@ -1,7 +1,6 @@
 ---
 title: "null"
 slug: Web/JavaScript/Reference/Operators/null
-original_slug: Web/JavaScript/Reference/Global_Objects/null
 ---
 
 {{jsSidebar("Objects")}}

--- a/files/zh-cn/web/javascript/reference/operators/nullish_coalescing/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/nullish_coalescing/index.md
@@ -1,7 +1,6 @@
 ---
 title: 空值合并运算符（??）
 slug: Web/JavaScript/Reference/Operators/Nullish_coalescing
-original_slug: Web/JavaScript/Reference/Operators/Nullish_coalescing_operator
 ---
 
 {{JSSidebar("Operators")}}

--- a/files/zh-cn/web/javascript/reference/operators/nullish_coalescing_assignment/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/nullish_coalescing_assignment/index.md
@@ -1,7 +1,6 @@
 ---
 title: 逻辑空赋值（??=）
 slug: Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment
-original_slug: Web/JavaScript/Reference/Operators/Logical_nullish_assignment
 ---
 
 {{jsSidebar("Operators")}}

--- a/files/zh-cn/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/optional_chaining/index.md
@@ -1,7 +1,6 @@
 ---
 title: 可选链运算符（?.）
 slug: Web/JavaScript/Reference/Operators/Optional_chaining
-original_slug: Web/JavaScript/Reference/Operators/可选链
 ---
 
 {{JSSidebar("Operators")}}

--- a/files/zh-cn/web/javascript/reference/regular_expressions/unicode_character_class_escape/index.md
+++ b/files/zh-cn/web/javascript/reference/regular_expressions/unicode_character_class_escape/index.md
@@ -1,7 +1,6 @@
 ---
 title: Unicode property escapes
 slug: Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape
-original_slug: Web/JavaScript/Guide/Regular_expressions/Unicode_property_escapes
 ---
 
 {{jsSidebar("JavaScript Guide")}}

--- a/files/zh-cn/web/media/autoplay_guide/index.md
+++ b/files/zh-cn/web/media/autoplay_guide/index.md
@@ -1,7 +1,6 @@
 ---
 title: Autoplay guide for media and Web Audio APIs
 slug: Web/Media/Autoplay_guide
-original_slug: Web/媒体/Autoplay_guide
 ---
 
 网页加载完成后立即播放音频（或带有音频轨道的视频）可能会意外地打扰到用户。尽管自动播放媒体文件是一个很实用的功能，但是我们也应该谨慎地使用它，保证只有在它被需要的时候才使用。为了让用户拥有控制权，通常浏览器会提供各种方式禁用自动播放音频功能。在这篇文章中，我们将介绍各种媒体和 Web Audio APIs 的自动播放功能，包括关于如何使用自动播放功能、如何优雅的处理阻止自动播放功能的一些简短的介绍。


### PR DESCRIPTION
This PR uses the front matter linter to lint the front matter of the Simplified Chinese locale.  This is the second part.
