### PR TITLE
[ru] update `Web/HTTP/Headers/Access-Control-Max-Age` translation

### DIFF
--- a/files/ru/web/http/headers/access-control-max-age/index.md
+++ b/files/ru/web/http/headers/access-control-max-age/index.md
@@ -1,20 +1,22 @@
 ---
 title: Access-Control-Max-Age
 slug: Web/HTTP/Headers/Access-Control-Max-Age
+l10n:
+  sourceCommit: 0880a90f3811475d78bc4b2c344eb4146f25f66c
 ---
 
-Заголовок ответа сервера **`Access-Control-Max-Age`** сообщает браузеру насколько {{glossary("предзапрос")}} (эта информация содержится в заголовках {{HTTPHeader("Access-Control-Allow-Methods")}} и {{HTTPHeader("Access-Control-Allow-Headers")}}) может быть кеширован и опущен при запросах к серверу.
+{{HTTPSidebar}}
+
+Заголовок ответа **`Access-Control-Max-Age`** указывает, на какое время может быть закеширован результат {{glossary("preflight request", "предзапроса")}}. Эта информация содержится в заголовках {{HTTPHeader("Access-Control-Allow-Methods")}} и {{HTTPHeader("Access-Control-Allow-Headers")}}.
 
 <table class="properties">
   <tbody>
     <tr>
       <th scope="row">Тип заголовка</th>
-      <td>{{Glossary("Заголовок ответа")}}</td>
+      <td>{{Glossary("Response header", "Заголовок ответа")}}</td>
     </tr>
     <tr>
-      <th scope="row">
-        {{Glossary("Запрещённое имя заголовка")}}
-      </th>
+      <th scope="row">{{Glossary("Forbidden header name", "Запрещённое имя заголовка")}}</th>
       <td>нет</td>
     </tr>
   </tbody>
@@ -22,22 +24,24 @@ slug: Web/HTTP/Headers/Access-Control-Max-Age
 
 ## Синтаксис
 
-```
+```http
 Access-Control-Max-Age: <delta-seconds>
 ```
 
 ## Параметры
 
-- \<delta-seconds>
-  - : Количество секунд, на которое запрос может быть кеширован.
-    Максимальное значение в Firefox составляет [24 часа](https://dxr.mozilla.org/mozilla-central/rev/7ae377917236b7e6111146aa9fb4c073c0efc7f4/netwerk/protocol/http/nsCORSListenerProxy.cpp#1131) (86400 секунд), в Chromium [10 минут](https://cs.chromium.org/chromium/src/services/network/public/cpp/cors/preflight_result.cc?rcl=43ab0ff8fdcf3a10a89c4d0d0421f461967f2bd5&l=36) (600 секунд). Chromium также определяет значение по умолчанию [5](https://cs.chromium.org/chromium/src/services/network/public/cpp/cors/preflight_result.cc?rcl=43ab0ff8fdcf3a10a89c4d0d0421f461967f2bd5&l=26) секунд.
-    Значение **-1** отменяет кеширование, отправляя предзапрос перед каждым запросом.
+- `<delta-seconds>`
+  - : Максимальное количество секунд, на которое может быть закеширован запрос, целое неотрицательное число.
+    В Firefox составляет [24 часа](https://searchfox.org/mozilla-central/source/netwerk/protocol/http/nsCORSListenerProxy.cpp#1207) (86400 секунд).
+    В Chromium (до версии 76) — [10 минут](https://source.chromium.org/chromium/chromium/src/+/main:services/network/public/cpp/cors/preflight_result.cc;drc=52002151773d8cd9ffc5f557cd7cc880fddcae3e;l=36) (600 секунд).
+    В Chromium (начиная с версии 76) — [2 часа](https://source.chromium.org/chromium/chromium/src/+/main:services/network/public/cpp/cors/preflight_result.cc;drc=49e7c0b4886cac1f3d09dc046bd528c9c811a0fa;l=31) (7200 секунд).
+    Значение по умолчанию равно 5 секундам.
 
 ## Примеры
 
-Кеширование предзапроса на 600 секунд:
+Кеширование предзапроса на 10 минут:
 
-```
+```http
 Access-Control-Max-Age: 600
 ```
 


### PR DESCRIPTION
### Description

This PR updates `Web/HTTP/Headers/Access-Control-Max-Age` translation for `ru` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/33585