### PR TITLE
zh-cn: update the description of `receiver` parameter in `handler.set()` method

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/set/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/set/index.md
@@ -11,9 +11,9 @@ slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set
 
 ## 语法
 
-```plain
-const p = new Proxy(target, {
-  set: function(target, property, value, receiver) {
+```js-nolint
+new Proxy(target, {
+  set(target, property, value, receiver) {
   }
 });
 ```

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/set/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/set/index.md
@@ -30,7 +30,7 @@ const p = new Proxy(target, {
   - : 新属性值。
 - `receiver`
 
-  - : 最初被调用的对象。通常是 proxy 本身，但 handler 的 set 方法也有可能在原型链上，或以其他方式被间接地调用（因此不一定是 proxy 本身）。
+  - : 最初接收赋值的对象。通常是 proxy 本身，但 handler 的 set 方法也有可能在原型链上，或以其他方式被间接地调用（因此不一定是 proxy 本身）。
 
     > **备注：** 假设有一段代码执行 `obj.name = "jen"`， `obj` 不是一个 proxy，且自身不含 `name` 属性，但是它的原型链上有一个 proxy，那么，那个 proxy 的 `set()` 处理器会被调用，而此时，`obj` 会作为 receiver 参数传进来。
 


### PR DESCRIPTION
### Description

Update the description of `receiver` parameter in `handler.set()` method.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set#receiver