### PR TITLE
Fix WebGL example links

### DIFF
--- a/files/es/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/es/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -262,7 +262,7 @@ Entonces establecemos la posición del cuadrado plano al cargar la posición de 
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample2/index.html', 670, 510) }}
 
-[Ver código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [Abrir esta demostración en una nueva página](http://mdn.github.io/webgl-examples/tutorial/sample2/)
+[Ver código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [Abrir esta demostración en una nueva página](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample2/)
 
 ## Utilidades para operaciones de Matrices
 

--- a/files/es/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/es/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -260,9 +260,9 @@ El primer paso es limpiar el canvas de nuestro color de fondo; establecemos la p
 
 Entonces establecemos la posición del cuadrado plano al cargar la posición de identidad y alejando la cámara en 6 unidades. Déspues de eso, enlazamos el buffer del vértice del cuadrado al atributo que el shader estaba usando para `aVertexPosition` y le decimos a WebGL como jalar los datos fuera de este. Finalmente dibujamos el objeto al llamar el método {{domxref("WebGLRenderingContext.drawArrays()", "drawArrays()")}}.
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample2/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample2/index.html', 670, 510) }}
 
-[Ver código completo](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample2) | [Abrir esta demostración en una nueva página](http://mdn.github.io/webgl-examples/tutorial/sample2/)
+[Ver código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [Abrir esta demostración en una nueva página](http://mdn.github.io/webgl-examples/tutorial/sample2/)
 
 ## Utilidades para operaciones de Matrices
 

--- a/files/es/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/es/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -262,7 +262,7 @@ Entonces establecemos la posición del cuadrado plano al cargar la posición de 
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample2/index.html', 670, 510) }}
 
-[Ver código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [Abrir esta demostración en una nueva página](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample2/)
+[Ver código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample2) | [Abrir esta demostración en una nueva página](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample2/)
 
 ## Utilidades para operaciones de Matrices
 

--- a/files/es/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -91,6 +91,6 @@ gl.bindBuffer(gl.ARRAY_BUFFER, squareVerticesColorBuffer); gl.vertexAttribPointe
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample3/index.html', 670, 510) }}
 
-[Ver el código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [Abrir demostración en una nueva página](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample3/)
+[Ver el código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample3) | [Abrir demostración en una nueva página](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample3/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}

--- a/files/es/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -89,8 +89,8 @@ Then, drawScene() puede ser revisado para que utilice dichos colores cuando dibu
 
 gl.bindBuffer(gl.ARRAY_BUFFER, squareVerticesColorBuffer); gl.vertexAttribPointer(vertexColorAttribute, 4, gl.FLOAT, false, 0, 0);
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample3/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample3/index.html', 670, 510) }}
 
-[Ver el código completo](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample3) | [Abrir demostración en una nueva página](http://mdn.github.io/webgl-examples/tutorial/sample3/)
+[Ver el código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [Abrir demostración en una nueva página](http://mdn.github.io/webgl-examples/tutorial/sample3/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}

--- a/files/es/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -91,6 +91,6 @@ gl.bindBuffer(gl.ARRAY_BUFFER, squareVerticesColorBuffer); gl.vertexAttribPointe
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample3/index.html', 670, 510) }}
 
-[Ver el código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [Abrir demostración en una nueva página](http://mdn.github.io/webgl-examples/tutorial/sample3/)
+[Ver el código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [Abrir demostración en una nueva página](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample3/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}

--- a/files/es/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -179,7 +179,7 @@ En este punto, el cubo giratorio debe estar listo.
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample6/index.html', 670, 510) }}
 
-[Ver el código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [Abrir esta demo en una nueva pestaña](http://mdn.github.io/webgl-examples/tutorial/sample6/)
+[Ver el código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [Abrir esta demo en una nueva pestaña](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample6/)
 
 ## Texturas entre dominios
 

--- a/files/es/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -177,9 +177,9 @@ GL proporciona 32 registros de textura; La primera de ellas es gl.TEXTURE0. Vinc
 
 En este punto, el cubo giratorio debe estar listo.
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample6/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample6/index.html', 670, 510) }}
 
-[Ver el código completo](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample6) | [Abrir esta demo en una nueva pestaña](http://mdn.github.io/webgl-examples/tutorial/sample6/)
+[Ver el código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [Abrir esta demo en una nueva pestaña](http://mdn.github.io/webgl-examples/tutorial/sample6/)
 
 ## Texturas entre dominios
 

--- a/files/es/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -179,7 +179,7 @@ En este punto, el cubo giratorio debe estar listo.
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample6/index.html', 670, 510) }}
 
-[Ver el código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [Abrir esta demo en una nueva pestaña](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample6/)
+[Ver el código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample6) | [Abrir esta demo en una nueva pestaña](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample6/)
 
 ## Texturas entre dominios
 

--- a/files/fr/web/api/webgl_api/by_example/video_textures/index.md
+++ b/files/fr/web/api/webgl_api/by_example/video_textures/index.md
@@ -9,6 +9,6 @@ Cet exemple illustre comment utiliser des fichiers vidéos comme textures.
 
 ### Des textures à partir de vidéos
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample8/index.html', 670, 510)}}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample8/index.html', 670, 510)}}
 
 {{Previous("Apprendre/WebGL/Par_exemple/Générer_des_textures_avec_du_code")}}

--- a/files/fr/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -188,7 +188,7 @@ Une fois que cela est fait, nous créons un tableau JavaScript contenant la posi
 
 Une fois que les shaders sont définis, que les emplacements sont retrouvés, et que les positions des sommets du carré 2D sont stockées dans le tampon, nous pouvons faire effectivement le rendu de la scène. Puisque nous n'animons rien dans cet exemple, notre fonction `drawScene()` est très simple. Elle utilise quelques routines utilitaires que nous décrirons sous peu.
 
-> **Note :** Vous pourriez obtenir une erreur JavaScript indiquant _"mat4 n'est pas défini"_. Cela signifie qu'il existe une dépendance à **glmatrix**. Vous pouvez inclure [gl-matrix.js](https://mdn.github.io/webgl-examples/tutorial/gl-matrix.js) pour résoudre ce problème, comme suggéré [ici](https://github.com/mdn/dom-examples/tree/main/webgl-examples/issues/20).
+> **Note :** Vous pourriez obtenir une erreur JavaScript indiquant _"mat4 n'est pas défini"_. Cela signifie qu'il existe une dépendance à **glmatrix**. Vous pouvez inclure [gl-matrix](https://www.npmjs.com/package/gl-matrix) pour résoudre ce problème.
 
 ```js
 function drawScene(gl, programInfo, buffers) {

--- a/files/fr/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -283,7 +283,7 @@ Ensuite, nous établissons la position du carré 2D en chargeant la position de 
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample2/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample2/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample2/)
 
 ## Opérations utilitaires matricielles
 

--- a/files/fr/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -283,7 +283,7 @@ Ensuite, nous établissons la position du carré 2D en chargeant la position de 
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample2/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample2/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample2) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample2/)
 
 ## Opérations utilitaires matricielles
 

--- a/files/fr/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -188,7 +188,7 @@ Une fois que cela est fait, nous créons un tableau JavaScript contenant la posi
 
 Une fois que les shaders sont définis, que les emplacements sont retrouvés, et que les positions des sommets du carré 2D sont stockées dans le tampon, nous pouvons faire effectivement le rendu de la scène. Puisque nous n'animons rien dans cet exemple, notre fonction `drawScene()` est très simple. Elle utilise quelques routines utilitaires que nous décrirons sous peu.
 
-> **Note :** Vous pourriez obtenir une erreur JavaScript indiquant _"mat4 n'est pas défini"_. Cela signifie qu'il existe une dépendance à **glmatrix**. Vous pouvez inclure [gl-matrix.js](https://mdn.github.io/webgl-examples/tutorial/gl-matrix.js) pour résoudre ce problème, comme suggéré [ici](https://github.com/mdn/webgl-examples/issues/20).
+> **Note :** Vous pourriez obtenir une erreur JavaScript indiquant _"mat4 n'est pas défini"_. Cela signifie qu'il existe une dépendance à **glmatrix**. Vous pouvez inclure [gl-matrix.js](https://mdn.github.io/webgl-examples/tutorial/gl-matrix.js) pour résoudre ce problème, comme suggéré [ici](https://github.com/mdn/dom-examples/tree/main/webgl-examples/issues/20).
 
 ```js
 function drawScene(gl, programInfo, buffers) {
@@ -281,9 +281,9 @@ La première étape consiste à effacer le canevas avec notre arrière plan ; en
 
 Ensuite, nous établissons la position du carré 2D en chargeant la position de l'origine et en nous déplaçant de 6 unités à partir de la caméra. Après cela, nous lions le tampon des sommets du carré à l'attribut que le shader utilise comme `aVertexPosition` et nous indiquons à WebGL comment en extraire les données. Enfin, nous dessinons l'objet en appelant la méthode {{domxref ("WebGLRenderingContext.drawArrays()", "drawArrays()")}}.
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample2/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample2/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample2) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample2/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample2/)
 
 ## Opérations utilitaires matricielles
 

--- a/files/fr/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
@@ -56,6 +56,6 @@ Ce code utilise le laps de temps qui s'est écoulé depuis la dernière fois que
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample4/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample4) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample4/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample4) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample4/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL", "Web/API/WebGL_API/Tutorial/Creating_3D_objects_using_WebGL") }}

--- a/files/fr/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
@@ -56,6 +56,6 @@ Ce code utilise le laps de temps qui s'est écoulé depuis la dernière fois que
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample4/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample4) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample4/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample4) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample4/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL", "Web/API/WebGL_API/Tutorial/Creating_3D_objects_using_WebGL") }}

--- a/files/fr/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
@@ -54,8 +54,8 @@ squareRotation += deltaTime;
 
 Ce code utilise le laps de temps qui s'est écoulé depuis la dernière fois que nous avons mis à jour la valeur `squareRotation` pour déterminer de combien faire tourner le carré.
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample4/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample4/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample4) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample4/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample4) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample4/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL", "Web/API/WebGL_API/Tutorial/Creating_3D_objects_using_WebGL") }}

--- a/files/fr/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -7,7 +7,7 @@ slug: Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL
 
 Cet article va vous donner une introduction aux bases de l'utilisation de WebGL. Il est supposé que vous avez déjà une compréhension des mathématiques impliquées dans les graphismes 3D, et cet article ne prétend pas vous enseigner les concepts des graphismes 3D par eux-mêmes.
 
-Les exemples de code de ce tutoriel peuvent aussi être trouvés dans le [webgl-examples GitHub repository](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial).
+Les exemples de code de ce tutoriel peuvent aussi être trouvés dans le [webgl-examples GitHub repository](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial).
 
 ## Préparation au rendu 3D
 
@@ -57,9 +57,9 @@ Si le contexte est initialisé avec succès, la variable `gl` sera notre référ
 
 A ce stade, votre code est suffisant pour que le contexte WebGL puisse s'initialiser avec succès, et vous devriez vous retrouver avec une grande boîte noire et vide, prête à - et attendant de - recevoir du contenu.
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample1/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample1/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample1) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample1/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample1) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample1/)
 
 ## Voir aussi
 

--- a/files/fr/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -7,7 +7,7 @@ slug: Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL
 
 Cet article va vous donner une introduction aux bases de l'utilisation de WebGL. Il est supposé que vous avez déjà une compréhension des mathématiques impliquées dans les graphismes 3D, et cet article ne prétend pas vous enseigner les concepts des graphismes 3D par eux-mêmes.
 
-Les exemples de code de ce tutoriel peuvent aussi être trouvés dans le [webgl-examples GitHub repository](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial).
+Les exemples de code de ce tutoriel peuvent aussi être trouvés dans le [webgl-examples GitHub repository](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial).
 
 ## Préparation au rendu 3D
 

--- a/files/fr/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -153,7 +153,7 @@ Et c'est tout !
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample7/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample7) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample7/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample7) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample7/)
 
 ## Exercices
 

--- a/files/fr/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -153,7 +153,7 @@ Et c'est tout !
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample7/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample7) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample7/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample7) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample7/)
 
 ## Exercices
 

--- a/files/fr/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -151,9 +151,9 @@ Ici nous récupérons la couleur de chaque texel (tas de pixel pour une texture)
 
 Et c'est tout !
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample7/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample7/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample7) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample7/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample7) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample7/)
 
 ## Exercices
 

