### PR TITLE
ja: fix link syntax in Reference/Operators/import

### DIFF
--- a/files/ja/web/javascript/reference/operators/import/index.md
+++ b/files/ja/web/javascript/reference/operators/import/index.md
@@ -63,7 +63,7 @@ import("/my-module.js").then((mod2) => {
 });
 ```
 
-ただし、1つだけ奇妙な場合があります。プロミスは決して [thenable] (/ja/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) に履行されることはないので、もし `my-module.js` モジュールが `then()` という関数をエクスポートすると、その関数はダイナミックインポートのプロミスが履行されると自動的に呼ばれることになります。
+ただし、1つだけ奇妙な場合があります。プロミスは決して [thenable](/ja/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) に履行されることはないので、もし `my-module.js` モジュールが `then()` という関数をエクスポートすると、その関数はダイナミックインポートのプロミスが履行されると自動的に呼ばれることになります。
 
 ```js
 // my-module.js

--- a/files/ja/web/javascript/reference/operators/import/index.md
+++ b/files/ja/web/javascript/reference/operators/import/index.md
@@ -63,7 +63,7 @@ import("/my-module.js").then((mod2) => {
 });
 ```
 
-ただし、1つだけ奇妙な場合があります。プロミスは決して [thenable](/ja/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) に履行されることはないので、もし `my-module.js` モジュールが `then()` という関数をエクスポートすると、その関数はダイナミックインポートのプロミスが履行されると自動的に呼ばれることになります。
+ただし、1つだけ奇妙な場合があります。プロミスは決して [thenable](/ja/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenable) に履行されることはないので、もし `my-module.js` モジュールが `then()` という関数をエクスポートすると、その関数はダイナミックインポートのプロミスが履行されると自動的に呼ばれることになります。
 
 ```js
 // my-module.js


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove an extra space between brackets in a Markdown link

### Motivation

The link is broken

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
