### PR TITLE
[ko] document.contentType 번역

### DIFF
--- a/files/ko/web/api/document/contenttype/index.md
+++ b/files/ko/web/api/document/contenttype/index.md
@@ -1,0 +1,25 @@
+---
+title: "Document: contentType property"
+short-title: contentType
+slug: Web/API/Document/contentType
+l10n:
+  sourceCommit: 41a8b9c9832359d445d136b6d7a8a28737badc6b
+---
+
+{{APIRef}}
+
+**`Document.contentType`** 은 document가 렌더링 되는 MIME 타입을 반환하는 읽기 전용 속성입니다. `Document.contentType`은 HTTP 헤더나 그 외에 MIME 정보 출처에서 나올 수 있으며 브라우저나 확장 프로그램에서 수행하는 자동 타입 변환의 영향을 받을 수 있습니다.
+
+> **참고:** 이 속성은 {{HTMLElement("meta")}}에 영향을 받지 않습니다.
+
+## 값
+
+`contentType`은 읽기 전용 속성입니다.
+
+## 명세서
+
+{{Specifications}}
+
+## 브라우저 호환성
+
+{{Compat}}


### PR DESCRIPTION
Description
Web -> api -> Document -> contentType 페이지를 번역했습니다.

Motivation
Additional details
원문 : https://developer.mozilla.org/en-US/docs/Web/API/Document/contentType