### PR TITLE
zh-cn: Lint front matter keys (part 3)

### DIFF
--- a/files/zh-cn/web/media/dash_adaptive_streaming_for_html_5_video/index.md
+++ b/files/zh-cn/web/media/dash_adaptive_streaming_for_html_5_video/index.md
@@ -1,7 +1,6 @@
 ---
 title: 为 HTML 5 视频提供的 DASH 自适应串流
 slug: Web/Media/DASH_Adaptive_Streaming_for_HTML_5_Video
-original_slug: Web/HTML/DASH_Adaptive_Streaming_for_HTML_5_Video
 ---
 
 经由 HTTP 的动态自适应串流（DASH）是一种自适应串流协议。这意味着它使得视频串流能基于网络性能来调整比特率，以保证视频流畅播放。

--- a/files/zh-cn/web/media/index.md
+++ b/files/zh-cn/web/media/index.md
@@ -1,7 +1,6 @@
 ---
 title: Web 媒体技术
 slug: Web/Media
-original_slug: Web/媒体
 ---
 
 {{QuickLinksWithSubpages("/zh-CN/docs/Web/Media")}}

--- a/files/zh-cn/web/performance/how_browsers_work/index.md
+++ b/files/zh-cn/web/performance/how_browsers_work/index.md
@@ -1,7 +1,6 @@
 ---
 title: 渲染页面：浏览器的工作原理
 slug: Web/Performance/How_browsers_work
-original_slug: Web/Performance/浏览器渲染页面的工作原理
 ---
 
 页面内容快速加载和流畅的交互是用户希望得到的 Web 体验，因此，开发者应力争实现这两个目标。

--- a/files/zh-cn/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/zh-cn/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -1,7 +1,6 @@
 ---
 title: 添加到主屏幕
 slug: Web/Progressive_web_apps/Guides/Making_PWAs_installable
-original_slug: Web/Progressive_web_apps/Add_to_home_screen
 ---
 
 添加到主屏幕（Add to Home Screen，简称 A2HS）是现代智能手机浏览器中的一项功能，使开发人员可以轻松便捷地将自己喜欢的 Web 应用程序（或网站）的快捷方式添加到主屏幕中，以便用户随后可以通过单击访问它。本指南说明了 A2HS 的使用方式，以及作为开发人员为使用户能利用 A2HS 所需做的事情。

--- a/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/app_structure/index.md
+++ b/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/app_structure/index.md
@@ -1,7 +1,6 @@
 ---
 title: PWA 结构
 slug: Web/Progressive_web_apps/Tutorials/js13kGames/App_structure
