### PR TITLE
pt-br: Lint front matter keys

### DIFF
--- a/files/pt-br/learn/common_questions/tools_and_setup/how_do_you_host_your_website_on_google_app_engine/index.md
+++ b/files/pt-br/learn/common_questions/tools_and_setup/how_do_you_host_your_website_on_google_app_engine/index.md
@@ -1,7 +1,6 @@
 ---
 title: Como você hospeda seu site no Google App Engine?
-slug: >-
-  Learn/Common_questions/Tools_and_setup/How_do_you_host_your_website_on_Google_App_Engine
+slug: Learn/Common_questions/Tools_and_setup/How_do_you_host_your_website_on_Google_App_Engine
 ---
 
 [Google App Engine](https://cloud.google.com/appengine/) é uma plataforma poderosa que lhe permite construir e rodar aplicações na infraestrutura do Google — se você precisa criar um aplicativo da web de várias camadas do zero ou hospedar um site estático. Aqui está um guia passo a passo para hospedar seu site no Google App Engine.

--- a/files/pt-br/web/api/htmlformelement/submit_event/index.md
+++ b/files/pt-br/web/api/htmlformelement/submit_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'HTMLFormElement: submit event'
+title: "HTMLFormElement: submit event"
 slug: Web/API/HTMLFormElement/submit_event
 ---
 

--- a/files/pt-br/web/api/location/reload/index.md
+++ b/files/pt-br/web/api/location/reload/index.md
@@ -2,8 +2,6 @@
 title: "location: reload() method"
 short-title: reload()
 slug: Web/API/Location/reload
-page-type: web-api-instance-method
-browser-compat: api.Location.reload
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/pt-br/web/api/location/search/index.md
+++ b/files/pt-br/web/api/location/search/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Location: search'
+title: "Location: search"
 slug: Web/API/Location/search
 ---
 

--- a/files/pt-br/web/css/-webkit-overflow-scrolling/index.md
+++ b/files/pt-br/web/css/-webkit-overflow-scrolling/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-overflow-scrolling'
+title: "-webkit-overflow-scrolling"
 slug: Web/CSS/-webkit-overflow-scrolling
 ---
 

--- a/files/pt-br/web/css/-webkit-text-security/index.md
+++ b/files/pt-br/web/css/-webkit-text-security/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-webkit-text-security'
+title: "-webkit-text-security"
 slug: Web/CSS/-webkit-text-security
 ---
 

--- a/files/pt-br/web/css/@charset/index.md
+++ b/files/pt-br/web/css/@charset/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@charset'
+title: "@charset"
 slug: Web/CSS/@charset
 ---
 

--- a/files/pt-br/web/css/@font-face/index.md
+++ b/files/pt-br/web/css/@font-face/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@font-face'
+title: "@font-face"
 slug: Web/CSS/@font-face
 ---
 

--- a/files/pt-br/web/css/@import/index.md
+++ b/files/pt-br/web/css/@import/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@import'
+title: "@import"
 slug: Web/CSS/@import
 ---
 

--- a/files/pt-br/web/css/@layer/index.md
+++ b/files/pt-br/web/css/@layer/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@layer'
+title: "@layer"
 slug: Web/CSS/@layer
 ---
 

--- a/files/pt-br/web/css/@media/index.md
+++ b/files/pt-br/web/css/@media/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@media'
+title: "@media"
 slug: Web/CSS/@media
 ---
 

--- a/files/pt-br/web/css/@page/index.md
+++ b/files/pt-br/web/css/@page/index.md
@@ -1,5 +1,5 @@
 ---
-title: '@page'
+title: "@page"
 slug: Web/CSS/@page
 ---
 

--- a/files/pt-br/web/css/_colon_active/index.md
+++ b/files/pt-br/web/css/_colon_active/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':active'
+title: ":active"
 slug: Web/CSS/:active
 ---
 

--- a/files/pt-br/web/css/_colon_blank/index.md
+++ b/files/pt-br/web/css/_colon_blank/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':blank'
+title: ":blank"
 slug: Web/CSS/:blank
 ---
 

--- a/files/pt-br/web/css/_colon_checked/index.md
+++ b/files/pt-br/web/css/_colon_checked/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':checked'
+title: ":checked"
 slug: Web/CSS/:checked
 ---
 

--- a/files/pt-br/web/css/_colon_disabled/index.md
+++ b/files/pt-br/web/css/_colon_disabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':disabled'
+title: ":disabled"
 slug: Web/CSS/:disabled
 ---
 

--- a/files/pt-br/web/css/_colon_empty/index.md
+++ b/files/pt-br/web/css/_colon_empty/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':empty'
+title: ":empty"
 slug: Web/CSS/:empty
 ---
 

--- a/files/pt-br/web/css/_colon_enabled/index.md
+++ b/files/pt-br/web/css/_colon_enabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':enabled'
+title: ":enabled"
 slug: Web/CSS/:enabled
 ---
 

--- a/files/pt-br/web/css/_colon_first-child/index.md
+++ b/files/pt-br/web/css/_colon_first-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':first-child'
+title: ":first-child"
 slug: Web/CSS/:first-child
 ---
 

--- a/files/pt-br/web/css/_colon_first-of-type/index.md
+++ b/files/pt-br/web/css/_colon_first-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':first-of-type'
+title: ":first-of-type"
 slug: Web/CSS/:first-of-type
 ---
 

--- a/files/pt-br/web/css/_colon_focus-within/index.md
+++ b/files/pt-br/web/css/_colon_focus-within/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':focus-within'
+title: ":focus-within"
 slug: Web/CSS/:focus-within
 ---
 

--- a/files/pt-br/web/css/_colon_focus/index.md
+++ b/files/pt-br/web/css/_colon_focus/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':focus'
+title: ":focus"
 slug: Web/CSS/:focus
 ---
 

--- a/files/pt-br/web/css/_colon_fullscreen/index.md
+++ b/files/pt-br/web/css/_colon_fullscreen/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':fullscreen'
+title: ":fullscreen"
 slug: Web/CSS/:fullscreen
 ---
 

--- a/files/pt-br/web/css/_colon_hover/index.md
+++ b/files/pt-br/web/css/_colon_hover/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':hover'
+title: ":hover"
 slug: Web/CSS/:hover
 ---
 

--- a/files/pt-br/web/css/_colon_invalid/index.md
+++ b/files/pt-br/web/css/_colon_invalid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':invalid'
+title: ":invalid"
 slug: Web/CSS/:invalid
 ---
 

--- a/files/pt-br/web/css/_colon_last-child/index.md
+++ b/files/pt-br/web/css/_colon_last-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':last-child'
+title: ":last-child"
 slug: Web/CSS/:last-child
 ---
 

--- a/files/pt-br/web/css/_colon_last-of-type/index.md
+++ b/files/pt-br/web/css/_colon_last-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':last-of-type'
+title: ":last-of-type"
 slug: Web/CSS/:last-of-type
 ---
 

--- a/files/pt-br/web/css/_colon_link/index.md
+++ b/files/pt-br/web/css/_colon_link/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':link'
+title: ":link"
 slug: Web/CSS/:link
 ---
 

--- a/files/pt-br/web/css/_colon_not/index.md
+++ b/files/pt-br/web/css/_colon_not/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':not()'
+title: ":not()"
 slug: Web/CSS/:not
 ---
 {{ CSSRef() }}

--- a/files/pt-br/web/css/_colon_nth-child/index.md
+++ b/files/pt-br/web/css/_colon_nth-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-child()'
+title: ":nth-child()"
 slug: Web/CSS/:nth-child
 ---
 

--- a/files/pt-br/web/css/_colon_nth-last-child/index.md
+++ b/files/pt-br/web/css/_colon_nth-last-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-last-child()'
+title: ":nth-last-child()"
 slug: Web/CSS/:nth-last-child
 ---
 

--- a/files/pt-br/web/css/_colon_nth-of-type/index.md
+++ b/files/pt-br/web/css/_colon_nth-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':nth-of-type()'
+title: ":nth-of-type()"
 slug: Web/CSS/:nth-of-type
 ---
 

--- a/files/pt-br/web/css/_colon_only-child/index.md
+++ b/files/pt-br/web/css/_colon_only-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':only-child'
+title: ":only-child"
 slug: Web/CSS/:only-child
 ---
 

--- a/files/pt-br/web/css/_colon_only-of-type/index.md
+++ b/files/pt-br/web/css/_colon_only-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':only-of-type'
+title: ":only-of-type"
 slug: Web/CSS/:only-of-type
 ---
 

--- a/files/pt-br/web/css/_colon_optional/index.md
+++ b/files/pt-br/web/css/_colon_optional/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':optional'
+title: ":optional"
 slug: Web/CSS/:optional
 ---
 

--- a/files/pt-br/web/css/_colon_out-of-range/index.md
+++ b/files/pt-br/web/css/_colon_out-of-range/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':out-of-range'
+title: ":out-of-range"
 slug: Web/CSS/:out-of-range
 ---
 

--- a/files/pt-br/web/css/_colon_read-write/index.md
+++ b/files/pt-br/web/css/_colon_read-write/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':read-write'
+title: ":read-write"
 slug: Web/CSS/:read-write
 ---
 

--- a/files/pt-br/web/css/_colon_required/index.md
+++ b/files/pt-br/web/css/_colon_required/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':required'
+title: ":required"
 slug: Web/CSS/:required
 ---
 

--- a/files/pt-br/web/css/_colon_root/index.md
+++ b/files/pt-br/web/css/_colon_root/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':root'
+title: ":root"
 slug: Web/CSS/:root
 ---
 

--- a/files/pt-br/web/css/_colon_target/index.md
+++ b/files/pt-br/web/css/_colon_target/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':target'
+title: ":target"
 slug: Web/CSS/:target
 ---
 

--- a/files/pt-br/web/css/_colon_valid/index.md
+++ b/files/pt-br/web/css/_colon_valid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':valid'
+title: ":valid"
 slug: Web/CSS/:valid
 ---
 

--- a/files/pt-br/web/css/_colon_visited/index.md
+++ b/files/pt-br/web/css/_colon_visited/index.md
@@ -1,5 +1,5 @@
 ---
-title: ':visited'
+title: ":visited"
 slug: Web/CSS/:visited
 ---
 

--- a/files/pt-br/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/pt-br/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::-webkit-scrollbar'
+title: "::-webkit-scrollbar"
 slug: Web/CSS/::-webkit-scrollbar
 ---
 

--- a/files/pt-br/web/css/_doublecolon_after/index.md
+++ b/files/pt-br/web/css/_doublecolon_after/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::after (:after)'
+title: "::after (:after)"
 slug: Web/CSS/::after
 ---
 

--- a/files/pt-br/web/css/_doublecolon_backdrop/index.md
+++ b/files/pt-br/web/css/_doublecolon_backdrop/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::backdrop'
+title: "::backdrop"
 slug: Web/CSS/::backdrop
 ---
 

--- a/files/pt-br/web/css/_doublecolon_before/index.md
+++ b/files/pt-br/web/css/_doublecolon_before/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::before (:before)'
+title: "::before (:before)"
 slug: Web/CSS/::before
 ---
 

--- a/files/pt-br/web/css/_doublecolon_first-letter/index.md
+++ b/files/pt-br/web/css/_doublecolon_first-letter/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::first-letter (:first-letter)'
+title: "::first-letter (:first-letter)"
 slug: Web/CSS/::first-letter
 ---
 

--- a/files/pt-br/web/css/_doublecolon_first-line/index.md
+++ b/files/pt-br/web/css/_doublecolon_first-line/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::first-line (:first-line)'
+title: "::first-line (:first-line)"
 slug: Web/CSS/::first-line
 ---
 

--- a/files/pt-br/web/css/_doublecolon_selection/index.md
+++ b/files/pt-br/web/css/_doublecolon_selection/index.md
@@ -1,5 +1,5 @@
 ---
-title: '::selection'
+title: "::selection"
 slug: Web/CSS/::selection
 ---
 

--- a/files/pt-br/web/css/box-ordinal-group/index.md
+++ b/files/pt-br/web/css/box-ordinal-group/index.md
@@ -1,5 +1,5 @@
 ---
-title: '-moz-box-ordinal-group'
+title: "-moz-box-ordinal-group"
 slug: Web/CSS/box-ordinal-group
 ---
 

--- a/files/pt-br/web/css/layout_cookbook/media_objects/index.md
+++ b/files/pt-br/web/css/layout_cookbook/media_objects/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Recipe: Media objects'
+title: "Recipe: Media objects"
 slug: Web/CSS/Layout_cookbook/Media_objects
 ---
 

--- a/files/pt-br/web/html/element/big/index.md
+++ b/files/pt-br/web/html/element/big/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<big>: Elemento para deixar o texto maio'
+title: "<big>: Elemento para deixar o texto maio"
 slug: Web/HTML/Element/big
 ---
 

--- a/files/pt-br/web/html/element/center/index.md
+++ b/files/pt-br/web/html/element/center/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<center>: O elemento de texto centralizado (obsoleto)'
+title: "<center>: O elemento de texto centralizado (obsoleto)"
 slug: Web/HTML/Element/center
 ---
 

--- a/files/pt-br/web/html/element/code/index.md
+++ b/files/pt-br/web/html/element/code/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<code>: O Elemento Inline Code'
+title: "<code>: O Elemento Inline Code"
 slug: Web/HTML/Element/code
 ---
 

--- a/files/pt-br/web/html/element/dd/index.md
+++ b/files/pt-br/web/html/element/dd/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<dd>: elemento Detalhes da Descrição'
+title: "<dd>: elemento Detalhes da Descrição"
 slug: Web/HTML/Element/dd
 ---
 

--- a/files/pt-br/web/html/element/dir/index.md
+++ b/files/pt-br/web/html/element/dir/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<dir>:  O elemento obsoleto Directory'
+title: "<dir>:  O elemento obsoleto Directory"
 slug: Web/HTML/Element/dir
 ---
 

--- a/files/pt-br/web/html/element/em/index.md
+++ b/files/pt-br/web/html/element/em/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<em>: O elemento de ênfase'
+title: "<em>: O elemento de ênfase"
 slug: Web/HTML/Element/em
 ---
 

--- a/files/pt-br/web/html/element/figcaption/index.md
+++ b/files/pt-br/web/html/element/figcaption/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<figcaption>: O elemento de legenda da figura'
+title: "<figcaption>: O elemento de legenda da figura"
 slug: Web/HTML/Element/figcaption
 ---
 

--- a/files/pt-br/web/html/element/figure/index.md
+++ b/files/pt-br/web/html/element/figure/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<figure>: O elemento Figure com Caption opcional'
+title: "<figure>: O elemento Figure com Caption opcional"
 slug: Web/HTML/Element/figure
 ---
 

--- a/files/pt-br/web/html/element/heading_elements/index.md
+++ b/files/pt-br/web/html/element/heading_elements/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<h1>–<h6>: Os elementos HTML de cabeçalho da seção'
+title: "<h1>–<h6>: Os elementos HTML de cabeçalho da seção"
 slug: Web/HTML/Element/Heading_Elements
 ---
 

--- a/files/pt-br/web/html/element/iframe/index.md
+++ b/files/pt-br/web/html/element/iframe/index.md
@@ -1,5 +1,5 @@
 ---
-title: "<iframe>"
+title: <iframe>
 slug: Web/HTML/Element/iframe
 ---
 

--- a/files/pt-br/web/html/element/slot/index.md
+++ b/files/pt-br/web/html/element/slot/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<content>: The Shadow DOM Content Placeholder element (obsolete)'
+title: "<content>: The Shadow DOM Content Placeholder element (obsolete)"
 slug: Web/HTML/Element/slot
 ---
 

--- a/files/pt-br/web/html/element/tfoot/index.md
+++ b/files/pt-br/web/html/element/tfoot/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<tfoot>: Elemento para o rodapé da tabela'
+title: "<tfoot>: Elemento para o rodapé da tabela"
 slug: Web/HTML/Element/tfoot
 ---
 

--- a/files/pt-br/web/html/element/title/index.md
+++ b/files/pt-br/web/html/element/title/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<title>: O titulo do documento.'
+title: "<title>: O titulo do documento."
 slug: Web/HTML/Element/title
 ---
 

--- a/files/pt-br/web/html/index.md
+++ b/files/pt-br/web/html/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'HTML: Linguagem de Marcação de Hipertexto'
+title: "HTML: Linguagem de Marcação de Hipertexto"
 slug: Web/HTML
 ---
 

--- a/files/pt-br/web/http/cors/errors/corsdidnotsucceed/index.md
+++ b/files/pt-br/web/http/cors/errors/corsdidnotsucceed/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Razão: A requisição CORS não foi bem sucedida'
+title: "Razão: A requisição CORS não foi bem sucedida"
 slug: Web/HTTP/CORS/Errors/CORSDidNotSucceed
 ---
 

--- a/files/pt-br/web/http/cors/errors/corsmissingalloworigin/index.md
+++ b/files/pt-br/web/http/cors/errors/corsmissingalloworigin/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Reason: CORS header ''Access-Control-Allow-Origin'' missing'
+title: "Reason: CORS header 'Access-Control-Allow-Origin' missing"
 slug: Web/HTTP/CORS/Errors/CORSMissingAllowOrigin
 ---
 

--- a/files/pt-br/web/http/cors/errors/corsnotsupportingcredentials/index.md
+++ b/files/pt-br/web/http/cors/errors/corsnotsupportingcredentials/index.md
@@ -1,6 +1,5 @@
 ---
-title: 'Reason: Credential is not supported if the CORS header ‘Access-Control-Allow-Origin’
-  is ‘*’'
+title: "Reason: Credential is not supported if the CORS header ‘Access-Control-Allow-Origin’ is ‘*’"
 slug: Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
 ---
 

--- a/files/pt-br/web/http/cors/errors/corsrequestnothttp/index.md
+++ b/files/pt-br/web/http/cors/errors/corsrequestnothttp/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Reason: CORS request not HTTP'
+title: "Reason: CORS request not HTTP"
 slug: Web/HTTP/CORS/Errors/CORSRequestNotHttp
 ---
 

--- a/files/pt-br/web/javascript/guide/introduction/index.md
+++ b/files/pt-br/web/javascript/guide/introduction/index.md
@@ -1,7 +1,6 @@
 ---
 title: Introdução
 slug: Web/JavaScript/Guide/Introduction
-page-type: guide
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide", "Web/JavaScript/Guide/Grammar_and_types")}}

--- a/files/pt-br/web/javascript/reference/errors/already_has_pragma/index.md
+++ b/files/pt-br/web/javascript/reference/errors/already_has_pragma/index.md
@@ -1,6 +1,5 @@
 ---
-title: 'Warning: -file- is being assigned a //# sourceMappingURL, but already has
-  one'
+title: "Warning: -file- is being assigned a //# sourceMappingURL, but already has one"
 slug: Web/JavaScript/Reference/Errors/Already_has_pragma
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/array_sort_argument/index.md
+++ b/files/pt-br/web/javascript/reference/errors/array_sort_argument/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'TypeError: invalid Array.prototype.sort argument'
+title: "TypeError: invalid Array.prototype.sort argument"
 slug: Web/JavaScript/Reference/Errors/Array_sort_argument
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
+++ b/files/pt-br/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ReferenceError: can''t access lexical declaration`X'' before initialization'
+title: "ReferenceError: can't access lexical declaration`X' before initialization"
 slug: Web/JavaScript/Reference/Errors/Cant_access_lexical_declaration_before_init
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/illegal_character/index.md
+++ b/files/pt-br/web/javascript/reference/errors/illegal_character/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: illegal character'
+title: "SyntaxError: illegal character"
 slug: Web/JavaScript/Reference/Errors/Illegal_character
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/pt-br/web/javascript/reference/errors/invalid_array_length/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'RangeError: invalid array length'
+title: "RangeError: invalid array length"
 slug: Web/JavaScript/Reference/Errors/Invalid_array_length
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
+++ b/files/pt-br/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ReferenceError: invalid assignment left-hand side'
+title: "ReferenceError: invalid assignment left-hand side"
 slug: Web/JavaScript/Reference/Errors/Invalid_assignment_left-hand_side
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/invalid_date/index.md
+++ b/files/pt-br/web/javascript/reference/errors/invalid_date/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'RangeError: invalid date'
+title: "RangeError: invalid date"
 slug: Web/JavaScript/Reference/Errors/Invalid_date
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/invalid_for-in_initializer/index.md
+++ b/files/pt-br/web/javascript/reference/errors/invalid_for-in_initializer/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: as declarações da cabeça do laço for-in podem não ter inicializadores'
+title: "SyntaxError: as declarações da cabeça do laço for-in podem não ter inicializadores"
 slug: Web/JavaScript/Reference/Errors/Invalid_for-in_initializer
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/invalid_for-of_initializer/index.md
+++ b/files/pt-br/web/javascript/reference/errors/invalid_for-of_initializer/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: uma declaração na cabeça de um laço for-of não pode ter um inicializador'
+title: "SyntaxError: uma declaração na cabeça de um laço for-of não pode ter um inicializador"
 slug: Web/JavaScript/Reference/Errors/Invalid_for-of_initializer
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/json_bad_parse/index.md
+++ b/files/pt-br/web/javascript/reference/errors/json_bad_parse/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: JSON.parse: bad parsing'
+title: "SyntaxError: JSON.parse: bad parsing"
 slug: Web/JavaScript/Reference/Errors/JSON_bad_parse
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/missing_colon_after_property_id/index.md
+++ b/files/pt-br/web/javascript/reference/errors/missing_colon_after_property_id/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Erro de Sintaxe: faltando : depois da propriedade id'
+title: "Erro de Sintaxe: faltando : depois da propriedade id"
 slug: Web/JavaScript/Reference/Errors/Missing_colon_after_property_id
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/missing_curly_after_function_body/index.md
+++ b/files/pt-br/web/javascript/reference/errors/missing_curly_after_function_body/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing } after function body'
+title: "SyntaxError: missing } after function body"
 slug: Web/JavaScript/Reference/Errors/Missing_curly_after_function_body
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/missing_curly_after_property_list/index.md
+++ b/files/pt-br/web/javascript/reference/errors/missing_curly_after_property_list/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing } after property list'
+title: "SyntaxError: missing } after property list"
 slug: Web/JavaScript/Reference/Errors/Missing_curly_after_property_list
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/missing_formal_parameter/index.md
+++ b/files/pt-br/web/javascript/reference/errors/missing_formal_parameter/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing formal parameter'
+title: "SyntaxError: missing formal parameter"
 slug: Web/JavaScript/Reference/Errors/Missing_formal_parameter
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
+++ b/files/pt-br/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing ; before statement'
+title: "SyntaxError: missing ; before statement"
 slug: Web/JavaScript/Reference/Errors/Missing_semicolon_before_statement
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/negative_repetition_count/index.md
+++ b/files/pt-br/web/javascript/reference/errors/negative_repetition_count/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'RangeError: repeat count must be non-negative'
+title: "RangeError: repeat count must be non-negative"
 slug: Web/JavaScript/Reference/Errors/Negative_repetition_count
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/no_variable_name/index.md
+++ b/files/pt-br/web/javascript/reference/errors/no_variable_name/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: missing variable name'
+title: "SyntaxError: missing variable name"
 slug: Web/JavaScript/Reference/Errors/No_variable_name
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/precision_range/index.md
+++ b/files/pt-br/web/javascript/reference/errors/precision_range/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'RangeError: precision is out of range'
+title: "RangeError: precision is out of range"
 slug: Web/JavaScript/Reference/Errors/Precision_range
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/stmt_after_return/index.md
+++ b/files/pt-br/web/javascript/reference/errors/stmt_after_return/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Warning: unreachable code after return statement'
+title: "Warning: unreachable code after return statement"
 slug: Web/JavaScript/Reference/Errors/Stmt_after_return
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/too_much_recursion/index.md
+++ b/files/pt-br/web/javascript/reference/errors/too_much_recursion/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'InternalError: too much recursion'
+title: "InternalError: too much recursion"
 slug: Web/JavaScript/Reference/Errors/Too_much_recursion
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/unexpected_token/index.md
+++ b/files/pt-br/web/javascript/reference/errors/unexpected_token/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: Unexpected token'
+title: "SyntaxError: Unexpected token"
 slug: Web/JavaScript/Reference/Errors/Unexpected_token
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/unnamed_function_statement/index.md
+++ b/files/pt-br/web/javascript/reference/errors/unnamed_function_statement/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Erro de sintaxe: declaração de função requer um nome'
+title: "Erro de sintaxe: declaração de função requer um nome"
 slug: Web/JavaScript/Reference/Errors/Unnamed_function_statement
 ---
 

