### PR TITLE
[ru] replace `APIRef("XMLHttpRequest")` macro calls with `"XMLHttpRequest API"` param

### DIFF
--- a/files/ru/web/api/formdata/append/index.md
+++ b/files/ru/web/api/formdata/append/index.md
@@ -3,7 +3,7 @@ title: FormData.append()
 slug: Web/API/FormData/append
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 Метод **`append()`** из интерфейса {{domxref("FormData")}} добавляет новое значение в существующий ключ внутри объекта `FormData`, или создаёт ключ, в случае если он отсутствует.
 

--- a/files/ru/web/api/formdata/append/index.md
+++ b/files/ru/web/api/formdata/append/index.md
@@ -3,6 +3,8 @@ title: FormData.append()
 slug: Web/API/FormData/append
 ---
 
+{{AvailableInWorkers}}
+
 {{APIRef("XMLHttpRequest API")}}
 
 Метод **`append()`** из интерфейса {{domxref("FormData")}} добавляет новое значение в существующий ключ внутри объекта `FormData`, или создаёт ключ, в случае если он отсутствует.

--- a/files/ru/web/api/formdata/delete/index.md
+++ b/files/ru/web/api/formdata/delete/index.md
@@ -3,6 +3,8 @@ title: FormData.delete()
 slug: Web/API/FormData/delete
 ---
 
+{{AvailableInWorkers}}
+
 {{APIRef("XMLHttpRequest API")}}
 
 Метод **`delete()`** интерфейса {{domxref("FormData")}} удаляет ключ и его значение(-ия) из объекта `FormData`.

--- a/files/ru/web/api/formdata/delete/index.md
+++ b/files/ru/web/api/formdata/delete/index.md
@@ -3,7 +3,7 @@ title: FormData.delete()
 slug: Web/API/FormData/delete
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 Метод **`delete()`** интерфейса {{domxref("FormData")}} удаляет ключ и его значение(-ия) из объекта `FormData`.
 

--- a/files/ru/web/api/formdata/entries/index.md
+++ b/files/ru/web/api/formdata/entries/index.md
@@ -3,6 +3,8 @@ title: FormData.entries()
 slug: Web/API/FormData/entries
 ---
 
+{{AvailableInWorkers}}
+
 {{APIRef("XMLHttpRequest API")}}
 
 Метод **`FormData.entries()`** возвращает {{jsxref("Iteration_protocols",'iterator')}}, позволяя пройтись по всем ключам/значениям в этом объекте. Ключ каждой пары - это объект {{domxref("USVString")}}, значение - это {{domxref("USVString")}} или {{domxref("Blob")}}.

--- a/files/ru/web/api/formdata/entries/index.md
+++ b/files/ru/web/api/formdata/entries/index.md
@@ -3,7 +3,7 @@ title: FormData.entries()
 slug: Web/API/FormData/entries
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 Метод **`FormData.entries()`** возвращает {{jsxref("Iteration_protocols",'iterator')}}, позволяя пройтись по всем ключам/значениям в этом объекте. Ключ каждой пары - это объект {{domxref("USVString")}}, значение - это {{domxref("USVString")}} или {{domxref("Blob")}}.
 

--- a/files/ru/web/api/formdata/formdata/index.md
+++ b/files/ru/web/api/formdata/formdata/index.md
@@ -3,6 +3,8 @@ title: FormData()
 slug: Web/API/FormData/FormData
 ---
 
+{{AvailableInWorkers}}
+
 {{APIRef("XMLHttpRequest API")}}
 
 Конструктор **`FormData()`** создаёт новые объект {{domxref("FormData")}}, если проще - HTML-форму**.**

--- a/files/ru/web/api/formdata/formdata/index.md
+++ b/files/ru/web/api/formdata/formdata/index.md
@@ -3,7 +3,7 @@ title: FormData()
 slug: Web/API/FormData/FormData
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 Конструктор **`FormData()`** создаёт новые объект {{domxref("FormData")}}, если проще - HTML-форму**.**
 

--- a/files/ru/web/api/formdata/get/index.md
+++ b/files/ru/web/api/formdata/get/index.md
@@ -3,7 +3,7 @@ title: FormData.get()
 slug: Web/API/FormData/get
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 Метод get() из интерфейса {{domxref("FormData")}} возвращает первое значение, связанное с переданным ключом из объекта FormData. Если вы ожидаете множественные значения и хотите получить их все, используйте метод getAll().
 

