### PR TITLE
Deleted "sinusoïdale" add replaced "onde" with "forme d'onde"

### DIFF
--- a/files/fr/web/api/baseaudiocontext/createperiodicwave/index.md
+++ b/files/fr/web/api/baseaudiocontext/createperiodicwave/index.md
@@ -5,7 +5,7 @@ slug: Web/API/BaseAudioContext/createPeriodicWave
 
 {{ APIRef("Web Audio API") }}
 
-La méthode `createPeriodicWave()` de l'interface {{ domxref("BaseAudioContext") }} est utilisée pour créer une {{domxref("PeriodicWave")}} (onde périodique), qui sert à définir une onde sinusoïdale périodique qui peut être utilisée pour modeler la sortie d'un {{ domxref("OscillatorNode") }}.
+La méthode `createPeriodicWave()` de l'interface {{ domxref("BaseAudioContext") }} est utilisée pour créer une {{domxref("PeriodicWave")}} (onde périodique), qui sert à définir une forme d'onde périodique qui peut être utilisée pour modeler la sortie d'un {{ domxref("OscillatorNode") }}.
 
 ## Syntaxe
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
I adapted the text so it's closer to the English text for 2 reasons:
- The french translation said "sert à définir une onde sinusoïdale". The use of "sinusoïdale" is not correct here because the point of "createPeriodicWave" is to be able to create custom waves (not only sine wave)
- I replaced "onde" with "form d'onde". The English is indeed "waveform" and is more appropriate


### Additional details

See the spec: https://webaudio.github.io/web-audio-api/#PeriodicWave

>[PeriodicWave](https://webaudio.github.io/web-audio-api/#PeriodicWave) represents an **arbitrary periodic waveform** to be used with an [OscillatorNode](https://webaudio.github.io/web-audio-api/#OscillatorNode).

