### PR TITLE
[ru] update "Syntax" section on `Web/JavaScript/Reference/Global_Objects/String/indexOf`

### DIFF
--- a/files/ru/web/javascript/reference/global_objects/string/indexof/index.md
+++ b/files/ru/web/javascript/reference/global_objects/string/indexof/index.md
@@ -9,10 +9,13 @@ slug: Web/JavaScript/Reference/Global_Objects/String/indexOf
 
 Метод **`indexOf()`** возвращает индекс первого вхождения указанного значения в строковый объект {{jsxref("Global_Objects/String", "String")}}, на котором он был вызван, начиная с индекса `fromIndex`. Возвращает -1, если значение не найдено.
 
+{{EmbedInteractiveExample("pages/js/string-indexof.html", "taller")}}
+
 ## Синтаксис
 
-```
-str.indexOf(searchValue[, fromIndex])
+```js-nolint
+indexOf(searchString)
+indexOf(searchString, position)
 ```
 
 ### Параметры

--- a/files/ru/web/javascript/reference/global_objects/string/indexof/index.md
+++ b/files/ru/web/javascript/reference/global_objects/string/indexof/index.md
@@ -12,7 +12,7 @@ slug: Web/JavaScript/Reference/Global_Objects/String/indexOf
 ## Синтаксис
 
 ```
-str.indexOf(searchValue, [fromIndex])
+str.indexOf(searchValue[, fromIndex])
 ```
 
 ### Параметры


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Commas usually go inside the square brackets of optional arguments, not outside them

### Motivation
It is better to have all pages conform to one spelling standard rather than several different ones.
