### PR TITLE
CSS: `@property` のコード例の誤り修正

### DIFF
--- a/files/ja/web/css/@property/index.md
+++ b/files/ja/web/css/@property/index.md
@@ -37,7 +37,7 @@ l10n:
   - : プロパティの初期値を設定します。
 
 `@property` ルールには {{cssxref("@property/syntax","syntax")}} および {{cssxref("@property/inherits","inherits")}} 記述子を含める必要があります。どちらかがない場合は、 `@property` ルール全体が無効となり、無視されます。
-{{cssxref("@property/initial-value","initial-value")}} 記述子は構文が [`*` 全称構文定義](https://drafts.css-houdini.org/css-properties-values-api/#universal-syntax-definition)（例えば `initial-value: *`）である場合のみ省略可能で、それ以外の場合は必須です。
+{{cssxref("@property/initial-value","initial-value")}} 記述子は構文が [`*` 全称構文定義](https://drafts.css-houdini.org/css-properties-values-api/#universal-syntax-definition)（例えば `syntax: *`）である場合のみ省略可能で、それ以外の場合は必須です。
 `initial-vaue` 記述子が必須である場合にこれが省略されると、ルール全体が無効となって無視されます。
 
 未知の記述子は無効で無視されますが、 `@property` ルールは無効になりません。

--- a/files/ja/web/css/@property/index.md
+++ b/files/ja/web/css/@property/index.md
@@ -37,7 +37,7 @@ l10n:
   - : プロパティの初期値を設定します。
 
 `@property` ルールには {{cssxref("@property/syntax","syntax")}} および {{cssxref("@property/inherits","inherits")}} 記述子を含める必要があります。どちらかがない場合は、 `@property` ルール全体が無効となり、無視されます。
-{{cssxref("@property/initial-value","initial-value")}} 記述子は構文が [`*` 全称構文定義](https://drafts.css-houdini.org/css-properties-values-api/#universal-syntax-definition)（例えば `syntax: *`）である場合のみ省略可能で、それ以外の場合は必須です。
+{{cssxref("@property/initial-value","initial-value")}} 記述子は構文が [`*` 全称構文定義](https://drafts.css-houdini.org/css-properties-values-api/#universal-syntax-definition)（例えば `syntax: "*"`）である場合のみ省略可能で、それ以外の場合は必須です。
 `initial-vaue` 記述子が必須である場合にこれが省略されると、ルール全体が無効となって無視されます。
 
 未知の記述子は無効で無視されますが、 `@property` ルールは無効になりません。


### PR DESCRIPTION
### Description

参考コード例のプロパティ名が誤っていたので修正しました。

- 英語版: 正しい
- 日本語版: 誤り
- その他の言語（フランス語、中文）: 当該の補足コードなし（原文と差異が生じてはいますが、誤訳など誤った情報を提示している状態ではありません）

文章を読めば英語版が正しく、日本語版が誤訳であることは明らかですが、念のため CSS 仕様における当該説明箇所はこちらになります。👉https://drafts.css-houdini.org/css-properties-values-api/#at-property-rule
