### PR TITLE
[zh-cn]: fix typo

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/string/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/string/index.md
@@ -43,7 +43,7 @@ const string4 = new String("A String object");
 "cat"[1]; // gives value "a"
 ```
 
-当使用方括号表示法进行字符串访问时，尝试删除或为其复制的行为将不成功。涉及的属性既不可写（writable）也不可配置（configurable）（更多细节，请参见 {{jsxref("Object.defineProperty()")}}）。
+当使用方括号表示法进行字符串访问时，尝试删除或为其赋值的行为将不成功。涉及的属性既不可写（writable）也不可配置（configurable）（更多细节，请参见 {{jsxref("Object.defineProperty()")}}）。
 
 ### 比较字符串
 

--- a/files/zh-cn/web/javascript/reference/global_objects/string/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/string/index.md
@@ -366,5 +366,5 @@ String(undefinedVar); // "undefined"
 
 ## 参见
 
-- [JavaScript 指南中的文本格式化](/zh-CN/docs/Web/JavaScript/Guide/Text_formatting)
+- [文本格式化](/zh-CN/docs/Web/JavaScript/Guide/Text_formatting)指南
 - {{jsxref("RegExp")}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
### Related issues and pull requests
* fixed: [21967](https://github.com/mdn/translated-content/issues/21967)
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/string/index.md
* Last commit: https://github.com/mdn/content/commit/9f65c82c3a80e6ab303f7a36bacd2385fd0d019b