### PR TITLE
[fr] replace all `APIRef("DOM Events")` macro calls with more suitable param

### DIFF
--- a/files/fr/web/api/compositionevent/index.md
+++ b/files/fr/web/api/compositionevent/index.md
@@ -3,7 +3,7 @@ title: CompositionEvent
 slug: Web/API/CompositionEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 Le `CompositionEvent DOM` représente les évènements qui se produisent en raison de l'utilisateur entrant indirectement le texte.
 

--- a/files/fr/web/api/event/cancelbubble/index.md
+++ b/files/fr/web/api/event/cancelbubble/index.md
@@ -3,7 +3,9 @@ title: Event.cancelBubble
 slug: Web/API/Event/cancelBubble
 ---
 
-{{APIRef("DOM Events")}}
+{{Deprecated_Header}}
+
+{{APIRef("DOM")}}
 
 La propriété **`Event.cancelBubble`** est un alias historique de {{domxref("Event.stopPropagation()")}}. Définir sa valeur à `true` (vrai) avant le renvoi à partir d'un gestionnaire d'évènements empêche la propagation de l'évènement. Dans les implémentations les plus tardives, cette définition à false (_faux_) ne fait rien. Voir [Compatibilité des navigateurs](#compatibilité_des_navigateurs) pour plus de détails.
 

--- a/files/fr/web/api/event/returnvalue/index.md
+++ b/files/fr/web/api/event/returnvalue/index.md
@@ -3,7 +3,9 @@ title: Event.returnValue
 slug: Web/API/Event/returnValue
 ---
 
-{{APIRef("DOM Events")}}{{Non-standard_header}}{{ Deprecated_header() }}
+{{Deprecated_Header}}
+
+{{APIRef("DOM")}}
 
 La propriété **`Event.returnValue`** indique si l'action par défaut pour cet évènement a été empêchée ou non. Elle est définie à `true` (_vrai_) par défaut, permettant à l'action par défaut de se produire. La définition de cette propriété à `false` (_faux_) empêche le déclenchement de l'action par défaut.
 

--- a/files/fr/web/api/eventtarget/addeventlistener/index.md
+++ b/files/fr/web/api/eventtarget/addeventlistener/index.md
@@ -3,7 +3,7 @@ title: EventTarget.addEventListener()
 slug: Web/API/EventTarget/addEventListener
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
 \>La méthode **`addEventListener()`** de {{domxref("EventTarget")}} attache une fonction à appeler chaque fois que l'évènement spécifié est envoyé à la cible.
 

--- a/files/fr/web/api/eventtarget/dispatchevent/index.md
+++ b/files/fr/web/api/eventtarget/dispatchevent/index.md
@@ -3,7 +3,7 @@ title: element.dispatchEvent
 slug: Web/API/EventTarget/dispatchEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
 Envoie un {{domxref("Event")}} (_évènement_) à la {{domxref("EventTarget")}} (_cible_) spécifiée (synchrone) en appelant les {{domxref("EventListener")}} (_écouteurs_) dans l'ordre approprié. Le processus normal de traitement de l'évènement (y compris les phases de capture et l'éventuelle propagation) s'applique aussi aux évènements diffusés manuellement avec `dispatchEvent()`.
 

--- a/files/fr/web/api/eventtarget/eventtarget/index.md
+++ b/files/fr/web/api/eventtarget/eventtarget/index.md
@@ -3,7 +3,7 @@ title: EventTarget()
 slug: Web/API/EventTarget/EventTarget
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
 Le constructeur **`EventTarget()`** crée une nouvelle instance d'objet {{domxref("EventTarget")}}.
 

--- a/files/fr/web/api/eventtarget/index.md
+++ b/files/fr/web/api/eventtarget/index.md
@@ -3,7 +3,7 @@ title: EventTarget
 slug: Web/API/EventTarget
 ---
 
-{{ApiRef("DOM Events")}}
+{{APIRef("DOM")}}
 
 `EventTarget` est une interface DOM implémentée par des objets qui peuvent recevoir des événements et peuvent avoir des écouteurs pour eux.
 

--- a/files/fr/web/api/eventtarget/removeeventlistener/index.md
+++ b/files/fr/web/api/eventtarget/removeeventlistener/index.md
@@ -3,7 +3,7 @@ title: element.removeEventListener
 slug: Web/API/EventTarget/removeEventListener
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
 La méthode **`EventTarget.removeEventListener()`** supprime d'une {{domxref("EventTarget")}} (_cible_) un écouteur d'évènements précédemment enregistré avec {{domxref("EventTarget.addEventListener()")}}. L'écouteur d'évènements à supprimer est identifié en utilisant la combinaison du type d'évènement, la fonction "event listener" elle-même et diverses options factultatives qui peuvent affecter le processus de correspondance ; voir la section _Correspondance utilisée pour la suppression d'écouteurs d'événements_ ci-après.
 

--- a/files/fr/web/api/focusevent/index.md
+++ b/files/fr/web/api/focusevent/index.md
@@ -3,7 +3,7 @@ title: FocusEvent
 slug: Web/API/FocusEvent
 ---
 
-{{APIRef("DOM Events")}}{{SeeCompatTable}}
+{{APIRef("UI Events")}}
 
 L'interface **`FocusEvent`** représente les événements liés au focus tels que [`focus`](/fr/docs/Web/API/Element/focus_event), [`blur`](/fr/docs/Web/API/Element/blur_event), [`focusin`](/fr/docs/Web/API/Element/focusin_event) ou [`focusout`](/fr/docs/Web/API/Element/focusout_event).
 

--- a/files/fr/web/api/gestureevent/index.md
+++ b/files/fr/web/api/gestureevent/index.md
@@ -3,9 +3,9 @@ title: GestureEvent
 slug: Web/API/GestureEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{Non-standard_Header}}
 
