### PR TITLE
[fr] remove outdated link to `discuss.atom.io`

### DIFF
--- a/files/fr/learn/common_questions/tools_and_setup/available_text_editors/index.md
+++ b/files/fr/learn/common_questions/tools_and_setup/available_text_editors/index.md
@@ -59,15 +59,16 @@ Voici un tableau de quelques éditeurs de texte connus :
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://atom.io/">Atom</a></td>
-      <td>MIT/BSD</td>
+      <td><a href="https://bluefish.openoffice.nl">Bluefish</a></td>
+      <td>GPL 3</td>
       <td style="text-align: center">Gratuit</td>
       <td>Windows, Mac, Linux</td>
-      <td><a href="https://discuss.atom.io/categories">Forum</a></td>
-      <td><a href="https://atom.io/docs/latest/">Manuel en ligne</a></td>
-      <td style="text-align: center">
-        <a href="https://atom.io/packages">Oui</a>
+      <td>
+        <a href="https://bfwiki.tellefsen.net/index.php/Mailinglists">liste de diffusion</a>,
+        <a href="https://bfwiki.tellefsen.net/index.php/Main_Page">Wiki</a>
       </td>
+      <td><a href="https://bluefish.openoffice.nl/manual/">Manuel en ligne</a></td>
+      <td>Oui</td>
     </tr>
     <tr>
       <td><a href="http://brackets.io/">Brackets</a></td>

--- a/files/fr/learn/common_questions/tools_and_setup/available_text_editors/index.md
+++ b/files/fr/learn/common_questions/tools_and_setup/available_text_editors/index.md
@@ -191,12 +191,12 @@ Voici un tableau de quelques éditeurs de texte connus :
       <td>Windows, Mac, Linux</td>
       <td><a href="http://forum.komodoide.com/" rel="external">Forum</a></td>
       <td>
-        <a href="http://docs.activestate.com/komodo/8.5/" rel="external"
+        <a href="https://docs.activestate.com/komodo" rel="external"
           >Manuel en ligne</a
         >
       </td>
       <td style="text-align: center">
-        <a href="http://komodoide.com/resources/addons/">Oui</a>
+        <a href="https://docs.activestate.com/komodo/12/manual/extensions.html">Oui</a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
### Description

This PR removes outdated "Atom" editor from `Learn/Common_questions/Tools_and_setup/Available_text_editors` and add "Bluefish" editor.

Also fixes links to Komodo resources.

### Motivation

Synchronization with https://github.com/mdn/content

### Related issues and pull requests

Relates to #7319