### PR TITLE
[fr] remove unnecessary `original_slug` front matter key

### DIFF
--- a/files/fr/learn/forms/user_input_methods/index.md
+++ b/files/fr/learn/forms/user_input_methods/index.md
@@ -1,7 +1,6 @@
 ---
 title: Entrées utilisateur et méthodes
 slug: Learn/Forms/User_input_methods
-original_slug: Web/Guide/User_input_methods
 ---
 
 Les entrées utilisateur modernes vont au-delà du simple clavier et souris: pensez aux écrans tactiles par exemple. Cet article fournit des recommendations pour gérer les entrées utilisateur et implémenter les contrôles des Open Web Apps, ainsi que des FAQs, des exemples concrets, et des liens pour ceux qui ont besoin d'informations supplémentaires sur les technologies utilisées. Les APIs et événements abordés sont en autre [les événements tactiles](/fr/docs/Web/Guide/DOM/Events/Touch_events), [l'API Pointer Lock](/fr/docs/WebAPI/Pointer_Lock), [l'API Screen Orientation](/fr/docs/Web/API/CSS_Object_Model/Managing_screen_orientation), [l'API Fullscreen](/fr/docs/Web/Guide/DOM/Using_full_screen_mode) et [Drag & Drop](/fr/docs/Web/API/API_HTML_Drag_and_Drop).

--- a/files/fr/web/api/element/beforeinput_event/index.md
+++ b/files/fr/web/api/element/beforeinput_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: "HTMLElement: beforeinput event"
 slug: Web/API/Element/beforeinput_event
-original_slug: Web/API/HTMLElement/beforeinput_event
 ---
 
 {{APIRef}} {{SeeCompatTable}}

--- a/files/fr/web/api/element/input_event/index.md
+++ b/files/fr/web/api/element/input_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: input
 slug: Web/API/Element/input_event
-original_slug: Web/API/HTMLElement/input_event
 ---
 
 L'évènement DOM `input` _(entrée)_ est déclenché de façon synchrone quand la valeur d'un élément {{HTMLElement("input")}} _(entrée)_, {{HTMLElement("select")}} _(sélection)_ ou {{ HTMLElement("textarea") }} _(zone de texte)_ est modifiée. (Pour les éléments `input` avec `type=checkbox` _(case à cocher)_ ou `type=radio` , l'évènement `input` n'est pas lancé quand l'utilisateur clique sur le contrôle, parce que la valeur attribuée ne peut être changée).

--- a/files/fr/web/api/window/indexeddb/index.md
+++ b/files/fr/web/api/window/indexeddb/index.md
@@ -1,7 +1,6 @@
 ---
 title: indexedDB
 slug: Web/API/Window/indexedDB
-original_slug: Web/API/indexedDB
 ---
 
 {{APIRef}}

--- a/files/fr/web/css/css_display/block_formatting_context/index.md
+++ b/files/fr/web/css/css_display/block_formatting_context/index.md
@@ -1,7 +1,6 @@
 ---
 title: Contexte de formatage de blocs
 slug: Web/CSS/CSS_display/Block_formatting_context
-original_slug: Web/Guide/CSS/Block_formatting_context
 ---
 
 {{CSSRef}}

--- a/files/fr/web/css/css_syntax/index.md
+++ b/files/fr/web/css/css_syntax/index.md
@@ -1,7 +1,6 @@
 ---
 title: Jeux de caractères CSS
 slug: Web/CSS/CSS_syntax
-original_slug: Web/CSS/CSS_charsets
 ---
 
 {{CSSRef}}

--- a/files/fr/web/media/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
+++ b/files/fr/web/media/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
@@ -1,7 +1,6 @@
 ---
 title: Mémoire tampon, position, et plages de temps
 slug: Web/Media/Audio_and_video_delivery/buffering_seeking_time_ranges
-original_slug: Web/Guide/Audio_and_video_delivery/buffering_seeking_time_ranges
 ---
 
 Il est parfois utile de savoir combien d'{{htmlelement("audio") }} ou {{htmlelement("video") }} a été téléchargé ou peut être joué sans délai — par exemple pour afficher la barre de progression du tampon dans un lecteur audio ou vidéo. Cet article explique comment construire une barre de progrès de mise en mémoire tampon en utilisant [TimeRanges](/fr/docs/Web/API/TimeRanges), et d'autres fonctionnalités de l'API Media.

--- a/files/fr/web/media/audio_and_video_delivery/index.md
+++ b/files/fr/web/media/audio_and_video_delivery/index.md
@@ -1,7 +1,6 @@
 ---
 title: Intégration audio et vidéo
 slug: Web/Media/Audio_and_video_delivery
-original_slug: Web/Guide/Audio_and_video_delivery
 ---
 
 On peut distribuer de l'audio et de la vidéo sur le web de plusieurs manières, du fichier média statique au <i lang="en">live stream</i> (flux en direct) adaptatif. Cet article se veut être le point de départ pour explorer les différents mécanismes de diffusion de média sur le web et la compatiblité avec les navigateurs populaires.

--- a/files/fr/web/media/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
+++ b/files/fr/web/media/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
@@ -1,7 +1,6 @@
 ---
 title: Live streaming web Audio et Vidéo
 slug: Web/Media/Audio_and_video_delivery/Live_streaming_web_audio_and_video
-original_slug: Web/Guide/Audio_and_video_delivery/Live_streaming_web_audio_and_video
 ---
 
 La technologie de _live streaming_ (diffusion en direct) est souvent utilisée pour relayer des événements en direct, tels que le sport, les concerts, ou de manière plus générale les programmes TV et radio en direct. Souvent raccourci au simple terme de _streaming_, le live streaming est le processus de transmissions d'un média _live_ (c'est à dire dynamique et non statique) aux ordinateurs et aux périphériques. C'est un sujet assez complexe et nouveau avec beaucoup de variables à prendre en considération, dans cet article nous allons vous introduire le sujet et vous donner des clés pour démarrer.

