### PR TITLE
[ru] remove invalid macro calls from `Web/JavaScript/Reference/Global_Objects/RegExp`

### DIFF
--- a/files/ru/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/ru/web/javascript/reference/global_objects/regexp/index.md
@@ -714,16 +714,6 @@ var re = new RegExp("\\w+");
 
 Глобальный объект `RegExp` не имеет собственных методов, однако, он наследует некоторые методы через цепочку прототипов.
 
-## Экземпляры регулярного выражения
-
-### Свойства
-
-{{page('/ru/docs/Web/JavaScript/Reference/Global_Objects/RegExp/prototype', 'Properties')}}
-
-### Методы
-
-{{page('/ru/docs/Web/JavaScript/Reference/Global_Objects/RegExp/prototype', 'Methods')}}
-
 ## Примеры
 
 ### Пример: использование регулярных выражений для смены формата данных


### PR DESCRIPTION
### Description

This PR removes invalid `{{page}}` macro calls from `Web/JavaScript/Reference/Global_Objects/RegExp` in `ru` locale.

### Related issues and pull requests

Relates to #3892
