### PR TITLE
[zh-tw] replace `APIRef("XMLHttpRequest")` macro calls with `"XMLHttpRequest API"` param

### DIFF
--- a/files/zh-tw/web/api/formdata/get/index.md
+++ b/files/zh-tw/web/api/formdata/get/index.md
@@ -3,11 +3,9 @@ title: FormData.get()
 slug: Web/API/FormData/get
 ---
 
-{{AvailableInWorkers}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
-{{APIRef("XMLHttpRequest API")}}
-
-{{domxref("FormData")}} 的 **`get()`** 方法會返回 `FormData 物件中，指定 `key` 值所對應之第一組物件中的 value 值。然而，如果你想要獲得多組以及全部的 value，那應該使用 {{domxref("FormData.getAll()","getAll()")}} 方法。
+{{domxref("FormData")}} 的 **`get()`** 方法會返回 `FormData` 物件中，指定 `key` 值所對應之第一組物件中的 value 值。然而，如果你想要獲得多組以及全部的 value，那應該使用 {{domxref("FormData.getAll()","getAll()")}} 方法。
 
 ## 語法
 
@@ -18,11 +16,11 @@ formData.get(name);
 ### 參數
 
 - `name`
-  - : 一個 {{domxref("USVString")}}，代表你想要得到的 value 所對應的 key 值名稱。
+  - : 一個字串，代表你想要得到的 value 所對應的 key 值名稱。
 
 ### 回傳值
 
-A {{domxref("FormDataEntryValue")}} containing the value.
+键值与指定的 `name` 匹配的值。否则为 [`null`](/zh-TW/docs/Web/JavaScript/Reference/Operators/null)。
 
 ## 範例
 

--- a/files/zh-tw/web/api/formdata/get/index.md
+++ b/files/zh-tw/web/api/formdata/get/index.md
@@ -3,11 +3,11 @@ title: FormData.get()
 slug: Web/API/FormData/get
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 {{domxref("FormData")}} 的 **`get()`** 方法會返回 `FormData 物件中，指定 `key` 值所對應之第一組物件中的 value 值。然而，如果你想要獲得多組以及全部的 value，那應該使用 {{domxref("FormData.getAll()","getAll()")}} 方法。
-
-**注意**: 這個方法已可以在 [Web Worker](/zh-TW/docs/Web/API/Web_Workers_API) 中使用。
 
 ## 語法
 

--- a/files/zh-tw/web/api/formdata/index.md
+++ b/files/zh-tw/web/api/formdata/index.md
@@ -3,9 +3,7 @@ title: FormData
 slug: Web/API/FormData
 ---
 
-{{AvailableInWorkers}}
-
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
 **`FormData`** 介面可為表單資料中的欄位/值建立相對應的的鍵/值對（key/value）集合，之後便可使用 {{domxref("XMLHttpRequest.send()")}} 方法來送出資料。它在編碼類型設定為 `multipart/form-data` 時會採用與表單相同的格式送出。
 
@@ -47,7 +45,5 @@ slug: Web/API/FormData
 
 ## 參見
 
-- {{domxref("XMLHTTPRequest")}}
-- [使用 XMLHttpRequest](/zh-TW/docs/Web/API/XMLHttpRequest_API/Using_XMLHttpRequest)
 - [使用 FormData 物件](/zh-TW/docs/Web/API/XMLHttpRequest_API/Using_FormData_Objects)
 - {{HTMLElement("Form")}}

--- a/files/zh-tw/web/api/formdata/index.md
+++ b/files/zh-tw/web/api/formdata/index.md
@@ -3,13 +3,13 @@ title: FormData
 slug: Web/API/FormData
 ---
 
-{{APIRef("XMLHttpRequest")}}
+{{AvailableInWorkers}}
+
+{{APIRef("XMLHttpRequest API")}}
 
 **`FormData`** 介面可為表單資料中的欄位/值建立相對應的的鍵/值對（key/value）集合，之後便可使用 {{domxref("XMLHttpRequest.send()")}} 方法來送出資料。它在編碼類型設定為 `multipart/form-data` 時會採用與表單相同的格式送出。
 
 實作 `FormData` 的物件可以直接利用 {{jsxref("Statements/for...of", "for...of")}} 語法結構來替代 {{domxref('FormData.entries()', 'entries()')}}：`for (var p of myFormData)` 等同於 `for (var p of myFormData.entries())`。
-
-> **備註：** 此特性適用於 [Web Workers](/zh-TW/docs/Web/API/Web_Workers_API)。
 
 ## 建構式
 


### PR DESCRIPTION
### Description

This PR replaces all `APIRef("XMLHttpRequest")` macro calls with more suitable (`XMLHttpRequest API`) param for `zh-TW` locale.

Also added `{{AvailableInWorkers}}` where necessary.

### Related issues and pull requests

Relates to https://github.com/mdn/content/issues/30070, https://github.com/mdn/content/pull/30081
