### PR TITLE
`fr` - Initial translation for Glossary/UUID and crypto/randomuuid()

### DIFF
--- a/files/fr/glossary/uuid/index.md
+++ b/files/fr/glossary/uuid/index.md
@@ -11,7 +11,7 @@ Un **identifiant universel unique** (dont l'acronyme anglais est **UUID** pour <
 
 Les systèmes informatiques génèrent des UUID localement en utilisant de très grands nombres aléatoires. En théorie, ces identifiants n'ont pas à être globalement uniques, même si la probabilité d'obtenir des doublons est très faible. Si un ou des systèmes ont besoin d'identifiants absolument uniques, ceux-ci doivent alors être émis par une autorité centrale.
 
-Les UUID sont des valeurs sur 128 bits qui sont représentées généralement comme une chaîne de 36 caractères au format `123e4567-e89b-12d3-a456-426614174000` (soit 5 chaînes de chiffres hexadécimaux, séparées par des tiret). Il existe plusieurs versions et formats qui dépendent du mode de calcul, certains UUID incluent par exemple une information temporelle.
+Les UUID sont des valeurs sur 128 bits qui sont représentées généralement comme une chaîne de 36 caractères au format `123e4567-e89b-12d3-a456-426614174000` (soit 5 chaînes de chiffres hexadécimaux, séparées par des tirets). Il existe plusieurs versions et formats qui dépendent du mode de calcul, certains UUID incluent par exemple une information temporelle.
 
 La définition formelle d'un UUID peut être trouvée dans [la RFC4122](https://www.rfc-editor.org/rfc/rfc4122).
 

--- a/files/fr/glossary/uuid/index.md
+++ b/files/fr/glossary/uuid/index.md
@@ -1,0 +1,21 @@
+---
+title: UUID
+slug: Glossary/UUID
+l10n:
+  sourceCommit: 59adb56b83da91ee1744b723f2f7a37195c2ec82
+---
+
+{{GlossarySidebar}}
+
+Un **identifiant universel unique** (dont l'acronyme anglais est **UUID** pour <i lang="en">Universally Unique Identifier</i>) est un libellé utilisé pour identifier de façon unique une ressource parmi toutes les autres ressources du même type.
+
+Les systèmes informatiques génèrent des UUID localement en utilisant de très grands nombres aléatoires. En théorie, ces identifiants n'ont pas à être globalement uniques, même si la probabilité d'obtenir des doublons est très faible. Si un ou des systèmes ont besoin d'identifiants absolument uniques, ceux-ci doivent alors être émis par une autorité centrale.
+
+Les UUID sont des valeurs sur 128 bits qui sont représentées généralement comme une chaîne de 36 caractères au format `123e4567-e89b-12d3-a456-426614174000` (soit 5 chaînes de chiffres hexadécimaux, séparées par des tiret). Il existe plusieurs versions et formats qui dépendent du mode de calcul, certains UUID incluent par exemple une information temporelle.
+
+La définition formelle d'un UUID peut être trouvée dans [la RFC4122](https://www.rfc-editor.org/rfc/rfc4122).
+
+## Voir aussi
+
+- [UUID](https://fr.wikipedia.org/wiki/Universally_unique_identifier) sur Wikipédia
+- [`Crypto.randomUUID()`](/fr/docs/Web/API/Crypto/randomUUID)

--- a/files/fr/web/api/crypto/randomuuid/index.md
+++ b/files/fr/web/api/crypto/randomuuid/index.md
@@ -1,0 +1,49 @@
+---
+title: "Crypto : méthode randomUUID()"
+slug: Web/API/Crypto/randomUUID
+l10n:
+  sourceCommit: 59adb56b83da91ee1744b723f2f7a37195c2ec82
+---
+
+{{APIRef("Web Crypto API")}}{{SecureContext_header}}
+
+La méthode **`randomUUID()`**, rattachée à l'interface [`Crypto`](/fr/docs/Web/API/Crypto), est utilisée pour générer un [UUID](/fr/docs/Glossary/UUID) v4 en utilisant un générateur de nombres aléatoires sécurisé.
+
+## Syntaxe
+
+```js-nolint
+randomUUID()
+```
+
+### Paramètres
+
+Aucun.
+
+### Valeur de retour
+
+Une chaîne de caractères générées aléatoirement et qui est un UUID au format v4 sur 36 caractères.
+
+## Exemples
+
+On accède à cette méthode à l'aide de la propriété globale [`crypto`](/fr/docs/Web/API/crypto_property).
+
+```js
+/* Si self.crypto.randomUUID() est bien disponible : */
+
+const uuid = self.crypto.randomUUID();
+console.log(uuid); // par exemple "36b8f84d-df4e-4d49-b662-bcde71a8764f"
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- [L'API Web Crypto](/fr/docs/Web/API/Web_Crypto_API)
+- La propriété globale [`crypto`](/fr/docs/Web/API/crypto_property) qui permet d'obtenir un objet [`Crypto`](/fr/docs/Web/API/Crypto).
+- [`Crypto.getRandomValues()`](/fr/docs/Web/API/Crypto/getRandomValues) qui permet d'obtenir des valeurs aléatoires sécurisées sur autant d'octets que souhaité.


### PR DESCRIPTION
Part of #16598 
Went with translating Web/API/Crypto/randomUUID as well :) 