### PR TITLE
chore(ci): bump prettier to v3.0.2 and re-format documents

### DIFF
--- a/files/es/web/api/screen_capture_api/index.md
+++ b/files/es/web/api/screen_capture_api/index.md
@@ -16,9 +16,8 @@ La API de captura de pantalla es relativamente simple de usar. Su único método
 Para comenzar a capturar video desde la pantalla, llama a `getDisplayMedia()` en `navigator.mediaDevices`:
 
 ```js
-captureStream = await navigator.mediaDevices.getDisplayMedia(
-  displayMediaOptions,
-);
+captureStream =
+  await navigator.mediaDevices.getDisplayMedia(displayMediaOptions);
 ```
 
 La {{jsxref("Promise","Promesa")}} devuelta por `getDisplayMedia()` se resuelve en un {{domxref("MediaStream")}} que transmite los medios capturados.

--- a/files/es/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/es/web/api/screen_capture_api/using_screen_capture/index.md
@@ -22,9 +22,8 @@ async function startCapture(displayMediaOptions) {
   let captureStream = null;
 
   try {
-    captureStream = await navigator.mediaDevices.getDisplayMedia(
-      displayMediaOptions,
-    );
+    captureStream =
+      await navigator.mediaDevices.getDisplayMedia(displayMediaOptions);
   } catch (err) {
     console.error(`Error: ${err}`);
   }
@@ -213,9 +212,8 @@ async function startCapture() {
   logElem.innerHTML = "";
 
   try {
-    videoElem.srcObject = await navigator.mediaDevices.getDisplayMedia(
-      displayMediaOptions,
-    );
+    videoElem.srcObject =
+      await navigator.mediaDevices.getDisplayMedia(displayMediaOptions);
     dumpOptionsInfo();
   } catch (err) {
     console.error(err);

--- a/files/fr/web/api/screen_capture_api/index.md
+++ b/files/fr/web/api/screen_capture_api/index.md
@@ -14,9 +14,8 @@ L'API Screen Capture est relativement simple à utiliser. Sa seule méthode est 
 Pour commencer à capturer une vidéo de l'écran, il faut appeler `getDisplayMedia()` dans une instance de `navigator.mediaDevices`
 
 ```js
-captureStream = await navigator.mediaDevices.getDisplayMedia(
-  displayMediaOptions,
-);
+captureStream =
+  await navigator.mediaDevices.getDisplayMedia(displayMediaOptions);
 ```
 
 La [promesse](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) retournée par `getDisplayMedia()` est résolue en un objet [`MediaStream`](/fr/docs/Web/API/MediaStream) qui diffuse le média capturé.

--- a/files/ru/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/ru/web/api/screen_capture_api/using_screen_capture/index.md
@@ -20,9 +20,8 @@ async function startCapture(displayMediaOptions) {
   let captureStream = null;
 
   try {
-    captureStream = await navigator.mediaDevices.getDisplayMedia(
-      displayMediaOptions,
-    );
+    captureStream =
+      await navigator.mediaDevices.getDisplayMedia(displayMediaOptions);
   } catch (err) {
     console.error("Error: " + err);
   }
@@ -233,9 +232,8 @@ async function startCapture() {
   logElem.innerHTML = "";
 
   try {
-    videoElem.srcObject = await navigator.mediaDevices.getDisplayMedia(
-      displayMediaOptions,
-    );
+    videoElem.srcObject =
+      await navigator.mediaDevices.getDisplayMedia(displayMediaOptions);
     dumpOptionsInfo();
   } catch (err) {
     console.error("Error: " + err);

--- a/files/zh-cn/web/api/mediadevices/getdisplaymedia/index.md
+++ b/files/zh-cn/web/api/mediadevices/getdisplaymedia/index.md
@@ -54,9 +54,8 @@ async function startCapture(displayMediaOptions) {
   let captureStream = null;
 
   try {
-    captureStream = await navigator.mediaDevices.getDisplayMedia(
-      displayMediaOptions,
-    );
+    captureStream =
+      await navigator.mediaDevices.getDisplayMedia(displayMediaOptions);
   } catch (err) {
     console.error("Error: " + err);
   }

--- a/files/zh-cn/web/api/screen_capture_api/index.md
+++ b/files/zh-cn/web/api/screen_capture_api/index.md
@@ -14,9 +14,8 @@ slug: Web/API/Screen_Capture_API
 要开始从屏幕上捕捉视频，你需要在 `getDisplayMedia()` 的实例上调用 `Media` `navigator.mediaDevices`：
 
 ```js
-captureStream = await navigator.mediaDevices.getDisplayMedia(
-  displayMediaOptions,
-);
+captureStream =
+  await navigator.mediaDevices.getDisplayMedia(displayMediaOptions);
 ```
 
 The {{jsxref("Promise")}} returned by `getDisplayMedia()` resolves to a {{domxref("MediaStream")}} which streams the captured media.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "markdownlint-cli2": "0.8.1",
     "markdownlint-rule-search-replace": "1.1.0",
     "ora": "^7.0.1",
-    "prettier": "3.0.1",
+    "prettier": "3.0.2",
     "yargs": "^17.7.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -662,10 +662,10 @@ pidtree@0.6.0:
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
   integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
 
-prettier@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.1.tgz#65271fc9320ce4913c57747a70ce635b30beaa40"
-  integrity sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==
+prettier@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmmirror.com/prettier/-/prettier-3.0.2.tgz#78fcecd6d870551aa5547437cdae39d4701dca5b"
+  integrity sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"


### PR DESCRIPTION
### Description

bump prettier to v3.0.2 and re-format documents

### Motivation

[Breaking changes in v3.0.3](https://github.com/prettier/prettier/blob/main/CHANGELOG.md#302).

### Related issues and pull requests

Follow: mdn/content#28648.
