### PR TITLE
fix(es): remove duplicate headings

### DIFF
--- a/files/es/glossary/hoisting/index.md
+++ b/files/es/glossary/hoisting/index.md
@@ -43,8 +43,6 @@ Como se puede observar, aunque primero llamamos a la función en el código, ant
 
 Hoisting se lleva también bien con otros tipos de datos y variables. Observemos el siguiente ejemplo:
 
-### Ejemplo técnico
-
 ```js
 var x = 5;
 

--- a/files/es/learn/css/css_layout/floats/index.md
+++ b/files/es/learn/css/css_layout/floats/index.md
@@ -100,7 +100,11 @@ body {
 }
 ```
 
-Si guardas y recargas la página, verás algo parecido a lo que esperarías: la caja se encuentra por encima del texto, en un flujo normal. Para flotar el texto alrededor, añade las propiedades {{cssxref("float")}} y {{cssxref("margin-right")}} a la regla `.box`:
+Si guardas y recargas la página, verás algo parecido a lo que esperarías: la caja se encuentra por encima del texto, en un flujo normal.
+
+### Flotar la caja
+
+Para flotar la caja, añade las propiedades {{cssxref("float")}} y {{cssxref("margin-right")}} a la regla `.box`:
 
 ```css
 .box {
@@ -115,8 +119,6 @@ Si guardas y recargas la página, verás algo parecido a lo que esperarías: la 
 ```
 
 Ahora, si guardas y recargas, podrás ver algo parecido a lo siguiente:
-
-## Ejemplo
 
 ```html hidden
 <h1>Ejemplo simple de caja flotante</h1>
@@ -160,23 +162,15 @@ body {
     Helvetica,
     sans-serif;
 }
-
-.box {
-  float: left;
-  margin-right: 15px;
-  width: 150px;
-  height: 150px;
-  border-radius: 5px;
-  background-color: rgb(207, 232, 220);
-  padding: 1em;
-}
 ```
 
-{{ EmbedLiveSample('Float_1', '100%', 500) }}
+{{ EmbedLiveSample('Flotar la caja', '100%', 500) }}
 
 Analicemos ahora cómo funciona el _float_ — el elemento con el _float_ aplicado (el elemento {{htmlelement("div")}} en este caso) es sacado del flujo normal del documento y está pegado al lado izquierdo de su elemento contenedor padre ({{htmlelement("body")}}, en este caso). Cualquier contenido que esté por debajo del elemento flotado en el flujo normal, ahora lo envolverá, rellenando el espacio a la derecha hasta la parte superior del elemento flotante. Allí se detendrá.
 
 Flotar el contenido a la derecha tiene exactamente el mismo efecto, pero a la inversa — el elemento flotado se pegará a la derecha, y el contenido lo envolverá por la izquierda. Prueba cambiando el valor de la propiedad _float_ a `right` y reemplaza {{cssxref("margin-right")}} con {{cssxref("margin-left")}} en el último conjunto de reglas para ver el resultado.
+
+### Visualizando el flotador
 
 Si bien podemos agregar un margen al flotante para alejar el texto, no podemos agregar un margen al texto para alejarlo del flotante. Esto se debe a que un elemento flotante se saca del flujo normal y las cajas de los siguientes elementos siguen detrás del flotador. Puedes comprobarlo haciendo algunos cambios en tu ejemplo.
 
@@ -191,8 +185,6 @@ Añade una clase `special` al primer párrafo de texto, el que sucede inmediatam
 ```
 
 Para que el efecto sea más fácil de ver, cambia el `margin-right` de tu elemento flotante a `margin`, para obtener espacio alrededor del elemento flotante. Verás que el fondo del párrafo pasa justo por debajo de la caja flotante, como en el ejemplo inferior.
-
-## Ejemplo
 
 ```html hidden
 <h1>Ejemplo simple de caja flotante</h1>
@@ -246,15 +238,9 @@ body {
   background-color: rgb(207, 232, 220);
   padding: 1em;
 }
-
-.special {
-  background-color: rgb(79, 185, 227);
-  padding: 10px;
-  color: #fff;
-}
 ```
 
-{{ EmbedLiveSample('Float_2', '100%', 500) }}
+{{ EmbedLiveSample('Visualizando el flotador', '100%', 500) }}
 
 Los cuadros de línea de nuestro siguiente elemento se han acortado para que el texto discurra alrededor del flotador, pero debido a que el flotador se eliminó del flujo normal, el cuadro alrededor del párrafo aún permanece en ancho completo.
 
@@ -328,7 +314,7 @@ body {
 }
 ```
 
