### PR TITLE
[ru] remove obsolete links to `http://mozvr.com`

### DIFF
--- a/files/ru/web/api/gamepad/displayid/index.md
+++ b/files/ru/web/api/gamepad/displayid/index.md
@@ -43,5 +43,4 @@ window.addEventListener("gamepadconnected", function (e) {
 
 ## See also
 
-- [WebVR API homepage](/ru/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — демосцены, материалы, доступные для скачивания и другие материалы команды the Mozilla VR team.
+- [WebVR API](/ru/docs/Web/API/WebVR_API)

--- a/files/ru/web/api/vrdisplay/requestanimationframe/index.md
+++ b/files/ru/web/api/vrdisplay/requestanimationframe/index.md
@@ -100,5 +100,4 @@ function drawVRScene() {
 
 ## See also
 
-- [WebVR API homepage](/ru/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — demos, downloads, and other resources from the Mozilla VR team.
+- [WebVR API](/ru/docs/Web/API/WebVR_API)

--- a/files/ru/web/api/vrdisplay/requestpresent/index.md
+++ b/files/ru/web/api/vrdisplay/requestpresent/index.md
@@ -92,5 +92,4 @@ if (navigator.getVRDisplays) {
 
 ## See also
 
-- [WebVR API homepage](/ru/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — demos, downloads, and other resources from the Mozilla VR team.
+- [WebVR API](/ru/docs/Web/API/WebVR_API)

--- a/files/ru/web/api/vrdisplaycapabilities/index.md
+++ b/files/ru/web/api/vrdisplaycapabilities/index.md
@@ -59,11 +59,10 @@ function reportDisplays() {
 
 {{Specifications}}
 
-## Режим совместимости браузера
+## Совместимость с браузерами
 
 {{Compat}}
 
-## Дополнительно
+## Смотрите также
 
-- [WebVR API homepage](/ru/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — демонстрационные, материалы для загрузки и другие ресурсы команды Mozilla VR team.
+- [WebVR API](/ru/docs/Web/API/WebVR_API)

--- a/files/ru/web/api/vrdisplayevent/display/index.md
+++ b/files/ru/web/api/vrdisplayevent/display/index.md
@@ -31,5 +31,4 @@ A {{domxref("VRDisplay")}} object.
 
 ## Дополнительно
 
-- [WebVR API homepage](/ru/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — демонстрационные материалы,материалы для загрузки и другие ресурсы команды Mozilla VR team.
+- [WebVR API](/ru/docs/Web/API/WebVR_API)

--- a/files/ru/web/api/vrdisplayevent/index.md
+++ b/files/ru/web/api/vrdisplayevent/index.md
@@ -45,5 +45,4 @@ window.addEventListener("vrdisplaypresentchange", function (e) {
 
 ## See also
 
-- [WebVR API homepage](/ru/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — демонстрации, загружаемые материалы и другие ресурсы команды the Mozilla VR team.
+- [WebVR API](/ru/docs/Web/API/WebVR_API)

--- a/files/ru/web/api/vrframedata/index.md
+++ b/files/ru/web/api/vrframedata/index.md
@@ -35,11 +35,10 @@ slug: Web/API/VRFrameData
 
 {{Specifications}}
 
-## Совместимость браузера
+## Совместимость с браузерами
 
 {{Compat}}
 
-## Дополнительно
+## Смотрите также
 
-- [WebVR API homepage](/ru/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — демонстрационные материалы, материалы доступные для загрузки и другие ресурсы команды Mozilla VR team.
+- [WebVR API](/ru/docs/Web/API/WebVR_API)

--- a/files/ru/web/api/vrpose/position/index.md
+++ b/files/ru/web/api/vrpose/position/index.md
@@ -37,11 +37,10 @@ var myPosition = VRPose.position;
 
 {{Specifications}}
 
-## Совместимость браузера
+## Совместимость с браузерами
 
 {{Compat}}
 
-## Дополнительно
+## Смотрите также
 
-- [WebVR API homepage](/ru/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — демонстрационные, материалы для загрузки и другие ресурсы команды Mozilla VR team.
+- [WebVR API](/ru/docs/Web/API/WebVR_API)

--- a/files/ru/web/api/vrstageparameters/sittingtostandingtransform/index.md
+++ b/files/ru/web/api/vrstageparameters/sittingtostandingtransform/index.md
@@ -27,11 +27,10 @@ var myTransform = vrStageParametersInstance.sittingToStandingTransform;
 
 {{Specifications}}
 
-## Режим совместимости браузера
+## Совместимость с браузерами
 
 {{Compat}}
 
-## Дополнительно
+## Смотрите также
 
-- [WebVR API homepage](/ru/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — демонстрационные, доступные для загрузки и другие материалы команды Mozilla VR team.
+- [WebVR API](/ru/docs/Web/API/WebVR_API)

--- a/files/ru/web/api/vrstageparameters/sizex/index.md
+++ b/files/ru/web/api/vrstageparameters/sizex/index.md
@@ -27,11 +27,10 @@ var mySizeX = vrStageParametersInstance.sizeX;
 
 {{Specifications}}
 
-## Browser compatibility
+## Совместимость с браузерами
 
 {{Compat}}
 
-## See also
+## Смотрите также
 
-- [WebVR API homepage](/ru/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — демонстрационные, материалы для загрузки и другие ресурсы команды Mozilla VR team.
+- [WebVR API](/ru/docs/Web/API/WebVR_API)

--- a/files/ru/web/api/vrstageparameters/sizey/index.md
+++ b/files/ru/web/api/vrstageparameters/sizey/index.md
@@ -27,11 +27,10 @@ var mySizeY = vrStageParametersInstance.sizeY;
 
 {{Specifications}}
 
-## Browser compatibility
+## Совместимость с браузерами
 
 {{Compat}}
 
-## See also
+## Смотрите также
 
-- [WebVR API homepage](/ru/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — демонстрационные материалы,загружаемые и другие ресурсы команды Mozilla VR team.
+- [WebVR API](/ru/docs/Web/API/WebVR_API)

--- a/files/ru/web/api/webvr_api/index.md
+++ b/files/ru/web/api/webvr_api/index.md
@@ -114,6 +114,5 @@ WebVR API расширяет следующие API, добавляя переч
 - [vr.mozilla.org](https://vr.mozilla.org) — Основная посадочная площадка Mozilla для WebVR с демонстрационными материалами, утилитами и другой информацией.
 - [A-Frame](https://aframe.io/) — Веб-платформа с открытым исходным кодом для создания опыта VR.
 - [webvr.info](https://webvr.info) — Актуальная информация о WebVR, настройке браузера и сообществе.
-- [MozVr.com](http://mozvr.com/) — Демонстрации, загрузки и другие ресурсы от команды Mozilla VR.
 - [threejs-vr-boilerplate](https://github.com/MozVR/vr-web-examples/tree/master/threejs-vr-boilerplate) — Полезный стартовый шаблон для написания приложений WebVR.
 - [Web VR polyfill](https://github.com/googlevr/webvr-polyfill/) — JavaScript-реализация WebVR.


### PR DESCRIPTION
### Description

This PR removes obsolete links to http://mozvr.com that is now redirects to https://hubs.mozilla.com/labs/ and has no specific relation to VR topic.
