### PR TITLE
[ru] fix operators order on `Web/JavaScript/Reference/Operators/Operator_precedence`

### DIFF
--- a/files/ru/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/ru/web/javascript/reference/operators/operator_precedence/index.md
@@ -51,276 +51,154 @@ a = b = 5;
       <th>Конкретные операторы</th>
     </tr>
     <tr>
-      <td>19</td>
-      <td>
-        {{jsxref("Operators/Grouping", "Группировка")}}
-      </td>
+      <td>18</td>
+      <td>{{jsxref("Operators/Grouping", "Группировка")}}</td>
       <td>не определено</td>
       <td><code>( … )</code></td>
     </tr>
     <tr>
-      <td rowspan="5">18</td>
-      <td>
-        {{jsxref("Operators/Property_Accessors", "Доступ к свойствам", "#Dot_notation")}}
-      </td>
+      <td rowspan="5">17</td>
+      <td>{{jsxref("Operators/Property_Accessors", "Доступ к свойствам", "#Dot_notation")}}</td>
       <td rowspan="2">слева направо</td>
       <td><code>… . …</code></td>
     </tr>
     <tr>
-      <td>
-        {{jsxref("Operators/Property_Accessors", "Доступ к свойствам с возможностью вычисления","#Bracket_notation")}}
-      </td>
+      <td>{{jsxref("Operators/Property_Accessors", "Доступ к свойствам с возможностью вычисления","#Bracket_notation")}}</td>
       <td><code>… [ … ]</code></td>
     </tr>
     <tr>
-      <td>
-        {{jsxref("Operators/new","new")}} (со списком аргументов)
-      </td>
+      <td>{{jsxref("Operators/new","new")}} (со списком аргументов)</td>
       <td>не определено</td>
       <td><code>new … ( … )</code></td>
     </tr>
     <tr>
-      <td>
-        <a href="/ru/docs/Web/JavaScript/Guide/Functions">Вызов функции</a>
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Guide/Functions">Вызов функции</a></td>
       <td rowspan="2">слева направо</td>
-      <td>
-        <code>… ( <var>… </var>)</code>
-      </td>
+      <td><code>… ( <var>… </var>)</code></td>
     </tr>
     <tr>
-      <td>
-        <a href="/ru/docs/Web/JavaScript/Reference/Operators/Optional_chaining"
-          >Оператор опциональной последовательности (?.)</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Optional_chaining">Оператор опциональной последовательности (?.)</a></td>
       <td><code>?.</code></td>
     </tr>
     <tr>
-      <td>17</td>
-      <td>
-        {{jsxref("Operators/new","new")}} (без списка аргументов)
-      </td>
+      <td>16</td>
+      <td>{{jsxref("Operators/new","new")}} (без списка аргументов)</td>
       <td>справа налево</td>
       <td><code>new …</code></td>
     </tr>
     <tr>
-      <td rowspan="2">16</td>
-      <td>
-        {{jsxref("Operators/Arithmetic_Operators","Постфиксный инкремент","#Increment")}}
-      </td>
+      <td rowspan="2">15</td>
+      <td>{{jsxref("Operators/Arithmetic_Operators","Постфиксный инкремент","#Increment")}}</td>
       <td rowspan="2">не определено</td>
       <td><code>… ++</code></td>
     </tr>
     <tr>
-      <td>
-        {{jsxref("Operators/Arithmetic_Operators","Постфиксный декремент","#Decrement")}}
-      </td>
+      <td>{{jsxref("Operators/Arithmetic_Operators","Постфиксный декремент","#Decrement")}}</td>
       <td><code>… --</code></td>
     </tr>
     <tr>
-      <td rowspan="10">15</td>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_NOT"
-          >Логическое отрицание (!)</a
-        >
-      </td>
+      <td rowspan="10">14</td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_NOT">Логическое отрицание (!)</a></td>
       <td rowspan="10">справа налево</td>
       <td><code>! …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_NOT"
-          >Побитовое отрицание (~)</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_NOT">Побитовое отрицание (~)</a></td>
       <td><code>~ …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Unary_plus"
-          >Унарный плюс</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Unary_plus">Унарный плюс</a></td>
       <td><code>+ …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Unary_negation"
-          >Унарный минус</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Unary_negation">Унарный минус</a></td>
       <td><code>- …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Increment"
-          >Префиксный инкремент</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Increment">Префиксный инкремент</a></td>
       <td><code>++ …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Decrement"
-          >Префиксный декремент</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Decrement">Префиксный декремент</a></td>
       <td><code>-- …</code></td>
     </tr>
     <tr>
