### PR TITLE
[ko] Clients/openWindow 신규 번역, Clients/claim 최신화

### DIFF
--- a/files/ko/web/api/clients/claim/index.md
+++ b/files/ko/web/api/clients/claim/index.md
@@ -1,31 +1,38 @@
 ---
-title: Clients.claim()
+title: "Clients: claim() 메서드"
+short-title: claim()
 slug: Web/API/Clients/claim
+l10n:
+  sourceCommit: 2ef36a6d6f380e79c88bc3a80033e1d3c4629994
 ---
 
-{{SeeCompatTable}}{{APIRef("Service Worker Clients")}}
+{{APIRef("Service Workers API")}}{{AvailableInWorkers("service")}}
 
-{{domxref("Clients")}} 의 **`claim()`** 메소드는 active 서비스워커가 그것의 {{domxref("ServiceWorkerRegistration.scope", "scope")}} 를 가지는 모든 클라이언트들의 {{domxref("ServiceWorkerContainer.controller", "controller")}} 로서 자신을 등록하는 것을 허용한다. 이것은 이 서비스워커가 제어하게 될 클라이언트들에 "`controllerchange`" 이벤트를 발생시킨다.
+{{domxref("Clients")}} 인터페이스의 **`claim()`** 메서드는 활성화된 서비스 워커가 자신의 {{domxref("ServiceWorkerRegistration.scope", "scope")}} 내 모든 클라이언트의 {{domxref("ServiceWorkerContainer.controller", "controller")}}로 설정될 수 있습니다.
+이렇게 하면 이 서비스 워커가 제어하는 클라이언트에서 {{domxref("ServiceWorkerContainer","navigator.serviceWorker")}}에 "`controllerchange`" 이벤트가 트리거됩니다.
 
-서비스워커가 최초에 등록되면, 페이지들은 다음 로드시까지 그것을 사용하지 않을 것이다. `claim()` 메소드는 그 페이지들을 즉시 제어될 수 있도록 한다. 이로 인해, 당신의 서비스워커는 네트워크 또는 다른 서비스워커를 통해 정기적으로 로드되는 페이지들을 제어하게 된다.
+서비스 워커가 처음 등록될 때, 페이지는 다음에 로드될 때까지 해당 서비스 워커를 사용하지 않습니다.
+`claim()` 메서드는 이런 페이지가 즉시 제어되도록 합니다.
+이로 인해 서비스 워커가 네트워크를 통해 정기적으로 로드된 페이지나
+다른 서비스 워커를 통해 로드된 페이지를 제어하게 됩니다.
 
-## Syntax
+## 구문
 
