### PR TITLE
[es]: add sidebar to all Glossary pages

### DIFF
--- a/files/es/glossary/abstraction/index.md
+++ b/files/es/glossary/abstraction/index.md
@@ -3,6 +3,8 @@ title: Abstracción
 slug: Glossary/Abstraction
 ---
 
+{{GlossarySidebar}}
+
 En {{Glossary("computer programming", "programación")}}, una abstracción es una manera de reducir la complejidad y permitir un diseño e implementación más eficientes en sistemas de software complejos. Oculta la dificultad técnica de los sistemas detrás de {{Glossary("API", "APIs")}} más simples.
 
 ## Ventajas de la Abstracción

--- a/files/es/glossary/accessibility/index.md
+++ b/files/es/glossary/accessibility/index.md
@@ -3,6 +3,8 @@ title: Accesibilidad
 slug: Glossary/Accessibility
 ---
 
+{{GlossarySidebar}}
+
 _La accesibilidad web_ (**A11Y**) hace referencia a las buenas prácticas para mantener la usabilidad de un sitio web a pesar de las restricciones físicas y técnicas. La accesibilidad web se define formalmente y es discutida en el {{Glossary("W3C")}} a través del {{Glossary("WAI","Web Accessibility Initiative")}} (WAI).
 
 ## Saber más

--- a/files/es/glossary/accessibility_tree/index.md
+++ b/files/es/glossary/accessibility_tree/index.md
@@ -3,6 +3,8 @@ title: Árbol de accesibilidad (AOM)
 slug: Glossary/Accessibility_tree
 ---
 
+{{GlossarySidebar}}
+
 El **árbol de accesibilidad** o **modelo de objeto de accesibillidad (AOM)**, contiene información relacionada con {{Glossary("accessibility")}} para la mayoría de los elementos HTML.
 
 Los navegadores convierten el lenguaje markup en una representación interna denominada _[DOM tree](/es/docs/Web/API/Document_object_model/How_to_create_a_DOM_tree)_ (árbol DOM). El árbol DOM contiene objetos para todos los elementos de markup, atributos y nodos de texto. Luego, los navegadores crean un árbol de accesibilidad basado en el árbol de DOM, el cual es usado por Accessibility APIs de plataformas específicas para las tecnologías asistenciales como los lectores de pantalla.
@@ -20,13 +22,8 @@ Hay cuatro elementos en un árbol de objeto de accesibilidad:
 
 Además, el árbol de accesibilidad usualmente contiene información sobre lo que se puede hacer con un elemento: _seguir_ un enlace, _completar_ un cuadro de texto, etc.
 
-<section id="Quick_links">
- <ol>
-  <li><a href="/es/docs/Glossary">Glossary</a>
-   <ol>
-    <li>{{Glossary("Accessibility")}}</li>
-    <li>{{Glossary("ARIA")}}</li>
-   </ol>
-  </li>
- </ol>
-</section>
+## Véase también
+
+- [Glosario de MDN Web Docs](/es/docs/Glossary)
+  - {{Glossary("Accessibility")}}
+  - {{Glossary("ARIA")}}

--- a/files/es/glossary/adobe_flash/index.md
+++ b/files/es/glossary/adobe_flash/index.md
@@ -3,6 +3,8 @@ title: Adobe Flash
 slug: Glossary/Adobe_Flash
 ---
 
+{{GlossarySidebar}}
+
 Flash es una tecnología obsolescente desarrollada por Adobe que hace posible crear aplicaciones Web ricas, gráficos vectoriales y multimedia. Para utilizar Flash dentro de un {{Glossary("Browser","web browser")}} es necesario instalar el complemento adecuado.
 
 ## Aprende más

--- a/files/es/glossary/ajax/index.md
+++ b/files/es/glossary/ajax/index.md
@@ -3,6 +3,8 @@ title: AJAX
 slug: Glossary/AJAX
 ---
 
+{{GlossarySidebar}}
+
 AJAX (de las siglas en Inglés **A**synchronous {{glossary("JavaScript")}} **A**nd {{glossary("XML")}} ) es una práctica de programación utilizada para construir páginas web más complejas y dinámicas, utilizando una tecnología conocida como {{Glossary("XHR_(XMLHttpRequest)","XMLHttpRequest")}}.
 
 Lo que AJAX nos permite hacer, es modificar partes específicas del {{Glossary("DOM")}} de una página {{Glossary("HTML")}} sin la necesidad de refrescar la página entera. AJAX tambien nos permite trabajar asincrónicamente; esto significa que tu código seguirá corriendo mientras esa parte de la página de tu sitio web intenta recargarse (en comparación, una carga síncrona bloquearía tu código hasta que esa parte de la página web terminara de recargarse)

--- a/files/es/glossary/algorithm/index.md
+++ b/files/es/glossary/algorithm/index.md
@@ -3,4 +3,6 @@ title: Algoritmo
 slug: Glossary/Algorithm
 ---
 
+{{GlossarySidebar}}
+
 Un algoritmo es un conjunto de instrucciones autocontenidas que realiza una función.

--- a/files/es/glossary/api/index.md
+++ b/files/es/glossary/api/index.md
@@ -3,6 +3,8 @@ title: API
 slug: Glossary/API
 ---
 
+{{GlossarySidebar}}
+
 ## Resumen
 
 Una **_Interfaz de Programación de Aplicaciones_** (API, por sus siglas en inglés) define un conjunto de directivas que pueden ser usadas para tener una pieza de software funcionando con algunas otras.

--- a/files/es/glossary/apple_safari/index.md
+++ b/files/es/glossary/apple_safari/index.md
@@ -3,6 +3,8 @@ title: Apple Safari
 slug: Glossary/Apple_Safari
 ---
 
