### PR TITLE
CSS: `caption-side` の内容を英語版に追従して更新

### DIFF
--- a/files/ja/web/css/caption-side/index.md
+++ b/files/ja/web/css/caption-side/index.md
@@ -16,9 +16,7 @@ slug: Web/CSS/caption-side
 caption-side: top;
 caption-side: bottom;
 
-/* 警告: 非標準の値 */
-caption-side: block-start;
-caption-side: block-end;
+/* 倫理値 */
 caption-side: inline-start;
 caption-side: inline-end;
 
@@ -34,12 +32,8 @@ caption-side: unset;
 ### 値
 
 - `top`
-  - : キャプションボックスを表の上方に配置します。
-- `bottom`
-  - : キャプションボックスを表の下方に配置します。
-- `block-start`
   - : キャプションボックスを表のブロック方向の先頭に配置します。
-- `block-end`
+- `bottom`
   - : キャプションボックスを表のブロック方向の末尾に配置します。
 - `inline-start`
   - : キャプションボックスを表のインライン方向の先頭に配置します。


### PR DESCRIPTION
### Description

`caption-side` プロパティに `block-*` の値は現状の CSS 仕様には存在しません。また `top` / `bottom` は `block-*` 相当に再定義されます。

長らく CSS 仕様と MDN 説明とで差異が生じていたのですが、先日英語版が修正されたので、日本語版もそれに合わせて修正を行いました。

### Related issues and pull requests

本更新は英語版の修正内容に準じます。👉https://github.com/mdn/content/pull/33903
