### PR TITLE
es: Convert noteblocks to GFM Alerts (part 7)

### DIFF
--- a/files/es/web/html/element/input/text/index.md
+++ b/files/es/web/html/element/input/text/index.md
@@ -106,7 +106,8 @@ El atributo `pattern`, cuando se especifica, es una expresión regular que el [`
 
 Si el patrón especificado no se especifica o no es válido, no se aplica ninguna expresión regular y este atributo se ignora por completo.
 
-> **Nota:** Utiliza el atributo [`title`](/es/docs/Web/HTML/Element/input#title) para especificar el texto que la mayoría de los navegadores mostrarán como información sobre herramientas para explicar cuáles son los requisitos para coincidir con el patrón. También debes incluir otro texto explicativo cercano.
+> [!NOTE]
+> Utiliza el atributo [`title`](/es/docs/Web/HTML/Element/input#title) para especificar el texto que la mayoría de los navegadores mostrarán como información sobre herramientas para explicar cuáles son los requisitos para coincidir con el patrón. También debes incluir otro texto explicativo cercano.
 
 Consulta [Especificación de un patrón](#especificación_de_un_patrón) para obtener más detalles y un ejemplo.
 
@@ -116,13 +117,15 @@ El atributo `placeholder` es una cadena que proporciona una breve pista al usuar
 
 Si el contenido del control tiene una direccionalidad ({{Glossary("LTR")}} o {{Glossary("RTL")}}) pero necesitas presentar el marcador de posición en la direccionalidad opuesta, puedes usar caracteres de formato de algoritmo bidireccional Unicode para anular la direccionalidad dentro del marcador de posición; consulta [Anulación de BiDi mediante caracteres de control Unicode](/es/docs/Web/Localization/Unicode_Bidirectional_Text_Algorithm#anulación_de_bidi_mediante_caracteres_de_control_unicode) para esos caracteres.
 
-> **Nota:** Evita utilizar el atributo `placeholder` si puedes. No es tan útil semánticamente como otras formas de explicar tu formulario y puede causar problemas técnicos inesperados con tu contenido. Consulta [Etiquetas y marcadores de posición](/es/docs/Web/HTML/Element/input#etiquetas_y_marcadores_de_posición) para obtener más información.
+> [!NOTE]
+> Evita utilizar el atributo `placeholder` si puedes. No es tan útil semánticamente como otras formas de explicar tu formulario y puede causar problemas técnicos inesperados con tu contenido. Consulta [Etiquetas y marcadores de posición](/es/docs/Web/HTML/Element/input#etiquetas_y_marcadores_de_posición) para obtener más información.
 
 ### `readonly`
 
 Un atributo booleano que, si está presente, significa que el usuario no puede editar este campo. Su `value`, sin embargo, aún se puede cambiar mediante el código JavaScript configurando directamente la propiedad {{DOMxRef("HTMLInputElement.value")}}.
 
-> **Nota:** Debido a que un campo de solo lectura no puede tener un valor, `required` no tiene ningún efecto en las entradas con el atributo `readonly` también especificado.
+> [!NOTE]
+> Debido a que un campo de solo lectura no puede tener un valor, `required` no tiene ningún efecto en las entradas con el atributo `readonly` también especificado.
 
 ### `size`
 
@@ -167,7 +170,8 @@ Una extensión de Safari, el atributo `autocorrect` es una cadena que indica si 
 
 Una extensión de Mozilla, compatible con Firefox para Android, que proporciona una pista sobre qué tipo de acción se realizará si el usuario presiona la tecla <kbd>Intro</kbd> o <kbd>Retorno</kbd> mientras edita el campo. Esta información se usa para decidir qué tipo de etiqueta usar en la tecla <kbd>Intro</kbd> del teclado virtual.
 
-> **Nota:** Este [se ha estandarizado](https://html.spec.whatwg.org/#input-modalities:-the-enterkeyhint-attribute) como el atributo global [`enterkeyhint`](/es/docs/Web/HTML/Global_attributes#enterkeyhint), pero aún no está ampliamente implementado. Para ver el estado del cambio que se está implementando en Firefox, consulta [Error 1490661 en Firefox](https://bugzil.la/1490661).
+> [!NOTE]
+> Este [se ha estandarizado](https://html.spec.whatwg.org/#input-modalities:-the-enterkeyhint-attribute) como el atributo global [`enterkeyhint`](/es/docs/Web/HTML/Global_attributes#enterkeyhint), pero aún no está ampliamente implementado. Para ver el estado del cambio que se está implementando en Firefox, consulta [Error 1490661 en Firefox](https://bugzil.la/1490661).
 
 Los valores permitidos son: `go`, `done`, `next`, `search` y `send`. El navegador decide, utilizando esta sugerencia, qué etiqueta poner en la tecla Intro.
 
@@ -248,7 +252,8 @@ El tamaño físico del cuadro de entrada se puede controlar mediante el atributo
 
 Los elementos {{HTMLElement("input")}} de tipo `text` no tienen validación automática aplicada (ya que una entrada de texto básica debe ser capaz de aceptar cualquier cadena arbitraria), pero hay algunas opciones de validación de lado del cliente disponibles, que verás a continuación.
 
-> **Nota:** La validación del formulario HTML _no_ sustituye a la de los scripts del servidor que garantizan que los datos introducidos tengan el formato adecuado. Es demasiado fácil para alguien realizar ajustes en el HTML que le permitan omitir la validación o eliminarla por completo. También es posible que alguien simplemente omita tu HTML por completo y envíe los datos directamente a tu servidor. Si tu código del lado del servidor no valida los datos que recibe, podría ocurrir un desastre cuando se ingresen en tu base de datos datos con formato incorrecto (o datos que son demasiado grandes, son del tipo incorrecto, etc.).
+> [!NOTE]
+> La validación del formulario HTML _no_ sustituye a la de los scripts del servidor que garantizan que los datos introducidos tengan el formato adecuado. Es demasiado fácil para alguien realizar ajustes en el HTML que le permitan omitir la validación o eliminarla por completo. También es posible que alguien simplemente omita tu HTML por completo y envíe los datos directamente a tu servidor. Si tu código del lado del servidor no valida los datos que recibe, podría ocurrir un desastre cuando se ingresen en tu base de datos datos con formato incorrecto (o datos que son demasiado grandes, son del tipo incorrecto, etc.).
 
 ### Una nota sobre estilizado
 
@@ -375,7 +380,8 @@ Esto se renderiza así:
 
 Si intentas enviar el formulario con menos de 4 caracteres, se te dará un mensaje de error apropiado (que difiere entre los navegadores). Si intentas ingresar más de 8 caracteres, el navegador no te lo permitirá.
 
-> **Nota:** Si especificas un `minlength` pero no especificas `required`, la entrada se considera válida, ya que no se requiere que el usuario especifique un valor.
+> [!NOTE]
+> Si especificas un `minlength` pero no especificas `required`, la entrada se considera válida, ya que no se requiere que el usuario especifique un valor.
 
 ### Especificación de un patrón
 

--- a/files/es/web/html/element/label/index.md
+++ b/files/es/web/html/element/label/index.md
@@ -23,7 +23,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
   - : El ID del elemento de formulario etiquetable relacionado en el mismo documento que el elemento label. El primer elemento en el documento con tal ID que coincida con el dispuesto en el atributo for será el control etiquetado para este elemento.
 
-    > **Nota:** Un elemento label puede contener ambos; El atributo for y el elemento de control anidado, siempre y cuando el atributo for apunte al mismo elemento.
+    > [!NOTE]
+    > Un elemento label puede contener ambos; El atributo for y el elemento de control anidado, siempre y cuando el atributo for apunte al mismo elemento.
 
 - `form`
   - : El formulario con el cual el label está asociado (su formulario dueño). El valor de este atributo debe ser un ID del elemento {{HTMLElement("form")}} en el mismo documento. Si este atributo no es especificado, este elemento `<label>` deberia ser descendiente de un elemento {{HTMLElement("form")}}. Este atributo permite ubicar el elemento label en cualquier lugar dentro del documento y no solo como descendiente de su respectivo formulario.

--- a/files/es/web/html/element/link/index.md
+++ b/files/es/web/html/element/link/index.md
@@ -7,7 +7,8 @@ slug: Web/HTML/Element/link
 
 El **elemento HTML `<link>`** especifica la relación entre el documento actual y un recurso externo. Los usos posibles de este elemento incluyen la definición de un marco relacional para navegación. Este elemento es más frecuentemente usado para enlazar hojas de estilos.
 
-> **Nota:** El atributo [`rel`](/es/docs/Web/HTML/Element/link#rel) puede ser establecido con muchos valores diferentes. Estos se encuentran [listados](/es/docs/Web/HTML/Tipos_de_enlaces) en una página separada.
+> [!NOTE]
+> El atributo [`rel`](/es/docs/Web/HTML/Element/link#rel) puede ser establecido con muchos valores diferentes. Estos se encuentran [listados](/es/docs/Web/HTML/Tipos_de_enlaces) en una página separada.
 
 | [Categorías de contenido](/es/docs/Web/Guide/HTML/categorias_de_contenido) | Contenido en metadatos. Si [`itemprop`](/es/docs/Web/HTML/Element/link#itemprop) está presente: [contenido dinámico](/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_dinámico) y [contenido textual o estático](/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_textual_o_estático) |
 | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -22,7 +23,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
 - `charset`{{deprecated_inline}}
   - : Este atributo define la codificación de caracteres del recurso enlazado. El valor es un espacio y/o una lista de grupos de caracteres según se define en {{rfc(2045)}}, separados por coma. El valor predeterminado es `iso-8859-1`.
-    > **Nota:** Este atributo es obsoleto y **no debe ser usado por autores**. Para conseguir su mismo efecto, se recomienda usar el encabezado HTTP Content-Type en el recurso enlazado.
+    > [!NOTE]
+    > Este atributo es obsoleto y **no debe ser usado por autores**. Para conseguir su mismo efecto, se recomienda usar el encabezado HTTP Content-Type en el recurso enlazado.
 - `crossorigin`
   - : Este atributo enumerado indica si se debe usar CORS cuando se solicite una imagen relacionada. Las [imágenes con CORS habilitado](/es/docs/Web/HTML/Imagen_con_CORS_habilitado) pueden ser reutilizadas en el elemento {{HTMLElement("canvas")}} sin que estén _corruptas_.Los valores permitidos son:_ `"anonymous"`
     _ : Una solicitud a un origen cruzado (esto es, con el encabezado HTTP `Origin:`) es realizada, pero no se envían credenciales (es decir, no se envían cookies, ni certificado X.509, ni datos de autenticación básica HTTP). Si el servidor no otorga credenciales al sitio de origen (por no enviar el encabezado HTTP `Access-Control-Allow-Origin:`) la imagen estará _corrupta_, y su uso estará restringido.
@@ -31,7 +33,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 - `disabled` {{Non-standard_inline}}
 
   - : Este atributo es usado para deshabilitar una relación de enlace. Agregando programación, este atributo puede ser usado para habilitar o deshabilitar la relación con distintas hojas de estilos.
-    > **Nota:** Aunque no hay atributo `disabled` en el estándar de HTML, **sí** hay un atributo `disabled` en el objeto DOM `HTMLLinkElement`.El uso de `disabled` como atributo HTML no es estándar, y solo puede ser usado en algunos navegadores ([W3 #27677](https://www.w3.org/Bugs/Public/show_bug.cgi?id=27677)). **No debe usarse**. Para lograr un efecto similar, se puede usar una de las siguientes técnicas:
+    > [!NOTE]
+    > Aunque no hay atributo `disabled` en el estándar de HTML, **sí** hay un atributo `disabled` en el objeto DOM `HTMLLinkElement`.El uso de `disabled` como atributo HTML no es estándar, y solo puede ser usado en algunos navegadores ([W3 #27677](https://www.w3.org/Bugs/Public/show_bug.cgi?id=27677)). **No debe usarse**. Para lograr un efecto similar, se puede usar una de las siguientes técnicas:
     >
     > - Si el atributo `disabled` fue añadido directamente al elemento en la página, no incluya el elemento {{HTMLElement("link")}} en vez de eso;
     > - Establezca la **propiedad** `disabled` del objeto DOM `StyleSheet` vía programación.
@@ -45,7 +48,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 - `media`
 
   - : Este atributo especifica el tipo de medio al que aplica el recurso enlazado. Su valor debe ser un [media query](/es/docs/CSS/Media_queries). Este atributo es usado principalmente cuando se enlaza a una hoja de esetilos externa en la que se le permita al agenete usuario seleccionar la que mejor se adapte al dispositivo sobre el que se ejecuta.
-    > **Nota:**
+    > [!NOTE]
     >
     > - En HTML 4, esto puede ser solamente una lista simple de literales de medios separadas por espacio, es decir, [tipos de medios y grupos](/es/docs/Web/CSS/@media), donde se definían valores para este atributo, tales como `print`, `screen`, `aural`, `braille`. HTML5 extiende esto a cualquier clase de [media queries](/es/docs/CSS/Media_queries), los cuales son un superconjunto de los valores permitidos de HTML 4.
     > - Los navegadores que no soporten los [Media Queries de CSS3](/es/docs/CSS/Media_queries) no necesariamente reconocerán el enlace adecuado; no olvide establecer enlaces de _fallback_, usando los conjuntos de media queriese definidos en HTML 4.
@@ -62,13 +65,14 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
   - : Este atributo indica la relación del documento enlazado con el actual. El atributo debe ser una lista de [tipos de enlaces](/es/docs/Web/HTML/Tipos_de_enlaces) separados por espacio. El uso más común para este atributo es especificar el enlace a una hoja de estilos externa: el atributo **rel** se establece con valor `stylesheet`, y el atributo **href** se establece con la URL de la hoja de estilos externa para dar formato a la página. WebTV también soporta el uso del valor `next` en **rel** para precargar la siguiente página en una serie de documentos.
 - `rev`{{deprecated_inline}}
   - : El valor de este atributo muestra la relación del documento actual al documento enlazado, como se define en el atributo [`href`](/es/docs/Web/HTML/Element/link#href). En consecuencia, este atributo define la relación inversa, en comparación al valor del atributo **rel**. Los [tipos de enlace](/es/docs/Web/HTML/Tipos_de_enlaces) para este atributo son similares a los disponibles para [`rel`](/es/docs/Web/HTML/Element/link#rel).
-    > **Nota:** Este atributo es obsoleto en HTML5. **No debe usarse**. Para lograr este efecto, use el atributo [`rel`](/es/docs/Web/HTML/Element/link#rel) con el [tipo de enlace](/es/docs/Web/HTML/Tipos_de_enlaces) contrario, por ejemplo, made debe reemplazar a author. Además, este atributo no significa _revision_ y no debe ser usado con un número de versión, que es desafortunadamente el caso de muchos sitios.
+    > [!NOTE]
+    > Este atributo es obsoleto en HTML5. **No debe usarse**. Para lograr este efecto, use el atributo [`rel`](/es/docs/Web/HTML/Element/link#rel) con el [tipo de enlace](/es/docs/Web/HTML/Tipos_de_enlaces) contrario, por ejemplo, made debe reemplazar a author. Además, este atributo no significa _revision_ y no debe ser usado con un número de versión, que es desafortunadamente el caso de muchos sitios.
 - `sizes`
 
   - : Este atributo define los tamaños de los íconos para medios visuales contenidos en el recurso. Debe estar presente solo si el atributo [`rel`](/es/docs/Web/HTML/Element/link#rel) contiene el [tipo de enlace](/es/docs/Web/HTML/Tipos_de_enlaces) icon. Puede tener los siguientes valores:
     - `any`, significa que el ícono puede ser escalado a cualquier tamaño, ya que está en un formato vectorial, como `image/svg+xml`.
     - una lista de tamaños separados por espacios en blanco, cada uno en formato `<anchura en píxeles>` x `<altura en píxeles>` or `<anchura en píxeles>` X `<altura en píxeles>`. Cada uno de estos tamaños debe estar contenido en el recurso.
-      > **Nota:**
+      > [!NOTE]
       >
       > - La mayoría de los formatos de ícono solo permiten almacenar un ícono; por lo que la mayoría de las ocasiones, el atributo [`sizes`](/es/docs/Web/HTML/Global_attributes#sizes) contiene solamente una entrada. El formato ICO de Microsoft lo hace, así como el formato ICN de Apple. Siendo ICO más común, es el que se recomienda usar.
       > - iOS de Apple no soporta este atributo, por lo que iPhone y iPad de Apple usan [tipos de enlaces](/es/docs/Web/HTML/Tipos_de_enlaces) especiales, no estándares, para definir los íconos a usar como Web Clip o contenedor de inicio: apple-touch-icon y apple-touch-startup-icon.
@@ -124,7 +128,8 @@ Se puede determinar cuando una hoja de estilos fue cargada estableciendo la ejec
   onerror="sheetError()" />
 ```
 
-> **Nota:** El evento `load` se dispara una vez que la hoja de estilos y todo su contenido importado ha sido cargado y procesado, e inmediatamente antes de que los estilos sean aplicados al contenido.
+> [!NOTE]
+> El evento `load` se dispara una vez que la hoja de estilos y todo su contenido importado ha sido cargado y procesado, e inmediatamente antes de que los estilos sean aplicados al contenido.
 
 ## Notas
 

--- a/files/es/web/html/element/map/index.md
+++ b/files/es/web/html/element/map/index.md
@@ -115,6 +115,7 @@ slug: Web/HTML/Element/map
 
 secciones futuras: == Soporte de los navegadores == == Valores por defecto y visualización en Firefox ==
 
-> **Nota:** Este documento está siendo editado, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
+> [!NOTE]
+> Este documento está siendo editado, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
 >
 > ¿Quieres participar en la elaboración de este documento? Para saber como hacerlo consulta MDC:Como ayudar.

--- a/files/es/web/html/element/mark/index.md
+++ b/files/es/web/html/element/mark/index.md
@@ -72,7 +72,8 @@ Este elemento no tiene atributos que no sean los [atributos globales](/es/docs/W
 - Por otro lado, `<mark>` indica una parte del contenido del documento que probablemente sea relevante para el usuario. Por ejemplo, se puede utilizar en una página que muestra los resultados de búsqueda para resaltar cada uno de estos por palabra.
 - No uses el elemento `<mark>` para resaltado de sintaxis; usa el elemento {{ HTMLElement("span") }} para este fin.
 
-> **Nota:** No se debe confundir el elemento `<mark>` con el elemento {{ HTMLElement("strong") }}. El elemento {{ HTMLElement("strong") }} se utiliza para denotar intervalos de texto de especial _importancia,_ mientras que el elemento `<mark>` se utiliza para denotar intervalos de texto de especial _relevancia._
+> [!NOTE]
+> No se debe confundir el elemento `<mark>` con el elemento {{ HTMLElement("strong") }}. El elemento {{ HTMLElement("strong") }} se utiliza para denotar intervalos de texto de especial _importancia,_ mientras que el elemento `<mark>` se utiliza para denotar intervalos de texto de especial _relevancia._
 
 ## Ejemplos
 

--- a/files/es/web/html/element/menu/index.md
+++ b/files/es/web/html/element/menu/index.md
@@ -19,7 +19,8 @@ Este elemento solo incluye los [atributos globales](/es/docs/Web/HTML/Global_att
 
 Los elementos `<menu>` y {{HTMLElement("ul")}} representan una lista desordenada de elementos. La diferencia clave es que {{HTMLElement("ul")}} contiene principalmente elementos para mostrar, mientras que `<menu>` estaba destinado a elementos interactivos. El elemento {{HTMLElement("menuitem")}} relacionado ha quedado obsoleto.
 
-> **Nota:** En las primeras versiones de la especificación HTML, el elemento `<menu>` tenía un caso de uso adicional como menú contextual. Esta funcionalidad se considera obsoleta y no está en la especificación.
+> [!NOTE]
+> En las primeras versiones de la especificación HTML, el elemento `<menu>` tenía un caso de uso adicional como menú contextual. Esta funcionalidad se considera obsoleta y no está en la especificación.
 
 ## Ejemplo
 

--- a/files/es/web/html/element/meta/index.md
+++ b/files/es/web/html/element/meta/index.md
@@ -190,7 +190,8 @@ Puede consultar esta [comparativa](http://www.webdevout.net/browser_support_html
 
 ---
 
-> **Nota:** Estamos ampliando este documento, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
+> [!NOTE]
+> Estamos ampliando este documento, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
 >
 > ¿Quieres participar en su elaboración? Para saber cómo hacerlo consulta MDC:Como ayudar.
 

--- a/files/es/web/html/element/noframes/index.md
+++ b/files/es/web/html/element/noframes/index.md
@@ -229,7 +229,8 @@ Puede consultar esta [comparativa](http://www.webdevout.net/browser_support_html
 
 ---
 
-> **Nota:** Estamos ampliando este documento, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
+> [!NOTE]
+> Estamos ampliando este documento, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
 >
 > ¿Quieres participar en su elaboración? Para saber cómo hacerlo consulta MDC:Como ayudar.
 

--- a/files/es/web/html/element/noscript/index.md
+++ b/files/es/web/html/element/noscript/index.md
@@ -221,7 +221,8 @@ Puede consultar esta [comparativa](http://www.webdevout.net/browser_support_html
 
 ---
 
-> **Nota:** Estamos ampliando este documento, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
+> [!NOTE]
+> Estamos ampliando este documento, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
 >
 > ¿Quieres participar en su elaboración? Para saber cómo hacerlo consulta MDC:Como ayudar.
 

--- a/files/es/web/html/element/option/index.md
+++ b/files/es/web/html/element/option/index.md
@@ -22,7 +22,8 @@ Este elemento posee los [atributos globales](/es/docs/Web/HTML/Global_attributes
   - : Si está establecido el elemento no se puede seleccionar. A menudo los navegadores ponen en gris el elemento y de esa manera no recibirá ningún evento de navegación como clicks de ratón o eventos relacionados con la obtención del foco. Si este atributo no está definido el elemento puede ser aún deshabilitado si uno de sus ancestros es un elemento {{HTMLElement("optgroup")}} deshabilitado.
 - `label`
   - : Este atributo es el texto para la etiqueta que determina el significado de la opción. Si el atributo **`label`** no está definidio su valor será el texto del contenido del elemento
-    > **Nota:** El atributo **label** está diseñado para contener una etiqueta corta que se usará típicamente en un menú jerárquico. El **`atributo value`** describe una etiqueta más larga para ser usada, por ejemplo, cerca de un radio button
+    > [!NOTE]
+    > El atributo **label** está diseñado para contener una etiqueta corta que se usará típicamente en un menú jerárquico. El **`atributo value`** describe una etiqueta más larga para ser usada, por ejemplo, cerca de un radio button
 - `selected`
   - : Si está presente, este atributo booleano indica si esta opción es la inicialmente seleccionada. Si el elemento `<option>` es descendiente de un elemento {{HTMLElement("select")}} cuyo atributo [`multiple`](/es/docs/Web/HTML/Element/select#multiple) no esté definidio únicamente un sólo `<option>` de este elemento {{HTMLElement("select")}} puede tener este atributo **selected** attribute.
 - `value`

--- a/files/es/web/html/element/p/index.md
+++ b/files/es/web/html/element/p/index.md
@@ -113,7 +113,8 @@ párrafo
 
 - [En la especificación del estándar](http://html.conclase.net/w3c/html401-es/struct/text.html#edef-P)
 
-> **Nota:** ¡Estamos en obras!... disculpen las molestias.
+> [!NOTE]
+> ¡Estamos en obras!... disculpen las molestias.
 > Este documento está siendo editado, posiblemente contenga carencias y defectos.
 >
 > ¿Quieres participar en la elaboración de este documento? Para más información sobre como ayudar o como empezar a hacerlo, consulta MDC:Como ayudar.

--- a/files/es/web/html/element/q/index.md
+++ b/files/es/web/html/element/q/index.md
@@ -68,7 +68,8 @@ La fuente de este ejemplo interactivo se almacena en un repositorio de GitHub. S
   </tbody>
 </table>
 
-> **Nota:** La mayoría de los navegadores modernos automáticamente agregarán comillas alrededor del texto dentro de un elemento `<q>`. Es posible que se necesite una regla de estilo para agregar comillas en navegadores antiguos.
+> [!NOTE]
+> La mayoría de los navegadores modernos automáticamente agregarán comillas alrededor del texto dentro de un elemento `<q>`. Es posible que se necesite una regla de estilo para agregar comillas en navegadores antiguos.
 
 ## Atributos
 

--- a/files/es/web/html/element/s/index.md
+++ b/files/es/web/html/element/s/index.md
@@ -107,4 +107,5 @@ slug: Web/HTML/Element/s
 
 ### Comentarios
 
-> **Advertencia:** DESAPROBADO
+> [!WARNING]
+> DESAPROBADO

--- a/files/es/web/html/element/select/index.md
+++ b/files/es/web/html/element/select/index.md
@@ -34,7 +34,8 @@ Este elemento incluye [global attributes](/es/docs/Web/HTML/Global_attributes).
 - `size`
   - : Si el control se presenta como una lista con scroll en caja, este atributo representa el numero de filas que la list tendrá visible la primera vez. Los navegadores no están requeridos a presentar un elemento select como una lista con escroll en caja. El valor por defecto es cero.
 
-> **Nota:** De acuerdo con las especificaciones de HTML5, el tamaño por defecto debe ser 1; sin embargo, en la práctica, esto hace que se rompan algunas páginas webs, y ningun otro navegador actualmente hace esto, así que Mozilla ha optado por continuar usando 0 desde que empezó con Firefox.
+> [!NOTE]
+> De acuerdo con las especificaciones de HTML5, el tamaño por defecto debe ser 1; sin embargo, en la práctica, esto hace que se rompan algunas páginas webs, y ningun otro navegador actualmente hace esto, así que Mozilla ha optado por continuar usando 0 desde que empezó con Firefox.
 
 ## DOM Interface
 

--- a/files/es/web/html/element/slot/index.md
+++ b/files/es/web/html/element/slot/index.md
@@ -132,7 +132,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 </template>
 ```
 
-> **Nota:** Puedes ver este ejemplo en accion en [element-details](https://github.com/mdn/web-components-examples/tree/master/element-details) (velo [running live](https://mdn.github.io/web-components-examples/element-details/)). Además, puedes encontrar una explicación en [Using templates and slots](/es/docs/Web/Web_Components/Using_templates_and_slots).
+> [!NOTE]
+> Puedes ver este ejemplo en accion en [element-details](https://github.com/mdn/web-components-examples/tree/master/element-details) (velo [running live](https://mdn.github.io/web-components-examples/element-details/)). Además, puedes encontrar una explicación en [Using templates and slots](/es/docs/Web/Web_Components/Using_templates_and_slots).
 
 ## Especificaciones
 

--- a/files/es/web/html/element/span/index.md
+++ b/files/es/web/html/element/span/index.md
@@ -256,7 +256,8 @@ Puede consultar esta [comparativa](http://www.webdevout.net/browser_support_html
 
 ---
 
-> **Nota:** Estamos ampliando este documento, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
+> [!NOTE]
+> Estamos ampliando este documento, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
 >
 > ¿Quieres participar en su elaboración? Para saber cómo hacerlo consulta MDC:Como ayudar.
 

--- a/files/es/web/html/element/strike/index.md
+++ b/files/es/web/html/element/strike/index.md
@@ -42,6 +42,7 @@ slug: Web/HTML/Element/strike
 
 ### Comentarios
 
-> **Advertencia:** DESAPROBADO
+> [!WARNING]
+> DESAPROBADO
 
 de momento no funciona

--- a/files/es/web/html/element/style/index.md
+++ b/files/es/web/html/element/style/index.md
@@ -182,7 +182,8 @@ Puede consultar esta [comparativa](http://www.webdevout.net/browser_support_html
 
 ---
 
-> **Nota:** Estamos ampliando este documento, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
+> [!NOTE]
+> Estamos ampliando este documento, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
 >
 > ¿Quieres participar en su elaboración? Para saber cómo hacerlo consulta MDC:Como ayudar.
 

--- a/files/es/web/html/element/table/index.md
+++ b/files/es/web/html/element/table/index.md
@@ -9,7 +9,8 @@ slug: Web/HTML/Element/table
 
 El _Elemento de Tabla HTML_ (`<table>`) representa datos en dos o mas dimensiones.
 
-> **Nota:** Antes de la creación de [CSS](/es/docs/CSS), los elementos HTML {{HTMLElement("table")}} eran frecuentemente utilizados para la disposición (posicionamiento) de una página. Este uso ha sido desalentado desde HTML 4, y el elemento no debe ser usado para dichos fines.
+> [!NOTE]
+> Antes de la creación de [CSS](/es/docs/CSS), los elementos HTML {{HTMLElement("table")}} eran frecuentemente utilizados para la disposición (posicionamiento) de una página. Este uso ha sido desalentado desde HTML 4, y el elemento no debe ser usado para dichos fines.
 
 ## Contexto de uso
 
@@ -77,7 +78,7 @@ Al igual que otros elementos HTML, este elemento también soporta [atributos glo
     - center, significa que la tabla será mostrada al centro del documento;
     - right, significa que la tabla será mostrada a la derecha del documento.
 
-    > **Nota:**
+    > [!NOTE]
     >
     > - **No usar este atributo**, ya que ha sido declarado obsoleto: el elemento {{HTMLElement("table")}} debe ser estilizado usando [CSS](/es/docs/CSS). A fin de dar un efecto similar al atributo align, las propiedades {{cssxref("text-align")}} y {{cssxref("vertical-align")}} deben ser usadas.
     > - Antes de la version 4 de Firefox, este ya soportaba sólo en el modo quirks (compatibilidad con navegadores antiguos) los valores `middle`, `absmiddle`, and `abscenter` como sinónimos de `center`_._
@@ -98,7 +99,8 @@ Al igual que otros elementos HTML, este elemento también soporta [atributos glo
     |     | purple (púrpura) = "#800080" |     | teal (verde esmeralda) = "#008080" |
     |     | fuchsia (fucsia) = "#FF00FF" |     | aqua (verde agua) = "#00FFFF"      |
 
-    > **Nota:** No usar este atributo, dado que ha sido declarado obsoleto. El elemento {{HTMLElement("table")}} debe ser estilizado utilizando [CSS](/es/docs/CSS). A fin de dar un efecto similar al atributo bgcolor, la propiedad [CSS](/es/docs/CSS) {{cssxref("background-color")}} debe ser usada.
+    > [!NOTE]
+    > No usar este atributo, dado que ha sido declarado obsoleto. El elemento {{HTMLElement("table")}} debe ser estilizado utilizando [CSS](/es/docs/CSS). A fin de dar un efecto similar al atributo bgcolor, la propiedad [CSS](/es/docs/CSS) {{cssxref("background-color")}} debe ser usada.
 
 <!---->
 
@@ -106,7 +108,8 @@ Al igual que otros elementos HTML, este elemento también soporta [atributos glo
 
   - : Este atributo entero define el tamaño del cuadro alrededor de la tabla . Si estuviese puesta en 0, implicaría que dicho atributo sería nulo.
 
-    > **Nota:** No usar este atributo en CSS dado que es obsoleto: el elemento {{HTMLElement("table")}} debe ser estilizado usando [CSS](/es/docs/CSS). A fin de dar un efecto similar al atributo, las propiedades CSS nativas {{cssxref("border")}}, {{cssxref("border-color")}}, {{cssxref("border-width")}} y {{cssxref("border-style")}} deben ser usadas.
+    > [!NOTE]
+    > No usar este atributo en CSS dado que es obsoleto: el elemento {{HTMLElement("table")}} debe ser estilizado usando [CSS](/es/docs/CSS). A fin de dar un efecto similar al atributo, las propiedades CSS nativas {{cssxref("border")}}, {{cssxref("border-color")}}, {{cssxref("border-width")}} y {{cssxref("border-style")}} deben ser usadas.
 
 <!---->
 
@@ -114,7 +117,8 @@ Al igual que otros elementos HTML, este elemento también soporta [atributos glo
 
   - : Este atributo define el espacio entre el contenido de una celda y su borde (mostrado o no), si fuese la longitud de un pixel, dicho espacio será aplicado en los 4 costados, caso que fuese un porcentaje, el contenido será centrado y todo el espacio vertical representará a este porcentaje. Lo mismo será válido para todo el espacio horizontal
 
-    > **Nota:** No usar este atributo en CSS dado que es obsoleto: el elemento {{HTMLElement("table")}} debe ser estilizado usando [CSS](/es/docs/CSS). Para dar un efecto similar al atributo border, use la propiedad CSS {{cssxref("border-collapse")}} con el valor collapse en el mismo elemento {{HTMLElement("table")}}, y la propiedad {{cssxref("padding")}} en el elemento {{HTMLElement("td")}}.
+    > [!NOTE]
+    > No usar este atributo en CSS dado que es obsoleto: el elemento {{HTMLElement("table")}} debe ser estilizado usando [CSS](/es/docs/CSS). Para dar un efecto similar al atributo border, use la propiedad CSS {{cssxref("border-collapse")}} con el valor collapse en el mismo elemento {{HTMLElement("table")}}, y la propiedad {{cssxref("padding")}} en el elemento {{HTMLElement("td")}}.
 
 <!---->
 
@@ -122,7 +126,8 @@ Al igual que otros elementos HTML, este elemento también soporta [atributos glo
 
   - : Este atributo define el espacio entre el contenido de una celda y su borde (mostrado o no), si fuese la longitud de un pixel, dicho espacio será aplicado en los 4 costados, caso que fuese un porcentaje, el contenido será centrado y todo el espacio vertical representará a este porcentaje. Lo mismo será válido para todo el espacio horizontal.
 
-    > **Nota:** No usar este atributo en CSS dado que es obsoleto: el elemento {{HTMLElement("table")}} debe ser estilizado usando [CSS](/es/docs/CSS). Para dar un efecto similar al atributo border, use la propiedad {{cssxref("border-collapse")}} con el valor collapse en el mismo elemento {{HTMLElement("table")}}, y la propiedad {{cssxref("margin")}} en el elemento {{HTMLElement("td")}}.
+    > [!NOTE]
+    > No usar este atributo en CSS dado que es obsoleto: el elemento {{HTMLElement("table")}} debe ser estilizado usando [CSS](/es/docs/CSS). Para dar un efecto similar al atributo border, use la propiedad {{cssxref("border-collapse")}} con el valor collapse en el mismo elemento {{HTMLElement("table")}}, y la propiedad {{cssxref("margin")}} en el elemento {{HTMLElement("td")}}.
 
 <!---->
 
@@ -137,7 +142,8 @@ Al igual que otros elementos HTML, este elemento también soporta [atributos glo
     |     | border |     | box    |
     |     | void   |     |        |
 
-    > **Nota:** No usar este atributo en CSS dado que es obsoleto: el elemento {{HTMLElement("table")}} debe ser estilizado usando [CSS](/es/docs/CSS). Para dar un efecto similar al atributo frame use las propiedades CSS {{cssxref("border-style")}} y {{cssxref("border-width")}}.
+    > [!NOTE]
+    > No usar este atributo en CSS dado que es obsoleto: el elemento {{HTMLElement("table")}} debe ser estilizado usando [CSS](/es/docs/CSS). Para dar un efecto similar al atributo frame use las propiedades CSS {{cssxref("border-style")}} y {{cssxref("border-width")}}.
 
 <!---->
 
@@ -151,7 +157,7 @@ Al igual que otros elementos HTML, este elemento también soporta [atributos glo
     - columns, que mostrará las reglas entre columnas;
     - all, que mostrará las reglas entre filas y columnas.
 
-    > **Nota:**
+    > [!NOTE]
     >
     > - El estilo de las reglas depende del navegador usado y no puede ser modificado.
     > - Nota de uso: No usar este atributo en CSS dado que es obsoleto: el elemento {{HTMLElement("table")}} debe ser estilizado usando [CSS](/es/docs/CSS). Use la propiedad {{cssxref("border")}} en los elementos adecuados {{HTMLElement("thead")}}, {{HTMLElement("tbody")}}, {{HTMLElement("tfoot")}}, {{HTMLElement("col")}} o {{HTMLElement("colgroup")}}.
@@ -162,7 +168,8 @@ Al igual que otros elementos HTML, este elemento también soporta [atributos glo
 
   - : Este atributo define un texto alternativo para describir una tabla en un usuario incapaz de mostrarlo, corrientemente contiene una descripcion de él que posibilita a discapacitaos visulaes (como invidentes navegando en pantallas braile) a obtener la información que necesitan.Si la información añadida en este atributo puede ser útil a otras personas, considere el utilizar el elemento {{HTMLElement("caption")}} en vez de este. instead. El atributo de resumen no es obligatorio usuarlo, pudiendo ser omitido si un elemento {{HTMLElement("caption")}} realiza similar labor.
 
-    > **Nota:** No use este atributo, dado que ha sido declarado obsoleto. En su lugar, use alguna de estas formas de describir una tabla:
+    > [!NOTE]
+    > No use este atributo, dado que ha sido declarado obsoleto. En su lugar, use alguna de estas formas de describir una tabla:
     >
     > - En prosa, rodeando la tabla (esta es la forma menos semántica de lograrlo).
     > - En el elemento {{HTMLElement("caption")}} de la tabla.
@@ -177,7 +184,8 @@ Al igual que otros elementos HTML, este elemento también soporta [atributos glo
 
   - : Este atributo define el ancho de una tabla, pudiendo contener una longitud de píxeles o un porcentaje, que representa un porcentaje de anchura del contenedor que la tabla debiera usar.
 
-    > **Nota:** No usar este atributo en CSS dado que es obsoleto: el elemento {{HTMLElement("table")}} debe ser estilizado usando [CSS](/es/docs/CSS). Para dar un efecto similar al atributo frame use la propiedad CSS {{cssxref("width")}} en su lugar.
+    > [!NOTE]
+    > No usar este atributo en CSS dado que es obsoleto: el elemento {{HTMLElement("table")}} debe ser estilizado usando [CSS](/es/docs/CSS). Para dar un efecto similar al atributo frame use la propiedad CSS {{cssxref("width")}} en su lugar.
 
 ### Interfaz DOM
 

--- a/files/es/web/html/element/td/index.md
+++ b/files/es/web/html/element/td/index.md
@@ -26,7 +26,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
   - : Este atributo contiene un pequeña descripción abreviada del contenido de la celda. Algunos agentes de usuario, como los lectores de voz, pueden presentar esta descripción antes que el propio contenido.
 
-    > **Nota:** No usar este atributo ya que esta obsoleto en la ultima version del estandar. Como alternativa, puedes poner una descripción abreviada dentro de la celda y colocar el contenido largo en el atributo **title**.
+    > [!NOTE]
+    > No usar este atributo ya que esta obsoleto en la ultima version del estandar. Como alternativa, puedes poner una descripción abreviada dentro de la celda y colocar el contenido largo en el atributo **title**.
 
 - `align` {{deprecated_inline}}
 
@@ -40,7 +41,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
     Si este atributo no se define, se selecciona por defecto `left`
 
-    > **Nota:** No usar este atributo ya que esta obsoleto en la ultima version.
+    > [!NOTE]
+    > No usar este atributo ya que esta obsoleto en la ultima version.
     >
     > - Para lograr el mismo efecto de los valores `left`, `center`, `right`, o `justify` , usa la propiedad CSS {{cssxref("text-align")}} en el.
     > - Para lograr el mismo efecto que el valor `char` , en CSS3,puedes usar el valor de la [`char`](/es/docs/Web/HTML/Element/td#char) como el valor de la propiedad {{cssxref("text-align")}}.
@@ -49,7 +51,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
   - : Este atributo contiene una lista de cadenas separadas por espacios . Cada cadena es el ID de un grupo de celdas a las que esta cabecera se aplica.
 
-    > **Nota:** No usar este atributo ya que esta obsoleto en la ultima version. En su lugar use el atributo [`scope`](/es/docs/Web/HTML/Element/td#scope) .
+    > [!NOTE]
+    > No usar este atributo ya que esta obsoleto en la ultima version. En su lugar use el atributo [`scope`](/es/docs/Web/HTML/Element/td#scope) .
 
 - `bgcolor` {{Non-standard_inline}}
 
@@ -65,26 +68,30 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
     |     | `Purpura` = "#800080" |     | `Verde Azulado` = "#008080" |
     |     | `Fucsia` = "#FF00FF"  |     | `agua` = "#00FFFF"          |
 
-    > **Nota:** Nota: No usar este atributo ya que esta obsoleto en la ultima version del estandar y solo implementado en algunas versiones de Microsoft Internet Explorer: El elemento {{HTMLElement("td")}} debe ser estilizado en CSS.
+    > [!NOTE]
+    > Nota: No usar este atributo ya que esta obsoleto en la ultima version del estandar y solo implementado en algunas versiones de Microsoft Internet Explorer: El elemento {{HTMLElement("td")}} debe ser estilizado en CSS.
     > Para crear un efecto similar en CSS en su lugar use la propiedad {{cssxref("background-color")}}.
 
 - `char` {{Deprecated_inline}} in HTML4.01 {{deprecated_inline}} in HTML5
 
   - : Este atributo se utiliza para establecer el carácter para alinear las celdas de una columna . Los valores típicos de esto incluyen un punto (. ) al intentar alinear los números o valores monetarios . Si [`align`](/es/docs/Web/HTML/Element/td#align) no está ajustado a char, este atributo se ignora.
 
-    > **Nota:** No usar este atributo ya que está obsoleto (y no soportado) en las últimas versiones estándares). Para lograr el mismo que el [`char`](/es/docs/Web/HTML/Element/thead#char), en CSS3, puedes usar el character set usando el atributo [`char`](/es/docs/Web/HTML/Element/th#char) como el valor de la propiedad {{cssxref("text-align")}}.
+    > [!NOTE]
+    > No usar este atributo ya que está obsoleto (y no soportado) en las últimas versiones estándares). Para lograr el mismo que el [`char`](/es/docs/Web/HTML/Element/thead#char), en CSS3, puedes usar el character set usando el atributo [`char`](/es/docs/Web/HTML/Element/th#char) como el valor de la propiedad {{cssxref("text-align")}}.
 
 - `charoff` {{Deprecated_inline}} in HTML4.01 {{deprecated_inline}} in HTML5
 
   - : Este atributo se utiliza para indicar el número de caracteres para compensar los datos de la columna de los personajes de alineación especificado por el atributo de carbón .
 
-    > **Nota:** Nota: No usar este atributo ya que esta obsoleto en la ultima version del estandar,
+    > [!NOTE]
+    > Nota: No usar este atributo ya que esta obsoleto en la ultima version del estandar,
 
 - `colspan`
 
   - : Este atributo contiene un valor entero no negativo que indica por el número de columnas se extiende la célula. Su valor por defecto es 1 ; si su valor se establece en 0 , se extiende hasta el final de la {{ HTMLElement ( "colgroup" ) }} , aunque implícitamente definido , que la célula pertenece. Los valores superiores a 1000 serán consideradas como incorrectas y se establecen en el valor predeterminado ( 1 ) .
 
-    > **Nota:** En HTML5 este atributo solo acepta valores mayores que 0 this attribute only accepts values greater than zero since it [must not be used to overlap cells](http://dev.w3.org/html5/spec/single-page.html#attr-tdth-colspan). Además, Firefox is the only browser to support the 0 value as defined in the HTML4.01 specification.
+    > [!NOTE]
+    > En HTML5 este atributo solo acepta valores mayores que 0 this attribute only accepts values greater than zero since it [must not be used to overlap cells](http://dev.w3.org/html5/spec/single-page.html#attr-tdth-colspan). Además, Firefox is the only browser to support the 0 value as defined in the HTML4.01 specification.
 
 - `headers`
   - : Este atributo contiene una lista de cadenas separadas por espacios , cada uno correspondiente al atributo ID de la {{ HTMLElement ( "th" ) }} elementos que se aplican a este elemento.
@@ -101,13 +108,15 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
     - `middle`, centra el texto de la celda
     - and `top`, pone el texto como cerca de la parte superior de la celda como es posible .
 
-    > **Nota:** Do not use this attribute as it is obsolete (and not supported) in the latest standard: instead set the CSS {{cssxref("vertical-align")}} property on it.
+    > [!NOTE]
+    > Do not use this attribute as it is obsolete (and not supported) in the latest standard: instead set the CSS {{cssxref("vertical-align")}} property on it.
 
 - `width` {{Deprecated_inline}} in HTML4.01
 
   - : Este atributo se utiliza para definir una anchura de celda recomendada. Propiedades CELLSPACING y cellpadding pueden añadir espacio adicional, y el elemento {{ HTMLElement ( "col" ) }} anchura pueden también tener algún efecto . En general, si el ancho de una columna es demasiado estrecha para mostrar una célula particular correctamente, y por lo tanto las células en el mismo, se puede ensanchar cuando se muestra .
 
-    > **Nota:** Do not use this attribute in the latest standard: instead set the CSS {{cssxref("width")}} property.
+    > [!NOTE]
+    > Do not use this attribute in the latest standard: instead set the CSS {{cssxref("width")}} property.
 
 ## DOM interfaz
 

--- a/files/es/web/html/element/th/index.md
+++ b/files/es/web/html/element/th/index.md
@@ -58,7 +58,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
   - : Este atributo contiene una breve descripción del contenido de las celdas. Algunos agentes de usuario (e.g., a speech reader) pueden presentar esta descripción antes que el propio contenido.
 
-    > **Nota:** No uses este atributo, ya que se ha vuelto obsoleto en el último estandar. Alternativamente, puedes poner la descripción abreviada dentro de la celda y colocarla el largo contenido en el atributo de **title**.
+    > [!NOTE]
+    > No uses este atributo, ya que se ha vuelto obsoleto en el último estandar. Alternativamente, puedes poner la descripción abreviada dentro de la celda y colocarla el largo contenido en el atributo de **title**.
 
 - `align` {{Deprecated_inline}} in HTML4, {{deprecated_inline}} in HTML5
 
@@ -72,7 +73,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
     El valor por defecto cuando no se especifica este atributo es `left`.
 
-    > **Nota:** No usar este atributo, ya que está obsoleto en el último estándar.
+    > [!NOTE]
+    > No usar este atributo, ya que está obsoleto en el último estándar.
     >
     > - Para lograr el mismo efecto que con los valores `left`, `center`, `right` o `justify`, aplicar la propiedad CSS {{cssxref("text-align")}} al elemento.
     > - Para lograr el mismo efecto que con el valor `char`, dar a la propiedad {{cssxref("text-align")}} el mismo valor que usarías para [`char`](/es/docs/Web/HTML/Element/th#char).
@@ -81,7 +83,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
   - : Este atributo contiene una lista de cadenas separadas por espacios. Cada cadena es el `id` de un grupo de celdas a las que se les aplica esta cabecera.
 
-    > **Nota:** Este atributo está obsoleto en el último estándar y no debe usarse. Puedes sustituirlo por [`scope`](/es/docs/Web/HTML/Element/th#scope).
+    > [!NOTE]
+    > Este atributo está obsoleto en el último estándar y no debe usarse. Puedes sustituirlo por [`scope`](/es/docs/Web/HTML/Element/th#scope).
 
 - `bgcolor` {{Non-standard_inline}}
 
@@ -97,7 +100,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
     |     | `purple` = "#800080"  |     | `teal` = "#008080"   |
     |     | `fuchsia` = "#FF00FF" |     | `aqua` = "#00FFFF"   |
 
-    > **Nota:** No usar este atributo, ya que no es un estándar y sólo esta implementado en algunas versiones de Microsoft Internet Explorer. El elemento {{HTMLElement("th")}} debe estilizarse usando [CSS](/es/docs/CSS). Para crear un efecto similar usa la propiedad {{cssxref("background-color")}}.
+    > [!NOTE]
+    > No usar este atributo, ya que no es un estándar y sólo esta implementado en algunas versiones de Microsoft Internet Explorer. El elemento {{HTMLElement("th")}} debe estilizarse usando [CSS](/es/docs/CSS). Para crear un efecto similar usa la propiedad {{cssxref("background-color")}}.
 
 <!---->
 
@@ -105,7 +109,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
   - : El contenido de la celda se alinea con un caracter en el elemento `<th>`. Los valores típicos incluyen un punto (.) para alinear números o valores monetarios. Si no se establece [`align`](/es/docs/Web/HTML/Element/th#align) como char, el atributo es ignorado.
 
-    > **Nota:** No usar este atributo, ya que no está soportado por el último estándar. Para lograr el mismo efecto, puedes especificar el caracter como el primer valor de la propiedad {{cssxref("text-align")}}.
+    > [!NOTE]
+    > No usar este atributo, ya que no está soportado por el último estándar. Para lograr el mismo efecto, puedes especificar el caracter como el primer valor de la propiedad {{cssxref("text-align")}}.
 
 <!---->
 
@@ -113,7 +118,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
   - : This attribute is used to shift column data to the right of the character specified by the **char** attribute. Its value specifies the length of this shift.
 
-    > **Nota:** No usar este atributo, ya que no está soportado por el último estándar.
+    > [!NOTE]
+    > No usar este atributo, ya que no está soportado por el último estándar.
 
 <!---->
 
@@ -142,13 +148,15 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
     - `middle`: Centers the text in the cell.
     - and `top`: Positions the text near the top of the cell.
 
-    > **Nota:** Do not use this attribute as it is no longer supported by the latest standard: use the CSS {{cssxref("vertical-align")}} property instead.
+    > [!NOTE]
+    > Do not use this attribute as it is no longer supported by the latest standard: use the CSS {{cssxref("vertical-align")}} property instead.
 
 - `width` {{Deprecated_inline}} in HTML4.01
 
   - : This attribute is used to define a recommended cell width. Additional space can be added with the [cellspacing](/es/docs/Web/API/HTMLTableElement/cellSpacing) and [cellpadding](/es/docs/Web/API/HTMLTableElement/cellPadding) properties and the width of the {{HTMLElement("col")}} element can also create extra width. But, if a column's width is too narrow to show a particular cell properly, it will be widened when displayed.
 
-    > **Nota:** Do not use this attribute in the latest standard: use the CSS {{cssxref("width")}} property instead.
+    > [!NOTE]
+    > Do not use this attribute in the latest standard: use the CSS {{cssxref("width")}} property instead.
 
 ## Examples
 

--- a/files/es/web/html/element/title/index.md
+++ b/files/es/web/html/element/title/index.md
@@ -115,7 +115,8 @@ Si el envío de un formulario contiene errores y el envío vuelve a representar 
 </title>
 ```
 
-> **Nota:** Actualmente, los lectores de pantalla no anunciarán automáticamente la actualización dinámica del título de una página. Si va a actualizar el título de la página para reflejar cambios significativos en el estado de una página, entonces también puede ser necesario el uso de [regiones en vivo de ARIA](/es/docs/Web/Accessibility/ARIA/ARIA_Live_Regions).
+> [!NOTE]
+> Actualmente, los lectores de pantalla no anunciarán automáticamente la actualización dinámica del título de una página. Si va a actualizar el título de la página para reflejar cambios significativos en el estado de una página, entonces también puede ser necesario el uso de [regiones en vivo de ARIA](/es/docs/Web/Accessibility/ARIA/ARIA_Live_Regions).
 
 - [MDN Entendiendo las WCAG, Directriz 2.4 explicaciones](/es/docs/Web/Accessibility/Understanding_WCAG/Operable#guideline_2.4_—_navigable_provide_ways_to_help_users_navigate_find_content_and_determine_where_they_are)
 - [Entendiendo el Criterio de Conformidad 2.4.2 | W3C Entendiendo las WCAG 2.1](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html)

--- a/files/es/web/html/element/tr/index.md
+++ b/files/es/web/html/element/tr/index.md
@@ -40,17 +40,20 @@ Este elemento incluye los [global attributes](/es/docs/HTML/Global_attributes).
 - `bgcolor` {{deprecated_inline}}
 
   - : Este atributo define el color de fondo de cada celda de la fila. Puede ser un código de #RRGGBB o una palabra clave de color de SVG.
-    > **Nota:** el elemento {{HTMLElement("tr")}} debe ser de estilo con CSS. Para dar un efecto similar al atributo bgcolor, utilice la propiedad CSS {{cssxref("background-color")}}.
+    > [!NOTE]
+    > El elemento {{HTMLElement("tr")}} debe ser de estilo con CSS. Para dar un efecto similar al atributo bgcolor, utilice la propiedad CSS {{cssxref("background-color")}}.
 
 - `char` {{deprecated_inline}}
 
   - : Este atributo es utilizado para establecer el caracter para alinear las celdas de una columna. Los valores típicos para éste incluyen un punto (.) al intentar alinear los números o valores monetarios. Si [`align`](/es/docs/Web/HTML/Element/tr#align) no se ha ajustado a char, este atributo se ignora.
-    > **Nota:** No utilice este atributo, ya que es obsoleta (y no es compatible) en el último estándar. Para lograr el mismo efecto que el [`char`](/es/docs/Web/HTML/Element/tr#char), en CSS3, puedes utilizar el juego de carácteres utilizando el atributo [`char`](/es/docs/Web/HTML/Element/tr#char) como el valor de la referencia externa de la propiedad {{cssxref("text-align")}}.
+    > [!NOTE]
+    > No utilice este atributo, ya que es obsoleta (y no es compatible) en el último estándar. Para lograr el mismo efecto que el [`char`](/es/docs/Web/HTML/Element/tr#char), en CSS3, puedes utilizar el juego de carácteres utilizando el atributo [`char`](/es/docs/Web/HTML/Element/tr#char) como el valor de la referencia externa de la propiedad {{cssxref("text-align")}}.
 
 - `charoff` {{deprecated_inline}}
 
   - : Este atributo se utiliza para indicar el número de caracteres para compensar los datos de la columna de los carácteres de alineación especificado por el atributo char.
-    > **Nota:** No utilice este atributo, ya que está obsoleto (y no es compatible) en el último estándar.
+    > [!NOTE]
+    > No utilice este atributo, ya que está obsoleto (y no es compatible) en el último estándar.
 
 - `valign` {{deprecated_inline}}
   - : Este atributo especifica la alineación vertical del texto dentro de cada fila de las celdas de la cabecera de la tabla. Los valores posibles para este atributo son:
@@ -58,7 +61,8 @@ Este elemento incluye los [global attributes](/es/docs/HTML/Global_attributes).
     - `bottom`,que pondrá el texto tan cerca de la parte inferior de la célula como sae posible;
     - `middle`,que centrará el texto en la celda;
     - y `top`, que pondrá el texto como cerca de la parte superior de la célula como es posible.
-      > **Nota:** No utilice este atributo, ya que está obsoleto (y no es compatible) en el último estándar: {{cssxref("vertical-align")}} en su lugar establecer la propiedad CSS en él.
+      > [!NOTE]
+      > No utilice este atributo, ya que está obsoleto (y no es compatible) en el último estándar: {{cssxref("vertical-align")}} en su lugar establecer la propiedad CSS en él.
 
 ## Interfaz DOM
 

--- a/files/es/web/html/element/u/index.md
+++ b/files/es/web/html/element/u/index.md
@@ -60,6 +60,7 @@ Para obtener el mismo resultado puede usarse La propiedad CSS text-decoration: u
 
 Si por algún motivo necesita usar elementos desaprobados como u, recuerde que debe declarar un DOCTYPE transicional.
 
-> **Advertencia:** DESAPROBADO
+> [!WARNING]
+> DESAPROBADO
 
 de momento no funciona

--- a/files/es/web/html/element/ul/index.md
+++ b/files/es/web/html/element/ul/index.md
@@ -250,7 +250,8 @@ Puede consultar esta [comparativa](http://www.webdevout.net/browser_support_html
 
 ---
 
-> **Nota:** Estamos ampliando este documento, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
+> [!NOTE]
+> Estamos ampliando este documento, posiblemente contenga defectos y carencias. ¡Estamos en obras!... disculpen las molestias.
 >
 > ¿Quieres participar en su elaboración? Para saber cómo hacerlo consulta MDC:Como ayudar.
 

--- a/files/es/web/html/element/video/index.md
+++ b/files/es/web/html/element/video/index.md
@@ -25,7 +25,8 @@ Para obtener una lista de formatos compatibles, consulta [Formatos multimedia ad
 
   - : Un atributo booleano; si se especifica, el video comenzará automáticamente a almacenarse en el búfer, incluso si no está listo para reproducirse de forma automática. Esto se debe utilizar para los casos en los que se considera probable que el video se reproduzca (por ejemplo, si el usuario accedió a esa página específica para reproducir el video, no si hay un video insertado junto con otros contenidos). El video se almacena en el búfer hasta que el caché de medios esté lleno.
 
-    > **Nota:** aunque forma parte de los primeros borradores de la especificación HTML 5, el atributo **autobuffer** se ha eliminado en versiones posteriores. Se ha quitado de Gecko 2.0 y otros navegadores, y en algunos nunca llegó a implementarse. La especificación define un nuevo atributo enumerado, **preload,** para sustituir el atributo **autobuffer,** con una sintaxis diferente. [Error 548523 en Firefox](https://bugzil.la/548523)
+    > [!NOTE]
+    > Aunque forma parte de los primeros borradores de la especificación HTML 5, el atributo **autobuffer** se ha eliminado en versiones posteriores. Se ha quitado de Gecko 2.0 y otros navegadores, y en algunos nunca llegó a implementarse. La especificación define un nuevo atributo enumerado, **preload,** para sustituir el atributo **autobuffer,** con una sintaxis diferente. [Error 548523 en Firefox](https://bugzil.la/548523)
 
 - `buffered`
   - : Un atributo que se puede leer para determinar qué intervalos de tiempo del multimedia se han almacenado en búfer. Este atributo contiene un objeto {{ domxref("TimeRanges") }} .
@@ -46,7 +47,7 @@ Para obtener una lista de formatos compatibles, consulta [Formatos multimedia ad
 
     Si no está configurado, su valor predeterminado está definido por el navegador (es decir, cada navegador puede elegir su propio valor predeterminado), aunque la especificación aconseje que se establezca a metadata.
 
-    > **Nota:**
+    > [!NOTE]
     >
     > - El atributo **autoplay** tiene prioridad sobre éste si se desea reproducir automáticamente un video, el navegador obviamente tendrá que descargarlo. La especificación permite establecer los atributos **autoplay** y **preload**.
     > - La especificación no fuerza al navegador a seguir el valor de este atributo; es tan sólo una sugerencia.
@@ -60,7 +61,8 @@ Para obtener una lista de formatos compatibles, consulta [Formatos multimedia ad
 
 Las compensaciones de tiempo se especifican actualmente como valores float que representan el número de segundos que se va a compensar.
 
-> **Nota:** la definición del valor de compensación de tiempo no se ha completado en HTML 5 aún y está sujeta a cambios.
+> [!NOTE]
+> La definición del valor de compensación de tiempo no se ha completado en HTML 5 aún y está sujeta a cambios.
 
 ## Ejemplos
 

--- a/files/es/web/html/element/xmp/index.md
+++ b/files/es/web/html/element/xmp/index.md
@@ -9,7 +9,8 @@ slug: Web/HTML/Element/xmp
 
 El elemento HTML example element \<xmp> dibuja texto entre las etiquetas de inicio y fin sin interpretar el HTML que se encuentra en medio y lo muestra usando un tipo de letra monoespaciada . La especificación de HTML2 recomendaba que que esta debería de ser dibujada suficientemente amplia para permitir 80 caracteres por línea .
 
-> **Nota:** No usar este elemento.
+> [!NOTE]
+> No usar este elemento.
 >
 > - Ha sido declarado obsoleto desde HTML3.2 y no fue implementado en una manera consistente . Fue completamente removido del lenguaje en HTML5 .
 > - Usar el elemento {{HTMLElement("pre")}} , o si es semánticamente adecuado , el elemento {{HTMLElement("code")}} en su lugar . Notar que necesitarás escapar los caracteres '<' como '\&lt' para asegurarse que no se interprete como marcado .
@@ -23,7 +24,8 @@ Este elemento no tiene otros atributos que los [atributos globales](/es/docs/Web
 
 Este elemento implementa la interface {{domxref('HTMLElement')}} .
 
-> **Nota:** hasta Gecko 1.9.2 inclusivamente , Firefox implemente la interface {{domxref('HTMLSpanElement')}} para este elemento .
+> [!NOTE]
+> Hasta Gecko 1.9.2 inclusivamente , Firefox implemente la interface {{domxref('HTMLSpanElement')}} para este elemento .
 
 ## Ver también
 

--- a/files/es/web/html/global_attributes/dir/index.md
+++ b/files/es/web/html/global_attributes/dir/index.md
@@ -11,7 +11,8 @@ El [atributo global](/es/docs/Web/HTML/Atributos_Globales) dir es un atributo en
 - `rtl`, significa _derecha_ a _izquierda_ y es usado para los lenguajes que son escritos de la derecha a la izquierda (como el árabe ) .
 - `auto`, permite al agente usuario decidir . Usa un algoritmo básico mientras parsea los caracteres dentro de un elemento hasta que encuentra un elemento con una direccionalidad fuerte , después aplica esa direccionalidad a todo el elemento .
 
-> **Nota:** Este atributo es obligatorio para el elemento {{ HTMLElement("bdo") }} donde este tiene un significado semántico diferente.
+> [!NOTE]
+> Este atributo es obligatorio para el elemento {{ HTMLElement("bdo") }} donde este tiene un significado semántico diferente.
 >
 > - Este atributo no es heredado por el elemento {{ HTMLElement("bdi") }} . Si no se establece , su valor es `auto`.
 > - Este atributo puede ser anulado por las propiedades de CSS {{ cssxref("direction") }} y {{ cssxref("unicode-bidi") }} , si una página CSS está activa y el elemento soporta estas propiedades.

--- a/files/es/web/html/global_attributes/hidden/index.md
+++ b/files/es/web/html/global_attributes/hidden/index.md
@@ -11,7 +11,8 @@ Esta atributo no debe de usarse para ocultar contenido que pudera ser legítimam
 
 Los elementos ocultos no deben de ser vinculados desde elementos no ocultos y elementos que son descendientes de un elemento oculto todavía activo ; lo que significa que los elementos del script pueden todavía ejecutarse y los elementos de formulario pueden todavía enviarse .
 
-> **Nota:** Cambiando el valor de la propiedad CSS {{cssxref("display")}} de un elemento con el atributo `hidden` sobrecarga el comportamiento . For ejemplo , un elemeneto diseñado `display : flex` será mostrado en la pantalla independientemente de que el atributo `hidden` esté presente .
+> [!NOTE]
+> Cambiando el valor de la propiedad CSS {{cssxref("display")}} de un elemento con el atributo `hidden` sobrecarga el comportamiento . For ejemplo , un elemeneto diseñado `display : flex` será mostrado en la pantalla independientemente de que el atributo `hidden` esté presente .
 
 ## Especificaciones
 

--- a/files/es/web/html/global_attributes/id/index.md
+++ b/files/es/web/html/global_attributes/id/index.md
@@ -11,7 +11,8 @@ El valor de este atributo es una cadena de caracteres opaca: es decir, el autor 
 
 El valor de este atributo no debe contener espacios en blanco. Los navegadores tratan los IDs que contienen espacios en blanco como si los espacios fueran parte del ID. En contraste con el atributo **class**, el cual permite valores separados por espacios, los elementos pueden tener sólo un ID definido mediante el atributo ID. Tenga en cuenta que un elemento puede tener muchos ID, pero los demás deben ser definidos de otra forma, como por medio de un script interactuando con el DOM.
 
-> **Nota:** El uso de caracteres a excepción de letras en ASCII, dígitos, '\_', `'-'` y `'.'` pueden ocasionar problemas de compatibilidad, por no ser permitidos en HTML 4. A pesar de que esta limitación ha sido removida en HTML 5, un ID debe iniciar con una letra para asegurar la compatibilidad.
+> [!NOTE]
+> El uso de caracteres a excepción de letras en ASCII, dígitos, '\_', `'-'` y `'.'` pueden ocasionar problemas de compatibilidad, por no ser permitidos en HTML 4. A pesar de que esta limitación ha sido removida en HTML 5, un ID debe iniciar con una letra para asegurar la compatibilidad.
 
 ## Especificaciones
 

--- a/files/es/web/html/global_attributes/index.md
+++ b/files/es/web/html/global_attributes/index.md
@@ -59,7 +59,8 @@ Además de los atributos globales HTML básicos, también existen los siguientes
 - **`[is](/es/docs/Web/HTML/Global_attributes/is)`**
   - : Te permite especificar que un elemento HTML estándar se debe comportar como un elemento integrado personalizado registrado (consulta [Uso de elementos personalizados](/es/docs/Web/Web_Components/Using_custom_elements) para obtener más detalles).
 
-> **Nota:** Los atributos `item*` son parte de [Función de microdatos HTML de WHATWG](https://html.spec.whatwg.org/multipage/microdata.html#microdata).
+> [!NOTE]
+> Los atributos `item*` son parte de [Función de microdatos HTML de WHATWG](https://html.spec.whatwg.org/multipage/microdata.html#microdata).
 
 - **`[itemid](/es/docs/Web/HTML/Global_attributes/itemid)`**
   - : El identificador único y global de un artículo.

--- a/files/es/web/html/global_attributes/itemid/index.md
+++ b/files/es/web/html/global_attributes/itemid/index.md
@@ -11,7 +11,8 @@ Un atributo `itemid` solo se puede especificar para un elemento que tiene atribu
 
 El significado exacto de un identificador global de `itemtype` lo proporciona la definición de ese identificador dentro del vocabulario especificado. El vocabulario define si pueden coexistir varios elementos con el mismo identificador global y, de ser así, cómo se manejan los elementos con el mismo identificador.
 
-> **Nota:** La definición {{glossary("WHATWG")}} especifica que un `itemid` debe ser una {{glossary("URL")}}. Sin embargo, el siguiente ejemplo ilustra correctamente que también se puede usar un {{glossary("URN")}}. Esta inconsistencia puede reflejar la naturaleza incompleta de la especificación de Microdata.
+> [!NOTE]
+> La definición {{glossary("WHATWG")}} especifica que un `itemid` debe ser una {{glossary("URL")}}. Sin embargo, el siguiente ejemplo ilustra correctamente que también se puede usar un {{glossary("URN")}}. Esta inconsistencia puede reflejar la naturaleza incompleta de la especificación de Microdata.
 
 ## Ejemplo
 

--- a/files/es/web/html/global_attributes/itemref/index.md
+++ b/files/es/web/html/global_attributes/itemref/index.md
@@ -11,7 +11,8 @@ Las propiedades que no son descendientes de un elemento con el atributo `itemsco
 
 El atributo itemref puede ser solo especificado en elementos que tienen un atributo itemscope especificado .
 
-> **Nota:** el atributo itemref no es parte del modelo de micro datos . Es solamente un constructor sintáctico que ayuda a los autores en el ingreso de anotaciones a las páginas donde los datos que se van a anotar no siguen una estructura de arbol conveniente . Por ejemplo , permite a los autores marcar los datos en una tabla para que cada columna defina un item separado mientras se mantienen las propiedades en las celdas .
+> [!NOTE]
+> El atributo itemref no es parte del modelo de micro datos . Es solamente un constructor sintáctico que ayuda a los autores en el ingreso de anotaciones a las páginas donde los datos que se van a anotar no siguen una estructura de arbol conveniente . Por ejemplo , permite a los autores marcar los datos en una tabla para que cada columna defina un item separado mientras se mantienen las propiedades en las celdas .
 
 ## Ejemplo
 

--- a/files/es/web/html/global_attributes/itemscope/index.md
+++ b/files/es/web/html/global_attributes/itemscope/index.md
@@ -9,7 +9,8 @@ slug: Web/HTML/Global_attributes/itemscope
 
 Todos los elementos HTML pueden tener un atributo `itemscope` especifico. Un elemento `itemscope` no tiene un asociado `itemtype` pero tiene un sociado `itemref`.
 
-> **Nota:** Encuentra mas acerca del atributo `itemtype` en <http://schema.org/Thing>
+> [!NOTE]
+> Encuentra mas acerca del atributo `itemtype` en <http://schema.org/Thing>
 
 ### Ejemplo simple
 
@@ -232,7 +233,8 @@ Los siguientes son un ejemplo renderizado resultado del codigo del anterior ejem
   </tbody>
 </table>
 
-> **Nota:** Una herramienta practica para extraer estructuras microdata del HTML es [Structured Data Testing Tool](https://developers.google.com/structured-data/testing-tool/) de Google. Pruebalo en el HTML del ejemplo anterior.
+> [!NOTE]
+> Una herramienta practica para extraer estructuras microdata del HTML es [Structured Data Testing Tool](https://developers.google.com/structured-data/testing-tool/) de Google. Pruebalo en el HTML del ejemplo anterior.
 
 ## Especificaciones
 

--- a/files/es/web/html/global_attributes/tabindex/index.md
+++ b/files/es/web/html/global_attributes/tabindex/index.md
@@ -5,7 +5,8 @@ slug: Web/HTML/Global_attributes/tabindex
 
 {{HTMLSidebar("Global_attributes")}}
 
-> **Nota:** El valor máximo para tabindex no debe de exceder 32767 ([sección 17.11.1 del W3C](https://www.w3.org/TR/html401/interact/forms.html#h-17.11.1)). Si no se especifica, el valor asignado por defecto es -1.
+> [!NOTE]
+> El valor máximo para tabindex no debe de exceder 32767 ([sección 17.11.1 del W3C](https://www.w3.org/TR/html401/interact/forms.html#h-17.11.1)). Si no se especifica, el valor asignado por defecto es -1.
 
 El [atributo global](/es/docs/Web/HTML/Atributos_Globales) **tabindex** indica si su elemento puede ser enfocado, y si participa en la navegación secuencial del teclado (usualmente con la tecla _Tab_, de ahí el nombre). Acepta un entero como valor, con diferentes resultados que dependen de dicho valor:
 

--- a/files/es/web/html/index.md
+++ b/files/es/web/html/index.md
@@ -24,7 +24,7 @@ Los siguientes artículos pueden ayudarte a obtener más información sobre HTML
 - Referencia HTML
   - : En nuestra extensa sección [referencia HTML](/es/docs/Web/HTML/Referencia) encontrarás los detalles sobre cada elemento y atributo en HTML.
 
-> **Observación:**
+> [!CALLOUT]
 >
 > ### ¿Quieres transformarte en un desarrollador de la interfaz de usuario web?
 >

--- a/files/es/web/html/microdata/index.md
+++ b/files/es/web/html/microdata/index.md
@@ -20,7 +20,8 @@ En un nivel elevado, los microdatos consisten de un grupo de conjuntos nombre-va
 
 Google, así como otros de los principales buscadores, admiten el vocabulario para datos estructurados de [Schema.org](schema.org). Este vocabulario define un conjunto estandarizado de nombres de tipos y de propiedades: por ejemplo, [Evento musical de Schema.org](http://schema.org/MusicEvent) señala conciertos, e incluye las propiedades _[startDate](http://schema.org/startDate)_ ('fecha inicial') y _[location](http://schema.org/location)_ ('ubicación') para definir los detalles clave del acontecimiento. En este caso, [Evento musical de Schema.org](http://schema.org/MusicEvent) es el URL usado por _itemtype_ y _startDate_, y la ubicación corresponde a las _itemprop_ que defina [Evento musical de Schema.org](http://schema.org/MusicEvent).
 
-> **Nota:** para obtener más información sobre los atributos _itemtype_, véase <http://schema.org/Thing> (en inglés)
+> [!NOTE]
+> Para obtener más información sobre los atributos _itemtype_, véase <http://schema.org/Thing> (en inglés)
 
 Los vocabularios de microdatos brindan la semántica, o el significado, de los elementos. Los programadores web pueden diseñar un vocabulario personalizado o servirse de los que existen disponibles en la web, como el ampliamente utilizado vocabulario de [Schema.org](http://schema.org). Schema.org ofrece una colección de vocabularios de etiquetado usados frecuentemente.
 
@@ -146,7 +147,8 @@ _[itemref](/es/docs/Web/HTML/Global_attributes/itemref)_: las propiedades que no
 
 {{EmbedLiveSample('', '', '100')}}
 
-> **Nota:** una útil herramienta para extraer estructuras de microdatos a partir de HTML es la [Herramienta de pruebas de datos estructurados](https://developers.google.com/structured-data/testing-tool/) de Google. Ponla a prueba en el HTML mostrado más arriba.
+> [!NOTE]
+> Una útil herramienta para extraer estructuras de microdatos a partir de HTML es la [Herramienta de pruebas de datos estructurados](https://developers.google.com/structured-data/testing-tool/) de Google. Ponla a prueba en el HTML mostrado más arriba.
 
 ## Véase también
 

--- a/files/es/web/http/basics_of_http/mime_types/index.md
+++ b/files/es/web/http/basics_of_http/mime_types/index.md
@@ -67,7 +67,8 @@ Este es el valor predeterminado para un archivo binario. Como realmente signific
 
 Este es el valor predeterminado para los archivos de texto. Incluso si realmente significa un archivo textual desconocido, los navegadores asumen que pueden mostrarlo.
 
-> **Nota:** Tenga en cuenta que `text/plain` no significa _cualquier tipo de datos textuales_. Si esperan un tipo específico de datos textuales, probablemente no lo considerarán una coincidencia. Específicamente, si descargan un archivo de texto sin formato `text/plain` de un elemento {{HTMLElement("link")}} que declara archivos CSS, no lo reconocerán como un archivo CSS válido si se presenta con `text/plain`. Se debe usar el tipo MIME CSS `text/css`.
+> [!NOTE]
+> Tenga en cuenta que `text/plain` no significa _cualquier tipo de datos textuales_. Si esperan un tipo específico de datos textuales, probablemente no lo considerarán una coincidencia. Específicamente, si descargan un archivo de texto sin formato `text/plain` de un elemento {{HTMLElement("link")}} que declara archivos CSS, no lo reconocerán como un archivo CSS válido si se presenta con `text/plain`. Se debe usar el tipo MIME CSS `text/css`.
 
 ### `text/css`
 

--- a/files/es/web/http/caching/index.md
+++ b/files/es/web/http/caching/index.md
@@ -249,7 +249,8 @@ El servidor devolverá `304 Not modified` si el valor del header `ETag` que dete
 
 Pero si el servidor determina que el recurso solicitado ahora debería tener un valor `ETag` diferente, el servidor responderá con `200 OK` y la última versión del recurso.
 
-> **Nota:** A la hora de evaluar como usar `ETag` y `Last-Modified`, se debería considerar lo siguiente:
+> [!NOTE]
+> A la hora de evaluar como usar `ETag` y `Last-Modified`, se debería considerar lo siguiente:
 > Durante la revalidación de la caché, si `ETag` y `Last-Modified` están presentes, `ETag` toma la preferencia.
 > Por lo tanto, si solamente se está considerando el almacenamiento en caché, se puede pensar que `Last-Modified` es innecesario.
 > Sin embargo, `Last-Modified` no solo es útil para el almacenamiento en caché; en cambio, es un encabezado HTTP estándar que también utilizan los sistemas de administración de contenido (CMS) para mostrar la hora de la última modificación, los rastreadores para ajustar la frecuencia de rastreo y para otros fines diversos.
@@ -560,7 +561,8 @@ A tener en cuenta que el número '41' tiene la 'max-age' más larga (1 año), pe
 
 El valor `public` tiene el efecto de hacer que la respuesta se pueda almacenar incluso si el encabezado `Authorization` está presente.
 
-> **Nota:** La directiva `public` solo debe usarse si es necesario almacenar la respuesta cuando se establece el header `Authorization`.
+> [!NOTE]
+> La directiva `public` solo debe usarse si es necesario almacenar la respuesta cuando se establece el header `Authorization`.
 > De lo contrario, no se requiere, porque una respuesta se almacenará en el caché compartido siempre que se proporcione `max-age`.
 
 Entonces, si la respuesta está personalizada con autenticación básica, la presencia de `public` puede causar problemas. Si le preocupa eso, puede elegir el segundo valor más largo, `37` (1 mes).
@@ -603,7 +605,8 @@ ETag: YsAIAAAA-QG4G6kCMAMBAAAAAAAoK
 
 Hacer que una respuesta se pueda almacenar en caché durante un largo período de tiempo cambiando la URL cuando cambia el contenido se denomina **cache busting**. Esa técnica se puede aplicar a todos los subrecursos, como las imágenes.
 
-> **Nota:** Al evaluar el uso de `immutable` y QPACK:
+> [!NOTE]
+> Al evaluar el uso de `immutable` y QPACK:
 > Si le preocupa que `immutable` cambie el valor predefinido proporcionado por QPACK, considere que
 > en este caso, la parte `immutable` se puede codificar por separado dividiendo el valor `Cache-Control` en dos líneas, aunque esto depende del algoritmo de codificación que utilice una implementación particular de QPACK.
 

--- a/files/es/web/http/connection_management_in_http_1.x/index.md
+++ b/files/es/web/http/connection_management_in_http_1.x/index.md
@@ -15,7 +15,8 @@ Dos nuevos modelos se presentaron en HTTP/1.1. La conexión persistente, mantien
 
 ![Compares the performance of the three HTTP/1.x connection models: short-lived connections, persistent connections, and HTTP pipelining.](http1_x_connections.png)
 
-> **Nota:** HTTP/2 añade nuevos modelos para la gestión de la conexión.
+> [!NOTE]
+> HTTP/2 añade nuevos modelos para la gestión de la conexión.
 
 Un punto significativo a tener en cuenta en la gestión de la conexión de HTTP, es que este se refiere a la conexión establecida entre dos nodos consecutivos de la red, esto se denomina [hop-by-hop](/es/docs/Web/HTTP/Headers#hbh), en contraposición al concepto de [end-to-end](/es/docs/Web/HTTP/Headers#e2e). El modelo de conexión entre un cliente y su primer proxy, puede ser distinto que la comunicación entre el proxy y el servidor de destino (u otro proxy intermedio). Las cabeceras de HTTP utilizadas para definir el modelo de conexión como {{HTTPHeader("Connection")}} y {{HTTPHeader("Keep-Alive")}}, se refieren a una conexión [hop-by-hop](/es/docs/Web/HTTP/Headers#hbh), y estos parámetros, pueden variar en las comunicaciones de los nodos intermedios.
 
@@ -29,7 +30,8 @@ La coordinación o inicialización de una comunicación en el protocolo TCP, req
 
 La conexión breve es la conexión usada por defecto en HTTP/1.0 (únicamente en el caso de no esté definida la cabecera {{HTTPHeader("Connection")}}, o su valor sea `close` entonces, no se utilizaria el modelo de conexiones breves). En HTTP/1.1, este modelo de conexión unicamente se utiliza al definir la cabecera {{HTTPHeader("Connection")}} como `close` .
 
-> **Nota:** A menos que se de la situación en que se ha de trabajar con sistemas antiguos que no soportan conexiones persistentes, no hay otra razón para el uso de este modelo de conexiones.
+> [!NOTE]
+> A menos que se de la situación en que se ha de trabajar con sistemas antiguos que no soportan conexiones persistentes, no hay otra razón para el uso de este modelo de conexiones.
 
 ## Conexiones persistentes
 
@@ -45,7 +47,8 @@ En HTTP/1.1 las conexiones son persistentes por defecto, así que esa cabecera n
 
 ## HTTP pipelining
 
-> **Nota:** HTTP pipelining no está activado por defecto en los navegacdores modernos:\* [Proxies](https://en.wikipedia.org/wiki/Proxy_server) con defectos de implementación son habituales y provocan comportamientos extraños y erráticos, que los desarrolladores de Webs, no pueden predecir, ni corregir fácilmente.
+> [!NOTE]
+> HTTP pipelining no está activado por defecto en los navegacdores modernos:\* [Proxies](https://en.wikipedia.org/wiki/Proxy_server) con defectos de implementación son habituales y provocan comportamientos extraños y erráticos, que los desarrolladores de Webs, no pueden predecir, ni corregir fácilmente.
 >
 > - HTTP Pipelining es complicado de implementar correctamente: el tamaño del recurso pedido, el correcto [RTT](https://en.wikipedia.org/wiki/Round-trip_delay_time) que será utilizado, así como el ancho de banda efectivo, tienen un impacto directo en la en la mejora de rendimiento de este método. Sin conocer estos valores, puede que mensajes importantes, se vean retrasados, por mensajes que no lo son. El concepto de "importante" incluso cambia según se carga la maquetación (layout) de la página. De ahí que este método solamente presente una mejora marginal en la mayoría de los casos.
 > - HTTP Pipelining presenta un problema conocido como [HOL](https://en.wikipedia.org/wiki/Head-of-line_blocking)
@@ -61,7 +64,8 @@ Hoy en día, todo proxy y servidor que cumpla con HTTP/1.1 debería dar soporte 
 
 ## Domain sharding
 
-> **Nota:** Unless you have a very specific immediate need, don't use this deprecated technique; switch to HTTP/2 instead. In HTTP/2, domain sharding is no more useful: the HTTP/2 connection is able to handle parallel unprioritized requests very well. Domain sharding is even detrimental to performance. Most HTTP/2 implementation use a technique called [connection coalescing](<I wonder if it's related to the nobash/nobreak/nopick secret exit s of Elrond's chambers.>) to revert eventual domain sharding.
+> [!NOTE]
+> Unless you have a very specific immediate need, don't use this deprecated technique; switch to HTTP/2 instead. In HTTP/2, domain sharding is no more useful: the HTTP/2 connection is able to handle parallel unprioritized requests very well. Domain sharding is even detrimental to performance. Most HTTP/2 implementation use a technique called [connection coalescing](<I wonder if it's related to the nobash/nobreak/nopick secret exit s of Elrond's chambers.>) to revert eventual domain sharding.
 
 As an HTTP/1.x connection is serializing requests, even without any ordering, it can't be optimal without large enough available bandwidth. As a solution, browsers open several connections to each domain, sending parallel requests. Default was once 2 to 3 connections, but this has now increased to a more common use of 6 parallel connections. There is a risk of triggering [DoS](/es/docs/Glossary/DOS_attack) protection on the server side if attempting more than this number.
 

--- a/files/es/web/http/cookies/index.md
+++ b/files/es/web/http/cookies/index.md
@@ -18,7 +18,8 @@ Las cookies se utilizan principalmente con tres propósitos:
 
 Las cookies se usaron una vez para el almacenamiento general del lado del cliente. Si bien esto era legítimo cuando eran la única forma de almacenar datos en el cliente, hoy en día se recomienda preferir las API de almacenamiento modernas. Las cookies se envían con cada solicitud, por lo que pueden empeorar el rendimiento (especialmente para las conexiones de datos móviles). Las APIs modernas para el almacenamiento del cliente son la [Web storage API](/es/docs/Web/API/Web_Storage_API) (`localStorage` y `sessionStorage`) e [IndexedDB](/es/docs/Web/API/IndexedDB_API).
 
-> **Nota:** Para ver las cookies almacenadas (y otro tipo de almacenamiento que una página web puede usar), puede habilitar el [Inspector de Almacenamiento](/es/docs/Tools/Storage_Inspector) en Herramientas del desarrollador y seleccionar Cookies en el árbol de almacenamiento.
+> [!NOTE]
+> Para ver las cookies almacenadas (y otro tipo de almacenamiento que una página web puede usar), puede habilitar el [Inspector de Almacenamiento](/es/docs/Tools/Storage_Inspector) en Herramientas del desarrollador y seleccionar Cookies en el árbol de almacenamiento.
 
 ## Creando cookies
 
@@ -34,7 +35,8 @@ Set-Cookie: <nombre-cookie>=<valor-cookie>
 
 Este encabezado del servidor le dice al cliente que almacene una cookie.
 
-> **Nota:** Aquí se explica como usar el encabezado `Set-Cookie` en varias aplicaciones del lado del servidor:
+> [!NOTE]
+> Aquí se explica como usar el encabezado `Set-Cookie` en varias aplicaciones del lado del servidor:
 >
 > - [PHP](https://secure.php.net/manual/en/function.setcookie.php)
 > - [Node.JS](https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_response_setheader_name_value)
@@ -70,7 +72,8 @@ En lugar de expirar cuando el cliente se cierra, las _cookies permanentes_ expir
 Set-Cookie: id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT;
 ```
 
-> **Nota:** Cuando se establece una fecha de expiración, la fecha y hora que se establece es relativa al cliente en el que se establece la cookie, no del servidor.
+> [!NOTE]
+> Cuando se establece una fecha de expiración, la fecha y hora que se establece es relativa al cliente en el que se establece la cookie, no del servidor.
 
 ### Cookies `Secure` y `HttpOnly`
 
@@ -134,7 +137,8 @@ Tenga en cuenta las cuestiones de seguridad en la siguiente sección [Seguridad]
 
 ## Seguridad
 
-> **Nota:** Nunca se debe almacenar ni transmitir información confidecial o sensible mediante Cookies HTTP, ya que todo el mecanismo es inherentemente inseguro.
+> [!NOTE]
+> Nunca se debe almacenar ni transmitir información confidecial o sensible mediante Cookies HTTP, ya que todo el mecanismo es inherentemente inseguro.
 
 ### Secuestro de session y XSS
 

--- a/files/es/web/http/cors/errors/corsmissingalloworigin/index.md
+++ b/files/es/web/http/cors/errors/corsmissingalloworigin/index.md
@@ -29,7 +29,8 @@ También puede configurar un sitio para permitirle el acceso desde cualquier otr
 Access-Control-Allow-Origin: *
 ```
 
-> **Advertencia:** Utilizar el comodín para permitir que todos los sitios accedan a una API privada es una mala idea.
+> [!WARNING]
+> Utilizar el comodín para permitir que todos los sitios accedan a una API privada es una mala idea.
 
 Para permitir que cualquier sitio realice peticiones CORS _sin_ usar el comodín `*` (por ejemplo, para activar credenciales), su servidor deberá leer el valor la cabecera `Origin` de la petición y usar dicho valor para `Access-Control-Allow-Origin` y además declarar una cabecera `Vary: Origin` para indicar que algunas cabeceras están siendo dinámicamente declaradas dependiendo del origen.
 

--- a/files/es/web/http/cors/errors/index.md
+++ b/files/es/web/http/cors/errors/index.md
@@ -28,7 +28,8 @@ impide leer el recurso remoto en https://alguna-url-aqui (razón:
 información adicional aquí).
 ```
 
-> **Nota:** Por razones de seguridad, los detalles sobre lo que salió mal con una solicitud CORS _no están disponibles para el código JavaScript_. Todo lo que el código sabe es que ocurrió un error. La única forma de determinar qué salió mal específicamente es mirar la consola del navegador para obtener más detalles.
+> [!NOTE]
+> Por razones de seguridad, los detalles sobre lo que salió mal con una solicitud CORS _no están disponibles para el código JavaScript_. Todo lo que el código sabe es que ocurrió un error. La única forma de determinar qué salió mal específicamente es mirar la consola del navegador para obtener más detalles.
 
 ## Mensajes de error de CORS
 

--- a/files/es/web/http/cors/index.md
+++ b/files/es/web/http/cors/index.md
@@ -63,7 +63,8 @@ Una petición simple es aquella que cumple todas las siguientes condiciones:
   - {{HTTPHeader("Content-Type")}} (Por favor, tenga en cuenta los siguientes requisitos adicionales)
   - {{HTTPHeader("Range")}} (solo con un [valor de cabecera de rango simple](https://fetch.spec.whatwg.org/#simple-range-header-value); por ejemplo, `bytes=256-` o `bytes=127-255`)
 
-> **Nota:** Firefox aún no ha implementado `Range` como una cabecera de solicitud en la lista segura. Véase el [error 1733981 en Firefox](https://bugzil.la/1733981).
+> [!NOTE]
+> Firefox aún no ha implementado `Range` como una cabecera de solicitud en la lista segura. Véase el [error 1733981 en Firefox](https://bugzil.la/1733981).
 
 - Las únicas combinaciones de tipo/subtipo permitidas para el {{Glossary("MIME type","media type")}} especificado en la cabecera {{HTTPHeader("Content-Type")}} son:
 
@@ -139,7 +140,8 @@ Este patrón de las cabeceras {{HTTPHeader("Origin")}} y {{HTTPHeader("Access-Co
 Access-Control-Allow-Origin: https://foo.example
 ```
 
-> **Nota:** Al responder a una petición con [solicitud con credenciales](#requests_with_credentials), el servidor debe especificar un origen en el valor de la cabecera `Access-Control-Allow-Origin`, en lugar de especificar el comodín "\*".
+> [!NOTE]
+> Al responder a una petición con [solicitud con credenciales](#requests_with_credentials), el servidor debe especificar un origen en el valor de la cabecera `Access-Control-Allow-Origin`, en lugar de especificar el comodín "\*".
 
 ### Solicitudes verificadas previamente
 
@@ -160,7 +162,8 @@ El ejemplo anterior crea un cuerpo para enviar con la solicitud `POST`. Además,
 
 ![Diagrama de una solicitud con verificación previa](preflight_correct.png)
 
-> **Nota:** Como se describe a continuación, la solicitud `POST` real no incluye las cabeceras `Access-Control-Request-*`. Estas solo son necesarias para la solicitud `OPTIONS`.
+> [!NOTE]
+> Como se describe a continuación, la solicitud `POST` real no incluye las cabeceras `Access-Control-Request-*`. Estas solo son necesarias para la solicitud `OPTIONS`.
 
 Veamos el intercambio completo entre cliente y servidor. El primer intercambio es la solicitud/respuesta verificadas previamente:
 
@@ -269,7 +272,8 @@ Sin embargo, si se trata de una solicitud que desencadena una verificación prev
 
 ### Solicitudes con credenciales
 
-> **Nota:** Cuando se realicen peticiones con credenciales a un dominio diferente, se seguirán aplicando las políticas de cookies de terceros. La política siempre se aplica independientemente de cualquier configuración en el servidor y el cliente, como se describe en este capítulo.
+> [!NOTE]
+> Cuando se realicen peticiones con credenciales a un dominio diferente, se seguirán aplicando las políticas de cookies de terceros. La política siempre se aplica independientemente de cualquier configuración en el servidor y el cliente, como se describe en este capítulo.
 
 La capacidad más interesante expuesta por {{domxref("XMLHttpRequest")}} o [Fetch](/es/docs/Web/API/Fetch_API) y CORS es la capacidad de hacer peticiones "con credenciales" que son conscientes de las [cookies HTTP](/es/docs/Web/HTTP/Cookies) y de la información de autentificación HTTP. Por defecto, en las invocaciones `XMLHttpRequest` o [Fetch](/es/docs/Web/API/Fetch_API) de origen cruzado, los navegadores **no** enviarán credenciales. Debe establecerse un indicador específico en el objeto `XMLHttpRequest` o en el constructor {{domxref("Request")}} cuando se invoca.
 
@@ -331,7 +335,8 @@ Aunque la línea 10 contiene la Cookie destinada al contenido en `https://bar.ot
 
 La solicitudes CORS de verificación previa nunca deben incluir credenciales. La respuesta a una solicitud de verificación previa debe especificar `Access-Control-Allow-Credentials: true` para indicar que la solicitud real se puede realizar con credenciales.
 
-> **Nota:** Algunos servicios de autenticación de empresas exigen que se envíen certificados de cliente TLS en las solicitudes de verificación previa, lo que contraviene la especificación [Fetch](https://fetch.spec.whatwg.org/#cors-protocol-and-credentials).
+> [!NOTE]
+> Algunos servicios de autenticación de empresas exigen que se envíen certificados de cliente TLS en las solicitudes de verificación previa, lo que contraviene la especificación [Fetch](https://fetch.spec.whatwg.org/#cors-protocol-and-credentials).
 >
 > Firefox 87 permite habilitar este comportamiento no conforme configurando la preferencia: `network.cors_preflight.allow_client_cert` en `true` ([error 1511151 en Firefox](https://bugzil.la/1511151)). Actualmente, los navegadores basados en Chromium siempre envían certificados de cliente TLS en solicitudes de verificación previa de CORS ([error 775438 en Chrome](https://crbug.com/775438)).
 
@@ -452,7 +457,8 @@ Origin: <origin>
 
 El origen es una URL que indica el servidor desde el que se inicia la solicitud. No incluye ninguna información de ruta, sólo el nombre del servidor.
 
-> **Nota:** El valor de `origin` puede ser `null`.
+> [!NOTE]
+> El valor de `origin` puede ser `null`.
 
 Tenga en cuenta que en cualquier solicitud de control de acceso, la cabecera {{HTTPHeader("Origin")}} **siempre** es enviada.
 

--- a/files/es/web/http/headers/authorization/index.md
+++ b/files/es/web/http/headers/authorization/index.md
@@ -27,7 +27,8 @@ Authorization: <tipo> <credenciales>
   - : Si se utiliza el esquema de la autenticación "Basic", las credenciales son construidas de esta forma:
     - El usuario y la contraseña se combinan con dos puntos (`aladdin:opensesame`).
     - El string resultante está basado en la codificación [base64](/es/docs/Web/API/WindowBase64/Base64_encoding_and_decoding) (`YWxhZGRpbjpvcGVuc2VzYW1l`).
-      > **Nota:** ¡La codificación Base64 no es equivalente a encriptación o hashing! Este método es igual de seguro a enviar las credenciales en un archivo plano de texto (la codificación base64 es reversible). Lo recomendable es utilizar HTTPS en conjunto a la autenticación básica.
+      > [!NOTE]
+      > ¡La codificación Base64 no es equivalente a encriptación o hashing! Este método es igual de seguro a enviar las credenciales en un archivo plano de texto (la codificación base64 es reversible). Lo recomendable es utilizar HTTPS en conjunto a la autenticación básica.
 
 ## Ejemplos
 

--- a/files/es/web/http/headers/content-security-policy/index.md
+++ b/files/es/web/http/headers/content-security-policy/index.md
@@ -40,7 +40,8 @@ Content-Security-Policy: <policy-directive>; <policy-directive>
 
   - : Define los origenes válidos para [web workers](/es/docs/Web/API/Web_Workers_API) y contextos de navegación anidados cargados usando elementos como {{HTMLElement("frame")}} and {{HTMLElement("iframe")}}.
 
-    > **Advertencia:** En lugar de **`child-src`**, los autores quienes deseen regular los contextos de navegación anidados y "workers" deberían usar las directivas {{CSP("frame-src")}} y {{CSP("worker-src")}}, respectivamente.
+    > [!WARNING]
+    > En lugar de **`child-src`**, los autores quienes deseen regular los contextos de navegación anidados y "workers" deberían usar las directivas {{CSP("frame-src")}} y {{CSP("worker-src")}}, respectivamente.
 
 - {{CSP("connect-src")}}
   - : Restringe las URLs que pueden ser cargados usando scripts.
@@ -105,7 +106,8 @@ Reporting directives control the reporting process of CSP violations. See also t
 
   - : Instructs the user agent to report attempts to violate the Content Security Policy. These violation reports consist of {{Glossary("JSON")}} documents sent via an HTTP `POST` request to the specified URI.
 
-    > **Advertencia:** Though the {{CSP("report-to")}} directive is intended to replace the deprecated **`report-uri`** directive, {{CSP("report-to")}} isn't supported in most browsers yet. So for compatibility with current browsers while also adding forward compatibility when browsers get {{CSP("report-to")}} support, you can specify both **`report-uri`** and {{CSP("report-to")}}:
+    > [!WARNING]
+    > Though the {{CSP("report-to")}} directive is intended to replace the deprecated **`report-uri`** directive, {{CSP("report-to")}} isn't supported in most browsers yet. So for compatibility with current browsers while also adding forward compatibility when browsers get {{CSP("report-to")}} support, you can specify both **`report-uri`** and {{CSP("report-to")}}:
     >
     > ```
     > Content-Security-Policy: ...; report-uri https://endpoint.example.com; report-to groupname

--- a/files/es/web/http/headers/digest/index.md
+++ b/files/es/web/http/headers/digest/index.md
@@ -38,7 +38,8 @@ Los argoritmos digest, también conocidos como [funciones criptográficas hash](
 
 Este algoritmo se especifica en [FIPS 180-4](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf), sección 6.1, y produce una salida de 160 bits de largo.
 
-> **Advertencia:** Este algoritmo se considera ahora vulnerable y no debe utilizarse para aplicaciones criptográficas.
+> [!WARNING]
+> Este algoritmo se considera ahora vulnerable y no debe utilizarse para aplicaciones criptográficas.
 
 ### SHA-256
 
@@ -52,7 +53,8 @@ Este algoritmo se especifica en [FIPS 180-4](https://nvlpubs.nist.gov/nistpubs/F
 
 Este algoritmo se especifica en [FIPS 180-4](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf), sección 6.4, y produce una salida de 512 bits de largo.
 
-> **Nota:** Sugerencia: Si estás buscando aquí cómo crear un código de autenticación de mensajes "keyed-hash" ([HMAC](/es/docs/Glossary/HMAC)), necesitas usar [SubtleCrypto.sign()](/es/docs/Web/API/SubtleCrypto/sign#HMAC) en su lugar.
+> [!NOTE]
+> Si estás buscando aquí cómo crear un código de autenticación de mensajes "keyed-hash" ([HMAC](/es/docs/Glossary/HMAC)), necesitas usar [SubtleCrypto.sign()](/es/docs/Web/API/SubtleCrypto/sign#HMAC) en su lugar.
 
 ## Ejemplos
 
@@ -105,7 +107,8 @@ console.log(digestHex);
 
 {{Compat}}
 
-> **Nota:** En Chrome 60, se añadió una característica que deshabilita crypto.subtle para conexiones no TLS.
+> [!NOTE]
+> En Chrome 60, se añadió una característica que deshabilita crypto.subtle para conexiones no TLS.
 
 ## Ver también
 

--- a/files/es/web/http/headers/keep-alive/index.md
+++ b/files/es/web/http/headers/keep-alive/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Headers/Keep-Alive
 
 El encabezado **`Keep-Alive`** permite al remitente indicar como será la forma de conexión, se puede establecer un tiempo de espera y una cantidad máxima de solicitudes.
 
-> **Nota:** El encabezado {{HTTPHeader("Connection")}} se tiene que establecer en "keep-alive" para que este encabezado tenga sentido. Además, {{HTTPHeader("Connection")}} y {{HTTPHeader("Keep-Alive")}} son ignorados en HTTP/2; la administración de la conexión se realiza mediante otros mecanismos.
+> [!NOTE]
+> El encabezado {{HTTPHeader("Connection")}} se tiene que establecer en "keep-alive" para que este encabezado tenga sentido. Además, {{HTTPHeader("Connection")}} y {{HTTPHeader("Keep-Alive")}} son ignorados en HTTP/2; la administración de la conexión se realiza mediante otros mecanismos.
 
 | Header type                           | {{Glossary("General header")}} |
 | ------------------------------------- | ------------------------------ |

--- a/files/es/web/http/headers/referer/index.md
+++ b/files/es/web/http/headers/referer/index.md
@@ -9,7 +9,8 @@ La cabecera de solicitud **`Referer`** ("referente") contiene la dirección de l
 
 Observe que _referer_ es una grafía errónea de la palabra _referrer_. Consulte [<em>HTTP referer</em> en Wikipedia](https://es.wikipedia.org/wiki/HTTP_referer) para obtener más información.
 
-> **Advertencia:** La cabecera `Referer` tiene el potencial de revelar información sobre el histórico de navegación del usuario, lo cual constituye un problema de privacidad.
+> [!WARNING]
+> La cabecera `Referer` tiene el potencial de revelar información sobre el histórico de navegación del usuario, lo cual constituye un problema de privacidad.
 
 Los navegadores no envían ninguna cabecera `Referer` si:
 

--- a/files/es/web/http/headers/referrer-policy/index.md
+++ b/files/es/web/http/headers/referrer-policy/index.md
@@ -55,7 +55,8 @@ Referrer-Policy: unsafe-url
 
   - : Se enviará un URL completo al realizarse una solicitud de origen equivalente o de origen transversal.
 
-    > **Nota:** Esta directiva filtrará los orígenes y las rutas de acceso de recursos protegidos por TLS a orígenes inseguros. Estudie atentamente el impacto resultante de esta configuración.
+    > [!NOTE]
+    > Esta directiva filtrará los orígenes y las rutas de acceso de recursos protegidos por TLS a orígenes inseguros. Estudie atentamente el impacto resultante de esta configuración.
 
 ## Ejemplos
 

--- a/files/es/web/http/headers/set-cookie/index.md
+++ b/files/es/web/http/headers/set-cookie/index.md
@@ -70,7 +70,8 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
     Si no está especificado, la cookie tendrá el tiempo de vida de una **session cookie.** Una sesión finaliza cuando el cliente lo culmina, esto quiere decir que la sesión será removida en ese punto.
 
-    > **Advertencia:** Sin embargo, muchos navegadores web tiene una caracteristica llamada "restaurar" que almacenará todas tus pestañas para tenerlas lista cuando el navegador sea usado nuevamente. Las cookies de sesión tambien estarán presentes como si nunca se hubiera cerrado el navegador.
+    > [!WARNING]
+    > Sin embargo, muchos navegadores web tiene una caracteristica llamada "restaurar" que almacenará todas tus pestañas para tenerlas lista cuando el navegador sea usado nuevamente. Las cookies de sesión tambien estarán presentes como si nunca se hubiera cerrado el navegador.
 
     Cuando una fecha de Expires es definida, la fecha límite es relativa al _cliente_ donde la cookie se define, no en el servidor.
 
@@ -91,7 +92,8 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
   - : Una cookie segura es sólo enviada al servidor cuando una petición es enviada con el esquema `https:`. (Sin embargo, información confidencial nunca debería ser almacenada en Cookies HTTP, como todo el mecanismo es However, confidential information should never be stored in HTTP Cookies, ya que todo el mecanismo es inherentemente inseguro y no encripta ninguna información.)
 
-    > **Nota:** Sitios inseguros (`http:`) no puenden almacenar directivas "seguras" apartir de Chrome 52+ y Firefox 52+.
+    > [!NOTE]
+    > Sitios inseguros (`http:`) no puenden almacenar directivas "seguras" apartir de Chrome 52+ y Firefox 52+.
 
 - `HttpOnly` {{optional_inline}}
   - : Impide que el código JavaScript acceda a la cookie. Por ejemplo, a través de la propiedad {{domxref("Document.cookie")}}, y la API {{domxref("XMLHttpRequest")}}, o la API {{domxref("Request")}}. Esto mitiga los ataques contra scripts cross-site ({{Glossary("XSS")}}).
@@ -105,7 +107,8 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
     Afirma que una cookie no debe ser enviada con peticiones cruzadas, proveiendo alguna protección contra ataques de falsificación de solicitudes cruzadas ({{Glossary("CSRF")}}).
 
-    > **Nota:** Los navegadores haciendo migraciones para que el comportamiento por defecto de las cookies en lugar de [default sea `SameSite=Lax`](https://www.chromestatus.com/feature/5088147346030592). Si una cookie necesita ser enviada en peticiones cruzadas, se tiene que optar por no restringir el mismo sitio (SameSite) usando la directiva `None`. La directiva `None` requiere el atributo [`Secure`](#Secure).
+    > [!NOTE]
+    > Los navegadores haciendo migraciones para que el comportamiento por defecto de las cookies en lugar de [default sea `SameSite=Lax`](https://www.chromestatus.com/feature/5088147346030592). Si una cookie necesita ser enviada en peticiones cruzadas, se tiene que optar por no restringir el mismo sitio (SameSite) usando la directiva `None`. La directiva `None` requiere el atributo [`Secure`](#Secure).
 
 ## Ejemplos
 
@@ -153,7 +156,8 @@ Los nombres de las cookies prefijadas con `__Secure-` o `__Host-` pueden ser sol
 
 Además, cookies con el prefijo `__Host-` deben tener una ruta de `/` (significando cualquier ruta del huésped) y no debe tener un atributo `Domain`.
 
-> **Advertencia:** Para clientes que no implementan prefijos para las cookies, no se puede contar con que estas garantías adicionales, y las cookies prefijadas sean aceptadas.
+> [!WARNING]
+> Para clientes que no implementan prefijos para las cookies, no se puede contar con que estas garantías adicionales, y las cookies prefijadas sean aceptadas.
 
 ```
 // Ambas aceptadas al venir de un origen seguro (HTTPS)

--- a/files/es/web/http/headers/strict-transport-security/index.md
+++ b/files/es/web/http/headers/strict-transport-security/index.md
@@ -36,7 +36,8 @@ Esto habilita el potencial ataque man-in-the-middle, donde el redireccionamiento
 
 El encabezado HTTP Strict Transport Security permite a un sitio web informar al navegador que nunca cargue el sitio usando HTTP y que debe automáticamente convertir todos los intentos de acceso HTTP a HTTPS.
 
-> **Nota:** El encabezado `Strict-Transport-Security` es **ignorado** por el navegador cuando el sitio es accedido usando HTTP; esto es porque un atacante podría interceptar las conexiones HTTP e inyectar el encabezado o removerlo. Cuando el sitio es accedido a través de HTTPS con un certificado sin errores, el navegador sabe que el sitio es capaz de usar HTTPS y cumple con lo indicado en el encabezado `Strict-Transport-Security`.
+> [!NOTE]
+> El encabezado `Strict-Transport-Security` es **ignorado** por el navegador cuando el sitio es accedido usando HTTP; esto es porque un atacante podría interceptar las conexiones HTTP e inyectar el encabezado o removerlo. Cuando el sitio es accedido a través de HTTPS con un certificado sin errores, el navegador sabe que el sitio es capaz de usar HTTPS y cumple con lo indicado en el encabezado `Strict-Transport-Security`.
 
 ### Un escenario de ejemplo
 

--- a/files/es/web/http/headers/user-agent/index.md
+++ b/files/es/web/http/headers/user-agent/index.md
@@ -9,7 +9,8 @@ l10n:
 
 El **User-Agent** {{Glossary("request header")}} es una cadena característica que le permite a los servidores y servicios de red identificar la aplicación, sistema operativo, compañía, y/o la versión del {{Glossary("user agent")}} que hace la petición.
 
-> **Advertencia:** Por favor lee [Detección de navegadores usando el agente de usuario](/es/docs/Web/HTTP/Browser_detection_using_the_user_agent) para entender por qué generalmente es una mala idea servir diferentes páginas Web o servicios dependiendo del navegador.
+> [!WARNING]
+> Por favor lee [Detección de navegadores usando el agente de usuario](/es/docs/Web/HTTP/Browser_detection_using_the_user_agent) para entender por qué generalmente es una mala idea servir diferentes páginas Web o servicios dependiendo del navegador.
 
 <table class="properties">
  <tbody>

--- a/files/es/web/http/headers/x-frame-options/index.md
+++ b/files/es/web/http/headers/x-frame-options/index.md
@@ -9,7 +9,8 @@ El encabezado de respuesta [HTTP](/es/docs/Web/HTTP) **`X-Frame-Options`** puede
 
 La seguridad añadida sólo es proporcionada si el usuario que está accediendo al documento está utilizando un navegador que soporte `X-Frame-Options`.
 
-> **Nota:** El encabezado HTTP {{HTTPHeader("Content-Security-Policy")}} tiene una directiva {{HTTPHeader("Content-Security-Policy/frame-ancestors", "frame-ancestors")}} que deja [obsoleto](https://www.w3.org/TR/CSP2/#frame-ancestors-and-frame-options) este encabezado para los navegadores compatibles.
+> [!NOTE]
+> El encabezado HTTP {{HTTPHeader("Content-Security-Policy")}} tiene una directiva {{HTTPHeader("Content-Security-Policy/frame-ancestors", "frame-ancestors")}} que deja [obsoleto](https://www.w3.org/TR/CSP2/#frame-ancestors-and-frame-options) este encabezado para los navegadores compatibles.
 
 <table class="properties">
   <tbody>
@@ -46,7 +47,8 @@ Si especifica `DENY`, fallarán no sólo los intentos de cargar la página en un
 
 ## Ejemplos
 
-> **Nota:** ¡Configurar X-Frame-Options en el tag {{HTMLElement("meta")}} es inútil! Por ejemplo, `<meta http-equiv="X-Frame-Options" content="deny">` no tiene efecto. ¡No lo use! `X-Frame-Options` sólo funcionará configurandolo a tráves del encabezado HTTP, como en los ejemplos a continuación.
+> [!NOTE]
+> ¡Configurar X-Frame-Options en el tag {{HTMLElement("meta")}} es inútil! Por ejemplo, `<meta http-equiv="X-Frame-Options" content="deny">` no tiene efecto. ¡No lo use! `X-Frame-Options` sólo funcionará configurandolo a tráves del encabezado HTTP, como en los ejemplos a continuación.
 
 ### Configurando Apache
 

--- a/files/es/web/http/protocol_upgrade_mechanism/index.md
+++ b/files/es/web/http/protocol_upgrade_mechanism/index.md
@@ -50,7 +50,8 @@ HTTP2-Settings: base64EncodedSettings
 
 Aquí, `base64EncodedSettings` es una propiedad de HTTP/2 `"SETTINGS"` del contenido de la trama que se expresa en formato `base64url`, seguido de un carácter de igual, `"="`, omitido aquí para que se pudiera incluir en esta cabecera expresada en texto.
 
-> **Nota:** El formato [base64url](https://tools.ietf.org/html/rfc4648#section-5) fno es el mismo que el formato estándar Base64. La única diferencia es que para asegurar que la cadena de caracteres es segura para que pueda usarse con URLs y nombres de archivos, los caracteres 62 y 63 en el alfabeto de este formato se cambian de : `"+"` y `"/"` a: `"-"` (menos) y `"_"` respectivamente.
+> [!NOTE]
+> El formato [base64url](https://tools.ietf.org/html/rfc4648#section-5) fno es el mismo que el formato estándar Base64. La única diferencia es que para asegurar que la cadena de caracteres es segura para que pueda usarse con URLs y nombres de archivos, los caracteres 62 y 63 en el alfabeto de este formato se cambian de : `"+"` y `"/"` a: `"-"` (menos) y `"_"` respectivamente.
 
 Si el servidor no puede hacer el cambio a HTTP/2, este responderá en HTTP/1 como si fuera una petición normal (con los códigos: `"200 OK"` si todo es correcto, o `30x` si quiere hacer una redirección, o `40x` ó `50x` si no puede responder con el recurso pedido). Así una petición de una página que exista será respondida con `"HTTP/1.1 200 OK"` seguido del resto de la cabecera de la página. Si el servidor, si que puede cambiar al protocolo HTTP/2 , la respuesta será: "`HTTP/1.1 101 Switching Protocols"`. A continuación, se presenta un ejemplo de una posible respuesta, a una petición de actualización a HTTP/2.
 
@@ -74,7 +75,8 @@ webSocket = new WebSocket("ws://destination.server.ext", "optionalProtocol");
 
 The {{domxref("WebSocket.WebSocket", "WebSocket()")}} constructor does all the work of creating an initial HTTP/1.1 connection then handling the handshaking and upgrade process for you.
 
-> **Nota:** You can also use the `"wss://"` URL scheme to open a secure WebSocket connection.
+> [!NOTE]
+> You can also use the `"wss://"` URL scheme to open a secure WebSocket connection.
 
 If you need to create a WebSocket connection from scratch, you'll have to handle the handshaking process yourself. After creating the initial HTTP/1.1 session, you need to request the upgrade by adding to a standard request the {{HTTPHeader("Upgrade")}} and {{HTTPHeader("Connection")}} headers, as follows:
 

--- a/files/es/web/http/session/index.md
+++ b/files/es/web/http/session/index.md
@@ -19,7 +19,8 @@ En un protocolo cliente servidor, es siempre el cliente el que establece la cone
 
 En TCP el puerto por defecto, para un servidor HTTP en un computador, es el puerto 80. Se pueden usar otros puertos como el 8000 o el 8080. La URL de la página pedida contiene tanto el nombre del dominio, como el número de puerto, aunque este puede ser omitido, si se trata del puerto 80. Véase la referencia de [Identificación de recursos en la Web](/es/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web) para más detalles.
 
-> **Nota:** El modelo cliente-servidor no permite que el servidor mande datos al cliente sin una petición explicita. Como solución parcial a este problema, los desarrolladores web, usan varias técnicas, como hacer un ping al servidor periódicamente, mediante {{domxref("XMLHTTPRequest")}}, {{domxref("Fetch")}} APIs, o usar la HTML [WebSockets API](/en/WebSockets) o protocolos similares.
+> [!NOTE]
+> El modelo cliente-servidor no permite que el servidor mande datos al cliente sin una petición explicita. Como solución parcial a este problema, los desarrolladores web, usan varias técnicas, como hacer un ping al servidor periódicamente, mediante {{domxref("XMLHTTPRequest")}}, {{domxref("Fetch")}} APIs, o usar la HTML [WebSockets API](/en/WebSockets) o protocolos similares.
 
 ## Mandando una petición
 

--- a/files/es/web/http/status/304/index.md
+++ b/files/es/web/http/status/304/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Status/304
 
 El código HTTP de redirección **`304 Not Modified`** en el response de la petición indica que no hay necesidad de retransmitir los recursos solicitados. Es una redirección implícita a un elemento/recurso de caché.Esto sucede cuando el método de la solicitud es {{glossary("seguro")}} ({{glossary("safe")}}), como en el las peticiones con métodos {{HTTPMethod("GET")}} o {{HTTPMethod("HEAD")}}, o cuando el request (petición) está condicionada y usa la cabecera {{HTTPHeader("If-None-Match")}} o un {{HTTPHeader("If-Modified-Since")}}El response {{HTTPStatus("200")}} `OK` habría incluido los encabezados {{HTTPHeader("Cache-Control")}}, {{HTTPHeader("Content-Location")}}, {{HTTPHeader("Date")}}, {{HTTPHeader("ETag")}}, {{HTTPHeader("Expires")}}, y {{HTTPHeader("Vary")}}.
 
-> **Nota:** Muchos [developer tools' network panels](/es/docs/Tools/Network_Monitor) (paneles de red de desarrollo) de los navegadores crean extraños request que conducen a un "response(respuesta del servidor) `304` ", entonces el acceso al caché local es accesible a los desarrollodares.
+> [!NOTE]
+> Muchos [developer tools' network panels](/es/docs/Tools/Network_Monitor) (paneles de red de desarrollo) de los navegadores crean extraños request que conducen a un "response(respuesta del servidor) `304` ", entonces el acceso al caché local es accesible a los desarrollodares.
 
 ## Status
 

--- a/files/es/web/http/status/400/index.md
+++ b/files/es/web/http/status/400/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Status/400
 
 La respuesta de código de estado del Protocolo de Transferencia de Hipertexto (HTTP) **`400 Bad Request`** indica que el servidor no puede o no procesará la petición debido a algo que es percibido como un error del cliente (p. ej., sintaxis de petición malformada, solicitud inválida de enmarcado de mensajes, o enrutamiento engañoso de peticiones).
 
-> **Advertencia:** El cliente no debería repetir esta petición sin modificarla.
+> [!WARNING]
+> El cliente no debería repetir esta petición sin modificarla.
 
 ## Estado
 

--- a/files/es/web/http/status/404/index.md
+++ b/files/es/web/http/status/404/index.md
@@ -31,7 +31,8 @@ ErrorDocument 404 /no-encontrado.html
 
 Para una pagina 404 de ejemplo, mire la pagina [MDN 404](/es/404).
 
-> **Nota:** Diseños personalizados son buenos, si se usan de manera moderada. Siente libre de hacer tus paginas 404 humoristicas y humanas, pero no confundas a tus usuarios.
+> [!NOTE]
+> Diseños personalizados son buenos, si se usan de manera moderada. Siente libre de hacer tus paginas 404 humoristicas y humanas, pero no confundas a tus usuarios.
 
 ## Especificaciones
 

--- a/files/es/web/http/status/408/index.md
+++ b/files/es/web/http/status/408/index.md
@@ -11,7 +11,8 @@ Un servidor debe enviar "close" en el campo de la cabecera {{HTTPHeader("Connect
 
 Esta respuesta es usada mucho más desde que algunos navegadores, como Chrome, Firefox 27+, y IE9, usan el mecanizmo de pre-conexión HTTP para acelerar la naveación.
 
-> **Nota:** Algunos servidores simplemente cierran la conexión sin enviar este mensaje.
+> [!NOTE]
+> Algunos servidores simplemente cierran la conexión sin enviar este mensaje.
 
 ## Estado
 

--- a/files/es/web/http/status/502/index.md
+++ b/files/es/web/http/status/502/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Status/502
 
 El código de respuesta de error del servidor de HTTP **`502 Bad Gateway`** indica que el servidor, mientras actuaba como una puerta de enlace o proxy, recibió una respuesta no válida del servidor ascendente.
 
-> **Nota:** Una [puerta de enlace](https://es.wikipedia.org/wiki/Puerta_de_enlace) puede referirse a cosas distintas en redes y un error 502 no es algo que normalmente puedas arreglar, ya que requiere correcciones por parte del servidor o los proxies a través de los que intentas acceder.
+> [!NOTE]
+> Una [puerta de enlace](https://es.wikipedia.org/wiki/Puerta_de_enlace) puede referirse a cosas distintas en redes y un error 502 no es algo que normalmente puedas arreglar, ya que requiere correcciones por parte del servidor o los proxies a través de los que intentas acceder.
 
 ## Estado
 

--- a/files/es/web/http/status/503/index.md
+++ b/files/es/web/http/status/503/index.md
@@ -9,7 +9,8 @@ El envío de un código de error **`503 Servicio No Disponible`** como respuesta
 
 Las causas más comunes son que el servidor esté apagado por mantenimiento o esté sobrecargado. Esta respuesta debería usarse para condiciones temporales y la cabecera HTTP {{HTTPHeader("Retry-After")}} debería, si es posible, contener el tiempo estimado para la recuperación del servicio.
 
-> **Nota:** debería enviarse con esta respuesta una página informativa explicando el problema.
+> [!NOTE]
+> Debería enviarse con esta respuesta una página informativa explicando el problema.
 
 Debe tenerse cuidado con las cabeceras relacionadas con la caché, ya que un estado 503 suele ser algo temporal, y, por lo tanto, no se deberían almacenar las respuestas en caché.
 

--- a/files/es/web/http/status/504/index.md
+++ b/files/es/web/http/status/504/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Status/504
 
 El código de respuesta de error del servidor de HTTP **`504 Gateway Timeout`** indica que el servidor, mientras actuaba como una puerta de enlace o proxy, no pudo obtener una respuesta a tiempo.
 
-> **Nota:** Una [puerta de enlace](https://es.wikipedia.org/wiki/Puerta_de_enlace) puede referirse a cosas distintas en redes y un error 502 no es algo que normalmente puedas arreglar, ya que requiere correcciones por parte del servidor o los proxies a través de los que intentas acceder.
+> [!NOTE]
+> Una [puerta de enlace](https://es.wikipedia.org/wiki/Puerta_de_enlace) puede referirse a cosas distintas en redes y un error 502 no es algo que normalmente puedas arreglar, ya que requiere correcciones por parte del servidor o los proxies a través de los que intentas acceder.
 
 ## Estado
 

--- a/files/es/web/javascript/closures/index.md
+++ b/files/es/web/javascript/closures/index.md
@@ -244,7 +244,8 @@ console.log(counter2.value()); // 0.
 
 Observa cómo los dos contadores mantienen su independencia el uno del otro. Cada _closure_ hace referencia a una versión diferente de la variable `privateCounter` a través de su propio _closure_. Cada vez que se llama a uno de los contadores, su entorno léxico cambia cambiando el valor de esta variable. Los cambios en el valor de la variable en un _closure_ no afectan el valor en el otro _closure_.
 
-> **Nota:** El uso de _closures_ de esta manera proporciona beneficios que normalmente se asocian con la programación orientada a objetos. En particular, _ocultación de datos_ y _encapsulación_.
+> [!NOTE]
+> El uso de _closures_ de esta manera proporciona beneficios que normalmente se asocian con la programación orientada a objetos. En particular, _ocultación de datos_ y _encapsulación_.
 
 ## Cadena de alcance de closure
 

--- a/files/es/web/javascript/data_structures/index.md
+++ b/files/es/web/javascript/data_structures/index.md
@@ -75,7 +75,8 @@ Infinity
 
 Aunque un `number` a menudo representa solo su valor, JavaScript proporciona {{jsxref("Operators/Bitwise_Operators", "operadores binarios (bitwise)")}}.
 
-> **Nota:** Aunque los operadores bit a bit se _pueden_ usar para representar múltiples valores Booleanos dentro de un solo número usando el [enmascaramiento de bits](<https://es.wikipedia.org/wiki/Máscara_(informática)>), esto generalmente se considera una mala práctica. JavaScript ofrece otros medios para representar un conjunto de valores booleanos (como un arreglo de valores booleanos o un objeto con valores booleanos asignados a propiedades con nombre). El enmascaramiento de bits también tiende a hacer que el código sea más difícil de leer, comprender y mantener.
+> [!NOTE]
+> Aunque los operadores bit a bit se _pueden_ usar para representar múltiples valores Booleanos dentro de un solo número usando el [enmascaramiento de bits](<https://es.wikipedia.org/wiki/Máscara_(informática)>), esto generalmente se considera una mala práctica. JavaScript ofrece otros medios para representar un conjunto de valores booleanos (como un arreglo de valores booleanos o un objeto con valores booleanos asignados a propiedades con nombre). El enmascaramiento de bits también tiende a hacer que el código sea más difícil de leer, comprender y mantener.
 
 Posiblemente sea necesario utilizar estas técnicas en entornos muy restringidos, como cuando se intenta hacer frente a las limitaciones del almacenamiento local, o en casos extremos (como cuando cada bit de la red cuenta). Esta técnica solo se debe considerar cuando sea la última medida que se pueda tomar para optimizar el tamaño.
 
@@ -141,7 +142,8 @@ En JavaScript, los objetos se pueden ver como una colección de propiedades. Con
 
 Hay dos tipos de propiedades de objeto que tienen ciertos atributos: la propiedad _data_ y la propiedad _accessor_.
 
-> **Nota:** Cada propiedad tiene _atributos correspondientes_. Los atributos, internamente los utiliza el motor JavaScript, por lo que no puedes acceder a ellos directamente. Es por eso que los atributos se enumeran entre corchetes dobles, en lugar de simples.Consulta {{jsxref("Object.defineProperty()")}} para obtener más información.
+> [!NOTE]
+> Cada propiedad tiene _atributos correspondientes_. Los atributos, internamente los utiliza el motor JavaScript, por lo que no puedes acceder a ellos directamente. Es por eso que los atributos se enumeran entre corchetes dobles, en lugar de simples.Consulta {{jsxref("Object.defineProperty()")}} para obtener más información.
 
 #### Propiedad `Data`
 

--- a/files/es/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/es/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -36,7 +36,8 @@ while (x < 10) {
 
 Aquí, `{ x++; }` es la declaración de bloque.
 
-> **Nota:** JavaScript anterior a ECMAScript2015 (6a edición) **no** tiene ámbito de bloque. En JavaScript más antiguo, las variables introducidas dentro de un bloque tienen como ámbito la función o script que las contiene, y los efectos de establecerlas persisten más allá del bloque en sí mismo. En otras palabras, las _declaraciones de bloque no definen un ámbito_.
+> [!NOTE]
+> JavaScript anterior a ECMAScript2015 (6a edición) **no** tiene ámbito de bloque. En JavaScript más antiguo, las variables introducidas dentro de un bloque tienen como ámbito la función o script que las contiene, y los efectos de establecerlas persisten más allá del bloque en sí mismo. En otras palabras, las _declaraciones de bloque no definen un ámbito_.
 >
 > Los bloques "independientes" en JavaScript pueden producir resultados completamente diferentes de los que producirían en C o Java. Por ejemplo:
 >
@@ -135,7 +136,8 @@ Los siguientes valores se evalúan como `false` (también conocidos como valores
 
 Todos los demás valores, incluidos todos los objetos, se evalúan como `true` cuando se pasan a una declaración condicional.
 
-> **Nota:** ¡No confundas los valores booleanos primitivos `true` y `false` con los valores `true` y `false` del objeto {{JSxRef("Boolean")}}!.Por ejemplo:```js
+> [!NOTE]
+> ¡No confundas los valores booleanos primitivos `true` y `false` con los valores `true` y `false` del objeto {{JSxRef("Boolean")}}!.Por ejemplo:```js
 > var b = new Boolean(false);
 > if (b) // esta condición se evalúa como verdadera
 > if (b == true) // esta condición se evalúa como false
@@ -261,7 +263,8 @@ throw {
 };
 ```
 
-> **Nota:** Puedes especificar un objeto cuando lanzas una excepción. A continuación, puedes hacer referencia a las propiedades del objeto en el bloque `catch`.
+> [!NOTE]
+> Puedes especificar un objeto cuando lanzas una excepción. A continuación, puedes hacer referencia a las propiedades del objeto en el bloque `catch`.
 
 ```js
 // Crea un objeto tipo de UserException
@@ -348,7 +351,8 @@ try {
 }
 ```
 
-> **Nota:** Cuando se registran errores en la consola dentro de un bloque `catch`, se usa `console.error()` en lugar de `console.log()` aconsejado para la depuración. Formatea el mensaje como un error y lo agrega a la lista de mensajes de error generados por la página.
+> [!NOTE]
+> Cuando se registran errores en la consola dentro de un bloque `catch`, se usa `console.error()` en lugar de `console.log()` aconsejado para la depuración. Formatea el mensaje como un error y lo agrega a la lista de mensajes de error generados por la página.
 
 #### El bloque `finally`
 

--- a/files/es/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/es/web/javascript/guide/expressions_and_operators/index.md
@@ -129,7 +129,8 @@ var var2 = 4;
 | {{JSxRef("Operadores/Comparison_Operators", "Menor que", "#Operador_menor_que")}} (`<`)                  | Devuelve `true` si el operando izquierdo es menor que el operando derecho.                                                                                                    | `var1 < var2`<br>`"2" < 12`                |
 | {{JSxRef("Operadores/Comparison_Operators", "Menor o igual", "#Operador_menor_que_o_igual")}} (`<=`)     | Devuelve `true` si el operando izquierdo es menor o igual que el operando derecho.                                                                                            | `var1 <= var2 var2 <= 5`                   |
 
-> **Nota:** (**=>**) no es un operador, sino la notación para {{JSxRef("Funciones/Arrow_functions", "Funciones flecha")}}.
+> [!NOTE]
+> (**=>**) no es un operador, sino la notación para {{JSxRef("Funciones/Arrow_functions", "Funciones flecha")}}.
 
 ### Operadores aritméticos
 

--- a/files/es/web/javascript/guide/functions/index.md
+++ b/files/es/web/javascript/guide/functions/index.md
@@ -144,7 +144,8 @@ function square(n) {
 
 El ámbito de una función es la función en la que se declara (o el programa completo, si se declara en el nivel superior).
 
-> **Nota:** Esto solo trabaja cuando se define la función usando la sintaxis anterior (es decir, `function funcName() {}`). El siguiente código no trabajará.Esto significa que la elevación de función solo trabaja con _declaraciones_ de función, no con _expresiones_ de función.
+> [!NOTE]
+> Esto solo trabaja cuando se define la función usando la sintaxis anterior (es decir, `function funcName() {}`). El siguiente código no trabajará.Esto significa que la elevación de función solo trabaja con _declaraciones_ de función, no con _expresiones_ de función.
 >
 > ```js example-bad
 > console.log(square) // square se eleva con un valor inicial undefined.
@@ -483,7 +484,8 @@ var getCode = (function () {
 getCode(); // Devuelve el apiCode
 ```
 
-> **Nota:** ¡Hay una serie de trampas a tener en cuenta al usar cierres!
+> [!NOTE]
+> ¡Hay una serie de trampas a tener en cuenta al usar cierres!
 >
 > Si una función encerrada define una variable con el mismo nombre que una variable en el ámbito externo, entonces no hay forma de hacer referencia a la variable en el ámbito externo nuevamente. (La variable de ámbito interno "anula" la externa, hasta que el programa sale de el ámbito interno).
 >
@@ -538,7 +540,8 @@ myConcat("; ", "elephant", "giraffe", "lion", "cheetah");
 myConcat(". ", "salvia", "albahaca", "orégano", "pimienta", "perejil");
 ```
 
-> **Nota:** La variable `arguments` es "similar a un arreglo", pero no es un arreglo. Es similar a un arreglo en el sentido de que tiene un índice numerado y una propiedad `length`. Sin embargo, _no_ posee todos los métodos de manipulación de arreglos.
+> [!NOTE]
+> La variable `arguments` es "similar a un arreglo", pero no es un arreglo. Es similar a un arreglo en el sentido de que tiene un índice numerado y una propiedad `length`. Sin embargo, _no_ posee todos los métodos de manipulación de arreglos.
 
 Consulta el objeto {{JSxRef("Function")}} en la referencia de JavaScript para obtener más información.
 

--- a/files/es/web/javascript/guide/grammar_and_types/index.md
+++ b/files/es/web/javascript/guide/grammar_and_types/index.md
@@ -23,7 +23,8 @@ En JavaScript, las instrucciones se denominan {{Glossary("Statement", "declaraci
 
 No es necesario un punto y coma después de una declaración si está escrita en su propia línea. Pero si se deseas más de una declaración en una línea, entonces _debes_ separarlas con punto y coma.
 
-> **Nota:** ECMAScript también tiene reglas para la inserción automática del punto y coma —{{JSxRef("Gramatica_lexica", "IAPC", "#Insercion_automatica_de_punto_y_coma")}}— (_ASI_ en inglés, por sus siglas «_Automatic Semicolon Insertion_») al final de las declaraciones. (Para obtener más información, consulta la referencia detallada sobre la {{JSxRef("Gramatica_lexica", "gramática léxica")}} de JavaScript).
+> [!NOTE]
+> ECMAScript también tiene reglas para la inserción automática del punto y coma —{{JSxRef("Gramatica_lexica", "IAPC", "#Insercion_automatica_de_punto_y_coma")}}— (_ASI_ en inglés, por sus siglas «_Automatic Semicolon Insertion_») al final de las declaraciones. (Para obtener más información, consulta la referencia detallada sobre la {{JSxRef("Gramatica_lexica", "gramática léxica")}} de JavaScript).
 
 Sin embargo, se considera una buena práctica escribir siempre un punto y coma después de una declaración, incluso cuando no sea estrictamente necesario. Esta práctica reduce las posibilidades de que se introduzcan errores en el código.
 
@@ -45,7 +46,8 @@ La sintaxis de los **comentarios** es la misma que en C++ y en muchos otros leng
 
 Los comentarios se comportan como espacios en blanco y se descartan durante la ejecución del script.
 
-> **Nota:** También puedes ver un tercer tipo de sintaxis de comentario al comienzo de algunos archivos JavaScript, que se parece a esto: `#!/usr/bin/env node`.Esto se denomina sintaxis de **comentario hashbang** y es un comentario especial que se utiliza para especificar la ruta a un motor JavaScript en particular que debe ejecutar el script. Consulta {{JSxRef("Gramatica_lexica", "Comentarios Hashbang", "#Comentarios_hashbang")}} para obtener más detalles.
+> [!NOTE]
+> También puedes ver un tercer tipo de sintaxis de comentario al comienzo de algunos archivos JavaScript, que se parece a esto: `#!/usr/bin/env node`.Esto se denomina sintaxis de **comentario hashbang** y es un comentario especial que se utiliza para especificar la ruta a un motor JavaScript en particular que debe ejecutar el script. Consulta {{JSxRef("Gramatica_lexica", "Comentarios Hashbang", "#Comentarios_hashbang")}} para obtener más detalles.
 
 ## Declaraciones
 
@@ -352,7 +354,8 @@ En el caso que un valor representando un número está en memoria como texto, ha
 
 `parseInt` solo devuelve números enteros, por lo que su uso se reduce para decimales.
 
-> **Nota:** Además, una práctica recomendada para `parseInt` es incluir siempre el parámetro _radix_. El parámetro `radix` se utiliza para especificar qué sistema numérico se utilizará.
+> [!NOTE]
+> Además, una práctica recomendada para `parseInt` es incluir siempre el parámetro _radix_. El parámetro `radix` se utiliza para especificar qué sistema numérico se utilizará.
 
 ```js
 parseInt("101", 2); // 5
@@ -388,11 +391,13 @@ El siguiente ejemplo crea el arreglo `coffees` con tres elementos y `length` de 
 let coffees = ["French Roast", "Colombian", "Kona"];
 ```
 
-> **Nota:** Un arreglo literal es un tipo de _iniciador de objeto_. Consulta {{JSxRef("Guide/Trabajando_con_objectos", "Uso de iniciadores de objetos", "#Uso_de_iniciadores_de_objeto")}}.
+> [!NOTE]
+> Un arreglo literal es un tipo de _iniciador de objeto_. Consulta {{JSxRef("Guide/Trabajando_con_objectos", "Uso de iniciadores de objetos", "#Uso_de_iniciadores_de_objeto")}}.
 
 Si creas un arreglo utilizando un literal en un script de nivel superior, JavaScript interpreta el arreglo cada vez que evalúa la expresión que contiene el arreglo literal. Además, cada vez que llamas a una función se crea un literal usado en ella.
 
-> **Nota:** Los arreglos literales también son objetos `Array`. Consulta {{JSxRef("Array")}} y {{JSxRef("Guide/colecciones_indexadas", "Colecciones indexadas")}} para obtener detalles sobre los objetos `Array`.
+> [!NOTE]
+> Los arreglos literales también son objetos `Array`. Consulta {{JSxRef("Array")}} y {{JSxRef("Guide/colecciones_indexadas", "Colecciones indexadas")}} para obtener detalles sobre los objetos `Array`.
 
 #### Comas adicionales en arreglos literales
 
@@ -412,7 +417,8 @@ Si incluyes una coma al final de la lista de los elementos, la coma es ignorada.
 
 En el siguiente ejemplo, el `length` del arreglo es tres. No hay `myList[3]`. Todas las demás comas de la lista indican un nuevo elemento.
 
-> **Nota:** Las comas finales pueden crear errores en versiones anteriores del navegador y se recomienda eliminarlas.
+> [!NOTE]
+> Las comas finales pueden crear errores en versiones anteriores del navegador y se recomienda eliminarlas.
 
 ```js-nolint
 let myList = ["home", , "school", ];
@@ -438,7 +444,8 @@ Sin embargo, al escribir tu propio código, debes declarar explícitamente los e
 
 El tipo booleano tiene dos valores literales: `true` y `false`.
 
-> **Nota:** No confundas los valores booleanos primitivos `true` y `false` con los valores `true` y `false` del objeto {{JSxRef("Boolean")}}.El objeto `Boolean` es un contenedor alrededor del tipo de dato primitivo `Boolean`. Consulta {{JSxRef("Boolean")}} para obtener más información.
+> [!NOTE]
+> No confundas los valores booleanos primitivos `true` y `false` con los valores `true` y `false` del objeto {{JSxRef("Boolean")}}.El objeto `Boolean` es un contenedor alrededor del tipo de dato primitivo `Boolean`. Consulta {{JSxRef("Boolean")}} para obtener más información.
 
 ### Literales numéricos
 

--- a/files/es/web/javascript/guide/indexed_collections/index.md
+++ b/files/es/web/javascript/guide/indexed_collections/index.md
@@ -43,7 +43,8 @@ let arr = [];
 arr.length = arrayLength;
 ```
 
-> **Nota:** En el código anterior, `arrayLength` debe ser un `Número`. De lo contrario, se creará un arreglo con un solo elemento (el valor proporcionado). Llamar a `arr.length` devolverá `arrayLength`, pero el arreglo no contiene ningún elemento. Un bucle {{jsxref("Statements/for...in", "for...in")}} no encontrarás ninguna propiedad en el arreglo.
+> [!NOTE]
+> En el código anterior, `arrayLength` debe ser un `Número`. De lo contrario, se creará un arreglo con un solo elemento (el valor proporcionado). Llamar a `arr.length` devolverá `arrayLength`, pero el arreglo no contiene ningún elemento. Un bucle {{jsxref("Statements/for...in", "for...in")}} no encontrarás ninguna propiedad en el arreglo.
 
 Además de una variable recién definida como se muestra arriba, los arreglos también se pueden asignar como una propiedad a un objeto nuevo o existente:
 
@@ -94,7 +95,8 @@ let myArray = ["Wind", "Rain", "Fire"];
 
 Puedes referirte al primer elemento del arreglo como `myArray[0]`, al segundo elemento del arreglo como `myArray[1]`, etc… El índice de los elementos comienza en cero.
 
-> **Nota:** También puedes utilizar la [propiedad `accessors`](/es/docs/Web/JavaScript/Reference/Operators/Property_Accessors) para acceder a otras propiedades del arreglo, como con un objeto.
+> [!NOTE]
+> También puedes utilizar la [propiedad `accessors`](/es/docs/Web/JavaScript/Reference/Operators/Property_Accessors) para acceder a otras propiedades del arreglo, como con un objeto.
 >
 > ```js
 > let arr = ["one", "two", "three"];
@@ -113,7 +115,8 @@ emp[1] = "Phil Lesh";
 emp[2] = "August West";
 ```
 
-> **Nota:** Si proporcionas un valor no entero al operador `array` en el código anterior, se creará una propiedad en el objeto que representa al arreglo, en lugar de un elemento del arreglo.
+> [!NOTE]
+> Si proporcionas un valor no entero al operador `array` en el código anterior, se creará una propiedad en el objeto que representa al arreglo, en lugar de un elemento del arreglo.
 >
 > ```js
 > let arr = [];

--- a/files/es/web/javascript/guide/keyed_collections/index.md
+++ b/files/es/web/javascript/guide/keyed_collections/index.md
@@ -107,7 +107,8 @@ for (let item of mySet) console.log(item);
 
 Puedes crear un {{JSxRef("Array")}} a partir de un `Set` usando {{JSxRef("Array.from")}} o el {{JSxRef("Operators/Spread_operator", "operador de propagación")}}. Además, el constructor `Set` acepta un `Array` para convertirlo en la otra dirección.
 
-> **Nota:** Recuerda que los objetos `Set` almacenan _valores únicos_, por lo que cualquier elemento duplicado de un arreglo se elimina al realizar la conversión.
+> [!NOTE]
+> Recuerda que los objetos `Set` almacenan _valores únicos_, por lo que cualquier elemento duplicado de un arreglo se elimina al realizar la conversión.
 
 ```js
 Array.from(mySet);

--- a/files/es/web/javascript/guide/modules/index.md
+++ b/files/es/web/javascript/guide/modules/index.md
@@ -25,7 +25,8 @@ Para demostrar el uso de módulos, hemos creado un [sencillo conjunto de ejemplo
 
 Estos son bastante triviales, pero se han mantenido deliberadamente simples para demostrar los módulos con claridad.
 
-> **Nota:** Si deseas descargar los ejemplos y ejecutarlos localmente, deberás ejecutarlos a través de un servidor web local.
+> [!NOTE]
+> Si deseas descargar los ejemplos y ejecutarlos localmente, deberás ejecutarlos a través de un servidor web local.
 
 ## Estructura básica de los ejemplos
 
@@ -39,7 +40,8 @@ modules/
     square.js
 ```
 
-> **Nota:** Todos los ejemplos de esta guía básicamente tienen la misma estructura; lo anterior debería empezar a resultarte bastante familiar.
+> [!NOTE]
+> Todos los ejemplos de esta guía básicamente tienen la misma estructura; lo anterior debería empezar a resultarte bastante familiar.
 
 Los dos módulos del directorio `modules` se describen a continuación:
 
@@ -131,7 +133,8 @@ se convierte en
 
 Puedes ver estas líneas en acción en [`main.js`](https://github.com/mdn/js-examples/blob/master/module-examples/basic-modules/main.js).
 
-> **Nota:** En algunos sistemas de módulos, puedes omitir la extensión del archivo y el punto (por ejemplo, `'/modules/square'`). Esto no funciona en módulos de JavaScript nativos.
+> [!NOTE]
+> En algunos sistemas de módulos, puedes omitir la extensión del archivo y el punto (por ejemplo, `'/modules/square'`). Esto no funciona en módulos de JavaScript nativos.
 
 Una vez que hayas importado las funciones a tu script, las puedes usar tal como se definieron dentro del mismo archivo. Lo siguiente se encuentra en `main.js`, debajo de las líneas `import`:
 
@@ -144,7 +147,8 @@ reportArea(square1.length, reportList);
 reportPerimeter(square1.length, reportList);
 ```
 
-> **Nota:** Aunque las funciones importadas están disponibles en el archivo, son vistas de solo lectura de la función que se exportó. No puedes cambiar la variable que se importó, pero aún puedes modificar propiedades similares a `const`. Además, estas características se importan como enlaces activos, lo cual significa que pueden cambiar de valor incluso si no puedes modificar el enlace a diferencia de `const`.
+> [!NOTE]
+> Aunque las funciones importadas están disponibles en el archivo, son vistas de solo lectura de la función que se exportó. No puedes cambiar la variable que se importó, pero aún puedes modificar propiedades similares a `const`. Además, estas características se importan como enlaces activos, lo cual significa que pueden cambiar de valor incluso si no puedes modificar el enlace a diferencia de `const`.
 
 ## Aplicar el módulo a tu HTML
 
@@ -208,7 +212,8 @@ Una vez más, ten en cuenta la falta de llaves. Esto se debe a que solo se permi
 import { default as randomSquare } from "./modules/square.js";
 ```
 
-> **Nota:** La sintaxis as para cambiar el nombre de los elementos exportados se explica a continuación en la sección [Renombrar importaciones y exportaciones](#Renombrar_impotaciones_y_exportaciones).
+> [!NOTE]
+> La sintaxis as para cambiar el nombre de los elementos exportados se explica a continuación en la sección [Renombrar importaciones y exportaciones](#Renombrar_impotaciones_y_exportaciones).
 
 ## Evitar conflictos de nombres
 
@@ -428,7 +433,8 @@ export { Circle } from "./shapes/circle.js";
 
 Estas toman las exportaciones de los submódulos individuales y las ponen a disposición de manera efectiva desde el módulo `shapes.js`.
 
-> **Nota:** Las exportaciones a las que se hace referencia en `shapes.js` básicamente se redirigen a través del archivo y realmente no existen allí, por lo que no podrás escribir ningún código relacionado útil dentro del mismo archivo.
+> [!NOTE]
+> Las exportaciones a las que se hace referencia en `shapes.js` básicamente se redirigen a través del archivo y realmente no existen allí, por lo que no podrás escribir ningún código relacionado útil dentro del mismo archivo.
 
 Entonces, ahora en el archivo `main.js`, podemos obtener acceso a las tres clases de módulos reemplazando
 

--- a/files/es/web/javascript/guide/regular_expressions/assertions/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/assertions/index.md
@@ -63,7 +63,8 @@ La siguiente sección también está duplicada en {{JSxRef("../Guide/Regular_Exp
 
 ### Otras aserciones
 
-> **Nota:** El caracter `?` también se puede utilizar como cuantificador.
+> [!NOTE]
+> El caracter `?` también se puede utilizar como cuantificador.
 
 | Caracteres | Significado                                                                                                                                                                                                                                                                                                                                |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/files/es/web/javascript/guide/regular_expressions/cheatsheet/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/cheatsheet/index.md
@@ -186,7 +186,8 @@ Si deseas contribuir a este documento, edita también [el artículo original](/e
 
 ### Otras aserciones
 
-> **Nota:** El caracter `?` también se puede utilizar como cuantificador.
+> [!NOTE]
+> El caracter `?` también se puede utilizar como cuantificador.
 
    <table class="standard-table">
     <thead>
@@ -243,7 +244,8 @@ Si deseas contribuir a este documento, edita también [el artículo original](/e
 
 Si deseas contribuir a este documento, edita también [el artículo original](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Quantifiers)
 
-> **Nota:** A continuación, _elemento_ se refiere no solo a caracteres singulares, sino que también incluye [clases de caracteres](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes), [escapes de propiedad Unicode](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes), [grupos y rangos](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges).
+> [!NOTE]
+> A continuación, _elemento_ se refiere no solo a caracteres singulares, sino que también incluye [clases de caracteres](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes), [escapes de propiedad Unicode](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes), [grupos y rangos](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges).
 
    <table class="standard-table">
     <thead>
@@ -342,4 +344,5 @@ Consulta también [PropertyValueAliases.txt](https://www.unicode.org/Public/UCD/
 - UnicodePropertyValue
   - : Uno de los fragmentos enumerados en la sección Valores, más adelante. Muchos valores tienen alias o abreviaturas (por ejemplo, el valor `Decimal_Number` para la propiedad `General_Category` se puede escribir cómo `Nd`, `digit`, o `Decimal_number`). Para la mayoría de los valores, la parte `UnicodePropertyName` y el signo igual se pueden omitir. Si se especifica un `UnicodePropertyName`, el valor debe corresponder al tipo de propiedad proporcionado.
 
-> **Nota:** Puesto que hay muchas propiedades y valores disponibles, no las describiremos exhaustivamente aquí, sino que proporcionaremos varios ejemplos.
+> [!NOTE]
+> Puesto que hay muchas propiedades y valores disponibles, no las describiremos exhaustivamente aquí, sino que proporcionaremos varios ejemplos.

--- a/files/es/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -67,7 +67,8 @@ do {
 } while ((match = regexpNames.exec(personList)) !== null);
 ```
 
-> **Nota:** No todos los navegadores admiten esta función; consulta la {{JSxRef("../Guide/Regular_Expressions", "tabla de compatibilidad", "#Compatibilidad_del_navegador")}}.
+> [!NOTE]
+> No todos los navegadores admiten esta función; consulta la {{JSxRef("../Guide/Regular_Expressions", "tabla de compatibilidad", "#Compatibilidad_del_navegador")}}.
 
 ## Especificaciones
 

--- a/files/es/web/javascript/guide/regular_expressions/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/index.md
@@ -31,7 +31,8 @@ Construyes una expresión regular en una de estas dos formas:
 
 Un patrón de expresión regular se compone de caracteres simples, como `/abc/`, o una combinación de caracteres simples y especiales, como `/ab*c/` o `/Capítulo (\d)\.\d*/`. El último ejemplo incluye paréntesis, que se utilizan como dispositivos de memoria. La coincidencia realizada con esta parte del patrón se recuerda para su uso posterior, como se describe en [Uso de grupos](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges#Using_groups).
 
-> **Nota:** Si ya estás familiarizado con las formas de una expresión regular, también puedes leer [la hoja de referencia](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet) para una búsqueda rápida de un patrón/construcción específica.
+> [!NOTE]
+> Si ya estás familiarizado con las formas de una expresión regular, también puedes leer [la hoja de referencia](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet) para una búsqueda rápida de un patrón/construcción específica.
 
 ### Usar patrones simples
 
@@ -284,7 +285,8 @@ La bandera `m` se utiliza para especificar que una cadena de entrada de varias l
 
 ## Ejemplos
 
-> **Nota:** También hay varios ejemplos disponibles en:
+> [!NOTE]
+> También hay varios ejemplos disponibles en:
 >
 > - Las páginas de referencia para {{jsxref("RegExp.exec", "exec()")}}, {{jsxref("RegExp.test", "test()")}}, {{jsxref("String.match", "match()")}}, {{jsxref("String.matchAll", "matchAll()")}}, {{jsxref("String.search", "search()")}}, {{jsxref("String.replace", "replace()")}}, {{jsxref("String.split", "split()")}}
 > - Artículos de esta guía: [clases de caracteres](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes), [aserciones](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions), [grupos y rangos](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges), [cuantificadores](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Quantifiers), [escapes de propiedades Unicode](/es/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes)

--- a/files/es/web/javascript/guide/regular_expressions/quantifiers/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/quantifiers/index.md
@@ -13,7 +13,8 @@ Los cuantificadores indican el número de caracteres o expresiones que deben coi
 
 La siguiente tabla también está duplicada en {{JSxRef("../Guide/Regular_Expressions/Cheatsheet", "esta hoja de referencia")}}. No olvides editarla también, ¡gracias!
 
-> **Nota:** A continuación, _elemento_ se refiere no solo a caracteres individuales, sino que también incluye {{JSxRef("../Guide/Regular_Expressions/Character_Classes", "clases de caracteres")}}, {{JSxRef("../Guide/Regular_Expressions/Unicode_Property_Escapes", "escapes de propiedades Unicode")}}, {{JSxRef("../Guide/Regular_Expressions/Grupos_y_rangos", "grupos y rangos")}}.
+> [!NOTE]
+> A continuación, _elemento_ se refiere no solo a caracteres individuales, sino que también incluye {{JSxRef("../Guide/Regular_Expressions/Character_Classes", "clases de caracteres")}}, {{JSxRef("../Guide/Regular_Expressions/Unicode_Property_Escapes", "escapes de propiedades Unicode")}}, {{JSxRef("../Guide/Regular_Expressions/Grupos_y_rangos", "grupos y rangos")}}.
 
 <table class="standard-table">
     <thead>

--- a/files/es/web/javascript/guide/typed_arrays/index.md
+++ b/files/es/web/javascript/guide/typed_arrays/index.md
@@ -143,7 +143,8 @@ let amountDueView = new Float32Array(buffer, 20, 1);
 
 Luego puedes acceder, por ejemplo, al monto adeudado con `amountDueView[0]`.
 
-> **Nota:** La [Data_structure_alignment](https://es.wikipedia.org/wiki/Data_structure_alignment) en una estructura C depende de la plataforma. Toma precauciones y consideraciones para estas diferencias de relleno.
+> [!NOTE]
+> La [Data_structure_alignment](https://es.wikipedia.org/wiki/Data_structure_alignment) en una estructura C depende de la plataforma. Toma precauciones y consideraciones para estas diferencias de relleno.
 
 ### Conversión a arreglos normales
 

--- a/files/es/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/es/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -19,7 +19,8 @@ Aunque las clases ahora se adoptan ampliamente y se han convertido en un nuevo p
 
 Los objetos en JavaScript son "contenedores" dinámicos de propiedades (referidas como sus **propiedades particulares**). Los objetos en JavaScript poseen un enlace a un objeto prototipo. Al intentar acceder a una propiedad de un objeto, la propiedad no sólo se buscará en el objeto sino en el prototipo del objeto, el prototipo del prototipo, y así sucesivamente hasta que se encuentre una propiedad con un nombre coincidente o el final de la cadena prototipo.
 
-> **Nota:** Siguiendo el estándar ECMAScript, la notación `algunObjeto.[[Prototype]]` se utiliza para designar el prototipo de `algunObjeto.` Se puede acceder y modificar la ranura interna `[[Prototype]]` con las funciones {{jsxref("Object.getPrototypeOf()")}} y {{jsxref("Object.setPrototypeOf()")}} respectivamente. Esto es equivalente al descriptor de acceso de JavaScript [`__proto__`](/es/docs/Web/JavaScript/Reference/Global_Objects/Object/proto), que no es estándar pero está implementado de facto por muchos motores de JavaScript. Para evitar confusiones y al mismo tiempo ser conciso, en nuestra notación evitaremos usar `obj.__proto__` y usaremos `obj.[[Prototype]]` en su lugar. Esto corresponde a `Object.getPrototypeOf(obj)`.
+> [!NOTE]
+> Siguiendo el estándar ECMAScript, la notación `algunObjeto.[[Prototype]]` se utiliza para designar el prototipo de `algunObjeto.` Se puede acceder y modificar la ranura interna `[[Prototype]]` con las funciones {{jsxref("Object.getPrototypeOf()")}} y {{jsxref("Object.setPrototypeOf()")}} respectivamente. Esto es equivalente al descriptor de acceso de JavaScript [`__proto__`](/es/docs/Web/JavaScript/Reference/Global_Objects/Object/proto), que no es estándar pero está implementado de facto por muchos motores de JavaScript. Para evitar confusiones y al mismo tiempo ser conciso, en nuestra notación evitaremos usar `obj.__proto__` y usaremos `obj.[[Prototype]]` en su lugar. Esto corresponde a `Object.getPrototypeOf(obj)`.
 >
 > No debe confundirse con la propiedad de funciones `func.prototype`, que en cambio especifican el `[[Prototype]]` que se asigna a todas las _instancias_ de los objetos creados por la función dada cuando se usa como constructor. Discutiremos la propiedad `prototype` de las funciones constructoras en [una sección posterior](#constructores).
 
@@ -179,7 +180,8 @@ const boxes = [new Box(1), new Box(2), new Box(3)];
 
 Decimos que `new Box(1)` es una _instancia_ creada a partir de la función constructora `Box`. `Box.prototype` no es muy diferente del objeto `boxPrototype` que creamos anteriormente; es simplemente un objeto simple. Cada instancia creada a partir de una función constructora tendrá automáticamente la propiedad [`prototype`](/es/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype) del constructor como su `[[Prototype]]` es decir, `Object.getPrototypeOf(new Box()) === Box.prototype`. `Constructor.prototype` por defecto tiene una propiedad: [`constructor`](/es/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor), que hace referencia a la misma función constructora, es decir,, `Box.prototype.constructor === Box`. Esto permite acceder al constructor original desde cualquier instancia.
 
-> **Nota:** Si la función constructora devuelve un valor no primitivo, ese valor se convertirá en el resultado de la expresión `new`. En este caso, es posible que el `[[Prototype]]` no esté correctamente vinculado, pero esto no debería suceder mucho en la práctica.
+> [!NOTE]
+> Si la función constructora devuelve un valor no primitivo, ese valor se convertirá en el resultado de la expresión `new`. En este caso, es posible que el `[[Prototype]]` no esté correctamente vinculado, pero esto no debería suceder mucho en la práctica.
 
 La función constructora anterior se puede reescribir en [clases](/es/docs/Web/JavaScript/Reference/Classes) de la siguiente manera:
 
@@ -247,7 +249,8 @@ const regexp = new RegExp("abc");
 
 Por ejemplo, los "métodos de array" como [`map()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/map) son simplemente métodos definidos en `Array.prototype`, por lo que están disponibles automáticamente en todas las instancias de la matriz.
 
-> **Advertencia:** Hay un error que solía ser frecuente: extender `Object.prototype` o uno de los otros prototipos integrados. Un ejemplo de esta característica errónea es definir `Array.prototype.myMethod = function () {...}` y luego usar `myMethod` en todas las instancias de matriz.
+> [!WARNING]
+> Hay un error que solía ser frecuente: extender `Object.prototype` o uno de los otros prototipos integrados. Un ejemplo de esta característica errónea es definir `Array.prototype.myMethod = function () {...}` y luego usar `myMethod` en todas las instancias de matriz.
 >
 > Esta característica errónea se llama _parche de mono_/_monkey patching_. Hacer parche de mono/monkey patching arriesga la compatibilidad futura, porque si el lenguaje agrega este método en el futuro pero con una firma diferente, su código se romperá. Ha provocado incidentes como el [SmooshGate](https://developer.chrome.com/blog/smooshgate?hl=es-419), y puede ser una gran molestia para que el lenguaje avance ya que JavaScript intenta "no romper la web".
 >
@@ -349,7 +352,8 @@ Como se vio arriba, `doSomething()` tiene una propiedad `prototype` predetermina
 }
 ```
 
-> **Nota:** La consola Chrome usa `[[Prototype]]` para indicar el prototipo del objeto, siguiendo los términos de la especificación; Firefox usa `<Prototype>`. Por coherencia usaremos `[[Prototype]]`.
+> [!NOTE]
+> La consola Chrome usa `[[Prototype]]` para indicar el prototipo del objeto, siguiendo los términos de la especificación; Firefox usa `<Prototype>`. Por coherencia usaremos `[[Prototype]]`.
 
 Podemos agregar propiedades al prototipo de `doSomething()`, como se muestra a continuación.
 

--- a/files/es/web/javascript/language_overview/index.md
+++ b/files/es/web/javascript/language_overview/index.md
@@ -11,7 +11,8 @@ Es útil comenzar con una descripción general de la historia del lenguaje. Java
 
 Varios meses después, Microsoft lanzó JScript con Internet Explorer 3. Era un JavaScript prácticamente compatible. Varios meses después de eso, Netscape envió JavaScript a [Ecma International](http://www.ecma-international.org/), una organización europea de estándares, que resultó en la primera edición del estándar {{Glossary("ECMAScript")}} ese año. El estándar recibió una actualización significativa como [ECMAScript edición 3](http://www.ecma-international.org/publications/standards/Ecma-262.htm) en 1999, y se ha mantenido bastante estable desde entonces. La cuarta edición fue abandonada debido a diferencias políticas sobre la complejidad del lenguaje. Muchas partes de la cuarta edición formaron la base para la edición 5 de ECMAScript, publicada en diciembre de 2009, y para la sexta edición principal del estándar, publicada en junio de 2015.
 
-> **Nota:** Debido a que es más familiar, nos referiremos a ECMAScript como "JavaScript" de ahora en adelante.
+> [!NOTE]
+> Debido a que es más familiar, nos referiremos a ECMAScript como "JavaScript" de ahora en adelante.
 
 A diferencia de la mayoría de los lenguajes de programación, el lenguaje JavaScript no tiene un concepto de entrada o salida. Está diseñado para ejecutarse como un lenguaje de `scripting` en un entorno hospedado, y depende del entorno para proporcionar los mecanismos para comunicarse con el mundo exterior. El entorno de alojamiento más común es el navegador, pero también se pueden encontrar intérpretes de JavaScript en una gran lista de otros lugares, incluidos Adobe Acrobat, Adobe Photoshop, imágenes SVG, el motor de widgets de Yahoo, entornos de lado del servidor como [Node.js](http://nodejs.org/), bases de datos NoSQL como [Apache CouchDB](http://couchdb.apache.org/) de código abierto, computadoras integradas, entornos de escritorio completos como [GNOME](http://www.gnome.org/) (una de las IGU —_Interfaz Gráfica de Usuario_— más populares para sistemas operativos GNU/Linux), y otros.
 
@@ -137,7 +138,8 @@ isFinite(-Infinity); // false
 isFinite(NaN); // false
 ```
 
-> **Nota:** Las funciones {{jsxref("Objetos_Globales/parseInt", "parseInt()")}} y {{jsxref("Objetos_Globales/parseFloat", "parseFloat()")}} analizan una cadena hasta que alcancen un caracter que no es válido para el formato de número especificado, luego devuelve el número analizado hasta ese punto. Sin embargo, el operador "+" simplemente convierte la cadena a `NaN` si contiene un caracter no válido. Intenta analizar la cadena "10.2abc" con cada método tú mismo en la consola y comprenderás mejor las diferencias.
+> [!NOTE]
+> Las funciones {{jsxref("Objetos_Globales/parseInt", "parseInt()")}} y {{jsxref("Objetos_Globales/parseFloat", "parseFloat()")}} analizan una cadena hasta que alcancen un caracter que no es válido para el formato de número especificado, luego devuelve el número analizado hasta ese punto. Sin embargo, el operador "+" simplemente convierte la cadena a `NaN` si contiene un caracter no válido. Intenta analizar la cadena "10.2abc" con cada método tú mismo en la consola y comprenderás mejor las diferencias.
 
 ## Strings
 
@@ -474,11 +476,13 @@ obj.for = "Simon"; // Error de sintaxis, porque 'for' es una palabra reservada
 obj["for"] = "Simon"; // trabaja bien
 ```
 
-> **Nota:** A partir de ECMAScript 5, las palabras reservadas se pueden utilizar como nombres de propiedad de objeto "en bruto". Esto significa que no necesitan "vestirse" entre comillas al definir objeto literales. Consulta la [especificación](http://es5.github.io/#x7.6.1) de ES5.
+> [!NOTE]
+> A partir de ECMAScript 5, las palabras reservadas se pueden utilizar como nombres de propiedad de objeto "en bruto". Esto significa que no necesitan "vestirse" entre comillas al definir objeto literales. Consulta la [especificación](http://es5.github.io/#x7.6.1) de ES5.
 
 Para obtener más información sobre objetos y prototipos, consulta {{jsxref("Objetos_Globales/Object/prototype", "Object.prototype")}}. Para obtener una explicación de los prototipos de objetos y las cadenas de prototipos de objetos, consulta [Herencia y la cadena de prototipos](/es/docs/Web/JavaScript/Inheritance_and_the_prototype_chain).
 
-> **Nota:** A partir de ECMAScript 2015, las claves de objeto se pueden definir mediante la variable en notación de corchetes al crearlas. `{[phoneType]: 12345}` es posible en lugar de solo `var userPhone = {}; userPhone[phoneType] = 12345`.
+> [!NOTE]
+> A partir de ECMAScript 2015, las claves de objeto se pueden definir mediante la variable en notación de corchetes al crearlas. `{[phoneType]: 12345}` es posible en lugar de solo `var userPhone = {}; userPhone[phoneType] = 12345`.
 
 ## Arreglos
 
@@ -635,7 +639,8 @@ function avg(...args) {
 avg(2, 3, 4, 5); // 3.5
 ```
 
-> **Nota:** En el código anterior, la variable **args** contiene todos los valores que se pasaron a la función.
+> [!NOTE]
+> En el código anterior, la variable **args** contiene todos los valores que se pasaron a la función.
 >
 > Es importante tener en cuenta que dondequiera que se coloque el operador de parámetro `rest` en una declaración de función, almacenará todos los argumentos _después_ de su declaración, pero no antes. _es decir, function_ _avg(_**firstValue,** _...args)_ almacenará el primer valor pasado a la función en la variable **firstValue** y los argumentos restantes en **args**. Esa es otra característica útil del lenguaje, pero nos lleva a un nuevo problema. La función `avg()` toma una lista de argumentos separados por comas, pero ¿qué sucede si deseas encontrar el promedio de un arreglo? Simplemente, podrías reescribir la función de la siguiente manera:
 
@@ -659,7 +664,8 @@ avg.apply(null, [2, 3, 4, 5]); // 3.5
 
 El segundo argumento de `apply()` es el arreglo que se utilizará como `arguments`; el primero se explicará más adelante. Esto enfatiza el hecho de que las funciones también son objetos.
 
-> **Nota:** Puedes lograr el mismo resultado utilizando el [operador de propagación](/es/docs/Web/JavaScript/Reference/Operators/Spread_operator) en la llamada de función.
+> [!NOTE]
+> Puedes lograr el mismo resultado utilizando el [operador de propagación](/es/docs/Web/JavaScript/Reference/Operators/Spread_operator) en la llamada de función.
 >
 > Por ejemplo: `avg(...numbers)`
 
@@ -728,7 +734,8 @@ Ten en cuenta que las funciones de JavaScript en sí mismas son objetos, como to
 
 ## Objetos personalizados
 
-> **Nota:** Para obtener una descripción más detallada de la programación orientada a objetos en JavaScript, consulta [Introducción a JavaScript orientado a objetos](/es/docs/Web/JavaScript/Introduction_to_Object-Oriented_JavaScript).
+> [!NOTE]
+> Para obtener una descripción más detallada de la programación orientada a objetos en JavaScript, consulta [Introducción a JavaScript orientado a objetos](/es/docs/Web/JavaScript/Introduction_to_Object-Oriented_JavaScript).
 
 En la programación clásica orientada a objetos, los objetos son colecciones de datos y métodos que operan sobre esos datos. JavaScript es un lenguaje basado en prototipos que no contiene una declaración de clase, como la encontrarías en C++ o Java (esto, a veces es confuso para los programadores acostumbrados a lenguajes con una declaración de clase). En cambio, JavaScript usa funciones como clases. Consideremos un objeto `person` con campos `first` y `last name`. Hay dos formas de mostrar el nombre: como "primero último" o como "último, primero". Usando las funciones y objetos que hemos explicado anteriormente, podríamos mostrar los datos de esta manera:
 

--- a/files/es/web/javascript/reference/classes/index.md
+++ b/files/es/web/javascript/reference/classes/index.md
@@ -61,7 +61,8 @@ console.log(Rectangulo.name);
 // output: "Rectangulo2"
 ```
 
-> **Nota:** Las **expresiones** de clase están sujetas a las mismas restricciones de elevación que se describen en la sección [Class declarations](#class_declarations).
+> [!NOTE]
+> Las **expresiones** de clase están sujetas a las mismas restricciones de elevación que se describen en la sección [Class declarations](#class_declarations).
 
 ## Cuerpo de la clase y definición de métodos
 

--- a/files/es/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/es/web/javascript/reference/classes/public_class_fields/index.md
@@ -5,7 +5,8 @@ slug: Web/JavaScript/Reference/Classes/Public_class_fields
 
 {{JsSidebar("Classes")}}
 
-> **Nota:** Las declaraciones de campos públicos y privados son una [característica experimental (en estado 3)](https://github.com/tc39/proposal-class-fields) propuesta por el [TC39](https://tc39.github.io/beta/), el comite de estandares de JavaScript. El soporte y funcionamiento en navegadores es limitado, pero la funcionalidad puede ser usada a través de un paso durante el proceso del build por medio de sistemas como [Babel](https://babeljs.io/). Revise [compat information](#Browser_compatibility) mas abajo.
+> [!NOTE]
+> Las declaraciones de campos públicos y privados son una [característica experimental (en estado 3)](https://github.com/tc39/proposal-class-fields) propuesta por el [TC39](https://tc39.github.io/beta/), el comite de estandares de JavaScript. El soporte y funcionamiento en navegadores es limitado, pero la funcionalidad puede ser usada a través de un paso durante el proceso del build por medio de sistemas como [Babel](https://babeljs.io/). Revise [compat information](#Browser_compatibility) mas abajo.
 
 Los campos públicos y estáticos son propieades editables, enumerables, y configurables. A diferencia de su contraparte privada, estos participan en la herencia de prototipo.
 

--- a/files/es/web/javascript/reference/errors/not_defined/index.md
+++ b/files/es/web/javascript/reference/errors/not_defined/index.md
@@ -17,7 +17,8 @@ ReferenceError: "x" no está definida.
 
 Hay una variable no existente que está siendo referida en algún lugar. Esta variable necesita ser declarada o se debe comprobar su disponibilidad en el {{Glossary("ámbito")}} actual del script.
 
-> **Nota:** Cuando una librería es cargada (como por ejemplo jQuery) asegúrese de que se haya cargado antes de intentar acceder a sus variables, como por ejemplo "$". Ponga la etiqueta {{HTMLElement("script")}}, que carga la librería antes del código que la utiliza.
+> [!NOTE]
+> Cuando una librería es cargada (como por ejemplo jQuery) asegúrese de que se haya cargado antes de intentar acceder a sus variables, como por ejemplo "$". Ponga la etiqueta {{HTMLElement("script")}}, que carga la librería antes del código que la utiliza.
 
 ## Ejemplo
 

--- a/files/es/web/javascript/reference/functions/arguments/index.md
+++ b/files/es/web/javascript/reference/functions/arguments/index.md
@@ -11,9 +11,11 @@ slug: Web/JavaScript/Reference/Functions/arguments
 
 ## Descripción
 
-> **Nota:** Si estás escribiendo código compatible con ES6, entonces se deben preferir los {{jsxref("Functions/rest_parameters", "parámetros resto")}}.
+> [!NOTE]
+> Si estás escribiendo código compatible con ES6, entonces se deben preferir los {{jsxref("Functions/rest_parameters", "parámetros resto")}}.
 
-> **Nota:** "similar a Array" significa que `arguments` tiene una propiedad {{jsxref("Functions/arguments/length", "lenght")}} y propiedades indexadas desde cero, pero no tiene métodos integrados de {{jsxref("Array")}} como {{jsxref("Array.forEach", "forEach()")}} o {{jsxref("Array.map", "map()")}}. Ve la [§Descripción](#Descripción) para obtener más detalles.
+> [!NOTE]
+> "Similar a Array" significa que `arguments` tiene una propiedad {{jsxref("Functions/arguments/length", "lenght")}} y propiedades indexadas desde cero, pero no tiene métodos integrados de {{jsxref("Array")}} como {{jsxref("Array.forEach", "forEach()")}} o {{jsxref("Array.map", "map()")}}. Ve la [§Descripción](#Descripción) para obtener más detalles.
 
 El objeto `arguments` es una variable local disponible en todas las funciones que no son {{jsxref("Functions/Arrow_functions", "funciones flecha")}}. Puedes hacer referencia a los argumentos de una función dentro de esa función utilizando su objeto `arguments`. Tiene entradas para cada argumento con el que se llamó a la función, con el índice de la primera entrada en `0`.
 
@@ -153,7 +155,8 @@ Si bien la presencia de parámetros `rest`, predeterminados o desestructurados n
 
 En el código de modo estricto, el objeto `arguments` se comporta de la misma manera independientemente de que se pasen parámetros `rest`, predeterminados o desestructurados a una función. Es decir, asignar nuevos valores a las variables en el cuerpo de la función no afectará al objeto `arguments`. La asignación de nuevas variables al objeto `arguments` tampoco afectará el valor de las variables.
 
-> **Nota:** No puedes escribir una directiva `"use strict";` en el cuerpo de una definición de función que acepte parámetros `rest`, predeterminados o desestructurados. Si lo haces, generará un {{jsxref("Errors/Strict_Non_Simple_Params", "error de sintaxis")}}.
+> [!NOTE]
+> No puedes escribir una directiva `"use strict";` en el cuerpo de una definición de función que acepte parámetros `rest`, predeterminados o desestructurados. Si lo haces, generará un {{jsxref("Errors/Strict_Non_Simple_Params", "error de sintaxis")}}.
 
 Las funciones no estrictas a las que se les pasan solo parámetros simples (es decir, no parámetros `rest`, predeterminados o desestructurados) sincronizarán el valor de los nuevos valores de las variables en el cuerpo de la función con el objeto `arguments`, y viceversa:
 

--- a/files/es/web/javascript/reference/functions/arguments/length/index.md
+++ b/files/es/web/javascript/reference/functions/arguments/length/index.md
@@ -33,7 +33,8 @@ function adder(base /*, n2, ... */) {
 }
 ```
 
-> **Nota:** Tenga en cuenta la diferencia entre {{jsxref("Function.length")}} y arguments.length
+> [!NOTE]
+> Tenga en cuenta la diferencia entre {{jsxref("Function.length")}} y arguments.length
 
 ## Especificaciones
 

--- a/files/es/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/es/web/javascript/reference/functions/arrow_functions/index.md
@@ -42,7 +42,8 @@ function (a){
 a => a + 100;
 ```
 
-> **Nota:** Como se muestra arriba, los { corchetes }, ( paréntesis ) y "return" son opcionales, pero pueden ser obligatorios.
+> [!NOTE]
+> Como se muestra arriba, los { corchetes }, ( paréntesis ) y "return" son opcionales, pero pueden ser obligatorios.
 
 Por ejemplo, si tienes **varios argumentos** o **ningún argumento**, deberás volver a introducir paréntesis alrededor de los argumentos:
 
@@ -166,7 +167,8 @@ Consulta también ["ES6 en profundidad: funciones flecha" en hacks.mozilla.org](
 
 Una de las razones por las que se introdujeron las funciones flecha fue para eliminar complejidades del ámbito ({{JSxRef("Operadores/this", "this")}}) y hacer que la ejecución de funciones sea mucho más intuitiva.
 
-> **Nota:** Si `this` es un misterio para ti, consulta {{JSxRef("Operadores/this", "este documento")}} para obtener más información sobre cómo funciona `this`. Para resumir, `this` se refiere a la instancia. Las instancias se crean cuando se invoca la palabra clave `new`. De lo contrario, `this` se establecerá —de forma predeterminada— en el {{Glossary("Scope", "ámbito o alcance")}} de window.
+> [!NOTE]
+> Si `this` es un misterio para ti, consulta {{JSxRef("Operadores/this", "este documento")}} para obtener más información sobre cómo funciona `this`. Para resumir, `this` se refiere a la instancia. Las instancias se crean cuando se invoca la palabra clave `new`. De lo contrario, `this` se establecerá —de forma predeterminada— en el {{Glossary("Scope", "ámbito o alcance")}} de window.
 
 En las **funciones tradicionales** de manera predeterminada `this` está en el ámbito de `window`:
 
@@ -215,7 +217,8 @@ f() === window; // o el objeto global
 
 Todas las demás reglas del {{JSxRef("Modo_estricto", "modo estricto")}} se aplican normalmente.
 
-> **Advertencia:** Comprueba las notas sobre el {{JSxRef("Modo_estricto", "modo estricto")}}.
+> [!WARNING]
+> Comprueba las notas sobre el {{JSxRef("Modo_estricto", "modo estricto")}}.
 
 ### Funciones flecha utilizadas como métodos
 

--- a/files/es/web/javascript/reference/functions/index.md
+++ b/files/es/web/javascript/reference/functions/index.md
@@ -103,7 +103,8 @@ function [nombre]([param[, param[, ...param]]]) {
 
 ### La expresión de función flecha (=>)
 
-> **Nota:** Las expresiones de función Flecha son una tecnología experimental, parte de la proposición Harmony (EcmaScript 6) y no son ampliamente implementadas por los navegadores.
+> [!NOTE]
+> Las expresiones de función Flecha son una tecnología experimental, parte de la proposición Harmony (EcmaScript 6) y no son ampliamente implementadas por los navegadores.
 
 Una expresión de función flecha tiene una sintaxis más corta y su léxico se une a este valor (ver {{jsxref("Funciones/Arrow_functions", "arrow functions", "", 1)}} para más detalles):
 
@@ -135,7 +136,8 @@ new Function (arg1, arg2, ... argN, functionBody)
 
 Llamar al contructor Function como una función, sin el operador new, tiene el mismo efecto que llamarlo como un constructor.
 
-> **Nota:** Utilizar el constructor Function no se recomienda, ya que necesita el cuerpo de la función como una cadena, lo cual puede ocasionar que no se optimize correctamente por el motor JS, y puede también causar otros problemas.
+> [!NOTE]
+> Utilizar el constructor Function no se recomienda, ya que necesita el cuerpo de la función como una cadena, lo cual puede ocasionar que no se optimize correctamente por el motor JS, y puede también causar otros problemas.
 
 ## El objeto `arguments`
 
@@ -514,9 +516,11 @@ if (0)
 
 Si se cambia el script para que la condición se convierta en '`if (1)`', se define la función `zero`.
 
-> **Nota:** Aunque esto parece una declaración de función, ésta es en realidad una expresión de función ya que está anidada dentro de otra instrucción. Ver [las diferencias entre las funciones de declaración y de expresión](#constructor_versus_declaration_versus_expression).
+> [!NOTE]
+> Aunque esto parece una declaración de función, ésta es en realidad una expresión de función ya que está anidada dentro de otra instrucción. Ver [las diferencias entre las funciones de declaración y de expresión](#constructor_versus_declaration_versus_expression).
 
-> **Nota:** Algunos motores JavaScript, sin incluir [SpiderMonkey](/es/docs/Mozilla/Projetos/SpiderMonkey), tratan incorrectamente cualquier expresión de función con un nombre como una declaración de función. Esto llevaría a que se definiera `zero` incluso con el siempre-falso("_always-false_") condicional. Una manera más segura de definir funciones condicionalmente es definir la función anónimamente y asignarla a una variable:
+> [!NOTE]
+> Algunos motores JavaScript, sin incluir [SpiderMonkey](/es/docs/Mozilla/Projetos/SpiderMonkey), tratan incorrectamente cualquier expresión de función con un nombre como una declaración de función. Esto llevaría a que se definiera `zero` incluso con el siempre-falso("_always-false_") condicional. Una manera más segura de definir funciones condicionalmente es definir la función anónimamente y asignarla a una variable:
 
 ```js
 if (0)
@@ -531,7 +535,8 @@ En JavaScript, los controladores de eventos [DOM](/es/DOM) son funciones (en opo
 
 Los posibles objetivos de eventos en un documento [HTML](/es/HTML) incluyen: `window` (`Window` objects("objeto de ventana"), including frames("marcos")), `document` (`HTMLDocument` objects("objetos HTMLDocument")), y elementos (`Element` objects("objetos Elemento")). En el [HTML DOM](http://www.w3.org/TR/DOM-Level-2-HTML/), los destinos de evento tienen propiedades de controlador de eventos. Estas propiedades son nombres de eventos en minúsculas con prefijo "on", e.g. `onfocus`. Los eventos [DOM Level 2 Events](http://www.w3.org/TR/DOM-Level-2-Events/) proporcionan una forma alternativa y más sólida de agregar oyentes de eventos.
 
-> **Nota:** Los eventos son parte del DOM, no de JavaScript. (JavaScript simplemente proporciona un enlace al DOM.)
+> [!NOTE]
+> Los eventos son parte del DOM, no de JavaScript. (JavaScript simplemente proporciona un enlace al DOM.)
 
 El ejemplo siguiente asigna una función a un manejador de eventos de "foco"("focus") de ventana.
 
@@ -657,7 +662,8 @@ if ("function" == typeof window.noFunc) {
 }
 ```
 
-> **Nota:** Tenga en cuenta que en la prueba `if`, e utiliza una referencia a `noFunc` aquí no hay paréntesis "()" después del nombre de la función para que la función real no se llame.
+> [!NOTE]
+> Tenga en cuenta que en la prueba `if`, e utiliza una referencia a `noFunc` aquí no hay paréntesis "()" después del nombre de la función para que la función real no se llame.
 
 ### Ver también
 

--- a/files/es/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/es/web/javascript/reference/functions/method_definitions/index.md
@@ -42,7 +42,8 @@ var obj = {
 };
 ```
 
-> **Nota:** La sintaxis abreviada usa funciones con nombre en lugar de funciones anónimas (como en … `foo: function() {}`…). Las funciones con nombre pueden ser llamadas desde el cuerpo de la función (esto es imposible con funciones anónimas, ya que no existe un identificador al que referirse). Para más detalles, ver {{jsxref("Operators/function","function","#Examples")}}.
+> [!NOTE]
+> La sintaxis abreviada usa funciones con nombre en lugar de funciones anónimas (como en … `foo: function() {}`…). Las funciones con nombre pueden ser llamadas desde el cuerpo de la función (esto es imposible con funciones anónimas, ya que no existe un identificador al que referirse). Para más detalles, ver {{jsxref("Operators/function","function","#Examples")}}.
 
 ### Abreviatura de métodos generadores
 

--- a/files/es/web/javascript/reference/functions/set/index.md
+++ b/files/es/web/javascript/reference/functions/set/index.md
@@ -85,7 +85,8 @@ console.log(o.a); // 5
 
 ### Usando un nombre de propiedad computado
 
-> **Nota:** Propiedades computadas son 'experimental technology'_,_ parte de la propuesta para ECMAScript 6, y no está soportado en todos los navegadores. Dará error de sintaxis en entornos no soportados.
+> [!NOTE]
+> Propiedades computadas son 'experimental technology'_,_ parte de la propuesta para ECMAScript 6, y no está soportado en todos los navegadores. Dará error de sintaxis en entornos no soportados.
 
 ```js
 const expr = "foo";

--- a/files/es/web/javascript/reference/global_objects/array/concat/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/concat/index.md
@@ -33,7 +33,8 @@ El método `concat` no altera `this` el array original, ni ninguno de los que fu
 - Referencias a Objetos (no el objeto real): `concat` copia las referencias de objetos en el nuevo array. Ambos, el array original y el nuevo refieren al mismo objeto. Es decir, si un objeto referenciado es modificado, los cambios serán visibles tanto en el array nuevo como en el antiguo.
 - Tipo de de datos como cadenas, números y boleanos (no objetos {{jsxref("Global_Objects/String", "String")}}, {{jsxref("Global_Objects/Number", "Number")}} o {{jsxref("Global_Objects/Boolean", "Boolean")}} objects): `concat` copia los valores de los strings y numeros en el nuevo array.
 
-> **Nota:** Al concatenar arrays o valores no se modificarán los originales. Además, las operaciones en el nuevo array (excepto las operaciones en elementos que son referencias a objetos) no tendrán efecto en el array original, y viceversa.
+> [!NOTE]
+> Al concatenar arrays o valores no se modificarán los originales. Además, las operaciones en el nuevo array (excepto las operaciones en elementos que son referencias a objetos) no tendrán efecto en el array original, y viceversa.
 
 ## Ejemplos
 

--- a/files/es/web/javascript/reference/global_objects/array/findindex/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/findindex/index.md
@@ -39,7 +39,8 @@ El método `findIndex()` ejecuta la función de _`callback`_ una vez por cada í
 
 Si dicho elemento es encontrado, `findIndex()` inmediatamente devuelve el índice del elemento. Si la función _`callback`_ nunca devuelve un valor verdadero (o el tamaño del array es 0), `findIndex` devuelve `-1`.
 
-> **Nota:** A diferencia de otros métodos de arrays como {{jsxref("Array.some()")}}, `callback` se ejecuta incluso en índices sin valores asignados.
+> [!NOTE]
+> A diferencia de otros métodos de arrays como {{jsxref("Array.some()")}}, `callback` se ejecuta incluso en índices sin valores asignados.
 
 _`callback`_ se invoca con tres argumentos:
 

--- a/files/es/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/foreach/index.md
@@ -55,7 +55,8 @@ El rango de elementos procesados por `forEach()` se establece antes de la primer
 
 `foreach()` no muta/modifica el array desde el que es llamado (aunque `callback`, si se invoca, podría hacerlo).
 
-> **Nota:** No hay forma de detener o cortar un bucle `forEach` que no sea lanzar una excepción. Si necesita dicho comportamiento, el método `.forEach()` es la herramienta equivocada, use una simple iteración en su lugar. Si está probando los elementos del array para un predicado y necesita devolver un valor boleano, puede usar {{jsxref("Array.prototype.every()", "every()")}} o {{jsxref("Array.prototype.some()", "some()")}} en su lugar.
+> [!NOTE]
+> No hay forma de detener o cortar un bucle `forEach` que no sea lanzar una excepción. Si necesita dicho comportamiento, el método `.forEach()` es la herramienta equivocada, use una simple iteración en su lugar. Si está probando los elementos del array para un predicado y necesita devolver un valor boleano, puede usar {{jsxref("Array.prototype.every()", "every()")}} o {{jsxref("Array.prototype.some()", "some()")}} en su lugar.
 
 ## Ejemplos
 

--- a/files/es/web/javascript/reference/global_objects/array/includes/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/includes/index.md
@@ -19,7 +19,8 @@ arr.includes(searchElement[, fromIndex])
 
 - `valueToFind`
   - : El valor a buscar.
-    > **Nota:** Al comparar cadenas de texto y caracteres, `includes()` **distingue mayúsculas y minúsculas**.
+    > [!NOTE]
+    > Al comparar cadenas de texto y caracteres, `includes()` **distingue mayúsculas y minúsculas**.
 - `fromIndex` {{optional_inline}}
   - : Posición en la matriz en la cuál se debe comenzar a buscar `valueToFind`; el primer caracter a buscar se encuentra en `fromIndex`. Un valor negativo inicia la búsqueda desde array.length + fromIndex en adelante. El valor por defecto es 0.
 
@@ -27,7 +28,8 @@ arr.includes(searchElement[, fromIndex])
 
 Un {{jsxref ("Boolean")}} que es `true` si el valor `valueToFind` se encuentra dentro de la matriz (o la parte de la matriz indicada por el índice `fromIndex`, si se especifica). Todos los valores de cero se consideran iguales independientemente del signo (es decir, -0 se considera igual a 0 y +0), pero `false` no se considera igual a 0.
 
-> **Nota:** Técnicamente hablando, `include()` usa el algoritmo [`sameValueZero`](/es/docs/Web/JavaScript/Equality_comparisons_and_sameness#Same-value-zero_equality) para determinar si se encuentra el elemento dado
+> [!NOTE]
+> Técnicamente hablando, `include()` usa el algoritmo [`sameValueZero`](/es/docs/Web/JavaScript/Equality_comparisons_and_sameness#Same-value-zero_equality) para determinar si se encuentra el elemento dado
 
 ## Ejemplos
 

--- a/files/es/web/javascript/reference/global_objects/array/indexof/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/indexof/index.md
@@ -7,7 +7,8 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/indexOf
 
 El método **indexOf()** retorna el primer índice en el que se puede encontrar un elemento dado en el array, ó retorna -1 si el elemento no esta presente.
 
-> **Nota:** Para el método String, ver {{jsxref("String.prototype.indexOf()")}}.
+> [!NOTE]
+> Para el método String, ver {{jsxref("String.prototype.indexOf()")}}.
 
 ## Sintaxis
 

--- a/files/es/web/javascript/reference/global_objects/array/join/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/join/index.md
@@ -28,7 +28,8 @@ Una cadena con todos los elementos de la matriz unidos. Si `arr.length` es `0`, 
 
 Las conversiones de cadena de todos los elementos de la matriz se unen en una cadena.
 
-> **Advertencia:** Si un elemento `no está definido` o es `nulo`, se convierte en la cadena vacía.
+> [!WARNING]
+> Si un elemento `no está definido` o es `nulo`, se convierte en la cadena vacía.
 
 ## Ejemplos
 

--- a/files/es/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/slice/index.md
@@ -112,7 +112,8 @@ nuevoCoche[0].color = azul
 
 ## Objetos array-like
 
-> **Nota:** Se dice que un objeto es **array-like** ( similar o que se asemeja a un array) cuando entre sus propiedades existen algunas cuyos nombres son **números** y en particular tiene una propiedad llamada **length**. Este hecho hace suponer que el objeto es algún tipo de colección de elementos indexados por números. Es conveniente, a veces, convertir estos objetos a arrays para otorgarles la funcionalidad que de serie se incorpora en todos los arrays a través de su prototipo.
+> [!NOTE]
+> Se dice que un objeto es **array-like** ( similar o que se asemeja a un array) cuando entre sus propiedades existen algunas cuyos nombres son **números** y en particular tiene una propiedad llamada **length**. Este hecho hace suponer que el objeto es algún tipo de colección de elementos indexados por números. Es conveniente, a veces, convertir estos objetos a arrays para otorgarles la funcionalidad que de serie se incorpora en todos los arrays a través de su prototipo.
 
 El método `slice` puede ser usado para convertir objetos parecidos a arrays o colecciones a un nuevo Array. Simplemente debe enlazar el método al objeto. El {{jsxref("Functions_and_function_scope/arguments", "arguments")}} dentro de una función es un ejemplo de un objeto parecido a arrays.
 

--- a/files/es/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/some/index.md
@@ -7,7 +7,8 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/some
 
 El método **`some()`** comprueba si al menos un elemento del array cumple con la condición implementada por la función proporcionada.
 
-> **Nota:** Este método devuelve `false` para cualquier condición puesta en un array vacío.
+> [!NOTE]
+> Este método devuelve `false` para cualquier condición puesta en un array vacío.
 
 {{EmbedInteractiveExample("pages/js/array-some.html")}}
 

--- a/files/es/web/javascript/reference/global_objects/asyncfunction/index.md
+++ b/files/es/web/javascript/reference/global_objects/asyncfunction/index.md
@@ -39,7 +39,8 @@ Los objetos {{jsxref("Statements/async_function", "async function")}} creados co
 
 Todos los argumentos que son pasados a la función son tratados por los nombres de los identificadores de los parámetros en la función creada, en el orden en que son pasados a la función.
 
-> **Nota:** Las {{jsxref("Statements/async_function", "async functions", "", 1)}} creadas con el constructor `AsyncFunction` no crean
+> [!NOTE]
+> Las {{jsxref("Statements/async_function", "async functions", "", 1)}} creadas con el constructor `AsyncFunction` no crean
 > [_closures_](/es/docs/Web/JavaScript/Closures) en sus contextos creados, siempre son creados en el contexto global.
 >
 > Cuando se ejecutan, solamente podran acceder a sus variables locales y globales, no a las variables de otros contextos en el cual

--- a/files/es/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/es/web/javascript/reference/global_objects/bigint/index.md
@@ -221,7 +221,8 @@ console.log(parsed);
 // { number: 1, big: 18014398509481982n }
 ```
 
-> **Nota:** Si bien es posible hacer el reemplazo de `JSON.stringify()` genérico y propiamente serializar los valores BigInt para todos los objetos, el reviver `JSON.parse()` tiene que ser específico para la forma de carga útil esperada, ya que la serialización tiene _pérdidas_: no es posible distinguir entre una cadena que representa un BigInt y una cadena normal.
+> [!NOTE]
+> Si bien es posible hacer el reemplazo de `JSON.stringify()` genérico y propiamente serializar los valores BigInt para todos los objetos, el reviver `JSON.parse()` tiene que ser específico para la forma de carga útil esperada, ya que la serialización tiene _pérdidas_: no es posible distinguir entre una cadena que representa un BigInt y una cadena normal.
 >
 > Además, el ejemplo de arriba crea un objeto entero en el replacing y reviving, lo que probablemente tenga implicaciónes de rendimiento y almacenamiento para objetos más grandes que contienen muchos BigInts. Si conoces la forma de carga útil esperada, puede ser mejor simplemente serializarlas como strings y revivirlas basadas en el nombre de la key.
 

--- a/files/es/web/javascript/reference/global_objects/boolean/index.md
+++ b/files/es/web/javascript/reference/global_objects/boolean/index.md
@@ -50,7 +50,8 @@ var s = Boolean(myString); // valor inicial de true
 
 No utilices un objeto `Boolean` en lugar de un `Boolean` primitivo.
 
-> **Nota:** Cuando la propiedad no estándar [`document.all`](/es/docs/Web/API/Document#Properties) se usa como argumento para este constructor, el resultado es un objeto `Boolean` con el valor `false`. Esta propiedad es heredada y no estándar y no se debe usar.
+> [!NOTE]
+> Cuando la propiedad no estándar [`document.all`](/es/docs/Web/API/Document#Properties) se usa como argumento para este constructor, el resultado es un objeto `Boolean` con el valor `false`. Esta propiedad es heredada y no estándar y no se debe usar.
 
 ## Constructor
 


### PR DESCRIPTION
This PR converts the noteblocks for the Spanish locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 7. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
