### PR TITLE
pt-br: Lint front matter keys for "orphaned"

### DIFF
--- a/files/pt-br/orphaned/games/examples/index.md
+++ b/files/pt-br/orphaned/games/examples/index.md
@@ -1,7 +1,6 @@
 ---
 title: Exemplos
 slug: orphaned/Games/Examples
-original_slug: Games/Examples
 ---
 
 {{GamesSidebar}}

--- a/files/pt-br/orphaned/glossary/dynamic_programming_language/index.md
+++ b/files/pt-br/orphaned/glossary/dynamic_programming_language/index.md
@@ -1,7 +1,6 @@
 ---
 title: Linguagem de programação dinâmica
 slug: orphaned/Glossary/Dynamic_programming_language
-original_slug: Glossary/Dynamic_programming_language
 ---
 
 Uma **linguagem de programação dinâmica** é uma linguagem de programação na qual determinadas operações podem ser feitas em tempo de execução em vez de em tempo de compilação. Por exemplo, em JavaScript é possível mudar o tipo de uma variável ou adicionar novas propriedades ou métodos a um objeto enquanto o programa está sendo executado.

--- a/files/pt-br/orphaned/glossary/jquery/index.md
+++ b/files/pt-br/orphaned/glossary/jquery/index.md
@@ -1,7 +1,6 @@
 ---
 title: jQuery
 slug: orphaned/Glossary/jQuery
-original_slug: Glossary/jQuery
 ---
 
 **jQuery** é uma {{Glossary("Biblioteca")}} {{Glossary("JavaScript")}} que visa a simplificação na manipulação do {{Glossary("DOM")}} , nas chamadas de {{Glossary("AJAX")}} e no gerenciamento de {{Glossary("Eventos")}} . É muito utilizado por desenvolvedores de Javascript.

--- a/files/pt-br/orphaned/mdn/tools/index.md
+++ b/files/pt-br/orphaned/mdn/tools/index.md
@@ -1,7 +1,6 @@
 ---
 title: Ferramentas do MDN
 slug: orphaned/MDN/Tools
-original_slug: MDN/Tools
 ---
 
 {{MDNSidebar}}

--- a/files/pt-br/orphaned/mdn/tools/kumascript/index.md
+++ b/files/pt-br/orphaned/mdn/tools/kumascript/index.md
@@ -1,7 +1,6 @@
 ---
 title: KumaScript
 slug: orphaned/MDN/Tools/KumaScript
-original_slug: MDN/Tools/KumaScript
 ---
 
 {{MDNSidebar}}

--- a/files/pt-br/orphaned/mdn/tools/kumascript/troubleshooting/index.md
+++ b/files/pt-br/orphaned/mdn/tools/kumascript/troubleshooting/index.md
@@ -1,7 +1,6 @@
 ---
 title: Solucionando problemas de erros de KumaScript
 slug: orphaned/MDN/Tools/KumaScript/Troubleshooting
-original_slug: MDN/Tools/KumaScript/Troubleshooting
 ---
 
 {{MDNSidebar}}

--- a/files/pt-br/orphaned/mdn/yari/index.md
+++ b/files/pt-br/orphaned/mdn/yari/index.md
@@ -1,7 +1,6 @@
 ---
-title: 'Kuma: MDN''s wiki platform'
+title: "Kuma: MDN's wiki platform"
 slug: orphaned/MDN/Yari
-original_slug: MDN/Yari
 ---
 
 {{MDNSidebar}}

--- a/files/pt-br/orphaned/mozilla/add-ons/webextensions/prerequisites/index.md
+++ b/files/pt-br/orphaned/mozilla/add-ons/webextensions/prerequisites/index.md
@@ -1,7 +1,6 @@
 ---
 title: Pré-requisitos
 slug: orphaned/Mozilla/Add-ons/WebExtensions/Prerequisites
-original_slug: Mozilla/Add-ons/WebExtensions/Prerequisites
 ---
 
 Para desenvolver utilizando as APIs de uma WebExtension, você precisa de uma configuração mínima.