--- a/files/ru/web/api/formdata/get/index.md
+++ b/files/ru/web/api/formdata/get/index.md
@@ -3,6 +3,8 @@ title: FormData.get()
 slug: Web/API/FormData/get
 ---
 
+{{AvailableInWorkers}}
+
 {{APIRef("XMLHttpRequest API")}}
 
 Метод get() из интерфейса {{domxref("FormData")}} возвращает первое значение, связанное с переданным ключом из объекта FormData. Если вы ожидаете множественные значения и хотите получить их все, используйте метод getAll().

--- a/files/ru/web/api/formdata/getall/index.md
+++ b/files/ru/web/api/formdata/getall/index.md
@@ -3,6 +3,8 @@ title: FormData.getAll()
 slug: Web/API/FormData/getAll
 ---
 
+{{AvailableInWorkers}}
+
 {{APIRef("XMLHttpRequest API")}}
 
 **`getAll()`** - метод объекта {{domxref("FormData")}}, который возвращает все значения, связанные с ключом в объекте FormData.

--- a/files/ru/web/api/formdata/getall/index.md
+++ b/files/ru/web/api/formdata/getall/index.md
@@ -3,7 +3,7 @@ title: FormData.getAll()
 slug: Web/API/FormData/getAll
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 **`getAll()`** - метод объекта {{domxref("FormData")}}, который возвращает все значения, связанные с ключом в объекте FormData.
 

--- a/files/ru/web/api/formdata/has/index.md
+++ b/files/ru/web/api/formdata/has/index.md
@@ -3,7 +3,7 @@ title: FormData.has()
 slug: Web/API/FormData/has
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 Метод **`has()`** из интерфейса {{domxref("FormData")}} возвращает логическое значение, указывающее, содержит ли объект `FormData` указанный ключ.
 

--- a/files/ru/web/api/formdata/has/index.md
+++ b/files/ru/web/api/formdata/has/index.md
@@ -3,6 +3,8 @@ title: FormData.has()
 slug: Web/API/FormData/has
 ---
 
+{{AvailableInWorkers}}
+
 {{APIRef("XMLHttpRequest API")}}
 
 Метод **`has()`** из интерфейса {{domxref("FormData")}} возвращает логическое значение, указывающее, содержит ли объект `FormData` указанный ключ.

