### PR TITLE
fr: Convert noteblocks to GFM Alerts (part 10)

### DIFF
--- a/files/fr/web/api/idbobjectstore/createindex/index.md
+++ b/files/fr/web/api/idbobjectstore/createindex/index.md
@@ -7,7 +7,8 @@ slug: Web/API/IDBObjectStore/createIndex
 
 La méthode **`createIndex()`** de l'interface {{domxref("IDBObjectStore")}} met en place sur le magasin d'objet {{domxref("IDBObjectStore","relié")}} un nouvel index et en renvoie l'{{domxref("IDBIndex","accès")}}.
 
-> **Note :** Cette méthode ne peut être appelé que si la transaction de l'accès au magasin d'objet est en mode VersionChange.
+> [!NOTE]
+> Cette méthode ne peut être appelé que si la transaction de l'accès au magasin d'objet est en mode VersionChange.
 
 {{AvailableInWorkers}}
 
@@ -144,7 +145,8 @@ DBOpenRequest.onupgradeneeded = function (event) {
 };
 ```
 
-> **Note :** Pour un exemple de travail complet, voir notre [To-do Notifications](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) app ([view example live](https://mdn.github.io/dom-examples/to-do-notifications/)).
+> [!NOTE]
+> Pour un exemple de travail complet, voir notre [To-do Notifications](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) app ([view example live](https://mdn.github.io/dom-examples/to-do-notifications/)).
 
 ## Spécifications
 

--- a/files/fr/web/api/idbobjectstore/deleteindex/index.md
+++ b/files/fr/web/api/idbobjectstore/deleteindex/index.md
@@ -7,7 +7,8 @@ slug: Web/API/IDBObjectStore/deleteIndex
 
 La méthode **`deleteIndex()`** de l'interface {{domxref("IDBObjectStore")}} supprime l'index dont le nom est passé en paramètre, du magasin d'objet relié ({{domxref("IDBObjectStore")}}).
 
-> **Note :** Cette méthode ne peut être appelée que si la transaction ({{domxref("IDBTransaction")}}) de l'accès ({{domxref("IDBObjectStore")}}) au magasin d'objet est en mode ({{domxref("IDBTransaction.mode")}}) **[versionchange](/fr/docs/Web/API/IDBTransaction/mode#versionchange)**. Les propriétés **indexNames ({{domxref("IDBObjectStore.indexNames")}})** des accès au magasin d'object seront aussi mises à jour.
+> [!NOTE]
+> Cette méthode ne peut être appelée que si la transaction ({{domxref("IDBTransaction")}}) de l'accès ({{domxref("IDBObjectStore")}}) au magasin d'objet est en mode ({{domxref("IDBTransaction.mode")}}) **[versionchange](/fr/docs/Web/API/IDBTransaction/mode#versionchange)**. Les propriétés **indexNames ({{domxref("IDBObjectStore.indexNames")}})** des accès au magasin d'object seront aussi mises à jour.
 
 {{AvailableInWorkers}}
 
@@ -89,7 +90,8 @@ DBOpenRequest.onupgradeneeded = function (event) {
 };
 ```
 
