### PR TITLE
es: Convert noteblocks to GFM Alerts (part 3)

### DIFF
--- a/files/es/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
@@ -34,7 +34,8 @@ browser-compat: api.Ink
 Una página que tiene un banner generalmente también tendrá metadatos de página "complementarios".
 Por ejemplo, una página que tiene `\{{SeeCompatTable}}` generalmente también debe tener el estado `experimental` agregado (como se muestra arriba) para garantizar que tenga los íconos apropiados en el menú lateral.
 
-> **Nota:** Las macros de banner no _dependen_ de los metadatos, pero sí lo hacen algunos otros contenidos insertados con macros.
+> [!NOTE]
+> Las macros de banner no _dependen_ de los metadatos, pero sí lo hacen algunos otros contenidos insertados con macros.
 > Por ejemplo, la macro `\{{Compat}}` depende del valor de metadatos `browser-compat`.
 
 ## Qué banners pueden/deben agregarse
@@ -50,4 +51,5 @@ En resumen:
   También agregue `status` de `non-standard` en los metadatos de la página.
 - `\{{SecureContext_Header}}`: Esto genera un banner de **Contexto seguro** que indica que la tecnología solo está disponible en un [contexto seguro](/es/docs/Web/Security/Secure_Contexts).
 
-> **Nota:** Los metadatos `page-type`, `status` y `browser-compat` solo son utilizados en el contenido en Inglés.
+> [!NOTE]
+> Los metadatos `page-type`, `status` y `browser-compat` solo son utilizados en el contenido en Inglés.

--- a/files/es/mdn/writing_guidelines/page_structures/code_examples/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/code_examples/index.md
@@ -9,7 +9,8 @@ l10n:
 
 En MDN, encontrarás numerosos ejemplos de código insertados en las páginas para demostrar el uso de las características de la plataforma web. Este artículo discute los diferentes mecanismos disponibles para agregar ejemplos de código a las páginas, junto con cuáles debes usar y cuándo.
 
-> **Nota:** Si buscas consejos sobre el estilo y el formato del código tal como aparece en un artículo de MDN, en lugar de las diferentes formas de incluir código, consulta nuestra [Guía de estilo de código](/es/docs/MDN/Writing_guidelines/Writing_style_guide/Code_style_guide).
+> [!NOTE]
+> Si buscas consejos sobre el estilo y el formato del código tal como aparece en un artículo de MDN, en lugar de las diferentes formas de incluir código, consulta nuestra [Guía de estilo de código](/es/docs/MDN/Writing_guidelines/Writing_style_guide/Code_style_guide).
 
 ## ¿Qué tipos de ejemplos de código están disponibles?
 

