### PR TITLE
[ru] remove legacy `{{SeeCompatTable}}` snippet from `Web/CSS/inset`

### DIFF
--- a/files/ru/web/css/inset/index.md
+++ b/files/ru/web/css/inset/index.md
@@ -3,7 +3,7 @@ title: inset
 slug: Web/CSS/inset
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 Свойство [CSS](/ru/docs/Web/CSS) **`inset`** определяет логический блок и встроенные начальное и конечное смещения элемента, которые отображают физическое смещение, зависящее от способа записи, направления и ориентации текста. Оно соответствует свойствам {{cssxref("top")}} и {{cssxref("bottom")}}, или {{cssxref("right")}} и {{cssxref("left")}}, в зависимости от значений, определённых для {{cssxref("writing-mode")}}, {{cssxref("direction")}}, и {{cssxref("text-orientation")}}.
 


### PR DESCRIPTION
### Description

Remove legacy {{SeeCompatTable}} snippet

### Related issues and pull requests
Fixes #19794 
