### PR TITLE
[es] Import sidebars from en-US

### DIFF
--- a/files/es/learn/common_questions/design_and_accessibility/common_web_layouts/index.md
+++ b/files/es/learn/common_questions/design_and_accessibility/common_web_layouts/index.md
@@ -3,6 +3,8 @@ title: ¿Qué contienen los diseños web comunes?
 slug: Learn/Common_questions/Design_and_accessibility/Common_web_layouts
 ---
 
+{{QuicklinksWithSubPages("Learn/Common_questions")}}
+
 Cuando diseña páginas para su sitio web es bueno tener una idea de los diseños más comunes.
 
 <table>

--- a/files/es/learn/common_questions/design_and_accessibility/thinking_before_coding/index.md
+++ b/files/es/learn/common_questions/design_and_accessibility/thinking_before_coding/index.md
@@ -3,6 +3,8 @@ title: ¿Cómo empiezo a diseñar mi sitio web?
 slug: Learn/Common_questions/Design_and_accessibility/Thinking_before_coding
 ---
 
+{{QuicklinksWithSubPages("Learn/Common_questions")}}
+
 Este artículo cubre el primer paso importante de cada proyecto: definir lo que se desea lograr con él.
 
 <table>

--- a/files/es/learn/common_questions/tools_and_setup/how_much_does_it_cost/index.md
+++ b/files/es/learn/common_questions/tools_and_setup/how_much_does_it_cost/index.md
@@ -3,6 +3,8 @@ title: ¿Cuánto cuesta hacer algo en la Web?
 slug: Learn/Common_questions/Tools_and_setup/How_much_does_it_cost
 ---
 
+{{QuicklinksWithSubPages("Learn/Common_questions")}}
+
 Dedicarse a la web no es tan barato como parece. En este artículo discutimos cuánto puedes tener que gastar, y por qué.
 
 <table>

--- a/files/es/learn/common_questions/tools_and_setup/set_up_a_local_testing_server/index.md
+++ b/files/es/learn/common_questions/tools_and_setup/set_up_a_local_testing_server/index.md
@@ -3,6 +3,8 @@ title: ¿Cómo se configura un servidor de prueba local?
 slug: Learn/Common_questions/Tools_and_setup/set_up_a_local_testing_server
 ---
 
+{{QuicklinksWithSubPages("Learn/Common_questions")}}
+
 En este artículo explica cómo configurar un servidor de prueba local simple en su equipo y los conceptos básicos de cómo utilizarlo.
 
 <table>

--- a/files/es/learn/common_questions/tools_and_setup/using_github_pages/index.md
+++ b/files/es/learn/common_questions/tools_and_setup/using_github_pages/index.md
@@ -3,6 +3,8 @@ title: ¿Cómo se utiliza Github pages?
 slug: Learn/Common_questions/Tools_and_setup/Using_GitHub_pages
 ---
 
