### PR TITLE
用語集 - Second-level_Domain の更新

### DIFF
--- a/files/ja/glossary/second-level_domain/index.md
+++ b/files/ja/glossary/second-level_domain/index.md
@@ -1,6 +1,6 @@
 ---
 title: SLD
-slug: Glossary/SLD
+slug: Glossary/Second-level_Domain
 ---
 
 {{GlossarySidebar}}


### PR DESCRIPTION
### Description

英語ページ https://developer.mozilla.org/en-US/docs/Glossary/SLD の日本語翻訳 https://developer.mozilla.org/ja/docs/Glossary/SLD は、実質英語ページ https://developer.mozilla.org/en-US/docs/Glossary/Second-level_Domain の翻訳となっているので、日本語翻訳のディレクトリを SLD -> Second-level_Domain に変更しました。

### Additional details

- https://github.com/mozilla-japan/translation/issues/749