### PR TITLE
[es] replace all `APIRef("DOM Events")` macro calls with more suitable param

### DIFF
--- a/files/es/conflicting/web/api/eventtarget/addeventlistener/index.md
+++ b/files/es/conflicting/web/api/eventtarget/addeventlistener/index.md
@@ -4,7 +4,7 @@ slug: conflicting/Web/API/EventTarget/addEventListener
 original_slug: Web/API/EventListener
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
 ## Información General del Método
 

--- a/files/es/web/api/eventtarget/addeventlistener/index.md
+++ b/files/es/web/api/eventtarget/addeventlistener/index.md
@@ -3,7 +3,7 @@ title: element.addEventListener
 slug: Web/API/EventTarget/addEventListener
 ---
 
-{{apiref("DOM Events")}}
+{{APIRef("DOM")}}
 
 ## Resumen
 

--- a/files/es/web/api/eventtarget/dispatchevent/index.md
+++ b/files/es/web/api/eventtarget/dispatchevent/index.md
@@ -3,7 +3,7 @@ title: element.dispatchEvent
 slug: Web/API/EventTarget/dispatchEvent
 ---
 
-{{ ApiRef("DOM Events")}}
+{{APIRef("DOM")}}
 
 ### Resumen
 

--- a/files/es/web/api/eventtarget/index.md
+++ b/files/es/web/api/eventtarget/index.md
@@ -3,7 +3,7 @@ title: EventTarget
 slug: Web/API/EventTarget
 ---
 
-{{ ApiRef("DOM Events") }}
+{{APIRef("DOM")}}
 
 `EventTarget` es una interfaz implementada por los objetos que pueden administrar eventos y sus escuchadores.
 

--- a/files/es/web/api/eventtarget/removeeventlistener/index.md
+++ b/files/es/web/api/eventtarget/removeeventlistener/index.md
@@ -3,7 +3,7 @@ title: EventTarget.removeEventListener()
 slug: Web/API/EventTarget/removeEventListener
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
 El método **`EventTarget.removeEventListener()`** remueve del {{domxref("EventTarget")}} un detector de evento previamente registrado con {{domxref("EventTarget.addEventListener")}}. El detector de evento a ser removido es identificado usando una combinación de tipos de eventos, la misma funcion del detector de eventos, y muchas opciones adicionales que pueden afectar
 

--- a/files/es/web/api/keyboardevent/index.md
+++ b/files/es/web/api/keyboardevent/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent
 slug: Web/API/KeyboardEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 Los objetos **`KeyboardEvent`** describen una interacción del usuario con el teclado. Cada evento describe una tecla; el tipo de evento(`keydown`, `keypress`, o `keyup`) identifica el tipo de acción realizada.
 

--- a/files/es/web/api/keyboardevent/metakey/index.md
+++ b/files/es/web/api/keyboardevent/metakey/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent.metaKey
 slug: Web/API/KeyboardEvent/metaKey
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 La propiedad **`KeyboardEvent.metaKey`** es de solo lectura y regresa un valor {{jsxref("Boolean")}} que indica si la tecla <kbd>Meta</kbd> estaba presionada (true) o no (false) cuando el evento ocurrio.
 

--- a/files/es/web/api/mouseevent/initmouseevent/index.md
+++ b/files/es/web/api/mouseevent/initmouseevent/index.md
@@ -3,7 +3,9 @@ title: event.initMouseEvent
 slug: Web/API/MouseEvent/initMouseEvent
 ---
 
-{{ApiRef("DOM Events")}}{{deprecated_header}}
+{{Deprecated_Header}}
+
+{{APIRef("UI Events")}}
 
 > **Nota:** **No utilize este método porque está obsoleto.**
 >

--- a/files/es/web/api/mouseevent/pagex/index.md
+++ b/files/es/web/api/mouseevent/pagex/index.md
@@ -3,7 +3,7 @@ title: event.pageX
 slug: Web/API/MouseEvent/pageX
 ---
 
-{{ ApiRef() }}
+{{APIRef("UI Events")}}
 
 ### Sumario
 

--- a/files/es/web/api/mouseevent/shiftkey/index.md
+++ b/files/es/web/api/mouseevent/shiftkey/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.shiftKey
 slug: Web/API/MouseEvent/shiftKey
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 El evento de **`MouseEvent.shiftKey`** es una propiedad de solo lectura que indica si la tecla de <kbd>shift</kbd> se presionó (`true`) o no (`false`).
 

--- a/files/es/web/api/wheelevent/deltay/index.md
+++ b/files/es/web/api/wheelevent/deltay/index.md
@@ -3,7 +3,7 @@ title: WheelEvent.deltaY
 slug: Web/API/WheelEvent/deltaY
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 La propiedad de solo lectura **`WheelEvent.deltaY`** es un `double` que representa la cantidad de deslizamiento vertical en la unidad {{domxref("WheelEvent.deltaMode")}} .
 

--- a/files/es/web/api/wheelevent/index.md
+++ b/files/es/web/api/wheelevent/index.md
@@ -3,7 +3,7 @@ title: WheelEvent
 slug: Web/API/WheelEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 El interface **`WheelEvent`** retrata los eventos que ocurren cuando el usuario mueve la rueda del ratón o de un dispositivo similar.
 


### PR DESCRIPTION
### Description

This PR replaces all add `APIRef("DOM Events")` macro calls with more suitable (`DOM` or `UI Events`) param for `es` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/15880
