### PR TITLE
ja: Remove unneeded .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -46,7 +46,6 @@ build/
 # The following folders still need a full pass:
 
 # ja
-/files/ja/mdn/**/*.md
 /files/ja/web/api/**/*.md
 /files/ja/web/css/**/*.md
 /files/ja/web/html/**/*.md


### PR DESCRIPTION
This PR removes an unneeded Prettier ignore for the `/mdn` folder of the Japanese locale.
