### PR TITLE
[ja] remove all occurrences of obsolete links to `mixedreality.mozilla.org`

### DIFF
--- a/files/ja/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.md
+++ b/files/ja/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.md
@@ -264,7 +264,6 @@ render();
 ## 関連情報
 
 - [A-Frame ウェブサイト](https://aframe.io/)
-- [Mozilla Mixed Reality ウェブサイト](https://mixedreality.mozilla.org/)
 - [Introducing A-Frame 0.1.0 article](https://aframe.io/blog/2015/12/16/introducing-aframe/)
 - [Made with A-Frame Tumblr](https://aframevr.tumblr.com/)
 - [A-Frame physics plugin](https://github.com/ngokevin/aframe-physics-components)

--- a/files/ja/games/techniques/3d_on_the_web/webxr/index.md
+++ b/files/ja/games/techniques/3d_on_the_web/webxr/index.md
@@ -28,7 +28,7 @@ Oculus Rift の人気とその他の多くの機器が間もなく市場に登�
 
 現在、 WebVR API のブラウザー対応はまだ実験的です — [nightly builds of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/) と [experimental builds of Chrome](https://drive.google.com/folderview?id=0BzudLt22BqGRbW9WTHMtOWMzNjQ&usp=sharing#list) で動作しますが（Mozilla と Google が一丸となって実装に取り組みます）、遅かれ早かれ通常のビルドで見ることができるようになるでしょう。
 
-[WebVR 仕様](http://mozvr.github.io/webvr-spec/webvr.html)は、編集者草案の状態にあり、これはまだ変更される可能性があることを意味します。 開発は、Mozilla の [Vladimir Vukicevic](https://twitter.com/vvuk) と Google の [Brandon Jones](https://twitter.com/tojiro) が主導しています。 詳細については、 <https://mixedreality.mozilla.org/> および [WebVR.info](https://webvr.info/) のウェブサイトにアクセスしてください。
+[WebVR 仕様](http://mozvr.github.io/webvr-spec/webvr.html)は、編集者草案の状態にあり、これはまだ変更される可能性があることを意味します。 開発は、Mozilla の [Vladimir Vukicevic](https://twitter.com/vvuk) と Google の [Brandon Jones](https://twitter.com/tojiro) が主導しています。 詳細については [WebVR.info](https://webvr.info/) のウェブサイトにアクセスしてください。
 
 ### WebVR API の使用
 

--- a/files/ja/web/api/gamepad/displayid/index.md
+++ b/files/ja/web/api/gamepad/displayid/index.md
@@ -46,5 +46,4 @@ window.addEventListener("gamepadconnected", (e) => {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームのデモ，ダウンロード，その他のリソース．
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/navigator/activevrdisplays/index.md
+++ b/files/ja/web/api/navigator/activevrdisplays/index.md
@@ -39,5 +39,4 @@ function showActive() {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/navigator/getvrdisplays/index.md
+++ b/files/ja/web/api/navigator/getvrdisplays/index.md
@@ -35,5 +35,4 @@ getVRDisplays();
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/cancelanimationframe/index.md
+++ b/files/ja/web/api/vrdisplay/cancelanimationframe/index.md
@@ -99,5 +99,4 @@ function drawVRScene() {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/capabilities/index.md
+++ b/files/ja/web/api/vrdisplay/capabilities/index.md
@@ -29,5 +29,4 @@ slug: Web/API/VRDisplay/capabilities
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/depthfar/index.md
+++ b/files/ja/web/api/vrdisplay/depthfar/index.md
@@ -39,5 +39,4 @@ navigator.getVRDisplays().then(function (displays) {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/depthnear/index.md
+++ b/files/ja/web/api/vrdisplay/depthnear/index.md
@@ -39,5 +39,4 @@ navigator.getVRDisplays().then(function (displays) {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/displayid/index.md
+++ b/files/ja/web/api/vrdisplay/displayid/index.md
@@ -29,5 +29,4 @@ slug: Web/API/VRDisplay/displayId
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/displayname/index.md
+++ b/files/ja/web/api/vrdisplay/displayname/index.md
@@ -31,5 +31,4 @@ slug: Web/API/VRDisplay/displayName
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/exitpresent/index.md
+++ b/files/ja/web/api/vrdisplay/exitpresent/index.md
@@ -88,5 +88,4 @@ if (navigator.getVRDisplays) {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/geteyeparameters/index.md
+++ b/files/ja/web/api/vrdisplay/geteyeparameters/index.md
@@ -40,5 +40,4 @@ getEyeParameters(whichEye);
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/getframedata/index.md
+++ b/files/ja/web/api/vrdisplay/getframedata/index.md
@@ -104,5 +104,4 @@ function drawVRScene() {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/getimmediatepose/index.md
+++ b/files/ja/web/api/vrdisplay/getimmediatepose/index.md
@@ -35,5 +35,4 @@ getImmediatePose();
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/getlayers/index.md
+++ b/files/ja/web/api/vrdisplay/getlayers/index.md
@@ -39,5 +39,4 @@ getLayers();
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/getpose/index.md
+++ b/files/ja/web/api/vrdisplay/getpose/index.md
@@ -63,5 +63,4 @@ if(navigator.getVRDisplays) {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/index.md
+++ b/files/ja/web/api/vrdisplay/index.md
@@ -85,5 +85,4 @@ if (navigator.getVRDisplays) {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/isconnected/index.md
+++ b/files/ja/web/api/vrdisplay/isconnected/index.md
@@ -48,5 +48,4 @@ navigator.getVRDisplays().then(function (displays) {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/ispresenting/index.md
+++ b/files/ja/web/api/vrdisplay/ispresenting/index.md
@@ -50,5 +50,4 @@ function onVRExitPresent() {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/requestanimationframe/index.md
+++ b/files/ja/web/api/vrdisplay/requestanimationframe/index.md
@@ -104,5 +104,4 @@ function drawVRScene() {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/requestpresent/index.md
+++ b/files/ja/web/api/vrdisplay/requestpresent/index.md
@@ -94,5 +94,4 @@ if (navigator.getVRDisplays) {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/resetpose/index.md
+++ b/files/ja/web/api/vrdisplay/resetpose/index.md
@@ -50,5 +50,4 @@ btn.addEventListener("click", function () {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/stageparameters/index.md
+++ b/files/ja/web/api/vrdisplay/stageparameters/index.md
@@ -29,5 +29,4 @@ slug: Web/API/VRDisplay/stageParameters
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplay/submitframe/index.md
+++ b/files/ja/web/api/vrdisplay/submitframe/index.md
@@ -102,5 +102,4 @@ function drawVRScene() {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplaycapabilities/canpresent/index.md
+++ b/files/ja/web/api/vrdisplaycapabilities/canpresent/index.md
@@ -33,5 +33,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplaycapabilities/hasexternaldisplay/index.md
+++ b/files/ja/web/api/vrdisplaycapabilities/hasexternaldisplay/index.md
@@ -33,5 +33,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplaycapabilities/hasorientation/index.md
+++ b/files/ja/web/api/vrdisplaycapabilities/hasorientation/index.md
@@ -31,5 +31,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplaycapabilities/hasposition/index.md
+++ b/files/ja/web/api/vrdisplaycapabilities/hasposition/index.md
@@ -31,5 +31,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplaycapabilities/index.md
+++ b/files/ja/web/api/vrdisplaycapabilities/index.md
@@ -62,5 +62,4 @@ function reportDisplays() {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplaycapabilities/maxlayers/index.md
+++ b/files/ja/web/api/vrdisplaycapabilities/maxlayers/index.md
@@ -31,5 +31,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplayevent/display/index.md
+++ b/files/ja/web/api/vrdisplayevent/display/index.md
@@ -37,5 +37,4 @@ window.addEventListener("vrdisplaypresentchange", (e) => {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplayevent/index.md
+++ b/files/ja/web/api/vrdisplayevent/index.md
@@ -47,5 +47,4 @@ window.addEventListener("vrdisplaypresentchange", (e) => {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplayevent/reason/index.md
+++ b/files/ja/web/api/vrdisplayevent/reason/index.md
@@ -42,5 +42,4 @@ window.addEventListener("vrdisplaypresentchange", (e) => {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrdisplayevent/vrdisplayevent/index.md
+++ b/files/ja/web/api/vrdisplayevent/vrdisplayevent/index.md
@@ -54,5 +54,4 @@ const myEventObject = new VRDisplayEvent("custom", {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vreyeparameters/fieldofview/index.md
+++ b/files/ja/web/api/vreyeparameters/fieldofview/index.md
@@ -31,5 +31,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vreyeparameters/index.md
+++ b/files/ja/web/api/vreyeparameters/index.md
@@ -65,5 +65,4 @@ navigator.getVRDisplays().then((displays) => {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vreyeparameters/maximumfieldofview/index.md
+++ b/files/ja/web/api/vreyeparameters/maximumfieldofview/index.md
@@ -27,6 +27,5 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
+- [WebVR API](/ja/docs/Web/API/WebVR_API)
 - {{domxref("VRFieldOfView")}}
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。

--- a/files/ja/web/api/vreyeparameters/minimumfieldofview/index.md
+++ b/files/ja/web/api/vreyeparameters/minimumfieldofview/index.md
@@ -27,6 +27,5 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
+- [WebVR API](/ja/docs/Web/API/WebVR_API)
 - {{domxref("VRFieldOfView")}}
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。

--- a/files/ja/web/api/vreyeparameters/offset/index.md
+++ b/files/ja/web/api/vreyeparameters/offset/index.md
@@ -35,5 +35,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vreyeparameters/renderheight/index.md
+++ b/files/ja/web/api/vreyeparameters/renderheight/index.md
@@ -33,5 +33,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vreyeparameters/renderwidth/index.md
+++ b/files/ja/web/api/vreyeparameters/renderwidth/index.md
@@ -33,5 +33,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrfieldofview/downdegrees/index.md
+++ b/files/ja/web/api/vrfieldofview/downdegrees/index.md
@@ -31,5 +31,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrfieldofview/index.md
+++ b/files/ja/web/api/vrfieldofview/index.md
@@ -87,5 +87,4 @@ function reportFieldOfView() {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrfieldofview/leftdegrees/index.md
+++ b/files/ja/web/api/vrfieldofview/leftdegrees/index.md
@@ -31,5 +31,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrfieldofview/rightdegrees/index.md
+++ b/files/ja/web/api/vrfieldofview/rightdegrees/index.md
@@ -31,5 +31,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrfieldofview/updegrees/index.md
+++ b/files/ja/web/api/vrfieldofview/updegrees/index.md
@@ -31,5 +31,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrframedata/index.md
+++ b/files/ja/web/api/vrframedata/index.md
@@ -45,5 +45,4 @@ slug: Web/API/VRFrameData
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrframedata/leftprojectionmatrix/index.md
+++ b/files/ja/web/api/vrframedata/leftprojectionmatrix/index.md
@@ -33,5 +33,4 @@ slug: Web/API/VRFrameData/leftProjectionMatrix
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrframedata/leftviewmatrix/index.md
+++ b/files/ja/web/api/vrframedata/leftviewmatrix/index.md
@@ -33,5 +33,4 @@ slug: Web/API/VRFrameData/leftViewMatrix
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrframedata/pose/index.md
+++ b/files/ja/web/api/vrframedata/pose/index.md
@@ -29,5 +29,4 @@ slug: Web/API/VRFrameData/pose
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrframedata/rightprojectionmatrix/index.md
+++ b/files/ja/web/api/vrframedata/rightprojectionmatrix/index.md
@@ -33,5 +33,4 @@ slug: Web/API/VRFrameData/rightProjectionMatrix
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrframedata/rightviewmatrix/index.md
+++ b/files/ja/web/api/vrframedata/rightviewmatrix/index.md
@@ -33,5 +33,4 @@ slug: Web/API/VRFrameData/rightViewMatrix
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrframedata/timestamp/index.md
+++ b/files/ja/web/api/vrframedata/timestamp/index.md
@@ -65,5 +65,4 @@ function drawVRScene() {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrframedata/vrframedata/index.md
+++ b/files/ja/web/api/vrframedata/vrframedata/index.md
@@ -35,5 +35,4 @@ new VRFrameData();
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrlayerinit/index.md
+++ b/files/ja/web/api/vrlayerinit/index.md
@@ -70,5 +70,4 @@ if(navigator.getVRDisplays) {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrlayerinit/leftbounds/index.md
+++ b/files/ja/web/api/vrlayerinit/leftbounds/index.md
@@ -32,5 +32,4 @@ slug: Web/API/VRLayerInit/leftBounds
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrlayerinit/rightbounds/index.md
+++ b/files/ja/web/api/vrlayerinit/rightbounds/index.md
@@ -32,5 +32,4 @@ slug: Web/API/VRLayerInit/rightBounds
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrlayerinit/source/index.md
+++ b/files/ja/web/api/vrlayerinit/source/index.md
@@ -25,5 +25,4 @@ slug: Web/API/VRLayerInit/source
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームによるデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrpose/angularacceleration/index.md
+++ b/files/ja/web/api/vrpose/angularacceleration/index.md
@@ -56,5 +56,4 @@ function drawVRScene() {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrpose/angularvelocity/index.md
+++ b/files/ja/web/api/vrpose/angularvelocity/index.md
@@ -56,5 +56,4 @@ function drawVRScene() {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrpose/index.md
+++ b/files/ja/web/api/vrpose/index.md
@@ -49,5 +49,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrpose/linearacceleration/index.md
+++ b/files/ja/web/api/vrpose/linearacceleration/index.md
@@ -56,5 +56,4 @@ function drawVRScene() {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrpose/linearvelocity/index.md
+++ b/files/ja/web/api/vrpose/linearvelocity/index.md
@@ -56,5 +56,4 @@ function drawVRScene() {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrpose/orientation/index.md
+++ b/files/ja/web/api/vrpose/orientation/index.md
@@ -42,5 +42,4 @@ yaw （y 軸周りの回転）の方向は、センサーを最初に読み込�
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrpose/position/index.md
+++ b/files/ja/web/api/vrpose/position/index.md
@@ -43,5 +43,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrstageparameters/index.md
+++ b/files/ja/web/api/vrstageparameters/index.md
@@ -58,5 +58,4 @@ navigator.getVRDisplays().then((displays) => {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrstageparameters/sittingtostandingtransform/index.md
+++ b/files/ja/web/api/vrstageparameters/sittingtostandingtransform/index.md
@@ -33,5 +33,4 @@ l10n:
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrstageparameters/sizex/index.md
+++ b/files/ja/web/api/vrstageparameters/sizex/index.md
@@ -33,5 +33,4 @@ float で表現された幅（メートル単位）。
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/vrstageparameters/sizey/index.md
+++ b/files/ja/web/api/vrstageparameters/sizey/index.md
@@ -33,5 +33,4 @@ float で表現された奥行き（メートル単位）。
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/webvr_api/index.md
+++ b/files/ja/web/api/webvr_api/index.md
@@ -130,7 +130,6 @@ WebVR API は、以下の API を継承することで、掲載されている�
 
 ## 関連情報
 
-- [vr.mozilla.org](https://mixedreality.mozilla.org/) — Mozilla の WebVR に関するメインのランディングパッドで、デモやユーティリティ、その他の情報が掲載されています。
 - [A-Frame](https://aframe.io/) — VR 体験を構築するためのオープンソースのウェブフレームワーク。
 - [webvr.info](https://webvr.info) — WebVR の最新情報、ブラウザー設定、コミュニティなど。
 - [threejs-vr-boilerplate](https://github.com/MozillaReality/vr-web-examples/tree/master/threejs-vr-boilerplate) — WebVR アプリを書き込むための有益なスターターテンプレートです。

--- a/files/ja/web/api/webxr_device_api/startup_and_shutdown/index.md
+++ b/files/ja/web/api/webxr_device_api/startup_and_shutdown/index.md
@@ -33,7 +33,7 @@ WebXR 仕様を設計しているチームは、WebXR API をサポートして�
 
 #### WebXR API エミュレーター拡張機能
 
-[Mozilla WebXR チーム](https://mixedreality.mozilla.org/)は、WebXR API をエミュレートし、HTC Vive、Oculus Go、Oculus Quest、Samsung Gear、Google Cardboard などの互換性のあるさまざまなデバイスをシミュレートする、Firefox と Chrome の両方と互換性のある [WebXR API Emulator](https://blog.mozvr.com/webxr-emulator-extension/) ブラウザー拡張機能を作成しました。 拡張機能を配置すると、ヘッドセットと任意のハンドコントローラーの位置と向き、およびコントローラーのボタンを制御できる開発者ツールパネルを開くことができます。
+Mozilla WebXR チームは、WebXR API をエミュレートし、HTC Vive、Oculus Go、Oculus Quest、Samsung Gear、Google Cardboard などの互換性のあるさまざまなデバイスをシミュレートする、Firefox と Chrome の両方と互換性のある [WebXR API Emulator](https://blog.mozvr.com/webxr-emulator-extension/) ブラウザー拡張機能を作成しました。 拡張機能を配置すると、ヘッドセットと任意のハンドコントローラーの位置と向き、およびコントローラーのボタンを制御できる開発者ツールパネルを開くことができます。
 
 ##### エミュレーターの使用
 

--- a/files/ja/web/api/window/vrdisplayactivate_event/index.md
+++ b/files/ja/web/api/window/vrdisplayactivate_event/index.md
@@ -70,5 +70,4 @@ window.onvrdisplayactivate = () => {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/window/vrdisplayconnect_event/index.md
+++ b/files/ja/web/api/window/vrdisplayconnect_event/index.md
@@ -70,5 +70,4 @@ window.onvrdisplayconnect = () => {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/window/vrdisplaydeactivate_event/index.md
+++ b/files/ja/web/api/window/vrdisplaydeactivate_event/index.md
@@ -70,5 +70,4 @@ window.onvrdisplaydeactivate = () => {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/window/vrdisplaydisconnect_event/index.md
+++ b/files/ja/web/api/window/vrdisplaydisconnect_event/index.md
@@ -70,5 +70,4 @@ window.onvrdisplaydisconnect = () => {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/api/window/vrdisplaypresentchange_event/index.md
+++ b/files/ja/web/api/window/vrdisplaypresentchange_event/index.md
@@ -74,5 +74,4 @@ window.onvrdisplaypresentchange = () => {
 
 ## 関連情報
 
-- [WebVR API ホームページ](/ja/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> — Mozilla VR チームが提供するデモ、ダウンロード、その他のリソース。
+- [WebVR API](/ja/docs/Web/API/WebVR_API)

--- a/files/ja/web/demos/index.md
+++ b/files/ja/web/demos/index.md
@@ -42,7 +42,7 @@ Mozilla は多種多様なオープンウェブ技術に対応しており、使
 ### バーチャルリアリティ
 
 - The Polar Sea ([source code](https://github.com/MozillaReality/polarsea))
-- [Sechelt fly-through](http://mozvr.github.io/sechelt/) ([source code](https://github.com/MozillaReality/sechelt))
+- [Sechelt fly-through](https://mozvr.github.io/sechelt/) ([source code](https://github.com/MozillaReality/sechelt))
 
 ## CSS
 

--- a/files/ja/web/demos/index.md
+++ b/files/ja/web/demos/index.md
@@ -42,7 +42,7 @@ Mozilla は多種多様なオープンウェブ技術に対応しており、使
 ### バーチャルリアリティ
 
 - The Polar Sea ([source code](https://github.com/MozillaReality/polarsea))
-- [Sechelt fly-through](https://mixedreality.mozilla.org/sechelt/) ([source code](https://github.com/MozillaReality/sechelt))
+- [Sechelt fly-through](http://mozvr.github.io/sechelt/) ([source code](https://github.com/MozillaReality/sechelt))
 
 ## CSS
 


### PR DESCRIPTION
### Description

This PR removes all occurrences of obsolete links to `mixedreality.mozilla.org` in `ja` locale.
https://mixedreality.mozilla.org/ now redirects to https://hubs.mozilla.com/labs/ and has no special relation to VR topic.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/31117