### PR TITLE
[ko] CSS_font_loading 신규 번역

### DIFF
--- a/files/ko/web/css/css_font_loading/index.md
+++ b/files/ko/web/css/css_font_loading/index.md
@@ -1,0 +1,45 @@
+---
+title: CSS font loading
+slug: Web/CSS/CSS_font_loading
+l10n:
+  sourceCommit: fe5361c29eab373c0b60d07bb86dbf0048220110
+---
+
+{{CSSRef}}
+
+**CSS font loading**은 글꼴 관련 리소스를 동적으로 로드하는 데 사용되는 이벤트와 인터페이스를 설명하는 모듈입니다.
+
+## 참고서
+
+### 인터페이스
+
+- {{domxref("fontFace")}} 
+  - [`FontFace()`](/en-US/docs/Web/API/FontFace/FontFace) 
+  - {{domxref("fontFace.family")}} 
+  - {{domxref("fontFace.style")}} 
+  - {{domxref("fontFace.weight")}} 
+  - {{domxref("fontFace.stretch")}} 
+  - {{domxref("fontFace.unicodeRange")}} 
+  - {{domxref("fontFace.variant")}} 
+  - {{domxref("fontFace.featureSettings")}} 
+  - {{domxref("fontFace.variationSettings")}} 
+  - {{domxref("fontFace.display")}} 
+  - {{domxref("fontFace.ascentOverride")}} 
+  - {{domxref("fontFace.descentOverride")}} 
+  - {{domxref("fontFace.lineGapOverride")}} 
+  - {{domxref("fontFace.load()")}} 
+- {{domxref("fontFaceSet")}} 
+- {{domxref("fontFaceSetLoadEvent")}} 
+
+## 가이드
+
+- [CSS font loading API](/en-US/docs/Web/API/CSS_Font_Loading_API)
+  - : 글꼴 리소스를 동적으로 로드하기 위한 이벤트와 인터페이스를 제공하는 CSS 글꼴 로딩 API에 대한 설명입니다.
+
+## 명세서
+
+{{Specifications}}
+
+## 같이 보기
+
+- [CSS fonts](/ko/docs/Web/CSS/CSS_fonts) 모듈


### PR DESCRIPTION

Description
CSS 문서 안에 있는 CSS_font_loading 번역을 진행했습니다. ([원문 깃허브 링크](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_font_loading/index.md), [원문 MDN 링크](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_font_loading))

Motivation
Additional details
Related issues and pull requests