### PR TITLE
zh-cn: sync the `Data.toJSON()` example from en-US

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/date/tojson/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/tojson/index.md
@@ -11,27 +11,23 @@ slug: Web/JavaScript/Reference/Global_Objects/Date/toJSON
 
 ## 语法
 
-```plain
-dateObj.toJSON()
+```js-nolint
+toJSON()
 ```
 
 ## 描述
 
-{{jsxref("Date")}} 实例引用一个具体的时间点。调用 `toJSON()` 返回一个 JSON 格式字符串 (使用 {{jsxref("Date.prototype.toISOString()", "toISOString()")}})，表示该日期对象的值。默认情况下，这个方法常用于 {{Glossary("JSON")}}序列化{{jsxref("Date")}}对象。
+{{jsxref("Date")}} 实例引用一个具体的时间点。调用 `toJSON()` 返回一个 JSON 格式字符串（使用 {{jsxref("Date.prototype.toISOString()", "toISOString()")}}），表示该日期对象的值。默认情况下，这个方法常用于 {{Glossary("JSON")}} 序列化 {{jsxref("Date")}} 对象。
 
-## 样例
+## 示例
 
-### `toJSON()` 样例
+### 使用 toJSON()
 
 ```js
-var date = new Date();
-console.log(date); //Thu Nov 09 2017 18:54:04 GMT+0800 (中国标准时间)
+const jsonDate = new Date(0).toJSON(); // '1970-01-01T00:00:00.000Z'
+const backToDate = new Date(jsonDate);
 
-var jsonDate = date.toJSON();
-console.log(jsonDate); //"2017-11-09T10:54:04.395Z"
-
-var backToDate = new Date(jsonDate);
-console.log(backToDate); //Thu Nov 09 2017 18:54:04 GMT+0800 (中国标准时间)
+console.log(jsonDate); // 1970-01-01T00:00:00.000Z
 ```
 
 ## 规范
@@ -42,7 +38,7 @@ console.log(backToDate); //Thu Nov 09 2017 18:54:04 GMT+0800 (中国标准时间
 
 {{Compat}}
 
-## 相关链接
+## 参见
 
 - {{jsxref("Date.prototype.toLocaleDateString()")}}
 - {{jsxref("Date.prototype.toTimeString()")}}

--- a/files/zh-cn/web/javascript/reference/global_objects/date/tojson/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/tojson/index.md
@@ -28,7 +28,7 @@ var date = new Date();
 console.log(date); //Thu Nov 09 2017 18:54:04 GMT+0800 (中国标准时间)
 
 var jsonDate = date.toJSON();
-console.log(jsonDate); //"2017-11-09T10:51:11.395Z"
+console.log(jsonDate); //"2017-11-09T10:54:04.395Z"
 
 var backToDate = new Date(jsonDate);
 console.log(backToDate); //Thu Nov 09 2017 18:54:04 GMT+0800 (中国标准时间)


### PR DESCRIPTION
The second log should be the same 54:04

### Motivation

Make it clearer.


