### PR TITLE
[es] unify `{{CSSRef}}` macro usage (remove unused parameter)

### DIFF
--- a/files/es/web/css/background-blend-mode/index.md
+++ b/files/es/web/css/background-blend-mode/index.md
@@ -3,7 +3,7 @@ title: background-blend-mode
 slug: Web/CSS/background-blend-mode
 ---
 
-{{CSSRef()}}
+{{CSSRef}}
 
 ## Resumen
 

--- a/files/es/web/css/border-image/index.md
+++ b/files/es/web/css/border-image/index.md
@@ -3,7 +3,7 @@ title: border-image
 slug: Web/CSS/border-image
 ---
 
-{{CSSRef("CSS Borders")}}
+{{CSSRef}}
 
 ## Resumen
 

--- a/files/es/web/css/child_combinator/index.md
+++ b/files/es/web/css/child_combinator/index.md
@@ -3,7 +3,7 @@ title: Selectores de hijo
 slug: Web/CSS/Child_combinator
 ---
 
-{{CSSRef("Selectors")}}
+{{CSSRef}}
 
 El combinador `>` separa a dos selectores y busca solo a los elementos que coindicen con el segundo selector y que son hijos **directos** del primero. EN contraste, cuando se combinan dos selectores con el [selector de descendiente](/es/docs/Web/CSS/Descendant_selectors), la expresión busca elementos que coinciden con el segundo selector y que tienen algun ancestro que coindice con el primero, sin importar el nivel de separación que tengan dentro del DOM.
 

--- a/files/es/web/css/class_selectors/index.md
+++ b/files/es/web/css/class_selectors/index.md
@@ -3,7 +3,7 @@ title: Selectores de clase
 slug: Web/CSS/Class_selectors
 ---
 
