### PR TITLE
fr: Lint front matter keys

### DIFF
--- a/files/fr/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
+++ b/files/fr/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
@@ -1,7 +1,6 @@
 ---
 title: Créer l'élément Canvas et l'afficher
-slug: >-
-  Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it
+slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it
 ---
 
 {{GamesSidebar}}

--- a/files/fr/learn/accessibility/css_and_javascript/test_your_skills_colon__css_and_javascript_accessibility/index.md
+++ b/files/fr/learn/accessibility/css_and_javascript/test_your_skills_colon__css_and_javascript_accessibility/index.md
@@ -1,7 +1,6 @@
 ---
 title: "Testez vos compétences : l'accessibilité en CSS et JavaScript"
-slug: >-
-  Learn/Accessibility/CSS_and_JavaScript/Test_your_skills:_CSS_and_JavaScript_accessibility
+slug: Learn/Accessibility/CSS_and_JavaScript/Test_your_skills:_CSS_and_JavaScript_accessibility
 ---
 
 {{LearnSidebar}}

--- a/files/fr/learn/common_questions/tools_and_setup/checking_that_your_web_site_is_working_properly/index.md
+++ b/files/fr/learn/common_questions/tools_and_setup/checking_that_your_web_site_is_working_properly/index.md
@@ -1,7 +1,6 @@
 ---
 title: Tester le bon fonctionnement de votre site web
-slug: >-
-  Learn/Common_questions/Tools_and_setup/Checking_that_your_web_site_is_working_properly
+slug: Learn/Common_questions/Tools_and_setup/Checking_that_your_web_site_is_working_properly
 ---
 
 Dans cet article, nous présenterons les différentes étapes permettant de diagnostiquer les problèmes d'un site web ainsi que les mesures à prendre pour corriger certains de ces problèmes.

--- a/files/fr/learn/common_questions/web_mechanics/pages_sites_servers_and_search_engines/index.md
+++ b/files/fr/learn/common_questions/web_mechanics/pages_sites_servers_and_search_engines/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  Quelle différence entre une page web, un site web, un serveur web et un moteur
-  de recherche ?
+title: Quelle différence entre une page web, un site web, un serveur web et un moteur de recherche ?
 slug: Learn/Common_questions/Web_mechanics/Pages_sites_servers_and_search_engines
 ---
 

--- a/files/fr/learn/html/tables/structuring_planet_data/index.md
+++ b/files/fr/learn/html/tables/structuring_planet_data/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Structurer les données des planètes"
+title: Structurer les données des planètes
 slug: Learn/HTML/Tables/Structuring_planet_data
 ---
 

--- a/files/fr/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
+++ b/files/fr/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
@@ -1,7 +1,6 @@
 ---
 title: Démarrer avec React
-slug: >-
-  Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started
+slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Main_features","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_todo_list_beginning", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}

--- a/files/fr/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
@@ -1,7 +1,6 @@
 ---
 title: contentScripts.RegisteredContentScript.unregister()
-slug: >-
-  Mozilla/Add-ons/WebExtensions/API/contentScripts/RegisteredContentScript/unregister
+slug: Mozilla/Add-ons/WebExtensions/API/contentScripts/RegisteredContentScript/unregister
 ---
 
 {{AddonSidebar()}}Annule l'inscription des scripts de contenu représentés par cet objet `RegisteredContentScript`.

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
@@ -1,7 +1,6 @@
 ---
 title: devtools.panels.ElementsPanel.createSidebarPane()
-slug: >-
-  Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel/createSidebarPane
+slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel/createSidebarPane
 ---
 
 {{AddonSidebar()}}

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
@@ -1,7 +1,6 @@
 ---
 title: onSelectionChanged
-slug: >-
-  Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel/onSelectionChanged
+slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel/onSelectionChanged
 ---
 
 {{AddonSidebar()}}

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
@@ -1,7 +1,6 @@
 ---
 title: devtools.panels.ExtensionSidebarPane.onHidden
