### PR TITLE
[ru] remove `page` macro usage from `Web/JavaScript/Reference/Global_Objects/Array`

### DIFF
--- a/files/ru/web/javascript/reference/global_objects/array/index.md
+++ b/files/ru/web/javascript/reference/global_objects/array/index.md
@@ -3,22 +3,9 @@ title: Array
 slug: Web/JavaScript/Reference/Global_Objects/Array
 ---
 
-{{JSRef("Global_Objects", "Array")}}
+{{JSRef}}
 
-Массив (**`Array`**) в JavaScript является глобальным объектом, который используется для создания массивов; которые представляют собой высокоуровневые спископодобные объекты.
-
-## Синтаксис
-
-```
-[element0, element1, ..., elementN]
-new Array(element0, element1[, ...[, elementN]])
-new Array(arrayLength)
-```
-
-- `elementN`
-  - : Массив в JavaScript инициализируется с помощью переданных элементов, за исключением случая, когда в конструктор `Array` передаётся один аргумент и этот аргумент является числом (см. ниже). Стоит обратить внимание, что этот особый случай применяется только к JavaScript-массивам, создаваемым с помощью конструктора `Array`, а не к литеральным массивам, создаваемым с использованием скобочного синтаксиса.
-- `arrayLength`
-  - : Если конструктору `Array` передаётся единственный аргумент, являющийся целым числом в диапазоне от 0 до 232-1 (включительно), будет возвращён новый пустой JavaScript-массив, длина которого установится в это число (**примечание**: это означает массив, содержащий `arrayLength` пустых ячеек, а не ячеек со значениями `undefined`). Если аргументом будет любое другое число, возникнет исключение {{jsxref("Global_Objects/RangeError", "RangeError")}}.
+Объект **`Array`**, как и массивы в других языках программирования, позволяет [хранить коллекцию из нескольких элементов под одним именем переменной](/ru/docs/Learn/JavaScript/First_steps/Arrays) и имеет методы для выполнения общих операций с массивами.
 
 ## Описание
 
@@ -134,120 +121,121 @@ const myArray = myRe.exec("cdbBdbsbz");
 | `[0]`            | Элемент только для чтения, определяющий последние сопоставившиеся символы.                                                                                                              | dbBd             |
 | `[1], ...[n]`    | Элементы только для чтения, определяющие сопоставившиеся подстроки, заключённые в круглые скобки, если те включены в регулярное выражение. Количество возможных подстрок не ограничено. | \[1]: bB \[2]: d |
 
-## Свойства
+## Конструктор
 
-- {{jsxref("Array.length")}}
-  - : Значение свойства `length` конструктора массива равно 1.
-- {{jsxref("Array.prototype")}}
-  - : Позволяет добавлять свойства ко всем объектам массива.
+- {{jsxref("Array/Array", "Array()")}}
+  - : Создаёт новый объект `Array`.
 
-## Методы
+## Статические свойства
 
-- {{jsxref("Array.from()")}} {{experimental_inline}}
-  - : Создаёт новый экземпляр `Array` из массивоподобного или итерируемого объекта.
+- {{jsxref("Array/@@species", "Array[@@species]")}}
+  - : Возвращает конструктор `Array`.
+
+## Статические методы
+
+- {{jsxref("Array.from()")}}
+  - : Создаёт новый экземпляр `Array` из итерируемого или массивоподобного объекта.
+- {{jsxref("Array.fromAsync()")}}
+  - : Создаёт новый экземпляр `Array` из асинхронно итерируемого, итерируемого или массивоподобного объекта.
 - {{jsxref("Array.isArray()")}}
-  - : Возвращает `true`, если значение является массивом, иначе возвращает `false`.
-- {{jsxref("Array.observe()")}} {{experimental_inline}}
-  - : Асинхронно наблюдает за изменениями в массиве, подобно методу {{jsxref("Object.observe()")}} для объектов. Метод предоставляет поток изменений в порядке их возникновения.
-- {{jsxref("Array.of()")}} {{experimental_inline}}
-  - : Создаёт новый экземпляр `Array` из любого количества аргументов, независимо от их количества или типа.
+  - : Возвращает `true` если аргумент является массивом и `false` в противном случае.
+- {{jsxref("Array.of()")}}
+  - : Создаёт новый экземпляр `Array` с переменным количеством аргументов, независимо от количества или типа аргументов.
 
