### PR TITLE
[ko] Intl.DateTimeFormat.prototype.format() 신규번역 외

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
+++ b/files/ko/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
@@ -32,7 +32,8 @@ format(date)
 
 ### format 사용하기
 
-단일 날짜의 서식을 지정하려면 `format` 접근자 함수를 사용합니다. 아래는 세르비아의 경우입니다.
+단일 날짜의 서식을 지정하려면 `format` 접근자 함수를 사용합니다.
+아래는 세르비아의 경우입니다.
 
 ```js
 const options = {
@@ -61,35 +62,6 @@ const formatted = a.map(dateTimeFormat.format);
 console.log(formatted.join("; "));
 // "setembro de 2012; dezembro de 2012; abril de 2012"
 ```
-
-### 형식이 지정된 날짜 값을 정적 값과 비교하지 않기
-
-대부분의 경우 `format()`이 반환하는 서식은 일관적입니다.
-그러나 이는 향후 변경될 수 있으며 모든 언어에 대해 보장되는 것은 아닙니다.
-설계에 따른 출력 변형은 사양에 따라 허용됩니다.
-특히 IE 와 Edge 브라우저는 날짜 주위에 양방향 제어 문자를 삽입하기 때문에 다른 텍스트와 연결할 때
-출력 텍스트가 제대로 흐릅니다.
-
-이러한 이유로 `format()`의 결과를 정적 값과 비교할 수 없습니다.
-
-```js example-bad
-let d = new Date("2019-01-01T00:00:00.000000Z");
-let formattedDate = Intl.DateTimeFormat(undefined, {
-  year: "numeric",
-  month: "numeric",
-  day: "numeric",
-  hour: "numeric",
-  minute: "numeric",
-  second: "numeric",
-}).format(d);
-
-"1.1.2019, 01:00:00" === formattedDate;
-// Firefox와 다른 곳에서는 true
-// IE와 Edge에서는 false
-```
-
-> **참고:** 보다 자세한 정보와 예제는 [StackOverflow 글타래](https://stackoverflow.com/questions/25574963/ies-tolocalestring-has-strange-characters-in-results)를
-> 참고하시기 바랍니다.
 
 ## 명세서
 

--- a/files/ko/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
+++ b/files/ko/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
@@ -1,0 +1,107 @@
+---
+title: Intl.DateTimeFormat.prototype.format()
+slug: Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/format
+l10n:
+  sourceCommit: 7ca252a5316512d024673614b5c361680c944daf
+---
+
+{{JSRef}}
+
+{{jsxref("Intl.DateTimeFormat")}} 인스턴스의 **`format()`** 메서드는 지역과 `Intl.DateTimeFormat` 객체의 형식 옵션에 맞는 날짜를 출력합니다.
+
+{{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-format.html", "taller")}}
+
+## 구문
+
+```js-nolint
+format(date)
+```
+
+### 매개변수
+
+- `date`
+  - : 형식을 지정할 날짜.
+
+### 반환 값
+
+지정된 `date`를 나타내는 문자열로, 이 {{jsxref("Intl.DateTimeFormat")}} 객체의 로케일 및 서식 옵션에 따라 형식이 지정됩니다.
+
+> **참고:** 대부분의 경우 `format()`이 반환하는 서식은 일관적입니다. 그러나 동일한 로케일 내에서도 구현에 따라 출력이 다를 수 있습니다. 출력 변형은 설계에 따른 것이며 사양에서 허용합니다. 또한 사용자의 예상과 다를 수도 있습니다. 예를 들어, 문자열이 줄 바꿈 없는 공백을 사용하거나 양방향 제어 문자로 둘러싸여 있을 수 있습니다. `format()`의 결과를 하드코딩된 상수와 비교해서는 안 됩니다.
+
+## 예제
+
+### format 사용하기
+
+단일 날짜의 서식을 지정하려면 `format` 접근자 함수를 사용합니다. 아래는 세르비아의 경우입니다.
+
+```js
+const options = {
+  weekday: "long",
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+};
+const dateTimeFormat = new Intl.DateTimeFormat("sr-RS", options);
+console.log(dateTimeFormat.format(new Date()));
+// "недеља, 7. април 2013."
+```
+
+### map과 함께 format 사용하기
+
+배열의 모든 날짜에 서식을 지정하려면 `format` 접근자 함수를 사용합니다.
+이 함수는 함수를 가져온 {{jsxref("Intl.DateTimeFormat")}}에 바인딩되어 있으므로
+{{jsxref("Array.prototype.map()")}}에 직접
+전달할 수 있습니다.
+
+```js
+const a = [new Date(2012, 8), new Date(2012, 11), new Date(2012, 3)];
+const options = { year: "numeric", month: "long" };
+const dateTimeFormat = new Intl.DateTimeFormat("pt-BR", options);
+const formatted = a.map(dateTimeFormat.format);
+console.log(formatted.join("; "));
+// "setembro de 2012; dezembro de 2012; abril de 2012"
+```
+
+### 형식이 지정된 날짜 값을 정적 값과 비교하지 않기
+
+대부분의 경우 `format()`이 반환하는 서식은 일관적입니다.
+그러나 이는 향후 변경될 수 있으며 모든 언어에 대해 보장되는 것은 아닙니다.
+설계에 따른 출력 변형은 사양에 따라 허용됩니다.
+특히 IE 와 Edge 브라우저는 날짜 주위에 양방향 제어 문자를 삽입하기 때문에 다른 텍스트와 연결할 때
+출력 텍스트가 제대로 흐릅니다.
+
+이러한 이유로 `format()`의 결과를 정적 값과 비교할 수 없습니다.
+
+```js example-bad
+let d = new Date("2019-01-01T00:00:00.000000Z");
+let formattedDate = Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
+}).format(d);
+
+"1.1.2019, 01:00:00" === formattedDate;
+// Firefox와 다른 곳에서는 true
+// IE와 Edge에서는 false
+```
+
+> **참고:** 보다 자세한 정보와 예제는 [StackOverflow 글타래](https://stackoverflow.com/questions/25574963/ies-tolocalestring-has-strange-characters-in-results)를
+> 참고하시기 바랍니다.
+
+## 명세서
+
+{{Specifications}}
+
+## 브라우저 호환성
+
+{{Compat}}
+
+## 같이 보기
+
+- {{jsxref("Intl.DateTimeFormat")}}
+- {{jsxref("Date.prototype.toLocaleString()")}}
+- {{jsxref("Date.prototype.toLocaleDateString()")}}
+- {{jsxref("Date.prototype.toLocaleTimeString()")}}

--- a/files/ko/web/javascript/reference/global_objects/string/trimstart/index.md
+++ b/files/ko/web/javascript/reference/global_objects/string/trimstart/index.md
@@ -1,30 +1,37 @@
 ---
 title: String.prototype.trimStart()
 slug: Web/JavaScript/Reference/Global_Objects/String/trimStart
+l10n:
+  sourceCommit: 27180875516cc311342e74b596bfb589b7211e0c
 ---
 
 {{JSRef}}
 
-**`trimStart()`** 메서드는 문자열 시작부분의 공백을 제거합니다. 또한 `trimLeft()`라는 별칭으로 호출이 가능합니다.
+{{jsxref("String")}} 값의 **`trimStart()`** 메서드는 이 문자열 시작 부분의 공백을 제거하고 기존 문자열의 수정 없이 새로운 문자열을 반환합니다. `trimLeft()`는 이 메서드의 별칭입니다.
+
 {{EmbedInteractiveExample("pages/js/string-trimstart.html")}}
 
 ## 구문
 
-```js
-trimStart();
+```js-nolint
+trimStart()
 
-trimLeft();
+trimLeft()
 ```
 
-### 반환값
+### 매개변수
 
-`str` 시작부분(왼쪽)에서 공백이 제거된 새 문자열을 반환합니다.
-`str` 에 공백이 없을시에도 에러가 발생하지 않고 여전히 새 문자열(본질적으로 `str` 의 복사본)이 반환됩니다.
+없음.
+
+### 반환 값
+
+시작 부분(왼쪽)에서 공백이 제거된 `str`을 나타내는 새 문자열입니다. 공백은 [공백](/ko/docs/Web/JavaScript/Reference/Lexical_grammar#white_space) 문자에 [줄 종결자](/ko/docs/Web/JavaScript/Reference/Lexical_grammar#line_terminators)를 더한 값으로 정의됩니다.
+
+`str`의 시작 부분에 공백이 없는 경우도 새 문자열이 반환됩니다(기본적으로 `str`의 복사본입니다).
 
 ### 별칭
 
-{{jsxref("String.prototype.padStart")}} 표준 메서드 이름과 같은 함수의 일관성을 위해서 `trimStart` 가 되었습니다.
-그러나, 웹 호환성을 위해서 `trimLeft` 이라는 별칭을 가집니다. 일부 엔진에서 이것은 다음 예시를 의미합니다.
+{{jsxref("String/trim", "trim()")}}가 표준화된 후, 엔진은 비표준 메서드인 `trimLeft`도 구현했습니다. 그러나 {{jsxref("String/padStart", "padStart()")}}와의 일관성을 위해 이 메서드가 표준화되었을 때 그 이름은 `trimStart`로 선택되었습니다. 웹 호환성을 위해 `trimLeft`는 `trimStart`의 별칭으로 남아 있으며, 완전히 동일한 함수 객체를 참조합니다. 일부 엔진에서는 이것이 의미하는 바가 있습니다.
 
 ```js
 String.prototype.trimLeft.name === "trimStart";
@@ -32,57 +39,18 @@ String.prototype.trimLeft.name === "trimStart";
 
 ## 예제
 
-### trimStart() 사용
+### trimStart() 사용하기
 
-다음 예제는 `'foo  '` 문자열을 표시합니다.
+다음 예제는 `str`의 시작부에 있는 공백을 제거하지만, 마지막의 공백은 제거하지 않습니다.
 
 ```js
-var str = "   foo  ";
+let str = "   foo  ";
 
 console.log(str.length); // 8
 
 str = str.trimStart();
 console.log(str.length); // 5
 console.log(str); // 'foo  '
-```
-
-## 폴리필
-
-```js
-//https://github.com/FabioVergani/js-Polyfill_String-trimStart
-
-(function (w) {
-  var String = w.String,
-    Proto = String.prototype;
-
-  (function (o, p) {
-    if (p in o ? (o[p] ? false : true) : true) {
-      var r = /^\s+/;
-      o[p] =
-        o.trimLeft ||
-        function () {
-          return this.replace(r, "");
-        };
-    }
-  })(Proto, "trimStart");
-})(window);
-
-/*
-ES6:
-(w=&gt;{
-    const String=w.String, Proto=String.prototype;
-
-    ((o,p)=&gt;{
-        if(p in o?o[p]?false:true:true){
-            const r=/^\s+/;
-            o[p]=o.trimLeft||function(){
-                return this.replace(r,'')
-            }
-        }
-    })(Proto,'trimStart');
-
-})(window);
-*/
 ```
 
 ## 명세서
@@ -95,6 +63,6 @@ ES6:
 
 ## 같이 보기
 
-- `String.prototype.trimStart` 의 폴리필은 [`core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)를 참고하세요.
+- [`core-js`에서의 `String.prototype.trimStart` 폴리필](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.trim()")}}
 - {{jsxref("String.prototype.trimEnd()")}}


### PR DESCRIPTION
- Intl.DateTimeFormat.prototype.format() 신규 번역
- String.prototype.trimStart() 최신화