-slug: >-
-  Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/onHidden
+slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/onHidden
 ---
 
 {{AddonSidebar()}}

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
@@ -1,7 +1,6 @@
 ---
 title: devtools.panels.ElementsPanel.setExpression()
-slug: >-
-  Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setExpression
+slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setExpression
 ---
 
 {{AddonSidebar()}}

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
@@ -1,7 +1,6 @@
 ---
 title: devtools.panels.ExtensionSidebarPane.setObject()
-slug: >-
-  Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setObject
+slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setObject
 ---
 
 {{AddonSidebar()}}

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.md
@@ -1,7 +1,6 @@
 ---
 title: webRequest.MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES
-slug: >-
-  Mozilla/Add-ons/WebExtensions/API/webRequest/MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES
+slug: Mozilla/Add-ons/WebExtensions/API/webRequest/MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES
 ---
 
 {{AddonSidebar}}

--- a/files/fr/web/api/devicemotioneventrotationrate/alpha/index.md
+++ b/files/fr/web/api/devicemotioneventrotationrate/alpha/index.md
@@ -1,7 +1,6 @@
 ---
 title: DeviceRotationRate.alpha
 slug: Web/API/DeviceMotionEventRotationRate/alpha
-translation_of_original: Web/API/DeviceRotationRate/alpha
 ---
 
 {{ ApiRef("Device Orientation Events") }}

--- a/files/fr/web/api/devicemotioneventrotationrate/beta/index.md
+++ b/files/fr/web/api/devicemotioneventrotationrate/beta/index.md
@@ -1,7 +1,6 @@
 ---
 title: DeviceRotationRate.beta
 slug: Web/API/DeviceMotionEventRotationRate/beta
-translation_of_original: Web/API/DeviceRotationRate/beta
 ---
 
 {{ ApiRef("Device Orientation Events") }}

--- a/files/fr/web/api/devicemotioneventrotationrate/gamma/index.md
+++ b/files/fr/web/api/devicemotioneventrotationrate/gamma/index.md
@@ -1,7 +1,6 @@
 ---
 title: DeviceRotationRate.gamma
 slug: Web/API/DeviceMotionEventRotationRate/gamma
-translation_of_original: Web/API/DeviceRotationRate/gamma
 ---
 
 {{ ApiRef("Device Orientation Events") }}

--- a/files/fr/web/api/devicemotioneventrotationrate/index.md
+++ b/files/fr/web/api/devicemotioneventrotationrate/index.md
@@ -1,7 +1,6 @@
 ---
 title: DeviceRotationRate
 slug: Web/API/DeviceMotionEventRotationRate
-translation_of_original: Web/API/DeviceRotationRate
 ---
 
 {{ ApiRef("Device Orientation Events") }} {{SeeCompatTable}}

--- a/files/fr/web/api/document/activeelement/index.md
+++ b/files/fr/web/api/document/activeelement/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.activeElement
 slug: Web/API/Document/activeElement
-translation_of_original: Web/API/Document/activeElement
 ---
 
 {{APIRef("Shadow DOM")}}

--- a/files/fr/web/api/document/elementfrompoint/index.md
+++ b/files/fr/web/api/document/elementfrompoint/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.elementFromPoint()
 slug: Web/API/Document/elementFromPoint
-translation_of_original: Web/API/Document/elementFromPoint
 ---
 
 {{APIRef("DOM")}}

--- a/files/fr/web/api/document/getselection/index.md
+++ b/files/fr/web/api/document/getselection/index.md
@@ -1,7 +1,6 @@
 ---
 title: document.getSelection
 slug: Web/API/Document/getSelection
-translation_of_original: Web/API/Document/getSelection
 ---
 
 {{APIRef("DOM")}}

--- a/files/fr/web/api/document/stylesheets/index.md
+++ b/files/fr/web/api/document/stylesheets/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.styleSheets
 slug: Web/API/Document/styleSheets
-translation_of_original: Web/API/Document/styleSheets
 ---
 
 {{APIRef}}

