### PR TITLE
[zh-cn]: update the translation of Document `open()` method

### DIFF
--- a/files/zh-cn/web/api/document/open/index.md
+++ b/files/zh-cn/web/api/document/open/index.md
@@ -52,7 +52,7 @@ document.close();
 
 `document.open()` 有一个鲜为人知且很少使用的三参数版本，它是 {{domxref("Window.open()")}} 的别名（详见其页面）。
 
-例如，该调用会在新窗口中打开 github.com，并将其打开程序设置为 `null`：
+例如，该调用会在新窗口中打开 github.com，并将其 opener 设置为 `null`：
 
 ```js
 document.open("https://www.github.com", "", "noopener=true");

--- a/files/zh-cn/web/api/document/open/index.md
+++ b/files/zh-cn/web/api/document/open/index.md
@@ -1,21 +1,23 @@
 ---
-title: Document.open()
+title: Document：open() 方法
 slug: Web/API/Document/open
+l10n:
+  sourceCommit: 41a8b9c9832359d445d136b6d7a8a28737badc6b
 ---
 
 {{APIRef("DOM")}}
 
-**`Document.open()`** 方法打开一个要[写入](/zh-CN/docs/Web/API/Document/write)的文档。
+**`Document.open()`** 方法可打开文档供{{domxref("Document.write", "写入", "", "1")}}。
 
 这将会有一些连带的影响。例如：
 
-- 此时已注册到文档、文档中的节点或文档的 window 的所有事件监听器会被清除。
+- 文档内所有节点、文档内或文档窗口上的事件监听器均移除。
 - 文档中的所有节点会被清除。
 
 ## 语法
 
-```plain
-document.open();
+```js-nolint
+open()
 ```
 
 ### 参数
@@ -24,60 +26,49 @@ document.open();
 
 ### 返回值
 
-一个 `Document` 对象实例。
+`Document` 对象实例。
 
 ## 示例
 
-以下简单的代码，会打开一个文档，并将原有内容替换为一些不同的 HTML 片段，然后关闭文档。
+以下的简单代码会打开文档，并用一些不同的 HTML 片段替换其内容，然后再次关闭。
 
-```plain
+```js
 document.open();
-document.write("<p>Hello world!</p>");
-document.write("<p>I am a fish</p>");
-document.write("<p>The number is 42</p>");
+document.write("<p>你好，世界！</p>");
+document.write("<p>我是一条鱼</p>");
+document.write("<p>数字为 42</p>");
 document.close();
 ```
 
-## 注意
+## 备注
 
-当 [document.write()](/zh-CN/DOM/document.write) 在页面加载后调用，会发生自动的 `document.open()`调用。
+在页面加载后调用 {{domxref("document.write()")}} 时，会自动调用 `document.open()`。
 
-很多年以来，Firefox 和 IE 浏览器会在清除所有节点的同时，将所有 Javascript 变量等一并清除，但现在已经不采用这一做法。
-document non-spec'ed parameters to document.open
+### 内容安全
 
-不要和 [window.open()](/zh-CN/DOM/window.open) 方法混淆。`document.open` 可用于重写当前的文档内容或者追加内容，而 `window.open` 是提供了打开一个新的窗口的方法，当前的网页文档内容会被保留。由于 `window` 是一个全局对象，直接调用 `open(...)` 和 `window.open(...)` 的效果是一样的。你可以使用 `document.close()` 关闭打开的文档。
-
-See [Security check basics](/zh-CN/Security_check_basics) for more about principals.
-
-如果不想在当前文本追加内容，使用 `open("text/html", "replace")` 替换 `open()`。
-
-### 针对 Gecko 的注意事项
-
-从 Gecko 1.9 开始，这个方法与其他属性一样受到同源策略的控制，若调用会使文档的源产生变化则不可用。
-
-从 Gecko 1.9.2 开始，`document.open()` 使用文档的使用的 URI 的[principal](/zh-CN/docs/Security_check_basics)大，而不是从 stack 中取来 principal。因此，你无需再在不可信的文档里调用 {{domxref("document.write()")}} ，包括使用[`wrappedJSObject`](/zh-CN/wrappedJSObject)。关于 principal 的更多信息详见[Security check basics](/zh-CN/Security_check_basics)。
+该方法与其他属性一样受[同源策略](/zh-CN/docs/Web/Security/Same-origin_policy)的限制，如果执行该方法会改变文档的源将不起作用。
 
 ## 三个参数的 document.open()
 
-有一个更少人知道且更少被使用的 `document.open()` 的版本，这是{{domxref("Window.open()")}} 的一个别名（前往该页面查看更多）。
+`document.open()` 有一个鲜为人知且很少使用的三参数版本，它是 {{domxref("Window.open()")}} 的别名（详见其页面）。
 
-这种调用，例如在新窗口打开 github.com，把 opener 设为`null`：
+例如，该调用会在新窗口中打开 github.com，并将其打开程序设置为 `null`：
 
-```plain
-document.open('https://www.github.com','', 'noopener=true')
+```js
+document.open("https://www.github.com", "", "noopener=true");
 ```
 
 ## 两个参数的 document.open()
 
