### PR TITLE
[ru] update `Web/JavaScript/Reference/Global_Objects/InternalError` translation

### DIFF
--- a/files/ru/web/javascript/reference/global_objects/internalerror/index.md
+++ b/files/ru/web/javascript/reference/global_objects/internalerror/index.md
@@ -1,68 +1,86 @@
 ---
 title: InternalError
 slug: Web/JavaScript/Reference/Global_Objects/InternalError
+l10n:
+  sourceCommit: 5c3c25fd4f2fbd7a5f01727a65c2f70d73f1880a
 ---
 
-{{JSRef("Global_Objects", "Error", "EvalError,InternalError,RangeError,ReferenceError,SyntaxError,TypeError,URIError")}} {{non-standard_header}}
+{{JSRef}}{{Non-standard_Header}}
 
-## Сводка
+Объект **`InternalError`** представляет ошибку, возникающую внутри движка JavaScript.
 
-Объект **`InternalError`** представляет ошибку, возникающую внутри движка JavaScript. Например: "InternalError: too much recursion".
+В основном такие ошибки связаны с тем, что что-то слишком велико, например:
 
-## Синтаксис
+- "too many switch cases",
+- "too many parentheses in regular expression",
+- "array initializer too large",
+- "too much recursion".
 
+`InternalError` является подклассом {{jsxref("Error")}}.
+
+## Конструктор
+
+- {{jsxref("InternalError/InternalError", "InternalError()")}} {{non-standard_inline}}
+  - : Создаёт новый объект `InternalError`.
+
+## Свойства экземпляра
+
+_Также наследует свойства экземпляра своего родителя {{jsxref("Error")}}_.
+
+Эти свойства определены в `InternalError.prototype` и есть у всех экземпляров `InternalError`.
+
+- {{jsxref("Object/constructor", "InternalError.prototype.constructor")}}
+  - : Функция-конструктор, создающая экземпляр объекта. Для экземпляров `InternalError` начальным значением является конструктор {{jsxref("InternalError/InternalError", "InternalError")}}.
+- {{jsxref("Error/name", "InternalError.prototype.name")}}
+  - : Представляет название типа ошибки. Начальным значением `InternalError.prototype.name` является `"InternalError"`.
+
+## Методы экземпляра
+
+_Наследует методы экземпляра своего родителя {{jsxref("Error")}}_.
+
+## Примеры
+
+### Слишком глубокая рекурсия
+
+Эта рекурсивная функция выполняется 10 раз в соответствии с условием выхода.
+
+```js
+function loop(x) {
+  // условие выхода из функции
+  if (x >= 10) return;
+
+  // рекурсивный вызов
+  loop(x + 1);
+}
+
+loop(0);
 ```
-new InternalError([message[, fileName[, lineNumber]]])
+
+Установка для этого условия чрезвычайно высокого значения может не сработать:
+
+```js example-bad
+function loop(x) {
+  if (x >= 1000000000000) return;
+
+  loop(x + 1);
+}
+
+loop(0);
+
+// InternalError: too much recursion
 ```
 
-### Параметры
+Для получения дополнительной информации смотрите [InternalError: too much recursion.](/ru/docs/Web/JavaScript/Reference/Errors/Too_much_recursion)
 
-- `message`
-  - : Необязательный параметр. Человеко-читаемое описание ошибки.
-- `fileName` {{non-standard_inline}}
-  - : Необязательный параметр. Имя файла, содержащего код, вызвавший исключение.
-- `lineNumber` {{non-standard_inline}}
-  - : Необязательный параметр. Номер строки кода, вызвавшей исключение.
+## Specifications
 
-## Описание
+Не является частью какого-либо стандарта.
 
-Исключение `InternalError` выбрасывается при возникновении внутренней ошибки в движке JavaScript.
-
-Как правило, эти ошибки связаны с тем, что что-то стало слишком большим, либо чего-то стало слишком много, например:
-
-- "too many switch cases" — слишком много веток `case` в операторе `switch`;
-- "too many parentheses in regular expression" — слишком много круглых скобок в регулярном выражении;
-- "array initializer too large" — инициализатор массива слишком большой;
-- "too much recursion" — слишком глубокая рекурсия.
-
-## Свойства
-
-- {{jsxref("InternalError.prototype")}}
-  - : Позволяет добавлять свойства в объект `InternalError`.
-
-## Методы
-
-Глобальный объект `InternalError` не содержит собственных методов, однако, он наследует некоторые методы из цепочки прототипов.
-
-## Экземпляры объекта `InternalError`
-
-### Свойства
-
-{{page('/ru/Web/JavaScript/Reference/Global_Objects/InternalError/prototype', 'Properties')}}
-
-### Методы
-
-{{page('/ru/Web/JavaScript/Reference/Global_Objects/InternalError/prototype', 'Methods')}}
-
-## Спецификации
-
-Не является частью какой-либо спецификации.
-
-## Совместимость с браузерами
+## Browser compatibility
 
 {{Compat}}
 
-## Смотрите также
+## See also
 
 - {{jsxref("Error")}}
-- {{jsxref("InternalError.prototype")}}
+- [InternalError: too much recursion](/ru/docs/Web/JavaScript/Reference/Errors/Too_much_recursion)


### PR DESCRIPTION
### Description

This PR updates `Web/JavaScript/Reference/Global_Objects/InternalError` translation for `ru` locale

### Related issues and pull requests

Relates to #3892 