### PR TITLE
fix(ru): correct the leading `id` of the live sample

### DIFF
--- a/files/ru/web/css/z-index/index.md
+++ b/files/ru/web/css/z-index/index.md
@@ -102,7 +102,7 @@ z-index: unset;
 
 #### Результат
 
-{{ EmbedLiveSample('Visually_layering_elements', '550', '200', '') }}
+{{ EmbedLiveSample('Визуальное наложение элементов', '550', '200', '') }}
 
 ## Спецификации
 


### PR DESCRIPTION
### Description

correct the leading `id` of the live sample

### Related issues and pull requests

Fixes: #22134