-{{Non-standard_header()}}
+{{APIRef("UI Events")}}
 
 L'interface propriétaire **`GestureEvent`** propre à WebKitdonne des informations sur les gestes multi-touches. Les événements utilisant cette interface incluent [`gesturestart`](/fr/docs/Web/API/Element/gesturestart_event), [`gesturechange`](/fr/docs/Web/API/Element/gesturechange_event) et [`gestureend`](/fr/docs/Web/API/Element/gestureend_event).
 

--- a/files/fr/web/api/inputevent/index.md
+++ b/files/fr/web/api/inputevent/index.md
@@ -3,7 +3,7 @@ title: InputEvent
 slug: Web/API/InputEvent
 ---
 
-{{APIRef("DOM Events")}} {{SeeCompatTable}}
+{{APIRef("UI Events")}}
 
 L'interface **`InputEvent`** représente un évènement notifiant la modification d'un contenu éditable.
 

--- a/files/fr/web/api/keyboardevent/charcode/index.md
+++ b/files/fr/web/api/keyboardevent/charcode/index.md
@@ -3,7 +3,9 @@ title: KeyboardEvent.charCode
 slug: Web/API/KeyboardEvent/charCode
 ---
 
-{{ ApiRef("DOM Events") }}{{non-standard_header}}{{deprecated_header}}
+{{Deprecated_Header}}
+
+{{APIRef("UI Events")}}
 
 La propriété en lecture seule {{domxref("KeyboardEvent.charCode")}} retourne la valeur Unicode d'une touche caractère pressée pendant un évènement {{ domxref("element.onkeypress", "keypress") }}.
 

--- a/files/fr/web/api/keyboardevent/code/index.md
+++ b/files/fr/web/api/keyboardevent/code/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent.code
 slug: Web/API/KeyboardEvent/code
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 La propriété **`KeyboardEvent.code`** représente une touche physique du clavier (contrairement au caractère généré par celle-ci). En d'autres termes, cette propriété retourne une valeur qui n'est pas modifiée par la disposition du clavier ou l'état des touches de modification.
 

--- a/files/fr/web/api/keyboardevent/index.md
+++ b/files/fr/web/api/keyboardevent/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent
 slug: Web/API/KeyboardEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 Les objets **`KeyboardEvent`** décrivent l'interaction d'un utilisateur avec le clavier. Chaque événement décrit une touche&nbsp;; le type d'événement (`keydown`, `keypress`, ou `keyup`) identifie quel type d'activité a été effectué.
 

--- a/files/fr/web/api/keyboardevent/key/index.md
+++ b/files/fr/web/api/keyboardevent/key/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent.key
 slug: Web/API/KeyboardEvent/key
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 La propriété en lecture seule de `key` de l'interface {{domxref("KeyboardEvent")}} retourne la valeur d'une ou plusieurs touches pressées par l'utilisateur, tout en tenant compte de l'état des touches de modification telles que la touche <kbd>Shift</kbd> (_majuscules_) ainsi que les paramètres régionaux des clavier et mise en page. Ce peut être l'une des valeurs suivantes :
 

--- a/files/fr/web/api/keyboardevent/keyboardevent/index.md
+++ b/files/fr/web/api/keyboardevent/keyboardevent/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent()
 slug: Web/API/KeyboardEvent/KeyboardEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 Le constructeur **`KeyboardEvent()`** crée un nouveau {{domxref("KeyboardEvent")}}.
 

