### PR TITLE
ru: Lint front matter keys for "conflicting"

### DIFF
--- a/files/ru/conflicting/learn/forms/form_validation/index.md
+++ b/files/ru/conflicting/learn/forms/form_validation/index.md
@@ -1,12 +1,6 @@
 ---
 title: Constraint validation API
 slug: conflicting/Learn/Forms/Form_validation
-tags:
-  - API
-  - Валидация ограничений
-  - Landing
-  - Reference
-original_slug: Web/API/Constraint_validation
 ---
 
 {{apiref()}}

--- a/files/ru/conflicting/learn/javascript/asynchronous/index.md
+++ b/files/ru/conflicting/learn/javascript/asynchronous/index.md
@@ -1,8 +1,6 @@
 ---
-title: 'Объединённый асинхронный JavaScript: Таймауты и интервалы'
+title: "Объединённый асинхронный JavaScript: Таймауты и интервалы"
 slug: conflicting/Learn/JavaScript/Asynchronous
-translation_of: Learn/JavaScript/Asynchronous/Timeouts_and_intervals
-original_slug: Learn/JavaScript/Asynchronous/Timeouts_and_intervals
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Asynchronous/Introducing", "Learn/JavaScript/Asynchronous/Promises", "Learn/JavaScript/Asynchronous")}}

--- a/files/ru/conflicting/learn/javascript/asynchronous/introducing/index.md
+++ b/files/ru/conflicting/learn/javascript/asynchronous/introducing/index.md
@@ -1,15 +1,6 @@
 ---
 title: Основные понятия асинхронного программирования
 slug: conflicting/Learn/JavaScript/Asynchronous/Introducing
-tags:
-  - JavaScript
-  - Promises
-  - Асинхронность
-  - Обучение
-  - блокировки
-  - потоки
-translation_of: Learn/JavaScript/Asynchronous/Concepts
-original_slug: Learn/JavaScript/Asynchronous/Concepts
 ---
 {{LearnSidebar}}{{NextMenu("Learn/JavaScript/Asynchronous/Introducing", "Learn/JavaScript/Asynchronous")}}
 

--- a/files/ru/conflicting/learn/javascript/objects/classes_in_javascript/index.md
+++ b/files/ru/conflicting/learn/javascript/objects/classes_in_javascript/index.md
@@ -1,17 +1,6 @@
 ---
 title: Объектно-ориентированный JavaScript для начинающих
 slug: conflicting/Learn/JavaScript/Objects/Classes_in_JavaScript
-tags:
-  - Constructor
-  - Create
-  - JavaScript
-  - OOJS
-  - Object
-  - Новичку
-  - ООП
-  - экземпляр
-translation_of: Learn/JavaScript/Objects/Object-oriented_JS
-original_slug: Learn/JavaScript/Objects/Object-oriented_JS
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Basics", "Learn/JavaScript/Objects/Object_prototypes", "Learn/JavaScript/Objects")}}

--- a/files/ru/conflicting/learn/server-side/express_nodejs/displaying_data/index.md
+++ b/files/ru/conflicting/learn/server-side/express_nodejs/displaying_data/index.md
@@ -1,11 +1,6 @@
 ---
 title: Асинхронное управление потоками при помощи async
 slug: conflicting/Learn/Server-side/Express_Nodejs/Displaying_data
