### PR TITLE
zh-cn: init translation of HTMLAnchorElement protocol property

### DIFF
--- a/files/zh-cn/web/api/htmlanchorelement/protocol/index.md
+++ b/files/zh-cn/web/api/htmlanchorelement/protocol/index.md
@@ -5,7 +5,7 @@ slug: Web/API/HTMLAnchorElement/protocol
 
 {{ApiRef("HTML DOM")}}
 
-**`HTMLAnchorElement.protocol`** 属性是一个表示 URL 协议方案的字符串，包括结尾的 `':'`。
+**`HTMLAnchorElement.protocol`** 属性是一个表示 URL 协议方案的字符串，包含结尾的 `':'`。
 
 ## 值
 

--- a/files/zh-cn/web/api/htmlanchorelement/protocol/index.md
+++ b/files/zh-cn/web/api/htmlanchorelement/protocol/index.md
@@ -13,10 +13,10 @@ slug: Web/API/HTMLAnchorElement/protocol
 
 ## 示例
 
-### 从 a 标签的链接中获取协议
+### 从锚点元素的链接中获取协议
 
 ```js
-// <a id="myAnchor" href="https://developer.mozilla.org/en-US/HTMLAnchorElement"> 元素在文档中
+// <a id="myAnchor" href="https://developer.mozilla.org/zh-CN/HTMLAnchorElement"> 元素在文档中
 const anchor = document.getElementById("myAnchor");
 anchor.protocol; // 返回 'https:'
 ```

--- a/files/zh-cn/web/api/htmlanchorelement/protocol/index.md
+++ b/files/zh-cn/web/api/htmlanchorelement/protocol/index.md
@@ -1,0 +1,34 @@
+---
+title: "HTMLAnchorElement: protocol property"
+slug: Web/API/HTMLAnchorElement/protocol
+---
+
+{{ApiRef("HTML DOM")}}
+
+**`HTMLAnchorElement.protocol`** 属性是一个表示 URL 协议方案的字符串，包括结尾的 `':'`。
+
+## 值
+
+一个字符串。
+
+## 示例
+
+### 从 a 标签的链接中获取协议
+
+```js
+// <a id="myAnchor" href="https://developer.mozilla.org/en-US/HTMLAnchorElement"> 元素在文档中
+const anchor = document.getElementById("myAnchor");
+anchor.protocol; // 返回 'https:'
+```
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- 所属的 {{domxref("HTMLAnchorElement")}} 接口。

--- a/files/zh-cn/web/api/htmlanchorelement/protocol/index.md
+++ b/files/zh-cn/web/api/htmlanchorelement/protocol/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTMLAnchorElement: protocol property"
+title: HTMLAnchorElement：protocol 属性
 slug: Web/API/HTMLAnchorElement/protocol
 ---
 

--- a/files/zh-cn/web/api/htmlanchorelement/protocol/index.md
+++ b/files/zh-cn/web/api/htmlanchorelement/protocol/index.md
@@ -16,7 +16,7 @@ slug: Web/API/HTMLAnchorElement/protocol
 ### 从锚点元素的链接中获取协议
 
 ```js
-// <a id="myAnchor" href="https://developer.mozilla.org/zh-CN/HTMLAnchorElement"> 元素在文档中
+// 文档中有一个 <a id="myAnchor" href="https://developer.mozilla.org/zh-CN/HTMLAnchorElement"> 元素
 const anchor = document.getElementById("myAnchor");
 anchor.protocol; // 返回 'https:'
 ```


### PR DESCRIPTION
Original: 
https://github.com/mdn/content/blob/eb99a4597802f746275e0d61b31cd2f42b398eab/files/en-us/web/api/htmlanchorelement/protocol/index.md

Detail: https://dochub.zjffun.com/translate/mdn-zh-cn/mdn/translated-content/main/files/zh-cn/web/api/htmlanchorelement/protocol/index.md