### PR TITLE
fix(url-check-locale): prevent replacing the empty url locale

### DIFF
--- a/scripts/check-url-locale.js
+++ b/scripts/check-url-locale.js
@@ -185,11 +185,14 @@ function fixUrlLocale(content, errors, expectedLocale) {
     }
     return a.line - b.line;
   });
+  expectedLocale = `/${expectedLocale}/`;
   const lines = content.split("\n");
   for (const { url, line, column, urlLocale } of errors) {
     let lineContent = lines[line - 1];
     const prefix = lineContent.slice(0, column - 1);
-    const newUrl = url.replace(urlLocale, expectedLocale);
+    // replace the slashed locale with the expected locale
+    // to prevent replacing the empty url locale
+    const newUrl = url.replace(`/${urlLocale}/`, expectedLocale);
     const suffix = lineContent.slice(column - 1).replace(url, newUrl);
     lines[line - 1] = `${prefix}${suffix}`;
   }
@@ -221,7 +224,7 @@ async function main() {
 
   spinner.text = "Crawling files...";
 
-  const dryRun = argv.dry;
+  const dryRun = !argv.fix;
 
   for (const fp of argv.files) {
     const fstats = await fs.stat(fp);


### PR DESCRIPTION
### Description

1. prevent replacing the empty url locale, as the replacement would be wrong when the locale part is empty, see: https://github.com/mdn/translated-content/blob/27a568bbdb06f41d85b907fae41d50cc7b169b59/files/ko/web/javascript/inheritance_and_the_prototype_chain/index.md?plain=1#L660
2. correct the `dryRun` key