### PR TITLE
[ru] add `l10n.sourceCommit` to `Web/API/Navigator` subpages

### DIFF
--- a/files/ru/web/api/navigator/appcodename/index.md
+++ b/files/ru/web/api/navigator/appcodename/index.md
@@ -1,6 +1,8 @@
 ---
 title: "Navigator: свойство appCodeName"
 slug: Web/API/Navigator/appCodeName
+l10n:
+  sourceCommit: ef75c1741b450c2331204be5563ee964ad5f4c48
 ---
 
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}

--- a/files/ru/web/api/navigator/appname/index.md
+++ b/files/ru/web/api/navigator/appname/index.md
@@ -1,6 +1,8 @@
 ---
 title: "Navigator: appName property"
 slug: Web/API/Navigator/appName
+l10n:
+  sourceCommit: ef75c1741b450c2331204be5563ee964ad5f4c48
 ---
 
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}

--- a/files/ru/web/api/navigator/appversion/index.md
+++ b/files/ru/web/api/navigator/appversion/index.md
@@ -1,6 +1,8 @@
 ---
 title: "Navigator: свойство appVersion"
 slug: Web/API/Navigator/appVersion
+l10n:
+  sourceCommit: ef75c1741b450c2331204be5563ee964ad5f4c48
 ---
 
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}

--- a/files/ru/web/api/navigator/platform/index.md
+++ b/files/ru/web/api/navigator/platform/index.md
@@ -1,6 +1,8 @@
 ---
 title: "navigator: свойство platform"
 slug: Web/API/Navigator/platform
+l10n:
+  sourceCommit: 1238ffad886924b20549d0cf3adca735cb0d074f
 ---
 
 {{APIRef("HTML DOM")}}{{Deprecated_Header}}

--- a/files/ru/web/api/navigator/product/index.md
+++ b/files/ru/web/api/navigator/product/index.md
@@ -1,6 +1,8 @@
 ---
 title: "Navigator: свойство product"
 slug: Web/API/Navigator/product
+l10n:
+  sourceCommit: ef75c1741b450c2331204be5563ee964ad5f4c48
 ---
 
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}

--- a/files/ru/web/api/navigator/taintenabled/index.md
+++ b/files/ru/web/api/navigator/taintenabled/index.md
@@ -1,6 +1,8 @@
 ---
 title: "Navigator: метод taintEnabled()"
 slug: Web/API/Navigator/taintEnabled
+l10n:
+  sourceCommit: b829b2fae917b5b931011ddeb6a0d1b2d2b81c54
 ---
 
 {{APIRef("HTML DOM")}} {{deprecated_header}}


### PR DESCRIPTION
### Description

This PR adds `l10n.sourceCommit` front matter field to recently updated `Web/API/Navigator` subpages in `ru` locale.

### Related issues and pull requests

Relates to #17022
