### PR TITLE
es/ja: Replace remaining calls to {{xref_cssvisual}}

### DIFF
--- a/files/es/orphaned/web/css/ime-mode/index.md
+++ b/files/es/orphaned/web/css/ime-mode/index.md
@@ -14,7 +14,7 @@ La propiedad `ime-mode` controla el estado del método de entrada del editor par
 - Se aplica a: campos de texto.
 - {{ Cssxref("inheritance", "Valor heredado") }}: no
 - Porcentajes: N/A
-- Media: {{ Xref_cssvisual() }}
+- Media: {{cssxref("Media/Visual", "visual")}}
 - {{ Cssxref("computed value", "Valor calculado") }}:
 
 ### Sintaxis

--- a/files/es/web/css/-webkit-mask-box-image/index.md
+++ b/files/es/web/css/-webkit-mask-box-image/index.md
@@ -14,7 +14,7 @@ slug: Web/CSS/-webkit-mask-box-image
 - {{ Xref_cssinitial() }}: none
 - Se aplica a : Todos los elementos
 - {{ Xref_cssinherited() }}: no
-- Media: {{ Xref_cssvisual() }}
+- Media: {{cssxref("Media/Visual", "visual")}}
 - {{ Xref_csscomputed() }}: tal y como se especfica
 
 ## Síntaxis

--- a/files/es/web/css/-webkit-mask-composite/index.md
+++ b/files/es/web/css/-webkit-mask-composite/index.md
@@ -12,7 +12,7 @@ La propiedad `-webkit-mask-composite` especifica la forma en la que múltiples i
 - {{ Xref_cssinitial() }}: source-over
 - Se aplica a : todos los elementos
 - {{ Xref_cssinherited() }}: no
-- Media: {{ Xref_cssvisual() }}
+- Media: {{cssxref("Media/Visual", "visual")}}
 - {{ Xref_csscomputed() }}: tal y como se especifica.
 
 ## Síntaxis

--- a/files/es/web/css/border-bottom-color/index.md
+++ b/files/es/web/css/border-bottom-color/index.md
@@ -13,7 +13,7 @@ La propiedad `border-bottom-color` define el color del borde inferior de un elem
 - Se aplica a: todos los elementos
 - {{ Cssxref("inheritance", "Valor heredado") }}: non
 - Porcentajes: N/A
-- Medio : {{ Xref_cssvisual() }}
+- Medio : {{cssxref("Media/Visual", "visual")}}
 - {{ Cssxref("computed value", "Valor calculado") }}: como se especifique o si proviene de la propiedad {{ Cssxref("color") }}, será el valor {{ Cssxref("color") }}.
 
 ### Sintaxis

--- a/files/es/web/css/border-bottom-style/index.md
+++ b/files/es/web/css/border-bottom-style/index.md
@@ -13,7 +13,7 @@ slug: Web/CSS/border-bottom-style
 - Se aplica a: todos los elementos
 - {{ Cssxref("inheritance", "Valor heredado") }}: no
 - Porcentajes: N/A
-- Medio: {{ Xref_cssvisual() }}
+- Medio: {{cssxref("Media/Visual", "visual")}}
 - {{ Cssxref("computed value", "Valor calculado") }}: como se especificó
 
 ### Sintaxis

--- a/files/es/web/css/border-bottom-width/index.md
+++ b/files/es/web/css/border-bottom-width/index.md
@@ -13,7 +13,7 @@ slug: Web/CSS/border-bottom-width
 - Se aplica a : todos los elementos
 - {{ Cssxref("inheritance", "Valor heredado") }}: no
 - Porcentajes: N/A
-- Medio: {{ Xref_cssvisual() }}
+- Medio: {{cssxref("Media/Visual", "visual")}}
 - {{ Cssxref("computed value", "Valor calculado") }}: largo absoluto o '0' si el estilo es `none` o `hidden`.
 
 ### Sintaxis

--- a/files/es/web/css/border-bottom/index.md
+++ b/files/es/web/css/border-bottom/index.md
@@ -13,7 +13,7 @@ La propiedad `border-bottom` permite de definir de una vez todas las propiedades
 - Se aplica a : todos los elementos
 - {{ Cssxref("inheritance", "Valor heredado") }}: no
 - Porcentajes: N/A
-- Medio: {{ Xref_cssvisual() }}
+- Medio: {{cssxref("Media/Visual", "visual")}}
 - {{ Cssxref("computed value", "Valor calculado") }}: ver propiedades individuales
 
 ### Sintaxis

