### PR TITLE
[es] replace `APIRef("XMLHttpRequest")` macro calls with `"XMLHttpRequest API"` param

### DIFF
--- a/files/es/web/api/formdata/index.md
+++ b/files/es/web/api/formdata/index.md
@@ -3,7 +3,9 @@ title: FormData
 slug: Web/API/FormData
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 La interfaz **`FormData`** proporciona una manera sencilla de construir un conjunto de parejas clave/valor que representan los campos de un formulario y sus valores, que pueden ser enviados fácilmente con el método {{domxref("XMLHttpRequest.send()")}}. Utiliza el mismo formato que usaría un formulario si el tipo de codificación fuera `"multipart/form-data"`.
 

--- a/files/es/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
+++ b/files/es/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
@@ -4,7 +4,7 @@ slug: Web/API/XMLHttpRequest_API/Using_XMLHttpRequest
 original_slug: Web/API/XMLHttpRequest/Using_XMLHttpRequest
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{DefaultAPISidebar("XMLHttpRequest API")}}
 
 En esta guía le echaremos un vistazo a cómo usar
 {{domxref("XMLHttpRequest")}} para enviar solicitudes [HTTP](/es/docs/Web/HTTP)


### PR DESCRIPTION
### Description

This PR replaces all `APIRef("XMLHttpRequest")` macro calls with more suitable (`XMLHttpRequest API`) param for `es` locale.

Also added `{{AvailableInWorkers}}` where necessary.

### Related issues and pull requests

Relates to https://github.com/mdn/content/issues/30070, https://github.com/mdn/content/pull/30081
