### PR TITLE
[zh-cn]: add translation for `FileReaderSync.readAsText()`

### DIFF
--- a/files/zh-cn/web/api/filereadersync/readastext/index.md
+++ b/files/zh-cn/web/api/filereadersync/readastext/index.md
@@ -1,0 +1,60 @@
+---
+title: FileReaderSync：readAsText() 方法
+slug: Web/API/FileReaderSync/readAsText
+l10n:
+  sourceCommit: 1dad49fff047729e8dcca313a45ccb4cc2d2526f
+---
+
+{{APIRef("File API")}} {{AvailableInWorkers("worker_except_service")}}
+
+{{DOMxRef("FileReaderSync")}} 接口的 **`readAsText()`** 方法允许以同步方式读取 {{DOMxRef("File")}} 或 {{DOMxRef("Blob")}} 对象 并转换为字符串。此接口仅在 [worker](/zh-CN/docs/Web/API/Worker) 中[可用](/zh-CN/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers)，因为它支持同步 I/O，可能导致潜在的阻塞。
+
+## 语法
+
+```js-nolint
+readAsText(blob)
+readAsText(blob, encoding)
+```
+
+### 参数
+
+- `blob`
+  - : 要读取的 {{DOMxRef("File")}} 或 {{DOMxRef("Blob")}} 对象。
+- `encoding` {{optional_inline}}
+  - : 此可选参数指定要使用的编码（例如 `iso-8859-1` 或 `UTF-8`）。如果不存在，如果不存在，该方法将对其应用检测算法以确定其编码。
+
+### 返回值
+
+表示输入数据的字符串。
+
+### 异常
+
+此方法可能引发以下异常：
+
+- `NotFoundError` {{domxref("DOMException")}}
+  - : 如果无法找到 DOM {{DOMxRef("File")}} 或 {{DOMxRef("Blob")}} 对象表示的资源，例如因为它已被删除，则抛出该异常。
+- `SecurityError` {{domxref("DOMException")}}
+  - : 如果检测到以下有问题的情况之一，则抛出该异常：
+    - 资源已被第三方修改；
+    - 同时执行太多读取；
+    - 资源指向的文件对于从 Web 上使用来说是不安全的（比如它是系统文件）。
+- `NotReadableError` {{domxref("DOMException")}}
+  - : 如果由于权限问题（例如并发锁）而无法读取资源，则抛出该异常。
+- `EncodingError` {{domxref("DOMException")}}
+  - : 如果资源是 data URL 并且超出每个浏览器定义的限制长度，则抛出该异常。
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- [文件 API](/zh-CN/docs/Web/API/File_API)
+- {{DOMxRef("File")}}
+- {{DOMxRef("FileReaderSync")}}
+- {{DOMxRef("FileReader")}}
+- {{ domxref("Blob") }}

--- a/files/zh-cn/web/api/filereadersync/readastext/index.md
+++ b/files/zh-cn/web/api/filereadersync/readastext/index.md
@@ -2,12 +2,12 @@
 title: FileReaderSync：readAsText() 方法
 slug: Web/API/FileReaderSync/readAsText
 l10n:
-  sourceCommit: 1dad49fff047729e8dcca313a45ccb4cc2d2526f
+  sourceCommit: 502e8c3f0be95c6f42afe6a72113b029b290b9e8
 ---
 
 {{APIRef("File API")}} {{AvailableInWorkers("worker_except_service")}}
 
-{{DOMxRef("FileReaderSync")}} 接口的 **`readAsText()`** 方法允许以同步方式读取 {{DOMxRef("File")}} 或 {{DOMxRef("Blob")}} 对象 并转换为字符串。此接口仅在 [worker](/zh-CN/docs/Web/API/Worker) 中[可用](/zh-CN/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers)，因为它支持同步 I/O，可能导致潜在的阻塞。
+{{DOMxRef("FileReaderSync")}} 接口的 **`readAsText()`** 方法允许以同步方式读取 {{DOMxRef("File")}} 或 {{DOMxRef("Blob")}} 对象并转换为字符串。此接口仅在 [worker](/zh-CN/docs/Web/API/Worker) 中[可用](/zh-CN/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers)，因为它支持同步 I/O，可能导致潜在的阻塞。
 
 ## 语法
 
@@ -21,7 +21,7 @@ readAsText(blob, encoding)
 - `blob`
   - : 要读取的 {{DOMxRef("File")}} 或 {{DOMxRef("Blob")}} 对象。
 - `encoding` {{optional_inline}}
-  - : 此可选参数指定要使用的编码（例如 `iso-8859-1` 或 `UTF-8`）。如果不存在，如果不存在，该方法将对其应用检测算法以确定其编码。
+  - : 此可选参数指定要使用的编码（例如 `iso-8859-1` 或 `UTF-8`）。如果不存在，该方法将对其应用检测算法以确定其编码。
 
 ### 返回值
 

--- a/files/zh-cn/web/api/filereadersync/readastext/index.md
+++ b/files/zh-cn/web/api/filereadersync/readastext/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{APIRef("File API")}} {{AvailableInWorkers("worker_except_service")}}
 
-{{DOMxRef("FileReaderSync")}} 接口的 **`readAsText()`** 方法允许以同步方式读取 {{DOMxRef("File")}} 或 {{DOMxRef("Blob")}} 对象并转换为字符串。此接口仅在 [worker](/zh-CN/docs/Web/API/Worker) 中[可用](/zh-CN/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers)，因为它支持同步 I/O，可能导致潜在的阻塞。
+{{DOMxRef("FileReaderSync")}} 接口的 **`readAsText()`** 方法允许以同步方式读取 {{DOMxRef("File")}} 或 {{DOMxRef("Blob")}} 对象并将其转换为字符串。此接口仅在 [worker](/zh-CN/docs/Web/API/Worker) 中[可用](/zh-CN/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers)，因为它支持同步 I/O，可能导致潜在的阻塞。
 
 ## 语法
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

see https://developer.mozilla.org/en-US/docs/Web/API/FileReaderSync/readAsText

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

part of the https://github.com/mdn/translated-content/issues/20165

depends on https://github.com/mdn/content/pull/33554 and https://github.com/mdn/content/pull/33551

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
