### PR TITLE
chore(ci): Bump actions/labeler from 4 to 5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,50 +1,60 @@
 system:
-  - package.json
-  - yarn.lock
-  - .github/**/*
-  - .husky/**/*
-  - .vscode/**/*
-  - .*
-  - front-matter-config.json
-
-l10n-de:
-  - files/de/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - package.json
+          - yarn.lock
+          - .github/**
+          - .husky/**
+          - .vscode/**
+          - .*
+          - front-matter-config.json
 
 l10n-es:
-  - files/es/**/*
-  - docs/es/**/*
-  - /.github/ISSUE_TEMPLATE/page-report-es.yml
+  - changed-files:
+      - any-glob-to-any-file:
+          - files/es/**
+          - docs/es/**
+          - .github/ISSUE_TEMPLATE/page-report-es.yml
 
 l10n-fr:
-  - files/fr/**/*
-  - /.github/ISSUE_TEMPLATE/page-report-fr.yml
+  - changed-files:
+      - any-glob-to-any-file:
+          - files/fr/**
+          - .github/ISSUE_TEMPLATE/page-report-fr.yml
 
 l10n-ja:
-  - files/ja/**/*
-  - docs/ja/**/*
-  - /.github/ISSUE_TEMPLATE/page-report-ja.yml
+  - changed-files:
+      - any-glob-to-any-file:
+          - files/ja/**
+          - docs/ja/**
+          - .github/ISSUE_TEMPLATE/page-report-ja.yml
 
 l10n-ko:
-  - files/ko/**/*
-  - docs/ko/**/*
-  - /.github/ISSUE_TEMPLATE/page-report-ko.yml
-
-l10n-pl:
-  - files/pl/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - files/ko/**
+          - docs/ko/**
+          - .github/ISSUE_TEMPLATE/page-report-ko.yml
 
 l10n-pt-br:
-  - files/pt-br/**/*
-  - /.github/ISSUE_TEMPLATE/page-report-pt-br.yml
+  - changed-files:
+      - any-glob-to-any-file:
+          - files/pt-br/**
+          - .github/ISSUE_TEMPLATE/page-report-pt-br.yml
 
 l10n-ru:
-  - files/ru/**/*
-  - docs/ru/**/*
-  - /.github/ISSUE_TEMPLATE/page-report-ru.yml
+  - changed-files:
+      - any-glob-to-any-file:
+          - files/ru/**
+          - docs/ru/**
+          - .github/ISSUE_TEMPLATE/page-report-ru.yml
 
 l10n-zh:
-  - files/zh-cn/**/*
-  - files/zh-tw/**/*
-  - docs/zh-cn/**/*
-  - docs/zh-tw/**/*
-  - /.github/ISSUE_TEMPLATE/page-report-zh-cn.yml
-  - /.github/ISSUE_TEMPLATE/page-report-zh-tw.yml
+  - changed-files:
+      - any-glob-to-any-file:
+          - files/zh-cn/**
+          - files/zh-tw/**
+          - docs/zh-cn/**
+          - docs/zh-tw/**
+          - .github/ISSUE_TEMPLATE/page-report-zh-cn.yml
+          - .github/ISSUE_TEMPLATE/page-report-zh-tw.yml

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,6 @@
+# This file is used by .github/workflows/pr-labeler.yml to label pull requests based on the files changed in the PR.
+# Object matching syntax: https://github.com/actions/labeler/blob/main/README.md#match-object
+
 system:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -8,6 +8,7 @@ jobs:
     if: github.repository == 'mdn/translated-content'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
### Description

Bump actions/labeler from 4 to 5.

The new [input: `sync-label`](https://github.com/actions/labeler?tab=readme-ov-file#inputs) is added to automatically remove unmatched labels (which is configured in label matching entries)

### Motivation

[All the actions which is running on Node 16 will be migrated to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). And the `actions/labeler@v4` is running on Node 16 which may not be supported in the future.

### Related issues and pull requests

#17278
testing: #18403, see [debug log](https://github.com/mdn/translated-content/actions/runs/8151891522/job/22280498958?pr=18403).
