### PR TITLE
fix(ru): typo in AbortController article

### DIFF
--- a/files/ru/web/api/abortcontroller/index.md
+++ b/files/ru/web/api/abortcontroller/index.md
@@ -17,7 +17,7 @@ slug: Web/API/AbortController
 ## Свойства
 
 - {{domxref("AbortController.signal")}} {{readonlyInline}}
-  - : Возвращает экземпляр {{domxref("AbortSignal")}}, который может быть использован для коммуникаций/останова DOM запросов.
+  - : Возвращает экземпляр {{domxref("AbortSignal")}}, который может быть использован для коммуникаций/остановки DOM запросов.
 
 ## Методы
 


### PR DESCRIPTION
### Description

fixes typo

### Motivation

### Additional details

### Related issues and pull requests

