### PR TITLE
[ja] remove unnecessary `original_slug` front matter key

### DIFF
--- a/files/ja/games/techniques/3d_on_the_web/webxr/index.md
+++ b/files/ja/games/techniques/3d_on_the_web/webxr/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebVR — ウェブによる仮想現実
 slug: Games/Techniques/3D_on_the_web/WebXR
-original_slug: Games/Techniques/3D_on_the_web/WebVR
 ---
 
 {{GamesSidebar}}

--- a/files/ja/learn/forms/user_input_methods/index.md
+++ b/files/ja/learn/forms/user_input_methods/index.md
@@ -1,7 +1,6 @@
 ---
 title: ユーザ入力とコントロール
 slug: Learn/Forms/User_input_methods
-original_slug: Web/Guide/User_input_methods
 ---
 
 現代のウェブのユーザー入力は、単純なマウスやキーボードだけではありません。この記事では、ユーザー入力を管理し、オープンなウェブアプリに制御を実装するための推奨事項を、FAQ、実例、および基礎となる技術について、より詳細な情報を必要とする人のための詳細な情報へのリンクとともに提供します。関連する API とイベントには、[タッチイベント](/ja/docs/Web/API/Touch_events)、[Pointer Lock API](/ja/docs/Web/API/Pointer_Lock_API)、[Screen Orientation API](/ja/docs/Web/API/CSS_Object_Model/Managing_screen_orientation)、[Fullscreen API](/ja/docs/Web/API/Fullscreen_API)、[ドラッグ＆ドロップ API](/ja/docs/Web/API/HTML_Drag_and_Drop_API) などがあります。

--- a/files/ja/web/api/console/assert_static/index.md
+++ b/files/ja/web/api/console/assert_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.assert()
 slug: Web/API/console/assert_static
-original_slug: Web/API/console/assert
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/clear_static/index.md
+++ b/files/ja/web/api/console/clear_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.clear()
 slug: Web/API/console/clear_static
-original_slug: Web/API/console/clear
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/count_static/index.md
+++ b/files/ja/web/api/console/count_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.count()
 slug: Web/API/console/count_static
-original_slug: Web/API/console/count
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/countreset_static/index.md
+++ b/files/ja/web/api/console/countreset_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.countReset()
 slug: Web/API/console/countreset_static
-original_slug: Web/API/console/countReset
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/debug_static/index.md
+++ b/files/ja/web/api/console/debug_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.debug()
 slug: Web/API/console/debug_static
-original_slug: Web/API/console/debug
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/dir_static/index.md
+++ b/files/ja/web/api/console/dir_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.dir()
 slug: Web/API/console/dir_static
-original_slug: Web/API/console/dir
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/dirxml_static/index.md
+++ b/files/ja/web/api/console/dirxml_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.dirxml()
 slug: Web/API/console/dirxml_static
-original_slug: Web/API/console/dirxml
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/error_static/index.md
+++ b/files/ja/web/api/console/error_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.error()
 slug: Web/API/console/error_static
-original_slug: Web/API/console/error
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/group_static/index.md
+++ b/files/ja/web/api/console/group_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.group()
 slug: Web/API/console/group_static
-original_slug: Web/API/console/group
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/groupcollapsed_static/index.md
+++ b/files/ja/web/api/console/groupcollapsed_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.groupCollapsed()
 slug: Web/API/console/groupcollapsed_static
-original_slug: Web/API/console/groupCollapsed
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/groupend_static/index.md
+++ b/files/ja/web/api/console/groupend_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.groupEnd()
 slug: Web/API/console/groupend_static
-original_slug: Web/API/console/groupEnd
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/info_static/index.md
+++ b/files/ja/web/api/console/info_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.info()
 slug: Web/API/console/info_static
-original_slug: Web/API/console/info
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/log_static/index.md
+++ b/files/ja/web/api/console/log_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.log()
 slug: Web/API/console/log_static
-original_slug: Web/API/console/log
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/profile_static/index.md
+++ b/files/ja/web/api/console/profile_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.profile()
 slug: Web/API/console/profile_static
-original_slug: Web/API/console/profile
 ---
 
 {{APIRef("Console API")}}{{Non-standard_header}}

--- a/files/ja/web/api/console/profileend_static/index.md
+++ b/files/ja/web/api/console/profileend_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.profileEnd()
 slug: Web/API/console/profileend_static
-original_slug: Web/API/console/profileEnd
 ---
 
 {{APIRef("Console API")}}{{Non-standard_header}}

--- a/files/ja/web/api/console/table_static/index.md
+++ b/files/ja/web/api/console/table_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.table()
 slug: Web/API/console/table_static