--- a/files/fr/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -121,8 +121,8 @@ Ensuite, `drawScene()` peut être modifié pour utiliser réellement ces couleur
 }
 ```
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample3/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample3/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample3) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample3/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample3/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}

--- a/files/fr/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -123,6 +123,6 @@ Ensuite, `drawScene()` peut être modifié pour utiliser réellement ces couleur
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample3/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample3/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample3/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}

--- a/files/fr/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -123,6 +123,6 @@ Ensuite, `drawScene()` peut être modifié pour utiliser réellement ces couleur
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample3/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample3/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample3) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample3/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}

--- a/files/fr/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -289,7 +289,7 @@ Arrivés ce point, le cube en rotation devrait être prêt à fonctionner.
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample6/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample6/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample6/)
 
 ## Textures inter-domaines
 

--- a/files/fr/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -287,9 +287,9 @@ function drawScene(gl, programInfo, buffers, texture, deltaTime) {
 
 Arrivés ce point, le cube en rotation devrait être prêt à fonctionner.
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample6/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample6/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample6) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample6/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample6/)
 
 ## Textures inter-domaines
 

--- a/files/fr/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -289,7 +289,7 @@ Arrivés ce point, le cube en rotation devrait être prêt à fonctionner.
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample6/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample6/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample6) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample6/)
 
 ## Textures inter-domaines
 

--- a/files/fr/web/guide/audio_and_video_manipulation/index.md
+++ b/files/fr/web/guide/audio_and_video_manipulation/index.md
@@ -30,10 +30,10 @@ On peut configurer notre lecteur vidéo et l'élément `<canvas>` comme ceci:
   height="270"
   crossorigin="anonymous">
   <source
-    src="http://jplayer.org/video/webm/Big_Buck_Bunny_Trailer.webm"
+    src="https://jplayer.org/video/webm/Big_Buck_Bunny_Trailer.webm"
     type="video/webm" />
   <source
-    src="http://jplayer.org/video/m4v/Big_Buck_Bunny_Trailer.m4v"
+    src="https://jplayer.org/video/m4v/Big_Buck_Bunny_Trailer.m4v"
     type="video/mp4" />
 </video>
 
@@ -127,7 +127,7 @@ HTML:
 <video
   id="my-video"
   controls
-  src="http://jplayer.org/video/m4v/Big_Buck_Bunny_Trailer.m4v"></video>
+  src="https://jplayer.org/video/m4v/Big_Buck_Bunny_Trailer.m4v"></video>
 ```
 
 JavaScript:
