### PR TITLE
[zh-cn] replace all `APIRef("DOM Events")` macro calls with more suitable param

### DIFF
--- a/files/zh-cn/web/api/compositionevent/index.md
+++ b/files/zh-cn/web/api/compositionevent/index.md
@@ -3,7 +3,7 @@ title: CompositionEvent
 slug: Web/API/CompositionEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 DOM 接口 **`CompositionEvent`** 表示用户间接输入文本（如使用输入法）时发生的事件。此接口的常用事件有{{domxref("Element/compositionstart_event", "compositionstart")}}, {{domxref("Element/compositionupdate_event", "compositionupdate")}} 和 {{domxref("Element/compositionend_event", "compositionend")}}
 

--- a/files/zh-cn/web/api/event/cancelbubble/index.md
+++ b/files/zh-cn/web/api/event/cancelbubble/index.md
@@ -3,9 +3,7 @@ title: Event.cancelBubble
 slug: Web/API/Event/cancelBubble
 ---
 
-{{Deprecated_Header}}
-
-{{APIRef("DOM")}}
+{{APIRef("DOM")}} {{Deprecated_Header}}
 
 **`Event.cancelBubble`** 属性是 {{domxref("Event.stopPropagation()")}}的一个曾用名。在从事件处理程序返回之前将其值设置为 true 可阻止事件的传播。
 

--- a/files/zh-cn/web/api/event/cancelbubble/index.md
+++ b/files/zh-cn/web/api/event/cancelbubble/index.md
@@ -3,7 +3,9 @@ title: Event.cancelBubble
 slug: Web/API/Event/cancelBubble
 ---
 
-{{APIRef("DOM Events")}}
+{{Deprecated_Header}}
+
+{{APIRef("DOM")}}
 
 **`Event.cancelBubble`** 属性是 {{domxref("Event.stopPropagation()")}}的一个曾用名。在从事件处理程序返回之前将其值设置为 true 可阻止事件的传播。
 

--- a/files/zh-cn/web/api/event/returnvalue/index.md
+++ b/files/zh-cn/web/api/event/returnvalue/index.md
@@ -3,9 +3,7 @@ title: Event.returnValue
 slug: Web/API/Event/returnValue
 ---
 
-{{Deprecated_Header}}
-
-{{APIRef("DOM")}}
+{{APIRef("DOM")}}{{Deprecated_Header}}
 
 **`Event.returnValue`** 属性表示该事件的默认操作是否已被阻止。默认情况下，它被设置为 `true`，即允许进行默认操作。将该属性设置为 `false` 即可阻止默认操作。
 

--- a/files/zh-cn/web/api/event/returnvalue/index.md
+++ b/files/zh-cn/web/api/event/returnvalue/index.md
@@ -3,7 +3,9 @@ title: Event.returnValue
 slug: Web/API/Event/returnValue
 ---
 
-{{APIRef("DOM Events")}}
+{{Deprecated_Header}}
+
+{{APIRef("DOM")}}
 
 **`Event.returnValue`** 属性表示该事件的默认操作是否已被阻止。默认情况下，它被设置为 `true`，即允许进行默认操作。将该属性设置为 `false` 即可阻止默认操作。
 

--- a/files/zh-cn/web/api/eventtarget/index.md
+++ b/files/zh-cn/web/api/eventtarget/index.md
@@ -3,7 +3,7 @@ title: EventTarget
 slug: Web/API/EventTarget
 ---
 
-{{ApiRef("DOM")}}
+{{APIRef("DOM")}}
 
 `EventTarget` 接口由可以接收事件、并且可以创建侦听器的对象实现。换句话说，任何事件目标都会实现与该接口有关的这三个方法。
 

--- a/files/zh-cn/web/api/focusevent/index.md
+++ b/files/zh-cn/web/api/focusevent/index.md
@@ -3,7 +3,7 @@ title: FocusEvent
 slug: Web/API/FocusEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`FocusEvent`** 接口表示和焦点相关的事件比如 [`focus`](/zh-CN/docs/Web/API/Element/focus_event), [`blur`](/zh-CN/docs/Web/API/Element/blur_event), [`focusin`](/zh-CN/docs/Web/API/Element/focusin_event), 和 [`focusout`](/zh-CN/docs/Web/API/Element/focusout_event)。
 

