### PR TITLE
[JA] Translate `WebGLRenderingContext: createRenderbuffer()` and `WebGLRenderingContext: createFramebuffer()` Page

### DIFF
--- a/files/ja/web/api/webglrenderingcontext/createframebuffer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createframebuffer/index.md
@@ -2,8 +2,6 @@
 title: WebGLRenderingContext.createFramebuffer()
 short-title: createFramebuffer()
 slug: Web/API/WebGLRenderingContext/createFramebuffer
-page-type: web-api-instance-method
-browser-compat: api.WebGLRenderingContext.createFramebuffer
 ---
 
 {{APIRef("WebGL")}}

--- a/files/ja/web/api/webglrenderingcontext/createframebuffer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createframebuffer/index.md
@@ -1,0 +1,50 @@
+---
+title: "WebGLRenderingContext.createFramebuffer()"
+short-title: createFramebuffer()
+slug: Web/API/WebGLRenderingContext/createFramebuffer
+page-type: web-api-instance-method
+browser-compat: api.WebGLRenderingContext.createFramebuffer
+---
+
+{{APIRef("WebGL")}}
+
+[WebGL API](/en-US/docs/Web/API/WebGL_API) の **`WebGLRenderingContext.createFramebuffer()`** メソッドは、 {{domxref("WebGLFramebuffer")}} を作成し、初期化します.
+
+## 構文
+
+```js-nolint
+createFramebuffer()
+```
+
+### 引数
+
+なし。
+
+### 返値
+
+{{domxref("WebGLFramebuffer")}} オブジェクト。
+
+## 例
+
+### フレームバッファを作成する
+
+```js
+const canvas = document.getElementById("canvas");
+const gl = canvas.getContext("webgl");
+const framebuffer = gl.createFramebuffer();
+```
+
+## 仕様策定状況
+
+{{Specifications}}
+
+## ブラウザの互換性
+
+{{Compat}}
+
+## 関連項目
+
+- {{domxref("WebGLRenderingContext.bindFramebuffer()")}}
+- {{domxref("WebGLRenderingContext.deleteFramebuffer()")}}
+- {{domxref("WebGLRenderingContext.isFramebuffer()")}}
+- 他のバッファ: {{domxref("WebGLBuffer")}}, {{domxref("WebGLRenderbuffer")}}

--- a/files/ja/web/api/webglrenderingcontext/createframebuffer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createframebuffer/index.md
@@ -26,7 +26,7 @@ createFramebuffer()
 
 ## 例
 
-### フレームバッファを作成する
+### フレームバッファーを作成する
 
 ```js
 const canvas = document.getElementById("canvas");
@@ -34,15 +34,15 @@ const gl = canvas.getContext("webgl");
 const framebuffer = gl.createFramebuffer();
 ```
 
-## 仕様策定状況
+## 仕様書
 
 {{Specifications}}
 
-## ブラウザの互換性
+## ブラウザーの互換性
 
 {{Compat}}
 
-## 関連項目
+## 関連情報
 
 - {{domxref("WebGLRenderingContext.bindFramebuffer()")}}
 - {{domxref("WebGLRenderingContext.deleteFramebuffer()")}}

--- a/files/ja/web/api/webglrenderingcontext/createframebuffer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createframebuffer/index.md
@@ -8,7 +8,9 @@ browser-compat: api.WebGLRenderingContext.createFramebuffer
 
 {{APIRef("WebGL")}}
 
-[WebGL API](/en-US/docs/Web/API/WebGL_API) の **`WebGLRenderingContext.createFramebuffer()`** メソッドは、 {{domxref("WebGLFramebuffer")}} を作成し、初期化します.
+[WebGL API](/en-US/docs/Web/API/WebGL_API) の **`WebGLRenderingContext.createFramebuffer()`** メソッドは、
+{{domxref("WebGLFramebuffer")}}
+を作成し、初期化します。
 
 ## 構文
 

--- a/files/ja/web/api/webglrenderingcontext/createframebuffer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createframebuffer/index.md
@@ -6,7 +6,7 @@ slug: Web/API/WebGLRenderingContext/createFramebuffer
 
 {{APIRef("WebGL")}}
 
-[WebGL API](/en-US/docs/Web/API/WebGL_API) の **`WebGLRenderingContext.createFramebuffer()`** メソッドは、
+[WebGL API](/ja/docs/Web/API/WebGL_API) の **`WebGLRenderingContext.createFramebuffer()`** メソッドは、
 {{domxref("WebGLFramebuffer")}}
 を作成し、初期化します。
 

--- a/files/ja/web/api/webglrenderingcontext/createframebuffer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createframebuffer/index.md
@@ -1,5 +1,5 @@
 ---
