### PR TITLE
pt-br: Remove "translation_of" front matter key

### DIFF
--- a/files/pt-br/web/css/gap/index.md
+++ b/files/pt-br/web/css/gap/index.md
@@ -1,7 +1,6 @@
 ---
 title: gap
 slug: Web/CSS/gap
-translation_of: Web/CSS/gap
 ---
 
 {{CSSRef}}


### PR DESCRIPTION
This PR removes the `translated_of` front matter key from the single document in the Brazilian Portuguese locale that has it, using a simple regex search and replace, skipping over `conflicting/` and `orphaned/`.

Regex used: `translation_of: (>-\n  )?[\w\d/(),.:;_@<>"'*-]+\n`

Note: this will be self-merged as it is a mechanical change that does not require review of individual changes.
