### PR TITLE
[ru] fix typo in `Learn/Server-side/Django/Models`

### DIFF
--- a/files/ru/learn/server-side/django/models/index.md
+++ b/files/ru/learn/server-side/django/models/index.md
@@ -45,33 +45,28 @@ slug: Learn/Server-side/Django/Models
 
 Модели обычно определяются в приложении **models.py**. Они реализуются как подклассы `django.db.models.Model`, и могут включать поля, методы и метаданные. В приведённом ниже фрагменте кода показана «типичная» модель, названная `MyModelName`:
 
-```
+```python
 from django.db import models
+from django.urls import reverse
 
 class MyModelName(models.Model):
-    """
-    A typical class defining a model, derived from the Model class.
-    """
+    """Типичный класс модели, производный от класса Model."""
 
-    # Fields
-    my_field_name = models.CharField(max_length=20, help_text="Enter field documentation")
-    ...
+    # Поля
+    my_field_name = models.CharField(max_length=20, help_text='Введите описание поля')
+    # …
 
-    # Metadata
+    # Метаданные
     class Meta:
-        ordering = ["-my_field_name"]
+        ordering = ['-my_field_name']
 
     # Methods
     def get_absolute_url(self):
-         """
-         Returns the url to access a particular instance of MyModelName.
-         """
-         return reverse('model-detail-view', args=[str(self.id)])
+        """Возвращает URL-адрес для доступа к определенному экземпляру MyModelName."""
+        return reverse('model-detail-view', args=[str(self.id)])
 
     def __str__(self):
-        """
-        String for representing the MyModelName object (in Admin site etc.)
-        """
+        """Строка для представления объекта MyModelName (например, в административной панели и т.д.)."""
         return self.my_field_name
 ```
 
@@ -82,13 +77,13 @@ class MyModelName(models.Model):
 Модель может иметь произвольное количество полей любого типа - каждый представляет столбец данных, который мы хотим сохранить в одной из наших таблиц базы данных. Каждая запись (строка) базы данных будет состоять из одного значения каждого поля. Давайте рассмотрим приведённый выше пример:
 
 ```python
-my_field_name = models.CharField(max_length=20, help_text="Enter field documentation")
+my_field_name = models.CharField(max_length=20, help_text="Введите описание поля")
 ```
 
 Наш вышеприведённый пример имеет одно поле, называемое my\_`field_name`, типа `models.CharField` — что означает, что это поле будет содержать строки буквенно-цифровых символов. Типы полей назначаются с использованием определённых классов, которые определяют тип записи, которая используется для хранения данных в базе данных, а также критерии проверки, которые должны использоваться, когда значения получены из формы HTML (то есть, что составляет действительное значение). Типы полей также могут принимать аргументы, которые дополнительно определяют, как поле хранится или может использоваться. В этом случае мы даём нашему полю два аргумента:
 
 - `max_length=20` — Указывает, что максимальная длина значения в этом поле составляет 20 символов.
-- `help_text="Enter field documentation"` — предоставляет текстовую метку для отображения, чтобы помочь пользователям узнать, какое значение необходимо предоставить, когда это значение должно быть введено пользователем через HTML-форму.
+- `help_text="Введите описание поля"` — предоставляет текстовую метку для отображения, чтобы помочь пользователям узнать, какое значение необходимо предоставить, когда это значение должно быть введено пользователем через HTML-форму.
 
 Имя поля используется для обращения к нему в запросах и шаблонах. В полях также есть метка, которая задаётся как аргумент (`verbose_name`), либо выводится путём заглавной буквы первой буквы имени переменной поля и замены любых символов подчёркивания пробелом (например, `my_field_name` будет иметь метку по умолчанию _My field name_).
 

--- a/files/ru/learn/server-side/django/models/index.md
+++ b/files/ru/learn/server-side/django/models/index.md
@@ -72,7 +72,7 @@ class MyModelName(models.Model):
         """
         String for representing the MyModelName object (in Admin site etc.)
         """
-        return self.field_name
+        return self.my_field_name
 ```
 
 В следующих разделах мы подробно рассмотрим каждый элемент внутри модели:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Fixed typo in the __str__ func. Field name was 

> field_name

while field name in the class is 

> my_field_name

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I believe this type can mislead the readers

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