+{{QuicklinksWithSubPages("Learn/Common_questions")}}
+
 [GitHub](https://github.com/) es un sitio "social coding". Te permite subir repositorios de código para almacenarlo en el **sistema de control de versiones** [Git](http://git-scm.com/). Tu puedes colaborar en proyectos de código, y el sistema es código abierto por defecto, lo que significa que cualquiera en el mundo puede encontrar tu código en GitHub, usarlo, aprender de el, y mejorarlo. ¡Tú puedes hacer eso con el código de otras personas tambien! Este artículo provee una guía básica para publicar contenido usando la característica gh-pages de Github.
 
 ## Publicando contenido

--- a/files/es/learn/common_questions/tools_and_setup/what_are_browser_developer_tools/index.md
+++ b/files/es/learn/common_questions/tools_and_setup/what_are_browser_developer_tools/index.md
@@ -3,6 +3,8 @@ title: ¿Cuáles son las herramientas de desarrollo del navegador?
 slug: Learn/Common_questions/Tools_and_setup/What_are_browser_developer_tools
 ---
 
+{{QuicklinksWithSubPages("Learn/Common_questions")}}
+
 Todos los navegadores web modernos incluyen un potente conjunto de herramientas para desarrolladores. Estas herramientas hacen una variedad de cosas, desde inspeccionar HTML, CSS y JavaScript actualmente cargados, hasta mostrar qué activos ha solicitado la página y cuánto tiempo tardaron en cargarse. Este artículo explica cómo utilizar las funciones básicas de las herramientas de desarrollo de tu navegador.
 
 > **Nota:** Antes de ejecutar los siguientes ejemplos, abre el [sitio de ejemplo para principiantes](http://mdn.github.io/beginner-html-site-scripted/) que creamos durante la serie de artículos [Introducción a la Web](/es/Learn/Getting_started_with_the_web). Lo deberías tener abierto mientras sigues los pasos que explicamos a continuación.

--- a/files/es/learn/common_questions/tools_and_setup/what_software_do_i_need/index.md
+++ b/files/es/learn/common_questions/tools_and_setup/what_software_do_i_need/index.md
@@ -3,6 +3,8 @@ title: ¿Qué software necesito para construir un sitio web?
 slug: Learn/Common_questions/Tools_and_setup/What_software_do_I_need
 ---
 
+{{QuicklinksWithSubPages("Learn/Common_questions")}}
+
 En este artículo se explican cuales componentes de software necesita para editar, cargar, o visualizar un sitio web.
 
 <table>

--- a/files/es/learn/common_questions/web_mechanics/how_does_the_internet_work/index.md
+++ b/files/es/learn/common_questions/web_mechanics/how_does_the_internet_work/index.md
@@ -3,6 +3,8 @@ title: ¿Cómo funciona Internet?
 slug: Learn/Common_questions/Web_mechanics/How_does_the_Internet_work
 ---
 
+{{QuicklinksWithSubPages("Learn/Common_questions")}}
+
 En este artículo se describe qué es Internet y cómo funciona.
 
 <table>

--- a/files/es/learn/common_questions/web_mechanics/pages_sites_servers_and_search_engines/index.md
+++ b/files/es/learn/common_questions/web_mechanics/pages_sites_servers_and_search_engines/index.md
@@ -3,6 +3,8 @@ title: ¿Cuál es la diferencia entre la página web, el sitio web, el servidor 
 slug: Learn/Common_questions/Web_mechanics/Pages_sites_servers_and_search_engines
 ---
 
+{{QuicklinksWithSubPages("Learn/Common_questions")}}
+
 En este artículo se describen varios conceptos referidos a la web: Páginas web, sitios web, servidores web, y motores de búsqueda. Estos términos con frecuencia son confundidos por recién llegados a la web, o son incorrectamente usados. ¡Vamos a aprender qué significa cada uno!
 
 <table>

--- a/files/es/learn/common_questions/web_mechanics/what_are_hyperlinks/index.md
+++ b/files/es/learn/common_questions/web_mechanics/what_are_hyperlinks/index.md
@@ -3,6 +3,8 @@ title: ¿Qué son los hipervínculos?
 slug: Learn/Common_questions/Web_mechanics/What_are_hyperlinks
 ---
 
+{{QuicklinksWithSubPages("Learn/Common_questions")}}
+
 En este artículo, repasaremos qué son los hipervínculos y por qué son importantes.
 
 <table>

--- a/files/es/learn/common_questions/web_mechanics/what_is_a_domain_name/index.md
+++ b/files/es/learn/common_questions/web_mechanics/what_is_a_domain_name/index.md
@@ -3,6 +3,8 @@ title: ¿Qué es un nombre de dominio?
 slug: Learn/Common_questions/Web_mechanics/What_is_a_domain_name
 ---
 
+{{QuicklinksWithSubPages("Learn/Common_questions")}}
+
 En este artículo discutiremos acerca de los nombres de los dominios: qué son, cómo se estructuran y cómo conseguir uno.
 
 <table>

--- a/files/es/learn/common_questions/web_mechanics/what_is_a_url/index.md
+++ b/files/es/learn/common_questions/web_mechanics/what_is_a_url/index.md
@@ -3,6 +3,8 @@ title: ¿Qué es una URL?
 slug: Learn/Common_questions/Web_mechanics/What_is_a_URL
 ---
 
+{{QuicklinksWithSubPages("Learn/Common_questions")}}
+
 Este artículo habla sobre las Uniform Resource Locators (URLs), explicando qué son y cómo se estructuran.
 
 <table>

--- a/files/es/learn/common_questions/web_mechanics/what_is_a_web_server/index.md
+++ b/files/es/learn/common_questions/web_mechanics/what_is_a_web_server/index.md
@@ -3,6 +3,8 @@ title: ¿Qué es un servidor WEB?
 slug: Learn/Common_questions/Web_mechanics/What_is_a_web_server
 ---
 
+{{QuicklinksWithSubPages("Learn/Common_questions")}}
+
 En este articulo veremos que son los servidores, cómo funcionan y por qué son importantes.
 
 <table>

--- a/files/es/learn/css/howto/css_faq/index.md
+++ b/files/es/learn/css/howto/css_faq/index.md
@@ -3,6 +3,8 @@ title: Preguntas frecuentes sobre CSS
 slug: Learn/CSS/Howto/CSS_FAQ
 ---
 
+{{LearnSidebar}}
+
 #### Mi CSS es válida, pero no se representa correctamente
 
 Los navegadores utilizan la declaración `DOCTYPE` para elegir entre mostrar el documento usando un modo que sea más compatible con los estándares de la Web o mostrarlo con los fallos de los navegadores antiguos. El uso de una declaración `DOCTYPE` correcta y moderna al inicio del código HTML mejorará el cumplimiento de los estándares del navegador.

--- a/files/es/learn/forms/index.md
+++ b/files/es/learn/forms/index.md
@@ -3,6 +3,8 @@ title: Formularios en HTML5
 slug: Learn/Forms
 ---
 
+{{LearnSidebar}}
+
 Los elementos y atributos para formularios en HTML5 proveen un mayor grado de marcado semántico que en HTML4 y eliminan gran parte del tedioso trabajo de programar y diseñar que se necesitaba en HTML4. Las funcionalidades de los formularios en HTML5 brindan una experiencia mejor para los usuarios al permitir que los formularios tengan un comportamiento más consistente entre diferentes sitios web y al darle una devolución inmediata acerca de la información ingresada. También proveen esta experiencia a los usuarios que han deshabilitado javascript en sus navegadores.
 
 Este documento describe los elementos nuevos o que han cambiado que están disponibles en Gecko/Firefox.

--- a/files/es/learn/html/howto/author_fast-loading_html_pages/index.md
+++ b/files/es/learn/html/howto/author_fast-loading_html_pages/index.md
@@ -3,7 +3,7 @@ title: Consejos para la creación de páginas HTML de carga rápida
 slug: Learn/HTML/Howto/Author_fast-loading_HTML_pages
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Learn/HTML/Howto")}}
+{{QuickLinksWithSubpages("/es/docs/Learn/HTML/Howto")}}
 
 ## Consejos para la creación de páginas HTML de carga rápida
 

--- a/files/es/learn/html/howto/author_fast-loading_html_pages/index.md
+++ b/files/es/learn/html/howto/author_fast-loading_html_pages/index.md
@@ -3,6 +3,8 @@ title: Consejos para la creación de páginas HTML de carga rápida
 slug: Learn/HTML/Howto/Author_fast-loading_HTML_pages
 ---
 
+{{QuickLinksWithSubpages("/en-US/docs/Learn/HTML/Howto")}}
+
 ## Consejos para la creación de páginas HTML de carga rápida
 
 Estos consejos estan basados en conocimiento común y experimentación.

--- a/files/es/learn/html/multimedia_and_embedding/index.md
+++ b/files/es/learn/html/multimedia_and_embedding/index.md
@@ -3,6 +3,8 @@ title: Multimedia e inserción
 slug: Learn/HTML/Multimedia_and_embedding
 ---
 
+{{LearnSidebar}}
+
 Hemos visto mucho texto hasta ahora en este curso, pero la web sería realmente aburrida solo usando textos. ¡Comencemos observando como hacer que la web cobre vida, con mucho más contenido interesante! Este módulo te acompañará a explorar maneras de usar HTML para incluir multimedia a tus páginas web, y las diferentes formas en la que podrás hacerlo, incluyendo como enlazar videos, audios e incluso otras páginas webs.
 
 ## Requisitos previos

--- a/files/es/learn/javascript/client-side_web_apis/fetching_data/index.md
+++ b/files/es/learn/javascript/client-side_web_apis/fetching_data/index.md
@@ -3,6 +3,8 @@ title: AJAX
 slug: Learn/JavaScript/Client-side_web_APIs/Fetching_data
 ---
 
+{{LearnSidebar}}
+
 **[Primeros Pasos](/es/docs/Web/Guide/AJAX/Getting_Started)**
 Una introducción a AJAX.
 

--- a/files/es/learn/server-side/configuring_server_mime_types/index.md
+++ b/files/es/learn/server-side/configuring_server_mime_types/index.md
@@ -3,6 +3,8 @@ title: Configurar correctamente los tipos MIME del servidor
 slug: Learn/Server-side/Configuring_server_MIME_types
 ---
 
+{{LearnSidebar}}
+
 ### Introduccion
 
 Por omisión, muchos servidores web estan configurados para reportar un tipo MIME de `texto/plano` ó `aplicacion/de fuente de octeto` para tipos de contenidos desconocidos. A medida son desarrollados nuevos tipos de contenidos, los administradores de red pueden equivocarse al añadirlos a la configuración del servidor web, y esta es la principal causa de problemas para usuarios de navegadores basados en Gecko, el cual respeta los tipos MIME tal y como son reportados por los servidores y las aplicaciones web.

--- a/files/es/learn/server-side/django/index.md
+++ b/files/es/learn/server-side/django/index.md
@@ -3,6 +3,8 @@ title: Framework Web Django (Python)
 slug: Learn/Server-side/Django
 ---
 
+{{LearnSidebar}}
+
 Django es un framework web extremadamente popular y completamente funcional, escrito en Python. El módulo muestra por qué Django es uno de los frameworks de servidores web más populares, cómo configurar un entorno de desarrollo y cómo empezar a usarlo para crear tus propias aplicaciones web.
 
 ## Requisitos Previos

--- a/files/es/mdn/at_ten/index.md
+++ b/files/es/mdn/at_ten/index.md
@@ -3,6 +3,8 @@ title: MDN en 10
 slug: MDN/At_ten
 ---
 
+{{MDNSidebar}}
+
 ## La historia de MDN (Mozilla Developers Network)
 
 Celebra 10 años documentando tu Web.

--- a/files/es/mozilla/add-ons/webextensions/api/index.md
+++ b/files/es/mozilla/add-ons/webextensions/api/index.md
@@ -3,6 +3,8 @@ title: API
 slug: Mozilla/Add-ons/WebExtensions/API
 ---
 
+{{AddonSidebar}}
+
 Las API de JavaScript para las Extensiones Web se pueden usar dentro de los [scripts en segundo plano](/es/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts) de la extensión y en cualquier otro documento contenido en la extensión, incluyendo las ventanas emergentes de [acción de página](/es/docs/Mozilla/Add-ons/WebExtensions/Page_actions) o [acción del navegador](/es/docs/Mozilla/Add-ons/WebExtensions/Browser_action), [barras laterales](/es/docs/Mozilla/Add-ons/WebExtensions/Sidebars), [páginas de opciones](/es/docs/Mozilla/Add-ons/WebExtensions/Options_pages) o [páginas de pestañas nuevas](/es/Add-ons/WebExtensions/manifest.json/chrome_url_overrides). A algunas de estas API también se puede acceder mediante los [scripts de contenido](/es/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Content_scripts) de una extensión ( consulte la [lista en la guía de script de contenido](/es/Add-ons/WebExtensions/Content_scripts#WebExtension_APIs)).
 
 Para usar API más poderosas debes [solicitar permiso](/es/Add-ons/WebExtensions/manifest.json/permissions) en manifest.json en tu extensión.

--- a/files/es/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/es/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -3,6 +3,8 @@ title: Incompatibilidades con Chrome
 slug: Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities
 ---
 
+{{AddonSidebar}}
+
 WebExtensions está diseñado para ser compatible con las extensiones de Chrome y Opera: en la medida de lo posible, las extensiones escritas para esos navegadores deberían ejecutarse en Firefox con cambios mínimos.
 
 Sin embargo, Firefox cuenta actualmente con soporte para sólo un conjunto limitado de funciones y API compatibles con Chrome y Opera. Estamos trabajando en agregar más soporte, pero muchas características aún no son compatibles, y es posible que nunca admitamos algunas.

--- a/files/es/mozilla/index.md
+++ b/files/es/mozilla/index.md
@@ -3,4 +3,6 @@ title: Mozilla
 slug: Mozilla
 ---
 
+{{FirefoxSidebar}}
+
 Esta página fue auto-generada ya que un usuario creó una sub-página a esta página.

--- a/files/es/web/accessibility/aria/attributes/aria-label/index.md
+++ b/files/es/web/accessibility/aria/attributes/aria-label/index.md
@@ -3,6 +3,8 @@ title: Utilizando el atributo  aria-label
 slug: Web/Accessibility/ARIA/Attributes/aria-label
 ---
 
+{{AccessibilitySidebar}}
+
 El atributo [`aria-label`](https://www.w3.org/TR/wai-aria/#aria-label) se utiliza para definir una cadena que etiqueta el elemento actual. Úselo en los casos en que no haya una etiqueta de texto visible en pantalla. Si hay texto visible etiquetando el elemento, utilice [aria-labelledby](/en/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute) en su lugar.
 
 Este atributo puede ser utilizado con cualquier elemento HTML típico; no se limita a los elementos que tienen un papel ARIA asignado.

--- a/files/es/web/accessibility/aria/attributes/aria-required/index.md
+++ b/files/es/web/accessibility/aria/attributes/aria-required/index.md
@@ -3,6 +3,8 @@ title: Usando el atributo aria-required
 slug: Web/Accessibility/ARIA/Attributes/aria-required
 ---
 
+{{AccessibilitySidebar}}
+
 ### Descripción
 
 El atributo [`aria-required`](http://www.w3.org/TR/wai-aria/states_and_properties#aria-required) es usado para indicar al usuario que un input es requerido en un elemento antes de que un form pueda ser enviado. Este atributo puede ser usado en un form con cualquier elemento HTML típico; no se limita a elementosque tengan un `role` ARIA asignado.

--- a/files/es/web/accessibility/aria/index.md
+++ b/files/es/web/accessibility/aria/index.md
@@ -3,6 +3,8 @@ title: ARIA
 slug: Web/Accessibility/ARIA
 ---
 
+{{AccessibilitySidebar}}
+
 Accessible Rich Internet Applications **(<abbr>ARIA</abbr>)** es una colección de atributos que definen como realizar contenido y aplicaciónes web (especialmente las desarrolladas con Javascript) más accesibles para las personas con discapacidades.
 
 Complementa HTML para que las interacciones y los widgets que se usan comúnmente en las aplicaciones puedan ser correctamente interpretadas por las tecnologías de asistencia cuando no existe otro mecanismo. Por ejemplo, ARIA habilita accesibilidad a widgets de JavaScript, sugerencias de formularios, mensajes de error, actualizaciones de contenido en vivo y más.

--- a/files/es/web/accessibility/aria/multipart_labels/index.md
+++ b/files/es/web/accessibility/aria/multipart_labels/index.md
@@ -3,6 +3,8 @@ title: "Etiquetas complejas: Utilizando ARIA para etiquetas con campos embebidos
 slug: Web/Accessibility/ARIA/Multipart_labels
 ---
 
+{{AccessibilitySidebar}}
+
 ## Problema
 
 Tiene un formulario donde le pregunta a su usuario una pregunta, pero la respuesta es mencionada en la misma pregunta. Un ejemplo clásico que todos conocemos de las configuraciones de nuestro navegador es la opción "Eliminar el historial despues de x días". "Eliminar el historial despues" está a la izquierda de la caja de texto, x es el número, por ejemplo 21, y la palabra "días" sigue a la caja de texto, formando una oración que es fácil de comprender.

--- a/files/es/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/es/web/accessibility/aria/roles/alert_role/index.md
@@ -3,6 +3,8 @@ title: Using the alert role
 slug: Web/Accessibility/ARIA/Roles/alert_role
 ---
 
+{{AccessibilitySidebar}}
+
 ### Descripción
 
 Esta técnica demuestra como usar el rol [alert](https://www.w3.org/TR/wai-aria-1.1/#alert) y describe el efecto que tiene en los navegadores y tecnologías de asistencia.

--- a/files/es/web/accessibility/aria/roles/alertdialog_role/index.md
+++ b/files/es/web/accessibility/aria/roles/alertdialog_role/index.md
@@ -3,6 +3,8 @@ title: Usando el rol alertdialog
 slug: Web/Accessibility/ARIA/Roles/alertdialog_role
 ---
 
+{{AccessibilitySidebar}}
+
 ### Descripción
 
 Esta técnica demuestra como usar el rol [`alertdialog`](http://www.w3.org/TR/2009/WD-wai-aria-20091215/roles#alertdialog).

--- a/files/es/web/accessibility/index.md
+++ b/files/es/web/accessibility/index.md
@@ -5,6 +5,8 @@ l10n:
   sourceCommit: acebfb2b738c2b3d7caf73607000f1aa4b4393d1
 ---
 
+{{AccessibilitySidebar}}
+
 La **accesibilidad web** (a menudo abreviada como **A11y** — como "a", luego 11 caracteres, y luego "y") se refiere a la posibilidad de acceso a los diferentes sitios web y a todo su contenido por todas las personas, independientemente de sus limitaciones físicas (discapacidad) o las derivadas del contexto de uso (tecnológicas o ambientales).
 
 Para muchas personas, la tecnología facilita las cosas. Para las personas con algun tipo de discapacidad, la tecnología hace las cosas posibles. Accesibilidad significa desarrollar contenido para que sea lo más accesible posible sin importar las habilidades físicas y cognitivas de un individuo y sin importar cómo acceda a la web.

--- a/files/es/web/accessibility/understanding_wcag/index.md
+++ b/files/es/web/accessibility/understanding_wcag/index.md
@@ -3,6 +3,8 @@ title: Understanding the Web Content Accessibility Guidelines
 slug: Web/Accessibility/Understanding_WCAG
 ---
 
+{{AccessibilitySidebar}}
+
 Esto es parte de un grupo de artículos que explican rápidamente los pasos necesario para cumplir con la normativa de W3C Web Content Accessibility Guides 2.0 o 2.1 (también conocida como WCAG).
 
 La norma WCAG 2.0 y 2.1 provee unas guías detalladas para lograr que el contenido de nuestro sitio sea accesible para personas con distintos tipos de discapacidades. Es exhaustivo y muy detallado, por lo que cuesta comprenderlo rápidamente. Por esta razón, hemos resumido los pasos a seguir para que puedas cumplir con las diferentes recomendaciones e incluimos links al pie para más detalles en los lugares necesarios.

--- a/files/es/web/accessibility/understanding_wcag/keyboard/index.md
+++ b/files/es/web/accessibility/understanding_wcag/keyboard/index.md
@@ -3,6 +3,8 @@ title: Teclado (Keyboard)
 slug: Web/Accessibility/Understanding_WCAG/Keyboard
 ---
 
+{{AccessibilitySidebar}}
+
 Para ser completamente accesible, una página web debe ser operable por alguién utilizando únicamente un teclado para acceder y controlarla. Esto incluye usuarios de lectores de pantalla, pero también puede incluir a quienes tienen dificultades utilizando un dispositivo apuntador como un ratón o una bola de rastreo, o aquellos cuyo ratón no esta funcionando temporalmente, o la gente que simplemente prefiere usar un teclado como entrada siempre que les sea posible.
 
 ## Los elementos enfocables deben tener una semántica interactiva

--- a/files/es/web/accessibility/understanding_wcag/perceivable/color_contrast/index.md
+++ b/files/es/web/accessibility/understanding_wcag/perceivable/color_contrast/index.md
@@ -3,6 +3,8 @@ title: Contraste del color
 slug: Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast
 ---
 
+{{AccessibilitySidebar}}
+
 El [contraste del color](https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio) entre el fondo y el contenido del primer plano (que suele ser texto) debe ser lo suficientemente alto como para garantizar la legibilidad.
 
 Al diseñar interfaces legibles para diferentes capacidades de visión, las directrices de la WCAG recomiendan las siguientes relaciones de contraste:

--- a/files/es/web/accessibility/understanding_wcag/perceivable/index.md
+++ b/files/es/web/accessibility/understanding_wcag/perceivable/index.md
@@ -3,6 +3,8 @@ title: Perceivable
 slug: Web/Accessibility/Understanding_WCAG/Perceivable
 ---
 
+{{AccessibilitySidebar}}
+
 Este artículo ofrece consejos prácticos sobre cómo hacer que tu sitio web cumpla con los criterios de **Percepción** de WCAG 2.0 y 2.1. Los estados perceptivos que los usuarios deben poder reconocer utilizando alguno de sus sentidos.
 
 > **Nota:** Para leer las definiciones de la W3C sobre Percepción y las guías para cumplir con los criterios dirígete a [Principle 1: Perceivable - Information and user interface components must be presentable to users in ways they can perceive.](https://www.w3.org/TR/WCAG21/#perceivable)

--- a/files/es/web/accessibility/understanding_wcag/text_labels_and_names/index.md
+++ b/files/es/web/accessibility/understanding_wcag/text_labels_and_names/index.md
@@ -3,6 +3,8 @@ title: Etiquetas de texto y nombres
 slug: Web/Accessibility/Understanding_WCAG/Text_labels_and_names
 ---
 
+{{AccessibilitySidebar}}
+
 Hay muchas situaciones en las cuales un control, dialogo o cualquier otra característica de un sitio web deberían recibir un nombre o etiqueta descriptiva para permitir a los usuarios de técnologías asistivas entender cual es su propósito y ser capaz de entenderlo y operarlo correctamente. Hay un número de diferentes tipos de problemas en esta categoría, dependientes del contexto, y cada uno tiene su propia solución. Los diferentes problemas y soluciones son discutidas en las secciones posteriores.
 
 ## Utilizar el atributo alt para etiquetar elementos que ocupen un área que tiene el atributo href

--- a/files/es/web/api/canvas_api/manipulating_video_using_canvas/index.md
+++ b/files/es/web/api/canvas_api/manipulating_video_using_canvas/index.md
@@ -3,6 +3,8 @@ title: Manipular video por medio de canvas
 slug: Web/API/Canvas_API/Manipulating_video_using_canvas
 ---
 
+{{DefaultAPISidebar("Canvas API")}}
+
 Al combinar las capacidades del elemento [`video`](/En/HTML/Element/Video) introducido en Firefox 3.5 con un elemento [`canvas`](/en/HTML/Canvas) , puedes manipular los datos de video en tiempo real para incorporar una variedad de efectos visuales que se mostrarán en el video. Este artículo, adaptado de [esta entrada del blog](http://blog.mozbox.org/post/2009/02/25/video-canvas%3A-special-effects) de Paul Rouget, muestra cómo realizar una inserción croma (también conocida como el "efecto pantalla verde") utilizando el código JavaScript.
 
 [Ver este ejemplo en vivo](/samples/video/chroma-key/index.xhtml) .

--- a/files/es/web/api/canvas_api/tutorial/drawing_text/index.md
+++ b/files/es/web/api/canvas_api/tutorial/drawing_text/index.md
@@ -3,6 +3,8 @@ title: Dibujar texto usando canvas
 slug: Web/API/Canvas_API/Tutorial/Drawing_text
 ---
 
+{{DefaultAPISidebar("Canvas API")}}
+
 El elemento [`<canvas>`](/es/HTML/Canvas) permite dibujar texto en él a través de una API experimental de Mozilla.
 
 ### API

--- a/files/es/web/api/canvas_api/tutorial/index.md
+++ b/files/es/web/api/canvas_api/tutorial/index.md
@@ -3,6 +3,8 @@ title: Tutorial Canvas
 slug: Web/API/Canvas_API/Tutorial
 ---
 
+{{DefaultAPISidebar("Canvas API")}}
+
 [**`<canvas>`**](/es/docs/HTML/Canvas) es un elemento [HTML](/es/docs/HTML) el cual puede ser usado para dibujar gráficos usando scripts (normalmente [JavaScript](/es/docs/JavaScript)). Este puede, por ejemplo, ser usado para dibujar gráficos, realizar composición de fotos o simples (y [no tan simples](/es/docs/HTML/Canvas/A_Basic_RayCaster)) animaciones.
 
 `<canvas>` fue introducido primero por Apple para el Mac OS X Dashboard y después implementado en Safari y Google Chrome. Navegadores basados en [Gecko](/es/docs/Gecko) 1.8, tal como Firefox 1.5, que también soportan este elemento. El `<canvas>` es un elemento parte de las especificaciones de la [WhatWG Web applications 1.0](http://www.whatwg.org/specs/web-apps/current-work/) mejor conocida como HTML5.

--- a/files/es/web/api/canvas_api/tutorial/optimizing_canvas/index.md
+++ b/files/es/web/api/canvas_api/tutorial/optimizing_canvas/index.md
@@ -3,6 +3,8 @@ title: Optimizing canvas
 slug: Web/API/Canvas_API/Tutorial/Optimizing_canvas
 ---
 
+{{DefaultAPISidebar("Canvas API")}}
+
 {{HTMLElement("canvas")}} es uno de los estándares más utilizados para la representación de gráficos 2D en la Web. Se utiliza ampliamente en los juegos y visualizaciones complejas. Sin embargo, as Web sites and apps push canvas to the limits, el rendimiento comienza a sufrir. This article aims to provide suggestions for optimizing your use of the canvas element, to ensure that your Web site or app performs well.
 
 A continuación una lista de tips par mejorar el rendimiento:

--- a/files/es/web/api/document/pointerlockchange_event/index.md
+++ b/files/es/web/api/document/pointerlockchange_event/index.md
@@ -3,6 +3,8 @@ title: pointerlockchange
 slug: Web/API/Document/pointerlockchange_event
 ---
 
+{{APIRef("Pointer Lock API")}}
+
 El evento `pointerlockchange` es disparado cuando el cursor del navegador es bloqueado o desbloqueado.
 
 ## Información general

--- a/files/es/web/api/document_object_model/examples/index.md
+++ b/files/es/web/api/document_object_model/examples/index.md
@@ -3,6 +3,8 @@ title: Ejemplos
 slug: Web/API/Document_Object_Model/Examples
 ---
 
+{{DefaultAPISidebar("DOM")}}
+
 En este capítulo se brindan ejemplos relativamente extensos que ilustran el uso del DOM para el desarrollo web y XML. Siempre que sea posible, usaremos las APIs, trucos y patrones comunes en JavaScript para la manipulación del objeto `document`.
 
 ### Ejemplo 1: Altos y anchos

--- a/files/es/web/api/document_object_model/how_to_create_a_dom_tree/index.md
+++ b/files/es/web/api/document_object_model/how_to_create_a_dom_tree/index.md
@@ -3,6 +3,8 @@ title: Cómo crear un DOM tree
 slug: Web/API/Document_Object_Model/How_to_create_a_DOM_tree
 ---
 
+{{DefaultAPISidebar("DOM")}}
+
 Esta página describe cómo usar el API [DOM Core](http://www.w3.org/TR/DOM-Level-3-Core/core.html) en JavaScript para crear o modificar objetos DOM. Es aplicable a todas las aplicaciones basadas en Gecko (como Mozilla Firefox) cuyo código tenga privilegios (como las extensiones) y a las que no (páginas web).
 
 ### Creación dinámica de un DOM tree

--- a/files/es/web/api/document_object_model/introduction/index.md
+++ b/files/es/web/api/document_object_model/introduction/index.md
@@ -3,6 +3,8 @@ title: Introducción
 slug: Web/API/Document_Object_Model/Introduction
 ---
 
+{{DefaultAPISidebar("DOM")}}
+
 Ésta sección da una breve introducción conceptual del [DOM](/es/DOM): qué es, cómo proporciona la estructura para los documentos [HTML](/es/HTML) y [XML](/es/XML), cómo se accede a él, y cómo esta ["API"](https://es.wikipedia.org/wiki/Interfaz_de_programaci%C3%B3n_de_aplicaciones) presenta la información de referencia y ejemplos.
 
 ## ¿Qué es el DOM?

--- a/files/es/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
+++ b/files/es/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
@@ -3,6 +3,8 @@ title: Localizando elementos DOM usando selectores
 slug: Web/API/Document_Object_Model/Locating_DOM_elements_using_selectors
 ---
 
+{{DefaultAPISidebar("DOM")}}
+
 Los selectores api proveen metodos que hacen mas facil y rapido devolver elementos del nodo {{domxref("Element")}} del DOM mediante emparejamiento de un conjunto de selectores. Esto es mucho mas rapido que las tecnicas anteriores, donde fuera necesario, por ejemplo usar un loop en un codigo JavaScript para localizar el item especifico que quisieras encontrar.
 
 ## Interfaz de NodeSelector

--- a/files/es/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
+++ b/files/es/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
@@ -3,6 +3,8 @@ title: Trazado de una tabla HTML mediante JavaScript y la Interface DOM
 slug: Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces
 ---
 
+{{DefaultAPISidebar("DOM")}}
+
 ## Introducción
 
 Este artículo es un resumen de algunos métodos DOM nivel 1 poderosos y fundamentales así como una descripción de cómo utilizarlos utilizando Javascript. Aprenderás a crear, accesar, controlar, y remover elementos HTML dinámicamente. Los métodos DOM presentados aquí no son específicos de HTML; también aplican para XML. Las demostraciones aquí proporcionadas funcionarán en cualquier navegador moderno, incluyendo todas las versiones de Firefox e IE 5+.

--- a/files/es/web/api/domexception/index.md
+++ b/files/es/web/api/domexception/index.md
@@ -3,6 +3,8 @@ title: DOMException
 slug: Web/API/DOMException
 ---
 
+{{ APIRef("DOM") }}
+
 La interfaz **`DOMException`** representa un evento anormal (llamado **excepción**) que ocurre como el resultado de llamar a un método o acceder a una propiedad de una API web. Asi es como las condiciones de error se describen en las API web.
 
 Cada excepción tiene un **nombre** (_name_), el cual es una cadena corta de estilo "PascalCase" que identifica el error o la condición anormal.

--- a/files/es/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/es/web/api/file_api/using_files_from_web_applications/index.md
@@ -3,6 +3,8 @@ title: Utilizar ficheros desde aplicaciones web
 slug: Web/API/File_API/Using_files_from_web_applications
 ---
 
+{{DefaultAPISidebar("File API")}}
+
 El uso de la API File añadida al DOM en HTML5, ahora hace posible que la página web solicite al usuario que seleccione archivos locales y, a continuación, leer el contenido de esos archivos. Esta selección se puede hacer, ya sea usando un elemento {{HTMLElement ( "input")}} de HTML o mediante arrastrar y soltar.
 
 ## Selección de ficheros utilizando HTML

--- a/files/es/web/api/filereader/readasdataurl/index.md
+++ b/files/es/web/api/filereader/readasdataurl/index.md
@@ -3,6 +3,8 @@ title: FileReader.readAsDataURL()
 slug: Web/API/FileReader/readAsDataURL
 ---
 
+{{APIRef("File API")}}
+
 El método `readAsDataURL` es usado para leer el contenido del especificado {{domxref("Blob")}} o {{domxref("File")}}. Cuando la operación de lectura es terminada, el {{domxref("FileReader.readyState","readyState")}} se convierte en `DONE`, y el [`loadend`](/es/docs/Web/Reference/Events/loadend) es lanzado. En ese momento, el atributo {{domxref("FileReader.result","result")}} contiene la información como un [datos: URL](/es/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) representando la información del archivo como una cadena de caracteres codificados en base64.
 
 > **Nota:** El {{domxref("FileReader.result","result")}} de blob no puede ser

--- a/files/es/web/api/history_api/index.md
+++ b/files/es/web/api/history_api/index.md
@@ -3,6 +3,8 @@ title: Manipulando el historial del navegador
 slug: Web/API/History_API
 ---
 
+{{DefaultAPISidebar("History API")}}
+
 El objeto DOM {{ domxref("window") }} proporciona acceso al historial del navegador a través del objeto {{ domxref("window.history", "history") }} . Este da acceso a métodos y propiedades útiles que permiten avanzar y retroceder a través del historial del usuario, así como --a partir de HTML5-- manipular el contenido del historial.
 
 ## Viajando a través del historial

--- a/files/es/web/api/html_drag_and_drop_api/index.md
+++ b/files/es/web/api/html_drag_and_drop_api/index.md
@@ -3,6 +3,8 @@ title: Arrastrar y soltar
 slug: Web/API/HTML_Drag_and_Drop_API
 ---
 
+{{DefaultAPISidebar("HTML Drag and Drop API")}}
+
 Firefox y otras aplicaciones de Mozilla admiten una serie de características para gestionar la funcionalidad de arrastrar y soltar. Esto le permite al usuario hacer clic y mantener presionado el botón del ratón/mouse sobre un elemento, arrastrarlo a otra ubicación y soltarlo para colocar el elemento allí. Al puntero le seguirá una representación transparente de lo que se está arrastrando durante la operación. La ubicación de destino puede ser una aplicación diferente. Sitios web, extensiones y aplicaciones XUL pueden hacer uso de esta funcionalidad para personalizar los elementos que pueden ser arrastrados, evaluar la operación, así como especificar el lugar donde los elementos se pueden soltar.
 
 > **Nota:** Esta sección trata sobre la funcionalidad de arrastrar y soltar en Firefox 3.5 (Gecko 1.9.1) y versiones posteriores. Consulta la [documentación de la API anterior](/es/docs/Drag_and_Drop) para Firefox 3.0 y versiones anteriores.

--- a/files/es/web/api/htmlelement/dragstart_event/index.md
+++ b/files/es/web/api/htmlelement/dragstart_event/index.md
@@ -3,6 +3,8 @@ title: "HTMLElement: dragstart event"
 slug: Web/API/HTMLElement/dragstart_event
 ---
 
+{{APIRef}}
+
 El evento `dragstart` se dispara cuando el usuario arrastra un elemento o una selección de texto.
 
 ## Sintaxis

--- a/files/es/web/api/htmlmediaelement/timeupdate_event/index.md
+++ b/files/es/web/api/htmlmediaelement/timeupdate_event/index.md
@@ -3,6 +3,8 @@ title: "HTMLMediaElement: timeupdate"
 slug: Web/API/HTMLMediaElement/timeupdate_event
 ---
 
+{{APIRef("HTMLMediaElement")}}
+
 El evento `timeupdate` es llamado cuando el tiempo indicado por el atributo `currentTime` es actualizado.
 
 La frecuencia del evento depende de la carga del sistema, pero se encuentra en un rango de 4Hz y 66Hz (asumiendo que los manejadores de eventos no toman mas de 250ms para correr). Se recomienda a los User agents variar la frecuencia del evento basados en la carga del sistema y el costo promedio de procesamiento del evento cada vez que corre, para que las actualizaciones a la UI no sean mas frecuentes que las que el user agent puede manejar confortablemente mientras se decodifica el video.

--- a/files/es/web/api/indexeddb_api/index.md
+++ b/files/es/web/api/indexeddb_api/index.md
@@ -3,7 +3,7 @@ title: IndexedDB
 slug: Web/API/IndexedDB_API
 ---
 
-{{ SeeCompatTable() }}
+{{DefaultAPISidebar("IndexedDB")}}{{ SeeCompatTable() }}
 
 IndexedDB es una API de bajo nivel que ofrece almacenamiento en el cliente de cantidades significativas de datos estructurados, incluyendo archivos y blobs. Para búsquedas de alto rendimiento en esos datos usa índices. Mientras [DOM Storage](/es/docs/DOM/Storage) es útil para el almacenamiento de pequeñas cantidades de datos, no es útil para almacenar grandes cantidades de datos estructurados. IndexedDB proporciona una solución.
 

--- a/files/es/web/api/indexeddb_api/using_indexeddb/index.md
+++ b/files/es/web/api/indexeddb_api/using_indexeddb/index.md
@@ -3,6 +3,8 @@ title: Usando IndexedDB
 slug: Web/API/IndexedDB_API/Using_IndexedDB
 ---
 
+{{DefaultAPISidebar("IndexedDB")}}
+
 IndexedDB es una manera de almacenar datos dentro del navegador del usuario. Debido a que permite la creación de aplicaciones con habilidades de consulta enriquecidas, con independencia de la disponibilidad de la red, sus aplicaciones pueden trabajar tanto en línea como fuera de línea.
 
 ## Acerca de este documento

--- a/files/es/web/api/media_capture_and_streams_api/index.md
+++ b/files/es/web/api/media_capture_and_streams_api/index.md
@@ -3,7 +3,7 @@ title: API de MediaStream
 slug: Web/API/Media_Capture_and_Streams_API
 ---
 
-{{SeeCompatTable}}
+{{DefaultAPISidebar("Media Capture and Streams")}}{{SeeCompatTable}}
 
 La API de proceso **_MediaStream_**, a veces llamada _Media Stream API_ o _Stream API_, es parte de la norma [WebRTC](/es/docs/WebRTC) y describe un flujo de datos de audio o video, los métodos para trabajar con ellos, las limitaciones asociadas con este tipo de datos, las respuestas de error y éxito al usar los datos asincrónicamente y los eventos que se disparan durante el proceso.
 

--- a/files/es/web/api/media_capture_and_streams_api/taking_still_photos/index.md
+++ b/files/es/web/api/media_capture_and_streams_api/taking_still_photos/index.md
@@ -3,6 +3,8 @@ title: Capturar fotografías con la cámara web
 slug: Web/API/Media_Capture_and_Streams_API/Taking_still_photos
 ---
 
+{{DefaultAPISidebar("Media Capture and Streams")}}
+
 ## Introducción y demostración
 
 Este es un tutorial rápido de cómo acceder a la cámara de tu laptop y capturar una foto con ella. Puedes observar el [código final en acción en este JSFiddle](https://jsfiddle.net/codepo8/agaRe/4/). También existe una versión más avanzada en JavaScript para cargar fotos a **imgur** disponible como [código en GitHub](https://github.com/codepo8/interaction-cam/) o [como demo](http://codepo8.github.com/interaction-cam/).

--- a/files/es/web/api/navigator/getusermedia/index.md
+++ b/files/es/web/api/navigator/getusermedia/index.md
@@ -3,6 +3,8 @@ title: Navigator.getUserMedia
 slug: Web/API/Navigator/getUserMedia
 ---
 
+{{APIRef("Media Capture and Streams")}}
+
 Pide al usuario permiso para usar un dispositivo multimedia como una cámara o micrófono. Si el usuario concede este permiso, el successCallback es invocado en la aplicación llamada con un objeto [LocalMediaStream](/es/docs/WebRTC/MediaStream_API#LocalMediaStream) como argumento.
 
 ## Sintaxis

--- a/files/es/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/es/web/api/server-sent_events/using_server-sent_events/index.md
@@ -3,6 +3,8 @@ title: Utilizando eventos enviados por el servidor (server-sent event)
 slug: Web/API/Server-sent_events/Using_server-sent_events
 ---
 
+{{DefaultAPISidebar("Server Sent Events")}}
+
 Desarrollar una aplicación web que utilice server-sent events es muy fácil. Solo necesitas un pequeño código del lado del servidor para transmitir los eventos a la aplicación web, pero del lado de la aplicacion web se trabaja prácticamente igual que con cualquier otro tipo de eventos.
 
 Puedes ver un ejemplo [aqui](/samples/sse/) (actualmente no funciona).

--- a/files/es/web/api/touch_events/index.md
+++ b/files/es/web/api/touch_events/index.md
@@ -3,6 +3,8 @@ title: Eventos de toque
 slug: Web/API/Touch_events
 ---
 
+{{DefaultAPISidebar("Touch Events")}}
+
 Con el fin de proporcionar soporte de calidad para usuarios de interfaces táctiles, los eventos táctiles dan la posibilidad de interpretar la actividad de los dedos en pantallas táctiles o trackpads.
 
 ## Definiciones

--- a/files/es/web/api/vibration_api/index.md
+++ b/files/es/web/api/vibration_api/index.md
@@ -3,6 +3,8 @@ title: Vibración API
 slug: Web/API/Vibration_API
 ---
 
+{{DefaultAPISidebar("Vibration API")}}
+
 La mayoría de los dispositivos modernos pueden vibrar a través del hardware, esto permite que a través del código de software se pueda emitir estas vibraciones. La **Vibration API** ofrece a las aplicaciones web la capacidad de acceder a este hardware en caso este lo soporte, caso contrario el dispositivo no hace nada.
 
 ## Describiendo vibraciones

--- a/files/es/web/api/web_speech_api/using_the_web_speech_api/index.md
+++ b/files/es/web/api/web_speech_api/using_the_web_speech_api/index.md
@@ -3,6 +3,8 @@ title: Uso de la Web Speech API
 slug: Web/API/Web_Speech_API/Using_the_Web_Speech_API
 ---
 
+{{DefaultAPISidebar("Web Speech API")}}
+
 La API Web Speech API proporciona dos funcionalidades distintas — reconocimiento de voz, y síntesis de voz (también conocido como texto a voz o tts) — lo que nos ofrece nuevas e interesantes posibilidades para accesibilidad y otros mecanismos. Este artículo ofrece una breve introducción en las dos áreas, así como unas demos.
 
 ## Reconocimiento de voz

--- a/files/es/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/es/web/api/web_workers_api/using_web_workers/index.md
@@ -3,6 +3,8 @@ title: Usando Web Workers
 slug: Web/API/Web_Workers_API/Using_web_workers
 ---
 
+{{DefaultAPISidebar("Web Workers API")}}
+
 Los Web Workers dedicados proveen un medio sencillo para que el contenido web ejecute scripts en hilos en segundo plano. Una vez creado, un worker puede enviar mensajes a la tarea creada mediante envio de mensajes al manejador de eventos especificado por el creador. Sin embargo, **los workers trabajan dentro de un [contexto global](/es/docs/JavaScript/DedicatedWorkerGlobalScope) diferente de la ventana actual** (usar el atajo {{ domxref("window") }} en lugar de {{ domxref("window.self","self") }} con el fin de obtener el scope actual dentro de un {{ domxref("Worker") }} retornaría, de hecho, un error).
 
 El hilo worker puede realizar tareas sin interferir con la interfaz de usuario. Ademas, pueden realizar I/O usando [`XMLHttpRequest`](/en/nsIXMLHttpRequest) (aunque el responseXML y los atributos channel son siempre null).

--- a/files/es/web/api/webrtc_api/session_lifetime/index.md
+++ b/files/es/web/api/webrtc_api/session_lifetime/index.md
@@ -3,6 +3,8 @@ title: WebRTC Introduction
 slug: Web/API/WebRTC_API/Session_lifetime
 ---
 
+{{DefaultAPISidebar("WebRTC")}}
+
 > **Nota:** WebRTC te permite establecer una comunicación par-a-par en una aplicación del navegador.
 
 ## Estableciendo la conexión

--- a/files/es/web/api/websocket/close_event/index.md
+++ b/files/es/web/api/websocket/close_event/index.md
@@ -3,6 +3,8 @@ title: close
 slug: Web/API/WebSocket/close_event
 ---
 
+{{APIRef("WebSockets API")}}
+
 El manejador `close` es ejecutado cuando una conexión con un websocket es cerrada.
 
 ## General info

--- a/files/es/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/es/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -3,6 +3,8 @@ title: Escribiendo aplicaciones con WebSockets
 slug: Web/API/WebSockets_API/Writing_WebSocket_client_applications
 ---
 
+{{DefaultAPISidebar("WebSockets API")}}
+
 WebSockets es una tecnología basada en el protocolo ws, este hace posible establecer una conexión continua full-duplex, entre un cliente y servidor. Un cliente websocket podría ser el navegador del usuario, pero el protocolo es una plataforma independiente.
 
 > **Nota:** Tenemos un ejemplo funcional de un sistema de chat/servidor usado para ejemplos de código que estará disponible una vez nuestra infraestructura esté en posición de hospedar ejemplos de WebSocket apropiadamente.

--- a/files/es/web/api/websockets_api/writing_websocket_server/index.md
+++ b/files/es/web/api/websockets_api/writing_websocket_server/index.md
@@ -3,6 +3,8 @@ title: Escribiendo un servidor WebSocket en C#
 slug: Web/API/WebSockets_API/Writing_WebSocket_server
 ---
 
+{{DefaultAPISidebar("WebSockets API")}}
+
 ## Introducción
 
 Si deseas utilizar la API WebSocket, es conveniente si tienes un servidor. En este artículo te mostraré como puedes escribir uno en C#. Tú puedes hacer esto en cualquier lenguaje del lado del servidor, pero para mantener las cosas simples y más comprensibles, elegí el lenguaje de Microsoft.

--- a/files/es/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/es/web/api/websockets_api/writing_websocket_servers/index.md
@@ -3,6 +3,8 @@ title: Escribir servidores WebSocket
 slug: Web/API/WebSockets_API/Writing_WebSocket_servers
 ---
 
+{{DefaultAPISidebar("WebSockets API")}}
+
 ## Introducción
 
 Un servidor WebSocket es simplemente una aplicación TCP que escucha en cualquier puerto de un servidor que sigue un protocolo específico. La tarea de crear un servidor propio personalizado suele asustar a los desarrolladores, sin embargo puede resultar muy fácil implementar un servidor WebSocket en la plataforma que elijas.

--- a/files/es/web/api/window/btoa/index.md
+++ b/files/es/web/api/window/btoa/index.md
@@ -4,6 +4,8 @@ slug: Web/API/Window/btoa
 original_slug: Web/API/btoa
 ---
 
+{{APIRef("HTML DOM")}}
+
 {{jsxref("String", "Cadenas JavaScript")}} son cadenas codificadas en UTF-16. Esto significa que cada unidad de código requiere dos bytes de memoria y puede representar `65535` puntos de código diferentes. Un subconjunto de estas cadenas está representado por cadenas UTF-16 que contienen solo caracteres ASCII (es decir, caracteres cuyo punto de código no excede `127`). Por ejemplo, la cadena `"¡Hola mundo!"` pertenece al subconjunto ASCII, mientras que la cadena `"ÀÈÌÒÙ"` no. Una **cadena binaria** es un concepto similar al subconjunto ASCII, pero en lugar de limitar el rango a `127`, permite hasta `255` puntos de código. Sin embargo, su propósito no es representar caracteres, sino datos binarios. El tamaño de los datos así representados es el doble de lo que sería en formato binario normal, sin embargo, esto no será visible para el usuario final, ya que la longitud de las cadenas de JavaScript se calcula usando dos bytes como unidad.
 
 Las cadenas binarias no forman parte del diseño del lenguaje JavaScript. Sin embargo, al menos una función nativa requiere cadenas binarias como entrada, {{domxref("WindowBase64.btoa", "btoa()")}}: invocarla en una cadena que contiene puntos de código mayores de `255` causará un error `Caracter fuera de rango`.

--- a/files/es/web/api/xmldocument/index.md
+++ b/files/es/web/api/xmldocument/index.md
@@ -3,6 +3,8 @@ title: Document.async
 slug: Web/API/XMLDocument
 ---
 
+{{APIRef("DOM")}}
+
 `document.async` es utilizado para indicar cuándo un llamado de {{domxref("document.load")}} debe ser sincrónico o asincrónico. `true` es su valor por defecto, indicando que el documento se cargó asincrónicamente.
 
 (Desde la versión 1.4 alpha es posible cargar documentos sincrónicamente)

--- a/files/es/web/api/xmlhttprequest/index.md
+++ b/files/es/web/api/xmlhttprequest/index.md
@@ -3,6 +3,8 @@ title: XMLHttpRequest
 slug: Web/API/XMLHttpRequest
 ---
 
+{{APIRef("XMLHttpRequest API")}}
+
 `XMLHttpRequest` es un objeto [JavaScript](/en/JavaScript) que fue diseñado por Microsoft y adoptado por Mozilla, Apple y Google. Actualmente es un [estándar de la W3C](http://www.w3.org/TR/XMLHttpRequest/). Proporciona una forma fácil de obtener información de una URL sin tener que recargar la página completa. Una página web puede actualizar sólo una parte de la página sin interrumpir lo que el usuario está haciendo. `XMLHttpRequest` es ampliamente usado en la programación AJAX.
 
 A pesar de su nombre, `XMLHttpRequest` puede ser usado para recibir cualquier tipo de dato, no solo XML, y admite otros formatos además de [HTTP](/en/HTTP) (incluyendo `file` y `ftp`).

--- a/files/es/web/api/xmlhttprequest/loadend_event/index.md
+++ b/files/es/web/api/xmlhttprequest/loadend_event/index.md
@@ -3,6 +3,8 @@ title: loadend
 slug: Web/API/XMLHttpRequest/loadend_event
 ---
 
+{{APIRef("XMLHttpRequest API")}}
+
 El evento `loadend` es emitido cuando el progreso de la carga de un recurso se ha detenido (e.g. despues que "error", "abort", o "load" han sido emitidos). Por ejemplo, esto aplica a las llamadas de {{domxref("XMLHttpRequest")}}, y al contenido de un elemento {{htmlelement("img")}} o {{htmlelement("video")}}.
 
 ## Información General

--- a/files/es/web/api/xmlhttprequest_api/using_formdata_objects/index.md
+++ b/files/es/web/api/xmlhttprequest_api/using_formdata_objects/index.md
@@ -3,6 +3,8 @@ title: Usando Objetos FormData
 slug: Web/API/XMLHttpRequest_API/Using_FormData_Objects
 ---
 
+{{DefaultAPISidebar("XMLHttpRequest API")}}
+
 Los objetos `FormData` le permiten compilar un conjunto de pares clave/valor para enviar mediante `XMLHttpRequest`. Están destinados principalmente para el envío de los datos del formulario, pero se pueden utilizar de forma independiente con el fin de transmitir los datos tecleados. Los datos transmitidos estarán en el mismo formato que usa el método `submit()` del formulario para enviar los datos si el tipo de codificación del formulario se establece en "multipart/form-data".
 
 ## Creación de un objeto FormData desde cero

--- a/files/es/web/css/-moz-user-focus/index.md
+++ b/files/es/web/css/-moz-user-focus/index.md
@@ -3,7 +3,7 @@ title: "-moz-user-focus"
 slug: Web/CSS/-moz-user-focus
 ---
 
-{{Non-standard_header}}
+{{CSSRef}}{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/@counter-style/additive-symbols/index.md
+++ b/files/es/web/css/@counter-style/additive-symbols/index.md
@@ -3,6 +3,8 @@ title: additive-symbols
 slug: Web/CSS/@counter-style/additive-symbols
 ---
 
+{{CSSRef}}
+
 ## Resumen
 
 El descriptor additive-symbols es similar al descriptor {{cssxref('symbols')}}, y permite al usuario especificar símbolos que se usarán para representación de contadores cuando el valor del descriptor {{cssxref('system')}} es _additive_. El descriptor `additive-symbols` define lo que se conoce como tuplas aditivas, cada una de las cuales es un par que contiene un símbolo y su peso como entero no negativo. El sistema aditivo es usado para construir sistemas de [numeración de valores de signos](http://en.wikipedia.org/wiki/Sign-value_notation) como la numeración romana.

--- a/files/es/web/css/@counter-style/symbols/index.md
+++ b/files/es/web/css/@counter-style/symbols/index.md
@@ -3,6 +3,8 @@ title: symbols
 slug: Web/CSS/@counter-style/symbols
 ---
 
+{{CSSRef}}
+
 ## Summary
 
 El descriptor `symbols` es usado para definir los símbolos que usará un sistema de conteo específico para construir una representación de conteo. Un símbolo puede ser un texto, una imagen o un identificador. El descriptor symbols debe ser especificado cuando el valor del descriptor {{cssxref('system')}} es _cyclic_, _numeric_, _alphabetic_, _symbolic_, o _fixed_. Cuando se usa el sistema _additive_, el descriptor {{cssxref('additive-symbols')}} es usado para especificar los símbolos.

--- a/files/es/web/css/@media/color/index.md
+++ b/files/es/web/css/@media/color/index.md
@@ -3,6 +3,8 @@ title: color
 slug: Web/CSS/@media/color
 ---
 
+{{CSSRef}}
+
 **`color`** es una característica CSS relativa al medio de presentación cuyo valor es un [`<integer>`](/es/docs/Web/CSS/integer) que contiene el número de bits por componente de color en el dispositivo de salida, o cero si el dispositivivo no es en color.
 
 ## Especificaciones

--- a/files/es/web/css/@media/resolution/index.md
+++ b/files/es/web/css/@media/resolution/index.md
@@ -3,6 +3,8 @@ title: Resolución
 slug: Web/CSS/@media/resolution
 ---
 
+{{CSSRef}}
+
 **`resolución`** es una función de medios de CSS cuyo valor es la densidad de píxeles del dispositivo de salida, como un CSS[`<resolution>`](/es/docs/Web/CSS/resolution).
 
 ## Especificaciones

--- a/files/es/web/css/align-items/index.md
+++ b/files/es/web/css/align-items/index.md
@@ -3,6 +3,8 @@ title: align-items
 slug: Web/CSS/align-items
 ---
 
+{{CSSRef}}
+
 La propiedad [CSS](/es/docs/Web/CSS) **`align-items`** establece el valor {{cssxref("align-self")}} sobre todos los descendientes directos de un grupo. La propiedad align-self indica la alineación de un elemento dentro del bloque que lo contiene. En Flexbox controla la alineación de los elementos del {{glossary("Cross Axis")}}, en Grid Layout controla la alineación de los elementos en el eje Block dentro de su [área grid](/es/docs/Glossary/Grid_Areas).
 
 El ejemplo interactivo a continuación demuestra algunos de los valores de `align-items` utilizando el sistema grid.

--- a/files/es/web/css/background-color/index.md
+++ b/files/es/web/css/background-color/index.md
@@ -3,6 +3,8 @@ title: background-color
 slug: Web/CSS/background-color
 ---
 
+{{CSSRef}}
+
 ### Resumen
 
 `Background-color` es un propiedad de CSS que define el color de fondo de un elemento, puede ser el valor de un color o la palabra clave `transparent`.

--- a/files/es/web/css/background-origin/index.md
+++ b/files/es/web/css/background-origin/index.md
@@ -3,6 +3,8 @@ title: background-origin
 slug: Web/CSS/background-origin
 ---
 
+{{CSSRef}}
+
 ## Resumen
 
 La propiedad background-origin especifica el área de origen de un fondo o imagen en determinada caja. para que la propiedad [background-position](/es/CSS/background-position) calcule la posición de inicio de un fondo o imagen definida por la propiedad [background-image](/es/CSS/background-image).

--- a/files/es/web/css/background-position/index.md
+++ b/files/es/web/css/background-position/index.md
@@ -3,7 +3,7 @@ title: background-position
 slug: Web/CSS/background-position
 ---
 
-{{ PreviousNext("CSS:background-image", "CSS:background-repeat") }}
+{{CSSRef}}{{ PreviousNext("CSS:background-image", "CSS:background-repeat") }}
 
 ## Resumen
 

--- a/files/es/web/css/border-bottom-color/index.md
+++ b/files/es/web/css/border-bottom-color/index.md
@@ -3,6 +3,8 @@ title: border-bottom-color
 slug: Web/CSS/border-bottom-color
 ---
 
+{{CSSRef}}
+
 ### Resumen
 
 La propiedad `border-bottom-color` define el color del borde inferior de un elemento, con la ayuda de un valor de color o con la palabra clave `transparent`.

--- a/files/es/web/css/border-bottom-style/index.md
+++ b/files/es/web/css/border-bottom-style/index.md
@@ -3,6 +3,8 @@ title: border-bottom-style
 slug: Web/CSS/border-bottom-style
 ---
 
+{{CSSRef}}
+
 << [Volver](/es/Guía_de_referencia_de_CSS)
 
 ### Resumen

--- a/files/es/web/css/border-bottom-width/index.md
+++ b/files/es/web/css/border-bottom-width/index.md
@@ -3,6 +3,8 @@ title: border-bottom-width
 slug: Web/CSS/border-bottom-width
 ---
 
+{{CSSRef}}
+
 ### Resumen
 
 `border-bottom-width` define el ancho del borde inferior de una caja.

--- a/files/es/web/css/border-bottom/index.md
+++ b/files/es/web/css/border-bottom/index.md
@@ -3,6 +3,8 @@ title: border-bottom
 slug: Web/CSS/border-bottom
 ---
 
+{{CSSRef}}
+
 ### Resumen
 
 La propiedad `border-bottom` permite de definir de una vez todas las propiedades individuales {{ Cssxref("border-bottom-color") }}, {{ Cssxref("border-bottom-style") }}, y {{ Cssxref("border-bottom-width") }}, las cuales describen el color, estilo y ancho del borde inferior de un elementos.

--- a/files/es/web/css/border-collapse/index.md
+++ b/files/es/web/css/border-collapse/index.md
@@ -3,6 +3,8 @@ title: border-collapse
 slug: Web/CSS/border-collapse
 ---
 
+{{CSSRef}}
+
 ### Resumen
 
 La propiedad `border-collapse` se utiliza para fusionar los bordes. Ésto tiene una gran influencia sobre la presentación y el estilo de las celdas de tabla. La representación de los bordes de tabla es dividida en dos categorías en CSS2 - "fusión" y "separación" (collapsed - separated). Esta propiedad especifica que modo de presentación de borde hay que usar.

--- a/files/es/web/css/border-color/index.md
+++ b/files/es/web/css/border-color/index.md
@@ -3,7 +3,7 @@ title: border-color
 slug: Web/CSS/border-color
 ---
 
-{{ PreviousNext("CSS:border", "CSS:border-style") }}
+{{CSSRef}}{{ PreviousNext("CSS:border", "CSS:border-style") }}
 
 ### Resumen
 

--- a/files/es/web/css/border-left-color/index.md
+++ b/files/es/web/css/border-left-color/index.md
@@ -3,6 +3,8 @@ title: border-left-color
 slug: Web/CSS/border-left-color
 ---
 
+{{CSSRef}}
+
 ### Resumen
 
 `border-left-color` pone el color del borde izquierdo de un elemento,con el valor de el color en hexadecimal o con palabras clave, como azul, verde, rojo `transparente`.

--- a/files/es/web/css/border-spacing/index.md
+++ b/files/es/web/css/border-spacing/index.md
@@ -3,6 +3,8 @@ title: border-spacing
 slug: Web/CSS/border-spacing
 ---
 
+{{CSSRef}}
+
 ### Resumen
 
 La propiedad de {{ Cssxref("border-spacing", "espaciado de borde") }} especifica la distancia entre los bordes de celdas adyacentes (sólo para el modelo de [separación de borde](/es/CSS/border-collapse)). Es el equivalente al atributo `cellspacing` en HTML.

--- a/files/es/web/css/border-width/index.md
+++ b/files/es/web/css/border-width/index.md
@@ -3,6 +3,8 @@ title: border-width
 slug: Web/CSS/border-width
 ---
 
+{{CSSRef}}
+
 ### Resumen
 
 La propiedad **`border-width`** define el ancho del borde.

--- a/files/es/web/css/border/index.md
+++ b/files/es/web/css/border/index.md
@@ -3,7 +3,7 @@ title: border
 slug: Web/CSS/border
 ---
 
-{{ PreviousNext("Guía de referencia de CSS", "CSS:border-color") }}
+{{CSSRef}}{{ PreviousNext("Guía de referencia de CSS", "CSS:border-color") }}
 
 ### Propiedades Constitutivas
 

--- a/files/es/web/css/content/index.md
+++ b/files/es/web/css/content/index.md
@@ -3,6 +3,8 @@ title: content
 slug: Web/CSS/content
 ---
 
+{{CSSRef}}
+
 << [Volver](/es/Gu%c3%ada_de_referencia_de_CSS)
 
 ### Resumen

--- a/files/es/web/css/css_backgrounds_and_borders/border-image_generator/index.md
+++ b/files/es/web/css/css_backgrounds_and_borders/border-image_generator/index.md
@@ -3,6 +3,8 @@ title: Generador Border-image
 slug: Web/CSS/CSS_backgrounds_and_borders/Border-image_generator
 ---
 
+{{CSSRef}}
+
 Esta herramienta permite generar valores para CSS3 {{cssxref("border-image")}}
 
 {{EmbedGHLiveSample("css-examples/tools/border-image-generator/", '100%', 1200)}}

--- a/files/es/web/css/css_backgrounds_and_borders/border-radius_generator/index.md
+++ b/files/es/web/css/css_backgrounds_and_borders/border-radius_generator/index.md
@@ -3,6 +3,8 @@ title: Generador de border-radius
 slug: Web/CSS/CSS_backgrounds_and_borders/Border-radius_generator
 ---
 
+{{CSSRef}}
+
 Esta herramienta puede ser usada para generar efectos de {{cssxref("border-radius")}} de CSS3.
 
 #### Herramienta

--- a/files/es/web/css/css_grid_layout/box_alignment_in_grid_layout/index.md
+++ b/files/es/web/css/css_grid_layout/box_alignment_in_grid_layout/index.md
@@ -3,6 +3,8 @@ title: Box alignment in CSS Grid Layout
 slug: Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout
 ---
 
+{{CSSRef}}
+
 Si estás familiarizado con [flexbox](/es/docs/Web/CSS/CSS_Flexible_Box_Layout) Entonces ya habrás encontrado la forma en que los items flexibles pueden ser alineados correctamente dentro de un contendor flex. Estas propiedades de alineación que encontramos por primera vez en la especificación de flexbox se han trasladado a una nueva especificación llamada [Box Alignment Level 3](https://drafts.csswg.org/css-align/). Esta especificación tiene detalles de cómo debería funcionar la alineación en todos los diferentes métodos de diseño.
 
 Cada método de diseño que implemente Box Alignment tendrá algunas diferencias debido a que cada método tiene características y restricciones diferentes (y acciones heredadas), por lo que es imposible hacer la alineación exactamente de la misma forma en todos los ámbitos. La especificación Box Alignment tiene detalles para cada método, sin embargo, te decepcionaría si intentaras alinear en muchos métodos en este momento, pues el soporte aún no está disponible para todos los navegadores. Donde sí tenemos soporte de navegador para las propiedades de alineación y distribución de espacio de la especificación Box Alignment es en grid layout.

--- a/files/es/web/css/css_multicol_layout/using_multicol_layouts/index.md
+++ b/files/es/web/css/css_multicol_layout/using_multicol_layouts/index.md
@@ -3,6 +3,8 @@ title: Columnas con CSS-3
 slug: Web/CSS/CSS_multicol_layout/Using_multicol_layouts
 ---
 
+{{CSSRef}}
+
 ### Introducción
 
 Cuando leemos un texto, las líneas muy largas resultan incómodas. Si son demasiado largas, al cambiar de línea nuestros ojos pueden perder la pista de la línea en la que estabas (al ir de un extremo al otro de la página). Por ello, pensando en los usuarios con monitores grandes, los autores deben limitar la anchura del texto dividiéndolo en columnas, más o menos, como hacen los periódicos. Por desgracia esto no es posible con HTML y CSS-2, a no ser que fuerces la ruptura de las columnas en puntos fijos, limites en gran medida el código a utilizar, o uses scripts complejos.

--- a/files/es/web/css/css_positioned_layout/understanding_z-index/index.md
+++ b/files/es/web/css/css_positioned_layout/understanding_z-index/index.md
@@ -3,6 +3,8 @@ title: Entendiendo la propiedad CSS z-index
 slug: Web/CSS/CSS_positioned_layout/Understanding_z-index
 ---
 
+{{CSSRef}}
+
 Usualmente se puede considerar que las páginas HTML tienen dos dimensiones, porque el texto, las imágenes y otros elementos son organizados en la página sin superponerse. Hay un solo flujo de renderizado, y todos los elementos son concientes del espacio ocupado por otros. El atributo {{cssxref("z-index")}} te permite ajustar el orden de las capas de los objetos cuando el contenido está siendo renderizado.
 
 > En CSS 2.1, cada caja tiene una posición en tres dimensiones. Adicionalmente a sus posiciones horizontales y verticales, las cajas caen a lo largo de un "eje-z" y son formadas una encima de la otra. Las posiciones eje-Z son particularmente relevantes cuando las cajas se superponen visualmente.

--- a/files/es/web/css/css_positioned_layout/understanding_z-index/stacking_context/index.md
+++ b/files/es/web/css/css_positioned_layout/understanding_z-index/stacking_context/index.md
@@ -3,6 +3,8 @@ title: El contexto de apilamiento
 slug: Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context
 ---
 
+{{CSSRef}}
+
 « [CSS](/es/CSS) « [ENTENDIENDO LA PROPIEDAD CSS Z-INDEX](/es/docs/Web/CSS/CSS_Positioning/entendiendo_z_index)
 
 El contexto de apilamiento es la conceptualización tridimensional de los elementos HTML a lo largo de un eje-Z imaginario relativo al usuario que se asume está de cara al viewport o página web. Los elementos HTML ocupan este espacio por orden de prioridad basado en sus atributos.

--- a/files/es/web/css/css_positioned_layout/understanding_z-index/stacking_context_example_1/index.md
+++ b/files/es/web/css/css_positioned_layout/understanding_z-index/stacking_context_example_1/index.md
@@ -3,6 +3,8 @@ title: Ejemplo 1 del contexto de apilamiento
 slug: Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context_example_1
 ---
 
+{{CSSRef}}
+
 « [CSS](/es/CSS) « [ENTENDIENDO LA PROPIEDAD CSS Z-INDEX](/es/docs/Web/CSS/CSS_Positioning/entendiendo_z_index)
 
 Empecemos con un ejemplo básico. En el contexto de apilamiento raíz tenemos dos DIVs (DIV #1 and DIV #3), ambos con posición relativa, pero sin propiedad z-index. Dentro del DIV #1 se encuentra el DIV #2 de posición absoluta, mientras que en el DIV #3 se encuentra el DIV #4 con posición absoluta, ambos sin propiedad z-index.

--- a/files/es/web/css/css_positioned_layout/understanding_z-index/stacking_context_example_2/index.md
+++ b/files/es/web/css/css_positioned_layout/understanding_z-index/stacking_context_example_2/index.md
@@ -3,6 +3,8 @@ title: Ejemplo 2 del contexto de apilamiento
 slug: Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context_example_2
 ---
 
+{{CSSRef}}
+
 « [CSS](/es/CSS) « [ENTENDIENDO LA PROPIEDAD CSS Z-INDEX](/es/docs/Web/CSS/CSS_Positioning/entendiendo_z_index)
 
 Este es un ejemplo muy simple, pero es la clave para entender el concepto de _contexto de apilamiento._ Tenemos los mismos 4 DIVs del ejemplo previo, pero ahora las propiedades z-index son asignadas en ambos niveles de la jerarquía.

--- a/files/es/web/css/css_positioned_layout/understanding_z-index/stacking_context_example_3/index.md
+++ b/files/es/web/css/css_positioned_layout/understanding_z-index/stacking_context_example_3/index.md
@@ -3,6 +3,8 @@ title: Ejemplo 3 del contexto de apilamiento
 slug: Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context_example_3
 ---
 
+{{CSSRef}}
+
 « [CSS](/en/CSS) « [Understanding CSS z-index](/en/CSS/Understanding_z-index)
 
 Este último ejemplo muestra los problemas que surgen cuando se combinan varios elementos posicionados en una jerarquía HTML multi nivel y cuando los valores z-index son asignados usando selectores de clase.

--- a/files/es/web/css/css_positioned_layout/understanding_z-index/stacking_without_z-index/index.md
+++ b/files/es/web/css/css_positioned_layout/understanding_z-index/stacking_without_z-index/index.md
@@ -3,6 +3,8 @@ title: Apilando sin z-index
 slug: Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_without_z-index
 ---
 
+{{CSSRef}}
+
 « [CSS](/es/CSS) « [ENTENDIENDO LA PROPIEDAD CSS Z-INDEX](/es/docs/Web/CSS/CSS_Positioning/entendiendo_z_index)
 
 Cuando ningún elemento tiene z-index, los elementos son apilados en este orden (de abajo hacia arriba):

--- a/files/es/web/css/css_positioned_layout/understanding_z-index/using_z-index/index.md
+++ b/files/es/web/css/css_positioned_layout/understanding_z-index/using_z-index/index.md
@@ -3,6 +3,8 @@ title: Agregando z-index
 slug: Web/CSS/CSS_positioned_layout/Understanding_z-index/Using_z-index
 ---
 
+{{CSSRef}}
+
 « [CSS](/es/CSS) « [ENTENDIENDO LA PROPIEDAD CSS Z-INDEX](/es/docs/Web/CSS/CSS_Positioning/entendiendo_z_index)
 
 ### Agregando {{ cssxref("z-index") }}

--- a/files/es/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/es/web/css/css_transitions/using_css_transitions/index.md
@@ -3,7 +3,7 @@ title: Transiciones de CSS
 slug: Web/CSS/CSS_transitions/Using_CSS_transitions
 ---
 
-{{ SeeCompatTable() }}
+{{CSSRef}}{{ SeeCompatTable() }}
 
 Las transiciones CSS, parte del borrador de la especificación CSS3, proporcionan una forma de animar los cambios de las propiedades CSS, en lugar de que los cambios surtan efecto de manera instantánea. Por ejemplo, si cambias el color de un elemento de blanco a negro, normalmente el cambio es instantáneo. Al habilitar las transiciones CSS, el cambio sucede en un intervalo de tiempo que puedes especificar, siguiendo una curva de aceleración que puedes personalizar.
 

--- a/files/es/web/css/env/index.md
+++ b/files/es/web/css/env/index.md
@@ -3,6 +3,8 @@ title: env()
 slug: Web/CSS/env
 ---
 
+{{CSSRef}}
+
 La función [CSS](/es/docs/Web/CSS) **`env()`** puede ser utilizada para insertar el valor de una variable de entorno, que sea global para un documento en particular, al contrario de una [propiedad personalizada](/es/docs/Web/CSS/--_). Entonces, la funcion env() puede ser utilizada para remplazar el valor en ubicaciones arbitrarias, de la misma manera que la función [var()](/es/docs/Web/CSS/var).
 
 La función env() puede ser utilizada en el lugar de cualquier parte de un valor en cualquier propiedad de cualquier elemento, o de cualquier parte de un valor en cualquier descriptor de cualquier regla @, y en varios otros lugares donde los valores CSS están permitidos.

--- a/files/es/web/css/index.md
+++ b/files/es/web/css/index.md
@@ -3,6 +3,8 @@ title: CSS
 slug: Web/CSS
 ---
 
+{{CSSRef}}
+
 **Hojas de Estilo en Cascada** (del inglés _**C**ascading **S**tyle **S**heets_) o **CSS** es el lenguaje de [estilos](/es/docs/Web/API/StyleSheet) utilizado para describir la presentación de documentos [HTML](/es/docs/HTML) o [XML](/es/docs/XML) (incluyendo varios lenguajes basados en XML como [SVG](/es/docs/Web/SVG), [MathML](/es/docs/Web/MathML) o {{Glossary("XHTML")}}). CSS describe cómo debe ser renderizado el elemento estructurado en la pantalla, en papel, en el habla o en otros medios.
 
 **CSS** es uno de los lenguajes base de la _Open Web_ y posee una [especificación estandarizada](http://www.w3.org/Style/CSS/#specs) por parte del W3C. Anteriormente , el desarrollo de varias partes de las especificaciones de CSS era realizado de manera sincrónica, lo que permitía el versionado de las recomendaciones. Probablemente habrás escuchado acerca de CSS1, CSS2.1, CSS3. Sin embargo, CSS4 nunca se ha lanzado como una versión oficial.

--- a/files/es/web/css/inherit/index.md
+++ b/files/es/web/css/inherit/index.md
@@ -3,6 +3,8 @@ title: inherit
 slug: Web/CSS/inherit
 ---
 
+{{CSSRef}}
+
 << [Volver](/es/Gu%c3%ada_de_referencia_de_CSS)
 
 ### Resumen

--- a/files/es/web/css/initial/index.md
+++ b/files/es/web/css/initial/index.md
@@ -3,6 +3,8 @@ title: initial
 slug: Web/CSS/initial
 ---
 
+{{CSSRef}}
+
 [Guía de referencia de CSS](/es/Gu%c3%ada_de_referencia_de_CSS)
 
 ### Resumen

--- a/files/es/web/css/initial_value/index.md
+++ b/files/es/web/css/initial_value/index.md
@@ -3,6 +3,8 @@ title: Valor inicial
 slug: Web/CSS/initial_value
 ---
 
+{{CSSRef}}
+
 << [Volver](/es/Gu%c3%ada_de_referencia_de_CSS)
 
 ### Resumen

--- a/files/es/web/css/margin-right/index.md
+++ b/files/es/web/css/margin-right/index.md
@@ -3,6 +3,8 @@ title: margin-right
 slug: Web/CSS/margin-right
 ---
 
+{{CSSRef}}
+
 ### Definicion
 
 El margen derecho de propiedad establece el margen derecho de un elemento.

--- a/files/es/web/css/max-height/index.md
+++ b/files/es/web/css/max-height/index.md
@@ -3,6 +3,8 @@ title: max-height
 slug: Web/CSS/max-height
 ---
 
+{{CSSRef}}
+
 ### Resumen
 
 La propiedad `max-height` se utiliza para definir la altura máxima de un elemento dado. Impide que el valor de la {{ Cssxref("height", "altura") }} pueda llegar a ser más grande que la de `max-height`.

--- a/files/es/web/css/minmax/index.md
+++ b/files/es/web/css/minmax/index.md
@@ -3,6 +3,8 @@ title: minmax()
 slug: Web/CSS/minmax
 ---
 
+{{CSSRef}}
+
 La función **`minmax()`** [en CSS](/es/docs/Web/CSS) define un rango de tamaño mayor o igual que _min_ y menor o igual que _max_. Se emplea con [rejillas CSS](/es/docs/Web/CSS/CSS_Grid_Layout).
 
 ```css

--- a/files/es/web/css/reference/index.md
+++ b/files/es/web/css/reference/index.md
@@ -3,6 +3,8 @@ title: Referencia CSS
 slug: Web/CSS/Reference
 ---
 
+{{CSSRef}}
+
 Esta _Referencia CSS_ muestra la sintáxis básica de una regla CSS; lista todas las propiedades estándares [CSS](/es/docs/Web/CSS), [pseudo-classes](/es/docs/Web/CSS/Pseudo-classes) y [pseudo-elementos](/es/docs/Web/CSS/Pseudoelementos), [reglas-at](/es/docs/Web/CSS/At-rule), [unidades](/es/docs/Web/CSS/length), y [selectores](/es/docs/Web/CSS/Introducci%C3%B3n/Selectors), todos juntos en [orden alfabético](#Keyword_index), así como los [selectores por tipo](#Selectors); y le permitirá acceso rápido a la información detallada de cada uno de ellos. No solo lista las propiedades de CSS 1 y CSS 2.1, sino que también es una referencia de CSS3 que enlaza cualquier propiedad y concepto de [CSS3](/es/docs/Web/CSS/CSS3) estandarizado, o ya establecido. También incluye una breve [referencia DOM-CSS / CSSOM](#DOM_CSS).
 
 Tenga en cuenta que las definiciones de reglas CSS son completamente [basadas en texto](https://www.w3.org/TR/css-syntax-3/#intro) (ASCII), mientras que DOM-CSS / CSSOM, el sistema de gestión de reglas, está [basado en objetos](https://www.w3.org/TR/cssom/#introduction).

--- a/files/es/web/css/specificity/index.md
+++ b/files/es/web/css/specificity/index.md
@@ -3,6 +3,8 @@ title: Especificidad
 slug: Web/CSS/Specificity
 ---
 
+{{CSSRef}}
+
 La **especificidad** es la manera mediante la cual los navegadores deciden qué valores de una propiedad CSS son más relevantes para un elemento y, por lo tanto, serán aplicados. La especificidad está basada en las reglas de coincidencia que están compuestas por diferentes tipos de [selectores CSS](/es/CSS/CSS_Reference#Selectors).
 
 ## ¿Cómo se calcula?

--- a/files/es/web/css/text-emphasis/index.md
+++ b/files/es/web/css/text-emphasis/index.md
@@ -3,6 +3,8 @@ title: text-emphasis
 slug: Web/CSS/text-emphasis
 ---
 
+{{CSSRef}}
+
 La **propiedad** **[CSS](/es/docs/Web/CSS)** de **text-emphasis**, es una propiedad _abreviada_ para establecer los valores de [text-empahasis-style](/es/docs/Web/CSS/text-emphasis-style) y [text-emphasis-color](/es/docs/Web/CSS/text-emphasis-color), en una sola declaración.
 
 Esta **propiedad** aplicara el énfasis a cada carácter especificado en el texto del elemento, a excepción de caracteres separados como espacios y caracteres de control .

--- a/files/es/web/css/tutorials/index.md
+++ b/files/es/web/css/tutorials/index.md
@@ -3,6 +3,8 @@ title: CSS Tutorials
 slug: Web/CSS/Tutorials
 ---
 
+{{CSSRef}}
+
 Aprender CSS puede ser una tarea desalentadora. Para ayudarte, hemos escrito numerosos **tutoriales acerca de CSS.** Algunos estan dirigidos a principiantes, y mientras que otros presentan complejas características para ser usadas por usuarios mas avanzados.
 
 Esta página enlista todo el contenido, con una descripción corta. Estan agrupados por grado de complejidad, para que escogas lo mas apropiado para tu nivel.

--- a/files/es/web/exslt/exsl/node-set/index.md
+++ b/files/es/web/exslt/exsl/node-set/index.md
@@ -3,7 +3,7 @@ title: node-set
 slug: Web/EXSLT/exsl/node-set
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `exsl:node-set()` devuelve un conjunto de nodos (node-set) de un fragmento de árbol resultante, que es lo que obtienes cuando miras en `xsl:variable` en vez de su atributo select para seleccionar el valor de la variable. Esto te permite procesar XML creado dentro de una variable en vez de procesarlo en múltiples pasos.
 

--- a/files/es/web/exslt/exsl/node-set/index.md
+++ b/files/es/web/exslt/exsl/node-set/index.md
@@ -3,7 +3,7 @@ title: node-set
 slug: Web/EXSLT/exsl/node-set
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `exsl:node-set()` devuelve un conjunto de nodos (node-set) de un fragmento de árbol resultante, que es lo que obtienes cuando miras en `xsl:variable` en vez de su atributo select para seleccionar el valor de la variable. Esto te permite procesar XML creado dentro de una variable en vez de procesarlo en múltiples pasos.
 

--- a/files/es/web/exslt/exsl/object-type/index.md
+++ b/files/es/web/exslt/exsl/object-type/index.md
@@ -3,7 +3,7 @@ title: object-type
 slug: Web/EXSLT/exsl/object-type
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{ XsltRef() }}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{ XsltRef() }}
 
 `exsl:object-type()` devuelve una cadena que indica el tipo del objeto especificado.
 

--- a/files/es/web/exslt/exsl/object-type/index.md
+++ b/files/es/web/exslt/exsl/object-type/index.md
@@ -3,7 +3,7 @@ title: object-type
 slug: Web/EXSLT/exsl/object-type
 ---
 
-{{ XsltRef() }}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{ XsltRef() }}
 
 `exsl:object-type()` devuelve una cadena que indica el tipo del objeto especificado.
 

--- a/files/es/web/exslt/math/highest/index.md
+++ b/files/es/web/exslt/math/highest/index.md
@@ -3,7 +3,7 @@ title: highest
 slug: Web/EXSLT/math/highest
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 `math:highest()` devuelve el nodo con el valor más alto (donde el valor más alto se calcula usando [`math:max()`](/es/docs/Web/EXSLT/math/max)) del conjunto de nodos (node-set) especificado.
 
 Un nodo tiene este valor máximo si convierte su valor de cadena a un número igual al valor máximo.

--- a/files/es/web/exslt/math/highest/index.md
+++ b/files/es/web/exslt/math/highest/index.md
@@ -3,7 +3,7 @@ title: highest
 slug: Web/EXSLT/math/highest
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 `math:highest()` devuelve el nodo con el valor más alto (donde el valor más alto se calcula usando [`math:max()`](/es/docs/Web/EXSLT/math/max)) del conjunto de nodos (node-set) especificado.
 
 Un nodo tiene este valor máximo si convierte su valor de cadena a un número igual al valor máximo.

--- a/files/es/web/exslt/math/lowest/index.md
+++ b/files/es/web/exslt/math/lowest/index.md
@@ -3,7 +3,7 @@ title: lowest
 slug: Web/EXSLT/math/lowest
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 `math:lowest()` devuelve el nodo del conjunto de nodos (node-set) especificado con el valor más bajo (donde el valor más bajo se calcula usando [`math:min()`](/es/docs/Web/EXSLT/math/min).
 
 Un nodo tiene este valor mínimo si convirtiendo su valor de cadena a número iguala el valor mínimo.

--- a/files/es/web/exslt/math/lowest/index.md
+++ b/files/es/web/exslt/math/lowest/index.md
@@ -3,7 +3,7 @@ title: lowest
 slug: Web/EXSLT/math/lowest
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 `math:lowest()` devuelve el nodo del conjunto de nodos (node-set) especificado con el valor más bajo (donde el valor más bajo se calcula usando [`math:min()`](/es/docs/Web/EXSLT/math/min).
 
 Un nodo tiene este valor mínimo si convirtiendo su valor de cadena a número iguala el valor mínimo.

--- a/files/es/web/exslt/math/max/index.md
+++ b/files/es/web/exslt/math/max/index.md
@@ -3,7 +3,7 @@ title: max
 slug: Web/EXSLT/math/max
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 `math:max()` devuelve el valor máximo de un conjunto de nodos (node-set).
 
 To compute the maximum value of the node-set, the node set is sorted into descending order as it would be using [`xsl:sort()`](/es/docs/Web/XSLT/sort) with a data type of `number`. The maximum value is then the first node in the sorted list, converted into a number.

--- a/files/es/web/exslt/math/max/index.md
+++ b/files/es/web/exslt/math/max/index.md
@@ -3,7 +3,7 @@ title: max
 slug: Web/EXSLT/math/max
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 `math:max()` devuelve el valor máximo de un conjunto de nodos (node-set).
 
 To compute the maximum value of the node-set, the node set is sorted into descending order as it would be using [`xsl:sort()`](/es/docs/Web/XSLT/sort) with a data type of `number`. The maximum value is then the first node in the sorted list, converted into a number.

--- a/files/es/web/exslt/math/min/index.md
+++ b/files/es/web/exslt/math/min/index.md
@@ -3,7 +3,7 @@ title: min
 slug: Web/EXSLT/math/min
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `math:min()` devuelve el valor mínimo de un conjunto de nodos (node-set).
 

--- a/files/es/web/exslt/math/min/index.md
+++ b/files/es/web/exslt/math/min/index.md
@@ -3,7 +3,7 @@ title: min
 slug: Web/EXSLT/math/min
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `math:min()` devuelve el valor mínimo de un conjunto de nodos (node-set).
 

--- a/files/es/web/exslt/regexp/match/index.md
+++ b/files/es/web/exslt/regexp/match/index.md
@@ -3,7 +3,7 @@ title: match
 slug: Web/EXSLT/regexp/match
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `regexp:match()` realiza la búsqueda de coincidencias de una expresión regular en una cadena, devolviendo las subcoincidencias halladas como resultado.
 

--- a/files/es/web/exslt/regexp/match/index.md
+++ b/files/es/web/exslt/regexp/match/index.md
@@ -3,7 +3,7 @@ title: match
 slug: Web/EXSLT/regexp/match
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `regexp:match()` realiza la búsqueda de coincidencias de una expresión regular en una cadena, devolviendo las subcoincidencias halladas como resultado.
 

--- a/files/es/web/exslt/regexp/replace/index.md
+++ b/files/es/web/exslt/regexp/replace/index.md
@@ -3,7 +3,7 @@ title: replace
 slug: Web/EXSLT/regexp/replace
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `regexp:replace()` reemplaza porciones de una cadena que coincide con la expresión regular dada por el contenido de otra cadena.
 

--- a/files/es/web/exslt/regexp/replace/index.md
+++ b/files/es/web/exslt/regexp/replace/index.md
@@ -3,7 +3,7 @@ title: replace
 slug: Web/EXSLT/regexp/replace
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `regexp:replace()` reemplaza porciones de una cadena que coincide con la expresión regular dada por el contenido de otra cadena.
 

--- a/files/es/web/exslt/regexp/test/index.md
+++ b/files/es/web/exslt/regexp/test/index.md
@@ -3,7 +3,7 @@ title: test
 slug: Web/EXSLT/regexp/test
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `regexp:test()` comprueba si una cadena coincide con una expresión regular especificada.
 

--- a/files/es/web/exslt/regexp/test/index.md
+++ b/files/es/web/exslt/regexp/test/index.md
@@ -3,7 +3,7 @@ title: test
 slug: Web/EXSLT/regexp/test
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `regexp:test()` comprueba si una cadena coincide con una expresión regular especificada.
 

--- a/files/es/web/exslt/set/difference/index.md
+++ b/files/es/web/exslt/set/difference/index.md
@@ -3,7 +3,7 @@ title: difference
 slug: Web/EXSLT/set/difference
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `set:difference()` devuelve la diferencia entre dos conjuntos de nodos. En otras palabras, devuelve un cojunto de nodos cuyos nodos están en uno de los conjuntos pero no en el otro.
 

--- a/files/es/web/exslt/set/difference/index.md
+++ b/files/es/web/exslt/set/difference/index.md
@@ -3,7 +3,7 @@ title: difference
 slug: Web/EXSLT/set/difference
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `set:difference()` devuelve la diferencia entre dos conjuntos de nodos. En otras palabras, devuelve un cojunto de nodos cuyos nodos están en uno de los conjuntos pero no en el otro.
 

--- a/files/es/web/exslt/set/distinct/index.md
+++ b/files/es/web/exslt/set/distinct/index.md
@@ -3,7 +3,7 @@ title: distinct
 slug: Web/EXSLT/set/distinct
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `set:distinct()` devuelve un subconjunto de los nodos del conjunto de nods especificado, devolviendo sólo los nodos con valores de texto únicos.
 

--- a/files/es/web/exslt/set/distinct/index.md
+++ b/files/es/web/exslt/set/distinct/index.md
@@ -3,7 +3,7 @@ title: distinct
 slug: Web/EXSLT/set/distinct
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `set:distinct()` devuelve un subconjunto de los nodos del conjunto de nods especificado, devolviendo sólo los nodos con valores de texto únicos.
 

--- a/files/es/web/exslt/set/has-same-node/index.md
+++ b/files/es/web/exslt/set/has-same-node/index.md
@@ -3,7 +3,7 @@ title: has-same-node
 slug: Web/EXSLT/set/has-same-node
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `set:has-same-node()` determina si dos conjuntos de nodos tienen algún nodo en común.
 

--- a/files/es/web/exslt/set/has-same-node/index.md
+++ b/files/es/web/exslt/set/has-same-node/index.md
@@ -3,7 +3,7 @@ title: has-same-node
 slug: Web/EXSLT/set/has-same-node
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `set:has-same-node()` determina si dos conjuntos de nodos tienen algún nodo en común.
 

--- a/files/es/web/exslt/set/intersection/index.md
+++ b/files/es/web/exslt/set/intersection/index.md
@@ -3,7 +3,7 @@ title: intersection
 slug: Web/EXSLT/set/intersection
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `set:intersection()` devuelve la intersección de dos conjuntos de nodos. En otras palabras, devuelve un conjunto de nodos que contiene todos los nodos de ambos conjuntos de nodos.
 

--- a/files/es/web/exslt/set/intersection/index.md
+++ b/files/es/web/exslt/set/intersection/index.md
@@ -3,7 +3,7 @@ title: intersection
 slug: Web/EXSLT/set/intersection
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `set:intersection()` devuelve la intersección de dos conjuntos de nodos. En otras palabras, devuelve un conjunto de nodos que contiene todos los nodos de ambos conjuntos de nodos.
 

--- a/files/es/web/exslt/set/leading/index.md
+++ b/files/es/web/exslt/set/leading/index.md
@@ -3,7 +3,7 @@ title: leading
 slug: Web/EXSLT/set/leading
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `set:leading()` devuelve los nodos de un conjunto de nodos que viene antes del primer nodo del otro conjunto de nodos.
 

--- a/files/es/web/exslt/set/leading/index.md
+++ b/files/es/web/exslt/set/leading/index.md
@@ -3,7 +3,7 @@ title: leading
 slug: Web/EXSLT/set/leading
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `set:leading()` devuelve los nodos de un conjunto de nodos que viene antes del primer nodo del otro conjunto de nodos.
 

--- a/files/es/web/exslt/set/trailing/index.md
+++ b/files/es/web/exslt/set/trailing/index.md
@@ -3,7 +3,7 @@ title: trailing
 slug: Web/EXSLT/set/trailing
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `set:trailing()` devuelve los nodos de un conjunto de nodos que vienen después del primer nodo de otro conjunto de nodos.
 

--- a/files/es/web/exslt/set/trailing/index.md
+++ b/files/es/web/exslt/set/trailing/index.md
@@ -3,7 +3,7 @@ title: trailing
 slug: Web/EXSLT/set/trailing
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `set:trailing()` devuelve los nodos de un conjunto de nodos que vienen después del primer nodo de otro conjunto de nodos.
 

--- a/files/es/web/exslt/str/concat/index.md
+++ b/files/es/web/exslt/str/concat/index.md
@@ -3,7 +3,7 @@ title: concat
 slug: Web/EXSLT/str/concat
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `str:concat()` devuelve una cadena que contiene todos los valores cadena de un conjunto de nodos (node-set) concatenados juntos.
 

--- a/files/es/web/exslt/str/concat/index.md
+++ b/files/es/web/exslt/str/concat/index.md
@@ -3,7 +3,7 @@ title: concat
 slug: Web/EXSLT/str/concat
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `str:concat()` devuelve una cadena que contiene todos los valores cadena de un conjunto de nodos (node-set) concatenados juntos.
 

--- a/files/es/web/exslt/str/split/index.md
+++ b/files/es/web/exslt/str/split/index.md
@@ -3,7 +3,7 @@ title: split
 slug: Web/EXSLT/str/split
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `str:split()` divide una cadena usando una cadena patrón que determina donde deberían ocurrir las divisiones y devuelve un conjunto de nodos que contiene las cadenas resultantes.
 

--- a/files/es/web/exslt/str/split/index.md
+++ b/files/es/web/exslt/str/split/index.md
@@ -3,7 +3,7 @@ title: split
 slug: Web/EXSLT/str/split
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `str:split()` divide una cadena usando una cadena patrón que determina donde deberían ocurrir las divisiones y devuelve un conjunto de nodos que contiene las cadenas resultantes.
 

--- a/files/es/web/exslt/str/tokenize/index.md
+++ b/files/es/web/exslt/str/tokenize/index.md
@@ -3,7 +3,7 @@ title: tokenize
 slug: Web/EXSLT/str/tokenize
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
+{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}{{XsltRef}}
 
 `str:tokenize()` divide una cadena usando un conjunto de caracteres como delimitadores que determinan donde deberían ocurrir las divisiones, devolviendo un conjunto de nodos que contiene las cadenas resultantes.
 

--- a/files/es/web/exslt/str/tokenize/index.md
+++ b/files/es/web/exslt/str/tokenize/index.md
@@ -3,7 +3,7 @@ title: tokenize
 slug: Web/EXSLT/str/tokenize
 ---
 
-{{XsltRef}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{XsltRef}}
 
 `str:tokenize()` divide una cadena usando un conjunto de caracteres como delimitadores que determinan donde deberían ocurrir las divisiones, devolviendo un conjunto de nodos que contiene las cadenas resultantes.
 

--- a/files/es/web/html/attributes/accept/index.md
+++ b/files/es/web/html/attributes/accept/index.md
@@ -3,6 +3,8 @@ title: "HTML el atributo: accept"
 slug: Web/HTML/Attributes/accept
 ---
 
+{{HTMLSidebar}}
+
 El atributo **`accept`** toma como valor una lista separada por comas de uno o más tipos de archivos, o [especificadores de tipo de archivo únicos](#especificadores_de_tipo_de_archivo_únicos), que describen qué tipos de archivo permitir. La propiedad «_accept_» es un atributo del tipo {{HTMLElement("input/file", "file")}} {{HTMLElement("input")}}. Se admitía en el elemento {{HTMLElement("form")}}, pero se eliminó a favor de {{HTMLElement("input/file", "file")}} en HTML5.
 
 Debido a que un determinado tipo de archivo se puede identificar de más de una manera, es útil proporcionar un conjunto completo de especificadores de tipo cuando necesiten archivos de un tipo específico, o usar el comodín para indicar que un tipo de cualquier formato es aceptable.

--- a/files/es/web/html/attributes/crossorigin/index.md
+++ b/files/es/web/html/attributes/crossorigin/index.md
@@ -3,6 +3,8 @@ title: Atributos de configuración CORS
 slug: Web/HTML/Attributes/crossorigin
 ---
 
+{{HTMLSidebar}}
+
 En HTML5, algunos elementos HTML que dan soporte para [CORS](/es/docs/HTTP/Access_control_CORS), tales como {{ HTMLElement("img") }} o {{ HTMLElement("video") }}, tienen un atributo `crossorigin` (propiedad `crossOrigin`), que les permite configurar las peticiones CORS de los datos que se cargan. Estos atributos están enumerados, y tienen los siguientes valores posibles:
 
 | Palabra clave     | Descripción                                                                                                                                      |

--- a/files/es/web/html/attributes/index.md
+++ b/files/es/web/html/attributes/index.md
@@ -3,6 +3,8 @@ title: Referencia de Atributos HTML
 slug: Web/HTML/Attributes
 ---
 
+{{HTMLSidebar("Attributes")}}
+
 Los elementos en HTML tienen **atributos**; estos son valores adicionales que configuran los elementos o ajustan su comportamiento de diversas formas para cumplir los criterios de los usuarios.
 
 ## Lista de Atributos

--- a/files/es/web/html/attributes/min/index.md
+++ b/files/es/web/html/attributes/min/index.md
@@ -3,6 +3,8 @@ title: "HTML el atributo: min"
 slug: Web/HTML/Attributes/min
 ---
 
+{{HTMLSidebar}}
+
 El atributo [`min`](/es/docs/Web/HTML/Element/input#min) define el valor mínimo que es aceptable y válido para el {{HTMLElement("input")}} que contiene el atributo. Si el [value](/es/docs/Web/HTML/Element/input#attr-value) del elemento es menor que esto, el elemento falla la [restricción de validación](/es/docs/Web/Guide/HTML/HTML5/Constraint_validation). Este valor debe ser menor o igual que el valor del atributo [`max`](/es/docs/Web/HTML/Element/input#max). Si se especifica un valor para [`min`](/es/docs/Web/HTML/Element/input#min) que no es un número válido, la entrada no tiene un valor mínimo.
 
 Válido para los tipos de entrada numérica, incluidos los tipos {{HTMLElement("input/date", "date")}}, {{HTMLElement("input/month", "month")}}, {{HTMLElement("input/week", "week")}}, {{HTMLElement("input/time", "time")}}, {{HTMLElement("input/datetime-local", "datetime-local")}}, {{HTMLElement("input/number", "number")}} y {{HTMLElement("input/range", "range")}}, y el elemento {{htmlelement('meter')}}, el atributo [`min`](/es/docs/Web/HTML/Element/input#min) es un número que especifica el valor mínimo de un control de formulario para ser considerado válido.

--- a/files/es/web/html/attributes/minlength/index.md
+++ b/files/es/web/html/attributes/minlength/index.md
@@ -3,6 +3,8 @@ title: "HTML el atributo: minlength"
 slug: Web/HTML/Attributes/minlength
 ---
 
+{{HTMLSidebar}}
+
 El atributo **`minlength`** define el número mínimo de caracteres (como unidades de código UTF-16) que el usuario puede ingresar en un {{HTMLElement('input')}} o {{HTMLElement('textarea')}}. Debe ser un valor entero 0 o superior. Si no se especifica una longitud mínima o se especifica un número no válido, el **`<input>`** no tiene una longitud mínima. Este valor debe ser menor o igual que el valor de [maxlength](/es/docs/Web/HTML/Attributes/maxlength); de lo contrario, el valor nunca será válido, puesto que es imposible cumplir con ambos criterios.
 
 El **`<input>`** fallará la restricción de validación si la longitud del valor de texto del campo es menor que la longitud mínima de unidades de código UTF-16, con {{DOMxRef('validityState.tooShort')}} devolviendo `true`. La validación de la restricción solo se aplica cuando el usuario cambia el valor. Una vez que el envío falla, algunos navegadores mostrarán un mensaje de error que indica la longitud mínima requerida y la longitud actual.

--- a/files/es/web/html/attributes/multiple/index.md
+++ b/files/es/web/html/attributes/multiple/index.md
@@ -3,6 +3,8 @@ title: "HTML el atributo: multiple"
 slug: Web/HTML/Attributes/multiple
 ---
 
+{{HTMLSidebar}}
+
 El atributo booleano [`multiple`](/es/docs/Web/HTML/Element/input#multiple), si se establece, significa que el control del formulario acepta uno o más valores. Válido para los {{HTMLElement("input")}}s de tipo {{HTMLElement("input/email", "email")}}, {{HTMLElement("input/file", "file")}} y {{HTMLElement("select")}}, la forma en que el usuario opta por valores múltiples depende del control del formulario.
 
 Dependiendo del tipo, el control de formulario puede tener una apariencia diferente si se establece el atributo [`multiple`](/es/docs/Web/HTML/Element/input#multiple). Para el {{HTMLElement("input")}} de tipo `file`, la mensajería nativa que proporciona el navegador es diferente. En Firefox, el {{HTMLElement("input")}} de tipo `file` dice "Ningún archivo seleccionado" cuando el atributo está presente y "Ningún archivo seleccionado", cuando no hay archivo seleccionado. La mayoría de los navegadores muestran un cuadro de lista de desplazamiento para un control {{HTMLElement("select")}} con el atributo [`multiple`](/es/docs/Web/HTML/Element/input#multiple) establecido frente a un menú desplegable de una sola línea cuando se omite el atributo. El {{HTMLElement("input")}} {{HTMLElement("input/email", "email")}} muestra lo mismo, pero coincidirá con la pseudoclase {{CSSxRef(':invalid')}} si hay más de una dirección de correo electrónico separada por comas incluido si el atributo no está presente.

--- a/files/es/web/html/content_categories/index.md
+++ b/files/es/web/html/content_categories/index.md
@@ -3,6 +3,8 @@ title: Categorías de contenido
 slug: Web/HTML/Content_categories
 ---
 
+{{HTMLSidebar}}
+
 Cada elemento [HTML](/es/docs/Web/HTML) es miembro de una o más **categorías de contenido** — estas categorías agrupan elementos que comparten características comunes. Esta es una agrupación flexible (en realidad no crea una relación entre los elementos de estas categorías), pero ayuda a definir y describir el comportamiento compartido de las categorías y sus reglas asociadas, especialmente cuando te encuentras con sus intrincados detalles. También es posible que los elementos no sean miembros de _ninguna_ de estas categorías.
 
 Hay tres tipos de categorías de contenido:

--- a/files/es/web/html/cors_enabled_image/index.md
+++ b/files/es/web/html/cors_enabled_image/index.md
@@ -3,6 +3,8 @@ title: Imagen con CORS habilitado
 slug: Web/HTML/CORS_enabled_image
 ---
 
+{{HTMLSidebar}}
+
 La especificación HTML introduce un atributo [`crossorigin`](/es/docs/Web/HTML/Element/img#crossorigin) para imágenes que, en conjunto con el encabezado {{Glossary("CORS")}} apropiado, permite definir imágenes con el elemento {{ HTMLElement("img") }} que se carguen de orígenes externos dentro de un lienzo (_canvas_) como si estas fuesen cargadas del origen actual.
 
 Vea el artículo ["Atributos de configuración CORS"](/en/HTML/CORS_settings_attributes) para mas detalles de como el atributo "crossorigin" es usado.

--- a/files/es/web/html/element/acronym/index.md
+++ b/files/es/web/html/element/acronym/index.md
@@ -3,6 +3,8 @@ title: acronym
 slug: Web/HTML/Element/acronym
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 **acromym** de acromyn=acrónimo

--- a/files/es/web/html/element/aside/index.md
+++ b/files/es/web/html/element/aside/index.md
@@ -3,6 +3,8 @@ title: aside
 slug: Web/HTML/Element/aside
 ---
 
+{{HTMLSidebar}}
+
 El **elemento HTML `<aside>`** representa una sección de una página que consiste en contenido que está indirectamente relacionado con el contenido principal del documento. Estas secciones son a menudo representadas como barras laterales o como inserciones y contienen una explicación al margen como una definición de glosario, elementos relacionados indirectamente, como publicidad, la biografía del autor, o en aplicaciones web, la información de perfil o enlaces a blogs relacionados.
 
 > **Nota:** Notas de uso:

--- a/files/es/web/html/element/audio/index.md
+++ b/files/es/web/html/element/audio/index.md
@@ -3,6 +3,8 @@ title: Audio
 slug: Web/HTML/Element/audio
 ---
 
+{{HTMLSidebar}}
+
 El elemento `audio` se usa para insertar contenido de audio en un documento HTML o XHTML. El elemento `audio` se agregó como parte de HTML 5.
 
 > **Nota:** actualmente Gecko admite solamente Vorbis, en contenedores Ogg, así como formato WAV. Asimismo, el servidor debe servir el archivo mediante el tipo MIME correcto con el fin de que Gecko lo reproduzca correctamente.

--- a/files/es/web/html/element/b/index.md
+++ b/files/es/web/html/element/b/index.md
@@ -3,6 +3,8 @@ title: b
 slug: Web/HTML/Element/b
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 **b** de bold=negrita.

--- a/files/es/web/html/element/bdo/index.md
+++ b/files/es/web/html/element/bdo/index.md
@@ -3,6 +3,8 @@ title: bdo
 slug: Web/HTML/Element/bdo
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 **bdo** Bi-Directional Overriding=Anulación de bidireccionalidad.

--- a/files/es/web/html/element/big/index.md
+++ b/files/es/web/html/element/big/index.md
@@ -3,6 +3,8 @@ title: big
 slug: Web/HTML/Element/big
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 **big** de big=grande

--- a/files/es/web/html/element/blockquote/index.md
+++ b/files/es/web/html/element/blockquote/index.md
@@ -3,6 +3,8 @@ title: blockquote
 slug: Web/HTML/Element/blockquote
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - **blockquote** -_cita en bloque_ . Crea citas en bloque, marca las citas a otros autores o documentos.

--- a/files/es/web/html/element/button/index.md
+++ b/files/es/web/html/element/button/index.md
@@ -3,6 +3,8 @@ title: button
 slug: Web/HTML/Element/button
 ---
 
+{{HTMLSidebar}}
+
 ## Definición
 
 **button** = botón.

--- a/files/es/web/html/element/canvas/index.md
+++ b/files/es/web/html/element/canvas/index.md
@@ -3,6 +3,8 @@ title: canvas
 slug: Web/HTML/Element/canvas
 ---
 
+{{HTMLSidebar}}
+
 El elemento HTML _canvas_ (\<canvas>) se puede utilizar para dibujar gráficos a través de secuencias de comandos (por lo general [JavaScript](/en/JavaScript) ). Por ejemplo, puede usarse para dibujar gráficos, hacer composiciones de fotos o incluso realizar animaciones.
 
 Las aplicaciones de Mozilla adquirieron la compatibilidad con `<canvas>` a partir de Gecko 1.8 (es decir, [Firefox 1.5](/en/Firefox_1.5_for_developers) ). El elemento fue originalmente introducido por Apple en el OS X [Dashboard](http://www.apple.com/macosx/features/dashboard/) y Safari. Internet Explorer, antes de la versión 9.0 beta, no admite de forma nativa `<canvas>` , pero una página puede de hecho añadir la compatibilidad mediante la inclusión de un script del proyecto [Explorer Canvas](http://excanvas.sourceforge.net/) de Google. Opera 9 también es compatible con `<canvas>` .

--- a/files/es/web/html/element/caption/index.md
+++ b/files/es/web/html/element/caption/index.md
@@ -3,6 +3,8 @@ title: caption
 slug: Web/HTML/Element/caption
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - Es el encargado de darle un título descriptivo a las tablas.

--- a/files/es/web/html/element/center/index.md
+++ b/files/es/web/html/element/center/index.md
@@ -3,7 +3,7 @@ title: <center> (obsoleto)
 slug: Web/HTML/Element/center
 ---
 
-{{Deprecated_Header}}
+{{HTMLSidebar}}{{Deprecated_Header}}
 
 ### Definición
 

--- a/files/es/web/html/element/cite/index.md
+++ b/files/es/web/html/element/cite/index.md
@@ -3,6 +3,8 @@ title: cite
 slug: Web/HTML/Element/cite
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - **cite** -_cita_ . Marca una referencia a una fuente, o el autor de un texto citado.

--- a/files/es/web/html/element/code/index.md
+++ b/files/es/web/html/element/code/index.md
@@ -3,6 +3,8 @@ title: code
 slug: Web/HTML/Element/code
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - Es el apropiado para marcar el código de un programa.

--- a/files/es/web/html/element/col/index.md
+++ b/files/es/web/html/element/col/index.md
@@ -3,6 +3,8 @@ title: col
 slug: Web/HTML/Element/col
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - Permite especificar propiedades para una columna o un grupo de ellas.

--- a/files/es/web/html/element/colgroup/index.md
+++ b/files/es/web/html/element/colgroup/index.md
@@ -3,6 +3,8 @@ title: colgroup
 slug: Web/HTML/Element/colgroup
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - **colgroup** de column group = Grupo de columnas. Permite crear [grupos de columnas](http://html.conclase.net/w3c/html401-es/struct/tables.html#h-11.2.4).

--- a/files/es/web/html/element/del/index.md
+++ b/files/es/web/html/element/del/index.md
@@ -3,6 +3,8 @@ title: del
 slug: Web/HTML/Element/del
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - El elemento `del` (deleted-borrado) marca las partes de un texto o documento que han sido suprimidas o sustituidas.

--- a/files/es/web/html/element/dfn/index.md
+++ b/files/es/web/html/element/dfn/index.md
@@ -3,6 +3,8 @@ title: dfn
 slug: Web/HTML/Element/dfn
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - Sirve para marcar el término que se quiere definir.

--- a/files/es/web/html/element/dir/index.md
+++ b/files/es/web/html/element/dir/index.md
@@ -3,6 +3,8 @@ title: dir
 slug: Web/HTML/Element/dir
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - El elemento `dir` (directorio) es un elemento desaprobado. En su origen fue pensado para crear directorios en multicolumna, en la actualidad es inutil.

--- a/files/es/web/html/element/embed/index.md
+++ b/files/es/web/html/element/embed/index.md
@@ -3,6 +3,8 @@ title: embed
 slug: Web/HTML/Element/embed
 ---
 
+{{HTMLSidebar}}
+
 > **Nota:** este tema documenta sólo el elemento \<embed> que se define como parte de HTML5. No trata las implementaciones anteriores no estandarizadas del elemento `<embed>`.
 
 El _Elemento HTML Embed_ ( `<embed>` ) representa un punto de integración para una aplicación externa o de contenido interactivo (en otras palabras, un plug-in).

--- a/files/es/web/html/element/fieldset/index.md
+++ b/files/es/web/html/element/fieldset/index.md
@@ -3,6 +3,8 @@ title: fieldset
 slug: Web/HTML/Element/fieldset
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - El elemento [fieldset](/es/HTML/Elemento/fieldset) (grupo de campos) permite organizar en grupos los campos de un formulario.

--- a/files/es/web/html/element/figure/index.md
+++ b/files/es/web/html/element/figure/index.md
@@ -3,6 +3,8 @@ title: figure
 slug: Web/HTML/Element/figure
 ---
 
+{{HTMLSidebar}}
+
 El _elemento HTML_ \<figure> representa contenido independiente, a menudo con un título. Si bien se relaciona con el flujo principal, su posición es independiente de éste. Por lo general, se trata de una imagen, una ilustración, un diagrama, un fragmento de código, o un esquema al que se hace referencia en el texto principal, pero que se puede mover a otra página o a un apéndice sin que afecte al flujo principal.
 
 > **Nota:**

--- a/files/es/web/html/element/font/index.md
+++ b/files/es/web/html/element/font/index.md
@@ -3,6 +3,8 @@ title: font
 slug: Web/HTML/Element/font
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - **font** -_fuente_ . Indica el tamaño, color, o fuente del texto que contiene.

--- a/files/es/web/html/element/footer/index.md
+++ b/files/es/web/html/element/footer/index.md
@@ -3,6 +3,8 @@ title: footer
 slug: Web/HTML/Element/footer
 ---
 
+{{HTMLSidebar}}
+
 El _Elemento_ _HTML Footer_ (`<footer>`) representa un pie de página para el contenido de sección más cercano o el elemento [raíz de sección](/en/Sections_and_Outlines_of_an_HTML5_document#sectioning_root) (p.e, su ancestro mas cercano [`<article>`](/es/HTML/Element/article), [`<aside>`](/es/HTML/Element/aside), [`<nav>`](/es/HTML/Element/nav), [`<section>`](/es/HTML/Element/section),[`<blockquote>`](/es/HTML/Element/blockquote), [`<body>`](/es/HTML/Element/body), [`<details>`](/es/HTML/Element/details), [`<fieldset>`](/es/HTML/Element/fieldset), [`<figure>`](/es/HTML/Element/figure), [`<td>`](/es/HTML/Element/td)). Un pie de página típicamente contiene información acerca de el autor de la sección, datos de derechos de autor o enlaces a documentos relacionados.
 
 \<meta http-equiv="content-type" content="text/html; charset=utf-8"/>

--- a/files/es/web/html/element/form/index.md
+++ b/files/es/web/html/element/form/index.md
@@ -3,6 +3,8 @@ title: form
 slug: Web/HTML/Element/form
 ---
 
+{{HTMLSidebar}}
+
 ## Resumen
 
 El elemento HTML form (`<form>`) representa una sección de un documento que contiene controles interactivos que permiten a un usuario enviar información a un servidor web.

--- a/files/es/web/html/element/frame/index.md
+++ b/files/es/web/html/element/frame/index.md
@@ -3,6 +3,8 @@ title: frame
 slug: Web/HTML/Element/frame
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - **frame** -_marcos_ . Define la organización de los marcos dentro de la ventana del usuario.

--- a/files/es/web/html/element/frameset/index.md
+++ b/files/es/web/html/element/frameset/index.md
@@ -3,6 +3,8 @@ title: frameset
 slug: Web/HTML/Element/frameset
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - **frameset** -_conjunto de marcos_ . Define la organización de los marcos dentro de la ventana del usuario.

--- a/files/es/web/html/element/header/index.md
+++ b/files/es/web/html/element/header/index.md
@@ -3,6 +3,8 @@ title: header
 slug: Web/HTML/Element/header
 ---
 
+{{HTMLSidebar}}
+
 El _elemento de HTML Header_ (\<header>) representa un grupo de ayudas introductorias o de navegación. Puede contener algunos elementos de encabezado, así como también un logo, un formulario de búsqueda, un nombre de autor y otros componentes.
 
 > **Nota:**

--- a/files/es/web/html/element/hgroup/index.md
+++ b/files/es/web/html/element/hgroup/index.md
@@ -3,6 +3,8 @@ title: hgroup
 slug: Web/HTML/Element/hgroup
 ---
 
+{{HTMLSidebar}}
+
 ## Resumen
 
 El _elemento de grupo de cabeceras HTML_ (\<hgroup>) representa el encabezado de una sección. Define un solo título que participa de [la estructura del documento](/en/Sections_and_Outlines_of_an_HTML5_document) como el encabezado de la sección implícita o explícita a la que pertenece.

--- a/files/es/web/html/element/hr/index.md
+++ b/files/es/web/html/element/hr/index.md
@@ -3,6 +3,8 @@ title: <hr>
 slug: Web/HTML/Element/hr
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - El **elemento HTML \<hr>** representa un cambio de tema entre párrafos (por ejemplo, un cambio de escena en una historia, un cambio de tema en una sección). En versiones previas de HTML representaba una línea horizontal. Aún puede ser representada como una línea horizontal en los navegadores visuales, pero ahora es definida en términos semánticos y no tanto en términos representativos, por tanto para dibujar una línea horizontal se debería usar el CSS apropiado.

--- a/files/es/web/html/element/i/index.md
+++ b/files/es/web/html/element/i/index.md
@@ -3,6 +3,8 @@ title: i
 slug: Web/HTML/Element/i
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - Muestra el texto marcado con un estilo en cursiva o italica.

--- a/files/es/web/html/element/img/index.md
+++ b/files/es/web/html/element/img/index.md
@@ -3,6 +3,8 @@ title: "<img>: El elemento incrustado de imagen"
 slug: Web/HTML/Element/img
 ---
 
+{{HTMLSidebar}}
+
 El elemento de imagen HTML **`<img>`** representa una imagen en el documento.
 
 > **Nota:**

--- a/files/es/web/html/element/input/checkbox/index.md
+++ b/files/es/web/html/element/input/checkbox/index.md
@@ -3,6 +3,8 @@ title: <input type="checkbox">
 slug: Web/HTML/Element/input/checkbox
 ---
 
+{{HTMLSidebar}}
+
 El elemento HTML **`<input type="checkbox">`** es un elemento de entrada que te permite insertar un vector o array de valores. El atributo **value** es usado para definr el valor enviado por el **checkbox**. El atributo **checked** se usa para indicar que el elemento está seleccionado. El atributo **indeterminate** se usa para indicar que el **checkbox** esta en un estado indeterminado (en la mayoria de las plataformas, esto dibuja una linea horizontal que atraviesa el **checkbox**).
 
 ## Atributos

--- a/files/es/web/html/element/input/datetime-local/index.md
+++ b/files/es/web/html/element/input/datetime-local/index.md
@@ -3,6 +3,8 @@ title: <input type="datetime">
 slug: Web/HTML/Element/input/datetime-local
 ---
 
+{{HTMLSidebar}}
+
 _El HTML_ `<input type="datetime">` es un control para ingresar tiempo y fecha (hora, minuto, segundo y fracción de segundo) basado en la zona horaria UTC .
 
 - [Categorías de contenido](/es/docs/Web/Guide/HTML/categorias_de_contenido) : Contenido dinámico , listed , submittable , resettable , contenido asociado a un formulario , contenido estático o de texto . Si `type` no tiene el valor `hidden`, elemenento labelable , contenido palpable .

--- a/files/es/web/html/element/input/index.md
+++ b/files/es/web/html/element/input/index.md
@@ -3,6 +3,8 @@ title: input
 slug: Web/HTML/Element/input
 ---
 
+{{HTMLSidebar}}
+
 ## Resumen
 
 El elemento HTML `<input>` se usa para crear controles interactivos para formularios basados en la web con el fin de recibir datos del usuario.Hay disponible una amplia variedad de tipos de datos de entrada y widgets de control, que dependen del dispositivo y el agente de usuario ([user agent](/es/docs/Glossary/user_agent)).El elemento `<input>` es uno de los más potentes y complejos en todo HTML debido a la gran cantidad de combinaciones de tipos y atributos de entrada.

--- a/files/es/web/html/element/ins/index.md
+++ b/files/es/web/html/element/ins/index.md
@@ -3,6 +3,8 @@ title: ins
 slug: Web/HTML/Element/ins
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - El elemento `ins` (insertado) marca las partes de un texto que han sido añadidos al documento.

--- a/files/es/web/html/element/kbd/index.md
+++ b/files/es/web/html/element/kbd/index.md
@@ -3,6 +3,8 @@ title: kbd
 slug: Web/HTML/Element/kbd
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - Marca el texto que debe introducir el usuario.

--- a/files/es/web/html/element/legend/index.md
+++ b/files/es/web/html/element/legend/index.md
@@ -3,6 +3,8 @@ title: legend
 slug: Web/HTML/Element/legend
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - El elemento \<legend> (leyenda) crea un título para un grupos los campos ({{ HTMLElement("fieldset") }}) de un formulario.

--- a/files/es/web/html/element/li/index.md
+++ b/files/es/web/html/element/li/index.md
@@ -3,6 +3,8 @@ title: li
 slug: Web/HTML/Element/li
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - El elemento `li` del ingles _item list_ o _elemento de lista_ declara cada uno de los elementos de una lista.

--- a/files/es/web/html/element/main/index.md
+++ b/files/es/web/html/element/main/index.md
@@ -3,6 +3,8 @@ title: <main>
 slug: Web/HTML/Element/main
 ---
 
+{{HTMLSidebar}}
+
 ## Resumen
 
 El **elemento HTML `<main>`** representa el contenido principal del {{HTMLElement("body")}} de un documento o aplicación. El área principal del contenido consiste en el contenido que está directamente relacionado, o se expande sobre el tema central de un documento o la funcionalidad central de una aplicación. Este contenido debe ser único al documento, excluyendo cualquier contenido que se repita a través de un conjunto de documentos como barras laterales, enlaces de navegación, información de derechos de autor, logos del sitio y formularios de búsqueda (a menos, claro, que la función principal del documento sea un formulario de búsqueda).

--- a/files/es/web/html/element/map/index.md
+++ b/files/es/web/html/element/map/index.md
@@ -3,6 +3,8 @@ title: map
 slug: Web/HTML/Element/map
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - descripción de uno o dos párrafos

--- a/files/es/web/html/element/meta/index.md
+++ b/files/es/web/html/element/meta/index.md
@@ -3,6 +3,8 @@ title: meta
 slug: Web/HTML/Element/meta
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - **meta** de "metainformation" - metainformación. Sirve para aportar información sobre el documento..

--- a/files/es/web/html/element/noframes/index.md
+++ b/files/es/web/html/element/noframes/index.md
@@ -3,6 +3,8 @@ title: noframes
 slug: Web/HTML/Element/noframes
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - **noframes** de -_sin marcos_ . Aporta contenidos alternativos a los marcos. Las aplicaciones de usuario que no soporten [marcos](http://html.conclase.net/w3c/html401-es/present/frames.html), o que estén configuradas para no mostrarlos, deben mostrar en su lugar el contenido de este elemento.

--- a/files/es/web/html/element/noscript/index.md
+++ b/files/es/web/html/element/noscript/index.md
@@ -3,6 +3,8 @@ title: noscript
 slug: Web/HTML/Element/noscript
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - **noscript** de -_no script_ . Aporta contenidos alternativos al elemento [script](/es/HTML/Elemento/script). las aplicaciones de usuario que no soporten scripts deben mostrar en su lugar el contenido de este elemento.

--- a/files/es/web/html/element/ol/index.md
+++ b/files/es/web/html/element/ol/index.md
@@ -3,6 +3,8 @@ title: ol
 slug: Web/HTML/Element/ol
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - El elemento `ol` permite definir listas o viñetas ordenadas ("Ordered List"), bien con numeración o alfabéticamente.

--- a/files/es/web/html/element/p/index.md
+++ b/files/es/web/html/element/p/index.md
@@ -3,6 +3,8 @@ title: p
 slug: Web/HTML/Element/p
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - El elemento [p](/es/HTML/Elemento/p) (párrafo) es el apropiado para distribuir el texto en párrafos.

--- a/files/es/web/html/element/pre/index.md
+++ b/files/es/web/html/element/pre/index.md
@@ -3,6 +3,8 @@ title: <pre>
 slug: Web/HTML/Element/pre
 ---
 
+{{HTMLSidebar}}
+
 ## Sumario
 
 El **Elemento** **HTML \<pre>** (o _Texto HTML Preformateado_) representa texto preformateado. El texto en este elemento típicamente se muestra en una fuente fija, no proporcional, exactamente como es mostrado en el archivo. Los espacios dentro de este elemento también son mostrados como están escritos.

--- a/files/es/web/html/element/s/index.md
+++ b/files/es/web/html/element/s/index.md
@@ -3,6 +3,8 @@ title: s
 slug: Web/HTML/Element/s
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - Muestra el texto tachado con una linea horizontal.

--- a/files/es/web/html/element/small/index.md
+++ b/files/es/web/html/element/small/index.md
@@ -3,6 +3,8 @@ title: small
 slug: Web/HTML/Element/small
 ---
 
+{{HTMLSidebar}}
+
 El **elemento HTML \<small>** hace el tamaño del texto una talla más pequeña (por ejemplo, de largo a mediano, o de pequeño a extra pequeño) que el tamaño mínimo de fuente del navegador. En HTML5, este elemento es reutilizado para representar comentarios laterales y letra pequeña, incluyendo derechos de autor y texto legal, independientemente de su estilo de presentación.
 
 {{EmbedInteractiveExample("pages/tabbed/small.html", "tabbed-shorter")}}

--- a/files/es/web/html/element/span/index.md
+++ b/files/es/web/html/element/span/index.md
@@ -3,6 +3,8 @@ title: span
 slug: Web/HTML/Element/span
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - **span** - _abarcar_. Es un contenedor en línea. Sirve para aplicar estilo al texto o agrupar elementos en línea.

--- a/files/es/web/html/element/strike/index.md
+++ b/files/es/web/html/element/strike/index.md
@@ -3,6 +3,8 @@ title: strike
 slug: Web/HTML/Element/strike
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - Muestra el texto tachado con una linea horizontal.

--- a/files/es/web/html/element/strong/index.md
+++ b/files/es/web/html/element/strong/index.md
@@ -3,6 +3,8 @@ title: strong
 slug: Web/HTML/Element/strong
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - El elemento **strong** es el apropiado para marcar con especial énfasis las partes más importantes de un texto.

--- a/files/es/web/html/element/style/index.md
+++ b/files/es/web/html/element/style/index.md
@@ -3,6 +3,8 @@ title: style
 slug: Web/HTML/Element/style
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - **style** - estilo. Es el elemento encargado de indicar la información de estilo.

--- a/files/es/web/html/element/table/index.md
+++ b/files/es/web/html/element/table/index.md
@@ -3,6 +3,8 @@ title: tabla
 slug: Web/HTML/Element/table
 ---
 
+{{HTMLSidebar}}
+
 ## Resumen
 
 El _Elemento de Tabla HTML_ (`<table>`) representa datos en dos o mas dimensiones.

--- a/files/es/web/html/element/template/index.md
+++ b/files/es/web/html/element/template/index.md
@@ -3,6 +3,8 @@ title: <template>
 slug: Web/HTML/Element/template
 ---
 
+{{HTMLSidebar}}
+
 El **elemento** **HTML `<template>`** es un mecanismo para mantener el contenido {{Glossary("HTML")}} del lado del cliente que no se renderiza cuando se carga una página, pero que posteriormente puede ser instanciado durante el tiempo de ejecución empleando JavaScript.
 
 Piensa en la plantilla como un fragmento de contenido que está siendo almacenado para un uso posterior en el documento. El analizador procesa el contenido del elemento **`<template>`** durante la carga de la página, pero sólo lo hace para asegurar que esos contenidos son válidos; sin embargo, estos contenidos del elemento no se renderizan.

--- a/files/es/web/html/element/time/index.md
+++ b/files/es/web/html/element/time/index.md
@@ -3,6 +3,8 @@ title: time
 slug: Web/HTML/Element/time
 ---
 
+{{HTMLSidebar}}
+
 El **elemento HTML `<time>`** representa un periodo específico en el tiempo. Puede incluir el atributo `datetime` para convertir las fechas en un formato interno legible por un ordenador, permitiendo mejores resultados en los motores de búsqueda o características personalizadas como recordatorios.
 
 Puede representar uno de los contenidos siguientes:

--- a/files/es/web/html/element/tt/index.md
+++ b/files/es/web/html/element/tt/index.md
@@ -3,6 +3,8 @@ title: tt
 slug: Web/HTML/Element/tt
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - Muestra el texto marcado con una fuente de ancho fijo.

--- a/files/es/web/html/element/u/index.md
+++ b/files/es/web/html/element/u/index.md
@@ -3,6 +3,8 @@ title: u
 slug: Web/HTML/Element/u
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - Muestra el texto subrayado.

--- a/files/es/web/html/element/ul/index.md
+++ b/files/es/web/html/element/ul/index.md
@@ -3,6 +3,8 @@ title: ul
 slug: Web/HTML/Element/ul
 ---
 
+{{HTMLSidebar}}
+
 ### Definición
 
 - **ul** de "unordered list" -_lista no ordenada_ . crea una lista no ordenada.

--- a/files/es/web/html/element/video/index.md
+++ b/files/es/web/html/element/video/index.md
@@ -3,6 +3,8 @@ title: video
 slug: Web/HTML/Element/video
 ---
 
+{{HTMLSidebar}}
+
 El elemento `video` se utiliza para incrustar vídeos en un documento HTML o XHTML.
 
 Para obtener una lista de formatos compatibles, consulta [Formatos multimedia admitidos por los elementos de audio y vídeo](/es/Formatos_multimedia_admitidos_por_los_elementos_de_video_y_audio) .

--- a/files/es/web/html/global_attributes/itemprop/index.md
+++ b/files/es/web/html/global_attributes/itemprop/index.md
@@ -3,6 +3,8 @@ title: itemprop
 slug: Web/HTML/Global_attributes/itemprop
 ---
 
+{{HTMLSidebar("Global_attributes")}}
+
 Podemos dar más información al motor de búsqueda acerca de imágenes o datos adentro de cualquier tipo de etiquetas , como las propiedades : actores , clasificación ,genero . Para etiquetar las propiedades de un elemento , usa el atributo itemprop . Por ejemplo , para identificar al actor de una película añadir itemprop="director" al elemento que encierra el nombre del director.
 
 Aquí hay un ejemplo .

--- a/files/es/web/html/global_attributes/itemref/index.md
+++ b/files/es/web/html/global_attributes/itemref/index.md
@@ -3,6 +3,8 @@ title: itemref
 slug: Web/HTML/Global_attributes/itemref
 ---
 
+{{HTMLSidebar("Global_attributes")}}
+
 ## Resumen
 
 Las propiedades que no son descendientes de un elemento con el atributo `itemscope` pueden ser asociadas con el elemento usando un **itemref** . **Itemref** provee una lista de ids de los elementos (no `itemids`) con propiedades adicionales en otras partes dentro del documento .

--- a/files/es/web/html/microdata/index.md
+++ b/files/es/web/html/microdata/index.md
@@ -3,6 +3,8 @@ title: Microdatos
 slug: Web/HTML/Microdata
 ---
 
+{{HTMLSidebar}}
+
 ## Resumen
 
 Los microdatos son una especificación HTML de [WHATWG](/es/docs/Glossary/WHATWG) que se emplea para anidar metadatos en el contenido existente de las páginas web.\[1] Buscadores, arañas web y navegadores pueden extraer y procesar los microdatos a partir de una página y utilizarlos para proveer una experiencia más enriquecida para los usuarios. Los buscadores se benefician considerablemente del acceso directo a estos datos estructurados, ya que les permite entender la información contenida en las páginas y ofrecer mejores resultados a sus usuarios. Los microdatos utilizan un vocabulario de apoyo para describir tanto los elementos como conjuntos de nombre y valor y así asignar valores a sus propiedades. Los microdatos representan un intento de brindar una manera más sencilla de anotar elementos HTML con etiquetas legibles por máquinas que los métodos similares consistentes en usar RDFa y microformatos.

--- a/files/es/web/html/microformats/index.md
+++ b/files/es/web/html/microformats/index.md
@@ -3,6 +3,8 @@ title: Microformatos
 slug: Web/HTML/microformats
 ---
 
+{{HTMLSidebar}}
+
 _Los [Microformatos](http://microformats.org)_ (en ocasiones abreviados como **μF)** son convenciones simples para incrustar semántica en HTML y para brindar rápidamente un API utilizable por los motores de búsqueda, agregadores y otras herramientas Estos pequeños patrones de HTML son usados para marcar entidades que varían entre fundamentales hasta información específica de un dominio, tales como personas, organizaciones, eventos y ubicaciones.
 
 Su formato simple busca ser útil para máquinas y también legible para humanos.

--- a/files/es/web/http/headers/accept-ranges/index.md
+++ b/files/es/web/http/headers/accept-ranges/index.md
@@ -3,6 +3,8 @@ title: Accept-Ranges
 slug: Web/HTTP/Headers/Accept-Ranges
 ---
 
+{{HTTPSidebar}}
+
 El encabezado de respuesta HTTP **`Accept-Ranges`** es un marcador usado por el servidor para notificar que soporta solicitudes parciales. El valor de este campo indica la unidad que puede ser usada para definir el rango.
 
 En caso de estar presente un encabezado de respuesta `Accept-Ranges`, el navegador puede intentar restablecer una descarga interrumpida, en vez de reiniciarla o comenzarla desde el principio.

--- a/files/es/web/http/headers/age/index.md
+++ b/files/es/web/http/headers/age/index.md
@@ -3,6 +3,8 @@ title: Age
 slug: Web/HTTP/Headers/Age
 ---
 
+{{HTTPSidebar}}
+
 El encabezado **`Age`** contiene el tiempo medido en segundos que el objeto ha estado en la memoria caché de servidor proxy.El encabezado **`Age`** suele estar seteado en 0 (cero). Si **`Age : 0`** probablemente en ese instante se acaba de obtener la respuesta del servidor de origen, de lo contrario, por lo general esto se calcula como la diferencia entre la fecha actual del proxy y la fecha dada por el parámetro en cabecera "Date" ({{HTTPHeader("Date")}} ) incluído en la respuesta HTTP.
 
 | Tipo de Cabecera                                                   | {{Glossary("Response header")}} |

--- a/files/es/web/http/headers/transfer-encoding/index.md
+++ b/files/es/web/http/headers/transfer-encoding/index.md
@@ -3,6 +3,8 @@ title: Transfer-Encoding
 slug: Web/HTTP/Headers/Transfer-Encoding
 ---
 
+{{HTTPSidebar}}
+
 El encabezado Transfer-Encoding especifica la forma de codificación utilizada para transferir de forma segura el {{Glossary("Payload body", "cuerpo del payload")}} al usuario.
 
 > **Nota:** [HTTP/2](https://wikipedia.org/wiki/HTTP/2) no admite el mecanismo de codificación de transferencia fragmentada de HTTP 1.1, ya que proporciona sus propios mecanismos, más eficientes, para la transmisión de datos.

--- a/files/es/web/http/headers/user-agent/firefox/index.md
+++ b/files/es/web/http/headers/user-agent/firefox/index.md
@@ -3,6 +3,8 @@ title: Cadenas del User Agent de Gecko
 slug: Web/HTTP/Headers/User-Agent/Firefox
 ---
 
+{{HTTPSidebar}}
+
 ### Uso Apropiado
 
 No se recomienda el uso de las cadenas del User Agent como su principal opción para la detección del navegador. Vea [Deteccion Cross browser y Soporte Cross Browser](/es/Deteccion_Cross_browser_y_Soporte_Cross_Browser) para una ojeada mas en profundo a varias técnicas sobre detección de navegadores con recomendaciones.

--- a/files/es/web/http/status/201/index.md
+++ b/files/es/web/http/status/201/index.md
@@ -3,6 +3,8 @@ title: 201 Created
 slug: Web/HTTP/Status/201
 ---
 
+{{HTTPSidebar}}
+
 El código de respuesta de estado de éxito creado HTTP **`201 Created`** indica que la solicitud ha tenido éxito y ha llevado a la creación de un recurso. El nuevo recurso se crea efectivamente antes de enviar esta respuesta. y el nuevo recurso se devuelve en el cuerpo del mensaje, su ubicación es la URL de la solicitud o el contenido del encabezado de la Ubicacion
 
 El caso de uso común de este código de estado es el resultado de una solicitud metodo POST

--- a/files/es/web/http/status/304/index.md
+++ b/files/es/web/http/status/304/index.md
@@ -3,6 +3,8 @@ title: 304 Not Modified
 slug: Web/HTTP/Status/304
 ---
 
+{{HTTPSidebar}}
+
 El código HTTP de redirección **`304 Not Modified`** en el response de la petición indica que no hay necesidad de retransmitir los recursos solicitados. Es una redirección implícita a un elemento/recurso de caché.Esto sucede cuando el método de la solicitud es {{glossary("seguro")}} ({{glossary("safe")}}), como en el las peticiones con métodos {{HTTPMethod("GET")}} o {{HTTPMethod("HEAD")}}, o cuando el request (petición) está condicionada y usa la cabecera {{HTTPHeader("If-None-Match")}} o un {{HTTPHeader("If-Modified-Since")}}El response {{HTTPStatus("200")}} `OK` habría incluido los encabezados {{HTTPHeader("Cache-Control")}}, {{HTTPHeader("Content-Location")}}, {{HTTPHeader("Date")}}, {{HTTPHeader("ETag")}}, {{HTTPHeader("Expires")}}, y {{HTTPHeader("Vary")}}.
 
 > **Nota:** Muchos [developer tools' network panels](/es/docs/Tools/Network_Monitor) (paneles de red de desarrollo) de los navegadores crean extraños request que conducen a un "response(respuesta del servidor) `304` ", entonces el acceso al caché local es accesible a los desarrollodares.

--- a/files/es/web/http/status/418/index.md
+++ b/files/es/web/http/status/418/index.md
@@ -3,6 +3,8 @@ title: 418 Soy una tetera
 slug: Web/HTTP/Status/418
 ---
 
+{{HTTPSidebar}}
+
 El código de error HTTP **`418 Soy una tetera`** indica que el servidor se rehusa a preparar café porque es una tetera. Este error es una referencia al Hyper Text Coffee Pot Control Protocol, creado como parte de una broma del April Fools' de 1998.
 
 ## Estado

--- a/files/es/web/http/status/504/index.md
+++ b/files/es/web/http/status/504/index.md
@@ -3,6 +3,8 @@ title: 504 Gateway Timeout
 slug: Web/HTTP/Status/504
 ---
 
+{{HTTPSidebar}}
+
 El código de respuesta de error del servidor de HTTP **`504 Gateway Timeout`** indica que el servidor, mientras actuaba como una puerta de enlace o proxy, no pudo obtener una respuesta a tiempo.
 
 > **Nota:** Una [puerta de enlace](https://es.wikipedia.org/wiki/Puerta_de_enlace) puede referirse a cosas distintas en redes y un error 502 no es algo que normalmente puedas arreglar, ya que requiere correcciones por parte del servidor o los proxies a través de los que intentas acceder.

--- a/files/es/web/javascript/reference/classes/private_properties/index.md
+++ b/files/es/web/javascript/reference/classes/private_properties/index.md
@@ -3,6 +3,8 @@ title: Private class fields
 slug: Web/JavaScript/Reference/Classes/Private_properties
 ---
 
+{{jsSidebar("Classes")}}
+
 Las propiedades de la clase son públicas de forma predeterminada y se pueden examinar o modificar fuera de la clase. Sin embargo, existe [una propuesta experimental](https://github.com/tc39/proposal-class-fields) para permitir la definición de campos de clase privados utilizando un `#` prefijo hash .
 
 ## Syntax

--- a/files/es/web/javascript/reference/global_objects/error/linenumber/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/linenumber/index.md
@@ -3,6 +3,8 @@ title: Error.prototype.lineNumber
 slug: Web/JavaScript/Reference/Global_Objects/Error/lineNumber
 ---
 
+{{JSRef}}
+
 No es una norma
 
 Esta característica no es una norma y no está en la lista de normas. No la utilice en sitios de producción que enfrenta la Web: no va a funcionar para todos los usuarios. También puede haber grandes incompatibilidades entre implementaciones y el comportamiento puede cambiar en el futuro.

--- a/files/es/web/javascript/reference/global_objects/escape/index.md
+++ b/files/es/web/javascript/reference/global_objects/escape/index.md
@@ -3,7 +3,7 @@ title: escape()
 slug: Web/JavaScript/Reference/Global_Objects/escape
 ---
 
-{{Deprecated_header}}
+{{jsSidebar("Objects")}}{{Deprecated_header}}
 
 > **Advertencia:** `escape()` no esta estrictamente en desuso("eliminada por los estándares Web"), esta definida en [Anexo B](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-additional-ecmascript-features-for-web-browsers) El estándar ECMA-262 , cuya introducción establece:
 >

--- a/files/es/web/manifest/index.md
+++ b/files/es/web/manifest/index.md
@@ -3,6 +3,8 @@ title: Web App Manifest
 slug: Web/Manifest
 ---
 
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+
 El manifiesto de aplicaciones web proporciona información sobre una aplicación (como nombre, autor, icono y descripción) en un documento simplificado. Su principal propósito es crear [progressive web apps](/es/docs/Web/Apps/Progressive): aplicaciones web que se pueden instalar desde la pantalla principal de un dispositivo sin necesidad de hacerlo a traves de una app store (y otras ventajas como disponibilidad offline y enviar notificaciones push cuando cambia el contenido de la aplicación.)
 
 ## Manifiesto de ejemplo

--- a/files/es/web/manifest/index.md
+++ b/files/es/web/manifest/index.md
@@ -3,7 +3,7 @@ title: Web App Manifest
 slug: Web/Manifest
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+{{QuickLinksWithSubpages("/es/docs/Web/Manifest")}}
 
 El manifiesto de aplicaciones web proporciona información sobre una aplicación (como nombre, autor, icono y descripción) en un documento simplificado. Su principal propósito es crear [progressive web apps](/es/docs/Web/Apps/Progressive): aplicaciones web que se pueden instalar desde la pantalla principal de un dispositivo sin necesidad de hacerlo a traves de una app store (y otras ventajas como disponibilidad offline y enviar notificaciones push cuando cambia el contenido de la aplicación.)
 

--- a/files/es/web/mathml/attribute/index.md
+++ b/files/es/web/mathml/attribute/index.md
@@ -3,6 +3,8 @@ title: MathML attribute reference
 slug: Web/MathML/Attribute
 ---
 
+{{MathMLRef}}
+
 Esta es una lista alfabetica de atributos de MathML. Más detalles de cada atributo está disponible en cada [página de los elementos](/es/docs/MathML/Element).
 
 Notas:

--- a/files/es/web/mathml/element/index.md
+++ b/files/es/web/mathml/element/index.md
@@ -3,6 +3,8 @@ title: Referencia de elementos de MathML
 slug: Web/MathML/Element
 ---
 
+{{MathMLRef}}
+
 A continuación se muestra una lista alfabética de elementos de **presentación** en MathML.
 La _etiqueta de presentación_ es usada para describir la estructura y el diseño de la notación matemática mientras que la _etiqueta de contenido_ proporciona el significado matemático subyacente y se supone que no se renderiza a través del parseador de MathML (ver [Error 276028 en Firefox](https://bugzil.la/276028)). Si quieres aprender más sobre la etiqueta de contenido deberías echar un vistazo al [Capítulo 4](http://www.w3.org/TR/MathML3/chapter4.html) en la [especificación de MathML 3](http://www.w3.org/TR/MathML3/).
 

--- a/files/es/web/mathml/examples/mathml_pythagorean_theorem/index.md
+++ b/files/es/web/mathml/examples/mathml_pythagorean_theorem/index.md
@@ -3,6 +3,8 @@ title: MathML Pythagorean Theorem
 slug: Web/MathML/Examples/MathML_Pythagorean_Theorem
 ---
 
+{{MathMLRef}}
+
 <math><mrow><msup><mi>a</mi>
 <mn>2</mn>
 </msup><mo>+</mo>

--- a/files/es/web/mathml/index.md
+++ b/files/es/web/mathml/index.md
@@ -3,6 +3,8 @@ title: MathML
 slug: Web/MathML
 ---
 
+{{MathMLRef}}
+
 **Lenguaje de Marcado Matemático (MathML)** es un lenguaje de marcado [XML](/es/docs/Introducción_a_XML) para describir expresiones matemáticas capturando tanto su contenido como su estructura.
 
 Aquí encontrarás enlaces a documentación, ejemplos y herramientas que te ayudarán a trabajar con esta tecnología poderosa. Para un resumen, vea la [presentación](https://fred-wang.github.io/MozSummitMathML/index.html) que se preparó para Mozilla Summit 2013.

--- a/files/es/web/opensearch/index.md
+++ b/files/es/web/opensearch/index.md
@@ -3,6 +3,8 @@ title: Creacion de plugins OpenSearch para Firefox
 slug: Web/OpenSearch
 ---
 
+{{AddonSidebar}}
+
 ## OpenSearch
 
 [Firefox 2](/es/Firefox_2) admite el formato de descripción [OpenSearch](http://opensearch.org/) para complementos (_plugins_) de búsqueda. Aquellos complementos que usen [la sintaxis OpenSearch](http://www.opensearch.org/Specifications/OpenSearch/1.1#OpenSearch_description_document) son compatibles con Firefox e Internet Explorer 7. Por ello es el formato recomendado para cualquier nuevo desarrollo.

--- a/files/es/web/performance/fundamentals/index.md
+++ b/files/es/web/performance/fundamentals/index.md
@@ -3,6 +3,8 @@ title: Performance fundamentals
 slug: Web/Performance/Fundamentals
 ---
 
+{{QuickLinksWithSubPages("Web/Performance")}}
+
 Performance significa eficiencia. En el contexto de Open Web Apps, este documento explica en general qué es performance, cómo la plataforma del navegador ayuda a mejorarlo y qué herramientas y procesos puede usar para probarlo y mejorarlo.
 
 ## ¿Qué es performance?

--- a/files/es/web/performance/index.md
+++ b/files/es/web/performance/index.md
@@ -3,6 +3,8 @@ title: Rendimiento Web
 slug: Web/Performance
 ---
 
+{{QuickLinksWithSubPages}}
+
 El rendimiento web es la medición objetiva y la experiencia percibida por el usuario del tiempo de carga y el tiempo de ejecución; es el tiempo que tarda un sitio en cargarse, ser interactivo y responsivo, y que tan fluido es el contenido durante las interacciones del usuario: ¿el desplazamiento es suave? ¿Se puede hacer clic en los botones? ¿Las ventanas emergentes se abren rápidamente y se animan fluidamente al hacerlo? El rendimiento web incluye mediciones objetivas como el tiempo de carga, cuadros por segundo y tiempo para interactuar y subjetivas de cuánto tiempo se sintió que tardó en cargarse el contenido.
 
 Cuanto más tarde un sitio en responder, más usuarios abandonarán el sitio. Es importante minimizar los tiempos de carga y respuesta, y agregar funciones adicionales para ocultar la latencia al hacer que la experiencia sea lo más accesible e interactiva posible, tan pronto como sea posible, mientras se carga de forma asíncrona en las partes que más tarda la experiencia.

--- a/files/es/web/performance/optimizing_startup_performance/index.md
+++ b/files/es/web/performance/optimizing_startup_performance/index.md
@@ -3,6 +3,8 @@ title: Mejorando el Rendimiento Inicial
 slug: Web/Performance/Optimizing_startup_performance
 ---
 
+{{QuickLinksWithSubPages("Web/Performance")}}
+
 Un aspecto que a menudo se pasa por alto en el desarrollo de software de aplicaciones, incluso entre aquellos enfocados en la optimización del rendimiento, es el rendimiento inicial. ¿Cuánto tiempo demora su aplicación en iniciarse? ¿Parece que se bloquea el dispositivo o el navegador del usuario no responde mientras se carga la aplicación? Eso hace que los usuarios se preocupen de que su aplicación haya fallado, o de que algo anda mal. Siempre es una buena idea invertir tiempo para asegurarse de que la aplicación se inicie de manera correcta. Este artículo ofrece consejos y sugerencias para ayudar a lograr ese objetivo, tanto al escribir una nueva aplicación como al migrar una aplicación de otra plataforma a la Web.
 
 ## Empezando Bien

--- a/files/es/web/progressive_web_apps/guides/installing/index.md
+++ b/files/es/web/progressive_web_apps/guides/installing/index.md
@@ -3,6 +3,8 @@ title: Instalar y desinstalar aplicaciones web
 slug: Web/Progressive_web_apps/Guides/Installing
 ---
 
+{{PWASidebar}}
+
 La instalación de aplicaciones web es una función disponible en los navegadores modernos que permite a los usuarios elegir "instalar" fácil y cómodamente una aplicación web en su dispositivo para que puedan acceder a ella de la misma manera que lo harían con cualquier otra aplicación. Dependiendo del dispositivo y las características del sistema operativo y el navegador, esto puede resultar en lo que esencialmente es una aplicación con todas las funciones (por ejemplo, usando [WebAPK](https://developers.google.com/web/fundamentals/integration/webapks) en Android) o como un acceso directo agregado a la pantalla de tu dispositivo. Esta guía explica cómo se realiza la instalación, qué significa y qué debes hacer como desarrollador para que los usuarios la aprovechen.
 
 ## ¿Por qué la instalación?

--- a/files/es/web/security/types_of_attacks/index.md
+++ b/files/es/web/security/types_of_attacks/index.md
@@ -3,6 +3,8 @@ title: Tipos de ataques
 slug: Web/Security/Types_of_attacks
 ---
 
+{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}
+
 Este artículo describe varios tipos de ataques de seguridad y técnicas para mitigarlos.
 
 ## Click-jacking

--- a/files/es/web/security/types_of_attacks/index.md
+++ b/files/es/web/security/types_of_attacks/index.md
@@ -3,7 +3,7 @@ title: Tipos de ataques
 slug: Web/Security/Types_of_attacks
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}
+{{QuickLinksWithSubpages("/es/docs/Web/Security")}}
 
 Este artículo describe varios tipos de ataques de seguridad y técnicas para mitigarlos.
 

--- a/files/es/web/svg/applying_svg_effects_to_html_content/index.md
+++ b/files/es/web/svg/applying_svg_effects_to_html_content/index.md
@@ -3,6 +3,8 @@ title: Aplicación de efectos de SVG para el contenido HTML
 slug: Web/SVG/Applying_SVG_effects_to_HTML_content
 ---
 
+{{SVGRef}}
+
 Aplicación de efectos de SVG para el contenido HTML.
 
 Firefox 3.5 introduce soporte para usar SVG como un componente de estilos CSS para aplicar efectos de SVG para el contenido HTML.

--- a/files/es/web/svg/attribute/stop-color/index.md
+++ b/files/es/web/svg/attribute/stop-color/index.md
@@ -3,6 +3,8 @@ title: stop-color
 slug: Web/SVG/Attribute/stop-color
 ---
 
+{{SVGRef}}
+
 « [SVG Attribute reference hom](/en/SVG/Attribute)e
 
 El atributo `stop-color` indica que color usar en el stop del gradiente. La keyword `currentColor` y ICC pueden ser especificadas de la misma manera con la especificación [\<paint>](/en/SVG/Content_type#Paint) para los atributos {{ SVGAttr("fill") }} y {{ SVGAttr("stroke") }}.

--- a/files/es/web/svg/attribute/transform/index.md
+++ b/files/es/web/svg/attribute/transform/index.md
@@ -3,6 +3,8 @@ title: transform
 slug: Web/SVG/Attribute/transform
 ---
 
+{{SVGRef}}
+
 « Indice de atributos SVG
 
 El atributo `transform` exhibe una lista de definiciones de transformación que se aplican a un elemento y a sus hijos. Los elementos en la lista de tranformación están separados por espacios en blanco y/o comas y se aplican de derecha a izquierda.

--- a/files/es/web/svg/element/svg/index.md
+++ b/files/es/web/svg/element/svg/index.md
@@ -3,6 +3,8 @@ title: <svg>
 slug: Web/SVG/Element/svg
 ---
 
+{{SVGRef}}
+
 El elemento `svg` es un contenedor que define un nuevo sistema de coordenadas y [viewport](/es/docs/Web/SVG/Attribute/viewBox). Es usado como el elemento más externo de cualquier documento SVG, pero también puede ser usado para agregar un fragmento de un SVG dentro de un documento SVG o HTML.
 
 ## Contexto de Uso

--- a/files/es/web/svg/index.md
+++ b/files/es/web/svg/index.md
@@ -3,6 +3,8 @@ title: SVG
 slug: Web/SVG
 ---
 
+{{SVGRef}}
+
 **[Comenzando con SVG](/es/docs/SVG/Tutorial)**
 Este tutorial te ayudará a comenzar a usar SVG.
 

--- a/files/es/web/svg/tutorial/getting_started/index.md
+++ b/files/es/web/svg/tutorial/getting_started/index.md
@@ -3,7 +3,7 @@ title: Getting Started
 slug: Web/SVG/Tutorial/Getting_Started
 ---
 
-{{ PreviousNext("SVG/Tutorial/Introduction", "SVG/Tutorial/Positions") }}
+{{SVGRef}}{{ PreviousNext("SVG/Tutorial/Introduction", "SVG/Tutorial/Positions") }}
 
 ### Un Ejemplo Simple
 

--- a/files/es/web/svg/tutorial/index.md
+++ b/files/es/web/svg/tutorial/index.md
@@ -3,6 +3,8 @@ title: Tutorial de SVG
 slug: Web/SVG/Tutorial
 ---
 
+{{SVGRef}}
+
 Los graficos de vectores escalables, SVG , es un dialecto XML de W#C usado para describir graficos. Esta parcialente implementado en Firefox, Opera, WebKit , Internet Explorer y otros.
 
 Este tutorial intenta explicar SVG a profundidad y esta elaborado con detalles tecnicos. Si quieres dibujar hermosas imagenes, podras encontrar recursos mas utiles en la [Documentacion de Inkscape](https://inkscape.org/en/learn/) . Otra buena introduccion es brindada por el W3C's [SVG Primer](http://www.w3.org/Graphics/SVG/IG/resources/svgprimer.html) .

--- a/files/es/web/svg/tutorial/introduction/index.md
+++ b/files/es/web/svg/tutorial/introduction/index.md
@@ -3,7 +3,7 @@ title: Introducción
 slug: Web/SVG/Tutorial/Introduction
 ---
 
-{{ PreviousNext("Web/SVG/Tutorial", "Web/SVG/Tutorial/Getting_Started") }}
+{{SVGRef}}{{ PreviousNext("Web/SVG/Tutorial", "Web/SVG/Tutorial/Getting_Started") }}
 
 ![Ejemplo de imagenes vectoriales, una cría de leon, una curva con flechas direccionales a intervalos regulares y un texto que sigue una trayectoria ondulada](svg_overview.png)[SVG](/es/docs/Web/SVG) es un lenguaje [XML](/es/docs/Introducción_a_XML), parecido a [XHTML](/es/docs/XHTML), el cual puede ser usado para dibujar gráficos vectoriales, como los mostrados a la derecha. Puede ser usado para crear una imagen ya sea especificando todas las líneas y formas necesarias, modificando las imágenes matriciales (raster images) o una combinación de ambas. La imagen y sus componentes pueden ser transformados, compuestos o filtrados para cambiar completamente su apariencia.
 

--- a/files/es/web/svg/tutorial/tools_for_svg/index.md
+++ b/files/es/web/svg/tutorial/tools_for_svg/index.md
@@ -3,7 +3,7 @@ title: Tools for SVG
 slug: Web/SVG/Tutorial/Tools_for_SVG
 ---
 
-{{ PreviousNext("Web/SVG/Tutorial/SVG_Image_Tag") }}
+{{SVGRef}}{{ PreviousNext("Web/SVG/Tutorial/SVG_Image_Tag") }}
 
 Ahora que hemos cubierto los aspectos básicos de los componentes internos de SVG, analizaremos algunas herramientas para trabajar con archivos SVG.
 

--- a/files/es/web/xml/parsing_and_serializing_xml/index.md
+++ b/files/es/web/xml/parsing_and_serializing_xml/index.md
@@ -3,6 +3,8 @@ title: Convertir código a cadena de texto (serializing) y visceversa (parsing) 
 slug: Web/XML/Parsing_and_serializing_XML
 ---
 
+{{QuickLinksWithSubpages("/en-US/docs/Web/XML")}}
+
 La plataforma web proveé Los siguientes objetos para hacer parsing (convertir una cadena de texto a código) y serializing (visceversa) a un XML:
 
 - [XMLSerializer](/en/XMLSerializer) para convertir a tipo string el arbol del DOM

--- a/files/es/web/xml/parsing_and_serializing_xml/index.md
+++ b/files/es/web/xml/parsing_and_serializing_xml/index.md
@@ -3,7 +3,7 @@ title: Convertir código a cadena de texto (serializing) y visceversa (parsing) 
 slug: Web/XML/Parsing_and_serializing_XML
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/XML")}}
+{{QuickLinksWithSubpages("/es/docs/Web/XML")}}
 
 La plataforma web proveé Los siguientes objetos para hacer parsing (convertir una cadena de texto a código) y serializing (visceversa) a un XML:
 

--- a/files/es/web/xml/xml_introduction/index.md
+++ b/files/es/web/xml/xml_introduction/index.md
@@ -3,6 +3,8 @@ title: Introducción a XML
 slug: Web/XML/XML_introduction
 ---
 
+{{QuickLinksWithSubpages("/en-US/docs/Web/XML")}}
+
 XML es un lenguaje de marcado similar a HTML. Significa Extensible Markup Language (Lenguaje de Marcado Extensible) y es una especificación de [W3C](https://www.w3.org/TR/xml/) como lenguaje de marcado de propósito general. Esto significa que, a diferencia de otros lenguajes de marcado, XML no está predefinido, por lo que debes definir tus propias etiquetas. El propósito principal del lenguaje es compartir datos a través de diferentes sistemas, como Internet.
 
 Hay muchos lenguajes basados en XML; Algunos ejemplos son [XHTML](/es/docs/XHTML), [MathML](/es/docs/Web/MathML), [SVG](/es/docs/Web/SVG), [XUL](/es/docs/Mozilla/Tech/XUL), [XBL](/es/docs/XBL), [RSS](/es/docs/Archive/RSS), y [RDF](/es/docs/RDF). También puedes crear uno propio.

--- a/files/es/web/xml/xml_introduction/index.md
+++ b/files/es/web/xml/xml_introduction/index.md
@@ -3,7 +3,7 @@ title: Introducción a XML
 slug: Web/XML/XML_introduction
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/XML")}}
+{{QuickLinksWithSubpages("/es/docs/Web/XML")}}
 
 XML es un lenguaje de marcado similar a HTML. Significa Extensible Markup Language (Lenguaje de Marcado Extensible) y es una especificación de [W3C](https://www.w3.org/TR/xml/) como lenguaje de marcado de propósito general. Esto significa que, a diferencia de otros lenguajes de marcado, XML no está predefinido, por lo que debes definir tus propias etiquetas. El propósito principal del lenguaje es compartir datos a través de diferentes sistemas, como Internet.
 

--- a/files/es/web/xpath/functions/contains/index.md
+++ b/files/es/web/xpath/functions/contains/index.md
@@ -3,7 +3,7 @@ title: contains
 slug: Web/XPath/Functions/contains
 ---
 
-{{ XsltRef() }}
+{{XsltSidebar}}{{ XsltRef() }}
 
 La función `contains` determina si la primera cadena del argumento contiene la segunda cadena del argumento y devuelve el booleano verdadero o falso.
 

--- a/files/es/web/xpath/functions/index.md
+++ b/files/es/web/xpath/functions/index.md
@@ -3,6 +3,8 @@ title: Funciones
 slug: Web/XPath/Functions
 ---
 
+{{XsltSidebar}}
+
 {{ XsltRef() }} A continuación se presenta una lista ordenada de las funciones core de XPath y agregados específicos de XSLT a XPath, incluyendo una descripción, sintaxis, un listado de argumentos, tipo de resultado, referencia apopiada a W3C y el estado actual de soporte en el motor Gecko. para más información sobre el uso de las funciones de XPath/XSLT, por favor vea la página [**Para más información**](/en/Transforming_XML_with_XSLT/For_Further_Reading).
 
 - [boolean()](/en/XPath/Functions/boolean)

--- a/files/es/web/xpath/functions/substring/index.md
+++ b/files/es/web/xpath/functions/substring/index.md
@@ -3,7 +3,7 @@ title: substring
 slug: Web/XPath/Functions/substring
 ---
 
-{{ XsltRef() }}
+{{XsltSidebar}}{{ XsltRef() }}
 
 La función `substring` devuelve una parte de una cadena dada.
 

--- a/files/es/web/xpath/functions/true/index.md
+++ b/files/es/web/xpath/functions/true/index.md
@@ -3,7 +3,7 @@ title: "true"
 slug: Web/XPath/Functions/true
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 La función `true` devuelve un valor booleano de verdadero.
 

--- a/files/es/web/xpath/index.md
+++ b/files/es/web/xpath/index.md
@@ -3,6 +3,8 @@ title: XPath
 slug: Web/XPath
 ---
 
+{{XsltSidebar}}
+
 El **Lenguaje de Caminos XML**
 proporciona un modo flexible de dirigirse (señalando a) a las distintas partes de un documento XML. También puede ser usado para cotejar nodos y determinar si encajan un modelo o no.
 

--- a/files/es/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/es/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -3,6 +3,8 @@ title: Introducción al uso de XPath en Javascript
 slug: Web/XPath/Introduction_to_using_XPath_in_JavaScript
 ---
 
+{{XsltSidebar}}
+
 Este documento describe la interfaz para usar [XPath](/es/docs/Web/XPath) internamente en JavaScript, en extensiones y desde sitios web. Mozilla implementa una gran parte del [DOM 3 XPath](http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html). Esto significa que las expresiones XPath pueden correrse en documentos HTML y XML.
 
 La interfaz principal a usar con XPath es la función [evaluate](/en/DOM/document.evaluate) del objeto [document](/en/DOM/document).

--- a/files/es/web/xslt/element/apply-imports/index.md
+++ b/files/es/web/xslt/element/apply-imports/index.md
@@ -3,7 +3,7 @@ title: apply-imports
 slug: Web/XSLT/Element/apply-imports
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:apply-imports>` es complejo en su uso, y es utilizado mayoritariamente en hojas de estilo muy complejas. La precedencia de importación indica que las plantillas en la hoja de estilo principal tienen mayor precedencia que las plantillas en las hojas de estilo importadas. Sin embargo, en ocasiones es útil forzar al procesador para que aplique una plantilla de menor procedencia contenida en la hoja de estilo importada en lugar de una plantilla equivalente en la hoja de estilo principal.
 

--- a/files/es/web/xslt/element/apply-templates/index.md
+++ b/files/es/web/xslt/element/apply-templates/index.md
@@ -3,7 +3,7 @@ title: apply-templates
 slug: Web/XSLT/Element/apply-templates
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:apply-templates>` selecciona un conjunto de nodos del documento de entrada e instruye al procesador para aplicar las plantillas apropiadas a ellos.
 

--- a/files/es/web/xslt/element/attribute-set/index.md
+++ b/files/es/web/xslt/element/attribute-set/index.md
@@ -3,7 +3,7 @@ title: attribute-set
 slug: Web/XSLT/Element/attribute-set
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:attribute-set>` genera un conjunto con nombre de atributos, el cual puede ser aplicado al documento de salida, de una manera similar a los estilos con nombre dentro de CSS.
 

--- a/files/es/web/xslt/element/attribute/index.md
+++ b/files/es/web/xslt/element/attribute/index.md
@@ -3,7 +3,7 @@ title: attribute
 slug: Web/XSLT/Element/attribute
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:attribute>` genera un atributo en el documento de salida, usando cualquier valor que puede ser accedido desde la hoja de estilo. Este elemento tiene que ser la primer cosa que se encuentre dentro del elemento del documento de salida para el cual se desea generar el atributo.
 

--- a/files/es/web/xslt/element/call-template/index.md
+++ b/files/es/web/xslt/element/call-template/index.md
@@ -3,7 +3,7 @@ title: call-template
 slug: Web/XSLT/Element/call-template
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:call-template>` invoca una plantilla con nombre.
 

--- a/files/es/web/xslt/element/choose/index.md
+++ b/files/es/web/xslt/element/choose/index.md
@@ -3,7 +3,7 @@ title: choose
 slug: Web/XSLT/Element/choose
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 El elemento `<xsl:choose>` define una elección entre un número de alternativas. Funciona como una sentencia switch en los lenguajes procedurales.
 
 ### Sintaxis

--- a/files/es/web/xslt/element/comment/index.md
+++ b/files/es/web/xslt/element/comment/index.md
@@ -3,7 +3,7 @@ title: comment
 slug: Web/XSLT/Element/comment
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:comment>` escribe un comentario en el documento de salida. Debe incluir sólo texto.
 

--- a/files/es/web/xslt/element/copy-of/index.md
+++ b/files/es/web/xslt/element/copy-of/index.md
@@ -3,7 +3,7 @@ title: copy-of
 slug: Web/XSLT/Element/copy-of
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:copy-of>` crea una copia completa (incluyendo nodos descendientes) en el documento de salida de lo que sea que indique el atributo.
 

--- a/files/es/web/xslt/element/copy/index.md
+++ b/files/es/web/xslt/element/copy/index.md
@@ -3,7 +3,7 @@ title: copy
 slug: Web/XSLT/Element/copy
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:copy>` genera una copia superficial (el nodo y cualquier nodo del nombre de espacio asociado) del nodo actual al documento de salida. Este elemento no copia ni elementos hijo ni atributos del nodo actual.
 

--- a/files/es/web/xslt/element/decimal-format/index.md
+++ b/files/es/web/xslt/element/decimal-format/index.md
@@ -3,7 +3,7 @@ title: decimal-format
 slug: Web/XSLT/Element/decimal-format
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:decimal-format>` define los caracteres y los símbolos que serán usados en la conversión de números a cadenas de texto usando la función `format-number( )`.
 

--- a/files/es/web/xslt/element/element/index.md
+++ b/files/es/web/xslt/element/element/index.md
@@ -3,7 +3,7 @@ title: element
 slug: Web/XSLT/Element/element
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:element>` genera un elemento en el documento de salida.
 

--- a/files/es/web/xslt/element/fallback/index.md
+++ b/files/es/web/xslt/element/fallback/index.md
@@ -3,7 +3,7 @@ title: fallback
 slug: Web/XSLT/Element/fallback
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:fallback>` indica la plantilla a usar en caso de que algun elemento extendido (o, eventualmente, una nueva versión) no esté soportado.
 

--- a/files/es/web/xslt/element/for-each/index.md
+++ b/files/es/web/xslt/element/for-each/index.md
@@ -3,7 +3,7 @@ title: for-each
 slug: Web/XSLT/Element/for-each
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:for-each>` selecciona un conjunto de nodos y procesa cada uno de ellos de la misma manera. Se usa comúnmente para iterar a través de un conjunto de nodos o para cambiar el nodo actual. Si se encuentran uno o más elementos `<xsl:sort>` como hijos de este elemento, el ordenado de los nodos ocurrirá antes del procesamiento. De otra manera, los nodos se procesarán en el orden del documento.
 

--- a/files/es/web/xslt/element/if/index.md
+++ b/files/es/web/xslt/element/if/index.md
@@ -3,7 +3,7 @@ title: if
 slug: Web/XSLT/Element/if
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 El elemento \<xsl:if> contiene un atributo a probar y una plantilla. Si el atributo resulta verdadero, la plantilla es procesada. Este comportamiento es similar a la sentencia if de otros lenguajes. Sin embargo, para conseguir la funcionalidad de una sentencia if-then-else, es necesario utilizar el elemento \<xsl:choose> con un elemento hijo \<xsl:when>, y otro elemento hijo \<xsl:otherwise>
 
 ### Sintaxis

--- a/files/es/web/xslt/element/import/index.md
+++ b/files/es/web/xslt/element/import/index.md
@@ -3,7 +3,7 @@ title: import
 slug: Web/XSLT/Element/import
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:import>` sirve para importar el contenido de una hoja de estilo dentro de otra hoja de estilo. En general, el contenido de la hoja de estilo importada tiene una menor precedencia que el contenido de la hoja de estilo que la importa. Esto contrasta con el elemento `<xsl:include>` en el que el contenido de la hoja de estilo incluida tiene exactamente la misma precedencia que el contenido de la hoja de estilo que la incluye.
 

--- a/files/es/web/xslt/element/include/index.md
+++ b/files/es/web/xslt/element/include/index.md
@@ -3,7 +3,7 @@ title: include
 slug: Web/XSLT/Element/include
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:include>` une el contenido de una hoja de estilo con otra. A diferencia del elemento `<xsl:import>`, el contenido de la hoja de estilo incluida tiene exactamente la misma precedencia que el contenido de la hoja de estilo que la incluye.
 

--- a/files/es/web/xslt/element/index.md
+++ b/files/es/web/xslt/element/index.md
@@ -3,6 +3,8 @@ title: Elementos
 slug: Web/XSLT/Element
 ---
 
+{{XsltSidebar}}
+
 {{XsltRef}} En este documento se discutiran dos tipos de elementos: elementos raíz e instrucciones. Un elemento raíz debe aparecer como un hijo ya sea de `<xsl:stylesheet>` o `<xsl:transform>`. Por otro lado, una instrucción está asociada con una plantilla. Una hoja de estilo puede incluir varias plantillas. Un tercer tipo de elemento, no discutido aquí, es el elemento de resultado literal (LRE por sus siglas en inglés). Un LRE también aparece dentro de una plantilla, y consiste de cualquier elemento que no sea instrucción y que debe ser copiado tal cual al documento resultante, por ejemplo el elemento `<hr>` cuando se usa en una hoja de estilo para general HTML.
 
 Como nota adicional, cualquier atributo en un LRE y algunos atributos de un conjunto específico de elemento XSLT también pueden incluir lo que se conoce como plantilla de valor de atributo. Que en pocas palabras significa que es una cadena de texto que especifíca una expresión XPath la cual indica el valor del atributo. En tiempo de ejecución la expresión es evaluada y el resultado es sustituido por la expresión XPath. Por ejemplo, asumamos que la variable "`image-dir`" es definida de la siguiente manera:

--- a/files/es/web/xslt/element/key/index.md
+++ b/files/es/web/xslt/element/key/index.md
@@ -3,7 +3,7 @@ title: key
 slug: Web/XSLT/Element/key
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:key>` declara una llave con nombre la cual puede ser usada en otro lugar dentro de la hoja de estilo usando la función `key( )`.
 

--- a/files/es/web/xslt/element/message/index.md
+++ b/files/es/web/xslt/element/message/index.md
@@ -3,7 +3,7 @@ title: message
 slug: Web/XSLT/Element/message
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:message>` muestra un mensaje (en la consola JavaScript en NS) y opcionalmente termina la ejecución de la hoja de estilos. Puede ser util para depuración.
 

--- a/files/es/web/xslt/element/namespace-alias/index.md
+++ b/files/es/web/xslt/element/namespace-alias/index.md
@@ -3,7 +3,7 @@ title: namespace-alias
 slug: Web/XSLT/Element/namespace-alias
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:namespace-alias>` es un mecanismo raramente usado para asociar un nombre de espacios en la hoja de estilos a otro nombre de espacios diferente en el árbol de salida. El uso más común para este elemento se da en la generación de una hoja de estilos a partir de otra hoja de estilos.
 

--- a/files/es/web/xslt/element/otherwise/index.md
+++ b/files/es/web/xslt/element/otherwise/index.md
@@ -3,7 +3,7 @@ title: otherwise
 slug: Web/XSLT/Element/otherwise
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:otherwise>` se utiliza para definir la acción que se debe tomar cuando no se aplica ninguna de las condiciones `<xsl:when>`. Es similar a `else` or `default` en otros lenguajes de programación.
 

--- a/files/es/web/xslt/element/when/index.md
+++ b/files/es/web/xslt/element/when/index.md
@@ -3,7 +3,7 @@ title: when
 slug: Web/XSLT/Element/when
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:when>` siempre aparece dentro de un elemento `<xsl:choose>`, actuando como una sentencia case.
 

--- a/files/es/web/xslt/element/with-param/index.md
+++ b/files/es/web/xslt/element/with-param/index.md
@@ -3,7 +3,7 @@ title: with-param
 slug: Web/XSLT/Element/with-param
 ---
 
-{{XsltRef}}
+{{XsltSidebar}}{{XsltRef}}
 
 El elemento `<xsl:with-param>` establece el valor de un parámetro que se pasará a una plantilla.
 

--- a/files/es/web/xslt/index.md
+++ b/files/es/web/xslt/index.md
@@ -3,6 +3,8 @@ title: XSLT
 slug: Web/XSLT
 ---
 
+{{XsltSidebar}}
+
 **[Tutorial XSLT (en)](http://www.w3schools.com/xsl/)**
 Este tutorial enseña como usar XSLT para transformar documentos XML en otros formatos.
 

--- a/files/es/web/xslt/transforming_xml_with_xslt/index.md
+++ b/files/es/web/xslt/transforming_xml_with_xslt/index.md
@@ -3,6 +3,8 @@ title: Transformando XML con XSLT
 slug: Web/XSLT/Transforming_XML_with_XSLT
 ---
 
+{{XsltSidebar}}
+
 ### Introducción
 
 La separación del contenido y la presentación es una característica clave en el diseño de [XML](/es/XML). La estructura de un documento XML esta diseñada para reflejar y clarificar relaciones importantes entre los aspectos individuales del contenido en si mismo, sin preocuparse de la forma en que posteriormente se visualizaran los datos. Una estructuración inteligente es particularmente importante cuando cada día se realizan más conexiones entre máquinas muy diferentes a través de la red.


### PR DESCRIPTION
### Description

Adds sidebar macro calls from the en-US version.

### Motivation

Sidebars have been added to almost all en-US pages, and many translated pages don't have them yet.

### Additional details

This was created using a custom version of the sync-translated-content tool (https://github.com/mdn/yari/commit/86ba2eac8690f3b8c1bca3cf5ad1aa813be4285c).

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
