### PR TITLE
chore(pt-br): remove the last reference to `@api/deki`

### DIFF
--- a/files/pt-br/web/html/element/audio/index.md
+++ b/files/pt-br/web/html/element/audio/index.md
@@ -63,10 +63,8 @@ O tempo de compensação (time offset) entre o áudio e o vídeo está especific
 
 ```html
 <!-- Reprodução simples de áudio -->
-<audio
-  src="https://developer.mozilla.org/@api/deki/files/2926/=AudioTest_(1).ogg"
-  autoplay>
-  O seu navegador não suporta o elemento <code>audio</code>.
+<audio src="AudioTest.ogg" autoplay>
+  <a href="AudioTest.ogg" download="AudioTest.ogg">Baixar áudio OGG</a>.
 </audio>
 
 <!-- Reprodução de áudio com legendas -->


### PR DESCRIPTION
### Description

remove the last reference to `@api/deki`. The replaced example is from [the en-US document](https://github.com/mdn/content/blob/71251662105fbac882aca295c641500175bb9ef1/files/en-us/web/html/element/audio/index.md?plain=1#L317-L320).

I can't speak Portuguese (Brazil), so please check if the translation is correct.

### Related issues and pull requests

Part of: #10487