--- a/files/fr/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
+++ b/files/fr/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
@@ -1,7 +1,6 @@
 ---
 title: Explorer un tableau HTML avec des interfaces DOM et JavaScript
-slug: >-
-  Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces
+slug: Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces
 ---
 
 ## Introduction

--- a/files/fr/web/api/dommatrix/index.md
+++ b/files/fr/web/api/dommatrix/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSSMatrix
 slug: Web/API/DOMMatrix
-translation_of_original: Web/API/CSSMatrix
 ---
 
 {{APIRef("CSSOM")}}{{Non-standard_header}}

--- a/files/fr/web/api/htmlelement/accesskey/index.md
+++ b/files/fr/web/api/htmlelement/accesskey/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.accessKey
 slug: Web/API/HTMLElement/accessKey
-translation_of_original: Web/API/Element/accessKey
 ---
 
 {{APIRef("DOM")}}

--- a/files/fr/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/fr/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -1,7 +1,6 @@
 ---
 title: L’essentiel du WebRTC
 slug: Web/API/WebRTC_API/Signaling_and_video_calling
-translation_of_original: Web/API/WebRTC_API/WebRTC_basics
 ---
 
 Maintenant que vous comprenez l'[architecture WebRTC](/fr/docs/Web/Guide/API/WebRTC/WebRTC_architecture), vous pouvez passer à cet article, qui vous emmène à travers la création d'une application RTC multi-navigateurs.A la fin de cet article vous devriez pouvoir créer un canal de données et de médias pair à pair qui fonctionne

--- a/files/fr/web/api/window/resize_event/index.md
+++ b/files/fr/web/api/window/resize_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onresize
 slug: Web/API/Window/resize_event
-translation_of_original: Web/API/Element.onresize
 ---
 
 {{ApiRef}}

--- a/files/fr/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_axis/index.md
+++ b/files/fr/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_axis/index.md
@@ -1,7 +1,6 @@
 ---
 title: Contrôler les proportions des boîtes flexibles le long de l'axe principal
-slug: >-
-  Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the_main_axis
+slug: Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the_main_axis
 ---
 
 {{CSSRef}}

--- a/files/fr/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
+++ b/files/fr/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
@@ -1,7 +1,6 @@
 ---
 title: Les liens entre flexbox et les autres méthodes de disposition
-slug: >-
-  Web/CSS/CSS_flexible_box_layout/Relationship_of_flexbox_to_other_layout_methods
+slug: Web/CSS/CSS_flexible_box_layout/Relationship_of_flexbox_to_other_layout_methods
 ---
 
 {{CSSRef}}

--- a/files/fr/web/css/css_logical_properties_and_values/basic_concepts_of_logical_properties_and_values/index.md
+++ b/files/fr/web/css/css_logical_properties_and_values/basic_concepts_of_logical_properties_and_values/index.md
@@ -1,7 +1,6 @@
 ---
 title: Concepts de base des propriétés et valeurs logiques
-slug: >-
-  Web/CSS/CSS_logical_properties_and_values/Basic_concepts_of_logical_properties_and_values
+slug: Web/CSS/CSS_logical_properties_and_values/Basic_concepts_of_logical_properties_and_values
 ---
 
 {{CSSRef}}

--- a/files/fr/web/css/margin/index.md
+++ b/files/fr/web/css/margin/index.md
@@ -1,7 +1,6 @@
 ---
 title: margin
 slug: Web/CSS/margin
-translation_of_original: Web/CSS/margin-new
 ---
 
 {{CSSRef}}

--- a/files/fr/web/html/element/frame/index.md
+++ b/files/fr/web/html/element/frame/index.md
@@ -1,5 +1,5 @@
 ---
-title: "<frame>"
+title: <frame>
 slug: Web/HTML/Element/frame
 ---
 

--- a/files/fr/web/html/viewport_meta_tag/index.md
+++ b/files/fr/web/html/viewport_meta_tag/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  Utilisation de la balise meta viewport pour contrôler la mise en page sur
-  mobile
+title: Utilisation de la balise meta viewport pour contrôler la mise en page sur mobile
 slug: Web/HTML/Viewport_meta_tag
 ---
 

