### PR TITLE
ja: Lint front matter keys for "orphaned"

### DIFF
--- a/files/ja/orphaned/code_snippets/toolbar/index.md
+++ b/files/ja/orphaned/code_snippets/toolbar/index.md
@@ -1,7 +1,6 @@
 ---
 title: Toolbar
 slug: orphaned/Code_snippets/Toolbar
-original_slug: Code_snippets/Toolbar
 ---
 
 ### ツールバーボタンを追加する

--- a/files/ja/orphaned/creating_toolbar_buttons/index.md
+++ b/files/ja/orphaned/creating_toolbar_buttons/index.md
@@ -1,7 +1,6 @@
 ---
 title: Creating toolbar buttons
 slug: orphaned/Creating_toolbar_buttons
-original_slug: Creating_toolbar_buttons
 ---
 
 この記事ではツールキットアプリケーション（Firefox、Thunderbird、Nvu など）に [オーバレイ](/ja/XUL_Overlays) を使用してツールバーボタンを追加する方法を説明します。[XUL](/ja/XUL) と [CSS](/ja/CSS) の基礎知識を備えた [拡張機能](/ja/Extension) の開発者が対象です。

--- a/files/ja/orphaned/dynamically_modifying_xul-based_user_interface/index.md
+++ b/files/ja/orphaned/dynamically_modifying_xul-based_user_interface/index.md
@@ -1,7 +1,6 @@
 ---
 title: Dynamically modifying XUL-based user interface
 slug: orphaned/Dynamically_modifying_XUL-based_user_interface
-original_slug: Dynamically_modifying_XUL-based_user_interface
 ---
 
 この記事では、[DOM](/ja/DOM) やその他の API を使って [XUL](/ja/XUL) インターフェイスを操作する方法について検討します。まず DOM

--- a/files/ja/orphaned/feed_content_access_api/index.md
+++ b/files/ja/orphaned/feed_content_access_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Feed content access API
 slug: orphaned/Feed_content_access_API
-original_slug: Feed_content_access_API
 ---
 
 [Firefox 2](/ja/Firefox_2) と Thunderbird 2 は拡張製作者に RSS と Atom フィードへのアクセスを簡単にする一連のインターフェースを導入します。

--- a/files/ja/orphaned/findbar_api/index.md
+++ b/files/ja/orphaned/findbar_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Findbar API
 slug: orphaned/Findbar_API
-original_slug: Findbar_API
 ---
 
 Mozilla 1.9 から検索バー機能が拡張や XULRunner アプリケーション向けに toolkit xul ウィジットとして利用可能になります。

--- a/files/ja/orphaned/games/examples/index.md
+++ b/files/ja/orphaned/games/examples/index.md
@@ -1,7 +1,6 @@
 ---
 title: 例
 slug: orphaned/Games/Examples
-original_slug: Games/Examples
 ---
 
 {{GamesSidebar}}

--- a/files/ja/orphaned/installing_extensions_and_themes_from_web_pages/index.md
+++ b/files/ja/orphaned/installing_extensions_and_themes_from_web_pages/index.md
@@ -1,7 +1,6 @@
 ---
 title: Web ページから拡張機能とテーマをインストールする
 slug: orphaned/Installing_Extensions_and_Themes_From_Web_Pages
-original_slug: Installing_Extensions_and_Themes_From_Web_Pages
 ---
 
 [拡張機能](/ja/Extension) と [テーマ](/ja/Themes) を Web ページからインストールするには、XPI ファイルに直接リンクしたり、[InstallTrigger](/ja/XPInstall_API_Reference/InstallTrigger_Object) オブジェクトを使用するなど様々な方法があります。

--- a/files/ja/orphaned/learn/server-side/express_nodejs/installing_on_pws_cloud_foundry/index.md
+++ b/files/ja/orphaned/learn/server-side/express_nodejs/installing_on_pws_cloud_foundry/index.md
@@ -1,7 +1,6 @@
 ---
 title: PWS/Cloud Foundry に LocalLibrary をインストールする
 slug: orphaned/Learn/Server-side/Express_Nodejs/Installing_on_PWS_Cloud_Foundry
