### PR TITLE
[fr] Import sidebars from en-US (fixup)

### DIFF
--- a/files/fr/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
+++ b/files/fr/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
@@ -3,7 +3,7 @@ title: Ajouter une carte de zones cliquables sur une image
 slug: Learn/HTML/Howto/Add_a_hit_map_on_top_of_an_image
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Learn/HTML/Howto")}}
+{{QuickLinksWithSubpages("/fr/docs/Learn/HTML/Howto")}}
 
 Dans cet article, nous verrons comment construire une carte imagée cliquable en commençant par les inconvénients de cette méthode.
 

--- a/files/fr/learn/html/howto/author_fast-loading_html_pages/index.md
+++ b/files/fr/learn/html/howto/author_fast-loading_html_pages/index.md
@@ -3,7 +3,7 @@ title: Astuces de création de pages HTML à affichage rapide
 slug: Learn/HTML/Howto/Author_fast-loading_HTML_pages
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Learn/HTML/Howto")}}
+{{QuickLinksWithSubpages("/fr/docs/Learn/HTML/Howto")}}
 
 C'est connu, les internautes sont de grands impatients, ils veulent des résultats immédiats, avec des gros titres et des réponses courtes et efficaces.
 Une page web optimisé prévoit non seulement un site plus réactif, mais aussi de réduire la charge sur vos serveurs Web et votre connexion Internet. Cela peut être crucial pour les gros sites ou des sites qui ont un pic de trafic dans des circonstances exceptionnelles (telles que les Unes des journaux fracassantes). De plus, Google en tient compte pour son classement.

--- a/files/fr/learn/html/howto/define_terms_with_html/index.md
+++ b/files/fr/learn/html/howto/define_terms_with_html/index.md
@@ -3,7 +3,7 @@ title: Définir des termes avec HTML
 slug: Learn/HTML/Howto/Define_terms_with_HTML
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Learn/HTML/Howto")}}
+{{QuickLinksWithSubpages("/fr/docs/Learn/HTML/Howto")}}
 
 HTML fournit plusieurs méthodes pour décrire la sémantique du contenu qu'on emploie (que ce soit intégré dans le texte ou dans un glossaire à part). Dans cet article, nous verrons comment correctement définir les termes utilisés au sein d'un document.
 

--- a/files/fr/learn/html/howto/use_javascript_within_a_webpage/index.md
+++ b/files/fr/learn/html/howto/use_javascript_within_a_webpage/index.md
@@ -3,7 +3,7 @@ title: Utiliser JavaScript au sein d'une page web
 slug: Learn/HTML/Howto/Use_JavaScript_within_a_webpage
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Learn/HTML/Howto")}}
+{{QuickLinksWithSubpages("/fr/docs/Learn/HTML/Howto")}}
 
 Dans cet article, nous verrons comment améliorer les pages web en ajoutant du code JavaScript dans des documents HTML.
 

--- a/files/fr/web/exslt/exsl/node-set/index.md
+++ b/files/fr/web/exslt/exsl/node-set/index.md
@@ -3,7 +3,7 @@ title: node-set
 slug: Web/EXSLT/exsl/node-set
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{ XsltRef() }}
+{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}{{ XsltRef() }}
 
 `exsl:node-set()` retourne un ensemble de nœuds d'un fragment d'arbre résultant, qui correspond à ce qu'on obtient en regardant [`xsl:variable`](/fr/XSLT/variable) plutôt que son attribut `select` pour récupérer la valeur d'une variable. Ceci permet de traiter le XML créé dans une variable pour de le traiter en plusieurs étapes.
 

