### PR TITLE
fr: Convert noteblocks to GFM Alerts (part 3)

### DIFF
--- a/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -11,7 +11,8 @@ La [référence des en-têtes HTTP](/fr/docs/Web/HTTP/Headers) sur MDN Web Docs 
 
 Vous devrez avoir des connaissances en [HTTP](/fr/docs/Web/HTTP) ou être prêt à vous familiariser avec ses détails.
 
-> **Note :** La documentation de nouvelles en-têtes HTTP doit d'abord avoir lieu en anglais avant de pouvoir traduire le nouveau contenu en français. L'organisation du contenu de MDN ne permet pas de créer du contenu en français si celui-ci n'existe pas déjà en anglais.
+> [!NOTE]
+> La documentation de nouvelles en-têtes HTTP doit d'abord avoir lieu en anglais avant de pouvoir traduire le nouveau contenu en français. L'organisation du contenu de MDN ne permet pas de créer du contenu en français si celui-ci n'existe pas déjà en anglais.
 
 ## Étape 1 - Déterminer l'en-tête HTTP à documenter
 

--- a/files/fr/mdn/writing_guidelines/howto/document_web_errors/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_web_errors/index.md
@@ -11,7 +11,8 @@ La [référence des erreurs JavaScript](/fr/docs/Web/JavaScript/Reference/Errors
 
 Les erreurs JavaScript contiennent un lien «&nbsp;En savoir plus&nbsp;» qui renvoie à la référence de l'erreur JavaScript contenant des conseils supplémentaires pour résoudre les problèmes. Pour pouvoir documenter ces erreurs, vous devez connaître ou être capable de vous plonger dans le [JavaScript](/fr/docs/Web/JavaScript).
 
-> **Note :** La documentation de nouvelles erreurs doit d'abord avoir lieu en anglais avant de pouvoir traduire le nouveau contenu en français. L'organisation du contenu de MDN ne permet pas de créer du contenu en français si celui-ci n'existe pas déjà en anglais.
+> [!NOTE]
+> La documentation de nouvelles erreurs doit d'abord avoir lieu en anglais avant de pouvoir traduire le nouveau contenu en français. L'organisation du contenu de MDN ne permet pas de créer du contenu en français si celui-ci n'existe pas déjà en anglais.
 
 ## Étape 1 - Déterminer l'erreur à documenter
 

--- a/files/fr/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/images_media/index.md
@@ -58,7 +58,8 @@ Prenons un exemple&nbsp;:
 
 Chaque image, `![]` et `<img>`, doit inclure un texte alternatif. Les attributs `alt` doivent être courts et fournir toutes les informations pertinentes que l'image transmet. Lorsque vous écrivez la description de l'image, réfléchissez aux informations précieuses de l'image et à la façon dont vous les transmettriez à quelqu'un qui peut lire le contenu de la page mais ne peut pas charger les images.
 
-> **Note :** Voir [la documentation sur l'attribut `alt` de `<img>` et notamment la façon d'écrire des textes alternatifs pertinents](/fr/docs/Web/HTML/Element/img#écrire_des_descriptions_alternatives_significatives).
+> [!NOTE]
+> Voir [la documentation sur l'attribut `alt` de `<img>` et notamment la façon d'écrire des textes alternatifs pertinents](/fr/docs/Web/HTML/Element/img#écrire_des_descriptions_alternatives_significatives).
 
 Soyez sûr que le texte alternatif de l'image est basé sur son contexte. Si la photo de Fluffy le chien est un avatar à côté d'un avis pour la nourriture pour chien Yuckymeat, `alt="Fluffy"` est approprié. Si la même photo fait partie de la page d'adoption de Fluffy, les informations transmises dans l'image sont pertinentes pour les futurs parents de chiens, telles que `alt="Fluffy, un terrier tricolore à poil très court, avec une balle de tennis dans la bouche."`. Le texte environnant indique probablement la taille et la race de Fluffy, il serait donc redondant de l'inclure. Évitez de décrire l'image avec trop de détails&nbsp;: le futur parent n'a pas besoin de savoir si le chien est à l'intérieur ou à l'extérieur, ou s'il a un collier rouge et une laisse bleue.
 
@@ -102,7 +103,8 @@ Plusieurs arguments s'opposent à l'utilisation de vidéos dans la documentation
 - La vidéo pose des problèmes d'accessibilité&nbsp;: elle est généralement plus coûteuse à produire que le texte, mais surtout à traduire ou à rendre utilisable par les utilisateurs de lecteurs d'écran.
 - Dans le prolongement du dernier point, la vidéo est beaucoup plus difficile à éditer/mettre à jour/maintenir que le contenu textuel.
 
-> **Note :** Il est utile de garder à l'esprit cette problématique, même lorsque vous réalisez des vidéos, afin d'essayer d'en atténuer certains aspects.
+> [!NOTE]
+> Il est utile de garder à l'esprit cette problématique, même lorsque vous réalisez des vidéos, afin d'essayer d'en atténuer certains aspects.
 
 Il existe de nombreux sites populaires qui fournissent de nombreux tutoriels vidéo. MDN n'est pas un site dont la majorité du contenu est de la vidéo, toutefois, il est possible d'intégrer des vidéos dans certains articles MDN selon le contexte.
 
@@ -183,7 +185,8 @@ Planifiez soigneusement les étapes que vous allez enregistrer et pratiquez cett
 
 - Planifiez les niveaux de zoom pour les portions de l'interface utilisateur que vous afficherez. Tout le monde ne pourra pas forcément consulter la vidéo en haute définition. Vous pourrez également zoomer sur certaines parties en post-production mais ça peut être une bonne idée de zoomer dès l'enregistrement.
 
-> **Note :** Ne zoomez pas au point que les éléments d'interfaces soient déformés ou semblent étranges.
+> [!NOTE]
+> Ne zoomez pas au point que les éléments d'interfaces soient déformés ou semblent étranges.
 
 #### Enregistrement
 
@@ -191,7 +194,8 @@ Lorsque vous enregistrez, avancez dans les étapes de façon calme et régulièr
 
 N'oubliez pas de faire une pause d'une ou deux secondes à la fin pour montrer le résultat final de la séquence d'actions.
 
-> **Note :** Si vous utilisez un outil simple comme QuickTime Player ou que vous ne pouvez pas effectuer de post-production, veillez à ce que la fenêtre soit de la bonne taille pour ce que vous voulez montrer.
+> [!NOTE]
+> Si vous utilisez un outil simple comme QuickTime Player ou que vous ne pouvez pas effectuer de post-production, veillez à ce que la fenêtre soit de la bonne taille pour ce que vous voulez montrer.
 
 #### Post-production
 
@@ -210,7 +214,8 @@ Si besoin, redimensionnez la vidéo aux proportions souhaitées.
 
 Actuellement, les vidéos doivent être uploadées sur YouTube afin d'être affichées sur MDN, par exemple sur la chaîne [mozhacks](https://www.youtube.com/user/mozhacks/videos). Demandez à un membre de l'équipe MDN de téléverser la vidéo si vous n'avez pas un meilleur endroit où la stocker.
 
-> **Note :** Marquez la vidéo en «&nbsp;non répertoriée&nbsp;» si celle-ci n'a pas de sens particulier en dehors du contexte de la page MDN.
+> [!NOTE]
+> Marquez la vidéo en «&nbsp;non répertoriée&nbsp;» si celle-ci n'a pas de sens particulier en dehors du contexte de la page MDN.
 
 #### Intégration
 

--- a/files/fr/mdn/writing_guidelines/howto/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/index.md
@@ -9,6 +9,7 @@ l10n:
 
 Cette section porte sur les règles d'écriture sur MDN Web Docs et contient toutes les informations détaillées pour accomplir des tâches spécifiques lors d'une contribution à MDN Web Docs&nbsp;: comment utiliser Markdown, comment ajouter une entrée au glossaire, comment déplacer ou supprimer des pages, et plus encore. Pour en savoir plus sur _comment contribuer_ (via GitHub), consultez nos [directives de contribution](/fr/docs/MDN/Community/Contributing).
 
-> **Note :** Tout au long de cette section, nous supposons que vous avez lu les directives de contribution, que vous connaissez les dépôts `mdn/content` et `mdn/translated-content`, et que vous savez comment utiliser Git et GitHub.
+> [!NOTE]
+> Tout au long de cette section, nous supposons que vous avez lu les directives de contribution, que vous connaissez les dépôts `mdn/content` et `mdn/translated-content`, et que vous savez comment utiliser Git et GitHub.
 
 {{LandingPageListSubpages}}

--- a/files/fr/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -195,7 +195,8 @@ Le bloc de code peut contenir d'autres éléments de type bloc.
 #### Note
 
 ```md
-> **Note :** Voici comment écrire une note.
+> [!NOTE]
+> Voici comment écrire une note.
 >
 > Elle peut avoir plusieurs lignes.
 ```
@@ -211,14 +212,16 @@ Cela produira le HTML suivant&nbsp;:
 
 Ce HTML sera affiché comme une boîte mise en valeur&nbsp;:
 
-> **Note :** Voici comment écrire une note.
+> [!NOTE]
+> Voici comment écrire une note.
 >
 > Elle peut avoir plusieurs lignes.
 
 #### Avertissements
 
 ```md
-> **Attention :** Voici comment écrire un avertissement.
+> [!WARNING]
+> Voici comment écrire un avertissement.
 >
 > Il peut avoir plusieurs paragraphes.
 ```
@@ -234,7 +237,8 @@ Cela produira le HTML suivant&nbsp;:
 
 Ce HTML sera affiché comme une boîte mise en valeur&nbsp;:
 
-> **Attention :** Voici comment écrire un avertissement.
+> [!WARNING]
+> Voici comment écrire un avertissement.
 >
 > Il peut avoir plusieurs paragraphes.
 
@@ -257,7 +261,7 @@ Cela produira le HTML suivant&nbsp;:
 
 Ce HTML sera affiché comme une remarque&nbsp;:
 
-> **Remarque :**
+> [!CALLOUT]
 >
 > **Voici comment écrire un encadré.**
 >
@@ -272,7 +276,8 @@ Les locales sont stockées dans [Yari (dépôt GitHub en anglais)](https://githu
 Par exemple, si nous voulons utiliser «&nbsp;Warnung&nbsp;» pour «&nbsp;Warning&nbsp;» en allemand, alors dans la page allemande nous écririons&nbsp;:
 
 ```md
-> **Warnung:** So schreibt man eine Warnung.
+> [!WARNING]
+> So schreibt man eine Warnung.
 ```
 
 Et cela produira&nbsp;:
@@ -288,7 +293,8 @@ Et cela produira&nbsp;:
 Cet exemple contient un bloc de code.
 
 ````md
-> **Note :** Voici comment écrire une note.
+> [!NOTE]
+> Voici comment écrire une note.
 >
 > Elle peut contenir des blocs de code.
 >
@@ -312,7 +318,8 @@ Cela produira le HTML suivant&nbsp;:
 
 Ce HTML sera affiché comme un bloc de code&nbsp;:
 
-> **Note :** Voici comment écrire une note.
+> [!NOTE]
+> Voici comment écrire une note.
 >
 > Elle peut contenir des blocs de code.
 >

--- a/files/fr/mdn/writing_guidelines/howto/research_technology/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/research_technology/index.md
@@ -44,7 +44,8 @@ De plus, nous disposons du guide sur [les informations contenues dans un fichier
 
 Vous reviendrez souvent à l'écriture d'exemples de code ou à la création de démonstrations au cours de la documentation d'une technologie, mais il est très utile de commencer par se familiariser avec le fonctionnement de celle-ci. C'est un exercice très utile, car il vous permet de bien comprendre les cas d'utilisation (_pourquoi_ une développeuse ou un développeur utiliserait cette technologie) et vous aide à créer des exemples de code en même temps.
 
-> **Note :** Si la spécification a été récemment mise à jour et que, par exemple, une méthode est désormais définie différemment, mais que l'ancienne méthode fonctionne toujours dans les navigateurs, vous devrez souvent documenter les deux au même endroit afin que l'ancienne et la nouvelle méthode soient couvertes. Si vous avez besoin d'aide, référez-vous aux démonstrations que vous avez trouvées ou demandez à un contact de l'équipe qui implémente la technologie.
+> [!NOTE]
+> Si la spécification a été récemment mise à jour et que, par exemple, une méthode est désormais définie différemment, mais que l'ancienne méthode fonctionne toujours dans les navigateurs, vous devrez souvent documenter les deux au même endroit afin que l'ancienne et la nouvelle méthode soient couvertes. Si vous avez besoin d'aide, référez-vous aux démonstrations que vous avez trouvées ou demandez à un contact de l'équipe qui implémente la technologie.
 
 ## Créer la liste des pages à écrire ou à mettre à jour
 

--- a/files/fr/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
@@ -13,7 +13,8 @@ Le glossaire ne sera potentiellement jamais complet, car le Web est en perpétue
 
 Contribuer au glossaire est une façon simple de rendre le Web plus compréhensible pour tout le monde. Il n'est pas nécessaire d'avoir des compétences techniques approfondies pour le faire. Les entrées du glossaire sont conçues pour être simples et concises.
 
-> **Note :** La suite de cet article explique comment créer une entrée du glossaire. Toutefois, la structure du contenu de MDN utilise le contenu anglophone comme référence. Aussi, toute page devra d'abord être créée en anglais avant d'être localisée en français. Vous pouvez également aider à la traduction du glossaire en français, voir [Localiser MDN](/fr/docs/MDN/Community/Contributing/Translated_content).
+> [!NOTE]
+> La suite de cet article explique comment créer une entrée du glossaire. Toutefois, la structure du contenu de MDN utilise le contenu anglophone comme référence. Aussi, toute page devra d'abord être créée en anglais avant d'être localisée en français. Vous pouvez également aider à la traduction du glossaire en français, voir [Localiser MDN](/fr/docs/MDN/Community/Contributing/Translated_content).
 
 ## Comment rédiger une entrée
 
@@ -25,7 +26,8 @@ Si vous avez une idée pour une nouvelle entrée, [créez une nouvelle page](htt
 
 Pour toute page du glossaire, le premier paragraphe consiste en une description simple et concise du terme. Idéalement, ce paragraphe ne devrait pas dépasser deux phrases. Assurez-vous que toute personne qui lit cette description peut immédiatement comprendre le terme qui est défini.
 
-> **Note :** Veillez à ne pas copier-coller de définitions ou de contenus provenant d'autres pages sur Internet, notamment depuis Wikipédia (les versions de sa licence sont plus restreintes et incompatibles avec celle de MDN). Le contenu de votre entrée de glossaire doit être original.
+> [!NOTE]
+> Veillez à ne pas copier-coller de définitions ou de contenus provenant d'autres pages sur Internet, notamment depuis Wikipédia (les versions de sa licence sont plus restreintes et incompatibles avec celle de MDN). Le contenu de votre entrée de glossaire doit être original.
 
 #### Rédiger une bonne entrée dans le glossaire
 

--- a/files/fr/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/fr/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -13,7 +13,8 @@ Voir la page [Autres macros](/fr/docs/MDN/Structures/Macros/Other) pour plus d'i
 
 MDN fournit plusieurs macros pour former des liens entre les pages de référence, le glossaire, etc.
 
-> **Attention :** Toutes les macros de lien devraient être remplacées dans le contenu en français par des liens écrit en Markdown. En effet, on souhaite réduire l'utilisation des macros «&nbsp;simples&nbsp;» qui peuvent être facilement remplacées par du HTML/Markdown.
+> [!WARNING]
+> Toutes les macros de lien devraient être remplacées dans le contenu en français par des liens écrit en Markdown. En effet, on souhaite réduire l'utilisation des macros «&nbsp;simples&nbsp;» qui peuvent être facilement remplacées par du HTML/Markdown.
 
 ### Liens vers le glossaire
 
@@ -22,7 +23,8 @@ La macro [`Glossary`](https://github.com/mdn/yari/blob/main/kumascript/macros/Gl
 1. Le nom du terme (par exemple `"HTML"`)&nbsp;: `\{{Glossary("HTML")}}`
 2. Un paramètre optionnel indiquant le texte à afficher à la place du terme&nbsp;: `\{{Glossary("CSS", "Cascading Style Sheets")}}`
 
-> **Attention :** Pour remplacer cette macro, on écrira plutôt&nbsp;: `[le texte à afficher](/fr/docs/Glossary/MonTerme)`.
+> [!WARNING]
+> Pour remplacer cette macro, on écrira plutôt&nbsp;: `[le texte à afficher](/fr/docs/Glossary/MonTerme)`.
 
 ### Liens vers des pages de référence
 

--- a/files/fr/mdn/writing_guidelines/what_we_write/index.md
+++ b/files/fr/mdn/writing_guidelines/what_we_write/index.md
@@ -58,7 +58,8 @@ Les sujets sur lesquels nous nous concentrons avant tout sont les technologies w
 
 Nous documentons également d'autres sujets comme [SVG](/fr/docs/Web/SVG), [XML](/fr/docs/Web/XML), [WebAssembly](/fr/docs/WebAssembly), [l'accessibilité](/fr/docs/Learn/Accessibility). De plus, nous écrivons [des guides d'apprentissage](/fr/docs/Learn) pour ces technologies et disposons également [d'un glossaire](/fr/docs/Glossary).
 
-> **Note :** Les technologies côté serveur ont, la plupart du temps, leur propre documentation et MDN n'a pas pour but de maintenir une autre version. Toutefois, [il existe certaines exceptions](/fr/docs/Learn/Server-side).
+> [!NOTE]
+> Les technologies côté serveur ont, la plupart du temps, leur propre documentation et MDN n'a pas pour but de maintenir une autre version. Toutefois, [il existe certaines exceptions](/fr/docs/Learn/Server-side).
 
 Le contenu présent sur MDN doit être pertinent pour la section dans laquelle il est situé. On attend des personnes qui contribuent à ce qu'elles suivent [les règles d'écritures sur MDN](/fr/docs/MDN/Writing_guidelines) tant pour la forme, les exemples de code que pour d'autres sujets.
 

--- a/files/fr/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
+++ b/files/fr/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
@@ -28,7 +28,8 @@ Les directives suivantes couvrent la manière d'écrire du HTML pour les exemple
 
 ## Doctype et méta-données
 
-> **Note :** Les directives de cette section ne s'appliquent que lorsque vous devez montrer un document HTML complet. La plupart du temps, vous n'aurez pas besoin de le faire ; un extrait est généralement suffisant pour démontrer une fonctionnalité. Lorsque vous utilisez la macro [EmbedLiveSample](/fr/docs/MDN/Structures/Code_examples#traditional_live_samples), il suffit d'inclure l'extrait HTML ; il sera automatiquement inséré dans un document HTML complet lors de son affichage.
+> [!NOTE]
+> Les directives de cette section ne s'appliquent que lorsque vous devez montrer un document HTML complet. La plupart du temps, vous n'aurez pas besoin de le faire ; un extrait est généralement suffisant pour démontrer une fonctionnalité. Lorsque vous utilisez la macro [EmbedLiveSample](/fr/docs/MDN/Structures/Code_examples#traditional_live_samples), il suffit d'inclure l'extrait HTML ; il sera automatiquement inséré dans un document HTML complet lors de son affichage.
 
 ### Doctype
 

--- a/files/fr/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
+++ b/files/fr/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
@@ -133,7 +133,8 @@ Pour un usage général\*, vous pouvez utiliser les fonctionnalités ES6 courant
 
 Cependant, nous ne recommandons pas encore l'utilisation générale des nouvelles fonctionnalités ES telles que [async](/fr/docs/Web/JavaScript/Reference/Statements/async_function)/[await](/fr/docs/Web/JavaScript/Reference/Operators/await), les virgules de fin sur les listes d'arguments, etc. Nous préférerions que vous ne les utilisiez pas, sauf si cela est strictement nécessaire, et si vous les utilisez, incluez une explication dans votre exemple pour dire ce qu'ils font, avec un lien vers le matériel de référence approprié.
 
-> **Note :** Par "usage général", nous entendons la rédaction d'exemples généraux. Les pages de référence couvrant des fonctionnalités spécifiques de l'ES moderne doivent évidemment utiliser les fonctionnalités qu'elles documentent !
+> [!NOTE]
+> Par "usage général", nous entendons la rédaction d'exemples généraux. Les pages de référence couvrant des fonctionnalités spécifiques de l'ES moderne doivent évidemment utiliser les fonctionnalités qu'elles documentent !
 
 ## Variables
 
@@ -157,7 +158,8 @@ let thisIsaveryLONGVariableThatRecordsPlayerscore345654 = 0;
 let s = d / t;
 ```
 
-> **Note :** The only place where it is OK to not use human-readable semantic names is where a very common recognized convention exists, such as using `i`, `j`, etc. for loop iterators.
+> [!NOTE]
+> The only place where it is OK to not use human-readable semantic names is where a very common recognized convention exists, such as using `i`, `j`, etc. for loop iterators.
 
 ### Déclaration des variables
 
@@ -377,7 +379,8 @@ function notVeryObviousName() {
 }
 ```
 
-> **Note :** Le seul endroit où il est acceptable de ne pas utiliser des noms sémantiques lisibles par l'homme est lorsqu'une convention reconnue très courante existe, comme l'utilisation de `i`, `j`, etc. pour les itérateurs de boucle.
+> [!NOTE]
+> Le seul endroit où il est acceptable de ne pas utiliser des noms sémantiques lisibles par l'homme est lorsqu'une convention reconnue très courante existe, comme l'utilisation de `i`, `j`, etc. pour les itérateurs de boucle.
 
 ### Définition des fonctions
 

--- a/files/fr/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/fr/mdn/writing_guidelines/writing_style_guide/index.md
@@ -54,7 +54,8 @@ var toolkitProfileService = Components.classes["@mozilla.org/toolkit/profile-ser
 
 ### Abréviations
 
-> **Note :** les abréviations sont à utiliser à bon escient et il faudra bien connaître leur sens (notamment pour les abrévations latines) afin de les utiliser correctement. Il faut être conscient que leur usage peut être source de confusion pour les lectrices et lecteurs qui pourraient ne pas y être habitués.
+> [!NOTE]
+> Les abréviations sont à utiliser à bon escient et il faudra bien connaître leur sens (notamment pour les abrévations latines) afin de les utiliser correctement. Il faut être conscient que leur usage peut être source de confusion pour les lectrices et lecteurs qui pourraient ne pas y être habitués.
 
 #### Dans les notes et parenthèses
 

--- a/files/fr/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.md
@@ -75,7 +75,8 @@ Au lieu de spécifier des scripts d'arrière-plan, vous pouvez spécifier une pa
 
 Les scripts d'arrière-plan s'exécutent dans le contexte de pages spéciales appelées pages d'arrière-plan. Cela leur donne une [`fenêtre`](/fr/docs/Web/API/Window) globale, ainsi que toutes les API DOM standard fournies par cet objet.
 
-> **Attention :** Dans Firefox, les pages d'arrière-plan ne supportent pas l'utilisation de [`alert()`](/fr/docs/Web/API/Window/alert), [`confirm()`](/fr/docs/Web/API/Window/confirm), ou [`prompt()`](/fr/docs/Web/API/Window/prompt).
+> [!WARNING]
+> Dans Firefox, les pages d'arrière-plan ne supportent pas l'utilisation de [`alert()`](/fr/docs/Web/API/Window/alert), [`confirm()`](/fr/docs/Web/API/Window/confirm), ou [`prompt()`](/fr/docs/Web/API/Window/prompt).
 
 #### APIs des WebExtensions
 

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
@@ -38,7 +38,7 @@ clearAlarms.then(onClearedAll);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.alarms`](https://developer.chrome.com/extensions/alarms).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/create/index.md
@@ -75,7 +75,7 @@ browser.alarms.create("my-periodic-alarm", {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.alarms`](https://developer.chrome.com/extensions/alarms).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/get/index.md
@@ -43,7 +43,7 @@ getAlarm.then(gotAlarm);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.alarms`](https://developer.chrome.com/extensions/alarms).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/getall/index.md
@@ -42,7 +42,7 @@ getAlarms.then(gotAll);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.alarms`](https://developer.chrome.com/extensions/alarms).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/index.md
@@ -38,7 +38,7 @@ Pour pouvoir utiliser cette API, vous devez disposer de la [permission](/fr/Add-
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.alarms`](https://developer.chrome.com/extensions/alarms).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/onalarm/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/onalarm/index.md
@@ -53,7 +53,7 @@ browser.alarms.onAlarm.addListener(handleAlarm);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.alarms`](https://developer.chrome.com/extensions/alarms).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -38,7 +38,7 @@ Un {{jsxref("object")}} avec les propriétés suivantes :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
@@ -17,7 +17,7 @@ Un type **`bookmarks.BookmarkTreeNodeUnmodifiable`** est utilisé pour indiquer 
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/create
 
 Crée un signet ou un dossier en tant qu'enfant de {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "BookmarkTreeNode")}} avec `parentId` spécifié. Pour créer un dossier, omettez ou laissez vide le paramètre {{WebExtAPIRef("bookmarks.CreateDetails", "CreateDetails", "url")}}.
 
-> **Attention :** Si votre extension tente de créer un nouveau signet dans le nœud racine de l'arborescence du signet, une erreur est générée: "_La racine du signet ne peut pas être modifiée_" et le signet ne sera pas créé.
+> [!WARNING]
+> Si votre extension tente de créer un nouveau signet dans le nœud racine de l'arborescence du signet, une erreur est générée: "_La racine du signet ne peut pas être modifiée_" et le signet ne sera pas créé.
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 
@@ -51,7 +52,7 @@ createBookmark.then(onCreated);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
@@ -28,7 +28,7 @@ Un {{jsxref("object")}} contenant une combinaison des champs suivants :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
@@ -49,7 +49,7 @@ gettingBookmarks.then(onFulfilled, onRejected);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
@@ -51,7 +51,7 @@ gettingChildren.then(onFulfilled, onRejected);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
@@ -51,7 +51,7 @@ gettingRecent.then(onFulfilled, onRejected);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
@@ -71,7 +71,7 @@ gettingSubTree.then(logSubTree, onRejected);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
@@ -67,7 +67,7 @@ gettingTree.then(logTree, onRejected);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/index.md
@@ -70,7 +70,7 @@ Les extensions ne peuvent pas créer, modifier ou supprimer des signets dans le 
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/move
 
 La méthode **`bookmarks.move()`** déplace le {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "BookmarkTreeNode")}} à la destination spécifiée dans l'arborescence des signets. Cela vous permet de déplacer un signet vers un nouveau dossier et / ou une position dans le dossier.
 
-> **Attention :** Si votre extension tente de déplacer un signet dans le nœud racine de l'arborescence de signets, l'appel déclenche une erreur avec le message suivant: "_La racine du signet ne peut pas être modifiée_" et le déplacement ne sera pas terminé.
+> [!WARNING]
+> Si votre extension tente de déplacer un signet dans le nœud racine de l'arborescence de signets, l'appel déclenche une erreur avec le message suivant: "_La racine du signet ne peut pas être modifiée_" et le déplacement ne sera pas terminé.
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 
@@ -62,7 +63,7 @@ movingBookmark.then(onMoved, onRejected);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.md
@@ -43,7 +43,8 @@ Les événements ont trois fonctions :
     - `changeInfo`
       - : [`object`](#changeInfo). Objet contenant deux propriétés : `title`, une chaîne contenant le titre de l'élément et `url`, une chaîne contenant l'URL de l'élément. Si l'élément est un dossier, l'`url` est omise.
 
-> **Note :** Plusieurs événements peuvent se produire lorsqu'un signet change, et cet objet changeInfo peut contenir uniquement les données qui ont changé, plutôt que toutes les données du signet. En d'autres termes, si l'`url` d'un signet change, le changeInfo ne peut contenir que les nouvelles informations de l'`url`.
+> [!NOTE]
+> Plusieurs événements peuvent se produire lorsqu'un signet change, et cet objet changeInfo peut contenir uniquement les données qui ont changé, plutôt que toutes les données du signet. En d'autres termes, si l'`url` d'un signet change, le changeInfo ne peut contenir que les nouvelles informations de l'`url`.
 
 ## Exemples
 
@@ -67,7 +68,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
@@ -68,7 +68,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
@@ -57,7 +57,7 @@ browser.bookmarks.onCreated.addListener(handleCreated);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
@@ -58,7 +58,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
@@ -58,7 +58,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
@@ -77,7 +77,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.md
@@ -73,7 +73,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/remove
 
 La méthode **`bookmarks.remove()`** supprime un seul signet ou un dossier de signets vide.
 
-> **Attention :** Si votre extension tente de supprimer un signet du nœud racine de l'arborescence de signets, l'appel déclenche une erreur avec le message suivant: "_La racine du signet ne peut pas être modifiée_" et le signet ne sera pas supprimé.
+> [!WARNING]
+> Si votre extension tente de supprimer un signet du nœud racine de l'arborescence de signets, l'appel déclenche une erreur avec le message suivant: "_La racine du signet ne peut pas être modifiée_" et le signet ne sera pas supprimé.
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 
@@ -51,7 +52,7 @@ removingBookmark.then(onRemoved, onRejected);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/removeTree
 
 La méthode **`bookmarks.removeTree()`** supprime récursivement un dossier de signets et tout son contenu.
 
-> **Attention :** Si votre extension tente de supprimer une arborescence de signets du nœud racine de cette dernière, l'appel déclenche une erreur avec le message suivant: "La racine de signet ne peut pas être modifiée" et le signet ne sera pas supprimé.
+> [!WARNING]
+> Si votre extension tente de supprimer une arborescence de signets du nœud racine de cette dernière, l'appel déclenche une erreur avec le message suivant: "La racine de signet ne peut pas être modifiée" et le signet ne sera pas supprimé.
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 
@@ -58,7 +59,7 @@ searchingBookmarks.then(removeMDN, onRejected);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
@@ -89,7 +89,7 @@ browser.browserAction.onClicked.addListener(checkActiveTab);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/update
 
 **`bookmarks.update()`** met à jour le titre et / ou l'URL d'un signet ou le nom d'un dossier de signets.
 
-> **Attention :** Si votre extension tente de mettre à jour un signet dans le nœud racine de l'arborescence de signets, l'appel déclenche une erreur avec le message suivant: "La racine du signet ne peut pas être modifiée" et le signet ne sera pas mis à jour.
+> [!WARNING]
+> Si votre extension tente de mettre à jour un signet dans le nœud racine de l'arborescence de signets, l'appel déclenche une erreur avec le message suivant: "La racine du signet ne peut pas être modifiée" et le signet ne sera pas mis à jour.
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 
@@ -72,7 +73,7 @@ searching.then(updateFolders, onRejected);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.bookmarks`](https://developer.chrome.com/extensions/bookmarks). Cette documentation provient de [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
@@ -22,7 +22,7 @@ Par exemple , le rouge opaque est `[255, 0, 0, 255]`.
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
@@ -46,7 +46,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 });
 ```
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
@@ -40,7 +40,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
@@ -59,7 +59,7 @@ browser.browserAction.getBadgeBackgroundColor({}).then(onGot, onFailure);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
@@ -56,7 +56,7 @@ gettingBadgeText.then(gotBadgeText);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
@@ -63,7 +63,7 @@ browser.browserAction.getBadgeTextColor({}).then(onGot, onFailure);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
@@ -56,7 +56,7 @@ gettingPopup.then(gotPopup);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
@@ -64,7 +64,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.md
@@ -17,7 +17,7 @@ Un objet [`ImageData`](/fr/docs/Web/API/ImageData).
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/index.md
@@ -71,7 +71,7 @@ Quand l'API `browserAction`, vous pouvez :
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
@@ -56,7 +56,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
@@ -76,7 +76,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
@@ -65,7 +65,7 @@ browser.browserAction.onClicked.addListener(increment);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
@@ -72,7 +72,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
@@ -148,7 +148,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
@@ -96,7 +96,7 @@ browser.contextMenus.onClicked.addListener(function (info, tab) {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
@@ -68,7 +68,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). Cette documentation est dérivée de [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
@@ -47,7 +47,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browsingData`](https://developer.chrome.com/extensions/browsingData).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/index.md
@@ -65,7 +65,7 @@ Pour utiliser cette API, vous devez disposer de l'[API permission](/fr/Add-ons/W
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browsingData`](https://developer.chrome.com/extensions/browsingData).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
@@ -37,7 +37,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browsingData`](https://developer.chrome.com/extensions/browsingData).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
@@ -79,7 +79,7 @@ browser.browsingData
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browsingData`](https://developer.chrome.com/extensions/browsingData).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
@@ -50,7 +50,7 @@ browser.browsingData.removeCache({}).then(onRemoved, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browsingData`](https://developer.chrome.com/extensions/browsingData).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
@@ -61,7 +61,7 @@ browser.browsingData
 
 Supprime tous les cookies :
 
-> **Attention :**
+> [!WARNING]
 >
 > L'utilisation de l'API pour supprimer tous les cookies effacera simultanément tous les objets de stockage locaux (y compris ceux des autres extensions).
 >
@@ -81,7 +81,7 @@ browser.browsingData.removeCookies({}).then(onRemoved, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browsingData`](https://developer.chrome.com/extensions/browsingData).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
@@ -75,7 +75,7 @@ browser.browsingData.removeDownloads({}).then(onRemoved, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browsingData`](https://developer.chrome.com/extensions/browsingData).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
@@ -74,7 +74,7 @@ browser.browsingData.removeFormData({}).then(onRemoved, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browsingData`](https://developer.chrome.com/extensions/browsingData).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
@@ -75,7 +75,7 @@ browser.browsingData.removeHistory({}).then(onRemoved, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browsingData`](https://developer.chrome.com/extensions/browsingData).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
@@ -53,7 +53,7 @@ browser.browsingData.removeLocalStorage({}).then(onRemoved, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browsingData`](https://developer.chrome.com/extensions/browsingData).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
@@ -75,7 +75,7 @@ browser.browsingData.removePasswords({}).then(onRemoved, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browsingData`](https://developer.chrome.com/extensions/browsingData).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
@@ -75,7 +75,7 @@ browser.browsingData.removePluginData({}).then(onRemoved, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browsingData`](https://developer.chrome.com/extensions/browsingData).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
@@ -60,7 +60,7 @@ browser.browsingData.settings().then(onGotSettings, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.browsingData`](https://developer.chrome.com/extensions/browsingData).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.md
@@ -13,7 +13,7 @@ Renvoyer l'URL canonique de la page de détection du portail des prisonniers. En
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#property-TAB_ID_NONE) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/clipboard/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/clipboard/index.md
@@ -26,6 +26,6 @@ Pour utiliser cette API, vous devez avoir la [permission](/fr/Add-ons/WebExtensi
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.clipboard`](https://developer.chrome.com/apps/clipboard).

--- a/files/fr/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
@@ -65,6 +65,6 @@ fetch(browser.runtime.getURL("image.png"))
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.clipboard`](https://developer.chrome.com/apps/clipboard).

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/command/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/command/index.md
@@ -26,6 +26,6 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.commands`](https://developer.chrome.com/extensions/commands).

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/getall/index.md
@@ -44,7 +44,7 @@ getCommands.then(logCommands);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.commands`](https://developer.chrome.com/extensions/commands).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/index.md
@@ -30,7 +30,7 @@ slug: Mozilla/Add-ons/WebExtensions/API/commands
 
 {{Compat}} {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.commands`](https://developer.chrome.com/extensions/commands).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
@@ -64,6 +64,6 @@ browser.commands.onCommand.addListener(function (command) {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.commands`](https://developer.chrome.com/extensions/commands).

--- a/files/fr/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
@@ -9,7 +9,8 @@ Un `RegisteredContentScript` est renvoyé par un appel à {{WebExtAPIRef("conten
 
 Il définit une seule fonction {{WebExtAPIRef("contentScripts.RegisteredContentScript.unregister()", "unregister()")}}, qui peut être utilisée pour annuler l'enregistrement des scripts de contenu.
 
-> **Note :** Si cet objet est détruit (par exemple parce qu'il est hors de portée), les scripts de contenu seront automatiquement désinscrits. Vous devriez donc garder une référence à cet objet aussi longtemps que vous voulez que les scripts de contenu restent enregistrés.
+> [!NOTE]
+> Si cet objet est détruit (par exemple parce qu'il est hors de portée), les scripts de contenu seront automatiquement désinscrits. Vous devriez donc garder une référence à cet objet aussi longtemps que vous voulez que les scripts de contenu restent enregistrés.
 
 ## Méthodes
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
@@ -62,7 +62,7 @@ gettingAll.then(logCookies);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.cookies`](https://developer.chrome.com/extensions/cookies). Cette documentation est dérivée de [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
@@ -52,7 +52,7 @@ browser.cookies.getAllCookieStores().then((stores) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.cookies`](https://developer.chrome.com/extensions/cookies). Cette documentation est dérivée de [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/get/index.md
@@ -70,7 +70,7 @@ getActive.then(getCookie);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.cookies`](https://developer.chrome.com/extensions/cookies). Cette documentation est dérivée de [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/getall/index.md
@@ -67,7 +67,7 @@ gettingAll.then(logCookies);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.cookies`](https://developer.chrome.com/extensions/cookies). Cette documentation est dérivée de [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.md
@@ -46,7 +46,7 @@ Chaque membre du tableau `cookieStores` est un objet {{WebExtAPIRef("cookies.Coo
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.cookies`](https://developer.chrome.com/extensions/cookies). Cette documentation est dérivée de [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/index.md
@@ -102,7 +102,7 @@ Lorsque l'isolation de la première partie est désactivée, le paramètre `firs
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.cookies`](https://developer.chrome.com/extensions/cookies). Cette documentation est dérivée de [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) dans le code Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
@@ -74,7 +74,7 @@ browser.cookies.onChanged.addListener(function (changeInfo) {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.cookies`](https://developer.chrome.com/extensions/cookies). Cette documentation est dérivée de [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
@@ -46,7 +46,7 @@ browser.cookies.onChanged.addListener(function (changeInfo) {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.cookies`](https://developer.chrome.com/extensions/cookies). Cette documentation est dérivée de [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/remove/index.md
@@ -69,7 +69,7 @@ getActive.then(removeCookie);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.cookies`](https://developer.chrome.com/extensions/cookies). Cette documentation est dérivée de [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -73,7 +73,7 @@ function setCookie(tabs) {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.cookies`](https://developer.chrome.com/extensions/cookies). Cette documentation est dérivée de [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/index.md
@@ -22,7 +22,8 @@ Pour utiliser cette API, [la permission](/fr/docs/Mozilla/Add-ons/WebExtensions/
 
 {{Compat}}
 
-> **Note :** Cette API est basée sur l'API Chromium [`chrome.devtools`](https://developer.chrome.com/docs/extensions/mv2/devtools/).
+> [!NOTE]
+> Cette API est basée sur l'API Chromium [`chrome.devtools`](https://developer.chrome.com/docs/extensions/mv2/devtools/).
 >
 > Les données de compatibilité relatives à Microsoft Edge sont fournies par Microsoft Corporation et incluses ici sous la licence Creative Commons Attribution 3.0 pour les États-Unis.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
@@ -161,7 +161,7 @@ inspectButton.addEventListener("click", () => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools`](https://developer.chrome.com/extensions/devtools).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow
 
 {{AddonSidebar}}
 
-> **Note :** Cette page décrit les API de développement de WebExtensions telles qu'elles existent dans Firefox 54. Bien que les API soient basées sur les [APIs de devtools de Chrome](https://developer.chrome.com/extensions/devtools), il existe encore de nombreuses fonctionnalités qui ne sont pas encore implémentées dans Firefox et ne sont donc pas documentées ici. Pour voir les fonctionnalités actuellement manquantes, regarder [Limitations des APIs devtools](/fr/Add-ons/WebExtensions/Using_the_devtools_APIs#Limitations_of_the_devtools_APIs).
+> [!NOTE]
+> Cette page décrit les API de développement de WebExtensions telles qu'elles existent dans Firefox 54. Bien que les API soient basées sur les [APIs de devtools de Chrome](https://developer.chrome.com/extensions/devtools), il existe encore de nombreuses fonctionnalités qui ne sont pas encore implémentées dans Firefox et ne sont donc pas documentées ici. Pour voir les fonctionnalités actuellement manquantes, regarder [Limitations des APIs devtools](/fr/Add-ons/WebExtensions/Using_the_devtools_APIs#Limitations_of_the_devtools_APIs).
 
 L'API `devtools.inspectedWindow` permet à un extension de devtools d'interagir avec la fenêtre sur laquelle les outils de développement sont attachés.
 
@@ -29,7 +30,7 @@ Comme toutes les APIs de `devtools`, cette API n'est disponible que pour exécut
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.inspectedWindow`](https://developer.chrome.com/extensions/devtools_inspectedWindow).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
@@ -49,7 +49,7 @@ reloadButton.addEventListener("click", () => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools`](https://developer.chrome.com/extensions/devtools).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
@@ -40,7 +40,7 @@ browser.runtime.onMessage.addListener(handleMessage);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools`](https://developer.chrome.com/extensions/devtools).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
@@ -45,7 +45,7 @@ logRequestsButton.addEventListener("click", logRequests);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.network`](https://developer.chrome.com/extensions/devtools_network).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/network/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/network/index.md
@@ -27,7 +27,7 @@ Comme toutes les APIs de devtools, cette API est uniquement disponible pour le c
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.network`](https://developer.chrome.com/extensions/devtools_network).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.md
@@ -51,7 +51,7 @@ browser.devtools.network.onNavigated.addListener(handleNavigated);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.devtools`](https://developer.chrome.com/extensions/devtools) de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.md
@@ -60,7 +60,7 @@ browser.devtools.network.onRequestFinished.addListener(handleRequestFinished);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.devtools`](https://developer.chrome.com/extensions/devtools) de Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
@@ -63,7 +63,7 @@ browser.devtools.panels
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.md
@@ -13,6 +13,6 @@ Un objet [`ElementsPanel`](/fr/Add-ons/WebExtensions/API/devtools.panels/Element
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).


### PR DESCRIPTION
This PR converts the noteblocks for the French locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 3. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