--- a/files/pt-br/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-describedby_attribute/index.md
+++ b/files/pt-br/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-describedby_attribute/index.md
@@ -1,8 +1,6 @@
 ---
 title: Usando o atributo aria-describedby
-slug: >-
-  orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute
-original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute
+slug: orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute
 ---
 
 ### Descrição

--- a/files/pt-br/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.md
+++ b/files/pt-br/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.md
@@ -1,7 +1,6 @@
 ---
 title: Usando o atributo aria-label
 slug: orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
-original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
 ---
 
 O atributo [`aria-label`](https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-label) é usado para definir uma _string_ na _tag_ do elemento atual. Use nos casos que a _tag_ do texto não seja visível na tela. Se há texto visível na _tag_ do elemento, usa [aria-labelledby](/en/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute "Using the aria-labelledby attribute") em vez.

--- a/files/pt-br/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-labelledby_attribute/index.md
+++ b/files/pt-br/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-labelledby_attribute/index.md
@@ -1,8 +1,6 @@
 ---
 title: Usando o atributo aria-labelledby
-slug: >-
-  orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute
-original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute
+slug: orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute
 ---
 
 ### Descrição

--- a/files/pt-br/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-required_attribute/index.md
+++ b/files/pt-br/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-required_attribute/index.md
@@ -1,8 +1,6 @@
 ---
 title: Usando o atributo aria-required
-slug: >-
-  orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute
-original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute
+slug: orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute
 ---
 
 ### Descrição

--- a/files/pt-br/orphaned/web/api/canvas_api/a_basic_ray-caster/index.md
+++ b/files/pt-br/orphaned/web/api/canvas_api/a_basic_ray-caster/index.md
@@ -1,7 +1,6 @@
 ---
 title: A basic ray-caster
 slug: orphaned/Web/API/Canvas_API/A_basic_ray-caster
-original_slug: Web/API/Canvas_API/A_basic_ray-caster
 ---
 
 {{DefaultAPISidebar("Canvas API")}}

--- a/files/pt-br/orphaned/web/api/fullscreenoptions/index.md
+++ b/files/pt-br/orphaned/web/api/fullscreenoptions/index.md
@@ -1,7 +1,6 @@
 ---
 title: FullscreenOptions
 slug: orphaned/Web/API/FullscreenOptions
-original_slug: Web/API/FullscreenOptions
 ---
 
 {{APIRef("Fullscreen API")}}

--- a/files/pt-br/orphaned/web/api/globaleventhandlers/index.md
+++ b/files/pt-br/orphaned/web/api/globaleventhandlers/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers
 slug: orphaned/Web/API/GlobalEventHandlers
-original_slug: Web/API/GlobalEventHandlers
 ---
 
 {{ApiRef("HTML DOM")}}

--- a/files/pt-br/orphaned/web/api/htmlelement/contextmenu/index.md
+++ b/files/pt-br/orphaned/web/api/htmlelement/contextmenu/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLElement.contextMenu
 slug: orphaned/Web/API/HTMLElement/contextMenu
-original_slug: Web/API/HTMLElement/contextMenu
 ---
 
 {{APIRef("HTML DOM")}}{{deprecated_header()}}

--- a/files/pt-br/orphaned/web/api/htmlorforeignelement/blur/index.md
+++ b/files/pt-br/orphaned/web/api/htmlorforeignelement/blur/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLElement.blur()
 slug: orphaned/Web/API/HTMLOrForeignElement/blur
-original_slug: Web/API/HTMLOrForeignElement/blur
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/pt-br/orphaned/web/api/htmlorforeignelement/focus/index.md
+++ b/files/pt-br/orphaned/web/api/htmlorforeignelement/focus/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLElement.focus()
 slug: orphaned/Web/API/HTMLOrForeignElement/focus
-original_slug: Web/API/HTMLOrForeignElement/focus
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/pt-br/orphaned/web/api/htmlshadowelement/index.md
+++ b/files/pt-br/orphaned/web/api/htmlshadowelement/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLShadowElement
 slug: orphaned/Web/API/HTMLShadowElement
