### PR TITLE
chore(pt-br): remove `{{htmlattrdef}}` macro

### DIFF
--- a/files/pt-br/web/html/element/area/index.md
+++ b/files/pt-br/web/html/element/area/index.md
@@ -17,37 +17,37 @@ O _HTML `<area>` elemento_ define uma região hot-spot em uma imagem, e, opciona
 
 Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 
-- {{Htmlattrdef ("accesskey")}}
+- `accesskey`
   - : Especifica um acelerador de navegação pelo teclado para o elemento. Pressionando ALT ou uma chave semelhante, em associação com o caractere especificado seleciona a forma de controle correlacionada com a seqüência de teclas. Os projetistas de página são avisados para evitar sequências de teclas já vinculados aos navegadores. Este atributo é global desde HTML5.
-- {{Htmlattrdef ("alt")}}
+- `alt`
   - : Uma alternativa seqüência de texto para exibir em navegadores que não exibem imagens. O texto deve ser formulada de modo a que apresenta o usuário com o mesmo tipo de escolha como a imagem iria oferecer quando exibido sem o texto alternativo. Em HTML4, este atributo é necessário, mas pode ser uma string vazia (""). Em HTML5, este atributo é necessário apenas se o **href** atributo é usado.
-- {{Htmlattrdef ("coords")}}
+- `coords`
   - : Um conjunto de valores que especificam as coordenadas da região de hot-spot. O número e o significado dos valores dependem do valor especificado para a **forma** de atributo. Para um `rect` forma ou retângulo, o **coords** valor é de dois pares x, y: left, top, right, e bottom. Para um `círculo` forma, o valor é `x, y, r` onde `x, y` é um par especificando o centro do círculo e `r` é um valor para o raio. Para um `poli` ou polígono \<forma>, o valor é um conjunto de pares x, y de cada ponto no polígono: `X1, Y1, X2, Y2, x3, y3`, e assim por diante. Em HTML4, os valores são números de pixels ou porcentagens, se um sinal de porcentagem (%) é anexado; em HTML5, os valores são números de pixels CSS.