-original_slug: Web/API/console/table
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/time_static/index.md
+++ b/files/ja/web/api/console/time_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.time()
 slug: Web/API/console/time_static
-original_slug: Web/API/console/time
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/timeend_static/index.md
+++ b/files/ja/web/api/console/timeend_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.timeEnd()
 slug: Web/API/console/timeend_static
-original_slug: Web/API/console/timeEnd
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/timelog_static/index.md
+++ b/files/ja/web/api/console/timelog_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.timeLog()
 slug: Web/API/console/timelog_static
-original_slug: Web/API/console/timeLog
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/timestamp_static/index.md
+++ b/files/ja/web/api/console/timestamp_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.timeStamp()
 slug: Web/API/console/timestamp_static
-original_slug: Web/API/console/timeStamp
 ---
 
 {{APIRef("Console API")}}{{Non-standard_header}}

--- a/files/ja/web/api/console/trace_static/index.md
+++ b/files/ja/web/api/console/trace_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.trace()
 slug: Web/API/console/trace_static
-original_slug: Web/API/console/trace
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/console/warn_static/index.md
+++ b/files/ja/web/api/console/warn_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.warn()
 slug: Web/API/console/warn_static
-original_slug: Web/API/console/warn
 ---
 
 {{APIRef("Console API")}}

--- a/files/ja/web/api/element/beforeinput_event/index.md
+++ b/files/ja/web/api/element/beforeinput_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: "HTMLElement: beforeinput イベント"
 slug: Web/API/Element/beforeinput_event
-original_slug: Web/API/HTMLElement/beforeinput_event
 ---
 
 {{APIRef}}

--- a/files/ja/web/api/element/input_event/index.md
+++ b/files/ja/web/api/element/input_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: "HTMLElement: input イベント"
 slug: Web/API/Element/input_event
-original_slug: Web/API/HTMLElement/input_event
 ---
 
 {{APIRef}}

--- a/files/ja/web/api/houdini_apis/index.md
+++ b/files/ja/web/api/houdini_apis/index.md
@@ -1,7 +1,6 @@
 ---
 title: Houdini API
 slug: Web/API/Houdini_APIs
-original_slug: Web/API/Houdini
 l10n:
   sourceCommit: 3b39e41fb9393a13b16aaf58ba25174a62205041
 ---

--- a/files/ja/web/api/screendetailed/availleft/index.md
+++ b/files/ja/web/api/screendetailed/availleft/index.md
@@ -1,7 +1,6 @@
 ---
 title: Screen.availLeft
 slug: Web/API/ScreenDetailed/availLeft
-original_slug: Web/API/Screen/availLeft
 ---
 
 {{APIRef("CSSOM")}}{{Non-standard_Header}}

--- a/files/ja/web/api/screendetailed/availtop/index.md
+++ b/files/ja/web/api/screendetailed/availtop/index.md
@@ -1,7 +1,6 @@
 ---
 title: Screen.availTop
 slug: Web/API/ScreenDetailed/availTop
-original_slug: Web/API/Screen/availTop
 ---
 
 {{APIRef("CSSOM")}}{{Non-standard_Header}}

--- a/files/ja/web/api/screendetailed/left/index.md
+++ b/files/ja/web/api/screendetailed/left/index.md
@@ -1,7 +1,6 @@
 ---
 title: Screen.left
 slug: Web/API/ScreenDetailed/left
-original_slug: Web/API/Screen/left
 ---
 
 {{APIRef("CSSOM")}}{{Non-standard_Header}}

--- a/files/ja/web/api/screendetailed/top/index.md
+++ b/files/ja/web/api/screendetailed/top/index.md
@@ -1,7 +1,6 @@
 ---
 title: Screen.top
 slug: Web/API/ScreenDetailed/top
-original_slug: Web/API/Screen/top
 ---
 
 {{APIRef("CSSOM")}}{{deprecated_header}}{{Non-standard_Header}}

--- a/files/ja/web/api/window/indexeddb/index.md
+++ b/files/ja/web/api/window/indexeddb/index.md
@@ -1,7 +1,6 @@
 ---
 title: indexedDB
 slug: Web/API/Window/indexedDB
-original_slug: Web/API/indexedDB
 ---
 
 {{ APIRef() }}

--- a/files/ja/web/api/window/issecurecontext/index.md
+++ b/files/ja/web/api/window/issecurecontext/index.md
@@ -1,7 +1,6 @@
 ---
 title: isSecureContext
 slug: Web/API/Window/isSecureContext
-original_slug: Web/API/isSecureContext
 ---
 
 {{APIRef}}

--- a/files/ja/web/css/css_containment/container_queries/index.md
+++ b/files/ja/web/css/css_containment/container_queries/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS コンテナークエリー
 slug: Web/CSS/CSS_containment/Container_queries
