### PR TITLE
[ja]Fix width and height were swapped at window.innerWidth

### DIFF
--- a/files/ja/web/api/window/innerwidth/index.md
+++ b/files/ja/web/api/window/innerwidth/index.md
@@ -49,8 +49,8 @@ console.log(top.innerWidth);
   <code>resize</code>
   イベントを発行させるためにブラウザーのウィンドウの大きさを変えてください。
 </p>
-<p>ウィンドウの幅: <span id="height"></span></p>
-<p>ウィンドウの高さ: <span id="width"></span></p>
+<p>ウィンドウの幅: <span id="width"></span></p>
+<p>ウィンドウの高さ: <span id="height"></span></p>
 ```
 
 ### JavaScript


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I fixed "width" and "height" were swapped at window.innerWidth.
https://developer.mozilla.org/ja/docs/Web/API/Window/innerWidth

Just in case I also checked `window.innerHeight`, but it was ok.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
