### PR TITLE
Fix wrong code example

### DIFF
--- a/files/es/web/api/htmlelement/change_event/index.md
+++ b/files/es/web/api/htmlelement/change_event/index.md
@@ -81,9 +81,9 @@ select {
 
 ```js
 const selectElement = document.querySelector(".nieve");
+const resultado = document.querySelector(".resultado");
 
 selectElement.addEventListener("change", (event) => {
-  const resultado = document.querySelector(".resultado");
   resultado.textContent = `Te gusta el sabor ${event.target.value}`;
 });
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There is an error. The example doesn't show the text when the option change because the resultado varible is create inside of the event listener. The declaration of the "resultado" should be outside of event listener.  If you see the example in english it works due to this small change: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event 
const resultado = document.querySelector(".resultado");
listener...

### Motivation

The example doesn't work. The declaration of the "resultado" variable should be outside of event listener. 

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
