### PR TITLE
zh-cn: remove the `none` value of the "min-hight" attribute

### DIFF
--- a/files/zh-cn/web/css/min-height/index.md
+++ b/files/zh-cn/web/css/min-height/index.md
@@ -39,8 +39,6 @@ min-height: unset;
   - : 定义 `min-height` 为一个相对于父容器高度的百分数。
 - `auto`
   - : 浏览器将通过计算为指定元素选择一个 `min-height` 值。
-- `none`
-  - : 不限制盒容器的尺寸。
 - `max-content`
   - : The intrinsic preferred `min-height`.
 - `min-content`


### PR DESCRIPTION
The attribute “min-height” has no attribute value “done”

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
“min-height” has no attribute value “done” according to mdn documentation
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
In the spirit of dedication and open source, avoid misleading readers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
![image](https://github.com/mdn/translated-content/assets/49317590/495e7056-8c86-49ad-959a-dae9a7158f45)


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
