### PR TITLE
[ru] update `Glossary/CORS-safelisted_request_header` and `Glossary/CORS-safelisted_response_header` translations

### DIFF
--- a/files/ru/glossary/cors-safelisted_request_header/index.md
+++ b/files/ru/glossary/cors-safelisted_request_header/index.md
@@ -2,7 +2,7 @@
 title: CORS-безопасный заголовок запроса
 slug: Glossary/CORS-safelisted_request_header
 l10n:
-  sourceCommit: fea9eb7420e6d70772144854242c30e421898415
+  sourceCommit: 50e5e8a9b8a6b7d0dd9877610c9639d8b90f329f
 ---
 
 {{GlossarySidebar}}
@@ -31,6 +31,7 @@ CORS-безопасные заголовки запроса должны соо�
 
 ## Смотрите также
 
-- {{Glossary("CORS-safelisted response header", "CORS-безопасный заголовок ответа")}}
-- {{Glossary("Forbidden header name", "Запрещённое имя заголовка")}}
-- {{Glossary("Request header", "Заголовок запроса")}}
+- Связанные термины глоссария:
+  - {{Glossary("CORS-safelisted response header", "CORS-безопасный заголовок ответа")}}
+  - {{Glossary("Forbidden header name", "Запрещённое имя заголовка")}}
+  - {{Glossary("Request header", "Заголовок запроса")}}

--- a/files/ru/glossary/cors-safelisted_response_header/index.md
+++ b/files/ru/glossary/cors-safelisted_response_header/index.md
@@ -2,7 +2,7 @@
 title: CORS-безопасный заголовок ответа
 slug: Glossary/CORS-safelisted_response_header
 l10n:
-  sourceCommit: fea9eb7420e6d70772144854242c30e421898415
+  sourceCommit: 50e5e8a9b8a6b7d0dd9877610c9639d8b90f329f
 ---
 
 {{GlossarySidebar}}
@@ -38,8 +38,7 @@ Access-Control-Expose-Headers: X-Custom-Header, Content-Encoding
 - [HTTP](/ru/docs/Web/HTTP)
 - [Заголовки HTTP](/ru/docs/Web/HTTP/Headers)
 - {{HTTPHeader("Access-Control-Expose-Headers")}}
-- [Глоссарий](/ru/docs/Glossary)
-
+- Связанные термины глоссария:
   - {{Glossary("CORS")}}
   - {{Glossary("CORS-safelisted_request_header", "CORS-безопасный заголовок запроса")}}
   - {{Glossary("Forbidden header name", "Запрещённое имя заголовка")}}


### PR DESCRIPTION
### Description

This PR updates `Glossary/CORS-safelisted_request_header` and `Glossary/CORS-safelisted_response_header` translations for `ru` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/34454