### PR TITLE
[ru] remove outdated `conflicting/Glossary/CORS-safelisted_response_header`

### DIFF
--- a/files/ru/conflicting/glossary/cors-safelisted_response_header/index.md
+++ b/files/ru/conflicting/glossary/cors-safelisted_response_header/index.md
@@ -1,9 +1,0 @@
----
-title: Простой заголовок ответа
-slug: conflicting/Glossary/CORS-safelisted_response_header
-original_slug: Glossary/Simple_response_header
----
-
-{{GlossarySidebar}}
-
-Старое название {{Glossary("CORS-safelisted response header", "CORS-безопасного заголовка ответа")}}.


### PR DESCRIPTION
### Description

This PR removes outdated `conflicting/Glossary/CORS-safelisted_response_header` document from `ru` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/33397