### PR TITLE
chore(ci): Make auto-generated PRs have 'mdn-bot' as author and committer

### DIFF
--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -67,25 +67,31 @@ jobs:
 
       - name: Create PR with only fixable issues
         if: success()
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "${{ matrix.lang }}: auto-fix Markdownlint issues"
           branch: markdownlint-auto-cleanup-${{ matrix.lang }}
           title: "Markdownlint auto-cleanup for ${{ matrix.lang }}"
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
+          committer: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           body: |
             All issues auto-fixed
+          labels: |
+            automated pr
           token: ${{ secrets.AUTOMERGE_TOKEN }}
 
       - name: Create PR with notice on unfixed issues
         if: failure()
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "${{ matrix.lang }}: auto-fix Markdownlint issues"
           branch: markdownlint-auto-cleanup-${{ matrix.lang }}
           title: "Markdownlint auto-cleanup for ${{ matrix.lang }}"
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
+          committer: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           body: |
             Auto-fix was run, but additional issues found.
             Please review the run log: https://github.com/mdn/translated-content/actions/runs/${{ github.run_id }}
+          labels: |
+            automated pr
           token: ${{ secrets.AUTOMERGE_TOKEN }}

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -60,11 +60,14 @@ jobs:
         run: yarn content sync-translated-content ${{ matrix.lang }}
 
       - name: Create PR with sync for ${{ matrix.lang }}
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "${{ matrix.lang }}: sync translated content"
           branch: content-sync-${{ matrix.lang }}
           title: "[${{ matrix.lang }}] sync translated content"
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
+          committer: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           body: Yari generated sync
+          labels: |
+            automated pr
           token: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
In `peter-evans/create-pull-request@v6` the new default for 'committer' is:

```
github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
```

Current [behavior for v5 is](https://github.com/mdn/content/actions/runs/7807766173/job/21296780418):

```
  Configured git committer as 'GitHub <noreply@github.com>'
  Configured git author as 'mdn-bot <108879845+mdn-bot@users.noreply.github.com>'
```

While not pressing, we can duplicate the mdn-bot account for both author and committer info.

__Additions:__

- Add `committer` field with mdn-bot details mirroring `author`
- Add an "automated pr" label to these pull requests

__Updates:__

- Bump `peter-evans/create-pull-request@v6`

### Additional details

- https://github.com/peter-evans/create-pull-request/releases/tag/v6.0.0

### Related issues and pull requests

- [x] https://github.com/mdn/content/pull/32154
