### PR TITLE
[ko] fix: Fix typo in css calc example code

### DIFF
--- a/files/ko/web/css/calc/index.md
+++ b/files/ko/web/css/calc/index.md
@@ -78,7 +78,7 @@ input {
   width: calc(100% - 1em);
 }
 
-#formbox {
+#form-box {
   width: calc(100% / 6);
   border: 1px solid black;
   padding: 4px;
@@ -89,7 +89,7 @@ input {
 
 ```html
 <form>
-  <div id="formBox">
+  <div id="form-box">
     <label>뭔가 입력해 보세요.</label>
     <input type="text" />
   </div>


### PR DESCRIPTION
### Description

Fix typo in example code's html id name.


### Motivation

Reduce confusion when running example code, and modify to the same ID value as the original example code.


### Additional details

No response

### Related issues and pull requests

No response


