### PR TITLE
[fr] replace `amazing.site` with `example.com` in `Web/HTTP/CORS/Errors/CORSMissingAllowOrigin` example

### DIFF
--- a/files/fr/web/http/cors/errors/corsmissingalloworigin/index.md
+++ b/files/fr/web/http/cors/errors/corsmissingalloworigin/index.md
@@ -23,10 +23,10 @@ La réponse à la requête [CORS](/fr/docs/Glossary/CORS) ne contient pas l'en-t
 
 Si vous avez le contrôle du serveur, vous pouvez ajouter l'origine de la requête à la liste des domaines autorisés à accéder aux ressources du serveur en l'ajoutant aux valeurs de l'en-tête `Access-Control-Allow-Origin`.
 
-Par exemple, pour autoriser le site `https://amazing.site` à accéder aux ressources avec CORS, l'en-tête doit être comme suit&nbsp;:
+Par exemple, pour autoriser le site `https://example.com` à accéder aux ressources avec CORS, l'en-tête doit être comme suit&nbsp;:
 
 ```http
-Access-Control-Allow-Origin: https://amazing.site
+Access-Control-Allow-Origin: https://example.com
 ```
 
 Vous pouvez aussi configurer le serveur pour autoriser tous les domaines à accéder aux ressources avec le caractère générique `*`. Ceci ne devrait être utilisé que pour des API publiques. Les API privées ne devraient jamais utiliser `*`, et devraient à la place utiliser un domaine ou un ensemble de domaines. De plus, l'astérisque ne fonctionne que pour les requêtes ayant `anonymous` comme valeur pour l'attribut [`crossorigin`](/fr/docs/Web/HTML/Attributes/crossorigin)&nbsp;; il empêche également l'envoi d'identifiants (par exemple des cookies) dans une requête.


### PR DESCRIPTION
### Description

This PR replaces `amazing.site` with `example.com` in `Web/HTTP/CORS/Errors/CORSMissingAllowOrigin` example for `fr` locale.

### Motivation

Synchronization with https://github.com/mdn/content

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/26252