### PR TITLE
[ru] add `l10n.sourceCommit` to recently updated `Web/JavaScript/Reference/Global_Objects/DataView` subpages

### DIFF
--- a/files/ru/web/javascript/reference/global_objects/dataview/buffer/index.md
+++ b/files/ru/web/javascript/reference/global_objects/dataview/buffer/index.md
@@ -1,6 +1,8 @@
 ---
 title: DataView.prototype.buffer
 slug: Web/JavaScript/Reference/Global_Objects/DataView/buffer
+l10n:
+  sourceCommit: 16bacf2194dc9e9ff6ee5bcc65316547cf88a8d9
 ---
 
 {{JSRef}}

--- a/files/ru/web/javascript/reference/global_objects/dataview/byteoffset/index.md
+++ b/files/ru/web/javascript/reference/global_objects/dataview/byteoffset/index.md
@@ -1,6 +1,8 @@
 ---
 title: DataView.prototype.byteOffset
 slug: Web/JavaScript/Reference/Global_Objects/DataView/byteOffset
+l10n:
+  sourceCommit: 16bacf2194dc9e9ff6ee5bcc65316547cf88a8d9
 ---
 
 {{JSRef}}

--- a/files/ru/web/javascript/reference/global_objects/dataview/setint32/index.md
+++ b/files/ru/web/javascript/reference/global_objects/dataview/setint32/index.md
@@ -1,6 +1,8 @@
 ---
 title: DataView.prototype.setInt32()
 slug: Web/JavaScript/Reference/Global_Objects/DataView/setInt32
+l10n:
+  sourceCommit: e01fd6206ce2fad2fe09a485bb2d3ceda53a62de
 ---
 
 {{JSRef}}

--- a/files/ru/web/javascript/reference/global_objects/dataview/setint8/index.md
+++ b/files/ru/web/javascript/reference/global_objects/dataview/setint8/index.md
@@ -1,6 +1,8 @@
 ---
 title: DataView.prototype.setInt8()
 slug: Web/JavaScript/Reference/Global_Objects/DataView/setInt8
+l10n:
+  sourceCommit: e01fd6206ce2fad2fe09a485bb2d3ceda53a62de
 ---
 
 {{JSRef}}


### PR DESCRIPTION
### Description

This PR adds `l10n.sourceCommit` front matter field to recently updated `Web/JavaScript/Reference/Global_Objects/DataView` subpages in `ru` locale.

### Related issues and pull requests

Relates to #14556, #14588, #14619, #14658

