### PR TITLE
[ja] Fix mistranslation in performance.now()

### DIFF
--- a/files/ja/web/api/performance/now/index.md
+++ b/files/ja/web/api/performance/now/index.md
@@ -79,8 +79,8 @@ console.log(`Call to doSomething took ${t1 - t0} milliseconds.`);
 
 タイミング攻撃や[フィンガープリンティング](/ja/docs/Glossary/Fingerprinting)から保護するために、 `performance.now()` はサイトの分離状態に基づいて粗くなります。
 
-- 独立したコンテキストでの解像度: 5 ミリ秒
-- 独立していないコンテキストでの解像度: 100 ミリ秒
+- 独立したコンテキストでの解像度: 5 マイクロ秒
+- 独立していないコンテキストでの解像度: 100 マイクロ秒
 
 {{HTTPHeader("Cross-Origin-Opener-Policy")}} と {{HTTPHeader("Cross-Origin-Embedder-Policy")}} ヘッダーを使用して、サイトをオリジン間分離します。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Part of the Japanese translation for the "Security requirements" section in the "Performance: now() method" page seems to be incorrect. The original English text says "microseconds", but the Japanese version says "ミリ秒" (milliseconds). This pull request tries to fix the mistranslation.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
