### PR TITLE
ループと反復処理ページのナビゲーションリンクを修正

### DIFF
--- a/files/ja/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/ja/web/javascript/guide/loops_and_iteration/index.md
@@ -22,14 +22,14 @@ for (let step = 0; step < 5; step++) {
 
 JavaScript で提供されるループ文は以下のとおりです :
 
-- [for 文](#for_statement)
-- [do...while 文](#do...while_statement)
-- [while 文](#while_statement)
-- [label 文](#label_statement)
-- [break 文](#break_statement)
-- [continue 文](#continue_statement)
-- [for...in 文](#for...in_statement)
-- [for...of 文](#for...of_statement)
+- [for 文](#for_文)
+- [do...while 文](#do...while_文)
+- [while 文](#while_文)
+- [ラベルつき 文](#ラベルつき文)
+- [break 文](#break_文)
+- [continue 文](#continue_文)
+- [for...in 文](#for...in_文)
+- [for...of 文](#for...of_文)
 
 ## `for` 文
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- 日本語版の[ループと反復処理のページ](https://developer.mozilla.org/ja/docs/Web/JavaScript/Guide/Loops_and_iteration)のページ内へのナビゲーションリンク箇所に対して、以下の２点の修正を実施しました。

1. フラグメント文字列をページ内のヘッダーが持つid属性の値に更新（英語版ページと同じフラグメント文字列のリンクになっていたことでページ内遷移ができなくなっていたため）
2. `label 文`の表記をページ内のヘッダーの記載（`ラベルつき 文`）に統一

### Motivation

- ユーザビリティの向上のため。

### Additional details

- 特になし

### Related issues and pull requests

- 特になし
