### PR TITLE
[fr] Dead link on Push_API page

### DIFF
--- a/files/fr/web/api/push_api/index.md
+++ b/files/fr/web/api/push_api/index.md
@@ -63,6 +63,6 @@ Les ajouts à [l'API <i lang="en">Service Worker</i>](/fr/docs/Web/API/Service_W
 ## Voir aussi
 
 - [Using the Push API \[EN\]](/fr/docs/Web/API/Push_API/Using_the_Push_API)
-- [Démo API Push](https://github.com/chrisdavidmills/push-api-demo), sur Github
+- [Démo API Push](https://github.com/gauntface/simple-push-demo), sur Github
 - [Push Notifications on the Open Web](http://updates.html5rocks.com/2015/03/push-notificatons-on-the-open-web), Matt Gaunt
 - [API Service Worker](/fr/docs/Web/API/Service_Worker_API)

--- a/files/fr/web/api/push_api/index.md
+++ b/files/fr/web/api/push_api/index.md
@@ -63,6 +63,6 @@ Les ajouts à [l'API <i lang="en">Service Worker</i>](/fr/docs/Web/API/Service_W
 ## Voir aussi
 
 - [Using the Push API \[EN\]](/fr/docs/Web/API/Push_API/Using_the_Push_API)
-- [Démo API Push](https://github.com/gauntface/simple-push-demo), sur Github
+- [Démo API Push](https://github.com/gauntface/simple-push-demo), sur GitHub
 - [Push Notifications on the Open Web](http://updates.html5rocks.com/2015/03/push-notificatons-on-the-open-web), Matt Gaunt
 - [API Service Worker](/fr/docs/Web/API/Service_Worker_API)


### PR DESCRIPTION
### URL MDN
https://developer.mozilla.org/fr/docs/Web/API/Push_API

Replaced broken link https://github.com/chrisdavidmills/push-api-demo with https://github.com/gauntface/simple-push-demo.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
I searched a new demo of the Push API and found this : https://github.com/gauntface/simple-push-demo (live demo at https://simple-push-demo.vercel.app/). I replaced the old broken link with the new one.

### Related issues and pull requests

Fixes #18923
