### PR TITLE
[zh-cn] unify `{{AddonSidebar}}` macro usage (remove unnecessary parentheses)

### DIFF
--- a/files/zh-cn/mozilla/add-ons/webextensions/api/alarms/create/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/alarms/create/index.md
@@ -3,7 +3,7 @@ title: alarms.create()
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/create
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 创建一个新的 alarm.
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -3,7 +3,7 @@ title: bookmarks.BookmarkTreeNode
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 代表书签树中的一个节点（书签或文件夹），子节点在它们的父文件夹中按顺序排列。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
@@ -3,7 +3,7 @@ title: bookmarks.getTree()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/getTree
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 **`bookmarks.getTree()`** 返回一个数组，该数组每一项为{{WebExtAPIRef("bookmarks.BookmarkTreeNode")}}对象，作为书签树的根节点。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
@@ -3,7 +3,7 @@ title: bookmarks.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/remove
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 **`bookmarks.remove()`** 方法用于删除单个书签或一个空的书签文件夹。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
@@ -3,7 +3,7 @@ title: clipboard.setImageData()
 slug: Mozilla/Add-ons/WebExtensions/API/clipboard/setImageData
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 将图像复制到剪贴板。在将图像写入剪贴板之前，会对图像进行重新编码。如果图像无效，则不会修改剪贴板。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
@@ -3,7 +3,7 @@ title: cookies.Cookie
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/Cookie
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 The `Cookie` type of the {{WebExtAPIRef("cookies")}} API represents information about an HTTP cookie.
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/downloads/download/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/downloads/download/index.md
@@ -3,7 +3,7 @@ title: downloads.download()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/download
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 {{WebExtAPIRef("downloads")}} API 的 **`download()`** 函数根据给出的 URL 和其他首选项下载一个文件。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
@@ -3,7 +3,7 @@ title: downloads.DownloadItem
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/DownloadItem
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 {{WebExtAPIRef("downloads")}} API 的 `DownloadItem` 类代表了一个被下载的文件。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
@@ -3,7 +3,9 @@ title: 连接本地应用程序方法 - runtime.connectNative()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/connectNative
 ---
 
-{{AddonSidebar}}该方法能够把附加组件和用户计算机上的一个本地应用程序相连接。同时我们需要本地应用程序的名称作为参数。当启动本地应用程序的时候会返回一个{{WebExtAPIRef("runtime.Port")}} 对象给调用者。之后可以通过该对象的 Port.onMessage() 和 Port.postMessage() 方法来和本地应用程序进行信息交互。本地应用程序会一直运行直到退出，除非调用了 `Port.disconnect()`方法，亦或创建该 Port 对象的页面被摧毁了。一旦 Port 对象断开连接，浏览器会给该进程几秒的时间以便安全优雅的退出和释放，之后如果发现该进程没退出的话就直接暴力干掉。
+{{AddonSidebar}}
+
+该方法能够把附加组件和用户计算机上的一个本地应用程序相连接。同时我们需要本地应用程序的名称作为参数。当启动本地应用程序的时候会返回一个{{WebExtAPIRef("runtime.Port")}} 对象给调用者。之后可以通过该对象的 Port.onMessage() 和 Port.postMessage() 方法来和本地应用程序进行信息交互。本地应用程序会一直运行直到退出，除非调用了 `Port.disconnect()`方法，亦或创建该 Port 对象的页面被摧毁了。一旦 Port 对象断开连接，浏览器会给该进程几秒的时间以便安全优雅的退出和释放，之后如果发现该进程没退出的话就直接暴力干掉。
 
 更多信息，请查看 [Native messaging](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/Native_messaging).
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
@@ -3,7 +3,7 @@ title: 连接本地应用程序方法 - runtime.connectNative()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/connectNative
 ---
 
-{{AddonSidebar()}}该方法能够把附加组件和用户计算机上的一个本地应用程序相连接。同时我们需要本地应用程序的名称作为参数。当启动本地应用程序的时候会返回一个{{WebExtAPIRef("runtime.Port")}} 对象给调用者。之后可以通过该对象的 Port.onMessage() 和 Port.postMessage() 方法来和本地应用程序进行信息交互。本地应用程序会一直运行直到退出，除非调用了 `Port.disconnect()`方法，亦或创建该 Port 对象的页面被摧毁了。一旦 Port 对象断开连接，浏览器会给该进程几秒的时间以便安全优雅的退出和释放，之后如果发现该进程没退出的话就直接暴力干掉。
+{{AddonSidebar}}该方法能够把附加组件和用户计算机上的一个本地应用程序相连接。同时我们需要本地应用程序的名称作为参数。当启动本地应用程序的时候会返回一个{{WebExtAPIRef("runtime.Port")}} 对象给调用者。之后可以通过该对象的 Port.onMessage() 和 Port.postMessage() 方法来和本地应用程序进行信息交互。本地应用程序会一直运行直到退出，除非调用了 `Port.disconnect()`方法，亦或创建该 Port 对象的页面被摧毁了。一旦 Port 对象断开连接，浏览器会给该进程几秒的时间以便安全优雅的退出和释放，之后如果发现该进程没退出的话就直接暴力干掉。
 
 更多信息，请查看 [Native messaging](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/Native_messaging).
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
@@ -3,7 +3,9 @@ title: 读取主文件信息方法 - runtime.getManifest()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getManifest
 ---
 
