### PR TITLE
[zh-tw] unify `{{CSSRef}}` macro usage (remove unused parameter)

### DIFF
--- a/files/zh-tw/web/css/descendant_combinator/index.md
+++ b/files/zh-tw/web/css/descendant_combinator/index.md
@@ -3,7 +3,7 @@ title: 後裔選擇器
 slug: Web/CSS/Descendant_combinator
 ---
 
-{{CSSRef("Selectors")}}
+{{CSSRef}}
 
 ## 簡介
 

--- a/files/zh-tw/web/css/replaced_element/index.md
+++ b/files/zh-tw/web/css/replaced_element/index.md
@@ -5,8 +5,6 @@ slug: Web/CSS/Replaced_element
 
 {{CSSRef}}
 
-{{CSSRef()}}
-
 ## 摘要
 
 CSS 中所謂的「置換元素 (**Replaced element**)」，即是該元素所呈現的內容不在 CSS 的控制範圍之內。這類外部物件所呈現的內容均獨立於 CSS 之外。常見的置換元素包含 {{HTMLElement("img")}}、{{HTMLElement("object")}}、{{HTMLElement("video")}}，或如 {{HTMLElement("textarea")}} 與 {{HTMLElement("input")}} 的表單元素。某些元素 (像是 {{HTMLElement("audio")}} 或 {{HTMLElement("canvas")}}) 只有在特殊情況下才是置替換元素。若是透過 CSS {{cssxref("content")}} 屬性所插入的物件，則稱為「不具名置換元素 (Anonymous replaced elements)」。


### PR DESCRIPTION
### Description

This PR unifies `{{CSSRef}}` macro usage by removing unused parameter (https://github.com/mdn/yari/blob/main/kumascript/macros/CSSRef.ejs) for `zh-tw` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/31843