### PR TITLE
/fr/docs/Web/CSS/column-gap - use section ids for `EmbedLiveSample` - Fixes #19079

### DIFF
--- a/files/fr/web/css/column-gap/index.md
+++ b/files/fr/web/css/column-gap/index.md
@@ -9,7 +9,7 @@ La propriété **`column-gap`** permet de définir la taille des espaces ([goutt
 
 {{EmbedInteractiveExample("pages/css/column-gap.html")}}
 
-La propriété `column-gap` était initialement définie dans le module de spécification [Colonnes CSS](/fr/docs/Web/CSS/CSS_Columns). Cette définition a depuis été élargie afin de pouvoir être utilisée dans les différents modes de disposition et fait désormais partie du module de spécification [_Box Alignment_ (alignement des boîtes en CSS)](/fr/docs/Web/CSS/CSS_Box_Alignment). Cette propriété peut être utilisée pour les dispositions multi-colonnes, les dispositions flexibles et les dispositions en grille.
+La propriété `column-gap` était initialement définie dans le module de spécification [Colonnes CSS](/fr/docs/Web/CSS/CSS_multicol_layout). Cette définition a depuis été élargie afin de pouvoir être utilisée dans les différents modes de disposition et fait désormais partie du module de spécification [_Box Alignment_ (alignement des boîtes en CSS)](/fr/docs/Web/CSS/CSS_box_alignment). Cette propriété peut être utilisée pour les dispositions multi-colonnes, les dispositions flexibles et les dispositions en grille.
 
 ## Syntaxe
 
@@ -82,7 +82,7 @@ column-gap: unset;
 
 #### Résultat
 
-{{EmbedLiveSample("","auto","130px")}}
+{{EmbedLiveSample("disposition_flexible","auto","130px")}}
 
 ### Disposition en grille
 
@@ -115,7 +115,7 @@ column-gap: unset;
 
 #### Résultat
 
-{{EmbedLiveSample("","auto", "130px")}}
+{{EmbedLiveSample("disposition_en_grille","auto", "130px")}}
 
 ### Disposition multi-colonnes
 
@@ -139,11 +139,11 @@ column-gap: unset;
 
 #### Résultat
 
-{{EmbedLiveSample("", "auto", "130px")}}
+{{EmbedLiveSample("disposition_multi-colonnes", "auto", "130px")}}
 
 ## Spécifications
 
-{{Specifications("css.properties.column-gap.grid_context")}}
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
@@ -152,5 +152,5 @@ column-gap: unset;
 ## Voir aussi
 
 - Les autres propriétés relatives aux gouttières&nbsp;: [`row-gap`](/fr/docs/Web/CSS/row-gap), [`gap`](/fr/docs/Web/CSS/gap)
-- Guide sur les grilles&nbsp;: _[Les concepts de base des grilles CSS&nbsp;: les gouttières](/fr/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#les_gouttières)_
-- Guide sur la disposition multi-colonnes&nbsp;: _[Mettre en forme les colonnes](/fr/docs/Web/CSS/CSS_Columns/Styling_Columns)_
+- Guide sur les grilles&nbsp;: _[Les concepts de base des grilles CSS&nbsp;: les gouttières](/fr/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#les_gouttières)_
+- Guide sur la disposition multi-colonnes&nbsp;: _[Mettre en forme les colonnes](/fr/docs/Web/CSS/CSS_multicol_layout/Styling_columns)_


### PR DESCRIPTION
### Description

Use section ids for `EmbedLiveSample` + flaws fix

### Motivation

Avoid code examples that don't work

### Additional details

**Fix:**
Add section ids as parameters

**Example:**
`{{EmbedLiveSample("","auto","130px")}}`
to
`{{EmbedLiveSample("disposition_flexible","auto","130px")}}`

### Related issues and pull requests

Fixes #19079