### PR TITLE
[ru] remove obsolete `orphaned/Web/API/NavigatorPlugins/mimeTypes`

### DIFF
--- a/files/ru/_wikihistory.json
+++ b/files/ru/_wikihistory.json
@@ -17051,10 +17051,6 @@
     "modified": "2019-03-23T22:54:31.545Z",
     "contributors": ["AlexAlex"]
   },
-  "orphaned/Web/API/NavigatorPlugins/mimeTypes": {
-    "modified": "2019-03-23T22:54:19.236Z",
-    "contributors": ["nik3402", "torbasow", "AlexAlex"]
-  },
   "orphaned/Web/API/NavigatorPlugins/plugins": {
     "modified": "2019-03-23T22:54:18.720Z",
     "contributors": ["AlexAlex"]

--- a/files/ru/web/api/navigator/mimetypes/index.md
+++ b/files/ru/web/api/navigator/mimetypes/index.md
@@ -1,11 +1,9 @@
 ---
-title: NavigatorPlugins.mimeTypes
-slug: orphaned/Web/API/NavigatorPlugins/mimeTypes
+title: "Navigator: свойство mimeTypes"
+slug: Web/API/Navigator/mimeTypes
 ---
 
-{{ ApiRef("HTML DOM") }}
-
-## Резюме
+{{ ApiRef("HTML DOM") }}{{deprecated_header}}
 
 Возвращает объект {{domxref("MimeTypeArray")}}, который содержит список объектов {{domxref("MimeType")}}, представляющий собой MIME-типы, известные браузеру.
 
@@ -21,11 +19,11 @@ mimeTypes = navigator.mimeTypes;
 
 ```js
 function isJavaPresent() {
-  return 'application/x-java-applet' in navigator.mimeTypes;
+  return "application/x-java-applet" in navigator.mimeTypes;
 }
 
 function getJavaPluginDescription() {
-  var mimetype = navigator.mimeTypes['application/x-java-applet'];
+  var mimetype = navigator.mimeTypes["application/x-java-applet"];
   if (mimetype === undefined) {
     // no Java plugin present
     return undefined;
@@ -34,6 +32,10 @@ function getJavaPluginDescription() {
 }
 ```
 
-## Спецификация
+## Спецификации
 
-_Не является частью какой-либо спецификации._
+{{Specifications}}
+
+## Совместимость с браузерами
+
+{{Compat}}


### PR DESCRIPTION
### Description

This PR removes obsolete `orphaned/Web/API/NavigatorPlugins/mimeTypes` and replaces it with `Web/API/Navigator/mimeTypes`

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/6637