### PR TITLE
[ko] Symbol.asyncIterator 신규 번역 외

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/array/push/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/push/index.md
@@ -1,69 +1,131 @@
 ---
 title: Array.prototype.push()
 slug: Web/JavaScript/Reference/Global_Objects/Array/push
+l10n:
+  sourceCommit: 2d337c37fb3ae7d7a32b5c372366bc7f97ff2602
 ---
 
 {{JSRef}}
 
-**`push()`** 메서드는 배열의 끝에 하나 이상의 요소를 추가하고, 배열의 새로운 길이를 반환합니다.
+{{jsxref("Array")}} 인스턴스의 **`push()`** 메서드는 배열의 끝에
+명시된 요소를 추가하고 배열의 새로운 길이를 반환합니다.
 
 {{EmbedInteractiveExample("pages/js/array-push.html")}}
 
 ## 구문
 
-```js
-    arr.push(element1[, ...[, elementN]])
+```js-nolint
+push()
+push(element1)
+push(element1, element2)
+push(element1, element2, /* …, */ elementN)
 ```
 
 ### 매개변수
 
-- `elementN`
-  - : 배열의 끝에 추가할 요소.
+- `element1`, …, `elementN`
+  - : 배열의 끝에 추가할 요소(들).
 
 ### 반환 값
 
-호출한 배열의 새로운 {{jsxref("Array.length", "length")}} 속성.
+이 메서드가 호출된 객체의 새로운 {{jsxref("Array/length", "length")}} 속성.
 
 ## 설명
 
 `push` 메서드는 배열 끝에 여러 값을 추가합니다.
 
-`push`는 의도적으로 [제네릭](https://en.wikipedia.org/wiki/Generic_programming)합니다. 배열을 닯은 객체에 {{jsxref("Function.call", "call()")}} 또는 {{jsxref("Function.apply", "apply()")}}로 사용될 수 있다. `push` 메서드는 주어진 값을 입력하는 것을 어디에 시작할 것인지를 결정하기 위해 `length` 속성에 의존한다. 만약 `length` 속성이 숫자로 변환 될 수 없다면 인덱스는 0을 사용한다. `length` 가 생성되게 될 경우에 길이 값이 존재하지 않을 가능성을 포함한다.
+{{jsxref("Array.prototype.unshift()")}}는 `push()`의 동작과 비슷하지만 배열의 시작 부분에 적용됩니다.
 
-String(문자열)이 변경할 수 없는 것처럼 비록 이 명령어의 어플리케이션들이 적합하지 않다고 할지라도 단지 원래 배열 같은 객체는 {{jsxref("Global_Objects/String", "strings", "", 1)}}이다.
+`push()` 메서드는 [변이 메서드](/ko/docs/Web/JavaScript/Reference/Global_Objects/Array#복사_메서드와_변경_메서드mutating_method)입니다. 이 메서드는 `this`의 길이와 내용을 변경합니다. `this`의 값은 동일하게 유지하지만 끝에 요소가 추가된 새로운 배열을 반환하길 원한다면 [`arr.concat([element0, element1, /* ... ,*/ elementN])`]을 대신 사용할 수 있습니다. 그렇지 않으면 요소 자체가 배열인 경우 `concat()`의 동작으로 인해 요소가 단일 요소로 푸시되는 대신 분산된다는 점에 유의하시기 바랍니다.
+
+`push()`는 [범용](/ko/docs/Web/JavaScript/Reference/Global_Objects/Array#범용_배열_메서드) 메서드입니다. 오직 `this` 값이 `length` 속성과 숫자 키 속성만 가지고 있을 것을 기대합니다. 문자열이 배열과 유사하긴 하지만, 문자열은 불변이기 때문에 이 메서드는 문자열에는 어울리지 않습니다.
 
 ## 예시
 
-### 배열에 엘리먼트를 추가 하기
+### 배열에 요소 추가하기
 
-다음 코드는 두가지 엘리먼트를 포함하는 스포츠 배열을 생성하고 두개의 엘리먼트를 추가 한다. `total` 변수는 추가한 배열의 새 길이 값을 포함한다.
+다음 코드는 2개의 요소를 가진 `sports` 배열을 생성하고 2개의 요소를 추가합니다. `total` 변수는 이 배열의 새로운 길이를 가집니다.
 
 ```js
