### PR TITLE
Add a script to get sourceCommit front matter in files

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "cld": "^2.9.0",
     "fdir": "^6.1.0",
+    "front-matter": "^4.0.2",
     "fs-extra": "^11.1.1",
     "husky": "8.0.3",
     "lint-staged": "14.0.1",

--- a/scripts/get-sourceCommit.js
+++ b/scripts/get-sourceCommit.js
@@ -1,0 +1,113 @@
+//
+// This script uses a language detection library to calculate what language
+// a document is written in. This will help us find any partially translated
+// or untranslated documents within the repository, as well as any documents
+// in the upstream content that shouldn't be translated.
+//
+// Written by Queen Vinyl Da.i'gyu-Kazotetsu (@queengooborg, https://www.queengoob.org)
+
+import fs from "fs-extra";
+import cld from "cld";
+import { fdir } from "fdir";
+import fm from "front-matter";
+import ora from "ora";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+const spinner = ora().start();
+
+const getSourceCommit = async (doc) => {
+  const data = fm(await fs.readFile(doc, "utf8"));
+  return data.attributes.l10n?.sourceCommit;
+};
+
+const printTable = (data, md = true) => {
+  // Print header
+  if (md) {
+    console.log("| File | Source Commit |");
+    console.log("| --- | --- |");
+  } else {
+    console.log("File,Source Commit");
+  }
+
+  // Print file details
+  for (const [k, v] of Object.entries(data)) {
+    if (md) {
+      console.log(`| ${k} | ${v} |`);
+    } else {
+      console.log(`${k},${v}`);
+    }
+  }
+};
+
+const printJSON = (data) => {
+  console.log(JSON.stringify(data));
+};
+
+const main = async () => {
+  const { argv } = yargs(hideBin(process.argv)).command(
+    "$0 [files..]",
+    "Check the given files for a sourceCommit front matter key",
+    (yargs) => {
+      yargs
+        .positional("files", {
+          describe:
+            "The files to check (relative to the current working directory)",
+          type: "string",
+          array: true,
+          default: ["./files/"],
+        })
+        .option("format", {
+          alias: "f",
+          describe: "The format to print results in",
+          type: "string",
+          default: "md",
+          choices: ["md", "csv", "json"],
+        });
+    },
+  );
+
+  const files = [];
+  const data = {};
+
+  spinner.text = "Crawling files...";
+
+  for (const fp of argv.files) {
+    const fstats = await fs.stat(fp);
+
+    if (fstats.isDirectory()) {
+      files.push(
+        ...new fdir()
+          .withBasePath()
+          .filter((path) => path.endsWith(".md"))
+          .crawl(fp)
+          .sync(),
+      );
+    } else if (fstats.isFile()) {
+      files.push(fp);
+    }
+  }
+
+  for (const i in files) {
+    const file = files[i];
+
+    spinner.text = `${i}/${files.length}: ${file}...`;
+
+    try {
+      data[file] = await getSourceCommit(file);
+    } catch (e) {
+      spinner.fail(`${file}: ${e}`);
+      spinner.start();
+    }
+  }
+
+  spinner.stop();
+
+  if (argv.format === "json") {
+    printJSON(data);
+  } else {
+    printTable(data, argv.format === "md");
+  }
+};
+
+await main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,6 +52,13 @@ ansi-styles@^6.0.0, ansi-styles@^6.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
+
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
@@ -222,6 +229,11 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
 eventemitter3@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
@@ -271,6 +283,13 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+front-matter@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-4.0.2.tgz#b14e54dc745cfd7293484f3210d15ea4edd7f4d5"
+  integrity sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==
+  dependencies:
+    js-yaml "^3.13.1"
 
 fs-extra@^11.1.1:
   version "11.1.1"
@@ -410,6 +429,14 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+js-yaml@^3.13.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 jsonfile@^6.0.1:
   version "6.1.0"
@@ -745,6 +772,11 @@ slice-ansi@^5.0.0:
   dependencies:
     ansi-styles "^6.0.0"
     is-fullwidth-code-point "^4.0.0"
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
 stdin-discarder@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This PR adds a script to grab the `sourceCommit` front matter keys from documents and present a list in Markdown, CSV or JSON format as requested.  This will help us better track progress for adding the `sourceCommit` key to all documents (and effectively, ensuring all translations will be up to date).