-{{ EmbedLiveSample('Float_3', '100%', 600) }}
+{{ EmbedLiveSample('Limpiando floats', '100%', 600) }}
 
 Deberías ver que el siguiente párrafo limpia el elemento flotante y ya no aparece junto a él. La propiedad `clear` acepta los siguientes valores:
 
@@ -338,9 +324,13 @@ Deberías ver que el siguiente párrafo limpia el elemento flotante y ya no apar
 
 ## Limpiar las cajas envueltas alrededor de un float
 
-Ahora ya sabes cómo limpiar un elemento que sigue a un elemento flotante, pero observa lo que sucede si tienes un flotante alto y un párrafo corto, con una caja envolviendo a ambos elementos. Modifica tu documento para que el primer párrafo y el cuadro flotante estén envueltos por un {{htmlelement("div")}} con una clase `wrapper`.
+Ahora ya sabes cómo limpiar un elemento que sigue a un elemento flotante, pero observa lo que sucede si tienes un flotante alto y un párrafo corto, con una caja envolviendo a ambos elementos.
 
-```html
+### El problema
+
+Modifica tu documento para que el primer párrafo y el cuadro flotante estén envueltos por un {{htmlelement("div")}} con una clase `wrapper`.
+
+```html live-sample___the_problem
 <div class="wrapper">
   <div class="box">Caja flotante</div>
 
@@ -353,7 +343,7 @@ Ahora ya sabes cómo limpiar un elemento que sigue a un elemento flotante, pero 
 
 En tu CSS, añade la siguiente regla para la clase `.wrapper` y después recarga la página:
 
