### PR TITLE
chore(zh-cn): remove the usage of {{unimplemented_inline}} macro

### DIFF
--- a/files/zh-cn/web/api/window/find/index.md
+++ b/files/zh-cn/web/api/window/find/index.md
@@ -19,23 +19,23 @@ window.find(aString, aCaseSensitive, aBackwards, aWrapAround,
 ```
 
 - `aString`
-  - : 将要搜索的字符串
+  - : 将要搜索的字符串。
 - `aCaseSensitive`
-  - : 布尔值，如果为`true`,表示搜索是区分大小写的。
+  - : 布尔值，如果为 `true`，表示搜索是区分大小写的。
 - `aBackwards`
-  - : 布尔值。如果为`true`, 表示搜索方向为向上搜索。
+  - : 布尔值。如果为 `true`，表示搜索方向为向上搜索。
 - `aWrapAround`
-  - : 布尔值。如果为`true`, 表示为循环搜索。
-- `aWholeWord` {{ unimplemented_inline() }}
-  - : 布尔值。如果为`true`,表示采用全字匹配搜索。该参数无效; 查看 [Firefox bug 481513](https://bugzil.la/481513).
+  - : 布尔值。如果为 `true`，表示为循环搜索。
+- `aWholeWord`
+  - : 布尔值。如果为 `true`，表示采用全字匹配搜索。
 - `aSearchInFrames`
-  - : 布尔值。如果为`true`, 表示会搜索框架内的文本。
+  - : 布尔值。如果为 `true`，表示会搜索框架内的文本。
 - `aShowDialog`
-  - : 布尔值。如果为`true`, 则会弹出一个搜索对话框。
+  - : 布尔值。如果为 `true`，则会弹出一个搜索对话框。
 
 ### 返回值
 
-`如果搜索到指定的字符串，则返回 true，否则`返回 false.
+如果搜索到指定的字符串，则返回 `true`，否则返回 `false`。
 
 ## 规范
 

--- a/files/zh-cn/web/html/element/col/index.md
+++ b/files/zh-cn/web/html/element/col/index.md
@@ -67,7 +67,7 @@ slug: Web/HTML/Element/col
     - `center`, centering the content in the cell
     - `right`, aligning the content to the right of the cell
     - `justify`, inserting spaces into the textual content so that the content is justified in the cell
-    - `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](/zh-CN/docs/Web/HTML/Element/col#char) and [`charoff`](/zh-CN/docs/Web/HTML/Element/col#charoff) attributes {{unimplemented_inline(2212)}}.If this attribute is not set, its value is inherited from the [`align`](/zh-CN/docs/Web/HTML/Element/colgroup#align) of the {{HTMLElement("colgroup")}} element this `<col>` element belongs too. If there are none, the `left` value is assumed.
+    - `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](/zh-CN/docs/Web/HTML/Element/col#char) and [`charoff`](/zh-CN/docs/Web/HTML/Element/col#charoff) attributes. If this attribute is not set, its value is inherited from the [`align`](/zh-CN/docs/Web/HTML/Element/colgroup#align) of the {{HTMLElement("colgroup")}} element this `<col>` element belongs too. If there are none, the `left` value is assumed.
 
     > **备注：** Do not use this attribute as it is obsolete (not supported) in the latest standard.
     > To achieve the same effect as the `left`, `center`, `right` or `justify` values:
@@ -75,7 +75,7 @@ slug: Web/HTML/Element/col
     > - Do not try to set the {{cssxref("text-align")}} property on a selector giving a {{HTMLElement("col")}} element. Because {{HTMLElement("td")}} elements are not descendant of the {{HTMLElement("col")}} element, they won't inherit it.
     > - If the table doesn't use a [`colspan`](/zh-CN/docs/Web/HTML/Element/td#colspan) attribute, use the `td:nth-child(an+b)` CSS selector where a is the total number of the columns in the table and b is the ordinal position of the column in the table. Only after this selector the {{cssxref("text-align")}} property can be used.
     > - If the table does use a [`colspan`](/zh-CN/docs/Web/HTML/Element/td#colspan) attribute, the effect can be achieved by combining adequate CSS attribute selectors like `[colspan=n]`, though this is not trivial.
-    > - To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](/zh-CN/docs/Web/HTML/Element/col#char) as the value of the {{cssxref("text-align")}} property {{unimplemented_inline}}.
+    > - To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](/zh-CN/docs/Web/HTML/Element/col#char) as the value of the {{cssxref("text-align")}} property.
 
 - `bgcolor` {{Non-standard_inline}}
 
@@ -87,7 +87,7 @@ slug: Web/HTML/Element/col
 
   - : This attribute is used to set the character to align the cells in a column on. Typical values for this include a period (.) when attempting to align numbers or monetary values. If [`align`](/zh-CN/docs/Web/HTML/Element/col#align) is not set to `char`, this attribute is ignored.
 
-    > **备注：** Do not use this attribute as it is obsolete (and not supported) in the latest standard. To achieve the same effect as the [`char`](/zh-CN/docs/Web/HTML/Element/col#char), in CSS3, you can use the character set using the [`char`](/zh-CN/docs/Web/HTML/Element/col#char) attribute as the value of the {{cssxref("text-align")}} property {{unimplemented_inline}}.
+    > **备注：** Do not use this attribute as it is obsolete (and not supported) in the latest standard. To achieve the same effect as the [`char`](/zh-CN/docs/Web/HTML/Element/col#char), in CSS3, you can use the character set using the [`char`](/zh-CN/docs/Web/HTML/Element/col#char) attribute as the value of the {{cssxref("text-align")}} property.
 
 - `charoff` {{deprecated_inline}}
 

--- a/files/zh-cn/web/html/element/colgroup/index.md
+++ b/files/zh-cn/web/html/element/colgroup/index.md
@@ -52,7 +52,7 @@ HTML 中的 表格列组（_Column Group_ **\<colgroup>**）标签用来定义�
     - `center`，元素中的内容居中对齐
     - `right`，元素中的内容右对齐
     - `justify`，插入空格，使元素中内容两端对齐
-    - `char`，针对确定的字符，设置一个最小偏移量，来进行布局，通过 [`char`](/zh-CN/docs/Web/HTML/Element/col#char) 和 [`charoff`](/zh-CN/docs/Web/HTML/Element/col#charoff) 属性进行定义 {{unimplemented_inline(2212)}}。此属性的默认值为 `left`。后代 {{HTMLElement("col")}} 元素可以用它们自己的 [`align`](/zh-CN/docs/Web/HTML/Element/col#align) 属性值来重写该属性。
+    - `char`，针对确定的字符，设置一个最小偏移量，来进行布局，通过 [`char`](/zh-CN/docs/Web/HTML/Element/col#char) 和 [`charoff`](/zh-CN/docs/Web/HTML/Element/col#charoff) 属性进行定义。此属性的默认值为 `left`。后代 {{HTMLElement("col")}} 元素可以用它们自己的 [`align`](/zh-CN/docs/Web/HTML/Element/col#align) 属性值来重写该属性。
 
     > **备注：** 不要使用这个属性，它在最新的标准中已经不被支持。
     >
@@ -60,7 +60,7 @@ HTML 中的 表格列组（_Column Group_ **\<colgroup>**）标签用来定义�
     > - 不要为一个 {{HTMLElement("colgroup")}} 元素选择器设置 {{cssxref("text-align")}} 属性.，因为{{HTMLElement("td")}} 元素并不是 {{HTMLElement("colgroup")}} 元素的后代，不继承于它。
     > - 如果表格不使用 [`colspan`](/zh-CN/docs/Web/HTML/Element/td#colspan) 属性，每列用一个 `td:nth-child(an+b)` 的 CSS 选择器，a 是表格中列的总数，b 是当前列在表格中的位列次序号。只有在这个选择器之后， {{cssxref("text-align")}} 属性可以使用。
     > - 如果表格使用了 [`colspan`](/zh-CN/docs/Web/HTML/Element/td#colspan) 属性，可以通过合并足够多的属性选择器来实现同样的效果，比如 `[colspan=n]`，但这不常用。
-    > - 若要实现与 `char` 相同的效果：在 CSS3 中，你可以使用 [`char`](/zh-CN/docs/Web/HTML/Element/colgroup#char) 作为 {{cssxref("text-align")}} 的属性值。 {{unimplemented_inline}}
+    > - 若要实现与 `char` 相同的效果：在 CSS3 中，你可以使用 [`char`](/zh-CN/docs/Web/HTML/Element/colgroup#char) 作为 {{cssxref("text-align")}} 的属性值。
 
 - `bgcolor` {{Non-standard_inline}}
 
@@ -72,7 +72,7 @@ HTML 中的 表格列组（_Column Group_ **\<colgroup>**）标签用来定义�
 
   - : This attribute specifies the alignment of the content in a column group to a character. Typical values for this include a period (.) when attempting to align numbers or monetary values. If [`align`](/zh-CN/docs/Web/HTML/Element/colgroup#align) is not set to `char`, this attribute is ignored, though it will still be used as the default value for the [`align`](/zh-CN/docs/Web/HTML/Element/col#align) of the {{HTMLElement("col")}} which are members of this column group.
 
-    > **备注：** Do not use this attribute as it is obsolete (and not supported) in the latest standard. To achieve the same effect as the [`char`](/zh-CN/docs/Web/HTML/Element/colgroup#char), in CSS3, you can use the character set using the [`char`](/zh-CN/docs/Web/HTML/Element/colgroup#char) attribute as the value of the {{cssxref("text-align")}} property {{unimplemented_inline}}.
+    > **备注：** Do not use this attribute as it is obsolete (and not supported) in the latest standard. To achieve the same effect as the [`char`](/zh-CN/docs/Web/HTML/Element/colgroup#char), in CSS3, you can use the character set using the [`char`](/zh-CN/docs/Web/HTML/Element/colgroup#char) attribute as the value of the {{cssxref("text-align")}} property.
 
 - `charoff` {{deprecated_inline}}
 

--- a/files/zh-cn/web/html/element/th/index.md
+++ b/files/zh-cn/web/html/element/th/index.md
@@ -61,7 +61,7 @@ slug: Web/HTML/Element/th
     > **备注：** 不要使用这个属性，因为它已经在最新标准中过时。
     >
     > - `left`, `center`, `right` 或 `justify` 这些对齐效果，应该使用 CSS 的{{cssxref("text-align")}} 来实现。
-    > - `char` 的对齐效果使用 CSS 的 {{cssxref("text-align")}} 实现， [`char`](/zh-CN/docs/Web/HTML/Element/th#char)亦同。{{unimplemented_inline}} in CSS3.
+    > - `char` 的对齐效果使用 CSS 的 {{cssxref("text-align")}} 实现，[`char`](/zh-CN/docs/Web/HTML/Element/th#char) 亦同。
 
 - `axis` {{Deprecated_Inline}}
 
@@ -77,9 +77,7 @@ slug: Web/HTML/Element/th
 
 - `char` {{Deprecated_inline}}
 
-  - : 列中的内容与`<th>` 元素中的字母对齐。通常其值包含一个 (.) 来排列数字或者货币值。如果 [`align`](/zh-CN/docs/Web/HTML/Element/th#align)没有被设置为`char`，这个属性就会被忽略。
-
-    > **备注：** 不要使用这个属性，因为它已经在最新标准中过时。为了达到同样的效果，你可以指定该字母为{{cssxref("text-align")}} 属性中的第一个值，或通过 CSS3 中的{{unimplemented_inline}}。
+  - : 列中的内容与 `<th>` 元素中的字母对齐。通常其值包含一个句点（`.`）来排列数字或者货币值。如果 [`align`](/zh-CN/docs/Web/HTML/Element/th#align) 没有被设置为 `char`，这个属性就会被忽略。
 
 - `charoff` {{Deprecated_inline}}
 

--- a/files/zh-cn/web/html/element/thead/index.md
+++ b/files/zh-cn/web/html/element/thead/index.md
@@ -48,12 +48,12 @@ This element includes the [global attributes](/zh-CN/docs/Web/HTML/Global_attrib
     - `center`, centering the content in the cell
     - `right`, aligning the content to the right of the cell
     - `justify`, inserting spaces into the textual content so that the content is justified in the cell
-    - `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](/zh-CN/docs/Web/HTML/Element/thead#char) and [`charoff`](/zh-CN/docs/Web/HTML/Element/thead#charoff) attributes {{ unimplemented_inline("2212") }}.If this attribute is not set, the `left` value is assumed.
+    - `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](/zh-CN/docs/Web/HTML/Element/thead#char) and [`charoff`](/zh-CN/docs/Web/HTML/Element/thead#charoff) attributes. If this attribute is not set, the `left` value is assumed.
 
     > **备注：** Do not use this attribute as it is obsolete (not supported) in the latest standard.
     >
     > - To achieve the same effect as the `left`, `center`, `right` or `justify` values, use the CSS {{ cssxref("text-align") }} property on it.
-    > - To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](/zh-CN/docs/Web/HTML/Element/thead#char) as the value of the {{ cssxref("text-align") }} property {{ unimplemented_inline() }}.
+    > - To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](/zh-CN/docs/Web/HTML/Element/thead#char) as the value of the {{ cssxref("text-align") }} property.
 
 - `bgcolor` {{ Non-standard_inline() }}
 
@@ -65,7 +65,7 @@ This element includes the [global attributes](/zh-CN/docs/Web/HTML/Global_attrib
 
   - : This attribute is used to set the character to align the cells in a column on. Typical values for this include a period (.) when attempting to align numbers or monetary values. If [`align`](/zh-CN/docs/Web/HTML/Element/tr#align) is not set to `char`, this attribute is ignored.
 
-    > **备注：** Do not use this attribute as it is obsolete (and not supported) in the latest standard. To achieve the same effect as the [`char`](/zh-CN/docs/Web/HTML/Element/thead#char), in CSS3, you can use the character set using the [`char`](/zh-CN/docs/Web/HTML/Element/thead#char) attribute as the value of the {{ cssxref("text-align") }} property {{ unimplemented_inline() }}.
+    > **备注：** Do not use this attribute as it is obsolete (and not supported) in the latest standard. To achieve the same effect as the [`char`](/zh-CN/docs/Web/HTML/Element/thead#char), in CSS3, you can use the character set using the [`char`](/zh-CN/docs/Web/HTML/Element/thead#char) attribute as the value of the {{ cssxref("text-align") }} property.
 
 - `charoff` {{Deprecated_Inline}}
 

--- a/files/zh-cn/web/html/element/tr/index.md
+++ b/files/zh-cn/web/html/element/tr/index.md
@@ -46,12 +46,12 @@ slug: Web/HTML/Element/tr
     - `center`, 内容在单元格中居中
     - `right`, 内容在单元格中右对齐
     - `justify`, 增加文本内容之间的空白以伸展这行文本，使得该单元格中的多行文本具有相同的长度。
-    - `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](/zh-CN/docs/Web/HTML/Element/tr#char) and [`charoff`](/zh-CN/docs/Web/HTML/Element/tr#charoff) attributes {{unimplemented_inline("2212")}}If this attribute is not set, the parent node's value is inherited.
+    - `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](/zh-CN/docs/Web/HTML/Element/tr#char) and [`charoff`](/zh-CN/docs/Web/HTML/Element/tr#charoff) attributes. If this attribute is not set, the parent node's value is inherited.
 
     > **备注：** Do not use this attribute as it is obsolete (not supported) in the latest standard.
     >
     > - To achieve the same effect as the `left`, `center`, `right` or `justify` values, use the CSS {{cssxref("text-align")}} property on it.
-    > - To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](/zh-CN/docs/Web/HTML/Element/tr#char) as the value of the {{cssxref("text-align")}} property {{unimplemented_inline}}.
+    > - To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](/zh-CN/docs/Web/HTML/Element/tr#char) as the value of the {{cssxref("text-align")}} property.
 
 - `bgcolor` {{Deprecated_inline}}
 
@@ -63,7 +63,7 @@ slug: Web/HTML/Element/tr
 
   - : This attribute is used to set the character to align the cells in a column on. Typical values for this include a period (.) when attempting to align numbers or monetary values. If [`align`](/zh-CN/docs/Web/HTML/Element/tr#align) is not set to `char`, this attribute is ignored.
 
-    > **备注：** Do not use this attribute as it is obsolete (and not supported) in the latest standard. To achieve the same effect as the [`char`](/zh-CN/docs/Web/HTML/Element/tr#char), in CSS3, you can use the character set using the [`char`](/zh-CN/docs/Web/HTML/Element/tr#char) attribute as the value of the {{cssxref("text-align")}} property {{unimplemented_inline}}.
+    > **备注：** Do not use this attribute as it is obsolete (and not supported) in the latest standard. To achieve the same effect as the [`char`](/zh-CN/docs/Web/HTML/Element/tr#char), in CSS3, you can use the character set using the [`char`](/zh-CN/docs/Web/HTML/Element/tr#char) attribute as the value of the {{cssxref("text-align")}} property.
 
 - `charoff` {{Deprecated_inline}}
 

--- a/files/zh-cn/web/javascript/reference/global_objects/float32array/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/float32array/index.md
@@ -81,8 +81,8 @@ new Float32Array(buffer [, byteOffset [, length]]);
   - : 返回数组中等于给定值的元素的最后（最大）位置，没有找到则返回 -1。参见{{jsxref("Array.prototype.lastIndexOf()")}}。
 - {{jsxref("TypedArray.map", "Float32Array.prototype.map()")}}
   - : 创建一个新的数组，数据由原数组每个元素依次传入给定函数后返回的值组成。参见{{jsxref("Array.prototype.map()")}}。
-- {{jsxref("TypedArray.move", "Float32Array.prototype.move()")}} {{non-standard_inline}} {{unimplemented_inline}}
-  - : {{jsxref("TypedArray.copyWithin", "Float32Array.prototype.copyWithin()")}}以前的一个非标准版本。
+- {{jsxref("TypedArray.move", "Float32Array.prototype.move()")}} {{non-standard_inline}}
+  - : {{jsxref("TypedArray.copyWithin", "Float32Array.prototype.copyWithin()")}} 以前的一个非标准版本。
 - {{jsxref("TypedArray.reduce", "Float32Array.prototype.reduce()")}}
   - : 传入一个函数作为累加器，从左到右遍历，最终得到一个值。参见{{jsxref("Array.prototype.reduce()")}}。
 - {{jsxref("TypedArray.reduceRight", "Float32Array.prototype.reduceRight()")}}

--- a/files/zh-cn/web/javascript/reference/global_objects/float64array/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/float64array/index.md
@@ -81,8 +81,8 @@ new Float64Array(buffer [, byteOffset [, length]]);
   - : 返回数组中等于给定值的元素的最后（最大）位置，没有找到则返回 -1。参见{{jsxref("Array.prototype.lastIndexOf()")}}。
 - {{jsxref("TypedArray.map", "Float64Array.prototype.map()")}}
   - : 创建一个新的数组，数据由原数组每个元素依次传入给定函数后返回的值组成。参见{{jsxref("Array.prototype.map()")}}。
-- {{jsxref("TypedArray.move", "Float64Array.prototype.move()")}} {{non-standard_inline}} {{unimplemented_inline}}
-  - : {{jsxref("TypedArray.copyWithin", "Float64Array.prototype.copyWithin()")}}以前的一个非标准版本。
+- {{jsxref("TypedArray.move", "Float64Array.prototype.move()")}} {{non-standard_inline}}
+  - : {{jsxref("TypedArray.copyWithin", "Float64Array.prototype.copyWithin()")}} 以前的一个非标准版本。
 - {{jsxref("TypedArray.reduce", "Float64Array.prototype.reduce()")}}
   - : 传入一个函数作为累加器，从左到右遍历，最终得到一个值。参见{{jsxref("Array.prototype.reduce()")}}。
 - {{jsxref("TypedArray.reduceRight", "Float64Array.prototype.reduceRight()")}}

--- a/files/zh-cn/web/javascript/reference/global_objects/int32array/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/int32array/index.md
@@ -81,7 +81,7 @@ new Int32Array(buffer [, byteOffset [, length]]);
   - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "Int32Array.prototype.map()")}}
   - : Creates a new array with the results of calling a provided function on every element in this array. See also {{jsxref("Array.prototype.map()")}}.
-- {{jsxref("TypedArray.move", "Int32Array.prototype.move()")}} {{non-standard_inline}} {{unimplemented_inline}}
+- {{jsxref("TypedArray.move", "Int32Array.prototype.move()")}} {{non-standard_inline}}
   - : Former non-standard version of {{jsxref("TypedArray.copyWithin", "Int32Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.reduce", "Int32Array.prototype.reduce()")}}
   - : Apply a function against an accumulator and each value of the array (from left-to-right) as to reduce it to a single value. See also {{jsxref("Array.prototype.reduce()")}}.

--- a/files/zh-cn/web/javascript/reference/global_objects/int8array/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/int8array/index.md
@@ -80,8 +80,8 @@ new Int8Array(buffer [, byteOffset [, length]]);
 - {{jsxref("TypedArray.lastIndexOf", "Int8Array.prototype.lastIndexOf()")}}
   - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "Int8Array.prototype.map()")}}
-  - : 返回一个由回调函数的返回值组成的新数组。. See also {{jsxref("Array.prototype.map()")}}.
-- {{jsxref("TypedArray.move", "Int8Array.prototype.move()")}} {{non-standard_inline}} {{unimplemented_inline}}
+  - : 返回一个由回调函数的返回值组成的新数组。参见 {{jsxref("Array.prototype.map()")}}。
+- {{jsxref("TypedArray.move", "Int8Array.prototype.move()")}} {{non-standard_inline}}
   - : {{jsxref("TypedArray.copyWithin", "Int8Array.prototype.copyWithin()")}} 早期的不标准定义。
 - {{jsxref("TypedArray.reduce", "Int8Array.prototype.reduce()")}}
   - : 从左到右为每个数组元素执行一次回调函数，并把上次回调函数的返回值放在一个暂存器中传给下次回调函数，并返回最后一次回调函数的返回值。参照 {{jsxref("Array.prototype.reduce()")}}

--- a/files/zh-cn/web/javascript/reference/global_objects/uint8array/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/uint8array/index.md
@@ -82,7 +82,7 @@ new Uint8Array(buffer [, byteOffset [, length]]);
   - : 返回数组中等于特定值的最后一个元素（下标最大），如果没有找到则返回 -1，请参见 {{jsxref("Array.prototype.lastIndexOf()")}}。
 - {{jsxref("TypedArray.map", "Uint8Array.prototype.map()")}}
   - : 使用在该数组的每个元素上调用函数的结果创建新数组，请参见{{jsxref("Array.prototype.map()")}}。
-- {{jsxref("TypedArray.move", "Uint8Array.prototype.move()")}} {{non-standard_inline}} {{unimplemented_inline}}
+- {{jsxref("TypedArray.move", "Uint8Array.prototype.move()")}} {{non-standard_inline}}
   - : {{jsxref("TypedArray.copyWithin", "Uint8Array.prototype.copyWithin()")}}的之前的非标准版本。
 - {{jsxref("TypedArray.reduce", "Uint8Array.prototype.reduce()")}}
   - : 对累加器和数组的每个值应用函数（从左到右），使其归约为单一的值，另见 {{jsxref("Array.prototype.reduce()")}}。

--- a/files/zh-cn/web/javascript/reference/global_objects/uint8clampedarray/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/uint8clampedarray/index.md
@@ -81,7 +81,7 @@ new Uint8ClampedArray(buffer [, byteOffset [, length]]);
   - : Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "Uint8ClampedArray.prototype.map()")}}
   - : Creates a new array with the results of calling a provided function on every element in this array. See also {{jsxref("Array.prototype.map()")}}.
-- {{jsxref("TypedArray.move", "Uint8ClampedArray.prototype.move()")}} {{non-standard_inline}} {{unimplemented_inline}}
+- {{jsxref("TypedArray.move", "Uint8ClampedArray.prototype.move()")}} {{non-standard_inline}}
   - : Former non-standard version of {{jsxref("TypedArray.copyWithin", "Uint8ClampedArray.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.reduce", "Uint8ClampedArray.prototype.reduce()")}}
   - : Apply a function against an accumulator and each value of the array (from left-to-right) as to reduce it to a single value. See also {{jsxref("Array.prototype.reduce()")}}.


### PR DESCRIPTION
### Description

remove the usage of {{unimplemented_inline}} macro. I did not remove the usage in `Web/API/Window/find` as I'll fix the error in en-US content.

### Related issues and pull requests

Part of: #18217
