### PR TITLE
chore(MDN): remove TenthCampaignQuote macro

### DIFF
--- a/files/es/mdn/at_ten/index.md
+++ b/files/es/mdn/at_ten/index.md
@@ -17,8 +17,6 @@ Por diez años, la comunidad MDN ha estado documentando la Web abierta. Desde la
 
 [Aprende más sobre contribuyendo](/es/docs/MDN_at_ten/Contributing_to_MDN)
 
-{{TenthCampaignQuote}}
-
 ## Subnav
 
 1. [MDN en 10](/es/docs/MDN_at_ten/)

--- a/files/ja/mdn/at_ten/index.md
+++ b/files/ja/mdn/at_ten/index.md
@@ -21,8 +21,6 @@ l10n:
 
 [参加についての詳細はこちら](/ja/docs/MDN/Contribute)
 
-{{TenthCampaignQuote}}
-
 ## 関連情報
 
 - [MDN のあゆみ](/ja/docs/MDN/At_ten/History_of_MDN)

--- a/files/ko/mdn/at_ten/index.md
+++ b/files/ko/mdn/at_ten/index.md
@@ -17,8 +17,6 @@ slug: MDN/At_ten
 
 [더 알아보기 about contributing](/ko/docs/MDN/Contribute)
 
-{{TenthCampaignQuote}}
-
 ## 추가정보
 
 - [MDN의 역사](/ko/docs/MDN/At_ten/History_of_MDN)

--- a/files/pt-br/mdn/at_ten/index.md
+++ b/files/pt-br/mdn/at_ten/index.md
@@ -17,8 +17,6 @@ Por dez anos a comunidade do MDN tem documentado a Web livre. Desde corrigir peq
 
 [Aprenda mais about contributing](/pt-BR/docs/MDN_at_ten/Contributing_to_MDN)
 
-{{TenthCampaignQuote}}
-
 ## Subnav
 
 1. [10 anos de MDN](/pt-BR/docs/MDN_at_ten/)

--- a/files/ru/mdn/at_ten/index.md
+++ b/files/ru/mdn/at_ten/index.md
@@ -17,8 +17,6 @@ slug: MDN/At_ten
 
 [Узнать большеabout contributing](/ru/docs/MDN_at_ten/Contributing_to_MDN)
 
-{{TenthCampaignQuote}}
-
 ## Содержание
 
 1. [10-летие MDN](/ru/docs/MDN_at_ten/)

--- a/files/zh-cn/mdn/at_ten/index.md
+++ b/files/zh-cn/mdn/at_ten/index.md
@@ -17,8 +17,6 @@ slug: MDN/At_ten
 
 [了解更多如何为 MDN 做出贡献](/zh-CN/docs/MDN/Contribute)
 
-{{TenthCampaignQuote}}
-
 ## 参见
 
 - [MDN 的历史渊源](/zh-CN/docs/MDN/At_ten/History_of_MDN)

--- a/files/zh-tw/mdn/at_ten/index.md
+++ b/files/zh-tw/mdn/at_ten/index.md
@@ -19,8 +19,6 @@ slug: MDN/At_ten
 
 [了解更多 about contributing](/zh-TW/docs/MDN_at_ten/Contributing_to_MDN)
 
-{{TenthCampaignQuote}}
-
 ## 參見
 
 - [MDN 的歷史](/zh-TW/docs/MDN/At_ten/History_of_MDN)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removes the invocation of the `{{TenthCampaignQuote}}` macro.

### Motivation

We want to remove it from yari, because it causes non-deterministic build results, and the page has very few users.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to:
- https://github.com/mdn/yari/pull/9906
- https://github.com/mdn/content/pull/29904