### PR TITLE
chore(ci/lint-fix): setup node only once

### DIFF
--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -24,6 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/checkout@v4
+        with:
+          repository: mdn/content
+          path: mdn/content
+
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
@@ -38,11 +43,6 @@ jobs:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: 0
-
-      - uses: actions/checkout@v4
-        with:
-          repository: mdn/content
-          path: mdn/content
 
       - name: Install all yarn packages for mdn/content
         working-directory: ${{ github.workspace }}/mdn/content

--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
+          cache-dependency-path: "**/yarn.lock"
 
       - name: Install all yarn packages
         run: |
@@ -42,13 +43,6 @@ jobs:
         with:
           repository: mdn/content
           path: mdn/content
-
-      - name: Setup Node.js environment for mdn/content
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "yarn"
-          cache-dependency-path: mdn/content/yarn.lock
 
       - name: Install all yarn packages for mdn/content
         working-directory: ${{ github.workspace }}/mdn/content


### PR DESCRIPTION
### Description

remove the duplicated "setup node" step.

### Additional details

Follow the ["check lint" workflow](https://github.com/mdn/translated-content/blob/a623aead87b937fc688ded558f2d17c2665ae93e/.github/workflows/pr-check-lint_content.yml#L70-L76)