### PR TITLE
[fr] fix: Corrections on `translateX` and `translateY` CSS pages

### DIFF
--- a/files/fr/web/css/transform-function/translatex/index.md
+++ b/files/fr/web/css/transform-function/translatex/index.md
@@ -107,7 +107,7 @@ transform: translateX(50%);
 ### Syntaxe formelle
 
 ```css
-translateX({{cssxref("&lt;length-percentage&gt;")}})
+translateX(<length-percentage>)
 ```
 
 ## Exemples

--- a/files/fr/web/css/transform-function/translatex/index.md
+++ b/files/fr/web/css/transform-function/translatex/index.md
@@ -19,7 +19,7 @@ transform: translateX(200px);
 transform: translateX(50%);
 ```
 
-### Values
+### Valeurs
 
 - `<length-percentage>`
   - : Une valeur exprimant une longueur (type [`<length>`](/fr/docs/Web/CSS/length)) ou un pourcentage ([`<percentage>`](/fr/docs/Web/CSS/percentage)) qui représente la composante horizontale du vecteur de translation. Lorsque la valeur est un pourcentage, elle est relative à la largeur de la boîte de référence définie par la propriété [`transform-box`](/fr/docs/Web/CSS/transform-box).

--- a/files/fr/web/css/transform-function/translatex/index.md
+++ b/files/fr/web/css/transform-function/translatex/index.md
@@ -7,7 +7,7 @@ slug: Web/CSS/transform-function/translateX
 
 La fonction CSS **`translateX()`** permet d'appliquer une translation en 2D. La valeur obtenue sera du type [`<transform-function>`](/fr/docs/Web/CSS/transform-function).
 
-![](transform-functions-translatex_2.png)
+{{EmbedInteractiveExample("pages/css/function-translateX.html")}}
 
 > **Note :** `translateX(tx)` est équivalent à `translate(tx, 0)` ou `translate3d(tx, 0, 0)`.
 
@@ -29,8 +29,8 @@ transform: translateX(50%);
     <tr>
       <th scope="col">Coordonnées cartésiennes sur ℝ<sup>2</sup></th>
       <th scope="col">Coordonnées homogènes sur ℝℙ<sup>2</sup></th>
-      <th scope="col">Coordonnées cartésiennes sur ℝ<sup>2</sup></th>
-      <th scope="col">Coordonnées homogènes sur ℝℙ<sup>2</sup></th>
+      <th scope="col">Coordonnées cartésiennes sur ℝ<sup>3</sup></th>
+      <th scope="col">Coordonnées homogènes sur ℝℙ<sup>3</sup></th>
     </tr>
   </thead>
   <tbody>
@@ -107,7 +107,7 @@ transform: translateX(50%);
 ### Syntaxe formelle
 
 ```css
