### PR TITLE
[ko] unify links to Mozilla Firefox source code

### DIFF
--- a/files/ko/web/api/indexeddb_api/using_indexeddb/index.md
+++ b/files/ko/web/api/indexeddb_api/using_indexeddb/index.md
@@ -1333,7 +1333,7 @@ Further reading for you to find out more information if desired.
 
 - [IndexedDB API Reference](/en/IndexedDB)
 - [Indexed Database API Specification](http://www.w3.org/TR/IndexedDB/)
-- IndexedDB [interface files](https://mxr.mozilla.org/mozilla-central/find?text=&string=dom%2FindexedDB%2F.*%5C.idl&regexp=1) in the Firefox source code
+- IndexedDB [interface files](https://searchfox.org/mozilla-central/search?q=dom%2FindexedDB%2F.*%5C.idl&path=&case=false&regexp=true) in the Firefox source code
 
 ### Tutorials and guides
 

--- a/files/ko/web/api/xsltprocessor/index.md
+++ b/files/ko/web/api/xsltprocessor/index.md
@@ -3,6 +3,8 @@ title: Using the Mozilla JavaScript interface to XSL Transformations
 slug: Web/API/XSLTProcessor
 ---
 
+{{APIRef("XSLT")}}
+
 이 문서는 Mozilla 1.2의 JavaScript 인터페이스부터 XSLT 처리 엔진(TransforMiiX)까지 설명합니다.
 
 ### XSLTProcessor 만들기
@@ -29,11 +31,11 @@ function onload() {
 }
 ```
 
-`importStylesheet`는 DOM 노드인 인수가 하나 필요합니다. 그 노드가 문서 노드면 전체 XSL Transform이나 [literal result element transform](http://www.w3.org/TR/xslt#result-element-stylesheet)에 넘길 수 있습니다, 그렇지 않으면 `xsl:stylesheet`나 `xsl:transform` 요소이어야 합니다.
+`importStylesheet`는 DOM 노드인 인수가 하나 필요합니다. 그 노드가 문서 노드면 전체 XSL Transform이나 [literal result element transform](https://www.w3.org/TR/xslt#result-element-stylesheet)에 넘길 수 있습니다, 그렇지 않으면 `xsl:stylesheet`나 `xsl:transform` 요소이어야 합니다.
 
 ### 문서 변환하기
 
-지정한 XSLT 스타일시트를 써서 문서를 변환하기 위해 [`transformToDocument()`](#transformToDocument)나 [`transformToFragment()`](#transformToFragment) 메소드를 쓸 수 있습니다.
+지정한 XSLT 스타일시트를 써서 문서를 변환하기 위해 [`transformToDocument()`](#transformtodocument)나 [`transformToFragment()`](#transformtofragment) 메소드를 쓸 수 있습니다.
 
 #### transformToDocument
 
@@ -43,7 +45,7 @@ function onload() {
 var newDocument = processor.transformToDocument(domToBeTransformed);
 ```
 
-결과 개체는 스타일시트의 [output 메소드](http://www.w3.org/TR/xslt#output)가 `html`이면 `HTMLDocument`, `xml`이면 `XMLDocument`, `text`이면 자식이 text인 단일 루트 요소 `<transformiix:result>`를 갖는 `XMLDocument`입니다.
+결과 개체는 스타일시트의 [output 메소드](https://www.w3.org/TR/xslt#output)가 `html`이면 `HTMLDocument`, `xml`이면 `XMLDocument`, `text`이면 자식이 text인 단일 루트 요소 `<transformiix:result>`를 갖는 `XMLDocument`입니다.
 
 #### transformToFragment
 
@@ -60,27 +62,22 @@ var newFragment = processor.transformToFragment(domToBeTransformed, ownerDocumen
 
 ### 매개변수 설정
 
-`setParameter`, `getParameter`, `removeParameter` 메소드를 써서 [parameters for the stylesheet](http://www.w3.org/TR/xslt#variables)를 조절할 수 있습니다. 이들은 모두 `setParameter` 메소드는 세 번째도 취하면서 처음 두 매개변수로 이름공간 URI와 지역명을 설정한 매개변수 값을 취합니다.
+`setParameter`, `getParameter`, `removeParameter` 메소드를 써서 [parameters for the stylesheet](https://www.w3.org/TR/xslt#variables)를 조절할 수 있습니다. 이들은 모두 `setParameter` 메소드는 세 번째도 취하면서 처음 두 매개변수로 이름공간 URI와 지역명을 설정한 매개변수 값을 취합니다.
 
 ### 재설정
 
 `XSLTProcessor` 개체는 또한 모든 스타일시트와 매개변수를 제거하고 처리기(processor)를 초기 상태로 되돌리는 데 쓸 수 있는 `reset()` 메소드를 구현합니다. 이 메소드는 [Mozilla](/ko/Gecko) 1.3과 그 뒤에 구현됩니다.
 
-### Resources
+## 명세서
 
-- [nsIXSLTProcessor.idl](https://dxr.mozilla.org/mozilla-central/source/content/xslt/public/nsIXSLTProcessor.idl)는 항상 `XSLTProcessor` 개체의 실제 인터페이스를 반영합니다.
+{{Specifications}}
 
-  - [A XULPlanet reference page](http://xulplanet.com/references/objref/XSLTProcessor.html).
+## 브라우저 호환성
 
-- [The nsIXMLProcessorObsolete IDL file](http://lxr.mozilla.org/seamonkey/source/content/xslt/public/nsIXSLTProcessorObsolete.idl)
+{{Compat}}
 
-  : 1.2판보다 앞서는 Mozilla의 JS 인터페이스.
+## 같이 보기
 
-### 원본 문서 정보
-
-- 저자:
-
-  <a class="link-mailto" href="mailto:mike@theoretic.com">Mike Hearn</a>
-
-- 최종 업데이트: December 21, 2005
-- 저작권 정보: Copyright (C) Mike Hearn
+- [XSLT](/ko/docs/Web/XSLT)
+- [XSLT 튜토리얼](https://www.zvon.org/xxl/XSLTutorial/Books/Book1/index.html)
+- [XPath 튜토리얼](https://www.zvon.org/xxl/XPathTutorial/General/examples.html)

--- a/files/ko/web/http/headers/strict-transport-security/index.md
+++ b/files/ko/web/http/headers/strict-transport-security/index.md
@@ -75,7 +75,7 @@ Google은 [HSTS 프리로딩 서비스](https://hstspreload.org/)를 관리하�
 그러나 HSTS 사양의 일부가 아니므로 공식적인 것으로 취급해서는 안 됩니다.
 
 - Chrome의 HSTS 사전 로드 목록 관련 정보: <https://www.chromium.org/hsts>
-- Firefox HSTS 사전 로드 목록 참조: [nsSTSPreloadList.inc](https://hg.mozilla.org/mozilla-central/raw-file/tip/security/manager/ssl/nsSTSPreloadList.inc)
+- Firefox HSTS 사전 로드 목록 참조: [nsSTSPreloadList.inc](https://searchfox.org/mozilla-central/source/security/manager/ssl/nsSTSPreloadList.inc)
 
 ## 예제
 

--- a/files/ko/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/ko/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -3,6 +3,8 @@ title: Introduction to using XPath in JavaScript
 slug: Web/XPath/Introduction_to_using_XPath_in_JavaScript
 ---
 
+{{XsltSidebar}}
+
 이 문서는 JavaScript 안, 확장기능, 웹사이트에서 [XPath](/ko/XPath)를 사용하기 위한 인터페이스를 설명합니다. Mozilla는 [DOM 3 XPath](http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html)를 상당량 구현합니다. 이것은 XPath 식이 HTML과 XML 문서 모두에서 잘 돌아간다는 것을 뜻합니다.
 
 XPath를 사용하는 주 인터페이스는 [document](/ko/DOM/document) 개체의 [evaluate](/ko/DOM/document.evaluate) 함수입니다.
@@ -21,11 +23,7 @@ var xpathResult = document.evaluate( xpathExpression, contextNode, namespaceReso
 
 - `xpathExpression`: 평가할 XPath 식을 포함하는 문자열
 
-<!---->
-
 - `contextNode`: `xpathExpression`이 평가될 모든 자식 노드를 포함하는 문서의 노드. [document](/ko/DOM/document) 노드가 가장 흔히 쓰입니다.
-
-<!---->
 
 - `namespaceResolver`: 그 접두사와 관련된 namespace URI를 나타내는 문자열을 반환하는 `xpathExpression` 내에 포함되는 모든 namespace 접두사를 넘겨주는 함수. 이는 XPath 식에 쓰(이)는 접두사와 문서에 쓰(이)는 아마도 다른 접두사 사이에 변환을 가능하게 합니다. 함수는 어느 한쪽일 수 있습니다.
 
@@ -38,7 +36,7 @@ var xpathResult = document.evaluate( xpathExpression, contextNode, namespaceReso
 
 ### 반환값
 
-`resultType` 매개변수에서 [지정한](#Specifying_the_Return_Type) 형의 `XPathResult` 개체인 `xpathResult`를 반환합니다. `XPathResult` 인터페이스는 [여기](http://lxr.mozilla.org/seamonkey/source/dom/public/idl/xpath/nsIDOMXPathResult.idl)에서 정의됩니다.
+`resultType` 매개변수에서 [지정한](#Specifying_the_Return_Type) 형의 `XPathResult` 개체인 `xpathResult`를 반환합니다. `XPathResult` 인터페이스는 [여기](/ko/docs/Web/API/XPathResult)에서 정의됩니다.
 
 ### Default Namespace Resolver 구현
 


### PR DESCRIPTION
### Description

This PR unifies links to Mozilla Firefox source code by using `searchfox.org` instead of `hg.mozilla.org` and obsolete `lxr.mozilla.org` and `mxr.mozilla.org` for `ko` locale.

Also updates some very old information in `Web/API/XSLTProcessor`.

### Motivation

Synchronization with https://github.com/mdn/content

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/33585