-tags:
-  - Node
-  - Часть 5
-translation_of: Learn/Server-side/Express_Nodejs/Displaying_data/flow_control_using_async
-original_slug: Learn/Server-side/Express_Nodejs/Displaying_data/flow_control_using_async
 ---
 
 Код контроллера для некоторых страниц библиотеки будет зависеть от результатов многих асинхронных запросов, которые должны выполняться в определённом порядке или параллельно. Для того, чтобы управлять потоком выполнения, и выводить страницы, когда получена вся необходимая информация, будет использован [async](https://www.npmjs.com/package/async) - известный модуль node.

--- a/files/ru/conflicting/mdn/contribute/index.md
+++ b/files/ru/conflicting/mdn/contribute/index.md
@@ -1,11 +1,6 @@
 ---
 title: Руководства "Как сделать"
 slug: conflicting/MDN/Contribute
-tags:
-  - Landing
-  - MDN Meta
-translation_of: MDN/Contribute/Howto
-original_slug: MDN/Contribute/Howto
 ---
 
 {{MDNSidebar}}

--- a/files/ru/conflicting/mdn/index.md
+++ b/files/ru/conflicting/mdn/index.md
@@ -1,15 +1,6 @@
 ---
 title: URL-суффиксы
 slug: conflicting/MDN
-tags:
-  - HTTP
-  - Kuma
-  - MDN Мета
-  - URL
-  - Параметры URL
-  - инструменты
-translation_of: MDN/Tools/Document_parameters
-original_slug: MDN/Tools/Unsupported_GET_API
 ---
 
 {{MDNSidebar}}

--- a/files/ru/conflicting/mdn/writing_guidelines/index.md
+++ b/files/ru/conflicting/mdn/writing_guidelines/index.md
@@ -1,10 +1,6 @@
 ---
 title: Руководства
 slug: conflicting/MDN/Writing_guidelines
-tags:
-  - Руководства
-translation_of: MDN/Guidelines
-original_slug: MDN/Guidelines
 ---
 
 {{MDNSidebar}}

--- a/files/ru/conflicting/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/ru/conflicting/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -1,8 +1,6 @@
 ---
 title: Как создать интерактивное обучающее упражнение
 slug: conflicting/MDN/Writing_guidelines/Page_structures/Live_samples
-translation_of: MDN/Contribute/Howto/Create_an_interactive_exercise_to_help_learning_the_web
-original_slug: MDN/Contribute/Howto/Create_an_interactive_exercise_to_help_learning_the_web
 ---
 
 {{MDNSidebar}}

--- a/files/ru/conflicting/web/api/abortsignal/abort_event/index.md
+++ b/files/ru/conflicting/web/api/abortsignal/abort_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: AbortSignal.onabort
 slug: conflicting/Web/API/AbortSignal/abort_event
-translation_of: Web/API/AbortSignal/onabort
-original_slug: Web/API/AbortSignal/onabort
 ---
 
 {{APIRef("DOM")}}{{SeeCompatTable}}

--- a/files/ru/conflicting/web/api/canvasrenderingcontext2d/index.md
+++ b/files/ru/conflicting/web/api/canvasrenderingcontext2d/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.currentTransform
 slug: conflicting/Web/API/CanvasRenderingContext2D
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - Experimental
-  - Property
-translation_of: Web/API/CanvasRenderingContext2D/currentTransform
-original_slug: Web/API/CanvasRenderingContext2D/currentTransform
 ---
 
 {{APIRef()}} {{SeeCompatTable}}

--- a/files/ru/conflicting/web/api/element/clientheight/index.md
+++ b/files/ru/conflicting/web/api/element/clientheight/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.height
 slug: conflicting/Web/API/Element/clientHeight
-tags:
-  - Document
-  - HTML
-  - Obsolete
-  - Property
-translation_of: Web/API/Document/height
-original_slug: Web/API/Document/height
 ---
 
 {{APIRef("DOM")}}

--- a/files/ru/conflicting/web/api/element/keydown_event/index.md
+++ b/files/ru/conflicting/web/api/element/keydown_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: GlobalEventHandlers.onkeydown
 slug: conflicting/Web/API/Element/keydown_event
-tags:
-  - API
-  - HTML DOM
-  - Свойство
-translation_of: Web/API/GlobalEventHandlers/onkeydown
-original_slug: Web/API/GlobalEventHandlers/onkeydown
 ---
 
 {{ApiRef("HTML DOM")}}

--- a/files/ru/conflicting/web/api/element/keypress_event/index.md
+++ b/files/ru/conflicting/web/api/element/keypress_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: GlobalEventHandlers.onkeypress
 slug: conflicting/Web/API/Element/keypress_event
-translation_of: Web/API/GlobalEventHandlers/onkeypress
-original_slug: Web/API/GlobalEventHandlers/onkeypress
 ---
 
 {{ApiRef("HTML DOM")}}

--- a/files/ru/conflicting/web/api/element/mousedown_event/index.md
+++ b/files/ru/conflicting/web/api/element/mousedown_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: GlobalEventHandlers.onmousedown
 slug: conflicting/Web/API/Element/mousedown_event
-translation_of: Web/API/GlobalEventHandlers/onmousedown
-original_slug: Web/API/GlobalEventHandlers/onmousedown
 ---
 
 {{ ApiRef("HTML DOM") }}

--- a/files/ru/conflicting/web/api/element/mouseup_event/index.md
+++ b/files/ru/conflicting/web/api/element/mouseup_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: GlobalEventHandlers.onmouseup
 slug: conflicting/Web/API/Element/mouseup_event
-translation_of: Web/API/GlobalEventHandlers/onmouseup
-original_slug: Web/API/GlobalEventHandlers/onmouseup
 ---
 
 {{ApiRef("HTML DOM")}}

--- a/files/ru/conflicting/web/api/eventtarget/addeventlistener/index.md
+++ b/files/ru/conflicting/web/api/eventtarget/addeventlistener/index.md
@@ -1,8 +1,6 @@
 ---
 title: EventListener
 slug: conflicting/Web/API/EventTarget/addEventListener
-translation_of: Web/API/EventListener
-original_slug: Web/API/EventListener
 ---
 
 {{APIRef("DOM Events")}}

--- a/files/ru/conflicting/web/api/file/name/index.md
+++ b/files/ru/conflicting/web/api/file/name/index.md
@@ -1,8 +1,6 @@
 ---
 title: File.fileName
 slug: conflicting/Web/API/File/name
-translation_of: Web/API/File/fileName
-original_slug: Web/API/File/fileName
 ---
 {{APIRef("File API")}}{{non-standard_header}}
 

--- a/files/ru/conflicting/web/api/geolocation/getcurrentposition/index.md
+++ b/files/ru/conflicting/web/api/geolocation/getcurrentposition/index.md
@@ -1,8 +1,6 @@
 ---
 title: PositionOptions
 slug: conflicting/Web/API/Geolocation/getCurrentPosition
-translation_of: Web/API/PositionOptions
-original_slug: Web/API/PositionOptions
 ---
 
 {{APIRef("Geolocation API")}}

--- a/files/ru/conflicting/web/api/htmlelement/dragstart_event/index.md
+++ b/files/ru/conflicting/web/api/htmlelement/dragstart_event/index.md
@@ -1,8 +1,6 @@
 ---
-title: 'Document: dragstart event'
+title: "Document: dragstart event"
 slug: conflicting/Web/API/HTMLElement/dragstart_event
-translation_of: Web/API/Document/dragstart_event
-original_slug: Web/API/Document/dragstart_event
 ---
 Событие dragstart вызывается, когда пользователь начинает перетаскивать выделенный элемент или текст.
 

--- a/files/ru/conflicting/web/api/htmlmediaelement/abort_event/index.md
+++ b/files/ru/conflicting/web/api/htmlmediaelement/abort_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: GlobalEventHandlers.onabort
 slug: conflicting/Web/API/HTMLMediaElement/abort_event
-translation_of: Web/API/GlobalEventHandlers/onabort
-original_slug: Web/API/GlobalEventHandlers/onabort
 ---
 
 {{ ApiRef("HTML DOM") }}

--- a/files/ru/conflicting/web/api/node/index.md
+++ b/files/ru/conflicting/web/api/node/index.md
@@ -1,8 +1,6 @@
 ---
 title: Node.isSupported()
 slug: conflicting/Web/API/Node
-translation_of: Web/API/Node/isSupported
-original_slug: Web/API/Node/isSupported
 ---
 
 {{APIRef("DOM")}}

--- a/files/ru/conflicting/web/api/pointer_events/index.md
+++ b/files/ru/conflicting/web/api/pointer_events/index.md
@@ -1,8 +1,6 @@
 ---
 title: Поддержка TouchEvent и MouseEvent
 slug: conflicting/Web/API/Pointer_events
-translation_of: Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent
-original_slug: Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent
 ---
 {{DefaultAPISidebar("Touch Events")}}
 

--- a/files/ru/conflicting/web/api/uievent/which/index.md
+++ b/files/ru/conflicting/web/api/uievent/which/index.md
@@ -1,11 +1,6 @@
 ---
 title: MouseEvent.which
 slug: conflicting/Web/API/UIEvent/which
-tags:
-  - API
-  - "События\_DOM"
-translation_of: Web/API/MouseEvent/which
-original_slug: Web/API/MouseEvent/which
 ---
 
 {{APIRef("DOM Events")}} {{Non-standard_header}}

--- a/files/ru/conflicting/web/api/window/beforeunload_event/index.md
+++ b/files/ru/conflicting/web/api/window/beforeunload_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: WindowEventHandlers.onbeforeunload
 slug: conflicting/Web/API/Window/beforeunload_event
-translation_of: Web/API/WindowEventHandlers/onbeforeunload
-original_slug: Web/API/WindowEventHandlers/onbeforeunload
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/ru/conflicting/web/api/window/deviceorientation_event/index.md
+++ b/files/ru/conflicting/web/api/window/deviceorientation_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.ondeviceorientation
 slug: conflicting/Web/API/Window/deviceorientation_event
-tags:
-  - API
-  - Мобильные устройства
-  - Ориентация
-  - Ориентация устройства
-  - Свойства
-translation_of: Web/API/Window/ondeviceorientation
-original_slug: Web/API/Window/ondeviceorientation
 ---
 
 {{ ApiRef() }}

--- a/files/ru/conflicting/web/api/window/gamepadconnected_event/index.md
+++ b/files/ru/conflicting/web/api/window/gamepadconnected_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: Window.ongamepadconnected
 slug: conflicting/Web/API/Window/gamepadconnected_event
-translation_of: Web/API/Window/ongamepadconnected
-original_slug: Web/API/Window/ongamepadconnected
 ---
 
 {{DefaultAPISidebar("Gamepad API")}}{{SeeCompatTable}}

--- a/files/ru/conflicting/web/api/window/gamepaddisconnected_event/index.md
+++ b/files/ru/conflicting/web/api/window/gamepaddisconnected_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: Window.ongamepaddisconnected
 slug: conflicting/Web/API/Window/gamepaddisconnected_event
-translation_of: Web/API/Window/ongamepaddisconnected
-original_slug: Web/API/Window/ongamepaddisconnected
 ---
 
 {{DefaultAPISidebar("Gamepad API")}}{{SeeCompatTable}}

--- a/files/ru/conflicting/web/api/window/hashchange_event/index.md
+++ b/files/ru/conflicting/web/api/window/hashchange_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: WindowEventHandlers.onhashchange
 slug: conflicting/Web/API/Window/hashchange_event
-translation_of: Web/API/WindowEventHandlers/onhashchange
-original_slug: Web/API/WindowEventHandlers/onhashchange
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/ru/conflicting/web/api/window/load_event/index.md
+++ b/files/ru/conflicting/web/api/window/load_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: GlobalEventHandlers.onload
 slug: conflicting/Web/API/Window/load_event
-translation_of: Web/API/GlobalEventHandlers/onload
-original_slug: Web/API/GlobalEventHandlers/onload
 ---
 
 {{ ApiRef("HTML DOM") }}

--- a/files/ru/conflicting/web/api/window/popstate_event/index.md
+++ b/files/ru/conflicting/web/api/window/popstate_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: WindowEventHandlers.onpopstate
 slug: conflicting/Web/API/Window/popstate_event
-translation_of: Web/API/WindowEventHandlers/onpopstate
-original_slug: Web/API/WindowEventHandlers/onpopstate
 ---
 {{APIRef}}
 

--- a/files/ru/conflicting/web/css/_colon_focus-visible/index.md
+++ b/files/ru/conflicting/web/css/_colon_focus-visible/index.md
@@ -1,11 +1,6 @@
 ---
 title: ":-moz-focusring"
 slug: conflicting/Web/CSS/:focus-visible
-tags:
-  - Фокус
-  - псевдокласс
-translation_of: Web/CSS/:-moz-focusring
-original_slug: Web/CSS/:-moz-focusring
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/ru/conflicting/web/css/css_fonts/index.md
+++ b/files/ru/conflicting/web/css/css_fonts/index.md
@@ -1,8 +1,6 @@
 ---
 title: HTMLBaseFontElement
 slug: conflicting/Web/CSS/CSS_Fonts
-translation_of: Web/API/HTMLBaseFontElement
-original_slug: Web/API/HTMLBaseFontElement
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/ru/conflicting/web/css/css_fonts_25d4b407d3e5044aeffb97faa9669a95/index.md
+++ b/files/ru/conflicting/web/css/css_fonts_25d4b407d3e5044aeffb97faa9669a95/index.md
@@ -1,8 +1,6 @@
 ---
 title: <basefont>
 slug: conflicting/Web/CSS/CSS_Fonts_25d4b407d3e5044aeffb97faa9669a95
-translation_of: Web/HTML/Element/basefont
-original_slug: Web/HTML/Element/basefont
 ---
 
 The obsolete **HTML Base Font element** (**`<basefont>`**) sets a default font face, size, and color for the other elements which are descended from its parent element. With this set, the font's size can then be varied relative to the base size using the {{HTMLElement("font")}} element.

--- a/files/ru/conflicting/web/css/cursor/index.md
+++ b/files/ru/conflicting/web/css/cursor/index.md
@@ -1,13 +1,6 @@
 ---
 title: Использование URL значений для свойства cursor
 slug: conflicting/Web/CSS/cursor
-tags:
-  - CSS
-  - Gecko
-  - Справка
-  - справочник
-translation_of: Web/CSS/CSS_Basic_User_Interface/Using_URL_values_for_the_cursor_property
-original_slug: Web/CSS/CSS_Basic_User_Interface/Using_URL_values_for_the_cursor_property
 ---
 
 {{cssref}}

--- a/files/ru/conflicting/web/guide/ajax/index.md
+++ b/files/ru/conflicting/web/guide/ajax/index.md
@@ -1,10 +1,6 @@
 ---
 title: С чего начать
 slug: conflicting/Web/Guide/AJAX
-tags:
-  - AJAX
-translation_of: Web/Guide/AJAX/Getting_Started
-original_slug: Web/Guide/AJAX/Getting_Started
 ---
 
 В этой статье рассмотрены основные принципы работы AJAX и даны два простых примера, использующих эту технологию.

--- a/files/ru/conflicting/web/html/element/input/datetime-local/index.md
+++ b/files/ru/conflicting/web/html/element/input/datetime-local/index.md
@@ -1,18 +1,6 @@
 ---
 title: <input type="datetime">
 slug: conflicting/Web/HTML/Element/input/datetime-local
-tags:
-  - Element
-  - HTML
-  - HTML формы
-  - Reference
-  - datetime
-  - Устаревший
-  - Формы
-  - Элемент
-  - Элемент ввода
-translation_of: Web/HTML/Element/input/datetime
-original_slug: Web/HTML/Element/Input/datetime
 ---
 {{HTMLSidebar}}
 

--- a/files/ru/conflicting/web/html/global_attributes/contenteditable/index.md
+++ b/files/ru/conflicting/web/html/global_attributes/contenteditable/index.md
@@ -1,11 +1,6 @@
 ---
 title: Создание контента для редактирования
 slug: conflicting/Web/HTML/Global_attributes/contenteditable
-tags:
-  - HTML5
-  - contenteditable
-translation_of: Web/Guide/HTML/Editable_content
-original_slug: Web/Guide/HTML/Editable_content
 ---
 
 В HTML любой элемент может быть доступен для редактирования. Используя некоторые обработчики событий JavaScript, вы можете превратить свою веб-страницу в полноценный и быстрый текстовый редактор. В этой статье содержится некоторая информация об этой функции.

--- a/files/ru/conflicting/web/http/status/404/index.md
+++ b/files/ru/conflicting/web/http/status/404/index.md
@@ -1,8 +1,6 @@
 ---
-title: '404'
+title: "404"
 slug: conflicting/Web/HTTP/Status/404
-translation_of: Glossary/404
-original_slug: Glossary/404
 ---
 Ошибка 404 — код стандартного ответа, означающий, что {{Glossary("Server", "сервер")}} не может найти запрашиваемый ресурс.
 

--- a/files/ru/conflicting/web/http/status/502/index.md
+++ b/files/ru/conflicting/web/http/status/502/index.md
@@ -1,14 +1,6 @@
 ---
-title: '502'
+title: "502"
 slug: conflicting/Web/HTTP/Status/502
-tags:
-  - '502'
-  - Глоссарий
-  - Коды ошибок HTTP
-  - Инфраструктура
-  - Навигация
-translation_of: Glossary/502
-original_slug: Glossary/502
 ---
 
 Код ошибки в протоколе {{Glossary("HTTP")}}, означающий «Ошибка шлюза».

--- a/files/ru/conflicting/web/javascript/index.md
+++ b/files/ru/conflicting/web/javascript/index.md
@@ -1,14 +1,6 @@
 ---
 title: О JavaScript
 slug: conflicting/Web/JavaScript
-tags:
-  - Beginner
-  - Introduction
-  - JavaScript
-  - Вступление
-  - Новичку
-translation_of: Web/JavaScript/About_JavaScript
-original_slug: Web/JavaScript/About_JavaScript
 ---
 
 {{JsSidebar()}}

--- a/files/ru/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/ru/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -1,8 +1,6 @@
 ---
 title: Подробнее об объектной модели
 slug: conflicting/Web/JavaScript/Inheritance_and_the_prototype_chain
-translation_of: Web/JavaScript/Guide/Details_of_the_Object_Model
-original_slug: Web/JavaScript/Guide/Details_of_the_Object_Model
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Working_with_Objects", "Web/JavaScript/Guide/Ispolzovanie_promisov")}}

--- a/files/ru/conflicting/web/javascript/javascript_technologies_overview/index.md
+++ b/files/ru/conflicting/web/javascript/javascript_technologies_overview/index.md
@@ -1,8 +1,6 @@
 ---
 title: Ресурсы по JavaScript
 slug: conflicting/Web/JavaScript/JavaScript_technologies_overview
-translation_of: Web/JavaScript/Language_Resources
-original_slug: Web/JavaScript/Language_Resources
 ---
 
 {{JsSidebar}}

--- a/files/ru/conflicting/web/javascript/javascript_technologies_overview_0191f05ec18a4ee4d771b548feb0701d/index.md
+++ b/files/ru/conflicting/web/javascript/javascript_technologies_overview_0191f05ec18a4ee4d771b548feb0701d/index.md
@@ -1,9 +1,6 @@
 ---
 title: JavaScript оболочки
-slug: >-
-  conflicting/Web/JavaScript/JavaScript_technologies_overview_0191f05ec18a4ee4d771b548feb0701d
-translation_of: Web/JavaScript/Shells
-original_slug: Web/JavaScript/Shells
+slug: conflicting/Web/JavaScript/JavaScript_technologies_overview_0191f05ec18a4ee4d771b548feb0701d
 ---
 
 {{JsSidebar}}

--- a/files/ru/conflicting/web/javascript/reference/deprecated_and_obsolete_features/index.md
+++ b/files/ru/conflicting/web/javascript/reference/deprecated_and_obsolete_features/index.md
@@ -1,8 +1,6 @@
 ---
 title: WeakMap.prototype.clear()
 slug: conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakMap/clear
-original_slug: Web/JavaScript/Reference/Global_Objects/WeakMap/clear
 ---
 
 {{JSRef}}

--- a/files/ru/conflicting/web/javascript/reference/deprecated_and_obsolete_features_3720fcfc8cf309ee8f3b5f3474dc9e12/index.md
+++ b/files/ru/conflicting/web/javascript/reference/deprecated_and_obsolete_features_3720fcfc8cf309ee8f3b5f3474dc9e12/index.md
@@ -1,12 +1,6 @@
 ---
-title: 'Warning: String.x is deprecated; use String.prototype.x instead'
-slug: >-
-  conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features_3720fcfc8cf309ee8f3b5f3474dc9e12
-tags:
-  - JavaScript
-  - предупреждение
-translation_of: Web/JavaScript/Reference/Errors/Deprecated_String_generics
-original_slug: Web/JavaScript/Reference/Errors/Deprecated_String_generics
+title: "Warning: String.x is deprecated; use String.prototype.x instead"
+slug: conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features_3720fcfc8cf309ee8f3b5f3474dc9e12
 ---
 
 {{jsSidebar("Errors")}}Поддержка строковых обобщённых методов прекращена с версии Firefox 68. Более старые версии предупреждают об использовании данных методов следующим образом:

--- a/files/ru/conflicting/web/javascript/reference/deprecated_and_obsolete_features_9896c9277d53005e5ad73315265daed1/index.md
+++ b/files/ru/conflicting/web/javascript/reference/deprecated_and_obsolete_features_9896c9277d53005e5ad73315265daed1/index.md
@@ -1,9 +1,6 @@
 ---
-title: 'Warning: Date.prototype.toLocaleFormat (Является устаревшим)'
-slug: >-
-  conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features_9896c9277d53005e5ad73315265daed1
-translation_of: Web/JavaScript/Reference/Errors/Deprecated_toLocaleFormat
-original_slug: Web/JavaScript/Reference/Errors/Deprecated_toLocaleFormat
+title: "Warning: Date.prototype.toLocaleFormat (Является устаревшим)"
+slug: conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features_9896c9277d53005e5ad73315265daed1
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/ru/conflicting/web/javascript/reference/deprecated_and_obsolete_features_ce02ff996e57a0f0af4fbdf5f792ff46/index.md
+++ b/files/ru/conflicting/web/javascript/reference/deprecated_and_obsolete_features_ce02ff996e57a0f0af4fbdf5f792ff46/index.md
@@ -1,12 +1,6 @@
 ---
-title: 'Предупреждение: затворы выражения являются устаревшими'
-slug: >-
-  conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features_ce02ff996e57a0f0af4fbdf5f792ff46
-tags:
-  - JavaScript
-  - Warning
-translation_of: Web/JavaScript/Reference/Errors/Deprecated_expression_closures
-original_slug: Web/JavaScript/Reference/Errors/Deprecated_expression_closures
+title: "Предупреждение: затворы выражения являются устаревшими"
+slug: conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features_ce02ff996e57a0f0af4fbdf5f792ff46
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/ru/conflicting/web/javascript/reference/errors/deprecated_octal/index.md
+++ b/files/ru/conflicting/web/javascript/reference/errors/deprecated_octal/index.md
@@ -1,12 +1,6 @@
 ---
-title: 'Внимание: 08/09 не является восьмеричной постоянной по ECMA-262'
+title: "Внимание: 08/09 не является восьмеричной постоянной по ECMA-262"
 slug: conflicting/Web/JavaScript/Reference/Errors/Deprecated_octal
-tags:
-  - Ошибки
-  - Предупреждения
-  - Синтаксические ошибки
-translation_of: Web/JavaScript/Reference/Errors/Bad_octal
-original_slug: Web/JavaScript/Reference/Errors/Bad_octal
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/ru/conflicting/web/javascript/reference/errors/missing_formal_parameter/index.md
+++ b/files/ru/conflicting/web/javascript/reference/errors/missing_formal_parameter/index.md
@@ -1,12 +1,6 @@
 ---
-title: 'SyntaxError: Malformed formal parameter'
+title: "SyntaxError: Malformed formal parameter"
 slug: conflicting/Web/JavaScript/Reference/Errors/Missing_formal_parameter
-tags:
-  - JavaScript
-  - SyntaxError
-  - Ошибки
-translation_of: Web/JavaScript/Reference/Errors/Malformed_formal_parameter
-original_slug: Web/JavaScript/Reference/Errors/Malformed_formal_parameter
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/ru/conflicting/web/javascript/reference/errors/unexpected_type/index.md
+++ b/files/ru/conflicting/web/javascript/reference/errors/unexpected_type/index.md
@@ -1,10 +1,6 @@
 ---
-title: >-
-  TypeError: can't access property "x" of "y"(Тип ошибки: не удаётся получить
-  доступ к свойству "x" из "y")
+title: 'TypeError: can''t access property "x" of "y"(Тип ошибки: не удаётся получить доступ к свойству "x" из "y")'
 slug: conflicting/Web/JavaScript/Reference/Errors/Unexpected_type
