### PR TITLE
Storage: remove broken markup

### DIFF
--- a/files/ja/web/api/storage/index.md
+++ b/files/ja/web/api/storage/index.md
@@ -19,7 +19,7 @@ l10n:
 ## メソッド
 
 - {{domxref("Storage.key()")}}
-  - : 数値 `n`` を渡すと、ストレージ内で n 番目のキーの名称を返します。
+  - : 数値 n を渡すと、ストレージ内で n 番目のキーの名称を返します。
 - {{domxref("Storage.getItem()")}}
   - : キーの名称を渡すと、キーに対する値を返します。
 - {{domxref("Storage.setItem()")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
`Storage.key()` の説明にある「n」のまわりのマークアップが壊れていたので、[key()](https://developer.mozilla.org/ja/docs/Web/API/Storage/key) のページと同様のマークアップなしに変更。

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
