### PR TITLE
fr: Convert noteblocks to GFM Alerts (part 7)

### DIFF
--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/session/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/session/index.md
@@ -31,7 +31,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.sessions`](https://developer.chrome.com/extensions/sessions).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
@@ -60,7 +60,7 @@ gettingPanel.then(onGot);
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Opera [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
@@ -64,7 +64,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Opera [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.md
@@ -17,7 +17,7 @@ Un objet [`ImageData`](/fr/docs/Web/API/ImageData).
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Opera [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/).
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
@@ -142,7 +142,7 @@ browser.webRequest.onBeforeRedirect.addListener(logResponse, {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -244,7 +244,7 @@ browser.webRequest.onBeforeRequest.addListener(
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
@@ -227,7 +227,7 @@ browser.webRequest.onBeforeSendHeaders.addListener(
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
@@ -143,7 +143,7 @@ browser.webRequest.onCompleted.addListener(logResponse, { urls: [target] });
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
@@ -133,7 +133,7 @@ browser.webRequest.onErrorOccurred.addListener(logError, { urls: [target] });
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
@@ -188,7 +188,7 @@ browser.webRequest.onHeadersReceived.addListener(
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
@@ -142,7 +142,7 @@ browser.webRequest.onResponseStarted.addListener(logResponse, {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
@@ -138,7 +138,7 @@ browser.webRequest.onSendHeaders.addListener(
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
@@ -28,7 +28,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
@@ -73,7 +73,7 @@ Les valeurs de ce type sont des chaînes de caractères. Les valeurs possibles s
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
@@ -22,7 +22,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API Chromium [`chrome.webRequest`](https://developer.chrome.com/extensions/webRequest). Cette documentation est dérivée de [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) dans le code Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/create/index.md
@@ -137,7 +137,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/createtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/createtype/index.md
@@ -22,7 +22,7 @@ Les valeurs de ce type sont des objets `strings`. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/get/index.md
@@ -31,7 +31,7 @@ var getting = browser.windows.get(
     - `windowTypes`{{optional_inline}}
       - : `Ensemble d'objets` {{WebExtAPIRef('windows.WindowType')}}. Si défini, le retour de {{WebExtAPIRef('windows.Window')}} sera filtré en fonction de son type. Si désactivé, le filtre par défaut est réglé sur `['normal', 'panel', 'popup']`, avec des types de fenêtres `'panel'` qui sont limités aux propres fenêtres de l'extension.
 
-> **Note :**
+> [!NOTE]
 >
 > Si fourni, le composant `windowTypes` de `getInfo` est ignoré. L'utilisation de `windowTypes` a été dépréciée à partir de Firefox 62.
 
@@ -43,7 +43,8 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 
 Cet exemple obtient la fenêtre actuelle et enregistre les URL des onglets qu'il contient. Notez que vous aurez besoin des [permission](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) "onglets" pour accéder aux URL des onglets.
 
-> **Note :** Cet exemple est un peu irréaliste: dans cette situation, vous utiliserez probablement {{WebExtAPIRef("windows.getCurrent()")}}.
+> [!NOTE]
+> Cet exemple est un peu irréaliste: dans cette situation, vous utiliserez probablement {{WebExtAPIRef("windows.getCurrent()")}}.
 
 ```js
 function logTabs(windowInfo) {
@@ -68,7 +69,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/getall/index.md
@@ -67,7 +67,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
@@ -30,7 +30,7 @@ var gettingCurrent = browser.windows.getCurrent(
     - `windowTypes`{{optional_inline}}
       - : Un ensemble d'objets `{{WebExtAPIRef('windows.WindowType')}}`. Si défini, le {{WebExtAPIRef('windows.Window')}} retourné sera filtré en fonction de son type. Si désactivé, le filtre par défaut est réglé sur `['normal', 'panel', 'popup']`, avec des types de fenêtres `'panneau'` qui sont limités aux propres fenêtres de l'extension.
 
-> **Note :**
+> [!NOTE]
 >
 > Si fourni, le composant `windowTypes` de `getInfo` est ignoré. L'utilisation de `windowTypes` a été dépréciée à partir de Firefox 62.
 
@@ -65,7 +65,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
@@ -28,7 +28,7 @@ var gettingWindow = browser.windows.getLastFocused(
     - `windowTypes`{{optional_inline}}
       - : Un ensemble d'objets {{WebExtAPIRef('windows.WindowType')}}. Si défini, le {{WebExtAPIRef('windows.Window')}} retourné sera filtré en fonction de son type. Si désactivé, le filtre par défaut est réglé sur `['normal', 'panel', 'popup']`, avec le type de fenêtre `'panel'` qui sont limités aux propres fenêtres de l'extension.
 
-> **Note :**
+> [!NOTE]
 >
 > Si fourni, le composant `windowTypes` de `getInfo` est ignoré. L'utilisation de `windowTypes` a été dépréciée à partir de Firefox 62.
 
@@ -63,7 +63,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/index.md
@@ -57,7 +57,7 @@ Intéragissez avec les fenêtres du navigateur. Vous pouvez utiliser cette API p
 
 {{WebExtExamples("h2")}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
@@ -51,7 +51,7 @@ browser.windows.onCreated.addListener((window) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/API/windows/onFocusChanged
 
 Attiré lorsque la fenêtre actuellement change. Sera {{WebExtAPIRef('windows.WINDOW_ID_NONE')}} si toutes les fenêtres du navigateur ont perdu le focus.
 
-> **Note :** Sur certains gestionnaires de fenêtres Linux, WINDOW_ID_NONE sera toujours envoyé immédiatement avant un passage d'une fenêtre de navigateur à l'autre.
+> [!NOTE]
+> Sur certains gestionnaires de fenêtres Linux, WINDOW_ID_NONE sera toujours envoyé immédiatement avant un passage d'une fenêtre de navigateur à l'autre.
 
 ## Syntaxe
 
@@ -53,7 +54,7 @@ browser.windows.onFocusChanged.addListener((windowId) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
@@ -51,7 +51,7 @@ browser.windows.onRemoved.addListener((windowId) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/remove/index.md
@@ -69,7 +69,7 @@ Dans Firefox, la même chose pourrait être réalisée avec la propriété de cr
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/update/index.md
@@ -75,7 +75,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/window/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/window/index.md
@@ -47,7 +47,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/window_id_current/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/window_id_current/index.md
@@ -13,7 +13,7 @@ slug: Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_CURRENT
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/window_id_none/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/window_id_none/index.md
@@ -13,7 +13,7 @@ La valeur `windowId` que représente l'absence d'une fenêtre du navigateur.
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
@@ -30,7 +30,7 @@ Compatibilité macOS : A partir de macOS 10.10, le comportement de maximisation 
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
@@ -22,7 +22,7 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 {{WebExtExamples}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette API est basée sur l'API de Chromnium [`chrome.windows`](https://developer.chrome.com/extensions/windows). Cette documentation provient de [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) dans le code de Chromium.
 >

--- a/files/fr/mozilla/add-ons/webextensions/browser_support_for_javascript_apis/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/browser_support_for_javascript_apis/index.md
@@ -7,7 +7,7 @@ slug: Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs
 
 {{WebExtAllCompatTables}}
 
-> **Note :**
+> [!NOTE]
 >
 > Les données de compatibilité Microsoft Edge sont fournies par Microsoft Corporation et sont incluses ici sous la licence Creative Commons Attribution 3.0 United States.
 

--- a/files/fr/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -42,7 +42,8 @@ Il existe deux approches pour gérer les événements asynchrones utilisées par
 
 Firefox prend également en charge les _callbacks_ pour les API qui prennent en charge l'espace de noms `chrome.*`. Cependant, il est recommandé d'utiliser des promesses (et l'espace de noms `browser.*` du navigateur). Des promesses ont été adoptées dans le cadre de la norme proposée. Cette approche simplifie grandement la gestion asynchrone des événements, en particulier lorsque vous devez enchaîner des événements.
 
-> **Note :** Si vous n'êtes pas familier avec les différences entre ces deux méthodes, jetez un coup d'oeil à [Apprendre à connaître le JavaScript asynchrone : Rappels, promesses et synchronisation/attente](https://medium.com/codebuddies/getting-to-know-asynchronous-javascript-callbacks-promises-and-async-await-17e0673281ee) ou la page sur [l'utilisation des promesses](/fr/docs/Web/JavaScript/Guide/Utiliser_les_promesses) de MDN.
+> [!NOTE]
+> Si vous n'êtes pas familier avec les différences entre ces deux méthodes, jetez un coup d'oeil à [Apprendre à connaître le JavaScript asynchrone : Rappels, promesses et synchronisation/attente](https://medium.com/codebuddies/getting-to-know-asynchronous-javascript-callbacks-promises-and-async-await-17e0673281ee) ou la page sur [l'utilisation des promesses](/fr/docs/Web/JavaScript/Guide/Utiliser_les_promesses) de MDN.
 
 #### Polyfill pour l'API WebExtension du navigateur
 
@@ -69,7 +70,8 @@ Ainsi, par exemple, ce code `manifest.json` rend le _polyfill_ disponible pour v
 
 Votre but est de vous assurer que le _polyfill_ s'exécute dans votre extension avant tout autre script qui attend le `browser.*` API namespace s'exécute.
 
-> **Note :** Pour plus de détails et d'informations sur l'utilisation du _polyfill_ avec un module bundler, voir le [readme du projet sur GitHub.](https://github.com/mozilla/webextension-polyfill/blob/master/README.md)
+> [!NOTE]
+> Pour plus de détails et d'informations sur l'utilisation du _polyfill_ avec un module bundler, voir le [readme du projet sur GitHub.](https://github.com/mozilla/webextension-polyfill/blob/master/README.md)
 
 Il existe d'autres options de _polyfill_ mais, au moment où nous écrivons ces lignes, aucune ne fournit une couverture équivalente à ce _polyfill_ pour l'API WebExtension du navigateur. Ainsi, lorsque vous n'avez pas choisi Firefox comme cible initiale de navigateur, vos options sont d'accepter les limitations des _polyfills_ alternatifs, de porter sur Firefox et d'ajouter la prise en charge multi-navigateur, ou de développer votre propre _polyfill_.
 

--- a/files/fr/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -13,7 +13,8 @@ Tout comme les scripts habituellement chargés par les pages web classiques, les
 
 Les scripts de contenu ne peuvent accéder qu'à [un sous-ensemble des API WebExtension](<#API WebExtensions>), mais ils peuvent [communiquer avec les scripts d'arrière-plan](#communication_background) grâce à un système de messages et ainsi accéder indirectement aux API WebExtension.
 
-> **Note :** que les scripts de contenu sont bloqués sur les domaines suivants :
+> [!NOTE]
+> Que les scripts de contenu sont bloqués sur les domaines suivants :
 >
 > - accounts-static.cdn.mozilla.net
 > - accounts.firefox.com
@@ -35,7 +36,8 @@ Les scripts de contenu ne peuvent accéder qu'à [un sous-ensemble des API WebEx
 >
 > Because these restrictions include addons.mozilla.org, users may attempt to use your extension immediately after installation—only to find that it doesn't work! You may want to add an appropriate warning, or an [onboarding page](/fr/docs/Mozilla/Add-ons/WebExtensions/onboarding_upboarding_offboarding_best_practices) to move users away from addons.mozilla.org.
 
-> **Note :** Les valeurs ajoutées à la portée globale d'un script de contenu avec `var foo` ou `window.foo = "bar"` peuvent disparaître à cause du bogue [1408996](https://bugzilla.mozilla.org/show_bug.cgi?id=1408996).
+> [!NOTE]
+> Les valeurs ajoutées à la portée globale d'un script de contenu avec `var foo` ou `window.foo = "bar"` peuvent disparaître à cause du bogue [1408996](https://bugzilla.mozilla.org/show_bug.cgi?id=1408996).
 
 ## Charger des scripts de contenu
 
@@ -132,7 +134,8 @@ Si un script de contenu veut utiliser une bibliothèque JavaScript, alors la bib
 ]
 ```
 
