### PR TITLE
perf(ci/pr-lint): specify lock file paths to reduce the search time

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -73,7 +73,9 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
-          cache-dependency-path: "**/yarn.lock"
+          cache-dependency-path: |
+            mdn/content/yarn.lock
+            yarn.lock
 
       - name: Install all yarn packages for mdn/translated-content
         if: ${{ env.DIFF_DOCUMENTS }}


### PR DESCRIPTION
### Description

Syntax: https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data

The setup-node we used here will consume more time than the one in [content](https://github.com/mdn/content/actions/workflows/pr-check-lint_content.yml) significantly.

### Test

Workflow run in my fork:

- https://github.com/yin1999/translated-content/actions/runs/8892465141/job/24416718380#step:7:1
