### PR TITLE
fix: Remove compat macro from WebAssembly overview pages

### DIFF
--- a/files/es/webassembly/index.md
+++ b/files/es/webassembly/index.md
@@ -68,10 +68,6 @@ Y lo mejor es que está siendo desarrollado como un estándar web a través del 
 
 {{Specifications}}
 
-## Compatibilidad con navegadores
-
-{{Compat}}
-
 ## Ver también
 
 - [WebAssembly en Mozilla Research](https://research.mozilla.org/webassembly/)

--- a/files/fr/webassembly/index.md
+++ b/files/fr/webassembly/index.md
@@ -3,7 +3,7 @@ title: WebAssembly
 slug: WebAssembly
 ---
 
-{{WebAssemblySidebar}}{{SeeCompatTable}}
+{{WebAssemblySidebar}}
 
 WebAssembly est un nouveau type de code qui peut être exécuté dans un navigateur web moderne. C'est un langage bas niveau, semblable à l'assembleur permettant d'atteindre des performances proches des applications natives (par exemple écrites en C/C++) tout en fonctionnant sur le Web. WebAssembly est conçu pour fonctionner en lien avec JavaScript.
 
@@ -63,10 +63,6 @@ WebAssembly est conçu comme un standard web par le [groupe communautaire du W3C
 ## Spécifications
 
 {{Specifications}}
-
-## Compatibilité des navigateurs
-
-{{Compat}}
 
 ## Voir aussi
 

--- a/files/ja/webassembly/index.md
+++ b/files/ja/webassembly/index.md
@@ -72,10 +72,6 @@ WebAssembly は JavaScript を補完、並行して動作するように設計�
 
 {{Specifications}}
 
-## ブラウザーの互換性
-
-{{Compat}}
-
 ## 関連情報
 
 - [WebAssembly on Mozilla Research](https://research.mozilla.org/)

--- a/files/ko/webassembly/index.md
+++ b/files/ko/webassembly/index.md
@@ -85,10 +85,6 @@ WebAssembly는 JavaScript와 함께 보완되고 실행되도록 설계되었습
 
 {{Specifications}}
 
-## 브라우저 호환성
-
-{{Compat}}
-
 ## 바깥 고리
 
 - [WebAssembly on Mozilla Research](https://research.mozilla.org/)

--- a/files/pt-br/webassembly/index.md
+++ b/files/pt-br/webassembly/index.md
@@ -3,7 +3,7 @@ title: WebAssembly
 slug: WebAssembly
 ---
 
-{{WebAssemblySidebar}}{{SeeCompatTable}}
+{{WebAssemblySidebar}}
 
 O WebAssembly é um novo tipo de código que pode ser executado em browsers modernos — se trata de uma linguagem de baixo nível como assembly, com um formato binário compacto que executa com performance quase nativa e que fornece um novo alvo de compilação para linguagens como C/C++, para que possam ser executadas na web. Também foi projetado para executar em conjunto com o JavaScript, permitindo que ambos trabalhem juntos.
 
@@ -63,10 +63,6 @@ E o que é ainda melhor é que ele está sendo desenvolvido como um padrão web 
 ## Especificações
 
 {{Specifications}}
-
-## Compatibilidade do navegador
-
-{{Compat}}
 
 ## Veja também
 

--- a/files/ru/webassembly/index.md
+++ b/files/ru/webassembly/index.md
@@ -66,10 +66,6 @@ WebAssembly разработан для дополнения JavaScript – ис
 
 {{Specifications}}
 
-## Совместимость с браузерами
-
-{{Compat}}
-
 ## Смотрите также
 
 - [WebAssembly on Mozilla Research](https://research.mozilla.org/webassembly/)

--- a/files/zh-tw/webassembly/index.md
+++ b/files/zh-tw/webassembly/index.md
@@ -70,10 +70,6 @@ WebAssembly 被設計來與 JavaScript 協同工作 —— 藉由 WebAssembly �
 
 {{Specifications}}
 
-## 瀏覽器相容性
-
-{{Compat}}
-
 ## 參見
 
 - [WebAssembly on Mozilla Research](https://research.mozilla.org/)


### PR DESCRIPTION
### Description

The macro was removed in https://github.com/mdn/content/pull/30635

### Motivation

Builds were reporting errors that the macro is not rendering.

### Related issues and pull requests

- [x] https://github.com/mdn/content/pull/30635

## Approvals

- [x] `es`
- [x] `fr`
- [x] `ru` 
- [x] `zh-CN`
- [x] `ja`
- [x] `pt-br`
- [x] `ko`