### PR TITLE
Docs(zh-cn): update the translation of fullscreen related properties under the Document interface

### DIFF
--- a/files/zh-cn/web/api/document/fullscreen/index.md
+++ b/files/zh-cn/web/api/document/fullscreen/index.md
@@ -1,42 +1,52 @@
 ---
-title: document.mozFullScreen
+title: Document：fullscreen 属性
 slug: Web/API/Document/fullscreen
+l10n:
+  sourceCommit: 41a8b9c9832359d445d136b6d7a8a28737badc6b
 ---
 
 {{APIRef("Fullscreen API")}}{{Deprecated_Header}}
 
-过时的{{domxref("Document")}}接口的 **`fullscreen`** 只读属性报告文档当前是否以全屏模式显示内容。
+过时的 {{domxref("Document")}} 接口的 **`fullscreen`** 只读属性表明页面当前是否以全屏模式显示内容。
 
-虽然这个属性是只读的，但如果修改它，它不会抛出 (即使在严格模式下);setter 是一个非操作，它将被忽略。
+尽管这个属性是只读的，但如果修改它，即使在严格模式下也不会抛出错误；它的 `setter` 方法是空操作将被忽略。
 
-> **备注：** 由于不推荐使用此属性，你可以通过检查{{DOMxRef("document.fullscreenelement")}}是否为 **`null`** 来确定文档上是否启用全屏模式。
+> **备注：** 由于该属性已被弃用，你可以通过检查 {{DOMxRef("Document.fullscreenElement")}} 是否不为 `null` 来确定页面是否处于全屏模式。
 
-### 概述
+## 值
 
-返回一个布尔值，表明当前文档是否处于全屏模式。
+返回一个布尔值，如果页面当前在全屏模式下显示元素，则为 `true`；否则为 `false`。
 
-### 语法
+## 示例
 
-```
-var isFullScreen = document.mozFullScreen || document.webkitIsFullScreen;
-```
-
-### 例子
+这个简单的函数使用过时的 `fullscreen` 属性报告当前是否激活了全屏模式。
 
 ```js
 function isDocumentInFullScreenMode() {
-  // 过去由 F11 触发的那种浏览器全屏模式和 HTML5 中内容的全屏模式是不一样的
-  return (
-    (document.fullscreenElement && document.fullscreenElement !== null) ||
-    (!document.mozFullScreen && !document.webkitIsFullScreen)
-  );
+  return document.fullscreen;
 }
 ```
 
-### 备注
+另一方面，下面的示例使用当前的 `fullscreenElement` 属性来确定同样的事情：
 
-查看[使用全屏模式](/zh-CN/docs/Web/API/Fullscreen_API)来了解更多相关内容。
+```js
+function isDocumentInFullScreenMode() {
+  return document.fullscreenElement !== null;
+}
+```
 
-### 浏览器兼容性
+如果 `fullscreenElement` 不为 `null`，则返回 `true`，表示全屏模式正处于生效状态。
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
 
 {{Compat}}
+
+## 参见
+
+- [全屏 API](/zh-CN/docs/Web/API/Fullscreen_API)
+- [全屏指南](/zh-CN/docs/Web/API/Fullscreen_API/Guide)
+- {{DOMxRef("Document.fullscreenEnabled")}}

--- a/files/zh-cn/web/api/document/fullscreenelement/index.md
+++ b/files/zh-cn/web/api/document/fullscreenelement/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{ApiRef("Fullscreen API")}}
 
-**`Document.fullscreenElement`** 是一个只读属性，返回当前页面中以全屏模式呈现的 {{domxref("Element")}}，如果当前页面未使用全屏模式，则返回 `null`。
+只读属性 **`Document.fullscreenElement`** 返回当前页面中以全屏模式呈现的 {{domxref("Element")}}，如果当前页面未使用全屏模式，则返回 `null`。
 
 尽管这个属性是只读的，但如果修改它，即使在严格模式下也不会抛出错误；它的 `setter` 方法是空操作将被忽略。
 

