### PR TITLE
ko: Lint front matter keys

### DIFF
--- a/files/ko/conflicting/web/css/css_paged_media/index.md
+++ b/files/ko/conflicting/web/css/css_paged_media/index.md
@@ -1,7 +1,6 @@
 ---
 title: Paged Media
 slug: conflicting/Web/CSS/CSS_paged_media
-original_slug: Web/CSS/Paged_Media
 ---
 
 인쇄 미디어(paged media) 속성은 인쇄 콘텐츠의 프레젠테이션 또는 콘텐츠를 개별 페이지로 나누는 다른 미디어를 제어합니다. 페이지 나누기 설정, 인쇄 가능 영역 제어, 서로 다른 좌우 페이지 스타일 및 요소 내부 나누기 제어를 할 수 있습니다. 널리 지원되는 속성은 포함합니다

--- a/files/ko/conflicting/web/guide/ajax/index.md
+++ b/files/ko/conflicting/web/guide/ajax/index.md
@@ -1,7 +1,6 @@
 ---
 title: Community
 slug: conflicting/Web/Guide/AJAX
-original_slug: Web/Guide/AJAX/Community
 ---
 
 AJAX와 관련된 유용한 mailing lists, newsgroups, 포럼, 다른 커뮤니티를 원한다면, 링크를 클릭하세요.

--- a/files/ko/conflicting/web/guide/ajax_21419c7dfa67c94789f037a33c4e4e3e/index.md
+++ b/files/ko/conflicting/web/guide/ajax_21419c7dfa67c94789f037a33c4e4e3e/index.md
@@ -1,7 +1,6 @@
 ---
 title: Ajax 시작하기
 slug: conflicting/Web/Guide/AJAX_21419c7dfa67c94789f037a33c4e4e3e
-original_slug: Web/Guide/AJAX/Getting_Started
 ---
 
 > **경고:** **중요**: 해당 문서는 2018/07/31 (원문 : 2018/04/23) 에 마지막으로 번역되었습니다. 원문의 변경이 잦아 내용이 다를 수 있으니 참고하십시오.

--- a/files/ko/conflicting/web/javascript/reference/errors/deprecated_octal/index.md
+++ b/files/ko/conflicting/web/javascript/reference/errors/deprecated_octal/index.md
@@ -1,7 +1,6 @@
 ---
-title: "SyntaxError: \"x\" is not a legal ECMA-262 octal constant"
+title: 'SyntaxError: "x" is not a legal ECMA-262 octal constant'
 slug: conflicting/Web/JavaScript/Reference/Errors/Deprecated_octal
-original_slug: Web/JavaScript/Reference/Errors/Bad_octal
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/ko/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
+++ b/files/ko/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
@@ -1,7 +1,6 @@
 ---
 title: 캔버스 생성과 그리기
-slug: >-
-  Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it
+slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it
 ---
 
 {{GamesSidebar}}

--- a/files/ko/learn/common_questions/design_and_accessibility/html_features_for_accessibility/index.md
+++ b/files/ko/learn/common_questions/design_and_accessibility/html_features_for_accessibility/index.md
@@ -1,7 +1,6 @@
 ---
 title: 어떤 HTML 기능이 접근성을 촉진할까?
-slug: >-
-  Learn/Common_questions/Design_and_accessibility/HTML_features_for_accessibility
+slug: Learn/Common_questions/Design_and_accessibility/HTML_features_for_accessibility
 ---
 
 이번 내용은 웹 페이지를 좀 더 서로 다른 장애를 가진 사람들에게 좀 더 접근하기 쉽게 만들 수 있는 HTML의 특정한 기능을 서술합니다.

--- a/files/ko/learn/common_questions/tools_and_setup/checking_that_your_web_site_is_working_properly/index.md
+++ b/files/ko/learn/common_questions/tools_and_setup/checking_that_your_web_site_is_working_properly/index.md
@@ -1,7 +1,6 @@
 ---
 title: 웹 사이트가 제대로 동작하는지 확인하는 방법
-slug: >-
-  Learn/Common_questions/Tools_and_setup/Checking_that_your_web_site_is_working_properly
+slug: Learn/Common_questions/Tools_and_setup/Checking_that_your_web_site_is_working_properly
 ---
 
 이번에는 웹사이트 동작과 관련한 다양한 문제해결 단계와 그 문제들을 해결하기 위한 방법들을 알아보겠습니다.

