### PR TITLE
chore(zh): remove the version arguments of Firefox_for_developers macros

### DIFF
--- a/files/zh-cn/mozilla/firefox/releases/119/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/119/index.md
@@ -74,4 +74,4 @@ l10n:
 
 ## 更早期的版本
 
-{{Firefox_for_developers(118)}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/120/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/120/index.md
@@ -80,4 +80,4 @@ l10n:
 
 ## 更早期的版本
 
-{{Firefox_for_developers(119)}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/121/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/121/index.md
@@ -85,4 +85,4 @@ l10n:
 
 ## 更早期的版本
 
-{{Firefox_for_developers(120)}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/14/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/14/index.md
@@ -74,4 +74,4 @@ _No change._
 
 ## 参见
 
-{{Firefox_for_developers('13')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/18/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/18/index.md
@@ -80,6 +80,6 @@ Firefox 18 已于 2013 年 1 月 8 日发布。
 - [Firefox 18 网站兼容性](/zh-CN/docs/Site_Compatibility_for_Firefox_18)
 - [Firefox 18 附加组件兼容性](https://blog.mozilla.org/addons/2012/12/28/compatibility-for-firefox-18/)
 
-### 更早版本
+### 更早期的版本
 
-{{Firefox_for_developers('17')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/19/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/19/index.md
@@ -59,6 +59,6 @@ Firefox 19 已于 2013 年 2 月 19 日正式发布。
 - [Firefox 19 网站兼容性](/zh-CN/docs/Site_Compatibility_for_Firefox_19)
 - [Firefox 19 附加组件兼容性](https://blog.mozilla.org/addons/2013/02/07/compatibility-for-firefox-19/)
 
-### 更早版本
+### 更早期的版本
 
-{{Firefox_for_developers('18')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/20/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/20/index.md
@@ -47,6 +47,6 @@ Firefox 20 正式版发布于 2013 年 4 月 2 日。
 - [Firefox 20 Aurora Release Notes](http://www.mozilla.org/zh-CN/firefox/20.0a1/nightlynotes/)
 - [Site Compatibility for Firefox 20](/zh-CN/docs/Site_Compatibility_for_Firefox_20)
 
-### 更早版本
+### 更早期的版本
 
-{{Firefox_for_developers('19')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/21/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/21/index.md
@@ -94,6 +94,6 @@ slug: Mozilla/Firefox/Releases/21
 - [Firefox 21 网站兼容性](/zh-CN/docs/Site_Compatibility_for_Firefox_21)
 - [Firefox 21 附加组件兼容性](https://blog.mozilla.org/addons/2013/04/26/compatibility-for-firefox-21/)
 
-### 更早版本
+### 更早期的版本
 
-{{Firefox_for_developers('20')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/22/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/22/index.md
@@ -69,6 +69,6 @@ slug: Mozilla/Firefox/Releases/22
 - [Site Compatibility for Firefox 22](/zh-CN/docs/Site_Compatibility_for_Firefox_22)
 - [Add-on Compatibility for Firefox 22](https://blog.mozilla.org/addons/2013/06/03/compatibility-for-firefox-22/)
 
-### Older versions
+### 更早期的版本
 
-{{Firefox_for_developers('21')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/24/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/24/index.md
@@ -24,6 +24,6 @@ slug: Mozilla/Firefox/Releases/24
 - [Firefox 24 Aurora Notes](http://www.mozilla.org/zh-CN/firefox/24.0a2/auroranotes/)
 - [Firefox 24 网站兼容性](/zh-CN/docs/Site_Compatibility_for_Firefox_24)
 
-### 更早版本
+### 更早期的版本
 
-{{Firefox_for_developers('23')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/25/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/25/index.md
@@ -50,6 +50,6 @@ slug: Mozilla/Firefox/Releases/25
 
 - [Firefox 25 网站兼容性](/zh-CN/docs/Mozilla/Firefox/Releases/25/Site_Compatibility)
 
-### 更早版本
+### 更早期的版本
 
-{{Firefox_for_developers('24')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/26/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/26/index.md
@@ -44,6 +44,6 @@ _No change._
 
 - [Firefox 26 网站兼容性](/zh-CN/docs/Mozilla/Firefox/Releases/26/Site_Compatibility)
 
-### 更早版本
+### 更早期的版本
 
-{{Firefox_for_developers('25')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/27/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/27/index.md
@@ -52,6 +52,6 @@ _No change._
 
 - [Site Compatibility for Firefox 27](/zh-CN/docs/Mozilla/Firefox/Releases/27/Site_Compatibility)
 
-### 更早版本
+### 更早期的版本
 
-{{Firefox_for_developers('26')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/3/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/3/index.md
@@ -151,4 +151,4 @@ l10n:
 
 ## 参见
 
-{{Firefox_for_developers('2')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/31/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/31/index.md
@@ -60,6 +60,6 @@ _No change._
 
 - [Site Compatibility for Firefox 31](/zh-CN/docs/Mozilla/Firefox/Releases/31/Site_Compatibility)
 
-### Older versions
+### 更早期的版本
 
-{{Firefox_for_developers('30')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/32/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/32/index.md
@@ -124,6 +124,6 @@ A `getDataDirectory()` method has been added to [`Addon`](/zh-CN/Add-ons/Add-on_
 
 - [Site Compatibility for Firefox 32](/zh-CN/docs/Mozilla/Firefox/Releases/32/Site_Compatibility)
 
-### Older versions
+### 更早期的版本
 
-{{Firefox_for_developers('31')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/33/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/33/index.md
@@ -53,6 +53,6 @@ _No change._
 
 - [Site Compatibility for Firefox 33](/zh-CN/docs/Mozilla/Firefox/Releases/33/Site_Compatibility)
 
-### 更早版本
+### 更早期的版本
 
-{{Firefox_for_developers('32')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/41/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/41/index.md
@@ -157,6 +157,6 @@ _没有变化。_
 
 - [Site Compatibility for Firefox 41](/zh-CN/docs/Mozilla/Firefox/Releases/41/Site_Compatibility)
 
-## 之前版本
+## 更早期的版本
 
-{{Firefox_for_developers('40')}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/59/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/59/index.md
@@ -102,6 +102,6 @@ _无变化。_
 
 - Firefox 59 的站点兼容性
 
-## 历史版本
+## 更早期的版本
 
-{{Firefox_for_developers(58)}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/65/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/65/index.md
@@ -101,4 +101,4 @@ _无变化。_
 
 ## 更早期的版本
 
-{{Firefox_for_developers(65)}}
+{{Firefox_for_developers}}

--- a/files/zh-cn/mozilla/firefox/releases/78/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/78/index.md
@@ -85,4 +85,4 @@ l10n:
 
 ## 更早期的版本
 
-{{Firefox_for_developers(77)}}
+{{Firefox_for_developers}}

--- a/files/zh-tw/mozilla/firefox/releases/61/index.md
+++ b/files/zh-tw/mozilla/firefox/releases/61/index.md
@@ -121,4 +121,4 @@ _無變動。_
 
 ## 舊版資訊
 
-{{Firefox_for_developers(60)}}
+{{Firefox_for_developers}}


### PR DESCRIPTION
### Description

remove the version arguments of Firefox_for_developers macros

### Related issues and pull requests

- upstream: mdn/content#32464
- yari: mdn/yari#10034
