### PR TITLE
[ru] remove outdated "Global attributes" section from `Web/SVG/Element/*` documents

### DIFF
--- a/files/ru/web/svg/element/a/index.md
+++ b/files/ru/web/svg/element/a/index.md
@@ -95,23 +95,6 @@ svg|a:active {
   - : URL или фрагмент URL, на который указывает гиперссылка. Может понадобиться для обратной совместимости со старыми браузерами.
     _Тип_: **[\<URL>](/docs/Web/SVG/Content_type#URL)** ; _Значение по умолчанию_: _none_; _Анимируем_: **да**
 
-### Глобальные атрибуты
-
-- [Core Attributes](/ru/docs/Web/SVG/Attribute/Core)
-  - : Наиболее используемые: {{SVGAttr('id')}}, {{SVGAttr('lang')}}, {{SVGAttr('tabindex')}}
-- [Styling Attributes](/docs/Web/SVG/Attribute/Styling)
-  - : {{SVGAttr('class')}}, {{SVGAttr('style')}}
-- [Conditional Processing Attributes](/docs/Web/SVG/Attribute/Conditional_Processing)
-  - : Наиболее используемые: {{SVGAttr('requiredExtensions')}}, {{SVGAttr('systemLanguage')}}
-- Event Attributes
-  - : [Global event attributes](/docs/Web/SVG/Attribute/Events#Global_Event_Attributes), [Document element event attributes](/docs/Web/SVG/Attribute/Events#Document_Element_Event_Attributes), [Graphical event attributes](/docs/Web/SVG/Attribute/Events#Graphical_Event_Attributes)
-- [Presentation Attributes](/docs/Web/SVG/Attribute/Presentation)
-  - : Наиболее используемые: {{SVGAttr('clip-path')}}, {{SVGAttr('clip-rule')}}, {{SVGAttr('color')}}, {{SVGAttr('color-interpolation')}}, {{SVGAttr('color-rendering')}}, {{SVGAttr('cursor')}}, {{SVGAttr('display')}}, {{SVGAttr('fill')}}, {{SVGAttr('fill-opacity')}}, {{SVGAttr('fill-rule')}}, {{SVGAttr('filter')}}, {{SVGAttr('mask')}}, {{SVGAttr('opacity')}}, {{SVGAttr('pointer-events')}}, {{SVGAttr('shape-rendering')}}, {{SVGAttr('stroke')}}, {{SVGAttr('stroke-dasharray')}}, {{SVGAttr('stroke-dashoffset')}}, {{SVGAttr('stroke-linecap')}}, {{SVGAttr('stroke-linejoin')}}, {{SVGAttr('stroke-miterlimit')}}, {{SVGAttr('stroke-opacity')}}, {{SVGAttr('stroke-width')}}, {{SVGAttr("transform")}}, {{SVGAttr('vector-effect')}}, {{SVGAttr('visibility')}}
-- XLink Attributes
-  - : Наиболее используемые: {{SVGAttr("xlink:title")}}
-- ARIA Attributes
-  - : `aria-activedescendant`, `aria-atomic`, `aria-autocomplete`, `aria-busy`, `aria-checked`, `aria-colcount`, `aria-colindex`, `aria-colspan`, `aria-controls`, `aria-current`, `aria-describedby`, `aria-details`, `aria-disabled`, `aria-dropeffect`, `aria-errormessage`, `aria-expanded`, `aria-flowto`, `aria-grabbed`, `aria-haspopup`, `aria-hidden`, `aria-invalid`, `aria-keyshortcuts`, `aria-label`, `aria-labelledby`, `aria-level`, `aria-live`, `aria-modal`, `aria-multiline`, `aria-multiselectable`, `aria-orientation`, `aria-owns`, `aria-placeholder`, `aria-posinset`, `aria-pressed`, `aria-readonly`, `aria-relevant`, `aria-required`, `aria-roledescription`, `aria-rowcount`, `aria-rowindex`, `aria-rowspan`, `aria-selected`, `aria-setsize`, `aria-sort`, `aria-valuemax`, `aria-valuemin`, `aria-valuenow`, `aria-valuetext`, `role`
-
 ## Примечания к использованию
 
 {{svginfo}}

--- a/files/ru/web/svg/element/animate/index.md
+++ b/files/ru/web/svg/element/animate/index.md
@@ -15,29 +15,6 @@ slug: Web/SVG/Element/animate
 
 » [animate.svg](/files/3258/animate.svg)
 
-## Атрибуты
-
-### Глобальные атрибуты
-
-- [Conditional processing attributes](/ru/docs/Web/SVG/Attribute#ConditionalProccessing) »
-- [Core attributes](/ru/docs/Web/SVG/Attribute#Core) »
-- [Animation event attributes](/ru/docs/Web/SVG/Attribute#AnimationEvent) »
-- [Xlink attributes](/ru/docs/Web/SVG/Attribute#XLink) »
-- [Animation attribute target attributes](/ru/docs/Web/SVG/Attribute#AnimationAttributeTarget) »
-- [Animation timing attributes](/ru/docs/Web/SVG/Attribute#AnimationTiming) »
-- [Animation value attributes](/ru/docs/Web/SVG/Attribute#AnimationValue) »
-- [Animation addition attributes](/ru/docs/Web/SVG/Attribute#AnimationAddition) »
-- {{SVGAttr("externalResourcesRequired")}}
-
-### Атрибуты элемента
-
-- {{SVGAttr("attributeName")}}
-- {{SVGAttr("attributeType")}}
-- {{SVGAttr("from")}}
-- {{SVGAttr("to")}}
-- {{SVGAttr("dur")}}
-- {{SVGAttr("repeatCount")}}
-
 ## DOM интерфейс
 
 Элемент реализует [`SVGAnimateElement`](/ru/docs/Web/DOM/SVGAnimateElement) интерфейс .

--- a/files/ru/web/svg/element/animatemotion/index.md
+++ b/files/ru/web/svg/element/animatemotion/index.md
@@ -7,75 +7,52 @@ slug: Web/SVG/Element/animateMotion
 
 Элемент **`<animateMotion>`** вызывает перемещение ссылочного элемента вдоль пути движения.
 
+## Пример
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  display: block;
+}
+```
+
+```html
+<svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+  <path
+    fill="none"
+    stroke="lightgrey"
+    d="M20,50 C20,-50 180,150 180,50 C180-50 20,150 20,50 z" />
+
+  <circle r="5" fill="red">
+    <animateMotion
+      dur="10s"
+      repeatCount="indefinite"
+      path="M20,50 C20,-50 180,150 180,50 C180-50 20,150 20,50 z" />
+  </circle>
+</svg>
+```
+
+{{EmbedLiveSample('Пример', 150, '100%')}}
+
 ## Контекст использования
 
 {{svginfo}}
 
 ## Атрибуты
 
-### Глобальные атрибуты
-
-- [Условные атрибуты обработки](/ru/docs/SVG/Attribute#Conditional_processing_attributes)
-- [Основные атрибуты](/ru/docs/SVG/Attribute#Core_attributes)
-- [Атрибуты события анимации](/ru/docs/SVG/Attribute#Animation_event_attributes)
-- [Атрибуты Xlink](/ru/docs/SVG/Attribute#XLink_attributes)
-- [Атрибуты времени анимации](/ru/docs/SVG/Attribute#Animation_timing_attributes)
-- [Величина атрибутов анимации](/ru/docs/SVG/Attribute#Animation_value_attributes)
-- [Атрибуты добавления анимации](/ru/docs/SVG/Attribute#Animation_addition_attributes)
-- {{SVGAttr("externalResourcesRequired")}}
-
-### Собственные атрибуты
-
-- {{SVGAttr("calcMode")}}
-- {{SVGAttr("path")}}
 - {{SVGAttr("keyPoints")}}
+- {{SVGAttr("path")}}
 - {{SVGAttr("rotate")}}
-- {{SVGAttr("origin")}}
 
 ## DOM интерфейс
 
 Этот элемент реализует интерфейс {{domxref("SVGAnimateMotionElement")}}.
 
-## Пример
-
-### SVG
-
-```html
-<?xml version="1.0"?>
-<svg
-  width="120"
-  height="120"
-  viewBox="0 0 120 120"
-  xmlns="http://www.w3.org/2000/svg"
-  version="1.1"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
-  <!-- Рисуем серый контур движения с двумя
-       маленькими кружками в ключевых точках -->
-  <path
-    id="theMotionPath"
-    stroke="lightgrey"
-    stroke-width="2"
-    fill="none"
-    d="M10,110 A120,120 -45 0,1 110 10 A120,120 -45 0,1 10,110" />
-  <circle cx="10" cy="110" r="3" fill="lightgrey" />
-  <circle cx="110" cy="10" r="3" fill="lightgrey" />
-
-  <!-- Рисуем красный круг, который будет перемещаться
-       вдоль траектории движения. -->
-  <circle cx="" cy="" r="5" fill="red">
-    <!-- Определяем анимацию пути движения -->
-    <animateMotion dur="6s" repeatCount="indefinite">
-      <mpath xlink:href="#theMotionPath" />
-    </animateMotion>
-  </circle>
-</svg>
-```
-
-### Результат
-
-{{EmbedLiveSample("Пример", 120, 120)}}
-
-## Характеристики
+## Спецификации
 
 {{Specifications}}
 

--- a/files/ru/web/svg/element/defs/index.md
+++ b/files/ru/web/svg/element/defs/index.md
@@ -15,23 +15,6 @@ SVG позволяет задавать графические объекты д
 
 {{svginfo}}
 
-## Атрибуты
-
-### Глобальные атрибуты
-
-- [Conditional processing attributes](/ru/docs/Web/SVG/Attribute#Conditional_processing_attributes)
-- [Core attributes](/ru/docs/Web/SVG/Attribute#Core_attributes)
-- [Graphical event attributes](/ru/docs/Web/SVG/Attribute#Graphical_event_attributes)
-- [Presentation attributes](/ru/docs/Web/SVG/Attribute#Presentation_attributes)
-- {{SVGAttr("class")}}
-- {{SVGAttr("style")}}
-- {{SVGAttr("externalResourcesRequired")}}
-- {{SVGAttr("transform")}}
-
-### Специфичные атрибуты
-
-_Нет._
-
 ## Интерфейс DOM
 
 Элемент реализует интерфейс {{domxref("SVGDefsElement")}}.

--- a/files/ru/web/svg/element/ellipse/index.md
+++ b/files/ru/web/svg/element/ellipse/index.md
@@ -42,35 +42,14 @@ svg {
   - : Радиус эллипса по y.
     _Тип значения_: `auto`|[**\<length>**](/docs/Web/SVG/Content_type#Length)|[**\<percentage>**](/docs/Web/SVG/Content_type#Percentage) ; _Значение по умолчанию_: `auto`; _Можно анимировать_: **да**
 - {{SVGAttr("pathLength")}}
-
   - : Этот атрибут позволяет установить длину всего пути.
-
     _Тип значения_: [**\<number>**](/docs/Web/SVG/Content_type#Number) ; _Значение по умолчанию_: _нет_; _Можно анимировать_: **да**
 
-    > **Примечание:** Начиная с SVG2, `cx`, `cy`, `rx` и `ry` это _Геометрические свойства_. Это означает, что они могут быть использованы как CSS-свойства элемента.
+> **Примечание:** Начиная с SVG2, `cx`, `cy`, `rx` и `ry` это _Геометрические свойства_. Это означает, что они могут быть использованы как CSS-свойства элемента.
 
-### Глобальные Атрибуты
-
-- [Основные атрибуты](/ru/docs/Web/SVG/Attribute/Core)
-  - : Самые важные: {{SVGAttr('id')}}, {{SVGAttr('tabindex')}}
-- [Атрибуты стиля](/docs/Web/SVG/Attribute/Styling)
-  - : {{SVGAttr('class')}}, {{SVGAttr('style')}}
-- [Условные атрибуты](/docs/Web/SVG/Attribute/Conditional_Processing)
-  - : Самые важные: {{SVGAttr('requiredExtensions')}}, {{SVGAttr('systemLanguage')}}
-- Атрибуты событий
-  - : [Глобальные атрибуты событий](/docs/Web/SVG/Attribute/Events#Global_Event_Attributes), [Атрибуты графических событий](/docs/Web/SVG/Attribute/Events#Graphical_Event_Attributes)
-- [Атрибуты представления](/docs/Web/SVG/Attribute/Presentation)
-  - : Самые важные: {{SVGAttr('clip-path')}}, {{SVGAttr('clip-rule')}}, {{SVGAttr('color')}}, {{SVGAttr('color-interpolation')}}, {{SVGAttr('color-rendering')}}, {{SVGAttr('cursor')}}, {{SVGAttr('display')}}, {{SVGAttr('fill')}}, {{SVGAttr('fill-opacity')}}, {{SVGAttr('fill-rule')}}, {{SVGAttr('filter')}}, {{SVGAttr('mask')}}, {{SVGAttr('opacity')}}, {{SVGAttr('pointer-events')}}, {{SVGAttr('shape-rendering')}}, {{SVGAttr('stroke')}}, {{SVGAttr('stroke-dasharray')}}, {{SVGAttr('stroke-dashoffset')}}, {{SVGAttr('stroke-linecap')}}, {{SVGAttr('stroke-linejoin')}}, {{SVGAttr('stroke-miterlimit')}}, {{SVGAttr('stroke-opacity')}}, {{SVGAttr('stroke-width')}}, {{SVGAttr("transform")}}, {{SVGAttr('vector-effect')}}, {{SVGAttr('visibility')}}
-- ARIA-атрибуты
-  - : `aria-activedescendant`, `aria-atomic`, `aria-autocomplete`, `aria-busy`, `aria-checked`, `aria-colcount`, `aria-colindex`, `aria-colspan`, `aria-controls`, `aria-current`, `aria-describedby`, `aria-details`, `aria-disabled`, `aria-dropeffect`, `aria-errormessage`, `aria-expanded`, `aria-flowto`, `aria-grabbed`, `aria-haspopup`, `aria-hidden`, `aria-invalid`, `aria-keyshortcuts`, `aria-label`, `aria-labelledby`, `aria-level`, `aria-live`, `aria-modal`, `aria-multiline`, `aria-multiselectable`, `aria-orientation`, `aria-owns`, `aria-placeholder`, `aria-posinset`, `aria-pressed`, `aria-readonly`, `aria-relevant`, `aria-required`, `aria-roledescription`, `aria-rowcount`, `aria-rowindex`, `aria-rowspan`, `aria-selected`, `aria-setsize`, `aria-sort`, `aria-valuemax`, `aria-valuemin`, `aria-valuenow`, `aria-valuetext`, `role`
-
-## Информация
+## Контекст использования
 
 {{svginfo}}
-
-## Интерфейс DOM
-
-Этот элемент реализует интерфейс {{ domxref("SVGEllipseElement") }}.
 
 ## Спецификации
 
@@ -82,4 +61,4 @@ svg {
 
 ## Смотрите также
 
-- {{SVGElement("circle")}}
+- Другие основные SVG фигуры: **{{ SVGElement('circle') }}**, {{ SVGElement('line') }}, {{ SVGElement('polygon') }}, {{ SVGElement('polyline') }}, {{ SVGElement('rect') }}

--- a/files/ru/web/svg/element/feblend/index.md
+++ b/files/ru/web/svg/element/feblend/index.md
@@ -13,16 +13,6 @@ slug: Web/SVG/Element/feBlend
 
 ## Атрибуты
 
-### Глобальные атрибуты
-
-- [Core attributes](/ru/docs/Web/SVG/Attribute#Core_attributes)
-- [Presentation attributes](/ru/docs/Web/SVG/Attribute#Presentation_attributes)
-- [Filter primitive attributes](/ru/docs/Web/SVG/Attribute#Filter_primitive_attributes)
-- {{SVGAttr("class")}}
-- {{SVGAttr("style")}}
-
-### Специальные атрибуты
-
 - {{SVGAttr("in")}}
 - {{SVGAttr("in2")}}
 - {{SVGAttr("mode")}}

--- a/files/ru/web/svg/element/foreignobject/index.md
+++ b/files/ru/web/svg/element/foreignobject/index.md
@@ -70,21 +70,6 @@ svg {
 
 > **Примечание:** Starting with SVG2 `x`, `y`, `width`, and `height` are Geometry Properties, meaning those attributes can also be used as CSS properties for that element.
 
-### Глобальные атрибуты
-
-- [Core Attributes](/ru/docs/Web/SVG/Attribute/Core)
-  - : Most notably: {{SVGAttr('id')}}, {{SVGAttr('tabindex')}}
-- [Styling Attributes](/docs/Web/SVG/Attribute/Styling)
-  - : {{SVGAttr('class')}}, {{SVGAttr('style')}}
-- [Conditional Processing Attributes](/docs/Web/SVG/Attribute/Conditional_Processing)
-  - : Most notably: {{SVGAttr('requiredExtensions')}}, {{SVGAttr('systemLanguage')}}
-- Event Attributes
-  - : [Global event attributes](/docs/Web/SVG/Attribute/Events#Global_Event_Attributes), [Graphical event attributes](/docs/Web/SVG/Attribute/Events#Graphical_Event_Attributes), [Document event attributes](/docs/Web/SVG/Attribute/Events#Document_Event_Attributes), [Document element event attributes](/docs/Web/SVG/Attribute/Events#Document_Element_Event_Attributes)
-- [Presentation Attributes](/docs/Web/SVG/Attribute/Presentation)
-  - : Most notably: {{SVGAttr('clip-path')}}, {{SVGAttr('clip-rule')}}, {{SVGAttr('color')}}, {{SVGAttr('color-interpolation')}}, {{SVGAttr('color-rendering')}}, {{SVGAttr('cursor')}}, {{SVGAttr('display')}}, {{SVGAttr('fill')}}, {{SVGAttr('fill-opacity')}}, {{SVGAttr('fill-rule')}}, {{SVGAttr('filter')}}, {{SVGAttr('mask')}}, {{SVGAttr('opacity')}}, {{SVGAttr('pointer-events')}}, {{SVGAttr('shape-rendering')}}, {{SVGAttr('stroke')}}, {{SVGAttr('stroke-dasharray')}}, {{SVGAttr('stroke-dashoffset')}}, {{SVGAttr('stroke-linecap')}}, {{SVGAttr('stroke-linejoin')}}, {{SVGAttr('stroke-miterlimit')}}, {{SVGAttr('stroke-opacity')}}, {{SVGAttr('stroke-width')}}, {{SVGAttr("transform")}}, {{SVGAttr('vector-effect')}}, {{SVGAttr('visibility')}}
-- Aria Attributes
-  - : `aria-activedescendant`, `aria-atomic`, `aria-autocomplete`, `aria-busy`, `aria-checked`, `aria-colcount`, `aria-colindex`, `aria-colspan`, `aria-controls`, `aria-current`, `aria-describedby`, `aria-details`, `aria-disabled`, `aria-dropeffect`, `aria-errormessage`, `aria-expanded`, `aria-flowto`, `aria-grabbed`, `aria-haspopup`, `aria-hidden`, `aria-invalid`, `aria-keyshortcuts`, `aria-label`, `aria-labelledby`, `aria-level`, `aria-live`, `aria-modal`, `aria-multiline`, `aria-multiselectable`, `aria-orientation`, `aria-owns`, `aria-placeholder`, `aria-posinset`, `aria-pressed`, `aria-readonly`, `aria-relevant`, `aria-required`, `aria-roledescription`, `aria-rowcount`, `aria-rowindex`, `aria-rowspan`, `aria-selected`, `aria-setsize`, `aria-sort`, `aria-valuemax`, `aria-valuemin`, `aria-valuenow`, `aria-valuetext`, `role`
-
 ## Примечания по использованию
 
 {{svginfo}}

--- a/files/ru/web/svg/element/image/index.md
+++ b/files/ru/web/svg/element/image/index.md
@@ -13,20 +13,6 @@ slug: Web/SVG/Element/image
 
 ## Атрибуты
 
-### Глобальные атрибуты
-
-- [Conditional processing attributes](/ru/docs/Web/SVG/Attribute#ConditionalProccessing) »
-- [Core attributes](/ru/docs/Web/SVG/Attribute#Core) »
-- [Graphical event attributes](/ru/docs/Web/SVG/Attribute#GraphicalEvent) »
-- [Xlink attributes](/ru/docs/Web/SVG/Attribute#XLink) »
-- [Presentation attributes](/ru/docs/Web/SVG/Attribute#Presentation) »
-- {{SVGAttr("class")}}
-- {{SVGAttr("style")}}
-- {{SVGAttr("externalResourcesRequired")}}
-- {{SVGAttr("transform")}}
-
-### Специфичные атрибуты
-
 - {{SVGAttr("x")}}
 - {{SVGAttr("y")}}
 - {{SVGAttr("width")}}

--- a/files/ru/web/svg/element/line/index.md
+++ b/files/ru/web/svg/element/line/index.md
@@ -46,21 +46,6 @@ svg {
   - : Определяет общую длину пути в пользовательских единицах.
     _Тип значения_: [**\<number>**](/docs/Web/SVG/Content_type#Number) ; _Значение по умолчанию_: _none_; А*неминуемый*: **да**
 
-### Глобальные атрибуты
-
-- [Основные атрибуты](/ru/docs/Web/SVG/Attribute/Core)
-  - : В первую очередь: {{SVGAttr('id')}}, {{SVGAttr('tabindex')}}
-- [Атрибуты оформления (стилей)](/docs/Web/SVG/Attribute/Styling)
-  - : {{SVGAttr('class')}}, {{SVGAttr('style')}}
-- [Атрибуты условной обработки](/docs/Web/SVG/Attribute/Conditional_Processing)
-  - : В первую очередь: {{SVGAttr('requiredExtensions')}}, {{SVGAttr('systemLanguage')}}
-- Атрибуты события
-  - : [Глобальные атрибуты события](/docs/Web/SVG/Attribute/Events#Global_Event_Attributes), [Графические атрибуты события](/docs/Web/SVG/Attribute/Events#Graphical_Event_Attributes)
-- [Атрибуты презентации](/docs/Web/SVG/Attribute/Presentation)
-  - : В первую очередь: {{SVGAttr('clip-path')}}, {{SVGAttr('clip-rule')}}, {{SVGAttr('color')}}, {{SVGAttr('color-interpolation')}}, {{SVGAttr('color-rendering')}}, {{SVGAttr('cursor')}}, {{SVGAttr('display')}}, {{SVGAttr('fill')}}, {{SVGAttr('fill-opacity')}}, {{SVGAttr('fill-rule')}}, {{SVGAttr('filter')}}, {{SVGAttr('mask')}}, {{SVGAttr('opacity')}}, {{SVGAttr('pointer-events')}}, {{SVGAttr('shape-rendering')}}, {{SVGAttr('stroke')}}, {{SVGAttr('stroke-dasharray')}}, {{SVGAttr('stroke-dashoffset')}}, {{SVGAttr('stroke-linecap')}}, {{SVGAttr('stroke-linejoin')}}, {{SVGAttr('stroke-miterlimit')}}, {{SVGAttr('stroke-opacity')}}, {{SVGAttr('stroke-width')}}, {{SVGAttr("transform")}}, {{SVGAttr('vector-effect')}}, {{SVGAttr('visibility')}}
-- ARIA-атрибуты
-  - : `aria-activedescendant`, `aria-atomic`, `aria-autocomplete`, `aria-busy`, `aria-checked`, `aria-colcount`, `aria-colindex`, `aria-colspan`, `aria-controls`, `aria-current`, `aria-describedby`, `aria-details`, `aria-disabled`, `aria-dropeffect`, `aria-errormessage`, `aria-expanded`, `aria-flowto`, `aria-grabbed`, `aria-haspopup`, `aria-hidden`, `aria-invalid`, `aria-keyshortcuts`, `aria-label`, `aria-labelledby`, `aria-level`, `aria-live`, `aria-modal`, `aria-multiline`, `aria-multiselectable`, `aria-orientation`, `aria-owns`, `aria-placeholder`, `aria-posinset`, `aria-pressed`, `aria-readonly`, `aria-relevant`, `aria-required`, `aria-roledescription`, `aria-rowcount`, `aria-rowindex`, `aria-rowspan`, `aria-selected`, `aria-setsize`, `aria-sort`, `aria-valuemax`, `aria-valuemin`, `aria-valuenow`, `aria-valuetext`, `role`
-
 ## Спецификации
 
 {{Specifications}}

--- a/files/ru/web/svg/element/lineargradient/index.md
+++ b/files/ru/web/svg/element/lineargradient/index.md
@@ -68,19 +68,6 @@ svg {
   - : Этот атрибут определяет координату y конечной точки векторного градиента, вдоль которой рисуется линейный градиент.
     _Тип значения_: [**\<length>**](/ru/docs/Web/SVG/Content_type#length) ; _Значение по умолчанию_: `0%`; _Анимируемый_: **да**
 
-### Глобальные атрибуты
-
-- [Основные атрибуты](/ru/docs/Web/SVG/Attribute/Core)
-  - : Прежде всего: {{SVGAttr('id')}}
-- [Атрибуты стилизации](/ru/docs/Web/SVG/Attribute/Styling)
-  - : {{SVGAttr('class')}}, {{SVGAttr('style')}}
-- Атрибуты событий
-  - : [Глобальные атрибуты событий](/ru/docs/Web/SVG/Attribute/Events#global_event_attributes), [Атрибуты событий элементов документа](/ru/docs/Web/SVG/Attribute/Events#document_element_event_attributes)
-- [Атрибуты презентации](/ru/docs/Web/SVG/Attribute/Presentation)
-  - : Прежде всего: {{SVGAttr('clip-path')}}, {{SVGAttr('clip-rule')}}, {{SVGAttr('color')}}, {{SVGAttr('color-interpolation')}}, {{SVGAttr('color-rendering')}}, {{SVGAttr('cursor')}}, {{SVGAttr('display')}}, {{SVGAttr('fill')}}, {{SVGAttr('fill-opacity')}}, {{SVGAttr('fill-rule')}}, {{SVGAttr('filter')}}, {{SVGAttr('mask')}}, {{SVGAttr('opacity')}}, {{SVGAttr('pointer-events')}}, {{SVGAttr('shape-rendering')}}, {{SVGAttr('stroke')}}, {{SVGAttr('stroke-dasharray')}}, {{SVGAttr('stroke-dashoffset')}}, {{SVGAttr('stroke-linecap')}}, {{SVGAttr('stroke-linejoin')}}, {{SVGAttr('stroke-miterlimit')}}, {{SVGAttr('stroke-opacity')}}, {{SVGAttr('stroke-width')}}, {{SVGAttr("transform")}}, {{SVGAttr('vector-effect')}}, {{SVGAttr('visibility')}}
-- XLink атрибуты
-  - : {{SVGAttr("xlink:href")}}, {{SVGAttr("xlink:title")}}
-
 ## Примечания по использованию
 
 {{svginfo}}

--- a/files/ru/web/svg/element/path/index.md
+++ b/files/ru/web/svg/element/path/index.md
@@ -39,21 +39,6 @@ svg {
   - : Этот атрибут позволяет указывать общую длину в пользовательских единицах.
     _Тип значения_: [**\<number>**](/docs/Web/SVG/Content_type#Number) ; _Значение по умолчанию_:_нет_; _Анимирование_: **Да**
 
-### Глобальные атрибуты
-
-- [Атрибуты ядра](/ru/docs/Web/SVG/Attribute/Core)
-  - : Most notably: {{SVGAttr('id')}}, {{SVGAttr('tabindex')}}
-- [Атрибуты стиля](/docs/Web/SVG/Attribute/Styling)
-  - : {{SVGAttr('class')}}, {{SVGAttr('style')}}
-- [Атрибуты условной обработки](/docs/Web/SVG/Attribute/Conditional_Processing)
-  - : Most notably: {{SVGAttr('requiredExtensions')}}, {{SVGAttr('systemLanguage')}}
-- Атрибуты событий
-  - : [Атрибуты глобальных событий](/docs/Web/SVG/Attribute/Events#Global_Event_Attributes), [Атрибуты графических событий](/docs/Web/SVG/Attribute/Events#Graphical_Event_Attributes)
-- [Presentation Attributes](/docs/Web/SVG/Attribute/Presentation)
-  - : Most notably: {{SVGAttr('clip-path')}}, {{SVGAttr('clip-rule')}}, {{SVGAttr('color')}}, {{SVGAttr('color-interpolation')}}, {{SVGAttr('color-rendering')}}, {{SVGAttr('cursor')}}, {{SVGAttr('display')}}, {{SVGAttr('fill')}}, {{SVGAttr('fill-opacity')}}, {{SVGAttr('fill-rule')}}, {{SVGAttr('filter')}}, {{SVGAttr('mask')}}, {{SVGAttr('opacity')}}, {{SVGAttr('pointer-events')}}, {{SVGAttr('shape-rendering')}}, {{SVGAttr('stroke')}}, {{SVGAttr('stroke-dasharray')}}, {{SVGAttr('stroke-dashoffset')}}, {{SVGAttr('stroke-linecap')}}, {{SVGAttr('stroke-linejoin')}}, {{SVGAttr('stroke-miterlimit')}}, {{SVGAttr('stroke-opacity')}}, {{SVGAttr('stroke-width')}}, {{SVGAttr("transform")}}, {{SVGAttr('vector-effect')}}, {{SVGAttr('visibility')}}
-- ARIA-атрибуты
-  - : `aria-activedescendant`, `aria-atomic`, `aria-autocomplete`, `aria-busy`, `aria-checked`, `aria-colcount`, `aria-colindex`, `aria-colspan`, `aria-controls`, `aria-current`, `aria-describedby`, `aria-details`, `aria-disabled`, `aria-dropeffect`, `aria-errormessage`, `aria-expanded`, `aria-flowto`, `aria-grabbed`, `aria-haspopup`, `aria-hidden`, `aria-invalid`, `aria-keyshortcuts`, `aria-label`, `aria-labelledby`, `aria-level`, `aria-live`, `aria-modal`, `aria-multiline`, `aria-multiselectable`, `aria-orientation`, `aria-owns`, `aria-placeholder`, `aria-posinset`, `aria-pressed`, `aria-readonly`, `aria-relevant`, `aria-required`, `aria-roledescription`, `aria-rowcount`, `aria-rowindex`, `aria-rowspan`, `aria-selected`, `aria-setsize`, `aria-sort`, `aria-valuemax`, `aria-valuemin`, `aria-valuenow`, `aria-valuetext`, `role`
-
 ## Использование
 
 {{svginfo}}

--- a/files/ru/web/svg/element/pattern/index.md
+++ b/files/ru/web/svg/element/pattern/index.md
@@ -82,19 +82,6 @@ svg {
   - : Этот атрибут определяет смещение координат y мозаичного элемента.
     _Value type_: [**\<length>**](/docs/Web/SVG/Content_type#Length)|[**\<percentage>**](/docs/Web/SVG/Content_type#Percentage) ; _Default value_: `0`; _Animatable_: **yes**
 
-### Глобальные атрибуты
-
-- [Core Attributes](/ru/docs/Web/SVG/Attribute/Core)
-  - : Most notably: {{SVGAttr('id')}}, {{SVGAttr('tabindex')}}
-- [Styling Attributes](/docs/Web/SVG/Attribute/Styling)
-  - : {{SVGAttr('class')}}, {{SVGAttr('style')}}
-- [Conditional Processing Attributes](/docs/Web/SVG/Attribute/Conditional_Processing)
-  - : Most notably: {{SVGAttr('requiredExtensions')}}, {{SVGAttr('systemLanguage')}}
-- [Presentation Attributes](/docs/Web/SVG/Attribute/Presentation)
-  - : Most notably: {{SVGAttr('clip-path')}}, {{SVGAttr('clip-rule')}}, {{SVGAttr('color')}}, {{SVGAttr('color-interpolation')}}, {{SVGAttr('color-rendering')}}, {{SVGAttr('cursor')}}, {{SVGAttr('display')}}, {{SVGAttr('fill')}}, {{SVGAttr('fill-opacity')}}, {{SVGAttr('fill-rule')}}, {{SVGAttr('filter')}}, {{SVGAttr('mask')}}, {{SVGAttr('opacity')}}, {{SVGAttr('pointer-events')}}, {{SVGAttr('shape-rendering')}}, {{SVGAttr('stroke')}}, {{SVGAttr('stroke-dasharray')}}, {{SVGAttr('stroke-dashoffset')}}, {{SVGAttr('stroke-linecap')}}, {{SVGAttr('stroke-linejoin')}}, {{SVGAttr('stroke-miterlimit')}}, {{SVGAttr('stroke-opacity')}}, {{SVGAttr('stroke-width')}}, {{SVGAttr("transform")}}, {{SVGAttr('vector-effect')}}, {{SVGAttr('visibility')}}
-- XLink Attributes
-  - : Most notably: {{SVGAttr("xlink:title")}}
-
 ## Нотации
 
 {{svginfo}}

--- a/files/ru/web/svg/element/polygon/index.md
+++ b/files/ru/web/svg/element/polygon/index.md
@@ -40,7 +40,7 @@ svg {
 
 ### Global attributes
 
-- [Основные атрибуты](/ru/docs/Web/SVG/Attribute/Core)
+- [Основные атрибуты](/ru/docs/Web/SVG/Attribute)
   - : Самые важные: {{SVGAttr('id')}}, {{SVGAttr('tabindex')}}
 - [Атрибуты стилизации](/docs/Web/SVG/Attribute/Styling)
   - : {{SVGAttr('class')}}, {{SVGAttr('style')}}

--- a/files/ru/web/svg/element/radialgradient/index.md
+++ b/files/ru/web/svg/element/radialgradient/index.md
@@ -13,17 +13,6 @@ slug: Web/SVG/Element/radialGradient
 
 ## Атрибуты
 
-### Глобальные атрибуты
-
-- [Основные атрибуты](/ru/docs/Web/SVG/Attribute#Core_attributes) »
-- [Атрибуты презентации](/ru/docs/Web/SVG/Attribute#Presentation_attributes) »
-- [Атрибуты Xlink](/ru/docs/Web/SVG/Attribute#XLink_attributes) »
-- {{SVGAttr("class")}}
-- {{SVGAttr("style")}}
-- {{SVGAttr("externalResourcesRequired")}}
-
-### Специфические атрибуты
-
 - {{SVGAttr("gradientUnits")}}
 - {{SVGAttr("gradientTransform")}}
 - {{SVGAttr("cx")}}

--- a/files/ru/web/svg/element/rect/index.md
+++ b/files/ru/web/svg/element/rect/index.md
@@ -49,17 +49,6 @@ slug: Web/SVG/Element/rect
 
 ## Атрибуты
 
-### Глобальные атрибуты
-
-- [Атрибуты условной обработки](/en/SVG/Attribute#ConditionalProccessing)
-- [Атрибуты ядра](/en/SVG/Attribute#Core)
-- [Атрибуты графических собы](/en/SVG/Attribute#GraphicalEvent)тий
-- [Атрибуты представления](/en/SVG/Attribute#Presentation)
-- {{ SVGAttr("class") }}
-- {{ SVGAttr("style") }}
-- {{ SVGAttr("externalResourcesRequired") }}
-- {{ SVGAttr("transform") }}
-
 ### Специальные атрибуты
 
 - {{ SVGAttr("x") }}

--- a/files/ru/web/svg/element/svg/index.md
+++ b/files/ru/web/svg/element/svg/index.md
@@ -71,21 +71,6 @@ svg {
 
 > **Примечание:** Примечание. Начиная с SVG2, `x`, `y`, `width` и `height` являются Geometry Properties, то есть эти атрибуты также можно использовать в качестве CSS-свойств.
 
-### Глобальные атрибуты
-
-- [Core Attributes](/ru/docs/Web/SVG/Attribute/Core)
-  - : Most notably: {{SVGAttr('id')}}, {{SVGAttr('tabindex')}}
-- [Styling Attributes](/ru/docs/Web/SVG/Attribute/Styling)
-  - : {{SVGAttr('class')}}, {{SVGAttr('style')}}
-- [Conditional Processing Attributes](/ru/docs/Web/SVG/Attribute/Conditional_Processing)
-  - : Most notably: {{SVGAttr('requiredExtensions')}}, {{SVGAttr('systemLanguage')}}
-- Event Attributes
-  - : [Global event attributes](/ru/docs/Web/SVG/Attribute/Events#Global_Event_Attributes), [Graphical event attributes](/ru/docs/Web/SVG/Attribute/Events#Graphical_Event_Attributes), [Document event attributes](/ru/docs/Web/SVG/Attribute/Events#Document_Event_Attributes), [Document element event attributes](/ru/docs/Web/SVG/Attribute/Events#Document_Element_Event_Attributes)
-- [Presentation Attributes](/ru/docs/Web/SVG/Attribute/Presentation)
-  - : Most notably: {{SVGAttr('clip-path')}}, {{SVGAttr('clip-rule')}}, {{SVGAttr('color')}}, {{SVGAttr('color-interpolation')}}, {{SVGAttr('color-rendering')}}, {{SVGAttr('cursor')}}, {{SVGAttr('display')}}, {{SVGAttr('fill')}}, {{SVGAttr('fill-opacity')}}, {{SVGAttr('fill-rule')}}, {{SVGAttr('filter')}}, {{SVGAttr('mask')}}, {{SVGAttr('opacity')}}, {{SVGAttr('pointer-events')}}, {{SVGAttr('shape-rendering')}}, {{SVGAttr('stroke')}}, {{SVGAttr('stroke-dasharray')}}, {{SVGAttr('stroke-dashoffset')}}, {{SVGAttr('stroke-linecap')}}, {{SVGAttr('stroke-linejoin')}}, {{SVGAttr('stroke-miterlimit')}}, {{SVGAttr('stroke-opacity')}}, {{SVGAttr('stroke-width')}}, {{SVGAttr("transform")}}, {{SVGAttr('vector-effect')}}, {{SVGAttr('visibility')}}
-- Aria атрибуты
-  - : `aria-activedescendant`, `aria-atomic`, `aria-autocomplete`, `aria-busy`, `aria-checked`, `aria-colcount`, `aria-colindex`, `aria-colspan`, `aria-controls`, `aria-current`, `aria-describedby`, `aria-details`, `aria-disabled`, `aria-dropeffect`, `aria-errormessage`, `aria-expanded`, `aria-flowto`, `aria-grabbed`, `aria-haspopup`, `aria-hidden`, `aria-invalid`, `aria-keyshortcuts`, `aria-label`, `aria-labelledby`, `aria-level`, `aria-live`, `aria-modal`, `aria-multiline`, `aria-multiselectable`, `aria-orientation`, `aria-owns`, `aria-placeholder`, `aria-posinset`, `aria-pressed`, `aria-readonly`, `aria-relevant`, `aria-required`, `aria-roledescription`, `aria-rowcount`, `aria-rowindex`, `aria-rowspan`, `aria-selected`, `aria-setsize`, `aria-sort`, `aria-valuemax`, `aria-valuemin`, `aria-valuenow`, `aria-valuetext`, `role`
-
 ## Примечания по использованию
 
 {{svginfo}}

--- a/files/ru/web/svg/element/text/index.md
+++ b/files/ru/web/svg/element/text/index.md
@@ -48,19 +48,6 @@ svg {
 
 ## Атрибуты
 
-### Глобальные атрибуты
-
-- [Условные атрибуты обработки](/ru/docs/Web/SVG/Attribute#Conditional_processing_attributes)
-- [Основные атрибуты](/ru/docs/Web/SVG/Attribute#Core_attributes)
-- [Графические атрибуты событий](/ru/docs/Web/SVG/Attribute#Graphical_event_attributes)
-- [Атрибуты представления](/ru/docs/Web/SVG/Attribute#Presentation_attributes)
-- {{SVGAttr("class")}}
-- {{SVGAttr("style")}}
-- {{SVGAttr("transform")}}
-- {{SVGAttr("externalResourcesRequired")}}
-
-### Специфические атрибуты
-
 - {{SVGAttr("х")}}
 - {{SVGAttr("у")}}
 - {{SVGAttr("dx")}}

--- a/files/ru/web/svg/element/use/index.md
+++ b/files/ru/web/svg/element/use/index.md
@@ -67,23 +67,6 @@ svg {
 
 > **Примечание:** Начиная с SVG2, `x`, `y`, `width`, и `height` являются _Свойствами Геометрии_, то есть эти атрибуты также могут быть использованы в качестве CSS-свойств для этого элемента.
 
-### Глобальные атрибуты
-
-- [Core Attributes](/ru/docs/Web/SVG/Attribute/Core)
-  - : Most notably: {{SVGAttr('id')}}, {{SVGAttr('tabindex')}}
-- [Styling Attributes](/docs/Web/SVG/Attribute/Styling)
-  - : {{SVGAttr('class')}}, {{SVGAttr('style')}}
-- [Conditional Processing Attributes](/docs/Web/SVG/Attribute/Conditional_Processing)
-  - : Most notably: {{SVGAttr('requiredExtensions')}}, {{SVGAttr('systemLanguage')}}
-- Атрибуты Событий
-  - : [Global event attributes](/docs/Web/SVG/Attribute/Events#Global_Event_Attributes), [Graphical event attributes](/docs/Web/SVG/Attribute/Events#Graphical_Event_Attributes)
-- [Presentation Attributes](/docs/Web/SVG/Attribute/Presentation)
-  - : Most notably: {{SVGAttr('clip-path')}}, {{SVGAttr('clip-rule')}}, {{SVGAttr('color')}}, {{SVGAttr('color-interpolation')}}, {{SVGAttr('color-rendering')}}, {{SVGAttr('cursor')}}, {{SVGAttr('display')}}, {{SVGAttr('fill')}}, {{SVGAttr('fill-opacity')}}, {{SVGAttr('fill-rule')}}, {{SVGAttr('filter')}}, {{SVGAttr('mask')}}, {{SVGAttr('opacity')}}, {{SVGAttr('pointer-events')}}, {{SVGAttr('shape-rendering')}}, {{SVGAttr('stroke')}}, {{SVGAttr('stroke-dasharray')}}, {{SVGAttr('stroke-dashoffset')}}, {{SVGAttr('stroke-linecap')}}, {{SVGAttr('stroke-linejoin')}}, {{SVGAttr('stroke-miterlimit')}}, {{SVGAttr('stroke-opacity')}}, {{SVGAttr('stroke-width')}}, {{SVGAttr("transform")}}, {{SVGAttr('vector-effect')}}, {{SVGAttr('visibility')}}
-- ARIA-Атрибуты
-  - : `aria-activedescendant`, `aria-atomic`, `aria-autocomplete`, `aria-busy`, `aria-checked`, `aria-colcount`, `aria-colindex`, `aria-colspan`, `aria-controls`, `aria-current`, `aria-describedby`, `aria-details`, `aria-disabled`, `aria-dropeffect`, `aria-errormessage`, `aria-expanded`, `aria-flowto`, `aria-grabbed`, `aria-haspopup`, `aria-hidden`, `aria-invalid`, `aria-keyshortcuts`, `aria-label`, `aria-labelledby`, `aria-level`, `aria-live`, `aria-modal`, `aria-multiline`, `aria-multiselectable`, `aria-orientation`, `aria-owns`, `aria-placeholder`, `aria-posinset`, `aria-pressed`, `aria-readonly`, `aria-relevant`, `aria-required`, `aria-roledescription`, `aria-rowcount`, `aria-rowindex`, `aria-rowspan`, `aria-selected`, `aria-setsize`, `aria-sort`, `aria-valuemax`, `aria-valuemin`, `aria-valuenow`, `aria-valuetext`, `role`
-- XLink Атрибуты
-  - : {{SVGAttr("xlink:href")}}, {{SVGAttr("xlink:title")}}
-
 ## Примечание по использованию
 
 {{svginfo}}


### PR DESCRIPTION
### Description

This PR removes outdated "Global attributes" section from `Web/SVG/Element/*` documents in `ru` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/32383