--- a/files/fr/web/exslt/set/difference/index.md
+++ b/files/fr/web/exslt/set/difference/index.md
@@ -3,7 +3,7 @@ title: difference
 slug: Web/EXSLT/set/difference
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{ XsltRef() }}
+{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}{{ XsltRef() }}
 `set:difference()` retourne la différence entre deux ensembles de nœuds. En d'autres termes, elle retourne un ensemble de nœuds qui sont dans un des ensembles mais par dans l'autre.
 
 La version*modèle* de `set:difference` applique des modèles à ces nœuds dans le mode `set:difference`, en copiant les nœuds afin de retourner un un fragment d'arbre résultant comprenant ces nœuds.

--- a/files/fr/web/exslt/set/distinct/index.md
+++ b/files/fr/web/exslt/set/distinct/index.md
@@ -3,7 +3,7 @@ title: distinct
 slug: Web/EXSLT/set/distinct
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{ XsltRef() }}
+{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}{{ XsltRef() }}
 
 `set:distinct()` retourne un sous-ensemble des nœuds appartenant à l'ensemble de nœuds spécifié, en ne retournant que les nœuds possédant une valeur de chaîne unique.
 

--- a/files/fr/web/exslt/set/has-same-node/index.md
+++ b/files/fr/web/exslt/set/has-same-node/index.md
@@ -3,7 +3,7 @@ title: has-same-node
 slug: Web/EXSLT/set/has-same-node
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{ XsltRef() }}
+{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}{{ XsltRef() }}
 
 `set:has-same-node()` détermine si deux ensembles de nœuds ont ou non des nœuds communs.
 

--- a/files/fr/web/exslt/set/intersection/index.md
+++ b/files/fr/web/exslt/set/intersection/index.md
@@ -3,7 +3,7 @@ title: intersection
 slug: Web/EXSLT/set/intersection
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{ XsltRef() }}
+{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}{{ XsltRef() }}
 
 `set:intersection()` retourne l'intersection de deux ensembles de nœuds. En d'autres termes, cette fonction retourne un ensemble de nœuds contenant tous les nœuds appartenant aux deux ensembles de nœuds.
 

--- a/files/fr/web/exslt/str/concat/index.md
+++ b/files/fr/web/exslt/str/concat/index.md
@@ -3,7 +3,7 @@ title: concat
 slug: Web/EXSLT/str/concat
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{ XsltRef() }}
+{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}{{ XsltRef() }}
 
 `str:concat()` retourne une chaîne contenant toutes les valeurs de chaînes d'un ensemble de nœuds concaténées ensembles.
 

--- a/files/fr/web/exslt/str/split/index.md
+++ b/files/fr/web/exslt/str/split/index.md
@@ -3,7 +3,7 @@ title: split
 slug: Web/EXSLT/str/split
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{ XsltRef() }}
+{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}{{ XsltRef() }}
 
 `str:split()` divise une chaîne en utilisation un motif pour déterminer où doivent être fait les séparations, en retournant un ensemble de nœuds contenant les chaînes résultantes.
 

--- a/files/fr/web/exslt/str/tokenize/index.md
+++ b/files/fr/web/exslt/str/tokenize/index.md
@@ -3,7 +3,7 @@ title: tokenize
 slug: Web/EXSLT/str/tokenize
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}{{ XsltRef() }}
+{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}{{ XsltRef() }}
 
 `str:tokenize()` divise une chaîne en utilisant un ensemble de caractère comme délimiteur qui détermine l'endroit où doivent être fait les séparations, en retournant un ensemble de nœuds contenant les chaînes résultantes.
 

--- a/files/fr/web/manifest/index.md
+++ b/files/fr/web/manifest/index.md
@@ -3,7 +3,7 @@ title: Manifeste des applications web
 slug: Web/Manifest
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
+{{QuickLinksWithSubpages("/fr/docs/Web/Manifest")}}
 
 Le manifeste d'une application web fournit des informations concernant celle-ci (comme son nom, son auteur, une icône et une description) dans un document texte JSON. Le but du manifeste est d'installer des applications sur l'écran d'accueil d'un appareil, offrant aux utilisateurs un accès plus rapide et une expérience plus riche.
 

