### PR TITLE
Fix front matter config for original_slug

### DIFF
--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -44,5 +44,5 @@
       }
     }
   },
-  "attribute-order": ["title", "short-title", "slug", "l10n"]
+  "attribute-order": ["title", "short-title", "slug", "original_slug", "l10n"]
 }


### PR DESCRIPTION
This PR fixes the front matter config regarding the `original_slug` key.
