### PR TITLE
Change some interactive example URLs

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/intl/pluralrules/supportedlocalesof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/pluralrules/supportedlocalesof/index.md
@@ -7,6 +7,8 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/supportedLocalesO
 
 **`Intl.PluralRules.supportedLocalesOf()`** メソッドは、ランタイムの既定のロケールのうち、代替する必要なく複数形の書式で対応されているものが入った配列を返します。
 
+{{EmbedInteractiveExample("pages/js/intl-pluralrules-supportedlocalesof.html")}}
+
 ## 構文
 
 ```js

--- a/files/ja/web/javascript/reference/global_objects/intl/segmenter/segment/segments/containing/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/segmenter/segment/segments/containing/index.md
@@ -7,7 +7,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/co
 
 **`Intl.Segments.containing()`** メソッドは、指定されたインデックスのコードユニットを含む文字列中のセグメントを記述したオブジェクトを返します。
 
-{{EmbedInteractiveExample("pages/js/intl-segments-prototype-containing.html")}}
+{{EmbedInteractiveExample("pages/js/segments-prototype-containing.html")}}
 
 ## 構文
 

--- a/files/ja/web/javascript/reference/global_objects/intl/segmenter/segment/segments/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/segmenter/segment/segments/index.md
@@ -7,7 +7,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments
 
 **`Intl.Segments`** のインスタンスは、テキスト文字列のセグメントを反復可能なコレクションとして保持します。[`Intl.Segmenter`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) オブジェクトの [`segment()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment) メソッドをコールすると、このインスタンスが返されます。
 
-{{EmbedInteractiveExample("pages/js/intl-segments-prototype-containing.html")}}
+{{EmbedInteractiveExample("pages/js/segments-prototype-containing.html")}}
 
 ## インスタンスメソッド
 

--- a/files/ja/web/javascript/reference/global_objects/string/@@iterator/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/@@iterator/index.md
@@ -10,7 +10,7 @@ l10n:
 **`[@@iterator]()`** は {{jsxref("String")}} 値のメソッドで、[反復可能プロトコル](/ja/docs/Web/JavaScript/Reference/Iteration_protocols)を実装しており、[スプレッド構文](/ja/docs/Web/JavaScript/Reference/Operators/Spread_syntax)や{{jsxref("Statements/for...of", "for...of")}}ループ
 文字列値のコードポイントを走査し、それぞれのコードポイントを文字列値として返すイテレーターオブジェクトを返します。
 
-{{EmbedInteractiveExample("pages/js/string-iterator.html")}}
+{{EmbedInteractiveExample("pages/js/string-prototype-@@iterator.html")}}
 
 ## 構文
 

--- a/files/ja/web/javascript/reference/operators/nullish_coalescing_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/nullish_coalescing_assignment/index.md
@@ -7,7 +7,7 @@ slug: Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment
 
 Null 合体代入 (`x ??= y`) 演算子は、`x` が {{Glossary("nullish")}} (`null` または `undefined`) である場合にのみ代入を行います。
 
-{{EmbedInteractiveExample("pages/js/expressions-logical-nullish-assignment.html")}}
+{{EmbedInteractiveExample("pages/js/expressions-nullish-coalescing-assignment.html")}}
 
 ## 構文
 


### PR DESCRIPTION
### Description

1. https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator
    - 64099dc65f0
1. https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/global_objects/typedarray/@@iterator
    - 1986e5e96a7
1. https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/supportedLocalesOf
1. https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/supportedLocalesOf
1. https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/supportedLocalesOf
1. https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/segmenter/segment/segments/@@iterator
    - 7d0e43d8530
1. https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/pluralrules/supportedlocalesof
    - Added by this commit
1. https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/segmenter/segment/segments/containing
1. https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/segmenter/segment/segments
1. https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/string/@@iterator
1. https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment
    - Fixed by this commit
1. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/supportedLocalesOf
    - `ja` not found

### Additional details

修正すべきページ一覧は以下より確認できますが、必要な修正は上記のみのようです。

- https://mdn.lavoscore.org/?not_regex_examples_ja=%5E%28null%7C%7Cfalse%29$

### Related issues and pull requests

- https://github.com/mdn/content/pull/28724
- https://github.com/mozilla-japan/translation/issues/730