### PR TITLE
[ja] CSS `:where()` のコード例を更新

### DIFF
--- a/files/ja/web/css/_colon_where/index.md
+++ b/files/ja/web/css/_colon_where/index.md
@@ -1,28 +1,15 @@
 ---
 title: ":where()"
 slug: Web/CSS/:where
+l10n:
+  sourceCommit: ac2874857a3de0be38430e58068597edf0afa2b2
 ---
 
 {{CSSRef}}
 
 **`:where()`** は [CSS](/ja/docs/Web/CSS) の[擬似クラス](/ja/docs/Web/CSS/Pseudo-classes)関数で、セレクターリストを引数として取り、列挙されたセレクターのうちの何れかに当てはまるすべての要素を選択します。
 
-```css
-/* ヘッダー、メイン、フッターの何れかの中にある段落に
-   カーソルをかざしたときに選択 */
-:where(header, main, footer) p:hover {
-  color: red;
-  cursor: pointer;
-}
-
-/* 上記のものは下記のものと同等です。 */
-header p:hover,
-main p:hover,
-footer p:hover {
-  color: red;
-  cursor: pointer;
-}
-```
+{{EmbedInteractiveExample("pages/tabbed/pseudo-class-where.html", "tabbed-shorter")}}
 
 `:where()` と {{CSSxRef(":is", ":is()")}} の違いは、 `:where()` は[詳細度](/ja/docs/Web/CSS/Specificity)が常に 0 であるのに対して、 `:is()` は引数内で最も詳細度の高いセレクターの詳細度を取ります。
 
@@ -34,15 +21,16 @@ CSS では、セレクターリストを使用する場合、いずれかのセ�
 
 ```css
 :where(:valid, :unsupported) {
-  ...
+  /* … */
 }
 ```
 
 は `:unsupported` の部分に対応していないブラウザーでも `:valid` の部分が有効となり正しく解釈されます。一方で
 
 ```css
-:valid, :unsupported {
-  ...
+:valid,
+:unsupported {
+  /* … */
 }
 ```
 
@@ -89,15 +77,15 @@ CSS では、セレクターリストを使用する場合、いずれかのセ�
     <p>
       こちらがメインコンテンツです。これは<a href="https://mozilla.org"
         >リンクを含んでいます</a
-      >.
+      >。
     </p>
   </section>
 
   <aside class="where-styling">
     <p>
-      こちらが脇コンテンツです。これは<a href="https://developer.mozilla.org"
+      こちらが脇コンテンツです。これも<a href="https://developer.mozilla.org"
         >リンクを含んでいます</a
-      >.
+      >。
     </p>
   </aside>
 
@@ -147,8 +135,10 @@ footer a {
 
 ## 構文
 
-```
-:where( <complex-selector-list> )
+```css-nolint
+:where(<complex-selector-list>) {
+  /* ... */
+}
 ```
 
 ## 仕様書
@@ -163,4 +153,4 @@ footer a {
 
 - {{CSSxRef(":is", ":is()")}}
 - [セレクターリスト](/ja/docs/Web/CSS/Selector_list)
-- [ウェブコンポーネント](/ja/docs/Web/Web_Components)
+- [ウェブコンポーネント](/ja/docs/Web/Web_components)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

CSS `:where()` 擬似クラスのページ内にあるコード例を最新のものに更新します。

本体最新版:
- https://github.com/mdn/content/blob/ac2874857a3de0be38430e58068597edf0afa2b2/files/en-us/web/css/_colon_where/index.md
- https://developer.mozilla.org/en-US/docs/Web/CSS/:where

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

最新版ではデモを動かすことが可能です。

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
なし。

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

なし。

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