@@ -142,10 +142,10 @@ myVideo.playbackRate = 2;
 ```html hidden
 <video id="my-video" controls="true" width="480" height="270">
   <source
-    src="http://jplayer.org/video/webm/Big_Buck_Bunny_Trailer.webm"
+    src="https://jplayer.org/video/webm/Big_Buck_Bunny_Trailer.webm"
     type="video/webm" />
   <source
-    src="http://jplayer.org/video/m4v/Big_Buck_Bunny_Trailer.m4v"
+    src="https://jplayer.org/video/m4v/Big_Buck_Bunny_Trailer.m4v"
     type="video/mp4" />
 </video>
 <div class="playable-buttons">

--- a/files/fr/web/guide/audio_and_video_manipulation/index.md
+++ b/files/fr/web/guide/audio_and_video_manipulation/index.md
@@ -113,9 +113,9 @@ processor.doLoad();
 
 Exemple:
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample8/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample8/index.html', 670, 510) }}
 
-> **Note :** Vous pouvez trouver le [code source de cette démo sur GitHub](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample8) ([la voir en direct](https://mdn.github.io/webgl-examples/tutorial/sample8/) aussi).
+> **Note :** Vous pouvez trouver le [code source de cette démo sur GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample8) ([la voir en direct](https://mdn.github.io/webgl-examples/tutorial/sample8/) aussi).
 
 ### Vitesse de lecture
 

--- a/files/fr/web/guide/audio_and_video_manipulation/index.md
+++ b/files/fr/web/guide/audio_and_video_manipulation/index.md
@@ -115,7 +115,7 @@ Exemple:
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample8/index.html', 670, 510) }}
 
-> **Note :** Vous pouvez trouver le [code source de cette démo sur GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample8) ([la voir en direct](https://mdn.github.io/webgl-examples/tutorial/sample8/) aussi).
+> **Note :** Vous pouvez trouver le [code source de cette démo sur GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample8) ([la voir en direct](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample8/) aussi).
 
 ### Vitesse de lecture
 

--- a/files/ja/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
@@ -93,7 +93,7 @@ mvTranslate([squareXOffset, squareYOffset, squareZOffset]);
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample4/index.html', 670, 510)}}
 
-[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample4) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample4/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample4) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample4/)
 
 ## さらに行列を操作する
 

--- a/files/ja/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
@@ -91,9 +91,9 @@ mvTranslate([squareXOffset, squareYOffset, squareZOffset]);
 
 以上で、正方形が回転するとともにズームイン・ズームアウトしながら、環境内を近づいたり遠ざかったりするようランダムに動き回ります。これはスクリーンセーバーのようです。
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample4/index.html', 670, 510)}}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample4/index.html', 670, 510)}}
 
-[コードを確認する](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample4) | [新しいページでデモを開く](http://mdn.github.io/webgl-examples/tutorial/sample4/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample4) | [新しいページでデモを開く](http://mdn.github.io/webgl-examples/tutorial/sample4/)
 
 ## さらに行列を操作する
 

--- a/files/ja/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
@@ -93,7 +93,7 @@ mvTranslate([squareXOffset, squareYOffset, squareZOffset]);
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample4/index.html', 670, 510)}}
 
-[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample4) | [新しいページでデモを開く](http://mdn.github.io/webgl-examples/tutorial/sample4/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample4) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample4/)
 
 ## さらに行列を操作する
 

--- a/files/ja/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -11,7 +11,7 @@ WebGL のプログラムは JavaScript で記述する制御コードと、コ�
 
 この記事では、 WebGL の基礎を紹介します。ここでは、三次元グラフィックスに関する数学的な知識を理解していることを前提とします。よって、 OpenGL そのものの説明は行いません。
 
-このチュートリアルで使用するコード例は、[GitHub の webgl-examples リポジトリー](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial)で確認できます。
+このチュートリアルで使用するコード例は、[GitHub の webgl-examples リポジトリー](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial)で確認できます。
 
 この一連の記事が WebGL 自体を紹介していることに注意してください。ただし [THREE.js](https://threejs.org/) など、 WebGL の機能をカプセル化する多くのフレームワークが利用でき、三次元アプリケーションとゲームを簡単に構築することが可能です。
 
@@ -65,7 +65,7 @@ window.onload = main;
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample1/index.html', 670, 510) }}
 
-[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample1) | [新しいページでデモを開く](https://mdn.github.io/webgl-examples/tutorial/sample1/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample1) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample1/)
 
 ## 関連情報
 

--- a/files/ja/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -11,7 +11,7 @@ WebGL のプログラムは JavaScript で記述する制御コードと、コ�
 
 この記事では、 WebGL の基礎を紹介します。ここでは、三次元グラフィックスに関する数学的な知識を理解していることを前提とします。よって、 OpenGL そのものの説明は行いません。
 
-このチュートリアルで使用するコード例は、[GitHub の webgl-examples リポジトリー](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial)で確認できます。
+このチュートリアルで使用するコード例は、[GitHub の webgl-examples リポジトリー](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial)で確認できます。
 
 この一連の記事が WebGL 自体を紹介していることに注意してください。ただし [THREE.js](https://threejs.org/) など、 WebGL の機能をカプセル化する多くのフレームワークが利用でき、三次元アプリケーションとゲームを簡単に構築することが可能です。
 
@@ -63,9 +63,9 @@ window.onload = main;
 
 この時点で、 WebGL コンテキストが正常に初期化されるのに十分なコードがあり、コンテンツを受信する準備ができて待機している大きな黒い空のボックスになります。
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample1/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample1/index.html', 670, 510) }}
 
-[コードを確認する](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample1) | [新しいページでデモを開く](https://mdn.github.io/webgl-examples/tutorial/sample1/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample1) | [新しいページでデモを開く](https://mdn.github.io/webgl-examples/tutorial/sample1/)
 
 ## 関連情報
 

--- a/files/ja/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -155,7 +155,7 @@ gl.uniformMatrix4fv(
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample7/index.html', 670, 510)}}
 
-[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample7) | [新しいページでデモを開く](http://mdn.github.io/webgl-examples/tutorial/sample7/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample7) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample7/)
 
 ## 読者への課題
 

--- a/files/ja/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -155,7 +155,7 @@ gl.uniformMatrix4fv(
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample7/index.html', 670, 510)}}
 
-[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample7) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample7/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample7) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample7/)
 
 ## 読者への課題
 

--- a/files/ja/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -153,9 +153,9 @@ gl.uniformMatrix4fv(
 
 以上で完成です!
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample7/index.html', 670, 510)}}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample7/index.html', 670, 510)}}
 
-[コードを確認する](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample7) | [新しいページでデモを開く](http://mdn.github.io/webgl-examples/tutorial/sample7/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample7) | [新しいページでデモを開く](http://mdn.github.io/webgl-examples/tutorial/sample7/)
 
 ## 読者への課題
 

--- a/files/ja/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -94,6 +94,6 @@ gl.vertexAttribPointer(vertexColorAttribute, 4, gl.FLOAT, false, 0, 0);
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample3/index.html', 670, 510)}}
 
-[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample3/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample3) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample3/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}

--- a/files/ja/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -92,8 +92,8 @@ gl.bindBuffer(gl.ARRAY_BUFFER, squareVerticesColorBuffer);
 gl.vertexAttribPointer(vertexColorAttribute, 4, gl.FLOAT, false, 0, 0);
 ```
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample3/index.html', 670, 510)}}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample3/index.html', 670, 510)}}
 
