### PR TITLE
[pt-br] remove broken link to mdn-samples.mozilla.org

### DIFF
--- a/files/pt-br/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
+++ b/files/pt-br/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
@@ -306,4 +306,4 @@ Isso começa por fechar cada par {{domxref("RTCDataChannel")}}, então, de forma
 
 ## Próximos passos
 
-Você poderia [tentar este exemplo](https://mdn-samples.mozilla.org/s/webrtc-simple-datachannel) e dar uma olhada no código fonte [webrtc-simple-datachannel](https://github.com/mdn/samples-server/tree/master/s/webrtc-simple-datachannel), disponível no GitHub.
+Dar uma olhada no código fonte [webrtc-simple-datachannel](https://github.com/mdn/samples-server/tree/master/s/webrtc-simple-datachannel), disponível no GitHub.


### PR DESCRIPTION
### Description

This PR removes broken link to `mdn-samples.mozilla.org` for `pt-BR` locale.

### Motivation

Synchronization with https://github.com/mdn/content

### Related issues and pull requests

Relates to #7325