-- {{Htmlattrdef ("download")}}
+- `download`
   - : Este atributo, se presente, indica que o autor tem a intenção que o hiperlink seja usado para o download de um recurso. Consulte {{HTMLElement ("a")}} para uma descrição completa da [`download`](/pt-BR/docs/Web/HTML/Element/a#download) atributo.
-- {{Htmlattrdef ("href")}}
+- `href`
   - : A meta de hyperlink para a área. Seu valor é uma URL válida. Em HTML4, quer este atributo ou o **nohref** atributo deve estar presente no elemento. Em HTML5, este atributo pode ser omitido; em caso afirmativo, o elemento de área não representa um hiperlink.
-- {{Htmlattrdef ("hreflang")}}
+- `hreflang`
   - : Indica o idioma do recurso ligado. Os valores permitidos são determinados por [BCP47](http://www.ietf.org/rfc/bcp/bcp47.txt) . Utilize este atributo somente se a **href** atributo está presente.
-- {{Htmlattrdef ("name")}}
+- `name`
   - : Defina um nome para a área clicável de modo que possa ser programado por navegadores mais antigos.
-- {{Htmlattrdef ("media")}}
+- `media`
 
   - : Uma dica da mídia para o qual o recurso ligado foi projetado, por exemplo `impressão e tela` . Se omitido, o padrão é `tudo` . Utilize este atributo somente se a **href** atributo está presente.
 
-- {{Htmlattrdef ("nohref")}}
+- `nohref`
 
   - : Indica que não existe hyperlink para a área associada. Ou este atributo ou a **href** atributo deve estar presente no elemento.
 
     > **Note:** **Nota de Uso:** Este atributo é obsoleto em HTML5, em vez omitindo o atributo **href** é suficiente.
 
-- {{Htmlattrdef ("rel")}}
+- `rel`
   - : Para âncoras contendo o **href** atributo, este atributo especifica a relação do objeto de destino para o objeto link. O valor é uma lista de valores de relacionamento, separados por vírgulas. Os valores e sua semântica será registrado por alguma autoridade que poderia ter significado para o autor do documento. A relação padrão, se nenhum outro é dado, é nula. Utilize este atributo somente se a **href** atributo está presente.
-- {{Htmlattrdef ("shape")}}
+- `shape`
   - : A forma do ponto de acesso associado. As especificações para colar 5 e HTML 4 definem os valores `rect` , que define uma região rectangular; `círculo` , o qual define uma região circular; `poli` , que define um polígono; e `padrão` , o que indica toda a região além de quaisquer formas definidas. Muitos navegadores, principalmente o Internet Explorer 4 e superior, apoio `circ` , `polígono` , e `retângulo` como valores válidos para **forma** ; estes valores são {{Non-standard_inline}}.
-- {{Htmlattrdef ("tabindex")}}
+- `tabindex`
   - : Um valor numérico que especifica a posição da área definida na ordem de tabulação browser. Este atributo é global em HTML5.
-- {{Htmlattrdef ("target")}}
+- `target`
 
   - : Este atributo especifica onde exibir o recurso ligado. Em HTML4, este é o nome de, ou uma palavra-chave para um quadro. Em HTML5, que é um nome ou palavra-chave para um _contexto de navegação_ (por exemplo, aba, janela ou quadro embutido). As seguintes palavras-chave têm significados especiais:
 
@@ -58,7 +58,7 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 
     Utilize este atributo somente se a **href** atributo está presente.
 
-- {{Htmlattrdef ("type")}}
+- `type`
   - : Este atributo especifica o tipo de mídia na forma de um tipo MIME para o destino do link. Geralmente, este é fornecido informações estritamente como consultivo; no entanto, no futuro, um navegador pode adicionar um pequeno ícone para os tipos de multimédia. Por exemplo, um navegador pode adicionar um pequeno ícone de alto-falante quando o tipo está definido para áudio / wav. Para obter uma lista completa de tipos MIME reconhecidos, consulte [https://www.w3.org/TR/html4/references.html # REF-MIMETYPES](https://www.w3.org/TR/html4/references.html#ref-MIMETYPES) . Utilize este atributo somente se a **href** atributo está presente.
 
 ## Exemplo

--- a/files/pt-br/web/html/element/audio/index.md
+++ b/files/pt-br/web/html/element/audio/index.md
@@ -21,23 +21,23 @@ Você pode utilizar recursos avançados da API de áudio — que são específic
 
 Como todos os elementos HTML, este elemento suporta os [global attributes](/pt-BR/docs/HTML/Global_attributes).
 
-- {{ htmlattrdef("autoplay") }}
+- `autoplay`
   - : Um atributo Booleano; se especificado (mesmo se o valor for "false"!), o áudio iniciará automaticamente assim que possível sem parar de carregar os dados.
-- {{ htmlattrdef("autobuffer") }}
+- `autobuffer`
   - : Um atributo Booleano; se especificado, o audio será baixado automaticamente, mesmo se não está configurado para reprodução automática. Isto continua até que o cache de mídia esteja cheio, ou até que o o arquivo de áudio completo tenha sido baixado, o que vier primeiro. Isto deve ser utilizado apenas quando é esperado que o usuário escolherá tocar o áudio; por exemplo, se o usuário navegou para a página utilizando um link "Reproduzir". Este atributo foi removido no Gecko 2.0 em razão do atributo `preload`.
-- {{ htmlattrdef("buffered") }}
+- `buffered`
   - : Um atributo que pode ser lido para determinar os intervalos do áudio que já foram carregados. Este atributo contém um objeto {{ domxref("TimeRanges") }}.
-- {{ htmlattrdef("controls") }}
+- `controls`
   - : Se esse atributo estiver presente, o navegador oferecerá controles para permitir ao usuário controlar a reprodução do áudio, incluindo volume, navegação, e pausa/continuação da reprodução.
-- {{ htmlattrdef("loop") }}
+- `loop`
   - : Um atributo Booleano; se especificado, ao chegar no fim do áudio, ele voltará automaticamente para o começo.
-- {{ htmlattrdef("mozCurrentSampleOffset") }} {{ non-standard_inline() }}
+- `mozCurrentSampleOffset` {{ non-standard_inline() }}
   - : The offset, specified as the number of samples since the beginning of the audio stream, at which the audio is currently playing.
-- {{ htmlattrdef("muted") }}
+- `muted`
   - : Um atributo Booleano que indica se o áudio será inicializado silenciado.
-- {{ htmlattrdef("played") }}
+- `played`
   - : Um objeto {{ domxref("TimeRanges") }}indicando que todo o áudio foi reproduzido.
-- {{ htmlattrdef("preload") }}
+- `preload`
 
   - : Esse atributo enumerado pretende dar uma sugestão ao navegador sobre o que o autor pensa que proporcionará uma melhor experiência do usuário. Ele pode ter os seguintes valores:
 
@@ -52,7 +52,7 @@ Como todos os elementos HTML, este elemento suporta os [global attributes](/pt-B
     >
     > - O navegador não é forçado pela especifição a seguir o valor desse atributo; é apenas uma sugestão.
 
-- {{ htmlattrdef("src") }}
+- `src`
   - : A URL do áudio a ser incorporado. Isso é sujeito a [HTTP access controls](/pt-BR/docs/HTTP_access_control). Isto é opcional; ao invés disso você pode usar o elemento [`<source>`](http://developer.mozilla.org/pt-BR/docs/pt-BR/HTML/Element/source) dentro do bloco do áudio para especificar o vídeo a ser incorporado .
 
 O tempo de compensação (time offset) entre o áudio e o vídeo está especificado como um valor de ponto flutuante (float) representando o número de segundos da compensação.

--- a/files/pt-br/web/html/element/canvas/index.md
+++ b/files/pt-br/web/html/element/canvas/index.md
@@ -21,9 +21,9 @@ Para mais artigos sobre canvas, veja [canvas topic page](/pt-BR/HTML/Canvas).
 
 Como qualquer outro elemento HTML, este também tem [global attributes](/pt-BR/HTML/Global_attributes).
 
-- {{ htmlattrdef("width") }}
+- `width`
   - : A largura do espaço em pixels CSS. O padrão é 300.
-- {{ htmlattrdef("height") }}
+- `height`
   - : A altura do espaço em pixels CSS. O padrão é 150.
 
 > **Nota:** The displayed size of the canvas can be changed using a stylesheet. The image is scaled during rendering to fit the styled size.

--- a/files/pt-br/web/html/element/details/index.md
+++ b/files/pt-br/web/html/element/details/index.md
@@ -19,7 +19,7 @@ O elemento HTML _details_ (`<details>`) é usado como uma ferramenta de onde o u
 
 Como todos os elementos HTML, esse elemento aceita os [global attributes](/pt-BR/HTML/Global_attributes).
 
-- {{ htmlattrdef("open") }}
+- `open`
   - : Esse atributo Booleano indica se os detalhes serão mostrados para o usuário ao carregar a página. Se omitido os detalhes não serão mostrados.
 
 ## Interface do DOM

--- a/files/pt-br/web/html/element/dl/index.md
+++ b/files/pt-br/web/html/element/dl/index.md
@@ -19,7 +19,7 @@ O elemento HTML _Definition List_ (`<dl>`) engloba uma lista de pares de termos 
 
 Como todo elemento HTML, ele fornece os [attributos globais](/pt-BR/HTML/Global_attributes).
 
-- {{ htmlattrdef("compact") }} {{ Non-standard_inline() }}
+- `compact` {{ Non-standard_inline() }}
   - : Obriga a definição da descrição aparecer na mesma linha que a definição do termo. Funciona apenas no Internet Explorer.
 
 ## Exemplos

--- a/files/pt-br/web/html/element/map/index.md
+++ b/files/pt-br/web/html/element/map/index.md
@@ -17,7 +17,7 @@ O **elemento HTML `<map>`** é usado com os elementos {{HTMLElement ("area")}} p
 
 Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 
-- {{Htmlattrdef ("name")}}
+- `name`
   - : O atributo name dá ao mapa de um nome, de modo que ela possa ser referenciada. O atributo deve estar presente e ter um valor não vazio, sem caracteres de espaço. O valor do atributo name não deve corresponder (independente da caixa) a um valor do atributo name de outro elemento no mesmo documento. Se o id de atributo também for especificado, ambos os atributos devem ter o mesmo valor.
 
 ## Exemplos

--- a/files/pt-br/web/html/element/meter/index.md
+++ b/files/pt-br/web/html/element/meter/index.md
@@ -22,19 +22,19 @@ O elemento HTML _meter_ (`<meter>`) pode representar um valor escalar dentro de 
 
 Como todos os elementos HTML, esse elemento suporta [attributes](/pt-BR/HTML/Global_attributes).
 
-- {{ htmlattrdef("value") }}
+- `value`
   - : O valor numérico atual. Ele deve estar entre os valores mínimos e máximo (o atributo **min** e o atributo **max**) se eles estiverem especificados. Se não especificado ou mal formatado, o valor é 0. Se especificado, mas fora do intervalo dado pelos atributos **min** e **max**, o valor é igual ao extremo do intervalo mais próximo.
-- {{ htmlattrdef("min") }}
+- `min`
   - : O limite numérico mínimo do intervalo medido. Deve ser menor que o valor máximo (o atributo **max**), se especificado. Se não especificado, o valor mínimo é 0.
-- {{ htmlattrdef("max") }}
+- `max`
   - : O limite numérico máximo do intervalo medido. Deve ser maior que o valor mínimo (o atributo **min**), se especificado. Se não especificado, o valor máximo é 1.
-- {{ htmlattrdef("low") }}
+- `low`
   - : O limite numérico máximo da parte inferior do intervalo medido. Deve ser maior que o valor mínimo (o atibuto **min**), e também ser menor que o valor alto e o valor máximo (os atributos **high** e **max**, respectivamente), se estiver especificado. Se não especificado, ou se for menor que o valor mínimo, o valor de **low** é igual ao valor mínimo.
-- {{ htmlattrdef("high") }}
+- `high`
   - : O limite numérico mínimo da parte superior do intervalo medido. Deve ser menor que o valor máximo (o atibuto **max**), e também ser maior que o valor baixo e o valor mínimo (os atributos **low** e **min**, respectivamente), se estiver especificado. Se não especificado, ou se for maior que o valor máximo, o valor de **high** é igual ao valor máximo.
-- {{ htmlattrdef("optimum") }}
+- `optimum`
   - : Esse atributo indica o valor numérico ótimo. Deve estar dentro do intervalo (definido pelos atributos **min** e **max**). Quando com os atributos **low** e **high**, ele indica a região do intervalo qu é considerada preferível. Por exemplo, se estiver entre os atributos **min** e **low**, então a parte inferior do intervalo é considerada como ótima.
-- {{ htmlattrdef("form") }}
+- `form`
   - : Esse atributo associa o elemento com um elemento `form` que é dono de um elemento `meter`. Por exemplo, um elemento `meter` pode estar mostrando um intervalo correspondente a um elemento `input` do **type**(tipo) _number_. Esse atributo só é utilizado se o elemento `meter` está sendo utilizado como um elemento associado a um formulário; mesmo assim, ele pode se romitido se o elemento for um descendente de um elemento `form`.
 
 ## Exemplos

--- a/files/pt-br/web/html/element/output/index.md
+++ b/files/pt-br/web/html/element/output/index.md
@@ -17,11 +17,11 @@ O elemento de saída (\<output>) é um elemento no qual um site ou aplicativo po
 
 Como qualquer elemento HTML, este elemento suporta os [global attributes](/pt-BR/HTML/Global_attributes).
 
-- {{ htmlattrdef("for") }}
+- `for`
   - : Uma lista de IDs de outros elementos, indicando que estes elementos contribuiram com valores de entrada (input) para o cálculo (ou outros afetados).
-- {{ htmlattrdef("form") }}
+- `form`
   - : O elemento form ao qual este elemento está associado (seu "proprietário do formulário"). O valor do atributo deve ser um ID de um elemento form no mesmo documento. Se este atributo não está especificado, o elemento output deve ser descendente de um elemento form. Este atributo permite que você coloque elementos output em qualquer lugar em um documento, não apenas como descendentes de seus elementos form.
-- {{ htmlattrdef("name") }}
+- `name`
   - : O nome do elemento.
 
 ## Interface DOM

--- a/files/pt-br/web/html/element/progress/index.md
+++ b/files/pt-br/web/html/element/progress/index.md
@@ -17,9 +17,9 @@ o elemento HTML progress (\<progress>) é usado para visualizar o progresso de u
 
 Como todos os outros elementos HTML, este elemento tem os atributos globais [(global attributes](https://developer-new.mozilla.org/en/HTML/Global_attributes))
 
-- {{ htmlattrdef("max") }}
+- `max`
   - : Este atributo descreve quanto trabalho é demandado pela tarefa indicada pelo elemento progress.
-- {{ htmlattrdef("value") }}
+- `value`
   - : Este atributo especifica quanto da tarefa foi concluído. Se este não existir, a barra de progresso é indeterminada; isso indica que uma atividade está em progresso sem previsão de quanto tempo é esperado para que seja concluída.
 
 Você pode usar a propriedade {{ cssxref("orient") }} para especificar se a barra de progresso deve ser renderizada horizontalmente (padrão) ou verticalmente. A pseudo-classe {{ cssxref(":indeterminate") }} pode ser associada a barras de progresso indeterminadas.

--- a/files/pt-br/web/html/element/source/index.md
+++ b/files/pt-br/web/html/element/source/index.md
@@ -21,11 +21,11 @@ O elemento `source` é utilizado para especificar múltiplos recursos de mídia 
 
 Como todos os outros elementos de HTML, esse elemento suporta os [global attributes](/pt-BR/HTML/Global_attributes).
 
-- {{ htmlattrdef("src") }}
+- `src`
   - : Requerido, endereço do arquivo de mídia.
-- {{ htmlattrdef("type") }}
+- `type`
   - : O tipo MIME do arquivo, opcionalmente com um parametro de `codecs`. Veja o [RFC 4281](https://www.rfc-editor.org/rfc/rfc4281.txt) para informações sobre como especificar codec.
-- {{ htmlattrdef("media") }}
+- `media`
   - : Definição do tipo de mídia ([Media query](/pt-BR/CSS/Media_queries)) pretendido.
 
 Se o atributo **type** não está especificado, o tipo da mídia é obtido no servidor e é verificado se o Gecko consegue reproduzi-lo; se não for possível reproduzi-lo, o próximo **source** é verificado. Se o atributo **type** está definido, ele é comparado aos tipos que o Gecko consegue reproduzir, e se não for reconhecido, o servido não é solicitado; ao invés disso, o próximo elemento **source** é verificado.

--- a/files/pt-br/web/html/element/textarea/index.md
+++ b/files/pt-br/web/html/element/textarea/index.md
@@ -44,33 +44,33 @@ Este elemento inclui os atributos globais.
 
     Se o `autocomplete` atributo não está especificado em um `<textarea>` elemento, o navegador usa o elemento `autocomplete` valor do atributo `<textarea>` proprietário do formulário do elemento. O proprietário do formulário é o {{HTMLElement("form")}} elemento que este`<textarea>` elemento é um descendente ou o elemento de formulário cuja `id` é especificado pelo `form` atributo do elemento de entrada. Para mais informações, consulte o [`autocomplete`](/pt-BR/docs/Web/HTML/Element/form#autocomplete) atribuno no {{HTMLElement("form")}}.
 
-- {{ htmlattrdef("autofocus") }}
+- `autofocus`
   - : Esse atributo booleano permite especificar que um controle de formulário tenha foco de entrada quando a página for carregada. Somente um elemento associado ao formulário em um documento pode ter esse atributo especificado.
-- {{ htmlattrdef("cols") }}
+- `cols`
   - : A largura visível do controle de texto, em larguras médias de caracteres. Se for especificado, deve ser um número inteiro positivo. Se não for especificado, o valor padrão é 20.
-- {{ htmlattrdef("disabled") }}
+- `disabled`
   - : Esse atributo booleano indica que o usuário não pode interagir com o controle. Se esse atributo não for especificado, o controle herdará sua configuração do elemento que contém, por exemplo {{ HTMLElement("fieldset") }}; se não houver elemento contendo quando o `disabled` atributo estiver definido, o controle está ativado.
-- {{ htmlattrdef("form") }}
+- `form`
   - : O elemento do formulário que o `<textarea>` elemento está associado (seu "proprietário do formulário"). O valor do atributo deve ser o `id` de um elemento de formulário no mesmo documento. Se este atributo não for especificado, o atributo `<textarea>` O elemento deve ser um descendente de um elemento do formulário. Este atributo permite que você coloque`<textarea>` elementos em qualquer lugar do documento, não apenas como descendentes de elementos do formulário.
-- {{ htmlattrdef("maxlength") }}
+- `maxlength`
   - : O número máximo de caracteres (pontos de código unicode) que o usuário pode inserir. Se esse valor não for especificado, o usuário poderá inserir um número ilimitado de caracteres.
-- {{ htmlattrdef("minlength") }}
+- `minlength`
   - : O número mínimo de caracteres (pontos de código unicode) exigidos pelo usuário.
-- {{ htmlattrdef("name") }}
+- `name`
   - : O nome do controle.
-- {{ htmlattrdef("placeholder") }}
+- `placeholder`
 
   - : Uma dica para o usuário sobre o que pode ser inserido no controle. Retornos de carro ou feeds de linha no texto do espaço reservado devem ser tratados como quebras de linha ao renderizar a dica.
 
     > **Note:** **Nota: Os espaços reservados devem ser usados apenas para mostrar um exemplo do tipo de dados que deve ser inserido em um formulário; eles não substituem uma adequada** {{HTMLElement("label")}} elemento vinculado à entrada. Veja [Labels e placeholders](/pt-BR/docs/Web/HTML/Element/input#labels_and_placeholders) para uma explicação completa.
 
-- {{ htmlattrdef("readonly") }}
+- `readonly`
   - : Esse atributo booleano indica que o usuário não pode modificar o valor do controle. Ao contrário do `disabled` atributo, o`readonly` O atributo não impede o usuário de clicar ou selecionar no controle. O valor de um controle somente leitura ainda é enviado com o formulário.
-- {{ htmlattrdef("required") }}
+- `required`
   - : Este atributo especifica que o usuário deve preencher um valor antes de enviar um formulário.
-- {{ htmlattrdef("rows") }}
+- `rows`
   - : O número de linhas de texto visíveis para o controle.
-- {{ htmlattrdef("spellcheck") }}
+- `spellcheck`
 
   - : Especifica se o `<textarea>`está sujeito a verificação ortográfica pelo navegador / SO subjacente. o valor pode ser:
 
@@ -78,7 +78,7 @@ Este elemento inclui os atributos globais.
     - `default` :Indica que o elemento deve agir de acordo com um comportamento padrão, possivelmente com base no próprio elemento pai `spellcheck` valor.
     - `false` : Indica que o elemento não deve ter verificação ortográfica.
 
-- {{ htmlattrdef("wrap") }}
+- `wrap`
 
   - : Indica como o controle quebra o texto. Os valores possíveis são:
 

--- a/files/pt-br/web/html/element/ul/index.md
+++ b/files/pt-br/web/html/element/ul/index.md
@@ -56,13 +56,13 @@ Não há nenhuma limitação para a profundidade e a imbricação das listas def
 
 Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 
-- {{ htmlattrdef("compact") }}{{ Deprecated_inline() }}
+- `compact`{{ Deprecated_inline() }}
 
   - : Este atributo booleano sugere que a lista será processada em um modelo compacto. A interpretação deste atributo depende do perfil de navegação (_user agent_) e não funciona em todos os navegadores.
 
     > **Note:** **Nota de utilização:** Não aplique este atributo, que foi preterido - o elemento {{ HTMLElement("ul") }} deve ser definido utilizando-se a folha de estilos [CSS](/pt-BR/CSS). Para dar um efeito similar ao atributo compacto, a propriedade [line-height](/pt-BR/CSS/line-height) (espaçamento), da [CSS](/pt-BR/CSS), pode ser utilizada com um valor de 80%.
 
-- {{ htmlattrdef("type") }}{{ Deprecated_inline() }}
+- `type`{{ Deprecated_inline() }}
 
   - : Usados para estabelecer o tipo de marcador da lista. Os valores definidos durante a [HTML3.2](/pt-BR/HTML3.2) e a versão de transição de [HTML 4.0/4.01](/pt-BR/HTML4.01), são:
 

--- a/files/pt-br/web/html/element/video/index.md
+++ b/files/pt-br/web/html/element/video/index.md
@@ -21,30 +21,30 @@ Para uma lista de formatos suportados veja [Media formats supported by the audio
 
 Como qualquer elemento HTML, este elemento suporta os [global attributes](/pt-BR/HTML/Global_attributes).
 
-- {{ htmlattrdef("autoplay") }}
+- `autoplay`
   - : Um atributo Booleano; se especificado, o video vai ser executado assim que possível sem precisar de carregar todo o arquivo.
 
 > **Nota:** Algumas versões do Chrome aceitam somente o `autostart` e não o autoplay
 
-- {{ htmlattrdef("autobuffer") }} {{ Non-standard_inline() }}
+- `autobuffer` {{ Non-standard_inline() }}
 
   - : Um atributo Booleano; se especificado, o video vai começar a carregar automaticamente mesmo que não especificado para tocar automaticamente. Isso deve ser usado em casos que é esperado que o vídeo seja reproduzido (por exemplo, se o usuário acessa a página para assistir o vídeo, mas não se o vídeo estiver incorporado à pagina junto a outro conteúdo). O vídeo é carregado até que o cache de mídia.
 
     > **Note:** **Nota de implementação:** embora parte dos primeiros rascunhos das especificações do HTML5, o atributo `autobuffer` foi removido das últimas versões. Ele foi removido do Gecko 2.0 e outros navegadores, e nunca implementado em outros. A especificação define um novo atributo enumerado, `preload`, para substituir o atributo `autobuffer`, com sintaxe diferente. {{ bug(548523) }}
 
-- {{ htmlattrdef("buffered") }}
+- `buffered`
   - : Um atributo que pode ser lido para determinar os intervalos do vídeo que já foram carregados. Este atributo contém um objeto {{ domxref("TimeRanges") }}.
-- {{ htmlattrdef("controls") }}
+- `controls`
   - : Se esse atributo estiver presente, o Gecko oferecerá controles para permitir o usuário controlar a reprodução do vídeo, incluindo volume, navegação, e pausa/continuação da reprodução.
-- {{ htmlattrdef("height") }}
+- `height`
   - : A altura da área de exibição do vídeo, em pixels de CSS.
-- {{ htmlattrdef("loop") }}
+- `loop`
   - : Um atributo Booleano; se especificado, ao chegar no fim do vídeo, ele voltará automaticamente para o começo.
-- {{ htmlattrdef("muted") }}
+- `muted`
   - : Um atributo Booleano que indica a configuração padrão do áudio contido no vídeo. Se definido, o áudio vai começar mudo. Seu valor padrão é falso, significando que o áudio será reproduzido juntamente com o vídeo.
-- {{ htmlattrdef("played") }}
+- `played`
   - : Um objeto {{ domxref("TimeRanges") }} indicando que todo o vídeo foi reproduzido.
-- {{ htmlattrdef("preload") }}
+- `preload`
 
   - : Esse atributo enumerado pretende dar uma sugestão ao navegador sobre o que o autor pensa que proporcionará uma melhor experiência do usuário. Ele pode ter os seguintes valores:
 
@@ -59,11 +59,11 @@ Como qualquer elemento HTML, este elemento suporta os [global attributes](/pt-BR
     >
     > - O navegador não é forçado pela especifição a seguir o valor desse atributo; é apenas uma sugestão.
 
-- {{ htmlattrdef("poster") }}
+- `poster`
   - : Uma URL indicando uma imagem de prévia do vídeo até o usuário reproduzir ou navegar por ele. Se este atributo não estiver especificado, nada será mostrado até que o primeiro quadro esteja disponível; então o primeiro quadro será exibido como imagem de prévia.
-- {{ htmlattrdef("src") }}
+- `src`
   - : A URL do vídeo a ser incorporado. Isto é opcional; ao invés disso você pode usar o elemento {{ HTMLElement("source") }} dentro do bloco do vídeo para especificar o vídeo a ser incorporado .
-- {{ htmlattrdef("width") }}
+- `width`
   - : A largura da área de exibição do vídeo, em pixels de CSS.
 
 O tempo de compensação (time offset) entre o áudio e o vídeo está especificado como um valor de ponto flutuante (float) representando o número de segundos da compensação.


### PR DESCRIPTION
### Description

remove `{{htmlattrdef}}` macro. This macro is only used to generate a 'id' attribute in DFL. But we doesn't need this anymore (the DFL would automatically generate id for them).

### Related issues and pull requests

https://github.com/orgs/mdn/discussions/263