--- a/files/fr/web/media/audio_and_video_manipulation/index.md
+++ b/files/fr/web/media/audio_and_video_manipulation/index.md
@@ -1,7 +1,6 @@
 ---
 title: Manipulation Audio et Vidéo
 slug: Web/Media/Audio_and_video_manipulation
-original_slug: Web/Guide/Audio_and_video_manipulation
 ---
 
 La beauté du web est qu'on peut combiner différentes technologies pour en créer de nouvelles. Avoir de l'audio et vidéo nativement dans le navigateur nous donne la possibilité d'utiliser ces flux de données avec d'autres technologies comme {{htmlelement("canvas")}}, [WebGL](/fr/docs/Web/API/WebGL_API) ou [Web Audio API](/fr/docs/Web/API/Web_Audio_API) pour modifier le média — par exemple ajouter des effets de réverbération ou de compression à l'audio, ou encore des filtres noir & blanc/sépia aux vidéos. Cet article fournit une référence pour expliquer ce que vous pouvez faire.

--- a/files/fr/web/performance/index.md
+++ b/files/fr/web/performance/index.md
@@ -1,7 +1,6 @@
 ---
 title: Optimisation et performances
 slug: Web/Performance
-original_slug: Web/Guide/Performance
 ---
 
 Lorsque l'on créent des sites et des applications internet modernes, il est important que notre code soit performant. C'est-à-dire, le faire fonctionner rapidement et efficacement. Lui permettant ainsi de fonctionner aussi efficacement à la fois pour les utilisateurs de puissants systèmes de bureau et pour les appareils portables ayant moins de puissance. On appel cela le PageSpeed Optimization (optimisation de la vitesse de chargement de pages web). Il y a plusieurs outils disponibles pour vérifiez les performances de chargement d'un site ou de blog internet. Les plus connus sont listés ci-dessous :


### PR DESCRIPTION
### Description

This PR removes unnecessary `original_slug` front matter key from all documents except `conflicting/` and `orphaned/` for `fr` locale.

### Related issues and pull requests

Relates to #14873
