### PR TITLE
[zh-cn]: fix wrong macro in `geolocation` introduction

### DIFF
--- a/files/zh-cn/web/api/geolocation/index.md
+++ b/files/zh-cn/web/api/geolocation/index.md
@@ -1,13 +1,15 @@
 ---
 title: Geolocation
 slug: Web/API/Geolocation
+l10n:
+  sourceCommit: 89c7b111d380e607e94b58abbd0d37951cf395c4
 ---
 
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 
 **`Geolocation`** 接口是一个用来获取设备地理位置的可编程的对象，它可以让 Web 内容访问到设备的地理位置，这将允许网站或应用基于用户的地理位置提供定制的信息。
 
-带有此接口的对象可以用由 {{domxref("Navigator")}} 实现的属性 {{domxref("NavigatorGeolocation.geolocation")}} 来获得。
+带有此接口的对象可以用由 {{domxref("Navigator")}} 实现的属性 {{domxref("navigator.geolocation")}} 来获得。
 
 > **备注：** 出于安全考虑，当一个网页尝试获取地理位置信息时，会请求用户批准地理位置访问权限。因为每个浏览器都有各自请求用户批准该权限的策略和方法。
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/zh-CN/docs/Web/API/Geolocation
* fixed: https://github.com/mdn/translated-content/issues/21612
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/translated-content/blob/main/files/zh-cn/web/api/geolocation/index.md
* Last commit: https://github.com/mdn/translated-content/commit/95bef5b17d069e88146b8ea3799029ee5288024d