### PR TITLE
[ko] unify `{{AddonSidebar}}` macro usage (remove unnecessary parentheses)

### DIFF
--- a/files/ko/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
+++ b/files/ko/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: 2c5465eab20015868a1eeca59c5623d37b105f7c
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 메뉴 항목이 표시될 수 있는 컨텍스트들입니다.
 

--- a/files/ko/mozilla/add-ons/webextensions/api/pageaction/show/index.md
+++ b/files/ko/mozilla/add-ons/webextensions/api/pageaction/show/index.md
@@ -3,7 +3,7 @@ title: pageAction.show()
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/show
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 지정한 탭의 페이지 액션을 보인다. 페이지 액션은 해당 탭이 활성일 때 표시된다.
 

--- a/files/ko/mozilla/add-ons/webextensions/api/storage/local/index.md
+++ b/files/ko/mozilla/add-ons/webextensions/api/storage/local/index.md
@@ -3,7 +3,7 @@ title: storage.local
 slug: Mozilla/Add-ons/WebExtensions/API/storage/local
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 `local` 저장소 영역을 표현한다. `local` 저장소의 항목은 확장이 설치된 기기에 제한된다.
 

--- a/files/ko/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/ko/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -3,7 +3,7 @@ title: StorageArea.get()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 저장소에서 하나 이상의 항목을 가져온다.
 

--- a/files/ko/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
+++ b/files/ko/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
@@ -3,7 +3,7 @@ title: StorageArea.set()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 저장소 영역에 하나 이상의 항목을 저장하거나, 있는 항목을 고친다.
 

--- a/files/ko/mozilla/add-ons/webextensions/api/storage/sync/index.md
+++ b/files/ko/mozilla/add-ons/webextensions/api/storage/sync/index.md
@@ -3,7 +3,7 @@ title: storage.sync
 slug: Mozilla/Add-ons/WebExtensions/API/storage/sync
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 `sync` 저장 공간을 의미합니다. `sync` 저장 공간에 있는 데이터는 브라우저 사이에서 동기화되며 서로 다른 기기 간에 사용자가 브라우저에 로그인 한 경우 언제든지 접근 가능합니다.
 

--- a/files/ko/mozilla/add-ons/webextensions/api/tabs/create/index.md
+++ b/files/ko/mozilla/add-ons/webextensions/api/tabs/create/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: 8d4f5dfc253d1d0181d72ce5debaf1bcc26112ef
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 새 탭을 만듭니다.
 


### PR DESCRIPTION
### Description

This PR unifies `{{AddonSidebar}}` macro usage by removing unnecessary parentheses in `ko` locale

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/31844