### PR TITLE
[ko] remove unnecessary `original_slug` front matter key

### DIFF
--- a/files/ko/glossary/internationalization/index.md
+++ b/files/ko/glossary/internationalization/index.md
@@ -1,7 +1,6 @@
 ---
 title: 국제화 (internationalization, I18N)
 slug: Glossary/Internationalization
-original_slug: Glossary/I18N
 ---
 
 {{GlossarySidebar}}

--- a/files/ko/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
+++ b/files/ko/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
@@ -1,7 +1,6 @@
 ---
 title: 도형 합성 예제
 slug: Web/API/CanvasRenderingContext2D/globalCompositeOperation
-original_slug: Web/API/Canvas_API/Tutorial/Compositing/Example
 ---
 
 {{DefaultAPISidebar("Canvas API")}}

--- a/files/ko/web/api/console/assert_static/index.md
+++ b/files/ko/web/api/console/assert_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.assert()
 slug: Web/API/console/assert_static
-original_slug: Web/API/console/assert
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/clear_static/index.md
+++ b/files/ko/web/api/console/clear_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.clear()
 slug: Web/API/console/clear_static
-original_slug: Web/API/console/clear
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/count_static/index.md
+++ b/files/ko/web/api/console/count_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.count()
 slug: Web/API/console/count_static
-original_slug: Web/API/console/count
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/countreset_static/index.md
+++ b/files/ko/web/api/console/countreset_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.countReset()
 slug: Web/API/console/countreset_static
-original_slug: Web/API/console/countReset
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/debug_static/index.md
+++ b/files/ko/web/api/console/debug_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.debug()
 slug: Web/API/console/debug_static
-original_slug: Web/API/console/debug
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/dir_static/index.md
+++ b/files/ko/web/api/console/dir_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.dir()
 slug: Web/API/console/dir_static
-original_slug: Web/API/console/dir
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/dirxml_static/index.md
+++ b/files/ko/web/api/console/dirxml_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.dirxml()
 slug: Web/API/console/dirxml_static
-original_slug: Web/API/console/dirxml
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/error_static/index.md
+++ b/files/ko/web/api/console/error_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.error()
 slug: Web/API/console/error_static
-original_slug: Web/API/console/error
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/group_static/index.md
+++ b/files/ko/web/api/console/group_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.group()
 slug: Web/API/console/group_static
-original_slug: Web/API/console/group
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/groupcollapsed_static/index.md
+++ b/files/ko/web/api/console/groupcollapsed_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.groupCollapsed()
 slug: Web/API/console/groupcollapsed_static
-original_slug: Web/API/console/groupCollapsed
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/groupend_static/index.md
+++ b/files/ko/web/api/console/groupend_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.groupEnd()
 slug: Web/API/console/groupend_static
-original_slug: Web/API/console/groupEnd
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/log_static/index.md
+++ b/files/ko/web/api/console/log_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.log()
 slug: Web/API/console/log_static
-original_slug: Web/API/console/log
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/table_static/index.md
+++ b/files/ko/web/api/console/table_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.table()
 slug: Web/API/console/table_static
-original_slug: Web/API/console/table
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/time_static/index.md
+++ b/files/ko/web/api/console/time_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.time()
 slug: Web/API/console/time_static
-original_slug: Web/API/console/time
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/timeend_static/index.md
+++ b/files/ko/web/api/console/timeend_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.timeEnd()
 slug: Web/API/console/timeend_static
-original_slug: Web/API/console/timeEnd
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/timelog_static/index.md
+++ b/files/ko/web/api/console/timelog_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.timeLog()
 slug: Web/API/console/timelog_static
-original_slug: Web/API/console/timeLog
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/trace_static/index.md
+++ b/files/ko/web/api/console/trace_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.trace()
 slug: Web/API/console/trace_static
-original_slug: Web/API/console/trace
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/console/warn_static/index.md
+++ b/files/ko/web/api/console/warn_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.warn()
 slug: Web/API/console/warn_static
-original_slug: Web/API/console/warn
 ---
 
 {{APIRef("Console API")}}

--- a/files/ko/web/api/element/input_event/index.md
+++ b/files/ko/web/api/element/input_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: "HTMLElement: input 이벤트"
 slug: Web/API/Element/input_event
-original_slug: Web/API/HTMLElement/input_event
 ---
 
 {{APIRef}}

