### PR TITLE
[zh-cn]: remove the duplicated description of parameters

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/string/includes/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/string/includes/index.md
@@ -1,11 +1,13 @@
 ---
 title: String.prototype.includes()
 slug: Web/JavaScript/Reference/Global_Objects/String/includes
+l10n:
+  sourceCommit: b7ca46c94631967ecd9ce0fe36579be334a01275
 ---
 
 {{JSRef}}
 
-**`includes()`** 方法执行区分大小写的搜索，以确定是否可以在一个字符串中找到另一个字符串，并根据情况返回 `true` 或 `false`。
+{{jsxref("String")}} 值的 **`includes()`** 方法执行区分大小写的搜索，以确定是否可以在一个字符串中找到另一个字符串，并根据情况返回 `true` 或 `false`。
 
 {{EmbedInteractiveExample("pages/js/string-includes.html", "shorter")}}
 
@@ -17,12 +19,6 @@ includes(searchString, position)
 ```
 
 ### 参数
-
-- `searchString`
-  - : 要在 `str` 中搜索的字符串。不能是正则表达式。
-- `position` {{optional_inline}}
-
-  - : 在字符串中开始搜索 `searchString` 的位置。（默认为 `0`。）
 
 - `searchString`
   - : 一个要在 `str` 中查找的字符串。[不能是正则表达式](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp#正则表达式的特殊处理)。所有非正则表达式的值都会被[强制转换为字符串](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/String#字符串强制转换)，因此如果该参数被省略或传入 `undefined`，`includes()` 方法会在字符串中搜索 `"undefined"`，这通常不是你想要的。


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes
fixed: https://github.com/mdn/translated-content/issues/21216
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/includes/index.md
* Last commit: https://github.com/mdn/content/commit/b7ca46c94631967ecd9ce0fe36579be334a01275