### PR TITLE
[ko] fix typo

### DIFF
--- a/files/ko/webassembly/c_to_wasm/index.md
+++ b/files/ko/webassembly/c_to_wasm/index.md
@@ -42,7 +42,7 @@ Emscripten SDK를 설치하기 위해, 아래 설명을 참고하세요.
    }
    ```
 
-2. Emscripten 컴파일 환경에 접속하는 데 사용한 terminal을 통ㅇ해 hello.c 파일과 동일한 폴더로 이동한 후 다음 명령을 실행하세요.
+2. Emscripten 컴파일 환경에 접속하는 데 사용한 terminal을 통해 hello.c 파일과 동일한 폴더로 이동한 후 다음 명령을 실행하세요.
 
    ```bash
    emcc hello.c -o hello.html


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
`c_to_wasm`부분에 오타를 수정했습니다.
(in the `c_to_wasm` section fixed typo)
- before: **통ㅇ해**
- after: **통해**

<img width="1159" alt="image" src="https://github.com/user-attachments/assets/2b680cfa-9d6e-4de7-892f-313473912e34">


### Motivation
오타는 읽는 사람에게 정확하지 못한 정보를 전달할 수 있는 우려가 있습니다.