### PR TITLE
Fixing typo in a comment

### DIFF
--- a/files/es/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/freeze/index.md
@@ -62,7 +62,7 @@ assert(Object.isFrozen(obj) === true);
 obj.foo = "quux"; // No hace nada de manera silenciosa
 obj.quaxxor = "the friendly duck"; // No agrega una nueva propiedad, de manera silenciosa
 
-// ...y en modo estrico tal intento arrojará TypeErrors
+// ...y en modo estricto tal intento arrojará TypeErrors
 function fail() {
   "use strict";
   obj.foo = "sparky"; // arroja un TypeError


### PR DESCRIPTION
### Description
Fixing typo in a comment.

### Motivation
Typos are bad.

### Additional details
-
### Related issues and pull requests
-
