### PR TITLE
feat(actions): ko-locale label email noti webhooks

### DIFF
--- a/.github/workflows/issue-label-mailer.yml
+++ b/.github/workflows/issue-label-mailer.yml
@@ -34,5 +34,5 @@ jobs:
           # Mail
           subject: "[l10n-ko] ${{ github.event.issue.title }}"
           body: "Issue URL: ${{ github.event.issue.html_url }}\n\nBody:\n${{env.TRIMMED_BODY}}"
-          to: ${{ secrets.EMAIL_USERNAME }}
+          to: yari-content-ko@googlegroups.com
           from: yari-content-ko

--- a/.github/workflows/issue-label-mailer.yml
+++ b/.github/workflows/issue-label-mailer.yml
@@ -1,0 +1,38 @@
+name: Issue Label Mailer
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  send_notification:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trim issue body to 3 lines
+        if: github.event.label.name == 'l10n-ko'
+        run: |
+          echo "${{ github.event.issue.body }}" | head -n 3 > trimmed_body.txt
+          echo "TRIMMED_BODY<<EOF" >> $GITHUB_ENV
+          while IFS= read -r line; do
+            echo "$line" >> $GITHUB_ENV
+          done < trimmed_body.txt
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Send Email Notification
+        if: github.event.label.name == 'l10n-ko'
+        uses: dawidd6/action-send-mail@v3
+        env:
+          TRIMMED_BODY: ${{ env.TRIMMED_BODY }}
+        with:
+          secure: true
+          server_address: smtp.gmail.com
+          server_port: 465
+          # user credentials
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          # Mail
+          subject: "[l10n-ko] ${{ github.event.issue.title }}"
+          body: "Issue URL: ${{ github.event.issue.html_url }}\n\nBody:\n${{env.TRIMMED_BODY}}"
+          to: ${{ secrets.EMAIL_USERNAME }}
+          from: yari-content-ko


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description


Suggestions for receiving notifications about issues assigned to the ko-locale team. (Email, Discord, etc..) There is currently no way to receive notifications.

Send a notification when the l10n-ko label is attached.

This PR is related to https://github.com/mdn/translated-content/pull/22297 

cc. @mdn/yari-content-ko 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Email content:

```
The above issue was recently published under [ko] label.

I haven't received any emails/notifications regarding this, so I'm leaving an inquiry because I'm curious about how other people can check.

If you need to check it manually, it would be a good idea to add our team mention to the ko issue template itself.
```

- https://groups.google.com/g/yari-content-ko/c/Ro49amZT-fU

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

I do not have permission to set the following secrets, so you need to set this.

- ${{ secrets.EMAIL_USERNAME }}
- ${{ secrets.EMAIL_PASSWORD }}
- Tested in https://github.com/1ilsang/dev/actions/runs/9959871940/job/27517711718

<img width="776" alt="image" src="https://github.com/user-attachments/assets/cdfd9ad8-c9b3-42f5-8b80-03a760b569a5">

- https://github.com/1ilsang/dev/issues/304

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

Relates to #22297