-[コードを確認する](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample3) | [新しいページでデモを開く](http://mdn.github.io/webgl-examples/tutorial/sample3/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [新しいページでデモを開く](http://mdn.github.io/webgl-examples/tutorial/sample3/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}

--- a/files/ja/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -94,6 +94,6 @@ gl.vertexAttribPointer(vertexColorAttribute, 4, gl.FLOAT, false, 0, 0);
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample3/index.html', 670, 510)}}
 
-[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [新しいページでデモを開く](http://mdn.github.io/webgl-examples/tutorial/sample3/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample3/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}

--- a/files/ja/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -180,7 +180,7 @@ GL は 32 個のテクスチャレジスタを提供し、その 1 つ目が `gl
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample6/index.html', 670, 510)}}
 
-[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [新しいページでデモを開く](http://mdn.github.io/webgl-examples/tutorial/sample6/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample6/)
 
 ## クロスドメインのテクスチャ
 

--- a/files/ja/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -180,7 +180,7 @@ GL は 32 個のテクスチャレジスタを提供し、その 1 つ目が `gl
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample6/index.html', 670, 510)}}
 
-[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample6/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample6) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample6/)
 
 ## クロスドメインのテクスチャ
 

--- a/files/ja/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -178,9 +178,9 @@ GL は 32 個のテクスチャレジスタを提供し、その 1 つ目が `gl
 
 以上でテクスチャが貼り付けられた、回転するキューブが完成します。
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample6/index.html', 670, 510)}}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample6/index.html', 670, 510)}}
 
-[コードを確認する](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample6) | [新しいページでデモを開く](http://mdn.github.io/webgl-examples/tutorial/sample6/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [新しいページでデモを開く](http://mdn.github.io/webgl-examples/tutorial/sample6/)
 
 ## クロスドメインのテクスチャ
 

--- a/files/ja/web/api/webxr_device_api/movement_and_motion/index.md
+++ b/files/ja/web/api/webxr_device_api/movement_and_motion/index.md
@@ -518,7 +518,7 @@ function applyViewerControls(refSpace) {
 
 `renderScene()` 関数は、ユーザーがその瞬間に見える世界の部分を実際にレンダリングするために呼び出されます。 XR ギアに必要な 3D 効果を確立するために、それぞれの目でわずかに異なる位置を使用し、それぞれの目に対して 1 回ずつ呼び出されます。
 
-このコードのほとんどは、[WebGL でのライティング](/ja/docs/Web/API/WebGL_API/Tutorial/Lighting_in_WebGL)の記事の `drawScene()` 関数から直接取得した典型的な WebGL レンダリングコードであり、この例の WebGL レンダリング部分の詳細についてはそこを参照してください（[GitHub でコードを見る](https://github.com/mdn/webgl-examples/blob/gh-pages/tutorial/sample7/webgl-demo.js)）。 しかし、ここでは、この例に固有のコードから始まっているので、その部分について詳しく見ていきます。
+このコードのほとんどは、[WebGL でのライティング](/ja/docs/Web/API/WebGL_API/Tutorial/Lighting_in_WebGL)の記事の `drawScene()` 関数から直接取得した典型的な WebGL レンダリングコードであり、この例の WebGL レンダリング部分の詳細についてはそこを参照してください（[GitHub でコードを見る](https://github.com/mdn/dom-examples/tree/main/webgl-examples/blob/gh-pages/tutorial/sample7/webgl-demo.js)）。 しかし、ここでは、この例に固有のコードから始まっているので、その部分について詳しく見ていきます。
 
 ```js
 const normalMatrix = mat4.create();

--- a/files/ja/web/guide/audio_and_video_manipulation/index.md
+++ b/files/ja/web/guide/audio_and_video_manipulation/index.md
@@ -119,9 +119,9 @@ processor.doLoad();
 
 [WebGL](/ja/docs/Web/WebGL) はキャンバスを使用してハードウェアアクセラレーションによる三次元や二次元の描画を行う強力な API です。 {{htmlelement("video")}} 要素と組み合わせることで、動画をテクチャとして利用できます。つまり三次元空間上に動画を配置し、再生できます。
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample8/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample8/index.html', 670, 510) }}
 
-> **メモ:** [このデモのソースコードは GitHub](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample8) にあります ([ライブで表示](https://mdn.github.io/webgl-examples/tutorial/sample8/)も)。
+> **メモ:** [このデモのソースコードは GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample8) にあります ([ライブで表示](https://mdn.github.io/webgl-examples/tutorial/sample8/)も)。
 
 ### 再生速度
 

--- a/files/ja/web/guide/audio_and_video_manipulation/index.md
+++ b/files/ja/web/guide/audio_and_video_manipulation/index.md
@@ -121,7 +121,7 @@ processor.doLoad();
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample8/index.html', 670, 510) }}
 
-> **メモ:** [このデモのソースコードは GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample8) にあります ([ライブで表示](https://mdn.github.io/webgl-examples/tutorial/sample8/)も)。
+> **メモ:** [このデモのソースコードは GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample8) にあります ([ライブで表示](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample8/)も)。
 
 ### 再生速度
 

--- a/files/pt-br/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/pt-br/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -188,9 +188,9 @@ The first step is to clear the context to our background color; then we establis
 
 Then we establish the position of the square by loading the identity position and translating away from the camera by 6 units. After that, we bind the square's vertex buffer to the context, configure it, and draw the object by calling the `drawArrays()` method.
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample2/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample2/index.html', 670, 510) }}
 
-[View the complete code](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample2) | [Open this demo on a new page](http://mdn.github.io/webgl-examples/tutorial/sample2/)
+[View the complete code](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [Open this demo on a new page](http://mdn.github.io/webgl-examples/tutorial/sample2/)
 
 ## Operações úteis da Matrix
 

--- a/files/pt-br/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/pt-br/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -190,7 +190,7 @@ Then we establish the position of the square by loading the identity position an
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample2/index.html', 670, 510) }}
 
-[View the complete code](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [Open this demo on a new page](http://mdn.github.io/webgl-examples/tutorial/sample2/)
+[View the complete code](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [Open this demo on a new page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample2/)
 
 ## Operações úteis da Matrix
 

--- a/files/pt-br/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/pt-br/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -190,7 +190,7 @@ Then we establish the position of the square by loading the identity position an
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample2/index.html', 670, 510) }}
 
-[View the complete code](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [Open this demo on a new page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample2/)
+[View the complete code](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample2) | [Open this demo on a new page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample2/)
 
 ## Operações úteis da Matrix
 

--- a/files/pt-br/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/pt-br/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -9,7 +9,7 @@ slug: Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL
 
 Esse artigo vai introduzir o básico sobre o uso do WebGL. Acredita-se que você já possui entendimento da matemática que envolve os gráficos 3D, e que este artigo não tem a pretensão de tentar ensinar-lhe OpenGL em si.
 
-Os exemplos de código deste tutorial também podem ser encontrados no [Exemplos de WebGL no repositório do GitHub](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial).
+Os exemplos de código deste tutorial também podem ser encontrados no [Exemplos de WebGL no repositório do GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial).
 
 ## Preparando-se para renderizar em 3D
 

--- a/files/pt-br/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/pt-br/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -9,7 +9,7 @@ slug: Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL
 
 Esse artigo vai introduzir o básico sobre o uso do WebGL. Acredita-se que você já possui entendimento da matemática que envolve os gráficos 3D, e que este artigo não tem a pretensão de tentar ensinar-lhe OpenGL em si.
 
-Os exemplos de código deste tutorial também podem ser encontrados no [Exemplos de WebGL no repositório do GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial).
+Os exemplos de código deste tutorial também podem ser encontrados no [Exemplos de WebGL no repositório do GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial).
 
 ## Preparando-se para renderizar em 3D
 

--- a/files/ru/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/ru/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -217,7 +217,7 @@ const programInfo = {
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample7/index.html', 670, 510) }}
 
-[Посмотреть код примера полностью](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample7) | [Открыть демо в новом окне](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample7/)
+[Посмотреть код примера полностью](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample7) | [Открыть демо в новом окне](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample7/)
 
 ## Самостоятельные упражнения
 

--- a/files/ru/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/ru/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -215,9 +215,9 @@ const programInfo = {
 
 И это всё!
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample7/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample7/index.html', 670, 510) }}
 
-[Посмотреть код примера полностью](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample7) | [Открыть демо в новом окне](http://mdn.github.io/webgl-examples/tutorial/sample7/)
+[Посмотреть код примера полностью](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample7) | [Открыть демо в новом окне](http://mdn.github.io/webgl-examples/tutorial/sample7/)
 
 ## Самостоятельные упражнения
 

--- a/files/ru/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/ru/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -217,7 +217,7 @@ const programInfo = {
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample7/index.html', 670, 510) }}
 
-[Посмотреть код примера полностью](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample7) | [Открыть демо в новом окне](http://mdn.github.io/webgl-examples/tutorial/sample7/)
+[Посмотреть код примера полностью](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample7) | [Открыть демо в новом окне](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample7/)
 
 ## Самостоятельные упражнения
 

--- a/files/ru/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/ru/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -266,9 +266,9 @@ function drawScene(gl, programInfo, buffers, texture, deltaTime) {
 
 Сейчас вращающийся куб должен иметь текстуру на гранях.
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample6/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample6/index.html', 670, 510) }}
 
-[Посмотреть код примера полностью](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample6) | [Открыть демо в новом окне](http://mdn.github.io/webgl-examples/tutorial/sample6/)
+[Посмотреть код примера полностью](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [Открыть демо в новом окне](http://mdn.github.io/webgl-examples/tutorial/sample6/)
 
 ## Кросс-доменные текстуры
 

--- a/files/ru/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/ru/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -268,7 +268,7 @@ function drawScene(gl, programInfo, buffers, texture, deltaTime) {
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample6/index.html', 670, 510) }}
 
-[Посмотреть код примера полностью](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [Открыть демо в новом окне](http://mdn.github.io/webgl-examples/tutorial/sample6/)
+[Посмотреть код примера полностью](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [Открыть демо в новом окне](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample6/)
 
 ## Кросс-доменные текстуры
 

--- a/files/ru/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/ru/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -268,7 +268,7 @@ function drawScene(gl, programInfo, buffers, texture, deltaTime) {
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample6/index.html', 670, 510) }}
 
-[Посмотреть код примера полностью](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample6) | [Открыть демо в новом окне](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample6/)
+[Посмотреть код примера полностью](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample6) | [Открыть демо в новом окне](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample6/)
 
 ## Кросс-доменные текстуры
 

--- a/files/ru/web/guide/audio_and_video_manipulation/index.md
+++ b/files/ru/web/guide/audio_and_video_manipulation/index.md
@@ -121,9 +121,9 @@ This is a pretty simple example showing how to manipulate video frames using a c
 
 [WebGL](/ru/docs/Web/WebGL) is a powerful API that uses canvas to draw hardware-accelerated 3D or 2D scenes. You can combine WebGL and the {{htmlelement("video")}} element to create video textures, which means you can put video inside 3D scenes.
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample8/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample8/index.html', 670, 510) }}
 
-> **Примечание:** You can find the [source code of this demo on GitHub](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample8) ([see it live](https://mdn.github.io/webgl-examples/tutorial/sample8/) also).
+> **Примечание:** You can find the [source code of this demo on GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample8) ([see it live](https://mdn.github.io/webgl-examples/tutorial/sample8/) also).
 
 ### Скорость воспроизведения
 

--- a/files/ru/web/guide/audio_and_video_manipulation/index.md
+++ b/files/ru/web/guide/audio_and_video_manipulation/index.md
@@ -123,7 +123,7 @@ This is a pretty simple example showing how to manipulate video frames using a c
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample8/index.html', 670, 510) }}
 
-> **Примечание:** You can find the [source code of this demo on GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample8) ([see it live](https://mdn.github.io/webgl-examples/tutorial/sample8/) also).
+> **Примечание:** You can find the [source code of this demo on GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample8) ([see it live](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample8/) also).
 
 ### Скорость воспроизведения
 

--- a/files/zh-cn/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/zh-cn/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -157,7 +157,7 @@ gl.uniformMatrix4fv(
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample7/index.html', 670, 510) }}
 
-[查看完整的源码](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample7) | [在新标签页中查看演示](https://mdn.github.io/webgl-examples/webgl-examples/tutorial/sample7/)
+[查看完整的源码](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample7) | [在新标签页中查看演示](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample7/)
 
 ## 读者练习
 

--- a/files/zh-cn/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/zh-cn/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -162,6 +162,6 @@ setColorAttribute(gl, buffers, programInfo);
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample3/index.html', 670, 510) }}
 
-[查看完整代码](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample3) | [在新页面中打开示例](http://mdn.github.io/webgl-examples/tutorial/sample3/)
+[查看完整代码](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [在新页面中打开示例](http://mdn.github.io/webgl-examples/tutorial/sample3/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}

--- a/files/zh-cn/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/zh-cn/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -162,6 +162,6 @@ setColorAttribute(gl, buffers, programInfo);
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample3/index.html', 670, 510) }}
 
-[查看完整代码](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [在新页面中打开示例](http://mdn.github.io/webgl-examples/tutorial/sample3/)
+[查看完整代码](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [在新页面中打开示例](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample3/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}

--- a/files/zh-cn/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/zh-cn/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -162,6 +162,6 @@ setColorAttribute(gl, buffers, programInfo);
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample3/index.html', 670, 510) }}
 
-[查看完整代码](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample3) | [在新页面中打开示例](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample3/)
+[查看完整代码](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample3) | [在新页面中打开示例](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample3/)
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}

--- a/files/zh-tw/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/zh-tw/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -262,7 +262,7 @@ function drawScene(gl, programInfo, buffers) {
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample2/index.html', 670, 510) }}
 
-[檢視完整程式碼](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [開啟新頁面來檢視結果](http://mdn.github.io/webgl-examples/tutorial/sample2/)
+[檢視完整程式碼](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [開啟新頁面來檢視結果](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample2/)
 
 ## 矩陣運算
 

--- a/files/zh-tw/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/zh-tw/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -262,7 +262,7 @@ function drawScene(gl, programInfo, buffers) {
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample2/index.html', 670, 510) }}
 
-[檢視完整程式碼](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [開啟新頁面來檢視結果](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample2/)
+[檢視完整程式碼](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample2) | [開啟新頁面來檢視結果](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample2/)
 
 ## 矩陣運算
 

--- a/files/zh-tw/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/zh-tw/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -260,9 +260,9 @@ function drawScene(gl, programInfo, buffers) {
 
 接下來，我們讀入正方形的位置，並把它擺在離相機 6 單位遠的位置。然後我們將正方形頂點的 buffer 綁定到 gl 上。最後我們呼叫{{domxref("WebGLRenderingContext.drawArrays()", "drawArrays()")}}函數來渲染物件。
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample2/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample2/index.html', 670, 510) }}
 
-[檢視完整程式碼](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample2) | [開啟新頁面來檢視結果](http://mdn.github.io/webgl-examples/tutorial/sample2/)
+[檢視完整程式碼](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample2) | [開啟新頁面來檢視結果](http://mdn.github.io/webgl-examples/tutorial/sample2/)
 
 ## 矩陣運算
 

--- a/files/zh-tw/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/zh-tw/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -9,7 +9,7 @@ slug: Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL
 
 這篇文章將會向您介紹 WebGL 的基礎。這篇文章假設您已經對於三維圖學涉及的數學有所了解，並且它將不會被佯裝為三維圖學的教材。在我們的學習區域內有初學者指南讓你完成編程任務：[Learn WebGL for 2D and 3D graphics](/zh-TW/docs/Learn/WebGL).
 
-在此教學文件中的程式碼範例都能在 [webgl-examples GitHub repository](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial) 之中找到。
+在此教學文件中的程式碼範例都能在 [webgl-examples GitHub repository](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial) 之中找到。
 
 ## 準備三維渲染
 
@@ -59,7 +59,7 @@ function main() {
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample1/index.html', 670, 510) }}
 
-[檢視完整程式碼](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample1) | [開啟新頁面來檢視結果](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample1/)
+[檢視完整程式碼](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample1) | [開啟新頁面來檢視結果](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample1/)
 
 ## 亦可參考
 

--- a/files/zh-tw/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/zh-tw/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -9,7 +9,7 @@ slug: Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL
 
 這篇文章將會向您介紹 WebGL 的基礎。這篇文章假設您已經對於三維圖學涉及的數學有所了解，並且它將不會被佯裝為三維圖學的教材。在我們的學習區域內有初學者指南讓你完成編程任務：[Learn WebGL for 2D and 3D graphics](/zh-TW/docs/Learn/WebGL).
 
-在此教學文件中的程式碼範例都能在 [webgl-examples GitHub repository](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial) 之中找到。
+在此教學文件中的程式碼範例都能在 [webgl-examples GitHub repository](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial) 之中找到。
 
 ## 準備三維渲染
 
@@ -57,9 +57,9 @@ function main() {
 
 至此，您已經有足夠初始化 WebGL 背景資料的程式碼，並且準備好了等待接收內容的容器。
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample1/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample1/index.html', 670, 510) }}
 
-[檢視完整程式碼](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample1) | [開啟新頁面來檢視結果](http://mdn.github.io/webgl-examples/tutorial/sample1/)
+[檢視完整程式碼](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample1) | [開啟新頁面來檢視結果](http://mdn.github.io/webgl-examples/tutorial/sample1/)
 
 ## 亦可參考
 

--- a/files/zh-tw/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/zh-tw/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -59,7 +59,7 @@ function main() {
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample1/index.html', 670, 510) }}
 
-[檢視完整程式碼](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample1) | [開啟新頁面來檢視結果](http://mdn.github.io/webgl-examples/tutorial/sample1/)
+[檢視完整程式碼](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tree/gh-pages/tutorial/sample1) | [開啟新頁面來檢視結果](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample1/)
 
 ## 亦可參考
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Replaced broken links using TextSS.net without manual verification:

* Replaced `https://github.com/mdn/webgl-examples/` to `https://github.com/mdn/dom-examples/tree/main/webgl-examples/`
* Replaced `EmbedGHLiveSample('webgl-examples/` to `EmbedGHLiveSample('dom-examples/webgl-examples/`
* Replaced `http://mdn.github.io/webgl-examples/` to `https://mdn.github.io/dom-examples/webgl-examples/`

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
