### PR TITLE
zh-cn: fix the broken link in Regular Expressions guide

### DIFF
--- a/files/zh-cn/web/javascript/guide/regular_expressions/index.md
+++ b/files/zh-cn/web/javascript/guide/regular_expressions/index.md
@@ -483,7 +483,7 @@ var re = new RegExp("ab+c");
         </p>
         <p>例如，<code>/\s\w*/</code> 匹配"foo bar."中的' bar'。</p>
         <p>
-          经测试，\s不匹配"<a href="https://unicode-table.com/cn/180E/"
+          经测试，\s不匹配"<a href="https://symbl.cc/cn/180E/"
             >\u180e</a
           >"，在当前版本 Chrome(v80.0.3987.122) 和 Firefox(76.0.1)
           控制台输入/\s/.test("\u180e") 均返回 false。


### PR DESCRIPTION
This URL https://unicode-table.com/ has changed to https://symbl.cc/, it will be cool if you fix it 😊