-      <td>
-        <a href="/ru/docs/Web/JavaScript/Reference/Operators/typeof">typeof</a>
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/typeof">typeof</a></td>
       <td><code>typeof …</code></td>
     </tr>
     <tr>
-      <td>
-        <a href="/ru/docs/Web/JavaScript/Reference/Operators/void">void</a>
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/void">void</a></td>
       <td><code>void …</code></td>
     </tr>
     <tr>
-      <td>
-        <a href="/ru/docs/Web/JavaScript/Reference/Operators/delete">delete</a>
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/delete">delete</a></td>
       <td><code>delete …</code></td>
     </tr>
     <tr>
-      <td>
-        <a href="/ru/docs/Web/JavaScript/Reference/Operators/await">await</a>
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/await">await</a></td>
       <td><code>await …</code></td>
     </tr>
     <tr>
-      <td>14</td>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation"
-          >Возведение в степень (**)</a
-        >
-      </td>
+      <td>13</td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation">Возведение в степень (**)</a></td>
       <td>справа налево</td>
       <td><code>… ** …</code></td>
     </tr>
     <tr>
-      <td rowspan="3">13</td>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Multiplication"
-          >Умножение (*)</a
-        >
-      </td>
+      <td rowspan="3">12</td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Multiplication">Умножение (*)</a></td>
       <td rowspan="3">слева направо</td>
       <td><code>… * …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Division"
-          >Деление (/)</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Division">Деление (/)</a></td>
       <td><code>… / …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Remainder"
-          >Остаток от деления (%)</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Remainder">Остаток от деления (%)</a></td>
       <td><code>… % …</code></td>
     </tr>
     <tr>
-      <td rowspan="2">12</td>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Addition"
-          >Сложение (+)</a
-        >
-      </td>
+      <td rowspan="2">11</td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Addition">Сложение (+)</a></td>
       <td rowspan="2">слева направо</td>
       <td><code>… + …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Subtraction"
-          >Вычитание (-)</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Subtraction">Вычитание (-)</a></td>
       <td><code>… - …</code></td>
     </tr>
     <tr>
