### PR TITLE
zh-cn: fix the Function hyperlink error

### DIFF
--- a/files/zh-cn/glossary/self-executing_anonymous_function/index.md
+++ b/files/zh-cn/glossary/self-executing_anonymous_function/index.md
@@ -5,6 +5,6 @@ slug: Glossary/Self-Executing_Anonymous_Function
 
 {{GlossarySidebar}}
 
-一个 {{glossary("JavaScript")}} {{glossary("函数")}} 在定义后立即执行。也被熟知为 {{glossary("IIFE")}} (立即执行函数表达式)(Immediately Invoked Function Expression).
+一个 {{glossary("JavaScript")}} {{glossary("function","函数")}} 在定义后立即执行。也被熟知为 {{glossary("IIFE")}} (立即执行函数表达式)(Immediately Invoked Function Expression).
 
 请浏览上面 IIFE 解释页链接获取更多信息/.

--- a/files/zh-cn/glossary/self-executing_anonymous_function/index.md
+++ b/files/zh-cn/glossary/self-executing_anonymous_function/index.md
@@ -5,6 +5,6 @@ slug: Glossary/Self-Executing_Anonymous_Function
 
 {{GlossarySidebar}}
 
-一个 {{glossary("JavaScript")}} {{glossary("function","函数")}} 在定义后立即执行。也被熟知为 {{glossary("IIFE")}} (立即执行函数表达式)(Immediately Invoked Function Expression).
+一个 {{glossary("JavaScript")}} {{glossary("function", "函数")}}在定义后立即执行。也被熟知为 {{glossary("IIFE")}}（立即调用函数表达式）。
 
 请浏览上面 IIFE 解释页链接获取更多信息/.

--- a/files/zh-cn/glossary/self-executing_anonymous_function/index.md
+++ b/files/zh-cn/glossary/self-executing_anonymous_function/index.md
@@ -7,4 +7,4 @@ slug: Glossary/Self-Executing_Anonymous_Function
 
 一个 {{glossary("JavaScript")}} {{glossary("function", "函数")}}在定义后立即执行。也被熟知为 {{glossary("IIFE")}}（立即调用函数表达式）。
 
-请浏览上面 IIFE 解释页链接获取更多信息/.
+请浏览上面 IIFE 解释页链接获取更多信息。


### PR DESCRIPTION
### Description

Repair Function of hyperlinks orientation error in https://developer.mozilla.org/zh-CN/docs/Glossary/Self-Executing_Anonymous_Function

### Motivation

There is no hyperlink when I enter the page during learning

