### PR TITLE
[es] remove unnecessary `original_slug` front matter key

### DIFF
--- a/files/es/learn/javascript/client-side_web_apis/fetching_data/index.md
+++ b/files/es/learn/javascript/client-side_web_apis/fetching_data/index.md
@@ -1,7 +1,6 @@
 ---
 title: AJAX
 slug: Learn/JavaScript/Client-side_web_APIs/Fetching_data
-original_slug: Web/Guide/AJAX
 ---
 
 **[Primeros Pasos](/es/docs/Web/Guide/AJAX/Getting_Started)**

--- a/files/es/mdn/community/contributing/index.md
+++ b/files/es/mdn/community/contributing/index.md
@@ -1,7 +1,6 @@
 ---
 title: Contribuir a MDN
 slug: MDN/Community/Contributing
-original_slug: MDN/Contribute
 ---
 
 {{MDNSidebar}}

--- a/files/es/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -1,7 +1,6 @@
 ---
 title: Ejemplos ejecutables
 slug: MDN/Writing_guidelines/Page_structures/Live_samples
-original_slug: MDN/Structures/Live_samples
 ---
 
 {{MDNSidebar}}

--- a/files/es/mdn/writing_guidelines/page_structures/sidebars/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/sidebars/index.md
@@ -1,7 +1,6 @@
 ---
 title: Enlaces rápidos
 slug: MDN/Writing_guidelines/Page_structures/Sidebars
-original_slug: MDN/Writing_guidelines/Page_structures/Quicklinks
 l10n:
   sourceCommit: aa66311219951396e7305df61eb31831360d2c79
 ---

--- a/files/es/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
@@ -1,7 +1,6 @@
 ---
 title: Ejemplo de composición
 slug: Web/API/CanvasRenderingContext2D/globalCompositeOperation
-original_slug: Web/API/Canvas_API/Tutorial/Compositing/Example
 ---
 
 {{DefaultAPISidebar("Canvas API")}}

--- a/files/es/web/api/console/assert_static/index.md
+++ b/files/es/web/api/console/assert_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.assert()
 slug: Web/API/console/assert_static
-original_slug: Web/API/console/assert
 ---
 
 {{APIRef("Console API")}}{{Non-standard_header}}

--- a/files/es/web/api/console/count_static/index.md
+++ b/files/es/web/api/console/count_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.count()
 slug: Web/API/console/count_static
-original_slug: Web/API/console/count
 ---
 
 {{APIRef("Console API")}}

--- a/files/es/web/api/console/dir_static/index.md
+++ b/files/es/web/api/console/dir_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.dir()
 slug: Web/API/console/dir_static
-original_slug: Web/API/console/dir
 ---
 
 {{APIRef("Console API")}}

--- a/files/es/web/api/console/dirxml_static/index.md
+++ b/files/es/web/api/console/dirxml_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.dirxml()
 slug: Web/API/console/dirxml_static
-original_slug: Web/API/console/dirxml
 ---
 
 {{APIRef("Console API")}}{{Non-standard_header}}

--- a/files/es/web/api/console/error_static/index.md
+++ b/files/es/web/api/console/error_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.error()
 slug: Web/API/console/error_static
-original_slug: Web/API/console/error
 ---
 
 {{APIRef("Console API")}}

--- a/files/es/web/api/console/info_static/index.md
+++ b/files/es/web/api/console/info_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.info()
 slug: Web/API/console/info_static
-original_slug: Web/API/console/info
 ---
 
 {{APIRef("Console API")}}Emite un mensaje informativo a la Consola Web. En Firefox y Chrome, se muestra un pequeño ícono "i" junto a estos elementos en el registro de la Consola Web.

--- a/files/es/web/api/console/log_static/index.md
+++ b/files/es/web/api/console/log_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.log()
 slug: Web/API/console/log_static
-original_slug: Web/API/console/log
 ---
 
 {{APIRef("Console API")}}Muestra un mensaje en la consola web (o del intérprete JavaScript).

--- a/files/es/web/api/console/table_static/index.md
+++ b/files/es/web/api/console/table_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.table()
 slug: Web/API/console/table_static
-original_slug: Web/API/console/table
 ---
 
 {{APIRef("Console API")}}

--- a/files/es/web/api/console/time_static/index.md
+++ b/files/es/web/api/console/time_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.time()
 slug: Web/API/console/time_static
-original_slug: Web/API/console/time
 ---
 
 {{APIRef("Console API")}}

--- a/files/es/web/api/console/timeend_static/index.md
+++ b/files/es/web/api/console/timeend_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.timeEnd()
 slug: Web/API/console/timeend_static
-original_slug: Web/API/console/timeEnd
 ---
 
 {{APIRef("Console API")}}

--- a/files/es/web/api/console/trace_static/index.md
+++ b/files/es/web/api/console/trace_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.trace()
 slug: Web/API/console/trace_static
-original_slug: Web/API/console/trace
 ---
 
 {{APIRef("Console API")}}{{Non-standard_header}}

