### PR TITLE
[zh-tw] remove unnecessary `original_slug` front matter key

### DIFF
--- a/files/zh-tw/learn/javascript/client-side_web_apis/fetching_data/index.md
+++ b/files/zh-tw/learn/javascript/client-side_web_apis/fetching_data/index.md
@@ -1,7 +1,6 @@
 ---
 title: Ajax
 slug: Learn/JavaScript/Client-side_web_APIs/Fetching_data
-original_slug: Web/Guide/AJAX
 ---
 
 <section id="Quick_links">

--- a/files/zh-tw/learn/tools_and_testing/cross_browser_testing/javascript/index.md
+++ b/files/zh-tw/learn/tools_and_testing/cross_browser_testing/javascript/index.md
@@ -1,7 +1,6 @@
 ---
 title: Writing forward-compatible websites
 slug: Learn/Tools_and_testing/Cross_browser_testing/JavaScript
-original_slug: Web/Guide/Writing_forward-compatible_websites
 ---
 
 這個頁面將解釋如何撰寫在新的瀏覽器版本發布時不會遭受毀損的網頁。


### PR DESCRIPTION
### Description

This PR removes unnecessary `original_slug` front matter key from all documents except `conflicting/` and `orphaned/` for `zh-TW` locale.

### Related issues and pull requests

Relates to #14873
