### PR TITLE
FIX: Live example in HTMLElement: drag event page

### DIFF
--- a/files/ja/web/api/htmlelement/drag_event/index.md
+++ b/files/ja/web/api/htmlelement/drag_event/index.md
@@ -136,7 +136,7 @@ target.addEventListener("drop", (event) => {
 
 #### 結果
 
-{{EmbedLiveSample('Drag and drop example')}}
+{{EmbedLiveSample('ドラッグ＆ドロップの例')}}
 
 ## 仕様書
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Live example in HTMLElement: drag event page is broken

### Motivation

Fixed broken.

### Related issues and pull requests

Fixes #14931
