### PR TITLE
fr: Fix typo in index.md

### DIFF
--- a/files/fr/web/api/wheelevent/index.md
+++ b/files/fr/web/api/wheelevent/index.md
@@ -30,7 +30,7 @@ _Cette interface hérite des propriétés de ses ancêtres, {{DOMxRef("MouseEven
   - : Renvoie un `double` représentant le montant du défilement pour l'axe z.
 - {{DOMxRef("WheelEvent.deltaMode")}}{{ReadOnlyInline}}
 
-  - : Revnoie un `unsigned long` représentant l'unité du montant de défilement des valeurs `delta*`. Les valeurs autorisées sont :
+  - : Renvoie un `unsigned long` représentant l'unité du montant de défilement des valeurs `delta*`. Les valeurs autorisées sont :
 
     <table class="standard-table">
       <thead>


### PR DESCRIPTION
### Description

Small typo in french translation: "Revnoie" instead of "Renvoie"

### Motivation

Typo correction

### Additional details

None.

### Related issues and pull requests

None.