--- a/files/ko/web/api/xsltprocessor/index.md
+++ b/files/ko/web/api/xsltprocessor/index.md
@@ -1,7 +1,6 @@
 ---
 title: Using the Mozilla JavaScript interface to XSL Transformations
 slug: Web/API/XSLTProcessor
-original_slug: Web/XSLT/Using_the_Mozilla_JavaScript_interface_to_XSL_Transformations
 ---
 
 이 문서는 Mozilla 1.2의 JavaScript 인터페이스부터 XSLT 처리 엔진(TransforMiiX)까지 설명합니다.

--- a/files/ko/web/css/css_syntax/index.md
+++ b/files/ko/web/css/css_syntax/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS Charsets
 slug: Web/CSS/CSS_syntax
-original_slug: Web/CSS/CSS_charsets
 ---
 
 {{CSSRef}}

--- a/files/ko/web/css/next-sibling_combinator/index.md
+++ b/files/ko/web/css/next-sibling_combinator/index.md
@@ -1,7 +1,6 @@
 ---
 title: 인접 형제 결합자
 slug: Web/CSS/Next-sibling_combinator
-original_slug: Web/CSS/Adjacent_sibling_combinator
 ---
 
 {{CSSRef}}

--- a/files/ko/web/css/subsequent-sibling_combinator/index.md
+++ b/files/ko/web/css/subsequent-sibling_combinator/index.md
@@ -1,7 +1,6 @@
 ---
 title: 일반 형제 결합자
 slug: Web/CSS/Subsequent-sibling_combinator
-original_slug: Web/CSS/General_sibling_combinator
 ---
 
 {{CSSRef}}

--- a/files/ko/web/javascript/reference/classes/private_properties/index.md
+++ b/files/ko/web/javascript/reference/classes/private_properties/index.md
@@ -1,7 +1,6 @@
 ---
 title: Private class fields
 slug: Web/JavaScript/Reference/Classes/Private_properties
-original_slug: Web/JavaScript/Reference/Classes/Private_class_fields
 ---
 
 {{JsSidebar("Classes")}}

--- a/files/ko/web/xml/parsing_and_serializing_xml/index.md
+++ b/files/ko/web/xml/parsing_and_serializing_xml/index.md
@@ -1,7 +1,6 @@
 ---
 title: XML 파싱 및 직렬화
 slug: Web/XML/Parsing_and_serializing_XML
-original_slug: Web/Guide/Parsing_and_serializing_XML
 ---
 
 웹 상에서 XML을 파싱하고 직렬화할 때 사용할 수 있는 객체는 다음과 같습니다.

--- a/files/ko/webassembly/javascript_interface/compile_static/index.md
+++ b/files/ko/webassembly/javascript_interface/compile_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.compile()
 slug: WebAssembly/JavaScript_interface/compile_static
-original_slug: WebAssembly/JavaScript_interface/compile
 ---
 
 {{WebAssemblySidebar}}

--- a/files/ko/webassembly/javascript_interface/compilestreaming_static/index.md
+++ b/files/ko/webassembly/javascript_interface/compilestreaming_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.compileStreaming()
 slug: WebAssembly/JavaScript_interface/compileStreaming_static
-original_slug: WebAssembly/JavaScript_interface/compileStreaming
 ---
 
 {{WebAssemblySidebar}}

--- a/files/ko/webassembly/javascript_interface/instantiate_static/index.md
+++ b/files/ko/webassembly/javascript_interface/instantiate_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.instantiate()
 slug: WebAssembly/JavaScript_interface/instantiate_static
-original_slug: WebAssembly/JavaScript_interface/instantiate
 ---
 
 {{WebAssemblySidebar}}

--- a/files/ko/webassembly/javascript_interface/instantiatestreaming_static/index.md
+++ b/files/ko/webassembly/javascript_interface/instantiatestreaming_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.instantiateStreaming()
 slug: WebAssembly/JavaScript_interface/instantiateStreaming_static
-original_slug: WebAssembly/JavaScript_interface/instantiateStreaming
 ---
 
 {{WebAssemblySidebar}}

--- a/files/ko/webassembly/javascript_interface/validate_static/index.md
+++ b/files/ko/webassembly/javascript_interface/validate_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly.validate()
 slug: WebAssembly/JavaScript_interface/validate_static
-original_slug: WebAssembly/JavaScript_interface/validate
 ---
 
 {{WebAssemblySidebar}}


### PR DESCRIPTION
### Description

This PR removes unnecessary `original_slug` front matter key from all documents except `conflicting/` and `orphaned/` for `ko` locale.

### Related issues and pull requests

Relates to #14873
