### PR TITLE
chore(codeowners): remove `@mdn/core-dev` from {CONTRIBUTING,PEERS_GUIDELINES}.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,4 +87,6 @@
 /.github/     @mdn/core-dev
 /*            @mdn/core-dev
 /*.md         @mdn/core-dev @mdn/core-yari-content
+/CONTRIBUTING.md            @mdn/core-yari-content
+/PEERS_GUIDELINES.md        @mdn/core-yari-content
 /.prettierignore


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updates the `CODEOWNERS` file so that `@mdn/core-dev` is no longer assigned as a reviewer to PRs changing the `CONTRIBUTING.md` and `PEERS_GUIDELINES.md` files.

### Motivation

A review by `@mdn/core-dev` is not necessary for those two files, and adds unnecessary noise.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

(Internal issue: MP-324)
