### PR TITLE
ja: There is no need to describe the scoped attribute of the style element.

### DIFF
--- a/files/ja/web/html/element/style/index.md
+++ b/files/ja/web/html/element/style/index.md
@@ -145,9 +145,6 @@ l10n:
       <td>
         <a href="/ja/docs/Web/HTML/Content_categories#メタデータコンテンツ"
           >メタデータコンテンツ</a
-        >、 <code>scoped</code> 属性が提供された場合:
-        <a href="/ja/docs/Web/HTML/Content_categories#フローコンテンツ"
-          >フローコンテンツ</a
         >
       </td>
     </tr>


### PR DESCRIPTION
style要素の scoped属性がついているときの コンテンツカテゴリー の説明は不要です。

### Description

There is no need to describe the scoped attribute of the style element.
Removed description of behavior when scoped attribute is attached to content category item.

### Motivation

The scoped attribute is no longer recommended, and there is no explanation as an attribute of the style element.

### Additional details

https://html.spec.whatwg.org/multipage/semantics.html#the-style-element
※ not found scoped attribute description.
