### PR TITLE
feat(sync-translated-content): gather releated upstream commits

### DIFF
--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -73,7 +73,7 @@ jobs:
             # gather related upstream commits
             COMMIT_URL=$(gh api -XGET repos/mdn/content/commits -F path="${MOVED_FILE}" -F per_page=1 -F sha="${UPSTREAM_HEAD_SHA}" --jq '.[0].html_url')
             if [ -n "${COMMIT_URL}" ]; then
-              FILE_COMMIT_URLS="${FILE_COMMIT_URLS}- ${COMMIT_URL}\n"
+              FILE_COMMIT_URLS+="- ${COMMIT_URL}\n"
             fi
           done <<< "${MOVED_FILES}"
 

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -63,12 +63,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # get upstream head sha
+          UPSTREAM_HEAD_SHA=$(cd "${{ github.workspace }}/mdn/content" && git rev-parse HEAD)
+          echo "upstream head sha: ${UPSTREAM_HEAD_SHA}"
           # get original path of moved files
           MOVED_FILES=$(git diff --cached --name-status --diff-filter=R | cut -f2 | sed "0,/${{ matrix.lang }}/s//en-us/")
           FILE_COMMIT_URLS=""
           while read -r MOVED_FILE; do
             # gather related upstream commits
-            COMMIT_URL=$(gh api -XGET repos/mdn/content/commits -F path="${MOVED_FILE}" -F per_page=1 --jq '.[0].html_url')
+            COMMIT_URL=$(gh api -XGET repos/mdn/content/commits -F path="${MOVED_FILE}" -F per_page=1 -F sha="${UPSTREAM_HEAD_SHA}" --jq '.[0].html_url')
             if [ -n "${COMMIT_URL}" ]; then
               FILE_COMMIT_URLS="${FILE_COMMIT_URLS}- ${COMMIT_URL}\n"
             fi

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -67,7 +67,7 @@ jobs:
           UPSTREAM_HEAD_SHA=$(cd "${{ github.workspace }}/mdn/content" && git rev-parse HEAD)
           echo "upstream head sha: ${UPSTREAM_HEAD_SHA}"
           # get original path of moved files
-          MOVED_FILES=$(git diff --cached --name-status --diff-filter=R | cut -f2 | sed "0,/${{ matrix.lang }}/s//en-us/")
+          MOVED_FILES=$(git diff --cached --name-status --diff-filter=R | cut -f2 | sed "s|files/${{ matrix.lang }}|files/en-us|")
           FILE_COMMIT_URLS=""
           while read -r MOVED_FILE; do
             # gather related upstream commits

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -59,6 +59,33 @@ jobs:
         working-directory: ${{ github.workspace }}/mdn/content
         run: yarn content sync-translated-content ${{ matrix.lang }}
 
+      - name: Gather related upstream commits
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # get original path of moved files
+          MOVED_FILES=$(git diff --cached --name-status --diff-filter=R | cut -f2 | sed "0,/${{ matrix.lang }}/s//en-us/")
+          FILE_COMMIT_URLS=""
+          while read -r MOVED_FILE; do
+            # gather related upstream commits
+            COMMIT_URL=$(gh api -XGET repos/mdn/content/commits -F path="${MOVED_FILE}" -F per_page=1 --jq '.[0].html_url')
+            if [ -n "${COMMIT_URL}" ]; then
+              FILE_COMMIT_URLS="${FILE_COMMIT_URLS}- ${COMMIT_URL}\n"
+            fi
+          done <<< "${MOVED_FILES}"
+
+          FILE_COMMIT_URLS=$(echo -e "${FILE_COMMIT_URLS}" | grep -v '^$' | sort | uniq)
+          echo -e "commit urls:\n${FILE_COMMIT_URLS}"
+
+          # set multiline string to env
+          # https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+          # as the commit urls would not contain 'EOF', we can use it as a delimiter
+          {
+            echo 'COMMIT_URLS<<EOF'
+            echo "${FILE_COMMIT_URLS}"
+            echo EOF
+          } >> "$GITHUB_ENV"
+
       - name: Create PR with sync for ${{ matrix.lang }}
         uses: peter-evans/create-pull-request@v6
         with:
@@ -67,7 +94,7 @@ jobs:
           title: "[${{ matrix.lang }}] sync translated content"
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           committer: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
-          body: Yari generated sync
+          body: "Yari generated sync. Related upstream commits:\n\n${{ env.COMMIT_URLS }}"
           labels: |
             automated pr
           token: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
### Description

gather releated upstream commits

---

Tested in my fork, check branch: https://github.com/yin1999/translated-content/tree/test-gather-urls

workflow run: https://github.com/yin1999/translated-content/actions/runs/8182413701

screenshot:

![image](https://github.com/mdn/translated-content/assets/15844309/ed872619-511f-4a36-a765-f31acd3b6306)

![image](https://github.com/mdn/translated-content/assets/15844309/f092a3c9-c567-4f5a-9292-b9e008a66589)

### Related issues and pull requests

https://github.com/mdn/translated-content/pull/9199#discussion_r992885708