-浏览器过往支持一个两个参数版本的`document.open()`，方法参数签名如下：
+浏览器曾支持具有以下签名的双参数 `document.open()`：
 
-```plain
-document.open(type, replace)
+```js
+document.open(type, replace);
 ```
 
-`type`指定了所需写入的数据的 MIME 类型，`replace`（如有设置，值为一个字符串“replace”）指定了新文档的历史写入会代替现有的例如写入。
+`type` 指定要写入的数据的 MIME 类型（例如 `text/html`），如果设置了 replace（即 `"replace"` 字符串），新文档历史记录会替换当前写入文档的记录。
 
-这种形式现在已经弃用；它不会抛出错误，但会直接调用`document.open()`（相当于无参数形式的调用）。这种历史写入替换行为现在一定会发生。
+这种形式现已过时；它不会抛出错误，而是直接转发到 `document.open()`（即相当于没有参数运行它）。历史替换行为现在总是会发生。
 
 ## 规范
 

--- a/files/zh-cn/web/api/document/open/index.md
+++ b/files/zh-cn/web/api/document/open/index.md
@@ -7,11 +7,11 @@ l10n:
 
 {{APIRef("DOM")}}
 
-**`Document.open()`** 方法可打开文档供{{domxref("Document.write", "写入", "", "1")}}。
+**`Document.open()`** 方法可打开文档以供{{domxref("Document.write", "写入", "", "1")}}。
 
 这将会有一些连带的影响。例如：
 
-- 文档内所有节点、文档内或文档窗口上的事件监听器均移除。
+- 此时已注册到文档、文档中的节点或文档的 window 的所有事件监听器会被清除。
 - 文档中的所有节点会被清除。
 
 ## 语法
@@ -46,7 +46,7 @@ document.close();
 
 ### 内容安全
 
-该方法与其他属性一样受[同源策略](/zh-CN/docs/Web/Security/Same-origin_policy)的限制，如果执行该方法会改变文档的源将不起作用。
+该方法与其他属性一样受[同源策略](/zh-CN/docs/Web/Security/Same-origin_policy)的限制，会改变文档的来源的方法调用不会起作用。
 
 ## 三个参数的 document.open()
 
@@ -68,7 +68,7 @@ document.open(type, replace);
 
 `type` 指定要写入的数据的 MIME 类型（例如 `text/html`），如果设置了 replace（即 `"replace"` 字符串），新文档历史记录会替换当前写入文档的记录。
 
-这种形式现已过时；它不会抛出错误，而是直接转发到 `document.open()`（即相当于没有参数运行它）。历史替换行为现在总是会发生。
+这种形式现已过时；它不会抛出错误，而是直接转发到 `document.open()`（相当于无参数形式的调用）。历史替换行为现在总是会发生。
 
 ## 规范
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/Document/open
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/document/open/index.md
* Last commit: https://github.com/mdn/content/commit/41a8b9c9832359d445d136b6d7a8a28737badc6b
https://github.com/mdn/translated-content/pull/20901