-{{CSSRef("Selectors")}}
+{{CSSRef}}
 
 En un documento HTML, los selectores de clase buscan un elemento basado en el contenido de su atributo `class`. El atributo [`class`](/es/docs/Web/HTML/Global_attributes#class) está definido como una lista de elementos separados por espacio, y uno de esos elementos debe coincidir exactamente con el nombre de clase dado en el selector.
 

--- a/files/es/web/css/margin-bottom/index.md
+++ b/files/es/web/css/margin-bottom/index.md
@@ -3,7 +3,7 @@ title: margin-bottom
 slug: Web/CSS/margin-bottom
 ---
 
-{{CSSRef()}}
+{{CSSRef}}
 
 ## Summary
 

--- a/files/es/web/css/next-sibling_combinator/index.md
+++ b/files/es/web/css/next-sibling_combinator/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/Next-sibling_combinator
 original_slug: Web/CSS/Adjacent_sibling_combinator
 ---
 
-{{CSSRef("Selectors")}}
+{{CSSRef}}
 
 Se hace referencia a este selector como selector adyacente o selector del próximo hermano. Sólo seleccionará un elemento especificado que esté inmediatamente después de otro elemento especificado.
 

--- a/files/es/web/css/position/index.md
+++ b/files/es/web/css/position/index.md
@@ -5,7 +5,7 @@ slug: Web/CSS/position
 
 {{CSSRef}}
 
-La propiedad **`position`** de [CSS](/es/docs/CSS) especifica cómo un elemento es posicionado en el documento. Las propiedades {{Cssxref("top")}}, {{Cssxref("right")}}, {{Cssxref("bottom")}}, y {{Cssxref("left")}} determinan la ubicación final de los elementos posicionados.
+La propiedad **`position`** de [CSS](/es/docs/Web/CSS) especifica cómo un elemento es posicionado en el documento. Las propiedades {{Cssxref("top")}}, {{Cssxref("right")}}, {{Cssxref("bottom")}}, y {{Cssxref("left")}} determinan la ubicación final de los elementos posicionados.
 
 {{EmbedInteractiveExample("pages/css/position.html")}}
 
@@ -13,17 +13,17 @@ El código fuente de este ejemplo interactivo se encuentra almacenado en un repo
 
 ### Tipos de posicionamiento
 
-- Un **elemento posicionado** es un elemento cuyo valor [computado](/es/docs/CSS/computed_value) de `position` es `relative`, `absolute`, `fixed`, o `sticky`. (En otras palabras, cualquiera excepto `static`).
-- Un **elemento posicionado relativamente** es un elemento cuyo valor [computado](/es/docs/CSS/computed_value) de `position` es `relative`. Las propiedades {{Cssxref("top")}} y {{Cssxref("bottom")}} especifican el desplazamiento vertical desde su posición original; las propiedades {{Cssxref("left")}} y {{Cssxref("right")}} especifican su desplazamiento horizontal.
-- Un **elemento posicionado absolutamente** es un elemento cuyo valor [computado](/es/docs/CSS/computed_value) de `position` es `absolute` o `fixed`. Las propiedades {{Cssxref("top")}}, {{Cssxref("right")}}, {{Cssxref("bottom")}}, y {{Cssxref("left")}} especifican el desplazamiento desde los bordes del [bloque contenedor](/es/docs/Web/CSS/All_About_The_Containing_Block) del elemento. (El bloque contenedor es el ancestro relativo al cual el elemento está posicionado). Si el elemento tiene márgenes, se agregarán al desplazamiento. el elemento establece un nuevo contexto de formato de bloque para su contenido
-- Un **elemento posicionado fijamente** es un elemento cuyo valor de [`position` computado](/es/docs/CSS/computed_value) es `sticky`. Es tratado como un elemento posicionado relativamente hasta que su [bloque contenedor](/es/docs/Web/CSS/All_About_The_Containing_Block) cruza un límite establecido (como por ejemplo dando a {{Cssxref("top")}} cualquier valor distinto de auto), dentro de su flujo principal (o el contenedor dentro del cual se mueve), desde el cual es tratado como "fijo" hasta que alcance el borde opuesto de su [bloque contenedor](/es/docs/Web/CSS/All_About_The_Containing_Block).
+- Un **elemento posicionado** es un elemento cuyo valor [computado](/es/docs/Web/CSS/computed_value) de `position` es `relative`, `absolute`, `fixed`, o `sticky`. (En otras palabras, cualquiera excepto `static`).
+- Un **elemento posicionado relativamente** es un elemento cuyo valor [computado](/es/docs/Web/CSS/computed_value) de `position` es `relative`. Las propiedades {{Cssxref("top")}} y {{Cssxref("bottom")}} especifican el desplazamiento vertical desde su posición original; las propiedades {{Cssxref("left")}} y {{Cssxref("right")}} especifican su desplazamiento horizontal.
+- Un **elemento posicionado absolutamente** es un elemento cuyo valor [computado](/es/docs/Web/CSS/computed_value) de `position` es `absolute` o `fixed`. Las propiedades {{Cssxref("top")}}, {{Cssxref("right")}}, {{Cssxref("bottom")}}, y {{Cssxref("left")}} especifican el desplazamiento desde los bordes del [bloque contenedor](/es/docs/Web/CSS/All_About_The_Containing_Block) del elemento. (El bloque contenedor es el ancestro relativo al cual el elemento está posicionado). Si el elemento tiene márgenes, se agregarán al desplazamiento. el elemento establece un nuevo contexto de formato de bloque para su contenido
+- Un **elemento posicionado fijamente** es un elemento cuyo valor de [`position` computado](/es/docs/Web/CSS/computed_value) es `sticky`. Es tratado como un elemento posicionado relativamente hasta que su [bloque contenedor](/es/docs/Web/CSS/All_About_The_Containing_Block) cruza un límite establecido (como por ejemplo dando a {{Cssxref("top")}} cualquier valor distinto de auto), dentro de su flujo principal (o el contenedor dentro del cual se mueve), desde el cual es tratado como "fijo" hasta que alcance el borde opuesto de su [bloque contenedor](/es/docs/Web/CSS/All_About_The_Containing_Block).
 
 La mayoría de las veces, los elementos absolutamente posicionados que tienen su {{Cssxref("height")}} y {{Cssxref("width")}} establecidos en `auto` son ajustados hasta acomodarse a su contenido. Sin embargo, elementos non-[replaced](/es/docs/Web/CSS/Replaced_element) y absolutamente posicionados se pueden crear para llenar el espacio vertical disponible, especificando tanto {{Cssxref("top")}} como {{Cssxref("bottom")}}, y dejando {{Cssxref("height")}} sin especificar (es decir, `auto`). De igual manera se pueden utilizar para llenar el espacio horizontal disponible especificando tanto {{Cssxref("left")}} como {{Cssxref("right")}}, y dando a {{Cssxref("width")}} el valor de `auto`.
 
 A excepción del caso anteriormente descrito (de elementos posicionados absolutamente rellenando el espacio disponible):
 
 - Si ambos, `top` y `bottom` están especificados (técnicamente, no `auto`), `top` gana.
-- Si ambos, `left` y `right`, están especificados, `left` gana cuando {{Cssref("direction")}} es `ltr` (Inglés, japonés horizontal, etc.) y `right` gana cuando {{Cssxref("direction")}} es `rtl` (Persa, árabe, hebreo, etc.).
+- Si ambos, `left` y `right`, están especificados, `left` gana cuando {{Cssxref("direction")}} es `ltr` (Inglés, japonés horizontal, etc.) y `right` gana cuando {{Cssxref("direction")}} es `rtl` (Persa, árabe, hebreo, etc.).
 
 ## Sintaxis
 
@@ -34,24 +34,24 @@ La propiedad `position` es especificada como una palabra única elegida de la si
 - `static`
   - : El elemento es posicionado de acuerdo al flujo normal del documento. Las propiedades {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}}, {{cssxref("left")}}, and {{cssxref("z-index")}} _no tienen efecto_. Este es el valor por defecto.
 - `relative`
