### PR TITLE
[es] fix typo in `Learn/CSS/First_steps/Getting_started`

### DIFF
--- a/files/es/learn/css/first_steps/getting_started/index.md
+++ b/files/es/learn/css/first_steps/getting_started/index.md
@@ -274,7 +274,7 @@ Dará formato a cualquier elemento con la clase `special`, dentro de un elemento
 
 En el HTML original que proporcionamos, el único elemento al que esto aplica estilo es `<span class="special">`.
 
-No te preocupes si ahora mismo te parece complicado: irás acostumbrarte a medida que escribas más CSS.
+No te preocupes si ahora mismo te parece complicado: irás acostumbrándote a medida que escribas más CSS.
 
 ## Para terminar
 


### PR DESCRIPTION
Word "irás acostumbrarte" changed to "irás acostumbrándote"

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
-Only i read the CSS documentation and i found that error, no more.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
What other people can read correctly the documentation without problems.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
