### PR TITLE
[zh-cn] unify `{{JSRef}}` macro usage (remove obsolete parameters)

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/date/getdate/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/getdate/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getDate()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getDate
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 根据本地时间，返回一个指定的日期对象为一个月中的哪一日（从 1--31）。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/gethours/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/gethours/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getHours()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getHours
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`getHours()`** 方法根据本地时间，返回一个指定的日期对象的小时。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/getmilliseconds/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/getmilliseconds/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getMilliseconds()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getMilliseconds
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`getMilliseconds()`** 方法根据本地时间，返回一个指定的日期对象的毫秒数。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/getminutes/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/getminutes/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getMinutes()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getMinutes
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`getMinutes()`** 方法根据本地时间，返回一个指定的日期对象的分钟数。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/getseconds/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/getseconds/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getSeconds()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getSeconds
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`getSeconds()`** 方法根据本地时间，返回一个指定的日期对象的秒数。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/gettimezoneoffset/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/gettimezoneoffset/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getTimezoneOffset()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`getTimezoneOffset()`** 方法返回协调世界时（UTC）相对于当前时区的时间差值，单位为分钟。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/getutcdate/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/getutcdate/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getUTCDate()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getUTCDate
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`getUTCDate()`** 方法以世界时为标准，返回一个指定的日期对象为一个月中的第几天
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/getutcday/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/getutcday/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getUTCDay()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getUTCDay
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`getUTCDay()`** 方法以世界时为标准，返回一个指定的日期对象为一星期中的第几天，其中 0 代表星期天。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/getutcfullyear/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/getutcfullyear/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getUTCFullYear()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getUTCFullYear
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`getUTCFullYear()`** 以世界时为标准，返回一个指定的日期对象的年份。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/getutchours/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/getutchours/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getUTCHours()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getUTCHours
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`getUTCHours()`** 方法以世界时为标准，返回一个指定的日期对象的小时数。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/getutcmilliseconds/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/getutcmilliseconds/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getUTCMilliseconds()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getUTCMilliseconds
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`getUTCMilliseconds()`** 方法以世界时为标准，返回一个指定的日期对象的毫秒数。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/getutcminutes/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/getutcminutes/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getUTCMinutes()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getUTCMinutes
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`getUTCMinutes()`** 方法以世界时为标准，返回一个指定的日期对象的分钟数。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/getutcmonth/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/getutcmonth/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getUTCMonth()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getUTCMonth
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`getUTCMonth()`** 方法以世界时为标准，返回一个指定的日期对象的月份，它是从 0 开始计数的（0 代表一年的第一个月）。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/getutcseconds/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/getutcseconds/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getUTCSeconds()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getUTCSeconds
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`getUTCSeconds()`** 方法以世界时为标准，返回一个指定的日期对象的秒数。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/getyear/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/getyear/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getYear()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getYear
 ---
 
-{{JSRef("Global_Objects", "Date")}} {{Deprecated_header("")}}
+{{JSRef}} {{Deprecated_header("")}}
 
 **`getYear()`** 方法返回指定的本地日期的年份。因为 `getYear()` 不返回千禧年（"year 2000 problem"），所以这个方法不再被使用，现在替换为 {{jsxref("Date.getFullYear", "getFullYear")}}。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/parse/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/parse/index.md