--- a/files/es/web/css/border-collapse/index.md
+++ b/files/es/web/css/border-collapse/index.md
@@ -15,7 +15,7 @@ En el modelo de separación, cada celda adyacente tiene su propio borde (la dist
 
 - {{ Cssxref("initial", "Valor inicial") }}: {{ Cssxref("separate", "separado") }}
 - {{ Cssxref("inheritance", "Valor heredado") }}: Yes
-- Media: {{ Xref_cssvisual() }}
+- Media: {{cssxref("Media/Visual", "visual")}}
 - {{ Cssxref("computed value", "Valor calculado") }}:
 
 ### Sintaxis

--- a/files/es/web/css/border-left-color/index.md
+++ b/files/es/web/css/border-left-color/index.md
@@ -11,7 +11,7 @@ slug: Web/CSS/border-left-color
 - Se aplica a : todos los elementos
 - {{ Xref_cssinherited() }}: no
 - Porcentajes: N/A
-- Media: {{ Xref_cssvisual() }}
+- Media: {{cssxref("Media/Visual", "visual")}}
 - {{ Xref_csscomputed() }}: cuando son tomados de la propiedad 'color',los valores computarizados de 'color'; de otra manera como sean especificados.
 
 ### Sintaxis

--- a/files/es/web/css/border-spacing/index.md
+++ b/files/es/web/css/border-spacing/index.md
@@ -12,7 +12,7 @@ La propiedad de {{ Cssxref("border-spacing", "espaciado de borde") }} especifica
 - {{ Cssxref("initial", "Valor inicial") }}: 0
 - Se aplica a: tablas y elementos con la propiedad `inline-table`
 - {{ Cssxref("inheritance", "Valor heredado") }}: sí
-- Medio: {{ Xref_cssvisual() }}
+- Medio: {{cssxref("Media/Visual", "visual")}}
 - {{ Cssxref("computed value", "Valor calculado") }}: dos largos absolutos.
 
 ### Sintaxis

--- a/files/es/web/css/line-height/index.md
+++ b/files/es/web/css/line-height/index.md
@@ -13,7 +13,7 @@ La propiedad [CSS](/es/docs/Web/CSS) `line-height` establece la altura de una ca
 - Aplicable a: todos los elementos.
 - {{ Cssxref("inheritance", "Valor heredado") }}: sí
 - Porcentajes: se refieren a tamaño de la fuente del elemento mismo.
-- Medio: {{ Xref_cssvisual() }}
+- Medio: {{cssxref("Media/Visual", "visual")}}
 - {{ Cssxref("computed value", "Valor calculado") }}: para los valores \<length> y \<percentage>, el valor absoluto, en otro caso, como se especifica.
 
 ## Syntax

--- a/files/es/web/css/max-height/index.md
+++ b/files/es/web/css/max-height/index.md
@@ -13,7 +13,7 @@ La propiedad `max-height` se utiliza para definir la altura máxima de un elemen
 - Se aplica a : elementos de bloque o remplazados
 - {{ Cssxref("inheritance", "Valor heredado") }}: no
 - Porcentajes: se refiere a la altura del bloque contenedor.
-- Medio: {{ Xref_cssvisual() }}
+- Medio: {{cssxref("Media/Visual", "visual")}}
 - {{ Cssxref("computed value", "Valor calculado") }}:
 
 ### Sintaxis

--- a/files/es/web/css/min-width/index.md
+++ b/files/es/web/css/min-width/index.md
@@ -13,7 +13,7 @@ La propiedad `min-width` se usa para determinar la anchura mínima de un element
 - Aplicable a: elementos de tipo bloque.
 - {{ Xref_cssinherited() }}: no
 - Porcentajes: se refieren a la anchura del bloque contenedor.
-- Media: {{ Xref_cssvisual() }}
+- Media: {{cssxref("Media/Visual", "visual")}}
 - {{ Xref_csscomputed() }}:
 
 ### Sintaxis

--- a/files/es/web/css/right/index.md
+++ b/files/es/web/css/right/index.md
@@ -15,7 +15,7 @@ Para los elementos con una posición absoluta (aquellos que tienen la propiedad 
 - Se aplica a: [positioned elements](/es/CSS/position)
 - {{ Xref_cssinherited() }}: no
 - Porcentajes: se refiere al ancho del bloque contenedor.
-- Media: {{ Xref_cssvisual() }}
+- Media: {{cssxref("Media/Visual", "visual")}}
 - {{ Xref_csscomputed() }}: valor absoluto, porcentaje ó auto.
 
 ### Sintaxis

--- a/files/es/web/css/top/index.md
+++ b/files/es/web/css/top/index.md
@@ -19,7 +19,7 @@ Cuando se define tanto la propiedad `top` como {{cssxref("bottom")}} para un ele
 - Aplicable a: [Posicionar Elementos](/es/CSS/position)
 - {{ Xref_cssinherited() }}: no
 - Porcentajes: se refieren a la altura del bloque contenedor.
-- Medio: {{ Xref_cssvisual() }}
+- Medio: {{cssxref("Media/Visual", "visual")}}
 - {{ Xref_csscomputed() }}: valor absoluto, porcentaje ó auto.
 
 ### Sintaxis

--- a/files/es/web/css/visibility/index.md
+++ b/files/es/web/css/visibility/index.md
@@ -16,7 +16,7 @@ La propiedad `visibility` se usa para dos efectos:
 - Se aplica a: Todos los elementos.
 - {{ Cssxref("inheritance", "Valor heredado") }}: Sí
 - Porcentajes: N/A
-- Medio: {{ Xref_cssvisual() }}
+- Medio: {{cssxref("Media/Visual", "visual")}}
 - {{ Cssxref("computed value", "Valor calculado") }}: Como se especifica.
 
 ### Sintaxis

--- a/files/ja/web/css/-webkit-mask-box-image/index.md
+++ b/files/ja/web/css/-webkit-mask-box-image/index.md
@@ -10,7 +10,7 @@ slug: Web/CSS/-webkit-mask-box-image
 - {{ Xref_cssinitial() }}: なし
 - 適用先: すべての要素
 - {{ Xref_cssinherited() }}: なし
-- メディア: {{ Xref_cssvisual() }}
+- メディア: {{cssxref("Media/Visual", "visual")}}
 - {{ Xref_csscomputed() }}: 指定通り
 
 ## 構文


### PR DESCRIPTION
This PR replaces all of the remaining calls to the deprecated `{{xref_cssvisual}}` with the `{{cssxref}}` macro it calls within.