--- a/files/ko/learn/performance/why_web_performance/index.md
+++ b/files/ko/learn/performance/why_web_performance/index.md
@@ -1,7 +1,7 @@
 ---
 title: 웹 성능이 중요한 "이유"
 slug: Learn/Performance/why_web_performance
-i10n:
+l10n:
   commitSource: bb026bcb88b7f45374d602301b7b0db5a49ff303
 ---
 

--- a/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
+++ b/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
@@ -1,7 +1,6 @@
 ---
 title: React 시작하기
-slug: >-
-  Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started
+slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started
 ---
 
 <div>{{LearnSidebar}}</div>

--- a/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
+++ b/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
@@ -1,7 +1,6 @@
 ---
 title: React todo list 시작하기
-slug: >-
-  Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_todo_list_beginning
+slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_todo_list_beginning
 ---
 
 {{LearnSidebar}}

--- a/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.md
+++ b/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.md
@@ -1,7 +1,6 @@
 ---
 title: Svelte 시작하기
-slug: >-
-  Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_getting_started
+slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_getting_started
 ---
 
 {{LearnSidebar}}

--- a/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/svelte_todo_list_beginning/index.md
+++ b/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/svelte_todo_list_beginning/index.md
@@ -1,7 +1,6 @@
 ---
 title: Svelte 할 일 목록 앱 시작
-slug: >-
-  Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_Todo_list_beginning
+slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_Todo_list_beginning
 l10n:
   sourceCommit: 4a5ceb89ac004d087669aeee3c26475c2207787f
 ---

--- a/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/svelte_variables_props/index.md
+++ b/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/svelte_variables_props/index.md
@@ -1,8 +1,6 @@
 ---
 title: "Svelte의 동적인 동작: 변수와 props 작용"
-slug: >-
-  Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_variables_props
-
+slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_variables_props
 l10n:
   sourceCommit: 4def230f85756724b59660e3cd9de363db724ef8
 ---

--- a/files/ko/mdn/community/contributing/index.md
+++ b/files/ko/mdn/community/contributing/index.md
@@ -1,7 +1,6 @@
 ---
 title: MDN Web Docs에 기여하기
 slug: MDN/Community/Contributing
-page-type: mdn-community-guide
 ---
 
 {{MDNSidebar}}

--- a/files/ko/orphaned/mozilla/add-ons/webextensions/prerequisites/index.md
+++ b/files/ko/orphaned/mozilla/add-ons/webextensions/prerequisites/index.md
@@ -1,7 +1,6 @@
 ---
 title: Prerequisites
 slug: orphaned/Mozilla/Add-ons/WebExtensions/Prerequisites
-original_slug: Mozilla/Add-ons/WebExtensions/Prerequisites
 ---
 
 {{AddonSidebar}}

--- a/files/ko/orphaned/web/api/proximity_events/index.md
+++ b/files/ko/orphaned/web/api/proximity_events/index.md
@@ -1,7 +1,6 @@
 ---
 title: Proximity Events
 slug: orphaned/Web/API/Proximity_Events
-original_slug: Web/API/Proximity_Events
 ---
 
 {{DefaultAPISidebar("Proximity Events")}}{{Deprecated_Header}}

--- a/files/ko/orphaned/web/html/element/applet/index.md
+++ b/files/ko/orphaned/web/html/element/applet/index.md
@@ -1,7 +1,6 @@
 ---
 title: <applet>
 slug: orphaned/Web/HTML/Element/applet
-original_slug: Web/HTML/Element/applet
 ---
 
 ## 개요

--- a/files/ko/orphaned/web/svg/element/altglyph/index.md
+++ b/files/ko/orphaned/web/svg/element/altglyph/index.md
@@ -1,7 +1,6 @@
 ---
 title: <altGlyph>
 slug: orphaned/Web/SVG/Element/altGlyph
-original_slug: Web/SVG/Element/altGlyph
 ---
 
 {{SVGRef}}{{deprecated_header}}

--- a/files/ko/web/accessibility/aria/attributes/aria-label/index.md
+++ b/files/ko/web/accessibility/aria/attributes/aria-label/index.md
@@ -1,5 +1,5 @@
 ---
-title: "aria-label"
+title: aria-label
 slug: Web/Accessibility/ARIA/Attributes/aria-label
 ---
 