--- a/files/fr/web/media/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
+++ b/files/fr/web/media/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
@@ -3,7 +3,7 @@ title: Mémoire tampon, position, et plages de temps
 slug: Web/Media/Audio_and_video_delivery/buffering_seeking_time_ranges
 ---
 
-{{QuickLinksWithSubPages("/en-US/docs/Web/Media")}}
+{{QuickLinksWithSubpages("/fr/docs/Web/Media")}}
 
 Il est parfois utile de savoir combien d'{{htmlelement("audio") }} ou {{htmlelement("video") }} a été téléchargé ou peut être joué sans délai — par exemple pour afficher la barre de progression du tampon dans un lecteur audio ou vidéo. Cet article explique comment construire une barre de progrès de mise en mémoire tampon en utilisant [TimeRanges](/fr/docs/Web/API/TimeRanges), et d'autres fonctionnalités de l'API Media.
 

--- a/files/fr/web/media/audio_and_video_delivery/index.md
+++ b/files/fr/web/media/audio_and_video_delivery/index.md
@@ -3,7 +3,7 @@ title: Intégration audio et vidéo
 slug: Web/Media/Audio_and_video_delivery
 ---
 
-{{QuickLinksWithSubPages("/en-US/docs/Web/Media")}}
+{{QuickLinksWithSubpages("/fr/docs/Web/Media")}}
 
 On peut distribuer de l'audio et de la vidéo sur le web de plusieurs manières, du fichier média statique au <i lang="en">live stream</i> (flux en direct) adaptatif. Cet article se veut être le point de départ pour explorer les différents mécanismes de diffusion de média sur le web et la compatiblité avec les navigateurs populaires.
 

--- a/files/fr/web/media/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
+++ b/files/fr/web/media/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
@@ -3,7 +3,7 @@ title: Live streaming web Audio et Vidéo
 slug: Web/Media/Audio_and_video_delivery/Live_streaming_web_audio_and_video
 ---
 
-{{QuickLinksWithSubPages("/en-US/docs/Web/Media")}}
+{{QuickLinksWithSubpages("/fr/docs/Web/Media")}}
 
 La technologie de _live streaming_ (diffusion en direct) est souvent utilisée pour relayer des événements en direct, tels que le sport, les concerts, ou de manière plus générale les programmes TV et radio en direct. Souvent raccourci au simple terme de _streaming_, le live streaming est le processus de transmissions d'un média _live_ (c'est à dire dynamique et non statique) aux ordinateurs et aux périphériques. C'est un sujet assez complexe et nouveau avec beaucoup de variables à prendre en considération, dans cet article nous allons vous introduire le sujet et vous donner des clés pour démarrer.
 

--- a/files/fr/web/media/audio_and_video_manipulation/index.md
+++ b/files/fr/web/media/audio_and_video_manipulation/index.md
@@ -3,7 +3,7 @@ title: Manipulation Audio et Vidéo
 slug: Web/Media/Audio_and_video_manipulation
 ---
 
-{{QuickLinksWithSubPages("/en-US/docs/Web/Media")}}
+{{QuickLinksWithSubpages("/fr/docs/Web/Media")}}
 
 La beauté du web est qu'on peut combiner différentes technologies pour en créer de nouvelles. Avoir de l'audio et vidéo nativement dans le navigateur nous donne la possibilité d'utiliser ces flux de données avec d'autres technologies comme {{htmlelement("canvas")}}, [WebGL](/fr/docs/Web/API/WebGL_API) ou [Web Audio API](/fr/docs/Web/API/Web_Audio_API) pour modifier le média — par exemple ajouter des effets de réverbération ou de compression à l'audio, ou encore des filtres noir & blanc/sépia aux vidéos. Cet article fournit une référence pour expliquer ce que vous pouvez faire.
 

