### PR TITLE
css/resolutionからcss/length#pxへのリンク切れを修正

### DIFF
--- a/files/ja/web/css/resolution/index.md
+++ b/files/ja/web/css/resolution/index.md
@@ -20,7 +20,7 @@ slug: Web/CSS/resolution
 - `dpcm`
   - : [センチメートルあたりのドット数](https://en.wikipedia.org/wiki/Dots_per_inch) を表します。1 インチは 2.54 cm なので、`1dpcm ≈ 2.54dpi` です。
 - `dppx`
-  - : ピクセル (`[px](/ja/docs/Web/CSS/length#px)`) あたりのドット数を表します。CSS の `in` と CSS の `px` の比率は 1:96 で固定なので、`1dppx` は `96dpi` と同じです。これは {{cssxref("image-resolution")}} で定義される、CSS の画像の既定の解像度に一致します。
+  - : ピクセル ([`px`](/ja/docs/Web/CSS/length#px)) あたりのドット数を表します。CSS の `in` と CSS の `px` の比率は 1:96 で固定なので、`1dppx` は `96dpi` と同じです。これは {{cssxref("image-resolution")}} で定義される、CSS の画像の既定の解像度に一致します。
 - `x`
   - : `dppx` の別名です。
 


### PR DESCRIPTION
### Description

https://developer.mozilla.org/ja/docs/Web/CSS/resolution のdppxでリンク指定が出来ていなかったので修正しました。

![image](https://github.com/mdn/translated-content/assets/34187067/ace46e3d-9596-4b1d-aba1-fbe1fae1a3c8)


### Motivation

### Additional details

参考：原文の記載方法. 
https://github.com/mdn/content/blob/c51e0599ea09c0e6d035c635db9f48ad1f241490/files/en-us/web/css/resolution/index.md?plain=1#L25

### Related issues and pull requests
