### PR TITLE
fix(ru): add missing translation for the "Object" article

### DIFF
--- a/files/ru/web/javascript/reference/global_objects/object/index.md
+++ b/files/ru/web/javascript/reference/global_objects/object/index.md
@@ -7,7 +7,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Object
 
 ## Сводка
 
-Конструктор **`Object`** создаёт объект-обёртку.
+Тип **`Object`** представляет один из [типов данных JavaScript](/ru/docs/Web/JavaScript/Data_structures). Он используется для хранения различных коллекций с ключами и более сложных сущностей. Объекты могут быть созданы с использованием конструктора {{jsxref("Object/Object", "Object()")}} или [синтаксиса инициализатора / литерала объекта](/ru/docs/Web/JavaScript/Reference/Operators/Object_initializer).
 
 ## Синтаксис
 


### PR DESCRIPTION
### Description
Fix translation of Object in [ru] according to this page
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object

### Motivation
Same translations in different languages.

### Additional details
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object

### Related issues and pull requests
No need