### PR TITLE
Replaced deprecated method "addListener" to "addEventListener"

### DIFF
--- a/files/zh-cn/web/api/window/devicepixelratio/index.md
+++ b/files/zh-cn/web/api/window/devicepixelratio/index.md
@@ -88,7 +88,7 @@ const updatePixelRatio = () => {
 
 updatePixelRatio();
 
-matchMedia(mqString).addListener(updatePixelRatio);
+matchMedia(mqString).addEventListener('change', updatePixelRatio);
 ```
 
 字符串`mqString`设置为媒体查询本身。媒体查询以`(resolution: 1dppx)`（对于标准显示）或`(resolution: 2dppx)`（对于 Retina / HiDPI 显示）开始，检查当前显示分辨率是否与每个像素`px`的实际设备像素点匹配。

--- a/files/zh-cn/web/api/window/devicepixelratio/index.md
+++ b/files/zh-cn/web/api/window/devicepixelratio/index.md
@@ -88,7 +88,7 @@ const updatePixelRatio = () => {
 
 updatePixelRatio();
 
-matchMedia(mqString).addEventListener('change', updatePixelRatio);
+matchMedia(mqString).addEventListener("change", updatePixelRatio);
 ```
 
 字符串`mqString`设置为媒体查询本身。媒体查询以`(resolution: 1dppx)`（对于标准显示）或`(resolution: 2dppx)`（对于 Retina / HiDPI 显示）开始，检查当前显示分辨率是否与每个像素`px`的实际设备像素点匹配。


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replaced deprecated method "addListener" to "addEventListener"

### Motivation

Found a warning from Rider said that addListener was deprecated and found this while reading the docs about difference between "addListener" and "addEventListener"

### Additional details

@*nothing*@

### Related issues and pull requests

@*nothing*@