### PR TITLE
zh-cn: update the translation of HTTP vary

### DIFF
--- a/files/zh-cn/web/http/headers/vary/index.md
+++ b/files/zh-cn/web/http/headers/vary/index.md
@@ -46,7 +46,7 @@ Vary: <header-name>, <header-name>, ...
 
 ### 兼容性备注
 
-- [小心使用 Vary – Vary 标头在 IE6-9 的问题](https://blogs.msdn.microsoft.com/ieinternals/2009/06/17/vary-with-care/)
+- [小心使用 Vary – Vary 标头在 IE6-9 的问题](https://docs.microsoft.com/archive/blogs/ieinternals/vary-with-care)
 
 ## 参见
 

--- a/files/zh-cn/web/http/headers/vary/index.md
+++ b/files/zh-cn/web/http/headers/vary/index.md
@@ -52,4 +52,4 @@ Vary: <header-name>, <header-name>, ...
 
 - [理解 Vary 标头 - Smashing Magazine](https://www.smashingmagazine.com/2017/11/understanding-vary-header/)
 - [使用 Vary 标头的最佳实践 – fastly.com](https://www.fastly.com/blog/best-practices-using-vary-header)
-- [内容协商](/en-US/docs/Web/HTTP/Content_negotiation)
+- [内容协商](/zh-CN/docs/Web/HTTP/Content_negotiation)

--- a/files/zh-cn/web/http/headers/vary/index.md
+++ b/files/zh-cn/web/http/headers/vary/index.md
@@ -5,37 +5,36 @@ slug: Web/HTTP/Headers/Vary
 
 {{HTTPSidebar}}
 
-**`Vary`** 是一个 HTTP 响应头部信息，它决定了对于未来的一个请求头，应该用一个缓存的回复 (response) 还是向源服务器请求一个新的回复。它被服务器用来表明在 [content negotiation](/zh-CN/docs/Web/HTTP/Content_negotiation) algorithm（内容协商算法）中选择一个资源代表的时候应该使用哪些头部信息（headers）.
+**`Vary`** HTTP 响应标头描述了除方法和 URL 之外影响响应内容的请求消息。大多数情况下，这用于在使用[内容协商](/zh-CN/docs/Web/HTTP/Content_negotiation) 时创建缓存键。
 
-在响应状态码为 {{HTTPStatus("304")}} `Not Modified` 的响应中，也要设置 Vary 首部，而且要与相应的 {{HTTPStatus("200")}} `OK` 响应设置得一模一样。
+给定 URL 的所有响应都应使用相同的 `Vary` 标头值，包括 {{HTTPStatus("304")}} `Not Modified` 响应和“默认”响应。
 
-| Header type                           | {{Glossary("Response header")}} |
-| ------------------------------------- | ------------------------------- |
-| {{Glossary("Forbidden header name")}} | no                              |
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">标头类型</th>
+      <td>{{Glossary("Response header","响应标头")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name","禁止修改的标头")}}</th>
+      <td>否</td>
+    </tr>
+  </tbody>
+</table>
 
 ## 语法
 
-```plain
+```http
 Vary: *
 Vary: <header-name>, <header-name>, ...
 ```
 
-## 说明
+## 指令
 
 - \*
-  - : 所有的请求都被视为唯一并且非缓存的，使用{{HTTPHeader("Cache-Control")}}`: no-store`,来实现则更适用，这样用于说明不存储该对象更加清晰。
+  - : 表示请求标头以外的因素影响了此响应的生成。意味着响应不可缓存。
 - \<header-name>
-  - : 逗号分隔的一系列 http 头部名称，用于确定缓存是否可用。
-
-## 例子
-
-### 动态服务
-
-`哪种情况下使用 Vary: 对于 User-Agent` 头部信息，例如你提供给移动端的内容是不同的，可用防止你客户端误使用了用于桌面端的缓存。并可帮助 Google 和其他搜索引擎来发现你的移动端版本的页面，同时告知他们不需要[Cloaking](https://en.wikipedia.org/wiki/Cloaking)。
-
-```plain
-Vary: User-Agent
-```
+  - : 可能影响此响应生成的请求标头名称的逗号分隔列表。
 
 ## 规范
 
@@ -45,12 +44,12 @@ Vary: User-Agent
 
 {{Compat}}
 
-## 更多关于浏览器兼容性：
+### 兼容性备注
 
-- [Vary with care – Vary header problems in IE6-9](https://blogs.msdn.microsoft.com/ieinternals/2009/06/17/vary-with-care/)
+- [小心使用 Vary – Vary 标头在 IE6-9 的问题](https://blogs.msdn.microsoft.com/ieinternals/2009/06/17/vary-with-care/)
 
-## 更多
+## 参见
 
-- {{HTTPHeader("Cache-Control")}}
-- {{HTTPHeader("User-Agent")}}
-- [Best Practices for Using the Vary Header – fastly.com](https://www.fastly.com/blog/best-practices-for-using-the-vary-header)
+- [理解 Vary 标头 - Smashing Magazine](https://www.smashingmagazine.com/2017/11/understanding-vary-header/)
+- [使用 Vary 标头的最佳实践 – fastly.com](https://www.fastly.com/blog/best-practices-using-vary-header)
+- [内容协商](/en-US/docs/Web/HTTP/Content_negotiation)

--- a/files/zh-cn/web/http/headers/vary/index.md
+++ b/files/zh-cn/web/http/headers/vary/index.md
@@ -13,10 +13,10 @@ slug: Web/HTTP/Headers/Vary
   <tbody>
     <tr>
       <th scope="row">标头类型</th>
-      <td>{{Glossary("Response header","响应标头")}}</td>
+      <td>{{Glossary("Response header", "响应标头")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name","禁止修改的标头")}}</th>
+      <th scope="row">{{Glossary("Forbidden header name", "禁止修改的标头")}}</th>
       <td>否</td>
     </tr>
   </tbody>

--- a/files/zh-cn/web/http/headers/vary/index.md
+++ b/files/zh-cn/web/http/headers/vary/index.md
@@ -5,7 +5,7 @@ slug: Web/HTTP/Headers/Vary
 
 {{HTTPSidebar}}
 
-**`Vary`** HTTP 响应标头描述了除方法和 URL 之外影响响应内容的请求消息。大多数情况下，这用于在使用[内容协商](/zh-CN/docs/Web/HTTP/Content_negotiation) 时创建缓存键。
+**`Vary`** HTTP 响应标头描述了除方法和 URL 之外影响响应内容的请求消息。大多数情况下，这用于在使用[内容协商](/zh-CN/docs/Web/HTTP/Content_negotiation)时创建缓存键。
 
 给定 URL 的所有响应都应使用相同的 `Vary` 标头值，包括 {{HTTPStatus("304")}} `Not Modified` 响应和“默认”响应。
 


### PR DESCRIPTION
Original: https://github.com/mdn/content/blob/1368da1927b8d414e1c43a52142b9317f73cfce7/files/en-us/web/http/headers/vary/index.md

Detail: https://dochub.zjffun.com/translate/mdn-zh-cn/mdn/translated-content/main/files/zh-cn/web/http/headers/vary/index.md