--- a/files/ko/web/css/-moz-image-region/index.md
+++ b/files/ko/web/css/-moz-image-region/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-image-region'
+title: "-moz-image-region"
 slug: Web/CSS/-moz-image-region
 ---
 

--- a/files/ko/web/css/-webkit-line-clamp/index.md
+++ b/files/ko/web/css/-webkit-line-clamp/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-line-clamp'
+title: "-webkit-line-clamp"
 slug: Web/CSS/-webkit-line-clamp
 ---
 

--- a/files/ko/web/css/-webkit-overflow-scrolling/index.md
+++ b/files/ko/web/css/-webkit-overflow-scrolling/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-overflow-scrolling'
+title: "-webkit-overflow-scrolling"
 slug: Web/CSS/-webkit-overflow-scrolling
 ---
 {{CSSRef}} {{Non-standard_header}}

--- a/files/ko/web/css/@charset/index.md
+++ b/files/ko/web/css/@charset/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@charset'
+title: "@charset"
 slug: Web/CSS/@charset
 ---
 {{ CSSRef }}

--- a/files/ko/web/css/@font-face/index.md
+++ b/files/ko/web/css/@font-face/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@font-face'
+title: "@font-face"
 slug: Web/CSS/@font-face
 ---
 {{CSSRef}}

--- a/files/ko/web/css/@import/index.md
+++ b/files/ko/web/css/@import/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@import'
+title: "@import"
 slug: Web/CSS/@import
 ---
 

--- a/files/ko/web/css/@keyframes/index.md
+++ b/files/ko/web/css/@keyframes/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@keyframes'
+title: "@keyframes"
 slug: Web/CSS/@keyframes
 ---
 {{CSSRef}}

--- a/files/ko/web/css/@media/index.md
+++ b/files/ko/web/css/@media/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@media'
+title: "@media"
 slug: Web/CSS/@media
 ---
 

--- a/files/ko/web/css/@namespace/index.md
+++ b/files/ko/web/css/@namespace/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@namespace'
+title: "@namespace"
 slug: Web/CSS/@namespace
 ---
 

--- a/files/ko/web/css/@page/index.md
+++ b/files/ko/web/css/@page/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@page'
+title: "@page"
 slug: Web/CSS/@page
 ---
 {{CSSRef}}

--- a/files/ko/web/css/@supports/index.md
+++ b/files/ko/web/css/@supports/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@supports'
+title: "@supports"
 slug: Web/CSS/@supports
 ---
 

--- a/files/ko/web/css/_colon_active/index.md
+++ b/files/ko/web/css/_colon_active/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':active'
+title: ":active"
 slug: Web/CSS/:active
 ---
 

--- a/files/ko/web/css/_colon_checked/index.md
+++ b/files/ko/web/css/_colon_checked/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':checked'
+title: ":checked"
 slug: Web/CSS/:checked
 ---
 

--- a/files/ko/web/css/_colon_default/index.md
+++ b/files/ko/web/css/_colon_default/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':default'
+title: ":default"
 slug: Web/CSS/:default
 ---
 {{CSSRef}}

--- a/files/ko/web/css/_colon_defined/index.md
+++ b/files/ko/web/css/_colon_defined/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':defined'
+title: ":defined"
 slug: Web/CSS/:defined
 ---
 {{CSSRef}}

--- a/files/ko/web/css/_colon_disabled/index.md
+++ b/files/ko/web/css/_colon_disabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':disabled'
+title: ":disabled"
 slug: Web/CSS/:disabled
 ---
 {{CSSRef}}

--- a/files/ko/web/css/_colon_enabled/index.md
+++ b/files/ko/web/css/_colon_enabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':enabled'
+title: ":enabled"
 slug: Web/CSS/:enabled
 ---
 {{CSSRef}}

--- a/files/ko/web/css/_colon_first-child/index.md
+++ b/files/ko/web/css/_colon_first-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':first-child'
+title: ":first-child"
 slug: Web/CSS/:first-child
 ---
 

--- a/files/ko/web/css/_colon_first-of-type/index.md
+++ b/files/ko/web/css/_colon_first-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':first-of-type'
+title: ":first-of-type"
 slug: Web/CSS/:first-of-type
 ---
 {{CSSRef}}

--- a/files/ko/web/css/_colon_first/index.md
+++ b/files/ko/web/css/_colon_first/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':first'
+title: ":first"
 slug: Web/CSS/:first
 ---
 

