### PR TITLE
[fr] Translation of the PWA tutorial landing page

### DIFF
--- a/files/fr/web/progressive_web_apps/tutorials/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/index.md
@@ -1,0 +1,18 @@
+---
+title: Tutoriels
+slug: Web/Progressive_web_apps/Tutorials
+l10n:
+  sourceCommit: 8d202854ade7328f827da2951bc714455f78674f
+---
+
+{{PWASidebar}}
+
+Cette page répertorie les tutoriels permettant d'apprendre à développer des Applications Web Progressives (abbrégé <abbr title="Progressive Web Apps">PWA</abbr> en anglais pour «&nbsp;<i lang="en">Progressive Web Apps</i>&nbsp;»). Les tutoriels décrivent les étapes de la création d'une application, du début à la fin, en expliquant comment les différentes fonctionnalités de l'application sont mises en œuvre.
+
+- [Créer votre première PWA](/fr/docs/Web/Progressive_web_apps/Tutorials/CycleTracker)
+
+  - : Ce tutoriel pour débutants présente la création d'une application web pour le suivi des cycles menstruels. Les leçons comprennent un passage en revue du HTML, du CSS et du JavaScript nécessaires pour créer une application web entièrement fonctionnelle, la mise en place d'un environnement de test et des explications complètes guidant l'apprenant dans la mise à niveau de l'application web en une Application web progressive&nbsp;; y compris le développement et l'inspection d'un manifeste, l'ajout d'un <i lang="en">service workers</i> et l'utilisation de <i lang="en">service workers</i> pour supprimer les caches périmés.
+
+- [Introduction aux progressive web apps](/fr/docs/Web/Progressive_web_apps/Tutorials/js13kGames)
+
+  - : Ce tutoriel de niveau intermédiaire présente la création d'une PWA qui répertorie les informations sur les jeux soumis dans la catégorie A-Frame du concours [js13kGames 2017](https://2017.js13kgames.com/). Ce tutoriel comprend toutes les bases de la création d'une PWA, avec des fonctionnalités supplémentaires, y compris les notifications, l'usage de <i lang="en">push</i> et les performances de l'application.

--- a/files/fr/web/progressive_web_apps/tutorials/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/index.md
@@ -7,12 +7,12 @@ l10n:
 
 {{PWASidebar}}
 
-Cette page répertorie les tutoriels permettant d'apprendre à développer des Applications Web Progressives (abbrégé <abbr title="Progressive Web Apps">PWA</abbr> en anglais pour «&nbsp;<i lang="en">Progressive Web Apps</i>&nbsp;»). Les tutoriels décrivent les étapes de la création d'une application, du début à la fin, en expliquant comment les différentes fonctionnalités de l'application sont mises en œuvre.
+Cette page répertorie les tutoriels permettant d'apprendre à développer des applications web progressives (abbrégé <abbr title="Progressive Web Apps">PWA</abbr> en anglais pour «&nbsp;<i lang="en">Progressive Web Apps</i>&nbsp;»). Les tutoriels décrivent les étapes de la création d'une application, du début à la fin, en expliquant comment les différentes fonctionnalités de l'application sont mises en œuvre.
 
 - [Créer votre première PWA](/fr/docs/Web/Progressive_web_apps/Tutorials/CycleTracker)
 
-  - : Ce tutoriel pour débutants présente la création d'une application web pour le suivi des cycles menstruels. Les leçons comprennent un passage en revue du HTML, du CSS et du JavaScript nécessaires pour créer une application web entièrement fonctionnelle, la mise en place d'un environnement de test et des explications complètes guidant l'apprenant dans la mise à niveau de l'application web en une Application web progressive&nbsp;; y compris le développement et l'inspection d'un manifeste, l'ajout d'un <i lang="en">service workers</i> et l'utilisation de <i lang="en">service workers</i> pour supprimer les caches périmés.
+  - : Ce tutoriel pour débutantes et débutants présente la création d'une application web pour le suivi des cycles menstruels. Les leçons comprennent un passage en revue du HTML, du CSS et du JavaScript nécessaires pour créer une application web entièrement fonctionnelle, la mise en place d'un environnement de test et des explications complètes guidant dans la mise à niveau de l'application web en une application web progressive&nbsp;; y compris le développement et l'inspection d'un manifeste, l'ajout d'un <i lang="en">service workers</i> et l'utilisation de <i lang="en">service workers</i> pour supprimer les caches périmés.
 
-- [Introduction aux progressive web apps](/fr/docs/Web/Progressive_web_apps/Tutorials/js13kGames)
+- [Introduction aux PWA](/fr/docs/Web/Progressive_web_apps/Tutorials/js13kGames)
 
   - : Ce tutoriel de niveau intermédiaire présente la création d'une PWA qui répertorie les informations sur les jeux soumis dans la catégorie A-Frame du concours [js13kGames 2017](https://2017.js13kgames.com/). Ce tutoriel comprend toutes les bases de la création d'une PWA, avec des fonctionnalités supplémentaires, y compris les notifications, l'usage de <i lang="en">push</i> et les performances de l'application.


### PR DESCRIPTION
### Description

First translation of `Web/Progressive_web_apps/Tutorials` landing page

### Motivation

Progressing of PWA tutorial translation

### Related issues and pull requests

Relates to #16137
