### PR TITLE
[ko] RegExp.rightContext ($') 신규 번역 외

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/ko/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -1,13 +1,23 @@
 ---
 title: Number.MAX_SAFE_INTEGER
 slug: Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+l10n:
+  sourceCommit: fcd80ee4c8477b6f73553bfada841781cf74cf46
 ---
 
 {{JSRef}}
 
-**`Number.MAX_SAFE_INTEGER`** 상수는 JavaScript에서 안전한 최대 정수값을 나타냅니다. (`2^53 - 1`).
+**`Number.MAX_SAFE_INTEGER`** 정적 데이터 속성은 JavaScript의 최대 안전 정수 값(2<sup>53</sup> – 1)을 나타냅니다.
 
-{{EmbedInteractiveExample("pages/js/number-maxsafeinteger.html")}}{{js_property_attributes(0, 0, 0)}}
+더 큰 정수는 {{jsxref("BigInt")}}를 고려해보시기 바랍니다.
+
+{{EmbedInteractiveExample("pages/js/number-maxsafeinteger.html")}}
+
+## 값
+
+`9007199254740991` (9,007,199,254,740,991, or \~9천 조).
+
+{{js_property_attributes(0, 0, 0)}}
 
 ## 설명
 
@@ -17,23 +27,27 @@ slug: Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
 
 `MAX_SAFE_INTEGER`는 {{jsxref("Number")}}의 정적 속성이기 때문에, 직접 생성한 {{jsxref("Number")}} 객체의 속성이 아니라 `Number.MAX_SAFE_INTEGER` 형식으로 사용해야 합니다.
 
+[배정밀도 부동 소수점 형식](https://en.wikipedia.org/wiki/Double_precision_floating-point_format)은 [가수부](/ko/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding)를 표현하기 위해 오직 52비트만 사용할 수 있습니다. 그래서 -(2<sup>53</sup> – 1) 부터 2<sup>53</sup> – 1 까지의 정수만 안전하게 표현할 수 있습니다. 이 문맥에서 "안전"이라는 말은 정수를 정확하게 표현하고 이 정수들을 올바르게 비교할 수 있음을 의미합니다. 예를 들어 `Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2`는 true로 평가되겠지만 수학적으로는 틀렸습니다. 보다 자세한 정보는 {{jsxref("Number.isSafeInteger()")}}를 참고하시기 바랍니다.
+
+{{jsxref("Number")}}는 `MAX_SAFE_INTEGER`는 정적 속성이기 때문에 숫자 값의 속성보다는 언제나 `Number.MAX_SAFE_INTEGER` 형태로 사용하세요.
+
 ## 예제
+
+### MAX_SAFE_INTEGER의 반환 값
 
 ```js
 Number.MAX_SAFE_INTEGER; // 9007199254740991
-Number.MAX_SAFE_INTEGER * Number.EPSILON; // 2 because in floating points, the value is actually the decimal trailing "1"
-// except for in subnormal precision cases such as zero
 ```
 
-## 폴리필
+### MAX_SAFE_INTEGER와 EPSILON의 관계
+
+{{jsxref("Number.EPSILON")}}는 2<sup>-52</sup>인데 반해 `MAX_SAFE_INTEGER`는 2<sup>53</sup> – 1 입니다. 두 값은 모두 53비트(가장 높은 비트는 언제나 1)인 가수부의 너비에서 파생됩니다. 이를 곱하면 2에 매우 가깝지만 같지는 않은 값이 나옵니다.
 
 ```js
-if (!Number.MAX_SAFE_INTEGER) {
-  Number.MAX_SAFE_INTEGER = Math.pow(2, 53) - 1; // 9007199254740991
-}
+Number.MAX_SAFE_INTEGER * Number.EPSILON; // 1.9999999999999998
 ```
 
-## 명세
+## 명세서
 
 {{Specifications}}
 
@@ -43,6 +57,7 @@ if (!Number.MAX_SAFE_INTEGER) {
 
 ## 같이 보기
 
+- [`core-js`에서의 `Number.MAX_SAFE_INTEGER` 폴리필](https://github.com/zloirock/core-js#ecmascript-number)
 - {{jsxref("Number.MIN_SAFE_INTEGER")}}
 - {{jsxref("Number.isSafeInteger()")}}
 - {{jsxref("BigInt")}}

--- a/files/ko/web/javascript/reference/global_objects/regexp/rightcontext/index.md
+++ b/files/ko/web/javascript/reference/global_objects/regexp/rightcontext/index.md
@@ -1,0 +1,49 @@
+---
+title: RegExp.rightContext ($')
+slug: Web/JavaScript/Reference/Global_Objects/RegExp/rightContext
+l10n:
+  sourceCommit: fb85334ffa4a2c88d209b1074909bee0e0abd57a
+---
+
+{{JSRef}} {{Deprecated_Header}}
+
+> **참고:** 마지막 일치 상태를 전역적으로 노출하는 모든 `RegExp` 정적 속성은 더 이상 사용되지 않습니다. 자세한 내용은 [더 이상 사용되지 않는 RegExp 기능](/ko/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#regexp)을 참고하세요.
+
+**`RegExp.rightContext`** 정적 접근자 속성은 가장 최근에 일치한 하위 문자열을 반환합니다. `RegExp["$'"]`는 이 속성의 별칭입니다.
+
+## 설명
+
+`rightContext`는 {{jsxref("RegExp")}}의 정적 속성이기 때문에, 생성한 `RegExp` 객체의 속성으로 사용하는 것보다는 항상 `RegExp.rightContext` 또는 ``RegExp["$'"]`로 사용해야 합니다.
+
+`rightContext`의 값은 `RegExp`(`RegExp` 하위 클래스 제외) 인스턴스가 일치에 성공할 때마다 갱신됩니다. 일치하는 항목이 없으면 `rightContext`는 빈 문자열입니다. `rightContext`의 설정 접근자는 `undefined`이므로 이 속성을 직접 변경할 수 없습니다.
+
+`'`는 유효한 식별자 부분이 아니므로 점 속성 접근자(`RegExp.$'`)와 함께 약칭을 사용할 수 없으며 이로 인해 {{jsxref("SyntaxError")}}가 발생합니다. 대신 [대괄호 표기법](/ko/docs/Web/JavaScript/Reference/Operators/Property_accessors)을 사용하시기 바랍니다.
+
+`$'`는 {{jsxref("String.prototype.replace()")}}의 대체 문자열에도 사용할 수 있지만, 이는 `RegExp["$'"]` 레거시 속성과는 관련이 없습니다.
+
+## 예제
+
+### rightContext와 $' 사용하기
+
+```js
+const re = /hello/g;
+re.test("hello world!");
+RegExp.rightContext; // " world!"
+RegExp["$'"]; // " world!"
+```
+
+## 명세서
+
+{{Specifications}}
+
+## 브라우저 호환성
+
+{{Compat}}
+
+## 같이 보기
+
+- {{jsxref("RegExp/input", "RegExp.input ($_)")}}
+- {{jsxref("RegExp/lastMatch", "RegExp.lastMatch ($&amp;)")}}
+- {{jsxref("RegExp/lastParen", "RegExp.lastParen ($+)")}}
+- {{jsxref("RegExp/leftContext", "RegExp.leftContext ($`)")}}
+- {{jsxref("RegExp/n", "RegExp.$1, …, RegExp.$9")}}


### PR DESCRIPTION
- RegExp.rightContext ($') 신규 번역
- Number.MAX_SAFE_INTEGER 최신화
