### PR TITLE
[es] remove obsolete `Glossary/Simple_header` from example

### DIFF
--- a/files/es/web/http/basics_of_http/evolution_of_http/index.md
+++ b/files/es/web/http/basics_of_http/evolution_of_http/index.md
@@ -93,14 +93,14 @@ HTTP/1.1 aclaró ambigüedades y añadió numerosas mejoras:
 
 El flujo normal de una serie de peticiones y respuestas, bajo una única conexión, se expone a continuación:
 
-```
-GET /es/docs/Glossary/Simple_header HTTP/1.1
+```http
+GET /es/docs/Glossary/CORS-safelisted_request_header HTTP/1.1
 Host: developer.mozilla.org
 User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:50.0) Gecko/20100101 Firefox/50.0
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
 Accept-Language: en-US,en;q=0.5
 Accept-Encoding: gzip, deflate, br
-Referer: https://developer.mozilla.org/es/docs/Glossary/Simple_header
+Referer: https://developer.mozilla.org/es/docs/Glossary/CORS-safelisted_request_header
 
 200 OK
 Connection: Keep-Alive
@@ -116,14 +116,13 @@ Vary: Cookie, Accept-Encoding
 
 (...contenido...)
 
-
 GET /static/img/header-background.png HTTP/1.1
 Host: developer.mozilla.org
 User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:50.0) Gecko/20100101 Firefox/50.0
 Accept: */*
 Accept-Language: en-US,en;q=0.5
 Accept-Encoding: gzip, deflate, br
-Referer: https://developer.mozilla.org/es/docs/Glossary/Simple_header
+Referer: https://developer.mozilla.org/es/docs/Glossary/CORS-safelisted_request_header
 
 200 OK
 Age: 9578461


### PR DESCRIPTION
### Description

This PR replaces obsolete URL in example in `Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP` document for `es` locale.

### Motivation

Synchronization with https://github.com/mdn/content

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/33397