### PR TITLE
[es] remove odd parameter from `Web/API/EventTarget/removeEventListener`

### DIFF
--- a/files/es/web/api/eventtarget/removeeventlistener/index.md
+++ b/files/es/web/api/eventtarget/removeeventlistener/index.md
@@ -25,7 +25,6 @@ target.removeEventListener(tipo, listener[, useCapture])
   - : Un objeto que especifíca diversas características acerca del detector de eventos. Las opciones disponibles son:
 
     - `capture`: Un {{jsxref("Boolean")}} que indica que eventos de este tipo serán enviados al `listener` antes de ser enviado a cualquier `EventTarget` debado de éste en el DOM.
-    - {{non-standard_inline}} `mozSystemGroup`: Sólo disponible ejecutando XBL o Firefox' chrome, es un {{jsxref("Boolean")}} que define si el detector es añadido al grupo del sistema.
 
 - `useCapture` {{optional_inline}}
 


### PR DESCRIPTION
### Description

This PR removes odd parameter `mozSystemGroup` from `Web/API/EventTarget/removeEventListener` in `es` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/9979
