### PR TITLE
[pt-br] fix typos in `Learn/Server-side/Express_Nodejs/development_environment`

### DIFF
--- a/files/pt-br/learn/server-side/express_nodejs/development_environment/index.md
+++ b/files/pt-br/learn/server-side/express_nodejs/development_environment/index.md
@@ -237,13 +237,13 @@ Os passos seguintes mostram como baixar pacotes via NPM, salvá-los nas dependê
 
 ### Desenvolvendo dependências
 
-Se você utilizar uma dependência apenas durante o desenvolvimento da aplicação, é recomendado que você a salve como uma "development dependency". Dessa forma, o pacote não será utilizado no ambiente de produção. Por exemplo: caso utilizar o pacote [esling](http://eslint.org/) (JavaScript Linting), você faria a instalação via NPM da seguinte forma.
+Se você utilizar uma dependência apenas durante o desenvolvimento da aplicação, é recomendado que você a salve como uma "development dependency". Dessa forma, o pacote não será utilizado no ambiente de produção. Por exemplo: caso utilizar o pacote [eslint](http://eslint.org/) (JavaScript Linting), você faria a instalação via NPM da seguinte forma.
 
 ```bash
 npm install eslint --save-dev
 ```
 
-Assim, a esling vai aparecer da seguinte forma na lista de dependências do **package.json**.
+Assim, a eslint vai aparecer da seguinte forma na lista de dependências do **package.json**.
 
 ```json
   "devDependencies": {
@@ -259,7 +259,7 @@ Além de definir e buscar dependências, você também pode nomear scripts dentr
 
 > **Nota:** Ferramentas de automação de tarefas como o [Gulp](http://gulpjs.com/) e o [Grunt](http://gruntjs.com/) também podem ser utilizados, além de outros pacotes externos.
 
-Para definir o script que roda o _esling_, citado na seção acima, nós precisamos adicionar o seguinte bloco no nosso **package.json** (importante: sua aplicação precisa ter como source está na pasta /src/js):
+Para definir o script que roda o _eslint_, citado na seção acima, nós precisamos adicionar o seguinte bloco no nosso **package.json** (importante: sua aplicação precisa ter como source está na pasta /src/js):
 
 ```json
 "scripts": {


### PR DESCRIPTION
I am reading the MDN documentation in Brazilian Portuguese, I noticed that there was an error in the text, the error was ESLING (referring to ESLINT), I changed it to ESLINT, if it was a wrong change, please correct me so I can continue reading the documentation and learning and bringing knowledge to my students and friends who study through this wonderful documentation. I love you all MDN S2 - Ass:. NVPanda

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
I'm learning with the documentation in my own mother language. I wanted the doc stays so good for the other than me.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Wanted to improve the understanding to others and for me.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Writing errors are good to make students and others persons curious, it's a good method to engage research, but newbies can be confused.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
