### PR TITLE
zh-cn: update the translation of "Prototype-based programming"

### DIFF
--- a/files/zh-cn/glossary/prototype-based_programming/index.md
+++ b/files/zh-cn/glossary/prototype-based_programming/index.md
@@ -1,16 +1,14 @@
 ---
-title: 原型编程
+title: 基于原型编程
 slug: Glossary/Prototype-based_programming
 ---
 
 {{GlossarySidebar}}
 
-**原型编程** 是一种 {{Glossary("OOP", "面向对象编程")}} 的风格。在这种风格中，我们不会显式地定义{{Glossary('Class', '类')}} ，而会通过向其他类的实例（对象）中添加属性和方法来创建类，甚至偶尔使用空对象创建类。
+**基于原型编程**是一种{{Glossary("OOP", "面向对象编程")}}的风格。在这种风格中，我们不会显式地定义{{Glossary('Class', '类')}}，而会通过向其他类的实例（对象）中添加属性和方法（甚至偶尔向空对象添加）来创建类。
 
-简单来说，这种风格是在不定义{{Glossary('Class', 'class')}}的情况下创建一个 {{Glossary('Object', 'object')}}。
+简单来说，这种风格是在不定义{{Glossary('Class', '类')}}的情况下创建一个{{Glossary('Object', '对象')}}。
 
-## 更多内容
-
-### 常识
+## 参见
 
 - [基于原型编程](https://zh.wikipedia.org/wiki/基于原型编程)的维基页面

--- a/files/zh-cn/glossary/prototype-based_programming/index.md
+++ b/files/zh-cn/glossary/prototype-based_programming/index.md
@@ -13,4 +13,4 @@ slug: Glossary/Prototype-based_programming
 
 ### 常识
 
-- [原型编程](https://zh.wikipedia.org/wiki/%E5%9F%BA%E4%BA%8E%E5%8E%9F%E5%9E%8B%E7%BC%96%E7%A8%8B) 的维基页面
+- [基于原型编程](https://zh.wikipedia.org/wiki/基于原型编程)的维基页面

--- a/files/zh-cn/glossary/prototype-based_programming/index.md
+++ b/files/zh-cn/glossary/prototype-based_programming/index.md
@@ -13,4 +13,4 @@ slug: Glossary/Prototype-based_programming
 
 ### 常识
 
-- [原型编程](https://zh.wikipedia.org/wiki/Prototype-based_programming) 的维基页面
+- [原型编程](https://zh.wikipedia.org/wiki/%E5%9F%BA%E4%BA%8E%E5%8E%9F%E5%9E%8B%E7%BC%96%E7%A8%8B) 的维基页面


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

“原型编程”页面下方的“[原型编程]的维基页面”一句的链接存在问题。
它指向了中文维基百科，但是链接所指向的条目标题却是英文的。
这使得链接指向了一个没有内容的页面。
实际访问时需要先用同一个标题访问英文条目，
然后再从英文条目中指向其他语言的链接切换回中文条目，
才能查看本来一次点击即可访问的内容。
这个问题已在PR中修正。

### Motivation

我为了相关维基条目查找了许久，浪费了很多时间。
所以我想修掉这个问题，避免其他人也浪费时间。

### Additional details

无。

### Related issues and pull requests

无。
