### PR TITLE
[es] add missing trailing comma in `Web/JavaScript/Reference/Operators/Destructuring_assignment` example code

### DIFF
--- a/files/es/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/es/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -162,8 +162,8 @@ console.log(b); // [2, 3]
 
 Ten en cuenta que se lanzará un {{jsxref("SyntaxError")}} si se usa una coma final en el lado derecho con un elemento `rest` o:
 
-```js example-bad
-const [a, ...b] = [1, 2, 3];
+```js-nolint example-bad
+const [a, ...b,] = [1, 2, 3];
 
 // SyntaxError: el elemento rest no puede tener una coma al final
 // Siempre considera usar el operador rest como último elemento


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added a missing trailing comma to a wrong syntax example.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
It can be confusing when the code example meant to demonstrate wrong syntax does not actually contain any errors.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