-original_slug: Web/API/HTMLShadowElement
 ---
 
 {{ APIRef("Web Components") }}

--- a/files/pt-br/orphaned/web/api/navigatorid/index.md
+++ b/files/pt-br/orphaned/web/api/navigatorid/index.md
@@ -1,7 +1,6 @@
 ---
 title: NavigatorID
 slug: orphaned/Web/API/NavigatorID
-original_slug: Web/API/NavigatorID
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/pt-br/orphaned/web/api/navigatorid/platform/index.md
+++ b/files/pt-br/orphaned/web/api/navigatorid/platform/index.md
@@ -1,7 +1,6 @@
 ---
 title: NavigatorID.platform
 slug: orphaned/Web/API/NavigatorID/platform
-original_slug: Web/API/NavigatorID/platform
 ---
 
 {{ ApiRef("HTML DOM") }}

--- a/files/pt-br/orphaned/web/api/navigatorid/useragent/index.md
+++ b/files/pt-br/orphaned/web/api/navigatorid/useragent/index.md
@@ -1,7 +1,6 @@
 ---
 title: NavigatorID.userAgent
 slug: orphaned/Web/API/NavigatorID/userAgent
-original_slug: Web/API/NavigatorID/userAgent
 ---
 
 {{ApiRef("HTML DOM")}}

--- a/files/pt-br/orphaned/web/api/navigatorlanguage/index.md
+++ b/files/pt-br/orphaned/web/api/navigatorlanguage/index.md
@@ -1,7 +1,6 @@
 ---
 title: NavigatorLanguage
 slug: orphaned/Web/API/NavigatorLanguage
-original_slug: Web/API/NavigatorLanguage
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/pt-br/orphaned/web/api/navigatorlanguage/language/index.md
+++ b/files/pt-br/orphaned/web/api/navigatorlanguage/language/index.md
@@ -1,7 +1,6 @@
 ---
 title: NavigatorLanguage.language
 slug: orphaned/Web/API/NavigatorLanguage/language
-original_slug: Web/API/NavigatorLanguage/language
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/pt-br/orphaned/web/api/navigatoronline/index.md
+++ b/files/pt-br/orphaned/web/api/navigatoronline/index.md
@@ -1,7 +1,6 @@
 ---
 title: NavigatorOnLine
 slug: orphaned/Web/API/NavigatorOnLine
-original_slug: Web/API/NavigatorOnLine
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/pt-br/orphaned/web/api/navigatoronline/online/index.md
+++ b/files/pt-br/orphaned/web/api/navigatoronline/online/index.md
@@ -1,7 +1,6 @@
 ---
 title: Navigator.onLine
 slug: orphaned/Web/API/NavigatorOnLine/onLine
-original_slug: Web/API/NavigatorOnLine/onLine
 ---
 
 {{ApiRef("HTML DOM")}}

--- a/files/pt-br/orphaned/web/api/navigatoronline/online_and_offline_events/index.md
+++ b/files/pt-br/orphaned/web/api/navigatoronline/online_and_offline_events/index.md
@@ -1,7 +1,6 @@
 ---
 title: Eventos on-line e off-line
 slug: orphaned/Web/API/NavigatorOnLine/Online_and_offline_events
