### PR TITLE
[zh-cn] replace `APIRef("XMLHttpRequest")` macro calls with `"XMLHttpRequest API"` param

### DIFF
--- a/files/zh-cn/web/api/formdata/append/index.md
+++ b/files/zh-cn/web/api/formdata/append/index.md
@@ -3,9 +3,7 @@ title: FormData.append()
 slug: Web/API/FormData/append
 ---
 
-{{AvailableInWorkers}}
-
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
 {{domxref("FormData")}} 接口的 **`append()`** 方法会添加一个新值到 `FormData` 对象内的一个已存在的键中，如果键不存在则会添加该键。
 

--- a/files/zh-cn/web/api/formdata/append/index.md
+++ b/files/zh-cn/web/api/formdata/append/index.md
@@ -3,13 +3,13 @@ title: FormData.append()
 slug: Web/API/FormData/append
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 {{domxref("FormData")}} 接口的 **`append()`** 方法会添加一个新值到 `FormData` 对象内的一个已存在的键中，如果键不存在则会添加该键。
 
 {{domxref("FormData.set")}} 和 `append()` 的区别在于，如果指定的键已经存在， {{domxref("FormData.set")}} 会使用新值覆盖已有的值，而 `append()` 会把新值添加到已有值集合的后面。
-
-> **备注：** 这个方法在 [Web Workers](/zh-CN/docs/Web/API/Web_Workers_API) 中可用。
 
 ## 语法
 

--- a/files/zh-cn/web/api/formdata/delete/index.md
+++ b/files/zh-cn/web/api/formdata/delete/index.md
@@ -3,9 +3,7 @@ title: FormData.delete()
 slug: Web/API/FormData/delete
 ---
 
-{{AvailableInWorkers}}
-
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
 {{domxref("FormData")}} 接口的 **`delete()`** 方法会从 `FormData` 对象中删除指定键，即 key，和它对应的值，即 value。
 

--- a/files/zh-cn/web/api/formdata/delete/index.md
+++ b/files/zh-cn/web/api/formdata/delete/index.md
@@ -3,11 +3,11 @@ title: FormData.delete()
 slug: Web/API/FormData/delete
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 {{domxref("FormData")}} 接口的 **`delete()`** 方法会从 `FormData` 对象中删除指定键，即 key，和它对应的值，即 value。
-
-> **备注：** 此方法可用于 [Web Workers](/zh-CN/docs/Web/API/Web_Workers_API)。
 
 ## 语法
 

--- a/files/zh-cn/web/api/formdata/entries/index.md
+++ b/files/zh-cn/web/api/formdata/entries/index.md
@@ -3,16 +3,14 @@ title: FormData.entries()
 slug: Web/API/FormData/entries
 ---
 
