### PR TITLE
[ja]:【Fix Typo】 「Reactを始める」のtypoの修正

### DIFF
--- a/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
+++ b/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
@@ -40,7 +40,7 @@ l10n:
 
 ## React の基礎
 
-公式のキャッチフレーズにあるように、[React](https://react.dev/) はユーザーインターフェイスを構築するためのライブラリーです。React はフレームワークではなく、ウェブに限定されるものでもありません。他のライブラリーと共に使用して、特定の環境にレンダリングしますます。たとえば、[React Native](https://reactnative.dev/) はモバイルアプリケーションの構築に使用できます。
+公式のキャッチフレーズにあるように、[React](https://react.dev/) はユーザーインターフェイスを構築するためのライブラリーです。React はフレームワークではなく、ウェブに限定されるものでもありません。他のライブラリーと共に使用して、特定の環境にレンダリングします。たとえば、[React Native](https://reactnative.dev/) はモバイルアプリケーションの構築に使用できます。
 
 ウェブ向けに構築するには、開発者は [ReactDOM](https://reactjs.org/docs/react-dom.html) と連携して React を使用します。React と ReactDOM は、他の本当のウェブ開発フレームワークと同じ土台で頻繫に議論され、同じような問題を解決するために用いられます。React を「フレームワーク」と呼ぶとき、それは口語的な理解として扱います。
 
@@ -104,7 +104,7 @@ JSX の詳細については、React チームの [Writing Markup with JSX](http
 
 ## 最初の React アプリをセットアップする
 
-React を使用する方法はたくさんありますが、前述のように、コマンドラインインターフェイス (CLI) ツールの create-react-app を使用します。これにより、いくつかのパッケージをインストールしていくつかを作成することにより、React アプリケーションの開発プロセスをスムーズにします。
+React を使用する方法はたくさんありますが、前述のように、コマンドラインインターフェイス (CLI) ツールの create-react-app を使用します。これにより、いくつかのパッケージをインストールして作成することにより、React アプリケーションの開発プロセスをスムーズにします。
 
 [`<script>`](/ja/docs/Web/HTML/Element/script) を HTML ファイルにコピーすることで [create-react-app なしでウェブサイトに React を追加する](https://reactjs.org/docs/add-react-to-a-website.html)ことは可能ですが、 create-react-app CLI は、React アプリケーションの一般的な始め方です。これを使うことで、アプリの作成に集中でき、セットアップに煩わされなくなります。
 


### PR DESCRIPTION
Fix typo of Getting Started React

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

明らかなtypoが２箇所あったため修正PullRequestです。

[Reactの基礎](https://developer.mozilla.org/ja/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started#:~:text=%E7%92%B0%E5%A2%83%E3%81%AB%E3%83%AC%E3%83%B3%E3%83%80%E3%83%AA%E3%83%B3%E3%82%B0-,%E3%81%97%E3%81%BE%E3%81%99%E3%81%BE%E3%81%99,-%E3%80%82%E3%81%9F%E3%81%A8%E3%81%88%E3%81%B0%E3%80%81React)

[最初のReactアプリをセットアップする](https://developer.mozilla.org/ja/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started#:~:text=%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%81%97%E3%81%A6-,%E3%81%84%E3%81%8F%E3%81%A4%E3%81%8B%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E3%81%93%E3%81%A8%E3%81%AB%E3%82%88%E3%82%8A,-%E3%80%81React%20%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE)



### Motivation

None

### Additional details

None

### Related issues and pull requests

None
