### PR TITLE
[fr] unify `{{AddonSidebar}}` macro usage (remove unnecessary parentheses)

### DIFF
--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/create/index.md
@@ -3,7 +3,7 @@ title: alarms.create()
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/create
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Cette méthode permet de créer une nouvelle alarme pour la session de navigation en cours. Une alarme peut se déclencher une ou plusieurs fois. Une alarme est effacée après qu'elle se soit déclenchée pour la dernière fois.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -3,7 +3,7 @@ title: bookmarks.BookmarkTreeNode
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet de type `bookmarks.BookmarkTreeNode` représente un nœud dans l'arborescence de signets, où chaque nœud est un signet, un dossier de signet ou un séparateur. Les noeuds enfants sont classés par `index` dans leurs dossiers parents respectifs.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
@@ -3,7 +3,7 @@ title: bookmarks.BookmarkTreeNodeType
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type **`bookmarks.BookmarkTreeNodeType`** est utilisé pour décrire si un nœud de l'arborescence de signets est un signet, un dossier ou un séparateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
@@ -3,7 +3,7 @@ title: bookmarks.BookmarkTreeNodeUnmodifiable
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeUnmodifiable
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un type **`bookmarks.BookmarkTreeNodeUnmodifiable`** est utilisé pour indiquer la raison pour laquelle un nœud de l'arborescence de signets (où chaque nœud est un signet ou un dossier de signets) ne peut pas être modifié. Ceci est utilisé comme valeur du champ {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "bookmarks.BookmarkTreeNode.unmodifiable", "unmodifiable")}} sur les nœuds de signets.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
@@ -3,7 +3,7 @@ title: bookmarks.create()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/create
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Crée un signet ou un dossier en tant qu'enfant de {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "BookmarkTreeNode")}} avec `parentId` spécifié. Pour créer un dossier, omettez ou laissez vide le paramètre {{WebExtAPIRef("bookmarks.CreateDetails", "CreateDetails", "url")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
@@ -3,7 +3,7 @@ title: bookmarks.CreateDetails
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/CreateDetails
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `CreateDetails` est utilisé pour décrire les propriétés d'un nouveau, d'un signet, d'un dossier de signets ou d'un séparateur lors de l'appel de la méthode {{WebExtAPIRef("bookmarks.create()")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
@@ -3,7 +3,7 @@ title: bookmarks.get()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/get
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Étant donné l'ID d'un {{WebExtAPIRef("bookmarks.BookmarkTreeNode")}} ou d'un tableau de ces ID, la méthode **`bookmarks.get()`** récupère les nœuds correspondants.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
@@ -3,7 +3,7 @@ title: bookmarks.getChildren()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/getChildren
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 **`bookmarks.getChildren()`** récupère tous les enfants immédiats d'un dossier de signets donné, identifié comme {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "BookmarkTreeNode")}} ID.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
@@ -3,7 +3,7 @@ title: bookmarks.getRecent()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/getRecent
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La méthode `bookmarks.getRecent()` récupère un nombre spécifié de signets ajoutés le plus récemment en tant que tableau d'objets {{WebExtAPIRef('bookmarks.BookmarkTreeNode', 'BookmarkTreeNode')}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
@@ -3,7 +3,7 @@ title: bookmarks.getSubTree()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/getSubTree
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La méthode **`bookmarks.getSubTree()`** récupère de façon asynchrone un {{WebExtAPIRef("bookmarks.BookmarkTreeNode")}}, étant donné son ID.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
@@ -3,7 +3,7 @@ title: bookmarks.getTree()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/getTree
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 **`bookmarks.getTree()`** renvoie un tableau contenant la racine de l'arborescence des signets en tant qu'objet {{WebExtAPIRef("bookmarks.BookmarkTreeNode")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
@@ -3,7 +3,7 @@ title: bookmarks.move()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/move
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La méthode **`bookmarks.move()`** déplace le {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "BookmarkTreeNode")}} à la destination spécifiée dans l'arborescence des signets. Cela vous permet de déplacer un signet vers un nouveau dossier et / ou une position dans le dossier.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
@@ -3,7 +3,7 @@ title: bookmarks.onChildrenReordered
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onChildrenReordered
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque les enfants d'un dossier ont changé leur commande en raison de la commande triée dans l'interface utilisateur. Cela n'est pas appelé à la suite d'un appel à {{WebExtAPIRef("bookmarks.move()")}} ou une opération glisser dans l'interface utilisateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
@@ -3,7 +3,7 @@ title: bookmarks.onCreated
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onCreated
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'un élément de signet (un signet ou un dossier) est créé.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
@@ -3,7 +3,7 @@ title: bookmarks.onImportBegan
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onImportBegan
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque le navigateur a commencé à importer un ensemble de signet.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
@@ -3,7 +3,7 @@ title: bookmarks.onImportEnded
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onImportEnded
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque le navigateur a fini d'importer un ensemble de signets.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
@@ -3,7 +3,7 @@ title: bookmarks.onMoved
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onMoved
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'un signet ou un dossier est déplacé vers un autre dossier parent et / ou position dans un dossier.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.md
@@ -3,7 +3,7 @@ title: bookmarks.onRemoved
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onRemoved
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'un signet ou un dossier est supprimé. Lorsqu'un dossier est supprimé de manière récursive, une seule notification est envoyée pour le dossier et aucune pour son contenu.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
@@ -3,7 +3,7 @@ title: bookmarks.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/remove
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La méthode **`bookmarks.remove()`** supprime un seul signet ou un dossier de signets vide.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
@@ -3,7 +3,7 @@ title: bookmarks.removeTree()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/removeTree
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La méthode **`bookmarks.removeTree()`** supprime récursivement un dossier de signets et tout son contenu.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
@@ -3,7 +3,7 @@ title: bookmarks.search()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/search
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`bookmarks.search()`** recherche les nœuds d'arborescence de signets correspondant à la requête donnée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
@@ -3,7 +3,7 @@ title: bookmarks.update()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/update
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 **`bookmarks.update()`** met à jour le titre et / ou l'URL d'un signet ou le nom d'un dossier de signets.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
@@ -3,7 +3,7 @@ title: browserAction.ColorArray
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/ColorArray
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 ## Type
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
@@ -3,7 +3,7 @@ title: browserAction.disable()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/disable
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Désactive l'action du navigateur pour un onglet, ce qui signifie qu'il ne peut pas être cliqué lorsque cet onglet est actif.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
@@ -3,7 +3,7 @@ title: browserAction.enable()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/enable
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Active l'action du navigateur pour un onglet. Par défaut, les actions du navigateur sont activées pour tous les onglets.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
@@ -3,7 +3,7 @@ title: browserAction.getBadgeBackgroundColor()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeBackgroundColor
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient la couleur d'arrière plan du badge de l'action du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
@@ -3,7 +3,7 @@ title: browserAction.getBadgeText()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeText
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient le texte du badge de l'action du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
@@ -3,7 +3,7 @@ title: browserAction.getBadgeTextColor()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeTextColor
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient la couleur du texte du badge de l'action du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
@@ -3,7 +3,7 @@ title: browserAction.getPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/getPopup
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient le document HTML défini comme la popup pour cette action du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
@@ -3,7 +3,7 @@ title: browserAction.getTitle()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/getTitle
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient le titre de l'action du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.md
@@ -3,7 +3,7 @@ title: browserAction.ImageDataType
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/ImageDataType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Données en pixels pour une image. Doit être un objet [`ImageData`](/fr/docs/Web/API/ImageData) (par exemple, un élément {{htmlelement("canvas")}}).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.md
@@ -3,7 +3,7 @@ title: browserAction.isEnabled()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/isEnabled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Renvoie `true` si l'action du navigateur est activée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
@@ -3,7 +3,7 @@ title: browserAction.onClicked
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Action quand l'icone d'action du navigateur est cliqué. Cet événement ne déclenchera pas si l'action du navigateur comporte une fenêtre contextuelle.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.md
@@ -3,7 +3,7 @@ title: browserAction.openPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup
 ---
 
-{{AddonSidebar()}}Ouvrez le popup de l'action du navigateur.
+{{AddonSidebar}}Ouvrez le popup de l'action du navigateur.
 
 Vous pouvez uniquement appeler cette fonction à partir du gestionnaire pour une [action utilisateur](/fr/Add-ons/WebExtensions/User_actions).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
@@ -3,7 +3,7 @@ title: browserAction.setBadgeBackgroundColor()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeBackgroundColor
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit la couleur de fond du badge. Les onglets sans couleur de fond de badge spécifique hériteront de la couleur de fond de badge globale, qui par défaut est `[217, 0, 0, 255]` dans Firefox.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
@@ -3,7 +3,7 @@ title: browserAction.setBadgeText()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeText
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit le texte du badge pour l'action du navigateur. Le badge est affiché en haut de l'icône.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
@@ -3,7 +3,7 @@ title: browserAction.setBadgeTextColor()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeTextColor
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit la couleur du texte du badge de l'action du navigateur. Les onglets sans couleur de texte de badge spécifique hériteront de la couleur globale du texte de badge.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
@@ -3,7 +3,7 @@ title: browserAction.setIcon()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/setIcon
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit l'icône pour l'action du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
@@ -3,7 +3,7 @@ title: browserAction.setPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/setPopup
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit le document HTML qui sera ouvert en tant que popup lorsque l'utilisateur clique sur l'icône de l'action du navigateur. Les onglets sans popup spécifique hériteront de la popup globale, qui par défaut est la [`default_popup`](/fr/Add-ons/WebExtensions/manifest.json/browser_action) spécifiée dans le manifest.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/allowpopupsforuserevents/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/allowpopupsforuserevents/index.md
@@ -3,7 +3,7 @@ title: browserSettings.allowPopupsForUserEvents
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/allowPopupsForUserEvents
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui peut etre utilisé pour activer ou désactiver la capacité des pages web d'ouvrir des popups en réponse aux actions de l'utilisateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/cacheenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/cacheenabled/index.md
@@ -3,7 +3,7 @@ title: browserSettings.cacheEnabled
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/cacheEnabled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui peut être utilisé pour activer ou désactiver globalement le cache du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/closetabsbydoubleclick/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/closetabsbydoubleclick/index.md
@@ -3,7 +3,7 @@ title: browserSettings.closeTabsByDoubleClick
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/closeTabsByDoubleClick
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui peut être utilisé pour activer ou désactiver la possibilité pour l'utilisateur de fermer un onglet en double-cliquant.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/contextmenushowevent/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/contextmenushowevent/index.md
@@ -3,7 +3,7 @@ title: contextMenuShowEvent
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/contextMenuShowEvent
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui détermine si le menu contextuel du navigateur est affiché sur l'événement mouseup ou sur l'événement mousedown.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.md
@@ -3,7 +3,7 @@ title: browserSettings.ftpProtocolEnabled
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/ftpProtocolEnabled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui détermine si le protocole FTP est activé dans le navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/homepageoverride/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/homepageoverride/index.md
@@ -3,7 +3,7 @@ title: browserSettings.homepageOverride
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/homepageOverride
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui peut être utilisé pour obtenir une chaîne représentant l'URL actuellement définie comme page d'accueil du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/imageanimationbehavior/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/imageanimationbehavior/index.md
@@ -3,7 +3,7 @@ title: browserSettings.imageAnimationBehavior
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/imageAnimationBehavior
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui peut être utilisé pour modifier la façon dont le navigateur traite les images animées, telles que les GIF.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.md
@@ -3,7 +3,7 @@ title: browserSettings.newTabPageOverride
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/newTabPageOverride
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui peut être utilisé pour obtenir une chaîne représentant l'URL de la page "nouvel onglet": c'est-à-dire, la page chargée lorsque l'utilisateur ouvre une nouvelle onglet vide.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/newtabposition/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/newtabposition/index.md
@@ -3,7 +3,7 @@ title: browserSettings.newTabPosition
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/newTabPosition
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui peut être utilisé pour contrôler la position des onglets nouvellement ouverts par rapport aux onglets déjà ouverts.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/openbookmarksinnewtabs/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/openbookmarksinnewtabs/index.md
@@ -3,7 +3,7 @@ title: browserSettings.openBookmarksInNewTabs
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/openBookmarksInNewTabs
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} dont la valeur sous-jacente est un booléen.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.md
@@ -3,7 +3,7 @@ title: browserSettings.openSearchResultsInNewTabs
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/openSearchResultsInNewTabs
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} dont la valeur sous-jacente est un booléen.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/openurlbarresultsinnewtabs/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/openurlbarresultsinnewtabs/index.md
@@ -3,7 +3,7 @@ title: browserSettings.openUrlbarResultsInNewTabs
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/openUrlbarResultsInNewTabs
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} dont la valeur sous-jacente est un booléen.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/overridedocumentcolors/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/overridedocumentcolors/index.md
@@ -3,7 +3,7 @@ title: browserSettings.overrideDocumentColors
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/overrideDocumentColors
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} dont la valeur sous-jacente est une chaîne.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/usedocumentfonts/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/usedocumentfonts/index.md
@@ -3,7 +3,7 @@ title: browserSettings.useDocumentFonts
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/useDocumentFonts
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} dont la valeur sous-jacente est un booléen.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/webnotificationsdisabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/webnotificationsdisabled/index.md
@@ -3,7 +3,7 @@ title: browserSettings.webNotificationsDisabled
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/webNotificationsDisabled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui peut être utilisé pour empêcher les sites Web d'afficher des [`Notifications`](/fr/docs/Web/API/Notifications_API) à l'aide de l'API Web de notifications.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/zoomfullpage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/zoomfullpage/index.md
@@ -3,7 +3,7 @@ title: browserSettings.zoomFullPage
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/zoomFullPage
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} dont la valeur sous-jaccente est un booléen.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/zoomsitespecific/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/zoomsitespecific/index.md
@@ -3,7 +3,7 @@ title: browserSettings.zoomSiteSpecific
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/zoomSiteSpecific
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} dont la valeur sous-jaccente est un booléen.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
@@ -3,7 +3,7 @@ title: browsingData.DataTypeSet
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/DataTypeSet
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type **`browsingData.DataTypeSet`** décrit un ensemble de types de données.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
@@ -3,7 +3,7 @@ title: browsingData.RemovalOptions
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/RemovalOptions
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type **`browsingData.RemovalOptions`** contient des options permettant de contrôler certains aspects de la suppression des données de navigation.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
@@ -3,7 +3,7 @@ title: browsingData.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/remove
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Supprime les données de navigation spécifiées.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
@@ -3,7 +3,7 @@ title: browsingData.removeCache()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removeCache
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Effacer le cache du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
@@ -3,7 +3,7 @@ title: browsingData.removeCookies()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removeCookies
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Efface les cookies du navigateur
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
@@ -3,7 +3,7 @@ title: browsingData.removeDownloads()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removeDownloads
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Efface l'historique de téléchargement du navigateur. Notez que cela ne supprime pas les objets téléchargés eux-mêmes, seulement les enregistrements de téléchargements dans l'historique du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
@@ -3,7 +3,7 @@ title: browsingData.removeFormData()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removeFormData
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Efface les données que le navigateur a enregistré pour les formulaires de remplissage automatique.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
@@ -3,7 +3,7 @@ title: browsingData.removeHistory()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removeHistory
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Efface l'enregistrement des pages Web que l'utilisateur a visité (historique de navigation).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
@@ -3,7 +3,7 @@ title: browsingData.removeLocalStorage()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removeLocalStorage
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Efface tout le [stockage local](/fr/docs/Web/API/Window/localStorage) créé par des sites Web.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
@@ -3,7 +3,7 @@ title: browsingData.removePasswords()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removePasswords
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Efface les mots de passes enregistrés
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
@@ -3,7 +3,7 @@ title: browsingData.removePluginData()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removePluginData
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Efface les données stockées par les plugins du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
@@ -3,7 +3,7 @@ title: browsingData.settings()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/settings
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Les navigateurs disposent d'une fonction "Effacer l'historique" intégrée, qui permet à l'utilisateur d'effacer différents types de données de navigation. Cela a une interface utilisateur qui permet à l'utilisateur de sélectionner le type de données à supprimer (par exemple l'historique, les téléchargements, ...) et à quelle distance remonter dans le temps pour supprimer des données.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.md
@@ -3,7 +3,7 @@ title: captivePortal.canonicalURL
 slug: Mozilla/Add-ons/WebExtensions/API/captivePortal/canonicalURL
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Renvoyer l'URL canonique de la page de détection du portail des prisonniers. En lecture seule.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.md
@@ -3,7 +3,7 @@ title: getLastChecked
 slug: Mozilla/Add-ons/WebExtensions/API/captivePortal/getLastChecked
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Retourne le temps écoulé depuis que la dernière demande a été complétée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/captiveportal/getstate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/captiveportal/getstate/index.md
@@ -3,7 +3,7 @@ title: getState
 slug: Mozilla/Add-ons/WebExtensions/API/captivePortal/getState
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Renvoie l'état du portail comme `unknown`, `not_captive`, `unlocked_portal`, ou `locked_portal`.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/captiveportal/onconnectivityavailable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/captiveportal/onconnectivityavailable/index.md
@@ -3,7 +3,7 @@ title: onConnectivityAvailable
 slug: Mozilla/Add-ons/WebExtensions/API/captivePortal/onConnectivityAvailable
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 S'allume lorsque le service de portail captif détermine que l'utilisateur peut se connecter à l'internet.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.md
@@ -3,7 +3,7 @@ title: onStateChanged
 slug: Mozilla/Add-ons/WebExtensions/API/captivePortal/onStateChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 S'allume lorsque l'état de portail captif change.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
