### PR TITLE
用語集 - JavaScript の更新; 不要な>の削除

### DIFF
--- a/files/ja/glossary/javascript/index.md
+++ b/files/ja/glossary/javascript/index.md
@@ -9,7 +9,7 @@ slug: Glossary/JavaScript
 
 JavaScript (または JS) は、主にウェブページの動的なクライアントサイドスクリプトとして使用されるプログラミング言語です。しかし、{{Glossary("Server","サーバー")}}サイドでも [Node.js](https://nodejs.org/) のようなランタイムを用いて、たびたび使用されています。
 
-JavaScript と [ブログラミング言語 Java](https://ja.wikipedia.org/wiki/Java) を混同**しないでください>**。_"Java"_ と _"JavaScript"_ のどちらも米国その他の国での Oracle の(登録)商標ですが、この 2 つのプログラミング言語は構文、セマンティクス、ユースケースがかなり異なります。
+JavaScript と [ブログラミング言語 Java](https://ja.wikipedia.org/wiki/Java) を混同**しないでください**。_"Java"_ と _"JavaScript"_ のどちらも米国その他の国での Oracle の(登録)商標ですが、この 2 つのプログラミング言語は構文、セマンティクス、ユースケースがかなり異なります。
 
 JavaScript は主にブラウザーで使用され、これにより {{Glossary("DOM")}} を介したウェブページ内容の操作、{{Glossary("AJAX")}} や {{Glossary("IndexedDB")}} によるデータ操作、{{Glossary("canvas")}} によるグラフィック描画、そして様々な {{Glossary("API")}} を介してブラウザーが稼働しているデバイスとの情報のやり取り、その他多数のことを開発者ができるようにします。JavaScript は世界で最も広く利用されている言語の一つであり、ここ最近のブラウザーで利用可能な {{Glossary("API")}} の成長とパフォーマンスの革新がその原動力となっています。
 

--- a/files/ja/glossary/javascript/index.md
+++ b/files/ja/glossary/javascript/index.md
@@ -9,17 +9,17 @@ slug: Glossary/JavaScript
 
 JavaScript (または JS) は、主にウェブページの動的なクライアントサイドスクリプトとして使用されるプログラミング言語です。しかし、{{Glossary("Server","サーバー")}}サイドでも [Node.js](https://nodejs.org/) のようなランタイムを用いて、たびたび使用されています。
 
-JavaScript と [ブログラミング言語 Java](https://ja.wikipedia.org/wiki/Java) を混同**しないでください**。_"Java"_ と _"JavaScript"_ のどちらも米国その他の国での Oracle の(登録)商標ですが、この 2 つのプログラミング言語は構文、セマンティクス、ユースケースがかなり異なります。
+JavaScript と [プログラミング言語 Java](https://ja.wikipedia.org/wiki/Java) を混同**しないでください**。_"Java"_ と _"JavaScript"_ のどちらも米国その他の国での Oracle の(登録)商標ですが、この 2 つのプログラミング言語は構文、セマンティクス、ユースケースがかなり異なります。
 
 JavaScript は主にブラウザーで使用され、これにより {{Glossary("DOM")}} を介したウェブページ内容の操作、{{Glossary("AJAX")}} や {{Glossary("IndexedDB")}} によるデータ操作、{{Glossary("canvas")}} によるグラフィック描画、そして様々な {{Glossary("API")}} を介してブラウザーが稼働しているデバイスとの情報のやり取り、その他多数のことを開発者ができるようにします。JavaScript は世界で最も広く利用されている言語の一つであり、ここ最近のブラウザーで利用可能な {{Glossary("API")}} の成長とパフォーマンスの革新がその原動力となっています。
 
 ## 起源と歴史
 
-(当時 Netscape コーポレーションの社員だった) Brendan Eich によりサーバーサイド用言語として考案され、それからすぐの 1995 年 9 月に、JavaScript は Netscape Navigator 2.0 に搭載されました。JavaScript は即座に成功を収め、1996 年 8 月には {{glossary("Microsoft Internet Explorer", "Internet Explorer 3.0")}} が JScript という名で JavaScript 対応を導入しました。
+(当時 Netscape コーポレーションの社員だった) Brendan Eich によりサーバーサイド用言語として考案され、それからすぐの 1995 年 9 月に、JavaScript は Netscape Navigator 2.0 に搭載されました。JavaScript は即座に成功を収め、1996 年 8 月には {{Glossary("Microsoft Internet Explorer", "Internet Explorer 3.0")}} が JScript という名で JavaScript 対応を導入しました。
 
 1996 年 11 月、JavaScript を工業規格にしようと Netscape 社は {{Glossary("ECMA","ECMA International")}} とともに作業を始めました。その後、標準化された JavaScript は ECMAScript と呼ばれ、ECMA-262 として仕様が規定されており、2019 年 6 月に最新の第 10 版 (ES2019) が完成しました。
 
-最近、JavaScript はブラウザー外で実行するクロスプラットフォームのもっとも有名な実行環境である [Node.js](https://nodejs.org/) プラットフォームの成功と共に人気が拡大しました。Node.js は [Chrome's V8 JavaScript エンジン](<https://en.wikipedia.org/wiki/V8_(JavaScript_engine)>)を使って作成されており、コンピューター上で自動処理を行うスクリプト言語として JavaScript を利用でき、またフル機能の {{Glossary("HTTP")}} サーバーや {{Glossary("Web Sockets", "ウェブソケット")}} サーバーを構築できます。
+最近、JavaScript はブラウザー外で実行するクロスプラットフォームのもっとも有名な実行環境である [Node.js](https://nodejs.org/) プラットフォームの成功と共に人気が拡大しました。Node.js は [Chrome の V8 JavaScript エンジン](<https://en.wikipedia.org/wiki/V8_(JavaScript_engine)>)を使って作成されており、コンピューター上で自動処理を行うスクリプト言語として JavaScript を利用でき、またフル機能の {{Glossary("HTTP")}} サーバーや {{Glossary("Web Sockets", "ウェブソケット")}} サーバーを構築できます。
 
 ## 詳細情報
 

--- a/files/ja/glossary/javascript/index.md
+++ b/files/ja/glossary/javascript/index.md
@@ -30,12 +30,12 @@ JavaScript は主にブラウザーで使用され、これにより {{Glossary(
 ### JavaScript の学習
 
 - MDN 上の記事「[JavaScript ガイド](/ja/docs/Web/JavaScript/Guide)」
-- [NodeSchool による JavaScript ワークショップ](http://nodeschool.io/#workshoppers)
+- [NodeSchool による JavaScript ワークショップ](https://nodeschool.io/#workshoppers)
 - [codecademy.com による JavaScript 演習コース](https://www.codecademy.com/tracks/javascript)
-- [John Resig によるチュートリアル _「Learning Advanced JavaScript」_](http://ejohn.org/apps/learn/)
+- [John Resig によるチュートリアル _「Learning Advanced JavaScript」_](https://ejohn.org/apps/learn/)
 
 ### 技術リファレンス
 
-- [最新の ECMAScript 仕様書](http://www.ecma-international.org/publications/standards/Ecma-262.htm)
+- [最新の ECMAScript 仕様書](https://www.ecma-international.org/publications/standards/Ecma-262.htm)
 - MDN 上の記事「[JavaScript リファレンス](/ja/docs/Web/JavaScript/Reference)」
-- [JavaScript テキスト「Eloquent JavaScript」](http://eloquentjavascript.net/)
+- [JavaScript テキスト「Eloquent JavaScript」](https://eloquentjavascript.net/)


### PR DESCRIPTION
### Description

用語集 - JavaScript の更新
- 不要な>の削除
- GitHub Actions bot の指摘に対応 `broken_links: Is currently http:// but can become https://`
- 誤字、フォーマットの修正

### Related issues and pull requests

https://github.com/mozilla-japan/translation/issues/754