-translation_of: Web/JavaScript/Reference/Errors/Cant_access_property
-original_slug: Web/JavaScript/Reference/Errors/Cant_access_property
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ru/conflicting/web/javascript/reference/global_objects/array/tostring/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/array/tostring/index.md
@@ -1,14 +1,6 @@
 ---
 title: Array.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Array/toString
-tags:
-  - Array
-  - JavaScript
-  - Method
-  - Non-standard
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/toSource
-original_slug: Web/JavaScript/Reference/Global_Objects/Array/toSource
 ---
 
 {{JSRef("Global_Objects", "Array")}} {{non-standard_header}}

--- a/files/ru/conflicting/web/javascript/reference/global_objects/boolean/tostring/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/boolean/tostring/index.md
@@ -1,14 +1,6 @@
 ---
 title: Boolean.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Boolean/toString
-tags:
-  - Boolean
-  - JavaScript
-  - Method
-  - Non-standard
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Boolean/toSource
-original_slug: Web/JavaScript/Reference/Global_Objects/Boolean/toSource
 ---
 
 {{JSRef("Global_Objects", "Boolean")}} {{non-standard_header}}

--- a/files/ru/conflicting/web/javascript/reference/global_objects/date/tostring/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/date/tostring/index.md
@@ -1,15 +1,6 @@
 ---
 title: Date.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Date/toString
