### PR TITLE
fr: Convert noteblocks to GFM Alerts (part 4)

### DIFF
--- a/files/fr/mdn/writing_guidelines/howto/document_a_css_property/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/document_a_css_property/index.md
@@ -11,13 +11,15 @@ Au fur et à mesure que les normes [CSS](/fr/docs/Web/CSS) évoluent, de nouvell
 
 Chaque page de référence des propriétés CSS suit la même structure. Cela permet au lectorat de trouver plus facilement les informations, surtout lorsqu'il est familiarisé avec le format standard des pages de référence.
 
-> **Note :** La documentation de nouvelles propriétés CSS doit d'abord avoir lieu en anglais avant de pouvoir traduire le nouveau contenu en français. L'organisation du contenu de MDN ne permet pas de créer du contenu en français si celui-ci n'existe pas déjà en anglais.
+> [!NOTE]
+> La documentation de nouvelles propriétés CSS doit d'abord avoir lieu en anglais avant de pouvoir traduire le nouveau contenu en français. L'organisation du contenu de MDN ne permet pas de créer du contenu en français si celui-ci n'existe pas déjà en anglais.
 
 ## Étape 1 - Déterminer la propriété à documenter
 
 Tout d'abord, vous devez déterminer la propriété CSS que vous souhaitez documenter. Vous avez peut-être remarqué qu'une page est manquante, ou vous avez peut-être vu des contenus manquants signalés dans notre [liste de problèmes du dépôt anglophone `mdn/content`](https://github.com/mdn/content/issues). Pour obtenir des détails sur la propriété CSS, vous devrez trouver une spécification pertinente (par exemple, une [spécification du W3C](https://www.w3.org/Style/CSS/) ou un rapport de bogue concernant une propriété non standard utilisée dans des moteurs de rendu tels que Gecko ou Blink).
 
-> **Note :** Lorsque vous utilisez une spécification du W3C, utilisez toujours la version **brouillon d'éditeur** (<i lang="en">Editor's draft</i>) (notez la bannière rouge sur le côté gauche) et non une version publiée (par exemple, <i lang="en">Working Draft</i>). La version en <i lang="en">Editor's Draft</i> est toujours plus proche de la version finale&nbsp;!
+> [!NOTE]
+> Lorsque vous utilisez une spécification du W3C, utilisez toujours la version **brouillon d'éditeur** (<i lang="en">Editor's draft</i>) (notez la bannière rouge sur le côté gauche) et non une version publiée (par exemple, <i lang="en">Working Draft</i>). La version en <i lang="en">Editor's Draft</i> est toujours plus proche de la version finale&nbsp;!
 
 Si l'implémentation et la spécification divergent, n'hésitez pas à le mentionner dans le bug d'implémentation. L'une des situations suivantes est possible&nbsp;:
 
@@ -37,6 +39,7 @@ Lorsque vous créez une page de référence, vous devez ajouter des exemples. Po
 
 ## Étape 4 - Faire réviser le contenu
 
