### PR TITLE
es: Convert noteblocks to GFM Alerts (part 5)

### DIFF
--- a/files/es/web/api/window/console/index.md
+++ b/files/es/web/api/window/console/index.md
@@ -31,4 +31,5 @@ Para obtener mas ejemplos, consulta la sección de [Ejemplos](/es/docs/Web/API/c
 
 {{Specifications}}
 
-> **Nota:** Actualmente hay muchas diferencias de implementación en los navegadores, pero se esta trabajando para hacerlos mas consistentes entre sí.
+> [!NOTE]
+> Actualmente hay muchas diferencias de implementación en los navegadores, pero se esta trabajando para hacerlos mas consistentes entre sí.

--- a/files/es/web/api/window/document/index.md
+++ b/files/es/web/api/window/document/index.md
@@ -9,7 +9,8 @@ slug: Web/API/Window/document
 
 Retorna una referencia al documento contenido en la ventana.
 
-> **Nota:** Firefox 3 altera la seguridad para los documentos entre ventanas, de modo que sólo el dominio desde el cual ha sido cargada una ventana puede acceder al documento. A pesar de que esto rompe el funcionamiento de algunos sitios existentes, es una modificación adoptada por Firefox 3 e Internet Explorer 7, que resulta en una mejora de seguridad.
+> [!NOTE]
+> Firefox 3 altera la seguridad para los documentos entre ventanas, de modo que sólo el dominio desde el cual ha sido cargada una ventana puede acceder al documento. A pesar de que esto rompe el funcionamiento de algunos sitios existentes, es una modificación adoptada por Firefox 3 e Internet Explorer 7, que resulta en una mejora de seguridad.
 
 ## Sintaxis
 

--- a/files/es/web/api/window/fetch/index.md
+++ b/files/es/web/api/window/fetch/index.md
@@ -14,7 +14,8 @@ Una promesa {{domxref("fetch","fetch()")}} se rechaza con un {{jsxref("TypeError
 
 El método `fetch()` es controlado por la directiva `connect-src` de la [Política de Seguridad de Contenido (Content Security Policy)](/es/docs/Security/CSP/CSP_policy_directives) en lugar de la directiva del recurso que se solicita.
 
-> **Nota:** Los parámetros del método `fetch()` son indénticos a los del constructor de {{domxref("Request.Request","Request()")}}.
+> [!NOTE]
+> Los parámetros del método `fetch()` son indénticos a los del constructor de {{domxref("Request.Request","Request()")}}.
 
 ## Sintaxis
 

--- a/files/es/web/api/window/frameelement/index.md
+++ b/files/es/web/api/window/frameelement/index.md
@@ -15,7 +15,8 @@ frameEl = window.frameElement;
 
 - `frame El` es el elemento dentro del cual está empotrada la ventana. Si la ventana no está incrustada dentro de otro documento, o si el documento en el que está empotrada tiene un origen diferente (como procede de un dominio diferente), este valor será `null`.
 
-> **Nota:** A pesar del nombre de esta propiedad, funciona para documentos empotrados en cualquier forma o método de incrustación, incluyendo {{HTMLElement("object")}}, {{HTMLElement("iframe")}}, or {{HTMLElement("embed")}}.
+> [!NOTE]
+> A pesar del nombre de esta propiedad, funciona para documentos empotrados en cualquier forma o método de incrustación, incluyendo {{HTMLElement("object")}}, {{HTMLElement("iframe")}}, or {{HTMLElement("embed")}}.
 
 ## Ejemplo
 

--- a/files/es/web/api/window/getscreendetails/index.md
+++ b/files/es/web/api/window/getscreendetails/index.md
@@ -50,7 +50,8 @@ for (const screen of screenDetails.screens) {
 }
 ```
 
-> **Nota:** Consulta [Entorno de aprendizaje de multiples ventanas](https://mdn.github.io/dom-examples/window-management-api/) para un ejemplo completo (consulta también el [codigo fuente](https://github.com/mdn/dom-examples/tree/main/window-management-api)).
+> [!NOTE]
+> Consulta [Entorno de aprendizaje de multiples ventanas](https://mdn.github.io/dom-examples/window-management-api/) para un ejemplo completo (consulta también el [codigo fuente](https://github.com/mdn/dom-examples/tree/main/window-management-api)).
 
 ## Especificaciones
 

--- a/files/es/web/api/window/index.md
+++ b/files/es/web/api/window/index.md
@@ -285,7 +285,8 @@ Estas son propiedades del objeto ventana que pueden ser fijadas para establecer 
 
 _Esta interfaz hereda controladores de eventos de la interfaz {{domxref("EventTarget")}} e implementa controladores de eventos desde {{domxref("WindowTimers")}} y {{domxref("WindowBase64")}}._
 
-> **Nota:** Empezando en Gecko 9.0, se puede usar el sintaxis `if ("onabort" in window)` para determinar si existe una propiedad dada de controlador de eventos o no. Esto es porque interfazes de controlador de eventos han sido actualizadas al respectivo web IDL interfaz. Ver [DOM event handlers](/es/docs/DOM/DOM_event_handlers) para mas detalles.
+> [!NOTE]
+> Empezando en Gecko 9.0, se puede usar el sintaxis `if ("onabort" in window)` para determinar si existe una propiedad dada de controlador de eventos o no. Esto es porque interfazes de controlador de eventos han sido actualizadas al respectivo web IDL interfaz. Ver [DOM event handlers](/es/docs/DOM/DOM_event_handlers) para mas detalles.
 
 - {{domxref("GlobalEventHandlers.onabort")}}
   - : An event handler property for abort events on the window.

--- a/files/es/web/api/window/localstorage/index.md
+++ b/files/es/web/api/window/localstorage/index.md
@@ -36,7 +36,8 @@ El siguiente código accede al objeto local {{DOMxRef("Storage")}} actual y agre
 localStorage.setItem("miGato", "Juan");
 ```
 
-> **Nota:** Por favor ver el articulo [Usando la Web Storage API](/es/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API) para un ejemplo completo.
+> [!NOTE]
+> Por favor ver el articulo [Usando la Web Storage API](/es/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API) para un ejemplo completo.
 
 La sintaxis para leer el ítem almacenado en `localStorage` es la siguiente:
 

--- a/files/es/web/api/window/location/index.md
+++ b/files/es/web/api/window/location/index.md
@@ -50,7 +50,8 @@ function reloadPageWithHash() {
 }
 ```
 
-> **Nota:** El ejemplo anterior funciona en situaciones cuando location.hash no necesita ser retenido. Sin embargo, en navegadores basados en Gecko, configurar `location.pathname` en esta manera eliminará cualquier información en location.hash, mientras que en WebKit (y posiblemente en otros navegadores), configurar el pathname no afectará el hash. Si necesitas cambiar el pathname pero mantener el hash como está, usa el método `replace()`, el cual funcionará consistentemente a través de los navegadores..
+> [!NOTE]
+> El ejemplo anterior funciona en situaciones cuando location.hash no necesita ser retenido. Sin embargo, en navegadores basados en Gecko, configurar `location.pathname` en esta manera eliminará cualquier información en location.hash, mientras que en WebKit (y posiblemente en otros navegadores), configurar el pathname no afectará el hash. Si necesitas cambiar el pathname pero mantener el hash como está, usa el método `replace()`, el cual funcionará consistentemente a través de los navegadores..
 
 ### Ejemplo 4: Muestra las propiedades de la URL actual en una ventana emergente
 
@@ -379,7 +380,8 @@ La siguiente URL con "?Some%20data" anexa es enviada al servidor (Si no hay ning
 </html>
 ```
 
-> **Nota:** La función showNode es también un ejemplo del uso del ciclo [`for`](/en/JavaScript/Reference/Statements/for) sin una sección de `statement`. En este caso **un punto y coma es siempre puesto inmediatamente después de la declaración de el ciclo.**
+> [!NOTE]
+> La función showNode es también un ejemplo del uso del ciclo [`for`](/en/JavaScript/Reference/Statements/for) sin una sección de `statement`. En este caso **un punto y coma es siempre puesto inmediatamente después de la declaración de el ciclo.**
 
 …De igual manera pero con un scroll animado:
 

--- a/files/es/web/api/window/online_event/index.md
+++ b/files/es/web/api/window/online_event/index.md
@@ -9,7 +9,8 @@ l10n:
 
 El evento **`online`** de la interface {{domxref("Window")}} se activa cuando el navegador ha obtenido acceso a la red y el valor de {{domxref("Navigator.onLine")}} cambia a `true`.
 
-> **Nota:** Este evento no debe usarse para determinar la disponibilidad de un sitio web en particular. Los problemas de red o cortafuegos aun pueden impedir que se acceda al sitio web.
+> [!NOTE]
+> Este evento no debe usarse para determinar la disponibilidad de un sitio web en particular. Los problemas de red o cortafuegos aun pueden impedir que se acceda al sitio web.
 
 ## Sintaxis
 

--- a/files/es/web/api/window/open/index.md
+++ b/files/es/web/api/window/open/index.md
@@ -76,7 +76,8 @@ If the `strWindowFeatures` parameter is used and if no position features are def
 
 **If the `strWindowFeatures` parameter is used, the features that are not listed will be disabled or removed** (except `titlebar` and `close` which are by default `yes`).
 
-> **Nota:** If using the `strWindowFeatures` parameter, only list the features to be enabled or rendered; the others (except `titlebar` and `close`) will be disabled or removed.
+> [!NOTE]
+> If using the `strWindowFeatures` parameter, only list the features to be enabled or rendered; the others (except `titlebar` and `close`) will be disabled or removed.
 >
 > Note that in some browsers, users can override the `strWindowFeatures` settings and enable (or prevent the disabling of) features.
 
@@ -127,7 +128,8 @@ If the `strWindowFeatures` parameter is used and if no position features are def
 
   - : If this feature is on, then the new secondary window renders the Location bar in Mozilla-based browsers. MSIE 5+ and Opera 7.x renders the Address Bar. Mozilla and Firefox users can force new windows to always render the location bar by setting `dom.disable_window_open_feature.location` to _true_ in [about:config](http://support.mozilla.com/en-US/kb/Editing+configuration+files#about_config) or in their [user.js file](http://support.mozilla.com/en-US/kb/Editing+configuration+files#user_js).
 
-    > **Nota:** In Firefox 3, `dom.disable_window_open_feature.location` now defaults to _true_, forcing the presence of the Location Bar much like in IE7. See bug 337344 for more information.
+    > [!NOTE]
+    > In Firefox 3, `dom.disable_window_open_feature.location` now defaults to _true_, forcing the presence of the Location Bar much like in IE7. See bug 337344 for more information.
 
     Supported in: ![Internet Explorer 5+](msie_ico.png), ![Netscape 6.x](ns6.gif), ![Netscape 7.x](ns7_ico4.gif), ![Mozilla 1.x](mozilla1_ico.png), ![Firefox 1.x](ff1x.png), ![Opera 6+](opera6.gif)
 
@@ -156,7 +158,8 @@ If the `strWindowFeatures` parameter is used and if no position features are def
 
     Starting with Firefox 3, secondary windows are always resizable ([Error 177838 en Firefox](https://bugzil.la/177838))
 
-    > **Nota:** For accessibility reasons, it is strongly recommended to set this feature always on
+    > [!NOTE]
+    > For accessibility reasons, it is strongly recommended to set this feature always on
 
     Mozilla and Firefox users can force new windows to be easily resizable by setting
     `dom.disable_window_open_feature.resizable`
@@ -166,7 +169,8 @@ If the `strWindowFeatures` parameter is used and if no position features are def
 
   - : If this feature is on, the new secondary window will show horizontal and/or vertical scrollbar(s) if the document doesn't fit into the window's viewport.
 
-    > **Nota:** For accessibility reasons, it is strongly encouraged to set this feature always on.
+    > [!NOTE]
+    > For accessibility reasons, it is strongly encouraged to set this feature always on.
 
     Mozilla and Firefox users can force this option to be always enabled for new windows by setting
     `dom.disable_window_open_feature.scrollbars`
@@ -184,7 +188,8 @@ The following features require the `UniversalBrowserWrite` privilege, otherwise 
 
   - : **Note**: Starting with Mozilla 1.2.1, this feature requires the `UniversalBrowserWrite` privilege ([Error 180048 en Firefox](https://bugzil.la/180048)). Without this privilege, it is ignored. If on, the new window is said to be modal. The user cannot return to the main window until the modal window is closed. A typical modal window is created by the [alert() function](/es/docs/DOM/window.alert). The exact behavior of modal windows depends on the platform and on the Mozilla release version.
 
-    > **Nota:** As of Gecko 1.9, the Internet Explorer equivalent to this feature is the {{domxref("window.showModalDialog()")}} method. For compatibility reasons, it's now supported in Firefox. Note also that starting in Gecko 2.0, you can use {{domxref("window.showModalDialog()")}} without UniversalBrowserWrite privileges.
+    > [!NOTE]
+    > As of Gecko 1.9, the Internet Explorer equivalent to this feature is the {{domxref("window.showModalDialog()")}} method. For compatibility reasons, it's now supported in Firefox. Note also that starting in Gecko 2.0, you can use {{domxref("window.showModalDialog()")}} without UniversalBrowserWrite privileges.
 
     Supported in: ![Netscape 6.x](ns6.gif), ![Netscape 7.x](ns7_ico4.gif), ![Mozilla 1.x](mozilla1_ico.png), ![Firefox 1.x](ff1x.png)
 

--- a/files/es/web/api/window/popstate_event/index.md
+++ b/files/es/web/api/window/popstate_event/index.md
@@ -9,7 +9,8 @@ La propiedad **`onpopstate`** es el [`event handler`](/es/docs/Web/Reference/Eve
 
 Se envía un evento `popstate` a la ventana cada vez que la entrada activa de la historia cambia entre otra otras dos entradas del mismo documento. Si la entrada de la historia fue creada al llamar a `history.pushState()`, o fue afectada por una llamada a `history.replaceState()`, la propiedad `state` del evento `popstate` contendrá una copia del objeto de estado de la entrada de la hisotria.
 
-> **Nota:** Llamar a `history.pushState()` o a `history.replaceState()` no dispararán un evento `popstate`. El evento `popstate` solamente se dispará realizando una acción de navegador, tal como pulsar el botón volver (o llamando a `history.back()` en JavaScript), mientras se navega entre dos entradas de la historia de un mismo documento.
+> [!NOTE]
+> Llamar a `history.pushState()` o a `history.replaceState()` no dispararán un evento `popstate`. El evento `popstate` solamente se dispará realizando una acción de navegador, tal como pulsar el botón volver (o llamando a `history.back()` en JavaScript), mientras se navega entre dos entradas de la historia de un mismo documento.
 
 ## Sintaxis
 

--- a/files/es/web/api/window/requestanimationframe/index.md
+++ b/files/es/web/api/window/requestanimationframe/index.md
@@ -5,7 +5,8 @@ slug: Web/API/Window/requestAnimationFrame
 
 {{APIRef}}El método **`window.requestAnimationFrame`** informa al navegador que quieres realizar una animación y solicita que el navegador programe el repintado de la ventana para el próximo ciclo de animación. El método acepta como argumento una función a la que llamar antes de efectuar el repintado.
 
-> **Nota:** Si no quieres que tu animación se detenga, debes asegurarte de llamar a su vez a `requestAnimationFrame()` desde tu callback.
+> [!NOTE]
+> Si no quieres que tu animación se detenga, debes asegurarte de llamar a su vez a `requestAnimationFrame()` desde tu callback.
 
 Debes llamar a este método cuando estés preparado para actualizar tu animación en la pantalla para pedir que se programe el repintado. Ésto puede suceder hasta 60 veces por segundo en pestañas en primer plano, pero se puede ver reducido a velocidades inferiores en pestañas en segundo plano.
 

--- a/files/es/web/api/window/sessionstorage/index.md
+++ b/files/es/web/api/window/sessionstorage/index.md
@@ -49,7 +49,8 @@ field.addEventListener("change", function () {
 });
 ```
 
-> **Nota:** Por favor diríjase al artículo [Usando la API de Web Storage](/es/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API) para un ejemplo completo.
+> [!NOTE]
+> Por favor diríjase al artículo [Usando la API de Web Storage](/es/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API) para un ejemplo completo.
 
 ## Especificaciones
 

--- a/files/es/web/api/window/showmodaldialog/index.md
+++ b/files/es/web/api/window/showmodaldialog/index.md
@@ -36,7 +36,8 @@ donde
 | `resizable: {on \| off \| yes \| no \| 1 \| 0 }` | Si el valor de este argumentoes `on`, `yes`, ó 1, la ventana de diálogo podrá ser redimensionada por el usuario; en caso controario su tamaño será fijo. El valor por defecto es `no`. |
 | `scroll: {on \| off \| yes \| no \| 1 \| 0 }`    | Si el valor de este argumento es `on`, `yes`, ó 1, la ventana de diálogo tendrá barras de desplazamiento; en caso contrario su tamaño será fijo. El valor por defecto es `no`.         |
 
-> **Nota:** Firefox no implementa los argumentos `dialogHide`, `edge`, `status`, ó `unadorned`.
+> [!NOTE]
+> Firefox no implementa los argumentos `dialogHide`, `edge`, `status`, ó `unadorned`.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/xmlhttprequest/index.md
+++ b/files/es/web/api/xmlhttprequest/index.md
@@ -17,7 +17,8 @@ var req = new XMLHttpRequest();
 
 Para obtener más información de cómo usar `XMLHttpRequest`, mira [Usar XMLHttpRequest](/Es/XMLHttpRequest/Using_XMLHttpRequest).
 
-> **Nota:** De forma predeterminada, Firefox 3 limita la cantidad de conexiones de `XMLHttpRequest` por servidor a 6 (las versiones previas limitan a 2 conexiones por servidor). Algunos sitios web interactivos pueden mantener una conexión `XMLHttpRequest` abierta, así que abrir múltiples sesiones a esos sitios puede derivar en congelamientos del navegador de una forma que la ventana no se actualiza y los controles no responden. Este valor puede ser cambiado al editar la preferencia `network.http.max-persistent-connections-per-server` en [`about:config`](/about:config).
+> [!NOTE]
+> De forma predeterminada, Firefox 3 limita la cantidad de conexiones de `XMLHttpRequest` por servidor a 6 (las versiones previas limitan a 2 conexiones por servidor). Algunos sitios web interactivos pueden mantener una conexión `XMLHttpRequest` abierta, así que abrir múltiples sesiones a esos sitios puede derivar en congelamientos del navegador de una forma que la ventana no se actualiza y los controles no responden. Este valor puede ser cambiado al editar la preferencia `network.http.max-persistent-connections-per-server` en [`about:config`](/about:config).
 
 ## Resumen del método
 
@@ -52,14 +53,16 @@ Para obtener más información de cómo usar `XMLHttpRequest`, mira [Usar XMLHtt
 
     Esto permite el uso del push del servidor; para cada documento XML que se escribe para este pedido, se crea un nuevo XMLDOMdocument y se llama al manejador `onload` entre cada documento.
 
-    > **Nota:** Cuando esto se elige, el manejador `onload` y otros manejadores de eventos no son reiniciados después de que el primer XMLdocument es cargado, y el manejador `onload` es llamado después de que cada parte de la respuesta es recibida.
+    > [!NOTE]
+    > Cuando esto se elige, el manejador `onload` y otros manejadores de eventos no son reiniciados después de que el primer XMLdocument es cargado, y el manejador `onload` es llamado después de que cada parte de la respuesta es recibida.
 
 - `onreadystatechange`
   : `nsIDOMEventListener`
 
   - : Una función del objeto JavaScript que se llama cuando el atributo `readyState` cambia. El callback se llama desde la interfaz del usuario.
 
-    > **Advertencia:** Esto no debe ser usado desde código nativo. Tampoco debes usarlo con pedidos sincrónicos.
+    > [!WARNING]
+    > Esto no debe ser usado desde código nativo. Tampoco debes usarlo con pedidos sincrónicos.
 
 - `readyState`: `long`
 
@@ -79,7 +82,8 @@ Para obtener más información de cómo usar `XMLHttpRequest`, mira [Usar XMLHtt
 
   - : La respuesta al pedido como un objeto DOM[`Document`](/es/DOM/document), o `null` si el pedido no fue exitoso, aún no fue enviado o no puede ser analizado como XML. La respuesta es analizada como si fuera `text/xml`. **Sólo lectura.**
 
-    > **Nota:** Si el servidor no aplica el encabezado de tipo de contenido `text/xml`, puedes usar `overrideMimeType()` para forzar a `XMLHttpRequest` a analizarlo como XML igualmente.
+    > [!NOTE]
+    > Si el servidor no aplica el encabezado de tipo de contenido `text/xml`, puedes usar `overrideMimeType()` para forzar a `XMLHttpRequest` a analizarlo como XML igualmente.
 
 - `status`: `unsigned long`
   - : El estado de la respuesta al pedido. Éste es el código HTTPresult (por ejemplo, `status` es 200 por un pedido exitoso). **Sólo lectura.**
@@ -91,7 +95,8 @@ Para obtener más información de cómo usar `XMLHttpRequest`, mira [Usar XMLHtt
 
   - : Indica cuando el pedido de Access-Control entre sitios debe o no ser realizado usando credenciales como cookies o encabezados de autorización.
 
-    > **Nota:** Esto nunca afecta los pedidos en para el propio sitio.
+    > [!NOTE]
+    > Esto nunca afecta los pedidos en para el propio sitio.
 
     El valor predeterminado es `false`.
 
@@ -113,7 +118,8 @@ Ninguno.
 
 Devuelve todos los encabezados de respuesta como una cadena.
 
-> **Nota:** Para pedidos multi partes, esto devuelve los encabezados de la parte _actual_ del pedido, no del canal original.
+> [!NOTE]
+> Para pedidos multi partes, esto devuelve los encabezados de la parte _actual_ del pedido, no del canal original.
 
 ```
 string getAllResponseHeaders();
@@ -173,7 +179,8 @@ Inicializa el objeto para que sea usado desde código C++.
 
 Inicializa el pedido. Este método es para ser usado desde código JavaScript, para inicializar un pedido desde código nativo, debes usar [`openRequest()`](</en/XMLHttpRequest#openRequest()>).
 
-> **Nota:** Llamar a este método en un pedido activo (uno para el cual `open()` o `openRequest()` ya han sido llamados) es equivalente a usar `abort()`.
+> [!NOTE]
+> Llamar a este método en un pedido activo (uno para el cual `open()` o `openRequest()` ya han sido llamados) es equivalente a usar `abort()`.
 
 ```
 void open(
@@ -204,7 +211,8 @@ Inicia la peticion, este metodo est
 
 Inicializa la peticion. Este método se utiliza desde el código nativo, para inicializar una solicitud desde el código JavaScript, utilice `open ()` en su lugar.
 
-> **Nota:** Calling this method an already active request (one for which `open()` or `openRequest()` has already been called) is the equivalent of calling `abort()`.
+> [!NOTE]
+> Calling this method an already active request (one for which `open()` or `openRequest()` has already been called) is the equivalent of calling `abort()`.
 
 ```
 void open(
@@ -233,7 +241,8 @@ void open(
 
 Overrides the MIMEtype returned by the server.
 
-> **Nota:** This method must be called before `send()`.
+> [!NOTE]
+> This method must be called before `send()`.
 
 ```
 void overrideMimeType(
@@ -250,7 +259,8 @@ void overrideMimeType(
 
 Sends the request. If the request is asynchronous (which is the default), this method returns as soon as the request is sent. If the request is synchronous, this method doesn't return until the response has arrived.
 
-> **Nota:** Any event listeners you wish to set must be set before calling `send()`.
+> [!NOTE]
+> Any event listeners you wish to set must be set before calling `send()`.
 
 ```
 void send(
@@ -288,7 +298,8 @@ void sendAsBinary(
 
 Sets the value of an HTTPrequest header.
 
-> **Nota:** You must call [`open()`](</en/XMLHttpRequest#open()>)before using this method.
+> [!NOTE]
+> You must call [`open()`](</en/XMLHttpRequest#open()>)before using this method.
 
 ```
 void setRequestHeader(

--- a/files/es/web/api/xmlhttprequest/timeout/index.md
+++ b/files/es/web/api/xmlhttprequest/timeout/index.md
@@ -7,7 +7,8 @@ slug: Web/API/XMLHttpRequest/timeout
 
 La propiedad **`XMLHttpRequest.timeout`** es un `unsigned long` que representa el número de milisegundos que puede tomar una solicitud antes de que se finalice automáticamente. El valor por defecto es 0, lo que significa que no hay tiempo de espera (_timeout_). _Timeout_ no debe utilizarse para solicitudes XMLHttpRequests sincrónicas usadas en un {{Glossary('document environment')}}, pues generará una excepción `InvalidAccessError`. Cuando ocurre un tiempo de espera, se dispara un evento [timeout](/es/docs/Web/Events/timeout).
 
-> **Nota:** No puede usar un _timeout_ para solicitudes sincrónicas con una ventana propietaria (_owning window_).
+> [!NOTE]
+> No puede usar un _timeout_ para solicitudes sincrónicas con una ventana propietaria (_owning window_).
 
 [Uso de _timeout_ con una solicitud asincrónica](/es/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests#Example_using_a_timeout)
 

--- a/files/es/web/api/xmlhttprequest_api/using_formdata_objects/index.md
+++ b/files/es/web/api/xmlhttprequest_api/using_formdata_objects/index.md
@@ -31,7 +31,8 @@ request.open("POST", "http://foo.com/submitform.php");
 request.send(formData);
 ```
 
-> **Nota:** Los campos "userfile" y "webmasterfile" contienen ambos un archivo. El número asignado al campo "accountnum" es inmediatamente convertido a string por el método [`FormData.append()`](</en/DOM/XMLHttpRequest/FormData#append()> "en/XMLHttpRequest/FormData#append()") (el valor del campo puede ser un {{ domxref("Blob") }}, {{ domxref("File") }}, o una cadena de texto; **si el valor no es ni un Blob, ni un File, será convertido a un string**).
+> [!NOTE]
+> Los campos "userfile" y "webmasterfile" contienen ambos un archivo. El número asignado al campo "accountnum" es inmediatamente convertido a string por el método [`FormData.append()`](</en/DOM/XMLHttpRequest/FormData#append()> "en/XMLHttpRequest/FormData#append()") (el valor del campo puede ser un {{ domxref("Blob") }}, {{ domxref("File") }}, o una cadena de texto; **si el valor no es ni un Blob, ni un File, será convertido a un string**).
 
 Este ejemplo construye una instancia de `FormData` que almacenará los valores de los campos "username", "accountnum", "userfile" y "webmasterfile", entonces usará el método [`send()`](</en/DOM/XMLHttpRequest#send()> "en/XMLHttpRequest#send()") de `XMLHttpRequest` para enviar los datos del formulario. El campo "webmasterfile" es un [`Blob`](/en/DOM/Blob). Un objeto [`Blob`](/en/DOM/Blob) representa un objeto de tipo similar a un fichero que es inalterable y que almacenará datos en formato raw. Los Blobs representan datos que no necesariamente tendrán un formato Javascript nativo. La interfaz {{ domxref("File") }} está basada en [`Blob`](/en/DOM/Blob), y hereda su funcionalidad y la amplía para dar soporte a archivos que estén en el sistema del usuario. Para construir un [`Blob`](/en/DOM/Blob), puede invocar [`al constructor del objeto Blob`](/en/DOM/Blob#Constructor).
 
@@ -118,7 +119,8 @@ form.addEventListener(
 );
 ```
 
-> **Nota:** el método especificado en el formulario será usado por encima del método utilizado en en la llamada a open().
+> [!NOTE]
+> El método especificado en el formulario será usado por encima del método utilizado en en la llamada a open().
 
 También puede añadir un {{ domxref("File") }} o un {{ domxref("Blob") }} directamente al objeto {{ domxref("XMLHttpRequest/FormData", "FormData") }} de la siguiente manera:
 

--- a/files/es/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
+++ b/files/es/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
@@ -40,13 +40,11 @@ de estos dos tipos de peticiones en la página [peticiones síncronas
 y asíncronas](/es/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests). No utilice solicitudes sincrónicas fuera de los Web
 Workers.
 
-> **Nota:** A partir de Gecko 30.0 (Firefox 30.0 / Thunderbird 30.0 / SeaMonkey 2.27), las peticiones síncronas en el hilo principal han sido marcadas como obsoletas debido a
-> los efectos negativos en la experiencia del usuario.
+> [!NOTE]
+> A partir de Gecko 30.0 (Firefox 30.0 / Thunderbird 30.0 / SeaMonkey 2.27), las peticiones síncronas en el hilo principal han sido marcadas como obsoletas debido a los efectos negativos en la experiencia del usuario.
 
-> **Nota:** La función constructora
-> `XMLHttpRequest` no se limita a los documentos XML. Comienza con
-> **"XML "** porque cuando se creó el formato principal que se utilizaba originalmente
-> para el intercambio de datos asíncrono era XML.
+> [!NOTE]
+> La función constructora `XMLHttpRequest` no se limita a los documentos XML. Comienza con **"XML"** porque cuando se creó el formato principal que se utilizaba originalmente para el intercambio de datos asíncrono era XML.
 
 ## Manejando las respuestas
 
@@ -191,9 +189,8 @@ function transferCanceled(evt) {
 Las líneas 3-6 añaden escuchadores de eventos para los distintos eventos que se envían al realizar una
 transferencia de datos utilizando `XMLHttpRequest`.
 
-> **Nota:** Tienes que añadir los escuchadores de eventos antes de
-> llamar a `open()` en la petición. De lo contrario, los eventos `progress
-> no se dispararán.
+> [!NOTE]
+> Tienes que añadir los escuchadores de eventos antes de llamar a `open()` en la petición. De lo contrario, los eventos `progress no se dispararán.
 
 El manejador de eventos de progreso, especificado por la función `updateProgress()` en
 este ejemplo, recibe el número total de bytes a transferir así como el número de
@@ -217,19 +214,14 @@ oReq.upload.addEventListener("abort", transferCanceled);
 oReq.open();
 ```
 
-> **Nota:** Los eventos de progreso no están disponibles para el
-> protocolo `file:`.
+> [!NOTE]
+> Los eventos de progreso no están disponibles para el protocolo `file:`.
 
-> **Nota:** A partir de Gecko 9.0, se puede confiar en que los eventos de progreso
-> lleguen para cada trozo de datos recibidos, incluyendo el último trozo en los casos
-> en los que se recibe el último paquete y se cierra la conexión antes de que se
-> dispare el evento de progreso. En este caso, el evento de progreso se dispara automáticamente
-> cuando se produce el evento de carga para ese paquete. Esto te permite ahora monitorizar
-> de forma fiable el progreso observando únicamente el evento "progress".
+> [!NOTE]
+> A partir de Gecko 9.0, se puede confiar en que los eventos de progreso lleguen para cada trozo de datos recibidos, incluyendo el último trozo en los casos en los que se recibe el último paquete y se cierra la conexión antes de que se dispare el evento de progreso. En este caso, el evento de progreso se dispara automáticamente cuando se produce el evento de carga para ese paquete. Esto te permite ahora monitorizar de forma fiable el progreso observando únicamente el evento "progress".
 
-> **Nota**: A partir de Gecko 12.0, si su evento de progreso es llamado con
-> un `responseType` de "moz-blob", el valor de la respuesta es un
-> {{domxref("Blob")}} que contiene los datos recibidos hasta el momento.
+> [!NOTE]
+> A partir de Gecko 12.0, si su evento de progreso es llamado con un `responseType` de "moz-blob", el valor de la respuesta es un {{domxref("Blob")}} que contiene los datos recibidos hasta el momento.
 
 También se pueden detectar las tres condiciones de finalización de la carga (`abort`,
 `load`, o `error`) utilizando el evento `loadend`:
@@ -708,25 +700,14 @@ La sintaxis para activar este script es:
 AJAXSubmit(myForm);
 ```
 
-> **Nota:** Este framework utiliza la API {{domxref("FileReader")}}
-> para transmitir las cargas de archivos. Este es un API reciente y no está implementada en IE9 o
-> inferiores. Por esta razón, la carga sólo en AJAX se considera **una técnica experimental**.
-> Si no necesita subir archivos binarios, este framework funciona
-> bien en la mayoría de los navegadores.
+> [!NOTE]
+> Este framework utiliza la API {{domxref("FileReader")}} para transmitir las cargas de archivos. Este es un API reciente y no está implementada en IE9 o inferiores. Por esta razón, la carga sólo en AJAX se considera **una técnica experimental**. Si no necesita subir archivos binarios, este framework funciona bien en la mayoría de los navegadores.
 
-> **Nota:** La mejor manera de enviar contenido binario es a través de
-> {{jsxref("ArrayBuffer", "ArrayBuffers")}} o {{domxref("Blob", "Blobs")}} junto con
-> con el método {{domxref("XMLHttpRequest.send()", "send()")}} y posiblemente el
-> método {{domxref("FileReader.readAsArrayBuffer()", "readAsArrayBuffer()")}} de la
-> API `FileReader`. Pero, como el objetivo de este script es trabajar con un [stringifiable](/es/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
-> de datos en bruto, utilizamos el método {{domxref("XMLHttpRequest.sendAsBinary()", "sendAsBinary()")}}
-> junto con el método {{domxref("FileReader.readAsBinaryString()", "readAsBinaryString()")}} de la API `FileReader`. Por lo tanto, el script anterior
-> tiene sentido sólo cuando se trata de archivos pequeños. Si no tiene intención de
-> de cargar contenido binario, considere utilizar la API `FormData`.
+> [!NOTE]
+> La mejor manera de enviar contenido binario es a través de {{jsxref("ArrayBuffer", "ArrayBuffers")}} o {{domxref("Blob", "Blobs")}} junto con con el método {{domxref("XMLHttpRequest.send()", "send()")}} y posiblemente el método {{domxref("FileReader.readAsArrayBuffer()", "readAsArrayBuffer()")}} de la API `FileReader`. Pero, como el objetivo de este script es trabajar con un [stringifiable](/es/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) de datos en bruto, utilizamos el método {{domxref("XMLHttpRequest.sendAsBinary()", "sendAsBinary()")}} junto con el método {{domxref("FileReader.readAsBinaryString()", "readAsBinaryString()")}} de la API `FileReader`. Por lo tanto, el script anterior tiene sentido sólo cuando se trata de archivos pequeños. Si no tiene intención de de cargar contenido binario, considere utilizar la API `FormData`.
 
-> **Nota:** El método no estándar `sendAsBinary`
-> se considera obsoleto a partir de Gecko 31 (Firefox 31 / Thunderbird 31 / SeaMonkey 2.28) y se eliminará pronto.
-> En su lugar se puede utilizar el método estándar `send(Blob data)`.
+> [!NOTE]
+> El método no estándar `sendAsBinary` se considera obsoleto a partir de Gecko 31 (Firefox 31 / Thunderbird 31 / SeaMonkey 2.28) y se eliminará pronto. En su lugar se puede utilizar el método estándar `send(Blob data)`.
 
 ### Uso de los objetos FormData
 
@@ -908,11 +889,8 @@ API `FormData`**. Nótese la brevedad del código:
 </html>
 ```
 
-> **Nota:** Como hemos dicho, los objetos **{{domxref("FormData")}}
-> no son objetos [stringifiable](/es/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)**. Si quieres transformar en string los datos enviados, utiliza [el ejemplo anterior en _puro_-AJAX](#un_pequeño_framework_vanilla). Tenga
-> en cuenta también que, aunque en este ejemplo hay algunos campos `file` {{HTMLElement("input") }}, **cuando se envía un formulario a través de la API `FormData`
-> tampoco es necesario utilizar la API {{domxref("FileReader")}}**:
-> los archivos se cargan y suben automáticamente.
+> [!NOTE]
+> Como hemos dicho, los objetos **{{domxref("FormData")}} no son objetos [stringifiable](/es/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)**. Si quieres transformar en string los datos enviados, utiliza [el ejemplo anterior en _puro_-AJAX](#un_pequeño_framework_vanilla). Tenga en cuenta también que, aunque en este ejemplo hay algunos campos `file` {{HTMLElement("input") }}, **cuando se envía un formulario a través de la API `FormData` tampoco es necesario utilizar la API {{domxref("FileReader")}}**: los archivos se cargan y suben automáticamente.
 
 ## Obtener la fecha de la última modificación
 

--- a/files/es/web/css/--_star_/index.md
+++ b/files/es/web/css/--_star_/index.md
@@ -22,7 +22,8 @@ Las propiedades personalizadas tienen como alcance los elementos en los que se d
 - `<declaración-valor>`
   - : Este valor coincide con cualquier secuencia de uno o más tokens, siempre que la secuencia no contenga un token no permitido.
 
-> **Nota:** Los nombres de las propiedades personalizadas distinguen entre mayúsculas y minúsculas — `--mi-color` se tratará como una propiedad personalizada separada de `--Mi-color`.
+> [!NOTE]
+> Los nombres de las propiedades personalizadas distinguen entre mayúsculas y minúsculas — `--mi-color` se tratará como una propiedad personalizada separada de `--Mi-color`.
 
 ### Sintaxis formal
 

--- a/files/es/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/es/web/css/-moz-force-broken-image-icon/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/-moz-force-broken-image-icon
 
 `-moz-force-broken-image-icon` es una propiedad CSS extendida. El valor `1` fuerza un icono de imagen no encontrada aunque la imagen tenga el atributo `alt`. Cuando el valor es `0` la imagen actuará normalmente y solo mostrará el atributo `alt`.
 
-> **Nota:** Aunque el valor sea `1` el atributo `alt` se seguirá mostrando. Más información debajo.
+> [!NOTE]
+> Aunque el valor sea `1` el atributo `alt` se seguirá mostrando. Más información debajo.
 
 {{cssinfo}}
 
@@ -39,7 +40,8 @@ img {
 
 {{ EmbedLiveSample('Examples','125','125','/files/4619/broken%20image%20link.png') }}
 
-> **Nota:** A no ser que la imagen tenga una altura y ancho especificados, el icono de imagen rota no se mostrará, pero el atributo alt no se mostrará si el valor de `-moz-force-broken-image-icon` es `1`.
+> [!NOTE]
+> A no ser que la imagen tenga una altura y ancho especificados, el icono de imagen rota no se mostrará, pero el atributo alt no se mostrará si el valor de `-moz-force-broken-image-icon` es `1`.
 
 ## Notas
 

--- a/files/es/web/css/@font-face/index.md
+++ b/files/es/web/css/@font-face/index.md
@@ -78,7 +78,8 @@ En este ejemplo, es utilizada la copia local de "Helvetica Neue Bold" del usuari
 ## Notas
 
 - En Gecko, las fuentes web están sujetas a la restricción del mismo dominio (los archivos de fuentes deben estar en el mismo dominio que la página que los utiliza), a menos que los [controles de acceso HTTP](/En/HTTP_access_control) sean utilizados para relajar esta restricción.
-- > **Nota:** Porque no hay tipos MIME definidos para fuentes TrueType, OpenType, y WOFF, el tipo MIME del archivo especificado no es considerado.
+- > [!NOTE]
+  > Porque no hay tipos MIME definidos para fuentes TrueType, OpenType, y WOFF, el tipo MIME del archivo especificado no es considerado.
 - Cuando Gecko muestra una página que usa fuentes web, inicialmente muestra el texto que usa la mejor fuente de reserva CSS disponible en la computadora del usuario mientras espera que la fuente web termine de descargarse. Mientras cada fuente web se termina de descargar, Gecko actualiza el texto que utiliza esa fuente. Esto permite al usuario leer más rápidamente el texto en la página.
 
 ## Compatibilidad del navegador

--- a/files/es/web/css/@media/index.md
+++ b/files/es/web/css/@media/index.md
@@ -26,7 +26,8 @@ Un `<media-query>` está compuesto por un tipo de medio opcional y/o un conjunto
 - `screen`
   - : Destinado a principalmente a pantallas de computadora a color.
 
-> **Nota:** CSS2.1 y Media Queries 3 definió varios tipos de media adicionales (`tty`, `tv`, `projection`, `handheld`, `braille`, `embossed`, `aural`, `speech`), pero fueron descontinuados en [Media Queries 4](https://dev.w3.org/csswg/mediaqueries/#media-types) y no deben ser usados.
+> [!NOTE]
+> CSS2.1 y Media Queries 3 definió varios tipos de media adicionales (`tty`, `tv`, `projection`, `handheld`, `braille`, `embossed`, `aural`, `speech`), pero fueron descontinuados en [Media Queries 4](https://dev.w3.org/csswg/mediaqueries/#media-types) y no deben ser usados.
 
 ## Características de Medios (media feature)
 

--- a/files/es/web/css/@media/pointer/index.md
+++ b/files/es/web/css/@media/pointer/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/@media/pointer
 
 La [caracteristica](/es/docs/Web/CSS/Media_Queries/Using_media_queries#Media_features) **`pointer`** [CSS](/es/docs/CSS) comprueba si el usuario tiene un dispositivo de puntero (como el ratón), y si es así, cuán preciso es el dispositivo de puntero primario.
 
-> **Nota:** Si quieres comprobar la precisión de cualquier dispositivo apuntador, usa [`any-pointer`](/es/docs/Web/CSS/@media/any-pointer) en su lugar.
+> [!NOTE]
+> Si quieres comprobar la precisión de cualquier dispositivo apuntador, usa [`any-pointer`](/es/docs/Web/CSS/@media/any-pointer) en su lugar.
 
 ## Sintaxis
 

--- a/files/es/web/css/@namespace/index.md
+++ b/files/es/web/css/@namespace/index.md
@@ -32,7 +32,8 @@ La regla `@namespace` también puede usarse para definir un **prefijo de namespa
 
 En [HTML5](/es/docs/Glossary/HTML5), conocidos como[elementos externos](https://html.spec.whatwg.org/#foreign-elements) automaticamente se les asignarán un namespace. Esto significa que los elementos HTML actuarán como si estuvieran en un namespace XHTML (`http://www.w3.org/1999/xhtml`), incluso si no hay ningún atributo xmlns en ninguna parte del document, y los elementos [\<svg>](/es/docs/Web/SVG/Element/svg) y [\<math>](/es/docs/Web/MathML/Element/math) se les asignará un namespace propio (`http://www.w3.org/2000/svg` and `http://www.w3.org/1998/Math/MathML`).
 
-> **Nota:** En XML, a menos que se defina un prefijo directamente sobre un atributo (_ejemplo._, `xlink:href`), ese atributo no tiene namespace. En otras palabras, los atributos no heredan el namespace del elemento en el que están. Para que coincida con este comportamiento, el namespace por defecto en CSS no se aplica a los selectores de atributos.
+> [!NOTE]
+> En XML, a menos que se defina un prefijo directamente sobre un atributo (_ejemplo._, `xlink:href`), ese atributo no tiene namespace. En otras palabras, los atributos no heredan el namespace del elemento en el que están. Para que coincida con este comportamiento, el namespace por defecto en CSS no se aplica a los selectores de atributos.
 
 ## Sintaxis
 

--- a/files/es/web/css/@page/index.md
+++ b/files/es/web/css/@page/index.md
@@ -11,7 +11,8 @@ La regla @page es usada para modificar algunas propiedades CSS cuando se va a im
 
 La regla `@page` puede ser accesada por medio de la interfaz modelo objeto {{domxref("CSSPageRule")}}.
 
-> **Nota:** La W3C esta discutiendo como manejar las unidades relativas {{cssxref("&lt;length&gt;")}} : `vh`, `vw`, `vmin`, y `vmax`. Mientras tanto, se recomienda no usarlas en la regla `@page`.
+> [!NOTE]
+> La W3C esta discutiendo como manejar las unidades relativas {{cssxref("&lt;length&gt;")}} : `vh`, `vw`, `vmin`, y `vmax`. Mientras tanto, se recomienda no usarlas en la regla `@page`.
 
 ## Sintaxis
 

--- a/files/es/web/css/@supports/index.md
+++ b/files/es/web/css/@supports/index.md
@@ -46,7 +46,8 @@ not ( not ( transform-origin: 2px ) )
 (display: flexbox) and ( not (display: inline-grid) )
 ```
 
-> **Nota:** no hay necesidad de encerrar el operador `not` entre paréntesis cuando se encuentra en el nivel superior. Para combinarlo con otros operadores, como `and` y `or`, sí se requieren paréntesis
+> [!NOTE]
+> No hay necesidad de encerrar el operador `not` entre paréntesis cuando se encuentra en el nivel superior. Para combinarlo con otros operadores, como `and` y `or`, sí se requieren paréntesis
 
 ### El operador "`and`"
 
@@ -90,7 +91,8 @@ es equivalente a:
 (( -o-transform-style: preserve-3d ) or ( -webkit-transform-style: preserve-3d  )))
 ```
 
-> **Nota:** cuando se usan `and` y `or`, el paréntesis debe ser usado para definir el orden en el cual aplican. Si no, la condición es inválida provocando que se ignore todo el "at-rule" .
+> [!NOTE]
+> Cuando se usan `and` y `or`, el paréntesis debe ser usado para definir el orden en el cual aplican. Si no, la condición es inválida provocando que se ignore todo el "at-rule" .
 
 ### Sintaxis formal
 

--- a/files/es/web/css/_colon_-moz-first-node/index.md
+++ b/files/es/web/css/_colon_-moz-first-node/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/:-moz-first-node
 
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) [CSS](/es/docs/Web/CSS) `:-moz-first-node` representa cualquier elemento que sea el primer nodo hijo de algún otro elemento. Se diferencia de {{Cssxref(":first-child")}} en que no selecciona al primer hijo si tiene texto (que no sea espacios en blanco) detrás de él.
 
-> **Nota:** Cualquier espacion en blanco al principio del elemento se ignora a la hora de determina cual elemento es `:-moz-first-node`.
+> [!NOTE]
+> Cualquier espacion en blanco al principio del elemento se ignora a la hora de determina cual elemento es `:-moz-first-node`.
 
 ## Síntaxis
 

--- a/files/es/web/css/_colon_-moz-last-node/index.md
+++ b/files/es/web/css/_colon_-moz-last-node/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/:-moz-last-node
 
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) [CSS](/es/docs/Web/CSS) `:-moz-last-node` selecciona un elemento si es el último nodo hijo de algún otro elemento. Se diferencia de {{cssxref(":last-child")}} en que no selecciona el último elemento hijo si tiene texto (sin contar espacios en blanco) después de él.
 
-> **Nota:** Cualquier espacio en blanco al final de un elemento se ignora al usar `:-moz-last-node`.
+> [!NOTE]
+> Cualquier espacio en blanco al final de un elemento se ignora al usar `:-moz-last-node`.
 
 ## Síntaxis
 

--- a/files/es/web/css/_colon_-moz-window-inactive/index.md
+++ b/files/es/web/css/_colon_-moz-window-inactive/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/:-moz-window-inactive
 
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) [CSS](/es/docs/Web/CSS) `:-moz-window-inactive` selecciona cualquier elemento mientras está en una ventana inactiva.
 
-> **Nota:** Antes de añadir esta pseudo-clase, dar dieferentes estilos a las ventanas de fondo podría lograrse con el atributo (`active="true"`) en la venta del nivel superior XUL. Este atributo ya no se usa.
+> [!NOTE]
+> Antes de añadir esta pseudo-clase, dar dieferentes estilos a las ventanas de fondo podría lograrse con el atributo (`active="true"`) en la venta del nivel superior XUL. Este atributo ya no se usa.
 
 `:-moz-window-inactive` funciona también en documentos de contenido HTML.
 

--- a/files/es/web/css/_colon_active/index.md
+++ b/files/es/web/css/_colon_active/index.md
@@ -16,7 +16,8 @@ a:active {
 
 Los estilos definidos por la pseudoclase `:active` serán anulados por cualquier pseudoclase posterior relacionada con el enlace ({{cssxref(":link")}}, {{cssxref(":hover")}} o {{cssxref(":visited")}}) que tenga al menos la misma especificidad. Para darle un estilo apropiado a los enlaces, coloque la regla `:active` después de todas las demás reglas relacionadas con el enlace, tal como lo define el orden LVHA: `:link` — `:visited` — `:hover` — `:active`.
 
-> **Nota:** En los sistemas con los ratones de varios botones, CSS3 especifica que la pseudo-clase `:active` sólo debe aplicarse al botón primario; en ratones diestros, este suele ser el botón más a la izquierda.
+> [!NOTE]
+> En los sistemas con los ratones de varios botones, CSS3 especifica que la pseudo-clase `:active` sólo debe aplicarse al botón primario; en ratones diestros, este suele ser el botón más a la izquierda.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_autofill/index.md
+++ b/files/es/web/css/_colon_autofill/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/:autofill
 
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) CSS `:-webkit-autofill` CSS selecciona un elemento {{HTMLElement("input")}} cuando su valor es rellenado automáticamente por el navegador.
 
-> **Nota:** La hoja de estilos por defecto de muchos navegadores usan `!important` en sus declaraciones de estilo `:-webkit-autofill` , haciendo que no puedan ser sobrescritos por páginas que no usen trucos JavaScript.
+> [!NOTE]
+> La hoja de estilos por defecto de muchos navegadores usan `!important` en sus declaraciones de estilo `:-webkit-autofill` , haciendo que no puedan ser sobrescritos por páginas que no usen trucos JavaScript.
 
 ## Especificaciones
 

--- a/files/es/web/css/_colon_blank/index.md
+++ b/files/es/web/css/_colon_blank/index.md
@@ -5,7 +5,8 @@ slug: Web/CSS/:blank
 
 {{CSSRef}}{{SeeCompatTable}}
 
-> **Nota:** El selector `:blank` esta considerado en riesgo, puesto que la CSSWG sigue haciendo cambios.Ver [CSSWG issue #1967](https://github.com/w3c/csswg-drafts/issues/1967).
+> [!NOTE]
+> El selector `:blank` esta considerado en riesgo, puesto que la CSSWG sigue haciendo cambios.Ver [CSSWG issue #1967](https://github.com/w3c/csswg-drafts/issues/1967).
 
 La [pseudo-clase CSS](/es/docs/Web/CSS) **`:blank`** selecciona elementos de entrada vaciós (eg. {{HTMLElement("input")}} or {{HTMLElement("textarea")}}).
 

--- a/files/es/web/css/_colon_checked/index.md
+++ b/files/es/web/css/_colon_checked/index.md
@@ -17,7 +17,8 @@ La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) `:checked` de [CSS](/es/docs/
 
 El usuario puede activar este estado marcando/seleccionando un elemento, o desactivándolo desmarcando/deseleccionando el elemento.
 
-> **Nota:** Debido a que los navegadores a menudo tratan las `<option>` s como [elementos reemplazados](/es/docs/Web/CSS/Replaced_element), la medida en que se pueden diseñar con la pseudo-clase `:checked` varía de un navegador a otro.
+> [!NOTE]
+> Debido a que los navegadores a menudo tratan las `<option>` s como [elementos reemplazados](/es/docs/Web/CSS/Replaced_element), la medida en que se pueden diseñar con la pseudo-clase `:checked` varía de un navegador a otro.
 
 ## Sintaxis
 
@@ -176,7 +177,8 @@ Este ejemplo utiliza la pseudoclase `:checked` para permitir al usuario alternar
 
 Puede usar la pseudoclase `:checked` para crear una galería de imágenes con imágenes de tamaño completo que solo se muestran cuando el usuario hace clic en una miniatura. Vea [esta demostración](css-checked-gallery.zip).
 
-> **Nota:** Para un efecto análogo, pero basado en la pseudoclase [`:hover`](/es/docs/CSS/:hover) y sin radioboxes ocultos, vea [esta demostración](css-gallery.zip), tomada de la página de referencia [:hover](/es/docs/CSS/:hover).
+> [!NOTE]
+> Para un efecto análogo, pero basado en la pseudoclase [`:hover`](/es/docs/CSS/:hover) y sin radioboxes ocultos, vea [esta demostración](css-gallery.zip), tomada de la página de referencia [:hover](/es/docs/CSS/:hover).
 
 ## Especificaciones
 

--- a/files/es/web/css/_colon_dir/index.md
+++ b/files/es/web/css/_colon_dir/index.md
@@ -16,9 +16,11 @@ La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) `:dir` de [CSS](/es/docs/Web/
 
 La pseudo-clase `:dir()` usa solo el valor _semántico_ de la direccionalidad, es decir, el definido en el documento mismo. No tiene en cuenta la direccionalidad del _estilo_, es decir, la direccionalidad establecida por las propiedades de CSS como {{cssxref("direction")}}.
 
-> **Nota:** Tenga en cuenta que el comportamiento de la pseudo-clase `:dir()` no es equivalente a los [selectores de atributo](/es/docs/Web/CSS/Attribute_selectors) `[dir=...]`. Estos últimos coinciden con el atributo HTML [`dir`](/es/docs/Web/HTML/Global_attributes#dir) e ignoran los elementos que carecen de él, incluso si heredan una dirección de su padre. (De forma similar, `[dir=rtl]` y `[dir=ltr]` no coincidirán con el valor `auto`.) En contraste, `:dir()` coincidirá con el valor calculado por {{glossary("user agent")}}, incluso si se hereda.
+> [!NOTE]
+> Tenga en cuenta que el comportamiento de la pseudo-clase `:dir()` no es equivalente a los [selectores de atributo](/es/docs/Web/CSS/Attribute_selectors) `[dir=...]`. Estos últimos coinciden con el atributo HTML [`dir`](/es/docs/Web/HTML/Global_attributes#dir) e ignoran los elementos que carecen de él, incluso si heredan una dirección de su padre. (De forma similar, `[dir=rtl]` y `[dir=ltr]` no coincidirán con el valor `auto`.) En contraste, `:dir()` coincidirá con el valor calculado por {{glossary("user agent")}}, incluso si se hereda.
 
-> **Nota:** En HTML, la dirección está determinada por el atributo [`dir`](/es/docs/Web/HTML/Global_attributes#dir) . Otros tipos de documentos pueden tener diferentes métodos.
+> [!NOTE]
+> En HTML, la dirección está determinada por el atributo [`dir`](/es/docs/Web/HTML/Global_attributes#dir) . Otros tipos de documentos pueden tener diferentes métodos.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_empty/index.md
+++ b/files/es/web/css/_colon_empty/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/:empty
 
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:empty`** de [CSS](/es/docs/Web/CSS) representa cualquier elemento que no tenga hijos. Los hijos pueden ser nodos de elemento o texto (incluido el espacio en blanco). Los comentarios o las instrucciones de procesamiento no afectan si un elemento se considera vacío.
 
-> **Nota:** En [Selectors Level 4](https://drafts.csswg.org/selectors-4/#the-empty-pseudo) la pseudo-clase `:empty` fue modificada para actuar como {{CSSxRef(":-moz-only-whitespace")}}, pero ningún navegador actualmente suporta aún esto.
+> [!NOTE]
+> En [Selectors Level 4](https://drafts.csswg.org/selectors-4/#the-empty-pseudo) la pseudo-clase `:empty` fue modificada para actuar como {{CSSxRef(":-moz-only-whitespace")}}, pero ningún navegador actualmente suporta aún esto.
 
 ```css
 /* Selecciona cualquier <div> que no contenga contenido */

--- a/files/es/web/css/_colon_first-child/index.md
+++ b/files/es/web/css/_colon_first-child/index.md
@@ -15,7 +15,8 @@ p:first-child {
 }
 ```
 
-> **Nota:** Como se definió originalmente, el elemento seleccionado tenía que tener un padre. Comenzando con el Nivel 4 de Selectores, esto ya no es necesario.
+> [!NOTE]
+> Como se definió originalmente, el elemento seleccionado tenía que tener un padre. Comenzando con el Nivel 4 de Selectores, esto ya no es necesario.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_first-of-type/index.md
+++ b/files/es/web/css/_colon_first-of-type/index.md
@@ -15,7 +15,8 @@ p:first-of-type {
 }
 ```
 
-> **Nota:** Como se definió originalmente, el elemento seleccionado tenía que tener un padre. Comenzando con el Nivel 4 de Selectores, esto ya no es necesario.
+> [!NOTE]
+> Como se definió originalmente, el elemento seleccionado tenía que tener un padre. Comenzando con el Nivel 4 de Selectores, esto ya no es necesario.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_first/index.md
+++ b/files/es/web/css/_colon_first/index.md
@@ -13,7 +13,8 @@ slug: Web/CSS/:first
 }
 ```
 
-> **Nota:** No puede cambiar todas las propiedades de CSS con esta pseudoclase. Solo puede cambiar los márgenes, {{cssxref("orphans")}}, {{cssxref("widows")}} y saltos de página del documento. Además, solo puede usar unidades de [longitud absoluta](/es/docs/Web/CSS/length#Absolute_length_units) al definir los márgenes. Todas las otras propiedades serán ignoradas.
+> [!NOTE]
+> No puede cambiar todas las propiedades de CSS con esta pseudoclase. Solo puede cambiar los márgenes, {{cssxref("orphans")}}, {{cssxref("widows")}} y saltos de página del documento. Además, solo puede usar unidades de [longitud absoluta](/es/docs/Web/CSS/length#Absolute_length_units) al definir los márgenes. Todas las otras propiedades serán ignoradas.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_focus/index.md
+++ b/files/es/web/css/_colon_focus/index.md
@@ -14,7 +14,8 @@ input:focus {
 }
 ```
 
-> **Nota:** Esta pseudo-clase se aplica solo al elemento enfocado en sí mismo. Utilice {{cssxref(":focus-within")}} si desea seleccionar un elemento que contenga un elemento enfocado.
+> [!NOTE]
+> Esta pseudo-clase se aplica solo al elemento enfocado en sí mismo. Utilice {{cssxref(":focus-within")}} si desea seleccionar un elemento que contenga un elemento enfocado.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_fullscreen/index.md
+++ b/files/es/web/css/_colon_fullscreen/index.md
@@ -24,7 +24,8 @@ div:fullscreen {
 }
 ```
 
-> **Nota:** La especificación W3C usa la palabra única `:fullscreen`, sin guiones, pero las implementaciones experimentales de WebKit y Gecko usan una variante prefijada con dos palabras separadas por un guión: `:-webkit-full-screen` y `:-moz-full-screen`, respectivamente. Microsoft Edge e Internet Explorer utilizan la convención estándar: `:fullscreen` y `:-ms-fullscreen`, respectivamente.
+> [!NOTE]
+> La especificación W3C usa la palabra única `:fullscreen`, sin guiones, pero las implementaciones experimentales de WebKit y Gecko usan una variante prefijada con dos palabras separadas por un guión: `:-webkit-full-screen` y `:-moz-full-screen`, respectivamente. Microsoft Edge e Internet Explorer utilizan la convención estándar: `:fullscreen` y `:-ms-fullscreen`, respectivamente.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_host/index.md
+++ b/files/es/web/css/_colon_host/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/:host
 
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) [CSS](/es/docs/Web/CSS) **`:host`** selecciona la sombra host de [sombra DOM](/es/docs/Web/Web_Components/Using_shadow_DOM) que contiene el CSS que se usa en el interior — es decir, esto le permite seleccionar un elemento personalizado desde su sombra DOM.
 
-> **Nota:** Esto no tiene ningún efecto cuando se usa fuera de una sombra DOM.
+> [!NOTE]
+> Esto no tiene ningún efecto cuando se usa fuera de una sombra DOM.
 
 ```css
 /* Selects a shadow root host */

--- a/files/es/web/css/_colon_hover/index.md
+++ b/files/es/web/css/_colon_hover/index.md
@@ -16,7 +16,8 @@ a:hover {
 
 Los estilos definidos por la pseudoclase `:active` serán anulados por cualquier pseudo-clase posterior relacionada con el _enlace_ ({{ cssxref(":link") }}, {{ cssxref(":visited") }}, o {{ cssxref(":active") }}) que tenga al menos la misma especificidad. Para darle un estilo apropiado a los enlaces, coloque la regla `:hover` después de las reglas `:link` y `:visited`, pero antes de `:active`, según lo definido por el _orden LVHA_: `:link` — `:visited` — `:hover` — `:active`.
 
-> **Nota:** La pseudo-clase `:hover` es problemática en las pantallas táctiles. Dependiendo del navegador, la pseudo-clase `:hover` podría no coincidir, coincidir solo por un momento después de tocar un elemento, o continuar coincidiendo incluso después de que el usuario haya dejado de tocar y hasta que el usuario toque otro elemento. Los desarrolladores web deben asegurarse de que el contenido sea accesible en dispositivos con capacidades _hovering_ limitadas o inexistentes.
+> [!NOTE]
+> La pseudo-clase `:hover` es problemática en las pantallas táctiles. Dependiendo del navegador, la pseudo-clase `:hover` podría no coincidir, coincidir solo por un momento después de tocar un elemento, o continuar coincidiendo incluso después de que el usuario haya dejado de tocar y hasta que el usuario toque otro elemento. Los desarrolladores web deben asegurarse de que el contenido sea accesible en dispositivos con capacidades _hovering_ limitadas o inexistentes.
 
 ## Sintaxis
 
@@ -53,7 +54,8 @@ a:hover {
 
 Puede usar la pseudoclase `:hover` para crear una galería de imágenes con imágenes de tamaño completo que solo se muestran cuando el mouse se mueve sobre una miniatura. Vea [esta demostración](css-gallery.zip) para una posible nota.
 
-> **Nota:** Para un efecto análogo, pero basado en la pseudo-clase [`:checked`](/es/docs/Web/CSS/%3Achecked) (aplicado a radioboxes ocultos), vea [esta demostración](css-checked-gallery.zip), tomada de la página de referencia [:checked](/es/docs/Web/CSS/:checked).
+> [!NOTE]
+> Para un efecto análogo, pero basado en la pseudo-clase [`:checked`](/es/docs/Web/CSS/%3Achecked) (aplicado a radioboxes ocultos), vea [esta demostración](css-checked-gallery.zip), tomada de la página de referencia [:checked](/es/docs/Web/CSS/:checked).
 
 ## Especificaciones
 

--- a/files/es/web/css/_colon_in-range/index.md
+++ b/files/es/web/css/_colon_in-range/index.md
@@ -17,7 +17,8 @@ input:in-range {
 
 Esta pseudo-clase es útil para dar al usuario una indicación visual de que el valor actual de un campo está dentro de los límites permitidos.
 
-> **Nota:** Esta pseudo-clase solo se aplica a los elementos que tienen (y pueden tomar) una limitación de rango. En ausencia de tal limitación, el elemento no puede estar "dentro del rango" ni "fuera de rango".
+> [!NOTE]
+> Esta pseudo-clase solo se aplica a los elementos que tienen (y pueden tomar) una limitación de rango. En ausencia de tal limitación, el elemento no puede estar "dentro del rango" ni "fuera de rango".
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_is/index.md
+++ b/files/es/web/css/_colon_is/index.md
@@ -9,7 +9,8 @@ l10n:
 
 La función [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) de [CSS](/es/docs/Web/CSS) **`:is()`** toma una lista de selectores como argumento y selecciona cualquier elemento que pueda ser seleccionado por uno de los selectores en esa lista. Esto es útil para escribir selectores grandes en una forma más compacta.
 
-> **Nota:** Originalmente llamado `:matches()` (y `:any()`), este selector pasó a llamarse `:is()` en [CSSWG número 3258](https://github.com/w3c/csswg-drafts/issues/3258).
+> [!NOTE]
+> Originalmente llamado `:matches()` (y `:any()`), este selector pasó a llamarse `:is()` en [CSSWG número 3258](https://github.com/w3c/csswg-drafts/issues/3258).
 
 {{EmbedInteractiveExample("pages/tabbed/pseudo-class-is.html", "tabbed-shorter")}}
 

--- a/files/es/web/css/_colon_lang/index.md
+++ b/files/es/web/css/_colon_lang/index.md
@@ -14,7 +14,8 @@ p:lang(en) {
 }
 ```
 
-> **Nota:** En HTML, el lenguaje está determinado por una combinación del atributo [`lang`](/es/docs/Web/HTML/Global_attributes#lang), el elemento {{HTMLElement("meta")}} y posiblemente por la información del protocolo (como los encabezados HTTP). Para otros tipos de documentos, puede haber otros métodos de documentos para determinar el idioma.
+> [!NOTE]
+> En HTML, el lenguaje está determinado por una combinación del atributo [`lang`](/es/docs/Web/HTML/Global_attributes#lang), el elemento {{HTMLElement("meta")}} y posiblemente por la información del protocolo (como los encabezados HTTP). Para otros tipos de documentos, puede haber otros métodos de documentos para determinar el idioma.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_last-child/index.md
+++ b/files/es/web/css/_colon_last-child/index.md
@@ -15,7 +15,8 @@ p:last-child {
 }
 ```
 
-> **Nota:** Como se definió originalmente, el elemento seleccionado tenía que tener un padre. Comenzando con el Nivel 4 de Selectores, esto ya no es necesario.
+> [!NOTE]
+> Como se definió originalmente, el elemento seleccionado tenía que tener un padre. Comenzando con el Nivel 4 de Selectores, esto ya no es necesario.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_last-of-type/index.md
+++ b/files/es/web/css/_colon_last-of-type/index.md
@@ -15,7 +15,8 @@ p:last-of-type {
 }
 ```
 
-> **Nota:** Como se definió originalmente, el elemento seleccionado tenía que tener un padre. Comenzando con el Nivel 4 de Selectores, esto ya no es necesario.
+> [!NOTE]
+> Como se definió originalmente, el elemento seleccionado tenía que tener un padre. Comenzando con el Nivel 4 de Selectores, esto ya no es necesario.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_left/index.md
+++ b/files/es/web/css/_colon_left/index.md
@@ -16,7 +16,8 @@ La **`:left`** [CSS](/es/docs/Web/CSS) [pseudo-clase](/es/docs/Web/CSS/Pseudo-cl
 
 La dirección principal de escritura del documento determina si una página es "izquierda" o "derecha". Por ejemplo, si la primera página tiene una dirección de escritura principal de izquierda a derecha, entonces será una página :right (derecha); si tiene una dirección de escritura importante de derecha a izquierda, será una página :left (izquierda).
 
-> **Nota:** Esta pseudoclase se puede usar para cambiar solo las propiedades margin, padding, border y background del cuadro de página. Se ignorarán todas las demás propiedades y solo se verá afectado el cuadro de página, no el contenido del documento en la página.
+> [!NOTE]
+> Esta pseudoclase se puede usar para cambiar solo las propiedades margin, padding, border y background del cuadro de página. Se ignorarán todas las demás propiedades y solo se verá afectado el cuadro de página, no el contenido del documento en la página.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_link/index.md
+++ b/files/es/web/css/_colon_link/index.md
@@ -16,7 +16,8 @@ a:link {
 
 Los estilos definidos por la pseudo-clase `:link` serán anulados por cualquier pseudo-clase posterior relacionada con el enlace ({{cssxref(":active")}}, {{cssxref(":hover")}}, o {{cssxref(":visited")}}) que tenga al menos la misma especificidad. Para darle un estilo apropiado a los enlaces, coloque la regla `:link` antes de todas las demás reglas relacionadas con el enlace, tal como lo define el _orden LVHA_: `:link` — `:visited` — `:hover` — `:active`.
 
-> **Nota:** Use {{cssxref(":any-link")}} para seleccionar un elemento independientemente de si ha sido visitado o no.
+> [!NOTE]
+> Use {{cssxref(":any-link")}} para seleccionar un elemento independientemente de si ha sido visitado o no.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_not/index.md
+++ b/files/es/web/css/_colon_not/index.md
@@ -14,7 +14,7 @@ La [pseudoclase](/es/docs/Web/CSS/Pseudo-classes) **`:not()`** de [CSS](/es/docs
 }
 ```
 
-> **Nota:**
+> [!NOTE]
 >
 > - Se pueden escribir selectores inútiles usando esta pseudoclase. Por ejemplo, `:not(*)` coincide con cualquier elemento que no sea un elemento, por lo que la regla nunca se aplicará.
 > - Esta pseudoclase puede aumentar la [especificidad](/es/docs/Web/CSS/Specificity) de una regla. Por ejemplo, `#foo:not(#bar)` coincidirá con el mismo elemento que el `#foo` más simple, pero tiene una especificidad más alta.
@@ -25,7 +25,8 @@ La [pseudoclase](/es/docs/Web/CSS/Pseudo-classes) **`:not()`** de [CSS](/es/docs
 
 La pseudoclase `:not()` requiere una lista separada por comas de uno o más selectores como argumento. La lista no debe contener otro selector de negación o un [pseudoelemento](/es/docs/Web/CSS/Pseudo-elements).
 
-> **Advertencia:** La capacidad de enumerar más de un selector es experimental y aún no es ampliamente compatible.
+> [!WARNING]
+> La capacidad de enumerar más de un selector es experimental y aún no es ampliamente compatible.
 
 {{csssyntax}}
 

--- a/files/es/web/css/_colon_nth-last-child/index.md
+++ b/files/es/web/css/_colon_nth-last-child/index.md
@@ -16,7 +16,8 @@ La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:nth-last-child()`** de [C
 }
 ```
 
-> **Nota:** Esta pseudo-clase es esencialmente la misma que {{Cssxref(":nth-child")}}, excepto que cuenta los elementos hacia atrás desde el final, no hacia adelante desde el principio.
+> [!NOTE]
+> Esta pseudo-clase es esencialmente la misma que {{Cssxref(":nth-child")}}, excepto que cuenta los elementos hacia atrás desde el final, no hacia adelante desde el principio.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_nth-last-of-type/index.md
+++ b/files/es/web/css/_colon_nth-last-of-type/index.md
@@ -16,7 +16,8 @@ p:nth-last-of-type(4n) {
 }
 ```
 
-> **Nota:** Esta pseudo-clase es esencialmente la misma que {{Cssxref(":nth-of-type")}}, excepto que cuenta los elementos hacia atrás desde el final, no hacia adelante desde el principio.
+> [!NOTE]
+> Esta pseudo-clase es esencialmente la misma que {{Cssxref(":nth-of-type")}}, excepto que cuenta los elementos hacia atrás desde el final, no hacia adelante desde el principio.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_only-child/index.md
+++ b/files/es/web/css/_colon_only-child/index.md
@@ -15,7 +15,8 @@ p:only-child {
 }
 ```
 
-> **Nota:** Como se definió originalmente, el elemento seleccionado tenía que tener un padre. Comenzando con el Nivel 4 de Selectores, esto ya no es necesario.
+> [!NOTE]
+> Como se definió originalmente, el elemento seleccionado tenía que tener un padre. Comenzando con el Nivel 4 de Selectores, esto ya no es necesario.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_only-of-type/index.md
+++ b/files/es/web/css/_colon_only-of-type/index.md
@@ -15,7 +15,8 @@ p:only-of-type {
 }
 ```
 
-> **Nota:** Como se definió originalmente, el elemento seleccionado tenía que tener un padre. Comenzando con el Nivel 4 de Selectores, esto ya no es necesario.
+> [!NOTE]
+> Como se definió originalmente, el elemento seleccionado tenía que tener un padre. Comenzando con el Nivel 4 de Selectores, esto ya no es necesario.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_optional/index.md
+++ b/files/es/web/css/_colon_optional/index.md
@@ -16,7 +16,8 @@ input:optional {
 
 Esta pseudo-clase es útil para diseñar campos que no son necesarios para enviar un formulario.
 
-> **Nota:** La pseudo-clase {{cssxref(":required")}} selecciona los campos de formulario _requeridos_.
+> [!NOTE]
+> La pseudo-clase {{cssxref(":required")}} selecciona los campos de formulario _requeridos_.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_out-of-range/index.md
+++ b/files/es/web/css/_colon_out-of-range/index.md
@@ -17,7 +17,8 @@ input:out-of-range {
 
 Esta pseudo-clase es útil para dar al usuario una indicación visual de que el valor actual de un campo está fuera de los límites permitidos.
 
-> **Nota:** Esta pseudo-clase solo se aplica a los elementos que tienen (y pueden tomar) una limitación de rango. En ausencia de tal limitación, el elemento no puede estar "dentro del rango" ni "fuera de rango".
+> [!NOTE]
+> Esta pseudo-clase solo se aplica a los elementos que tienen (y pueden tomar) una limitación de rango. En ausencia de tal limitación, el elemento no puede estar "dentro del rango" ni "fuera de rango".
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_read-only/index.md
+++ b/files/es/web/css/_colon_read-only/index.md
@@ -23,7 +23,8 @@ input:read-only {
 }
 ```
 
-> **Nota:** El selector no solo selecciona {{htmlElement("input")}} marcados como [`readonly`](/es/docs/Web/HTML/Element/input#readonly); también selecccionará cualquier elemento que no pueda ser editar por el usuario. Lea sobre el atributo [contenteditable](/es/docs/Web/HTML/Global_attributes/contenteditable).
+> [!NOTE]
+> El selector no solo selecciona {{htmlElement("input")}} marcados como [`readonly`](/es/docs/Web/HTML/Element/input#readonly); también selecccionará cualquier elemento que no pueda ser editar por el usuario. Lea sobre el atributo [contenteditable](/es/docs/Web/HTML/Global_attributes/contenteditable).
 
 ## Síntaxis
 

--- a/files/es/web/css/_colon_read-write/index.md
+++ b/files/es/web/css/_colon_read-write/index.md
@@ -20,7 +20,8 @@ input:read-write {
 }
 ```
 
-> **Nota:** Este selector no solo selecciona texto de {{htmlElement("input")}}; seleccionará _cualquier_ elemento que pueda editar el usuario, como un elemento {{htmlelement("p")}} con [`contenteditable`](/es/docs/Web/HTML/Global_attributes#contenteditable) establecido en él.
+> [!NOTE]
+> Este selector no solo selecciona texto de {{htmlElement("input")}}; seleccionará _cualquier_ elemento que pueda editar el usuario, como un elemento {{htmlelement("p")}} con [`contenteditable`](/es/docs/Web/HTML/Global_attributes#contenteditable) establecido en él.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_required/index.md
+++ b/files/es/web/css/_colon_required/index.md
@@ -16,7 +16,8 @@ input:required {
 
 Esta pseudo-clase es útil para resaltar campos que deben tener datos válidos antes de que se pueda enviar un formulario.
 
-> **Nota:** La pseudoclase {{cssxref(":optional")}} selecciona campos de formulario _opcionales_.
+> [!NOTE]
+> La pseudoclase {{cssxref(":optional")}} selecciona campos de formulario _opcionales_.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_right/index.md
+++ b/files/es/web/css/_colon_right/index.md
@@ -16,7 +16,8 @@ La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) [CSS](/es/docs/Web/CSS) **`:r
 
 Que una página dada sea "izquierda" o "derecha" está determinada por la dirección principal de escritura del documento. Por ejemplo, si la primera página tiene una dirección de escritura principal de izquierda a derecha, entonces será una página `:right`; si tiene una dirección de escritura principal de derecha a izquierda, entonces será una página {{Cssxref(":left")}}.
 
-> **Nota:** No puede cambiar todas las propiedades de CSS con esta pseudo-clase. Solo puede cambiar las propiedades {{ Cssxref("margin") }}, {{ Cssxref("padding") }}, {{ Cssxref("border") }}, y {{ Cssxref("background") }} de la caja de página. Se ignorarán todas las demás propiedades y solo se verá afectada la caja de página, no el contenido del documento en la página.
+> [!NOTE]
+> No puede cambiar todas las propiedades de CSS con esta pseudo-clase. Solo puede cambiar las propiedades {{ Cssxref("margin") }}, {{ Cssxref("padding") }}, {{ Cssxref("border") }}, y {{ Cssxref("background") }} de la caja de página. Se ignorarán todas las demás propiedades y solo se verá afectada la caja de página, no el contenido del documento en la página.
 
 ## Sintaxis
 

--- a/files/es/web/css/_colon_target/index.md
+++ b/files/es/web/css/_colon_target/index.md
@@ -90,7 +90,8 @@ p:target i {
 
 Puede usar la pseudo-clase `:target` para crear un lightbox sin usar JavaScript. Esta técnica se basa en la capacidad de los enlaces de anclaje para señalar elementos que están inicialmente ocultos en la página. Una vez segmentado, el CSS cambia su `display` para que se muestren.
 
-> **Nota:** Un CSS-Puro lightbox más completo basado en la pseudoclase `:target` está [disponible en GitHub](https://github.com/madmurphy/takefive.css/) ([demo](https://madmurphy.github.io/takefive.css/)).
+> [!NOTE]
+> Un CSS-Puro lightbox más completo basado en la pseudoclase `:target` está [disponible en GitHub](https://github.com/madmurphy/takefive.css/) ([demo](https://madmurphy.github.io/takefive.css/)).
 
 #### HTML
 

--- a/files/es/web/css/_colon_visited/index.md
+++ b/files/es/web/css/_colon_visited/index.md
@@ -25,7 +25,8 @@ Por motivos de privacidad, los navegadores limitan estrictamente los estilos que
 - El componente alfa de los estilos permitidos será ignorado. En su lugar, se utilizará el componente alfa del estado non-`:visited` del elemento, excepto cuando ese componente sea 0, en cuyo caso el estilo establecido en `:visited` se ignorará por completo.
 - Aunque estos estilos pueden cambiar la apariencia de los colores para el usuario final, el método {{domxref("window.getComputedStyle")}} mentirá y siempre devolverá el valor del color non-`:visited`.
 
-> **Nota:** Para obtener más información sobre estas limitaciones y las razones detrás de ellas, vea [Privacidad y el selector :visited](/es/docs/CSS/Privacy_and_the_:visited_selector).
+> [!NOTE]
+> Para obtener más información sobre estas limitaciones y las razones detrás de ellas, vea [Privacidad y el selector :visited](/es/docs/CSS/Privacy_and_the_:visited_selector).
 
 ## Sintaxis
 

--- a/files/es/web/css/_doublecolon_-moz-color-swatch/index.md
+++ b/files/es/web/css/_doublecolon_-moz-color-swatch/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/::-moz-color-swatch
 
 El **`::-moz-color-swatch`** [pdseudo-elemento CSS](/es/docs/Web/CSS) es una [extension de Mozilla](/es/docs/Web/CSS/Mozilla_Extensions) que representa el color seleccionado en un {{HTMLElement("input")}} de `type="color"`.
 
-> **Nota:** Usando `::-moz-color-swatch` con cualquier cosa excepto `<input type="color">` no concuerda con nada y no tiene efecto.
+> [!NOTE]
+> Usando `::-moz-color-swatch` con cualquier cosa excepto `<input type="color">` no concuerda con nada y no tiene efecto.
 
 ## Sintaxis
 

--- a/files/es/web/css/_doublecolon_-moz-range-progress/index.md
+++ b/files/es/web/css/_doublecolon_-moz-range-progress/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/::-moz-range-progress
 
 El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) [CSS](/es/docs/Web/CSS) **`::-moz-range-progress`** representa la parte del "camino" (la ranura sobre la que desliza) de un elemento {{HTMLElement("input")}} con `type="range"`, que se corresponde con los valores inferiores al valor seleccionado actualmente en ese "camino".
 
-> **Nota:** Si usamos `::-moz-range-progress` con cualquier otra cosa que no sea `<input type="range">` ni seleccionaremos nada ni conseguiremos ningún efecto.
+> [!NOTE]
+> Si usamos `::-moz-range-progress` con cualquier otra cosa que no sea `<input type="range">` ni seleccionaremos nada ni conseguiremos ningún efecto.
 
 ## Síntaxis
 

--- a/files/es/web/css/_doublecolon_-moz-range-thumb/index.md
+++ b/files/es/web/css/_doublecolon_-moz-range-thumb/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/::-moz-range-thumb
 
 El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) CSS **`::-moz-range-thumb`** representa el elemento que el usuario puede usar en el _"camino"_ marcado por un elemento {{HTMLElement("input")}} con `type="range"` para alterar su valor numérico.
 
-> **Nota:** Si se usa `::-moz-range-thumb` en cualquier elemento que no sea `<input type="range">` ni se seleccionará nada ni se conseguirá efecto alguno.
+> [!NOTE]
+> Si se usa `::-moz-range-thumb` en cualquier elemento que no sea `<input type="range">` ni se seleccionará nada ni se conseguirá efecto alguno.
 
 ## Syntax
 

--- a/files/es/web/css/_doublecolon_-moz-range-track/index.md
+++ b/files/es/web/css/_doublecolon_-moz-range-track/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/::-moz-range-track
 
 El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) CSS **`::-moz-range-track`** representa la trayectoría, es decir la ranura sobre la cual se desliza el indicador de un {{HTMLElement("input")}} con `type="range"`.
 
-> **Nota:** Si usamos `::-moz-range-track` con cualquier otra cosa que no sea un `<input type="range">` ni seleccionaremos nada ni se mostrará efecto alguno.
+> [!NOTE]
+> Si usamos `::-moz-range-track` con cualquier otra cosa que no sea un `<input type="range">` ni seleccionaremos nada ni se mostrará efecto alguno.
 
 ## Síntaxis
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-bar/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-bar/index.md
@@ -32,7 +32,8 @@ meter::-webkit-meter-bar {
 
 {{ EmbedLiveSample('Ejemplos', '100%', 50) }}
 
-> **Nota:** Sólo funciona en navegadores basados en Webkit/Blink.
+> [!NOTE]
+> Sólo funciona en navegadores basados en Webkit/Blink.
 
 ## Especificaciones
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
@@ -25,7 +25,8 @@ meter::-webkit-meter-even-less-good-value {
 
 {{ EmbedLiveSample('Ejemplos', '100%', 50) }}
 
-> **Nota:** This will only work in Webkit/Blink-based browsers.
+> [!NOTE]
+> This will only work in Webkit/Blink-based browsers.
 
 ## Especificaciones
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-inner-element/index.md
@@ -32,7 +32,8 @@ meter::-webkit-meter-inner-element {
 
 {{ EmbedLiveSample('Ejemplos', '100%', 50) }}
 
-> **Nota:** Sólo funcionará en navegadores basasdo en Webkit/Blink.
+> [!NOTE]
+> Sólo funcionará en navegadores basasdo en Webkit/Blink.
 
 ## Especificaciones
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
@@ -32,7 +32,8 @@ meter::-webkit-meter-optimum-value {
 
 {{ EmbedLiveSample('Ejemplos', '100%', 50) }}
 
-> **Nota:** Sólo funciona en navegadores basado en Webkit/Blink.
+> [!NOTE]
+> Sólo funciona en navegadores basado en Webkit/Blink.
 
 ## Especificaciones
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
@@ -25,7 +25,8 @@ meter::-webkit-meter-suboptimum-value {
 
 {{ EmbedLiveSample('Ejemplos', '100%', 50) }}
 
-> **Nota:** Sólo funciona en navegadores basados en Webkit/Blink
+> [!NOTE]
+> Sólo funciona en navegadores basados en Webkit/Blink
 
 ## Especificaciones
 

--- a/files/es/web/css/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-progress-bar/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/::-webkit-progress-bar
 
 El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) [CSS](/es/docs/Web/CSS) **`::-webkit-progress-bar`** representa la barra entera del elemento {{HTMLElement("progress")}} . Normalmente sólo está visible a partir de la porción rellena de la barra ya que, por defecto se muestra debajo del pseudo-lemento {{ cssxref("::-webkit-progress-value") }}. Es hijo del pseudo-elemento {{cssxref("::-webkit-progress-inner-element")}} y padre del pseudo-elemento {{cssxref("::-webkit-progress-value")}}.
 
-> **Nota:** para que `::-webkit-progress-value` tenga efecto , en el elemento `<progress>` {{cssxref("-webkit-appearance")}} debe tener el valor _none_.
+> [!NOTE]
+> Para que `::-webkit-progress-value` tenga efecto , en el elemento `<progress>` {{cssxref("-webkit-appearance")}} debe tener el valor _none_.
 
 ## Ejemplo
 

--- a/files/es/web/css/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-progress-inner-element/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/::-webkit-progress-inner-element
 
 El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) [CSS](/es/docs/Web/CSS) **`::-webkit-progress-inner-element`** representa la parte más exterior de un elemento {{HTMLElement("progress")}}. Es el padre del pseudo-elemento {{cssxref("::-webkit-progress-bar")}}.
 
-> **Nota:** para que `::-webkit-progress-inner-element` tenga efecto , hay que darle valor none a {{cssxref("-webkit-appearance")}} en el elemento `<progress>`.
+> [!NOTE]
+> Para que `::-webkit-progress-inner-element` tenga efecto , hay que darle valor none a {{cssxref("-webkit-appearance")}} en el elemento `<progress>`.
 
 ## Ejemplo
 

--- a/files/es/web/css/_doublecolon_-webkit-progress-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-progress-value/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/::-webkit-progress-value
 
 El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) [CSS](/es/docs/Web/CSS) **`::-webkit-progress-value`** representa la parte rellena de la barra del elemento {{HTMLElement("progress")}}. Es hija del pseudo-elemento {{cssxref("::-webkit-progress-bar")}}.
 
-> **Nota:** para que `::-webkit-progress-value` tenga efecto en el elemento \<progress> {{cssxref("-webkit-appearance")}} deberá tener _none_ como valor.
+> [!NOTE]
+> Para que `::-webkit-progress-value` tenga efecto en el elemento \<progress> {{cssxref("-webkit-appearance")}} deberá tener _none_ como valor.
 
 ## Ejemplo
 

--- a/files/es/web/css/_doublecolon_after/index.md
+++ b/files/es/web/css/_doublecolon_after/index.md
@@ -14,13 +14,15 @@ a::after {
 }
 ```
 
-> **Nota:** Los pseudo-elementos generados por `::before` y `::after` son [contenidos por la caja de formato del elemento](https://www.w3.org/TR/CSS2/generate.html#before-after-content), y por lo tanto no aplica a _[elementos reemplazados](/es/docs/Web/CSS/Replaced_element)_ como los elementos {{HTMLElement("img")}}, o {{HTMLElement("br")}}.
+> [!NOTE]
+> Los pseudo-elementos generados por `::before` y `::after` son [contenidos por la caja de formato del elemento](https://www.w3.org/TR/CSS2/generate.html#before-after-content), y por lo tanto no aplica a _[elementos reemplazados](/es/docs/Web/CSS/Replaced_element)_ como los elementos {{HTMLElement("img")}}, o {{HTMLElement("br")}}.
 
 ## Sintaxis
 
 {{CSSSyntax}}
 
-> **Nota:** CSS3 introdujo la notación `::after` (con doble dos puntos) para distinguir [pseudo-clases](/es/docs/Web/CSS/Pseudo-classes) de [pseudo-elementos](/es/docs/Web/CSS/Pseudo-elements). Los navegadores también aceptan `:after`, añadido en CSS2.
+> [!NOTE]
+> CSS3 introdujo la notación `::after` (con doble dos puntos) para distinguir [pseudo-clases](/es/docs/Web/CSS/Pseudo-classes) de [pseudo-elementos](/es/docs/Web/CSS/Pseudo-elements). Los navegadores también aceptan `:after`, añadido en CSS2.
 
 ## Ejemplos
 

--- a/files/es/web/css/_doublecolon_backdrop/index.md
+++ b/files/es/web/css/_doublecolon_backdrop/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/::backdrop
 
 Cada uno de los elementos en la pila de la [capa superior](https://fullscreen.spec.whatwg.org/#top-layer) posee un _`::backdrop`_ {{Cssxref("pseudo-elements", "pseudo-element")}}. Este pseudo-elemento es una caja que se muestra inmediatamente debajo del elemento (y sobre el elemento inmediatamente inferior de la pila, si es que hay), dentro de dicha capa superior.
 
-> **Nota:** El pseudo-elemento `::backdrop` se puede usar para crear un fondo que oculte el documento subyacente detrás de la pila de la capa superior, p.ej., para el elemento que es mostrado a pantalla complete tal y como se describe en esta especificación.
+> [!NOTE]
+> El pseudo-elemento `::backdrop` se puede usar para crear un fondo que oculte el documento subyacente detrás de la pila de la capa superior, p.ej., para el elemento que es mostrado a pantalla complete tal y como se describe en esta especificación.
 
 No se hereda ni es heredado de ningún elemento. Tampoco se hacen restricciones sobre qué propiedades se aplican a este pseudo-elemento.
 

--- a/files/es/web/css/_doublecolon_before/index.md
+++ b/files/es/web/css/_doublecolon_before/index.md
@@ -14,13 +14,15 @@ a::before {
 }
 ```
 
-> **Nota:** Los pseudoelementos generados por `::before` y `::after` son [contenidos por la caja de formato del elemento](https://www.w3.org/TR/CSS2/generate.html#before-after-content), y por lo tanto, no aplica a _[elementos de reemplazo](/es/docs/Web/CSS/Replaced_element)_ como los elementos {{htmlelement("img")}}, o {{htmlelement("br")}}.
+> [!NOTE]
+> Los pseudoelementos generados por `::before` y `::after` son [contenidos por la caja de formato del elemento](https://www.w3.org/TR/CSS2/generate.html#before-after-content), y por lo tanto, no aplica a _[elementos de reemplazo](/es/docs/Web/CSS/Replaced_element)_ como los elementos {{htmlelement("img")}}, o {{htmlelement("br")}}.
 
 ## Sintaxis
 
 {{csssyntax}}
 
-> **Nota:** CSS3 introdujo la notación `::before` (con doble dos puntos) para diferenciar [pseudo-clases](/es/docs/Web/CSS/Pseudo-classes) con [pseudo-elementos](/es/docs/Web/CSS/Pseudo-elements). Los navegadores aceptan `:before`, añadido en CSS2.
+> [!NOTE]
+> CSS3 introdujo la notación `::before` (con doble dos puntos) para diferenciar [pseudo-clases](/es/docs/Web/CSS/Pseudo-classes) con [pseudo-elementos](/es/docs/Web/CSS/Pseudo-elements). Los navegadores aceptan `:before`, añadido en CSS2.
 
 ## Ejemplos
 

--- a/files/es/web/css/_doublecolon_file-selector-button/index.md
+++ b/files/es/web/css/_doublecolon_file-selector-button/index.md
@@ -9,7 +9,8 @@ El [pseudoelemento](/es/docs/Web/CSS/Pseudo-elements) [CSS](/es/docs/Web/CSS) **
 
 {{EmbedInteractiveExample("pages/tabbed/pseudo-element-file-selector-button.html", "tabbed-shorter")}}
 
-> **Nota:** Las versiones anteriores de navegadores compatibles con WebKit/Blink como Chrome, Opera y Safari (indicados por el prefijo `-webkit`) admitían un pseudoelemento no estándar `::-webkit-file-upload-button`.
+> [!NOTE]
+> Las versiones anteriores de navegadores compatibles con WebKit/Blink como Chrome, Opera y Safari (indicados por el prefijo `-webkit`) admitían un pseudoelemento no estándar `::-webkit-file-upload-button`.
 >
 > Legacy Edge y las versiones posteriores de IE admitían un pseudoelemento no estándar `::-ms-browse`.
 >

--- a/files/es/web/css/_doublecolon_first-letter/index.md
+++ b/files/es/web/css/_doublecolon_first-letter/index.md
@@ -20,7 +20,8 @@ La primera letra de un elemento no es siempre fácil de identificar:
 - Algunos idiomas tienen dígrafos que siempre se capitalizan juntos, como el `IJ` en holandés. En estos casos, ambas letras del dígrafo deben coincidir con el pseudo-elemento `::first-letter`. (Esto pobremente implementado en los navegadores; consulte la tabla de compatibilidad).
 - La combinación del pseudoelemento {{ cssxref("::before") }} y la propiedad {{ cssxref("content") }} podría inyectar texto al inico del elemento. En dicho caso, `::first-letter` se aplicaría a la primera letra de este contenido generado.
 
-> **Nota:** CSS3 introdujo la notación`::first-letter` (con doble dos puntos) para distinguir [pseudo-clases](/es/docs/Web/CSS/Pseudo-classes) de [pseudo-elementos](/es/docs/Web/CSS/Pseudo-elements). Los navegadores también aceptan`:first-letter`, introducido en CSS2.
+> [!NOTE]
+> CSS3 introdujo la notación`::first-letter` (con doble dos puntos) para distinguir [pseudo-clases](/es/docs/Web/CSS/Pseudo-classes) de [pseudo-elementos](/es/docs/Web/CSS/Pseudo-elements). Los navegadores también aceptan`:first-letter`, introducido en CSS2.
 
 ## Propiedades permitidas
 

--- a/files/es/web/css/_doublecolon_first-line/index.md
+++ b/files/es/web/css/_doublecolon_first-line/index.md
@@ -14,7 +14,8 @@ p::first-line {
 }
 ```
 
-> **Nota:** CSS3 introdujo la notación `::first-line` (con doble dos puntos) para distinguir [pseudo-clases](/es/docs/Web/CSS/Pseudo-classes) de [pseudo-elementos](/es/docs/Web/CSS/Pseudo-elements). Los navegadores también aceptan `:first-line`, añadido en CSS2.
+> [!NOTE]
+> CSS3 introdujo la notación `::first-line` (con doble dos puntos) para distinguir [pseudo-clases](/es/docs/Web/CSS/Pseudo-classes) de [pseudo-elementos](/es/docs/Web/CSS/Pseudo-elements). Los navegadores también aceptan `:first-line`, añadido en CSS2.
 
 ## Propiedades permitidas
 

--- a/files/es/web/css/_doublecolon_marker/index.md
+++ b/files/es/web/css/_doublecolon_marker/index.md
@@ -23,7 +23,8 @@ Sólo ciertas propiedades CSS puedes utilizarse en una regla con `::marker` como
 - La propiedad {{CSSxRef("text-combine-upright")}}, {{CSSxRef("unicode-bidi")}} y {{CSSxRef("direction")}}
 - La propiedad {{CSSxRef("content")}}
 
-> **Nota:** En la especificación se indica que en el futuro de pueden admitir propiedades CSS adicionales.
+> [!NOTE]
+> En la especificación se indica que en el futuro de pueden admitir propiedades CSS adicionales.
 
 ## Sintaxis
 

--- a/files/es/web/css/_doublecolon_placeholder/index.md
+++ b/files/es/web/css/_doublecolon_placeholder/index.md
@@ -16,7 +16,8 @@ El [pseudo-elemento CSS](/es/docs/Web/CSS/Pseudo-elements) **`::placeholder`** r
 
 Solo el subconjuto de las propiedades CSS que aplican al pseudo-elemento {{cssxref("::first-line")}} puede ser usado en una regla utilizando `::placeholder` en su selector.
 
-> **Nota:** En la mayoría de navegadores, la apariencia del texto provisional es traslúcido o un color gris claro por defecto.
+> [!NOTE]
+> En la mayoría de navegadores, la apariencia del texto provisional es traslúcido o un color gris claro por defecto.
 
 ## Sintáxis
 

--- a/files/es/web/css/animation-duration/index.md
+++ b/files/es/web/css/animation-duration/index.md
@@ -33,7 +33,8 @@ animation-duration: 10s, 30s, 230ms
 - `<time>`
   - : El tiempo que tarda la animación en terminar su secuencia. Podemos especificarlo en segundos (usando `s`) o milisegundos (usando `ms`). Si no especificamos la unidad, la sentencia no será válida.
 
-> **Nota:** No acepta valores negativos, si los ponemos la sentencia se ignorará. Algunas implementaciones antiguas (con prefijos) pueden considerar los valores negativos como si fueran `0s`.
+> [!NOTE]
+> No acepta valores negativos, si los ponemos la sentencia se ignorará. Algunas implementaciones antiguas (con prefijos) pueden considerar los valores negativos como si fueran `0s`.
 
 ## Ejemplos
 

--- a/files/es/web/css/background-image/index.md
+++ b/files/es/web/css/background-image/index.md
@@ -17,7 +17,8 @@ Los [bordes](/es/docs/Web/CSS/border) del elemento se dibujan encima de ellos y 
 
 Si no se puede dibujar una imagen específica (por ejemplo, cuando no se puede cargar el archivo indicado por el URI especificado), los navegadores lo manejan como si fuera un valor `none`.
 
-> **Nota:** Incluso si las imágenes son opacas y el color no se mostrará en circunstancias normales, los desarrolladores web siempre deben especificar un {{cssxref("background-color")}}. Si las imágenes no se pueden cargar, por ejemplo, cuando la red no funciona, el color de fondo se utilizará como alternativa.
+> [!NOTE]
+> Incluso si las imágenes son opacas y el color no se mostrará en circunstancias normales, los desarrolladores web siempre deben especificar un {{cssxref("background-color")}}. Si las imágenes no se pueden cargar, por ejemplo, cuando la red no funciona, el color de fondo se utilizará como alternativa.
 
 ## Sintaxis
 

--- a/files/es/web/css/background-size/index.md
+++ b/files/es/web/css/background-size/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/background-size
 
 La propiedad CSS **`background-size`** especifica el tamaño de las imágenes de fondo.
 
-> **Nota:** Si el valor de esta propiedad no se encuentra en una propiedad abreviada {{ cssxref("background") }} esta es aplicada para los elementos después de la propiedad CSS `background-size`, el valor de esta propiedad se restablece a su valor inicial de la propiedad abreviada.
+> [!NOTE]
+> Si el valor de esta propiedad no se encuentra en una propiedad abreviada {{ cssxref("background") }} esta es aplicada para los elementos después de la propiedad CSS `background-size`, el valor de esta propiedad se restablece a su valor inicial de la propiedad abreviada.
 
 {{cssinfo}}
 
@@ -42,7 +43,8 @@ Este comportamiento ha cambiado en Gecko 8.0 (Firefox 8.0 / Thunderbird 8.0 / Se
 
 Las imágenes de fondo generados a partir de elementos con {{ cssxref("-moz-element") }} (que en realidad coincide con un elemento) se tratan actualmente como las imágenes con las dimensiones del elemento, o de la zona de posicionamiento de fondo si el elemento es SVG, con la proporción propia correspondiente.
 
-> **Nota:** El comportamiento de los `<degradados>` cambió en Gecko 8.0 (Firefox 8.0 / Thunderbird 8.0 / SeaMonkey 2.5). Anteriormente se trataban como imágenes sin dimensiones intrínsecas, pero con proporciones intrínsecas idénticas a las del área de posicionamiento del fondo.
+> [!NOTE]
+> El comportamiento de los `<degradados>` cambió en Gecko 8.0 (Firefox 8.0 / Thunderbird 8.0 / SeaMonkey 2.5). Anteriormente se trataban como imágenes sin dimensiones intrínsecas, pero con proporciones intrínsecas idénticas a las del área de posicionamiento del fondo.
 
 El tamaño representado de la imagen de fondo se calcula como sigue:
 

--- a/files/es/web/css/border-bottom-left-radius/index.md
+++ b/files/es/web/css/border-bottom-left-radius/index.md
@@ -13,7 +13,8 @@ La propiedad CSS **`border-bottom-left-radius`** establece el redondeo de la esq
 
 Un fondo, siendo una imagen o color, está limitado a los bordes, incluso a los redondeados; la posición exacta del corte será definida por el valor de la propiedad {{cssxref("background-clip")}}.
 
-> **Nota:** Si el valor de esta propiedad no se establece en una propiedad reducida {{cssxref("border-radius")}} que es aplicada al elemento después de la propiedad `border-bottom-left-radius`, el valor de esta propiedad es restaurado a su valor inicial por la [propiedad de forma reducida](/es/docs/Web/CSS/Shorthand_properties).
+> [!NOTE]
+> Si el valor de esta propiedad no se establece en una propiedad reducida {{cssxref("border-radius")}} que es aplicada al elemento después de la propiedad `border-bottom-left-radius`, el valor de esta propiedad es restaurado a su valor inicial por la [propiedad de forma reducida](/es/docs/Web/CSS/Shorthand_properties).
 
 {{cssinfo}}
 

--- a/files/es/web/css/border-bottom-right-radius/index.md
+++ b/files/es/web/css/border-bottom-right-radius/index.md
@@ -13,7 +13,8 @@ La propiedad CSS **`border-bottom-right-radius`** establece el redondeo de la es
 
 Un fondo, siendo una imagen o color, está limitado a los bordes, incluso a los redondeados; la posición exacta del corte será definida por el valor de la propiedad {{cssxref("background-clip")}}.
 
-> **Nota:** Si el valor de esta propiedad no se establece en una propiedad reducida {{cssxref("border-radius")}} que es aplicada al elemento después de la propiedad `border-bottom-right-radius`, el valor de esta propiedad es restaurado a su valor inicial por la [propiedad de forma reducida](/es/docs/Web/CSS/Shorthand_properties).
+> [!NOTE]
+> Si el valor de esta propiedad no se establece en una propiedad reducida {{cssxref("border-radius")}} que es aplicada al elemento después de la propiedad `border-bottom-right-radius`, el valor de esta propiedad es restaurado a su valor inicial por la [propiedad de forma reducida](/es/docs/Web/CSS/Shorthand_properties).
 
 {{cssinfo}}
 

--- a/files/es/web/css/border-image-outset/index.md
+++ b/files/es/web/css/border-image-outset/index.md
@@ -33,7 +33,8 @@ border-image-outset: inherit;
 
 ### Valores
 
-> **Nota:** Cuando un valor se especifica como valor {{cssxref("&lt;number&gt;")}} sin unidad, el valor es multiplicado por el {{cssxref("border-width")}} calculado correspondiente, para determinar el valor de `border-image-outset`. Los valores negativos no son permitidos.
+> [!NOTE]
+> Cuando un valor se especifica como valor {{cssxref("&lt;number&gt;")}} sin unidad, el valor es multiplicado por el {{cssxref("border-width")}} calculado correspondiente, para determinar el valor de `border-image-outset`. Los valores negativos no son permitidos.
 
 - _sides_
   - : Es un valor {{cssxref("&lt;length&gt;")}} o {{cssxref("&lt;number&gt;")}} para la cantidad en la que se extiende la imagen de borde más allá de los límites de la caja, en las cuatro direcciones.

--- a/files/es/web/css/border-top-left-radius/index.md
+++ b/files/es/web/css/border-top-left-radius/index.md
@@ -11,7 +11,8 @@ La propiedad CSS **`border-top-left-radius`** establece el redondeo de la esquin
 
 Un fondo, siendo una imagen o color, está limitado a los bordes, incluso a los redondeados; la posición exacta del corte será definida por el valor de la propiedad {{cssxref("background-clip")}}.
 
-> **Nota:** Si el valor de esta propiedad no se establece en una propiedad reducida {{cssxref("border-radius")}} que es aplicada al elemento después de la propiedad `border-top-left-radius`, el valor de esta propiedad es restaurado a su valor inicial por la [propiedad de forma reducida](/es/docs/Web/CSS/Shorthand_properties).
+> [!NOTE]
+> Si el valor de esta propiedad no se establece en una propiedad reducida {{cssxref("border-radius")}} que es aplicada al elemento después de la propiedad `border-top-left-radius`, el valor de esta propiedad es restaurado a su valor inicial por la [propiedad de forma reducida](/es/docs/Web/CSS/Shorthand_properties).
 
 {{cssinfo}}
 

--- a/files/es/web/css/border-top-right-radius/index.md
+++ b/files/es/web/css/border-top-right-radius/index.md
@@ -13,7 +13,8 @@ La propiedad CSS **`border-top-right-radius`** establece el redondeo de la esqui
 
 Un fondo, siendo una imagen o color, está limitado a los bordes, incluso a los redondeados; la posición exacta del corte será definida por el valor de la propiedad {{cssxref("background-clip")}}.
 
-> **Nota:** Si el valor de esta propiedad no se establece en una propiedad reducida {{cssxref("border-radius")}} que es aplicada al elemento después de la propiedad `border-top-radius-radius`, el valor de esta propiedad es restaurado a su valor inicial por la [propiedad de forma reducida](/es/docs/Web/CSS/Shorthand_properties).
+> [!NOTE]
+> Si el valor de esta propiedad no se establece en una propiedad reducida {{cssxref("border-radius")}} que es aplicada al elemento después de la propiedad `border-top-radius-radius`, el valor de esta propiedad es restaurado a su valor inicial por la [propiedad de forma reducida](/es/docs/Web/CSS/Shorthand_properties).
 
 {{cssinfo}}
 

--- a/files/es/web/css/border-top/index.md
+++ b/files/es/web/css/border-top/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/border-top
 
 La propiedad de [CSS](/es/docs/CSS) **`border-top`** es una abreviatura que establece los valores de {{Cssxref("border-top-color")}}, {{Cssxref("border-top-style")}}, y {{Cssxref("border-top-width")}}. Estas propiedades las características del borde superior de un elemento.
 
-> **Nota:** Los tres valores de la abreviatura pueden ser especificados en cualquier orden, y uno o dos de ellos pueden ser omitidos.
+> [!NOTE]
+> Los tres valores de la abreviatura pueden ser especificados en cualquier orden, y uno o dos de ellos pueden ser omitidos.
 >
 > Como con todas las propiedades abreviadas, border-top siempre establece los valores de todas las propiedades que sean posibles, aun si no están especificadas. Establece aquellas que no son especificadas a sus valores por defecto. Esto significa que:
 >

--- a/files/es/web/css/box-flex/index.md
+++ b/files/es/web/css/box-flex/index.md
@@ -5,7 +5,8 @@ slug: Web/CSS/box-flex
 
 {{CSSRef}}
 
-> **Advertencia:** Esta propiedad es para controlar parte del modelo de caja XUL. No coincide ni con el antiguo borrador del módulo CSS para el diseño de caja flexibles '`box-flex`' (que se basa en esta propiedad) ni con el comportamiento de '`-webkit-box-flex`' (que se basa en esos borradores).
+> [!WARNING]
+> Esta propiedad es para controlar parte del modelo de caja XUL. No coincide ni con el antiguo borrador del módulo CSS para el diseño de caja flexibles '`box-flex`' (que se basa en esta propiedad) ni con el comportamiento de '`-webkit-box-flex`' (que se basa en esos borradores).
 
 Ver [Flexbox](/es/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes) para más información acerca de qué usar en vez de esta propiedad.
 

--- a/files/es/web/css/box-ordinal-group/index.md
+++ b/files/es/web/css/box-ordinal-group/index.md
@@ -5,7 +5,8 @@ slug: Web/CSS/box-ordinal-group
 
 {{CSSRef}}
 
-> **Advertencia:** Esta propiedad pertenece al borrador original del diseño o esquema de la caja CSS flexible, y ha sido reemplazada en borradores posteriores.
+> [!WARNING]
+> Esta propiedad pertenece al borrador original del diseño o esquema de la caja CSS flexible, y ha sido reemplazada en borradores posteriores.
 
 Ver [Flexbox](/es/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes) para más información sobre qué usar en sustitución de esta propiedad.
 

--- a/files/es/web/css/box-pack/index.md
+++ b/files/es/web/css/box-pack/index.md
@@ -5,7 +5,8 @@ slug: Web/CSS/box-pack
 
 {{CSSRef}}
 
-> **Advertencia:** Esta propiedad es parte del módulo estándar original para el diseño de las cajas CSS Flexible que fue sustituida por un nuevo estándar.
+> [!WARNING]
+> Esta propiedad es parte del módulo estándar original para el diseño de las cajas CSS Flexible que fue sustituida por un nuevo estándar.
 
 Ver [Flexbox](/es/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes) para más información.
 

--- a/files/es/web/css/calc/index.md
+++ b/files/es/web/css/calc/index.md
@@ -37,9 +37,11 @@ La expresión puede ser una combinación de los siguientes operadores:
 
 Los operandos en la expresión pueden ser valores tanto positivos como negativos. Puedes usar diferentes unidades para cada valor si lo deseas. Es recomendable el uso de paréntesis para añadir legibilidad a la expresión o para forzar precedencia en las operaciones en caso necesario.
 
-> **Nota:** La división por cero dará lugar a un error generado por el analizador de HTML del navegador.
+> [!NOTE]
+> La división por cero dará lugar a un error generado por el analizador de HTML del navegador.
 
-> **Nota:** las operaciones + y - siempre deben estar separadas de sus operandos mediante espacios en blanco. La expresión `calc(50% -8px)` será tomada como un operando de porcentaje seguido de otro operando de signo negativo (una expresión inválida, dado que no hay operador en medio), mientras que la expresión `calc(50% - 8px)` es un porcentaje seguido de una operación de resta.
+> [!NOTE]
+> Las operaciones + y - siempre deben estar separadas de sus operandos mediante espacios en blanco. La expresión `calc(50% -8px)` será tomada como un operando de porcentaje seguido de otro operando de signo negativo (una expresión inválida, dado que no hay operador en medio), mientras que la expresión `calc(50% - 8px)` es un porcentaje seguido de una operación de resta.
 > Los operadores `* y` `/` no requieren espacio en blanco, pero es recomendable añadirlo por consistencia.
 
 ## Ejemplos

--- a/files/es/web/css/caret-color/index.md
+++ b/files/es/web/css/caret-color/index.md
@@ -20,7 +20,8 @@ caret-color: rgb(0, 200, 0);
 caret-color: hsla(228, 4%, 24%, 0.8);
 ```
 
-> **Nota:** Los agentes usuario podrían incluir otras cosas que consideren "cursor de texto". Por ejemplo, puede haber una "cursor para navegación", que actúa de forma similar al cursor de texto pero puede ser movido en textos no editables. Por otro lado, la imagen de cursor mostrada cuando se coloca el cursor del ratón sobre texto cuando la propiedad {{cssxref("cursor")}} es `auto`, o sobre un elemento donde la propiedad `cursor` es `text` o `vertical-text`, aunque a veces se parezca al cursor de texto, no lo es (es un cursor del ratón). En algunos navegadores que no soportan esta propiedad, el color del cursor de texto no está asociado al color de la fuente.
+> [!NOTE]
+> Los agentes usuario podrían incluir otras cosas que consideren "cursor de texto". Por ejemplo, puede haber una "cursor para navegación", que actúa de forma similar al cursor de texto pero puede ser movido en textos no editables. Por otro lado, la imagen de cursor mostrada cuando se coloca el cursor del ratón sobre texto cuando la propiedad {{cssxref("cursor")}} es `auto`, o sobre un elemento donde la propiedad `cursor` es `text` o `vertical-text`, aunque a veces se parezca al cursor de texto, no lo es (es un cursor del ratón). En algunos navegadores que no soportan esta propiedad, el color del cursor de texto no está asociado al color de la fuente.
 
 {{cssinfo}}
 
@@ -32,7 +33,8 @@ caret-color: hsla(228, 4%, 24%, 0.8);
 
   - : Los agentes usuarios deberán usar `currentcolor`, pero podrían ajustar automáticamente el color del cursor para asegurar la correcta visibilidad y contraste con el contenido alrededor, posiblemente con base en `currentcolor`, el fondo, sombras, etc.
 
-    > **Nota:** Aunque los agentes usuarios puedan usar `currentcolor` (que usualmente es animable) para el valor `auto`, `auto` no es interpolado en las transiciones/animaciones.
+    > [!NOTE]
+    > Aunque los agentes usuarios puedan usar `currentcolor` (que usualmente es animable) para el valor `auto`, `auto` no es interpolado en las transiciones/animaciones.
 
 - {{cssxref("&lt;color&gt;")}}
   - : Color del cursor de texto.

--- a/files/es/web/css/clear/index.md
+++ b/files/es/web/css/clear/index.md
@@ -13,7 +13,8 @@ Cuando se aplica a elementos flotantes, mueve el [margin edge](/es/docs/CSS/box_
 
 Los floats que son relevantes para ser limpiados (cleared) son los primeros floats dentro del mismo [contexto de formato de bloque](/es/docs/Web/Guide/CSS/Block_formatting_context).
 
-> **Nota:** Si deseas que un elemento contenga todos los elementos flotantes dentro, puedes hacer dos cosas, o bien flotar el contenedor también o usar `clear` en un [pseudo-element](/es/docs/Web/CSS/Pseudo-elements) {{cssxref("::after")}}.
+> [!NOTE]
+> Si deseas que un elemento contenga todos los elementos flotantes dentro, puedes hacer dos cosas, o bien flotar el contenedor también o usar `clear` en un [pseudo-element](/es/docs/Web/CSS/Pseudo-elements) {{cssxref("::after")}}.
 >
 > ```css
 > #container::after {
@@ -59,7 +60,8 @@ clear: inherit;
 
 ## Ejemplo
 
-> **Nota:** El div con clase 'wrapper' añade un borde para una mejor visibilidad de la utilidad de la propiedad clear
+> [!NOTE]
+> El div con clase 'wrapper' añade un borde para una mejor visibilidad de la utilidad de la propiedad clear
 
 ### clear: left
 

--- a/files/es/web/css/clip/index.md
+++ b/files/es/web/css/clip/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/clip
 
 La propiedad de CSS `clip` define qué porción de un elemento es visible. La propiedad `clip` se aplica solamente sobre elementos con {{ cssxref("position","position:absolute") }} o {{cssxref("position", "position:fixed")}}.
 
-> **Advertencia:** This property is deprecated. Use {{cssxref("clip-path")}} instead.
+> [!WARNING]
+> This property is deprecated. Use {{cssxref("clip-path")}} instead.
 
 {{cssinfo}}
 

--- a/files/es/web/css/color_value/index.md
+++ b/files/es/web/css/color_value/index.md
@@ -19,7 +19,8 @@ Asociado con el color en el espacio sRGB, un valor `<color>` también consiste e
 
 Aunque los valores de colores en CSS son definidos de manera precisa existe la posibilidad de que parezcan distintos en dispositivos diferentes. La mayoría de ellos no están calibrados y algunos navegadores no soportan los [color profile](http://en.wikipedia.org/wiki/ICC_profile) de algunos dispositivos de salidas. En esta situación el color puede variar bastante.
 
-> **Nota:** La recomendación [WCAG 2.0](http://www.w3.org/TR/WCAG/#visual-audio-contrast) de la W3C aconseja a los autores web de manera clara que no usen _color_ como el único medido para especificar una información, acción o resultado concreto. Algunos usuarios tienen problemas para diferenciar colores y existe la posibilidad de que la información transmitida no sea captada. Por supuesto esto no impide que se use el color, sólo su uso como único medio para describir alguna información.
+> [!NOTE]
+> La recomendación [WCAG 2.0](http://www.w3.org/TR/WCAG/#visual-audio-contrast) de la W3C aconseja a los autores web de manera clara que no usen _color_ como el único medido para especificar una información, acción o resultado concreto. Algunos usuarios tienen problemas para diferenciar colores y existe la posibilidad de que la información transmitida no sea captada. Por supuesto esto no impide que se use el color, sólo su uso como único medio para describir alguna información.
 
 ## Interpolación
 
@@ -954,7 +955,7 @@ El color `rebeccapurple` es equivalente al color `#639`, y se puede encontrar in
 
 La palaba `transparent` representa un color totalmente transparente, es decir, el color que veremos será el colore de fondo. Técnicamente es un color negro con un valor mínimo en el canal alfa y la manera de representarlo es `rgba(0,0,0,0)`.
 
-> **Nota:**
+> [!NOTE]
 > La palabra clave `transparent` no fue un color en CSS hasta CSS Nivel 2 (Revisión 1). Podía ser usada en lugar de un valor \<color> regular en dos propiedades CSS: {{Cssxref("background")}} y {{Cssxref("border")}}. En esencia fue añadida para permitir sobreescribir valores sólidos heredados.
 >
 > Con el soporte de la opacidad que nos proporcionan los [alpha channels](http://en.wikipedia.org/wiki/Alpha_compositing), `transparent` fue redefinido como un color verdadero más en CSS Nivel 3 permitiendo su use en cualquier sitio donde de requiera un valor `<color>` , como la propiedad {{Cssxref("color")}}.

--- a/files/es/web/css/css_animations/using_css_animations/index.md
+++ b/files/es/web/css/css_animations/using_css_animations/index.md
@@ -46,7 +46,8 @@ Además puedes, opcionalmente, incluir fotogramas que describan pasos intermedio
 
 ## Ejemplos
 
-> **Nota:** Los siguientes ejemplos no usan ningún prefijo en las propiedades CSS de animación. Los navegadores antiguos pueden necesitarlos. Al hacer click en "Ver el ejemplo vivo" se incluye el prefijo `-webkit`.
+> [!NOTE]
+> Los siguientes ejemplos no usan ningún prefijo en las propiedades CSS de animación. Los navegadores antiguos pueden necesitarlos. Al hacer click en "Ver el ejemplo vivo" se incluye el prefijo `-webkit`.
 
 ### Haciendo que un texto se delice por la ventana del navegador
 
@@ -232,7 +233,8 @@ p {
 }
 ```
 
-> **Nota:** Puedes encontrar más detalles en la página de referencia {{cssxref("animation")}}
+> [!NOTE]
+> Puedes encontrar más detalles en la página de referencia {{cssxref("animation")}}
 
 ### Estableciendo multiples valores de propiedades animation
 


### PR DESCRIPTION
This PR converts the noteblocks for the Spanish locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 5. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