-{{AvailableInWorkers}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
-{{APIRef("XMLHttpRequest API")}}
-
-The **`FormData.entries()`** 方法返回一个 {{jsxref("Iteration_protocols",'iterator')}}对象，此对象可以遍历访问 FormData 中的键值对。其中键值对的 key 是一个 {{domxref("USVString")}} 对象；value 是一个 {{domxref("USVString")}} , 或者 {{domxref("Blob")}}对象。
+**`FormData.entries()`** 方法返回一个 {{jsxref("Iteration_protocols",'iterator')}}对象，此对象可以遍历访问 {{domxref("FormData")}} 中的键值对。其中键值对的键是一个字符串对象；值是一个字符串或者 {{domxref("Blob")}} 对象。
 
 ## 语法
 
-```
-formData.entries();
+```js-nolint
+entries()
 ```
 
 ### 返回值

--- a/files/zh-cn/web/api/formdata/entries/index.md
+++ b/files/zh-cn/web/api/formdata/entries/index.md
@@ -3,11 +3,11 @@ title: FormData.entries()
 slug: Web/API/FormData/entries
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 The **`FormData.entries()`** 方法返回一个 {{jsxref("Iteration_protocols",'iterator')}}对象，此对象可以遍历访问 FormData 中的键值对。其中键值对的 key 是一个 {{domxref("USVString")}} 对象；value 是一个 {{domxref("USVString")}} , 或者 {{domxref("Blob")}}对象。
-
-> **备注：** 此方法在 [Web Workers](/zh-CN/docs/Web/API/Web_Workers_API) 可用。
 
 ## 语法
 

--- a/files/zh-cn/web/api/formdata/formdata/index.md
+++ b/files/zh-cn/web/api/formdata/formdata/index.md
@@ -3,11 +3,11 @@ title: FormData()
 slug: Web/API/FormData/FormData
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 **`FormData()`** 构造函数用于创建一个新的{{domxref("FormData")}}对象。
-
-> **备注：** 该功能在 [Web Workers](/zh-CN/docs/Web/API/Web_Workers_API) 中可用。
 
 ## 语法
 

--- a/files/zh-cn/web/api/formdata/formdata/index.md
+++ b/files/zh-cn/web/api/formdata/formdata/index.md
@@ -3,9 +3,7 @@ title: FormData()
 slug: Web/API/FormData/FormData
 ---
 
-{{AvailableInWorkers}}
-
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
 **`FormData()`** 构造函数用于创建一个新的{{domxref("FormData")}}对象。
 

--- a/files/zh-cn/web/api/formdata/get/index.md
+++ b/files/zh-cn/web/api/formdata/get/index.md
@@ -3,9 +3,7 @@ title: FormData.get()
 slug: Web/API/FormData/get
 ---
 
-{{AvailableInWorkers}}
-
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
 {{domxref("FormData")}} 的 `get()` 方法用于返回 FormData 对象中和指定的键关联的第一个值，如果你想要返回和指定键关联的全部值，那么可以使用 {{domxref("FormData.getAll()","getAll()")}} 方法。
 

--- a/files/zh-cn/web/api/formdata/get/index.md
+++ b/files/zh-cn/web/api/formdata/get/index.md
@@ -3,11 +3,11 @@ title: FormData.get()
 slug: Web/API/FormData/get
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 {{domxref("FormData")}} 的 `get()` 方法用于返回 FormData 对象中和指定的键关联的第一个值，如果你想要返回和指定键关联的全部值，那么可以使用 {{domxref("FormData.getAll()","getAll()")}} 方法。
-
-> **备注：** 该方法在[Web Workers](/zh-CN/docs/Web/API/Web_Workers_API)中有效。
 
 ## 语法
 

--- a/files/zh-cn/web/api/formdata/getall/index.md
+++ b/files/zh-cn/web/api/formdata/getall/index.md
@@ -3,11 +3,11 @@ title: FormData.getAll()
 slug: Web/API/FormData/getAll
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 **`getAll()`** 方法会返回该 {{domxref("FormData")}} 对象指定 key 的所有值。
-
-> **备注：** 该方法在 [Web Workers](/zh-CN/docs/Web/API/Web_Workers_API) 中可用。
 
 ## 语法
 

--- a/files/zh-cn/web/api/formdata/getall/index.md
+++ b/files/zh-cn/web/api/formdata/getall/index.md
@@ -3,9 +3,7 @@ title: FormData.getAll()
 slug: Web/API/FormData/getAll
 ---
 
-{{AvailableInWorkers}}
-
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
 **`getAll()`** 方法会返回该 {{domxref("FormData")}} 对象指定 key 的所有值。
 

--- a/files/zh-cn/web/api/formdata/has/index.md
+++ b/files/zh-cn/web/api/formdata/has/index.md
@@ -3,11 +3,11 @@ title: FormData.has()
 slug: Web/API/FormData/has
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 **`has()`**方法会返回一个布尔值，表示该{{domxref("FormData")}}对象是否含有某个 key。
-
-> **备注：** 该方法在 [Web Workers](/zh-CN/docs/Web/API/Web_Workers_API) 可用。
 
 ## 语法
 

--- a/files/zh-cn/web/api/formdata/has/index.md
+++ b/files/zh-cn/web/api/formdata/has/index.md
@@ -3,9 +3,7 @@ title: FormData.has()
 slug: Web/API/FormData/has
 ---
 
-{{AvailableInWorkers}}
-
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
 **`has()`**方法会返回一个布尔值，表示该{{domxref("FormData")}}对象是否含有某个 key。
 

--- a/files/zh-cn/web/api/formdata/index.md
+++ b/files/zh-cn/web/api/formdata/index.md
@@ -3,9 +3,7 @@ title: FormData
 slug: Web/API/FormData
 ---
 
-{{AvailableInWorkers}}
-
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
 **`FormData`** 接口提供了一种表示表单数据的键值对 `key/value` 的构造方式，并且可以轻松的将数据通过{{domxref("XMLHttpRequest.send()")}} 方法发送出去，本接口和此方法都相当简单直接。如果送出时的编码类型被设为 `"multipart/form-data"`，它会使用和表单一样的格式。
 

--- a/files/zh-cn/web/api/formdata/index.md
+++ b/files/zh-cn/web/api/formdata/index.md
@@ -3,15 +3,15 @@ title: FormData
 slug: Web/API/FormData
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 **`FormData`** 接口提供了一种表示表单数据的键值对 `key/value` 的构造方式，并且可以轻松的将数据通过{{domxref("XMLHttpRequest.send()")}} 方法发送出去，本接口和此方法都相当简单直接。如果送出时的编码类型被设为 `"multipart/form-data"`，它会使用和表单一样的格式。
 
 如果你想构建一个简单的`GET`请求，并且通过{{HTMLElement("form")}}的形式带有查询参数，可以将它直接传递给{{domxref("URLSearchParams")}}。
 
 实现了 `FormData` 接口的对象可以直接在{{jsxref("Statements/for...of", "for...of")}}结构中使用，而不需要调用{{domxref('FormData.entries()', 'entries()')}} : `for (var p of myFormData)` 的作用和 `for (var p of myFormData.entries())` 是相同的。
-
-> **备注：** 此特性可用于 [Web Workers](/zh-CN/docs/Web/API/Web_Workers_API)。
 
 ## 构造函数
 

--- a/files/zh-cn/web/api/formdata/keys/index.md
+++ b/files/zh-cn/web/api/formdata/keys/index.md
@@ -3,9 +3,7 @@ title: FormData.keys()
 slug: Web/API/FormData/keys
 ---
 
-{{AvailableInWorkers}}
-
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
 **`FormData.keys()`** 该方法返回一个迭代器（{{jsxref("Iteration_protocols",'iterator')}}），遍历了该 formData 包含的所有 key，这些 key 是 {{domxref("USVString")}} 对象。
 

--- a/files/zh-cn/web/api/formdata/keys/index.md
+++ b/files/zh-cn/web/api/formdata/keys/index.md
@@ -3,11 +3,11 @@ title: FormData.keys()
 slug: Web/API/FormData/keys
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 **`FormData.keys()`** 该方法返回一个迭代器（{{jsxref("Iteration_protocols",'iterator')}}），遍历了该 formData 包含的所有 key，这些 key 是 {{domxref("USVString")}} 对象。
-
-> **备注：** 该方法在 [Web Workers](/zh-CN/docs/Web/API/Web_Workers_API) 可用。
 
 ## 语法
 

--- a/files/zh-cn/web/api/formdata/set/index.md
+++ b/files/zh-cn/web/api/formdata/set/index.md
@@ -3,9 +3,7 @@ title: FormData.set()
 slug: Web/API/FormData/set
 ---
 
-{{AvailableInWorkers}}
-
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
 **`set()`** 方法会对 `FormData` 对象里的某个 `key` 设置一个新的值，如果该 `key` 不存在，则添加。
 

--- a/files/zh-cn/web/api/formdata/set/index.md
+++ b/files/zh-cn/web/api/formdata/set/index.md
@@ -3,13 +3,13 @@ title: FormData.set()
 slug: Web/API/FormData/set
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 **`set()`** 方法会对 `FormData` 对象里的某个 `key` 设置一个新的值，如果该 `key` 不存在，则添加。
 
 `set()` 和 {{domxref("FormData.append")}} 不同之处在于：如果某个 key 已经存在，`set()` 会直接覆盖所有该 key 对应的值，而 {{domxref("FormData.append")}} 则是在该 key 的最后位置再追加一个值。
-
-> **备注：** 该方法在 [Web Workers](/zh-CN/docs/Web/API/Web_Workers_API) 可用。
 
 ## 语法
 

--- a/files/zh-cn/web/api/formdata/values/index.md
+++ b/files/zh-cn/web/api/formdata/values/index.md
@@ -3,11 +3,11 @@ title: FormData.values()
 slug: Web/API/FormData/values
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 **`FormData.values()`** 方法返回一个允许遍历该对象中所有值的 {{jsxref("Iteration_protocols",'迭代器')}} 。这些值是 {{domxref("USVString")}} 或是{{domxref("Blob")}} 对象。
-
-> **备注：** 此方法在 [Web Workers](/zh-CN/docs/Web/API/Web_Workers_API) 中可用
 
 ## 语法
 

--- a/files/zh-cn/web/api/formdata/values/index.md
+++ b/files/zh-cn/web/api/formdata/values/index.md
@@ -3,11 +3,9 @@ title: FormData.values()
 slug: Web/API/FormData/values
 ---
 
-{{AvailableInWorkers}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
-{{APIRef("XMLHttpRequest API")}}
-
-**`FormData.values()`** 方法返回一个允许遍历该对象中所有值的 {{jsxref("Iteration_protocols",'迭代器')}} 。这些值是 {{domxref("USVString")}} 或是{{domxref("Blob")}} 对象。
+**`FormData.values()`** 方法返回一个允许遍历 {{domxref("FormData")}} 中所有值的[迭代器](/zh-CN/docs/Web/JavaScript/Reference/Iteration_protocols)。这些值是字符串或是 {{domxref("Blob")}} 对象。
 
 ## 语法
 

--- a/files/zh-cn/web/api/progressevent/loaded/index.md
+++ b/files/zh-cn/web/api/progressevent/loaded/index.md
@@ -3,7 +3,7 @@ title: ProgressEvent.loaded
 slug: Web/API/ProgressEvent/loaded
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 **`ProgressEvent.loaded`** 只读属性是一个整数，表示底层的进程已经执行的工作量。可以使用该属性和 `ProgressEvent.total` 计算完成工作的比率。当使用 HTTP 下载一个资源，其值以字节（而不是位）为单位，且仅表示内容（body）部分，不包含标头和其他开销。
 

--- a/files/zh-cn/web/api/progressevent/progressevent/index.md
+++ b/files/zh-cn/web/api/progressevent/progressevent/index.md
@@ -3,7 +3,7 @@ title: ProgressEvent()
 slug: Web/API/ProgressEvent/ProgressEvent
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 **`ProgressEvent()`** 构造函数返回一个新的 {{domxref("ProgressEvent")}} 对象，表示当前一个漫长处理过程的完成进度。
 

--- a/files/zh-cn/web/api/progressevent/total/index.md
+++ b/files/zh-cn/web/api/progressevent/total/index.md
@@ -3,7 +3,7 @@ title: ProgressEvent.total
 slug: Web/API/ProgressEvent/total
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{APIRef("XMLHttpRequest API")}}
 
 **`ProgressEvent.total`** 只读属性是一个无符号 64 位整数值，表明正在处理或者传输的数据的总大小。在 HTTP 传输的情况下，这是消息体的大小（`Content-Length`）并且不包含标头和其他的开销。
 

--- a/files/zh-cn/web/api/xmlhttprequest_api/html_in_xmlhttprequest/index.md
+++ b/files/zh-cn/web/api/xmlhttprequest_api/html_in_xmlhttprequest/index.md
@@ -3,7 +3,7 @@ title: XMLHttpRequest 中的 HTML
 slug: Web/API/XMLHttpRequest_API/HTML_in_XMLHttpRequest
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{DefaultAPISidebar("XMLHttpRequest API")}}
 
 W3C {{domxref("XMLHttpRequest")}} 规范为 {{domxref("XMLHttpRequest")}} 添加 [HTML](/zh-CN/docs/Web/HTML) 解析功能，此前它仅支持 {{Glossary("XML")}} 解析。该功能允许 Web 应用程序使用 `XMLHttpRequest` 获得已解析的 {{Glossary("DOM")}} 形式的 HTML 资源。
 

--- a/files/zh-cn/web/api/xmlhttprequest_api/sending_and_receiving_binary_data/index.md
+++ b/files/zh-cn/web/api/xmlhttprequest_api/sending_and_receiving_binary_data/index.md
@@ -3,6 +3,8 @@ title: 发送和接收二进制数据
 slug: Web/API/XMLHttpRequest_API/Sending_and_Receiving_Binary_Data
 ---
 
+{{DefaultAPISidebar("XMLHttpRequest API")}}
+
 ## 使用 JavaScript 类型数组接受二进制数据
 
 可以通过设置一个 XMLHttpRequest 对象的 `responseType`属性来改变一个从服务器上返回的响应的数据类型。可用的属性值为空字符串 (默认)，"arraybuffer"、"blob"、"document"、"json" 和 "text"。`response` 属性的值会根据 `responseType` 属性包含实体主体（entity body），它可能会是一个 `ArrayBuffer`、`Blob`、`Document`、`JSON`, string，或者为`NULL(如果请求未完成或失败)`
@@ -157,5 +159,3 @@ req.open("PUT", url, false); // 同步模式！
 req.setRequestHeader("Content-Type", mimeType);
 req.send(stream);
 ```
-
-{{APIRef("XMLHttpRequest")}}

--- a/files/zh-cn/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
+++ b/files/zh-cn/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
@@ -3,7 +3,7 @@ title: 使用 XMLHttpRequest
 slug: Web/API/XMLHttpRequest_API/Using_XMLHttpRequest
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{DefaultAPISidebar("XMLHttpRequest API")}}
 
 在该教程中，我们将使用{{domxref("XMLHttpRequest")}} 来发送 [HTTP](/zh-CN/docs/Web/HTTP) 请求以实现网站和服务器之间的数据交换。`XMLHttpRequest`常见和晦涩的使用情况都将包含在例子中。
 