-tags:
-  - Date
-  - JavaScript
-  - Method
-  - Non-standard
-  - Prototype
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/toSource
-original_slug: Web/JavaScript/Reference/Global_Objects/Date/toSource
 ---
 
 {{JSRef("Global_Objects", "Date")}} {{non-standard_header}}

--- a/files/ru/conflicting/web/javascript/reference/global_objects/date/toutcstring/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/date/toutcstring/index.md
@@ -1,15 +1,6 @@
 ---
 title: Date.prototype.toGMTString()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Date/toUTCString
-tags:
-  - Date
-  - Deprecated
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/toGMTString
-original_slug: Web/JavaScript/Reference/Global_Objects/Date/toGMTString
 ---
 
 {{JSRef("Global_Objects", "Date")}} {{deprecated_header}}

--- a/files/ru/conflicting/web/javascript/reference/global_objects/error/tostring/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/error/tostring/index.md
@@ -1,14 +1,6 @@
 ---
 title: Error.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Error/toString
-tags:
-  - Error
-  - JavaScript
-  - Method
-  - Non-standard
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Error/toSource
-original_slug: Web/JavaScript/Reference/Global_Objects/Error/toSource
 ---
 
 {{JSRef("Global_Objects", "Error", "EvalError,InternalError,RangeError,ReferenceError,SyntaxError,TypeError,URIError")}} {{non-standard_header}}

