### PR TITLE
chore(ci/pr-check_redirects): remove path filter to always run the required test

### DIFF
--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - .nvmrc
-      - files/**
-      - .github/workflows/pr-check_redirects.yml
 
 jobs:
   check_redirects:

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -14,12 +14,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # This is a "required" workflow so path filtering can not be used:
+      # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+      # We have to rely on a custom filtering mechanism to run the checks only if required files are modified.
+      - uses: dorny/paths-filter@v2
+        name: See if any file needs checking
+        id: filter
+        with:
+          filters: |
+            required_files:
+              - ".nvmrc"
+              - "files/**"
+              - ".github/workflows/pr-check_redirects.yml"
+
       - uses: actions/checkout@v4
+        if: steps.filter.outputs.required_files == 'true'
         with:
           repository: mdn/content
           path: mdn/content
 
       - name: Setup Node.js environment
+        if: steps.filter.outputs.required_files == 'true'
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -27,6 +42,7 @@ jobs:
           cache-dependency-path: mdn/content/yarn.lock
 
       - name: Install all yarn packages
+        if: steps.filter.outputs.required_files == 'true'
         working-directory: ${{ github.workspace }}/mdn/content
         run: |
           yarn --frozen-lockfile
@@ -35,6 +51,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check redirects file(s)
+        if: steps.filter.outputs.required_files == 'true'
         env:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/files


### PR DESCRIPTION
### Description

The pr-check_redirects workflow is now a required ci test. It should always be triggerd, removing the path filter as the [upstream does](https://github.com/mdn/content/pull/28277).

### Related issues and pull requests

mdn/content#28277
mdn/content#30210
