### PR TITLE
Update index.md

### DIFF
--- a/files/es/web/css/max-height/index.md
+++ b/files/es/web/css/max-height/index.md
@@ -29,9 +29,9 @@ max-height: <length> | <percentage>
 ### Ejemplos
 
 ```
-table { max-width: 75%; }
+table { max-height: 75%; }
 
-form { max-width: none; }
+form { max-height: none; }
 ```
 
 ### Notas


### PR DESCRIPTION
Examples were using width property instead of height property

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

The examples should be using height property instead of width

<!-- ✍️ Summarize your changes in one or two sentences -->

I was using the page and I saw the error

<!-- ❓ Why are you making these changes and how do they help readers? -->

