### PR TITLE
[ru] remove `page` macro usage from `Web/JavaScript/Guide/Indexed_collections`

### DIFF
--- a/files/ru/web/javascript/guide/indexed_collections/index.md
+++ b/files/ru/web/javascript/guide/indexed_collections/index.md
@@ -480,8 +480,6 @@ Array.prototype.forEach.call("a string", function (chr) {
 
 Название типизированного представления массива говорит само за себя. Оно представляет массив в распространённых числовых форматах, таких как `Int8`, `Uint32`, `Float64` и так далее. Среди прочих существует специальное представление `Uint8ClampedArray`. Оно ограничивает значения интервалом от 0 до 255. Это полезно, например, при [Обработке данных изображения в Canvas](/ru/docs/Web/API/ImageData).
 
-{{page("/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray", "TypedArray_objects")}}
-
 Для получения подробных сведений смотрите [Типизированные массивы JavaScript](/ru/docs/Web/JavaScript/Typed_arrays) и справочную документацию для {{jsxref("TypedArray")}}.
 
 {{PreviousNext("Web/JavaScript/Guide/Regular_Expressions", "Web/JavaScript/Guide/Keyed_Collections")}}


### PR DESCRIPTION
### Description

This PR removes `page` macro usage from `Web/JavaScript/Guide/Indexed_collections` in `ru` locale

### Related issues and pull requests

Relates to #3892