### PR TITLE
fix: remove {{experimental_inline}} for "let" and "const"

### DIFF
--- a/files/pt-br/web/javascript/guide/grammar_and_types/index.md
+++ b/files/pt-br/web/javascript/guide/grammar_and_types/index.md
@@ -41,9 +41,9 @@ Existem três tipos de declarações em JavaScript.
 
 - {{jsxref("Statements/var", "var")}}
   - : Declara uma variável, opcionalmente, inicializando-a com um valor.
-- {{experimental_inline}} {{jsxref("Statements/let", "let")}}
+- {{jsxref("Statements/let", "let")}}
   - : Declara uma variável local de escopo do bloco, opcionalmente, inicializando-a com um valor.
-- {{experimental_inline}} {{jsxref("Statements/const", "const")}}
+- {{jsxref("Statements/const", "const")}}
   - : Declara uma constante de escopo de bloco, apenas de leitura.
 
 ### Variáveis


### PR DESCRIPTION
The "en" translate don't contain this experimental reference.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The English documentation don't have this {{experimental_inline}} references, so probably our "pt-br" has wrong or older information about this.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
