### PR TITLE
[zh-cn] fix wrong macro content in the SVG `<font-face-src>` element

### DIFF
--- a/files/zh-cn/web/svg/element/font-face-src/index.md
+++ b/files/zh-cn/web/svg/element/font-face-src/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{SVGRef}}{{deprecated_header}}
 
-**`<font-face-src>`** [SVG](/zh-CN/docs/Web/SVG) 元素对应于 CSS {{cssxref("@font-face/src", "src")}} 规则中的 {{cssxref("@font-face")}} 描述符。它是 {{SVGElement("font-face-name")}} 和 {{{SVGElement("font-face-uri")}} 的容器，前者指向本地安装的字体副本，后者则使用远程定义的字体。
+**`<font-face-src>`** [SVG](/zh-CN/docs/Web/SVG) 元素对应于 CSS {{cssxref("@font-face/src", "src")}} 规则中的 {{cssxref("@font-face")}} 描述符。它是 {{SVGElement("font-face-name")}} 和 {{SVGElement("font-face-uri")}} 的容器，前者指向本地安装的字体副本，后者则使用远程定义的字体。
 
 ## 使用上下文
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/font-face-src
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/svg/element/font-face-src/index.md
* Last commit: https://github.com/mdn/content/commit/3a1ef2abc8233835f0b0cc73afaf36e44edaf4a1