### PR TITLE
Update index.md, fix misplacement of a charactor

### DIFF
--- a/files/zh-cn/web/javascript/guide/regular_expressions/index.md
+++ b/files/zh-cn/web/javascript/guide/regular_expressions/index.md
@@ -41,16 +41,14 @@ var re = new RegExp("ab+c");
 
 下面的页面与表格列出了一个正则表达式中可以利用的特殊字符的完整列表和描述。
 
-- [断言（Assertions）](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Assertions)
+- [断言](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Assertions)指南
   - : 表示一个匹配在某些条件下发生。断言包含先行断言、后行断言和条件表达式。
-- [字符类（Character Classes）](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes)
+- [字符类](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes)指南
   - : 区分不同类型的字符，例如区分字母和数字。
-- [组和范围（Groups and Ranges）](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences)
-  - : 表示表达式字符的分组和范围。
-- [量词（Quantifiers）](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Quantifiers)
+- [组和反向引用](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences)指南
+  - : 当使用正则表达式模式与字符串匹配时，组会将多个模式组合成一个整体，捕获组会提供额外的子匹配信息。反向引用指的是同一正则表达式中以前捕获的组。
+- [量词](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Quantifiers)指南
   - : 表示匹配的字符或表达式的数量。
-- [Unicode 属性转义（Unicode Property Escapes）](/zh-CN/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape)
-  - : 基于 unicode 字符属性区分字符。例如大写和小写字母、数学符号和标点。
 
 <table class="standard-table">
   <caption>

--- a/files/zh-cn/web/javascript/guide/regular_expressions/index.md
+++ b/files/zh-cn/web/javascript/guide/regular_expressions/index.md
@@ -45,7 +45,7 @@ var re = new RegExp("ab+c");
   - : 表示一个匹配在某些条件下发生。断言包含先行断言、后行断言和条件表达式。
 - [字符类（Character Classes）](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes)
   - : 区分不同类型的字符，例如区分字母和数字。
-- [组和范围（Groups and Ranges）](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_Ranges)
+- [组和范围（Groups and Ranges）](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences)
   - : 表示表达式字符的分组和范围。
 - [量词（Quantifiers）](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Quantifiers)
   - : 表示匹配的字符或表达式的数量。

--- a/files/zh-cn/web/javascript/guide/regular_expressions/quantifiers/index.md
+++ b/files/zh-cn/web/javascript/guide/regular_expressions/quantifiers/index.md
@@ -103,7 +103,7 @@ slug: Web/JavaScript/Guide/Regular_expressions/Quantifiers
         <p>
           默认情况下，像 <code>* </code>和
           <code>+ </code
-          >这样的量词是“贪婪的”，这意味着它们试图匹配尽可能多的字符串。?量词后面的字符使量词“非贪婪”：意思是它一旦找到匹配就会停止。例如，给定一个字符串“some
+          >这样的量词是“贪婪的”，这意味着它们试图匹配尽可能多的字符串。量词后面的字符?使量词“非贪婪”：意思是它一旦找到匹配就会停止。例如，给定一个字符串“some
           &#x3C;foo> &#x3C;bar> new &#x3C;/bar> &#x3C;/foo> thing”:
         </p>
         <ul>

--- a/files/zh-cn/web/javascript/guide/regular_expressions/quantifiers/index.md
+++ b/files/zh-cn/web/javascript/guide/regular_expressions/quantifiers/index.md
@@ -103,7 +103,7 @@ slug: Web/JavaScript/Guide/Regular_expressions/Quantifiers
         <p>
           默认情况下，像 <code>* </code>和
           <code>+ </code
-          >这样的量词是“贪婪的”，这意味着它们试图匹配尽可能多的字符串。量词后面的字符？使量词“非贪婪”：意思是它一旦找到匹配就会停止。例如，给定一个字符串“some
+          >这样的量词是“贪婪的”，这意味着它们试图匹配尽可能多的字符串。量词后面的字符 `?` 使量词“非贪婪”：它一旦找到匹配就会停止。例如，给定一个字符串“some
           &#x3C;foo> &#x3C;bar> new &#x3C;/bar> &#x3C;/foo> thing”:
         </p>
         <ul>