-  - : El elemento es posicionado de acuerdo al flujo normal del documento, y luego es desplazado _con relación a sí mismo_, con base en los valores de `top`, `right`, `bottom`, and `left`. El desplazamiento no afecta la posición de ningún otro elemento; por lo que, el espacio que se le da al elemento en el esquema de la página es el mismo como si la posición fuera `static`. Este valor crea un nuevo [contexto de apilamiento](/es/docs/Web/CSS/CSS_Positioning/entendiendo_z_index/El_contexto_de_apilamiento), donde el valor de `z-index` no es `auto`. El efecto que tiene `relative` sobre los elementos `table-*-group`, `table-row`, `table-column`, `table-cell`, y `table-caption` no está definido.
+  - : El elemento es posicionado de acuerdo al flujo normal del documento, y luego es desplazado _con relación a sí mismo_, con base en los valores de `top`, `right`, `bottom`, and `left`. El desplazamiento no afecta la posición de ningún otro elemento; por lo que, el espacio que se le da al elemento en el esquema de la página es el mismo como si la posición fuera `static`. Este valor crea un nuevo [contexto de apilamiento](/es/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context), donde el valor de `z-index` no es `auto`. El efecto que tiene `relative` sobre los elementos `table-*-group`, `table-row`, `table-column`, `table-cell`, y `table-caption` no está definido.
 - `absolute`
 
   - : El elemento es removido del flujo normal del documento, sin crearse espacio alguno para el elemento en el esquema de la página. Es posicionado relativo a su ancestro posicionado más cercano, si lo hay; de lo contrario, se ubica relativo al [bloque contenedor](/es/docs/Web/CSS/All_About_The_Containing_Block) inicial. Su posición final está determinada por los valores de `top`, `right`, `bottom`, y `left`.
 
