### PR TITLE
zh-cn: fix typo

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/array/tosorted/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/array/tosorted/index.md
@@ -57,7 +57,7 @@ console.log(sortedMonths); // ['Dec', 'Feb', 'Jan', 'Mar']
 console.log(months); // ['Mar', 'Jan', 'Feb', 'Dec']
 
 const values = [1, 10, 21, 2];
-const sortedValues = values.toSorted((a, b) => a - b));
+const sortedValues = values.toSorted((a, b) => a - b);
 console.log(sortedValues); // [1, 2, 10, 21]
 console.log(values); // [1, 10, 21, 2]
 ```


### PR DESCRIPTION
### Description

const sortedValues = values.toSorted((a, b) => a - b));
to
const sortedValues = values.toSorted((a, b) => a - b);

### Motivation

原来的代码多了个右括号，删掉了