### PR TITLE
[fr] fix broken links and duplication on `Web/CSS/:placeholder-shown`

### DIFF
--- a/files/fr/web/css/_colon_placeholder-shown/index.md
+++ b/files/fr/web/css/_colon_placeholder-shown/index.md
@@ -5,7 +5,7 @@ slug: Web/CSS/:placeholder-shown
 
 {{CSSRef}}
 
-La [pseudo-classe](/fr/docs/Web/CSS/Pseudo-classes) **`:placeholder-shown`** permet de représenter n'importe quel élément {{htmlElement("input")}} ou {{htmlElement("textarea")}} affichant [un texte de substitution](/fr/docs/Web/Guide/HTML/Forms_in_HTML#The_placeholder_attribute).
+La [pseudo-classe](/fr/docs/Web/CSS/Pseudo-classes) **`:placeholder-shown`** permet de représenter n'importe quel élément {{htmlElement("input")}} ou {{htmlElement("textarea")}} affichant [un texte de substitution](fr/docs/Web/HTML/Element/input#placeholder).
 
 ```css
 /* Cible tout élément <input> ou <textarea> avec un */
@@ -194,7 +194,6 @@ input.studentid:placeholder-shown {
 ## Voir aussi
 
 - {{cssxref("::placeholder")}}
-- {{cssxref("::-moz-placeholder")}}
 - {{HTMLElement("input")}}
 - {{HTMLElement("textarea")}}
-- [Les formulaires HTML](/fr/docs/Web/Guide/HTML/Formulaires)
+- [Les formulaires HTML](/fr/docs/Learn/Forms)

--- a/files/fr/web/css/_colon_placeholder-shown/index.md
+++ b/files/fr/web/css/_colon_placeholder-shown/index.md
@@ -5,7 +5,7 @@ slug: Web/CSS/:placeholder-shown
 
 {{CSSRef}}
 
-La [pseudo-classe](/fr/docs/Web/CSS/Pseudo-classes) **`:placeholder-shown`** permet de représenter n'importe quel élément {{htmlElement("input")}} ou {{htmlElement("textarea")}} affichant [un texte de substitution](fr/docs/Web/HTML/Element/input#placeholder).
+La [pseudo-classe](/fr/docs/Web/CSS/Pseudo-classes) **`:placeholder-shown`** permet de représenter n'importe quel élément {{htmlElement("input")}} ou {{htmlElement("textarea")}} affichant [un texte de substitution](/fr/docs/Web/HTML/Element/input#placeholder).
 
 ```css
 /* Cible tout élément <input> ou <textarea> avec un */


### PR DESCRIPTION
### Description

2 broken links and potential duplicate

### Motivation

Better readability and links to up-to-date documentation in French

### Additional details

- 1 link in English, using the existing article in French
- 1 link with redirection, use of direct link
- `::-moz-placeholder` and `::placeholder` link to the same page

### Related issues and pull requests

N/A
