### PR TITLE
[fr] fix: default value + better translation on `Mozilla/Add-ons/WebExtensions/manifest.json/browser_action`

### DIFF
--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/browser_action/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/browser_action/index.md
@@ -127,7 +127,7 @@ La clé `browser_action` est un objet qui peut avoir l'une des propriétés suiv
           </li>
         </ul>
         <p>Cette propriété est seulement supportée dans Firefox.</p>
-        <p>Cett propriété est facultative, et defaut à "navbar".</p>
+        <p>Cette propriété est facultative et a pour valeur par défaut "menupanel".</p>
         <p>
           Firefox se souvient des paramètres <code>default_area</code> d'une
           extension, même si cette extension est désinstallée et réinstallée


### PR DESCRIPTION
### Description

Better translation and update of default value

### Motivation

Better translation and update of default value

### Additional details

- Issue : https://github.com/mdn/content/issues/23797
- PR : https://github.com/mdn/content/pull/24086

> Firefox 109 changed this default to the Extensions button drop-down or, if the user has set [`extensions.unifiedExtensions.enabled`](https://github.com/mdn/translated-content/issues/url) to false, the overflow menu. In effect, the default now behaves the same as "menupanel".

### Related issues and pull requests

Fixes #17994