--- a/files/zh-cn/web/api/gestureevent/index.md
+++ b/files/zh-cn/web/api/gestureevent/index.md
@@ -3,9 +3,9 @@ title: GestureEvent
 slug: Web/API/GestureEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{Non-standard_Header}}
 
-{{Non-standard_header()}}
+{{APIRef("UI Events")}}
 
 **`GestureEvent`** 是 WebKit 的专有接口，提供多点触控的信息。这个接口的事件包括 {{domxref("Element/gesturestart_event", "gesturestart")}}、{{domxref("Element/gesturechange_event", "gesturechange")}} 和 {{domxref("Element/gestureend_event", "gestureend")}}.
 

--- a/files/zh-cn/web/api/gestureevent/index.md
+++ b/files/zh-cn/web/api/gestureevent/index.md
@@ -3,9 +3,7 @@ title: GestureEvent
 slug: Web/API/GestureEvent
 ---
 
-{{Non-standard_Header}}
-
-{{APIRef("UI Events")}}
+{{APIRef("UI Events")}}{{Non-standard_header}}
 
 **`GestureEvent`** 是 WebKit 的专有接口，提供多点触控的信息。这个接口的事件包括 {{domxref("Element/gesturestart_event", "gesturestart")}}、{{domxref("Element/gesturechange_event", "gesturechange")}} 和 {{domxref("Element/gestureend_event", "gestureend")}}.
 

--- a/files/zh-cn/web/api/keyboardevent/altkey/index.md
+++ b/files/zh-cn/web/api/keyboardevent/altkey/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent.altKey
 slug: Web/API/KeyboardEvent/altKey
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`KeyboardEvent.altKey`** 只读属性返回一个 {{jsxref("Boolean")}} 值，表示事件触发时 <kbd>alt</kbd> 键 (OS X 系统上的 <kbd>Option</kbd> 或 <kbd>⌥</kbd> 键) 是 (`true`) 否 (`false`) 被按下。
 

--- a/files/zh-cn/web/api/keyboardevent/charcode/index.md
+++ b/files/zh-cn/web/api/keyboardevent/charcode/index.md
@@ -3,7 +3,9 @@ title: KeyboardEvent.charCode
 slug: Web/API/KeyboardEvent/charCode
 ---
 
-{{ ApiRef("DOM Events") }}{{non-standard_header}}{{deprecated_header}}
+{{Deprecated_Header}}
+
+{{APIRef("UI Events")}}
 
 {{domxref("KeyboardEvent.charCode")}} 只读属性，返回 {{ domxref("element.onkeypress", "keypress") }} 事件触发时按下的字符键的字符 Unicode 值。
 

--- a/files/zh-cn/web/api/keyboardevent/charcode/index.md
+++ b/files/zh-cn/web/api/keyboardevent/charcode/index.md
@@ -3,9 +3,7 @@ title: KeyboardEvent.charCode
 slug: Web/API/KeyboardEvent/charCode
 ---
 
-{{Deprecated_Header}}
-
-{{APIRef("UI Events")}}
+{{APIRef("UI Events")}}{{Deprecated_Header}}
 
 {{domxref("KeyboardEvent.charCode")}} 只读属性，返回 {{ domxref("element.onkeypress", "keypress") }} 事件触发时按下的字符键的字符 Unicode 值。
 

--- a/files/zh-cn/web/api/keyboardevent/code/index.md
+++ b/files/zh-cn/web/api/keyboardevent/code/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent.code
 slug: Web/API/KeyboardEvent/code
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 `KeyboardEvent.code`属性表示键盘上的物理键（与按键生成的字符相对）。换句话说，此属性返回一个值，该值不会被键盘布局或修饰键的状态改变。
 

--- a/files/zh-cn/web/api/keyboardevent/ctrlkey/index.md
+++ b/files/zh-cn/web/api/keyboardevent/ctrlkey/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent.ctrlKey
 slug: Web/API/KeyboardEvent/ctrlKey
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`KeyboardEvent.ctrlKey`** 只读属性返回一个 {{jsxref("Boolean")}} 值，表示事件触发时 <kbd>control</kbd> 键是 (`true`) 否 (`false`) 按下。
 