--- a/files/zh-cn/web/api/document/fullscreenelement/index.md
+++ b/files/zh-cn/web/api/document/fullscreenelement/index.md
@@ -1,34 +1,47 @@
 ---
-title: document.mozFullScreenElement
+title: Document：FullScreenElement 属性
 slug: Web/API/Document/fullscreenElement
+l10n:
+  sourceCommit: 41a8b9c9832359d445d136b6d7a8a28737badc6b
 ---
 
-{{ ApiRef() }}
+{{ApiRef("Fullscreen API")}}
 
-### 概述
+**`Document.fullscreenElement`** 是一个只读属性，返回当前页面中以全屏模式呈现的 {{domxref("Element")}}，如果当前页面未使用全屏模式，则返回 `null`。
 
-返回当前文档中正在以全屏模式显示的{{ domxref("Element") }}节点，如果没有使用全屏模式，则返回`null`.
+尽管这个属性是只读的，但如果修改它，即使在严格模式下也不会抛出错误；它的 `setter` 方法是空操作将被忽略。
 
-### 语法
+## 值
 
-```plain
-var element = document.mozFullScreenElement;
-```
+返回当前处于全屏模式的 {{domxref("Element")}} 对象；如果当前页面未使用全屏模式，则返回 `null`。
 
-### 示例
+## 示例
 
