### PR TITLE
Fix accidental use of "i10n" vs. "l10n"

### DIFF
--- a/files/ja/webassembly/exported_functions/index.md
+++ b/files/ja/webassembly/exported_functions/index.md
@@ -1,7 +1,7 @@
 ---
 title: エクスポートされた WebAssembly 関数
 slug: WebAssembly/Exported_functions
-i10n:
+l10n:
   sourceCommit: 0cfdd279edb09f70fbeb52c67ecc2876da5ce32d
 ---
 

--- a/files/ja/webassembly/loading_and_running/index.md
+++ b/files/ja/webassembly/loading_and_running/index.md
@@ -1,7 +1,7 @@
 ---
 title: WebAssembly コードの読み込みと実行
 slug: WebAssembly/Loading_and_running
-i10n:
+l10n:
   sourceCommit: 4a6dacf8c68925a8538585be3b2728bcb271241e
 ---
 

--- a/files/ja/webassembly/text_format_to_wasm/index.md
+++ b/files/ja/webassembly/text_format_to_wasm/index.md
@@ -1,7 +1,7 @@
 ---
 title: WebAssembly テキスト形式から Wasm への変換
 slug: WebAssembly/Text_format_to_Wasm
-i10n:
+l10n:
   sourceCommit: 0cfdd279edb09f70fbeb52c67ecc2876da5ce32d
 ---
 

--- a/files/ja/webassembly/understanding_the_text_format/index.md
+++ b/files/ja/webassembly/understanding_the_text_format/index.md
@@ -1,7 +1,7 @@
 ---
 title: WebAssembly テキスト形式の理解
 slug: WebAssembly/Understanding_the_text_format
-i10n:
+l10n:
   sourceCommit: acfe8c9f1f4145f77653a2bc64a9744b001358dc
 ---
 

--- a/files/ja/webassembly/using_the_javascript_api/index.md
+++ b/files/ja/webassembly/using_the_javascript_api/index.md
@@ -1,7 +1,7 @@
 ---
 title: WebAssembly JavaScript API の使用
 slug: WebAssembly/Using_the_JavaScript_API
-i10n:
+l10n:
   sourceCommit: acfe8c9f1f4145f77653a2bc64a9744b001358dc
 ---
 

--- a/files/ko/learn/performance/video/index.md
+++ b/files/ko/learn/performance/video/index.md
@@ -1,7 +1,7 @@
 ---
 title: "멀티미디어: 비디오"
 slug: Learn/Performance/video
-i10n:
+l10n:
   sourceCommit: bb026bcb88b7f45374d602301b7b0db5a49ff303
 ---
 

--- a/files/ko/web/javascript/reference/global_objects/aggregateerror/aggregateerror/index.md
+++ b/files/ko/web/javascript/reference/global_objects/aggregateerror/aggregateerror/index.md
@@ -1,7 +1,7 @@
 ---
 title: AggregateError() constructor
 slug: Web/JavaScript/Reference/Global_Objects/AggregateError/AggregateError
-i10n:
+l10n:
   sourceCommit: 6a0f9553932823cd0c4dcf695d4b4813474964fb
 ---
 


### PR DESCRIPTION
This PR fixes accidental use of `i10n` as the front matter key, instead of `l10n`.