--- a/files/zh-cn/web/api/keyboardevent/index.md
+++ b/files/zh-cn/web/api/keyboardevent/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent
 slug: Web/API/KeyboardEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`KeyboardEvent`** 对象描述了用户与键盘的交互。每个事件都描述了用户与一个按键（或一个按键和修饰键的组合）的单个交互；事件类型`keydown`， `keypress` 与 `keyup` 用于识别不同的键盘活动类型。
 

--- a/files/zh-cn/web/api/keyboardevent/initkeyevent/index.md
+++ b/files/zh-cn/web/api/keyboardevent/initkeyevent/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent.initKeyEvent()
 slug: Web/API/KeyboardEvent/initKeyEvent
 ---
 
-{{ ApiRef("DOM Events") }}
+{{APIRef("UI Events")}}
 
 > **警告：** 不要再使用这个方法，而是使用 {{domxref("KeyboardEvent.KeyboardEvent", "KeyboardEvent()")}} 构造函数。
 >

--- a/files/zh-cn/web/api/keyboardevent/iscomposing/index.md
+++ b/files/zh-cn/web/api/keyboardevent/iscomposing/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent.isComposing
 slug: Web/API/KeyboardEvent/isComposing
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`KeyboardEvent.isComposing`** 只读属性，返回一个 {{jsxref("Boolean")}} 值，表示该事件是否在 [`compositionstart`](/zh-CN/docs/Web/API/Element/compositionstart_event) 之后和 [`compositionend`](/zh-CN/docs/Web/API/Element/compositionend_event) 之前被触发。
 

--- a/files/zh-cn/web/api/keyboardevent/key/index.md
+++ b/files/zh-cn/web/api/keyboardevent/key/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent.key
 slug: Web/API/KeyboardEvent/key
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 只读属性 **`KeyboardEvent.key`** 返回用户按下的物理按键的值。它还与 `shiftKey` 等调节性按键的状态和键盘的区域 / 和布局有关。它的值由以下因素决定：
 

--- a/files/zh-cn/web/api/keyboardevent/keyboardevent/index.md
+++ b/files/zh-cn/web/api/keyboardevent/keyboardevent/index.md
@@ -3,7 +3,7 @@ title: 键盘事件 KeyboardEvent()
 slug: Web/API/KeyboardEvent/KeyboardEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`KeyboardEvent()`** 构造函数新建一个 {{domxref("KeyboardEvent")}} 实例。
 

--- a/files/zh-cn/web/api/keyboardevent/keycode/index.md
+++ b/files/zh-cn/web/api/keyboardevent/keycode/index.md
@@ -3,9 +3,7 @@ title: KeyboardEvent.keyCode
 slug: Web/API/KeyboardEvent/keyCode
 ---
 
-{{Deprecated_Header}}
-
-{{APIRef("UI Events")}}
+{{APIRef("UI Events")}}{{Deprecated_Header}}
 
 这个只读的属性 **`KeyboardEvent.keyCode`** 代表着一个唯一标识的所按下的键的未修改值，它依据于一个系统和实现相关的数字代码。这通常是与密钥对应的二进制的 ASCII ({{RFC(20)}}) 或 Windows 1252 码。如果这个键不能被标志，这个值为 0。
 

--- a/files/zh-cn/web/api/keyboardevent/keycode/index.md
+++ b/files/zh-cn/web/api/keyboardevent/keycode/index.md
@@ -3,7 +3,9 @@ title: KeyboardEvent.keyCode
 slug: Web/API/KeyboardEvent/keyCode
 ---
 
-{{APIRef("DOM Events")}}{{deprecated_header()}}
+{{Deprecated_Header}}
+
+{{APIRef("UI Events")}}
 
 这个只读的属性 **`KeyboardEvent.keyCode`** 代表着一个唯一标识的所按下的键的未修改值，它依据于一个系统和实现相关的数字代码。这通常是与密钥对应的二进制的 ASCII ({{RFC(20)}}) 或 Windows 1252 码。如果这个键不能被标志，这个值为 0。
 

--- a/files/zh-cn/web/api/keyboardevent/metakey/index.md
+++ b/files/zh-cn/web/api/keyboardevent/metakey/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent.metaKey
 slug: Web/API/KeyboardEvent/metaKey
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`KeyboardEvent.metaKey`** 为只读属性，返回一个 {{jsxref("Boolean", "布尔值")}}，在事件发生时，用于指示 <kbd>Meta</kbd> 键是按下状态（`true`），还是释放状态（`false`）。
 

