### PR TITLE
[ko] remove broken external link to `thimble.mozilla.org`

### DIFF
--- a/files/ko/learn/accessibility/index.md
+++ b/files/ko/learn/accessibility/index.md
@@ -13,7 +13,7 @@ slug: Learn/Accessibility
 
 > **참고:**
 >
-> 당신은 당신이 당신의 자신의 파일을 생성 할 수 있는 기능이 없는 컴퓨터 / 태블릿 / 다른 장치에서 작업하는 경우, 당신은 [JSBin](http://jsbin.com/) 또는 [Thimble](https://thimble.mozilla.org/) 같은 온라인 코딩 프로그램에서 코드 예제의 대부분을 테스트 할 수 있습니다.
+> 당신은 당신이 당신의 자신의 파일을 생성 할 수 있는 기능이 없는 컴퓨터 / 태블릿 / 다른 장치에서 작업하는 경우, 당신은 [JSBin](https://jsbin.com/) 또는 [Glitch](https://glitch.com/) 같은 온라인 코딩 프로그램에서 코드 예제의 대부분을 테스트 할 수 있습니다.
 
 ## 가이드
 

--- a/files/ko/learn/css/building_blocks/index.md
+++ b/files/ko/learn/css/building_blocks/index.md
@@ -18,7 +18,7 @@ slug: Learn/CSS/Building_blocks
 3. [HTML 소개](/ko/docs/Learn/HTML/Introduction_to_HTML) 과목에서 설명한 HTML 에 대한 기본적인 친숙성.
 4. [CSS 첫 번째 단계](/ko/docs/Learn/CSS/First_steps) 과목에서 논의된 CSS 의 기본 사항에 대한 이해.
 
-> **참고:** 자신의 파일을 만들 수 없는 컴퓨터/태블릿/기타 장치에서 작업하는 경우, [JSBin](http://jsbin.com/) 또는 [Thimble](https://thimble.mozilla.org/) 와 같은 온라인 코딩 프로그램에서 대부분의 코드 예제를 시험해 볼 수 있습니다.
+> **참고:** 자신의 파일을 만들 수 없는 컴퓨터/태블릿/기타 장치에서 작업하는 경우, [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/) 또는 [Glitch](https://glitch.com/) 와 같은 온라인 코딩 프로그램에서 대부분의 코드 예제를 시험해 볼 수 있습니다.
 
 ## 안내
 

--- a/files/ko/learn/css/css_layout/index.md
+++ b/files/ko/learn/css/css_layout/index.md
@@ -17,7 +17,7 @@ l10n:
 2. [CSS 소개](/ko/docs/Learn/CSS/Introduction_to_CSS) 과정에서 논의한 대로 CSS 기본 사항에 대해 익숙해야 합니다.
 3. [박스 스타일 지정](/ko/docs/Learn/CSS/Styling_boxes) 방법에 대한 이해가 있어야 합니다.
 
-> **참고:** 직접 파일을 생성할 수 없는 컴퓨터/태블릿/기타 장치에서 작업하고 있는 경우, [JSBin](http://jsbin.com/)나 [Glitch](https://glitch.com/)과 같은 온라인 코딩 프로그램에서 코드 예제를 시험해 볼 수 있습니다.
+> **참고:** 직접 파일을 생성할 수 없는 컴퓨터/태블릿/기타 장치에서 작업하고 있는 경우, [JSBin](https://jsbin.com/)나 [Glitch](https://glitch.com/)과 같은 온라인 코딩 프로그램에서 코드 예제를 시험해 볼 수 있습니다.
 
 ## 안내서
 

--- a/files/ko/learn/css/first_steps/index.md
+++ b/files/ko/learn/css/first_steps/index.md
@@ -15,7 +15,7 @@ CSS (Cascading Style Sheets) 는 콘텐츠의 글꼴, 색상, 크기 및 간격�
 2. [기본 소프트웨어 설치](/ko/docs/Learn/Getting_started_with_the_web/Installing_basic_software) 에서 자세히 설명한 대로 설정된 기본 작업 환경과 [파일 다루기](/ko/docs/Learn/Getting_started_with_the_web/Dealing_with_files) 에서 자세히 설명한 대로 파일을 생성하고 관리하는 방법을 이해합니다.
 3. [HTML 소개](/ko/docs/Learn/HTML/Introduction_to_HTML) 에서 설명한 바와 같이 HTML에 대한 기본적인 친숙성입니다.
 
-> **참고:** 자신의 파일을 만들 수 없는 컴퓨터/태블릿/기타 장치에서 작업하는 경우, [JSBin](http://jsbin.com/) 또는 [Glitch](https://glitch.com/) 와 같은 온라인 코딩 프로그램에서 코드 예제를 시험해 볼 수 있습니다.
+> **참고:** 자신의 파일을 만들 수 없는 컴퓨터/태블릿/기타 장치에서 작업하는 경우, [JSBin](https://jsbin.com/) 또는 [Glitch](https://glitch.com/) 와 같은 온라인 코딩 프로그램에서 코드 예제를 시험해 볼 수 있습니다.
 
 ## 안내
 

--- a/files/ko/learn/css/styling_text/index.md
+++ b/files/ko/learn/css/styling_text/index.md
@@ -11,7 +11,7 @@ CSS 기초가 어느 정도 완성되었다면, 여러분이 집중해야 할 �
 
 이 강의를 시작하기 전에, [HTML 소개](/ko/docs/Learn/HTML/Introduction_to_HTML) 에서 설명한대로 이미 HTML 에 대해 잘 알고 있어야하며, [CSS 소개](/ko/docs/Learn/CSS/Introduction_to_CSS) 에서 설명한대로 CSS 기본 사항에 익숙해야합니다.
 
-> **참고:** 자신의 파일을 만들 수 없는 컴퓨터/태블릿/기타 장치에서 작업하는 경우, [JSBin](http://jsbin.com/), [CodePen](https://codepen.io/) 또는 [Thimble](https://thimble.mozilla.org/) 와 같은 온라인 코딩 프로그램에서 대부분의 코드 예제를 시험해 볼 수 있습니다.
+> **참고:** 자신의 파일을 만들 수 없는 컴퓨터/태블릿/기타 장치에서 작업하는 경우, [JSBin](https://jsbin.com/) 또는 [Glitch](https://glitch.com/) 와 같은 온라인 코딩 프로그램에서 대부분의 코드 예제를 시험해 볼 수 있습니다.
 
 ## 안내
 

--- a/files/ko/learn/getting_started_with_the_web/publishing_your_website/index.md
+++ b/files/ko/learn/getting_started_with_the_web/publishing_your_website/index.md
@@ -50,7 +50,7 @@ HTML, CSS 그리고 JavaScript 를 입력할 수 있게 하고 웹사이트로 �
 
 - [JSFiddle](https://jsfiddle.net/)
 - [Thimble](https://thimble.webmaker.org/)
-- [JSBin](http://jsbin.com/)
+- [JSBin](https://jsbin.com/)
 
 ![](jsbin-screen.png)
 

--- a/files/ko/learn/html/howto/use_data_attributes/index.md
+++ b/files/ko/learn/html/howto/use_data_attributes/index.md
@@ -62,9 +62,9 @@ article[data-columns="4"] {
 }
 ```
 
-[JSBin 예제](http://jsbin.com/ujiday/2/edit)에서 함께 작동하는 것을 볼 수 있습니다.
+[JSBin 예제](https://jsbin.com/ujiday/2/edit)에서 함께 작동하는 것을 볼 수 있습니다.
 
-데이터 속성들은 게임 점수와 같이 계속 변하는 정보도 저장할 수 있습니다. CSS 선택자와 JavaScript 접근을 이용해서, display 규칙을 사용하지 않고도 훌륭한 효과를 만들 수도 있습니다. 생성된 content와 CSS transition의 예시를 보려면 [이 screencast](http://www.youtube.com/watch?v=On_WyUB1gOk)를 확인하세요([JSBin 예제](http://jsbin.com/atawaz/3/edit)).
+데이터 속성들은 게임 점수와 같이 계속 변하는 정보도 저장할 수 있습니다. CSS 선택자와 JavaScript 접근을 이용해서, display 규칙을 사용하지 않고도 훌륭한 효과를 만들 수도 있습니다. 생성된 content와 CSS transition의 예시를 보려면 [이 screencast](http://www.youtube.com/watch?v=On_WyUB1gOk)를 확인하세요([JSBin 예제](https://jsbin.com/atawaz/3/edit)).
 
 데이터 값은 문자열입니다. 스타일을 적용하려면 숫자 값은 선택자에 따옴표 안에 써주어야 합니다.
 

--- a/files/ko/learn/html/introduction_to_html/index.md
+++ b/files/ko/learn/html/introduction_to_html/index.md
@@ -13,7 +13,7 @@ l10n:
 
 이번 과정을 시작하기 전에, HTML에 대한 사전 지식은 필요하지 않습니다만, 기본적으로 컴퓨터 사용에 친숙해야 하고, 웹사이트의 콘텐츠를 탐색하는 정도의 웹을 사용할 줄 알아야 합니다. [기본 소프트웨어 설치](/ko/docs/Learn/Getting_started_with_the_web/Installing_basic_software)에 있는 기본적인 작업 환경이 구축되어 있어야 하고, [파일 다루기](/ko/docs/Learn/Getting_started_with_the_web/Dealing_with_files)에 있는 파일을 생성하고 관리하는 방법을 이해하고 있어야 합니다. 이 두가지 내용은 [웹 시작하기](/ko/docs/Learn/Getting_started_with_the_web)를 위한 초급 과정입니다.
 
-> **참고:** 혹시, 파일을 생성하기 힘든 컴퓨터/테블릿 혹은 다른 기기에서 작업한다면, [JSBin](http://jsbin.com/) 이나 [Thimble](https://thimble.mozilla.org/) 같은 온라인 코딩 프로그램을 이용하여 대부분의 코드 예제를 작성해 볼 수 있습니다.
+> **참고:** 혹시, 파일을 생성하기 힘든 컴퓨터/테블릿 혹은 다른 기기에서 작업한다면, [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/) 이나 [Glitch](https://glitch.com/) 같은 온라인 코딩 프로그램을 이용하여 대부분의 코드 예제를 작성해 볼 수 있습니다.
 
 > **알림:**
 >

--- a/files/ko/learn/html/tables/index.md
+++ b/files/ko/learn/html/tables/index.md
@@ -11,7 +11,7 @@ HTML에서 매우 일반적인 작업으로 표 형식의 데이터를 구조화
 
 이 모듈을 시작하기 전에, 당신은 이미 HTML의 기본 지식을 가지고 있어야 합니다. — [Introduction to HTML](/ko/docs/Learn/HTML/Introduction_to_HTML).
 
-> **참고:** 컴퓨터/태블릿/기타 장치에서 자신만의 파일들을 생성 할 수 없다면, 대부분의 예제 코드는 [JSBin](http://jsbin.com/) 또는 [Thimble](https://thimble.mozilla.org/) 같은 온라인 코딩 프로그램에서 시도해 볼 수 있습니다.
+> **참고:** 컴퓨터/태블릿/기타 장치에서 자신만의 파일들을 생성 할 수 없다면, 대부분의 예제 코드는 [JSBin](https://jsbin.com/) 또는 [Glitch](https://glitch.com/) 같은 온라인 코딩 프로그램에서 시도해 볼 수 있습니다.
 
 ## 가이드
 

--- a/files/ko/learn/javascript/building_blocks/index.md
+++ b/files/ko/learn/javascript/building_blocks/index.md
@@ -13,7 +13,7 @@ slug: Learn/JavaScript/Building_blocks
 
 시작하기 전에, 기본적인 [HTML](/ko/docs/Learn/HTML/Introduction_to_HTML)과 [CSS](/ko/docs/Learn/CSS/First_steps) 지식을 알고 계셔야 하고, 또한 지난 모듈인 [JavaScript 첫걸음](/ko/docs/Learn/JavaScript/First_steps)을 학습하셔야 합니다.
 
-> **참고:** 여기 나온 코드를 작성하고 실행해 볼 수 없는 환경이라면 (태블릿, 스마트폰, 기타 장치), [JSBin](http://jsbin.com/)이나 [Glitch](https://glitch.com)에서 대부분의 예제를 시험해 볼 수 있습니다.
+> **참고:** 여기 나온 코드를 작성하고 실행해 볼 수 없는 환경이라면 (태블릿, 스마트폰, 기타 장치), [JSBin](https://jsbin.com/)이나 [Glitch](https://glitch.com)에서 대부분의 예제를 시험해 볼 수 있습니다.
 
 ## 가이드
 

--- a/files/ko/learn/javascript/client-side_web_apis/index.md
+++ b/files/ko/learn/javascript/client-side_web_apis/index.md
@@ -13,7 +13,7 @@ slug: Learn/JavaScript/Client-side_web_APIs
 
 [HTM](/ko/docs/Learn/HTML)과[CSS](/ko/docs/Learn/CSS)에 관한 기본지식이 있으면 좋습니다!
 
-> **참고:** 코드를 작성 할 수 없는 디바이스에서 작업하는 경우 [JSBin](http://jsbin.com/) 또는 [Thimble](https://thimble.mozilla.org/).과 같은 온라인 코딩 프로그램에서 코드 예제를 시험해 볼 수 있습니다.
+> **참고:** 코드를 작성 할 수 없는 디바이스에서 작업하는 경우 [JSBin](https://jsbin.com/) 또는 [Glitch](https://glitch.com/).과 같은 온라인 코딩 프로그램에서 코드 예제를 시험해 볼 수 있습니다.
 
 ## Guides
 

--- a/files/ko/learn/javascript/first_steps/silly_story_generator/index.md
+++ b/files/ko/learn/javascript/first_steps/silly_story_generator/index.md
@@ -34,7 +34,7 @@ l10n:
 - [HTML 예제 파일이 있는 사이트](https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/assessment-start/index.html)로 이동하여 파일을 복사하여 자기 컴퓨터에 새 디렉토리를 만들고 파일이름 `index.html` 로 저장합니다. 이 안에는 예제를 위한 CSS가 포함되어 있습니다.
 - 또 다른 [가공 전의 텍스트가 있는 사이트](https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/assessment-start/raw-text.txt) 로 가서 별도의 브라우저 탭으로 열어 놓으세요. 이것은 나중에 필요합니다.
 
-위 방법 대신에, 여러분은 테스트에 [JSBin](http://jsbin.com/) 또는 [Glitch](https://glitch.com/) 같은 사이트를 이용할 수 있습니다. 이 온라인 에디터들 내부에 HTML, CSS 그리고 JavaScript를 붙여넣을 수 있습니다. 만약 당신이 사용하는 온라인 에디터가 Javascript 패널(또는 탭)을 갖고 있지 않다면, 자유롭게 HTML 페이지 내부에 `<script>` 엘리멘트를 넣을 수 있습니다.
+위 방법 대신에, 여러분은 테스트에 [JSBin](https://jsbin.com/) 또는 [Glitch](https://glitch.com/) 같은 사이트를 이용할 수 있습니다. 이 온라인 에디터들 내부에 HTML, CSS 그리고 JavaScript를 붙여넣을 수 있습니다. 만약 당신이 사용하는 온라인 에디터가 Javascript 패널(또는 탭)을 갖고 있지 않다면, 자유롭게 HTML 페이지 내부에 `<script>` 엘리멘트를 넣을 수 있습니다.
 
 > **참고:** 문제가 해결되지 않으면 이 페이지 하단의 [평가 또는 추가 도움말](#assessment_or_further_help) 섹션을 참조해 도움을 요청하세요.
 

--- a/files/ko/learn/javascript/objects/index.md
+++ b/files/ko/learn/javascript/objects/index.md
@@ -15,7 +15,7 @@ JavaScript에서는 배열과같은 기능부터 JavaScript 위에 구축된 브
 
 JavaScript 객체에 대해 자세히 알아보려면, 기본 문법에 대해 어느 정도 능숙해야 합니다. 이 장을 읽기 전에 [JavaScript 첫걸음](/ko/docs/Learn/JavaScript/First_steps)과 [JavaScript 구성 요소](/ko/docs/Learn/JavaScript/Building_blocks)를 먼저 읽어보시기를 바랍니다.
 
-> **참고:** 컴퓨터/태블릿/혹은 다른 디바이스 상에서 스스로 파일을 만들수 없는 환경이라면, [JSBin](http://jsbin.com/) 또는 [Thimble](https://thimble.mozilla.org/) 과 같은 온라인 코딩 프로그램을 이용하여 (거의 모든) 예제 코드를 테스트해 보실 수 있습니다.
+> **참고:** 컴퓨터/태블릿/혹은 다른 디바이스 상에서 스스로 파일을 만들수 없는 환경이라면, [JSBin](https://jsbin.com/) 또는 [Glitch](https://glitch.com/) 과 같은 온라인 코딩 프로그램을 이용하여 (거의 모든) 예제 코드를 테스트해 보실 수 있습니다.
 
 ## 가이드
 

--- a/files/ko/web/api/document/execcommand/index.md
+++ b/files/ko/web/api/document/execcommand/index.md
@@ -121,7 +121,7 @@ bool = document.execCommand(aCommandName, aShowDefaultUI, aValueArgument);
 
 ## 예제
 
-CodePen의 [how to use](http://codepen.io/netsi1964/full/QbLLGW/)를 참고하세요.
+CodePen의 [how to use](https://codepen.io/netsi1964/full/QbLLGW/)를 참고하세요.
 
 ## 명세
 

--- a/files/ko/web/api/html_drag_and_drop_api/index.md
+++ b/files/ko/web/api/html_drag_and_drop_api/index.md
@@ -228,7 +228,7 @@ function dragstart_handler(ev) {
 
 - [Copying and moving elements with the `DataTransfer` interface](https://mdn.github.io/dom-examples/drag-and-drop/copy-move-DataTransfer.html)
 - [Copying and moving elements with the `DataTransferListItem` interface](https://mdn.github.io/dom-examples/drag-and-drop/copy-move-DataTransferItemList.html)
-- 파일 드래그 앤 드롭; Firefox 전용: <http://jsfiddle.net/9C2EF/>
+- 파일 드래그 앤 드롭; Firefox 전용: <https://jsfiddle.net/9C2EF/>
 - 파일 드래그 앤 드롭; 모든 브라우저: [https://jsbin.com/hiqasek/](https://jsbin.com/hiqasek/edit?html,js,output)
 
 ## 명세서

--- a/files/ko/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/ko/web/css/css_transitions/using_css_transitions/index.md
@@ -65,8 +65,6 @@ CSS transitions는 여러분이 (명시적으로 목록을 작성해서) 어떤 
 }
 ```
 
-{{ EmbedLiveSample('%EB%8B%A4%EC%88%98%EC%9D%98_%EC%95%A0%EB%8B%88%EB%A9%94%EC%9D%B4%EC%85%98%EC%9D%B4_%EC%A0%81%EC%9A%A9%EB%90%9C_%EC%86%8D%EC%84%B1_%EC%98%88%EC%A0%9C', '600', '300', '', 'Web/Guide/CSS/Using_CSS_transitions') }}
-
 ## 트랜지션 정의에 사용한 CSS 속성
 
 CSS 트랜지션은 단축(shorthand) 속성 {{cssxref("transition")}}을 사용하여 제어합니다. 이것은 트랜지션을 설정하는 가장 좋은 방법입니다. 파라미터 목록의 길이가 싱크가 맞지 않는 것을 피하기가 더 쉬워지기 때문입니다. 싱크가 맞지 않으면 CSS를 디버그하는데 많은 시간을 들여야 해서 크게 좌절할 수 있습니다.

--- a/files/ko/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/ko/web/css/css_transitions/using_css_transitions/index.md
@@ -1122,7 +1122,7 @@ p {
 }
 ```
 
-여기에서 확인할 수 있습니다. <http://jsfiddle.net/RwtHn/5/>
+여기에서 확인할 수 있습니다. <https://jsfiddle.net/RwtHn/5/>
 
 ## 명세
 

--- a/files/ko/web/svg/tutorial/paths/index.md
+++ b/files/ko/web/svg/tutorial/paths/index.md
@@ -236,6 +236,6 @@ A 명령어는 일단 x축, y축 반지름을 매개변수로 받는다. 혹시 
 
 원을 한 바퀴 도는 패스의 경우 시작점과 끝점이 같으므로 선택할 수 있는 원이 무한히 있으며, 그러므로 실제 패스가 정의되지 않는다. 이때는 시작점과 끝점을 살짝 비뚤어지게 배치하고 이 둘을 다른 패스 선으로 마저 이음으로써 비슷하게 만들 수 있지만, 이때는 실제 원이나 타원 노드를 쓰는 것이 쉬울 때가 많다.
 
-[캔버스](/ko/docs/Web/HTML/Canvas)에서 SVG로 넘어오는 사람에게는 호가 가장 배우기 어려울 수도 있지만, 그런 만큼 강력하기도 하다. 다음 반응형 예제를 보면 SVG 호의 개념을 이해하는 데 도움이 될 것이다. <http://codepen.io/lingtalfi/pen/yaLWJG> (크롬과 Firefox로만 테스트했으므로 일부 브라우저에서 동작하지 않을 수 있음)
+[캔버스](/ko/docs/Web/HTML/Canvas)에서 SVG로 넘어오는 사람에게는 호가 가장 배우기 어려울 수도 있지만, 그런 만큼 강력하기도 하다. 다음 반응형 예제를 보면 SVG 호의 개념을 이해하는 데 도움이 될 것이다. <https://codepen.io/lingtalfi/pen/yaLWJG> (크롬과 Firefox로만 테스트했으므로 일부 브라우저에서 동작하지 않을 수 있음)
 
 {{ PreviousNext("Web/SVG/Tutorial/Basic_Shapes", "Web/SVG/Tutorial/Fills_and_Strokes") }}


### PR DESCRIPTION
### Description

This PR replaces for `ko` locale:
* obsolete `thimble.mozilla.org` external links with `glitch.com`
* `http` with `https` for `jsbin.com`, `jsfiddle.net` and `codepen.io` external links

Also remove broken `EmbedLiveSample` macro from `Web/CSS/CSS_transitions/Using_CSS_transitions` because of this the check did not pass successfully.

### Related issues and pull requests

Relates to #7327
