### PR TITLE
fr: Adding french translation of `Document_an_HTTP_header` for #16686

### DIFF
--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -38,7 +38,7 @@ Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt 
 - Rédigez un texte sur le nouvel en-tête HTTP.
 - Assurez-vous d'avoir les sections suivantes&nbsp;:
   - Texte d'introduction dont la première phrase mentionne le nom de l'en-tête (en gras) et résume son objectif.
-  - Une boîte d'information contenant au moins le type d'en-tête et si l'en-tête est un {{Glossary("Forbidden header name","nom d'en-tête interdit")}}.
+  - - Une boîte d'information contenant au moins le type d'en-tête et si l'en-tête est un [nom d'en-tête interdit](/fr/docs/Glossary/Forbidden_header_name).
   - Un encart syntaxique contenant toutes les directives/paramètres/valeurs possibles de l'en-tête HTTP.
   - Une section expliquant ces directives/valeurs.
   - Une section d'exemples qui contient un cas d'utilisation pratique pour cet en-tête ou qui montre où et comment il se produit habituellement.

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -14,7 +14,7 @@ Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt 
 - De nombreux en-têtes HTTP sont définis dans diverses normes de l'IETF.
 - L'IANA tient un [registre des champs d'en-tête HTTP](https://www.iana.org/assignments/http-fields/http-fields.xhtml) et Wikipédia répertorie [les champs d'en-tête connus](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields), mais tous ne sont pas pertinents pour les développeurs web ou ne font pas partie d'une norme officielle.
 - S'il existe des **liens rouges** sur la page de [référence des en-têtes HTTP](/fr/docs/Web/HTTP/Headers), ces en-têtes sont un bon choix à documenter.
-- En cas de doute, [demandez à l'équipe de MDN Web Docs](/en-US/docs/MDN/Community/Communication_channels) s'il est judicieux d'écrire sur l'en-tête que vous avez choisi.
+- En cas de doute, [demandez à l'équipe de MDN Web Docs](/fr/docs/MDN/Community/Communication_channels) s'il est judicieux d'écrire sur l'en-tête que vous avez choisi.
 
 ## Étape 2 - Vérifier les pages d'en-tête HTTP existantes
 

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -52,4 +52,4 @@ Assurez-vous que votre en-tête est répertorié dans une catégorie appropriée
 
 ## Étape 7 - Révision du contenu
 
-Après avoir créé la page d'en-tête, soumettez-la en tant que Pull Request. Un membre de notre équipe de révision sera automatiquement désigné pour réviser votre page.
+Après avoir créé la page d'en-tête, soumettez-la en tant que [<i lang="en">Pull Request</i>](https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request). Un membre de notre équipe de révision sera automatiquement désigné pour réviser votre page.

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -23,7 +23,7 @@ Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt 
 ## Étape 2 - Vérifier les pages d'en-tête HTTP existantes
 
 - Les en-têtes HTTP existants sont documentés [ici](/fr/docs/Web/HTTP/Headers).
-- Il existe différentes catégories d'en-têtes : {{Glossary("Request header","En-tête de requête")}}, {{Glossary("Response header","En-tête de réponse")}}, et {{Glossary("Representation header","En-tête de représentation")}}.
+- Il existe différentes catégories d'en-têtes&nbsp;: [en-tête de requête](/fr/docs/Glossary/Request_header), [en-tête de réponse](/en-US/docs/Glossary/Response_header), et [en-tête de représentation](/fr/docs/Glossary/Representation_header).
 - Trouvez la catégorie de l'en-tête que vous vous apprêtez à documenter (notez que certains en-têtes peuvent être à la fois des en-têtes de demande et des en-têtes de réponse, selon le contexte).
 - Accédez à une page de référence d'en-tête existant dans la même catégorie.
 

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -23,7 +23,7 @@ Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt 
 ## Étape 2 - Vérifier les pages d'en-tête HTTP existantes
 
 - Les en-têtes HTTP existants sont documentés [ici](/fr/docs/Web/HTTP/Headers).
-- Il existe différentes catégories d'en-têtes&nbsp;: [en-tête de requête](/fr/docs/Glossary/Request_header), [en-tête de réponse](/en-US/docs/Glossary/Response_header), et [en-tête de représentation](/fr/docs/Glossary/Representation_header).
+- Il existe différentes catégories d'en-têtes&nbsp;: [en-tête de requête](/fr/docs/Glossary/Request_header), [en-tête de réponse](/fr/docs/Glossary/Response_header), et [en-tête de représentation](/fr/docs/Glossary/Representation_header).
 - Trouvez la catégorie de l'en-tête que vous vous apprêtez à documenter (notez que certains en-têtes peuvent être à la fois des en-têtes de requête et des en-têtes de réponse, selon le contexte).
 - Accédez à une page de référence d'en-tête existant dans la même catégorie.
 

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -30,7 +30,7 @@ Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt 
 
 ## Étape 4 - Rédiger le contenu
 
-- Vous pouvez soit partir de notre [modèle de page d'en-tête HTTP](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types#http_header_reference_page), soit utiliser une structure copiée à partir de l'un des documents d'en-tête HTTP existants que vous avez trouvés à l'étape 2. C'est à vous de choisir.
+- Vous pouvez soit partir de notre [modèle de page d'en-tête HTTP](/fr/docs/MDN/Writing_guidelines/Page_structures/Page_types#http_header_reference_page), soit utiliser une structure copiée à partir de l'un des documents d'en-tête HTTP existants que vous avez trouvés à l'étape 2. C'est à vous de choisir.
 - Rédigez un texte sur le nouvel en-tête HTTP.
 - Assurez-vous d'avoir les sections suivantes :
   - Texte d'introduction dont la première phrase mentionne le nom de l'en-tête (en gras) et résume son objectif.

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -56,4 +56,4 @@ Assurez-vous que votre en-tête est répertorié dans une catégorie appropriée
 
 ## Étape 7 - Révision du contenu
 
-Après avoir créé la page d'en-tête, soumettez-la en tant que [<i lang="en">Pull Request</i>](https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request). Un membre de notre équipe de révision sera automatiquement désigné pour réviser votre page.
+Après avoir créé la page d'en-tête, soumettez-la en tant que [<i lang="en">pull request</i>](https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request). Un membre de notre équipe de révision sera automatiquement désigné pour réviser votre page.

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -36,7 +36,7 @@ Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt 
 
 - Vous pouvez soit partir de notre [modèle de page d'en-tête HTTP](/fr/docs/MDN/Writing_guidelines/Page_structures/Page_types#http_header_reference_page), soit utiliser une structure copiée à partir de l'un des documents d'en-tête HTTP existants que vous avez trouvés à l'étape 2. C'est à vous de choisir.
 - Rédigez un texte sur le nouvel en-tête HTTP.
-- Assurez-vous d'avoir les sections suivantes :
+- Assurez-vous d'avoir les sections suivantes&nbsp;:
   - Texte d'introduction dont la première phrase mentionne le nom de l'en-tête (en gras) et résume son objectif.
   - Une boîte d'information contenant au moins le type d'en-tête et si l'en-tête est un {{Glossary("Forbidden header name","nom d'en-tête interdit")}}.
   - Un encart syntaxique contenant toutes les directives/paramètres/valeurs possibles de l'en-tête HTTP.

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -11,6 +11,8 @@ La [référence des en-têtes HTTP](/fr/docs/Web/HTTP/Headers) sur MDN Web Docs 
 
 Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt à vous familiariser avec ses détails.
 
+> **Note :** La documentation de nouvelles en-têtes HTTP doit d'abord avoir lieu en anglais avant de pouvoir traduire le nouveau contenu en français. L'organisation du contenu de MDN ne permet pas de créer du contenu en français si celui-ci n'existe pas déjà en anglais.
+
 ## Étape 1 - Déterminer l'en-tête HTTP à documenter
 
 - De nombreux en-têtes HTTP sont définis dans diverses normes de l'IETF.

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -29,7 +29,7 @@ Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt 
 
 ## Étape 3 - Créer la page d'en-tête HTTP
 
-- Toutes les pages d'en-tête se trouvent sous cette arborescence : [/docs/Web/HTTP/Headers/](/fr/docs/Web/HTTP/Headers)
+- Toutes les pages d'en-tête se trouvent sous cette arborescence&nbsp;: [/docs/Web/HTTP/Headers/](/fr/docs/Web/HTTP/Headers)
 - Pour créer une nouvelle page, voir les instructions dans notre [guide de création de pages](/fr/docs/MDN/Writing_guidelines/Howto/Creating_moving_deleting).
 
 ## Étape 4 - Rédiger le contenu

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -24,7 +24,7 @@ Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt 
 
 - Les en-têtes HTTP existants sont documentés [ici](/fr/docs/Web/HTTP/Headers).
 - Il existe différentes catégories d'en-têtes&nbsp;: [en-tête de requête](/fr/docs/Glossary/Request_header), [en-tête de réponse](/en-US/docs/Glossary/Response_header), et [en-tête de représentation](/fr/docs/Glossary/Representation_header).
-- Trouvez la catégorie de l'en-tête que vous vous apprêtez à documenter (notez que certains en-têtes peuvent être à la fois des en-têtes de demande et des en-têtes de réponse, selon le contexte).
+- Trouvez la catégorie de l'en-tête que vous vous apprêtez à documenter (notez que certains en-têtes peuvent être à la fois des en-têtes de requête et des en-têtes de réponse, selon le contexte).
 - Accédez à une page de référence d'en-tête existant dans la même catégorie.
 
 ## Étape 3 - Créer la page d'en-tête HTTP

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -1,0 +1,55 @@
+---
+title: Comment documenter un en-tête HTTP
+slug: MDN/Writing_guidelines/Howto/Document_an_HTTP_header
+---
+
+{{MDNSidebar}}
+
+La [référence des en-têtes HTTP](/fr/docs/Web/HTTP/Headers) sur MDN Web Docs documente les champs d'en-têtes HTTP. Ce sont des composants de la section d'en-tête des messages de requête et de réponse dans le protocole de transfert hypertexte ([HTTP](/fr/docs/Web/HTTP)). Ils définissent les paramètres de fonctionnement d'une transaction HTTP. Cet article explique comment créer une nouvelle page de référence pour un en-tête HTTP.
+
+Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt à vous familiariser avec ses détails.
+
+## Étape 1 - Déterminer l'en-tête HTTP à documenter
+
+- De nombreux en-têtes HTTP sont définis dans diverses normes de l'IETF.
+- L'IANA tient un [registre des champs d'en-tête HTTP](https://www.iana.org/assignments/http-fields/http-fields.xhtml) et Wikipédia répertorie [les champs d'en-tête connus](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields), mais tous ne sont pas pertinents pour les développeurs web ou ne font pas partie d'une norme officielle.
+- S'il existe des **liens rouges** sur la page de [référence des en-têtes HTTP](/fr/docs/Web/HTTP/Headers), ces en-têtes sont un bon choix à documenter.
+- En cas de doute, [demandez à l'équipe de MDN Web Docs](/en-US/docs/MDN/Community/Communication_channels) s'il est judicieux d'écrire sur l'en-tête que vous avez choisi.
+
+## Étape 2 - Vérifier les pages d'en-tête HTTP existantes
+
+- Les en-têtes HTTP existants sont documentés [ici](/fr/docs/Web/HTTP/Headers).
+- Il existe différentes catégories d'en-têtes : {{Glossary("Request header","En-tête de requête")}}, {{Glossary("Response header","En-tête de réponse")}}, et {{Glossary("Representation header","En-tête de représentation")}}.
+- Trouvez la catégorie de l'en-tête que vous vous apprêtez à documenter (notez que certains en-têtes peuvent être à la fois des en-têtes de demande et des en-têtes de réponse, selon le contexte).
+- Accédez à une page de référence d'en-tête existant dans la même catégorie.
+
+## Étape 3 - Créer la page d'en-tête HTTP
+
+- Toutes les pages d'en-tête se trouvent sous cette arborescence : [/docs/Web/HTTP/Headers/](/fr/docs/Web/HTTP/Headers)
+- Pour créer une nouvelle page, voir les instructions dans notre [guide de création de pages](/fr/docs/MDN/Writing_guidelines/Howto/Creating_moving_deleting).
+
+## Étape 4 - Rédiger le contenu
+
+- Vous pouvez soit partir de notre [modèle de page d'en-tête HTTP](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types#http_header_reference_page), soit utiliser une structure copiée à partir de l'un des documents d'en-tête HTTP existants que vous avez trouvés à l'étape 2. C'est à vous de choisir.
+- Rédigez un texte sur le nouvel en-tête HTTP.
+- Assurez-vous d'avoir les sections suivantes :
+  - Texte d'introduction dont la première phrase mentionne le nom de l'en-tête (en gras) et résume son objectif.
+  - Une boîte d'information contenant au moins le type d'en-tête et si l'en-tête est un  {{Glossary("Forbidden header name","nom d'en-tête interdit")}}.
+  - Un encart syntaxique contenant toutes les directives/paramètres/valeurs possibles de l'en-tête HTTP.
+  - Une section expliquant ces directives/valeurs.
+  - Une section d'exemples qui contient un cas d'utilisation pratique pour cet en-tête ou qui montre où et comment il se produit habituellement.
+  - Une section de spécification listant les documents standards RFC pertinents.
+  - Une section "Voir aussi" énumérant les ressources pertinentes.
+
+## Étape 5 - Ajouter des informations sur la compatibilité des navigateurs
+
+- Si vous avez consulté d'autres pages d'en-tête HTTP, vous verrez qu'il existe une macro `{{Compat}}` qui remplit une table du navigateur pour vous.
+- La page du tableau de compatibilité est générée à partir de données structurées. Si vous souhaitez contribuer à ces données, veuillez consulter les instructions à l'adresse <https://github.com/mdn/browser-compat-data/blob/main/README.md> et nous envoyer une Pull Request.
+
+## Étape 6 - Mise à jour de la liste des en-têtes HTTP
+
+Assurez-vous que votre en-tête est répertorié dans une catégorie appropriée sur la [page de référence des en-têtes HTTP](/fr/docs/Web/HTTP/Headers).
+
+## Étape 7 - Révision du contenu
+
+Après avoir créé la page d'en-tête, soumettez-la en tant que Pull Request. Un membre de notre équipe de révision sera automatiquement désigné pour réviser votre page.

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -1,6 +1,8 @@
 ---
 title: Comment documenter un en-tête HTTP
 slug: MDN/Writing_guidelines/Howto/Document_an_HTTP_header
+l10n:
+  sourceCommit: 17db3c03142f7077dc335f6f7c127388e2c64442
 ---
 
 {{MDNSidebar}}

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -16,7 +16,7 @@ Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt 
 ## Étape 1 - Déterminer l'en-tête HTTP à documenter
 
 - De nombreux en-têtes HTTP sont définis dans diverses normes de l'IETF.
-- L'IANA tient un [registre des champs d'en-tête HTTP](https://www.iana.org/assignments/http-fields/http-fields.xhtml) et Wikipédia répertorie [les champs d'en-tête connus](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields), mais tous ne sont pas pertinents pour les développeurs web ou ne font pas partie d'une norme officielle.
+- L'IANA tient un [registre des champs d'en-tête HTTP](https://www.iana.org/assignments/http-fields/http-fields.xhtml) et Wikipédia répertorie [les champs d'en-tête connus](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields), mais tous ne sont pas pertinents pour les développeuses et développeurs web ou ne font pas partie d'une norme officielle.
 - S'il existe des **liens rouges** sur la page de [référence des en-têtes HTTP](/fr/docs/Web/HTTP/Headers), ces en-têtes sont un bon choix à documenter.
 - En cas de doute, [demandez à l'équipe de MDN Web Docs](/fr/docs/MDN/Community/Communication_channels) s'il est judicieux d'écrire sur l'en-tête que vous avez choisi.
 

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -34,7 +34,7 @@ Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt 
 - Rédigez un texte sur le nouvel en-tête HTTP.
 - Assurez-vous d'avoir les sections suivantes :
   - Texte d'introduction dont la première phrase mentionne le nom de l'en-tête (en gras) et résume son objectif.
-  - Une boîte d'information contenant au moins le type d'en-tête et si l'en-tête est un  {{Glossary("Forbidden header name","nom d'en-tête interdit")}}.
+  - Une boîte d'information contenant au moins le type d'en-tête et si l'en-tête est un {{Glossary("Forbidden header name","nom d'en-tête interdit")}}.
   - Un encart syntaxique contenant toutes les directives/paramètres/valeurs possibles de l'en-tête HTTP.
   - Une section expliquant ces directives/valeurs.
   - Une section d'exemples qui contient un cas d'utilisation pratique pour cet en-tête ou qui montre où et comment il se produit habituellement.

--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -48,7 +48,7 @@ Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt 
 ## Étape 5 - Ajouter des informations sur la compatibilité des navigateurs
 
 - Si vous avez consulté d'autres pages d'en-tête HTTP, vous verrez qu'il existe une macro `{{Compat}}` qui remplit une table du navigateur pour vous.
-- La page du tableau de compatibilité est générée à partir de données structurées. Si vous souhaitez contribuer à ces données, veuillez consulter les instructions à l'adresse <https://github.com/mdn/browser-compat-data/blob/main/README.md> et nous envoyer une Pull Request.
+- La page du tableau de compatibilité est générée à partir de données structurées. Si vous souhaitez contribuer à ces données, veuillez consulter les instructions à l'adresse <https://github.com/mdn/browser-compat-data/blob/main/README.md> et nous envoyer une <i lang="en">pull request</i>.
 
 ## Étape 6 - Mise à jour de la liste des en-têtes HTTP
 


### PR DESCRIPTION
### Description

Adding the `Document_an_HTTP_header` french translation to `/fr/mdn/writing_guidelines/howto`

### Related issues and pull requests

- https://github.com/mdn/translated-content/issues/16686
