### PR TITLE
fr: Updating the `howto` content of writing guidelines for #16686

### DIFF
--- a/files/fr/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
@@ -5,43 +5,166 @@ slug: MDN/Writing_guidelines/Howto/Creating_moving_deleting
 
 {{MDNSidebar}}
 
-Cet article est destiné à présenter aux personnes souhaitant contribuer à MDN le processus de modification de pages existantes et de création de nouvelles pages.
+Cet article décrit comment créer, déplacer, supprimer ou modifier une page. Dans tous ces cas, il est conseillé de consulter nos directives concernant [ce que nous écrivons](/fr/docs/MDN/Writing_guidelines/What_we_write) pour confirmer si l'une de ces actions doit être entreprise et d'en discuter avec l'équipe sur le [canal de discussion du MDN Web Docs](/fr/docs/MDN/Community/Communication_channels#salons_de_discussions) avant de procéder.
 
-> **Note :** Le contenu de MDN s'organise au sein de deux dépôts Git : [`mdn/content`](https://github.com/mdn/content) avec le contenu en anglais et [`mdn/translated-content`](https://github.com/mdn/translated-content) avec le contenu traduit (y compris en français). C'est le dépôt `mdn/content` qui constitue la référence. Si vous souhaitez créer une page en français, celle-ci devra au préalable avoir été créée en anglais.
+## Créer de nouvelles pages
 
-## Modifier une page existante
+Toutes les pages du MDN Web Docs sont rédigées au format Markdown. Le contenu est écrit dans un fichier nommé `index.md`, qui est stocké dans un répertoire unique. Le nom du répertoire représente le nom de la page. Par exemple, si `align-content` est une nouvelle propriété CSS pour laquelle vous voulez créer une nouvelle page de référence, vous devez créer un dossier dans `en-us/web/css` (ou `fr/web/css` si vous procédez à sa traduction) nommé `align-content` et créer un fichier appelé `index.md` à l'intérieur de ce dossier.
 
-Pour modifier une page, vous devez trouver la page source :
+> **Note :** Le nom du répertoire diffère légèrement de l'intitulé de la page. En particulier, le slug suit la casse de la phrase.
 
