### PR TITLE
zh-CN: Update 修改 JSON.Parse 返回值的中文翻译

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/json/parse/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/json/parse/index.md
@@ -24,7 +24,7 @@ JSON.parse(text[, reviver])
 
 ### 返回值
 
-{{jsxref("Object")}}, {{jsxref("Array")}}, string, number, boolean, 或者 `null` 类型，对应给定 JSON 文本的对象/值。
+与给定的 JSON `text` 相对应的 {{jsxref("Object")}}、{{jsxref("Array")}}、string、number、boolean 或者 `null` 值。
 
 ### 异常
 

--- a/files/zh-cn/web/javascript/reference/global_objects/json/parse/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/json/parse/index.md
@@ -24,7 +24,7 @@ JSON.parse(text[, reviver])
 
 ### 返回值
 
-{{jsxref("Object")}} 类型，对应给定 JSON 文本的对象/值。
+{{jsxref("Object")}}, {{jsxref("Array")}}, string, number, boolean, 或者 `null` 类型，对应给定 JSON 文本的对象/值。
 
 ### 异常
 

--- a/files/zh-cn/web/javascript/reference/global_objects/json/parse/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/json/parse/index.md
@@ -11,15 +11,16 @@ slug: Web/JavaScript/Reference/Global_Objects/JSON/parse
 
 ## 语法
 
-```plain
-JSON.parse(text[, reviver])
+```js-nolint
+JSON.parse(text)
+JSON.parse(text, reviver)
 ```
 
 ### 参数
 
 - `text`
   - : 要被解析成 JavaScript 值的字符串，关于 JSON 的语法格式，请参考：{{jsxref("JSON")}}。
-- `reviver` {{optional_inline()}}
+- `reviver` {{optional_inline}}
   - : 转换器，如果传入该参数 (函数)，可以用来修改解析生成的原始值，调用时机在 parse 函数返回之前。
 
 ### 返回值
@@ -28,7 +29,8 @@ JSON.parse(text[, reviver])
 
 ### 异常
 
-若传入的字符串不符合 JSON 规范，则会抛出 {{jsxref("SyntaxError")}} 异常。
+- {{jsxref("SyntaxError")}}
+  - : 若传入的字符串不符合 JSON 规范，则会抛出此异常。
 
 ## 示例
 
@@ -77,103 +79,6 @@ JSON.parse("[1, 2, 3, 4, ]");
 JSON.parse('{"foo" : 1, }');
 ```
 
-## Polyfill
-
-```js
-// From https://github.com/douglascrockford/JSON-js/blob/master/json2.js
-if (typeof JSON.parse !== "function") {
-  var rx_one = /^[\],:{}\s]*$/;
-  var rx_two = /\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g;
-  var rx_three =
-    /"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g;
-  var rx_four = /(?:^|:|,)(?:\s*\[)+/g;
-  var rx_dangerous =
-    /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g;
-  JSON.parse = function (text, reviver) {
-    // The parse method takes a text and an optional reviver function, and returns
-    // a JavaScript value if the text is a valid JSON text.
-
-    var j;
-
-    function walk(holder, key) {
-      // The walk method is used to recursively walk the resulting structure so
-      // that modifications can be made.
-
-      var k;
-      var v;
-      var value = holder[key];
-      if (value && typeof value === "object") {
-        for (k in value) {
-          if (Object.prototype.hasOwnProperty.call(value, k)) {
-            v = walk(value, k);
-            if (v !== undefined) {
-              value[k] = v;
-            } else {
-              delete value[k];
-            }
-          }
-        }
-      }
-      return reviver.call(holder, key, value);
-    }
-
-    // Parsing happens in four stages. In the first stage, we replace certain
-    // Unicode characters with escape sequences. JavaScript handles many characters
-    // incorrectly, either silently deleting them, or treating them as line endings.
-
-    text = String(text);
-    rx_dangerous.lastIndex = 0;
-    if (rx_dangerous.test(text)) {
-      text = text.replace(rx_dangerous, function (a) {
-        return "\\u" + ("0000" + a.charCodeAt(0).toString(16)).slice(-4);
-      });
-    }
-
-    // In the second stage, we run the text against regular expressions that look
-    // for non-JSON patterns. We are especially concerned with "()" and "new"
-    // because they can cause invocation, and "=" because it can cause mutation.
-    // But just to be safe, we want to reject all unexpected forms.
-
-    // We split the second stage into 4 regexp operations in order to work around
-    // crippling inefficiencies in IE's and Safari's regexp engines. First we
-    // replace the JSON backslash pairs with "@" (a non-JSON character). Second, we
-    // replace all simple value tokens with "]" characters. Third, we delete all
-    // open brackets that follow a colon or comma or that begin the text. Finally,
-    // we look to see that the remaining characters are only whitespace or "]" or
-    // "," or ":" or "{" or "}". If that is so, then the text is safe for eval.
-
-    if (
-      rx_one.test(
-        text.replace(rx_two, "@").replace(rx_three, "]").replace(rx_four, ""),
-      )
-    ) {
-      // In the third stage we use the eval function to compile the text into a
-      // JavaScript structure. The "{" operator is subject to a syntactic ambiguity
-      // in JavaScript: it can begin a block or an object literal. We wrap the text
-      // in parens to eliminate the ambiguity.
-
-      j = eval("(" + text + ")");
-
-      // In the optional fourth stage, we recursively walk the new structure, passing
-      // each name/value pair to a reviver function for possible transformation.
-
-      return typeof reviver === "function"
-        ? walk(
-            {
-              "": j,
-            },
-            "",
-          )
-        : j;
-    }
-
-    // If the text is not JSON parseable, then a SyntaxError is thrown.
-
-    throw new SyntaxError("JSON.parse");
-  };
-}
-```
-
 ## 规范
 
 {{Specifications}}
@@ -182,6 +87,6 @@ if (typeof JSON.parse !== "function") {
 
 {{Compat}}
 
-## 相关链接
+## 参见
 
 - {{jsxref("JSON.stringify()")}}


### PR DESCRIPTION


### 返回值

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
修改了`返回值`部分的翻译内容
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
[英文文档](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse)原文是:


*The Object, Array, string, number, boolean, or null value corresponding to the given JSON text*

也就是说，返回值可以是

Object，Array,string,number,boolean或者null类型。中文翻译少了这一部分内容，给补上。

比如 

```javascript
JSON.parse('90')； // 90
```
是可以正常执行的。

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
