### PR TITLE
[ru] remove broken links to `mdn-samples.mozilla.org`

### DIFF
--- a/files/ru/web/api/media_capture_and_streams_api/taking_still_photos/index.md
+++ b/files/ru/web/api/media_capture_and_streams_api/taking_still_photos/index.md
@@ -1,15 +1,13 @@
 ---
-title: Захват кадров с WebRTC
+title: Захват кадров с помощью getUserMedia()
 slug: Web/API/Media_Capture_and_Streams_API/Taking_still_photos
 ---
 
 {{DefaultAPISidebar("Media Capture and Streams")}}
 
-В этой статье объясняется как использовать WebRTC для получения доступа к камере компьютера или мобильного устройства, и захвата кадров с их помощью. [Ознакомьтесь с примером,](https://mdn-samples.mozilla.org/s/webrtc-capturestill) а затем узнайте как это работает.
+В этой статье объясняется как использовать [`navigator.mediaDevices.getUserMedia()`](/ru/docs/Web/API/MediaDevices/getUserMedia) для получения доступа к камере компьютера или мобильного устройства с поддержкой `getUserMedia()` и создания изображений.
 
-![Uz WebRTC balstīta attēla uztveršanas lietotne - kreisajā pusē un bez tīmekļa kameras uzņemšanas video straumē un poga](web-rtc-demo.png)
-
-Перейдите непосредственно [к коду на Github](https://github.com/mdn/samples-server/tree/master/s/webrtc-capturestill) , при желании.
+![Приложение для захвата изображений на основе getUserMedia: слева видеопоток с веб-камеры и кнопка «Take photo», а справа неподвижное изображение после съёмки фотографии.](web-rtc-demo.png)
 
 ## Разметка HTML
 
@@ -119,7 +117,7 @@ slug: Web/API/Media_Capture_and_Streams_API/Taking_still_photos
 
 #### Обработка события начала воспроизведения
 
-После момента вызова метода [`HTMLMediaElement.play()`](/ru/docs/Web/API/HTMLMediaElement#play) на элементе {{HTMLElement("video")}}, возникает промежуток времени до начала воспроизведения видеопотока. Для недопущения блокирования интерфейса пользователя в это промежуток, нужно установить обработчик события {{event("canplay")}} элемента `video` , который сработает, когда элемент начнёт воспроизведение видеопотока. В этот момент все свойства элемента `video` конфигурируются на основе формата потока.
+После момента вызова метода [`HTMLMediaElement.play()`](/ru/docs/Web/API/HTMLMediaElement#play) на элементе {{HTMLElement("video")}}, возникает промежуток времени до начала воспроизведения видеопотока. Для недопущения блокирования интерфейса пользователя в это промежуток, нужно установить обработчик события элемента `video` , который сработает, когда элемент начнёт воспроизведение видеопотока. В этот момент все свойства элемента `video` конфигурируются на основе формата потока.
 
 ```
     video.addEventListener('canplay', function(ev){
@@ -143,7 +141,7 @@ slug: Web/API/Media_Capture_and_Streams_API/Taking_still_photos
 
 #### Обработка нажатий кнопки
 
-Для захвата кадра, пользователь каждый раз нажимает кнопку `startbutton`, нужно добавить обработчик события кнопки, для его вызова при возникновении события {{event("click")}} :
+Для захвата кадра, пользователь каждый раз нажимает кнопку `startbutton`, нужно добавить обработчик события кнопки, для его вызова при возникновении события :
 
 ```
     startbutton.addEventListener('click', function(ev){
@@ -218,7 +216,7 @@ slug: Web/API/Media_Capture_and_Streams_API/Taking_still_photos
 
 Поскольку мы снимаем изображения с веб-камеры пользователя, захватывая кадры из элемента {{HTMLElement("video")}} , можно легко применить фильтры и забавные эффекты к элементу video. Оказывается, любые CSS-фильтры, которые вы применяете к элементу с помощью свойства {{cssxref ("filter")}}, влияют на захваченную фотографию.Эти фильтры могут варьироваться от простых (делая изображение черно-белым) до экстремальных (размытие по Гауссу и вращение оттенка).
 
-Вы можете экспериментировать с этими эффектами, используя, например, инструмент разработчика FirefoxYou [редактор стилей](/ru/docs/Tools/Style_Editor); смотрим [Редактирование с CSS фильтрами](/ru/docs/Tools/Page_Inspector/How_to/Edit_CSS_filters) о подробностях выполнения.
+Вы можете экспериментировать с этими эффектами, используя, например, инструмент разработчика FirefoxYou [редактор стилей](https://firefox-source-docs.mozilla.org/devtools-user/style_editor/index.html); смотрим [Редактирование с CSS фильтрами](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_css_filters/index.html) о подробностях выполнения.
 
 ## Использование определённых устройств
 
@@ -226,8 +224,7 @@ slug: Web/API/Media_Capture_and_Streams_API/Taking_still_photos
 
 ## Смотрите также
 
-- [Пробуем пример](https://mdn-samples.mozilla.org/s/webrtc-capturestill)
-- [Примеры на Github](https://github.com/mdn/samples-server/tree/master/s/webrtc-capturestill)
-- {{domxref("Navigator.mediaDevices.getUserMedia()")}}
-- [Использование изображений](/ru/docs/Web/API/Canvas_API/Tutorial/Using_images)
+- [Пример на Github](https://github.com/mdn/samples-server/tree/master/s/webrtc-capturestill)
+- {{domxref("MediaDevices.getUserMedia")}}
+- [Использование кадров из видео](/ru/docs/Web/API/Canvas_API/Tutorial/Using_images#использование_кадров_из_видео) в руководстве по Canvas
 - {{domxref("CanvasRenderingContext2D.drawImage()")}}

--- a/files/ru/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
+++ b/files/ru/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
@@ -5,7 +5,7 @@ slug: Web/API/WebRTC_API/Simple_RTCDataChannel_sample
 
 {{DefaultAPISidebar("WebRTC")}}
 
-Интерфейс {{domxref("RTCDataChannel")}} является функциональностью [WebRTC API](/ru/docs/Web/API/WebRTC_API) , который позволяет открыть канал между узлами соединения, по которому можно отправлять и получать произвольные данные. Эти API намеренно сходны с [WebSocket API](/ru/docs/Web/API/WebSocket_API), для использования единой программной модели.
+Интерфейс {{domxref("RTCDataChannel")}} является функциональностью [WebRTC API](/ru/docs/Web/API/WebRTC_API) , который позволяет открыть канал между узлами соединения, по которому можно отправлять и получать произвольные данные. Эти API намеренно сходны с [WebSocket API](/ru/docs/Web/API/WebSockets_API), для использования единой программной модели.
 
 В этом примере мы откроем соединение {{domxref ("RTCDataChannel")}}, связывающее два элемента на одной странице. Хотя это явно надуманный сценарий, он полезен для демонстрации последовательности соединения двух узлов. Мы расскажем о механизме выполнения соединения, передачи и получения данных, но оставим немного информации о поиске и подключении к удалённому компьютеру для другого примера.
 
@@ -64,7 +64,7 @@ The WebRTC API makes heavy use of {{jsxref("Promise")}}s. They make it very easy
 
 ### Starting up
 
-When the script is run, we set up an {{event("load")}} event listener, so that once the page is fully loaded, our `startup()` function is called.
+When the script is run, we set up an event listener, so that once the page is fully loaded, our `startup()` function is called.
 
 ```js
 function startup() {
@@ -111,7 +111,7 @@ remoteConnection = new RTCPeerConnection();
 remoteConnection.ondatachannel = receiveChannelCallback;
 ```
 
-The remote end is set up similarly, except that we don't need to explicitly create an {{domxref("RTCDataChannel")}} ourselves, since we're going to be connected through the channel established above. Instead, we set up a {{event("datachannel")}} event handler; this will be called when the data channel is opened; this handler will receive an `RTCDataChannel` object; you'll see this below.
+The remote end is set up similarly, except that we don't need to explicitly create an {{domxref("RTCDataChannel")}} ourselves, since we're going to be connected through the channel established above. Instead, we set up a event handler; this will be called when the data channel is opened; this handler will receive an `RTCDataChannel` object; you'll see this below.
 
 #### Set up the ICE candidates
 
@@ -129,7 +129,7 @@ remoteConnection.onicecandidate = (e) =>
   localConnection.addIceCandidate(e.candidate).catch(handleAddCandidateError);
 ```
 
-We configure each {{domxref("RTCPeerConnection")}} to have an event handler for the {{event("icecandidate")}} event.
+We configure each {{domxref("RTCPeerConnection")}} to have an event handler for the event.
 
 #### Start the connection attempt
 
@@ -164,7 +164,7 @@ Let's go through this line by line and decipher what it means.
 
 #### Handling successful peer connection
 
-As each side of the peer-to-peer connection is successfully linked up, the corresponding {{domxref("RTCPeerConnection")}}'s {{event("icecandidate")}} event is fired. These handlers can do whatever's needed, but in this example, all we need to do is update the user interface:
+As each side of the peer-to-peer connection is successfully linked up, the corresponding {{domxref("RTCPeerConnection")}}'s event is fired. These handlers can do whatever's needed, but in this example, all we need to do is update the user interface:
 
 ```js
 function handleLocalAddCandidateSuccess() {
@@ -180,7 +180,7 @@ The only thing we do here is disable the "Connect" button when the local peer is
 
 #### Connecting the data channel
 
-Once the {{domxref("RTCPeerConnection")}} is open, the {{event("datachannel")}} event is sent to the remote to complete the process of opening the data channel; this invokes our `receiveChannelCallback()` method, which looks like this:
+Once the {{domxref("RTCPeerConnection")}} is open, the event is sent to the remote to complete the process of opening the data channel; this invokes our `receiveChannelCallback()` method, which looks like this:
 
 ```js
 function receiveChannelCallback(event) {
@@ -191,7 +191,7 @@ function receiveChannelCallback(event) {
 }
 ```
 
-The {{event("datachannel")}} event includes, in its channel property, a reference to a {{domxref("RTCDataChannel")}} representing the remote peer's end of the channel. This is saved, and we set up, on the channel, event listeners for the events we want to handle. Once this is done, our `handleReceiveMessage()` method will be called each time data is received by the remote peer, and the `handleReceiveChannelStatusChange()` method will be called any time the channel's connection state changes, so we can react when the channel is fully opened and when it's closed.
+The event includes, in its channel property, a reference to a {{domxref("RTCDataChannel")}} representing the remote peer's end of the channel. This is saved, and we set up, on the channel, event listeners for the events we want to handle. Once this is done, our `handleReceiveMessage()` method will be called each time data is received by the remote peer, and the `handleReceiveChannelStatusChange()` method will be called any time the channel's connection state changes, so we can react when the channel is fully opened and when it's closed.
 
 ### Handling channel status changes
 
@@ -240,7 +240,7 @@ The `handleReceiveChannelStatusChange()` method receives as an input parameter t
 
 ### Sending messages
 
-When the user presses the "Send" button, the sendMessage() method we've established as the handler for the button's {{event("click")}} event is called. That method is simple enough:
+When the user presses the "Send" button, the sendMessage() method we've established as the handler for the button's event is called. That method is simple enough:
 
 ```js
 function sendMessage() {
@@ -306,4 +306,4 @@ This starts by closing each peer's {{domxref("RTCDataChannel")}}, then, similarl
 
 ## Следующие шаги
 
-[Попробуйте пример в деле](https://mdn-samples.mozilla.org/s/webrtc-simple-datachannel) и посмотрите на [исходный код простого примера](https://github.com/mdn/samples-server/tree/master/s/webrtc-simple-datachannel), доступный на GitHub.
+Посмотрите на [исходный код простого примера](https://github.com/mdn/samples-server/tree/master/s/webrtc-simple-datachannel), доступный на GitHub.


### PR DESCRIPTION
### Description

This PR removes broken links to `mdn-samples.mozilla.org` for `ru` locale.

And also fixes autofixeble flaws in affected documents.

### Related issues and pull requests

Relates to #7322