### PR TITLE
[fr] fix broken link to W3C in banner_role page

### DIFF
--- a/files/fr/web/accessibility/aria/roles/banner_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/banner_role/index.md
@@ -7,7 +7,7 @@ slug: Web/Accessibility/ARIA/Roles/banner_role
 
 ### Description
 
-Cette technique présente l'utilisation du rôle [`banner` (en)](https://www.w3.org/TR/wai-aria/roles#banner).
+Cette technique présente l'utilisation du rôle [`banner` (en)](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/banner.html).
 
 La zone d'entête principale d'un site devrait être structurée avec `<header role="banner">`. Cette zone peut contenir le logo du site, sa description, le moteur de recherche.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Update link from https://www.w3.org/TR/wai-aria/roles#banner to https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/banner.html
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
https://www.w3.org/TR/wai-aria/roles#banner is broken
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