@@ -3,7 +3,7 @@ title: Date.parse()
 slug: Web/JavaScript/Reference/Global_Objects/Date/parse
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`Date.parse()`** 方法解析一个表示某个日期的字符串，并返回从 1970-1-1 00:00:00 UTC 到该日期对象（该日期对象的 UTC 时间）的毫秒数，如果该字符串无法识别，或者一些情况下，包含了不合法的日期数值（如：2015-02-31），则返回值为 NaN。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/setdate/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/setdate/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.setDate()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setDate
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`setDate()`** 方法根据本地时间来指定一个日期对象的天数。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/setfullyear/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/setfullyear/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.setFullYear()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setFullYear
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`setFullYear()`** 方法根据本地时间为一个日期对象设置年份。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/sethours/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/sethours/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.setHours()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setHours
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`setHours()`** 方法根据本地时间为一个日期对象设置小时数，返回从 1970-01-01 00:00:00 UTC 到更新后的 {{jsxref("Global_Objects/Date", "日期")}} 对象实例所表示时间的毫秒数。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/setminutes/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/setminutes/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.setMinutes()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setMinutes
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`setMinutes()`** 方法根据本地时间为一个日期对象设置分钟数。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/setmonth/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/setmonth/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.setMonth()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setMonth
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`setMonth()`** 方法根据本地时间为一个日期对象设置月份。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/setseconds/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/setseconds/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.setSeconds()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setSeconds
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`setSeconds()`** 方法根据本地时间设置一个日期对象的秒数。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/settime/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/settime/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.setTime()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setTime
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`setTime()`** 方法以一个表示从 1970-1-1 00:00:00 UTC 计时的毫秒数为来为 `Date` 对象设置时间。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/setutcdate/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/setutcdate/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.setUTCDate()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setUTCDate
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`setUTCDate()`** 方法就是根据全球时间设置特定 date 对象的日期。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/todatestring/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/todatestring/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.toDateString()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toDateString
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`toDateString()`** 方法以美式英语和人类易读的形式返回一个日期对象日期部分的字符串。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/totimestring/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/totimestring/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.toTimeString()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toTimeString
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`toTimeString()`** 方法以人类易读形式返回一个日期对象时间部分的字符串，该字符串以美式英语格式化。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/toutcstring/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/toutcstring/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.toUTCString()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toUTCString
 ---
 
-{{JSRef("Global_Objects", "Date")}}
+{{JSRef}}
 
 **`toUTCString()`** 方法把一个日期转换为一个字符串，使用 UTC 时区。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/error/message/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/error/message/index.md
@@ -3,7 +3,7 @@ title: Error.prototype.message
 slug: Web/JavaScript/Reference/Global_Objects/Error/message
 ---
 
