### PR TITLE
fr: Refresh `Element.scrollWidth` page

### DIFF
--- a/files/fr/web/api/element/scrollwidth/index.md
+++ b/files/fr/web/api/element/scrollwidth/index.md
@@ -1,15 +1,16 @@
 ---
-title: element.scrollWidth
+title: "Element : propriété scrollWidth"
+short-title: scrollWidth
 slug: Web/API/Element/scrollWidth
 l10n:
   sourceCommit: acfe8c9f1f4145f77653a2bc64a9744b001358dc
 ---
 
-{{ ApiRef() }}
+{{APIRef("DOM")}}
 
-**scrollWidth** est une propriété en lecture seule qui renvoie, parmi la largeur en pixels du contenu d'un élément, et la largeur de l'élément, celle qui est la plus grande.
+**`Element.scrollWidth`** est une propriété en lecture seule correspondant à la mesure de la largeur du contenu d'un élément, incluant le contenu qui ne serait pas visible à l'écran en raison d'un dépassement.
 
-La valeur `scrollWidth` est égale à la largeur minimale dont l'élément aurait besoin pour s'adapter à tout le contenu de la fenêtre sans utiliser de barre de défilement horizontale. La largeur est mesurée de la même manière que [`clientWidth`](/fr/docs/Web/API/Element/clientWidth)&nbsp;: elle inclut le remplissage de l'élément, mais pas sa bordure, sa marge ou sa barre de défilement verticale (si présente). Il peut également inclure la largeur des pseudo-éléments tels que [`::before`](/fr/docs/Web/CSS/::before) ou [`::after`](/fr/docs/Web/CSS/::after). Si le contenu de l'élément peut s'adapter sans avoir besoin d'une barre de défilement horizontale, sa `scrollWidth` est égale à [`clientWidth`](/fr/docs/Web/API/Element/clientWidth).
+La valeur `scrollWidth` est égale à la largeur minimale dont l'élément aurait besoin pour s'adapter à tout le contenu de la fenêtre sans utiliser de barre de défilement horizontale. La largeur est mesurée de la même manière que [`clientWidth`](/fr/docs/Web/API/Element/clientWidth)&nbsp;: elle inclut le remplissage (<i lang="en">padding</i>) de l'élément, mais pas sa bordure, sa marge ou sa barre de défilement verticale (si présente). Elle peut également inclure la largeur des pseudo-éléments tels que [`::before`](/fr/docs/Web/CSS/::before) ou [`::after`](/fr/docs/Web/CSS/::after). Pour un élément donné, si son contenu peut s'adapter sans avoir besoin d'une barre de défilement horizontale, `scrollWidth` sera égale à [`clientWidth`](/fr/docs/Web/API/Element/clientWidth).
 
 > **Note :** Cette propriété arrondira la valeur à un nombre entier. Si vous avez besoin d'une valeur fractionnaire, utilisez [`element.getBoundingClientRect()`](/fr/docs/Web/API/Element/getBoundingClientRect).
 
@@ -17,70 +18,68 @@ La valeur `scrollWidth` est égale à la largeur minimale dont l'élément aurai
 
 Un nombre.
 
-## Exemple
+## Exemples
+
+### HTML
 
 ```html
-<!doctype html>
-<html lang="fr">
-  <head>
-    <meta charset="UTF-8" />
-    <title>Exemple</title>
-    <style>
-      div {
-        overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-      }
+<div id="uneDiv">TotoTruc-TotoTruc-TotoTruc-TotoTruc</div>
+<button id="unBouton">Vérifier le débordement</button>
 
-      #uneDiv {
-        width: 100px;
-      }
+<div id="uneAutreDiv">TotoTruc-TotoTruc-TotoTruc-TotoTruc</div>
+<button id="unAutreBouton">Vérifier le débordement</button>
+```
 
-      button {
-        margin-bottom: 2em;
-      }
-    </style>
-  </head>
+### CSS
 
-  <body>
-    <div id="uneDiv">FooBar-FooBar-FooBar-FooBar</div>
-    <button id="unBouton">Vérifier le débordement</button>
+```css
+div {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
 
-    <div id="uneAutreDiv">FooBar-FooBar-FooBar-FooBar</div>
-    <button id="unAutreBouton">Vérifier le débordement</button>
-  </body>
-  <script>
-    const boutonUn = document.getElementById("unBouton");
-    const boutonDeux = document.getElementById("unAutreBouton");
-    const blocUn = document.getElementById("uneDiv");
-    const blocDeux = document.getElementById("uneAutreDiv");
+#uneDiv {
+  width: 100px;
+}
 
-    // vérifie pour déterminer si un débordement se produit
-    function isOverflowing(element) {
-      return element.scrollWidth > element.offsetWidth;
-    }
+button {
+  margin-bottom: 2em;
+}
+```
 
-    function alertOverflow(element) {
-      if (isOverflowing(element)) {
-        alert("Le contenu à débordé du cadre.");
-      } else {
-        alert("Aucun débordement !");
-      }
-    }
+### JavaScript
 