+{{GlossarySidebar}}
+
 [Safari](http://www.apple.com/safari/) es un {{Glossary("Browser","navegador web")}} desarrollado por Apple y ligado a Mac OS X y iOS. Está basado en el motor de código abierto [WebKit](http://www.webkit.org/).
 
 ## Saber más

--- a/files/es/glossary/application_context/index.md
+++ b/files/es/glossary/application_context/index.md
@@ -3,6 +3,8 @@ title: Contexto de aplicación
 slug: Glossary/Application_context
 ---
 
+{{GlossarySidebar}}
+
 Un contexto de aplicación es un [contexto de navegación](/es/docs/Glossary/Browsing_context) de nivel superior que tiene aplicado un [manifiesto](/es/docs/Web/Manifest).
 
 Si un contexto de aplicación es creado como resultado de una petición al agente usuario para que navegue a un enlace profundo, el agente usuario debe navegar inmediatamente hacia al enlace profundo con sustitución habilitada. De otra manera, cuando se crea el contexto de aplicación, el agente usuario debe navegar inmediatamente a la URL de inicio con sustitución habilitada.

--- a/files/es/glossary/argument/index.md
+++ b/files/es/glossary/argument/index.md
@@ -3,6 +3,8 @@ title: Argumento
 slug: Glossary/Argument
 ---
 
+{{GlossarySidebar}}
+
 Un argumento es un valor (primitivo u objeto) (Véase {{glossary("value")}}, {{Glossary("primitive")}}, {{Glossary("object")}}) pasado como valor de entrada a una función ({{Glossary("function")}}).
 
 ## Saber más

--- a/files/es/glossary/aria/index.md
+++ b/files/es/glossary/aria/index.md
@@ -3,6 +3,8 @@ title: ARIA
 slug: Glossary/ARIA
 ---
 
+{{GlossarySidebar}}
+
 **ARIA** (_Accessible Rich {{glossary("Internet")}} Applications_) es una especificación de la {{Glossary("W3C")}} para agregar semantica y otros metadatos a {{Glossary("HTML")}} para ayudar a los usuarios con tecnologia de apoyo.
 
 Por ejemplo, puedes agregar el atributo `role="alert"` a un {{HTMLElement("p")}} {{glossary("tag")}} para notificar a un usuario con discapacidad visual que una información es importante .

--- a/files/es/glossary/arpa/index.md
+++ b/files/es/glossary/arpa/index.md
@@ -3,6 +3,8 @@ title: ARPA
 slug: Glossary/ARPA
 ---
 
+{{GlossarySidebar}}
+
 **.arpa** (parametros de dirección y enrutamiento) es un {{glossary("TLD","dominio de alto nivel")}} usado para propositos de infraestructura de Internet, especialmente busqueda inversa de DNS (ej., encontrar el {{glossary('nombre de dominio')}} para una {{glossary("dirección IP")}}) suministrada.
 
 ## Learn more

--- a/files/es/glossary/arpanet/index.md
+++ b/files/es/glossary/arpanet/index.md
@@ -3,6 +3,8 @@ title: Arpanet
 slug: Glossary/Arpanet
 ---
 
+{{GlossarySidebar}}
+
 La **ARPAnet** (advanced research projects agency network) o Red de Angencias de Proyectos de Investigación Avanzada en español, era una red de computadoras construida en 1969 como un medio resistente para enviar datos militares y conectar principales grupos de investigación a través de los Estados Unidos. ARPAnet ejecutó NCP (network control protocol/protocolo de control de red) y subsequentemente la primera versión del protocolo de Internet o la suite {{glossary("TCP")}}/{{glossary("IPv6","IP")}}, teniendo la ARPAnet una descatada parte en la naciente {{glossary("Internet")}}. ARPAnet finalizó a comienzos de 1990.
 
 ## Saber más

--- a/files/es/glossary/array/index.md
+++ b/files/es/glossary/array/index.md
@@ -3,6 +3,8 @@ title: Arreglos (Matrices)
 slug: Glossary/Array
 ---
 
+{{GlossarySidebar}}
+
 Un arreglo (matriz) es una colección ordenada de datos (tanto {{glossary("Primitivo", "primitivos")}} u {{glossary("Object", "objetos")}} dependiendo del lenguaje). Los arreglos (matrices) se emplean para almacenar multiples valores en una sola variable, frente a las variables que sólo pueden almacenar un valor (por cada variable).
 
 Cada elemento del arreglo (matriz) tiene un número al que está asociado, llamado **"índice numérico"** (numeric index), que permite acceder a él.

--- a/files/es/glossary/ascii/index.md
+++ b/files/es/glossary/ascii/index.md
@@ -3,6 +3,8 @@ title: ASCII
 slug: Glossary/ASCII
 ---
 
+{{GlossarySidebar}}
+
 **ASCII** (_American Standard Code for Information Interchange_) es uno de los métodos de codificación más utilizados por las computadoras para convertir letras, números, signos de puntuación y códigos de control en formato digital. Desde 2007, {{Glossary("UTF-8")}} lo reemplazó en la Web.
 
 ## Aprender más

--- a/files/es/glossary/asynchronous/index.md
+++ b/files/es/glossary/asynchronous/index.md
@@ -3,6 +3,8 @@ title: Asíncrono
 slug: Glossary/Asynchronous
 ---
 
+{{GlossarySidebar}}
+
 El término **asíncrono** se refiere al concepto de que más de una cosa ocurre al mismo tiempo, o múltiples cosas relacionadas ocurren sin esperar a que la previa se haya completado. En informática, la palabra "asíncrono" se usa en los siguientes contextos:
 
 - Redes y comunicaciones

--- a/files/es/glossary/atag/index.md
+++ b/files/es/glossary/atag/index.md
@@ -3,6 +3,8 @@ title: ATAG
 slug: Glossary/ATAG
 ---
 
+{{GlossarySidebar}}
+
 ATAG (Authoring Tool {{glossary("Accessibility")}} Guidelines/Pautas de accesibilidad de herramientas de autor) es una recomendación de la {{Glossary("W3C")}} para la construcción de herramientas de autor y producir contenido accesible.
 
 ## Saber más

--- a/files/es/glossary/attribute/index.md
+++ b/files/es/glossary/attribute/index.md
@@ -3,6 +3,8 @@ title: Atributo
 slug: Glossary/Attribute
 ---
 
+{{GlossarySidebar}}
+
 Un atributo amplía una etiqueta ({{Glossary("tag")}}), cambiando su comportamiento o proporcionando metadatos. Un atributo tiene la forma nombre=valor (especificando el identificador del atributo y el valor asociado al atributo).
 
 ## Saber más

--- a/files/es/glossary/bandwidth/index.md
+++ b/files/es/glossary/bandwidth/index.md
@@ -3,6 +3,8 @@ title: Ancho de banda
 slug: Glossary/Bandwidth
 ---
 
+{{GlossarySidebar}}
+
 El ancho de banda es la medida de cuanta información puede pasar a través de una conexión de datos en un momento dado. El ancho de banda suele medirse en múltipos de bits-por-segundo (bps), por ejemplo, megabits-por-segundo (Mbps) o gigabits-por-segundo (Gbps).
 
 ## Saber más

--- a/files/es/glossary/base64/index.md
+++ b/files/es/glossary/base64/index.md
@@ -3,6 +3,8 @@ title: Base64 codificando y decodificando
 slug: Glossary/Base64
 ---
 
+{{GlossarySidebar}}
+
 **Base64** es un grupo de esquemas de [codificación de binario a texto](https://es.wikipedia.org/wiki/Codificaci%C3%B3n_de_binario_a_texto) que representa los datos binarios mediante una cadena ASCII, traduciéndolos en una representación radix-64. El término _Base64_ se origina de un [sistema de codificación de transmisión de contenido MIME](https://es.wikipedia.org/wiki/Multipurpose_Internet_Mail_Extensions#Content-Transfer-Encoding) específico.
 
 Los esquemas de codificación Base64 son comúnmente usados cuando se necesita codificar datos binarios para que sean almacenados y transferidos sobre un medio diseñado para tratar con datos textuales. Esto es para asegurar que los datos se mantienen intactos y sin modificaciones durante la transmisión. Base64 es comúnmente usado en muchas aplicaciones, incluyendo la escritura de emails vía [MIME](https://es.wikipedia.org/wiki/Multipurpose_Internet_Mail_Extensions) y el almacenamiento de datos complejos en [XML](/es/docs/XML).

--- a/files/es/glossary/bigint/index.md
+++ b/files/es/glossary/bigint/index.md
@@ -3,6 +3,8 @@ title: BigInt
 slug: Glossary/BigInt
 ---
 
+{{GlossarySidebar}}
+
 En {{Glossary("JavaScript")}}, **BigInt** es un tipo de dato numerico que puede representar números enteros en el [formato de precision arbitrario](https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic). En otros lenguajes de programación pueden existir diferentes tipos numéricos, por ejemplo: enteros, flotantes, dobles o bignums (numeros grandes).
 
 ## Aprende más

--- a/files/es/glossary/blink/index.md
+++ b/files/es/glossary/blink/index.md
@@ -3,6 +3,8 @@ title: Blink
 slug: Glossary/Blink
 ---
 
+{{GlossarySidebar}}
+
 Blink es un motor de renderizado para [navegadores](/es/docs/Glossary/Browser) de código abierto desarrollado por Google, que forma parte de Chromium (y por lo tanto también de [Chrome](/es/docs/Glossary/Google_Chrome)). Concretamente, Blink es una copia de la librería WebCore de [WebKit](/es/docs/Glossary/WebKit), que se encarga del diseño, renderizado, y del [DOM](/es/docs/Glossary/DOM).
 
 ## Para saber más

--- a/files/es/glossary/block-level_content/index.md
+++ b/files/es/glossary/block-level_content/index.md
@@ -3,6 +3,8 @@ title: Elementos en bloque
 slug: Glossary/Block-level_content
 ---
 
+{{GlossarySidebar}}
+
 Los elementos, en HTML (lenguaje de marcas de hipertexto - **Hypertext Markup Language**) usualmente son elementos "en bloque" o [elementos "en línea"](/es/docs/Web/HTML/Elementos_en_línea). Un elemento en bloque ocupa todo el espacio de su elemento padre (contenedor), creando así un "bloque". Este artículo ayuda a explicar lo que esto significa.
 
 Los navegadores suelen mostrar el elemento a nivel de bloque con un salto de línea antes y después del elemento. El siguiente ejemplo demuestra la influencia elementos en bloque:

--- a/files/es/glossary/block/css/index.md
+++ b/files/es/glossary/block/css/index.md
@@ -3,6 +3,8 @@ title: Block (CSS)
 slug: Glossary/Block/CSS
 ---
 
+{{GlossarySidebar}}
+
 Un **bloque** en una página web es un {{glossary("elemento")}} {{glossary("HTML")}} que aparece en una nueva línea, por ejemplo debajo del elemento precedente y encima del siguiente elemento (comúnmente conocido como _block-level element)_. Por ejemplo, visto que {{htmlelement("a")}} es un _elemento en línea_ — puedes colocar varios enlaces uno al lado del otro en el código HTML y no se posicionarán en la misma línea como uno al otro en la salida representada.
 
 Usando la propiedad {{cssxref("display")}} puedes cambiar si un elemento se muestre en línea o en bloque (entre muchas otras opciones); los **bloques** también están sujetos a los efectos de posicionaresquemas y usar la propiedad {{cssxref("position")}}.

--- a/files/es/glossary/block/index.md
+++ b/files/es/glossary/block/index.md
@@ -3,6 +3,8 @@ title: Block
 slug: Glossary/Block
 ---
 
+{{GlossarySidebar}}
+
 El término **bloque** puede tener diferentes significados dependiendo del conexto. Puede referirse a:
 
 {{GlossaryDisambiguation}}

--- a/files/es/glossary/boolean/index.md
+++ b/files/es/glossary/boolean/index.md
@@ -3,6 +3,8 @@ title: Boolean
 slug: Glossary/Boolean
 ---
 
+{{GlossarySidebar}}
+
 En ciencias de informática, un **boolean** es un dato lógico que solo puede tener los valores true o false.
 
 ## Aprender más

--- a/files/es/glossary/breadcrumb/index.md
+++ b/files/es/glossary/breadcrumb/index.md
@@ -3,6 +3,8 @@ title: Miga de pan
 slug: Glossary/Breadcrumb
 ---
 
+{{GlossarySidebar}}
+
 Una **miga de pan**, o rastro de migas de pan, es una ayuda a la navegación que se sitúa normalmente entre la cabecera del sitio y el contenido principal y muestra, bien la jerarquía de la página actual en relación con la estructura del sitio desde el nivel superior o bien una lista de los enlaces utilizados para llegar a la página actual en el orden en que se han visitado.
 
 Una miga de pan para este documento se vería más o menos así:

--- a/files/es/glossary/browser/index.md
+++ b/files/es/glossary/browser/index.md
@@ -3,6 +3,8 @@ title: Navegador
 slug: Glossary/Browser
 ---
 
+{{GlossarySidebar}}
+
 Un _Navegador web_ es un programa o aplicación que da acceso a la [Web](/es/docs/Glossary/World_Wide_Web), y permite a los usuarios el acceso a más páginas a través de [hipervínculos](/es/docs/Glossary/Hyperlink).
 
 ## Para saber más

--- a/files/es/glossary/browsing_context/index.md
+++ b/files/es/glossary/browsing_context/index.md
@@ -3,6 +3,8 @@ title: Contexto de navegación
 slug: Glossary/Browsing_context
 ---
 
+{{GlossarySidebar}}
+
 Un **contexto de navegación** es el entorno en el que un {{glossary("navegador")}} muestra un {{domxref("Documento")}} (normalmente una pestaña, pero posiblemente también una ventana o un marco (_frame_) dentro de una página).
 
 Cada contexto de navegación tiene un {{glossary("origen")}} específico, el origen del documento activo y un historial que enumera todos los documentos mostrados en orden.
@@ -15,5 +17,3 @@ La comunicación entre contextos de navegación está severamente restringida. E
 
 - [Browsing context on WHATWG](https://html.spec.whatwg.org/multipage/browsers.html#windows)
 - [Browsing context on W3C](http://w3c.github.io/html/browsers.html#sec-browsing-contexts)
-
-{{QuickLinksWithSubpages("/es/docs/Glossary")}}

--- a/files/es/glossary/buffer/index.md
+++ b/files/es/glossary/buffer/index.md
@@ -3,6 +3,8 @@ title: Buffer
 slug: Glossary/Buffer
 ---
 
+{{GlossarySidebar}}
+
 Un búfer es un espacio de memoria en el que se almacenan datos de forma temporal mientras se están transfiriendo de un sitio a otro.
 
 ## Saber más

--- a/files/es/glossary/cache/index.md
+++ b/files/es/glossary/cache/index.md
@@ -3,6 +3,8 @@ title: Caché
 slug: Glossary/Cache
 ---
 
+{{GlossarySidebar}}
+
 La **caché** (o caché web) es un componente que almacena temporalmente respuestas HTTP para que puedan ser usadas por peticiones HTTP posteriores mientras cumplan ciertas condiciones.
 
 ## Saber más

--- a/files/es/glossary/cacheable/index.md
+++ b/files/es/glossary/cacheable/index.md
@@ -3,6 +3,8 @@ title: Cacheable
 slug: Glossary/Cacheable
 ---
 
+{{GlossarySidebar}}
+
 Una respuesta **_cacheable_** es una respuesta HTTP que se puede almacenar en caché, que se almacena para recuperarla y usarla más tarde, guardando una nueva solicitud en el servidor. No todas las respuestas HTTP se pueden almacenar en caché, estas son las siguientes restricciones para que una respuesta HTTP se almacene en caché:
 
 - El método utilizado en la solicitud se puede almacenar en caché, es decir, un método {{HTTPMethod("GET")}} o {{HTTPMethod("HEAD")}}. Una respuesta a una solicitud {{HTTPMethod("POST")}} o {{HTTPMethod("PATCH")}} también se puede almacenar en caché si se indica frescura y el encabezado {{HTTPHeader("Content-Location")}} es establecido, pero esto rara vez se implementa. (Por ejemplo, Firefox no lo admite según <https://bugzilla.mozilla.org/show_bug.cgi?id=109553>.) Otros métodos, como {{HTTPMethod("PUT")}} o {{HTTPMethod("DELETE")}} no se pueden almacenar en caché y su resultado no se puede almacenar en caché.

--- a/files/es/glossary/call_stack/index.md
+++ b/files/es/glossary/call_stack/index.md
@@ -3,6 +3,8 @@ title: Pila de llamadas
 slug: Glossary/Call_stack
 ---
 
+{{GlossarySidebar}}
+
 Una **pila de llamadas** es un mecanismo para que un intérprete (como el intérprete de JavaScript en un navegador web) realice un seguimiento de en que lugar se llama a múltiples {{glossary("function","funciones")}}, qué función se esta ejecutando actualmente y qué funciones son llamadas desde esa función, etc.
 
 - Cuando un script llama a una función, el intérprete la añade a la pila de llamadas y luego empieza a ejecutar la función.
@@ -59,13 +61,7 @@ El código del ejemplo se ejecutaría de la siguiente manera:
 
 En resumen, empezamos con una lista de la pila llamadas vacía. Cuando invocamos una función, ésta es automáticamente añadida a la pila de llamadas. Una vez ha ejecutado todo su código, también de manera automática es eliminada de la pila de llamadas. Finalmente, la pila de llamadas vuelve a estar vacía.
 
-<section id="Quick_links">
- <ul>
-  <li><a href="/es/docs/Glossary">Glosario</a>
-   <ul>
-    <li>{{Glossary("Call stack", "Pila de llamadas")}}</li>
-    <li>{{Glossary("function", "Función")}}</li>
-   </ul>
-  </li>
- </ul>
-</section>
+## Véase también
+
+- [Glosario de MDN Web Docs](/es/docs/Glossary)
+  - {{Glossary("function", "Función")}}

--- a/files/es/glossary/callback_function/index.md
+++ b/files/es/glossary/callback_function/index.md
@@ -3,6 +3,8 @@ title: Función Callback
 slug: Glossary/Callback_function
 ---
 
+{{GlossarySidebar}}
+
 Una función de callback es una función que se pasa a otra función como un argumento, que luego se invoca dentro de la función externa para completar algún tipo de rutina o acción.
 
 Ejemplo:

--- a/files/es/glossary/canvas/index.md
+++ b/files/es/glossary/canvas/index.md
@@ -3,6 +3,8 @@ title: Canvas
 slug: Glossary/Canvas
 ---
 
+{{GlossarySidebar}}
+
 El **elemento canvas** forma parte de [HTML5](https://es.wikipedia.org/wiki/HTML5) y habilita la [representación (rendering)](https://es.wikipedia.org/wiki/Renderizaci%C3%B3n) dinámica y en [scripts](https://es.wikipedia.org/wiki/Script) de figuras en 2D y 3D de imágenes de [mapas de Bits](https://es.wikipedia.org/wiki/Bitmap).
 
 Es a un bajo nivel, un modelo procedimental que actualiza un [mapa de bits](https://es.wikipedia.org/wiki/Bitmap) y no tiene un [grafo de escena](https://en.wikipedia.org/wiki/Scene_graph) integrado. Proporciona una zona gráfica vacía en la cual {{Glossary("JavaScript")}} {{Glossary("API","APIs")}} específicas pueden dibujar (como Canvas 2D o {{Glossary("WebGL")}}).

--- a/files/es/glossary/card_sorting/index.md
+++ b/files/es/glossary/card_sorting/index.md
@@ -3,6 +3,8 @@ title: Clasificación por tarjetas (card sorting)
 slug: Glossary/Card_sorting
 ---
 
+{{GlossarySidebar}}
+
 La clasificación por tarjetas (card sorting) es una técnica simple utilizada en la {{glossary("Information architecture", "arquitectura de la información")}} en la cual las personas involucradas en el diseño de una página web (u otro tipo de producto) están invitadas a describir el contenido / servicios / características que creen que el producto debería contener, para luego organizar estas características dentro de categorías o grupos. Esto se puede usar, por ejemplo, para determinar qué debe aparecer en cada página de una aplicación web. El nombre proviene del hecho de que a menudo la clasificación de las cartas se lleva a cabo literalmente escribiendo los elementos que se van a clasificar en tarjetas, y luego apilando las tarjetas.
 
 ## Saber más

--- a/files/es/glossary/cdn/index.md
+++ b/files/es/glossary/cdn/index.md
@@ -3,6 +3,8 @@ title: CDN
 slug: Glossary/CDN
 ---
 
+{{GlossarySidebar}}
+
 Una **Red de distribución de contenidos** (_CDN en inglés_) es un grupo de servidores distribuidos en muchas ubicaciones. Estos servidores almacenan copias duplicadas de datos para que los servidores puedan cumplir con las solicitudes de datos en función de qué servidores están más cerca de los respectivos usuarios finales. Las CDN hacen que el servicio rápido se vea menos afectado por el alto tráfico.
 
 Los CDN se usan ampliamente para entregar hojas de estilo y archivos Javascript (activos estáticos) de bibliotecas como Bootstrap, jQuery, etc. Es preferible usar CDN para esos archivos de biblioteca por varias razones:

--- a/files/es/glossary/challenge/index.md
+++ b/files/es/glossary/challenge/index.md
@@ -3,6 +3,8 @@ title: Protocolos desafío-respuesta
 slug: Glossary/Challenge
 ---
 
+{{GlossarySidebar}}
+
 En protocolos de seguridad, un _desafío_ es una información enviada al cliente por el servidor con el fin de generar una respuesta diferente cada vez . Los protocolos desafío-respuesta son una forma de batallar contra los [ataques de REPLAY](https://es.wikipedia.org/wiki/Ataque_de_REPLAY) donde un atacante escucha los mensajes previos y los reenvía en un momento posterior para obtener las mismas credenciales que el mensaje original.
 
 El [protocolo de autenticación HTTP](/es/docs/Web/HTTP/Authentication) está basado en los protocolos desafío-respuesta, aunque la autenticación "Basic" no usa un desafío real (el _realm_ siempre es el mismo).

--- a/files/es/glossary/character/index.md
+++ b/files/es/glossary/character/index.md
@@ -3,6 +3,8 @@ title: Caracter
 slug: Glossary/Character
 ---
 
+{{GlossarySidebar}}
+
 Un _caracter_ es un símbolo (letras, números, puntuación) o un caracter de "control" que no se imprime (p. ej., Retorno de carro o guión suave — `soft hypen`). {{Glossary("UTF-8")}} es el conjunto de caracteres más común e incluye los grafemas de los lenguajes humanos más populares.
 
 ## Aprende más

--- a/files/es/glossary/character_encoding/index.md
+++ b/files/es/glossary/character_encoding/index.md
@@ -3,6 +3,8 @@ title: Codificación de caracteres
 slug: Glossary/Character_encoding
 ---
 
+{{GlossarySidebar}}
+
 Una codificación define cómo se traducen los bytes a texto y viceversa. Una secuencia de bytes se pueden interpretar de diferentes formas. Eligiendo una codificación en particular (como UTF-8), decimos como la secuencia de bytes debe ser interpretada.
 
 Por ejemplo, en HTML normalmente especificamos que la codificiación va a ser UTF-8 con la siguiente linea:

--- a/files/es/glossary/character_set/index.md
+++ b/files/es/glossary/character_set/index.md
@@ -3,25 +3,18 @@ title: Conjunto de caracteres
 slug: Glossary/Character_set
 ---
 
+{{GlossarySidebar}}
+
 Un **conjunto de caracteres** es un sistema de codificación para que las computadoras sepan cómo reconocer un {{Glossary("Character", "caracter")}}, incluidas letras, números, signos de puntuación y espacios en blanco.
 
 En épocas anteriores, los países desarrollaron sus propios conjuntos de caracteres debido a los diferentes idiomas utilizados, como los códigos Kanji JIS (por ejemplo, Shift-JIS, EUC-JP, etc.) para japonés, Big5 para chino tradicional y KOI8-R para ruso. Sin embargo, {{Glossary("Unicode")}} se convirtió gradualmente en el conjunto de caracteres más aceptable por su soporte de idiomas universal.
 
 Si un conjunto de caracteres se usa incorrectamente (por ejemplo, Unicode para un artículo codificado en Big5), es posible que no vean más que caracteres rotos, que se llaman [Mojibake](https://es.wikipedia.org/wiki/Mojibake).
 
-<section id="Quick_links">
-  <ol>
-    <li>Artículos de Wikipedia
-     <ol>
-      <li>[Codificación de caracteres](https://es.wikipedia.org/wiki/Codificación_de_caracteres)</li>
-      <li>[Mojibake](https://es.wikipedia.org/wiki/Mojibake)</li>
-     </ol>
-    </li>
-    <li><a href="/es/docs/Glossary">Glosario</a>
-     <ol>
-      <li>{{Glossary("Character", "Caracter")}}</li>
-      <li>{{Glossary("Unicode")}}</li>
-     </ol>
-    </li>
-  </ol>
-</section>
+## Véase también
+
+- [Codificación de caracteres](https://es.wikipedia.org/wiki/Codificación_de_caracteres) en Wikipedia
+- [Mojibake](https://es.wikipedia.org/wiki/Mojibake) en Wikipedia
+- [Glosario de MDN Web Docs](/es/docs/Glossary)
+  - {{Glossary("Character", "Caracter")}}
+  - {{Glossary("Unicode")}}

--- a/files/es/glossary/chrome/index.md
+++ b/files/es/glossary/chrome/index.md
@@ -3,6 +3,8 @@ title: Chrome
 slug: Glossary/Chrome
 ---
 
+{{GlossarySidebar}}
+
 En un navegador, Chrome es cualquier aspecto visible de un navegador aparte de las páginas web en sí (por ejemplo, barras de herramientas, barra de menús, pestañas). Esto no debe confundirse con el navegador {{glossary("Google Chrome")}}.
 
 ## Leer más

--- a/files/es/glossary/cia/index.md
+++ b/files/es/glossary/cia/index.md
@@ -3,6 +3,8 @@ title: CID
 slug: Glossary/CIA
 ---
 
+{{GlossarySidebar}}
+
 CID (Confidencialidad, Integridad, Disponibilidad) (también llamado la triada CID o la triada DIC) es un modelo que guía las políticas de una organización para la seguridad de la información.
 
 ## Saber más

--- a/files/es/glossary/cipher/index.md
+++ b/files/es/glossary/cipher/index.md
@@ -3,6 +3,8 @@ title: Algoritmo criptográfico
 slug: Glossary/Cipher
 ---
 
+{{GlossarySidebar}}
+
 En {{glossary("cryptography", "criptografía")}}, un algoritmo criptográfico es un algoritmo que puede {{glossary("encryption", "encriptar")}} {{glossary("cleartext", "texto en lenguaje natural")}} para hacerlo ilegible, y para que sea {{glossary("decryption", "desencriptado")}} con el fin de recuperar el texto original.
 
 Los algoritmos de cifrado eran muy comunes mucho antes de la era de la información (e.g., [cifrados por sustitucion](https://es.wikipedia.org/wiki/Cifrado_por_sustituci%C3%B3n) y [cifrados por transposición](https://es.wikipedia.org/wiki/Cifrado_por_transposici%C3%B3n)), pero ninguno de ellos era criptográficamente seguros excepto [one-time pad](https://es.wikipedia.org/wiki/Libreta_de_un_solo_uso).

--- a/files/es/glossary/ciphertext/index.md
+++ b/files/es/glossary/ciphertext/index.md
@@ -3,6 +3,8 @@ title: Texto Cifrado
 slug: Glossary/Ciphertext
 ---
 
+{{GlossarySidebar}}
+
 En {{glossary("Cryptography", "Criptografía")}}, un texto cifrado es un mensaje codificado que transmite información pero no es legible a menos que se {{glossary("decryption","descifre")}} con el {{glossary("cipher", "algoritmo criptográfico")}} correcto y el secreto correcto (generalmente una {{glossary("key","clave")}}), reproduciendo el {{glossary("cleartext", "texto simple")}} original. La seguridad de un texto cifrado, y por lo tanto el secreto de la información contenida, depende de usar un cifrado seguro y mantener la clave en secreto.
 
 ## Saber más

--- a/files/es/glossary/class/index.md
+++ b/files/es/glossary/class/index.md
@@ -3,6 +3,8 @@ title: Clase
 slug: Glossary/Class
 ---
 
+{{GlossarySidebar}}
+
 En {{glossary("OOP","programación orientada a objetos")}}, una clase define las características de un {{glossary("object","objeto")}}. Una clase es una plantilla que define {{glossary("property","propiedades")}} y {{glossary("method","métodos")}}, es un modelo abstracto a partir del cual se pueden crear instancias más específicas.
 
 ## Saber más

--- a/files/es/glossary/clickjacking/index.md
+++ b/files/es/glossary/clickjacking/index.md
@@ -3,6 +3,8 @@ title: Clickjacking
 slug: Glossary/Clickjacking
 ---
 
+{{GlossarySidebar}}
+
 Clickjacking es un ataque basado en la interfaz que engaña a los usuarios de un sitio web para que sin saberlo hagan clic en enlaces maliciosos. En clickjacking, los atacantes incrustan sus enlaces maliciosos en botones o páginas legítimas en un sitio web. En un {{glossary("Site")}} infectado, cada vez que un usuario hace clic en un enlace legítimo, el atacante obtiene información confidencial de ese usuario, lo que finalmente compromete la privacidad del usuario en Internet.
 
 El clickjacking puede ser evitado implementando una [Política de Seguridad de Contenido (frame-ancestors)](/es/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) e implementando [atributos de Set-Cookie](/es/docs/Web/HTTP/Headers/Set-Cookie#attributes).

--- a/files/es/glossary/closure/index.md
+++ b/files/es/glossary/closure/index.md
@@ -3,6 +3,8 @@ title: Clausura
 slug: Glossary/Closure
 ---
 
+{{GlossarySidebar}}
+
 Una clausura o _closure_ es una función que guarda referencias del estado adyacente (**{{glossary("scope", "ámbito léxico")}}**). En otras palabras, una clausura permite acceder al ámbito de una función exterior desde una función interior. En {{glossary("JavaScript")}}, las clausuras se crean cada vez que una **{{glossary("function","función")}}** es creada.
 
 ## Saber más

--- a/files/es/glossary/cms/index.md
+++ b/files/es/glossary/cms/index.md
@@ -3,6 +3,8 @@ title: Sistema de gestión de contenidos
 slug: Glossary/CMS
 ---
 
+{{GlossarySidebar}}
+
 Un sistema de gestión de contenidos o CMS es un programa informático que permite a los usuarios publicar, organizar, cambiar o eliminar diferentes tipos de contenido como texto, imágenes incrustadas, video, audio y código interactivo.
 
 ## Saber más

--- a/files/es/glossary/codec/index.md
+++ b/files/es/glossary/codec/index.md
@@ -3,6 +3,8 @@ title: Códec
 slug: Glossary/Codec
 ---
 
+{{GlossarySidebar}}
+
 Un _códec_ (acrónimo de "**_co_**dificador-**_dec_**odificador") es un programa, algoritmo, o dispositivo que codifica o decodifica un flujo de datos. Cada códec sabe cómo tratar un estándar específico de codificado o compresión.
 
 ## Saber más

--- a/files/es/glossary/compile/index.md
+++ b/files/es/glossary/compile/index.md
@@ -5,6 +5,8 @@ l10n:
   sourceCommit: ed947b2c608428b62a60f07d09dc543f732dc09b
 ---
 
+{{GlossarySidebar}}
+
 Compilar es el proceso de transformar un programa informático escrito en un {{Glossary("computer programming", "lenguaje")}} en un conjunto de instrucciones en otro formato o lenguaje. Un **compilador** es un programa de computadora que realiza dicha tarea.
 
 Normalmente, un compilador transforma código escrito en un lenguaje de alto nivel como [C++](https://es.wikipedia.org/wiki/C++), [Rust](<https://es.wikipedia.org/wiki/Rust_(lenguaje_de_programaci%C3%B3n)>) o [Java](<https://es.wikipedia.org/wiki/Java_(lenguaje_de_programaci%C3%B3n)>) en código ejecutable — llamado **código binario** o **código máquina**. [WebAssembly](/es/docs/WebAssembly), por ejemplo, es una forma de código binario ejecutable que [puede ser compilado desde código escrito en C++, Rust, C#, Go, Swift y muchos otros lenguajes](https://webassembly.org/getting-started/developers-guide/) y luego puede ser ejecutado en cualquier página web de cualquier navegador.

--- a/files/es/glossary/compile_time/index.md
+++ b/files/es/glossary/compile_time/index.md
@@ -3,6 +3,8 @@ title: Tiempo de compilación
 slug: Glossary/Compile_time
 ---
 
+{{GlossarySidebar}}
+
 El _tiempo de compilación_ es el tiempo desde que el programa es cargado por primera vez hasta que el programa es {{Glossary("parse","parsed")}}.
 
 ## Aprende más

--- a/files/es/glossary/computer_programming/index.md
+++ b/files/es/glossary/computer_programming/index.md
@@ -3,6 +3,8 @@ title: Programación de computadoras
 slug: Glossary/Computer_Programming
 ---
 
+{{GlossarySidebar}}
+
 Programación de computadoras es un proceso de componer y organizar un conjunto de instrucciones. Éstas le indican a una computadora/software qué hacer en un lenguaje comprensible para la computadora. Estas instrucciones pueden presentarse en diferentes lenguajes, tales como C++, Java, JavaScript, HTML, Python, Ruby y Rust.
 
 Usando un lenguaje apropiado, puedes programar/crear todo tipo de software. Por ejemplo, un programa que ayude a científicos con cálculos complejos; una base de datos que almacene grandes cantidades de datos; un sitio web que permita a la gente descargar música, o un software de animación que permita a la gente crear películas animadas.

--- a/files/es/glossary/constant/index.md
+++ b/files/es/glossary/constant/index.md
@@ -3,6 +3,8 @@ title: Constante
 slug: Glossary/Constant
 ---
 
+{{GlossarySidebar}}
+
 Una constante es un valor que el programador no puede cambiar, por ejemplo números (1, 2, 42). Con {{glossary("variable","variables")}}, por otra parte, el programador puede asignar un nuevo {{glossary("value", "valor")}} a una variable cuyo nombre ya esté en uso.
 
 Al igual que las variables, algunas constantes están unidas a identificadores. Por ejemplo, el identificador `pi` podría estar vinculado al valor 3.14... .

--- a/files/es/glossary/constructor/index.md
+++ b/files/es/glossary/constructor/index.md
@@ -3,6 +3,8 @@ title: Constructor
 slug: Glossary/Constructor
 ---
 
+{{GlossarySidebar}}
+
 Un **constructor** pertenece a una clase objeto ({{glossary("object")}}) particular la cual es instanciada. El constructor inicializa este objeto y puede otorgar acceso a su información privada. El concepto de objeto puede ser aplicado a la mayoría de los lenguajes orientados a objetos ({{glossary("OOP","object-oriented programming")}}). En esencia, un constructor en {{glossary("JavaScript")}} suele ser declarado al comienzo de una instancia de una clase ({{glossary("class")}}).
 
 ## Sintaxis

--- a/files/es/glossary/cookie/index.md
+++ b/files/es/glossary/cookie/index.md
@@ -3,6 +3,8 @@ title: Cookie
 slug: Glossary/Cookie
 ---
 
+{{GlossarySidebar}}
+
 Una cookie es una pequeña información enviada por un sitio web que se almacena en el navegador del ordenador del usuario.
 
 Las cookies sirven para personalizar la experiencia que tiene el usuario al navegar por un sitio web. Pueden contener las preferencias del usuario o entradas de información al acceder a dicha web. El usuario puede personalizar su navegador para aceptar, rechazar, o borrar las cookies.

--- a/files/es/glossary/copyleft/index.md
+++ b/files/es/glossary/copyleft/index.md
@@ -3,6 +3,8 @@ title: Copyleft
 slug: Glossary/Copyleft
 ---
 
+{{GlossarySidebar}}
+
 _Copyleft_ es un término, que normalmente se refiere a una licencia, y que se utiliza para indicar que toda redistribución de un trabajo bajo esta licencia **es obligatorio** que esté sujeta a la **misma licencia** **que el original**. Un buen ejemplo de copyleft es la licencia GNU [GPL](/es/docs/Glossary/GPL) (para aplicaciones software) y la licencia _Creative Commons SA_ (_Share Alike_ en español Compartir Igual) (para trabajos y obras de arte).
 
 ## Para saber más

--- a/files/es/glossary/cors-safelisted_request_header/index.md
+++ b/files/es/glossary/cors-safelisted_request_header/index.md
@@ -3,6 +3,8 @@ title: Encabezado de solicitud incluido en la lista segura de CORS
 slug: Glossary/CORS-safelisted_request_header
 ---
 
+{{GlossarySidebar}}
+
 Un [encabezado de solicitud incluido en la lista segura de CORS](https://fetch.spec.whatwg.org/#cors-safelisted-request-header)
 es uno de los siguientes [encabezados HTTP](/es/docs/Web/HTTP/Headers):
 

--- a/files/es/glossary/cors/index.md
+++ b/files/es/glossary/cors/index.md
@@ -3,6 +3,8 @@ title: CORS
 slug: Glossary/CORS
 ---
 
+{{GlossarySidebar}}
+
 **CORS** (_Cross-Origin Resource Sharing_ o en español Intercambio de recursos de origen cruzado) es un sistema que consiste en transmitir {{Glossary("HTTP_header", "HTTP headers")}}, que determina si los navegadores bloquean el acceso del código JavaScript frontend a las respuestas de peticiones de origen cruzado.
 
 La [política de seguridad del mismo origen](/es/docs/Web/Security/Same-origin_policy) prohíbe el acceso a los recursos de orígenes cruzados. Pero CORS brinda a los servidores web la capacidad de decir que desean optar por permitir el acceso de origen cruzado a sus recursos.

--- a/files/es/glossary/cross-site_scripting/index.md
+++ b/files/es/glossary/cross-site_scripting/index.md
@@ -3,6 +3,8 @@ title: Cross-site scripting
 slug: Glossary/Cross-site_scripting
 ---
 
+{{GlossarySidebar}}
+
 Cross-site scripting (XSS) es una vulnerabilidad de seguridad que permite a un atacante inyectar en un sitio web código malicioso del lado del cliente. Este código es ejecutado por las víctimas y permite a los atacante eludir los controles de acceso y hacerse pasar por usuarios. Según el Open Web Application Security Project, XSS fue la [séptima vulnerabilidad más común de las aplicaciones web](https://www.owasp.org/images/7/72/OWASP_Top_10-2017_%28en%29.pdf.pdf) en 2017.
 
 Estos ataques tienen éxito si la aplicación web no emplea suficiente validación o codificación. El navegador del usuario no puede detectar que el script malicioso no es confiable, por lo que da acceso a cookies, tokens de sesión u otra información sensible específica del sitio, o permite que el escript reescriba contenido {{glossary("HTML")}}.

--- a/files/es/glossary/crud/index.md
+++ b/files/es/glossary/crud/index.md
@@ -3,6 +3,8 @@ title: CRUD
 slug: Glossary/CRUD
 ---
 
+{{GlossarySidebar}}
+
 **CRUD** (Create, Read, Update, Delete) es un acrónimo para las maneras en las que se puede operar sobre información almacenada. Es un nemónico para las cuatro funciones del almacenamiento persistente. CRUD usualmente se refiere a operaciones llevadas a cabo en una base de datos o un almácen de datos, pero también pude aplicar a funciones de un nivel superior de una aplicación como soft deletes donde la información no es realmente eliminada, sino es marcada como eliminada a tráves de un estatus.
 
 ## Aprende más

--- a/files/es/glossary/cryptanalysis/index.md
+++ b/files/es/glossary/cryptanalysis/index.md
@@ -3,6 +3,8 @@ title: Criptoanálisis
 slug: Glossary/Cryptanalysis
 ---
 
+{{GlossarySidebar}}
+
 El criptoanálisis es la rama de {{glossary ("cryptography","criptografía")}} que estudia cómo romper códigos y criptosistemas. El criptoanálisis crea técnicas para romper {{glossary ("cipher", "cifrados")}}, en particular por métodos más eficientes que una búsqueda por fuerza bruta. Además de los métodos tradicionales como el análisis de frecuencia y el índice de coincidencia, el criptoanálisis incluye métodos más recientes, como el criptoanálisis lineal o el criptoanálisis diferencial, que puede romper cifrados más avanzados.
 
 ## Saber más

--- a/files/es/glossary/cryptography/index.md
+++ b/files/es/glossary/cryptography/index.md
@@ -3,6 +3,8 @@ title: Criptografía
 slug: Glossary/Cryptography
 ---
 
+{{GlossarySidebar}}
+
 Criptografía, o criptología, es la ciencia que estudia como codificar y transmitir mensajes de manera segura. La criptografía diseña y estudia algoritmos que son usados para la codificación y decoficación de mensajes en un entorno inseguro y sus aplicaciones. Más que confidencialidad de información, la criptografía también aborda la identificación, autenticación, el no repudio y la integridad de la información. Para ello tambien estudia el uso de métodos criptográficos en contexto, criptosistemas.
 
 ## Aprende más

--- a/files/es/glossary/csrf/index.md
+++ b/files/es/glossary/csrf/index.md
@@ -3,6 +3,8 @@ title: CSRF
 slug: Glossary/CSRF
 ---
 
+{{GlossarySidebar}}
+
 **CSRF** (Cross-Site Request Forgery) es un ataque que falsifica una petición a un servidor web haciéndose pasar por un usuario de confianza. Esto se puede hacer, por ejemplo, incluyendo parámetros maliciosos en una {{glossary("URL")}} después de un enlace que pretende redirigir a otro sitio.
 
 ## Saber más

--- a/files/es/glossary/css/index.md
+++ b/files/es/glossary/css/index.md
@@ -3,6 +3,8 @@ title: CSS
 slug: Glossary/CSS
 ---
 
+{{GlossarySidebar}}
+
 **CSS,** de las siglas en inglés **C**ascading **S**tyle **S**heets (Hojas de Estilo en Cascada), es un lenguaje declarativo que controla el aspecto de las páginas web en el {{glossary("browser","navegador")}}. El navegador aplica declaraciones de estilo CSS a los elementos seleccionados para exhibirlos correctamente. Una declaración de estilos contiene las propiedades y sus respectivos valores, los cuales determinan cómo se verá una página web.
 
 CSS es una de las tres principales tecnologias web, junto con {{Glossary("HTML")}} y {{Glossary("JavaScript")}}. CSS usualmente le da estilo a los ({{Glossary("Element","elementos HTML")}}), pero también puede ser utilizado con otros lenguajes de marcado como {{Glossary("SVG")}} o {{Glossary("XML")}}.

--- a/files/es/glossary/css_preprocessor/index.md
+++ b/files/es/glossary/css_preprocessor/index.md
@@ -3,6 +3,8 @@ title: Preprocesador CSS
 slug: Glossary/CSS_preprocessor
 ---
 
+{{GlossarySidebar}}
+
 Un preprocesador CSS es un programa que te permite generar {{Glossary("CSS")}} a partir de la {{Glossary("syntax")}} única del preprocesador. Existen varios preprocesadores CSS de los cuales escoger, sin embargo la mayoría de preprocesadores CSS añadiran algunas características que no existen en CSS puro, como {{Glossary("variable")}}, mixins, selectores anidados, entre otros. Estas características hacen la estructura de CSS más legible y fácil de mantener.
 
 Para utilizar un preprocesador CSS debes instalar un compilador CSS en tu web {{Glossary("server")}}.

--- a/files/es/glossary/data_structure/index.md
+++ b/files/es/glossary/data_structure/index.md
@@ -3,6 +3,8 @@ title: Estructura de datos
 slug: Glossary/Data_structure
 ---
 
+{{GlossarySidebar}}
+
 **Estructura de datos** es una forma particular de organizar datos para que puedan ser usados eficientemente.
 
 ## Aprende más

--- a/files/es/glossary/decryption/index.md
+++ b/files/es/glossary/decryption/index.md
@@ -3,6 +3,8 @@ title: Descifrado
 slug: Glossary/Decryption
 ---
 
+{{GlossarySidebar}}
+
 En {{glossary("cryptography" ,"criptografía")}}, el descifrado es la conversión de {{glossary("Ciphertext", "texto cifrado")}} en {{glossary("Plaintext", "texto simple")}}.
 
 El descifrado es una primitiva criptográfica: transforma un mensaje de texto cifrado en texto simple utilizando un algoritmo criptográfico llamado {{glossary("cipher", "cifrado")}}. Al igual que el cifrado, el descifrado en cifrados modernos se realiza mediante un algoritmo específico y una {{glossary("Key", "clave")}}. Dado que el algoritmo suele ser público, la clave debe permanecer secreta si el cifrado se mantiene seguro.

--- a/files/es/glossary/doctype/index.md
+++ b/files/es/glossary/doctype/index.md
@@ -3,6 +3,8 @@ title: Doctype
 slug: Glossary/Doctype
 ---
 
+{{GlossarySidebar}}
+
 `<!DOCTYPE>` informa al {{Glossary("navegador")}} qué versión de {{Glossary("HTML")}} (o {{glossary("XML")}}) se usó para escribir el documento. Doctype es una declaración no una {{Glossary("etiqueta")}}. Además, podemos referirnos a ella como "document type declaration" o por las siglas "DTD".
 
 ## Saber más

--- a/files/es/glossary/dom/index.md
+++ b/files/es/glossary/dom/index.md
@@ -3,6 +3,8 @@ title: DOM
 slug: Glossary/DOM
 ---
 
+{{GlossarySidebar}}
+
 El _DOM_ (Document Object Model, en español **Modelo de Objetos del Documento**) es una [API](/es/docs/Glossary/API) definida para representar e interactuar con cualquier documento [HTML](/es/docs/Glossary/HTML) o [XML](/es/docs/Glossary/XML). El DOM es un modelo de documento que se carga en el [navegador web](/es/docs/Glossary/Browser) y que representa el documento como un árbol de nodos, en donde cada nodo representa una parte del documento (puede tratarse de un [elemento](/es/docs/Glossary/element), una cadena de texto o un comentario).
 
 El DOM es una de las APIs más usadas en la [Web](/es/docs/Glossary/World_Wide_Web), pues permite ejecutar código en el navegador para acceder e interactuar con cualquier nodo del documento. Estos nodos pueden crearse, moverse o modificarse. Pueden añadirse a estos nodos manejadores de eventos (_event listeners_ en inglés) que se ejecutarán/activarán cuando ocurra el evento indicado en este manejador.

--- a/files/es/glossary/domain/index.md
+++ b/files/es/glossary/domain/index.md
@@ -3,6 +3,8 @@ title: Dominio
 slug: Glossary/Domain
 ---
 
+{{GlossarySidebar}}
+
 Un dominio es una autoridad dentro de internet que controla sus propios recursos. Su "nombre de dominio" es una forma de dirigirse a esta autoridad como parte de la jerarquía en una {{Glossary("URL")}}, que generalmente es la parte más significativa de la misma, por ejemplo, un nombre de marca.
 
 Un nombre de dominio completo (FQDN, por sus siglas en inglés) contiene todas las partes necesarias para buscar esta autoridad por su nombre sin ambigüedades utilizando el sistema {{Glossary("DNS")}} de Internet.

--- a/files/es/glossary/domain_name/index.md
+++ b/files/es/glossary/domain_name/index.md
@@ -3,6 +3,8 @@ title: Nombre de dominio
 slug: Glossary/Domain_name
 ---
 
+{{GlossarySidebar}}
+
 Un nombre de dominio es la dirección de un sitio web en {{Glossary("Internet")}}. Los nombres de dominio se utilizan en {{Glossary("URL","URLs")}} para identificar a qué servidor pertenece una página web específica. El nombre de dominio consiste en una secuencia jerárquica de nombres (etiquetas) separados por puntos y que terminan con una {{glossary("TLD","extensión")}}.
 
 ## Saber más

--- a/files/es/glossary/dynamic_typing/index.md
+++ b/files/es/glossary/dynamic_typing/index.md
@@ -3,6 +3,8 @@ title: Tipado Dinámico
 slug: Glossary/Dynamic_typing
 ---
 
+{{GlossarySidebar}}
+
 **Los lenguajes de tipado dinámico** son aquellos (como {{glossary("JavaScript")}}) donde el intérprete asigna a las {{glossary("variable","variables")}} un {{glossary("tipo")}} durante el tiempo de ejecución basado en su {{glossary("valor")}} en ese momento.
 
 ## Ver más

--- a/files/es/glossary/ecmascript/index.md
+++ b/files/es/glossary/ecmascript/index.md
@@ -3,6 +3,8 @@ title: ECMAScript
 slug: Glossary/ECMAScript
 ---
 
+{{GlossarySidebar}}
+
 **ECMAScript** es una especificación de lenguaje de scripting en la que se basa {{Glossary("JavaScript")}}. [Ecma International](http://www.ecma-international.org) está a cargo de estandarizar ECMAScript.
 
 ## Aprende más

--- a/files/es/glossary/element/index.md
+++ b/files/es/glossary/element/index.md
@@ -3,6 +3,8 @@ title: Elemento
 slug: Glossary/Element
 ---
 
+{{GlossarySidebar}}
+
 Un elemento es parte de una página web. En XML y HTML, un elemento puede contener un elemento de datos o un fragmento de texto o una imagen, o tal vez nada. Un elemento típico incluye una etiqueta de apertura con algunos atributos, contenido de texto cerrado y una etiqueta de cierre.
 ![Example: in <p class="nice">Hello world!</p>, '<p class="nice">' is an opening tag, 'class="nice"' is an attribute and its value, 'Hello world!' is enclosed text content, and '</p>' is a closing tag.](anatomy-of-an-html-element.png)
 

--- a/files/es/glossary/encapsulation/index.md
+++ b/files/es/glossary/encapsulation/index.md
@@ -3,6 +3,8 @@ title: Encapsulación
 slug: Glossary/Encapsulation
 ---
 
+{{GlossarySidebar}}
+
 La encapsulación es el empaquetamiento de datos y {{glossary("function","funciones")}} en un componente (por ejemplo, una {{glossary("class", "clase")}}) y para luego controlar el acceso a ese componente para hacer un ejecto de "caja negra" fuera del {{glossary("object", "objeto")}}. Debido a esto, un usuario de esa clase solo necesita conocer su interfaz (es decir, los datos y las funciones expuestas fuera de la clase), no la implementación oculta.
 
 ## Saber más

--- a/files/es/glossary/encryption/index.md
+++ b/files/es/glossary/encryption/index.md
@@ -3,6 +3,8 @@ title: Encriptación
 slug: Glossary/Encryption
 ---
 
+{{GlossarySidebar}}
+
 En {{glossary("cryptography", "criptografía")}}, la **encriptación** es la conversión del {{glossary("cleartext", "lenguaje natural")}} en un texto codificado o {{glossary("ciphertext", "cifrado")}}. Un texto cifrado es utilizado para ser ilegible por lectores no autorizados.
 
 La encriptación es una primitiva criptográfica: transforma un mensaje en texto plano en un texto cifrado usando un {{glossary("cipher", "algoritmo criptográfico")}}. La encriptación en los algoritmos modernos se lleva a cabo usando un algoritmo específico y un secreto, llamado la {{glossary("key", "clave")}}. Ya que la mayoría de los algoritmos son públicos, la clave debe ser secreta para que la encriptación sea segura.

--- a/files/es/glossary/entity/index.md
+++ b/files/es/glossary/entity/index.md
@@ -3,6 +3,8 @@ title: Entidad
 slug: Glossary/Entity
 ---
 
+{{GlossarySidebar}}
+
 Una **entidad** {{glossary("HTML")}} es un conjunto de caracteres ("string") que comienza con un ampersand (`&`) y termina con un punto y coma (`;`) . Las entidades son utilizadas frecuentemente para imprimir en pantalla caracteres reservados (aquellos que serían interpretados como HTML por el navegador) o invisibles (cómo tabulaciones). También pueden usarse para representar caracteres que no existan en algunos teclados, por ejemplo caracterés con tilde o diéresis.
 
 > **Nota:** Muchos caracteres tienen entidades con nombres fáciles de recordar, como las vocales con tilde (`á`) es `&aacute;`, (`é`) es `&eacute;` y así sucesivamente. Otro ejempo es el simbolo de copyright, (`©`) representado por la entidad `&copy;`. Al lidiar con entidades menos representativas de los caracteres que representan, es de gran ayuda utilizar una [tabla de referencia](https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references) o un [decodificador](https://mothereff.in/html-entities).

--- a/files/es/glossary/event/index.md
+++ b/files/es/glossary/event/index.md
@@ -3,6 +3,8 @@ title: Evento
 slug: Glossary/Event
 ---
 
+{{GlossarySidebar}}
+
 Los eventos son sucesos generados por elementos del [DOM](/es/docs/Glossary/DOM), que pueden ser manipulados por un código Javascript
 
 ## Saber más

--- a/files/es/glossary/first-class_function/index.md
+++ b/files/es/glossary/first-class_function/index.md
@@ -3,6 +3,8 @@ title: Funcion de primera clase
 slug: Glossary/First-class_Function
 ---
 
+{{GlossarySidebar}}
+
 Un lenguaje de programación se dice que tiene **Funciones de primera clase** cuando las funciones en ese lenguaje son tratadas como cualquier otra variable. Por ejemplo, en ese lenguaje, una función puede ser pasada como argumento a otras funciones, puede ser retornada por otra función y puede ser asignada a una variable.
 
 ## Ejemplo | Asignar función a una variable
@@ -87,19 +89,8 @@ diHola()();
 
 Usamos paréntesis doble `()()` para invocar también a la función retornada.
 
-## Aprender más
-
-### Conocimiento general
-
-<section id="Quick_links">
- <ol>
-  <li>[First-class functions](https://es.wikipedia.org/wiki/First-class_function) on Wikipedia</li>
-  <li><a href="/es/docs/Glossary">MDN Web Docs Glossary</a>
-   <ul>
-    <li>{{glossary("Callback function")}}</li>
-    <li>{{glossary("Function")}}</li>
-    <li>{{glossary("Variable")}}</li>
-   </ul>
-  </li>
- </ol>
-</section>
+- [First-class functions](ttps://es.wikipedia.org/wiki/First-class_function) en Wikipedia
+- [Glosario de MDN Web Docs](/es/docs/Glossary)
+  - {{Glossary("Callback function")}}
+  - {{Glossary("Function")}}
+  - {{Glossary("Variable")}}

--- a/files/es/glossary/flex/index.md
+++ b/files/es/glossary/flex/index.md
@@ -3,6 +3,8 @@ title: Flex
 slug: Glossary/Flex
 ---
 
+{{GlossarySidebar}}
+
 flex es una nueva herramienta agregada a la propiedad CSS {{cssxref ("display")}}. Junto con inline-flex, hace que el elemento al que se aplica se convierta en un {{glossary("flex container")}}, y los hijos del elemento se conviertan cada uno en un {{glossary("flex item")}}.
 
 Luego, los elementos participan en el diseño flexible y se pueden aplicar todas las propiedades definidas en el módulo de diseño de caja flexible CSS (CSS Flexible Box).

--- a/files/es/glossary/flex_container/index.md
+++ b/files/es/glossary/flex_container/index.md
@@ -3,6 +3,8 @@ title: Flex Container
 slug: Glossary/Flex_Container
 ---
 
+{{GlossarySidebar}}
+
 Una plantilla con {{glossary("flexbox")}} puede ser definida usando los valores `flex` o `inline-flex` en las propiedades de `display`. Este elemento es un **contenedor flex**, y cada uno de los contenedores que heredan propiedades de este, son conocidos como {{glossary("flex item")}}.
 
 El valor asignado a la variable `flex` ocasiona que este tipo de elementos sean un bloque de elementos del tipo (Flex Container), y la variable `inline-flex` genera un Contenedor Flex de nivel Inline (Interno. Estos Valores crean un Contexto de formato Flex para los elementos que es similar a un bloque flotante no introducido en el contenedor, y los margenes del contenedor no chocaran con otros items.

--- a/files/es/glossary/flexbox/index.md
+++ b/files/es/glossary/flexbox/index.md
@@ -3,6 +3,8 @@ title: Flexbox
 slug: Glossary/Flexbox
 ---
 
+{{GlossarySidebar}}
+
 Flexbox es como se llama comúnmente a [Módulo de diseño de caja flexible CSS](https://www.w3.org/TR/css-flexbox-1/), un modelo de diseño para mostrar elementos en una sola dimensión, como una fila o como una columna.
 
 En la especificación, flexbox se describe como un modelo de diseño para la interfaz de usuario. La característica clave de Flexbox es el hecho de que los elementos en un diseño flexible pueden crecer y reducirse. El espacio se puede asignar a los mismos elementos, o distribuidos entre o alrededor de los elementos.

--- a/files/es/glossary/forbidden_header_name/index.md
+++ b/files/es/glossary/forbidden_header_name/index.md
@@ -3,6 +3,8 @@ title: Nombre de encabezado prohibido
 slug: Glossary/Forbidden_header_name
 ---
 
+{{GlossarySidebar}}
+
 Un nombre de encabezado prohibido es un nombre de [encabezado HTTP](/es/docs/Web/HTTP/Headers) que no se puede modificar mediante programación; específicamente, un nombre de encabezado de HTTP **solicitud** HTTP.
 
 Contrasta con el {{Glossary("Forbidden response header name")}}.

--- a/files/es/glossary/fps/index.md
+++ b/files/es/glossary/fps/index.md
@@ -3,6 +3,8 @@ title: frame rate (FPS)
 slug: Glossary/FPS
 ---
 
+{{GlossarySidebar}}
+
 Un **cuadro por segundo** es la velocidad en la cual el navegador web, es capaz de recalcular la disposición y dibujar el contenido de la pantalla.
 
 **FPS (frames per second)**, refiere a la cantidad de cuadros que pueden ser redibujados en un segundo. El ideal de esta metrica para un sitio web es de **60fps**

--- a/files/es/glossary/ftp/index.md
+++ b/files/es/glossary/ftp/index.md
@@ -3,6 +3,8 @@ title: FTP
 slug: Glossary/FTP
 ---
 
+{{GlossarySidebar}}
+
 FTP (del inglés _File Transfer Protocol_, Protocolo de transferencia de archivos) fue el [protocolo](/es/docs/Glossary/Protocol) estándar durante muchos años para transferir archivos entre equipos a través de Internet. Sin embargo, cada vez más los equipos y las cuentas de alojamiento no permiten el FTP y en su lugar dependen de un sistema de control de versiones como Git. Se encuentra todavía en funcionamiento en las cuentas de alojamiento más antiguas, pero no es exagerado decir que el FTP ya no es considerada la mejor práctica.
 
 ## Aprenda más

--- a/files/es/glossary/function/index.md
+++ b/files/es/glossary/function/index.md
@@ -3,6 +3,8 @@ title: Función
 slug: Glossary/Function
 ---
 
+{{GlossarySidebar}}
+
 Una **función** es un fragmento de código que puede ser llamado por otro código o por sí mismo, o por una {{Glossary("variable")}} que haga referencia a la función. Cuando se llama a una función, los {{Glossary("Argument", "argumentos")}} se pasan a la función como entrada, y la función puede devolver opcionalmente una salida. Una función en {{glossary("JavaScript")}} es también un {{glossary("object", "objeto")}}.
 
 El nombre de la función es un {{Glossary("identifier", "identificador")}} declarado como parte de una declaración de función o expresión de función. El {{Glossary("scope", "ámbito")}} de la función depende de si el nombre de la función es una declaración o una expresión.

--- a/files/es/glossary/general_header/index.md
+++ b/files/es/glossary/general_header/index.md
@@ -3,6 +3,8 @@ title: Cabecera general
 slug: Glossary/General_header
 ---
 
+{{GlossarySidebar}}
+
 Una **cabecera general** es una {{glossary('Header', 'cabecera HTTP')}} que puede ser utilizada tanto en mensajes de consultas como de respuestas pero que no se aplican al contenido en sí mismo. Dependiendo del contexto en que son usadas, las cabeceras generales pueden ser de {{glossary("Response header", "respuesta")}} o de {{glossary("request header", "consulta")}}. Sin embargo, no son {{glossary("entity header", "cabeceras de entidad.")}}.
 
 Las cabeceras generales más comunes son {{HTTPHeader('Date')}}, {{HTTPheader("Cache-Control")}} y {{HTTPHeader("Connection")}}.

--- a/files/es/glossary/gif/index.md
+++ b/files/es/glossary/gif/index.md
@@ -3,6 +3,8 @@ title: GIF
 slug: Glossary/GIF
 ---
 
+{{GlossarySidebar}}
+
 **GIF** (**G**raphics **I**nterchange **F**ormat en español **Formato de Intercambio de Gráficos**) es un formato de imagen con una baja compresión y se puede usar para animaciones. Un GIF usa hasta 8 bits por pixel y contiene un máximo de 256 colores con un rango de 24-bit.
 
 ## Aprender más

--- a/files/es/glossary/git/index.md
+++ b/files/es/glossary/git/index.md
@@ -3,6 +3,8 @@ title: Git
 slug: Glossary/Git
 ---
 
+{{GlossarySidebar}}
+
 **Git** es un software de control de versiones ({{Glossary("SCM", "SCV", 1)}}) distribuido, libre y de código abierto. Facilita el manejo de código fuente con equipos de desarrollo distribuidos. La principal diferencia con SCV previos es la habilidad para hacer operaciones comunes (branching, committing, etc.) en el equipo de desarrollo local, sin tener que modificar el repositorio master o tener de acceso de escritura a él.
 
 ## Saber más

--- a/files/es/glossary/google_chrome/index.md
+++ b/files/es/glossary/google_chrome/index.md
@@ -3,6 +3,8 @@ title: Google Chrome
 slug: Glossary/Google_Chrome
 ---
 
+{{GlossarySidebar}}
+
 _Google Chrome_ es un [navegador](/es/docs/Glossary/Browser) web gratuito desarrollado por Google. Está basado en el proyecto open source (código abierto / software libre) [Chromium](http://www.chromium.org/). Algunas de las principales diferencias se encuentran en [Chromium wiki](https://code.google.com/p/chromium/wiki/ChromiumBrowserVsGoogleChrome). El motor de diseño que utilizan ambos es una copia del motor [Blink](/es/docs/Glossary/Blink) de [WebKit](/es/docs/Glossary/WebKit). Cabe señalar que en la versión de Chrome en iOS se utiliza WebKit y no Blink.
 
 ## Para saber más

--- a/files/es/glossary/gpl/index.md
+++ b/files/es/glossary/gpl/index.md
@@ -3,6 +3,8 @@ title: GPL
 slug: Glossary/GPL
 ---
 
+{{GlossarySidebar}}
+
 La lincencia GNU _GPL_ (GNU General Public License en español **Licencia Pública General de GNU**) es una licencia de software libre [copyleft](/es/docs/Glossary/copyleft) publicada por la _Free Software Foundation_. Los usuarios de un programa con licencia GPL son libres para usarlo, acceder al código fuente, modificarlo y distribuir los cambios; siempre que redistribuyan el programa completo (modificado o no modificado) bajo la misma licencia.
 
 ## Para saber más

--- a/files/es/glossary/grid/index.md
+++ b/files/es/glossary/grid/index.md
@@ -3,6 +3,8 @@ title: Grid
 slug: Glossary/Grid
 ---
 
+{{GlossarySidebar}}
+
 _CSS grid_ es definido usando el valor grid en la propiedad `display`; puedes definir columnas y filas en tu diseño grid, con las propiedades {{cssxref("grid-template-rows")}} y {{cssxref("grid-template-columns")}} .
 
 El grid que configures usando estas propiedades es definido como la grilla explícita (_explicit grid_).

--- a/files/es/glossary/grid_areas/index.md
+++ b/files/es/glossary/grid_areas/index.md
@@ -3,6 +3,8 @@ title: Grid Areas
 slug: Glossary/Grid_Areas
 ---
 
+{{GlossarySidebar}}
+
 Un **grid area** es una o más {{glossary("grid cell", "grid cells")}} que forman un área rectangular en la cuadrícula. Los grid areas se crean cuando se coloca un elemento usando [disposición basada en líneas](/es/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid) o cuando se definen áreas usando [grid areas con nombre](/es/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas).
 
 ![Imagen mostrando una grid area resaltada](1_grid_area.png)

--- a/files/es/glossary/grid_column/index.md
+++ b/files/es/glossary/grid_column/index.md
@@ -3,6 +3,8 @@ title: Grid Column
 slug: Glossary/Grid_Column
 ---
 
+{{GlossarySidebar}}
+
 Una **columna de grid** es una pista vertical en un [CSS Grid Layout](/es/docs/Web/CSS/CSS_Grid_Layout), y es el espacio entre dos líneas verticales de cuadrícula. Está definido por la propiedad {{cssxref("grid-template-columns")}} o por las propiedades abreviadas {{cssxref("grid")}} o {{cssxref("grid-template")}}.
 
 Además, se pueden crear columnas en la _cuadrícula implícita_ cuando los elementos se colocan fuera de las columnas creadas en la _cuadrícula explícita_. Estas columnas serán de tamaño automático por defecto, o pueden tener un tamaño especificado con la propiedad {{cssxref("grid-auto-columns")}}.

--- a/files/es/glossary/grid_lines/index.md
+++ b/files/es/glossary/grid_lines/index.md
@@ -3,6 +3,8 @@ title: Líneas de Cuadrícula
 slug: Glossary/Grid_Lines
 ---
 
+{{GlossarySidebar}}
+
 Las **Líneas de Cuadrícula** se crean cuando defines las {{glossary("tracks", "Pistas de Cuadrícula")}} esto sucede dentro de un contenedor que este usando [CSS Grid Layout](/es/docs/Web/CSS/CSS_Grid_Layout).
 
 En el siguiente ejemplo hay una cuadrícula con tres pistas de columna y dos pistas de filas. Esto nos da **4 Líneas de Columnas** y **3 Líneas de Fila**.

--- a/files/es/glossary/grid_row/index.md
+++ b/files/es/glossary/grid_row/index.md
@@ -3,6 +3,8 @@ title: Grid Row
 slug: Glossary/Grid_Row
 ---
 
+{{GlossarySidebar}}
+
 Una **grid row** es una pista horizontal en un [CSS Grid Layout](/es/docs/Web/CSS/CSS_Grid_Layout), es el espacio entre dos líneas de cuadrícula horizontales. Se define por la propiedad {{cssxref("grid-template-rows")}} o con la propiedad shorthand {{cssxref("grid")}} o {{cssxref("grid-template")}}.
 
 Además, se pueden crear filas en la _cuadrícula implícita_ cuando los elementos se colocan fuera de las filas creadas en la _cuadrícula explícita_. Estas filas serán de tamaño automático por defecto, o pueden tener un tamaño especificado con la propiedad {{cssxref("grid-auto-rows")}}.

--- a/files/es/glossary/head/index.md
+++ b/files/es/glossary/head/index.md
@@ -3,6 +3,8 @@ title: Head
 slug: Glossary/Head
 ---
 
+{{GlossarySidebar}}
+
 La cabecera (en inglés _Head_) es la parte de un documento [HTML](/es/docs/Glossary/Head) que contiene [metadatos](/es/docs/Glossary/Metadato) sobre ese documento, como el autor, la descripción y los enlaces a los archivos [CSS](/es/docs/Glossary/CSS) o [JavaScript](/es/docs/Glossary/JavaScript) que se deben aplicar al documento HTML. Es la parte del documento web que no es visible al usuario.
 
 ## Aprenda más

--- a/files/es/glossary/hoisting/index.md
+++ b/files/es/glossary/hoisting/index.md
@@ -3,6 +3,8 @@ title: Hoisting
 slug: Glossary/Hoisting
 ---
 
+{{GlossarySidebar}}
+
 Hoisting es un término que _no_ encontrará utilizado en ninguna especificación previa a la [Especificación del Lenguaje ECMAScript® 2015](http://www.ecma-international.org/ecma-262/6.0/index.html). El concepto de Hoisting fue pensado como una manera general de referirse a cómo funcionan los contextos de ejecución en JavaScript (específicamente las fases de creación y ejecución). Sin embargo, el concepto puede ser un poco confuso al principio.
 
 Conceptualmente, por ejemplo, una estricta definición de hoisting sugiere que las declaraciones de variables y funciones son físicamente movidas al comienzo del código, pero esto no es lo que ocurre en realidad. Lo que sucede es que las declaraciones de variables y funciones son **asignadas en memoria** durante la fase de **compilación**, pero quedan exactamente en dónde las has escrito en el código.

--- a/files/es/glossary/host/index.md
+++ b/files/es/glossary/host/index.md
@@ -3,6 +3,8 @@ title: Anfitrión
 slug: Glossary/Host
 ---
 
+{{GlossarySidebar}}
+
 Un anfitrión (del ingles _host_) es un dispositivo conectado a {{glossary("Internet")}} (o una red de área local). Algunos anfitriones denominados {{glossary("server","servidores")}} ofrecen servicios adicionales como servir páginas web o alojar archivos y correos electrónicos.
 
 El anfitrión no es necesariamente un elemento hardware. Pueden ser generado como máquinas virtuales. El anfitrión generado en una máquina virtual se suele denominar "Alojamiento virtual".

--- a/files/es/glossary/html/index.md
+++ b/files/es/glossary/html/index.md
@@ -3,6 +3,8 @@ title: HTML
 slug: Glossary/HTML
 ---
 
+{{GlossarySidebar}}
+
 HTML (Lenguaje de marcado de hipertexto o HyperText Markup Language por sus siglas en inglés) es un lenguaje descriptivo que especifica la estructura de las páginas web.
 
 ## Breve historia

--- a/files/es/glossary/html5/index.md
+++ b/files/es/glossary/html5/index.md
@@ -3,6 +3,8 @@ title: HTML5
 slug: Glossary/HTML5
 ---
 
+{{GlossarySidebar}}
+
 La última versión estable de [HTML](/es/docs/Glossary/HTML), HTML5 convierte a HTML de un simple formato de marcado para estructurar documentos en una plataforma completa de desarrollo de aplicaciones. Entre otras características, HTML5 incluye nuevos elementos y [API](/es/docs/Glossary/API) de [JavaScript](/es/docs/Glossary/JavaScript) para mejorar el almacenamiento, la multimedia y el acceso al hardware.
 
 ## Aprenda más

--- a/files/es/glossary/http/index.md
+++ b/files/es/glossary/http/index.md
@@ -3,6 +3,8 @@ title: HTTP
 slug: Glossary/HTTP
 ---
 
+{{GlossarySidebar}}
+
 El protocolo de transferencia de hipertexto o HTTP (HyperText Transfer Protocol) es el protocolo de red que permite la transferencia de documentos de hipermedia en la red, generalmente entre un navegador y un servidor, para que los humanos puedan leerlos. La versión actual de la especificación se llama HTTP/2.
 
 En un {{glossary("URI")}}, como por ejemplo <https://developer.mozilla.org>, se indica en el esquema y puede tomar los valores: 'http:' o 'https:'. 'https:' se refiere a la versión segura del protocolo.

--- a/files/es/glossary/https/index.md
+++ b/files/es/glossary/https/index.md
@@ -3,6 +3,8 @@ title: HTTPS
 slug: Glossary/HTTPS
 ---
 
+{{GlossarySidebar}}
+
 HTTPS (HTTP Secure) es una versión encriptada del protocolo {{Glossary("HTTP")}}. Normalmente utiliza {{Glossary("SSL")}} o {{Glossary("TLS")}} para cifrar toda la comunicación entre un cliente y un servidor. Esta conexión segura permite a los clientes intercambiar datos confidenciales de forma segura con un servidor, por ejemplo, para actividades bancarias o compras en línea.
 
 ## Aprender más

--- a/files/es/glossary/hyperlink/index.md
+++ b/files/es/glossary/hyperlink/index.md
@@ -3,6 +3,8 @@ title: Hipervínculo
 slug: Glossary/Hyperlink
 ---
 
+{{GlossarySidebar}}
+
 Los _Hipervínculos_ ó _enlaces_ permiten conectar entre sí datos ó páginas web. En [HTML](/es/docs/Glossary/HTML), los elementos {{HTMLElement("a")}} representan hipervínculos que tienen como origen un elemento de la página web (por ejemplo cadenas de texto o imágenes), y que pueden tener como destino un elemento de otro sitio web (incluso pueden enlazar a otro punto de la misma página).
 
 ## Para saber más

--- a/files/es/glossary/hypertext/index.md
+++ b/files/es/glossary/hypertext/index.md
@@ -3,6 +3,8 @@ title: Hipertexto
 slug: Glossary/Hypertext
 ---
 
+{{GlossarySidebar}}
+
 El hipertexto es texto que contiene enlaces a otros textos, y no un flujo único y lineal como el de una novela.
 
 El término fue acuñado por Ted Nelson alrededor del año 1965.

--- a/files/es/glossary/ide/index.md
+++ b/files/es/glossary/ide/index.md
@@ -3,6 +3,8 @@ title: IDE
 slug: Glossary/IDE
 ---
 
+{{GlossarySidebar}}
+
 Un entorno de desarrollo integrado (**IDE**) o entorno de desarrollo interactivo es una aplicación que proporciona facilidades a los programadores para el desarrollo de software. Un IDE normalmente consta de un editor de código, herramientas automatizadas para producir el proyecto y un depurador.
 
 ## Saber más

--- a/files/es/glossary/identifier/index.md
+++ b/files/es/glossary/identifier/index.md
@@ -3,28 +3,18 @@ title: Identificador
 slug: Glossary/Identifier
 ---
 
+{{GlossarySidebar}}
+
 Un **Identificador** es una secuencia de caracteres en el código que identifica una {{Glossary("Variable")}}, {{Glossary("Function", "función")}} o {{Glossary("Property", "propiedad")}}.
 
 En {{Glossary("JavaScript")}}, los identificadores distinguen entre mayúsculas y minúsculas y pueden contener letras {{Glossary("Unicode")}}, `$`, `_`, y dígitos (0-9), pero no puede comenzar con un dígito.
 
 Un identificador se diferencia de una cadena en que una {{Glossary("String", "cadena")}} son datos, mientras que un identificador es parte del código. En JavaScript, no hay forma de convertir identificadores en cadenas, pero a veces es posible procesar cadenas como identificadores.
 
-## Aprende más
-
-### Conocimientos generales
+## Véase también
 
 - [Identificador](https://es.wikipedia.org/wiki/Identificador#Identificadores_en_lenguajes_informáticos) en Wikipedia
-
-<section id="Quick_links">
- <ol>
-  <li><a href="/es/docs/Glossary">Glosario</a>
-   <ol>
-    <li>{{Glossary("Identifier", "Identificador")}}</li>
-    <li>{{Glossary("Scope", "Alcance")}}</li>
-    <li>{{Glossary("String", "Cadena")}}</li>
-    <li>{{Glossary("Unicode")}}</li>
-   </ol>
-  </li>
-  <li>[Identificador](https://es.wikipedia.org/wiki/Identificador#Identificadores_en_lenguajes_informáticos) en Wikipedia</li>
- </ol>
-</section>
+- [Glosario de MDN Web Docs](/es/docs/Glossary)
+  - {{Glossary("Scope", "Alcance")}}
+  - {{Glossary("String", "Cadena")}}
+  - {{Glossary("Unicode")}}

--- a/files/es/glossary/iife/index.md
+++ b/files/es/glossary/iife/index.md
@@ -3,6 +3,8 @@ title: "IIFE: Expresión de función ejecutada inmediatamente"
 slug: Glossary/IIFE
 ---
 
+{{GlossarySidebar}}
+
 Las expresiones de función ejecutadas inmediatamente (**IIFE** por su sigla en inglés) son funciones que se ejecutan tan pronto como se definen.
 
 ```js

--- a/files/es/glossary/immutable/index.md
+++ b/files/es/glossary/immutable/index.md
@@ -3,6 +3,8 @@ title: Inmutable
 slug: Glossary/Immutable
 ---
 
+{{GlossarySidebar}}
+
 Un {{glossary("object", "objeto")}} inmutable es aquel cuyo contenido no se puede cambiar.Un objeto puede ser inmutable por varias razones, por ejemplo:
 
 - Para mejorar el rendimiento (al no haber planificados cambios futuros del objeto)

--- a/files/es/glossary/index.md
+++ b/files/es/glossary/index.md
@@ -1,18 +1,17 @@
 ---
 title: "Glosario de MDN Web Docs: Definiciones de términos relacionados con la Web"
 slug: Glossary
+short-title: Glosario de MDN Web Docs
 l10n:
   sourceCommit: ed947b2c608428b62a60f07d09dc543f732dc09b
 ---
+
+{{GlossarySidebar}}
+
+{{GlossarySidebar}}
 
 Las tecnologías web contienen largas listas de jerga y abreviaturas que se utilizan en la documentación y la codificación. Este glosario proporciona definiciones de palabras y abreviaturas que necesita saber para comprender y crear correctamente para la web.
 
 Los términos del glosario se pueden seleccionar en la barra lateral.
 
-> **Nota:** Este glosario es un trabajo en progreso interminable. Puede ayudar a mejorarlo [escribiendo nuevas entradas](/es/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_Glossary) o mejorando las existentes.
-
-<section id="Quick_links">
- <ol>
-  <li><strong><a href="/es/docs/Glossary">Glosario de MDN Web Docs</a></strong>{{ListSubpagesForSidebar("/es/docs/Glossary", 1)}}</li>
- </ol>
-</section>
+> **Nota:** Este glosario es un trabajo en progreso interminable. Puede ayudar a mejorarlo [escribiendo nuevas entradas](/es/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary) o mejorando las existentes.

--- a/files/es/glossary/index.md
+++ b/files/es/glossary/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Glosario de MDN Web Docs: Definiciones de términos relacionados con la Web"
-slug: Glossary
 short-title: Glosario de MDN Web Docs
+slug: Glossary
 l10n:
   sourceCommit: ed947b2c608428b62a60f07d09dc543f732dc09b
 ---

--- a/files/es/glossary/indexeddb/index.md
+++ b/files/es/glossary/indexeddb/index.md
@@ -3,6 +3,8 @@ title: IndexedDB
 slug: Glossary/IndexedDB
 ---
 
+{{GlossarySidebar}}
+
 IndexedDB es una {{glossary("API")}} Web diseñada para almacenar estructuras de datos grandes en los navegadores e indexarlas para realizar búsquedas de alto rendimiento. Al igual que los sistemas [RDBMS](https://es.wikipedia.org/wiki/Sistema_de_gesti%C3%B3n_de_bases_de_datos_relacionales) basados en {{glossary("SQL")}}, IndexedDB es un sistema de base de datos transaccional. Sin embargo, usa objetos de {{glossary("JavaScript")}} en vez de columnas fijas para almacenar los datos.
 
 ## Conoce más

--- a/files/es/glossary/information_architecture/index.md
+++ b/files/es/glossary/information_architecture/index.md
@@ -3,6 +3,8 @@ title: Arquitectura de la información
 slug: Glossary/Information_architecture
 ---
 
+{{GlossarySidebar}}
+
 La arquitectura de la información, aplicada al diseño y desarrollo web, es la práctica de organizar la información, contenido y funcionalidad de un sitio web para que presente la mejor experiencia de usuario posible, con información y servicios fáciles de usar y encontrar.
 
 ## Aprende más

--- a/files/es/glossary/internet/index.md
+++ b/files/es/glossary/internet/index.md
@@ -3,6 +3,8 @@ title: Internet
 slug: Glossary/Internet
 ---
 
+{{GlossarySidebar}}
+
 La Internet es una red mundial de redes que utiliza el conjunto de protocolos de Internet (tambien conocidos como {{glossary("TCP")}}/{{glossary("IPv6","IP")}} (art. en ingles) siendo sus dos mas importantes {{glossary("protocol","protocolos")}}).
 
 ## Aprender más

--- a/files/es/glossary/ip_address/index.md
+++ b/files/es/glossary/ip_address/index.md
@@ -3,6 +3,8 @@ title: Dirección IP
 slug: Glossary/IP_Address
 ---
 
+{{GlossarySidebar}}
+
 Una dirección IP es un número asignado a cada dispositivo conectado a una red que utiliza el protocolo de Internet.
 
 La «dirección IP» normalmente se sigue refiriendo a las direcciones IPv4 de 32 bits hasta que el IPv6 se despliegue más ampliamente.

--- a/files/es/glossary/ipv6/index.md
+++ b/files/es/glossary/ipv6/index.md
@@ -3,6 +3,8 @@ title: IPv6
 slug: Glossary/IPv6
 ---
 
+{{GlossarySidebar}}
+
 **IPv6** es la versión actual del protocolo de comunicación subyacente a Internet. Lentamente, IPv6 está reemplazando a IPv4, entre otras razones porque IPv6 permite muchas direcciones de IP diferentes.
 
 ## Aprende más

--- a/files/es/glossary/irc/index.md
+++ b/files/es/glossary/irc/index.md
@@ -3,6 +3,8 @@ title: IRC
 slug: Glossary/IRC
 ---
 
+{{GlossarySidebar}}
+
 **IRC** (_Internet Relay Chat_) es un sistema de chat mundial que requiere una conexión a Internet y un cliente IRC, que envía y recibe mensajes atravéz del servidor IRC.
 
 Diseñado a finales de la década de 1980 por Jarrko Oikarinen, IRC usa {{glossary("TCP")}} y es un protocolo abierto. El servidor IRC transmite mensajes a todos los que están conectados a uno de los muchos canales de IRC (cada uno con su propio ID).

--- a/files/es/glossary/isp/index.md
+++ b/files/es/glossary/isp/index.md
@@ -3,6 +3,8 @@ title: ISP
 slug: Glossary/ISP
 ---
 
+{{GlossarySidebar}}
+
 Un ISP (del inglés _Internet Service Provider_, Proveedor de servicios de Internet) es una empresa (en su mayoría compañías telefónicas) que vende acceso a Internet y, a veces, correo electrónico, alojamiento de páginas web y voz sobre IP, ya sea mediante una conexión de marcación a través de una línea telefónica (antes más común), o a través de una conexión de banda ancha como un módem de cable o un servicio DSL.
 
 ## Aprenda más

--- a/files/es/glossary/java/index.md
+++ b/files/es/glossary/java/index.md
@@ -3,15 +3,14 @@ title: Java
 slug: Glossary/Java
 ---
 
+{{GlossarySidebar}}
+
 Java es un lenguaje de {{Glossary("computer programming", "programación")}} semi-compilado, {{glossary("OOP", "orientado a objetos")}} y portable.
 
 Java está tipado estáticamente y tiene una sintaxis parecida a la de C. Tiene una gran librería de funciones fáciles de usar, el Java Software Development Kit (SDK).
 
 Los programas son {{glossary("Compile", "compilados")}} primero una única vez a byte code y empaquetados en un formato que puede ser ejecutado por la Máquina Virtual de Java (JVM). La JVM está disponible para multiples plataformas, lo que permite que los programas en Java funcionen en casi todos los sistemas sin tener que volver a compilar y empaquetar el proyecto cada vez. Esto hace que sea el lenguaje preferido de muchas empresas con distintos propósitos, aunque puede ser considerado como muy "pesado".
 
-## Saber más
-
-### Conocimientos generales
+## Véase también
 
 - [Java](<https://es.wikipedia.org/wiki/Java_(lenguaje_de_programación)>) en Wikipedia
-- {{QuickLinksWithSubpages("/es/docs/Glossary")}}

--- a/files/es/glossary/javascript/index.md
+++ b/files/es/glossary/javascript/index.md
@@ -3,6 +3,8 @@ title: JavaScript
 slug: Glossary/JavaScript
 ---
 
+{{GlossarySidebar}}
+
 {{jsSidebar}}
 
 ## Resumen

--- a/files/es/glossary/jpeg/index.md
+++ b/files/es/glossary/jpeg/index.md
@@ -3,6 +3,8 @@ title: JPEG
 slug: Glossary/JPEG
 ---
 
+{{GlossarySidebar}}
+
 **JPEG** (_Joint Photographic Experts Group_) es un método comúnmente utilizado en la compresión con pérdida de información en imágenes digitales.
 
 ## Saber más

--- a/files/es/glossary/json/index.md
+++ b/files/es/glossary/json/index.md
@@ -3,6 +3,8 @@ title: JSON
 slug: Glossary/JSON
 ---
 
+{{GlossarySidebar}}
+
 **JSON (notación de objetos javascript)** es un formato de intercambio de datos. Es muy parecido a un subconjunto de sintaxis JavaScript, aunque no es un subconjunto en sentido estricto. (Ver JSON en la Referencia JavaScript para más detalles.) Aunque muchos lenguajes de programación lo soportan, JSON es especialmente útil al escribir cualquier tipo de aplicación basada en JavaScript, incluyendo sitios web y extensiones del navegador. Por ejemplo, es posible almacenar la información del usuario en formato JSON en una cookie o almacenar las preferencias de extensión en JSON en una cadena de valores de preferencias del navegador.
 
 JSON es capaz de representar números, valores lógicos, cadenas, valores nulos, arreglos y matrices (secuencias ordenadas de valores) y objetos (mapas de cadena de valores) compuestos de estos valores (o de otras matrices y objetos). JSON no representa de manera nativa tipos de datos más complejos como funciones, expresiones regulares, fechas, y así sucesivamente (en objetos de fecha serializados por defecto como una cadena que contiene la fecha en formato ISO, al no hacerlo de ida y vuelta, la información no se pierde por completo). Si se necesita que JSON represente tipos de datos adicionales, se puede transformar los valores, ya que son serializados, o antes de su deserialización.

--- a/files/es/glossary/key/index.md
+++ b/files/es/glossary/key/index.md
@@ -3,6 +3,8 @@ title: Clave
 slug: Glossary/Key
 ---
 
+{{GlossarySidebar}}
+
 Una clave es una pieza de información utilizada por un algoritmo criptográfico para el {{Glossary("encryption", "cifrado")}} y/o {{Glossary("decryption", "descifrado")}}. Los mensajes cifrados deben permanecer seguros incluso si todo lo relacionado con el {{Glossary("cryptosystem","sistema de cifrado")}}, excepto la clave, es de conocimiento público.
 
 En la {{Glossary("symmetric-key cryptography", "criptografía de clave simétrica")}}, la misma clave se utiliza tanto para el cifrado como para el descifrado. En la criptografía de clave pública, existen un par de claves relacionadas conocidas como _clave pública_ y _clave privada_. La clave pública está disponible libremente, mientras que la clave privada se mantiene secreta. La clave pública puede cifrar mensajes que sólo la clave privada correspondiente puede descifrar, y viceversa.

--- a/files/es/glossary/keyword/index.md
+++ b/files/es/glossary/keyword/index.md
@@ -3,6 +3,8 @@ title: Palabra clave
 slug: Glossary/Keyword
 ---
 
+{{GlossarySidebar}}
+
 Una **palabra clave** es una palabra o frase que describe contenido. Las palabras clave en línea se utilizan como consultas para los motores de búsqueda o como palabras que identifican el contenido de los sitios web.
 
 Cuando usas un motor de búsqueda, utilizas palabras clave para especificar lo que estás buscando y el motor de búsqueda devuelve páginas web relevantes. Para obtener resultados más precisos, prueba con palabras clave más específicas, como "Mustang GTO azul" en lugar de simplemente "Mustang". Las páginas web también utilizan palabras clave en una etiqueta `<meta>` (en la sección {{htmlelement("head")}}) para describir el contenido de la página, de manera que los motores de búsqueda puedan identificar y organizar mejor las páginas web.

--- a/files/es/glossary/lgpl/index.md
+++ b/files/es/glossary/lgpl/index.md
@@ -3,6 +3,8 @@ title: LGPL
 slug: Glossary/LGPL
 ---
 
+{{GlossarySidebar}}
+
 _LGPL_ (GNU Lesser General Public License en español **Licencia Pública General Reducida de GNU**) es una licencia de software libre publicada por la _Free Software Foundation_. LGPL es una alternativa más permisiva que la estricta licencia [copyleft](/es/docs/Glossary/copyleft) [GPL](/es/docs/Glossary/GPL).
 
 Esto supone que cualquier trabajo que use un elemento con licencia GPL **tiene la obligación** de ser publicado bajo las mismas condiciones (libre de usar, compartir, estudiar, y modificar). Por otro lado, LGPL solo requiere que los componentes derivados del elemento bajo LGPL continuen con esta licencia, y no el programa al completo.

--- a/files/es/glossary/long_task/index.md
+++ b/files/es/glossary/long_task/index.md
@@ -3,6 +3,8 @@ title: Long task
 slug: Glossary/Long_task
 ---
 
+{{GlossarySidebar}}
+
 Una '**long task'** (tarea larga) es una tarea que tarda más de 50 ms en completarse. Es un período ininterrumpido en el que el subproceso de la interfaz de usuario principal está ocupado durante 50 ms o más. Los ejemplos comunes incluyen controladores de eventos de ejecución prolongada, [reflujos](/es/docs/Glossary/Reflow) costosos y otras representaciones, y el trabajo que realiza el navegador entre diferentes turnos del bucle de eventos que supera los 50 ms.
 
 Ver también

--- a/files/es/glossary/main_thread/index.md
+++ b/files/es/glossary/main_thread/index.md
@@ -3,23 +3,16 @@ title: Hilo principal
 slug: Glossary/Main_thread
 ---
 
+{{GlossarySidebar}}
+
 El hilo principal es donde un navegador procesa eventos y pinturas del usuario. De manera predeterminada, el navegador usa un solo hilo para ejecutar todo el JavaScript en su página, así como para realizar el diseño, los reflujos y la recolección de basura. Esto significa que las funciones de JavaScript de larga duración pueden bloquear el hilo, lo que lleva a una página que no responde y a una mala experiencia del usuario.
 
 A menos que use intencionalmente un trabajador web, como un trabajador de servicio, JavaScript se ejecuta en el hilo principal, por lo que es fácil que un script provoque retrasos en el procesamiento o la pintura de eventos. Cuanto menos trabajo se requiera del hilo principal, más puede responder ese hilo a los eventos del usuario, pintar y, en general, responder al usuario.
 
-<section id="Quick_links">
-  <ol>
-    <li>También ver
-     <ol>
-      <li><a href="/es/docs/Learn/JavaScript/Asynchronous">Asynchronous JavaScript</a></li>
-      <li><a href="/es/docs/Web/API/Web_Workers_API">Web worker API</a></li>
-      <li><a href="/es/docs/Web/API/Service_Worker_API">Service worker API</a></li>
-     </ol>
-    </li>
-    <li><a href="/es/docs/Glossary">Glossary</a>
-     <ol>
-      <li>{{Glossary("Thread")}}</li>
-     </ol>
-    </li>
-  </ol>
-</section>
+## Véase también
+
+- [Asynchronous JavaScript](/es/docs/Learn/JavaScript/Asynchronous)
+- [Web worker API](/es/docs/Web/API/Web_Workers_API)
+- [Service worker API](/es/docs/Web/API/Service_Worker_API)
+- [Glosario de MDN Web Docs](/es/docs/Glossary)
+  - {{Glossary("Thread")}}

--- a/files/es/glossary/metadata/index.md
+++ b/files/es/glossary/metadata/index.md
@@ -3,6 +3,8 @@ title: Metadatos
 slug: Glossary/Metadata
 ---
 
+{{GlossarySidebar}}
+
 Los **metadatos** son, en su definición más simple, datos que describen otros datos. Por ejemplo, un documento {{glossary("HTML")}} son datos, pero HTML también puede contener metadatos en su elemento {{htmlelement("head")}} que describe el documento, como por ejemplo, quién lo escribió y su resumen.
 
 ## Saber más

--- a/files/es/glossary/method/index.md
+++ b/files/es/glossary/method/index.md
@@ -3,6 +3,8 @@ title: Método
 slug: Glossary/Method
 ---
 
+{{GlossarySidebar}}
+
 Un **metodo** es una {{glossary("function", "función")}} la cual es {{glossary("property", "propiedad")}} de un {{glossary("Objecto", "Objeto")}}. Existen dos tipos de métodos: _Métodos de Instancia_ los cuales son tareas integradas realizadas por la instacia de un objeto, y los _Métodos Estáticos_ que son tareas que pueden ser llamadas directamente en el constructor de un objeto.
 
 > **Nota:** en JavaScript las funciones en si son objetos, asi que, en ese contexto, un método es de hecho un {{glossary("Object Reference", "objeto de referencia")}} a una función.

--- a/files/es/glossary/mitm/index.md
+++ b/files/es/glossary/mitm/index.md
@@ -3,6 +3,8 @@ title: MitM
 slug: Glossary/MitM
 ---
 
+{{GlossarySidebar}}
+
 Un ataque de Intermediario \[**Man-in-the-middle attack** (MitM)] intercepta una comunicación entre dos sistemas. Por ejemplo, un router Wi-Fi puede estar en peligro.
 
 Comparémoslo con un correo físico: si usted está escribiendo una carta a una persona, el cartero puede interceptar cada carta que envíe. Ellos la abren, la leen y finalmente la modifican, y entonces la reempaquetan y solamente entonces la envían a los destinatarios que usted pretendió. El receptor original podría entonces contestarle y el cartero abriría de nuevo la carta, la leería y finalmente la modificaria, la reempaquetaría y se la da. Usted ignoraría que hay un hombre en medio de su canal de comunicación – el cartero es invisible para usted y para su destinatario.

--- a/files/es/glossary/mixin/index.md
+++ b/files/es/glossary/mixin/index.md
@@ -3,6 +3,8 @@ title: Mixin
 slug: Glossary/Mixin
 ---
 
+{{GlossarySidebar}}
+
 Un _mixin_ es un conjunto coherente de {{glossary("method","métodos")}} y {{glossary("property","propiedades")}} implementadas por otras interfaces y {{glossary("class","clases")}}.
 
 Ejemplo

--- a/files/es/glossary/mobile_first/index.md
+++ b/files/es/glossary/mobile_first/index.md
@@ -3,4 +3,6 @@ title: Mobile First
 slug: Glossary/Mobile_First
 ---
 
+{{GlossarySidebar}}
+
 **Mobile first**, una forma de {{Glossary("progressive enhancement", "mejora progresiva")}}, es un enfoque de desarrollo y diseño web que se enfoca en la priorización del diseño y el desarrollo para dispositivos móviles por encima del diseño y desarrollo para pantallas de escritorio. El fundamento detrás del enfoque "mobile-first" es proveer al usuario una buena experiencia para todos los tamaños de pantalla—empezando por una experiencia de usuario que funcione bien para dispositivos pequeños, para posteriormente, basada en dicha experiencia, continuar desarrollando para enriquecer la experiencia de usuario conforme el tamaño de pantalla es mayor. El enfoque "mobile-first" contrasta con el antiguo enfoque de diseño para escritorio en el que se pensaba primero en el diseño/desarrollo para tamaños de pantalla de escritorio y posteriormente se realizaban ajustes para conseguir que dichos diseños y desarrollos funcionases correctamente en dispositivos móbilies.

--- a/files/es/glossary/mozilla_firefox/index.md
+++ b/files/es/glossary/mozilla_firefox/index.md
@@ -3,6 +3,8 @@ title: Mozilla Firefox
 slug: Glossary/Mozilla_Firefox
 ---
 
+{{GlossarySidebar}}
+
 Mozilla Firefox es un {{Glossary("navegador")}} gratuito de codigo abierto cuyo desarrollo es supervisado por Mozilla Corporation. Firefox functiona sobre Windows, OS X, Linus y Android.
 
 Lanzado en Noviembre del 2004, Firefox es completamente personalizable con temas y [complementos](/es/Add-ons). Firefox usa {{glossary("Gecko")}} para renderizar paginas webs, e implementa tanto actuales como próximos estandares Web.

--- a/files/es/glossary/mvc/index.md
+++ b/files/es/glossary/mvc/index.md
@@ -3,6 +3,8 @@ title: MVC
 slug: Glossary/MVC
 ---
 
+{{GlossarySidebar}}
+
 **MVC** (Modelo-Vista-Controlador) es un patrón en el diseño de software comúnmente utilizado para implementar interfaces de usuario, datos y lógica de control. Enfatiza una separación entre la lógica de negocios y su visualización. Esta "separación de preocupaciones" proporciona una mejor división del trabajo y una mejora de mantenimiento. Algunos otros patrones de diseño se basan en MVC, como MVVM (Modelo-Vista-modelo de vista), MVP (Modelo-Vista-Presentador) y MVW (Modelo-Vista-Whatever).
 
 Las tres partes del patrón de diseño de software MVC se pueden describir de la siguiente manera:

--- a/files/es/glossary/namespace/index.md
+++ b/files/es/glossary/namespace/index.md
@@ -5,6 +5,8 @@ l10n:
   sourceCommit: 4bd65a01204446af2254bb8864bd22ad87bc86b0
 ---
 
+{{GlossarySidebar}}
+
 Un Espacio de Nombres es un contexto para identificadores, un agrupamiento lógico de nombres usado en un programa. Dentro del mismo contexto, y el mismo ámbito, un identificator debe reconocer una entidad de forma única.
 
 En un sistema operativo, un directorio es un espacio de nombre. Cada archivo o subdirectorio tiene un nombre único, pero un archivo puede usar el mismo nombre múltiples veces.

--- a/files/es/glossary/node.js/index.md
+++ b/files/es/glossary/node.js/index.md
@@ -3,6 +3,8 @@ title: Node.js
 slug: Glossary/Node.js
 ---
 
+{{GlossarySidebar}}
+
 Node.js es un entorno de ejecucion multiplataforma en {{Glossary("JavaScript")}} que permite a los desarrolladores construir aplicaciones del lado del servidor y de red con JavaScript.
 
 ## Saber más

--- a/files/es/glossary/node/dom/index.md
+++ b/files/es/glossary/node/dom/index.md
@@ -3,6 +3,8 @@ title: Node (DOM)
 slug: Glossary/Node/DOM
 ---
 
+{{GlossarySidebar}}
+
 En el contexto del {{Glossary("DOM")}}, un **nodo** es un único punto en el arbol de nodos. Los nodos pueden ser varias cosas el documento mismo, elementos, texto y comentarios.
 
 ## Saber más

--- a/files/es/glossary/node/index.md
+++ b/files/es/glossary/node/index.md
@@ -3,6 +3,8 @@ title: Node
 slug: Glossary/Node
 ---
 
+{{GlossarySidebar}}
+
 El término **nodo** puede tener varios significados según el contexto. Puede referirse a:
 
 {{GlossaryDisambiguation}}

--- a/files/es/glossary/null/index.md
+++ b/files/es/glossary/null/index.md
@@ -3,6 +3,8 @@ title: "Null"
 slug: Glossary/Null
 ---
 
+{{GlossarySidebar}}
+
 En ciencias informáticas, un valor **null** representa una referencia que apunta, generalmente intencionadamente, a una inexistente o inválido {{glossary("objecto","objeto")}} o dirección. El significado de una referencia null varía entre las implementaciones de lenguajes.
 
 En {{Glossary("JavaScript")}}, null es uno de los {{Glossary("Primitivo", "valores primitivos")}}.

--- a/files/es/glossary/number/index.md
+++ b/files/es/glossary/number/index.md
@@ -3,6 +3,8 @@ title: Number
 slug: Glossary/Number
 ---
 
+{{GlossarySidebar}}
+
 En {{Glossary("JavaScript")}}, **Number** es un tipo de datos numérico ([double-precision 64-bit floating point format (IEEE 754)](https://es.wikipedia.org/wiki/Formato_en_coma_flotante_de_doble_precisi%C3%B3n)). En otros lenguajes de programación puede existir diferentes tipos numéricos, por ejemplo: Integers, Floats, Doubles, or Bignums.
 
 ## Aprende más

--- a/files/es/glossary/object/index.md
+++ b/files/es/glossary/object/index.md
@@ -3,6 +3,8 @@ title: Object
 slug: Glossary/Object
 ---
 
+{{GlossarySidebar}}
+
 El [Object](/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object) se refiere a una estructura de datos que contiene datos e instrucciones para trabajar con los datos. Algunas veces los Objects se refieren a cosas del mundo real, por ejemplo, un object de un coche o mapa en un juego de carreras. {{glossary("JavaScript")}}, Java, C++, y Python son ejemplos de {{glossary("OOP","programación orientada a objetos")}}.
 
 ## Aprender más

--- a/files/es/glossary/oop/index.md
+++ b/files/es/glossary/oop/index.md
@@ -3,6 +3,8 @@ title: Programación orientada a objetos
 slug: Glossary/OOP
 ---
 
+{{GlossarySidebar}}
+
 **OOP** (Programación orientada a objetos) es un paradigma de programación en el que los datos son encapsulados en **{{glossary("object","objetos")}},** los cuales tienen su propio comportamiento.
 
 {{glossary("JavaScript")}} esta altamente orientado a objetos. Sigue el modelo basado en prototipado (en oposición al modelo basado en **{{glossary("Class","clases")}}**).

--- a/files/es/glossary/operand/index.md
+++ b/files/es/glossary/operand/index.md
@@ -3,6 +3,8 @@ title: Operando
 slug: Glossary/Operand
 ---
 
+{{GlossarySidebar}}
+
 **Un operando** es la parte de una instruccion que representa los datos manipulados por el {{glossary("Operator")}}. por ejemplo, cuando sumas dos numeros, los numeros son el operando y "+" es el operador.
 
 ## Aprende mas

--- a/files/es/glossary/operator/index.md
+++ b/files/es/glossary/operator/index.md
@@ -3,6 +3,8 @@ title: Operador
 slug: Glossary/Operator
 ---
 
+{{GlossarySidebar}}
+
 Parte de la sintaxis reservada consistente en signos de puntuación o carácteres alfanuméricos que tienen funcionalidades incorporadas. Por ejemplo, "+" indica el operador suma y "!" indica el operador "not" (negación).
 
 ## Aprende más

--- a/files/es/glossary/parse/index.md
+++ b/files/es/glossary/parse/index.md
@@ -3,6 +3,8 @@ title: Parse (análisis sintáctico)
 slug: Glossary/Parse
 ---
 
+{{GlossarySidebar}}
+
 "Parsing" significa analizar y convertir un programa en un formato interno que un entorno de ejecución pueda realmente ejecutar, por ejemplo el motor {{glossary("JavaScript")}} dentro de los navegadores.
 
 El [navegador analiza el HTML](/docs/Web/Guide/HTML/HTML5/HTML5_Parser) en un árbol {{glossary('DOM')}}. El análisis de HTML implica la "[tokenización](/docs/Web/API/DOMTokenList)" (dividir en fragmentos) y en la construcción del árbol. Los "tokens" HTML incluyen etiquetas de inicio y final, así como nombres de atributos y valores. Si el documento está bien formado, el análisis sintáctico es más sencillo y rápido. El "parser" analiza la entrada simbólica en el documento, construyendo el árbol del documento.

--- a/files/es/glossary/php/index.md
+++ b/files/es/glossary/php/index.md
@@ -5,6 +5,8 @@ l10n:
   sourceCommit: 4bd65a01204446af2254bb8864bd22ad87bc86b0
 ---
 
+{{GlossarySidebar}}
+
 PHP (una inicialización recursiva para PHP: preprocesador de hipertexto) es un lenguaje de script de código abierto del lado del servidor que puede integrarse en HTML para crear aplicaciones web y sitios web dinámicos.
 
 ## Ejemplos
@@ -51,7 +53,6 @@ PHP (una inicialización recursiva para PHP: preprocesador de hipertexto) es un 
 - [PHP](https://es.wikipedia.org/wiki/PHP) en Wikipedia
 - [Programación PHP](https://en.wikibooks.org/wiki/PHP_Programming) en Wikibooks
 - [Glosario de documentos web de MDN](/es/docs/Glossary)
-
   - {{Glossary("Java")}}
   - {{Glossary("JavaScript")}}
   - {{Glossary("Python")}}

--- a/files/es/glossary/plaintext/index.md
+++ b/files/es/glossary/plaintext/index.md
@@ -3,6 +3,8 @@ title: Texto Simple
 slug: Glossary/Plaintext
 ---
 
+{{GlossarySidebar}}
+
 Texto simple se refiere a la información que se está utilizando como entrada para un {{Glossary("algorithm", "algoritmo")}} de {{Glossary("encryption","cifrado")}}, o para el {{Glossary("ciphertext", "texto cifrado")}} que se ha descifrado.
 
 Con frecuencia se usa indistintamente con el término texto claro, que se refiere de manera más general a cualquier información, como un documento de texto, una imagen, etc., que no se haya cifrado y que un humano o una computadora puedan leer sin procesamiento adicional.

--- a/files/es/glossary/polyfill/index.md
+++ b/files/es/glossary/polyfill/index.md
@@ -3,6 +3,8 @@ title: Polyfill
 slug: Glossary/Polyfill
 ---
 
+{{GlossarySidebar}}
+
 Un polyfill es un fragmento de código (generalmente JavaScript en la Web) que se utiliza para proporcionar una funcionalidad moderna en navegadores antiguos que no lo admiten de forma nativa.
 
 Por ejemplo, se podría usar un polyfill para imitar la funcionalidad de un elemento HTML Canvas en Microsoft Internet Explorer 7 usando un complemento de Silverlight, o un soporte mímico para las unidades rem CSS, o {{cssxref("text-shadow")}}, o lo que tu quieras.

--- a/files/es/glossary/pop/index.md
+++ b/files/es/glossary/pop/index.md
@@ -3,20 +3,17 @@ title: POP3
 slug: Glossary/POP
 ---
 
+{{GlossarySidebar}}
+
 **POP3** (Protocolo de Oficina de Correo por sus siglas en inglés) es un [protocolo](/es/docs/Glossary/Protocol) muy común para obtener correos desde un servidor de correos por medio de una conexión [TCP](/es/docs/Glossary/TCP). POP3 no soporta directorios, a diferencia del más reciente [IMAP4](/es/docs/Glossary/IMAP), el cual es más difícil de implementar dada su extructura más compleja.
 
 Los clientes usualmente recuperan todos los mensajes y luego los eliminan del servidor, pero POP3 permite retener una copia en el servidor. Casi todos los servidores y clientes de correo actualmente soportan POP3.
 
-<section id="Quick_links">
- <ul>
-  <li><a href="https://es.wikipedia.org/wiki/Protocolo_de_oficina_de_correo">POP</a> en Wikipedia</li>
-  <li><a href="https://tools.ietf.org/html/rfc1734">RFC 1734</a> (Especificación del mecanismo de autenticación de POP3)</li>
-  <li><a href="https://tools.ietf.org/html/rfc1939">RFC 1939</a> (Especificación de POP3)</li>
-  <li><a href="https://tools.ietf.org/html/rfc2449">RFC 2449</a> (Especificación del mecanismo de extensión de POP3)</li>
-  <li><a href="/es/docs/Glossary">MDN Glosario de Web Docs</a>:
-   <ul>
-    <li><a href="/es/docs/Glossary/IMAP">IMAP4</a></li>
-   </ul>
-  </li>
- </ul>
-</section>
+## Véase también
+
+- [POP](https://es.wikipedia.org/wiki/Protocolo_de_oficina_de_correo) en Wikipedia
+- [RFC 1734](https://tools.ietf.org/html/rfc1734) (Especificación del mecanismo de autenticación de POP3)
+- [RFC 1939](https://tools.ietf.org/html/rfc1939) (Especificación de POP3)
+- [RFC 2449](https://tools.ietf.org/html/rfc2449) (Especificación del mecanismo de extensión de POP3)
+- [Glosario de MDN Web Docs](/es/docs/Glossary)
+  - {{Glossary("IMAP", "IMAP4")}}

--- a/files/es/glossary/port/index.md
+++ b/files/es/glossary/port/index.md
@@ -3,6 +3,8 @@ title: Puerto
 slug: Glossary/Port
 ---
 
+{{GlossarySidebar}}
+
 Para un ordenador conectado a una red con una [dirección IP](/es/docs/Glossary/IP_address), un **puerto** es el destino de la comunicación. Los puertos están designados por números, por debajo de 1024 cada puerto está asociado por defecto con un [protocolo](/es/docs/Glossary/Protocol) específico.
 
 Por ejemplo, el puerto por defecto para el protocolo [HTTP](/es/docs/Glossary/HTTP) es 80 y el puerto por defecto para el protocolo [HTTPS](/es/docs/Glossary/https) es 443, por lo tanto un servidor HTTP espera peticiones en esos puertos. Cada protocolo de internet está asociado con un puerto por defecto: [SMTP](/es/docs/Glossary/SMTP) (25), [POP3](/es/docs/Glossary/POP) (110), [IMAP](/es/docs/Glossary/IMAP) (143), [IRC](/es/docs/Glossary/IRC) (194), y así sucesivamente.

--- a/files/es/glossary/preflight_request/index.md
+++ b/files/es/glossary/preflight_request/index.md
@@ -3,6 +3,8 @@ title: Preflight petición
 slug: Glossary/Preflight_request
 ---
 
+{{GlossarySidebar}}
+
 Una petición preflight CORS es una petición [CORS](/es/docs/Glossary/CORS) realizada para comprobar si el protocolo {{Glossary("CORS")}} es comprendido.
 
 Es una petición {{HTTPMethod("OPTIONS")}}, que emplea tres cabeceras HTTP: {{HTTPHeader("Access-Control-Request-Method")}}, {{HTTPHeader("Access-Control-Request-Headers")}}, y la cabecera {{HTTPHeader("Origin")}} .
@@ -29,7 +31,7 @@ Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE
 Access-Control-Max-Age: 86400
 ```
 
-## See also
+## Véase también
 
 - [CORS](/es/docs/Glossary/CORS)
 - {{HTTPMethod("OPTIONS")}}

--- a/files/es/glossary/primitive/index.md
+++ b/files/es/glossary/primitive/index.md
@@ -3,6 +3,8 @@ title: Primitivo
 slug: Glossary/Primitive
 ---
 
+{{GlossarySidebar}}
+
 En {{Glossary("JavaScript")}}, un **primitive** (valor primitivo, tipo de dato primitivo) son datos que no son un {{Glossary("object", "objeto")}} y no tienen {{Glossary("method", "métodos")}}. Hay 6 tipos de datos primitivos: {{Glossary("string")}}, {{Glossary("number")}}, {{Glossary("bigint")}}, {{Glossary("boolean")}}, {{Glossary("undefined")}} y {{Glossary("symbol")}}. También hay {{Glossary("null")}}, que aparentemente es primitivo, pero de hecho es un caso especial para cada {{JSxRef("Object")}}: y cualquier tipo estructurado se deriva de `null` por la [Cadena de prototipos](/es/docs/Learn/JavaScript/Objects/Inheritance).
 
 La mayoría de las veces, un valor primitivo se representa directamente en el nivel más bajo de la implementación del lenguaje.
@@ -89,27 +91,16 @@ A excepción de `null` y `undefined`, todos los valores primitivos tienen objeto
 
 El método {{JSxRef("Objetos_globales/Object/valueOf"," valueOf()")}} del contenedor devuelve el valor primitivo.
 
-## Aprende más
+## Véase también
 
-### Conocimientos generales
-
-- {{JSxRef("Data_structures", "Introducción a los tipos de datos de JavaScript")}}
+- [Tipos de datos JavaScript](/es/docs/Web/JavaScript/Data_structures)
 - [Tipo de dato primitivo](https://es.wikipedia.org/wiki/Tipo_de_dato_primitivo) en Wikipedia
-
-<section id="Quick_links">
- <ol>
-  <li><a href="/es/docs/Glossary">Glosario</a>
-   <ol>
-    <li>{{Glossary("JavaScript")}}</li>
-    <li>{{Glossary("string")}}</li>
-    <li>{{Glossary("number")}}</li>
-    <li>{{Glossary("bigint")}}</li>
-    <li>{{Glossary("boolean")}}</li>
-    <li>{{Glossary("null")}}</li>
-    <li>{{Glossary("undefined")}}</li>
-    <li>{{Glossary("symbol")}}</li>
-   </ol>
-  </li>
-  <li>{{JSxRef("Data_structures", "Tipos de datos JavaScript")}}</li>
- </ol>
-</section>
+- [Glosario de MDN Web Docs](/es/docs/Glossary)
+  - {{Glossary("JavaScript")}}
+  - {{Glossary("string")}}
+  - {{Glossary("number")}}
+  - {{Glossary("bigint")}}
+  - {{Glossary("boolean")}}
+  - {{Glossary("null")}}
+  - {{Glossary("undefined")}}
+  - {{Glossary("symbol")}}

--- a/files/es/glossary/progressive_enhancement/index.md
+++ b/files/es/glossary/progressive_enhancement/index.md
@@ -3,6 +3,8 @@ title: Mejora Progresiva
 slug: Glossary/Progressive_Enhancement
 ---
 
+{{GlossarySidebar}}
+
 **Mejora progresiva** es una filosofía de diseño que se centra en proporcionar una base de contenido y funcionalidad esenciales para la mayor cantidad de usuarios posible. Al mismo tiempo va más allá y trata de ofrecer la mejor experiencia posible sólo a los usuarios de los navegadores más modernos los cuales pueden ejecutar todo código requerido.
 
 La [detección de características](/es/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection) se usa generalmente para determinar si los navegadores pueden manejar todo el contenido de alto nivel o no. Habitualmente se usan los [polyfills](/es/docs/Glossary/Polyfill) para incorporar las características faltantes con JavaScript.

--- a/files/es/glossary/promise/index.md
+++ b/files/es/glossary/promise/index.md
@@ -3,6 +3,8 @@ title: Promesa
 slug: Glossary/Promise
 ---
 
+{{GlossarySidebar}}
+
 Una **{{jsxref("Promesa")}}** es un {{Glossary("objeto")}} devuelto por una {{Glossary("función")}} que no ha completado su tarea. La promesa representa literalmente una promesa creada por una función a la que le llegará un resultado en un futuro.
 
 Cuando la función termina su tarea {{Glossary("asynchronous", "de forma asíncrona")}}, una función del objeto "promesa" será ejecutada.

--- a/files/es/glossary/property/index.md
+++ b/files/es/glossary/property/index.md
@@ -3,6 +3,8 @@ title: Propiedad
 slug: Glossary/Property
 ---
 
+{{GlossarySidebar}}
+
 El término **propiedad** puede tener varios significados según el contexto. Se puede referir a:
 
 {{GlossaryDisambiguation}}

--- a/files/es/glossary/protocol/index.md
+++ b/files/es/glossary/protocol/index.md
@@ -3,6 +3,8 @@ title: Protocolo
 slug: Glossary/Protocol
 ---
 
+{{GlossarySidebar}}
+
 Un **protocolo** es un conjunto de reglas que definen cómo se intercambian los datos dentro o entre ordenadores. La comunicación entre dispositivos requiere que estos estén de acuerdo con el formato de los datos que están siendo intercambiados. Al conjunto de reglas que definen este formato se le llama protocolo.
 
 ## Saber más

--- a/files/es/glossary/prototype-based_programming/index.md
+++ b/files/es/glossary/prototype-based_programming/index.md
@@ -3,6 +3,8 @@ title: Prototype-based programming
 slug: Glossary/Prototype-based_programming
 ---
 
+{{GlossarySidebar}}
+
 **La programación basada en prototipos** es un estilo de {{Glossary("OOP", "programación orientada a objetos")}} en el que las {{Glossary('Clase', 'clases')}} no se definen explícitamente, sino que se derivan de agregar propiedades y métodos a una instancia de otra clase o, con menos frecuencia, agregarlos a un objeto vacío.
 
 En palabras simples: este tipo de estilo permite la creación de un {{Glossary('Objeto', 'objeto')}} sin definir primero su {{Glossary('Clase', 'clase')}}.

--- a/files/es/glossary/prototype/index.md
+++ b/files/es/glossary/prototype/index.md
@@ -3,6 +3,8 @@ title: Prototipo
 slug: Glossary/Prototype
 ---
 
+{{GlossarySidebar}}
+
 Un prototipo es un modelo que muestra pronto en el ciclo de desarrollo la apariencia y el comportamiento de una aplicación o producto.
 
 Mira [La herencia y la cadena de prototipado.](/es/docs/Web/JavaScript/Inheritance_and_the_prototype_chain)

--- a/files/es/glossary/pseudo-class/index.md
+++ b/files/es/glossary/pseudo-class/index.md
@@ -3,6 +3,8 @@ title: Pseudo-clase
 slug: Glossary/Pseudo-class
 ---
 
+{{GlossarySidebar}}
+
 En CSS, un selector de **pseudo-clase** apunta a elementos dependiendo de su estado en lugar de en su información en el arbol del documento. Por ejemplo, el selector `a` {{cssxref(":visited")}} aplica estilos solamente a los links que el usuario ha visitado.
 
 ## Aprender más

--- a/files/es/glossary/pseudocode/index.md
+++ b/files/es/glossary/pseudocode/index.md
@@ -3,6 +3,8 @@ title: Pseudocódigo
 slug: Glossary/Pseudocode
 ---
 
+{{GlossarySidebar}}
+
 El pseudocódigo se refiere a la sintaxis del código que generalmente se usa para indicar a los humanos cómo funciona dicho código, o para ilustrar el diseño de un elemento. No funcionará si intentas ejecutarlo como código.
 
 ## Saber más

--- a/files/es/glossary/public-key_cryptography/index.md
+++ b/files/es/glossary/public-key_cryptography/index.md
@@ -3,6 +3,8 @@ title: Criptografía de clave pública
 slug: Glossary/Public-key_cryptography
 ---
 
+{{GlossarySidebar}}
+
 La criptografía de clave pública es un sistema criptográfico en el que las claves vienen en pares. La transformación realizada por una de las claves solo se puede deshacer con la otra clave. Una clave (la clave privada) se mantiene secreta mientras que la otra se hace pública.
 
 Cuando se usa para firmas digitales, la clave privada se usa para firmar y la clave pública para verificar. Esto significa que cualquier persona puede verificar una firma, pero solo el propietario de la clave privada correspondiente podría haberla generado.

--- a/files/es/glossary/python/index.md
+++ b/files/es/glossary/python/index.md
@@ -3,6 +3,8 @@ title: Python
 slug: Glossary/Python
 ---
 
+{{GlossarySidebar}}
+
 **Python** es un leguaje de programación de alto nivel y de propósito general. Utiliza un enfoque multiparadigma, lo que significa que soporta programación orientada a objetos, procedural y en menor medida, programación funcional.
 
 Fue creado por Guido van Rossun como sucesor a otro lenguaje (llamado ABC) entre 1985 y 1990, y es usado actualmente en una gran variedad de campos, como el desarrollo web, en la creación de aplicaciones actuales y para la construcción de archivos de procesamiento por lotes (Scripts).

--- a/files/es/glossary/recursion/index.md
+++ b/files/es/glossary/recursion/index.md
@@ -3,6 +3,8 @@ title: Recursión
 slug: Glossary/Recursion
 ---
 
+{{GlossarySidebar}}
+
 Es el acto de una función llamándose a sí misma. La recursión es utilizada para resolver problemas que contienen subproblemas más pequeños. Una función recursiva puede recibir 2 entradas: un caso base (finaliza la recursión) o un un caso recursivo (continúa la recursión).
 
 ## Saber más

--- a/files/es/glossary/reflow/index.md
+++ b/files/es/glossary/reflow/index.md
@@ -3,6 +3,8 @@ title: Reflow
 slug: Glossary/Reflow
 ---
 
+{{GlossarySidebar}}
+
 **Un Reflow** sucede cuando un {{glossary("navegador")}} debe procesar y pintar parte de, o toda una pagina web nuevamente, Como despues de actualizar un sitio web interactivo
 
 ## Aprende más

--- a/files/es/glossary/regular_expression/index.md
+++ b/files/es/glossary/regular_expression/index.md
@@ -3,6 +3,8 @@ title: Expresiones regulares
 slug: Glossary/Regular_expression
 ---
 
+{{GlossarySidebar}}
+
 **Expresiones regulares** (o _regex_) son reglas que definen las secuencias de caracteres obtenidas en una busqueda.
 
 Las expresiones regulares están incluidas en varios lenguages, pero las más conocida es la de Perl, que ha dado lugar a su propio ecosistema llamado PCRE (_Perl Compatible Regular Expression_). En la web, {{glossary("JavaScript")}} proporciona otra implementación de expresiones regulares a través del objeto {{jsxref("RegExp")}}.

--- a/files/es/glossary/response_header/index.md
+++ b/files/es/glossary/response_header/index.md
@@ -3,6 +3,8 @@ title: Cabecera de respuesta
 slug: Glossary/Response_header
 ---
 
+{{GlossarySidebar}}
+
 Una **cabecera de respuesta** (en inglés _response header_) es una {{Glossary("HTTP header")}} que puede ser usada en una respuesta HTTP y que no tiene que ver con el contenido del mensaje. Las cabeceras de respuesta, como {{HTTPHeader("Age")}}, {{HTTPHeader("Location")}} o {{HTTPHeader("Server")}} son usadas para dar un contexto más detallado de la respuesta.
 
 No todas las cabeceras que aparecen en una respuesta son categorizada como _cabeceras de respuesta_ por la especificación. Por ejemplo, la cabecera {{HTTPHeader("Content-Type")}} es una {{glossary("representation header")}} indicando el tipo original de datos en el cuerpo del mensaje de respuesta (previo a que la codificación en la cabecera de representación {{HTTPHeader("Content-Encoding")}} sea aplicada). Sin embargo, en un mensaje de respuesta, "conversacionalmente" todas las cabeceras son usualmente llamadas como cabeceras de respuesta.

--- a/files/es/glossary/responsive_web_design/index.md
+++ b/files/es/glossary/responsive_web_design/index.md
@@ -3,6 +3,8 @@ title: Diseño web responsivo
 slug: Glossary/Responsive_web_design
 ---
 
+{{GlossarySidebar}}
+
 Diseño web responsivo (del inglés _**R**esponsive **W**eb **D**esign_) o **RWD** es un concepto de desarrollo web que se centra en hacer que los sitios se vean y se comporten de manera óptima en todos los dispositivos informáticos personales, desde el escritorio hasta el móvil.
 
 ## Aprender más

--- a/files/es/glossary/rest/index.md
+++ b/files/es/glossary/rest/index.md
@@ -3,6 +3,8 @@ title: REST
 slug: Glossary/REST
 ---
 
+{{GlossarySidebar}}
+
 El término "Transferencia de Estado Representacional" (**REST**) representa un conjunto de características de diseño de arquitecturas software que aportan confiabilidad, eficiencia y escalibilidad a los sistemas distribuidos. Un sistema es llamado RESTful cuando se ajusta a estas características.
 
 La idea básica de REST es que un recurso, e.j. un documento, es transferido con su estado y su relaciones (hipertexto) mediante formatos y operaciones estandarizadas bien definidas.

--- a/files/es/glossary/rgb/index.md
+++ b/files/es/glossary/rgb/index.md
@@ -3,6 +3,8 @@ title: RGB
 slug: Glossary/RGB
 ---
 
+{{GlossarySidebar}}
+
 Red Green Blue (RGB) es un modelo de color que representa los colores como mezclas de tres componentes subyacentes (o canales), rojo, verde y azul. Cada color se describe mediante una secuencia de tres números (normalmente entre 0.0 y 1.0, o entre 0 y 255) que representan las diferentes intensidades (o contribuciones) de rojo, verde y azul para determinar el color final.
 
 Hay muchas formas de describir los componentes RGB de un color. En {{Glossary("CSS")}} se pueden representar como un solo entero de 24 bits en notación hexadecimal (por ejemplo, `#ADD8E6` is azul claro), o en notación funcional como tres enteros de 8 bits separados (por ejemplo , rgb (46, 139, 87) es verde mar). En {{Glossary("OpenGL")}}, {{Glossary("WebGL")}}, y {{Glossary("GLSL")}} los componentes rojo-verde-azul son fracciones (números en coma flotante entre 0.0 y 1.0), aunque en el búfer de color real normalmente se almacenan como enteros de 8 bits. Gráficamente, un color se puede representar como un punto en una cuadrícula o cubo tridimensional, donde cada dimensión (o eje) corresponde a un canal diferente.

--- a/files/es/glossary/rss/index.md
+++ b/files/es/glossary/rss/index.md
@@ -3,6 +3,8 @@ title: RSS
 slug: Glossary/RSS
 ---
 
+{{GlossarySidebar}}
+
 _RSS_ (Really Simple Syndication en español Sindicación Realmente Simple) hace referencia a los diferentes formatos de [XML](/es/docs/Glossary/XML) diseñados para sitios web de noticias.
 
 Cuando te subscribes a un _feed_ RSS (boletín de noticias de servicios web), éste te envía información y actualizaciones al _feed_ de tu lector RSS, y de esta manera no es necesario que el usuario busque manuelmente en cada sitio web.

--- a/files/es/glossary/ruby/index.md
+++ b/files/es/glossary/ruby/index.md
@@ -5,6 +5,8 @@ l10n:
   sourceCommit: 4bd65a01204446af2254bb8864bd22ad87bc86b0
 ---
 
+{{GlossarySidebar}}
+
 **Ruby** es un lenguaje de programación de código abierto. En el contexto {{glossary("world wide web", "Web")}}, Ruby se suele usar en el lado del servidor con el framework **Ruby On Rails** (ROR) para producir sitios web y aplicaciones.
 
 Ruby también es un método para anotar texto de Asia oriental en documentos HTML para proporcionar información de pronunciación; consulte el elemento {{HTMLElement("ruby")}}.

--- a/files/es/glossary/safe/index.md
+++ b/files/es/glossary/safe/index.md
@@ -3,6 +3,8 @@ title: Seguro
 slug: Glossary/Safe
 ---
 
+{{GlossarySidebar}}
+
 Un método HTTP es **seguro** cuando no altera el estado del servidor. En otras palabras, un método HTTP es seguro solo cuando ejecuta una operación de lectura. Todos los métodos seguros también son {{glossary("idempotent")}} así como algunos, pero no todos, métodos inseguros como {{HTTPMethod("PUT")}}, o {{HTTPMethod("DELETE")}}.
 
 Incluso si los métodos seguros tienen una semántica de solo lectura, los servidores pueden alterar su estado: por ejemplo, pueden registrar o mantener estadísticas. Lo importante aquí es que al llamar a un método seguro, el cliente no solicita ningún cambio en el servidor y, por lo tanto, no creará una carga o carga innecesaria para el servidor. Los navegadores pueden llamar a métodos seguros sin temor a causar ningún daño al servidor: esto les permite realizar actividades como la búsqueda previa sin riesgos. Los rastreadores web también confían en llamar a métodos seguros.

--- a/files/es/glossary/scm/index.md
+++ b/files/es/glossary/scm/index.md
@@ -3,6 +3,8 @@ title: SCV
 slug: Glossary/SCM
 ---
 
+{{GlossarySidebar}}
+
 Un SCV (sistema de control de versiones) es un sistema para gestionar código fuente. Normalmente se refiere al uso de software para manejar versiones de ficheros fuente. Un programador puede modificar ficheros de código fuente sin miedo a eliminar código que funciona, porque un SCV realiza un seguimiento de cómo el código fuente ha cambiado y quién ha realizado los cambios.
 
 Algunos sistemas SCV son CVS, SVN y Git.

--- a/files/es/glossary/scope/index.md
+++ b/files/es/glossary/scope/index.md
@@ -3,6 +3,8 @@ title: Scope
 slug: Glossary/Scope
 ---
 
+{{GlossarySidebar}}
+
 El contexto actual de ejecución. El contexto en el que los valores y las expresiones son "visibles" o pueden ser referenciados. Si una variable u otra expresión no está "en el Scope- alcance actual", entonces no está disponible para su uso. Los Scope también se pueden superponer en una jerarquía, de modo que los Scope secundarios tengan acceso a los ámbitos primarios, pero no al revés.
 
 Una función sirve como un cierre en JavaScript y, por lo tanto, crea un ámbito, de modo que (por ejemplo) no se puede acceder a una variable definida exclusivamente dentro de la función desde fuera de la función o dentro de otras funciones. Por ejemplo, lo siguiente no es válido:

--- a/files/es/glossary/seo/index.md
+++ b/files/es/glossary/seo/index.md
@@ -3,6 +3,8 @@ title: SEO
 slug: Glossary/SEO
 ---
 
+{{GlossarySidebar}}
+
 **SEO** (Search Engine Optimization) también conocido como posicionamiento web, es el proceso de hacer un sitio web más visible en los resultados de búsqueda o mejorar el ranking de búsqueda.
 
 Los motores de búsqueda siguen los enlaces de una página a otra, y el índice del contenido encontrado. Al realizar una búsqueda, el motor de búsqueda muestra el contenido indexado en base a su tabla de contenidos organizándolos guiados por las reglas de su algoritmo. El cumplimiento de las directrices de los buscadores con exactitud no implica el correcto posicionamiento del proyecto asociado en los mejores resultados, pero sí la ausencia de una penalización por parte del algoritmo del buscador.

--- a/files/es/glossary/sgml/index.md
+++ b/files/es/glossary/sgml/index.md
@@ -3,6 +3,8 @@ title: SGML
 slug: Glossary/SGML
 ---
 
+{{GlossarySidebar}}
+
 El _Lenguaje de marcado generalizado estándar_ (**SGML**) es una especificación {{Glossary("ISO")}} para definir lenguajes de marcado declarativos.
 
 En la Web, {{Glossary("HTML")}} 4, {{Glossary("XHTML")}}, y {{Glossary("XML")}} son lenguajes populares basados en SGML. Vale la pena señalar que desde la quinta edición, HTML ya no está basado en SGML y tiene sus propias reglas de análisis.

--- a/files/es/glossary/simd/index.md
+++ b/files/es/glossary/simd/index.md
@@ -3,6 +3,8 @@ title: SIMD
 slug: Glossary/SIMD
 ---
 
+{{GlossarySidebar}}
+
 SIMD (pronunciado "sim-dee" en inglés) son las siglas de **Single Instruction/Multiple Data**, el cual es un tipo de [clasificación de arquitecturas de computadores](https://es.wikipedia.org/wiki/Taxonomía_de_Flynn). SIMD permite realizar la misma operación en distintos datos lo que permite paralelismo mejorando el rendimiento — por ejemplo, en la compresión de gráficos 3D y videos, simulaciones físicas, criptografía y otros entornos.
 
 En contraposición, {{Glossary("SISD")}} es una arquitectura que funciona de forma secuencial tanto para datos como para instrucciones.

--- a/files/es/glossary/sisd/index.md
+++ b/files/es/glossary/sisd/index.md
@@ -3,6 +3,8 @@ title: SISD
 slug: Glossary/SISD
 ---
 
+{{GlossarySidebar}}
+
 SISD son las siglas de **Single Instruction/Single Data** la cual es una [clasificación de arquitecturas](https://es.wikipedia.org/wiki/Flynn%27s_taxonomy). En las arquitecturas SISD, un único procesador ejecuta una única instrucción sobre un único punto de la memoria.
 
 En contraposición {{Glossary("SIMD")}} es una arquitectura que permite realizar una operación sobre distintos puntos de memoria.

--- a/files/es/glossary/sld/index.md
+++ b/files/es/glossary/sld/index.md
@@ -3,6 +3,8 @@ title: SLD
 slug: Glossary/SLD
 ---
 
+{{GlossarySidebar}}
+
 Un dominio de nivel secundario, o SLD (Second Level Domain) es el nombre que se encuentra antes del dominio de nivel primario, o TLD (Top Level Domain).
 
 Por ejemplo, en el dominio `mozilla.org`, `mozilla` es el dominio de nivel secundario del TLD `.org`.

--- a/files/es/glossary/sloppy_mode/index.md
+++ b/files/es/glossary/sloppy_mode/index.md
@@ -3,6 +3,8 @@ title: Modo poco riguroso — Sloppy
 slug: Glossary/Sloppy_mode
 ---
 
+{{GlossarySidebar}}
+
 {{Glossary("ECMAScript")}} 5 y versiones posteriores permiten que los scripts opten por un nuevo {{jsxref("Strict_mode", "Modo estricto", "", 1)}}, que modifica la semántica de JavaScript de varias formas para mejorar su capacidad de recuperación y facilitar la comprensión de lo que sucede cuando hay problemas.
 
 El modo normal, no estricto de JavaScript a veces se denomina **sloppy mode — modo poco riguroso**. Esta no es una designación oficial, pero es probable que la encuentres si pasas tiempo haciendo código JavaScript serio.

--- a/files/es/glossary/slug/index.md
+++ b/files/es/glossary/slug/index.md
@@ -3,6 +3,8 @@ title: Slug
 slug: Glossary/Slug
 ---
 
+{{GlossarySidebar}}
+
 Un "slug" es un identificador único parte de una dirección web, típicamente al final de una "URL". por ejemplo, en el contexto de MDN (página actual), el "slug" es la parte del url después de "\<locale>/docs/" es decir "Glossary/Slug"
 
 Ver también

--- a/files/es/glossary/smtp/index.md
+++ b/files/es/glossary/smtp/index.md
@@ -3,24 +3,17 @@ title: SMTP
 slug: Glossary/SMTP
 ---
 
+{{GlossarySidebar}}
+
 **SMTP** (Protocolo de Transferencia de Correo Simple por sus siglas en inglés) es un [protocolo](/es/docs/Glossary/Protocol) utilizado para enviar un nuevo correo. Como [POP3](/es/docs/Glossary/POP) y [NNTP](/es/docs/Glossary/NNTP), es un protocolo dirigido por [estado de máquina](/es/docs/Glossary/State_machine).
 
 El protocolo es relativamente simple. Las complicaciones principales incluyen soportar varios mecanismos de autenticación ([GSSAPI](http://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface), [CRAM-MD5](http://en.wikipedia.org/wiki/CRAM-MD5), [NTLM](http://en.wikipedia.org/wiki/NTLM), MSN, AUTH LOGIN, AUTH PLAIN, etc.), manejo de respuestas de error, y retroceder cuando los mecanismos de autenticación fallan (p. ej., el servidor asegura que soporta un mecanismo, pero no).
 
-<section id="Quick_links">
-  <ol>
-    <li><a href="/es/docs/Glossary">Glosario</a>
-     <ol>
-      <li><a href="/es/docs/Glossary/NNTP">NNTP</a></li>
-      <li><a href="/es/docs/Glossary/POP">POP3</a></li>
-      <li><a href="/es/docs/Glossary/Protocol">protocolo</a></li>
-      <li><a href="/es/docs/Glossary/State_machine">estado de máquina</a></li>
-     </ol>
-    </li>
-    <li>Artículos de Wikipedia
-     <ol>
-      <li><a href="https://es.wikipedia.org/wiki/Protocolo_para_transferencia_simple_de_correo">SMTP</a></li>
-     </ol>
-    </li>
-  </ol>
-</section>
+## Véase también
+
+- [SMTP](https://es.wikipedia.org/wiki/Protocolo_para_transferencia_simple_de_correo) en Wikipedia
+- [Glosario de MDN Web Docs](/es/docs/Glossary)
+  - {{Glossary("NNTP")}}
+  - {{Glossary("POP", "POP3")}}
+  - {{Glossary("Protocol", "protocolo")}}
+  - {{Glossary("State_machine", "estado de máquina")}}

--- a/files/es/glossary/speculative_parsing/index.md
+++ b/files/es/glossary/speculative_parsing/index.md
@@ -3,6 +3,8 @@ title: Optimizar sus páginas para análisis especulativo
 slug: Glossary/Speculative_parsing
 ---
 
+{{GlossarySidebar}}
+
 Tradicionalmente en los navegadores el analizador de HTML corre en el hilo de ejecución principal y se queda bloqueado después de una etiqueta \</script> hasta que el código se haya recuperado y ejecutado. El analizador de HTML de Firefox 4 y posteriores soporta análisis especulativo fuera del hilo de ejecución principal. Este analiza anticipadamente mientras el codigo está siendo descargado y ejecutado. Como en Firefox 3.5 y 3.6, el analizador de HTML es el que inicia la carga especulativa de código, las hojas de estilos y las imagenes que va encontrando en el flujo de la página. Sin embargo en Firefox 4 y posteriores el analizador de HTML también ejecuta el algoritmo especulativo de la construcción del árbol HTML. La ventaja es que cuando lo especulado tiene exito, no hay necesidad de reanalizar la parte del archivo de entrada que ya fue analizada junto la descarga de código, hojas de estilo y las imágenes. La desventaja es que se ha realizado un trabajo inútil cuando la especulación fracasa.
 
 Este documento le ayuda a evitar este tipo de situaciones que hacen que la especulación falle y ralentize la carga de la página.

--- a/files/es/glossary/sql/index.md
+++ b/files/es/glossary/sql/index.md
@@ -5,6 +5,8 @@ l10n:
   sourceCommit: d2a9f2e26a8139d4bb270d7dc3cddd8b848719fe
 ---
 
+{{GlossarySidebar}}
+
 **SQL** por sus siglas en inglés significa Lenguaje de Consulta Estructurada (Structured Query Language), es un lenguaje de programación diseñado para actualizar, obtener, y calcular información en bases de datos relacionales.
 
 ## Véase también

--- a/files/es/glossary/statement/index.md
+++ b/files/es/glossary/statement/index.md
@@ -3,6 +3,8 @@ title: Sentencias
 slug: Glossary/Statement
 ---
 
+{{GlossarySidebar}}
+
 En un lenguaje de programación, una **sentencia** es una línea de código al mando de una tarea Cada programa consiste en una secuencia de sentencias.
 
 ## Aprender más

--- a/files/es/glossary/static_typing/index.md
+++ b/files/es/glossary/static_typing/index.md
@@ -3,6 +3,8 @@ title: Tipificación estática
 slug: Glossary/Static_typing
 ---
 
+{{GlossarySidebar}}
+
 Un lenguaje de **tipo estático** es un lenguaje (como Java, C, o C++) en donde los tipos de variables se conocen en tiempo de compilación. En la mayoria de estos lenguajes, los tipos deben ser expresamente indicados por el programador; en otros casos (como en OCaml), la inferencia de tipos permite al programador no indicar sus tipos de variables.
 
 ## Learn more

--- a/files/es/glossary/string/index.md
+++ b/files/es/glossary/string/index.md
@@ -3,6 +3,8 @@ title: String
 slug: Glossary/String
 ---
 
+{{GlossarySidebar}}
+
 En cualquier lenguaje de programación, un string es una secuencia de {{Glossary("character","caracteres")}} usado para representar el texto.
 
 En {{Glossary("JavaScript","JavaScript")}}, un String es uno de los {{Glossary("Primitivo", "valores primitivos")}} y el objeto {{jsxref("String")}} es un {{Glossary("wrapper","envoltorio")}} alrededor de un String primitivo.

--- a/files/es/glossary/svg/index.md
+++ b/files/es/glossary/svg/index.md
@@ -3,6 +3,8 @@ title: SVG
 slug: Glossary/SVG
 ---
 
+{{GlossarySidebar}}
+
 Gráficos vectoriales escalables (del inglés _**S**calable **V**ector **G**raphics_) o **SVG** es un formato de imagen vectorial 2D basado en una sintaxis de {{Glossary("XML")}} .
 
 {{Glossary("W3C")}} comenzó a trabajar en SVG a finales de la década de 1990, pero SVG solo se hizo popular cuando {{Glossary("Microsoft Internet Explorer", "Internet Explorer")}} 9 salió con soporte para SVG. Todos los principales {{Glossary("browser","navegadores")}} ahora son compatibles con SVG.

--- a/files/es/glossary/svn/index.md
+++ b/files/es/glossary/svn/index.md
@@ -3,6 +3,8 @@ title: SVN
 slug: Glossary/SVN
 ---
 
+{{GlossarySidebar}}
+
 Apache Subversion (**SVN**) es un sistema ({{Glossary("SCM")}}) de código abierto de control de almacenamiento. Permite a los desarrolladores mantener un historial de modificaciones de texto y código. Aunque SVN también puede manejar archivos binarios, no recomendamos su utilización para tales archivos.
 
 ## Saber más

--- a/files/es/glossary/symmetric-key_cryptography/index.md
+++ b/files/es/glossary/symmetric-key_cryptography/index.md
@@ -3,6 +3,8 @@ title: Criptografía de clave simétrica
 slug: Glossary/Symmetric-key_cryptography
 ---
 
+{{GlossarySidebar}}
+
 La criptografía de clave simétrica es un término utilizado para los algoritmos criptográficos que utilizan la misma clave para el cifrado y el descifrado. La clave se suele llamar "clave simétrica" o "clave secreta".
 
 Esto generalmente se contrasta con {{Glossary ("public-key cryptography","criptografía de clave pública")}} en el que las claves se generan en pares, y la transformación realizada por una clave solo se puede revertir utilizando la otra clave.

--- a/files/es/glossary/synchronous/index.md
+++ b/files/es/glossary/synchronous/index.md
@@ -3,6 +3,8 @@ title: Sincrónico
 slug: Glossary/Synchronous
 ---
 
+{{GlossarySidebar}}
+
 Sincrónico _se_ refiere a la comunicación en tiempo real donde cada lado recibe (y si es necesario, procesa y responde) mensajes instantáneamente (o lo más cerca posible a instantáneamente).
 
 Un ejemplo humano es el teléfono — durante una llamada telefónica tiendes a responder a la otra persona inmediatamente.

--- a/files/es/glossary/tag/index.md
+++ b/files/es/glossary/tag/index.md
@@ -3,6 +3,8 @@ title: Etiqueta
 slug: Glossary/Tag
 ---
 
+{{GlossarySidebar}}
+
 En {{Glossary("HTML")}} una etiqueta es usada para crear un {{Glossary("elemento")}}. El **nombre** de un elemento HTML es el **nombre** utilizado entre paréntesis angulares así como la etiqueta `<p>` para el párrafo. Tenga en cuenta que el nombre de la etiqueta de cierre está precedido por un carácter de barra inclinada, `</p>`, y que en los elementos vacíos la etiqueta final no es necesaria ni permitida. Si no se mencionan atributos, se utilizan valores por defecto en cada caso.
 
 ## Aprende más

--- a/files/es/glossary/tcp/index.md
+++ b/files/es/glossary/tcp/index.md
@@ -3,6 +3,8 @@ title: TCP
 slug: Glossary/TCP
 ---
 
+{{GlossarySidebar}}
+
 **TCP** (**Protocolo de Control de Transmisión**, por sus siglas en inglés _Transmission Control Protocol_) es {{Glossary("protocol","protocolo")}} de red importante que permite que dos anfitriones (_hosts_) se conecten e intercambien flujos de datos. TCP garantiza la entrega de datos y {{Glossary("Packet","paquetes")}} en el mismo orden en que se enviaron. Vint Cerf y Bob Kahn, científicos de DARPA por aquél entonces, diseñaron TCP en la década de los 70.
 
 El rol de TCP es garantizar que los paquetes se entreguen de forma confiable y sin errores. TCP tiene control de concurrencia, lo que significa que las solicitudes iniciales serán pequeñas, aumentando de tamaño a los niveles de ancho de banda que los ordenadores, servidores y redes puedan soportar.

--- a/files/es/glossary/three_js/index.md
+++ b/files/es/glossary/three_js/index.md
@@ -3,6 +3,8 @@ title: Three js
 slug: Glossary/Three_js
 ---
 
+{{GlossarySidebar}}
+
 three.js es un motor {{Glossary("WebGL")}} basado en {{Glossary("JavaScript")}} que puede ejecutar juegos con GPU y otras aplicaciones con gráficos directamente desde el {{Glossary("browser")}}
 
 La biblioteca three.js proporciona muchas funciones y {{Glossary("API","APIs")}} para dibujar escenas 3D en su navegador.

--- a/files/es/glossary/truthy/index.md
+++ b/files/es/glossary/truthy/index.md
@@ -3,6 +3,8 @@ title: Truthy
 slug: Glossary/Truthy
 ---
 
+{{GlossarySidebar}}
+
 En {{Glossary("JavaScript")}}, un **valor verdadero** es un valor que se considera `true/verdadero` cuando es evaluado en un contexto {{Glossary("Booleano")}}. Todos los valores son verdaderos a menos que se definan como {{Glossary("Falso", "falso")}} (es decir, excepto `false`, `0`, `""`, `null`, `undefined`, y `NaN`).
 
 {{Glossary("JavaScript")}} usa {{Glossary("Type_Conversion", "coerción")}} en los contextos Booleanos.
@@ -28,5 +30,3 @@ if (-Infinity)
 - {{Glossary("Falsy")}}
 - {{Glossary("Type_Conversion", "Coercion")}}
 - {{Glossary("Boolean")}}
-
-{{QuickLinksWithSubpages("/es/docs/Glossary")}}

--- a/files/es/glossary/type/index.md
+++ b/files/es/glossary/type/index.md
@@ -3,6 +3,8 @@ title: Type
 slug: Glossary/Type
 ---
 
+{{GlossarySidebar}}
+
 El **tipo** (_type_ o _data type_) es una característica of una {{glossary("value", "valor")}} que afecta al tipo de datos que puede almacenar; por ejemplo, en JavaScript un {{domxref("Boolean")}} solo tiene valores `true`/`false`, mientras que un {{domxref("String")}} contiene cadenas de texto, un {{domxref("Number")}} contiene números de cualquier tipo, y así sucesivamente.
 
 El tipo de datos de un valor también afecta a qué operaciones son válidas en ese valor. Por ejemplo, un entero puede multiplicarse por un entero, pero no por una cadena.

--- a/files/es/glossary/type_coercion/index.md
+++ b/files/es/glossary/type_coercion/index.md
@@ -3,6 +3,8 @@ title: Coerción
 slug: Glossary/Type_coercion
 ---
 
+{{GlossarySidebar}}
+
 La coerción es la conversión automática o implicita de valores de un tipo de dato a otro (Ejemplo: de cadena de texto a número). La conversión es similar a la coerción porque ambas convierten valores de un tipo de dato a otro pero con una diferencia clave - la coerción es implícita mientras que la conversión puede ser implícita o explícita.
 
 ## Examples

--- a/files/es/glossary/ui/index.md
+++ b/files/es/glossary/ui/index.md
@@ -3,6 +3,8 @@ title: IU
 slug: Glossary/UI
 ---
 
+{{GlossarySidebar}}
+
 La _Interfaz de Usuario_ (IU) es el medio que facilita la interacción entre el usuario y la máquina. En el campo de la informática, puede ser un teclado, un joystick, una pantalla, o un programa. En el caso del software, puede ser una entrada de línea de comandos, una página web, un formulario, o el front-end de cualquier aplicación.
 
 ## Saber más

--- a/files/es/glossary/undefined/index.md
+++ b/files/es/glossary/undefined/index.md
@@ -3,6 +3,8 @@ title: undefined
 slug: Glossary/Undefined
 ---
 
+{{GlossarySidebar}}
+
 Un valor **{{Glossary("primitivo")}}** automáticamente asignado a las **variables** que solo han sido declarados o a los **{{Glossary("Argument","argumentos")}}** formales para los cuales no existe argumentos reales.
 
 ## Aprender más

--- a/files/es/glossary/unicode/index.md
+++ b/files/es/glossary/unicode/index.md
@@ -3,6 +3,8 @@ title: Unicode
 slug: Glossary/Unicode
 ---
 
+{{GlossarySidebar}}
+
 Unicode es un {{Glossary("Character set", "conjunto de caracteres")}} estándar que numera y define {{Glossary("Character", "caracteres")}} de diferentes idiomas, sistemas de escritura y símbolos. Al asignar un número a cada caracter, los programadores pueden crear {{Glossary("Character encoding", "codificaciones de caracteres")}}, para permitir que las computadoras almacenen, procesen y transmitan cualquier combinación de idiomas en el mismo archivo o programa.
 
 Antes de Unicode, era difícil y propenso a errores mezclar idiomas en los mismos datos. Por ejemplo, un juego de caracteres almacenaría caracteres japoneses y otro almacenaría el alfabeto árabe. Si no estuviera claramente marcado qué partes de los datos estaban en qué juego de caracteres, otros programas y computadoras mostrarían el texto incorrectamente o lo dañarían durante el procesamiento. Si alguna vez has visto texto en el que caracteres como comillas entrecruzadas (`“”`) fueron reemplazadas por un galimatías como `Ã‚Â£`, entonces has visto este problema, conocido como [Mojibake](https://es.wikipedia.org/wiki/Mojibake).

--- a/files/es/glossary/uri/index.md
+++ b/files/es/glossary/uri/index.md
@@ -3,6 +3,8 @@ title: URI
 slug: Glossary/URI
 ---
 
+{{GlossarySidebar}}
+
 Un **URI** _(Identificador Uniforme de Recursos de sus siglas en inglés: Uniform Resource Identifier)_ es una cadena que se refiere a un recurso. Los más comunes son {{Glossary("URL","URLs")}}, que identifican el recurso dando su ubicación en la Web. {{Glossary("URN","URNs")}}, por el contrario, se refiere a un recurso por un nombre, en un espacio de nombres determinados, como el ISBN(International Standard Book Number) de un libro.
 
 ## Aprende más

--- a/files/es/glossary/url/index.md
+++ b/files/es/glossary/url/index.md
@@ -3,6 +3,8 @@ title: URL
 slug: Glossary/URL
 ---
 
+{{GlossarySidebar}}
+
 La «**_Uniform Resource Locator_**» (**URL** o _Localizadora Uniforme de Recursos_ en Español) es una cadena de texto que especifica dónde se puede encontrar un recurso (como una página web, una imagen o un video) en Internet.
 
 En el contexto de {{Glossary("HTTP")}}, las URLs se denominan "dirección web" o "enlace". Tu {{Glossary("browser", "navegador")}} muestra las URLs en su barra de direcciones, por ejemplo: `https://developer.mozilla.org` — Algunos navegadores muestran solo la parte de una URL después de "//", es decir, el {{Glossary("Domain name", "Nombre de dominio")}}.

--- a/files/es/glossary/utf-8/index.md
+++ b/files/es/glossary/utf-8/index.md
@@ -3,6 +3,8 @@ title: UTF-8
 slug: Glossary/UTF-8
 ---
 
+{{GlossarySidebar}}
+
 UTF-8 (UCS Transformation Format 8) es la {{Glossary("Character encoding", "Codificación de caracteres")}} más común en la red. El número de bytes que representan un carácter pueden ser desde uno hasta cuatro. UTF-8 es retrocompatible con {{Glossary("ASCII")}} y puede representar cualquier carácter Unicode estandar.
 
 Los primeros 128 carácteres UTF-8 se ajustan a los 128 primeros carácteres ASCII, lo cual significa que los textos escritos en ASCII son válidos en UTF-8. El resto de caracteres usan de dos a cuatro bytes. Cada byte reserva unos bits para albergar información sobre la codificación. Como los caracteres que no son ASCII necesitan más de un byte cuando son almacenados, corren el riesgo de corromperse si estos bytes son separados y no se vuelven a juntar.

--- a/files/es/glossary/ux/index.md
+++ b/files/es/glossary/ux/index.md
@@ -3,6 +3,8 @@ title: UX
 slug: Glossary/UX
 ---
 
+{{GlossarySidebar}}
+
 **UX** es un acrónimo de User eXperience. Es el estudio de la interacción entre usuarios y un sistema. Su objetivo es hacer que un sistema sea fácil de interactuar desde el punto de vista del usuario.
 
 El sistema puede ser cualquier tipo de producto o aplicación con el que un usuario final deba interactuar. Los estudios de UX realizados en una página web, por ejemplo, pueden demostrar si es fácil para los usuarios entender la página, navegar a diferentes áreas y completar tareas comunes, y dónde dichos procesos podrían tener menos fricciones.

--- a/files/es/glossary/validator/index.md
+++ b/files/es/glossary/validator/index.md
@@ -3,6 +3,8 @@ title: Validador
 slug: Glossary/Validator
 ---
 
+{{GlossarySidebar}}
+
 Un validador es un programa que comprueba errores de sintaxis en el código. Las validadores pueden ser creados para cualquier formato o lenguaje, pero en este contexto se habla de herramientas que comprueban {{Glossary("HTML")}}, {{Glossary("CSS")}}, y {{Glossary("XML")}}.
 
 ## Saber más

--- a/files/es/glossary/value/index.md
+++ b/files/es/glossary/value/index.md
@@ -3,6 +3,8 @@ title: Valor
 slug: Glossary/Value
 ---
 
+{{GlossarySidebar}}
+
 {{jsSidebar}}
 
 En el contexto de datos o un objeto **{{Glossary("Wrapper", "wrapper")}}** alrededor de esos datos, el valor es el **{{Glossary("Primitive", "valor primitivo")}}** que contiene el contenedor de objetos. En el contexto de una **{{Glossary("Variable", "variable")}}** o **{{Glossary("Property", "property")}}**, el El valor puede ser primitivo o **{{Glossary("Object reference", "Referencia de objeto")}}**.

--- a/files/es/glossary/variable/index.md
+++ b/files/es/glossary/variable/index.md
@@ -3,6 +3,8 @@ title: Variable
 slug: Glossary/Variable
 ---
 
+{{GlossarySidebar}}
+
 {{jsSidebar}}
 
 Una variable es una ubicación nombrada para almacenar un {{Glossary("Value", "valor")}}. De esta manera se puede acceder a un valor impredecible por medio de un nombre predeterminado.

--- a/files/es/glossary/vendor_prefix/index.md
+++ b/files/es/glossary/vendor_prefix/index.md
@@ -3,6 +3,8 @@ title: Vendor Prefix
 slug: Glossary/Vendor_Prefix
 ---
 
+{{GlossarySidebar}}
+
 Los proveedores de navegadores a veces agregan prefijos a las propiedades de CSS experimentales o no estándar y las API de JavaScript, por lo que los desarrolladores pueden experimentar con nuevas ideas mientras que, en teoría, evitan que se confíe en sus experimentos y luego rompan el código de los desarrolladores web durante el proceso de estandarización. Los desarrolladores deben esperar para incluir la propiedad sin prefijar hasta que se estandarice el comportamiento del navegador.
 
 > **Nota:** Los proveedores de navegadores están trabajando para dejar de usar los prefijos de proveedores para funciones experimentales. Los desarrolladores web los han estado utilizando en sitios web de producción, a pesar de su naturaleza experimental. Esto ha hecho que sea más difícil para los proveedores de navegadores garantizar la compatibilidad y trabajar en nuevas características; También ha sido perjudicial para los navegadores más pequeños que terminan obligados a agregar prefijos de otros navegadores para cargar sitios web populares.
@@ -45,5 +47,3 @@ Los prefijos para propiedades y métodos son minúsculas:
 ### Conocimientos generales
 
 - [Vendor prefix](https://es.wikipedia.org/wiki/CSS_hack#Browser_prefixes) on Wikipedia
-
-{{QuickLinksWithSubpages("/es/docs/Glossary")}}

--- a/files/es/glossary/viewport/index.md
+++ b/files/es/glossary/viewport/index.md
@@ -3,6 +3,8 @@ title: Viewport
 slug: Glossary/Viewport
 ---
 
+{{GlossarySidebar}}
+
 Un viewport representa la región poligonal (normalmente rectangular) en gráficas de computación que está siendo visualizada en ese instante. En términos de navegadores web, se refiere a la parte del documento que usted está viendo, la cual es actualmente visible en su ventana (o la pantalla, si el documento está siendo visto en modo pantalla completa). El contenido fuera del viewport no es visible en la pantalla hasta que sea desplazado dentro de él.
 
 La porción del viewport que se encuentra visible en ese momento se denomina **visual viewport**. Este puede ser más pequeño que el viewport de diseño, por ejemplo, cuando el usuario hace uso del zoom. El viewport de diseño (**layout viewport**), sigue siendo el mismo, pero el visual viewport se empequeñeció.

--- a/files/es/glossary/void_element/index.md
+++ b/files/es/glossary/void_element/index.md
@@ -3,6 +3,8 @@ title: Elemento vacío
 slug: Glossary/Void_element
 ---
 
+{{GlossarySidebar}}
+
 Un **elemento vacío** es un {{Glossary("elemento")}} de HTML, SVG, o MathML que **no puede** tener nodos secundarios (es decir, elementos anidados o nodos de texto).
 
 Las especificaciones [HTML](https://html.spec.whatwg.org/multipage/), [SVG](https://www.w3.org/TR/SVG2/), y [MathML](https://www.w3.org/TR/MathML3/) definen con precisión lo que cada elemento puede contener. Muchas combinaciones no tienen sentido semántico, por ejemplo un elemento {{HTMLElement("audio")}} anidado dentro de un elemento {{HTMLElement("hr")}}.

--- a/files/es/glossary/wcag/index.md
+++ b/files/es/glossary/wcag/index.md
@@ -3,6 +3,8 @@ title: WCAG
 slug: Glossary/WCAG
 ---
 
+{{GlossarySidebar}}
+
 Las _Pautas de Accesibilidad para el Contenido Web_ (**WCAG**, por us siglas en inglés) son una recomendación publicada por el grupo {{Glossary("WAI","Web Accessibility Initiative")}} en el {{Glossary("W3C")}}. Describen un conjunto de pautas para hacer que el contenido sea accesible principalmente para personas con discapacidades, pero también para dispositivos de recursos limitados, como los teléfonos móviles.
 
 WCAG 2.0, que reemplazó a WCAG 1.0, se publicó como una recomendación del W3C el 11 de diciembre de 2008. Consta de 12 directrices organizadas en 4 principios (perceptibles, operables, comprensibles y robustos) y cada guía tiene criterios de éxito comprobables.

--- a/files/es/glossary/webkit/index.md
+++ b/files/es/glossary/webkit/index.md
@@ -3,6 +3,8 @@ title: WebKit
 slug: Glossary/WebKit
 ---
 
+{{GlossarySidebar}}
+
 _WebKit_ es un _framework_ (marco o interfaz) que proporciona páginas web "bien formadas" basadas es su lenguaje de marcado. El principal navegador que utiliza este framework es [Safari](/es/docs/Glossary/Apple_Safari), aunque también lo hacen muchos otros navegadores web para dispositivos móviles (debido a que WebKit es muy portable y customizable).
 
 WebKit comenzó como una copia del KHTML de KDE y sus librerías KJS, pero desde entonces ha habido una gran multitud de particulares y empresas que han contribuido en su desarrollo (incluyendo KDE, Apple, Google, y Nokia).

--- a/files/es/glossary/websockets/index.md
+++ b/files/es/glossary/websockets/index.md
@@ -3,6 +3,8 @@ title: WebSockets
 slug: Glossary/WebSockets
 ---
 
+{{GlossarySidebar}}
+
 _WebSocket_ es un {{Glossary("protocolo")}} que permite establecer conexiones {{Glossary("TCP")}} entre el {{Glossary("Server", "servidor")}} y el cliente, permitiendo así el transporte de datos en cualquier momento.
 
 Cualquier cliente o servidor de aplicaciones puede usar WebSockets, pero principalmente es usado por {{Glossary("Navegador", "browsers")}} y el servidor web. WebScoket permite enviar datos al cliente sin la necesidad de recibir ningún tipo de notificación, permitiendo la actualización dinámica del contenido.

--- a/files/es/glossary/webvtt/index.md
+++ b/files/es/glossary/webvtt/index.md
@@ -5,6 +5,8 @@ l10n:
   sourceCommit: 4bd65a01204446af2254bb8864bd22ad87bc86b0
 ---
 
+{{GlossarySidebar}}
+
 WebVTT (Pistas de Texto para Videos Web) es una especificación del {{Glossary("W3C")}} para un formato de archivo para crear pistas de texto en combinación con el elemento HTML {{HTMLElement("track")}}.
 
 Los archivos WebVTT proporcionan metadatos alineados en el tiempo con contenido de audio o video, como subtítulos para contenido de video, descripciones de video de texto, capítulos para navegación de contenido y más.

--- a/files/es/glossary/whatwg/index.md
+++ b/files/es/glossary/whatwg/index.md
@@ -3,6 +3,8 @@ title: WHATWG
 slug: Glossary/WHATWG
 ---
 
+{{GlossarySidebar}}
+
 EL ( Grupo de trabajo de tecnología de aplicaciones de hipertexto web) por sus siglas en inglés WHATWG es una organización que mantinene y desarrolla {{Glossary("HTML")}} y {{Glossary("API", "APIs")}} para las aplicaciones Web. Antiguos empleados de Apple, Mozilla y Opera establecieron el WHATWG en el 2004.
 
 Los editores de especificación en el WHATWG investigan y recopilan comentarios para los documentos de especificación. El grupo también tiene un pequeño comité de miembros invitados y autorizados para anular o reemplazar editores de especificación. Puedes unirte como un colaborador registrándote en la [lista de correo](https://whatwg.org/mailing-list).

--- a/files/es/glossary/whitespace/index.md
+++ b/files/es/glossary/whitespace/index.md
@@ -3,6 +3,8 @@ title: Espacio en blanco
 slug: Glossary/Whitespace
 ---
 
+{{GlossarySidebar}}
+
 El **espacio en blanco** es un conjunto de {{Glossary("Caracter", "caracteres")}} que se utiliza para mostrar espacios horizontales o verticales entre otros caracteres. A menudo se utilizan para separar fragmentos en {{Glossary("HTML")}}, {{Glossary("CSS")}}, {{Glossary("JavaScript")}} y otros lenguajes informáticos.Los caracteres de espacio en blanco y su uso varía de un lenguaje a otro.
 
 ## En HTML
@@ -13,29 +15,11 @@ La [_HTML Living Standard_](https://html.spec.whatwg.org/) especifica 5 caracter
 
 La [especificación del lenguaje ECMAScript® 2015](https://www.ecma-international.org/ecma-262/6.0/#sec-white-space) establece varios puntos de código Unicode como espacio en blanco: `U+0009` CARACTERES de TABULACIÓN \<TAB>, `U+000B` TABULACIÓN DE LÍNEA \<VT>, `U+000C` FORM FEED \<FF>, `U+0020` ESPACIO \<SP>, `U+00A0` ESPACIO SIN ROTURA \<NBSP>, `U+FEFF` ANCHO CERO NO -BREAK SPACE \<ZWNBSP> y otra categoría "Zs" Cualquier otro punto de código Unicode "Separador, espacio" \<USP>. Estos caracteres suelen ser innecesarios para la funcionalidad del código.
 
-<section id="Quick_links">
- <ol>
-  <li>Especificaciones
-   <ol>
-    <li><a href="https://infra.spec.whatwg.org/#ascii-whitespace">Espacio en blanco ASCII</a></li>
-    <li><a href="https://www.ecma-international.org/ecma-262/6.0/#sec-white-space">Especificación del lenguaje ECMAScript® 2015</a></li>
-   </ol>
-  </li>
-  <li>Referencias
-   <ol>
-    <li><a href="/es/docs/Web/API/Document_Object_Model/Whitespace">Cómo se manejan los espacios en blanco mediante HTML, CSS y el DOM</a></li>
-    <li>{{cssxref("white-space")}}</li>
-   </ol>
-  </li>
-  <li>Artículos de Wikipedia
-   <ol>
-    <li>[El caracter de espacio en blanco](https://es.wikipedia.org/wiki/El_caracter_de_espacio_en_blanco)</li>
-   </ol>
-  </li>
-  <li><a href="/es/docs/Glossary">Glosario</a>
-   <ol>
-    <li>{{Glossary("Character", "Caracter")}}</li>
-   </ol>
-  </li>
- </ol>
-</section>
+## Véase también
+
+- [Espacio en blanco ASCII](https://infra.spec.whatwg.org/#ascii-whitespace)
+- [Especificación del lenguaje ECMAScript® 2015](https://www.ecma-international.org/ecma-262/6.0/#sec-white-space)
+- [Cómo se manejan los espacios en blanco mediante HTML, CSS y el DOM](/es/docs/Web/API/Document_Object_Model/Whitespace)
+- [El caracter de espacio en blanco](https://es.wikipedia.org/wiki/El_caracter_de_espacio_en_blanco) en Wikipedia
+- [Glosario de MDN Web Docs](/es/docs/Glossary)
+  - {{Glossary("Character", "Caracter")}}

--- a/files/es/glossary/world_wide_web/index.md
+++ b/files/es/glossary/world_wide_web/index.md
@@ -3,6 +3,8 @@ title: World Wide Web
 slug: Glossary/World_Wide_Web
 ---
 
+{{GlossarySidebar}}
+
 La _World Wide Web_ —comúnmente conocida como **WWW**, **W3**, o **la Web**— es un sistema interconectado de páginas web públicas accesibles a través de {{Glossary("Internet")}}. La Web no es lo mismo que el Internet: la Web es una de las muchas aplicaciones construidas sobre Internet.
 
 Tim Berners-Lee propuso la arquitectura de lo que es conocido como la World Wide Web. Él creó el primer servidor web ({{Glossary("Server","server")}}), el primer navegador de internet ({{Glossary("Browser","browser")}}), y la primera página web, en su computadora del laboratorio de investigación de física del CERN en 1990. En 1991, anunció su creación en el grupo de noticias alt.hypertext, marcando con esto el momento en que la Web se hizo pública.

--- a/files/es/glossary/wrapper/index.md
+++ b/files/es/glossary/wrapper/index.md
@@ -3,24 +3,16 @@ title: Wrapper
 slug: Glossary/Wrapper
 ---
 
+{{GlossarySidebar}}
+
 En lenguajes de programación como JavaScript, un wrapper o envoltorio es una función que llama a una o varias funciones, unas veces únicamente por convenio y otras para adaptarlas con el objetivo de hacer una tarea ligeramente diferente.
 
 Por ejemplo, las librerías SDK de AWS son un ejemplo de wrappers.
 
-## Saber más
+## Véase también
 
-### Conocimientos generales
-
-[Wrapper function](https://es.wikipedia.org/wiki/Wrapper_function) on Wikipedia
-
-<section id="Quick_links">
- <ol>
-  <li><a href="/es/docs/Glossary">MDN Web Docs Glossary</a>
-   <ol>
-    <li>{{Glossary("API")}}</li>
-    <li>{{Glossary("Class")}}</li>
-    <li>{{Glossary("Function")}}</li>
-   </ol>
-  </li>
- </ol>
-</section>
+- [Wrapper function](https://es.wikipedia.org/wiki/Wrapper_function) on Wikipedia
+- [Glosario de MDN Web Docs](/es/docs/Glossary)
+  - {{Glossary("API")}}
+  - {{Glossary("Class")}}
+  - {{Glossary("Function")}}

--- a/files/es/glossary/xforms/index.md
+++ b/files/es/glossary/xforms/index.md
@@ -3,6 +3,8 @@ title: XForm
 slug: Glossary/XForms
 ---
 
+{{GlossarySidebar}}
+
 **XForms** es una norma para la creación de formularios web y el procesamiento de datos de formulario en formato {{glossary("XML")}}. Actualmente ningún navegador soporta Xforms—sugerimos en su lugar utilizar los formularios en [HTML5 forms](/es/docs/Web/Guide/HTML/Forms).
 
 ## Saber más

--- a/files/es/glossary/xhtml/index.md
+++ b/files/es/glossary/xhtml/index.md
@@ -3,6 +3,8 @@ title: XHTML
 slug: Glossary/XHTML
 ---
 
+{{GlossarySidebar}}
+
 **XHTML** es a [XML](/es/XML) como [HTML](/es/HTML) es a [SGML](/es/SGML). Es decir, XHTML es un lenguaje de marcado que es similar al HTML, pero con un sintaxis más estricta. Dos versiones de XHTML han sido terminadas por el [W3C](http://www.w3.org/):
 
 - [XHTML 1.0](http://www.sidar.org/recur/desdi/traduc/es/xhtml/xhtml11.htm) es HTML4 reformulado como una aplicación XML, y es compatible con versiones anteriores de HTML en casos limitados.

--- a/files/es/glossary/xml/index.md
+++ b/files/es/glossary/xml/index.md
@@ -3,6 +3,8 @@ title: XML
 slug: Glossary/XML
 ---
 
+{{GlossarySidebar}}
+
 _XML_ (eXtensible Markup Language en español **Lenguaje de Marcado eXtensible**) es un lenguaje de marcado genérico especificado por la W3C. La industria de tecnologías de la información (_IT Industry_) utiliza muchos lenguajes de descripción de datos (_data-description language_) que están basados en XML.
 
 Las etiquetas XML ó _tags_ son muy similares a las de [HTML](/es/docs/Glossary/HTML), pero en el caso de XML, es mucho más flexible debido a que permite a los usuarios definir sus propias etiquetas. En este sentido XML actúa como un metalenguaje (debido a esto, puede ser usado para definir otros lenguajes como por ejemplo [RSS](/es/docs/Glossary/RSS)). Además de esto, cabe señalar que HTML es un lenguaje de presentación, miestras que XML es un lenguaje descripción de datos.


### PR DESCRIPTION
### Description

Add sidebar (with list of terms) to all Glossary pages in Spanish locale.

### Motivation

Sidebar is useful for navigation in Glossary, so this change will improve user experience.

### Related issues and pull requests

Fixes #16942
Relates to #16863
