### PR TITLE
[ja] correction of mistranslation for non-async

### DIFF
--- a/files/ja/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -80,9 +80,9 @@ browser.runtime.onMessage.hasListener(listener)
         - `sendResponse()` に対する参照を保持したままリスナー関数から `true` を返す。そうすると、リスナー関数から復帰した後でも `sendResponse()` が実行できます。
         - リスナー関数から {{jsxref("Promise")}} を返して、応答の準備ができたときにその Promise を解決する。こちらがより好ましい方法です。
 
-    リスナー関数は、Boolean または {{jsxref("Promise")}} のいずれかを返します。
+    リスナー関数は、論理値または {{jsxref("Promise")}} のいずれかを返します。
 
-    > **メモ:** `addListener()` に非同期関数を渡すと、リスナーはメッセージを受け取るたびに Promise を返すため、他のリスナーが応答できなくなります。
+    > **メモ:** `addListener()` に非同期関数を渡すと、リスナーはメッセージを受け取るたびにプロミスを返すため、他のリスナーが応答できなくなります。
     >
     > ```js example-bad
     > // このようにしないでください
@@ -93,7 +93,7 @@ browser.runtime.onMessage.hasListener(listener)
     > });
     > ```
     >
-    > もし、リスナーが特定の種類のメッセージにのみ応答したい場合は、リスナーを `async` ではない関数として定義し、リスナーが応答するメッセージに対してのみ Promise を、それ以外は false または undefined を返してください。
+    > もし、リスナーが特定の種類のメッセージにのみ応答したい場合は、リスナーを `async` ではない関数として定義し、リスナーが応答するメッセージに対してのみプロミスを、それ以外は false または undefined を返してください。
     >
     > ```js example-good
     > browser.runtime.onMessage.addListener((data, sender) => {

--- a/files/ja/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -80,7 +80,7 @@ browser.runtime.onMessage.hasListener(listener)
         - `sendResponse()` に対する参照を保持したままリスナー関数から `true` を返す。そうすると、リスナー関数から復帰した後でも `sendResponse()` が実行できます。
         - リスナー関数から {{jsxref("Promise")}} を返して、応答の準備ができたときにその Promise を解決する。こちらがより好ましい方法です。
 
-    リスナー関数は、Boolea または {{jsxref("Promise")}} のいずれかを返します。
+    リスナー関数は、Boolean または {{jsxref("Promise")}} のいずれかを返します。
 
     > **メモ:** `addListener()` に非同期関数を渡すと、リスナーはメッセージを受け取るたびに Promise を返すため、他のリスナーが応答できなくなります。
     >

--- a/files/ja/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -80,9 +80,9 @@ browser.runtime.onMessage.hasListener(listener)
         - `sendResponse()` に対する参照を保持したままリスナー関数から `true` を返す。そうすると、リスナー関数から復帰した後でも `sendResponse()` が実行できます。
         - リスナー関数から {{jsxref("Promise")}} を返して、応答の準備ができたときにその Promise を解決する。こちらがより好ましい方法です。
 
-    リスナー関数は、論理値または {{jsxref("Promise")}} のいずれかを返します。
+    リスナー関数は、Boolea または {{jsxref("Promise")}} のいずれかを返します。
 
-    > **メモ:** `addListener()` に非同期関数を渡すと、リスナーはメッセージを受け取るたびにプロミスを返すため、他のリスナーが応答できないようになります。
+    > **メモ:** `addListener()` に非同期関数を渡すと、リスナーはメッセージを受け取るたびに Promise を返すため、他のリスナーが応答できなくなります。
     >
     > ```js example-bad
     > // このようにしないでください
@@ -93,7 +93,7 @@ browser.runtime.onMessage.hasListener(listener)
     > });
     > ```
     >
-    > もし、リスナーが特定の種類のメッセージにのみ応答したい場合は、リスナーを非同期関数として定義し、リスナーが応答する予定のメッセージに対してのみプロミスを返す必要があります - そうでなければ、false または undefined を返してください。
+    > もし、リスナーが特定の種類のメッセージにのみ応答したい場合は、リスナーを `async` ではない関数として定義し、リスナーが応答するメッセージに対してのみ Promise を、それ以外は false または undefined を返してください。
     >
     > ```js example-good
     > browser.runtime.onMessage.addListener((data, sender) => {


### PR DESCRIPTION
- non-`async`
  - x : 非同期関数
  - o : async ではない関数

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

In Current Japanese document, that non-`async` function is translated to 非同期関数 (asynchronous function) in Japanese.
I've corrected it with `async` を使わない関数 which means that a function doesn't use `asynx` in Japanese.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

It just mistranslation to opposition mean.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
