### PR TITLE
[zh-tw] unify `{{JSRef}}` macro usage (remove obsolete parameters)

### DIFF
--- a/files/zh-tw/web/javascript/reference/global_objects/string/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/string/index.md
@@ -3,7 +3,7 @@ title: 字串
 slug: Web/JavaScript/Reference/Global_Objects/String
 ---
 
-{{JSRef("Global_Objects", "String")}}
+{{JSRef}}
 
 **`String`** 全域物件為字串的構造函數，或是一個字符序列。
 


### PR DESCRIPTION
### Description

This PR unifies `{{JSRef}}` macro usage by removing obsolete parameters (https://github.com/mdn/yari/blob/main/kumascript/macros/JSRef.ejs) for `zh-tw` locale.

### Related issues and pull requests

Relates to #17981, #17987, #17988, #17989