### PR TITLE
[pt-br] remove broken external link to `thimble.mozilla.org`

### DIFF
--- a/files/pt-br/learn/accessibility/index.md
+++ b/files/pt-br/learn/accessibility/index.md
@@ -25,7 +25,7 @@ O recurso **Inspecionar propriedades de acessibilidade** é uma ótima ferrament
 
 Para ter o máximo proveito deste módulo, recomendamos que esteja familiarizados com pelos os dois primeiros módulos de [HTML](/pt-BR/docs/Learn/HTML), [CSS](/pt-BR/docs/Learn/CSS), e [JavaScript](/pt-BR/docs/Learn/JavaScript), ou melhor ainda, com as partes principais do módulo de acessibilidade de cada capítulo, à medida em que vai estudando.
 
-> **Nota:** Se você está estudando em um dispositivo que não pode criar novos arquivos, voce pode testar os exemplos em alguma aplicação de codificação online, como [JSBin](http://jsbin.com/) ou [Thimble](https://thimble.mozilla.org/).
+> **Nota:** Se você está estudando em um dispositivo que não pode criar novos arquivos, voce pode testar os exemplos em alguma aplicação de codificação online, como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 
@@ -51,4 +51,4 @@ Para ter o máximo proveito deste módulo, recomendamos que esteja familiarizado
 
 - [Comece a desenvolver aplicações web hoje](https://egghead.io/courses/start-building-accessible-web-applications-today) — Marcy Sutton apresenta uma excelente série de video tutorials.
 - [Recursos Universidade Deque](https://dequeuniversity.com/resources/) — inclui codigos de exemplo, leitores de tela, e outros recursos interessantes.
-- [Recursos webAIM](http://webaim.org/resources/) — inlui guias, checklists, ferramentas e outras coisas.
+- [Recursos webAIM](https://webaim.org/resources/) — inlui guias, checklists, ferramentas e outras coisas.

--- a/files/pt-br/learn/css/building_blocks/index.md
+++ b/files/pt-br/learn/css/building_blocks/index.md
@@ -18,7 +18,7 @@ Antes de iniciar este módulo, você deve ter:
 3. Familiaridade básica com HTML, como foi discutido no módulo [Introdução ao HTML](/pt-BR/docs/Learn/HTML/Introduction_to_HTML).
 4. Um entendimento do básico em CSS, como o mostrado no módulo [Primeiros Passos com CSS](/pt-BR/docs/Learn/CSS/First_steps).
 
-> **Nota:** Se você estiver usando um computador/tablet/outro dispositivo onde você não puder criar seus próprios arquivos, você pode tentar rodar (a maioria) os códigos de exemplo em um programa de codificação online como o [JSBin](http://jsbin.com/) ou [Glitch](https://glitch.com/).
+> **Nota:** Se você estiver usando um computador/tablet/outro dispositivo onde você não puder criar seus próprios arquivos, você pode tentar rodar (a maioria) os códigos de exemplo em um programa de codificação online como o [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/css/first_steps/index.md
+++ b/files/pt-br/learn/css/first_steps/index.md
@@ -15,7 +15,7 @@ Antes de iniciar este módulo, você deve ter:
 2. Um ambiente de trabalho básico configurado conforme detalhado em [Instalando Software Básico](/pt-BR/docs/Learn/Getting_started_with_the_web/Installing_basic_software/pt-BR/docs/) e um entendimento de como criar e gerenciar arquivos, conforme detalhado em [Lidando com Arquivos](/pt-BR/docs/Learn/Getting_started_with_the_web/Dealing_with_files).
 3. Familiaridade básica com HTML, como discutido no módulo [Introdução ao HTML](/pt-BR/docs/Learn/HTML/Introduction_to_HTML).
 
-> **Nota:** Se você está trabalhando em um computador/tablet/ou outro dispostivo onde você não tem habilidade para criar seus próprios arquivos, você poderá tentar (a maioria) os exemplos de códigos em um programa online de codificação como [JSBin](http://jsbin.com/) ou [Thimble](https://thimble.mozilla.org/).
+> **Nota:** Se você está trabalhando em um computador/tablet/ou outro dispostivo onde você não tem habilidade para criar seus próprios arquivos, você poderá tentar (a maioria) os exemplos de códigos em um programa online de codificação como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/css/styling_text/index.md
+++ b/files/pt-br/learn/css/styling_text/index.md
@@ -11,7 +11,7 @@ Com o básico de CSS compreendido, o próximo passo para você se concentrar ser
 
 Antes de começar este módulo, você já deverá ter familiaridade básica com HTML, como dissemos no módulos [Introdução ao HTML](/pt-BR/docs/Learn/HTML/Introduction_to_HTML), e estar confortável com os fundamentos de CSS, como discutido em [Introdução ao CSS](/pt-BR/docs/Learn/CSS/Introduction_to_CSS).
 
-> **Nota:** Se você está usando um computador/tablet/outro dispositivo onde não tem a possibilidade de criar seus próprios arquivos, você poderá treinar os códigos-exemplo em um programa de código online como [JSBin](http://jsbin.com/), [CodePen](https://codepen.io/) or [Thimble](https://thimble.mozilla.org/).
+> **Nota:** Se você está usando um computador/tablet/outro dispositivo onde não tem a possibilidade de criar seus próprios arquivos, você poderá treinar os códigos-exemplo em um programa de código online como [JSBin](https://jsbin.com/) or [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/forms/index.md
+++ b/files/pt-br/learn/forms/index.md
@@ -11,7 +11,7 @@ Este guia tem uma série de artigos que vão ajudar você a ficar craque em HTML
 
 Antes de iniciar este guia, você deve estar familiarizado com os conceitos da nossa [Introdução ao HTML](/pt-BR/docs/Aprender/HTML/Introducao_ao_HTML).
 
-> **Nota:** **Dica**: Se você está usando um computador/tablet/outro aparelho onde você não pode criar seus próprios arquivos, você pode testar (a maior parte) dos códigos de exemplo em uma ferramenta online como [JSBin](http://jsbin.com/) ou [Thimble](https://thimble.mozilla.org/pt-BR/).
+> **Nota:** **Dica**: Se você está usando um computador/tablet/outro aparelho onde você não pode criar seus próprios arquivos, você pode testar (a maior parte) dos códigos de exemplo em uma ferramenta online como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias básicos
 

--- a/files/pt-br/learn/getting_started_with_the_web/publishing_your_website/index.md
+++ b/files/pt-br/learn/getting_started_with_the_web/publishing_your_website/index.md
@@ -48,9 +48,9 @@ Há um número grande de web apps que emulam um ambiente de desenvolvimento de s
 
 Tente codificar com alguns desses exemplos, e veja qual se encaixa melhor para você:
 
-- [JSFiddle](http://jsfiddle.net/)
-- [Thimble](https://thimble.mozilla.org/pt-BR/)
-- [JSBin](http://jsbin.com/)
+- [JSFiddle](https://jsfiddle.net/)
+- [Glitch](https://glitch.com/)
+- [JS Bin](https://jsbin.com/)
 - [CodePen](https://codepen.io/)
 
 ![](jsbin-screen.png)

--- a/files/pt-br/learn/html/howto/use_data_attributes/index.md
+++ b/files/pt-br/learn/html/howto/use_data_attributes/index.md
@@ -56,9 +56,9 @@ article[data-columns="4"] {
 }
 ```
 
-Pode-se tudo isso em funcionamento neste [exemplo JSBin](http://jsbin.com/ujiday/2/edit).
+Pode-se tudo isso em funcionamento neste [exemplo JSBin](https://jsbin.com/ujiday/2/edit).
 
-Atributos data também podem ser utilizados para conter informações que mudam constantemente, como a pontuação em um jogo. Usando seletores CSS e acesso com JavaScript permite que se construa efeitos excelentes sem ter que escrever suas próprias rotinas de display. Veja [esta tela](http://www.youtube.com/watch?v=On_WyUB1gOk) para um exemplo utilizando conteúdo gerado e transições CSS ([exemplo JSBin](http://jsbin.com/atawaz/3/edit)).
+Atributos data também podem ser utilizados para conter informações que mudam constantemente, como a pontuação em um jogo. Usando seletores CSS e acesso com JavaScript permite que se construa efeitos excelentes sem ter que escrever suas próprias rotinas de display. Veja [esta tela](http://www.youtube.com/watch?v=On_WyUB1gOk) para um exemplo utilizando conteúdo gerado e transições CSS ([exemplo JSBin](https://jsbin.com/atawaz/3/edit)).
 
 Uma vez que valores data são strings, todos os valores devem estar entre aspas ou então a estilização não fará efeito.
 

--- a/files/pt-br/learn/html/introduction_to_html/index.md
+++ b/files/pt-br/learn/html/introduction_to_html/index.md
@@ -11,7 +11,7 @@ Em sua essência, {{glossary("HTML")}} é uma linguagem bastante simples compost
 
 Antes de iniciar este módulo, você não precisa de nenhum conhecimento prévio sobre HTML, mas deve ter pelo menos uma familiaridade básica em utilizar computadores e utilizar a web passivamente (por exemplo, apenas navegando e consumindo conteúdo). Você deve ter um ambiente de trabalho básico configurado (como detalhado em [Instalando os programas básicos](/pt-BR/docs/Aprender/Getting_started_with_the_web/instalando_programas_basicos)) e entender como criar e gerenciar arquivos (como detalhado em [Lidando com arquivos](/pt-BR/docs/Aprender/Getting_started_with_the_web/lidando_com_arquivos)). Ambos são partes do nosso módulo completo para iniciantes [indrodução à web](/pt-BR/docs/Aprender/Getting_started_with_the_web).
 
-> **Nota:** **Nota**: Se você estiver trabalhando em um computador/tablet/outro dispositivo que não permita a criação de seus próprios arquivos, você pode testar (a maior parte) dos exemplos de códigos em um programa de codificação online como [JSBin](http://jsbin.com/) ou [Glitch](https://glitch.com/).
+> **Nota:** **Nota**: Se você estiver trabalhando em um computador/tablet/outro dispositivo que não permita a criação de seus próprios arquivos, você pode testar (a maior parte) dos exemplos de códigos em um programa de codificação online como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/html/multimedia_and_embedding/index.md
+++ b/files/pt-br/learn/html/multimedia_and_embedding/index.md
@@ -11,7 +11,7 @@ Nós vimos muito sobre texto até aqui nesse curso, mas a internet seria muito c
 
 Antes de iniciar esse módulo, você deve ter um conhecimento razoável de HTML, como previamente abrangido em [introdução a HTML](/pt-BR/docs/Learn/HTML/Introduction_to_HTML). Se você não estudou esse módulo (ou algo similar), estude-o primeiro e depois retorne!
 
-> **Nota:** Se você está trabalhando em um computador/tablet/outro dispositivo onde você não tem a habilidade de criar seus próprios arquivos, você pode testar (maior parte) dos exemplos de códigos em um programa online para codar tais como [JSBin](http://jsbin.com/) ou [Thimble](https://thimble.mozilla.org/).
+> **Nota:** Se você está trabalhando em um computador/tablet/outro dispositivo onde você não tem a habilidade de criar seus próprios arquivos, você pode testar (maior parte) dos exemplos de códigos em um programa online para codar tais como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/html/tables/index.md
+++ b/files/pt-br/learn/html/tables/index.md
@@ -11,7 +11,7 @@ Uma tarefa muito comum em HTML é estruturar os dados tabulares, e há vários e
 
 Antes de iniciar este módulo, você deverá ter domínio dos básicos de HTML — consulte [Introdução ao HTML](/pt-BR/docs/Learn/HTML/Introducao_ao_HTML).
 
-> **Nota:** se está utilizando um computador/tablet/outro dispositivo onde não tem a possibilidade de criar os seus próprios arquivos, pode testar a maioria dos exemplos de código num programa de codificação on-line, tais como [JSBin](http://jsbin.com/) ou [Thimble](https://thimble.mozilla.org/).
+> **Nota:** se está utilizando um computador/tablet/outro dispositivo onde não tem a possibilidade de criar os seus próprios arquivos, pode testar a maioria dos exemplos de código num programa de codificação on-line, tais como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/javascript/asynchronous/index.md
+++ b/files/pt-br/learn/javascript/asynchronous/index.md
@@ -11,7 +11,7 @@ Javascript Assíncrono é um tópico razoavelmente avançado e é aconselhada a 
 
 Se você não estiver familiarizado com os conceitos de programação assíncrona, a sugestão é iniciar com o artigo [Conceitos gerais da programação assíncrona](/pt-BR/docs/Learn/JavaScript/Asynchronous/Conceitos) desse módulo. Caso contrário, você pode provavelmente pular para o módulo [Introdução ao Javascript Assíncrono](/pt-BR/docs/Learn/JavaScript/Asynchronous/Introdu%C3%A7%C3%A3o).
 
-> **Nota:** Se você está estudando a partir de um computador/tablet/ outro dispositivo onde não é capaz de criar seus próprios arquivos, é possível executar os códigos de exemplo (a maioria deles) em plataformas como [JSBin](http://jsbin.com/) ou [Thimble](https://thimble.mozilla.org/).
+> **Nota:** Se você está estudando a partir de um computador/tablet/ outro dispositivo onde não é capaz de criar seus próprios arquivos, é possível executar os códigos de exemplo (a maioria deles) em plataformas como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com).
 
 ## Guias
 

--- a/files/pt-br/learn/javascript/building_blocks/image_gallery/index.md
+++ b/files/pt-br/learn/javascript/building_blocks/image_gallery/index.md
@@ -30,7 +30,7 @@ Agora que analisamos os blocos de construção fundamentais do JavaScript, testa
 
 Para começar esta avaliação, você deve [pegar o arquivo ZIP](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/gallery/gallery-start.zip?raw=true) para o exemplo e descompactá-lo em algum lugar no seu computador.
 
-> **Nota:** Como alternativa, você pode usar um site como o [JSBin](http://jsbin.com/) ou [Thimble](https://thimble.mozilla.org/) para fazer sua avaliação. Você pode colar o HTML, CSS e JavaScript em um desses editores on-line. Se o editor on-line que você está usando não tiver painéis JavaScript / CSS separados, sinta-se à vontade para colocar os elementos in-line `<script>` e `<style>` dentro da página HTML.
+Como alternativa, você pode usar um site como o [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/) ou [Glitch](https://glitch.com/) para fazer sua avaliação. Você pode colar o HTML, CSS e JavaScript em um desses editores on-line. Se o editor on-line que você está usando não tiver painéis JavaScript / CSS separados, sinta-se à vontade para colocar os elementos in-line `<script>` e `<style>` dentro da página HTML.
 
 ## Resumo do projeto
 

--- a/files/pt-br/learn/javascript/building_blocks/index.md
+++ b/files/pt-br/learn/javascript/building_blocks/index.md
@@ -11,7 +11,7 @@ Neste módulo, continuaremos nossa abordagem por todos os recursos-chave fundame
 
 Antes de iniciar este módulo, você deve ter familiaridade com os conceitos básicos de [HTML](/pt-BR/docs/Aprender/HTML/Introducao_ao_HTML) e [CSS](/pt-BR/docs/Aprender/CSS/Introduction_to_CSS), além de ter estudado nosso módulo anterior, [primeiros passos no Javacript](/pt-BR/docs/Learn/JavaScript/First_steps).
 
-> **Nota:** Se você está trabalhando em um computador, tablet ou outro dispositivo onde você não tem a habilidade para criar seus próprios arquivos, você pode testar os exemplos de código (a maioria deles) em um programa de codificação online, tal como [JSBin](http://jsbin.com/) ou [Thimble](https://thimble.mozilla.org/).
+> **Nota:** Se você está trabalhando em um computador, tablet ou outro dispositivo onde você não tem a habilidade para criar seus próprios arquivos, você pode testar os exemplos de código (a maioria deles) em um programa de codificação online, tal como [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/javascript/client-side_web_apis/index.md
+++ b/files/pt-br/learn/javascript/client-side_web_apis/index.md
@@ -13,7 +13,7 @@ Para tirar o máximo proveito deste módulo, é recomendável a leitura dos mód
 
 Conhecimento básico de [HTML](/pt-BR/docs/Learn/HTML) e [CSS](/pt-BR/docs/Learn/CSS) serão utéis.
 
-> **Nota:** **Notes** Se você estiver trabalhando de um dispositivo que não permita a criação de arquivos. Você pode tentar editar os arquivos em um editor online como [JSBin](http://jsbin.com/) ou [Thimble](https://thimble.mozilla.org/).
+> **Nota:** **Notes** Se você estiver trabalhando de um dispositivo que não permita a criação de arquivos. Você pode tentar editar os arquivos em um editor online como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/javascript/first_steps/index.md
+++ b/files/pt-br/learn/javascript/first_steps/index.md
@@ -15,7 +15,7 @@ Antes de iniciar esse módulo, você não precisa de nenhum conhecimento prévio
 - [Introdução ao HTML](/pt-BR/docs/Learn/HTML/Introduction_to_HTML)
 - [Introdução ao CSS](/pt-BR/docs/Learn/CSS/First_steps)
 
-> **Nota:** Se você está trabalhando em um computador/tablet/outro dispositivo onde você não pode criar os seus próprio arquivos, você pode experimentar (em sua maioria) os códigos de exemplo em um programa de codificação online como [JSBin](http://jsbin.com/) ou [Thimble](https://thimble.mozilla.org/).
+> **Nota:** Se você está trabalhando em um computador/tablet/outro dispositivo onde você não pode criar os seus próprio arquivos, você pode experimentar (em sua maioria) os códigos de exemplo em um programa de codificação online como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/javascript/first_steps/silly_story_generator/index.md
+++ b/files/pt-br/learn/javascript/first_steps/silly_story_generator/index.md
@@ -33,7 +33,7 @@ Para começar esta avaliação, você deve:
 - [Pegue o arquivo HTML](https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/assessment-start/index.html) para o exemplo e salve uma cópia local deste arquivo como index.html em um novo diretório em algum local do seu computador. Este arquivo ainda contém o CSS para estilizar o exemplo contido no arquivo.
 - Vá para a [página que contém o texto bruto](https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/assessment-start/raw-text.txt) e matenha-a aberta em uma aba separada do navegador em algum lugar. Você precisará dela mais tarde.
 
-> **Nota:** Alternativamente, você pode utilizar um site como [JSBin](http://jsbin.com/) ou [Thimble](https://thimble.mozilla.org/) para fazer a sua avaliação. Você pode colar o HTML, CSS e javaScript em um desses editores online. Se o editor online que você estiver utilizando não possuir um painel separado para javaScript, sinta-se a vontade para inseri-lo em um elemento \<script> dentro da página HTML.
+Alternativamente, você pode utilizar um site como [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/) ou [Glitch](https://glitch.com/) para fazer a sua avaliação. Você pode colar o HTML, CSS e javaScript em um desses editores online. Se o editor online que você estiver utilizando não possuir um painel separado para javaScript, sinta-se a vontade para inseri-lo em um elemento \<script> dentro da página HTML.
 
 ## Resumo do projeto
 

--- a/files/pt-br/learn/javascript/objects/adding_bouncing_balls_features/index.md
+++ b/files/pt-br/learn/javascript/objects/adding_bouncing_balls_features/index.md
@@ -30,7 +30,7 @@ Nesta avaliação, espera-se que você use a demonstração de bolas saltantes d
 
 Para iniciar essa avaliação, faça uma cópia local de [index-finished.html](https://github.com/mdn/learning-area/blob/master/javascript/oojs/bouncing-balls/index-finished.html), [style.css](https://github.com/mdn/learning-area/blob/master/javascript/oojs/bouncing-balls/style.css), e [main-finished.js](https://github.com/mdn/learning-area/blob/master/javascript/oojs/bouncing-balls/main-finished.js) do nosso último artigo em um novo diretório em seu computador local.
 
-> **Nota:** Alternatively, you could use a site like [JSBin](http://jsbin.com/) or [Thimble](https://thimble.mozilla.org/) to do your assessment. You could paste the HTML, CSS and JavaScript into one of these online editors. If the online editor you are using doesn't have separate JavaScript/CSS panels, feel free to put them inline `<script>`/`<style>` elements inside the HTML page.
+Alternatively, you could use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/). You could paste the HTML, CSS and JavaScript into one of these online editors. If the online editor you are using doesn't have a separate JavaScript panel, feel free to put it inline in a `<script>` element inside the HTML page.
 
 ## Resumo do projeto
 

--- a/files/pt-br/web/api/animation/currenttime/index.md
+++ b/files/pt-br/web/api/animation/currenttime/index.md
@@ -22,7 +22,7 @@ Um número que representará no tempo atual da animação em milésimos de segun
 
 ## Examples
 
-No [jogo Drink Me/Eat Me](http://codepen.io/rachelnabors/pen/PNYGZQ?editors=0010), O tamanho da Alice é animado e pode crescer ou diminuir. No início do jogo, o tamanho dela foi colocado entre os dois extremos do animation's `currentTime` no meio do [`KeyframeEffect`'s duration](/pt-BR/docs/Web/API/Web_Animations_API/Animation_timing_options), desta maneira:
+No [jogo Drink Me/Eat Me](https://codepen.io/rachelnabors/pen/PNYGZQ?editors=0010), O tamanho da Alice é animado e pode crescer ou diminuir. No início do jogo, o tamanho dela foi colocado entre os dois extremos do animation's `currentTime` no meio do [`KeyframeEffect`'s duration](/pt-BR/docs/Web/API/Web_Animations_API/Animation_timing_options), desta maneira:
 
 ```js
 aliceChange.currentTime = aliceChange.effect.timing.duration / 2;

--- a/files/pt-br/web/api/animation/playstate/index.md
+++ b/files/pt-br/web/api/animation/playstate/index.md
@@ -32,7 +32,7 @@ Animation.playState =novoEstado;
 
 ## Exemplo
 
-No [jogo](http://codepen.io/rachelnabors/pen/PNYGZQ?editors=0010) [Growing/Shrinking Alice Game](http://codepen.io/rachelnabors/pen/PNYGZQ?editors=0010) , os jogadores podem chegar ao final com a [Alice chorando em uma poça de lágrimas](http://codepen.io/rachelnabors/pen/EPJdJx?editors=0010). No jogo, por razões de performance, as lágrimas só são animadas quando estão visiveis. Então elas devem ficar pausadas enquanto a animação ocorre, como no exemplo:
+No [jogo](https://codepen.io/rachelnabors/pen/PNYGZQ?editors=0010) [Growing/Shrinking Alice Game](https://codepen.io/rachelnabors/pen/PNYGZQ?editors=0010) , os jogadores podem chegar ao final com a [Alice chorando em uma poça de lágrimas](https://codepen.io/rachelnabors/pen/EPJdJx?editors=0010). No jogo, por razões de performance, as lágrimas só são animadas quando estão visiveis. Então elas devem ficar pausadas enquanto a animação ocorre, como no exemplo:
 
 ```js
 // Configurando a animação das lágrimas

--- a/files/pt-br/web/api/canvas_api/tutorial/finale/index.md
+++ b/files/pt-br/web/api/canvas_api/tutorial/finale/index.md
@@ -11,7 +11,7 @@ Parabéns! Você terminou o [Canvas tutorial](/pt-BR/docs/Web/API/Canvas_API/Tut
 
 Há uma variedade de demonstrações e mais explicações sobre canvas nesses sites:
 
-- [Codepen.io](http://codepen.io/search?q=canvas)
+- [Codepen.io](https://codepen.io/search?q=canvas)
   - : Front End Developer Playground & Code Editor no navegador.
 - [HTML5CanvasTutorials](http://www.html5canvastutorials.com/)
   - : Exemplos para a maioria das APIs canvas.

--- a/files/pt-br/web/api/datatransfer/index.md
+++ b/files/pt-br/web/api/datatransfer/index.md
@@ -82,7 +82,7 @@ Contains a list of all the local files available on the data transfer. If the dr
 
 These examples dump the list of files dragged into the browser window.
 
-- (Firefox only): <http://jsfiddle.net/9C2EF/>
+- (Firefox only): <https://jsfiddle.net/9C2EF/>
 - (All browsers): [https://jsbin.com/hiqasek/](https://jsbin.com/hiqasek/edit?html,js,output)
 
 ### types

--- a/files/pt-br/web/api/element/click_event/index.md
+++ b/files/pt-br/web/api/element/click_event/index.md
@@ -61,7 +61,7 @@ O evento `click` event é disparado quando o botão de um dispositivo apontador 
 
 ### Internet Explorer
 
-O Internet Explorer 8 e 9 apresentam um bug onde o elemento com a propriedade {{cssxref("background-color")}} é definida como [`transparent`](/pt-BR/docs/Web/CSS/color_value#transparent_keyword) that are overlaid on top of other element(s) won't receive `click` events. Todos os eventos `click` serão disparados no elemento underlying instead. Veja uma demonstração [neste exemplo](http://jsfiddle.net/YUKma/show/).
+O Internet Explorer 8 e 9 apresentam um bug onde o elemento com a propriedade {{cssxref("background-color")}} é definida como [`transparent`](/pt-BR/docs/Web/CSS/color_value#transparent_keyword) that are overlaid on top of other element(s) won't receive `click` events. Todos os eventos `click` serão disparados no elemento underlying instead. Veja uma demonstração [neste exemplo](https://jsfiddle.net/YUKma/show/).
 
 Soluções de contorno para este bug:
 
@@ -74,7 +74,7 @@ Soluções de contorno para este bug:
 
 ### Safari Mobile
 
-Safari Mobile 7.0+ (and likely earlier versions too) [suffers from a bug](https://bugs.webkit.org/show_bug.cgi?id=153887) where `click` events aren't fired on elements that aren't typically interactive (e.g. {{HTMLElement("div")}}) and which also don't have event listeners directly attached to the elements themselves (i.e. [event delegation](http://davidwalsh.name/event-delegate) is being used). See [this live example](http://jsfiddle.net/cvrhulu/k9t0sdnf/show/) for a demonstration. See also [Safari's docs on making elements clickable](https://developer.apple.com/library/safari/documentation/appleapplications/reference/safariwebcontent/HandlingEvents/HandlingEvents.html#//apple_ref/doc/uid/TP40006511-SW6) and the [definition of "clickable element"](https://developer.apple.com/library/safari/documentation/appleapplications/reference/safariwebcontent/HandlingEvents/HandlingEvents.html#//apple_ref/doc/uid/TP40006511-SW7).
+Safari Mobile 7.0+ (and likely earlier versions too) [suffers from a bug](https://bugs.webkit.org/show_bug.cgi?id=153887) where `click` events aren't fired on elements that aren't typically interactive (e.g. {{HTMLElement("div")}}) and which also don't have event listeners directly attached to the elements themselves (i.e. [event delegation](http://davidwalsh.name/event-delegate) is being used). See [this live example](https://jsfiddle.net/cvrhulu/k9t0sdnf/show/) for a demonstration. See also [Safari's docs on making elements clickable](https://developer.apple.com/library/safari/documentation/appleapplications/reference/safariwebcontent/HandlingEvents/HandlingEvents.html#//apple_ref/doc/uid/TP40006511-SW6) and the [definition of "clickable element"](https://developer.apple.com/library/safari/documentation/appleapplications/reference/safariwebcontent/HandlingEvents/HandlingEvents.html#//apple_ref/doc/uid/TP40006511-SW7).
 
 Known workarounds for this bug:
 

--- a/files/pt-br/web/api/html_drag_and_drop_api/index.md
+++ b/files/pt-br/web/api/html_drag_and_drop_api/index.md
@@ -217,7 +217,7 @@ Como podem ser visto no [DataTransferItem interface's Browser Compatibility tabl
 
 - [Copiando e movendo elementos com a interface `DataTransfer`](https://mdn.github.io/dom-examples/drag-and-drop/copy-move-DataTransfer.html)
 - [Copiando e movendo elementos com a interface `DataTransferListItem`](http://mdn.github.io/dom-examples/drag-and-drop/copy-move-DataTransferItemList.html)
-- Arrastando e soltando arquivos; Apenas para o Firefox: <http://jsfiddle.net/9C2EF/>
+- Arrastando e soltando arquivos; Apenas para o Firefox: <https://jsfiddle.net/9C2EF/>
 - Arrastando e soltando arquivos; Todos os navegadores: [https://jsbin.com/hiqasek/](https://jsbin.com/hiqasek/edit?html,js,output)
 
 ## Veja também

--- a/files/pt-br/web/api/touch_events/index.md
+++ b/files/pt-br/web/api/touch_events/index.md
@@ -259,7 +259,7 @@ function log(msg) {
 
 If your browser supports it, you can {{ LiveSampleLink('Example', 'see it live') }}.
 
-[jsFiddle example](http://jsfiddle.net/Darbicus/z3Xdx/10/)
+[jsFiddle example](https://jsfiddle.net/Darbicus/z3Xdx/10/)
 
 ## Additional tips
 

--- a/files/pt-br/web/api/web_animations_api/using_the_web_animations_api/index.md
+++ b/files/pt-br/web/api/web_animations_api/using_the_web_animations_api/index.md
@@ -23,9 +23,9 @@ Uma das maneiras mais familiares de abordar a Web Animations API é começar com
 
 ### A versão CSS
 
-Aqui temos uma animação escrita com CSS mostrando Alice caindo no buraco de coelho que leva ao País das Maravilhas (veja o [código completo no Codepen](http://codepen.io/rachelnabors/pen/QyOqqW)):
+Aqui temos uma animação escrita com CSS mostrando Alice caindo no buraco de coelho que leva ao País das Maravilhas (veja o [código completo no Codepen](https://codepen.io/rachelnabors/pen/QyOqqW)):
 
-[![Alice Tumbling down the rabbit's hole.](tumbling-alice_optimized.gif)](http://codepen.io/rachelnabors/pen/rxpmJL)
+[![Alice Tumbling down the rabbit's hole.](tumbling-alice_optimized.gif)](https://codepen.io/rachelnabors/pen/rxpmJL)
 
 Perceba que o fundo se mexe, a Alice gira e sua cor muda em sincronia com o giro. Nós vamos focar somente na Alice para este tutorial. Segue a versão simplificada do CSS que controla a animação da Alice:
 
@@ -101,7 +101,7 @@ Agora vamos juntar o que já fizemos com o método {{domxref("Element.animate()"
 document.getElementById("alice").animate(aliceTumbling, aliceTiming);
 ```
 
-E pronto: a animação começa a tocar (veja a [versão final no Codepen](http://codepen.io/rachelnabors/pen/rxpmJL)).
+E pronto: a animação começa a tocar (veja a [versão final no Codepen](https://codepen.io/rachelnabors/pen/rxpmJL)).
 
 O método `animate()` pode ser chamado em qualquer elemento do DOM que pode ser animado com CSS. E pode ser escrito de algumas maneiras. Ao invés de criar objetos para os keyframes e propriedades temporais, podemos passar seus valores diretamentes, tipo:
 
@@ -134,9 +134,9 @@ document.getElementById("alice").animate(
 
 ## Controlando a reprodução com play(), pause(), reverse() e updatePlaybackRate()
 
-Por mais que possamos escrever Animações CSS utilizando a Web Animations API, a API realmente mostra seu potencial quando precisamos manipular a reprodução da animação. A Web Animations API fornece vários métodos úteis para controlar a reprodução. Vamos dar uma olhada em como pausar e tocar animações no jogo da Alice Crescendo/Encolhendo (confira o [código completo no Codepen](http://codepen.io/rachelnabors/pen/PNYGZQ)):
+Por mais que possamos escrever Animações CSS utilizando a Web Animations API, a API realmente mostra seu potencial quando precisamos manipular a reprodução da animação. A Web Animations API fornece vários métodos úteis para controlar a reprodução. Vamos dar uma olhada em como pausar e tocar animações no jogo da Alice Crescendo/Encolhendo (confira o [código completo no Codepen](https://codepen.io/rachelnabors/pen/PNYGZQ)):
 
-[![Playing the growing and shrinking game with Alice.](growing-shrinking_article_optimized.gif)](http://codepen.io/rachelnabors/pen/PNYGZQ?editors=0010)
+[![Playing the growing and shrinking game with Alice.](growing-shrinking_article_optimized.gif)](https://codepen.io/rachelnabors/pen/PNYGZQ?editors=0010)
 
 Nesse jogo, Alice tem uma animação que a encolhe ou aumenta seu tamanho, que controlamos por uma garrafa e um cupcake. Cada um tem sua própria animação.
 
@@ -206,9 +206,9 @@ bottle.addEventListener("mousedown", shrinkAlice, false);
 bottle.addEventListener("touchstart", shrinkAlice, false);
 ```
 
-Em [Alice Através do Espelho](https://en.wikipedia.org/wiki/Through_the_Looking-Glass), Alice viaja para um mundo onde ela deve correr para se manter no lugar — e correr com o dobro de velocidade para avançar! No exemplo da Corrida da Rainha Vermelha, Alice e a Rainha Vermelha estão correndo para se manter no lugar (veja o [código completo no Codepen](http://codepen.io/rachelnabors/pen/PNGGaV)):
+Em [Alice Através do Espelho](https://en.wikipedia.org/wiki/Through_the_Looking-Glass), Alice viaja para um mundo onde ela deve correr para se manter no lugar — e correr com o dobro de velocidade para avançar! No exemplo da Corrida da Rainha Vermelha, Alice e a Rainha Vermelha estão correndo para se manter no lugar (veja o [código completo no Codepen](https://codepen.io/rachelnabors/pen/PNGGaV)):
 
-[![Alice and the Red Queen race to get to the next square in this game.](red-queen-race_optimized.gif)](http://codepen.io/rachelnabors/pen/PNGGaV)
+[![Alice and the Red Queen race to get to the next square in this game.](red-queen-race_optimized.gif)](https://codepen.io/rachelnabors/pen/PNGGaV)
 
 Já que crianças pequenas se cansam facilmente, diferente de peças de xadrez autônomas, Alice está constantemente desacelerando. Nós podemos fazer isso definindo uma queda no `playbackRate` da animação dela. Usamos o `updatePlaybackRate()` no lugar de definir manualmente o playbackRate, já que isso produz uma atualização mais suave:
 
@@ -363,6 +363,6 @@ Essas são as funcionalidades básicas da Web Animations API, a maioria delas j�
 
 ## Veja também
 
-- A [coleção completa de demos de Alice no País das Maravilhas](http://codepen.io/collection/bpEza/) no CodePen para você brincar, compartilhar e editar
+- A [coleção completa de demos de Alice no País das Maravilhas](https://codepen.io/collection/bpEza/) no CodePen para você brincar, compartilhar e editar
 - [Animating like you just don't care with Element.animate](https://hacks.mozilla.org/2016/08/animating-like-you-just-dont-care-with-element-animate/) (em inglês) — Um ótimo artigo para se ler que explica mais sobre a Web Animations API por baixo dos panos, e por que ela tem uma performance melhor do que os outros métodos de animação web
 - [web-animations-js](https://github.com/web-animations/web-animations-js) — O polyfill da Web Animations API

--- a/files/pt-br/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/pt-br/web/css/css_transitions/using_css_transitions/index.md
@@ -1099,7 +1099,7 @@ p {
 }
 ```
 
-Você pode brincar um pouco aqui: <http://jsfiddle.net/9h261pzo/291/>
+Você pode brincar um pouco aqui: <https://jsfiddle.net/9h261pzo/291/>
 
 ### Detectando o começo e a completude de uma transição
 

--- a/files/pt-br/web/demos/index.md
+++ b/files/pt-br/web/demos/index.md
@@ -57,7 +57,7 @@ Se você conhece uma boa demonstração ou aplicação da tecnologia web aberta,
 ## CSS
 
 - [CSS Zen Garden](http://www.csszengarden.com/)
-- [CSS floating logo "mozilla"](http://codepen.io/SoftwareRVG/pen/OXkOWj/)
+- [CSS floating logo "mozilla"](https://codepen.io/SoftwareRVG/pen/OXkOWj/)
 - [Paperfold](http://felixniklas.com/paperfold/)
 - [CSS Blockout](http://ondras.github.io/blockout/)
 - [Rubik's cube](http://ondras.zarovi.cz/demos/rubik/)

--- a/files/pt-br/web/html/element/iframe/index.md
+++ b/files/pt-br/web/html/element/iframe/index.md
@@ -123,7 +123,7 @@ Scripts trying to access a frame's content are subject to the [same-origin polic
 
 ## Resultado
 
-[Live example](http://jsfiddle.net/pablofiumara/mCfAe/)
+[Live example](https://jsfiddle.net/pablofiumara/mCfAe/)
 
 ## Notas
 

--- a/files/pt-br/web/javascript/closures/index.md
+++ b/files/pt-br/web/javascript/closures/index.md
@@ -25,7 +25,7 @@ init();
 
 A função `init()` cria uma variável local chamada `name`, e depois define uma função chamada `displayName()`. `displayName()` é uma função aninhada (uma _closure_) — ela é definida dentro da função `init()`, e está disponivel apenas dentro do corpo daquela função. Diferente de init(), `displayName()` não tem variáveis locais próprias, e ao invés disso reusa a variável `name` declarada na função pai.
 
-[Rode](http://jsfiddle.net/xAFs9/3/) o código e veja que isso funciona. Este é um exemplo de _escopo léxico:_ em JavaScript, o escopo de uma variável é definido por sua localização dentro do código fonte (isto é aparentemente _léxico_) e funções aninhadas têm acesso às variáveis declaradas em seu escopo externo.
+[Rode](https://jsfiddle.net/xAFs9/3/) o código e veja que isso funciona. Este é um exemplo de _escopo léxico:_ em JavaScript, o escopo de uma variável é definido por sua localização dentro do código fonte (isto é aparentemente _léxico_) e funções aninhadas têm acesso às variáveis declaradas em seu escopo externo.
 
 ## Closure
 


### PR DESCRIPTION
### Description

This PR replaces for `pt-BR` locale:
* obsolete `thimble.mozilla.org` external links with `glitch.com`
* `http` with `https` for `jsbin.com`, `jsfiddle.net` and `codepen.io` external links
