### PR TITLE
[ru] remove obsolete links to `mail.mozilla.org`

### DIFF
--- a/files/ru/mozilla/add-ons/webextensions/index.md
+++ b/files/ru/mozilla/add-ons/webextensions/index.md
@@ -8,8 +8,6 @@ slug: Mozilla/Add-ons/WebExtensions
 [WebExtension API](/ru/docs/Mozilla/Add-ons/WebExtensions) — кросс-браузерная система разработки дополнений браузера.
 В значительной степени эта система совместима с [Chrome Extensions API](https://developer.chrome.com/extensions), которая поддерживается в Google Chrome и Opera. Расширения, написанные для этих браузеров, в большинстве случаев будут работать с Firefox или [Microsoft Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/documentation/extensions/) [лишь с минимальными изменениями](/ru/Add-ons/WebExtensions/Porting_from_Google_Chrome). Эти API также полностью совместимы с [мультипоточным Firefox](/ru/Firefox/Multiprocess_Firefox).
 
-Также мы намерены расширять API для поддержки нужд разработчиков дополнений, поэтому, если у вас есть идеи, то мы их с удовольствием выслушаем. Вы можете связаться с нами через [dev-addons mailing list](https://mail.mozilla.org/listinfo/dev-addons) или [#webextensions](irc://irc.mozilla.org/webextensions) на [IRC](https://wiki.mozilla.org/IRC).
-
 ### Приступая к работе
 
 - [Что такое расширения?](/ru/Add-ons/WebExtensions/What_are_WebExtensions)

--- a/files/ru/mozilla/add-ons/webextensions/what_are_webextensions/index.md
+++ b/files/ru/mozilla/add-ons/webextensions/what_are_webextensions/index.md
@@ -45,8 +45,6 @@ slug: Mozilla/Add-ons/WebExtensions/What_are_WebExtensions
 
 Расширения для Firefox создаются с помощью [WebExtension API](/ru/docs/Mozilla/Add-ons/WebExtensions) — кросс-браузерной системы разработки дополнений браузера. В значительной степени её API совместим с [extension API](https://developer.chrome.com/extensions), который поддерживается браузерами Google Chrome и Opera. Расширения, разработанные для этих браузеров, в большинстве случаев будут работать в Firefox или Microsoft Edge с минимальными изменениями. Также API полностью совместим с [мультипроцессным Firefox](/ru/Firefox/Multiprocess_Firefox).
 
-Мы также намерены расширять API для поддержки нужд разработчиков дополнений, и если у вас есть идеи, мы будем рады услышать их. Вы можете связаться с нами через рассылку [dev-addons mailing list](https://mail.mozilla.org/listinfo/dev-addons) или на [IRC](https://wiki.mozilla.org/IRC) канале [#webextensions](irc://irc.mozilla.org/webextensions).
-
 ## Что дальше?
 
 - Попробуйте создать [Ваше первое расширение](/ru/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension).


### PR DESCRIPTION
### Description

This PR removes obsolete links to `mail.mozilla.org` from `ru` locale

### Related issues and pull requests

Relates to #7322