-> **Note :** Pour un exemple de travail complet, voir notre [To-do Notifications](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) app ([view example live](https://mdn.github.io/dom-examples/to-do-notifications/)).
+> [!NOTE]
+> Pour un exemple de travail complet, voir notre [To-do Notifications](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) app ([view example live](https://mdn.github.io/dom-examples/to-do-notifications/)).
 
 ## Spécifications
 

--- a/files/fr/web/api/idbobjectstore/get/index.md
+++ b/files/fr/web/api/idbobjectstore/get/index.md
@@ -9,7 +9,8 @@ La méthode **`get()`**, rattachée à l'interface [`IDBObjectStore`](/fr/docs/W
 
 Si une valeur est trouvée, un clone structuré est créé et placé comme valeur de l'attribut [`result`](/fr/docs/Web/API/IDBRequest#attr_result) de l'objet qui représente la requête.
 
-> **Note :** Cette méthode produira le même résultat si l'enregistrement n'existe pas dans la base de données ou s'il a une valeur indéfinie. Pour distinguer ces deux cas, on appellera la méthode avec la même clé&nbsp;: elle fournira un curseur si l'enregistrement existe et aucun curseur sinon.
+> [!NOTE]
+> Cette méthode produira le même résultat si l'enregistrement n'existe pas dans la base de données ou s'il a une valeur indéfinie. Pour distinguer ces deux cas, on appellera la méthode avec la même clé&nbsp;: elle fournira un curseur si l'enregistrement existe et aucun curseur sinon.
 
 {{AvailableInWorkers}}
 

--- a/files/fr/web/api/idbobjectstore/index.md
+++ b/files/fr/web/api/idbobjectstore/index.md
@@ -136,7 +136,8 @@ objectStoreRequest.onsuccess = function (event) {
 };
 ```
 
-> **Note :** Pour un exemple de travail complet, voir notre [To-do Notifications](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) app ([view example live](https://mdn.github.io/dom-examples/to-do-notifications/)).
+> [!NOTE]
+> Pour un exemple de travail complet, voir notre [To-do Notifications](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) app ([view example live](https://mdn.github.io/dom-examples/to-do-notifications/)).
 
 ## Spécifications
 

--- a/files/fr/web/api/idbobjectstore/index/index.md
+++ b/files/fr/web/api/idbobjectstore/index/index.md
@@ -85,7 +85,8 @@ function displayDataByIndex() {
 }
 ```
 
-> **Note :** pour un exemple fonctionnel complet, voir notre [exemple sur GitHub](https://github.com/mdn/dom-examples/tree/main/indexeddb-examples/idbindex) ([la démonstration associée](https://mdn.github.io/dom-examples/indexeddb-examples/idbindex/)).
+> [!NOTE]
+> Pour un exemple fonctionnel complet, voir notre [exemple sur GitHub](https://github.com/mdn/dom-examples/tree/main/indexeddb-examples/idbindex) ([la démonstration associée](https://mdn.github.io/dom-examples/indexeddb-examples/idbindex/)).
 
 ## Spécifications
 

--- a/files/fr/web/api/idbobjectstore/transaction/index.md
+++ b/files/fr/web/api/idbobjectstore/transaction/index.md
@@ -83,7 +83,8 @@ function addData() {
 }
 ```
 
-> **Note :** Pour un exemple de travail complet, voir notre [To-do Notifications](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) app ([view example live](https://mdn.github.io/dom-examples/to-do-notifications/)).
+> [!NOTE]
+> Pour un exemple de travail complet, voir notre [To-do Notifications](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) app ([view example live](https://mdn.github.io/dom-examples/to-do-notifications/)).
 
 ## Spécifications
 

--- a/files/fr/web/api/idbrequest/result/index.md
+++ b/files/fr/web/api/idbrequest/result/index.md
@@ -7,7 +7,8 @@ slug: Web/API/IDBRequest/result
 
 La propriété **`result`**, rattachée à l'interface [`IDBRequest`](/fr/docs/Web/API/IDBRequest), renvoie le résultat de la requête. Si la requête échoue et que le résultat n'est pas disponible, une exception `InvalidStateError` sera levée.
 
-> **Note :** Cette fonctionnalité est disponible via les [Web Workers](/fr/docs/Web/API/Web_Workers_API).
+> [!NOTE]
+> Cette fonctionnalité est disponible via les [Web Workers](/fr/docs/Web/API/Web_Workers_API).
 
 ## Syntaxe
 

--- a/files/fr/web/api/idbrequest/transaction/index.md
+++ b/files/fr/web/api/idbrequest/transaction/index.md
@@ -7,7 +7,8 @@ slug: Web/API/IDBRequest/transaction
 
 La propriété **`transaction`** de l'interface IDBRequest renvoie la {{domxref("IDBTransaction","transaction")}} dans laquelle on fait la requête.La propriètè peut renvoiyer `null` si requête se fait sans transaction, comme un objet IDBRequest renvoyé par {{domxref("IDBFactory.open")}} dans ce cas on est juste connecté à la base de données.
 
-> **Note :** Durant la gestion d'un événement {{domxref("IDBOpenDBRequest.onupgradeneeded", "upgradeneeded")}} qui met à jour la version de la base de données, la propriété **`transaction`** doit être une {{domxref("IDBTransaction","transaction")}} ouverte en {{domxref("IDBTransaction.mode", "mode")}} `"versionchange"`, on peut alors accéder aux {{domxref("IDBObjectStore","magasins d'objets")}} et {{domxref("IDBIndex","index")}} ou annulé la mise à niveau. Après quoi, la propriété **`transaction`** renverra encore `null`.
+> [!NOTE]
+> Durant la gestion d'un événement {{domxref("IDBOpenDBRequest.onupgradeneeded", "upgradeneeded")}} qui met à jour la version de la base de données, la propriété **`transaction`** doit être une {{domxref("IDBTransaction","transaction")}} ouverte en {{domxref("IDBTransaction.mode", "mode")}} `"versionchange"`, on peut alors accéder aux {{domxref("IDBObjectStore","magasins d'objets")}} et {{domxref("IDBIndex","index")}} ou annulé la mise à niveau. Après quoi, la propriété **`transaction`** renverra encore `null`.
 
 {{AvailableInWorkers}}
 

--- a/files/fr/web/api/idbtransaction/db/index.md
+++ b/files/fr/web/api/idbtransaction/db/index.md
@@ -83,7 +83,8 @@ function addData() {
 }
 ```
 
-> **Note :** pour un exemple fonctionnel complet, voir notre [application To-do](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) ([exemple](https://mdn.github.io/dom-examples/to-do-notifications/)).
+> [!NOTE]
+> Pour un exemple fonctionnel complet, voir notre [application To-do](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) ([exemple](https://mdn.github.io/dom-examples/to-do-notifications/)).
 
 ## Spécifications
 

--- a/files/fr/web/api/idbtransaction/error/index.md
+++ b/files/fr/web/api/idbtransaction/error/index.md
@@ -21,7 +21,8 @@ L'{{domxref("DOMError","erreur","",1)}} correspondante qui est un objet `DOMErro
 
 Cette propriété vaut `null` si la transaction n'est pas terminée ou qu'elle est terminée avec succès ou qu'elle a été annulée avec la méthode {{domxref("IDBTransaction.abort","abort")}}.
 
-> **Note :** Dans Chrome 48+ cette propriété renvoie une exception {{domxref ("DOMException")}} parce que le type {{domxref("DOMError")}} a été retiré de la norme DOM.
+> [!NOTE]
+> Dans Chrome 48+ cette propriété renvoie une exception {{domxref ("DOMException")}} parce que le type {{domxref("DOMError")}} a été retiré de la norme DOM.
 
 ## Exemples
 
@@ -87,7 +88,8 @@ function addData() {
 }
 ```
 
-> **Note :** pour un exemple fonctionnel complet, voir notre [application To-do](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) ([exemple](https://mdn.github.io/dom-examples/to-do-notifications/)).
+> [!NOTE]
+> Pour un exemple fonctionnel complet, voir notre [application To-do](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) ([exemple](https://mdn.github.io/dom-examples/to-do-notifications/)).
 
 ## Spécifications
 

--- a/files/fr/web/api/idbtransaction/objectstore/index.md
+++ b/files/fr/web/api/idbtransaction/objectstore/index.md
@@ -101,7 +101,8 @@ function addData() {
 }
 ```
 
-> **Note :** Pour un exemple fonctionnel complet, voir notre application [To-do Notifications](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) ([l'exemple _live_ est disponible ici](https://mdn.github.io/dom-examples/to-do-notifications/)).
+> [!NOTE]
+> Pour un exemple fonctionnel complet, voir notre application [To-do Notifications](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) ([l'exemple _live_ est disponible ici](https://mdn.github.io/dom-examples/to-do-notifications/)).
 
 ## Spécifications
 

--- a/files/fr/web/api/indexeddb_api/basic_terminology/index.md
+++ b/files/fr/web/api/indexeddb_api/basic_terminology/index.md
@@ -49,7 +49,8 @@ Si vous avez l'habitude de travailler avec d'autres types de base de données, I
 
   Cette règle de sécurité qui porte sur IndexedDB empêche les applications d'accéder aux données des autres origines. Ainsi, bien qu'une application ou une page située sur [http://www.example.com/app/](https://www.example.com/app/) puisse récupérer des données à propos de [http://www.example.com/dir/](https://www.example.com/dir/), car elles partagent la même origine&nbsp;; elle ne peut pas récupérer des données provenant de [http://www.example.com:8080/dir/](https://www.example.com:8080/dir/) (le port est différent) ou de <https://www.example.com/dir/> (le protocole est différent), car les origines sont différentes.
 
-  > **Note :** Le contenu tiers d'une fenêtre (par exemple celui d'une [`<iframe>`](/fr/docs/Web/HTML/Element/iframe)) peut accéder au magasin IndexedDB de l'origine dans laquelle il est embarqué, à moins que le navigateur soit paramétré [pour ne jamais accepter les cookies tiers](https://support.mozilla.org/en-US/kb/third-party-cookies-firefox-tracking-protection) (voir [le bug 1147821](https://bugzilla.mozilla.org/show_bug.cgi?id=1147821)).
+  > [!NOTE]
+  > Le contenu tiers d'une fenêtre (par exemple celui d'une [`<iframe>`](/fr/docs/Web/HTML/Element/iframe)) peut accéder au magasin IndexedDB de l'origine dans laquelle il est embarqué, à moins que le navigateur soit paramétré [pour ne jamais accepter les cookies tiers](https://support.mozilla.org/en-US/kb/third-party-cookies-firefox-tracking-protection) (voir [le bug 1147821](https://bugzilla.mozilla.org/show_bug.cgi?id=1147821)).
 
 ### Limitations
 

--- a/files/fr/web/api/indexeddb_api/index.md
+++ b/files/fr/web/api/indexeddb_api/index.md
@@ -9,7 +9,8 @@ IndexedDB est une API de bas niveau qui permet le stockage côté client de quan
 
 {{AvailableInWorkers}}
 
-> **Note :** L'API IndexedDB est puissante, mais elle peut sembler trop compliquée dans les cas simples. Si vous préferez une API plus simple, essayez des librairies comme [localForage](https://localforage.github.io/localForage/), [dexie.js](http://www.dexie.org/), [ZangoDB](https://github.com/erikolson186/zangodb), [PouchDB](https://pouchdb.com/), [idb](https://www.npmjs.com/package/idb), [idb-keyval](https://www.npmjs.com/package/idb-keyval), [JsStore](http://jsstore.net/) et [lovefield](https://github.com/google/lovefield) qui offrent de nombreux avantages aux développeurs de IndexedDB.
+> [!NOTE]
+> L'API IndexedDB est puissante, mais elle peut sembler trop compliquée dans les cas simples. Si vous préferez une API plus simple, essayez des librairies comme [localForage](https://localforage.github.io/localForage/), [dexie.js](http://www.dexie.org/), [ZangoDB](https://github.com/erikolson186/zangodb), [PouchDB](https://pouchdb.com/), [idb](https://www.npmjs.com/package/idb), [idb-keyval](https://www.npmjs.com/package/idb-keyval), [JsStore](http://jsstore.net/) et [lovefield](https://github.com/google/lovefield) qui offrent de nombreux avantages aux développeurs de IndexedDB.
 
 ## Concepts clés et utilisation
 
@@ -19,7 +20,8 @@ IndexedDB est un système de gestion de base de données transactionnel, similai
 - Apprenez à utiliser IndexedDB de manière asynchrone à partir des principes fondamentaux grâce à notre guide [Utiliser IndexedDB](/fr/docs/IndexedDB/Using_IndexedDB).
 - Combinez IndexedDB pour le stockage des données en mode déconnecté avec les Service Workers pour stocker des assets en mode déconnecté, comme précisé dans [Faire fonctionner les PWAs en mode déconnecté grâce aux Service workers](/fr/docs/Web/Progressive_web_apps/Offline_Service_workers).
 
-> **Note :** Comme la plupart des solutions de stockage en ligne, IndexedDB suit la politique [same-origin policy](http://www.w3.org/Security/wiki/Same_Origin_Policy). Alors même que vous pouvez accèder à des données stockées au sein d'un domaine, vous ne pouvez pas accéder à des données sur plusieurs domaines.
+> [!NOTE]
+> Comme la plupart des solutions de stockage en ligne, IndexedDB suit la politique [same-origin policy](http://www.w3.org/Security/wiki/Same_Origin_Policy). Alors même que vous pouvez accèder à des données stockées au sein d'un domaine, vous ne pouvez pas accéder à des données sur plusieurs domaines.
 
 ### Synchrone et asynchrone
 

--- a/files/fr/web/api/indexeddb_api/using_indexeddb/index.md
+++ b/files/fr/web/api/indexeddb_api/using_indexeddb/index.md
@@ -76,7 +76,8 @@ La requête "open" n'ouvre pas la base de données ni ne démarre une transactio
 
 Le second paramètre de la méthode open est la version de la base de données. La version de la base détermine le schéma de celle-ci — Les objets stockés dans la base de données et leur structure. Si la base de données n'existe pas déjà, elle est créée via l'opération `open()`, puis, un événement `onupgradeneeded` est déclenché et vous créez le schéma de la base dans le gestionnaire pour cet événement. Si la base de données existe, mais que vous spécifiez un numéro de version plus élevé, un événement `onupgradeneeded` est déclenché immédiatement, vous permettant de mettre à jour le schéma dans son gestionnaire – plus d'informations dans [Updating the version of the database](#Updating_the_version_of_the_database) plus bas et la page référence {{ domxref("IDBFactory.open") }}.
 
-> **Attention :** Le numéro de version est un nombre "`unsigned long long`" ce qui signifie qu'il peut s'agir d'un entier très grand. Cela veut également dire que vous ne pouvez pas utiliser de réél, sinon, il sera converti au nombre entier le plus proche (inférieur) et la transaction peut ne pas démarrer ou ne pas déclencher l'événement `upgradeneeded`. Par exemple, n'utilisez pas 2.4 comme un numéro de version :
+> [!WARNING]
+> Le numéro de version est un nombre "`unsigned long long`" ce qui signifie qu'il peut s'agir d'un entier très grand. Cela veut également dire que vous ne pouvez pas utiliser de réél, sinon, il sera converti au nombre entier le plus proche (inférieur) et la transaction peut ne pas démarrer ou ne pas déclencher l'événement `upgradeneeded`. Par exemple, n'utilisez pas 2.4 comme un numéro de version :
 > `var request = indexedDB.open("MyTestDatabase", 2.4); // Ne faites pas ça, même si la version sera arrondie à 2`
 
 #### Générer des gestionnaires
@@ -259,7 +260,8 @@ Pour changer le "schéma" ou la structure de la base de données — qui impliqu
 
 Pour lire les enregistrements d'un objet de stockage existant, la transaction peut être en mode `readonly` ou `readwrite`. Pour appliquer des changements à un objet de stockage existant, la transaction doit être en mode `readwrite`. Vous démarrez ces transactions avec {{domxref("IDBDatabase.transaction")}}. La méthode accepte deux paramètres : les `storeNames` (la portée, définie comme un tableau des objets de stockage auxquels vous souhaitez accéder) et le `mode` (`readonly` ou `readwrite`) pour la transaction. La méthode retourne un objet de transaction contenant la méthode {{domxref("IDBIndex.objectStore")}}, que vous utilisez pour accéder à votre objet de stockage. Par défaut, lorsqu'aucun mode n'est spécifié, les transactions démarrent en mode `readonly`.
 
-> **Note :** À partir de Firefox 40, les transactions IndexedDB ont des garanties de durabilité relachées afin d'augmenter les performances (voir [bug Firefox 1112702](https://bugzil.la/1112702).) Auparavant, lors d'une transaction `readwrite` {{domxref("IDBTransaction.oncomplete")}} était déclenché seulement lorsque les données étaient garanties pour une écriture sur le disque. Dans Firefox 40+ l'évènement `complete` est déclenché une fois que l'OS a autorisé l'écriture de données, mais potentiellement avant que les données soient réellement écrites sur le disque. L'évènement `complete` peut ainsi être livré plus vite qu'avant, cependant, il existe un petit risque que l'ensemble de la transaction soit perdu si l'OS s'effondre ou si un problème électrique survient avant que les données soient écrites. Comme de tels évènements catastrophiques sont rares, la plupart des utilisateurs n'ont pas à s'en soucier. Si vous devez vous assurer de la durabilité pour quelconque raison que ce soit (par exemple, vous stockez des données critiques qui ne peuvent être recalculées plus tard) vous pouvez forcer une transaction à écrire sur le disque avant que l'évènement `complete` ne soit délivré en créant une transaction utilisant un mode expérimental (non-standard) `readwriteflush` (se référer à {{domxref("IDBDatabase.transaction")}}.
+> [!NOTE]
+> À partir de Firefox 40, les transactions IndexedDB ont des garanties de durabilité relachées afin d'augmenter les performances (voir [bug Firefox 1112702](https://bugzil.la/1112702).) Auparavant, lors d'une transaction `readwrite` {{domxref("IDBTransaction.oncomplete")}} était déclenché seulement lorsque les données étaient garanties pour une écriture sur le disque. Dans Firefox 40+ l'évènement `complete` est déclenché une fois que l'OS a autorisé l'écriture de données, mais potentiellement avant que les données soient réellement écrites sur le disque. L'évènement `complete` peut ainsi être livré plus vite qu'avant, cependant, il existe un petit risque que l'ensemble de la transaction soit perdu si l'OS s'effondre ou si un problème électrique survient avant que les données soient écrites. Comme de tels évènements catastrophiques sont rares, la plupart des utilisateurs n'ont pas à s'en soucier. Si vous devez vous assurer de la durabilité pour quelconque raison que ce soit (par exemple, vous stockez des données critiques qui ne peuvent être recalculées plus tard) vous pouvez forcer une transaction à écrire sur le disque avant que l'évènement `complete` ne soit délivré en créant une transaction utilisant un mode expérimental (non-standard) `readwriteflush` (se référer à {{domxref("IDBDatabase.transaction")}}.
 
 Vous pouvez accélérer l'accès à vos données en utilisant le bon mode et la bonne portée dans la transaction. Voici deux astuces :
 
@@ -387,7 +389,8 @@ request.onsuccess = function (event) {
 
 Ici, nous avons créé une variable `objectStore` et nous avons recherché un enregistrement d'un client, identifié par la valeur ssn (`444-44-4444`). Nous avons ensuite mis le résultat dans une variable (`data`), mis à jour la propriété `age` de cet objet, puis créé une deuxième requête (`requestUpdate`) pour mettre l'enregistrement du client dans l'`objectStore`, en écrasant la valeur précédente.
 
-> **Note :** dans ce cas, nous avons eu à spécifier une transaction `readwrite` puisque nous voulions écrire dans la base, et pas seulement la lire.
+> [!NOTE]
+> Dans ce cas, nous avons eu à spécifier une transaction `readwrite` puisque nous voulions écrire dans la base, et pas seulement la lire.
 
 ### Utiliser un curseur
 
@@ -425,7 +428,8 @@ objectStore.openCursor().onsuccess = function (event) {
 };
 ```
 
-> **Note :** Mozilla a aussi implémenté `getAll()` pour gérer ce cas (et `getAllKeys()`, qui est actuellement caché derrière la préférence `dom.indexedDB.experimental` dans about:config) . ceux-ci ne font pas partie d' IndexedDB standard, et peuvent disparaître dans le futur. Nous les avons inclus partceque nous pensons qu'ils sont utiles. Le code suivant fait exactement la même chose que ci-dessus :
+> [!NOTE]
+> Mozilla a aussi implémenté `getAll()` pour gérer ce cas (et `getAllKeys()`, qui est actuellement caché derrière la préférence `dom.indexedDB.experimental` dans about:config) . ceux-ci ne font pas partie d' IndexedDB standard, et peuvent disparaître dans le futur. Nous les avons inclus partceque nous pensons qu'ils sont utiles. Le code suivant fait exactement la même chose que ci-dessus :
 >
 > ```js
 > objectStore.getAll().onsuccess = function (event) {
@@ -637,7 +641,8 @@ Cette nouvelle fonctionnalité permet aux développeurs de spécifier une "local
 
 {{domxref("IDBIndex")}} a également eu de nouvelles propriétés qui lui ont été ajoutées pour spécifier la langue : `locale` (retourne la langue si elle est spécifiée, ou null sinon) et `isAutoLocale` (retourne `true` _(vrai)_ si l'index a été créé avec une "locale auto", ce qui signifie que la langue par défaut de la plate-forme est utilisée, sinon `false`).
 
-> **Note :** Cette fonctionnalité est couramment cachée derrière une marque (flag) — pour l'activer et l'expérimenter, aller à about:config et activez `dom.indexedDB.experimental`.
+> [!NOTE]
+> Cette fonctionnalité est couramment cachée derrière une marque (flag) — pour l'activer et l'expérimenter, aller à about:config et activez `dom.indexedDB.experimental`.
 
 ## Exemple complet d'IndexedDB
 

--- a/files/fr/web/api/intersectionobserver/takerecords/index.md
+++ b/files/fr/web/api/intersectionobserver/takerecords/index.md
@@ -7,7 +7,8 @@ slug: Web/API/IntersectionObserver/takeRecords
 
 La méthode **`takeRecords()`** de l'interface [`IntersectionObserver`](/fr/docs/Web/API/IntersectionObserver) renvoie un tableau d'objets [`IntersectionObserverEntry`](/fr/docs/Web/API/IntersectionObserverEntry), un pour chaque élément ciblé qui a subi un changement d'intersection depuis la dernière vérification des intersections, soit explicitement par un appel à cette méthode, soit implicitement par un appel automatique à la fonction de rappel de l'observateur.
 
-> **Note :** Si vous utilisez la fonction de rappel pour surveiller ces changements, vous n'avez pas besoin d'appeler cette méthode. L'appel de cette méthode efface la liste des intersections en attente, de sorte que la fonction de rappel ne sera pas exécutée.
+> [!NOTE]
+> Si vous utilisez la fonction de rappel pour surveiller ces changements, vous n'avez pas besoin d'appeler cette méthode. L'appel de cette méthode efface la liste des intersections en attente, de sorte que la fonction de rappel ne sera pas exécutée.
 
 ## Syntaxe
 

--- a/files/fr/web/api/intersectionobserver/thresholds/index.md
+++ b/files/fr/web/api/intersectionobserver/thresholds/index.md
@@ -21,7 +21,8 @@ Un tableau de seuils d'intersection, spécifiés lors de l'instanciation via `op
 
 Si aucune option `threshold` n'est fournie lors de l'instanciation avec `IntersectionObserver()`, la valeur par défaut de `thresholds` est définie à `[0]`.
 
-> **Attention :** Bien que l'objet d'`options` qu'on peut spécifier à la création d'un [`IntersectionObserver`](/fr/docs/Web/API/IntersectionObserver) possède une propriété champ nommée [`threshold`](/fr/docs/Web/API/IntersectionObserver/IntersectionObserver), cette propriété-ci s'appelle `thresholds` (avec un « s » supplémentaire donc). _Cela peut porter à confusion_. Si vous utilisez `thresholds` par erreur comme nom pour la propriété de l'objet `options`, le tableau porté par `thresholds` va se retrouver égal à `[0.0]`, ce qui n'est probablement pas ce à quoi vous vous attendiez. Le déboguage n'en sera que plus chaotique.
+> [!WARNING]
+> Bien que l'objet d'`options` qu'on peut spécifier à la création d'un [`IntersectionObserver`](/fr/docs/Web/API/IntersectionObserver) possède une propriété champ nommée [`threshold`](/fr/docs/Web/API/IntersectionObserver/IntersectionObserver), cette propriété-ci s'appelle `thresholds` (avec un « s » supplémentaire donc). _Cela peut porter à confusion_. Si vous utilisez `thresholds` par erreur comme nom pour la propriété de l'objet `options`, le tableau porté par `thresholds` va se retrouver égal à `[0.0]`, ce qui n'est probablement pas ce à quoi vous vous attendiez. Le déboguage n'en sera que plus chaotique.
 
 ## Spécifications
 

--- a/files/fr/web/api/keyboardevent/charcode/index.md
+++ b/files/fr/web/api/keyboardevent/charcode/index.md
@@ -11,7 +11,8 @@ La propriété en lecture seule {{domxref("KeyboardEvent.charCode")}} retourne l
 
 Pour des constantes équivalant ces codes numériques, voir {{ domxref("KeyboardEvent", "KeyEvent") }}.
 
-> **Note :** N'utilisez plus cette propriété, elle est dépréciée. Utilisez plutôt {{domxref("KeyboardEvent.key")}}.
+> [!NOTE]
+> N'utilisez plus cette propriété, elle est dépréciée. Utilisez plutôt {{domxref("KeyboardEvent.key")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/api/keyboardevent/index.md
+++ b/files/fr/web/api/keyboardevent/index.md
@@ -67,15 +67,18 @@ _Cette interface hérite également des propriétés de ses parents, {{domxref("
 
   - : Renvoie une {{domxref("DOMString")}} représentant la valeur de caractère de la touche. Si la touche correspond à un caractère imprimable, cette valeur est une chaîne Unicode non vide contenant ce caractère. Si la touche n'a pas de représentation imprimable, il s'agit d'une chaîne vide.
 
-    > **Note :** si la touche est utilisée comme une macro insérant plusieurs caractères, la valeur de cet attribut est la chaîne entière, pas seulement le premier caractère.
+    > [!NOTE]
+    > Si la touche est utilisée comme une macro insérant plusieurs caractères, la valeur de cet attribut est la chaîne entière, pas seulement le premier caractère.
 
-    > **Attention :** cela a été supprimé des DOM Level 3 Events. C'est pris en charge uniquement sur IE9 + et Microsoft Edge.
+    > [!WARNING]
+    > Cela a été supprimé des DOM Level 3 Events. C'est pris en charge uniquement sur IE9 + et Microsoft Edge.
 
 - {{domxref("KeyboardEvent.charCode")}} {{Deprecated_inline}}{{Readonlyinline}}
 
   - : Retourne un {{jsxref ("Number")}} représentant le numéro de référence Unicode de la touche ; cet attribut est utilisé uniquement par l'événement `keypress`. Pour les touches dont l'attribut `char` contient plusieurs caractères, il s'agit de la valeur Unicode du premier caractère de cet attribut. Dans Firefox 26, cela retourne des codes pour les caractères imprimables.
 
-    > **Attention :** cet attribut est obsolète : vous devriez utiliser {{domxref("KeyboardEvent.key")}} à la place, si disponible.
+    > [!WARNING]
+    > Cet attribut est obsolète : vous devriez utiliser {{domxref("KeyboardEvent.key")}} à la place, si disponible.
 
 - {{domxref("KeyboardEvent.code")}} {{Readonlyinline}}
   - : Retourne une {{domxref ("DOMString")}} avec la valeur du code de la touche représentée par l'événement.
@@ -95,7 +98,8 @@ _Cette interface hérite également des propriétés de ses parents, {{domxref("
 
   - : Retourne un {{jsxref("Number")}} représentant un code numérique dépendant du système et de l'implémentation, identifiant la valeur non modifiée de la touche pressée.
 
-    > **Attention :** cet attribut est obsolète. vous devriez utiliser {{domxref("KeyboardEvent.key")}} à la place, si disponible.
+    > [!WARNING]
+    > Cet attribut est obsolète. vous devriez utiliser {{domxref("KeyboardEvent.key")}} à la place, si disponible.
 
 - {{domxref("KeyboardEvent.keyIdentifier")}} {{Non-standard_inline}}{{deprecated_inline}}{{Readonlyinline}}
   - : Cette propriété n'est pas standard et a été abandonnée en faveur de {{domxref("KeyboardEvent.key")}}. Elle faisait partie d'une ancienne version de DOM Level 3 Events.
@@ -105,7 +109,8 @@ _Cette interface hérite également des propriétés de ses parents, {{domxref("
 
   - : Retourne une {{domxref("DOMString")}} représentant une chaîne de paramètres régionaux indiquant les paramètres régionaux pour lesquels le clavier est configuré. Cela peut être une chaîne vide si le navigateur ou l'appareil ne connaît pas les paramètres régionaux du clavier.
 
-    > **Note :** cela ne décrit pas les paramètres régionaux des données entrées. Un utilisateur peut utiliser une disposition du clavier donnée, tout en saisissant du texte dans une autre langue.
+    > [!NOTE]
+    > Cela ne décrit pas les paramètres régionaux des données entrées. Un utilisateur peut utiliser une disposition du clavier donnée, tout en saisissant du texte dans une autre langue.
 
 - {{domxref("KeyboardEvent.location")}}{{Readonlyinline}}
   - : Retourne un {{jsxref ("Number")}} représentant l'emplacement de la touche du clavier ou tout autre dispositif d'entrée.
@@ -139,7 +144,8 @@ _Cette interface hérite également des propriétés de ses parents, {{domxref("
 
   - : Retourne un {{jsxref("Number")}} représentant un code numérique dépendant du système et de l'implémentation, identifiant la valeur non modifiée de la touche pressée ; c'est généralement le même que `keyCode`.
 
-    > **Attention :** cet attribut est obsolète ; vous devriez utiliser {{domxref("KeyboardEvent.key")}} à la place, si disponible.
+    > [!WARNING]
+    > Cet attribut est obsolète ; vous devriez utiliser {{domxref("KeyboardEvent.key")}} à la place, si disponible.
 
 ## Notes
 
@@ -153,7 +159,8 @@ Les événements existants sont `keydown`, `keypress` et `keyup`. Pour la plupar
 
 Certaines touches inversent l'état d'un voyant lumineux ; celles-ci comprennent des touches telles que Caps Lock, Num Lock et Scroll Lock. Sous Windows et Linux, ces touches génèrent uniquement les événements `keydown` et `keyup`.
 
-> **Note :** Sous Linux, Firefox 12 et les versions antérieures ont également envoyé l'événement `keypress` pour ces touches.
+> [!NOTE]
+> Sous Linux, Firefox 12 et les versions antérieures ont également envoyé l'événement `keypress` pour ces touches.
 
 Cependant, une limitation du modèle d'événement Mac OS X fait que Caps Lock ne génère que l'événement `keydown`. Num Lock était supporté sur certains modèles d'ordinateurs portables plus anciens (modèles 2007 et plus anciens), mais depuis lors, Mac OS X n'a pas supporté Num Lock même sur les claviers externes. Sur les MacBooks plus anciens avec une touche Num Lock, cette touche ne génère aucun événement touche. Gecko supporte la touche Scroll Lock si un clavier externe ayant une touche F14 est connecté. Dans certaines anciennes versions de Firefox, cette touche générait un événement `keypress` ; ce comportement incohérent était le [bug Firefox 602812](https://bugzil.la/602812).
 
@@ -196,7 +203,8 @@ Avant Gecko 5.0, la gestion du clavier était moins cohérente entre les plates-
 - Linux
   - : Le comportement de l'événement dépend de la plate-forme particulière. Il se comportera comme Windows ou Mac suivant ce que fait le modèle d'événement natif.
 
-> **Note :** le déclenchement manuel d'un événement ne génère _pas_ l'action par défaut associée à cet événement. Par exemple, le déclenchement manuel d'un événement touche n'entraîne pas l'apparition de cette lettre dans une zone de saisie de texte ayant la focalisation. Dans le cas des événements de l'interface utilisateur, cela est important pour des raisons de sécurité, car cela empêche les scripts de simuler les actions de l'utilisateur interagissant avec le navigateur lui-même.
+> [!NOTE]
+> Le déclenchement manuel d'un événement ne génère _pas_ l'action par défaut associée à cet événement. Par exemple, le déclenchement manuel d'un événement touche n'entraîne pas l'apparition de cette lettre dans une zone de saisie de texte ayant la focalisation. Dans le cas des événements de l'interface utilisateur, cela est important pour des raisons de sécurité, car cela empêche les scripts de simuler les actions de l'utilisateur interagissant avec le navigateur lui-même.
 
 ## Exemple
 

--- a/files/fr/web/api/keyboardevent/key/index.md
+++ b/files/fr/web/api/keyboardevent/key/index.md
@@ -152,7 +152,8 @@ btnClearConsole.addEventListener("click", (e) => {
 
 {{EmbedLiveSample('Exemple_de_séquence_KeyboardEvent')}}
 
-> **Note :** Sur les navigateurs qui n'implémentent pas complètement l'interface {{domxref("InputEvent")}} qui est utilisée pour les événements {{domxref("HTMLElement/beforeinput_event", "beforeinput")}} et {{domxref("HTMLElement/input_event", "input")}}, vous pouvez obtenir une réponse incorrecte sur ces lignes du journal de sortie.
+> [!NOTE]
+> Sur les navigateurs qui n'implémentent pas complètement l'interface {{domxref("InputEvent")}} qui est utilisée pour les événements {{domxref("HTMLElement/beforeinput_event", "beforeinput")}} et {{domxref("HTMLElement/input_event", "input")}}, vous pouvez obtenir une réponse incorrecte sur ces lignes du journal de sortie.
 
 ### Cas 1
 

--- a/files/fr/web/api/keyboardevent/keyboardevent/index.md
+++ b/files/fr/web/api/keyboardevent/keyboardevent/index.md
@@ -34,7 +34,8 @@ event = new KeyboardEvent(typeArg, KeyboardEventInit);
     - `"keyCode"`, optionnel et par défaut `0`, de type `unsigned long`, qui définit la valeur du déprécié {{domxref("KeyboardEvent.keyCode")}}.
     - `"which"`, optionnel et par défaut `0`, de type `unsigned long`, qui définit la valeur du déprécié {{domxref("KeyboardEvent.which")}}.
 
-> **Note :** Le dictionnaire `KeyboardEventInit` accepte aussi les champs des dictionnaires {{domxref("UIEvent.UIEvent", "UIEventInit")}} et {{domxref("Event.Event", "EventInit")}}.
+> [!NOTE]
+> Le dictionnaire `KeyboardEventInit` accepte aussi les champs des dictionnaires {{domxref("UIEvent.UIEvent", "UIEventInit")}} et {{domxref("Event.Event", "EventInit")}}.
 
 ## Spécifications
 

--- a/files/fr/web/api/media_capture_and_streams_api/taking_still_photos/index.md
+++ b/files/fr/web/api/media_capture_and_streams_api/taking_still_photos/index.md
@@ -221,7 +221,8 @@ Comme pour chaque fois où il faut manipuler le contenu d'un canevas, on commenc
 
 Ensuite, si la hauteur et la largeur ne sont pas nulles (indiquant par là qu'il y a potentiellement des données d'image valides), on définit la largeur et la hauteur du canevas pour correspondre à celles de l'image capturée. Ensuite, on appelle [`drawImage()`](/fr/docs/Web/API/CanvasRenderingContext2D/drawImage) afin de dessiner l'image courante de la vidéo dans ce contexte, remplissant ainsi tous le canevas avec l'image.
 
-> **Note :** On tire parti de la ressemblance entre l'interface [`HTMLVideoElement`](/fr/docs/Web/API/HTMLVideoElement) et l'interface [`HTMLImageElement`](/fr/docs/Web/API/HTMLImageElement) lorsqu'on fournit `video` à `drawImage()`.
+> [!NOTE]
+> On tire parti de la ressemblance entre l'interface [`HTMLVideoElement`](/fr/docs/Web/API/HTMLVideoElement) et l'interface [`HTMLImageElement`](/fr/docs/Web/API/HTMLImageElement) lorsqu'on fournit `video` à `drawImage()`.
 
 Lorsque le canevas contient l'image capturée, on la convertit au format PNG à l'aide de [`HTMLCanvasElement.toDataURL()`](/fr/docs/Web/API/HTMLCanvasElement/toDataURL). Enfin, on appelle [`photo.setAttribute()`](/fr/docs/Web/API/Element/setAttribute) pour afficher l'image ainsi formée dans la boîte affichée à l'écran.
 

--- a/files/fr/web/api/mediadevices/getusermedia/index.md
+++ b/files/fr/web/api/mediadevices/getusermedia/index.md
@@ -9,7 +9,8 @@ La méthode **`MediaDevices.getUserMedia()`** invite l'utilisateur à autoriser 
 
 Il renvoie un {{jsxref("Promise")}} qui est résolu avec succès si l'utilisateur donne son autorisation; {{domxref("MediaStream")}} est fourni à ce moment-là. Si l'utilisateur refuse ou si le média correspondant n'est pas disponible, le {{jsxref("Promise")}} est rejetée avec respectivement `PermissionDeniedError` ou `NotFoundError`.
 
-> **Note :** Il est possible que le {{jsxref("Promise")}} renvoyé ne soit _ni_ résolu ni rejeté, car l'utilisateur n'est pas tenu de faire un choix. .
+> [!NOTE]
+> Il est possible que le {{jsxref("Promise")}} renvoyé ne soit _ni_ résolu ni rejeté, car l'utilisateur n'est pas tenu de faire un choix. .
 
 Généralement, vous accédez à l'objet {{domxref("MediaDevices")}} avec {{domxref("navigator.mediaDevices")}} , comme ceci:
 
@@ -123,7 +124,8 @@ Les rejets du {{jsxref("Promise")}} retourné sont effectués en passant un obje
 
   - : L'utilisateur a spécifié que l'instance de navigation actuelle n'a pas accès au périphérique; Ou l'utilisateur a refusé l'accès pour la session en cours; Ou l'utilisateur a refusé tout l'accès aux périphériques multimédias utilisateurs dans le monde entier.
 
-    > **Note :** Les versions plus anciennes de la spécification ont utilisé `SecurityError` pour cela à la place; `SecurityError` a pris une nouvelle signification.
+    > [!NOTE]
+    > Les versions plus anciennes de la spécification ont utilisé `SecurityError` pour cela à la place; `SecurityError` a pris une nouvelle signification.
 
 - `NotFoundError`
   - : Aucune piste multimédia du type spécifié n'a été trouvée satisfaisant les contraintes données.
@@ -133,7 +135,8 @@ Les rejets du {{jsxref("Promise")}} retourné sont effectués en passant un obje
 
   - : Aucun dispositif candidat répondant aux critères demandés. L'erreur est un objet de type `OverconstrainedError` et possède une propriété de `constraint` dont la valeur de chaîne est le nom d'une contrainte impossible à honorer et une propriété `message` contenant une chaîne lisible par l'homme expliquant le problème.
 
-    > **Note :** Étant donné que cette erreur peut se produire même lorsque l'utilisateur n'a pas encore autorisé l'utilisation du périphérique sous-jacent, il peut être utilisé comme surface d'empreinte digitale.
+    > [!NOTE]
+    > Étant donné que cette erreur peut se produire même lorsque l'utilisateur n'a pas encore autorisé l'utilisation du périphérique sous-jacent, il peut être utilisé comme surface d'empreinte digitale.
 
 - `SecurityError`
   - : Le support multimédia utilisateur est désactivé sur le {{domxref("Document")}} sur lequel `getUserMedia()` été appelé. Le mécanisme par lequel le support média utilisateur est activé/désactivé est laissé à la discrétion de l'utilisateur.

--- a/files/fr/web/api/mutationobserver/index.md
+++ b/files/fr/web/api/mutationobserver/index.md
@@ -49,7 +49,8 @@ new MutationObserver( function callback );
   </tbody>
 </table>
 
-> **Note :** La cible {{domxref("Node")}} ne doit pas être confondue avec celle de [NodeJS](https://nodejs.org/en/).
+> [!NOTE]
+> La cible {{domxref("Node")}} ne doit pas être confondue avec celle de [NodeJS](https://nodejs.org/en/).
 
 ### `observe()`
 
@@ -66,7 +67,8 @@ void observe( {{domxref("Node")}} target, MutationObserverInit options );
 - `options`
   - : Un objet du type [`MutationObserverInit`](#MutationObserverInit). Il spécifie quelles mutations DOM sont à rapporter.
 
-> **Note :** ajouter un observateur sur un élément revient à utiliser `addEventListener`. Si vous observez un élément plusieurs fois, cela n'a pas d'impact, dans le sens où, si vous observez un élément deux fois, la callback ne sera pas appelée deux fois, et vous n'aurez pas besoin d'appeler `disconnect()` deux fois. En d'autres termes, une fois qu'un élément est observé, l'observer à nouveau avec la même instance n'a pas d'effet. Cependant, si la callback est différente, un nouvel observateur sera ajouté.
+> [!NOTE]
+> Ajouter un observateur sur un élément revient à utiliser `addEventListener`. Si vous observez un élément plusieurs fois, cela n'a pas d'impact, dans le sens où, si vous observez un élément deux fois, la callback ne sera pas appelée deux fois, et vous n'aurez pas besoin d'appeler `disconnect()` deux fois. En d'autres termes, une fois qu'un élément est observé, l'observer à nouveau avec la même instance n'a pas d'effet. Cependant, si la callback est différente, un nouvel observateur sera ajouté.
 
 ### `disconnect()`
 
@@ -76,7 +78,8 @@ L'instance `MutationObserver` cesse de recevoir les notifications de mutations D
 void disconnect();
 ```
 
-> **Note :** Selon la [spécification](https://dom.spec.whatwg.org/#garbage-collection), un `MutationObserver` est supprimé par le garbage collector si l'élément cible est supprimé.
+> [!NOTE]
+> Selon la [spécification](https://dom.spec.whatwg.org/#garbage-collection), un `MutationObserver` est supprimé par le garbage collector si l'élément cible est supprimé.
 
 ### `takeRecords()`
 
@@ -93,7 +96,8 @@ Array takeRecords();
 
 `MutationObserverInit` est un objet pouvant avoir les propriétés suivantes&nbsp;:
 
-> **Note :** Au moins une propriété parmi `childList`, `attributes` ou `characterData` doit être initialisée à `true`, sinon l'erreur <i lang="en">"An invalid or illegal string was specified</i>" sera émise.
+> [!NOTE]
+> Au moins une propriété parmi `childList`, `attributes` ou `characterData` doit être initialisée à `true`, sinon l'erreur <i lang="en">"An invalid or illegal string was specified</i>" sera émise.
 
 <table class="standard-table">
   <tbody>

--- a/files/fr/web/api/namednodemap/index.md
+++ b/files/fr/web/api/namednodemap/index.md
@@ -9,7 +9,8 @@ L'interface **`NamedNodeMap`** représente une collection d'objets {{domxref("At
 
 Un objet `NamedNodeMap` est _vivant_ et sera automatiquement mis à jour si des modifications sont apportées à son contenu (que cela provienne d'une source interne ou externe).
 
-> **Note :** Bien qu'intitulée `NamedNodeMap`, cette interface ne manipule pas d'objets {{domxref("Node")}} mais des objets {{domxref("Attr")}}. Ces derniers étaient à l'origine (et le sont toujours pour certaines implémentations) une classe spécialisée de {{domxref("Node")}}.
+> [!NOTE]
+> Bien qu'intitulée `NamedNodeMap`, cette interface ne manipule pas d'objets {{domxref("Node")}} mais des objets {{domxref("Attr")}}. Ces derniers étaient à l'origine (et le sont toujours pour certaines implémentations) une classe spécialisée de {{domxref("Node")}}.
 
 ## Propriétés
 

--- a/files/fr/web/api/navigator/geolocation/index.md
+++ b/files/fr/web/api/navigator/geolocation/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Navigator/geolocation
 
 **`Navigator.geolocation`** est une propriété en lecture seule, qui retoune un objet {{domxref("Geolocation")}} donnant accès aux contenus web de localisation de l'appareil. Ceci permet à un site Internet ou à une application d'offrir des résultats personnalisés basés sur la localisation des utilisateurs.
 
-> **Note :** Pour des raisons de sécurité, quand une page web essaie d'accéder aux informations de localisation, l'utilisateur reçoit une notification qui lui demande la permission d'activer cette fonctionnalité. Chaque navigateur a sa propre politique et ses propres méthodes pour demander cette permission.
+> [!NOTE]
+> Pour des raisons de sécurité, quand une page web essaie d'accéder aux informations de localisation, l'utilisateur reçoit une notification qui lui demande la permission d'activer cette fonctionnalité. Chaque navigateur a sa propre politique et ses propres méthodes pour demander cette permission.
 
 ## Syntaxe
 

--- a/files/fr/web/api/navigator/getusermedia/index.md
+++ b/files/fr/web/api/navigator/getusermedia/index.md
@@ -9,7 +9,8 @@ La méthode obsolète **Navigator.getUserMedia()** demande à la personne la per
 
 Si la permission est accordée, un objet `MediaStream` dont les pistes proviennent de ces appareils est transmis à la fonction de rappel. Si la permission est refusée, que le périphérique n'existe pas, ou qu'une erreur quelconque se produit, c'est la fonction de rappel d'erreur qui est exécutée, avec comme paramètre un objet [`MediaStreamError`](/fr/docs/Web/API/MediaStreamError) qui décrit l'erreur qui vient de se produire. Si l'utilisatrice ou l'utilisateur ne fait aucun choix, aucune des deux fonctions de rappel n'est exécutée.
 
-> **Note :** Il s'agit d'une méthode historique, veuillez utiliser la méthode [`navigator.mediaDevices.getUserMedia()`](/fr/docs/Web/API/MediaDevices/getUserMedia) à la place. Bien qu'elle ne soit pas techniquement obsolète, l'utilisation de fonctions de rappels pour celle-ci est indiqué comme obsolète dans la spécification qui encourage l'utilisation de la nouvelle version utilisant les promesses.
+> [!NOTE]
+> Il s'agit d'une méthode historique, veuillez utiliser la méthode [`navigator.mediaDevices.getUserMedia()`](/fr/docs/Web/API/MediaDevices/getUserMedia) à la place. Bien qu'elle ne soit pas techniquement obsolète, l'utilisation de fonctions de rappels pour celle-ci est indiqué comme obsolète dans la spécification qui encourage l'utilisation de la nouvelle version utilisant les promesses.
 
 ## Syntaxe
 
@@ -92,7 +93,8 @@ Voir [`permission: audio-capture`](/fr/docs/Web/Apps/Developing/App_permissions#
 
 ## Compatibilité des navigateurs
 
-> **Attention :** Du nouveau code devrait utiliser [`MediaDevices.getUserMedia()`](/fr/docs/Web/API/MediaDevices/getUserMedia) à la place.
+> [!WARNING]
+> Du nouveau code devrait utiliser [`MediaDevices.getUserMedia()`](/fr/docs/Web/API/MediaDevices/getUserMedia) à la place.
 
 {{Compat}}
 

--- a/files/fr/web/api/navigator/registerprotocolhandler/index.md
+++ b/files/fr/web/api/navigator/registerprotocolhandler/index.md
@@ -16,7 +16,8 @@ registerProtocolHandler(schema, url);
 registerProtocolHandler(schema, url, titre);
 ```
 
-> **Note :** La version avec l'argument déprécié `titre` est recommandée pour des raisons de compatibilité. Voir les informations sur les paramètres ci-après.
+> [!NOTE]
+> La version avec l'argument déprécié `titre` est recommandée pour des raisons de compatibilité. Voir les informations sur les paramètres ci-après.
 
 ### Paramètres
 
@@ -29,14 +30,16 @@ registerProtocolHandler(schema, url, titre);
   - : Une chaîne de caractères qui contient l'URL du gestionnaire.
     **Cette URL doit inclure `%s`**, comme emplacement à remplacer avec l'URL [échappée](/fr/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) à gérer.
 
-    > **Note :** L'URL du gestionnaire doit également utiliser le schéma `https`. Les anciens navigateurs prenaient aussi en charge `http`.
+    > [!NOTE]
+    > L'URL du gestionnaire doit également utiliser le schéma `https`. Les anciens navigateurs prenaient aussi en charge `http`.
 
 - `titre` {{deprecated_inline}}
 
   - : Un titre, lisible par un humain, pour le gestionnaire.
     **Cette valeur sera affichée à l'utilisatrice ou à l'utilisateur**, par exemple pour lui demander «&nbsp;Autorisez-vous ce site à gérer les liens \[schema]&nbsp;?&nbsp;» ou pour lister les gestionnaires enregistrés dans les paramètres du navigateur.
 
-    > **Note :** Le titre a été retiré de la spécification en raison des risques d'usurpation.
+    > [!NOTE]
+    > Le titre a été retiré de la spécification en raison des risques d'usurpation.
     > Ce paramètre `titre` devrait toujours être défini, car certains navigateurs **le considèrent obligatoire** (voir [le tableau de compatibilité qui suit](#compatibilité_des_navigateurs)).
     > Les navigateurs qui implémentent la spécification à jour accepteront probablement ce paramètre supplémentaire en l'ignorant.
 

--- a/files/fr/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
+++ b/files/fr/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
@@ -37,7 +37,8 @@ Lorsqu'un navigateur exécutera ce code, il devra demander la permission d'autor
 
 ![](protocolregister.png)
 
-> **Note :** Le modèle d'URL fourni lors de l'enregistrement **doit** provenir de la même origine que la page web qui demande l'enregistrement, sinon celle-ci échouera. Ainsi, `http://example.com/homepage.html` pourra enregistrer un gestionnaire de protocole pour `http://example.com/handle_mailto/%s`, mais pas pour `http://example.org/handle_mailto/%s`.
+> [!NOTE]
+> Le modèle d'URL fourni lors de l'enregistrement **doit** provenir de la même origine que la page web qui demande l'enregistrement, sinon celle-ci échouera. Ainsi, `http://example.com/homepage.html` pourra enregistrer un gestionnaire de protocole pour `http://example.com/handle_mailto/%s`, mais pas pour `http://example.org/handle_mailto/%s`.
 
 Enregistrer plus d'une fois le même gestionnaire de protocole déclenchera l'apparition d'une notification différente, indiquant que le gestionnaire de protocole est déjà enregistré. Aussi, mieux vaut effectuer une vérification préalable dans le code pour voir si le gestionnaire n'est pas déjà enregistré, comme illustré dans l'exemple qui suit.
 
@@ -82,7 +83,8 @@ http://www.google.com/?uri=web+burger:cheeseburger
 
 Un code côté serveur peut extraire les paramètres de la chaîne de requête et effectuer l'action désirée.
 
-> **Note :** Le code côté serveur reçoit le contenu **entier** de l'attribut `href`. Cela signifie que le serveur doit traiter la chaîne pour retirer le protocole des données.
+> [!NOTE]
+> Le code côté serveur reçoit le contenu **entier** de l'attribut `href`. Cela signifie que le serveur doit traiter la chaîne pour retirer le protocole des données.
 
 #### Exemple
 

--- a/files/fr/web/api/node/clonenode/index.md
+++ b/files/fr/web/api/node/clonenode/index.md
@@ -20,7 +20,8 @@ var dupNode = node.cloneNode([deep]);
 - deep _{{optional_inline}} (profondeur)_
   - : `true` (_vrai_) si les enfants du noeud doivent aussi être clonés ou `false` (_faux_) si seul le noeud spécifié doit l'être.
 
-> **Note :** Dans la spécification DOM4 (telle qu'implémentée dans Gecko 13.0), `deep` est un argument facultatif. S'il est omis, la méthode agit comme si la valeur de `deep` était **`true`** par défaut, elle utilise le clonage profond comme comportement par défaut. Pour créer un clone superficiel, `deep` doit être défini sur `false`.
+> [!NOTE]
+> Dans la spécification DOM4 (telle qu'implémentée dans Gecko 13.0), `deep` est un argument facultatif. S'il est omis, la méthode agit comme si la valeur de `deep` était **`true`** par défaut, elle utilise le clonage profond comme comportement par défaut. Pour créer un clone superficiel, `deep` doit être défini sur `false`.
 >
 > Le comportement a été modifié dans la dernière spécification et, s'il est omis, la méthode doit agir comme si la valeur de `deep` était **`false`**. Bien que ce soit toujours facultatif, vous devriez toujours fournir l'argument `deep` pour la compatibilité amont et aval. Avec Gecko 28.0, la console a averti les développeurs de ne pas omettre l'argument. À partir de Gecko 29.0, un clone superficiel est défini par défaut au lieu d'un clone profond.
 

--- a/files/fr/web/api/node/comparedocumentposition/index.md
+++ b/files/fr/web/api/node/comparedocumentposition/index.md
@@ -38,9 +38,11 @@ if (
 }
 ```
 
-> **Note :** Parce que le résultat renvoyé par `compareDocumentPosition` est un masque de bits, des [opérateurs binaires](/fr/docs/Web/JavaScript/Reference/Opérateurs/Opérateurs_binaires) doivent être utilisés pour des résultats significatifs.
+> [!NOTE]
+> Parce que le résultat renvoyé par `compareDocumentPosition` est un masque de bits, des [opérateurs binaires](/fr/docs/Web/JavaScript/Reference/Opérateurs/Opérateurs_binaires) doivent être utilisés pour des résultats significatifs.
 
-> **Note :** La première instruction utilise l' `item(0)` de la méthode [NodeList](/fr/docs/Web/API/NodeList/item) , qui est l'équivalent de `getElementsByTagName('head')[0].`
+> [!NOTE]
+> La première instruction utilise l' `item(0)` de la méthode [NodeList](/fr/docs/Web/API/NodeList/item) , qui est l'équivalent de `getElementsByTagName('head')[0].`
 
 ## Spécifications
 

--- a/files/fr/web/api/node/index.md
+++ b/files/fr/web/api/node/index.md
@@ -69,12 +69,14 @@ _Hérite les propriétés de son parent {{domxref("EventTarget")}}_.
 - {{DOMxRef("Node.localName")}} {{deprecated_inline}}{{readonlyInline}}
   - : Retourne un {{domxref("DOMString")}} représentant la partie locale du nom d'un élément.
 
-> **Note :** Dans Firefox 3.5 et versions antérieures, la propriété saisit le nom local pour les éléments HTML (mais pas les éléments XHTML). Dans les versions ultérieures, cela ne se produit pas, donc la propriété est en minuscule pour HTML et XHTML.
+> [!NOTE]
+> Dans Firefox 3.5 et versions antérieures, la propriété saisit le nom local pour les éléments HTML (mais pas les éléments XHTML). Dans les versions ultérieures, cela ne se produit pas, donc la propriété est en minuscule pour HTML et XHTML.
 
 - {{DOMxRef("Node.namespaceURI")}} {{deprecated_inline}}{{readonlyInline}}
   - : L'URI du "Namespace" de ce nom, ou `null` s'il n'y en a pas.
 
-> **Note :** Dans Firefox 3.5 et versions antérieures, les éléments HTML ne contiennent aucun "namespace". Dans les versions ultérieures, les éléments HTML sont dans le "namespace" [`https://www.w3.org/1999/xhtml/`](https://www.w3.org/1999/xhtml/) pour HTML et XML.
+> [!NOTE]
+> Dans Firefox 3.5 et versions antérieures, les éléments HTML ne contiennent aucun "namespace". Dans les versions ultérieures, les éléments HTML sont dans le "namespace" [`https://www.w3.org/1999/xhtml/`](https://www.w3.org/1999/xhtml/) pour HTML et XML.
 
 - {{DOMxRef("Node.prefix")}} {{deprecated_inline}}{{readonlyInline}}
   - : Est une {{domxref("DOMString")}} représentant le préfixe de l'espace de nom du nœud ou `null` si aucun préfixe n'est spécifié.

--- a/files/fr/web/api/nodelist/index.md
+++ b/files/fr/web/api/nodelist/index.md
@@ -7,7 +7,8 @@ slug: Web/API/NodeList
 
 Les objets **`NodeList`** sont des collections de nœuds comme celles retournées par {{domxref("Node.childNodes")}} et la méthode {{domxref("document.querySelectorAll()")}}.
 
-> **Note :** Bien que `NodeList` ne soit pas un tableau (`Array`), il est possible d'itérer dessus en utilisant `forEach()`. Il peut également être converti en tableau (`Array`) en utilisant {{jsxref("Array.from()")}}.
+> [!NOTE]
+> Bien que `NodeList` ne soit pas un tableau (`Array`), il est possible d'itérer dessus en utilisant `forEach()`. Il peut également être converti en tableau (`Array`) en utilisant {{jsxref("Array.from()")}}.
 >
 > Néanmoins certains vieux navigateurs n'ont pas encore implémenté `NodeList.forEach()` ni `Array.from()`. Mais ces limitations peuvent être contournées en utilisant {{jsxref("Array.forEach()", "Array.prototype.forEach()")}} (plus dans ce document).
 

--- a/files/fr/web/api/notification/actions/index.md
+++ b/files/fr/web/api/notification/actions/index.md
@@ -9,7 +9,8 @@ La propriété **`actions`** en lecture seule de l'interface {{domxref ("Notific
 
 Il s'agit d'une liste des actions définies par l'application que l'utilisateur peut choisir de prendre directement depuis le contexte d'une notification.
 
-> **Note :** Le périphérique et l'agent utilisateur peuvent ne pouvoir afficher qu'un nombre limité d'actions (en raison, par exemple, d'un espace d'écran limité). Cette limite peut être déduite de {{DOMxRef ("Notification.maxActions")}}.
+> [!NOTE]
+> Le périphérique et l'agent utilisateur peuvent ne pouvoir afficher qu'un nombre limité d'actions (en raison, par exemple, d'un espace d'écran limité). Cette limite peut être déduite de {{DOMxRef ("Notification.maxActions")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/api/notification/close/index.md
+++ b/files/fr/web/api/notification/close/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Notification/close
 
 La méthode `close()` de l'interface {{domxref("Notification")}} est utilisée pour fermer / supprimer une notification précédemment affichée.
 
-> **Note :** Cette API ne doit pas être utilisée uniquement pour supprimer la notification de l'écran après un délai fixe, car cette méthode supprimera également la notification de toute barre de notification, empêchant ainsi les utilisateurs d'interagir avec elle après son affichage initial. Une utilisation valable de cette API serait de supprimer une notification qui n'est plus pertinente (par exemple, l'utilisateur a déjà lu la notification sur la page Web dans le cas d'une application de messagerie ou la chanson suivante est déjà en cours de lecture dans une application musicale).
+> [!NOTE]
+> Cette API ne doit pas être utilisée uniquement pour supprimer la notification de l'écran après un délai fixe, car cette méthode supprimera également la notification de toute barre de notification, empêchant ainsi les utilisateurs d'interagir avec elle après son affichage initial. Une utilisation valable de cette API serait de supprimer une notification qui n'est plus pertinente (par exemple, l'utilisateur a déjà lu la notification sur la page Web dans le cas d'une application de messagerie ou la chanson suivante est déjà en cours de lecture dans une application musicale).
 
 ## Syntaxe
 

--- a/files/fr/web/api/notification/dir/index.md
+++ b/files/fr/web/api/notification/dir/index.md
@@ -21,7 +21,8 @@ Une {{domxref ("DOMString")}} spécifiant la direction du texte. Les valeurs pos
 - `ltr`: de gauche à droite.
 - `rtl` : de droite à gauche.
 
-> **Note :** La plupart des navigateurs semblent ignorer les paramètres explicites de ltr et rtl, et utilisent simplement le paramètre à l'échelle du navigateur.
+> [!NOTE]
+> La plupart des navigateurs semblent ignorer les paramètres explicites de ltr et rtl, et utilisent simplement le paramètre à l'échelle du navigateur.
 
 ## Spécifications
 

--- a/files/fr/web/api/notification/index.md
+++ b/files/fr/web/api/notification/index.md
@@ -131,7 +131,8 @@ function notifyMe() {
 
 Nous ne montrons plus d'exemple en direct sur cette page, car Chrome et Firefox n'autorisent plus les demandes de notification des {{htmlelement ("iframe")}}s d'origine croisée, avec d'autres navigateurs à suivre. Pour voir un exemple en action, consultez notre [exemple de liste de tâches](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) (voir également l'[application en cours d'exécution](https://mdn.github.io/dom-examples/to-do-notifications/).)
 
-> **Note :** Dans l'exemple ci-dessus, nous générons des notifications en réponse à un geste de l'utilisateur (en cliquant sur un bouton). Il ne s'agit pas seulement d'une bonne pratique - vous ne devriez pas envoyer de spam aux utilisateurs avec des notifications qu'ils n'acceptent pas - mais les navigateurs suivants interdiront explicitement les notifications non déclenchées en réponse à un geste de l'utilisateur. Firefox le fait déjà depuis la version 72, par exemple.
+> [!NOTE]
+> Dans l'exemple ci-dessus, nous générons des notifications en réponse à un geste de l'utilisateur (en cliquant sur un bouton). Il ne s'agit pas seulement d'une bonne pratique - vous ne devriez pas envoyer de spam aux utilisateurs avec des notifications qu'ils n'acceptent pas - mais les navigateurs suivants interdiront explicitement les notifications non déclenchées en réponse à un geste de l'utilisateur. Firefox le fait déjà depuis la version 72, par exemple.
 
 ## Spécifications
 

--- a/files/fr/web/api/notification/requestpermission_static/index.md
+++ b/files/fr/web/api/notification/requestpermission_static/index.md
@@ -5,9 +5,11 @@ slug: Web/API/Notification/requestPermission_static
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 
-> **Note :** Cette fonctionnalité n'est pas disponible dans {{domxref("SharedWorker")}}
+> [!NOTE]
+> Cette fonctionnalité n'est pas disponible dans {{domxref("SharedWorker")}}
 
-> **Note :** Safari utilise toujours la syntaxe de function de rappel (callback ) pour obtenir l'autorisation. Lisez [Utilisation de l'API Notifications](/fr/docs/Web/API/Notifications_API/Using_the_Notifications_API) pour un bon exemple de la fonctionnalité de détection et d'exécution du code le cas échéant.
+> [!NOTE]
+> Safari utilise toujours la syntaxe de function de rappel (callback ) pour obtenir l'autorisation. Lisez [Utilisation de l'API Notifications](/fr/docs/Web/API/Notifications_API/Using_the_Notifications_API) pour un bon exemple de la fonctionnalité de détection et d'exécution du code le cas échéant.
 
 La méthode **`requestPermission()`** de l'interface {{domxref ("Notification")}} demande l'autorisation à l'utilisateur pour l'origine actuelle d'afficher des notifications.
 
@@ -79,7 +81,8 @@ function notifyMe() {
 
 Nous ne montrons plus d'exemple en direct sur cette page, car Chrome et Firefox n'autorisent plus les demandes de notification des {{htmlelement ("iframe")}}s d'origine croisée, avec d'autres navigateurs à suivre. Pour voir un exemple en action, consultez notre [exemple de liste de tâches](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) (voir également l'[application en cours d'exécution](https://mdn.github.io/dom-examples/to-do-notifications/).)
 
-> **Note :** Dans l'exemple ci-dessus, nous générons des notifications en réponse à un geste de l'utilisateur (en cliquant sur un bouton). Il ne s'agit pas seulement d'une bonne pratique - vous ne devriez pas envoyer de spam aux utilisateurs avec des notifications qu'ils n'acceptent pas - mais les navigateurs suivants interdiront explicitement les notifications non déclenchées en réponse à un geste de l'utilisateur. Firefox le fait déjà depuis la version 72, par exemple.
+> [!NOTE]
+> Dans l'exemple ci-dessus, nous générons des notifications en réponse à un geste de l'utilisateur (en cliquant sur un bouton). Il ne s'agit pas seulement d'une bonne pratique - vous ne devriez pas envoyer de spam aux utilisateurs avec des notifications qu'ils n'acceptent pas - mais les navigateurs suivants interdiront explicitement les notifications non déclenchées en réponse à un geste de l'utilisateur. Firefox le fait déjà depuis la version 72, par exemple.
 
 ## Spécifications
 

--- a/files/fr/web/api/notifications_api/index.md
+++ b/files/fr/web/api/notifications_api/index.md
@@ -32,7 +32,8 @@ Lors de la demande d'autorisation, une boîte de dialogue apparaît dans le navi
 
 Ainsi, on peut choisir d'autoriser les notifications d'une origine donnée ou les bloquer. Une fois le choix effectué, le paramètre persistera généralement pour la session en cours.
 
-> **Note :** Pour Firefox, à partir de Firefox 44, les permissions pour les notifications et [l'API Push](/fr/docs/Web/API/Push_API) ont été fusionnées. Ainsi, si on autorise les notifications, les messages et notifications <i lang="en">push</i> seront également autorisées.
+> [!NOTE]
+> Pour Firefox, à partir de Firefox 44, les permissions pour les notifications et [l'API Push](/fr/docs/Web/API/Push_API) ont été fusionnées. Ainsi, si on autorise les notifications, les messages et notifications <i lang="en">push</i> seront également autorisées.
 
 ### Création de la notification
 
@@ -40,7 +41,8 @@ Ensuite, on peut créer une nouvelle notification à l'aide du constructeur [`No
 
 En outre, la spécification de l'API Notifications spécifie un certain nombre d'ajouts à l'[API ServiceWorker](/fr/docs/Web/API/Service_Worker_API), qui permettent aux <i lang="en">service worker</i> de déclencher des notifications.
 
-> **Note :** Pour mieux savoir comment utiliser les notifications au sein de votre propre application, lisez [Utiliser l'API Notifications](/fr/docs/Web/API/Notifications_API/Using_the_Notifications_API).
+> [!NOTE]
+> Pour mieux savoir comment utiliser les notifications au sein de votre propre application, lisez [Utiliser l'API Notifications](/fr/docs/Web/API/Notifications_API/Using_the_Notifications_API).
 
 ## Interfaces
 

--- a/files/fr/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/fr/web/api/notifications_api/using_the_notifications_api/index.md
@@ -60,7 +60,8 @@ Notification.requestPermission((resultat) => {
 
 Cette version accepte en paramètre une fonction de rappel qui sera appelée une fois que l'utilisatrice ou l'utilisateur aura répondu à la demande de permission.
 
-> **Note :** Il n'est pas possible de tester avec certitude la prise en charge du la forme de `Notification.requestPermission()` avec les promesses. S'il vous faut prendre en charge les navigateurs plus anciens, utilisez la version basée sur les fonctions de rappel, même si elle est dépréciée, elle fonctionne dans les navigateurs récents. Voir [le tableau de compatibilité](/fr/docs/Web/API/Notification/requestPermission_static#compatibilité_des_navigateurs) pour plus d'informations.
+> [!NOTE]
+> Il n'est pas possible de tester avec certitude la prise en charge du la forme de `Notification.requestPermission()` avec les promesses. S'il vous faut prendre en charge les navigateurs plus anciens, utilisez la version basée sur les fonctions de rappel, même si elle est dépréciée, elle fonctionne dans les navigateurs récents. Voir [le tableau de compatibilité](/fr/docs/Web/API/Notification/requestPermission_static#compatibilité_des_navigateurs) pour plus d'informations.
 
 ### Exemple
 
@@ -120,9 +121,11 @@ document.addEventListener("visibilitychange", () => {
 });
 ```
 
-> **Note :** Cette API ne devrait pas être utilisée pour retirer la notification de l'écran après un délai donné, car elle supprimera également la notification de la liste des notifications et empêchera toute interaction avec celle-ci après qu'elle a initialement été affichée.
+> [!NOTE]
+> Cette API ne devrait pas être utilisée pour retirer la notification de l'écran après un délai donné, car elle supprimera également la notification de la liste des notifications et empêchera toute interaction avec celle-ci après qu'elle a initialement été affichée.
 
-> **Note :** Lorsque vous recevez un évènement `close`, il n'y a aucune garantie que celui-ci provienne de l'utilisatrice ou de l'utilisateur. Cela correspond à la spécification qui indique&nbsp;: «&nbsp;lorsqu'une notification est fermée, que ce soit par la plateforme sous-jacente ou par l'utilisateur, l'étape de fermeture correspondante doit être exécutée.&nbsp;».
+> [!NOTE]
+> Lorsque vous recevez un évènement `close`, il n'y a aucune garantie que celui-ci provienne de l'utilisatrice ou de l'utilisateur. Cela correspond à la spécification qui indique&nbsp;: «&nbsp;lorsqu'une notification est fermée, que ce soit par la plateforme sous-jacente ou par l'utilisateur, l'étape de fermeture correspondante doit être exécutée.&nbsp;».
 
 ## Évènements relatifs aux notifications
 

--- a/files/fr/web/api/offscreencanvas/index.md
+++ b/files/fr/web/api/offscreencanvas/index.md
@@ -7,7 +7,8 @@ slug: Web/API/OffscreenCanvas
 
 L'interface `OffscreenCanvas` fournit un canevas qui peut être restitué hors écran. Il est disponible dans les contextes à la fois window et [worker](/fr/docs/Web/API/Web_Workers_API).
 
-> **Note :** Cette API n'est actuellement implémentée que pour les contextes [WebGL1](/fr/docs/Web/API/WebGLRenderingContext) et[WebGL2](/fr/docs/Web/API/WebGL2RenderingContext). Voir [bug Firefox 801176](https://bugzil.la/801176) pour le support de l'[API canvas](/fr/docs/Web/API/Canvas_API) depuis les workers.
+> [!NOTE]
+> Cette API n'est actuellement implémentée que pour les contextes [WebGL1](/fr/docs/Web/API/WebGLRenderingContext) et[WebGL2](/fr/docs/Web/API/WebGL2RenderingContext). Voir [bug Firefox 801176](https://bugzil.la/801176) pour le support de l'[API canvas](/fr/docs/Web/API/Canvas_API) depuis les workers.
 
 ## Constructeur
 

--- a/files/fr/web/api/payment_request_api/index.md
+++ b/files/fr/web/api/payment_request_api/index.md
@@ -23,7 +23,8 @@ Pour demander un paiement, une page web crée un {{domxref("PaymentRequest")}} o
 
 Vous pouvez trouver un guide complet dans l'article [Using the Payment Request API](/fr/docs/Web/API/Payment_Request_API/Using_the_Payment_Request_API).
 
-> **Note :** L'API est disponible à l'intérieur des éléments cross-origin {{htmlelement("iframe")}} seulement si on leur a affecté l'attribut [`allowpaymentrequest`](/fr/docs/Web/HTML/Element/iframe#allowpaymentrequest).
+> [!NOTE]
+> L'API est disponible à l'intérieur des éléments cross-origin {{htmlelement("iframe")}} seulement si on leur a affecté l'attribut [`allowpaymentrequest`](/fr/docs/Web/HTML/Element/iframe#allowpaymentrequest).
 
 ## Interfaces
 

--- a/files/fr/web/api/performance/index.md
+++ b/files/fr/web/api/performance/index.md
@@ -9,7 +9,8 @@ L'interface **`Performance`** donne accès à des informations liées aux perfor
 
 Un objet de ce type peut être obtenu en appelant l'attribut en lecture seule {{domxref("window.performance")}}.
 
-> **Note :** Cette interface et ses attributs sont accessibles aux [Web Workers](/fr/docs/Web/API/Web_Workers_API) via [`WorkerGlobalScope.performance`](/fr/docs/Web/API/WorkerGlobalScope/performance) sauf dans les cas cités ci-dessous. Notez également que les marqueurs et les mesures de performance sont définis par contexte. Si vous créez un marqueur dans le processus principal (ou un autre Web Worker), vous ne pourrez pas le voir dans le processus du Web Worker, et réciproquement.
+> [!NOTE]
+> Cette interface et ses attributs sont accessibles aux [Web Workers](/fr/docs/Web/API/Web_Workers_API) via [`WorkerGlobalScope.performance`](/fr/docs/Web/API/WorkerGlobalScope/performance) sauf dans les cas cités ci-dessous. Notez également que les marqueurs et les mesures de performance sont définis par contexte. Si vous créez un marqueur dans le processus principal (ou un autre Web Worker), vous ne pourrez pas le voir dans le processus du Web Worker, et réciproquement.
 
 ## Propriétés
 
@@ -19,13 +20,15 @@ _L'interface `Performance` n'hérite d'aucune propriété._
 
   - : {{domxref("PerformanceNavigation")}} est un objet qui fournit des informations contextuelles sur les opérations incluses dans les indicateurs de `timing`, notamment si la page a été chargée ou actualisée, combien de redirections ont été effectuées, etc…
 
-    > **Note :** Indisponible dans les Web Workers.
+    > [!NOTE]
+    > Indisponible dans les Web Workers.
 
 - {{domxref("performance.timing")}} {{readonlyInline}} {{deprecated_inline}}
 
   - : {{domxref("PerformanceTiming")}} est un objet contenant des informations de performance liées à la latence.
 
-    > **Note :** Indisponible dans les Web Workers.
+    > [!NOTE]
+    > Indisponible dans les Web Workers.
 
 - {{domxref("performance.memory")}} {{readonlyInline}} {{Non-standard_inline}}
   - : Une extension _non standard_ ajoutée dans Chrome, cette propriété fournit à un objet des informations de base sur l'utilisation de la mémoire. _Vous **ne devriez pas utiliser** cette API non standard._

--- a/files/fr/web/api/performance/navigation/index.md
+++ b/files/fr/web/api/performance/navigation/index.md
@@ -11,7 +11,8 @@ L'ancienne propriété **`Performance.navigation`** en lecture seule renvoie un 
 
 Cette propriété n'est pas disponible pour les <i lang="en">workers</i>.
 
-> **Attention :** Cette propriété est dépréciée dans la [spécification de mesure des durées de navigation (<i lang="en">Navigation Timing</i>)](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette propriété est dépréciée dans la [spécification de mesure des durées de navigation (<i lang="en">Navigation Timing</i>)](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 ## Valeur
 

--- a/files/fr/web/api/performance/timing/index.md
+++ b/files/fr/web/api/performance/timing/index.md
@@ -11,7 +11,8 @@ L'ancienne propriété **`Performance.timing`** en lecture seule renvoie un obje
 
 Cette propriété n'est pas disponible pour les <i lang="en">workers</i>.
 
-> **Attention :** Cette propriété est dépréciée dans la [spécification de mesure des durées de navigation (<i lang="en">Navigation Timing</i>)](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette propriété est dépréciée dans la [spécification de mesure des durées de navigation (<i lang="en">Navigation Timing</i>)](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 ## Valeur
 

--- a/files/fr/web/api/performanceelementtiming/element/index.md
+++ b/files/fr/web/api/performanceelementtiming/element/index.md
@@ -36,7 +36,8 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ entryTypes: ["element"] });
 ```
 
-> **Note :** Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
+> [!NOTE]
+> Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
 
 ## Spécifications
 

--- a/files/fr/web/api/performanceelementtiming/id/index.md
+++ b/files/fr/web/api/performanceelementtiming/id/index.md
@@ -40,7 +40,8 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ entryTypes: ["element"] });
 ```
 
-> **Note :** Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) `element` afin d'utiliser l'interface `PerformanceElementTiming`.
+> [!NOTE]
+> Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) `element` afin d'utiliser l'interface `PerformanceElementTiming`.
 
 ## Spécifications
 

--- a/files/fr/web/api/performanceelementtiming/identifier/index.md
+++ b/files/fr/web/api/performanceelementtiming/identifier/index.md
@@ -40,7 +40,8 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ entryTypes: ["element"] });
 ```
 
-> **Note :** Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) `element` afin d'utiliser l'interface `PerformanceElementTiming`.
+> [!NOTE]
+> Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) `element` afin d'utiliser l'interface `PerformanceElementTiming`.
 
 ## Spécifications
 

--- a/files/fr/web/api/performanceelementtiming/intersectionrect/index.md
+++ b/files/fr/web/api/performanceelementtiming/intersectionrect/index.md
@@ -42,7 +42,8 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ entryTypes: ["element"] });
 ```
 
-> **Note :** Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
+> [!NOTE]
+> Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
 
 ## Spécifications
 

--- a/files/fr/web/api/performanceelementtiming/loadtime/index.md
+++ b/files/fr/web/api/performanceelementtiming/loadtime/index.md
@@ -40,7 +40,8 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ entryTypes: ["element"] });
 ```
 
-> **Note :** Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
+> [!NOTE]
+> Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
 
 ## Spécifications
 

--- a/files/fr/web/api/performanceelementtiming/naturalheight/index.md
+++ b/files/fr/web/api/performanceelementtiming/naturalheight/index.md
@@ -40,7 +40,8 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ entryTypes: ["element"] });
 ```
 
-> **Note :** Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
+> [!NOTE]
+> Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
 
 ## Spécifications
 

--- a/files/fr/web/api/performanceelementtiming/naturalwidth/index.md
+++ b/files/fr/web/api/performanceelementtiming/naturalwidth/index.md
@@ -40,7 +40,8 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ entryTypes: ["element"] });
 ```
 
-> **Note :** Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
+> [!NOTE]
+> Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
 
 ## Spécifications
 

--- a/files/fr/web/api/performanceelementtiming/rendertime/index.md
+++ b/files/fr/web/api/performanceelementtiming/rendertime/index.md
@@ -44,7 +44,8 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ entryTypes: ["element"] });
 ```
 
-> **Note :** Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
+> [!NOTE]
+> Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
 
 ## Spécifications
 

--- a/files/fr/web/api/performanceelementtiming/tojson/index.md
+++ b/files/fr/web/api/performanceelementtiming/tojson/index.md
@@ -41,7 +41,8 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ entryTypes: ["element"] });
 ```
 
-> **Note :** Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
+> [!NOTE]
+> Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
 
 ## Spécifications
 

--- a/files/fr/web/api/performanceelementtiming/url/index.md
+++ b/files/fr/web/api/performanceelementtiming/url/index.md
@@ -40,7 +40,8 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ entryTypes: ["element"] });
 ```
 
-> **Note :** Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
+> [!NOTE]
+> Cet exemple utilise l'interface [`PerformanceObserver`](/fr/docs/Web/API/PerformanceObserver) pour créer une liste d'événements de mesure des performances. Dans notre cas, nous observons l'élément [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) afin d'utiliser l'interface `PerformanceElementTiming`.
 
 ## Spécifications
 

--- a/files/fr/web/api/performanceentry/duration/index.md
+++ b/files/fr/web/api/performanceentry/duration/index.md
@@ -29,7 +29,8 @@ entry.duration;
 
 Un objet [`DOMHighResTimeStamp`](/fr/docs/Web/API/DOMHighResTimeStamp) représentant la durée de l'[entrée de performance](/fr/docs/Web/API/PerformanceEntry). Si le concept de durée ne s'applique pas à une mesure de performance particulière, le navigateur peut choisir de renvoyer une durée de 0.
 
-> **Note :** si l'entrée de performance a un [`entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) "`resource`" (c'est-à-dire que l'entrée est un objet [`PerformanceResourceTiming`](/fr/docs/Web/API/PerformanceResourceTiming)), cette propriété renvoie la différence entre les [`timestamps`](/fr/docs/Web/API/DOMHighResTimeStamp) [`PerformanceEntry.responseEnd`](/fr/docs/Web/API/PerformanceResourceTiming/responseEnd) et [`PerformanceEntry.startTime`](/fr/docs/Web/API/PerformanceEntry/startTime).
+> [!NOTE]
+> Si l'entrée de performance a un [`entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) "`resource`" (c'est-à-dire que l'entrée est un objet [`PerformanceResourceTiming`](/fr/docs/Web/API/PerformanceResourceTiming)), cette propriété renvoie la différence entre les [`timestamps`](/fr/docs/Web/API/DOMHighResTimeStamp) [`PerformanceEntry.responseEnd`](/fr/docs/Web/API/PerformanceResourceTiming/responseEnd) et [`PerformanceEntry.startTime`](/fr/docs/Web/API/PerformanceEntry/startTime).
 
 ## Exemple
 

--- a/files/fr/web/api/performanceentry/starttime/index.md
+++ b/files/fr/web/api/performanceentry/starttime/index.md
@@ -30,7 +30,8 @@ entry.startTime;
 
 Un objet [`DOMHighResTimeStamp`](/fr/docs/Web/API/DOMHighResTimeStamp) représentant le premier horodatage lorsque l'[entrée de performance](/fr/docs/Web/API/PerformanceEntry) a été créée.
 
-> **Note :** Si l'entrée de performance a un [`entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) "`resource`" (c'est-à-dire que l'entrée est un objet [`PerformanceResourceTiming`](/fr/docs/Web/API/PerformanceResourceTiming)), cette propriété renvoie la valeur de l'horodatage fournie par [`PerformanceResourceTiming.fetchStart`](/fr/docs/Web/API/PerformanceResourceTiming/fetchStart).
+> [!NOTE]
+> Si l'entrée de performance a un [`entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) "`resource`" (c'est-à-dire que l'entrée est un objet [`PerformanceResourceTiming`](/fr/docs/Web/API/PerformanceResourceTiming)), cette propriété renvoie la valeur de l'horodatage fournie par [`PerformanceResourceTiming.fetchStart`](/fr/docs/Web/API/PerformanceResourceTiming/fetchStart).
 
 ## Exemple
 

--- a/files/fr/web/api/performancenavigation/index.md
+++ b/files/fr/web/api/performancenavigation/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceNavigation
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne interface **`PerformanceNavigation`** représente des informations sur la façon dont la navigation vers le document actuel a été effectuée.
 

--- a/files/fr/web/api/performancenavigation/redirectcount/index.md
+++ b/files/fr/web/api/performancenavigation/redirectcount/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceNavigation/redirectCount
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.redirectCount`](/fr/docs/Web/API/PerformanceNavigationTiming/redirectCount) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.redirectCount`](/fr/docs/Web/API/PerformanceNavigationTiming/redirectCount) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`PerformanceNavigation.redirectCount`** renvoie un `unsigned short` représentant le nombre de **Redirections** effectués avant d'atteindre la page.
 

--- a/files/fr/web/api/performancenavigation/type/index.md
+++ b/files/fr/web/api/performancenavigation/type/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceNavigation/type
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.type`](/fr/docs/Web/API/PerformanceNavigationTiming/type) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.type`](/fr/docs/Web/API/PerformanceNavigationTiming/type) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété **`PerformanceNavigation.type`** en lecture seule renvoie un `unsigned short` contenant une constante décrivant comment la navigation vers cette page a été effectuée. Les valeurs possibles sont :
 

--- a/files/fr/web/api/performanceobserver/observe/index.md
+++ b/files/fr/web/api/performanceobserver/observe/index.md
@@ -25,7 +25,8 @@ observer.observe(options);
     - `type` : Une [`DOMString`](/fr/docs/Web/API/DOMString) unique spécifiant exactement un type d'entrée de performance à observer. Ne peut pas être utilisé avec l'option `entryTypes`.
     - `buffered` : Un indicateur booléen pour indiquer si les entrées en mémoire tampon doivent être mises en file d'attente dans la mémoire tampon de l'observateur. Ne doit être utilisé qu'avec l'option « `type` ».
 
-    > **Note :** Voir [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) pour une liste des noms de types d'entrées de performance valides. Les types non reconnus sont ignorés, bien que le navigateur puisse afficher un message d'avertissement sur la console pour aider les développeurs à déboguer leur code. Si aucun type valide n'est trouvé, `observe()` n'a aucun effet.
+    > [!NOTE]
+    > Voir [`PerformanceEntry.entryType`](/fr/docs/Web/API/PerformanceEntry/entryType) pour une liste des noms de types d'entrées de performance valides. Les types non reconnus sont ignorés, bien que le navigateur puisse afficher un message d'avertissement sur la console pour aider les développeurs à déboguer leur code. Si aucun type valide n'est trouvé, `observe()` n'a aucun effet.
 
 ## Exemple
 

--- a/files/fr/web/api/performanceobserverentrylist/getentries/index.md
+++ b/files/fr/web/api/performanceobserverentrylist/getentries/index.md
@@ -7,7 +7,8 @@ slug: Web/API/PerformanceObserverEntryList/getEntries
 
 La méthode **`getEntries()`** de l'interface [`PerformanceObserverEntryList`](/fr/docs/Web/API/PerformanceObserverEntryList) retourne une liste d'objets explicitement _observés_ d'[entrées de performance](/fr/docs/Web/API/PerformanceEntry) pour un filtre donné. Les membres de la liste sont déterminés par l'ensemble des [types d'entrée](/fr/docs/Web/API/PerformanceEntry/entryType) spécifiés dans l'appel à la méthode [`observe()`](/fr/docs/Web/API/PerformanceObserver/observe). La liste est disponible dans la fonction de rappel de l'observateur (en tant que premier paramètre de la fonction de rappel).
 
-> **Note :** Cette interface est exposée à [`Window`](/fr/docs/Web/API/Window) et [`Worker`](/fr/docs/Web/API/Worker).
+> [!NOTE]
+> Cette interface est exposée à [`Window`](/fr/docs/Web/API/Window) et [`Worker`](/fr/docs/Web/API/Worker).
 
 ## Syntaxe
 

--- a/files/fr/web/api/performanceobserverentrylist/getentriesbyname/index.md
+++ b/files/fr/web/api/performanceobserverentrylist/getentriesbyname/index.md
@@ -7,7 +7,8 @@ slug: Web/API/PerformanceObserverEntryList/getEntriesByName
 
 La méthode **`getEntriesByName()`** de l'interface [`PerformanceObserverEntryList`](/fr/docs/Web/API/PerformanceObserverEntryList) retourne une liste d'objets [d'entrée de performance](/fr/docs/Web/API/PerformanceEntry) explicitement _observés_ pour un _[`name`](/fr/docs/Web/API/PerformanceEntry/name)_ et _[`entryType`](/fr/docs/Web/API/PerformanceEntry/entryType)_ donnés. Les membres de la liste sont déterminés par l'ensemble des [types d'entrées](/fr/docs/Web/API/PerformanceEntry/entryType) spécifiés dans l'appel à la méthode [`observe()`](/fr/docs/Web/API/PerformanceObserver/observe). La liste est disponible dans la fonction de rappel de l'observateur (en tant que premier paramètre de la fonction de rappel).
 
-> **Note :** Cette interface est exposée à [`Window`](/fr/docs/Web/API/Window) et [`Worker`](/fr/docs/Web/API/Worker).
+> [!NOTE]
+> Cette interface est exposée à [`Window`](/fr/docs/Web/API/Window) et [`Worker`](/fr/docs/Web/API/Worker).
 
 ## Syntaxe
 

--- a/files/fr/web/api/performanceobserverentrylist/getentriesbytype/index.md
+++ b/files/fr/web/api/performanceobserverentrylist/getentriesbytype/index.md
@@ -7,7 +7,8 @@ slug: Web/API/PerformanceObserverEntryList/getEntriesByType
 
 La méthode **`getEntriesByType()`** de la [`PerformanceObserverEntryList`](/fr/docs/Web/API/PerformanceObserverEntryList) retourne une liste d'objets [d'entrée de performance](/fr/docs/Web/API/PerformanceEntry) explicitement _observés_ pour un [type d'entrée de performance](/fr/docs/Web/API/PerformanceEntry/entryType). Les membres de la liste sont déterminés par l'ensemble des [types d'entrées](/fr/docs/Web/API/PerformanceEntry/entryType) spécifiés dans l'appel à la méthode [`observe()`](/fr/docs/Web/API/PerformanceObserver/observe). La liste est disponible dans la fonction de rappel de l'observateur (en tant que premier paramètre de la fonction de rappel).
 
-> **Note :** Cette interface est exposée à [`Window`](/fr/docs/Web/API/Window) et [`Worker`](/fr/docs/Web/API/Worker).
+> [!NOTE]
+> Cette interface est exposée à [`Window`](/fr/docs/Web/API/Window) et [`Worker`](/fr/docs/Web/API/Worker).
 
 ## Syntaxe
 

--- a/files/fr/web/api/performanceobserverentrylist/index.md
+++ b/files/fr/web/api/performanceobserverentrylist/index.md
@@ -7,7 +7,8 @@ slug: Web/API/PerformanceObserverEntryList
 
 L'interface **`PerformanceObserverEntryList`** est une liste d'[événements de performance](/fr/docs/Web/API/PerformanceEntry) qui ont été explicitement _observés_ via la méthode [`observe()`](/fr/docs/Web/API/PerformanceObserver/observe).
 
-> **Note :** Cette interface est exposée à [`Window`](/fr/docs/Web/API/Window) et [`Worker`](/fr/docs/Web/API/Worker).
+> [!NOTE]
+> Cette interface est exposée à [`Window`](/fr/docs/Web/API/Window) et [`Worker`](/fr/docs/Web/API/Worker).
 
 ## Méthodes
 

--- a/files/fr/web/api/performancetiming/connectend/index.md
+++ b/files/fr/web/api/performancetiming/connectend/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/connectEnd
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`connectEnd`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où la connexion a été ouverte en réseau. Si la couche de transport signale une erreur et que l'établissement de la connexion est recommencé, l'heure de fin du dernier établissement de la connexion est donnée. Si une connexion persistante est utilisée, la valeur sera la même que [`PerformanceTiming.fetchStart`](/fr/docs/Web/API/PerformanceTiming/fetchStart). Une connexion est considérée comme ouverte lorsque toute poignée de main de connexion sécurisée, ou authentification SOCKS, est terminée.
 

--- a/files/fr/web/api/performancetiming/connectstart/index.md
+++ b/files/fr/web/api/performancetiming/connectstart/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/connectStart
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`connectStart`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où la demande d'ouverture de connexion est envoyée au réseau. Si la couche transport signale une erreur et que l'établissement de la connexion est relancé, le dernier moment de début d'établissement de la connexion est donné. Si une connexion persistante est utilisée, la valeur sera la même que [`PerformanceTiming.fetchStart`](/fr/docs/Web/API/PerformanceTiming/fetchStart).
 

--- a/files/fr/web/api/performancetiming/domainlookupend/index.md
+++ b/files/fr/web/api/performancetiming/domainlookupend/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/domainLookupEnd
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`domainLookupEnd`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où la recherche de domaine est terminée. Si une connexion persistante est utilisée, ou si les informations sont stockées dans un cache ou une ressource locale, la valeur sera la même que [`PerformanceTiming.fetchStart`](/fr/docs/Web/API/PerformanceTiming/fetchStart).
 

--- a/files/fr/web/api/performancetiming/domainlookupstart/index.md
+++ b/files/fr/web/api/performancetiming/domainlookupstart/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/domainLookupStart
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`domainLookupStart`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où la recherche de domaine commence. Si une connexion persistante est utilisée, ou si les informations sont stockées dans un cache ou une ressource locale, la valeur sera la même que [`PerformanceTiming.fetchStart`](/fr/docs/Web/API/PerformanceTiming/fetchStart).
 

--- a/files/fr/web/api/performancetiming/domcomplete/index.md
+++ b/files/fr/web/api/performancetiming/domcomplete/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/domComplete
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.domComplete`](/fr/docs/Web/API/PerformanceNavigationTiming/domComplete) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.domComplete`](/fr/docs/Web/API/PerformanceNavigationTiming/domComplete) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`domComplete`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où le parseur a terminé son travail sur le document principal, c'est-à-dire lorsque son [`Document.readyState`](/fr/docs/Web/API/Document/readyState) passe à `'complete'` et que l'événement [`readystatechange`](/fr/docs/Web/API/Document/readystatechange_event) correspondant est lancé.
 

--- a/files/fr/web/api/performancetiming/domcontentloadedeventend/index.md
+++ b/files/fr/web/api/performancetiming/domcontentloadedeventend/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/domContentLoadedEventEnd
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.domContentLoadedEventEnd`](/fr/docs/Web/API/PerformanceNavigationTiming/domContentLoadedEventEnd) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.domContentLoadedEventEnd`](/fr/docs/Web/API/PerformanceNavigationTiming/domContentLoadedEventEnd) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`domContentLoadedEventEnd`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, juste après que tous les scripts qui doivent être exécutés le plus rapidement possible, dans l'ordre ou non, aient été exécutés.
 

--- a/files/fr/web/api/performancetiming/domcontentloadedeventstart/index.md
+++ b/files/fr/web/api/performancetiming/domcontentloadedeventstart/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/domContentLoadedEventStart
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.domContentLoadedEventStart`](/fr/docs/Web/API/PerformanceNavigationTiming/domContentLoadedEventStart) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.domContentLoadedEventStart`](/fr/docs/Web/API/PerformanceNavigationTiming/domContentLoadedEventStart) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`domContentLoadedEventStart`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, juste avant que le parseur n'envoie l'événement [`DOMContentLoaded`](/fr/docs/Web/API/Document/DOMContentLoaded_event), c'est-à-dire juste après que tous les scripts qui doivent être exécutés juste après le parsing aient été exécutés.
 

--- a/files/fr/web/api/performancetiming/dominteractive/index.md
+++ b/files/fr/web/api/performancetiming/dominteractive/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/domInteractive
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.domInteractive`](/fr/docs/Web/API/PerformanceNavigationTiming/domInteractive) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.domInteractive`](/fr/docs/Web/API/PerformanceNavigationTiming/domInteractive) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`domInteractive`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où le parseur a terminé son travail sur le document principal, c'est-à-dire lorsque son [`Document.readyState`](/fr/docs/Web/API/Document/readyState) passe à `"interactive"` et que l'événement [`readystatechange`](/fr/docs/Web/API/Document/readystatechange_event) correspondant est lancé.
 

--- a/files/fr/web/api/performancetiming/domloading/index.md
+++ b/files/fr/web/api/performancetiming/domloading/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/domLoading
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`domLoading`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où le parseur a commencé son travail, c'est-à-dire lorsque son [`Document.readyState`](/fr/docs/Web/API/Document/readyState) passe à `"loading"` et que l'événement [`readystatechange`](/fr/docs/Web/API/Document/readystatechange_event) correspondant est déclenché.
 

--- a/files/fr/web/api/performancetiming/fetchstart/index.md
+++ b/files/fr/web/api/performancetiming/fetchstart/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/fetchStart
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`fetchStart`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où le navigateur est prêt à aller chercher le document en utilisant une requête HTTP. Ce moment est _avant_ la vérification de tout cache d'application.
 

--- a/files/fr/web/api/performancetiming/index.md
+++ b/files/fr/web/api/performancetiming/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'interface **`PerformanceTiming`** est une interface héritée conservée pour la rétrocompatibilité et contient des propriétés qui offrent des informations sur la chronologie des performances pour divers événements qui se produisent pendant le chargement et l'utilisation de la page actuelle. Vous obtenez un objet `PerformanceTiming` décrivant votre page en utilisant la propriété [`window.performance.timing`](/fr/docs/Web/API/Performance/timing).
 

--- a/files/fr/web/api/performancetiming/loadeventend/index.md
+++ b/files/fr/web/api/performancetiming/loadeventend/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/loadEventEnd
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.loadEventEnd`](/fr/docs/Web/API/PerformanceNavigationTiming/loadEventEnd) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.loadEventEnd`](/fr/docs/Web/API/PerformanceNavigationTiming/loadEventEnd) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`loadEventEnd`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où le gestionnaire d'événement [`load`](/fr/docs/Web/API/Document/load_event) s'est terminé, c'est-à-dire lorsque l'événement de chargement est terminé. Si cet événement n'a pas encore été envoyé, ou n'est pas encore terminé, il retourne `0`.
 

--- a/files/fr/web/api/performancetiming/loadeventstart/index.md
+++ b/files/fr/web/api/performancetiming/loadeventstart/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/loadEventStart
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.loadEventStart`](/fr/docs/Web/API/PerformanceNavigationTiming/loadEventStart) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.loadEventStart`](/fr/docs/Web/API/PerformanceNavigationTiming/loadEventStart) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`loadEventStart`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où l'événement [`load`](/fr/docs/Web/API/Document/load_event) a été envoyé pour le document actuel. Si cet événement n'a pas encore été envoyé, il retourne `0`.
 

--- a/files/fr/web/api/performancetiming/navigationstart/index.md
+++ b/files/fr/web/api/performancetiming/navigationstart/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/navigationStart
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`navigationStart`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, juste après la fin de l'invite de déchargement sur le document précédent dans le même contexte de navigation. S'il n'y a pas de document précédent, cette valeur sera la même que [`PerformanceTiming.fetchStart`](/fr/docs/Web/API/PerformanceTiming/fetchStart).
 

--- a/files/fr/web/api/performancetiming/redirectend/index.md
+++ b/files/fr/web/api/performancetiming/redirectend/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/redirectEnd
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`redirectEnd`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où la dernière redirection HTTP est terminée, c'est-à-dire lorsque le dernier octet de la réponse HTTP a été reçu. S'il n'y a pas de redirection, ou si l'une des redirections n'est pas de la même origine, la valeur renvoyée est `0`.
 

--- a/files/fr/web/api/performancetiming/redirectstart/index.md
+++ b/files/fr/web/api/performancetiming/redirectstart/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/redirectStart
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`redirectStart`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où la première redirection HTTP commence. S'il n'y a pas de redirection, ou si l'une des redirections n'est pas de la même origine, la valeur renvoyée est `0`.
 

--- a/files/fr/web/api/performancetiming/requeststart/index.md
+++ b/files/fr/web/api/performancetiming/requeststart/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/requestStart
 
 {{ APIRef("PerformanceTiming") }}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`requestStart`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où le navigateur a envoyé la requête pour obtenir le document actuel, depuis le serveur ou depuis un cache. Si la couche de transport échoue après le début de la requête et que la connexion est rouverte, cette propriété sera définie sur le temps correspondant à la nouvelle requête.
 

--- a/files/fr/web/api/performancetiming/responseend/index.md
+++ b/files/fr/web/api/performancetiming/responseend/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/responseEnd
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`responseEnd`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où le navigateur a reçu le dernier octet de la réponse, ou lorsque la connexion est fermée si cela s'est produit en premier, depuis le serveur à partir d'un cache ou d'une ressource locale.
 

--- a/files/fr/web/api/performancetiming/responsestart/index.md
+++ b/files/fr/web/api/performancetiming/responsestart/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/responseStart
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`responseStart`** retourne un `unsigned long long` représentant le moment (en millisecondes depuis l'époque UNIX) où le navigateur a reçu le premier octet de la réponse du serveur, du cache ou de la ressource locale.
 

--- a/files/fr/web/api/performancetiming/secureconnectionstart/index.md
+++ b/files/fr/web/api/performancetiming/secureconnectionstart/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/secureConnectionStart
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`secureConnectionStart`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où la poignée de main de connexion sécurisée commence. Si aucune connexion de ce type n'est demandée, elle retourne `0`.
 

--- a/files/fr/web/api/performancetiming/unloadeventend/index.md
+++ b/files/fr/web/api/performancetiming/unloadeventend/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/unloadEventEnd
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.unloadEventEnd`](/fr/docs/Web/API/PerformanceNavigationTiming/unloadEventEnd) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.unloadEventEnd`](/fr/docs/Web/API/PerformanceNavigationTiming/unloadEventEnd) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`unloadEventEnd`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où le gestionnaire d'événement [`unload`](/fr/docs/Web/API/Window/unload_event) se termine. S'il n'y a pas de document précédent, ou si le document précédent, ou l'une des redirections nécessaires, n'est pas de la même origine, la valeur retournée est `0`.
 

--- a/files/fr/web/api/performancetiming/unloadeventstart/index.md
+++ b/files/fr/web/api/performancetiming/unloadeventstart/index.md
@@ -5,7 +5,8 @@ slug: Web/API/PerformanceTiming/unloadEventStart
 
 {{APIRef("Navigation Timing")}}
 
-> **Attention :** Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.unloadEventStart`](/fr/docs/Web/API/PerformanceNavigationTiming/unloadEventStart) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
+> [!WARNING]
+> Cette interface est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser la propriété [`PerformanceNavigationTiming.unloadEventStart`](/fr/docs/Web/API/PerformanceNavigationTiming/unloadEventStart) de l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
 L'ancienne propriété en lecture seule **`unloadEventStart`** retourne un `unsigned long long` représentant le moment, en millisecondes depuis l'époque UNIX, où l'événement [`unload`](/fr/docs/Web/API/Window/unload_event) a été lancé. S'il n'y a pas de document précédent, ou si le document précédent, ou l'une des redirections nécessaires, n'est pas de la même origine, la valeur retournée est `0`.
 

--- a/files/fr/web/api/permissions_api/index.md
+++ b/files/fr/web/api/permissions_api/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Permissions_API
 
 L'API Permissions fournit une manière cohérente pour connaître, dans un programme, le statut des permissions dans le contexte courant. On pourra par exemple utiliser cette API afin de déterminer si la permission d'accéder à une API donnée a été accordée ou refusée.
 
-> **Note :** Cette fonctionnalité est disponible via [les Web Workers](/fr/docs/Web/API/Web_Workers_API) bien que les versions actuelles de Firefox n'implémentent pas [WorkerNavigator.permissions](/fr/docs/Web/API/WorkerNavigator/permissions).
+> [!NOTE]
+> Cette fonctionnalité est disponible via [les Web Workers](/fr/docs/Web/API/Web_Workers_API) bien que les versions actuelles de Firefox n'implémentent pas [WorkerNavigator.permissions](/fr/docs/Web/API/WorkerNavigator/permissions).
 
 ## Concepts et usages
 

--- a/files/fr/web/api/plugin/index.md
+++ b/files/fr/web/api/plugin/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Plugin
 
 L'interface `Plugin` fournit des informations à propos d'un [plugin](/fr/docs/Mozilla/Add-ons/Plugins) du navigateur.
 
-> **Note :** Les propriétés propres des objets `Plugin` ne sont plus énumérables dans les dernières versions des navigateurs.
+> [!NOTE]
+> Les propriétés propres des objets `Plugin` ne sont plus énumérables dans les dernières versions des navigateurs.
 
 ## Propriétés
 

--- a/files/fr/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/fr/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -9,7 +9,8 @@ Ajouter la gestion des _gestes_ à une application peut améliorer de manière s
 
 Cet exemple montre comment détecter les gestes de _pinch/zoom_ (pincer/zoomer), en utilisant les {{domxref("Pointer_events","événements de pointeur")}} pour détecter si l'utilisateur bouge deux pointeurs plus proches ou plus loin l'un de l'autre.
 
-> **Note :** Une version _en direct_ de cette application est disponible sur [Github](https://mdn.github.io/dom-examples/pointerevents/Pinch_zoom_gestures.html). Le [code source est également disponible sur Github](https://github.com/mdn/dom-examples/blob/master/pointerevents/Pinch_zoom_gestures.html); les pull requests et [bug reports](https://github.com/mdn/dom-examples/issues) sont les bienvenus.
+> [!NOTE]
+> Une version _en direct_ de cette application est disponible sur [Github](https://mdn.github.io/dom-examples/pointerevents/Pinch_zoom_gestures.html). Le [code source est également disponible sur Github](https://github.com/mdn/dom-examples/blob/master/pointerevents/Pinch_zoom_gestures.html); les pull requests et [bug reports](https://github.com/mdn/dom-examples/issues) sont les bienvenus.
 
 ## Exemple
 
@@ -150,7 +151,8 @@ function pointerup_handler(ev) {
 
 Cette application utilise un élément {{HTMLElement("div")}} comme zone de toucher et fournit des boutons pour activer et nettoyer les logs.
 
-> **Note :** Pour empêcher que le comportement par défaut du navigateur au toucher surcharge le gestionnaire de l'application, la propriété {{cssxref("touch-action")}} est appliquée à l'élément {{HTMLElement("body")}}.
+> [!NOTE]
+> Pour empêcher que le comportement par défaut du navigateur au toucher surcharge le gestionnaire de l'application, la propriété {{cssxref("touch-action")}} est appliquée à l'élément {{HTMLElement("body")}}.
 
 ```html
 <body onload="init();" style="touch-action:none">

--- a/files/fr/web/api/pointer_lock_api/index.md
+++ b/files/fr/web/api/pointer_lock_api/index.md
@@ -113,7 +113,8 @@ function lockError(e) {
 }
 ```
 
-> **Note :** Jusqu'à Firefox 50, les événements ci-dessus étaient préfixés avec `moz`.
+> [!NOTE]
+> Jusqu'à Firefox 50, les événements ci-dessus étaient préfixés avec `moz`.
 
 ## Extensions aux événements de souris
 

--- a/files/fr/web/api/pointerevent/index.md
+++ b/files/fr/web/api/pointerevent/index.md
@@ -50,7 +50,8 @@ _Cette interface hérite des proprétés de {{domxref("MouseEvent")}} et {{domxr
 
 L'interface `PointerEvent` a plusieurs types d'évènements. Pour déterminer quel évènement s'est produit, regardez la propriété {{ domxref("Event.type", "type") }} de l'évènement.
 
-> **Note :** Il est important de remarquer que dans beaucoup de cas, à la fois les évènements du pointeur et de la souris sont envoyés (afin de laisser la logique interagir avec l'utilisateur même lorsqu'elle n'est pas spécifique à un type de pointeur) . Si vous utilisez les évènements de pointeur, vous devez exécuter {{ domxref("event.preventDefault()") }} afin d'empêcher l'évènement de la souris d'être également envoyée.
+> [!NOTE]
+> Il est important de remarquer que dans beaucoup de cas, à la fois les évènements du pointeur et de la souris sont envoyés (afin de laisser la logique interagir avec l'utilisateur même lorsqu'elle n'est pas spécifique à un type de pointeur) . Si vous utilisez les évènements de pointeur, vous devez exécuter {{ domxref("event.preventDefault()") }} afin d'empêcher l'évènement de la souris d'être également envoyée.
 
 - [`pointerover`](/fr/docs/Web/API/Element/pointerover_event)
   - : Cet évènement est déclenché lorsqu'un appareil de pointage est déplacé vers la zone du test de ciblage d'un élément.

--- a/files/fr/web/api/popover_api/using/index.md
+++ b/files/fr/web/api/popover_api/using/index.md
@@ -17,7 +17,8 @@ Dans sa forme la plus simple, un <i lang="en">popover</i> est créé en ajoutant
 <div id="my-popover" popover>Contenu du popover</div>
 ```
 
-> **Note :** Définir l'attribut `popover` sans valeur est équivalent à utiliser `popover="auto"`.
+> [!NOTE]
+> Définir l'attribut `popover` sans valeur est équivalent à utiliser `popover="auto"`.
 
 Ajouter cet attribut masque l'élément dès le chargement de la page, comme si on lui appliquait la déclaration CSS [`display: none`](/fr/docs/Web/CSS/display). Pour afficher/masquer le <i lang="en">popover</i>, il faut utiliser un ou plusieurs boutons de contrôle. Vous pouvez utiliser un élément [`<button>`](/fr/docs/Web/HTML/Element/button) (ou [`<input>`](/fr/docs/Web/HTML/Element/input) avec l'attribut `type="button"`) en lui ajoutant l'attribut [`popovertarget`](/fr/docs/Web/HTML/Element/button#popovertarget) avec la valeur de l'identifiant (attribut `id`) de l'élément <i lang="en">popover</i> à contrôler.
 
@@ -42,7 +43,8 @@ Vous pouvez modifier ce comportement en utilisant l'attribut [`popovertargetacti
 
 Vous pouvez voir ce code en action dans [notre exemple de <i lang="en">popover</i> déclaratif](https://mdn.github.io/dom-examples/popover-api/basic-declarative/) ([voir le code source](https://github.com/mdn/dom-examples/tree/main/popover-api/basic-declarative)).
 
-> **Note :** Si l'attribut `popovertargetaction` n'est pas défini, il vaudra `"toggle"` par défaut.
+> [!NOTE]
+> Si l'attribut `popovertargetaction` n'est pas défini, il vaudra `"toggle"` par défaut.
 
 Quand un <i lang="en">popover</i> est affiché, la déclaration CSS `display:none` associée est retirée et il est placé dans la [couche supérieure](/fr/docs/Glossary/Top_layer)&nbsp;: de cette manière il est affiché par-dessus les autres éléments de la page.
 
@@ -54,7 +56,8 @@ Quand un élément <i lang="en">popover</i> a l'attribut `popover` ou `popover="
 - Le <i lang="en">popover</i> peut être fermé à l'aide des mécanismes fournis par le navigateur, comme la touche <kbd>Esc</kbd> du clavier.
 - En général, un seul <i lang="en">popover</i> peut être affiché à la fois. Si un <i lang="en">popover</i> est déjà affiché, l'affichage d'un autre <i lang="en">popover</i> masquera le premier. La seule exception porte sur les <i lang="en">popovers</i> imbriqués les uns dans les autres. Lisez la section [<i lang="en">Popovers</i> imbriqués](#popovers_imbriqués) pour plus d'informations.
 
-> **Note :** Les <i lang="en">popovers</i> avec l'état automatique sont également masqués lorsque les méthodes [`HTMLDialogElement.showModal()`](/fr/docs/Web/API/HTMLDialogElement/showModal) et [`Element.requestFullscreen()`](/fr/docs/Web/API/Element/requestFullscreen) sont appelées sur un autre élément du document. Gardez à l'esprit qu'appeler ces méthodes sur un élément <i lang="en">popover</i> visible échouera dans la mesure ou ces méthodes n'ont pas de sens pour un <i lang="en">popover</i> visible. Cependant, vous pouvez appeler ces méthodes sur un élément avec l'attribut `popover` qui n'est pas encore visible.
+> [!NOTE]
+> Les <i lang="en">popovers</i> avec l'état automatique sont également masqués lorsque les méthodes [`HTMLDialogElement.showModal()`](/fr/docs/Web/API/HTMLDialogElement/showModal) et [`Element.requestFullscreen()`](/fr/docs/Web/API/Element/requestFullscreen) sont appelées sur un autre élément du document. Gardez à l'esprit qu'appeler ces méthodes sur un élément <i lang="en">popover</i> visible échouera dans la mesure ou ces méthodes n'ont pas de sens pour un <i lang="en">popover</i> visible. Cependant, vous pouvez appeler ces méthodes sur un élément avec l'attribut `popover` qui n'est pas encore visible.
 
 L'état automatique est utile pour afficher un seul <i lang="en">popover</i> à la fois. Cela peut être utile lorsqu'on a plusieurs messages à afficher les uns à la suite des autres (plutôt que d'avoir un affichage confus et encombré), ou lorsqu'on affiche des messages de statut, où le dernier l'emportera de toute façon sur le statut précédent.
 
@@ -318,7 +321,8 @@ Les <i lang="en">popovers</i> sont mis en forme avec la déclaration `display: n
 - Quand `display` est animé de `none` à `block` (ou toute autre valeur visible de `display`), la valeur passera à `block` à 0% de la durée de l'animation, ce qui la rendra visible du début à la fin.
 - Quand `display` est animé de `block` (ou toute autre valeur visible de `display`) à `none`, la valeur passera à `none` à 100% de la durée de l'animation, ce qui la rendra visible du début à la fin.
 
-> **Note :** Quand on anime en utilisant [les transitions CSS](/fr/docs/Web/CSS/CSS_transitions), la déclaration [`transition-behavior: allow-discrete`](/fr/docs/Web/CSS/transition-behavior) doit être appliquée sur l'élément <i lang="en">popover</i> pour activer le comportement décrit ci-avant. Quand on anime avec [les animations CSS](/fr/docs/Web/CSS/CSS_animations), le comportement décrit ci-avant est activé par défaut, et il n'y a pas besoin de définir cette propriété.
+> [!NOTE]
+> Quand on anime en utilisant [les transitions CSS](/fr/docs/Web/CSS/CSS_transitions), la déclaration [`transition-behavior: allow-discrete`](/fr/docs/Web/CSS/transition-behavior) doit être appliquée sur l'élément <i lang="en">popover</i> pour activer le comportement décrit ci-avant. Quand on anime avec [les animations CSS](/fr/docs/Web/CSS/CSS_animations), le comportement décrit ci-avant est activé par défaut, et il n'y a pas besoin de définir cette propriété.
 
 ### Les transitions sur les <i lang="en">popovers</i>
 
@@ -431,7 +435,8 @@ Le code donne ce résultat&nbsp;:
 
 {{EmbedLiveSample("", "100%", "200")}}
 
-> **Note :** Parce que les <i lang="en">popovers</i> passent de `display: none` à `display: block` à chaque fois qu'ils apparaissent, le <i lang="en">popover</i> transitionne des styles définis dans `@starting-style` aux styles définis dans `[popover]:popover-open` à chaque fois qu'il apparait. Quand le <i lang="en">popover</i> se ferme, il transitionne des styles définis dans `[popover]:popover-open` aux styles définis dans `[popover]`.
+> [!NOTE]
+> Parce que les <i lang="en">popovers</i> passent de `display: none` à `display: block` à chaque fois qu'ils apparaissent, le <i lang="en">popover</i> transitionne des styles définis dans `@starting-style` aux styles définis dans `[popover]:popover-open` à chaque fois qu'il apparait. Quand le <i lang="en">popover</i> se ferme, il transitionne des styles définis dans `[popover]:popover-open` aux styles définis dans `[popover]`.
 >
 > Il est possible que les styles de transition pour l'entrée et la sortie puissent être différents. Regarder [notre démonstration d'utilisation des styles de départ](/fr/docs/Web/CSS/@starting-style#demonstration_of_when_starting_styles_are_used) pour voir un exemple.
 

--- a/files/fr/web/api/push_api/index.md
+++ b/files/fr/web/api/push_api/index.md
@@ -11,7 +11,8 @@ L'**API <i lang="en">Push</i>** permet aux applications web de recevoir des mess
 
 ## Concepts et usages de Push
 
-> **Attention :** Lorsqu'on implémente des abonnements via `PushManager`, il est primordial de se protéger contre les attaques CSRF/XSRF. Pour plus d'informations, voir les articles suivants&nbsp;:
+> [!WARNING]
+> Lorsqu'on implémente des abonnements via `PushManager`, il est primordial de se protéger contre les attaques CSRF/XSRF. Pour plus d'informations, voir les articles suivants&nbsp;:
 >
 > - [Anti-sèche pour se protéger contre les attaques CSRF (<i lang="en">Cross-Site Request Forgery</i>) (en anglais)](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)
 > - [Prévenir les attaques CSRF et XSRF (en anglais)](https://blog.codinghorror.com/preventing-csrf-and-xsrf-attacks/)

--- a/files/fr/web/api/pushmanager/permissionstate/index.md
+++ b/files/fr/web/api/pushmanager/permissionstate/index.md
@@ -10,7 +10,8 @@ l10n:
 
 La méthode **`permissionState()`** de l'interface [`PushManager`](/fr/docs/Web/API/PushManager) renvoie une [promesse (`Promise`)](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) qui se résout en une chaîne de caractères indiquant l'état de la permission du gestionnaire de push. Les valeurs possibles sont `'prompt'`, `'denied'`, ou `'granted'`.
 
-> **Note :** Depuis Firefox 44, les autorisations pour [Notifications](/fr/docs/Web/API/Notifications_API) et [Push](/fr/docs/Web/API/Push_API) ont été fusionnées. Si l'autorisation est accordée pour les notifications, le push sera également activé.
+> [!NOTE]
+> Depuis Firefox 44, les autorisations pour [Notifications](/fr/docs/Web/API/Notifications_API) et [Push](/fr/docs/Web/API/Push_API) ont été fusionnées. Si l'autorisation est accordée pour les notifications, le push sera également activé.
 
 ## Syntaxe
 

--- a/files/fr/web/api/pushmanager/subscribe/index.md
+++ b/files/fr/web/api/pushmanager/subscribe/index.md
@@ -29,7 +29,8 @@ subscribe(options)
     - `applicationServerKey`
       - : Une chaîne encodée en Base64 ou un [`ArrayBuffer`](/fr/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) contenant une clé publique [ECDSA](https://fr.wikipedia.org/wiki/Elliptic_curve_digital_signature_algorithm) P-256 que le serveur push utilisera pour authentifier votre serveur d'application. Si vous le spécifiez, tous les messages provenant de votre serveur d'application doivent utiliser le schéma d'authentification [VAPID](https://datatracker.ietf.org/doc/html/rfc8292) et inclure un JWT signé avec la clé privée correspondante. Cette clé **_n'est pas_** la même clé ECDH que celle que vous utilisez pour chiffrer les données. Pour plus d'informations, voir «&nbsp;[Utiliser VAPID avec WebPush (en anglais)](https://blog.mozilla.org/services/2016/04/04/using-vapid-with-webpush/)&nbsp;».
 
-    > **Note :** Ce paramètre est nécessaire dans certains navigateurs comme Chrome et Edge.
+    > [!NOTE]
+    > Ce paramètre est nécessaire dans certains navigateurs comme Chrome et Edge.
 
 ### Valeur de retour
 

--- a/files/fr/web/api/request/index.md
+++ b/files/fr/web/api/request/index.md
@@ -66,7 +66,8 @@ Vous pouvez créer un nouvel objet `Request` en utilisant le constructeur {{domx
 - {{domxref("Body.text()")}}
   - : Renvoie une promesse qui se résout avec une représentation {{domxref("USVString")}} (texte) du coprs de la requête.
 
-> **Note :** Les fonctions {{domxref("Body")}} ne peuvent être exécutées qu'une seule fois; les appels suivants seront résolus avec des chaînes vides / ArrayBuffers.
+> [!NOTE]
+> Les fonctions {{domxref("Body")}} ne peuvent être exécutées qu'une seule fois; les appels suivants seront résolus avec des chaînes vides / ArrayBuffers.
 
 ## Exemples
 
@@ -104,7 +105,8 @@ const credentials = request.credentials;
 const bodyUsed = request.bodyUsed;
 ```
 
-> **Note :** Le type de body ne peut être qu'un {{domxref("Blob")}}, {{domxref("BufferSource")}}, {{domxref("FormData")}}, {{domxref("URLSearchParams")}}, {{domxref("USVString")}} ou {{domxref("ReadableStream")}} donc pour ajouter un objet JSON à la charge utile, vous devez stringify cet objet.
+> [!NOTE]
+> Le type de body ne peut être qu'un {{domxref("Blob")}}, {{domxref("BufferSource")}}, {{domxref("FormData")}}, {{domxref("URLSearchParams")}}, {{domxref("USVString")}} ou {{domxref("ReadableStream")}} donc pour ajouter un objet JSON à la charge utile, vous devez stringify cet objet.
 
 Vous pouvez ensuite récupérer cette demande d'API en passant l'objet `Request` en tant que paramètre à un appel [`fetch()`](/fr/docs/Web/API/fetch), par exemple et obtenir la réponse:
 

--- a/files/fr/web/api/request/request/index.md
+++ b/files/fr/web/api/request/request/index.md
@@ -115,7 +115,8 @@ Vous pouvez aussi passer un objet {{domxref("Request")}} au constructeur `Reques
 var copie = new Request(maRequete);
 ```
 
-> **Note :** Cette dernière utilisation n'est probablement utile que dans [ServiceWorkers](/fr/docs/Web/API/ServiceWorker_API).
+> [!NOTE]
+> Cette dernière utilisation n'est probablement utile que dans [ServiceWorkers](/fr/docs/Web/API/ServiceWorker_API).
 
 ## Spécifications
 

--- a/files/fr/web/api/response/ok/index.md
+++ b/files/fr/web/api/response/ok/index.md
@@ -21,7 +21,8 @@ Un {{domxref("Boolean")}}.
 
 Dans [notre exemple](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (voir [la démonstration en ligne](https://mdn.github.io/fetch-examples/fetch-response/)) nous créons un nouvel objet {{domxref("Request")}} en utilisant le constructeur {{domxref("Request.Request","Request()")}} avec le chemin vers un JPG en argument. On récupère (_fetch_ en anglais) ensuite la requête en utilisant {{domxref("GlobalFetch.fetch()")}}, on extrait un _blob_ de la réponse en utilisant {{domxref("Body.blob")}} pour créer un objet URL grâce à {{domxref("URL.createObjectURL")}} et l'afficher dans une balise {{htmlelement("img")}}.
 
-> **Note :** Nous affichons la valeur de la propriété `ok` de la réponse dans la console en haut du bloc `fetch()`.
+> [!NOTE]
+> Nous affichons la valeur de la propriété `ok` de la réponse dans la console en haut du bloc `fetch()`.
 
 ```js
 var myImage = document.querySelector("img");

--- a/files/fr/web/api/rtcpeerconnection/rtcpeerconnection/index.md
+++ b/files/fr/web/api/rtcpeerconnection/rtcpeerconnection/index.md
@@ -41,13 +41,15 @@ new RTCPeerConnection(configuration)
 
       - : Un tableau ([`Array`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Array)) contenant des objets [`RTCCertificate`](/fr/docs/Web/API/RTCCertificate) utilisés par la connexion pour l'authentification. Si cette propriété n'est pas fournie, un ensemble de certificats est généré automatiquement pour chaque connexion [`RTCPeerConnection`](/fr/docs/Web/API/RTCPeerConnection). Bien qu'un seul certificat est utilisé pour une connexion donnée, fournir des certificats basés sur des algorithmes différents pourra augmenter les chances de réussir la connexion dans certaines conditions circonstances. Voir ci-après, [la section sur l'utilisation des certificats](#utiliser_des_certificats) pour plus d'informations.
 
-        > **Note :** Cette option de configuration ne peut pas être modifiée après qu'elle a été fournie initialement. Une fois que les certificats ont été paramétrés, cette propriété sera ignorée par les appels ultérieurs à [`RTCPeerConnection.setConfiguration()`](/fr/docs/Web/API/RTCPeerConnection/setConfiguration).
+        > [!NOTE]
+        > Cette option de configuration ne peut pas être modifiée après qu'elle a été fournie initialement. Une fois que les certificats ont été paramétrés, cette propriété sera ignorée par les appels ultérieurs à [`RTCPeerConnection.setConfiguration()`](/fr/docs/Web/API/RTCPeerConnection/setConfiguration).
 
     - `iceCandidatePoolSize` {{optional_inline}}
 
       - : Un entier non-signé sur 16 bits qui indique la taille du volume de candidats ICE qui seront collectés au préalable (<i lang="en">prefetched</i>). La valeur par défaut est 0 (indiquant qu'aucune collecte préalable des candidats n'a lieu). Dans certains cas, l'établissement de la connexion pourra être plus rapide en permettant à l'agent ICE de récupérer les candidats ICE avant la tentative de connexion, afin qu'ils soient disponibles pour une inspection lors de l'appel à [`RTCPeerConnection.setLocalDescription()`](/fr/docs/Web/API/RTCPeerConnection/setLocalDescription).
 
-        > **Note :** Modifier la taille du volume de candidats ICE pourra déclencher le début de la collecte ICE.
+        > [!NOTE]
+        > Modifier la taille du volume de candidats ICE pourra déclencher le début de la collecte ICE.
 
     - `iceServers` {{optional_inline}}
 

--- a/files/fr/web/api/rtcpeerconnection/setconfiguration/index.md
+++ b/files/fr/web/api/rtcpeerconnection/setconfiguration/index.md
@@ -12,7 +12,8 @@ Le cas d'usage le plus probable (bien qu'il ne soit probablement pas répandu) e
 - L'objet {{domxref("RTCPeerConnection")}} a été instancié sans qu'un serveur ICE soit spécifié. Si le constructeur {{domxref("RTCPeerConnection.RTCPeerConnection()", "RTCPeerConnection()")}} a été appelé sans paramètre, on doit alors appeler `setConfiguration()` pour ajouter des serveurs ICE avant que la négociation ICE puisse avoir lieu.
 - La connexion doit être renégociée et il faut utiliser un autre ensemble de serveurs ICE pour une certaine raison (ex. l'utilisateur s'est déplacé dans une nouvelle région et il faut donc utiliser de nouveaux serveurs ICE régionaux). Dans ce cas, on pourra appeler `setConfiguration()` pour passer sur les serveurs régionaux puis initier [un redémarrage ICE](/fr/docs/Web/API/WebRTC_API/Session_lifetime#ICE_restart).
 
-> **Note :** On ne peut pas changer les informations d'identité d'une connexion une fois que celle-ci a été créée.
+> [!NOTE]
+> On ne peut pas changer les informations d'identité d'une connexion une fois que celle-ci a été créée.
 
 ## Syntaxe
 


### PR DESCRIPTION
This PR converts the noteblocks for the French locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 10. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
