### PR TITLE
chore(pt-br): replace old-style specification tables part1

### DIFF
--- a/files/pt-br/conflicting/web/api/animationevent/animationevent/index.md
+++ b/files/pt-br/conflicting/web/api/animationevent/animationevent/index.md
@@ -42,7 +42,7 @@ animationEvent.initAnimationEvent(typeArg, canBubbleArg, cancelableArg, animatio
 
 ## Especificações
 
-_Esse método é não-padrão e não é parte de qualquer especificação, no entanto ele esteve presente nos primeiros rascunhos de {{SpecName("CSS3 Animations")}}._
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/conflicting/web/api/customelementregistry/define/index.md
+++ b/files/pt-br/conflicting/web/api/customelementregistry/define/index.md
@@ -49,9 +49,7 @@ mytag.textContent = "I am a my-tag element.";
 
 ## Especificações
 
-| Especificação                            | Estado                               | Comentário        |
-| ---------------------------------------- | ------------------------------------ | ----------------- |
-| {{SpecName('Custom Elements')}} | {{Spec2('Custom Elements')}} | definição inicial |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/conflicting/web/api/geolocation/getcurrentposition/index.md
+++ b/files/pt-br/conflicting/web/api/geolocation/getcurrentposition/index.md
@@ -22,9 +22,7 @@ A interface `PositionOptions` não implementa ou herda nenhum método.
 
 ## Especificações
 
-| Specification                                                                            | Status                           | Comment            |
-| ---------------------------------------------------------------------------------------- | -------------------------------- | ------------------ |
-| {{SpecName('Geolocation', '#positionoptions', 'PositionOptions')}} | {{Spec2('Geolocation')}} | Initial definition |
+{{Specifications}}
 
 ## Navegadores compatíveis
 

--- a/files/pt-br/conflicting/web/api/htmlslotelement_ded38e17cacb3809f7af4fec22adcc56/index.md
+++ b/files/pt-br/conflicting/web/api/htmlslotelement_ded38e17cacb3809f7af4fec22adcc56/index.md
@@ -22,9 +22,7 @@ myContentObject.select = "h1 .error";
 
 ## Especificações
 
-| Especificações                                                                   | Status                           | Commentário |
-| -------------------------------------------------------------------------------- | -------------------------------- | ----------- |
-| {{SpecName('Shadow DOM', '#the-content-element', 'content')}} | {{Spec2('Shadow DOM')}} |             |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/conflicting/web/api/window/load_event/index.md
+++ b/files/pt-br/conflicting/web/api/window/load_event/index.md
@@ -50,9 +50,7 @@ Existe também os [Gecko-Specific DOM Events](/pt-BR/docs/Web/Events), como o `D
 
 ## Especificações
 
-| Especificação                                                                                    | Status                           | Comentário        |
-| ------------------------------------------------------------------------------------------------ | -------------------------------- | ----------------- |
-| {{SpecName("HTML WHATWG", "webappapis.html#handler-onload", "onload")}} | {{Spec2("HTML WHATWG")}} | Definição inicial |
+{{Specifications}}
 
 ## Veja também
 

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/date/toutcstring/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/date/toutcstring/index.md
@@ -34,9 +34,7 @@ console.log(str);               // Mon, 18 Dec 1995 17:28:35 GMT
 
 ## Especificações
 
-| Especificação                                                                                                        |
-| -------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('ESDraft', '#sec-date.prototype.togmtstring', 'Date.prototype.toGMTString')}} |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/string/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/string/index.md
@@ -11,12 +11,7 @@ Passando [`null`](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/null) para
 
 ## Especificações
 
-| Specification                                                                                | Status                       | Comment                                                        |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------------------- |
-| {{SpecName('WebIDL', '#idl-DOMString', 'DOMString')}}                     | {{Spec2('WebIDL')}}     | Reformulação da definição para remover alguns casos estranhos. |
-| {{SpecName('DOM3 Core', 'core.html#DOMString', 'DOMString')}}             | {{Spec2('DOM3 Core')}} | Nenhuma mudança da {{SpecName('DOM2 Core')}}            |
-| {{SpecName('DOM2 Core', 'core.html#ID-C74D1578', 'DOMString')}}         | {{Spec2('DOM2 Core')}} | Nenhuma mudança da {{SpecName('DOM1')}}                |
-| {{SpecName('DOM1', 'level-one-core.html#ID-C74D1578', 'DOMString')}} | {{Spec2('DOM1')}}     | Definição inicial.                                             |
+{{Specifications}}
 
 ## Veja também
 

--- a/files/pt-br/orphaned/web/api/htmlshadowelement/index.md
+++ b/files/pt-br/orphaned/web/api/htmlshadowelement/index.md
@@ -20,9 +20,7 @@ _Esta interface herda os métodos do {{domxref("HTMLElement")}}._
 
 ## Especificações
 
-| Especificação                                                                    | Status                           | Comentário |
-| -------------------------------------------------------------------------------- | -------------------------------- | ---------- |
-| {{SpecName('Shadow DOM', '#the-shadow-element', 'shadow')}} | {{Spec2('Shadow DOM')}} |            |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/orphaned/web/api/navigatorid/platform/index.md
+++ b/files/pt-br/orphaned/web/api/navigatorid/platform/index.md
@@ -33,9 +33,7 @@ No Firefox, a preferência `general.platform.override` pode ser usada para sobre
 
 ## Especificações
 
-| Especificação                                                                                            | Status                           | Comentário         |
-| -------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------ |
-| {{SpecName('HTML WHATWG', '#dom-navigator-platform', 'NavigatorID.platform')}} | {{Spec2('HTML WHATWG')}} | Definição inicial. |
+{{Specifications}}
 
 ## Compatibilidade
 

--- a/files/pt-br/orphaned/web/api/navigatorid/useragent/index.md
+++ b/files/pt-br/orphaned/web/api/navigatorid/useragent/index.md
@@ -45,9 +45,7 @@ alert(window.navigator.userAgent)
 
 ## Especificações
 
-| Especificação                                                                                                | Status                           | Comentário         |
-| ------------------------------------------------------------------------------------------------------------ | -------------------------------- | ------------------ |
-| {{SpecName('HTML WHATWG', '#dom-navigator-useragent', 'NavigatorID.userAgent')}} | {{Spec2('HTML WHATWG')}} | Definição inicial. |
+{{Specifications}}
 
 ## Compatibilidade
 

--- a/files/pt-br/orphaned/web/api/navigatoronline/index.md
+++ b/files/pt-br/orphaned/web/api/navigatoronline/index.md
@@ -22,10 +22,7 @@ _A interface **`NavigatorOnLine`** não implementa nem herda nenhum método._
 
 ## Especificações
 
-| Especificação                                                                            | Status                           | Comentário                                                                      |
-| ---------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------- |
-| {{SpecName('HTML WHATWG', '#navigatoronline', 'NavigatorOnLine')}} | {{Spec2('HTML WHATWG')}} | Nenhuma mudança desde a ultima atualização, do {{SpecName('HTML5 W3C')}} |
-| {{SpecName('HTML5 W3C', '#navigatoronline', 'NavigatorOnLine')}}     | {{Spec2('HTML5 W3C')}}     | Snapshot do {{SpecName('HTML WHATWG')}} com sua especificação inicial  |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/orphaned/web/api/navigatoronline/online/index.md
+++ b/files/pt-br/orphaned/web/api/navigatoronline/online/index.md
@@ -51,9 +51,7 @@ window.addEventListener('online', function(e) { console.log('online'); });
 
 ## Especificações
 
-| Especificações                                                                                                   | Status                           | Comentário        |
-| ---------------------------------------------------------------------------------------------------------------- | -------------------------------- | ----------------- |
-| {{SpecName("HTML WHATWG", "browsers.html#dom-navigator-online", "navigator.onLine")}} | {{Spec2("HTML WHATWG")}} | Definição inicial |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/orphaned/web/api/navigatorplugins/index.md
+++ b/files/pt-br/orphaned/web/api/navigatorplugins/index.md
@@ -23,9 +23,7 @@ A interface NavigatorPlugins* `NavigatorPlugins`* não herda nenhum método.
 
 ## Especificações
 
-| Especificação                                                                                | Estado                           | Comentário         |
-| -------------------------------------------------------------------------------------------- | -------------------------------- | ------------------ |
-| {{SpecName('HTML WHATWG', '#navigatorplugins', 'NavigatorPlugins')}} | {{Spec2('HTML WHATWG')}} | Definição inicial. |
+{{Specifications}}
 
 ## Navegador compativeis
 

--- a/files/pt-br/orphaned/web/api/navigatorplugins/javaenabled/index.md
+++ b/files/pt-br/orphaned/web/api/navigatorplugins/javaenabled/index.md
@@ -27,9 +27,7 @@ O valor de retorno para este método indica se a preferência que controla o Jav
 
 ## Especificações
 
-| Esécificações                                                                                                            | Estado                           | Comentário         |
-| ------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | ------------------ |
-| {{SpecName('HTML WHATWG', '#dom-navigator-javaenabled', 'NavigatorPlugins.javaEnabled')}} | {{Spec2('HTML WHATWG')}} | Definição inicial. |
+{{Specifications}}
 
 ## Navegadores compativeis
 

--- a/files/pt-br/web/api/file/index.md
+++ b/files/pt-br/web/api/file/index.md
@@ -43,9 +43,7 @@ A interface `File` herda as propriedades da interface {{domxref("Blob")}}.
 
 ## Especificações
 
-| Especificação            | Status                | Comentários        |
-| ------------------------ | --------------------- | ------------------ |
-| {{SpecName('File API')}} | {{Spec2('File API')}} | Definição Inicial. |
+{{Specifications}}
 
 ## Compatibilidade com os Navegadores
 

--- a/files/pt-br/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/pt-br/web/api/htmlcanvaselement/todataurl/index.md
@@ -120,11 +120,7 @@ function removeColors() {
 
 ## Especificações
 
-| Specification                                                                                     | Status                   | Comment                                                                        |
-| ------------------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------ |
-| {{SpecName('HTML WHATWG', "scripting.html#dom-canvas-todataurl", "HTMLCanvasElement.toDataURL")}} | {{Spec2('HTML WHATWG')}} | No change since the latest snapshot, {{SpecName('HTML5 W3C')}}                 |
-| {{SpecName('HTML5.1', "scripting-1.html#dom-canvas-todataurl", "HTMLCanvasElement.toDataURL")}}   | {{Spec2('HTML5.1')}}     |                                                                                |
-| {{SpecName('HTML5 W3C', "scripting-1.html#dom-canvas-todataurl", "HTMLCanvasElement.toDataURL")}} | {{Spec2('HTML5 W3C')}}   | Snapshot of the {{SpecName('HTML WHATWG')}} containing the initial definition. |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/--_star_/index.md
+++ b/files/pt-br/web/css/--_star_/index.md
@@ -78,9 +78,7 @@ Propriedades personalizadas participam na cascata: cada uma delas pode aparecer 
 
 ## Especificações
 
-| Specification                                                | Status                      | Comment            |
-| ------------------------------------------------------------ | --------------------------- | ------------------ |
-| {{SpecName("CSS3 Variables", "#defining-variables", "--*")}} | {{Spec2("CSS3 Variables")}} | Initial definition |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/@charset/index.md
+++ b/files/pt-br/web/css/@charset/index.md
@@ -41,9 +41,7 @@ onde :
 
 ## Especificações
 
-| Especificação                                            | Status                | Comentário |
-| -------------------------------------------------------- | --------------------- | ---------- |
-| {{ SpecName('CSS2.1', 'syndata.html#x57', '@charset') }} | {{ Spec2('CSS2.1') }} |            |
+{{Specifications}}
 
 ## Compatibilidade de navegadores
 

--- a/files/pt-br/web/css/@font-face/index.md
+++ b/files/pt-br/web/css/@font-face/index.md
@@ -124,11 +124,7 @@ Neste exemplo, a cópia local do usuário "Helvetica Neue Bold" é usada; se o u
 
 ## Especificações
 
-| Especificação                                               | Status                  | Comentário                                                           |
-| ----------------------------------------------------------- | ----------------------- | -------------------------------------------------------------------- |
-| {{SpecName('WOFF2.0', '', 'WOFF2 font format')}}            | {{Spec2('WOFF2.0')}}    | Especificação de formato de fonte com novo algoritmo de compactação. |
-| {{SpecName('WOFF1.0', '', 'WOFF font format')}}             | {{Spec2('WOFF1.0')}}    | Especificação de formato                                             |
-| {{SpecName('CSS3 Fonts', '#font-face-rule', '@font-face')}} | {{Spec2('CSS3 Fonts')}} | Definição Inicial                                                    |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/@import/index.md
+++ b/files/pt-br/web/css/@import/index.md
@@ -42,11 +42,7 @@ where:
 
 ## Especificações
 
-| Especificação                                               | Situação                        | Comentário                                                                                                                                                        |
-| ----------------------------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('CSS3 Media Queries', '#media0', '@import')}}    | {{Spec2('CSS3 Media Queries')}} | Estendeu a sintaxe para apoiar qualquer consulta de mídia e não apenas simples [tipos de mídia (media types)](/pt-BR/docs/Web/CSS/@media#Media_types).            |
-| {{SpecName('CSS2.1', 'cascade.html#at-import', '@import')}} | {{Spec2('CSS2.1')}}             | Adicionado suporte para {{cssxref("&lt;string&gt;")}} para denotar a URL de uma folha de estilo, e obrigatoriedade da regra `@import` no início do documento CSS. |
-| {{SpecName('CSS1', '#the-cascade', '@import')}}             | {{Spec2('CSS1')}}               | Definição inicial                                                                                                                                                 |
+{{Specifications}}
 
 ## Browser compatibilidade
 

--- a/files/pt-br/web/css/@media/display-mode/index.md
+++ b/files/pt-br/web/css/@media/display-mode/index.md
@@ -33,9 +33,7 @@ O recurso `display-mode` é especificado como um valor de uma palavra chave esco
 
 ## Especificações
 
-| Specification                                                               | Status                | Comment            |
-| --------------------------------------------------------------------------- | --------------------- | ------------------ |
-| {{SpecName('Manifest', '#the-display-mode-media-feature', 'display-mode')}} | {{Spec2('Manifest')}} | Definição inicial. |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/@media/prefers-color-scheme/index.md
+++ b/files/pt-br/web/css/@media/prefers-color-scheme/index.md
@@ -83,9 +83,7 @@ Os elementos abaixo têm um tema de cores inicial. Eles podem ser mais temático
 
 ## Especificações
 
-| Especificação                                                                                     | Estado                          | Comentários        |
-| ------------------------------------------------------------------------------------------------- | ------------------------------- | ------------------ |
-| {{SpecName('CSS5 Media Queries', '#descdef-media-prefers-color-scheme', 'prefers-color-scheme')}} | {{Spec2('CSS5 Media Queries')}} | Definição inicial. |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/@page/index.md
+++ b/files/pt-br/web/css/@page/index.md
@@ -31,10 +31,7 @@ Podemos fazer referência a vários [pseudo-classes](/pt-BR/docs/CSS/Pseudo-clas
 
 ## Especificações
 
-| Specification                                               | Status                        | Comment                                                                                          |
-| ----------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------ |
-| {{SpecName('CSS3 Paged Media', '#at-page-rule', '@page')}}  | {{Spec2('CSS3 Paged Media')}} | Sem mudanças para {{SpecName('CSS2.1')}}, though more CSS at-rules can be used inside a `@page`. |
-| {{SpecName('CSS2.1', 'page.html#page-selectors', '@page')}} | {{Spec2('CSS2.1')}}           |                                                                                                  |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_active/index.md
+++ b/files/pt-br/web/css/_colon_active/index.md
@@ -47,12 +47,7 @@ a:active {
 
 ## Especificações
 
-| Especificação                                                             | Status                      | Comentário         |
-| ------------------------------------------------------------------------- | --------------------------- | ------------------ |
-| {{SpecName('CSS4 Selectors', '#active-pseudo', ':active')}}               | {{Spec2('CSS4 Selectors')}} | Nenhuma mudança.   |
-| {{SpecName('CSS3 Selectors', '#useraction-pseudos', ':active')}}          | {{Spec2('CSS3 Selectors')}} | Nenhuma mudança.   |
-| {{SpecName('CSS2.1', 'selector.html#dynamic-pseudo-classes', ':active')}} | {{Spec2('CSS2.1')}}         | Nenhuma mudança.   |
-| {{SpecName('CSS1', '#anchor-pseudo-classes', ':active')}}                 | {{Spec2('CSS1')}}           | Definição inicial. |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_blank/index.md
+++ b/files/pt-br/web/css/_colon_blank/index.md
@@ -17,9 +17,7 @@ A [pseudo-classe](/pt-BR/docs/Web/CSS/Pseudo-classes) [CSS](/pt-BR/docs/Web/CSS)
 
 ## Especificações
 
-| Specification                                             | Status                      | Comment            |
-| --------------------------------------------------------- | --------------------------- | ------------------ |
-| {{SpecName("CSS4 Selectors", "#blank-pseudo", ":blank")}} | {{Spec2("CSS4 Selectors")}} | Definição inicial. |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_checked/index.md
+++ b/files/pt-br/web/css/_colon_checked/index.md
@@ -156,13 +156,7 @@ Você também pode usar a pseudo-classe `:checked`aplicada a um radioboxe escond
 
 ## Especificações
 
-| Especificação                                                  | Estatus                       | Comentários                                          |
-| -------------------------------------------------------------- | ----------------------------- | ---------------------------------------------------- |
-| {{ SpecName('HTML WHATWG', '#selector-checked', ':checked') }} | {{ Spec2('HTML WHATWG') }}    | Sem mudanças.                                        |
-| {{ SpecName('HTML5 W3C', '#selector-checked', ':checked') }}   | {{ Spec2('HTML5 W3C') }}      | Define a semântica sobre o HTML.                     |
-| {{ SpecName('CSS4 Selectors', '#checked', ':checked') }}       | {{ Spec2('CSS4 Selectors') }} | Sem mudanças.                                        |
-| {{ SpecName('CSS3 Basic UI', '#pseudo-checked', ':checked') }} | {{ Spec2('CSS3 Basic UI') }}  | Link para Seletores nível 3                          |
-| {{ SpecName('CSS3 Selectors', '#checked', ':checked') }}       | {{ Spec2('CSS3 Selectors') }} | Define a pseudo-classe, mas não associação semântica |
+{{Specifications}}
 
 ## Compatibilidade de navegadores
 

--- a/files/pt-br/web/css/_colon_first-child/index.md
+++ b/files/pt-br/web/css/_colon_first-child/index.md
@@ -69,10 +69,7 @@ li:first-child {
 
 ## Especificações
 
-| Especificação                                                           | Status                        | Comentário         |
-| ----------------------------------------------------------------------- | ----------------------------- | ------------------ |
-| {{ SpecName('CSS4 Selectors', '#first-child-pseudo', ':first-child') }} | {{ Spec2('CSS4 Selectors') }} | Sem mudança.       |
-| {{ SpecName('CSS3 Selectors', '#first-child-pseudo', ':first-child') }} | {{ Spec2('CSS3 Selectors') }} | Definição inicial. |
+{{Specifications}}
 
 ## Browsers compatíveis
 

--- a/files/pt-br/web/css/_colon_first-of-type/index.md
+++ b/files/pt-br/web/css/_colon_first-of-type/index.md
@@ -80,10 +80,7 @@ article :first-of-type {
 
 ## Especificações
 
-| Specification                                                             | Status                      | Comment                                                           |
-| ------------------------------------------------------------------------- | --------------------------- | ----------------------------------------------------------------- |
-| {{SpecName('CSS4 Selectors', '#first-of-type-pseudo', ':first-of-type')}} | {{Spec2('CSS4 Selectors')}} | Os elementos correspondentes não são necessários para ter um pai. |
-| {{SpecName('CSS3 Selectors', '#first-of-type-pseudo', ':first-of-type')}} | {{Spec2('CSS3 Selectors')}} | Definição inicial.                                                |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_focus-within/index.md
+++ b/files/pt-br/web/css/_colon_focus-within/index.md
@@ -63,9 +63,7 @@ input {
 
 ## Especificações
 
-| Especificação                                                               | Status                      | Comentário          |
-| --------------------------------------------------------------------------- | --------------------------- | ------------------- |
-| {{SpecName("CSS4 Selectors", "#the-focus-within-pseudo", ":focus-within")}} | {{Spec2("CSS4 Selectors")}} | Initial definition. |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_hover/index.md
+++ b/files/pt-br/web/css/_colon_hover/index.md
@@ -83,11 +83,7 @@ Você pode usar a pseudo-classe `:hover` para construir uma galeria de imagem, e
 
 ## Especificações
 
-| Especificação                                                                           | Status                        | Comentário                                    |
-| --------------------------------------------------------------------------------------- | ----------------------------- | --------------------------------------------- |
-| {{ SpecName('CSS4 Selectors', '#hover', ':hover') }}                                    | {{ Spec2('CSS4 Selectors') }} | Pode ser aplicado a qualquer pseudo-elemento. |
-| {{ SpecName('CSS3 Selectors', '#the-user-action-pseudo-classes-hover-act', ':hover') }} | {{ Spec2('CSS3 Selectors') }} | Sem mudança significativa.                    |
-| {{ SpecName('CSS2.1', 'selector.html#dynamic-pseudo-classes', ':hover') }}              | {{ Spec2('CSS2.1') }}         | definição inicial.                            |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_invalid/index.md
+++ b/files/pt-br/web/css/_colon_invalid/index.md
@@ -98,11 +98,7 @@ Você pode desabilitar o "brilho" usando o CSS a seguir, ou substituir completam
 
 ## Especificações
 
-| Especificação                                                   | Status                      | Comentário                                            |
-| --------------------------------------------------------------- | --------------------------- | ----------------------------------------------------- |
-| {{SpecName('HTML WHATWG', '#selector-invalid', ':invalid')}}    | {{Spec2('HTML WHATWG')}}    | Nenhuma alteração.                                    |
-| {{SpecName('HTML5 W3C', '#selector-invalid', ':invalid')}}      | {{Spec2('HTML5 W3C')}}      | Define a semântica do HTML e validação de restrições. |
-| {{SpecName('CSS4 Selectors', '#validity-pseudos', ':invalid')}} | {{Spec2('CSS4 Selectors')}} | Definição inicial.                                    |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_last-child/index.md
+++ b/files/pt-br/web/css/_colon_last-child/index.md
@@ -39,10 +39,7 @@ li:last-child {
 
 ## Especificações
 
-| Especificação                                                  | Status                        | Comentário         |
-| -------------------------------------------------------------- | ----------------------------- | ------------------ |
-| {{ SpecName('CSS4 Selectors', '#last-child', ':last-child') }} | {{ Spec2('CSS4 Selectors') }} | Sem mudança.       |
-| {{ SpecName('CSS3 Selectors', '#last-child', ':last-child') }} | {{ Spec2('CSS3 Selectors') }} | Definição inicial. |
+{{Specifications}}
 
 ## Compatibilidade de navegadores
 

--- a/files/pt-br/web/css/_colon_last-of-type/index.md
+++ b/files/pt-br/web/css/_colon_last-of-type/index.md
@@ -49,10 +49,7 @@ p em:last-of-type {
 
 ## Especificações
 
-| Specification                                                           | Status                      | Comment            |
-| ----------------------------------------------------------------------- | --------------------------- | ------------------ |
-| {{SpecName('CSS4 Selectors', '#last-of-type-pseudo', ':last-of-type')}} | {{Spec2('CSS4 Selectors')}} | No change          |
-| {{SpecName('CSS3 Selectors', '#last-of-type-pseudo', ':last-of-type')}} | {{Spec2('CSS3 Selectors')}} | Initial definition |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_link/index.md
+++ b/files/pt-br/web/css/_colon_link/index.md
@@ -22,12 +22,7 @@ a:link {
 
 ## Especificações
 
-| Especificação                                                          | Status                        | Comentário                                       |
-| ---------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------ |
-| {{ SpecName('CSS4 Selectors', '#link', ':link') }}                     | {{ Spec2('CSS4 Selectors') }} | Nenhuma mudança.                                 |
-| {{ SpecName('CSS3 Selectors', '#link', ':link') }}                     | {{ Spec2('CSS3 Selectors') }} | Nenhuma mudança.                                 |
-| {{ SpecName('CSS2.1', 'selector.html#link-pseudo-classes', ':link') }} | {{ Spec2('CSS2.1') }}         | Uso estrito ao elemento {{ HTMLElement("a") }} . |
-| {{ SpecName('CSS1', '#anchor-pseudo-classes', ':link') }}              | {{ Spec2('CSS1') }}           | Definição Inicial.                               |
+{{Specifications}}
 
 ## Compatibilidade do navegador
 

--- a/files/pt-br/web/css/_colon_not/index.md
+++ b/files/pt-br/web/css/_colon_not/index.md
@@ -46,10 +46,7 @@ Se obtém resultados como este:
 
 ## Especificações
 
-| Especificação                                           | Status                        | Comentário                                                   |
-| ------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------ |
-| {{ SpecName('CSS4 Selectors', '#negation', ':not()') }} | {{ Spec2('CSS4 Selectors') }} | Extende seus argumentos para permitir seletores não-simples. |
-| {{ SpecName('CSS3 Selectors', '#negation', ':not()') }} | {{ Spec2('CSS3 Selectors') }} | Definição inicial.                                           |
+{{Specifications}}
 
 ## Compatibilidade em Navegadores
 

--- a/files/pt-br/web/css/_colon_nth-child/index.md
+++ b/files/pt-br/web/css/_colon_nth-child/index.md
@@ -154,10 +154,7 @@ div em {
 
 ## Especificações
 
-| Especificação                                                     | Status                      | Comentário                                                                                                                    |
-| ----------------------------------------------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('CSS4 Selectors', '#nth-child-pseudo', ':nth-child')}} | {{Spec2('CSS4 Selectors')}} | Adiciona a sintaxe `of <selector>` e especifica que os elementos correspondentes ao seletor não precisam ter um elemento pai. |
-| {{SpecName('CSS3 Selectors', '#nth-child-pseudo', ':nth-child')}} | {{Spec2('CSS3 Selectors')}} | Definição inicial.                                                                                                            |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_nth-last-child/index.md
+++ b/files/pt-br/web/css/_colon_nth-last-child/index.md
@@ -104,10 +104,7 @@ tr:nth-last-child(-n + 3) {
 
 ## Especificações
 
-| Especificação                                                               | Status                      | Comentário                                                  |
-| --------------------------------------------------------------------------- | --------------------------- | ----------------------------------------------------------- |
-| {{SpecName('CSS4 Selectors', '#nth-last-child-pseudo', ':nth-last-child')}} | {{Spec2('CSS4 Selectors')}} | Elementos correspondentes não precisam ter um elemento-pai. |
-| {{SpecName('CSS3 Selectors', '#nth-last-child-pseudo', ':nth-last-child')}} | {{Spec2('CSS3 Selectors')}} | Definição inicial.                                          |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_nth-of-type/index.md
+++ b/files/pt-br/web/css/_colon_nth-of-type/index.md
@@ -67,10 +67,7 @@ p:nth-of-type(1) {
 
 ## Especificações
 
-| Especificação                                                         | Sitação                     | Comentário                                                       |
-| --------------------------------------------------------------------- | --------------------------- | ---------------------------------------------------------------- |
-| {{SpecName('CSS4 Selectors', '#nth-of-type-pseudo', ':nth-of-type')}} | {{Spec2('CSS4 Selectors')}} | Não é necessário que os elementos correspondentes tenham um pai. |
-| {{SpecName('CSS3 Selectors', '#nth-of-type-pseudo', ':nth-of-type')}} | {{Spec2('CSS3 Selectors')}} | Definição inicial.                                               |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_only-child/index.md
+++ b/files/pt-br/web/css/_colon_only-child/index.md
@@ -94,10 +94,7 @@ li:only-child {
 
 ## Especificações
 
-| Especificação                                                       | Status                      | Comentário                                                             |
-| ------------------------------------------------------------------- | --------------------------- | ---------------------------------------------------------------------- |
-| {{SpecName('CSS4 Selectors', '#only-child-pseudo', ':only-child')}} | {{Spec2('CSS4 Selectors')}} | Não é necessário que os elementos selecionados tenham um elemento-pai. |
-| {{SpecName('CSS3 Selectors', '#only-child-pseudo', ':only-child')}} | {{Spec2('CSS3 Selectors')}} | Definição inicial.                                                     |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_optional/index.md
+++ b/files/pt-br/web/css/_colon_optional/index.md
@@ -37,12 +37,7 @@ Entradas requeridas devem ser indicadas visualmente, utilizando um tratamento qu
 
 ## Especificações
 
-| Specification                                                          | Status                        | Comment                                                 |
-| ---------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------- |
-| {{ SpecName('HTML WHATWG', '#selector-optional', ':optional') }}       | {{ Spec2('HTML WHATWG') }}    | Sem mudança.                                            |
-| {{ SpecName('HTML5 W3C', '#selector-optional', ':optional') }}         | {{ Spec2('HTML5 W3C') }}      | Define a semântica da validação e da restrição do HTML. |
-| {{ SpecName('CSS4 Selectors', '#opt-pseudos', ':optional') }}          | {{ Spec2('CSS4 Selectors') }} | Sem mudança.                                            |
-| {{ SpecName('CSS3 Basic UI', '#pseudo-required-value', ':optional') }} | {{ Spec2('CSS3 Basic UI') }}  | Define a pseudo-classe, mas não a semântica associada.  |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_read-write/index.md
+++ b/files/pt-br/web/css/_colon_read-write/index.md
@@ -82,11 +82,7 @@ p:read-write {
 
 ## Especificações
 
-| Especificação                                                        | Status                        | Comentário                                                     |
-| -------------------------------------------------------------------- | ----------------------------- | -------------------------------------------------------------- |
-| {{ SpecName('HTML WHATWG', '#selector-read-write', ':read-write') }} | {{ Spec2('HTML WHATWG') }}    | Nenhuma mudança.                                               |
-| {{ SpecName('HTML5 W3C', '#selector-read-write', ':read-write') }}   | {{ Spec2('HTML5 W3C') }}      | Define a semântica em relação à validação de HTML e restrição. |
-| {{ SpecName('CSS4 Selectors', '#rw-pseudos', ':read-write') }}       | {{ Spec2('CSS4 Selectors') }} | Define a pseudo-classe, mas não a semântica associada.         |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_required/index.md
+++ b/files/pt-br/web/css/_colon_required/index.md
@@ -37,12 +37,7 @@ Se o formulário também possui campos [opcionais](/pt-BR/docs/Web/CSS/:optional
 
 ## Especificações
 
-| Especificação                                                          | Status                        | Comentário                                             |
-| ---------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------ |
-| {{ SpecName('HTML WHATWG', '#selector-required', ':required') }}       | {{ Spec2('HTML WHATWG') }}    | Sem mudança.                                           |
-| {{ SpecName('HTML5 W3C', '#selector-required', ':required') }}         | {{ Spec2('HTML5 W3C') }}      | Define a semântica de validação e de restrição HTML.   |
-| {{ SpecName('CSS4 Selectors', '#opt-pseudos', ':required') }}          | {{ Spec2('CSS4 Selectors') }} | Sem mudança.                                           |
-| {{ SpecName('CSS3 Basic UI', '#pseudo-required-value', ':required') }} | {{ Spec2('CSS3 Basic UI') }}  | Define a pseudo-classe, mas não a semântica associada. |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_target/index.md
+++ b/files/pt-br/web/css/_colon_target/index.md
@@ -191,11 +191,7 @@ Você pode usar a pseudo-classe `:target` para criar uma lightbox sem usar JavaS
 
 ## Especificações
 
-| Especificações                                                          | Status                      | Comentário                           |
-| ----------------------------------------------------------------------- | --------------------------- | ------------------------------------ |
-| {{SpecName("HTML WHATWG", "browsers.html#selector-target", ":target")}} | {{Spec2("HTML WHATWG")}}    | Define semântica específica do HTML. |
-| {{SpecName("CSS4 Selectors", "#the-target-pseudo", ":target")}}         | {{Spec2("CSS4 Selectors")}} | Não há mudanças.                     |
-| {{SpecName("CSS3 Selectors", "#target-pseudo", ":target")}}             | {{Spec2("CSS3 Selectors")}} | Definição inicial.                   |
+{{Specifications}}
 
 ## Navegadores compatíveis
 

--- a/files/pt-br/web/css/_colon_valid/index.md
+++ b/files/pt-br/web/css/_colon_valid/index.md
@@ -26,11 +26,7 @@ Veja {{cssxref(":invalid")}} para um exemplo.
 
 ## Especificações
 
-| Specification                                                 | Status                      | Comment                                                 |
-| ------------------------------------------------------------- | --------------------------- | ------------------------------------------------------- |
-| {{SpecName('HTML WHATWG', '#selector-valid', ':valid')}}      | {{Spec2('HTML WHATWG')}}    | Sem alterações.                                         |
-| {{SpecName('HTML5 W3C', '#selector-valid', ':valid')}}        | {{Spec2('HTML5 W3C')}}      | Define a semântica do HTML e a validação de restrições. |
-| {{SpecName('CSS4 Selectors', '#validity-pseudos', ':valid')}} | {{Spec2('CSS4 Selectors')}} | Definição inicial                                       |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_colon_visited/index.md
+++ b/files/pt-br/web/css/_colon_visited/index.md
@@ -88,13 +88,7 @@ a:visited {
 
 ## Especificações
 
-| Especificações                                                               | Status                        | Comentário                                                                                                                                                            |
-| ---------------------------------------------------------------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{ SpecName('HTML WHATWG', 'scripting.html#selector-visited', ':visited') }} | {{ Spec2('HTML WHATWG') }}    |                                                                                                                                                                       |
-| {{ SpecName('CSS4 Selectors', '#link', ':visited') }}                        | {{ Spec2('CSS4 Selectors') }} | Sem mudança.                                                                                                                                                          |
-| {{ SpecName('CSS3 Selectors', '#link', ':visited') }}                        | {{ Spec2('CSS3 Selectors') }} | Sem mudança.                                                                                                                                                          |
-| {{ SpecName('CSS2.1', 'selector.html#link-pseudo-classes', ':visited') }}    | {{ Spec2('CSS2.1') }}         | Eleva a restrição para aplicar apenas :visited ao elemento {{HTMLElement ("a")}}. Permite que os navegadores restrinjam seu comportamento por motivos de privacidade. |
-| {{ SpecName('CSS1', '#anchor-pseudo-classes', ':visited') }}                 | {{ Spec2('CSS1') }}           | Definição inicial.                                                                                                                                                    |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_doublecolon_after/index.md
+++ b/files/pt-br/web/css/_doublecolon_after/index.md
@@ -122,13 +122,7 @@ span[data-descr]:hover::after {
 
 ## Especificações
 
-| Especificação                                                                                          | Status                            | Comentário                                                        |
-| ------------------------------------------------------------------------------------------------------ | --------------------------------- | ----------------------------------------------------------------- |
-| {{SpecName('CSS4 Pseudo-Elements', '#selectordef-after', '::after')}}                                  | {{Spec2('CSS4 Pseudo-Elements')}} | Sem mudanças significativas em relação à especificação anterior.  |
-| {{Specname("CSS3 Transitions", "#animatable-properties", "transitions on pseudo-element properties")}} | {{Spec2("CSS3 Transitions")}}     | Permite transições em propriedades definidas em pseudo-elementos. |
-| {{Specname("CSS3 Animations", "", "animations on pseudo-element properties")}}                         | {{Spec2("CSS3 Animations")}}      | Permite animações em propriedades definidas em pseudo-elementos.  |
-| {{SpecName('CSS3 Selectors', '#gen-content', '::after')}}                                              | {{Spec2('CSS3 Selectors')}}       | Introduz a sintaxe de dois sinais de dois pontos.                 |
-| {{SpecName('CSS2.1', 'generate.html#before-after-content', '::after')}}                                | {{Spec2('CSS2.1')}}               | Definição inicial, usando a sintaxe de um sinal de dois pontos.   |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_doublecolon_backdrop/index.md
+++ b/files/pt-br/web/css/_doublecolon_backdrop/index.md
@@ -13,9 +13,7 @@ Ele não herda de nenhum elemento e também não é herdado. Não há restriçã
 
 ## Especificações
 
-| Especificação                                                          | Status                  | Comentário        |
-| ---------------------------------------------------------------------- | ----------------------- | ----------------- |
-| {{SpecName('Fullscreen', '#::backdrop-pseudo-element', '::backdrop')}} | {{Spec2('Fullscreen')}} | Definição inicial |
+{{Specifications}}
 
 ## Copatibilidade com navegadores
 

--- a/files/pt-br/web/css/_doublecolon_first-letter/index.md
+++ b/files/pt-br/web/css/_doublecolon_first-letter/index.md
@@ -56,13 +56,7 @@ p::first-letter {
 
 ## Especificações
 
-| Especificações                                                                           | Status                             | Comentários                                                                                                                                                                                                                   |
-| ---------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{ SpecName('CSS4 Pseudo-Elements', '#first-letter-pseudo', '::first-letter')}}          | {{ Spec2('CSS4 Pseudo-Elements')}} | Propriedades permitidas generalizadas para tipografia, decoração de texto e propriedades de layout embutido, {{ cssxref("opacity") }} e {{ cssxref("box-shadow") }}.                                                          |
-| {{ SpecName('CSS3 Text Decoration', '#text-shadow', 'text-shadow with ::first-letter')}} | {{ Spec2('CSS3 Text Decoration')}} | Permitido uso de {{cssxref("text-shadow")}} com `::first-letter`.                                                                                                                                                             |
-| {{ SpecName('CSS3 Selectors', '#first-letter', '::first-letter') }}                      | {{ Spec2('CSS3 Selectors') }}      | Comportamento definido entre maiúsculas e minúsculas, como nos itens da lista, ou com comportamento específico do idioma (como o dígrafo holandês `IJ`). A sintaxe de dois dois-pontos para pseudo-elementos foi introduzida. |
-| {{ SpecName('CSS2.1', 'selector.html#first-letter', '::first-letter') }}                 | {{ Spec2('CSS2.1') }}              | Sem mudanças significativas, apesar que CSS nível 2 continuar aceitando apenas um dois-pontos.                                                                                                                                |
-| {{ SpecName('CSS1', '#the-first-letter-pseudo-element', '::first-letter') }}             | {{ Spec2('CSS1') }}                | Definição inicial de um dois-pontos.                                                                                                                                                                                          |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_doublecolon_first-line/index.md
+++ b/files/pt-br/web/css/_doublecolon_first-line/index.md
@@ -66,13 +66,7 @@ Somente um pequeno subconjunto de propriedades CSS pode ser usado com o`::first-
 
 ## Especificações
 
-| Especificação                                                                                  | Status                            | Comentário                                                                                                                                                                                                                           |
-| ---------------------------------------------------------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| {{SpecName('CSS4 Pseudo-Elements', '#first-line-pseudo', '::first-line')}}                     | {{Spec2('CSS4 Pseudo-Elements')}} | Define mais estritamente onde `::first-letter` pode ocorrer. Generaliza propriedades permitidas para tipografia, decoração de texto e propriedades de layout embutido e {{cssxref("opacity")}}. Define a herança de`::first-letter`. |
-| {{SpecName('CSS3 Text Decoration', '#text-shadow-property', 'text-shadow with ::first-line')}} | {{Spec2('CSS3 Text Decoration')}} | Permite o uso de {{cssxref("text-shadow")}} com `::first-letter`.                                                                                                                                                                    |
-| {{SpecName('CSS3 Selectors', '#first-line', '::first-line')}}                                  | {{Spec2('CSS3 Selectors')}}       | Introdução da sintaxe de dois-pontos.                                                                                                                                                                                                |
-| {{SpecName('CSS2.1', 'selector.html#first-line-pseudo', '::first-line')}}                      | {{Spec2('CSS2.1')}}               | Nenhuma mudança.                                                                                                                                                                                                                     |
-| {{SpecName('CSS1', '#the-first-line-pseudo-element', '::first-line')}}                         | {{Spec2('CSS1')}}                 | Definição inicial, usando a sintaxe de dois pontos.                                                                                                                                                                                  |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/_doublecolon_selection/index.md
+++ b/files/pt-br/web/css/_doublecolon_selection/index.md
@@ -94,11 +94,7 @@ Facilite para os usuários ver e ouvir o conteúdo, incluindo a separação do p
 
 ## Especificações
 
-| Especificações                                                                | Status                            | Comentário         |
-| ----------------------------------------------------------------------------- | --------------------------------- | ------------------ |
-| {{SpecName('CSS4 Pseudo-Elements', '#selectordef-selection', '::selection')}} | {{Spec2('CSS4 Pseudo-Elements')}} | Definição inicial. |
-
-> **Nota:** `::selection` estava nos rascunhos do Nível 3 dos Seletores de CSS, mas foi removido na fase Recomendação do Candidato porque estava subespecificado (especialmente com elementos aninhados) e a interoperabilidade não foi alcançada ([com base na lista de discussão de estilos W3C](http://lists.w3.org/Archives/Public/www-style/2008Oct/0268.html)). Ele retornou no [Nível 4 dos Pseudo-Elementos](http://dev.w3.org/csswg/css-pseudo-4/).
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/actual_value/index.md
+++ b/files/pt-br/web/css/actual_value/index.md
@@ -9,9 +9,7 @@ The **actual value** of a CSS property is the [used value](/pt-BR/docs/Web/CSS/u
 
 ## Especificações
 
-| Especificações                                                      | Status              | Comentario        |
-| ------------------------------------------------------------------- | ------------------- | ----------------- |
-| {{SpecName('CSS2.1', 'cascade.html#actual-value', 'actual value')}} | {{Spec2('CSS2.1')}} | Definição inicial |
+{{Specifications}}
 
 ## Veja também
 

--- a/files/pt-br/web/css/align-items/index.md
+++ b/files/pt-br/web/css/align-items/index.md
@@ -229,12 +229,7 @@ display.addEventListener("change", function (evt) {
 
 ## Especificações
 
-| Especificação                                                             | Status                          | Comentário                                      |
-| ------------------------------------------------------------------------- | ------------------------------- | ----------------------------------------------- |
-| {{SpecName("CSS3 Box Alignment", "#propdef-align-items", "align-items")}} | {{Spec2("CSS3 Box Alignment")}} | Atualização para últimas definições de sintaxe. |
-| {{SpecName('CSS3 Flexbox', '#propdef-align-items', 'align-items')}}       | {{Spec2('CSS3 Flexbox')}}       | Definição inicial                               |
-
-{{cssinfo}}
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/align-self/index.md
+++ b/files/pt-br/web/css/align-self/index.md
@@ -121,12 +121,7 @@ div:nth-child(3) {
 
 ## Especificações
 
-| Especificação                                                           | Status                          | Comentário                                   |
-| ----------------------------------------------------------------------- | ------------------------------- | -------------------------------------------- |
-| {{SpecName("CSS3 Box Alignment", "#propdef-align-self", "align-self")}} | {{Spec2("CSS3 Box Alignment")}} | Atualiza para últimas definições de sintaxe. |
-| {{SpecName("CSS3 Flexbox", "#propdef-align-self", "align-self")}}       | {{Spec2("CSS3 Flexbox")}}       | Definição inicial.                           |
-
-{{cssinfo}}
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/attr/index.md
+++ b/files/pt-br/web/css/attr/index.md
@@ -82,10 +82,7 @@ p::before {
 
 ## Especificações
 
-| Especificação                                           | Status                   | Comentário                                                                                                                                                                                                                       |
-| ------------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('CSS3 Values', '#attr-notation', 'attr()')}} | {{Spec2('CSS3 Values')}} | Added two optional parameters; can be used on all properties; may return other values than {{cssxref("&lt;string&gt;")}}. These changes are experimental and may be dropped during the CR phase if browser support is too small. |
-| {{SpecName('CSS2.1', 'generate.html#x18', 'attr()')}}   | {{Spec2('CSS2.1')}}      | Limited to the {{cssxref("content")}} property; always return a {{cssxref("&lt;string&gt;")}}.                                                                                                                                   |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/attribute_selectors/index.md
+++ b/files/pt-br/web/css/attribute_selectors/index.md
@@ -139,11 +139,7 @@ div[data-lang="zh-TW"] {
 
 ## Especificações
 
-| Specification                                                                      | Status                      | Comment                                                           |
-| ---------------------------------------------------------------------------------- | --------------------------- | ----------------------------------------------------------------- |
-| {{SpecName('CSS4 Selectors', '#attribute-selectors', 'attribute selectors')}}      | {{Spec2('CSS4 Selectors')}} | Adiciona um modificador para a seleção do valor do atributo ASCII |
-| {{SpecName('CSS3 Selectors', '#attribute-selectors', 'attribute selectors')}}      | {{Spec2('CSS3 Selectors')}} |                                                                   |
-| {{SpecName('CSS2.1', 'selector.html#attribute-selectors', 'attribute selectors')}} | {{Spec2('CSS2.1')}}         | Definição Inicial                                                 |
+{{Specifications}}
 
 ## Browser compatibilidade
 

--- a/files/pt-br/web/css/backface-visibility/index.md
+++ b/files/pt-br/web/css/backface-visibility/index.md
@@ -186,9 +186,7 @@ td {
 
 ## Especificações
 
-| Especificação                                                                           | Status                       | Comentário        |
-| --------------------------------------------------------------------------------------- | ---------------------------- | ----------------- |
-| {{SpecName('CSS3 Transforms', '#backface-visibility-property', 'backface-visibility')}} | {{Spec2('CSS3 Transforms')}} | Definição Inicial |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/background-attachment/index.md
+++ b/files/pt-br/web/css/background-attachment/index.md
@@ -99,11 +99,7 @@ p {
 
 ## Especificações
 
-| Especificação                                                                                | Status                        | Comentário                                                                                      |
-| -------------------------------------------------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------- |
-| {{SpecName('CSS3 Backgrounds', '#the-background-attachment', 'background-attachment')}}      | {{Spec2('CSS3 Backgrounds')}} | The shorthand property has been extended to support multiple backgrounds and the `local` value. |
-| {{SpecName('CSS2.1', 'colors.html#propdef-background-attachment', 'background-attachment')}} | {{Spec2('CSS2.1')}}           | Mudança não significativa.                                                                      |
-| {{SpecName('CSS1', '#background-attachment', 'background-attachment')}}                      | {{Spec2('CSS1')}}             | Mudança não significativa                                                                       |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/background-blend-mode/index.md
+++ b/files/pt-br/web/css/background-blend-mode/index.md
@@ -80,9 +80,7 @@ console.log(document.getElementById("div"));
 
 ## Especificações
 
-| Especificação                                                                    | Status                     | Comentário         |
-| -------------------------------------------------------------------------------- | -------------------------- | ------------------ |
-| {{ SpecName('Compositing', '#background-blend-mode', 'background-blend-mode') }} | {{ Spec2('Compositing') }} | Initial definition |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/background-clip/index.md
+++ b/files/pt-br/web/css/background-clip/index.md
@@ -159,9 +159,7 @@ p {
 
 ## Especificações
 
-| Especificação                                                               | Estado                        | Comentário |
-| --------------------------------------------------------------------------- | ----------------------------- | ---------- |
-| {{SpecName('CSS3 Backgrounds', '#the-background-clip', 'background-clip')}} | {{Spec2('CSS3 Backgrounds')}} |            |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/background-color/index.md
+++ b/files/pt-br/web/css/background-color/index.md
@@ -104,11 +104,7 @@ A cor do contrast é determinada comparando a luminância da cor do texto e da c
 
 ## Especificações
 
-| Specification                                                                      | Comment                                                                                                                                                | Feedback                                                                                          |
-| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| {{SpecName('CSS3 Backgrounds', '#background-color', 'background-color')}}          | Though technically removing the `transparent` keyword, this doesn't change anything as it has been incorporated as a true {{cssxref("&lt;color&gt;")}} | [Backgrounds Level 3 GitHub issues](https://github.com/w3c/csswg-drafts/labels/css-backgrounds-3) |
-| {{SpecName('CSS2.1', 'colors.html#propdef-background-color', 'background-color')}} |                                                                                                                                                        |                                                                                                   |
-| {{SpecName('CSS1', '#background-color', 'background-color')}}                      | Initial definition                                                                                                                                     |                                                                                                   |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/background-origin/index.md
+++ b/files/pt-br/web/css/background-origin/index.md
@@ -76,11 +76,7 @@ div {
 
 ## Especificações
 
-| Especificação                                                                   | Status                        | Comentário          |
-| ------------------------------------------------------------------------------- | ----------------------------- | ------------------- |
-| {{SpecName('CSS3 Backgrounds', '#the-background-origin', 'background-origin')}} | {{Spec2('CSS3 Backgrounds')}} | Initial definition. |
-
-{{cssinfo}}
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/background/index.md
+++ b/files/pt-br/web/css/background/index.md
@@ -88,11 +88,7 @@ Um ou mais dos seguintes, por qualquer ordem:
 
 ## Especificações
 
-| Especificação                                                         | estado                     | Comente                                                                                                                                                                                           |
-| --------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName ( 'Fundos CSS3', '# a-fundo', 'fundo')}}                   | {{Spec2 ( 'Fundos CSS3')}} | A propriedade taquigráfica foi estendido para suportar múltiplas origens e a nova {{cssxref("background-size")}}, {{cssxref("background-origem")}} e {{cssxref("background-clip")}} propriedades. |
-| {{SpecName ( 'CSS2.1', '# propdef-fundo colors.html', 'background')}} | {{Spec2 ( 'CSS2.1')}}      | Não ocorreram alterações significativas                                                                                                                                                           |
-| {{SpecName ( 'CSS1', '#background', 'background')}}                   | {{Spec2 ( 'CSS1')}}        | definição inicial                                                                                                                                                                                 |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/box-sizing/index.md
+++ b/files/pt-br/web/css/box-sizing/index.md
@@ -41,9 +41,7 @@ box-sizing: inherit
 
 ## Especificações
 
-| Especificação                                              | Situação                   | Comentário |
-| ---------------------------------------------------------- | -------------------------- | ---------- |
-| {{SpecName('CSS3 Basic UI', '#box-sizing', 'box-sizing')}} | {{Spec2('CSS3 Basic UI')}} |            |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/calc/index.md
+++ b/files/pt-br/web/css/calc/index.md
@@ -130,9 +130,7 @@ Isso garante que o tamanho do texto será redimensionado se a página for amplia
 
 ## Especificações
 
-| Especificação                                           | Status                   | Comentário        |
-| ------------------------------------------------------- | ------------------------ | ----------------- |
-| {{SpecName('CSS3 Values', '#calc-notation', 'calc()')}} | {{Spec2('CSS3 Values')}} | Definição inicial |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/class_selectors/index.md
+++ b/files/pt-br/web/css/class_selectors/index.md
@@ -74,12 +74,7 @@ Observe que isso é o mesmo que [`seletor de atributo`](/pt-BR/docs/Web/CSS/Attr
 
 ## Especificações
 
-| Especificação                                                         | Status                      | Comentário        |
-| --------------------------------------------------------------------- | --------------------------- | ----------------- |
-| {{SpecName('CSS4 Selectors', '#class-html', 'class selectors')}}      | {{Spec2('CSS4 Selectors')}} | Sem mudança       |
-| {{SpecName('CSS3 Selectors', '#class-html', 'class selectors')}}      | {{Spec2('CSS3 Selectors')}} |                   |
-| {{SpecName('CSS2.1', 'selector.html#class-html', 'child selectors')}} | {{Spec2('CSS2.1')}}         |                   |
-| {{SpecName('CSS1', '#class-as-selector', 'child selectors')}}         | {{Spec2('CSS1')}}           | Definição inicial |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/clear/index.md
+++ b/files/pt-br/web/css/clear/index.md
@@ -207,13 +207,7 @@ p {
 
 ## Especificações
 
-| Specification                                                             | Status                              | Comment                                               |
-| ------------------------------------------------------------------------- | ----------------------------------- | ----------------------------------------------------- |
-| {{SpecName('CSS Logical Properties', '#float-clear', 'float and clear')}} | {{Spec2('CSS Logical Properties')}} | Adds the values `inline-start` and `inline-end`       |
-| {{SpecName('CSS2.1', 'visuren.html#flow-control', 'clear')}}              | {{Spec2('CSS2.1')}}                 | No significant changes, though details are clarified. |
-| {{SpecName('CSS1', '#clear', 'clear')}}                                   | {{Spec2('CSS1')}}                   | Initial definition                                    |
-
-{{cssinfo}}
+{{Specifications}}
 
 ## Compatibilidade dos browsers
 

--- a/files/pt-br/web/css/computed_value/index.md
+++ b/files/pt-br/web/css/computed_value/index.md
@@ -24,9 +24,7 @@ The {{domxref("Window.getComputedStyle", "getComputedStyle()")}} DOM API returns
 
 ## Especificações
 
-| Especificações                                                          | Status              | Comentário            |
-| ----------------------------------------------------------------------- | ------------------- | --------------------- |
-| {{SpecName("CSS2.1", "cascade.html#computed-value", "computed value")}} | {{Spec2("CSS2.1")}} | Especificação inicial |
+{{Specifications}}
 
 ## Veja também
 

--- a/files/pt-br/web/css/contain/index.md
+++ b/files/pt-br/web/css/contain/index.md
@@ -59,9 +59,7 @@ Esta propriedade é útil em páginas que contêm um monte de widgets que são t
 
 ## Especificações
 
-| Especificação                   | Status                       | Comentário         |
-| ------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('CSS Containment')}} | {{Spec2('CSS Containment')}} | Initial definition |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/content/index.md
+++ b/files/pt-br/web/css/content/index.md
@@ -239,10 +239,7 @@ li {
 
 ## Especificações
 
-| Especificação                                                | Status                    | Comentário        |
-| ------------------------------------------------------------ | ------------------------- | ----------------- |
-| {{SpecName("CSS3 Content", "#content-property", "content")}} | {{Spec2("CSS3 Content")}} |                   |
-| {{SpecName("CSS2.1", "generate.html#content", "content")}}   | {{Spec2("CSS2.1")}}       | Definição inicial |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/css_basic_user_interface/index.md
+++ b/files/pt-br/web/css/css_basic_user_interface/index.md
@@ -35,8 +35,4 @@ slug: Web/CSS/CSS_basic_user_interface
 
 ## Especificações
 
-| Especificação                     | Status                     | Comentário         |
-| --------------------------------- | -------------------------- | ------------------ |
-| {{SpecName("CSS4 Basic UI")}}     | {{Spec2("CSS4 Basic UI")}} |                    |
-| {{SpecName("CSS3 Basic UI")}}     | {{Spec2("CSS3 Basic UI")}} |                    |
-| {{SpecName("CSS2.1", "ui.html")}} | {{Spec2("CSS2.1")}}        | Definição inicial. |
+{{Specifications}}

--- a/files/pt-br/web/css/css_box_model/index.md
+++ b/files/pt-br/web/css/css_box_model/index.md
@@ -62,8 +62,4 @@ slug: Web/CSS/CSS_box_model
 
 ## Especificações
 
-| Especificação                      | Situação              | Comentário         |
-| ---------------------------------- | --------------------- | ------------------ |
-| {{SpecName("CSS3 Box")}}           | {{Spec2("CSS3 Box")}} |                    |
-| {{SpecName("CSS2.1", "box.html")}} | {{Spec2("CSS2.1")}}   |                    |
-| {{SpecName("CSS1")}}               | {{Spec2("CSS1")}}     | Initial definition |
+{{Specifications}}

--- a/files/pt-br/web/css/css_counter_styles/using_css_counters/index.md
+++ b/files/pt-br/web/css/css_counter_styles/using_css_counters/index.md
@@ -94,9 +94,7 @@ Produz este resultado:
 
 ## Especificações
 
-| Specification                                                                   | Status              | Comment |
-| ------------------------------------------------------------------------------- | ------------------- | ------- |
-| {{SpecName('CSS2.1', 'generate.html#generate.html#counters', 'counter-reset')}} | {{Spec2('CSS2.1')}} |         |
+{{Specifications}}
 
 ## Veja mais
 

--- a/files/pt-br/web/css/css_display/index.md
+++ b/files/pt-br/web/css/css_display/index.md
@@ -60,13 +60,7 @@ slug: Web/CSS/CSS_display
 
 ## Especificações
 
-| Specification                                                      | Status                    | Comment                                                                                  |
-| ------------------------------------------------------------------ | ------------------------- | ---------------------------------------------------------------------------------------- |
-| {{SpecName("CSS3 Display", "#the-display-properties", "display")}} | {{Spec2("CSS3 Display")}} | Adicionado `run-in`, `flow`, `flow-root`, `contents` e valores de várias palavras-chave. |
-| {{SpecName("CSS2.1", "visuren.html#display-prop", "display")}}     | {{Spec2("CSS2.1")}}       | Adicionados os valores do modelo de tabela e `inline-block`.                             |
-| {{SpecName("CSS1", "#display", "display")}}                        | {{Spec2("CSS1")}}         | Definição inicial. Valores básicos: `none`, `block`, `inline` e `list-item`.             |
-
-Além do nível de especificação de exibição CSS 3, outras especificações definem o comportamento de vários valores da exibição.
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/css_flexible_box_layout/index.md
+++ b/files/pt-br/web/css/css_flexible_box_layout/index.md
@@ -70,9 +70,7 @@ A propriedade `align-content`, `align-self`, `align-items` e `justify-content` a
 
 ## Especificações
 
-| Especificação                  | Status                      | Comentário         |
-| ------------------------------ | --------------------------- | ------------------ |
-| {{ SpecName('CSS3 Flexbox') }} | {{ Spec2('CSS3 Flexbox') }} | Definição inicial. |
+{{Specifications}}
 
 ## Veja também
 

--- a/files/pt-br/web/css/css_grid_layout/index.md
+++ b/files/pt-br/web/css/css_grid_layout/index.md
@@ -3,6 +3,8 @@ title: CSS Grid Layout
 slug: Web/CSS/CSS_grid_layout
 ---
 
+{{CSSRef}}
+
 > **Nota:** CSS Grid será suportado por vários navegadores até meados de 2017. O suporte em navegadores antigos pode ser obtido habilitando-se uma flag que permite o uso da API. Nesse caso não se esqueça de consultar e fazer referência a cada propriedade e funcionalidade da especificação para certificar-se da sua compatibilidade, bem como para obter maiores informações.
 
 **CSS Grid layout** é uma especificação do W3C projetada para proporcionar um método bi-dimensional para criação de layout CSS que oferece a possibilidade de "layoutar" itens da página com uso de linhas e colunas. CSS grid poderá ser usado para obter uma infinidade de diferentes layouts. O diferencial desse método de criação de layouts reside na possibilidade de se dividir uma página em grandes regiões e de se definir o relacionamento em termos de medidas, posicionamento e camadas entre os diferentes componentes da marcação HTML.
@@ -97,54 +99,16 @@ Tal como as tabelas, grid layout permite ao autor alinhar os componentes da pág
 
 ## Especificações
 
-| Especificação               | Status                   | Comentários        |
-| --------------------------- | ------------------------ | ------------------ |
-| {{ SpecName('CSS3 Grid') }} | {{ Spec2('CSS3 Grid') }} | Definição inicial. |
+{{Specifications}}
 
-1. [**CSS**](/pt-BR/docs/Web/CSS)
-2. [**CSS Referência**](/pt-BR/docs/Web/CSS/Reference)
-3. [CSS Grid Layout](/pt-BR/docs/Web/CSS/CSS_Grid_Layout)
-4. **Guias**
+## Veja também
 
-   1. [Conceitos básicos de grid layout](/pt-BR/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout)
-   2. [Relação com outros métodos de layout](/pt-BR/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout)
-   3. [Posicionamento baseado em linha](/pt-BR/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid)
-   4. [Grid template areas](/pt-BR/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas)
-   5. [Layout usando grid lines nomeadas](/pt-BR/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines)
-   6. [Posicionamento Automático no grid layout](/pt-BR/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout)
-   7. [Alinhamento box no grid layout](/pt-BR/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout)
-   8. [Grids, Valores Lógicos e Modos de Escrita](/pt-BR/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid,_Logical_Values_and_Writing_Modes)
-   9. [CSS Grid Layout e Acessibilidade](/pt-BR/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility)
-   10. [CSS Grid Layout e Aprimoramento Progressivo](/pt-BR/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement)
-   11. [Realizando layouts comuns usando CSS Grids](/pt-BR/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout)
+- Glossário:
 
-5. **Propriedades**
-
-   1. [grid](/pt-BR/docs/Web/CSS/grid)
-   2. [grid-area](/pt-BR/docs/Web/CSS/grid-area)
-   3. [grid-auto-columns](/pt-BR/docs/Web/CSS/grid-auto-columns)
-   4. [grid-auto-flow](/pt-BR/docs/Web/CSS/grid-auto-flow)
-   5. [grid-auto-rows](/pt-BR/docs/Web/CSS/grid-auto-rows)
-   6. [grid-column](/pt-BR/docs/Web/CSS/grid-column)
-   7. [grid-column-end](/pt-BR/docs/Web/CSS/grid-column-end)
-   8. [grid-column-gap](/pt-BR/docs/Web/CSS/grid-column-gap)
-   9. [grid-column-start](/pt-BR/docs/Web/CSS/grid-column-start)
-   10. [grid-gap](/pt-BR/docs/Web/CSS/grid-gap)
-   11. [grid-row](/pt-BR/docs/Web/CSS/grid-row)
-   12. [grid-row-end](/pt-BR/docs/Web/CSS/grid-row-end)
-   13. [grid-row-gap](/pt-BR/docs/Web/CSS/grid-row-gap)
-   14. [grid-row-start](/pt-BR/docs/Web/CSS/grid-row-start)
-   15. [grid-template](/pt-BR/docs/Web/CSS/grid-template)
-   16. [grid-template-areas](/pt-BR/docs/Web/CSS/grid-template-areas)
-   17. [grid-template-colunms](/pt-BR/docs/Web/CSS/grid-template-columns)
-   18. [grid-template-rows](/pt-BR/docs/Web/CSS/grid-template-rows)
-
-6. **Glossário**
-
-   1. [Grid lines](/pt-BR/docs/Glossary/Grid_lines)
-   2. [Grid tracks](/pt-BR/docs/Glossary/Grid_tracks)
-   3. [Grid cell](/pt-BR/docs/Glossary/Grid_cell)
-   4. [Grid areas](/pt-BR/docs/Glossary/Grid_areas)
-   5. [Gutters](/pt-BR/docs/Glossary/Gutters)
-   6. [Grid row](/pt-BR/docs/Glossary/Grid_rows)
-   7. [Grid column](/pt-BR/docs/Glossary/Grid_column)
+  - [Grid lines](/pt-BR/docs/Glossary/Grid_lines)
+  - [Grid tracks](/pt-BR/docs/Glossary/Grid_tracks)
+  - [Grid cell](/pt-BR/docs/Glossary/Grid_cell)
+  - [Grid areas](/pt-BR/docs/Glossary/Grid_areas)
+  - [Gutters](/pt-BR/docs/Glossary/Gutters)
+  - [Grid row](/pt-BR/docs/Glossary/Grid_rows)
+  - [Grid column](/pt-BR/docs/Glossary/Grid_column)

--- a/files/pt-br/web/css/css_positioned_layout/index.md
+++ b/files/pt-br/web/css/css_positioned_layout/index.md
@@ -29,7 +29,4 @@ slug: Web/CSS/CSS_positioned_layout
 
 ## Especificações
 
-| Especificação                            | Status                          | Comentário |
-| ---------------------------------------- | ------------------------------- | ---------- |
-| {{ SpecName('CSS3 Positioning') }}       | {{ Spec2('CSS3 Positioning') }} |            |
-| {{ SpecName('CSS2.1', 'visuren.html') }} | {{ Spec2('CSS2.1') }}           |            |
+{{Specifications}}

--- a/files/pt-br/web/css/css_selectors/index.md
+++ b/files/pt-br/web/css/css_selectors/index.md
@@ -56,9 +56,4 @@ Os Seletores definem quais elementos um conjunto de regras CSS se aplica.
 
 ## Especificações
 
-| Especificação                           | Status                      | Comentário        |
-| --------------------------------------- | --------------------------- | ----------------- |
-| {{SpecName('CSS4 Selectors')}}          | {{Spec2('CSS4 Selectors')}} |                   |
-| {{SpecName('CSS3 Selectors')}}          | {{Spec2('CSS3 Selectors')}} |                   |
-| {{SpecName('CSS2.1', 'selector.html')}} | {{Spec2('CSS2.1')}}         |                   |
-| {{SpecName('CSS1')}}                    | {{Spec2('CSS1')}}           | Definição inicial |
+{{Specifications}}

--- a/files/pt-br/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/pt-br/web/css/css_transitions/using_css_transitions/index.md
@@ -1127,9 +1127,7 @@ el.addEventListener("transitionstart", signalStart, true);
 
 ## Especificações
 
-| Especificação                            | Status                        | Comentário        |
-| ---------------------------------------- | ----------------------------- | ----------------- |
-| {{SpecName('CSS3 Transitions', '', '')}} | {{Spec2('CSS3 Transitions')}} | Definição Inícial |
+{{Specifications}}
 
 ## Veja Também
 

--- a/files/pt-br/web/css/css_types/index.md
+++ b/files/pt-br/web/css/css_types/index.md
@@ -37,6 +37,4 @@ Na sintaxe formal, os tipos de dados são indicados pela palavra chave aplicada 
 
 ## Especificações
 
-| Especificação                 | Status                     | Comentário         |
-| ----------------------------- | -------------------------- | ------------------ |
-| {{ SpecName('CSS3 Values') }} | {{ Spec2('CSS3 Values') }} | Definição inicial. |
+{{Specifications}}

--- a/files/pt-br/web/css/descendant_combinator/index.md
+++ b/files/pt-br/web/css/descendant_combinator/index.md
@@ -65,12 +65,7 @@ li li {
 
 ## Especificações
 
-| Especificação                                                                        | Status                      | Comment            |
-| ------------------------------------------------------------------------------------ | --------------------------- | ------------------ |
-| {{SpecName("CSS4 Selectors", "#descendant-combinators", "descendant combinator")}}   | {{Spec2("CSS4 Selectors")}} |                    |
-| {{SpecName("CSS3 Selectors", "#descendant-combinators", "descendant combinator")}}   | {{Spec2("CSS3 Selectors")}} |                    |
-| {{SpecName("CSS2.1", "selector.html#descendant-selectors", "descendant selectors")}} | {{Spec2("CSS2.1")}}         |                    |
-| {{SpecName("CSS1", "#contextual-selectors", "contextual selectors")}}                | {{Spec2("CSS1")}}           | Initial definition |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/element/index.md
+++ b/files/pt-br/web/css/element/index.md
@@ -68,9 +68,7 @@ Esse exemplo usa um elemento {{HTMLElement("button")}} se repetindo como _backgr
 
 ## Especificações
 
-| Especificação                                                                                        | Estatus                  | Comentário                      |
-| ---------------------------------------------------------------------------------------------------- | ------------------------ | ------------------------------- |
-| {{SpecName('CSS4 Images', '#element-notation', 'Using Elements as Images: the element() notation')}} | {{Spec2('CSS4 Images')}} | Actualmente adiado para o CSS4. |
+{{Specifications}}
 
 ## Compatibilidade dos navegadores
 

--- a/files/pt-br/web/css/env/index.md
+++ b/files/pt-br/web/css/env/index.md
@@ -103,9 +103,7 @@ A sintaxe _fallback_, como de propriedades customizadas, permite vírgulas. Mas 
 
 ## Especificações
 
-| Especificação                                                        | Status                                  | Comentário         |
-| -------------------------------------------------------------------- | --------------------------------------- | ------------------ |
-| {{SpecName("CSS3 Environment Variables", "#env-function", "env()")}} | {{Spec2("CSS3 Environment Variables")}} | Definição inicial. |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/flex-flow/index.md
+++ b/files/pt-br/web/css/flex-flow/index.md
@@ -54,9 +54,7 @@ elemento {
 
 ## Especificações
 
-| Especificação                                                    | Status                      | Comentário        |
-| ---------------------------------------------------------------- | --------------------------- | ----------------- |
-| {{ SpecName('CSS3 Flexbox','#flex-flow-property','flex-flow') }} | {{ Spec2('CSS3 Flexbox') }} | Definição inicial |
+{{Specifications}}
 
 {{cssinfo}}
 

--- a/files/pt-br/web/css/float/index.md
+++ b/files/pt-br/web/css/float/index.md
@@ -129,12 +129,7 @@ p.withRedBoxes {
 
 ## Especificações
 
-| Especificação                                                             | Situação                            | Comentário                                                                                                                                                           |
-| ------------------------------------------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('CSS Logical Properties', '#float-clear', 'float and clear')}} | {{Spec2('CSS Logical Properties')}} | Adiciona os valores `inline-start` e `inline-end`.                                                                                                                   |
-| {{SpecName('CSS3 Box', '#float', 'float')}}                               | {{Spec2('CSS3 Box')}}               | Muitos valores novos, nem todos claramente definidos ainda. Qualquer diferença em comportamento não relacionado a novas funções são involutárias; por favor informe. |
-| {{SpecName('CSS2.1', 'visuren.html#float-position', 'float')}}            | {{Spec2('CSS2.1')}}                 | Sem mudanças                                                                                                                                                         |
-| {{SpecName('CSS1', '#float', 'float')}}                                   | {{Spec2('CSS1')}}                   | Definição inicial                                                                                                                                                    |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/font-feature-settings/index.md
+++ b/files/pt-br/web/css/font-feature-settings/index.md
@@ -96,9 +96,7 @@ td.tabular {
 
 ## Especificações
 
-| Especificacão                                                                         | Estado                  | Comment            |
-| ------------------------------------------------------------------------------------- | ----------------------- | ------------------ |
-| {{SpecName('CSS3 Fonts', '#propdef-font-feature-settings', 'font-feature-settings')}} | {{Spec2('CSS3 Fonts')}} | Initial definition |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/font-variation-settings/index.md
+++ b/files/pt-br/web/css/font-variation-settings/index.md
@@ -79,9 +79,7 @@ O CSS do exemplo a seguir pode ser editado para permitir que você mude os valor
 
 ## Especificações
 
-| Especificação                                                                                                                            | Status                  | Comentário         |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------------ |
-| {{SpecName('CSS4 Fonts', '#low-level-font-variation-settings-control-the-font-variation-settings-property', 'font-variation-settings')}} | {{Spec2('CSS4 Fonts')}} | Initial definition |
+{{Specifications}}
 
 {{cssinfo}}
 

--- a/files/pt-br/web/css/font-weight/index.md
+++ b/files/pt-br/web/css/font-weight/index.md
@@ -153,12 +153,7 @@ span {
 
 ## Especificações
 
-| Especificações                                                          | Status                        | Comentário                                  |
-| ----------------------------------------------------------------------- | ----------------------------- | ------------------------------------------- |
-| {{SpecName('CSS3 Fonts', '#font-weight-prop', 'font-weight')}}          | {{Spec2('CSS3 Fonts')}}       | Sem alterações.                             |
-| {{SpecName('CSS3 Transitions', '#animatable-css', 'font-weight')}}      | {{Spec2('CSS3 Transitions')}} | Permite animação do atributo `font-weight`. |
-| {{SpecName('CSS2.1', 'fonts.html#propdef-font-weight', 'font-weight')}} | {{Spec2('CSS2.1')}}           | Sem alterações.                             |
-| {{SpecName('CSS1', '#font-weight', 'font-weight')}}                     | {{Spec2('CSS1')}}             |                                             |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/general_sibling_combinator/index.md
+++ b/files/pt-br/web/css/general_sibling_combinator/index.md
@@ -36,10 +36,7 @@ p ~ span {
 
 ## Especificações
 
-| Specification                                                                                    | Status                      | Comment                                         |
-| ------------------------------------------------------------------------------------------------ | --------------------------- | ----------------------------------------------- |
-| {{ SpecName('CSS4 Selectors', '#general-sibling-combinators', 'following-sibling combinator') }} | {{Spec2('CSS4 Selectors')}} | Renomeia o combinador como "irmão subsequente". |
-| {{ SpecName('CSS3 Selectors', '#general-sibling-combinators', 'general sibling combinator') }}   | {{Spec2('CSS3 Selectors')}} | Definição inicial.                              |
+{{Specifications}}
 
 ## Navegadores compatíveis
 

--- a/files/pt-br/web/css/grid-auto-flow/index.md
+++ b/files/pt-br/web/css/grid-auto-flow/index.md
@@ -118,9 +118,7 @@ function changeGridAutoFlow() {
 
 ## Especificações
 
-| Especificação                                                          | Status                 | Comentário        |
-| ---------------------------------------------------------------------- | ---------------------- | ----------------- |
-| {{SpecName("CSS3 Grid", "#propdef-grid-auto-flow", "grid-auto-flow")}} | {{Spec2("CSS3 Grid")}} | Definição Inicial |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/grid-template-columns/index.md
+++ b/files/pt-br/web/css/grid-template-columns/index.md
@@ -111,9 +111,7 @@ grid-template-columns: unset;
 
 ## Especificações
 
-| Especificação                                                                        | Status                 | Comentário        |
-| ------------------------------------------------------------------------------------ | ---------------------- | ----------------- |
-| {{SpecName("CSS3 Grid", "#propdef-grid-template-columns", "grid-template-columns")}} | {{Spec2("CSS3 Grid")}} | Definição inicial |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/grid/index.md
+++ b/files/pt-br/web/css/grid/index.md
@@ -99,9 +99,7 @@ grid: unset;
 
 ## Especificações
 
-| Especificação                                      | Status                 | Comment           |
-| -------------------------------------------------- | ---------------------- | ----------------- |
-| {{SpecName("CSS3 Grid", "#propdef-grid", "grid")}} | {{Spec2("CSS3 Grid")}} | Definição inicial |
+{{Specifications}}
 
 {{cssinfo}}
 

--- a/files/pt-br/web/css/height/index.md
+++ b/files/pt-br/web/css/height/index.md
@@ -104,12 +104,7 @@ div {
 
 ## Especificações
 
-| Specification                                                          | Status                        | Comment                                                                                                   |
-| ---------------------------------------------------------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------- |
-| {{SpecName('CSS3 Box', '#the-width-and-height-properties', 'height')}} | {{Spec2('CSS3 Box')}}         | Added the `max-content`, `min-content`, `available`, `fit-content`, `border-box`, `content-box` keywords. |
-| {{SpecName('CSS3 Transitions', '#animatable-css', 'height')}}          | {{Spec2('CSS3 Transitions')}} | Lists `height` as animatable.                                                                             |
-| {{SpecName('CSS2.1', 'visudet.html#the-height-property', 'height')}}   | {{Spec2('CSS2.1')}}           | Adds support for the {{cssxref("&lt;length&gt;")}} values and precises on which element it applies to.    |
-| {{SpecName('CSS1', '#height', 'height')}}                              | {{Spec2('CSS1')}}             | Initial specification.                                                                                    |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/hyphens/index.md
+++ b/files/pt-br/web/css/hyphens/index.md
@@ -98,9 +98,7 @@ p.auto {
 
 ## Especificações
 
-| Especificação                                             | Condição               | Comentário         |
-| --------------------------------------------------------- | ---------------------- | ------------------ |
-| {{SpecName("CSS3 Text", "#hyphens-property", "hyphens")}} | {{Spec2("CSS3 Text")}} | Initial definition |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/id_selectors/index.md
+++ b/files/pt-br/web/css/id_selectors/index.md
@@ -36,12 +36,7 @@ span#identificado {
 
 ## Especificações
 
-| Especificação                                                        | Status                      | Comentário        |
-| -------------------------------------------------------------------- | --------------------------- | ----------------- |
-| {{SpecName("CSS4 Selectors", "#id-selectors", "ID selectors")}}      | {{Spec2("CSS4 Selectors")}} |                   |
-| {{SpecName("CSS3 Selectors", "#id-selectors", "ID selectors")}}      | {{Spec2("CSS3 Selectors")}} |                   |
-| {{SpecName("CSS2.1", "selector.html#id-selectors", "ID selectors")}} | {{Spec2("CSS2.1")}}         |                   |
-| {{SpecName("CSS1", "#id-as-selector", "ID selectors")}}              | {{Spec2("CSS1")}}           | Definição inicial |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/image/index.md
+++ b/files/pt-br/web/css/image/index.md
@@ -66,10 +66,7 @@ element(#fakeid)  /* Um elemento ID deve ser um ID existente na página. */
 
 ## Especificações
 
-| Especificações                                                 | Status                   | Comentário                                                                                                                                                                |
-| -------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('CSS4 Images', '#typedef-image', '&lt;image&gt;')}} | {{Spec2('CSS4 Images')}} | Adiciona {{cssxref("element()")}}, {{cssxref("image()")}}, {{cssxref("conic-gradient()")}}, {{cssxref("repeating-conic-gradient()")}}, e {{cssxref("image-resolution")}}. |
-| {{SpecName('CSS3 Images', '#typedef-image', '&lt;image&gt;')}} | {{Spec2('CSS3 Images')}} | Definição inicial. Depois disso, não existe definição explicita do tipo de data `<image>`. Imagens podem ser somente definidas usando a notação funciona `url()` .        |
+{{Specifications}}
 
 ## Compatibilidade do navegador
 

--- a/files/pt-br/web/css/initial/index.md
+++ b/files/pt-br/web/css/initial/index.md
@@ -39,10 +39,7 @@ em {
 
 ## Especificações
 
-| Specification                                         | Status                    | Comment                  |
-| ----------------------------------------------------- | ------------------------- | ------------------------ |
-| {{ SpecName('CSS4 Cascade', '#initial', 'initial') }} | {{Spec2('CSS4 Cascade')}} | No changes from Level 3. |
-| {{ SpecName('CSS3 Cascade', '#initial', 'initial') }} | {{Spec2('CSS3 Cascade')}} | Initial definition.      |
+{{Specifications}}
 
 ## Compatibilidade de navegadores
 

--- a/files/pt-br/web/css/inline-size/index.md
+++ b/files/pt-br/web/css/inline-size/index.md
@@ -66,9 +66,7 @@ A propriedade `inline-size` aproveita os mesmos valores que as propriedades {{cs
 
 ## Especificações
 
-| Especificação                                                                          | Status                              | Comentário        |
-| -------------------------------------------------------------------------------------- | ----------------------------------- | ----------------- |
-| {{SpecName("CSS Logical Properties", "#logical-dimension-properties", "inline-size")}} | {{Spec2("CSS Logical Properties")}} | Definição Inicial |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/isolation/index.md
+++ b/files/pt-br/web/css/isolation/index.md
@@ -77,9 +77,7 @@ Uma das palavras-chave listadas abaixo.
 
 ## Especificações
 
-| Specification                                            | Status                     | Comment            |
-| -------------------------------------------------------- | -------------------------- | ------------------ |
-| {{ SpecName('Compositing', '#isolation', 'Isolation') }} | {{ Spec2('Compositing') }} | Initial definition |
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/css/line-break/index.md
+++ b/files/pt-br/web/css/line-break/index.md
@@ -39,9 +39,7 @@ line-break: unset;
 
 ## Especificações
 
-| Especificações                                                  | Status                 | Comentário        |
-| --------------------------------------------------------------- | ---------------------- | ----------------- |
-| {{SpecName('CSS3 Text', '#line-break-property', 'line-break')}} | {{Spec2('CSS3 Text')}} | Definição inicial |
+{{Specifications}}
 
 {{cssinfo}}
 

--- a/files/pt-br/web/css/margin/index.md
+++ b/files/pt-br/web/css/margin/index.md
@@ -122,12 +122,7 @@ Contudo, em navegadores antigos, como IE8-9 que não suporta layout flexbox, est
 
 ## Especificações
 
-| Especificação                                                    | Status                          | Comentário                               |
-| ---------------------------------------------------------------- | ------------------------------- | ---------------------------------------- |
-| {{ SpecName('CSS3 Box', '#margin', 'margin') }}                  | {{ Spec2('CSS3 Box') }}         | Nenhuma mudança significativa.           |
-| {{ SpecName('CSS3 Transitions', '#animatable-css', 'margin') }}  | {{ Spec2('CSS3 Transitions') }} | Define `margin` como animável.           |
-| {{ SpecName('CSS2.1', 'box.html#margin-properties', 'margin') }} | {{ Spec2('CSS2.1') }}           | Remove seu efeito em elementos _inline_. |
-| {{ SpecName('CSS1', '#margin', 'margin') }}                      | {{ Spec2('CSS1') }}             | Definição inicial.                       |
+{{Specifications}}
 
 {{cssinfo}}
 


### PR DESCRIPTION
### Description

replace old-style specification tables part1.

Used script is [this](https://gist.github.com/yin1999/4bd96356ee5a17b6fbb421b2fcd7fb2f), logic:

1. check if the `SpecName` macro is in file
2. if has, check if the specification macro is in en-US
3. if in en-us, replace this section with specification macro

### Related issues and pull requests

Part of: #11594
