### PR TITLE
メディアキャプチャとストリーム API (メディアストリーム)の `ブラウザーの互換性` の表記を修正する

### DIFF
--- a/files/ja/web/api/media_capture_and_streams_api/index.md
+++ b/files/ja/web/api/media_capture_and_streams_api/index.md
@@ -58,7 +58,7 @@ l10n:
 
 [getUserMedia() による写真の撮影](/ja/docs/Web/API/Media_Capture_and_Streams_API/Taking_still_photos) の記事では、[`getUserMedia()`](/ja/docs/Web/API/MediaDevices/getUserMedia) を使用して、 `getUserMedia()` に対応しているコンピューターや携帯電話のカメラにアクセスし、それで写真を撮る方法を示しています。
 
-## ブラウザー互換性
+## ブラウザーの互換性
 
 {{Compat}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

[メディアキャプチャとストリーム API (メディアストリーム)](https://developer.mozilla.org/ja/docs/Web/API/Media_Capture_and_Streams_API)ページで、
他のページでは「ブラウザーの互換性」という見出しが、このページでは「ブラウザー互換性」となっていたので修正しました。
