### PR TITLE
[ko] Intl.DateTimeFormat.prototype.formatRange() 신규 번역

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/intl/datetimeformat/formatrange/index.md
+++ b/files/ko/web/javascript/reference/global_objects/intl/datetimeformat/formatrange/index.md
@@ -1,0 +1,76 @@
+---
+title: Intl.DateTimeFormat.prototype.formatRange()
+slug: Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRange
+l10n:
+  sourceCommit: fb85334ffa4a2c88d209b1074909bee0e0abd57a
+---
+
+{{JSRef}}
+
+{{jsxref("Intl.DateTimeFormat")}} 인스턴스의 **`formatRange()`** 메서드는
+이 `Intl.DateTimeFormat` 객체를 인스턴스화할 때 제공되는
+로케일과 옵션을 기반으로 가장 간결한 방식으로
+날짜 범위의 형식을 맞춥니다.
+
+{{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-formatrange.html", "taller")}}
+
+## 구문
+
+```js-nolint
+formatRange(startDate, endDate)
+```
+
+### 매개변수
+
+- `startDate`
+  - : 날짜 범위의 시작을 나타내는 {{jsxref("Date")}} 객체입니다.
+- `endDate`
+  - : 날짜 범위의 끝을 나타내는 {{jsxref("Date")}} 객체입니다.
+
+### 반환 값
+
+{{jsxref("Intl.DateTimeFormat")}} 객체의 로케일 및 서식 옵션에 따라 형식이 맞춰진 지정된 날짜 범위를 나타내는 문자열입니다.
+
+## 예제
+
+### 기본적인 formatRange 사용
+
+이 메서드는 두 개의 {{jsxref("Date")}}를 받아서 {{jsxref("Intl.DateTimeFormat")}}을 초기화 할 때 주어진 `locales`와 `options`을 기반으로 가장 간결한 방법으로 날짜 범위의 형식을 맞춥니다.
+
+```js
+const date1 = new Date(Date.UTC(1906, 0, 10, 10, 0, 0)); // Wed, 10 Jan 1906 10:00:00 GMT
+const date2 = new Date(Date.UTC(1906, 0, 10, 11, 0, 0)); // Wed, 10 Jan 1906 11:00:00 GMT
+const date3 = new Date(Date.UTC(1906, 0, 20, 10, 0, 0)); // Sat, 20 Jan 1906 10:00:00 GMT
+
+const fmt1 = new Intl.DateTimeFormat("en", {
+  year: "2-digit",
+  month: "numeric",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+});
+console.log(fmt1.format(date1)); // '1/10/06, 10:00 AM'
+console.log(fmt1.formatRange(date1, date2)); // '1/10/06, 10:00 – 11:00 AM'
+console.log(fmt1.formatRange(date1, date3)); // '1/10/06, 10:00 AM – 1/20/07, 10:00 AM'
+
+const fmt2 = new Intl.DateTimeFormat("en", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+});
+console.log(fmt2.format(date1)); // 'Jan 10, 1906'
+console.log(fmt2.formatRange(date1, date2)); // 'Jan 10, 1906'
+console.log(fmt2.formatRange(date1, date3)); // 'Jan 10 – 20, 1906'
+```
+
+## 명세서
+
+{{Specifications}}
+
+## 브라우저 호환성
+
+{{Compat}}
+
+## 같이 보기
+
+- {{jsxref("Intl.DateTimeFormat")}}

--- a/files/ko/web/javascript/reference/global_objects/string/tolowercase/index.md
+++ b/files/ko/web/javascript/reference/global_objects/string/tolowercase/index.md
@@ -1,33 +1,43 @@
 ---
 title: String.prototype.toLowerCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toLowerCase
+l10n:
+  sourceCommit: c2445ce1dc3a0170e2fbfdbee10e18a7455c2282
 ---
 
-{{JSRef}}**`toLowerCase()`** 메서드는 문자열을 소문자로 변환해 반환합니다.{{EmbedInteractiveExample("pages/js/string-tolowercase.html")}}
+{{jsxref("String")}} 값의 **`toLowerCase()`** 메서드는 소문자로 변환된 이 문자열을 반환합니다.
+
+{{EmbedInteractiveExample("pages/js/string-tolowercase.html", "shorter")}}
 
 ## 구문
 
-```js
-str.toLowerCase();
+```js-nolint
+toLowerCase()
 ```
 
-### 반환값
+### 매개변수
 
-호출 문자열을 소문자로 변환한 새로운 문자열
+없음.
+
+### 반환 값
+
+소문자로 변환된 호출 문자열을 표현하는 새로운 문자열.
 
 ## 설명
 
-`toLowerCase()` 메서드는 호출 문자열을 소문자로 변환해 반환합니다. `toLowerCase()` 는 원래의 `str`에 영향을 주지 않습니다.
+`toLowerCase()` 메서드는 소문자로 변환된 문자열의
+값을 반환합니다. `toLowerCase()`는 문자열 `str` 자체의
+값에는 영향을 주지 않습니다.
 
 ## 예제
 
-### `toLowerCase()`
+### `toLowerCase()` 사용하기
 
 ```js
 console.log("ALPHABET".toLowerCase()); // 'alphabet'
 ```
 
-## 명세
+## 명세서
 
 {{Specifications}}
 
@@ -35,7 +45,7 @@ console.log("ALPHABET".toLowerCase()); // 'alphabet'
 
 {{Compat}}
 
-## 참조
+## 같이 보기
 
 - {{jsxref("String.prototype.toLocaleLowerCase()")}}
 - {{jsxref("String.prototype.toLocaleUpperCase()")}}


### PR DESCRIPTION
- Intl.DateTimeFormat.prototype.formatRange() 신규 번역
- String.prototype.toLowerCase() 최신화
