### PR TITLE
ja: `数r` is a typo for `する`.

### DIFF
--- a/files/ja/web/css/css_nesting/nesting_at-rules/index.md
+++ b/files/ja/web/css/css_nesting/nesting_at-rules/index.md
@@ -99,7 +99,7 @@ l10n:
 
 ### カスケードレイヤーの入れ子 (`@layer`)
 
-[カスケードレイヤー](/ja/docs/Web/CSS/@layer)は[子レイヤーを作成](/ja/docs/Web/CSS/@layer#nesting_layers)するために入れ子に数rことができます。これらは `.` （ドット）で接続します。
+[カスケードレイヤー](/ja/docs/Web/CSS/@layer)は[子レイヤーを作成](/ja/docs/Web/CSS/@layer#nesting_layers)するために入れ子にすることができます。これらは `.` （ドット）で接続します。
 
 #### 親＆子レイヤーの定義
 


### PR DESCRIPTION
### Description

`数r` is a typo for `する`.

### Motivation

To correct typos