### PR TITLE
[zh-cn]: update the translation of URL `revokeObjectURL()` static method

### DIFF
--- a/files/zh-cn/web/api/url/revokeobjecturl_static/index.md
+++ b/files/zh-cn/web/api/url/revokeobjecturl_static/index.md
@@ -30,7 +30,7 @@ URL.revokeObjectURL(objectURL)
 
 ## 示例
 
-参见[使用对象 URL 来显示图片](/zh-CN/docs/Web/API/File_API/Using_files_from_web_applications#示例：使用对象_URL_来显示图片)。
+参见[使用对象 URL 来显示图片](/zh-CN/docs/Web/API/File_API/Using_files_from_web_applications#示例：使用对象_url_来显示图片)。
 
 ## 规范
 
@@ -43,5 +43,5 @@ URL.revokeObjectURL(objectURL)
 ## 参见
 
 - [在 web 应用程序中使用文件](/zh-CN/docs/Web/API/File_API/Using_files_from_web_applications)
-- [使用对象 URL 来显示图片](/zh-CN/docs/Web/API/File_API/Using_files_from_web_applications#示例：使用对象_URL_来显示图片)
+- [使用对象 URL 来显示图片](/zh-CN/docs/Web/API/File_API/Using_files_from_web_applications#示例：使用对象_url_来显示图片)
 - {{domxref("URL.createObjectURL_static", "URL.createObjectURL()")}}

--- a/files/zh-cn/web/api/url/revokeobjecturl_static/index.md
+++ b/files/zh-cn/web/api/url/revokeobjecturl_static/index.md
@@ -1,34 +1,36 @@
 ---
-title: URL.revokeObjectURL()
+title: URL：revokeObjectURL() 实例方法
 slug: Web/API/URL/revokeObjectURL_static
+l10n:
+  sourceCommit: 367b982b93c07f7f99e7bb768a6bf326fa5198e6
 ---
 
-{{ApiRef("URL")}}
+{{APIRef("File API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
-**`URL.revokeObjectURL()`** 静态方法用来释放一个之前已经存在的、通过调用 {{domxref("URL.createObjectURL()")}} 创建的 URL 对象。当你结束使用某个 URL 对象之后，应该通过调用这个方法来让浏览器知道不用在内存中继续保留对这个文件的引用了。
+{{domxref("URL")}} 接口的 **`revokeObjectURL()`** 静态方法用于释放之前通过调用 {{domxref("URL.createObjectURL_static", "URL.createObjectURL()")}} 创建的现有对象 URL。
 
-你可以在 `sourceopen` 被处理之后的任何时候调用 `revokeObjectURL()`。这是因为 `createObjectURL()` 仅仅意味着将一个媒体元素的 `src` 属性关联到一个 {{domxref("MediaSource")}} 对象上去。调用`revokeObjectURL()` 使这个潜在的对象回到原来的地方，允许平台在合适的时机进行垃圾收集。
+当你完成对对象 URL 的使用后，请调用此方法，让浏览器知道无需再保持对文件的引用。
 
-{{AvailableInWorkers}}
+> **备注：** 由于 {{domxref("Blob")}} 接口的生命周期问题及潜在的内存泄漏风险，此方法在 [Service Workers](/zh-CN/docs/Web/API/Service_Worker_API) 中*不*可用。
 
 ## 语法
 
-```plain
-window.URL.revokeObjectURL(objectURL);
+```js-nolint
+URL.revokeObjectURL(objectURL)
 ```
 
 ### 参数
 
 - `objectURL`
-  - : 一个 {{domxref("DOMString")}}，表示通过调用 {{domxref("URL.createObjectURL()") }} 方法产生的 URL 对象。
+  - : 表示之前通过调用 {{domxref("URL.createObjectURL_static", "createObjectURL()")}} 方法创建的对象 URL 的字符串。
 
-### Return value
+### 返回值
 
-undefined
+无（{{jsxref("undefined")}}）。
 
 ## 示例
 
-查看[使用对象 URL 显示图片](/zh-CN/docs/Using_files_from_web_applications#Example.3a_Using_object_URLs_to_display_images)。
+参见[使用对象 URL 来显示图片](/zh-CN/docs/Web/API/File_API/Using_files_from_web_applications#示例：使用对象_URL_来显示图片)。
 
 ## 规范
 
@@ -40,6 +42,6 @@ undefined
 
 ## 参见
 
-- [在 Web 应用程序中使用文件](/zh-CN/docs/Using_files_from_web_applications)
-- [使用对象 URL 显示图像](/zh-CN/docs/Using_files_from_web_applications#Example_Using_object_URLs_to_display_images)
-- {{domxref("URL.createObjectURL()") }}
+- [在 web 应用程序中使用文件](/zh-CN/docs/Web/API/File_API/Using_files_from_web_applications)
+- [使用对象 URL 来显示图片](/zh-CN/docs/Web/API/File_API/Using_files_from_web_applications#示例：使用对象_URL_来显示图片)
+- {{domxref("URL.createObjectURL_static", "URL.createObjectURL()")}}

--- a/files/zh-cn/web/api/url/revokeobjecturl_static/index.md
+++ b/files/zh-cn/web/api/url/revokeobjecturl_static/index.md
@@ -11,7 +11,7 @@ l10n:
 
 当你完成对对象 URL 的使用后，请调用此方法，让浏览器知道无需再保持对文件的引用。
 
-> **备注：** 由于 {{domxref("Blob")}} 接口的生命周期问题及潜在的内存泄漏风险，此方法在 [Service Workers](/zh-CN/docs/Web/API/Service_Worker_API) 中*不*可用。
+> **备注：** 由于 {{domxref("Blob")}} 接口的生命周期问题及潜在的内存泄漏风险，此方法在 [Service Worker](/zh-CN/docs/Web/API/Service_Worker_API) 中*不*可用。
 
 ## 语法
 

--- a/files/zh-cn/web/api/url/revokeobjecturl_static/index.md
+++ b/files/zh-cn/web/api/url/revokeobjecturl_static/index.md
@@ -1,5 +1,5 @@
 ---
-title: URL：revokeObjectURL() 实例方法
+title: URL：revokeObjectURL() 静态方法
 slug: Web/API/URL/revokeObjectURL_static
 l10n:
   sourceCommit: 367b982b93c07f7f99e7bb768a6bf326fa5198e6


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL_static
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/url/revokeobjecturl_static/index.md
* Last commit: https://github.com/mdn/content/commit/367b982b93c07f7f99e7bb768a6bf326fa5198e6
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