-title: "WebGLRenderingContext.createFramebuffer()"
+title: WebGLRenderingContext.createFramebuffer()
 short-title: createFramebuffer()
 slug: Web/API/WebGLRenderingContext/createFramebuffer
 page-type: web-api-instance-method

--- a/files/ja/web/api/webglrenderingcontext/createrenderbuffer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createrenderbuffer/index.md
@@ -1,0 +1,52 @@
+---
+title: "WebGLRenderingContext.createRenderbuffer()"
+short-title: createRenderbuffer()
+slug: Web/API/WebGLRenderingContext/createRenderbuffer
+page-type: web-api-instance-method
+browser-compat: api.WebGLRenderingContext.createRenderbuffer
+---
+
+{{APIRef("WebGL")}}
+
+[WebGL API](/en-US/docs/Web/API/WebGL_API) の **`WebGLRenderingContext.createRenderbuffer()`** メソッドは、
+{{domxref("WebGLRenderbuffer")}}
+オブジェクトを作成し、初期化します。
+
+## 構文
+
+```js-nolint
+createRenderbuffer()
+```
+
+### 引数
+
+なし。
+
+### 返値
+
+画像または、レンダリングのソースやターゲットとなるデータを保存する {{domxref("WebGLRenderbuffer")}} オブジェクト。
+
+## 例
+
+### レンダリングバッファを作成する
+
+```js
+const canvas = document.getElementById("canvas");
+const gl = canvas.getContext("webgl");
+const renderBuffer = gl.createRenderbuffer();
+```
+
+## 仕様策定状況
+
+{{Specifications}}
+
+## ブラウザの互換性
+
+{{Compat}}
+
+## 関連項目
+
+- {{domxref("WebGLRenderingContext.bindRenderbuffer()")}}
+- {{domxref("WebGLRenderingContext.deleteRenderbuffer()")}}
+- {{domxref("WebGLRenderingContext.isRenderbuffer()")}}
+- 他のバッファ: {{domxref("WebGLBuffer")}}, {{domxref("WebGLFramebuffer")}}

--- a/files/ja/web/api/webglrenderingcontext/createrenderbuffer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createrenderbuffer/index.md
@@ -8,7 +8,7 @@ browser-compat: api.WebGLRenderingContext.createRenderbuffer
 
 {{APIRef("WebGL")}}
 
-[WebGL API](/en-US/docs/Web/API/WebGL_API) の **`WebGLRenderingContext.createRenderbuffer()`** メソッドは、
+[WebGL API](/ja/docs/Web/API/WebGL_API) の **`WebGLRenderingContext.createRenderbuffer()`** メソッドは、
 {{domxref("WebGLRenderbuffer")}}
 オブジェクトを作成し、初期化します。
 

--- a/files/ja/web/api/webglrenderingcontext/createrenderbuffer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createrenderbuffer/index.md
@@ -1,5 +1,5 @@
 ---
-title: "WebGLRenderingContext.createRenderbuffer()"
+title: WebGLRenderingContext.createRenderbuffer()
 short-title: createRenderbuffer()
 slug: Web/API/WebGLRenderingContext/createRenderbuffer
 page-type: web-api-instance-method

--- a/files/ja/web/api/webglrenderingcontext/createrenderbuffer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createrenderbuffer/index.md
@@ -26,7 +26,7 @@ createRenderbuffer()
 
 ## 例
 
-### レンダリングバッファを作成する
+### レンダリングバッファーを作成する
 
 ```js
 const canvas = document.getElementById("canvas");
@@ -34,15 +34,15 @@ const gl = canvas.getContext("webgl");
 const renderBuffer = gl.createRenderbuffer();
 ```
 
-## 仕様策定状況
+## 仕様書
 
 {{Specifications}}
 
-## ブラウザの互換性
+## ブラウザーの互換性
 
 {{Compat}}
 
-## 関連項目
+## 関連情報
 
 - {{domxref("WebGLRenderingContext.bindRenderbuffer()")}}
 - {{domxref("WebGLRenderingContext.deleteRenderbuffer()")}}

--- a/files/ja/web/api/webglrenderingcontext/createrenderbuffer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createrenderbuffer/index.md
@@ -2,8 +2,6 @@
 title: WebGLRenderingContext.createRenderbuffer()
 short-title: createRenderbuffer()
 slug: Web/API/WebGLRenderingContext/createRenderbuffer
-page-type: web-api-instance-method
-browser-compat: api.WebGLRenderingContext.createRenderbuffer
 ---
 
 {{APIRef("WebGL")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

I translated `WebGLRenderingContext: createRenderbuffer()` and `WebGLRenderingContext: createFramebuffer()` page from en-US into Japanese.

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