@@ -3,7 +3,7 @@ title: clipboard.setImageData()
 slug: Mozilla/Add-ons/WebExtensions/API/clipboard/setImageData
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Copie une image dans le presse-papiers. L'image est recodée avant d'être écrite dans le presse-papiers. Si l'image n'est pas valide, le presse-papiers n'est pas modifié.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/command/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/command/index.md
@@ -3,7 +3,7 @@ title: Command
 slug: Mozilla/Add-ons/WebExtensions/API/commands/Command
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Information sur une commande. Cela contient les informations spécifiées pour la commande dans la [`commande` clef manifest.json](/fr/Add-ons/WebExtensions/manifest.json/commands).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/getall/index.md
@@ -3,7 +3,7 @@ title: getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/commands/getAll
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obient toutes les commandes pour l'exécution que vous avez enregistré à l'aide d'une des [`commandes` clef du manifest.json](/fr/Add-ons/WebExtensions/manifest.json/commands).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
@@ -3,7 +3,7 @@ title: onCommand
 slug: Mozilla/Add-ons/WebExtensions/API/commands/onCommand
 ---
 
-{{AddonSidebar()}}Lancer quand une commande est exécutée à l'aide de son raccourci clavier associé.L'écouteur reçoit le nom de la commande. Cela correspond au nom donnée à la commande dans une [entrée manifest.json](/fr/Add-ons/WebExtensions/manifest.json/commands).
+{{AddonSidebar}}Lancer quand une commande est exécutée à l'aide de son raccourci clavier associé.L'écouteur reçoit le nom de la commande. Cela correspond au nom donnée à la commande dans une [entrée manifest.json](/fr/Add-ons/WebExtensions/manifest.json/commands).
 
 ## Syntaxe
 

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/reset/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/reset/index.md
@@ -3,7 +3,7 @@ title: commands.reset()
 slug: Mozilla/Add-ons/WebExtensions/API/commands/reset
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Réinitialise la description de la commande donnée et le raccourci clavier aux valeurs indiquées dans [`commands` de la clé du manifest.json](/fr/Add-ons/WebExtensions/manifest.json/commands) de l'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/update/index.md
@@ -3,7 +3,7 @@ title: commands.update()
 slug: Mozilla/Add-ons/WebExtensions/API/commands/update
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Changez la description ou le raccourci clavier pour la commande donnée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -3,7 +3,7 @@ title: contentScripts.register()
 slug: Mozilla/Add-ons/WebExtensions/API/contentScripts/register
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Utilisez cette fonction pour enregistrer un ou plusieurs scripts de contenu.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
@@ -3,7 +3,7 @@ title: contentScripts.RegisteredContentScript
 slug: Mozilla/Add-ons/WebExtensions/API/contentScripts/RegisteredContentScript
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un `RegisteredContentScript` est renvoyé par un appel à {{WebExtAPIRef("contentScripts.register()")}} et représente les scripts de contenu enregistrés dans cet appel.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
@@ -3,7 +3,7 @@ title: contentScripts.RegisteredContentScript.unregister()
 slug: Mozilla/Add-ons/WebExtensions/API/contentScripts/RegisteredContentScript/unregister
 ---
 
