### PR TITLE
[ru] add `Glossary/CORS-safelisted_response_header` translation

### DIFF
--- a/files/ru/glossary/cors-safelisted_response_header/index.md
+++ b/files/ru/glossary/cors-safelisted_response_header/index.md
@@ -1,0 +1,46 @@
+---
+title: CORS-безопасный заголовок ответа
+slug: Glossary/CORS-safelisted_response_header
+l10n:
+  sourceCommit: ada5fa5ef15eadd44b549ecf906423b4a2092f34
+---
+
+{{GlossarySidebar}}
+
+_CORS-безопасный заголовок ответа_ — это [HTTP-заголовок](/ru/docs/Web/HTTP/Headers) в ответе [CORS](/ru/docs/Web/HTTP/CORS), который считается _безопасным_ для доступа к клиентским скриптам. Веб-страницам доступны только заголовки ответа из списка безопасных.
+
+По умолчанию этот список включает следующие заголовки ответов:
+
+- {{HTTPHeader("Cache-Control")}}
+- {{HTTPHeader("Content-Language")}}
+- {{HTTPHeader("Content-Length")}}
+- {{HTTPHeader("Content-Type")}}
+- {{HTTPHeader("Expires")}}
+- {{HTTPHeader("Last-Modified")}}
+- {{HTTPHeader("Pragma")}}
+
+Дополнительные заголовки можно добавить с помощью {{HTTPHeader("Access-Control-Expose-Headers")}}.
+
+> **Примечание:** {{HTTPHeader("Content-Length")}} не входил в исходный набор безопасных заголовков [[ref](https://github.com/whatwg/fetch/pull/626)]
+
+## Примеры
+
+### Расширение безопасного списка
+
+Расширить список CORS-безопасных заголовков ответа можно используя заголовок {{HTTPHeader("Access-Control-Expose-Headers")}}:
+
+```http
+Access-Control-Expose-Headers: X-Custom-Header, Content-Encoding
+```
+
+## Смотрите также
+
+- [HTTP](/ru/docs/Web/HTTP)
+- [Заголовки HTTP](/ru/docs/Web/HTTP/Headers)
+- {{HTTPHeader("Access-Control-Expose-Headers")}}
+- [Глоссарий](/ru/docs/Glossary)
+
+  - {{Glossary("CORS")}}
+  - {{Glossary("CORS-safelisted_request_header", "CORS-безопасный заголовок запроса")}}
+  - {{Glossary("Forbidden header name", "Запрещённое имя заголовка")}}
+  - {{Glossary("Request header", "Заголовок запроса")}}

--- a/files/ru/glossary/simple_response_header/index.md
+++ b/files/ru/glossary/simple_response_header/index.md
@@ -7,4 +7,4 @@ l10n:
 
 {{GlossarySidebar}}
 
-Старый термин для {{Glossary("CORS-safelisted response header", "CORS-безопасный заголовок ответа")}}.
+Старое название {{Glossary("CORS-safelisted response header", "CORS-безопасного заголовка ответа")}}.

--- a/files/ru/glossary/simple_response_header/index.md
+++ b/files/ru/glossary/simple_response_header/index.md
@@ -1,0 +1,10 @@
+---
+title: Простой заголовок ответа
+slug: Glossary/Simple_response_header
+l10n:
+  sourceCommit: ada5fa5ef15eadd44b549ecf906423b4a2092f34
+---
+
+{{GlossarySidebar}}
+
+Старый термин для {{Glossary("CORS-safelisted response header", "CORS-безопасный заголовок ответа")}}.


### PR DESCRIPTION
### Description

This PR adds `Glossary/CORS-safelisted_response_header` and `Glossary/Simple_response_header` translations for `ru` locale
