### PR TITLE
[ko] replace `APIRef("XMLHttpRequest")` macro calls with `"XMLHttpRequest API"` param

### DIFF
--- a/files/ko/web/api/formdata/append/index.md
+++ b/files/ko/web/api/formdata/append/index.md
@@ -3,7 +3,9 @@ title: FormData.append()
 slug: Web/API/FormData/append
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 {{domxref("FormData")}} 인터페이스의 **`append()`** 메서드는 `FormData` 객체의 기존 키에 새 값을 추가하거나, 키가 없는 경우 키를 추가합니다.
 

--- a/files/ko/web/api/formdata/delete/index.md
+++ b/files/ko/web/api/formdata/delete/index.md
@@ -3,7 +3,9 @@ title: FormData.delete()
 slug: Web/API/FormData/delete
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 {{domxref("FormData")}} 인터페이스의 **`delete()`** 메서드는 `FormData` 객체에서 key와 그 값에 해당하는 것을 지웁니다.
 

--- a/files/ko/web/api/formdata/entries/index.md
+++ b/files/ko/web/api/formdata/entries/index.md
@@ -3,7 +3,9 @@ title: FormData.entries()
 slug: Web/API/FormData/entries
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 **`FormData.entries()`** 메서드는 이 객체에 포함된 모든 key/value 쌍을 통과하는 {{jsxref("Iteration_protocols",'iterator')}} 를 반환합니다. 각 쌍의 key는 {{domxref("USVString")}} 객체입니다; value는 {{domxref("USVString")}} 또는 {{domxref("Blob")}} 중 하나입니다.
 

--- a/files/ko/web/api/formdata/formdata/index.md
+++ b/files/ko/web/api/formdata/formdata/index.md
@@ -3,7 +3,9 @@ title: FormData()
 slug: Web/API/FormData/FormData
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 **`FormData()`** 생성자(Constructor)는 새로운 {{domxref("FormData")}}객체를 만듭니다.
 

--- a/files/ko/web/api/formdata/get/index.md
+++ b/files/ko/web/api/formdata/get/index.md
@@ -3,7 +3,9 @@ title: FormData.get()
 slug: Web/API/FormData/get
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 {{domxref("FormData")}} 인터페이스의 **`get()`** 메서드는 `FormData` 객체에서 지정한 키와 연관된 첫 번째 값을 반환합니다. 값이 여러개이고, 모든 값을 원하면 이 메서드 대신 {{domxref("FormData.getAll()","getAll()")}} 메서드를 사용하십시오.
 

--- a/files/ko/web/api/formdata/getall/index.md
+++ b/files/ko/web/api/formdata/getall/index.md
@@ -3,7 +3,9 @@ title: FormData.getAll()
 slug: Web/API/FormData/getAll
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 {{domxref("FormData")}} 인터페이스의 **`getAll()`** 메서드는 `FormData` 객체에서 지정된 키와 연관된 모든 값을 반환합니다.
 

--- a/files/ko/web/api/formdata/has/index.md
+++ b/files/ko/web/api/formdata/has/index.md
@@ -3,7 +3,9 @@ title: FormData.has()
 slug: Web/API/FormData/has
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 {{domxref("FormData")}} 인터페이스의 **`has()`** 메서드는 `FormData` 객체에 특정 키가 들어 있는지 여부를 나타내는 boolean 을 반환합니다.
 

--- a/files/ko/web/api/formdata/index.md
+++ b/files/ko/web/api/formdata/index.md
@@ -3,7 +3,9 @@ title: FormData
 slug: Web/API/FormData
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 **`FormData`** 인터페이스는 form 필드와 그 값을 나타내는 일련의 key/value 쌍을 쉽게 생성할 수 있는 방법을 제공합니다. 또한 {{domxref("XMLHttpRequest.send()")}} 메서드를 사용하여 쉽게 전송할 수 있습니다. 인코딩 타입이 `"multipart/form-data"`로 설정된 경우, form에서 사용하는 것과 동일한 포맷을 사용해야 합니다.
 

--- a/files/ko/web/api/formdata/keys/index.md
+++ b/files/ko/web/api/formdata/keys/index.md
@@ -3,7 +3,9 @@ title: FormData.keys()
 slug: Web/API/FormData/keys
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 **`FormData.keys()`** 메서드는 이 객체에 포함된 모든 키를 통과하는 {{jsxref("Iteration_protocols",'iterator')}} 를 반환합니다. 키는 {{domxref("USVString")}} 객체입니다.
 

--- a/files/ko/web/api/formdata/set/index.md
+++ b/files/ko/web/api/formdata/set/index.md
@@ -3,7 +3,9 @@ title: FormData.set()
 slug: Web/API/FormData/set
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 {{domxref("FormData")}} 인터페이스의 **`set()`** 메서드는 `FormData` 객체 내에 있는 기존 키에 새 값을 설정하거나, 존재하지 않을 경우 key/value을 추가합니다.
 

--- a/files/ko/web/api/formdata/values/index.md
+++ b/files/ko/web/api/formdata/values/index.md
@@ -3,7 +3,9 @@ title: FormData.values()
 slug: Web/API/FormData/values
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 **`FormData.values()`** 메서드는 이 객체에 포함 된 모든 value를 통과하는 {{jsxref("Iteration_protocols",'iterator')}}를 반환합니다. value는 {{domxref("USVString")}} 또는 {{domxref("Blob")}} 객체입니다.
 


### PR DESCRIPTION
### Description

This PR replaces all `APIRef("XMLHttpRequest")` macro calls with more suitable (`XMLHttpRequest API`) param for `ko` locale.

Also added `{{AvailableInWorkers}}` where necessary.

### Related issues and pull requests

Relates to https://github.com/mdn/content/issues/30070, https://github.com/mdn/content/pull/30081
