### PR TITLE
[fr]: fix typo in CustomEvent page

### DIFF
--- a/files/fr/web/api/customevent/index.md
+++ b/files/fr/web/api/customevent/index.md
@@ -21,7 +21,7 @@ L'interface **`CustomEvent`** représente un évènement initialisé par une app
 _Cette interface hérite des propriétés de son parent, [`Event`](/fr/docs/Web/API/Event)._
 
 - [`CustomEvent.detail`](/fr/docs/Web/API/CustomEvent/detail) {{readonlyinline}}
-  - : Renvoie toutes les données passées lor de l'initialisation de l'évènement.
+  - : Renvoie toutes les données passées lors de l'initialisation de l'évènement.
 
 ## Méthodes
 


### PR DESCRIPTION
### Description

While reading the French version of the [CustomEvent](https://developer.mozilla.org/fr/docs/Web/API/CustomEvent) page, I noticed a typo.

### Motivation

This removes a typo in the documentation, so the content is orthographically correct.