--- a/files/ru/conflicting/web/javascript/reference/global_objects/function/tostring/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/function/tostring/index.md
@@ -1,13 +1,6 @@
 ---
 title: Function.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Function/toString
-tags:
-  - Function
-  - JavaScript
-  - Method
-  - Non-standard
-translation_of: Web/JavaScript/Reference/Global_Objects/Function/toSource
-original_slug: Web/JavaScript/Reference/Global_Objects/Function/toSource
 ---
 
 {{JSRef("Global_Objects", "Function")}} {{non-standard_header}}

--- a/files/ru/conflicting/web/javascript/reference/global_objects/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/index.md
@@ -1,11 +1,6 @@
 ---
 title: uneval()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects
-tags:
-  - JavaScript
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/uneval
-original_slug: Web/JavaScript/Reference/Global_Objects/uneval
 ---
 
 {{jsSidebar("Objects")}}{{Non-standard_header}}

--- a/files/ru/conflicting/web/javascript/reference/global_objects/number/tostring/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/number/tostring/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Number/toString
-tags:
-  - JavaScript
-  - Method
-  - Non-standard
-  - Number
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/toSource
-original_slug: Web/JavaScript/Reference/Global_Objects/Number/toSource
 ---
 
 {{JSRef("Global_Objects", "Number")}} {{non-standard_header}}

