### PR TITLE
es: Fix sourceCommit frontmatter

### DIFF
--- a/files/es/web/javascript/reference/global_objects/array/keys/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/keys/index.md
@@ -1,6 +1,8 @@
 ---
 title: Array.prototype.keys()
 slug: Web/JavaScript/Reference/Global_Objects/Array/keys
+l10n:
+  sourceCommit: 194d3e00cb93a6e5ea44812548f4131cb17f0381
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/error/cause/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/cause/index.md
@@ -1,6 +1,8 @@
 ---
 title: "Error: cause"
 slug: Web/JavaScript/Reference/Global_Objects/Error/cause
+l10n:
+  sourceCommit: 6a0f9553932823cd0c4dcf695d4b4813474964fb
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/error/message/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/message/index.md
@@ -1,6 +1,8 @@
 ---
 title: "Error: message"
 slug: Web/JavaScript/Reference/Global_Objects/Error/message
+l10n:
+  sourceCommit: 6b728699f5f38f1070a94673b5e7afdb1102a941
 ---
 
 {{JSRef}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I notice that the `sourceCommit` frontmatter was removed due to a typo in the name

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!--
  https://github.com/mdn/translated-content/pull/14852
  https://github.com/mdn/translated-content/pull/14853
-->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
