### PR TITLE
[ja] remove all `blink` HTML element occurrences

### DIFF
--- a/files/ja/mozilla/firefox/releases/23/index.md
+++ b/files/ja/mozilla/firefox/releases/23/index.md
@@ -20,7 +20,7 @@ Gecko 23 を搭載した Firefox 23 は米国時間 2013 年 8 月 6 日にリ�
 
 ### HTML
 
-- {{HTMLElement("blink")}} 要素のサポートを完全に廃止しました。`<blink>` タグは {{domxref("HTMLUnknownElement")}} インターフェイスを実装します ([Firefox バグ 857820](https://bugzil.la/857820))。
+- `<blink>` 要素のサポートを完全に廃止しました。`<blink>` タグは {{domxref("HTMLUnknownElement")}} インターフェイスを実装します ([Firefox バグ 857820](https://bugzil.la/857820))。
 - {{HTMLElement("input")}} 要素の `range` ステート (`<input type="range">`) を、デフォルトで有効にしました ([Firefox バグ 841950](https://bugzil.la/841950))。
 
 ### JavaScript

--- a/files/ja/web/api/htmlunknownelement/index.md
+++ b/files/ja/web/api/htmlunknownelement/index.md
@@ -27,4 +27,4 @@ slug: Web/API/HTMLUnknownElement
 
 ## 関連情報
 
-- このインターフェイスを持つ非標準要素及び廃止要素 : {{HTMLElement("bgsound")}} 、 {{HTMLElement("blink")}} 、 {{HTMLElement("isindex")}} 、 {{HTMLElement("multicol")}} 、 {{HTMLElement("nextid")}} 、 {{HTMLElement("rb")}} 、 {{HTMLElement("spacer")}}
+- このインターフェイスを持つ非標準要素及び廃止要素 : {{HTMLElement("bgsound")}} 、 {{HTMLElement("isindex")}} 、 {{HTMLElement("multicol")}} 、 {{HTMLElement("nextid")}} 、 {{HTMLElement("rb")}} 、 {{HTMLElement("spacer")}}


### PR DESCRIPTION
### Description

This PR removes all occurrences of obsolete `blink` HTML element in `ja` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/26904