-{{AddonSidebar()}}Annule l'inscription des scripts de contenu représentés par cet objet `RegisteredContentScript`.
+{{AddonSidebar}}Annule l'inscription des scripts de contenu représentés par cet objet `RegisteredContentScript`.
 
 ## Syntaxe
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/contextualidentity/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/contextualidentity/index.md
@@ -3,7 +3,7 @@ title: contextualIdentitities.ContextualIdentity
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/ContextualIdentity
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type **`contextualIdentities.ContextualIdentity`** décrit une identité contextuelle unique.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/create/index.md
@@ -3,7 +3,7 @@ title: contextualIdentities.create()
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/create
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Crée une nouvelle identité contextuelle. Une fois créée, l'utilisateur pourra créer de nouveaux onglets appartenant à cette identité contextuelle, tout comme ils peuvent le faire avec les identités intégrées.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/get/index.md
@@ -3,7 +3,7 @@ title: contextualIdentities.get()
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/get
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient des informations sur une identité contextuelle, compte tenu de son ID de cookie.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.md
@@ -3,7 +3,7 @@ title: contextualIdentities.onCreated
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/onCreated
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'une nouvelle identité contextuelle est créée. Les identités contextuelles peuvent être créées par des extensions en utilisant l'API `contextualIdentities`, ou directement par l'utilisateur, en utilisant l'interface utilisateur du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.md
@@ -3,7 +3,7 @@ title: contextualIdentities.onRemoved
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/onRemoved
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'une nouvelle identité contextuelle est supprimée. Les identités contextuelles peuvent être supprimées par des extensions en utilisant l'API `contextualIdentities`, ou directement par l'utilisateur, en utilisant l'interface utilisateur du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.md
@@ -3,7 +3,7 @@ title: contextualIdentities.onUpdated
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/onUpdated
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque les propriétés d'une identité contextuelle, telles que son nom, son icône ou sa couleur, sont modifiées. Les identités contextuelles peuvent être mises à jour par des extensions en utilisant l'API `contextualIdentities` , ou directement par l'utilisateur, en utilisant l'interface utilisateur du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/query/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/query/index.md
@@ -3,7 +3,7 @@ title: contextualIdentities.query()
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/query
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient des informations sur toutes les identités contextuelles ou sur les identités contextuelles correspondant à un argument de filtre donné.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.md
@@ -3,7 +3,7 @@ title: contextualIdentities.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/remove
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Supprime une identité contextuelle, compte tenu de son ID de cookie.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/update/index.md
@@ -3,7 +3,7 @@ title: contextualIdentities.update()
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/update
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Met à jour les propriétés d'une identité contextuelle, compte tenu de son ID de cookie.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
@@ -3,7 +3,7 @@ title: cookies.Cookie
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/Cookie
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `Cookie` de l'API {{WebExtAPIRef("cookies")}} représente des informations sur un cookie HTTP.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
@@ -3,7 +3,7 @@ title: cookies.CookieStore
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/CookieStore
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `CookieStore` de l'API {{WebExtAPIRef("cookies")}} représente un cookie store dans le navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/get/index.md
@@ -3,7 +3,7 @@ title: cookies.get()
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/get
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La méthode **`get()`** de l'API {{WebExtAPIRef("cookies")}} récupère les informations d'un seul cookie, par son nom et son URL.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/getall/index.md
@@ -3,7 +3,7 @@ title: cookies.getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/getAll
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La méthode **`getAll()`** de l'API {{WebExtAPIRef("cookies")}} récupère tous les cookies d'un seul cookie store qui correspondent aux informations fournies.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.md
@@ -3,7 +3,7 @@ title: cookies.getAllCookieStores()
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/getAllCookieStores
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La méthode **`getAllCookieStores()`** de l'API {{WebExtAPIRef("cookies")}} retourne une liste de tous les cookies stores.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
@@ -3,7 +3,7 @@ title: cookies.onChanged
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/onChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'événement `onChanged` de l'API {{WebExtAPIRef("cookies")}} est déclenché lorsqu'un cookie est défini ou supprimé.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
@@ -3,7 +3,7 @@ title: cookies.OnChangedCause
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/OnChangedCause
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `OnChangedCause` de l'API {{WebExtAPIRef("cookies")}} représente la raison pour laquelle un cookie a été modifié.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/remove/index.md
@@ -3,7 +3,7 @@ title: cookies.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/remove
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La méthode **`remove()`** de l'API {{WebExtAPIRef("cookies")}} supprime un cookie, compte tenu de son nom et de son URL.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/samesitestatus/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/samesitestatus/index.md
@@ -3,7 +3,7 @@ title: cookies.SameSiteStatus
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/SameSiteStatus
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `SameSiteStatus` de l'API {{WebExtAPIRef("cookies")}} représente des informations sur l'état `SameSite` d'un cookie.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -3,7 +3,7 @@ title: cookies.set()
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/set
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La méthode **`set()`** de l'API {{WebExtAPIRef("cookies")}} définit un cookie contenant des données précises de cookie. Cette méthode équivaut à l'émission d'un en-tête HTTP `Set-Cookie` lors d'une requête à une URL donnée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
@@ -3,7 +3,7 @@ title: devtools.inspectedWindow.eval()
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/eval
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Exécute JavaScript dans la fenêtre à laquelle les devtools sont attachés.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
@@ -3,7 +3,7 @@ title: devtools.inspectedWindow.reload()
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/reload
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Recharge la fenêtre à laquelle les devtools sont attachés.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
@@ -3,7 +3,7 @@ title: devtools.inspectedWindow.tabId
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/tabId
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'ID de {{WebExtAPIRef("tabs.Tab", "tab")}} est que cette instance des devtools est jointe, représenté comme un nombre.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
@@ -3,7 +3,7 @@ title: devtools.network.getHAR()
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/network/getHAR
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtenez un [journal HAR](http://www.softwareishard.com/blog/har-12-spec/#log) pour la page chargée dans l'onglet en cours.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.md
@@ -3,7 +3,7 @@ title: devtools.network.onNavigated
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/network/onNavigated
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Mise en place lorsque l'utilisateur navigue dans la fenêtre inspectée vers une nouvelle page
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.md
@@ -3,7 +3,7 @@ title: devtools.network.onRequestFinished
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/network/onRequestFinished
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'une requête réseau est terminée et que ses détails sont disponibles pour l'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
@@ -3,7 +3,7 @@ title: devtools.panels.create()
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/create
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Ajoute un nouveau panneau aux devtools.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.md
@@ -3,7 +3,7 @@ title: devtools.panels.elements
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/elements
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet [`ElementsPanel`](/fr/Add-ons/WebExtensions/API/devtools.panels/ElementsPanel) qui représente l'inspecteur HTML/CSS du navigateur
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
@@ -3,7 +3,7 @@ title: devtools.panels.ElementsPanel.createSidebarPane()
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel/createSidebarPane
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Ajoute un nouveau volet à la barre latérale dans l'inspecteur HTML / CSS.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.md
@@ -3,7 +3,7 @@ title: devtools.panels.ElementsPanel
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un `ElementsPanel` représente l'inspecteur HTML/CSS dans la devtools du navigateur. C'est ce qu'on appelle l'inspecteur de page dans Firefox et le panneau Éléments de Chrome.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
@@ -3,7 +3,7 @@ title: onSelectionChanged
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel/onSelectionChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Appelles lorsque l'utilisateur sélectionne un élément de page différent pour l'inspection avec les outils de développement du navigateur, par exemple en sélectionnant l'élément de menu contextuel "Inspect Element" dans Firefox.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
@@ -3,7 +3,7 @@ title: devtools.panels.ExtensionPanel
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionPanel
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Une `ExtensionPanel` représente un panneau ajouté aux devtools. C'est la résolution de la [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) renvoyé par [`browser.devtools.panels.create()`](/fr/Add-ons/WebExtensions/API/devtools.panels/create).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
@@ -3,7 +3,7 @@ title: devtools.panels.ExtensionSidebarPane.onHidden
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/onHidden
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Appelé lorsque le volet de la barre latérale est masqué, suite à l'abandon de l'utilisateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.md
@@ -3,7 +3,7 @@ title: devtools.panels.ExtensionSidebarPane.onShown
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/onShown
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque le volet latéral devient visible suite à un changement d'utilisateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
@@ -3,7 +3,7 @@ title: devtools.panels.ElementsPanel.setExpression()
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setExpression
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Evalue une expression dans le contexte de la page inspectée et affiche le résultat dans le volet de la barre latérale d'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
@@ -3,7 +3,7 @@ title: devtools.panels.ExtensionSidebarPane.setObject()
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setObject
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Affiche un objet JSON dans le volet de la barre latérale de l'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.md
@@ -3,7 +3,7 @@ title: devtools.panels.onThemeChanged
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/onThemeChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Remplacement quand le thème de devtools change
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.md
@@ -3,7 +3,7 @@ title: devtools.panels.themeName
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels/themeName
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le nom du thème de **devtools** actuellement sélectionné.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/dns/resolve/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/dns/resolve/index.md
@@ -3,7 +3,7 @@ title: dns.resolve()
 slug: Mozilla/Add-ons/WebExtensions/API/dns/resolve
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Résout le nom d'hôte donné en un enregistrement DNS.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
@@ -3,7 +3,7 @@ title: downloads.acceptDanger()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/acceptDanger
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`acceptDanger()`** de l'API {{WebExtAPIRef("downloads")}} invite l'utilisateur à accepter ou à annuler un téléchargement potentiellement dangereux.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
@@ -3,7 +3,7 @@ title: downloads.BooleanDelta
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/BooleanDelta
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `BooleanDelta` de l'API {{WebExtAPIRef("downloads")}} représente la différence entre deux booléens.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
@@ -3,7 +3,7 @@ title: downloads.cancel()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/cancel
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`cancel()`** de l'API de {{WebExtAPIRef("downloads")}} annule un téléchargement. L'appel échouera si le téléchargement n'est pas actif : par exemple, parce qu'il a terminé le téléchargement..
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/dangertype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/dangertype/index.md
@@ -3,7 +3,7 @@ title: downloads.DangerType
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/DangerType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `DangerType` de l'API {{WebExtAPIRef("downloads")}} définit un ensemble de raisons possibles pour lesquelles un fichier téléchargeable peut être considéré comme dangereux..
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
@@ -3,7 +3,7 @@ title: downloads.DoubleDelta
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/DoubleDelta
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `DoubleDelta` de l'API {{WebExtAPIRef("downloads")}} représente la différence entre deux doubles.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/download/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/download/index.md
@@ -3,7 +3,7 @@ title: downloads.download()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/download
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`download()`** de l'API {{WebExtAPIRef("downloads")}} télécharge le fichier, compte tenu de son URL et d'autres préférences optionnelles.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
@@ -3,7 +3,7 @@ title: downloads.DownloadItem
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/DownloadItem
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `DownloadItem` de l'API {{WebExtAPIRef("downloads")}} représente un fichier téléchargé.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
@@ -3,7 +3,7 @@ title: downloads.DownloadQuery
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/DownloadQuery
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `DownloadQuery` de l'API {{WebExtAPIRef("downloads")}} définit un ensemble de paramètres pouvant être utilisés pour rechercher dans le gestionnaire de téléchargements un ensemble spécifique de téléchargements.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.md
@@ -3,7 +3,7 @@ title: downloads.DownloadTime
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/DownloadTime
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `DownloadTime` de l'API {{WebExtAPIRef("downloads")}} représente le temps nécessaire au téléchargement.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/drag/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/drag/index.md
@@ -3,7 +3,7 @@ title: downloads.drag()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/drag
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`drag()`** de l'API {{WebExtAPIRef("downloads")}} initie le glissement du fichier téléchargé vers une autre application.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/erase/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/erase/index.md
@@ -3,7 +3,7 @@ title: downloads.erase()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/erase
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`erase()`** de l'API {{WebExtAPIRef("downloads")}} efface la correspondance {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} de l'historique de téléchargement du navigateur sans supprimer les fichiers téléchargés du disque.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.md
@@ -3,7 +3,7 @@ title: downloads.FilenameConflictAction
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/FilenameConflictAction
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `FilenameConflictAction` de l'API {{WebExtAPIRef("downloads")}} spécifie que faire si le nom d'un fichier téléchargé est en conflit avec un fichier existant.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
@@ -3,7 +3,7 @@ title: downloads.getFileIcon()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/getFileIcon
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`getFileIcon()`** de l'API {{WebExtAPIRef("downloads")}} récupère une icône pour le téléchargement spécifié.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.md
@@ -3,7 +3,7 @@ title: downloads.InterruptReason
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/InterruptReason
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `InteruptReason` de l'API {{WebExtAPIRef("downloads")}} définit un ensemble de raisons possibles pour lesquelles un téléchargement a été interrompu.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
@@ -3,7 +3,7 @@ title: downloads.onChanged
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/onChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'événement **`onChanged()`** de l'API {{WebExtAPIRef("downloads")}} est déclenché lorsque l'une des propriétés de {{WebExtAPIRef('downloads.DownloadItem')}} change (à l'exception de `bytesReceived`).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/oncreated/index.md
@@ -3,7 +3,7 @@ title: downloads.onCreated
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/onCreated
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'événement **`onCreated()`** de l'API {{WebExtAPIRef("downloads")}} se déclenche lorsqu'un téléchargement commence, c'est à dire lorsque quand {{WebExtAPIRef("downloads.download()")}} est appelé avec succès.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
@@ -3,7 +3,7 @@ title: downloads.onErased
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/onErased
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'événement **`onErased()`** de l'API {{WebExtAPIRef("downloads")}} se déclenche lorsqu'un téléchargement est effacé de l'historique du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/open/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/open/index.md
@@ -3,7 +3,7 @@ title: downloads.open()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/open
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`open()`** de l'API {{WebExtAPIRef("downloads")}} ouvre le fichier téléchargé avec son application associée. Un événement {{WebExtAPIRef("downloads.onChanged")}} se déclenche lorsque l'élément est ouvert pour la première fois.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/pause/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/pause/index.md
@@ -3,7 +3,7 @@ title: downloads.pause()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/pause
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`pause()`** de l'API {{WebExtAPIRef("downloads")}} interrompt un téléchargement.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
@@ -3,7 +3,7 @@ title: downloads.removeFile()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/removeFile
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`removeFile()`** de l'API {{WebExtAPIRef("downloads")}} supprime un fichier téléchargé du disque.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/resume/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/resume/index.md
@@ -3,7 +3,7 @@ title: downloads.resume()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/resume
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`resume()`** de l'API {{WebExtAPIRef("downloads")}} reprend un téléchargement suspendu. Si la demande a abouti, le téléchargement ne sera pas interrompu et la progression reprendra. L'appel `resume()` échouera si le téléchargement n'est pas actif: par exemple, parce qu'il a fini le téléchargement.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/search/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/search/index.md
@@ -3,7 +3,7 @@ title: downloads.search()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/search
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`search()`** de l'API {{WebExtAPIRef("downloads")}} interroge les {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} disponibles dans le gestionnaire de téléchargements du navigateur, et renvoie celles qui correspondent aux spécifications critères de recherche.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.md
@@ -3,7 +3,7 @@ title: downloads.setShelfEnabled()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/setShelfEnabled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`setShelfEnabled()`** de l'API {{WebExtAPIRef("downloads")}} active ou désactive l'étagère grise située en bas de chaque fenêtre associée au profil de navigateur actuel. L'étagère sera désactivée si au moins une extension l'a désactivée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/show/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/show/index.md
@@ -3,7 +3,7 @@ title: downloads.show()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/show
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`show()`** de l'API {{WebExtAPIRef("downloads")}} affiche le fichier téléchargé dans son dossier contenant dans le gestionnaire de fichiers de la plate-forme sous-jacente.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
@@ -3,7 +3,7 @@ title: downloads.showDefaultFolder()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/showDefaultFolder
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La fonction **`showDefaultFolder()`** de l'API {{WebExtAPIRef("downloads")}} ouvre le dossier de téléchargement par défaut dans le gestionnaire de fichiers de la plateforme.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/state/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/state/index.md
@@ -3,7 +3,7 @@ title: downloads.State
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/State
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type d'`état` de l'API {{WebExtAPIRef("downloads")}} définit différents états dans lesquels un téléchargement en cours peut se trouver.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
@@ -3,7 +3,7 @@ title: downloads.StringDelta
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/StringDelta
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `StringDelta` de l'API {{WebExtAPIRef("downloads")}} représente la différence entre deux chaînes.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/events/event/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/events/event/index.md
@@ -3,7 +3,7 @@ title: events.Event
 slug: Mozilla/Add-ons/WebExtensions/API/events/Event
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet qui permet l'ajout et la suppression d'écouteurs pour un événement de navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/events/rule/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/events/rule/index.md
@@ -3,7 +3,7 @@ title: events.Rule
 slug: Mozilla/Add-ons/WebExtensions/API/events/Rule
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Description d'une règle déclarative pour la gestion des événements.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
@@ -3,7 +3,7 @@ title: events.UrlFilter
 slug: Mozilla/Add-ons/WebExtensions/API/events/UrlFilter
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Décrit différents critères de filtrage des URL. Si tous les critères spécifiés dans les propriétés du filtre correspondent à l'URL, le filtre correspond. Les filtres sont souvent fournis aux méthodes API dans un [Array](/fr/docs/Web/JavaScript/Reference/Global_Objects/Array) d'UrlFilters. Par exemple, les écouteurs [webNavigation](/fr/Add-ons/WebExtensions/API/webNavigation) peuvent être ajoutés avec un filtre qui est un objet avec une seule propriété url qui est un [Array](/fr/docs/Web/JavaScript/Reference/Global_Objects/Array) de UrlFilters, par exemple `{url:[UrlFilter,UrlFilter,...]}`. Si un filtre dans le tableau de UrlFilters correspond, il est considéré comme une correspondance pour le tableau. En effet, les critères spécifiés dans un seul filtre sont associés ensemble, alors que tous les filtres individuels dans un tableau sont où.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.md
@@ -3,7 +3,7 @@ title: extension.getBackgroundPage()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/getBackgroundPage
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Alias de {{WebExtAPIRef("runtime.getBackgroundPage()")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
@@ -3,7 +3,7 @@ title: extension.getExtensionTabs()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/getExtensionTabs
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 > **Attention :** Cette méthode a été dépréciée. Utilisez {{WebExtAPIRef("extension.getViews()")}} à la place.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/getviews/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/getviews/index.md
@@ -3,7 +3,7 @@ title: extension.getViews()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/getViews
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Renvoie un tableau des objets [Window](/fr/docs/Web/API/Window) pour chacune des pages exécutées dans l'extension en cours. Cela inclut, par exemple :
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.md
@@ -3,7 +3,7 @@ title: extension.inIncognitoContext
 slug: Mozilla/Add-ons/WebExtensions/API/extension/inIncognitoContext
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Valeur booléenne, `true` pour les scripts de contenu s'exécutant dans les onglets de navigation privée et pour les pages d'extension exécutées dans un processus de navigation privé..
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
@@ -3,7 +3,7 @@ title: extension.isAllowedFileSchemeAccess()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/isAllowedFileSchemeAccess
 ---
 
-{{AddonSidebar()}}Renvoie `true` si l'extension peut accéder au schéma "file://", sinon `false`.
+{{AddonSidebar}}Renvoie `true` si l'extension peut accéder au schéma "file://", sinon `false`.
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.md
@@ -3,7 +3,7 @@ title: extension.isAllowedIncognitoAccess()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/isAllowedIncognitoAccess
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Vérifiez si l'extension est autorisée à accéder aux onglets ouverts en mode "navigation privée".
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/lasterror/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/lasterror/index.md
@@ -3,7 +3,7 @@ title: extension.lastError
 slug: Mozilla/Add-ons/WebExtensions/API/extension/lastError
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un alias de {{WebExtAPIRef("runtime.lastError")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/onrequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/onrequest/index.md
@@ -3,7 +3,7 @@ title: extension.onRequest
 slug: Mozilla/Add-ons/WebExtensions/API/extension/onRequest
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 > **Attention :** Ceci n'est pas implémenté dans Firefox car il est obsolète depuis Chrome 33. Veuillez utiliser [runtime.onMessageExternal](/fr/Add-ons/WebExtensions/API/runtime/onMessageExternal) à la place.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
@@ -3,7 +3,7 @@ title: extension.onRequestExternal
 slug: Mozilla/Add-ons/WebExtensions/API/extension/onRequestExternal
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 > **Attention :** Ceci n'est pas implémenté dans Firefox car il est obsolète depuis Chrome 33. Veuillez utiliser [runtime.onMessageExternal](/fr/Add-ons/WebExtensions/API/runtime/onMessageExternal) à la place.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.md
@@ -3,7 +3,7 @@ title: extension.setUpdateUrlData()
 slug: Mozilla/Add-ons/WebExtensions/API/extension/setUpdateUrlData
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit les paramètres de l'URL de mise à jour de l'extension. Cette valeur est ignorée pour les extensions hébergées dans le magasin du fournisseur du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/viewtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/viewtype/index.md
@@ -3,7 +3,7 @@ title: extension.ViewType
 slug: Mozilla/Add-ons/WebExtensions/API/extension/ViewType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type de vue de l'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
@@ -3,7 +3,7 @@ title: extensionTypes.ImageDetails
 slug: Mozilla/Add-ons/WebExtensions/API/extensionTypes/ImageDetails
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Details sur le format et la qualité de l'image.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.md
@@ -3,7 +3,7 @@ title: extensionTypes.ImageFormat
 slug: Mozilla/Add-ons/WebExtensions/API/extensionTypes/ImageFormat
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Les valeurs de ce type sont des chaînes de caractères. Les valeurs possibles sont : `"jpeg"`, `"png"`.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
@@ -3,7 +3,7 @@ title: extensionTypes.RunAt
 slug: Mozilla/Add-ons/WebExtensions/API/extensionTypes/RunAt
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le plus tot que le Javascript ou CSS sera injecté dans l'onglet.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/find/find/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/find/find/index.md
@@ -3,7 +3,7 @@ title: find.find()
 slug: Mozilla/Add-ons/WebExtensions/API/find/find
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Recherche du texte dans un onglet.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/find/highlightresults/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/find/highlightresults/index.md
@@ -3,7 +3,7 @@ title: find.highlightResults()
 slug: Mozilla/Add-ons/WebExtensions/API/find/highlightResults
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Souligne les résultats d'un précédent appel à {{WebExtAPIRef("find.find()")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/find/removehighlighting/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/find/removehighlighting/index.md
@@ -3,7 +3,7 @@ title: find.removeHighlighting()
 slug: Mozilla/Add-ons/WebExtensions/API/find/removeHighlighting
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Supprimer toute mise en évidence d'une recherche précédente qui a été appliquée par un appel précédent à {{WebExtAPIRef("highlightResults()")}}, ou par l'interface utilisateur native du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/addurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/addurl/index.md
@@ -3,7 +3,7 @@ title: history.addUrl()
 slug: Mozilla/Add-ons/WebExtensions/API/history/addUrl
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Ajoute un enregistrement à l'historique du navigateur d'une visite à l'URL donnée. L'heure de la visite est enregistrée comme l'heure de l'appel, et le {{WebExtAPIRef("history.TransitionType", "TransitionType")}} est enregistré comme "liens".
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/deleteall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/deleteall/index.md
@@ -3,7 +3,7 @@ title: history.deleteAll()
 slug: Mozilla/Add-ons/WebExtensions/API/history/deleteAll
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Supprime toutes les visites de l'historique du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/deleterange/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/deleterange/index.md
@@ -3,7 +3,7 @@ title: history.deleteRange()
 slug: Mozilla/Add-ons/WebExtensions/API/history/deleteRange
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Supprime toutes les visites aux pages que l'utilisateur a effectuées pendant la période donnée. Si cela supprime toutes les visites effectuées sur une page donnée, alors la page n'apparaîtra plus dans l'historique du navigateur et {{WebExtAPIRef("history.onVisitRemoved")}} se déclenchera pour cela.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
@@ -3,7 +3,7 @@ title: history.deleteUrl()
 slug: Mozilla/Add-ons/WebExtensions/API/history/deleteUrl
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Supprime toutes les visites à l'URL donnée de l'historique du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/getvisits/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/getvisits/index.md
@@ -3,7 +3,7 @@ title: history.getVisits()
 slug: Mozilla/Add-ons/WebExtensions/API/history/getVisits
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Récupère des informations sur toutes les visites de l'URL donnée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/historyitem/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/historyitem/index.md
@@ -3,7 +3,7 @@ title: history.HistoryItem
 slug: Mozilla/Add-ons/WebExtensions/API/history/HistoryItem
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet `HistoryItem` fournit des informations sur une page dans l'historique du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
@@ -3,7 +3,7 @@ title: history.onTitleChanged
 slug: Mozilla/Add-ons/WebExtensions/API/history/onTitleChanged
 ---
 
-{{AddonSidebar()}}Lancé lorsque le titre d'une page visitée par l'utilisateur est enregistré.Pour écouter les visites d'une page, vous pouvez utiliser {{WebExtAPIRef("history.onVisited")}}. Cependant, le {{WebExtAPIRef("history.HistoryItem")}} que cet événement passe à son écouteur n'inclut pas le titre de la page, car le titre de la page n'est généralement pas connu au moment où `history.onVisited` est envoyé.Au lieu de cela, {{WebExtAPIRef("history.HistoryItem")}} stocké est mis à jour avec le titre de la page après le chargement de la page, une fois le titre connu. L'événement history.onTitleChanged est déclenché à ce moment-là. Donc, si vous avez besoin de connaître les titres des pages telles qu'elles sont visitées, écoutez `history.onTitleChanged`.
+{{AddonSidebar}}Lancé lorsque le titre d'une page visitée par l'utilisateur est enregistré.Pour écouter les visites d'une page, vous pouvez utiliser {{WebExtAPIRef("history.onVisited")}}. Cependant, le {{WebExtAPIRef("history.HistoryItem")}} que cet événement passe à son écouteur n'inclut pas le titre de la page, car le titre de la page n'est généralement pas connu au moment où `history.onVisited` est envoyé.Au lieu de cela, {{WebExtAPIRef("history.HistoryItem")}} stocké est mis à jour avec le titre de la page après le chargement de la page, une fois le titre connu. L'événement history.onTitleChanged est déclenché à ce moment-là. Donc, si vous avez besoin de connaître les titres des pages telles qu'elles sont visitées, écoutez `history.onTitleChanged`.
 
 ## Syntaxe
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/onvisited/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/onvisited/index.md
@@ -3,7 +3,7 @@ title: history.onVisited
 slug: Mozilla/Add-ons/WebExtensions/API/history/onVisited
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Mise en place à chaque fois que l'utilisateur visite une page. Un objet {{WebExtAPIRef("history.HistoryItem")}} est transmis à l'écouteur. Cet événement se déclenche avant que la page ne soit chargée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.md
@@ -3,7 +3,7 @@ title: history.onVisitRemoved
 slug: Mozilla/Add-ons/WebExtensions/API/history/onVisitRemoved
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'une page est complètement supprimée de l'historique du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/search/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/search/index.md
@@ -3,7 +3,7 @@ title: history.search()
 slug: Mozilla/Add-ons/WebExtensions/API/history/search
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Recherche dans l'historique du navigateur les objets {{WebExtAPIRef("history.HistoryItem")}} correspondant aux critères donnés.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/transitiontype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/transitiontype/index.md
@@ -3,7 +3,7 @@ title: history.TransitionType
 slug: Mozilla/Add-ons/WebExtensions/API/history/TransitionType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Ceci décrit comment le navigateur a navigué vers une page particulière. Par exemple, "lien" signifie que le navigateur a navigué vers la page parce que l'utilisateur a cliqué sur un lien
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/visititem/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/visititem/index.md
@@ -3,7 +3,7 @@ title: history.VisitItem
 slug: Mozilla/Add-ons/WebExtensions/API/history/VisitItem
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet décrivant une seule visite sur une page.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
@@ -3,7 +3,7 @@ title: i18n.detectLanguage()
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/detectLanguage
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Détecte la langue du texte fourni à l'aide du [détecteur de langue compact](https://github.com/CLD2Owners/cld2) (CLD).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
@@ -3,7 +3,7 @@ title: i18n.getAcceptLanguages()
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/getAcceptLanguages
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient les [accept-languages](/fr/docs/Web/HTTP/Content_negotiation#The_Accept-Language_header) du navigateur. Ceci est différent des paramètres régionaux utilisés par le navigateur. Pour obtenir les paramètres régionaux, utilisez {{WebExtAPIRef('i18n.getUILanguage')}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
@@ -3,7 +3,7 @@ title: i18n.getMessage()
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/getMessage
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient la chaîne localisée pour le message spécifié.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
@@ -3,7 +3,7 @@ title: i18n.getUILanguage()
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/getUILanguage
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient la langue de l'interface utilisateur du navigateur. Ceci est différent de {{WebExtAPIRef('i18n.getAcceptLanguages')}} qui renvoie les langues utilisateur préférées.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
@@ -3,7 +3,7 @@ title: i18n.LanguageCode
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/LanguageCode
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Une [balise de langue](https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.10) telle que `"en-US"` ou "`fr`".
 

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/locale-specific_message_reference/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/locale-specific_message_reference/index.md
@@ -3,7 +3,7 @@ title: Locale-specific message reference
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Chaque extension internationalisée a au moins un fichier nommé `messages.json` qui fournit des chaînes spécifiques aux paramètres régionaux. Cette page décrit le format des fichiers `messages.json`.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
@@ -3,7 +3,7 @@ title: identity.getRedirectURL()
 slug: Mozilla/Add-ons/WebExtensions/API/identity/getRedirectURL
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Génère une URL que vous pouvez utiliser comme URL de redirection.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
@@ -3,7 +3,7 @@ title: identity.launchWebAuthFlow
 slug: Mozilla/Add-ons/WebExtensions/API/identity/launchWebAuthFlow
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Effectue la première partie d'un flux [OAuth2](https://oauth.net/2/) y compris l'authentification de l'utilisateur et l'autorisation du client.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/idlestate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/idlestate/index.md
@@ -3,7 +3,7 @@ title: idle.IdleState
 slug: Mozilla/Add-ons/WebExtensions/API/idle/IdleState
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Chaîne d'écrivant l'état d'inactivité du périphérique.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.md
@@ -3,7 +3,7 @@ title: idle.onStateChanged
 slug: Mozilla/Add-ons/WebExtensions/API/idle/onStateChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque le système change passe à l'état actif, inactif ou vérouillé. L'écouteur d'événement reçoit une chaîne qui a l'une des trois valeurs suivantes :
 

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/querystate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/querystate/index.md
@@ -3,7 +3,7 @@ title: idle.queryState()
 slug: Mozilla/Add-ons/WebExtensions/API/idle/queryState
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Renvoie `"locked"` si le système est vérouillé, `"inactif"` si l'utilisation n'a généré aucune entrée pendant un nombre de secondes spécifié, ou `"actif"` dans le cas contraire.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.md
@@ -3,7 +3,7 @@ title: idle.setDetectionInterval()
 slug: Mozilla/Add-ons/WebExtensions/API/idle/setDetectionInterval
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit l'intervalle, en secondes, utilisé pour déterminer quand le système est dans un état inactif pour les événements {{WebExtAPIRef("idle.onStateChanged")}} . L'intervalle par défaut est de 60 secondes.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/extensioninfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/extensioninfo/index.md
@@ -3,7 +3,7 @@ title: ExtensionInfo
 slug: Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet `ExtensionInfo` contenant les informations sur l'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/get/index.md
@@ -3,7 +3,7 @@ title: management.get()
 slug: Mozilla/Add-ons/WebExtensions/API/management/get
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Récupère un objet {{WebExtAPIRef("management.ExtensionInfo", "ExtensionInfo")}} contenant des informations sur l'extension spécifiée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/getall/index.md
@@ -3,7 +3,7 @@ title: management.getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/management/getAll
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Récupère un ensemble d'objets {{WebExtAPIRef("management.ExtensionInfo", "ExtensionInfo")}}, un pour chaque extension installé.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
@@ -3,7 +3,7 @@ title: management.getPermissionWarningsById()
 slug: Mozilla/Add-ons/WebExtensions/API/management/getPermissionWarningsById
 ---
 
-{{AddonSidebar()}}Lorsque l'utilisateur installe ou met à jour une extension, le navigateur peut avertir l'utilisateur des [permissions](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) particulièrement puissantes que l'extension a demandée. Toutes les permissions ne donnent pas lieu à des alertes et ce comportement n'est pas normalisé dans les navigateurs.
+{{AddonSidebar}}Lorsque l'utilisateur installe ou met à jour une extension, le navigateur peut avertir l'utilisateur des [permissions](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) particulièrement puissantes que l'extension a demandée. Toutes les permissions ne donnent pas lieu à des alertes et ce comportement n'est pas normalisé dans les navigateurs.
 
 Compte tenu de l'ID d'une extension, cette fonction retourne les avertisseurs de permissions comme un tableau de chaînes.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
@@ -3,7 +3,7 @@ title: management.getPermissionWarningsByManifest()
 slug: Mozilla/Add-ons/WebExtensions/API/management/getPermissionWarningsByManifest
 ---
 
-{{AddonSidebar()}}Lorsque l'utilisateur installe ou met à jour une extension, la navigateur peut avertir l'utilisateur des [permissions](/fr/Add-ons/WebExtensions/manifest.json/permissions) obligatoires. Toutes les permissions ne donnent pas lieu à des avertissements, et cela n'est pas normalisé dans les navigateurs.
+{{AddonSidebar}}Lorsque l'utilisateur installe ou met à jour une extension, la navigateur peut avertir l'utilisateur des [permissions](/fr/Add-ons/WebExtensions/manifest.json/permissions) obligatoires. Toutes les permissions ne donnent pas lieu à des avertissements, et cela n'est pas normalisé dans les navigateurs.
 
 Compte tenu du texte du fichier [manifest.json](/fr/Add-ons/WebExtensions/manifest.json), cette fonction retourne les avertisseurs de permissions qui seraient donnés pour l'extension comme un ensemble de chaines.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/getself/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/getself/index.md
@@ -3,7 +3,7 @@ title: management.getSelf()
 slug: Mozilla/Add-ons/WebExtensions/API/management/getSelf
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Récupère un objet {{WebExtAPIRef("management.ExtensionInfo", "ExtensionInfo")}} contenant les informations de l'extension appelée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/install/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/install/index.md
@@ -3,7 +3,7 @@ title: management.install()
 slug: Mozilla/Add-ons/WebExtensions/API/management/install
 ---
 
-{{AddonSidebar()}}Installe et active une extension de thème à partir de l'URL donnée.
+{{AddonSidebar}}Installe et active une extension de thème à partir de l'URL donnée.
 
 Cette API nécessite la [permission de l'API](/fr/Add-ons/WebExtensions/manifest.json/permissions) "management" et ne fonctionnera qu'avec des thèmes signés.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/ondisabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/ondisabled/index.md
@@ -3,7 +3,7 @@ title: management.onDisabled()
 slug: Mozilla/Add-ons/WebExtensions/API/management/onDisabled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Action quand l'extension est désactivée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/onenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/onenabled/index.md
@@ -3,7 +3,7 @@ title: management.onEnabled()
 slug: Mozilla/Add-ons/WebExtensions/API/management/onEnabled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'auditeur de l'événement appelé lorsque l'événement `enabled` est déclenché, indiquant qu'un add-on est maintenant activé.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/oninstalled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/oninstalled/index.md
@@ -3,7 +3,7 @@ title: management.onInstalled()
 slug: Mozilla/Add-ons/WebExtensions/API/management/onInstalled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Action quand une extension est installée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/onuninstalled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/onuninstalled/index.md
@@ -3,7 +3,7 @@ title: management.onUninstalled()
 slug: Mozilla/Add-ons/WebExtensions/API/management/onUninstalled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Action quand une extension est désinstallée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/setenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/setenabled/index.md
@@ -3,7 +3,7 @@ title: management.setEnabled()
 slug: Mozilla/Add-ons/WebExtensions/API/management/setEnabled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Active ou désactive l'extension ajoutée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -3,7 +3,7 @@ title: management.uninstall()
 slug: Mozilla/Add-ons/WebExtensions/API/management/uninstall
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Désinstalle une extension, compte tenu de son ID.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
@@ -3,7 +3,7 @@ title: management.uninstallSelf()
 slug: Mozilla/Add-ons/WebExtensions/API/management/uninstallSelf
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Désinstalle l'appel de l'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.md
@@ -3,7 +3,7 @@ title: menus.ACTION_MENU_TOP_LEVEL_LIMIT
 slug: Mozilla/Add-ons/WebExtensions/API/menus/ACTION_MENU_TOP_LEVEL_LIMIT
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le nombre maximal d'éléments d'extension de niveau supérieur pouvant être ajoutés à un élément de menu dont {{WebExtAPIRef("contextMenus.ContextType", "ContextType")}} est "browser_action" ou "page_action". Tout élément au-delà de cette limite sera ignoré.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
@@ -3,7 +3,7 @@ title: menus.ContextType
 slug: Mozilla/Add-ons/WebExtensions/API/menus/ContextType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Les différents contextes dans lesquels un élément de menu peut apparaître.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/create/index.md
@@ -3,7 +3,7 @@ title: menus.create()
 slug: Mozilla/Add-ons/WebExtensions/API/menus/create
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Crée un nouvel élément de menu, avec un objet d'options définissant les propriétés de l'élément.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/itemtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/itemtype/index.md
@@ -3,7 +3,7 @@ title: menus.ItemType
 slug: Mozilla/Add-ons/WebExtensions/API/menus/ItemType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type d'élément de menu.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
@@ -3,7 +3,7 @@ title: menus.OnClickData
 slug: Mozilla/Add-ons/WebExtensions/API/menus/OnClickData
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Informations transmises à l'écouteur d'événement {{WebExtAPIRef("menus.onClicked")}} lorsque vous cliquez sur un élément de menu.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
@@ -3,7 +3,7 @@ title: menus.onClicked
 slug: Mozilla/Add-ons/WebExtensions/API/menus/onClicked
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'un élément de menu est cliqué.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/onhidden/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/onhidden/index.md
@@ -3,7 +3,7 @@ title: menus.onHidden
 slug: Mozilla/Add-ons/WebExtensions/API/menus/onHidden
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque le navigateur cesse d'afficher un menu: par exemple, parce que l'utilisateur a cliqué à l'extérieur ou sélectionné un élément.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/onshown/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/onshown/index.md
@@ -3,7 +3,7 @@ title: menus.onShown
 slug: Mozilla/Add-ons/WebExtensions/API/menus/onShown
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque le navigateur a montré un menu.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/refresh/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/refresh/index.md
@@ -3,7 +3,7 @@ title: menus.refresh()
 slug: Mozilla/Add-ons/WebExtensions/API/menus/refresh
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Actualise un menu affiché.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/remove/index.md
@@ -3,7 +3,7 @@ title: menus.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/menus/remove
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Supprime un élément de menu.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/removeall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/removeall/index.md
@@ -3,7 +3,7 @@ title: menus.removeAll()
 slug: Mozilla/Add-ons/WebExtensions/API/menus/removeAll
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Supprime tous les éléments de menu ajoutés par l'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/update/index.md
@@ -3,7 +3,7 @@ title: menus.update()
 slug: Mozilla/Add-ons/WebExtensions/API/menus/update
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Met à jour un élément de menu précédemment créé.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/clear/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/clear/index.md
@@ -3,7 +3,7 @@ title: notifications.clear()
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/clear
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Efface une notification, compte tenu de son identifiant.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/create/index.md
@@ -3,7 +3,7 @@ title: notifications.create()
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/create
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Crée et affiche une notification.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/getall/index.md
@@ -3,7 +3,7 @@ title: notifications.getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/getAll
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient toutes les notifications actuellement actives créées par l'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
@@ -3,7 +3,7 @@ title: notifications.NotificationOptions
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Ce type contient les données nécessaires pour :
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.md
@@ -3,7 +3,7 @@ title: notifications.onButtonClicked
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/onButtonClicked
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque l'utilisateur clique sur l'un des boutons de la notification.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/onclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/onclicked/index.md
@@ -3,7 +3,7 @@ title: notifications.onClicked
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/onClicked
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque l'utilisateur clique sur une notification, mais pas sur l'un des boutons de la notification (pour cela, voir {{WebExtAPIRef("notifications.onButtonClicked")}}).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/onclosed/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/onclosed/index.md
@@ -3,7 +3,7 @@ title: notifications.onClosed
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/onClosed
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'une notification est fermée, soit par le système, soit par l'utilisateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
@@ -3,7 +3,7 @@ title: notifications.onShown
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/onShown
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé immédiatement après l'affichage d'une notification.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
@@ -3,7 +3,7 @@ title: notifications.TemplateType
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/TemplateType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Ceci est une chaîne et représente le type de notification à créer. Il existe quatre types de notification : "basic", "image", "list", "progress".
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/update/index.md
@@ -3,7 +3,7 @@ title: notifications.update()
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/update
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Met à jour une notification, compte tenu de son identifiant
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.md
@@ -3,7 +3,7 @@ title: omnibox.onInputCancelled
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/onInputCancelled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque l'utilisateur a annulé son interaction avec votre poste (par exemple, en cliquant en dehors de la barre d'adresse).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
@@ -3,7 +3,7 @@ title: omnibox.onInputChanged
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/onInputChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé chaque fois que l'utilisateur modifie sa saisie, après avoir commencé à interagir avec votre extension en saisissant son mot-clé dans la barre d'adresse, puis en appuyant sur la touche espace.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
@@ -3,7 +3,7 @@ title: omnibox.onInputEntered
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/onInputEntered
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque l'utilisateur a sélectionné l'une des suggestions que votre extension a ajoutées à la liste déroulante de la barre d'adresse.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.md
@@ -3,7 +3,7 @@ title: omnibox.OnInputEnteredDisposition
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/OnInputEnteredDisposition
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type **`omnibox.OnInputEnteredDisposition`** décrit comment l'extension doit gérer une sélection d'utilisateur à partir des suggestions dans la liste déroulante de la barre d'adresse.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
@@ -3,7 +3,7 @@ title: omnibox.onInputStarted
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/onInputStarted
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque l'utilisateur commence à interagir avec votre extension en entrant son mot-clé dans la barre d'adresse, puis en appuyant sur la touche espace.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
@@ -3,7 +3,7 @@ title: omnibox.setDefaultSuggestion()
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/setDefaultSuggestion
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définissez la suggestion par défaut à afficher dans la liste déroulante de la barre d'adresse lorsque l'utilisateur commence à interagir avec votre extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.md
@@ -3,7 +3,7 @@ title: omnibox.SuggestResult
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox/SuggestResult
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type **`omnibox.SuggestResult`** définit une suggestion unique que l'extension peut ajouter à la liste déroulante de la barre d'adresse.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
@@ -3,7 +3,7 @@ title: pageAction.getPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/getPopup
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient l'URL d'un document HTML en tant que popup pour cette action de page.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
@@ -3,7 +3,7 @@ title: pageAction.getTitle()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/getTitle
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient le titre de la page action.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/hide/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/hide/index.md
@@ -3,7 +3,7 @@ title: pageAction.hide()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/hide
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Masque l'action de page pour un onglet donné.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.md
@@ -3,7 +3,7 @@ title: pageAction.ImageDataType
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/ImageDataType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Données en pixel pour une image.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/isshown/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/isshown/index.md
@@ -3,7 +3,7 @@ title: pageAction.isShown()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/isShown
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Renvoie `true` si l'action de la page est affichée pour l'onglet donné..
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.md
@@ -3,7 +3,7 @@ title: pageAction.openPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/openPopup
 ---
 
-{{AddonSidebar()}}Ouvrez le menu contextuel de l'action de la page.
+{{AddonSidebar}}Ouvrez le menu contextuel de l'action de la page.
 
 Vous pouvez uniquement appeler cette fonction à partir du gestionnaire pour une [action utilisateur](/fr/Add-ons/WebExtensions/User_actions).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
@@ -3,7 +3,7 @@ title: pageAction.setPopup()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/setPopup
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit le document HTML à ouvrir en tant que fenêtre contextuelle lorsque l'utilisateur clique sur l'icône de l'action de la page.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/settitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/settitle/index.md
@@ -3,7 +3,7 @@ title: pageAction.setTitle()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/setTitle
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit le titre de la page action. Le titre est affiché dans une info-bulle lorsque l'utilisateur survole l'action de la page
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/show/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/show/index.md
@@ -3,7 +3,7 @@ title: pageAction.show()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/show
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Affiche l'action de la page pour un onglet donné. L'action de la page est affichée chaque fois que l'onglet donné est l'onglet actif.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/contains/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/contains/index.md
@@ -3,7 +3,7 @@ title: permissions.contains()
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/contains
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Vérifiez si l'extension a les permissions listées dans l'objet {{WebExtAPIRef("permissions.Permissions")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/getall/index.md
@@ -3,7 +3,7 @@ title: permissions.getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/getAll
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Récupère un objet {{WebExtAPIRef("permissions.Permissions")}} contenant toutes les permissions actuellement acccordées à l'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/onadded/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/onadded/index.md
@@ -3,7 +3,7 @@ title: permissions.onAdded
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/onAdded
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Activé lorsque l'extension a accordé de nouvelles permissions.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/onremoved/index.md
@@ -3,7 +3,7 @@ title: permissions.onRemoved
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/onRemoved
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Activé lorsque certaines permissions sont supprimés de l'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
@@ -3,7 +3,7 @@ title: Permissions
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/Permissions
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet `Permissions` représente une collection de permissions.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/remove/index.md
@@ -3,7 +3,7 @@ title: permissions.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/remove
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Demander d'abandonner les permissions listées dans l'objet {{WebExtAPIRef("permissions.Permissions")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/request/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/request/index.md
@@ -3,7 +3,7 @@ title: permissions.request()
 slug: Mozilla/Add-ons/WebExtensions/API/permissions/request
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Demandez l'ensemble des permissions répertoriées dans l'objet {{WebExtAPIRef("permissions.Permissions")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.md
@@ -3,7 +3,7 @@ title: pkcs11.getModuleSlots()
 slug: Mozilla/Add-ons/WebExtensions/API/pkcs11/getModuleSlots
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Enumérer les emplacements d'un module. Cette fonction renvoie un tableau contenant une entrée pour chaque emplacement. Chaque entrée contient le nom de l'emplacement et, si l'emplacement contient un jeton, des informations sur le jeton.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.md
@@ -3,7 +3,7 @@ title: pkcs11.installModule()
 slug: Mozilla/Add-ons/WebExtensions/API/pkcs11/installModule
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Installe le module PKCS # 11 nommé, le rendant disponible pour Firefox
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.md
@@ -3,7 +3,7 @@ title: pkcs11.isModuleInstalled()
 slug: Mozilla/Add-ons/WebExtensions/API/pkcs11/isModuleInstalled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Vérifie si le module PKCS #11 nommé est actuellement installé dans Firefox.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.md
@@ -3,7 +3,7 @@ title: pkcs11.uninstallModule()
 slug: Mozilla/Add-ons/WebExtensions/API/pkcs11/uninstallModule
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Désinstalle le module PKCS #11 nommé de Firefox.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/onerror/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/onerror/index.md
@@ -3,7 +3,7 @@ title: proxy.onProxyError
 slug: Mozilla/Add-ons/WebExtensions/API/proxy/onError
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé en cas d'erreur lors de l'évaluation du fichier PAC ou l'écouteur `onRequest`.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/onrequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/onrequest/index.md
@@ -3,7 +3,7 @@ title: proxy.onRequest
 slug: Mozilla/Add-ons/WebExtensions/API/proxy/onRequest
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Déclenché lorsqu'une requête Web est sur le point d'être effectuée, pour donner à l'extension la possibilité de l'utiliser comme proxy.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
@@ -3,7 +3,7 @@ title: proxy.ProxyInfo
 slug: Mozilla/Add-ons/WebExtensions/API/proxy/ProxyInfo
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Contient des informations sur un proxy. Cet objet, ou un tableau de ces objets, est renvoyé par le programme d'écoute à {{WebExtAPIRef("proxy.onRequest")}}. Il indique au navigateur si la requête doit être mandatée et, dans l'affirmative, quel proxy utiliser.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
@@ -3,7 +3,7 @@ title: proxy.RequestDetails
 slug: Mozilla/Add-ons/WebExtensions/API/proxy/RequestDetails
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Contient des informations sur une requête Web que le navigateur est sur le point de faire. Une instance de cet objet est passée dans l'écouteur {{WebExtAPIRef("proxy.onRequest")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/settings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/settings/index.md
@@ -3,7 +3,7 @@ title: browserSettings.proxyConfig
 slug: Mozilla/Add-ons/WebExtensions/API/proxy/settings
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui peut être utilisé pour modifier les paramètres de proxy du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/connect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/connect/index.md
@@ -3,7 +3,7 @@ title: runtime.connect()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/connect
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Créer une connexion pour plusieurs cas d'utilisation pout votre extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
@@ -3,7 +3,7 @@ title: runtime.connectNative()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/connectNative
 ---
 
-{{AddonSidebar()}}Connecte l'extension à une appplication native sur l'ordinateur de l'utilisateur.Cela prend le nom d'une application native en tant que paramètre. Il démarre l'application native et retourne un objet {{WebExtAPIRef("runtime.Port")}} à l'appelant.L'appelant peut utiliser le `Port` pour échanger des messages avec l'application native utilisant `Port.postMessage()` et `port.onMessage`.L'application native s'exécute jusqu'à ce qu'elle se termine, ou l'appelant appelle `Port.disconnect()`, ou la page qui a créé le `Port` est détruite. Une fois le `Port` est déconnecté, le navigateur mettra quelques secondes à se terminer pour quitter le processus, puis le désactiver s'il ne s'est pas arrêté.
+{{AddonSidebar}}Connecte l'extension à une appplication native sur l'ordinateur de l'utilisateur.Cela prend le nom d'une application native en tant que paramètre. Il démarre l'application native et retourne un objet {{WebExtAPIRef("runtime.Port")}} à l'appelant.L'appelant peut utiliser le `Port` pour échanger des messages avec l'application native utilisant `Port.postMessage()` et `port.onMessage`.L'application native s'exécute jusqu'à ce qu'elle se termine, ou l'appelant appelle `Port.disconnect()`, ou la page qui a créé le `Port` est détruite. Une fois le `Port` est déconnecté, le navigateur mettra quelques secondes à se terminer pour quitter le processus, puis le désactiver s'il ne s'est pas arrêté.
 
 Pour plus d'informations, voir [messagerie native](/fr/Add-ons/WebExtensions/Native_messaging).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
@@ -3,7 +3,7 @@ title: runtime.getBackgroundPage()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getBackgroundPage
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Récupère l'objet [`Window`](/fr/docs/Web/API/Window) pour la page d'arrière-plan qui s'exécute dans l'extension en cours.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
@@ -3,7 +3,7 @@ title: runtime.getManifest()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getManifest
 ---
 
-{{AddonSidebar()}}Obtenez le fichier [manifest.json](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json) complet, sérialisé à un objet JSON.
+{{AddonSidebar}}Obtenez le fichier [manifest.json](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json) complet, sérialisé à un objet JSON.
 
 ## Syntaxe
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
@@ -3,7 +3,7 @@ title: runtime.getPackageDirectoryEntry()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getPackageDirectoryEntry
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Renvoie un objet `DirectoryEntry` représentant le répertoire du package.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
@@ -3,7 +3,7 @@ title: runtime.getPlatformInfo()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getPlatformInfo
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Renvoies des informations sur la plate-forme actuelle. Ceci ne peut être appelé que dans le contexte du script d'arrière-plan.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
@@ -3,7 +3,7 @@ title: runtime.getURL()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getURL
 ---
 
-{{AddonSidebar()}}Etant donné un chemin relatif de [manifest.json](/fr/Add-ons/WebExtensions/manifest.json) à une ressource empaquetée avec l'extension, renvoyez une URL complète.Cette fonction ne vérifie pas que la ressource existe réellement à cette URL.
+{{AddonSidebar}}Etant donné un chemin relatif de [manifest.json](/fr/Add-ons/WebExtensions/manifest.json) à une ressource empaquetée avec l'extension, renvoyez une URL complète.Cette fonction ne vérifie pas que la ressource existe réellement à cette URL.
 
 ## Syntaxe
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/id/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/id/index.md
@@ -3,7 +3,7 @@ title: runtime.id
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/id
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'ID de l'extension
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
@@ -3,7 +3,7 @@ title: runtime.lastError
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/lastError
 ---
 
-{{AddonSidebar()}}Cette valeur est utilisée pour signaler un message d'erreur provenant d'une API asynchrone, lorsque l'API asynchrone reçoit un rappel. Cela est utile pour les extensions qui utilisent la valeur basée sur le rappel des API WebExtension.Vpous n'avez pas besoin de vérifier cette propriété si vous utilisez la version basée sur la promesse des API : à la place, passez un gestionnaire d'erreurs à la promesse :
+{{AddonSidebar}}Cette valeur est utilisée pour signaler un message d'erreur provenant d'une API asynchrone, lorsque l'API asynchrone reçoit un rappel. Cela est utile pour les extensions qui utilisent la valeur basée sur le rappel des API WebExtension.Vpous n'avez pas besoin de vérifier cette propriété si vous utilisez la version basée sur la promesse des API : à la place, passez un gestionnaire d'erreurs à la promesse :
 
 ```js
 var gettingCookies = browser.cookies.getAll();

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
@@ -3,7 +3,7 @@ title: runtime.MessageSender
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet contenant des informations sur l'expéditeur d'un message ou d'une demande de connexion ; ceci est passé à l'écouteur {{WebExtAPIRef("runtime.onMessage()")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
@@ -3,7 +3,7 @@ title: runtime.onConnect
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onConnect
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé quand une connexion est établie avec un processus d'extension ou un script de contenu.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
@@ -3,7 +3,7 @@ title: runtime.onConnectExternal
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onConnectExternal
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'une extension reçoit une demande de connexion d'une extension différente.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
@@ -3,7 +3,7 @@ title: runtime.onInstalled
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onInstalled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque l'extension est installée pour la première fois, lorsque l'extension est mise à jour vers une nouvelle version et lorsque le navigateur est mis à jour vers une nouvelle version.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.md
@@ -3,7 +3,7 @@ title: runtime.OnInstalledReason
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/OnInstalledReason
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Les valeurs pour laquelle l'événement {{WebExtAPIRef("runtime.onInstalled")}} est en cours d'envoi.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -3,7 +3,7 @@ title: runtime.onMessage
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onMessage
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Utilisez cet événement pour écouter les messages d'une autre partie de votre extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.md
@@ -3,7 +3,7 @@ title: runtime.onMessageExternal
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal
 ---
 
-{{AddonSidebar()}}Utilisez cet événement pour écouter les messages d'une autre extension.
+{{AddonSidebar}}Utilisez cet événement pour écouter les messages d'une autre extension.
 
 Pour envoyer un message qui sera reçu par le module d'écoute `onMessageExternal`, utilisez {{WebExtAPIRef("runtime.sendMessage()")}}, en transmettant l'ID du destinataire dans le paramètre `extensionId`.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.md
@@ -3,7 +3,7 @@ title: runtime.onRestartRequired
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onRestartRequired
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'une application ou le périphérique sur lequel elle s'exécute doit être redémarré. L'application devrait fermer toutes ses fenêtres dans les meilleurs délais pour permettre le redémarrage. Si l'application ne fait rien, un redémarrage sera appliqué après une période de grâce de 24 heures. Actuellement, cet événement est uniquement déclenché pour les applications de kiosque ChromeOS.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.md
@@ -3,7 +3,7 @@ title: runtime.OnRestartRequiredReason
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/OnRestartRequiredReason
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La raison pour laquelle l'événement {{WebExtAPIRef("runtime.onRestartRequired", "onRestartRequired")}} est en cours d'exécution.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onstartup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onstartup/index.md
@@ -3,7 +3,7 @@ title: runtime.onStartup
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onStartup
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé quand un profil ayant cette extension installée démarre une session. Cet événement n'est pas déclenché lorsqu'une navigation privée / profil privé est démarré, même si cette extension fonctionne en mode de navigation privée 'split'.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.md
@@ -3,7 +3,7 @@ title: runtime.onSuspend
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onSuspend
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Envoyé sur la page de l'événement juste avant son déchargement. Cela donne à l'extension l'opportunité de faire un peu de nettoyage. Notez que, comme la page est en cours de déchargement, les opérations asynchrones démarrées lors de la gestion de cet événement ne sont pas garanties.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.md
@@ -3,7 +3,7 @@ title: runtime.onSuspendCanceled
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onSuspendCanceled
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Envoyé après {{WebExtAPIRef("runtime.onSuspend")}} pour indiquer que l'application ne sera pas déchargée après tout.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.md
@@ -3,7 +3,7 @@ title: runtime.onUpdateAvailable
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onUpdateAvailable
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Déclenché quand une mise à jour de l'extension est disponible. Cet événement permet à une extension de retarder une mise à jour : par exemple, car elle est au milieu d'une opération qui ne doit pas être interrompue.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
@@ -3,7 +3,7 @@ title: runtime.openOptionsPage()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/openOptionsPage
 ---
 
-{{AddonSidebar()}}Si votre extension a défini une [page d'options](/fr/Add-ons/WebExtensions/user_interface/Options_pages), cette méthode l'ouvre.
+{{AddonSidebar}}Si votre extension a défini une [page d'options](/fr/Add-ons/WebExtensions/user_interface/Options_pages), cette méthode l'ouvre.
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
@@ -3,7 +3,7 @@ title: runtime.PlatformArch
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'architecture du processeur de la machine.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
@@ -3,7 +3,7 @@ title: runtime.PlatformInfo
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/PlatformInfo
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet contenant des informations sur la plate-forme actuelle.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
@@ -3,7 +3,7 @@ title: runtime.PlatformNaclArch
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/PlatformNaclArch
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'architecture du client natif. Cela peut-etre différent de arch sur certaines plate-formes.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
@@ -3,7 +3,7 @@ title: runtime.PlatformOs
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/PlatformOs
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le système d'exploitation sur lequel le navigateur fonctionne.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/port/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/port/index.md
@@ -3,7 +3,7 @@ title: runtime.Port
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/Port
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet `Port` represente une extrémité d'une connexion entre deux contextes spécifiques, qui peut-être utilisée pour échanger des messages.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/reload/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/reload/index.md
@@ -3,7 +3,7 @@ title: runtime.reload()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/reload
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Recharge une extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
@@ -3,7 +3,7 @@ title: runtime.requestUpdateCheck()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/requestUpdateCheck
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Vérifie de voir si un mise à jour de l'extension est disponible.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.md
@@ -3,7 +3,7 @@ title: runtime.RequestUpdateCheckStatus
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/RequestUpdateCheckStatus
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Résultat d'un appel à {{WebExtAPIRef("runtime.requestUpdateCheck()")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
@@ -3,7 +3,7 @@ title: runtime.sendMessage()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Envoie un simple message aux écouteurs d'événement dans votre extension ou une extension différente.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
@@ -3,7 +3,7 @@ title: runtime.sendNativeMessage()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/sendNativeMessage
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Envoie un seul message d'une extension à une application native.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
@@ -3,7 +3,7 @@ title: runtime.setUninstallURL()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/setUninstallURL
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit l'URL à visiter lorsque l'extension est déinstallée. Cela peut être utilisé pour nettoyer les données côté serveur, effectuer des analyses ou implémenter des enquêtes. L'URL peut contenir au maximum 255 caractères.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/search/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/search/get/index.md
@@ -3,7 +3,7 @@ title: search.get()
 slug: Mozilla/Add-ons/WebExtensions/API/search/get
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient un tableau de tous les moteurs de recherche installés.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/search/search/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/search/search/index.md
@@ -3,7 +3,7 @@ title: search.search()
 slug: Mozilla/Add-ons/WebExtensions/API/search/search
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Effectuer une recherche en utilisant le moteur de recherche spécifié, ou le moteur de recherche par défaut si aucun moteur de recherche n'est spécifié.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/filter/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/filter/index.md
@@ -3,7 +3,7 @@ title: sessions.Filter
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/Filter
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'objet `Filter` permet de restreindre le nombre d'objets {{WebExtAPIRef("sessions.Session", "Session")}} retournés par un appel à {{WebExtAPIRef("sessions.getRecentlyClosed()")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
@@ -3,7 +3,7 @@ title: sessions.forgetClosedTab()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/forgetClosedTab
 ---
 
-{{AddonSidebar()}}Supprime un onglet fermé de la liste des onglets récemment fermés du navigateur.Notez que les sites visités par cet onglet ne sont pas supprimés de l'historique du navigateur. Utilisez les API {{WebExtAPIRef("browsingData")}} oo {{WebExtAPIRef("history")}} pour supprimer l'historique.
+{{AddonSidebar}}Supprime un onglet fermé de la liste des onglets récemment fermés du navigateur.Notez que les sites visités par cet onglet ne sont pas supprimés de l'historique du navigateur. Utilisez les API {{WebExtAPIRef("browsingData")}} oo {{WebExtAPIRef("history")}} pour supprimer l'historique.
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
@@ -3,7 +3,7 @@ title: sessions.forgetClosedWindow()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/forgetClosedWindow
 ---
 
-{{AddonSidebar()}}Supprime une fenêtre fermée de la liste des fenêtres récemment fermées du navigateur.Notez que les sites visités par cette fenêtre ne sont pas supprimés de l'historique du navigateur. Utilisez les API {{WebExtAPIRef("browsingData")}} ou {{WebExtAPIRef("history")}} pour supprimer l'historique.
+{{AddonSidebar}}Supprime une fenêtre fermée de la liste des fenêtres récemment fermées du navigateur.Notez que les sites visités par cette fenêtre ne sont pas supprimés de l'historique du navigateur. Utilisez les API {{WebExtAPIRef("browsingData")}} ou {{WebExtAPIRef("history")}} pour supprimer l'historique.
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
@@ -3,7 +3,7 @@ title: sessions.getRecentlyClosed()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/getRecentlyClosed
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Renvoie un ensemble d'objets {{WebExtAPIRef("sessions.Session", "Session")}}, représentant des fenêtres et des onglets qui ont été fermés dans la session du navigation actuelle (c'est à dire l'heure écoulée depuis le démarrage du navigateur).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.md
@@ -3,7 +3,7 @@ title: sessions.getTabValue()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/getTabValue
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Récupère une valeur précédemment stockée par un appel à {{WebExtAPIRef("sessions.setTabValue")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.md
@@ -3,7 +3,7 @@ title: sessions.getWindowValue()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/getWindowValue
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Récupère une valeur précédemment stockée par un appel à {{WebExtAPIRef("sessions.setWindowValue")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.md
@@ -3,7 +3,7 @@ title: sessions.MAX_SESSION_RESULTS
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/MAX_SESSION_RESULTS
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le nombre maximum de sessions qui seront retournées par un appel à {{WebExtAPIRef("sessions.getRecentlyClosed()")}}. Il est en lecture seule pour le code des WebExtensions, et défini à 25.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
@@ -3,7 +3,7 @@ title: sessions.onChanged
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/onChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Mise en place lorsque une liste d'onglets fermes ou de fenêtre changes.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.md
@@ -3,7 +3,7 @@ title: sessions.removeTabValue()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/removeTabValue
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Supprime une valeur précédemment stockée par un appel à {{WebExtAPIRef("sessions.setTabValue")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.md
@@ -3,7 +3,7 @@ title: sessions.removeWindowValue()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/removeWindowValue
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Supprime une valeur précédemment stockée par un appel à {{WebExtAPIRef("sessions.setWindowValue")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/restore/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/restore/index.md
@@ -3,7 +3,7 @@ title: sessions.restore()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/restore
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Restaure un onglet ou une fenêtre fermée. La restauration ne réouvre pas seulement l'onglet ou la fenêtre : elle rétablit également l'historique de navigation de l'onglet afin que les boutons arrière/avant fonctionnent. La restauration d'une fenêtre restaurera tous les onglets que la fenêtre contenait lors de sa fermeture.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/session/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/session/index.md
@@ -3,7 +3,7 @@ title: sessions.Session
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/Session
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'objet de `Session` représente un onglet ou une fenêtre que l'utilisateur a fermé dans la session de navigation actuelle.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.md
@@ -3,7 +3,7 @@ title: sessions.setTabValue()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/setTabValue
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Stocke une paire clé / valeur à associer à un onglet donné. Vous pouvez ensuite récupérer cette valeur en utilisant {{WebExtAPIRef("sessions.getTabValue")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.md
@@ -3,7 +3,7 @@ title: sessions.setWindowValue()
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/setWindowValue
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Stocke une paire clé / valeur à associer à une fenêtre donnée. Vous pouvez ensuite récupérer cette valeur en utilisant {{WebExtAPIRef("sessions.getWindowValue")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/close/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/close/index.md
@@ -3,7 +3,7 @@ title: sidebarAction.close()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/close
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Ferme la barre latérale dans la fenêtre active, s'il s'agit de la barre latérale de l'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
@@ -3,7 +3,7 @@ title: sidebarAction.getPanel()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/getPanel
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient une URL vers le document HTML qui définit le contenu de la barre latérale.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
@@ -3,7 +3,7 @@ title: sidebarAction.getTitle()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/getTitle
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient le titre de la barre latérale.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.md
@@ -3,7 +3,7 @@ title: sidebarAction.ImageDataType
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/ImageDataType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Données de pixel pour une image. Doit être un objet [`ImageData`](/fr/docs/Web/API/ImageData) (par exemple, à partir d'un élément {{htmlelement("canvas")}}).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.md
@@ -3,7 +3,7 @@ title: sidebarAction.isOpen()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/isOpen
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Renvoie `true` si la barre latérale de l'extension est ouverte dans une fenêtre donnée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/open/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/open/index.md
@@ -3,7 +3,7 @@ title: sidebarAction.open()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/open
 ---
 
-{{AddonSidebar()}}Ouvrez la barre latérale dans la fenêtre active.
+{{AddonSidebar}}Ouvrez la barre latérale dans la fenêtre active.
 
 Vous pouvez uniquement appeler cette fonction à l'intérieur du gestionnaire pour une [action utilisateur](/fr/Add-ons/WebExtensions/User_actions).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
@@ -3,7 +3,7 @@ title: sidebarAction.setIcon()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/setIcon
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit l'icône de la barre latérale.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
@@ -3,7 +3,7 @@ title: sidebarAction.setPanel()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/setPanel
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit le panneau de la barre latérale: c'est-à-dire le document HTML qui définit le contenu de cette barre latérale.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
@@ -3,7 +3,7 @@ title: sidebarAction.setTitle()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/setTitle
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit le titre de la barre latérale. Le titre est affiché n'importe où dans les barres latérales du navigateur. Par exemple, Firefox l'affichera dans le menu "Affichage > Barre latérale". Il est également affiché en haut de la barre latérale lorsque la barre latérale est ouverte.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.md
@@ -3,7 +3,7 @@ title: sidebarAction.toggle()
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction/toggle
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Permet de basculer la visibilité de la barre latérale dans la fenêtre active, si la barre latérale appartient à l'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/local/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/local/index.md
@@ -3,7 +3,7 @@ title: storage.local
 slug: Mozilla/Add-ons/WebExtensions/API/storage/local
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Représente la zone de stockage `local`. Les éléments stockés `localement` sont locaux sur la machine sur laquelle l'extension a été installée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/managed/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/managed/index.md
@@ -3,7 +3,7 @@ title: storage.managed
 slug: Mozilla/Add-ons/WebExtensions/API/storage/managed
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet {{WebExtAPIRef("storage.StorageArea")}} qui représente la zone de stockage gérée. Les éléments de stockage `géré` sont définis par l'administrateur du domaine ou d'autres applications natives installées sur l'ordinateur de l'utilisateur et sont en lecture seule pour l'extension. Essayer de modifier cette zone de stockage entraîne une erreur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -3,7 +3,7 @@ title: storage.onChanged
 slug: Mozilla/Add-ons/WebExtensions/API/storage/onChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'un ou plusieurs éléments changent.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
@@ -3,7 +3,7 @@ title: StorageArea.clear()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/clear
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Supprime tous les éléments de la zone de stockage.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -3,7 +3,7 @@ title: StorageArea.get()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Récupère un ou plusieurs éléments de la zone de stockage.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
@@ -3,7 +3,7 @@ title: StorageArea.getBytesInUse()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient la quantité d'espace de stockage, en octets, utilisé un ou plusieurs éléments stockés dans la zone de stockage.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
@@ -3,7 +3,7 @@ title: storage.StorageArea
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 StorageArea est un objet représentant une zone de stockage.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
@@ -3,7 +3,7 @@ title: StorageArea.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Supprime un ou plusieurs éléments de la zone de stockage.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
@@ -3,7 +3,7 @@ title: StorageArea.set()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Stocke un ou plusieurs éléments dans la zone de stockage ou met à jour les éléments existants..
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
@@ -3,7 +3,7 @@ title: storage.StorageChange
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageChange
 ---
 
-{{AddonSidebar()}}`StorageChange` est un objet représentant une modification d'une zone de stockage.
+{{AddonSidebar}}`StorageChange` est un objet représentant une modification d'une zone de stockage.
 
 ## Type
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/sync/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/sync/index.md
@@ -3,7 +3,7 @@ title: storage.sync
 slug: Mozilla/Add-ons/WebExtensions/API/storage/sync
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Représente la zone de stockage `sync` (pour la synchronisation). Les éléments stockés dans le stockage `sync` sont synchronisés par le navigateur et disponibles sur toutes les instances de ce navigateur auxquelles l'utilisatrice ou l'utilisateur est connecté (par exemple via la synchronisation Firefox ou un compte Google), sur différents appareils.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
@@ -3,7 +3,7 @@ title: tabs.captureTab()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/captureTab
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Crée un URI de données codant une image de la zone visible de l'onglet donné. Vous devez avoir la [permission](/fr/Add-ons/WebExtensions/manifest.json/permissions) `<all_urls>` pour utiliser cette méthode.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
@@ -3,7 +3,7 @@ title: tabs.captureVisibleTab()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/captureVisibleTab
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Crée une URI de données codant une image de la zone visible de l'onglet actuellement actif dans la fenêtre spécifiée. Vous devez avoir la [permission](/fr/Add-ons/WebExtensions/manifest.json/permissions) `<all_urls>` pour utiliser cette méthode. (Alternativement, Chrome permet l'utilisation de cette méthode avec la [permission](/fr/Add-ons/WebExtensions/manifest.json/permissions) `activeTab` et un geste utilisateur qualifiant).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/connect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/connect/index.md
@@ -3,7 +3,7 @@ title: tabs.connect()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/connect
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Appelez cette fonction pour configurer une connexion entre les scripts d'arrière-plan de l'extension (ou d'autres scripts privilégiés, tels que les scripts d'arrière-plan de l'extrension (ou d'autres scripts privilégiés, tels que les scripts de pages d'options) et les [scripts de contenu](/fr/docs/Mozilla/Add-ons/WebExtensions/Content_scripts) appartenant à cette extension et s'exécutant dans l'onglet spécifié. Cette fonction renvoie un objet {{WebExtAPIRef("runtime.Port")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/create/index.md
@@ -3,7 +3,7 @@ title: tabs.create()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/create
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Crée un nouvel onglet
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.md
@@ -3,7 +3,7 @@ title: tabs.detectLanguage()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/detectLanguage
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Détecte la langue principale du contenu dans un onglet, en utilisant le [détecteur de langue compact](https://github.com/CLD2Owners/cld2) (CLD).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/discard/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/discard/index.md
@@ -3,7 +3,7 @@ title: tabs.discard()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/discard
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Rejette un ou plusieurs onglets.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/duplicate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/duplicate/index.md
@@ -3,7 +3,7 @@ title: tabs.duplicate()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/duplicate
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Duplique un onglet dont l'identifiant est donné.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
@@ -3,7 +3,7 @@ title: tabs.executeScript()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/executeScript
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Injecte du code JavaScript dans une page.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/get/index.md
@@ -3,7 +3,7 @@ title: tabs.get()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/get
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Étant donné un ID d'onglet, obtenez les détails de l'onglet en tant qu'objet {{WebExtAPIRef("tabs.Tab")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.md
@@ -3,7 +3,7 @@ title: tabs.getCurrent()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/getCurrent
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtenez un {{WebExtAPIRef("tabs.Tab")}} contenant des informations sur l'onglet dans lequel ce script s'exécute.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
@@ -3,7 +3,7 @@ title: tabs.getSelected()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/getSelected
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 > **Attention :** Cette méthode est dépréciée. utilisez {{WebExtAPIRef("tabs.query", "tabs.query({active: true})")}} à la place.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
@@ -3,7 +3,7 @@ title: tabs.getZoom()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/getZoom
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient le facteur de zoom actuel pour l'onglet spécifié.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
@@ -3,7 +3,7 @@ title: tabs.getZoomSettings()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/getZoomSettings
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient les paramètres de zoom actuels pour un onglet spécifié.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/goback/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/goback/index.md
@@ -3,7 +3,7 @@ title: tabs.goBack()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/goBack
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Naviguer à la page précédente dans l'historique de l'onglet, si disponible.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
@@ -3,7 +3,7 @@ title: tabs.goForward()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/goForward
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Passez à la page suivante dans l'historique de l'onglet, si disponible.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/hide/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/hide/index.md
@@ -3,7 +3,7 @@ title: tabs.hide()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/hide
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Masque un ou plusieurs onglets.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
@@ -3,7 +3,7 @@ title: tabs.highlight()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/highlight
 ---
 
-{{AddonSidebar()}}Met en évidence (sélectionné) un ou plusieurs onglets. Les onglets sont spécifiés à l'aide d'un identifiant de fenêtre et d'une plage d'indices de tabulation.
+{{AddonSidebar}}Met en évidence (sélectionné) un ou plusieurs onglets. Les onglets sont spécifiés à l'aide d'un identifiant de fenêtre et d'une plage d'indices de tabulation.
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
@@ -3,7 +3,7 @@ title: tabs.insertCSS()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Injecter du code CSS dans une page web.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/move/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/move/index.md
@@ -3,7 +3,7 @@ title: tabs.move()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/move
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Déplace un ou plusieurs onglets vers une nouvelle position dans la même fenêtre ou vers une autre fenêtre.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/moveinsuccession/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/moveinsuccession/index.md
@@ -3,7 +3,7 @@ title: tabs.moveInSuccession()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/moveInSuccession
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Modifie la relation de succession pour un groupe d'onglets.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
@@ -3,7 +3,7 @@ title: tabs.MutedInfo
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfo
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Cet objet contient un booléen indiquant si l'onglet est muet et la raison du dernier changement d'état.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
@@ -3,7 +3,7 @@ title: tabs.MutedInfoReason
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfoReason
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Spécifie la raison pour laquelle un onglet a été désactivé ou désactivé.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
@@ -3,7 +3,7 @@ title: tabs.onActivated
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onActivated
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Se déclenche lorsque l'onglet actif dans une fenêtre change. Notez que l'URL de l'onglet peut ne pas être définie au moment où cet événement s'est déclenché, mais vous pouvez écouter les événements {{WebExtAPIRef("tabs.onUpdated")}} pour être averti lorsqu'une URL est définie.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.md
@@ -3,7 +3,7 @@ title: tabs.onActiveChanged
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onActiveChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 > **Attention :** Cet événement est obsolète. Utilisez {{WebExtAPIRef("tabs.onActivated")}} à la place.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onattached/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onattached/index.md
@@ -3,7 +3,7 @@ title: tabs.onAttached
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onAttached
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'un onglet est attaché à une fenêtre, par exemple parce qu'il a été déplacé entre les fenêtres.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/oncreated/index.md
@@ -3,7 +3,7 @@ title: tabs.onCreated
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onCreated
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'un onglet est créé.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/ondetached/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/ondetached/index.md
@@ -3,7 +3,7 @@ title: tabs.onDetached
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onDetached
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'un onglet est détaché d'une fenêtre, par exemple parce qu'il est déplacé entre des fenêtres.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.md
@@ -3,7 +3,7 @@ title: tabs.onHighlightChanged
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onHighlightChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 > **Attention :** Cet événement est obsolète. Utilisez {{WebExtAPIRef("tabs.onHighlighted")}} à la place.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.md
@@ -3,7 +3,7 @@ title: tabs.onHighlighted
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onHighlighted
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque l'ensemble des onglets en surbrillance dans une fenêtre change
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
@@ -3,7 +3,7 @@ title: tabs.onMoved
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onMoved
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'un onglet est déplacé dans une fenêtre
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onremoved/index.md
@@ -3,7 +3,7 @@ title: tabs.onRemoved
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onRemoved
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé quand un onglet est fermé.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.md
@@ -3,7 +3,7 @@ title: tabs.onReplaced
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onReplaced
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'un onglet est remplacé par un autre en raison d'un prérendering ou d'un instantané.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.md
@@ -3,7 +3,7 @@ title: tabs.onSelectionChanged
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onSelectionChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 > **Attention :** Cet événement est obsolète. Utilisez {{WebExtAPIRef("tabs.onActivated")}} à la place.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.md
@@ -3,7 +3,7 @@ title: tabs.onZoomChange
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onZoomChange
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Envoyé lorsqu'un onglet est agrandi.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/print/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/print/index.md
@@ -3,7 +3,7 @@ title: tabs.print()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/print
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Appelez cette fonction pour imprimer le contenu de l'onglet actif. Si cette fonction est appelée, l'utilisateur recevra la boîte de dialogue d'impression de la plate-forme sous-jacente et aura la possibilité de modifier les paramètres d'impression, puis d'imprimer l'onglet actuellement actif.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/printpreview/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/printpreview/index.md
@@ -3,7 +3,7 @@ title: tabs.printPreview()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/printPreview
 ---
 
-{{AddonSidebar()}}Ouvre l'aperçu avant impression pour l'onglet actif.C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).Une extension peut détecter lorsque l'aperçu d'impression a été fermé en écoutant l'événement [afterprint](/fr/docs/Web/Events/afterprint) :
+{{AddonSidebar}}Ouvre l'aperçu avant impression pour l'onglet actif.C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).Une extension peut détecter lorsque l'aperçu d'impression a été fermé en écoutant l'événement [afterprint](/fr/docs/Web/Events/afterprint) :
 
 ```js
 window.addEventListener("afterprint", resumeFunction, false);

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/query/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/query/index.md
@@ -3,7 +3,7 @@ title: tabs.query()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/query
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient tous les onglets qui ont les propriétés spécifiées, ou tous les onglets si aucune propriété n'est spécifiée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/reload/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/reload/index.md
@@ -3,7 +3,7 @@ title: tabs.reload()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/reload
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Rechargez un onglet, en contournant éventuellement le cache Web local.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/remove/index.md
@@ -3,7 +3,7 @@ title: tabs.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/remove
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Ferme un ou plusieurs onglets.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
@@ -3,7 +3,7 @@ title: tabs.removeCSS()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/removeCSS
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Supprime d'une page CSS précédemment injectée par un appel à {{WebExtAPIRef("tabs.insertCSS()")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/saveaspdf/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/saveaspdf/index.md
@@ -3,7 +3,7 @@ title: tabs.saveAsPDF()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/saveAsPDF
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Enregistre la page en cours en tant que fichier PDF. Cela ouvrira une boîte de dialogue, fournie par le système d'exploitation sous-jacent, demandant à l'utilisateur où il veut enregistrer le fichier PDF.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.md
@@ -3,7 +3,7 @@ title: tabs.sendMessage()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/sendMessage
 ---
 
-{{AddonSidebar()}}Envoi un message unique depuis le script d'arrière plan d'extension (ou autre scripts accrédité, comme les scripts popup ou les scripts de page d'options) vers n'importe quel [script de contenu](/fr/docs/Mozilla/Add-ons/WebExtensions/Content_scripts) concerné par l'extension et qui s'execute dans l'onglet spécifié.Ce message sera reçu dans script de contenu par n'importe quel gestionnaire d'évènements à l'écoute de l'évènement
+{{AddonSidebar}}Envoi un message unique depuis le script d'arrière plan d'extension (ou autre scripts accrédité, comme les scripts popup ou les scripts de page d'options) vers n'importe quel [script de contenu](/fr/docs/Mozilla/Add-ons/WebExtensions/Content_scripts) concerné par l'extension et qui s'execute dans l'onglet spécifié.Ce message sera reçu dans script de contenu par n'importe quel gestionnaire d'évènements à l'écoute de l'évènement
 
 {{WebExtAPIRef("runtime.onMessage")}}. Les gestionnaires d'évènements peuvent optionellement envoyé une réponse en retour au script d'arrière plan en utilisant l'argument `sendResponse`.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.md
@@ -3,7 +3,7 @@ title: tabs.sendRequest()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/sendRequest
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 > **Attention :** Cette méthode a été dépréciée. Utilisez {{WebExtAPIRef("tabs.sendMessage()")}} à la place.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
@@ -3,7 +3,7 @@ title: tabs.setZoom()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/setZoom
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Effectue un zoom sur l'onglet spécifié.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
@@ -3,7 +3,7 @@ title: tabs.setZoomSettings()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/setZoomSettings
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit les paramètres de zoom pour l'onglet spécifié. Ces paramètres sont réinitialisés aux paramètres par défaut lors de la navigation dans l'onglet.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/show/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/show/index.md
@@ -3,7 +3,7 @@ title: tabs.show()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/show
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Affiche un ou plusieurs onglets précédemment masqués par un appel à {{WebExtAPIRef("tabs.hide")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/tab/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/tab/index.md
@@ -3,7 +3,7 @@ title: tabs.Tab
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/Tab
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type **`tabs.Tab`** contient des informations sur un onglet. Cela donne accès à des informations sur le contenu de l'onglet, la taille du contenu, les états spéciaux ou les restrictions en vigueur, etc.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.md
@@ -3,7 +3,7 @@ title: tabs.TAB_ID_NONE
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/TAB_ID_NONE
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Une valeur d'ID spéciale donnée aux onglets qui ne sont pas des onglets du navigateur (par exemple, des onglets dans les fenêtres devtools).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.md
@@ -3,7 +3,7 @@ title: tabs.TabStatus
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/TabStatus
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Indique si l'onglet a terminé le chargement.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.md
@@ -3,7 +3,7 @@ title: tabs.toggleReaderMode()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/toggleReaderMode
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Bascule en mode Lecteur pour l'onglet donné.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/update/index.md
@@ -3,7 +3,7 @@ title: tabs.update()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/update
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Parcourez l'onglet vers une nouvelle URL ou modifiez d'autres propriétés de l'onglet.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/windowtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/windowtype/index.md
@@ -3,7 +3,7 @@ title: tabs.WindowType
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/WindowType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type de fenêtre qui héberge cet onglet.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
@@ -3,7 +3,7 @@ title: tabs.ZoomSettings
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettings
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit les paramètres de zoom pour un onglet : {{WebExtAPIRef("tabs.ZoomSettingsMode", "mode")}}, {{WebExtAPIRef("tabs.ZoomSettingsScope", "scope")}}, et le facteur de zoom par défaut.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.md
@@ -3,7 +3,7 @@ title: tabs.ZoomSettingsMode
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettingsMode
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit comment les modifications de zoom sont gérées. Les extensions peuvent transférer cette valeur dans {{WebExtAPIRef("tabs.setZoomSettings()")}} pour contrôler la façon dont le navigateur gère les tentatives de modification des paramètres de zoom pour un onglet. Par défaut à "automatique".
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.md
@@ -3,7 +3,7 @@ title: tabs.ZoomSettingsScope
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettingsScope
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Définit si les changements de zoom persisteront pour l'origine de la page ou ne prendront effet que dans cet onglet. La valeur par défaut est à `per-origin` lorsque {{WebExtAPIRef("tabs.zoomSettingsMode")}} est "automatique", et est toujours `per-tab`.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
@@ -3,7 +3,7 @@ title: theme.getCurrent()
 slug: Mozilla/Add-ons/WebExtensions/API/theme/getCurrent
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Retourne le theme utilisé actuellement sous la forme d'un objet {{WebExtAPIRef("theme.Theme", "Theme")}}. Les arguments disponible dans l'objet couleur sont listés dans les [propriétés de la couleur](/fr/Add-ons/WebExtensions/manifest.json/theme#colors).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/theme/onupdated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/theme/onupdated/index.md
@@ -3,7 +3,7 @@ title: theme.onUpdated
 slug: Mozilla/Add-ons/WebExtensions/API/theme/onUpdated
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'événement se déclenche lorsqu'un thème fourni en tant qu'extension de navigateur est appliqué ou supprimé, plus précisément :
 

--- a/files/fr/mozilla/add-ons/webextensions/api/theme/reset/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/theme/reset/index.md
@@ -3,7 +3,7 @@ title: theme.reset()
 slug: Mozilla/Add-ons/WebExtensions/API/theme/reset
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Réinitialise tout thème appliqué à l'aide de la méthode {{WebExtAPIRef("theme.update()")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/theme/theme/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/theme/theme/index.md
@@ -3,7 +3,7 @@ title: Theme
 slug: Mozilla/Add-ons/WebExtensions/API/theme/Theme
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet thème représente la spécification d'un thème.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/theme/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/theme/update/index.md
@@ -3,7 +3,7 @@ title: update
 slug: Mozilla/Add-ons/WebExtensions/API/theme/update
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Met à jour le thème du navigateur en fonction du contenu de l'objet {{WebExtAPIRef("theme.Theme", "Theme")}} donné.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/topsites/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/topsites/get/index.md
@@ -3,7 +3,7 @@ title: topSites.get()
 slug: Mozilla/Add-ons/WebExtensions/API/topSites/get
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient un tableau contenant des informations sur les pages que l'utilisateur a visitées souvent et récemment.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.md
@@ -3,7 +3,7 @@ title: topSites.MostVisitedURL
 slug: Mozilla/Add-ons/WebExtensions/API/topSites/MostVisitedURL
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type `MostVisitedURL` contient deux propriétés : le titre de la page et son URL.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
@@ -3,7 +3,7 @@ title: get()
 slug: Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/get
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La méthode `BrowserSetting.get()` obtient la valeur actuelle du paramètre du navigateur et une énumération indiquant comment la valeur du paramètre est actuellement controléee..
 

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/index.md
@@ -3,7 +3,7 @@ title: BrowserSetting
 slug: Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un `BrowserSetting` est un objet représentant un paramètre de navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.md
@@ -3,7 +3,7 @@ title: onChange
 slug: Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/onChange
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'événement `BrowserSetting.onChanged` est déclenché lorsque le paramètre est modifié.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
@@ -3,7 +3,7 @@ title: set()
 slug: Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/set
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Utilisez `BrowserSetting.set()` pour modifier le paramètre du navigateur vers une nouvelle valeur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/index.md
@@ -3,7 +3,7 @@ title: userScripts.RegisteredUserScript
 slug: Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un RegisteredUserScript est retourné par un appel à {{WebExtAPIRef("userScripts.register","userScripts.register()")}} et représente les scripts utilisateur enregistrés dans cet appel.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
@@ -3,7 +3,7 @@ title: webNavigation.getAllFrames()
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/getAllFrames
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Étant donné un ID d'onglet, récupère des informations sur toutes les images qu'il contient.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
@@ -3,7 +3,7 @@ title: webNavigation.getFrame()
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/getFrame
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Récupère des informations sur un cadre particulier. Un cadre peut être l'image de niveau supérieur dans un onglet ou un [iframe](/fr/docs/Web/HTML/Element/iframe) imbriqué, et est identifié de manière unique par un ID de tabulation et un ID de cadre.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
@@ -3,7 +3,7 @@ title: webNavigation.onBeforeNavigate
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onBeforeNavigate
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque le navigateur est sur le point de démarrer un événement de navigation.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
@@ -3,7 +3,7 @@ title: webNavigation.onCommitted
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onCommitted
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'une navigation est validée. Au moins une partie du nouveau document a été reçue du serveur et le navigateur a décidé de passer au nouveau document.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
@@ -3,7 +3,7 @@ title: webNavigation.onCompleted
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onCompleted
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'un document, y compris les ressources auxquelles il fait référence, est complètement chargé et initialisé. Ceci est équivalent à l'événement [`chargement`](/fr/docs/Web/Events/load) du DOM.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
@@ -3,7 +3,7 @@ title: webNavigation.onCreatedNavigationTarget
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onCreatedNavigationTarget
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'une nouvelle fenêtre ou un nouvel onglet dans une fenêtre existante est créé pour héberger la cible d'une navigation. Par exemple, cet événement est envoyé lorsque :
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
@@ -3,7 +3,7 @@ title: webNavigation.onDOMContentLoaded
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onDOMContentLoaded
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque l'événement [DOMContentLoaded](/fr/docs/Web/Events/DOMContentLoaded) est déclenché dans la page. À ce stade, le document est chargé et analysé, et le DOM est entièrement construit, mais les ressources liées telles que les images, les feuilles de style et les sous-trames peuvent ne pas encore être chargées.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
@@ -3,7 +3,7 @@ title: webNavigation.onErrorOccurred
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onErrorOccurred
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsqu'une erreur se produit et que la navigation est annulée. Cela peut se produire si une erreur réseau s'est produite ou si l'utilisateur a interrompu la navigation.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
@@ -3,7 +3,7 @@ title: webNavigation.onHistoryStateUpdated
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onHistoryStateUpdated
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque la page a utilisé l'[API history](http://diveintohtml5.info/history.html) pour mettre à jour l'URL affichée dans la barre d'adresse du navigateur. Tous les événements futurs de ce cadre utiliseront l'URL mise à jour.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
@@ -3,7 +3,7 @@ title: webNavigation.onReferenceFragmentUpdated
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onReferenceFragmentUpdated
 ---
 
-{{AddonSidebar()}}Lancé si [identificateur dee fragment](https://en.wikipedia.org/wiki/Fragment_identifier) d'une page est modifié. Par exemple, si une page implémente une table des matières à l'aide de fragments et que l'utilisateur clique sur une entrée dans la table des matières, cet événement se déclenche. Tous les événements futurs de ce cadre utiliseront l'URL mise à jour.
+{{AddonSidebar}}Lancé si [identificateur dee fragment](https://en.wikipedia.org/wiki/Fragment_identifier) d'une page est modifié. Par exemple, si une page implémente une table des matières à l'aide de fragments et que l'utilisateur clique sur une entrée dans la table des matières, cet événement se déclenche. Tous les événements futurs de ce cadre utiliseront l'URL mise à jour.
 
 ## Syntaxe
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
@@ -3,7 +3,7 @@ title: webNavigation.onTabReplaced
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/onTabReplaced
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque le contenu de l'onglet est remplacé par un onglet différent (généralement précédemment pré-rendu).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
@@ -3,7 +3,7 @@ title: webNavigation.TransitionQualifier
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/TransitionQualifier
 ---
 
-{{AddonSidebar()}}Informations supplémentaires sur une transition.Notez que beaucoup de valeurs ne sont actuellement pas supportées dans Firefox : voir la [table de compatibilité](/fr/Add-ons/WebExtensions/API/WebNavigation/TransitionQualifier#Browser_compatibility) pour plus de détails.
+{{AddonSidebar}}Informations supplémentaires sur une transition.Notez que beaucoup de valeurs ne sont actuellement pas supportées dans Firefox : voir la [table de compatibilité](/fr/Add-ons/WebExtensions/API/WebNavigation/TransitionQualifier#Browser_compatibility) pour plus de détails.
 
 ## Type
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.md
@@ -3,7 +3,7 @@ title: webNavigation.TransitionType
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation/TransitionType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Cause de la navigation: par exemple, l'utilisateur a cliqué sur un lien, ou a tapé une adresse, ou a cliqué sur un signet.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
@@ -3,7 +3,7 @@ title: webRequest.BlockingResponse
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/BlockingResponse
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet de ce type est renvoyé par les auditeurs d'événements qui ont défini le `"blocking"` dans leur argument `extraInfoSpec`.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.md
@@ -3,7 +3,7 @@ title: webRequest.CertificateInfo
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/CertificateInfo
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet décrivant un seul [certificat X.509](https://tools.ietf.org/html/rfc5280).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
@@ -3,7 +3,7 @@ title: webRequest.filterResponseData()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/filterResponseData
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Utilisez cette fonction pour créer un objet {{WebExtAPIRef("webRequest.StreamFilter")}} pour une requête particulière.
 Vous pouvez ensuite utiliser le filtre de flux pour surveiller et modifier la réponse. Vous appelez typiquement cette fonction à partir d'un écouteur d'événements `webRequest`.

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
@@ -3,7 +3,7 @@ title: webRequest.getSecurityInfo()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/getSecurityInfo
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Utilisez cette fonction pour obtenir des informations détaillées sur la connexion [TLS](/fr/docs/Glossaire/TLS) associée à une demande particulière..
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
@@ -3,7 +3,7 @@ title: webRequest.handlerBehaviorChanged()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/handlerBehaviorChanged
 ---
 
-{{AddonSidebar()}}Cette fonction peut être utilisée pour s'assurer que les auditeurs d'événements sont appliqués correctement lorsque les pages se trouvent dans le cache en mémoire du navigateur.Si le navigateur a chargé une page et que la page est rechargée, le navigateur peut recharger la page à partir de son cache en mémoire, et dans ce cas, les événements ne seront pas déclenchés pour la demande.
+{{AddonSidebar}}Cette fonction peut être utilisée pour s'assurer que les auditeurs d'événements sont appliqués correctement lorsque les pages se trouvent dans le cache en mémoire du navigateur.Si le navigateur a chargé une page et que la page est rechargée, le navigateur peut recharger la page à partir de son cache en mémoire, et dans ce cas, les événements ne seront pas déclenchés pour la demande.
 
 Supposons que le travail d'une extension consiste à bloquer les requêtes Web par rapport à un modèle, et le scénario suivant se produit :
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
@@ -3,7 +3,7 @@ title: webRequest.HttpHeaders
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/HttpHeaders
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un tableau d'en-tetes HTTP. Chaque en-tête est représenté comme un objet avec deux propriétés : `name` et `valeur` ou `binaryValue`.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
@@ -3,7 +3,7 @@ title: webRequest.onAuthRequired
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onAuthRequired
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Mise en place quand le serveur envoie un code status 401 ou 407 : c'est-à-dire lorsque le serveur demande au client de fournir des informations d'authentification telles qu'un nom d'utilisateur et un mot de passe.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
@@ -3,7 +3,7 @@ title: webRequest.onBeforeRedirect
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRedirect
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Déclenché lorsqu'une redirection initiée par le serveur est sur le point de se produire.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -3,7 +3,7 @@ title: webRequest.onBeforeRequest
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRequest
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Cet événement est déclenché lorsqu'une demande est sur le point d'être faite et avant que les en-têtes ne soient disponibles. C'est un bon endroit pour écouter si vous voulez annuler ou rediriger la demande.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
@@ -3,7 +3,7 @@ title: webRequest.onBeforeSendHeaders
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeSendHeaders
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Cet événement est déclenché avant l'envoi de données HTTP, mais après que tous les en-têtes HTTP soient disponibles. C'est un bon endroit pour écouter si vous voulez modifier les en-têtes de requête HTTP.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
@@ -3,7 +3,7 @@ title: webRequest.onCompleted
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onCompleted
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Utilisé lorsqu'une demande est complétée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
@@ -3,7 +3,7 @@ title: webRequest.onErrorOccurred
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onErrorOccurred
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Utilisé lorsqu'une demande n'a pas pu être traitée en raison d'une erreur : par exemple, un manque de connectivité Internet.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
@@ -3,7 +3,7 @@ title: webRequest.onHeadersReceived
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onHeadersReceived
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque les en-têtes de réponse HTTP associés à une requête ont été reçus. Vous pouvez utiliser cet événement pour modifier les en-têtes de réponse HTTP.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
@@ -3,7 +3,7 @@ title: webRequest.onResponseStarted
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onResponseStarted
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancé lorsque le premier octet du corps de réponse est reçu.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
@@ -3,7 +3,7 @@ title: webRequest.onSendHeaders
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/onSendHeaders
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Cet événement est déclenché juste avant l'envoi des en-têtes. Si votre extension ou une autre extension a modifié les en-têtes dans `{{WebExtAPIRef("webRequest.onBeforeSendHeaders", "onBeforeSendHeaders")}}`, vous verrez la version modifiée ici.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
@@ -3,7 +3,7 @@ title: webRequest.RequestFilter
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un objet décrivant les filtres à appliquer aux événements webRequest.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
@@ -3,7 +3,7 @@ title: webRequest.ResourceType
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Ce type est une chaîne de caractères, qui représente le contexte dans lequel une ressource a été récupérée dans une requête web.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.md
@@ -3,7 +3,7 @@ title: webRequest.SecurityInfo
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/SecurityInfo
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Objet décrivant les propriétés de sécurité d'une requête Web particulière. Un objet de ce type est retourné depuis l'API {{WebExtAPIRef("webRequest.getSecurityInfo()")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.md
@@ -3,7 +3,7 @@ title: webRequest.StreamFilter.close()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/close
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Ferme la demande. Après cet appel, aucune autre donnée de réponse ne sera transmise au moteur de rendu du navigateur et aucun autre événement de filtrage ne sera donné à l'extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
@@ -3,7 +3,7 @@ title: webRequest.StreamFilter.disconnect()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/disconnect
 ---
 
-{{AddonSidebar()}}Déconnecte le filtre de la requête. Après cela, le navigateur continuera à traiter la réponse, mais plus aucun événement de filtrage ne se déclenchera, et plus aucun appel de fonction de filtrage n'aura d'effet.Notez la différence entre cette fonction et {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}. Avec `disconnect()`, le navigateur continuera à traiter d'autres données de réponse, mais il ne sera pas accessible par le filtre. Avec `close()`, le navigateur ignorera toutes les données de réponse qui n'ont pas déjà été transmises au moteur de rendu.
+{{AddonSidebar}}Déconnecte le filtre de la requête. Après cela, le navigateur continuera à traiter la réponse, mais plus aucun événement de filtrage ne se déclenchera, et plus aucun appel de fonction de filtrage n'aura d'effet.Notez la différence entre cette fonction et {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}. Avec `disconnect()`, le navigateur continuera à traiter d'autres données de réponse, mais il ne sera pas accessible par le filtre. Avec `close()`, le navigateur ignorera toutes les données de réponse qui n'ont pas déjà été transmises au moteur de rendu.
 
 Vous devriez toujours appeler `disconnect()` ou `close()` une fois que vous n'avez plus besoin d'interagir avec la réponse.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.md
@@ -3,7 +3,7 @@ title: webRequest.Streamfilter.error
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/error
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Une chaîne de caractères qui contiendra un message d'erreur après le déclenchement de l'événement {{WebExtAPIRef("webRequest.StreamFilter.onerror", "onerror")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
@@ -3,7 +3,7 @@ title: webRequest.StreamFilter
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un `StreamFilter` est un objet que vous pouvez utiliser pour surveiller et modifier les réponses HTTP.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
@@ -3,7 +3,7 @@ title: webRequest.StreamFilter.ondata
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/ondata
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un gestionnaire d'événements qui sera appelé à plusieurs reprises lorsque les données de réponse sont disponibles. Le gestionnaire est passé un objet `event` qui contient une propriété de `data`, qui contient un morceau des données de réponse sous la forme d'un {{domxref("ArrayBuffer")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
@@ -3,7 +3,7 @@ title: webRequest.StreamFilter.onerror
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onerror
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un gestionnaire d'événements qui sera appelé lorsqu'une erreur se produit. C'est le plus souvent parce qu'un ID de requête invalide a été passé dans {{WebExtAPIRef("webRequest.filterResponseData()")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.md
@@ -3,7 +3,7 @@ title: webRequest.StreamFilter.onstart
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onstart
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un gestionnaire d'événements qui sera appelé lorsque le flux est ouvert et est sur le point de commencer à livrer les données. A partir de ce point, l'extension peut utiliser des fonctions de filtrage telles que {{WebExtAPIRef("webRequest.StreamFilter.write()", "write()")}}, {{WebExtAPIRef("webRequest.StreamFilter.disconnect()", "disconnect()")}}, ou {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.md
@@ -3,7 +3,7 @@ title: webRequest.StreamFilter.onstop
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onstop
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Un gestionnaire d'événements qui sera appelé lorsque le flux n'a plus de données à livrer. IDans le gestionnaire d'événements, vous pouvez toujours appeler des fonctions de filtrage telles que {{WebExtAPIRef("webRequest.StreamFilter.write()", "write()")}}, {{WebExtAPIRef("webRequest.StreamFilter.disconnect()", "disconnect()")}}, ou {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.md
@@ -3,7 +3,7 @@ title: webRequest.StreamFilter.resume()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/resume
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Reprend une requête qui a été précédemment suspendue par un appel à {{WebExtAPIRef("webRequest.StreamFilter.suspend()", "suspend()")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.md
@@ -3,7 +3,7 @@ title: webRequest.StreamFilter.status
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/status
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Une chaîne de caractères qui décrit l'état actuel de la demande. Ce sera l'une des valeurs suivantes :
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.md
@@ -3,7 +3,7 @@ title: webRequest.StreamFilter.suspend()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/suspend
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Suspend une demande. Après cet appel, plus aucune donnée ne sera livrée jusqu'à ce que la requête soit reprise avec un appel à {{WebExtAPIRef("webRequest.StreamFilter.resume()", "resume()")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
@@ -3,7 +3,7 @@ title: webRequest.StreamFilter.write()
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/write
 ---
 
-{{AddonSidebar()}}Écrit quelques données de réponse dans le flux de sortie..Vous ne pouvez appeler cette fonction qu'après le déclenchement de l'événement {{WebExtAPIRef("webRequest.StreamFilter.onstart", "onstart")}}.
+{{AddonSidebar}}Écrit quelques données de réponse dans le flux de sortie..Vous ne pouvez appeler cette fonction qu'après le déclenchement de l'événement {{WebExtAPIRef("webRequest.StreamFilter.onstart", "onstart")}}.
 
 ## Syntaxe
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
@@ -3,7 +3,7 @@ title: webRequest.UploadData
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/UploadData
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Contient les données téléchargées dans une requête URL..
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/create/index.md
@@ -3,7 +3,7 @@ title: windows.create()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/create
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Crée une nouvelle fenêtre.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/createtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/createtype/index.md
@@ -3,7 +3,7 @@ title: windows.CreateType
 slug: Mozilla/Add-ons/WebExtensions/API/windows/CreateType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Spécifie le type de fenêtre du navigateur à créer.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/get/index.md
@@ -3,7 +3,7 @@ title: windows.get()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/get
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient les détails sur une fenêtre, compte tenu de son identifiant. Les détails sont transmis à un rappel.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/getall/index.md
@@ -3,7 +3,7 @@ title: windows.getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/getAll
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient des informations sur toutes les fenêtres ouvertes, en les passant dans un rappel.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
@@ -3,7 +3,7 @@ title: windows.getCurrent()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/getCurrent
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient la fenêtre actuelle du navigateur, en passant ses détails dans un rappel.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
@@ -3,7 +3,7 @@ title: windows.getLastFocused()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/getLastFocused
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Obtient la fenêtre qui a été recentrée récemment — généralement la fenêtre 'en haut'.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
@@ -3,7 +3,7 @@ title: windows.onCreated
 slug: Mozilla/Add-ons/WebExtensions/API/windows/onCreated
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancer quand la fenêtre est créée
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
@@ -3,7 +3,7 @@ title: windows.onFocusChanged
 slug: Mozilla/Add-ons/WebExtensions/API/windows/onFocusChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Attiré lorsque la fenêtre actuellement change. Sera {{WebExtAPIRef('windows.WINDOW_ID_NONE')}} si toutes les fenêtres du navigateur ont perdu le focus.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
@@ -3,7 +3,7 @@ title: windows.onRemoved
 slug: Mozilla/Add-ons/WebExtensions/API/windows/onRemoved
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Lancer quand une fenêtre est fermée.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/remove/index.md
@@ -3,7 +3,7 @@ title: windows.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/remove
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Ferme une fenêtre et tous les onglets à l'intérieur, compte tenu de l'ID de la fenêtre.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/update/index.md
@@ -3,7 +3,7 @@ title: windows.update()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/update
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Mises à jour des propriétés d'une fenêtre. Utilisez ceci pour déplacer, redimensionner, et (un) se concentrer sur une fenêtre, etc.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/window/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/window/index.md
@@ -3,7 +3,7 @@ title: windows.Window
 slug: Mozilla/Add-ons/WebExtensions/API/windows/Window
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Informations sur une fenêtre du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/window_id_current/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/window_id_current/index.md
@@ -3,7 +3,7 @@ title: windows.WINDOW_ID_CURRENT
 slug: Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_CURRENT
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 `browser.windows.WINDOW_ID_CURRENT` est une valeur qui peut être utilisée comme paramètre `windowId` dans certaines APIs pour représenter la fenêtre courante.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/window_id_none/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/window_id_none/index.md
@@ -3,7 +3,7 @@ title: windows.WINDOW_ID_NONE
 slug: Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_NONE
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 La valeur `windowId` que représente l'absence d'une fenêtre du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
@@ -3,7 +3,7 @@ title: windows.WindowState
 slug: Mozilla/Add-ons/WebExtensions/API/windows/WindowState
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'état de cette fenêtre du navigateur.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
@@ -3,7 +3,7 @@ title: windows.WindowType
 slug: Mozilla/Add-ons/WebExtensions/API/windows/WindowType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Le type de la fenêtre du navigateur est comme çà.
 

--- a/files/fr/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -3,7 +3,7 @@ title: Construction d'une extension multi-navigateur
 slug: Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 L'introduction de l'API WebExtension a créé un paysage plus homogène pour le développement des extensions des navigateurs. Cependant, parmi les navigateurs qui utilisent les API d'extensions (les principaux étant Chrome, Firefox, Opera et Edge), il existe des différences à la fois dans l'implémentation de l'API et dans la couverture des différentes fonctionnalités. Par ailleurs, Safari utilise ses propres extensions Safari Extensions JS.
 

--- a/files/fr/mozilla/add-ons/webextensions/user_interface/extension_pages/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/user_interface/extension_pages/index.md
@@ -3,7 +3,7 @@ title: Extension pages
 slug: Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Vous pouvez inclure des pages HTML dans votre extension sous la forme de formulaires, d'aide ou tout autre contenu dont votre extension a besoin.
 

--- a/files/fr/mozilla/add-ons/webextensions/user_interface/omnibox/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/user_interface/omnibox/index.md
@@ -3,7 +3,7 @@ title: Suggestions de la barre d'adresse
 slug: Mozilla/Add-ons/WebExtensions/user_interface/Omnibox
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 En utilisant l'API {{WebExtAPIRef("omnibox")}}, WebExtensions peut personnaliser les suggestions proposées dans la liste déroulante de la barre d'adresse du navigateur lorsque l'utilisateur entre un mot-clé.
 

--- a/files/fr/mozilla/add-ons/webextensions/working_with_files/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/working_with_files/index.md
@@ -3,7 +3,7 @@ title: Travailler avec des fichiers
 slug: Mozilla/Add-ons/WebExtensions/Working_with_files
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 Votre extension de navigateur peut avoir besoin de fichiers pour offrir des fonctionnalités complètes. Cet article examine les cinq mécanismes permettant de gérer les fichiers :
 


### PR DESCRIPTION
### Description

This PR unifies `{{AddonSidebar}}` macro usage by removing unnecessary parentheses in `fr` locale

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/31844