### PR TITLE
Update index.md

### DIFF
--- a/files/zh-cn/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/zh-cn/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -414,7 +414,7 @@ console.log(doSomeInstancing);
 
 如果 `doSomeInstancing` 没有该属性，那么运行时会在 `doSomeInstancing.[[Prototype]]`（也就是 `doSomething.prototype`）中查找该属性。如果 `doSomeInstancing.[[Prototype]]` 有该属性，那么就会使用 `doSomeInstancing.[[Prototype]]` 上的该属性。
 
-否则，如果 `doSomeInstancing.[[Prototype]]` 没有该属性，那么就会在 `doSomeInstancing.[[Prototype]].[[Prototype]]` 中查找该属性。默认情况下，任何函数的 `prototype` 属性的 `[[Prototype]]` 都是 `Object.prototype`。因此，然后会在 `doSomeInstancing.[[Prototype]].[[Prototype]]`（也就是 `doSomething.prototype.[[Prototype]]`（也就是 `Object.prototype`））上查找该属性。
+否则，如果 `doSomeInstancing.[[Prototype]]` 没有该属性，那么就会在 `doSomeInstancing.[[Prototype]].[[Prototype]]` 中查找该属性。默认情况下，任何函数的 `prototype` 属性的 `[[Prototype]]` 都是 `Object.prototype`。因此会在 `doSomeInstancing.[[Prototype]].[[Prototype]]`（也就是 `doSomething.prototype.[[Prototype]]`（也就是 `Object.prototype`））上查找该属性。
 
 如果在 `doSomeInstancing.[[Prototype]].[[Prototype]]` 中没有找到该属性，那么就会在 `doSomeInstancing.[[Prototype]].[[Prototype]].[[Prototype]]` 中查找该属性。但是，这里有一个问题：`doSomeInstancing.[[Prototype]].[[Prototype]].[[Prototype]]` 不存在，因为 `Object.prototype.[[Prototype]]` 是 `null`。然后，只有在查找完整个 `[[Prototype]]` 链之后，运行时才会断言该属性不存在，并得出该属性的值为 `undefined`。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
delete '然后‘ from zh-cn/web/javascript/inheritance_and_the_prototype_chain/index.md

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

上文中介绍了`doSomeInstancing`向上查找一步`[[Prototype]]`后获得到了结果就会使用查找结果。下文中说明了如果向上查找不到就继续向上查找到`Object.prototype`，此时应使用一个承接关系词来表达因为上方的原因所以获得了如此这般的结果。而此处用了两个承接关系词并且其中“然后”使用的并不恰当，然后的意思是前面内容结束后，后面内容接着发生。所以此处应该删去然后。

>The above section describes how to use the result of `doSomeInstancing` when you get a result after looking up one step to `[[Prototype]]`. The following section explains that if you can't go up to `Object.prototype`, you should use one conjunction to express that you got such-and-such a result because of the above. In this case, two conjunctions are used and the use of "然后" is not appropriate, as "然后" means that after the previous content is finished, the next content will follow. Therefore, the word "然后" should be deleted.

