### PR TITLE
[zh-cn] remove unnecessary `original_slug` front matter key

### DIFF
--- a/files/zh-cn/web/api/console/error_static/index.md
+++ b/files/zh-cn/web/api/console/error_static/index.md
@@ -1,7 +1,6 @@
 ---
 title: console：error() 静态方法
 slug: Web/API/console/error_static
-original_slug: Web/API/console/error
 ---
 
 {{APIRef("Console API")}}

--- a/files/zh-cn/web/api/screendetailed/availleft/index.md
+++ b/files/zh-cn/web/api/screendetailed/availleft/index.md
@@ -1,7 +1,6 @@
 ---
 title: Screen.availLeft
 slug: Web/API/ScreenDetailed/availLeft
-original_slug: Web/API/Screen/availLeft
 ---
 
 {{ ApiRef() }}

--- a/files/zh-cn/web/api/screendetailed/availtop/index.md
+++ b/files/zh-cn/web/api/screendetailed/availtop/index.md
@@ -1,7 +1,6 @@
 ---
 title: Screen.availTop
 slug: Web/API/ScreenDetailed/availTop
-original_slug: Web/API/Screen/availTop
 ---
 
 {{ ApiRef() }}


### PR DESCRIPTION
### Description

This PR removes unnecessary `original_slug` front matter key from all documents except `conflicting/` and `orphaned/` for `zh-CN` locale.

### Related issues and pull requests

Relates to #14873
