### PR TITLE
pt-br: Lint front matter keys for "conflicting"

### DIFF
--- a/files/pt-br/conflicting/learn/index.md
+++ b/files/pt-br/conflicting/learn/index.md
@@ -1,7 +1,6 @@
 ---
 title: Learning area release notes
 slug: conflicting/Learn
-original_slug: Learn/Release_notes
 ---
 
 {{learnsidebar}}

--- a/files/pt-br/conflicting/learn/javascript/asynchronous/introducing/index.md
+++ b/files/pt-br/conflicting/learn/javascript/asynchronous/introducing/index.md
@@ -1,7 +1,6 @@
 ---
 title: Conceitos gerais da programação assíncrona
 slug: conflicting/Learn/JavaScript/Asynchronous/Introducing
-original_slug: Learn/JavaScript/Asynchronous/Concepts
 ---
 
 {{LearnSidebar}}{{NextMenu("Learn/JavaScript/Asynchronous/Introducing", "Learn/JavaScript/Asynchronous")}}

--- a/files/pt-br/conflicting/learn/javascript/asynchronous/promises/index.md
+++ b/files/pt-br/conflicting/learn/javascript/asynchronous/promises/index.md
@@ -1,7 +1,6 @@
 ---
 title: Tornando mais fácil a programação assíncrona com async e await
 slug: conflicting/Learn/JavaScript/Asynchronous/Promises
-original_slug: Learn/JavaScript/Asynchronous/Async_await
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Asynchronous/Promises", "Learn/JavaScript/Choosing_the_right_approach", "Learn/JavaScript/Asynchronous")}}

--- a/files/pt-br/conflicting/learn/javascript/asynchronous_ae5a561b0ec11fc53c167201aa8af5df/index.md
+++ b/files/pt-br/conflicting/learn/javascript/asynchronous_ae5a561b0ec11fc53c167201aa8af5df/index.md
@@ -1,7 +1,6 @@
 ---
 title: Timeouts e intervalos
 slug: conflicting/Learn/JavaScript/Asynchronous_ae5a561b0ec11fc53c167201aa8af5df
-original_slug: Learn/JavaScript/Asynchronous/Timeouts_and_intervals
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Asynchronous/Introducing", "Learn/JavaScript/Asynchronous/Promises", "Learn/JavaScript/Asynchronous")}}

--- a/files/pt-br/conflicting/learn/javascript/objects/classes_in_javascript/index.md
+++ b/files/pt-br/conflicting/learn/javascript/objects/classes_in_javascript/index.md
@@ -1,7 +1,6 @@
 ---
 title: JavaScript orientado a objetos para iniciantes
 slug: conflicting/Learn/JavaScript/Objects/Classes_in_JavaScript
-original_slug: Learn/JavaScript/Objects/Object-oriented_JS
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Basics", "Learn/JavaScript/Objects/Object_prototypes", "Learn/JavaScript/Objects")}}

--- a/files/pt-br/conflicting/learn/server-side/express_nodejs/displaying_data/index.md
+++ b/files/pt-br/conflicting/learn/server-side/express_nodejs/displaying_data/index.md
@@ -1,7 +1,6 @@
 ---
 title: Controle de fluxo assíncrono usando async
 slug: conflicting/Learn/Server-side/Express_Nodejs/Displaying_data
