### PR TITLE
[zh-cn]: update the translation and add sourceCommit hash

### DIFF
--- a/files/zh-cn/web/javascript/reference/errors/already_has_pragma/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/already_has_pragma/index.md
@@ -23,7 +23,7 @@ Warning: -file- is being assigned a //# sourceMappingURL, but already has one.
 
 对于给定的 JavaScript 源码，源码映射规定了不止一次。
 
-JavaScript 源码通常被组合和压缩，使其从服务器传递更加高效。使用[源码映射](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/)，调试器能够将执行的源码映射到原始的源码。有两种指派源码映射的方式，通过注释，或者对 JavaScript 设置标题。
+JavaScript 源码通常被组合和压缩，使其从服务器传递更加高效。使用[源码映射](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/)，调试器能够将执行的源码映射到原始的源码。有两种指派源码映射的方式，通过注释，或者对 JavaScript 设置标头。
 
 ## 示例
 
@@ -35,7 +35,7 @@ JavaScript 源码通常被组合和压缩，使其从服务器传递更加高效
 //# sourceMappingURL=http://example.com/path/to/your/sourcemap.map
 ```
 
-或者，你可以对你的 JavaScript 文件设置一个标题：
+或者，你可以对你的 JavaScript 文件设置标头：
 
 ```js example-good
 X-SourceMap: /path/to/file.js.map
@@ -43,5 +43,5 @@ X-SourceMap: /path/to/file.js.map
 
 ## 参见
 