-original_slug: Learn/Server-side/Express_Nodejs/Installing_on_PWS_Cloud_Foundry
 ---
 
 {{LearnSidebar}}

--- a/files/ja/orphaned/localizing_extension_descriptions/index.md
+++ b/files/ja/orphaned/localizing_extension_descriptions/index.md
@@ -1,7 +1,6 @@
 ---
 title: Localizing extension descriptions
 slug: orphaned/Localizing_extension_descriptions
-original_slug: Localizing_extension_descriptions
 ---
 
 ### Gecko 1.9 におけるローカライズ

--- a/files/ja/orphaned/mdn/about/linking_to_mdn/index.md
+++ b/files/ja/orphaned/mdn/about/linking_to_mdn/index.md
@@ -1,7 +1,6 @@
 ---
 title: MDN にリンクするには
 slug: orphaned/MDN/About/Linking_to_MDN
-original_slug: MDN/About/Linking_to_MDN
 ---
 
 {{MDNSidebar}}

--- a/files/ja/orphaned/mdn/community/conversations/index.md
+++ b/files/ja/orphaned/mdn/community/conversations/index.md
@@ -1,7 +1,6 @@
 ---
 title: MDN コミュニティでの対話
 slug: orphaned/MDN/Community/Conversations
-original_slug: MDN/Community/Conversations
 ---
 
 {{MDNSidebar}}

--- a/files/ja/orphaned/mdn/community/doc_sprints/index.md
+++ b/files/ja/orphaned/mdn/community/doc_sprints/index.md
@@ -1,7 +1,6 @@
 ---
 title: Doc sprints
 slug: orphaned/MDN/Community/Doc_sprints
-original_slug: MDN/Community/Doc_sprints
 ---
 
 {{MDNSidebar}}

--- a/files/ja/orphaned/mdn/community/whats_happening/index.md
+++ b/files/ja/orphaned/mdn/community/whats_happening/index.md
@@ -1,7 +1,6 @@
 ---
 title: 何が起きているかを追跡する
 slug: orphaned/MDN/Community/Whats_happening
-original_slug: MDN/Community/Whats_happening
 ---
 
 {{MDNSidebar}}

--- a/files/ja/orphaned/mdn/community/working_in_community/index.md
+++ b/files/ja/orphaned/mdn/community/working_in_community/index.md
@@ -1,7 +1,6 @@
 ---
 title: コミュニティでの作業
 slug: orphaned/MDN/Community/Working_in_community
-original_slug: MDN/Community/Working_in_community
 ---
 
 {{MDNSidebar}}

--- a/files/ja/orphaned/mdn/contribute/howto/add_or_update_browser_compatibility_data/index.md
+++ b/files/ja/orphaned/mdn/contribute/howto/add_or_update_browser_compatibility_data/index.md
@@ -1,7 +1,6 @@
 ---
 title: ブラウザーの互換性データを追加したり更新したりするには
 slug: orphaned/MDN/Contribute/Howto/Add_or_update_browser_compatibility_data
-original_slug: MDN/Contribute/Howto/Add_or_update_browser_compatibility_data
 ---
 
 {{MDNSidebar}}

--- a/files/ja/orphaned/mdn/structures/live_samples/simple_live_sample_demo/index.md
+++ b/files/ja/orphaned/mdn/structures/live_samples/simple_live_sample_demo/index.md
@@ -1,7 +1,6 @@
 ---
 title: ライブコードサンプルの簡単なデモ
 slug: orphaned/MDN/Structures/Live_samples/Simple_live_sample_demo
-original_slug: MDN/Structures/Live_samples/Simple_live_sample_demo
 ---
 
 {{MDNSidebar}}

--- a/files/ja/orphaned/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.md
+++ b/files/ja/orphaned/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.md
@@ -1,7 +1,6 @@
 ---
 title: デバッグ (Firefox 50 より前)
 slug: orphaned/Mozilla/Add-ons/WebExtensions/Debugging_(before_Firefox_50)