--- a/files/zh-cn/web/javascript/guide/regular_expressions/quantifiers/index.md
+++ b/files/zh-cn/web/javascript/guide/regular_expressions/quantifiers/index.md
@@ -103,7 +103,7 @@ slug: Web/JavaScript/Guide/Regular_expressions/Quantifiers
         <p>
           默认情况下，像 <code>* </code>和
           <code>+ </code
-          >这样的量词是“贪婪的”，这意味着它们试图匹配尽可能多的字符串。量词后面的字符?使量词“非贪婪”：意思是它一旦找到匹配就会停止。例如，给定一个字符串“some
+          >这样的量词是“贪婪的”，这意味着它们试图匹配尽可能多的字符串。量词后面的字符？使量词“非贪婪”：意思是它一旦找到匹配就会停止。例如，给定一个字符串“some
           &#x3C;foo> &#x3C;bar> new &#x3C;/bar> &#x3C;/foo> thing”:
         </p>
         <ul>

--- a/files/zh-cn/web/javascript/guide/regular_expressions/quantifiers/index.md
+++ b/files/zh-cn/web/javascript/guide/regular_expressions/quantifiers/index.md
@@ -14,8 +14,8 @@ slug: Web/JavaScript/Guide/Regular_expressions/Quantifiers
 <table class="standard-table">
   <thead>
     <tr>
-      <th scope="col">Characters</th>
-      <th scope="col">Meaning</th>
+      <th scope="col">字符集</th>
+      <th scope="col">意义</th>
     </tr>
   </thead>
   <tbody>
@@ -108,17 +108,17 @@ slug: Web/JavaScript/Guide/Regular_expressions/Quantifiers
         </p>
         <ul>
           <li>
-            <code>/&#x3C;.*>/</code> will match "&#x3C;foo> &#x3C;bar> new
-            &#x3C;/bar> &#x3C;/foo>"
+            <code>/&#x3C;.*>/</code> 将匹配“&#x3C;foo> &#x3C;bar> new
+            &#x3C;/bar> &#x3C;/foo>”
           </li>
-          <li><code>/&#x3C;.*?>/</code> will match "&#x3C;foo>"</li>
+          <li><code>/&#x3C;.*?>/</code> 将匹配“&#x3C;foo>”</li>
         </ul>
       </td>
     </tr>
   </tbody>
 </table>
 
-## 举例说明
+## 示例
 
 ### 重复模式
 
@@ -162,7 +162,7 @@ console.table(americanText.match(regexpEnding));
 // ["neighbor", "favor"]
 ```
 
-### 贪婪 与 非贪婪的
+### 贪婪匹配与非贪婪匹配
 
 ```js
 var text = "I must be getting somewhere near the centre of the earth.";
@@ -182,11 +182,8 @@ console.log(text.match(nonGreedyRegexp));
 
 ## 参见
 
-- [Regular expressions guide](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions)
-
-  - [Character classes](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes)
-  - [Assertions](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Assertions)
-  - [Unicode property escapes](/zh-CN/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape)
-  - [Groups and ranges](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_Ranges)
-
-- [The `RegExp()` constructor](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
+- [正则表达式](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions)指南
+- [字符类](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes)指南
+- [断言](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Assertions)指南
+- [组和反向引用](/zh-CN/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences)指南
+- [`RegExp`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp)


### PR DESCRIPTION

"?量词后面的字符使量词" , 语句不通，应该是"量词后面的字符?使量词"
### Description
Fix a misplacement of charator

### Motivation
Make this sentence more clear. 
Old : ?量词后面的字符使量词 , means "?the character after the quantifier makes the quantifier" , ? misplaced
New: 量词后面的字符?使量词, means "the character ? after the quantifier makes the quantifier"", clearify the charator is '?'
### Additional details

Just fix a charactor misplacement

### Related issues and pull requests

