### PR TITLE
[zh-tw] unify `{{AddonSidebar}}` macro usage (remove unnecessary parentheses)

### DIFF
--- a/files/zh-tw/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
+++ b/files/zh-tw/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
@@ -3,7 +3,7 @@ title: cookies.CookieStore
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/CookieStore
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 {{WebExtAPIRef("cookies")}} API 的 `CookieStore` 型別代表瀏覽器中的 cookie 存放空間。
 

--- a/files/zh-tw/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
+++ b/files/zh-tw/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
@@ -3,7 +3,7 @@ title: cookies.onChanged
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/onChanged
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 {{WebExtAPIRef("cookies")}} API 的 `onChanged` 事件會在 cookie 設定或刪除時觸發。
 

--- a/files/zh-tw/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
+++ b/files/zh-tw/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
@@ -3,7 +3,7 @@ title: cookies.OnChangedCause
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/OnChangedCause
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 {{WebExtAPIRef("cookies")}} API 的 `OnChangedCause` 型別，代表觸發 cookie 資料變動的原因。
 

--- a/files/zh-tw/mozilla/add-ons/webextensions/api/storage/local/index.md
+++ b/files/zh-tw/mozilla/add-ons/webextensions/api/storage/local/index.md
@@ -3,7 +3,7 @@ title: storage.local
 slug: Mozilla/Add-ons/WebExtensions/API/storage/local
 ---
 
-{{AddonSidebar()}}
+{{AddonSidebar}}
 
 代表 `local` 儲存空間。通常 `local` 裡面的東西，會放在套件安裝的地方。
 


### PR DESCRIPTION
### Description

This PR unifies `{{AddonSidebar}}` macro usage by removing unnecessary parentheses in `zh-tw` locale

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/31844