-original_slug: Mozilla/Add-ons/WebExtensions/Debugging_(before_Firefox_50)
 ---
 
 {{AddonSidebar}}

--- a/files/ja/orphaned/new_in_javascript_1.8/index.md
+++ b/files/ja/orphaned/new_in_javascript_1.8/index.md
@@ -1,7 +1,6 @@
 ---
 title: New in JavaScript 1.8
 slug: orphaned/New_in_JavaScript_1.8
-original_slug: New_in_JavaScript_1.8
 ---
 
 JavaScript 1.8 は（[Firefox 3](/ja/docs/Mozilla/Firefox/Releases/3) に組み込まれている） Gecko 1.9 の一部分です。これは [JavaScript 1.7](/ja/docs/Web/JavaScript/New_in_JavaScript/1.7) よりは大きな更新ではありませんが、ECMAScript 4/JavaScript 2 の進歩に追随するための更新がいくつか含まれています。このリリースは [JavaScript 1.6](/ja/docs/Web/JavaScript/New_in_JavaScript/1.6) および [JavaScript 1.7](/ja/docs/Web/JavaScript/New_in_JavaScript/1.7) で仕様化された新機能の全てを含んでいます。

--- a/files/ja/orphaned/setting_up_extension_development_environment/index.md
+++ b/files/ja/orphaned/setting_up_extension_development_environment/index.md
@@ -1,7 +1,6 @@
 ---
 title: Setting up extension development environment
 slug: orphaned/Setting_up_extension_development_environment
-original_slug: Setting_up_extension_development_environment
 ---
 
 この記事では、あなたの Mozilla アプリケーションにおいて拡張機能の開発を容易にするためのノウハウを提案します。

--- a/files/ja/orphaned/the_importance_of_correct_html_commenting/index.md
+++ b/files/ja/orphaned/the_importance_of_correct_html_commenting/index.md
@@ -1,7 +1,6 @@
 ---
 title: The Importance of Correct HTML Commenting
 slug: orphaned/The_Importance_of_Correct_HTML_Commenting
