### PR TITLE
リクエスト: DeepCopy(ディープコピー) の更新

### DIFF
--- a/files/ja/glossary/deep_copy/index.md
+++ b/files/ja/glossary/deep_copy/index.md
@@ -9,7 +9,7 @@ slug: Glossary/Deep_copy
 
 結果として、コピー元かコピー先のどちらかを変更しても、そのほかのオブジェクトにも変更を及ぼしていないことを保証できます。すなわち、コピー元かコピー先に意図せずに予期しない変更が加えられるこはありません。
 
-この振る舞いは[シャローコピー](/ja/docs/Glossary/Shallow_copy)とは対照的で、コピー元かコピー先のどちらかを変更すると他のオブジェクトも変更される可能性があります。（なぜならば、それら2つのオブジェクトは参照を共有しているためです）
+この振る舞いは[シャローコピー](/ja/docs/Glossary/Shallow_copy)とは対照的です。シャローコピーでは、コピー元かコピー先のどちらかを変更すると他のオブジェクトも変更される可能性があります。（なぜならば、それら2つのオブジェクトは参照を共有しているためです）
 
 JavaScript では、オブジェクトを操作する標準の組み込み構文や関数（[スプレッド構文](/ja/docs/Web/JavaScript/Reference/Operators/Spread_syntax), [`Array.prototype.concat()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/concat), [`Array.prototype.slice()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/slice), [`Array.from()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/from), [`Object.assign()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/assign), [`Object.create()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/create)）はディープコピーを作成しません。（代わりにシャローコピーで作成されます）。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There was a misleading expression in the description of deep copy and shallow copy,so I modified it.
ディープコピーのセクションの中でシャローコピーに触れている部分に誤解を招く表現が含まれている。

### Motivation

The Japanese in this section is misleading, so I rewrote it just in case.
ディープコピーの説明のなかでシャローコピーについて軽く触れられている。
しかしその際の下記添付画像の日本語表現を素直に受け取ってしまうと順接でつながっているように見えるため、シャローコピーの振る舞いをディープコピーの振る舞いとして受け取ってしまう可能性がある

### Additional details

![image](https://github.com/mdn/translated-content/assets/77439783/7a23b090-6ec3-4c1e-bdab-cf819ff81fff)


### Related issues and pull requests
https://github.com/mozilla-japan/translation/issues/725


