### PR TITLE
fr: Convert noteblocks to GFM Alerts (part 8)

### DIFF
--- a/files/fr/web/api/attr/prefix/index.md
+++ b/files/fr/web/api/attr/prefix/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Attr/prefix
 
 La propriété **`Attr.prefix`** en lecture seule renvoie le préfixe de l'espace de noms de l'attribut spécifié ou `null` si aucun préfixe n'est spécifié.
 
-> **Note :** Avant DOM4, cette API a été définie dans l'interface {{domxref ("Node")}}.
+> [!NOTE]
+> Avant DOM4, cette API a été définie dans l'interface {{domxref ("Node")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/api/audiobuffersourcenode/buffer/index.md
+++ b/files/fr/web/api/audiobuffersourcenode/buffer/index.md
@@ -21,7 +21,8 @@ Un objet [`AudioBuffer`](/fr/docs/Web/API/AudioBuffer) qui contient les données
 
 ## Exemple
 
-> **Note :** Pour un exemple complet, voir [cette démonstration](https://mdn.github.io/webaudio-examples/audio-buffer/), ou [le code source correspondant](https://github.com/mdn/webaudio-examples/blob/master/audio-buffer/index.html).
+> [!NOTE]
+> Pour un exemple complet, voir [cette démonstration](https://mdn.github.io/webaudio-examples/audio-buffer/), ou [le code source correspondant](https://github.com/mdn/webaudio-examples/blob/master/audio-buffer/index.html).
 
 ```js
 let AudioContext = window.AudioContext || window.webkitAudioContext;

--- a/files/fr/web/api/audiobuffersourcenode/detune/index.md
+++ b/files/fr/web/api/audiobuffersourcenode/detune/index.md
@@ -16,7 +16,8 @@ var source = contexteAudio.createBufferSource();
 source.detune.value = 100; // valeur en cents
 ```
 
-> **Note :** bien que l'`AudioParam` renvoyé soit en lecture seule, la valeur qu'il représente ne l'est pas.
+> [!NOTE]
+> Bien que l'`AudioParam` renvoyé soit en lecture seule, la valeur qu'il représente ne l'est pas.
 
 ### Valeur
 

--- a/files/fr/web/api/audiobuffersourcenode/index.md
+++ b/files/fr/web/api/audiobuffersourcenode/index.md
@@ -68,7 +68,8 @@ _Hérite des méthodes de son parent, {{domxref("AudioNode")}}._
 
 Cet exemple crée un tampon de deux secondes, le remplit avec du bruit blanc et le joue par l'intermédiaire d'un `AudioBufferSourceNode`.
 
-> **Note :** Vous pouvez aussi [exécuter the code](http://mdn.github.io/audio-buffer/), ou [regarder le code source](https://github.com/mdn/audio-buffer).
+> [!NOTE]
+> Vous pouvez aussi [exécuter the code](http://mdn.github.io/audio-buffer/), ou [regarder le code source](https://github.com/mdn/audio-buffer).
 
 ```js
 var contexteAudio = new (window.AudioContext || window.webkitAudioContext)();
@@ -117,7 +118,8 @@ bouton.onclick = function () {
 };
 ```
 
-> **Note :** Pour un exemple de `decodeAudioData()`, voir la page {{domxref("AudioContext.decodeAudioData")}}.
+> [!NOTE]
+> Pour un exemple de `decodeAudioData()`, voir la page {{domxref("AudioContext.decodeAudioData")}}.
 
 ## Spécifications
 

--- a/files/fr/web/api/audiobuffersourcenode/loop/index.md
+++ b/files/fr/web/api/audiobuffersourcenode/loop/index.md
@@ -26,7 +26,8 @@ Lorsque la lecture en boucle est activée, le son commence à jouer au point sp�
 
 Dans cet exemple, la fonction {{domxref("AudioContext.decodeAudioData")}} est utilisée pour décoder une piste audio et la placer dans un {{domxref("AudioBufferSourceNode")}}. Les boutons mis à disposition permettent de lire et d'arrêter la lecture audio, et un slider est utilisé pour changer la valeur de `playbackRate` en temps réel. Quand la lecture est terminée, elle boucle.
 
-> **Note :** Vous pouvez [essayer un exemple live](http://mdn.github.io/decode-audio-data/) (or [voir la source](https://github.com/mdn/decode-audio-data).)
+> [!NOTE]
+> Vous pouvez [essayer un exemple live](http://mdn.github.io/decode-audio-data/) (or [voir la source](https://github.com/mdn/decode-audio-data).)
 
 ```js
 function getData() {

--- a/files/fr/web/api/audiobuffersourcenode/loopend/index.md
+++ b/files/fr/web/api/audiobuffersourcenode/loopend/index.md
@@ -24,7 +24,8 @@ Dans cet exemple, la fonction {{domxref("AudioContext.decodeAudioData")}} est ut
 
 Lorsque la lecture de la source audio est terminée, elle boucle. Il est possible de contrôler la durée de la boucle en modifiant `loopStart` et `loopEnd`. Par exemple, si leurs valeurs sont fixées à 20 et 25, respectivement, le son bouclera entre la 20ème et la 25ème secondes du morceau.
 
-> **Note :** Voir [l'exemple complet](http://mdn.github.io/decode-audio-data/) et [son code source](https://github.com/mdn/decode-audio-data).
+> [!NOTE]
+> Voir [l'exemple complet](http://mdn.github.io/decode-audio-data/) et [son code source](https://github.com/mdn/decode-audio-data).
 
 ```js
 function getData() {

--- a/files/fr/web/api/audiobuffersourcenode/loopstart/index.md
+++ b/files/fr/web/api/audiobuffersourcenode/loopstart/index.md
@@ -23,7 +23,8 @@ Dans cet exemple, la fonction {{domxref("AudioContext.decodeAudioData")}} est ut
 
 Lorsque la lecture de la source audio est terminée, elle boucle. Il est possible de contrôler la durée de la boucle en modifiant `loopStart` et `loopEnd`. Par exemple, si leurs valeurs sont fixées à 20 et 25, respectivement, le son bouclera entre la 20ème et la 25ème secondes du morceau.
 
-> **Note :** Voir l'exemple complet [en direct](https://mdn.github.io/webaudio-examples/decode-audio-data/) et [son code source](https://github.com/mdn/webaudio-examples/tree/master/decode-audio-data).
+> [!NOTE]
+> Voir l'exemple complet [en direct](https://mdn.github.io/webaudio-examples/decode-audio-data/) et [son code source](https://github.com/mdn/webaudio-examples/tree/master/decode-audio-data).
 
 ```js
 function getData() {

--- a/files/fr/web/api/audiobuffersourcenode/playbackrate/index.md
+++ b/files/fr/web/api/audiobuffersourcenode/playbackrate/index.md
@@ -16,7 +16,8 @@ var source = contexteAudio.createBufferSource();
 source.playbackRate.value = 1.25; // proportion : 25% plus rapide que la vitesse normale
 ```
 
-> **Note :** Bien que le `AudioParam` renvoyé soit en lecture seule, la valeur qu'il représente ne l'est pas.
+> [!NOTE]
+> Bien que le `AudioParam` renvoyé soit en lecture seule, la valeur qu'il représente ne l'est pas.
 
 ### Valeur
 
@@ -32,7 +33,8 @@ Considérons un buffer audio échantillonné à 44.1 kHz (44,100 échantillons p
 
 Dans cet exemple, la fonction {{domxref("AudioContext.decodeAudioData")}} est utilisée pour décoder une piste audio et la mettre dans un {{domxref("AudioBufferSourceNode")}}. L'interface fournit deux boutons pour démarrer et arrêter la lecture, et des sliders pour modifier les propriétés `playbackRate`, `loopStart` et `loopEnd` à la volée.
 
-> **Note :** Voir l'exemple complet [en direct](https://mdn.github.io/webaudio-examples/decode-audio-data/) et [son code source](https://github.com/mdn/webaudio-examples/tree/master/decode-audio-data).
+> [!NOTE]
+> Voir l'exemple complet [en direct](https://mdn.github.io/webaudio-examples/decode-audio-data/) et [son code source](https://github.com/mdn/webaudio-examples/tree/master/decode-audio-data).
 
 ```html
 <input

--- a/files/fr/web/api/audiobuffersourcenode/start/index.md
+++ b/files/fr/web/api/audiobuffersourcenode/start/index.md
@@ -49,7 +49,8 @@ L'exemple suivant, plus complexe, jouera, après une seconde de pause, un tronç
 source.start(contexteAudio.currentTime + 1, 3, 10);
 ```
 
-> **Note :** Pour un exemple plus complexe montrant la méthode `start()` en action, consulter l'exemple [`AudioContext.decodeAudioData`](/fr/docs/Web/API/BaseAudioContext/decodeAudioData). Voir aussi l'exemple complet [en direct](https://mdn.github.io/webaudio-examples/decode-audio-data/) et [son code source](https://github.com/mdn/webaudio-examples/tree/master/decode-audio-data).
+> [!NOTE]
+> Pour un exemple plus complexe montrant la méthode `start()` en action, consulter l'exemple [`AudioContext.decodeAudioData`](/fr/docs/Web/API/BaseAudioContext/decodeAudioData). Voir aussi l'exemple complet [en direct](https://mdn.github.io/webaudio-examples/decode-audio-data/) et [son code source](https://github.com/mdn/webaudio-examples/tree/master/decode-audio-data).
 
 ## Spécifications
 

--- a/files/fr/web/api/audiocontext/createmediaelementsource/index.md
+++ b/files/fr/web/api/audiocontext/createmediaelementsource/index.md
@@ -29,7 +29,8 @@ Un {{domxref("MediaElementAudioSourceNode")}}.
 
 Cet exemple simple crée une source depuis un élément {{ htmlelement("audio") }} grâce à `createMediaElementSource()`, puis passe le signal audio à travers un {{ domxref("GainNode") }} avant de l'injecter dans le {{ domxref("AudioDestinationNode") }} pour la lecture. Quand le pointeur de la souris est déplacé, la fonction `updatePage()` est invoquée, et calcule le gain actuel comme rapport de la position Y de la souris divisée par la hauteur totale de la fenêtre. Vous pouvez ainsi augmenter ou diminuer le volume de la musique jouée, en déplaçant le pointeur de la souris vers le haut ou vers le bas.
 
-> **Note :** Vous pouvez également [voir cet exemple en temps réel](http://mdn.github.io/webaudio-examples/media-source-buffer/), ou [examiner le code source](https://github.com/mdn/webaudio-examples/tree/master/media-source-buffer).
+> [!NOTE]
+> Vous pouvez également [voir cet exemple en temps réel](http://mdn.github.io/webaudio-examples/media-source-buffer/), ou [examiner le code source](https://github.com/mdn/webaudio-examples/tree/master/media-source-buffer).
 
 ```js
 var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -74,7 +75,8 @@ source.connect(gainNode);
 gainNode.connect(audioCtx.destination);
 ```
 
-> **Note :** Du fait de l'appel à `createMediaElementSource()`, la lecture de l'audio du {{ domxref("HTMLMediaElement") }} est redirigée dans le graphe de traitement de l'AudioContext. Ainsi, jouer / mettre en pause le média est toujours possible via l'API des éléments média ou via les contrôles du lecteur.
+> [!NOTE]
+> Du fait de l'appel à `createMediaElementSource()`, la lecture de l'audio du {{ domxref("HTMLMediaElement") }} est redirigée dans le graphe de traitement de l'AudioContext. Ainsi, jouer / mettre en pause le média est toujours possible via l'API des éléments média ou via les contrôles du lecteur.
 
 ## Spécifications
 

--- a/files/fr/web/api/audiolistener/index.md
+++ b/files/fr/web/api/audiolistener/index.md
@@ -13,7 +13,8 @@ Il est important de noter qu'il n'y a qu'un seul auditeur par contexte, et qu'il
 
 ## Propriétés
 
-> **Note :** Les valeurs de position, d'orientation, et du haut de la tête peuvent être définies et lues à l'aide de différentes syntaxes. Par exemple, l'accès se fait à l'aide de la propriété, `AudioListener.positionX`, tandis que la même propriété est définie à l'aide de `AudioListener.positionX.value`. C'est pourquoi ces valeurs ne sont pas marquées en lecture seule, bien qu'elles apparaissent comme telle dans la spécification IDL.
+> [!NOTE]
+> Les valeurs de position, d'orientation, et du haut de la tête peuvent être définies et lues à l'aide de différentes syntaxes. Par exemple, l'accès se fait à l'aide de la propriété, `AudioListener.positionX`, tandis que la même propriété est définie à l'aide de `AudioListener.positionX.value`. C'est pourquoi ces valeurs ne sont pas marquées en lecture seule, bien qu'elles apparaissent comme telle dans la spécification IDL.
 
 - [`AudioListener.positionX`](/fr/docs/Web/API/AudioListener/positionX)
   - : La position horizontale de la personne qui écoute avec des coordonnées cartésiennes selon la règle de la main droite. La valeur par défaut est `0`.
@@ -41,7 +42,8 @@ Il est important de noter qu'il n'y a qu'un seul auditeur par contexte, et qu'il
 - [`AudioListener.setPosition()`](/fr/docs/Web/API/AudioListener/setPosition) {{deprecated_inline}}
   - : Définit la position de la personne qui écoute.
 
-> **Note :** Bien que ces méthodes soient dépréciées, il s'agit de l'unique façon de définir l'orientation et la position pour Firefox, Internet Explorer et Safari.
+> [!NOTE]
+> Bien que ces méthodes soient dépréciées, il s'agit de l'unique façon de définir l'orientation et la position pour Firefox, Internet Explorer et Safari.
 
 ## Fonctionnalités dépréciées
 

--- a/files/fr/web/api/audionode/index.md
+++ b/files/fr/web/api/audionode/index.md
@@ -15,7 +15,8 @@ Un `AudioNode` a des entrées et sorties, chacune avec un certain nombre de _can
 
 Plusieurs noeuds peuvent être reliés dans un _graphe de traitement_. Un tel graphe est contenu dans un {{domxref("AudioContext")}}. Chaque `AudioNode` fait partie d'exactement un contexte. Les noeuds de traitement héritent des propriétés et méthodse d'`AudioNode`, mais définissent aussi leurs propres fonctionnalités par dessus. Pour plus de détails, voir les pages individuelles liées sur la page d'accueil [Web Audio API](/fr/docs/Web/API/Web_Audio_API).
 
-> **Note :** Un `AudioNode` peut être la cible d'évènements, et implémente donc l'interface {{domxref("EventTarget")}}.
+> [!NOTE]
+> Un `AudioNode` peut être la cible d'évènements, et implémente donc l'interface {{domxref("EventTarget")}}.
 
 ## Propriétés
 

--- a/files/fr/web/api/audioprocessingevent/index.md
+++ b/files/fr/web/api/audioprocessingevent/index.md
@@ -7,7 +7,8 @@ slug: Web/API/AudioProcessingEvent
 
 AudioProcessingEvent représente l'évènement qui est passé lorsqu'un tampon {{domxref ("ScriptProcessorNode")}} est prêt à être traité.
 
-> **Note :** Cette fonctionnalité est dépréciée à partir de la version du 29 Août 2014 de la spécification Web Audio API, elle sera remplacée par les [Audio Workers](/fr/docs/Web/API/Web_Audio_API#Audio_Workers).
+> [!NOTE]
+> Cette fonctionnalité est dépréciée à partir de la version du 29 Août 2014 de la spécification Web Audio API, elle sera remplacée par les [Audio Workers](/fr/docs/Web/API/Web_Audio_API#Audio_Workers).
 
 ## Propriétés
 

--- a/files/fr/web/api/baseaudiocontext/createbuffer/index.md
+++ b/files/fr/web/api/baseaudiocontext/createbuffer/index.md
@@ -23,7 +23,8 @@ var tampon = baseAudioContext.createBuffer(
 
 ### Paramètres
 
-> **Note :** pour une explication en profondeur de la façon dont les tampons audio fonctionnent, ainsi que de leur signification, lire [Les concepts de base de la Web Audio API](/fr/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API) de notre guide des concepts de base.
+> [!NOTE]
+> Pour une explication en profondeur de la façon dont les tampons audio fonctionnent, ainsi que de leur signification, lire [Les concepts de base de la Web Audio API](/fr/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API) de notre guide des concepts de base.
 
 - nbDeCanaux
   - : Un nombre entier représentant le nombre de canaux que ce tampon doit avoir. Les implémentations doivent prendre en charge un minimum de 1 canal et un maximum de 32 canaux.
@@ -54,7 +55,8 @@ var tampon = ctxAudio.createBuffer(1, 22050, 22050);
 
 Si vous utilisez cet appel, vous obtiendrez un tampon mono (un canal), qui, lorsqu'il sera relu avec un `AudioContext` fonctionnant à 44100Hz, sera automatiquement \*rééchantillonné\* à 44100Hz (et produira donc 44100 trames), et durera 1,0 seconde : 44100 images / 44100Hz = 1 seconde.
 
-> **Note :** le rééchantillonnage audio est très similaire au redimensionnement d'une image : supposons que vous ayez une image 16 x 16, mais que vous vouliez qu'elle remplisse une zone 32x32: vous la redimensionnez (rééchantillonnez). Le résultat aura une qualité moindre (il pourra être flou ou bizarre, selon l'algorithme de redimensionnement), mais cela fonctionnera, et l'image redimensionnée prendra moins de place. L'audio rééchantillonné est exactement la même chose - vous économisez de l'espace, mais en pratique, vous ne pourrez pas reproduire correctement le contenu haute fréquence (les sons aigus).
+> [!NOTE]
+> Le rééchantillonnage audio est très similaire au redimensionnement d'une image : supposons que vous ayez une image 16 x 16, mais que vous vouliez qu'elle remplisse une zone 32x32: vous la redimensionnez (rééchantillonnez). Le résultat aura une qualité moindre (il pourra être flou ou bizarre, selon l'algorithme de redimensionnement), mais cela fonctionnera, et l'image redimensionnée prendra moins de place. L'audio rééchantillonné est exactement la même chose - vous économisez de l'espace, mais en pratique, vous ne pourrez pas reproduire correctement le contenu haute fréquence (les sons aigus).
 
 Examinons maintenant un exemple de `createBuffer()` plus complexe, dans lequel nous créons un tampon de deux secondes, le remplissons de bruit blanc, puis le reproduisons via {{domxref("AudioBufferSourceNode")}}. Le commentaire devrait clairement faire comprendre ce qui se passe. Vous pouvez également exécuter le code en direct ou regarder le source.
 

--- a/files/fr/web/api/baseaudiocontext/createbuffersource/index.md
+++ b/files/fr/web/api/baseaudiocontext/createbuffersource/index.md
@@ -23,7 +23,8 @@ Un {{domxref("AudioBufferSourceNode")}}.
 
 Dans cet exemple, on crée un tampon de deux secondes, on le remplit avec du bruit blanc, puis on le joue via un {{ domxref("AudioBufferSourceNode") }}. Les commentaires devraient expliquer clairement ce qui se passe.
 
-> **Note :** Vous pouvez également [exécuter le code en direct](https://mdn.github.io/webaudio-examples/audio-buffer/), ou [voir la source](https://github.com/mdn/webaudio-examples/blob/master/audio-buffer/index.html).
+> [!NOTE]
+> Vous pouvez également [exécuter le code en direct](https://mdn.github.io/webaudio-examples/audio-buffer/), ou [voir la source](https://github.com/mdn/webaudio-examples/blob/master/audio-buffer/index.html).
 
 ```js
 var audioCtx = new (window.AudioContext || window.webkitAudioContext)();

--- a/files/fr/web/api/baseaudiocontext/createpanner/index.md
+++ b/files/fr/web/api/baseaudiocontext/createpanner/index.md
@@ -113,7 +113,8 @@ function positionPanner() {
 }
 ```
 
-> **Note :** In terms of working out what position values to apply to the listener and panner, to make the sound appropriate to what the visuals are doing on screen, there is quite a bit of math involved, but you will soon get used to it with a bit of experimentation.
+> [!NOTE]
+> In terms of working out what position values to apply to the listener and panner, to make the sound appropriate to what the visuals are doing on screen, there is quite a bit of math involved, but you will soon get used to it with a bit of experimentation.
 
 ## Spécifications
 

--- a/files/fr/web/api/baseaudiocontext/createperiodicwave/index.md
+++ b/files/fr/web/api/baseaudiocontext/createperiodicwave/index.md
@@ -29,7 +29,8 @@ Un {{domxref("PeriodicWave")}}.
 
     - `disableNormalization`: si réglé à `true`, la normalisation est désactivée pour l'onde périodique. Sa valeur par défaut est `false`.
 
-> **Note :** Si normalisée, l'onde résultante aura une valeur absolue de sommet égale à 1.
+> [!NOTE]
+> Si normalisée, l'onde résultante aura une valeur absolue de sommet égale à 1.
 
 ## Exemple
 

--- a/files/fr/web/api/battery_status_api/index.md
+++ b/files/fr/web/api/battery_status_api/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Battery_Status_API
 
 L'**API <i lang="en">Battery Status</i>**, souvent mentionnée sous le nom **<i lang="en">Battery API</i>** (l'API <i lang="en">Battery</i>), fournit des informations sur le niveau de charge du système et permet d'envoyer des événements pour prévenir d'un changement du niveau de charge de la batterie. Cela peut être utilisé pour ajuster la consommation d'une application et la réduire pour réduire l'utilisation de la batterie lorsque son niveau de charge est bas ou encore de sauvegarder les données quand la batterie est bientôt vide.
 
-> **Note :** Cette API _n'est pas disponible_ dans les [Web Workers](/fr/docs/Web/API/Web_Workers_API) (elle n'est pas exposée via [`WorkerNavigator`](/fr/docs/Web/API/WorkerNavigator)).
+> [!NOTE]
+> Cette API _n'est pas disponible_ dans les [Web Workers](/fr/docs/Web/API/Web_Workers_API) (elle n'est pas exposée via [`WorkerNavigator`](/fr/docs/Web/API/WorkerNavigator)).
 
 ## Interfaces
 

--- a/files/fr/web/api/batterymanager/chargingtime/index.md
+++ b/files/fr/web/api/batterymanager/chargingtime/index.md
@@ -7,7 +7,8 @@ slug: Web/API/BatteryManager/chargingTime
 
 La propriété **`BatteryManager.chargingTime`** indique le temps, en secondes, qu'il reste jusqu'à que la batterie soit rechargée, ou vaut `0` si la batterie est déjà rechargée. Si la batterie est en décharge, la variable vaut [`Infinity`](/fr/docs/JavaScript/Reference/Global_Objects/Infinity). Lorsque sa valeur change, l'évènement [`chargingtimechange`](/fr/docs/Web/API/BatteryManager/chargingtimechange_event) est déclenché.
 
-> **Note :** Même si le temps retourné devrait être précis à la seconde, les navigateurs arrondissent cette valeur (typiquement à 15 minutes près) pour des raisons de confidentialité.
+> [!NOTE]
+> Même si le temps retourné devrait être précis à la seconde, les navigateurs arrondissent cette valeur (typiquement à 15 minutes près) pour des raisons de confidentialité.
 
 ## Exemple
 

--- a/files/fr/web/api/batterymanager/dischargingtime/index.md
+++ b/files/fr/web/api/batterymanager/dischargingtime/index.md
@@ -7,7 +7,8 @@ slug: Web/API/BatteryManager/dischargingTime
 
 La propriété **`BatteryManager.dischargingTime`** indique le temps, en secondes, qu'il reste jusqu'à que la batterie soit déchargée, ou vaut [`Infinity`](/fr/docs/JavaScript/Reference/Global_Objects/Infinity) si la batterie est en train d'être chargée ou si le système ne parvient pas à calculer un temps restant. Lorsque sa valeur change, l'évènement [`dischargingtimechange`](/fr/docs/Web/API/BatteryManager/dischargingtimechange_event) est déclenché.
 
-> **Note :** Même si le temps retourné devrait être précis à la seconde, les navigateurs arrondissent cette valeur (typiquement à 15 minutes près) pour des raisons de confidentialité.
+> [!NOTE]
+> Même si le temps retourné devrait être précis à la seconde, les navigateurs arrondissent cette valeur (typiquement à 15 minutes près) pour des raisons de confidentialité.
 
 ## Exemple
 

--- a/files/fr/web/api/biquadfilternode/frequency/index.md
+++ b/files/fr/web/api/biquadfilternode/frequency/index.md
@@ -17,7 +17,8 @@ var filtreBiquad = contexteAudio.createBiquadFilter();
 filtreBiquad.frequency.value = 3000;
 ```
 
-> **Note :** Bien que le `AudioParam` renvoyé soit en lecture seule, la valeur qu'il représente ne l'est pas.
+> [!NOTE]
+> Bien que le `AudioParam` renvoyé soit en lecture seule, la valeur qu'il représente ne l'est pas.
 
 ### Valeur
 

--- a/files/fr/web/api/blob/index.md
+++ b/files/fr/web/api/blob/index.md
@@ -11,9 +11,11 @@ Pour construire un `Blob` à partir d'objets qui ne sont pas des blobs ou à par
 
 Les API qui acceptent des objets `Blob` sont également listées sur la documentation de {{domxref("File")}}.
 
-> **Note :** La méthode `slice()` utilisait auparavant un deuxième argument qui indiquait le nombre d'octets à copier dans le nouveau blob. Si on utilisait un couple de valeur `début + longueur` qui dépassait la taille du blob source, le blob qui était renvoyé contenait les données à partir de l'indice de début et jusuq'à la fin du blob.
+> [!NOTE]
+> La méthode `slice()` utilisait auparavant un deuxième argument qui indiquait le nombre d'octets à copier dans le nouveau blob. Si on utilisait un couple de valeur `début + longueur` qui dépassait la taille du blob source, le blob qui était renvoyé contenait les données à partir de l'indice de début et jusuq'à la fin du blob.
 
-> **Note :** La méthode `slice()` doit être utilisée avec certains préfixes sur certaines versions de navigateurs : `blob.mozSlice()` pour Firefox 12 et antérieur, `blob.webkitSlice()` dans Safari. Un ancienne version de `slice()` sans préfixes avait une sémantique différente et est désormais obsolète. La prise en charge de `blob.mozSlice()` a été abandonnée avec Firefox 30.
+> [!NOTE]
+> La méthode `slice()` doit être utilisée avec certains préfixes sur certaines versions de navigateurs : `blob.mozSlice()` pour Firefox 12 et antérieur, `blob.webkitSlice()` dans Safari. Un ancienne version de `slice()` sans préfixes avait une sémantique différente et est désormais obsolète. La prise en charge de `blob.mozSlice()` a été abandonnée avec Firefox 30.
 
 ## Constructeur
 

--- a/files/fr/web/api/blob/size/index.md
+++ b/files/fr/web/api/blob/size/index.md
@@ -9,7 +9,8 @@ slug: Web/API/Blob/size
 
 Renvoie la taille du fichier en octets.
 
-> **Note :** Cette propriété est dépréciée. Utilisez {{domxref("Blob.size")}} à la place.
+> [!NOTE]
+> Cette propriété est dépréciée. Utilisez {{domxref("Blob.size")}} à la place.
 
 ## Syntaxe
 

--- a/files/fr/web/api/btoa/index.md
+++ b/files/fr/web/api/btoa/index.md
@@ -8,7 +8,7 @@ slug: Web/API/btoa
 La méthode `WindowOrWorkerGlobalScope.btoa()` crée une chaîne ASCII codée en base 64 à partir d'un objet {{jsxref ("String")}} dans lequel chaque caractère de la chaîne est traité comme un octet de données binaires.
 
 > [!NOTE]
-> étant donné que cette fonction traite chaque caractère comme un octet de données binaires, quel que soit le nombre d'octets composant le caractère, une exception `InvalidCharacterError` est déclenchée si le {{Glossary("code point")}} d'un caractère quelconque est en dehors de la plage 0x00 à 0xFF. Voir [Chaînes Unicode](#chaînes_unicode) pour un exemple montrant comment encoder des chaînes avec des caractères en dehors de la plage 0x00 à 0xFF.
+> Étant donné que cette fonction traite chaque caractère comme un octet de données binaires, quel que soit le nombre d'octets composant le caractère, une exception `InvalidCharacterError` est déclenchée si le {{Glossary("code point")}} d'un caractère quelconque est en dehors de la plage 0x00 à 0xFF. Voir [Chaînes Unicode](#chaînes_unicode) pour un exemple montrant comment encoder des chaînes avec des caractères en dehors de la plage 0x00 à 0xFF.
 
 ## Syntaxe
 

--- a/files/fr/web/api/btoa/index.md
+++ b/files/fr/web/api/btoa/index.md
@@ -7,7 +7,8 @@ slug: Web/API/btoa
 
 La méthode `WindowOrWorkerGlobalScope.btoa()` crée une chaîne ASCII codée en base 64 à partir d'un objet {{jsxref ("String")}} dans lequel chaque caractère de la chaîne est traité comme un octet de données binaires.
 
-> **Note :** étant donné que cette fonction traite chaque caractère comme un octet de données binaires, quel que soit le nombre d'octets composant le caractère, une exception `InvalidCharacterError` est déclenchée si le {{Glossary("code point")}} d'un caractère quelconque est en dehors de la plage 0x00 à 0xFF. Voir [Chaînes Unicode](#chaînes_unicode) pour un exemple montrant comment encoder des chaînes avec des caractères en dehors de la plage 0x00 à 0xFF.
+> [!NOTE]
+> étant donné que cette fonction traite chaque caractère comme un octet de données binaires, quel que soit le nombre d'octets composant le caractère, une exception `InvalidCharacterError` est déclenchée si le {{Glossary("code point")}} d'un caractère quelconque est en dehors de la plage 0x00 à 0xFF. Voir [Chaînes Unicode](#chaînes_unicode) pour un exemple montrant comment encoder des chaînes avec des caractères en dehors de la plage 0x00 à 0xFF.
 
 ## Syntaxe
 

--- a/files/fr/web/api/cache/index.md
+++ b/files/fr/web/api/cache/index.md
@@ -11,11 +11,14 @@ Une origine peut avoir plusieurs objets nommés `Cache`. Vous êtes responsable 
 
 Vous êtes également responsable de la purge périodique des entrées du cache. Chaque navigateur a une limite stricte sur la quantité de mémoire cache qu'une origine donnée peut utiliser. Les estimations de l'utilisation du quota de cache sont disponibles via le lien {{domxref("StorageEstimate")}} API. Le navigateur fait de son mieux pour gérer l'espace disque, mais il peut supprimer le stockage en cache d'une origine. Le navigateur supprime généralement toutes les données d'une origine ou aucune des données d'une origine. Veillez à nommer les caches et à n'utiliser les caches qu'à partir de la version du script sur laquelle ils peuvent fonctionner en toute sécurité. Pour plus d'informations, voir [Suppression des anciens caches](/fr/docs/Web/API/Service_Worker_API/Using_Service_Workers#Supprimer_les_anciens_caches).
 
-> **Note :** Les implémentations initiales du cache (dans Blink et Gecko) résolvent les engagements {{domxref("Cache.add()")}}, {{domxref("Cache.addAll()")}}, et {{domxref("Cache.put()")}} lorsque le corps de la réponse est entièrement écrit sur le stockage. Des versions plus récentes de la spécification précisent que le navigateur peut résoudre la promesse dès que l'entrée est enregistrée dans la base de données, même si le corps de réponse est encore en cours d'écriture.
+> [!NOTE]
+> Les implémentations initiales du cache (dans Blink et Gecko) résolvent les engagements {{domxref("Cache.add()")}}, {{domxref("Cache.addAll()")}}, et {{domxref("Cache.put()")}} lorsque le corps de la réponse est entièrement écrit sur le stockage. Des versions plus récentes de la spécification précisent que le navigateur peut résoudre la promesse dès que l'entrée est enregistrée dans la base de données, même si le corps de réponse est encore en cours d'écriture.
 
-> **Note :** L'algorithme des correspondances de clés est dépendant de la valeur de l'[en-tête VARY](https://www.fastly.com/blog/best-practices-using-vary-header). Ainsi, pour faire correspondre une nouvelle clé, il faut examiner à la fois la clé et la valeur des entrées dans le Cache.
+> [!NOTE]
+> L'algorithme des correspondances de clés est dépendant de la valeur de l'[en-tête VARY](https://www.fastly.com/blog/best-practices-using-vary-header). Ainsi, pour faire correspondre une nouvelle clé, il faut examiner à la fois la clé et la valeur des entrées dans le Cache.
 
-> **Note :** L'API de mise en cache n'honore pas les en-têtes de mise en cache HTTP.
+> [!NOTE]
+> L'API de mise en cache n'honore pas les en-têtes de mise en cache HTTP.
 
 ## Méthodes
 
@@ -44,7 +47,8 @@ Le code gère les exceptions déclenchées par l'opération de {{domxref("Global
 
 Cet extrait de code illustre également une bonne pratique pour versionner les caches utilisés par le service worker. Bien qu'il y ait seulement un cache dans cet exemple, la même approche peut être utilisée pour des caches multiples. Il associe un identifiant court avec un nom de cache versionné et spécifique. Le code supprime aussi tous les caches qui ne sont pas nommés dans `CURRENT_CACHES`.
 
-> **Note :** In Chrome, visit chrome://inspect/#service-workers and click on the "inspect" link below the registered service worker to view logging statements for the various actions the [service-worker.js](https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/selective-caching/service-worker.js) script is performing.
+> [!NOTE]
+> In Chrome, visit chrome://inspect/#service-workers and click on the "inspect" link below the registered service worker to view logging statements for the various actions the [service-worker.js](https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/selective-caching/service-worker.js) script is performing.
 
 ```js
 var CACHE_VERSION = 1;

--- a/files/fr/web/api/cache/keys/index.md
+++ b/files/fr/web/api/cache/keys/index.md
@@ -9,7 +9,8 @@ La méthode **`keys()`** de l'interface {{domxref("Cache")}} retourne une {{jsxr
 
 Les requêtes sont retournées dans le même ordre que l'ordre d'insertion.
 
-> **Note :** Les requêtes avec des URLs déjà présentes mais des headers différents peuvent être retournées si leurs réponses comportent le header `VARY`.
+> [!NOTE]
+> Les requêtes avec des URLs déjà présentes mais des headers différents peuvent être retournées si leurs réponses comportent le header `VARY`.
 
 ## Syntaxe
 

--- a/files/fr/web/api/cache/put/index.md
+++ b/files/fr/web/api/cache/put/index.md
@@ -20,9 +20,11 @@ fetch(url).then(function (response) {
 
 > **Note :** `put()` écrasera toute paire clé/valeur précedemment stockée en cache et qui correspond à la requête.
 
-> **Note :** Les implémentations initiales de Cache (à la fois dans Blink et Gecko) résolvent les promesses {{domxref("Cache.add")}}, {{domxref("Cache.addAll")}}, et {{domxref("Cache.put")}} quand le corps de la réponse est entièrement écrit en stockage. Les versions plus récentes des spécifications sont plus précises en déclarant que le navigateur peut résoudre ces promesses dès que l'entrée est enregistrée en base de donnée, même si le reste de la requête est encore en train d'arriver.
+> [!NOTE]
+> Les implémentations initiales de Cache (à la fois dans Blink et Gecko) résolvent les promesses {{domxref("Cache.add")}}, {{domxref("Cache.addAll")}}, et {{domxref("Cache.put")}} quand le corps de la réponse est entièrement écrit en stockage. Les versions plus récentes des spécifications sont plus précises en déclarant que le navigateur peut résoudre ces promesses dès que l'entrée est enregistrée en base de donnée, même si le reste de la requête est encore en train d'arriver.
 
-> **Note :** Depuis Chrome 46, l'API Cache ne stocke que les requêtes depuis des origines sécurisées, à savoir celles servies en HTTPS.
+> [!NOTE]
+> Depuis Chrome 46, l'API Cache ne stocke que les requêtes depuis des origines sécurisées, à savoir celles servies en HTTPS.
 
 ## Syntaxe
 
@@ -43,7 +45,8 @@ cache.put(request, response).then(function () {
 
 Une {{jsxref("Promise", "Promesse")}} est retournée avec void.
 
-> **Note :** La promesse sera rompue avec un `TypeError` si le schéma d'URL n'est pas `http` ou `https`.
+> [!NOTE]
+> La promesse sera rompue avec un `TypeError` si le schéma d'URL n'est pas `http` ou `https`.
 
 ## Exemples
 

--- a/files/fr/web/api/cachestorage/index.md
+++ b/files/fr/web/api/cachestorage/index.md
@@ -21,7 +21,8 @@ Utilisez {{domxref("CacheStorage.match()")}} pour vérifier si une {{domxref("Re
 
 Vous pouvez accéder à `CacheStorage` via la propriété globale [`caches`](/fr/docs/Web/API/caches).
 
-> **Note :** CacheStorage échouera systématiquement avec une `SecurityError` sur les domaines non certifiés (i.e. ceux qui n'utilisent pas HTTPS, bien que cette définition risque de devenir plus complexe dans le future). Pendant vos tests vous pouvez contourner ce comportement en cochant l'option "Enable Service Workers over HTTP (when toolbox is open)" dans les options Firefox Devtools / le menu gear.
+> [!NOTE]
+> CacheStorage échouera systématiquement avec une `SecurityError` sur les domaines non certifiés (i.e. ceux qui n'utilisent pas HTTPS, bien que cette définition risque de devenir plus complexe dans le future). Pendant vos tests vous pouvez contourner ce comportement en cochant l'option "Enable Service Workers over HTTP (when toolbox is open)" dans les options Firefox Devtools / le menu gear.
 
 > **Note :** {{domxref("CacheStorage.match()")}} est une méthode de convenance. Il est possible d'implémenter une fonctionnalité équivalente pour matcher une entrée de cache en appelant {{domxref("CacheStorage.open()")}}, puis en retournant {{domxref("CacheStorage.keys()")}}, et en matchant les entrées voulues avec {{domxref("CacheStorage.match()")}}.
 

--- a/files/fr/web/api/cachestorage/open/index.md
+++ b/files/fr/web/api/cachestorage/open/index.md
@@ -9,7 +9,8 @@ La fonction **`open()`** de l'interface {{domxref("CacheStorage")}} retourne une
 
 Vous pouvez accéder à `CacheStorage` via la propriété globale [`caches`](/fr/docs/Web/API/caches).
 
-> **Note :** Si le {{domxref("Cache")}} spécifié n'existe pas, un nouveau cache sera crée avec `cacheName` et retournera une {{jsxref("Promise", "Promesse")}} renvoyant le nouvel objet {{domxref("Cache")}}.
+> [!NOTE]
+> Si le {{domxref("Cache")}} spécifié n'existe pas, un nouveau cache sera crée avec `cacheName` et retournera une {{jsxref("Promise", "Promesse")}} renvoyant le nouvel objet {{domxref("Cache")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/fr/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -18,7 +18,8 @@ Jusqu'à présent, nous avons seulement vu des méthodes sur le contexte de dess
 
 `color` est une chaîne représentant un CSS {{cssxref("&lt;color&gt;")}}, d'un objet gradient ou d'un objet motif. Nous allons examiner le gradient et la structure des objets plus tard. Par défaut, l'encadrement et la couleur de remplissage sont fixés sur noir (valeur `#000000` de CSS `color`).
 
-> **Note :** Lorsque vous définissez `strokeStyle` et `fillStyle`, la nouvelle valeur devient la valeur par défaut pour toutes les formes en cours d'élaboration à partir de là. Pour chaque forme que vous voulez dans une couleur différente, vous aurez besoin de réaffecter `fillStyle` ou `strokeStyle`.
+> [!NOTE]
+> Lorsque vous définissez `strokeStyle` et `fillStyle`, la nouvelle valeur devient la valeur par défaut pour toutes les formes en cours d'élaboration à partir de là. Pour chaque forme que vous voulez dans une couleur différente, vous aurez besoin de réaffecter `fillStyle` ou `strokeStyle`.
 
 Les chaînes pour être valides, doivent être conforme à la spécification CSS {{cssxref("&lt;color&gt;")}}. Chacun des exemples suivants décrit la même couleur.
 
@@ -257,7 +258,8 @@ Si vous considérez un tracé de (3,1) à (3,5) avec une épaisseur de ligne de 
 
 Pour résoudre ce problème, vous devez être très précis dans la création de votre tracé. Sachant qu'une largeur de `1.0` s'étendra d'une demi-unité de chaque côté du tracé, créer le tracé de (3.5,1) à (3.5,5) aboutit à l'exemple trois pour une largeur de `1.0` et au remplissage d'un seul pixel de ligne verticale.
 
-> **Note :** Sachez que dans notre exemple de ligne verticale, la position Y fait toujours référence à une position de grille entière — sinon, vous verrez des pixels à moitié colorés à gauche et à droite (mais notez aussi que ce comportement dépend de l'actuel style `lineCap`, dont la valeur par défaut est `butt`. Vous pouvez essayer de tracer des traits consistants avec des coordonnées non-entières pour les lignes et avec une largeur particulière, en définissant le style `lineCap` à `square`, pour que le bord extérieur du trait autour du point final soit automatiquement étendu pour couvrir le pixel entier).
+> [!NOTE]
+> Sachez que dans notre exemple de ligne verticale, la position Y fait toujours référence à une position de grille entière — sinon, vous verrez des pixels à moitié colorés à gauche et à droite (mais notez aussi que ce comportement dépend de l'actuel style `lineCap`, dont la valeur par défaut est `butt`. Vous pouvez essayer de tracer des traits consistants avec des coordonnées non-entières pour les lignes et avec une largeur particulière, en définissant le style `lineCap` à `square`, pour que le bord extérieur du trait autour du point final soit automatiquement étendu pour couvrir le pixel entier).
 >
 > Notez également que seuls les points de début et de fin d'un chemin sont affectés : si un chemin est fermé avec `closePath ()`, il n'y a pas de point de départ ni de point final ; à la place, tous les points d'extrémité du chemin sont connectés à leurs segments joints précédent et suivant, en utilisant le paramètre courant du style `lineJoin`, dont la valeur par défaut est `miter`, avec pour effet d'étendre automatiquement les bordures extérieures des segments connectés à leur point d'intersection. Ainsi, le trait de rendu couvrira exactement les pixels pleins centrés à chaque extrémité si ces segments connectés sont horizontaux et / ou verticaux. Voir les deux sections suivantes pour les démonstrations de ces styles de lignes supplémentaires.
 
@@ -627,7 +629,8 @@ img.src = "someimage.png";
 var ptrn = ctx.createPattern(img, "repeat");
 ```
 
-> **Note :** Comme avec la méthode `drawImage ()`, vous devez vous assurer que l'image que vous utilisez est chargée avant d'appeler cette méthode, ou le motif pourrait être mal dessiné.
+> [!NOTE]
+> Comme avec la méthode `drawImage ()`, vous devez vous assurer que l'image que vous utilisez est chargée avant d'appeler cette méthode, ou le motif pourrait être mal dessiné.
 
 ### Un exemple de `createPattern`
 
@@ -680,7 +683,8 @@ La propriété `shadowBlur` indique la taille de l'effet de flou ; cette valeur 
 
 La propriété `shadowColor` est une valeur de couleur CSS standard indiquant la couleur de l'effet d'ombre ; par défaut, il est entièrement en noir transparent.
 
-> **Note :** Les ombres ne sont dessinées que pour les [opérations de composition](/fr/docs/Web/API/Canvas_API/Tutorial/Compositing) `source-over`.
+> [!NOTE]
+> Les ombres ne sont dessinées que pour les [opérations de composition](/fr/docs/Web/API/Canvas_API/Tutorial/Compositing) `source-over`.
 
 ### Un exemple de texte ombré
 

--- a/files/fr/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/fr/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -45,7 +45,8 @@ Si vous voulez faire un jeu, et utiliser les événements du clavier et de la so
 
 Dans les exemples suivants, nous utiliserons {{domxref("window.requestAnimationFrame()")}} pour contrôler les animations. Cette technique est plus fluide et plus efficace, elle appelle les opérations de rendu quand le système est prêt à dessiner l'image. Dans des conditions idéales, la fonction est alors lancée 60 fois par seconde, mais la fréquence sera réduite si l'animation se passe dans un onglet non visible.
 
-> **Note :** Pour plus d'informations sur la boucle d'animation, plus spécialement pour les jeux, rendez-vous sur l'article [L'anatomie d'un jeu vidéo](/fr/docs/Jeux/Anatomie) dans notre section [Développement de jeux vidéo](/fr/docs/Jeux).
+> [!NOTE]
+> Pour plus d'informations sur la boucle d'animation, plus spécialement pour les jeux, rendez-vous sur l'article [L'anatomie d'un jeu vidéo](/fr/docs/Jeux/Anatomie) dans notre section [Développement de jeux vidéo](/fr/docs/Jeux).
 
 ## Un système terrestre animé
 

--- a/files/fr/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/fr/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -15,7 +15,8 @@ Commençons par regarder l'élément {{HTMLElement("canvas")}} lui-même.
 
 Ceci ressemble beaucoup à l'élément \<img>. La seule différence est qu'il n'y a pas les attributs `src` et `alt`. L'élément `<canvas>` a seulement deux attributs : [`width`](/fr/docs/Web/HTML/Element/canvas#width) et [`height`](/fr/docs/Web/HTML/Element/canvas#height) (« largeur » et « hauteur »). Ces deux attributs sont optionnels et peuvent aussi être fixés à travers le [DOM](/fr/docs/Référence_du_DOM_Gecko). Quand les attributs **width** et **height** ne sont pas spécifiés, le canvas sera initialement large de **300 pixels** et haut de **150 pixels**. Les dimensions du canvas peuvent être modifiés par du [CSS](/fr/docs/Web/CSS), mais l'image sera dessinée selon les valeurs **width** et **height** du canvas et ensuite étirée pour afficher dans l'espace donné par le CSS.
 
-> **Note :** Si l'image semble déformée, essayez de spécifier de manière explicite vos attributs `width` et `height` dans l'élément `<canvas>`, et de ne pas utiliser de CSS.
+> [!NOTE]
+> Si l'image semble déformée, essayez de spécifier de manière explicite vos attributs `width` et `height` dans l'élément `<canvas>`, et de ne pas utiliser de CSS.
 
 L'attribut `id` n'est pas spécifique à l'élément `<canvas>`. C'est en fait un des attributs HTML de base qui peut être utilisé par presque tous les éléments HTML. C'est toujours mieux d'assigner une `id` car ça facilite beaucoup l'identification du `canvas` dans le code `javascript`.
 
@@ -43,7 +44,8 @@ Le contenu de repli pourrait, par exemple, donner une description texte du canva
 
 Au contraire de l'élément {{HTMLElement("img")}}, l'élément {{HTMLElement("canvas")}} **requiert** la balise fermante (`</canvas>`).
 
-> **Note :** Bien que quelques unes des premières versions du navigateur Safari ne requièrent pas la balise fermante, la spécification HTML indique qu'elle est nécessaire, alors il est mieux de l'inclure pour avoir le plus de compatibilité possible. Ces anciennes versions de Safari (avant la version 2.0) affichent le contenu de repli en plus que le canvas lui-même, sauf si vous utilisez des trucs CSS pour le masquer. Heureusement, il y a très peu d'utilisateurs de ces vieilles versions de Safari de nos jours.
+> [!NOTE]
+> Bien que quelques unes des premières versions du navigateur Safari ne requièrent pas la balise fermante, la spécification HTML indique qu'elle est nécessaire, alors il est mieux de l'inclure pour avoir le plus de compatibilité possible. Ces anciennes versions de Safari (avant la version 2.0) affichent le contenu de repli en plus que le canvas lui-même, sauf si vous utilisez des trucs CSS pour le masquer. Heureusement, il y a très peu d'utilisateurs de ces vieilles versions de Safari de nos jours.
 
 Si vous n'avez pas besoin de contenu de repli, un simple `<canvas id="foo" ...></canvas>` est totalement compatible avec tous les navigateurs qui ont pris en charge la fonctionnalité canvas.
 

--- a/files/fr/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/fr/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -87,13 +87,15 @@ Voici les functions utilisées pour réaliser ces étapes :
 
 La première étape pour créer un trajet est d'appeler `beginPath()`. En interne, les trajets sont stockés comme une liste de sous-trajets (lignes, arcs, etc) qui ensemble réalisent une forme. Chaque fois que cette méthode est appelée, la liste est remise à zéro, et nous pouvons commencer à dessiner de nouvelles formes.
 
-> **Note :** Lorsque le trajet en cours est vide, par exemple immédiatement après avoir appelé `beginPath()`, ou sur un canvas nouvellement créé, la première instruction de construction de trajet est toujours traitée comme un `moveTo()`, indépendamment de ce qu'elle est en réalité. Pour cette raison, il sera pratiquement toujours souhaitable d'indiquer la position de départ après la réinitialisation d'un trajet.
+> [!NOTE]
+> Lorsque le trajet en cours est vide, par exemple immédiatement après avoir appelé `beginPath()`, ou sur un canvas nouvellement créé, la première instruction de construction de trajet est toujours traitée comme un `moveTo()`, indépendamment de ce qu'elle est en réalité. Pour cette raison, il sera pratiquement toujours souhaitable d'indiquer la position de départ après la réinitialisation d'un trajet.
 
 La deuxième étape est d'appeler les méthodes qui indiquent effectivement les sous-trajets à dessiner. Nous verrons ces méthodes bientôt.
 
 La troisième méthode, optionnelle, est l'appel à `closePath()`. Cette méthode essaye de fermer la forme géométrique en dessinant une ligne droite depuis le point courant jusqu'au début du trajet. Si la forme a déjà été fermée ou s'il n'y a qu'un seul point dans la liste, cette fonction ne fait rien.
 
-> **Note :** Quand vous appelez `fill()`, toutes les formes ouvertes sont automatiquement fermées, ainsi vous n'avez pas à appeler `closePath()`. Ce n'est **pas** le cas quand vous appelez `stroke()`.
+> [!NOTE]
+> Quand vous appelez `fill()`, toutes les formes ouvertes sont automatiquement fermées, ainsi vous n'avez pas à appeler `closePath()`. Ce n'est **pas** le cas quand vous appelez `stroke()`.
 
 ### Dessin d'un triangle
 
@@ -170,7 +172,8 @@ Le résultat ressemble à ce qui suit&nbsp;:
 
 Si vous voulez voir les lignes d'interconnexion, vous pouvez enlever les lignes qui appellent `moveTo()`.
 
-> **Note :** Pour en savoir plus sur la fonction `arc()`, voir la section [Les arcs](#les_arcs) ci-dessous.
+> [!NOTE]
+> Pour en savoir plus sur la fonction `arc()`, voir la section [Les arcs](#les_arcs) ci-dessous.
 
 ### Les lignes
 
@@ -232,7 +235,8 @@ Pour dessiner des arcs ou des cercles, on utilise les méthodes `arc() ou arcTo(
 
 Regardons plus en détail la méthode `arc`, qui prend six paramètres : `x` et `y` sont les coordonnées du centre du cercle sur lequel l'arc doit être tracé. `rayon` se passe d'explication. Les paramètres `angleInitial et` `angleFinal` définissent en radians les points de départ et d'arrivée de l'arc, le long de la courbe du cercle. Ceux-ci sont mesurés à partir de l'axe des x. Le paramètre `antihoraire` est une valeur booléenne qui, lorsque `true`, dessine l'arc dans le sens antihoraire, sinon, l'arc est dessiné dans le sens horaire.
 
-> **Note :** Les angles dans la fonction `arc` sont mesurés en radians, et non en degrés. Pour convertir des degrés en radians, vous pouvez utiliser l'expression JavaScript suivante : `radians = (Math.PI/180)*degres`.
+> [!NOTE]
+> Les angles dans la fonction `arc` sont mesurés en radians, et non en degrés. Pour convertir des degrés en radians, vous pouvez utiliser l'expression JavaScript suivante : `radians = (Math.PI/180)*degres`.
 
 L'exemple suivant est un peu plus complexe que ceux que nous avons vus plus haut. Il dessine 12 arcs différents, avec des angles et des remplissages différents.
 
@@ -242,7 +246,8 @@ Les coordonnées `x` et `y` devraient être claires. `rayon` et `angleInitial` s
 
 L'instruction pour le paramètre `antihoraire` a pour résultat que la première et de la troisième ligne sont dessinées comme des arcs de sens horaire, et que la deuxième et quatrième sont dessinées comme des arcs de sens antihoraire. Enfin, l'instruction `if` fait des arcs filaires dans la moité supérieure, et des arcs remplis dans la moitié inférieure.
 
-> **Note :** Cet exemple requiert canevas légèrement plus large que les autres sur cette page : 150 x 200 pixels.
+> [!NOTE]
+> Cet exemple requiert canevas légèrement plus large que les autres sur cette page : 150 x 200 pixels.
 
 ```html hidden
 <html>

--- a/files/fr/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/fr/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -60,7 +60,8 @@ var monImageData = ctx.getImageData(gauche, haut, largeur, hauteur);
 
 Cette méthode retourne un objet `ImageData` représentant les données pixel pour la zone du canevas dont les coins sont représentés par les points (`left`, `top`) _`(gauche,haut)`_, (`left+width`, `top`) _(gauche+largeur, haut)_, (`left`, `top+height`) _(gauche, haut+hauteur)_ et (`left+width`, `top+height`) _(gauche+largeur, haut+hauteur)_. Les coordonnées sont spécifiées en unités d'espace de coordonnées du canevas.
 
-> **Note :** Tous les pixels en dehors du canevas seront retournés comme noirs transparents dans l'objet `ImageData` résultant.
+> [!NOTE]
+> Tous les pixels en dehors du canevas seront retournés comme noirs transparents dans l'objet `ImageData` résultant.
 
 Cette méthode est aussi présentée dans l'article [Manipulation vidéo utilisant canvas](/fr/docs/HTML/Manipulating_video_using_canvas).
 

--- a/files/fr/web/api/canvas_api/tutorial/transformations/index.md
+++ b/files/fr/web/api/canvas_api/tutorial/transformations/index.md
@@ -124,7 +124,8 @@ Le point central de rotation est toujours l'origine de la toile. Pour changer le
 
 Dans cet exemple, nous utiliserons la méthode `rotate ()` pour faire d'abord tourner un rectangle à partir de l'origine du canevas, puis du centre du rectangle lui-même à l'aide de `translate ()`.
 
-> **Note :** Les angles sont en radians, pas en degrés. Pour convertir en degrés, nous utilisons : `radians = (Math.PI/180)*degrees`.
+> [!NOTE]
+> Les angles sont en radians, pas en degrés. Pour convertir en degrés, nous utilisons : `radians = (Math.PI/180)*degrees`.
 
 ```js
 function draw() {

--- a/files/fr/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/fr/web/api/canvas_api/tutorial/using_images/index.md
@@ -114,7 +114,8 @@ Une fois la référence à l'objet image source obtenue, on peut utiliser la mé
 - [`drawImage(image, x, y)`](/fr/docs/Web/API/CanvasRenderingContext2D/drawImage)
   - : Dessine le `CanvasImageSource` spécifié par le paramètre `image` aux coordonnées (`x`, `y`).
 
-> **Note :** Les images SVG doivent spécifier une largeur et une hauteur dans l'élément racine `<svg>`.
+> [!NOTE]
+> Les images SVG doivent spécifier une largeur et une hauteur dans l'élément racine `<svg>`.
 
 ### Exemple : un graphique linéaire simple
 
@@ -161,7 +162,8 @@ La seconde variante de la méthode `drawImage()` ajoute deux paramètres supplé
 
 Dans cet exemple, nous utiliserons une image comme fond d'écran en la répétant plusieurs fois sur le canevas. Cette opération est réalisée simplement en faisant une boucle qui place l'image redimensionnée à différentes positions. Dans le code ci-dessous, la première boucle `for` s'occupe des lignes alors que la seconde gère les colonnes. L'image est redimensionnée à un tiers de sa taille originale, ce qui fait 50×38 pixels.
 
-> **Note :** Les images peuvent devenir floues lorsqu'elles sont agrandies ou granuleuses si elles sont réduites. Il vaut mieux ne pas redimensionner une image contenant du texte devant rester lisible.
+> [!NOTE]
+> Les images peuvent devenir floues lorsqu'elles sont agrandies ou granuleuses si elles sont réduites. Il vaut mieux ne pas redimensionner une image contenant du texte devant rester lisible.
 
 ```html hidden
 <html>

--- a/files/fr/web/api/canvasrenderingcontext2d/linejoin/index.md
+++ b/files/fr/web/api/canvasrenderingcontext2d/linejoin/index.md
@@ -9,7 +9,8 @@ La propriété **`CanvasRenderingContext2D.lineJoin`** de l'API Canvas 2D déter
 
 Cette propriété n'a aucun effet quand deux segments connectés ont la même direction, car aucune zone de jonction ne sera ajoutée dans ce cas. Les segments dégénérés d'une longueur de zéro (c'est à dire avec les extrémités à la même position) seront ignorés.
 
-> **Note :** Les lignes peuvent être dessinées aves les méthodes {{domxref("CanvasRenderingContext2D.stroke()", "stroke()")}}, {{domxref("CanvasRenderingContext2D.strokeRect()", "strokeRect()")}} et {{domxref("CanvasRenderingContext2D.strokeText()", "strokeText()")}}.
+> [!NOTE]
+> Les lignes peuvent être dessinées aves les méthodes {{domxref("CanvasRenderingContext2D.stroke()", "stroke()")}}, {{domxref("CanvasRenderingContext2D.strokeRect()", "strokeRect()")}} et {{domxref("CanvasRenderingContext2D.strokeText()", "strokeText()")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/api/canvasrenderingcontext2d/setlinedash/index.md
+++ b/files/fr/web/api/canvasrenderingcontext2d/setlinedash/index.md
@@ -7,7 +7,8 @@ slug: Web/API/CanvasRenderingContext2D/setLineDash
 
 La méthode **`setLineDash()`** de l'interface Canvas 2D API's {{domxref("CanvasRenderingContext2D")}} définit le modèle à utiliser pour les pointillés lors du dessin de la ligne, en utilisant un tableau de valeurs qui spécifie les longueurs des alternances entre pleins et creux.
 
-> **Note :** Pour renvoyer une ligne pleine, configurez la liste pour les pointillés avec un tableau vide.
+> [!NOTE]
+> Pour renvoyer une ligne pleine, configurez la liste pour les pointillés avec un tableau vide.
 
 ## Syntaxe
 

--- a/files/fr/web/api/clipboard/index.md
+++ b/files/fr/web/api/clipboard/index.md
@@ -5,7 +5,8 @@ slug: Web/API/Clipboard
 
 {{APIRef("Clipboard API")}}
 
-> **Note :** Le **presse-papiers** est un tampon de données utilisé pour le stockage ou le transfert à court terme de données, éventuellement entre documents ou applications. Il est généralement mis en œuvre sous la forme d'une [mémoire tampon](https://fr.wikipedia.org/wiki/Mémoire_tampon) temporaire, parfois appelée «&nbsp;tampon de collage&nbsp;», qui peut être accédé par la plupart ou tous les programmes de l'environnement via des [interfaces de programmation](https://fr.wikipedia.org/wiki/Interface_de_programmation) définies.
+> [!NOTE]
+> Le **presse-papiers** est un tampon de données utilisé pour le stockage ou le transfert à court terme de données, éventuellement entre documents ou applications. Il est généralement mis en œuvre sous la forme d'une [mémoire tampon](https://fr.wikipedia.org/wiki/Mémoire_tampon) temporaire, parfois appelée «&nbsp;tampon de collage&nbsp;», qui peut être accédé par la plupart ou tous les programmes de l'environnement via des [interfaces de programmation](https://fr.wikipedia.org/wiki/Interface_de_programmation) définies.
 >
 > Une application typique accède aux fonctionnalités du presse-papiers en associant des [entrées utilisateur](https://fr.wikipedia.org/wiki/Entrées-sorties) telles que des [raccourcis clavier](https://fr.wikipedia.org/wiki/Raccourci_clavier), des éléments de [menus](<https://fr.wikipedia.org/wiki/Menu_(informatique)>), etc. à ces interfaces.
 
@@ -15,7 +16,8 @@ Le presse-papiers du système est exposé via la propriété globale {{domxref("
 
 Les appels aux méthodes de l'objet `Clipboard` échoueront si l'utilisateur ou l'utilisatrice n'a pas accordé les permissions requises en utilisant l'[API permissions](/fr/docs/Web/API/Permissions_API), et la permission `"clipboard-read"` ou `"clipboard-write"` selon le besoin.
 
-> **Note :** En réalité, actuellement, les prérequis des navigateurs pour accéder au presse-papiers varient significativement. Veuillez consulter la section [Disponibilité du presse-papiers](#disponibilité_du_presse-papiers) pour plus de détails.
+> [!NOTE]
+> En réalité, actuellement, les prérequis des navigateurs pour accéder au presse-papiers varient significativement. Veuillez consulter la section [Disponibilité du presse-papiers](#disponibilité_du_presse-papiers) pour plus de détails.
 
 Toutes les méthodes de l'API clipboard fonctionnent de manière asynchrone&nbsp;; elles renvoient une {{jsxref("Promise")}} qui est résolue une fois que l'accès au presse-papiers a réussi. La promesse est rejetée si l'accès au presse-papiers est refusé.
 

--- a/files/fr/web/api/clipboard/write/index.md
+++ b/files/fr/web/api/clipboard/write/index.md
@@ -9,7 +9,8 @@ La methode **`write()`** de {{domxref("Clipboard")}} écrie des données arbitra
 
 Avant de pouvoir écrire dans le presse-papier, vous devez utiliser [Permissions API](/fr/docs/Web/API/Permissions_API) pour avoir l'autorisation `"clipboard-write"`.
 
-> **Note :** Les API Presse-papiers (<i lang="en">clipboard</i>) asynchrones sont toujours en cours d'implémentation. Consultez le [tableau de compatibilité](#compatibilité_des_navigateurs) et la section [Disponibilité du presse-papiers](/fr/docs/Web/API/clipboard#disponibilité_du_presse-papiers) sur la page [`Clipboard`](/fr/docs/Web/API/clipboard) pour plus d'informations.
+> [!NOTE]
+> Les API Presse-papiers (<i lang="en">clipboard</i>) asynchrones sont toujours en cours d'implémentation. Consultez le [tableau de compatibilité](#compatibilité_des_navigateurs) et la section [Disponibilité du presse-papiers](/fr/docs/Web/API/clipboard#disponibilité_du_presse-papiers) sur la page [`Clipboard`](/fr/docs/Web/API/clipboard) pour plus d'informations.
 
 ## Syntaxe
 

--- a/files/fr/web/api/clipboard/writetext/index.md
+++ b/files/fr/web/api/clipboard/writetext/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Clipboard/writeText
 
 La méthode **`writeText()`** de l'interface {{domxref("Clipboard")}} écrit le texte spécifié dans le presse-papiers du système.
 
-> **Note :** La spécification requiert que l'[API Permissions](/fr/docs/Web/API/Permissions_API) soit utilisée pour obtenir la permission `"clipboardWrite"` avant d'écrire dans le presse-papiers. Cependant, les prérequis exacts varient de navigateur en navigateur, car c'est une API récente. Consultez la [table de compatibilité](#compatibilité_des_navigateurs) et la section [Disponibilité du presse-papiers](/fr/docs/Web/API/clipboard#disponibilité_du_presse-papiers) sur la page [`Clipboard`](/fr/docs/Web/API/clipboard) pour plus de détails.
+> [!NOTE]
+> La spécification requiert que l'[API Permissions](/fr/docs/Web/API/Permissions_API) soit utilisée pour obtenir la permission `"clipboardWrite"` avant d'écrire dans le presse-papiers. Cependant, les prérequis exacts varient de navigateur en navigateur, car c'est une API récente. Consultez la [table de compatibilité](#compatibilité_des_navigateurs) et la section [Disponibilité du presse-papiers](/fr/docs/Web/API/clipboard#disponibilité_du_presse-papiers) sur la page [`Clipboard`](/fr/docs/Web/API/clipboard) pour plus de détails.
 
 ## Syntaxe
 

--- a/files/fr/web/api/clipboard_api/index.md
+++ b/files/fr/web/api/clipboard_api/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Clipboard_API
 
 L'**API Clipboard** (en français&nbsp;: API Presse-papiers) fournit la possibilité de répondre aux commandes du presse-papiers (couper, copier et coller) ainsi que de lire et écrire sur le presse-papiers système de façon asynchrone. L'accès aux contenus du presse-papiers est protégé par l'[API Permissions](/fr/docs/Web/API/Permissions_API)&nbsp;: la permission `clipboard-write` est donnée automatiquement aux pages lorsqu'elles sont dans l'onglet actif. La permission `clipboard-read` doit quant à elle être demandée, ce que vous pouvez faire en tentant de lire les données du presse-papiers.
 
-> **Note :** Cette API _n'est pas disponible_ dans les [Web Workers](/fr/docs/Web/API/Web_Workers_API) (elle n'est pas exposée via {{domxref("WorkerNavigator")}}).
+> [!NOTE]
+> Cette API _n'est pas disponible_ dans les [Web Workers](/fr/docs/Web/API/Web_Workers_API) (elle n'est pas exposée via {{domxref("WorkerNavigator")}}).
 
 Cette API est conçue pour remplacer l'accès au presse-papiers précédemment proposé via {{domxref("document.execCommand()")}}.
 

--- a/files/fr/web/api/console/index.md
+++ b/files/fr/web/api/console/index.md
@@ -19,7 +19,8 @@ Dans cette page, nous verrons [les méthodes](#méthodes) disponibles sur l'obje
 
 {{AvailableInWorkers}}
 
-> **Note :** Certains IDE et éditeurs peuvent implémenter l'API Console différemment. Cela se traduit par un comportement différent ou une absence de certaines fonctionnalités de l'API. Par exemple, les méthodes liées aux chronomètres pourraient ne pas afficher les durées en sortie. En cas de doute, utilisez la console des outils de développement de votre navigateur pour observer le fonctionnement décrit dans cette documentation.
+> [!NOTE]
+> Certains IDE et éditeurs peuvent implémenter l'API Console différemment. Cela se traduit par un comportement différent ou une absence de certaines fonctionnalités de l'API. Par exemple, les méthodes liées aux chronomètres pourraient ne pas afficher les durées en sortie. En cas de doute, utilisez la console des outils de développement de votre navigateur pour observer le fonctionnement décrit dans cette documentation.
 
 ## Méthodes statiques
 
@@ -127,7 +128,8 @@ Lorsqu'on passe une chaîne de caractères à l'une des méthodes d'affichage de
 - `%f`
   - : Permettra d'afficher une valeur décimale. Le formatage numérique est pris en charge et on pourra par exemple écrire `console.log("Toto %.2f", 1.1)` pour avoir deux chiffres décimaux&nbsp;: `Toto 1.10`.
 
-> **Attention :** Ce formatage pour la précision numérique ne fonctionne pas dans Chrome.
+> [!WARNING]
+> Ce formatage pour la précision numérique ne fonctionne pas dans Chrome.
 
 Chaque chaîne de substitution est associé au paramètre correspondant dans la liste (la première chaîne avec le deuxième paramètre, la deuxième chaîne avec le troisième paramètre, et ainsi de suite).
 
@@ -194,7 +196,8 @@ Les propriétés qui peuvent être utilisées avec cette syntaxe sont (au moins 
 - [`word-spacing`](/fr/docs/Web/CSS/word-spacing) et [`word-break`](/fr/docs/Web/CSS/word-break)
 - [`writing-mode`](/fr/docs/Web/CSS/writing-mode)
 
-> **Note :** Le message de la console se comporte par défaut comme un élément en ligne. Pour observer des effets avec `padding`, `margin` ou autre, il faut modifier son affichage, par exemple avec `display: inline-block`.
+> [!NOTE]
+> Le message de la console se comporte par défaut comme un élément en ligne. Pour observer des effets avec `padding`, `margin` ou autre, il faut modifier son affichage, par exemple avec `display: inline-block`.
 
 ### Utiliser des groupes dans la console
 
@@ -266,7 +269,8 @@ Avec le fragment de code précédent, on aura la trace suivante dans la console&
 
 {{Compat}}
 
-> **Note :** Dans Firefox, si une page définit un objet `console`, cet objet surchargera l'objet natif exposé par Firefox.
+> [!NOTE]
+> Dans Firefox, si une page définit un objet `console`, cet objet surchargera l'objet natif exposé par Firefox.
 
 ## Voir aussi
 

--- a/files/fr/web/api/console/table_static/index.md
+++ b/files/fr/web/api/console/table_static/index.md
@@ -15,7 +15,8 @@ La fonction affiche `data` sous la forme d'un tableau. Chaque élément du table
 
 La première colonne dans le tableau sera intitulée `(index)`. Si `data` est un tableau ([`Array`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Array)), alors les valeurs de cette colonne seront les indices du tableau JavaScript. Si `data` est un objet, ce seront les noms des propriétés qui seront affichés dans cette colonne `(index)`.
 
-> **Note :** Dans Firefox, `console.table()` limite l'affichage aux 1000 premières lignes.
+> [!NOTE]
+> Dans Firefox, `console.table()` limite l'affichage aux 1000 premières lignes.
 
 {{AvailableInWorkers}}
 

--- a/files/fr/web/api/console/trace_static/index.md
+++ b/files/fr/web/api/console/trace_static/index.md
@@ -11,7 +11,8 @@ La méthode **`console.trace()`** permet d'afficher la trace de la pile d'appels
 
 {{AvailableInWorkers}}
 
-> **Note :** Dans certains navigateurs, `console.trace()` pourra également afficher la séquence des appels et des évènements asynchrones qui ont mené à l'appel courant de `console.trace()` et qui ne sont pas nécessairement dans la pile d'appels, pour aider à déterminer l'origine de la boucle d'évaluation courante.
+> [!NOTE]
+> Dans certains navigateurs, `console.trace()` pourra également afficher la séquence des appels et des évènements asynchrones qui ont mené à l'appel courant de `console.trace()` et qui ne sont pas nécessairement dans la pile d'appels, pour aider à déterminer l'origine de la boucle d'évaluation courante.
 
 Voir [la section sur le traçage des piles d'appels dans la documentation de `console`](/fr/docs/Web/API/console#traces_de_piles_dappels) pour plus de détails et d'exemples.
 

--- a/files/fr/web/api/console/warn_static/index.md
+++ b/files/fr/web/api/console/warn_static/index.md
@@ -11,7 +11,8 @@ La méthode **`console.warn()`** affiche un message d'avertissement dans la cons
 
 {{AvailableInWorkers}}
 
-> **Note :** Dans Chrome et Firefox, les avertissements sont indiqués par un triangle avec un point d'exclamation.
+> [!NOTE]
+> Dans Chrome et Firefox, les avertissements sont indiqués par un triangle avec un point d'exclamation.
 
 ## Syntaxe
 

--- a/files/fr/web/api/credential_management_api/index.md
+++ b/files/fr/web/api/credential_management_api/index.md
@@ -13,7 +13,8 @@ Cette API permet aux sites web d'interagir avec le système de mots de passe de 
 
 Ainsi, sans cette API, un agent utilisateur pourra rencontrer certaines difficultés à gérer des fournisseurs d'identité fédérée ou d'autres mécanismes de connexion.
 
-> **Note :** Cette API est restreinte aux contextes de plus haut niveau. Les appels à `get()` et `store()` depuis une {{HTMLElement("iframe")}} seront résolus sans aucun effet.
+> [!NOTE]
+> Cette API est restreinte aux contextes de plus haut niveau. Les appels à `get()` et `store()` depuis une {{HTMLElement("iframe")}} seront résolus sans aucun effet.
 
 ### Informations d'authentification partagées entre les sous-domaines
 

--- a/files/fr/web/api/credentialscontainer/create/index.md
+++ b/files/fr/web/api/credentialscontainer/create/index.md
@@ -10,7 +10,8 @@ La méthode **`create()`**, rattachée à l'interface {{domxref("CredentialsCont
 - une nouvelle instance {{domxref("Credential")}} construite avec les options fournies
 - {{jsxref("null")}} si aucun objet `Credential` ne peut être créé.
 
-> **Note :** Cette méthode ne peut être utilisé que pour les contextes de navigation les plus hauts. Les appels lancés depuis une {{HTMLElement("iframe")}} résoudront la promesse sans aucun effet.
+> [!NOTE]
+> Cette méthode ne peut être utilisé que pour les contextes de navigation les plus hauts. Les appels lancés depuis une {{HTMLElement("iframe")}} résoudront la promesse sans aucun effet.
 
 ## Syntaxe
 

--- a/files/fr/web/api/credentialscontainer/get/index.md
+++ b/files/fr/web/api/credentialscontainer/get/index.md
@@ -11,7 +11,8 @@ Cette méthode collecte l'ensemble des informations d'authentification stockées
 
 Cette méthode récupère les informations d'authentification en appelant la méthode `CollectFromCredentialStore` pour chaque type d'authentification permis par l'argument **`options`**. Ainsi, si la propriété `options.password` existe dans l'argument passé, {{domxref("PasswordCredential")}}`.[[CollectFromCredentialStore]]` sera appelée.
 
-> **Note :** Cette méthode ne peut être utilisé que pour les contextes de navigation les plus hauts. Les appels lancés depuis une {{HTMLElement("iframe")}} résoudront la promesse sans aucun effet.
+> [!NOTE]
+> Cette méthode ne peut être utilisé que pour les contextes de navigation les plus hauts. Les appels lancés depuis une {{HTMLElement("iframe")}} résoudront la promesse sans aucun effet.
 
 ## Syntaxe
 

--- a/files/fr/web/api/credentialscontainer/store/index.md
+++ b/files/fr/web/api/credentialscontainer/store/index.md
@@ -7,7 +7,8 @@ slug: Web/API/CredentialsContainer/store
 
 La méthode **`store()`**, rattachée à l'interface {{domxref("CredentialsContainer")}}, enregistre un ensemble d'informations d'authentification pour l'utilisateur dans une instance {{domxref("Credential")}} et renvoie cette instance au travers d'une promesse ({{domxref("Promise")}}).
 
-> **Note :** Cette méthode ne peut être utilisé que pour les contextes de navigation les plus hauts. Les appels lancés depuis une {{HTMLElement("iframe")}} résoudront la promesse sans aucun effet.
+> [!NOTE]
+> Cette méthode ne peut être utilisé que pour les contextes de navigation les plus hauts. Les appels lancés depuis une {{HTMLElement("iframe")}} résoudront la promesse sans aucun effet.
 
 ## Syntaxe
 

--- a/files/fr/web/api/css_font_loading_api/index.md
+++ b/files/fr/web/api/css_font_loading_api/index.md
@@ -7,7 +7,8 @@ slug: Web/API/CSS_Font_Loading_API
 
 L'API CSS Font Loading API fournit des évènements et interfaces pour le chargement dynamique des ressources associées aux polices.
 
-> **Note :** cette fonctionnalité est disponible dans [l'API Web Workers](/fr/docs/Web/API/Web_Workers_API) (`self.fonts` donne accès à {{domxref('FontFaceSet')}}).
+> [!NOTE]
+> Cette fonctionnalité est disponible dans [l'API Web Workers](/fr/docs/Web/API/Web_Workers_API) (`self.fonts` donne accès à {{domxref('FontFaceSet')}}).
 
 ## Interfaces
 

--- a/files/fr/web/api/css_object_model/managing_screen_orientation/index.md
+++ b/files/fr/web/api/css_object_model/managing_screen_orientation/index.md
@@ -116,11 +116,13 @@ Et voici le résultat:
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
 | {{ EmbedLiveSample("Ajuster_la_mise_en_page_selon_l'orientation", 180, 350) }} | {{ EmbedLiveSample("Ajuster_la_mise_en_page_selon_l'orientation", 350, 180) }} |
 
-> **Note :** La media query orientation s'applique en vérité selon l'orientation de la fenêtre du navigateur (ou iframe) et non l'orientation de l'appareil.
+> [!NOTE]
+> La media query orientation s'applique en vérité selon l'orientation de la fenêtre du navigateur (ou iframe) et non l'orientation de l'appareil.
 
 ## Verrouiller l'orientation de l'écran
 
-> **Attention :** Cette API est expérimentale et est actuellement disponible sur [Firefox OS](/fr/docs/Mozilla/Firefox_OS) et [Firefox pour Android](/fr/docs/Mozilla/Firefox_for_Android) avec le préfixe `moz`, et sur Internet Explorer pour Windows 8.1 et plus avec le préfixe `ms`.
+> [!WARNING]
+> Cette API est expérimentale et est actuellement disponible sur [Firefox OS](/fr/docs/Mozilla/Firefox_OS) et [Firefox pour Android](/fr/docs/Mozilla/Firefox_for_Android) avec le préfixe `moz`, et sur Internet Explorer pour Windows 8.1 et plus avec le préfixe `ms`.
 
 Certains appareils (principalement les appareils mobiles) peuvent changer dynamiquement d'orientation d'écran selon leur propre orientation, garantissant que l'utilisateur sera toujours capable de lire ce qu'il y a sur l'écran. Bien que ce comportement soit parfaitement adapté au contenu texte, certains contenus peuvent être affectés négativement par ce changement. Par exemple, les jeux basés sur l'orientation de l'appareil être gachés par un tel changement.
 
@@ -146,7 +148,8 @@ Toute application web peut verrouiller l'écran dans une orientation pour répon
 screen.lockOrientation("landscape");
 ```
 
-> **Note :** Un verrouillage d'écran est dépendant de l'application web. Si une a application A est verrouillée à `landscape` et l'application B est verrouillée à `portrait`, passer de l'application A à B ou à A ne va pas déclencher un événement [`orientationchange`](/fr/docs/Web/API/Window/orientationchange_event) parce que les deux applications gardent l'orientation qu'elles avaient.
+> [!NOTE]
+> Un verrouillage d'écran est dépendant de l'application web. Si une a application A est verrouillée à `landscape` et l'application B est verrouillée à `portrait`, passer de l'application A à B ou à A ne va pas déclencher un événement [`orientationchange`](/fr/docs/Web/API/Window/orientationchange_event) parce que les deux applications gardent l'orientation qu'elles avaient.
 >
 > En revanche, verrouiller l'orientation peut décléncher l'événement [`orientationchange`](/fr/docs/Web/API/Window/orientationchange_event) si l'orientation a dû être changée pour satisfaire aux critères du verrouillage.
 

--- a/files/fr/web/api/customelementregistry/define/index.md
+++ b/files/fr/web/api/customelementregistry/define/index.md
@@ -50,7 +50,8 @@ Aucune ([`undefined`](/fr/docs/Web/JavaScript/Reference/Global_Objects/undefined
 - [`TypeError`](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypeError)
   - : Exception levée si le deuxième argument passé n'est pas un constructeur.
 
-> **Note :** Si vous rencontrez l'exception `NotSupportedError` lors d'un appel à `define()`, cela ne signifie pas nécessairement que c'est cette méthode qui échoue. Il s'agit plutôt généralement d'un problème lié à [`Element.attachShadow()`](/fr/docs/Web/API/Element/attachShadow).
+> [!NOTE]
+> Si vous rencontrez l'exception `NotSupportedError` lors d'un appel à `define()`, cela ne signifie pas nécessairement que c'est cette méthode qui échoue. Il s'agit plutôt généralement d'un problème lié à [`Element.attachShadow()`](/fr/docs/Web/API/Element/attachShadow).
 
 ## Exemples
 
@@ -145,7 +146,8 @@ customElements.define("popup-info", PopUpInfo);
   data-text="Le cryptogramme visuel de votre carte permet une meilleure sécurité. Il s'agit d'une séquence de 3 ou 4 chiffres au dos de votre carte."></popup-info>
 ```
 
-> **Note :** Les constructeurs pour les éléments personnalisés autonomes doivent étendre [`HTMLElement`](/fr/docs/Web/API/HTMLElement).
+> [!NOTE]
+> Les constructeurs pour les éléments personnalisés autonomes doivent étendre [`HTMLElement`](/fr/docs/Web/API/HTMLElement).
 
 ### Élément personnalisé natif
 

--- a/files/fr/web/api/customevent/initcustomevent/index.md
+++ b/files/fr/web/api/customevent/initcustomevent/index.md
@@ -9,7 +9,8 @@ La méthode **`CustomEvent.initCustomEvent()`** initialise un objet `CustomEvent
 
 Les évènements initialisés par ce moyen doivent être créés avec la méthode {{domxref("Document.createEvent()")}}. Cette méthode doit être appelée pour définir l'évènement avant son envoi en utilisant {{domxref("EventTarget.dispatchEvent()") }}. Une fois l'évènement envoyé, la méthode ne fait rien.
 
-> **Attention :** N'utilisez plus cette méthode car elle est dépréciée.
+> [!WARNING]
+> N'utilisez plus cette méthode car elle est dépréciée.
 >
 > À la place, utilisez les constructeurs d'évènements spécifiques comme {{domxref("CustomEvent.CustomEvent", "CustomEvent()")}}. La page [Création et déclenchement d'évènements](/fr/docs/Web/Guide/DOM/Events/Creating_and_triggering_events) donne plus d'informations sur la façon de les utiliser.
 

--- a/files/fr/web/api/datatransfer/cleardata/index.md
+++ b/files/fr/web/api/datatransfer/cleardata/index.md
@@ -11,7 +11,8 @@ Si cette méthode est appelée sans argument ou que le format est une chaîne de
 
 Cette méthode _ne retire pas_ les fichiers de l'opération de glisser-déposer et il est donc possible d'avoir un élément restant avec le type `Files` dans la liste [`DataTransfer.types`](/fr/docs/Web/API/DataTransfer/types) si des fichiers font partie du glisser-déposer.
 
-> **Note :** Cette méthode peut uniquement être utilisée dans le gestionnaire d'évènement pour [`dragstart`](/fr/docs/Web/API/Document/dragstart_event), car c'est le seul moment où le magasin de données pour l'opération de glisser-déposer est accessible en écriture.
+> [!NOTE]
+> Cette méthode peut uniquement être utilisée dans le gestionnaire d'évènement pour [`dragstart`](/fr/docs/Web/API/Document/dragstart_event), car c'est le seul moment où le magasin de données pour l'opération de glisser-déposer est accessible en écriture.
 
 ## Syntaxe
 

--- a/files/fr/web/api/datatransfer/index.md
+++ b/files/fr/web/api/datatransfer/index.md
@@ -239,7 +239,8 @@ Contient une liste des types de format des données stockées pour le premier é
 
 L'état du curseur au cours d'un glisser. Cette propriété est surtout utilisée pour contrôler le curseur au cours d'un glisser d'onglet.
 
-> **Note :** Cette méthode n'est actuellement implémentée que sur Windows.
+> [!NOTE]
+> Cette méthode n'est actuellement implémentée que sur Windows.
 
 #### Valeurs possibles
 
@@ -248,25 +249,29 @@ L'état du curseur au cours d'un glisser. Cette propriété est surtout utilisé
 - `default`
   - : Utilise le comportement par défaut de Gecko, qui consiste à utiliser une flèche pour curseur au cours d'un glisser.
 
-> **Note :** Si vous spécifiez une valeur autre que "default", "auto" est supposé.
+> [!NOTE]
+> Si vous spécifiez une valeur autre que "default", "auto" est supposé.
 
 ### mozItemCount
 
 Le nombre d'éléments glissés.
 
-> **Note :** Cette propriété est spécifique a Gecko.
+> [!NOTE]
+> Cette propriété est spécifique a Gecko.
 
 ### mozSourceNode
 
 le {{ domxref("Node") }} au dessus duquel le curseur de la souris se trouvait lorsque le bouton a été pressé pour initialiser le glisser. Cette valeur est nulle pour un glisser externe, ou si l'appelant ne peut pas accéder au nœud.
 
-> **Note :** Cette propriété est spécifique a Gecko.
+> [!NOTE]
+> Cette propriété est spécifique a Gecko.
 
 ### mozUserCancelled
 
 Cette propriété s'applique uniquement à l'événement `dragend`, et est positionnée à `true` si l'utilisateur a annulé le glisser en appuyant sur la touche échappe. Elle est positionnée à `false` dans les autres cas, y compris si le glisser a échoué pour toute autre raison, par exemple en raison d'un déposer sur un emplacement non valide. Cette propriété n'est pas encore implémenté sous Linux.
 
-> **Note :** Cette propriété est spécifique a Gecko.
+> [!NOTE]
+> Cette propriété est spécifique a Gecko.
 
 ## Methods
 
@@ -368,7 +373,8 @@ Si le dernier format de l'élément est supprimé, l'élément entier est retir�
 
 Si la liste `format` est vide, alors les données associées à tous les formats sont supprimées. Si le format n'est pas trouvé, alors cette méthode n'a aucun effet.
 
-> **Note :** Cette méthode est spécifique à Gecko.
+> [!NOTE]
+> Cette méthode est spécifique à Gecko.
 
 ```
 void mozClearDataAt(
@@ -388,7 +394,8 @@ void mozClearDataAt(
 
 Récupère les données associées au format donné pour un élément à l'index spécifié, ou null si elle n'existe pas. L'indice devrait être compris entre zéro et le nombre d'éléments moins un.
 
-> **Note :** Cette méthode est spécifique à Gecko.
+> [!NOTE]
+> Cette méthode est spécifique à Gecko.
 
 ```
 nsIVariant mozGetDataAt(
@@ -412,7 +419,8 @@ Les données doivent être ajoutées par ordre de préférence, avec le format l
 
 La donnée doit être une chaîne, ou un type primitif booléen, ou un type numérique (qui sera converti en une chaîne), ou une [nsISupports](/fr/docs/XPCOM_Interface_Reference/nsISupports).
 
-> **Note :** Cette méthode est spécifique à Gecko.
+> [!NOTE]
+> Cette méthode est spécifique à Gecko.
 
 ```
 void mozSetDataAt(
@@ -435,7 +443,8 @@ void mozSetDataAt(
 
 Contient une liste des types de format des données qui sont stockées pour un élément à l'index spécifié. Si l'index n'est pas dans compris entre 0 et le nombre d'éléments moins un, une liste de chaîne vide est retournée.
 
-> **Note :** Cette méthode est spécifique à Gecko.
+> [!NOTE]
+> Cette méthode est spécifique à Gecko.
 
 ```
 nsIVariant mozTypesAt(

--- a/files/fr/web/api/dedicatedworkerglobalscope/close/index.md
+++ b/files/fr/web/api/dedicatedworkerglobalscope/close/index.md
@@ -23,7 +23,8 @@ close();
 
 `close()` et `self.close()` sont effectivement équivalents — les deux représentent une instruction `close()` qui est appelée de l'intérieur de la portée interne du worker.
 
-> **Note :** Il y a une autre façon d'arrêter le worker depuis le fil principal : la méthode {{domxref("Worker.terminate")}}.
+> [!NOTE]
+> Il y a une autre façon d'arrêter le worker depuis le fil principal : la méthode {{domxref("Worker.terminate")}}.
 
 ## Spécifications
 

--- a/files/fr/web/api/device_orientation_events/detecting_device_orientation/index.md
+++ b/files/fr/web/api/device_orientation_events/detecting_device_orientation/index.md
@@ -46,7 +46,8 @@ function handleOrientation(event) {
 }
 ```
 
-> **Note :** La bibliothèque tierce [parallax.js](https://github.com/wagerfield/parallax) est une prothèse d'émulation (<i lang="en">polyfill</i>) pour normaliser les données de l'accéléromètre et du gyroscope pour les appareils mobiles. Elle peut s'avérer utile pour gommer certaines différences de prise en charge des appareils.
+> [!NOTE]
+> La bibliothèque tierce [parallax.js](https://github.com/wagerfield/parallax) est une prothèse d'émulation (<i lang="en">polyfill</i>) pour normaliser les données de l'accéléromètre et du gyroscope pour les appareils mobiles. Elle peut s'avérer utile pour gommer certaines différences de prise en charge des appareils.
 
 ### Explication des valeurs relatives à l'orientation
 

--- a/files/fr/web/api/device_orientation_events/index.md
+++ b/files/fr/web/api/device_orientation_events/index.md
@@ -23,7 +23,8 @@ Par exemple, on pourra gérer les évènements liés à l'orientation de l'appar
 
 - Pour la reconnaissance de certains gestes. Par exemple, on pourra identifier que l'appareil est secoué et déclencher une action en conséquence, comme la réinitialisation d'un champ.
 
-> **Note :** Cette API est bien prise en charge par les navigateurs mobiles. Pour les navigateurs de bureaux, il pourra y avoir des limitations liées aux capacités matérielles de ces appareils. Toutefois, ces contraintes sont rarement un problème, car l'API repose principalement sur une utilisation avec des appareils dotés de capteurs adéquats.
+> [!NOTE]
+> Cette API est bien prise en charge par les navigateurs mobiles. Pour les navigateurs de bureaux, il pourra y avoir des limitations liées aux capacités matérielles de ces appareils. Toutefois, ces contraintes sont rarement un problème, car l'API repose principalement sur une utilisation avec des appareils dotés de capteurs adéquats.
 
 ## Interfaces
 

--- a/files/fr/web/api/device_orientation_events/orientation_and_motion_data_explained/index.md
+++ b/files/fr/web/api/device_orientation_events/orientation_and_motion_data_explained/index.md
@@ -31,7 +31,8 @@ Le système de coordonnées de l'appareil a son origine située au centre de l'a
 - L'axe **y** se situe sur le plan de l'écran et est positif vers le haut et négatif vers le bas.
 - L'axe **z** est perpendiculaire à l'écran ou au clavier et va positivement lorsqu'on s'éloigne de l'écran.
 
-> **Note :** Sur un téléphone ou une tablette, l'orientation de l'appareil est toujours prise selon l'orientation standard de l'écran. Sur la plupart des appareils, il s'agit de l'orientation en portrait. Sur un ordinateur portable, l'orientation est relative au clavier. Si vous souhaitez détecter les changements d'orientation d'un appareil afin de les compenser, vous pouvez utiliser l'évènement [`change`](/fr/docs/Web/API/ScreenOrientation/change_event).
+> [!NOTE]
+> Sur un téléphone ou une tablette, l'orientation de l'appareil est toujours prise selon l'orientation standard de l'écran. Sur la plupart des appareils, il s'agit de l'orientation en portrait. Sur un ordinateur portable, l'orientation est relative au clavier. Si vous souhaitez détecter les changements d'orientation d'un appareil afin de les compenser, vous pouvez utiliser l'évènement [`change`](/fr/docs/Web/API/ScreenOrientation/change_event).
 
 ## À propos de la rotation
 

--- a/files/fr/web/api/devicemotionevent/index.md
+++ b/files/fr/web/api/devicemotionevent/index.md
@@ -9,7 +9,8 @@ slug: Web/API/DeviceMotionEvent
 
 `DeviceMotionEvent` fournit aux développeurs Web des informations sur la vitesse des changements de position et d'orientation de l'appareil.
 
-> **Attention :** Actuellement, Firefox et Chrome ne gèrent pas les coordonnées de la même manière. Faites attention à cela lorsque vous les utilisez.
+> [!WARNING]
+> Actuellement, Firefox et Chrome ne gèrent pas les coordonnées de la même manière. Faites attention à cela lorsque vous les utilisez.
 
 ## Constructeur
 

--- a/files/fr/web/api/devicemotionevent/rotationrate/index.md
+++ b/files/fr/web/api/devicemotionevent/rotationrate/index.md
@@ -7,7 +7,8 @@ slug: Web/API/DeviceMotionEvent/rotationRate
 
 La propriété **`rotationRate`** renvoie la vitesse de rotation de l'appareil autour de chacun de ses axes en degrés par seconde.
 
-> **Note :** Si le matériel n'est pas capable de fournir cette information, la propriété renvoie `null`.
+> [!NOTE]
+> Si le matériel n'est pas capable de fournir cette information, la propriété renvoie `null`.
 
 ## Syntaxe
 

--- a/files/fr/web/api/deviceorientationevent/index.md
+++ b/files/fr/web/api/deviceorientationevent/index.md
@@ -10,7 +10,7 @@ slug: Web/API/DeviceOrientationEvent
 L'évènement `DeviceOrientationEvent` met à la disposition du développeur des informations sur l'orientation de l'appareil visitant une page Web
 
 > [!WARNING]
-> à l'heure actuelle, Firefox et Chrome ne gèrent pas les cordonnées de la même façon. Tenez-en compte lors de l'utilisation de cette API.
+> À l'heure actuelle, Firefox et Chrome ne gèrent pas les cordonnées de la même façon. Tenez-en compte lors de l'utilisation de cette API.
 
 ## Propriétés
 

--- a/files/fr/web/api/deviceorientationevent/index.md
+++ b/files/fr/web/api/deviceorientationevent/index.md
@@ -9,7 +9,8 @@ slug: Web/API/DeviceOrientationEvent
 
 L'évènement `DeviceOrientationEvent` met à la disposition du développeur des informations sur l'orientation de l'appareil visitant une page Web
 
-> **Attention :** à l'heure actuelle, Firefox et Chrome ne gèrent pas les cordonnées de la même façon. Tenez-en compte lors de l'utilisation de cette API.
+> [!WARNING]
+> à l'heure actuelle, Firefox et Chrome ne gèrent pas les cordonnées de la même façon. Tenez-en compte lors de l'utilisation de cette API.
 
 ## Propriétés
 

--- a/files/fr/web/api/document/activeelement/index.md
+++ b/files/fr/web/api/document/activeelement/index.md
@@ -11,7 +11,8 @@ La plupart du temps, `activeElement` renverra un objet [`HTMLInputElement`](/fr/
 
 Généralement, une personne utilise la touche <kbd>Tabulation</kbd> pour déplacer le focus entre les éléments qui peuvent le recevoir et utilise la touche <kbd>Espace</kbd> pour activer l'élément (c'est-à-dire pour appuyer sur un bouton ou pour changer l'état d'un bouton radio). Les éléments qui peuvent recevoir le focus dépendent de la plateforme et de la configuration du navigateur. Ainsi, sur les systèmes macOS et par défaut, les éléments qui ne sont pas des champs de saisie texte ne peuvent pas recevoir le focus.
 
-> **Note :** Le focus (qui détermine l'élément qui recevra les informations saisies) n'est pas la même chose que la sélection (la partie actuellement surlignée dans le document). Pour accéder à la sélection courante, on pourra utiliser la méthode [`window.getSelection()`](/fr/docs/Web/API/Window/getSelection).
+> [!NOTE]
+> Le focus (qui détermine l'élément qui recevra les informations saisies) n'est pas la même chose que la sélection (la partie actuellement surlignée dans le document). Pour accéder à la sélection courante, on pourra utiliser la méthode [`window.getSelection()`](/fr/docs/Web/API/Window/getSelection).
 
 ## Valeur
 

--- a/files/fr/web/api/document/characterset/index.md
+++ b/files/fr/web/api/document/characterset/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Document/characterSet
 
 **`Document.characterSet`** propriété en lecture seule, renvoie l'encodage du document en cours. Un encodage décrit l'ensemble des caractères possibles et la façon de décoder les octets en ces caractères.
 
-> **Note :** La propriété `document.charset` et `document.inputEncoding` sont les alias de `document.characterSet`. Ne plus les utiliser.
+> [!NOTE]
+> La propriété `document.charset` et `document.inputEncoding` sont les alias de `document.characterSet`. Ne plus les utiliser.
 
 Les utilisateurs peuvent surcharger l'encodage indiqué pour le document (transmis par l'en-tête {{HTTPHeader("Content-Type")}} ou via le {{HTMLElement("meta")}} : `<meta charset="utf-8">`) grâce au menu <kbd>Affichage → Encodage du texte</kbd>. Cela peut notamment permettre de corriger le comportement d'un document dont l'encodage indiqué est incorrect.
 

--- a/files/fr/web/api/document/compatmode/index.md
+++ b/files/fr/web/api/document/compatmode/index.md
@@ -28,7 +28,8 @@ mode = document.compatMode;
 
 <!---->
 
-> **Note :** tous ces modes sont maintenant définis dans les normes, de sorte que les anciens «standards» et «presque standards» sont absurdes et ne sont plus utilisés dans les normes.
+> [!NOTE]
+> Tous ces modes sont maintenant définis dans les normes, de sorte que les anciens «standards» et «presque standards» sont absurdes et ne sont plus utilisés dans les normes.
 
 ## Exemple
 

--- a/files/fr/web/api/document/createattribute/index.md
+++ b/files/fr/web/api/document/createattribute/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Document/createAttribute
 
 La méthode **`Document.createAttribute()`** crée un nouveau nœud d'attribut et le renvoie. L'objet a créé un noeud implémentant l'interface {{domxref("Attr")}}. Le DOM n'impose pas le type d'attribut à ajouter à un élément particulier de cette manière.
 
-> **Note :** La chaîne de caractères donnée dans le paramètre est convertie en minuscules.
+> [!NOTE]
+> La chaîne de caractères donnée dans le paramètre est convertie en minuscules.
 
 ## Syntaxe
 

--- a/files/fr/web/api/document/createelement/index.md
+++ b/files/fr/web/api/document/createelement/index.md
@@ -93,7 +93,8 @@ let expandingList = document.createElement("ul", { is: "expanding-list" });
 
 Le nouvel élément donnera un attribut [`is`](/fr/docs/Web/HTML/Global_attributes/is) dont la valeur est la balise de nom de l'élément personnalisé.
 
-> **Note :** Pour la rétrocompatibilité avec les versions précédentes de la [spécification des éléments personnalisés](https://www.w3.org/TR/custom-elements/), quelques navigateurs permettent de passer une chaîne de caractères ici, à la place d'un objet, dont la valeur est la balise de nom de l'élément personnalisé.
+> [!NOTE]
+> Pour la rétrocompatibilité avec les versions précédentes de la [spécification des éléments personnalisés](https://www.w3.org/TR/custom-elements/), quelques navigateurs permettent de passer une chaîne de caractères ici, à la place d'un objet, dont la valeur est la balise de nom de l'élément personnalisé.
 
 ## Spécifications
 

--- a/files/fr/web/api/document/createelementns/index.md
+++ b/files/fr/web/api/document/createelementns/index.md
@@ -70,7 +70,8 @@ Cet exemple crée un nouvel élément \<div> dans l'espace de noms [XHTML](/fr/d
 </page>
 ```
 
-> **Note :** Cet exemple utilise un script interne, ce qui n'est pas recommandé dans les documents XHTML. Cet exemple particulier est en fait un document XUL intégrant du XHTML. Cependant, la recommandation s'applique quand même.
+> [!NOTE]
+> Cet exemple utilise un script interne, ce qui n'est pas recommandé dans les documents XHTML. Cet exemple particulier est en fait un document XUL intégrant du XHTML. Cependant, la recommandation s'applique quand même.
 
 ## Spécifications
 

--- a/files/fr/web/api/document/createevent/index.md
+++ b/files/fr/web/api/document/createevent/index.md
@@ -3,7 +3,8 @@ title: Document.createEvent()
 slug: Web/API/Document/createEvent
 ---
 
-> **Attention :** De nombreuses méthodes utilisées avec `createEvent`, tels que `initCustomEvent`, sont obsolètes. Utilisez le [constructeur d'évènement](/fr/docs/Web/API/CustomEvent) à la place.
+> [!WARNING]
+> De nombreuses méthodes utilisées avec `createEvent`, tels que `initCustomEvent`, sont obsolètes. Utilisez le [constructeur d'évènement](/fr/docs/Web/API/CustomEvent) à la place.
 
 {{ ApiRef("DOM") }}
 

--- a/files/fr/web/api/document/createnodeiterator/index.md
+++ b/files/fr/web/api/document/createnodeiterator/index.md
@@ -137,7 +137,8 @@ var nodeIterator = document.createNodeIterator(root, whatToShow, filter);
 - `filter` {{ optional_inline() }}
   - : Un objet implémentant l'interface {{ domxref("NodeFilter") }} ; sa méthode `acceptNode()` sera appelée pour chaque nœud du sous-arbre basé à la racine qui est accepté comme inclus par l'indicateur whatToShow pour déterminer s'il faut ou non l'inclure dans la liste des nœuds iterables (une simple fonction de rappel peut également être utilisée à la place). La méthode devrait retourner l'un des `NodeFilter.FILTER_ACCEPT`, `NodeFilter.FILTER_REJECT` ou `NodeFilter.FILTER_SKIP`. Voir l'[exemple](#exemple).
 
-> **Note :** Avant Gecko 12.0, cette méthode acceptait un quatrième paramètre facultatif (`entityReferenceExpansion`). Cela ne faisait pas partie de la spécification DOM4 et a donc été supprimé. Ce paramètre indiquait si les enfants des nœuds de référence d'entité étaient visibles ou non par l'itérateur. Puisque de tels noeuds n'ont jamais été créés dans les navigateurs, ce paramètre n'a eu aucun effet.
+> [!NOTE]
+> Avant Gecko 12.0, cette méthode acceptait un quatrième paramètre facultatif (`entityReferenceExpansion`). Cela ne faisait pas partie de la spécification DOM4 et a donc été supprimé. Ce paramètre indiquait si les enfants des nœuds de référence d'entité étaient visibles ou non par l'itérateur. Puisque de tels noeuds n'ont jamais été créés dans les navigateurs, ce paramètre n'a eu aucun effet.
 
 ## Exemple
 

--- a/files/fr/web/api/document/exitfullscreen/index.md
+++ b/files/fr/web/api/document/exitfullscreen/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Document/exitFullscreen
 
 La méthode **`Document.exitFullscreen()`** extrait le document du mode plein écran ; elle est utilisée pour inverser les effets d'un appel au mode plein écran réalisé avec la méthode {{domxref("Element.requestFullscreen()")}}.
 
-> **Note :** Si un autre élément était précédemment en mode plein écran lorsque l'élément en cours a été placé en mode plein écran, cet élément précédent reprend le mode plein écran. Une "pile" d'éléments en plein écran est maintenue par le navigateur à cette fin.
+> [!NOTE]
+> Si un autre élément était précédemment en mode plein écran lorsque l'élément en cours a été placé en mode plein écran, cet élément précédent reprend le mode plein écran. Une "pile" d'éléments en plein écran est maintenue par le navigateur à cette fin.
 
 ## Syntaxe
 

--- a/files/fr/web/api/document/forms/index.md
+++ b/files/fr/web/api/document/forms/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Document/forms
 
 La propriété `forms` de {{domxref("Document")}} retourne une collection ({{domxref("HTMLCollection")}}) des éléments {{HTMLElement("form")}} présents dans le document actuel.
 
-> **Note :** De même, vous pouvez accéder à une liste des éléments d'entrée utilisateur d'un formulaire à l'aide de la propriété {{domxref ("HTMLFormElement.elements")}}.
+> [!NOTE]
+> De même, vous pouvez accéder à une liste des éléments d'entrée utilisateur d'un formulaire à l'aide de la propriété {{domxref ("HTMLFormElement.elements")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/api/document/getelementsbytagnamens/index.md
+++ b/files/fr/web/api/document/getelementsbytagnamens/index.md
@@ -28,9 +28,11 @@ getElementsByTagNameNS(namespace, name)
 
 Une liste [`NodeList`](/fr/docs/Web/API/NodeList) dynamique (voir la note qui suit) qui contient les éléments trouvés, dans l'ordre selon lequel ils apparaissent dans l'arbre.
 
-> **Note :** Bien que la spécification W3C indique que la valeur renvoyée est de type `NodeList`, Firefox renvoie un objet [`HTMLCollection`](/fr/docs/Web/API/HTMLCollection). Opera renvoie un objet `NodeList` qui implémente une méthode `namedItem`, le rendant ainsi semblable à un objet `HTMLCollection`. À partir de janvier 2012, seuls les navigateurs WebKit renvoient un vrai objet `NodeList`. Voir [le bogue 14869](https://bugzilla.mozilla.org/show_bug.cgi?id=14869) pour plus de détails.
+> [!NOTE]
+> Bien que la spécification W3C indique que la valeur renvoyée est de type `NodeList`, Firefox renvoie un objet [`HTMLCollection`](/fr/docs/Web/API/HTMLCollection). Opera renvoie un objet `NodeList` qui implémente une méthode `namedItem`, le rendant ainsi semblable à un objet `HTMLCollection`. À partir de janvier 2012, seuls les navigateurs WebKit renvoient un vrai objet `NodeList`. Voir [le bogue 14869](https://bugzilla.mozilla.org/show_bug.cgi?id=14869) pour plus de détails.
 
-> **Note :** Les valeurs des paramètres de cette méthode sont sensibles à la casse (alors qu'elles ne l'étaient pas pour Firefox 3.5 et les versions antérieures, voir [les notes de version de Firefox 3.6](/fr/docs/Mozilla/Firefox/Releases/3.6#dom) et la note présente dans [le tableau de compatibilité de `Element.getElementsByTagNameNS()`](/fr/docs/Web/API/Element/getElementsByTagNameNS#compatibilité_des_navigateurs) pour plus de détails).
+> [!NOTE]
+> Les valeurs des paramètres de cette méthode sont sensibles à la casse (alors qu'elles ne l'étaient pas pour Firefox 3.5 et les versions antérieures, voir [les notes de version de Firefox 3.6](/fr/docs/Mozilla/Firefox/Releases/3.6#dom) et la note présente dans [le tableau de compatibilité de `Element.getElementsByTagNameNS()`](/fr/docs/Web/API/Element/getElementsByTagNameNS#compatibilité_des_navigateurs) pour plus de détails).
 
 ## Exemples
 

--- a/files/fr/web/api/document/hasfocus/index.md
+++ b/files/fr/web/api/document/hasfocus/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Document/hasFocus
 
 La méthode **`Document.hasFocus()`** retourne une valeur {{jsxref("Boolean")}} `true` _(vrai)_ indiquant si le document ou tout élément à l'intérieur du document a le focus. Cette méthode peut être utilisée pour déterminer si l'élément actif d'un document a le focus.
 
-> **Note :** Lors de la visualisation d'un document, un élément avec focus est toujours l'élément actif dans le document, mais un élément actif n'a pas nécessairement le focus. Par exemple, un élément actif dans une fenêtre contextuelle qui n'est pas le premier plan n'a pas de focus.
+> [!NOTE]
+> Lors de la visualisation d'un document, un élément avec focus est toujours l'élément actif dans le document, mais un élément actif n'a pas nécessairement le focus. Par exemple, un élément actif dans une fenêtre contextuelle qui n'est pas le premier plan n'a pas de focus.
 
 ## Syntaxe
 

--- a/files/fr/web/api/document/importnode/index.md
+++ b/files/fr/web/api/document/importnode/index.md
@@ -18,7 +18,8 @@ var node = document.importNode(externalNode, deep);
 - `deep`
   - : Une valeur booléenne qui indique s'il faut ou non importer la totalité de la sous-arborescence DOM provenant de `externalNode`. Si ce paramètre est `true` (_vrai_), alors `externalNode` et tous ses descendants sont copiés; si `false` _(faux)_, seul le nœud unique, `externalNode`, est importé.
 
-> **Note :** Dans la spécification DOM4, `deep` est répertorié en tant qu'argument facultatif. S'il est omis, la méthode agit comme si la valeur de `deep` était `true`, par défaut, elle utilisait le clonage profond comme comportement par défaut. Pour créer un clone superficiel, la profondeur doit être définie sur `false`.
+> [!NOTE]
+> Dans la spécification DOM4, `deep` est répertorié en tant qu'argument facultatif. S'il est omis, la méthode agit comme si la valeur de `deep` était `true`, par défaut, elle utilisait le clonage profond comme comportement par défaut. Pour créer un clone superficiel, la profondeur doit être définie sur `false`.
 >
 > Ce comportement a été modifié dans la dernière spécification, et s'il est omis, la méthode agira comme si la valeur de `deep` était `false`. Bien que ce soit toujours facultatif, vous devriez toujours fournir l'argument `deep` à la fois pour la compatibilité en amont et en aval. Avec Gecko 28.0, la console a averti les développeurs de ne pas omettre l'argument. À partir de Gecko 29.0, un clone superficiel est défini par défaut au lieu d'un clone profond.
 

--- a/files/fr/web/api/document/lastmodified/index.md
+++ b/files/fr/web/api/document/lastmodified/index.md
@@ -80,7 +80,8 @@ if (isNaN(nLastVisit) || nLastModif > nLastVisit) {
 }
 ```
 
-> **Note :** WebKit renvoie le temps sous forme de chaîne de caractère en UTC; Gecko et Internet Explorer renvoient le temps selon le fuseau horaire local. (Voir: [Bogue 4363 – document.lastModified renoive la date en UTC, mais devrait la renvoyer selon le fuseau horaire local](https://bugs.webkit.org/show_bug.cgi?id=4363))
+> [!NOTE]
+> WebKit renvoie le temps sous forme de chaîne de caractère en UTC; Gecko et Internet Explorer renvoient le temps selon le fuseau horaire local. (Voir: [Bogue 4363 – document.lastModified renoive la date en UTC, mais devrait la renvoyer selon le fuseau horaire local](https://bugs.webkit.org/show_bug.cgi?id=4363))
 
 Si vous voulez savoir **si _une page externe_ a changé,** veuillez lire [ce paragraphe à propos de l'API `XMLHttpRequest()`](/fr/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Get_last_modified_date).
 

--- a/files/fr/web/api/document/laststylesheetset/index.md
+++ b/files/fr/web/api/document/laststylesheetset/index.md
@@ -15,7 +15,8 @@ lastStyleSheetSet = document.lastStyleSheetSet;
 
 En retour, `lastStyleSheetSet` indique le jeu de feuilles de styles qui a été défini le plus récemment. Si le jeu de feuilles de style en cours n'a pas été modifié en définissant {{ domxref("document.selectedStyleSheetSet") }}, la valeur retournée est `null`.
 
-> **Note :** Cette valeur ne doit pas changer lorsque {{ domxref("document.enableStyleSheetsForSet()") }} est appelé.
+> [!NOTE]
+> Cette valeur ne doit pas changer lorsque {{ domxref("document.enableStyleSheetsForSet()") }} est appelé.
 
 ## Exemple
 

--- a/files/fr/web/api/document/queryselector/index.md
+++ b/files/fr/web/api/document/queryselector/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Document/querySelector
 
 La méthode **`querySelector()`** de l'interface {{domxref("Document")}} retourne le premier {{domxref("Element")}} dans le document correspondant au sélecteur - ou groupe de sélecteurs - spécifié(s), ou `null` si aucune correspondance n'est trouvée.
 
-> **Note :** La correspondance est effectuée en utilisant le parcours pré-ordonné profondeur-d'abord des nœuds du document, en partant du premier élément dans le balisage du document et en itérant à travers les nœuds en séquence, par ordre du compte de nœuds enfants.
+> [!NOTE]
+> La correspondance est effectuée en utilisant le parcours pré-ordonné profondeur-d'abord des nœuds du document, en partant du premier élément dans le balisage du document et en itérant à travers les nœuds en séquence, par ordre du compte de nœuds enfants.
 
 ## Syntaxe
 
@@ -20,7 +21,8 @@ element = document.querySelector(sélecteurs);
 - `selectors` (sélecteurs)
   - : une {{domxref("DOMString")}} (_chaîne de caractères_) qui contient un ou plusieurs sélecteurs à comparer. La chaîne doit être composée de sélecteurs CSS valides ; sinon une exception `SYNTAX_ERR` est lancée. Voir [Localisation des éléments DOM avec les sélecteurs](/fr/docs/Web/API/Document_Object_Model/Localisation_des_éléments_DOM_avec_les_sélecteurs) pour plus d'informations sur les sélecteurs et leur gestion.
 
-> **Note :** les caractères qui n'appartiennent pas à la syntaxe standard CSS doivent être échappés par un antislash ("\\"). Puisque JavaScript utilise aussi cette barre pour l'échappement, une attention particulière est nécessaire quand des chaînes comprennent ces caractères. Voir [Échapper des caractères spéciaux](#échapper_des_caractères_spéciaux) pour plus d'informations.
+> [!NOTE]
+> Les caractères qui n'appartiennent pas à la syntaxe standard CSS doivent être échappés par un antislash ("\\"). Puisque JavaScript utilise aussi cette barre pour l'échappement, une attention particulière est nécessaire quand des chaînes comprennent ces caractères. Voir [Échapper des caractères spéciaux](#échapper_des_caractères_spéciaux) pour plus d'informations.
 
 ### Valeur retournée
 

--- a/files/fr/web/api/document/queryselectorall/index.md
+++ b/files/fr/web/api/document/queryselectorall/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Document/querySelectorAll
 
 La méthode **`querySelectorAll()`** de {{domxref("Element")}} renvoie une {{domxref("NodeList")}} statique représentant une liste des éléments du document qui correspondent au groupe de sélecteurs spécifiés.
 
-> **Note :** Cette méthode est implémentée à partir de {{domxref("ParentNode")}}, méthode du mixin {{domxref("ParentNode.querySelectorAll", "querySelectorAll()")}} .
+> [!NOTE]
+> Cette méthode est implémentée à partir de {{domxref("ParentNode")}}, méthode du mixin {{domxref("ParentNode.querySelectorAll", "querySelectorAll()")}} .
 
 ## Syntaxe
 
@@ -20,13 +21,15 @@ elementList = parentNode.querySelectorAll(selectors);
 - `selecteurs`
   - : une {{domxref("DOMString")}} (_chaîne de caractères_) qui contient un ou plusieurs [sélecteurs CSS](/fr/docs/Web/CSS/CSS_Selectors) ; s'il n'y en a pas, une exception `SyntaxError` est lancée. Voir [localisation des éléments DOM avec les sélecteurs](/fr/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors) pour plus d'informations sur l'utilisation des sélecteurs en vue d'identifier les éléments. Plusieurs sélecteurs peuvent être spécifiés, séparés par une virgule.
 
-> **Note :** Les caractères qui ne font pas partie de la syntaxe CSS standard doivent être échappés à l'aide d'une barre oblique inverse. Puisque JavaScript utilise également l'échappement en retour arrière, un soin particulier doit être pris lors de l'écriture de littéraux de chaîne utilisant ces caractères. Voir [Échapper des caractères spéciaux](/fr/docs/Web/API/Document/querySelector#échapper_des_caractères_spéciaux) pour plus d'informations.
+> [!NOTE]
+> Les caractères qui ne font pas partie de la syntaxe CSS standard doivent être échappés à l'aide d'une barre oblique inverse. Puisque JavaScript utilise également l'échappement en retour arrière, un soin particulier doit être pris lors de l'écriture de littéraux de chaîne utilisant ces caractères. Voir [Échapper des caractères spéciaux](/fr/docs/Web/API/Document/querySelector#échapper_des_caractères_spéciaux) pour plus d'informations.
 
 ### Valeur renvoyée
 
 Une {{domxref("NodeList")}} statique contenant un objet {{domxref("Element")}} pour chaque élément qui correspond à au-moins un des sélecteurs spécifiés ou une {{domxref("NodeList")}} vide si aucune correspondance n'est trouvée .
 
-> **Note :** Si les `selectors` spécifiés contiennent un [pseudo-element CSS](/fr/docs/Web/CSS/Pseudo-elements), la liste retournée sera toujours vide.
+> [!NOTE]
+> Si les `selectors` spécifiés contiennent un [pseudo-element CSS](/fr/docs/Web/CSS/Pseudo-elements), la liste retournée sera toujours vide.
 
 ### Exceptions
 

--- a/files/fr/web/api/document/scroll_event/index.md
+++ b/files/fr/web/api/document/scroll_event/index.md
@@ -40,7 +40,8 @@ L'évènement **`scroll`** (défilement) est émis lorsque l'on fait défiler le
   </tbody>
 </table>
 
-> **Note :** Sur iOS UIWebViews, les évènements `scroll` ne sont pas émis pendant le défilement, mais une fois que celui-ci est terminé. Voir [Bootstrap issue #16202](https://github.com/twbs/bootstrap/issues/16202). Safari et WKWebViews ne sont pas affectés par ce bogue.
+> [!NOTE]
+> Sur iOS UIWebViews, les évènements `scroll` ne sont pas émis pendant le défilement, mais une fois que celui-ci est terminé. Voir [Bootstrap issue #16202](https://github.com/twbs/bootstrap/issues/16202). Safari et WKWebViews ne sont pas affectés par ce bogue.
 
 ## Propriétés
 

--- a/files/fr/web/api/document/selectedstylesheetset/index.md
+++ b/files/fr/web/api/document/selectedstylesheetset/index.md
@@ -19,7 +19,8 @@ En retour, `currentStyleSheetSet` indique le nom du jeu de feuilles de styles en
 
 La définition de la valeur de cette propriété équivaut à appeler {{ domxref("document.enableStyleSheetsForSet()") }} avec la valeur de `currentStyleSheetSet`, puis de définir la valeur de `lastStyleSheetSet` sur cette valeur.
 
-> **Note :** Cette valeur d'attribut est directe : sa modification affectera la valeur de l'attribut.
+> [!NOTE]
+> Cette valeur d'attribut est directe : sa modification affectera la valeur de l'attribut.
 
 ## Exemple
 
@@ -29,7 +30,8 @@ console.log("Current style sheet set: " + document.selectedStyleSheetSet);
 document.selectedStyleSheetSet = "Some other style sheet";
 ```
 
-> **Note :** Cet exemple vous aidera à comprendre la différence de comportement entre la définition de la valeur de `selectedStyleSheetSet` et l'appel de {{ domxref("document.enableStyleSheetsForSet()") }}.
+> [!NOTE]
+> Cet exemple vous aidera à comprendre la différence de comportement entre la définition de la valeur de `selectedStyleSheetSet` et l'appel de {{ domxref("document.enableStyleSheetsForSet()") }}.
 
 ## Voir aussi
 

--- a/files/fr/web/api/document/write/index.md
+++ b/files/fr/web/api/document/write/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Document/write
 
 Écrit une chaîne de texte dans un document ouvert par [document.open()](/fr/docs/Web/API/Document/open).
 
-> **Note :** comme `document.write` écrit dans le flux de documents, appeler `document.write` sur un document fermé (chargé) appelle automatiquement `document.open`, ce qui efface le document.
+> [!NOTE]
+> Comme `document.write` écrit dans le flux de documents, appeler `document.write` sur un document fermé (chargé) appelle automatiquement `document.open`, ce qui efface le document.
 
 ## Syntaxe
 
@@ -61,9 +62,11 @@ Si l'appel à `document.write()` est intégré directement dans le code HTML, il
 
 > **Note :** `document.write` dans les scripts [deferred (_différé_)](/fr/docs/Web/HTML/Element/script#attr-defer) ou [asynchronous (_asynchrone_)](/fr/docs/Web/HTML/Element/script#attr-async) sera ignoré et vous recevrez un message comme "A call to `document.write()` from an asynchronously-loaded external script was ignored" dans la console d'erreurs.
 
-> **Note :** Dans Edge seulement, appeler plusieurs fois `document.write` dans un "iframe" déclenche une erreur "SCRIPT70: Permission denied." _(autorisation refusée)_.
+> [!NOTE]
+> Dans Edge seulement, appeler plusieurs fois `document.write` dans un "iframe" déclenche une erreur "SCRIPT70: Permission denied." _(autorisation refusée)_.
 
-> **Note :** À partir de la version 55, Chrome n'exécute pas les éléments `<script>` injectés via `document.write()` en cas d'échec de cache HTTP pour les utilisateurs sur une connexion 2G.
+> [!NOTE]
+> À partir de la version 55, Chrome n'exécute pas les éléments `<script>` injectés via `document.write()` en cas d'échec de cache HTTP pour les utilisateurs sur une connexion 2G.
 
 ## Spécification
 

--- a/files/fr/web/api/document/xmlencoding/index.md
+++ b/files/fr/web/api/document/xmlencoding/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Document/xmlEncoding
 
 Renvoie le codage déterminé par la déclaration XML. Devrait être `null` si non précisé ou inconnu.
 
-> **Attention :** N'utilisez pas cet attribut ; il a été supprimé de la spécification DOM Niveau 4 et n'est plus pris en charge dans Gecko 10.0.
+> [!WARNING]
+> N'utilisez pas cet attribut ; il a été supprimé de la spécification DOM Niveau 4 et n'est plus pris en charge dans Gecko 10.0.
 
 Si la déclaration XML indique :
 

--- a/files/fr/web/api/document_object_model/index.md
+++ b/files/fr/web/api/document_object_model/index.md
@@ -282,7 +282,8 @@ Un objet `HTMLDocument` donne également accès à différentes fonctionnalités
 
 Voici l'API du DOM pour les types de donnée utilisés pour les propriétés et attributs SVG.
 
-> **Note :** À partir de Gecko 5.0, les interfaces suivantes relatives à SVG et qui représentent des listes d'objets sont indexées et permettent d'y accéder. Elles possèdent en plus une propriété de longueur qui indique le nombre d'éléments dans la liste : {{domxref("SVGLengthList")}}, {{domxref("SVGNumberList")}}, {{domxref("SVGPathSegList")}} et {{domxref("SVGPointList")}}.
+> [!NOTE]
+> À partir de Gecko 5.0, les interfaces suivantes relatives à SVG et qui représentent des listes d'objets sont indexées et permettent d'y accéder. Elles possèdent en plus une propriété de longueur qui indique le nombre d'éléments dans la liste : {{domxref("SVGLengthList")}}, {{domxref("SVGNumberList")}}, {{domxref("SVGPathSegList")}} et {{domxref("SVGPointList")}}.
 
 #### Interfaces statiques
 

--- a/files/fr/web/api/document_object_model/introduction/index.md
+++ b/files/fr/web/api/document_object_model/introduction/index.md
@@ -82,7 +82,8 @@ Un autre exemple. Cette fonction crée un nouvel élément H1, y ajoute du texte
 
 Cette référence tente de décrire les différents objets et types de la manière la plus simple possible. Mais il y a un certain nombre de types de données utilisées par l'API que vous devez connaître.
 
-> **Note :** Parce que la vaste majorité de codes qui utilisent le DOM gravitent autour de la manipulation de documents HTML, il est courant de toujours se référer aux nœuds du DOM comme éléments, étant donné que dans le document HTML, chaque nœud est un élément. Bien que n'étant pas strictement exact, la documentation que vous trouverez dans MDN fera souvent la même chose, à cause de la fréquence de cette hypothèse.
+> [!NOTE]
+> Parce que la vaste majorité de codes qui utilisent le DOM gravitent autour de la manipulation de documents HTML, il est courant de toujours se référer aux nœuds du DOM comme éléments, étant donné que dans le document HTML, chaque nœud est un élément. Bien que n'étant pas strictement exact, la documentation que vous trouverez dans MDN fera souvent la même chose, à cause de la fréquence de cette hypothèse.
 
 **NDTR:** (Pour simplifier, les exemples de syntaxe présentés dans cette référence se réfèreront aux nœuds en les appelant `elements`, aux tableaux de nœuds en tant que `nodeLists` (ou même simplement éléments), et aux nœuds d'attributs en tant qu'`attributes)`.
 

--- a/files/fr/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
+++ b/files/fr/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
@@ -16,7 +16,8 @@ Cette spécification ajoute deux nouvelles méthodes à tous les objets mettant 
 - `querySelectorAll`
   - : Renvoie une [`NodeList`](/fr/docs/Web/API/NodeList) (_liste de noeuds_) contenant tous les noeuds `Element` correspondants dans la sous-arborescence du noeud, ou une `NodeList` vide si aucune correspondance n'a été trouvée.
 
-> **Note :** La [`NodeList`](/fr/docs/Web/API/NodeList) retournée par [`querySelectorAll()`](/fr/docs/Web/API/Element/querySelectorAll) n'est pas directe. À la différence des autres méthodes de requêtes DOM qui retournent une liste de noeuds directe.
+> [!NOTE]
+> La [`NodeList`](/fr/docs/Web/API/NodeList) retournée par [`querySelectorAll()`](/fr/docs/Web/API/Element/querySelectorAll) n'est pas directe. À la différence des autres méthodes de requêtes DOM qui retournent une liste de noeuds directe.
 
 Vous pouvez trouver des exemples et des détails en lisant la documentation sur les méthodes [`querySelector()`](/fr/docs/Web/API/Element/querySelector) et [`querySelectorAll()`](/fr/docs/Web/API/Element/querySelectorAll), ainsi que dans l'article [Extraits de code pour querySelector](/fr/docs/Archive/Add-ons/Code_snippets/QuerySelector).
 

--- a/files/fr/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
+++ b/files/fr/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
@@ -9,7 +9,8 @@ slug: Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and
 
 Cet article propose une vue d'ensemble de certaines méthodes DOM Level 1 fondamentales et la façon de les utiliser depuis JavaScript. Vous y apprendrez à créer, accéder, contrôler et supprimer dynamiquement des éléments HTML. Les méthodes DOM décrites ne sont pas spécifiques au HTML et s'appliquent également au XML. Les exemples fonctionneront dans tous les navigateurs offrant le support complet du DOM niveau 1, ce qui est le cas de tous les navigateurs basés sur Mozilla comme Firefox ou Netscape. Les morceaux de code de ce document fonctionneront également dans Internet Explorer 5.
 
-> **Note :** Les méthodes décrites ici font partie de la spécification Document Object Model level 1 (Core). DOM level 1 comprend des méthodes destinées à l'accès et à la manipulation des documents (DOM 1 core) ainsi que des méthodes spécifiques aux documents HTML (DOM 1 HTML).
+> [!NOTE]
+> Les méthodes décrites ici font partie de la spécification Document Object Model level 1 (Core). DOM level 1 comprend des méthodes destinées à l'accès et à la manipulation des documents (DOM 1 core) ainsi que des méthodes spécifiques aux documents HTML (DOM 1 HTML).
 
 ## Création d'un tableau HTML dynamiquement
 
@@ -216,7 +217,8 @@ En exécutant cet exemple, vous pouvez remarquer que les mots «&nbsp;hello&nbsp
 
 ![](sample2b2.jpg)
 
-> **Note :** L'utilisation de `createTextNode` et de `appendChild` permet aisément d'ajouter un espace entre ces deux mots. Notez cependant que la méthode `appendChild` ajoute le nouvel enfant à la suite de ceux déjà présents, à la manière de «&nbsp;world&nbsp;» placé après «&nbsp;hello&nbsp;». Pour ajouter un nœud texte entre «&nbsp;hello&nbsp;» et «&nbsp;world&nbsp;» (par exemple un espace), utilisez `insertBefore` à la place de `appendChild`.
+> [!NOTE]
+> L'utilisation de `createTextNode` et de `appendChild` permet aisément d'ajouter un espace entre ces deux mots. Notez cependant que la méthode `appendChild` ajoute le nouvel enfant à la suite de ceux déjà présents, à la manière de «&nbsp;world&nbsp;» placé après «&nbsp;hello&nbsp;». Pour ajouter un nœud texte entre «&nbsp;hello&nbsp;» et «&nbsp;world&nbsp;» (par exemple un espace), utilisez `insertBefore` à la place de `appendChild`.
 
 ### Création de nouveaux éléments avec l'objet document et la méthode `createElement(...)`
 
@@ -265,7 +267,8 @@ On peut décomposer la création du tableau de Exemple1.html en trois étapes&nb
 
 Le code source qui suit est un exemple commenté qui crée le tableau de Exemple1.
 
-> **Note :** Il y a une ligne de code supplémentaire à la fin de la fonction `start()`, qui définit la propriété bordure du tableau en employant la méthode `setAttribute`. `setAttribute` utilise deux arguments&nbsp;: le nom de l'attribut et sa valeur, et permet de définir n'importe quelle propriété de n'importe quel élément.
+> [!NOTE]
+> Il y a une ligne de code supplémentaire à la fin de la fonction `start()`, qui définit la propriété bordure du tableau en employant la méthode `setAttribute`. `setAttribute` utilise deux arguments&nbsp;: le nom de l'attribut et sa valeur, et permet de définir n'importe quelle propriété de n'importe quel élément.
 
 ```html
 <head>
@@ -318,7 +321,8 @@ Le code source qui suit est un exemple commenté qui crée le tableau de Exemple
 
 Cet exemple présente deux nouveaux attributs DOM. D'abord, l'attribut `childNodes` qui est utilisé pour récupérer la liste des nœuds enfants de `cel`. A la différence de `getElementsByTagName`, la liste renvoyée par `childNodes` comporte tous les enfants sans considération de type. Une fois la liste obtenue, la notation `[x]` est employée pour sélectionner l'élément enfant désiré. Dans cet exemple, le nœud texte de la seconde cellule de la seconde ligne du tableau est enregistré dans `celtext`. Ensuite, un nouveau nœud texte contenant les données de `celtext` est greffé en tant qu'enfant sur l'élément \<body>.
 
-> **Note :** Si l'objet est un nœud texte, vous pouvez récupérer le texte qu'il contient en employant l'attribut `data`.
+> [!NOTE]
+> Si l'objet est un nœud texte, vous pouvez récupérer le texte qu'il contient en employant l'attribut `data`.
 
 ```js
 mybody = document.getElementsByTagName("body")[0];

--- a/files/fr/web/api/documentfragment/queryselectorall/index.md
+++ b/files/fr/web/api/documentfragment/queryselectorall/index.md
@@ -9,7 +9,8 @@ La méthode **`DocumentFragment.querySelectorAll()`** renvoie une {{domxref("Nod
 
 Si les sélecteurs spécifiés dans paramètre sont invalides une {{domxref("DOMException")}} avec une valeur `SYNTAX_ERR` est lancée.
 
-> **Note :** La définition de cet API a été déplacé vers l'interface {{domxref("ParentNode")}}.
+> [!NOTE]
+> La définition de cet API a été déplacé vers l'interface {{domxref("ParentNode")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/api/domexception/index.md
+++ b/files/fr/web/api/domexception/index.md
@@ -27,7 +27,8 @@ Chaque exception a un **nom**, qui est une courte chaîne identifiant l'erreur o
 
 Les noms d'erreurs courants sont répertoriés ici. Certaines API définissent leurs propres ensembles de noms, il ne s'agit donc pas ici nécessairement d'une liste complète.
 
-> **Note :** Parce qu'historiquement les erreurs ont été identifiées par une valeur numérique qui correspondait à une variable nommée définie pour avoir cette valeur, certaines des entrées ci-dessous indiquent la valeur de code héritée et le nom de constante qui ont été utilisés dans le passé.
+> [!NOTE]
+> Parce qu'historiquement les erreurs ont été identifiées par une valeur numérique qui correspondait à une variable nommée définie pour avoir cette valeur, certaines des entrées ci-dessous indiquent la valeur de code héritée et le nom de constante qui ont été utilisés dans le passé.
 
 - `IndexSizeError`
   - : L'index n'est pas dans la plage autorisée. Par exemple, cela peut être lancé par un objet {{ domxref("Range") }}. (Valeur de code héritée : `1` et nom de la constante héritée : `INDEX_SIZE_ERR`)

--- a/files/fr/web/api/dompoint/index.md
+++ b/files/fr/web/api/dompoint/index.md
@@ -61,7 +61,8 @@ function setView() {
 }
 ```
 
-> **Note :** Voir notre [positionsensorvrdevice demo](https://github.com/mdn/webvr-tests/blob/gh-pages/positionsensorvrdevice/index.html) pour le code complet.
+> [!NOTE]
+> Voir notre [positionsensorvrdevice demo](https://github.com/mdn/webvr-tests/blob/gh-pages/positionsensorvrdevice/index.html) pour le code complet.
 
 ## Spécifications
 

--- a/files/fr/web/api/element/animate/index.md
+++ b/files/fr/web/api/element/animate/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Element/animate
 
 La méthode **`animate()`** de l'interface [`Element`](/fr/docs/Web/API/Element) est un raccourci permettant de créer un nouvel objet [`Animation`](/fr/docs/Web/API/Animation), de l'appliquer à un élément puis de la jouer. Elle retourne l'instance [`Animation`](/fr/docs/Web/API/Animation) alors créée.
 
-> **Note :** Les éléments peuvent avoir plusieurs animations qui leur sont appliquées. Vous pouvez obtenir une liste des animations qui affectent un élément en appelant [`Element.getAnimations()`](/fr/docs/Web/API/Element/getAnimations).
+> [!NOTE]
+> Les éléments peuvent avoir plusieurs animations qui leur sont appliquées. Vous pouvez obtenir une liste des animations qui affectent un élément en appelant [`Element.getAnimations()`](/fr/docs/Web/API/Element/getAnimations).
 
 ## Syntaxe
 

--- a/files/fr/web/api/element/auxclick_event/index.md
+++ b/files/fr/web/api/element/auxclick_event/index.md
@@ -9,7 +9,8 @@ La propriété **`onauxclick`** du mixin {{domxref("GlobalEventHandlers")}} est 
 
 L'événement `auxclick` est déclenché lorsqu'un bouton non principal a été enfoncé sur un périphérique d'entrée (par exemple, la molette de la souris). Il se déclenche après les événements [`mousedown`](/fr/docs/Web/API/Element/mousedown_event) et [`mouseup`](/fr/docs/Web/API/Element/mouseup_event), dans cet ordre.
 
-> **Note :** Les fournisseurs de navigateurs implémentent cette propriété dans le cadre d'un plan visant à améliorer la compatibilité en ce qui concerne le comportement des boutons. Plus précisément, le comportement des événements est mis à jour afin que l'évènement [`click`](/fr/docs/Web/API/Element/click_event) ne se déclenche que pour les clics sur le bouton principal (par exemple, le bouton gauche de la souris), tandis que l'évènement `auxclick` se déclenche pour le bouton non principal. Historiquement, [`click`](/fr/docs/Web/API/Element/click_event) s'est généralement déclenché pour le clic de n'importe quel bouton d'entrée de périphérique, bien que le comportement du navigateur soit quelque peu incohérent.
+> [!NOTE]
+> Les fournisseurs de navigateurs implémentent cette propriété dans le cadre d'un plan visant à améliorer la compatibilité en ce qui concerne le comportement des boutons. Plus précisément, le comportement des événements est mis à jour afin que l'évènement [`click`](/fr/docs/Web/API/Element/click_event) ne se déclenche que pour les clics sur le bouton principal (par exemple, le bouton gauche de la souris), tandis que l'évènement `auxclick` se déclenche pour le bouton non principal. Historiquement, [`click`](/fr/docs/Web/API/Element/click_event) s'est généralement déclenché pour le clic de n'importe quel bouton d'entrée de périphérique, bien que le comportement du navigateur soit quelque peu incohérent.
 
 ## Syntaxe
 
@@ -48,7 +49,8 @@ button.onauxclick = function () {
 };
 ```
 
-> **Note :** Si vous utilisez une souris à trois boutons, vous remarquerez que le gestionnaire `onauxclick` est exécuté lorsque l'un des boutons non gauche de la souris est cliqué.
+> [!NOTE]
+> Si vous utilisez une souris à trois boutons, vous remarquerez que le gestionnaire `onauxclick` est exécuté lorsque l'un des boutons non gauche de la souris est cliqué.
 
 ## Spécifications
 

--- a/files/fr/web/api/element/childelementcount/index.md
+++ b/files/fr/web/api/element/childelementcount/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Element/childElementCount
 
 La propriété **`ParentNode.childElementCount`** en lecture seule renvoie un `unsigned long` (_long non signé_) représentant le nombre d'élèments fils de l'élément donné.
 
-> **Note :** Cette propriété a été définie dans la pure interface {{domxref("ElementTraversal")}}.
+> [!NOTE]
+> Cette propriété a été définie dans la pure interface {{domxref("ElementTraversal")}}.
 > Comme cette interface contenait deux différents jeux de propriétés, l'un visant les {{domxref("Node")}} (_noeuds_) qui ont des enfants, l'autre les enfants, ils ont été déplacés dans deux interfaces pures, {{domxref("ParentNode")}} et {{domxref("ChildNode")}}. Dans ce cas, `childElementCount` a été rattaché à {{domxref("ParentNode")}}. C'est un changement assez technique qui ne devrait pas affecter la compatibilité.
 
 ## Syntaxe

--- a/files/fr/web/api/element/classlist/index.md
+++ b/files/fr/web/api/element/classlist/index.md
@@ -71,7 +71,8 @@ div.classList.remove(...cls);
 div.classList.replace("foo", "bar");
 ```
 
-> **Note :** Les versions de Firefox antérieures à la 26 n'implémentent pas l'utilisation de plusieurs arguments dans les méthodes add/remove/toggle. Voir <https://bugzilla.mozilla.org/show_bug.cgi?id=814014>
+> [!NOTE]
+> Les versions de Firefox antérieures à la 26 n'implémentent pas l'utilisation de plusieurs arguments dans les méthodes add/remove/toggle. Voir <https://bugzilla.mozilla.org/show_bug.cgi?id=814014>
 
 ## Prothèse d'émulation
 

--- a/files/fr/web/api/element/clientheight/index.md
+++ b/files/fr/web/api/element/clientheight/index.md
@@ -11,7 +11,8 @@ La propriété en lecture seule **`Element.clientHeight`** vaut zéro pour les �
 
 Lorsque `clientHeight` est utilisée sur l'élément racine (l'élément `<html>`), (ou sur `<body>` si le document est en mode de compatibilité (<i lang="en">quirks mode</i>)), c'est la hauteur de la zone d'affichage (<i lang="en">viewport</i>) (sans tenir compte des barres de défilement) qui est renvoyée. [Il s'agit ici d'un cas aux limites pour `clientHeight`](https://www.w3.org/TR/2016/WD-cssom-view-1-20160317/#dom-element-clientheight).
 
-> **Note :** Cette propriété sera arrondie en un entier. Si vous souhaitez utiliser une valeur décimale, vous pouvez utiliser [`element.getBoundingClientRect()`](/fr/docs/Web/API/Element/getBoundingClientRect).
+> [!NOTE]
+> Cette propriété sera arrondie en un entier. Si vous souhaitez utiliser une valeur décimale, vous pouvez utiliser [`element.getBoundingClientRect()`](/fr/docs/Web/API/Element/getBoundingClientRect).
 
 ## Syntaxe
 

--- a/files/fr/web/api/element/clientleft/index.md
+++ b/files/fr/web/api/element/clientleft/index.md
@@ -9,9 +9,11 @@ La propriété en lecture seule **`Element.clientLeft`** représente la largeur 
 
 Lorsque la préférence [`layout.scrollbar.side`](http://kb.mozillazine.org/Layout.scrollbar.side) est paramétrée à 1 ou à 3 et que la direction du texte est de droite à gauche, **alors la barre de défilement verticale est placée à gauche** et ce placement aura donc un impact sur la valeur de `clientLeft`.
 
-> **Note :** Cette propriété sera arrondie en une valeur entière. Si vous souhaitez utiliser une valeur décimale, vous pouvez utiliser [`element.getBoundingClientRect()`](/fr/docs/Web/API/Element/getBoundingClientRect).
+> [!NOTE]
+> Cette propriété sera arrondie en une valeur entière. Si vous souhaitez utiliser une valeur décimale, vous pouvez utiliser [`element.getBoundingClientRect()`](/fr/docs/Web/API/Element/getBoundingClientRect).
 
-> **Note :** Lorsqu'un élément se voit appliquer `display: inline`, `clientLeft` renvoie `0`, quelle que soit la bordure de l'élément.
+> [!NOTE]
+> Lorsqu'un élément se voit appliquer `display: inline`, `clientLeft` renvoie `0`, quelle que soit la bordure de l'élément.
 
 ## Syntaxe
 

--- a/files/fr/web/api/element/clientwidth/index.md
+++ b/files/fr/web/api/element/clientwidth/index.md
@@ -9,7 +9,8 @@ La propriété **`Element.clientWidth`** vaut zéro pour les éléments en ligne
 
 Lorsque `clientWidth` est utilisée sur l'élément racine (l'élément `<html>` par défaut ou `<body>` si le document utilise le mode _quirks_), c'est la largeur de la zone d'affichage (_viewport_) à l'exception des barres de défilement qui est renvoyée. [Il s'agit d'un cas au limite pour `clientWidth`](https://www.w3.org/TR/2016/WD-cssom-view-1-20160317/#dom-element-clientwidth).
 
-> **Note :** La valeur de cette propriété sera arondie en un entier. Si vous devez utiliser une valeur décimale, privilégiez {{domxref("element.getBoundingClientRect()")}}.
+> [!NOTE]
+> La valeur de cette propriété sera arondie en un entier. Si vous devez utiliser une valeur décimale, privilégiez {{domxref("element.getBoundingClientRect()")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/api/element/getattributens/index.md
+++ b/files/fr/web/api/element/getattributens/index.md
@@ -28,7 +28,8 @@ getAttributeNS(namespace, name)
 
 Une chaîne de caractères avec la valeur de l'attribut recherché. Si l'attribut n'existe pas, le résultat est `null`.
 
-> **Note :** Les versions antérieures de la spécification DOM avaient cette méthode décrite comme renvoyant une chaîne vide pour des attributs inexistants, mais elle n'était généralement pas implémentée de cette façon, car `null` a plus de sens. La spécification DOM4 indique maintenant que cette méthode devrait retourner `null` pour les attributs inexistants.
+> [!NOTE]
+> Les versions antérieures de la spécification DOM avaient cette méthode décrite comme renvoyant une chaîne vide pour des attributs inexistants, mais elle n'était généralement pas implémentée de cette façon, car `null` a plus de sens. La spécification DOM4 indique maintenant que cette méthode devrait retourner `null` pour les attributs inexistants.
 
 ## Exemples
 

--- a/files/fr/web/api/element/id/index.md
+++ b/files/fr/web/api/element/id/index.md
@@ -9,7 +9,8 @@ La propriété **`Element.id`** représente l'identifiant de l'élément, reflé
 
 Il doit être unique dans un document et est souvent utilisé pour extraire l'élément en utilisant {{domxref("document.getElementById","getElementById")}}. Les autres utilisations courantes de `id` comprennent l'utilisation de l'[ID de l'élément en tant que sélecteur](/fr/docs/Web/CSS/Sélecteurs_d_ID) lors de la mise en forme du document avec [CSS](/fr/docs/Web/CSS).
 
-> **Note :** Les identifiants sont sensibles à la casse, mais vous devez éviter de créer des ID qui ne diffèrent que par la casse (voir [Sensibilité à la casse dans les noms de classe et d'identifiant](/fr/docs/Archive/Case_Sensitivity_in_class_and_id_Names)).
+> [!NOTE]
+> Les identifiants sont sensibles à la casse, mais vous devez éviter de créer des ID qui ne diffèrent que par la casse (voir [Sensibilité à la casse dans les noms de classe et d'identifiant](/fr/docs/Archive/Case_Sensitivity_in_class_and_id_Names)).
 
 ## Syntaxe
 


### PR DESCRIPTION
This PR converts the noteblocks for the French locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 8. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