-> **Note :** Si l'anglais n'est pas votre langue maternelle ou que vous ne l'utilisez pas couramment, n'hésitez pas à demander une relecture en français via le canal [#l10n-fr](https://chat.mozilla.org/#/room/#l10n-fr:mozilla.org) pour assurer la clarté de votre contribution.
+> [!NOTE]
+> Si l'anglais n'est pas votre langue maternelle ou que vous ne l'utilisez pas couramment, n'hésitez pas à demander une relecture en français via le canal [#l10n-fr](https://chat.mozilla.org/#/room/#l10n-fr:mozilla.org) pour assurer la clarté de votre contribution.
 
 Après avoir créé la page de la propriété, soumettez-la en tant que [<i lang="en">Pull Request</i>](https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request). Un membre de notre équipe de révision sera automatiquement désigné pour réviser votre page.

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
@@ -57,7 +57,7 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.md
@@ -23,7 +23,7 @@ Un `ElementsPanel` représente l'inspecteur HTML/CSS dans la devtools du navigat
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
@@ -53,6 +53,6 @@ browser.devtools.panels.elements.onSelectionChanged.addListener(
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools`](https://developer.chrome.com/extensions/devtools).

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
@@ -47,7 +47,7 @@ browser.devtools.panels
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.md
@@ -33,7 +33,7 @@ Pour créer un `ExtensionSidebarPane`, appelez la fonction [`browser.devtools.pa
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
@@ -55,6 +55,6 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.md
@@ -55,6 +55,6 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
@@ -55,7 +55,7 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
@@ -56,7 +56,7 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.md
@@ -44,7 +44,7 @@ function onCreated(sidebarPane) {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels
 
 {{AddonSidebar}}
 
-> **Note :** Bien que les API soient basées sur les [APIs de devtools de Chrome](https://developer.chrome.com/extensions/devtools), il existe encore de nombreuses fonctionnalités qui ne sont pas encore implémentées dans Firefox et ne sont donc pas documentées ici. Pour voir les fonctionnalités actuellement manquantes, regarder [Limitations des APIs devtools](/fr/Add-ons/WebExtensions/Using_the_devtools_APIs#Limitations_of_the_devtools_APIs).
+> [!NOTE]
+> Bien que les API soient basées sur les [APIs de devtools de Chrome](https://developer.chrome.com/extensions/devtools), il existe encore de nombreuses fonctionnalités qui ne sont pas encore implémentées dans Firefox et ne sont donc pas documentées ici. Pour voir les fonctionnalités actuellement manquantes, regarder [Limitations des APIs devtools](/fr/Add-ons/WebExtensions/Using_the_devtools_APIs#Limitations_of_the_devtools_APIs).
 
 L'API devtools.panels permet à une extension devtools de définir son interface utilisateur à l'intérieur de la fenêtre devtools.
 
@@ -47,7 +48,7 @@ Comme toutes les API de devtools, cette API est uniquement disponible pour le co
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.md
@@ -49,7 +49,7 @@ browser.devtools.panels.onThemeChanged.addListener((newThemeName) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.md
@@ -19,7 +19,7 @@ Il s'agit d'une chaîne dont les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.devtools.panels`](https://developer.chrome.com/extensions/devtools_panels).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
@@ -34,7 +34,7 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Lorsq
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
@@ -22,7 +22,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
@@ -49,7 +49,7 @@ canceling.then(onCanceled, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/dangertype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/dangertype/index.md
@@ -9,7 +9,8 @@ Le type `DangerType` de l'API {{WebExtAPIRef("downloads")}} définit un ensemble
 
 Une propriété de `danger` {{WebExtAPIRef('downloads.DownloadItem')}} contiendra une chaîne tirée des valeurs définies dans ce type.
 
-> **Note :** Ces constantes de chaîne ne changeront jamais, mais l'ensemble de DangerTypes peut changer.
+> [!NOTE]
+> Ces constantes de chaîne ne changeront jamais, mais l'ensemble de DangerTypes peut changer.
 
 ## Type
 
@@ -38,7 +39,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
@@ -22,7 +22,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/download/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/download/index.md
@@ -51,7 +51,8 @@ var downloading = browser.downloads.download(
 
         Si cette option est omise, le navigateur affichera le sélecteur de fichier ou non en fonction de la préférence générale de l'utilisateur pour ce comportement (dans Firefox cette préférence est intitulée "Toujours vous demander où enregistrer les fichiers" dans about:preferences, ou `browser.download.useDownloadDir` dans about:config).
 
-        > **Note :** Firefox pour Android provoque une erreur si `saveAs` est à `true`. Le paramètre est ignoré lorsque `saveAs` est `false` ou non inclus.
+        > [!NOTE]
+        > Firefox pour Android provoque une erreur si `saveAs` est à `true`. Le paramètre est ignoré lorsque `saveAs` est `false` ou non inclus.
 
     - `url`
       - : Un `string` représentant l'URL à télécharger.
@@ -92,7 +93,7 @@ downloading.then(onStartedDownload, onFailed);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
@@ -58,7 +58,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
@@ -70,7 +70,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.md
@@ -25,7 +25,7 @@ Un `DownloadTime` peut être l'un de trois types différents :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/erase/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/erase/index.md
@@ -11,7 +11,8 @@ Pour supprimer les fichiers du disque, vous devez utiliser {{WebExtAPIRef("downl
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 
-> **Note :** Si vous souhaitez supprimer un fichier téléchargé du disque et l'effacer de l'historique, vous devez appeler {{WebExtAPIRef("downloads.removeFile()")}} before you call `erase()`. Si vous l'essayez dans l'autre sens, vous obtiendrez une erreur lors de l'appel de {{WebExtAPIRef("downloads.removeFile()")}}, car il n'existe plus selon le navigateur.
+> [!NOTE]
+> Si vous souhaitez supprimer un fichier téléchargé du disque et l'effacer de l'historique, vous devez appeler {{WebExtAPIRef("downloads.removeFile()")}} before you call `erase()`. Si vous l'essayez dans l'autre sens, vous obtiendrez une erreur lors de l'appel de {{WebExtAPIRef("downloads.removeFile()")}}, car il n'existe plus selon le navigateur.
 
 ## Syntaxe
 
@@ -72,7 +73,7 @@ erasing.then(onErased, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.md
@@ -26,7 +26,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
@@ -72,7 +72,7 @@ searching.then(getIcon, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/index.md
@@ -78,7 +78,7 @@ Pour utiliser cette API, vous devez disposer de l' [API permission](/fr/Add-ons/
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.md
@@ -58,7 +58,7 @@ Divers :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
@@ -92,7 +92,7 @@ browser.downloads.onChanged.addListener(handleChanged);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/extensions/downloads#event-onChanged) API.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/oncreated/index.md
@@ -55,7 +55,7 @@ browser.downloads.onCreated.addListener(handleCreated);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
@@ -60,7 +60,7 @@ var erasing = browser.downloads.erase({
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/open/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/open/index.md
@@ -62,7 +62,7 @@ searching.then(openDownload, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/pause/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/pause/index.md
@@ -47,7 +47,7 @@ pausing.then(onPaused, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
@@ -13,7 +13,8 @@ Pour supprimer un fichier de l'historique des téléchargements, vous devez util
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 
-> **Note :** Si vous souhaitez supprimer un fichier téléchargé du disque et l'effacer de l'historique, vous devez appeler `removeFile()` avant d'appeler {{WebExtAPIRef("downloads.erase()")}}. Si vous l'essayez dans l'autre sens, vous obtiendrez une erreur lors de l'appel de `removeFile()`, car le navigateur n'aura plus d'enregistrement du téléchargement.
+> [!NOTE]
+> Si vous souhaitez supprimer un fichier téléchargé du disque et l'effacer de l'historique, vous devez appeler `removeFile()` avant d'appeler {{WebExtAPIRef("downloads.erase()")}}. Si vous l'essayez dans l'autre sens, vous obtiendrez une erreur lors de l'appel de `removeFile()`, car le navigateur n'aura plus d'enregistrement du téléchargement.
 
 ## Syntaxe
 
@@ -66,7 +67,7 @@ searching.then(remove, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/resume/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/resume/index.md
@@ -49,7 +49,7 @@ resuming.then(onResumed, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/search/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/search/index.md
@@ -122,7 +122,7 @@ Vous pouvez voir ce code en action par exemple dans notre [dernier téléchargem
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.md
@@ -9,7 +9,8 @@ La fonction **`setShelfEnabled()`** de l'API {{WebExtAPIRef("downloads")}} activ
 
 Si vous essayez d'activer l'étagère lorsqu'au moins une autre extension l'a déjà désactivé, l'appel échouera et {{WebExtAPIRef("runtime.lastError")}} sera défini avec un message d'erreur approprié.
 
-> **Note :** Pour utiliser cette fonction dans votre extension, vous devez demander la [permission manifest](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions), `"downloads.shelf"`, ainsi que la permission `"downloads"`.
+> [!NOTE]
+> Pour utiliser cette fonction dans votre extension, vous devez demander la [permission manifest](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions), `"downloads.shelf"`, ainsi que la permission `"downloads"`.
 
 ## Syntaxe
 
@@ -30,7 +31,7 @@ Cette API est également disponible en tant que `browser.downloads.setShelfEnabl
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/show/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/show/index.md
@@ -61,7 +61,7 @@ searching.then(openDownload, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
@@ -35,7 +35,7 @@ showBtn.onclick = function () {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/state/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/state/index.md
@@ -20,7 +20,8 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - `complete`
   - : Le téléchargement s'est terminé avec succès.
 
-> **Note :** Ces constantes de chaîne ne changeront jamais, mais de nouvelles constantes peuvent être ajoutées.
+> [!NOTE]
+> Ces constantes de chaîne ne changeront jamais, mais de nouvelles constantes peuvent être ajoutées.
 
 ## Compatibilité des navigateurs
 
@@ -28,7 +29,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
@@ -22,7 +22,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.downloads`](https://developer.chrome.com/extensions/downloads).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/events/event/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/events/event/index.md
@@ -34,7 +34,7 @@ Les valeurs de ce type sont des objets.
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.events`](https://developer.chrome.com/extensions/events). Cette documentation est dérivée de [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/events/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/events/index.md
@@ -22,7 +22,7 @@ Types communs utilisés par les API qui distribuent les événements.
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.events`](https://developer.chrome.com/extensions/events). Cette documentation est dérivée de [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/events/rule/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/events/rule/index.md
@@ -28,7 +28,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.events`](https://developer.chrome.com/extensions/events). Cette documentation est dérivée de [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
@@ -88,7 +88,7 @@ Toutefois, notez que ces deux derniers modèles ne correspondent pas au dernier 
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.events`](https://developer.chrome.com/extensions/events). Cette documentation est dérivée de [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/extension/getBackgroundPage
 
 Alias de {{WebExtAPIRef("runtime.getBackgroundPage()")}}.
 
-> **Note :** Cette méthode ne peut pas être utilisée en mode Navigation privée - elle renvoie toujours un tableau vide. Pour plus d'informations, voir le [bug Firefox 1329304](https://bugzil.la/1329304).
+> [!NOTE]
+> Cette méthode ne peut pas être utilisée en mode Navigation privée - elle renvoie toujours un tableau vide. Pour plus d'informations, voir le [bug Firefox 1329304](https://bugzil.la/1329304).
 
 ## Syntaxe
 
@@ -50,7 +51,7 @@ page.foo(); // -> "I'm defined in background.js"
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/extension/getExtensionTabs
 
 {{AddonSidebar}}
 
-> **Attention :** Cette méthode a été dépréciée. Utilisez {{WebExtAPIRef("extension.getViews()")}} à la place.
+> [!WARNING]
+> Cette méthode a été dépréciée. Utilisez {{WebExtAPIRef("extension.getViews()")}} à la place.
 
 Renvoie un tableau des objets de la [Window](/fr/docs/Web/API/Window) JavaScriptpour chacun des onglets qui s'exécutent dans l'extension actuelle. Si `windowId` est spécifié, renvoie uniquement les objets Window des onglets attachés à la fenêtre spécifiée.
 
@@ -34,7 +35,7 @@ Cette API est également disponible en tant que `browser.extension.getExtensionT
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/geturl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/geturl/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/extension/getURL
 
 {{AddonSidebar}}
 
-> **Attention :** Cette fonction est obsolète. Veuillez utiliser [`runtime.getURL`](/fr/Add-ons/WebExtensions/API/runtime/getURL).
+> [!WARNING]
+> Cette fonction est obsolète. Veuillez utiliser [`runtime.getURL`](/fr/Add-ons/WebExtensions/API/runtime/getURL).
 
 Convertit un chemin relatif dans le répertoire d'installation d'une extension en une URL complète.
 
@@ -43,7 +44,7 @@ var fullURL = browser.extension.getURL("beasts/frog.html");
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/getviews/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/getviews/index.md
@@ -67,7 +67,7 @@ var windows = browser.extension.getViews({ type: "popup" });
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/index.md
@@ -51,7 +51,7 @@ Utilitaires liés à votre extension. Obtenez des URL vers des packages de resso
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.md
@@ -13,7 +13,7 @@ Valeur booléenne, `true` pour les scripts de contenu s'exécutant dans les ongl
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
@@ -40,7 +40,7 @@ isAllowed.then(logIsAllowed);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.md
@@ -40,7 +40,7 @@ isAllowed.then(logIsAllowed);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/lasterror/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/lasterror/index.md
@@ -13,7 +13,7 @@ Un alias de {{WebExtAPIRef("runtime.lastError")}}.
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/onrequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/onrequest/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/extension/onRequest
 
 {{AddonSidebar}}
 
-> **Attention :** Ceci n'est pas implémenté dans Firefox car il est obsolète depuis Chrome 33. Veuillez utiliser [runtime.onMessageExternal](/fr/Add-ons/WebExtensions/API/runtime/onMessageExternal) à la place.
+> [!WARNING]
+> Ceci n'est pas implémenté dans Firefox car il est obsolète depuis Chrome 33. Veuillez utiliser [runtime.onMessageExternal](/fr/Add-ons/WebExtensions/API/runtime/onMessageExternal) à la place.
 
 Lancé lorsqu'une requête est envoyée par un processus d'extension ou un script de contenu.
 
@@ -57,7 +58,7 @@ Les événements ont trois fonctions :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/extension/onRequestExternal
 
 {{AddonSidebar}}
 
-> **Attention :** Ceci n'est pas implémenté dans Firefox car il est obsolète depuis Chrome 33. Veuillez utiliser [runtime.onMessageExternal](/fr/Add-ons/WebExtensions/API/runtime/onMessageExternal) à la place.
+> [!WARNING]
+> Ceci n'est pas implémenté dans Firefox car il est obsolète depuis Chrome 33. Veuillez utiliser [runtime.onMessageExternal](/fr/Add-ons/WebExtensions/API/runtime/onMessageExternal) à la place.
 
 Lancé lorsqu'une requête est envoyée depuis une autre extension.
 
@@ -57,7 +58,7 @@ Les événements ont trois fonctions :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/extension/sendRequest
 
 {{AddonSidebar}}{{Deprecated_Header}}
 
-> **Attention :** Cette méthode est dépréciée. utilisez {{WebExtAPIRef("runtime.sendMessage")}} à la place.
+> [!WARNING]
+> Cette méthode est dépréciée. utilisez {{WebExtAPIRef("runtime.sendMessage")}} à la place.
 
 Envoie une seule requête aux autres écouteurs de l'extension. Similaire à {{WebExtAPIRef('runtime.connect')}},mais envoie seulement une seule requête avec une réponse optionnelle. L'événement {{WebExtAPIRef('extension.onRequest')}} est déclenché dans chaque page de l'extension
 
@@ -40,7 +41,7 @@ Cette API est également disponible en tant que `browser.extension.sendRequest()
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.md
@@ -28,7 +28,7 @@ browser.extension.setUpdateUrlData(
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/viewtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/viewtype/index.md
@@ -17,7 +17,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont : `"tab"`, 
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.extension`](https://developer.chrome.com/extensions/extension). Cette documentation est dérivée de [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
@@ -22,7 +22,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basé sur l'API Chromium [`chrome.extensionTypes`](https://developer.chrome.com/extensions/extensionTypes) . Cette documentation provient de [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.md
@@ -17,7 +17,7 @@ Les valeurs de ce type sont des chaines. Les valeurs possibles sont : `"jpeg"`, 
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basé sur l'API Chromium [`chrome.extensionTypes`](https://developer.chrome.com/extensions/extensionTypes) . Cette documentation provient de [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/index.md
@@ -26,7 +26,7 @@ Certains types communs utilisés dans d'autres APIs WebExtensions.
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basé sur l'API Chromium [`chrome.extensionTypes`](https://developer.chrome.com/extensions/extensionTypes) . Cette documentation provient de [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
@@ -23,7 +23,7 @@ La valeur par défaut est `"document_idle"`.
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basé sur l'API Chromium [`chrome.extensionTypes`](https://developer.chrome.com/extensions/extensionTypes) . Cette documentation provient de [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/addurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/addurl/index.md
@@ -100,7 +100,7 @@ addingUrl.then(onAdded);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.history`](https://developer.chrome.com/extensions/history). Cette documentation est dérivée de [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/deleteall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/deleteall/index.md
@@ -48,7 +48,7 @@ deleteAllHistory();
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.history`](https://developer.chrome.com/extensions/history). Cette documentation est dérivée de [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/deleterange/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/deleterange/index.md
@@ -55,7 +55,7 @@ browser.history.deleteRange({
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/extensions/history#method-deleteRange) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
@@ -92,7 +92,7 @@ searching.then(onGot);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.history`](https://developer.chrome.com/extensions/history). Cette documentation est dérivée de [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/getvisits/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/getvisits/index.md
@@ -67,7 +67,7 @@ searching.then(listVisits);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.history`](https://developer.chrome.com/extensions/history). Cette documentation est dérivée de [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/historyitem/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/historyitem/index.md
@@ -30,7 +30,7 @@ C'est un objet avec les propriétés suivantes :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.history`](https://developer.chrome.com/extensions/history). Cette documentation est dérivée de [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/index.md
@@ -9,7 +9,8 @@ Utilisez l'API `historique` pour interargir avec l'historique du navigateur.
 
 Si vous recherchez des informations sur l'historique de session du navigateur, consultez l'[interface historique](/fr/docs/Web/API/History).
 
-> **Note :** Les téléchargements sont traités comme des objets [`HistoryItem`](/fr/Add-ons/WebExtensions/API/history/HistoryItem). Par conséquent, des événements tels que [`history.onVisited`](/fr/Add-ons/WebExtensions/API/history/onVisited) seront également déclenchés pour les téléchargements.
+> [!NOTE]
+> Les téléchargements sont traités comme des objets [`HistoryItem`](/fr/Add-ons/WebExtensions/API/history/HistoryItem). Par conséquent, des événements tels que [`history.onVisited`](/fr/Add-ons/WebExtensions/API/history/onVisited) seront également déclenchés pour les téléchargements.
 
 L'historique du navigateur est un enregistrement chronologique des pages que l'utilisateur a visitées. l'API d'historique vous permet de :
 
@@ -64,7 +65,7 @@ Pour utiliser cette API, une extension doit demander la [permission](/fr/Add-ons
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.history`](https://developer.chrome.com/extensions/history). Cette documentation est dérivée de [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
@@ -54,7 +54,7 @@ browser.history.onTitleChanged.addListener(handleTitleChanged);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.history`](https://developer.chrome.com/extensions/history). Cette documentation est dérivée de [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/onvisited/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/onvisited/index.md
@@ -57,7 +57,7 @@ browser.history.onVisited.addListener(onVisited);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.history`](https://developer.chrome.com/extensions/history). Cette documentation est dérivée de [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.md
@@ -63,7 +63,7 @@ browser.history.onVisitRemoved.addListener(onRemoved);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.history`](https://developer.chrome.com/extensions/history). Cette documentation est dérivée de [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/search/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/search/index.md
@@ -114,7 +114,7 @@ searching.then(onGot);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.history`](https://developer.chrome.com/extensions/history). Cette documentation est dérivée de [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/transitiontype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/transitiontype/index.md
@@ -40,7 +40,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.history`](https://developer.chrome.com/extensions/history). Cette documentation est dérivée de [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/visititem/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/visititem/index.md
@@ -28,7 +28,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.history`](https://developer.chrome.com/extensions/history). Cette documentation est dérivée de [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
@@ -59,7 +59,7 @@ detecting.then(onLanguageDetected);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.i18n`](https://developer.chrome.com/extensions/i18n). Cette documentation est dérivée de [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/i18n.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
@@ -41,7 +41,7 @@ gettingAcceptLanguages.then(onGot);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.i18n`](https://developer.chrome.com/extensions/i18n). Cette documentation est dérivée de [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/i18n.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
@@ -70,7 +70,7 @@ Si `target.url` est "https\://developer.mozilla.org", alors la valeur de message
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.i18n`](https://developer.chrome.com/extensions/i18n). Cette documentation est dérivée de [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/i18n.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
@@ -36,7 +36,7 @@ console.log(uiLanguage);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.i18n`](https://developer.chrome.com/extensions/i18n). Cette documentation est dérivée de [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/i18n.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/index.md
@@ -34,7 +34,7 @@ Pour plus de détails sur l'utilisation de i18n pour votre extension, voir :
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 > Cette API est basée sur l'API Chromium [`chrome.i18n`](https://developer.chrome.com/extensions/i18n). Cette documentation est dérivée de [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/i18n.json) dans le code de Chromium.
 >
 > Les données de compatibilité relatives à Microsoft Edge sont fournies par Microsoft Corporation et incluses ici sous la licence Creative Commons Attribution 3.0 pour les États-Unis.

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
@@ -17,7 +17,7 @@ Les valeurs de ce type sont des chaînes.
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.i18n`](https://developer.chrome.com/extensions/i18n). Cette documentation est dérivée de [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/i18n.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/locale-specific_message_reference/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/locale-specific_message_reference/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference
 
 Chaque extension internationalisée a au moins un fichier nommé `messages.json` qui fournit des chaînes spécifiques aux paramètres régionaux. Cette page décrit le format des fichiers `messages.json`.
 
-> **Note :** Pour plus d'informations sur l'internationalisation de vos extensions, consultez notre guide [i18n](/fr/Add-ons/WebExtensions/WebExtension_i18n).
+> [!NOTE]
+> Pour plus d'informations sur l'internationalisation de vos extensions, consultez notre guide [i18n](/fr/Add-ons/WebExtensions/WebExtension_i18n).
 
 ## Exemple messages.json
 
@@ -63,7 +64,8 @@ Le nom peut inclure les caractères suivants :
 - \_ (underscore)
 - @
 
-> **Note :** Vous ne devez pas définir les noms commençant par @@. Ces noms sont réservés aux [messages prédéfinis](/fr/Add-ons/WebExtensions/Internationalization#Predefined_messages).
+> [!NOTE]
+> Vous ne devez pas définir les noms commençant par @@. Ces noms sont réservés aux [messages prédéfinis](/fr/Add-ons/WebExtensions/Internationalization#Predefined_messages).
 
 ### message
 

--- a/files/fr/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
@@ -39,7 +39,7 @@ var redirectURL = browser.identity.getRedirectURL();
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.identity`](https://developer.chrome.com/extensions/identity).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/identity/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/identity/index.md
@@ -54,7 +54,7 @@ Cela aura tendance à être spécifique au fournisseur de services, mais en gén
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.identity`](https://developer.chrome.com/extensions/identity).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
@@ -98,7 +98,7 @@ function getAccessToken() {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.identity`](https://developer.chrome.com/extensions/identity).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/idlestate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/idlestate/index.md
@@ -17,7 +17,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont : `"active"
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.idle`](https://developer.chrome.com/extensions/idle). Cette documentation est dérivée de [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/index.md
@@ -32,7 +32,7 @@ Pour utiliser cette API, vous disposez de la [permission](/fr/Add-ons/WebExtensi
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.idle`](https://developer.chrome.com/extensions/idle). Cette documentation est dérivée de [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.md
@@ -55,7 +55,7 @@ browser.idle.onStateChanged.addListener(newState);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.idle`](https://developer.chrome.com/extensions/idle). Cette documentation est dérivée de [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/querystate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/querystate/index.md
@@ -49,7 +49,7 @@ querying.then(onGot);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.idle`](https://developer.chrome.com/extensions/idle). Cette documentation est dérivée de [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.md
@@ -34,7 +34,7 @@ browser.idle.setDetectionInterval(15);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.idle`](https://developer.chrome.com/extensions/idle). Cette documentation est dérivée de [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/management/extensioninfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/extensioninfo/index.md
@@ -75,7 +75,7 @@ Il s'agit d'un objet avec les propriétés suivantes :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/management/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/get/index.md
@@ -49,7 +49,7 @@ getting.then(got);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/management/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/getall/index.md
@@ -50,7 +50,7 @@ gettingAll.then(gotAll);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
@@ -51,7 +51,7 @@ gettingWarnings.then(gotWarnings);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
@@ -61,7 +61,7 @@ gettingWarnings.then(gotWarnings, gotError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/management/getself/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/getself/index.md
@@ -44,7 +44,7 @@ gettingSelf.then(gotSelf);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/management/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/index.md
@@ -60,7 +60,7 @@ La plupart de ces opérations requièrent les [permissions d'APIs](/fr/Add-ons/W
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/management/ondisabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/ondisabled/index.md
@@ -53,7 +53,7 @@ browser.management.onDisabled.addListener((info) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/management/onenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/onenabled/index.md
@@ -53,7 +53,7 @@ browser.management.onEnabled.addListener((info) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >


### PR DESCRIPTION
This PR converts the noteblocks for the French locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 4. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
