### PR TITLE
fr, ja, ko: update glossary/code_splitting

### DIFF
--- a/files/fr/glossary/code_splitting/index.md
+++ b/files/fr/glossary/code_splitting/index.md
@@ -13,7 +13,6 @@ Le code splitting est une fonctionnalité prise en charge par les contructeurs (
 
 ## Voir aussi
 
-- Regroupement
 - [Lazy loading](/fr/docs/Web/Performance/Lazy_loading)
 - [HTTP/2](/fr/docs/Glossary/HTTP_2)
 - [Tree shaking](/fr/docs/Glossary/Tree_shaking)

--- a/files/ja/glossary/code_splitting/index.md
+++ b/files/ja/glossary/code_splitting/index.md
@@ -13,7 +13,6 @@ slug: Glossary/Code_splitting
 
 ## 関連項目
 
-- Bundling
 - [Lazy loading](/ja/docs/Learn/Performance/Lazy_loading)
 - [HTTP/2](/ja/docs/Glossary/HTTP_2)
 - [Tree shaking](/ja/docs/Glossary/Tree_shaking)

--- a/files/ko/glossary/code_splitting/index.md
+++ b/files/ko/glossary/code_splitting/index.md
@@ -2,7 +2,7 @@
 title: Code splitting (코드분할)
 slug: Glossary/Code_splitting
 l10n:
-  sourceCommit: ada5fa5ef15eadd44b549ecf906423b4a2092f34
+  sourceCommit: d821201936ea3f67634381b2086998ebfc29f39c
 ---
 
 {{GlossarySidebar}}
@@ -15,7 +15,6 @@ l10n:
 
 ## 같이 보기
 
-- 번들링(Bundling)
 - [지연 로딩](/ko/docs/Web/Performance/Lazy_loading)
 - [HTTP/2](/ko/docs/Glossary/HTTP_2)
 - [트리 쉐이킹(Tree shaking)](/ko/docs/Glossary/Tree_shaking)


### PR DESCRIPTION
linted one url. sync with mdn/content#33404

related hash: d821201936ea3f67634381b2086998ebfc29f39c