### PR TITLE
fr: Convert noteblocks to GFM Alerts (part 6)

### DIFF
--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/index.md
@@ -48,7 +48,7 @@ L'API sidebarAction est basée sur l'[API sidebarAction](https://dev.opera.com/e
 
 - [annotate-page](https://github.com/mdn/webextensions-examples/tree/master/annotate-page)
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Opera [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
@@ -123,6 +123,6 @@ browser.browserAction.onClicked.addListener(toggle);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Opera [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/).

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
@@ -80,7 +80,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Opera [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
@@ -73,7 +73,7 @@ browser.browserAction.onClicked.addListener(setTitleForTab);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Opera [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/index.md
@@ -20,7 +20,8 @@ Chaque extension a sa propre zone de stockage, qui peut être divisée entre plu
 
 Bien que cette API soit semblable à {{domxref("Window.localStorage")}} il est conseillé de ne pas utiliser `Window.localStorage` dans le code de l'extension pour stocker ses données. Firefox effacera les données stockées via l'API localStorage par les extensions dans plusieurs scénarios où les utilisateurs effacent leur historique de navigation ou des données pour des raisons de confidentialité, alors que les données sauvées en utilisant l'API [`storage.local`](/fr/docs/Mozilla/Add-ons/WebExtensions/API/storage/local) seront correctement conservées dans ces scénarios.
 
-> **Note :** La zone de stockage n'est pas chiffrée et ne doit pas être utilisée pour stocker des informations confidentielles sur les utilisateurs.
+> [!NOTE]
+> La zone de stockage n'est pas chiffrée et ne doit pas être utilisée pour stocker des informations confidentielles sur les utilisateurs.
 
 ## Types
 
@@ -51,7 +52,7 @@ Bien que cette API soit semblable à {{domxref("Window.localStorage")}} il est c
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.storage`](https://developer.chrome.com/extensions/storage). Cette documentation est dérivée de [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/local/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/local/index.md
@@ -39,7 +39,7 @@ L'objet `local` local implémente les méthodes définies sur le type {{WebExtAP
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.storage`](https://developer.chrome.com/extensions/storage). Cette documentation est dérivée de [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/managed/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/managed/index.md
@@ -93,7 +93,7 @@ Pour plus d'informations, voir l'article de Chrome pour les zones de stockage [M
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.storage`](https://developer.chrome.com/extensions/storage). Cette documentation est dérivée de [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) dans le code de Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -71,7 +71,7 @@ browser.storage.onChanged.addListener(logStorageChange);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.storage`](https://developer.chrome.com/extensions/storage). Cette documentation est dérivée de [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
@@ -46,7 +46,7 @@ clearStorage.then(onCleared, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.storage`](https://developer.chrome.com/extensions/storage). Cette documentation est dérivée de [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -28,7 +28,8 @@ let gettingItem = browser.storage.<storageType>.get(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet de `resultat` contenant tous les objets dans les `clefs` trouvées dans la zone de stockage. Si l'opération a échoué, la promesse sera rejetée avec un message d'erreur. Si le stockage géré n'est pas défini, les données `non définies` seront retournées.
 
-> **Attention :** Lorsqu'elle est utilisée dans un script de contenu dans les versions de Firefox antérieures à 52, la promesse retournée par `browser.storage.local.get()` est remplie avec un tableau contenant un objet. L'objet dans le tableau contient les `clefs` trouvées dans la zone de stockage, comme décrit ci-dessus. La promesse est correctement remplie avec un objet lorsqu'il est utilisé dans le contexte d'arrière-plan
+> [!WARNING]
+> Lorsqu'elle est utilisée dans un script de contenu dans les versions de Firefox antérieures à 52, la promesse retournée par `browser.storage.local.get()` est remplie avec un tableau contenant un objet. L'objet dans le tableau contient les `clefs` trouvées dans la zone de stockage, comme décrit ci-dessus. La promesse est correctement remplie avec un objet lorsqu'il est utilisé dans le contexte d'arrière-plan
 > (scripts d'arrière-plan, popups, pages d'options, etc.). Lorsque cette API est utilisée en tant que `chrome.storage.local.get()`, elle transmet correctement un objet à la fonction de rappel.
 
 ## Compatibilité des navigateurs
@@ -134,7 +135,7 @@ chrome.storage.local.get("kitten", (items) => {
 });
 ```
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.storage`](https://developer.chrome.com/extensions/storage). Cette documentation est dérivée de [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
@@ -34,7 +34,7 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.storage`](https://developer.chrome.com/extensions/storage). Cette documentation est dérivée de [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
@@ -30,7 +30,7 @@ Les valeurs de ce type sont des objets.
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.storage`](https://developer.chrome.com/extensions/storage). Cette documentation est dérivée de [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
@@ -51,7 +51,7 @@ removeKitten.then(onRemoved, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.storage`](https://developer.chrome.com/extensions/storage). Cette documentation est dérivée de [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
@@ -80,6 +80,6 @@ browser.storage.local.get("monster").then(gotMonster, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.storage`](https://developer.chrome.com/extensions/storage). Cette documentation est dérivée de [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) dans le code de Chromium.

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
@@ -20,7 +20,7 @@ Les objets `StorageChange` contiennent les propriétés suivantes :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.storage`](https://developer.chrome.com/extensions/storage). Cette documentation est dérivée de [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
@@ -54,7 +54,7 @@ browser.browserAction.onClicked.addListener(function () {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
@@ -54,7 +54,7 @@ browser.browserAction.onClicked.addListener(function () {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/connect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/connect/index.md
@@ -70,7 +70,7 @@ browser.browserAction.onClicked.addListener(function () {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/create/index.md
@@ -39,7 +39,8 @@ var creating = browser.tabs.create(
 
       - : `boolean`. Si l'onglet doit devenir l'onglet sélectionné dans la fenêtre. Par défaut à `true`.
 
-        > **Attention :** Cette propriété est obsolète et n'est pas prise en charge dans Firefox. Utilisez `actif` à la place.
+        > [!WARNING]
+        > Cette propriété est obsolète et n'est pas prise en charge dans Firefox. Utilisez `actif` à la place.
 
     - `url`{{optional_inline}}
 
@@ -92,7 +93,7 @@ browser.browserAction.onClicked.addListener(function () {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.md
@@ -79,7 +79,7 @@ browser.browserAction.onClicked.addListener(function () {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/discard/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/discard/index.md
@@ -70,7 +70,7 @@ discarding.then(onDiscarded, onError);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/duplicate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/duplicate/index.md
@@ -35,7 +35,8 @@ let duplicating = browser.tabs.duplicate(
 
 Une [promesse (`Promise`)](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) dont la valeur de résolution sera un objet [`tabs.Tab`](/fr/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab) contenant des détails sur l'onglet dupliqué. L'objet `Tab` contiendra les propriétés `url`, `title` et `favIconUrl` uniquement si l'extension dispose de la [permission `"tabs"`](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) ou lorsque [l'hôte correspond à un hôte ciblé dans les permissions](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions). Si une erreur se produit, la promesse sera rejetée avec un message d'erreur.
 
-> **Note :** À partir de Firefox 68, la promesse renvoyée par `browser.tabs.duplicate()` se résout dès que l'onglet a été dupliqué. Auparavant, la promesse n'était résolue qu'une fois l'onglet entièrement chargé.
+> [!NOTE]
+> À partir de Firefox 68, la promesse renvoyée par `browser.tabs.duplicate()` se résout dès que l'onglet a été dupliqué. Auparavant, la promesse n'était résolue qu'une fois l'onglet entièrement chargé.
 
 ## Exemples
 
@@ -72,7 +73,7 @@ querying.then(duplicateFirstTab, onError);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
@@ -133,7 +133,7 @@ executing.then(onExecuted, onError);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/get/index.md
@@ -49,7 +49,7 @@ browser.tabs.onActivated.addListener(logListener);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
@@ -35,7 +35,7 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) qui se
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.md
@@ -48,7 +48,7 @@ gettingCurrent.then(onGot, onError);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/tabs/getSelected
 
 {{AddonSidebar}}
 
-> **Attention :** Cette méthode est dépréciée. utilisez {{WebExtAPIRef("tabs.query", "tabs.query({active: true})")}} à la place.
+> [!WARNING]
+> Cette méthode est dépréciée. utilisez {{WebExtAPIRef("tabs.query", "tabs.query({active: true})")}} à la place.
 
 Obtient l'onglet sélectionné dans la fenêtre spécifiée
 
@@ -34,7 +35,7 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
@@ -64,7 +64,7 @@ gettingZoom.then(onGot, onError);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
@@ -49,7 +49,7 @@ gettingZoomSettings.then(onGot, onError);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/goback/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/goback/index.md
@@ -52,7 +52,7 @@ goingBack.then(onGoBack, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-getZoomSettings) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
@@ -52,7 +52,7 @@ goingForward.then(onGoForward, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-getZoomSettings) de Chromium.Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
@@ -27,7 +27,8 @@ var highlighting = browser.tabs.highlight(
 
       - : `boolean`. Par défaut la valeur est `true`. S'il est défini sur `false`, l'objet {{WebExtAPIRef('windows.Window')}} n'aura pas de propriété `tabs` contenant une liste d'objets {{WebExtAPIRef('tabs.Tab')}} représentant les onglets ouverts dans la fenêtre.
 
-        > **Note :** Remplir la fenêtre (le comportement par défaut) peut être une opération coûteuse s'il y a beaucoup d'onglets. Pour de meilleures performances, il est recommandé de définir manuellement configuré `populate` à `false` si vous n'avez pas besoin des détails de l'onglet.
+        > [!NOTE]
+        > Remplir la fenêtre (le comportement par défaut) peut être une opération coûteuse s'il y a beaucoup d'onglets. Pour de meilleures performances, il est recommandé de définir manuellement configuré `populate` à `false` si vous n'avez pas besoin des détails de l'onglet.
 
     - `tabs`
       - : `array` de valeurs entières spécifiant un ou plusieurs onglets à mettre en évidence. Les onglets surlignés précédemment qui ne sont pas inclus dans les `onglets` cesseront d'être surlignés. Le premier onglet des `onglets` devient actif.
@@ -42,7 +43,7 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) qui se
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/index.md
@@ -161,7 +161,7 @@ De nombreuses opérations d'onglet utilisent un identifiant (`id`) d'onglet. Les
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
@@ -11,7 +11,8 @@ Pour utiliser cette API vous devez avoir la permission "[host permission](/fr/Ad
 
 Vous ne pouvez injecter du CSS que dans des pages dont l'URL peut être exprimée en utilisant un [motif de correspondance](/fr/docs/Mozilla/Add-ons/WebExtensions/Match_patterns), ce qui signifie que son schéma doit être "http", "https", "file", "ftp". Cela signifie que vous ne pouvez pas injecter de CSS dans les pages intégrées du navigateur, telles que about:debugging, about:addons, ou la page qui s'ouvre lorsque vous ouvrez un nouvel onglet vide.
 
-> **Note :** Firefox résout les URL dans les fichiers CSS injectés par rapport au fichier CSS lui-même, plutôt qu'à la page dans laquelle il est injecté.
+> [!NOTE]
+> Firefox résout les URL dans les fichiers CSS injectés par rapport au fichier CSS lui-même, plutôt qu'à la page dans laquelle il est injecté.
 
 Le CSS inséré peut être retiré à nouveau en appelant {{WebExtAPIRef("tabs.removeCSS()")}}.
 
@@ -89,7 +90,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/move/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/move/index.md
@@ -125,7 +125,7 @@ browser.browserAction.onClicked.addListener(function () {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
@@ -24,7 +24,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
@@ -24,7 +24,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
@@ -64,7 +64,7 @@ browser.tabs.onActivated.addListener(handleActivated);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/tabs/onActiveChanged
 
 {{AddonSidebar}}
 
-> **Attention :** Cet événement est obsolète. Utilisez {{WebExtAPIRef("tabs.onActivated")}} à la place.
+> [!WARNING]
+> Cet événement est obsolète. Utilisez {{WebExtAPIRef("tabs.onActivated")}} à la place.
 
 Se déclenche lorsque l'onglet sélectionné dans une fenêtre change. Notez que l'URL de l'onglet peut ne pas être définie au moment où cet événement a été déclenché, mais vous pouvez écouter les événements {{WebExtAPIRef('tabs.onUpdated')}} pour être averti lorsqu'une URL est définie.
 
@@ -55,7 +56,7 @@ Les événements ont trois fonctions :
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onattached/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onattached/index.md
@@ -69,7 +69,7 @@ browser.tabs.onAttached.addListener(handleAttached);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/oncreated/index.md
@@ -55,7 +55,7 @@ browser.tabs.onCreated.addListener(handleCreated);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/ondetached/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/ondetached/index.md
@@ -69,7 +69,7 @@ browser.tabs.onDetached.addListener(handleDetached);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/tabs/onHighlightChanged
 
 {{AddonSidebar}}
 
-> **Attention :** Cet événement est obsolète. Utilisez {{WebExtAPIRef("tabs.onHighlighted")}} à la place.
+> [!WARNING]
+> Cet événement est obsolète. Utilisez {{WebExtAPIRef("tabs.onHighlighted")}} à la place.
 
 Lancé lorsque les onglets en surbrillance ou sélectionnés dans une fenêtre changent.
 
@@ -50,7 +51,7 @@ Les événements ont trois fonctions :
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.md
@@ -64,7 +64,7 @@ browser.tabs.onHighlighted.addListener(handleHighlighted);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
@@ -78,7 +78,7 @@ browser.tabs.onMoved.addListener(handleMoved);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onremoved/index.md
@@ -69,7 +69,7 @@ browser.tabs.onRemoved.addListener(handleRemoved);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.md
@@ -61,7 +61,7 @@ browser.tabs.onReplaced.addListener(handleReplaced);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/tabs/onSelectionChanged
 
 {{AddonSidebar}}
 
-> **Attention :** Cet événement est obsolète. Utilisez {{WebExtAPIRef("tabs.onActivated")}} à la place.
+> [!WARNING]
+> Cet événement est obsolète. Utilisez {{WebExtAPIRef("tabs.onActivated")}} à la place.
 
 Se déclenche lorsque l'onglet sélectionné dans une fenêtre change.
 
@@ -55,7 +56,7 @@ Les événements ont trois fonctions:
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -214,7 +214,7 @@ browser.tabs.onUpdated.addListener(handleUpdated, filter);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.md
@@ -68,7 +68,7 @@ browser.tabs.onZoomChange.addListener(handleZoomed);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/query/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/query/index.md
@@ -144,7 +144,7 @@ querying.then(logTabs, onError);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/reload/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/reload/index.md
@@ -68,7 +68,7 @@ reloading.then(onReloaded, onError);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/remove/index.md
@@ -64,7 +64,7 @@ removing.then(onRemoved, onError);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
@@ -71,7 +71,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.md
@@ -9,7 +9,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/tabs/sendMessage
 
 Il s'agit d'une fonction asynchrone qui renvoit un objet [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise).
 
-> **Note :** Vous pouvez également utiliser une [approche basée sur la connexion pour échanger des messages](/fr/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#Communication_avec_les_scripts_darrière-plan).
+> [!NOTE]
+> Vous pouvez également utiliser une [approche basée sur la connexion pour échanger des messages](/fr/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#Communication_avec_les_scripts_darrière-plan).
 
 ## Syntaxe
 
@@ -92,7 +93,7 @@ browser.runtime.onMessage.addListener((request) => {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/tabs/sendRequest
 
 {{AddonSidebar}}
 
-> **Attention :** Cette méthode a été dépréciée. Utilisez {{WebExtAPIRef("tabs.sendMessage()")}} à la place.
+> [!WARNING]
+> Cette méthode a été dépréciée. Utilisez {{WebExtAPIRef("tabs.sendMessage()")}} à la place.
 
 Envoie une seule requête au(x) script(s) de contenu dans l'onglet spécifié, avec un rappel facultatif à exécuter lorsqu'une réponse est renvoyée. L'événement {{WebExtAPIRef('extension.onRequest')}} est déclenché dans chaque script de contenu exécuté dans l'onglet spécifié pour l'extension en cours.
 
@@ -35,7 +36,7 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
@@ -59,7 +59,7 @@ setting.then(null, onError);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
@@ -52,7 +52,7 @@ setting.then(onSet, onError);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/tab/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/tab/index.md
@@ -80,7 +80,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.md
@@ -13,7 +13,7 @@ Une valeur d'ID spéciale donnée aux onglets qui ne sont pas des onglets du nav
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#property-TAB_ID_NONE). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.md
@@ -17,7 +17,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont : `"loading
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/update/index.md
@@ -120,7 +120,7 @@ querying.then(updateFirstTab, onError);
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript) de Chromium. Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/windowtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/windowtype/index.md
@@ -22,7 +22,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont:
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
@@ -24,7 +24,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.md
@@ -24,7 +24,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.md
@@ -22,7 +22,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.tabs`](https://developer.chrome.com/extensions/tabs#method-executeScript). Cette documentation est dérivée de [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/theme/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/theme/index.md
@@ -9,7 +9,8 @@ Permet aux extensions du navigateur de mettre à jour le thème du navigateur.
 
 Pour utiliser cette API, une extension doit demander la [permission](/fr/Add-ons/WebExtensions/manifest.json/permissions) "theme" dans son fichier [manifest.json](/fr/Add-ons/WebExtensions/manifest.json).
 
-> **Note :** quand on met un thème en arrière plan, on doit déclarer la [permission](/fr/Add-ons/WebExtensions/manifest.json/permissions) 'theme' et on ne peut pas utiliser la fonction [theme](/fr/Add-ons/WebExtensions/manifest.json/theme) du manifest, puisque ce n'est pas compatible.
+> [!NOTE]
+> Quand on met un thème en arrière plan, on doit déclarer la [permission](/fr/Add-ons/WebExtensions/manifest.json/permissions) 'theme' et on ne peut pas utiliser la fonction [theme](/fr/Add-ons/WebExtensions/manifest.json/theme) du manifest, puisque ce n'est pas compatible.
 
 ## Types
 

--- a/files/fr/mozilla/add-ons/webextensions/api/topsites/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/topsites/get/index.md
@@ -96,7 +96,7 @@ gettingTopSites.then(logTopSites, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.topSites`](https://developer.chrome.com/extensions/topSites).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/topsites/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/topsites/index.md
@@ -27,7 +27,7 @@ Pour utiliser l'API topSites, vous devez disposez de l' [API permission](/fr/Add
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.topSites`](https://developer.chrome.com/extensions/topSites).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.md
@@ -26,7 +26,7 @@ Values of this type are objects. They contain the following properties:
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.topSites`](https://developer.chrome.com/extensions/topSites).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
@@ -51,7 +51,7 @@ clearing.then(onCleared);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.types`](https://developer.chrome.com/extensions/types).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
@@ -72,7 +72,7 @@ getting.then((got) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.types`](https://developer.chrome.com/extensions/types).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/index.md
@@ -31,7 +31,7 @@ Notez que si cet objet est basé sur le type [ChromeSetting](https://developer.c
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.types`](https://developer.chrome.com/extensions/types).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.md
@@ -71,7 +71,7 @@ Les événement ont trois fonctions :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.types`](https://developer.chrome.com/extensions/types).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
@@ -71,7 +71,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.types`](https://developer.chrome.com/extensions/types).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/types/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/index.md
@@ -16,7 +16,7 @@ Définit le type `BrowserSetting` , qui est utilisé pour représenter un param�
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.types`](https://developer.chrome.com/extensions/types).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/userscripts/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/userscripts/index.md
@@ -13,11 +13,13 @@ Cette API offre des capacités similaires à {{WebExtAPIRef("contentScripts")}} 
 - l'accès à la `fenêtre` et aux valeurs globales du `document` liées à la page web à laquelle le script utilisateur est attaché.
 - aucun accès aux API de WebExtension ou aux autorisations associées accordées à l'extension : le script API, qui hérite des autorisations de l'extension, peut fournir des API de WebExtension packagées aux scripts utilisateur enregistrés. Un script API est déclaré dans le fichier manifeste de l'extension en utilisant la clé du manifeste "user_scripts".
 
-> **Attention :** Cette API requiert la présence de la clé [`user_scripts`](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts) dans le manifest.json, même si aucun script API n'est spécifié. Par exemple, `user_scripts: {}`.
+> [!WARNING]
+> Cette API requiert la présence de la clé [`user_scripts`](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts) dans le manifest.json, même si aucun script API n'est spécifié. Par exemple, `user_scripts: {}`.
 
 Pour utiliser l'API, appelez `{{WebExtAPIRef("userScripts.register","register()")}}` en passant un objet définissant les scripts à enregistrer. La méthode renvoie une promesse qui est résolue par un objet `{{WebExtAPIRef("userScripts.RegisteredUserScript","RegisteredUserScript")}}`.
 
-> **Note :** Les scripts utilisateur sont désenregistrés lorsque la page d'extension correspondante (à partir de laquelle les scripts utilisateur ont été enregistrés) est déchargée, vous devez donc enregistrer un script utilisateur depuis une page d'extension qui persiste au moins aussi longtemps que vous voulez que les scripts utilisateur restent enregistrés
+> [!NOTE]
+> Les scripts utilisateur sont désenregistrés lorsque la page d'extension correspondante (à partir de laquelle les scripts utilisateur ont été enregistrés) est déchargée, vous devez donc enregistrer un script utilisateur depuis une page d'extension qui persiste au moins aussi longtemps que vous voulez que les scripts utilisateur restent enregistrés
 
 ## Types
 

--- a/files/fr/mozilla/add-ons/webextensions/api/userscripts/register/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/userscripts/register/index.md
@@ -52,7 +52,8 @@ Contrairement aux options de script de contenu, l'objet userScriptOptions n'a pa
 
 Une {{JSxRef("Promise")}} qui sera rempli avec un objet {{WebExtAPIRef("userScripts.RegisteredUserScript","RegisteredUserScript")}} que vous pouvez utiliser pour désinscrire ce script utilisateur particulier.
 
-> **Note :** Actuellement, les scripts utilisateur sont désenregistrés lorsque la page d'extension correspondante (à partir de laquelle les scripts utilisateur ont été enregistrés) est déchargée, vous devez donc enregistrer un script utilisateur depuis une page d'extension qui persiste au moins aussi longtemps que vous voulez que les scripts utilisateur restent enregistrés.
+> [!NOTE]
+> Actuellement, les scripts utilisateur sont désenregistrés lorsque la page d'extension correspondante (à partir de laquelle les scripts utilisateur ont été enregistrés) est déchargée, vous devez donc enregistrer un script utilisateur depuis une page d'extension qui persiste au moins aussi longtemps que vous voulez que les scripts utilisateur restent enregistrés.
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/index.md
@@ -9,7 +9,8 @@ Un RegisteredUserScript est retourné par un appel à {{WebExtAPIRef("userScript
 
 L'objet définit une méthode unique, {{WebExtAPIRef("userScripts.RegisteredUserScript.unregister","unregister()")}}, qui peut être utilisée pour désinscrire les scripts utilisateur.
 
-> **Note :** Si cet objet est détruit (par exemple parce qu'il sort du champ d'application), les scripts associés seront automatiquement désenregistrés, vous devez donc conserver une référence à cet objet aussi longtemps que vous voulez que les scripts de contenu restent enregistrés.
+> [!NOTE]
+> Si cet objet est détruit (par exemple parce qu'il sort du champ d'application), les scripts associés seront automatiquement désenregistrés, vous devez donc conserver une référence à cet objet aussi longtemps que vous voulez que les scripts de contenu restent enregistrés.
 
 ## Méthodes
 

--- a/files/fr/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/unregister/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/unregister/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript/unregis
 
 La méthode `unregister()` de l'interface {{WebExtAPIRef("userScripts.RegisteredUserScript","RegisteredUserScript")}} désenregistre le script utilisateur représenté par cette instance d'interface et précédemment enregistré via {{WebExtAPIRef("userScripts.register","userScripts.register()")}}.
 
-> **Note :** Les scripts utilisateur sont automatiquement désenregistrés lorsque la page d'extension correspondante (à partir de laquelle les scripts utilisateur ont été enregistrés) est déchargée, vous devez donc enregistrer un script utilisateur depuis une page d'extension qui persiste au moins aussi longtemps que vous voulez que les scripts utilisateur restent enregistrés..
+> [!NOTE]
+> Les scripts utilisateur sont automatiquement désenregistrés lorsque la page d'extension correspondante (à partir de laquelle les scripts utilisateur ont été enregistrés) est déchargée, vous devez donc enregistrer un script utilisateur depuis une page d'extension qui persiste au moins aussi longtemps que vous voulez que les scripts utilisateur restent enregistrés..
 
 ## Syntaxe
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
@@ -81,7 +81,7 @@ browser.browserAction.onClicked.addListener(function () {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation). Cette documentation est dérivée de [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
@@ -71,7 +71,7 @@ gettingFrame.then(onGot, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation). Cette documentation est dérivée de [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/index.md
@@ -76,7 +76,7 @@ Pour utiliser cette API, vous devez avoir la [permission](/fr/Add-ons/WebExtensi
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation). Cette documentation est dérivée de [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
@@ -80,7 +80,7 @@ browser.webNavigation.onBeforeNavigate.addListener(logOnBefore, filter);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation). Cette documentation est dérivée de [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
@@ -86,7 +86,7 @@ browser.webNavigation.onCommitted.addListener(logOnCommitted, filter);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation). Cette documentation est dérivée de [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
@@ -78,7 +78,7 @@ browser.webNavigation.onCompleted.addListener(logOnCompleted, filter);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation). Cette documentation est dérivée de [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
@@ -94,7 +94,7 @@ browser.webNavigation.onCreatedNavigationTarget.addListener(
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation). Cette documentation est dérivée de [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
@@ -81,7 +81,7 @@ browser.webNavigation.onDOMContentLoaded.addListener(
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation). Cette documentation est dérivée de [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
@@ -81,7 +81,7 @@ browser.webNavigation.onErrorOccurred.addListener(logOnErrorOccurred, filter);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation). Cette documentation est dérivée de [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
@@ -87,7 +87,7 @@ browser.webNavigation.onHistoryStateUpdated.addListener(
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation). Cette documentation est dérivée de [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
@@ -85,7 +85,7 @@ browser.webNavigation.onReferenceFragmentUpdated.addListener(
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation). Cette documentation est dérivée de [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
@@ -65,7 +65,7 @@ browser.webNavigation.onTabReplaced.addListener(logOnTabReplaced);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation#event-onTabReplaced) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
@@ -24,7 +24,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation). Cette documentation est dérivée de [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.md
@@ -42,7 +42,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webNavigation`](https://developer.chrome.com/extensions/webNavigation). Cette documentation est dérivée de [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) dans le code de Chromium code.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
@@ -47,7 +47,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
@@ -59,7 +59,7 @@ flushingCache.then(onFlushed, onError);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
@@ -24,7 +24,7 @@ Un `tableau` d'`objet`s. Chaque objet a les propriétés suivantes :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/index.md
@@ -54,7 +54,8 @@ Sur certains de ces événements, vous pouvez modifier la demande. Plus précis�
 
 Pour ce faire, vous devez transmettre une option avec la valeur "blocking" dans l'argument `extraInfoSpec` à la fonction `addListener()` de l'événement. Cela rend l'auditeur synchrone. Dans l'écouteur, vous pouvez alors renvoyer un objet {{WebExtAPIRef("webRequest.BlockingResponse", "BlockingResponse")}}, qui indique la modification à apporter : par exemple, l'en-tête de requête modifié que vous souhaitez envoyer.
 
-> **Attention :** Les protocoles non-HTTP(S) ne supportent pas actuellement la fonctionnalité de "`blockage`", donc la modification de ces requêtes n'est pas disponible pour le moment. Voir le [bug Firefox 1475832](https://bugzil.la/1475832) pour plus de détails.
+> [!WARNING]
+> Les protocoles non-HTTP(S) ne supportent pas actuellement la fonctionnalité de "`blockage`", donc la modification de ces requêtes n'est pas disponible pour le moment. Voir le [bug Firefox 1475832](https://bugzil.la/1475832) pour plus de détails.
 
 ## Accéder aux informations de sécurité
 
@@ -130,7 +131,7 @@ Pour ce faire, vous devez disposer de la permission de l'API "webRequestBlocking
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.md
@@ -15,7 +15,7 @@ Cette propriété est en lecture seule.
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
@@ -279,7 +279,7 @@ browser.webRequest.onErrorOccurred.addListener(completed, { urls: [target] });
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >


### PR DESCRIPTION
This PR converts the noteblocks for the French locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 6. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