--- a/files/ko/web/css/_colon_focus-within/index.md
+++ b/files/ko/web/css/_colon_focus-within/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':focus-within'
+title: ":focus-within"
 slug: Web/CSS/:focus-within
 ---
 {{CSSRef}}

--- a/files/ko/web/css/_colon_focus/index.md
+++ b/files/ko/web/css/_colon_focus/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':focus'
+title: ":focus"
 slug: Web/CSS/:focus
 ---
 

--- a/files/ko/web/css/_colon_fullscreen/index.md
+++ b/files/ko/web/css/_colon_fullscreen/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':fullscreen'
+title: ":fullscreen"
 slug: Web/CSS/:fullscreen
 ---
 {{CSSRef}}

--- a/files/ko/web/css/_colon_hover/index.md
+++ b/files/ko/web/css/_colon_hover/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':hover'
+title: ":hover"
 slug: Web/CSS/:hover
 ---
 

--- a/files/ko/web/css/_colon_link/index.md
+++ b/files/ko/web/css/_colon_link/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':link'
+title: ":link"
 slug: Web/CSS/:link
 ---
 

--- a/files/ko/web/css/_colon_not/index.md
+++ b/files/ko/web/css/_colon_not/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':not()'
+title: ":not()"
 slug: Web/CSS/:not
 ---
 {{ CSSRef() }}

--- a/files/ko/web/css/_colon_nth-child/index.md
+++ b/files/ko/web/css/_colon_nth-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-child'
+title: ":nth-child"
 slug: Web/CSS/:nth-child
 ---
 {{CSSRef}}

--- a/files/ko/web/css/_colon_root/index.md
+++ b/files/ko/web/css/_colon_root/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':root'
+title: ":root"
 slug: Web/CSS/:root
 ---
 {{CSSRef}}

--- a/files/ko/web/css/_colon_visited/index.md
+++ b/files/ko/web/css/_colon_visited/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':visited'
+title: ":visited"
 slug: Web/CSS/:visited
 ---
 {{ CSSRef }}

--- a/files/ko/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/ko/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-scrollbar'
+title: "::-webkit-scrollbar"
 slug: Web/CSS/::-webkit-scrollbar
 ---
 {{CSSRef}}{{Non-standard_Header}}

--- a/files/ko/web/css/_doublecolon_after/index.md
+++ b/files/ko/web/css/_doublecolon_after/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::after (:after)'
+title: "::after (:after)"
 slug: Web/CSS/::after
 ---
 

--- a/files/ko/web/css/_doublecolon_before/index.md
+++ b/files/ko/web/css/_doublecolon_before/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::before (:before)'
+title: "::before (:before)"
 slug: Web/CSS/::before
 ---
 {{CSSRef}}

--- a/files/ko/web/css/_doublecolon_placeholder/index.md
+++ b/files/ko/web/css/_doublecolon_placeholder/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::placeholder'
+title: "::placeholder"
 slug: Web/CSS/::placeholder
 ---
 

--- a/files/ko/web/css/at-rule/index.md
+++ b/files/ko/web/css/at-rule/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@-규칙'
+title: "@-규칙"
 slug: Web/CSS/At-rule
 ---
 

--- a/files/ko/web/css/index.md
+++ b/files/ko/web/css/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'CSS: Cascading Style Sheets'
+title: "CSS: Cascading Style Sheets"
 slug: Web/CSS
 ---
 

--- a/files/ko/web/css/justify-content/index.md
+++ b/files/ko/web/css/justify-content/index.md
@@ -2,7 +2,7 @@
 title: justify-content
 slug: Web/CSS/justify-content
 l10n:
-  sourceCommit: 73091fbe590d96857d743eaeec5aee4a8101994f 
+  sourceCommit: 73091fbe590d96857d743eaeec5aee4a8101994f
 ---
 
 {{CSSRef}}