--- a/files/fr/web/api/mouseevent/index.md
+++ b/files/fr/web/api/mouseevent/index.md
@@ -3,7 +3,7 @@ title: MouseEvent
 slug: Web/API/MouseEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 L'interface **`MouseEvent`** représente les événements qui se produisent lors d'une interaction de l'utilisateur avec un appareil de pointage (tel qu'une souris). Les événements communs utilisant cette interface incluent [`click`](/fr/docs/Web/API/Element/click_event), [`dblclick`](/fr/docs/Web/API/Element/dblclick_event), [`mouseup`](/fr/docs/Web/API/Element/mouseup_event) et [`mousedown`](/fr/docs/Web/API/Element/mousedown_event).
 

--- a/files/fr/web/api/mouseevent/layerx/index.md
+++ b/files/fr/web/api/mouseevent/layerx/index.md
@@ -3,7 +3,9 @@ title: event.layerX
 slug: Web/API/MouseEvent/layerX
 ---
 
-{{APIRef("DOM Events")}} {{Non-standard_header}}
+{{Non-standard_Header}}
+
+{{APIRef("UI Events")}}
 
 La propriété en lecture seule **`UIEvent.layerX`** retourne la coordonnée horizontale de l'évènement relativement à la couche en cours.
 

--- a/files/fr/web/api/mouseevent/offsetx/index.md
+++ b/files/fr/web/api/mouseevent/offsetx/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.offsetX
 slug: Web/API/MouseEvent/offsetX
 ---
 
-{{APIRef("DOM Events")}}{{SeeCompatTable}}
+{{APIRef("UI Events")}}
 
 La propriété en lecture seule **`offsetX`** de l'interface {{domxref("MouseEvent")}} fournit le décalage sur l'axe X du pointeur de la souris entre cet évènement et la bordure de la marge intérieure du noeud cible.
 

--- a/files/fr/web/api/mouseevent/offsety/index.md
+++ b/files/fr/web/api/mouseevent/offsety/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.offsetY
 slug: Web/API/MouseEvent/offsetY
 ---
 
-{{APIRef("DOM Events")}}{{SeeCompatTable}}
+{{APIRef("UI Events")}}
 
 La propriété en lecture seule **`offsetY`** de l'interface {{domxref("MouseEvent")}} fournit le décalage sur l'axe Y du pointeur de la souris entre cet évènement et la bordure de la marge intérieure du noeud cible.
 

--- a/files/fr/web/api/uievent/detail/index.md
+++ b/files/fr/web/api/uievent/detail/index.md
@@ -3,7 +3,7 @@ title: UIEvent.detail
 slug: Web/API/UIEvent/detail
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`UIEvent.detail`** est une propriété en lecture seule, qui, lorsqu'elle ne vaut pas zéro, donne le nombre de clics courant (ou suivant en fonction de l'événement).
 

--- a/files/fr/web/api/uievent/index.md
+++ b/files/fr/web/api/uievent/index.md
@@ -3,7 +3,7 @@ title: UIEvent
 slug: Web/API/UIEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 L'interface **`UIEvent`** représente des évènements simples de l'interface utilisateur.
 

--- a/files/fr/web/api/wheelevent/deltax/index.md
+++ b/files/fr/web/api/wheelevent/deltax/index.md
@@ -3,7 +3,7 @@ title: WheelEvent.deltaX
 slug: Web/API/WheelEvent/deltaX
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 La propriété en lecture seule **`WheelEvent.deltaX`** est un `double` représentant la quantité de défilement horizontal dans l'unité {{domxref("WheelEvent.deltaMode")}}.
 

--- a/files/fr/web/api/wheelevent/deltay/index.md
+++ b/files/fr/web/api/wheelevent/deltay/index.md
@@ -3,7 +3,7 @@ title: WheelEvent.deltaY
 slug: Web/API/WheelEvent/deltaY
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 La propriété en lecture seule **`WheelEvent.deltaY`** est un `double` représentant la quantité de défilement vertical dans l'unité {{domxref("WheelEvent.deltaMode")}}.
 

--- a/files/fr/web/api/wheelevent/deltaz/index.md
+++ b/files/fr/web/api/wheelevent/deltaz/index.md
@@ -3,7 +3,7 @@ title: WheelEvent.deltaZ
 slug: Web/API/WheelEvent/deltaZ
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 La propriété en lecture seule **`WheelEvent.deltaZ`** est un `double` représentant la quantité de défilement le long de l'axe z, dans l'unité {{domxref("WheelEvent.deltaMode")}}.
 

--- a/files/fr/web/api/wheelevent/index.md
+++ b/files/fr/web/api/wheelevent/index.md
@@ -3,7 +3,7 @@ title: WheelEvent
 slug: Web/API/WheelEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 L'interface **`WheelEvent`** représente les évènements qui se produisent lorsque l'utilisateur déplace la molette de la souris ou un périphérique d'entrée similaire.
 


### PR DESCRIPTION
### Description

This PR replaces all add `APIRef("DOM Events")` macro calls with more suitable (`DOM` or `UI Events`) param for `fr` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/15880