--- a/files/zh-cn/web/api/keyboardevent/repeat/index.md
+++ b/files/zh-cn/web/api/keyboardevent/repeat/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent.repeat
 slug: Web/API/KeyboardEvent/repeat
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`KeyboardEvent.repeat`**是一个只读属性，返回一个布尔值{{jsxref("Boolean")}}，如果按键被一直按住，返回值为`true`。
 

--- a/files/zh-cn/web/api/keyboardevent/shiftkey/index.md
+++ b/files/zh-cn/web/api/keyboardevent/shiftkey/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent.shiftKey
 slug: Web/API/KeyboardEvent/shiftKey
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`KeyboardEvent.shiftKey`** 只读属性返回一个 {{jsxref("Boolean")}} 值，表示事件触发时 <kbd>shift</kbd> 键是 (`true`) 否 (`false`) 按下。
 

--- a/files/zh-cn/web/api/mouseevent/altkey/index.md
+++ b/files/zh-cn/web/api/mouseevent/altkey/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.altKey
 slug: Web/API/MouseEvent/altKey
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`MouseEvent.altKey`** 只读属性是一个{{jsxref("Boolean")}}变量。当事件触发时，如果<kbd>alt</kbd> 被按下，则返回 true，否则返回 false。
 

--- a/files/zh-cn/web/api/mouseevent/button/index.md
+++ b/files/zh-cn/web/api/mouseevent/button/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.button
 slug: Web/API/MouseEvent/button
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`MouseEvent.button`**是只读属性，它返回一个值，代表用户按下并触发了事件的鼠标按键。
 

--- a/files/zh-cn/web/api/mouseevent/buttons/index.md
+++ b/files/zh-cn/web/api/mouseevent/buttons/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.buttons
 slug: Web/API/MouseEvent/buttons
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 只读属性 **`MouseEvent.buttons`** 指示事件触发时哪些鼠标按键被按下。
 

--- a/files/zh-cn/web/api/mouseevent/clientx/index.md
+++ b/files/zh-cn/web/api/mouseevent/clientx/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.clientX
 slug: Web/API/MouseEvent/clientX
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`MouseEvent.clientX`** 是只读属性，它提供事件发生时的应用客户端区域的水平坐标 (与页面坐标不同)。例如，不论页面是否有水平滚动，当你点击客户端区域的左上角时，鼠标事件的 `clientX` 值都将为 0。最初这个属性被定义为长整型（long integer），如今 **CSSOM** 视图模块将其重新定义为双精度浮点数（double float）。你可以查阅浏览器兼容性部分的文档来进一步了解有关信息。
 

--- a/files/zh-cn/web/api/mouseevent/clienty/index.md
+++ b/files/zh-cn/web/api/mouseevent/clienty/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.clientY
 slug: Web/API/MouseEvent/clientY
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`MouseEvent.clientY`** 是只读属性，它提供事件发生时的应用客户端区域的垂直坐标 (与页面坐标不同)。例如，当你点击客户端区域的左上角时，鼠标事件的 `clientY` 值为 0，这一值与页面是否有垂直滚动无关。
 

--- a/files/zh-cn/web/api/mouseevent/ctrlkey/index.md
+++ b/files/zh-cn/web/api/mouseevent/ctrlkey/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.ctrlKey
 slug: Web/API/MouseEvent/ctrlKey
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`MouseEvent.ctrlKey`** 是只读属性，可返回一个布尔值，当 ctrl 键被按下，返回 true，否则返回 false。
 

--- a/files/zh-cn/web/api/mouseevent/index.md
+++ b/files/zh-cn/web/api/mouseevent/index.md
@@ -3,7 +3,7 @@ title: 鼠标事件
 slug: Web/API/MouseEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`MouseEvent`** 接口指用户与指针设备（如鼠标）交互时发生的事件。使用此接口的常见事件包括：[`click`](/zh-CN/docs/Web/API/Element/click_event)、[`dblclick`](/zh-CN/docs/Web/API/Element/dblclick_event)、[`mouseup`](/zh-CN/docs/Web/API/Element/mouseup_event)、[`mousedown`](/zh-CN/docs/Web/API/Element/mousedown_event)。
 

