### PR TITLE
[ja]: fix typo

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/array/index.md
+++ b/files/ja/web/javascript/reference/global_objects/array/index.md
@@ -661,7 +661,7 @@ console.log(moreFruits);
 
 ### 配列のコピー
 
-この例では、既存の配列 `fruits` から新しい配列を生成する方法を 3 通り示します。最初のものは[スプレッド構文](/ja/docs/Web/JavaScript/Reference/Operators/Spread_syntax)を使用するもので、次は [`from()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/from) メソッドを使用するもの、その次は [`slice()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/slice) 円そっどを使用するものです。
+この例では、既存の配列 `fruits` から新しい配列を生成する方法を 3 通り示します。最初のものは[スプレッド構文](/ja/docs/Web/JavaScript/Reference/Operators/Spread_syntax)を使用するもので、次は [`from()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/from) メソッドを使用するもの、その次は [`slice()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/slice) メソッドを使用するものです。
 
 ```js
 const fruits = ["いちご", "マンゴー"];


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

誤字を修正しました。

`円そっどを使用` -> `メソッドを使用`
