### PR TITLE
[ko]: fix typo in  String.prototype.toLocaleLowerCase() reference

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
+++ b/files/ko/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
@@ -32,7 +32,7 @@ toLocaleLowerCase(locales)
 
 ## 설명
 
-`theLocaleLowerCase()` 메서드는 지역 특정 대/소문자 맴핑에 따른 소문자로 변환된 문자열 값을 반환합니다. `toLocaleUpperCase()`는 문자열 자체 값에 영향을 미치지 않습니다. 대부분의 경우, {{jsxref("String.prototype.toLowerCase()", "toLowerCase()")}}와 같은 결과를 제공하지만 터키와 같은 일부 지역에서는 대/소문자 매핑이 유니코드의 기존 대/소문자 매핑을 따르지 않아 다른 결과가 있을 수 있습니다.
+`theLocaleLowerCase()` 메서드는 지역 특정 대/소문자 매핑에 따른 소문자로 변환된 문자열 값을 반환합니다. `toLocaleUpperCase()`는 문자열 자체 값에 영향을 미치지 않습니다. 대부분의 경우, {{jsxref("String.prototype.toLowerCase()", "toLowerCase()")}}와 같은 결과를 제공하지만 터키와 같은 일부 지역에서는 대/소문자 매핑이 유니코드의 기존 대/소문자 매핑을 따르지 않아 다른 결과가 있을 수 있습니다.
 
 ## 예제
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

fix typo in  String.prototype.toLocaleLowerCase() reference
"맴핑" -> "매핑"

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

It seems make sense when "맴핑" has changed to "매핑"
"맴핑" is not correct word.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
