### PR TITLE
fix(fr): remove duplicate heading

### DIFF
--- a/files/fr/glossary/spa/index.md
+++ b/files/fr/glossary/spa/index.md
@@ -11,18 +11,16 @@ Cela permet donc aux utilisateurs d'utiliser des sites web sans charger de nouve
 
 ## Voir aussi
 
-### Connaissance générale
-
-Certains des frameworks SPA les plus populaires incluent:
-
-- [React](https://reactjs.org/)
-- [Angular](https://angular.io/)
-- [Vue.JS](https://vuejs.org/)
-
-## Voir aussi
-
 - [Application web monopage](https://fr.wikipedia.org/wiki/Application_web_monopage) sur Wikipédia
-- [API](/fr/docs/Glossary/API)
-- [AJAX](/fr/docs/Glossary/AJAX)
-- [JavaScript](/fr/docs/Glossary/JavaScript)
 - [Comprendre les frameworks JavaScript côté client](/fr/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks)
+- [Glossaire](/fr/docs/Glossary)
+
+  - [API](/fr/docs/Glossary/API)
+  - [AJAX](/fr/docs/Glossary/AJAX)
+  - [JavaScript](/fr/docs/Glossary/JavaScript)
+
+- Certains des frameworks SPA les plus populaires incluent:
+
+  - [React](https://reactjs.org/)
+  - [Angular](https://angular.io/)
+  - [Vue.JS](https://vuejs.org/)

--- a/files/fr/learn/css/css_layout/supporting_older_browsers/index.md
+++ b/files/fr/learn/css/css_layout/supporting_older_browsers/index.md
@@ -121,10 +121,6 @@ Pour de nombreux ajustements de mise en page dans les navigateurs plus anciens, 
 
 Dans la disposition flottante, le pourcentage est calculé à partir du conteneur — 33,333 % correspond à un tiers de la largeur du conteneur. Dans la grille, cependant, ces 33,333 % sont calculés à partir de la zone de la grille dans laquelle l'élément est placé, de sorte qu'il devient en fait un tiers de la taille souhaitée une fois que la disposition en grille est introduite.
 
-### Exemple
-
-#### CSS
-
 ```css
 * {
   box-sizing: border-box;
@@ -147,8 +143,6 @@ Dans la disposition flottante, le pourcentage est calculé à partir du conteneu
 }
 ```
 
-#### HTML
-
 ```html
 <div class="wrapper">
   <div class="item">Item One</div>
@@ -157,7 +151,7 @@ Dans la disposition flottante, le pourcentage est calculé à partir du conteneu
 </div>
 ```
 
-{{EmbedLiveSample('Exemple_2', '', '150')}}
+{{EmbedLiveSample('Méthodes de substitution', '100%', '200')}}
 
 Pour résoudre ce problème, nous devons trouver un moyen de détecter si la grille est prise en charge et donc si elle remplacera la largeur. CSS a une solution pour nous ici.
 
@@ -166,10 +160,6 @@ Pour résoudre ce problème, nous devons trouver un moyen de détecter si la gri
 Les requêtes de fonctionnalités vous permettent de vérifier si un navigateur prend en charge une fonctionnalité CSS particulière. Cela signifie que vous pouvez écrire du CSS pour les navigateurs qui ne prennent pas en charge une certaine fonctionnalité, puis vérifier si le navigateur la prend en charge et, si c'est le cas, intégrer votre mise en page.
 
 Si nous ajoutons une requête de fonctionnalité à l'exemple ci-dessus, nous pouvons l'utiliser pour remettre les largeurs de nos éléments sur `auto` si nous savons que nous avons un support de grille.
-
-### Exemple
-
-#### CSS
 
 ```css
 * {
@@ -199,8 +189,6 @@ Si nous ajoutons une requête de fonctionnalité à l'exemple ci-dessus, nous po
 }
 ```
 
-#### HTML
-
 ```html
 <div class="wrapper">
   <div class="item">Item One</div>
@@ -209,7 +197,7 @@ Si nous ajoutons une requête de fonctionnalité à l'exemple ci-dessus, nous po
 </div>
 ```
 
-{{EmbedLiveSample('Exemple_3', '', '150')}}
+{{EmbedLiveSample('Requêtes de fonctionnalités', '100%', '200') }}
 
 La prise en charge des requêtes de caractéristiques est très bonne dans les navigateurs modernes. Toutefois, vous devez noter que ce sont les navigateurs qui ne prennent pas en charge la grille CSS, qui ne prennent pas non plus en charge les requêtes de fonctionnalités. Cela signifie qu'une approche telle que celle décrite ci-dessus fonctionnera pour ces navigateurs. Ce que nous faisons, c'est écrire notre ancien CSS en premier, en dehors de toute requête de fonctionnalité. Les navigateurs qui ne prennent pas en charge la grille et la requête de fonctionnalité utiliseront les informations de mise en page qu'ils peuvent comprendre et ignoreront complètement tout le reste. Les navigateurs qui prennent en charge la requête de fonctionnalité prennent également en charge CSS Grid et exécuteront donc le code de la grille et le code contenu dans la requête de fonctionnalité.
 

--- a/files/fr/web/api/htmlelement/offsetleft/index.md
+++ b/files/fr/web/api/htmlelement/offsetleft/index.md
@@ -34,8 +34,6 @@ if (tOLeft > 5) {
 }
 ```
 
-### Exemple
-
 Comme noté plus haut, cet exemple montre une «&nbsp;longue&nbsp;» phrase qui déborde dans un div avec une bordure bleue, et une boîte rouge dont on pourrait croire qu'elle décrit les limites du span.
 
 ![](offsetleft.jpg)

--- a/files/fr/web/html/element/title/index.md
+++ b/files/fr/web/html/element/title/index.md
@@ -49,8 +49,6 @@ Les personnes utilisant des outils d'assistance peuvent utiliser le titre de la 
 
 Mettre à jour la valeur de `title` afin de refléter un changement d'état important (un problème de validation d'un formulaire par exemple) peut également s'avérer utile :
 
-#### Exemple
-
 ```html
 <title>
   2 erreurs sur votre commande - Restaurant chinois Maison bleue - Commande en

--- a/files/fr/web/xpath/functions/translate/index.md
+++ b/files/fr/web/xpath/functions/translate/index.md
@@ -38,13 +38,13 @@ XPath note que la fonction `translate` n'est pas une solution suffisante pour la
 
 Cependant, `translate` est à l'heure actuelle la fonction la plus proche d'une fonction pouvant convertir une chaîne en bas de casse ou haut de casse.
 
-#### Exemple
+Exemple
 
 ```xml
 <xsl:value-of select="translate('Le rapide renard.', 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')" />
 ```
 
-#### Sortie
+Sortie
 
 ```
 LE RAPIDE RENARD.
@@ -52,13 +52,13 @@ LE RAPIDE RENARD.
 
 - Si `abc` est plus long que `XYZ`, alors chaque occurrence d'un caractère de `abc` qui n'a pas de correspondance dans `XYZ` sera supprimée.
 
-#### Exemple
+Exemple
 
 ```xml
 <xsl:value-of select="translate('Le renard rapide.', 'renard', 'panda')" />
 ```
 
-#### Sortie
+Sortie
 
 ```
 La pandp pdpia.


### PR DESCRIPTION
### Description

remove duplicate heading

### Motivation

Prepare for enabling [the `no-duplicate-heading` markdown-lint rule](https://github.com/mdn/translated-content/blob/d13c47b2b819b24e7623bb55ad5f24606c537d87/.markdownlint.jsonc#L20-L22).
Part of #17582