-original_slug: Learn/Server-side/Express_Nodejs/Displaying_data/flow_control_using_async
 ---
 
 O código da _Controller_, para algumas de nossas páginas dependerá dos resultados de várias solicitações assíncronas, que talvez possam ser necessárias para serem executadas em uma ordem específica ou em paralelo. Para gerenciar o controle do nosso fluxo e renderizar páginas quando tivermos todas as informações necessárias disponíveis, usaremos o popular módulo [async](https://www.npmjs.com/package/async).

--- a/files/pt-br/conflicting/mdn/community/contributing/getting_started/index.md
+++ b/files/pt-br/conflicting/mdn/community/contributing/getting_started/index.md
@@ -1,7 +1,6 @@
 ---
 title: GitHub para iniciantes
 slug: conflicting/MDN/Community/Contributing/Getting_started
-original_slug: MDN/Contribute/GitHub_beginners
 ---
 
 {{MDNSidebar}}

--- a/files/pt-br/conflicting/mdn/contribute/howto/create_an_interactive_exercise_to_help_learning_the_web/index.md
+++ b/files/pt-br/conflicting/mdn/contribute/howto/create_an_interactive_exercise_to_help_learning_the_web/index.md
@@ -1,9 +1,6 @@
 ---
 title: distant example
-slug: >-
-  conflicting/MDN/Contribute/Howto/Create_an_interactive_exercise_to_help_learning_the_web
-original_slug: >-
-  MDN/Contribute/Howto/Create_an_interactive_exercise_to_help_learning_the_web/distant_example
+slug: conflicting/MDN/Contribute/Howto/Create_an_interactive_exercise_to_help_learning_the_web
 ---
 
 {{MDNSidebar}}

--- a/files/pt-br/conflicting/mdn/contribute/index.md
+++ b/files/pt-br/conflicting/mdn/contribute/index.md
@@ -1,7 +1,6 @@
 ---
 title: Guia de contribuição
 slug: conflicting/MDN/Contribute
-original_slug: MDN/Contribute/Howto
 ---
 
 {{MDNSidebar}}

--- a/files/pt-br/conflicting/mdn/writing_guidelines/index.md
+++ b/files/pt-br/conflicting/mdn/writing_guidelines/index.md
@@ -1,7 +1,6 @@
 ---
 title: MDN content and style guides
 slug: conflicting/MDN/Writing_guidelines
-original_slug: MDN/Guidelines
 ---
 
 {{MDNSidebar}}

--- a/files/pt-br/conflicting/mdn/writing_guidelines/page_structures/index.md
+++ b/files/pt-br/conflicting/mdn/writing_guidelines/page_structures/index.md
@@ -1,7 +1,6 @@
 ---
 title: Estruturas dos documentos
 slug: conflicting/MDN/Writing_guidelines/Page_structures
-original_slug: MDN/Structures
 ---
 
 {{MDNSidebar}}

--- a/files/pt-br/conflicting/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/pt-br/conflicting/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -1,7 +1,6 @@
 ---
 title: Como criar um exercício de aprendizado interativo
 slug: conflicting/MDN/Writing_guidelines/Page_structures/Live_samples
-original_slug: MDN/Contribute/Howto/Create_an_interactive_exercise_to_help_learning_the_web
 ---
 
 {{MDNSidebar}}

--- a/files/pt-br/conflicting/mdn/writing_guidelines/page_structures_978c99f4f82eae196d51ce675e5181c7/index.md
+++ b/files/pt-br/conflicting/mdn/writing_guidelines/page_structures_978c99f4f82eae196d51ce675e5181c7/index.md
@@ -1,8 +1,6 @@
 ---
 title: Macros
-slug: >-
-  conflicting/MDN/Writing_guidelines/Page_structures_978c99f4f82eae196d51ce675e5181c7
-original_slug: MDN/Structures/Macros
+slug: conflicting/MDN/Writing_guidelines/Page_structures_978c99f4f82eae196d51ce675e5181c7
 ---
 
 {{MDNSidebar}}

--- a/files/pt-br/conflicting/web/accessibility/aria/index.md
+++ b/files/pt-br/conflicting/web/accessibility/aria/index.md
@@ -1,7 +1,6 @@
 ---
 title: Alerts
 slug: conflicting/Web/Accessibility/ARIA
-original_slug: Web/Accessibility/ARIA/forms/alerts
 ---
 
 ## O problema

--- a/files/pt-br/conflicting/web/accessibility/aria_184f054b1090ff5cd518146ac4e09122/index.md
+++ b/files/pt-br/conflicting/web/accessibility/aria_184f054b1090ff5cd518146ac4e09122/index.md
@@ -1,7 +1,6 @@
 ---
 title: Aplicações web e ARIA - Perguntas Frequentes (FAQ)
 slug: conflicting/Web/Accessibility/ARIA_184f054b1090ff5cd518146ac4e09122
-original_slug: Web/Accessibility/ARIA/Web_applications_and_ARIA_FAQ
 ---
 
 ## O que significa ARIA?

--- a/files/pt-br/conflicting/web/accessibility/aria_229a3bbc8da83524de32990b14561155/index.md
+++ b/files/pt-br/conflicting/web/accessibility/aria_229a3bbc8da83524de32990b14561155/index.md
@@ -1,7 +1,6 @@
 ---
 title: widgets
 slug: conflicting/Web/Accessibility/ARIA_229a3bbc8da83524de32990b14561155
-original_slug: Web/Accessibility/ARIA/widgets
 ---
 
 This page was auto-generated because a user created a sub-page to this page.

--- a/files/pt-br/conflicting/web/accessibility/aria_44f49c8e1fe8e4c12920395d890bd793/index.md
+++ b/files/pt-br/conflicting/web/accessibility/aria_44f49c8e1fe8e4c12920395d890bd793/index.md
@@ -1,7 +1,6 @@
 ---
 title: Formulários
 slug: conflicting/Web/Accessibility/ARIA_44f49c8e1fe8e4c12920395d890bd793
-original_slug: Web/Accessibility/ARIA/forms
 ---
 
 As páginas a seguir fornecem várias técnicas para melhorar a acessibilidade nos formulários _web_:

--- a/files/pt-br/conflicting/web/accessibility/aria_64707ba1917a56654679cbe273e2f4ea/index.md
+++ b/files/pt-br/conflicting/web/accessibility/aria_64707ba1917a56654679cbe273e2f4ea/index.md
@@ -1,7 +1,6 @@
 ---
 title: Dicas básicas de form
 slug: conflicting/Web/Accessibility/ARIA_64707ba1917a56654679cbe273e2f4ea
-original_slug: Web/Accessibility/ARIA/forms/Basic_form_hints
 ---
 
 ## Form labels

--- a/files/pt-br/conflicting/web/api/animationevent/animationevent/index.md
+++ b/files/pt-br/conflicting/web/api/animationevent/animationevent/index.md
@@ -1,7 +1,6 @@
 ---
 title: AnimationEvent.initAnimationEvent()
 slug: conflicting/Web/API/AnimationEvent/AnimationEvent
-original_slug: Web/API/AnimationEvent/initAnimationEvent
 ---
 
 {{non-standard_header}}{{ apiref("Web Animations API") }}

--- a/files/pt-br/conflicting/web/api/customelementregistry/define/index.md
+++ b/files/pt-br/conflicting/web/api/customelementregistry/define/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.registerElement()
 slug: conflicting/Web/API/CustomElementRegistry/define
-original_slug: Web/API/Document/registerElement
 ---
 
 {{APIRef("DOM")}}

--- a/files/pt-br/conflicting/web/api/element/click_event/index.md
+++ b/files/pt-br/conflicting/web/api/element/click_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onclick
 slug: conflicting/Web/API/Element/click_event
-original_slug: Web/API/GlobalEventHandlers/onclick
 ---
 
 {{ ApiRef("HTML DOM") }}

--- a/files/pt-br/conflicting/web/api/element/keyup_event/index.md
+++ b/files/pt-br/conflicting/web/api/element/keyup_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onkeyup
 slug: conflicting/Web/API/Element/keyup_event
-original_slug: Web/API/GlobalEventHandlers/onkeyup
 ---
 
 {{ApiRef("HTML DOM")}}

--- a/files/pt-br/conflicting/web/api/element/keyup_event_c3958d9a752bb3f2d72ac974b4e226ea/index.md
+++ b/files/pt-br/conflicting/web/api/element/keyup_event_c3958d9a752bb3f2d72ac974b4e226ea/index.md
@@ -1,7 +1,6 @@
 ---
-title: 'Document: keyup event'
+title: "Document: keyup event"
 slug: conflicting/Web/API/Element/keyup_event_c3958d9a752bb3f2d72ac974b4e226ea
-original_slug: Web/API/Document/keyup_event
 ---
 
 {{APIRef}}

--- a/files/pt-br/conflicting/web/api/eventtarget/addeventlistener/index.md
+++ b/files/pt-br/conflicting/web/api/eventtarget/addeventlistener/index.md
@@ -1,7 +1,6 @@
 ---
 title: EventListener
 slug: conflicting/Web/API/EventTarget/addEventListener
-original_slug: Web/API/EventListener
 ---
 
 {{APIRef("DOM Events")}}

--- a/files/pt-br/conflicting/web/api/geolocation/getcurrentposition/index.md
+++ b/files/pt-br/conflicting/web/api/geolocation/getcurrentposition/index.md
@@ -1,7 +1,6 @@
 ---
 title: PositionOptions
 slug: conflicting/Web/API/Geolocation/getCurrentPosition
-original_slug: Web/API/PositionOptions
 ---
 
 {{APIRef("Geolocation API")}}A interface **`PositionOptions`** consiste em um objeto que contém propriedades opcionais para passar como um parâmetro de {{domxref("Geolocation.getCurrentPosition()")}} e {{domxref("Geolocation.watchPosition()")}}.

--- a/files/pt-br/conflicting/web/api/htmlmediaelement/abort_event/index.md
+++ b/files/pt-br/conflicting/web/api/htmlmediaelement/abort_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onabort
 slug: conflicting/Web/API/HTMLMediaElement/abort_event
-original_slug: Web/API/GlobalEventHandlers/onabort
 ---
 
 {{ ApiRef("HTML DOM") }}

--- a/files/pt-br/conflicting/web/api/htmlslotelement/index.md
+++ b/files/pt-br/conflicting/web/api/htmlslotelement/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLContentElement
 slug: conflicting/Web/API/HTMLSlotElement
-original_slug: Web/API/HTMLContentElement
 ---
 
 {{ APIRef("Web Components") }}

--- a/files/pt-br/conflicting/web/api/htmlslotelement_ded38e17cacb3809f7af4fec22adcc56/index.md
+++ b/files/pt-br/conflicting/web/api/htmlslotelement_ded38e17cacb3809f7af4fec22adcc56/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLContentElement.select
 slug: conflicting/Web/API/HTMLSlotElement_ded38e17cacb3809f7af4fec22adcc56
-original_slug: Web/API/HTMLContentElement/select
 ---
 
 {{ APIRef("Web Components") }}

--- a/files/pt-br/conflicting/web/api/window/index.md
+++ b/files/pt-br/conflicting/web/api/window/index.md
@@ -1,7 +1,6 @@
 ---
 title: window.openDialog
 slug: conflicting/Web/API/Window
-original_slug: Web/API/Window/openDialog
 ---
 
 {{ ApiRef() }}

--- a/files/pt-br/conflicting/web/api/window/load_event/index.md
+++ b/files/pt-br/conflicting/web/api/window/load_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onload
 slug: conflicting/Web/API/Window/load_event
-original_slug: Web/API/GlobalEventHandlers/onload
 ---
 
 {{ApiRef("HTML DOM")}}

--- a/files/pt-br/conflicting/web/api/window/popstate_event/index.md
+++ b/files/pt-br/conflicting/web/api/window/popstate_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: WindowEventHandlers.onpopstate
 slug: conflicting/Web/API/Window/popstate_event
-original_slug: Web/API/WindowEventHandlers/onpopstate
 ---
 
 {{APIRef}}

--- a/files/pt-br/conflicting/web/api/xmldocument/index.md
+++ b/files/pt-br/conflicting/web/api/xmldocument/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.async
 slug: conflicting/Web/API/XMLDocument
-original_slug: Web/API/XMLDocument/async
 ---
 
 {{APIRef("DOM")}}{{Deprecated_header}} {{Non-standard_header}}

--- a/files/pt-br/conflicting/web/css/index.md
+++ b/files/pt-br/conflicting/web/css/index.md
@@ -1,7 +1,6 @@
 ---
 title: Ferramentas
 slug: conflicting/Web/CSS
-original_slug: Web/CSS/Tools
 ---
 
 O CSS oferece diversos recursos poderosos e um grande número de parâmetros que, às vezes, podem ser difíceis de usar. Então, é bem melhor quando você pode visualizá-los enquanto trabalha com eles.

--- a/files/pt-br/conflicting/web/guide/ajax/index.md
+++ b/files/pt-br/conflicting/web/guide/ajax/index.md
@@ -1,7 +1,6 @@
 ---
 title: Primeiros passos
 slug: conflicting/Web/Guide/AJAX
-original_slug: Web/Guide/AJAX/Getting_Started
 ---
 
 Esse artigo guia você através dos princípios do AJAX e oferece dois exemplos práticos simples para poder começar.

--- a/files/pt-br/conflicting/web/html/global_attributes/contenteditable/index.md
+++ b/files/pt-br/conflicting/web/html/global_attributes/contenteditable/index.md
@@ -1,7 +1,6 @@
 ---
 title: Content Editable
 slug: conflicting/Web/HTML/Global_attributes/contenteditable
-original_slug: Web/Guide/HTML/Editable_content
 ---
 
 No HTML5 qualquer elemento pode ser editado. Usando alguns eventos de JavaScript podemos transformar sua web page em um editor de texto completo e rápido. Este artigo fornece algumas informações sobre esta funcionalidade.

--- a/files/pt-br/conflicting/web/http/headers/cookie/index.md
+++ b/files/pt-br/conflicting/web/http/headers/cookie/index.md
@@ -1,7 +1,6 @@
 ---
 title: Cookie2
 slug: conflicting/Web/HTTP/Headers/Cookie
-original_slug: Web/HTTP/Headers/Cookie2
 ---
 
 {{HTTPSidebar}}

--- a/files/pt-br/conflicting/web/http/headers/expect-ct/index.md
+++ b/files/pt-br/conflicting/web/http/headers/expect-ct/index.md
@@ -1,7 +1,6 @@
 ---
 title: Public-Key-Pins
 slug: conflicting/Web/HTTP/Headers/Expect-CT
-original_slug: Web/HTTP/Headers/Public-Key-Pins
 ---
 
 {{HTTPSidebar}}{{deprecated_header}}

--- a/files/pt-br/conflicting/web/http/headers/expect-ct_63e560324d2c47190db4456d746ba07b/index.md
+++ b/files/pt-br/conflicting/web/http/headers/expect-ct_63e560324d2c47190db4456d746ba07b/index.md
@@ -1,7 +1,6 @@
 ---
 title: Public-Key-Pins-Report-Only
 slug: conflicting/Web/HTTP/Headers/Expect-CT_63e560324d2c47190db4456d746ba07b
-original_slug: Web/HTTP/Headers/Public-Key-Pins-Report-Only
 ---
 
 {{HTTPSidebar}}{{deprecated_header}}

--- a/files/pt-br/conflicting/web/http/headers/set-cookie/index.md
+++ b/files/pt-br/conflicting/web/http/headers/set-cookie/index.md
@@ -1,7 +1,6 @@
 ---
 title: Set-Cookie2
 slug: conflicting/Web/HTTP/Headers/Set-Cookie
-original_slug: Web/HTTP/Headers/Set-Cookie2
 ---
 
 {{HTTPSidebar}}

--- a/files/pt-br/conflicting/web/http/status/404/index.md
+++ b/files/pt-br/conflicting/web/http/status/404/index.md
@@ -1,7 +1,6 @@
 ---
-title: '404'
+title: "404"
 slug: conflicting/Web/HTTP/Status/404
-original_slug: Glossary/404
 ---
 
 O 404 é um código de resposta padrão que significa que o {{Glossary("Server", "server")}} não consegue encontrar o recurso solicitado.

--- a/files/pt-br/conflicting/web/http/status/502/index.md
+++ b/files/pt-br/conflicting/web/http/status/502/index.md
@@ -1,7 +1,6 @@
 ---
-title: '502'
+title: "502"
 slug: conflicting/Web/HTTP/Status/502
-original_slug: Glossary/502
 ---
 
 Um erro {{Glossary("HTTP")}} que significa "Bad Gateway".

--- a/files/pt-br/conflicting/web/javascript/index.md
+++ b/files/pt-br/conflicting/web/javascript/index.md
@@ -1,7 +1,6 @@
 ---
 title: Sobre JavaScript
 slug: conflicting/Web/JavaScript
-original_slug: Web/JavaScript/About_JavaScript
 ---
 
 {{JsSidebar}}

--- a/files/pt-br/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/pt-br/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -1,7 +1,6 @@
 ---
 title: Detalhes do modelo de objeto
 slug: conflicting/Web/JavaScript/Inheritance_and_the_prototype_chain
-original_slug: Web/JavaScript/Guide/Details_of_the_Object_Model
 ---
 
 JavaScript é uma linguagem orientada a objetos com base em protótipos, em vez de ser baseada em classes. Devido a essa base diferente, pode ser menos evidente como o JavaScript permite criar hierarquias de objetos e ter herança de propriedades e seus valores. Este capítulo tenta esclarecer essa situação.

--- a/files/pt-br/conflicting/web/javascript/javascript_technologies_overview/index.md
+++ b/files/pt-br/conflicting/web/javascript/javascript_technologies_overview/index.md
@@ -1,7 +1,6 @@
 ---
 title: Recursos de linguagem JavaScript
 slug: conflicting/Web/JavaScript/JavaScript_technologies_overview
-original_slug: Web/JavaScript/Language_Resources
 ---
 
 {{JsSidebar}}

--- a/files/pt-br/conflicting/web/javascript/reference/deprecated_and_obsolete_features/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/deprecated_and_obsolete_features/index.md
@@ -1,7 +1,6 @@
 ---
 title: "Warning: String.x é depreciado; use String.prototype.x em vez disso"
 slug: conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features
-original_slug: Web/JavaScript/Reference/Errors/Deprecated_String_generics
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/pt-br/conflicting/web/javascript/reference/errors/unexpected_type/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/errors/unexpected_type/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'TypeError: can''t access property "x" of "y"'
 slug: conflicting/Web/JavaScript/Reference/Errors/Unexpected_type
-original_slug: Web/JavaScript/Reference/Errors/Cant_access_property
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/array/tostring/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/array/tostring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Array.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Array/toString
-original_slug: Web/JavaScript/Reference/Global_Objects/Array/toSource
 ---
 
 {{JSRef}} {{non-standard_header}}

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/boolean/tostring/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/boolean/tostring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Boolean.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Boolean/toString
-original_slug: Web/JavaScript/Reference/Global_Objects/Boolean/toSource
 ---
 
 {{JSRef}} {{non-standard_header}}

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/date/tostring/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/date/tostring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Date.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Date/toString
-original_slug: Web/JavaScript/Reference/Global_Objects/Date/toSource
 ---
 
 {{JSRef}}

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/date/toutcstring/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/date/toutcstring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Date.prototype.toGMTString()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Date/toUTCString
-original_slug: Web/JavaScript/Reference/Global_Objects/Date/toGMTString
 ---
 
 {{JSRef}} {{deprecated_header}}

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/error/tostring/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/error/tostring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Error.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Error/toString
-original_slug: Web/JavaScript/Reference/Global_Objects/Error/toSource
 ---
 
 {{JSRef}} {{non-standard_header}}

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/function/tostring/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/function/tostring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Function.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Function/toString
-original_slug: Web/JavaScript/Reference/Global_Objects/Function/toSource
 ---
 
 {{JSRef}} {{non-standard_header}}

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/index.md
@@ -1,7 +1,6 @@
 ---
 title: uneval()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects
-original_slug: Web/JavaScript/Reference/Global_Objects/uneval
 ---
 
 {{jsSidebar("Objects")}}{{Non-standard_header}}

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/map/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/map/index.md
@@ -1,7 +1,6 @@
 ---
 title: Map.prototype[@@toStringTag]
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Map
-original_slug: Web/JavaScript/Reference/Global_Objects/Map/@@toStringTag
 ---
 
 {{JSRef}}

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/number/tostring/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/number/tostring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Number.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Number/toString
-original_slug: Web/JavaScript/Reference/Global_Objects/Number/toSource
 ---
 
 {{JSRef}} {{non-standard_header}}

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/object/tostring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Object.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Object/toString
-original_slug: Web/JavaScript/Reference/Global_Objects/Object/toSource
 ---
 
 {{JSRef}}

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/string/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/string/index.md
@@ -1,7 +1,6 @@
 ---
 title: DOMString
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/String
-original_slug: Web/API/DOMString
 ---
 
 {{APIRef("DOM")}}

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/string/tostring/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/string/tostring/index.md
@@ -1,7 +1,6 @@
 ---
 title: String.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/String/toString
-original_slug: Web/JavaScript/Reference/Global_Objects/String/toSource
 ---
 
 {{JSRef}}

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/symbol/index.md
@@ -1,7 +1,6 @@
 ---
 title: Symbol
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Symbol
-original_slug: Glossary/Symbol
 ---
 
 Esse termo do glossário descreve tanto o tipo de dados chamado "**symbol**", quando a função/classe "{{jsxref("Symbol")}}`()`", que entre outras coisas, cria instâncias do tipo de dados **symbol**.

--- a/files/pt-br/conflicting/web/javascript/reference/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/index.md
@@ -1,7 +1,6 @@
 ---
 title: Sobre esta referência
 slug: conflicting/Web/JavaScript/Reference
-original_slug: Web/JavaScript/Reference/About
 ---
 
 {{JsSidebar}}

--- a/files/pt-br/conflicting/web/progressive_web_apps/index.md
+++ b/files/pt-br/conflicting/web/progressive_web_apps/index.md
@@ -1,7 +1,6 @@
 ---
 title: Sites separados para celular e desktop
 slug: conflicting/Web/Progressive_web_apps
-original_slug: Web/Guide/Mobile/Separate_sites
 ---
 
 The "separate sites" approach to mobile Web development involves creating different sites for mobile and desktop Web users. This approach has positive and negative aspects.

--- a/files/pt-br/conflicting/web/svg/element/animate/index.md
+++ b/files/pt-br/conflicting/web/svg/element/animate/index.md
@@ -1,7 +1,6 @@
 ---
 title: animateColor
 slug: conflicting/Web/SVG/Element/animate
-original_slug: Web/SVG/Element/animateColor
 ---
 
 {{SVGRef}}{{deprecated_header}}

--- a/files/pt-br/conflicting/web/svg/index.md
+++ b/files/pt-br/conflicting/web/svg/index.md
@@ -1,7 +1,6 @@
 ---
 title: Compatibility sources
 slug: conflicting/Web/SVG
-original_slug: Web/SVG/Compatibility_sources
 ---
 
 As seguintes fontes são usada para as tabelas de compatibilidade no elemento SVG e atributos:


### PR DESCRIPTION
This PR lints and fixes the front matter keys throughout the Brazilian Portuguese locale using the front matter linter, followed by manual fixes as needed.  This specifically performs linting for the `conflicting/` directory.