--- a/files/zh-cn/web/api/mouseevent/initmouseevent/index.md
+++ b/files/zh-cn/web/api/mouseevent/initmouseevent/index.md
@@ -3,7 +3,9 @@ title: MouseEvent.initMouseEvent()
 slug: Web/API/MouseEvent/initMouseEvent
 ---
 
-{{APIRef("DOM Events")}}{{deprecated_header}}
+{{Deprecated_Header}}
+
+{{APIRef("UI Events")}}
 
 **`MouseEvent.initMouseEvent()`** 方法用以在鼠标事件创建时 (一般用 {{domxref("Document.createEvent()")}}方法创建) 初始化其属性的值。
 

--- a/files/zh-cn/web/api/mouseevent/initmouseevent/index.md
+++ b/files/zh-cn/web/api/mouseevent/initmouseevent/index.md
@@ -3,9 +3,7 @@ title: MouseEvent.initMouseEvent()
 slug: Web/API/MouseEvent/initMouseEvent
 ---
 
-{{Deprecated_Header}}
-
-{{APIRef("UI Events")}}
+{{APIRef("UI Events")}}{{deprecated_header}}
 
 **`MouseEvent.initMouseEvent()`** 方法用以在鼠标事件创建时 (一般用 {{domxref("Document.createEvent()")}}方法创建) 初始化其属性的值。
 

--- a/files/zh-cn/web/api/mouseevent/metakey/index.md
+++ b/files/zh-cn/web/api/mouseevent/metakey/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.metaKey
 slug: Web/API/MouseEvent/metaKey
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`MouseEvent.metaKey`** 为只读属性，返回一个{{jsxref("Boolean", "布尔值")}}，在鼠标事件发生时，用于指示 <kbd>Meta</kbd> 键是按下状态（`true`），还是释放状态（`false`）。
 

--- a/files/zh-cn/web/api/mouseevent/mouseevent/index.md
+++ b/files/zh-cn/web/api/mouseevent/mouseevent/index.md
@@ -3,7 +3,7 @@ title: MouseEvent()
 slug: Web/API/MouseEvent/MouseEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`MouseEvent()`** 构造器创建一个 {{domxref("MouseEvent")}}。
 

--- a/files/zh-cn/web/api/mouseevent/movementx/index.md
+++ b/files/zh-cn/web/api/mouseevent/movementx/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.movementX
 slug: Web/API/MouseEvent/movementX
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("Pointer Lock API")}}
 
 **`MouseEvent.movementX`** 是只读属性，它提供了当前事件和上一个[`mousemove`](/zh-CN/docs/Web/API/Element/mousemove_event)事件之间鼠标在水平方向上的移动值。换句话说，这个值是这样计算的 : `currentEvent.movementX = currentEvent.screenX - previousEvent.screenX`.
 

--- a/files/zh-cn/web/api/mouseevent/movementy/index.md
+++ b/files/zh-cn/web/api/mouseevent/movementy/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.movementY
 slug: Web/API/MouseEvent/movementY
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("Pointer Lock API")}}
 
 {{domxref("MouseEvent")}} 接口的 **`MouseEvent.movementY`** 只读属性提供了当前事件和上一个 {{domxref("Element/mousemove_event", "mousemove")}} 事件之间鼠标在竖直方向上的移动值。换句话说，这个值是这样计算的：`currentEvent.movementY = currentEvent.screenY - previousEvent.screenY`。
 

--- a/files/zh-cn/web/api/mouseevent/pagex/index.md
+++ b/files/zh-cn/web/api/mouseevent/pagex/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.pageX
 slug: Web/API/MouseEvent/pageX
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`pageX`** 是一个由 {{domxref("MouseEvent")}} 接口返回的相对于整个文档的 x（水平）坐标以像素为单位的只读属性。
 

--- a/files/zh-cn/web/api/mouseevent/pagey/index.md
+++ b/files/zh-cn/web/api/mouseevent/pagey/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.pageY
 slug: Web/API/MouseEvent/pageY
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`pageY`** 是一个只读属性，它返回触发事件的位置相对于整个 document 的 Y 坐标值。由于其参考物是整个 dom，所以这个值受页面垂直方向的滚动影响。例如：当你垂直方向向下滚动了 50 pixel，那么你在顶端进行点击的时候，获取的 **`pageY`** 为 50pixed 而不是 0。最初这个属性被定义为长整型（long integer），如今 **CSSOM** 视图模块将其重新定义为双精度浮点数（double float）。你可以查阅浏览器兼容性部分的文档来进一步了解有关信息。
 

