### PR TITLE
Add --expectedLocale argument to check-document-locale script

### DIFF
--- a/scripts/check-document-locale.js
+++ b/scripts/check-document-locale.js
@@ -153,6 +153,13 @@ const main = async () => {
           type: "string",
           default: "md",
           choices: ["md", "csv", "json"],
+        })
+        .option("expectedLocale", {
+          alias: "l",
+          describe: "The expected locale of the files",
+          type: "string",
+          default: "ENGLISH",
+          choices: LANGUAGES,
         });
     },
   );
@@ -184,7 +191,7 @@ const main = async () => {
     spinner.text = `${i}/${files.length}: ${file}...`;
 
     try {
-      data[file] = await getDocumentLanguages(file);
+      data[file] = await getDocumentLanguages(file, argv.expectedLocale);
 
       if (!data[file]) {
         spinner.fail(`${file}: Failed to identify language!`);


### PR DESCRIPTION
This PR adds an `--expectedLocale` argument to the `check-document-locale` script.  This is passed into the underlying library to give it a hint at what locale is expected, which may improve results.
