### PR TITLE
`browser_specific_settings` キーを使用する

### DIFF
--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
@@ -77,7 +77,7 @@ slug: Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings
 使用可能なキーをすべて使用した例です。たいていの拡張機能では `strict_max_version` と `update_url` は省略するのに注意してください。
 
 ```json
-"applications": {
+"browser_specific_settings": {
   "gecko": {
     "id": "addon@example.com",
     "strict_min_version": "42.0",


### PR DESCRIPTION
### Description

manifest.json の例として `applications` キーを使用していましたが、Firefox の仕様に合わせて `browser_specific_settings` キーを使用する例に変更しました。

### Motivation

最新のFirefoxの仕様に合わせます。

### Additional details

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