--- a/files/fr/web/javascript/reference/errors/delete_in_strict_mode/index.md
+++ b/files/fr/web/javascript/reference/errors/delete_in_strict_mode/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  SyntaxError: applying the 'delete' operator to an unqualified name is
-  deprecated
+title: "SyntaxError: applying the 'delete' operator to an unqualified name is deprecated"
 slug: Web/JavaScript/Reference/Errors/Delete_in_strict_mode
 ---
 

--- a/files/fr/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
+++ b/files/fr/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //#
-  instead
+title: "SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //# instead"
 slug: Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma
 ---
 

--- a/files/fr/web/javascript/reference/errors/invalid_for-of_initializer/index.md
+++ b/files/fr/web/javascript/reference/errors/invalid_for-of_initializer/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  SyntaxError: a declaration in the head of a for-of loop can't have an
-  initializer
+title: "SyntaxError: a declaration in the head of a for-of loop can't have an initializer"
 slug: Web/JavaScript/Reference/Errors/Invalid_for-of_initializer
 ---
 

--- a/files/fr/web/javascript/reference/global_objects/date/date/index.md
+++ b/files/fr/web/javascript/reference/global_objects/date/date/index.md
@@ -1,7 +1,6 @@
 ---
 title: Constructeur Date()
 slug: Web/JavaScript/Reference/Global_Objects/Date/Date
-translation-of: Web/JavaScript/Reference/Global_Objects/Date/Date
 ---
 
 {{JSRef}}

--- a/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
@@ -1,7 +1,6 @@
 ---
 title: Intl.RelativeTimeFormat.prototype.resolvedOptions()
-slug: >-
-  Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/resolvedOptions
+slug: Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/resolvedOptions
 ---
 
 {{JSRef}}

--- a/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/supportedlocalesof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/supportedlocalesof/index.md
@@ -1,7 +1,6 @@
 ---
 title: Intl.RelativeTimeFormat.supportedLocalesOf()
-slug: >-
-  Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/supportedLocalesOf
+slug: Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/supportedLocalesOf
 ---
 
 {{JSRef}}

--- a/files/fr/web/javascript/reference/global_objects/intl/segmenter/segment/segments/@@iterator/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/segmenter/segment/segments/@@iterator/index.md
@@ -1,7 +1,6 @@
 ---
 title: Intl.Segments.prototype[@@iterator]()
-slug: >-
-  Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/@@iterator
+slug: Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/@@iterator
 ---
 
 {{JSRef}}

--- a/files/fr/web/javascript/reference/global_objects/intl/segmenter/segment/segments/containing/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/segmenter/segment/segments/containing/index.md
@@ -1,7 +1,6 @@
 ---
 title: Intl.Segments.prototype.containing()
-slug: >-
-  Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/containing
+slug: Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/containing
 ---
 
 {{JSRef}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/index.md
@@ -1,7 +1,6 @@
 ---
 title: Gestionnaire de Proxy (handler)
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy
-translation_of_original: Web/JavaScript/Reference/Global_Objects/Proxy/handler
 ---
 
 {{JSRef}}

--- a/files/fr/web/progressive_web_apps/tutorials/js13kgames/re-engageable_notifications_push/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/js13kgames/re-engageable_notifications_push/index.md
@@ -1,7 +1,5 @@
 ---
-title: >-
-  Comment faire pour que les PWAs relancent les utilisateurs en utilisant des
-  notifications et des messages poussés
+title: Comment faire pour que les PWAs relancent les utilisateurs en utilisant des notifications et des messages poussés
 slug: Web/Progressive_web_apps/Tutorials/js13kGames/Re-engageable_Notifications_Push
 ---
 


### PR DESCRIPTION
This PR lints and fixes the front matter keys throughout the French locale using the front matter linter, followed by manual fixes as needed.

Note: this will be self-merged as it involves infrastructure and linting that should not require locale-specific review.
