### PR TITLE
[pt-br] replace `amazing.site` with `example.com` in `Web/HTTP/CORS/Errors/CORSMissingAllowOrigin` example

### DIFF
--- a/files/pt-br/web/http/cors/errors/corsmissingalloworigin/index.md
+++ b/files/pt-br/web/http/cors/errors/corsmissingalloworigin/index.md
@@ -17,10 +17,10 @@ A resposta à requisição {{Glossary ("CORS")}} está sem o cabeçalho {{HTTPHe
 
 Se o servidor estiver sob seu controle, adicione a origem do site solicitante ao conjunto de domínios de acesso permitido, adicionando-o ao valor do cabeçalho `Access-Control-Allow-Origin`.
 
-Por exemplo, para permitir que um site da origem `https://amazing.site` acesse ao recurso usando CORS, o cabeçalho deve conter:
+Por exemplo, para permitir que um site da origem `https://example.com` acesse ao recurso usando CORS, o cabeçalho deve conter:
 
 ```
-Access-Control-Allow-Origin: https://amazing.site
+Access-Control-Allow-Origin: https://example.com
 ```
 
 Você também pode configurar um site para permitir que qualquer site o acesse usando o curinga `"*"`. Você só deve usar isso para APIs públicas. As APIs privadas nunca devem usar `"*"` e devem ter um domínio ou domínios específicos definidos. Além disso, o curinga só funciona para solicitações feitas com o atributo [`crossorigin`](/pt-BR/docs/Web/HTML/Global_attributes#crossorigin) definido como `"anonymous"`.

--- a/files/pt-br/web/http/cors/errors/corsmissingalloworigin/index.md
+++ b/files/pt-br/web/http/cors/errors/corsmissingalloworigin/index.md
@@ -19,13 +19,13 @@ Se o servidor estiver sob seu controle, adicione a origem do site solicitante ao
 
 Por exemplo, para permitir que um site da origem `https://example.com` acesse ao recurso usando CORS, o cabeçalho deve conter:
 
-```
+```http
 Access-Control-Allow-Origin: https://example.com
 ```
 
 Você também pode configurar um site para permitir que qualquer site o acesse usando o curinga `"*"`. Você só deve usar isso para APIs públicas. As APIs privadas nunca devem usar `"*"` e devem ter um domínio ou domínios específicos definidos. Além disso, o curinga só funciona para solicitações feitas com o atributo [`crossorigin`](/pt-BR/docs/Web/HTML/Global_attributes#crossorigin) definido como `"anonymous"`.
 
-```
+```http
 Access-Control-Allow-Origin: *
 ```
 


### PR DESCRIPTION
### Description

This PR replaces `amazing.site` with `example.com` in `Web/HTTP/CORS/Errors/CORSMissingAllowOrigin` example for `pt-BR` locale.

### Motivation

Synchronization with https://github.com/mdn/content

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/26252, #7325