### PR TITLE
fix(pt-BR): correct the incorrect word in the documentation for JavaScript Array.prototype.reduce()

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/reduce/index.md
@@ -56,7 +56,7 @@ Se a array estiver vazia e o `valorInicial` não tiver sido informado, uma exce�
 
 Se a array possuir somente um elemento (independente da posição) e o `valorInicial` não tiver sido fornecido, ou se `valorInicial` for fornecido, mas a array estiver vazia, o valor será retornado sem que a função de `callback` seja chamada.
 
-É mais seguro provir um `valorInicial`, porque existem até _quatro_ possíveis saídas sem o `valorInicial`, como mostrado no exemplo:
+É mais seguro prover um `valorInicial`, porque existem até _quatro_ possíveis saídas sem o `valorInicial`, como mostrado no exemplo:
 
 ```js
 var maxCallback = (acc, cur) => Math.max(acc.x, cur.x);
@@ -99,7 +99,7 @@ Você também pode usar uma {{jsxref("Functions/Arrow_functions", "Arrow Functio
 [0, 1, 2, 3, 4].reduce((accum, curr) => accum + curr);
 ```
 
-Se você informar um valorInicial como o segundo argumento de reduce, o resultado será:
+Se você informar um `valorInicial` como o segundo argumento de reduce, o resultado será:
 
 ```js
 [0, 1, 2, 3, 4].reduce(function (acumulador, valorAtual, indice, array) {
@@ -141,7 +141,7 @@ var total = [0, 1, 2, 3].reduce(
 
 ### Soma de valores de um objeto de um array
 
-Para resumir os valores contidos em um array, você **deve** fornecer um valorInicial, para que cada item passe por sua função.
+Para resumir os valores contidos em um array, você **deve** fornecer um `valorInicial`, para que cada item passe por sua função.
 
 ```js
 var valorInicial = 0;


### PR DESCRIPTION
Description
In the documentation, it is written as 'provir um valor inicial' when it should be 'prover um valor inicial'.

Motivation
Improve the understanding of the documentation.

Additional details
Related issues and pull requests