--- a/files/ko/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/ko/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTML5 영상에 캡션과 자막 붙이기
-slug: >-
-  Web/Guide/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video
+slug: Web/Guide/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video
 ---
 
 우리는 다른 글에서 {{ domxref("HTMLMediaElement") }}과(와) {{ domxref("Window.fullScreen") }} API를 활용하여 [다양한 브라우저에서 호환되는 영상 플레이어를 제작하는 방법](/en-US/Apps/Build/Manipulating_media/cross_browser_video_player)과 [플레이어에 스타일을 적용하는 방법](/en-US/Apps/Build/Manipulating_media/Video_player_styling_basics)을 살펴보았습니다. 이번 글에서는 위에서 제작했던 플레이어를 활용하여 {{ domxref("Web_Video_Text_Tracks_Format","WebVTT 포맷 파일") }}과(와) {{ htmlelement("track") }} 엘리먼트를 이용해 캡션과 자막을 붙이는 방법을 살펴보려고 합니다.

--- a/files/ko/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
+++ b/files/ko/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
@@ -1,7 +1,6 @@
 ---
 title: "Reason: CORS header 'Access-Control-Allow-Origin' does not match 'xyz'"
 slug: Web/HTTP/CORS/Errors/CORSAllowOriginNotMatchingOrigin
-page-type: http-cors-error
 ---
 
 {{HTTPSidebar}}

--- a/files/ko/web/http/cors/errors/corsnotsupportingcredentials/index.md
+++ b/files/ko/web/http/cors/errors/corsnotsupportingcredentials/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  Reason: Credential is not supported if the CORS header
-  'Access-Control-Allow-Origin' is '*'
+title: "Reason: Credential is not supported if the CORS header 'Access-Control-Allow-Origin' is '*'"
 slug: Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
 ---
 

--- a/files/ko/web/javascript/reference/errors/bad_radix/index.md
+++ b/files/ko/web/javascript/reference/errors/bad_radix/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'RangeError: radix must be an integer'
+title: "RangeError: radix must be an integer"
 slug: Web/JavaScript/Reference/Errors/Bad_radix
 ---
 

--- a/files/ko/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
+++ b/files/ko/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ReferenceError: can''t access lexical declaration`X'' before initialization'
+title: "ReferenceError: can't access lexical declaration`X' before initialization"
 slug: Web/JavaScript/Reference/Errors/Cant_access_lexical_declaration_before_init
 ---
 

--- a/files/ko/web/javascript/reference/errors/delete_in_strict_mode/index.md
+++ b/files/ko/web/javascript/reference/errors/delete_in_strict_mode/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  SyntaxError: applying the 'delete' operator to an unqualified name is
-  deprecated
+title: "SyntaxError: applying the 'delete' operator to an unqualified name is deprecated"
 slug: Web/JavaScript/Reference/Errors/Delete_in_strict_mode
 ---
 

--- a/files/ko/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
+++ b/files/ko/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ReferenceError: deprecated caller or arguments usage'
+title: "ReferenceError: deprecated caller or arguments usage"
 slug: Web/JavaScript/Reference/Errors/Deprecated_caller_or_arguments_usage
 ---
 

--- a/files/ko/web/javascript/reference/errors/identifier_after_number/index.md
+++ b/files/ko/web/javascript/reference/errors/identifier_after_number/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: identifier starts immediately after numeric literal'
+title: "SyntaxError: identifier starts immediately after numeric literal"
 slug: Web/JavaScript/Reference/Errors/Identifier_after_number
 ---
 

--- a/files/ko/web/javascript/reference/errors/illegal_character/index.md
+++ b/files/ko/web/javascript/reference/errors/illegal_character/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: illegal character'
+title: "SyntaxError: illegal character"
 slug: Web/JavaScript/Reference/Errors/Illegal_character
 ---
 

--- a/files/ko/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/ko/web/javascript/reference/errors/invalid_array_length/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'RangeError: invalid array length'
+title: "RangeError: invalid array length"
 slug: Web/JavaScript/Reference/Errors/Invalid_array_length
 ---
 

--- a/files/ko/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
+++ b/files/ko/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ReferenceError: invalid assignment left-hand side'
+title: "ReferenceError: invalid assignment left-hand side"
 slug: Web/JavaScript/Reference/Errors/Invalid_assignment_left-hand_side
 ---
 

--- a/files/ko/web/javascript/reference/errors/invalid_date/index.md
+++ b/files/ko/web/javascript/reference/errors/invalid_date/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'RangeError: invalid date'
+title: "RangeError: invalid date"
 slug: Web/JavaScript/Reference/Errors/Invalid_date
 ---
 

