### PR TITLE
Interactive example for backreferences is renamed

### DIFF
--- a/files/ja/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/ja/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -9,7 +9,7 @@ l10n:
 
 グループは複数のパターンを全体としてグループ化し、グループをキャプチャすることで、正規表現パターンを使用して文字列と一致する場合に、追加の副一致情報を提供します。後方参照は、同じ正規表現で以前に捕捉したグループを参照します。
 
-{{EmbedInteractiveExample("pages/js/regexp-groups-ranges.html")}}
+{{EmbedInteractiveExample("pages/js/regexp-groups-backreferences.html")}}
 
 ## 種類
 


### PR DESCRIPTION
### Description

https://github.com/mdn/interactive-examples/pull/2671 の更新に追従する

### Motivation

### Additional details

### Related issues and pull requests

- refs. https://github.com/mozilla-japan/translation/issues/730
- https://github.com/mdn/content/pull/30964
- https://github.com/mdn/interactive-examples/pull/2671