### PR TITLE
[ja] Fix class names in flex-grow page

### DIFF
--- a/files/ja/web/css/flex-grow/index.md
+++ b/files/ja/web/css/flex-grow/index.md
@@ -85,12 +85,12 @@ flex-grow: unset;
   align-items: stretch;
 }
 
-.box {
+.small {
   flex-grow: 1;
   border: 3px solid rgba(0, 0, 0, 0.2);
 }
 
-.box1 {
+.double {
   flex-grow: 2;
   border: 3px solid rgba(0, 0, 0, 0.2);
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix class names in flex-grow page:
https://developer.mozilla.org/ja/docs/Web/CSS/flex-grow
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Fix previews.

Japanese page:
<img width="789" alt="image" src="https://github.com/mdn/translated-content/assets/25113178/29a8f2ae-cc01-4783-8a1e-076f74c14c39">

English page:
<img width="801" alt="image" src="https://github.com/mdn/translated-content/assets/25113178/12efce73-08d5-484c-a10a-ff6ead59f861">

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