--- a/files/es/mdn/writing_guidelines/page_structures/compatibility_tables/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/compatibility_tables/index.md
@@ -61,4 +61,5 @@ Las llamadas a las macros generan las siguientes tablas (y el correspondiente co
 
 {{Specifications}}
 
-> **Nota:** El metadato `browser-compat` solo es utilizado en el contenido en Inglés.
+> [!NOTE]
+> El metadato `browser-compat` solo es utilizado en el contenido en Inglés.

--- a/files/es/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -80,11 +80,13 @@ El primer paso es agregar snippets o asegurarse que los existentes están listos
 
 Cada pieza de código debe estar en un bloque {{HTMLElement("pre")}}, con un bloque separado para cada lenguaje, propiamente marcado con el lenguaje correspondiente. La mayoría de las veces, esto ya se hizo, pero vale la pena volver revisar para asegurarse que cada pieza de código está estructurado con la sintaxis correcta. A la derecha del ícono **PRE** en la barra de tareas hay un menú desplegable (herramienta: Syntax Highlighter) con varios lenguajes para los que MDN hace distinción de sintaxis. Establecer el lenguaje para la distinción de sintaxis del bloque también lo correlaciona con un lenguaje para los propósitos del sistema de ejemplos ejecutables.
 
-> **Nota:** Puedes tener más de un bloque para cada lenguaje; todos son concatenados juntos. Esto te permite tener una parte de código, seguida de una explicación de como funciona, luego otra parte de código, etc. Esto hace aun más fácil producir tutoriales y utilizar ejemplo ejecutables intercalados con texto que los explique.
+> [!NOTE]
+> Puedes tener más de un bloque para cada lenguaje; todos son concatenados juntos. Esto te permite tener una parte de código, seguida de una explicación de como funciona, luego otra parte de código, etc. Esto hace aun más fácil producir tutoriales y utilizar ejemplo ejecutables intercalados con texto que los explique.
 
 Así que asegurate que la distinción de sintaxis de los bloques {{HTMLElement("pre")}} para tu código HTML, CSS, y/o JavaScript estén cada uno configurado para el lenguaje correcto, y estarás bien.
 
-> **Nota:** Al pegar contenido en MDN, se conciente que si pegas contenido formateado (incluyendo, por ejemplo, distinción de sintaxis en código copeado de otro sitio) puedes estar trayendo formatos o clases que no quieres y no necesitas. Ten cuidado de no hacer esto; si es necesario, revisa tu edición en modo fuente y elimina estos formatos y clases innecesarios (o revísalo antes de pegarlo, o usa la opción "Pegar como texto plano").
+> [!NOTE]
+> Al pegar contenido en MDN, se conciente que si pegas contenido formateado (incluyendo, por ejemplo, distinción de sintaxis en código copeado de otro sitio) puedes estar trayendo formatos o clases que no quieres y no necesitas. Ten cuidado de no hacer esto; si es necesario, revisa tu edición en modo fuente y elimina estos formatos y clases innecesarios (o revísalo antes de pegarlo, o usa la opción "Pegar como texto plano").
 
 #### Insertar la macro de ejemplo ejecutable
 
@@ -139,7 +141,8 @@ Al buscar ejemplos existentes que actualizar, hay tres tipos principales de actu
 - Corregir bugs en un ejemplo ejecutable existente.
 - Mejorar un ejemplo ejecutable existente, o actualizar un ejemplo basándose en cambios tecnológicos.
 
-> **Nota:** Si encuentras artículos que necesitan ser actualizados para usar el sistema de ejemplos ejecutables, por favor agrega a la página la etiqueta "NeedsLiveSample".
+> [!NOTE]
+> Si encuentras artículos que necesitan ser actualizados para usar el sistema de ejemplos ejecutables, por favor agrega a la página la etiqueta "NeedsLiveSample".
 
 ### Encontrando ejemplos que necesitan convertirse a ejemplos ejecutables
 
@@ -211,7 +214,8 @@ Aquí un enlace que resulta de llamar los bloques de código vía `\{{LiveSample
 
 ## Convenciones acerca de los ejemplos ejecutables
 
-> **Nota:** Esto es actual (Feb. 2016) en discusión en la lista de emails dev-mdc (ver [this thread](https://groups.google.com/forum/#!topic/mozilla.dev.mdc/49oqJAHFnWQ)). Cualquier entrada es bienvenida. Si esta nota persiste después de unos meses (Apr. 2016), por favor contactar al autor del primer email en este hilo para actualizar esta página.
+> [!NOTE]
+> Esto es actual (Feb. 2016) en discusión en la lista de emails dev-mdc (ver [this thread](https://groups.google.com/forum/#!topic/mozilla.dev.mdc/49oqJAHFnWQ)). Cualquier entrada es bienvenida. Si esta nota persiste después de unos meses (Apr. 2016), por favor contactar al autor del primer email en este hilo para actualizar esta página.
 
 - Orden de los bloques de código
   - : Al agregar un ejemplo ejecutable, los bloques de código deben ser organizados para que el primero corresponda al lenguaje principal (si hay uno). Por ejemplo, al agregar un ejemplo ejecutable para una referencia HTML, el primer bloque debe ser HTML, al agregar un ejemplo ejecutable para una referencia CSS, debe ser el de CSS y así.

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
@@ -115,7 +115,8 @@ Cada ejemplo debe tener un encabezado H3 que nombre el ejemplo. El encabezado de
 
 Consulte nuestra guía sobre cómo agregar [ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples) para obtener más información.
 
-> **Nota:** A veces querrá enlazar a ejemplos dados en otra página.
+> [!NOTE]
+> A veces querrá enlazar a ejemplos dados en otra página.
 >
 > **Escenario 1:** Si tiene algunos ejemplos en esta página y algunos más en otra página:
 >

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -96,7 +96,8 @@ Cada ejemplo debe tener un encabezado H3 (`###`) que nombre el ejemplo. El encab
 
 Consulta nuestra guía sobre cómo añadir [ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples) para obtener más información.
 
-> **Nota:** A veces querrás enlazar a ejemplos dados en otra página.
+> [!NOTE]
+> A veces querrás enlazar a ejemplos dados en otra página.
 >
 > **Escenario 1:** Si tiene algunos ejemplos en esta página y algunos ejemplos más en otra página:
 >

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/aria_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/aria_page_template/index.md
@@ -66,7 +66,8 @@ Incluya una descripción completa del atributo o rol.
 - Cambio de valores de atributos
   - : Explicación de cada uno
 
-> **Nota:** Incluye una nota sobre alternativas semánticas al uso de este rol o atributo. La primera regla de uso de ARIA es que puedes usar una función nativa con la semántica y el comportamiento que requieres ya incorporados, en lugar de reutilizar un elemento y **agregar** un rol, estado o propiedad de ARIA para hacerlo accesible, y luego hacerlo. Luego publique todos los detalles en la sección de mejores prácticas a continuación.
+> [!NOTE]
+> Incluye una nota sobre alternativas semánticas al uso de este rol o atributo. La primera regla de uso de ARIA es que puedes usar una función nativa con la semántica y el comportamiento que requieres ya incorporados, en lugar de reutilizar un elemento y **agregar** un rol, estado o propiedad de ARIA para hacerlo accesible, y luego hacerlo. Luego publique todos los detalles en la sección de mejores prácticas a continuación.
 
 ## Ejemplos
 
@@ -78,7 +79,8 @@ Cada ejemplo debe tener un encabezado H3 (`###`) que nombre el ejemplo. El encab
 
 Consulta nuestra guía sobre cómo añadir [ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples) para obtener más información.
 
-> **Nota:** A veces querrás enlazar a ejemplos dados en otra página.
+> [!NOTE]
+> A veces querrás enlazar a ejemplos dados en otra página.
 >
 > **Escenario 1:** Si tiene algunos ejemplos en esta página y algunos ejemplos más en otra página:
 >

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -130,7 +130,8 @@ Cada ejemplo debe tener un título H3 (`###`) que nombre el ejemplo. El título 
 
 Consulta nuestra guía sobre cómo agregar [ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples) para obtener más información.
 
-> **Nota:** A veces querrás enlazar a ejemplos dados en otra página.
+> [!NOTE]
+> A veces querrás enlazar a ejemplos dados en otra página.
 >
 > **Escenario 1:** Si tienes algunos ejemplos en esta página y algunos más en otra página:
 >

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
@@ -96,7 +96,8 @@ Cada ejemplo debe tener un encabezado H3 (`###`) que nombre el ejemplo. El encab
 
 Consulta nuestra guía sobre cómo añadir [ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples) para obtener más información.
 
-> **Nota:** A veces, querrás vincular a ejemplos dados en otra página.
+> [!NOTE]
+> A veces, querrás vincular a ejemplos dados en otra página.
 >
 > **Escenario 1:** Si tiene algunos ejemplos en esta página y algunos ejemplos más en otra página:
 >

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
@@ -132,7 +132,8 @@ Cada ejemplo debe tener un encabezado H3 (###) que nombre el ejemplo. El encabez
 
 Consulta nuestra guía sobre cómo agregar [ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples) para obtener más información.
 
-> **Nota:** A veces querrás enlazar a ejemplos dados en otra página.
+> [!NOTE]
+> A veces querrás enlazar a ejemplos dados en otra página.
 >
 > **Escenario 1:** Si tienes algunos ejemplos en esta página y algunos más en otra página:
 >

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
@@ -116,7 +116,8 @@ Cada ejemplo debe tener un encabezado H3 (`###`) que nombre el ejemplo. El encab
 
 Consulta nuestra guía sobre cómo agregar [ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples) para obtener más información.
 
-> **Nota:** A veces querrás vincular a ejemplos dados en otra página.
+> [!NOTE]
+> A veces querrás vincular a ejemplos dados en otra página.
 >
 > **Escenario 1:** Si tienes algunos ejemplos en esta página y algunos más en otra página:
 >

--- a/files/es/mdn/writing_guidelines/what_we_write/criteria_for_inclusion/index.md
+++ b/files/es/mdn/writing_guidelines/what_we_write/criteria_for_inclusion/index.md
@@ -51,7 +51,8 @@ Hay muchas bibliotecas y _frameworks_ en existencia, que no son estándares web 
 
 El equipo de MDN Web Docs se concentra en documentar la plataforma web abierta. Si quieres que se considere una tecnología en esta área para la documentación en MDN Web Docs, necesitarás tener una comunidad reunida que esté dispuesta a escribir la documentación y mantenerla después de completarla. Nuestro equipo está feliz de proporcionar orientación en tales casos, incluidas ediciones y comentarios, pero no tenemos los recursos para más que eso.
 
-> **Nota:** El trabajo de MDN Web Docs se lleva a cabo en GitHub y 'en abierto'. Tu equipo debería estar familiarizado con git y GitHub y sentirse cómodo trabajando en código abierto.
+> [!NOTE]
+> El trabajo de MDN Web Docs se lleva a cabo en GitHub y 'en abierto'. Tu equipo debería estar familiarizado con git y GitHub y sentirse cómodo trabajando en código abierto.
 
 ## Proceso para seleccionar la nueva tecnología
 
@@ -79,7 +80,8 @@ Las tecnologías serán consideradas para su inclusión en MDN Web Docs caso por
 
 No necesitas proporcionarnos cientos de páginas de detalle en esta etapa (de hecho, preferiríamos que no lo hicieras). Un par de párrafos sobre cada uno de los puntos anteriores son más que adecuados.
 
-> **Nota:** MDN Web Docs es principalmente un sitio en inglés (en-US). El idioma principal para tu proyecto debe ser en inglés de EE. UU.
+> [!NOTE]
+> MDN Web Docs es principalmente un sitio en inglés (en-US). El idioma principal para tu proyecto debe ser en inglés de EE. UU.
 
 ### Esperar una respuesta
 

--- a/files/es/mdn/writing_guidelines/what_we_write/index.md
+++ b/files/es/mdn/writing_guidelines/what_we_write/index.md
@@ -58,7 +58,8 @@ Nuestro objetivo principal es escribir sobre las siguientes tecnologías web fro
 
 También documentamos algunos temas más amplios, como [SVG](/es/docs/Web/SVG), [XML](/es/docs/Web/XML), [WebAssembly](/es/docs/WebAssembly) y [Accesibilidad](/es/docs/Learn/Accessibility). Además, proporcionamos extensas [guías de aprendizaje](/es/docs/Learn) para estas tecnologías y también un [glosario](/es/docs/Glossary).
 
-> **Nota:** Las tecnologías de backend generalmente tienen su propia documentación en otro lugar que MDN Web Docs no intenta reemplazar, aunque [tenemos algunas excepciones](/es/docs/Learn/Server-side).
+> [!NOTE]
+> Las tecnologías de backend generalmente tienen su propia documentación en otro lugar que MDN Web Docs no intenta reemplazar, aunque [tenemos algunas excepciones](/es/docs/Learn/Server-side).
 
 Todo el contenido de MDN Web Docs debe ser relevante para la sección de tecnología en la que aparece. Se espera que los colaboradores sigan estas [pautas de escritura de MDN](/es/docs/MDN/Writing_guidelines) para el estilo de escritura, las muestras de código y otros temas.
 

--- a/files/es/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
+++ b/files/es/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
@@ -23,7 +23,8 @@ Prettier formatea todo el código y mantiene el estilo consistente. Sin embargo,
 
 ## Documento HTML completo
 
-> **Nota:** Las pautas de esta sección solo se aplican cuando necesita mostrar un documento HTML completo. Por lo general, un fragmento es suficiente para demostrar una función. Cuando utilice la [macro EmbedLiveSample](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples#traditional_live_samples), simplemente incluya el fragmento HTML se insertará automáticamente en un documento HTML completo cuando se muestre.
+> [!NOTE]
+> Las pautas de esta sección solo se aplican cuando necesita mostrar un documento HTML completo. Por lo general, un fragmento es suficiente para demostrar una función. Cuando utilice la [macro EmbedLiveSample](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples#traditional_live_samples), simplemente incluya el fragmento HTML se insertará automáticamente en un documento HTML completo cuando se muestre.
 
 ### Tipo de documento
 

--- a/files/es/mdn/writing_guidelines/writing_style_guide/code_style_guide/index.md
+++ b/files/es/mdn/writing_guidelines/writing_style_guide/code_style_guide/index.md
@@ -58,7 +58,8 @@ Para garantizar el formato adecuado y el resaltado de sintaxis de los bloques de
 
 Si el bloque de código es pseudocódigo, la salida de un comando, o de alguna manera no es un lenguaje de programación, establece explícitamente el lenguaje como `plain`.
 
-> **Advertencia:** si el lenguaje deseado aún no es compatible con MDN, **no** establezcas el lenguaje de un bloque de código en un lenguaje similar, ya que hacerlo puede tener efectos secundarios no deseados con el formato de Prettier y el resaltado de sintaxis.
+> [!WARNING]
+> Si el lenguaje deseado aún no es compatible con MDN, **no** establezcas el lenguaje de un bloque de código en un lenguaje similar, ya que hacerlo puede tener efectos secundarios no deseados con el formato de Prettier y el resaltado de sintaxis.
 
 ### Longitud de línea de código
 

--- a/files/es/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
+++ b/files/es/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
@@ -427,9 +427,11 @@ Cuando los [bucles](/es/docs/Learn/JavaScript/Building_blocks/Looping_code) son 
   }
   ```
 
-> **Advertencia:** Nunca utilice `for...in` en matrices y cadenas.
+> [!WARNING]
+> Nunca utilice `for...in` en matrices y cadenas.
 
-> **Nota:** Considere no usar un bucle `for` en absoluto. Si estás utilizando un [`Array`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array) (o un [`String`](/es/docs/Web/JavaScript/Reference/Global_Objects/String) para algunas operaciones), considere usar más métodos de iteración semántica en su lugar, como [`map()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/map), [`every()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/every), [`findIndex()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex), [`find()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/find), [`includes()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/includes), y muchos más.
+> [!NOTE]
+> Considere no usar un bucle `for` en absoluto. Si estás utilizando un [`Array`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array) (o un [`String`](/es/docs/Web/JavaScript/Reference/Global_Objects/String) para algunas operaciones), considere usar más métodos de iteración semántica en su lugar, como [`map()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/map), [`every()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/every), [`findIndex()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex), [`find()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/find), [`includes()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/includes), y muchos más.
 
 ### Sentencias de control
 
@@ -557,7 +559,8 @@ Las sentencias `switch` pueden ser un poco complicadas.
   }
   ```
 
-> **Nota:** Tenga en cuenta que solo los errores _recuperables_ deben detectarse y manejarse.
+> [!NOTE]
+> Tenga en cuenta que solo los errores _recuperables_ deben detectarse y manejarse.
 > Todos los errores no recuperables deben dejarse pasar y aumentar la pila de llamadas.
 
 ## Objetos
@@ -788,7 +791,8 @@ Los buenos nombres de variables son esenciales para comprender el código.
   const s = d / t;
   ```
 
-> **Nota:** El único lugar donde está permitido no usar nombres semánticos legibles por humanos es donde existe una convención comúnmente reconocida, como usar `i` y `j` para iteradores de bucle.
+> [!NOTE]
+> El único lugar donde está permitido no usar nombres semánticos legibles por humanos es donde existe una convención comúnmente reconocida, como usar `i` y `j` para iteradores de bucle.
 
 ### Declaración de Variables
 

--- a/files/es/mozilla/add-ons/webextensions/api/storage/index.md
+++ b/files/es/mozilla/add-ons/webextensions/api/storage/index.md
@@ -20,7 +20,8 @@ Cada extensión tiene su propia área de almacenamiento, que se puede dividir en
 
 Aunque esta API es similar a {{domxref ("Window.localStorage")}}, se recomienda que no use Window\.localStorage en el código de extensión para almacenar datos relacionados con la extensión. Firefox borrará los datos almacenados por las extensiones utilizando la API localStorage en varios escenarios donde los usuarios borran su historial de navegación y los datos por razones de privacidad, mientras que los datos guardados utilizando la API [`storage.local`](/es/docs/Mozilla/Add-ons/WebExtensions/API/storage/local) se conservarán correctamente en estos escenarios.
 
-> **Nota:** El área de almacenamiento no está encriptada y no debe utilizarse para almacenar información confidencial del usuario, como claves.
+> [!NOTE]
+> El área de almacenamiento no está encriptada y no debe utilizarse para almacenar información confidencial del usuario, como claves.
 
 ## Tipos
 

--- a/files/es/mozilla/add-ons/webextensions/browser_support_for_javascript_apis/index.md
+++ b/files/es/mozilla/add-ons/webextensions/browser_support_for_javascript_apis/index.md
@@ -9,7 +9,8 @@ l10n:
 
 {{WebExtAllCompatTables}}
 
-> **Nota:** Los datos de compatibilidad de Microsoft Edge son proporcionados por Microsoft Corporation y se incluyen aquí bajo la licencia Creative Commons Attribution 3.0 United States License.
+> [!NOTE]
+> Los datos de compatibilidad de Microsoft Edge son proporcionados por Microsoft Corporation y se incluyen aquí bajo la licencia Creative Commons Attribution 3.0 United States License.
 
 ## Véase también
 

--- a/files/es/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
+++ b/files/es/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
@@ -13,7 +13,8 @@ Con WebExtensions, los ajustes generalmente se almacenan utilizando la API [`sto
 - Escribir un script, incluido desde el archivo HTML , que establece la página de configuración desde su almacenamiento y actualiza los ajustes seleccionados cuando el usuario los modifica.
 - Establecer la ruta al archivo HTML como la clave [`options_ui`](/es/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) en manifest.json. Haciendo esto, el documento HTML se mostrará en el administrador de complementos del navegador, junto al nombre del complemento y su descripción.
 
-> **Nota:** También puedes abrir esta página mediante programación utilizando la función [`runtime.openOptionsPage()`](/es/docs/Mozilla/Add-ons/WebExtensions/API/runtime/openOptionsPage) .
+> [!NOTE]
+> También puedes abrir esta página mediante programación utilizando la función [`runtime.openOptionsPage()`](/es/docs/Mozilla/Add-ons/WebExtensions/API/runtime/openOptionsPage) .
 
 ## Una sencilla ExtensionWeb
 

--- a/files/es/mozilla/add-ons/webextensions/manifest.json/icons/index.md
+++ b/files/es/mozilla/add-ons/webextensions/manifest.json/icons/index.md
@@ -49,7 +49,8 @@ Puede usar SVG y el navegador escalará su icono adecuadamente. Sin embargo, hay
    }
    ```
 
-> **Nota:** Si está usando un programa como Inkscape para crear SVG, puede que quiera guardarlo como un "SVG simple". Firefox podría confundirse con varios espacios de nombres especiales y no mostrar su icono.
+> [!NOTE]
+> Si está usando un programa como Inkscape para crear SVG, puede que quiera guardarlo como un "SVG simple". Firefox podría confundirse con varios espacios de nombres especiales y no mostrar su icono.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/mozilla/add-ons/webextensions/manifest.json/index.md
+++ b/files/es/mozilla/add-ons/webextensions/manifest.json/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/manifest.json
 
 {{AddonSidebar}}
 
-> **Nota:** Este artículo describe manifest.json para extensiones web. Si estás buscando información acerca de manifest.json en PWAs, revisa el artículo sobre [Web App Manifest](/es/docs/Web/Manifest).
+> [!NOTE]
+> Este artículo describe manifest.json para extensiones web. Si estás buscando información acerca de manifest.json en PWAs, revisa el artículo sobre [Web App Manifest](/es/docs/Web/Manifest).
 
 El archivo `manifest.json` es el único archivo que toda extensión usando la API WebExtension debe contener necesariamente.
 

--- a/files/es/mozilla/add-ons/webextensions/modify_a_web_page/index.md
+++ b/files/es/mozilla/add-ons/webextensions/modify_a_web_page/index.md
@@ -37,9 +37,11 @@ Para empezar, crea un nuevo directorio llamado "modify-page". En este directorio
 
 La llave [`content_scripts`](/es/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) es el método de carga de scripts a páginas cuya URL encaje con los patrones. En este caso, `content_scripts` le dice al navegador que cargue una script llamada "page-eater.js" en todas las páginas con <https://developer.mozilla.org/>.
 
-> **Nota:** Debido a que el atributo `"js"` de `content_scripts` es una array, puedes usarla para inyectar más de una script a las páginas que encajen con el patrón. Si haces esto las páginas compartiran el mismo campo de aplicación, igual que múltiples scripts cargadas por una página, y son cargadas en el mismo orden en las que están dispuestas en la array.
+> [!NOTE]
+> Debido a que el atributo `"js"` de `content_scripts` es una array, puedes usarla para inyectar más de una script a las páginas que encajen con el patrón. Si haces esto las páginas compartiran el mismo campo de aplicación, igual que múltiples scripts cargadas por una página, y son cargadas en el mismo orden en las que están dispuestas en la array.
 
-> **Nota:** La llave `content_scripts` tambien tiene un atributo de `"css"` que puedes usar para inyectar código CSS.
+> [!NOTE]
+> La llave `content_scripts` tambien tiene un atributo de `"css"` que puedes usar para inyectar código CSS.
 
 Después, crea un archivo llamado "page-eater.js" dentro del directorio "modify-page" e introduce el contenido de a continuación:
 
@@ -55,7 +57,8 @@ Ahora, [instala la extensión](/es/Add-ons/WebExtensions/Temporary_Installation_
 
 {{EmbedYouTube("lxf2Tkg6U1M")}}
 
-> **Nota:** Ten en cuenta que aunque este video muestra el contenido de la script operando en [addons.mozilla.org](https://addons.mozilla.org/en-US/firefox/), las scripts de contenido están bloqueadas en esta página por el momento.
+> [!NOTE]
+> Ten en cuenta que aunque este video muestra el contenido de la script operando en [addons.mozilla.org](https://addons.mozilla.org/en-US/firefox/), las scripts de contenido están bloqueadas en esta página por el momento.
 
 ## Modificando las páginas programaticamente
 
@@ -114,7 +117,8 @@ Ahora [recarga la extensión](/es/Add-ons/WebExtensions/Temporary_Installation_i
 
 {{EmbedYouTube("zX4Bcv8VctA")}}
 
-> **Nota:** Ten en cuenta que aunque este video muestra el contenido de la script operando en [addons.mozilla.org](https://addons.mozilla.org/en-US/firefox/), las scripts de contenido están bloqueadas en esta página por el momento.
+> [!NOTE]
+> Ten en cuenta que aunque este video muestra el contenido de la script operando en [addons.mozilla.org](https://addons.mozilla.org/en-US/firefox/), las scripts de contenido están bloqueadas en esta página por el momento.
 
 ## Mensajería
 
@@ -177,7 +181,8 @@ Ahora, en vez de simplemente comer la página, el contenido espera a un mensaje 
 
 Debido a que [`tabs.executeScript()`](/es/Add-ons/WebExtensions/API/tabs/executeScript) es una función asincrónica y para asegurarnos de que mandamos el mensaje solo cuando el escuchador ha sido añadido en "page-eater.js", usamos `onExecuted` que sera llamado después de que "page-eater.js" se ejecute.
 
-> **Nota:** Pulsa Ctrl+Shift+J (o Cmd+Shift+J en el Mac) o `web-ext run --bc` para abrir la consola de navegación para ver `console.log` en la script de fondo. Alternativamente puedes usar el [Add-on Debugger](/es/Add-ons/Add-on_Debugger), el cual te permite poner un breakpoint. De momento no hay forma de iniciar un [Add-on Debugger directamente de una extensión web](https://github.com/mozilla/web-ext/issues/759).
+> [!NOTE]
+> Pulsa Ctrl+Shift+J (o Cmd+Shift+J en el Mac) o `web-ext run --bc` para abrir la consola de navegación para ver `console.log` en la script de fondo. Alternativamente puedes usar el [Add-on Debugger](/es/Add-ons/Add-on_Debugger), el cual te permite poner un breakpoint. De momento no hay forma de iniciar un [Add-on Debugger directamente de una extensión web](https://github.com/mozilla/web-ext/issues/759).
 
 Si queremos enviar mensajes directamente desde el contenido script de vuelta a la página de fondo, podríamos usar[`runtime.sendMessage()`](/es/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage) en vez de [`tabs.sendMessage()`](/es/docs/Mozilla/Add-ons/WebExtensions/API/tabs/sendMessage). Por ejemplo:
 
@@ -187,7 +192,8 @@ browser.runtime.sendMessage({
 });
 ```
 
-> **Nota:** Todos estos ejemplos inyectan Javascript; también puedes inyectar CSS programaticamente usando la función[`tabs.insertCSS()`](/es/docs/Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS).
+> [!NOTE]
+> Todos estos ejemplos inyectan Javascript; también puedes inyectar CSS programaticamente usando la función[`tabs.insertCSS()`](/es/docs/Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS).
 
 ## Aprende más
 

--- a/files/es/mozilla/add-ons/webextensions/user_interface/index.md
+++ b/files/es/mozilla/add-ons/webextensions/user_interface/index.md
@@ -9,7 +9,8 @@ l10n:
 
 Las extensiones que usan las API de WebExtension se proporcionan con varias opciones de interfaz de usuario para que su funcionalidad pueda estar disponible para el usuario. A continuación se proporciona un resumen de esas opciones, con una introducción más detallada a cada opción de la interfaz de usuario en esta sección.
 
-> **Nota:** Para obtener consejos sobre el uso de estos componentes de la interfaz de usuario para crear una excelente experiencia de usuario en su extensión, consulte el artículo [Prácticas recomendadas para la experiencia del usuario](https://extensionworkshop.com/documentation/develop/user-experience-best-practices/).
+> [!NOTE]
+> Para obtener consejos sobre el uso de estos componentes de la interfaz de usuario para crear una excelente experiencia de usuario en su extensión, consulte el artículo [Prácticas recomendadas para la experiencia del usuario](https://extensionworkshop.com/documentation/develop/user-experience-best-practices/).
 
 <table class="standard-table">
   <thead>

--- a/files/es/mozilla/add-ons/webextensions/your_first_webextension/index.md
+++ b/files/es/mozilla/add-ons/webextensions/your_first_webextension/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/Your_first_WebExtension
 
 {{AddonSidebar}}
 
-> **Nota:** Si estás familiarizado/a con los conceptos básicos de las extensiones de navegador, omite esta sección y ve a [cómo se ponen juntos los archivos](/es/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension). Entonces, usa la [documentación de referencia](/es/docs/Mozilla/Add-ons/WebExtensions#Reference) para empezar a construir tu extensión. Visita el [Firefox Extension Workshop](https://extensionworkshop.com/?utm_source=developer.mozilla.org&utm_medium=documentation&utm_campaign=your-first-extension) para aprender más sobre el flujo de trabajo para probar y publicar extensiones para Firefox.
+> [!NOTE]
+> Si estás familiarizado/a con los conceptos básicos de las extensiones de navegador, omite esta sección y ve a [cómo se ponen juntos los archivos](/es/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension). Entonces, usa la [documentación de referencia](/es/docs/Mozilla/Add-ons/WebExtensions#Reference) para empezar a construir tu extensión. Visita el [Firefox Extension Workshop](https://extensionworkshop.com/?utm_source=developer.mozilla.org&utm_medium=documentation&utm_campaign=your-first-extension) para aprender más sobre el flujo de trabajo para probar y publicar extensiones para Firefox.
 
 En este artículo abordaremos la creación de una extensión para Firefox, desde el comienzo hasta el final. La extensión solo agrega un borde rojo a cualquiera de las páginas cargadas desde "mozilla.org" o cualquiera de sus subdominios.
 
@@ -125,7 +126,8 @@ Ahora pruebe visitando una página bajo "mozilla.org", y usted verá el borde ro
 
 {{EmbedYouTube("rxBQl2Z9IBQ")}}
 
-> **Nota:** No lo intentes en addons.mozilla.org! Los scripts de contenido están actualmente bloqueados en ese dominio.
+> [!NOTE]
+> No lo intentes en addons.mozilla.org! Los scripts de contenido están actualmente bloqueados en ese dominio.
 
 Experimenta un poco. Edita el contenido del script para cambiar el color del borde, o haz algo más en el contenido de la página. Si actualizas el script de contenido, recarga los archivos de la extensión haciendo clic en el botón "Recargar" en about:debugging. Podrás ver los cambios en el momento:
 

--- a/files/es/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/es/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -307,7 +307,8 @@ browser.tabs
 
 Empecemos por la linea 96. La ventana emergente ejecuta un script de contenido en la pestaña activa tan pronto como se termina de cargar, usando la API [`browser.tabs.executeScript()`](/es/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript). Si la ejecución del script de contenido es exitosa, este quedará cargado en la página hasta que sea cerrada la pestaña o hasta que el usuario navegue hacia una página distinta.
 
-> **Nota:** Un motivo común por el cual el llamado a `browser.tabs.executeScript()` puede fallar, es porque no es posible ejecutar scripts de contenido en todas las páginas, por ejemplo, en páginas de navegador privilegiadas como about:debugging, o páginas del dominio [addons.mozilla.org](https://addons.mozilla.org/), no es posible hacerlo.
+> [!NOTE]
+> Un motivo común por el cual el llamado a `browser.tabs.executeScript()` puede fallar, es porque no es posible ejecutar scripts de contenido en todas las páginas, por ejemplo, en páginas de navegador privilegiadas como about:debugging, o páginas del dominio [addons.mozilla.org](https://addons.mozilla.org/), no es posible hacerlo.
 
 Si la ejecución falla, `reportExecuteScriptError()` ocultará el `<div>` `"popup-content"`, mostrará el `<div>` `"error-content"`, y reportará el error en la consola.
 

--- a/files/es/mozilla/firefox/releases/3/updating_extensions/index.md
+++ b/files/es/mozilla/firefox/releases/3/updating_extensions/index.md
@@ -128,7 +128,8 @@ O bien, emplear la siguiente técnica para hacer que la superposición funcione 
 </window>
 ```
 
-> **Nota:** Este cambio es efectivo para Firefox 3 beta 4 y la prebeta 4.
+> [!NOTE]
+> Este cambio es efectivo para Firefox 3 beta 4 y la prebeta 4.
 
 #### Otros cambios
 

--- a/files/es/mozilla/firefox/releases/3/updating_web_applications/index.md
+++ b/files/es/mozilla/firefox/releases/3/updating_web_applications/index.md
@@ -65,7 +65,8 @@ content mypackage location/ contentaccessible=yes
 
 Esto no debería ser algo que se haga muy seguido, pero está disponible para aquellos casos raros en los que es necesario. Debe tomarse en cuenta que es posible que Firefox alerte al usuario que su extensión utiliza una bandera en el contentaccessible de alguna manera, ya que consituye un riesgo potencial en la seguridad.
 
-> **Nota:** Ya que Firefox 2 no entiende la bandera `contentaccessible` (ignorará la instrucción completa de que contiene la bandera), si se desea que el complemento sea compatible con Firefox 2 y Firefox 3, hay que hacer algo como esto:
+> [!NOTE]
+> Ya que Firefox 2 no entiende la bandera `contentaccessible` (ignorará la instrucción completa de que contiene la bandera), si se desea que el complemento sea compatible con Firefox 2 y Firefox 3, hay que hacer algo como esto:
 >
 > ```
 > content mypackage location/

--- a/files/es/mozilla/firefox/releases/57/index.md
+++ b/files/es/mozilla/firefox/releases/57/index.md
@@ -11,7 +11,8 @@ Este artículo proporciona información sobre los cambios incluidos en Firefox 5
 
 Hemos bautizado a Firefox 57 como **Quantum** por el proyecto de ingeniería [Firefox Quantum](https://wiki.mozilla.org/Quantum), cuyo objetivo ha sido el de reconstruir Firefox desde cero para darle un rendimiento y una estabilidad excelentes, así como mejorar su apariencia visual. Esta es la primera versión de Firefox en incluir algunos de estos cambios, así que quisimos conmemorar el acontecimiento.
 
-> **Nota:** para obtener más información sobre las funciones de Quantum incluidas en esta versión, consúltese el artículo [«Firefox Quantum Developer Edition: el Firefox más rápido, con IU Photon y mejores herramientas»](https://hacks.mozilla.org/2017/09/firefox-quantum-developer-edition-fastest-firefox-ever/), escrito por Dan Callahan.
+> [!NOTE]
+> Para obtener más información sobre las funciones de Quantum incluidas en esta versión, consúltese el artículo [«Firefox Quantum Developer Edition: el Firefox más rápido, con IU Photon y mejores herramientas»](https://hacks.mozilla.org/2017/09/firefox-quantum-developer-edition-fastest-firefox-ever/), escrito por Dan Callahan.
 
 [El nuevo procesador de CSS en paralelo de Firefox](https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo/) ―también denominado **Quantum CSS** o **Stylo**― está activado de manera predeterminada en Firefox 57 para escritorio; las versiones para móviles darán el salto en el futuro. Los programadores no deberían notar ninguna diferencia importante, aparte de la amplia gama de mejoras de rendimiento. Sin embargo, existen algunas diferencias menores de funcionalidad en Stylo, las cuales se han implementado para corregir comportamientos no estándares de Gecko que habrían de desaparecer. Informaremos de esas diferencias en las páginas de referencia y en las notas de publicación según proceda (véanse [Notas sobre Quantum CSS](#notas_sobre_quantum_css)).
 
@@ -83,7 +84,8 @@ _No hay ningún cambio._
 
 - Ahora se admiten mensajes de cualquier tamaño (hasta 1 GiB, aunque 256 kiB es más interoperativo) en {{domxref("RTCDataChannel")}} por medio del uso de la opción «end-of-record» (EOR) en los mensajes de SCTP. Consúltese [Understanding message size limits](/es/docs/Web/API/WebRTC_API/Using_data_channels#understanding_message_size_limits) para obtener más información ([Error 979417 en Firefox](https://bugzil.la/979417)).
 
-  > **Nota:** Como Firefox aún no admite el protocolo ndata de SCTP, que permite intercalar mensajes de SCTP de varias fuentes, enviar objetos de datos grandes puede causar retardos importantes en el resto del tránsito SCTP. Véase el [Error 1381145 en Firefox](https://bugzil.la/1381145) para estar al tanto de la implementación de ndata en Firefox.
+  > [!NOTE]
+  > Como Firefox aún no admite el protocolo ndata de SCTP, que permite intercalar mensajes de SCTP de varias fuentes, enviar objetos de datos grandes puede causar retardos importantes en el resto del tránsito SCTP. Véase el [Error 1381145 en Firefox](https://bugzil.la/1381145) para estar al tanto de la implementación de ndata en Firefox.
 
 - El método {{domxref("RTCDataChannel.send()")}} ahora puede emitir una excepción `TypeError` si el tamaño del mensaje que se intenta enviar no es compatible con el agente de usuario de destino (esto se implementó como parte del [Error 979417 en Firefox](https://bugzil.la/979417)).
 - La [API MediaStream Recording](/es/docs/Web/API/MediaStream_Recording_API) se ha actualizado de modo que los sucesos [`error`](/es/docs/Web/Reference/Events/error) que se envíen para notificar problemas acaecidos durante la grabación son ahora del tipo {{domxref("MediaRecorderErrorEvent")}} en lugar de sucesos genéricos.
@@ -119,7 +121,8 @@ _No hay ningún cambio._
 
 ## Cambios relativos a los complementos y los programadores de Mozilla
 
-> **Nota:** A partir de Firefox 57, se ha eliminado por completo la compatibilidad con los complementos basados en la tecnología XPCOM. Todas las extensiones deben convertirse para emplear la [tecnología nueva](/es/Add-ons/WebExtensions), conocida como WebExtensions, o de lo contrario dejarán de funcionar.
+> [!NOTE]
+> A partir de Firefox 57, se ha eliminado por completo la compatibilidad con los complementos basados en la tecnología XPCOM. Todas las extensiones deben convertirse para emplear la [tecnología nueva](/es/Add-ons/WebExtensions), conocida como WebExtensions, o de lo contrario dejarán de funcionar.
 
 ### WebExtensions
 

--- a/files/es/mozilla/firefox/releases/9/updating_add-ons/index.md
+++ b/files/es/mozilla/firefox/releases/9/updating_add-ons/index.md
@@ -13,7 +13,8 @@ Si tu complemento se distribuye en [addons.mozilla.org](https://addons.mozilla.o
 
 Así que puedes empezar visitando AMO para comprobar si tu complemento requiere trabajo.
 
-> **Nota:** Todavía debes testear tu complemento en Firefox 9, incluso si ha sido actualizado automáticamente. Existen casos extremos que pueden no ser automáticamente detectados.
+> [!NOTE]
+> Todavía debes testear tu complemento en Firefox 9, incluso si ha sido actualizado automáticamente. Existen casos extremos que pueden no ser automáticamente detectados.
 
 ## Los componentes de inicio pueden remover scripts con carga retrasada
 

--- a/files/es/orphaned/web/css/-moz-context-properties/index.md
+++ b/files/es/orphaned/web/css/-moz-context-properties/index.md
@@ -6,7 +6,8 @@ original_slug: Web/CSS/-moz-context-properties
 
 {{CSSRef}}{{Non-standard_header}}
 
-> **Nota:** Este recurso esta disponible desde Firefox 55, pero solamente es compatible con imagenes SVG cargadas via `chrome://` o `resource://` URLs. Para experimentar con la caracteristica SVG en la web, es necesario poner `svg.context-properties.content.enabled` en `true`.
+> [!NOTE]
+> Este recurso esta disponible desde Firefox 55, pero solamente es compatible con imagenes SVG cargadas via `chrome://` o `resource://` URLs. Para experimentar con la caracteristica SVG en la web, es necesario poner `svg.context-properties.content.enabled` en `true`.
 
 Si mencionas una imagen SVG en una pagina web({{htmlelement("img")}} como elemento o como fondo de pagina), la imagen SVG puede coordinarse con el elemento incrustado(su contexto) para que la imagen adopte las propiedades puestas en el elemento incrustado. Para hacer esto, el elemento incrustado necesita listar las propiedades que deben estar disponibles para la imagen listadolas como valores de la propiedad **`-moz-context-properties`**, y la imagen necesita optar a usar esas propiedades utilizando valores tales como el valor de `context-fill`.
 
@@ -66,7 +67,8 @@ Ahora que has hecho eso la imagen SVG puede utlizar los valores de {{cssxref("fi
 
 Aqui hemos puesto que la imagen `src` sea una URL de datos que contiene una imagen SVG simple; el `<rect>` de dentro ha sido hecho para coger sus valores de `fill` y `stroke` de {{cssxref("fill")}} y {{cssxref("stroke")}} puestos en el elemento `<img>` poniendo `context-fill`/`context-stroke` en sus valores asi como un color para rellenar(rojo) que sera utilizado en caso que el SVG es cargado independientemente en una ventana superior(donde no tendra contexto para dar los valores ). Tener en cuenta que si un colore es directamente puesto en el SVG, pero el color del contexto tambien es especificado, el color del contexto sobreescribe el color directo.
 
-> **Nota:** Puedes en contrar un [ejemplo de ejecucion en Github](https://mdn.github.io/css-examples/moz-context-properties/).
+> [!NOTE]
+> Puedes en contrar un [ejemplo de ejecucion en Github](https://mdn.github.io/css-examples/moz-context-properties/).
 
 ## Especificaciones
 

--- a/files/es/orphaned/web/css/css_properties_reference/index.md
+++ b/files/es/orphaned/web/css/css_properties_reference/index.md
@@ -8,7 +8,8 @@ original_slug: Web/CSS/CSS_Properties_Reference
 
 La siguiente lista es una lista de la propiedades CSS más comunes junto con su equivalente en notación DOM que es cómo son normalmente accedidas desde JavaScript.
 
-> **Nota:** Es una lista incompleta. Para descubrir más propiedades CSS visita [la referencia principal CSS ](/es/docs/Web/CSS/Reference)y and [las Extensiones CSS de Mozilla](/es/docs/Web/CSS/Mozilla_Extensions). Los artículos de referencia incluyen ejemplos sobre cómo usar todas estas propiedades.
+> [!NOTE]
+> Es una lista incompleta. Para descubrir más propiedades CSS visita [la referencia principal CSS ](/es/docs/Web/CSS/Reference)y and [las Extensiones CSS de Mozilla](/es/docs/Web/CSS/Mozilla_Extensions). Los artículos de referencia incluyen ejemplos sobre cómo usar todas estas propiedades.
 
 | **CSS**               | **JavaScript**       |
 | --------------------- | -------------------- |

--- a/files/es/orphaned/web/css/ime-mode/index.md
+++ b/files/es/orphaned/web/css/ime-mode/index.md
@@ -54,11 +54,13 @@ input[type=password] {
 }
 ```
 
-> **Nota:** En general, no es apropiado por un sitio público la manipulación el estado del modo de IME. Esta propiedad debería usarse para aplicaciones web o similares.
+> [!NOTE]
+> En general, no es apropiado por un sitio público la manipulación el estado del modo de IME. Esta propiedad debería usarse para aplicaciones web o similares.
 
 La versión de Gecko 1.9 para Macintosh no es capaz de recuperar el estado previo del IME cuando el campo para el cual se ha desactivado pierde el foco, por tanto, los usuarios de Mac podrían enfadarse cuando se utiliza el valor `disabled`.
 
-> **Nota:** Desactivar el IME para prevenir la entrada de caracteres extendidos en los formularios no impide que los usuarios puedan pegar caracteres extendidos en los campos del formulario.
+> [!NOTE]
+> Desactivar el IME para prevenir la entrada de caracteres extendidos en los formularios no impide que los usuarios puedan pegar caracteres extendidos en los campos del formulario.
 
 ### Especificaciones
 

--- a/files/es/web/accessibility/aria/attributes/aria-label/index.md
+++ b/files/es/web/accessibility/aria/attributes/aria-label/index.md
@@ -15,7 +15,8 @@ string
 
 ### Posibles efectos sobre los agentes de usuario y la tecnología de asistencia
 
-> **Nota:** Las opiniones pueden diferir en cómo la tecnología asistencial debe manejar esta técnica. La información proporcionada más arriba es una de esas opiniones y por lo tanto no normativa.
+> [!NOTE]
+> Las opiniones pueden diferir en cómo la tecnología asistencial debe manejar esta técnica. La información proporcionada más arriba es una de esas opiniones y por lo tanto no normativa.
 
 ## Ejemplos
 

--- a/files/es/web/accessibility/aria/attributes/aria-required/index.md
+++ b/files/es/web/accessibility/aria/attributes/aria-required/index.md
@@ -21,7 +21,8 @@ Los lectores de pantalla deben anunciar el campo como requerido.
 
 Nota que este atributo no cambiará automáticamente la presentación del campo.
 
-> **Nota:** Las opiniones pueden diferir en cuanto a cómo esta técnica debería ser manejada por la tecnología asistente. La información prevista arribaes una de esas opciones y por lo tanto no es normativa.
+> [!NOTE]
+> Las opiniones pueden diferir en cuanto a cómo esta técnica debería ser manejada por la tecnología asistente. La información prevista arribaes una de esas opciones y por lo tanto no es normativa.
 
 ### Ejemplos
 

--- a/files/es/web/accessibility/aria/attributes/index.md
+++ b/files/es/web/accessibility/aria/attributes/index.md
@@ -9,7 +9,8 @@ Esta página enumera las páginas de referencia que cubren todos los atributos d
 
 Los atributos <abbr>ARIA</abbr> permiten modificar los estados y las propiedades de un elemento tal como se define en el árbol d
 
-> **Nota:** ARIA solo modifica el árbol de accesibilidad, modificando cómo la tecnología de asistencia presenta el contenido a sus usuarios. ARIA no cambia nada sobre la función o el comportamiento de un elemento. Cuando no use elementos HTML semánticos para su propósito previsto y funcionalidad predeterminada, debe usar JavaScript para administrar el comportamiento, el enfoque y los estados ARIA.
+> [!NOTE]
+> ARIA solo modifica el árbol de accesibilidad, modificando cómo la tecnología de asistencia presenta el contenido a sus usuarios. ARIA no cambia nada sobre la función o el comportamiento de un elemento. Cuando no use elementos HTML semánticos para su propósito previsto y funcionalidad predeterminada, debe usar JavaScript para administrar el comportamiento, el enfoque y los estados ARIA.
 
 ## Tipos de atributos ARIA
 

--- a/files/es/web/accessibility/aria/index.md
+++ b/files/es/web/accessibility/aria/index.md
@@ -9,11 +9,13 @@ Accessible Rich Internet Applications **(<abbr>ARIA</abbr>)** es una colección 
 
 Complementa HTML para que las interacciones y los widgets que se usan comúnmente en las aplicaciones puedan ser correctamente interpretadas por las tecnologías de asistencia cuando no existe otro mecanismo. Por ejemplo, ARIA habilita accesibilidad a widgets de JavaScript, sugerencias de formularios, mensajes de error, actualizaciones de contenido en vivo y más.
 
-> **Advertencia:** Muchos de estos widgets se incorporaron posteriormente a HTML5, y **los desarrolladores deberían preferir usar el elemento HTML semántico correcto en lugar de usar ARIA**, si tal elemento existe. Por ejemplo, los elementos nativos tienen incorporado [accesibilidad de teclado](/es/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets), roles y estados. Sin embargo, si elige usar ARIA, es responsable de imitar el comportamiento equivalente del navegador en la secuencia de comandos.
+> [!WARNING]
+> Muchos de estos widgets se incorporaron posteriormente a HTML5, y **los desarrolladores deberían preferir usar el elemento HTML semántico correcto en lugar de usar ARIA**, si tal elemento existe. Por ejemplo, los elementos nativos tienen incorporado [accesibilidad de teclado](/es/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets), roles y estados. Sin embargo, si elige usar ARIA, es responsable de imitar el comportamiento equivalente del navegador en la secuencia de comandos.
 
 [La primera regla de ARIA](https://www.w3.org/TR/using-aria/#rule1) es "Si puede usar un elemento o atributo HTML nativo con la semántica y el comportamiento que necesita ya integrado, en lugar de reutilizar un elemento y agregar un rol, estado o propiedad de ARIA para hacerlo accesible, hágalo".
 
-> **Nota:** Hay un dicho "No utilizar ARIA es mejor que utilizar una mala ARIA". En [la encuesta de WebAim de más de un millón de páginas de inicio](https://webaim.org/projects/million#aria), encontraron que las páginas de inicio con ARIA presentes promediaron un 41 % más de errores detectados que aquellas sin ARIA. Si bien ARIA está diseñado para hacer que las páginas web sean más accesibles, si se usa incorrectamente, puede hacer más daño que bien.
+> [!NOTE]
+> Hay un dicho "No utilizar ARIA es mejor que utilizar una mala ARIA". En [la encuesta de WebAim de más de un millón de páginas de inicio](https://webaim.org/projects/million#aria), encontraron que las páginas de inicio con ARIA presentes promediaron un 41 % más de errores detectados que aquellas sin ARIA. Si bien ARIA está diseñado para hacer que las páginas web sean más accesibles, si se usa incorrectamente, puede hacer más daño que bien.
 
 Aquí está el marcado para una barra de progreso:
 
@@ -55,9 +57,11 @@ Habría sido mucho más simple usar el elemento nativo {{HTMLElement('progress')
 <progress id="percent-loaded" value="75" max="100">75 %</progress>
 ```
 
-> **Nota:** El atributo `min` no está permitido para el elemento {{HTMLElement('progress')}}; su valor mínimo es siempre `0`.
+> [!NOTE]
+> El atributo `min` no está permitido para el elemento {{HTMLElement('progress')}}; su valor mínimo es siempre `0`.
 
-> **Nota:** Los elementos de referencia HTML ({{HTMLElement("main")}}, {{HTMLElement("header")}}, {{HTMLElement("nav")}} etc.) tienen roles ARIA implícitos, por lo que no es necesario duplicarlos.
+> [!NOTE]
+> Los elementos de referencia HTML ({{HTMLElement("main")}}, {{HTMLElement("header")}}, {{HTMLElement("nav")}} etc.) tienen roles ARIA implícitos, por lo que no es necesario duplicarlos.
 
 ## Soporte
 

--- a/files/es/web/accessibility/aria/multipart_labels/index.md
+++ b/files/es/web/accessibility/aria/multipart_labels/index.md
@@ -36,7 +36,8 @@ Tanto **aria-labelledby** y **aria-describedby** se especifican en el elemento d
 
 JAWS 8.0 tiene su propia lógica para encontrar etiquetas, causando que siempre sobreescriba el nombre accesible que obtiene la caja de texto de un documento HTML. Con JAWS 8, no se ha encontrado una manera de hacer que acepte la etiqueta del ejemplo anterior. Pero NVDA y Window-Eyes funcionan correctamente, Orca on Linux tampoco tiene problemas.
 
-> **Nota:** TBD (pendiente): añadir más información sobre compatiblidad
+> [!NOTE]
+> TBD (pendiente): añadir más información sobre compatiblidad
 
 ## ¿Puede hacerse sin ARIA?
 

--- a/files/es/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/es/web/accessibility/aria/roles/alert_role/index.md
@@ -29,7 +29,8 @@ Productos de tecnología asistencial deben escuchar por dicho evento y notificar
 - Lectores de pantalla pueden interrumpir la entrada actual (sea por voz o braile) e inmediatamente anunciar o desplegar el mensaje de alerta.
 - Lupas de pantalla pueden indicar visualmente que una alerta ha ocurrido y que texto tuvo la alerta.
 
-> **Nota:** Opiniones pueden diferir en como tecnologías de asistencia deben manejar esta técnica. La información proveida anteriormente es una de estas opiniones y por lo tanto no es normativa.
+> [!NOTE]
+> Opiniones pueden diferir en como tecnologías de asistencia deben manejar esta técnica. La información proveida anteriormente es una de estas opiniones y por lo tanto no es normativa.
 
 ### Ejemplos
 

--- a/files/es/web/accessibility/aria/roles/alertdialog_role/index.md
+++ b/files/es/web/accessibility/aria/roles/alertdialog_role/index.md
@@ -19,7 +19,8 @@ La diferencia con díalogos normales es que el rol de `alertdialog` debe ser uti
 
 Debido a su carácter urgente los díalogos de alerta deben ser siempre modales.
 
-> **Nota:** Este rol solo debe ser usado para mensajes de alerta que tienen controles interactivos asociado. Si un díalogo de alerta solo contiene contenido estático y no tiene controles interactivos, `alertdialog` es probablemente el rol incorrecto para ser utilizado.. El rol `alert` debe ser usado en su lugar en éste caso (como se describe en la técnica de [Utilizando el rol `alert`](/en/ARIA/ARIA_Techniques/Using_the_alert_role)).
+> [!NOTE]
+> Este rol solo debe ser usado para mensajes de alerta que tienen controles interactivos asociado. Si un díalogo de alerta solo contiene contenido estático y no tiene controles interactivos, `alertdialog` es probablemente el rol incorrecto para ser utilizado.. El rol `alert` debe ser usado en su lugar en éste caso (como se describe en la técnica de [Utilizando el rol `alert`](/en/ARIA/ARIA_Techniques/Using_the_alert_role)).
 
 ### Posibles efectos de agentes de usuario y tecnología de asistencia
 
@@ -32,7 +33,8 @@ Cuando la aleta de díalogo aparece, los lectores de pantalla deberían anunciar
 
 Cuando el díalogo de alerta es etiquetado correctamente y el foco es movido de un control a el interior del díalogo, los lectores de pantalla deberían anunciar el rol accesible del díalogo así como su nombre y su descriipción antes de anunciar el elemento enfocado.
 
-> **Nota:** Opiniones pueden diferir en como tecnología de asistencia debe manejar esta técnica. La información proveída arriba es una de éstas opiniones y por lo tanto no es normativa.
+> [!NOTE]
+> Opiniones pueden diferir en como tecnología de asistencia debe manejar esta técnica. La información proveída arriba es una de éstas opiniones y por lo tanto no es normativa.
 
 ### Ejemplos
 

--- a/files/es/web/accessibility/understanding_wcag/keyboard/index.md
+++ b/files/es/web/accessibility/understanding_wcag/keyboard/index.md
@@ -11,7 +11,8 @@ Para ser completamente accesible, una página web debe ser operable por alguién
 
 Si un elemento puede ser enfocado utilizando un teclado, entonces debería ser interactivo, es decir, el usuario debería ser capaz de hacer algo y producir un cambio de algún tipo (por ejemplo, activar un enlace o cambiar una opción).
 
-> **Nota:** Una excepción importante a esta regla es si el elemento tiene aplicado `role="document"`, **dentro** un contexto interactivo (como un `role="application"`). En tal caso, enfocar el documento anidado es la única forma de devolver la tecnología de asistencia a un estado de no interactividad (comúnmente llamado "modo navegador").
+> [!NOTE]
+> Una excepción importante a esta regla es si el elemento tiene aplicado `role="document"`, **dentro** un contexto interactivo (como un `role="application"`). En tal caso, enfocar el documento anidado es la única forma de devolver la tecnología de asistencia a un estado de no interactividad (comúnmente llamado "modo navegador").
 
 La mayoría de los elementos son enfocables por defecto, y se puede hacer que un elemento sea enfocable al añadir el atributo `tabindex=0`. Sin embargo, sólo se debería añadir `tabindex` si el elemento también se hace interactivo, por ejemplo, definiendo los eventos de teclado apropiados para los manejadores de eventos.
 

--- a/files/es/web/accessibility/understanding_wcag/perceivable/index.md
+++ b/files/es/web/accessibility/understanding_wcag/perceivable/index.md
@@ -7,7 +7,8 @@ slug: Web/Accessibility/Understanding_WCAG/Perceivable
 
 Este artículo ofrece consejos prácticos sobre cómo hacer que tu sitio web cumpla con los criterios de **Percepción** de WCAG 2.0 y 2.1. Los estados perceptivos que los usuarios deben poder reconocer utilizando alguno de sus sentidos.
 
-> **Nota:** Para leer las definiciones de la W3C sobre Percepción y las guías para cumplir con los criterios dirígete a [Principle 1: Perceivable - Information and user interface components must be presentable to users in ways they can perceive.](https://www.w3.org/TR/WCAG21/#perceivable)
+> [!NOTE]
+> Para leer las definiciones de la W3C sobre Percepción y las guías para cumplir con los criterios dirígete a [Principle 1: Perceivable - Information and user interface components must be presentable to users in ways they can perceive.](https://www.w3.org/TR/WCAG21/#perceivable)
 
 ## Pauta 1.1 — Dar alternativas de texto para contenido no textual
 
@@ -124,7 +125,8 @@ La clave aquí es convertir el texto a otros formatos que puedan ser entendidos 
   </tbody>
 </table>
 
-> **Nota:** Ver también [WCAG description for Guideline 1.1: Text alternatives](https://www.w3.org/TR/WCAG21/#text-alternatives).
+> [!NOTE]
+> Ver también [WCAG description for Guideline 1.1: Text alternatives](https://www.w3.org/TR/WCAG21/#text-alternatives).
 
 ## Pauta 1.2 — Proporcionar alternativas para los medios tempo-dependientes
 
@@ -142,7 +144,8 @@ Los medios tempo-dependientes se refieren a multimedia con una duración (audio 
 | 1.2.8 Provee una alternativa para los elementos multimedia pre-grabados (AAA) | For all content that features video, a descriptive text transcript should be provided, for example a script of the movie you are watching. This is for the benefit of hearing impaired viewers who cannot hear the content.                                                                     | See [Audio transcripts](/es/docs/Learn/Accessibility/Multimedia#Audio_transcripts) for transcript information.                                                                                                                                                                                                                                                |
 | 1.2.9 Provee una transcripción para el audio en vivo (AAA)                    | For any live audio content being broadcast, a descriptive text should be provided, for example a script of the play or musical you are listening to. This is for the benefit of hearing impaired viewers who cannot hear the content.                                                           | See [Audio transcripts](/es/docs/Learn/Accessibility/Multimedia#Audio_transcripts) for transcript information.                                                                                                                                                                                                                                                |
 
-> **Nota:** Ver también la descripción de [WCAG Guideline 1.2: Time-based Media: Provide alternatives for time-based media](https://www.w3.org/TR/WCAG21/#time-based-media).
+> [!NOTE]
+> Ver también la descripción de [WCAG Guideline 1.2: Time-based Media: Provide alternatives for time-based media](https://www.w3.org/TR/WCAG21/#time-based-media).
 
 ## Pauta 1.3 — Crear contenido que pueda presentarse de diferentes formas
 
@@ -246,7 +249,8 @@ Esta pauta hace referencia a la posibilidad de que todo contenido pueda ser cons
   </tbody>
 </table>
 
-> **Nota:** Ver también la descripción de WCAG: [Guideline 1.3: Adaptable: Create content that can be presented in different ways without losing information or structure.](https://www.w3.org/TR/WCAG21/#adaptable)
+> [!NOTE]
+> Ver también la descripción de WCAG: [Guideline 1.3: Adaptable: Create content that can be presented in different ways without losing information or structure.](https://www.w3.org/TR/WCAG21/#adaptable)
 
 ## Pauta 1.4: Facilitar a los usuarios ver y oír el contenido, incluyendo la separación entre el primer plano y el fondo
 
@@ -397,4 +401,5 @@ Esta pauta tiene como objetivo la creación de contenido que sea fácil de difer
   </thead>
 </table>
 
-> **Nota:** Ver también la descripción de WCAG: [Guideline 1.4: Distinguishable: Make it easier for users to see and hear content including separating foreground from background.](https://www.w3.org/TR/WCAG21/#distinguishable)[.](https://www.w3.org/TR/WCAG21/#distinguishable)
+> [!NOTE]
+> Ver también la descripción de WCAG: [Guideline 1.4: Distinguishable: Make it easier for users to see and hear content including separating foreground from background.](https://www.w3.org/TR/WCAG21/#distinguishable)[.](https://www.w3.org/TR/WCAG21/#distinguishable)

--- a/files/es/web/api/analysernode/index.md
+++ b/files/es/web/api/analysernode/index.md
@@ -78,7 +78,8 @@ _Inherits methods from its parent,_ _{{domxref("AudioNode")}}_.
 
 ## Examples
 
-> **Nota:** See the guide [Visualizations with Web Audio API](/es/docs/Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API) for more information on creating audio visualizations.
+> [!NOTE]
+> See the guide [Visualizations with Web Audio API](/es/docs/Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API) for more information on creating audio visualizations.
 
 ### Basic usage
 

--- a/files/es/web/api/animation/cancel/index.md
+++ b/files/es/web/api/animation/cancel/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Animation/cancel
 
 El método `cancel()` de la Web Animations API de la interfaz {{domxref("Animation")}} borra todos los {{domxref("KeyframeEffect")}} causados por esta animación y aborta su reproducción.
 
-> **Nota:** Cuando se cancela una animación, su {{domxref("Animation.startTime", "startTime")}} y su {{domxref("Animation.currentTime", "currentTime")}} se establecen en `null`.
+> [!NOTE]
+> Cuando se cancela una animación, su {{domxref("Animation.startTime", "startTime")}} y su {{domxref("Animation.currentTime", "currentTime")}} se establecen en `null`.
 
 ## Sintaxis
 

--- a/files/es/web/api/animation/cancel_event/index.md
+++ b/files/es/web/api/animation/cancel_event/index.md
@@ -9,7 +9,8 @@ La propiedad `oncancel` de la interfaz {{domxref("Animation")}} de la [Web Anima
 
 El evento `cancel` puede ser activado manualmente con {{domxref("Animation.cancel()")}} cuando la animación entra en estado de reproducción `"idle"(inactivo)` desde otro estado, como cuando una animación se elimina de un elemento antes de que termine de reproducirse.
 
-> **Nota:** La creación de una nueva animación, inicialmente inactiva, no activa el evento [`cancel`](/es/docs/Web/Reference/Events/cancel) en la nueva animación.
+> [!NOTE]
+> La creación de una nueva animación, inicialmente inactiva, no activa el evento [`cancel`](/es/docs/Web/Reference/Events/cancel) en la nueva animación.
 
 ## Sintaxis
 

--- a/files/es/web/api/animation/finish_event/index.md
+++ b/files/es/web/api/animation/finish_event/index.md
@@ -9,7 +9,8 @@ La propiedad `onfinish` de la interfaz {{domxref("Animation")}} (de la [Web Anim
 
 El evento `finish` ocurre cuando la reproducción se completa de forma natural, así como cuando se llama al método {{domxref("Animation.finish()")}} para que la animación termine inmediatamente.
 
-> **Nota:** El estado de reproducción `"paused"` reemplaza al estado `"finished"`. Si la animación está pausada y finalizada, el estado`"paused"` será el único reportado. Puedes forzar el estado de la animación a `"finished"` configurando su {{domxref("Animation.startTime", "startTime")}} a `document.timeline.currentTime - (Animation.currentTime * Animation.playbackRate)`.
+> [!NOTE]
+> El estado de reproducción `"paused"` reemplaza al estado `"finished"`. Si la animación está pausada y finalizada, el estado`"paused"` será el único reportado. Puedes forzar el estado de la animación a `"finished"` configurando su {{domxref("Animation.startTime", "startTime")}} a `document.timeline.currentTime - (Animation.currentTime * Animation.playbackRate)`.
 
 ## Sintaxis
 

--- a/files/es/web/api/animation/finished/index.md
+++ b/files/es/web/api/animation/finished/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Animation/finished
 
 La propiedad de solo-lectura de `Animation.finished` de la [Web Animations API](/es/docs/Web/API/Web_Animations_API) devuelve un {{jsxref("Promise")}} que se resuelve una vez que la animación a terminado de reproducirse.
 
-> **Nota:** Una vez que la reproducción de la animación abandona el estado `finished` (es decir, la reproducción se está ejecutando otra vez), Un nuevo `Promise` es creado para esta propiedad. El nuevo `Promise` será resuelto cuando se haya completado la actual secuencia de la animación.
+> [!NOTE]
+> Una vez que la reproducción de la animación abandona el estado `finished` (es decir, la reproducción se está ejecutando otra vez), Un nuevo `Promise` es creado para esta propiedad. El nuevo `Promise` será resuelto cuando se haya completado la actual secuencia de la animación.
 
 ## Sintaxis
 

--- a/files/es/web/api/animation/playbackrate/index.md
+++ b/files/es/web/api/animation/playbackrate/index.md
@@ -21,7 +21,8 @@ Animation.playbackRate = newRate;
 
 Toma un número que puede ser 0, negativo o positivo. Los valores negativos invierten la animación. El valor es un factor de escala, por lo que, por ejemplo, un valor de 2 duplicaría la velocidad de reproducción.
 
-> **Nota:** si establecemos el `playbackRate` a `0` pausa la animación de manera efectiva (sin embargo, su {{domxref("Animation.playstate", "playstate")}} no se convierte necesariamente en `paused`).
+> [!NOTE]
+> Si establecemos el `playbackRate` a `0` pausa la animación de manera efectiva (sin embargo, su {{domxref("Animation.playstate", "playstate")}} no se convierte necesariamente en `paused`).
 
 ## Ejemplos
 

--- a/files/es/web/api/animation/playstate/index.md
+++ b/files/es/web/api/animation/playstate/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Animation/playState
 
 La propiedad `Animation.playState` de la [Web Animations API](/es/docs/Web/API/Web_Animations_API) devuelve y establece un valor enumerado que describe el estado de reproducción de una animación.
 
-> **Nota:** Esta propiedad es de solo lectura para las Animaciones y Transiciones en CSS.
+> [!NOTE]
+> Esta propiedad es de solo lectura para las Animaciones y Transiciones en CSS.
 
 ## Sintaxis
 

--- a/files/es/web/api/animation/ready/index.md
+++ b/files/es/web/api/animation/ready/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Animation/ready
 
 La propiedad de solo-lectura `Animation.ready` de la [Web Animations API](/es/docs/Web/API/Web_Animations_API) devuelve un {{jsxref("Promise")}} que se resuelve cuando la animación está lista para reproducirse. Una nueva 'promesa' es creada cada vez que la animación entra en [play state(estado de reproducción)](/es/docs/Web/API/Animation/playState) `"pending"(pendiente)` así como si la reproducción es cancelada, ya que en ambos escenarios, la animación estará lista para ser reiniciada.
 
-> **Nota:** Dado que la misma {{jsxref("Promise")}} es usada para las solicitudes pendientes de `play` y `pause` , se recomienda a los autores que comprueben el estado de la animación cuando se resuelva la promesa.
+> [!NOTE]
+> Dado que la misma {{jsxref("Promise")}} es usada para las solicitudes pendientes de `play` y `pause` , se recomienda a los autores que comprueben el estado de la animación cuando se resuelva la promesa.
 
 ## Sintaxis
 

--- a/files/es/web/api/attr/index.md
+++ b/files/es/web/api/attr/index.md
@@ -26,7 +26,8 @@ Este tipo representa un atributo de un elemento DOM como un objeto. En muchos mÃ
 - {{domxref("Attr.value", "value")}}
   - : El valor del atributo.
 
-> **Nota:** DOM Level 3 defined `namespaceURI`, `localName` and `prefix` on the {{domxref("Node")}} interface. In DOM4 they were moved to `Attr`.
+> [!NOTE]
+> DOM Level 3 defined `namespaceURI`, `localName` and `prefix` on the {{domxref("Node")}} interface. In DOM4 they were moved to `Attr`.
 >
 > This change is implemented in Chrome since version 46.0 and Firefox since version 48.0.
 

--- a/files/es/web/api/audionode/index.md
+++ b/files/es/web/api/audionode/index.md
@@ -16,7 +16,8 @@ Ejemplos que la incluyen:
 
 {{InheritanceDiagram}}
 
-> **Nota:** un `AudioNode` puede ser objetivo de eventos, por lo que implementa la interfaz {{domxref("EventTarget")}}.
+> [!NOTE]
+> Un `AudioNode` puede ser objetivo de eventos, por lo que implementa la interfaz {{domxref("EventTarget")}}.
 
 ## Descripción
 

--- a/files/es/web/api/battery_status_api/index.md
+++ b/files/es/web/api/battery_status_api/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Battery_Status_API
 
 La **API de Estado de Batería**, también conocida como "**Battery API**", provee información acerca del sistema de carga de la batería y permite notificar mediante eventos que son enviados cuando el nivel de la batería cambia. Este puede ser usado para ajustar el uso de recursos por parte de una aplicación y evitar un gasto innecesario de energía cuando la batería esta baja o para guardar cambios en un archivo antes de que la batería se agote y así prevenir perdida de información.
 
-> **Nota:** Esta API _no está disponible_ en los [Web Workers](/es/docs/Web/API/Web_Workers_API) (no está expuesta en {{domxref("WorkerNavigator")}}).
+> [!NOTE]
+> Esta API _no está disponible_ en los [Web Workers](/es/docs/Web/API/Web_Workers_API) (no está expuesta en {{domxref("WorkerNavigator")}}).
 
 ## Interfaces
 

--- a/files/es/web/api/batterymanager/chargingtime/index.md
+++ b/files/es/web/api/batterymanager/chargingtime/index.md
@@ -9,7 +9,8 @@ slug: Web/API/BatteryManager/chargingTime
 
 Indica la cantidad de tiempo, en segundos, que faltan para que la batería esté completamente cargada.
 
-> **Nota:** Incluso si el tiempo devuelto es exacto al segundo, los navegadores los redondean a un intervalo más alto (típicamente a los 15 minutos más cercanos) por razones de privacidad.
+> [!NOTE]
+> Incluso si el tiempo devuelto es exacto al segundo, los navegadores los redondean a un intervalo más alto (típicamente a los 15 minutos más cercanos) por razones de privacidad.
 
 ## Sintaxis
 

--- a/files/es/web/api/batterymanager/dischargingtime/index.md
+++ b/files/es/web/api/batterymanager/dischargingtime/index.md
@@ -8,7 +8,8 @@ slug: Web/API/BatteryManager/dischargingTime
 Indíca la cantidad de tiempo, en segundos,
 que restan antes de que la batería se descargue completamente.
 
-> **Nota:** Incluso si el tiempo devuelto es exacto al segundo, los navegadores los redondean a un intervalo más alto (típicamente a los 15 minutos más cercanos) por razones de privacidad.
+> [!NOTE]
+> Incluso si el tiempo devuelto es exacto al segundo, los navegadores los redondean a un intervalo más alto (típicamente a los 15 minutos más cercanos) por razones de privacidad.
 
 ## Sintaxis
 

--- a/files/es/web/api/blob/index.md
+++ b/files/es/web/api/blob/index.md
@@ -28,7 +28,8 @@ Una forma fácil de construir un `Blob` es invocando el constructor {{domxref("B
 - {{domxref("Blob.slice()")}}
   - : `Regresa un nuevo objeto Blob` conteniendo los datos de un rango específico de bytes del origen del `Blob`.
 
-> **Nota:** Esté consciente que el método `slice()` posee prefijos propios del fabricante en algunos exploradores y versiones: `blob.mozSlice()` para Firefox 12 e inferior y `blob.webkitSlice()` en Safari. Una versión anterior del método `slice()`, sin prefijos del fabricante, tenía diferente semántica, y se encuentra obsoleto. El soporte para `blob.mozSlice()` ha sido eliminado a partir de Firefox 30.
+> [!NOTE]
+> Esté consciente que el método `slice()` posee prefijos propios del fabricante en algunos exploradores y versiones: `blob.mozSlice()` para Firefox 12 e inferior y `blob.webkitSlice()` en Safari. Una versión anterior del método `slice()`, sin prefijos del fabricante, tenía diferente semántica, y se encuentra obsoleto. El soporte para `blob.mozSlice()` ha sido eliminado a partir de Firefox 30.
 
 ## Ejemplos
 
@@ -50,7 +51,8 @@ oBuilder.append(aFileParts[0]);
 var oMyBlob = oBuilder.getBlob("text/xml"); // the blob
 ```
 
-> **Advertencia:** La interfaz {{ domxref("BlobBuilder") }} ofrece otra manera de crear `Blob`, pero se encuentra ahora obsoleta y no debería volverse a utilizar.
+> [!WARNING]
+> La interfaz {{ domxref("BlobBuilder") }} ofrece otra manera de crear `Blob`, pero se encuentra ahora obsoleta y no debería volverse a utilizar.
 
 ### Ejemplo para crear una URL en un arreglo tipado utilizando un blob
 

--- a/files/es/web/api/cachestorage/open/index.md
+++ b/files/es/web/api/cachestorage/open/index.md
@@ -10,7 +10,8 @@ El método **`open()`** de la interfaz {{domxref("CacheStorage")}} devuelve una 
 Puedes acceder a `CacheStorage` a través de la propiedad global
 {{domxref("caches")}}.
 
-> **Nota:** Si la {{domxref("Cache")}} especificada no existe, se crea
+> [!NOTE]
+> Si la {{domxref("Cache")}} especificada no existe, se crea
 > una nueva caché con ese `cacheName` y una {{jsxref("Promise")}} que
 > resuelve este nuevo objeto {{domxref("Cache")}} devuelto.
 

--- a/files/es/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/es/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -41,7 +41,8 @@ Primero {{domxref("window.setInterval()")}}, {{domxref("window.setTimeout()")}},
 
 Si no quieres ninguna interacción del usuario puedes usar la función `setInterval()` que repite la ejecución del código suministrado. Si lo que queremos es hacer un juego, podríamos usar eventos de teclado o el mouse para controlar la animación y usar `setTimeout()`. Al establecer los {{domxref("EventListener")}}, capturamos cualquier interacción del usuario y ejecutamos nuestras funciones de animación.
 
-> **Nota:** En los siguiente ejemplo,usaremos el método para controlar animaciones {{domxref("window.requestAnimationFrame()")}}. El método `requestAnimationFrame` provee formas amigables y mas eficientes para animar llamando cada marco de animación cuando el sistema esta listo para dibujar. La cantidad de devoluciones de llamadas suele ser 60 veces por segundo y podría ser reducido a menor periodo cuando se corre en un segundo plano. Para mas información acerca de los ciclos de animación, especialmente para juegos, Ver el Articulo [Anatomía de un videojuego](/es/docs/Games/Anatomy) en nuestra [GameZona de desarrollo de Juegos](/es/docs/Games).
+> [!NOTE]
+> En los siguiente ejemplo,usaremos el método para controlar animaciones {{domxref("window.requestAnimationFrame()")}}. El método `requestAnimationFrame` provee formas amigables y mas eficientes para animar llamando cada marco de animación cuando el sistema esta listo para dibujar. La cantidad de devoluciones de llamadas suele ser 60 veces por segundo y podría ser reducido a menor periodo cuando se corre en un segundo plano. Para mas información acerca de los ciclos de animación, especialmente para juegos, Ver el Articulo [Anatomía de un videojuego](/es/docs/Games/Anatomy) en nuestra [GameZona de desarrollo de Juegos](/es/docs/Games).
 
 ## Un sistema solar animado
 

--- a/files/es/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/es/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -15,7 +15,8 @@ Comenzamos este tutorial observando el elemento {{HTMLElement("canvas")}}. Al fi
 
 A primera vista, un elemento {{HTMLElement("canvas")}} es parecido al elemento {{HTMLElement("img")}}, con la diferencia que este no tiene los atributos `src` y `alt`. El elemento `<canvas>` tiene solo dos atributos - [`width`](/es/docs/Web/HTML/Element/canvas#width) y [`height`](/es/docs/Web/HTML/Element/canvas#height). Ambos son opcionales y pueden ser definidos usando propiedades [DOM](/es/docs/DOM). Cuando los atributos ancho y alto no estan especificados, el lienzo se inicializara con **300 pixels** ancho y **150 pixels** de alto. El elemento puede ser arbitrariamente redimensionado por CSS, pero durante el renderizado la imagen es escalada para ajustarse al tamaño de su layout. Si el tamaño del CSS no respeta el ratio del canvas inicial, este aparecerá distorsionado.
 
-> **Nota:** Si su renderizado se ve distorsionado, pruebe especificar los atributos width y height explícitamente en los atributos del `<canvas>` , y no usando CSS.
+> [!NOTE]
+> Si su renderizado se ve distorsionado, pruebe especificar los atributos width y height explícitamente en los atributos del `<canvas>` , y no usando CSS.
 
 El atributo [id](/es/docs/Web/HTML/Atributos_Globales/id) no está especificado para el elemento `<canvas>` pero es uno de los [atributos globales de HTML](/es/docs/Web/HTML/Atributos_Globales) el cual puede ser aplicado a cualquier elemento HTML (como [class](/es/docs/Web/HTML/Global_attributes/class) por ejemplo). Siempre es buena idea proporcionar un `id` porque esto hace más fácil identificarlo en un script.
 
@@ -43,7 +44,8 @@ Por ejemplo, podremos proporcionar un texto descriptivo del contenido del canvas
 
 De manera distinta al elemento {{HTMLElement("img")}}, el elemento {{HTMLElement("canvas")}} requiere cerrar la etiqueta (`</canvas>`).
 
-> **Nota:** Aunque las versiones anteriores del navegador Safari de Apple no requeria el cierre de la etiqueta, la especificacion indica que es necesaria, asi que tu deberias incluir esta para asegurarte la compatibilidad. Aquellas versiones de Safari (anteriores versiones a 2.0) renderizaran el contenido de regreso agregandolo al canvas mismo a no ser que utilice trucos de CSS para enmascararlo. Afortunadamente, los usuarios de aquellas versiones de Safari son raros hoy en dia.
+> [!NOTE]
+> Aunque las versiones anteriores del navegador Safari de Apple no requeria el cierre de la etiqueta, la especificacion indica que es necesaria, asi que tu deberias incluir esta para asegurarte la compatibilidad. Aquellas versiones de Safari (anteriores versiones a 2.0) renderizaran el contenido de regreso agregandolo al canvas mismo a no ser que utilice trucos de CSS para enmascararlo. Afortunadamente, los usuarios de aquellas versiones de Safari son raros hoy en dia.
 
 Si el contenido alternativo no se necesita, un simple `<canvas id="foo" ...></canvas>` es completamente compatible con todos los navegadores que soportan canvas.
 

--- a/files/es/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/es/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -91,13 +91,15 @@ Aquí están las funciones utilizadas para realizar estos pasos:
 
 El primer paso para crear un trazado es llamar a `beginPath()`. Internamente, los trazados se almacenan como una lista de sub-trazados (líneas, arcos, etc.) que juntos forman una forma. Cada vez que se llama a este método, la lista se restablece y podemos empezar a dibujar nuevas formas.
 
-> **Nota:** Cuando el trazado actual está vacío, como por ejemplo inmediatamente después de llamar a `beginPath()`, o en un canvas recién creado, el primer comando de construcción del trazado siempre se trata como un `moveTo()`, independientemente de lo que realmente sea. Por esta razón, casi siempre querrá establecer específicamente su posición inicial después de reiniciar un trazado.
+> [!NOTE]
+> Cuando el trazado actual está vacío, como por ejemplo inmediatamente después de llamar a `beginPath()`, o en un canvas recién creado, el primer comando de construcción del trazado siempre se trata como un `moveTo()`, independientemente de lo que realmente sea. Por esta razón, casi siempre querrá establecer específicamente su posición inicial después de reiniciar un trazado.
 
 El segundo paso es llamar a los métodos que realmente especifican los trazados a dibujar. Los veremos en breve.
 
 El tercer paso, y opcional, es llamar a `closePath()`. Este método intenta cerrar la forma dibujando una línea recta desde el punto actual hasta el inicio. Si la forma ya ha sido cerrada o sólo hay un punto en la lista, esta función no hace nada.
 
-> **Nota:** Cuando se llama a `fill()`, cualquier forma abierta se cierra automáticamente, por lo que no es necesario llamar a `closePath()`. Este **no** es el caso cuando se llama a `stroke()`.
+> [!NOTE]
+> Cuando se llama a `fill()`, cualquier forma abierta se cierra automáticamente, por lo que no es necesario llamar a `closePath()`. Este **no** es el caso cuando se llama a `stroke()`.
 
 ### Dibujar un triángulo
 
@@ -174,7 +176,8 @@ El resultado se ve así:
 
 Si quisieras ver las líneas conectadas, puedes eliminar las líneas que llaman a `moveTo()`.
 
-> **Nota:** Para saber más sobre la función `arc()`, consulte la sección [Arcos](#arcos) más abajo.
+> [!NOTE]
+> Para saber más sobre la función `arc()`, consulte la sección [Arcos](#arcos) más abajo.
 
 ### Líneas
 
@@ -236,7 +239,8 @@ Para dibujar arcos o círculos, utilizamos los métodos `arc()` o `arcTo()`.
 
 Veamos con más detalle el método `arc`, que toma seis parámetros: `x` e `y` son las coordenadas del centro del círculo sobre el que se dibujará el arco. El parámetro `radio` se explica por sí mismo. Los parámetros `startAngle` y `endAngle` definen los puntos inicial y final del arco en radianes, a lo largo de la curva del círculo. Se miden desde el eje x. El parámetro `counterclockwise` es un valor Booleano que, cuando es `true`, dibuja el arco en sentido contrario a las agujas del reloj; en caso contrario, el arco se dibuja en sentido de las agujas del reloj.
 
-> **Nota:** Los ángulos en la función `arc` se miden en radianes, no en grados. Para convertir los grados en radianes puedes utilizar la siguiente expresión de JavaScript: `radianes = (Math.PI/180)*grados`.
+> [!NOTE]
+> Los ángulos en la función `arc` se miden en radianes, no en grados. Para convertir los grados en radianes puedes utilizar la siguiente expresión de JavaScript: `radianes = (Math.PI/180)*grados`.
 
 El siguiente ejemplo es un poco más complejo que los que hemos visto anteriormente. Dibuja 12 arcos diferentes, todos con diferentes ángulos y rellenos.
 
@@ -246,7 +250,8 @@ Las coordenadas `x` e `y` deberían ser lo suficientemente claras. `radius` y `s
 
 La sentencia para el parámetro `clockwise` hace que la primera y tercera fila se dibujen como arcos en el sentido de las agujas del reloj y la segunda y cuarta fila como arcos en sentido contrario. Por último, la sentencia `if` hace que la mitad superior tenga arcos trazados y la mitad inferior arcos rellenos.
 
-> **Nota:** Este ejemplo requiere un canvas ligeramente más grande que los otros de esta página: 150 x 200 píxeles.
+> [!NOTE]
+> Este ejemplo requiere un canvas ligeramente más grande que los otros de esta página: 150 x 200 píxeles.
 
 ```html hidden
 <html>

--- a/files/es/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/es/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -102,7 +102,8 @@ var myImageData = ctx.getImageData(left, top, width, height);
 
 This method returns an `ImageData` object representing the pixel data for the area of the canvas whose corners are represented by the points (`left`, `top`), (`left+width`, `top`), (`left`, `top+height`), and (`left+width`, `top+height`). The coordinates are specified in canvas coordinate space units.
 
-> **Nota:** Any pixels outside the canvas are returned as transparent black in the resulting `ImageData` object.
+> [!NOTE]
+> Any pixels outside the canvas are returned as transparent black in the resulting `ImageData` object.
 
 This method is also demonstrated in the article [Manipulating video using canvas](/es/docs/Web/API/Canvas_API/Manipulating_video_using_canvas).
 

--- a/files/es/web/api/canvasrenderingcontext2d/linecap/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/linecap/index.md
@@ -7,7 +7,8 @@ slug: Web/API/CanvasRenderingContext2D/lineCap
 
 La propiedad **`CanvasRenderingContext2D.lineCap`** del API Canvas 2D determina la forma usada para dibujar los puntos finales de las líneas.
 
-> **Nota:** La líneas se puede dibujar con los métodos {{domxref("CanvasRenderingContext2D.stroke()", "stroke()")}}, {{domxref("CanvasRenderingContext2D.strokeRect()", "strokeRect()")}}, y {{domxref("CanvasRenderingContext2D.strokeText()", "strokeText()")}}.
+> [!NOTE]
+> La líneas se puede dibujar con los métodos {{domxref("CanvasRenderingContext2D.stroke()", "stroke()")}}, {{domxref("CanvasRenderingContext2D.strokeRect()", "strokeRect()")}}, y {{domxref("CanvasRenderingContext2D.strokeText()", "strokeText()")}}.
 
 ## Sintaxis
 

--- a/files/es/web/api/console/assert_static/index.md
+++ b/files/es/web/api/console/assert_static/index.md
@@ -9,7 +9,8 @@ Aparece un mensaje de error en la consola si la afirmación es falsa. Si la afir
 
 {{AvailableInWorkers}}
 
-> **Nota:** El método `console.assert()` se implementa de diferente manera en Node.js que el mismo método disponible en los navegadores.
+> [!NOTE]
+> El método `console.assert()` se implementa de diferente manera en Node.js que el mismo método disponible en los navegadores.
 >
 > En los navegadores, llamando `console.assert()` con una falsa afirmación hará que el `message` se imprima por consola sin interrumpir la ejecución del código posterior. En Node.js, sin embargo, una falsa afirmación lanzará un `AssertionError`.
 

--- a/files/es/web/api/console/index.md
+++ b/files/es/web/api/console/index.md
@@ -118,7 +118,8 @@ Cuando se pasa una cadena a uno de los métodos del objeto `console` que la acep
 - `%f`
   - : Muestra un valor de punto flotante. El formateo está soportado, por ejemplo `console.log("Foo %.2f", 1.1)` mostrará el número con dos decimales: `Foo 1.10`.
 
-> **Nota:** El formateo de precisión no funciona en Chrome.
+> [!NOTE]
+> El formateo de precisión no funciona en Chrome.
 
 Cada uno de ellos trae el siguiente argumento posterior a la cadena de la lista de parámetros. Por ejemplo:
 
@@ -185,7 +186,8 @@ Las propiedadas utilizables junto con la directiva `%c` son las siguientes (al m
 - {{cssxref("word-spacing")}} y {{cssxref("word-break")}}
 - {{cssxref("writing-mode")}}
 
-> **Nota:** Los mensajes de consola se comportan como un elemento en línea por defecto. Para ver los efectos de `padding`, `margin`, etc. debes establecerlo como por ejemplo `display: inline-block`.
+> [!NOTE]
+> Los mensajes de consola se comportan como un elemento en línea por defecto. Para ver los efectos de `padding`, `margin`, etc. debes establecerlo como por ejemplo `display: inline-block`.
 
 ### Usando grupos en la consola
 
@@ -230,7 +232,8 @@ Registrará el tiempo necesitado por el usuario para descartar el cuadro de aler
 
 Nótese que el nombre del temporizador es mostrado tanto cuando el temporizador es iniciado como cuando es detenido.
 
-> **Nota:** Es importante saber que si estas usando esto para registrar el tiempo del trafico de red, el temporizador reportará el tiempo total para la transacción, mientras que el tiempo listado en el panel de conexiones o panel de red es solo la cantidad de tiempo requerida para obtener la cabecera.
+> [!NOTE]
+> Es importante saber que si estas usando esto para registrar el tiempo del trafico de red, el temporizador reportará el tiempo total para la transacción, mientras que el tiempo listado en el panel de conexiones o panel de red es solo la cantidad de tiempo requerida para obtener la cabecera.
 > Si en cambio tienes el registro de cuerpo (`response body logging`) habilitado, el tiempo listado para la respuesta de la cabecera y el cuerpo combinados debiera coincidir con lo que ves en la salida de la consola.
 
 ### Trazas de pila

--- a/files/es/web/api/console/warn_static/index.md
+++ b/files/es/web/api/console/warn_static/index.md
@@ -9,7 +9,8 @@ Imprime un mensaje de advertencia en la Consola Web.
 
 {{AvailableInWorkers}}
 
-> **Nota:** En Firefox, las advertencias tienen un pequeño icono de signo de exclamación junto a estas en el registro de la Consola Web.
+> [!NOTE]
+> En Firefox, las advertencias tienen un pequeño icono de signo de exclamación junto a estas en el registro de la Consola Web.
 
 ## Sintaxis
 

--- a/files/es/web/api/cssrule/csstext/index.md
+++ b/files/es/web/api/cssrule/csstext/index.md
@@ -10,7 +10,8 @@ l10n:
 
 La propiedad **`cssText`** de la interfaz {{domxref("CSSRule")}} devuelve el texto real de una regla de estilo {{domxref("CSSStyleSheet")}}.
 
-> **Nota:** No confunda esta propiedad con el estilo de elemento {{domxref("CSSStyleDeclaration.cssText")}}.
+> [!NOTE]
+> No confunda esta propiedad con el estilo de elemento {{domxref("CSSStyleDeclaration.cssText")}}.
 
 Tenga en cuenta que esta propiedad ya no se puede configurar directamente, ya que [ahora se especifica](https://www.w3.org/TR/cssom-1/#changes-from-5-december-2013) para ser _funcionalmente_ solo modificable, y sin ser notado. En otras palabras, intentar configurarlo _no hace absolutamente nada_ y ni siquiera emite una advertencia o un error.
 Además, no tiene subpropiedades configurables. Por lo tanto, para modificarlo, use las propiedades {{domxref("CSSStyleRule.selectorText", ".selectorText")}} y {{domxref ("CSSStyleRule.style", ".style")}} (o sus subpropiedades). Véase [Uso de información de estilo dinámico](/es/docs/Web/API/CSS_Object_Model/Using_dynamic_styling_information) para más detalles.

--- a/files/es/web/api/cssstylesheet/index.md
+++ b/files/es/web/api/cssstylesheet/index.md
@@ -39,7 +39,8 @@ _Hereda las propiedades de su padre, {{domxref("StyleSheet")}}._
 
   - : Devuelve un {{domxref("CSSRuleList")}} activo que mantiene una lista actualizada de los objetos {{domxref("CSSRuleList")}} que componen la hoja de estilo.
 
-    > **Nota:** En algunos navegadores, si se carga una hoja de estilo desde un dominio diferente, acceder a `cssRules` genera un `SecurityError`.
+    > [!NOTE]
+    > En algunos navegadores, si se carga una hoja de estilo desde un dominio diferente, acceder a `cssRules` genera un `SecurityError`.
 
 - {{domxref("CSSStyleSheet.ownerRule")}} {{ReadOnlyInline}}
   - : Si esta hoja de estilo se importa al documento mediante una regla {{cssxref("@import")}}, la propiedad `ownerRule` devuelve la correspondiente {{domxref("CSSImportRule")}}; de lo contrario, el valor de esta propiedad es `null`.

--- a/files/es/web/api/customelementregistry/define/index.md
+++ b/files/es/web/api/customelementregistry/define/index.md
@@ -42,7 +42,8 @@ Void.
 | `SyntaxError`       | El nombre proporcionado no es un [nombre válido de elemento personalizado](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name).                                                                                          |
 | `TypeError`         | El constructor referenciado no es un constructor                                                                                                                                                                                                            |
 
-> **Nota:** A menudo se obtienen excepciones `NotSupportedError`s cuando el método `define()` está fallando, pero realmente es un problema relacionado con {{domxref("Element.attachShadow()")}}.
+> [!NOTE]
+> A menudo se obtienen excepciones `NotSupportedError`s cuando el método `define()` está fallando, pero realmente es un problema relacionado con {{domxref("Element.attachShadow()")}}.
 
 ## Ejemplos
 
@@ -137,7 +138,8 @@ customElements.define("popup-info", PopUpInfo);
   text="Su código de validación de tarjeta (CVC) es una característica extra de seguridad — consiste en 3 o 4 numeros en la parte posterior de su tarjeta."></popup-info>
 ```
 
-> **Nota:** Los constructores de elementos personalizados autónomos deben extender {{domxref("HTMLElement")}}.
+> [!NOTE]
+> Los constructores de elementos personalizados autónomos deben extender {{domxref("HTMLElement")}}.
 
 ### Elemento personalizado preconstruido
 

--- a/files/es/web/api/document/cookie/index.md
+++ b/files/es/web/api/document/cookie/index.md
@@ -46,7 +46,8 @@ En el código anterior, _`nuevacookie`_ es una cadena de la forma _`clave=valor`
   - `__Secure-` Señales para el navegador que solo deben incluirse en las perticiones de cookie transmitidas por un canal seguro.
   - `__Host-` Señales del navegador que además de la restricción de uso de cookies que provienen de un origen serugo, el ámbito de la cookie está limitado a un atributo path que proporciona el servidor. Si el servidor omite el atributo path, el directorio de las petición URI está en uso. Tabién las señales del atributo dominio no deben estar presentes, lo cual previene que la cookie sea usada en otros dominis. Para Chrome, el atributo path debe tener el mismo origen.
 
-> **Nota:** Nótese que previamente a Gecko 6.0 (Firefox 6.0 / Thunderbird 6.0 / SeaMonkey 2.3), rutas que contenían comillas eran tratadas como si las comillas fueran parte de la cadena, en lugar de considerarse como un delimitador de la ruta actual. Esto ya ha sido arreglado.
+> [!NOTE]
+> Nótese que previamente a Gecko 6.0 (Firefox 6.0 / Thunderbird 6.0 / SeaMonkey 2.3), rutas que contenían comillas eran tratadas como si las comillas fueran parte de la cadena, en lugar de considerarse como un delimitador de la ruta actual. Esto ya ha sido arreglado.
 
 ## Ejemplos
 

--- a/files/es/web/api/document/createattribute/index.md
+++ b/files/es/web/api/document/createattribute/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Document/createAttribute
 
 El método **`Document.createAttribute()`** crea un nuevo nodo de tipo atributo (attr), y lo retorna. El objeto crea un nodo implementando la interfaz {{domxref("Attr")}}. El DOM no impone que tipo de atributos pueden ser agregados a un particular elemento de esta forma.
 
-> **Nota:** El texto pasado como parametro es convertido a minusculas.
+> [!NOTE]
+> El texto pasado como parametro es convertido a minusculas.
 
 ## Sintaxis
 

--- a/files/es/web/api/document/createelementns/index.md
+++ b/files/es/web/api/document/createelementns/index.md
@@ -73,7 +73,8 @@ El código siguiente crea un elemento \<div> nuevo en el namespace [XHTML](/es/d
 </page>
 ```
 
-> **Nota:** El ejemplo dado arriba usa script en linea lo cúal no es recomendable en documentos XHTML. Este ejemplo en particular es un documento XUL con XHTML embedido, de cualquier forma la recomendación aplica.
+> [!NOTE]
+> El ejemplo dado arriba usa script en linea lo cúal no es recomendable en documentos XHTML. Este ejemplo en particular es un documento XUL con XHTML embedido, de cualquier forma la recomendación aplica.
 
 ## Especificaciones
 

--- a/files/es/web/api/document/exitfullscreen/index.md
+++ b/files/es/web/api/document/exitfullscreen/index.md
@@ -37,7 +37,8 @@ document.onclick = function (event) {
 };
 ```
 
-> **Nota:** Para un ejemplo más completo, vea [Example](/es/docs/Web/API/Element/requestFullScreen#example).
+> [!NOTE]
+> Para un ejemplo más completo, vea [Example](/es/docs/Web/API/Element/requestFullScreen#example).
 
 ## Especificaciones
 

--- a/files/es/web/api/document/importnode/index.md
+++ b/files/es/web/api/document/importnode/index.md
@@ -20,7 +20,8 @@ var node = document.importNode(externalNode, deep);
 - `deep`
   - : Un booleano que indica si los descendientes del nodo deben ser importados también.
 
-> **Nota:** En la especificación DOM4 (tal y como se ha implementado en Gecko 13.0 (Firefox 13 / Thunderbird 13 / SeaMonkey 2.10)), `deep` es un argumento opcional. En el caso de ser omitido, adopta el valor de **`true`**, por lo que se hace una _deep copy_ por defecto. Para realizar una copia superficial (_shallow copy_), _deep_ debe ser **`false`**.
+> [!NOTE]
+> En la especificación DOM4 (tal y como se ha implementado en Gecko 13.0 (Firefox 13 / Thunderbird 13 / SeaMonkey 2.10)), `deep` es un argumento opcional. En el caso de ser omitido, adopta el valor de **`true`**, por lo que se hace una _deep copy_ por defecto. Para realizar una copia superficial (_shallow copy_), _deep_ debe ser **`false`**.
 >
 > Este comportamiento ha cambiado en la ultima especificación, por lo que si se omite el parámetro _deep,_ éste adopta el valor **`false`**. Aunque aún es opcional, debería ser siempre provisto por razones de compatibilidad. Con Gecko 28.0 (Firefox 28 / Thunderbird 28 / SeaMonkey 2.25 / Firefox OS 1.3), la consola advertia a los desarrolladores de no omitir el argumento. Empezando con Gecko 29.0 (Firefox 29 / Thunderbird 29 / SeaMonkey 2.26)), se realiza una copia superficial (_shallow copy_) por defecto.
 

--- a/files/es/web/api/document/open/index.md
+++ b/files/es/web/api/document/open/index.md
@@ -40,7 +40,8 @@ document.close();
 
 ## Notas
 
-> **Nota:** Traducción pendiente para el texto que sigue
+> [!NOTE]
+> Traducción pendiente para el texto que sigue
 
 An automatic `document.open()` call happens when {{domxref("document.write()")}} is called after the page has loaded.
 

--- a/files/es/web/api/document/queryselectorall/index.md
+++ b/files/es/web/api/document/queryselectorall/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Document/querySelectorAll
 
 El método **`querySelectorAll()`** de un {{domxref("Element")}} devuelve una {{domxref("NodeList")}} estática (no viva) que representa una lista de elementos del documento que coinciden con el grupo de selectores indicados.
 
-> **Nota:** Esto método se implementa en base al método {{domxref("ParentNode.querySelectorAll", "querySelectorAll()")}} del mixin {{domxref("ParentNode")}}.
+> [!NOTE]
+> Esto método se implementa en base al método {{domxref("ParentNode.querySelectorAll", "querySelectorAll()")}} del mixin {{domxref("ParentNode")}}.
 
 ## Sintaxis
 
@@ -20,13 +21,15 @@ elementList = parentNode.querySelectorAll(selectors);
 - `selectors`
   - : Un {{domxref("DOMString")}} que contiene uno o más selectores para buscar coincidencias. Esta cadena de texto debe ser una cadena [CSS selector](/es/docs/Web/CSS/CSS_Selectors) válida; si no lo es, se lanzará una excepción `SyntaxError`. Vea [Locating DOM elements using selectors](/es/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors) para más información acerca de utilizar selectores para identificar elementos. Se pueden especificar varios selectores separándolos utilizando comas.
 
-> **Nota:** Los caracteres que no son parte de la sintaxis estándar de CSS deben ser escapados utilizando el caracter de barra invertida. Dado que JavaScript también utiliza el escapado por retroceso, se debe tener especial cuidado al escribir cadenas de texto literales utilizando estos caracteres. Vea [Escapando caracteres especiales](#escapando_caracteres_especiales) para más información.
+> [!NOTE]
+> Los caracteres que no son parte de la sintaxis estándar de CSS deben ser escapados utilizando el caracter de barra invertida. Dado que JavaScript también utiliza el escapado por retroceso, se debe tener especial cuidado al escribir cadenas de texto literales utilizando estos caracteres. Vea [Escapando caracteres especiales](#escapando_caracteres_especiales) para más información.
 
 ### Valor devuelto
 
 Una {{domxref("NodeList")}} _no viva_ que contenga un objeto {{domxref("Element")}} para cada elemento que coincida con al menos uno de los selectores especificados o una {{domxref("NodeList")}} vacía en caso de que no haya coincidencias.
 
-> **Nota:** Si los selectores indicados incluyen un [pseudo-elemento CSS](/es/docs/Web/CSS/Pseudo-elements), la lista devuelta siempre estará vacía.
+> [!NOTE]
+> Si los selectores indicados incluyen un [pseudo-elemento CSS](/es/docs/Web/CSS/Pseudo-elements), la lista devuelta siempre estará vacía.
 
 ### Excepciones
 

--- a/files/es/web/api/document/write/index.md
+++ b/files/es/web/api/document/write/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Document/write
 
 Escribe una cadena de texto dentro del hilo de un `document` abierto por [document.open()](/es/docs/Web/API/document.open).
 
-> **Nota:** Dado que `document.write` escribe directo al hilo **(stream**) de un documento, la llamada a `document.write` en un documento ya cargado automáticamente ejecuta `document.open`, [lo cual limpiará todo el contenido del documento en cuestión](/es/docs/Web/API/document.open#Notes).
+> [!NOTE]
+> Dado que `document.write` escribe directo al hilo **(stream**) de un documento, la llamada a `document.write` en un documento ya cargado automáticamente ejecuta `document.open`, [lo cual limpiará todo el contenido del documento en cuestión](/es/docs/Web/API/document.open#Notes).
 
 ## Sintaxis
 

--- a/files/es/web/api/document/writeln/index.md
+++ b/files/es/web/api/document/writeln/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Document/writeln
 
 Escribe una cadena de texto en el documento, seguida de una nueva línea.
 
-> **Nota:** Dado que `document.writeln` (al igual que `document.write)` escribe directo al hilo (`stream`) de un documento, la llamada a `document.write` en un documento ya cargado automáticamente ejecuta `document.open`, [lo cual limpiará todo el contenido del documento en cuestión](/es/docs/Web/API/document.open#Notes).
+> [!NOTE]
+> Dado que `document.writeln` (al igual que `document.write)` escribe directo al hilo (`stream`) de un documento, la llamada a `document.write` en un documento ya cargado automáticamente ejecuta `document.open`, [lo cual limpiará todo el contenido del documento en cuestión](/es/docs/Web/API/document.open#Notes).
 
 ## Sintaxis
 

--- a/files/es/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
+++ b/files/es/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
@@ -16,7 +16,8 @@ Esta especificación añade dos nuevos metodos a cualquier objeto implementando 
 - {{domxref("Element.querySelectorAll", "querySelectorAll()")}}
   - : devuelve un listado de nodos {{domxref("NodeList")}} conteniendo todos los elementos del nodo coincidentes( `Element`) dentro de las subramas del nodo, o Devuelve un Listado de Nodos vacio `NodeList` sino se encuentran coincidencias.
 
-> **Nota:** El {{domxref("NodeList")}} devuelto por {{domxref("Element.querySelectorAll()", "querySelectorAll()")}} no es dinamico, Es decir que cualquier cambio realizado en el DOM no se vera reflejado en la coleccion. Esto es diferente de otros metodos de querying del dom que si devuelven listados de nodos dinamicos.
+> [!NOTE]
+> El {{domxref("NodeList")}} devuelto por {{domxref("Element.querySelectorAll()", "querySelectorAll()")}} no es dinamico, Es decir que cualquier cambio realizado en el DOM no se vera reflejado en la coleccion. Esto es diferente de otros metodos de querying del dom que si devuelven listados de nodos dinamicos.
 
 Encontraras ejemplos y detalles leyendo el documento de metodos {{domxref("Element.querySelector()")}} y {{domxref("Element.querySelectorAll()")}}, Tambien en el articulo [Code snippets for querySelector](/es/docs/Code_snippets/QuerySelector).
 

--- a/files/es/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
+++ b/files/es/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
@@ -9,7 +9,8 @@ slug: Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and
 
 Este artículo es un resumen de algunos métodos DOM nivel 1 poderosos y fundamentales así como una descripción de cómo utilizarlos utilizando Javascript. Aprenderás a crear, accesar, controlar, y remover elementos HTML dinámicamente. Los métodos DOM presentados aquí no son específicos de HTML; también aplican para XML. Las demostraciones aquí proporcionadas funcionarán en cualquier navegador moderno, incluyendo todas las versiones de Firefox e IE 5+.
 
-> **Nota:** Los métodos DOM presentados aquí forman parte del Modelo de Documento basado en Objetos (DOM: Document Object Model por sus siglas en inglés) de especificación nivel 1. DOM nivel 1 incluye métodos tanto para acceso genérico del documento (DOM 1 Core) así como métodos específicos para documentos HTML (DOM 1 HTML).
+> [!NOTE]
+> Los métodos DOM presentados aquí forman parte del Modelo de Documento basado en Objetos (DOM: Document Object Model por sus siglas en inglés) de especificación nivel 1. DOM nivel 1 incluye métodos tanto para acceso genérico del documento (DOM 1 Core) así como métodos específicos para documentos HTML (DOM 1 HTML).
 
 ## Ejemplo: Crear una tabla HTML dinámicamente (`Ejemplo1.html`)
 
@@ -214,7 +215,8 @@ After testing this sample, note that the words hello and world are together: hel
 
 ![Image:sample2b2.jpg](sample2b2.jpg)
 
-> **Nota:** createTextNode and appendChild is a simple way to include white space between the words hello and world. Another important note is that the appendChild method will append the child after the last child, just like the word world has been added after the word hello. So if you want to append a Text Node between hello and world you will need to use insertBefore instead of appendChild.
+> [!NOTE]
+> CreateTextNode and appendChild is a simple way to include white space between the words hello and world. Another important note is that the appendChild method will append the child after the last child, just like the word world has been added after the word hello. So if you want to append a Text Node between hello and world you will need to use insertBefore instead of appendChild.
 
 ### Creating New Elements with the document object and the `createElement(..)` method
 
@@ -261,7 +263,8 @@ The basic steps to create the table in sample1.html are:
 - Create all the elements.
 - Finally, append each child according to the table structure (as in the above figure). The following source code is a commented version for the sample1.html.
 
-> **Nota:** At the end of the start function there is a new line of code. The table's border property was set using another DOM method, `setAttribute`. setAttribute has two arguments: the attribute name and the attribute value. You can set any attribute of any element using the setAttribute method.
+> [!NOTE]
+> At the end of the start function there is a new line of code. The table's border property was set using another DOM method, `setAttribute`. setAttribute has two arguments: the attribute name and the attribute value. You can set any attribute of any element using the setAttribute method.
 
 ```html
 <head>
@@ -314,7 +317,8 @@ The basic steps to create the table in sample1.html are:
 
 This example introduces two new DOM attributes. First it uses the `childNodes` attribute to get the list of child nodes of mycel. The `childNodes` list includes all child nodes, regardless of what their name or type is. Like getElementsByTagName(), it returns a list of nodes. The differences are that (a) getElementsByTagName() only returns elements of the specified tag name; and (b) getElementsByTagName() returns descendants at any level, not just immediate children. Once you have the returned list, use `[x]` method to retrieve the desired child item. This example stores in myceltext the text node of the second cell in the second row of the table. Then, to display the results in this example, it creates a new text node whose content is the data of myceltext and appends it as a child of the \<body> element.
 
-> **Nota:** If your object is a text node, you can use the data attribute and retrieve the text content of the node.
+> [!NOTE]
+> If your object is a text node, you can use the data attribute and retrieve the text content of the node.
 
 ```js
 mybody = document.getElementsByTagName("body")[0];

--- a/files/es/web/api/domexception/index.md
+++ b/files/es/web/api/domexception/index.md
@@ -35,7 +35,8 @@ Tenga en cuenta que los siguientes errores históricos obsoletos no tienen un no
 - Valor de código heredado: `6`, nombre de constante heredado: `NO_DATA_ALLOWED_ERR`
 - Valor de código heredado: `16`, nombre de constante heredado: `VALIDATION_ERR`
 
-> **Nota:** Debido a que históricamente los errores estaban identificados por un valor numérico que correspondía con un nombre de variable definida para tener ese valor, algunas de las entradas a continuación indican el valor de código heredado y el nombre constante que se usó en el pasado.
+> [!NOTE]
+> Debido a que históricamente los errores estaban identificados por un valor numérico que correspondía con un nombre de variable definida para tener ese valor, algunas de las entradas a continuación indican el valor de código heredado y el nombre constante que se usó en el pasado.
 
 - `IndexSizeError`
   - : El índice no está en el rango permitido. Por ejemplo, esto podría ser arrojado por el objeto {{ domxref("Range") }}. (Valor de código heradado: `1` y nombre de constante heredado: `INDEX_SIZE_ERR`)

--- a/files/es/web/api/element/animate/index.md
+++ b/files/es/web/api/element/animate/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Element/animate
 
 El método `animate()` de la interfaz {{domxref("Element")}} es un método abreviado el cual crea un nuevo {{domxref("Animation")}}, aplicado al elemento, luego reproduce la animación. Devuelve la instancia creada de un objeto {{domxref("Animation")}}.
 
-> **Nota:** Los elementos pueden tener multiples animaciones aplicadas a ellos. Puedes obtener una
+> [!NOTE]
+> Los elementos pueden tener multiples animaciones aplicadas a ellos. Puedes obtener una
 > lista de las animaciones que afectan a un elemento llamando a {{domxref("Element.getAnimations()")}}.
 
 ## Síntaxis

--- a/files/es/web/api/element/blur_event/index.md
+++ b/files/es/web/api/element/blur_event/index.md
@@ -22,7 +22,8 @@ El evento `blur` es disparado cuando un elemento ha perdido su foco. La diferenc
 - Acción por defecto
   - : Ninguna.
 
-> **Nota:** El valor de {{domxref("Document.activeElement")}} varía a traves de navegadores mientras este evento está siendo manejado ([Error 452307 en Firefox](https://bugzil.la/452307)): IE10 lo agrega al elemento al cual el foco se movera, mientras Firefox y Chrome muy seguido lo agregan al cuerpo del documento.
+> [!NOTE]
+> El valor de {{domxref("Document.activeElement")}} varía a traves de navegadores mientras este evento está siendo manejado ([Error 452307 en Firefox](https://bugzil.la/452307)): IE10 lo agrega al elemento al cual el foco se movera, mientras Firefox y Chrome muy seguido lo agregan al cuerpo del documento.
 
 ## Propiedades
 

--- a/files/es/web/api/element/childelementcount/index.md
+++ b/files/es/web/api/element/childelementcount/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Element/childElementCount
 
 La propiedad de sólo lectura `ParentNode.childElementCount` devuelve un número del tipo `unsigned long` que representa la cantidad de elementos hijo que penden del elemento padre (ParentNode).
 
-> **Nota:** Esta propiedad fue inicialmente definida en la interfaz pura {{domxref("ElementTraversal")}}. Como esta interfaz contenía dos conjuntos distintos de propiedades: una apuntaba al {{domxref("Node")}} con hijos y otra a los hijos, fueron trasladados a dos interfaces puras separadas: {{domxref("ParentNode")}} y {{domxref("ChildNode")}}. En este caso, `childElementCount` se mudó a {{domxref("ParentNode")}}. Este es un cambio bastante técnico que no debería afectar a la compatibilidad.
+> [!NOTE]
+> Esta propiedad fue inicialmente definida en la interfaz pura {{domxref("ElementTraversal")}}. Como esta interfaz contenía dos conjuntos distintos de propiedades: una apuntaba al {{domxref("Node")}} con hijos y otra a los hijos, fueron trasladados a dos interfaces puras separadas: {{domxref("ParentNode")}} y {{domxref("ChildNode")}}. En este caso, `childElementCount` se mudó a {{domxref("ParentNode")}}. Este es un cambio bastante técnico que no debería afectar a la compatibilidad.
 
 ## Sintaxis
 

--- a/files/es/web/api/element/classlist/index.md
+++ b/files/es/web/api/element/classlist/index.md
@@ -57,7 +57,8 @@ div.classList.remove("foo", "bar");
 div.classList.replace("foo", "bar");
 ```
 
-> **Nota:** Las versiones de Firefox anteriores a la 26 no implementan el uso de múltiples argumentos en los métodos add/remove/toggle. Vea <https://bugzilla.mozilla.org/show_bug.cgi?id=814014>
+> [!NOTE]
+> Las versiones de Firefox anteriores a la 26 no implementan el uso de múltiples argumentos en los métodos add/remove/toggle. Vea <https://bugzilla.mozilla.org/show_bug.cgi?id=814014>
 
 ## Especificaciones
 

--- a/files/es/web/api/element/clientheight/index.md
+++ b/files/es/web/api/element/clientheight/index.md
@@ -9,7 +9,8 @@ La propiedad de sólo lectura `Element.clientHeight` devuelve la altura de un el
 
 `clientHeight` puede ser calculado como CSS `height` + CSS `padding` - alto de la barra horizontal (si existe).
 
-> **Nota:** Esta propiedad redondeará el valor a un entero. Si necesitas un valor fraccional usa {{ domxref("element.getBoundingClientRect()") }}.
+> [!NOTE]
+> Esta propiedad redondeará el valor a un entero. Si necesitas un valor fraccional usa {{ domxref("element.getBoundingClientRect()") }}.
 
 ## Sintaxis
 

--- a/files/es/web/api/element/clientwidth/index.md
+++ b/files/es/web/api/element/clientwidth/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Element/clientWidth
 
 La propiedad `Element.clientWidth` es cero para elementos sin CSS o cajas de diseño (layout), en caso contrario es la anchura interior de un elemento en pixels, incluyendo la anchura de relleno (padding) pero no la anchura de la barra de desplazamiento vertical (si está presente, si está dibujada), el borde o el margen.
 
-> **Nota:** El valor de esta propiedad será redondeado a un entero. Si necesita un valor fraccional, use {{ domxref("element.getBoundingClientRect()") }}.
+> [!NOTE]
+> El valor de esta propiedad será redondeado a un entero. Si necesita un valor fraccional, use {{ domxref("element.getBoundingClientRect()") }}.
 
 ## Sintaxis
 

--- a/files/es/web/api/element/getclientrects/index.md
+++ b/files/es/web/api/element/getclientrects/index.md
@@ -17,7 +17,8 @@ var rectCollection = object.getClientRects();
 
 El valor devuelto es una colección de objetos rectangulares {{domxref("DOMRect")}}, uno para cada cuadro borde CSS asociado al elemento. Cada objeto {{domxref("DOMRect")}} contiene las propiedades de sólo lectura: `left`, `top`, `right` y `bottom`, que describen la caja, en pixeles, con el valor top-left relativo al valor top-left del _viewport._ En el caso de tablas con subtítulos, el subtítulo es incluido aún cuado esté fuera del cuadro borde de la tabla. En caso de ser ejecutado en algún elemento SVG que no sea el `<svg>` externo, el "viewport" al cual los rectángulos de resultado serán relativos será el "viewport" que establece el `<svg>` externo (y serán transformados por las trasnformaciones del `<svg>` externo, si estas existen).
 
-> **Nota:** Firefox 3.5 ha agregado las propiedades `width` y `height` al objeto `TextRectangle`.
+> [!NOTE]
+> Firefox 3.5 ha agregado las propiedades `width` y `height` al objeto `TextRectangle`.
 
 La cantidad de desplazamiento que ha tenido el área del viewport (o cualquier otro elemento desplazable) se tiene en cuenta al calcular los rectángulos.
 

--- a/files/es/web/api/element/getelementsbytagname/index.md
+++ b/files/es/web/api/element/getelementsbytagname/index.md
@@ -19,7 +19,8 @@ elements = element.getElementsByTagName(tagName);
 - `element` es el elemento a partir del cual debe empezar la búsqueda. Recuerda que sólo se buscan los elementos descendentes del elemento dado, sin incluir el propio elemento.
 - `tagName` es el nombre que se busca. La cadena especial `"*"` representa todos los elementos.
 
-> **Nota:** En Firefox 2 (Gecko 1.8.1) y anteriores, este método no funcionaba correctamente si el árbol contenía algún elemento con etiqueta de nombre conteniendo espacios. (Ver [Error 206053 en Firefox](https://bugzil.la/206053) para más detalles).
+> [!NOTE]
+> En Firefox 2 (Gecko 1.8.1) y anteriores, este método no funcionaba correctamente si el árbol contenía algún elemento con etiqueta de nombre conteniendo espacios. (Ver [Error 206053 en Firefox](https://bugzil.la/206053) para más detalles).
 >
 > Es recomendable usar [DOM:document.getElementsByTagNameNS](/es/DOM/document.getElementsByTagNameNS) cuando se manejan documentos con "multi-namespace".
 

--- a/files/es/web/api/element/id/index.md
+++ b/files/es/web/api/element/id/index.md
@@ -9,7 +9,8 @@ La propiedad `Element.id` representa el identificador del elemento, reflejando e
 
 debe ser un único documento, y con frecuencia es utilizado para recuperar el elemento usando {{domxref("document.getElementById", "getElementById")}}. Otros usos comunes de `id` incluyen la utilización de elementos [ID como un selector](/es/docs/Web/CSS/ID_selectors) cuando se está estilando el documento con [CSS](/es/docs/Web/CSS).
 
-> **Nota:** los identificadores distinguen mayúsculas y minúsculas, pero se debe evitar la creación de IDs que difieran solamente en la capitalization (ver [diferenciación de mayúsculas y minúsculas en nombres y destacados](/es/docs/Case_Sensitivity_in_class_and_id_Names)).
+> [!NOTE]
+> Los identificadores distinguen mayúsculas y minúsculas, pero se debe evitar la creación de IDs que difieran solamente en la capitalization (ver [diferenciación de mayúsculas y minúsculas en nombres y destacados](/es/docs/Case_Sensitivity_in_class_and_id_Names)).
 
 ## Síntaxis
 

--- a/files/es/web/api/element/innerhtml/index.md
+++ b/files/es/web/api/element/innerhtml/index.md
@@ -11,7 +11,8 @@ La propiedad `Element.innerHTML` devuelve o establece la sintaxis HTML describie
 
 Al establecerse se reemplaza la sintaxis HTML del elemento por la nueva.
 
-> **Nota:** Si un nodo tiene un texto secundario que incluye los caracteres `(&), (<),` o `(>)`, `innerHTML` devuelve estos caracteres como \&amp, \&lt y \&gt respectivamente. Use {{ domxref("Node.textContent") }} para conseguir una copia correcta del contenido de estos nodos de texto.
+> [!NOTE]
+> Si un nodo tiene un texto secundario que incluye los caracteres `(&), (<),` o `(>)`, `innerHTML` devuelve estos caracteres como \&amp, \&lt y \&gt respectivamente. Use {{ domxref("Node.textContent") }} para conseguir una copia correcta del contenido de estos nodos de texto.
 
 Para **insertar el código HTML** en el documento en lugar de cambiar el contenido de un elemento, use el método [insertAdjacentHTML().](/es/docs/Web/API/Element/insertAdjacentHTML)
 
@@ -63,7 +64,8 @@ document.documentElement.innerHTML =
   "<pre>" + document.documentElement.innerHTML.replace(/</g, "&lt;") + "</pre>";
 ```
 
-> **Nota:** Esta propiedad fue inicialmente implementada por navegadores web, y luego especificada por el WHATWG y el W3C en HTML5. Implementaciones antiguas no la implementarán exactamente igual. Por ejemplo, cuando el texto es ingresado en una caja de **texto multilinea (elemento `textarea`)**, Internet Explorer cambiará el valor de la propiedad `innerHTML` del **elemento `textarea`**, mientras que los navegadores Gecko no lo hacen.
+> [!NOTE]
+> Esta propiedad fue inicialmente implementada por navegadores web, y luego especificada por el WHATWG y el W3C en HTML5. Implementaciones antiguas no la implementarán exactamente igual. Por ejemplo, cuando el texto es ingresado en una caja de **texto multilinea (elemento `textarea`)**, Internet Explorer cambiará el valor de la propiedad `innerHTML` del **elemento `textarea`**, mientras que los navegadores Gecko no lo hacen.
 
 ### Consideración de seguridad
 

--- a/files/es/web/api/element/input_event/index.md
+++ b/files/es/web/api/element/input_event/index.md
@@ -40,7 +40,8 @@ El evento también aplica a los elementos con la propiedad {{domxref("HTMLElemen
 
 Para elementos `<input>` con `type=checkbox` o `type=radio`, el evento `input` debería disparar cuando el usuario alterna el control, por [la especificación HTML5](https://html.spec.whatwg.org/multipage/input.html#the-input-element:event-input-2). Sin embargo, históricamente no siempre es el caso. Revise la compatibilidad o use el evento [`change`](/es/docs/Web/Reference/Events/change) en su lugar para estos tipos.
 
-> **Nota:** A diferencia de `input`, el evento [`change`](/es/docs/Web/Reference/Events/change) no es disparado necesariamente por cada alteración al valor (`value`) de un elemento.
+> [!NOTE]
+> A diferencia de `input`, el evento [`change`](/es/docs/Web/Reference/Events/change) no es disparado necesariamente por cada alteración al valor (`value`) de un elemento.
 
 ## Ejemplos
 

--- a/files/es/web/api/element/insertadjacentelement/index.md
+++ b/files/es/web/api/element/insertadjacentelement/index.md
@@ -50,7 +50,8 @@ El elemento insertado o `null`, si la inserción falla.
 <!-- afterend -->
 ```
 
-> **Nota:** Las posiciones `beforebegin` y `afterend` sólo funcionan si el nodo está en un árbol y tiene un padre.
+> [!NOTE]
+> Las posiciones `beforebegin` y `afterend` sólo funcionan si el nodo está en un árbol y tiene un padre.
 
 ## Ejemplo
 

--- a/files/es/web/api/element/insertadjacenthtml/index.md
+++ b/files/es/web/api/element/insertadjacenthtml/index.md
@@ -39,7 +39,8 @@ element.insertAdjacentHTML(posición, texto);
 <!-- afterend -->
 ```
 
-> **Nota:** Las posiciones `beforebegin` y `afterend` funcionan únicamente si el nodo se encuentra en el árbol DOM y tiene un elemento padre.
+> [!NOTE]
+> Las posiciones `beforebegin` y `afterend` funcionan únicamente si el nodo se encuentra en el árbol DOM y tiene un elemento padre.
 
 ## Ejemplo
 

--- a/files/es/web/api/element/keydown_event/index.md
+++ b/files/es/web/api/element/keydown_event/index.md
@@ -54,7 +54,8 @@ _Esta interfaz también hereda las propiedades de sus padres, {{domxref("UIEvent
 
   - : Devuelve una cadena con el valor del código de la tecla física representada por el evento.
 
-    > **Advertencia:** Esto ignora el diseño del teclado del usuario, de modo que si el usuario presiona la tecla en la posición "Y" en un diseño de teclado QWERTY (cerca del medio de la fila sobre la fila de inicio), esto siempre devolverá "KeyY", incluso si el el usuario tiene un teclado QWERTZ (lo que significaría que el usuario espera una "Z" y todas las demás propiedades indicarían una "Z") o un diseño de teclado Dvorak (donde el usuario esperaría una "F"). Si desea mostrar las pulsaciones de teclas correctas al usuario, puede usar {{domxref("Keyboard.getLayoutMap()")}}.
+    > [!WARNING]
+    > Esto ignora el diseño del teclado del usuario, de modo que si el usuario presiona la tecla en la posición "Y" en un diseño de teclado QWERTY (cerca del medio de la fila sobre la fila de inicio), esto siempre devolverá "KeyY", incluso si el el usuario tiene un teclado QWERTZ (lo que significaría que el usuario espera una "Z" y todas las demás propiedades indicarían una "Z") o un diseño de teclado Dvorak (donde el usuario esperaría una "F"). Si desea mostrar las pulsaciones de teclas correctas al usuario, puede usar {{domxref("Keyboard.getLayoutMap()")}}.
 
 - {{domxref("KeyboardEvent.ctrlKey")}} {{ReadOnlyInline}}
 
@@ -68,7 +69,8 @@ _Esta interfaz también hereda las propiedades de sus padres, {{domxref("UIEvent
 
   - : Devuelve una cadena que representa una cadena de configuración regional que indica la configuración regional para la que está configurado el teclado. Esta puede ser la cadena vacía si el navegador o el dispositivo no conocen la configuración regional del teclado.
 
-    > **Nota:** Esto no describe la configuración regional de los datos que se ingresan. Un usuario puede estar usando un diseño de teclado mientras escribe texto en un idioma diferente.
+    > [!NOTE]
+    > Esto no describe la configuración regional de los datos que se ingresan. Un usuario puede estar usando un diseño de teclado mientras escribe texto en un idioma diferente.
 
 - {{domxref("KeyboardEvent.location")}} {{ReadOnlyInline}}
   - : Devuelve un número que representa la ubicación de la tecla en el teclado u otro dispositivo de entrada.

--- a/files/es/web/api/element/keyup_event/index.md
+++ b/files/es/web/api/element/keyup_event/index.md
@@ -53,7 +53,8 @@ _Esta interfaz también hereda propiedades de sus padres, {{domxref("UIEvent")}}
 
   - : Devuelve una cadena con el valor del código de la clave física representada por el evento.
 
-    > **Advertencia:** Esto ignora el diseño del teclado del usuario, de modo que si el usuario presiona la tecla en la posición "Y" en un diseño de teclado QWERTY (cerca del medio de la fila sobre la fila de inicio), esto siempre devolverá "KeyY", incluso si el el usuario tiene un teclado QWERTZ (lo que significaría que el usuario espera una "Z" y todas las demás propiedades indicarían una "Z") o un diseño de teclado Dvorak (donde el usuario esperaría una "F"). Si desea mostrar las pulsaciones de teclas correctas al usuario, puede usar {{domxref("Keyboard.getLayoutMap()")}}.
+    > [!WARNING]
+    > Esto ignora el diseño del teclado del usuario, de modo que si el usuario presiona la tecla en la posición "Y" en un diseño de teclado QWERTY (cerca del medio de la fila sobre la fila de inicio), esto siempre devolverá "KeyY", incluso si el el usuario tiene un teclado QWERTZ (lo que significaría que el usuario espera una "Z" y todas las demás propiedades indicarían una "Z") o un diseño de teclado Dvorak (donde el usuario esperaría una "F"). Si desea mostrar las pulsaciones de teclas correctas al usuario, puede usar {{domxref("Keyboard.getLayoutMap()")}}.
 
 - {{domxref("KeyboardEvent.ctrlKey")}} {{ReadOnlyInline}}
 
@@ -67,7 +68,8 @@ _Esta interfaz también hereda propiedades de sus padres, {{domxref("UIEvent")}}
 
   - : Devuelve una cadena que representa una cadena de configuración regional que indica la configuración regional para la que está configurado el teclado. Esta puede ser la cadena vacía si el navegador o el dispositivo no conocen la configuración regional del teclado.
 
-    > **Nota:** Esto no describe la configuración regional de los datos que se ingresan. Un usuario puede estar usando un diseño de teclado mientras escribe texto en un idioma diferente.
+    > [!NOTE]
+    > Esto no describe la configuración regional de los datos que se ingresan. Un usuario puede estar usando un diseño de teclado mientras escribe texto en un idioma diferente.
 
 - {{domxref("KeyboardEvent.location")}} {{ReadOnlyInline}}
   - : Devuelve un número que representa la ubicación de la tecla en el teclado u otro dispositivo de entrada. Una lista de las constantes que identifican las ubicaciones se muestra en [Ubicaciones del teclado](/es/docs/Web/API/KeyboardEvent#keyboard_locations).

--- a/files/es/web/api/element/localname/index.md
+++ b/files/es/web/api/element/localname/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Element/localName
 
 La propiedad únicamente de lectura `Element.localName` devuelve la parte local del nombre calificado de un objeto.
 
-> **Nota:** Antes de DOM4 esta API fué definida dentro de la interfaz{{domxref("Node")}}.
+> [!NOTE]
+> Antes de DOM4 esta API fué definida dentro de la interfaz{{domxref("Node")}}.
 
 ## Sintasix
 
@@ -62,7 +63,8 @@ El nombre local de un nodo es la parte del nombre completo del nodo que va situa
 6  </ecomm:business>
 ```
 
-> **Nota:** En Gecko 1.9.2 y anteriores,devuelve la versión en mayúsculas del nombre local para elementos HTML en HTML DOMs (en contraposición a elementos XHTML en XML DOMs). En versiones posteriores, en concordancia con HTML5,la propiedad devuelve en el caso de almacenamiento interno DOM , minúscula para ambos elementos HTML en HTML DOM y elementos XHTML en DOM XML. La propiedad {{domxref("element.tagName","tagName")}} continua devolviéndolo en mayúsculas para elementos HTML en HTML DOMs.
+> [!NOTE]
+> En Gecko 1.9.2 y anteriores,devuelve la versión en mayúsculas del nombre local para elementos HTML en HTML DOMs (en contraposición a elementos XHTML en XML DOMs). En versiones posteriores, en concordancia con HTML5,la propiedad devuelve en el caso de almacenamiento interno DOM , minúscula para ambos elementos HTML en HTML DOM y elementos XHTML en DOM XML. La propiedad {{domxref("element.tagName","tagName")}} continua devolviéndolo en mayúsculas para elementos HTML en HTML DOMs.
 
 ## Especificaciones
 

--- a/files/es/web/api/element/namespaceuri/index.md
+++ b/files/es/web/api/element/namespaceuri/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Element/namespaceURI
 
 La propiedad `Element.namespaceURI` unicamente de lectura devuelve la URI namespace de el elemento, `o la anula si el elemento no está en un` namespace.
 
-> **Nota:** Antes de DOM4 esta API fué definida dentro de la interfaz {{domxref("Node")}}.
+> [!NOTE]
+> Antes de DOM4 esta API fué definida dentro de la interfaz {{domxref("Node")}}.
 
 ## Síntaxis
 

--- a/files/es/web/api/element/prefix/index.md
+++ b/files/es/web/api/element/prefix/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Element/prefix
 
 La propiedad `Element.prefix` unicamente de lectura devuelve el namespace prefix de el elemento especificado, o `null` si no hay especificado prefix.
 
-> **Nota:** Antes de DOM4 esta API fué definida dentro de la interfaz {{domxref("Node")}}.
+> [!NOTE]
+> Antes de DOM4 esta API fué definida dentro de la interfaz {{domxref("Node")}}.
 
 ## Síntaxis
 

--- a/files/es/web/api/element/scrollheight/index.md
+++ b/files/es/web/api/element/scrollheight/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Element/scrollHeight
 
 El elemento **Element.scrollHeight** atributo unicamente de lectura es una medida de la altura del contenido de un elemento, incluyendo el contenido que no es visible en la pantalla debido al desbordamiento. El valor `scrollHeight` es igual a la altura mínima (donde la altura incluye el relleno , pero no incluye bordes y márgenes) El elemento lo necesita con el fin de adaptarse a todos los contenidos en el punto de vista sin necesidad de utilizar una barra de desplazamiento vertical. Incluye el elemento relleno pero no su margen.
 
-> **Nota:** Esta propiedad redondea el valor a un número entero. Si se necesita un valor fraccionario, utilizar {{domxref("Element.getBoundingClientRect()")}}.
+> [!NOTE]
+> Esta propiedad redondea el valor a un número entero. Si se necesita un valor fraccionario, utilizar {{domxref("Element.getBoundingClientRect()")}}.
 
 ## Sintaxis
 

--- a/files/es/web/api/element/scrollwidth/index.md
+++ b/files/es/web/api/element/scrollwidth/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Element/scrollWidth
 
 La propiedad de sólo lectura `Element.scrollWidth` retorna bien la anchura en pixels del contenido de un elemento o bien la anchura del elemento en si, la que sea mayor de ambas. Si el elemento es más ancho que su área contenedora (por ejemplo, si existen barras de desplazamiento para desplazarse a través del contenido), `scrollWidth` es mayor que `clientWidth`.
 
-> **Nota:** El valor de esta propiedad será red redondedo a un entero. Si necesita un valor fraccional, use {{ domxref("element.getBoundingClientRect()") }}.
+> [!NOTE]
+> El valor de esta propiedad será red redondedo a un entero. Si necesita un valor fraccional, use {{ domxref("element.getBoundingClientRect()") }}.
 
 ## Sintaxis
 

--- a/files/es/web/api/element/touchstart_event/index.md
+++ b/files/es/web/api/element/touchstart_event/index.md
@@ -9,7 +9,8 @@ Un {{domxref("GlobalEventHandlers","global event handler")}} para el evento [`to
 
 {{SeeCompatTable}}
 
-> **Nota:** Este atributo _no_ ha sido estandarizado formalmente. Está especificado en la especificación [Touch Events – Level 2](https://w3c.github.io/touch-events/) Draft y no en [Touch Events](https://www.w3.org/TR/touch-events/) Recommendation. Este atributo no está totalmente implementado.
+> [!NOTE]
+> Este atributo _no_ ha sido estandarizado formalmente. Está especificado en la especificación [Touch Events – Level 2](https://w3c.github.io/touch-events/) Draft y no en [Touch Events](https://www.w3.org/TR/touch-events/) Recommendation. Este atributo no está totalmente implementado.
 
 ## Sintaxis
 


### PR DESCRIPTION
This PR converts the noteblocks for the Spanish locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 3. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
