### PR TITLE
[zh-cn]: update the translation of Error `columnNumber` datatype

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/error/columnnumber/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/error/columnnumber/index.md
@@ -1,5 +1,5 @@
 ---
-title: Error: columnNumber
+title: Error.prototype.columnNumber
 slug: Web/JavaScript/Reference/Global_Objects/Error/columnNumber
 l10n:
   sourceCommit: 5c3c25fd4f2fbd7a5f01727a65c2f70d73f1880a

--- a/files/zh-cn/web/javascript/reference/global_objects/error/columnnumber/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/error/columnnumber/index.md
@@ -1,25 +1,35 @@
 ---
-title: Error.prototype.columnNumber
+title: "Error：columnNumber"
 slug: Web/JavaScript/Reference/Global_Objects/Error/columnNumber
+l10n:
+  sourceCommit: 5c3c25fd4f2fbd7a5f01727a65c2f70d73f1880a
 ---
 
-{{JSRef}} {{non-standard_header}}
+{{JSRef}} {{Non-standard_Header}}
 
-**`columnNumber`**属性包含引发此错误的文件行中的列号。
+{{jsxref("Error")}} 实例的 **`columnNumber`** 数据属性包含引发此错误的文件行中的列号。
+
+## 值
+
+正整数。
+
+{{js_property_attributes(1, 0, 1)}}
 
 ## 示例
 
-### 使用 `columnNumber`
+### 使用 columnNumber
 
 ```js
-var e = new Error("Could not parse input");
-throw e;
-console.log(e.columnNumber); // 0
+try {
+  throw new Error("无法解析输入");
+} catch (err) {
+  console.log(err.columnNumber); // 9
+}
 ```
 
 ## 规范
 
-{{Specifications}}
+不属于任何规范。
 
 ## 浏览器兼容性
 
@@ -27,6 +37,6 @@ console.log(e.columnNumber); // 0
 
 ## 参见
 
-- {{jsxref("Error.prototype.stack")}} {{non-standard_inline}}
-- {{jsxref("Error.prototype.lineNumber")}} {{non-standard_inline}}
-- {{jsxref("Error.prototype.fileName")}} {{non-standard_inline}}
+- {{jsxref("Error.prototype.stack")}}
+- {{jsxref("Error.prototype.lineNumber")}}
+- {{jsxref("Error.prototype.fileName")}}

--- a/files/zh-cn/web/javascript/reference/global_objects/error/columnnumber/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/error/columnnumber/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Error：columnNumber"
+title: Error: columnNumber
 slug: Web/JavaScript/Reference/Global_Objects/Error/columnNumber
 l10n:
   sourceCommit: 5c3c25fd4f2fbd7a5f01727a65c2f70d73f1880a


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/error/columnnumber/index.md
* Last commit: https://github.com/mdn/content/commit/5c3c25fd4f2fbd7a5f01727a65c2f70d73f1880a