### PR TITLE
fix cookie-value wrap with double quotes zh-cn translation error

### DIFF
--- a/files/zh-cn/web/http/headers/set-cookie/index.md
+++ b/files/zh-cn/web/http/headers/set-cookie/index.md
@@ -54,7 +54,7 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
   - : 一个 cookie 开始于一个名称/值对：
 
     - `<cookie-name>` 可以是除了控制字符、空格或制表符之外的任何 US-ASCII 字符。同时不能包含以下分隔字符：`( ) < > @ , ; : \ " / [ ] ? = { }`。
-    - `<cookie-value>` 是可选的，如果存在的话，那么需要包含在双引号里面。支持除了控制字符、{{glossary("Whitespace", "空格")}}、双引号、逗号、分号以及反斜线之外的任意 US-ASCII 字符。
+    - `<cookie-value>` 可以选择包裹在双引号中。支持除了控制字符、{{glossary("Whitespace", "空格")}}、双引号、逗号、分号以及反斜线之外的任意 US-ASCII 字符。
 
     **关于编码**：许多应用会对 cookie 值按照 URL 编码规则进行编码，但是按照 RFC 规范，这不是必须的。不过满足规范中对于 `<cookie-value>` 所允许使用的字符的要求是有用的。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
"A \<cookie-value\> can optionally be wrapped in double quotes ..." should be translated to Chinese as "可以选择包裹在双引号中". Original translation means cookie-value is optional itself and if exists, must be wrapped with double quotes.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
translation error makes me confused.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
- English version is correct: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes
- For compatibility, it's optional to wrap cookie-value with double quotes. https://stackoverflow.com/questions/25395845/double-quotes-and-trailing-equal-sign-missing-from-cookies-values-in-servletexec

### Related issues and pull requests
N/A
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