-      <td rowspan="3">11</td>
-      <td>
-        <a
-          href="https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators"
-          >Побитовый сдвиг влево (&#x3C;&#x3C;)</a
-        >
-      </td>
+      <td rowspan="3">10</td>
+      <td><a href="https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators">Побитовый сдвиг влево (&#x3C;&#x3C;)</a></td>
       <td rowspan="3">слева направо</td>
       <td><code>… &#x3C;&#x3C; …</code></td>
     </tr>
     <tr>
-      <td>
-        <a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators"
-          >Побитовый сдвиг вправо (>>)</a
-        >
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators">Побитовый сдвиг вправо (>>)</a>
       </td>
       <td><code>… >> …</code></td>
     </tr>
     <tr>
-      <td>
-        <a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators"
-          >Сдвиг вправо с заполнением нулей (>>>)</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators">Сдвиг вправо с заполнением нулей (>>>)</a></td>
       <td><code>… >>> …</code></td>
     </tr>
     <tr>
-      <td rowspan="6">10</td>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Less_than_operator"
-          >Меньше (&#x3C;)</a
-        >
-      </td>
+      <td rowspan="6">9</td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Less_than_operator">Меньше (&#x3C;)</a></td>
       <td rowspan="6">слева направо</td>
       <td><code>… &#x3C; …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Less_than__or_equal_operator"
-          >Меньше или равно (&#x3C;=)</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Less_than__or_equal_operator">Меньше или равно (&#x3C;=)</a></td>
       <td><code>… &#x3C;= …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Greater_than_operator"
-          >Больше (>)</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Greater_than_operator">Больше (>)</a></td>
       <td><code>… > …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Greater_than_or_equal_operator"
-          >Больше или равно (>=)</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Greater_than_or_equal_operator">Больше или равно (>=)</a></td>
       <td><code>… >= …</code></td>
     </tr>
     <tr>
@@ -328,134 +206,64 @@ a = b = 5;
       <td><code>… in …</code></td>
     </tr>
     <tr>
-      <td>
-        <a href="/ru/docs/Web/JavaScript/Reference/Operators/instanceof"
-          >instanceof</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/instanceof">instanceof</a></td>
       <td><code>… instanceof …</code></td>
     </tr>
     <tr>
-      <td rowspan="4">9</td>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Equality"
-          >Равенство (==)</a
-        >
-      </td>
+      <td rowspan="4">8</td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Equality">Равенство (==)</a></td>
       <td rowspan="4">слева направо</td>
       <td><code>… == …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Inequality"
-          >Неравенство (!=)</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Inequality">Неравенство (!=)</a></td>
       <td><code>… != …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Identity"
-          >Строгое равенство (===)</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Identity">Строгое равенство (===)</a></td>
       <td><code>… === …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Nonidentity"
-          >Строгое неравенство (!==)</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Nonidentity">Строгое неравенство (!==)</a></td>
       <td><code>… !== …</code></td>
     </tr>
     <tr>
-      <td>8</td>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_AND"
-          >Побитовое «И» (&#x26;)</a
-        >
-      </td>
+      <td>7</td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_AND">Побитовое «И» (&#x26;)</a></td>
       <td>слева направо</td>
       <td><code>… &#x26; …</code></td>
     </tr>
     <tr>
-      <td>7</td>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_XOR"
-          >Побитовое исключающее «ИЛИ» (^)</a
-        >
-      </td>
+      <td>6</td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_XOR">Побитовое исключающее «ИЛИ» (^)</a></td>
       <td>слева направо</td>
       <td><code>… ^ …</code></td>
     </tr>
     <tr>
-      <td>6</td>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_OR"
-          >Побитовое «ИЛИ» (|)</a
-        >
-      </td>
+      <td>5</td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_OR">Побитовое «ИЛИ» (|)</a></td>
       <td>слева направо</td>
       <td><code>… | …</code></td>
     </tr>
     <tr>
-      <td>5</td>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_AND"
-          >Логическое «И» (&#x26;&#x26;)</a
-        >
-      </td>
+      <td>4</td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_AND">Логическое «И» (&#x26;&#x26;)</a></td>
       <td>слева направо</td>
       <td><code>… &#x26;&#x26; …</code></td>
     </tr>
     <tr>
-      <td rowspan="2">4</td>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_OR"
-          >Логическое «ИЛИ» (||)</a
-        >
-      </td>
+      <td rowspan="2">3</td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_OR">Логическое «ИЛИ» (||)</a></td>
       <td rowspan="2">слева направо</td>
       <td><code>… || …</code></td>
     </tr>
     <tr>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator"
-          >Оператор нулевого слияния (??)</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator">Оператор нулевого слияния (??)</a></td>
       <td><code>… ?? …</code></td>
     </tr>
     <tr>
-      <td>3</td>
-      <td>
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Conditional_Operator"
-          >Условный (тернарный) оператор</a
-        >
-      </td>
-      <td>справа налево</td>
-      <td><code>… ? … : …</code></td>
-    </tr>
-    <tr>
-      <td rowspan="18">2</td>
-      <td rowspan="16">
-        <a
-          href="/ru/docs/Web/JavaScript/Reference/Operators/Assignment_Operators"
-          >Присваивание</a
-        >
-      </td>
+      <td rowspan="19">2</td>
+      <td rowspan="16"><a href="/ru/docs/Web/JavaScript/Reference/Operators/Assignment_Operators">Присваивание</a></td>
       <td rowspan="16">справа налево</td>
       <td><code>… = …</code></td>
     </tr>
@@ -505,25 +313,22 @@ a = b = 5;
       <td><code>… ??= …</code></td>
     </tr>
     <tr>
-      <td>
-        <a href="/ru/docs/Web/JavaScript/Reference/Operators/yield">yield</a>
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Conditional_Operator">Условный (тернарный) оператор</a></td>
+      <td>справа налево</td>
+      <td><code>… ? … : …</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/yield">yield</a></td>
       <td rowspan="2">справа налево</td>
       <td><code>yield …</code></td>
     </tr>
     <tr>
-      <td>
-        <a href="/ru/docs/Web/JavaScript/Reference/Operators/yield*">yield*</a>
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/yield*">yield*</a></td>
       <td><code>yield* …</code></td>
     </tr>
     <tr>
       <td>1</td>
-      <td>
-        <a href="/ru/docs/Web/JavaScript/Reference/Operators/Comma_Operator"
-          >Запятая / Последовательность</a
-        >
-      </td>
+      <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comma_Operator">Запятая / Последовательность</a></td>
       <td>слева направо</td>
       <td><code>… , …</code></td>
     </tr>


### PR DESCRIPTION
### Description

This PR fixes operators order on `Web/JavaScript/Reference/Operators/Operator_precedence` for `ru` locale

### Related issues and pull requests

Fixes #7889