### PR TITLE
[zh-tw] replace all `APIRef("DOM Events")` macro calls with more suitable param

### DIFF
--- a/files/zh-tw/web/api/eventtarget/addeventlistener/index.md
+++ b/files/zh-tw/web/api/eventtarget/addeventlistener/index.md
@@ -3,7 +3,7 @@ title: EventListener
 slug: Web/API/EventTarget/addEventListener
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
 **`EventListener`** 介面表示一個可以處理由 {{domxref("EventTarget")}} 物件分派事件的物件。
 

--- a/files/zh-tw/web/api/eventtarget/dispatchevent/index.md
+++ b/files/zh-tw/web/api/eventtarget/dispatchevent/index.md
@@ -3,7 +3,7 @@ title: EventTarget.dispatchEvent()
 slug: Web/API/EventTarget/dispatchEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("DOM")}}
 
 於此 {{domxref("EventTarget")}} 物件上觸發特定的 {{domxref("Event")}} 物件實體，相當於依照註冊的順序呼叫它的 {{domxref("EventListener")}}。一般事件處理規則（包含捕捉（capturing）和可選的冒泡（bubbling）階段）也適用於用 `dispatchEvent()` 手動觸發事件。
 

--- a/files/zh-tw/web/api/eventtarget/index.md
+++ b/files/zh-tw/web/api/eventtarget/index.md
@@ -3,7 +3,7 @@ title: EventTarget
 slug: Web/API/EventTarget
 ---
 
-{{ ApiRef("DOM Events") }}
+{{APIRef("DOM")}}
 
 **`EventTarget`** 介面定義了其實作的物件具有接收事件的能力，也可能擁有處理事件的監聽器。
 

--- a/files/zh-tw/web/api/keyboardevent/index.md
+++ b/files/zh-tw/web/api/keyboardevent/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent
 slug: Web/API/KeyboardEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`KeyboardEvent`** objects 用來詳述使用者和網頁之間，經由鍵盤產生的互動。每個事件（`event`）都記錄著一次鍵盤動作。事件類型（`keydown` 、 `keypress` 和 `keyup`）用來表示鍵盤執行哪種動作。
 

--- a/files/zh-tw/web/api/keyboardevent/keyboardevent/index.md
+++ b/files/zh-tw/web/api/keyboardevent/keyboardevent/index.md
@@ -3,7 +3,7 @@ title: KeyboardEvent()
 slug: Web/API/KeyboardEvent/KeyboardEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`KeyboardEvent()`** constructor 能用來建立一個新的 {{domxref("KeyboardEvent")}}。
 

--- a/files/zh-tw/web/api/uievent/index.md
+++ b/files/zh-tw/web/api/uievent/index.md
@@ -3,7 +3,7 @@ title: UIEvent
 slug: Web/API/UIEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`UIEvent`** 介面是使用者介面的事件的基本型態。
 

--- a/files/zh-tw/web/api/uievent/uievent/index.md
+++ b/files/zh-tw/web/api/uievent/uievent/index.md
@@ -3,7 +3,7 @@ title: UIEvent()
 slug: Web/API/UIEvent/UIEvent
 ---
 
-{{APIRef("DOM Events")}}
+{{APIRef("UI Events")}}
 
 **`UIEvent()`** constructor 是用來建立新的 {{domxref("UIEvent")}}。
 


### PR DESCRIPTION
### Description

This PR replaces all add `APIRef("DOM Events")` macro calls with more suitable (`DOM` or `UI Events`) param for `zh-TW` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/15880
