### PR TITLE
[zh-cn]: update the translation of TypedArray prototype `length` property

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/typedarray/length/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/typedarray/length/index.md
@@ -1,33 +1,35 @@
 ---
 title: TypedArray.prototype.length
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/length
+l10n:
+  sourceCommit: c2445ce1dc3a0170e2fbfdbee10e18a7455c2282
 ---
 
 {{JSRef}}
 
-**`length`** 访问器属性表示类型化数组的长度（元素数）。
+{{jsxref("TypedArray")}} 实例的 **`length`** 访问器属性返回该类型数组的（以元素为单位）长度。
 
 {{EmbedInteractiveExample("pages/js/typedarray-length.html","shorter")}}
 
 ## 描述
 
-`length` 是一个访问器属性，它的 set 访问器函数是`undefined`，意思是你只能够读取这个属性。它的值在*TypedArray*构造时建立，不能被修改。如果 _TypedArray_ 没有指定`byteOffset` 或者 `length`，会返回所引用的`ArrayBuffer` 的`length`。_TypedArray_ 是这里的 [TypedArray 对象](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#TypedArray_objects)之一。
+`length` 属性是一个设置访问器函数为 `undefined` 的访问器属性，这意味着你只能读取该属性。该值在构建 _TypedArray_ 时确定，不可更改。如果 _TypedArray_ 没有指定 `byteOffset` 或 `length`，则将返回引用的 {{jsxref("ArrayBuffer")}} 的长度。_TypedArray_ 是 [TypedArray 对象](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_对象)之一。
 
 ## 示例
 
-### 使用`length` 属性
+### 使用 `length` 属性
 
 ```js
-var buffer = new ArrayBuffer(8);
+const buffer = new ArrayBuffer(8);
 
-var uint8 = new Uint8Array(buffer);
-uint8.length; // 8 (符合 buffer 的 length)
+let uint8 = new Uint8Array(buffer);
+uint8.length; // 8（与缓冲区 length 相匹配）
 
-var uint8 = new Uint8Array(buffer, 1, 5);
-uint8.length; // 5 (在 Uint8Array 构造时指定)
+uint8 = new Uint8Array(buffer, 1, 5);
+uint8.length; // 5（在构建 Uint8Array 时指定）
 
-var uint8 = new Uint8Array(buffer, 2);
-uint8.length; // 6 (根据被构造的 Uint8Array 的 offset)
+uint8 = new Uint8Array(buffer, 2);
+uint8.length; // 6（根据被构造的 Uint8Array 的偏移量）
 ```
 
 ## 规范
@@ -40,5 +42,5 @@ uint8.length; // 6 (根据被构造的 Uint8Array 的 offset)
 
 ## 参见
 
-- [JavaScript 类型化数组](/zh-CN/docs/Web/JavaScript/Typed_arrays)
+- [JavaScript 类型化数组](/zh-CN/docs/Web/JavaScript/Guide/Typed_arrays)指南
 - {{jsxref("TypedArray")}}

--- a/files/zh-cn/web/javascript/reference/global_objects/typedarray/length/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/typedarray/length/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{JSRef}}
 
-{{jsxref("TypedArray")}} 实例的 **`length`** 访问器属性返回该类型数组的（以元素为单位）长度。
+{{jsxref("TypedArray")}} 实例的 **`length`** 访问器属性返回该类型化数组的（以元素为单位）长度。
 
 {{EmbedInteractiveExample("pages/js/typedarray-length.html","shorter")}}
 

--- a/files/zh-cn/web/javascript/reference/global_objects/typedarray/length/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/typedarray/length/index.md
@@ -7,13 +7,13 @@ l10n:
 
 {{JSRef}}
 
-{{jsxref("TypedArray")}} 实例的 **`length`** 访问器属性返回该类型化数组的（以元素为单位）长度。
+{{jsxref("TypedArray")}} 实例的 **`length`** 访问器属性返回该类型化数组的长度（以元素为单位）。
 
 {{EmbedInteractiveExample("pages/js/typedarray-length.html","shorter")}}
 
 ## 描述
 
-`length` 属性是一个设置访问器函数为 `undefined` 的访问器属性，这意味着你只能读取该属性。该值在构建 _TypedArray_ 时确定，不可更改。如果 _TypedArray_ 没有指定 `byteOffset` 或 `length`，则将返回引用的 {{jsxref("ArrayBuffer")}} 的长度。_TypedArray_ 是 [TypedArray 对象](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_对象)之一。
+`length` 属性是一个 set 访问器函数为 `undefined` 的访问器属性，这意味着你只能读取该属性。该值在构建 _TypedArray_ 时确定，不可更改。如果 _TypedArray_ 没有指定 `byteOffset` 或 `length`，则将返回引用的 {{jsxref("ArrayBuffer")}} 的长度。_TypedArray_ 是 [TypedArray 对象](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_对象)之一。
 
 ## 示例
 
@@ -26,7 +26,7 @@ let uint8 = new Uint8Array(buffer);
 uint8.length; // 8（与缓冲区 length 相匹配）
 
 uint8 = new Uint8Array(buffer, 1, 5);
-uint8.length; // 5（在构建 Uint8Array 时指定）
+uint8.length; // 5（在构造 Uint8Array 时指定）
 
 uint8 = new Uint8Array(buffer, 2);
 uint8.length; // 6（根据被构造的 Uint8Array 的偏移量）


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/length
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/typedarray/length/index.md
* Last commit: https://github.com/mdn/content/commit/c2445ce1dc3a0170e2fbfdbee10e18a7455c2282