--- a/files/zh-cn/web/api/xmlhttprequesteventtarget/index.md
+++ b/files/zh-cn/web/api/xmlhttprequesteventtarget/index.md
@@ -3,9 +3,7 @@ title: XMLHttpRequestEventTarget
 slug: Web/API/XMLHttpRequestEventTarget
 ---
 
-{{AvailableInWorkers("window_and_worker_except_service")}}
-
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 `XMLHttpRequestEventTarget` 是一个描述事件处理程序的接口，你可以在一个用于处理 {{ domxref("XMLHttpRequest") }} 事件的对象中使用到该事件处理程序。
 

--- a/files/zh-cn/web/api/xmlhttprequesteventtarget/index.md
+++ b/files/zh-cn/web/api/xmlhttprequesteventtarget/index.md
@@ -3,7 +3,9 @@ title: XMLHttpRequestEventTarget
 slug: Web/API/XMLHttpRequestEventTarget
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers("window_and_worker_except_service")}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 `XMLHttpRequestEventTarget` 是一个描述事件处理程序的接口，你可以在一个用于处理 {{ domxref("XMLHttpRequest") }} 事件的对象中使用到该事件处理程序。
 


### PR DESCRIPTION
### Description

This PR replaces all `APIRef("XMLHttpRequest")` macro calls with more suitable (`XMLHttpRequest API`) param for `zh-CN` locale.

Also added `{{AvailableInWorkers}}` where necessary.

### Related issues and pull requests

Relates to https://github.com/mdn/content/issues/30070, https://github.com/mdn/content/pull/30081