--- a/files/ko/web/javascript/reference/errors/invalid_for-in_initializer/index.md
+++ b/files/ko/web/javascript/reference/errors/invalid_for-in_initializer/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: for-in loop head declarations may not have initializers'
+title: "SyntaxError: for-in loop head declarations may not have initializers"
 slug: Web/JavaScript/Reference/Errors/Invalid_for-in_initializer
 ---
 

--- a/files/ko/web/javascript/reference/errors/invalid_for-of_initializer/index.md
+++ b/files/ko/web/javascript/reference/errors/invalid_for-of_initializer/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  SyntaxError: a declaration in the head of a for-of loop can't have an
-  initializer
+title: "SyntaxError: a declaration in the head of a for-of loop can't have an initializer"
 slug: Web/JavaScript/Reference/Errors/Invalid_for-of_initializer
 ---
 

--- a/files/ko/web/javascript/reference/errors/is_not_iterable/index.md
+++ b/files/ko/web/javascript/reference/errors/is_not_iterable/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'TypeError: ''x'' is not iterable'
+title: "TypeError: 'x' is not iterable"
 slug: Web/JavaScript/Reference/Errors/is_not_iterable
 ---
 

--- a/files/ko/web/javascript/reference/errors/json_bad_parse/index.md
+++ b/files/ko/web/javascript/reference/errors/json_bad_parse/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: JSON.parse: bad parsing'
+title: "SyntaxError: JSON.parse: bad parsing"
 slug: Web/JavaScript/Reference/Errors/JSON_bad_parse
 ---
 

--- a/files/ko/web/javascript/reference/errors/missing_bracket_after_list/index.md
+++ b/files/ko/web/javascript/reference/errors/missing_bracket_after_list/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing ] after element list'
+title: "SyntaxError: missing ] after element list"
 slug: Web/JavaScript/Reference/Errors/Missing_bracket_after_list
 ---
 

--- a/files/ko/web/javascript/reference/errors/missing_colon_after_property_id/index.md
+++ b/files/ko/web/javascript/reference/errors/missing_colon_after_property_id/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing : after property id'
+title: "SyntaxError: missing : after property id"
 slug: Web/JavaScript/Reference/Errors/Missing_colon_after_property_id
 ---
 

--- a/files/ko/web/javascript/reference/errors/missing_curly_after_property_list/index.md
+++ b/files/ko/web/javascript/reference/errors/missing_curly_after_property_list/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing } after property list'
+title: "SyntaxError: missing } after property list"
 slug: Web/JavaScript/Reference/Errors/Missing_curly_after_property_list
 ---
 

--- a/files/ko/web/javascript/reference/errors/missing_initializer_in_const/index.md
+++ b/files/ko/web/javascript/reference/errors/missing_initializer_in_const/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing = in const declaration'
+title: "SyntaxError: missing = in const declaration"
 slug: Web/JavaScript/Reference/Errors/Missing_initializer_in_const
 ---
 

--- a/files/ko/web/javascript/reference/errors/missing_name_after_dot_operator/index.md
+++ b/files/ko/web/javascript/reference/errors/missing_name_after_dot_operator/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing name after . operator'
+title: "SyntaxError: missing name after . operator"
 slug: Web/JavaScript/Reference/Errors/Missing_name_after_dot_operator
 ---
 

--- a/files/ko/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
+++ b/files/ko/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing ) after argument list'
+title: "SyntaxError: missing ) after argument list"
 slug: Web/JavaScript/Reference/Errors/Missing_parenthesis_after_argument_list
 ---
 

--- a/files/ko/web/javascript/reference/errors/missing_parenthesis_after_condition/index.md
+++ b/files/ko/web/javascript/reference/errors/missing_parenthesis_after_condition/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing ) after condition'
+title: "SyntaxError: missing ) after condition"
 slug: Web/JavaScript/Reference/Errors/Missing_parenthesis_after_condition
 ---
 

--- a/files/ko/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
+++ b/files/ko/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing ; before statement'
+title: "SyntaxError: missing ; before statement"
 slug: Web/JavaScript/Reference/Errors/Missing_semicolon_before_statement
 ---
 

--- a/files/ko/web/javascript/reference/errors/more_arguments_needed/index.md
+++ b/files/ko/web/javascript/reference/errors/more_arguments_needed/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'TypeError: More arguments needed'
+title: "TypeError: More arguments needed"
 slug: Web/JavaScript/Reference/Errors/More_arguments_needed
 ---
 

