### PR TITLE
fix(lint-staged): markdownlint and prettier can race on md files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-  "*": "prettier --ignore-unknown --write",
-  "*.md": "markdownlint-cli2-fix"
+  "!*.md": "prettier --ignore-unknown --write",
+  "*.md": ["markdownlint-cli2 --fix", "prettier --write"]
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "type": "module",
   "scripts": {
     "fix:json": "prettier -w \"**/*.json\"",
-    "fix:md": "markdownlint-cli2-fix \"**/*.md\" && prettier -w \"**/*.md\"",
+    "fix:md": "markdownlint-cli2 --fix \"**/*.md\" && prettier -w \"**/*.md\"",
     "fix:yml": "prettier -w \"**/*.yml\"",
     "lint:json": "prettier -c \"**/*.json\"",
     "lint:md": "markdownlint-cli2 \"**/*.md\" && prettier -c \"**/*.md\"",


### PR DESCRIPTION
### Description

Synchronize script changes from upstream.

### Related issues and pull requests

upstream changes: mdn/content#28306
