### PR TITLE
[pt-br] remove unnecessary `original_slug` front matter key

### DIFF
--- a/files/pt-br/learn/javascript/client-side_web_apis/fetching_data/index.md
+++ b/files/pt-br/learn/javascript/client-side_web_apis/fetching_data/index.md
@@ -1,7 +1,6 @@
 ---
 title: AJAX
 slug: Learn/JavaScript/Client-side_web_APIs/Fetching_data
-original_slug: Web/Guide/AJAX
 ---
 
 **[Primeiros passos](/pt-BR/docs/AJAX/Getting_Started)** Uma introdução ao AJAX.

--- a/files/pt-br/mdn/community/contributing/index.md
+++ b/files/pt-br/mdn/community/contributing/index.md
@@ -1,7 +1,6 @@
 ---
 title: Contribuindo para o MDN
 slug: MDN/Community/Contributing
-original_slug: MDN/Contribute
 ---
 
 {{MDNSidebar}}

--- a/files/pt-br/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
+++ b/files/pt-br/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
@@ -1,7 +1,6 @@
 ---
 title: Exemplo de Composição
 slug: Web/API/CanvasRenderingContext2D/globalCompositeOperation
-original_slug: Web/API/Canvas_API/Tutorial/Compositing/Example
 ---
 
 {{DefaultAPISidebar("Canvas API")}}

--- a/files/pt-br/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
+++ b/files/pt-br/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
@@ -7,7 +7,7 @@ slug: Web/API/CanvasRenderingContext2D/globalCompositeOperation
 
 Esse exemplo demonstra várias [operações de composição](/pt-BR/docs/Web/API/CanvasRenderingContext2D/globalCompositeOperation). A saída se parece assim:
 
-{{ EmbedLiveSample('Exemplo_de_composição', '', '7240px', '', 'Web/Guide/HTML/Canvas_tutorial/Compositing/Exemplo') }}
+{{EmbedLiveSample("Exemplo_de_composição", "100%", 7250)}}
 
 ## Exemplo de composição
 

--- a/files/pt-br/web/api/console/assert_static/index.md
+++ b/files/pt-br/web/api/console/assert_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.assert()
 slug: Web/API/console/assert_static
-original_slug: Web/API/console/assert
 ---
 
 {{APIRef("Console API")}}

--- a/files/pt-br/web/api/console/clear_static/index.md
+++ b/files/pt-br/web/api/console/clear_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console.clear()
 slug: Web/API/console/clear_static
-original_slug: Web/API/console/clear
 ---
 
 {{APIRef("Console API")}}

--- a/files/pt-br/web/api/console/count_static/index.md
+++ b/files/pt-br/web/api/console/count_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.count()
 slug: Web/API/console/count_static
-original_slug: Web/API/console/count
 ---
 
 {{APIRef("Console API")}}

--- a/files/pt-br/web/api/console/dir_static/index.md
+++ b/files/pt-br/web/api/console/dir_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.dir()
 slug: Web/API/console/dir_static
-original_slug: Web/API/console/dir
 ---
 
 {{ APIRef("Console API") }}{{Non-standard_header}}

--- a/files/pt-br/web/api/console/error_static/index.md
+++ b/files/pt-br/web/api/console/error_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.error()
 slug: Web/API/console/error_static
-original_slug: Web/API/console/error
 ---
 
 {{APIRef("Console API")}}{{Non-standard_header}}

--- a/files/pt-br/web/api/console/info_static/index.md
+++ b/files/pt-br/web/api/console/info_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.info()
 slug: Web/API/console/info_static
-original_slug: Web/API/console/info
 ---
 
 {{APIRef("Console API")}}{{Non-standard_header}}

--- a/files/pt-br/web/api/console/log_static/index.md
+++ b/files/pt-br/web/api/console/log_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.log()
 slug: Web/API/console/log_static
-original_slug: Web/API/console/log
 ---
 
 {{APIRef("Console API")}}{{Non-standard_header}}

--- a/files/pt-br/web/api/console/table_static/index.md
+++ b/files/pt-br/web/api/console/table_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.table()
 slug: Web/API/console/table_static
-original_slug: Web/API/console/table
 ---
 
 {{APIRef("Console API")}}

--- a/files/pt-br/web/api/console/time_static/index.md
+++ b/files/pt-br/web/api/console/time_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.time()
 slug: Web/API/console/time_static
-original_slug: Web/API/console/time
 ---
 
 {{ APIRef("Console API") }}{{Non-standard_header}}

--- a/files/pt-br/web/api/console/timeend_static/index.md
+++ b/files/pt-br/web/api/console/timeend_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.timeEnd()
 slug: Web/API/console/timeend_static
-original_slug: Web/API/console/timeEnd
 ---
 
 {{APIRef("Console API")}}{{Non-standard_header}}

--- a/files/pt-br/web/api/console/timestamp_static/index.md
+++ b/files/pt-br/web/api/console/timestamp_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.timeStamp()
 slug: Web/API/console/timestamp_static
-original_slug: Web/API/console/timeStamp
 ---
 
 {{ APIRef("Console API") }}{{Non-standard_header}}

--- a/files/pt-br/web/api/console/warn_static/index.md
+++ b/files/pt-br/web/api/console/warn_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.warn()
 slug: Web/API/console/warn_static
-original_slug: Web/API/console/warn
 ---
 
 {{APIRef("Console API")}}{{non-standard_header}}

--- a/files/pt-br/web/api/element/input_event/index.md
+++ b/files/pt-br/web/api/element/input_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: input
 slug: Web/API/Element/input_event
