### PR TITLE
[FR] Fix: Update intro for `Web/JavaScript/Reference/Global_Objects/Map/set` (Fixes #20735) 

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/map/set/index.md
+++ b/files/fr/web/javascript/reference/global_objects/map/set/index.md
@@ -1,11 +1,13 @@
 ---
 title: Map.prototype.set()
 slug: Web/JavaScript/Reference/Global_Objects/Map/set
+l10n:
+  sourceCommit: 3cfd663738e9963157d90f359789d675a6662ec2
 ---
 
 {{JSRef}}
 
-La méthode **`set()`** ajoute un nouvel élément avec une `clé` et une `valeur` données à un objet `Map`.
+La méthode **`set()`** ajoute ou met à jour un élément avec une `clé` et une `valeur` données à un objet `Map`.
 
 {{EmbedInteractiveExample("pages/js/map-prototype-set.html")}}
 

--- a/files/fr/web/javascript/reference/global_objects/map/set/index.md
+++ b/files/fr/web/javascript/reference/global_objects/map/set/index.md
@@ -33,7 +33,7 @@ L'objet `Map` courant (auquel l'élément a été ajouté).
 ### Utiliser la méthode `set()`
 
 ```js
-var maMap = new Map();
+const maMap = new Map();
 
 // On ajoute de nouveaux éléments à l'objet map
 maMap.set("truc", "toto");


### PR DESCRIPTION
### Description

Updated intro with a better translation of the original page.
Using `const` instead of `var` in exemple.

### Motivation

Better translation

### Additional details

N/A

### Related issues and pull requests

- Fixes: #20735 