### PR TITLE
fr: update glossary link description

### DIFF
--- a/files/fr/glossary/accessibility_tree/index.md
+++ b/files/fr/glossary/accessibility_tree/index.md
@@ -28,7 +28,6 @@ Toujours à l'état de brouillon au sein du Web Incubator Community Group en avr
 
 ## Voir aussi
 
-- [Glossaire](/fr/docs/Glossary)
-
+- Termes du glossaire associés
   - [Accessibilité](/fr/docs/Glossary/Accessibility)
   - [ARIA](/fr/docs/Glossary/ARIA)

--- a/files/fr/glossary/blink/index.md
+++ b/files/fr/glossary/blink/index.md
@@ -14,8 +14,7 @@ l10n:
 - [Page d'accueil](https://www.chromium.org/blink) du projet Blink
 - [Blink](<https://fr.wikipedia.org/wiki/Blink_(moteur_de_rendu)>) sur Wikipédia.
 - [FAQ](https://www.chromium.org/blink/developer-faq/) sur Blink
-- [Glossaire](/fr/docs/Glossary)
-  - [Google Chrome](/fr/docs/Glossary/Google_Chrome)
+- Termes du glossaire associés - [Google Chrome](/fr/docs/Glossary/Google_Chrome)
   - [Gecko](/fr/docs/Glossary/Gecko)
   - [Trident](/fr/docs/Glossary/Trident)
   - [WebKit](/fr/docs/Glossary/WebKit)

--- a/files/fr/glossary/cryptography/index.md
+++ b/files/fr/glossary/cryptography/index.md
@@ -12,5 +12,6 @@ La **cryptographie**, ou cryptologie, est la science qui étudie comment coder e
 ### Culture générale
 
 - [Cryptographie](https://fr.wikipedia.org/wiki/Cryptographie) sur Wikipédia
-- {{glossary("Cryptanalysis","cryptanalyse")}}
+- Termes du glossaire associés
+  - {{glossary("Cryptanalysis","cryptanalyse")}}
 - [Tutoriel sur la sécurité de l'information](/fr/Apprendre/Tutoriels/Les_bases_de_la_sécurité_informatique)

--- a/files/fr/glossary/lossless_compression/index.md
+++ b/files/fr/glossary/lossless_compression/index.md
@@ -11,9 +11,8 @@ slug: Glossary/Lossless_compression
 
 ## Voir aussi
 
-[Glossary](/fr/docs/Glossary)
-
-1. {{glossary("GZIP")}}
-2. {{glossary("Brotli")}}
-3. {{glossary("PNG")}}
-4. {{glossary("Lossy compression")}}
+- Termes du glossaire associés
+  - {{glossary("GZIP")}}
+  - {{glossary("Brotli")}}
+  - {{glossary("PNG")}}
+  - {{glossary("Lossy compression")}}

--- a/files/fr/glossary/public-key_cryptography/index.md
+++ b/files/fr/glossary/public-key_cryptography/index.md
@@ -17,7 +17,7 @@ Parmi les systèmes de chiffrement par clé publique les plus courants, on retro
 
 ## Voir aussi
 
-- [Glossaire](/fr/docs/Glossary)
+- Termes du glossaire associés
 
   - [Chiffrement par clé symétrique](/fr/docs/Glossary/Symmetric-key_cryptography)
 

--- a/files/fr/glossary/raster_image/index.md
+++ b/files/fr/glossary/raster_image/index.md
@@ -11,5 +11,4 @@ Les fichiers d'image matricielle contiennent généralement un ensemble de dimen
 
 ## Voir aussi
 
-- {{glossary("Vector images","Image vectorielle")}}
 - [Image matricielle](https://fr.wikipedia.org/wiki/Image_matricielle) sur Wikipédia

--- a/files/fr/glossary/second-level_domain/index.md
+++ b/files/fr/glossary/second-level_domain/index.md
@@ -16,8 +16,7 @@ Autre exemple, dans `developer.mozilla.org`, le sous-domaine `developer` sert à
 ## Voir aussi
 
 - [SLD](https://fr.wikipedia.org/wiki/Domaine_de_deuxième_niveau) (Wikipédia)
-- [Glossaire](/fr/docs/Glossary)
-  - [DNS](/fr/docs/Glossary/DNS)
+- Termes du glossaire associés - [DNS](/fr/docs/Glossary/DNS)
   - [Domaine](/fr/docs/Glossary/Domain)
   - [Nom de domaine](/fr/docs/Glossary/Domain_name)
   - [TLD](/fr/docs/Glossary/TLD)

--- a/files/fr/glossary/spa/index.md
+++ b/files/fr/glossary/spa/index.md
@@ -13,7 +13,7 @@ Cela permet donc aux utilisateurs d'utiliser des sites web sans charger de nouve
 
 - [Application web monopage](https://fr.wikipedia.org/wiki/Application_web_monopage) sur Wikipédia
 - [Comprendre les frameworks JavaScript côté client](/fr/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks)
-- [Glossaire](/fr/docs/Glossary)
+- Termes du glossaire associés
 
   - [API](/fr/docs/Glossary/API)
   - [AJAX](/fr/docs/Glossary/AJAX)

--- a/files/fr/glossary/symmetric-key_cryptography/index.md
+++ b/files/fr/glossary/symmetric-key_cryptography/index.md
@@ -15,8 +15,7 @@ La plupart des algorithmes par clé symétrique actuellement utilisés sont des 
 
 ## Voir aussi
 
-- [Glossaire](/fr/docs/Glossary)
-
+- Termes du glossaire associés
   - [Chiffrement par bloc](/fr/docs/Glossary/Block_cipher_mode_of_operation)
   - [Cryptographie](/fr/docs/Glossary/Cryptography)
   - [Fonction de hachage cryptographique](/fr/docs/Glossary/Cryptographic_hash_function)

--- a/files/fr/glossary/synchronous/index.md
+++ b/files/fr/glossary/synchronous/index.md
@@ -15,5 +15,6 @@ De nombreuses commandes de programmation sont synchrones, par exemple quand vous
 
 ### Référence technique
 
-- {{glossary("Asynchronous")}}
+- Termes du glossaire associés
+  - {{glossary("Asynchronous")}}
 - [Requêtes synchrones et asynchrones](/fr/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests) avec l'{{glossary("API")}} [XMLHttpRequest()](/fr/docs/Web/API/XMLHttpRequest)

--- a/files/fr/glossary/tcp/index.md
+++ b/files/fr/glossary/tcp/index.md
@@ -14,8 +14,7 @@ Le rôle de TCP est d'assurer la livraison fiable et sans erreur des paquets. TC
 - [La page à propose de TCP sur Wikipédia](https://fr.wikipedia.org/wiki/Transmission_Control_Protocol)
 - [Aperçu de HTTP](/fr/docs/Web/HTTP/Overview)
 - [Le fonctionnement des navigateurs](/fr/docs/Web/Performance/How_browsers_work)
-- [Glossaire](/fr/docs/Glossary)
-
+- Termes du glossaire associés
   - [IPv4](/fr/docs/Glossary/IPv4)
   - [IPv6](/fr/docs/Glossary/IPv6)
   - [Paquet](/fr/docs/Glossary/Packet)


### PR DESCRIPTION
mdn/content#34454

tried to do a batch replacement, but found that most entries under `fr/glossary` are not up-to-date...