### PR TITLE
zh-cn: fix typo in `toLocaleUpperCase()`

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
@@ -30,7 +30,7 @@ toLocaleUpperCase(locales)
 
 ## 描述
 
-`toLocaleUpperCase()` 方法返回根据特定区域设置的大小写映射规则将字符串转换为小写形式的值。`toLocaleUpperCase()` 不会影响字符串本身的值。在大多数情况下，这将产生与 {{jsxref("String.prototype.toUpperCase()", "toUpperCase()")}} 相同的结果，但对于某些区域设置（例如土耳其语），它们的大小写映射与 Unicode 的默认映射不同，可能会得到不同的结果。
+`toLocaleUpperCase()` 方法返回根据特定区域设置的大小写映射规则将字符串转换为大写形式的值。`toLocaleUpperCase()` 不会影响字符串本身的值。在大多数情况下，这将产生与 {{jsxref("String.prototype.toUpperCase()", "toUpperCase()")}} 相同的结果，但对于某些区域设置（例如土耳其语），它们的大小写映射与 Unicode 的默认映射不同，可能会得到不同的结果。
 
 还要注意，转换不一定是一对一的字符映射，因为某些字符在转换为小写形式时可能会产生两个（甚至更多）字符。因此，结果字符串的长度可能与输入长度不同。这也意味着转换是不稳定的，因此下面的例子可能返回 `false`：
 `x.toLocaleLowerCase() === x.toLocaleUpperCase().toLocaleLowerCase()`


### PR DESCRIPTION
“The toLocaleUpperCase() method returns the value of the string converted to upper case according to any locale-specific case mappings” should be translated as "toLocaleUpperCase（）方法返回根据任何特定于区域设置的大小写映射转换为大写的字符串的值".

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
