### PR TITLE
zh-cn: sync type for `TypedArray`

### DIFF
--- a/files/zh-cn/web/api/crypto/getrandomvalues/index.md
+++ b/files/zh-cn/web/api/crypto/getrandomvalues/index.md
@@ -18,7 +18,7 @@ cryptoObj.getRandomValues(typedArray);
 ### 参数
 
 - `typedArray`
-  - : 是一个基于整数的 {{jsxref("TypedArray")}}，它可以是 {{jsxref("Int8Array")}}、{{jsxref("Uint8Array")}}、{{jsxref("Int16Array")}}、 {{jsxref("Uint16Array")}}、 {{jsxref("Int32Array")}} 或者 {{jsxref("Uint32Array")}}。在数组中的所有的元素会被随机数重写。（注释：生成的随机数储存在 `typedArray` 数组上。）
+  - : 是一个基于整数的 {{jsxref("TypedArray")}}，它可以是 {{jsxref("Int8Array")}}、{{jsxref("Uint8Array")}}、{{jsxref("Int16Array")}}、 {{jsxref("Uint16Array")}}、 {{jsxref("Int32Array")}} 或者 {{jsxref("Uint32Array")}}（**不可**使用 `Float32Array` 或者 `Float64Array`）。在数组中的所有的元素会被随机数重写。（注释：生成的随机数储存在 `typedArray` 数组上。）
 
 ### 异常事件
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Translate `(but not Float32Array nor Float64Array)` from en-us.

### Motivation

Sync with en-us

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues#typedarray

### Related issues and pull requests

None