### PR TITLE
fr_single_double_quote problem fixed

### DIFF
--- a/files/fr/learn/html/introduction_to_html/getting_started/index.md
+++ b/files/fr/learn/html/introduction_to_html/getting_started/index.md
@@ -462,8 +462,8 @@ Nous vous recommandons de toujours inclure les guillemets afin d'éviter ce type
 
 Dans cet article, vous remarquerez que les valeurs des attributs sont toutes entre des guillemets doubles ("&nbsp;"). Vous pouvez cependant voir des guillemets simples ('&nbsp;') dans le code HTML de certaines personnes. C'est purement une question de style, et vous êtes libre de choisir la solution que vous préférez. Les deux lignes suivantes sont équivalentes :
 
-```html
-<a href="http://www.exemple.com">Un lien vers mon exemple.</a>
+```html-nolint
+<a href='http://www.exemple.com'>Un lien vers mon exemple.</a>
 
 <a href="http://www.example.com">Un lien vers mon exemple</a>
 ```


### PR DESCRIPTION
Fixes #17954 
### Description

I changed "" to '' in the fr version for Single and Double quotes and use `-nolint` suffix is used to prevent prettier from formating the code example.