### PR TITLE
fix(ci/pr-check-lint): setup node only once

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -59,26 +59,21 @@ jobs:
           DIFF_DOCUMENTS=$(echo "${DIFF_DOCUMENTS}" | egrep -i ".*\.md$" | xargs)
           echo "DIFF_DOCUMENTS=${DIFF_DOCUMENTS}" >> $GITHUB_ENV
 
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-          cache: yarn
-
-      - name: Install all yarn packages
-        run: yarn --frozen-lockfile
-
       - uses: actions/checkout@v3
         with:
           repository: mdn/content
           path: mdn/content
 
-      - name: Setup Node.js environment for mdn/content
+      - name: Setup Node.js environment
+        if: ${{ env.DIFF_DOCUMENTS }}
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-          cache: "yarn"
-          cache-dependency-path: mdn/content/yarn.lock
+          cache: yarn
+          cache-dependency-path: "**/yarn.lock"
+
+      - name: Install all yarn packages for mdn/translated-content
+        run: yarn --frozen-lockfile
 
       - name: Install all yarn packages for mdn/content
         working-directory: ${{ github.workspace }}/mdn/content

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -65,7 +65,6 @@ jobs:
           path: mdn/content
 
       - name: Setup Node.js environment
-        if: ${{ env.DIFF_DOCUMENTS }}
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"


### PR DESCRIPTION
### Description

setup node only once, avoid duplication of setup nodes.

### Additional details

This cache feature is supported by [action/setup-node@v3](https://github.com/actions/setup-node/blob/5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d/docs/advanced-usage.md?plain=1#L272C4-L283).

Tested here: yin1999/translated-content#28 (also port mdn/content#28448 into translated-content, I'd like to do this in another PR).
