### PR TITLE
[fr] Fix issues where EmbedLiveSample doesn't work properly

### DIFF
--- a/files/fr/web/css/gap/index.md
+++ b/files/fr/web/css/gap/index.md
@@ -103,7 +103,7 @@ Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement su
 
 #### Résultat
 
-{{EmbedLiveSample("", "auto", "230px")}}
+{{EmbedLiveSample("Disposition flexible", "auto", "230px")}}
 
 ### Disposition en grille
 
@@ -147,7 +147,7 @@ Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement su
 
 #### Résultat
 
-{{EmbedLiveSample("", "auto", "230px")}}
+{{EmbedLiveSample("Disposition en grille", "auto", "230px")}}
 
 ### Disposition multi-colonnes
 
@@ -172,7 +172,7 @@ Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement su
 
 #### Résultat
 
-{{EmbedLiveSample("", "auto", "120px")}}
+{{EmbedLiveSample("Disposition multi-colonnes", "auto", "120px")}}
 
 ## Spécifications
 

--- a/files/fr/web/css/list-style-type/index.md
+++ b/files/fr/web/css/list-style-type/index.md
@@ -247,7 +247,7 @@ ol.shortcut {
 
 #### Résultat
 
-{{EmbedLiveSample('',"200","300")}}
+{{EmbedLiveSample("Définition de l'apparence des puces","200","300")}}
 
 ### Tous les styles de liste
 
@@ -707,7 +707,7 @@ container.addEventListener("change", (event) => {
 
 #### Résultat
 
-{{EmbedLiveSample("", "600", "850")}}
+{{EmbedLiveSample("Tous les styles de liste", "600", "850")}}
 
 ## Spécifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I'm fixing the usage of `EmbedLiveSample` in two pages here, as a first validation step.
To go further, maybe the macro can be improved, or we need to go through all files and fix the broken ones.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The macro `EmbedLiveSample` isn't working properly in some files.
Because it's not using the required [`sample_id`](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Live_samples#sample_id) parameter, it results on some broken demos.


### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
You can see the [demos on the French gap page](https://developer.mozilla.org/fr/docs/Web/CSS/gap) have broken demos (only the HTML is rendered, not picking up the CSS).
But the [English demos](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) are working as expected.

| French | English |
-|-
| ![image](https://github.com/mdn/translated-content/assets/1302282/d3df9b43-9e0b-4470-9aee-b6aea50c893c) | ![image](https://github.com/mdn/translated-content/assets/1302282/490f80c1-8b15-4860-b553-622543f737bb) |

Same for the [list-style-type](https://developer.mozilla.org/fr/docs/Web/CSS/list-style-type#exemples).

The difference is that the English version does:
`{{EmbedLiveSample("Grid_layout", "auto", 250)}}` on [this line](https://github.com/mdn/content/blob/main/files/en-us/web/css/gap/index.md?plain=1#L153)
The French version does:
`{{EmbedLiveSample("", "auto", "230px")}}` on [this line](https://github.com/mdn/translated-content/blob/main/files/fr/web/css/gap/index.md?plain=1#L150)

It's not providing a `sample_id` and because there is some various heading levels, maybe the macro automatic matching gets lost..

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes mdn/yari#123" -->
<!-- 👉 Highlight related pull requests using "Relates to mdn/yari#123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** mdn/yari#123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

----

~:warning: I haven't tested this locally, I only commited via the Github Codespace interface as a proof of concept of what can be done to solve this.~
The auto-deploy shows that this fix is working properly.