-> **Note :** Firefox _fournis_ certaines API qui permettent aux scripts de contenu d'accéder aux objets JavaScript créés par les scripts de page et d'exposer leurs propres objets JavaScript aux scripts de page.
+> [!NOTE]
+> Firefox _fournis_ certaines API qui permettent aux scripts de contenu d'accéder aux objets JavaScript créés par les scripts de page et d'exposer leurs propres objets JavaScript aux scripts de page.
 >
 > Voir [Partage d'objets avec des scripts de page](/fr/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts) pour plus de détails.
 
@@ -402,7 +405,8 @@ window.addEventListener("message", function (event) {
 
 Pour un exemple complet et fonctionnel, [visitez la page de démo sur Github](https://mdn.github.io/webextensions-examples/content-script-page-script-messaging.html) et suivez les instructions.
 
-> **Attention :** Notez que vous devez être très prudent lorsque vous interagissez avec du contenu Web non fiable de cette manière. Les extensions sont du code privilégié qui peut avoir de puissantes capacités et les pages Web hostiles peuvent facilement les amener à accéder à ces capacités.
+> [!WARNING]
+> Notez que vous devez être très prudent lorsque vous interagissez avec du contenu Web non fiable de cette manière. Les extensions sont du code privilégié qui peut avoir de puissantes capacités et les pages Web hostiles peuvent facilement les amener à accéder à ces capacités.
 >
 > Pour donner un exemple trivial, supposons que le code du script de contenu qui reçoit le message ressemble à ceci&nbsp;:
 >
@@ -483,7 +487,8 @@ Dans le script de la page, window.y: undefined
 
 La même chose s'applique pour [`setTimeout()`](/fr/docs/Web/API/WindowTimers/setTimeout), [`setInterval()`](/fr/docs/Web/API/WindowTimers/setInterval), et [`Function()`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Function).
 
-> **Attention :** Lorsque vous exécutez du code dans le contexte de la page, l'avertissement précédent reste nécessaire : l'environnement de la page est contrôlé par des pages web potentiellement malveillantes qui peuvent redéfinir les objets avec lesquels vous interagissez&nbsp;:
+> [!WARNING]
+> Lorsque vous exécutez du code dans le contexte de la page, l'avertissement précédent reste nécessaire : l'environnement de la page est contrôlé par des pages web potentiellement malveillantes qui peuvent redéfinir les objets avec lesquels vous interagissez&nbsp;:
 >
 > ```js
 > // page.js redéfinit console.log

--- a/files/fr/mozilla/add-ons/webextensions/developing_webextensions_for_thunderbird/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/developing_webextensions_for_thunderbird/index.md
@@ -9,7 +9,8 @@ Vous aborderez le codage d'une extension pour Thunderbird de la même manière q
 
 ## Différences des API
 
-> **Note :** Voir la documentation de l'API WebExtension de [ReadTheDocs](https://thunderbird-webextensions.readthedocs.io/en/latest/) pour Thunderbird.
+> [!NOTE]
+> Voir la documentation de l'API WebExtension de [ReadTheDocs](https://thunderbird-webextensions.readthedocs.io/en/latest/) pour Thunderbird.
 
 Étant tous deux basés sur Gecko, Thunderbird supporte plusieurs des APIs que Firefox supporte, avec quelques différences, voir la [compatibilité du navigateur pour manifest.json](/fr/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json) et le [support du navigateur pour les APIs JavaScript](/fr/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs) pour les détails.
 

--- a/files/fr/mozilla/add-ons/webextensions/examples/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/examples/index.md
@@ -9,7 +9,8 @@ Pour illustrer la manière d'utiliser les API WebExtension, nous disposons d'un 
 
 Ces exemples fonctionnent dans Firefox Nightly : la plupart travaillent dans les versions antérieures de Firefox, mais vérifiez la version minimum [strict_min_version](/fr/Add-ons/WebExtensions/manifest.json/applications) dans le fichier manifest.json de l'extension pour en être sur.
 
-> **Attention :** Certains exemples ne fonctionnent que sur des domaines ou des pages spécifiques. Les détails des restrictions éventuelles sont fournis dans le fichier "readme" de chaque exemple. Aucun des exemples ne fonctionne par défaut dans les fenêtres de navigation privée, voir [Extensions dans la navigation privée](https://support.mozilla.org/en-US/kb/extensions-private-browsing#w_enabling-or-disabling-extensions-in-private-windows) pour plus de détails.
+> [!WARNING]
+> Certains exemples ne fonctionnent que sur des domaines ou des pages spécifiques. Les détails des restrictions éventuelles sont fournis dans le fichier "readme" de chaque exemple. Aucun des exemples ne fonctionne par défaut dans les fenêtres de navigation privée, voir [Extensions dans la navigation privée](https://support.mozilla.org/en-US/kb/extensions-private-browsing#w_enabling-or-disabling-extensions-in-private-windows) pour plus de détails.
 
 Pour essayer ces exemples, clonez ensuite le dépôt :
 
@@ -17,7 +18,8 @@ Pour essayer ces exemples, clonez ensuite le dépôt :
 2. Couvrir le dossier source de l'extension en ligne de commande et utiliser le [web-ext](/fr/Add-ons/WebExtensions/Getting_started_with_web-ext) pour exécuter l'extension. L'extension reste chargée jusqu'à ce que vous redémarriez Firefox.
 3. Dans Firefox utilisez **File** > **Open File** et trouvez l'exemple dans le dossier de [`build`](https://github.com/mdn/webextensions-examples/tree/master/build). Le dossier `build` contient les versions construites et signées de tous les exemples. L'exemple est ainsi installé de façon permanente.
 
-> **Attention :** Veuillez ne pas soumettre ces exemples de WebExtension à AMO (addons.mozilla.org), vous n'avez pas besoin de signer l'add-on pour exécuter les exemples de WebExtension. Il suffit de suivre les étapes ci-dessus.
+> [!WARNING]
+> Veuillez ne pas soumettre ces exemples de WebExtension à AMO (addons.mozilla.org), vous n'avez pas besoin de signer l'add-on pour exécuter les exemples de WebExtension. Il suffit de suivre les étapes ci-dessus.
 
 Si vous souhaitez contribuer au dépôt, [envoyez-nous une demande](https://github.com/mdn/webextensions-examples/blob/master/CONTRIBUTING.md)
 

--- a/files/fr/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/Extending_the_developer_tools
 
 {{AddonSidebar}}
 
-> **Note :** Cette page décrit les API de devtools telles qu'elles existent dans Firefox 55. Bien que les API soient basées sur les [API devtools de chrome](https://developer.chrome.com/extensions/devtools), il existe encore de nombreuses fonctionnalités qui ne sont pas encore implémentées dans Firefox et ne sont donc pas documentées ici. Pour voir quelles fonctionnalités sont actuellement manquantes, voir les [Limitations des APIs devtools](/fr/Add-ons/WebExtensions/Using_the_devtools_APIs#Limitations_of_the_devtools_APIs).
+> [!NOTE]
+> Cette page décrit les API de devtools telles qu'elles existent dans Firefox 55. Bien que les API soient basées sur les [API devtools de chrome](https://developer.chrome.com/extensions/devtools), il existe encore de nombreuses fonctionnalités qui ne sont pas encore implémentées dans Firefox et ne sont donc pas documentées ici. Pour voir quelles fonctionnalités sont actuellement manquantes, voir les [Limitations des APIs devtools](/fr/Add-ons/WebExtensions/Using_the_devtools_APIs#Limitations_of_the_devtools_APIs).
 
 Vous pouvez utiliser les API WebExtensions pour étendre les outils de développement intégrés du navigateur. Pour créer une extension devtools, incluez la clé "[devtools_page](/fr/Add-ons/WebExtensions/manifest.json/devtools_page)" dans [manifest.json](/fr/Add-ons/WebExtensions/manifest.json):
 
@@ -80,7 +81,8 @@ C'est un peu comme utiliser {{WebExtAPIRef("tabs.executeScript()")}} pour inject
 
 - Contrairement aux scripts de contenu, les scripts chargés à partir de `devtools.inspectedWindow.eval()` **n'obtiennent pas** [une "vue nette du DOM"](/fr/Add-ons/WebExtensions/Content_scripts#DOM_access) : c'est-à-dire qu'ils peuvent voir des modifications apportées à la page par les scripts de page.
 
-> **Note :** Une vue propre du DOM est une fonction de sécurité destinée à empêcher les pages hostiles de tromper WebExtensions en redéfinissant le comportement des fonctions DOM natives. Cela signifie que vous devez être très prudent en utilisant eval () et utiliser un script de contenu normal si vous le pouvez.
+> [!NOTE]
+> Une vue propre du DOM est une fonction de sécurité destinée à empêcher les pages hostiles de tromper WebExtensions en redéfinissant le comportement des fonctions DOM natives. Cela signifie que vous devez être très prudent en utilisant eval () et utiliser un script de contenu normal si vous le pouvez.
 
 Les scripts chargés à l'aide de `devtools.inspectedWindow.eval()` ne voient pas non plus de variables JavaScript définies par les scripts de contenu.
 

--- a/files/fr/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
@@ -13,7 +13,8 @@ Avec les WebExtensions, les paramètres sont généralement stockés en utilisan
 - Écrire un script, inclus depuis le fichier HTML, qui alimente les paramètres depuis le stockage et met à jour les paramètres stockés quand l'utilisateur les change.
 - Renseigner le chemin du fichier HTML come clé de [`options_ui`](/fr/Add-ons/WebExtensions/manifest.json/options_ui) dans manifest.json. Ainsi, le document HTML sera affiché dans le gestionnaire d'extension, aux cotés des nom et description de l'extension.
 
-> **Note :** Vous pouvez aussi ouvrir cette page automatiquement en utilisant la fonction [`runtime.openOptionsPage()`](/fr/Add-ons/WebExtensions/API/runtime/openOptionsPage).
+> [!NOTE]
+> Vous pouvez aussi ouvrir cette page automatiquement en utilisant la fonction [`runtime.openOptionsPage()`](/fr/Add-ons/WebExtensions/API/runtime/openOptionsPage).
 
 ## Une WebExtension simple
 
@@ -146,11 +147,13 @@ Cela fait deux choses :
 
 Vous pouvez stocker les valeurs des paramètres dans le stockage local à la place si vous pensez que le stockage local est préférable pour votre extension.
 
-> **Note :** L'implémentation de `storage.sync` dans Firefox repose sur l'ID du module complémentaire. Si vous utilisez `storage.sync`, vous devez définir un ID pour votre extension à l'aide de la clé manifest.json des [`applications`](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/applications) comme indiqué dans l'exemple de manifeste ci-dessus.
+> [!NOTE]
+> L'implémentation de `storage.sync` dans Firefox repose sur l'ID du module complémentaire. Si vous utilisez `storage.sync`, vous devez définir un ID pour votre extension à l'aide de la clé manifest.json des [`applications`](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/applications) comme indiqué dans l'exemple de manifeste ci-dessus.
 
 Finalement, mettez à jour "borderify.js" pour lire la couleur de la bordure depuis le stockage :
 
-> **Attention :** A cause d'un bug dans [browser.storage.local.get()](/fr/Add-ons/WebExtensions/API/storage/StorageArea/get) dans Firefox pour les versions précédant la 52, le code qui suit ne fonctionnera pas. Pour le faire fonctionner pour les versions de Firefox avant la 52, les deux occurrences d'`item.color` dans `onGot()` doivent être changer pour `item[0].color`.
+> [!WARNING]
+> A cause d'un bug dans [browser.storage.local.get()](/fr/Add-ons/WebExtensions/API/storage/StorageArea/get) dans Firefox pour les versions précédant la 52, le code qui suit ne fonctionnera pas. Pour le faire fonctionner pour les versions de Firefox avant la 52, les deux occurrences d'`item.color` dans `onGot()` doivent être changer pour `item[0].color`.
 
 ```js
 function onError(error) {

--- a/files/fr/mozilla/add-ons/webextensions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/index.md
@@ -18,7 +18,8 @@ La technologie d'extensions Firefox est, en grande partie, compatible avec l'[AP
 - Flux de travail pour Firefox
   - : Découvrez comment créer et publier des extensions pour Firefox : plongez dans le fonctionnement des outils de développement, de la publication, de la distribution, et du portage avec [l'atelier des extensions Firefox](https://extensionworkshop.com/).
 
-> **Note :** Si vous avez des idées, des questions ou si vous avez besoin d'aide, vous pouvez nous contacter sur [le forum communautaire](https://discourse.mozilla.org/c/add-ons) ou sur [le salon Add-ons](https://matrix.to/#/!CuzZVoCbeoDHsxMCVJ:mozilla.org?via=mozilla.org&via=matrix.org&via=humanoids.be) sur [Matrix](https://wiki.mozilla.org/Matrix).
+> [!NOTE]
+> Si vous avez des idées, des questions ou si vous avez besoin d'aide, vous pouvez nous contacter sur [le forum communautaire](https://discourse.mozilla.org/c/add-ons) ou sur [le salon Add-ons](https://matrix.to/#/!CuzZVoCbeoDHsxMCVJ:mozilla.org?via=mozilla.org&via=matrix.org&via=humanoids.be) sur [Matrix](https://wiki.mozilla.org/Matrix).
 
 ## Premiers pas
 

--- a/files/fr/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard
 
 La gestion du presse-papier avec les extensions s'effectue avec l'objet [`navigator.clipboard`](/fr/docs/Web/API/Clipboard) (elle s'effectuait avant avec la méthode [`document.execCommand()`](/fr/docs/Web/API/Document/execCommand) qui est désormais dépréciée).
 
-> **Note :** L'API [`navigator.clipboard`](/fr/docs/Web/API/Clipboard) est un ajout relativement récent à la spécification et peut ne pas être complètement implémentée par l'ensemble des navigateurs. Cet article décrit certaines des limitations, mais il est préférable de vérifier les tableaux de compatibilité de chaque méthode avant de les utiliser.
+> [!NOTE]
+> L'API [`navigator.clipboard`](/fr/docs/Web/API/Clipboard) est un ajout relativement récent à la spécification et peut ne pas être complètement implémentée par l'ensemble des navigateurs. Cet article décrit certaines des limitations, mais il est préférable de vérifier les tableaux de compatibilité de chaque méthode avant de les utiliser.
 
 La différence entre les deux API peut se décrire ainsi&nbsp;: [`document.execCommand()`](/fr/docs/Web/API/Document/execCommand) est analogue aux actions de copier/coller/couper du clavier en échangeant des données entre une page web et un presse-papier tandis que [`navigator.clipboard`](/fr/docs/Web/API/Clipboard) permet de lire et d'écrire des données arbitraires dans le presse-papier.
 
@@ -39,7 +40,8 @@ navigator.permissions.query({ name: "clipboard-write" }).then((result) => {
 });
 ```
 
-> **Note :** La permission intitulée `clipboard-write` est uniquement prise en charge pour les navigateurs basés sur Chromium et pas dans Firefox.
+> [!NOTE]
+> La permission intitulée `clipboard-write` est uniquement prise en charge pour les navigateurs basés sur Chromium et pas dans Firefox.
 
 La fonction qui suit prend en argument une chaîne de caractères et l'écrit dans le presse-papier&nbsp;:
 

--- a/files/fr/mozilla/add-ons/webextensions/internationalization/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/internationalization/index.md
@@ -9,7 +9,8 @@ l10n:
 
 L'API [WebExtensions](/fr/docs/Mozilla/Add-ons/WebExtensions) dispose d'un module pour [l'internationalisation](/fr/docs/Glossary/Internationalization) des extensions&nbsp;: [`i18n`](/fr/docs/Mozilla/Add-ons/WebExtensions/API/i18n). Dans cet article, nous allons explorer ses fonctionnalités et illustrer son utilisation par un exemple pratique. L'API `i18n` pour les extensions web est similaire aux bibliothèques JavaScript tierces d'internationalisation.
 
-> **Note :** L'exemple d'extension présenté dans cet article, [`notify-link-clicks-i18n`](https://github.com/mdn/webextensions-examples/tree/main/notify-link-clicks-i18n), est disponible sur GitHub. Suivez le code source pendant que vous parcourez cette page.
+> [!NOTE]
+> L'exemple d'extension présenté dans cet article, [`notify-link-clicks-i18n`](https://github.com/mdn/webextensions-examples/tree/main/notify-link-clicks-i18n), est disponible sur GitHub. Suivez le code source pendant que vous parcourez cette page.
 
 ## Anatomie d'une extension internationalisée
 
@@ -34,9 +35,11 @@ Examinons chacune de ces fonctionnalités supplémentaires. Chacune des sections
 
 L'internationalisation nécessite de fournir des chaînes traduites pour les différentes locales qu'on souhaite prendre en charge. Pour les extensions, le répertoire `_locales`, présent à la racine de l'extension, contient un sous-répertoire pour chaque locale, nommé grâce à [l'étiquette de langue correspondante](https://fr.wikipedia.org/wiki/%C3%89tiquette_d%27identification_de_langues_IETF) et ce dernier contient un fichier `messages.json` avec les chaînes de caractères traduites pour la locale correspondante.
 
-> **Attention :** Contrairement à la convention qui consiste à séparer la sous-étiquette de base et celle de la variante régionale par un tiret (par exemple `en-US` ou `fr-CA`), **il faudra utiliser un tiret bas pour le nom du répertoire sous `_locales`** (par exemple `en_US` ou `fr_CA`).
+> [!WARNING]
+> Contrairement à la convention qui consiste à séparer la sous-étiquette de base et celle de la variante régionale par un tiret (par exemple `en-US` ou `fr-CA`), **il faudra utiliser un tiret bas pour le nom du répertoire sous `_locales`** (par exemple `en_US` ou `fr_CA`).
 
-> **Note :** Vous pouvez rechercher des étiquettes de langue à l'aide de [cet outil en ligne (en anglais)](https://r12a.github.io/app-subtags/). Notez que vous devez rechercher le nom anglais de la langue.
+> [!NOTE]
+> Vous pouvez rechercher des étiquettes de langue à l'aide de [cet outil en ligne (en anglais)](https://r12a.github.io/app-subtags/). Notez que vous devez rechercher le nom anglais de la langue.
 
 Dans [le répertoire `_locales` de notre exemple d'extension](https://github.com/mdn/webextensions-examples/tree/main/notify-link-clicks-i18n/_locales), nous avons des répertoires pour l'anglais (`en`), l'allemand (`de`), le français tel que parlé en France (`fr_FR`), le japonais (`ja`), le norvégien tel que parlé en Norvège (`nb_NO`), le néerlandais (`nl`), et le portugais brésilien (`pt_BR`). Chacun de ces répertoires contient un fichier `messages.json`.
 
@@ -74,7 +77,8 @@ Regardons maintenant la structure de l'un de ces fichiers ([`_locales/en/message
 
 Ce fichier est du JSON standard, chaque propriété est un objet avec un nom, qui contient une propriété `message` et une propriété `description`. Tous ces éléments sont des chaînes de caractères et `$URL$` est un emplacement de substitution qui sera remplacé par une sous-chaîne lorsque la propriété `notificationContent` sera manipulée par l'extension. Nous verrons comment faire dans la section [Récupération des messages localisés dans le code JavaScript](#récupérer_des_messages_localisés_dans_le_code_javascript).
 
-> **Note :** Pour plus d'informations sur le contenu des fichiers `messages.json`, voir [la référence des formats de messages localisés](/fr/docs/Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference).
+> [!NOTE]
+> Pour plus d'informations sur le contenu des fichiers `messages.json`, voir [la référence des formats de messages localisés](/fr/docs/Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference).
 
 ## Internationalisation du manifeste
 

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
@@ -79,7 +79,8 @@ Par exemple :
 
 ### Propriétés Microsoft Edge
 
-> **Attention :** L'ajout de propriétés spécifiques à Edge au manifeste a causé une erreur avant Firefox 69 qui peut empêcher l'extension de s'installer.
+> [!WARNING]
+> L'ajout de propriétés spécifiques à Edge au manifeste a causé une erreur avant Firefox 69 qui peut empêcher l'extension de s'installer.
 
 Microsoft Edge stocke les paramètres spécifiques à son navigateur dans la sous-clé `edge`, qui possède les propriétés suivantes :
 

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/externally_connectable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/externally_connectable/index.md
@@ -53,7 +53,8 @@ Une connexion externe permet au développeur d'extensions de contrôler quelles 
 
 Les correspondances permettent la communication entre cette extension et les pages Web. Voici une liste d'expressions régulières pour les URL de page avec lesquelles vous souhaitez communiquer.
 
-> **Note :** Si `browser_action` n'est pas spécifié, la communication entre les extensions est toujours autorisée, comme si `browser_action` était `{"ids": ["*"] }`, par conséquent, si vous spécifiez `browser_action.matches` n'oubliez pas d'ajouter des identifiants si vous souhaitez toujours communiquer. avec d'autres extensions.
+> [!NOTE]
+> Si `browser_action` n'est pas spécifié, la communication entre les extensions est toujours autorisée, comme si `browser_action` était `{"ids": ["*"] }`, par conséquent, si vous spécifiez `browser_action.matches` n'oubliez pas d'ajouter des identifiants si vous souhaitez toujours communiquer. avec d'autres extensions.
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/icons/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/icons/index.md
@@ -69,7 +69,8 @@ Vous pouvez utiliser SVG et le navigateur mettra à l'échelle appropriée votre
    }
    ```
 
-> **Note :** si vous utilisez un programme comme Inkscape pour créer un SVG, vous voudrez peut-être l'enregistrer en tant que "SVG simple". Firefox peut être gêné par des espaces de noms spéciaux, et ne pas afficher votre icône.
+> [!NOTE]
+> Si vous utilisez un programme comme Inkscape pour créer un SVG, vous voudrez peut-être l'enregistrer en tant que "SVG simple". Firefox peut être gêné par des espaces de noms spéciaux, et ne pas afficher votre icône.
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/manifest.json
 
 {{AddonSidebar}}
 
-> **Note :** Cet article décrit le format du fichier `manifest.json` pour les extensions web. Si vous cherchez des informations quant au manifeste des applications web progressives (PWA), consultez plutôt [l'article sur les manifestes d'application web](/fr/docs/Web/Manifest).
+> [!NOTE]
+> Cet article décrit le format du fichier `manifest.json` pour les extensions web. Si vous cherchez des informations quant au manifeste des applications web progressives (PWA), consultez plutôt [l'article sur les manifestes d'application web](/fr/docs/Web/Manifest).
 
 Le fichier `manifest.json` est le seul fichier que toute extension basée sur les API WebExtension doit contenir.
 
@@ -37,7 +38,8 @@ browser.runtime.getManifest().version;
 
 Le bloc qui suit illustre la syntaxe de certaines des clés les plus fréquemment utilisées.
 
-> **Note :** Il ne s'agit pas d'un exemple prêt à copier-coller. Lorsque vous développez une extension, sélectionnez avec soin les clés dont vous avez besoin.
+> [!NOTE]
+> Il ne s'agit pas d'un exemple prêt à copier-coller. Lorsque vous développez une extension, sélectionnez avec soin les clés dont vous avez besoin.
 
 Pour des exemples complets d'extensions, vous pouvez consulter [ces exemples d'extensions](/fr/docs/Mozilla/Add-ons/WebExtensions/Examples).
 

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/options_page/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/options_page/index.md
@@ -26,7 +26,8 @@ slug: Mozilla/Add-ons/WebExtensions/manifest.json/options_page
 
 {{Deprecated_Header}}
 
-> **Attention :** Cette clé du manifest a été dépréciée. Utilisez [`options_ui`](/fr/Add-ons/WebExtensions/manifest.json/options_ui)à la place.
+> [!WARNING]
+> Cette clé du manifest a été dépréciée. Utilisez [`options_ui`](/fr/Add-ons/WebExtensions/manifest.json/options_ui)à la place.
 
 Utilisez la clé d'`options_page` pour définir une [page d'options](/fr/Add-ons/WebExtensions/Options_pages) pour votre extension.
 

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/storage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/storage/index.md
@@ -34,7 +34,8 @@ Les données gérées déclarent les politiques d'entreprise soutenues par l'app
 
 Après avoir déclaré les politiques, elles sont lues à partir de l'API {{WebExtAPIRef("storage.managed")}}. Cependant, si une valeur de politique n'est pas conforme au schéma, elle n'est pas publiée par l'API `storage.managed`. Il appartient à l'application d'appliquer les politiques configurées par l'administrateur.
 
-> **Note :** Firefox ne définit pas de schéma pour le stockage géré, soir {{WebExtAPIRef("storage.managed")}} pour plus de détails.
+> [!NOTE]
+> Firefox ne définit pas de schéma pour le stockage géré, soir {{WebExtAPIRef("storage.managed")}} pour plus de détails.
 
 La clé de `storage` est un objet qui possède les propriétés requises suivantes:
 
@@ -56,6 +57,6 @@ La clé de `storage` est un objet qui possède les propriétés requises suivant
 
 {{Compat}}
 
-> **Note :**
+> [!NOTE]
 >
 > Cette page comprend les détails de la page du site web des développeurs de Chrome [Manifeste pour les zones de stockage](https://developer.chrome.com/apps/manifest/storage) incluses ici sous la licence Creative Commons Attribution 3.0 United States License.

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/theme/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/theme/index.md
@@ -36,11 +36,14 @@ slug: Mozilla/Add-ons/WebExtensions/manifest.json/theme
 
 Utilisez la clé du thème pour définir un thème statique à appliquer à Firefox.
 
-> **Note :** Si vous voulez inclure un thème avec une extension, veuillez voir l'API {{WebExtAPIRef("theme")}}.
+> [!NOTE]
+> Si vous voulez inclure un thème avec une extension, veuillez voir l'API {{WebExtAPIRef("theme")}}.
 
-> **Note :** Depuis mai 2019, les thèmes doivent être signés pour être installés ([bug Firefox 1545109](https://bugzil.la/1545109)). Voir [Signature et distribution votre extension](/fr/docs/Mozilla/Add-ons/Distribution) pour plus de détails.
+> [!NOTE]
+> Depuis mai 2019, les thèmes doivent être signés pour être installés ([bug Firefox 1545109](https://bugzil.la/1545109)). Voir [Signature et distribution votre extension](/fr/docs/Mozilla/Add-ons/Distribution) pour plus de détails.
 
-> **Note :** Prise en charge des thèmes dans Firefox pour Android : Une nouvelle version de Firefox pour Android, basée sur GeckoView, est en cours de développement. Une [pré-version](https://play.google.com/store/apps/details?id=org.mozilla.fenix) ne support pas les thèmes.
+> [!NOTE]
+> Prise en charge des thèmes dans Firefox pour Android : Une nouvelle version de Firefox pour Android, basée sur GeckoView, est en cours de développement. Une [pré-version](https://play.google.com/store/apps/details?id=org.mozilla.fenix) ne support pas les thèmes.
 
 ## Formats des images
 
@@ -270,7 +273,8 @@ Ces propriétés définissent les couleurs utilisées pour les différentes part
   </tbody>
 </table>
 
-> **Note :** Lorsqu'un composant est affecté par plusieurs propriétés de couleur, les propriétés sont listées par ordre de priorité.
+> [!NOTE]
+> Lorsqu'un composant est affecté par plusieurs propriétés de couleur, les propriétés sont listées par ordre de priorité.
 
 Toutes ces propriétés peuvent être spécifiées sous la forme d'une chaîne contenant un [code de couleur CSS](/fr/docs/Web/CSS/color_value), ou un tableau RVB tel que `"tab_background_text": [ 107 , 99 , 23 ]`, ou en héxadécimal, tel que `"tab_background_text": #6b6317`.
 
@@ -1250,7 +1254,8 @@ Toutes ces propriétés peuvent être spécifiées sous la forme d'une chaîne c
 
 En outre, cette clé accepte diverses propriétés qui sont des alias pour l'une des propriétés ci-dessus. Ceux-ci sont fournis pour la compatibilité avec Chrome. Si un alias est donné et que la version non-alias est également donnée, alors la valeur sera tirée de la version non-alias.
 
-> **Attention :** A partir de Firefox 70, les propriétés suivantes sont supprimées : `accentcolor` et `textcolor`. Utilisez à la place `frame` et `tab_background_text`. L'utilisation de ces valeurs dans des thèmes chargés dans Firefox 65 ou une version ultérieure augmentera les avertissements.
+> [!WARNING]
+> A partir de Firefox 70, les propriétés suivantes sont supprimées : `accentcolor` et `textcolor`. Utilisez à la place `frame` et `tab_background_text`. L'utilisation de ces valeurs dans des thèmes chargés dans Firefox 65 ou une version ultérieure augmentera les avertissements.
 
 | Nom                   | Alias pour                           |
 | --------------------- | ------------------------------------ |

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.md
@@ -45,9 +45,11 @@ Cette clé permet de définir les propriétés de la clé expérimentale de [`th
 
 Pour découvrir les sélecteurs CSS des éléments de l'interface utilisateur Firefox ou des variables CSS internes de Firefox, utilise la [boite à outils du navigateur](/fr/docs/Outils/Boîte_à_outils_du_navigateur).
 
-> **Note :** Cette clé est uniquement disponible pour une utilisation dans les canaux Firefox Developer Edition et Firefox Nightly et nécessite l'activation de la préférence `extensions.legacy.enabled`.
+> [!NOTE]
+> Cette clé est uniquement disponible pour une utilisation dans les canaux Firefox Developer Edition et Firefox Nightly et nécessite l'activation de la préférence `extensions.legacy.enabled`.
 
-> **Attention :** Cette fonctionnalité est expérimentale et peut être sujette à modification.
+> [!WARNING]
+> Cette fonctionnalité est expérimentale et peut être sujette à modification.
 
 ## Syntaxe
 

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
@@ -66,7 +66,8 @@ moz-extension://<extension-UUID>/images/my-image.png"
 
 `<extension-UUID>` n'est **pas** l'identifiant de votre extension. Il est généré de manière aléatoire pour chaque instance de navigateur. Ceci empêche les sites Web de prendre les empreintes digitales d'un navigateur en examinant les extensions qu'il a installées.
 
-> **Note :** Dans Chrome, l'ID d'une extension est fixe. Quand une ressource est listée dans `web_accessible_resources`, elle est accessible comme `chrome-extension://<your-extension-id>/<path/to/resource>`.
+> [!NOTE]
+> Dans Chrome, l'ID d'une extension est fixe. Quand une ressource est listée dans `web_accessible_resources`, elle est accessible comme `chrome-extension://<your-extension-id>/<path/to/resource>`.
 
 L'approche recommandée pour obtenir l'URL de la ressource est d'utiliser [`runtime.getURL`](/fr/Add-ons/WebExtensions/API/runtime/getURL) en passant le chemin relatif à manifest.json, par exemple :
 

--- a/files/fr/mozilla/add-ons/webextensions/match_patterns/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/match_patterns/index.md
@@ -11,7 +11,8 @@ Les API qui utilisent des modèles de correspondance acceptent généralement un
 
 ## Structure du modèle de correspondance
 
-> **Note :** Certains navigateurs ne prennent pas en charge certains schémas.
+> [!NOTE]
+> Certains navigateurs ne prennent pas en charge certains schémas.
 > Consultez le [tableau de compatibilité du navigateur](#Browser_compatibility) pour plus de détails.
 
 Tous les modèles de correspondance sont spécifiés comme des chaînes. Outre le motif spécial « [\<all_urls>](/fr/Add-ons/WebExtensions/Match_patterns#%3Call_urls%3E) », les modèles de correspondance se composent de trois partie : _schéma_, l'hôte, et le _chemin d'accès._ Le schéma et l'hôte sont séparés par « :// ».
@@ -93,7 +94,8 @@ La valeur du _chemin_ matches correspond à la chaîne de caractères qui est le
 
 Ni l'[identificateur de fragment d'URL](https://en.wikipedia.org/wiki/Fragment_identifier), ni le `#` qui le précède, ne sont considérés comme faisant partie du _chemin_.
 
-> **Note :** La chaîne de modèle de chemin d'accès ne doit pas inclure de numéro de port. Ajout d'un port, comme dans : `http://localhost:1234/*` fait que le motif de match est ignoré. Cependant, `http://localhost:1234` correspondra avec `http://localhost/*`.
+> [!NOTE]
+> La chaîne de modèle de chemin d'accès ne doit pas inclure de numéro de port. Ajout d'un port, comme dans : `http://localhost:1234/*` fait que le motif de match est ignoré. Cependant, `http://localhost:1234` correspondra avec `http://localhost/*`.
 
 ### \<all_urls>
 

--- a/files/fr/mozilla/add-ons/webextensions/modify_a_web_page/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/modify_a_web_page/index.md
@@ -41,9 +41,11 @@ Tout d'abord, créez un nouveau répertoire intitulé "modify-page". Dans ce ré
 
 La clé [`content_scripts`](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) est la façon dont vous chargez les scripts dans des pages qui correspondent aux modèles d'URL. Dans ce cas, les instructions `content_scripts demandent au navigateur de charger un script appelé` "page-eater.js" dans toutes les pages sous [https://developer.mozilla.org/](/).
 
-> **Note :** Puisque la propriété "js" de content_scripts est un tableau, vous pouvez l'utiliser pour injecter plus d'un script dans des pages correspondantes. Si vous faites cela, les pages partagent la même portée, tout comme les scripts multiples chargés par une page, et ils sont chargés dans l'ordre dans lequel ils sont répertoriés dans le tableau.
+> [!NOTE]
+> Puisque la propriété "js" de content_scripts est un tableau, vous pouvez l'utiliser pour injecter plus d'un script dans des pages correspondantes. Si vous faites cela, les pages partagent la même portée, tout comme les scripts multiples chargés par une page, et ils sont chargés dans l'ordre dans lequel ils sont répertoriés dans le tableau.
 
-> **Note :** La clé content_scripts possède également une propriété "css" que vous pouvez utiliser pour injecter des feuilles de style CSS.
+> [!NOTE]
+> La clé content_scripts possède également une propriété "css" que vous pouvez utiliser pour injecter des feuilles de style CSS.
 
 Ensuite, créez un fichier appelé "page-eater.js" dans le dossier "modify-page" et donnez-lui le contenu suivant :
 
@@ -59,7 +61,8 @@ Maintenant [installer la WebExtension](/fr/Add-ons/WebExtensions/Temporary_Insta
 
 {{EmbedYouTube("lxf2Tkg6U1M")}}
 
-> **Note :** Cette vidéo montre le script de contenu fonctionnant dans [addons.mozilla.org](/fr/firefox/), les scripts de contenu sont actuellement bloqués pour ce site.
+> [!NOTE]
+> Cette vidéo montre le script de contenu fonctionnant dans [addons.mozilla.org](/fr/firefox/), les scripts de contenu sont actuellement bloqués pour ce site.
 
 ## Modification des pages par programme
 
@@ -118,7 +121,8 @@ Maintenant [rechargeons la WebExtension](/fr/Add-ons/WebExtensions/Temporary_Ins
 
 {{EmbedYouTube("zX4Bcv8VctA")}}
 
-> **Note :** Bien que cette vidéo montre le script de contenu fonctionnant dans [addons.mozilla.org](/fr/firefox/), les scripts de contenu sont actuellement bloqués pour ce site.
+> [!NOTE]
+> Bien que cette vidéo montre le script de contenu fonctionnant dans [addons.mozilla.org](/fr/firefox/), les scripts de contenu sont actuellement bloqués pour ce site.
 
 ## Messagerie
 
@@ -170,7 +174,8 @@ Cependant, ils peuvent communiquer en envoyant des messages. Une extrémité met
   </thead>
 </table>
 
-> **Note :** En ajoutant à cette méthode de communication, qui envoie des messages uniques, vous pouvez également utiliser une [approche basée sur la connexion pour échanger des messages](/fr/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#Communication_avec_les_scripts_darrière-plan).
+> [!NOTE]
+> En ajoutant à cette méthode de communication, qui envoie des messages uniques, vous pouvez également utiliser une [approche basée sur la connexion pour échanger des messages](/fr/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#Communication_avec_les_scripts_darrière-plan).
 
 Mettons à jour notre exemple pour montrer comment envoyer un message à partir du script en arrière-plan.
 
@@ -223,7 +228,8 @@ Maintenant, au lieu de simplement d'afficher la page tout de suite, le script de
 
 Si nous voulions envoyer des messages du script de contenu à la page d'arrière-plan, la configuration serait inverse de cet exemple, sauf que nous utiliserions [`runtime.sendMessage()`](/fr/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage) dans le script de contenu.
 
-> **Note :** Ces exemples injectent JavaScript; Vous pouvez également injecter CSS par programme en utilisant la fonction [`tabs.insertCSS()`](/fr/docs/Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS).
+> [!NOTE]
+> Ces exemples injectent JavaScript; Vous pouvez également injecter CSS par programme en utilisant la fonction [`tabs.insertCSS()`](/fr/docs/Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS).
 
 ## Apprendre plus
 

--- a/files/fr/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -84,7 +84,8 @@ Par exemple, voici un manifeste pour l'application native "ping_pong" :
 
 Ceci autorise l'application dont l'ID est « ping_pong\@example.org » à se connecter, en passant le nom « ping_pong » comme paramètre à la fonction de l'API {{WebExtAPIRef("runtime")}} concernée. L'application, elle‐même se trouve dans le fichier « /path/to/native‐messaging/app/ping_pong.py ».
 
-> **Note :** Pour Windows dans l'exemple ci‐dessus, l'application native est un script Python. Il peut être compliqué d'amener Windows à faire fonctionner correctement des scripts Python, une méthode alternative est de fournir un fichier .bat, et de l'indiquer dans le manifest :
+> [!NOTE]
+> Pour Windows dans l'exemple ci‐dessus, l'application native est un script Python. Il peut être compliqué d'amener Windows à faire fonctionner correctement des scripts Python, une méthode alternative est de fournir un fichier .bat, et de l'indiquer dans le manifest :
 >
 > ```json
 > {
@@ -123,7 +124,8 @@ L'application native passe deux arguments lorsqu'elle démarre :
 - le chemin complet du manifest de l'application
 - (nouveau dans Firefox 55) l'ID (tel qu'indiqué dans la clé du manifest.json de [browser_specific_settings](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings)) of the add-on that started it.
 
-> **Note :** Chrome gère différemment les arguments passés :
+> [!NOTE]
+> Chrome gère différemment les arguments passés :
 >
 > - Sous Linux et Mac, Chrome passe un argument, l'origine de l'extension qui l'a lancé sous la forme : `chrome-extension://[extensionID]`. Ceci permet à l'application d'identifier l'extension.
 > - Sous Windows, Chrome passe deux arguments : le premier est l'origine de l'extension, et le second est une poignée à la fenêtre native Chrome qui a lancé l'application.

--- a/files/fr/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
@@ -5,9 +5,11 @@ slug: Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts
 
 {{AddonSidebar}}
 
-> **Note :** Les techniques décrites dans cette section sont uniquement disponibles dans Firefox, et seulement à partir de Firefox 49
+> [!NOTE]
+> Les techniques décrites dans cette section sont uniquement disponibles dans Firefox, et seulement à partir de Firefox 49
 
-> **Attention :** En tant que développeur d'extensions, vous devez considérer que les scripts s'exécutant sur des pages Web arbitraires sont des codes hostiles dont le but est de voler les informations personnelles de l'utilisateur, d'endommager leur ordinateur ou de les attaquer d'une autre manière.
+> [!WARNING]
+> En tant que développeur d'extensions, vous devez considérer que les scripts s'exécutant sur des pages Web arbitraires sont des codes hostiles dont le but est de voler les informations personnelles de l'utilisateur, d'endommager leur ordinateur ou de les attaquer d'une autre manière.
 >
 > L'isolation entre les scripts de contenu et les scripts chargés par les pages Web a pour but de rendre plus difficile la tâche des pages Web hostiles.
 >

--- a/files/fr/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
@@ -16,7 +16,8 @@ Si cela est inclus et défini sur `true`, votre document obtiendra une ou plusie
 
 Lorsque vous envisagez d'utiliser le `browser_style: true`, vous devez tester votre extension avec différents thèmes (intégrés ou AMO) pour vous assurer que l'interface d'extension se comporte comme vous l'attendez..
 
-> **Attention :** Quand `browser_style: true` est inclus dans le manifest de votre extension web, la sélection de texte dans l'interface utilisateur de votre extension est désactivée sauf dans les contrôles de saisie. Si cela pose un problème, incluez plutôt browser_style:false.
+> [!WARNING]
+> Quand `browser_style: true` est inclus dans le manifest de votre extension web, la sélection de texte dans l'interface utilisateur de votre extension est désactivée sauf dans les contrôles de saisie. Si cela pose un problème, incluez plutôt browser_style:false.
 
 > **Note :** **Google Chrome** et **Opera** utilisent `chrome_style` au lieu de `browser_style`, donc si vous souhaitez les prendre en charge, vous devez ajouter les deux clés.
 
@@ -98,7 +99,8 @@ La plupart des styles sont automatiquement appliqués, mais certains éléments 
   </tbody>
 </table>
 
-> **Note :** Voir le [bug Firefox 1465256](https://bugzil.la/1465256) pour la suppression de cette exigence inutile.
+> [!NOTE]
+> Voir le [bug Firefox 1465256](https://bugzil.la/1465256) pour la suppression de cette exigence inutile.
 
 ## Compatibilité des navigateurs
 
@@ -106,7 +108,8 @@ La plupart des styles sont automatiquement appliqués, mais certains éléments 
 
 ## Composants du panneau Firefox
 
-> **Attention :** Cette fonctionnalité est non standard et ne fonctionne que dans Firefox.
+> [!WARNING]
+> Cette fonctionnalité est non standard et ne fonctionne que dans Firefox.
 
 La feuille de style `chrome://browser/content/extension.css` contient également les styles des composants du panneau Firefox.
 

--- a/files/fr/mozilla/add-ons/webextensions/user_interface/devtools_panels/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/user_interface/devtools_panels/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/user_interface/devtools_panels
 
 {{AddonSidebar}}
 
-> **Note :** Cette fonctionnalité deviendra disponible dans Firefox 54.
+> [!NOTE]
+> Cette fonctionnalité deviendra disponible dans Firefox 54.
 
 Lorsqu'une extension fournit des outils utiles aux développeurs, il est possible d'ajouter une interface utilisateur pour les outils de développement du navigateur en tant que nouveau panneau.
 

--- a/files/fr/mozilla/add-ons/webextensions/user_interface/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/user_interface/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/user_interface
 
 Les WebExtensions disposent de plusieurs options d'interface utilisateur afin que leur fonctionnalité puisse être mise à la disposition de l'utilisateur. Un résumé de ces options est fourni ci-dessous, avec une introduction plus détaillée à chaque option d'interface utilisateur dans cette section.
 
-> **Note :** Pour en revenir des conseils sur l'utilisation de ces composants d'interface utilisateur afin de créer une expérience utilisateur générale dans votre extension, consultez l'article sur les [bonnes pratiques de l'expérience utilisateur](/fr/Add-ons/WebExtensions/User_experience_best_practices).
+> [!NOTE]
+> Pour en revenir des conseils sur l'utilisation de ces composants d'interface utilisateur afin de créer une expérience utilisateur générale dans votre extension, consultez l'article sur les [bonnes pratiques de l'expérience utilisateur](/fr/Add-ons/WebExtensions/User_experience_best_practices).
 
 <table class="standard-table">
   <thead>

--- a/files/fr/mozilla/add-ons/webextensions/what_are_webextensions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/what_are_webextensions/index.md
@@ -7,7 +7,8 @@ l10n:
 
 {{AddonSidebar}}
 
-> **Note :** Si vous connaissez déjà les concepts de base pour les extensions de navigateur, vous pouvez passer cette section et voir directement [comment s'organisent les fichiers d'une extension](/fr/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension). Ensuite, utilisez [la documentation de référence](/fr/docs/Mozilla/Add-ons/WebExtensions#référence) pour commencer à construire votre extension. [L'atelier des extensions Firefox (en anglais)](https://extensionworkshop.com) vous permettra d'en savoir plus à propos des outils et méthodes de tests et de publication des extensions pour Firefox.
+> [!NOTE]
+> Si vous connaissez déjà les concepts de base pour les extensions de navigateur, vous pouvez passer cette section et voir directement [comment s'organisent les fichiers d'une extension](/fr/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension). Ensuite, utilisez [la documentation de référence](/fr/docs/Mozilla/Add-ons/WebExtensions#référence) pour commencer à construire votre extension. [L'atelier des extensions Firefox (en anglais)](https://extensionworkshop.com) vous permettra d'en savoir plus à propos des outils et méthodes de tests et de publication des extensions pour Firefox.
 
 Une extension permet d'ajouter des fonctionnalités à un navigateur. Elles sont fabriquées à l'aide des technologies web usuelles&nbsp;: HTML, CSS, et JavaScript. Une extension peut utiliser les mêmes API JavaScript qu'une page web et dispose d'API JavaScript supplémentaires. Cela signifie qu'il est possible de faire plus avec une extension que ce qu'on peut faire avec une page web. Voici quelques exemples de ce qu'on peut construire.
 

--- a/files/fr/mozilla/add-ons/webextensions/work_with_the_cookies_api/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/work_with_the_cookies_api/index.md
@@ -7,7 +7,8 @@ slug: Mozilla/Add-ons/WebExtensions/Work_with_the_Cookies_API
 
 Avec l'API Cookies, vos extensions ont accès à des fonctionnalités similaires à celles utilisées par les sites Web pour stocker et lire les cookies. Les fonctionnalités de l'API permettent aux extensions de stocker des informations site par site. Ainsi, comme nous le verrons dans l'exemple, vous pouvez stocker des détails sur le choix de la couleur de fond d'un site pour un utilisateur. Ensuite, lorsque l'utilisateur revient sur le site, votre extension peut utiliser la capacité de l'API pour obtenir des détails sur les cookies et les lire pour récupérer le choix de l'utilisateur et l'appliquer au site Web.
 
-> **Note :** Le comportement des cookies peut être contrôlé à l'aide de la propriété {{WebExtAPIRef("privacy.websites")}} `cookieConfig`. Cette propriété contrôle si et comment les cookies sont acceptés ou si tous les cookies sont traités comme des cookies de session.
+> [!NOTE]
+> Le comportement des cookies peut être contrôlé à l'aide de la propriété {{WebExtAPIRef("privacy.websites")}} `cookieConfig`. Cette propriété contrôle si et comment les cookies sont acceptés ou si tous les cookies sont traités comme des cookies de session.
 
 ## Permissions
 

--- a/files/fr/mozilla/add-ons/webextensions/working_with_files/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/working_with_files/index.md
@@ -25,7 +25,8 @@ browser.downloads.download({ url : ‘https://example.org/image.png’ })
 
 Vous pouvez laisser l'utilisateur télécharger à un endroit de son choix en précisant le paramètre`saveAs`.
 
-> **Note :** En utilisant [URL.createObjectURL()](/fr/docs/Web/API/URL/createObjectURL), vous pouvez également télécharger des fichiers et des blobs définis dans votre JavaScript, y compris le contenu local extrait de IndexedDB.
+> [!NOTE]
+> En utilisant [URL.createObjectURL()](/fr/docs/Web/API/URL/createObjectURL), vous pouvez également télécharger des fichiers et des blobs définis dans votre JavaScript, y compris le contenu local extrait de IndexedDB.
 
 L'API de téléchargement fournit également des fonctionnalités pour annuler, mettre en pause, reprendre, effacer et supprimer les téléchargements, rechercher les fichiers téléchargés dans le gestionnaire de téléchargement, afficher les fichiers téléchargés dans le gestionnaire de fichiers de l'ordinateur, et ouvrir un fichier dans une application associée.
 
@@ -42,7 +43,8 @@ Exemple : [Imagify](https://github.com/mdn/webextensions-examples/tree/master/im
 Guide : [Using files from web applications](/fr/docs/Using_files_from_web_applications)
 API références : [HTML input element](/fr/docs/Web/HTML/Element/input/file) | [DOM File API](/fr/docs/Web/API/File)
 
-> **Note :** Si vous souhaitez accéder ou traiter tous les fichiers dans un dossier sélectionné, vous pouvez le faire en utilisant `<input type="file" webkitdirectory="true"/>` pour sélectionner le dossier et récupérer tous les fichiers qu'il contient.
+> [!NOTE]
+> Si vous souhaitez accéder ou traiter tous les fichiers dans un dossier sélectionné, vous pouvez le faire en utilisant `<input type="file" webkitdirectory="true"/>` pour sélectionner le dossier et récupérer tous les fichiers qu'il contient.
 
 ## Ouverture de fichiers dans une extension avec glisser-déposer
 
@@ -129,7 +131,8 @@ Une fois que l'URL du blob a été révoquée, toute tentative de la charger ent
 Exemple : [Store Collected Images](https://github.com/mdn/webextensions-examples/tree/master/store-collected-images/webextension-plain)
 API Référence : [idb-file-storage library](https://rpl.github.io/idb-file-storage/)
 
-> **Note :** Vous pouvez également utiliser l' [IndexedDB API](/fr/docs/Web/API/API_IndexedDB) pour stocker des données de votre extension. Cela peut être utile lorsque vous devez stocker des données qui ne sont pas bien gérées par les paires de clés / valeurs simples offertes par le DOM [Storage API](/fr/Add-ons/WebExtensions/API/Storage).
+> [!NOTE]
+> Vous pouvez également utiliser l' [IndexedDB API](/fr/docs/Web/API/API_IndexedDB) pour stocker des données de votre extension. Cela peut être utile lorsque vous devez stocker des données qui ne sont pas bien gérées par les paires de clés / valeurs simples offertes par le DOM [Storage API](/fr/Add-ons/WebExtensions/API/Storage).
 
 ## Traitement de fichiers dans une application locale
 

--- a/files/fr/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
@@ -17,7 +17,8 @@ Dans cet article, nous allons regarder :
 
 Nous concluons ensuite en examinant d'autres fonctionnalités diverses offertes par l'API.
 
-> **Note :** Certaines fonctionnalités de l'API d'onglet sont couvert ailleurs. Voici les méthodes que vous pouvez utiliser pour manipuler le contenu de l'onglet avec des scripts ({{WebExtAPIRef("tabs.connect")}}, {{WebExtAPIRef("tabs.sendMessage")}}, et {{WebExtAPIRef("tabs.executeScript")}}). Si vous voulez plus d'informations sur ces méthodes, reportez-vous à l'article [scripts de contenu](/fr/Add-ons/WebExtensions/Content_scripts) et le guide pratique [modifier une page web](/fr/Add-ons/WebExtensions/Modify_a_web_page).
+> [!NOTE]
+> Certaines fonctionnalités de l'API d'onglet sont couvert ailleurs. Voici les méthodes que vous pouvez utiliser pour manipuler le contenu de l'onglet avec des scripts ({{WebExtAPIRef("tabs.connect")}}, {{WebExtAPIRef("tabs.sendMessage")}}, et {{WebExtAPIRef("tabs.executeScript")}}). Si vous voulez plus d'informations sur ces méthodes, reportez-vous à l'article [scripts de contenu](/fr/Add-ons/WebExtensions/Content_scripts) et le guide pratique [modifier une page web](/fr/Add-ons/WebExtensions/Modify_a_web_page).
 
 ## Permissions et l'API Tabs
 
@@ -76,7 +77,7 @@ Voici le [manifest.json](https://github.com/mdn/webextensions-examples/blob/mast
 }
 ```
 
-> **Note :**
+> [!NOTE]
 >
 > - **tabs.html est défini comme `default_popup` dans `browser_action`**. C'est affiché chaque fois que l'utilisateur clique sur l'icône de la barre d'outils de l'extension.
 > - **Les permissions incluent des onglets.** Ceci est nécessaire pour prendre en charge la fonction de liste d'onglets, car l'extension lit le titre des onglets à afficher dans la fenêtre contextuelle.
@@ -243,7 +244,7 @@ Après avoir recueilli des informations sur les onglets, vous voudrez probableme
 - Mettre à jour l'URL d'un onglet — accéderefficacement à une nouvelle page — ({{WebExtAPIRef("tabs.update")}}).
 - Rechargez la page de l'onglet ({{WebExtAPIRef("tabs.reload")}}).
 
-> **Note :**
+> [!NOTE]
 >
 > Ces fonctions nécessitent toutes l'ID (ou les ID) de l'onglet qu'elles manipulent :
 >

--- a/files/fr/mozilla/add-ons/webextensions/your_first_webextension/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/your_first_webextension/index.md
@@ -5,7 +5,8 @@ slug: Mozilla/Add-ons/WebExtensions/Your_first_WebExtension
 
 {{AddonSidebar}}
 
-> **Note :** Si vous connaissez déjà les concepts de base des extensions de navigateur, vous pouvez [passer directement à l'article suivant afin de voir comment les fichiers d'extension sont assemblés](/fr/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension). Ensuite, utilisez la [documentation de référence](/fr/docs/Mozilla/Add-ons/WebExtensions#référence) pour commencer la construction de votre extension. Consultez le site de [l'atelier sur les extensions de Firefox](https://extensionworkshop.com/?utm_source=developer.mozilla.org&utm_medium=documentation&utm_campaign=your-first-extension) pour en savoir plus sur le processus de test et de publication des WebExtensions pour Firefox.
+> [!NOTE]
+> Si vous connaissez déjà les concepts de base des extensions de navigateur, vous pouvez [passer directement à l'article suivant afin de voir comment les fichiers d'extension sont assemblés](/fr/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension). Ensuite, utilisez la [documentation de référence](/fr/docs/Mozilla/Add-ons/WebExtensions#référence) pour commencer la construction de votre extension. Consultez le site de [l'atelier sur les extensions de Firefox](https://extensionworkshop.com/?utm_source=developer.mozilla.org&utm_medium=documentation&utm_campaign=your-first-extension) pour en savoir plus sur le processus de test et de publication des WebExtensions pour Firefox.
 
 Cet article vous montre comment créer une extension Firefox, du début à la fin. L'extension ajoute une bordure rouge sur toutes les pages chargées depuis le site `mozilla.org` ou n'importe lequel de ses sous-domaines.
 
@@ -117,13 +118,15 @@ Une autre alternative est d'exécuter l'extension depuis la ligne de commande à
 
 ### Tester l'extension
 
-> **Note :** Par défaut, [les extensions ne sont pas autorisées à fonctionner en navigation privée](https://support.mozilla.org/fr/kb/extensions-en-navigation-privee). Si vous souhaitez tester votre extension en mode de navigation privée, accédez à `about:addons`, cliquez sur l'extension, puis cliquez sur le bouton radio «&nbsp;Autoriser&nbsp;» pour l'option «&nbsp;Exécution dans les fenêtres privées&nbsp;».
+> [!NOTE]
+> Par défaut, [les extensions ne sont pas autorisées à fonctionner en navigation privée](https://support.mozilla.org/fr/kb/extensions-en-navigation-privee). Si vous souhaitez tester votre extension en mode de navigation privée, accédez à `about:addons`, cliquez sur l'extension, puis cliquez sur le bouton radio «&nbsp;Autoriser&nbsp;» pour l'option «&nbsp;Exécution dans les fenêtres privées&nbsp;».
 
 Rendez-vous sur une page web du domaine `mozilla.org`. Vous devriez y voir une bordure rouge qui entoure la page&nbsp;:
 
 ![Une bordure rouge entourant la page mozilla.org](border_on_mozilla_org.png)
 
-> **Note :** Toutefois, n'essayez pas ce module sur `addons.mozilla.org`&nbsp;! Les scripts de contenu sont bloqués sur ce domaine.
+> [!NOTE]
+> Toutefois, n'essayez pas ce module sur `addons.mozilla.org`&nbsp;! Les scripts de contenu sont bloqués sur ce domaine.
 
 Expérimentez un peu en modifiant le script de contenu, en changeant par exemple la couleur de la bordure ou en altérant le contenu de la page. Puis sauvegardez le script de contenu et rechargez les fichiers du module en cliquant sur le bouton «&nbsp;Recharger&nbsp;» dans `about:debugging`. Les changements sont immédiats.
 

--- a/files/fr/mozilla/firefox/experimental_features/index.md
+++ b/files/fr/mozilla/firefox/experimental_features/index.md
@@ -1508,7 +1508,7 @@ Cela modifie également l'avertissement de la console : si la mise à niveau ré
 
 [Feature-Policy](/fr/docs/Web/HTTP/Feature_Policy) est un en-tête HTTP qui permet de choisir l'activation, la désactivation ou certaines des fonctionnalités et API dans le navigateur. Cet en-tête est similaire au CSP mais permet de contrôler des fonctionnalités plutôt que des traits liés à la sécurité.
 
-> **Note :**
+> [!NOTE]
 >
 > L'en-tête `Feature-Policy` a été renommé en `Permissions-Policy` dans la spécification. Cet article sera mis à jour afin de refléter ce changement.
 

--- a/files/fr/mozilla/firefox/releases/3/updating_extensions/index.md
+++ b/files/fr/mozilla/firefox/releases/3/updating_extensions/index.md
@@ -64,11 +64,13 @@ Et réinstallez ensuite votre extension.
 
 Notez que Firefox 3 n'a plus besoin d'un «&nbsp;.0&nbsp;» supplémentaire dans son numéro de version, donc au lieu d'utiliser «&nbsp;3.0.0.\*&nbsp;», il ne faut plus indiquer que «&nbsp;3.0.\*&nbsp;».
 
-> **Note :** Notez qu'à ce point, il faut s'attendre à d'autres changements dans Firefox 3. Ceux-ci peuvent poser des problèmes à certaines extensions, il faut donc éviter de publier une extension avec la valeur `3.0.0.*` pour `maxVersion` avant que la RC de Firefox 3 soit disponible. Durant la pariode beta de Firefox 3, il convient d'utiliser `3.0b5` comme valeur de `maxVersion`.
+> [!NOTE]
+> Notez qu'à ce point, il faut s'attendre à d'autres changements dans Firefox 3. Ceux-ci peuvent poser des problèmes à certaines extensions, il faut donc éviter de publier une extension avec la valeur `3.0.0.*` pour `maxVersion` avant que la RC de Firefox 3 soit disponible. Durant la pariode beta de Firefox 3, il convient d'utiliser `3.0b5` comme valeur de `maxVersion`.
 
 Il y a eu (et il y aura encore) un certain nombre de changements dans les API qui poseront probablement des problèmes à certaines. Nous sommes encore en train d'établir une liste complète de ces changements.
 
-> **Note :** Si votre extension utilise toujours un script [`Install.js`](/fr/docs/Install.js) plutôt qu'un [manifeste d'installation](/fr/docs/Install_Manifests), il vous faudra faire la transition vers un manifeste d'installation maintenant. Firefox 3 ne gère plus les scripts `install.js` dans les fichiers XPI.
+> [!NOTE]
+> Si votre extension utilise toujours un script [`Install.js`](/fr/docs/Install.js) plutôt qu'un [manifeste d'installation](/fr/docs/Install_Manifests), il vous faudra faire la transition vers un manifeste d'installation maintenant. Firefox 3 ne gère plus les scripts `install.js` dans les fichiers XPI.
 
 #### Ajout de localisations au manifeste d'installation
 
@@ -169,7 +171,8 @@ Ou utilisez la technique suivante pour que votre overlay fonctionne tant avec Fi
 </window>
 ```
 
-> **Note :** Ce changement s'applique à partir de Firefox 3 beta 4 et des nightlies précédentes.
+> [!NOTE]
+> Ce changement s'applique à partir de Firefox 3 beta 4 et des nightlies précédentes.
 
 ### Autres changements
 

--- a/files/fr/mozilla/firefox/releases/3/updating_web_applications/index.md
+++ b/files/fr/mozilla/firefox/releases/3/updating_web_applications/index.md
@@ -65,7 +65,8 @@ content mypackage location/ contentaccessible=yes
 
 Cette manipulation ne devrait pas être nécessaire la plupart du temps, mais elle existe toutefois pour les rares cas où elle reste indispensable. Notez qu'il n'est pas exclu que Firefox avertisse l'utilisateur de cette utilisation du paramètre `contentaccessible`, étant donné qu'il constitue un risque potentiel de sécurité.
 
-> **Note :** Firefox 2 ne gérant pas le paramètre contentaccessible (la ligne le contenant sera entièrement ignorée), si vous voulez que votre module reste compatible avec Firefox 2 et Firefox 3, ajoutez plutôt quelque chose comme ceci&nbsp;:
+> [!NOTE]
+> Firefox 2 ne gérant pas le paramètre contentaccessible (la ligne le contenant sera entièrement ignorée), si vous voulez que votre module reste compatible avec Firefox 2 et Firefox 3, ajoutez plutôt quelque chose comme ceci&nbsp;:
 >
 > ```
 > content mypackage location/

--- a/files/fr/mozilla/firefox/releases/5/index.md
+++ b/files/fr/mozilla/firefox/releases/5/index.md
@@ -80,7 +80,8 @@ Firefox 5, basé sur Gecko 5.0, est sorti le 21 juin 2011. Cet article fournit d
 
 Pour des conseils utiles sur la mise à jour des extensions pour Firefox 5, voir [Updating add-ons for Firefox 5](/fr/docs/Firefox/Updating_add-ons_for_Firefox_5).
 
-> **Note :** Firefox 5 requiert que les composants binaires soient recompilés, comme pour toutes les versions majeures de Firefox. Pour plus de détails, voir [Interfaces Binaires](/fr/docs/Developer_Guide/Interface_Compatibility#Binary_Interfaces).
+> [!NOTE]
+> Firefox 5 requiert que les composants binaires soient recompilés, comme pour toutes les versions majeures de Firefox. Pour plus de détails, voir [Interfaces Binaires](/fr/docs/Developer_Guide/Interface_Compatibility#Binary_Interfaces).
 
 ### Changements dans les modules de code JavaScript
 

--- a/files/fr/mozilla/firefox/releases/6/index.md
+++ b/files/fr/mozilla/firefox/releases/6/index.md
@@ -151,7 +151,8 @@ Firefox 6, basé sur Gecko 6.0, est sorti le 16 août 2011. Cet article fournit 
 
 Pour des conseils utiles sur la mise à jour des extensions pour Firefox 6, voir [Updating add-ons for Firefox 6](/fr/docs/Firefox/Updating_add-ons_for_Firefox_6).
 
-> **Note :** Firefox 6 requiert que les composants binaires soient recompilés, comme pour toutes les versions majeures de Firefox. Pour plus de détails, voir [Interfaces Binaires](/fr/docs/Developer_Guide/Interface_Compatibility#Binary_Interfaces).
+> [!NOTE]
+> Firefox 6 requiert que les composants binaires soient recompilés, comme pour toutes les versions majeures de Firefox. Pour plus de détails, voir [Interfaces Binaires](/fr/docs/Developer_Guide/Interface_Compatibility#Binary_Interfaces).
 
 ### Modules de code JavaScript
 

--- a/files/fr/mozilla/firefox/releases/7/index.md
+++ b/files/fr/mozilla/firefox/releases/7/index.md
@@ -87,7 +87,8 @@ Firefox 7, basé sur Gecko 7.0, est sorti le 27 september 2011. Cet article four
 
 Ces changements affectent les développeurs d'extensions ainsi que les développeurs qui travaillent sur ou avec le code de Mozilla lui-même. Les developpeurs d'extensions doivent voir [Updating extensions for Firefox 7](/fr/docs/Firefox/Updating_extensions_for_Firefox_7) pour plus d'informations.
 
-> **Note :** Firefox 7 requiert que les composants binaires soient recompilés, comme pour toutes les versions majeures de Firefox. Pour plus de détails, voir [Interfaces Binaires](/fr/docs/Developer_Guide/Interface_Compatibility#Binary_Interfaces).
+> [!NOTE]
+> Firefox 7 requiert que les composants binaires soient recompilés, comme pour toutes les versions majeures de Firefox. Pour plus de détails, voir [Interfaces Binaires](/fr/docs/Developer_Guide/Interface_Compatibility#Binary_Interfaces).
 
 ### Modules de code JavaScript
 

--- a/files/fr/mozilla/firefox/releases/8/index.md
+++ b/files/fr/mozilla/firefox/releases/8/index.md
@@ -123,7 +123,8 @@ Firefox 8, basé sur Gecko 8.0, est sorti le 8 novembre 2011. Cet article fourni
 
 Voir [Updating add-ons for Firefox 8](/fr/docs/Firefox/Updating_add-ons_for_Firefox_8) pour vous guidez dans les modifications que vous êtes susceptibles d'avoir à faire pour rendre vos extensions compatibles avec Firefox 8.
 
-> **Note :** Firefox 8 requiert que les composants binaires soient recompilés, comme pour toutes les versions majeures de Firefox. Pour plus de détails, voir [Interfaces Binaires](/fr/docs/Developer_Guide/Interface_Compatibility#Binary_Interfaces).
+> [!NOTE]
+> Firefox 8 requiert que les composants binaires soient recompilés, comme pour toutes les versions majeures de Firefox. Pour plus de détails, voir [Interfaces Binaires](/fr/docs/Developer_Guide/Interface_Compatibility#Binary_Interfaces).
 
 ### XPCOM
 

--- a/files/fr/web/accessibility/an_overview_of_accessible_web_applications_and_widgets/index.md
+++ b/files/fr/web/accessibility/an_overview_of_accessible_web_applications_and_widgets/index.md
@@ -41,7 +41,8 @@ _Example 2: Telles qu'elles sont représentées ci-dessous, les tabulations peuv
 
 [WAI-ARIAI](https://www.w3.org/WAI/standards-guidelines/aria/), les spécifications concernant les applications **internet "riches" et accessibles** sont publiées par l'iniative du [W3C sur l'accessibilité](https://www.w3.org/WAI/), et fournissent la sémantique essentielle au bon fonctionnement des lecteurs d'écran. ARIA permet aux développeurs de décrire en quelque sorte leurs widgets plus finement en ajoutant des attributs spéciaux à leurs balises. Ces spécifications comblent le vide qui existait entre les spécifications du standard HTML et des widgets. ARIA spécifie des rôles et des états permettant de décrire en quelque sorte le fonctionnement des widgets d'interfaces utilisateurs les plus connus.
 
-> **Attention :** Beaucoup d'entre eux ont été ajouté plus tard dans HTML5, et **les développeurs devraient toujours préférer utiliser la balise HTML correspondante plutôt qu'utiliser ARIA**.
+> [!WARNING]
+> Beaucoup d'entre eux ont été ajouté plus tard dans HTML5, et **les développeurs devraient toujours préférer utiliser la balise HTML correspondante plutôt qu'utiliser ARIA**.
 
 Les spécifications ARIA distinguent 3 types d'attributs : rôles, états et propriétés. Les rôles sont utilisés pour les widgets ne faisant pas partie des spécifications HTML 4 comme des sliders, menus, barres, boites de dialogue... Les propriétés sont utilisées pour représenter les caractéristiques de ces widgets, elles décrivent les caractéristiques de ces widgets comme s'il sont déplaçables avec la souris, requièrent un élément ou ont un popup associés à eux. Les états, comme leur nom l'indique, servent à representer l'état actuel de ces éléments en informant les technologies d'assistance s'il est occupé, désactivé, sélectionné ou masqué.
 

--- a/files/fr/web/accessibility/aria/aria_live_regions/index.md
+++ b/files/fr/web/accessibility/aria/aria_live_regions/index.md
@@ -19,7 +19,8 @@ Le contenu dynamique qui s'actualise sans rechargement de la page est générale
 
   - : L'attribut `aria-controls=[LISTE_IDs]` est utilisé pour associer un contrôle avec les zones qu'il contrôle. Les zones sont identifiées comme un `ID` dans un élément {{ HTMLElement("div") }}, et plusieurs zones peuvent être associées à un unique contrôle, en séparant les identifiants des zones par un espace, par exemple&nbsp;: `aria-controls="maZoneID1 maZoneID2"`.
 
-    > **Attention :** Nous ne savons pas si `aria-controls` pour les zones «&nbsp;live&nbsp;» est utilisé dans des technologies d'assistance modernes, et si oui lesquelles. Des recherches sont nécessaires.
+    > [!WARNING]
+    > Nous ne savons pas si `aria-controls` pour les zones «&nbsp;live&nbsp;» est utilisé dans des technologies d'assistance modernes, et si oui lesquelles. Des recherches sont nécessaires.
 
 Normalement, seul `aria-live="polite"` est utilisé. Toute zone recevant une mise à jour qu'il est important de faire suivre à l'utilisateur, mais pas au point de le déranger dans sa navigation, devrait recevoir cet attribut. Le lecteur d'écran lira les changements dès que l'utilisateur sera inoccupé.
 

--- a/files/fr/web/accessibility/aria/attributes/aria-required/index.md
+++ b/files/fr/web/accessibility/aria/attributes/aria-required/index.md
@@ -13,13 +13,15 @@ Lorsque des contrôles de formulaire sont créés avec des éléments non-séman
 
 À l'instar de l'attribut HTML `required` pour les contrôles de formulaire en HTML sémantique, l'attribut `aria-required` exprime explicitement aux outils d'assistance que l'élément doit être rempli avant que le formulaire puisse être envoyé. L'attribut `required` d'un contrôle de formulaire en HTML sémantique empêchera l'envoi du formulaire si aucune valeur n'est présente, fournissant un message d'erreur natif pour certains navigateurs si une valeur requise est invalide lors de la tentative d'envoi du formulaire. L'attribut `aria-required`, comme tous les états et propriétés ARIA, n'a aucun impact sur les fonctionnalités de l'élément. Toute fonctionnalité et comportement doit être implémenté à l'aide de JavaScript.
 
-> **Note :** ARIA modifie uniquement l'arbre d'accessibilité, modifiant ainsi la façon dont les outils d'assistance présentent le contenu aux personnes qui les utilisent. ARIA ne modifie en rien les fonctionnalités ou le comportement d'un élément. Lorsqu'on utilise des éléments HTML en dehors de leur sémantique et de leurs fonctionnalités prévues, il faudra utiliser JavaScript pour gérer le comportement, le focus et les états ARIA.
+> [!NOTE]
+> ARIA modifie uniquement l'arbre d'accessibilité, modifiant ainsi la façon dont les outils d'assistance présentent le contenu aux personnes qui les utilisent. ARIA ne modifie en rien les fonctionnalités ou le comportement d'un élément. Lorsqu'on utilise des éléments HTML en dehors de leur sémantique et de leurs fonctionnalités prévues, il faudra utiliser JavaScript pour gérer le comportement, le focus et les états ARIA.
 
 Les pseudo-classes CSS [`:required`](/fr/docs/Web/CSS/:required) et [`:optional`](/fr/docs/Web/CSS/:optional) ciblent les éléments [`<input>`](/fr/docs/Web/HTML/Element/input), [`<select>`](/fr/docs/Web/HTML/Element/select), et [`<textarea>`](/fr/docs/Web/HTML/Element/Textarea) selon qu'ils sont obligatoires ou optionnels. Lorsqu'on utilise un élément non-sémantique pour un contrôle de formulaire, ces pseudo-classes ne le ciblent pas. En revanche, il est possible d'utiliser des sélecteurs d'attribut pour déterminer si l'attribut est présent&nbsp;: `[aria-required="true"]` ou `[aria-required="false"]`.
 
 Si un formulaire contient à la fois des éléments de formulaire obligatoires et optionnels, les éléments obligatoires devraient être indiqués visuellement d'une façon qui ne repose pas uniquement sur une couleur. Généralement, on utilise un texte descriptif et/ou une icône.
 
-> **Note :** Les éléments obligatoires devraient être distinguables pour toutes les personnes. Assurez-vous que la présentation visuelle indique que le contrôle est obligatoire d'une façon claire, cohérente et visible et rappelez-vous que la couleur ne suffit pas à communiquer cette information.
+> [!NOTE]
+> Les éléments obligatoires devraient être distinguables pour toutes les personnes. Assurez-vous que la présentation visuelle indique que le contrôle est obligatoire d'une façon claire, cohérente et visible et rappelez-vous que la couleur ne suffit pas à communiquer cette information.
 
 ## Exemples
 

--- a/files/fr/web/accessibility/aria/attributes/index.md
+++ b/files/fr/web/accessibility/aria/attributes/index.md
@@ -7,7 +7,8 @@ Cette page constitue un index des pages de référence couvrant l'ensemble des a
 
 Les attributs ARIA permettent de modifier les états et les propriétés d'un élément dans l'arbre d'accessibilité.
 
-> **Note :** ARIA modifie uniquement l'arbre d'accessibilité, modifiant ainsi la façon dont les outils d'assistance présentent le contenu aux personnes qui les utilisent. ARIA ne modifie en rien les fonctionnalités ou le comportement d'un élément. Lorsqu'on utilise des éléments HTML en dehors de leur sémantique et de leurs fonctionnalités prévues, il faudra utiliser JavaScript pour gérer le comportement, le focus et les états ARIA.
+> [!NOTE]
+> ARIA modifie uniquement l'arbre d'accessibilité, modifiant ainsi la façon dont les outils d'assistance présentent le contenu aux personnes qui les utilisent. ARIA ne modifie en rien les fonctionnalités ou le comportement d'un élément. Lorsqu'on utilise des éléments HTML en dehors de leur sémantique et de leurs fonctionnalités prévues, il faudra utiliser JavaScript pour gérer le comportement, le focus et les états ARIA.
 
 ## Types d'attribut ARIA
 

--- a/files/fr/web/accessibility/aria/how_to_file_aria-related_bugs/index.md
+++ b/files/fr/web/accessibility/aria/how_to_file_aria-related_bugs/index.md
@@ -7,7 +7,8 @@ slug: Web/Accessibility/ARIA/How_to_file_ARIA-related_bugs
 
 L'état de la technologie ARIA a toujours dépendu de la communauté. Si vous remarquez un problème d'implémentation, veuillez prendre un instant pour en informer les développeurs. Voici comment déposer les bugs :
 
-> **Note :** Quand vous trouvez un bug, veuillez en aviser les tables de compatibilité liées dans la [page des exemples.](/fr/ARIA/examples)
+> [!NOTE]
+> Quand vous trouvez un bug, veuillez en aviser les tables de compatibilité liées dans la [page des exemples.](/fr/ARIA/examples)
 
 A faire : ajouter la bon lien d'accessibilité à la table
 

--- a/files/fr/web/accessibility/aria/index.md
+++ b/files/fr/web/accessibility/aria/index.md
@@ -11,11 +11,13 @@ l10n:
 
 ARIA complète HTML afin que les éléments interactifs et les widgets puissent être utilisés par les outils d'assistance quand les fonctionnalités standard ne le permettent pas. Ainsi, ARIA permet de rendre accessible les widgets JavaScript, les indications dans les formulaires, les messages d'erreur et les mises à jour dynamiques du contenu, etc.
 
-> **Attention :** La plupart de ces widgets ont été intégrés au sein d'HTML5 et **mieux vaudra donc utiliser les éléments sémantiques** HTML lorsqu'ils sont disponibles. Ainsi, les éléments natifs disposent de fonctionnalités [de navigation au clavier](/fr/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets), de rôles et d'états définis en standard. Toutefois, lorsque vous choisissez d'utiliser ARIA, il vous revient de recoder les fonctionnalités équivalentes dans vos scripts.
+> [!WARNING]
+> La plupart de ces widgets ont été intégrés au sein d'HTML5 et **mieux vaudra donc utiliser les éléments sémantiques** HTML lorsqu'ils sont disponibles. Ainsi, les éléments natifs disposent de fonctionnalités [de navigation au clavier](/fr/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets), de rôles et d'états définis en standard. Toutefois, lorsque vous choisissez d'utiliser ARIA, il vous revient de recoder les fonctionnalités équivalentes dans vos scripts.
 
 [La première règle d'ARIA](https://www.w3.org/TR/using-aria/#rule1) s'énonce ainsi&nbsp;: «&nbsp;Si vous pouvez utiliser un élément natif HTML ou un attribut avec la sémantique et le comportement voulu qui existe nativement, faites-le plutôt que d'utiliser un autre élément en lui ajoutant un rôle, un état ou une propriété ARIA afin de le rendre accessible.&nbsp;».
 
-> **Note :** On peut parfois lire l'expression «&nbsp;Mieux vaut ne pas utiliser ARIA que de l'utiliser incorrectement&nbsp;». Lors [d'un sondage WebAIM sur plus d'un million de pages d'accueil de sites](https://webaim.org/projects/million/#aria), il a été observé que les pages utilisant ARIA avaient 41% d'erreurs supplémentaires détectées par rapport aux pages sans ARIA. Bien qu'ARIA soit conçu pour rendre les pages web plus accessibles, lorsqu'il est utilisé incorrectement, il fait plus de mal que de bien.
+> [!NOTE]
+> On peut parfois lire l'expression «&nbsp;Mieux vaut ne pas utiliser ARIA que de l'utiliser incorrectement&nbsp;». Lors [d'un sondage WebAIM sur plus d'un million de pages d'accueil de sites](https://webaim.org/projects/million/#aria), il a été observé que les pages utilisant ARIA avaient 41% d'erreurs supplémentaires détectées par rapport aux pages sans ARIA. Bien qu'ARIA soit conçu pour rendre les pages web plus accessibles, lorsqu'il est utilisé incorrectement, il fait plus de mal que de bien.
 
 Voici un widget utilisé pour une barre de progression&nbsp;:
 
@@ -59,9 +61,11 @@ Tout le contenu qui est disponible pour les personnes qui n'utilisent pas d'outi
 <progress id="percent-loaded" value="75" max="100">75 %</progress>
 ```
 
-> **Note :** L'attribut `min` n'est pas autorisé pour l'élément [`<progress>`](/fr/docs/Web/HTML/Element/Progress), sa valeur minimale est toujours `0`.
+> [!NOTE]
+> L'attribut `min` n'est pas autorisé pour l'élément [`<progress>`](/fr/docs/Web/HTML/Element/Progress), sa valeur minimale est toujours `0`.
 
-> **Note :** Les éléments qui sont des points de repère dans la navigation du document ([`<main>`](/fr/docs/Web/HTML/Element/main), [`<header>`](/fr/docs/Web/HTML/Element/header), [`<nav>`](/fr/docs/Web/HTML/Element/nav), etc.) ont des rôles ARIA implicites natifs, il n'est pas nécessaire de les dupliquer.
+> [!NOTE]
+> Les éléments qui sont des points de repère dans la navigation du document ([`<main>`](/fr/docs/Web/HTML/Element/main), [`<header>`](/fr/docs/Web/HTML/Element/header), [`<nav>`](/fr/docs/Web/HTML/Element/nav), etc.) ont des rôles ARIA implicites natifs, il n'est pas nécessaire de les dupliquer.
 
 ## Prise en charge
 

--- a/files/fr/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/alert_role/index.md
@@ -21,7 +21,8 @@ Le rôle `alert` doit uniquement être utilisé pour le contenu texte et pas pou
 
 Le rôle `alert` est à ajouter au nœud contenant le message d'alerte, **il ne doit pas** être ajouté à l'élément qui a déclenché l'alerte. Les alertes sont [des régions dynamiques assertives](/fr/docs/Web/Accessibility/ARIA/ARIA_Live_Regions). Utiliser `role="alert"` sera équivalent à définir [`aria-live="assertive"`](/fr/docs/Web/Accessibility/ARIA/Attributes/aria-live) et [`aria-atomic="true"`](/fr/docs/Web/Accessibility/ARIA/Attributes/aria-atomic). Ces régions n'ayant pas besoin du focus, il n'a pas à être géré et aucune interaction utilisateur ne doit être requise.
 
-> **Attention :** Étant donné sa nature intrusive, le rôle `alert` doit être utilisé avec parcimonie et uniquement pour les situations où l'attention de la personne doit être sollicitée.
+> [!WARNING]
+> Étant donné sa nature intrusive, le rôle `alert` doit être utilisé avec parcimonie et uniquement pour les situations où l'attention de la personne doit être sollicitée.
 
 Le rôle [`alert`](https://www.w3.org/TR/wai-aria-1.1/#alert) est l'un des cinq rôles associés aux [régions dynamiques](/fr/docs/Web/Accessibility/ARIA/ARIA_Live_Regions). Les modifications dynamiques moins urgentes doivent utiliser une méthode moins agressive, par exemple en incluant `aria-live="polite"` ou en utilisant un autre rôle de région dynamique comme [`status`](/fr/docs/Web/Accessibility/ARIA/Roles/status_role). Si la personne doit pouvoir fermer l'alerte, on utilisera plutôt le rôle [`alertdialog`](/fr/docs/Web/Accessibility/ARIA/Roles/alertdialog_role).
 

--- a/files/fr/web/accessibility/aria/roles/alertdialog_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/alertdialog_role/index.md
@@ -19,7 +19,8 @@ La différence avec les boîtes de dialogues classiques réside dans le fait que
 
 Du fait de sa nature urgente, les boîtes de dialogues d'alertes doivent toujours être modales.
 
-> **Note :** ce rôle ne devrait être utilisé que pour des messages d'alertes associés à des contrôles interactifs. Si une boîte de dialogue d'alerte ne comporte que du contenu statique et qu'elle ne possède absolument aucun contrôle interactif, `alertdialog` n'est probablement pas le rôle le plus judicieux à utiliser. Le rôle `alert` est plus adapté pour ce cas (comme décrit dans l'article sur la technique d'[utilisation du rôle `alert`](/fr/Accessibilité/ARIA/Techniques_ARIA/Utiliser_le_role_alert)).
+> [!NOTE]
+> Ce rôle ne devrait être utilisé que pour des messages d'alertes associés à des contrôles interactifs. Si une boîte de dialogue d'alerte ne comporte que du contenu statique et qu'elle ne possède absolument aucun contrôle interactif, `alertdialog` n'est probablement pas le rôle le plus judicieux à utiliser. Le rôle `alert` est plus adapté pour ce cas (comme décrit dans l'article sur la technique d'[utilisation du rôle `alert`](/fr/Accessibilité/ARIA/Techniques_ARIA/Utiliser_le_role_alert)).
 
 ### Effets possibles sur les agents utilisateurs et les technologies d'assistance
 
@@ -32,7 +33,8 @@ Lorsque la boîte de dialogue de l'alerte apparaît, les lecteurs d'écran devra
 
 Lorsque la boîte de dialogue est correctement labélisée et que le focus se place sur un contrôle qu'elle contient, les lecteurs d'écran devraient annoncer le rôle accessible de la boîte de dialogue, son nom et éventuellement sa description, avant d'annoncer l'élément qui a reçu le focus.
 
-> **Note :** il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
+> [!NOTE]
+> Il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
 
 ### Exemples
 

--- a/files/fr/web/accessibility/aria/roles/article_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/article_role/index.md
@@ -17,7 +17,8 @@ Le rôle `article` indique qu'une section d'une page pourrait tout à fait être
 
 Dans l'exemple qui précède, on a deux articles côte à côte sur une même page qui pourraient partager la même structure et être liés l'un à l'autre.
 
-> **Note :** Plutôt qu'un élément `<div>` avec un rôle `article`, on utilisera plutôt un élément [`<article>`](/fr/docs/Web/HTML/Element/article). **On privilégiera toujours les éléments natifs s'ils sont disponibles.**
+> [!NOTE]
+> Plutôt qu'un élément `<div>` avec un rôle `article`, on utilisera plutôt un élément [`<article>`](/fr/docs/Web/HTML/Element/article). **On privilégiera toujours les éléments natifs s'ils sont disponibles.**
 
 Pour l'exemple qui précède, mieux vaut ne pas utiliser `role="article"` mais privilégier l'élément `<article>`.
 

--- a/files/fr/web/accessibility/aria/roles/banner_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/banner_role/index.md
@@ -15,7 +15,8 @@ Une page web ne doit pas contenir plus d'un rôle `banner`, mais il est tout à 
 
 ### Effets possibles sur les agents utilisateurs et les technologies d'assistance
 
-> **Note :** il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
+> [!NOTE]
+> Il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
 
 ### Exemples
 

--- a/files/fr/web/accessibility/aria/roles/button_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/button_role/index.md
@@ -17,7 +17,8 @@ L'exemple précédent crée un bouton simple qui sera le premier à obtenir le f
 <button id="saveChanges">Enregistrer</button>
 ```
 
-> **Note :** Si on utilise `role="button"` plutôt que les éléments sémantiques `<button>` ou `<input type="button">`, il faudra : permettre à l'élément de recevoir le focus, définir des gestionnaires d'évènements pour [`click`](/fr/docs/Web/API/Element/click_event) et [`keydown`](/fr/docs/Web/API/Document/keydown_event), y compris la gestion des touches <kbd>Entrée</kbd> et <kbd>Espace</kbd>, afin de traiter la saisie de l'utilisateur. Voir [l'exemple de code officiel de WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/examples/button/button.html).
+> [!NOTE]
+> Si on utilise `role="button"` plutôt que les éléments sémantiques `<button>` ou `<input type="button">`, il faudra : permettre à l'élément de recevoir le focus, définir des gestionnaires d'évènements pour [`click`](/fr/docs/Web/API/Element/click_event) et [`keydown`](/fr/docs/Web/API/Document/keydown_event), y compris la gestion des touches <kbd>Entrée</kbd> et <kbd>Espace</kbd>, afin de traiter la saisie de l'utilisateur. Voir [l'exemple de code officiel de WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/examples/button/button.html).
 
 ## Description
 
@@ -258,7 +259,8 @@ function toggleButton(element) {
 
 Les boutons sont des contrôles interactifs et, à ce titre, peuvent recevoir le focus. Si le rôle `button` est ajouté à un élément qui ne peut recevoir le focus nativement (comme `<span>`, `<div>` ou `<p>`), l'attribut `tabindex` devra être utilisé afin de permettre le focus sur le bouton.
 
-> **Attention :** Lorsqu'on utilise des liens avec le rôle `button`, il faut rajouter un gestionnaire d'évènement pour la touche <kbd>Espace</kbd>. En effet, les boutons s'activent avec <kbd>Espace</kbd> ou <kbd>Entrée</kbd> tandis que, nativement, les liens ne se déclenchent qu'avec <kbd>Entrée</kbd>.
+> [!WARNING]
+> Lorsqu'on utilise des liens avec le rôle `button`, il faut rajouter un gestionnaire d'évènement pour la touche <kbd>Espace</kbd>. En effet, les boutons s'activent avec <kbd>Espace</kbd> ou <kbd>Entrée</kbd> tandis que, nativement, les liens ne se déclenchent qu'avec <kbd>Entrée</kbd>.
 
 Lorsqu'on utilise le rôle `button`, les lecteurs d'écran annonce l'élément comme un bouton, généralement en énonçant « clic » suivi du nom accessible du bouton. Le nom accessible correspond au contenu de l'élément ou à la valeur de `aria-label` ou à l'élément référencé avec l'attribut `aria-labelledby`, ou à une description si elle existe.
 

--- a/files/fr/web/accessibility/aria/roles/checkbox_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/checkbox_role/index.md
@@ -30,7 +30,8 @@ Les technologies d'assistance doivent faire la chose suivante&nbsp;:
 
 - Les lecteurs d'écran devraient annoncer l'élément comme une case à cocher, et, éventuellement, fournir des instructions sur les façons de l'activer.
 
-> **Note :** il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
+> [!NOTE]
+> Il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
 
 ### Exemples
 

--- a/files/fr/web/accessibility/aria/roles/dialog_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/dialog_role/index.md
@@ -42,7 +42,8 @@ Si une boîte de dialogue a une barre de titre visible, le texte de cette barre 
 </div>
 ```
 
-> **Note :** Gardez en tête que le titre d'une boîte de dialogue et sa description ne doivent pas être focalisables afin de toujours être perçus par les lecteurs d'écran opérant en mode non-virtuel. La combinaison du rôle ARIA `dialog` et des techniques de labélisation devrait permettre aux lecteurs d'écran d'annoncer les informations de la boîte de dialogue lorsque le focus arrive sur cette dernière.
+> [!NOTE]
+> Gardez en tête que le titre d'une boîte de dialogue et sa description ne doivent pas être focalisables afin de toujours être perçus par les lecteurs d'écran opérant en mode non-virtuel. La combinaison du rôle ARIA `dialog` et des techniques de labélisation devrait permettre aux lecteurs d'écran d'annoncer les informations de la boîte de dialogue lorsque le focus arrive sur cette dernière.
 
 #### Gestion du focus
 
@@ -62,7 +63,8 @@ Lorsque le rôle `dialog` est utilisé, l'agent utilisateur doit faire la chose 
 
 Lorsque la boîte de dialogue est correctement labélisée et que le focus est déplacé vers un contrôle à l'intérieur de la boîte, les lecteurs d'écran devraient annoncer le rôle accessible du dialogue, son nom et éventuellement sa description avant d'annoncer l'élément qui a reçu le focus.
 
-> **Note :** plusieurs points de vue existent sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
+> [!NOTE]
+> Plusieurs points de vue existent sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
 
 ### Exemples
 
@@ -136,7 +138,8 @@ Pour prendre en charge les navigateurs ou les produits de technologies d'assista
 
 ### Notes
 
-> **Note :** bien qu'il soit possible d'empêcher les utilisateurs de clavier de bouger le focus vers des éléments en dehors des boîtes de dialogues, les utilisateurs de lecteurs d'écran ont toujours la possibilité de parcourir ce contenu pratiquement en utilisant le curseur virtuel du lecteur d'écran. À cause de cela, les boîtes de dialogue sont considérées comme des cas spéciaux du rôle `application`&nbsp;: on s'attend à ce qu'elles soient parcourues avec le mode de navigation non-virtuel par les utilisateurs de lecteur d'écran.
+> [!NOTE]
+> Bien qu'il soit possible d'empêcher les utilisateurs de clavier de bouger le focus vers des éléments en dehors des boîtes de dialogues, les utilisateurs de lecteurs d'écran ont toujours la possibilité de parcourir ce contenu pratiquement en utilisant le curseur virtuel du lecteur d'écran. À cause de cela, les boîtes de dialogue sont considérées comme des cas spéciaux du rôle `application`&nbsp;: on s'attend à ce qu'elles soient parcourues avec le mode de navigation non-virtuel par les utilisateurs de lecteur d'écran.
 
 ### Attributs ARIA utilisés
 

--- a/files/fr/web/accessibility/aria/roles/group_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/group_role/index.md
@@ -29,7 +29,8 @@ Les technologies d'assistance devraient être à l'écoute de tels événements 
 - Les lecteurs d'écran devraient annoncer le groupe lorsque le focus atteint l'un des contrôles appartenant au groupe, et si [aria-describedby](http://www.w3.org/TR/wai-aria/states_and_properties#aria-describedby) a été défini, la description peut être lue. Après cela seulement le contrôle focalisé devrait être annoncé.
 - Les loupes d'écran devraient agrandir le groupe.
 
-> **Note :** il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
+> [!NOTE]
+> Il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
 
 ### Exemples
 

--- a/files/fr/web/accessibility/aria/roles/link_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/link_role/index.md
@@ -25,7 +25,8 @@ Les technologies d'assistance devraient être à l'écoute de tels événements 
 - Les lecteurs d'écran devraient annoncer le texte du lien ou son label lorsque l'élément avec le rôle `link` reçoit le focus, en plus du fait ce que c'est un lien. Les liens ARIA devraient être intégré dans la fonction « lister les liens » (_List Links_) des lecteurs d'écran de la même façon que les liens ordinaires, et les actions dans cette liste de dialogue, tels que « Activer le lien » ou « Déplacer le lien », devraient se comporter de la meme façon qu'avec des liens ordinaires.
 - Les loupes d'écran devraient agrandir le lien.
 
-> **Note :** il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
+> [!NOTE]
+> Il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
 
 ### Exemples
 

--- a/files/fr/web/accessibility/aria/roles/listbox_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/listbox_role/index.md
@@ -27,7 +27,8 @@ Les technologies d'assistance devraient être à l'écoute de tels événements 
 - Les lecteurs d'écran devraient annoncer le label et le rôle de la boîte liste lorsqu'elle obtient le focus. Si un élément de la liste obtient le focus, il devrait être annoncé après, suivi par une indication de la position de l'élément dans la liste si le lecteur d'écran prend en charge cette fonction. Lorsque le focus se déplace dans la liste, le lecteur d'écran devrait annoncer les éléments de la liste appropriés.
 - Les loupes d'écran devraient agrandir la boîte liste.
 
-> **Note :** il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
+> [!NOTE]
+> Il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
 
 ### Exemples
 

--- a/files/fr/web/accessibility/aria/roles/log_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/log_role/index.md
@@ -25,7 +25,8 @@ Les technologies d'assistance devraient être à l'écoute de tels événements 
 - Les lecteurs d'écran devraient annoncer les changements intervenus dans le fichier de journalisation lorsque l'utilisateur est inactif, à moins que `aria-live="assertive"` soit défini, dans quel cas l'utilisateur peut être interrompu.
 - Les loupes d'écran devraient indiquer visuellement la disponibilité d'une mise à jour du fichier de journalisation.
 
-> **Note :** il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
+> [!NOTE]
+> Il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
 
 ### Exemples
 

--- a/files/fr/web/accessibility/aria/roles/presentation_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/presentation_role/index.md
@@ -15,7 +15,8 @@ Le rôle `presentation` est utilisé pour retirer toute représentation sémanti
 
 Les agents utilisateurs ou les technologies d'assistance ne devrait normalement pas lire les éléments marqués comme étant de rôle `presentation`.
 
-> **Note :** il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
+> [!NOTE]
+> Il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
 
 ## Exemples
 

--- a/files/fr/web/accessibility/aria/roles/progressbar_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/progressbar_role/index.md
@@ -17,15 +17,18 @@ Lorsqu'une tâche progresse, la valeur `aria-valuenow` doit être dynamiquement 
 
 Si le rôle `progressbar` décrit la progression du chargement d'une zone particulière d'une page, l'auteur **DOIT** utiliser l'attribut [`aria-describedby`](http://www.w3.org/TR/wai-aria/states_and_properties#aria-describedby) pour pointer vers l'état courant, et définir l'attribut [`aria-busy`](https://www.w3.org/TR/wai-aria-1.1/#aria-busy) à `true` pour la zone jusqu'à la fin du chargement. Il n'est pas possible à l'utilisateur de modifier la valeur de `progressbar` car elle est toujours en lecture seule.
 
-> **Note :** généralement les technologies d'assistance retourneront la valeur de l'attribut [`aria-valuenow`](https://www.w3.org/TR/wai-aria-1.1/#aria-valuenow) sous la forme d'un pourcentage d'une plage de valeurs comprise entre [`aria-valuemin`](https://www.w3.org/TR/wai-aria-1.1/#aria-valuemin) et [`aria-valuemax`](https://www.w3.org/TR/wai-aria-1.1/#aria-valuemax), sauf si [`aria-valuetext`](https://www.w3.org/TR/wai-aria-1.1/#aria-valuetext) est spécifié. Il est préférable de définir les valeurs pour les attributs `aria-valuemin`, `aria-valuemax` et `aria-valuenow` de façon appropriée pour ce calcul.
+> [!NOTE]
+> Généralement les technologies d'assistance retourneront la valeur de l'attribut [`aria-valuenow`](https://www.w3.org/TR/wai-aria-1.1/#aria-valuenow) sous la forme d'un pourcentage d'une plage de valeurs comprise entre [`aria-valuemin`](https://www.w3.org/TR/wai-aria-1.1/#aria-valuemin) et [`aria-valuemax`](https://www.w3.org/TR/wai-aria-1.1/#aria-valuemax), sauf si [`aria-valuetext`](https://www.w3.org/TR/wai-aria-1.1/#aria-valuetext) est spécifié. Il est préférable de définir les valeurs pour les attributs `aria-valuemin`, `aria-valuemax` et `aria-valuenow` de façon appropriée pour ce calcul.
 
-> **Note :** les éléments possédant le rôle `progressbar` ont une valeur `aria-readonly` implicite définie à `true`.
+> [!NOTE]
+> Les éléments possédant le rôle `progressbar` ont une valeur `aria-readonly` implicite définie à `true`.
 
 ### Effets possibles sur les agents utilisateurs et les technologies d'assistance
 
 Les lecteurs devraient annoncer les mises à jour de la progression dès qu'elles se produisent. Si la barre de progression a un label, il devrait également être mentionné.
 
-> **Note :** il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
+> [!NOTE]
+> Il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
 
 ### Exemples
 

--- a/files/fr/web/accessibility/aria/roles/slider_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/slider_role/index.md
@@ -23,7 +23,8 @@ Le curseur doit pouvoir recevoir le focus et être manipulable au clavier. Lorsq
 
 ### Effets possibles sur les agents utilisateurs et les technologies d'assistance
 
-> **Note :** il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
+> [!NOTE]
+> Il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
 
 ### Exemples
 

--- a/files/fr/web/accessibility/aria/roles/status_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/status_role/index.md
@@ -27,7 +27,8 @@ Les technologies d'assistance devraient être à l'écoute de tels événements 
 - Les lecteurs d'écran peuvent fournir une touche spécifique pour annoncer l'état actuel et ce dernier devrait présenter les contenus des états des zones live. Cela devrait être annoncé lorsque l'utilisateur est inactif, à moins que l'attribut `aria-live=”assertive”` soit défini dans quel cas l'utilisateur peut être interrompu&nbsp;;
 - Les loupes d'écran devraient agrandir l'objet d'état.
 
-> **Note :** il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
+> [!NOTE]
+> Il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
 
 ### Exemples
 

--- a/files/fr/web/accessibility/aria/roles/textbox_role/index.md
+++ b/files/fr/web/accessibility/aria/roles/textbox_role/index.md
@@ -27,7 +27,8 @@ Les technologies d'assistance devraient être à l'écoute de tels événements 
 - Les lecteurs d'écran devraient annoncer son label et son rôle lorsque le focus est sur la boite de texte. Si elle contient également du contenu, il devrait être annoncé comme avec une boite de texte régulière&nbsp;;
 - Les loupes d'écran devraient agrandir la boite de texte.
 
-> **Note :** il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
+> [!NOTE]
+> Il existe plusieurs points de vue sur la façon dont les technologies d'assistance devraient traiter cette technique. L'information fournie ci-dessus est l'une de ces opinions et n'est pas normative.
 
 ### Exemples
 

--- a/files/fr/web/accessibility/understanding_wcag/perceivable/index.md
+++ b/files/fr/web/accessibility/understanding_wcag/perceivable/index.md
@@ -9,7 +9,8 @@ l10n:
 
 Dans cet article, nous verrons des conseils pratiques pour écrire du contenu web qui respecte le principe de **perceptibilité** décrit dans les règles pour l'accessibilité des contenus web (WCAG) 2.0 et 2.1. Les états du contenu doivent pouvoir être perçus par les utilisatrices et utilisateurs d'une façon ou d'une autre en utilisant un de leurs sens.
 
-> **Note :** Les définitions du W3C pour cette catégorie, les règles associées et les critères de réussite sont présentes sur la page [Principe 1&nbsp;: l'information et les composants de l'interface utilisateur doivent être présentés à l'utilisatrice ou à l'utilisateur de façon à ce qu'il puisse les percevoir](https://www.w3.org/Translations/WCAG21-fr/#perceivable).
+> [!NOTE]
+> Les définitions du W3C pour cette catégorie, les règles associées et les critères de réussite sont présentes sur la page [Principe 1&nbsp;: l'information et les composants de l'interface utilisateur doivent être présentés à l'utilisatrice ou à l'utilisateur de façon à ce qu'il puisse les percevoir](https://www.w3.org/Translations/WCAG21-fr/#perceivable).
 
 ## Règle 1.1 — Des équivalents textuels doivent être fournis pour tout contenu non textuel
 
@@ -77,7 +78,8 @@ L'information principale à retenir ici est que le texte peut être converti sou
   </tbody>
 </table>
 
-> **Note :** Voir aussi [la description du WCAG pour la règle 1.1 sur les alternatives textuelles](https://www.w3.org/Translations/WCAG21-fr/#text-alternatives).
+> [!NOTE]
+> Voir aussi [la description du WCAG pour la règle 1.1 sur les alternatives textuelles](https://www.w3.org/Translations/WCAG21-fr/#text-alternatives).
 
 ## Règle 1.2 — Fournir des alternatives textuelles aux médias temporels
 
@@ -140,7 +142,8 @@ Les médias temporels sont les médias qui ont une durée comme les fichiers aud
  </tbody>
 </table>
 
-> **Note :** Voir aussi [la description du WCAG pour la règle 1.2 sur les alternatives aux médias temporels](https://www.w3.org/Translations/WCAG21-fr/#time-based-media).
+> [!NOTE]
+> Voir aussi [la description du WCAG pour la règle 1.2 sur les alternatives aux médias temporels](https://www.w3.org/Translations/WCAG21-fr/#time-based-media).
 
 ## Règle 1.3 — Créer du contenu pouvant être présenté de différentes façons
 
@@ -248,7 +251,8 @@ Cette règle correspond à la capacité à pouvoir utiliser du contenu de plusie
   </tbody>
 </table>
 
-> **Note :** Voir aussi [la description du WCAG pour la règle 1.3 sur le contenu adaptable, qui peut être présenté de différentes façons sans perte d'information ou de structure](https://www.w3.org/Translations/WCAG21-fr/#adaptable).
+> [!NOTE]
+> Voir aussi [la description du WCAG pour la règle 1.3 sur le contenu adaptable, qui peut être présenté de différentes façons sans perte d'information ou de structure](https://www.w3.org/Translations/WCAG21-fr/#adaptable).
 
 ## Règle 1.4 — Faciliter la perception visuelle et auditive du contenu, notamment en séparant le premier plan de l'arrière-plan
 
@@ -450,7 +454,8 @@ Cette règle consiste à s'assurer que le contenu principal peut facilement se d
   </thead>
 </table>
 
-> **Note :** Voir aussi [la description du WCAG pour la règle 1.4 sur le contenu distinguable et la facilitation de la perception visuelle et auditive du contenu, notamment pour distinguer le premier-plan de l'arrière-plan](https://www.w3.org/Translations/WCAG21-fr/#distinguishable).
+> [!NOTE]
+> Voir aussi [la description du WCAG pour la règle 1.4 sur le contenu distinguable et la facilitation de la perception visuelle et auditive du contenu, notamment pour distinguer le premier-plan de l'arrière-plan](https://www.w3.org/Translations/WCAG21-fr/#distinguishable).
 
 ## Voir aussi
 

--- a/files/fr/web/api/abortsignal/index.md
+++ b/files/fr/web/api/abortsignal/index.md
@@ -55,7 +55,8 @@ function fetchVideo() {
 }
 ```
 
-> **Note :** Lorsque `abort()` est appelé, la réponse `fetch()` rejette avec une erreur `AbortError`.
+> [!NOTE]
+> Lorsque `abort()` est appelé, la réponse `fetch()` rejette avec une erreur `AbortError`.
 
 vous pouvez trouver un exemple de travail complet sur GitHub — voir [abort-api](https://github.com/mdn/dom-examples/tree/master/abort-api) ([voir cas d'usage concret](https://mdn.github.io/dom-examples/abort-api/)).
 

--- a/files/fr/web/api/analysernode/fftsize/index.md
+++ b/files/fr/web/api/analysernode/fftsize/index.md
@@ -9,7 +9,8 @@ La propriété `fftSize` de l'objet {{ domxref("AnalyserNode") }} est un nombre 
 
 La valeur de la propriété `fftSize` property's doit être une puissance de 2 non nulle située dans l'intervalle compris entre `32` et 32768 ; sa valeur par défaut est `2048`.
 
-> **Note :** Si la valeur n'est pas une puissance de 2, ou si elle ne se trouve pas dans l'intervalle spécifiée, l'exception `INDEX_SIZE_ERR` est levée.
+> [!NOTE]
+> Si la valeur n'est pas une puissance de 2, ou si elle ne se trouve pas dans l'intervalle spécifiée, l'exception `INDEX_SIZE_ERR` est levée.
 
 ## Syntaxe
 

--- a/files/fr/web/api/analysernode/index.md
+++ b/files/fr/web/api/analysernode/index.md
@@ -83,7 +83,8 @@ _Hérite des propriétés de son parent,_ _{{domxref("AudioNode")}}_.
 
 ## Exemples
 
-> **Note :** Voir [Visualisations avec la Web Audio API](/fr/docs/Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API) pour plus d'informations.
+> [!NOTE]
+> Voir [Visualisations avec la Web Audio API](/fr/docs/Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API) pour plus d'informations.
 
 L'exemple suivant montre comment créer simplement un `AnalyserNode` avec {{domxref("AudioContext")}}, puis utiliser {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} et {{htmlelement("canvas")}} pour collecter les données temporelles et dessiner un oscilloscope en sortie. Pour des exemples plus complets, voir notre démo [Voice-change-O-matic](https://mdn.github.io/voice-change-o-matic/) (et en particulier [app.js lines 128–205](https://github.com/mdn/voice-change-o-matic/blob/gh-pages/scripts/app.js#L128-L205)).
 

--- a/files/fr/web/api/analysernode/maxdecibels/index.md
+++ b/files/fr/web/api/analysernode/maxdecibels/index.md
@@ -9,7 +9,8 @@ La propriété **`maxDecibels`** de l'objet {{ domxref("AnalyserNode") }} est un
 
 Sa valeur par défaut est `-30`.
 
-> **Note :** Si une valeur supérieure à `AnalyserNode.maxDecibels` est indiquée, une erreur `INDEX_SIZE_ERR` est levée.
+> [!NOTE]
+> Si une valeur supérieure à `AnalyserNode.maxDecibels` est indiquée, une erreur `INDEX_SIZE_ERR` est levée.
 
 ## Syntaxe
 

--- a/files/fr/web/api/analysernode/mindecibels/index.md
+++ b/files/fr/web/api/analysernode/mindecibels/index.md
@@ -9,7 +9,8 @@ La propriété **`minDecibels`** de l'objet {{ domxref("AnalyserNode") }} est un
 
 Sa valeur par défaut est `-100`.
 
-> **Note :** Si une valeur inférieure à `AnalyserNode.minDecibels` est indiquée, une erreur `INDEX_SIZE_ERR` est levée.
+> [!NOTE]
+> Si une valeur inférieure à `AnalyserNode.minDecibels` est indiquée, une erreur `INDEX_SIZE_ERR` est levée.
 
 ## Syntaxe
 

--- a/files/fr/web/api/analysernode/smoothingtimeconstant/index.md
+++ b/files/fr/web/api/analysernode/smoothingtimeconstant/index.md
@@ -11,7 +11,8 @@ La valeur est `0.8` par défaut; elle doit être comprise entre `0` et `1`. Lors
 
 En termes techniques, on applique une [fenêtre de Blackman](http://webaudio.github.io/web-audio-api/#blackman-window) pour lisser les valeurs dans le temps. La valeur par défaut convient à la plupart des cas.
 
-> **Note :** Si la valeur n'est pas comprise entre 0 et 1, une exception `INDEX_SIZE_ERR` est levée.
+> [!NOTE]
+> Si la valeur n'est pas comprise entre 0 et 1, une exception `INDEX_SIZE_ERR` est levée.
 
 ## Syntaxe
 

--- a/files/fr/web/api/attr/index.md
+++ b/files/fr/web/api/attr/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Attr
 
 Ce type représente un attribut d'un élément DOM comme un objet. Dans la plupart des méthodes DOM, vous auriez probablement récupéré l'attribut directement comme une chaîne (par exemple, {{domxref ("element.getAttribute()")}}, mais certaines fonctions (par exemple, {{domxref ("element.getAttributeNode()" )}}) ou des moyens d'itération donnent des types Attr.
 
-> **Attention :** À partir de Gecko 7.0, ceux qui vont être retirés afficheront des messages d'avertissement dans la console. Vous devriez modifier votre code en conséquence. Voir [Propriétés et méthodes dépréciées](#propriétés_et_méthodes_dépréciées) pour une liste complète.
+> [!WARNING]
+> À partir de Gecko 7.0, ceux qui vont être retirés afficheront des messages d'avertissement dans la console. Vous devriez modifier votre code en conséquence. Voir [Propriétés et méthodes dépréciées](#propriétés_et_méthodes_dépréciées) pour une liste complète.
 
 ## Propriétés
 
@@ -22,7 +23,8 @@ Ce type représente un attribut d'un élément DOM comme un objet. Dans la plupa
 - {{domxref("Attr.ownerElement", "ownerElement")}} {{readOnlyInline}}
   - : L'élément contenant l'attribut.
 
-> **Note :** DOM Niveau 4 a supprimé cette propriété . L'hypothèse était que puisque nous obtenons un objet Attr d'un {{domxref("Element")}}, nous devrions déjà connaître les éléments associés.
+> [!NOTE]
+> DOM Niveau 4 a supprimé cette propriété . L'hypothèse était que puisque nous obtenons un objet Attr d'un {{domxref("Element")}}, nous devrions déjà connaître les éléments associés.
 > Comme cela n'est pas vrai quand les objets `Attr` sont retournés par {{domxref("Document.evaluate")}}, le DOM Living Standard a réintroduit la propriété.
 >
 > Gecko affiche une note de dépréciation à partir de Gecko 7.0. Cette note a été supprimée dans Gecko 49.0.
@@ -32,7 +34,8 @@ Ce type représente un attribut d'un élément DOM comme un objet. Dans la plupa
 - {{domxref("Attr.value", "Value")}}
   - : La valeur de l'attribut.
 
-> **Note :** DOM Niveau 3 a défini `namespaceURI`, `localName` et `prefix` sur l'interface {{domxref("Node")}}. Dans DOM4 ils ont été déplacés vers `Attr`.
+> [!NOTE]
+> DOM Niveau 3 a défini `namespaceURI`, `localName` et `prefix` sur l'interface {{domxref("Node")}}. Dans DOM4 ils ont été déplacés vers `Attr`.
 >
 > Cette modification est implémentée dans Chrome depuis la version 46.0 et Firefox à partir de la version 48.0.
 


### PR DESCRIPTION
This PR converts the noteblocks for the French locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 7. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