-```js
-await clients.claim();
+```js-nolint
+claim()
 ```
 
-### Parameters
+### 매개변수
 
-None.
+없음.
 
-### Returns
+### 반환 값
 
-A {{jsxref("Promise")}} for `void`.
+`undefined`로 이행되는 {{jsxref("Promise")}}.
 
-## Example
+## 예제
 
-다음 예시는 서비스워커의 "`activate`" 이벤트 리스너에서 `claim()` 를 사용하므로, fetch 들이 이 서비스워커를 통과하기 전에 동일한 스코프에서 로드된 클라이언트들은 다시 로드될 필요가 없다. .
+다음 예제는 서비스 워커의 "`activate`" 이벤트 수신기 내에서 `claim()`을 사용하여 동일한 범위 내에서 로드된 클라이언트가 이 서비스 워커를 통해 페치를 수행하기 전에 다시 로드될 필요가 없도록 합니다.
 
 ```js
 self.addEventListener("activate", (event) => {
@@ -41,10 +48,8 @@ self.addEventListener("activate", (event) => {
 
 {{Compat}}
 
-## See also
+## 같이 보기
 
-- [Using Service Workers](/ko/docs/Web/API/ServiceWorker_API/Using_Service_Workers)
-- [The service worker lifecycle](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/lifecycle)
-- [Is ServiceWorker ready?](https://jakearchibald.github.io/isserviceworkerready/)
-- {{jsxref("Promise", "Promises")}}
-- {{domxref("ServiceWorkerGlobalScope.skipWaiting()", "self.skipWaiting()")}} - skip the service worker's waiting phase
+- [서비스 워커 사용하기](/ko/docs/Web/API/Service_Worker_API/Using_Service_Workers)
+- [서비스 워커 수명 주기](https://web.dev/articles/service-worker-lifecycle)
+- {{domxref("ServiceWorkerGlobalScope.skipWaiting()", "self.skipWaiting()")}} - 서비스 워커의 대기 단계 건너뛰기

--- a/files/ko/web/api/clients/openwindow/index.md
+++ b/files/ko/web/api/clients/openwindow/index.md
@@ -1,0 +1,91 @@
+---
+title: "Clients: openWindow() 메서드"
+short-title: openWindow()
+slug: Web/API/Clients/openWindow
+l10n:
+  sourceCommit: 2ef36a6d6f380e79c88bc3a80033e1d3c4629994
+---
+
+{{APIRef("Service Workers API")}}{{AvailableInWorkers("service")}}
+
+{{domxref("Clients")}} 인터페이스의 **`openWindow()`** 메서드는
+새로운 최상위 브라우징 맥락을 생성하고 주어진 URL을 로드합니다.
+호출하는 스크립트에 팝업 표시 권한이 없는 경우, `openWindow()`는 `InvalidAccessError`를 발생시킵니다.
+
+Firefox에서는 알림 클릭 이벤트의 결과로 호출된 경우에만 메서드가 팝업을 표시할 수 있습니다.
+
+Android용 Chrome에서, 이 메서드는 사용자의 홈 화면에 이전에 추가된 [독립형 웹 앱](/ko/docs/Web/Progressive_web_apps)에서 제공하는 기존 브라우징 맥락에서 URL을 대신 열 수 있습니다.
+최근부터 Windows용 Chrome에서도 이렇게 작동합니다.
+
+## 구문
+
+```js-nolint
+openWindow(url)
+```
+
+### 매개변수
+
+- `url`
+  - : 창에서 열려는 클라이언트의 URL을 나타내는 문자열.
+    일반적으로 이 값은 호출하는 스크립트와 동일한 출처의 URL이어야 합니다.
+
+### 반환 값
+
+서비스 워커와 동일한 출처의 URL이면 {{domxref("WindowClient")}} 객체로,
+그렇지 않은 경우 {{Glossary("null", "null 값")}}으로 이행된 {{jsxref("Promise")}}.
+
+### 예외
+
+- `InvalidAccessError` {{domxref("DOMException")}}
+  - : 앱의 출처에 [임시 활성화](/ko/docs/Web/Security/User_activation)된 창이 없는 경우 이 예외로 프로미스가 거부됩니다.
+
+## 보안 요구 사항
+
+- 앱의 출처에 적어도 하나의 창은 [임시 활성화](/ko/docs/Web/Security/User_activation)되어 있어야 합니다.
+
+## 예제
+
+```js
+// 해당되는 경우 OS에 알림 보내기
+if (self.Notification.permission === "granted") {
+  const notificationObject = {
+    body: "Click here to view your messages.",
+    data: { url: `${self.location.origin}/some/path` },
+    // data: { url: 'http://example.com' },
+  };
+  self.registration.showNotification(
+    "You've got messages!",
+    notificationObject,
+  );
+}
+
+// 알림 클릭 이벤트 수신기
+self.addEventListener("notificationclick", (e) => {
+  // 알림 팝업 닫기
+  e.notification.close();
+  // 모든 Window 클라이언트 가져오기
+  e.waitUntil(
+    clients.matchAll({ type: "window" }).then((clientsArr) => {
+      // 타겟 URL과 일치하는 창이 이미 존재하는 경우, 해당 탭에 포커스
+      const hadWindowToFocus = clientsArr.some((windowClient) =>
+        windowClient.url === e.notification.data.url
+          ? (windowClient.focus(), true)
+          : false,
+      );
+      // 그렇지 않은 경우, 해당 URL로 새로운 탭을 열고 포커스.
+      if (!hadWindowToFocus)
+        clients
+          .openWindow(e.notification.data.url)
+          .then((windowClient) => (windowClient ? windowClient.focus() : null));
+    }),
+  );
+});
+```
+
+## 명세서
+
+{{Specifications}}
+
+## 브라우저 호환성
+
+{{Compat}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Clients의 `openWindow()` 메서드는 신규 번역, `claim()` 메서드는 최신화하였습니다.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
- claim() 메서드의 같이 보기 부분의 'lifecycle'은
링크에 적혀있는 ‘수명 주기’로 번역하였습니다.

### Related issues and pull requests
#21459 에 이어 Clients의 남은 두 메서드입니다.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
