### PR TITLE
[ja] Fix typoの修正: `startWith` -> `startsWith`

### DIFF
--- a/files/ja/learn/javascript/first_steps/useful_string_methods/index.md
+++ b/files/ja/learn/javascript/first_steps/useful_string_methods/index.md
@@ -86,7 +86,7 @@ if (browserType.includes("zilla")) {
 }
 ```
 
-文字列が特定の部分文字列で始まるか終わるかを知りたいことはよくあります。これはよくあるニーズなので、 2 つの特別なメソッドがあります。 {{jsxref("String.prototype.startsWith()", "startWith()")}} と {{jsxref("String.prototype.endsWith()", "endsWith()")}} です。
+文字列が特定の部分文字列で始まるか終わるかを知りたいことはよくあります。これはよくあるニーズなので、 2 つの特別なメソッドがあります。 {{jsxref("String.prototype.startsWith()", "startsWith()")}} と {{jsxref("String.prototype.endsWith()", "endsWith()")}} です。
 
 ```js
 const browserType = "mozilla";


### PR DESCRIPTION
### Description

「[便利な文字列メソッド](https://developer.mozilla.org/ja/docs/Learn/JavaScript/First_steps/Useful_string_methods)」における「これはよくあるニーズなので、 2 つの特別なメソッドがあります。 startWith() と endsWith() です。」という記載では `startWith()` というメソッドに言及してますが、実際には `startsWith()` が正しいので修正しました。

### Related issues and pull requests

Fix https://github.com/mozilla-japan/translation/issues/752
