### PR TITLE
[zh-tw] remove all `HTMLKeygenElement` occurrences

### DIFF
--- a/files/zh-tw/web/api/document_object_model/index.md
+++ b/files/zh-tw/web/api/document_object_model/index.md
@@ -108,7 +108,6 @@ slug: Web/API/Document_Object_Model
 - {{domxref("HTMLIFrameElement")}}
 - {{domxref("HTMLImageElement")}}
 - {{domxref("HTMLInputElement")}}
-- {{domxref("HTMLKeygenElement")}}
 - {{domxref("HTMLLabelElement")}}
 - {{domxref("HTMLLegendElement")}}
 - {{domxref("HTMLLIElement")}}


### PR DESCRIPTION
### Description

This PR removes all occurrences (specifically one :)) of obsolete `keygen` HTML element in `zh-tw` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/26902
