### PR TITLE
zh-cn: fix the description of the `"inactive"` direction value

### DIFF
--- a/files/zh-cn/web/api/rtcrtptransceiver/direction/index.md
+++ b/files/zh-cn/web/api/rtcrtptransceiver/direction/index.md
@@ -47,7 +47,7 @@ A {{domxref("DOMString")}} whose value is one of the strings which are a member 
     </tr>
     <tr>
       <th scope="row"><code>"inactive"</code></th>
-      <td><em>不</em>可以接收 RTP 数据，无论如何都不会接收数据。</td>
+      <td><em>不</em>可以发送 RTP 数据，无论如何都不会发送数据。</td>
       <td><em>不</em>可以接收 RTP 数据，无论如何都不会接收数据。</td>
     </tr>
   </tbody>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description   fix typo
sdp  a=inactive的时候 RTCRtpSender 是 “不提供发送rtp数据 ” 
