### PR TITLE
fr: add precision about selecting numeric IDs with QuerySelector

### DIFF
--- a/files/fr/web/api/document/queryselector/index.md
+++ b/files/fr/web/api/document/queryselector/index.md
@@ -40,6 +40,17 @@ Si le sélecteur correspond à un ID et que cet ID est utilisé de façon erron�
 
 Les [pseudo-éléments](/fr/docs/Web/CSS/Pseudo-elements) CSS ne retourneront jamais aucun élément, comme spécifié dans l'[API des sélecteurs](http://www.w3.org/TR/selectors-api/#grammar) (en).
 
+> **Note :** Si le sélecteur correspond à un ID et que cet ID commence par un nombre (0-9), une erreur de syntaxe sera renvoyée.
+```html
+<div id="0123"></div>
+<div id="abcd"></div>
+
+<script>
+  document.querySelector("#0123"); // erreur syntaxe
+  document.querySelector("#abcd"); // correspond au second div
+</script>
+```
+
 ### Échapper des caractères spéciaux
 
 Pour faire correspondre un ID (_identifiant_) ou un sélecteur qui ne respecte pas la syntaxe CSS (en utilisant un point virgule ou un espace par exemple), vous devez échapper le caractère avec un antislash (\\). Comme l'antislash est un caractère d'échappement en JavaScript, si vous entrez une chaîne de caractères littérale, vous devez donc l'échapper _deux fois_ (une pour la chaîne de caractères JavaScript et une autre fois pour `querySelector`)&nbsp;:


### PR DESCRIPTION
### Description

Add a precision about selecting item with id starting by a number

### Motivation

I encountered this issue a few times and only really found a [StackOverflow](https://stackoverflow.com/questions/20306204/using-queryselector-with-ids-that-are-numbers) post about this without proper documentation

### Additional details

- [StackOverflow discussion about this problem](https://stackoverflow.com/questions/20306204/using-queryselector-with-ids-that-are-numbers)
- [W3Docs about HTML5 IDs](https://www.w3docs.com/snippets/html/which-are-the-valid-values-for-the-id-attribute.html#:~:text=In%20HTML5%2C%20the%20id%20attribute,id%20attribute%20is%20case%20sensitive.)
