### PR TITLE
[ja] replace all `APIRef("DOM Events")` macro calls with more suitable param

### DIFF
--- a/files/ja/conflicting/web/api/eventtarget/addeventlistener/index.md
+++ b/files/ja/conflicting/web/api/eventtarget/addeventlistener/index.md
@@ -4,7 +4,7 @@ slug: conflicting/Web/API/EventTarget/addEventListener
 original_slug: Web/API/EventListener/handleEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
 {{domxref("EventListener")}} の **`handleEvent()`** メソッドは、
 監視されている {{domxref("EventTarget")}} 上で発生するイベントを処理するために

--- a/files/ja/conflicting/web/api/eventtarget/addeventlistener_380cb5f366307beb2c072f74e561ee98/index.md
+++ b/files/ja/conflicting/web/api/eventtarget/addeventlistener_380cb5f366307beb2c072f74e561ee98/index.md
@@ -4,7 +4,7 @@ slug: conflicting/Web/API/EventTarget/addEventListener_380cb5f366307beb2c072f74e
 original_slug: Web/API/EventListener
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
 **`EventListener`** インターフェイスは、{{domxref("EventTarget")}} オブジェクトによってディスパッチされたイベントを処理できるオブジェクトを表します。
 

--- a/files/ja/web/api/focusevent/relatedtarget/index.md
+++ b/files/ja/web/api/focusevent/relatedtarget/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: 1511e914c6b1ce6f88056bfefd48a6aa585cebce
 ---
 
-{{ apiref("DOM Events") }}
+{{APIRef("UI Events")}}
 
 **`FocusEvent.relatedTarget`** は読み取り専用プロパティで、イベントの種類に応じた副ターゲットを表します。
 

--- a/files/ja/web/api/mouseevent/movementx/index.md
+++ b/files/ja/web/api/mouseevent/movementx/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: b3638d40efb549704bd2e73d8aa93514978892cf
 ---
 
-{{APIRef("UI Events")}}
+{{APIRef("Pointer Lock API")}}
 
 **`movementX`** は {{domxref("MouseEvent")}} インターフェイスの読み取り専用プロパティで、直前の {{domxref("Element/mousemove_event", "mousemove")}} イベントとこのイベントのマウスポインターの X 座標の差を示します。このプロパティの値は `currentEvent.movementX = currentEvent.screenX - previousEvent.screenX` のように計算されます。
 

--- a/files/ja/web/api/mouseevent/movementy/index.md
+++ b/files/ja/web/api/mouseevent/movementy/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: b3638d40efb549704bd2e73d8aa93514978892cf
 ---
 
-{{APIRef("UI Events")}}
+{{APIRef("Pointer Lock API")}}
 
 **`movementY`** は {{domxref("MouseEvent")}} インターフェイスの読み取り専用プロパティで、直前の {{domxref("Element/mousemove_event", "mousemove")}} イベントとこのイベントのマウスポインターの Y 座標の差を示します。このプロパティの値は `currentEvent.movementY = currentEvent.screenY - previousEvent.screenY` のように計算されます。
 


### PR DESCRIPTION
### Description

This PR replaces all add `APIRef("DOM Events")` macro calls with more suitable (`DOM`, `UI Events` or `Pointer Lock API`) param for `ja` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/15880, https://github.com/mdn/content/pull/30450
