### PR TITLE
chore(ci/markdown-lint-fix): replace deprecated command

### DIFF
--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Lint Markdown files
         run: |
-          yarn markdownlint-cli2-fix "**/${{ matrix.lang }}/**/*.md"
+          yarn markdownlint-cli2 --fix "**/${{ matrix.lang }}/**/*.md"
           yarn prettier -w "**/${{ matrix.lang }}/**/*.md"
           cd ${{ github.workspace }}/mdn/content && yarn fix:fm --config-file ${{ github.workspace }}/front-matter-config.json "${{ github.workspace }}/files/${{ matrix.lang }}"
 


### PR DESCRIPTION
### Description

replace [deprecated command](https://github.com/DavidAnson/markdownlint-cli2#command-line): `markdownlint-cli2-fix`.

As we have already done this in [package.json](https://github.com/mdn/translated-content/blob/978a7f49b586dd1e8f477aa49ab36b6fdd5745b9/package.json#L19)
