### PR TITLE
fr: Convert noteblocks to GFM Alerts (part 5)

### DIFF
--- a/files/fr/mozilla/add-ons/webextensions/api/management/oninstalled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/oninstalled/index.md
@@ -53,7 +53,7 @@ browser.management.onInstalled.addListener((info) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/management/onuninstalled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/onuninstalled/index.md
@@ -53,7 +53,7 @@ browser.management.onUninstalled.addListener((info) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/management/setenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/setenabled/index.md
@@ -56,7 +56,7 @@ toggleEnabled(id);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -58,7 +58,7 @@ uninstalling.then(null, onCanceled);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
@@ -73,7 +73,7 @@ uninstalling.then(null, onCanceled);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.management`](https://developer.chrome.com/extensions/management). Cette documentation est dérivée de [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.md
@@ -17,7 +17,7 @@ Pour la compatibilité avec d'autres navigateurs, Firefox rend cette propriété
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.contextMenus`](https://developer.chrome.com/extensions/contextMenus) de chromium. Cette documentation est dérivée de [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) dans le code Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
@@ -50,7 +50,7 @@ Notez que "launcher" n'est pas supporté.
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.contextMenus`](https://developer.chrome.com/extensions/contextMenus) de chromium. Cette documentation est dérivée de [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) dans le code Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/create/index.md
@@ -68,7 +68,8 @@ browser.menus.create(
             }
         ```
 
-        > **Note :** L'élément de menu de niveau supérieur utilise les [icônes](/fr/Add-ons/WebExtensions/manifest.json/icons) spécifiées dans le manifest plutôt que ce qui est spécifié avec cette touche.
+        > [!NOTE]
+        > L'élément de menu de niveau supérieur utilise les [icônes](/fr/Add-ons/WebExtensions/manifest.json/icons) spécifiées dans le manifest plutôt que ce qui est spécifié avec cette touche.
 
     - `id` {{optional_inline}}
       - : `string`. Identifiant unique à attribuer à cet élément Obligatoire pour les pages d'événement. Ne peut pas être identique à un autre ID pour cette extension.
@@ -179,7 +180,7 @@ browser.menus.onClicked.addListener(function (info, tab) {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.contextMenus`](https://developer.chrome.com/extensions/contextMenus) de chromium. Cette documentation est dérivée de [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) dans le code Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/index.md
@@ -166,7 +166,7 @@ browser.menus.create(
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.contextMenus`](https://developer.chrome.com/extensions/contextMenus) de chromium. Cette documentation est dérivée de [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) dans le code Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/itemtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/itemtype/index.md
@@ -26,7 +26,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont:
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.contextMenus`](https://developer.chrome.com/extensions/contextMenus) de chromium. Cette documentation est dérivée de [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) dans le code Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
@@ -54,7 +54,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.contextMenus`](https://developer.chrome.com/extensions/contextMenus) de chromium. Cette documentation est dérivée de [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) dans le code Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
@@ -64,7 +64,7 @@ browser.menus.onClicked.addListener((info, tab) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.contextMenus`](https://developer.chrome.com/extensions/contextMenus) de chromium. Cette documentation est dérivée de [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) dans le code Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/remove/index.md
@@ -61,7 +61,7 @@ browser.menus.onClicked.addListener(function (info, tab) {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.contextMenus`](https://developer.chrome.com/extensions/contextMenus) de chromium. Cette documentation est dérivée de [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) dans le code Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/removeall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/removeall/index.md
@@ -60,7 +60,7 @@ browser.menus.onClicked.addListener(function (info, tab) {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.contextMenus`](https://developer.chrome.com/extensions/contextMenus) de chromium. Cette documentation est dérivée de [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) dans le code Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/update/index.md
@@ -70,7 +70,8 @@ var updating = browser.menus.update(
             }
         ```
 
-        > **Note :** The top-level menu item uses the [icons](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons) specified in the manifest rather than what is specified with this key.
+        > [!NOTE]
+        > The top-level menu item uses the [icons](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons) specified in the manifest rather than what is specified with this key.
 
     - `id` {{optional_inline}}
       - : `string`. L'ID unique à affecter à cet article. Obligatoire pour les pages d'événements. Ne peut pas être le même qu'un autre ID pour cette extension.
@@ -140,7 +141,7 @@ browser.menus.onClicked.addListener(function (info, tab) {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.contextMenus`](https://developer.chrome.com/extensions/contextMenus) de chromium. Cette documentation est dérivée de [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) dans le code Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/clear/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/clear/index.md
@@ -60,7 +60,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.notifications`](https://developer.chrome.com/extensions/notifications).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/create/index.md
@@ -13,7 +13,8 @@ Vous pouvez éventuellement fournir un ID pour la notification. Si vous omettez 
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 
-> **Attention :** Si vous appelez `notifications.create()` plus d'une fois de suite, Firefox peut ne pas afficher de notification pour tout.
+> [!WARNING]
+> Si vous appelez `notifications.create()` plus d'une fois de suite, Firefox peut ne pas afficher de notification pour tout.
 
 ## Syntaxe
 
@@ -130,7 +131,7 @@ browser.notifications.onButtonClicked.addListener((id, index) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.notifications`](https://developer.chrome.com/extensions/notifications).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/getall/index.md
@@ -73,7 +73,7 @@ browser.notifications.getAll().then(logNotifications);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.notifications`](https://developer.chrome.com/extensions/notifications).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/index.md
@@ -48,6 +48,6 @@ La notification est identique sur tous les systèmes d'exploitation de bureau. Q
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.notifications`](https://developer.chrome.com/extensions/notifications).

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
@@ -67,7 +67,7 @@ Notez que les propriétés `appIconMaskUrl` et `isClickable` ne sont pas support
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API chromium [`chrome.notifications`](https://developer.chrome.com/extensions/notifications).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.md
@@ -43,7 +43,7 @@ Les événements ont trois fonctions :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.notifications`](https://developer.chrome.com/extensions/notifications).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/onclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/onclicked/index.md
@@ -51,7 +51,7 @@ browser.notifications.onClicked.addListener(function (notificationId) {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.notifications`](https://developer.chrome.com/extensions/notifications).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/onclosed/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/onclosed/index.md
@@ -53,7 +53,7 @@ browser.notifications.onClosed.addListener(function (notificationId) {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.notifications`](https://developer.chrome.com/extensions/notifications).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
@@ -56,6 +56,6 @@ browser.notifications.onShown.addListener(logShown);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.notifications`](https://developer.chrome.com/extensions/notifications).

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
@@ -41,7 +41,7 @@ Actuellement Firefox ne supporte que "basic" ici.
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.notifications`](https://developer.chrome.com/extensions/notifications).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/update/index.md
@@ -90,7 +90,7 @@ browser.browserAction.onClicked.addListener(function () {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.notifications`](https://developer.chrome.com/extensions/notifications).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/index.md
@@ -47,7 +47,7 @@ L'API omnibox fournit à l'extension un moyen de personnaliser les suggestions a
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.omnibox`](https://developer.chrome.com/extensions/omnibox).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.md
@@ -42,7 +42,7 @@ browser.omnibox.onInputCancelled.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.omnibox`](https://developer.chrome.com/extensions/omnibox).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
@@ -125,7 +125,7 @@ browser.omnibox.onInputEntered.addListener((url, disposition) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.omnibox`](https://developer.chrome.com/extensions/omnibox).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
@@ -125,7 +125,7 @@ browser.omnibox.onInputEntered.addListener((url, disposition) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.omnibox`](https://developer.chrome.com/extensions/omnibox).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.md
@@ -24,7 +24,7 @@ Les valeurs de ce type sont des chaînes. Ils peuvent prendre l'une des valeurs 
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.omnibox`](https://developer.chrome.com/extensions/omnibox).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
@@ -47,7 +47,7 @@ browser.omnibox.onInputStarted.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.omnibox`](https://developer.chrome.com/extensions/omnibox).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
@@ -40,7 +40,7 @@ browser.omnibox.setDefaultSuggestion({
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.omnibox`](https://developer.chrome.com/extensions/omnibox).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.md
@@ -22,7 +22,7 @@ Les valeurs de ce type sont des objets. Ils ont les propriétés suivantes :
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.omnibox`](https://developer.chrome.com/extensions/omnibox).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
@@ -58,7 +58,7 @@ browser.contextMenus.onClicked.addListener(function (info, tab) {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.pageAction`](https://developer.chrome.com/extensions/pageAction). Cette documentation est dérivée de [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
@@ -53,7 +53,7 @@ browser.pageAction.onClicked.addListener((tab) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.pageAction`](https://developer.chrome.com/extensions/pageAction). Cette documentation est dérivée de [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/hide/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/hide/index.md
@@ -38,7 +38,7 @@ browser.pageAction.onClicked.addListener((tab) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.pageAction`](https://developer.chrome.com/extensions/pageAction). Cette documentation est dérivée de [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.md
@@ -17,7 +17,7 @@ Un objet [`ImageData`](/fr/docs/Web/API/ImageData) , par exemple à partir d'un 
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.pageAction`](https://developer.chrome.com/extensions/pageAction). Cette documentation est dérivée de [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/index.md
@@ -54,7 +54,7 @@ Les actions de page sont pour des actions qui ne sont pertinentes que pour des p
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.pageAction`](https://developer.chrome.com/extensions/pageAction). Cette documentation est dérivée de [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
@@ -58,7 +58,7 @@ browser.pageAction.onClicked.addListener(function () {});
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.pageAction`](https://developer.chrome.com/extensions/pageAction). Cette documentation est dérivée de [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
@@ -55,7 +55,7 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tabInfo) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.pageAction`](https://developer.chrome.com/extensions/pageAction). Cette documentation est dérivée de [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/settitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/settitle/index.md
@@ -46,7 +46,7 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tabInfo) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.pageAction`](https://developer.chrome.com/extensions/pageAction). Cette documentation est dérivée de [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/show/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/show/index.md
@@ -51,7 +51,7 @@ browser.contextMenus.onClicked.addListener(function (info, tab) {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.pageAction`](https://developer.chrome.com/extensions/pageAction). Cette documentation est dérivée de [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/contains/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/contains/index.md
@@ -76,7 +76,7 @@ browser.permissions.contains(testPermissions4).then((result) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.permissions`](https://developer.chrome.com/extensions/permissions).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/getall/index.md
@@ -41,7 +41,7 @@ browser.permissions.getAll().then((result) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.permissions`](https://developer.chrome.com/extensions/permissions).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/index.md
@@ -49,7 +49,7 @@ Pour utiliser l'API de permissions, déterminez les permissions que votre extens
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.permissions`](https://developer.chrome.com/extensions/permissions).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/onadded/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/onadded/index.md
@@ -52,7 +52,7 @@ browser.permissions.onAdded.addListener(handleAdded);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.permissions`](https://developer.chrome.com/extensions/permissions).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/onremoved/index.md
@@ -52,7 +52,7 @@ browser.permissions.onRemoved.addListener(handleRemoved);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.permissions`](https://developer.chrome.com/extensions/permissions).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
@@ -22,7 +22,7 @@ Un {{jsxref("object")}} avec les propriétés suivantes :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.permissions`](https://developer.chrome.com/extensions/permissions).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/remove/index.md
@@ -53,7 +53,7 @@ document.querySelector("#remove").addEventListener("click", remove);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.permissions`](https://developer.chrome.com/extensions/permissions).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/request/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/request/index.md
@@ -73,7 +73,7 @@ document
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Actuellement un [bug avec la demande d'origines](https://bugzilla.mozilla.org/show_bug.cgi?id=1411873) et la [demande des permissions sur la page about:addons](https://bugzilla.mozilla.org/show_bug.cgi?id=1382953).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/pkcs11/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pkcs11/index.md
@@ -22,7 +22,8 @@ Effectuez les étapes suivantes :
    ![](load_device_driver.png)
 6. Entrez un nom pour le module de sécurité, tel que "_Ma Base de données Client_"
 
-   > **Attention :** il y a actuellement un bogue dans Firefox où les caractères internationaux peuvent causer des problèmes.
+   > [!WARNING]
+   > Il y a actuellement un bogue dans Firefox où les caractères internationaux peuvent causer des problèmes.
 
 7. Choisir **Parcourir...** pour trouver l'emplacement du module PKCS #11 sur votre ordinateur local, puis cliquez ou appuyez sur **OK** pour confirmer.
 
@@ -30,7 +31,8 @@ Effectuez les étapes suivantes :
 
 ## Provisionnement des modules PKCS #11
 
-> **Note :** A partir de Firefox 58, les extensions peuvent utiliser l'API [pkcs11](/fr/Add-ons/WebExtensions/API/pkcs11) pour énumérer les modules PKCS #11 et les rendre accessibles au navigateur comme sources de clés et certificats.
+> [!NOTE]
+> A partir de Firefox 58, les extensions peuvent utiliser l'API [pkcs11](/fr/Add-ons/WebExtensions/API/pkcs11) pour énumérer les modules PKCS #11 et les rendre accessibles au navigateur comme sources de clés et certificats.
 
 Il y a 2 pré-requis pour pouvoir utiliser cette API:
 

--- a/files/fr/mozilla/add-ons/webextensions/api/privacy/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/privacy/index.md
@@ -24,7 +24,7 @@ Pour utiliser l'API de confidentialité, vous devez avoir [l'autorisation de l'A
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.privacy`](https://developer.chrome.com/extensions/privacy).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/privacy/network/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/privacy/network/index.md
@@ -57,7 +57,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.privacy`](https://developer.chrome.com/extensions/privacy). Cette documentation est dérivée de [`privacy.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/privacy.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/privacy/services/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/privacy/services/index.md
@@ -48,6 +48,6 @@ getting.then((got) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.privacy`](https://developer.chrome.com/extensions/privacy).

--- a/files/fr/mozilla/add-ons/webextensions/api/privacy/websites/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/privacy/websites/index.md
@@ -99,7 +99,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.privacy`](https://developer.chrome.com/extensions/privacy). Cette documentation est dérivée de [`privacy.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/privacy.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/settings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/settings/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/proxy/settings
 
 Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui peut être utilisé pour modifier les paramètres de proxy du navigateur.
 
-> **Note :** La possibilité de modifier les paramètres de proxy nécessite un accès à une fenêtre privée car les paramètres de proxy affectent à la fois les fenêtres privées et non privées. Par conséquent, si une extension n'a pas reçu l'autorisation de fenêtre privée, les appels à `proxy.settings.set()` lanceront une exception.
+> [!NOTE]
+> La possibilité de modifier les paramètres de proxy nécessite un accès à une fenêtre privée car les paramètres de proxy affectent à la fois les fenêtres privées et non privées. Par conséquent, si une extension n'a pas reçu l'autorisation de fenêtre privée, les appels à `proxy.settings.set()` lanceront une exception.
 
 La valeur sous-jacente est un objet avec les propriétés énumérées ci-dessous.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/connect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/connect/index.md
@@ -102,7 +102,7 @@ browser.browserAction.onClicked.addListener(function () {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
@@ -56,7 +56,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
@@ -66,7 +66,7 @@ getting.then(onGot, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.md
@@ -47,6 +47,6 @@ gettingInfo.then(gotBrowserInfo);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Les données de compatibilité relatives à Microsoft Edge sont fournies par Microsoft Corporation et incluses ici sous la licence Creative Commons Attribution 3.0 pour les États-Unis.

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
@@ -34,7 +34,7 @@ console.log(manifest.name);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
@@ -40,7 +40,7 @@ gettingEntry.then(gotDirectoryEntry);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
@@ -42,7 +42,7 @@ gettingInfo.then(gotPlatformInfo);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
@@ -39,7 +39,7 @@ console.log(fullURL);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/id/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/id/index.md
@@ -23,7 +23,7 @@ Une `chaîne` représentant l'ID du module complémentaire. Si l'extension a sp�
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/index.md
@@ -101,7 +101,7 @@ Il fournit également des API de messagerie vous permettant de:
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
@@ -64,7 +64,7 @@ setCookie.then(logCookie, logError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
@@ -30,7 +30,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
@@ -51,7 +51,7 @@ browser.runtime.onBrowserUpdateAvailable.addListener(
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
@@ -97,7 +97,7 @@ browser.browserAction.onClicked.addListener(function () {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
@@ -83,7 +83,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
@@ -68,7 +68,7 @@ browser.runtime.onInstalled.addListener(handleInstalled);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.md
@@ -26,7 +26,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -16,7 +16,8 @@ Voici quelques exemples de cas d'utilisation :
 
 Pour envoyer un message reçu par l'écouteur `onMessage`, utilisez {{WebExtAPIRef("runtime.sendMessage()")}} ou (pour envoyer un message à un script de contenu) {{WebExtAPIRef("tabs.sendMessage()")}}.
 
-> **Note :** Évitez de créer plusieurs écouteurs `onMessage` pour le même type de message, car l'ordre de déclenchement des différents écouteurs ne sera pas garanti.
+> [!NOTE]
+> Évitez de créer plusieurs écouteurs `onMessage` pour le même type de message, car l'ordre de déclenchement des différents écouteurs ne sera pas garanti.
 >
 > Lorsque vous voulez garantir la livraison d'un message à une terminaison spécifique, utilisez l'[approche basée sur la connexion pour échanger des messages](/fr/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#les_messages_en_flux_continu).
 
@@ -32,11 +33,13 @@ Pour envoyer une réponse asynchrone, il existe deux options&nbsp;:
 - Renvoyer `true` à partir de l'écouteur d'événement. Cela permet de conserver la fonction `sendResponse()` après le retour de l'écouteur pour éventuellement l'appeler plus tard. [Voir un exemple](/fr/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#sending_an_asynchronous_response_using_sendresponse).
 - Renvoyer une `Promise` depuis l'écouteur d'événement, et la résoudre lorsque vous avez la réponse (ou la rejeter en cas d'erreur). [Voir un exemple](/fr/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#sending_an_asynchronous_response_using_a_promise).
 
-> **Attention :** Retourner une promesse ([`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise)) est désormais la méthode à privilégier car `sendResponse()` [sera retirée de la spécification W3C](https://github.com/mozilla/webextension-polyfill/issues/16#issuecomment-296693219).
+> [!WARNING]
+> Retourner une promesse ([`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise)) est désormais la méthode à privilégier car `sendResponse()` [sera retirée de la spécification W3C](https://github.com/mozilla/webextension-polyfill/issues/16#issuecomment-296693219).
 >
 > La bibliothèque populaire [webextension-polyfill](https://github.com/mozilla/webextension-polyfill) a déjà supprimé cette fonction de son implémentation.
 
-> **Note :** Vous pouvez également utiliser une [approche basée sur la connexion pour échanger des messages](/fr/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#connection-based_messaging).
+> [!NOTE]
+> Vous pouvez également utiliser une [approche basée sur la connexion pour échanger des messages](/fr/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#connection-based_messaging).
 
 ## Syntaxe
 
@@ -88,7 +91,8 @@ Les événements ont trois fonctions&nbsp;:
 
     La fonction `listener` peut renvoyer un booléen ou une {{jsxref("Promise")}}.
 
-    > **Note :** N'appelez pas `addListener()` en utilisant une fonction `async` :
+    > [!NOTE]
+    > N'appelez pas `addListener()` en utilisant une fonction `async` :
     >
     > ```js example-bad
     > // ne faites pas ça
@@ -278,7 +282,7 @@ browser.runtime.onMessage.addListener(handleMessage);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.md
@@ -90,7 +90,7 @@ browser.runtime.onMessageExternal.addListener(handleMessage);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.md
@@ -43,7 +43,7 @@ Les événements ont trois fonctions :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.md
@@ -21,7 +21,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onstartup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onstartup/index.md
@@ -45,7 +45,7 @@ function handleStartup() {
 browser.runtime.onStartup.addListener(handleStartup);
 ```
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/runtime/onSuspend
 
 Envoyé sur la page de l'événement juste avant son déchargement. Cela donne à l'extension l'opportunité de faire un peu de nettoyage. Notez que, comme la page est en cours de déchargement, les opérations asynchrones démarrées lors de la gestion de cet événement ne sont pas garanties.
 
-> **Note :** Si quelque chose empêche le déchargement de la page d'événement, l'événement {{WebExtAPIRef("runtime.onSuspendCanceled")}} sera envoyé et la page ne sera pas déchargée.
+> [!NOTE]
+> Si quelque chose empêche le déchargement de la page d'événement, l'événement {{WebExtAPIRef("runtime.onSuspendCanceled")}} sera envoyé et la page ne sera pas déchargée.
 
 ## Syntaxe
 
@@ -52,7 +53,7 @@ browser.runtime.onSuspend.addListener(handleSuspend);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.md
@@ -49,7 +49,7 @@ browser.runtime.onSuspendCanceled.addListener(handleSuspendCanceled);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.md
@@ -59,7 +59,7 @@ browser.runtime.onUpdateAvailable.addListener(handleUpdateAvailable);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
@@ -44,7 +44,7 @@ opening.then(onOpened, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
@@ -24,7 +24,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possible sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
@@ -24,7 +24,7 @@ Les valeurs de ce type sont des objets qui contiennent les propriétés suivante
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
@@ -17,7 +17,7 @@ Les valeurs de type sont des chaînes. Les valeurs possible sont : `"arm"`, `"x8
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
@@ -30,7 +30,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont:
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/port/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/port/index.md
@@ -170,7 +170,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/reload/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/reload/index.md
@@ -35,7 +35,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
@@ -58,7 +58,7 @@ requestingCheck.then(onRequested, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.md
@@ -24,7 +24,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
@@ -15,7 +15,8 @@ Les extensions ne peuvent pas envoyer de messages aux scripts de contenu en util
 
 C'est une fonction asynchrone qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 
-> **Note :** Vous pouvez également utiliser une [approche basée sur la connexion pour échanger des messages](/fr/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#Communication_avec_les_scripts_darrière-plan).
+> [!NOTE]
+> Vous pouvez également utiliser une [approche basée sur la connexion pour échanger des messages](/fr/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#Communication_avec_les_scripts_darrière-plan).
 
 ## Syntaxe
 
@@ -111,7 +112,7 @@ browser.runtime.onMessage.addListener(handleMessage);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
@@ -64,7 +64,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
@@ -47,7 +47,7 @@ settingUrl.then(onSetURL, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.runtime`](https://developer.chrome.com/extensions/runtime#event-onConnect). Cette documentation est dérivée de [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/filter/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/filter/index.md
@@ -22,7 +22,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les proriétés suivante
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.sessions`](https://developer.chrome.com/extensions/sessions).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
@@ -64,7 +64,7 @@ browser.browserAction.onClicked.addListener(function () {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.sessions`](https://developer.chrome.com/extensions/sessions).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/index.md
@@ -61,7 +61,7 @@ Pour utiliser l'API des sessions, vous devez avoir la [permission API](/fr/Add-o
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.sessions`](https://developer.chrome.com/extensions/sessions).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.md
@@ -11,7 +11,7 @@ Le nombre maximum de sessions qui seront retournées par un appel à {{WebExtAPI
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.sessions`](https://developer.chrome.com/extensions/sessions).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
@@ -69,7 +69,7 @@ browser.sessions.onChanged.addListener(restoreMostRecent);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.sessions`](https://developer.chrome.com/extensions/sessions).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/restore/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/restore/index.md
@@ -62,7 +62,7 @@ browser.browserAction.onClicked.addListener(function () {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.sessions`](https://developer.chrome.com/extensions/sessions).
 >


### PR DESCRIPTION
This PR converts the noteblocks for the French locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 5. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