-{{JSRef("Global_Objects", "Error", "EvalError,InternalError,RangeError,ReferenceError,SyntaxError,TypeError,URIError")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/error/name/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/error/name/index.md
@@ -3,7 +3,7 @@ title: Error.prototype.name
 slug: Web/JavaScript/Reference/Global_Objects/Error/name
 ---
 
-{{JSRef("Global_Objects", "Error", "EvalError,InternalError,RangeError,ReferenceError,SyntaxError,TypeError,URIError")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/acos/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/acos/index.md
@@ -3,7 +3,7 @@ title: Math.acos()
 slug: Web/JavaScript/Reference/Global_Objects/Math/acos
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/asin/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/asin/index.md
@@ -3,7 +3,7 @@ title: Math.asin()
 slug: Web/JavaScript/Reference/Global_Objects/Math/asin
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/atan/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/atan/index.md
@@ -3,7 +3,7 @@ title: Math.atan()
 slug: Web/JavaScript/Reference/Global_Objects/Math/atan
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/atan2/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/atan2/index.md
@@ -3,7 +3,7 @@ title: Math.atan2()
 slug: Web/JavaScript/Reference/Global_Objects/Math/atan2
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/cbrt/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/cbrt/index.md
@@ -3,7 +3,7 @@ title: Math.cbrt()
 slug: Web/JavaScript/Reference/Global_Objects/Math/cbrt
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 **`Math.cbrt()`** 函数返回任意数字的立方根。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/clz32/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/clz32/index.md
@@ -3,7 +3,7 @@ title: Math.clz32()
 slug: Web/JavaScript/Reference/Global_Objects/Math/clz32
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/cos/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/cos/index.md
@@ -3,7 +3,7 @@ title: Math.cos()
 slug: Web/JavaScript/Reference/Global_Objects/Math/cos
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/e/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/e/index.md
@@ -3,7 +3,7 @@ title: Math.E
 slug: Web/JavaScript/Reference/Global_Objects/Math/E
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/exp/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/exp/index.md
@@ -3,7 +3,7 @@ title: Math.exp()
 slug: Web/JavaScript/Reference/Global_Objects/Math/exp
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/fround/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/fround/index.md
@@ -3,7 +3,7 @@ title: Math.fround()
 slug: Web/JavaScript/Reference/Global_Objects/Math/fround
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/imul/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/imul/index.md
@@ -3,7 +3,9 @@ title: Math.imul()
 slug: Web/JavaScript/Reference/Global_Objects/Math/imul
 ---
 
-{{JSRef("Global_Objects", "Math")}}该函数将两个参数分别转换为 32 位整数，相乘后返回 32 位结果，类似 C 语言的 32 位整数相乘。
+{{JSRef}}
+
+该函数将两个参数分别转换为 32 位整数，相乘后返回 32 位结果，类似 C 语言的 32 位整数相乘。
 
 {{EmbedInteractiveExample("pages/js/math-imul.html")}}
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/ln10/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/ln10/index.md
@@ -3,7 +3,7 @@ title: Math.LN10
 slug: Web/JavaScript/Reference/Global_Objects/Math/LN10
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/ln2/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/ln2/index.md
@@ -3,7 +3,7 @@ title: Math.LN2
 slug: Web/JavaScript/Reference/Global_Objects/Math/LN2
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/log/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/log/index.md
@@ -3,7 +3,7 @@ title: Math.log()
 slug: Web/JavaScript/Reference/Global_Objects/Math/log
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/log10/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/log10/index.md
@@ -3,7 +3,7 @@ title: Math.log10()
 slug: Web/JavaScript/Reference/Global_Objects/Math/log10
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/log10e/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/log10e/index.md
@@ -3,7 +3,7 @@ title: Math.LOG10E
 slug: Web/JavaScript/Reference/Global_Objects/Math/LOG10E
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/log1p/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/log1p/index.md
@@ -3,7 +3,7 @@ title: Math.log1p()
 slug: Web/JavaScript/Reference/Global_Objects/Math/log1p
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/log2/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/log2/index.md
@@ -3,7 +3,7 @@ title: Math.log2()
 slug: Web/JavaScript/Reference/Global_Objects/Math/log2
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/log2e/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/log2e/index.md
@@ -3,7 +3,7 @@ title: Math.LOG2E
 slug: Web/JavaScript/Reference/Global_Objects/Math/LOG2E
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/pi/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/pi/index.md
@@ -3,7 +3,7 @@ title: Math.PI
 slug: Web/JavaScript/Reference/Global_Objects/Math/PI
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/sin/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/sin/index.md
@@ -3,7 +3,7 @@ title: Math.sin()
 slug: Web/JavaScript/Reference/Global_Objects/Math/sin
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/sinh/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/sinh/index.md
@@ -3,7 +3,7 @@ title: Math.sinh()
 slug: Web/JavaScript/Reference/Global_Objects/Math/sinh
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/sqrt1_2/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/sqrt1_2/index.md
@@ -3,7 +3,7 @@ title: Math.SQRT1_2
 slug: Web/JavaScript/Reference/Global_Objects/Math/SQRT1_2
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/sqrt2/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/sqrt2/index.md
@@ -3,7 +3,7 @@ title: Math.SQRT2
 slug: Web/JavaScript/Reference/Global_Objects/Math/SQRT2
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/math/tan/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/math/tan/index.md
@@ -3,7 +3,7 @@ title: Math.tan()
 slug: Web/JavaScript/Reference/Global_Objects/Math/tan
 ---
 
-{{JSRef("Global_Objects", "Math")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
@@ -3,7 +3,7 @@ title: handler.getPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getPrototypeOf
 ---
 
-{{JSRef("Global_Objects", "Proxy")}}
+{{JSRef}}
 
 **`handler.getPrototypeOf()`** 是一个代理（Proxy）方法，当读取代理对象的原型时，该方法就会被调用。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/proxy/revocable/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/proxy/revocable/index.md
@@ -3,7 +3,7 @@ title: Proxy.revocable()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/revocable
 ---
 
-{{JSRef("Global_Objects", "Proxy")}}
+{{JSRef}}
 
 **`Proxy.revocable()`** 方法可以用来创建一个可撤销的代理对象。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/global/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/global/index.md
@@ -3,7 +3,7 @@ title: RegExp.prototype.global
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/global
 ---
 
-{{JSRef("Global_Objects", "RegExp")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/ignorecase/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/ignorecase/index.md
@@ -3,7 +3,7 @@ title: RegExp.prototype.ignoreCase
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase
 ---
 
-{{JSRef("Global_Objects", "RegExp")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/lastindex/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/lastindex/index.md
@@ -3,7 +3,7 @@ title: RegExp.lastIndex
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex
 ---
 
-{{JSRef("Global_Objects", "RegExp")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/multiline/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/multiline/index.md
@@ -3,7 +3,7 @@ title: RegExp.prototype.multiline
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/multiline
 ---
 
-{{JSRef("Global_Objects", "RegExp")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/source/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/source/index.md
@@ -3,7 +3,7 @@ title: RegExp.prototype.source
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/source
 ---
 
-{{JSRef("Global_Objects", "RegExp")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/tostring/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/tostring/index.md
@@ -3,7 +3,7 @@ title: RegExp.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/toString
 ---
 
-{{JSRef("Global_Objects", "RegExp")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/string/raw/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/string/raw/index.md
@@ -3,7 +3,7 @@ title: String.raw()
 slug: Web/JavaScript/Reference/Global_Objects/String/raw
 ---
 
-{{JSRef()}}
+{{JSRef}}
 
 **`String.raw()`** 静态方法是[模板字符串](/zh-CN/docs/Web/JavaScript/Reference/template_strings)的标签函数。它的作用类似于 Python 中的 `r` 前缀或 C# 中用于字符串字面量的 `@` 前缀。它用于获取模板字符串的原始字符串形式——即，替换表达式（例如 `${foo}`）会被替换处理，但转义序列（例如 `\n`）不会被处理。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/symbol/keyfor/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/symbol/keyfor/index.md
@@ -3,7 +3,7 @@ title: Symbol.keyFor()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/keyFor
 ---
 
-{{JSRef("Global_Objects", "Symbol")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/symbol/tostring/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/symbol/tostring/index.md
@@ -3,7 +3,7 @@ title: Symbol.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/toString
 ---
 
-{{JSRef("Global_Objects", "Symbol")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/symbol/valueof/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/symbol/valueof/index.md
@@ -3,7 +3,7 @@ title: Symbol.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/valueOf
 ---
 
-{{JSRef("Global_Objects", "Symbol")}}
+{{JSRef}}
 
 ## 概述
 

--- a/files/zh-cn/web/javascript/reference/global_objects/typedarray/bytes_per_element/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/typedarray/bytes_per_element/index.md
@@ -3,7 +3,7 @@ title: TypedArray.BYTES_PER_ELEMENT
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/BYTES_PER_ELEMENT
 ---
 
-{{JSRef("Global_Objects", "TypedArray", "Int8Array,Uint8Array,Uint8ClampedArray,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array")}}
+{{JSRef}}
 
 ## 概要
 

--- a/files/zh-cn/web/javascript/reference/global_objects/uint32array/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/uint32array/index.md
@@ -3,7 +3,7 @@ title: Uint32Array
 slug: Web/JavaScript/Reference/Global_Objects/Uint32Array
 ---
 
-{{JSRef("Global_Objects", "TypedArray", "Int8Array,Uint8Array,Uint8ClampedArray,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array")}}
+{{JSRef}}
 
 **`Uint32Array`** 表示一个由基于平台字节序的 32 位无符号字节组成的数组。如果需要对字节顺序进行控制 (译者注：即 littleEndian 或 bigEndian)，请使用 {{jsxref("DataView")}} 代替。数组中每个元素的初始值都是`0`。一旦创建，你可以用对象的方法引用数组里的元素，或者使用标准的数组索引语法（即，使用中括号）。
 


### PR DESCRIPTION
### Description

This PR unifies `{{JSRef}}` macro usage by removing obsolete parameters (https://github.com/mdn/yari/blob/main/kumascript/macros/JSRef.ejs) for `zh-cn` locale.

### Related issues and pull requests

Relates to #17981, #17987, #17988