### PR TITLE
[zh-cn]: fix typo

### DIFF
--- a/files/zh-cn/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/zh-cn/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -266,7 +266,7 @@ myVariable = '韩梅梅';
 ```js
 let iceCream = "chocolate";
 if (iceCream === "chocolate") {
-  alert("我最喜欢巧克力冰激淋了。");
+  alert("我最喜欢巧克力冰淇淋了。");
 } else {
   alert("但是巧克力才是我的最爱呀……");
 }


### PR DESCRIPTION
### Description

Adjusted the Chinese translation for 'ice cream' from '冰激淋' to '冰淇淋' for more commonly used terminology in Simplified Chinese context.

### Additional details

Supported by the official Chinese document GB/T 31114-2014, which designates '冰淇淋' as the standard term for 'ice cream'.