### PR TITLE
 Object.groupBy() と Map.groupBy() の更新

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/map/groupby/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/groupby/index.md
@@ -1,58 +1,58 @@
 ---
 title: Map.groupBy()
 slug: Web/JavaScript/Reference/Global_Objects/Map/groupBy
-page-type: javascript-static-method
-browser-compat: javascript.builtins.Map.groupBy
+l10n:
+  sourceCommit: c607c483fe079c61de5e32fba1a6cce61896e97d
 ---
 
 {{JSRef}}
 
-> **Note:** In some versions of some browsers, this method was implemented as the method `Array.prototype.groupToMap()`. Due to web compatibility issues, it is now implemented as a static method. Check the [browser compatibility table](#browser_compatibility) for details.
+> **メモ:** 一部のブラウザーのあるバージョンでは、このメソッドは `Array.prototype.groupToMap()` というメソッドとして実装されていました。ウェブの互換性の問題により、現在は静的メソッドとして実装されています。詳細は[ブラウザーの互換性](#ブラウザーの互換性)を確認してください
 
-The **`Map.groupBy()`** static method groups the elements of a given iterable using the values returned by a provided callback function. The final returned {{jsxref("Map")}} uses the unique values from the test function as keys, which can be used to get the array of elements in each group.
+**Map.groupBy()** 静的メソッドは、指定されたコールバック関数によって返された値を使用して、指定された反復可能な要素をグループ化します。最終的に返される {{jsxref("Map")}} は、テスト関数からの一意な値をキーとして使用し、各グループの要素の配列を取得するために使用できます。
 
-The method is primarily useful when grouping elements that are associated with an object, and in particular when that object might change over time. If the object is invariant, you might instead represent it using a string, and group elements with {{jsxref("Object.groupBy()")}}.
+このメソッドは主に、あるオブジェクトに関連する要素をグループ化するときに便利で、特にそのオブジェクトが時間の経過とともに変化する可能性がある場合に便利です。オブジェクトが不変である場合は、代わりに文字列を使用してそれを表現し、{{jsxref("Object.groupBy()")}} で要素をグループ化することができます。
 
 {{EmbedInteractiveExample("pages/js/map-groupby.html", "taller")}}
 
-## Syntax
+## 構文
 
 ```js-nolint
 Map.groupBy(items, callbackFn)
 ```
 
-### Parameters
+### 引数
 
 - `items`
-  - : An [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) (such as an {{jsxref("Array")}}) whose elements will be grouped.
+  - : 要素がグループ化される[反復可能な要素](/ja/docs/Web/JavaScript/Reference/Iteration_protocols#反復可能プロトコル)（{{jsxref("Array")}} など）。
 - `callbackFn`
-  - : A function to execute for each element in the iterable. It should return a value ({{Glossary("object")}} or {{Glossary("primitive")}}) indicating the group of the current element. The function is called with the following arguments:
+  - : 反復可能な各要素に対して実行される関数。これは、現在の要素のグループを示す値（オブジェクトまたはプリミティブ）を返す必要があります。この関数は以下の引数で呼び出されます。
     - `element`
-      - : The current element being processed.
+      - : 現在処理中の要素。
     - `index`
-      - : The index of the current element being processed.
+      - : 現在処理中の要素のインデックス。
 
-### Return value
+### 返値
 
-A {{jsxref("Map")}} object with keys for each group, each assigned to an array containing the elements of the associated group.
+各グループのキーを持つ {{jsxref("Map")}} オブジェクトで、それぞれに関連するグループの要素を含む配列が割り当てられたものです。
 
-## Description
+## 解説
 
-`Map.groupBy()` calls a provided `callbackFn` function once for each element in an iterable. The callback function should return a value indicating the group of the associated element. The values returned by `callbackFn` are used as keys for the {{jsxref("Map")}} returned by `Map.groupBy()`. Each key has an associated array containing all the elements for which the callback returned the same value.
+`Map.groupBy()` は、指定された `callbackFn` 関数を反復可能な要素ごとに 1 回呼び出します。コールバック関数は、関連付けられた要素のグループを示す値を返す必要があります。`callbackFn` が返す値は、`Map.groupBy()` が返す {{jsxref("Map")}} のキーとして使用されます。各キーには、コールバックが同じ値を返したすべての要素を含む関連配列があります。
 
-The elements in the returned {{jsxref("Map")}} and the original iterable are the same (not {{Glossary("deep copy", "deep copies")}}). Changing the internal structure of the elements will be reflected in both the original iterable and the returned {{jsxref("Map")}}.
+返された {{jsxref("Map")}} と元の反復可能な要素は同じです（{{Glossary("deep copy", "ディープコピー")}}ではありません）。要素の内部構造を変更すると、元の反復可能な要素と返された {{jsxref("Map")}} の両方に反映されます。
 
-This method is useful when you need to group information that is related to a particular object that might potentially change over time. This is because even if the object is modified, it will continue to work as a key to the returned `Map`. If you instead create a string representation for the object and use that as a grouping key in {{jsxref("Object.groupBy()")}}, you must maintain the mapping between the original object and its representation as the object changes.
+このメソッドは、時間の経過とともに変更される可能性のある特定のオブジェクトに関連する情報をグループ化する必要がある場合に便利です。オブジェクトが変更されても、返される `Map` のキーとして機能し続けるからです。代わりにオブジェクトの文字列表現を作成し、それを {{jsxref("Object.groupBy()")}} のグループ化キーとして使用する場合は、オブジェクトが変更されても元のオブジェクトとその表現との間のマッピングを維持する必要があります。
 
-> **Note:** To access the groups in the returned `Map`, you must use the same object that was originally used as a key in the `Map` (although you may modify its properties). You can't use another object that just happens to have the same name and properties.
+> **メモ:** 返された `Map` のグループにアクセスするには、`Map` のキーとして元々使用されていたのと同じオブジェクトを使用する必要があります（ただし、そのオブジェクトのプロパティを変更することはできます）。たまたま同じ名前とプロパティを持つ別のオブジェクトを使うことはできません。
 
-`Map.groupBy` does not read the value of `this`. It can be called on any object and a new {{jsxref("Map")}} instance will be returned.
+`Map.groupBy` は `this` の値を読みません。どんなオブジェクトでも呼び出すことができ、新しい {{jsxref("Map")}} インスタンスが返されます。
 
-## Examples
+## 例
 
-### Using Map.groupBy()
+### Map.groupBy() の使用
 
-First we define an array containing objects representing an inventory of different foodstuffs. Each food has a `type` and a `quantity`.
+最初に、さまざまな食品の在庫を表すオブジェクトを含む配列を定義します。 それぞれの食品は `type` （種類）と `quantity` （量）を保有しています。
 
 ```js
 const inventory = [
@@ -64,7 +64,7 @@ const inventory = [
 ];
 ```
 
-The code below uses `Map.groupBy()` with an arrow function that returns the object keys named `restock` or `sufficient`, depending on whether the element has `quantity < 6`. The returned `result` object is a `Map` so we need to call `get()` with the key to obtain the array.
+以下のコードでは、`Map.groupBy()` とアロー関数を使用しています。この関数は、要素が `quantity < 6` であるかどうかに応じて、`restock` または `enough` というオブジェクトであるキーを返します。返された `result` オブジェクトは `Map` なので、配列を取得するためにキーで `get()` を呼び出す必要があります。
 
 ```js
 const restock = { restock: true };
@@ -76,33 +76,33 @@ console.log(result.get(restock));
 // [{ name: "bananas", type: "fruit", quantity: 5 }]
 ```
 
-Note that the function argument `{ quantity }` is a basic example of [object destructuring syntax for function arguments](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#unpacking_properties_from_objects_passed_as_a_function_parameter). This unpacks the `quantity` property of an object passed as a parameter, and assigns it to a variable named `quantity` in the body of the function. This is a very succinct way to access the relevant values of elements within a function.
+関数の引数 `{ quantity }` は、[関数の引数に対するオブジェクトの分割構文](/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#関数の引数として渡されたオブジェクトからのプロパティの展開)の基本例であることに注意してください。これは、引数として渡されたオブジェクトの `quantity` プロパティを展開し、関数本体の `quantity` という変数に代入します。これは、関数内の要素に関連する値にアクセスするためのとても簡潔な方法です。
 
-The key to a `Map` can be modified and still used. However you can't recreate the key and still use it. For this reason it is important that anything that needs to use the map keeps a reference to its keys.
+キーである `Map` は内容を変更しても使用し続けることができます。しかし、キーを再作成して使用することはできません。このため、`Map` を使用する必要があるものは、そのキーへの参照を保持し続けることが重要です。
 
 ```js
-// The key can be modified and still used
+// キーの内容を変更しても使用し続けられます
 restock["fast"] = true;
 console.log(result.get(restock));
 // [{ name: "bananas", type: "fruit", quantity: 5 }]
 
-// A new key can't be used, even if it has the same structure!
+// 新しいキーは、たとえ同じ構造の map であっても使用できません
 const restock2 = { restock: true };
 console.log(result.get(restock2)); // undefined
 ```
 
-## Specifications
+## 仕様書
 
 {{Specifications}}
 
-## Browser compatibility
+## ブラウザーの互換性
 
 {{Compat}}
 
-## See also
+## 関連情報
 
-- [Polyfill of `Map.groupBy` in `core-js`](https://github.com/zloirock/core-js#array-grouping)
-- [Indexed collections](/en-US/docs/Web/JavaScript/Guide/Indexed_collections) guide
+- [`Map.groupBy` のポリフィル (`core-js`)](https://github.com/zloirock/core-js#array-grouping)
+- [インデックス付きコレクション](/ja/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array.prototype.reduce()")}}
 - {{jsxref("Map/Map", "Map()")}}
 - {{jsxref("Object.groupBy()")}}

--- a/files/ja/web/javascript/reference/global_objects/map/groupby/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/groupby/index.md
@@ -1,127 +1,58 @@
 ---
-title: Array.prototype.groupToMap()
+title: Map.groupBy()
 slug: Web/JavaScript/Reference/Global_Objects/Map/groupBy
+page-type: javascript-static-method
+browser-compat: javascript.builtins.Map.groupBy
 ---
 
-{{JSRef}} {{SeeCompatTable}}
+{{JSRef}}
 
-**`groupToMap()`** メソッドは、指定されたテスト関数によって返された値を使用して、呼び出された配列の要素をグループ化します。
-最終的に返される {{jsxref("Map")}} は、テスト関数から得られる固有の値をキーとして使用し、これを用いて各グループに属する要素の配列を取得することができます。
+> **Note:** In some versions of some browsers, this method was implemented as the method `Array.prototype.groupToMap()`. Due to web compatibility issues, it is now implemented as a static method. Check the [browser compatibility table](#browser_compatibility) for details.
 
-<!-- {{EmbedInteractiveExample("pages/js/array-groupbytomap.html")}} -->
+The **`Map.groupBy()`** static method groups the elements of a given iterable using the values returned by a provided callback function. The final returned {{jsxref("Map")}} uses the unique values from the test function as keys, which can be used to get the array of elements in each group.
 
-このメソッドは、あるオブジェクトに関連する要素をグループ化するときに、特にそのオブジェクトが時間の経過とともに変化する可能性がある場合に特に有用です。
-オブジェクトが不変である場合、代わりに文字列を使用してそれを表現し、{{jsxref("Array.prototype.group()")}}で要素をグループ化することができるかもしれません。
+The method is primarily useful when grouping elements that are associated with an object, and in particular when that object might change over time. If the object is invariant, you might instead represent it using a string, and group elements with {{jsxref("Object.groupBy()")}}.
 
-## 構文
+{{EmbedInteractiveExample("pages/js/map-groupby.html", "taller")}}
 
-```js
-// アロー関数
-groupToMap((element) => {
-  /* … */
-});
-groupToMap((element, index) => {
-  /* … */
-});
-groupToMap((element, index, array) => {
-  /* … */
-});
+## Syntax
 
-// コールバック関数
-groupToMap(callbackFn);
-groupToMap(callbackFn, thisArg);
-
-// インラインコールバック関数
-groupToMap(function (element) {
-  /* … */
-});
-groupToMap(function (element, index) {
-  /* … */
-});
-groupToMap(function (element, index, array) {
-  /* … */
-});
-groupToMap(function (element, index, array) {
-  /* … */
-}, thisArg);
+```js-nolint
+Map.groupBy(items, callbackFn)
 ```
 
-### 引数
+### Parameters
 
+- `items`
+  - : An [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) (such as an {{jsxref("Array")}}) whose elements will be grouped.
 - `callbackFn`
-
-  - : 配列のそれぞれの要素に対して実行する関数です。
-
-    この関数は以下の引数と共に呼び出されます。
-
+  - : A function to execute for each element in the iterable. It should return a value ({{Glossary("object")}} or {{Glossary("primitive")}}) indicating the group of the current element. The function is called with the following arguments:
     - `element`
-      - : 配列における現在の要素。
+      - : The current element being processed.
     - `index`
-      - : 配列における現在の要素の添字（位置）。
-    - `array`
-      - : `groupToMap()` が呼び出された配列。
+      - : The index of the current element being processed.
 
-    コールバックから返される値（{{Glossary("object", "オブジェクト")}}または{{Glossary("primitive", "プリミティブ")}}）は、現在の要素のグループを示します。
+### Return value
 
-- `thisArg` {{optional_inline}}
+A {{jsxref("Map")}} object with keys for each group, each assigned to an array containing the elements of the associated group.
 
-  - : `callbackFn` 内で {{jsxref("Operators/this", "this")}} として使用されるオブジェクト。
+## Description
 
-    この引数はアロー関数では無視されます。アロー関数は自分自身でレキシカルなスコープを保有しており、それが代わりに使用されるからです。
-    それ以外の場合、もし `thisArg` が指定されていなければ、実行中のスコープの `this` が使用されます。関数が[厳格モード](/ja/docs/Web/JavaScript/Reference/Strict_mode)で呼び出された場合には `undefined` が使用されます。
+`Map.groupBy()` calls a provided `callbackFn` function once for each element in an iterable. The callback function should return a value indicating the group of the associated element. The values returned by `callbackFn` are used as keys for the {{jsxref("Map")}} returned by `Map.groupBy()`. Each key has an associated array containing all the elements for which the callback returned the same value.
 
-### 返値
+The elements in the returned {{jsxref("Map")}} and the original iterable are the same (not {{Glossary("deep copy", "deep copies")}}). Changing the internal structure of the elements will be reflected in both the original iterable and the returned {{jsxref("Map")}}.
 
-各グループのキーを持つ {{jsxref("Map")}} オブジェクトで、それぞれが関連するグループの要素を含む配列に割り当てられています。
+This method is useful when you need to group information that is related to a particular object that might potentially change over time. This is because even if the object is modified, it will continue to work as a key to the returned `Map`. If you instead create a string representation for the object and use that as a grouping key in {{jsxref("Object.groupBy()")}}, you must maintain the mapping between the original object and its representation as the object changes.
 
-### 例外
+> **Note:** To access the groups in the returned `Map`, you must use the same object that was originally used as a key in the `Map` (although you may modify its properties). You can't use another object that just happens to have the same name and properties.
 
-- `TypeError`
-  - : 指定されたコールバック関数が呼び出し可能でない場合。
+`Map.groupBy` does not read the value of `this`. It can be called on any object and a new {{jsxref("Map")}} instance will be returned.
 
-## 解説
+## Examples
 
-`groupToMap()` メソッドは、配列の各添字に対して `callbackFn` を一度ずつ実行します。
-コールバック関数は、関連付けられた要素のグループを示す値を返します。
-`callbackFn` が返す値は、 `groupToMap()` が返す {{jsxref("Map")}} のキーとして使用されます。
-各キーには、コールバックが同じ値を返したすべての要素を含む、連想配列があります。
+### Using Map.groupBy()
 
-返される {{jsxref("Map")}} と元の配列の要素は同じです（{{glossary("deep copy", "ディープコピー")}}ではありません）。
-要素の内部構造を変更すると、元の配列と返される {{jsxref("Map")}} の両方に反映されます。
-
-このメソッドは、時間の経過とともに変化する可能性のある特定のオブジェクトに関連する情報をグループ化する必要がある場合に有用です。
-これは、たとえオブジェクトが変更されたとしても、返された `Map` のキーとして動作し続けるからです。
-代わりにオブジェクトの文字列表現を作成し、それを {{jsxref("Array.prototype.group()") }} でグループ化のキーとして使用する場合、オブジェクトが変更されたときに元のオブジェクトとその表現との間の対応を維持する必要があります。
-
-> **メモ:** 返された `Map` のグループにアクセスするには、もともと `Map` のキーとして使用されていたオブジェクトと同じものを使用しなければなりません（ただし、そのプロパティを変更することは可能です）。
-> たまたま同じ名前とプロパティを持つだけの別のオブジェクトを使用することはできません。
-
-`callbackFn` は現在の要素の値、現在の添字、および配列そのものを指定して呼び出されます。
-グループは現在の要素にのみ依存することが多いのですが、配列の他の要素の値に基づいたグループ化方針を実装することも可能です。
-
-`callbackFn` は、値が割り当てられている添字だけでなく、配列のすべての添字に対して呼び出されます。
-このため、代入された値のみを参照するメソッドと比較して、不連続な配列では効率が悪くなることがあります。
-
-`groupToMap()` に `thisArg` 引数が指定された場合は、 `callbackFn` を呼び出すたびに `this` の値として使用されます。
-指定されなかった場合は、{{jsxref("undefined")}} が使用されます。
-
-### コールバックでの配列の書き替え
-
-`groupToMap()` メソッドは呼び出された配列を書き替えませんが、 `callbackFn` に指定された関数は書き替えることができます。
-ただし、 `groupToMap()` で処理される要素は最初に `callbackFn` を呼び出す前に設定されることに注意してください。
-したがって、以下のようになります。
-
-- `callbackFn` は `groupToMap()` の呼び出しが始まった後に配列に追加された要素に対しては呼び出されません。
-- 既に呼び出された添字に割り当てられた要素や、範囲外の添字に割り当てられた要素に対しては、 `callbackFn` は呼び出されません。
-- 配列の既存の、まだ呼び出されていない要素が `callbackFn` によって変更された場合、 `callbackFn` に渡される値は、 `groupToMap()` がその要素の添字を処理した時点での値になります。
-- [削除](/ja/docs/Web/JavaScript/Reference/Operators/delete#deleting_array_elements)された要素に対しても呼び出されます。
-
-> **警告:** 前項で説明したような、参照中の配列の同時進行での変更は（特殊な場合を除いて）普通は避けるべきです。多くの場合、理解しにくいコードになります。
-
-## 例
-
-最初に、さまざまな食品の在庫を表すオブジェクトを含む配列を定義します。
-それぞれの食品は `type` （種類）と `quantity` （量）を保有しています。
+First we define an array containing objects representing an inventory of different foodstuffs. Each food has a `type` and a `quantity`.
 
 ```js
 const inventory = [
@@ -133,48 +64,45 @@ const inventory = [
 ];
 ```
 
-以下のコードでは、`groupToMap()` にアロー関数を使用し、要素が `quantity < 6` であるかどうかによって `restock` または `sufficient` というオブジェクトのキーを返しています。
-返される `result` オブジェクトは `Map` なので、配列を返すにはキーを指定して `get()` を呼び出す必要があります。
+The code below uses `Map.groupBy()` with an arrow function that returns the object keys named `restock` or `sufficient`, depending on whether the element has `quantity < 6`. The returned `result` object is a `Map` so we need to call `get()` with the key to obtain the array.
 
 ```js
 const restock = { restock: true };
 const sufficient = { restock: false };
-const result = inventory.groupToMap(({ quantity }) =>
+const result = Map.groupBy(inventory, ({ quantity }) =>
   quantity < 6 ? restock : sufficient,
 );
 console.log(result.get(restock));
-// expected output: Array [Object { name: "bananas", type: "fruit", quantity: 5 }]
+// [{ name: "bananas", type: "fruit", quantity: 5 }]
 ```
 
-関数の引数 `{ quantity }` は、[関数の引数に対するオブジェクトの分割構文](/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#引数に指定されたオブジェクトの属性への参照)の基本例であることに注意してください。
-これは、引数として渡されたオブジェクトの `quantity` プロパティを展開し、関数本体の `quantity` という名前の変数に代入します。
-これは、関数内の要素に関連する値にアクセスするためのとても簡潔な方法です。
+Note that the function argument `{ quantity }` is a basic example of [object destructuring syntax for function arguments](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#unpacking_properties_from_objects_passed_as_a_function_parameter). This unpacks the `quantity` property of an object passed as a parameter, and assigns it to a variable named `quantity` in the body of the function. This is a very succinct way to access the relevant values of elements within a function.
 
-`Map` のキーは変更されても使用することができます。
-しかし、キーを再作成して、それを使用することはできません。
-このため、マップを使用する必要がある何らかのものは、そのキーへの参照を保持することが重要です。
+The key to a `Map` can be modified and still used. However you can't recreate the key and still use it. For this reason it is important that anything that needs to use the map keeps a reference to its keys.
 
 ```js
 // The key can be modified and still used
 restock["fast"] = true;
 console.log(result.get(restock));
-// expected output: Array [Object { name: "bananas", type: "fruit", quantity: 5 }]
+// [{ name: "bananas", type: "fruit", quantity: 5 }]
 
 // A new key can't be used, even if it has the same structure!
 const restock2 = { restock: true };
-console.log(result.get(restock2));
-// expected output: undefined
+console.log(result.get(restock2)); // undefined
 ```
 
-## 仕様書
+## Specifications
 
 {{Specifications}}
 
-## ブラウザーの互換性
+## Browser compatibility
 
 {{Compat}}
 
-## 関連情報
+## See also
 
-- {{jsxref("Array.prototype.group()")}}
-- [`Array.prototype.group` のポリフィル (`core-js`)](https://github.com/zloirock/core-js#array-grouping)
+- [Polyfill of `Map.groupBy` in `core-js`](https://github.com/zloirock/core-js#array-grouping)
+- [Indexed collections](/en-US/docs/Web/JavaScript/Guide/Indexed_collections) guide
+- {{jsxref("Array.prototype.reduce()")}}
+- {{jsxref("Map/Map", "Map()")}}
+- {{jsxref("Object.groupBy()")}}

--- a/files/ja/web/javascript/reference/global_objects/object/groupby/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/groupby/index.md
@@ -34,7 +34,7 @@ Object.groupBy(items, callbackFn)
 
 ### 返値
 
-すべてのグループのプロパティを持つ [`null`-prototype object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects) で、それぞれに関連するグループの要素を含む配列が割り当てられたものです。
+すべてのグループのプロパティを持つ [`null`-prototype object](/ja/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects) で、それぞれに関連するグループの要素を含む配列が割り当てられたものです。
 
 ## 解説
 

--- a/files/ja/web/javascript/reference/global_objects/object/groupby/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/groupby/index.md
@@ -1,120 +1,52 @@
 ---
-title: Array.prototype.group()
+title: Object.groupBy()
 slug: Web/JavaScript/Reference/Global_Objects/Object/groupBy
+page-type: javascript-static-method
+browser-compat: javascript.builtins.Object.groupBy
 ---
 
-{{JSRef}} {{SeeCompatTable}}
+{{JSRef}}
 
-**`group()`** メソッドは、指定されたテスト関数によって返された文字列の値に従って、呼び出された配列の要素をグループ化します。
-返されたオブジェクトは、それぞれのグループに対して別個のプロパティを持ち、その中にグループの要素を持つ配列が含まれます。
+> **Note:** In some versions of some browsers, this method was implemented as the method `Array.prototype.group()`. Due to web compatibility issues, it is now implemented as a static method. Check the [browser compatibility table](#browser_compatibility) for details.
 
-<!-- {{EmbedInteractiveExample("pages/js/array-groupby.html")}} -->
+The **`Object.groupBy()`** static method groups the elements of a given iterable according to the string values returned by a provided callback function. The returned object has separate properties for each group, containing arrays with the elements in the group.
 
-このメソッドは、グループ名が文字列で表現できる場合に使用すべきものです。
-任意の値をキーとして要素をグループ化する必要がある場合は、代わりに {{jsxref("Array.prototype.groupToMap()")}} を使用してください。
+This method should be used when group names can be represented by strings. If you need to group elements using a key that is some arbitrary value, use {{jsxref("Map.groupBy()")}} instead.
 
-## 構文
+<!-- {{EmbedInteractiveExample("pages/js/object-groupby.html")}} -->
 
-```js
-// アロー関数
-group((element) => {
-  /* … */
-});
-group((element, index) => {
-  /* … */
-});
-group((element, index, array) => {
-  /* … */
-});
+## Syntax
 
-// コールバック関数
-group(callbackFn);
-group(callbackFn, thisArg);
-
-// インラインコールバック関数
-group(function (element) {
-  /* … */
-});
-group(function (element, index) {
-  /* … */
-});
-group(function (element, index, array) {
-  /* … */
-});
-group(function (element, index, array) {
-  /* … */
-}, thisArg);
+```js-nolint
+Object.groupBy(items, callbackFn)
 ```
 
-### 引数
+### Parameters
 
+- `items`
+  - : An [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) (such as an {{jsxref("Array")}}) whose elements will be grouped.
 - `callbackFn`
-
-  - : 配列のそれぞれの要素に対して実行する関数
-
-    この関数は以下の引数と共に呼び出されます。
-
+  - : A function to execute for each element in the iterable. It should return a value that can get coerced into a property key (string or [symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)) indicating the group of the current element. The function is called with the following arguments:
     - `element`
-      - : 配列における現在の要素の値。
+      - : The current element being processed.
     - `index`
-      - : 配列における現在の要素の添字（位置）。
-    - `array`
-      - : `group()` が呼び出された配列。
+      - : The index of the current element being processed.
 
-    コールバックから返されるオブジェクトは、現在の要素のグループを示します。
-    この返されたコールバック値は、文字列に変換することが可能でなければなりません（この文字列は、最終的に返されるオブジェクトのプロパティ名として使用されます）。
+### Return value
 
-- `thisArg` {{optional_inline}}
+A [`null`-prototype object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects) with properties for all groups, each assigned to an array containing the elements of the associated group.
 
-  - : `callbackFn` 内で {{jsxref("Operators/this", "this")}} として使用されるオブジェクト。
+## Description
 
-    この引数はアロー関数では無視されます。アロー関数は自分自身でレキシカルなスコープを保有しており、それが代わりに使用されるからです。
-    それ以外の場合、もし `thisArg` が指定されていなければ、実行中のスコープの `this` が使用されます。関数が[厳格モード](/ja/docs/Web/JavaScript/Reference/Strict_mode)で呼び出された場合には `undefined` が使用されます。
+`Object.groupBy()` calls a provided `callbackFn` function once for each element in an iterable. The callback function should return a string or symbol (values that are neither type are [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion)) indicating the group of the associated element. The values returned by `callbackFn` are used as keys for the object returned by `Map.groupBy()`. Each key has an associated array containing all the elements for which the callback returned the same value.
 
-### 返値
+The elements in the returned object and the original iterable are the same (not {{Glossary("deep copy", "deep copies")}}). Changing the internal structure of the elements will be reflected in both the original iterable and the returned object.
 
-すべてのグループのプロパティを持つ [`Object`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Object) で、それぞれに関連するグループの要素を含む配列が割り当てられてたものです。値は、 `Object.prototype` を継承しないオブジェクトです。
+## Examples
 
-### 例外
+### Using Object.groupBy()
 
-- `TypeError`
-  - : 指定されたコールバック関数が呼び出し可能でない場合。
-
-## 解説
-
-`group()` メソッドは、配列のそれぞれの要素に対して、その要素のグループを示す文字列（または文字列に強制できる値）を返す `callbackFn` 関数を一度ずつ実行します。
-コールバックによって返された固有のグループ名ごとに、新しいプロパティと配列が結果のオブジェクトに作成されます。
-それぞれの要素は、そのグループに対応するプロパティ内の配列に追加されます。
-
-返されたオブジェクトは、元の配列と同じ要素を参照することに注意しましょう（{{glossary("deep copy","ディープコピー")}}ではありません）。
-これらの要素の内部構造を変更すると、元の配列と返されるオブジェクトの両方に反映されます。
-
-`callbackFn` は現在の要素の値、現在の添字、および配列そのものを指定して呼び出されます。
-グループは現在の要素にのみ依存することが多いのですが、配列の他の要素の値に基づいたグループ化方針を実装することも可能です。
-
-`callbackFn` は、値が割り当てられている添字だけでなく、配列のすべての添字に対して呼び出されます。
-このため、代入された値のみを参照するメソッドと比較して、不連続な配列では効率が悪くなることがあります。
-
-`group()` に `thisArg` 引数が指定された場合は、 `callbackFn` を呼び出すたびに `this` の値として使用されます。
-指定されなかった場合は、{{jsxref("undefined")}} が使用されます。
-
-### コールバックでの配列の書き替え
-
-`group()` メソッドは呼び出された配列を書き替えませんが、 `callbackFn` に指定された関数は書き替えることができます。
-ただし、 `group()` で処理される要素は最初に `callbackFn` を呼び出す前に設定されることに注意してください。
-したがって、以下のようになります。
-
-- `callbackFn` は `group()` の呼び出しが始まった後に配列に追加された要素に対しては呼び出されません。
-- 既に呼び出された添字に割り当てられた要素や、範囲外の添字に割り当てられた要素に対しては、 `callbackFn` は呼び出されません。
-- 配列の既存の、まだ呼び出されていない要素が `callbackFn` によって変更された場合、 `callbackFn` に渡される値は、 `group()` がその要素の添字を処理した時点での値になります。
-- {{jsxref("Operators/delete", "削除", "", 1)}}された要素に対しても呼び出されます。
-
-> **警告:** 前項で説明したような、参照中の配列の同時進行での変更は（特殊な場合を除いて）普通は避けるべきです。多くの場合、理解しにくいコードになります。
-
-## 例
-
-最初に、さまざまな食品の在庫を表すオブジェクトを含む配列を定義します。
-それぞれの食品は `type` （種類）と `quantity` （量）を保有しています。
+First we define an array containing objects representing an inventory of different foodstuffs. Each food has a `type` and a `quantity`.
 
 ```js
 const inventory = [
@@ -126,12 +58,12 @@ const inventory = [
 ];
 ```
 
-以下のコードでは、 type` プロパティの値によって要素をグループ化します。
+The code below groups the elements by the value of their `type` property.
 
 ```js
-const result = inventory.group(({ type }) => type);
+const result = Object.groupBy(inventory, ({ type }) => type);
 
-/* 結果:
+/* Result is:
 {
   vegetables: [
     { name: 'asparagus', type: 'vegetables', quantity: 5 },
@@ -148,22 +80,19 @@ const result = inventory.group(({ type }) => type);
 */
 ```
 
-このアロー関数は、呼び出されるたびに配列のそれぞれの要素の `型` を返すだけです。
-関数の引数 `{ type }` は、[関数の引数に対するオブジェクトの分割構文](/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#引数に指定されたオブジェクトの属性への参照)の基本例であることに注意してください。
-これは、引数として渡されたオブジェクトの `type` プロパティを展開し、関数本体の `type` という名前の変数に代入します。
-これは、関数内の要素に関連する値にアクセスするためのとても簡潔な方法です。
+The arrow function just returns the `type` of each array element each time it is called. Note that the function argument `{ type }` is a basic example of [object destructuring syntax for function arguments](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#unpacking_properties_from_objects_passed_as_a_function_parameter). This unpacks the `type` property of an object passed as a parameter, and assigns it to a variable named `type` in the body of the function.
+This is a very succinct way to access the relevant values of elements within a function.
 
-また、要素の 1 つまたは複数のプロパティの値から推測されるグループを作成することもできます。
-以下は、 `quantity` フィールドの値に基づいて、項目を `ok` または `restock` グループに入れる、とても似たような例です。
+We can also create groups inferred from values in one or more properties of the elements. Below is a very similar example that puts the items into `ok` or `restock` groups based on the value of the `quantity` field.
 
 ```js
 function myCallback({ quantity }) {
   return quantity > 5 ? "ok" : "restock";
 }
 
-result = inventory.group(myCallback);
+const result2 = Object.groupBy(inventory, myCallback);
 
-/* 結果:
+/* Result is:
 {
   restock: [
     { name: "asparagus", type: "vegetables", quantity: 5 },
@@ -178,15 +107,18 @@ result = inventory.group(myCallback);
 */
 ```
 
-## 仕様書
+## Specifications
 
 {{Specifications}}
 
-## ブラウザーの互換性
+## Browser compatibility
 
 {{Compat}}
 
-## 関連情報
+## See also
 
-- {{jsxref("Array.prototype.groupToMap()")}} – 任意の種類のオブジェクトをキーまたは値として使用し、配列をマップにグループ化します。
-- [`Array.prototype.group` のポリフィル (`core-js`)](https://github.com/zloirock/core-js#array-grouping)
+- [Polyfill of `Object.groupBy` in `core-js`](https://github.com/zloirock/core-js#array-grouping)
+- [Indexed collections](/en-US/docs/Web/JavaScript/Guide/Indexed_collections) guide
+- {{jsxref("Array.prototype.reduce()")}}
+- {{jsxref("Object.fromEntries()")}}
+- {{jsxref("Map.groupBy()")}}

--- a/files/ja/web/javascript/reference/global_objects/object/groupby/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/groupby/index.md
@@ -1,52 +1,52 @@
 ---
 title: Object.groupBy()
 slug: Web/JavaScript/Reference/Global_Objects/Object/groupBy
-page-type: javascript-static-method
-browser-compat: javascript.builtins.Object.groupBy
+l10n:
+  sourceCommit: f15b8d5828c480af144a9b8f88b2724e2997f571
 ---
 
 {{JSRef}}
 
-> **Note:** In some versions of some browsers, this method was implemented as the method `Array.prototype.group()`. Due to web compatibility issues, it is now implemented as a static method. Check the [browser compatibility table](#browser_compatibility) for details.
+> **メモ:** 一部のブラウザーのあるバージョンでは、このメソッドは `Array.prototype.group()` というメソッドとして実装されていました。ウェブの互換性の問題により、現在は静的メソッドとして実装されています。詳細は[ブラウザーの互換性](#ブラウザーの互換性)を確認してください。
 
-The **`Object.groupBy()`** static method groups the elements of a given iterable according to the string values returned by a provided callback function. The returned object has separate properties for each group, containing arrays with the elements in the group.
+**`Object.groupBy()`** 静的メソッドは、指定されたコールバック関数によって返された文字列値に従って、指定された反復可能な要素をグループ化します。返されるオブジェクトには、グループごとに個別のプロパティがあり、グループ内の要素を含む配列が格納されます。
 
-This method should be used when group names can be represented by strings. If you need to group elements using a key that is some arbitrary value, use {{jsxref("Map.groupBy()")}} instead.
+このメソッドは、グループ名が文字列で表現できる場合に使用します。任意の値をキーとして要素をグループ化する必要がある場合は、代わりに {{jsxref("Map.groupBy()")}} を使用してください。
 
 <!-- {{EmbedInteractiveExample("pages/js/object-groupby.html")}} -->
 
-## Syntax
+## 構文
 
 ```js-nolint
 Object.groupBy(items, callbackFn)
 ```
 
-### Parameters
+### 引数
 
 - `items`
-  - : An [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) (such as an {{jsxref("Array")}}) whose elements will be grouped.
+  - : 要素がグループ化される[反復可能な要素](/ja/docs/Web/JavaScript/Reference/Iteration_protocols#反復可能プロトコル)（{{jsxref("Array")}} など）。
 - `callbackFn`
-  - : A function to execute for each element in the iterable. It should return a value that can get coerced into a property key (string or [symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)) indicating the group of the current element. The function is called with the following arguments:
+  - : 反復可能な各要素に対して実行される関数。これは、現在の要素のグループを示すプロパティのキー（文字列または[シンボル](/ja/docs/Web/JavaScript/Reference/Global_Objects/Symbol)）に変換できる値を返す必要があります。この関数は以下の引数で呼び出されます。
     - `element`
-      - : The current element being processed.
+      - : 現在処理中の要素。
     - `index`
-      - : The index of the current element being processed.
+      - : 現在処理中の要素のインデックス。
 
-### Return value
+### 返値
 
-A [`null`-prototype object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects) with properties for all groups, each assigned to an array containing the elements of the associated group.
+すべてのグループのプロパティを持つ [`null`-prototype object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects) で、それぞれに関連するグループの要素を含む配列が割り当てられたものです。
 
-## Description
+## 解説
 
-`Object.groupBy()` calls a provided `callbackFn` function once for each element in an iterable. The callback function should return a string or symbol (values that are neither type are [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion)) indicating the group of the associated element. The values returned by `callbackFn` are used as keys for the object returned by `Map.groupBy()`. Each key has an associated array containing all the elements for which the callback returned the same value.
+`Object.groupBy()` は、指定された `callbackFn` 関数を反復可能な要素ごとに 1 回呼び出します。コールバック関数は、関連付けられた要素のグループを示す文字列またはシンボル（どちらの型でもない値は[文字列変換](/ja/docs/Web/JavaScript/Reference/Global_Objects/String#文字列変換)されます）を返す必要があります。`callbackFn` が返す値は、`Map.groupBy()` が返すオブジェクトのキーとして使用されます。各キーには、コールバックが同じ値を返したすべての要素を含む連想配列があります。
 
-The elements in the returned object and the original iterable are the same (not {{Glossary("deep copy", "deep copies")}}). Changing the internal structure of the elements will be reflected in both the original iterable and the returned object.
+返されたオブジェクトの要素と元の反復可能な要素は同じです（{{Glossary("deep copy", "ディープコピー")}}ではありません）。要素の内部構造を変更すると、反復可能な要素と返されたオブジェクトの両方に反映されます。
 
-## Examples
+## 例
 
-### Using Object.groupBy()
+### Object.groupBy() の使用
 
-First we define an array containing objects representing an inventory of different foodstuffs. Each food has a `type` and a `quantity`.
+最初に、さまざまな食品の在庫を表すオブジェクトを含む配列を定義します。 それぞれの食品は `type` （種類）と `quantity` （量）を保有しています。
 
 ```js
 const inventory = [
@@ -58,12 +58,12 @@ const inventory = [
 ];
 ```
 
-The code below groups the elements by the value of their `type` property.
+以下のコードでは、`type` プロパティの値によって要素をグループ化します。
 
 ```js
 const result = Object.groupBy(inventory, ({ type }) => type);
 
-/* Result is:
+/* 結果:
 {
   vegetables: [
     { name: 'asparagus', type: 'vegetables', quantity: 5 },
@@ -80,10 +80,9 @@ const result = Object.groupBy(inventory, ({ type }) => type);
 */
 ```
 
-The arrow function just returns the `type` of each array element each time it is called. Note that the function argument `{ type }` is a basic example of [object destructuring syntax for function arguments](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#unpacking_properties_from_objects_passed_as_a_function_parameter). This unpacks the `type` property of an object passed as a parameter, and assigns it to a variable named `type` in the body of the function.
-This is a very succinct way to access the relevant values of elements within a function.
+このアロー関数は、呼び出されるたびに配列のそれぞれの要素の 型 を返すだけです。 関数の引数 { type } は、[関数の引数に対するオブジェクトの分割構文](/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#関数の引数として渡されたオブジェクトからのプロパティの展開)の基本例であることに注意してください。 これは、引数として渡されたオブジェクトの `type` プロパティを展開し、関数本体の `type` という名前の変数に代入します。 これは、関数内の要素に関連する値にアクセスするためのとても簡潔な方法です。
 
-We can also create groups inferred from values in one or more properties of the elements. Below is a very similar example that puts the items into `ok` or `restock` groups based on the value of the `quantity` field.
+また、要素の 1 つまたは複数のプロパティの値から推測されるグループを作成することもできます。 以下は、`quantity` フィールドの値に基づいて、項目を `ok` または `restock` グループに入れる、とても似たような例です。
 
 ```js
 function myCallback({ quantity }) {
@@ -92,7 +91,7 @@ function myCallback({ quantity }) {
 
 const result2 = Object.groupBy(inventory, myCallback);
 
-/* Result is:
+/* 結果:
 {
   restock: [
     { name: "asparagus", type: "vegetables", quantity: 5 },
@@ -107,18 +106,18 @@ const result2 = Object.groupBy(inventory, myCallback);
 */
 ```
 
-## Specifications
+## 仕様書
 
 {{Specifications}}
 
-## Browser compatibility
+## ブラウザーの互換性
 
 {{Compat}}
 
-## See also
+## 関連情報
 
-- [Polyfill of `Object.groupBy` in `core-js`](https://github.com/zloirock/core-js#array-grouping)
-- [Indexed collections](/en-US/docs/Web/JavaScript/Guide/Indexed_collections) guide
+- [`Object.groupBy` のポリフィル (`core-js`)](https://github.com/zloirock/core-js#array-grouping)
+- [インデックス付きコレクション](/ja/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array.prototype.reduce()")}}
 - {{jsxref("Object.fromEntries()")}}
 - {{jsxref("Map.groupBy()")}}


### PR DESCRIPTION
### Description

- https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy
- https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy

### Additional details

https://developer.mozilla.org/ja/docs/Mozilla/Firefox/Releases/119#javascript

> 反復可能な要素をグループ化するための [Object.groupBy()](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy) および [Map.groupBy()](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy) 静的メソッドをサポートしました (詳しくは [Firefox bug 1792650](https://bugzil.la/1792650) をご覧ください)。

とあるが、日本語版が更新されていない。

### Related issues and pull requests

https://github.com/mozilla-japan/translation/issues/727

### Notes

- `Object.groupBy()` の翻訳に際して、本文中に [`null`-prototype object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects) のリンクがありましたが、当該セクションの日本語訳が存在せずリンクが機能しないため、意図的に `en-US` 版へのリンクとして残しています。