### PR TITLE
[ko] RegExp.leftContext ($`) 신규 번역 외

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/regexp/leftcontext/index.md
+++ b/files/ko/web/javascript/reference/global_objects/regexp/leftcontext/index.md
@@ -1,0 +1,49 @@
+---
+title: RegExp.leftContext ($`)
+slug: Web/JavaScript/Reference/Global_Objects/RegExp/leftContext
+l10n:
+  sourceCommit: fb85334ffa4a2c88d209b1074909bee0e0abd57a
+---
+
+{{JSRef}} {{Deprecated_Header}}
+
+> **참고:** 마지막 일치 상태를 전역적으로 노출하는 모든 `RegExp` 정적 속성은 더 이상 사용되지 않습니다. 자세한 내용은 [더 이상 사용되지 않는 RegExp 기능](/ko/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#regexp)을 참고하세요.
+
+**`RegExp.leftContext`** 정적 접근자 속성은 가장 최근 일치 항목 앞에 있는 하위 문자열을 반환합니다. ``RegExp["$`"]``는 이 속성의 별칭입니다.
+
+## 설명
+
+`leftContext`는 {{jsxref("RegExp")}}의 정적 속성이기 때문에, 생성한 `RegExp` 객체의 속성으로 사용하는 것보다는 항상 `RegExp.leftContext` 또는 ``RegExp["$`"]``로 사용해야 합니다.
+
+`leftContext`의 값은 `RegExp`(`RegExp` 하위 클래스 제외) 인스턴스가 일치에 성공할 때마다 갱신됩니다. 일치하는 항목이 없으면 `leftContext`는 빈 문자열입니다. `leftContext`의 설정 접근자는 `undefined`이므로 이 속성을 직접 변경할 수 없습니다.
+
+`` ` ``는 유효한 식별자 부분이 아니므로 점 속성 접근자(``RegExp.$` ``)와 함께 약칭을 사용할 수 없으며 이로 인해 {{jsxref("SyntaxError")}}가 발생합니다. 대신 [대괄호 표기법](/ko/docs/Web/JavaScript/Reference/Operators/Property_accessors)을 사용하시기 바랍니다.
+
+``$` ``는 {{jsxref("String.prototype.replace()")}}의 대체 문자열에도 사용할 수 있지만, 이는 ``RegExp["$`"]`` 레거시 속성과는 관련이 없습니다.
+
+## 예제
+
+### leftContext와 $\` 사용하기
+
+```js
+const re = /world/g;
+re.test("hello world!");
+RegExp.leftContext; // "hello "
+RegExp["$`"]; // "hello "
+```
+
+## 명세서
+
+{{Specifications}}
+
+## 브라우저 호환성
+
+{{Compat}}
+
+## 같이 보기
+
+- {{jsxref("RegExp/input", "RegExp.input ($_)")}}
+- {{jsxref("RegExp/lastMatch", "RegExp.lastMatch ($&amp;)")}}
+- {{jsxref("RegExp/lastParen", "RegExp.lastParen ($+)")}}
+- {{jsxref("RegExp/rightContext", "RegExp.rightContext ($')")}}
+- {{jsxref("RegExp/n", "RegExp.$1, …, RegExp.$9")}}

--- a/files/ko/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/ko/web/javascript/reference/global_objects/string/slice/index.md
@@ -2,7 +2,7 @@
 title: String.prototype.slice()
 slug: Web/JavaScript/Reference/Global_Objects/String/slice
 l10n:
-  sourceCommit: 4406757f6bb4404b5309756bac2acb994c169e40
+  sourceCommit: 5f08178b7c2c97b15dd5d6483580fd70abd5169a
 ---
 
 {{JSRef}}
@@ -50,7 +50,7 @@ slice(indexStart, indexEnd)
 - `indexStart >= str.length`이라면, 빈 문자열이 반환됩니다.
 - `indexStart < 0`이라면, 문자열의 끝부터 인덱스를 셉니다. 보다 공식적으로 말하자면 이 경우, 하위 문자열은 `max(indexStart + str.length, 0)`에서 시작합니다.
 - `indexStart`가 생략되었거나 정의되지 않았거나 [숫자로 변환](/ko/docs/Web/JavaScript/Reference/Global_Objects/Number#number_coercion)할 수 없는 경우, `0`으로 처리됩니다.
-- `indexEnd`가 생략되었거나, 정의되지 않았거나, [숫자로 변환](/ko/docs/Web/JavaScript/Reference/Global_Objects/Number#number_coercion)할 수 없는 경우 또는 `indexEnd >= str.length`이면 `slice()`는 문자열 끝으로 추출합니다.
+- `indexEnd`가 생략되었거나 혹은 정의되지 않았거나 혹은 `indexEnd >= str.length`이면 `slice()`는 문자열 끝으로 추출합니다.
 - `indexEnd < 0`이면 문자열의 끝부터 인덱스를 셉니다. 보다 공식적으로 말하자면 이 경우, 하위 문자열은 `max(indexEnd + str.length, 0)`에서 끝납니다.
 - 음수 값을 정규화한 후 (즉, `indexEnd`가 `indexStart` 앞에 있는 문자를 나타내는 경우) `indexEnd <= indexStart`인 경우 빈 문자열이 반환됩니다.
 

--- a/files/ko/web/javascript/reference/global_objects/string/substr/index.md
+++ b/files/ko/web/javascript/reference/global_objects/string/substr/index.md
@@ -1,85 +1,67 @@
 ---
 title: String.prototype.substr()
 slug: Web/JavaScript/Reference/Global_Objects/String/substr
+l10n:
+  sourceCommit: c2445ce1dc3a0170e2fbfdbee10e18a7455c2282
 ---
 
-{{JSRef}}
+{{JSRef}} {{Deprecated_Header}}
 
-> **경고:** 경고: 엄밀히 말해서 `String.prototype.substr()` 메서드가 더 이상 사용되지 않는, 즉 "웹 표준에서 제거된" 건 아닙니다. 그러나 `substr()`이 포함된 ECMA-262 표준의 [부록 B](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-additional-ecmascript-features-for-web-browsers)는 다음과 같이 명시하고 있습니다.> … 본 부록이 포함한 모든 언어 기능과 행동은 하나 이상의 바람직하지 않은 특징을 갖고 있으며 사용처가 없어질 경우 명세에서 제거될 것입니다. …
->
-> > … 프로그래머는 새로운 ECMAScript 코드를 작성할 때 본 부록이 포함한 기능을 사용하거나 존재함을 가정해선 안됩니다. …
+{{jsxref("String")}} 값의 **`substr()`** 메서드는 지정된 인덱스에서 시작하여 그 다음에 지정된 문자 수만큼 확장되는 이 문자열의 일부를 반환합니다.
 
-**`substr()`** 메서드는 문자열에서 특정 위치에서 시작하여 특정 문자 수 만큼의 문자들을 반환합니다.
+> **참고:** `substr()`은 기본 ECMAScript 명세의 일부가 아니며, 비브라우저 런타임에 대한 권장 선택 사항인[부록 B: 웹 브라우저용 추가 ECMAScript 기능](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html)에 정의되어 있습니다. 그러므로 코드를 최대한 크로스 플랫폼 친화적으로 만들려면 표준 [`String.prototype.substring()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/String/substring) 그리고 [`String.prototype.slice()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/String/slice) 메서드를 대신 사용을 권장합니다. [`String.prototype.substring()` 페이지](/ko/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr)에는 세 가지 메서드 간의 비교가 나와 있습니다.
 
 {{EmbedInteractiveExample("pages/js/string-substr.html")}}
 
 ## 구문
 
-```js
-str.substr(start[, length])
+```js-nolint
+substr(start)
+substr(start, length)
 ```
 
 ### 매개변수
 
 - `start`
-  - : 추출하고자 하는 문자들의 시작위치입니다. 만약 음수가 주어진다면, `문자열총길이 + start`의 값으로 취급합니다. 예를 들면, `start`에 -3을 설정하면, 자동적으로 `문자열총길이 - 3`으로 설정하게 됩니다.
-- `length`
-  - : 옵션값. 추출할 문자들의 총 숫자.
+  - : 반환된 부분 문자열에 포함할 첫 번째 문자의 인덱스입니다.
+- `length` {{optional_inline}}
+  - : 추출할 문자 수입니다.
+
+### 반환 값
+
+주어진 문자열의 지정된 부분을 포함하는 새 문자열입니다.
 
 ## 설명
 
-`start` 는 문자 인덱스입니다. 문자열에서 첫 번째 문자의 인덱스는 0이며, 마지막 문자의 인덱스는 문자열 전체 길이에서 1을 뺀 값입니다. `substr()` 는 `start` 에서 문자들을 추출을 시작하여 `length` 만큼 문자들을 수집합니다.
+문자열의 `substr()` 메서드는 `start` 인덱스부터 `length` 만큼의 문자를 추출합니다.
 
-만약 `start` 값이 양수이고 문자열 전체 길이보다 크거가 같을 경우, `substr()`은 빈 문자열을 반환합니다.
+- `start >= str.length`이면 빈 문자열이 반환됩니다.
+- `start < 0`이면 인덱스는 문자열의 끝부터 카운트를 시작합니다. 보다 공식적으로는 이 경우 하위 문자열은 `max(start + str.length, 0)`에서 시작합니다.
+- `start`가 생략되거나 {{jsxref("undefined")}}가 있으면 `start`는 `0`으로 처리됩니다.
+- `length`가 생략되거나 {{jsxref("undefined")}}인 경우 혹은 `start + length >= str.length`인 경우 `substr()`은 문자열의 끝 부분까지 문자를 추출합니다.
+- `length < 0`이면 빈 문자열이 반환됩니다.
+- `start`와 `length` 모두에 대해 {{jsxref("NaN")}}는 `0`으로 처리됩니다.
 
-만약 `start`가 음수이면, `substr()`은 문자열 끝에서 `start` 숫자만큼 뺀 곳에서 시작하게 됩니다. 만약 `start`가 음수이고 절대값이 문자열 전체보다 크다면, `substr()`은 문자열의 0 인덱스부터 시작하게 됩니다. (주의: `start`의 음수값은 Microsoft JScript에서는 위의 설명과 같이 동작하지 않습니다.)
-
-만약 `length`가 0 혹은 음수이면, `substr()`은 빈 문자열을 반환합니다. 만약 `length`가 생략되면, `substr()`은 문자열의 끝까지 추출하여 반환합니다.
+`substr()` 사용을 피하는 것이 좋지만, 기본적으로 `substr()`에 대한 폴리필을 작성하지 않고도 레거시 코드에서 `substr()`을 `slice()` 또는 `substring()`으로 마이그레이션하는 간단한 방법은 없습니다. 예를 들어, `str = "01234", a = 1, l = -2`인 경우 `str.substr(a, l)`, `str.slice(a, a + l)`, `str.substring(a, a + l)`는 모두 다른 결과를 반환하지만, `substr()`는 빈 문자열을 반환하고 `slice()`는 `"123"`을 반환하지만 `substring()`는 `"0"`을 반환합니다. 실제 리팩토링 방법은 `a`와 `l`의 범위에 대한 지식에 따라 달라집니다.
 
 ## 예제
 
-### `substr()` 사용하기
+### substr() 사용하기
 
 ```js
-var str = "abcdefghij";
+const aString = "Mozilla";
 
-console.log("(1, 2): " + str.substr(1, 2)); // '(1, 2): bc'
-console.log("(-3, 2): " + str.substr(-3, 2)); // '(-3, 2): hi'
-console.log("(-3): " + str.substr(-3)); // '(-3): hij'
-console.log("(1): " + str.substr(1)); // '(1): bcdefghij'
-console.log("(-20, 2): " + str.substr(-20, 2)); // '(-20, 2): ab'
-console.log("(20, 2): " + str.substr(20, 2)); // '(20, 2): '
+console.log(aString.substr(0, 1)); // 'M'
+console.log(aString.substr(1, 0)); // ''
+console.log(aString.substr(-1, 1)); // 'a'
+console.log(aString.substr(1, -1)); // ''
+console.log(aString.substr(-3)); // 'lla'
+console.log(aString.substr(1)); // 'ozilla'
+console.log(aString.substr(-20, 2)); // 'Mo'
+console.log(aString.substr(20, 2)); // ''
 ```
 
-## 폴리필
-
-Microsoft의 JScript는 시작 인덱스에서 음수값을 지원하지 않습니다. 만약 여러분이 이렇게 동작하길 원한다면, 아래 코드를 사용하여 해결할 수 있습니다:
-
-```js
-// only run when the substr() function is broken
-if ("ab".substr(-1) != "b") {
-  /**
-   *  Get the substring of a string
-   *  @param  {integer}  start   where to start the substring
-   *  @param  {integer}  length  how many characters to return
-   *  @return {string}
-   */
-  String.prototype.substr = (function (substr) {
-    return function (start, length) {
-      // call the original method
-      return substr.call(
-        this,
-        // did we get a negative start, calculate how much it is from the beginning of the string
-        // adjust the start parameter for negative value
-        start < 0 ? this.length + start : start,
-        length,
-      );
-    };
-  })(String.prototype.substr);
-}
-```
-
-## 명세
+## 명세서
 
 {{Specifications}}
 
@@ -89,5 +71,6 @@ if ("ab".substr(-1) != "b") {
 
 ## 같이 보기
 
+- [`core-js`의 `String.prototype.substr` 폴리필](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.slice()")}}
 - {{jsxref("String.prototype.substring()")}}


### PR DESCRIPTION
- RegExp.leftContext ($`) 신규 번역
- String.prototype.slice() 최신화
- String.prototype.substr() 최신화
