### PR TITLE
[ko] doublecolon target text 번역

### DIFF
--- a/files/ko/web/css/_doublecolon_target-text/index.md
+++ b/files/ko/web/css/_doublecolon_target-text/index.md
@@ -1,0 +1,51 @@
+---
+title: "::target-text"
+slug: Web/CSS/::target-text
+status:
+  - experimental
+l10n:
+  sourceCommit: 5fea7c9593f5e4b4ef13ec65064acf1eabf01e4e
+---
+
+{{CSSRef}}{{SeeCompatTable}}
+
+**`::target-text`** [CSS](/ko/docs/Web/CSS) [의사 요소](/ko/docs/Web/CSS/Pseudo-elements)는 브라우저가 [텍스트 조각](/ko/docs/Web/Text_fragments)을 지원하는 경우에 스크롤된 텍스트를 나타냅니다. 이는 작성자가 해당 텍스트의 일부를 강조하는 방법을 선택할 수 있게 합니다.
+
+```css
+::target-text {
+  background-color: pink;
+}
+```
+
+## 구문
+
+```css
+::target-text {
+  /* ... */
+}
+```
+
+## 예제
+
+### 텍스트 조각 강조하기
+
+```css
+::target-text {
+  background-color: rebeccapurple;
+  color: white;
+}
+```
+
+CSS의 동작 방식을 확인하려면 [scroll-to-text demo](https://mdn.github.io/css-examples/target-text/index.html#:~:text=From%20the%20foregoing%20remarks%20we%20may%20gather%20an%20idea%20of%20the%20importance) 링크를 방문해 보세요.
+
+## 명세서
+
+{{Specifications}}
+
+## 브라우저 호환성
+
+{{Compat}}
+
+## 같이 보기
+
+- [텍스트 조각](/ko/docs/Web/Text_fragments)

--- a/files/ko/web/css/_doublecolon_target-text/index.md
+++ b/files/ko/web/css/_doublecolon_target-text/index.md
@@ -1,8 +1,6 @@
 ---
 title: "::target-text"
 slug: Web/CSS/::target-text
-status:
-  - experimental
 l10n:
   sourceCommit: 5fea7c9593f5e4b4ef13ec65064acf1eabf01e4e
 ---


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

기존에 한국어로 존재하지 않던 문서 [::target-text](https://developer.mozilla.org/en-US/docs/Web/CSS/::target-text)를 번역합니다.

### Additional details

text fragment 는 직역하자면 텍스트의 파편인데 텍스트 조각으로 번역했어요. 
status 의 experimental flag 는 삭제하지 않고 그냥 두었는데, 맞는 건지 모르겠네요! 
리뷰 감사합니다. 

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
