### PR TITLE
[ru] remove outdated `conflicting/Glossary/CORS-safelisted_request_header`

### DIFF
--- a/files/ru/_wikihistory.json
+++ b/files/ru/_wikihistory.json
@@ -15946,10 +15946,6 @@
     "modified": "2019-06-12T07:08:20.267Z",
     "contributors": ["deadblackclover", "vkorniiko"]
   },
-  "conflicting/Glossary/CORS-safelisted_request_header": {
-    "modified": "2019-03-18T21:32:57.580Z",
-    "contributors": ["Skinny-Hunter"]
-  },
   "conflicting/Web/API/Fetch_API/Using_Fetch": {
     "modified": "2019-03-18T21:00:16.677Z",
     "contributors": ["Akh-rman", "qqwweeaassdd"]

--- a/files/ru/conflicting/glossary/cors-safelisted_request_header/index.md
+++ b/files/ru/conflicting/glossary/cors-safelisted_request_header/index.md
@@ -1,9 +1,0 @@
----
-title: Простой заголовок
-slug: conflicting/Glossary/CORS-safelisted_request_header
-original_slug: Glossary/Simple_header
----
-
-{{GlossarySidebar}}
-
-Старое название {{Glossary("CORS-safelisted request header", "CORS-безопасного заголовка запроса")}}.


### PR DESCRIPTION
### Description

This removes outdated `conflicting/Glossary/CORS-safelisted_request_header` document from `ru` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/33397
