### PR TITLE
zh-cn: correct the translation of `PerformanceNavigationTiming`

### DIFF
--- a/files/zh-cn/web/api/performancenavigationtiming/index.md
+++ b/files/zh-cn/web/api/performancenavigationtiming/index.md
@@ -11,8 +11,6 @@ slug: Web/API/PerformanceNavigationTiming
 
 {{InheritanceDiagram}}
 
-## 属性
-
 下图显示了 `PerformanceNavigationTiming` 中定义的所有时间戳属性。
 
 ![按获取文档记录的顺序列出时间戳的时间戳图](timestamp-diagram.svg)


### PR DESCRIPTION
#12756 forgot to delete a title.

Detail: https://dochub.zjffun.com/translate/mdn-zh-cn/mdn/translated-content/main/files/zh-cn/web/api/performancenavigationtiming/index.md

mdn/content Original: https://github.com/mdn/content/blob/4b4638246aad5d39b9a2e5c572b179b4c39c0a84/files/en-us/web/api/performancenavigationtiming/index.md
mdn/content Modified: https://github.com/mdn/content/blob/dccf6af14ff81e105c84fc90d7e2bc863dc28648/files/en-us/web/api/performancenavigationtiming/index.md