-    boutonUn.addEventListener("click", () => {
-      alertOverflow(blocUn);
-    });
-    boutonDeux.addEventListener("click", () => {
-      alertOverflow(blocDeux);
-    });
-  </script>
-</html>
+```js
+const boutonUn = document.getElementById("unBouton");
+const boutonDeux = document.getElementById("unAutreBouton");
+const blocUn = document.getElementById("uneDiv");
+const blocDeux = document.getElementById("uneAutreDiv");
+
+// vérifie pour déterminer si un débordement se produit
+function isOverflowing(element) {
+  return element.scrollWidth > element.offsetWidth;
+}
+
+function alertOverflow(element) {
+  if (isOverflowing(element)) {
+    alert("Le contenu a débordé du cadre.");
+  } else {
+    alert("Aucun débordement !");
+  }
+}
+
+boutonUn.addEventListener("click", () => {
+  alertOverflow(blocUn);
+});
+boutonDeux.addEventListener("click", () => {
+  alertOverflow(blocDeux);
+});
 ```
 
 ### Résultat
 
-{{EmbedLiveSample('Exemple')}}
+{{EmbedLiveSample('')}}
 
 ## Spécifications
 

--- a/files/fr/web/api/element/scrollwidth/index.md
+++ b/files/fr/web/api/element/scrollwidth/index.md
@@ -1,42 +1,97 @@
 ---
 title: element.scrollWidth
 slug: Web/API/Element/scrollWidth
+l10n:
+  sourceCommit: acfe8c9f1f4145f77653a2bc64a9744b001358dc
 ---
 
 {{ ApiRef() }}
 
-### Résumé
-
 **scrollWidth** est une propriété en lecture seule qui renvoie, parmi la largeur en pixels du contenu d'un élément, et la largeur de l'élément, celle qui est la plus grande.
 
-### Syntaxe
+La valeur `scrollWidth` est égale à la largeur minimale dont l'élément aurait besoin pour s'adapter à tout le contenu de la fenêtre sans utiliser de barre de défilement horizontale. La largeur est mesurée de la même manière que [`clientWidth`](/fr/docs/Web/API/Element/clientWidth)&nbsp;: elle inclut le remplissage de l'élément, mais pas sa bordure, sa marge ou sa barre de défilement verticale (si présente). Il peut également inclure la largeur des pseudo-éléments tels que [`::before`](/fr/docs/Web/CSS/::before) ou [`::after`](/fr/docs/Web/CSS/::after). Si le contenu de l'élément peut s'adapter sans avoir besoin d'une barre de défilement horizontale, sa `scrollWidth` est égale à [`clientWidth`](/fr/docs/Web/API/Element/clientWidth).
 
-```js
-var xScrollWidth = element.scrollWidth;
-```
+> **Note :** Cette propriété arrondira la valeur à un nombre entier. Si vous avez besoin d'une valeur fractionnaire, utilisez [`element.getBoundingClientRect()`](/fr/docs/Web/API/Element/getBoundingClientRect).
 
-_xScrollWidth_ est la largeur du contenu d'_element_ en pixels.
+## Valeur
 
-### Exemple
+Un nombre.
+
+## Exemple
 
 ```html
-<div id="aDiv" style="width: 100px; height: 200px; overflow: auto;">
-  -FooBar-FooBar-FooBar
-</div>
-<br />
-<input
-  type="button"
-  value="Show scrollWidth"
-  onclick="alert(document.getElementById('aDiv').scrollWidth);" />
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Exemple</title>
+    <style>
+      div {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+
+      #uneDiv {
+        width: 100px;
+      }
+
+      button {
+        margin-bottom: 2em;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="uneDiv">FooBar-FooBar-FooBar-FooBar</div>
+    <button id="unBouton">Vérifier le débordement</button>
+
+    <div id="uneAutreDiv">FooBar-FooBar-FooBar-FooBar</div>
+    <button id="unAutreBouton">Vérifier le débordement</button>
+  </body>
+  <script>
+    const boutonUn = document.getElementById("unBouton");
+    const boutonDeux = document.getElementById("unAutreBouton");
+    const blocUn = document.getElementById("uneDiv");
+    const blocDeux = document.getElementById("uneAutreDiv");
+
+    // vérifie pour déterminer si un débordement se produit
+    function isOverflowing(element) {
+      return element.scrollWidth > element.offsetWidth;
+    }
+
+    function alertOverflow(element) {
+      if (isOverflowing(element)) {
+        alert("Le contenu à débordé du cadre.");
+      } else {
+        alert("Aucun débordement !");
+      }
+    }
+
+    boutonUn.addEventListener("click", () => {
+      alertOverflow(blocUn);
+    });
+    boutonDeux.addEventListener("click", () => {
+      alertOverflow(blocDeux);
+    });
+  </script>
+</html>
 ```
 
-### Spécification
+### Résultat
 
-Il n'y a pas de spécification du W3C pour **scrollWidth**.
+{{EmbedLiveSample('Exemple')}}
 
-Un brouillon de l'éditeur existe cependant&nbsp;: [Cascading Style Sheets Object Model (CSSOM)](http://dev.w3.org/cvsweb/~checkout~/csswg/cssom/Overview.src.html)
+## Spécifications
 
-### Références
+{{Specifications}}
 
-- [_scrollWidth_
-  sur MSDN](http://msdn.microsoft.com/workshop/author/dhtml/reference/properties/scrollwidth.asp)
+## Compabilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- La propriété [`Element.clientWidth`](/fr/docs/Web/API/Element/clientWidth)
+- La propriété [`HTMLElement.offsetWidth`](/fr/docs/Web/API/HTMLElement/offsetWidth)
+- [Déterminer les dimensions des éléments](/fr/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements)


### PR DESCRIPTION
### Description

Refreshing `Element.scrollWidth` content and remove old MDSN link, removed by Microsoft.

### Related issues and pull requests

Fix #16623
