### PR TITLE
Fix incorrect translation

### DIFF
--- a/files/fr/web/media/formats/image_types/index.md
+++ b/files/fr/web/media/formats/image_types/index.md
@@ -873,7 +873,7 @@ Le JPEG est en fait un format de données pour les photos compressées, plutôt 
     <tr>
       <th scope="row">Compression</th>
       <td>
-        Sans perte; sur la base de la
+        Avec perte; sur la base de la
         <a
           href="https://fr.wikipedia.org/wiki/Transformée_en_cosinus_discrète"
           >transformée en cosinus discrète</a


### PR DESCRIPTION
Lossy was translated by the French for lossless (JPEG).

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
For JPEG, lossy ("Avec perte") was translated with the French word for lossless ("Sans perte")

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Even though the rest of the document tells JPEG is lossy this might confuse newbies.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