-original_slug: Web/API/NavigatorOnLine/Online_and_offline_events
 ---
 
 IAlguns navegadores utilizam [Online/Offline events](http://www.whatwg.org/specs/web-apps/current-work/#offline) relacionados à [WHATWG Web Applications 1.0 specification](http://www.whatwg.org/specs/web-apps/current-work/).

--- a/files/pt-br/orphaned/web/api/navigatorplugins/index.md
+++ b/files/pt-br/orphaned/web/api/navigatorplugins/index.md
@@ -1,7 +1,6 @@
 ---
 title: NavigatorPlugins
 slug: orphaned/Web/API/NavigatorPlugins
-original_slug: Web/API/NavigatorPlugins
 ---
 
 {{APIRef("HTML DOM")}}{{SeeCompatTable}}

--- a/files/pt-br/orphaned/web/api/navigatorplugins/javaenabled/index.md
+++ b/files/pt-br/orphaned/web/api/navigatorplugins/javaenabled/index.md
@@ -1,7 +1,6 @@
 ---
 title: NavigatorPlugins.javaEnabled()
 slug: orphaned/Web/API/NavigatorPlugins/javaEnabled
-original_slug: Web/API/NavigatorPlugins/javaEnabled
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/pt-br/orphaned/web/api/notificationaction/index.md
+++ b/files/pt-br/orphaned/web/api/notificationaction/index.md
@@ -1,7 +1,6 @@
 ---
 title: NotificationAction
 slug: orphaned/Web/API/NotificationAction
-original_slug: Web/API/NotificationAction
 ---
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/pt-br/orphaned/web/api/window/applicationcache/index.md
+++ b/files/pt-br/orphaned/web/api/window/applicationcache/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.applicationCache
 slug: orphaned/Web/API/Window/applicationCache
-original_slug: Web/API/Window/applicationCache
 ---
 
 {{APIRef}}

--- a/files/pt-br/orphaned/web/api/window/setcursor/index.md
+++ b/files/pt-br/orphaned/web/api/window/setcursor/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.setCursor()
 slug: orphaned/Web/API/Window/setCursor
-original_slug: Web/API/Window/setCursor
 ---
 
 {{ ApiRef() }}

--- a/files/pt-br/orphaned/web/api/windoweventhandlers/index.md
+++ b/files/pt-br/orphaned/web/api/windoweventhandlers/index.md
@@ -1,7 +1,6 @@
 ---
 title: WindowEventHandlers
 slug: orphaned/Web/API/WindowEventHandlers
-original_slug: Web/API/WindowEventHandlers
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/pt-br/orphaned/web/api/windoworworkerglobalscope/index.md
+++ b/files/pt-br/orphaned/web/api/windoworworkerglobalscope/index.md
@@ -1,7 +1,6 @@
 ---
 title: WindowOrWorkerGlobalScope
 slug: orphaned/Web/API/WindowOrWorkerGlobalScope
-original_slug: Web/API/WindowOrWorkerGlobalScope
 ---
 
 {{ApiRef()}}

--- a/files/pt-br/orphaned/web/css/-moz-context-properties/index.md
+++ b/files/pt-br/orphaned/web/css/-moz-context-properties/index.md
@@ -1,7 +1,6 @@
 ---
-title: '-moz-context-properties'
+title: "-moz-context-properties"
 slug: orphaned/Web/CSS/-moz-context-properties
-original_slug: Web/CSS/-moz-context-properties
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/pt-br/orphaned/web/css/css_animations/detecting_css_animation_support/index.md
+++ b/files/pt-br/orphaned/web/css/css_animations/detecting_css_animation_support/index.md
@@ -1,7 +1,6 @@
 ---
 title: Detectando suporte a animação CSS
 slug: orphaned/Web/CSS/CSS_Animations/Detecting_CSS_animation_support
-original_slug: Web/CSS/CSS_Animations/Detecting_CSS_animation_support
 ---
 
 {{CSSRef}}

--- a/files/pt-br/orphaned/web/css/microsoft_extensions/index.md
+++ b/files/pt-br/orphaned/web/css/microsoft_extensions/index.md
@@ -1,7 +1,6 @@
 ---
 title: Extensões CSS da Microsoft
 slug: orphaned/Web/CSS/Microsoft_Extensions
-original_slug: Web/CSS/Microsoft_Extensions
 ---
 
 {{CSSRef}}

--- a/files/pt-br/orphaned/web/html/element/applet/index.md
+++ b/files/pt-br/orphaned/web/html/element/applet/index.md
@@ -1,7 +1,6 @@
 ---
 title: <applet>
 slug: orphaned/Web/HTML/Element/applet
-original_slug: Web/HTML/Element/applet
 ---
 
 ## Resumo

--- a/files/pt-br/orphaned/web/html/element/blink/index.md
+++ b/files/pt-br/orphaned/web/html/element/blink/index.md
@@ -1,7 +1,6 @@
 ---
 title: <blink>
 slug: orphaned/Web/HTML/Element/blink
-original_slug: Web/HTML/Element/blink
 ---
 
 {{Deprecated_header}} {{Non-standard_header}}

--- a/files/pt-br/orphaned/web/http/feature_policy/using_feature_policy/index.md
+++ b/files/pt-br/orphaned/web/http/feature_policy/using_feature_policy/index.md
@@ -1,7 +1,6 @@
 ---
 title: Using Feature Policy
 slug: orphaned/Web/HTTP/Feature_Policy/Using_Feature_Policy
-original_slug: Web/HTTP/Feature_Policy/Using_Feature_Policy
 ---
 
 {{HTTPSidebar}}

--- a/files/pt-br/orphaned/web/http/headers/set-cookie/samesite/index.md
+++ b/files/pt-br/orphaned/web/http/headers/set-cookie/samesite/index.md
@@ -1,7 +1,6 @@
 ---
 title: SameSite cookies
 slug: orphaned/Web/HTTP/Headers/Set-Cookie/SameSite
-original_slug: Web/HTTP/Headers/Set-Cookie/SameSite
 ---
 
 O atributo **`SameSite`** do {{HTTPHeader("Set-Cookie")}} . O cabeçalho de resposta HTTP permite que você declare se o seu cookie deve ser restrito a um contexto de primeira ou mesma parte.

--- a/files/pt-br/orphaned/web/javascript/guide/working_with_private_class_features/index.md
+++ b/files/pt-br/orphaned/web/javascript/guide/working_with_private_class_features/index.md
@@ -1,7 +1,6 @@
 ---
 title: Trabalhando com recursos de classe privada.
 slug: orphaned/Web/JavaScript/Guide/Working_With_Private_Class_Features
-original_slug: Web/JavaScript/Guide/Working_With_Private_Class_Features
 ---
 
 {{jsSidebar("JavaScript Guide")}}

--- a/files/pt-br/orphaned/web/javascript/reference/errors/for-each-in_loops_are_deprecated/index.md
+++ b/files/pt-br/orphaned/web/javascript/reference/errors/for-each-in_loops_are_deprecated/index.md
@@ -1,7 +1,6 @@
 ---
-title: 'Warning: JavaScript 1.6''s for-each-in loops are deprecated'
+title: "Warning: JavaScript 1.6's for-each-in loops are deprecated"
 slug: orphaned/Web/JavaScript/Reference/Errors/For-each-in_loops_are_deprecated
-original_slug: Web/JavaScript/Reference/Errors/For-each-in_loops_are_deprecated
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/pt-br/orphaned/web/svg/element/altglyph/index.md
+++ b/files/pt-br/orphaned/web/svg/element/altglyph/index.md
@@ -1,7 +1,6 @@
 ---
 title: altGlyph
 slug: orphaned/Web/SVG/Element/altGlyph
-original_slug: Web/SVG/Element/altGlyph
 ---
 
 {{SVGRef}}

--- a/files/pt-br/orphaned/web/svg/element/altglyphdef/index.md
+++ b/files/pt-br/orphaned/web/svg/element/altglyphdef/index.md
@@ -1,7 +1,6 @@
 ---
 title: altGlyphDef
 slug: orphaned/Web/SVG/Element/altGlyphDef
-original_slug: Web/SVG/Element/altGlyphDef
 ---
 
 {{SVGRef}}

--- a/files/pt-br/orphaned/web/svg/element/altglyphitem/index.md
+++ b/files/pt-br/orphaned/web/svg/element/altglyphitem/index.md
@@ -1,7 +1,6 @@
 ---
 title: altGlyphItem
 slug: orphaned/Web/SVG/Element/altGlyphItem
-original_slug: Web/SVG/Element/altGlyphItem
 ---
 
 {{SVGRef}}


### PR DESCRIPTION
This PR lints and fixes the front matter keys throughout the Brazilian Portuguese locale using the front matter linter, followed by manual fixes as needed.  This specifically performs linting for the `orphaned/` directory.