--- a/files/es/web/api/console/warn_static/index.md
+++ b/files/es/web/api/console/warn_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.warn()
 slug: Web/API/console/warn_static
-original_slug: Web/API/console/warn
 ---
 
 {{APIRef("Console API")}}

--- a/files/es/web/api/element/input_event/index.md
+++ b/files/es/web/api/element/input_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: Evento input
 slug: Web/API/Element/input_event
-original_slug: Web/API/HTMLElement/input_event
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/indexeddb/index.md
+++ b/files/es/web/api/window/indexeddb/index.md
@@ -1,7 +1,6 @@
 ---
 title: indexedDB
 slug: Web/API/Window/indexedDB
-original_slug: Web/API/indexedDB
 ---
 
 {{ APIRef() }}

--- a/files/es/web/api/window/issecurecontext/index.md
+++ b/files/es/web/api/window/issecurecontext/index.md
@@ -1,7 +1,6 @@
 ---
 title: isSecureContext
 slug: Web/API/Window/isSecureContext
-original_slug: Web/API/isSecureContext
 ---
 
 {{APIRef()}}{{SeeCompatTable}}

--- a/files/es/web/api/xmlhttprequest_api/using_formdata_objects/index.md
+++ b/files/es/web/api/xmlhttprequest_api/using_formdata_objects/index.md
@@ -1,7 +1,6 @@
 ---
 title: Usando Objetos FormData
 slug: Web/API/XMLHttpRequest_API/Using_FormData_Objects
-original_slug: Web/API/FormData/Using_FormData_Objects
 ---
 
 Los objetos `FormData` le permiten compilar un conjunto de pares clave/valor para enviar mediante `XMLHttpRequest`. Están destinados principalmente para el envío de los datos del formulario, pero se pueden utilizar de forma independiente con el fin de transmitir los datos tecleados. Los datos transmitidos estarán en el mismo formato que usa el método `submit()` del formulario para enviar los datos si el tipo de codificación del formulario se establece en "multipart/form-data".

--- a/files/es/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
+++ b/files/es/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
@@ -1,7 +1,6 @@
 ---
 title: Utilizando XMLHttpRequest
 slug: Web/API/XMLHttpRequest_API/Using_XMLHttpRequest
-original_slug: Web/API/XMLHttpRequest/Using_XMLHttpRequest
 ---
 
 {{DefaultAPISidebar("XMLHttpRequest API")}}

--- a/files/es/web/css/css_containment/container_queries/index.md
+++ b/files/es/web/css/css_containment/container_queries/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS Container Queries
 slug: Web/CSS/CSS_containment/Container_queries
-original_slug: Web/CSS/CSS_container_queries
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/css_display/block_formatting_context/index.md
+++ b/files/es/web/css/css_display/block_formatting_context/index.md
@@ -1,7 +1,6 @@
 ---
 title: Contexto de formato de bloque
 slug: Web/CSS/CSS_display/Block_formatting_context
-original_slug: Web/Guide/CSS/Block_formatting_context
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/next-sibling_combinator/index.md
+++ b/files/es/web/css/next-sibling_combinator/index.md
@@ -1,7 +1,6 @@
 ---
 title: Selectores de hermanos adyacentes
 slug: Web/CSS/Next-sibling_combinator
-original_slug: Web/CSS/Adjacent_sibling_combinator
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/subsequent-sibling_combinator/index.md
+++ b/files/es/web/css/subsequent-sibling_combinator/index.md
@@ -1,7 +1,6 @@
 ---
 title: Selectores de hermanos generales
 slug: Web/CSS/Subsequent-sibling_combinator
-original_slug: Web/CSS/General_sibling_combinator
 ---
 
 {{CSSRef}}

--- a/files/es/web/javascript/reference/classes/private_properties/index.md
+++ b/files/es/web/javascript/reference/classes/private_properties/index.md
@@ -1,7 +1,6 @@
 ---
 title: Private class fields
 slug: Web/JavaScript/Reference/Classes/Private_properties
-original_slug: Web/JavaScript/Reference/Classes/Private_class_fields
 ---
 
 Las propiedades de la clase son públicas de forma predeterminada y se pueden examinar o modificar fuera de la clase. Sin embargo, existe [una propuesta experimental](https://github.com/tc39/proposal-class-fields) para permitir la definición de campos de clase privados utilizando un `#` prefijo hash .

--- a/files/es/web/xml/parsing_and_serializing_xml/index.md
+++ b/files/es/web/xml/parsing_and_serializing_xml/index.md
@@ -1,7 +1,6 @@
 ---
 title: Convertir código a cadena de texto (serializing) y visceversa (parsing) a un  XML
 slug: Web/XML/Parsing_and_serializing_XML
-original_slug: Web/Guide/Parsing_and_serializing_XML
 ---
 
 La plataforma web proveé Los siguientes objetos para hacer parsing (convertir una cadena de texto a código) y serializing (visceversa) a un XML:


### PR DESCRIPTION
### Description

This PR removes unnecessary `original_slug` front matter key from all documents except `conflicting/` and `orphaned/` for `es` locale.

### Related issues and pull requests

Relates to #14873
