### PR TITLE
[zh-cn]: fix incorrect style of self-closing input tag

### DIFF
--- a/files/zh-cn/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
+++ b/files/zh-cn/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
@@ -231,7 +231,7 @@ function App(props) {
 <label className="todo-label" htmlFor="todo-0"> Eat </label>
 ```
 
-`<input/ >` 标签中的 `defaultChecked` 属性告诉 React 最初要检查这个复选框。如果我们像在普通的 HTML 中那样使用 `checked`，React 会在浏览器控制台中记录一些与处理复选框事件有关的警告，这是我们不想要的。现在不用太担心这个问题——我们将在以后使用事件的时候讨论这个问题。
+`<input />` 标签中的 `defaultChecked` 属性告诉 React 最初要检查这个复选框。如果我们像在普通的 HTML 中那样使用 `checked`，React 会在浏览器控制台中记录一些与处理复选框事件有关的警告，这是我们不想要的。现在不用太担心这个问题——我们将在以后使用事件的时候讨论这个问题。
 
 `htmlFor` 属性对应于 HTML 中使用的 `for` 属性。因为 `for` 是一个保留词，我们不能在 JSX 中使用 `for` 作为属性，所以 React 使用 `htmlFor` 代替。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The self-closed tag `<input/ >` should be written as `<input />`.

### Motivation

In the docs in en-US, the tag is written as `<input />`
https://github.com/mdn/content/blob/01f2a438359101538bd9ac8b520cc2b6feba4e6f/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md?plain=1#L243
