### PR TITLE
[ru] fix `{{cssxref}}` macro usage on `Learn/CSS/Building_blocks/Backgrounds_and_borders` page

### DIFF
--- a/files/ru/learn/css/building_blocks/backgrounds_and_borders/index.md
+++ b/files/ru/learn/css/building_blocks/backgrounds_and_borders/index.md
@@ -194,7 +194,7 @@ background-position:
 - `background-color` можно указывать только после последней запятой.
 - Значения `background-size` могут быть включены только сразу после `background-position`, разделённые символом '/', например: `center/80%`.
 
-Посетите страницу MDN свойства {{cssref ("background")}}, чтобы увидеть полное описание.
+Посетите страницу MDN свойства {{cssxref("background")}}, чтобы увидеть полное описание.
 
 {{EmbedGHLiveSample("css-examples/learn/backgrounds-borders/background.html", '100%', 600)}}
 


### PR DESCRIPTION
### Description

This PR fixes `{{cssxref}}` macro usage on `Learn/CSS/Building_blocks/Backgrounds_and_borders` page in `ru` locale

### Related issues and pull requests

Relates to #18021