### PR TITLE
ja/ko: Fix l10n front matter keys

### DIFF
--- a/files/ja/mdn/at_ten/history_of_mdn/index.md
+++ b/files/ja/mdn/at_ten/history_of_mdn/index.md
@@ -1,7 +1,7 @@
 ---
 title: MDN のあゆみ
 slug: MDN/At_ten/History_of_MDN
-i10n:
+l10n:
   sourceCommit: 356b0655db61fafedd864b54d39e04529b52fff4
 ---
 

--- a/files/ja/mdn/at_ten/index.md
+++ b/files/ja/mdn/at_ten/index.md
@@ -1,7 +1,7 @@
 ---
 title: MDN は 10 周年を迎えました
 slug: MDN/At_ten
-i10n:
+l10n:
   sourceCommit: aa66311219951396e7305df61eb31831360d2c79
 ---
 

--- a/files/ja/mdn/community/contributing/getting_started/index.md
+++ b/files/ja/mdn/community/contributing/getting_started/index.md
@@ -1,7 +1,7 @@
 ---
 title: MDN を始めよう
 slug: MDN/Community/Contributing/Getting_started
-i10n:
+l10n:
   sourceCommit: e7981a5962663764c953ef509d7a8f2d0f934885
 ---
 

--- a/files/ja/mdn/community/contributing/index.md
+++ b/files/ja/mdn/community/contributing/index.md
@@ -1,7 +1,7 @@
 ---
 title: MDN Web Docs への協力
 slug: MDN/Community/Contributing
-i10n:
+l10n:
   sourceCommit: e7981a5962663764c953ef509d7a8f2d0f934885
 ---
 

--- a/files/ja/mdn/community/contributing/our_repositories/index.md
+++ b/files/ja/mdn/community/contributing/our_repositories/index.md
@@ -1,7 +1,7 @@
 ---
 title: MDN Web Docs のリポジトリー
 slug: MDN/Community/Contributing/Our_repositories
-i10n:
+l10n:
   sourceCommit: db5093f0ffaecdf744b086751a56fc1ad591b00a
 ---
 

--- a/files/ja/mdn/community/discussions/index.md
+++ b/files/ja/mdn/community/discussions/index.md
@@ -1,7 +1,7 @@
 ---
 title: コミュニティのディスカッション
 slug: MDN/Community/Discussions
-i10n:
+l10n:
   sourceCommit: e7981a5962663764c953ef509d7a8f2d0f934885
 ---
 

--- a/files/ja/mdn/community/index.md
+++ b/files/ja/mdn/community/index.md
@@ -1,7 +1,7 @@
 ---
 title: コミュニティガイドライン
 slug: MDN/Community
-i10n:
+l10n:
   sourceCommit: 6d83d1a87aa6480f4ef5aae29ee50cfe6a8d47a2
 ---
 

--- a/files/ja/mdn/community/learn_forum/index.md
+++ b/files/ja/mdn/community/learn_forum/index.md
@@ -1,7 +1,7 @@
 ---
 title: 学習フォーラム
 slug: MDN/Community/Learn_forum
-i10n:
+l10n:
   sourceCommit: 4c6b993ad0d43bc679688a3488e13a4ec0b2c3ec
 ---
 

--- a/files/ja/mdn/community/mdn_content/index.md
+++ b/files/ja/mdn/community/mdn_content/index.md
@@ -1,7 +1,7 @@
 ---
 title: MDN コンテンツのバグ修正
 slug: MDN/Community/MDN_content
-i10n:
+l10n:
   sourceCommit: 4c6b993ad0d43bc679688a3488e13a4ec0b2c3ec
 ---
 

--- a/files/ja/mdn/community/mdn_content/pull_requests/index.md
+++ b/files/ja/mdn/community/mdn_content/pull_requests/index.md
@@ -1,7 +1,7 @@
 ---
 title: MDN Web Docs におけるプルリクエストのエチケットとプロセス
 slug: MDN/Community/MDN_content/Pull_requests
-i10n:
+l10n:
   sourceCommit: 6d83d1a87aa6480f4ef5aae29ee50cfe6a8d47a2
 ---
 