-```css
+```css live-sample___the_problem
 .wrapper {
   background-color: rgb(79, 185, 227);
   padding: 10px;
@@ -371,9 +361,7 @@ Además, elimina la clase `.cleared` anterior:
 
 Verás que, como en el ejemplo en el que hemos puesto un color de fondo al párrafo, el color de fondo pasa por detrás del elemento flotante.
 
-## Ejemplo
-
-```html hidden
+```html hidden live-sample___the_problem
 <h1>Ejemplo simple de caja flotante</h1>
 <div class="wrapper">
   <div class="box">Caja flotante</div>
@@ -406,7 +394,7 @@ Verás que, como en el ejemplo en el que hemos puesto un color de fondo al párr
 </p>
 ```
 
-```css hidden
+```css hidden live-sample___the_problem
 body {
   width: 90%;
   max-width: 900px;
@@ -415,12 +403,6 @@ body {
     0.9em/1.2 Arial,
     Helvetica,
     sans-serif;
-}
-
-.wrapper {
-  background-color: rgb(79, 185, 227);
-  padding: 10px;
-  color: #fff;
 }
 
 .box {
@@ -434,7 +416,7 @@ body {
 }
 ```
 
-{{ EmbedLiveSample('Float_4', '100%', 600) }}
+{{ EmbedLiveSample('the_problem', '100%', 600) }}
 
 Una vez más, esto se debe a que el flotador se ha sacado del flujo normal. Limpiar el siguiente elemento no ayuda con este problema de limpieza de caja, donde queremos que la parte inferior de la caja envuelva el elemento flotante y envuelva el contenido incluso si el contenido es más corto. Hay tres formas posibles de lidiar con esto, dos que funcionan en todos los navegadores, pero tienen algo de truco, y una tercera, nueva forma de lidiar con esta situación correctamente.
 
@@ -520,7 +502,7 @@ body {
 }
 ```
 
-{{ EmbedLiveSample('Float_5', '100%', 600) }}
+{{ EmbedLiveSample('El hack clearfix', '100%', 600) }}
 
 ### Usando overflow
 
@@ -598,7 +580,7 @@ body {
 }
 ```
 
-{{ EmbedLiveSample('Float_6', '100%', 600) }}
+{{ EmbedLiveSample('Usando overflow', '100%', 600) }}
 
 Este ejemplo funciona creando lo que se conoce como un _**block formatting context**_ (BFC) o contexto de formato de bloque. Es como un pequeño diseño dentro de nuestra página dentro del cual todo está contenido, por lo tanto, nuestro elemento flotante está contenido dentro del BFC y el fondo se encuentra detrás de ambos elementos. Esto generalmente funcionará, sin embargo, en ciertos casos, es posible que encuentre barras de desplazamiento no deseadas o sombras recortadas debido a las consecuencias no deseadas del uso del desbordamiento..
 
@@ -676,7 +658,7 @@ body {
 }
 ```
 
-{{ EmbedLiveSample('Float_7', '100%', 600) }}
+{{ EmbedLiveSample('display: flow-root', '100%', 600) }}
 
 ## Resumen
 

--- a/files/es/learn/css/css_layout/introduction/index.md
+++ b/files/es/learn/css/css_layout/introduction/index.md
@@ -61,7 +61,7 @@ El flujo normal es el modo como el navegador presenta las páginas HTML de forma
 
 Por defecto, el navegador mostrará este código de la manera siguiente:
 
-{{ EmbedLiveSample('Normal_flow', '100%', 200) }}
+{{ EmbedLiveSample('Flujo normal', '100%', 200) }}
 
 Observa aquí cómo se muestra el HTML en el orden exacto en que aparece en el código fuente, con los elementos uno debajo del otro: el primer párrafo, seguido de la lista desordenada, y a continuación el segundo párrafo.
 
@@ -90,6 +90,8 @@ Además de poder cambiar la presentación predeterminada de un elemento `block` 
 ## Flexbox
 
 Flexbox es el nombre corto del [módulo de diseño de cajas flexibles](/es/docs/Web/CSS/CSS_Flexible_Box_Layout), pensado para facilitarnos la distribución de las cosas en una dimensión, ya sea como una fila o como una columna. Para usar el método Flexbox, aplica `display: flex` al elemento padre de los elementos que deseas distribuir; todos sus elementos hijo directos se convierten en elementos flexibles. Vamos a verlo en un ejemplo sencillo.
+
+### Establecer display: flex
 
 El marcado HTML siguiente nos proporciona un elemento contenedor con una clase `wrapper` dentro del cual hay tres elementos {{htmlelement ("div")}}. Por defecto, estos elementos se mostrarían como elementos de bloque, uno debajo del otro, en nuestro documento en español.
 
@@ -121,13 +123,13 @@ Sin embargo, si añadimos `display: flex` al elemento padre, los tres elementos 
 </div>
 ```
 
-{{ EmbedLiveSample('Flex_1', '300', '200') }}
+{{ EmbedLiveSample('Establecer display: flex', '300', '200') }}
+
+### Establecer la propiedad flex
 
 Además de las propiedades anteriores, que pueden aplicarse a contenedores flexibles, también hay propiedades que pueden aplicarse a los elementos flexibles. Estas propiedades, entre otras cosas, pueden cambiar el comportamiento de estos elementos flexibles y permitirles expandirse y contraerse para adaptarse al espacio disponible.
 
 Como un ejemplo sencillo de esto podemos añadir la propiedad {{cssxref ("flex")}} a todos nuestros elementos secundarios, con un valor de `1`. Esto hará que todos los elementos crezcan y llenen el contenedor, en lugar de dejar espacio al final. Si hay más espacio, los artículos se ensancharán; si hay menos espacio, se volverán más estrechos. Además, si añades al código otro elemento, todos los elementos se volverán más pequeños para dejarle espacio; ajustarán el tamaño para ocupar la misma cantidad de espacio, cualquiera que sea.
-
-## Ejemplo
 
 ```css hidden
 * {
@@ -159,13 +161,15 @@ Como un ejemplo sencillo de esto podemos añadir la propiedad {{cssxref ("flex")
 </div>
 ```
 
-{{ EmbedLiveSample('Flex_2', '300', '200') }}
+{{ EmbedLiveSample('Establecer la propiedad flex', '300', '200') }}
 
 > **Nota:** Esta ha sido una breve introducción de lo que permite el método Flexbox. Para obtener más información, consulta nuestro artículo sobre [Flexbox](/es/docs/Learn/CSS/CSS_layout/Flexbox).
 
 ## Diseño de cuadrícula
 
 Mientras que el método Flexbox está pensado para distribuir elementos unidimensionalmente, el diseño de cuadrícula está diseñado para distribuir elementos en dos dimensiones: alinear elementos en filas y columnas.
+
+### Establecer display: grid
 
 Una vez más, puedes activar el diseño de páginas web en cuadrícula con un valor de visualización específico: `display: grid`. El ejemplo siguiente utiliza un marcado similar al del ejemplo del método Flexbox, con un contenedor y algunos elementos secundarios. Además de usar `display: grid`, también definimos algunos tramos de filas y columnas en el elemento padre con las propiedades {{cssxref("grid-template-rows")}} y {{cssxref("grid-template-columns")}}. Hemos definido tres columnas, cada una de `1fr`, y dos filas de `100px`. No necesitamos poner ninguna regla sobre los elementos secundarios porque se colocan automáticamente en las celdas que nuestra cuadrícula ha creado.
 
@@ -201,11 +205,11 @@ Una vez más, puedes activar el diseño de páginas web en cuadrícula con un va
 </div>
 ```
 
-{{ EmbedLiveSample('Grid_1', '300', '330') }}
+{{ EmbedLiveSample('Establecer display: grid', '300', '330') }}
+
+### Colocar elementos en la cuadrícula
 
 Cuando ya tienes una cuadrícula, se puede colocar tus elementos en ella explícitamente en lugar de confiar en el comportamiento de colocación automática que hemos visto arriba. En el segundo ejemplo, hemos definido la misma cuadrícula, pero esta vez con tres elementos secundarios. Hemos establecido la línea de inicio y final de cada elemento con las propiedades {{cssxref ("grid-column")}} y {{cssxref ("grid-row")}}. Esto hace que los elementos abarquen varios tramos.
-
-## Ejemplo
 
 ```css hidden
 * {
@@ -251,7 +255,7 @@ Cuando ya tienes una cuadrícula, se puede colocar tus elementos en ella explíc
 </div>
 ```
 
-{{ EmbedLiveSample('Grid_2', '300', '330') }}
+{{ EmbedLiveSample('Colocar elementos en la cuadrícula', '300', '330') }}
 
 > **Nota:** Estos dos ejemplos son solo una pequeña parte del poder del diseño de cuadrículas; para obtener más información, consulta nuestro artículo sobre [Diseñar cuadrículas](/es/docs/Learn/CSS/CSS_layout/Grids).
 
@@ -317,7 +321,7 @@ p {
 }
 ```
 
-{{ EmbedLiveSample('Float_1', '100%', 600) }}
+{{ EmbedLiveSample('Floats', '100%', 600) }}
 
 > **Nota:** El método de flotación se explica al completo en nuestro artículo sobre [las propiedades float y clear](/es/docs/Learn/CSS/CSS_layout/Floats). El método de flotación es el que se usaba para crear diseños de columnas antes de la aparición de técnicas como los métodos Flexbox y diseño en rejillas. En la red aún puedes toparte con estos métodos. Vamos a exponer todo esto en el artículo sobre [métodos de diseño heredados](/es/docs/Learn/CSS/CSS_layout/Legacy_Layout_Methods).
 
@@ -366,7 +370,7 @@ p {
 
 La salida que se obtiene es la siguiente:
 
-{{ EmbedLiveSample('Simple_positioning_example', '100%', 300) }}
+{{ EmbedLiveSample('Ejemplo sencillo de posicionamiento', '100%', 300) }}
 
 ### El posicionamiento relativo
 
@@ -405,19 +409,14 @@ p {
   margin: 10px;
   border-radius: 5px;
 }
-```
 
-```css
 .positioned {
-  position: relative;
-  background: rgba(255, 84, 104, 0.3);
-  border: 2px solid rgb(255, 84, 104);
-  top: 30px;
-  left: 30px;
+  background: rgb(255 84 104 / 30%);
+  border: 2px solid rgb(255 84 104);
 }
 ```
 
-{{ EmbedLiveSample('Relative_1', '100%', 300) }}
+{{ EmbedLiveSample('El posicionamiento relativo', '100%', 300) }}
 
 ### El posicionamiento absoluto
 
@@ -456,19 +455,14 @@ p {
   margin: 10px;
   border-radius: 5px;
 }
-```
 
-```css
 .positioned {
-  position: absolute;
-  background: rgba(255, 84, 104, 0.3);
-  border: 2px solid rgb(255, 84, 104);
-  top: 30px;
-  left: 30px;
+  background: rgb(255 84 104 / 30%);
+  border: 2px solid rgb(255 84 104);
 }
 ```
 
-{{ EmbedLiveSample('Absolute_1', '100%', 300) }}
+{{ EmbedLiveSample('El posicionamiento absoluto', '100%', 300) }}
 
 ¡Este resultado es muy diferente! El elemento posicionado ahora se ha separado por completo del resto del diseño de la página y se superpone encima de este. Los otros dos párrafos ahora se asientan juntos, como si su hermano con posicionamiento absoluto no existiera. Las propiedades {{cssxref ("top")}} y {{cssxref ("left")}} tienen un efecto diferente en elementos con posicionamiento absoluto que en elementos con posicionamiento relativo. En este caso, los desplazamientos se han calculado desde la parte superior e izquierda de la página. Es posible cambiar el elemento padre para que se convierta en este tipo de contenedor, y lo veremos en el artículo sobre [posicionamiento](/es/docs/Learn/CSS/CSS_layout/Positioning).
 
@@ -479,18 +473,6 @@ El posicionamiento fijo elimina nuestro elemento del flujo de documentos de la m
 En este ejemplo nuestro HTML tiene tres párrafos de texto para poder tener una página que se desplace, y un cuadro al que asignamos la propiedad `position: fixed`.
 
 ```html
-<h1>Posicionamiento fijo</h1>
-
-<div class="positioned">Fijo</div>
-
-<p>Párrafo 1.</p>
-<p>Párrafo 2.</p>
-<p>Párrafo 3.</p>
-```
-
-## Ejemplo
-
-```html hidden
 <h1>Posicionamiento fijo</h1>
 
 <div class="positioned">Fijo</div>
@@ -553,7 +535,7 @@ body {
 }
 ```
 
-{{ EmbedLiveSample('Fixed_1', '100%', 200) }}
+{{ EmbedLiveSample('Posicionamiento fijo', '100%', 200) }}
 
 ### Posicionamiento pegajoso
 
@@ -622,7 +604,7 @@ body {
 }
 ```
 
-{{ EmbedLiveSample('Sticky_1', '100%', 200) }}
+{{ EmbedLiveSample('Posicionamiento pegajoso', '100%', 200) }}
 
 > **Nota:** para obtener más información sobre el posicionamiento, consulta nuestro artículo [Posicionamiento](/es/docs/Learn/CSS/CSS_layout/Positioning).
 
@@ -699,7 +681,7 @@ form p {
 
 Esto nos da el resultado siguiente:
 
-{{ EmbedLiveSample('Table_layout', '100%', '170') }}
+{{ EmbedLiveSample('Diseño de tablas', '100%', '170') }}
 
 También puedes ver este ejemplo en vivo en [css-tables-example.html](https://mdn.github.io/learning-area/css/styling-boxes/box-model-recap/css-tables-example.html) (ver el [código fuente](https://github.com/mdn/learning-area/blob/master/css/styling-boxes/box-model-recap/css-tables-example.html)).
 
@@ -712,19 +694,6 @@ Para convertir un bloque en un contenedor, utilizamos la propiedad {{cssxref ("c
 En el ejemplo siguiente comenzamos con un bloque de HTML dentro de un elemento `<div>` que contiene una clase `container`.
 
 ```html
-<div class="container">
-  <h1>Diseño en columnas</h1>
-
-  <p>Párrafo 1.</p>
-  <p>Párrafo 2.</p>
-</div>
-```
-
-## Ejemplo
-
-Utilizamos un `column-width` de 200 píxeles en ese contenedor, que crea en el navegador tantas columnas de 200 píxeles como quepan en el contenedor y luego comparte el espacio restante entre las columnas creadas.
-
-```html hidden
 <div class="container">
   <h1>Diseño en columnas</h1>
 
@@ -766,7 +735,7 @@ body {
 }
 ```
 
-{{ EmbedLiveSample('Multicol_1', '100%', 200) }}
+{{ EmbedLiveSample('Diseño en columnas', '100%', 200) }}
 
 ## Resumen
 

--- a/files/es/learn/html/introduction_to_html/advanced_text_formatting/index.md
+++ b/files/es/learn/html/introduction_to_html/advanced_text_formatting/index.md
@@ -251,8 +251,6 @@ Si una sección de contenido a nivel de bloque (ya sea un párrafo, varios párr
 </p>
 ```
 
-## Ejemplo
-
 Para convertir esto en una cita en bloque independiente, simplemente harías lo siguiente:
 
 ```html

--- a/files/es/learn/server-side/django/sessions/index.md
+++ b/files/es/learn/server-side/django/sessions/index.md
@@ -25,7 +25,7 @@ Este tutorial extiende nuestro sitio web de la [BibliotecaLocal](/es/docs/Learn/
   </tbody>
 </table>
 
-## Resumen
+## Descripción general
 
 El sitio web de la [BibliotecaLocal](/es/docs/Learn/Server-side/Django/Tutorial_local_library_website) que creamos en los tutoriales previos permite a los usuarios explorar los libros y autores en el catálogo. Mientras que el contenido se genera dinámicamente desde la base de datos, todos los usuarios básicamente tendrán acceso a las mismas páginas y tipos de información cuando usan el sitio.
 

--- a/files/es/web/api/cssrule/index.md
+++ b/files/es/web/api/cssrule/index.md
@@ -37,8 +37,6 @@ Existen varias clases de reglas y todas ellas comparten unas cuantas propiedades
 - [style](/Es/DOM/CssRule.style)
   - : Devuelve el objeto [CSSStyleDeclaration](http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration) para el bloque [declaration block](http://www.w3.org/TR/1998/REC-CSS2-19980512/syndata.html#block) de la regla.
 
-### CSSStyleRule
-
 ### CSSMediaRule
 
 ### CSSFontFaceRule

--- a/files/es/web/api/document/getelementbyid/index.md
+++ b/files/es/web/api/document/getelementbyid/index.md
@@ -59,7 +59,7 @@ Los usuarios nuevos deberían notar que escribir en mayúsculas 'Id' en el nombr
 
 A diferencia de otros métodos similares, getElementById sólo está disponible como un método del objeto global document, y no se encuentra disponible como un método en todos los objetos del DOM. Como los valores ID deben ser únicos a traves del documento, no existe necesidad para versiones "locales" de la función.
 
-## Ejemplo
+### Ejemplo
 
 ```html
 <!doctype html>

--- a/files/es/web/api/event/bubbles/index.md
+++ b/files/es/web/api/event/bubbles/index.md
@@ -5,11 +5,9 @@ slug: Web/API/Event/bubbles
 
 {{ ApiRef("DOM") }}
 
-### Resumen
-
 Indica si el evento determinado _se propaga_ (burbujea) a través del DOM o no. Esta propagación se refiere a si el evento viaja desde el elemento donde se originó hasta los elementos padres en orden de anidamiento.
 
-### Sintaxis
+## Sintaxis
 
 ```
 event.bubbles
@@ -17,7 +15,7 @@ event.bubbles
 
 Retorna un valor Booleano que es `true` si el evento se propaga en el DOM.
 
-### Ejemplo
+## Ejemplo
 
 ```
 var bool = event.bubbles;
@@ -25,7 +23,7 @@ var bool = event.bubbles;
 
 `bool` tiene el valor `true` o `false`, dependiendo de si el evento puede ser burbuja o no.
 
-### Notas
+## Notas
 
 Sólo ciertos eventos pueden ser burbuja. Los eventos que pueden ser burbuja tienen esta propiedad con el valor `true`. Podemos usar esta propiedad para comprobar si un elemento puede ser burbuja o no.
 

--- a/files/es/web/api/window/index.md
+++ b/files/es/web/api/window/index.md
@@ -360,32 +360,9 @@ _Esta interfaz hereda controladores de eventos de la interfaz {{domxref("EventTa
 - {{domxref("Window.onuserproximity")}}
   - : An event handler property for user proximity events
 
-## Constructores
-
-See also the [DOM Interfaces](/es/docs/DOM/DOM_Reference).
-
-- {{domxref("Window.DOMParser")}}
-  - : {{todo("NeedsContents")}}
-- {{domxref("Window.GeckoActiveXObject")}}
-  - : {{todo("NeedsContents")}}
-- {{domxref("Image")}}
-  - : Used for creating an {{domxref("HTMLImageElement")}}.
-- {{domxref("Option")}}
-  - : Used for creating an {{domxref("HTMLOptionElement")}}
-- {{domxref("Window.QueryInterface")}}
-  - : {{todo("NeedsContents")}}
-- {{domxref("Window.XMLSerializer")}}
-  - : {{todo("NeedsContents")}}
-- {{domxref("Worker")}}
-  - : Used for creating a [Web worker](/es/docs/DOM/Using_web_workers)
-- {{domxref("Window.XPCNativeWrapper")}}
-  - : {{todo("NeedsContents")}}
-- {{domxref("Window.XPCSafeJSObjectWrapper")}}
-  - : {{todo("NeedsContents")}}
-
 ## Interfaces
 
-Ver [DOM Reference](/es/docs/DOM/DOM_Reference)
+Ver [DOM Reference](/es/docs/Web/API/Document_Object_Model)
 
 ## Ver Tambien
 

--- a/files/es/web/css/_colon_indeterminate/index.md
+++ b/files/es/web/css/_colon_indeterminate/index.md
@@ -61,7 +61,7 @@ for (var i = 0; i < inputs.length; i++) {
 }
 ```
 
-### Resultado
+#### Resultado
 
 {{EmbedLiveSample('Checkbox_y_radio_button', 'auto', 50)}}
 
@@ -87,7 +87,7 @@ progress:indeterminate {
 }
 ```
 
-### Resultado
+#### Resultado
 
 {{EmbedLiveSample('Barra_de_progreso', 'auto', 30)}}
 

--- a/files/es/web/css/next-sibling_combinator/index.md
+++ b/files/es/web/css/next-sibling_combinator/index.md
@@ -16,11 +16,15 @@ elemento_anterior + elemento_afectado { estilos }
 
 ## Ejemplo
 
+### CSS
+
 ```css
 li:first-of-type + li {
   color: red;
 }
 ```
+
+### HTML
 
 ```html
 <ul>
@@ -30,24 +34,9 @@ li:first-of-type + li {
 </ul>
 ```
 
-{{EmbedLiveSample('Example_1', 200, 100)}}
+### Resultado
 
-## Ejemplo
-
-Otro caso podría ser dar estilos a un span que se use de pie de foto de los siguientes elementos {{HTMLElement("img")}} :
-
-```css
-img + span.caption {
-  font-style: italic;
-}
-```
-
-que coincidiría con los siguientes elementos {{HTMLElement("span")}} :
-
-```html
-<img src="photo1.jpg" /><span class="caption">The first photo</span>
-<img src="photo2.jpg" /><span class="caption">The second photo</span>
-```
+{{EmbedLiveSample('Ejemplo', 200, 100)}}
 
 ## Especificaciones
 

--- a/files/es/web/html/element/input/color/index.md
+++ b/files/es/web/html/element/input/color/index.md
@@ -9,13 +9,7 @@ Los elementos {{HTMLElement("input")}} del tipo «**`color`**» proporciona un e
 
 La presentación del elemento puede variar considerablamente entre navegadores y plataformas: podría ser un campo de entrada sencillo que valida automáticamente que la entrada esté en el formato adecuado, o podría lanzar un selector de colores estándar de la plataforma, o incluso podría abrir una ventana de colores personalizada.
 
-## Ejemplo
-
-```html
-<input type="color" />
-```
-
-{{EmbedLiveSample("summary_example1", 700, 30)}}
+{{EmbedInteractiveExample("pages/tabbed/input-range.html", "tabbed-standard")}}
 
 | **[Value](#value)**             | Una {{domxref("DOMString")}} de siete caracteres que especifica un {{cssxref("&lt;color&gt;")}} en notación hexadecimal en minúsculas |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
@@ -42,7 +36,7 @@ Puede actualizar el ejemplo simple anterior para definir un valor predeterminado
 <input type="color" value="#ff0000" />
 ```
 
-{{EmbedLiveSample("Providing_a_default_color", 700, 30)}}
+{{EmbedLiveSample("Proporcionar un color predeterminado", 700, 30)}}
 
 Si no especifica un valor, se utilizará «`#000000`», negro, de manera predeterminada. El valor debe especificarse en la notación hexadecimal de siete caracteres; esto es, el carácter «#» seguido de dos dígitos para representar el rojo, el verde y el azul: «`#rrggbb`». Si utiliza colores especificados en cualquier otro formato (como los nombres de colores CSS o las funciones cromáticas de CSS como `rgb()` o `rgba()`), deberá convertirlos en valores hexadecimales antes de definir `value`.
 
@@ -161,7 +155,7 @@ Esto define el color de cada uno de los bloques {{HTMLElement("p")}} de manera q
 
 El resultado final es el siguiente:
 
-{{EmbedLiveSample("Example", 700, 200)}}
+{{EmbedLiveSample("Ejemplo", 700, 200)}}
 
 ## Especificaciones
 

--- a/files/es/web/html/element/input/range/index.md
+++ b/files/es/web/html/element/input/range/index.md
@@ -199,9 +199,13 @@ Captura de pantalla
 
 ### Cambiar la orientación
 
+### Crear controles de rango vertical
+
 Por defecto, si un navegador renderiza un input range, lo mostrará como un "slider" (deslizador) que se desliza hacia la izquierda y hacia la derecha. By default, if a browser renders a range input as a slider, it will render it so that the knob slides left and right. Sin embargo puedes cambiar esto fácilmente para que se deslice hacia arriba y hacia abajo simplemente usando CSS
 
 > **Nota:** Esto aún no está implementado por los principales navegadores. This is not actually implemented yet by any of the major browsers. See Firefox [Error 981916 en Firefox](https://bugzil.la/981916), [Chrome bug 341071](https://bugs.chromium.org/p/chromium/issues/detail?id=341071).
+
+#### Control de rango horizontal
 
 Si tenemos el siguiente control range:
 
@@ -209,34 +213,35 @@ Si tenemos el siguiente control range:
 <input type="range" id="volume" min="0" max="11" value="7" step="1" />
 ```
 
-{{EmbedLiveSample("Orientation_sample1", 200, 200, "orientation_sample1.png")}}
+{{EmbedLiveSample("Control de rango horizontal", 200, 40)}}
 
-Dicho control se muestra en horizontal (al menos en los principales navegadores, o otros puede variar). Presentarlo en vertical es tan simple como añadir CSS para cambiar las dimensiones del control, de la siguiente manera:
+Dicho control se muestra en horizontal (al menos en los principales navegadores, o otros puede variar).
 
-#### CSS
+#### Usando la propiedad de appearance
+
+La propiedad {{cssxref('appearance')}} tiene un valor no estándar de `slider-vertical` que, bueno, hace que los controles deslizantes sean verticales.
+
+Usamos el mismo HTML que en los ejemplos anteriores:
+
+```html
+<input type="range" min="0" max="11" value="7" step="1" />
+```
+
+Nos dirigimos solo a las entradas con un tipo de rango:
 
 ```css
-#volume {
-  height: 150px;
-  width: 50px;
+input[type="range"] {
+  appearance: slider-vertical;
 }
 ```
 
-#### HTML
+{{EmbedLiveSample("Usando la propiedad de appearance", 200, 200)}}
 
-```html
-<input type="range" id="volume" min="0" max="11" value="7" step="1" />
-```
-
-#### Result
-
-{{EmbedLiveSample("Orientation_sample2", 200, 200, "orientation_sample2.png")}}
-
-**En la actualidad, ninguno de los navegadores principales soporta la creación de inputs range usando este CSS, incluso a perar de que la especificación recomienda que lo hagan.**
+#### Control de rango vertical
 
 La especificación HTML recomienda que los navegadores cambien la orientación del range si el ancho especificado es menor que el alto. Desafortunadamente, ninguno de los principales navegadores soportar controles range verticales directamente. Para conseguir un range vertical, la forma más fácil es usar CSS, aplicando {{cssxref("transform")}} para rotar el elemento y mostrarlo en vertical. Veamos cómo.
 
-#### HTML
+##### HTML
 
 El HTML necesita que el elemento {{HTMLElement("input")}} esté dentro de un elemento {{HTMLElement("div")}} :
 
@@ -246,7 +251,7 @@ El HTML necesita que el elemento {{HTMLElement("input")}} esté dentro de un ele
 </div>
 ```
 
-#### CSS
+##### CSS
 
 Ahora necesitamos un poco de CSS. Primero escribimos el CSS del div contenedor; especificamos el modo de display y el tamaño que queremos que tenga, reservando un área en la página para el "slider" que vamos a rotar.
 
@@ -273,9 +278,9 @@ Después ponemos la información para el elemento `<input>`:
 
 El tamaño del range es 150 pixeles de ancho por 20 pixeles de alto. Ponemos los márgenes a 0 y con {{cssxref("transform-origin")}} cambiamos centro que usaremos para rotar el range. Como el input mide 150 pixeles de ancho y largo, girará en una cuadrado de 150 pixeles de lado. Colocamos el centro de giro a 75px horizontal y verticalmente y, finalmente, rotamos 90º en sentido contrario a las agujas del reloj. El resultado final es un input range que ha girado y cuyo valor máximo está en la parte superior y el valor mínimo en la parte inferior.
 
-#### Result
+##### Resultado
 
-{{EmbedLiveSample("Orientation_sample3", 200, 200, "orientation_sample3.png")}}
+{{EmbedLiveSample("Control de rango vertical", 200, 200)}}
 
 ## Validación
 

--- a/files/es/web/html/element/title/index.md
+++ b/files/es/web/html/element/title/index.md
@@ -108,8 +108,6 @@ Una técnica de navegación común para los usuarios de tecnología de asistenci
 
 Si el envío de un formulario contiene errores y el envío vuelve a representar la página actual, el título se puede usar para ayudar a que los usuarios se den cuenta de cualquier error en su envío. Por ejemplo, actualice el valor de `title` de la página para reflejar cambios significativos en el estado de la página (como problemas de validación de formularios).
 
-### Ejemplo
-
 ```html
 <title>
   2 errores - Tu orden - Comida china Blue House - FoodYum: ¡Comida a domicilio

--- a/files/es/web/javascript/reference/global_objects/function/name/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/name/index.md
@@ -7,9 +7,11 @@ slug: Web/JavaScript/Reference/Global_Objects/Function/name
 
 La propiedad **`function.name`** retorna el nombre de la función o retorna `"anonymous"` por funciones creadas anónimamente.
 
-{{js_property_attributes(0,0,1)}}Nótese que en implementaciones no estándar previas a ES2015 el atributo `configurable` también era `false`.
+{{js_property_attributes(0,0,1)}}
 
-## Ejemplos
+Nótese que en implementaciones no estándar previas a ES2015 el atributo `configurable` también era `false`.
+
+## Descripción
 
 ### Nombre de una declaración de función
 


### PR DESCRIPTION
### Description

remove duplicate headings. Since I don't speak Spanish, please feel free to correct my mistakes.

### Motivation

Prepare for enabling [the `no-duplicate-heading` markdown-lint rule](https://github.com/mdn/translated-content/blob/d13c47b2b819b24e7623bb55ad5f24606c537d87/.markdownlint.jsonc#L20-L22).
Part of #17582