--- a/files/fr/web/security/certificate_transparency/index.md
+++ b/files/fr/web/security/certificate_transparency/index.md
@@ -3,7 +3,7 @@ title: Public Key Pinning
 slug: Web/Security/Certificate_Transparency
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}
+{{QuickLinksWithSubpages("/fr/docs/Web/Security")}}
 
 L'extention **Public Key Pinning pour HTTP** (HPKP) est une fonctionnalité de sécurité qui dit au client web d'associer une clé publique cryptographique avec un certain serveur web pour éviter les attaques [MITM](https://fr.wikipedia.org/wiki/Attaque_de_l%27homme_du_milieu) avec des certificats contrefaits.
 

--- a/files/fr/web/security/referer_header_colon__privacy_and_security_concerns/index.md
+++ b/files/fr/web/security/referer_header_colon__privacy_and_security_concerns/index.md
@@ -3,7 +3,7 @@ title: "Referer header: privacy and security concerns"
 slug: Web/Security/Referer_header:_privacy_and_security_concerns
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}
+{{QuickLinksWithSubpages("/fr/docs/Web/Security")}}
 
 L'[entête HTTP Referer](/fr/docs/Web/HTTP/Headers/Referer) présente des risques de confidentialité et de sécurité[.](/fr/docs/Web/HTTP/Headers/Referer) Cet article les décrit et donne des conseils pour les minimiser.
 

--- a/files/fr/web/security/same-origin_policy/index.md
+++ b/files/fr/web/security/same-origin_policy/index.md
@@ -3,7 +3,7 @@ title: Same-origin policy
 slug: Web/Security/Same-origin_policy
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}
+{{QuickLinksWithSubpages("/fr/docs/Web/Security")}}
 
 La same-origin policy restreint la manière dont un document ou un script chargé depuis une origine peut interagir avec une autre ressource chargée depuis une autre origine.
 

--- a/files/fr/web/security/secure_contexts/index.md
+++ b/files/fr/web/security/secure_contexts/index.md
@@ -3,7 +3,7 @@ title: Secure Contexts
 slug: Web/Security/Secure_Contexts
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}
+{{QuickLinksWithSubpages("/fr/docs/Web/Security")}}
 
 Un navigateur entre dans un **contexte sécurisé** quand il a satisfait les exigences minimale de sécurité. Un contexte sécurisé permet au navigateur de mettre à disposition des APIs qui nécessitent des transferts sécurisés avec l'utilisateur.
 

--- a/files/fr/web/security/subresource_integrity/index.md
+++ b/files/fr/web/security/subresource_integrity/index.md
@@ -3,7 +3,7 @@ title: Subresource Integrity
 slug: Web/Security/Subresource_Integrity
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}
+{{QuickLinksWithSubpages("/fr/docs/Web/Security")}}
 
 **_Subresource Integrity_** (SRI, ou « Intégrité des sous-ressources ») est une fonction de sécurité qui permet aux navigateurs de vérifier que les fichiers qu'ils vont chercher (par exemple, à partir d'un [CDN](/fr/docs/Glossaire/CDN)) sont livrés sans manipulation inattendue. Cela fonctionne en permettant de fournir un hachage cryptographique (« _hash_ ») auquel le fichier récupéré doit correspondre.
 

--- a/files/fr/web/xml/xml_introduction/index.md
+++ b/files/fr/web/xml/xml_introduction/index.md
@@ -3,7 +3,7 @@ title: Introduction à XML
 slug: Web/XML/XML_introduction
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/XML")}}
+{{QuickLinksWithSubpages("/fr/docs/Web/XML")}}
 
 ### Définition
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes sidebar macro calls that were imported from the en-US version.

### Motivation

The `QuicklinksWithSubPages` macro requires a path including the current locale (see [here](https://github.com/mdn/translated-content/pull/21366#discussion_r1628618027)).

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Follow-up of https://github.com/mdn/translated-content/pull/21361.