-    Este valor crea un nuevo [contexto de apilamiento](/es/docs/Web/CSS/CSS_Positioning/entendiendo_z_index/El_contexto_de_apilamiento) cuando el valor de `z-index` no es `auto`. Elementos absolutamente posicionados pueden tener margen, y no colapsan con ningún otro margen.
+    Este valor crea un nuevo [contexto de apilamiento](/es/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) cuando el valor de `z-index` no es `auto`. Elementos absolutamente posicionados pueden tener margen, y no colapsan con ningún otro margen.
 
 - `fixed`
 
   - : El elemento es removido del flujo normal del documento, sin crearse espacio alguno para el elemento en el esquema de la página. Es posicionado con relación al [bloque contenedor](/es/docs/Web/CSS/All_About_The_Containing_Block) inicial establecido por el {{glossary("viewport")}}, excepto cuando uno de sus ancestros tiene una propiedad `transform`, `perspective`, o `filter` establecida en algo que no sea `none` (ver [CSS Transforms Spec](https://www.w3.org/TR/css-transforms-1/#propdef-transform)), en cuyo caso ese ancestro se comporta como el bloque contenedor. (Notar que hay inconsistencias del navegador con `perspective` y `filter` contribuyendo a la formación del bloque contenedor.) Su posición final es determinada por los valores de `top`, `right`, `bottom`, y `left`.
 
-    Estos valores siempre crean un nuevo [contexto de apilamiento](/es/docs/Web/CSS/CSS_Positioning/entendiendo_z_index/El_contexto_de_apilamiento). En documentos impresos, el elemento se coloca en la misma posición en _cada página_.
+    Estos valores siempre crean un nuevo [contexto de apilamiento](/es/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context). En documentos impresos, el elemento se coloca en la misma posición en _cada página_.
 
 - `sticky` {{experimental_inline}}
 
   - : El elemento es posicionado de acuerdo al flujo normal del documento, y luego es desplazado _con relación a su ancestro que se desplace más cercano y su_ [bloque contenedor](/es/docs/Web/CSS/All_About_The_Containing_Block) (ancestro en nivel de bloque más cercano) incluyendo elementos relacionados a tablas, basados en los valores de `top`, `right`, `bottom`, y `left`. El desplazamiento no afecta la posición de ningún otro elmento.
 
-    Estos valores siempre crean un nuevo [contexto de apilamiento](/es/docs/Web/CSS/CSS_Positioning/entendiendo_z_index/El_contexto_de_apilamiento). Nótese que un elemento sticky se "adhiere" a su ancestro más cercano que tiene un "mecanismo de desplazamiento" (creado cuando el `overflow` es `hidden`, `scroll`, `auto`, o bien `overlay`), aún si ese ancestro no es el ancestro con desplazamiento más cercano. Esto inhibe efectivamente el comportamiento "sticky" (ver el [Github issue en W3C CSSWG](https://github.com/w3c/csswg-drafts/issues/865)).
+    Estos valores siempre crean un nuevo [contexto de apilamiento](/es/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context). Nótese que un elemento sticky se "adhiere" a su ancestro más cercano que tiene un "mecanismo de desplazamiento" (creado cuando el `overflow` es `hidden`, `scroll`, `auto`, o bien `overlay`), aún si ese ancestro no es el ancestro con desplazamiento más cercano. Esto inhibe efectivamente el comportamiento "sticky" (ver el [Github issue en W3C CSSWG](https://github.com/w3c/csswg-drafts/issues/865)).
 
 ### Sintaxis formal
 
@@ -289,7 +289,7 @@ dd + dd {
 
 Asegurarse de que los elementos posicionados con valor `absolute` o `fixed` no oscurezcan el resto del contenido cuando la página sea ampliada para aumentar el tamaño del texto.
 
-- [MDN entendiendo el WCAG, explicaciones de los lineamientos 1.4.](/es/docs/Web/Accessibility/Understanding_WCAG/Perceivable#Guideline_1.4_Make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
+- [MDN entendiendo el WCAG, explicaciones de los lineamientos 1.4.](/es/docs/Web/Accessibility/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
 - [Presentación visual: Entendiendo SC 1.4.8 | Entendiendo WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-visual-presentation.html)
 
 ### Performance y accesibilidad

--- a/files/es/web/css/replaced_element/index.md
+++ b/files/es/web/css/replaced_element/index.md
@@ -3,7 +3,7 @@ title: Elemento de reemplazo
 slug: Web/CSS/Replaced_element
 ---
 
-{{CSSRef()}}
+{{CSSRef}}
 
 ## Summary
 

--- a/files/es/web/css/subsequent-sibling_combinator/index.md
+++ b/files/es/web/css/subsequent-sibling_combinator/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/Subsequent-sibling_combinator
 original_slug: Web/CSS/General_sibling_combinator
 ---
 
-{{CSSRef("Selectors")}}
+{{CSSRef}}
 
 ## Resumen
 

--- a/files/es/web/css/transition-property/index.md
+++ b/files/es/web/css/transition-property/index.md
@@ -3,7 +3,7 @@ title: transition-property
 slug: Web/CSS/transition-property
 ---
 
-{{CSSRef("CSS Transitions")}}
+{{CSSRef}}
 
 La propiedad CSS **`transition-property`** se usa para definir los nombres de las propiedades CSS en las que el efecto de la transición debe aplicarse.
 

--- a/files/es/web/css/value_definition_syntax/index.md
+++ b/files/es/web/css/value_definition_syntax/index.md
@@ -3,7 +3,7 @@ title: Sintaxis de definición de valor
 slug: Web/CSS/Value_definition_syntax
 ---
 
-{{CSSRef()}}
+{{CSSRef}}
 
 **La sintaxis de definición de valores CSS**, una gramática formal, se utiliza para definir el conjunto de valores válidos para una propiedad o función CSS. Además de esta sintaxis, el conjunto de valores válidos puede restringirse aún más mediante restricciones semánticas (por ejemplo, para que un número sea estrictamente positivo).
 


### PR DESCRIPTION
### Description

This PR unifies `{{CSSRef}}` macro usage by removing unused parameter (https://github.com/mdn/yari/blob/main/kumascript/macros/CSSRef.ejs) for `es` locale.

Also in one file fix `Cssxref` instead of `Cssref` and some flaws (apply auto-fix :slightly_smiling_face:)

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/31843