-original_slug: The_Importance_of_Correct_HTML_Commenting
 ---
 
 HTML を [標準モード](/ja/Mozilla's_DOCTYPE_sniffing) で記述する場合、不正確に書かれたコメントによってページの表示が崩れ、コンテンツの一部または全体がコメントアウトされた状態になってしまいます。XHTML や XML を記述する場合、不正確なコメントが含まれると、ドキュメントそのものが表示できなくなります。

--- a/files/ja/orphaned/toolkit_api/official_references/index.md
+++ b/files/ja/orphaned/toolkit_api/official_references/index.md
@@ -1,7 +1,6 @@
 ---
 title: Official References
 slug: orphaned/Toolkit_API/Official_References
-original_slug: Toolkit_API/Official_References
 ---
 
 Official References. Do not add to this list without contacting Benjamin Smedberg. Note that this page is included from the pages listed below. So: Don't Add Breadcrumbs!

--- a/files/ja/orphaned/tutorials/index.md
+++ b/files/ja/orphaned/tutorials/index.md
@@ -1,7 +1,6 @@
 ---
 title: チュートリアル
 slug: orphaned/Tutorials
-original_slug: Tutorials
 ---
 
 SDK を使用したアドオンの開発方法を実践的に説明したページの一覧です。

--- a/files/ja/orphaned/web/api/canvas_api/tutorial/hit_regions_and_accessibility/index.md
+++ b/files/ja/orphaned/web/api/canvas_api/tutorial/hit_regions_and_accessibility/index.md
@@ -1,7 +1,6 @@
 ---
 title: ヒット領域とアクセシビリティ
 slug: orphaned/Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility
-original_slug: Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility
 ---
 
 <div>{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas", "Web/API/Canvas_API/Tutorial/Optimizing_canvas")}}</div>

--- a/files/ja/orphaned/web/api/datatransfer/mozcleardataat/index.md
+++ b/files/ja/orphaned/web/api/datatransfer/mozcleardataat/index.md
@@ -1,7 +1,6 @@
 ---
 title: DataTransfer.mozClearDataAt()
 slug: orphaned/Web/API/DataTransfer/mozClearDataAt
-original_slug: Web/API/DataTransfer/mozClearDataAt
 ---
 
 {{APIRef("HTML Drag and Drop API")}}

--- a/files/ja/orphaned/web/api/datatransfer/mozcursor/index.md
+++ b/files/ja/orphaned/web/api/datatransfer/mozcursor/index.md
@@ -1,7 +1,6 @@
 ---
 title: DataTransfer.mozCursor
 slug: orphaned/Web/API/DataTransfer/mozCursor
-original_slug: Web/API/DataTransfer/mozCursor
 ---
 
 {{APIRef("HTML Drag and Drop API")}}

--- a/files/ja/orphaned/web/api/datatransfer/mozgetdataat/index.md
+++ b/files/ja/orphaned/web/api/datatransfer/mozgetdataat/index.md
@@ -1,7 +1,6 @@
 ---
 title: DataTransfer.mozGetDataAt()
 slug: orphaned/Web/API/DataTransfer/mozGetDataAt
-original_slug: Web/API/DataTransfer/mozGetDataAt
 ---
 
 {{APIRef("HTML Drag and Drop API")}}

--- a/files/ja/orphaned/web/api/datatransfer/mozitemcount/index.md
+++ b/files/ja/orphaned/web/api/datatransfer/mozitemcount/index.md
@@ -1,7 +1,6 @@
 ---
 title: DataTransfer.mozItemCount
 slug: orphaned/Web/API/DataTransfer/mozItemCount
-original_slug: Web/API/DataTransfer/mozItemCount
 ---
 
 {{APIRef("HTML Drag and Drop API")}}

--- a/files/ja/orphaned/web/api/datatransfer/mozsetdataat/index.md
+++ b/files/ja/orphaned/web/api/datatransfer/mozsetdataat/index.md
@@ -1,7 +1,6 @@
 ---
 title: DataTransfer.mozSetDataAt()
 slug: orphaned/Web/API/DataTransfer/mozSetDataAt
-original_slug: Web/API/DataTransfer/mozSetDataAt
 ---
 
 {{APIRef("HTML Drag and Drop API")}}

--- a/files/ja/orphaned/web/api/datatransfer/mozsourcenode/index.md
+++ b/files/ja/orphaned/web/api/datatransfer/mozsourcenode/index.md
@@ -1,7 +1,6 @@
 ---
 title: DataTransfer.mozSourceNode
 slug: orphaned/Web/API/DataTransfer/mozSourceNode
-original_slug: Web/API/DataTransfer/mozSourceNode
 ---
 
 {{APIRef("HTML Drag and Drop API")}}

--- a/files/ja/orphaned/web/api/datatransfer/moztypesat/index.md
+++ b/files/ja/orphaned/web/api/datatransfer/moztypesat/index.md
@@ -1,7 +1,6 @@
 ---
 title: DataTransfer.mozTypesAt()
 slug: orphaned/Web/API/DataTransfer/mozTypesAt
-original_slug: Web/API/DataTransfer/mozTypesAt
 ---
 
 {{APIRef("HTML Drag and Drop API")}}

--- a/files/ja/orphaned/web/api/datatransfer/mozusercancelled/index.md
+++ b/files/ja/orphaned/web/api/datatransfer/mozusercancelled/index.md
@@ -1,7 +1,6 @@
 ---
 title: DataTransfer.mozUserCancelled
 slug: orphaned/Web/API/DataTransfer/mozUserCancelled
-original_slug: Web/API/DataTransfer/mozUserCancelled
 ---
 
 {{APIRef("HTML Drag and Drop API")}}

--- a/files/ja/orphaned/web/api/document_object_model/events/index.md
+++ b/files/ja/orphaned/web/api/document_object_model/events/index.md
@@ -1,7 +1,6 @@
 ---
 title: イベントと DOM
 slug: orphaned/Web/API/Document_Object_Model/Events
-original_slug: Web/API/Document_Object_Model/Events
 ---
 
 {{DefaultAPISidebar("DOM")}}

--- a/files/ja/orphaned/web/api/element/show_event/index.md
+++ b/files/ja/orphaned/web/api/element/show_event/index.md
@@ -1,7 +1,6 @@
 ---
-title: 'Element: show イベント'
+title: "Element: show イベント"
 slug: orphaned/Web/API/Element/show_event
-original_slug: Web/API/Element/show_event
 l10n:
   sourceCommit: a122e87245c624ba56197641b4d7b21b643a6021
 ---

--- a/files/ja/orphaned/web/api/html_drag_and_drop_api/multiple_items/index.md
+++ b/files/ja/orphaned/web/api/html_drag_and_drop_api/multiple_items/index.md
@@ -1,7 +1,6 @@
 ---
 title: 複数のアイテムのドラッグ & ドロップ
 slug: orphaned/Web/API/HTML_Drag_and_Drop_API/Multiple_items
-original_slug: Web/API/HTML_Drag_and_Drop_API/Multiple_items
 ---
 
 {{DefaultAPISidebar("HTML Drag and Drop API")}}

--- a/files/ja/orphaned/web/api/htmlelement/contextmenu/index.md
+++ b/files/ja/orphaned/web/api/htmlelement/contextmenu/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLElement.contextMenu
 slug: orphaned/Web/API/HTMLElement/contextMenu
-original_slug: Web/API/HTMLElement/contextMenu
 ---
 
 {{APIRef("HTML DOM")}}{{Deprecated_Header}}

--- a/files/ja/orphaned/web/api/request/priority/index.md
+++ b/files/ja/orphaned/web/api/request/priority/index.md
@@ -1,7 +1,6 @@
 ---
 title: Request.priority
 slug: orphaned/Web/API/Request/priority
-original_slug: Web/API/Request/priority
 l10n:
   sourceCommit: e0e09b1df51489867f2e74c18586d168ba5e00d1
 ---

--- a/files/ja/orphaned/web/api/window/applicationcache/index.md
+++ b/files/ja/orphaned/web/api/window/applicationcache/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.applicationCache
 slug: orphaned/Web/API/Window/applicationCache
-original_slug: Web/API/Window/applicationCache
 ---
 
 {{APIRef}}{{Deprecated_Header}}{{Non-standard_Header}}{{SecureContext_Header}}

--- a/files/ja/orphaned/web/api/xsltprocessor/browser_differences/index.md
+++ b/files/ja/orphaned/web/api/xsltprocessor/browser_differences/index.md
@@ -1,7 +1,6 @@
 ---
 title: ブラウザー間の違い
 slug: orphaned/Web/API/XSLTProcessor/Browser_Differences
-original_slug: Web/API/XSLTProcessor/Browser_Differences
 ---
 
 ## ブラウザー間の違い

--- a/files/ja/orphaned/web/compatibility_faq/broken_table_layout.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/broken_table_layout.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: テーブルのレイアウトが崩れている
 slug: orphaned/Web/Compatibility_FAQ/Broken_Table_Layout.html
-original_slug: Web/Compatibility_FAQ/Broken_Table_Layout.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/cut_off_text.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/cut_off_text.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: 文字列の一部が表示されずに見切れる
 slug: orphaned/Web/Compatibility_FAQ/Cut_Off_Text.html
-original_slug: Web/Compatibility_FAQ/Cut_Off_Text.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/empty_background_color.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/empty_background_color.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: アイコン,バナーの色が抜けている
 slug: orphaned/Web/Compatibility_FAQ/Empty_Background_Color.html
-original_slug: Web/Compatibility_FAQ/Empty_Background_Color.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/index.md
@@ -1,7 +1,6 @@
 ---
 title: サイト表示互換性に関するノウハウ
 slug: orphaned/Web/Compatibility_FAQ
-original_slug: Web/Compatibility_FAQ
 ---
 
 モバイルデバイスを利用する上で、特定のデバイス／ブラウザに依存せず、どのブラウザでもサイトが正常表示可能な環境が理想的と考えています。

--- a/files/ja/orphaned/web/compatibility_faq/invalid_icon_size.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/invalid_icon_size.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: アイコン、画像が期待と異なるサイズで表示される
 slug: orphaned/Web/Compatibility_FAQ/Invalid_Icon_Size.html
-original_slug: Web/Compatibility_FAQ/Invalid_Icon_Size.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/misaligned_icon.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/misaligned_icon.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: アイコン、画像の表示位置がずれる
 slug: orphaned/Web/Compatibility_FAQ/Misaligned_Icon.html
-original_slug: Web/Compatibility_FAQ/Misaligned_Icon.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/misaligned_text.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/misaligned_text.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: 文字列の表示位置がずれる
 slug: orphaned/Web/Compatibility_FAQ/Misaligned_Text.html
-original_slug: Web/Compatibility_FAQ/Misaligned_Text.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/misaligned_text_inside_icon.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/misaligned_text_inside_icon.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: アイコンの中身が外側にはみ出すなどして形が壊れている
 slug: orphaned/Web/Compatibility_FAQ/Misaligned_Text_Inside_Icon.html
-original_slug: Web/Compatibility_FAQ/Misaligned_Text_Inside_Icon.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/no_background_shown.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/no_background_shown.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: ページの背景色が抜けている
 slug: orphaned/Web/Compatibility_FAQ/No_Background_Shown.html
-original_slug: Web/Compatibility_FAQ/No_Background_Shown.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/no_border_line_shown.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/no_border_line_shown.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: 罫線が表示されない
 slug: orphaned/Web/Compatibility_FAQ/No_Border_Line_Shown.html
-original_slug: Web/Compatibility_FAQ/No_Border_Line_Shown.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/no_checkbox_check_shown.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/no_checkbox_check_shown.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: チェックボックスのレ点が表示されない
 slug: orphaned/Web/Compatibility_FAQ/No_Checkbox_Check_Shown.html
-original_slug: Web/Compatibility_FAQ/No_Checkbox_Check_Shown.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/no_decoreation_shown.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/no_decoreation_shown.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: 枠のシャドウや角丸が抜けている
 slug: orphaned/Web/Compatibility_FAQ/No_Decoreation_Shown.html
-original_slug: Web/Compatibility_FAQ/No_Decoreation_Shown.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/no_icon_shown.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/no_icon_shown.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: アイコンが表示されない
 slug: orphaned/Web/Compatibility_FAQ/No_Icon_Shown.html
-original_slug: Web/Compatibility_FAQ/No_Icon_Shown.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/no_wrap.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/no_wrap.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: 画面外に不要な空白が発生する
 slug: orphaned/Web/Compatibility_FAQ/No_Wrap.html
-original_slug: Web/Compatibility_FAQ/No_Wrap.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/overwrapped_icon.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/overwrapped_icon.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: アイコンが隣接する他のアイコンと重なってしまう
 slug: orphaned/Web/Compatibility_FAQ/Overwrapped_Icon.html
-original_slug: Web/Compatibility_FAQ/Overwrapped_Icon.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/overwrapped_navigation.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/overwrapped_navigation.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: ナビゲーションメニューが他のアイコンと重なって表示されたり、画面からはみ出たりしてしまう
 slug: orphaned/Web/Compatibility_FAQ/Overwrapped_Navigation.html
-original_slug: Web/Compatibility_FAQ/Overwrapped_Navigation.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/tips_default_style_difference.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/tips_default_style_difference.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: ブラウザごとの表示の違い(User-Agent-Stylesheetによる表示差異)
 slug: orphaned/Web/Compatibility_FAQ/Tips_Default_Style_Difference.html
-original_slug: Web/Compatibility_FAQ/Tips_Default_Style_Difference.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/tips_vendor_prefix.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/tips_vendor_prefix.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: mobile版Firefox向けベンダープレフィックス対処方法まとめ
 slug: orphaned/Web/Compatibility_FAQ/Tips_Vendor_Prefix.html
-original_slug: Web/Compatibility_FAQ/Tips_Vendor_Prefix.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/underline_color_diffrence.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/underline_color_diffrence.html/index.md
@@ -1,7 +1,6 @@
 ---
 title: 下線の色が相違している
 slug: orphaned/Web/Compatibility_FAQ/Underline_Color_Diffrence.html
-original_slug: Web/Compatibility_FAQ/Underline_Color_Diffrence.html
 ---
 
 ## 概要

--- a/files/ja/orphaned/web/css/color_value/hexadecimal_rgb/index.md
+++ b/files/ja/orphaned/web/css/color_value/hexadecimal_rgb/index.md
@@ -1,7 +1,6 @@
 ---
 title: 16 進カラー構文
 slug: orphaned/Web/CSS/color_value/hexadecimal_rgb
-original_slug: Web/CSS/color_value/hexadecimal_rgb
 ---
 
 {{CSSRef}}

--- a/files/ja/orphaned/web/css/css_animations/detecting_css_animation_support/index.md
+++ b/files/ja/orphaned/web/css/css_animations/detecting_css_animation_support/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS アニメーション対応の検出
 slug: orphaned/Web/CSS/CSS_Animations/Detecting_CSS_animation_support
-original_slug: Web/CSS/CSS_Animations/Detecting_CSS_animation_support
 ---
 
 {{CSSRef}}

--- a/files/ja/orphaned/web/css/css_properties_reference/index.md
+++ b/files/ja/orphaned/web/css/css_properties_reference/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS プロパティリファレンス
 slug: orphaned/Web/CSS/CSS_Properties_Reference
-original_slug: Web/CSS/CSS_Properties_Reference
 ---
 
 ## 一般的な CSS プロパティリファレンス

--- a/files/ja/orphaned/web/guide/html/using_html_sections_and_outlines/index.md
+++ b/files/ja/orphaned/web/guide/html/using_html_sections_and_outlines/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTML のセクションとアウトラインの使用
 slug: orphaned/Web/Guide/HTML/Using_HTML_sections_and_outlines
-original_slug: Web/Guide/HTML/Using_HTML_sections_and_outlines
 ---
 
 {{HTMLSidebar}}

--- a/files/ja/orphaned/web/guide/localizations_and_character_encodings/index.md
+++ b/files/ja/orphaned/web/guide/localizations_and_character_encodings/index.md
@@ -1,7 +1,6 @@
 ---
 title: ローカライゼーションと文字エンコーディング
 slug: orphaned/Web/Guide/Localizations_and_character_encodings
-original_slug: Web/Guide/Localizations_and_character_encodings
 ---
 
 ブラウザは内部的にテキストを Unicode として処理します。ただし、ネットワークを介してブラウザにテキストを転送するには、文字をバイトで表現する方法 (文字エンコーディング) が使用されます。[HTML 仕様](http://www.whatwg.org/specs/web-apps/current-work/multipage/semantics.html#charset)では、UTF-8 エンコーディング (これはすべての Unicode を表すことができます) の使用を推奨しています。使用されるエンコーディングにかかわらず、Web コンテンツがどのエンコーディングを使用するかを宣言する必要があります。

--- a/files/ja/orphaned/web/javascript/guide/objects_and_properties/index.md
+++ b/files/ja/orphaned/web/javascript/guide/objects_and_properties/index.md
@@ -1,7 +1,6 @@
 ---
 title: オブジェクトとプロパティ
 slug: orphaned/Web/JavaScript/Guide/Objects_and_Properties
-original_slug: Web/JavaScript/Guide/Objects_and_Properties
 ---
 
 ### オブジェクトとプロパティ

--- a/files/ja/orphaned/web/javascript/reference/errors/for-each-in_loops_are_deprecated/index.md
+++ b/files/ja/orphaned/web/javascript/reference/errors/for-each-in_loops_are_deprecated/index.md
@@ -1,7 +1,6 @@
 ---
-title: 'Warning: JavaScript 1.6''s for-each-in loops are deprecated'
+title: "Warning: JavaScript 1.6's for-each-in loops are deprecated"
 slug: orphaned/Web/JavaScript/Reference/Errors/For-each-in_loops_are_deprecated
-original_slug: Web/JavaScript/Reference/Errors/For-each-in_loops_are_deprecated
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/ja/orphaned/web/javascript/reference/errors/typed_array_invalid_arguments/index.md
+++ b/files/ja/orphaned/web/javascript/reference/errors/typed_array_invalid_arguments/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'TypeError: invalid arguments'
+title: "TypeError: invalid arguments"
 slug: orphaned/Web/JavaScript/Reference/Errors/Typed_array_invalid_arguments
 ---
 

--- a/files/ja/orphaned/web/javascript/reference/errors/var_hides_argument/index.md
+++ b/files/ja/orphaned/web/javascript/reference/errors/var_hides_argument/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'TypeError: variable "x" redeclares argument'
 slug: orphaned/Web/JavaScript/Reference/Errors/Var_hides_argument
-original_slug: Web/JavaScript/Reference/Errors/Var_hides_argument
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/ja/orphaned/web/security/information_security_basics/index.md
+++ b/files/ja/orphaned/web/security/information_security_basics/index.md
@@ -1,7 +1,6 @@
 ---
 title: 情報セキュリティの基本
 slug: orphaned/Web/Security/Information_Security_Basics
-original_slug: Web/Security/Information_Security_Basics
 ---
 
 情報セキュリティを基本的に理解しておくことは、ソフトウェアやサイトが危険で脆弱なままで、資産を奪ったりその他の悪意の理由のために弱点を悪用されるのを防ぐのに役立ちます。これらの記事は知るべきことを学ぶのに役立ちます。 この情報から、ウェブ開発を通じて、またそれ以外のコンテンツのデプロイにおいても、セキュリティの役割と重要性に気づくでしょう。

--- a/files/ja/orphaned/web/svg/element/hatchpath/index.md
+++ b/files/ja/orphaned/web/svg/element/hatchpath/index.md
@@ -1,7 +1,6 @@
 ---
 title: <hatchpath>
 slug: orphaned/Web/SVG/Element/hatchpath
-original_slug: Web/SVG/Element/hatchpath
 ---
 
 {{SVGRef}}{{SeeCompatTable}}

--- a/files/ja/orphaned/web/svg/other_resources/index.md
+++ b/files/ja/orphaned/web/svg/other_resources/index.md
@@ -1,7 +1,6 @@
 ---
 title: その他のリソース
 slug: orphaned/Web/SVG/Other_Resources
-original_slug: Web/SVG/Other_Resources
 ---
 
 こちらは SVG の追加リソースの一覧です。

--- a/files/ja/orphaned/web/web_components/status_in_firefox/index.md
+++ b/files/ja/orphaned/web/web_components/status_in_firefox/index.md
@@ -1,7 +1,6 @@
 ---
 title: Firefox での Web Components のサポート状況
 slug: orphaned/Web/Web_Components/Status_in_Firefox
-original_slug: Web/Web_Components/Status_in_Firefox
 ---
 
 {{DefaultAPISidebar("Web Components")}}{{SeeCompatTable}}

--- a/files/ja/orphaned/working_with_windows_in_chrome_code/index.md
+++ b/files/ja/orphaned/working_with_windows_in_chrome_code/index.md
@@ -1,7 +1,6 @@
 ---
 title: window.arguments
 slug: orphaned/Working_with_windows_in_chrome_code
-original_slug: Web/API/Window/arguments
 ---
 
 [『chrome コードでウィンドウを取り扱う』の頁の『ウィンドウ間でのデータのやり取り』の章](/ja/docs/Working_with_windows_in_chrome_code#Passing_data_between_windows)をご覧下さい。


### PR DESCRIPTION
This PR lints and fixes the front matter keys throughout the Japanese locale using the front matter linter, followed by manual fixes as needed.  This specifically performs linting for the `orphaned/` directory.