--- a/files/pt-br/web/javascript/reference/errors/unterminated_string_literal/index.md
+++ b/files/pt-br/web/javascript/reference/errors/unterminated_string_literal/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SyntaxError: unterminated string literal'
+title: "SyntaxError: unterminated string literal"
 slug: Web/JavaScript/Reference/Errors/Unterminated_string_literal
 ---
 

--- a/files/pt-br/web/javascript/reference/operators/logical_and/index.md
+++ b/files/pt-br/web/javascript/reference/operators/logical_and/index.md
@@ -1,8 +1,6 @@
 ---
 title: AND lógico (&&)
 slug: Web/JavaScript/Reference/Operators/Logical_AND
-page-type: javascript-operator
-browser-compat: javascript.operators.logical_and
 ---
 
 {{jsSidebar("Operators")}}

--- a/files/pt-br/web/javascript/reference/operators/null/index.md
+++ b/files/pt-br/web/javascript/reference/operators/null/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'null'
+title: "null"
 slug: Web/JavaScript/Reference/Operators/null
 ---
 

--- a/files/pt-br/web/svg/index.md
+++ b/files/pt-br/web/svg/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'SVG: Gráficos Vetoriais Escaláveis'
+title: "SVG: Gráficos Vetoriais Escaláveis"
 slug: Web/SVG
 ---
 


### PR DESCRIPTION
This PR lints and fixes the front matter keys throughout the Brazilian Portuguese locale using the front matter linter, followed by manual fixes as needed.

Note: this will be self-merged as it involves infrastructure and linting that should not require locale-specific review.