--- a/files/ko/web/javascript/reference/errors/negative_repetition_count/index.md
+++ b/files/ko/web/javascript/reference/errors/negative_repetition_count/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'RangeError: repeat count must be non-negative'
+title: "RangeError: repeat count must be non-negative"
 slug: Web/JavaScript/Reference/Errors/Negative_repetition_count
 ---
 

--- a/files/ko/web/javascript/reference/errors/no_variable_name/index.md
+++ b/files/ko/web/javascript/reference/errors/no_variable_name/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing variable name'
+title: "SyntaxError: missing variable name"
 slug: Web/JavaScript/Reference/Errors/No_variable_name
 ---
 

--- a/files/ko/web/javascript/reference/errors/precision_range/index.md
+++ b/files/ko/web/javascript/reference/errors/precision_range/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'RangeError: precision is out of range'
+title: "RangeError: precision is out of range"
 slug: Web/JavaScript/Reference/Errors/Precision_range
 ---
 

--- a/files/ko/web/javascript/reference/errors/reduce_of_empty_array_with_no_initial_value/index.md
+++ b/files/ko/web/javascript/reference/errors/reduce_of_empty_array_with_no_initial_value/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'TypeError: Reduce of empty array with no initial value'
+title: "TypeError: Reduce of empty array with no initial value"
 slug: Web/JavaScript/Reference/Errors/Reduce_of_empty_array_with_no_initial_value
 ---
 

--- a/files/ko/web/javascript/reference/errors/resulting_string_too_large/index.md
+++ b/files/ko/web/javascript/reference/errors/resulting_string_too_large/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'RangeError: repeat count must be less than infinity'
+title: "RangeError: repeat count must be less than infinity"
 slug: Web/JavaScript/Reference/Errors/Resulting_string_too_large
 ---
 

--- a/files/ko/web/javascript/reference/errors/too_much_recursion/index.md
+++ b/files/ko/web/javascript/reference/errors/too_much_recursion/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'InternalError: too much recursion'
+title: "InternalError: too much recursion"
 slug: Web/JavaScript/Reference/Errors/Too_much_recursion
 ---
 

--- a/files/ko/web/javascript/reference/errors/unexpected_token/index.md
+++ b/files/ko/web/javascript/reference/errors/unexpected_token/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: Unexpected token'
+title: "SyntaxError: Unexpected token"
 slug: Web/JavaScript/Reference/Errors/Unexpected_token
 ---
 

--- a/files/ko/web/javascript/reference/errors/unnamed_function_statement/index.md
+++ b/files/ko/web/javascript/reference/errors/unnamed_function_statement/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: function statement requires a name'
+title: "SyntaxError: function statement requires a name"
 slug: Web/JavaScript/Reference/Errors/Unnamed_function_statement
 ---
 

--- a/files/ko/web/javascript/reference/operators/addition/index.md
+++ b/files/ko/web/javascript/reference/operators/addition/index.md
@@ -2,7 +2,7 @@
 title: 더하기 (+)
 slug: Web/JavaScript/Reference/Operators/Addition
 l10n:
-  sourceCommit:93d2d79c1c68af93f2730d27cdea9d527eee0d7a
+  sourceCommit: 93d2d79c1c68af93f2730d27cdea9d527eee0d7a
 ---
 
 {{jsSidebar("Operators")}}

--- a/files/ko/web/javascript/reference/operators/equality/index.md
+++ b/files/ko/web/javascript/reference/operators/equality/index.md
@@ -2,7 +2,7 @@
 title: 동등 연산자(==)
 slug: Web/JavaScript/Reference/Operators/Equality
 l10n:
-  sourceCommit:3e2369d97e2d6fbfe33a3c496a8edd90e0b539e2
+  sourceCommit: 3e2369d97e2d6fbfe33a3c496a8edd90e0b539e2
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ko/web/javascript/reference/operators/null/index.md
+++ b/files/ko/web/javascript/reference/operators/null/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'null'
+title: "null"
 slug: Web/JavaScript/Reference/Operators/null
 ---
 


### PR DESCRIPTION
This PR lints and fixes the front matter keys throughout the Korean locale using the front matter linter, followed by manual fixes as needed.

Note: the build errors may be ignored as they are not related to the changes made in this PR.

Note: this will be self-merged as it involves infrastructure and linting that should not require locale-specific review.