### PR TITLE
fix(ru): live example in `background-clip` article

### DIFF
--- a/files/ru/web/css/background-clip/index.md
+++ b/files/ru/web/css/background-clip/index.md
@@ -43,7 +43,7 @@ background-clip: unset;
 
 ## Примеры
 
-#### HTML
+### HTML
 
 ```html
 <p class="border-box">The background extends behind the border.</p>
@@ -56,7 +56,7 @@ background-clip: unset;
 <p class="text">The background is clipped to the foreground text.</p>
 ```
 
-#### CSS
+### CSS
 
 ```css
 p {

--- a/files/ru/web/css/background-clip/index.md
+++ b/files/ru/web/css/background-clip/index.md
@@ -87,7 +87,7 @@ p {
 
 #### Результат
 
-{{EmbedLiveSample('Example', 600, 580)}}
+{{EmbedLiveSample('Примеры', 600, 580)}}
 
 ## Спецификации
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I went to the page [background-clip](https://developer.mozilla.org/ru/docs/Web/CSS/background-clip) and have noticed an error. The example does not work properly.

*\*I'm writing on English because it's easier for me.*

### Motivation

It fixes a bug that provides wrong example. **Currently, the example don't applies styles.**

### Additional details

- https://developer.mozilla.org/ru/docs/Web/CSS/background-clip

### Related issues and pull requests

None.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
