### PR TITLE
[ru] remove `page` macro usage from `Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString`

### DIFF
--- a/files/ru/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
+++ b/files/ru/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
@@ -3,25 +3,41 @@ title: Date.prototype.toLocaleDateString()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
 ---
 
-{{JSRef("Global_Objects", "Date")}}
-
-## Сводка
+{{JSRef}}
 
 Метод **`toLocaleDateString()`** возвращает строку с языкозависимым представлением части с датой в этой дате. Новые аргументы `locales` и `options` позволяют приложениям определять язык, чьи соглашения по форматированию должны использоваться, а также менять поведение этого метода. В старых реализациях, игнорирующих аргументы `locales` и `options`, используемая локаль и форма возвращённой строки целиком зависит от реализации.
 
+При форматировании большого количества дат лучшим вариантом будет создание объекта {{jsxref("Global_Objects/DateTimeFormat", "Intl.DateTimeFormat")}} и использование функции, предоставляемой его свойством {{jsxref("DateTimeFormat.prototype.format", "format")}}.
+
+{{EmbedInteractiveExample("pages/js/date-tolocaledatestring.html", "taller")}}
+
 ## Синтаксис
 
-```
-dateObj.toLocaleDateString([locales [, options]])
+```js-nolint
+toLocaleDateString()
+toLocaleDateString(locales)
+toLocaleDateString(locales, options)
 ```
 
 ### Параметры
 
-Проверьте раздел [Совместимость с браузерами](#Browser_compatibility), чтобы увидеть, какие браузеры поддерживают аргументы `locales` и `options`, и [Пример: проверка поддержки аргументов `locales` и `options`](#Example:_Checking_for_support_for_locales_and_options_arguments) для определения этой возможности.
+Параметры `locales` и `options` изменяют поведение функции и позволяют приложениям определять язык, правила форматирования которого, следует использовать.
 
-{{page('/ru/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat', 'Parameters')}}
+В реализациях, поддерживающих [`Intl.DateTimeFormat` API](/ru/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat), эти параметры соответствуют параметрам конструктора [`Intl.DateTimeFormat()`](/ru/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat). Реализации без поддержки `Intl.DateTimeFormat` должны игнорировать оба параметра, используя локаль и формат возвращаемой строки определяемые самой реализацией.
 
-Значением по умолчанию для каждой компоненты даты-времени является {{jsxref("Global_Objects/undefined", "undefined")}}, однако, если все свойства `weekday`, `year`, `month` и `day` равны {{jsxref("Global_Objects/undefined", "undefined")}}, то их значения предполагаются равными `"numeric"`.
+- `locales` {{optional_inline}}
+
+  - : Строка с языковым тегом BCP 47 или массив таких строк. Соответствует параметру [`locales`](/ru/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#locales) конструктора `Intl.DateTimeFormat().
+
+    В реализациях без поддержки `Intl.DateTimeFormat` этот параметр игнорируется и обычно используется локаль устройства.
+
+- `options` {{optional_inline}}
+
+  - : Объект определяющий выходной формат. Соответствует параметру [`options`](/ru/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options) конструктора `Intl.DateTimeFormat()`. Опция `timeStyle` должна быть `undefined` или будет возникать {{jsxref("TypeError")}}. Если `weekday`, `year`, `month` и `day` одновременно равны `undefined`, то `year`, `month` и `day` будут установлены в `"numeric"`.
+
+    В реализациях без поддержки `Intl.DateTimeFormat` этот параметр игнорируется.
+
+Смотрите описание [конструктора `Intl.DateTimeFormat()`](/ru/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat) для подробностей использования этих параметров.
 
 ## Примеры
 
@@ -114,10 +130,6 @@ console.log(date.toLocaleDateString("en-US", options));
 // → "Thursday, December 20, 2012, GMT"
 ```
 
-## Производительность
-
-При форматировании большого количества дат лучшим вариантом будет создание объекта {{jsxref("Global_Objects/DateTimeFormat", "Intl.DateTimeFormat")}} и использование функции, предоставляемой его свойством {{jsxref("DateTimeFormat.prototype.format", "format")}}.
-
 ## Спецификации
 
 {{Specifications}}
@@ -128,7 +140,7 @@ console.log(date.toLocaleDateString("en-US", options));
 
 ## Смотрите также
 
-- {{jsxref("Global_Objects/DateTimeFormat", "Intl.DateTimeFormat")}}
+- {{jsxref("Intl.DateTimeFormat")}}
 - {{jsxref("Date.prototype.toLocaleString()")}}
 - {{jsxref("Date.prototype.toLocaleTimeString()")}}
 - {{jsxref("Date.prototype.toString()")}}


### PR DESCRIPTION
### Description

This PR removes `page` macro usage from `Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString` in `ru` locale

### Related issues and pull requests

Relates to #3892