-{{AddonSidebar}}该方法会获取一个完整的主文件 [manifest.json](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/manifest.json), 并返回一个序列化后的 JSON 对象。
+{{AddonSidebar}}
+
+该方法会获取一个完整的主文件 [manifest.json](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/manifest.json)，并返回一个序列化后的 JSON 对象。
 
 ## 语法
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
@@ -3,7 +3,7 @@ title: 读取主文件信息方法 - runtime.getManifest()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getManifest
 ---
 
-{{AddonSidebar()}}该方法会获取一个完整的主文件 [manifest.json](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/manifest.json), 并返回一个序列化后的 JSON 对象。
+{{AddonSidebar}}该方法会获取一个完整的主文件 [manifest.json](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/manifest.json), 并返回一个序列化后的 JSON 对象。
 
 ## 语法
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
@@ -3,7 +3,7 @@ title: runtime.onConnect
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onConnect
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 当使用扩展处理或 content script 建立连接时触发。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
@@ -3,7 +3,7 @@ title: 获取处理器架构 - runtime.PlatformArch
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 当前浏览器所在的计算机的处理器架构。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
@@ -3,7 +3,7 @@ title: 获取当前操作系统 - runtime.PlatformOs
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/PlatformOs
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 获取当前浏览器运行所在的操作系统。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: d6856a051d0ba078ec1d24b80908b1ca174917db
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 向你的扩展或其他扩展中的事件监听器发送一条消息。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
@@ -3,7 +3,7 @@ title: runtime.sendNativeMessage()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/sendNativeMessage
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 从 WebExtension 发送单条消息到 native application。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/search/search/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/search/search/index.md
@@ -3,7 +3,7 @@ title: search.search()
 slug: Mozilla/Add-ons/WebExtensions/API/search/search
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 使用指定的搜索引擎或默认搜索引擎进行搜索。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/sessions/session/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/sessions/session/index.md
@@ -3,7 +3,7 @@ title: sessions.Session
 slug: Mozilla/Add-ons/WebExtensions/API/sessions/Session
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 该`Session`对象表示用户在当前浏览会话中已关闭的选项卡或窗口。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
@@ -3,7 +3,7 @@ title: tabs.insertCSS()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 向一个页面注入 CSS
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
@@ -3,7 +3,7 @@ title: tabs.onActivated
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onActivated
 ---
 
-{{AddonSidebar()}}当窗体的活动标签变化时触发。请注意事件触发时标签的 URL 可能尚未设置，但是你可以通过监听 {{WebExtAPIRef("tabs.onUpdated")}} 事件在 URL 被设置后得到通知。
+{{AddonSidebar}}当窗体的活动标签变化时触发。请注意事件触发时标签的 URL 可能尚未设置，但是你可以通过监听 {{WebExtAPIRef("tabs.onUpdated")}} 事件在 URL 被设置后得到通知。
 
 ## 语法
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
@@ -3,7 +3,9 @@ title: tabs.onActivated
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onActivated
 ---
 
-{{AddonSidebar}}当窗体的活动标签变化时触发。请注意事件触发时标签的 URL 可能尚未设置，但是你可以通过监听 {{WebExtAPIRef("tabs.onUpdated")}} 事件在 URL 被设置后得到通知。
+{{AddonSidebar}}
+
+当窗体的活动标签变化时触发。请注意事件触发时标签的 URL 可能尚未设置，但是你可以通过监听 {{WebExtAPIRef("tabs.onUpdated")}} 事件在 URL 被设置后得到通知。
 
 ## 语法
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/tabs/query/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/tabs/query/index.md
@@ -3,7 +3,7 @@ title: tabs.query()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/query
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 获取具有指定属性的所有标签页，如果未指定任何属性，则获取所有标签页。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/tabs/tab/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/tabs/tab/index.md
@@ -3,7 +3,7 @@ title: tabs.Tab
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/Tab
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 **`tabs.Tab`** 包含有关标签页的信息 . 这样可以访问有关标签页中的内容，内容有多大，特殊状态或限制有效的信息等等。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: 5ff95690a38837afa6a80d00c31adc3ea0217a6e
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 在页面中触发 [DOMContentLoaded](/zh-CN/docs/Web/API/Document/DOMContentLoaded_event) 事件时触发。此时，文档被加载和解析，并且 DOM 被完全构造，但链接的资源（例如图像、样式表和子框架）可能尚未被加载。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
@@ -3,7 +3,7 @@ title: webRequest.RequestFilter
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 webRequest 事件参数
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/windows/create/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/windows/create/index.md
@@ -3,7 +3,7 @@ title: windows.create()
 slug: Mozilla/Add-ons/WebExtensions/API/windows/create
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 创建一个新的窗口。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
@@ -3,7 +3,7 @@ title: windows.WindowState
 slug: Mozilla/Add-ons/WebExtensions/API/windows/WindowState
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 浏览器窗口的状态。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
@@ -3,7 +3,7 @@ title: windows.WindowType
 slug: Mozilla/Add-ons/WebExtensions/API/windows/WindowType
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 浏览器窗口的类型。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -3,7 +3,7 @@ title: 构建一个跨浏览器的扩展程序
 slug: Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 浏览器扩展 API 的引入为浏览器扩展的开发创造了“一次开发跨浏览器”的前景。然而，在使用扩展 API 的浏览器中 (主要是 Chrome、Firefox、Opera 和 Edge) ，API 的实现和覆盖范围都存在差异。除此之外，Safari 使用了它自己的 Safari 扩展脚本系统。
 


### PR DESCRIPTION
### Description

This PR unifies `{{AddonSidebar}}` macro usage by removing unnecessary parentheses in `zh-cn` locale

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/31844