### PR TITLE
[ru] add `Glossary/CORS-safelisted_request_header` translation

### DIFF
--- a/files/ru/glossary/cors-safelisted_request_header/index.md
+++ b/files/ru/glossary/cors-safelisted_request_header/index.md
@@ -1,0 +1,36 @@
+---
+title: CORS-безопасный заголовок запроса
+slug: Glossary/CORS-safelisted_request_header
+l10n:
+  sourceCommit: 5e9631df85d021e84133e14f4bd3c712e4f8fe08
+---
+
+{{GlossarySidebar}}
+
+[CORS-безопасный заголовок запроса](https://fetch.spec.whatwg.org/#cors-safelisted-request-header) — это один из следующих [HTTP-заголовков](/ru/docs/Web/HTTP/Headers):
+
+- {{HTTPHeader("Accept")}}
+- {{HTTPHeader("Accept-Language")}}
+- {{HTTPHeader("Content-Language")}}
+- {{HTTPHeader("Content-Type")}}
+- {{HTTPHeader("Range")}}
+
+Если запрос содержит только эти заголовки (и значения, соответствующие дополнительным требованиям, изложенным ниже), запросу не требуется отправлять {{Glossary("preflight request", "предварительный запрос")}} в контексте [CORS](/ru/docs/Glossary/CORS).
+
+Дополнительные заголовки можно добавить в список безопасных, используя заголовок {{HTTPHeader("Access-Control-Allow-Headers")}}, а также необходимо перечислить указанные выше заголовки, чтобы обойти следующие дополнительные ограничения.
+
+## Дополнительные ограничения
+
+CORS-безопасные заголовки запроса должны соответствовать следующим требованиям:
+
+- {{HTTPHeader("Accept-Language")}} и {{HTTPHeader("Content-Language")}} должны содержать значения, состоящие только из `0-9`, `A-Z`, `a-z`, пробелов и `*,-.;=`.
+- {{HTTPHeader("Accept")}} и {{HTTPHeader("Content-Type")}} не должны содержать _CORS-небезопасные байты в заголовках запроса_: `0x00-0x1F` (за исключением `0x09 (HT)`, который допускается), `"():<>?@[\]{}` и `0x7F (DEL)`.
+- {{HTTPHeader("Content-Type")}} должен иметь один из следующих MIME-типов: `application/x-www-form-urlencoded`, `multipart/form-data` или `text/plain`.
+- {{HTTPHeader("Range")}} должен иметь однобайтовое значение в виде `bytes=[0-9]+-[0-9]*`. Смотрите документацию заголовка {{HTTPHeader("Range")}} для более подробной информации.
+- Для значения любого заголовка не должна превышать 128.
+
+## Смотрите также
+
+- {{Glossary("CORS-safelisted response header", "CORS-безопасный заголовок ответа")}}
+- {{Glossary("Forbidden header name", "Запрещённое имя заголовка")}}
+- {{Glossary("Request header", "Заголовок запроса")}}

--- a/files/ru/glossary/simple_header/index.md
+++ b/files/ru/glossary/simple_header/index.md
@@ -7,4 +7,4 @@ l10n:
 
 {{GlossarySidebar}}
 
-Старый термин для {{Glossary("CORS-safelisted request header", "CORS-безопасный заголовок запроса")}}.
+Старое название {{Glossary("CORS-safelisted request header", "CORS-безопасного заголовка запроса")}}.

--- a/files/ru/glossary/simple_header/index.md
+++ b/files/ru/glossary/simple_header/index.md
@@ -1,30 +1,10 @@
 ---
 title: Простой заголовок
 slug: Glossary/Simple_header
+l10n:
+  sourceCommit: ada5fa5ef15eadd44b549ecf906423b4a2092f34
 ---
 
 {{GlossarySidebar}}
 
-_Простой заголовок (или заголовок запроса с поддержкой безопасности CORS_) - это один из следующих [HTTP заголовков](/ru/docs/Web/HTTP/Заголовки):
-
-- {{HTTPHeader("Accept")}},
-- {{HTTPHeader("Accept-Language")}},
-- {{HTTPHeader("Content-Language")}},
-- {{HTTPHeader("Content-Type")}} с MIME-типом, найденным в этом значении (исключая параметры), либо `application/x-www-form-urlencoded`, `multipart/form-data` или `text/plain`.
-
-Или один из этих клиентских заголовков:
-
-- {{HTTPHeader("DPR")}}
-- {{HTTPHeader("Downlink")}}
-- {{HTTPHeader("Save-Data")}}
-- {{HTTPHeader("Viewport-Width")}}
-- {{HTTPHeader("Width")}}
-
-Если они содержат только простые заголовки, запросы считаются простыми и не нужно отправлять {{glossary("preflight request")}} в контексте {{glossary("CORS")}}.
-
-## Смотрите также
-
-- [HTTP заголовки](/ru/docs/Web/HTTP/Заголовки)
-- {{Glossary("Simple response header")}}
-- {{Glossary("Forbidden header name")}}
-- {{Glossary("Request header")}}
+Старый термин для {{Glossary("CORS-safelisted request header", "CORS-безопасный заголовок запроса")}}.


### PR DESCRIPTION
### Description

This PR adds `Glossary/CORS-safelisted_request_header` and `Glossary/Simple_header` translations for `ru` locale