-original_slug: Web/API/HTMLElement/input_event
 ---
 
 O evento `input` do DOM é disparado sincronicamente quando o valor de um elemento {{HTMLElement("input")}}, {{HTMLElement("select")}}, ou {{HTMLElement("textarea")}} é alterado. (Para elementos input com `type=checkbox` ou `type=radio`, o evento `input` não é disparado quando o usuário clica no elemento, porque o valor do atributo não é alterado.) Além disso, o evento é disparado no [`contenteditable`](/pt-BR/docs/Web/API/HTMLElement/contentEditable) editors quando o seu conteúdo é alterado. Nesse caso, O alvo do evento é o elemento host da edição. Se houver dois ou mais elementos que tenha `contenteditable` como true, o "host de edição" é o elemento antepassado mais próximo cujo pai não é editável. Similarmente, ele também é disparado no element raiz do [`designMode`](/pt-BR/docs/Web/API/Document/designMode) editors.

--- a/files/pt-br/web/api/history_api/working_with_the_history_api/index.md
+++ b/files/pt-br/web/api/history_api/working_with_the_history_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Exemplo de navegação Ajax
 slug: Web/API/History_API/Working_with_the_History_API
-original_slug: Web/API/History_API/Example
 ---
 
 Esse é um exemplo de um web site em AJAX web site composto por apenas três páginas (_first_page.php_, _second_page.php_ e _third_page.php_). Para ver como funciona, crie os arquivos a seguir (ou _git clone_ [https://github.com/giabao/mdn-ajax-nav-example.git](https://github.com/giabao/mdn-ajax-nav-example) ):

--- a/files/pt-br/web/api/xmlhttprequest_api/synchronous_and_asynchronous_requests/index.md
+++ b/files/pt-br/web/api/xmlhttprequest_api/synchronous_and_asynchronous_requests/index.md
@@ -1,7 +1,6 @@
 ---
 title: Requisições síncronas e assíncronas
 slug: Web/API/XMLHttpRequest_API/Synchronous_and_Asynchronous_Requests
-original_slug: Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests
 ---
 
 `XMLHttpRequest` suporta comunicações síncronas e assíncronas. No geral, entretando, requisições assíncronas devem prevalecer sobre requisições síncronas por questões de performance.

--- a/files/pt-br/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
+++ b/files/pt-br/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
@@ -1,7 +1,6 @@
 ---
 title: Usando XMLHttpRequest
 slug: Web/API/XMLHttpRequest_API/Using_XMLHttpRequest
-original_slug: Web/API/XMLHttpRequest/Using_XMLHttpRequest
 ---
 
 [`XMLHttpRequest`](/pt-BR/docs/DOM/XMLHttpRequest) torna o envio de requisições HTTP muito fácil. Basta criar uma instância do objeto, abrir uma url e enviar uma requisição. O [status](/pt-BR/docs/HTTP/HTTP_response_codes) [HTTP](/pt-BR/docs/HTTP/HTTP_response_codes)do resultado assim como o seu conteúdo estarão disponíveis quando a transação for completada. Esta página descreve alguns casos comuns de uso desse poderoso objeto JavaScript.

--- a/files/pt-br/web/api/xsltprocessor/index.md
+++ b/files/pt-br/web/api/xsltprocessor/index.md
@@ -1,7 +1,6 @@
 ---
 title: Exemplo Avançado
 slug: Web/API/XSLTProcessor
-original_slug: Web/XSLT/XSLT_JS_interface_in_Gecko/Advanced_Example
 ---
 
 ## Exemplo Avançado

--- a/files/pt-br/web/css/css_media_queries/printing/index.md
+++ b/files/pt-br/web/css/css_media_queries/printing/index.md
@@ -1,7 +1,6 @@
 ---
 title: Printing
 slug: Web/CSS/CSS_media_queries/Printing
-original_slug: Web/Guide/Printing
 ---
 
 Pode haver momentos em que seu site ou aplicação queira melhorar a experiência do usuário quando imprime um conteúdo. Existem diversos cenários possíveis:

--- a/files/pt-br/web/css/subsequent-sibling_combinator/index.md
+++ b/files/pt-br/web/css/subsequent-sibling_combinator/index.md
@@ -1,7 +1,6 @@
 ---
 title: General sibling selectors
 slug: Web/CSS/Subsequent-sibling_combinator
-original_slug: Web/CSS/General_sibling_combinator
 ---
 
 {{CSSRef}}

--- a/files/pt-br/web/performance/index.md
+++ b/files/pt-br/web/performance/index.md
@@ -1,7 +1,6 @@
 ---
 title: Otimização e Performance
 slug: Web/Performance
-original_slug: Web/Guide/Performance
 ---
 
 Quando construímos aplicações para web e sites modernos, é importante fazer seu conteúdo funcionar bem. Isso é, faze-lo funcionar eficientemente e rápido. Isso permite que ele funcione com eficaz tanto para usuários de computadores mais poderosos quanto para dispositivos portáteis com menos poder. Existem diversas ferramentas disponíveis para checar a performance de um site ou blog. As mais notáveis seguem abaixo:


### PR DESCRIPTION
### Description

This PR removes unnecessary `original_slug` front matter key from all documents except `conflicting/` and `orphaned/` for `pt-BR` locale.

Also fixes `EmbedLiveSample` macro in `Web/API/CanvasRenderingContext2D/globalCompositeOperation`.

### Related issues and pull requests

Relates to #14873