-var sports = ["축구", "야구"];
-var total = sports.push("미식축구", "수영");
+const sports = ["soccer", "baseball"];
+const total = sports.push("football", "swimming");
 
-console.log(sports); // ['축구', '야구', '미식축구', '수영']
+console.log(sports); // ['soccer', 'baseball', 'football', 'swimming']
 console.log(total); // 4
 ```
 
-### 두개의 배열을 합치기
+### 두 개의 배열을 합치기
 
-이 예제는 두번째 배열의 모든 엘리먼트를 push 하기 위해 {{jsxref("Function.apply", "apply()")}}를 사용한다.
-
-만약 두번째 배열( 아래 예제에서는 moreVegs )이 매우 클 경우, 이 메소드를 사용하지 말아야 한다. 실제로 한 함수가 사용가능한 매개변수의 최대 개수에는 제한이 있기 때문이다. 더 자세한 사항은 {{jsxref("Function.apply", "apply()")}} 에서 찾아볼 수 있다.
+아래 예제는 {{jsxref("Operators/Spread_syntax", "spread syntax", "", 1)}}를 사용하여
+두 번째 배열의 모든 요소를 첫 번째에 넣습니다.
 
 ```js
-var vegetables = ["설탕당근", "감자"];
-var moreVegs = ["셀러리", "홍당무"];
+const vegetables = ["parsnip", "potato"];
+const moreVegs = ["celery", "beetroot"];
 
-// 첫번째 배열에 두번째 배열을 합친다.
-// vegetables.push('셀러리', '홍당무'); 하는 것과 동일하다.
-Array.prototype.push.apply(vegetables, moreVegs);
+// 두 번째 배열을 첫 번째 배열로 합칩니다
+vegetables.push(...moreVegs);
 