--- a/files/ru/conflicting/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/object/tostring/index.md
@@ -1,14 +1,6 @@
 ---
 title: Object.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Object/toString
-tags:
-  - JavaScript
-  - Method
-  - Non-standard
-  - Object
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/toSource
-original_slug: Web/JavaScript/Reference/Global_Objects/Object/toSource
 ---
 
 {{JSRef("Global_Objects", "Object")}} {{non-standard_header}}

--- a/files/ru/conflicting/web/javascript/reference/global_objects/regexp/tostring/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/regexp/tostring/index.md
@@ -1,15 +1,6 @@
 ---
 title: RegExp.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/RegExp/toString
-tags:
-  - JavaScript
-  - Method
-  - Non-standard
-  - Prototype
-  - Reference
-  - RegExp
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/toSource
-original_slug: Web/JavaScript/Reference/Global_Objects/RegExp/toSource
 ---
 
 {{JSRef("Global_Objects", "RegExp")}} {{non-standard_header}}

--- a/files/ru/conflicting/web/javascript/reference/global_objects/string/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/string/index.md
@@ -1,10 +1,6 @@
 ---
 title: ByteString
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/String
-tags:
-  - Строки
-translation_of: Web/API/ByteString
-original_slug: Web/API/ByteString
 ---
 
 {{APIRef("DOM")}}