--- a/files/zh-cn/web/api/mouseevent/relatedtarget/index.md
+++ b/files/zh-cn/web/api/mouseevent/relatedtarget/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.relatedTarget
 slug: Web/API/MouseEvent/relatedTarget
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 只读属性 **`MouseEvent.relatedTarget`** 是鼠标事件的次要目标（如果存在），它包括：
 

--- a/files/zh-cn/web/api/mouseevent/shiftkey/index.md
+++ b/files/zh-cn/web/api/mouseevent/shiftkey/index.md
@@ -3,7 +3,7 @@ title: MouseEvent.shiftKey
 slug: Web/API/MouseEvent/shiftKey
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`MouseEvent.shiftKey`** 是只读属性，指出触发鼠标事件时是否按住了 `shift` 键
 

--- a/files/zh-cn/web/api/mousescrollevent/index.md
+++ b/files/zh-cn/web/api/mousescrollevent/index.md
@@ -3,7 +3,11 @@ title: MouseScrollEvent
 slug: Web/API/MouseScrollEvent
 ---
 
-{{APIRef("DOM Events")}}{{ non-standard_header() }}{{deprecated_header}}
+{{Non-standard_Header}}
+
+{{Deprecated_Header}}
+
+{{APIRef("UI Events")}}
 
 `MouseScrollEvent` 事件对象代表了当用户在滚动鼠标滚轮或操作其他类似的输入设备时触发的事件。
 

--- a/files/zh-cn/web/api/mousescrollevent/index.md
+++ b/files/zh-cn/web/api/mousescrollevent/index.md
@@ -3,11 +3,7 @@ title: MouseScrollEvent
 slug: Web/API/MouseScrollEvent
 ---
 
-{{Non-standard_Header}}
-
-{{Deprecated_Header}}
-
-{{APIRef("UI Events")}}
+{{APIRef("UI Events")}}{{Non-standard_Header}}{{Deprecated_Header}}
 
 `MouseScrollEvent` 事件对象代表了当用户在滚动鼠标滚轮或操作其他类似的输入设备时触发的事件。
 

--- a/files/zh-cn/web/api/progressevent/index.md
+++ b/files/zh-cn/web/api/progressevent/index.md
@@ -3,7 +3,7 @@ title: ProgressEvent
 slug: Web/API/ProgressEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("XMLHttpRequest API")}}
 
 **`ProgressEvent`** 接口是测量如 HTTP 请求（一个`XMLHttpRequest`，或者一个 {{HTMLElement("img")}}，{{HTMLElement("audio")}}，{{HTMLElement("video")}}，{{HTMLElement("style")}} 或 {{HTMLElement("link")}} 等底层资源的加载）等底层流程进度的事件。
 

--- a/files/zh-cn/web/api/progressevent/lengthcomputable/index.md
+++ b/files/zh-cn/web/api/progressevent/lengthcomputable/index.md
@@ -3,7 +3,7 @@ title: ProgressEvent.lengthComputable
 slug: Web/API/ProgressEvent/lengthComputable
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("XMLHttpRequest API")}}
 
 **`ProgressEvent.lengthComputable`** 只读属性是一个布尔{{domxref("Boolean")}} 标志，表示{{domxref("ProgressEvent")}} 所关联的资源是否具有可以计算的长度。否则，{{domxref("ProgressEvent.total")}} 属性将是一个无意义的值。
 

--- a/files/zh-cn/web/api/uievent/detail/index.md
+++ b/files/zh-cn/web/api/uievent/detail/index.md
@@ -3,7 +3,7 @@ title: UIEvent.detail
 slug: Web/API/UIEvent/detail
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`UIEvent.detail`** 是只读属性，当值为非空的时候，提供当前点击数 (和环境有关) 。
 

--- a/files/zh-cn/web/api/uievent/index.md
+++ b/files/zh-cn/web/api/uievent/index.md
@@ -3,7 +3,7 @@ title: UIEvent
 slug: Web/API/UIEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 `UIEvent` 接口表示简单的用户界面事件。
 