--- a/files/ru/web/api/formdata/index.md
+++ b/files/ru/web/api/formdata/index.md
@@ -3,7 +3,7 @@ title: FormData
 slug: Web/API/FormData
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 XMLHttpRequest 2 добавляет поддержку для нового интерфейса FormData. Объекты FormData позволяют вам легко конструировать наборы пар ключ-значение, представляющие поля формы и их значения, которые в дальнейшем можно отправить с помощью метода [`send()`](</ru/docs/DOM/XMLHttpRequest#send()> "XMLHttpRequest#send()").
 

--- a/files/ru/web/api/formdata/index.md
+++ b/files/ru/web/api/formdata/index.md
@@ -3,6 +3,8 @@ title: FormData
 slug: Web/API/FormData
 ---
 
+{{AvailableInWorkers}}
+
 {{APIRef("XMLHttpRequest API")}}
 
 XMLHttpRequest 2 добавляет поддержку для нового интерфейса FormData. Объекты FormData позволяют вам легко конструировать наборы пар ключ-значение, представляющие поля формы и их значения, которые в дальнейшем можно отправить с помощью метода [`send()`](</ru/docs/DOM/XMLHttpRequest#send()> "XMLHttpRequest#send()").

--- a/files/ru/web/api/formdata/keys/index.md
+++ b/files/ru/web/api/formdata/keys/index.md
@@ -3,7 +3,7 @@ title: FormData.keys()
 slug: Web/API/FormData/keys
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 **`FormData.keys()`** метод возвращает {{jsxref("Iteration_protocols",'iterator')}} позволяя пройтись по всем ключам содержащимся в этом объекте. Ключи являются {{domxref("USVString")}} объектами.
 

--- a/files/ru/web/api/formdata/keys/index.md
+++ b/files/ru/web/api/formdata/keys/index.md
@@ -3,6 +3,8 @@ title: FormData.keys()
 slug: Web/API/FormData/keys
 ---
 
+{{AvailableInWorkers}}
+
 {{APIRef("XMLHttpRequest API")}}
 
 **`FormData.keys()`** метод возвращает {{jsxref("Iteration_protocols",'iterator')}} позволяя пройтись по всем ключам содержащимся в этом объекте. Ключи являются {{domxref("USVString")}} объектами.

--- a/files/ru/web/api/formdata/set/index.md
+++ b/files/ru/web/api/formdata/set/index.md
@@ -3,6 +3,8 @@ title: FormData.set()
 slug: Web/API/FormData/set
 ---
 
+{{AvailableInWorkers}}
+
 {{APIRef("XMLHttpRequest API")}}
 
 Метод set() из интерфейса {{domxref("FormData")}} присваивает новое значение существующему ключу внутри объекта `FormData`, или добавляет ключ/значение если до этого они не были установлены.

--- a/files/ru/web/api/formdata/set/index.md
+++ b/files/ru/web/api/formdata/set/index.md
@@ -3,7 +3,7 @@ title: FormData.set()
 slug: Web/API/FormData/set
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 Метод set() из интерфейса {{domxref("FormData")}} присваивает новое значение существующему ключу внутри объекта `FormData`, или добавляет ключ/значение если до этого они не были установлены.
 

--- a/files/ru/web/api/formdata/values/index.md
+++ b/files/ru/web/api/formdata/values/index.md
@@ -3,6 +3,8 @@ title: FormData.values()
 slug: Web/API/FormData/values
 ---
 
+{{AvailableInWorkers}}
+
 {{APIRef("XMLHttpRequest API")}}
 
 The **`FormData.values()`** метод возвращает {{jsxref("Iteration_protocols",'iterator')}} позволяя пройтись по всем значениям в этом объекте. Значения - это {{domxref("USVString")}} или {{domxref("Blob")}} объекты.

--- a/files/ru/web/api/formdata/values/index.md
+++ b/files/ru/web/api/formdata/values/index.md
@@ -3,7 +3,7 @@ title: FormData.values()
 slug: Web/API/FormData/values
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 The **`FormData.values()`** метод возвращает {{jsxref("Iteration_protocols",'iterator')}} позволяя пройтись по всем значениям в этом объекте. Значения - это {{domxref("USVString")}} или {{domxref("Blob")}} объекты.
 

--- a/files/ru/web/api/xmlhttprequest/index.md
+++ b/files/ru/web/api/xmlhttprequest/index.md
@@ -3,7 +3,9 @@ title: XMLHttpRequest
 slug: Web/API/XMLHttpRequest
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers("window_and_worker_except_service")}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 `XMLHttpRequest` это API, который предоставляет клиенту функциональность для обмена данными между клиентом и сервером. Данный API предоставляет простой способ получения данных по ссылке без перезагрузки страницы. Это позволяет обновлять только часть веб-страницы не прерывая пользователя. `XMLHttpRequest используется в AJAX запросах и особенно в single-page приложениях.`
 

--- a/files/ru/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
+++ b/files/ru/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
@@ -3,7 +3,9 @@ title: Использование XMLHttpRequest
 slug: Web/API/XMLHttpRequest_API/Using_XMLHttpRequest
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers("window_and_worker_except_service")}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 Это инструкция по использованию {{domxref("XMLHttpRequest")}} для обмена информацией между сайтом и сервером по [HTTP-протоколу](/ru/docs/Web/HTTP).
 

--- a/files/ru/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
+++ b/files/ru/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
@@ -3,9 +3,7 @@ title: Использование XMLHttpRequest
 slug: Web/API/XMLHttpRequest_API/Using_XMLHttpRequest
 ---
 
-{{AvailableInWorkers("window_and_worker_except_service")}}
-
-{{APIRef("XMLHttpRequest API")}}
+{{DefaultAPISidebar("XMLHttpRequest API")}}
 
 Это инструкция по использованию {{domxref("XMLHttpRequest")}} для обмена информацией между сайтом и сервером по [HTTP-протоколу](/ru/docs/Web/HTTP).
 


### PR DESCRIPTION
### Description

This PR replaces all `APIRef("XMLHttpRequest")` macro calls with more suitable (`XMLHttpRequest API`) param for `ru` locale.

Also added `{{AvailableInWorkers}}` where necessary.

### Related issues and pull requests

Relates to https://github.com/mdn/content/issues/30070, https://github.com/mdn/content/pull/30081