--- a/files/ja/mdn/community/open_source_etiquette/index.md
+++ b/files/ja/mdn/community/open_source_etiquette/index.md
@@ -1,7 +1,7 @@
 ---
 title: オープンソースのエチケット
 slug: MDN/Community/Open_source_etiquette
-i10n:
+l10n:
   sourceCommit: e7981a5962663764c953ef509d7a8f2d0f934885
 ---
 

--- a/files/ja/mdn/index.md
+++ b/files/ja/mdn/index.md
@@ -1,8 +1,8 @@
 ---
 title: MDN Web Docs プロジェクト
 slug: MDN
-i10n:
-  commitSource: 8dbe0b2acd7fdbf533a9bd2f517999cc2035d952
+l10n:
+  sourceCommit: 8dbe0b2acd7fdbf533a9bd2f517999cc2035d952
 ---
 
 {{MDNSidebar}}

--- a/files/ja/web/api/console/profileend/index.md
+++ b/files/ja/web/api/console/profileend/index.md
@@ -1,7 +1,7 @@
 ---
 title: console.profileEnd()
 slug: Web/API/console/profileEnd
-i10n:
+l10n:
   sourceCommit: 6c498a447fb5e776a67af7f9801a3aa407fc4d1c
 ---
 

--- a/files/ja/web/api/console/trace/index.md
+++ b/files/ja/web/api/console/trace/index.md
@@ -1,7 +1,7 @@
 ---
 title: console.trace()
 slug: Web/API/console/trace
-i10n:
+l10n:
   sourceCommit: 71aac3e50b8bc5afea791d69d232dab98e1c5c0d
 ---
 

--- a/files/ja/web/api/console/warn/index.md
+++ b/files/ja/web/api/console/warn/index.md
@@ -1,7 +1,7 @@
 ---
 title: console.warn()
 slug: Web/API/console/warn
-i10n:
+l10n:
   sourceCommit: d19d68bf6078c23d527b6e1355925795e745d124
 ---
 

--- a/files/ja/webassembly/exported_functions/index.md
+++ b/files/ja/webassembly/exported_functions/index.md
@@ -1,7 +1,7 @@
 ---
 title: エクスポートされた WebAssembly 関数
 slug: WebAssembly/Exported_functions
-i10n:
+l10n:
   sourceCommit: 0bb1a8c4e18c5068319e888bbf18c3599adb8324
 ---
 

--- a/files/ja/webassembly/loading_and_running/index.md
+++ b/files/ja/webassembly/loading_and_running/index.md
@@ -1,7 +1,7 @@
 ---
 title: WebAssembly コードの読み込みと実行
 slug: WebAssembly/Loading_and_running
-i10n:
+l10n:
   sourceCommit: 1ef12f2e0815d0d285d6027219c987a3e4e228a3
 ---
 

--- a/files/ja/webassembly/using_the_javascript_api/index.md
+++ b/files/ja/webassembly/using_the_javascript_api/index.md
@@ -1,7 +1,7 @@
 ---
 title: WebAssembly JavaScript API の使用
 slug: WebAssembly/Using_the_JavaScript_API
-i10n:
+l10n:
   sourceCommit: 754a5590dd7d8d1e231ed0443a5a3feacc9ad4c0
 ---
 

--- a/files/ko/learn/performance/why_web_performance/index.md
+++ b/files/ko/learn/performance/why_web_performance/index.md
@@ -1,8 +1,8 @@
 ---
 title: 웹 성능이 중요한 "이유"
 slug: Learn/Performance/why_web_performance
-i10n:
-  commitSource: bb026bcb88b7f45374d602301b7b0db5a49ff303
+l10n:
+  sourceCommit: bb026bcb88b7f45374d602301b7b0db5a49ff303
 ---
 
 {{LearnSidebar}}{{NextMenu("Learn/Performance/What_is_web_performance", "Learn/Performance")}}


### PR DESCRIPTION
This PR fixes the `l10n` front matter keys in the Japanese and Korean locales.  They were accidentally using `i10n` instead of `l10n`.

This will be self-merged as it involves front matter keys and infrastructure.
