### PR TITLE
[ko] add missing code in 'rust_to_wasm' md

### DIFF
--- a/files/ko/webassembly/rust_to_wasm/index.md
+++ b/files/ko/webassembly/rust_to_wasm/index.md
@@ -186,6 +186,7 @@ JavaScript 함수를 호출하고 싶을 때면 언제든지 이들을 파일에
     description = "A sample project with wasm-pack"
     license = "MIT/Apache-2.0"
     repository = "https://github.com/yourgithubusername/hello-wasm"
+    edition = "2018"
 
     [lib]
     crate-type = ["cdylib"]


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
<!-- ✍️ Summarize your changes in one or two sentences -->
Add missing code in 'rust_to_wasm' md

### Motivation
<!-- ❓ Why are you making these changes and how do they help readers? -->
If `edition` is missing, default edition is "2015" which edition version could cause errors.
Othere languages already added this edition code. But ko version of this document is missing.

### Additional details
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
I could not found this issue, but I found it following 'rust_to_wasm' md document.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