-console.log(vegetables); // ['설탕당근', '감자', '셀러리', '홍당무']
+console.log(vegetables); // ['parsnip', 'potato', 'celery', 'beetroot']
 ```
 
-## 명세
+{{jsxref("Array/concat", "concat()")}}을 사용해서도 두 배열을 합칠 수 있습니다.
+
+### 배열이 아닌 객체에 push() 호출하기
+
+`push()` 메서드는 `this`의 `length` 속성을 읽습니다. 그런 다음, `push()`에 전달된 인수들을 이용해 `this`의 `length`부터 각 인덱스에 값을 설정합니다. 마지막으로, 이전 `length`에 추가된 요소의 개수를 더하여 `length`를 설정합니다.
+
+```js
+const arrayLike = {
+  length: 3,
+  unrelated: "foo",
+  2: 4,
+};
+Array.prototype.push.call(arrayLike, 1, 2);
+console.log(arrayLike);
+// { '2': 4, '3': 1, '4': 2, length: 5, unrelated: 'foo' }
+
+const plainObj = {};
+// length 속성이 없으므로 길이는 0입니다.
+Array.prototype.push.call(plainObj, 1, 2);
+console.log(plainObj);
+// { '0': 1, '1': 2, length: 2 }
+```
+
+### 유사 배열과 방식으로 객체 사용하기
+
+위에서 언급했듯이 `push`는 의도적으로 범용이며, 이를 유리하게 사용할 수 있습니다.
+이 예시에서 볼 수 있듯이 `Array.prototype.push`는
+객체에서 잘 작동합니다.
+
+객체 컬렉션을 저장하기 위해 배열을 만들지 않는다는 점에 유의하시기 바랍니다.
+대신 객체 자체에 컬렉션을 저장하고 `Array.prototype.push`에서
+`call`을 사용하여 메서드가 배열을 다루고 있다고 생각하도록 속입니다.
+이는 JavaScript가 원하는 방식으로 실행 맥락을
+설정할 수 있는 방식 덕분에 작동합니다.
+
+```js
+const obj = {
+  length: 0,
+
+  addElem(elem) {
+    // obj.length는 요소가 추가 될때마다
+    // 자동으로 증가합니다.
+    [].push.call(this, elem);
+  },
+};
+
+// 설명을 위해 빈 객체를 몇 개 추가해 보겠습니다.
+obj.addElem({});
+obj.addElem({});
+console.log(obj.length); // 2
+```
+
+`obj`가 배열이 아님에도, 실제 배열을 다루는 것 처럼
+`push` 메서드가 성공적으로 `obj`의 `length` 속성을
+증가시킨 것을 주목하시기 바랍니다.
+
+## 명세서
 
 {{Specifications}}
 
@@ -73,7 +135,11 @@ console.log(vegetables); // ['설탕당근', '감자', '셀러리', '홍당무']
 
 ## 같이 보기
 
+- [이 메서드를 고친 `core-js`에서의 `Array.prototype.push` 폴리필](https://github.com/zloirock/core-js#ecmascript-array)
+- [인덱스 기반](/ko/docs/Web/JavaScript/Guide/Indexed_collections) 안내서
+- {{jsxref("Array")}}
 - {{jsxref("Array.prototype.pop()")}}
 - {{jsxref("Array.prototype.shift()")}}
 - {{jsxref("Array.prototype.unshift()")}}
 - {{jsxref("Array.prototype.concat()")}}
+- {{jsxref("Array.prototype.splice()")}}

--- a/files/ko/web/javascript/reference/global_objects/symbol/asynciterator/index.md
+++ b/files/ko/web/javascript/reference/global_objects/symbol/asynciterator/index.md
@@ -1,0 +1,64 @@
+---
+title: Symbol.asyncIterator
+slug: Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator
+l10n:
+  sourceCommit: 6e93ec8fc9e1f3bd83bf2f77e84e1a39637734f8
+---
+
+{{JSRef}}
+
+**`Symbol.asyncIterator`** 정적 데이터 속성은 [잘 알려진 심볼](/ko/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `Symbol.asyncIterator`를 나타냅니다.
+[비동기 순회 프로토콜](/ko/docs/Web/JavaScript/Reference/Iteration_proocols#the_async_iterator_and_async_iterable_proocols)은 객체에 대한 비동기 반복기를 반환하는 메서드에 대해 이 심볼을 검색합니다. 객체가 비동기 순회가 되려면 `Symbol.asyncIterator` 키가 있어야 합니다.
+
+{{EmbedInteractiveExample("pages/js/symbol-asynciterator.html", "taller")}}
+
+## 값
+
+잘 알려진 심볼 `Symbol.asyncIterator`.
+
+{{js_property_attributes(0, 0, 0)}}
+
+## 예제
+
+### 사용자 정의 비동기 순회
+
+객체에 `[Symbol.asyncIterator]` 속성을 설정하여 자신만의 비동기 순회를 정의할 수 있습니다.
+
+```js
+const myAsyncIterable = {
+  async *[Symbol.asyncIterator]() {
+    yield "hello";
+    yield "async";
+    yield "iteration!";
+  },
+};
+
+(async () => {
+  for await (const x of myAsyncIterable) {
+    console.log(x);
+  }
+})();
+// Logs:
+// "hello"
+// "async"
+// "iteration!"
+```
+
+API를 만들 때 비동기 순회는 대부분의 상황에서 콜백이나 이벤트를 완전히 대체하는 것이 아니라 데이터 스트림이나 목록과 같이 순회를 표현하도록 설계되었음을 기억하시기 바랍니다.
+
+### 내장 비동기 순회
+
+핵심 JavaScript 언어에는 비동기 순회 가능한 객체가 없습니다. {{domxref("ReadableStream")}}와 같은 일부 웹 API에는 기본적으로 `Symbol.asyncIterator` 메서드가 설정되어 있습니다.
+
+## 명세서
+
+{{Specifications}}
+
+## 브라우저 호환성
+
+{{Compat}}
+
+## 같이 보기
+
+- [순회 프로토콜](/ko/docs/Web/JavaScript/Reference/Iteration_protocols)
+- [for await...of](/ko/docs/Web/JavaScript/Reference/Statements/for-await...of)


### PR DESCRIPTION
- Symbol.asyncIterator 신규 번역
- Array.prototype.push() 최신화

~다음은 (Commit: 6e93ec8fc9e1f3bd83bf2f77e84e1a39637734f8) 중 Symbol 일부 대응. `@@` -> `Symbol.`~
~- Symbol.isConcatSpreadable~
~- Symbol.match~
~- Symbol.split~
~- Symbol.toPrimitive~
~- Symbol.toStringTag~