### PR TITLE
Update paths in markdown-lint.yml

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - .nvmrc
       - .markdownlint-cli2.jsonc
+      - .markdownlint.jsonc
+      - "**/.markdownlint.jsonc"
       - package.json
       - yarn.lock
       - .github/workflows/markdown-lint.yml

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - .nvmrc
       - .markdownlint-cli2.jsonc
-      - .markdownlint.jsonc
       - "**/.markdownlint.jsonc"
       - package.json
       - yarn.lock


### PR DESCRIPTION
This updates the `markdown-lint` workflow to check for changes to any `.markdownlint.jsonc` file as well. This is a follow-up to #15106.