### PR TITLE
fr: remove the `{{DOMAttributeMethods}}` macros - Fixes #19044 

### DIFF
--- a/files/fr/web/api/element/getattributenode/index.md
+++ b/files/fr/web/api/element/getattributenode/index.md
@@ -35,8 +35,6 @@ Les nœuds `Attr` héritent de `Node`, mais ne sont pas considérés comme faisa
 
 [getAttribute](/fr/DOM/element.getAttribute) est habituellement utilisé à la place de `getAttributeNode` pour obtenir la valeur d'un attribut d'un élément.
 
-{{ DOMAttributeMethods() }}
-
 ## Spécification
 
 - [DOM Level 2 Core&nbsp;: getAttributeNode](http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-217A91B8) — [traduction en français](http://www.yoyodesign.org/doc/w3c/dom2-core/core.html#ID-217A91B8) (non normative)

--- a/files/fr/web/api/element/getattributenodens/index.md
+++ b/files/fr/web/api/element/getattributenodens/index.md
@@ -30,8 +30,6 @@ attributeNode = element.getAttributeNodeNS(namespace, nodeName);
 
 `getAttributeNodeNS` est plus spécifique que {{ domxref("Element.getAttributeNode") }} en ce qu'il permet de spécifier les attributs faisant partis d'un espace de noms particulier. La méthode de réglage correspondante est {{ domxref("Element.setAttributeNodeNS") }}.
 
-{{ DOMAttributeMethods() }}
-
 ### Spécification
 
 - [DOM Level 2 Core: getAttributeNodeNS (en)](http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-ElGetAtNodeNS) — [traduction en français](http://www.yoyodesign.org/doc/w3c/dom2-core/core.html#ID-ElGetAtNodeNS) (non normative)

--- a/files/fr/web/api/element/getattributens/index.md
+++ b/files/fr/web/api/element/getattributens/index.md
@@ -85,8 +85,6 @@ La méthode `getAttributeNS` diffère de {{domxref("element.getAttribute()", "ge
 
 Avant la spécification DOM4, cette méthode était spécifiée pour renvoyer une chaîne vide plutôt que null pour les attributs inexistants. Cependant, la plupart des navigateurs ont renvoyé null. À partir de DOM4, la spécification dit maintenant de retourner null. Cependant, certains navigateurs plus anciens renvoient une chaîne vide. Pour cette raison, vous devez utiliser {{domxref("element.hasAttributeNS ()","hasAttributeNS ()")}} pour vérifier l'existence d'un attribut avant d'appeler `getAttributeNS()` s'il est possible que l'attribut demandé n'existe pas sur l'élément spécifié.
 
-{{ DOMAttributeMethods() }}
-
 ## Spécifications
 
 {{Specifications}}

--- a/files/fr/web/api/element/hasattribute/index.md
+++ b/files/fr/web/api/element/hasattribute/index.md
@@ -39,10 +39,6 @@ if (foo.hasAttribute("bar")) {
 })(Element.prototype);
 ```
 
-## Notes
-
-{{DOMAttributeMethods}}
-
 ## Spécifications
 
 {{Specifications}}

--- a/files/fr/web/api/element/hasattributens/index.md
+++ b/files/fr/web/api/element/hasattributens/index.md
@@ -35,10 +35,6 @@ if (
 }
 ```
 
-## Notes
-
-{{ DOMAttributeMethods() }}
-
 ## Spécification
 
 - [DOM Level 2 Core: hasAttributeNS (en)](http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-ElHasAttrNS) — [traduction en français](http://www.yoyodesign.org/doc/w3c/dom2-core/core.html#ID-ElHasAttrNS) (non normative)

--- a/files/fr/web/api/element/removeattribute/index.md
+++ b/files/fr/web/api/element/removeattribute/index.md
@@ -26,8 +26,6 @@ element.removeAttribute(nomAttribut);
 
 `removeAttribute()` devrait être utilisée plutôt que de passer la valeur de l'attribut à `null` (que ce soit directement ou en appelant [`setAttribute()`](/fr/docs/Web/API/Element/setAttribute). De nombreux attributs ne fonctionneront pas comme espéré si on les passe à `null`.
 
-{{ DOMAttributeMethods() }}
-
 ## Exemple
 
 ```js

--- a/files/fr/web/api/element/removeattributenode/index.md
+++ b/files/fr/web/api/element/removeattributenode/index.md
@@ -32,8 +32,6 @@ Si l'attribut enlevé a une valeur par défaut, celle-ci remplace immédiatement
 
 Il n'y a pas de `removeAttributeNodeNS` (contrairement à la paire `setAttributeNode` et `setAttributeNodeNS` pour lesquels il est nécessaire de savoir quel attribut remplacer (le cas échéant), `removeAttributeNode` n'a pas cette exigence. `removeAttributeNode` peut supprimer des attributs, qu'ils soient d'espace de noms ou pas.
 
-{{ DOMAttributeMethods() }}
-
 ## Spécification
 
 - [DOM Level 2 Core&nbsp;: removeAttributeNode](http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-D589198) — [traduction en français](http://www.yoyodesign.org/doc/w3c/dom2-core/core.html#ID-D589198) (non normative)

--- a/files/fr/web/api/element/removeattributens/index.md
+++ b/files/fr/web/api/element/removeattributens/index.md
@@ -28,10 +28,6 @@ d.removeAttributeNS("http://www.mozilla.org/ns/specialspace", "specialAlign");
 // l'élément est devenu&nbsp;: <div id="div1" width="200px" />
 ```
 
-## Notes
-
-{{ DOMAttributeMethods() }}
-
 ## Spécification
 
 - [DOM Level 2 Core: removeAttributeNS (en)](http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-ElRemAtNS) — [traduction en français](http://www.yoyodesign.org/doc/w3c/dom2-core/core.html#ID-ElRemAtNS) (non normative)

--- a/files/fr/web/api/element/setattribute/index.md
+++ b/files/fr/web/api/element/setattribute/index.md
@@ -61,8 +61,6 @@ Ceci démontre 2 choses :
 
 {{ EmbedLiveSample('Exemple', '300', '50') }}
 
-{{DOMAttributeMethods}}
-
 ## Spécifications
 
 - [DOM Level 2 Core&nbsp;: setAttribute](http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-F68F082) — [traduction en français](http://www.yoyodesign.org/doc/w3c/dom2/core/core.html#ID-F68F082) (non normative)

--- a/files/fr/web/api/element/setattributenode/index.md
+++ b/files/fr/web/api/element/setattributenode/index.md
@@ -35,8 +35,6 @@ Si l'attribut nommé existe déjà sur l'élément, cet attribut est remplacé p
 
 Cette méthode est peu utilisée. On lui préfère souvent {{domxref("Element.setAttribute()")}} pour modifier la valeur d'un attribut d'élément.
 
-{{DOMAttributeMethods()}}
-
 ## Spécification
 
 - [DOM Level 2 Core&nbsp;: setAttributeNode](http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-887236154) — [traduction en français](http://www.yoyodesign.org/doc/w3c/dom2-core/core.html#ID-887236154) (non normative (Introduit dans [DOM Level 1 Core](http://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#method-setAttributeNode))

--- a/files/fr/web/api/element/setattributenodens/index.md
+++ b/files/fr/web/api/element/setattributenodens/index.md
@@ -39,8 +39,6 @@ Si l'attribut spécifié existe déjà sur l'élément, cet attribut est remplac
 
 Notez que si vous essayez de définir sans cloner le noeud, Mozilla donne une erreur "Attribut déjà utilisé" NS_ERROR_DOM_INUSE_ATTRIBUTE_ERR, car le DOM nécessite que le clonage d'`Attr` soit réutilisé (contrairement aux autres Noeuds qui peuvent être déplacés).
 
-{{ DOMAttributeMethods() }}
-
 ## Spécification
 
 - [DOM Level 2 Core: setAttributeNodeNS (en)](http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-ElSetAtNodeNS) — [traduction en français](http://www.yoyodesign.org/doc/w3c/dom2-core/core.html#ID-ElSetAtNodeNS) (non normative)

--- a/files/fr/web/api/element/setattributens/index.md
+++ b/files/fr/web/api/element/setattributens/index.md
@@ -24,10 +24,6 @@ var d = document.getElementById("d1");
 d.setAttributeNS("http://www.mozilla.org/ns/specialspace", "align", "center");
 ```
 
-## Notes
-
-{{ DOMAttributeMethods() }}
-
 `setAttributeNS` est la seule méthode pour les attributs d'espace nom qui attend le nom qualifié complet, c'est-à-dire `"namespace:localname"`.
 
 ## Spécification


### PR DESCRIPTION
### Description

fix: remove `{{DOMAttributeMethods}}` macro
+ add/update _Specifications_ section
+ add/update _Compat_ section
+ add/update _See also_ section
    + listing complementary methods
+ Fixing broken links

### Motivation

Participates in resolving #19009 

### Additional details

Files updated:
- [x] files/fr/web/api/element/hasattribute/index.md
- [x] files/fr/web/api/element/setattributens/index.md
- [x] files/fr/web/api/element/setattributenode/index.md
- [x] files/fr/web/api/element/getattributenode/index.md
- [x] files/fr/web/api/element/hasattributens/index.md
- [x] files/fr/web/api/element/getattributens/index.md
- [x] files/fr/web/api/element/removeattributenode/index.md
- [x] files/fr/web/api/element/setattributenodens/index.md
- [x] files/fr/web/api/element/getattributenodens/index.md
- [x] files/fr/web/api/element/removeattributens/index.md
- [x] files/fr/web/api/element/removeattribute/index.md
- [x] files/fr/web/api/element/setattribute/index.md

### Related issues and pull requests

Fixes #19044 
