### PR TITLE
[fr] remove all occurrences of obsolete links to `mixedreality.mozilla.org` and `mozvr.com`

### DIFF
--- a/files/fr/web/api/vrdisplaycapabilities/index.md
+++ b/files/fr/web/api/vrdisplaycapabilities/index.md
@@ -36,5 +36,4 @@ TBD.
 
 ## Voir aussi
 
-- [Page d'accueil de l'API WebVR](/fr/docs/Web/API/WebVR_API).
-- <https://mixedreality.mozilla.org/> — démos, téléchargements et autres ressources de l'équipe Mozilla VR.
+- [WebVR API](/fr/docs/Web/API/WebVR_API)

--- a/files/fr/web/api/webvr_api/index.md
+++ b/files/fr/web/api/webvr_api/index.md
@@ -69,7 +69,6 @@ Vous pouvez retrouver plusieurs exemples dans ces repos Github:
 
 - [webvr.info](https://webvr.info) - Up-to-date information about WebVR, browser setup, and community.
 - [Is WebVR Ready?](https://iswebvrready.com) - Up-to-date information about WebVR browser support (including experimental builds).
-- [MozVr.com](http://mozvr.com/) — demos, downloads, and other resources from the Mozilla VR team.
 - [A-Frame](https://aframe.io) — a web framework for building VR experiences (with HTML), from the Mozilla VR team.
 - [Console Game on Web](http://dsmu.me/ConsoleGameOnWeb/) — a collection of interesting game concept demos, some of which include WebVR.
 - [threejs-vr-boilerplate](https://github.com/MozVR/vr-web-examples/tree/master/threejs-vr-boilerplate) — a very useful starter template for writing WebVR apps into.

--- a/files/fr/web/api/window/vrdisplayconnect_event/index.md
+++ b/files/fr/web/api/window/vrdisplayconnect_event/index.md
@@ -64,5 +64,4 @@ window.onvrdisplayconnect = function () {
 
 ## Voir aussi
 
-- [WebVR API homepage](/fr/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — démos, téléchargements et autres ressources de l'équipe Mozilla VR.
+- [WebVR API](/fr/docs/Web/API/WebVR_API)

--- a/files/fr/web/api/window/vrdisplaydisconnect_event/index.md
+++ b/files/fr/web/api/window/vrdisplaydisconnect_event/index.md
@@ -64,5 +64,4 @@ window.onvrdisplaydisconnect = function() {
 
 ## Voir aussi
 
-- [WebVR API homepage](/fr/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — démos, téléchargements et autres ressources de l'équipe Mozilla VR.
+- [WebVR API](/fr/docs/Web/API/WebVR_API)

--- a/files/fr/web/api/window/vrdisplaypresentchange_event/index.md
+++ b/files/fr/web/api/window/vrdisplaypresentchange_event/index.md
@@ -72,5 +72,4 @@ window.onvrdisplaypresentchange = function () {
 
 ## Voir aussi
 
-- [WebVR API homepage](/fr/docs/Web/API/WebVR_API)
-- [MozVr.com](http://mozvr.com/) — démos, téléchargements et autres ressources de l'équipe Mozilla VR.
+- [WebVR API](/fr/docs/Web/API/WebVR_API)

--- a/files/fr/web/demos/index.md
+++ b/files/fr/web/demos/index.md
@@ -66,8 +66,8 @@ Mozilla supporte une large gamme de technologies open web vraiment intéressante
 
 ### Réalité Virtuelle
 
-- La Mer Polaire ([code source](https://github.com/MozVR/polarsea))
-- Sechelt fly-through ([code source](https://github.com/mozvr/sechelt))
+- [La Mer Polaire](https://github.com/MozillaReality/polarsea)
+- [Sechelt fly-through](https://github.com/MozillaReality/sechelt)
 
 ### Réalité augmentée
 

--- a/files/fr/web/demos/index.md
+++ b/files/fr/web/demos/index.md
@@ -66,8 +66,8 @@ Mozilla supporte une large gamme de technologies open web vraiment intéressante
 
 ### Réalité Virtuelle
 
-- [La Mer Polaire](https://mozvr.com/demos/polarsea/) ([code source](https://github.com/MozVR/polarsea))
-- [Sechelt fly-through](https://mozvr.github.io/sechelt/) ([code source](https://github.com/mozvr/sechelt))
+- La Mer Polaire ([code source](https://github.com/MozVR/polarsea))
+- Sechelt fly-through ([code source](https://github.com/mozvr/sechelt))
 
 ### Réalité augmentée
 


### PR DESCRIPTION
### Description

This PR removes all occurrences of obsolete links to `mixedreality.mozilla.org` and `mozvr.com` in `fr` locale.
https://mixedreality.mozilla.org/ and https://mozvr.com/ now redirects to https://hubs.mozilla.com/labs/ and has no special relation to VR topic.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/31117