### PR TITLE
chore(gitignore): add .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 _githistory.json
 .DS_Store
 .idea
+.vscode
 mdn/content
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
### Description

Add `.vscode` item to `.gitignore` file.

### Motivation

The `.vscode` folder contains settings for a widely used editor [Visual Studio Code](https://code.visualstudio.com/). To allow users to save their workspace settings, we must add `.vscode` to the `.gitignore` file.

For example my settings (enables auto formatting markdown files with installed [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) extension):
```
{
  "editor.codeActionsOnSave": {
    "source.fixAll.markdownlint": true
  },
  "[markdown]": {
    "editor.formatOnSave": true
  }
}
```