### PR TITLE
fix: glossary string에서 누락된 sidebar 추가

### DIFF
--- a/files/ko/glossary/string/index.md
+++ b/files/ko/glossary/string/index.md
@@ -3,6 +3,8 @@ title: String
 slug: Glossary/String
 ---
 
+{{GlossarySidebar}}
+
 특정한 컴퓨터 프로그래밍 언어에서 문자를 표현하는 데 사용되는, {{Glossary("character","문자")}} 열 시퀀스이다.
 
 {{Glossary("JavaScript")}}에서 String은 {{Glossary("Primitive", "원시 값들")}} 중 하나이고 {{jsxref("String")}}객체는 String primitive를 둘러싼 {{Glossary("wrapper")}}다.

--- a/files/ko/glossary/string/index.md
+++ b/files/ko/glossary/string/index.md
@@ -14,4 +14,4 @@ slug: Glossary/String
 ### 일반적인 지식
 
 - Wikipedia의 [String (computer science)](<https://en.wikipedia.org/wiki/String_(computer_science)>)
-- [JavaScript data types and data structures](/ko/docs/Web/JavaScript/Data_structures#String_type)
+- [JavaScript data types and data structures](/ko/docs/Web/JavaScript/Data_structures#string_type)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
glossary sidebar가 누락되어 있었습니다.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
glossary sidebar가 누락되어 있었습니다.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