-- 火狐源文档中的[使用源码映射](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html)
+- 火狐源代码文档中的[使用源码映射](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html)
 - 在 developer.chrome.com 上的 [JavaScript 源码映射简介](https://developer.chrome.google.cn/blog/sourcemaps/)（2012）

--- a/files/zh-cn/web/javascript/reference/errors/already_has_pragma/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/already_has_pragma/index.md
@@ -23,7 +23,7 @@ Warning: -file- is being assigned a //# sourceMappingURL, but already has one.
 
 对于给定的 JavaScript 源码，源码映射规定了不止一次。
 
-JavaScript 源码通常被组合和压缩，使其从服务器传递更加高效。使用了[源码映射](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/)，调试器能够将执行的源码映射到原始的源码。有两种指派源码映射的方式，通过注释，或者对 JavaScript 设置标题。
+JavaScript 源码通常被组合和压缩，使其从服务器传递更加高效。使用[源码映射](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/)，调试器能够将执行的源码映射到原始的源码。有两种指派源码映射的方式，通过注释，或者对 JavaScript 设置标题。
 
 ## 示例
 
@@ -44,4 +44,4 @@ X-SourceMap: /path/to/file.js.map
 ## 参见
 
 - 火狐源文档中的[使用源码映射](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html)
-- 在 developer.chrome.com（2012）上的 [JavaScript 源码映射简介](https://developer.chrome.com/blog/sourcemaps/)
+- 在 developer.chrome.com 上的 [JavaScript 源码映射简介](https://developer.chrome.google.cn/blog/sourcemaps/)（2012）

--- a/files/zh-cn/web/javascript/reference/errors/already_has_pragma/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/already_has_pragma/index.md
@@ -1,11 +1,15 @@
 ---
 title: "Warning: -file- is being assigned a //# sourceMappingURL, but already has one"
 slug: Web/JavaScript/Reference/Errors/Already_has_pragma
+l10n:
+  sourceCommit: a71b8929628a2187794754c202ad399fe357141b
 ---
 
 {{jsSidebar("Errors")}}
 
-## 消息
+当给定的 JavaScript 源文件被指定了多次源码映射时，JavaScript 会发出“-file- is being assigned a //# sourceMappingURL, but already has one.”警告。
+
+## 错误信息
 
 ```plain
 Warning: -file- is being assigned a //# sourceMappingURL, but already has one.
@@ -13,15 +17,17 @@ Warning: -file- is being assigned a //# sourceMappingURL, but already has one.
 
 ## 错误类型
 
-一个警告。JavaScript 的执行不会中止。
+警告。JavaScript 的执行不会中止。
 
-## 哪里有问题？
+## 什么地方出错了？
 
 对于给定的 JavaScript 源码，源码映射规定了不止一次。
 
 JavaScript 源码通常被组合和压缩，使其从服务器传递更加高效。使用了[源码映射](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/)，调试器能够将执行的源码映射到原始的源码。有两种指派源码映射的方式，通过注释，或者对 JavaScript 设置标题。
 
 ## 示例
+
+### 设置源码映射
 
 使用文件中的注释来设置源码映射：
 
@@ -37,5 +43,5 @@ X-SourceMap: /path/to/file.js.map
 
 ## 参见
 
-- [如何使用源码映射 – Firefox Tools documentation](/zh-CN/docs/Tools/Debugger/How_to/Use_a_source_map)
-- [源码映射简介 – HTML5 rocks](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/)
+- 火狐源文档中的[使用源码映射](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html)
+- 在 developer.chrome.com（2012）上的 [JavaScript 源码映射简介](https://developer.chrome.com/blog/sourcemaps/)

--- a/files/zh-cn/web/javascript/reference/errors/malformed_uri/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/malformed_uri/index.md
@@ -29,7 +29,7 @@ URI 编码和解码不成功。传递给 {{jsxref("decodeURI")}}、{{jsxref("enc
 
 ### 编码
 
-编码操作会将每一个字符实例替换为一到四个相对应的 UTF-8 编码形式的转义序列。如果试图编码一个非高 - 低位完整的代理字符，将会抛出一个 {{jsxref("URIError")}} 错误，例如：
+编码操作会将每一个字符实例替换为一到四个相对应的 UTF-8 编码形式的转义序列。如果试图编码一个非高-低位完整的代理字符，将会抛出 {{jsxref("URIError")}} 错误，例如：
 
 ```js example-bad
 encodeURI("\uD800");
@@ -39,7 +39,7 @@ encodeURI("\uDFFF");
 // "URIError: malformed URI sequence"
 ```
 
-高 - 低位完整的代理字符是没问题的，例如：
+高-低位完整的代理字符是没问题的，例如：
 
 ```js example-good
 encodeURI("\uD800\uDFFF");

--- a/files/zh-cn/web/javascript/reference/errors/malformed_uri/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/malformed_uri/index.md
@@ -29,7 +29,7 @@ URI 编码和解码不成功。传递给 {{jsxref("decodeURI")}}、{{jsxref("enc
 
 ### 编码
 
-编码操作会将每一个字符实例替换为一到四个相对应的 UTF-8 编码形式的转义序列。如果试图编码一个非高-低位完整的代理字符，将会抛出 {{jsxref("URIError")}} 错误，例如：
+编码操作会将每一个字符实例替换为一到四个相对应的 UTF-8 编码形式的转义序列。如果试图编码一个非高低位完整的代理字符，将会抛出 {{jsxref("URIError")}} 错误，例如：
 
 ```js example-bad
 encodeURI("\uD800");
@@ -39,7 +39,7 @@ encodeURI("\uDFFF");
 // "URIError: malformed URI sequence"
 ```
 
-高-低位完整的代理字符是没问题的，例如：
+高低位完整的代理字符是没问题的，例如：
 
 ```js example-good
 encodeURI("\uD800\uDFFF");

--- a/files/zh-cn/web/javascript/reference/errors/malformed_uri/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/malformed_uri/index.md
@@ -29,7 +29,7 @@ URI 编码和解码不成功。传递给 {{jsxref("decodeURI")}}、{{jsxref("enc
 
 ### 编码
 
-编码操作会将每一个字符实例替换为一到四个相对应的 UTF-8 编码形式的转义序列。如果试图编码一个非高低位完整的代理字符，将会抛出 {{jsxref("URIError")}} 错误，例如：
+编码操作会将每一个字符实例替换为一到四个相对应的 UTF-8 编码形式的转义序列。如果试图编码一个非高—低位完整的代理字符，将会抛出 {{jsxref("URIError")}} 错误，例如：
 
 ```js example-bad
 encodeURI("\uD800");
@@ -39,7 +39,7 @@ encodeURI("\uDFFF");
 // "URIError: malformed URI sequence"
 ```
 
-高低位完整的代理字符是没问题的，例如：
+高—低位完整的代理字符是没问题的，例如：
 
 ```js example-good
 encodeURI("\uD800\uDFFF");

--- a/files/zh-cn/web/javascript/reference/errors/malformed_uri/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/malformed_uri/index.md
@@ -1,24 +1,29 @@
 ---
 title: "URIError: malformed URI sequence"
 slug: Web/JavaScript/Reference/Errors/Malformed_URI
+l10n:
+  sourceCommit: 6d606174faaedaa5dee7b7ebd87602cd51e5dd7e
 ---
 
 {{jsSidebar("Errors")}}
 
-## 错误提示
+当 URI 编码或解码没有成功完成时，JavaScript 会抛出“malformed URI sequence”异常。
+
+## 错误信息
 
 ```plain
+URIError: URI malformed (V8-based)
 URIError: malformed URI sequence (Firefox)
-URIError: URI malformed (Chrome)
+URIError: String contained an illegal UTF-16 sequence. (Safari)
 ```
 
 ## 错误类型
 
 {{jsxref("URIError")}}
 
-## 哪里出错了？
+## 什么地方出错了？
 
-URI 编码和解码不成功。传递给 {{jsxref("decodeURI")}}、{{jsxref("encodeURI")}}、{{jsxref("encodeURIComponent")}} 或者 {{jsxref("decodeURIComponent")}} 这些函数的参数不合法，导致函数无法正确对其进行编解码。
+URI 编码和解码不成功。传递给 {{jsxref("decodeURI")}}、{{jsxref("encodeURI")}}、{{jsxref("encodeURIComponent")}} 或 {{jsxref("decodeURIComponent")}} 函数的参数不合法，导致函数无法正确对其进行编解码。
 
 ## 示例
 
@@ -57,7 +62,7 @@ decodeURIComponent("JavaScript_%D1%88%D0%B5%D0%BB%D0%BB%D1%8B");
 // "JavaScript_шеллы"
 ```
 
-## 相关内容
+## 参见
 
 - {{jsxref("URIError")}}
 - {{jsxref("decodeURI")}}

--- a/files/zh-cn/web/javascript/reference/errors/stmt_after_return/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/stmt_after_return/index.md
@@ -11,7 +11,7 @@ l10n:
 
 ## 错误信息
 
-```
+```plain
 Warning: unreachable code after return statement (Firefox)
 ```
 
@@ -41,32 +41,32 @@ Warning: unreachable code after return statement (Firefox)
 
 ### 无效的例子
 
-```js example-bad
+```js-nolint example-bad
 function f() {
   let x = 3;
   x += 4;
-  return x; // return 语句立即退出当前方法
-  x -= 3; // 因而该语句从不会执行，即该语句为不可达语句
+  return x;   // return 立刻退出函数
+  x -= 3;     // 因此这一行永远不会执行；它是不可到达的代码。
 }
 
-function f() {
-  return; // 这条语句被视作 `return;`
-  3 + 4; // 因而此处该函数已经返回，该语句永不会执行
+function g() {
+  return     // 这被视为 `return;`
+    3 + 4;   // 因此函数返回，这行永不执行。
 }
 ```
 
 ### 有效的例子
 
-```js example-good
+```js-nolint example-good
 function f() {
   let x = 3;
   x += 4;
   x -= 3;
-  return x; // OK：执行完成所有语句之后返回
+  return x; // OK：在所有其他语句之后返回。
 }
 
-function f() {
-  return 3 + 4; // OK：省略分号的 return 语句与执行的表达式在同一行
+function g() {
+  return 3 + 4 // OK：在同一行上，无需分号的返回表达式。
 }
 ```
 

--- a/files/zh-cn/web/javascript/reference/errors/stmt_after_return/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/stmt_after_return/index.md
@@ -1,13 +1,15 @@
 ---
 title: "Warning: unreachable code after return statement"
 slug: Web/JavaScript/Reference/Errors/Stmt_after_return
+l10n:
+  sourceCommit: a71b8929628a2187794754c202ad399fe357141b
 ---
 
 {{jsSidebar("Errors")}}
 
 当在 {{jsxref("Statements/return", "return")}} 语句之后使用别的语句，或在无分号返回语句之后直接在后面跟随表达式，会出现 JavaScript 警告“unreachable code after return statement”。
 
-## 信息
+## 错误信息
 
 ```
 Warning: unreachable code after return statement (Firefox)
@@ -60,14 +62,14 @@ function f() {
   let x = 3;
   x += 4;
   x -= 3;
-  return x; // OK: 执行完成所有语句之后返回
+  return x; // OK：执行完成所有语句之后返回
 }
 
 function f() {
-  return 3 + 4; // OK: 省略分号的 return 语句与执行的表达式在同一行
+  return 3 + 4; // OK：省略分号的 return 语句与执行的表达式在同一行
 }
 ```
 
 ## 参见
 
-- {{jsxref("Statements/return", "自动插入分号", "#自动插入分号", 1)}}
+- [自动分号补全](/zh-CN/docs/Web/JavaScript/Reference/Lexical_grammar#自动分号补全)


### PR DESCRIPTION
### Description
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Stmt_after_return

* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Already_has_pragma


* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Malformed_URI

### Related issues and pull requests

#### Stmt_after_return

* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/errors/stmt_after_return/index.md
* Last commit: https://github.com/mdn/content/commit/a71b8929628a2187794754c202ad399fe357141b

#### already_has_pragma

* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/errors/already_has_pragma/index.md
* Last commit: https://github.com/mdn/content/commit/a71b8929628a2187794754c202ad399fe357141b

#### malformed_uri

* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/errors/malformed_uri/index.md
* Last commit: https://github.com/mdn/content/commit/6d606174faaedaa5dee7b7ebd87602cd51e5dd7e
