### PR TITLE
[fr] fix:15843 PNG lossless compression

### DIFF
--- a/files/fr/web/html/element/img/index.md
+++ b/files/fr/web/html/element/img/index.md
@@ -32,7 +32,7 @@ Les formats d'image qu'on rencontre le plus fréquemment sur le Web sont&nbsp;:
 - [AVIF (<i lang="en">AV1 Image File Format</i>)](/fr/docs/Web/Media/Formats/Image_types#avif) pour les images et les images animées avec de hautes performances
 - [GIF (<i lang="en">Graphics Interchange Format</i>)](/fr/docs/Web/Media/Formats/Image_types#gif_graphics_interchange_format) pour les images et animations _simples_
 - [JPEG (<i lang="en">Joint Photographic Expert Group image</i>)](/fr/docs/Web/Media/Formats/Image_types#jpeg_joint_photographic_experts_group_image) pour une compression avec pertes d'images statiques, il s'agit du format le plus utilisé
-- [PNG (<i lang="en">Portable Network Graphics</i>)](/fr/docs/Web/Media/Formats/Image_types#png_portable_network_graphics) pour une compression sans pertes d'images statiques, de meilleure qualité que le JPEG
+- [PNG (<i lang="en">Portable Network Graphics</i>)](/fr/docs/Web/Media/Formats/Image_types#png_portable_network_graphics) pour une compression sans perte d'images statiques, de meilleure qualité que le JPEG
 - [SVG (<i lang="en">Scalable Vector Graphics</i>)](/fr/docs/Web/Media/Formats/Image_types#svg_scalable_vector_graphics) pour un format d'image vectorielle (qui permet de dessiner une image précisément à différentes échelles)
 - [WebP (<i lang="en">Web Picture format</i>)](/fr/docs/Web/Media/Formats/Image_types#webp) pour les images statiques et animées
 

--- a/files/fr/web/html/element/img/index.md
+++ b/files/fr/web/html/element/img/index.md
@@ -32,7 +32,7 @@ Les formats d'image qu'on rencontre le plus fréquemment sur le Web sont&nbsp;:
 - [AVIF (<i lang="en">AV1 Image File Format</i>)](/fr/docs/Web/Media/Formats/Image_types#avif) pour les images et les images animées avec de hautes performances
 - [GIF (<i lang="en">Graphics Interchange Format</i>)](/fr/docs/Web/Media/Formats/Image_types#gif_graphics_interchange_format) pour les images et animations _simples_
 - [JPEG (<i lang="en">Joint Photographic Expert Group image</i>)](/fr/docs/Web/Media/Formats/Image_types#jpeg_joint_photographic_experts_group_image) pour une compression avec pertes d'images statiques, il s'agit du format le plus utilisé
-- [PNG (<i lang="en">Portable Network Graphics</i>)](/fr/docs/Web/Media/Formats/Image_types#png_portable_network_graphics) pour une compression avec pertes d'images statiques, de meilleure qualité que le JPEG
+- [PNG (<i lang="en">Portable Network Graphics</i>)](/fr/docs/Web/Media/Formats/Image_types#png_portable_network_graphics) pour une compression sans pertes d'images statiques, de meilleure qualité que le JPEG
 - [SVG (<i lang="en">Scalable Vector Graphics</i>)](/fr/docs/Web/Media/Formats/Image_types#svg_scalable_vector_graphics) pour un format d'image vectorielle (qui permet de dessiner une image précisément à différentes échelles)
 - [WebP (<i lang="en">Web Picture format</i>)](/fr/docs/Web/Media/Formats/Image_types#webp) pour les images statiques et animées
 

--- a/files/fr/web/media/formats/image_types/index.md
+++ b/files/fr/web/media/formats/image_types/index.md
@@ -891,7 +891,7 @@ Le JPEG est en fait un format de données pour les photos compressées, plutôt 
 
 ### PNG (Portable Network Graphics)
 
-Le [PNG](/fr/docs/Glossary/PNG) (prononcé "**png**") utilise une compression sans perte ou avec perte afin de fournir une compression plus efficace, et prend en charge des profondeurs de couleurs plus élevées que [GIF](#gif), ainsi qu'une transparence alpha complète.
+Le format d'image [PNG](/fr/docs/Glossary/PNG) (prononcé "**png**") utilise une compression sans perte, prend en charge des profondeurs de couleurs plus élevées que le [GIF](#gif) et supporte la transparence alpha complète.
 
 Le format PNG est largement soutenu, tous les principaux navigateurs offrant une prise en charge complète de ses fonctionnalités. Internet Explorer, qui a introduit le support PNG dans les versions 4-5, ne l'a pas entièrement pris en charge avant IE 9, et a connu de nombreux bogues tristement célèbres pendant de nombreuses années, y compris dans l'Internet Explorer 6, autrefois omniprésent. Cela a ralenti l'adoption de la PNG, mais elle est maintenant couramment utilisée, surtout lorsqu'il faut reproduire avec précision l'image source.
 

--- a/files/fr/web/media/formats/image_types/index.md
+++ b/files/fr/web/media/formats/image_types/index.md
@@ -891,7 +891,7 @@ Le JPEG est en fait un format de données pour les photos compressées, plutôt 
 
 ### PNG (Portable Network Graphics)
 
-Le format d'image [PNG](/fr/docs/Glossary/PNG) (prononcé "**png**") utilise une compression sans perte, prend en charge des profondeurs de couleurs plus élevées que le [GIF](#gif) et supporte la transparence alpha complète.
+Le format d'image [PNG](/fr/docs/Glossary/PNG) utilise une compression sans perte, prend en charge des profondeurs de couleurs plus élevées que le [GIF](#gif), est plus efficace, et prend complètement en charge la transparence alpha.
 
 Le format PNG est largement soutenu, tous les principaux navigateurs offrant une prise en charge complète de ses fonctionnalités. Internet Explorer, qui a introduit le support PNG dans les versions 4-5, ne l'a pas entièrement pris en charge avant IE 9, et a connu de nombreux bogues tristement célèbres pendant de nombreuses années, y compris dans l'Internet Explorer 6, autrefois omniprésent. Cela a ralenti l'adoption de la PNG, mais elle est maintenant couramment utilisée, surtout lorsqu'il faut reproduire avec précision l'image source.
 


### PR DESCRIPTION
### Description
1- J'ai retiré les `compression avec perte` concernant le PNG sur [la page des types d'image](https://developer.mozilla.org/fr/docs/Web/Media/Formats/Image_types#png_portable_network_graphics) et [la page img](https://developer.mozilla.org/fr/docs/Web/HTML/Element/Img#formats_dimage_pris_en_charge)

2- J'ai également reformulé une phrase.

### Motivation
1- La documentation en-US parle uniquement de compression sans perte et non avec perte.

2- je trouve ça plus facile à lire 

### Related issues and pull requests

Fixes #15843