-original_slug: Web/CSS/CSS_container_queries
 ---
 
 {{CSSRef}}

--- a/files/ja/web/css/css_fonts/woff/index.md
+++ b/files/ja/web/css/css_fonts/woff/index.md
@@ -1,7 +1,6 @@
 ---
 title: WOFF (Web Open Font Format)
 slug: Web/CSS/CSS_fonts/WOFF
-original_slug: Web/Guide/WOFF
 ---
 
 **WOFF (Web Open Font Format)** は、Mozilla が Type Supply や LettError、他の組織と提携して開発した新しい Web フォント形式です。これは、TrueType および OpenType, Open Font Format に使用されているテーブルベースの `sfnt` 構造と同じ圧縮されたバージョンを使用しています。WOFF には、これにメタデータと個人利用のためのデータ構造が追加されており、作成者とベンダーがライセンス情報を書き込むことができる予約フィールドも含まれています。

--- a/files/ja/web/css/css_media_queries/printing/index.md
+++ b/files/ja/web/css/css_media_queries/printing/index.md
@@ -1,7 +1,6 @@
 ---
 title: 印刷
 slug: Web/CSS/CSS_media_queries/Printing
-original_slug: Web/Guide/Printing
 ---
 
 コンテンツを印刷するときに、ウェブサイトまたはアプリケーションで使い勝手を向上させたい場合があります。考えられるシナリオはいくつかあります。

--- a/files/ja/web/css/next-sibling_combinator/index.md
+++ b/files/ja/web/css/next-sibling_combinator/index.md
@@ -1,7 +1,6 @@
 ---
 title: 次兄弟結合子
 slug: Web/CSS/Next-sibling_combinator
-original_slug: Web/CSS/Next-sibling_combinator
 l10n:
   sourceCommit: bb652aaf3e38f3c7fef970a62f813047dffac879
 ---

--- a/files/ja/web/media/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/ja/web/media/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTML5 の動画へのキャプションと字幕の追加
 slug: Web/Media/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video
-original_slug: Web/Guide/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video
 ---
 
 他の記事で、 [ブラウザーに依存しない動画プレイヤーの構築](/ja/Apps/Build/Manipulating_media/cross_browser_video_player)を、 {{ domxref("HTMLMediaElement") }} 及び {{ domxref("Window.fullScreen") }} API を使用して行う方法と、[プレイヤーのスタイル付け](/ja/Apps/Build/Manipulating_media/Video_player_styling_basics)の方法について見てきました。この記事では、同じプレイヤーと使って、 {{ domxref("Web_Video_Text_Tracks_Format","WebVTT 形式") }}及び {{ htmlelement("track") }} 要素を用いてキャプションや字幕を追加する方法を紹介します。

--- a/files/ja/web/media/audio_and_video_delivery/index.md
+++ b/files/ja/web/media/audio_and_video_delivery/index.md
@@ -1,7 +1,6 @@
 ---
 title: 音声と動画の配信
 slug: Web/Media/Audio_and_video_delivery
-original_slug: Web/Guide/Audio_and_video_delivery
 ---
 
 静的な」メディアファイルからアダプティブなライブストリームまで、さまざまな方法で音声と動画をウェブ上に配信することができます。この記事は、ウェブベースのメディアの様々な配信メカニズムや、一般的なブラウザーへの互換性を探るための出発点として意図されています。

--- a/files/ja/web/media/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
+++ b/files/ja/web/media/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
@@ -1,7 +1,6 @@
 ---
 title: ウェブの音声や動画のライブストリーミング
 slug: Web/Media/Audio_and_video_delivery/Live_streaming_web_audio_and_video
-original_slug: Web/Guide/Audio_and_video_delivery/Live_streaming_web_audio_and_video
 ---
 
 ライブストリーミング技術は、よくスポーツやコンサートなどのイベントの中継や、もっと一般的にはテレビやラジオの番組の配信などによく採用されています。よくストリーミングと略されるライブストリーミングは、コンピューターや機器へメディアを「ライブ」で転送するプロセスです。これは実に複雑で数多くの変量がある初期段階の主題ですので、この記事では主題を紹介し、どのように始めることができるかを説明します。

--- a/files/ja/web/media/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.md
+++ b/files/ja/web/media/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.md
@@ -1,7 +1,6 @@
 ---
 title: Setting up adaptive streaming media sources
 slug: Web/Media/Audio_and_video_delivery/Setting_up_adaptive_streaming_media_sources
-original_slug: Web/Guide/Audio_and_video_delivery/Setting_up_adaptive_streaming_media_sources
 ---
 
 たとえば、 HTML5 メディア要素内で利用するために、サーバー上の適応型ストリーミングメディアソースを設定するとします。あなたはどうしますか？この記事では、最も一般的な形式である MPEG-DASH と HLS (HTTP Live Streaming) の二つについて見ていきます。

