### PR TITLE
remove extra closing brackets about Statements > label in Japanese.

### DIFF
--- a/files/ja/web/javascript/reference/statements/label/index.md
+++ b/files/ja/web/javascript/reference/statements/label/index.md
@@ -94,7 +94,7 @@ loop1: for (i = 0; i < 3; i++) {
 
 ```js
 // 1 から 100 までの数
-const items = Array.from({ length: 100 }, (_, i) => i + 1));
+const items = Array.from({ length: 100 }, (_, i) => i + 1);
 const tests = [
   { pass: (item) => item % 2 === 0 },
   { pass: (item) => item % 3 === 0 },
@@ -117,7 +117,7 @@ itemIteration: for (const item of items) {
 
 ```js
 // 1 から 100 までの数
-const items = Array.from({ length: 100 }, (_, i) => i + 1));
+const items = Array.from({ length: 100 }, (_, i) => i + 1);
 const tests = [
   { pass: (item) => item % 2 === 0 },
   { pass: (item) => item % 3 === 0 },
@@ -145,7 +145,7 @@ for (const item of items) {
 
 ```js
 // 1 から 100 までの数
-const items = Array.from({ length: 100 }, (_, i) => i + 1));
+const items = Array.from({ length: 100 }, (_, i) => i + 1);
 const tests = [
   { pass: (item) => item % 2 === 0 },
   { pass: (item) => item % 3 === 0 },
@@ -167,7 +167,7 @@ itemIteration: for (const item of items) {
 
 ```js
 // 1 から 100 までの数
-const items = Array.from({ length: 100 }, (_, i) => i + 1));
+const items = Array.from({ length: 100 }, (_, i) => i + 1);
 const tests = [
   { pass: (item) => item % 2 === 0 },
   { pass: (item) => item % 3 === 0 },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
There was a syntax error in the sample code for 「Using a labeled continue statement」and 「Using a labeled break statement」 in Japanese.

### Motivation
Reading safe code.

### Additional details
Other languages were not a problem.
e.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
