### PR TITLE
[fr] remove all `blink` HTML element occurrences

### DIFF
--- a/files/fr/mozilla/firefox/releases/23/index.md
+++ b/files/fr/mozilla/firefox/releases/23/index.md
@@ -20,7 +20,7 @@ slug: Mozilla/Firefox/Releases/23
 
 ### HTML
 
-- Le support de l'élément {{HTMLElement("blink")}} a désormais été abandonné. La balise `<blink>` fait désormais partie de l'interface {{domxref("HTMLUnknownElement")}} ([bug Firefox 857820](https://bugzil.la/857820).)
+- Le support de l'élément `<blink>` a désormais été abandonné. La balise `<blink>` fait désormais partie de l'interface {{domxref("HTMLUnknownElement")}} ([bug Firefox 857820](https://bugzil.la/857820).)
 - Le type `range` de l'élément {{HTMLElement("input")}} (`<input type="range">`) a été activé par défaut ([bug Firefox 841950](https://bugzil.la/841950)).
 
 ### JavaScript

--- a/files/fr/web/api/htmlunknownelement/index.md
+++ b/files/fr/web/api/htmlunknownelement/index.md
@@ -27,5 +27,5 @@ _Pas de méthode spécifique&nbsp;; hérite des méthodes de son parent, {{DOMxR
 
 ## Voir aussi
 
-- Les éléments HTML obsolètes ou non standard implémentant cette interface&nbsp;: {{HTMLElement("bgsound")}}, {{HTMLElement("blink")}}, {{HTMLElement("isindex")}}, {{HTMLElement("multicol")}}, {{HTMLElement("nextid")}}, {{HTMLElement("rb")}}, {{HTMLElement("spacer")}}
+- Les éléments HTML obsolètes ou non standard implémentant cette interface&nbsp;: {{HTMLElement("bgsound")}}, {{HTMLElement("isindex")}}, {{HTMLElement("multicol")}}, {{HTMLElement("nextid")}}, {{HTMLElement("rb")}}, {{HTMLElement("spacer")}}
 - {{DOMxRef("SVGUnknownElement")}}

--- a/files/fr/web/javascript/reference/global_objects/string/blink/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/blink/index.md
@@ -5,7 +5,7 @@ slug: Web/JavaScript/Reference/Global_Objects/String/blink
 
 {{JSRef}}{{deprecated_header}}
 
-La méthode **`blink()`** crée un élément HTML {{HTMLElement("blink")}} qui affiche la chaine de caractères en clignotant.
+La méthode **`blink()`** crée un élément HTML `<blink>` qui affiche la chaine de caractères en clignotant.
 
 > **Attention :** Les textes clignotants sont fortement déconseillés par de nombreux standards d'accessibilité. L'élément `<blink>` est lui-même non standard et obsolète !
 
@@ -17,7 +17,7 @@ str.blink();
 
 ### Valeur de retour
 
-Une chaine de caractères représentant un élément HTML {{HTMLElement("blink")}}.
+Une chaine de caractères représentant un élément HTML `<blink>`.
 
 ## Description
 


### PR DESCRIPTION
### Description

This PR removes all occurrences of obsolete `blink` HTML element in `fr` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/26904
