### PR TITLE
[pt-BR][es] Remove experimental warning from flatMap translation

### DIFF
--- a/files/es/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -3,7 +3,7 @@ title: Array.prototype.flatMap()
 slug: Web/JavaScript/Reference/Global_Objects/Array/flatMap
 ---
 
-{{JSRef}} {{SeeCompatTable}}
+{{JSRef}}
 
 El método **`flatMap()`** primero mapea cada elemento usando una función de mapeo, luego aplana el resultado en una nueva matriz. Es idéntico a un [map](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/map) seguido de un [flatten](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/flatten)de profundidad 1, pero `flatMap` es a menudo útil y la fusión de ambos en un método es ligeramente más eficiente.
 

--- a/files/pt-br/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -3,7 +3,7 @@ title: Array.prototype.flatMap()
 slug: Web/JavaScript/Reference/Global_Objects/Array/flatMap
 ---
 
-{{JSRef}} {{SeeCompatTable}}
+{{JSRef}}
 
 O método **`flatMap()`** primeiro mapeia cada elemento usando uma função de mapeamento e, em seguida, nivela o resultado em um novo array. É idêntico a um `map` seguido por um `flat` de profundidade 1, mas **`flatMap`** é bastante útil e mescla ambos em um método um pouco mais eficiente.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

Removing the section that says that this is an experimental technology (in both pt-BR and es translations) because this section isn't there in the upstream (english) doc.
I don't know why it was there tbh because I searched in the git history of the upstream doc and I was not able to find that in older versions of that file.

✍️ Summarize your changes in one or two sentences

Remove "experimental technology" section

❓ Why are you making these changes and how do they help readers?

To make sure the translation is telling the truth about the state of the flatMap API and do not discourage someone to use that API.
