### PR TITLE
[zh-cn]: update the translation of "SyntaxError: invalid assignment left-hand side"

### DIFF
--- a/files/zh-cn/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
@@ -23,7 +23,7 @@ SyntaxError: Left side of assignment is not a reference. (Safari)
 
 ## 什么地方出错了？
 
-在某处出现了意外地赋值情况。比如说，这可能是因为[赋值运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators#赋值运算符)与[相等运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators#相等运算符)不匹配。单个 `=` 符号用于给变量赋值，而 `==` 或 `===` 运算符则是用于比较值。
+在某处出现了意外的赋值情况。比如说，这可能是因为[赋值运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators#赋值运算符)与[相等运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators#相等运算符)不匹配。单个 `=` 符号用于给变量赋值，而 `==` 或 `===` 运算符则是用于比较值。
 
 ## 示例
 
@@ -49,7 +49,7 @@ if (Math.PI + 1 === 3 || Math.PI + 1 === 4) {
 const str = "你好，" + "来自" + "另一个世界！";
 ```
 
-### 导致 ReferenceErrors 的赋值操作
+### 导致 ReferenceError 的赋值操作
 
 无效的赋值操作不一定会产生语法错误。有时语法几乎是正确的，但在运行过程中，左侧表达式计算得出的是一个*值*而非*引用*，因此赋值仍然无效。这类错误会在程序执行到该语句时发生，即在实际执行阶段出现。
 

--- a/files/zh-cn/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
@@ -1,49 +1,95 @@
 ---
-title: "ReferenceError: invalid assignment left-hand side"
+title: "SyntaxError: invalid assignment left-hand side"
 slug: Web/JavaScript/Reference/Errors/Invalid_assignment_left-hand_side
+l10n:
+  sourceCommit: ee1599cba00284fd6af713e61e96dae61bb10287
 ---
 
 {{jsSidebar("Errors")}}
 
-## Message
+当在代码中出现意外的赋值情况时，JavaScript 就会抛出“invalid assignment left-hand side”的异常。当使用单个 `=` 符号而不是 `==` 或 `===` 时，可能会触发此异常。
+
+## 错误信息
 
 ```plain
-ReferenceError: invalid assignment left-hand side
+SyntaxError: Invalid left-hand side in assignment (V8-based)
+SyntaxError: invalid assignment left-hand side (Firefox)
+SyntaxError: Left side of assignment is not a reference. (Safari)
 ```
 
-## Error type
+## 错误类型
 
-{{jsxref("ReferenceError")}}.
+{{jsxref("SyntaxError")}} 或 {{jsxref("ReferenceError")}}，根据语法情况来定。
 
-## What went wrong?
+## 什么地方出错了？
 
-有时会出现不可预料的赋值情况。这可能是因为[赋值运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators/Assignment_Operators)或[比较运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators/Comparison_Operators)不匹配的缘故。正确的是，使用“=”号将值赋给一个变量，使用“==”或者“===”来比较一个值。
+在某处出现了意外地赋值情况。这可能是由于[赋值运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators#赋值运算符)与[相等运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators#相等运算符)不匹配导致的，例如。单个 `=` 符号用于给变量赋值，而 `==` 或 `===` 运算符则是用于比较值。
 
-## Examples
+## 示例
 
-```js example-bad
-if (Math.PI = 3 || Math.PI = 4) {
-  console.log('no way!');
+### 典型的无效赋值情况
+
+```js-nolint example-bad
+if (Math.PI + 1 = 3 || Math.PI + 1 = 4) {
+  console.log("没门！");
 }
-// ReferenceError: invalid assignment left-hand side
+// SyntaxError: invalid assignment left-hand side
 
-var str = 'Hello, '
-+= 'is it me '
-+= 'you\'re looking for?';
-// ReferenceError: invalid assignment left-hand side
+const str = "你好，" += "你是在" += "找我吗？";
+// SyntaxError: invalid assignment left-hand side
 ```
 
-在 `if` 语句中，你要使用比较运算符 ("==")，而在字符串连接中，使用加号运算符 ("+")。
+在 `if` 语句中，你需要使用严格相等运算符（`===`），而对于字符串拼接，则需要使用加号（`+`）运算符。
+
+```js-nolint example-good
+if (Math.PI + 1 === 3 || Math.PI + 1 === 4) {
+  console.log("没门！");
+}
+
+const str = "你好，" + "来自" + "另一个世界！";
+```
+
+### 导致 ReferenceErrors 的赋值操作
+
+无效的赋值操作不一定会产生语法错误。有时语法几乎是正确的，但在运行过程中，左侧表达式计算得出的是一个*值*而非*引用*，因此赋值仍然无效。这类错误会在程序执行到该语句时发生，即在实际执行阶段出现。
+
+```js-nolint example-bad
+function foo() {
+  return { a: 1 };
+}
+foo() = 1; // ReferenceError: invalid assignment left-hand side
+```
+
+函数调用、[`new`](/zh-CN/docs/Web/JavaScript/Reference/Operators/new) 调用、[`super()`](/zh-CN/docs/Web/JavaScript/Reference/Operators/super) 和 [`this`](/zh-CN/docs/Web/JavaScript/Reference/Operators/this) 都是值而不是引用。
+
+如果你想在左侧使用它们，赋值目标需要是它们产生的属性值。
 
 ```js example-good
-if (Math.PI == 3 || Math.PI == 4) {
-  console.log("no way!");
+function foo() {
+  return { a: 1 };
 }
-
-var str = "Hello, " + "from the " + "other side!";
+foo().a = 1;
 ```
 
-## See also
+> **备注：** 在 Firefox 和 Safari 中，第一个示例在非严格模式下会产生 `ReferenceError` 错误，而在[严格模式](/zh-CN/docs/Web/JavaScript/Reference/Strict_mode)下则会产生 `SyntaxError` 错误。Chrome 在严格模式和非严格模式下都会抛出运行时的 `ReferenceError` 错误。
 
-- [赋值运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators/Assignment_Operators)
-- [比较运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators/Comparison_Operators)
+### 使用可选链运算符作为赋值目标
+
+[可选链运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators/Optional_chaining)不是有效地赋值目标。
+
+```js-nolint example-bad
+obj?.foo = 1; // SyntaxError: invalid assignment left-hand side
+```
+
+相反，你必须首先处理可能为空值的情况。
+
+```js example-good
+if (obj) {
+  obj.foo = 1;
+}
+```
+
+## 参见
+
+- [赋值运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators#赋值运算符)
+- [相等运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators#相等运算符)

--- a/files/zh-cn/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
@@ -23,7 +23,7 @@ SyntaxError: Left side of assignment is not a reference. (Safari)
 
 ## 什么地方出错了？
 
-在某处出现了意外地赋值情况。这可能是由于[赋值运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators#赋值运算符)与[相等运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators#相等运算符)不匹配导致的，例如。单个 `=` 符号用于给变量赋值，而 `==` 或 `===` 运算符则是用于比较值。
+在某处出现了意外地赋值情况。比如说，这可能是因为[赋值运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators#赋值运算符)与[相等运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators#相等运算符)不匹配。单个 `=` 符号用于给变量赋值，而 `==` 或 `===` 运算符则是用于比较值。
 
 ## 示例
 
@@ -60,9 +60,7 @@ function foo() {
 foo() = 1; // ReferenceError: invalid assignment left-hand side
 ```
 
-函数调用、[`new`](/zh-CN/docs/Web/JavaScript/Reference/Operators/new) 调用、[`super()`](/zh-CN/docs/Web/JavaScript/Reference/Operators/super) 和 [`this`](/zh-CN/docs/Web/JavaScript/Reference/Operators/this) 都是值而不是引用。
-
-如果你想在左侧使用它们，赋值目标需要是它们产生的属性值。
+函数调用、[`new`](/zh-CN/docs/Web/JavaScript/Reference/Operators/new) 调用、[`super()`](/zh-CN/docs/Web/JavaScript/Reference/Operators/super) 和 [`this`](/zh-CN/docs/Web/JavaScript/Reference/Operators/this) 都是值而不是引用。如果你想在左侧使用它们，赋值目标需要是它们产生的属性值。
 
 ```js example-good
 function foo() {
@@ -75,7 +73,7 @@ foo().a = 1;
 
 ### 使用可选链运算符作为赋值目标
 
-[可选链运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators/Optional_chaining)不是有效地赋值目标。
+[可选链运算符](/zh-CN/docs/Web/JavaScript/Reference/Operators/Optional_chaining)不是有效的赋值目标。
 
 ```js-nolint example-bad
 obj?.foo = 1; // SyntaxError: invalid assignment left-hand side


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_assignment_left-hand_side

### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
* Last commit: https://github.com/mdn/content/commit/ee1599cba00284fd6af713e61e96dae61bb10287
