### PR TITLE
[zh-tw] Use symbl.cc instead of unicode-table.com + minor content fixes

### DIFF
--- a/files/zh-tw/web/javascript/reference/global_objects/json/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/json/index.md
@@ -16,7 +16,7 @@ JSON 是序列物件、陣列、數字、字串、布林值、還有 {{jsxref("n
 | JavaScript 型別 | 與 JSON 的差別                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 物件與陣列      | 屬性名稱必須是包含在雙引號中的字串；禁止尾後逗號。                                                                                                                                                                                                                                                                                                                                                                                                          |
-| 數字            | 數字不可以 0 作為開頭(在 JSON.stringify 0 會被忽略，但是在 JSON.parse 會造成語法錯誤)；小數點前面必須至少有一位數字。                                                                                                                                                                                                                                                                                                                                       |
+| 數字            | 數字不可以 0 作為開頭；小數點前面必須至少有一位數字。                                                                                                                                                                                                                                                                                                                                       |
 | 字串            | Only a limited set of characters may be escaped; certain control characters are prohibited; the Unicode line separator ([U+2028](https://symbl.cc/en/2028/)) and paragraph separator ([U+2029](https://symbl.cc/en/2029/)) characters are permitted; strings must be double-quoted. See the following example where {{jsxref("JSON.parse()")}} works fine and a {{jsxref("SyntaxError")}} is thrown when evaluating the code as JavaScript: |
 
 ```js
@@ -25,56 +25,59 @@ JSON.parse(code); // evaluates to "\u2028\u2029" in all engines
 eval(code); // throws a SyntaxError in old engines
 ```
 
-JSON 的完整語法如下：
+### JSON 的完整語法
 
 ```plain
-JSON = null
-    or true or false
-    or JSONNumber
-    or JSONString
-    or JSONObject
-    or JSONArray
-
-JSONNumber = - PositiveNumber
-          or PositiveNumber
-PositiveNumber = DecimalNumber
-              or DecimalNumber . Digits
-              or DecimalNumber . Digits ExponentPart
-              or DecimalNumber ExponentPart
-DecimalNumber = 0
-             or OneToNine Digits
-ExponentPart = e Exponent
-            or E Exponent
-Exponent = Digits
-        or + Digits
-        or - Digits
-Digits = Digit
-      or Digits Digit
-Digit = 0 through 9
-OneToNine = 1 through 9
-
-JSONString = ""
-          or " StringCharacters "
-StringCharacters = StringCharacter
-                or StringCharacters StringCharacter
-StringCharacter = any character
-                  except " or \ or U+0000 through U+001F
-               or EscapeSequence
-EscapeSequence = \" or \/ or \\ or \b or \f or \n or \r or \t
-              or \u HexDigit HexDigit HexDigit HexDigit
-HexDigit = 0 through 9
-        or A through F
-        or a through f
-
-JSONObject = { }
-          or { Members }
-Members = JSONString : JSON
-       or Members , JSONString : JSON
-
-JSONArray = [ ]
-         or [ ArrayElements ]
-ArrayElements = JSON
-             or ArrayElements , JSON
+JSON-text = object / array
+begin-array     = ws %x5B ws  ; [ left square bracket
+begin-object    = ws %x7B ws  ; { left curly bracket
+end-array       = ws %x5D ws  ; ] right square bracket
+end-object      = ws %x7D ws  ; } right curly bracket
+name-separator  = ws %x3A ws  ; : colon
+value-separator = ws %x2C ws  ; , comma
+ws = *(
+     %x20 /              ; Space
+     %x09 /              ; Horizontal tab
+     %x0A /              ; Line feed or New line
+     %x0D                ; Carriage return
+     )
+value = false / null / true / object / array / number / string
+false = %x66.61.6c.73.65   ; false
+null  = %x6e.75.6c.6c      ; null
+true  = %x74.72.75.65      ; true
+object = begin-object [ member *( value-separator member ) ]
+         end-object
+member = string name-separator value
+array = begin-array [ value *( value-separator value ) ] end-array
+number = [ minus ] int [ frac ] [ exp ]
+decimal-point = %x2E       ; .
+digit1-9 = %x31-39         ; 1-9
+e = %x65 / %x45            ; e E
+exp = e [ minus / plus ] 1*DIGIT
+frac = decimal-point 1*DIGIT
+int = zero / ( digit1-9 *DIGIT )
+minus = %x2D               ; -
+plus = %x2B                ; +
+zero = %x30                ; 0
+string = quotation-mark *char quotation-mark
+char = unescaped /
+    escape (
+        %x22 /          ; "    quotation mark  U+0022
+        %x5C /          ; \    reverse solidus U+005C
+        %x2F /          ; /    solidus         U+002F
+        %x62 /          ; b    backspace       U+0008
+        %x66 /          ; f    form feed       U+000C
+        %x6E /          ; n    line feed       U+000A
+        %x72 /          ; r    carriage return U+000D
+        %x74 /          ; t    tab             U+0009
+        %x75 4HEXDIG )  ; uXXXX                U+XXXX
+escape = %x5C              ; \
+quotation-mark = %x22      ; "
+unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
+HEXDIG = DIGIT / %x41-46 / %x61-66   ; 0-9, A-F, or a-f
+       ; HEXDIG equivalent to HEXDIG rule in [RFC5234]
+DIGIT = %x30-39            ; 0-9
+      ; DIGIT equivalent to DIGIT rule in [RFC5234]
 ```
 
 Insignificant whitespace may be present anywhere except within a `JSONNumber` (numbers must contain no whitespace) or `JSONString` (where it is interpreted as the corresponding character in the string, or would cause an error). The tab character ([U+0009](https://symbl.cc/en/0009/)), carriage return ([U+000D](https://symbl.cc/en/000D/)), line feed ([U+000A](https://symbl.cc/en/000A/)), and space ([U+0020](https://symbl.cc/en/0020/)) characters are the only valid whitespace characters.
@@ -85,76 +88,6 @@ Insignificant whitespace may be present anywhere except within a `JSONNumber` (n
   - : 解析 JSON 字串，能改變給定值和屬性、接著回傳解析值。
 - {{jsxref("JSON.stringify()")}}
   - : 回傳給定的 JSON 對應字串，可自行決定只想包括哪些特定屬性、或替換的屬性值。
-
-## Polyfill
-
-舊版瀏覽器並不支援 `JSON`。你可以在程式碼開頭插入以下程式碼，以解決這個問題。這個程式碼能實做不支援原生 `JSON` 物件的瀏覽器（如 Internet Explorer 6）。
-
-以下演算法能仿製原生 `JSON` 物件。
-
-```js
-if (!window.JSON) {
-  window.JSON = {
-    parse: function (sJSON) {
-      return eval("(" + sJSON + ")");
-    },
-    stringify: (function () {
-      var toString = Object.prototype.toString;
-      var hasOwnProperty = Object.prototype.hasOwnProperty;
-      var isArray =
-        Array.isArray ||
-        function (a) {
-          return toString.call(a) === "[object Array]";
-        };
-      var escMap = {
-        '"': '\\"',
-        "\\": "\\\\",
-        "\b": "\\b",
-        "\f": "\\f",
-        "\n": "\\n",
-        "\r": "\\r",
-        "\t": "\\t",
-      };
-      var escFunc = function (m) {
-        return (
-          escMap[m] ||
-          "\\u" + (m.charCodeAt(0) + 0x10000).toString(16).substr(1)
-        );
-      };
-      var escRE = /[\\"\u0000-\u001F\u2028\u2029]/g;
-      return function stringify(value) {
-        if (value == null) {
-          return "null";
-        } else if (typeof value === "number") {
-          return isFinite(value) ? value.toString() : "null";
-        } else if (typeof value === "boolean") {
-          return value.toString();
-        } else if (typeof value === "object") {
-          if (typeof value.toJSON === "function") {
-            return stringify(value.toJSON());
-          } else if (isArray(value)) {
-            var res = "[";
-            for (var i = 0; i < value.length; i++)
-              res += (i ? ", " : "") + stringify(value[i]);
-            return res + "]";
-          } else if (toString.call(value) === "[object Object]") {
-            var tmp = [];
-            for (var k in value) {
-              // in case "hasOwnProperty" has been shadowed
-              if (hasOwnProperty.call(value, k))
-                tmp.push(stringify(k) + ": " + stringify(value[k]));
-            }
-            return "{" + tmp.join(", ") + "}";
-          }
-        }
-        return '"' + value.toString().replace(escRE, escFunc) + '"';
-      };
-    })(),
-  };
-}
-```
-
-More complex well-known [polyfills](http://remysharp.com/2010/10/08/what-is-a-polyfill/) for the `JSON` object are [JSON2](https://github.com/douglascrockford/JSON-js) and [JSON3](http://bestiejs.github.com/json3).
 
 ## 規範
 

--- a/files/zh-tw/web/javascript/reference/global_objects/json/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/json/index.md
@@ -13,17 +13,10 @@ slug: Web/JavaScript/Reference/Global_Objects/JSON
 
 JSON 是序列物件、陣列、數字、字串、布林值、還有 {{jsxref("null")}} 的語法。它建基、但不同於 JavaScript：有些 JavaScript 不是 JSON、而有些 JSON 不是 JavaScript。請參見 [JSON: The JavaScript subset that isn't](http://timelessrepo.com/json-isnt-a-javascript-subset)。
 
-| JavaScript 型別 | 與 JSON 的差別                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 物件與陣列      | 屬性名稱必須是包含在雙引號中的字串；禁止尾後逗號。                                                                                                                                                                                                                                                                                                                                                                                                          |
-| 數字            | 數字不可以 0 作為開頭；小數點前面必須至少有一位數字。                                                                                                                                                                                                                                                                                                                                       |
-| 字串            | Only a limited set of characters may be escaped; certain control characters are prohibited; the Unicode line separator ([U+2028](https://symbl.cc/cn/2028/)) and paragraph separator ([U+2029](https://symbl.cc/cn/2029/)) characters are permitted; strings must be double-quoted. See the following example where {{jsxref("JSON.parse()")}} works fine and a {{jsxref("SyntaxError")}} is thrown when evaluating the code as JavaScript: |
-
-```js
-const code = '"\u2028\u2029"';
-JSON.parse(code); // evaluates to "\u2028\u2029" in all engines
-eval(code); // throws a SyntaxError in old engines
-```
+| JavaScript 型別 | 與 JSON 的差別                                                                                             |
+| --------------- | ---------------------------------------------------------------------------------------------------------- |
+| 物件與陣列      | 屬性名稱必須是包含在雙引號中的字串；禁止[尾後逗號](/zh-TW/docs/Web/JavaScript/Reference/Trailing_commas)。 |
+| 數字            | 數字不可以 0 作為開頭；小數點前面必須至少有一位數字；不支援 `NaN` 和 `Infinity`。                          |
 
 ### JSON 的完整語法
 

--- a/files/zh-tw/web/javascript/reference/global_objects/json/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/json/index.md
@@ -17,7 +17,7 @@ JSON 是序列物件、陣列、數字、字串、布林值、還有 {{jsxref("n
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 物件與陣列      | 屬性名稱必須是包含在雙引號中的字串；禁止尾後逗號。                                                                                                                                                                                                                                                                                                                                                                                                          |
 | 數字            | 數字不可以 0 作為開頭；小數點前面必須至少有一位數字。                                                                                                                                                                                                                                                                                                                                       |
-| 字串            | Only a limited set of characters may be escaped; certain control characters are prohibited; the Unicode line separator ([U+2028](https://symbl.cc/en/2028/)) and paragraph separator ([U+2029](https://symbl.cc/en/2029/)) characters are permitted; strings must be double-quoted. See the following example where {{jsxref("JSON.parse()")}} works fine and a {{jsxref("SyntaxError")}} is thrown when evaluating the code as JavaScript: |
+| 字串            | Only a limited set of characters may be escaped; certain control characters are prohibited; the Unicode line separator ([U+2028](https://symbl.cc/cn/2028/)) and paragraph separator ([U+2029](https://symbl.cc/cn/2029/)) characters are permitted; strings must be double-quoted. See the following example where {{jsxref("JSON.parse()")}} works fine and a {{jsxref("SyntaxError")}} is thrown when evaluating the code as JavaScript: |
 
 ```js
 const code = '"\u2028\u2029"';
@@ -80,7 +80,7 @@ DIGIT = %x30-39            ; 0-9
       ; DIGIT equivalent to DIGIT rule in [RFC5234]
 ```
 
-Insignificant whitespace may be present anywhere except within a `JSONNumber` (numbers must contain no whitespace) or `JSONString` (where it is interpreted as the corresponding character in the string, or would cause an error). The tab character ([U+0009](https://symbl.cc/en/0009/)), carriage return ([U+000D](https://symbl.cc/en/000D/)), line feed ([U+000A](https://symbl.cc/en/000A/)), and space ([U+0020](https://symbl.cc/en/0020/)) characters are the only valid whitespace characters.
+Insignificant whitespace may be present anywhere except within a `JSONNumber` (numbers must contain no whitespace) or `JSONString` (where it is interpreted as the corresponding character in the string, or would cause an error). The tab character ([U+0009](https://symbl.cc/cn/0009/)), carriage return ([U+000D](https://symbl.cc/cn/000D/)), line feed ([U+000A](https://symbl.cc/cn/000A/)), and space ([U+0020](https://symbl.cc/cn/0020/)) characters are the only valid whitespace characters.
 
 ## 方法
 

--- a/files/zh-tw/web/javascript/reference/global_objects/json/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/json/index.md
@@ -17,7 +17,7 @@ JSON 是序列物件、陣列、數字、字串、布林值、還有 {{jsxref("n
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 物件與陣列      | 屬性名稱必須是包含在雙引號中的字串；禁止尾後逗號。                                                                                                                                                                                                                                                                                                                                                                                                          |
 | 數字            | 數字不可以 0 作為開頭(在 JSON.stringify 0 會被忽略，但是在 JSON.parse 會造成語法錯誤)；小數點前面必須至少有一位數字。                                                                                                                                                                                                                                                                                                                                       |
-| 字串            | Only a limited set of characters may be escaped; certain control characters are prohibited; the Unicode line separator ([U+2028](http://unicode-table.com/en/2028/)) and paragraph separator ([U+2029](http://unicode-table.com/en/2029/)) characters are permitted; strings must be double-quoted. See the following example where {{jsxref("JSON.parse()")}} works fine and a {{jsxref("SyntaxError")}} is thrown when evaluating the code as JavaScript: |
+| 字串            | Only a limited set of characters may be escaped; certain control characters are prohibited; the Unicode line separator ([U+2028](https://symbl.cc/en/2028/)) and paragraph separator ([U+2029](https://symbl.cc/en/2029/)) characters are permitted; strings must be double-quoted. See the following example where {{jsxref("JSON.parse()")}} works fine and a {{jsxref("SyntaxError")}} is thrown when evaluating the code as JavaScript: |
 
 ```js
 const code = '"\u2028\u2029"';
@@ -77,7 +77,7 @@ ArrayElements = JSON
              or ArrayElements , JSON
 ```
 
-Insignificant whitespace may be present anywhere except within a `JSONNumber` (numbers must contain no whitespace) or `JSONString` (where it is interpreted as the corresponding character in the string, or would cause an error). The tab character ([U+0009](http://unicode-table.com/en/0009/)), carriage return ([U+000D](http://unicode-table.com/en/000D/)), line feed ([U+000A](http://unicode-table.com/en/000A/)), and space ([U+0020](http://unicode-table.com/en/0020/)) characters are the only valid whitespace characters.
+Insignificant whitespace may be present anywhere except within a `JSONNumber` (numbers must contain no whitespace) or `JSONString` (where it is interpreted as the corresponding character in the string, or would cause an error). The tab character ([U+0009](https://symbl.cc/en/0009/)), carriage return ([U+000D](https://symbl.cc/en/000D/)), line feed ([U+000A](https://symbl.cc/en/000A/)), and space ([U+0020](https://symbl.cc/en/0020/)) characters are the only valid whitespace characters.
 
 ## 方法
 


### PR DESCRIPTION
This URL https://unicode-table.com/ has changed to https://symbl.cc/

