### PR TITLE
[ko] CSS_font_loading 신규 번역

### DIFF
--- a/files/ko/web/css/css_font_loading/index.md
+++ b/files/ko/web/css/css_font_loading/index.md
@@ -1,0 +1,45 @@
+---
+title: CSS font loading
+slug: Web/CSS/CSS_font_loading
+l10n:
+  sourceCommit: fe5361c29eab373c0b60d07bb86dbf0048220110
+---
+
+{{CSSRef}}
+
+**CSS font loading**은 글꼴 관련 리소스를 동적으로 로드하는 데 사용되는 이벤트와 인터페이스를 설명하는 모듈입니다.
+
+## 참고서
+
+### 인터페이스
+
+- {{domxref("fontFace")}} 
+  - [`FontFace()`](/en-US/docs/Web/API/FontFace/FontFace) 
+  - {{domxref("fontFace.family")}} 
+  - {{domxref("fontFace.style")}} 
+  - {{domxref("fontFace.weight")}} 
+  - {{domxref("fontFace.stretch")}} 
+  - {{domxref("fontFace.unicodeRange")}} 
+  - {{domxref("fontFace.variant")}} 
+  - {{domxref("fontFace.featureSettings")}} 
+  - {{domxref("fontFace.variationSettings")}} 
+  - {{domxref("fontFace.display")}} 
+  - {{domxref("fontFace.ascentOverride")}} 
+  - {{domxref("fontFace.descentOverride")}} 
+  - {{domxref("fontFace.lineGapOverride")}} 
+  - {{domxref("fontFace.load()")}} 
+- {{domxref("fontFaceSet")}} 
+- {{domxref("fontFaceSetLoadEvent")}} 
+
+## 가이드
+
+- [CSS font loading API](/en-US/docs/Web/API/CSS_Font_Loading_API)
+  - : 글꼴 리소스를 동적으로 로드하기 위한 이벤트와 인터페이스를 제공하는 CSS 글꼴 로딩 API에 대한 설명입니다.
+
+## 명세서
+
+{{Specifications}}
+
+## 같이 보기
+
+- [CSS fonts](/ko/docs/Web/CSS/CSS_fonts) 모듈

--- a/files/ko/web/css/css_font_loading/index.md
+++ b/files/ko/web/css/css_font_loading/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{CSSRef}}
 
-**CSS font loading**은 글꼴 관련 리소스를 동적으로 로드하는 데 사용되는 이벤트와 인터페이스를 설명하는 모듈입니다.
+**CSS 글꼴 로딩**은 글꼴 관련 리소스를 동적으로 로드하는 데 사용되는 이벤트와 인터페이스를 설명하는 모듈입니다.
 
 ## 참고서
 
@@ -31,9 +31,9 @@ l10n:
 - {{domxref("fontFaceSet")}} 인터페이스
 - {{domxref("fontFaceSetLoadEvent")}} 이벤트
 
-## 가이드
+## 안내서
 
-- [CSS font loading API](/ko/docs/Web/API/CSS_Font_Loading_API)
+- [CSS 글꼴 로딩 API](/ko/docs/Web/API/CSS_Font_Loading_API)
   - : 글꼴 리소스를 동적으로 로드하기 위한 이벤트와 인터페이스를 제공하는 CSS 글꼴 로딩 API에 대한 설명입니다.
 
 ## 명세서
@@ -42,4 +42,4 @@ l10n:
 
 ## 같이 보기
 
-- [CSS fonts](/ko/docs/Web/CSS/CSS_fonts) 모듈
+- [CSS 폰트](/ko/docs/Web/CSS/CSS_fonts) 모듈

--- a/files/ko/web/css/css_font_loading/index.md
+++ b/files/ko/web/css/css_font_loading/index.md
@@ -13,27 +13,27 @@ l10n:
 
 ### 인터페이스
 
-- {{domxref("fontFace")}} 
-  - [`FontFace()`](/en-US/docs/Web/API/FontFace/FontFace) 
-  - {{domxref("fontFace.family")}} 
-  - {{domxref("fontFace.style")}} 
-  - {{domxref("fontFace.weight")}} 
-  - {{domxref("fontFace.stretch")}} 
-  - {{domxref("fontFace.unicodeRange")}} 
-  - {{domxref("fontFace.variant")}} 
-  - {{domxref("fontFace.featureSettings")}} 
-  - {{domxref("fontFace.variationSettings")}} 
-  - {{domxref("fontFace.display")}} 
-  - {{domxref("fontFace.ascentOverride")}} 
-  - {{domxref("fontFace.descentOverride")}} 
-  - {{domxref("fontFace.lineGapOverride")}} 
-  - {{domxref("fontFace.load()")}} 
-- {{domxref("fontFaceSet")}} 
-- {{domxref("fontFaceSetLoadEvent")}} 
+- {{domxref("fontFace")}} 인터페이스
+  - [`FontFace()`](/ko/docs/Web/API/FontFace/FontFace) 생성자
+  - {{domxref("fontFace.family")}} 속성
+  - {{domxref("fontFace.style")}} 속성
+  - {{domxref("fontFace.weight")}} 속성
+  - {{domxref("fontFace.stretch")}} 속성
+  - {{domxref("fontFace.unicodeRange")}} 속성
+  - {{domxref("fontFace.variant")}} 속성
+  - {{domxref("fontFace.featureSettings")}} 속성
+  - {{domxref("fontFace.variationSettings")}} 속성
+  - {{domxref("fontFace.display")}} 속성
+  - {{domxref("fontFace.ascentOverride")}} 속성
+  - {{domxref("fontFace.descentOverride")}} 속성
+  - {{domxref("fontFace.lineGapOverride")}} 속성
+  - {{domxref("fontFace.load()")}} promise 반환 메서드
+- {{domxref("fontFaceSet")}} 인터페이스
+- {{domxref("fontFaceSetLoadEvent")}} 이벤트
 
 ## 가이드
 
-- [CSS font loading API](/en-US/docs/Web/API/CSS_Font_Loading_API)
+- [CSS font loading API](/ko/docs/Web/API/CSS_Font_Loading_API)
   - : 글꼴 리소스를 동적으로 로드하기 위한 이벤트와 인터페이스를 제공하는 CSS 글꼴 로딩 API에 대한 설명입니다.
 
 ## 명세서


### PR DESCRIPTION
Description
CSS 문서 안에 있는 CSS_font_loading 문서가 존재하지 않아 번역을 진행하였습니다. 

Additional details
([원문 깃허브 링크](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_font_loading/index.md), [원문 MDN 링크](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_font_loading))