### PR TITLE
Overhaul contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,13 +66,7 @@ Once that is done, you will also need to fork and clone this repository by follo
 2. Next, define an environment variable in a `.env` file called `CONTENT_TRANSLATED_ROOT` containing the path to the _translated-content_ repo’s `files` directory:
 
    ```bash
-   # macOS/Linux
    echo CONTENT_TRANSLATED_ROOT=/path/to/translated-content/files >> .env
-   ```
-
-   ```batch
-   # Windows
-   echo CONTENT_TRANSLATED_ROOT=\path\to\translated-content\files > .env
    ```
 
    (the `.env` file will be created for you if it does not already exist.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you've found a typo on the Simplified Chinese [JavaScript landing page](/zh-C
 4. Click the edit (pencil) button
 
 From there, the GitHub UI will walk you through the rest by creating a [fork](https://docs.github.com/get-started/quickstart/fork-a-repo) and a branch to commit your changes to.
-After you have made changes to your branch, the goal is to open a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for your changes to be incorporated.
+After you have made changes to your branch, the goal is to open a [pull request](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for your changes to be incorporated.
 
 A pull request represents the work you want to be reviewed, approved, and merged into the `main` branch of the MDN repository.
 See the [Creating a pull request](#creating-a-pull-request) for more details on creating and handling pull requests successfully.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,139 @@
+# MDN Web Docs contribution guide
+
+Thanks for taking the time to contribute to [MDN Web Docs](https://developer.mozilla.org)' translated content! :tada:
+
+This document covers project setup steps along with a set of guidelines for contributing to MDN Web Docs translated content.
+Everyone participating in this project is expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Getting started
+
+Before contributing to translated content, we strongly recommend learning about [how to contribute to the original (English) content][Contributing guide] (often referred to as "upstream content"). The upstream contributing guide explains the guidelines and conventions of MDN pages, as well as setup instructions for more significant changes.
+
+We also strongly recommend reading the [Translation guidelines][].
+
+In addition to the requirements described in the upstream contributing guide, there are additional prerequesites you must have when contributing to this repository:
+
+- **Moderate knowledge of the English language:** You must have a good enough understanding of the English language to be able to decipher the meaning of a page while translating. (For simple typo fixes, this is not required.)
+- **Fluency in the downstream locale:** You must be able to fluently speak the language you are contributing to.
+
+### Simple changes
+
+If you want to make a small change like fixing a typo, the GitHub UI is the easiest way to get started.
+If you've found a typo on the Simplified Chinese [JavaScript landing page](/zh-CN/docs/Web/JavaScript), for example, you can propose a fix as follows:
+
+1. Sign in to [GitHub](https://github.com/)
+2. Navigate to [https://github.com/mdn/translated-content](https://github.com/mdn/translated-content)
+3. Find the source file `files/zh-cn/web/javascript/index.md`
+4. Click the edit (pencil) button
+
+From there, the GitHub UI will walk you through the rest by creating a [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) and a branch to commit your changes to.
+After you have made changes to your branch, the goal is to open a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for your changes to be incorporated.
+
+A pull request represents the work you want to be reviewed, approved, and merged into the `main` branch of the MDN repository.
+See the [Creating a pull request](#creating-a-pull-request) for more details on creating and handling pull requests successfully.
+
+If you're not certain of the changes that you want to make, [get in touch with us](/en-US/docs/MDN/Community/Communication_channels)!
+
+> **Note:** You can click the **View the source on GitHub** or **Edit the page on GitHub** link at the bottom of an MDN page to jump directly to the page source on GitHub.
+
+### Forking and cloning the repository
+
+If you want to make changes to more than one file, the GitHub UI is not very efficient because you have to make separate pull requests for each file you want to change.
+Instead of using the GitHub UI, you need to use `git` or a client like [GitHub Desktop](https://docs.github.com/en/get-started/using-github/github-desktop) or [GitHub CLI](https://docs.github.com/en/github-cli/github-cli/about-github-cli).
+
+#### Set up `mdn/content` repo
+
+First, you will need to set up the `mdn/content` repo locally. If you do not plan to contribute to upstream content, you will not need to fork it as described in its [Contributing guide](https://github.com/mdn/content/blob/main/CONTRIBUTING.md#forking-and-cloning-the-repository); all you need to do is clone it by running the following command:
+
+```bash
+git clone git@github.com:mdn/content.git
+```
+
+After the repository has been cloned, follow the [steps to prepare the project](https://github.com/mdn/content/blob/main/CONTRIBUTING.md#preparing-the-project).
+
+#### Set up `mdn/translated-content` repo
+
+Once that is done, you will also need to fork and clone this repository by following the [upstream Contributing guide](https://github.com/mdn/content/blob/main/CONTRIBUTING.md#forking-and-cloning-the-repository), replacing `content` with `translated-content`.
+
+#### Link translated content
+
+1. Navigate to your local clone of the content repository fork:
+
+   ```bash
+   cd /path/to/content
+   ```
+
+2. Next, define an environment variable in a `.env` file called `CONTENT_TRANSLATED_ROOT` containing the path to the _translated-content_ repo’s `files` directory:
+
+   ```bash
+   # macOS/Linux
+   echo CONTENT_TRANSLATED_ROOT=/path/to/translated-content/files >> .env
+   ```
+
+   ```batch
+   # Windows
+   echo CONTENT_TRANSLATED_ROOT=\path\to\translated-content\files > .env
+   ```
+
+   (the `.env` file will be created for you if it does not already exist.)
+
+3. Run the command `yarn start` to start the local server at `localhost:5042`.
+
+#### Working in the translated-content repo
+
+This repo has exactly the same folder structure and concepts as the [upstream content repo](https://github.com/mdn/content). The main difference is in the setup you need to do before you can start editing. It is mostly the same, but there is a little bit more to consider. Primarily, commands such as `yarn content` are only available from the upstream content repo; linting commands are available here, however, as they often use different configuration.
+
+## Contributing to MDN translated content
+
+This section describes how to perform the most common types of contributions to MDN translated content.
+
+### Fix a typo
+
+To fix a typo, refer to the [Simple changes](#simple-changes) section.
+
+### Create a new translation
+
+To create a new translation for a page that does not yet have one, perform the following steps. For this example, we'll assume you are trying to translate the MDN landing page into French.
+
+1. Find the source file in the upstream content repository. (ex. `files/en-us/mdn/index.md`)
+2. Copy the file to the appropriate locale's folder. (ex. `cp files/en-us/mdn/index.md files/fr/mdn/index.md`)
+3. Update the front matter of the document.
+
+   1. Remove excess front matter properties (see [Translation guidelines][] to see which ones should be kept).
+   2. Localize the `title` and `short-title` (if present)
+   3. Add a new `l10n.sourceCommit` key, which contains the commit hash of the latest commit that modified the file. You can do this by running `git log <file>`.
+
+   The front matter should look like this:
+
+   ```md
+   ---
+   title: Le projet MDN Web Docs
+   slug: MDN
+   l10n:
+     sourceCommit: 048f6b1c75e22103ddb0304d67ee79d6d8a014f0
+   ---
+   ```
+
+4. Translate the file, following the [Translation guidelines][].
+5. Create a commit, push your branch and create a pull request!
+
+### Update an existing translation
+
+If a translation is no longer in sync with upstream content (in other words, the English version has changed since the page was translated), the translation will need to be updated.
+
+At the time of writing this document, a massive cleanup of translated content is in progress. Many documents still do not have a `l10n.sourceCommit` front matter property. As we update these old files, eventually we aim to have a `l10n.sourceCommit` property defined on all files.
+
+#### Has a source commit property
+
+XXX Write me...
+
+#### No source commit present
+
+XXX Write me...
+
+## License
+
+When contributing to the content you agree to license your contributions according to [our license](LICENSE.md).
+
+[Contributing guide]: https://github.com/mdn/content/blob/main/CONTRIBUTING.md
+[Translation guidelines]: docs/README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,4 +132,4 @@ When contributing to the content you agree to license your contributions accordi
 [Contributing guide]: https://github.com/mdn/content/blob/main/CONTRIBUTING.md
 [Translation guidelines]: docs/README.md
 [JavaScript landing page]: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript
-[get in touch with us]: https://developer.mozilla.org/en-US/docs/MDN/Community/Communication_channels
+[get in touch with us]: https://developer.mozilla.org/docs/MDN/Community/Communication_channels

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,11 @@ In addition to the requirements described in the upstream contributing guide, th
 ### Simple changes
 
 If you want to make a small change like fixing a typo, the GitHub UI is the easiest way to get started.
-If you've found a typo on the Simplified Chinese [JavaScript landing page](/zh-CN/docs/Web/JavaScript), for example, you can propose a fix as follows:
+If you've found a typo on the Simplified Chinese [JavaScript landing page][], for example, you can propose a fix as follows:
 
 1. Sign in to [GitHub](https://github.com/)
 2. Navigate to [https://github.com/mdn/translated-content](https://github.com/mdn/translated-content)
-3. Find the source file `files/zh-cn/web/javascript/index.md`
+3. Find the source file [`files/zh-cn/web/javascript/index.md`](files/zh-cn/web/javascript/index.md)
 4. Click the edit (pencil) button
 
 From there, the GitHub UI will walk you through the rest by creating a [fork](https://docs.github.com/get-started/quickstart/fork-a-repo) and a branch to commit your changes to.
@@ -32,7 +32,7 @@ After you have made changes to your branch, the goal is to open a [pull request]
 A pull request represents the work you want to be reviewed, approved, and merged into the `main` branch of the MDN repository.
 See the [Creating a pull request](#creating-a-pull-request) for more details on creating and handling pull requests successfully.
 
-If you're not certain of the changes that you want to make, [get in touch with us](/en-US/docs/MDN/Community/Communication_channels)!
+If you're not certain of the changes that you want to make, [get in touch with us][]!
 
 > **Note:** You can click the **View the source on GitHub** or **Edit the page on GitHub** link at the bottom of an MDN page to jump directly to the page source on GitHub.
 
@@ -131,3 +131,5 @@ When contributing to the content you agree to license your contributions accordi
 
 [Contributing guide]: https://github.com/mdn/content/blob/main/CONTRIBUTING.md
 [Translation guidelines]: docs/README.md
+[JavaScript landing page]: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript
+[get in touch with us]: https://developer.mozilla.org/en-US/docs/MDN/Community/Communication_channels

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ If you're not certain of the changes that you want to make, [get in touch with u
 ### Forking and cloning the repository
 
 If you want to make changes to more than one file, the GitHub UI is not very efficient because you have to make separate pull requests for each file you want to change.
-Instead of using the GitHub UI, you need to use `git` or a client like [GitHub Desktop](https://docs.github.com/en/get-started/using-github/github-desktop) or [GitHub CLI](https://docs.github.com/en/github-cli/github-cli/about-github-cli).
+Instead of using the GitHub UI, you need to use `git` or a client like [GitHub Desktop](https://docs.github.com/get-started/using-github/github-desktop) or [GitHub CLI](https://docs.github.com/github-cli/github-cli/about-github-cli).
 
 #### Set up `mdn/content` repo
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you've found a typo on the Simplified Chinese [JavaScript landing page](/zh-C
 3. Find the source file `files/zh-cn/web/javascript/index.md`
 4. Click the edit (pencil) button
 
-From there, the GitHub UI will walk you through the rest by creating a [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) and a branch to commit your changes to.
+From there, the GitHub UI will walk you through the rest by creating a [fork](https://docs.github.com/get-started/quickstart/fork-a-repo) and a branch to commit your changes to.
 After you have made changes to your branch, the goal is to open a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for your changes to be incorporated.
 
 A pull request represents the work you want to be reviewed, approved, and merged into the `main` branch of the MDN repository.
@@ -46,7 +46,7 @@ Instead of using the GitHub UI, you need to use `git` or a client like [GitHub D
 First, you will need to set up the `mdn/content` repo locally. If you do not plan to contribute to upstream content, you will not need to fork it as described in its [Contributing guide](https://github.com/mdn/content/blob/main/CONTRIBUTING.md#forking-and-cloning-the-repository); all you need to do is clone it by running the following command:
 
 ```bash
-git clone git@github.com:mdn/content.git
+git clone https://github.com/mdn/content.git
 ```
 
 After the repository has been cloned, follow the [steps to prepare the project](https://github.com/mdn/content/blob/main/CONTRIBUTING.md#preparing-the-project).
@@ -95,8 +95,8 @@ To fix a typo, refer to the [Simple changes](#simple-changes) section.
 
 To create a new translation for a page that does not yet have one, perform the following steps. For this example, we'll assume you are trying to translate the MDN landing page into French.
 
-1. Find the source file in the upstream content repository. (ex. `files/en-us/mdn/index.md`)
-2. Copy the file to the appropriate locale's folder. (ex. `cp files/en-us/mdn/index.md files/fr/mdn/index.md`)
+1. Find the source file in the upstream content repository. (ex. `/path/to/content/files/en-us/mdn/index.md`)
+2. Copy the file to the appropriate locale's folder. (ex. `cp /path/to/content/files/en-us/mdn/index.md files/fr/mdn/index.md`)
 3. Update the front matter of the document.
 
    1. Remove excess front matter properties (see [Translation guidelines][] to see which ones should be kept).

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ By participating in and contributing to our projects and discussions, you acknow
 
 ## Get in touch
 
-You can communicate with the MDN Web Docs team and community using the [communication channels](/en-US/docs/MDN/Community/Communication_channels).
+You can communicate with the MDN Web Docs team and community using the [communication channels][main communication].
 
-Additionally, you can communicate with a specific localization tem using their own available [communication channels](/en-US/docs/MDN/Community/Contributing/Translated_content).
+Additionally, you can communicate with a specific localization tem using their own available [communication channels][localization communication].
+
+[main communication]: https://developer.mozilla.org/en-US/docs/MDN/Community/Communication_channels
+[localization communication]: https://developer.mozilla.org/en-US/docs/MDN/Community/Contributing/Translated_content

--- a/README.md
+++ b/README.md
@@ -28,59 +28,16 @@ Everyone participating in this project is expected to follow our [Code of Conduc
 
 When contributing to the content you agree to license your contributions according to [our license](LICENSE.md).
 
-## Making contributions
+## Contribute to MDN Web Docs
 
-A good place to learn about general guidelines for contributing to [MDN Web Docs](https://developer.mozilla.org) is the [Guidelines document][]. For example, you can find out more about MDN's writing-style guidelines via the [Writing style guide][].
+You can contribute to MDN Web Docs and be a part of our community through content contributions, engineering, or translation work.
+The MDN Web Docs project welcomes contributions from everyone who shares our goals and wants to contribute constructively and respectfully within our community.
 
-### Setting up to edit
+To find out how to get started, see the [CONTRIBUTING.md](CONTRIBUTING.md) document in this repository.
+By participating in and contributing to our projects and discussions, you acknowledge that you have read and agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
 
-This repo has exactly the same folder structure, concepts, and commands available to it as the [content repo](https://github.com/mdn/content), which holds all of MDN's English content. The main difference is in the setup you need to do before you can start editing. It is mostly the same, but there is a little bit more to consider.
+## Get in touch
 
-The basic build steps are described in the content repo [Build the site](https://github.com/mdn/content#build-the-site) section. More detailed steps along with hints for tooling are covered in the content repo [Contributing guide](https://github.com/mdn/content/blob/main/CONTRIBUTING.md)
+You can communicate with the MDN Web Docs team and community using the [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
-Now you need to fork and clone both the [content repo](https://github.com/mdn/content) and the translated-content repo (this repo).
-
-### Content repo setup
-
-1. Navigate to your local clone of the content repository fork:
-
-   ```bash
-   cd ~/path/to/content
-   ```
-
-2. Run the command `yarn install` to fetch the latest packages and get the local MDN testing environment set up. It is also recommended that you run `yarn install` before every update you do to the source, to make sure you have the latest packages.
-
-3. Next, create an environment variable called `CONTENT_TRANSLATED_ROOT` containing the path to the _translated-content_ repo’s `files` directory. You could do this for a single session like so:
-
-   ```bash
-   export CONTENT_TRANSLATED_ROOT=/path/to/translated-content/files
-   ```
-
-   You must set this every time you start a new shell or terminal session. To avoid this, you can put the environment variable in a `.env` file at the root of your content repo. You can do this with the following command:
-
-   ```bash
-   echo CONTENT_TRANSLATED_ROOT=/path/to/translated-content/files >> .env
-   ```
-
-   (the `.env` file will be created for you if it does not already exist.)
-
-4. Run the command `yarn start` to start the local server at `localhost:5042`.
-
-### Working in the translated-content repo
-
-Over in the translated-content repo, decide what change you want to make, and then:
-
-1. Create a new branch to make your changes in.
-
-2. Switch to your new branch and make the changes you want to make. You can keep going back to `localhost:5042/<your_locale>` (e.g. `localhost:5042/fr` for French) to test your changes and make sure the content looks how you want it to look.
-
-3. When you are satisfied with your changes, create a pull request and one of our review teams will review it.
-
-4. When your pull request is merged by a reviewer, the changes may take up to 48 hours to be visible.
-
-### For more info on editing this repo
-
-For more information, we'd like to suggest that you go to the [content repo](https://github.com/mdn/content) and read its contribution guide, particularly to learn about [how to get started](https://github.com/mdn/content/blob/main/CONTRIBUTING.md#getting-started), [pull request etiquette](https://github.com/mdn/content/blob/main/CONTRIBUTING.md#pull-request-etiquette), and common actions such as [adding](https://github.com/mdn/content/blob/main/CONTRIBUTING.md#adding-a-new-document), [moving](https://github.com/mdn/content/blob/main/CONTRIBUTING.md#moving-documents), or [deleting](https://github.com/mdn/content/blob/main/CONTRIBUTING.md#deleting-a-document) documents.
-
-[Guidelines document]: https://developer.mozilla.org/docs/MDN/Writing_guidelines
-[Writing style guide]: https://developer.mozilla.org/docs/MDN/Writing_guidelines/Writing_style_guide
+Additionally, you can communicate with a specific localization tem using their own available [communication channels](/en-US/docs/MDN/Community/Contributing/Translated_content).

--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ You can communicate with the MDN Web Docs team and community using the [communic
 
 Additionally, you can communicate with a specific localization tem using their own available [communication channels][localization communication].
 
-[main communication]: https://developer.mozilla.org/en-US/docs/MDN/Community/Communication_channels
-[localization communication]: https://developer.mozilla.org/en-US/docs/MDN/Community/Contributing/Translated_content
+[main communication]: https://developer.mozilla.org/docs/MDN/Community/Communication_channels
+[localization communication]: https://developer.mozilla.org/docs/MDN/Community/Contributing/Translated_content

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,8 @@
-# General guidelines for MDN translated content
+# Translation guidelines for MDN translated content
 
-In this README you can find a collection of general guidelines for translating
-MDN content, which apply to every locale.
+This document describes the general guidelines for translating MDN content, which apply to every locale.
 
-For guidelines relating to specific locales, we have locale-specific docs in
-subdirectories:
+For guidelines relating to specific locales, we have locale-specific docs in subdirectories:
 
 - [Russian translation guide / Участие в переводе](ru/translation-guide.md)
 - [Simplified Chinese Guide / 简体中文翻译指南](zh-cn/translation-guide.md)
@@ -13,66 +11,41 @@ subdirectories:
 - [Japanese translation guide / 日本語翻訳ガイド](ja/README.md)
 - [Korean translation guide / 한국 번역 지침](ko/README.md)
 
-If you want to add a guide to document some specific guidelines for your locale
-and it does not already appear here, you are welcome to add one, or
-[talk to the locale teams](https://github.com/mdn/translated-content/blob/main/PEERS_GUIDELINES.md#review-teams)
-about it. Similarly, if you can think of a good general guideline that you'd
-like to add here, feel free to create an issue to talk about it.
+> **Note:** If you want to add a guide to document some specific guidelines for your locale and it does not already appear here, you are welcome to add one, or [talk to the locale teams](https://github.com/mdn/translated-content/blob/main/PEERS_GUIDELINES.md#review-teams) about it.
 
-## Translating heading IDs
+## Do not copy all front matter properties from English pages
 
-Our article headings are nearly always given IDs, so that we can automatically
-generate in-article navigation, identify code blocks to create live samples,
-and other reasons too. When translating headings, you don't need to translate
-the ID too; the rest of the slug is not translated, so this keeps it all
-consistent.
+In upstream content, pages will have many front matter properties, including `page-type` and `browser-compat`. However, these properties do not need to be copied to translated pages; Yari merges the front matter of the English and translated versions of a page. Localized documents should only have the following front matter properties:
 
-For example:
+- `title` - A long title for the page; to localize
+- `short-title` - A short title for the page which appears in sidebars; also to localize
+- `slug` - needs to match the original page's `slug`
+- `l10n.sourceCommit` - The commit hash of the upstream commit the translation is synchronized with
 
-```html
-<h2 id="tutorials">Tutorials</h2>
-```
+This guideline is enforced by a linter.
 
-in the `fr` locale would be
+## Do not partially translate a document
 
-```html
-<h2 id="tutorials">Tutoriels</h2>
-```
+At the time of writing, there are numerous documents throughout the repository that are partially translated. The documents were created in the wiki era before this project transitioned to GitHub, where anyone could make changes to the pages without review. Partially translated pages are bad for numerous reasons:
 
-We generally advise that you write all IDs in lower-case. The platform
-automatically converts them at render time anyway, but keeping them lower-case
-means that there is less chance of a manually-created anchor link not working
-because of the conversion.
+- They provide a negative user experience if only part of the page is in their requested locale
+- They produce a negative SEO score because of the above reason
+- The upstream content may have changed, but contributors will likely continue working on the English content in that file
 
-## Translating code blocks
+If you are translating a document, please follow through and translate the entire page. If you need assistance translating a section, please ask a member of your locale for help.
 
-When translating code blocks, it is fine to translate comments, strings,
-variable names, and output representations.
+## Do not use machine translation
 
-However, don't translate actual code terms such as syntax. The example needs
-to still work after you are finished with it.
+Using machine translation services can be helpful to discern the meaning of a word you may not know, and machine translations have greatly improved over the years. However, machines are not able to _localize_ content. They cannot discern complete context, and may over-translate or use different words for the same terms in different sentences. Do not use machine translations to localize content; only use them as a reference.
 
-Also, when considering translating examples, bear in mind that some examples
-will link to a live version or source code on a separate repo. You might also
-want to consider creating a translated version of the external code examples
-to link to from your translated page.
+## Localizing code blocks
 
-## Line breaks in HTML source
+Many code blocks are present in MDN pages. We encourage the localization of code blocks, as long as you follow the following guidelines:
 
-In some of the article source code, you may find line breaks in the block-level
-elements that aren't strictly necessary, for example:
+- Translate comments, strings and output representations
+  - Translating variable and function names is not recommended, except in learn/
+- Do not translate syntax (`await`, `console`, etc.) which would break the code
+- Ensure that the code example is not completely rewritten, unless it is absolutely essential
+  - If a code block must be rewritten to meet a locale's requirements, add a comment explaining why
 
-```html-nolint
-<p>The
-  <strong><code>HTMLCanvasElement.transferControlToOffscreen()</code></strong>
-  method transfers control to an {{domxref("OffscreenCanvas")}} object, either on the main
-  thread or on a worker.</p>
-
-<pre
-  class="brush: js">OffscreenCanvas HTMLCanvasElement.transferControlToOffscreen()</pre>
-```
-
-Generally we don't use line breaks like this in our source code, so you are
-free to remove them if you want to, and don't add them in when creating new
-translations. However, don't spend too much time trying to remove these, as
-they don't make any difference to the final rendered result.
+Also, when considering translating examples, bear in mind that some examples will link to a live version or source code on a separate repo. You might also want to consider creating a translated version of the external code examples to link to from your translated page.


### PR DESCRIPTION
This PR overhauls the contribution docs, performing a few main updates:

- Adds CONTRIBUTING.md with a structure similar to upstream
  - Moves the "Getting started" section in the main readme to there
  - Adds a new section for common contribution types
  - Better explains the setup process
- Updates the general translation guidelines
  - Removes outdated guidelines and adds new ones
