### PR TITLE
VideoFrame: timestampプロパティの単位を修正

### DIFF
--- a/files/ja/web/api/videoframe/timestamp/index.md
+++ b/files/ja/web/api/videoframe/timestamp/index.md
@@ -8,7 +8,7 @@ l10n:
 
 {{APIRef("Web Codecs API")}}
 
-**`timestamp`** は {{domxref("VideoFrame")}} インターフェイスのプロパティで、動画のタイムスタンプをミリ秒単位で表す整数を返します。
+**`timestamp`** は {{domxref("VideoFrame")}} インターフェイスのプロパティで、動画のタイムスタンプをマイクロ秒単位で表す整数を返します。
 
 ## 値
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
原文ではmicrosecondsと表記されており、[W3Cのドラフトにもmicrosecondsと表記がある](https://w3c.github.io/webcodecs/#dom-videoframe-timestamp)ことから、現在の日本語訳が誤りであると判断し修正しました

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
