### PR TITLE
ko: Format /web/api using Prettier (part 7)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -51,7 +51,6 @@ build/
 /files/ja/web/svg/**/*.md
 
 # ko
-/files/ko/web/api/**/*.md
 /files/ko/web/css/**/*.md
 /files/ko/web/javascript/**/*.md
 

--- a/files/ko/web/api/background_tasks_api/index.md
+++ b/files/ko/web/api/background_tasks_api/index.md
@@ -86,8 +86,7 @@ Background Tasks API 는 단 하나의 새 인터페이스를 추가합니다:
 ```html
 <p>
   Demonstration of using
-  <a
-    href="https://developer.mozilla.org/ko/docs/Web/API/Background_Tasks_API">
+  <a href="https://developer.mozilla.org/ko/docs/Web/API/Background_Tasks_API">
     cooperatively scheduled background tasks</a
   >
   using the <code>requestIdleCallback()</code>


### PR DESCRIPTION
This PR formats the `/web/api` folder of the Korean locale using Prettier.  This is the seventh and final part.