--- a/files/ru/conflicting/web/javascript/reference/global_objects/string/tostring/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/string/tostring/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/String/toString
-tags:
-  - JavaScript
-  - Method
-  - Non-standard
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/toSource
-original_slug: Web/JavaScript/Reference/Global_Objects/String/toSource
 ---
 
 {{JSRef("Global_Objects", "String")}} {{non-standard_header}}

--- a/files/ru/conflicting/web/javascript/reference/global_objects/string_6fa58bba0570d663099f0ae7ae8883ab/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/string_6fa58bba0570d663099f0ae7ae8883ab/index.md
@@ -1,9 +1,6 @@
 ---
 title: DOMString
-slug: >-
-  conflicting/Web/JavaScript/Reference/Global_Objects/String_6fa58bba0570d663099f0ae7ae8883ab
-translation_of: Web/API/DOMString
-original_slug: Web/API/DOMString
+slug: conflicting/Web/JavaScript/Reference/Global_Objects/String_6fa58bba0570d663099f0ae7ae8883ab
 ---
 {{APIRef("DOM")}}
 

--- a/files/ru/conflicting/web/javascript/reference/global_objects/string_9094f63a1f7efd350dd69d6a8ae174fb/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/string_9094f63a1f7efd350dd69d6a8ae174fb/index.md
@@ -1,15 +1,6 @@
 ---
 title: USVString