-original_slug: Web/Progressive_web_apps/App_structure
 ---
 
 {{PWASidebar}} {{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/js13kGames/Introduction", "Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers", "Web/Progressive_web_apps/Tutorials/js13kGames")}}

--- a/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/index.md
+++ b/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/index.md
@@ -1,7 +1,6 @@
 ---
 title: 渐进式 Web 应用介绍
 slug: Web/Progressive_web_apps/Tutorials/js13kGames
-original_slug: Web/Progressive_web_apps/Tutorials/js13kGames/Introduction
 ---
 
 {{PWASidebar}} {{NextMenu("Web/Progressive_web_apps/Tutorials/js13kGames/App_structure", "Web/Progressive_web_apps/Tutorials/js13kGames")}}

--- a/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/installable_pwas/index.md
+++ b/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/installable_pwas/index.md
@@ -1,7 +1,6 @@
 ---
 title: 让 PWA 易于安装
 slug: Web/Progressive_web_apps/Tutorials/js13kGames/Installable_PWAs
-original_slug: Web/Progressive_web_apps/Installable_PWAs
 ---
 
 {{PWASidebar}} {{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers", "Web/Progressive_web_apps/Tutorials/js13kGames/Re-engageable_Notifications_Push", "Web/Progressive_web_apps/Tutorials/js13kGames")}}

--- a/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/loading/index.md
+++ b/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/loading/index.md
@@ -1,7 +1,6 @@
 ---
 title: 渐进式加载
 slug: Web/Progressive_web_apps/Tutorials/js13kGames/Loading
-original_slug: Web/Progressive_web_apps/Loading
 ---
 
 {{PWASidebar}} {{PreviousMenu("Web/Progressive_web_apps/Tutorials/js13kGames/Re-engageable_Notifications_Push", "Web/Progressive_web_apps/Tutorials/js13kGames")}}

--- a/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/offline_service_workers/index.md
+++ b/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/offline_service_workers/index.md
@@ -1,7 +1,6 @@
 ---
 title: 通过 Service workers 让 PWA 离线工作
 slug: Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers
-original_slug: Web/Progressive_web_apps/Offline_Service_workers
 ---
 
 {{PWASidebar}} {{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/js13kGames/App_structure", "Web/Progressive_web_apps/Tutorials/js13kGames/Installable_PWAs", "Web/Progressive_web_apps/Tutorials/js13kGames")}}

--- a/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/re-engageable_notifications_push/index.md
+++ b/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/re-engageable_notifications_push/index.md
@@ -1,7 +1,6 @@
 ---
 title: 通过通知推送让 PWA 可重用
 slug: Web/Progressive_web_apps/Tutorials/js13kGames/Re-engageable_Notifications_Push
-original_slug: Web/Progressive_web_apps/Re-engageable_Notifications_Push
 ---
 
 {{PWASidebar}} {{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/js13kGames/Installable_PWAs", "Web/Progressive_web_apps/Tutorials/js13kGames/Loading", "Web/Progressive_web_apps/Tutorials/js13kGames")}}

--- a/files/zh-cn/web/security/transport_layer_security/index.md
+++ b/files/zh-cn/web/security/transport_layer_security/index.md
@@ -1,7 +1,6 @@
 ---
 title: 传输层安全协议
 slug: Web/Security/Transport_Layer_Security
-original_slug: Web/Security/传输层安全协议
 ---
 
 使用传输层安全性协议（TLS）进行的任何连接的安全性在很大程度上取决于密码套件和所选的安全性参数。本文的目的是帮助您确保客户端和服务器之间的机密性和完整性通信。Mozilla 运营安全团队（OpSec）维护了 [服务器端 TLS 参考配置的 Wiki 条目](https://wiki.mozilla.org/Security/Server_Side_TLS)。

--- a/files/zh-cn/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/zh-cn/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -1,7 +1,6 @@
 ---
 title: Introduction to using XPath in JavaScript
 slug: Web/XPath/Introduction_to_using_XPath_in_JavaScript
-original_slug: Web/JavaScript/Introduction_to_using_XPath_in_JavaScript
 ---
 
 该篇文档描述了如何在扩展和网站内部通过 JavaScript 调用 [XPath](/zh-CN/XPath) 接口。Mozilla 实现了相当多的 [DOM 3 XPath](http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html)，意味着 Xpath 表达式已经可以在 HTML 和 XML 文档中使用。

--- a/files/zh-cn/web/xslt/element/index.md
+++ b/files/zh-cn/web/xslt/element/index.md
@@ -1,7 +1,6 @@
 ---
 title: Elements
 slug: Web/XSLT/Element
-original_slug: Web/XSLT/Elements
 ---
 
 {{ XsltRef() }} There are two types of elements discussed here: top-level elements and instructions. A top-level element must appear as the child of either `<xsl:stylesheet>` or `<xsl:transform>`. An instruction, on the other hand, is associated with a template. A stylesheet may include several templates. A third type of element, not discussed here, is the literal result element (LRE). An LRE also appears in a template. It consists of any non-instruction element that should be copied as-is to the result document, for example, an `<hr>` element in an HTML conversion stylesheet.

--- a/files/zh-cn/webassembly/javascript_interface/compile/index.md
+++ b/files/zh-cn/webassembly/javascript_interface/compile/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.compile()
 slug: WebAssembly/JavaScript_interface/compile
-original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/compile
 ---
 
 {{WebAssemblySidebar}} {{SeeCompatTable}}

--- a/files/zh-cn/webassembly/javascript_interface/compileerror/index.md
+++ b/files/zh-cn/webassembly/javascript_interface/compileerror/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.CompileError()
 slug: WebAssembly/JavaScript_interface/CompileError
-original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError
 ---
 
 {{WebAssemblySidebar}}

--- a/files/zh-cn/webassembly/javascript_interface/compilestreaming/index.md
+++ b/files/zh-cn/webassembly/javascript_interface/compilestreaming/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.compileStreaming()
 slug: WebAssembly/JavaScript_interface/compileStreaming
-original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/compileStreaming
 ---
 
 {{WebAssemblySidebar}}

--- a/files/zh-cn/webassembly/javascript_interface/global/index.md
+++ b/files/zh-cn/webassembly/javascript_interface/global/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.Global
 slug: WebAssembly/JavaScript_interface/Global
-original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Global
 ---
 
 {{WebAssemblySidebar}}

--- a/files/zh-cn/webassembly/javascript_interface/index.md
+++ b/files/zh-cn/webassembly/javascript_interface/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly
 slug: WebAssembly/JavaScript_interface
-original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly
 ---
 
 {{WebAssemblySidebar}}

--- a/files/zh-cn/webassembly/javascript_interface/instance/index.md
+++ b/files/zh-cn/webassembly/javascript_interface/instance/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.Instance
 slug: WebAssembly/JavaScript_interface/Instance
-original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance
 ---
 
 {{WebAssemblySidebar}} {{SeeCompatTable}}

--- a/files/zh-cn/webassembly/javascript_interface/instantiate/index.md
+++ b/files/zh-cn/webassembly/javascript_interface/instantiate/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.instantiate()
 slug: WebAssembly/JavaScript_interface/instantiate
-original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate
 ---
 
 {{WebAssemblySidebar}}

--- a/files/zh-cn/webassembly/javascript_interface/instantiatestreaming/index.md
+++ b/files/zh-cn/webassembly/javascript_interface/instantiatestreaming/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.instantiateStreaming()
 slug: WebAssembly/JavaScript_interface/instantiateStreaming
-original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
 ---
 
 {{WebAssemblySidebar}}

--- a/files/zh-cn/webassembly/javascript_interface/memory/index.md
+++ b/files/zh-cn/webassembly/javascript_interface/memory/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.Memory()
 slug: WebAssembly/JavaScript_interface/Memory
-original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory
 ---
 
 {{WebAssemblySidebar}}

--- a/files/zh-cn/webassembly/javascript_interface/runtimeerror/index.md
+++ b/files/zh-cn/webassembly/javascript_interface/runtimeerror/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.RuntimeError()
 slug: WebAssembly/JavaScript_interface/RuntimeError
-original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError
 ---
 
 {{WebAssemblySidebar}}

--- a/files/zh-cn/webassembly/javascript_interface/table/index.md
+++ b/files/zh-cn/webassembly/javascript_interface/table/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.Table()
 slug: WebAssembly/JavaScript_interface/Table
-original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table
 ---
 
 {{WebAssemblySidebar}}

--- a/files/zh-cn/webassembly/javascript_interface/validate/index.md
+++ b/files/zh-cn/webassembly/javascript_interface/validate/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.validate()
 slug: WebAssembly/JavaScript_interface/validate
-original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/validate
 ---
 
 {{WebAssemblySidebar}}


### PR DESCRIPTION
This PR uses the front matter linter to lint the front matter keys of the Simplified Chinese locale.  This is the third part.