-```plain
-function isVideoInFullsreen() {
-  if (document.mozFullScreenElement && document.mozFullScreenElement.nodeName == 'VIDEO') {
-    console.log('你的视频正在以全屏模式显示');
+这个示例展示了一个名为 `isVideoInFullscreen()` 的函数，该函数查看 `fullscreenElement` 返回的值；如果文档处于全屏模式（`fullscreenElement` 不为 `null`）并且全屏元素的 {{domxref("Node.nodeName", "nodeName")}} 为 `VIDEO`，表示为 {{HTMLElement("video")}} 元素，则函数返回 `true`，表示视频处于全屏模式。
+
+```js
+function isVideoInFullscreen() {
+  if (document.fullscreenElement?.nodeName === "VIDEO") {
+    return true;
   }
+  return false;
 }
 ```
 
-### 辅助
+## 规范
 
-查看[使用"全屏模式"](/zh-CN/docs/DOM/Using_full-screen_mode)页面了解详情。
+{{Specifications}}
 
-### 浏览器兼容性
+## 浏览器兼容性
 
 {{Compat}}
+
+## 参见
+
+- [全屏 API](/zh-CN/docs/Web/API/Fullscreen_API)
+- [全屏 API 指南](/zh-CN/docs/Web/API/Fullscreen_API/Guide)
+- {{domxref("Element.requestFullscreen()")}}
+- {{domxref("Document.exitFullscreen()")}}
+- {{domxref("Document.fullscreenEnabled")}}
+- {{cssxref(":fullscreen")}} 和 {{cssxref("::backdrop")}}
+- {{HTMLElement("iframe")}} [`allowfullscreen`](/zh-CN/docs/Web/HTML/Element/iframe#allowfullscreen) 属性

--- a/files/zh-cn/web/api/document/fullscreenenabled/index.md
+++ b/files/zh-cn/web/api/document/fullscreenenabled/index.md
@@ -1,38 +1,48 @@
 ---
-title: document.mozFullScreenEnabled
+title: Document：fullscreenEnabled 属性
 slug: Web/API/Document/fullscreenEnabled
+l10n:
+  sourceCommit: 41a8b9c9832359d445d136b6d7a8a28737badc6b
 ---
 
-{{ ApiRef() }}
+{{APIRef("Fullscreen API")}}
 
-### 概述
+{{domxref("Document")}} 接口上的只读属性 **fullscreenEnabled** 表明全屏模式是否可用。全屏模式仅适用于不包含任何窗口化插件的页面，或者页面中的所有 {{HTMLElement("iframe")}} 元素都设置了 [`allowfullscreen`](/zh-CN/docs/Web/HTML/Element/iframe#allowfullscreen) 属性。
 
-返回一个布尔值，表明浏览器是否支持全屏模式。全屏模式只在那些不包含窗口化的插件的页面中可用。对于一个{{ HTMLElement("iframe") }}元素中的页面，则它必需拥有[`mozallowfullscreen`](/zh-CN/docs/Web/HTML/Element/iframe#mozallowfullscreen)属性。
+尽管这个属性是只读的，但如果修改它，即使在严格模式下也不会抛出错误；它的 `setter` 方法是空操作将被忽略。
 
-### 语法
+## 值
 
-```plain
-var isFullScreenAvailable = document.mozFullScreenEnabled;
-```
+一个布尔值，如果调用 {{domxref("Element.requestFullscreen()")}} 能进入全屏模式，则为 `true`。如果全屏模式不可用，则该值为 `false`。
 
-如果当前文档可以进入全屏模式，则`isFullScreenAvailable`为`true`
+## 示例
 
-### 例子
+在下面的示例中，在 {{htmlElement("video")}} 元素尝试请求全屏模式之前，检查 `fullscreenEnabled` 的值，以避免在不可用时调用 {{domxref("Element.requestFullscreen()")}} 方法。
 
-```plain
-function requestFullScreen() {
-  if (document.mozFullScreenEnabled) {
-    videoElement.requestFullScreen();
+```js
+function requestFullscreen() {
+  if (document.fullscreenEnabled) {
+    videoElement.requestFullscreen();
   } else {
-    console.log('你的浏览器不支持全屏模式！');
+    console.log("你的浏览器现在无法使用全屏模式");
   }
 }
 ```
 
-### 备注
+## 规范
 
-进入页面[使用全屏模式](/zh-CN/DOM/Using_full-screen_mode)查看详情和示例。
+{{Specifications}}
 
-### 浏览器兼容性
+## 浏览器兼容性
 
 {{Compat}}
+
+## 参见
+
+- [全屏 API](/zh-CN/docs/Web/API/Fullscreen_API)
+- [全屏指南](/zh-CN/docs/Web/API/Fullscreen_API/Guide)
+- {{domxref("Element.requestFullscreen()")}}
+- {{domxref("Document.exitFullscreen()")}}
+- {{domxref("Document.fullscreenElement")}}
+- {{cssxref(":fullscreen") }} 和 {{cssxref("::backdrop")}}
+- {{HTMLElement("iframe")}} [`allowfullscreen`](/zh-CN/docs/Web/HTML/Element/iframe#allowfullscreen) 属性

--- a/files/zh-cn/web/api/document/fullscreenenabled/index.md
+++ b/files/zh-cn/web/api/document/fullscreenenabled/index.md
@@ -7,7 +7,9 @@ l10n:
 
 {{APIRef("Fullscreen API")}}
 
-{{domxref("Document")}} 接口上的只读属性 **fullscreenEnabled** 表明全屏模式是否可用。全屏模式仅适用于不包含任何窗口化插件的页面，或者页面中的所有 {{HTMLElement("iframe")}} 元素都设置了 [`allowfullscreen`](/zh-CN/docs/Web/HTML/Element/iframe#allowfullscreen) 属性。
+{{domxref("Document")}} 接口上的只读属性 **`fullscreenEnabled`** 表明全屏模式是否可用。
+
+全屏模式仅适用于不包含任何窗口化插件的页面，或者页面中的所有 {{HTMLElement("iframe")}} 元素都设置了 [`allowfullscreen`](/zh-CN/docs/Web/HTML/Element/iframe#allowfullscreen) 属性。
 
 尽管这个属性是只读的，但如果修改它，即使在严格模式下也不会抛出错误；它的 `setter` 方法是空操作将被忽略。
 


### PR DESCRIPTION
### Description

update the translation of fullscreen related properties under the Document interface

### Motivation

Chinese documentation is out of date.

### Additional details

- `document.fullscreen`
- `document.fullscreenElement`
- `document.fullscreenEnabled`