--- a/files/ja/web/media/audio_and_video_manipulation/index.md
+++ b/files/ja/web/media/audio_and_video_manipulation/index.md
@@ -1,7 +1,6 @@
 ---
 title: 音声と動画の加工
 slug: Web/Media/Audio_and_video_manipulation
-original_slug: Web/Guide/Audio_and_video_manipulation
 ---
 
 ウェブのよいところは、複数の技術をまとめて新しいものを作ることができる点です。ネイティブの音声や動画をブラウザー上で利用できるということは、これらのデータストリームを {{htmlelement("canvas")}}、[WebGL](/ja/docs/Web/WebGL)、[Web Audio API](/ja/docs/Web/API/Web_Audio_API) を利用して操作することで、音声や動画に直接変更を加えることができることを意味します。例えば音声にリバーブやコンプレッション効果をかけたり、動画にグレイスケールやセピアのフィルターをかけたりすることができます。この記事では、必要なことを説明するためのリファレンスを提供します。

--- a/files/ja/web/xml/parsing_and_serializing_xml/index.md
+++ b/files/ja/web/xml/parsing_and_serializing_xml/index.md
@@ -1,7 +1,6 @@
 ---
 title: XML のパースとシリアライズ
 slug: Web/XML/Parsing_and_serializing_XML
-original_slug: Web/Guide/Parsing_and_serializing_XML
 ---
 
 <section id="Quick_links">

--- a/files/ja/webassembly/javascript_interface/compile_static/index.md
+++ b/files/ja/webassembly/javascript_interface/compile_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.compile()
 slug: WebAssembly/JavaScript_interface/compile_static
-original_slug: WebAssembly/JavaScript_interface/compile
 ---
 
 {{WebAssemblySidebar}}

--- a/files/ja/webassembly/javascript_interface/compilestreaming_static/index.md
+++ b/files/ja/webassembly/javascript_interface/compilestreaming_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.compileStreaming()
 slug: WebAssembly/JavaScript_interface/compileStreaming_static
-original_slug: WebAssembly/JavaScript_interface/compileStreaming
 ---
 
 {{WebAssemblySidebar}}

--- a/files/ja/webassembly/javascript_interface/instantiate_static/index.md
+++ b/files/ja/webassembly/javascript_interface/instantiate_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.instantiate()
 slug: WebAssembly/JavaScript_interface/instantiate_static
-original_slug: WebAssembly/JavaScript_interface/instantiate
 ---
 
 {{WebAssemblySidebar}}

--- a/files/ja/webassembly/javascript_interface/instantiatestreaming_static/index.md
+++ b/files/ja/webassembly/javascript_interface/instantiatestreaming_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.instantiateStreaming()
 slug: WebAssembly/JavaScript_interface/instantiateStreaming_static
-original_slug: WebAssembly/JavaScript_interface/instantiateStreaming
 ---
 
 {{WebAssemblySidebar}}

--- a/files/ja/webassembly/javascript_interface/module/customsections_static/index.md
+++ b/files/ja/webassembly/javascript_interface/module/customsections_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.Module.customSections()
 slug: WebAssembly/JavaScript_interface/Module/customSections_static
-original_slug: WebAssembly/JavaScript_interface/Module/customSections
 ---
 
 {{WebAssemblySidebar}}

--- a/files/ja/webassembly/javascript_interface/module/exports_static/index.md
+++ b/files/ja/webassembly/javascript_interface/module/exports_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.Module.exports()
 slug: WebAssembly/JavaScript_interface/Module/exports_static
-original_slug: WebAssembly/JavaScript_interface/Module/exports
 ---
 
 {{WebAssemblySidebar}}

--- a/files/ja/webassembly/javascript_interface/module/imports_static/index.md
+++ b/files/ja/webassembly/javascript_interface/module/imports_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.Module.imports()
 slug: WebAssembly/JavaScript_interface/Module/imports_static
-original_slug: WebAssembly/JavaScript_interface/Module/imports
 ---
 
 {{WebAssemblySidebar}}

--- a/files/ja/webassembly/javascript_interface/validate_static/index.md
+++ b/files/ja/webassembly/javascript_interface/validate_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.validate()
 slug: WebAssembly/JavaScript_interface/validate_static
-original_slug: WebAssembly/JavaScript_interface/validate
 ---
 
 {{WebAssemblySidebar}}


### PR DESCRIPTION
### Description

This PR removes unnecessary `original_slug` front matter key from all documents except `conflicting/` and `orphaned/` for `ja` locale.

### Related issues and pull requests

Relates to #14873
