### PR TITLE
[ja] Fix typo in performance.now()

### DIFF
--- a/files/ja/web/api/performance/now/index.md
+++ b/files/ja/web/api/performance/now/index.md
@@ -31,7 +31,7 @@ now()
 [`Date.now`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Date/now) とは異なり、`performance.now()` が返すタイムスタンプは 1 ミリ秒の解像度に制限されません。時刻をマイクロ秒精度までの浮動小数点数で表します。
 
 また、 `Date.now()` は Unix 元期 (1970-01-01T00:00:00Z) からの相対値で、システムクロックに依存しているため、システムクロックやユーザークロックの調整、クロックスキューなどの影響を受ける可能性があります。
-一方、 `performance.now()` メソッドは、 [monotonic clock](https://w3c.github.io/hr-time/#dfn-monotonic-clock) である `timeOrigin` プロパティ空の相対値です。その現在時刻は決して減少せず、調整の対象にはなりません。
+一方、 `performance.now()` メソッドは、 [monotonic clock](https://w3c.github.io/hr-time/#dfn-monotonic-clock) である `timeOrigin` プロパティからの相対値です。その現在時刻は決して減少せず、調整の対象にはなりません。
 
 ### `performance.now` の仕様の変更
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
「プロパティ空の相対値」を「プロパティ**から**の相対値」に修正。

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
