### PR TITLE
flex-shrinkのページの例にCSSが含まれていない

### DIFF
--- a/files/ja/web/css/flex-shrink/index.md
+++ b/files/ja/web/css/flex-shrink/index.md
@@ -86,7 +86,7 @@ flex-shrink: unset;
 
 #### 結果
 
-{{EmbedLiveSample('Setting_flex_item_shrink_factor', 500, 300)}}
+{{EmbedLiveSample('フレックスアイテムの縮小係数の設定', 500, 300)}}
 
 ## 仕様書
 


### PR DESCRIPTION
### Description
https://developer.mozilla.org/ja/docs/Web/CSS/flex-shrink#%E4%BE%8B
にCSSが反映されていない

EmbedLiveSampleマクロの引数を見出しに合わせたものに変更してCSSを反映されるようにする

### Motivation
flex-shrinkについてを説明した正しい例を確認してもらいたい！
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