-translateX([`<length-percentage>`](/fr/docs/Web/CSS/length-percentage))
+translateX({{cssxref("&lt;length-percentage&gt;")}})
 ```
 
 ## Exemples

--- a/files/fr/web/css/transform-function/translatey/index.md
+++ b/files/fr/web/css/transform-function/translatey/index.md
@@ -22,7 +22,7 @@ transform: translateY(50%);
 ### Valeurs
 
 - `<length-percentage>`
-  - : valeur de type [`<length>`](/fr/docs/Web/CSS/length) ou [`<percentage>`](/fr/docs/Web/CSS/percentage) représentant l'ordonnée (verticale, coordonnée y) du vecteur de translation [0, ty]. Dans [le système de coordonnées cartésiennes](/fr/docs/Web/CSS/transform-function#le_système_de_coordonnées_cartésiennes), elle représente le déplacement le long de l'axe y. Une valeur en pourcentage fait référence à la hauteur de la boîte de référence définie par la propriété [`transform-box`](/fr/docs/Web/CSS/transform-box).
+  - : Valeur de type [`<length>`](/fr/docs/Web/CSS/length) ou [`<percentage>`](/fr/docs/Web/CSS/percentage) représentant l'ordonnée (verticale, coordonnée y) du vecteur de translation [0, ty]. Dans [le système de coordonnées cartésiennes](/fr/docs/Web/CSS/transform-function#le_système_de_coordonnées_cartésiennes), elle représente le déplacement le long de l'axe y. Une valeur en pourcentage fait référence à la hauteur de la boîte de référence définie par la propriété [`transform-box`](/fr/docs/Web/CSS/transform-box).
 
 <table class="standard-table">
   <thead>

--- a/files/fr/web/css/transform-function/translatey/index.md
+++ b/files/fr/web/css/transform-function/translatey/index.md
@@ -7,9 +7,9 @@ slug: Web/CSS/transform-function/translateY
 
 La fonction **`translateY()`** permet de déplacer un élement verticalement sur le plan. Cette transformation est caractérisée par une longueur (type [`<length>`](/fr/docs/Web/CSS/length)) qui définit l'amplitude du déplacement. La valeur obtenue par cette fonction est de type [`<transform-function>`](/fr/docs/Web/CSS/transform-function).
 
-![](translatey.png)
+{{EmbedInteractiveExample("pages/css/function-translateY.html")}}
 
-`translateY(ty)` est une notation raccourcie équivalente à `translate(0, ty)`.
+> **Note :** `translateY(ty)` est équivalent à `translate(0, ty)` ou `translate3d(0, ty, 0)`.
 
 ## Syntaxe
 
@@ -21,8 +21,8 @@ transform: translateY(50%);
 
 ### Valeurs
 
-- `t`
-  - : Une valeur de type [`<length>`](/fr/docs/Web/CSS/length) qui représente l'ordonnée du vecteur de translation (la composante en Y).
+- `<length-percentage>`
+  - : valeur de type `<length>` ou `<percentage>` représentant l'ordonnée (verticale, coordonnée y) du vecteur de translation [0, ty]. Dans [le système de coordonnées cartésiennes](/fr/docs/Web/CSS/transform-function#le_système_de_coordonnées_cartésiennes), elle représente le déplacement le long de l'axe y. Une valeur en pourcentage fait référence à la hauteur de la boîte de référence définie par la propriété [`transform-box`](/fr/docs/Web/CSS/transform-box).
 
 <table class="standard-table">
   <thead>
@@ -92,7 +92,7 @@ transform: translateY(50%);
 ### Syntaxe formelle
 
 ```css
-translateY([`<length-percentage>`](/fr/docs/Web/CSS/length-percentage))
+translateY({{cssxref("&lt;length-percentage&gt;")}})
 ```
 
 ## Exemples
@@ -134,5 +134,7 @@ div {
 
 ## Voir aussi
 
+- [`translate()`](/fr/docs/Web/CSS/transform-function/translate)
+- [`translateX()`](/fr/docs/Web/CSS/transform-function/translateX)
 - [`transform`](/fr/docs/Web/CSS/transform)
 - [`<transform-function>`](/fr/docs/Web/CSS/transform-function)

--- a/files/fr/web/css/transform-function/translatey/index.md
+++ b/files/fr/web/css/transform-function/translatey/index.md
@@ -22,7 +22,7 @@ transform: translateY(50%);
 ### Valeurs
 
 - `<length-percentage>`
-  - : valeur de type `<length>` ou `<percentage>` représentant l'ordonnée (verticale, coordonnée y) du vecteur de translation [0, ty]. Dans [le système de coordonnées cartésiennes](/fr/docs/Web/CSS/transform-function#le_système_de_coordonnées_cartésiennes), elle représente le déplacement le long de l'axe y. Une valeur en pourcentage fait référence à la hauteur de la boîte de référence définie par la propriété [`transform-box`](/fr/docs/Web/CSS/transform-box).
+  - : valeur de type [`<length>`](/fr/docs/Web/CSS/length) ou [`<percentage>`](/fr/docs/Web/CSS/percentage) représentant l'ordonnée (verticale, coordonnée y) du vecteur de translation [0, ty]. Dans [le système de coordonnées cartésiennes](/fr/docs/Web/CSS/transform-function#le_système_de_coordonnées_cartésiennes), elle représente le déplacement le long de l'axe y. Une valeur en pourcentage fait référence à la hauteur de la boîte de référence définie par la propriété [`transform-box`](/fr/docs/Web/CSS/transform-box).
 
 <table class="standard-table">
   <thead>


### PR DESCRIPTION
### Description

Corrections on `translateX` and `translateY` CSS pages

### Motivation

Fixing an issue and improving the general readability of articles

### Additional details

`/fr/docs/Web/CSS/transform-function/translateX`

- Fix Typo - #19167
- Adding `EmbedInteractiveExample`
- Fix CSS Code
- Better Translation

`/fr/docs/Web/CSS/transform-function/translateY`

- Adding `EmbedInteractiveExample`
- Fix CSS Code
- Better Translation
- Adding more link to the _See more_ section

### Related issues and pull requests

Fixes #19167