--- a/files/zh-cn/web/api/uievent/uievent/index.md
+++ b/files/zh-cn/web/api/uievent/uievent/index.md
@@ -3,7 +3,7 @@ title: UIEvent()
 slug: Web/API/UIEvent/UIEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`UIEvent()`** 作为构造函数，可用于构造一个新的 {{domxref("UIEvent")}} 对象。
 

--- a/files/zh-cn/web/api/uievent/view/index.md
+++ b/files/zh-cn/web/api/uievent/view/index.md
@@ -3,7 +3,7 @@ title: 用户界面项目视图
 slug: Web/API/UIEvent/view
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 The **`UIEvent.view`** 只读属性返回的生成事件的 {{domxref("document.defaultView")}} (`window` of the document) 对象。在浏览器中，这是事件所在的 {{ domxref("Window") }} 对象。
 

--- a/files/zh-cn/web/api/uievent/which/index.md
+++ b/files/zh-cn/web/api/uievent/which/index.md
@@ -3,7 +3,9 @@ title: KeyboardEvent.which
 slug: Web/API/UIEvent/which
 ---
 
-{{ APIRef("DOM Events") }} {{Deprecated_header}}
+{{Deprecated_Header}}
+
+{{APIRef("UI Events")}}
 
 {{domxref("KeyboardEvent")}} 接口的 **`which`** 只读属性返回所按下键的数字 `keyCode` 或所按下字母数字键的字符代码 (`charCode`) 。
 

--- a/files/zh-cn/web/api/uievent/which/index.md
+++ b/files/zh-cn/web/api/uievent/which/index.md
@@ -3,9 +3,7 @@ title: KeyboardEvent.which
 slug: Web/API/UIEvent/which
 ---
 
-{{Deprecated_Header}}
-
-{{APIRef("UI Events")}}
+{{APIRef("UI Events")}}{{Deprecated_Header}}
 
 {{domxref("KeyboardEvent")}} 接口的 **`which`** 只读属性返回所按下键的数字 `keyCode` 或所按下字母数字键的字符代码 (`charCode`) 。
 

--- a/files/zh-cn/web/api/wheelevent/deltamode/index.md
+++ b/files/zh-cn/web/api/wheelevent/deltamode/index.md
@@ -3,7 +3,7 @@ title: WheelEvent.deltaMode
 slug: Web/API/WheelEvent/deltaMode
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`WheelEvent.deltaMode`** 只读属性返回一个 `unsigned long` 类型的值，声明 delta 的滚动值的单位。可能的值为：
 

--- a/files/zh-cn/web/api/wheelevent/deltax/index.md
+++ b/files/zh-cn/web/api/wheelevent/deltax/index.md
@@ -3,7 +3,7 @@ title: WheelEvent.deltaX
 slug: Web/API/WheelEvent/deltaX
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`WheelEvent.deltaX`** 只读属性是一个 `double` 类型值，声明水平滚动量以{{domxref("WheelEvent.deltaMode")}} 为单位。
 

--- a/files/zh-cn/web/api/wheelevent/deltay/index.md
+++ b/files/zh-cn/web/api/wheelevent/deltay/index.md
@@ -3,7 +3,7 @@ title: WheelEvent.deltaY
 slug: Web/API/WheelEvent/deltaY
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`WheelEvent.deltaY`** 只读属性是一个 `double` 类型值，声明垂直滚动量以 [`WheelEvent.deltaMode`](/zh-CN/docs/Web/API/WheelEvent/deltaMode) 为单位。
 

--- a/files/zh-cn/web/api/wheelevent/deltaz/index.md
+++ b/files/zh-cn/web/api/wheelevent/deltaz/index.md
@@ -3,7 +3,7 @@ title: WheelEvent.deltaZ
 slug: Web/API/WheelEvent/deltaZ
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`WheelEvent.deltaZ`** 只读属性是一个 `double` 类型值，声明 Z 轴滚动量以[`WheelEvent.deltaMode`](/zh-CN/docs/Web/API/WheelEvent/deltaMode) 为单位。
 


### PR DESCRIPTION
### Description

This PR replaces all add `APIRef("DOM Events")` macro calls with more suitable (`DOM`, `UI Events`, `Pointer Lock API` or `XMLHttpRequest API`) param for `zh-CN` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/15880, https://github.com/mdn/content/pull/30450
