### PR TITLE
fix(ci/pr-check-lint): run front matter lint with correct context

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -106,7 +106,7 @@ jobs:
 
           echo "Linting front-matter"
           FM_LINT_FAILED=false
-          FM_LINT_LOG=$(cd ${{ github.workspace }}/mdn/content && yarn fix:fm --config-file ${{ github.workspace }}/front-matter-config.json --fix true ${files_to_lint} 2>&1) || FM_LINT_FAILED=true
+          FM_LINT_LOG=$(node ${{ github.workspace }}/mdn/content/scripts/front-matter_linter.js --config-file front-matter-config.json --fix true ${files_to_lint} 2>&1) || FM_LINT_FAILED=true
           echo "FM_LINT_LOG<<${EOF}" >> $GITHUB_ENV
           echo "${FM_LINT_LOG}" >> $GITHUB_ENV
           echo "${EOF}" >> $GITHUB_ENV
@@ -121,6 +121,7 @@ jobs:
 
           # info for troubleshooting
           echo MD_LINT_FAILED=${MD_LINT_FAILED}
+          echo FM_LINT_FAILED=${FM_LINT_FAILED}
           git diff
 
       - name: Setup reviewdog
@@ -157,9 +158,11 @@ jobs:
             -reporter="github-pr-review"
 
       - name: Fail if any issues pending
-        if: env.FILES_MODIFIED == 'true' || env.MD_LINT_FAILED == 'true'
+        if: env.FILES_MODIFIED == 'true' || env.MD_LINT_FAILED == 'true' || env.FM_LINT_FAILED == 'true'
         run: |
           echo -e "\nLogs from markdownlint:"
           echo "${{ env.MD_LINT_LOG }}"
+          echo -e "\nLogs from front-matter linter:"
+          echo "${{ env.FM_LINT_LOG }}"
           echo -e "\nPlease fix all the linting issues mentioned in above logs and in the review comments."
           exit 1

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -106,7 +106,9 @@ jobs:
 
           echo "Linting front-matter"
           FM_LINT_FAILED=false
-          FM_LINT_LOG=$(node ${{ github.workspace }}/mdn/content/scripts/front-matter_linter.js --config-file front-matter-config.json --fix true ${files_to_lint} 2>&1) || FM_LINT_FAILED=true
+          # absolute_paths is needed because front-matter linter is run from mdn/content directory
+          absolute_paths=$(echo "${files_to_lint}" | xargs realpath -e | xargs)
+          FM_LINT_LOG=$(cd ${{ github.workspace }}/mdn/content && yarn fix:fm --config-file ${{ github.workspace }}/front-matter-config.json ${absolute_paths} 2>&1) || FM_LINT_FAILED=true
           echo "FM_LINT_LOG<<${EOF}" >> $GITHUB_ENV
           echo "${FM_LINT_LOG}" >> $GITHUB_ENV
           echo "${EOF}" >> $GITHUB_ENV


### PR DESCRIPTION
### Description

run front matter lint with correct context.

### Motivation

When check the working directory to `mdn/content` the front matter lint wil not find the document correctly.

See the log here: https://github.com/mdn/translated-content/actions/runs/6091642909/job/16528549282#step:14:26

And CI [won't fail](https://github.com/mdn/translated-content/actions/runs/6091730430) if the front-matter linter finds an error, adding the `env.FM_LINT_FAILED == 'true'` condition to the "Fail if any issues pending" step. (check the environment variable here: https://github.com/mdn/translated-content/actions/runs/6091642909/job/16528549282#step:14:30)
