### PR TITLE
[ja] Fix: toFixed の digits の例外章の誤訳を修正

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/number/tofixed/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/tofixed/index.md
@@ -30,7 +30,7 @@ toFixed(digits)
 ## 例外
 
 - {{jsxref("RangeError")}}
-  - : `digits` が `1` 以上 `100` 以下ではない場合に発生します。
+  - : `digits` が `0` 以上 `100` 以下ではない場合に発生します。
 - {{jsxref("TypeError")}}
   - : このメソッドが {{jsxref("Number")}} ではないオブジェクト上で実行された場合に発生します。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
例外に書かれている
```
`digits` が `1` 以上 `100` 以下ではない場合に発生します。
```
は、0も受理してエラーは発生しないので、
```
`digits` が `0` 以上 `100` 以下ではない場合に発生します。
```
の誤訳です。

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
[英語版](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
