### PR TITLE
ja: ライブデモのJavaScriptが実行されない不具合を修正

### DIFF
--- a/files/ja/web/api/element/paste_event/index.md
+++ b/files/ja/web/api/element/paste_event/index.md
@@ -76,7 +76,7 @@ target.addEventListener("paste", (event) => {
 
 #### 結果
 
-{{ EmbedLiveSample('Live_example', '100%', '120px') }}
+{{ EmbedLiveSample('ライブデモ', '100%', '120px') }}
 
 ## 仕様書
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description


問題
- https://developer.mozilla.org/ja/docs/Web/API/Element/paste_event#%E3%83%A9%E3%82%A4%E3%83%96%E3%83%87%E3%83%A2
- 上記ページのライブデモにて、JavaScriptが実行されない不具合

原因
- `EmbedLiveSample(id)` のid指定で、節タイトルである`"ライブデモ"`にすべきところを、en-us版のまま `"Live_example"` になっていました。

修正
- `EmbedLiveSample("ライブデモ")` 修正しました。

動作確認
- プレビューページにて、適切に動作することを確認しました
	- paste用の入力要素で、文字列選択した状態でペーストすると、uppercaseに変換されてペーストされる