-slug: >-
-  conflicting/Web/JavaScript/Reference/Global_Objects/String_9094f63a1f7efd350dd69d6a8ae174fb
-tags:
-  - API
-  - DOM
-  - Reference
-  - String
-  - WebIDL
-translation_of: Web/API/USVString
-original_slug: Web/API/USVString
+slug: conflicting/Web/JavaScript/Reference/Global_Objects/String_9094f63a1f7efd350dd69d6a8ae174fb
 ---
 
 {{APIRef("DOM")}}

--- a/files/ru/conflicting/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/ru/conflicting/web/javascript/reference/global_objects/symbol/index.md
@@ -1,8 +1,6 @@
 ---
 title: Symbol (Символ)
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Symbol
-translation_of: Glossary/Symbol
-original_slug: Glossary/Symbol
 ---
 
 На этой странице описывается тип данных «символ» и функция «{{jsxref("Symbol")}}`()`», которая (среди прочего) создаёт экземпляры типа «символ».

--- a/files/ru/conflicting/web/javascript/reference/index.md
+++ b/files/ru/conflicting/web/javascript/reference/index.md
@@ -1,8 +1,6 @@
 ---
 title: Об этой справке
 slug: conflicting/Web/JavaScript/Reference
-translation_of: Web/JavaScript/Reference/About
-original_slug: Web/JavaScript/Reference/About
 ---
 
 {{JsSidebar}}

--- a/files/ru/conflicting/web/javascript/reference/strict_mode/index.md
+++ b/files/ru/conflicting/web/javascript/reference/strict_mode/index.md
@@ -1,11 +1,6 @@
 ---
 title: Переход к строгому режиму
 slug: conflicting/Web/JavaScript/Reference/Strict_mode
-tags:
-  - Advanced
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Strict_mode/Transitioning_to_strict_mode
-original_slug: Web/JavaScript/Reference/Strict_mode/Transitioning_to_strict_mode
 ---
 
 {{jsSidebar("More")}}

--- a/files/ru/conflicting/web/manifest/index.md
+++ b/files/ru/conflicting/web/manifest/index.md
@@ -1,12 +1,6 @@
 ---
 title: dir
 slug: conflicting/Web/Manifest
-tags:
-  - Manifest
-  - Web
-  - dir
-translation_of: Web/Manifest/dir
-original_slug: Web/Manifest/dir
 ---
 
 {{QuickLinksWithSubpages('/ru/docs/Web/Manifest')}}

--- a/files/ru/conflicting/web/manifest_7ec32c6987e59d5f1cb08f8c9d900a4c/index.md
+++ b/files/ru/conflicting/web/manifest_7ec32c6987e59d5f1cb08f8c9d900a4c/index.md
@@ -1,12 +1,6 @@
 ---
 title: lang
 slug: conflicting/Web/Manifest_7ec32c6987e59d5f1cb08f8c9d900a4c
-tags:
-  - Manifest
-  - Web
-  - lang
-translation_of: Web/Manifest/lang
-original_slug: Web/Manifest/lang
 ---
 
 {{QuickLinksWithSubpages('/ru/docs/Web/Manifest')}}

--- a/files/ru/conflicting/web/manifest_e8c4835b067e177a000dc29c18483205/index.md
+++ b/files/ru/conflicting/web/manifest_e8c4835b067e177a000dc29c18483205/index.md
@@ -1,12 +1,6 @@
 ---
 title: iarc_rating_id
 slug: conflicting/Web/Manifest_e8c4835b067e177a000dc29c18483205
-tags:
-  - Manifest
-  - Web
-  - iarc_rating_id
-translation_of: Web/Manifest/iarc_rating_id
-original_slug: Web/Manifest/iarc_rating_id
 ---
 
 {{QuickLinksWithSubpages("/ru/docs/Web/Manifest")}}

--- a/files/ru/conflicting/web/web_components/index.md
+++ b/files/ru/conflicting/web/web_components/index.md
@@ -1,8 +1,6 @@
 ---
 title: HTML Импорты
 slug: conflicting/Web/Web_Components
-translation_of: Web/Web_Components/HTML_Imports
-original_slug: Web/Web_Components/HTML_Imports
 ---
 
 > **Предупреждение:** Firefox will not ship _HTML Imports_ in its current form. See this [status update](https://hacks.mozilla.org/2015/06/the-state-of-web-components/) for more information. Until there is a consensus on the standard or alternative mechanisms are worked out, you can use a polyfill such as Google's [`webcomponents.js`](https://github.com/webcomponents/webcomponentsjs).


### PR DESCRIPTION
This PR lints and fixes the front matter keys throughout the Russian locale using the front matter linter, followed by manual fixes as needed.  This specifically performs linting for the `conflicting/` directory.
