### PR TITLE
[zh-cn] improve value type on `Web/SVG/Attribute/cx` and `Web/SVG/Attribute/cy`

### DIFF
--- a/files/zh-cn/web/svg/attribute/cx/index.md
+++ b/files/zh-cn/web/svg/attribute/cx/index.md
@@ -38,10 +38,22 @@ svg {
 
 对于 {{SVGElement('circle')}}，`cx` 用来定义图形中心的 x 轴坐标。
 
-| 值     | **[\<length>](/zh-CN/docs/Web/SVG/Content_type#Length)** \| **[\<percentage>](/zh-CN/docs/Web/SVG/Content_type#Percentage)** |
-| ------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| 默认值 | `0`                                                                                                                          |
-| 可变性 | Yes                                                                                                                          |
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">值</th>
+      <td>{{cssxref("length-percentage")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">默认值</th>
+      <td><code>0</code></td>
+    </tr>
+    <tr>
+      <th scope="row">可变性</th>
+      <td>Yes</td>
+    </tr>
+  </tbody>
+</table>
 
 注：起始于 SVG2 `cx`，是一个几何属性，意味着该属性也可以用作圆的 CSS 属性。
 
@@ -49,10 +61,22 @@ svg {
 
 对于 {{SVGElement('ellipse')}}，`cx` 用来定义图形中心的 x 轴坐标。
 
-| 值     | **[\<length>](/zh-CN/docs/Web/SVG/Content_type#Length)** \| **[\<percentage>](/zh-CN/docs/Web/SVG/Content_type#Percentage)** |
-| ------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| 默认值 | `0`                                                                                                                          |
-| 可变性 | Yes                                                                                                                          |
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">值</th>
+      <td>{{cssxref("length-percentage")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">默认值</th>
+      <td><code>0</code></td>
+    </tr>
+    <tr>
+      <th scope="row">可变性</th>
+      <td>Yes</td>
+    </tr>
+  </tbody>
+</table>
 
 **注：** 起始于 SVG2 `cx`，是一个几何属性，意味着该属性也可以用作椭圆的 CSS 属性。
 
@@ -60,10 +84,22 @@ svg {
 
 对于 {{SVGElement('radialGradient')}}, `cx` 用来定义径向渐变终止圆的 x 轴坐标。
 
-| 值     | **[\<length>](/zh-CN/docs/Web/SVG/Content_type#Length)** |
-| ------ | -------------------------------------------------------- |
-| 默认值 | `50%`                                                    |
-| 可变性 | Yes                                                      |
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">值</th>
+      <td>{{cssxref("length-percentage")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">默认值</th>
+      <td><code>50%</code></td>
+    </tr>
+    <tr>
+      <th scope="row">可变性</th>
+      <td>Yes</td>
+    </tr>
+  </tbody>
+</table>
 
 #### 示例
 
@@ -126,3 +162,8 @@ svg {
 ## 规范
 
 {{Specifications}}
+
+## 参见
+
+- {{SVGAttr("cy")}}
+- {{SVGAttr("r")}}

--- a/files/zh-cn/web/svg/attribute/cy/index.md
+++ b/files/zh-cn/web/svg/attribute/cy/index.md
@@ -38,10 +38,22 @@ svg {
 
 对于 {{SVGElement('circle')}}，`cy` 用来定义图形中心的 y 轴坐标。
 
-| 值     | **[\<length>](/zh-CN/docs/Web/SVG/Content_type#Length)** \| **[\<percentage>](/zh-CN/docs/Web/SVG/Content_type#Percentage)** |
-| ------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| 默认值 | `0`                                                                                                                          |
-| 可变性 | Yes                                                                                                                          |
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">值</th>
+      <td>{{cssxref("length-percentage")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">默认值</th>
+      <td><code>0</code></td>
+    </tr>
+    <tr>
+      <th scope="row">可变性</th>
+      <td>Yes</td>
+    </tr>
+  </tbody>
+</table>
 
 **注：**起始于 SVG2，`cy` 是一个几何属性，意味着该属性也可以用作圆的 CSS 属性。
 
@@ -49,10 +61,22 @@ svg {
 
 对于 {{SVGElement('ellipse')}}，`cy` 用来定义图形中心的 y 轴坐标。
 
-| 值     | **[\<length>](/zh-CN/docs/Web/SVG/Content_type#Length)** \| **[\<percentage>](/zh-CN/docs/Web/SVG/Content_type#Percentage)** |
-| ------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| 默认值 | `0`                                                                                                                          |
-| 可变性 | Yes                                                                                                                          |
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">值</th>
+      <td>{{cssxref("length-percentage")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">默认值</th>
+      <td><code>0</code></td>
+    </tr>
+    <tr>
+      <th scope="row">可变性</th>
+      <td>Yes</td>
+    </tr>
+  </tbody>
+</table>
 
 **注：**起始于 SVG2，`cy` 是一个几何属性，意味着该属性也可以用作椭圆的 CSS 属性。
 
@@ -60,10 +84,22 @@ svg {
 
 对于 {{SVGElement('radialGradient')}}，`cy` 用来定义径向渐变终止圆的 y 轴坐标。
 
-| 值     | **[\<length>](/zh-CN/docs/Web/SVG/Content_type#Length)** |
-| ------ | -------------------------------------------------------- |
-| 默认值 | `50%`                                                    |
-| 可变性 | Yes                                                      |
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">值</th>
+      <td>{{cssxref("length-percentage")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">默认值</th>
+      <td><code>50%</code></td>
+    </tr>
+    <tr>
+      <th scope="row">可变性</th>
+      <td>Yes</td>
+    </tr>
+  </tbody>
+</table>
 
 #### 示例
 
@@ -126,3 +162,8 @@ svg {
 ## 规范
 
 {{Specifications}}
+
+## 参见
+
+- {{SVGAttr("cx")}}
+- {{SVGAttr("r")}}


### PR DESCRIPTION
### Description

This PR improves value type on `Web/SVG/Attribute/cx` and `Web/SVG/Attribute/cy` for `zh-cn` locale: 
- sets `length-percentage` for `radialGradient`,
- applies modern markup (`{{cssxref("length-percentage")}}`),
- adds `See also` section.

### Motivation

The desire to improve the markup and bring it to a unified look.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/31003
