### PR TITLE
fix(zh-cn): avoid the line breaks in tutorials

### DIFF
--- a/files/zh-cn/learn/html/introduction_to_html/html_text_fundamentals/index.md
+++ b/files/zh-cn/learn/html/introduction_to_html/html_text_fundamentals/index.md
@@ -873,9 +873,7 @@ textarea.onkeyup = () => {
 
 ```html
 <p>
-  这杯液体<strong>毒性很大</strong>——如果饮用了它，你<strong
-    >可能<em>会死</em></strong
-  >。
+  这杯液体<strong>毒性很大</strong>——如果饮用了它，你<strong>可能<em>会死</em></strong>。
 </p>
 ```
 

--- a/files/zh-cn/learn/html/introduction_to_html/html_text_fundamentals/index.md
+++ b/files/zh-cn/learn/html/introduction_to_html/html_text_fundamentals/index.md
@@ -871,7 +871,7 @@ textarea.onkeyup = () => {
 
 如有需要你可以将 strong 元素和 em 元素嵌套在其他的标签中：
 
-```html
+```html-nolint
 <p>
   这杯液体<strong>毒性很大</strong>——如果饮用了它，你<strong>可能<em>会死</em></strong>。
 </p>


### PR DESCRIPTION
### Description

An issue was found where the `<strong>` tag was not closed correctly, which has been fixed.
