### PR TITLE
Fix lint script when files are only deleted

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -69,6 +69,7 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Lint and format markdown files
+        if: ${{ env.DIFF_DOCUMENTS }}
         run: |
           # Generate random delimiter
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -1,9 +1,3 @@
-# This is more or less a copy of
-# https://github.com/mdn/content/blob/main/.github/workflows/pr-check-lint_content.yml
-# but done in a way that it first checks out mdn/translated-content (or
-# fork of) and _then_ checks out mdn/content which has the relevant
-# CI related tooling.
-
 name: Lint and review content files
 
 on:


### PR DESCRIPTION
This PR fixes the lint workflow to only perform formatting when there are files to format.  This prevents a failure when documents have only been deleted.

Additionally, this removes a now outdated comment.