### PR TITLE
[pt-br] remove all occurrences of obsolete links to `mozvr.com`

### DIFF
--- a/files/pt-br/web/api/webvr_api/index.md
+++ b/files/pt-br/web/api/webvr_api/index.md
@@ -69,7 +69,6 @@ Você pode encontrar uma série de exemplos nesses repositórios Github:
 
 - [webvr.info](https://webvr.info)- Informações atualizadas sobre WebVR, configuração do navegador e comunidade.
 - [webvr.rocks](https://iswebvrready.com)- Informações atualizadas sobre o suporte ao navegador WebVR (incluindo compilações experimentais).
-- [MozVr.com](http://mozvr.com/)- Demos, downloads, outros recursos da equipe de VR da Mozilla.
 - [A-Frame](https://aframe.io)- A web framework para a construção de experiências VR (com HTML), a partir da equipe Mozilla VR.
 - [Console Game on Web](http://dsmu.me/ConsoleGameOnWeb/)- Uma coleção de demonstrações interessantes conceito de jogo, alguns dos quais incluem WebVR.
 - [threejs-vr-boilerplate](https://github.com/MozVR/vr-web-examples/tree/master/threejs-vr-boilerplate)- Um modelo de iniciador muito útil para escrever aplicações WebVR.

--- a/files/pt-br/web/demos/index.md
+++ b/files/pt-br/web/demos/index.md
@@ -52,7 +52,7 @@ Se você conhece uma boa demonstração ou aplicação da tecnologia web aberta,
 ### Realidade virtual
 
 - The Polar Sea ([source code](https://github.com/MozVR/polarsea))
-- [Sechelt fly-through](http://mozvr.github.io/sechelt/) ([source code](https://github.com/mozvr/sechelt))
+- [Sechelt fly-through](https://mozvr.github.io/sechelt/) ([source code](https://github.com/mozvr/sechelt))
 
 ## CSS
 

--- a/files/pt-br/web/demos/index.md
+++ b/files/pt-br/web/demos/index.md
@@ -51,8 +51,8 @@ Se você conhece uma boa demonstração ou aplicação da tecnologia web aberta,
 
 ### Realidade virtual
 
-- [The Polar Sea](http://mozvr.com/demos/polarsea/) ([source code](https://github.com/MozVR/polarsea))
-- Sechelt fly-through ([source code](https://github.com/mozvr/sechelt))
+- The Polar Sea ([source code](https://github.com/MozVR/polarsea))
+- [Sechelt fly-through](http://mozvr.github.io/sechelt/) ([source code](https://github.com/mozvr/sechelt))
 
 ## CSS
 


### PR DESCRIPTION
### Description

This PR removes all occurrences of obsolete links to `mozvr.com` in `pt-br` locale.
https://mozvr.com/ now redirects to https://hubs.mozilla.com/labs/ and has no special relation to VR topic.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/31117