-- Si elle est en anglais : [sur notre dépôt <i lang="en">content</i>](https://github.com/mdn/content)
+Il existe de nombreux [types de pages](/fr/docs/MDN/Writing_guidelines/Page_structures/Page_types) avec certaines structures et des modèles de pages qui les accompagnent, que vous pouvez copier pour commencer.
 
-  <i lang="en">content</i>
+Le fichier `index.md` d'un document doit commencer par des informations préliminaires qui définissent le `titre`, le `slug` et le `type de page` (ce dernier est uniquement réservé à la version anglaise). Toutes ces informations peuvent être trouvées dans les modèles de page mentionnés ci-dessus. Alternativement, vous pouvez trouver utile de vous référer à la matière première dans le fichier `index.md` d'un document similaire.
 
-- Si elle est en français ou dans une autre langue : [sur notre dépôt <i lang="en">translated-content</i>](https://github.com/mdn/translated-content)
+Le processus général de création d'une page, étape par étape, est le suivant&nbsp;:
 
-  <i lang="en">translated-content</i>
+1. Démarrer une nouvelle branche, actualisée, pour y travailler.
 
-.
+   ```bash
+   cd ~/repos/mdn/translated-content
+   git checkout main
+   git pull translated-content main
+   # Exécutez à nouveau « yarn » pour vous assurer que vous avez
+   # installé la dernière dépendance de Yari.
+   yarn
+   git checkout -b mon-ajout
+   ```
 
-La façon la plus rapide de la trouver est d'aller sur la page que vous souhaitez modifier, puis de vous rendre en bas de cette page et enfin de cliquer sur le lien <i lang="en">«&nbsp;Source on GitHub&nbsp;»</i>.
+2. Créer un ou plusieurs nouveaux dossiers, chacun avec ses propres fichiers `index.md`.
 
-Une fois que vous avez trouvé la source à modifier, rendez-vous sur notre fichier <i lang="en">README</i> et parcourez notre [guide sur la contribution (en anglais)](https://github.com/mdn/translated-content/#making-contributions). Vous pouvez également consulter [ce billet en français](https://tech.mozfr.org/post/2021/03/16/MDN-sur-GitHub-comment-contribuer) pour savoir comment contribuer.
+3. Ajouter et livrer (<i lang="en">commit</i> en anglais) vos nouveaux fichiers et poussez votre nouvelle branche sur votre fork.
 
-### Prévisualiser vos modifications
+   ```bash
+   git add files/fr/dossier/cree
+   git commit -m "un message approprié des changements"
+   git push -u origin mon-ajout
+   ```
 
-SI vous modifiez la page en local, vous pouvez voir à quoi ressembleront vos modifications en allant sur le dossier du dépôt nommé <i lang="en">content</i>, en exécutant la commande CLI `yarn start`, puis en vous rendant à l'URL `localhost:5042` dans votre navigateur, et enfin en retrouvant la page sur laquelle vous travaillez. Pour la trouver plus facilement, utilisez la boîte de recherche. La page que vous prévisualisez sera rafraîchie automatiquement au fur et à mesure que vous modifiez son code source.
+4. Créer votre requête de tirage (<i lang="en">pull request</i> en anglais).
 
-### Ajouter des pièces jointes
+## Déplacer des pages
 
-Pour ajouter un fichier en pièce jointe à votre article, vous avez simplement besoin de l'inclure dans le même répertoire du fichier `index.html` de votre article, puis de l'ajouter dans votre page, typiquement à l'aide d'un élément `<a>`.
+Il est facile de déplacer un ou plusieurs documents ou une arborescence entière de documents, car nous avons créé une commande spéciale qui s'occupe des détails pour vous&nbsp;:
 
-## Créer une nouvelle page
+- Si la page est en anglais&nbsp;: [sur notre dépôt <i lang="en">content</i>](https://github.com/mdn/content)
 
-Pour créer une nouvelle page, consultez les instructions fournies sur la [documentation concernant l'ajout de nouveaux documents (en anglais)](https://github.com/mdn/content#adding-a-new-document).
+  ```bash
+  yarn content move <slug-de-depart> <nouveau-slug> en-US
+  ```
 
-> **Attention :** Pour créer une page en français (ou dans une autre langue), celle-ci devra préalablement exister/avoir été créée en anglais.
+- Si la page est en français&nbsp;: [sur notre dépôt <i lang="en">translated-content</i>](https://github.com/mdn/translated-content)
 
-## Voir aussi
+  ```bash
+  yarn content move <slug-de-depart> <nouveau-slug> fr
+  ```
 
-- [Guide stylistique de MDN](/fr/docs/MDN/Guidelines/Writing_style_guide)
-- [MDN sur GitHub&nbsp;: comment contribuer&nbsp;?](https://tech.mozfr.org/post/2021/03/16/MDN-sur-GitHub-comment-contribuer)
+Il vous suffit de spécifier le nom du document existant que vous souhaitez déplacer (par exemple, `Learn/Accessibility`), ainsi que le nom de son nouvel emplacement (par exemple, `Learn/A11y`), suivi éventuellement de la langue du document existant (par défaut `en-US`).
+
+Si le document existant que vous souhaitez déplacer a des documents enfants (c'est-à-dire qu'il représente une arborescence de  documents), le nom de l'arborescence peut être modifié, il représente une arborescence de documents), la commande `yarn content move` déplacera l'arbre entier.
+
+1. Vous commencerez à travailler dans une nouvelle branche.
+
+   ```bash
+   cd ~/repos/mdn/translated-content
+   git checkout main
+   git pull translated-content main
+   # Exécutez à nouveau « yarn » pour vous assurer que vous avez
+   # installé la dernière dépendance de Yari.
+   yarn
+   git checkout -b mon-deplacement
+   ```
+
+2. Effectuer le déplacement (qui supprimera et modifiera les fichiers existants et en créera de nouveaux).
+
+   ```bash
+   yarn content move Learn/Accessibility Learn/A11y fr
+   ```
+
+3. Ajouter et livrer (<i lang="en">commit</i> en anglais) tous les fichiers supprimés, créés et modifiés, et poussez votre branche vers votre fork.
+
+   ```bash
+   git commit -a
+   git push -u origin mon-deplacement
+   ```
+
+4. Créer votre requête de tirage (<i lang="en">pull request</i> en anglais).
+
+> **Note :** `yarn content move` ajoute automatiquement les informations de redirection nécessaires au fichier `_redirects.txt` afin que l'ancien emplacement soit redirigé vers le nouveau. N'éditez pas le fichier `_redirects.txt` manuellement&nbsp;! Des erreurs peuvent facilement se glisser si vous le faites. Si vous avez besoin d'ajouter une redirection sans déplacer un fichier, parlez-en à l'équipe sur le [salon de discussion du MDN Web Docs](/fr/docs/MDN/Community/Communication_channels#salons_de_discussions).
+
+## Supprimer des pages
+
+Les documents ne doivent être retirés du MDN Web Docs que dans des circonstances particulières. Si vous envisagez de supprimer des pages, veuillez en discuter avec l'équipe sur la page [salon de discussion du MDN Web Docs](/fr/docs/MDN/Community/Communication_channels#salons_de_discussions) en premier.
+
+La suppression d'un ou plusieurs documents ou d'une arborescence entière de documents est facile, tout comme le déplacement de pages, car nous avons créé une commande spéciale qui s'occupe des détails pour vous&nbsp;:
+
+```bash
+yarn content delete <lien-du-document> [langue]
+```
+
+> **Note :** Vous devez utiliser la commande `yarn content delete` pour supprimer les pages du MDN Web Docs. Ne vous contentez pas de supprimer leurs répertoires du référentiel. La commande `yarn content delete` gère également d'autres changements nécessaires comme la mise à jour du fichier `_wikihistory.json`.
+
+Vous devez simplement spécifier le nom du document existant que vous souhaitez supprimer (par exemple, `Learn/Accessibility`), suivi éventuellement de la langue du document existant (par défaut `en-US`).
+
+Si le document existant que vous souhaitez supprimer a des documents enfants (c'est-à-dire qu'il représente une arborescence de documents), vous devez également spécifier l'option `-r, --recursive`, sinon la commande échouera.
+
+Par exemple, si vous souhaitez supprimer l'intégralité de l'arbre `/fr/Learn/Accessibility`, vous devez effectuer les étapes suivantes&nbsp;:
+
+1. Commencez à travailler dans une nouvelle branche.
+
+   ```bash
+   cd ~/repos/mdn/translated-content
+   git checkout main
+   git pull translated-content main
+   # Exécutez à nouveau « yarn » pour vous assurer que vous avez
+   # installé la dernière dépendance de Yari.
+   yarn
+   git checkout -b ma-suppression
+   ```
+
+2. Supprimer le document (qui supprimera l'arborescence entière).
+
+   ```bash
+   yarn content delete Learn/Accessibility fr --recursive
+   ```
+
+3. Ajouter une redirection. La page cible peut être une URL externe ou une autre page sur le MDN Web Docs.
+
+   ```bash
+   yarn content add-redirect /fr/chemin/de/la/page/supprimee /fr/chemin/de/la/page/cible
+   ```
+
+4. Ajouter et livrer (<i lang="en">commit</i> en anglais) tous les fichiers supprimés, créés et modifiés, et poussez votre branche vers votre fork.
+
+   ```bash
+   git commit -a
+   git push -u origin ma-suppression
+   ```
+
+5. Créer votre requête de tirage (<i lang="en">pull request</i> en anglais).
+
+> **Note :** Si le nom de la page que vous souhaitez supprimer contient des caractères spéciaux, mettez-le entre guillemets, comme suit&nbsp;:
+>
+> ```bash
+> yarn content delete "Mozilla/Add-ons/WebExtensions/Debugging_(before_Firefox_50)"
+> ```
+
+La suppression du contenu des documents Web MDN entraînera inévitablement la mise à jour du contenu existant. Comme de nombreux articles renvoient à d'autres, le contenu supprimé sera probablement référencé ailleurs. L'ajout de la redirection atténuera l'impact de la suppression du contenu&nbsp;; cependant, la meilleure pratique consiste à modifier le contenu pour refléter le changement et à inclure les modifications du contenu avec la demande de suppression.
+
+## Modifier des pages existantes
+
+Pour modifier une page, vous devez trouver la source de la page dans nos dépôts [content](https://github.com/mdn/content) (fichiers anglais) et [translated-content](https://github.com/mdn/translated-content) (fichiers traduits). La façon la plus simple de la trouver est de naviguer jusqu'à la page que vous voulez éditer, d'aller en bas de la page et de cliquer sur le lien «&nbsp;<i lang="en">View the source on GitHub</i>&nbsp;» (Voir la source sur GitHub pour son équivalent Français).
+
+### Prévisualiser les modifications
+
+- **Si vous éditez la version anglaise**
+  - : Si vous éditez la page localement, pour voir à quoi ressemblent vos changements, vous pouvez aller dans le dossier `content` du dépôt, exécuter la commande CLI `yarn start`, aller à `localhost:5042` dans votre navigateur, et naviguer jusqu'à la page et la voir.
+
+- **Si vous éditez une version traduite**
+  - : Pour éditer la page localement et voir à quoi ressemblent vos modifications, il vous faut aller dans le dossier `yari` (Vous devez préalablement avoir paramétré votre environnement et avoir au même niveau que `yari` les dossiers `content` et `translated-content`), exécuter la commande CLI `yarn start`, aller à `localhost:5042` dans votre navigateur, et naviguer jusqu'à la page et la voir.
+  
+Entrez le titre dans la barre de recherche pour la trouver facilement. La page prévisualisée se mettra à jour dans le navigateur au fur et à mesure que vous modifierez la source.
+
+### Joindre des fichiers
+
+Pour joindre un fichier à votre article, il vous suffit de l'inclure dans le même répertoire que le fichier `index.md` de l'article. Incluez le fichier dans votre page, généralement via un élément [`<a>`](/fr/docs/Web/HTML/Element/a). Pour la traduction française, il est recommendé de ne le faire que si le fichier est traduit (exemple pour les images).

--- a/files/fr/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
@@ -160,13 +160,10 @@ Pour modifier une page, vous devez trouver la source de la page dans nos dépôt
 ### Prévisualiser les modifications
 
 - **Si vous éditez la version anglaise**
-
   - : Si vous éditez la page localement, pour voir à quoi ressemblent vos changements, vous pouvez aller dans le dossier `content` du dépôt, exécuter la commande CLI `yarn start`, aller à `localhost:5042` dans votre navigateur, et naviguer jusqu'à la page et la voir.
-
 - **Si vous éditez une version traduite**
-
   - : Pour éditer la page localement et voir à quoi ressemblent vos modifications, il vous faut aller dans le dossier `yari` (Vous devez préalablement avoir paramétré votre environnement et avoir au même niveau que `yari` les dossiers `content` et `translated-content`), exécuter la commande CLI `yarn start`, aller à `localhost:5042` dans votre navigateur, et naviguer jusqu'à la page et la voir.
-  
+
 Entrez le titre dans la barre de recherche pour la trouver facilement. La page prévisualisée se mettra à jour dans le navigateur au fur et à mesure que vous modifierez la source.
 
 ### Joindre des fichiers

--- a/files/fr/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
@@ -11,17 +11,23 @@ Cet article décrit comment créer, déplacer, supprimer ou modifier une page. D
 
 ## Créer de nouvelles pages
 
-Toutes les pages du MDN Web Docs sont rédigées au format Markdown. Le contenu est écrit dans un fichier nommé `index.md`, qui est stocké dans un répertoire unique. Le nom du répertoire représente le nom de la page. Par exemple, si `align-content` est une nouvelle propriété CSS pour laquelle vous voulez créer une nouvelle page de référence, vous devez créer un dossier dans `en-us/web/css` (ou `fr/web/css` si vous procédez à sa traduction) nommé `align-content` et créer un fichier appelé `index.md` à l'intérieur de ce dossier.
+Toutes les pages du MDN Web Docs sont rédigées au format Markdown. Le contenu est écrit dans un fichier nommé `index.md`, qui est stocké dans un répertoire unique. Le nom du répertoire représente le nom de la page.
 
-> **Note :** Le nom du répertoire diffère légèrement de l'intitulé de la page. En particulier, le slug suit la casse de la phrase.
+C'est le contenu anglais (du dépôt `mdn/content`) qui est la référence du contenu disponible en français. Si vous souhaitez créer une page qui n'existe pas (ni en anglais ni en français), il vous faudra d'abord créer la page en anglais. N'hésitez pas à [consulter la documentation à ce sujet](/fr/docs/MDN/Writing_guidelines/Howto/Creating_moving_deleting#creating_pages).
 
-Il existe de nombreux [types de pages](/fr/docs/MDN/Writing_guidelines/Page_structures/Page_types) avec certaines structures et des modèles de pages qui les accompagnent, que vous pouvez copier pour commencer.
+Si vous souhaitez créer une traduction d'une page qui existe en anglais, mais pas en français, vous devez créer un répertoire correspondant dans votre arborescence de `mdn/translated-content`. Par exemple, si vous souhaitez traduire la page documentant la propriété CSS `align-content`&nbsp;:
 
-Le fichier `index.md` d'un document doit commencer par des informations préliminaires qui définissent le `titre`, le `slug` et le `type de page` (ce dernier est uniquement réservé à la version anglaise). Toutes ces informations peuvent être trouvées dans les modèles de page mentionnés ci-dessus. Alternativement, vous pouvez trouver utile de vous référer à la matière première dans le fichier `index.md` d'un document similaire.
+1. Dans votre copie locale de `mdn/translated-content`, créez un répertoire `align-content` sous `./files/fr/web/css`
+2. Dans votre copie locale de `mdn/content`, copiez le fichier `./files/en-us/web/css/align-content/index.md`
+3. Collez ce fichier dans `./files/fr/web/css/align-content`.
+
+> **Note :** Le nom du répertoire diffère légèrement de l'intitulé de la page. En particulier, le <i lang="en">slug</i> suit la casse de la phrase, alors que le chemin sur le système de fichiers est exclusivement en minuscules.
+
+Le fichier `index.md` d'un document doit commencer par des informations préliminaires qui définissent le `titre`, le `slug` (les autres métadonnées comme `page-type` sont réservées à la version anglaise).
 
 Le processus général de création d'une page, étape par étape, est le suivant&nbsp;:
 
-1. Démarrer une nouvelle branche, actualisée, pour y travailler.
+1. Démarrez une nouvelle branche, actualisée, pour y travailler.
 
    ```bash
    cd ~/repos/mdn/translated-content
@@ -33,9 +39,9 @@ Le processus général de création d'une page, étape par étape, est le suivan
    git checkout -b mon-ajout
    ```
 
-2. Créer un ou plusieurs nouveaux dossiers, chacun avec ses propres fichiers `index.md`.
+2. Créez un ou plusieurs nouveaux dossiers, chacun avec ses propres fichiers `index.md`.
 
-3. Ajouter et livrer (<i lang="en">commit</i> en anglais) vos nouveaux fichiers et poussez votre nouvelle branche sur votre fork.
+3. Ajoutez et livrez (<i lang="en">commit</i> en anglais) vos nouveaux fichiers et poussez votre nouvelle branche sur votre <i lang="en">fork</i>.
 
    ```bash
    git add files/fr/dossier/cree
@@ -43,119 +49,17 @@ Le processus général de création d'une page, étape par étape, est le suivan
    git push -u origin mon-ajout
    ```
 
-4. Créer votre requête de tirage (<i lang="en">pull request</i> en anglais).
+4. Créez votre requête de tirage (<i lang="en">pull request</i> en anglais) sur `mdn/translated-content`.
 
-## Déplacer des pages
+## Déplacer et supprimer des pages
 
-Il est facile de déplacer un ou plusieurs documents ou une arborescence entière de documents, car nous avons créé une commande spéciale qui s'occupe des détails pour vous&nbsp;:
+Le contenu francophone suit la structure du contenu anglophone (situé sur `mdn/content`). Aussi, si vous souhaitez déplacer ou supprimer des pages, il faudra le faire sur la version anglophone en premier lieu. Nous vous invitons donc à lire [la documentation associée](/fr/docs/MDN/Writing_guidelines/Howto/Creating_moving_deleting#moving_pages).
 
-- Si la page est en anglais&nbsp;: [sur notre dépôt <i lang="en">content</i>](https://github.com/mdn/content)
-
-  ```bash
-  yarn content move <slug-de-depart> <nouveau-slug> en-US
-  ```
-
-- Si la page est en français&nbsp;: [sur notre dépôt <i lang="en">translated-content</i>](https://github.com/mdn/translated-content)
-
-  ```bash
-  yarn content move <slug-de-depart> <nouveau-slug> fr
-  ```
-
-Il vous suffit de spécifier le nom du document existant que vous souhaitez déplacer (par exemple, `Learn/Accessibility`), ainsi que le nom de son nouvel emplacement (par exemple, `Learn/A11y`), suivi éventuellement de la langue du document existant (par défaut `en-US`).
-
-Si le document existant que vous souhaitez déplacer a des documents enfants (c'est-à-dire qu'il représente une arborescence de documents), le nom de l'arborescence peut être modifié, il représente une arborescence de documents), la commande `yarn content move` déplacera l'arbre entier.
-
-1. Vous commencerez à travailler dans une nouvelle branche.
-
-   ```bash
-   cd ~/repos/mdn/translated-content
-   git checkout main
-   git pull translated-content main
-   # Exécutez à nouveau « yarn » pour vous assurer que vous avez
-   # installé la dernière dépendance de Yari.
-   yarn
-   git checkout -b mon-deplacement
-   ```
-
-2. Effectuer le déplacement (qui supprimera et modifiera les fichiers existants et en créera de nouveaux).
-
-   ```bash
-   yarn content move Learn/Accessibility Learn/A11y fr
-   ```
-
-3. Ajouter et livrer (<i lang="en">commit</i> en anglais) tous les fichiers supprimés, créés et modifiés, et poussez votre branche vers votre fork.
-
-   ```bash
-   git commit -a
-   git push -u origin mon-deplacement
-   ```
-
-4. Créer votre requête de tirage (<i lang="en">pull request</i> en anglais).
-
-> **Note :** `yarn content move` ajoute automatiquement les informations de redirection nécessaires au fichier `_redirects.txt` afin que l'ancien emplacement soit redirigé vers le nouveau. N'éditez pas le fichier `_redirects.txt` manuellement&nbsp;! Des erreurs peuvent facilement se glisser si vous le faites. Si vous avez besoin d'ajouter une redirection sans déplacer un fichier, parlez-en à l'équipe sur le [salon de discussion du MDN Web Docs](/fr/docs/MDN/Community/Communication_channels#salons_de_discussions).
-
-## Supprimer des pages
-
-Les documents ne doivent être retirés du MDN Web Docs que dans des circonstances particulières. Si vous envisagez de supprimer des pages, veuillez en discuter avec l'équipe sur la page [salon de discussion du MDN Web Docs](/fr/docs/MDN/Community/Communication_channels#salons_de_discussions) en premier.
-
-La suppression d'un ou plusieurs documents ou d'une arborescence entière de documents est facile, tout comme le déplacement de pages, car nous avons créé une commande spéciale qui s'occupe des détails pour vous&nbsp;:
-
-```bash
-yarn content delete <lien-du-document> [langue]
-```
-
-> **Note :** Vous devez utiliser la commande `yarn content delete` pour supprimer les pages du MDN Web Docs. Ne vous contentez pas de supprimer leurs répertoires du référentiel. La commande `yarn content delete` gère également d'autres changements nécessaires comme la mise à jour du fichier `_wikihistory.json`.
-
-Vous devez simplement spécifier le nom du document existant que vous souhaitez supprimer (par exemple, `Learn/Accessibility`), suivi éventuellement de la langue du document existant (par défaut `en-US`).
-
-Si le document existant que vous souhaitez supprimer a des documents enfants (c'est-à-dire qu'il représente une arborescence de documents), vous devez également spécifier l'option `-r, --recursive`, sinon la commande échouera.
-
-Par exemple, si vous souhaitez supprimer l'intégralité de l'arbre `/fr/Learn/Accessibility`, vous devez effectuer les étapes suivantes&nbsp;:
-
-1. Commencez à travailler dans une nouvelle branche.
-
-   ```bash
-   cd ~/repos/mdn/translated-content
-   git checkout main
-   git pull translated-content main
-   # Exécutez à nouveau « yarn » pour vous assurer que vous avez
-   # installé la dernière dépendance de Yari.
-   yarn
-   git checkout -b ma-suppression
-   ```
-
-2. Supprimer le document (qui supprimera l'arborescence entière).
-
-   ```bash
-   yarn content delete Learn/Accessibility fr --recursive
-   ```
-
-3. Ajouter une redirection. La page cible peut être une URL externe ou une autre page sur le MDN Web Docs.
-
-   ```bash
-   yarn content add-redirect /fr/chemin/de/la/page/supprimee /fr/chemin/de/la/page/cible
-   ```
-
-4. Ajouter et livrer (<i lang="en">commit</i> en anglais) tous les fichiers supprimés, créés et modifiés, et poussez votre branche vers votre fork.
-
-   ```bash
-   git commit -a
-   git push -u origin ma-suppression
-   ```
-
-5. Créer votre requête de tirage (<i lang="en">pull request</i> en anglais).
-
-> **Note :** Si le nom de la page que vous souhaitez supprimer contient des caractères spéciaux, mettez-le entre guillemets, comme suit&nbsp;:
->
-> ```bash
-> yarn content delete "Mozilla/Add-ons/WebExtensions/Debugging_(before_Firefox_50)"
-> ```
-
-La suppression du contenu des documents Web MDN entraînera inévitablement la mise à jour du contenu existant. Comme de nombreux articles renvoient à d'autres, le contenu supprimé sera probablement référencé ailleurs. L'ajout de la redirection atténuera l'impact de la suppression du contenu&nbsp;; cependant, la meilleure pratique consiste à modifier le contenu pour refléter le changement et à inclure les modifications du contenu avec la demande de suppression.
+Une fois ces modifications apportées sur la version anglaise, un processus automatique déclenchera des <i lang="en">pull requests</i> pour que l'équivalent soit appliqué sur les différentes locales dont le français.
 
 ## Modifier des pages existantes
 
-Pour modifier une page, vous devez trouver la source de la page dans nos dépôts [content](https://github.com/mdn/content) (fichiers anglais) et [translated-content](https://github.com/mdn/translated-content) (fichiers traduits). La façon la plus simple de la trouver est de naviguer jusqu'à la page que vous voulez éditer, d'aller en bas de la page et de cliquer sur le lien «&nbsp;<i lang="en">View the source on GitHub</i>&nbsp;» (Voir la source sur GitHub pour son équivalent Français).
+Pour modifier une page, vous devez trouver la source de la page dans nos dépôts [`mdn/content`](https://github.com/mdn/content) (fichiers anglais) et [`mdn/translated-content`](https://github.com/mdn/translated-content) (fichiers traduits). La façon la plus simple de la trouver est d'utiliser votre navigateur pour accéder à la page que vous voulez éditer, d'aller en bas de la page et de cliquer sur le lien «&nbsp;<i lang="en">View the source on GitHub</i>&nbsp;» (Voir la source sur GitHub pour son équivalent Français).
 
 ### Prévisualiser les modifications
 
@@ -168,4 +72,4 @@ Entrez le titre dans la barre de recherche pour la trouver facilement. La page p
 
 ### Joindre des fichiers
 
-Pour joindre un fichier à votre article, il vous suffit de l'inclure dans le même répertoire que le fichier `index.md` de l'article. Incluez le fichier dans votre page, généralement via un élément [`<a>`](/fr/docs/Web/HTML/Element/a). Pour la traduction française, il est recommendé de ne le faire que si le fichier est traduit (exemple pour les images).
+Pour joindre un fichier à votre article, il vous suffit de l'inclure dans le même répertoire que le fichier `index.md` de l'article. Incluez le fichier dans votre page, généralement via un élément [`<a>`](/fr/docs/Web/HTML/Element/a). Pour la traduction française, il est uniquement nécessaire de le faire si le fichier doit être traduit (exemple pour les images)&nbsp;; les fichiers qui n'ont pas à être traduits sont automatiquement récupérés depuis le dépôt anglais.

--- a/files/fr/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
@@ -63,7 +63,7 @@ Il est facile de déplacer un ou plusieurs documents ou une arborescence entièr
 
 Il vous suffit de spécifier le nom du document existant que vous souhaitez déplacer (par exemple, `Learn/Accessibility`), ainsi que le nom de son nouvel emplacement (par exemple, `Learn/A11y`), suivi éventuellement de la langue du document existant (par défaut `en-US`).
 
-Si le document existant que vous souhaitez déplacer a des documents enfants (c'est-à-dire qu'il représente une arborescence de  documents), le nom de l'arborescence peut être modifié, il représente une arborescence de documents), la commande `yarn content move` déplacera l'arbre entier.
+Si le document existant que vous souhaitez déplacer a des documents enfants (c'est-à-dire qu'il représente une arborescence de documents), le nom de l'arborescence peut être modifié, il représente une arborescence de documents), la commande `yarn content move` déplacera l'arbre entier.
 
 1. Vous commencerez à travailler dans une nouvelle branche.
 
@@ -160,9 +160,11 @@ Pour modifier une page, vous devez trouver la source de la page dans nos dépôt
 ### Prévisualiser les modifications
 
 - **Si vous éditez la version anglaise**
+
   - : Si vous éditez la page localement, pour voir à quoi ressemblent vos changements, vous pouvez aller dans le dossier `content` du dépôt, exécuter la commande CLI `yarn start`, aller à `localhost:5042` dans votre navigateur, et naviguer jusqu'à la page et la voir.
 
 - **Si vous éditez une version traduite**
+
   - : Pour éditer la page localement et voir à quoi ressemblent vos modifications, il vous faut aller dans le dossier `yari` (Vous devez préalablement avoir paramétré votre environnement et avoir au même niveau que `yari` les dossiers `content` et `translated-content`), exécuter la commande CLI `yarn start`, aller à `localhost:5042` dans votre navigateur, et naviguer jusqu'à la page et la voir.
   
 Entrez le titre dans la barre de recherche pour la trouver facilement. La page prévisualisée se mettra à jour dans le navigateur au fur et à mesure que vous modifierez la source.

--- a/files/fr/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
@@ -1,6 +1,8 @@
 ---
 title: Créer et modifier des pages
 slug: MDN/Writing_guidelines/Howto/Creating_moving_deleting
+l10n:
+  sourceCommit: 6b01400b286e8bdfa7060d56af84757dd4b8de48
 ---
 
 {{MDNSidebar}}

--- a/files/fr/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/images_media/index.md
@@ -1,23 +1,127 @@
 ---
-title: Contenu vidéo sur MDN
+title: Comment ajouter des images et vidéos
 slug: MDN/Writing_guidelines/Howto/Images_media
+l10n:
+  sourceCommit: 8d0cbeacdc1872f7e4d966177151585c58fb879e
 ---
 
 {{MDNSidebar}}
 
-MDN n'est pas un site contenant beaucoup de vidéos. Toutefois, certaines documentations sont propices à ce type de média. Dans cet article, nous verrons quand inclure des vidéos sur MDN et quelques conseils permettant de créer des vidéos simples et efficaces.
+# Ajouter des images
 
-## Quand utiliser des vidéos sur MDN
+Pour ajouter une image à un document, ajoutez le fichier image dans le dossier du document puis référencez l'image dans le fichier `index.md` du document en utilisant un élément `<img>` ou [la syntaxe Markdown équivalente](https://github.github.com/gfm/#images).
 
-L'utilisation de vidéo pour de la documentation technique n'est pas indiquée par défaut pour plusieurs raisons&nbsp;:
+Prenons un exemple&nbsp;:
 
-- Une vidéo est linéaire. Les personnes ne consultent pas la documentation de façon linéaire, du début à la fin&nbsp;: [ils scannent la documentation](https://www.sensible.com/chapter.html). Faire de même pour une vidéo est quasi impossible et cela force à visualiser le contenu de A à Z.
-- Une vidéo possède une densité d'information plus faible que le texte. Il faut plus de temps pour regarder une vidéo expliquant une notion que de lire un article texte équivalent.
-- Une vidéo a un poids numérique plus élevé et est donc plus coûteuse et moins performante que le texte.
-- Une vidéo peut poser des problèmes d'accessibilité&nbsp;: elle est plus coûteuse à réaliser, à localiser ou à rendre accessible aux personnes qui utilisent des lecteurs d'écran.
-- Enfin, une vidéo est beaucoup plus difficile à éditer/mettre à jour/maintenir que du texte.
+1. Commencez avec une branche de travail fraîche avec le contenu le plus récent de la branche `main` du dépôt distant du `mdn`.
 
-> **Note :** Il est important de garder ces limitations en tête lorsqu'on réalise des vidéos afin de les minimiser autant que possible.
+   ```bash
+   cd ~/path/to/mdn/translated-content
+   git checkout main
+   git pull translated-content main
+   # Exécutez "yarn" à nouveau pour vous assurer
+   # que vous avez installé la dernière dépendance Yari.
+   yarn
+   git checkout -b mes-images
+   ```
+
+2. Ajoutez votre image au dossier du document. Pour cet exemple, supposons que nous ajoutons une nouvelle image au document `files/fr/web/css`.
+
+   ```bash
+   cd ~/path/to/mdn/translated-content
+   cp ../some/path/ma-superbe-image.png files/fr/web/css/
+   ```
+
+3. Exécutez `filecheck` sur chaque image, ce dernier vous alerte si quelque chose ne va pas.
+   Pour plus de détails, consultez la section [Compression des images](#compression-des-images).
+
+   ```bash
+   yarn filecheck files/fr/web/css/ma-superbe-image.png
+   ```
+
+4. Référencez votre image dans le document avec un élément `<img>` et un attribut `alt` dans `files/fr/web/css/index.md` :
+
+   ```html
+    <img src="ma-superbe-image.png" alt="Ma superbe image" />
+    ```
+
+5. Ajoutez et livrez (<i lang="en">commit</i> en anglais) tous les fichiers supprimés, créés et modifiés, puis poussez votre branche vers votre fork&nbsp;:
+
+   ```bash
+   git add files/fr/web/css/ma-superbe-image.png files/fr/web/css/index.html
+   git commit
+   git push -u origin mes-images
+   ```
+
+6. Vous êtes maintenant prêt à créer votre [requête de tirage (<i lang="en">pull request</i> en anglais)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
+
+
+## Ajouter les textes alternatifs aux images
+
+Chaque image, `![]` et `<img>`, doit inclure un texte alternatif.
+Les attributs `alt` doivent être courts et fournir toutes les informations pertinentes que l'image transmet.
+Lorsque vous écrivez la description de l'image, réfléchissez aux informations précieuses de l'image et à la façon dont vous les transmettriez à quelqu'un qui peut lire le contenu de la page mais ne peut pas charger les images.
+
+Soyez sûr que le texte alternatif de l'image est basé sur son contexte.
+Si la photo de Fluffy le chien est un avatar à côté d'un avis pour la nourriture pour chien Yuckymeat, `alt="Fluffy"` est approprié.
+Si la même photo fait partie de la page d'adoption de Fluffy, les informations transmises dans l'image sont pertinentes pour les futurs parents de chiens, telles que `alt="Fluffy, un terrier tricolore à poil très court, avec une balle de tennis dans la bouche."`.
+Le texte environnant indique probablement la taille et la race de Fluffy, il serait donc redondant de l'inclure.
+Évitez de décrire l'image avec trop de détails&nbsp;: le futur parent n'a pas besoin de savoir si le chien est à l'intérieur ou à l'extérieur, ou s'il a un collier rouge et une laisse bleue.
+
+Avec les captures d'écran, écrivez ce que vous apprenez de l'image, ne détaillez pas le contenu de la capture d'écran et omettez les informations dont les lecteurs n'ont pas besoin ou qu'ils connaissent déjà.
+Par exemple, si vous êtes sur une page expliquant comment modifier les paramètres de Bing, si vous avez une capture d'écran d'un résultat de recherche Bing, n'incluez pas le terme de recherche ou le nombre de résultats, etc., car ce ne sont pas le but de l'image.
+Limitez l'attribut `alt` au sujet en question&nbsp;: comment modifier les paramètres dans Bing.
+L'attribut `alt` pourrait être `alt="L'icône des paramètres se trouve dans la barre de navigation sous le champ de recherche."`.
+N'incluez pas «&nbsp;capture d'écran&nbsp;» ou «&nbsp;Bing&nbsp;» car l'utilisateur n'a pas besoin de savoir qu'il s'agit d'une capture d'écran et il sait déjà que c'est Bing car il est sur une page expliquant comment modifier les paramètres de Bing.
+
+La syntaxe en markdown et HTML&nbsp;:
+
+```html-nolint
+![<texte-alternatif>](<url-de-l-image>)
+<img alt="<texte-alternatif>" src="<url-de-l-image>">
+```
+
+Exemples&nbsp;:
+
+```html
+![Logo OpenWebDocs : Carle la chenille](carle.png)
+<img alt="Logo OpenWebDocs : Carle la chenille" src="carle.png" />
+```
+
+Alors que les images purement décoratives doivent avoir un attribut `alt` vide, les images ajoutées à la documentation MDN doivent avoir une raison d'être, et nécessitent donc une description sous forme de chaîne non vide.
+
+## Compression des images
+
+Lorsque vous ajoutez des images à une page du MDN Web Docs, vous devez vous assurer qu'elles sont compressées autant que possible (sans dégradation de la qualité) afin de réduire la taille du téléchargement pour nos lecteurs.
+En fait, si vous ne le faites pas, notre processus de CI échouera et les résultats de la construction vous avertiront que certaines de vos images sont trop volumineuses.
+
+La meilleure façon de compresser les images est d'utiliser l'outil de compression intégré.
+Vous pouvez compresser une image de manière appropriée en utilisant la commande `filecheck` avec l'option `--save-compression`.
+Cette option compresse l'image autant que possible et remplace l'original par la version compressée.
+Par exemple&nbsp;:
+
+```bash
+yarn filecheck files/fr/web/css/ma-superbe-image.png --save-compression
+```
+
+## Ajouter des vidéos
+
+MDN Web Docs n'est pas un site très riche en vidéos, mais il y a certains endroits où il est judicieux d'utiliser du contenu vidéo dans un article.
+Cet article examine les cas où il est approprié d'inclure des vidéos dans les articles et donne des conseils sur la façon de créer des vidéos simples mais efficaces avec un budget limité.
+
+Plusieurs arguments s'opposent à l'utilisation de vidéos dans la documentation technique, en particulier dans les documents de référence et les guides de niveau avancé. Certains d'entre eux sont énumérés ci-dessous&nbsp;:
+
+- La vidéo est linéaire.
+  Les gens n'ont pas tendance à lire la documentation en ligne de manière linéaire, en commençant par le début et en lisant jusqu'à la fin.
+  _Ils scannent_.
+  La vidéo est vraiment difficile à parcourir — elle oblige l'utilisateur à consommer le contenu du début à la fin.
+- La vidéo est moins dense en informations que le texte.
+  Il faut plus de temps pour consommer une vidéo expliquant quelque chose que pour lire les instructions équivalentes.
+- La vidéo est volumineuse en termes de taille de fichier et, par conséquent, plus coûteuse et moins performante que le texte.
+- La vidéo pose des problèmes d'accessibilité&nbsp;: elle est généralement plus coûteuse à produire que le texte, mais surtout à traduire ou à rendre utilisable par les utilisateurs de lecteurs d'écran.
+- Dans le prolongement du dernier point, la vidéo est beaucoup plus difficile à éditer/mettre à jour/maintenir que le contenu textuel.
+
+> **Note :** Il est utile de garder à l'esprit cette problématique, même lorsque vous réalisez des vidéos, afin d'essayer d'en atténuer certains aspects.
 
 Il existe de nombreux sites populaires qui fournissent de nombreux tutoriels vidéo. MDN n'est pas un site dont la majorité du contenu est de la vidéo, toutefois, il est possible d'intégrer des vidéos dans certains articles MDN selon le contexte.
 
@@ -25,7 +129,7 @@ Sur MDN, les vidéos sont particulièrement utilisées lorsqu'on souhaite décri
 
 Dans de telles situations, il est souvent plus pratique de **montrer** ce qu'on indique.
 
-## À quoi doit ressembler une vidéo sur MDN&nbsp;?
+## Lignes de conduite pour les vidéos
 
 Une vidéo à destination de MDN devrait être&nbsp;:
 
@@ -33,16 +137,20 @@ Une vidéo à destination de MDN devrait être&nbsp;:
 - **Simple**&nbsp;: On essaiera de garder un cheminement simple avec 2 à 4 fragments distincts pour que les étapes soient faciles à suivre.
 - **Silencieuse**&nbsp;: Le son permet d'avoir des vidéos plus impactantes mais demande également plus de temps pour la réalisation et l'implication d'un spectateur ou d'une spectatrice qui peut ne pas pouvoir écouter au moment où il/elle regarde la vidéo. Cela peut également rallonger la vidéo et rajoute des coûts de maintenance et de localisation.
 
-Pour expliquer quelque chose de complexes, on pourra utiliser un ensemble de vidéos courtes et de captures d'écran avec du texte. Le texte permettra ainsi d'insister sur les notions vues dans les vidéos et la personne qui consulte le contenu pourra alors choisir de suivre le texte et/ou la vidéo.
+Pour expliquer quelque chose de complexes, on pourra utiliser un ensemble de vidéos courtes et de captures d'écran avec du texte.
+Le texte permettra ainsi d'insister sur les notions vues dans les vidéos et la personne qui consulte le contenu pourra alors choisir de suivre le texte et/ou la vidéo.
+Voir [Travailler avec l'inspecteur d'animation (en anglais)](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/work_with_animations/index.html#animation-inspector) pour un bon exemple.
 
 De plus, on fera attention aux conseils suivants&nbsp;:
 
 - La vidéo sera uploadée sur YouTube avant d'être intégrée à la page MDN. On recommande un format 16:9 afin que tout le cadre soit rempli et qu'il n'y ait pas de barres noires. Voici quelques résolutions qui peuvent être utilisées&nbsp;: 1024×576, 1152×648 ou 1280×720.
 - La vidéo devra être enregistrée en HD afin qu'elle ait le meilleur aspect possible lors de l'<i lang="en">upload</i>.
+- Pour les vidéos sur les DevTools, il est souvent judicieux de choisir un thème contrasté par rapport au contenu de la page. Par exemple, si la page est claire, on choisira le thème sombre. Cela permet de mieux voir ce qui se passe et de mieux distinguer les DevTools du contenu de la page.
+- Pour les vidéos sur les DevTools, on zoomera autant que possible sur les DevTools tout en montrant tout ce qu'on souhaite montrer et en gardant un aspect correct.
 - Le curseur de la souris ne doit pas couvrir les éléments qu'on souhaite indiquer.
 - Si c'est utile, on configurera l'outil d'enregistrement afin d'enregistrer les clics et/ou le pointeur de la souris.
 
-## Outils
+## Lignes de conduite pour les outils de vidéo
 
 Il vous faudra un outil pour enregistrer la vidéo. Il en existe une variété allant d'outils gratuits à payants, de simples à complexes. Si vous avez déjà créé du contenu vidéo&nbsp;: parfait. Sinon, nous vous conseillons de commencer avec un outil simple puis de choisir ensuite quelque chose de plus complexe si besoin.
 
@@ -88,10 +196,10 @@ Planifiez soigneusement les étapes que vous allez enregistrer et pratiquez cett
 - Ne commencez pas une vidéo au milieu d'une suite d'étape. Veillez à ce que le spectateur ait suffisamment de contexte pour que les actions illustrées aient du sens.
 - Pour chacune de vos actions, assurez-vous de les réaliser suffisamment lentement et de les mettre en évidence. Par exemple, lorsqu'on doit cliquer quelque part on pourra&nbsp;:
 
-  1. Déplacer la souris sur l'icône
-  2. Mettre en évidence ou zoomer (selon ce qui est le plus pertinent)
-  3. Suspendre le mouvement pendant un instant
-  4. Cliquer sur l'icône
+  - Déplacer la souris sur l'icône
+  - Mettre en évidence ou zoomer (selon ce qui est le plus pertinent)
+  - Suspendre le mouvement pendant un instant
+  - Cliquer sur l'icône
 
 - Planifiez les niveaux de zoom pour les portions de l'interface utilisateur que vous afficherez. Tout le monde ne pourra pas forcément consulter la vidéo en haute définition. Vous pourrez également zoomer sur certaines parties en post-production mais ça peut être une bonne idée de zoomer dès l'enregistrement.
 

--- a/files/fr/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/images_media/index.md
@@ -1,5 +1,5 @@
 ---
-title: Comment ajouter des images et vidéos
+title: Comment ajouter des images et des médias
 slug: MDN/Writing_guidelines/Howto/Images_media
 l10n:
   sourceCommit: 8d0cbeacdc1872f7e4d966177151585c58fb879e
@@ -13,10 +13,10 @@ Pour ajouter une image à un document, ajoutez le fichier image dans le dossier 
 
 Prenons un exemple&nbsp;:
 
-1. Commencez avec une branche de travail fraîche avec le contenu le plus récent de la branche `main` du dépôt distant du `mdn`.
+1. Commencez avec une branche de travail fraîche avec le contenu le plus récent de la branche `main` du dépôt distant du `translated-content`.
 
    ```bash
-   cd ~/path/to/mdn/translated-content
+   cd ~/chemin/vers/mdn/translated-content
    git checkout main
    git pull translated-content main
    # Exécutez "yarn" à nouveau pour vous assurer
@@ -28,18 +28,17 @@ Prenons un exemple&nbsp;:
 2. Ajoutez votre image au dossier du document. Pour cet exemple, supposons que nous ajoutons une nouvelle image au document `files/fr/web/css`.
 
    ```bash
-   cd ~/path/to/mdn/translated-content
-   cp ../some/path/ma-superbe-image.png files/fr/web/css/
+   cd ~/chemin/vers/mdn/translated-content
+   cp ../un/chemin/vers/ma-superbe-image.png files/fr/web/css/
    ```
 
-3. Exécutez `filecheck` sur chaque image, ce dernier vous alerte si quelque chose ne va pas.
-   Pour plus de détails, consultez la section [Compression des images](#compression-des-images).
+3. **Dans le répertoire de votre copie locale de `mdn/content`**, exécutez `filecheck` sur chaque image, ce dernier vous alerte si quelque chose ne va pas. Pour plus de détails, consultez la section [Compression des images](#compression-des-images).
 
    ```bash
-   yarn filecheck files/fr/web/css/ma-superbe-image.png
+   yarn filecheck /chemin/vers/translated-content/files/fr/web/css/ma-superbe-image.png
    ```
 
-4. Référencez votre image dans le document avec un élément `<img>` et un attribut `alt` dans `files/fr/web/css/index.md` :
+4. Référencez votre image dans le document avec un élément `<img>` et un attribut `alt` dans `files/fr/web/css/index.md`&nbsp;:
 
    ```html
    <img src="ma-superbe-image.png" alt="Ma superbe image" />
@@ -57,21 +56,13 @@ Prenons un exemple&nbsp;:
 
 ## Ajouter les textes alternatifs aux images
 
-Chaque image, `![]` et `<img>`, doit inclure un texte alternatif.
-Les attributs `alt` doivent être courts et fournir toutes les informations pertinentes que l'image transmet.
-Lorsque vous écrivez la description de l'image, réfléchissez aux informations précieuses de l'image et à la façon dont vous les transmettriez à quelqu'un qui peut lire le contenu de la page mais ne peut pas charger les images.
+Chaque image, `![]` et `<img>`, doit inclure un texte alternatif. Les attributs `alt` doivent être courts et fournir toutes les informations pertinentes que l'image transmet. Lorsque vous écrivez la description de l'image, réfléchissez aux informations précieuses de l'image et à la façon dont vous les transmettriez à quelqu'un qui peut lire le contenu de la page mais ne peut pas charger les images.
 
-Soyez sûr que le texte alternatif de l'image est basé sur son contexte.
-Si la photo de Fluffy le chien est un avatar à côté d'un avis pour la nourriture pour chien Yuckymeat, `alt="Fluffy"` est approprié.
-Si la même photo fait partie de la page d'adoption de Fluffy, les informations transmises dans l'image sont pertinentes pour les futurs parents de chiens, telles que `alt="Fluffy, un terrier tricolore à poil très court, avec une balle de tennis dans la bouche."`.
-Le texte environnant indique probablement la taille et la race de Fluffy, il serait donc redondant de l'inclure.
-Évitez de décrire l'image avec trop de détails&nbsp;: le futur parent n'a pas besoin de savoir si le chien est à l'intérieur ou à l'extérieur, ou s'il a un collier rouge et une laisse bleue.
+> **Note :** Voir [la documentation sur l'attribut `alt` de `<img>` et notamment la façon d'écrire des textes alternatifs pertinents](/fr/docs/Web/HTML/Element/img#écrire_des_descriptions_alternatives_significatives).
 
-Avec les captures d'écran, écrivez ce que vous apprenez de l'image, ne détaillez pas le contenu de la capture d'écran et omettez les informations dont les lecteurs n'ont pas besoin ou qu'ils connaissent déjà.
-Par exemple, si vous êtes sur une page expliquant comment modifier les paramètres de Bing, si vous avez une capture d'écran d'un résultat de recherche Bing, n'incluez pas le terme de recherche ou le nombre de résultats, etc., car ce ne sont pas le but de l'image.
-Limitez l'attribut `alt` au sujet en question&nbsp;: comment modifier les paramètres dans Bing.
-L'attribut `alt` pourrait être `alt="L'icône des paramètres se trouve dans la barre de navigation sous le champ de recherche."`.
-N'incluez pas «&nbsp;capture d'écran&nbsp;» ou «&nbsp;Bing&nbsp;» car l'utilisateur n'a pas besoin de savoir qu'il s'agit d'une capture d'écran et il sait déjà que c'est Bing car il est sur une page expliquant comment modifier les paramètres de Bing.
+Soyez sûr que le texte alternatif de l'image est basé sur son contexte. Si la photo de Fluffy le chien est un avatar à côté d'un avis pour la nourriture pour chien Yuckymeat, `alt="Fluffy"` est approprié. Si la même photo fait partie de la page d'adoption de Fluffy, les informations transmises dans l'image sont pertinentes pour les futurs parents de chiens, telles que `alt="Fluffy, un terrier tricolore à poil très court, avec une balle de tennis dans la bouche."`. Le texte environnant indique probablement la taille et la race de Fluffy, il serait donc redondant de l'inclure. Évitez de décrire l'image avec trop de détails&nbsp;: le futur parent n'a pas besoin de savoir si le chien est à l'intérieur ou à l'extérieur, ou s'il a un collier rouge et une laisse bleue.
+
+Avec les captures d'écran, écrivez ce que vous apprenez de l'image, ne détaillez pas le contenu de la capture d'écran et omettez les informations dont les lecteurs n'ont pas besoin ou qu'ils connaissent déjà. Par exemple, si vous êtes sur une page expliquant comment modifier les paramètres de Bing, si vous avez une capture d'écran d'un résultat de recherche Bing, n'incluez pas le terme de recherche ou le nombre de résultats, etc., car ce ne sont pas le but de l'image. Limitez l'attribut `alt` au sujet en question&nbsp;: comment modifier les paramètres dans Bing. L'attribut `alt` pourrait être `alt="L'icône des paramètres se trouve dans la barre de navigation sous le champ de recherche."`. N'incluez pas «&nbsp;capture d'écran&nbsp;» ou «&nbsp;Bing&nbsp;» car l'utilisateur n'a pas besoin de savoir qu'il s'agit d'une capture d'écran et il sait déjà que c'est Bing, car il est sur une page expliquant comment modifier les paramètres de Bing.
 
 La syntaxe en markdown et HTML&nbsp;:
 
@@ -91,31 +82,22 @@ Alors que les images purement décoratives doivent avoir un attribut `alt` vide,
 
 ## Compression des images
 
-Lorsque vous ajoutez des images à une page du MDN Web Docs, vous devez vous assurer qu'elles sont compressées autant que possible (sans dégradation de la qualité) afin de réduire la taille du téléchargement pour nos lecteurs.
-En fait, si vous ne le faites pas, notre processus de CI échouera et les résultats de la construction vous avertiront que certaines de vos images sont trop volumineuses.
+Lorsque vous ajoutez des images à une page du MDN Web Docs, vous devez vous assurer qu'elles sont compressées autant que possible (sans dégradation de la qualité) afin de réduire la taille du téléchargement pour nos lectrices et lecteurs. L'absence de compression entraînera l'échec de l'intégration continue, qui vous avertira que certaines de vos images sont trop volumineuses.
 
-La meilleure façon de compresser les images est d'utiliser l'outil de compression intégré.
-Vous pouvez compresser une image de manière appropriée en utilisant la commande `filecheck` avec l'option `--save-compression`.
-Cette option compresse l'image autant que possible et remplace l'original par la version compressée.
-Par exemple&nbsp;:
+La meilleure façon de compresser les images est d'utiliser l'outil de compression intégré. Vous pouvez compresser une image de manière appropriée en utilisant la commande `filecheck` avec l'option `--save-compression`. Cette option compresse l'image autant que possible et remplace l'original par la version compressée. Par exemple, **depuis le répertoire de votre copie locale de `mdn/content`**&nbsp;:
 
 ```bash
-yarn filecheck files/fr/web/css/ma-superbe-image.png --save-compression
+yarn filecheck /chemin/vers/translated-content/files/fr/web/css/ma-superbe-image.png --save-compression
 ```
 
 ## Ajouter des vidéos
 
-MDN Web Docs n'est pas un site très riche en vidéos, mais il y a certains endroits où il est judicieux d'utiliser du contenu vidéo dans un article.
-Cet article examine les cas où il est approprié d'inclure des vidéos dans les articles et donne des conseils sur la façon de créer des vidéos simples mais efficaces avec un budget limité.
+MDN Web Docs n'est pas un site très riche en vidéos, mais il y a certains endroits où il est judicieux d'utiliser du contenu vidéo dans un article. Cet article examine les cas où il est approprié d'inclure des vidéos dans les articles et donne des conseils sur la façon de créer des vidéos simples mais efficaces avec un budget limité.
 
 Plusieurs arguments s'opposent à l'utilisation de vidéos dans la documentation technique, en particulier dans les documents de référence et les guides de niveau avancé. Certains d'entre eux sont énumérés ci-dessous&nbsp;:
 
-- La vidéo est linéaire.
-  Les gens n'ont pas tendance à lire la documentation en ligne de manière linéaire, en commençant par le début et en lisant jusqu'à la fin.
-  _Ils scannent_.
-  La vidéo est vraiment difficile à parcourir — elle oblige l'utilisateur à consommer le contenu du début à la fin.
-- La vidéo est moins dense en informations que le texte.
-  Il faut plus de temps pour consommer une vidéo expliquant quelque chose que pour lire les instructions équivalentes.
+- La vidéo est linéaire. Les gens n'ont pas tendance à lire la documentation en ligne de manière linéaire, en commençant par le début et en lisant jusqu'à la fin. _Ils scannent_. La vidéo est vraiment difficile à scanner ainsi&nbsp;: elle oblige la personne à consommer le contenu du début à la fin.
+- La vidéo est moins dense en informations que le texte. Il faut plus de temps pour consommer une vidéo expliquant quelque chose que pour lire les instructions équivalentes.
 - La vidéo est volumineuse en termes de taille de fichier et, par conséquent, plus coûteuse et moins performante que le texte.
 - La vidéo pose des problèmes d'accessibilité&nbsp;: elle est généralement plus coûteuse à produire que le texte, mais surtout à traduire ou à rendre utilisable par les utilisateurs de lecteurs d'écran.
 - Dans le prolongement du dernier point, la vidéo est beaucoup plus difficile à éditer/mettre à jour/maintenir que le contenu textuel.
@@ -128,30 +110,29 @@ Sur MDN, les vidéos sont particulièrement utilisées lorsqu'on souhaite décri
 
 Dans de telles situations, il est souvent plus pratique de **montrer** ce qu'on indique.
 
-## Lignes de conduite pour les vidéos
+### Lignes de conduite pour les vidéos
 
 Une vidéo à destination de MDN devrait être&nbsp;:
 
-- **Courte**&nbsp;: On essaiera d'avoir des vidéos dont la durée est inférieure à 30 secondes, idéalement inférieure à 20 secondes. Elle sera ainsi suffisamment courte pour ne pas demander un temps d'attention trop long au spectateur ou à la spectatrice.
-- **Simple**&nbsp;: On essaiera de garder un cheminement simple avec 2 à 4 fragments distincts pour que les étapes soient faciles à suivre.
-- **Silencieuse**&nbsp;: Le son permet d'avoir des vidéos plus impactantes mais demande également plus de temps pour la réalisation et l'implication d'un spectateur ou d'une spectatrice qui peut ne pas pouvoir écouter au moment où il/elle regarde la vidéo. Cela peut également rallonger la vidéo et rajoute des coûts de maintenance et de localisation.
+- Courte
+  - : On essaiera d'avoir des vidéos dont la durée est inférieure à 30 secondes, idéalement inférieure à 20 secondes. Elle sera ainsi suffisamment courte pour ne pas demander un temps d'attention trop long au spectateur ou à la spectatrice.
+- Simple
+  - : On essaiera de garder un cheminement simple avec 2 à 4 fragments distincts pour que les étapes soient faciles à suivre.
+- Silencieuse
+  - : Le son permet d'avoir des vidéos plus impactantes mais demande également plus de temps pour la réalisation et l'implication d'un spectateur ou d'une spectatrice qui peut ne pas pouvoir écouter au moment où il/elle regarde la vidéo. Cela peut également rallonger la vidéo et rajoute des coûts de maintenance et de localisation.
 
-Pour expliquer quelque chose de complexes, on pourra utiliser un ensemble de vidéos courtes et de captures d'écran avec du texte.
-Le texte permettra ainsi d'insister sur les notions vues dans les vidéos et la personne qui consulte le contenu pourra alors choisir de suivre le texte et/ou la vidéo.
-Voir [Travailler avec l'inspecteur d'animation (en anglais)](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/work_with_animations/index.html#animation-inspector) pour un bon exemple.
+Pour expliquer quelque chose de complexe, on pourra utiliser un ensemble de vidéos courtes et de captures d'écran avec du texte. Le texte permettra ainsi d'insister sur les notions vues dans les vidéos et la personne qui consulte le contenu pourra alors choisir de suivre le texte et/ou la vidéo.
 
 De plus, on fera attention aux conseils suivants&nbsp;:
 
 - La vidéo sera uploadée sur YouTube avant d'être intégrée à la page MDN. On recommande un format 16:9 afin que tout le cadre soit rempli et qu'il n'y ait pas de barres noires. Voici quelques résolutions qui peuvent être utilisées&nbsp;: 1024×576, 1152×648 ou 1280×720.
 - La vidéo devra être enregistrée en HD afin qu'elle ait le meilleur aspect possible lors de l'<i lang="en">upload</i>.
-- Pour les vidéos sur les DevTools, il est souvent judicieux de choisir un thème contrasté par rapport au contenu de la page. Par exemple, si la page est claire, on choisira le thème sombre. Cela permet de mieux voir ce qui se passe et de mieux distinguer les DevTools du contenu de la page.
-- Pour les vidéos sur les DevTools, on zoomera autant que possible sur les DevTools tout en montrant tout ce qu'on souhaite montrer et en gardant un aspect correct.
 - Le curseur de la souris ne doit pas couvrir les éléments qu'on souhaite indiquer.
 - Si c'est utile, on configurera l'outil d'enregistrement afin d'enregistrer les clics et/ou le pointeur de la souris.
 
-## Lignes de conduite pour les outils de vidéo
+### Lignes de conduite pour les outils de vidéo
 
-Il vous faudra un outil pour enregistrer la vidéo. Il en existe une variété allant d'outils gratuits à payants, de simples à complexes. Si vous avez déjà créé du contenu vidéo&nbsp;: parfait. Sinon, nous vous conseillons de commencer avec un outil simple puis de choisir ensuite quelque chose de plus complexe si besoin.
+Il vous faudra un outil pour enregistrer la vidéo. Il en existe une variété allant d'outils gratuits à payants, de simples à complexes. Si vous avez déjà créé du contenu vidéo&nbsp;: parfait. Sinon, nous vous conseillons de commencer avec un outil simple, puis de choisir ensuite quelque chose de plus complexe si besoin.
 
 Le tableau qui suit fournit quelques recommandations d'outils pour commencer.
 
@@ -164,7 +145,7 @@ Le tableau qui suit fournit quelques recommandations d'outils pour commencer.
 | ScreenFlow                | macOS                  | Intermédiaire | Oui                                       |
 | Kazam                     | Linux                  | Gratuit       | Minimales                                 |
 
-### Conseils pour QuickTime
+#### Conseils pour QuickTime
 
 Si vous utilisez macOS, Quicktime Player est disponible et dispose de quelques fonctionnalités pour l'enregistrement&nbsp;:
 
@@ -176,15 +157,15 @@ Si vous utilisez macOS, Quicktime Player est disponible et dispose de quelques f
 6. Appuyez sur le bouton _Stop_.
 7. Choisissez _Fichier_ > _Exporter en tant que…_ > _1080p_ à partir du menu principal afin d'avoir une définition suffisamment élevée.
 
-### Autres ressources
+#### Autres ressources
 
 - [Comment ajouter des boîtes de légende personnalisées aux <i lang="en">screencasts</i> dans Screenflow (en anglais)](https://photography.tutsplus.com/tutorials/how-to-add-custom-callouts-to-screencast-videos-in-screenflow--cms-27122)
 
-## Étapes de création d'une vidéo
+### Étapes de création d'une vidéo
 
 Les sections qui suivent décrivent les étapes principales à suivre pour créer une vidéo et l'intégrer à une page MDN.
 
-### Préparation
+#### Préparation
 
 Tout d'abord, planifiez la suite d'actions que vous souhaitez enregistrer et choisissez les meilleures façons de commencer et de finir.
 
@@ -192,7 +173,7 @@ Assurez-vous que votre arrière-plan de bureau et votre profil de navigateur soi
 
 Planifiez soigneusement les étapes que vous allez enregistrer et pratiquez cette séquence d'actions plusieurs fois avant d'enregistrer&nbsp;:
 
-- Ne commencez pas une vidéo au milieu d'une suite d'étape. Veillez à ce que le spectateur ait suffisamment de contexte pour que les actions illustrées aient du sens.
+- Ne commencez pas une vidéo au milieu d'une suite d'étape. Veillez à ce qu'il y ait suffisamment de contexte pour que les actions illustrées aient du sens.
 - Pour chacune de vos actions, assurez-vous de les réaliser suffisamment lentement et de les mettre en évidence. Par exemple, lorsqu'on doit cliquer quelque part on pourra&nbsp;:
 
   - Déplacer la souris sur l'icône
@@ -204,7 +185,7 @@ Planifiez soigneusement les étapes que vous allez enregistrer et pratiquez cett
 
 > **Note :** Ne zoomez pas au point que les éléments d'interfaces soient déformés ou semblent étranges.
 
-### Enregistrement
+#### Enregistrement
 
 Lorsque vous enregistrez, avancez dans les étapes de façon calme et régulière. Effectuez des pauses d'une seconde ou deux aux moments importants (lorsqu'il faut cliquer sur un bouton par exemple) et assurez-vous que le pointeur de la souris n'occulte pas d'icône ou de texte important.
 
@@ -212,7 +193,7 @@ N'oubliez pas de faire une pause d'une ou deux secondes à la fin pour montrer l
 
 > **Note :** Si vous utilisez un outil simple comme QuickTime Player ou que vous ne pouvez pas effectuer de post-production, veillez à ce que la fenêtre soit de la bonne taille pour ce que vous voulez montrer.
 
-### Post-production
+#### Post-production
 
 En post-production, vous pourrez mettre en avant certains éléments notamment grâce à&nbsp;:
 
@@ -225,22 +206,22 @@ Attention à ne pas abuser de ces effets, on ne veut pas que les spectateurs aie
 
 Si besoin, redimensionnez la vidéo aux proportions souhaitées.
 
-### <i lang="en">Upload</i>
+#### <i lang="en">Upload</i>
 
-Actuellement, les vidéos doivent être uploadées sur YouTube afin d'être affichées sur MDN.
+Actuellement, les vidéos doivent être uploadées sur YouTube afin d'être affichées sur MDN, par exemple sur la chaîne [mozhacks](https://www.youtube.com/user/mozhacks/videos). Demandez à un membre de l'équipe MDN de téléverser la vidéo si vous n'avez pas un meilleur endroit où la stocker.
 
 > **Note :** Marquez la vidéo en «&nbsp;non répertoriée&nbsp;» si celle-ci n'a pas de sens particulier en dehors du contexte de la page MDN.
 
-### Intégration
+#### Intégration
 
 Une fois la vidéo uploadée, vous pouvez intégrer la vidéo à la page avec la macro [`EmbedYouTube`](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedYouTube.ejs). Elle permet d'insérer la vidéo à l'emplacement de la macro&nbsp;:
 
-```
+```plain
 \{{EmbedYouTube("you-tube-url-slug")}}
 ```
 
 Cette macro utilise un seul argument qui correspond à la fin de l'URL de la vidéo. Ainsi, pour afficher la vidéo disponible à l'URL `https://www.youtube.com/watch?v=ELS2OOUvxIw`, on appellera la macro ainsi&nbsp;:
 
-```
+```plain
 \{{EmbedYouTube("ELS2OOUvxIw")}}
 ```

--- a/files/fr/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/images_media/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{MDNSidebar}}
 
-# Ajouter des images
+## Ajouter des images
 
 Pour ajouter une image à un document, ajoutez le fichier image dans le dossier du document puis référencez l'image dans le fichier `index.md` du document en utilisant un élément `<img>` ou [la syntaxe Markdown équivalente](https://github.github.com/gfm/#images).
 
@@ -42,8 +42,8 @@ Prenons un exemple&nbsp;:
 4. Référencez votre image dans le document avec un élément `<img>` et un attribut `alt` dans `files/fr/web/css/index.md` :
 
    ```html
-    <img src="ma-superbe-image.png" alt="Ma superbe image" />
-    ```
+   <img src="ma-superbe-image.png" alt="Ma superbe image" />
+   ```
 
 5. Ajoutez et livrez (<i lang="en">commit</i> en anglais) tous les fichiers supprimés, créés et modifiés, puis poussez votre branche vers votre fork&nbsp;:
 
@@ -54,7 +54,6 @@ Prenons un exemple&nbsp;:
    ```
 
 6. Vous êtes maintenant prêt à créer votre [requête de tirage (<i lang="en">pull request</i> en anglais)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
-
 
 ## Ajouter les textes alternatifs aux images
 

--- a/files/fr/mdn/writing_guidelines/howto/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/index.md
@@ -7,8 +7,8 @@ l10n:
 
 {{MDNSidebar}}
 
-Cette section des directives d'écriture du MDN Web Docs contient toutes les informations pas à pas pour accomplir des tâches spécifiques lors d'une contribution au MDN Web Docs&nbsp;: comment utiliser le markdown, comment ajouter une entrée au glossaire, comment déplacer ou supprimer des pages, et plus encore. Pour en savoir plus sur _comment contribuer_ (via GitHub), consultez nos [directives de contribution](/fr/docs/MDN/Community/Contributing).
+Cette section porte sur les règles d'écriture sur MDN Web Docs et contient toutes les informations détaillées pour accomplir des tâches spécifiques lors d'une contribution à MDN Web Docs&nbsp;: comment utiliser Markdown, comment ajouter une entrée au glossaire, comment déplacer ou supprimer des pages, et plus encore. Pour en savoir plus sur _comment contribuer_ (via GitHub), consultez nos [directives de contribution](/fr/docs/MDN/Community/Contributing).
 
-> **Note :** Tout au long de cette section, nous supposons que vous avez lu les directives de contribution, que vous êtes familier avec les dépôts `mdn/content` et `mdn/translated-content`, et que vous savez comment utiliser git et GitHub.
+> **Note :** Tout au long de cette section, nous supposons que vous avez lu les directives de contribution, que vous connaissez les dépôts `mdn/content` et `mdn/translated-content`, et que vous savez comment utiliser Git et GitHub.
 
 {{LandingPageListSubpages}}

--- a/files/fr/mdn/writing_guidelines/howto/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/index.md
@@ -1,0 +1,14 @@
+---
+title: Guides des bonnes pratiques
+slug: MDN/Writing_guidelines/Howto
+l10n:
+  sourceCommit: aa66311219951396e7305df61eb31831360d2c79
+---
+
+{{MDNSidebar}}
+
+Cette section des directives d'écriture du MDN Web Docs contient toutes les informations pas à pas pour accomplir des tâches spécifiques lors d'une contribution au MDN Web Docs&nbsp;: comment utiliser le markdown, comment ajouter une entrée au glossaire, comment déplacer ou supprimer des pages, et plus encore. Pour en savoir plus sur _comment contribuer_ (via GitHub), consultez nos [directives de contribution](/fr/docs/MDN/Community/Contributing).
+
+> **Note :** Tout au long de cette section, nous supposons que vous avez lu les directives de contribution, que vous êtes familier avec les dépôts `mdn/content` et `mdn/translated-content`, et que vous savez comment utiliser git et GitHub.
+
+{{LandingPageListSubpages}}

--- a/files/fr/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
@@ -29,7 +29,7 @@ Pour toute page du glossaire, le premier paragraphe consiste en une description 
 
 #### Rédiger une bonne entrée dans le glossaire
 
-Ajoutez quelques paragraphes si nécessaire, mais attention au risque d'écrire un article complet. Un article complet est intéressant mais n'a pas sa place dans le glossaire. Si vous n'êtes pas certaine ou certain de l'emplacement de votre page, n'hésitez pas à [nous contacter pour en discuter](/fr/docs/MDN/Community/Contributing/Getting_started#step_4_ask_for_help).
+Ajoutez quelques paragraphes si nécessaire, mais attention au risque d'écrire un article complet. Un article complet est intéressant mais n'a pas sa place dans le glossaire. Si vous n'êtes pas certaine ou certain de l'emplacement de votre page, n'hésitez pas à [nous contacter pour en discuter](/fr/docs/MDN/Community/Discussions).
 
 Voici quelques lignes directrices à garder à l'esprit pour écrire une bonne entrée de glossaire&nbsp;:
 
@@ -39,12 +39,12 @@ Voici quelques lignes directrices à garder à l'esprit pour écrire une bonne e
 
 ### Ajouter des liens
 
-Une entrée du glossaire devrait toujours finir par une section _En savoir plus_. Dans cette section, on devrait trouver des liens qui aident la lectrice ou le lecteur à aller plus loin en découvrant plus de détails, ou en apprenant à utiliser la technologie associée.
+Une entrée du glossaire devrait toujours finir par une section _Voir aussi_. Dans cette section, on devrait trouver des liens qui aident la lectrice ou le lecteur à aller plus loin en découvrant plus de détails, ou en apprenant à utiliser la technologie associée.
 
 Une bonne pratique consiste à organiser ces liens en trois groupes&nbsp;:
 
 - Connaissances générales
-  - : Ces liens fournissent des informations généralistes à propos du terme ou du sujet. Il peut par exemple s'agir d'un lien vers une page [Wikipédia](https://www.wikipedia.org/) correspondante.
+  - : Ces liens fournissent des informations généralistes à propos du terme ou du sujet. Il peut par exemple s'agir d'un lien vers une page [Wikipédia](https://fr.wikipedia.org/) correspondante.
 - Référence technique
   - : Ces liens fournissent des ressources avec des informations techniques détaillées, sur MDN ou d'autres sites.
 - En apprendre plus

--- a/files/fr/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
@@ -13,7 +13,7 @@ Le glossaire ne sera potentiellement jamais complet, car le Web est en perpétue
 
 Contribuer au glossaire est une façon simple de rendre le Web plus compréhensible pour tout le monde. Il n'est pas nécessaire d'avoir des compétences techniques approfondies pour le faire. Les entrées du glossaire sont conçues pour être simples et concises.
 
-> **Note :** La suite de cet article explique comment créer une entrée du glossaire. Toutefois, la structure du contenu de MDN utilise le contenu anglophone comme référence. Aussi, toute page devra d'abord être créée en anglais avant d'être localisée en français. Vous pouvez également aider à la traduction du glossaire en français, voir [Localiser MDN](/fr/docs/MDN/Contribute/Localize).
+> **Note :** La suite de cet article explique comment créer une entrée du glossaire. Toutefois, la structure du contenu de MDN utilise le contenu anglophone comme référence. Aussi, toute page devra d'abord être créée en anglais avant d'être localisée en français. Vous pouvez également aider à la traduction du glossaire en français, voir [Localiser MDN](/fr/docs/MDN/Community/Contributing/Translated_content).
 
 ## Comment rédiger une entrée
 
@@ -29,7 +29,7 @@ Pour toute page du glossaire, le premier paragraphe consiste en une description 
 
 #### Rédiger une bonne entrée dans le glossaire
 
-Ajoutez quelques paragraphes si nécessaire, mais attention au risque d'écrire un article complet. Un article complet est intéressant mais n'a pas sa place dans le glossaire. Si vous n'êtes pas certaine ou certain de l'emplacement de votre page, n'hésitez pas à [nous contacter pour en discuter](/fr/docs/MDN/Contribute/Getting_started#step_4_ask_for_help).
+Ajoutez quelques paragraphes si nécessaire, mais attention au risque d'écrire un article complet. Un article complet est intéressant mais n'a pas sa place dans le glossaire. Si vous n'êtes pas certaine ou certain de l'emplacement de votre page, n'hésitez pas à [nous contacter pour en discuter](/fr/docs/MDN/Community/Contributing/Getting_started#step_4_ask_for_help).
 
 Voici quelques lignes directrices à garder à l'esprit pour écrire une bonne entrée de glossaire&nbsp;:
 

--- a/files/fr/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
@@ -1,6 +1,8 @@
 ---
 title: Écrire et référencer une entrée de glossaire
 slug: MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary
+l10n:
+  sourceCommit: aa66311219951396e7305df61eb31831360d2c79
 ---
 
 {{MDNSidebar}}


### PR DESCRIPTION
Relates to #16686

- [x] Create the index of "How to"
- [x] Update `Creating_moving_deleting` page
- [x] Update `Images_media page`
- [x] Add missing `sourceCommit` of `Write_a_new_entry_in_the_glossary`