-## Экземпляры массива
+## Свойства экземпляра
 
-Все экземпляры массива наследуются от {{jsxref("Array.prototype")}}. Изменения в объекте прототипа конструктора массива затронет все экземпляры `Array`.
+Эти свойства определены в `Array.prototype` и есть у всех экземпляров `Array`.
 
-### Свойства
+- {{jsxref("Object/constructor", "Array.prototype.constructor")}}
+  - : Функция-конструктор, создающая экземпляр объекта. Для экземпляров `Array` начальным значением является конструктор {{jsxref("Array/Array", "Array")}}.
+- {{jsxref("Array/@@unscopables", "Array.prototype[@@unscopables]")}}
+  - : Содержит имена свойств, которые не включены в стандарт ECMAScript до версии ES2015 и которые игнорируются оператором [`with`](/ru/docs/Web/JavaScript/Reference/Statements/with).
 
-{{page('/ru/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype', 'Properties')}}
+Собственные свойства каждого экземпляра `Array`:
 
-### Методы
+- {{jsxref("Array/length", "length")}}
+  - : Отражает количество элементов в массиве.
 
-#### Методы изменения
+## Методы экземпляра
 
-{{page('ru/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype', 'Mutator_methods')}}
-
-#### Методы доступа
-
-{{page('ru/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype', 'Accessor_methods')}}
-
-#### Методы обхода
-
-{{page('ru/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype', 'Iteration_methods')}}
-
-## Общие методы массива
-
-Иногда хочется применить методы массива к строкам или другим массивоподобным объектам (например, к {{jsxref("Functions_and_function_scope/arguments", "аргументам", "", 1)}} функции). Делая это, вы трактуете строку как массив символов (другими словами, рассматриваете не-массив в качестве массива). Например, в порядке проверки каждого символа в переменной _str_ на то, что он является буквой (латинского алфавита), вы пишете следующий код:
-
-```js
-function isLetter(character) {
-  return character >= "a" && character <= "z";
-}
-
-if (Array.prototype.every.call(str, isLetter)) {
-  console.log("Строка '" + str + "' содержит только (латинские) буквы!");
-}
-```
-
-Эта запись довольно расточительна и в JavaScript 1.6 введён общий сокращённый вид:
-
-```js
-if (Array.every(str, isLetter)) {
-  console.log("Строка '" + str + "' содержит только (латинские) буквы!");
-}
-```
-
-{{jsxref("Global_Objects/String", "Общие методы", "#String_generic_methods", 1)}} также доступны для объекта {{jsxref("Global_Objects/String", "String")}}.
-
-В настоящее время они не являются частью стандартов ECMAScript (хотя в ES2015 для достижения поставленной цели можно использовать [`Array.from()`](https://github.com/monolithed/ECMAScript-6)). Следующая прослойка позволяет использовать их во всех браузерах:
-
-```js
-// Предполагаем, что дополнения массива уже присутствуют (для них так же можно использовать polyfill'ы)
-(function () {
-  "use strict";
-
-  // Мы могли построить массив методов следующим образом, однако метод
-  //  getOwnPropertyNames() нельзя реализовать на JavaScript:
-  // Object.getOwnPropertyNames(Array).filter(function(methodName) {
-  //   return typeof Array[methodName] === 'function'
-  // });
-  const methods = [
-    "join",
-    "reverse",
-    "sort",
-    "push",
-    "pop",
-    "shift",
-    "unshift",
-    "splice",
-    "concat",
-    "slice",
-    "indexOf",
-    "lastIndexOf",
-    "forEach",
-    "map",
-    "reduce",
-    "reduceRight",
-    "filter",
-    "some",
-    "every",
-  ];
-  const methodCount = methods.length;
-  const assignArrayGeneric = function (methodName) {
-    if (!Array[methodName]) {
-      const method = Array.prototype[methodName];
-      if (typeof method === "function") {
-        Array[methodName] = function () {
-          return method.call.apply(method, arguments);
-        };
-      }
-    }
-  };
-
-  for (let i = 0; i < methodCount; i++) {
-    assignArrayGeneric(methods[i]);
-  }
-})();
-```
+- {{jsxref("Array.prototype.at()")}}
+  - : Возвращает элемент массива с указанным индексом. Принимает отрицательные значения, для которых отсчёт идёт с конца массива.
+- {{jsxref("Array.prototype.concat()")}}
+  - : Возвращает новый массив, который является объединением текущего с другими массивами или значениями.
+- {{jsxref("Array.prototype.copyWithin()")}}
+  - : Копирует последовательность элементов внутри массива.
+- {{jsxref("Array.prototype.entries()")}}
+  - : Возвращает новый объект [_array iterator_](/ru/docs/Web/JavaScript/Guide/Iterators_and_generators), который содержит пары ключ/значение для каждого индекса в массиве.
+- {{jsxref("Array.prototype.every()")}}
+  - : Возвращает `true` если для каждого элемента массива переданная в качестве аргумента функция возвращает `true`.
+- {{jsxref("Array.prototype.fill()")}}
+  - : Заполняет все элементы массива от начального индекса до последнего указанным значением.
+- {{jsxref("Array.prototype.filter()")}}
+  - : Возвращает новый массив, содержащий все элементы исходного массива, для которых переданная функция вернула `true`.
+- {{jsxref("Array.prototype.find()")}}
+  - : Возвращает значение первого элемента массива, для которого переданная в качестве аргумента функция возвращает `true`, или `undefined` если таких элементов нет.
+- {{jsxref("Array.prototype.findIndex()")}}
+  - : Возвращает индекс первого элемента массива, для которого переданная в качестве аргумента функция возвращает `true`, или `-1` если таких элементов нет.
+- {{jsxref("Array.prototype.findLast()")}}
+  - : Возвращает значение последнего элемента массива, для которого переданная в качестве аргумента функция возвращает `true`, или `undefined` если таких элементов нет.
+- {{jsxref("Array.prototype.findLastIndex()")}}
+  - : Возвращает индекс последнего элемента массива, для которого переданная в качестве аргумента функция возвращает `true`, или `-1` если таких элементов нет.
+- {{jsxref("Array.prototype.flat()")}}
+  - : Возвращает новый массив, содержащий элементы всех вложенных массивов до указанной глубины.
+- {{jsxref("Array.prototype.flatMap()")}}
+  - : Возвращает новый массив, сформированный вызовом переданной функции с каждым элементом, а затем «уплощённый» на один уровень.
+- {{jsxref("Array.prototype.forEach()")}}
+  - : Вызывает функцию для каждого элемента массива.
+- {{jsxref("Array.prototype.includes()")}}
+  - : Возвращает `true`, если массив содержит переданное значение и `false` в противном случае.
+- {{jsxref("Array.prototype.indexOf()")}}
+  - : Возвращает первый (наименьший) индекс, по которому может быть найден переданный элемент.
+- {{jsxref("Array.prototype.join()")}}
+  - : Объединяет все элементы массива в строку.
+- {{jsxref("Array.prototype.keys()")}}
+  - : Возвращает новый объект [_array iterator_](/ru/docs/Web/JavaScript/Guide/Iterators_and_generators), который содержит ключи каждого индекса массива.
+- {{jsxref("Array.prototype.lastIndexOf()")}}
+  - : Возвращает последний (наибольший) индекс, по которому может быть найден переданный элемент или `-1` если таких элементов нет.
+- {{jsxref("Array.prototype.map()")}}
+  - : Возвращает новый массив, содержащий результат применения переданной функции к каждому элементу исходного массива.
+- {{jsxref("Array.prototype.pop()")}}
+  - : Удаляет последний элемент массива и возвращает его значение.
+- {{jsxref("Array.prototype.push()")}}
+  - : Добавляет один или более элементов в конец массива и возвращает новое значение `length` массива.
+- {{jsxref("Array.prototype.reduce()")}}
+  - : Вызывает указанную функцию-редьюсер для каждого элемента массива (слева направо) для получения единственного значения.
+- {{jsxref("Array.prototype.reduceRight()")}}
+  - : Вызывает указанную функцию-редьюсер для каждого элемента массива (справа налево) для получения единственного значения.
+- {{jsxref("Array.prototype.reverse()")}}
+  - : Изменяет порядок элементов массива _на месте_ (то есть изменяя исходный массив) на обратный (первый станет последним, последний — первым).
+- {{jsxref("Array.prototype.shift()")}}
+  - : Удаляет первый элемент массива и возвращает его значение.
+- {{jsxref("Array.prototype.slice()")}}
+  - : Извлекает часть массива и возвращает её в виде нового массива.
+- {{jsxref("Array.prototype.some()")}}
+  - : Возвращает `true` если хотя бы для одного элемента массива переданная в качестве аргумента функция возвращает `true`.
+- {{jsxref("Array.prototype.sort()")}}
+  - : Сортирует элементы массива _на месте_ (то есть изменяя исходный массив) и возвращает массив.
+- {{jsxref("Array.prototype.splice()")}}
+  - : Добавляет и/или удаляет элементы массива.
+- {{jsxref("Array.prototype.toLocaleString()")}}
+  - : Возвращает локализованную строку, представляющую исходный массив и его элементы. Переопределяет метод {{jsxref("Object.prototype.toLocaleString()")}}.
+- {{jsxref("Array.prototype.toReversed()")}}
+  - : Возвращает новый массив с элементами в обратном порядке без изменения исходного массива.
+- {{jsxref("Array.prototype.toSorted()")}}
+  - : Возвращает новый массив с отсортированными по возрастанию элементами без изменения исходного массива.
+- {{jsxref("Array.prototype.toSpliced()")}}
+  - : Возвращает новый массив с удалёнными и/или заменёнными элементами без изменения исходного массива.
+- {{jsxref("Array.prototype.toString()")}}
+  - : Возвращает строку, представляющую исходный массив и его элементы. Переопределяет метод {{jsxref("Object.prototype.toString()")}}.
+- {{jsxref("Array.prototype.unshift()")}}
+  - : Добавляет один или более элементов в начало массива и возвращает новое значение `length` массива.
+- {{jsxref("Array.prototype.values()")}}
+  - : Возвращает новый объект [_array iterator_](/ru/docs/Web/JavaScript/Guide/Iterators_and_generators), который содержит значения каждого индекса массива.
+- {{jsxref("Array.prototype.with()")}}
+  - : Возвращает новый массив с заменённым значением элемента с указанным индексом без изменения исходного массива.
+- [`Array.prototype[@@iterator]()`](/ru/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator)
+  - : Псевдоним метода [`values()`](/ru/docs/Web/JavaScript/Reference/Global_Objects/Array/values).
 
 ## Примеры
 
@@ -418,14 +406,12 @@ r,n,b,q,k,b,n,r
 
 {{Specifications}}
 
-## Поддержка браузерами
+## Совместимость с браузерами
 
 {{Compat}}
 
 ## Смотрите также
 
-- [Руководство JavaScript: «Индексирование объекта свойствами»](/ru/docs/Web/JavaScript/Guide_ru/Working_with_Objects#.D0.98.D0.BD.D0.B4.D0.B5.D0.BA.D1.81.D1.8B_.D1.81.D0.B2.D0.BE.D0.B9.D1.81.D1.82.D0.B2_.D0.BE.D0.B1.D1.8A.D0.B5.D0.BA.D1.82.D0.B0)
-- [Руководство JavaScript: «Предопределённые объекты ядра: объект `Array`»](/ru/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_Object)
-- [Выражения заполнения массива](/ru/docs/Web/JavaScript/Reference/Operators/Array_comprehensions)
-- [Полифил для общих методов массива из JavaScript 1.8.5 и дополнений массива из ECMAScript 5](https://github.com/plusdude/array-generics)
-- [Типизированные массивы](/ru/docs/Web/JavaScript/Typed_arrays)
+- [Упорядоченные наборы данных](/ru/docs/Web/JavaScript/Guide/Indexed_collections)
+- {{jsxref("TypedArray")}}
+- {{jsxref("ArrayBuffer")}}


### PR DESCRIPTION
### Description

This PR removes `page` macro usage from `Web/JavaScript/Reference/Global_Objects/Array` in `ru` locale

### Related issues and pull requests

Relates to #3892