### PR TITLE
fr: Convert noteblocks to GFM Alerts (part 11)

### DIFF
--- a/files/fr/web/api/selection_api/index.md
+++ b/files/fr/web/api/selection_api/index.md
@@ -5,7 +5,8 @@ slug: Web/API/Selection_API
 
 {{DefaultAPISidebar("Selection API")}}
 
-> **Note :** Cette API _n'est pas disponible_ dans [les <i lang="en">web workers</i>](/fr/docs/Web/API/Web_Workers_API) (elle n'est pas exposée via [`WorkerNavigator`](/fr/docs/Web/API/WorkerNavigator)).
+> [!NOTE]
+> Cette API _n'est pas disponible_ dans [les <i lang="en">web workers</i>](/fr/docs/Web/API/Web_Workers_API) (elle n'est pas exposée via [`WorkerNavigator`](/fr/docs/Web/API/WorkerNavigator)).
 
 L'**API Selection** permet d'accéder et de manipuler les portions du document sélectionnées par l'utilisatrice ou l'utilisateur.
 

--- a/files/fr/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/fr/web/api/server-sent_events/using_server-sent_events/index.md
@@ -97,7 +97,8 @@ Ce code génère un évènement de type «&nbsp;ping&nbsp;» à chaque seconde. 
 
 La boucle s'exécute indépendamment du statut de la connexion, on a donc une vérification pour terminer l'exécution si la connexion a été terminée.
 
-> **Note :** Vous pouvez trouver un exemple complet utilisant le code ci-dessus sur GitHub : voir [Démonstration d'évènements serveur avec PHP.](https://github.com/mdn/dom-examples/tree/master/server-sent-events)
+> [!NOTE]
+> Vous pouvez trouver un exemple complet utilisant le code ci-dessus sur GitHub : voir [Démonstration d'évènements serveur avec PHP.](https://github.com/mdn/dom-examples/tree/master/server-sent-events)
 
 ## Gestion des erreurs
 
@@ -121,7 +122,8 @@ evtSource.close();
 
 Le flux d'évènements est un simple flux de données de texte, qui doit être encodé en [UTF-8](/fr/docs/Glossary/UTF-8). Les messages dans le flux d'évènements sont séparés par une paire de sauts de ligne. Un caractère deux-points «&nbsp;:&nbsp;» en début de ligne représente un commentaire, et est ignoré.
 
-> **Note :** Une ligne de commentaire peut être utilisée pour empêcher les connexions d'expirer. Un serveur peut envoyer périodiquement des commentaires afin de garder la connexion ouverte.
+> [!NOTE]
+> Une ligne de commentaire peut être utilisée pour empêcher les connexions d'expirer. Un serveur peut envoyer périodiquement des commentaires afin de garder la connexion ouverte.
 
 Chaque message consiste en une ou plusieurs lignes de texte décrivant les champs de ce message. Chaque champ est représenté par le nom du champ, suivi d'un «&nbsp;:&nbsp;», suivi des données de texte pour la valeur de ce champ.
 
@@ -140,7 +142,8 @@ Chaque message reçu contient un ou plusieurs de ces champs, un par ligne :
 
 Tous les autres noms de champs sont ignorés.
 
-> **Note :** Si une ligne ne contient aucun caractère deux-points, la ligne entière est considérée comme le nom du champ, avec un contenu vide.
+> [!NOTE]
+> Si une ligne ne contient aucun caractère deux-points, la ligne entière est considérée comme le nom du champ, avec un contenu vide.
 
 ### Exemples
 

--- a/files/fr/web/api/service_worker_api/index.md
+++ b/files/fr/web/api/service_worker_api/index.md
@@ -17,11 +17,14 @@ Un <i lang="en">service worker</i> s'exécute dans le contexte d'un <i lang="en"
 
 Pour des raisons de sécurité, les <i lang="en">service workers</i> ne fonctionnent qu'avec le protocole HTTPS. En effet, les connexions HTTP sont susceptibles d'être victimes d'injection de code par [attaque du monstre du milieu](/fr/docs/Glossary/MitM) et l'accès à ces API aggraverait ces attaques.
 
-> **Note :** Sur Firefox, les <i lang="en">service workers</i> ne fonctionnent pas en navigation privée.
+> [!NOTE]
+> Sur Firefox, les <i lang="en">service workers</i> ne fonctionnent pas en navigation privée.
 
-> **Note :** Sur Firefox, il est possible de tester les <i lang="en">service workers</i> via HTTP (donc de façon non-sécurisée) en cochant l'option **Activer les Service Workers via HTTP (lorsque la boîte à outils est ouverte)** dans les options des outils de développement.
+> [!NOTE]
+> Sur Firefox, il est possible de tester les <i lang="en">service workers</i> via HTTP (donc de façon non-sécurisée) en cochant l'option **Activer les Service Workers via HTTP (lorsque la boîte à outils est ouverte)** dans les options des outils de développement.
 
-> **Note :** Les <i lang="en">service workers</i> utilisent [les promesses](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise). Ils attendent généralement l'arrivée de réponses auxquelles ils répondront par une action de réussite ou d'échec. L'architecture asynchrone des promesses est idéale pour ce mode de fonctionnement.
+> [!NOTE]
+> Les <i lang="en">service workers</i> utilisent [les promesses](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise). Ils attendent généralement l'arrivée de réponses auxquelles ils répondront par une action de réussite ou d'échec. L'architecture asynchrone des promesses est idéale pour ce mode de fonctionnement.
 
 ### Enregistrement
 
@@ -54,7 +57,8 @@ Il existe également un évènement [`activate`](/fr/docs/Web/API/ServiceWorkerG
 
 Un <i lang="en">service worker</i> peut répondre aux requêtes en utilisant l'évènement [`FetchEvent`](/fr/docs/Web/API/FetchEvent). Les réponses à ces requêtes peuvent être modifiées en utilisant la méthode [`FetchEvent.respondWith()`](/fr/docs/Web/API/FetchEvent/respondWith).
 
-> **Note :** Comme les évènements `install`/`activate` peuvent prendre un certain temps à finir, la spécification fournit une méthode [`waitUntil()`](/fr/docs/Web/API/ExtendableEvent/waitUntil). Lorsque celle-ci est appelée sur les évènements `install` ou `activate` avec une promesse, les évènements fonctionnels comme `fetch` et `push` attendront la résolution de la promesse.
+> [!NOTE]
+> Comme les évènements `install`/`activate` peuvent prendre un certain temps à finir, la spécification fournit une méthode [`waitUntil()`](/fr/docs/Web/API/ExtendableEvent/waitUntil). Lorsque celle-ci est appelée sur les évènements `install` ou `activate` avec une promesse, les évènements fonctionnels comme `fetch` et `push` attendront la résolution de la promesse.
 
 Pour un tutoriel complet illustrant comment construire un premier exemple simple fonctionnel, voir le guide [Utiliser les <i lang="en">service workers</i>](/fr/docs/Web/API/Service_Worker_API/Using_Service_Workers).
 

--- a/files/fr/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/fr/web/api/service_worker_api/using_service_workers/index.md
@@ -89,7 +89,8 @@ Cela permet d'enregistrer un <i lang="en">service worker</i> qui s'exécute dans
 
 Un seul <i lang="en">service worker</i> peut contrôler de nombreuses pages. Chaque fois qu'une page concernée par la portée du <i lang="en">service worker</i> est chargée, le <i lang="en">service worker</i> est installé pour cette page et s'en occupe. Il faut donc faire attention aux variables globales dans le script d'un <i lang="en">service worker</i>, car chaque page ne récupère un exemplaire séparé distinct.
 
-> **Note :** En utilisant la détection de fonctionnalité comme nous l'avons fait plus haut, cela permet aux navigateurs qui ne prennent pas en charge ces fonctionnalités de servir l'application en ligne normalement.
+> [!NOTE]
+> En utilisant la détection de fonctionnalité comme nous l'avons fait plus haut, cela permet aux navigateurs qui ne prennent pas en charge ces fonctionnalités de servir l'application en ligne normalement.
 
 #### Pourquoi est-ce l'enregistrement de mon <i lang="en">service worker</i> échoue&nbsp;?
 
@@ -141,7 +142,8 @@ self.addEventListener("install", (event) => {
 
 > **Note :** [L'API <i lang="en">Web Storage</i> (`localStorage`)](/fr/docs/Web/API/Web_Storage_API) fonctionne de façon semblable au cache d'un <i lang="en">service worker</i> mais est synchrone et son utilisation n'est donc pas autorisée dans les <i lang="en">services workers</i>.
 
-> **Note :** Si besoin, [l'API IndexedDB](/fr/docs/Web/API/IndexedDB_API) peut être utilisée dans un <i lang="en">service worker</i> pour stocker des données.
+> [!NOTE]
+> Si besoin, [l'API IndexedDB](/fr/docs/Web/API/IndexedDB_API) peut être utilisée dans un <i lang="en">service worker</i> pour stocker des données.
 
 ### Créer des réponses sur mesure pour les requêtes
 
@@ -387,7 +389,8 @@ On notera dans cet exemple qu'on télécharge et met en cache les mêmes donnée
 
 Si le <i lang="en">service worker</i> a précédemment été installé et qu'une nouvelle version est disponible lors du rafraîchissement ou du chargement de la page, la nouvelle version est installée en arrière-plan, mais n'est pas activée. Elle est uniquement activée lorsqu'il n'y a plus de pages chargées qui utilisent l'ancien <i lang="en">service worker</i>. Dès qu'il n'y a plus de page chargée, le nouveau <i lang="en">service worker</i> s'active.
 
-> **Note :** Il est possible de contourner ce comportement en utilisant [`Clients.claim()`](/fr/docs/Web/API/Clients/claim).
+> [!NOTE]
+> Il est possible de contourner ce comportement en utilisant [`Clients.claim()`](/fr/docs/Web/API/Clients/claim).
 
 Il faut alors mettre à jour le gestionnaire d'évènement pour `install` dans le nouveau <i lang="en">service worker</i> (notez le nouveau numéro de version)&nbsp;:
 

--- a/files/fr/web/api/serviceworkerregistration/active/index.md
+++ b/files/fr/web/api/serviceworkerregistration/active/index.md
@@ -9,7 +9,8 @@ La propriété **`active`** de l'interface {{domxref("ServiceWorkerRegistration"
 
 Un _worker_ actif contrôle un {{domxref("ServiceWorkerClient")}} si l'URL du client appartient au domaine de l'inscription (l'option `scope` définie lorsque {{domxref("ServiceWorkerContainer.register")}} est initialement appelé.)
 
-> **Note :** Cette fonctionnalité est disponible dans les [Web Workers](/fr/docs/Web/API/Web_Workers_API).
+> [!NOTE]
+> Cette fonctionnalité est disponible dans les [Web Workers](/fr/docs/Web/API/Web_Workers_API).
 
 ## Syntaxe
 

--- a/files/fr/web/api/serviceworkerregistration/scope/index.md
+++ b/files/fr/web/api/serviceworkerregistration/scope/index.md
@@ -7,7 +7,8 @@ slug: Web/API/ServiceWorkerRegistration/scope
 
 La propriété en lecture seule **`scope`** de l'interface {{domxref ("ServiceWorkerRegistration")}} renvoie un identifiant unique pour un enregistrement de service worker. Le service worker doit être sur la même origine que le document qui enregistre le {{domxref ("ServiceWorker")}}.
 
-> **Note :** Cette fonctionnalité est disponible dans [Web Workers](/fr/docs/Web/API/Web_Workers_API).
+> [!NOTE]
+> Cette fonctionnalité est disponible dans [Web Workers](/fr/docs/Web/API/Web_Workers_API).
 
 ## Syntaxe
 

--- a/files/fr/web/api/serviceworkerregistration/shownotification/index.md
+++ b/files/fr/web/api/serviceworkerregistration/shownotification/index.md
@@ -7,7 +7,8 @@ slug: Web/API/ServiceWorkerRegistration/showNotification
 
 La méthode **`showNotification()`** de l'interface {{domxref("ServiceWorkerRegistration")}} crée une notification dans un service worker actif.
 
-> **Note :** Cette fonctionnalité est disponible dans les [Web Workers](/fr/docs/Web/API/Web_Workers_API).
+> [!NOTE]
+> Cette fonctionnalité est disponible dans les [Web Workers](/fr/docs/Web/API/Web_Workers_API).
 
 ## Syntaxe
 

--- a/files/fr/web/api/shadowroot/delegatesfocus/index.md
+++ b/files/fr/web/api/shadowroot/delegatesfocus/index.md
@@ -7,7 +7,8 @@ slug: Web/API/ShadowRoot/delegatesFocus
 
 **`delegatesFocus`** est une propriété en lecture seule, rattachée à l'interface {{domxref("ShadowRoot")}} et qui renvoie un booléen indiquant si l'option `delegatesFocus` a été intialisée lors de l'attachement de la racine _shadow_ (cf. {{domxref("Element.attachShadow()")}}).
 
-> **Attention :** Cette fonctionnalité est expérimentale, non-standard et uniquement disponible dans Chrome.
+> [!WARNING]
+> Cette fonctionnalité est expérimentale, non-standard et uniquement disponible dans Chrome.
 
 ## Syntaxe
 

--- a/files/fr/web/api/sharedworker/index.md
+++ b/files/fr/web/api/sharedworker/index.md
@@ -7,7 +7,8 @@ slug: Web/API/SharedWorker
 
 L'interface **`SharedWorker`** représente un type spécifique de worker qui peut être _accédé_ à partir de plusieurs contextes de navigation, tels que plusieurs fenêtres, iframes ou même workers. Ils implémentent une autre interface que les workers dédiés et ont un contexte global différent, {{domxref("SharedWorkerGlobalScope")}}.
 
-> **Note :** Si un SharedWorker peut être accédé à partir de plusieurs contextes de navigation, tous ces contextes de navigation doivent partager exactement la même origine (même protocole, hôte et port.)
+> [!NOTE]
+> Si un SharedWorker peut être accédé à partir de plusieurs contextes de navigation, tous ces contextes de navigation doivent partager exactement la même origine (même protocole, hôte et port.)
 
 ## Constructeurs
 

--- a/files/fr/web/api/sharedworker/sharedworker/index.md
+++ b/files/fr/web/api/sharedworker/sharedworker/index.md
@@ -9,7 +9,8 @@ l10n:
 
 Le constructeur **`SharedWorker()`** crée un objet [`SharedWorker`](/fr/docs/Web/API/SharedWorker) qui exécute le script depuis l'URL indiquée. Le script doit respecter la [politique de même origine](/fr/docs/Web/Security/Same-origin_policy).
 
-> **Note :** Il y a désaccord entre les éditeurs de navigateur pour savoir si une URL de données partage la même origine. Bien que Gecko 10.0 et les versions supérieures acceptent des URL de données, ce n'est pas le cas de tous les autres navigateurs.
+> [!NOTE]
+> Il y a désaccord entre les éditeurs de navigateur pour savoir si une URL de données partage la même origine. Bien que Gecko 10.0 et les versions supérieures acceptent des URL de données, ce n'est pas le cas de tous les autres navigateurs.
 
 ## Syntaxe
 

--- a/files/fr/web/api/sharedworkerglobalscope/connect_event/index.md
+++ b/files/fr/web/api/sharedworkerglobalscope/connect_event/index.md
@@ -34,7 +34,8 @@ onconnect = function (e) {
 
 Pour l'exemple complet en fonctionnement, voir [Basic shared worker example](https://github.com/mdn/simple-shared-worker) ([run shared worker](http://mdn.github.io/simple-shared-worker/).)
 
-> **Note :** La propriété `data` de l'objet évènement est `null` dans Firefox. À partir de la version 65, elle est initialisée comme une chaîne vide, selon les spécifications ([bug Firefox 1508824](https://bugzil.la/1508824)).
+> [!NOTE]
+> La propriété `data` de l'objet évènement est `null` dans Firefox. À partir de la version 65, elle est initialisée comme une chaîne vide, selon les spécifications ([bug Firefox 1508824](https://bugzil.la/1508824)).
 
 ## Spécifications
 

--- a/files/fr/web/api/storage/clear/index.md
+++ b/files/fr/web/api/storage/clear/index.md
@@ -31,7 +31,8 @@ function peuplerLeStockage() {
 }
 ```
 
-> **Note :** Pour voir un exemple réel, vous pouvez visitez notre [Démo de stockage web](https://mdn.github.io/dom-examples/web-storage/). Les modifications sont visibles dans la console, vous pouvez actualiser la page et conserver les modifications.
+> [!NOTE]
+> Pour voir un exemple réel, vous pouvez visitez notre [Démo de stockage web](https://mdn.github.io/dom-examples/web-storage/). Les modifications sont visibles dans la console, vous pouvez actualiser la page et conserver les modifications.
 
 ## Spécifications
 

--- a/files/fr/web/api/storage/getitem/index.md
+++ b/files/fr/web/api/storage/getitem/index.md
@@ -41,7 +41,8 @@ function setStyles() {
 }
 ```
 
-> **Note :** Pour voir cette fonction utilisée dans un exemple réel, dirigez-vous vers notre [Demo de Stockage Web (en)](https://github.com/mdn/web-storage-demo).
+> [!NOTE]
+> Pour voir cette fonction utilisée dans un exemple réel, dirigez-vous vers notre [Demo de Stockage Web (en)](https://github.com/mdn/web-storage-demo).
 
 ## Spécifications
 

--- a/files/fr/web/api/storage/key/index.md
+++ b/files/fr/web/api/storage/key/index.md
@@ -34,7 +34,8 @@ function forEachKey(callback) {
 }
 ```
 
-> **Note :** Pour un exemple plus poussé, consultez la [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> [!NOTE]
+> Pour un exemple plus poussé, consultez la [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Autre exemple
 

--- a/files/fr/web/api/storage/length/index.md
+++ b/files/fr/web/api/storage/length/index.md
@@ -31,7 +31,8 @@ function populateStorage() {
 }
 ```
 
-> **Note :** Pour voir ceci utilisé dans un exemple concret, regardez notre [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> [!NOTE]
+> Pour voir ceci utilisé dans un exemple concret, regardez notre [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Spécifications
 

--- a/files/fr/web/api/storage/removeitem/index.md
+++ b/files/fr/web/api/storage/removeitem/index.md
@@ -50,7 +50,8 @@ function populateStorage() {
 }
 ```
 
-> **Note :** Pour voir ce code en fonctionnement, voir [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> [!NOTE]
+> Pour voir ce code en fonctionnement, voir [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Spécifications
 

--- a/files/fr/web/api/storage/setitem/index.md
+++ b/files/fr/web/api/storage/setitem/index.md
@@ -41,7 +41,8 @@ function remplissageStockage() {
 }
 ```
 
-> **Note :** Pour voir ceci utilisé dans un exemple concret, regardez notre [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> [!NOTE]
+> Pour voir ceci utilisé dans un exemple concret, regardez notre [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Spécifications
 

--- a/files/fr/web/api/storage_api/index.md
+++ b/files/fr/web/api/storage_api/index.md
@@ -47,7 +47,8 @@ Modifier le mode de boîte d'une origine nécessite la permission d'utiliser la 
 
 Si le site ou l'application a la permission sur la fonctionnalité **`"persistent-storage"`**, il ou elle peut utiliser la méthode {{domxref("StorageManager.persist()")}} pour faire la requête que sa boîte devienne persistante. Il est également possible pour l'agent utilisateur de décider de rendre l'unité de stockage du site persistante sur la base de caractéristiques d'usage ou d'autres métriques. Les drapeaux (_flags_), algorithmes et types associés à la permission `"persistent-storage"`, sont tous positionnés sur les valeurs par défaut standard pour une permission, excepté que **l'état de permission** doit être le même sur l'ensemble de l'origine, et que si l'état de permission n'est pas `"granted"` (c'est-à-dire que si, pour une raison ou une autre, l'accès à la fonctionnalité de stockage persistant a été refusé), le mode de boîte de l'unité de stockage de site de l'origine est toujours `"best-effort"`.
 
-> **Note :** Voir [Using the Permissions API](/fr/docs/Web/API/Permissions_API/Using_the_Permissions_API) pour plus de détails sur l'obtension et la gestion des permissions.
+> [!NOTE]
+> Voir [Using the Permissions API](/fr/docs/Web/API/Permissions_API/Using_the_Permissions_API) pour plus de détails sur l'obtension et la gestion des permissions.
 
 Lors du nettoyage d'unités de stockage de site, la boîte d'une origine est traitée comme une seule entité&nbsp;; si l'agent utilisateur a besoin de la nettoyer et si l'utilisateur ou l'utilisatrice approuve, le stockage de données entier est nettoyé plutôt que de fournir un moyen de nettoyer seulement les données d'une API individuelle.
 

--- a/files/fr/web/api/storage_api/storage_quotas_and_eviction_criteria/index.md
+++ b/files/fr/web/api/storage_api/storage_quotas_and_eviction_criteria/index.md
@@ -5,9 +5,11 @@ slug: Web/API/Storage_API/Storage_quotas_and_eviction_criteria
 
 {{DefaultAPISidebar("IndexedDB")}}
 
-> **Note :** Il existe un certain nombre de technologies Web qui stockent des données d'un type ou d'un autre du côté client (c'est-à-dire sur le disque local). Le processus par lequel le navigateur calcule l'espace alloué au stockage de données Web et les données à supprimer quand la limite est atteinte n'est pas simple et diffère d'un navigateur à l'autre. Cet article tente d'expliquer comment tout cela fonctionne.
+> [!NOTE]
+> Il existe un certain nombre de technologies Web qui stockent des données d'un type ou d'un autre du côté client (c'est-à-dire sur le disque local). Le processus par lequel le navigateur calcule l'espace alloué au stockage de données Web et les données à supprimer quand la limite est atteinte n'est pas simple et diffère d'un navigateur à l'autre. Cet article tente d'expliquer comment tout cela fonctionne.
 
-> **Note :** Les informations ci-dessous devraient être assez précises pour la plupart des navigateurs modernes, mais les spécificités du navigateur sont évoquées quand elles sont connues. Opera et Chrome devraient se comporter de la même manière dans tous les cas. Mais [Opera Mini](http://www.opera.com/mobile/mini) (encore basé sur presto du côté serveur) ne stocke aucune donnée sur le client.
+> [!NOTE]
+> Les informations ci-dessous devraient être assez précises pour la plupart des navigateurs modernes, mais les spécificités du navigateur sont évoquées quand elles sont connues. Opera et Chrome devraient se comporter de la même manière dans tous les cas. Mais [Opera Mini](http://www.opera.com/mobile/mini) (encore basé sur presto du côté serveur) ne stocke aucune donnée sur le client.
 
 ## Les différents types de stockage des données
 
@@ -55,13 +57,17 @@ Chaque type de stockage représente un référentiel distinct, voici la cartogra
 - `<profile>/storage/temporary` — répertoire de stockage des données temporaires.
 - `<profile>/storage/default` — répertoire de stockage des données par défaut.
 
-> **Note :** Depuis l'introduction de l' [API Storage](/fr/docs/Web/API/Storage_API) , le dossier "permanent" peut être considéré comme obsolète, il n'est plus utilisé que pour les bases de données de type persistant IndexedDB. Peu importe le mode, "best-effort" _(meilleur effort)_ ou "persistant", les données sont stockées sous `<profile>/storage/default`.
+> [!NOTE]
+> Depuis l'introduction de l' [API Storage](/fr/docs/Web/API/Storage_API) , le dossier "permanent" peut être considéré comme obsolète, il n'est plus utilisé que pour les bases de données de type persistant IndexedDB. Peu importe le mode, "best-effort" _(meilleur effort)_ ou "persistant", les données sont stockées sous `<profile>/storage/default`.
 
-> **Note :** Dans Firefox, vous pouvez trouver votre dossier profil en entrant : `support` dans la barre d'URL et en appuyant sur le bouton _Show in.._. _(Afficher dans ...)_ (par exemple, _"Show in Finder"_ sur Mac OS X) à côté du titre _"Profile Folder" (dossier de profil)_ .
+> [!NOTE]
+> Dans Firefox, vous pouvez trouver votre dossier profil en entrant : `support` dans la barre d'URL et en appuyant sur le bouton _Show in.._. _(Afficher dans ...)_ (par exemple, _"Show in Finder"_ sur Mac OS X) à côté du titre _"Profile Folder" (dossier de profil)_ .
 
-> **Note :** Si vous regardez dans votre profil les répertoires de données stockées, vous pouvez voir un quatrième dossier : `persistent` . À la base, le dossier `persistent` a été renommé `permanent,` il y a quelques temps, pour faciliter les mises à niveau / migrations.
+> [!NOTE]
+> Si vous regardez dans votre profil les répertoires de données stockées, vous pouvez voir un quatrième dossier : `persistent` . À la base, le dossier `persistent` a été renommé `permanent,` il y a quelques temps, pour faciliter les mises à niveau / migrations.
 
-> **Note :** Les utilisateurs ne doivent pas ajouter leurs propres répertoires ou fichiers sous `<profile>/storage` . Cela entraînerait l'échec de l'initialisation du stockage ; par exemple {{domxref ("IDBFactory.open ()", "open ()")}} déclencherait un événement d'erreur.
+> [!NOTE]
+> Les utilisateurs ne doivent pas ajouter leurs propres répertoires ou fichiers sous `<profile>/storage` . Cela entraînerait l'échec de l'initialisation du stockage ; par exemple {{domxref ("IDBFactory.open ()", "open ()")}} déclencherait un événement d'erreur.
 
 ## Limites de stockage
 
@@ -85,7 +91,8 @@ Les deux limites reagissent différemment quand la limite est atteinte :
 - La limite de groupe est également appelée «limite dure»: elle ne déclenche pas l'éviction d'origine.
 - La limite globale est une «limite douce» car il est possible que certains espaces soient libérés et que l'opération puisse se poursuivre.
 
-> **Note :** Si la limite de groupe est dépassée, ou si l'éviction d'origine ne crée pas assez d'espace libre, le navigateur lance `QuotaExceededError`.
+> [!NOTE]
+> Si la limite de groupe est dépassée, ou si l'éviction d'origine ne crée pas assez d'espace libre, le navigateur lance `QuotaExceededError`.
 
 ## Politique LRU
 

--- a/files/fr/web/api/storagemanager/estimate/index.md
+++ b/files/fr/web/api/storagemanager/estimate/index.md
@@ -30,7 +30,8 @@ Une promesse (un objet [`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Obje
 - `usageDetails` {{Non-standard_Inline}}
   - : Un objet contenant une décomposition de `usage` par système de stockage. Toutes les propriétés incluses sur cet objet auront un `usage` supérieur à 0 et tout système de stockage avec `usage` à 0 ne sera pas fourni comme propriété de cet objet.
 
-> **Note :** Les valeurs renvoyées ne sont pas précisément exactes. Cela est lié à la compression, la déduplication de données et au masquage des informations pour des raisons de sécurité.
+> [!NOTE]
+> Les valeurs renvoyées ne sont pas précisément exactes. Cela est lié à la compression, la déduplication de données et au masquage des informations pour des raisons de sécurité.
 
 Vous pourrez observer que `quota` varie en fonction des origines. Cette variation est basée sur plusieurs facteurs dont&nbsp;:
 

--- a/files/fr/web/api/streams_api/index.md
+++ b/files/fr/web/api/streams_api/index.md
@@ -25,7 +25,8 @@ Un usage plus avancé consiste à créer son propre flux en utilisant le constru
 
 Vous pouvez aussi écrire des données vers les flux en utilisant {{domxref("WritableStream")}}.
 
-> **Note :** Vous trouverez plus de détails sur la théorie et la mise en pratique des flux dans nos articles — [Streams API concepts](/fr/docs/Web/API/Streams_API/Concepts), [Using readable streams](/fr/docs/Web/API/Streams_API/Using_readable_streams), et [Using writable streams](/fr/docs/Web/API/Streams_API/Using_writable_streams).
+> [!NOTE]
+> Vous trouverez plus de détails sur la théorie et la mise en pratique des flux dans nos articles — [Streams API concepts](/fr/docs/Web/API/Streams_API/Concepts), [Using readable streams](/fr/docs/Web/API/Streams_API/Using_readable_streams), et [Using writable streams](/fr/docs/Web/API/Streams_API/Using_writable_streams).
 
 ## Stream interfaces
 
@@ -63,7 +64,8 @@ Vous pouvez aussi écrire des données vers les flux en utilisant {{domxref("Wri
 
 ### Interfaces liées aux flux d'octets
 
-> **Attention :** Ces méthodes ne sont pas implémentés pour le moment, des questions ont été soulevées afin de déterminer si les détails des specs sont dans état suffisamment stable pour être implémentés. Ceci pourrait changer avec le temps.
+> [!WARNING]
+> Ces méthodes ne sont pas implémentés pour le moment, des questions ont été soulevées afin de déterminer si les détails des specs sont dans état suffisamment stable pour être implémentés. Ceci pourrait changer avec le temps.
 
 - {{domxref("ReadableStreamBYOBReader")}}
   - : Correspond à un lecteur BYOB ("bring your own buffer") pouvant être utilisé pour lire des flux de données fourni par le développeur (c.a.d. un constructeur {{domxref("ReadableStream.ReadableStream", "ReadableStream()")}} personalisé).

--- a/files/fr/web/api/subtlecrypto/digest/index.md
+++ b/files/fr/web/api/subtlecrypto/digest/index.md
@@ -38,7 +38,8 @@ Les algorithmes de condensé, aussi connue sous le nom de [fonctions de hachage 
 
 Cet algorithme est spécifié dans [FIPS 180-4](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf), section 6.1, et produit un résultat de 160 bits de long.
 
-> **Attention :** Cet algorithme est maintenant considérer comme vulnérable et ne doit pas être utilisé pour des applications cryptographiques.
+> [!WARNING]
+> Cet algorithme est maintenant considérer comme vulnérable et ne doit pas être utilisé pour des applications cryptographiques.
 
 ### SHA-256
 
@@ -52,7 +53,8 @@ Cet algorithme est spécifié dans [FIPS 180-4](https://nvlpubs.nist.gov/nistpub
 
 Cet algorithme est spécifié dans [FIPS 180-4](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf), section 6.4, et produit un résultat de 512 bits de long.
 
-> **Note :** Si vous cherchez à créer un condensé pour authentifié un message ([HMAC](/fr/docs/Glossary/HMAC)), vous aurez plutôt besoin de [SubtleCrypto.sign()](/fr/docs/Web/API/SubtleCrypto/sign#HMAC).
+> [!NOTE]
+> Si vous cherchez à créer un condensé pour authentifié un message ([HMAC](/fr/docs/Glossary/HMAC)), vous aurez plutôt besoin de [SubtleCrypto.sign()](/fr/docs/Web/API/SubtleCrypto/sign#HMAC).
 
 ## Exemples
 

--- a/files/fr/web/api/textencoder/index.md
+++ b/files/fr/web/api/textencoder/index.md
@@ -7,9 +7,11 @@ slug: Web/API/TextEncoder
 
 **`TextEncoder`** prend un flux de points de code en entrée et émet un flux d'octets. Pour une bibliothèque non native plus extensible, voir [`StringView` – une représentation des chaînes de caractères proche de celle de C basée sur les tableaux typés](/fr/Add-ons/Code_snippets/StringView).
 
-> **Note :** Firefox, Chrome et Opera ont pour habitude de supporter les types d'encodage autres que `utf-8` (tels que `utf-16`, `iso-8859-2`, `koi8`, `cp1261`, et `gbk`). À partir de Firefox 48 ([bug Firefox 1257877](https://bugzil.la/1257877)), Chrome 54 ([ticket](https://www.chromestatus.com/feature/5630760492990464)) et Opera 41, aucun type d'encodage autre que `utf-8` n'est disponible, de manière à être en accord avec la [spécification](https://www.w3.org/TR/encoding/#dom-textencoder). Dans tous les cas, passer un type d'encodage au constructeur sera ignoré et un TextEncoder utf-8 sera créé (le {{DOMxRef("TextDecoder")}} permet toujours d'autres types pour le décodage).
+> [!NOTE]
+> Firefox, Chrome et Opera ont pour habitude de supporter les types d'encodage autres que `utf-8` (tels que `utf-16`, `iso-8859-2`, `koi8`, `cp1261`, et `gbk`). À partir de Firefox 48 ([bug Firefox 1257877](https://bugzil.la/1257877)), Chrome 54 ([ticket](https://www.chromestatus.com/feature/5630760492990464)) et Opera 41, aucun type d'encodage autre que `utf-8` n'est disponible, de manière à être en accord avec la [spécification](https://www.w3.org/TR/encoding/#dom-textencoder). Dans tous les cas, passer un type d'encodage au constructeur sera ignoré et un TextEncoder utf-8 sera créé (le {{DOMxRef("TextDecoder")}} permet toujours d'autres types pour le décodage).
 
-> **Note :** Il y a une prothèse d'émulation d'implantation pour supporter tous les encodages hérités dans [GitHub](https://github.com/inexorabletash/text-encoding).
+> [!NOTE]
+> Il y a une prothèse d'émulation d'implantation pour supporter tous les encodages hérités dans [GitHub](https://github.com/inexorabletash/text-encoding).
 
 ## Constructeur
 

--- a/files/fr/web/api/textencoder/textencoder/index.md
+++ b/files/fr/web/api/textencoder/textencoder/index.md
@@ -17,7 +17,8 @@ encoder = new TextEncoder();
 
 - `TextEncoder()` ne prend plus de paramètre depuis Firefox 48 et Chrome 53.
 
-> **Note :** Avant Firefox 48 et Chrome 53, le nom de l'encodage était accepté comme un paramètre pour le constructeur de `TextEncoder`.
+> [!NOTE]
+> Avant Firefox 48 et Chrome 53, le nom de l'encodage était accepté comme un paramètre pour le constructeur de `TextEncoder`.
 > Depuis, ces deux navigateurs ont supprimé le support pour les encodages autres que l'`utf-8` afin de respecter les [spécifications](https://www.w3.org/TR/encoding/#dom-textencoder).
 > Désormais, n'importe quelle indication d'encodage passée au constructeur sera ignorée et `TextEncoder` sera créé avec le support de l'encodage `utf-8` uniquement.
 

--- a/files/fr/web/api/touch_events/index.md
+++ b/files/fr/web/api/touch_events/index.md
@@ -31,7 +31,8 @@ Les évènements tactiles sont semblables aux évènements liés à la souris, s
 
 Dans cet exemple, on suit plusieurs points de contact à la fois, ce qui permet à la personne de dessiner dans un canevas ([`<canvas>`](/fr/docs/Web/HTML/Element/canvas)) avec plusieurs doigts en même temps. Cet exemple ne fonctionnera qu'avec un navigateur qui prend en charge les évènements tactiles.
 
-> **Note :** Dans le texte qui suit, on utilise le terme «&nbsp;doigt&nbsp;» pour décrire le contact avec la surface. Bien entendu, il peut s'agir d'une autre méthode de contact, comme un stylet ou autre.
+> [!NOTE]
+> Dans le texte qui suit, on utilise le terme «&nbsp;doigt&nbsp;» pour décrire le contact avec la surface. Bien entendu, il peut s'agir d'une autre méthode de contact, comme un stylet ou autre.
 
 ### Création du canevas
 
@@ -266,7 +267,8 @@ Vous pouvez tester cet exemple sur un appareil mobile en touchant le cadre qui s
 
 {{EmbedLiveSample('','100%', 900)}}
 
-> **Note :** De façon plus générale, cet exemple fonctionne sur les plateformes qui fournissent des évènements tactiles. Il est possible de tester cet exemple sur les navigateurs de bureau qui peuvent simuler de tels évènements&nbsp;:
+> [!NOTE]
+> De façon plus générale, cet exemple fonctionne sur les plateformes qui fournissent des évènements tactiles. Il est possible de tester cet exemple sur les navigateurs de bureau qui peuvent simuler de tels évènements&nbsp;:
 >
 > - Sur Firefox, on peut activer «&nbsp;la simulation des évènements tactiles&nbsp;» dans [la vue adaptative](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/index.html#toggling-responsive-design-mode) (il peut être nécessaire de recharger la page).
 > - Sur Chrome, on peut utiliser [le mode appareil](https://developer.chrome.com/docs/devtools/device-mode/) et choisir [un type d'appareil](https://developer.chrome.com/docs/devtools/device-mode/#type) qui émet des évènements tactiles.

--- a/files/fr/web/api/treewalker/index.md
+++ b/files/fr/web/api/treewalker/index.md
@@ -143,7 +143,8 @@ _Cette interface n'hérite d'aucune propriété._
 
 _Cette interface n'hérite d'aucune méthode._
 
-> **Note :** Le TreeWalker considère uniquement les nœuds DOM visibles.
+> [!NOTE]
+> Le TreeWalker considère uniquement les nœuds DOM visibles.
 
 - {{domxref("TreeWalker.parentNode()")}}
   - : Déplace le {{domxref("Node")}} actuel vers le premier noeud ancêtre _visible_ dans l'ordre du document et renvoie le noeud trouvé. Il déplace également le noeud actuel vers celui-ci. Si aucun noeud n'existe ou s'il est antérieur au _noeud racine_ défini lors de la construction de l'objet, renvoie `null` et le noeud courant n'est pas modifié.

--- a/files/fr/web/api/url/createobjecturl_static/index.md
+++ b/files/fr/web/api/url/createobjecturl_static/index.md
@@ -10,7 +10,8 @@ Pour libérer une URL d'objet, il faut appeler {{domxref("URL.revokeObjectURL", 
 
 {{AvailableInWorkers}}
 
-> **Note :** Cette fonctionnalité n'est pas disponible dans les [Service Workers](/fr/docs/Web/API/ServiceWorker) à cause de possible fuite mémoire.
+> [!NOTE]
+> Cette fonctionnalité n'est pas disponible dans les [Service Workers](/fr/docs/Web/API/ServiceWorker) à cause de possible fuite mémoire.
 
 ## Syntaxe
 
@@ -43,7 +44,8 @@ Les navigateurs libèrent automatiquement les URL d'objet lorsque le document es
 
 Dans d'anciennes versions de la spécification de Media Source, attacher un flux à un élément {{HTMLElement("video")}} requérait de créer une URL d'objet pour le {{domxref("MediaStream")}}. Cela n'est plus nécessaire, et les navigateurs cessent progressivement de supporter cette pratique.
 
-> **Attention :** si vous avez toujours du code qui repose sur {{domxref("URL.createObjectURL")}} pour attacher des flux à des éléments média, vous devez mettre à jour votre code pour attacher simplement {{domxref("HTMLMediaElement.srcObject", "srcObject")}} directement au `MediaStream`.
+> [!WARNING]
+> Si vous avez toujours du code qui repose sur {{domxref("URL.createObjectURL")}} pour attacher des flux à des éléments média, vous devez mettre à jour votre code pour attacher simplement {{domxref("HTMLMediaElement.srcObject", "srcObject")}} directement au `MediaStream`.
 
 ## Spécifications
 

--- a/files/fr/web/api/url/url/index.md
+++ b/files/fr/web/api/url/url/index.md
@@ -24,7 +24,8 @@ url = new URL(url, [base])
 - _base_ {{optional_inline}}
   - : Un {{domxref("USVString")}} représentant l'URL de base à utiliser dans le cas où l'URL est une URL relative. Si non spécifié, il est par défaut à `''`.
 
-> **Note :** Vous pouvez toujours utiliser un objet {{domxref ("URL")}} existant pour la base, qui se stringifie en attribut {{domxref ("DOMString.href", "href")}} de l'objet.
+> [!NOTE]
+> Vous pouvez toujours utiliser un objet {{domxref ("URL")}} existant pour la base, qui se stringifie en attribut {{domxref ("DOMString.href", "href")}} de l'objet.
 
 ### Exceptions
 

--- a/files/fr/web/api/urlsearchparams/entries/index.md
+++ b/files/fr/web/api/urlsearchparams/entries/index.md
@@ -7,7 +7,8 @@ slug: Web/API/URLSearchParams/entries
 
 La méthode **`URLSearchParams.entries()`** retourne un itérateur( {{jsxref("Iteration_protocols",'iterator')}}) permettant de parcourir les paires de clé/valeur contenues dans cet objet. La clé et la valeur de chaque paire est un objet {{domxref("USVString")}} .
 
-> **Note :** This method is available in [Web Workers](/fr/docs/Web/API/Web_Workers_API).
+> [!NOTE]
+> This method is available in [Web Workers](/fr/docs/Web/API/Web_Workers_API).
 
 ## Syntaxe
 

--- a/files/fr/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.md
+++ b/files/fr/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.md
@@ -55,7 +55,8 @@ Prenons deux {{ domxref("AudioBuffer") }}, l'un en mono et l'autre en stéréo, 
 
 Lorsqu'un noeud de mémoire tampon est lu, on entend d'abord la trame la trame la plus à gauche, puis celle qui la suit à droite, etc. Dans le cas de la stéréo, on entend les deux canaux en même temps. Les trames d'échantillon sont très utiles, car elles représentent le temps indépendamment du nombre de canaux.
 
-> **Note :** Pour obtenir le temps en secondes à partir du nombre de trames, diviser le nombre de trames par le taux d'échantillonage. Pour obtenir le nombre de trames à partir du nombre d'échantillons, diviser le nombre d'échantillons par le nombre de canaux.
+> [!NOTE]
+> Pour obtenir le temps en secondes à partir du nombre de trames, diviser le nombre de trames par le taux d'échantillonage. Pour obtenir le nombre de trames à partir du nombre d'échantillons, diviser le nombre d'échantillons par le nombre de canaux.
 
 Voici quelques exemples simples:
 
@@ -79,7 +80,8 @@ var memoireTampon = context.createBuffer(1, 22050, 22050);
 
 Ce code génère une mémoire tampon mono (un seul canal) qui, lorsqu'elle est lue dans un AudioContext à 44100Hzz, est automatiquement \*rééchantillonnée\* à 44100Hz (et par conséquent produit 44100 trames), et dure 1.0 seconde: 44100 frames / 44100Hz = 1 seconde.
 
-> **Note :** le rééchantillonnage audio est très similaire à la redimension d'une image&nbsp;: imaginons que vous ayiez une image de 16 x 16, mais que vous vouliez remplir une surface de 32x32: vous la redimensionnez (rééchantillonnez). Le résultat est de qualité inférieure (il peut être flou ou crénelé, en fonction de l'algorithme de redimensionnement), mais cela fonctionne, et l'image redimensionnée prend moins de place que l'originale. C'est la même chose pour le rééchantillonnage audio — vous gagnez de la place, mais en pratique il sera difficle de reproduire correctement des contenus de haute fréquence (c'est-à-dire des sons aigus).
+> [!NOTE]
+> Le rééchantillonnage audio est très similaire à la redimension d'une image&nbsp;: imaginons que vous ayiez une image de 16 x 16, mais que vous vouliez remplir une surface de 32x32: vous la redimensionnez (rééchantillonnez). Le résultat est de qualité inférieure (il peut être flou ou crénelé, en fonction de l'algorithme de redimensionnement), mais cela fonctionne, et l'image redimensionnée prend moins de place que l'originale. C'est la même chose pour le rééchantillonnage audio — vous gagnez de la place, mais en pratique il sera difficle de reproduire correctement des contenus de haute fréquence (c'est-à-dire des sons aigus).
 
 ### Mémoire tampon linéaire ou entrelacée
 
@@ -385,7 +387,8 @@ On peut accéder aux données en utilisant les méthodes suivantes:
 - {{domxref("AnalyserNode.getByteTimeDomainData()")}}
   - : Copie les données de l'onde de forme, ou domaine temporel, dans le tableau d'octets non signés {{domxref("Uint8Array")}} passé en argument.
 
-> **Note :** Pour plus d'informations, voir notre article [Visualizations with Web Audio API](/fr/docs/Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API).
+> [!NOTE]
+> Pour plus d'informations, voir notre article [Visualizations with Web Audio API](/fr/docs/Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API).
 
 ## Spatialisations
 
@@ -399,7 +402,8 @@ La position de l'auditeur est décrite avec des coodonnées cartésiennes selon 
 
 ![On voit la position d'un auditeur, ainsi que les vecteurs de direction haut et de face qui forment un angle de 90°](listener.svg)
 
-> **Note :** For more information, see our [Web audio spatialization basics](/fr/docs/Web/API/Web_Audio_API/Web_audio_spatialization_basics) article.
+> [!NOTE]
+> For more information, see our [Web audio spatialization basics](/fr/docs/Web/API/Web_Audio_API/Web_audio_spatialization_basics) article.
 
 ## Fan-in et Fan-out
 

--- a/files/fr/web/api/web_audio_api/index.md
+++ b/files/fr/web/api/web_audio_api/index.md
@@ -29,7 +29,8 @@ Le timing est contrôlé avec une grande précision et une latence faible, ce qu
 
 La Web Audio API permet également de contrôler la _spatialisation_ du son. En utilisant un système basé sur le modèle _émetteur - récepteur,_ elle permet le contrôle de la balance ainsi que la gestion de l'atténuation du son en fonction de la distance, ou effet doppler, induite par un déplacement de la source sonore (ou de l'auditeur).
 
-> **Note :** Vous pouvez lire davantage de détails sur l'API <i lang="en">Web Audio</i> en vous rendant sur notre article [Les concepts de base de l'API <i lang="en">Web Audio</i>](/fr/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API).
+> [!NOTE]
+> Vous pouvez lire davantage de détails sur l'API <i lang="en">Web Audio</i> en vous rendant sur notre article [Les concepts de base de l'API <i lang="en">Web Audio</i>](/fr/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API).
 
 ## Interface de la Web Audio API
 
@@ -108,7 +109,8 @@ Une fois que le signal audio a été traité, ces interfaces définissent sa des
 
 ### Traitement audio avec JavaScript
 
-> **Note :** Au jour de la publication de la spécification Web Audio API le 29 août 2014, ces fonctionnalités sont dépréciées, et seront bientôt remplacées par [Audio_Workers](#audio_workers).
+> [!NOTE]
+> Au jour de la publication de la spécification Web Audio API le 29 août 2014, ces fonctionnalités sont dépréciées, et seront bientôt remplacées par [Audio_Workers](#audio_workers).
 
 - {{domxref("ScriptProcessorNode")}}
   - : Un noeud **`ScriptProcessorNode`** permet de générer, traiter ou analyser du son avec JavaScript. C'est un module de traitement audio qui est lié à deux buffers, l'un en entrée, et l'autre en sortie. Un évènement implémentant {{domxref("AudioProcessingEvent")}} est envoyé à l'objet à chaque fois que le buffer d'entrée reçoit de nouvelles données, et le gestionnaire d'évènement prend fin lorsque les nouvelles données ont été communiquées au buffer de sortie.

--- a/files/fr/web/api/web_audio_api/using_web_audio_api/index.md
+++ b/files/fr/web/api/web_audio_api/using_web_audio_api/index.md
@@ -21,7 +21,8 @@ Notre premier exemple est [Voice-change-O-matic](http://github.com/mdn/voice-cha
 
 ## Concepts de base
 
-> **Note :** la plupart des extraits de code dans cette section viennent de l'exemple [Violent Theremin](https://github.com/mdn/violent-theremin).
+> [!NOTE]
+> La plupart des extraits de code dans cette section viennent de l'exemple [Violent Theremin](https://github.com/mdn/violent-theremin).
 
 La Web Audio API impliqe de réaliser les opérations de traitement audio dans un **contexte audio**, et elle a été conçue pour permettre le **routage modulaire**. Les opérations de traitement de base sont réalisées par des **noeuds audio**, qui sont reliés entre eux pour former un **graphe de routage audio**. Plusieurs sources — avec différentes configuration de canaux — peuvent cohabiter dans un seul contexte. Ce design modulaire offre la flexibilité nécessaire pour créer des fonctions complexes avec des effets dynamiques.
 
@@ -41,7 +42,8 @@ Commencez par créer une instance de [`AudioContext`](/fr/docs/Web/API/AudioCont
 var contexteAudio = new AudioContext();
 ```
 
-> **Note :** On peut créer plusieurs contextes audio dans le même document, bien que ce soit probablement superflu dans la plupart des cas.
+> [!NOTE]
+> On peut créer plusieurs contextes audio dans le même document, bien que ce soit probablement superflu dans la plupart des cas.
 
 Il faut rajouter une version préfixée pour les navigateurs Webkit/Blink browsers, tout en conservant la version non préfixée pour Firefox (desktop/mobile/OS). Ce qui donne :
 
@@ -49,7 +51,8 @@ Il faut rajouter une version préfixée pour les navigateurs Webkit/Blink browse
 var contexteAudio = new (window.AudioContext || window.webkitAudioContext)();
 ```
 
-> **Note :** Safari risque de planter si l'objet `window` n'est pas explicitement mentionné lors de la création d'un contexte audio
+> [!NOTE]
+> Safari risque de planter si l'objet `window` n'est pas explicitement mentionné lors de la création d'un contexte audio
 
 ### Création d'une source audio
 
@@ -67,9 +70,11 @@ var oscillateur = contexteAudio.createOscillator();
 var noeudGain = contexteAudio.createGain();
 ```
 
-> **Note :** Pour jouer un fichier audio directement, il faut charger le fichier en XHR, le décoder en mémoire tampon, puis associer le tampon à une source. Voir l'exemple [Voice-change-O-matic](https://github.com/mdn/voice-change-o-matic/blob/gh-pages/scripts/app.js#L48-L68).
+> [!NOTE]
+> Pour jouer un fichier audio directement, il faut charger le fichier en XHR, le décoder en mémoire tampon, puis associer le tampon à une source. Voir l'exemple [Voice-change-O-matic](https://github.com/mdn/voice-change-o-matic/blob/gh-pages/scripts/app.js#L48-L68).
 
-> **Note :** Scott Michaud a écrit la librairie [AudioSampleLoader](https://github.com/ScottMichaud/AudioSampleLoader), très pratique pour charger et décoder un ou plusieurs extraits audio. Elle peut aider à simplifier le processus de chargement XHR / mémoire tampon décrit dans la note précédente.
+> [!NOTE]
+> Scott Michaud a écrit la librairie [AudioSampleLoader](https://github.com/ScottMichaud/AudioSampleLoader), très pratique pour charger et décoder un ou plusieurs extraits audio. Elle peut aider à simplifier le processus de chargement XHR / mémoire tampon décrit dans la note précédente.
 
 ### Lien entre les noeuds source et destination
 
@@ -100,7 +105,8 @@ Ce code créerait le graphe audio suivant :
 
 Il est possible de connecter plusieurs noeuds à un seul noeud, par exemple pour mixer plusieurs sources ensemble, et les passer dans un seul noeud d'effet, tel qu'un noeud de gain.
 
-> **Note :** Depuis Firefox 32, les outils de développement intégrés incluent un [éditeur audio](/fr/docs/Tools/Web_Audio_Editor), très utile pour débugger les graphes audio.
+> [!NOTE]
+> Depuis Firefox 32, les outils de développement intégrés incluent un [éditeur audio](/fr/docs/Tools/Web_Audio_Editor), très utile pour débugger les graphes audio.
 
 ### Lecture du son et définition du pitch
 

--- a/files/fr/web/api/web_audio_api/visualizations_with_web_audio_api/index.md
+++ b/files/fr/web/api/web_audio_api/visualizations_with_web_audio_api/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API
 
 L'une des fonctionnalités les plus intéressantes de la Web Audio API est la possibilité d'extraire de la source audio la fréquence, la forme d'onde et d'autres données, qui permettent de créer des visualisations. Cet article explique comment, et fournit quelques exemples basiques.
 
-> **Note :** Vous pouvez trouver des exemples de tous les extraits de the code dans notre démo [Voice-change-O-matic](https://mdn.github.io/voice-change-o-matic/).
+> [!NOTE]
+> Vous pouvez trouver des exemples de tous les extraits de the code dans notre démo [Voice-change-O-matic](https://mdn.github.io/voice-change-o-matic/).
 
 ## Concepts de base
 
@@ -27,11 +28,13 @@ analyseur.connect(distortion);
 // etc.
 ```
 
-> **Note :** il n'est pas nécessaire de connecter la sortie de l'analyseur à un noeud pour qu'il fonctionne, il suffit que l'entrée soit connectée à la source, directement ou via un autre noeud.
+> [!NOTE]
+> Il n'est pas nécessaire de connecter la sortie de l'analyseur à un noeud pour qu'il fonctionne, il suffit que l'entrée soit connectée à la source, directement ou via un autre noeud.
 
 L'analyseur va alors capturer les données audio en usant une Transformation de Fourier Rapide (fft) à une certaine fréquence, en fonction de ce qui est spécifié dans la propriété {{ domxref("AnalyserNode.fftSize") }} (la valeur par défaut est 2048).
 
-> **Note :** Vous pouvez aussi spécifier des valeurs de puissance minimum et maximum pour la plage de mise à l'échelle fft, en utilisant {{ domxref("AnalyserNode.minDecibels") }} et {{ domxref("AnalyserNode.maxDecibels") }}, et plusieurs valeurs de transition en utilisant {{ domxref("AnalyserNode.smoothingTimeConstant") }}.
+> [!NOTE]
+> Vous pouvez aussi spécifier des valeurs de puissance minimum et maximum pour la plage de mise à l'échelle fft, en utilisant {{ domxref("AnalyserNode.minDecibels") }} et {{ domxref("AnalyserNode.maxDecibels") }}, et plusieurs valeurs de transition en utilisant {{ domxref("AnalyserNode.smoothingTimeConstant") }}.
 
 Pour capturer des données, il faut utiliser les méthodes {{ domxref("AnalyserNode.getFloatFrequencyData()") }} et {{ domxref("AnalyserNode.getByteFrequencyData()") }} pour la fréquence, et {{ domxref("AnalyserNode.getByteTimeDomainData()") }} et {{ domxref("AnalyserNode.getFloatTimeDomainData()") }} pour la forme d'onde.
 
@@ -210,4 +213,5 @@ Ce code donne le résultat suivant:
 
 ![Une série de barres rouges dans un barre-graphe qui illustre l'intensité des différentes fréquences d'un signal audio](bar-graph.png)
 
-> **Note :** Les exemples de cet article montrent l'utilisation de [`AnalyserNode.getByteFrequencyData()`](/fr/docs/Web/API/AnalyserNode/getByteFrequencyData) et [`AnalyserNode.getByteTimeDomainData()`](/fr/docs/Web/API/AnalyserNode/getByteTimeDomainData). Pour des exemples montrant [`AnalyserNode.getFloatFrequencyData()`](/fr/docs/Web/API/AnalyserNode/getFloatFrequencyData) et [`AnalyserNode.getFloatTimeDomainData()`](/fr/docs/Web/API/AnalyserNode/getFloatTimeDomainData), voir notre démo [<i lang="en">Voice-change-O-matic-float-data</i>](https://mdn.github.io/voice-change-o-matic-float-data/) (et son [code source](https://github.com/mdn/voice-change-o-matic-float-data)) — elle est identique à la [<i lang="en">Voice-change-O-matic</i>](https://mdn.github.io/voice-change-o-matic/) originale, à ceci près qu'elle utilise des données à virgule flottante, au lieu de données non signées.
+> [!NOTE]
+> Les exemples de cet article montrent l'utilisation de [`AnalyserNode.getByteFrequencyData()`](/fr/docs/Web/API/AnalyserNode/getByteFrequencyData) et [`AnalyserNode.getByteTimeDomainData()`](/fr/docs/Web/API/AnalyserNode/getByteTimeDomainData). Pour des exemples montrant [`AnalyserNode.getFloatFrequencyData()`](/fr/docs/Web/API/AnalyserNode/getFloatFrequencyData) et [`AnalyserNode.getFloatTimeDomainData()`](/fr/docs/Web/API/AnalyserNode/getFloatTimeDomainData), voir notre démo [<i lang="en">Voice-change-O-matic-float-data</i>](https://mdn.github.io/voice-change-o-matic-float-data/) (et son [code source](https://github.com/mdn/voice-change-o-matic-float-data)) — elle est identique à la [<i lang="en">Voice-change-O-matic</i>](https://mdn.github.io/voice-change-o-matic/) originale, à ceci près qu'elle utilise des données à virgule flottante, au lieu de données non signées.

--- a/files/fr/web/api/web_audio_api/web_audio_spatialization_basics/index.md
+++ b/files/fr/web/api/web_audio_api/web_audio_spatialization_basics/index.md
@@ -17,7 +17,8 @@ C'est un outil pratique pour WebXR et les jeux vidéo.
 
 Dans l'espace en trois dimensions, c'est la seule façon de réaliser des effets audio réalistes. Des bibliothèques tierces comme [three.js](https://threejs.org/) et [A-frame](https://aframe.io/) l'utilisent pour gérer le son. On notera quand même qu'il n'y a pas _forcément_ besoin de déplacer le son dans un espace en trois dimensions, on peut tout à fait utiliser cette interface pour gérer un son dans un espace en deux dimensions.
 
-> **Note :** Il existe également [`StereoPannerNode`](/fr/docs/Web/API/StereoPannerNode) qui permet de gérer des effets simples de défilement à gauche ou à droite. Celle-ci est plus simple à utiliser, mais est moins flexible. Si vous souhaitez un simple effet de panoramique stéréo, voyez [l'exemple `StereoPannerNode`](https://mdn.github.io/webaudio-examples/stereo-panner-node/) ([le code source correspondant](https://github.com/mdn/webaudio-examples/tree/master/stereo-panner-node)), qui devrait vous fournir ce dont vous avez besoin.
+> [!NOTE]
+> Il existe également [`StereoPannerNode`](/fr/docs/Web/API/StereoPannerNode) qui permet de gérer des effets simples de défilement à gauche ou à droite. Celle-ci est plus simple à utiliser, mais est moins flexible. Si vous souhaitez un simple effet de panoramique stéréo, voyez [l'exemple `StereoPannerNode`](https://mdn.github.io/webaudio-examples/stereo-panner-node/) ([le code source correspondant](https://github.com/mdn/webaudio-examples/tree/master/stereo-panner-node)), qui devrait vous fournir ce dont vous avez besoin.
 
 ## Démo avec le radiocassette en 3D
 
@@ -29,7 +30,8 @@ Le radiocassette est placé dans un espace (défini par les bords de la zone d'a
 
 Lorsqu'on déplace le radiocassette, le son produit change de façon correspondante, se décalant de droite à gauche selon le déplacement ou s'atténuant si on l'éloigne dans le fond ou si on le pivote pour que les hauts-parleurs nous tournent le dos. Ces effets sont obtenus en jouant sur les différentes propriétés de l'objet `PannerNode` lors du mouvement, pour émuler cette spatialisation.
 
-> **Note :** Le résultat obtenu sera bien meilleur si vous utilisez un casque ou des écouteurs ou un système stéréo surround.
+> [!NOTE]
+> Le résultat obtenu sera bien meilleur si vous utilisez un casque ou des écouteurs ou un système stéréo surround.
 
 ## Créer un auditeur
 
@@ -520,7 +522,8 @@ Pour une exploration plus avancée de la lecture et du contrôle audio, ainsi qu
 
 Nous espérons que cet article vous a permis de mieux comprendre le fonctionnement de la spatialisation avec l'API Web Audio et le rôle des propriétés de [`PannerNode`](/fr/docs/Web/API/PannerNode) (il y en a un certain nombre). La manipulation de ces valeurs peut s'avérer délicate selon le cas d'usage, c'est normal que de passer du temps à les paramétrer.
 
-> **Note :** Il existe quelques différences entre les navigateurs pour ce qui concerne la spatialisation audio. Le nœud panoramique manipule des opérations mathématiques avancées et il existe [plusieurs tests](https://wpt.fyi/results/webaudio/the-audio-api/the-pannernode-interface?label=stable&aligned=true) que vous pouvez consulter pour connaître l'état d'avancement sur ce type de nœud sur les différentes plateformes.
+> [!NOTE]
+> Il existe quelques différences entre les navigateurs pour ce qui concerne la spatialisation audio. Le nœud panoramique manipule des opérations mathématiques avancées et il existe [plusieurs tests](https://wpt.fyi/results/webaudio/the-audio-api/the-pannernode-interface?label=stable&aligned=true) que vous pouvez consulter pour connaître l'état d'avancement sur ce type de nœud sur les différentes plateformes.
 
 À nouveau, vous pouvez [consulter la version finale de la démo ici](https://mdn.github.io/webaudio-examples/spatialization/), ainsi que [le code source de l'exemple final](https://github.com/mdn/webaudio-examples/tree/master/spatialization). Cette démonstration est [également disponible sur CodePen](https://codepen.io/Rumyra/pen/MqayoK?editors=0100).
 

--- a/files/fr/web/api/web_authentication_api/index.md
+++ b/files/fr/web/api/web_authentication_api/index.md
@@ -27,7 +27,8 @@ De nombreux sites web ont des pages qui permettent de créer un compte ou de s'a
 - [`navigator.credentials.get()`](/fr/docs/Web/API/CredentialsContainer/get)
   - : Lorsqu'elle est utilisée avec l'option `publicKey`, elle utilise des informations d'authentification existantes afin de s'authentifier sur un service, pour connecter la personne ou comme deuxième facteur d'authentification.
 
-> **Note :** Ces deux méthodes, `create()` et `get()`, doivent être utilisées depuis [un contexte securisé](/fr/docs/Web/Security/Secure_Contexts) (c'est-à-dire que la connexion au serveur soit en HTTPS ou que le site soit servi depuis localhost). Elles ne seront pas disponibles si le navigateur n'est pas dans un tel contexte.
+> [!NOTE]
+> Ces deux méthodes, `create()` et `get()`, doivent être utilisées depuis [un contexte securisé](/fr/docs/Web/Security/Secure_Contexts) (c'est-à-dire que la connexion au serveur soit en HTTPS ou que le site soit servi depuis localhost). Elles ne seront pas disponibles si le navigateur n'est pas dans un tel contexte.
 
 Dans leurs formes les plus simples, `create()` et `get()` reçoivent un grand nombre aléatoire appelé «&nbsp;challenge&nbsp;» de la part du serveur et renvoient au serveur le challenge signé avec la clé privée. Cela prouve au serveur que la personne est en possession de la clé privée requise pour l'authentification, sans révéler de secrets sur le réseau.
 
@@ -54,7 +55,8 @@ Les étapes suivantes sont&nbsp;:
 
    - Ces informations sont envoyées au programme JavaScript. Le protocole de communication avec le serveur ne fait pas partie de la spécification de l'API Web Authentication. Il s'agit généralement d'une communication via HTTPS en [REST](/fr/docs/Glossary/REST) (et qui utilisera probablement [l'API Fetch](/fr/docs/Web/API/Fetch_API) ou encore [`XMLHttpRequest`](/fr/docs/Web/API/XMLHttpRequest)) (en théorie, tout protocole sécurisé peut être utilisé). Les paramètres reçus du serveur seront passés lors de l'appel à [`create()`](/fr/docs/Web/API/CredentialsContainer/create) (généralement avec peu ou pas de modification) qui renverra [une promesse](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) dont la valeur de résolution sera un objet [`PublicKeyCredential`](/fr/docs/Web/API/PublicKeyCredential) contenant un objet [`AuthenticatorAttestationResponse`](/fr/docs/Web/API/AuthenticatorAttestationResponse).
 
-   > **Attention :** Il est absolument nécessaire que le challenge soit un tampon mémoire d'informations aléatoires (d'au moins 16 octets) et qui soit généré sur le serveur afin de garantir la sécurité du processus d'enregistrement.
+   > [!WARNING]
+   > Il est absolument nécessaire que le challenge soit un tampon mémoire d'informations aléatoires (d'au moins 16 octets) et qui soit généré sur le serveur afin de garantir la sécurité du processus d'enregistrement.
 
 2. **Le navigateur appelle `authenticatorMakeCredential()` qui sollicite l'authentificateur.**
 
@@ -72,7 +74,8 @@ Les étapes suivantes sont&nbsp;:
 
    - La promesse fournie par `create()` est résolue en un objet [`PublicKeyCredential`](/fr/docs/Web/API/PublicKeyCredential), possédant une propriété [`PublicKeyCredential.rawId`](/fr/docs/Web/API/PublicKeyCredential/rawId) qui correspond à l'identifiant d'authentification globalement unique et une propriété [`PublicKeyCredential.response`](/fr/docs/Web/API/PublicKeyCredential/response) contenant le reste de la réponse sous la forme d'un objet [`AuthenticatorAttestationResponse`](/fr/docs/Web/API/AuthenticatorAttestationResponse) qui contient [`AuthenticatorResponse.clientDataJSON`](/fr/docs/Web/API/AuthenticatorResponse/clientDataJSON) et [`AuthenticatorAttestationResponse.attestationObject`](/fr/docs/Web/API/AuthenticatorAttestationResponse/attestationObject). Cet objet [`PublicKeyCredential`](/fr/docs/Web/API/PublicKeyCredential) est renvoyé au serveur en utilisant le format et le protocole voulu.
 
-   > **Note :** Les propriétés qui sont des `ArrayBuffer` doivent être encodés en base64 ou d'une autre façon.
+   > [!NOTE]
+   > Les propriétés qui sont des `ArrayBuffer` doivent être encodés en base64 ou d'une autre façon.
 
 6. **Le serveur valide et finalise l'enregistrement.**
 
@@ -82,7 +85,8 @@ Les étapes suivantes sont&nbsp;:
       2. La vérification que l'origine correspond bien à l'origine attendu&nbsp;;
       3. La validation de la signature de l'empreinte des données du client et de l'attestation en utilisant la chaîne de certificats associée au modèle de l'authentificateur.
 
-      > **Note :** La liste complète des étapes de validation [est détaillée dans la spécification de l'API](https://w3c.github.io/webauthn/#registering-a-new-credential).
+      > [!NOTE]
+      > La liste complète des étapes de validation [est détaillée dans la spécification de l'API](https://w3c.github.io/webauthn/#registering-a-new-credential).
 
    2. Si toutes les vérifications sont réussies, le serveur enregistre la nouvelle clé publique pour le compte de la personne afin qu'elle puisse être utilisée par la suite (quand la personne s'authentifiera).
 
@@ -107,7 +111,8 @@ On a ensuite ces étapes pour l'authentification&nbsp;:
 
    - Le serveur envoie un challenge au programme JavaScript. Le protocole de communication n'est pas détaillé par la spécification. Généralement, on a une requête HTTPS [REST](/fr/docs/Glossary/REST) (qui utilise [l'API Fetch](/fr/docs/Web/API/Fetch_API) ou encore [`XMLHttpRequest`](/fr/docs/Web/API/XMLHttpRequest)), mais il peut s'agir, en théorie, de n'importe quel protocole sécurisé. Les paramètres reçus du serveur sont passés à l'appel de la méthode [`get()`](/fr/docs/Web/API/CredentialsContainer/get) avec peu ou pas de modification.
 
-   > **Attention :** Il est crucial que le challenge soit un tampon d'informations aléatoires (au moins 16 octets) et que celui-ci ait été généré sur le serveur pour garantir la sécurité du processus d'authentification.
+   > [!WARNING]
+   > Il est crucial que le challenge soit un tampon d'informations aléatoires (au moins 16 octets) et que celui-ci ait été généré sur le serveur pour garantir la sécurité du processus d'authentification.
 
 2. **Le navigateur appelle `authenticatorGetCredential()` qui sollicite l'authentificateur.**
 
@@ -133,7 +138,8 @@ On a ensuite ces étapes pour l'authentification&nbsp;:
       2. Vérifier que le challenge signé par l'authenticateur correspond à celui généré par le serveur.
       3. Vérifier que l'identifiant du tiers de confiance est celui attendu pour ce service.
 
-      > **Note :** La liste complète des étapes de validation d'une assertion [est détaillée dans la spécification de l'API](https://w3c.github.io/webauthn/#verifying-assertion).
+      > [!NOTE]
+      > La liste complète des étapes de validation d'une assertion [est détaillée dans la spécification de l'API](https://w3c.github.io/webauthn/#verifying-assertion).
 
    2. Si la validation est réussie, le serveur notera que la personne est authentifiée. Bien que cela ne soit pas dans le périmètre de la spécification de l'API, cela pourra par exemple se traduire par le dépôt d'un cookie pour la session de la personne.
 
@@ -173,7 +179,8 @@ On a ensuite ces étapes pour l'authentification&nbsp;:
 
 ### Exemple d'utilisation
 
-> **Attention :** Pour des raisons de sécurité, les appels à [`create()`](/fr/docs/Web/API/CredentialsContainer/create) et [`get()`](/fr/docs/Web/API/CredentialsContainer/get) sont annulés si la fenêtre du navigateur perd le focus lorsque l'appel est en attente.
+> [!WARNING]
+> Pour des raisons de sécurité, les appels à [`create()`](/fr/docs/Web/API/CredentialsContainer/create) et [`get()`](/fr/docs/Web/API/CredentialsContainer/get) sont annulés si la fenêtre du navigateur perd le focus lorsque l'appel est en attente.
 
 ```js
 // des arguments d'exemple pour un enregistrement

--- a/files/fr/web/api/web_components/using_custom_elements/index.md
+++ b/files/fr/web/api/web_components/using_custom_elements/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Web_components/Using_custom_elements
 
 L'un des aspects les plus importants des composants web est la possibilité de créer des éléments personnalisés qui encapsulent bien vos fonctionnalités sur une page HTML, plutôt que de devoir se contenter d'une soupe de balises définissant des fonctionnalités personnalisées. Cet article passe en revue les bases de l'utilisation d'éléments personnalisés.
 
-> **Note :** Les éléments personnalisés sont pris en charge par défaut dans Chrome et Opera. Firefox en est très proche, ils sont disponibles si vous mettez les préférences dom.webcomponents.enabled et dom.webcomponents.customelements.enabled à true, leur implémentation étant prévue pour être activée par défaut dans la version 60/61. Safari ne prend en charge que les éléments personnalisés indépendants pour l'instant, et Edge travaille de même sur une implémentation.
+> [!NOTE]
+> Les éléments personnalisés sont pris en charge par défaut dans Chrome et Opera. Firefox en est très proche, ils sont disponibles si vous mettez les préférences dom.webcomponents.enabled et dom.webcomponents.customelements.enabled à true, leur implémentation étant prévue pour être activée par défaut dans la version 60/61. Safari ne prend en charge que les éléments personnalisés indépendants pour l'instant, et Edge travaille de même sur une implémentation.
 
 ## Vue d'ensemble
 
@@ -138,7 +139,8 @@ Il est maintenant disponible pour utilisation dans notre page. Dans notre code H
   back of your card."></popup-info>
 ```
 
-> **Note :** Vous pouvez voir le [code source JavaScript complet](https://github.com/mdn/web-components-examples/blob/master/popup-info-box-web-component/main.js) ici.
+> [!NOTE]
+> Vous pouvez voir le [code source JavaScript complet](https://github.com/mdn/web-components-examples/blob/master/popup-info-box-web-component/main.js) ici.
 
 ### Eléments intégrés personnalisés
 
@@ -177,7 +179,8 @@ L'utilisation de l'élément intégré dans un document web se présente égalem
 
 Vous utilisez l'élément `<ul>` comme d'habitude, mais vous spécifiez le nom de l'élément personnalisé dans l'attribut `is`.
 
-> **Note :** à nouveau, vous pouvez voir le [code source JavaScript](https://github.com/mdn/web-components-examples/blob/master/expanding-list-web-component/main.js) complet ici.
+> [!NOTE]
+> à nouveau, vous pouvez voir le [code source JavaScript](https://github.com/mdn/web-components-examples/blob/master/expanding-list-web-component/main.js) complet ici.
 
 ## Utilisation des rappels de cycle de vie
 
@@ -266,4 +269,5 @@ static get observedAttributes() {return ['w', 'l']; }
 
 Dans notre exemple, cela est mis au tout début du constructeur.
 
-> **Note :** vous pouvez trouver le [full JavaScript source](https://github.com/mdn/web-components-examples/blob/master/life-cycle-callbacks/main.js) .
+> [!NOTE]
+> Vous pouvez trouver le [full JavaScript source](https://github.com/mdn/web-components-examples/blob/master/life-cycle-callbacks/main.js) .

--- a/files/fr/web/api/web_components/using_shadow_dom/index.md
+++ b/files/fr/web/api/web_components/using_shadow_dom/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Web_components/Using_shadow_DOM
 
 Un aspect important des composants web est l'encapsulation — être capable de garder la structure de balisage, le style et le comportement cachés et séparés du reste de code de la page tel que différentes parties n'entrent pas en conflit et que le code puisse rester agréable et propre. L'API Shadow DOM est un moyen d'y parvenir, fournissant une manière d'associer à un élément un DOM séparé et caché. Cet article couvre les bases de l'utilisation du DOM fantôme.
 
-> **Note :** L'API Shadow DOM est supportée par défaut dans Firefox (63 et suivants), Chrome, Opera, et Safari. Le nouveau Edge basé sur Chromium (75 et suivants) le supportent aussi; le vieux Edge ne le supporte pas.
+> [!NOTE]
+> L'API Shadow DOM est supportée par défaut dans Firefox (63 et suivants), Chrome, Opera, et Safari. Le nouveau Edge basé sur Chromium (75 et suivants) le supportent aussi; le vieux Edge ne le supporte pas.
 
 ## Vue de haut niveau
 
@@ -70,7 +71,8 @@ let monDomFantome = monElementPerso.shadowRoot;
 
 Si vous associez une racine fantôme à un élément personnalisé avec la propriété `mode` définie à `closed`, vous ne serez pas autorisé à accéder au DOM fantôme depuis l'extérieur — `monElementPerso.shadowRoot` retournera `null`. C'est le cas avec les éléments natifs contenant des DOM fantômes tels que `<video>`.
 
-> **Note :** Comme montre [cet article de blog](https://blog.revillweb.com/open-vs-closed-shadow-dom-9f3d7427d1af) (en anglais), il est actuellement assez simple de pénétrer les DOM fantômes fermés, et les cacher complètement n'en vaut souvent pas la peine.
+> [!NOTE]
+> Comme montre [cet article de blog](https://blog.revillweb.com/open-vs-closed-shadow-dom-9f3d7427d1af) (en anglais), il est actuellement assez simple de pénétrer les DOM fantômes fermés, et les cacher complètement n'en vaut souvent pas la peine.
 
 Si vous voulez associer un DOM fantôme à un élément personnalisé en tant que partie de son constructeur (de loin la plus utile application du DOM fantôme), vous devriez utiliser une instruction comme :
 

--- a/files/fr/web/api/web_components/using_templates_and_slots/index.md
+++ b/files/fr/web/api/web_components/using_templates_and_slots/index.md
@@ -75,7 +75,8 @@ On peut maintenant utiliser le modèle dans le document HTML:
 <my-paragraph></my-paragraph>
 ```
 
-> **Note :** Les modèles sont bien pris en charge par les navigateurs&nbsp;; l'API Shadow DOM est pris en charge par défaut dans Firefox (à partir de la version 63), Chrome, Opera, Safari et Edge (à partir de la version 70).
+> [!NOTE]
+> Les modèles sont bien pris en charge par les navigateurs&nbsp;; l'API Shadow DOM est pris en charge par défaut dans Firefox (à partir de la version 63), Chrome, Opera, Safari et Edge (à partir de la version 70).
 
 ## Plus de flexibilité avec les slots
 
@@ -110,7 +111,8 @@ ou
 </my-paragraph>
 ```
 
-> **Note :** Un élément [`<slot>`](/fr/docs/Web/HTML/Element/slot) sans nom sera rempli avec l'ensemble des nœuds-fils de plus haut niveau de l'élément personnalisé qui n'ont pas d'attribut [`slot`](/fr/docs/Web/HTML/Global_attributes#slot). Cela inclut les nœuds texte.
+> [!NOTE]
+> Un élément [`<slot>`](/fr/docs/Web/HTML/Element/slot) sans nom sera rempli avec l'ensemble des nœuds-fils de plus haut niveau de l'élément personnalisé qui n'ont pas d'attribut [`slot`](/fr/docs/Web/HTML/Global_attributes#slot). Cela inclut les nœuds texte.
 
 Et c'est tout pour ce premier exemple. Si vous souhaitez manipuler les emplacements, vous pouvez [voir la page sur GitHub](https://github.com/mdn/web-components-examples/tree/master/simple-template) (voir aussi [le résultat](https://mdn.github.io/web-components-examples/simple-template/)).
 
@@ -127,7 +129,8 @@ Il est techniquement possible d'utiliser un élément [`<slot>`](/fr/docs/Web/HT
 
 De plus, même si l'élément n'est pas déjà rendu, le rôle de conteneur porté par le modèle sera sémantiquement plus clair en utilisant [`<template>`](/fr/docs/Web/HTML/Element/template). De plus, [`<template>`](/fr/docs/Web/HTML/Element/template) peut avoir des éléments qui lui sont directement rattachés comme [`<td>`](/fr/docs/Web/HTML/Element/td). Ce même élément disparaîtrait s'il était ajouté à un élément [`<div>`](/fr/docs/Web/HTML/Element/div).
 
-> **Note :** Vous pourrez retrouver l'exemple complet sur [le dépôt GitHub pour element-details](https://github.com/mdn/web-components-examples/tree/master/element-details) (voir également [le résultat en action](https://mdn.github.io/web-components-examples/element-details/)).
+> [!NOTE]
+> Vous pourrez retrouver l'exemple complet sur [le dépôt GitHub pour element-details](https://github.com/mdn/web-components-examples/tree/master/element-details) (voir également [le résultat en action](https://mdn.github.io/web-components-examples/element-details/)).
 
 ### Créer un modèle avec des emplacements
 

--- a/files/fr/web/api/web_crypto_api/index.md
+++ b/files/fr/web/api/web_crypto_api/index.md
@@ -9,7 +9,8 @@ L'API **Web Cryptography** (aussi appelée <i lang="en">Web Crypto API</i>) est 
 
 {{AvailableInWorkers}}
 
-> **Attention :** L'API Web Crypto fournit un ensemble de primitives cryptographiques de bas niveau. Il est très facile de mal les utiliser et les pièges peuvent être très subtils.
+> [!WARNING]
+> L'API Web Crypto fournit un ensemble de primitives cryptographiques de bas niveau. Il est très facile de mal les utiliser et les pièges peuvent être très subtils.
 >
 > Même si vous utilisez les fonctionnalités cryptographiques basiques correctement, ayez conscience que la gestion sécurisée des clés et la conception générale d'un système sécurisé sont des tâches extrêmement difficiles à réaliser correctement et qui incombent donc généralement à des experts en sécurité.
 >

--- a/files/fr/web/api/web_crypto_api/non-cryptographic_uses_of_subtle_crypto/index.md
+++ b/files/fr/web/api/web_crypto_api/non-cryptographic_uses_of_subtle_crypto/index.md
@@ -122,7 +122,8 @@ Un cas où ceci peut être utile est la vérification d'un fichier téléchargé
 
 Vous avez peut-être entendu l'expression _«&nbsp;saler le hash&nbsp;»_. Ce n'est pas quelque chose qui est directement pertinent ici, mais qu'il est intéressant de connaître.
 
-> **Note :** Cette section aborde la sécurité des mots de passe et les fonctions de hachage fournies par `SubtleCrypto` ne sont pas adaptées à un tel usage. Pour hacher un mot de passe, il faut des fonctions de hachage lentes et coûteuses (en complexité de calcul) comme `scrypt` et `bcrypt`. SHA est conçu pour être rapide et efficace, ce qui le rend inadapté au hachage de mots de passe. Cette section est purement informationnelle, n'utilisez pas l'API Web Crypto pour hacher des mots de passe côté client.
+> [!NOTE]
+> Cette section aborde la sécurité des mots de passe et les fonctions de hachage fournies par `SubtleCrypto` ne sont pas adaptées à un tel usage. Pour hacher un mot de passe, il faut des fonctions de hachage lentes et coûteuses (en complexité de calcul) comme `scrypt` et `bcrypt`. SHA est conçu pour être rapide et efficace, ce qui le rend inadapté au hachage de mots de passe. Cette section est purement informationnelle, n'utilisez pas l'API Web Crypto pour hacher des mots de passe côté client.
 
 Afin d'éviter de stocker des mots de passe en clair, on calcule leur empreinte afin que le mot de passe original ne puisse pas être reconstitué si jamais la base de données avec l'identifiant et le mot de passe était piratée. Mais on peut déterminer les mots de passe à partir des empreintes si on génère les empreintes de l'ensemble des mots de passe connu. Concaténer une chaîne de caractères aux mots de passe modifie l'empreinte. Toutefois si on utilise la même chaîne à concaténer pour tous les mots de passe, on retombe sur le même problème.
 

--- a/files/fr/web/api/web_speech_api/using_the_web_speech_api/index.md
+++ b/files/fr/web/api/web_speech_api/using_the_web_speech_api/index.md
@@ -13,7 +13,8 @@ La reconnaissance vocale implique de recevoir de la voix à travers un dispositi
 
 L'API Web Speech a une interface principale de contrôle — {{domxref("SpeechRecognition")}} — plus un nombre d'interfaces inter-reliées pour représenter une grammaire, des résultats, etc. Généralement, le système de reconnaissance vocale par défaut disponible sur le dispositif matériel sera utilisé pour la reconnaissance vocale — la plupart des systèmes d'exploitation modernes ont un système de reonnaissance vocale pour transmettre des commandes vocales. On pense à Dictation sur macOS, Siri sur iOS, Cortana sur Windows 10, Android Speech, etc.
 
-> **Note :** Sur certains navigateurs, comme Chrome, utiliser la reconnaissance vocale sur une page web implique de disposer d'un moteur de reconnaissance basé sur un serveur. Votre flux audio est envoyé à un service web pour traitement, le moteur ne fonctionnera donc pas hors ligne.
+> [!NOTE]
+> Sur certains navigateurs, comme Chrome, utiliser la reconnaissance vocale sur une page web implique de disposer d'un moteur de reconnaissance basé sur un serveur. Votre flux audio est envoyé à un service web pour traitement, le moteur ne fonctionnera donc pas hors ligne.
 
 ### Demo
 

--- a/files/fr/web/api/web_storage_api/index.md
+++ b/files/fr/web/api/web_storage_api/index.md
@@ -16,11 +16,14 @@ Les deux mécanismes au sein du web storage sont les suivantes:
 
 Ces mécanismes sont disponibles via les propriétés {{domxref("Window.sessionStorage")}} et {{domxref("Window.localStorage")}} (pour être plus précis, pour le support des navigateurs, l'objet `Window` implemente le `WindowLocalStorage` et l'object `WindowSessionStorage`, dont les propriétés `localStorage` et `sessionStorage` dépendent) — L'appel de l'une de ces propriétés va créer une instance de l'objet {{domxref("Storage")}}, à travers de laquelle les éléments de données peuvent être définis, récupérés et éliminés. Un objet de stockage différent est utilisé pour le sessionStorage et le localStorage pour chaque origine — ils fonctionnent et sont contrôlés séparément.
 
-> **Note :** À partir de Firefox 45, lorsque le navigateur se bloque / redémarre, la quantité de données sauvegardées par origine est limitée à 10 Mo. Cela a été mis en place pour éviter les problèmes de mémoire causés par une utilisation excessive du stockage Web.
+> [!NOTE]
+> À partir de Firefox 45, lorsque le navigateur se bloque / redémarre, la quantité de données sauvegardées par origine est limitée à 10 Mo. Cela a été mis en place pour éviter les problèmes de mémoire causés par une utilisation excessive du stockage Web.
 
-> **Note :** L'accès au Web Storage à partir d'iframes externes est interdit si l'utilisateur a [désactivé les cookies tierce-partie](https://support.mozilla.org/en-US/kb/disable-third-party-cookies) (Firefox a adopté ce comportement à partir de la [version 43](/fr/docs/Mozilla/Firefox/Releases/43) et suivantes.)
+> [!NOTE]
+> L'accès au Web Storage à partir d'iframes externes est interdit si l'utilisateur a [désactivé les cookies tierce-partie](https://support.mozilla.org/en-US/kb/disable-third-party-cookies) (Firefox a adopté ce comportement à partir de la [version 43](/fr/docs/Mozilla/Firefox/Releases/43) et suivantes.)
 
-> **Note :** Le <i lang="en">Web Storage</i> n'est pas identique au `mozStorage` (interfaces XPCOM de Mozilla vers SQLite) ou l'API <i lang="en">Session Store</i> (un utilitaire de stockage XPCOM utilisable par des extensions).
+> [!NOTE]
+> Le <i lang="en">Web Storage</i> n'est pas identique au `mozStorage` (interfaces XPCOM de Mozilla vers SQLite) ou l'API <i lang="en">Session Store</i> (un utilitaire de stockage XPCOM utilisable par des extensions).
 
 ## Web Storage interfaces
 

--- a/files/fr/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/fr/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -17,7 +17,8 @@ localStorage["colorSetting"] = "#a4509b";
 localStorage.setItem("colorSetting", "#a4509b");
 ```
 
-> **Note :** Il est recommandé d'utiliser l'API "Web Storage" (`setItem`, `getItem`, `removeItem`, `key`, `length`) pour prévenir les [embûches](http://www.2ality.com/2012/01/objects-as-maps.html) associées à l'utilisation d'objets capable de stocker des couples clé-valeur.
+> [!NOTE]
+> Il est recommandé d'utiliser l'API "Web Storage" (`setItem`, `getItem`, `removeItem`, `key`, `length`) pour prévenir les [embûches](http://www.2ality.com/2012/01/objects-as-maps.html) associées à l'utilisation d'objets capable de stocker des couples clé-valeur.
 
 Les deux principaux mécanismes internes du Stockage Web sont :
 
@@ -91,7 +92,8 @@ Nous avons aussi fournit une [page pour l'événement émis](https://mdn.github.
 
 ![](event-output.png)
 
-> **Note :** En plus de l'affichage en temps réel des pages en utilisant les liens ci-dessus, vous pouvez aussi [regarder le code-source](https://github.com/mdn/dom-examples/tree/master/web-storage).
+> [!NOTE]
+> En plus de l'affichage en temps réel des pages en utilisant les liens ci-dessus, vous pouvez aussi [regarder le code-source](https://github.com/mdn/dom-examples/tree/master/web-storage).
 
 ## Tester si le stockage a déjà été rempli
 

--- a/files/fr/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
+++ b/files/fr/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
@@ -34,7 +34,8 @@ Les fonctions suivantes sont **uniquement** disponibles pour les pour les <i lan
 
 ## Les API web disponibles pour les <i lang="en">workers</i>
 
-> **Note :** Si une API listée ici est prise en charge par une plateforme donnée pour une version donnée, on peut généralement partir du principe que l'API fonctionnera pour les <i lang="en">web workers</i>.
+> [!NOTE]
+> Si une API listée ici est prise en charge par une plateforme donnée pour une version donnée, on peut généralement partir du principe que l'API fonctionnera pour les <i lang="en">web workers</i>.
 
 Les API web suivantes sont disponibles pour les <i lang="en">workers</i>&nbsp;:
 

--- a/files/fr/web/api/web_workers_api/index.md
+++ b/files/fr/web/api/web_workers_api/index.md
@@ -24,7 +24,8 @@ En plus des workers dédiés, il y a d'autres types de worker :
 - Les Workers Chrome sont un type de worker spécifique à Firefox que vous pouvez utiliser si vous développez des extensions et que vous voulez y utiliser des workers et avoir accès aux [js-ctypes](/fr/docs/Mozilla/js-ctypes) dans votre worker. Consulter {{domxref("ChromeWorker")}} pour plus de détails.
 - Les [Audio Workers](/fr/docs/Web/API/Web_Audio_API#Audio_Workers) donne la possibilité d'effectuer directement dans le contexte d'un worker web un traitement audio scripté.
 
-> **Note :** Selon les [Spécifications de Web Worker](https://html.spec.whatwg.org/multipage/workers.html#runtime-script-errors-2), les erreurs dans les workers ne devraient pas déborder (voir [bug Firefox 1188141](https://bugzil.la/1188141)). Cela a été implémenté dans Firefox 42.
+> [!NOTE]
+> Selon les [Spécifications de Web Worker](https://html.spec.whatwg.org/multipage/workers.html#runtime-script-errors-2), les erreurs dans les workers ne devraient pas déborder (voir [bug Firefox 1188141](https://bugzil.la/1188141)). Cela a été implémenté dans Firefox 42.
 
 ## Les interfaces Web Worker
 

--- a/files/fr/web/api/web_workers_api/structured_clone_algorithm/index.md
+++ b/files/fr/web/api/web_workers_api/structured_clone_algorithm/index.md
@@ -84,7 +84,8 @@ function clone(objectToBeCloned) {
 }
 ```
 
-> **Note :** Cet algorithme ne prend en charge que les objets spéciaux [`RegExp`](/fr/docs/JavaScript/Reference/Global_Objects/RegExp), [`Array`](/fr/docs/JavaScript/Reference/Global_Objects/Array) et [`Date`](/fr/docs/JavaScript/Reference/Global_Objects/Date). Vous pouvez implémenter d'autres cas spéciaux selon vos besoins.
+> [!NOTE]
+> Cet algorithme ne prend en charge que les objets spéciaux [`RegExp`](/fr/docs/JavaScript/Reference/Global_Objects/RegExp), [`Array`](/fr/docs/JavaScript/Reference/Global_Objects/Array) et [`Date`](/fr/docs/JavaScript/Reference/Global_Objects/Date). Vous pouvez implémenter d'autres cas spéciaux selon vos besoins.
 
 ## Voir aussi
 

--- a/files/fr/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/fr/web/api/web_workers_api/using_web_workers/index.md
@@ -13,7 +13,8 @@ Un _worker_ est un objet créé à l'aide d'un constructeur (par exemple {{domxr
 
 Le contexte du _worker_ est représenté par un objet {{domxref("DedicatedWorkerGlobalScope")}} pour les _workers_ dédiés et par un objet {{domxref("SharedWorkerGlobalScope")}} sinon. Un _worker_ dédié est uniquement accessible au travers du script qui l'a déclenché tandis qu'un _worker_ partagé peut être utilisé par différents scripts.
 
-> **Note :** Voir [la page d'entrée pour l'API Web Workers](/fr/docs/Web/API/Web_Workers_API) pour consulter la documentation de référence sur les _workers_ et d'autres guides.
+> [!NOTE]
+> Voir [la page d'entrée pour l'API Web Workers](/fr/docs/Web/API/Web_Workers_API) pour consulter la documentation de référence sur les _workers_ et d'autres guides.
 
 Il est possible d'exécuter n'importe quel code JavaScript dans le _thread_ du _worker_, à l'exception des méthodes de manipulation du DOM ou de certaines propriétés et méthodes rattachées à {{domxref("window")}}. On notera cependant qu'on peut tout à fait utiliser certaines API rendues disponibles via `window` comme les [WebSockets](/fr/docs/Web/API/WebSockets_API), les API de stockage de données telles que [IndexedDB](/fr/docs/Web/API/API_IndexedDB). Pour plus de détails, voir [les fonctions et classes disponibles au sein des _workers_](/fr/docs/Web/API/Worker/Functions_and_classes_available_to_workers).
 
@@ -87,9 +88,11 @@ monWorker.onmessage = function (e) {
 
 Ici, nous récupérons les données grâce à l'attribut `data` de l'évènement et nous mettons à jour le contenu du paragraphe avec l'attribut `textContent` de l'élément. Ainsi, l'utilisateur peut visualiser le résultat du calcul.
 
-> **Note :** On notera que `onmessage` et `postMessage()` doivent être rattachés à un objet `Worker` lorsqu'ils sont utilisés depuis le _thread_ principal (ici, c'était `monWorker`) mais pas lorsqu'ils sont employés depuis le _worker_. En effet, dans le _worker_, c'est le _worker_ qui constitue la portée globale et qui met à disposition ces méthodes.
+> [!NOTE]
+> On notera que `onmessage` et `postMessage()` doivent être rattachés à un objet `Worker` lorsqu'ils sont utilisés depuis le _thread_ principal (ici, c'était `monWorker`) mais pas lorsqu'ils sont employés depuis le _worker_. En effet, dans le _worker_, c'est le _worker_ qui constitue la portée globale et qui met à disposition ces méthodes.
 
-> **Note :** Lorsqu'un message est envoyé d'un _thread_ à l'autre, ses données sont copiées. Elles ne sont pas partagées. Voir [ci-après](#échange) pour plus d'explications à ce sujet.
+> [!NOTE]
+> Lorsqu'un message est envoyé d'un _thread_ à l'autre, ses données sont copiées. Elles ne sont pas partagées. Voir [ci-après](#échange) pour plus d'explications à ce sujet.
 
 ### Clôturer un _worker_
 
@@ -135,7 +138,8 @@ importScripts(
 
 Lors d'un import, le navigateur chargera chacun des scripts puis l'exécutera. Chaque script pourra ainsi mettre à disposition des objets globaux qui pourront être utilisés par le _worker_. Si le script ne peut pas être chargé, une exception `NETWORK_ERROR` sera levée et le code assicé ne sera pas exécuté. Le code exécuté précédemment (y compris celui-ci reporté à l'aide de {{domxref("window.setTimeout()")}}) continuera cependant d'être fonctionnel. Les déclarations de fonction situées **après** `importScripts()` sont également exécutées car évaluées avant le reste du code.
 
-> **Note :** Les scripts peuvent être téléchargés dans n'importe quel ordre mais ils seront exécutés dans l'ordre des arguments passés à `importScripts()` . Cet exécution est effectuée de façon synchrone et `importScripts()` ne rendra pas la main tant que l'ensemble des scripts n'auront pas été chargés et exécutés.
+> [!NOTE]
+> Les scripts peuvent être téléchargés dans n'importe quel ordre mais ils seront exécutés dans l'ordre des arguments passés à `importScripts()` . Cet exécution est effectuée de façon synchrone et `importScripts()` ne rendra pas la main tant que l'ensemble des scripts n'auront pas été chargés et exécutés.
 
 ## Les _workers_ partagés
 
@@ -143,9 +147,11 @@ Un _worker_ partagé est accessible par plusieurs scripts (même si ceux-ci prov
 
 Ici, nous nous intéresserons particulièrement aux différences entre les _workers_ dédiés et les _workers_ partagés. Dans cet exemple, nous aurons deux pages HTML, chacune utilisant du code JavaScript employant le même _worker_.
 
-> **Note :** Si on peut accéder à un _worker_ partagé depuis différents contextes de navigations, ces contextes de navigation doivent néanmoins partager la même origine (même protocole, même hôte, même port).
+> [!NOTE]
+> Si on peut accéder à un _worker_ partagé depuis différents contextes de navigations, ces contextes de navigation doivent néanmoins partager la même origine (même protocole, même hôte, même port).
 
-> **Note :** Dans Firefox, les _workers_ partagés ne peuvent pas être partagés entre les documents chargés en navigation privée et les documents chargés en navigation classique ([bug Firefox 1177621](https://bugzil.la/1177621)).
+> [!NOTE]
+> Dans Firefox, les _workers_ partagés ne peuvent pas être partagés entre les documents chargés en navigation privée et les documents chargés en navigation classique ([bug Firefox 1177621](https://bugzil.la/1177621)).
 
 ### Initier un _worker_ partagé
 
@@ -159,7 +165,8 @@ Une différence fondamentale avec les _workers_ dédiés est l'utilisation d'un 
 
 La connexion au port doit être démarrée implicitement avec l'utilisation du gestionnaire d'évènement `onmessage` ou explicitement avec la méthode `start()` avant qu'un message soit envoyé. On utilisera uniquement `start()` si l'évènement `message` est détecté avec la méthode `addEventListener()`.
 
-> **Note :** Lorsqu'on utilise la méthode `start()` afin d'ouvrir le port de connexion, celle-ci doit être appelée de part et d'autre (depuis le _thread_ parent **et** depuis le _worker_) si on souhaite disposer d'une connexion bidirectionnelle.
+> [!NOTE]
+> Lorsqu'on utilise la méthode `start()` afin d'ouvrir le port de connexion, celle-ci doit être appelée de part et d'autre (depuis le _thread_ parent **et** depuis le _worker_) si on souhaite disposer d'une connexion bidirectionnelle.
 
 ### Échanger des messages avec un _worker_ partagé et y réagir
 
@@ -308,7 +315,8 @@ for (var i = 0; i < uInt8Array.length; ++i) {
 worker.postMessage(uInt8Array.buffer, [uInt8Array.buffer]);
 ```
 
-> **Note :** Pour plus d'informations quant aux objets transférables, aux performances associées et à la détection de ces fonctionnalités, on pourra lire [Transferable Objects: Lightning Fast](https://developers.google.com/web/updates/2011/12/Transferable-Objects-Lightning-Fast).
+> [!NOTE]
+> Pour plus d'informations quant aux objets transférables, aux performances associées et à la détection de ces fonctionnalités, on pourra lire [Transferable Objects: Lightning Fast](https://developers.google.com/web/updates/2011/12/Transferable-Objects-Lightning-Fast).
 
 ## _Workers_ embarqués
 
@@ -499,7 +507,8 @@ La plupart des fonctionnalités JavaScript standard peuvent être utilisées dan
 
 En revanche, un _worker_ ne pourra pas directement manipuler la page parente et notamment le DOM et les objets de la page. Il faudra effectuer ce traitement indirectement, via des messages.
 
-> **Note :** Pour avoir une liste exhaustive des fonctionnalités disponibles pour les _workers_, voir [les fonctions et interfaces disponibles pour les _workers_](/fr/docs/Web/API/Worker/Functions_and_classes_available_to_workers).
+> [!NOTE]
+> Pour avoir une liste exhaustive des fonctionnalités disponibles pour les _workers_, voir [les fonctions et interfaces disponibles pour les _workers_](/fr/docs/Web/API/Worker/Functions_and_classes_available_to_workers).
 
 ## Spécifications
 

--- a/files/fr/web/api/webgl2renderingcontext/index.md
+++ b/files/fr/web/api/webgl2renderingcontext/index.md
@@ -14,7 +14,8 @@ var canevas = document.getElementById("monCanevas");
 var gl = canevas.getContext("webgl2");
 ```
 
-> **Note :** WebGL 2 est une extension de WebGL 1. L'interface `WebGL2RenderingContext` implémente tous les membres de l'interface {{domxref("WebGLRenderingContext")}}. Certaines méthodes du contexte WebGL 1 peuvent accepter des valeurs supplémentaires lorsqu'elles sont utilisées dans un contexte WebGL 2. Vous trouverez cette information sur les pages de référence WebGL 1.
+> [!NOTE]
+> WebGL 2 est une extension de WebGL 1. L'interface `WebGL2RenderingContext` implémente tous les membres de l'interface {{domxref("WebGLRenderingContext")}}. Certaines méthodes du contexte WebGL 1 peuvent accepter des valeurs supplémentaires lorsqu'elles sont utilisées dans un contexte WebGL 2. Vous trouverez cette information sur les pages de référence WebGL 1.
 
 Le [didacticiel WebGL](/fr/docs/Web/API/WebGL_API/Tutorial) contient plus d'informations, d'exemples et de ressources sur la façon de démarrer avec WebGL.
 

--- a/files/fr/web/api/webgl_api/by_example/hello_glsl/index.md
+++ b/files/fr/web/api/webgl_api/by_example/hello_glsl/index.md
@@ -7,7 +7,8 @@ slug: Web/API/WebGL_API/By_example/Hello_GLSL
 
 Dans cet article, on décrit un programme de manipulation de _shaders_ qui dessine un carré de couleur.
 
-> **Note :** Cet exemple devrait fonctionner pour l'ensemble des navigateurs récents. Cependant, pour les versions anciennes ou mobiles, il peut y avoir des dysfonctionnements. Si le canevas reste blanc, vous pouvez vérifier le résultat avec l'exemple suivant qui dessine exactement la même chose. Assurez-vous de bien lire les explications et le code présent sur cette page avant de passer à la suivante.
+> [!NOTE]
+> Cet exemple devrait fonctionner pour l'ensemble des navigateurs récents. Cependant, pour les versions anciennes ou mobiles, il peut y avoir des dysfonctionnements. Si le canevas reste blanc, vous pouvez vérifier le résultat avec l'exemple suivant qui dessine exactement la même chose. Assurez-vous de bien lire les explications et le code présent sur cette page avant de passer à la suivante.
 
 {{EmbedLiveSample("Hello_World_en_GLSL",660,425)}}
 

--- a/files/fr/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -188,7 +188,8 @@ Une fois que cela est fait, nous créons un tableau JavaScript contenant la posi
 
 Une fois que les shaders sont définis, que les emplacements sont retrouvés, et que les positions des sommets du carré 2D sont stockées dans le tampon, nous pouvons faire effectivement le rendu de la scène. Puisque nous n'animons rien dans cet exemple, notre fonction `drawScene()` est très simple. Elle utilise quelques routines utilitaires que nous décrirons sous peu.
 
-> **Note :** Vous pourriez obtenir une erreur JavaScript indiquant _"mat4 n'est pas défini"_. Cela signifie qu'il existe une dépendance à **glmatrix**. Vous pouvez inclure [gl-matrix](https://www.npmjs.com/package/gl-matrix) pour résoudre ce problème.
+> [!NOTE]
+> Vous pourriez obtenir une erreur JavaScript indiquant _"mat4 n'est pas défini"_. Cela signifie qu'il existe une dépendance à **glmatrix**. Vous pouvez inclure [gl-matrix](https://www.npmjs.com/package/gl-matrix) pour résoudre ce problème.
 
 ```js
 function drawScene(gl, programInfo, buffers) {

--- a/files/fr/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -11,7 +11,8 @@ Maintenant que notre programme peut faire tourner un cube 3D, appliquons lui une
 
 La première chose à faire est d'ajouter le code pour charger les textures. Dans notre cas, nous utiliserons une texture unique, appliquée à chacune des six faces de notre cube en rotation ; mais la même technique peut être utilisée un nombre quelconque de textures.
 
-> **Note :** il est important de noter que le chargement des textures suit les [règles inter-domaines](/fr/docs/Web/HTTP/CORS) donc vous pouvez seulement charger des textures depuis les sites pour lesquels votre contenu a l'approbation CORS. Voir les textures inter-domaines ci-dessous pour plus de détails.
+> [!NOTE]
+> Il est important de noter que le chargement des textures suit les [règles inter-domaines](/fr/docs/Web/HTTP/CORS) donc vous pouvez seulement charger des textures depuis les sites pour lesquels votre contenu a l'approbation CORS. Voir les textures inter-domaines ci-dessous pour plus de détails.
 
 Le code qui charge la texture ressemble à ce qui suit&nbsp;:
 
@@ -297,12 +298,15 @@ Le chargement des textures WebGL est soumis aux contrôles d'accès inter-domain
 
 Voir cet [article sur hacks.mozilla.org](http://hacks.mozilla.org/2011/11/using-cors-to-load-webgl-textures-from-cross-domain-images/) pour une explication de l'utilisation des images approuvées CORS comme textures WebGL, avec [un exemple complet](http://people.mozilla.org/~bjacob/webgltexture-cors-js.html).
 
-> **Note :** le support CORS pour les texture WebGL et l'attribut `crossOrigin` pour les éléments image est implémenté dans Gecko 8.0.
+> [!NOTE]
+> Le support CORS pour les texture WebGL et l'attribut `crossOrigin` pour les éléments image est implémenté dans Gecko 8.0.
 
 Les canevas 2D dégradés (en écriture seule) ne peuvent pas être utilisés comme des textures WebGL. Un {{HTMLElement ("canvas")}} 2D devient dégradé par exemple lorsqu'il est utilisé pour dessiner une image inter-domaine.
 
-> **Note :** le support CORS pour `drawImage` de Canvas 2D est implémenté dans Gecko 9.0. Cela signifie que l'utilisation d'une image inter-domaine ayant l'approbation CORS ne dégrade plus le canevas 2D, de sorte que le canevas 2D reste utilisable comme source d'une texture WebGL.
+> [!NOTE]
+> Le support CORS pour `drawImage` de Canvas 2D est implémenté dans Gecko 9.0. Cela signifie que l'utilisation d'une image inter-domaine ayant l'approbation CORS ne dégrade plus le canevas 2D, de sorte que le canevas 2D reste utilisable comme source d'une texture WebGL.
 
-> **Note :** le support CORS pour les vidéos inter-domaines et l'attribut `crossorigin` pour les éléments {{HTMLElement ("video")}} est implémenté dans Gecko 12.0.
+> [!NOTE]
+> Le support CORS pour les vidéos inter-domaines et l'attribut `crossorigin` pour les éléments {{HTMLElement ("video")}} est implémenté dans Gecko 12.0.
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Creating_3D_objects_using_WebGL", "Web/API/WebGL_API/Tutorial/Lighting_in_WebGL")}}

--- a/files/fr/web/api/webglrenderingcontext/enablevertexattribarray/index.md
+++ b/files/fr/web/api/webglrenderingcontext/enablevertexattribarray/index.md
@@ -7,7 +7,8 @@ slug: Web/API/WebGLRenderingContext/enableVertexAttribArray
 
 La méthode {{domxref ("WebGLRenderingContext")}} **`enableVertexAttribArray()` -** qui fait partie de l'API WebGL - active le tableau générique des attributs de sommet à l'indice spécifié dans la liste des tableaux d'attributs.
 
-> **Note :** Vous pouvez désactiver le tableau d'attributs en appelant {{domxref("WebGLRenderingContext.disableVertexAttribArray", "disableVertexAttribArray()")}}.
+> [!NOTE]
+> Vous pouvez désactiver le tableau d'attributs en appelant {{domxref("WebGLRenderingContext.disableVertexAttribArray", "disableVertexAttribArray()")}}.
 
 Dans WebGL, les valeurs s'appliquant à un sommet particulier sont stockées dans des attributs. Ceux-ci ne sont disponibles que pour le code JavaScript et le shader de sommet. Les attributs sont référencés par un numéro d'indice dans la liste des attributs gérés par la GPU. Certains indices d'attributs de sommet peuvent avoir des buts prédéfinis, suivant la plate-forme et/ou la GPU. D'autres sont affectés par la couche WebGL lorsque vous créez les attributs.
 
@@ -57,7 +58,8 @@ gl.vertexAttribPointer(
 gl.drawArrays(gl.TRIANGLES, 0, vertexCount);
 ```
 
-> **Note :** Cet extrait de code provient de [la fonction animateScene()](/fr/docs/Web/API/WebGL_API/Basic_2D_animation_example#drawing_and_animating_the_scene) dans "Un exemple d'animation WebGL 2D de base". Voir cet article pour l'exemple complet et pour voir l'animation résultante en action.
+> [!NOTE]
+> Cet extrait de code provient de [la fonction animateScene()](/fr/docs/Web/API/WebGL_API/Basic_2D_animation_example#drawing_and_animating_the_scene) dans "Un exemple d'animation WebGL 2D de base". Voir cet article pour l'exemple complet et pour voir l'animation résultante en action.
 
 Ce code définit le tampon des sommets qui sera utilisé pour dessiner les triangles de la forme en appelant {{domxref("WebGLRenderingContext.bindBuffer", "bindBuffer()")}}. Ensuite, l'indice de l'attribut de position des sommets est obtenu à partir du programme shader en appelant {{domxref("WebGLRenderingContext.getAttribLocation", "getAttribLocation()")}}.
 

--- a/files/fr/web/api/webglrenderingcontext/getuniformlocation/index.md
+++ b/files/fr/web/api/webglrenderingcontext/getuniformlocation/index.md
@@ -33,7 +33,8 @@ Une valeur {{domxref ("WebGLUniformLocation")}} indiquant l'emplacement de la va
 
 `WebGLUniformLocation` est une valeur opaque utilisée pour identifier de manière unique l'emplacement dans la mémoire de la GPU auquel se trouve la variable uniform. Avec cette valeur en main, vous pouvez appeler d'autres méthodes WebGL pour accéder à la valeur de la variable uniform.
 
-> **Note :** Le type `WebGLUniformLocation` est compatible avec le type `GLint` pour indiquer l'indice ou l'emplacement d'un attribut uniform.
+> [!NOTE]
+> Le type `WebGLUniformLocation` est compatible avec le type `GLint` pour indiquer l'indice ou l'emplacement d'un attribut uniform.
 
 ### Erreurs
 
@@ -60,7 +61,8 @@ gl.uniform2fv(uRotationVector, currentRotation);
 gl.uniform4fv(uGlobalColor, [0.1, 0.7, 0.2, 1.0]);
 ```
 
-> **Note :** Cet extrait de code provient de [la fonction animateScene()](/fr/docs/Web/API/WebGL_API/Basic_2D_animation_example#drawing_and_animating_the_scene) dans "Un exemple d'animation WebGL 2D de base". Voir cet article pour l'exemple complet et pour voir l'animation résultante en action.
+> [!NOTE]
+> Cet extrait de code provient de [la fonction animateScene()](/fr/docs/Web/API/WebGL_API/Basic_2D_animation_example#drawing_and_animating_the_scene) dans "Un exemple d'animation WebGL 2D de base". Voir cet article pour l'exemple complet et pour voir l'animation résultante en action.
 
 Après avoir défini le programme d'ombrage en cours comme `programmeShader`, ce code récupère les trois uniforms `"uScalingFactor"`, `"uGlobalColor"` et `"uRotationVector"`, en appelant `getUniformLocation()` une fois pour chaque uniform.
 

--- a/files/fr/web/api/webglrenderingcontext/uniform/index.md
+++ b/files/fr/web/api/webglrenderingcontext/uniform/index.md
@@ -7,7 +7,8 @@ slug: Web/API/WebGLRenderingContext/uniform
 
 Les méthodes **`WebGLRenderingContext.uniform[1234][fi][v]()`** de l'[API WebGL](/fr/docs/Web/API/WebGL_API) indiquent les valeurs des variables uniform.
 
-> **Note :** Beaucoup des fonctions décrites ici ont des interfaces WebGL 2 étendues, qui peuvent être trouvées en {{domxref("WebGL2RenderingContext.uniform","WebGL2RenderingContext.uniform[1234][uif][v]()")}}.
+> [!NOTE]
+> Beaucoup des fonctions décrites ici ont des interfaces WebGL 2 étendues, qui peuvent être trouvées en {{domxref("WebGL2RenderingContext.uniform","WebGL2RenderingContext.uniform[1234][uif][v]()")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/api/webrtc_api/session_lifetime/index.md
+++ b/files/fr/web/api/webrtc_api/session_lifetime/index.md
@@ -5,7 +5,8 @@ slug: Web/API/WebRTC_API/Session_lifetime
 
 {{DefaultAPISidebar("WebRTC")}}
 
-> **Note :** WebRTC vous permet de faire de la communication pair-à-pair dans une application du navigateur.
+> [!NOTE]
+> WebRTC vous permet de faire de la communication pair-à-pair dans une application du navigateur.
 
 ## Etablir la connexion
 

--- a/files/fr/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/fr/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -113,7 +113,8 @@ pc.setRemoteDescription(
 
 Tout ce qui est en dessous de ce point est potentiellement obsolète. Il est toujours là en attente d'examen et d'intégration possible dans d'autres parties de la documentation où il serait encore valides.
 
-> **Note :** Ne pas utiliser les examples de cette page. Voir l'article [signalisation et appel vidéo](/fr/docs/Web/API/WebRTC_API/Signaling_and_video_calling) ,pour des example mis a jour sur l'utilisation des medias WebRTC.
+> [!NOTE]
+> Ne pas utiliser les examples de cette page. Voir l'article [signalisation et appel vidéo](/fr/docs/Web/API/WebRTC_API/Signaling_and_video_calling) ,pour des example mis a jour sur l'utilisation des medias WebRTC.
 
 ## Note
 

--- a/files/fr/web/api/websocket/close/index.md
+++ b/files/fr/web/api/websocket/close/index.md
@@ -44,7 +44,8 @@ WebSocket.close(code, reason);
 
     non appairés.
 
-> **Note :** Avant Gecko 8.0, cette méthode ne prenait en charge aucun paramètre.
+> [!NOTE]
+> Avant Gecko 8.0, cette méthode ne prenait en charge aucun paramètre.
 
 ## Spécifications
 

--- a/files/fr/web/api/websocket/send/index.md
+++ b/files/fr/web/api/websocket/send/index.md
@@ -51,7 +51,8 @@ WebSocket.send("Coucou serveur !");
 
     non appairés.
 
-> **Note :** Pour Gecko 6.0, l'implémentation de `send()` varie de la spécification : le moteur renvoie un booléen indiquant si la connexion est toujours ouverte (par extension, cela indique si les données ont été correctement rajoutées à la queue ou transmises). Ce comportement a été corrigé avec Gecko 8.0.
+> [!NOTE]
+> Pour Gecko 6.0, l'implémentation de `send()` varie de la spécification : le moteur renvoie un booléen indiquant si la connexion est toujours ouverte (par extension, cela indique si les données ont été correctement rajoutées à la queue ou transmises). Ce comportement a été corrigé avec Gecko 8.0.
 >
 > Avec Gecko 11.0, la prise en charge des [`ArrayBuffer`](/fr/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) est implémentée mais pas celle pour les objets [`Blob`](/fr/docs/Web/API/Blob).
 

--- a/files/fr/web/api/websockets_api/index.md
+++ b/files/fr/web/api/websockets_api/index.md
@@ -7,7 +7,8 @@ slug: Web/API/WebSockets_API
 
 L'**API WebSocket** est une technologie évoluée qui permet d'ouvrir un canal de communication bidirectionnelle entre un navigateur (côté client) et un serveur. Avec cette API vous pouvez envoyer des messages à un serveur et recevoir ses réponses de manière événementielle sans avoir à aller consulter le serveur pour obtenir une réponse.
 
-> **Note :** Bien que les connexions WebSocket soient fonctionnellement similaires aux sockets standard de type Unix, elles ne sont pas liées.
+> [!NOTE]
+> Bien que les connexions WebSocket soient fonctionnellement similaires aux sockets standard de type Unix, elles ne sont pas liées.
 
 ## Interfaces
 

--- a/files/fr/web/api/websockets_api/writing_a_websocket_server_in_java/index.md
+++ b/files/fr/web/api/websockets_api/writing_a_websocket_server_in_java/index.md
@@ -180,7 +180,8 @@ Opcode _0x1_ signifie que ceci est un texte. [Liste exhaustive des Opcodes](http
 
 Si le second octet moins 128 est entre 0 et 125, alors il s'agit de la longueur du message. Si c'est 126, les deux octets suivants (entier non signé de 16-bits), si c'est 127, les huit octets suivants (entier non signé de 64-bis, dont le poid ford doit être 0) sont la longueur.
 
-> **Note :** Je peux prendre 128 car le premier bit est toujours 1.
+> [!NOTE]
+> Je peux prendre 128 car le premier bit est toujours 1.
 
 \- 167, 225, 225 et 210 sont les octets de la clef à décoder. Cela change en permanence.
 

--- a/files/fr/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/fr/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -7,7 +7,8 @@ slug: Web/API/WebSockets_API/Writing_WebSocket_client_applications
 
 Les WebSockets représentent une technologie, basée sur le protocole web socket, qui permet d'établir une session de communication bilatérale entre un navigateur web et un serveur. Un navigateur web est un exemple typique de client websocket typique mais le protocole n'est dépendant d'aucune plateforme.
 
-> **Note :** Un exemple d'utilisation des WebSockets à travers un système de chat sera mis à disposition sous forme de code dès que nos infrastructures seront en mesure de supporter les WebSockets.
+> [!NOTE]
+> Un exemple d'utilisation des WebSockets à travers un système de chat sera mis à disposition sous forme de code dès que nos infrastructures seront en mesure de supporter les WebSockets.
 
 {{AvailableInWorkers}}
 
@@ -77,7 +78,8 @@ Une fois la connexion ouverte on peut commencer à tranférer des données vers 
 
 Les données peuvent être envoyées sous forme de chaîne {{ domxref("Blob") }} ou de [`ArrayBuffer`](/fr/docs/Web/API/JavaScript_typed_arrays/ArrayBuffer).
 
-> **Note :** Avant la version 11, Firefox supportait l'envoi de données uniquement sous forme de chaîne.
+> [!NOTE]
+> Avant la version 11, Firefox supportait l'envoi de données uniquement sous forme de chaîne.
 
 Comme l'établissement d'une connexion est asynchrone, et peut potentiellemet échouer, appeler la méthode `send()` juste après la création d'un objet WebSocket peut ne pas fonctionner. Il est plus sûr de définir un gestionnaire d'évènement `onopen`, et de n'essayer d'envoyer des données que lorsqu'il est appelé.
 

--- a/files/fr/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/fr/web/api/websockets_api/writing_websocket_servers/index.md
@@ -11,7 +11,8 @@ Un serveur WebSocket peut être écrit dans n'importe quel language de programma
 
 Avant de débuter, vous **devez** connaître précisément le fonctionnement du protocole HTTP et disposer d'une certaine expérience sur celui-ci. Des connaissances sur les sockets TCP dans votre langage de développement est également précieux. Ce guide ne présente ainsi que le _minimum_ des connaissances requises et non un guide ultime.
 
-> **Note :** Lire la dernière spécification officielle sur les WebSockets [RFC 6455](http://datatracker.ietf.org/doc/rfc6455/?include_text=1). Les sections 1 et 4-7 sont particulièrement intéressantes pour ce qui nous occupe. La section 10 évoque la sécurité et doit être connue et mise en oeuvre avant d'exposer votre serveur au-delà du réseau local / lors de la mise en production.
+> [!NOTE]
+> Lire la dernière spécification officielle sur les WebSockets [RFC 6455](http://datatracker.ietf.org/doc/rfc6455/?include_text=1). Les sections 1 et 4-7 sont particulièrement intéressantes pour ce qui nous occupe. La section 10 évoque la sécurité et doit être connue et mise en oeuvre avant d'exposer votre serveur au-delà du réseau local / lors de la mise en production.
 
 Un serveur WebSocket est compris ici en "bas niveau" (_c'est-à-dire plus proche du langage machine que du langage humain_. Les WebSockets sont souvent séparés et spécialisés vis-à-vis de leurs homologues serveurs (pour des questions de montées en charge ou d'autres raisons), donc vous devez souvent utiliser un [proxy inverse](https://fr.wikipedia.org/wiki/Proxy_inverse) (_c'est-à-dire de l'extérieur vers l'intérieur du réseau local, comme pour un serveur HTTP classique_) pour détecter les "poignées de mains" spécifiques au WebSocket, qui précédent l'échange et permettent d'aiguiller les clients vers le bon logiciel. Dans ce cas, vous ne devez pas ajouter à votre serveur des _cookies_ et d'autres méthodes d'authentification.
 
@@ -19,7 +20,8 @@ Un serveur WebSocket est compris ici en "bas niveau" (_c'est-à-dire plus proche
 
 En tout premier lieu, le serveur doit écouter les connexions sockets entrantes utilisant le protocole TCP standard. Suivant votre plateforme, celui-ci peut déjà le faire pour vous. Pour l'exemple qui suit, nous prenons pour acquis que votre serveur écoute le domaine _exemple.com_ sur le port 8000 et votre serveur socket répond aux requêtes de type GET sur le chemin _/chat_.
 
-> **Attention :** Si le serveur peut écouter n'importe quel port, mais que vous décidez de ne pas utiliser un port standard (80 ou 443 pour SSL), cela peut créer en avant des problèmes avec les parefeux et/ou les proxys. De plus, gardez en mémoire que certains navigateur Web (notablement Firefox 8+), n'autorisent pas les connexions WebSocket non-SSL sur une page SSL.
+> [!WARNING]
+> Si le serveur peut écouter n'importe quel port, mais que vous décidez de ne pas utiliser un port standard (80 ou 443 pour SSL), cela peut créer en avant des problèmes avec les parefeux et/ou les proxys. De plus, gardez en mémoire que certains navigateur Web (notablement Firefox 8+), n'autorisent pas les connexions WebSocket non-SSL sur une page SSL.
 
 La _poignée de mains_ est la partie "Web" dans les WebSockets : c'est le pont entre le protocole HTTP et le WebSocket. Durant cette poignée, les détails (les paramètres) de la connexion sont négociés et l'une des parties peut interromptre la transaction avant la fin si l'un des termes ne lui est pas autorisé / ne lui est pas possible. Le serveur doit donc être attentif à comprendre parfaitement les demandes et attentes du client, sans quoi des procédures de sécurité seront déclenchées.
 
@@ -40,9 +42,11 @@ Le client peut solliciter des extensions de protocoles ou des sous-protocoles à
 
 Si un des entêtes n'est pas compris ou sa valeur n'est pas correcte, le serveur devrait envoyer une réponse "[400 Bad Request](/fr/docs/HTTP/Response_codes#400)" (_erreur 400 : la requête est incorrecte_) et clore immédiatement la connexion. Il peut par ailleurs indiquer la raison pour laquelle la poignée de mains a échoué dans le corps de réponse HTTP, mais le message peut ne jamais être affiché par le navigateur (_en somme, tout dépend du comportement du client_). Si le serveur ne comprend pas la version de WebSockets présentée, il doit envoyer dans la réponse un entête _Sec-WebSocket-Version_ correspondant à la ou les version-s supportée-s. Ici le guide explique la version 13, la plus récente à l'heure de l'écriture du tutoriel (_voir le tutoriel en version anglaise pour la date exacte ; il s'agit là d'une traduction_). Maintenant, nous allons passer à l'entête attendu : _Sec-WebSocket-Key_.
 
-> **Note :** Un grand nombre de navigateurs enverront un [`Entête d'origine`](/fr/docs/HTTP/Access_control_CORS#Origin). Vous pouvez alors l'utiliser pour vérifier la sécurité de la transaction (par exemple vérifier la similitude des domaines, listes blanches ou noires, etc.) et éventuellement retourner une réponse [403 Forbidden](/fr/docs/HTTP/Response_codes#403) si l'origine ne vous plaît pas. Toutefois garder à l'esprit que cet entête peut être simulé ou trompeur (il peut être ajouté manuellement ou lors du transfert). De nombreuses applications refusent les transactions sans celui-ci.
+> [!NOTE]
+> Un grand nombre de navigateurs enverront un [`Entête d'origine`](/fr/docs/HTTP/Access_control_CORS#Origin). Vous pouvez alors l'utiliser pour vérifier la sécurité de la transaction (par exemple vérifier la similitude des domaines, listes blanches ou noires, etc.) et éventuellement retourner une réponse [403 Forbidden](/fr/docs/HTTP/Response_codes#403) si l'origine ne vous plaît pas. Toutefois garder à l'esprit que cet entête peut être simulé ou trompeur (il peut être ajouté manuellement ou lors du transfert). De nombreuses applications refusent les transactions sans celui-ci.
 
-> **Note :** L'URI de la requête (`/chat` dans notre cas) n'a pas de signification particulièrement dans les spécifications en usage&nbsp;: elle permet simplement, par convention, de disposer d'une multitude d'applications en parallèle grâce à WebSocket. Par exemple, `exemple.com/chat` peut être associée à une API/une application de dialogue multiutilisateurs lorsque `/game` invoquera son homologue pour un jeu.
+> [!NOTE]
+> L'URI de la requête (`/chat` dans notre cas) n'a pas de signification particulièrement dans les spécifications en usage&nbsp;: elle permet simplement, par convention, de disposer d'une multitude d'applications en parallèle grâce à WebSocket. Par exemple, `exemple.com/chat` peut être associée à une API/une application de dialogue multiutilisateurs lorsque `/game` invoquera son homologue pour un jeu.
 
 > **Note :** [Les codes réguliers (_c-à-d défini par le protocole standard_) HTTP](/fr/docs/HTTP/Response_codes) ne peuvent être utilisés qu'**_avant_** la poignée : ceux après la poignée, sont définis d'une manière spécifique dans la section 7.4 de la documentation sus-nommée.
 
@@ -59,11 +63,13 @@ Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
 
 En sus, le serveur peut décider de proposer des extensions de protocoles ou des sous-protocoles à cet instant ; voir [Miscellaneous](#Miscellaneous) pour les détails. L'entête Sec-WebSocket-Accept nous intéresse ici : le serveur doit la former depuis l'entête Sec-WebSocket-Key envoyée précédemment par le client. Pour l'obtenir, vous devez concaténater (_rassembler_) la valeur de _Sec-WebSocket-Key_ et "_258EAFA5-E914-47DA-95CA-C5AB0DC85B11_" (valeur fixée par défaut : c'est une "[magic string](https://en.wikipedia.org/wiki/Magic_string)") puis procéder au hash par la méthode [SHA-1](https://en.wikipedia.org/wiki/SHA-1) du résultat et retourner le format au format [base64](https://en.wikipedia.org/wiki/Base64).
 
-> **Note :** Ce processus qui peut paraître inutilement complexe, permet de certifier que le serveur et le client sont bien sur une base WebSocket et non une requête HTTP (qui serait alors mal interprétée).
+> [!NOTE]
+> Ce processus qui peut paraître inutilement complexe, permet de certifier que le serveur et le client sont bien sur une base WebSocket et non une requête HTTP (qui serait alors mal interprétée).
 
 Ainsi si la clé (la valeur de l'entête du client) était "`dGhlIHNhbXBsZSBub25jZQ==`", le retour (_Accept \* dans la version d'origine du tutoriel_) sera : "`s3pPLMBiTxaQ9kYGzzhZRbK+xOo=`". Une fois que le serveur a envoyé les entêtes attendues, alors la poignée de mains est considérée comme effectuée et vous pouvez débuter l'échange de données !
 
-> **Note :** Le serveur peut envoyer à ce moment, d'autres entêtes comme par exemple Set-Cookie, ou demander une authenficiation ou encore une redirection via les codes standards HTTP et ce **avant** la fin du processus de poignée de main.
+> [!NOTE]
+> Le serveur peut envoyer à ce moment, d'autres entêtes comme par exemple Set-Cookie, ou demander une authenficiation ou encore une redirection via les codes standards HTTP et ce **avant** la fin du processus de poignée de main.
 
 ### Suivre les clients confirmés
 
@@ -75,7 +81,8 @@ Le client ou le serveur peuvent choisir d'envoyer un message à n'importe quel m
 
 ### Format
 
-> **Attention :** Dans cette partie, `payload` équivaut en bon français à _charge utile_. C'est-à-dire les données qui ne font pas partie du fonctionnement de la trame mais de l'échange entre le serveur et le client. Ainsi «&nbsp;<i lang="en">payload data</i>&nbsp;» est traduit par «&nbsp;données utiles&nbsp;».
+> [!WARNING]
+> Dans cette partie, `payload` équivaut en bon français à _charge utile_. C'est-à-dire les données qui ne font pas partie du fonctionnement de la trame mais de l'échange entre le serveur et le client. Ainsi «&nbsp;<i lang="en">payload data</i>&nbsp;» est traduit par «&nbsp;données utiles&nbsp;».
 
 Chaque trame (dans un sens ou dans un autre) suit le schéma suivant :
 
@@ -136,7 +143,8 @@ for (var i = 0; i < ENCODED.length; i++) {
 }
 ```
 
-> **Note :** Ici la variable `DECODED` correspond aux données utiles à votre application - en fonction de l'utilisation ou non d'un sous-protocole (_si c'est `json`, vous devez encore décoder les données utiles reçues avec le parseur JSON_).
+> [!NOTE]
+> Ici la variable `DECODED` correspond aux données utiles à votre application - en fonction de l'utilisation ou non d'un sous-protocole (_si c'est `json`, vous devez encore décoder les données utiles reçues avec le parseur JSON_).
 
 ### La fragmentation des messages
 
@@ -164,7 +172,8 @@ A n'importe quel moment après le processus de poignée de mains, le client ou l
 
 Le _ping_ ou le _pong_ sont des trames classiques dites **de contrôle**. Les _pings_ disposent d'un opcode à `0x9` et les _pongs_ à `0xA`. Lorsqu'un _ping_ est envoyé, le _pong_ doit disposer de la même donnée utile en réponse que le ping (et d'une taille maximum autorisé de 125). Le _pong_ seul (c-à-d sans _ping_) est ignoré.
 
-> **Note :** Lorsque plusieurs pings sont envoyés à la suite, un **seul** pong suffit en réponse (_le plus récent pour la donnée utile renvoyée_).
+> [!NOTE]
+> Lorsque plusieurs pings sont envoyés à la suite, un **seul** pong suffit en réponse (_le plus récent pour la donnée utile renvoyée_).
 
 ## Clore la connexion
 
@@ -172,23 +181,27 @@ La connexion peut être close à l'initiative du client ou du serveur grâce à 
 
 ## Diverses informations utiles
 
-> **Note :** L'ensemble des codes, extensions et sous-protocoles liés aux WebSocket sont enregistrés dans le (registre) [IANA WebSocket Protocol Registry](http://www.iana.org/assignments/websocket/websocket.xml).
+> [!NOTE]
+> L'ensemble des codes, extensions et sous-protocoles liés aux WebSocket sont enregistrés dans le (registre) [IANA WebSocket Protocol Registry](http://www.iana.org/assignments/websocket/websocket.xml).
 
 Les extensions et sous-protocoles des WebSockets sont négociés durant [l'échange des entêtes de la poignée de mains](#PoignéeDeMain). Si l'on pourrait croire qu'extensions et sous-protocles sont finalement la même chose, il n'en est rien : **le contrôle des extensions agit sur les trames** ce qui modifie la charge utile ; **alors que les sous-protocoles modifient uniquement la charge utile,** et rien d'autre. Les extensions sont optionnelles et généralisées (par exemple pour la compression des données) ; les sous-protocoles sont souvent obligatoires et ciblés (par exemple dans le cadre d'une application de chat ou d'un jeu MMORPG).
 
-> **Attention :** Les sous-extensions ou les sous-protocoles ne sont pas obligatoires pour l'échange de données par WebSockets ; mais l'esprit développé ici est de rendre soit plus efficace ou sécurisée la transmission (l'esprit d'une extension) ; soit de délimiter et de normaliser le contenu de l'échange (l'esprit d'un sous-protocole ; qui étend donc le protocole par défaut des WebSockets qu'est l'échange de texte simple au format UTF-8).
+> [!WARNING]
+> Les sous-extensions ou les sous-protocoles ne sont pas obligatoires pour l'échange de données par WebSockets ; mais l'esprit développé ici est de rendre soit plus efficace ou sécurisée la transmission (l'esprit d'une extension) ; soit de délimiter et de normaliser le contenu de l'échange (l'esprit d'un sous-protocole ; qui étend donc le protocole par défaut des WebSockets qu'est l'échange de texte simple au format UTF-8).
 
 ### Les extensions
 
 L'idée des extensions pourrait être, par exemple, la compression d'un fichier avant de l'envoyer par courriel / email à quelqu'un : les données transférées ne changent pas de contenu, mais leur format oui (et leur taille aussi...). Ce n'est donc pas le format du contenu qui change que le mode transmission - c'est le principe des extensions en WebSockets, dont le principe de base est d'être un protocole simple d'échange de données.
 
-> **Note :** Les extensions sont présentées et expliquées dans les sections 5.8, 9, 11.3.2, and 11.4 de la documentation sus-nommées.
+> [!NOTE]
+> Les extensions sont présentées et expliquées dans les sections 5.8, 9, 11.3.2, and 11.4 de la documentation sus-nommées.
 
 ### Les sous-protocoles
 
 Les sous-protocoles sont à comparer à [un schéma XML](https://en.wikipedia.org/wiki/XML_schema) ou [une déclaration de DocType](https://en.wikipedia.org/wiki/Document_Type_Definition). Ainsi vous pouvez utiliser seulement du XML et sa syntaxe et, imposer par le biais des sous-protocoles, son utilisation durant l'échange WebSocket. C'est l'intérêt de ces sous-protocoles : établir une structure définie (_et intangible : le client se voit imposer la mise en oeuvre par le serveur_), bien que les deux doivent l'accepter pour communiquer ensemble.
 
-> **Note :** Les sous-protocoles sont expliqués dans les sections 1.9, 4.2, 11.3.4, and 11.5 de la documentation sus-nommés.
+> [!NOTE]
+> Les sous-protocoles sont expliqués dans les sections 1.9, 4.2, 11.3.4, and 11.5 de la documentation sus-nommés.
 
 Exemple : un client souhaite demander un sous-protocole spécifique. Pour se faire, il envoie dans les entêtes d'origine du processus de poignées de mains :
 
@@ -212,11 +225,13 @@ Le serveur doit désormais choisir l'un des protocoles suggérés par le client 
 Sec-WebSocket-Protocol: soap
 ```
 
-> **Attention :** Le serveur ne peut (ne doit) envoyer plus d'un entête `Sec-Websocket-Protocol`. **S'il n'en supporte aucun, il ne doit pas renvoyer l'entête `Sec-WebSocket-Protocol` (l'entête vide n'est pas correct).** Le client peut alors interrompre la connexion s'il n'a pas le sous-protocole qu'il souhaite (ou qu'il supporte).
+> [!WARNING]
+> Le serveur ne peut (ne doit) envoyer plus d'un entête `Sec-Websocket-Protocol`. **S'il n'en supporte aucun, il ne doit pas renvoyer l'entête `Sec-WebSocket-Protocol` (l'entête vide n'est pas correct).** Le client peut alors interrompre la connexion s'il n'a pas le sous-protocole qu'il souhaite (ou qu'il supporte).
 
 Si vous souhaitez que votre serveur puisse supporter certains sous-protocoles, vous pourriez avoir besoin d'une application ou de scripts supplémentaires sur le serveur. Imaginons par exemple que vous utilisiez le sous-protocole json - où toutes les données échangées par WebSockets sont donc formatés suivant le format [JSON](https://fr.wikipedia.org/wiki/JavaScript_Object_Notation). Si le client sollicite ce sous-protocole et que le serveur souhaite l'accepter, vous **devez disposer** d'un parseur (d'un décodeur) JSON et décoder les données par celui-ci.
 
-> **Note :** Pour éviter des conflits d'espaces de noms, il est recommandé d'utiliser le sous-protocole comme un sous-domaine de celui utilisé. Par exemple si vous utilisez un sous-protocole propriétaire qui utilise un format d'échange de données non-standard pour une application de _chat_ sur le domaine _exemple.com_, vous devrirez utiliser&nbsp;: `Sec-WebSocket-Protocol: chat.exemple.com`. S'il y a différentes versions possibles, modifiez le chemin pour faire correspondre le path à votre version comme ceci : `chat.exemple.com/2.0`. Notez que ce n'est pas obligatoire, c'est une convention d'écriture optionnel et qui peut être utilisée d'une toute autre façon.
+> [!NOTE]
+> Pour éviter des conflits d'espaces de noms, il est recommandé d'utiliser le sous-protocole comme un sous-domaine de celui utilisé. Par exemple si vous utilisez un sous-protocole propriétaire qui utilise un format d'échange de données non-standard pour une application de _chat_ sur le domaine _exemple.com_, vous devrirez utiliser&nbsp;: `Sec-WebSocket-Protocol: chat.exemple.com`. S'il y a différentes versions possibles, modifiez le chemin pour faire correspondre le path à votre version comme ceci : `chat.exemple.com/2.0`. Notez que ce n'est pas obligatoire, c'est une convention d'écriture optionnel et qui peut être utilisée d'une toute autre façon.
 
 ## Contenus associés
 

--- a/files/fr/web/api/wheelevent/index.md
+++ b/files/fr/web/api/wheelevent/index.md
@@ -7,9 +7,11 @@ slug: Web/API/WheelEvent
 
 L'interface **`WheelEvent`** représente les évènements qui se produisent lorsque l'utilisateur déplace la molette de la souris ou un périphérique d'entrée similaire.
 
-> **Attention :** Il s'agit de l'interface d'évènement de roue standard à utiliser. Les anciennes versions des navigateurs implémentaient les interfaces {{DOMxRef("MouseWheelEvent")}} et {{DOMxRef("MouseScrollEvent")}} non standard et non compatibles avec plusierus navigateurs. Utilisez cette interface et évitez les non standard.
+> [!WARNING]
+> Il s'agit de l'interface d'évènement de roue standard à utiliser. Les anciennes versions des navigateurs implémentaient les interfaces {{DOMxRef("MouseWheelEvent")}} et {{DOMxRef("MouseScrollEvent")}} non standard et non compatibles avec plusierus navigateurs. Utilisez cette interface et évitez les non standard.
 
-> **Note :** Ne confondez pas l'évènement {{domxref("Element/wheel_event", "wheel")}} avec l'énénement {{domxref("Element/scroll_event", "scroll")}} : L'action par défaut d'un évènement `wheel` est définie par l'implantation. Ainsi, un évènement `wheel` ne distribue pas nécessairement un évènement `scroll`. Même lorsque c'est le cas, cela ne signifie pas que les valeurs `delta*` dans l'évènement `wheel` reflètent nécessairement la direction de défilement du contenu. Par conséquent, ne comptez pas sur les propriétés `delta*` pour obtenir la direction de défilement du contenu. Au lieu de cela, détectez les changements de valeurs de {{DOMxRef("Element.scrollLeft", "scrollLeft")}} et {{DOMxRef("Element.scrollTop", "scrollTop")}} de la cible dans l'évènement `scroll`.
+> [!NOTE]
+> Ne confondez pas l'évènement {{domxref("Element/wheel_event", "wheel")}} avec l'énénement {{domxref("Element/scroll_event", "scroll")}} : L'action par défaut d'un évènement `wheel` est définie par l'implantation. Ainsi, un évènement `wheel` ne distribue pas nécessairement un évènement `scroll`. Même lorsque c'est le cas, cela ne signifie pas que les valeurs `delta*` dans l'évènement `wheel` reflètent nécessairement la direction de défilement du contenu. Par conséquent, ne comptez pas sur les propriétés `delta*` pour obtenir la direction de défilement du contenu. Au lieu de cela, détectez les changements de valeurs de {{DOMxRef("Element.scrollLeft", "scrollLeft")}} et {{DOMxRef("Element.scrollTop", "scrollTop")}} de la cible dans l'évènement `scroll`.
 
 {{InheritanceDiagram}}
 

--- a/files/fr/web/api/window/back/index.md
+++ b/files/fr/web/api/window/back/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Window/back
 
 La méthode obsolète et non standard `back()` sur l'objet {{domxref("window")}} renvoie la fenêtre à l'élément précédent de l'historique. Il s'agissait d'une méthode spécifique à Firefox et a été supprimée dans Firefox 31.
 
-> **Note :** Utilisez plutôt la méthode standard {{domxref("history.back")}}.
+> [!NOTE]
+> Utilisez plutôt la méthode standard {{domxref("history.back")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/api/window/beforeunload_event/index.md
+++ b/files/fr/web/api/window/beforeunload_event/index.md
@@ -9,9 +9,11 @@ L'événement **`beforeunload`** est déclenché quand la fênetre, ou le docume
 
 Lorsqu'une chaîne de caractères est assignée à la propriété `returnValue` de {{domxref("Event")}}, une boîte de dialogue apparaît demandant confirmation avant de quitter la page (voir exemple plus bas). Certains navigateurs affichent la valeur retournée, alors que d'autres affichent leur propre message. Si aucune valeur n'est fournie, l'événement est traité silencieusement.
 
-> **Note :** Afin d'éviter les "pop-ups" indésirables, les navigateurs peuvent ne pas afficher les alertes créées dans les gestionnaires `beforeunload`.
+> [!NOTE]
+> Afin d'éviter les "pop-ups" indésirables, les navigateurs peuvent ne pas afficher les alertes créées dans les gestionnaires `beforeunload`.
 
-> **Attention :** Attacher un gestionnaire d'événement `beforeunload` à `window` ou à `document` empêche les navigateurs d'utiliser leur mémoire cache ; consulter [Utilisation du cache de Firefox 1.5](/fr/docs/Utilisation_du_cache_de_Firefox_1.5) ou [WebKit's Page Cache](https://webkit.org/blog/516/webkit-page-cache-ii-the-unload-event/) (en anglais).
+> [!WARNING]
+> Attacher un gestionnaire d'événement `beforeunload` à `window` ou à `document` empêche les navigateurs d'utiliser leur mémoire cache ; consulter [Utilisation du cache de Firefox 1.5](/fr/docs/Utilisation_du_cache_de_Firefox_1.5) ou [WebKit's Page Cache](https://webkit.org/blog/516/webkit-page-cache-ii-the-unload-event/) (en anglais).
 
 <table class="properties">
   <tbody>

--- a/files/fr/web/api/window/blur_event/index.md
+++ b/files/fr/web/api/window/blur_event/index.md
@@ -9,7 +9,8 @@ La propriété **`onblur`**, rattachée au mixin [`GlobalEventHandlers`](/fr/doc
 
 L'évènement `blur` est déclenché lorsqu'un élément perd le focus.
 
-> **Note :** Le gestionnaire d'évènement opposé à `onblur` est [`onfocus`](/fr/docs/Web/API/GlobalEventHandlers/onfocus).
+> [!NOTE]
+> Le gestionnaire d'évènement opposé à `onblur` est [`onfocus`](/fr/docs/Web/API/GlobalEventHandlers/onfocus).
 
 ## Syntaxe
 

--- a/files/fr/web/api/window/clearimmediate/index.md
+++ b/files/fr/web/api/window/clearimmediate/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Window/clearImmediate
 
 Cette méthode efface l'action spécifiée par {{DOMxRef("window.setImmediate")}}.
 
-> **Note :** Cette méthode ne devrait pas devenir standard et n'est implémentée que par les versions récentes d'Internet Explorer et de Node.js 0.10+. Il rencontre la résistance à la fois de [Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=686201) (Firefox) et [Webkit](http://code.google.com/p/chromium/issues/detail?id=146172) (Google/Apple).
+> [!NOTE]
+> Cette méthode ne devrait pas devenir standard et n'est implémentée que par les versions récentes d'Internet Explorer et de Node.js 0.10+. Il rencontre la résistance à la fois de [Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=686201) (Firefox) et [Webkit](http://code.google.com/p/chromium/issues/detail?id=146172) (Google/Apple).
 
 ## Syntaxe
 

--- a/files/fr/web/api/window/console/index.md
+++ b/files/fr/web/api/window/console/index.md
@@ -31,4 +31,5 @@ Pour plus d'exemples, voir la section [Exemples](/fr/docs/Web/API/Console#exempl
 
 {{Specifications}}
 
-> **Note :** Il existe de nombreuses différences d'implémentation parmi les navigateurs. Un travail d'homogénéisation et de standardisation est en cours afin de les rapprocher.
+> [!NOTE]
+> Il existe de nombreuses différences d'implémentation parmi les navigateurs. Un travail d'homogénéisation et de standardisation est en cours afin de les rapprocher.

--- a/files/fr/web/api/window/event/index.md
+++ b/files/fr/web/api/window/event/index.md
@@ -9,7 +9,8 @@ L'événement de propriété {{domxref("Window")}} en lecture seule renvoie le {
 
 Vous devez éviter d'utiliser cette propriété dans un nouveau code et utiliser à la place le {{domxref ("Event")}} transmis à la fonction de gestionnaire d'événements. Cette propriété n'est pas prise en charge universellement et même lorsqu'elle est prise en charge, elle introduit une fragilité potentielle dans votre code.
 
-> **Note :** Cette propriété peut être fragile, dans la mesure où il peut y avoir des situations dans lesquelles `l'événement` renvoyé n'est pas la valeur attendue. De plus, `Window.event` n'est pas précis pour les événements distribués dans {{Glossary("shadow tree", "shadow trees")}}.
+> [!NOTE]
+> Cette propriété peut être fragile, dans la mesure où il peut y avoir des situations dans lesquelles `l'événement` renvoyé n'est pas la valeur attendue. De plus, `Window.event` n'est pas précis pour les événements distribués dans {{Glossary("shadow tree", "shadow trees")}}.
 
 ## Spécifications
 

--- a/files/fr/web/api/window/find/index.md
+++ b/files/fr/web/api/window/find/index.md
@@ -5,7 +5,8 @@ slug: Web/API/Window/find
 
 {{ApiRef}}{{Non-standard_Header}}
 
-> **Note :** La prise en charge de `Window.find()` pourrait changer dans les futures versions de Gecko. Voir [bug Firefox 672395](https://bugzil.la/672395).
+> [!NOTE]
+> La prise en charge de `Window.find()` pourrait changer dans les futures versions de Gecko. Voir [bug Firefox 672395](https://bugzil.la/672395).
 
 La méthode **`Window.find()`** trouve une chaîne dans une fenêtre.
 

--- a/files/fr/web/api/window/focus_event/index.md
+++ b/files/fr/web/api/window/focus_event/index.md
@@ -11,7 +11,8 @@ L'évènement `focus` est déclenché lorsque la personne active le focus sur un
 
 Afin que `onfocus` soit déclenché sur les éléments qui ne sont pas des éléments `<input>`, il faut que ces derniers aient un attribut [`tabindex`](/fr/docs/Web/HTML/Global_attributes#attr-tabindex). Voir la section [Remettre l'accessibilité au clavier](/fr/docs/Learn/Accessibility/HTML#remettre_laccessibilité_au_clavier) pour plus de détails.
 
-> **Note :** Le gestionnaire d'évènement opposé à `onfocus` est [`onblur`](/fr/docs/Web/API/GlobalEventHandlers/onblur).
+> [!NOTE]
+> Le gestionnaire d'évènement opposé à `onfocus` est [`onblur`](/fr/docs/Web/API/GlobalEventHandlers/onblur).
 
 ## Syntaxe
 

--- a/files/fr/web/api/window/frameelement/index.md
+++ b/files/fr/web/api/window/frameelement/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Window/frameElement
 
 La propriété **`Window.frameElement`** renvoie l'élément (tel que {{HTMLElement("iframe")}} ou {{HTMLElement("object")}}) dans lequel la fenêtre est intégrée.
 
-> **Note :** Malgré le nom de cette propriété, elle fonctionne pour les documents intégrés dans n'importe quel point d'incorporation, y compris {{HTMLElement("object")}}, {{HTMLElement("iframe")}}, ou {{HTMLElement("embed")}}.
+> [!NOTE]
+> Malgré le nom de cette propriété, elle fonctionne pour les documents intégrés dans n'importe quel point d'incorporation, y compris {{HTMLElement("object")}}, {{HTMLElement("iframe")}}, ou {{HTMLElement("embed")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/api/window/getcomputedstyle/index.md
+++ b/files/fr/web/api/window/getcomputedstyle/index.md
@@ -20,7 +20,8 @@ var style = window.getComputedStyle(element[, pseudoElt]);
 - pseudoElt {{ optional_inline() }}
   - : Chaîne de caractère spécifiant le pseudo-élément à cibler. Doit être `null` (ou non spécifiée) pour les éléments communs.
 
-> **Note :** Avant Gecko 2.0, le paramètre `pseudoElt` était obligatoire. Aucun autre navigateur majeur ne requiert que ce paramètre soit renseigné si il est null. Gecko a été modifié pour se comporter comme les autres navigateurs.
+> [!NOTE]
+> Avant Gecko 2.0, le paramètre `pseudoElt` était obligatoire. Aucun autre navigateur majeur ne requiert que ce paramètre soit renseigné si il est null. Gecko a été modifié pour se comporter comme les autres navigateurs.
 
 La valeur de retour `style` est un objet [`CSSStyleDeclaration`](/fr/docs/Web/API/CSSStyleDeclaration).
 

--- a/files/fr/web/api/window/index.md
+++ b/files/fr/web/api/window/index.md
@@ -309,7 +309,8 @@ Ce sont des propriétés de l'objet window qui peuvent être définies pour éta
 
 _Cette interface hérite des gestionnaires d'événements de l'interface {{domxref("EventTarget")}} et elle implémente les gestionnaires d'événements de {{domxref("WindowEventHandlers")}}._
 
-> **Note :** à partir de Gecko 9.0, vous pouvez maintenant utiliser la syntaxe `if ("onabort" in window)` pour déterminer si une propriété de gestionnaire d'événements donnée existe ou non. Cela est dû au fait que les interfaces du gestionnaire d'événements ont été mises à jour pour être des interfaces Web IDL correctes. Voir les gestionnaires d'événements DOM pour plus de détails.
+> [!NOTE]
+> à partir de Gecko 9.0, vous pouvez maintenant utiliser la syntaxe `if ("onabort" in window)` pour déterminer si une propriété de gestionnaire d'événements donnée existe ou non. Cela est dû au fait que les interfaces du gestionnaire d'événements ont été mises à jour pour être des interfaces Web IDL correctes. Voir les gestionnaires d'événements DOM pour plus de détails.
 
 - {{domxref("GlobalEventHandlers.onabort")}}
 

--- a/files/fr/web/api/window/innerheight/index.md
+++ b/files/fr/web/api/window/innerheight/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Window/innerHeight
 
 Récupère la hauteur (en pixels) de la partie visible de la fenêtre de navigation en incluant, si elle est affichée, la barre de défilement horizontale.
 
-> **Note :** La valeur retournée par cette propriété correspond le cas échéant à la hauteur de la fenêtre définie par `nsIDOMWindowUtils.setCSSViewport()`, dans le cas où vous utilisez cette méthode pour définir les dimensions de la fenêtre virtuelle dans le but d'agencer la page.
+> [!NOTE]
+> La valeur retournée par cette propriété correspond le cas échéant à la hauteur de la fenêtre définie par `nsIDOMWindowUtils.setCSSViewport()`, dans le cas où vous utilisez cette méthode pour définir les dimensions de la fenêtre virtuelle dans le but d'agencer la page.
 
 ## Syntaxe
 

--- a/files/fr/web/api/window/localstorage/index.md
+++ b/files/fr/web/api/window/localstorage/index.md
@@ -53,7 +53,8 @@ La syntaxe pour supprimer tous les éléments de `localStorage` est la suivante 
 localStorage.clear();
 ```
 
-> **Note :** Se référer à l'article [Using the Web Storage API](/fr/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API) pour voir un exemple complet.
+> [!NOTE]
+> Se référer à l'article [Using the Web Storage API](/fr/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API) pour voir un exemple complet.
 
 ## Spécifications
 

--- a/files/fr/web/api/window/mozinnerscreenx/index.md
+++ b/files/fr/web/api/window/mozinnerscreenx/index.md
@@ -9,7 +9,8 @@ slug: Web/API/Window/mozInnerScreenX
 
 Obtient la coordonnée X du coin supérieur gauche de la fenêtre de la fenêtre, en coordonnées d'écran.
 
-> **Note :** Cette coordonnée est indiquée en pixels CSS et non en pixels matériels. Cela signifie qu'il peut être affecté par le niveau de zoom&nbsp;; pour calculer le nombre réel de pixels d'écran physiques, vous devez utiliser la propriété [`nsIDOMWindowUtils.screenPixelsPerCSSPixel`](/fr/docs/XPCOM_Interface_Reference/nsIDOMWindowUtils).
+> [!NOTE]
+> Cette coordonnée est indiquée en pixels CSS et non en pixels matériels. Cela signifie qu'il peut être affecté par le niveau de zoom&nbsp;; pour calculer le nombre réel de pixels d'écran physiques, vous devez utiliser la propriété [`nsIDOMWindowUtils.screenPixelsPerCSSPixel`](/fr/docs/XPCOM_Interface_Reference/nsIDOMWindowUtils).
 
 ## Syntaxe
 

--- a/files/fr/web/api/window/mozinnerscreeny/index.md
+++ b/files/fr/web/api/window/mozinnerscreeny/index.md
@@ -9,7 +9,8 @@ slug: Web/API/Window/mozInnerScreenY
 
 Obtient la coordonnée Y du coin supérieur gauche de la fenêtre de la fenêtre, en coordonnées d'écran.
 
-> **Note :** Cette coordonnée est indiquée en pixels CSS et non en pixels matériels. Cela signifie qu'il peut être affecté par le niveau de zoom&nbsp;; pour calculer le nombre réel de pixels d'écran physiques, vous devez utiliser la propriété [`nsIDOMWindowUtils.screenPixelsPerCSSPixel`](/fr/docs/XPCOM_Interface_Reference/nsIDOMWindowUtils).
+> [!NOTE]
+> Cette coordonnée est indiquée en pixels CSS et non en pixels matériels. Cela signifie qu'il peut être affecté par le niveau de zoom&nbsp;; pour calculer le nombre réel de pixels d'écran physiques, vous devez utiliser la propriété [`nsIDOMWindowUtils.screenPixelsPerCSSPixel`](/fr/docs/XPCOM_Interface_Reference/nsIDOMWindowUtils).
 
 ## Syntaxe
 

--- a/files/fr/web/api/window/online_event/index.md
+++ b/files/fr/web/api/window/online_event/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Window/online_event
 
 L'événement **`online`** de l'interface {{domxref("Window")}} est déclenché lorsque le navigateur a obtenu l'accès au réseau et que la valeur de {{domxref("Navigator.onLine")}} passe à `true`.
 
-> **Note :** Cet événement ne doit pas être utilisé pour déterminer la disponibilité d'un site Web particulier. Des problèmes de réseau ou des pare-feu peuvent encore empêcher l'accès au site Web.
+> [!NOTE]
+> Cet événement ne doit pas être utilisé pour déterminer la disponibilité d'un site Web particulier. Des problèmes de réseau ou des pare-feu peuvent encore empêcher l'accès au site Web.
 
 <table class="properties">
   <tbody>

--- a/files/fr/web/api/window/open/index.md
+++ b/files/fr/web/api/window/open/index.md
@@ -38,7 +38,8 @@ open(url, target, windowFeatures);
 
         Si `popup` n'est pas activée et qu'il n'y a pas d'autres fonctionnalités déclarées avec ce paramètre, le nouveau contexte de navigation sera un onglet.
 
-        > **Note :** Indiquer n'importe quelle fonctionnalité avec `windowFeatures`, en dehors de `noopener` ou `noreferrer`, aura pour effet de demander l'ouverture d'une popup.
+        > [!NOTE]
+        > Indiquer n'importe quelle fonctionnalité avec `windowFeatures`, en dehors de `noopener` ou `noreferrer`, aura pour effet de demander l'ouverture d'une popup.
 
         Pour activer cette fonctionnalité, on indiquera simplement le nom `popup` sans valeur ou avec les valeurs `yes`, `1`, ou `true`.
 

--- a/files/fr/web/api/window/requestanimationframe/index.md
+++ b/files/fr/web/api/window/requestanimationframe/index.md
@@ -7,13 +7,15 @@ slug: Web/API/window/requestAnimationFrame
 
 La méthode **`window.requestAnimationFrame()`** indique au navigateur qu'on souhaite exécuter une animation et demande que celui-ci exécute une fonction spécifique de mise à jour de l'animation, avant le prochain rafraîchissement à l'écran du navigateur. Cette méthode prend comme argument une fonction de rappel qui sera appelée avant le rafraîchissement du navigateur.
 
-> **Note :** Si vous souhaitez animer une nouvelle <i lang="en">frame</i> durant le prochain affichage, la fonction de rappel doit de nouveau appeler la méthode `requestAnimationFrame()`. Autrement dit, `requestAnimationFrame()` ne fonctionne qu'une fois.
+> [!NOTE]
+> Si vous souhaitez animer une nouvelle <i lang="en">frame</i> durant le prochain affichage, la fonction de rappel doit de nouveau appeler la méthode `requestAnimationFrame()`. Autrement dit, `requestAnimationFrame()` ne fonctionne qu'une fois.
 
 Cette méthode doit être appelée dès que le code est prêt à rafraîchir l'animation. La fonction de rappel contenant l'animation sera ainsi appelée par le navigateur avant le prochain rafraîchissement. La fonction de rappel est généralement appelée 60 fois par seconde. En réalité, cette fréquence correspondra le plus souvent au taux de rafraîchissement de l'écran dans la plupart des navigateurs, d'après les recommandations du W3C. Les appels à `requestAnimationFrame()` sont mis en pause dans la plupart des navigateurs lors d'une exécution dans des onglets en arrière-plan ou dans des [`<iframe>`](/fr/docs/Web/HTML/Element/iframe) masquées afin d'améliorer les performances et la durée de vie des batteries.
 
 La fonction de rappel reçoit un seul argument, une valeur [`DOMHighResTimeStamp`](/fr/docs/Web/API/DOMHighResTimeStamp), qui indique le temps actuel (exprimé en nombre de millisecondes écoulées depuis [l'origine temporelle](/fr/docs/Web/API/DOMHighResTimeStamp#lorigine_temporelle)). Lorsque plusieurs fonctions de rappel sont mises en attente et que `requestAnimationFrame()` commence à se déclencher pour une image donnée, chaque fonction reçoit le même horodatage, même si du temps s'est écoulé pendant le calcul de la fonction de rappel précédente (dans l'exemple ci-après, on anime uniquement l'image lorsque l'horodatage change, c'est-à-dire à la première fonction de rappel). Cette valeur temporelle est un nombre décimal, exprimant une valeur en millisecondes, avec une précision minimale de 1ms (1000 µs).
 
-> **Attention :** Assurez-vous de toujours utiliser le premier argument (ou une autre méthode pour obtenir le temps courant) afin de calculer la progression nécessaire de l'animation pour une <i lang="en">frame</i>. Sinon, l'animation s'exécutera plus rapidement sur les écrans avec une fréquence de rafraîchissement plus élevée. Voyez l'exemple ci-après pour une technique permettant de faire ce calcul.
+> [!WARNING]
+> Assurez-vous de toujours utiliser le premier argument (ou une autre méthode pour obtenir le temps courant) afin de calculer la progression nécessaire de l'animation pour une <i lang="en">frame</i>. Sinon, l'animation s'exécutera plus rapidement sur les écrans avec une fréquence de rafraîchissement plus élevée. Voyez l'exemple ci-après pour une technique permettant de faire ce calcul.
 
 ## Syntaxe
 

--- a/files/fr/web/api/window/sessionstorage/index.md
+++ b/files/fr/web/api/window/sessionstorage/index.md
@@ -57,7 +57,8 @@ champ.addEventListener("change", function () {
 });
 ```
 
-> **Note :** Veuillez vous référer à l'article [Utilisation de l'API Web Storage](/fr/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API) pour des exemples plus complets.
+> [!NOTE]
+> Veuillez vous référer à l'article [Utilisation de l'API Web Storage](/fr/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API) pour des exemples plus complets.
 
 ## Spécifications
 

--- a/files/fr/web/api/window/showmodaldialog/index.md
+++ b/files/fr/web/api/window/showmodaldialog/index.md
@@ -5,7 +5,8 @@ slug: Web/API/Window/showModalDialog
 
 {{deprecated_header}}{{APIRef}}
 
-> **Attention :** Cette fonctionnalité a été retirée. Veuillez corriger les sites ou applications web sous votre responsabilité qui l'utiliseraient encore.
+> [!WARNING]
+> Cette fonctionnalité a été retirée. Veuillez corriger les sites ou applications web sous votre responsabilité qui l'utiliseraient encore.
 >
 > Cette méthode a été retirée avec Chrome 43 et Firefox 56.
 
@@ -79,7 +80,8 @@ showModalDialog(uri, arguments, options);
   </tbody>
 </table>
 
-> **Note :** Firefox n'implémente pas les arguments `dialogHide`, `edge`, `status`, ou `unadorned`.
+> [!NOTE]
+> Firefox n'implémente pas les arguments `dialogHide`, `edge`, `status`, ou `unadorned`.
 
 ### Valeur de retour
 

--- a/files/fr/web/api/worker/index.md
+++ b/files/fr/web/api/worker/index.md
@@ -13,7 +13,8 @@ De plus les workers peuvent utiliser [`XMLHttpRequest`](/fr/docs/DOM/XMLHttpRequ
 
 [Toutes les interfaces et toutes les fonctions](/fr/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers) ne seront pas disponibles pour le script associé au `Worker`.
 
-> **Note :** Dans Firefox, si vous souhaitez utiliser les workers dans une extension et que vous souhaitez avoir accès au [js-ctypes](/fr/docs/js-ctypes), vous devez utiliser le {{ domxref("ChromeWorker") }} à la place.
+> [!NOTE]
+> Dans Firefox, si vous souhaitez utiliser les workers dans une extension et que vous souhaitez avoir accès au [js-ctypes](/fr/docs/js-ctypes), vous devez utiliser le {{ domxref("ChromeWorker") }} à la place.
 
 ## Constructeurs
 

--- a/files/fr/web/api/worker/message_event/index.md
+++ b/files/fr/web/api/worker/message_event/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Worker/message_event
 
 La propriété **`onmessage`** de l'interface {{domxref("Worker")}} représente un gestionnaire d'évènement, à savoir une fonction qui est appelée lorsque l'événement `message` survient. Ces événements sont du type {{domxref("MessageEvent")}} et sont appelés quand le parent du worker reçoit un message (c'est-à-dire à partir de la méthode {{domxref("DedicatedWorkerGlobalScope.postMessage")}}).
 
-> **Note :** Le contenu du message est fourni par la propriété `data` de l'événement `message`.
+> [!NOTE]
+> Le contenu du message est fourni par la propriété `data` de l'événement `message`.
 
 ## Syntaxe
 

--- a/files/fr/web/api/worker/terminate/index.md
+++ b/files/fr/web/api/worker/terminate/index.md
@@ -31,7 +31,8 @@ var myWorker = new Worker("worker.js");
 myWorker.terminate();
 ```
 
-> **Note :** Les <i lang="en">workers</i> dédiés ou partagés peuvent également être stoppés par l'instance même du [<i lang="en">worker</i>](/fr/docs/Web/API/Worker) en utilisant les méthodes [`DedicatedWorkerGlobalScope.close()`](/fr/docs/Web/API/DedicatedWorkerGlobalScope/close) ou [`SharedWorkerGlobalScope.close()`](/fr/docs/Web/API/SharedWorkerGlobalScope/close).
+> [!NOTE]
+> Les <i lang="en">workers</i> dédiés ou partagés peuvent également être stoppés par l'instance même du [<i lang="en">worker</i>](/fr/docs/Web/API/Worker) en utilisant les méthodes [`DedicatedWorkerGlobalScope.close()`](/fr/docs/Web/API/DedicatedWorkerGlobalScope/close) ou [`SharedWorkerGlobalScope.close()`](/fr/docs/Web/API/SharedWorkerGlobalScope/close).
 
 ## Spécifications
 

--- a/files/fr/web/api/worker/worker/index.md
+++ b/files/fr/web/api/worker/worker/index.md
@@ -7,7 +7,8 @@ slug: Web/API/Worker/Worker
 
 Le constructeur **`Worker()`** crée un objet {{domxref("Worker")}} qui exécute le script à l'URL spécifiée. Ce script doit obéir à la [same-origin policy](/fr/docs/Web/Security/Same-origin_policy).
 
-> **Note :** il y a un désaccord entre les éditeurs de navigateur sur la question de savoir si une donnée URI relève ou non de la même origine. Bien que Gecko 10.0 et suivant accepte les données URIs, ce n'est pas le cas dans tous les autres navigateurs.
+> [!NOTE]
+> Il y a un désaccord entre les éditeurs de navigateur sur la question de savoir si une donnée URI relève ou non de la même origine. Bien que Gecko 10.0 et suivant accepte les données URIs, ce n'est pas le cas dans tous les autres navigateurs.
 
 ## Syntaxe
 

--- a/files/fr/web/api/workerglobalscope/dump/index.md
+++ b/files/fr/web/api/workerglobalscope/dump/index.md
@@ -5,7 +5,8 @@ slug: Web/API/WorkerGlobalScope/dump
 
 {{APIRef("Web Workers API")}}
 
-> **Attention :** Cette fonctionnalité n'est ni standard, ni en voie de standardisation. Ne l'utilisez pas pour des sites accessibles sur le Web : elle ne fonctionnera pas pour tout utilisateur. Il peut également y avoir d'importantes incompatibilités entre les implémentations et son comportement peut être modifié dans le futur.
+> [!WARNING]
+> Cette fonctionnalité n'est ni standard, ni en voie de standardisation. Ne l'utilisez pas pour des sites accessibles sur le Web : elle ne fonctionnera pas pour tout utilisateur. Il peut également y avoir d'importantes incompatibilités entre les implémentations et son comportement peut être modifié dans le futur.
 
 La méthode **`dump()`** de l'interface {{domxref("WorkerGlobalScope")}} permet d'écrire des messages vers `stdout` — i.e. dans le terminal, seulement sur Firefox. C'est la même chose que {{domxref("window.dump")}} dans Firefox, mais pour les *worker*s.
 

--- a/files/fr/web/api/workerglobalscope/index.md
+++ b/files/fr/web/api/workerglobalscope/index.md
@@ -84,7 +84,8 @@ importScripts("foo.js");
 console.log(navigator);
 ```
 
-> **Note :** Étant donné que la portée globale du script de worker est effectivement la portée globale du worker que vous exécutez ({{domxref ("DedicatedWorkerGlobalScope")}} ou autre) et que toutes les portées globales de worker héritent des méthodes, des propriétés, etc. À partir de `WorkerGlobalScope`, vous pouvez exécuter des lignes telles que celles ci-dessus sans spécifier d'objet parent.
+> [!NOTE]
+> Étant donné que la portée globale du script de worker est effectivement la portée globale du worker que vous exécutez ({{domxref ("DedicatedWorkerGlobalScope")}} ou autre) et que toutes les portées globales de worker héritent des méthodes, des propriétés, etc. À partir de `WorkerGlobalScope`, vous pouvez exécuter des lignes telles que celles ci-dessus sans spécifier d'objet parent.
 
 ## Spécifications
 

--- a/files/fr/web/api/workerglobalscope/location/index.md
+++ b/files/fr/web/api/workerglobalscope/location/index.md
@@ -43,7 +43,8 @@ WorkerLocation {hash: "", search: "", pathname: "/worker.js", port: "8000", host
 
 Vous pouvez utiliser l'objet location pour récupérer des informations supplémentaires sur la localisation du document, comme vous pourriez le faire avec un objet {{domxref("Location")}} normal.
 
-> **Note :** Firefox rencontre un bogue avec l'utilisation de `console.log` à l'intérieur des workers partagés/service (voir [bug Firefox 1058644](https://bugzil.la/1058644)), ce qui peut occasionner d'étranges résultats, mais cela devrait être bientôt corrigé.
+> [!NOTE]
+> Firefox rencontre un bogue avec l'utilisation de `console.log` à l'intérieur des workers partagés/service (voir [bug Firefox 1058644](https://bugzil.la/1058644)), ce qui peut occasionner d'étranges résultats, mais cela devrait être bientôt corrigé.
 
 ## Spécifications
 

--- a/files/fr/web/api/workerglobalscope/navigator/index.md
+++ b/files/fr/web/api/workerglobalscope/navigator/index.md
@@ -42,7 +42,8 @@ Object {onLine: true, userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1
 
 Vous pouvez utiliser l'objet navigator pour récupérer des informations supplémentaires sur l'environnement d'exécution, comme vous pourriez le faire avec un objet {{domxref("Navigator")}} normal.
 
-> **Note :** Firefox rencontre un bogue avec l'utilisation de `console.log` à l'intérieur des workers partagés/service (voir [bug Firefox 1058644](https://bugzil.la/1058644)), ce qui peut occasionner d'étranges résultats, mais cela devrait être bientôt corrigé.
+> [!NOTE]
+> Firefox rencontre un bogue avec l'utilisation de `console.log` à l'intérieur des workers partagés/service (voir [bug Firefox 1058644](https://bugzil.la/1058644)), ce qui peut occasionner d'étranges résultats, mais cela devrait être bientôt corrigé.
 
 ## Spécifications
 

--- a/files/fr/web/api/xmlhttprequest/index.md
+++ b/files/fr/web/api/xmlhttprequest/index.md
@@ -43,7 +43,8 @@ _Cette interface hérite également des propriétés de {{domxref("XMLHttpReques
 - {{domxref("XMLHttpRequest.statusText")}} {{readonlyinline}}
   - : Une chaîne {{domxref("DOMString")}} qui contient la chaîne de caractères / réponse renvoyée par le serveur HTTP. À la différence de {{domxref("XMLHttpRequest.status")}}, tout le texte du statut est inclus ("`200 OK`" plutôt que "`200`" par exemple).
 
-> **Note :** Selon la spécification HTTP/2 ([voir 8.1.2.4](https://http2.github.io/http2-spec/#rfc.section.8.1.2.4) [Response Pseudo-Header Fields](https://http2.github.io/http2-spec/#HttpResponse)), HTTP/2 ne définit pas de méthode pour porter la version ou la raison/phrase incluse dans la ligne de statut HTTP/1.1.
+> [!NOTE]
+> Selon la spécification HTTP/2 ([voir 8.1.2.4](https://http2.github.io/http2-spec/#rfc.section.8.1.2.4) [Response Pseudo-Header Fields](https://http2.github.io/http2-spec/#HttpResponse)), HTTP/2 ne définit pas de méthode pour porter la version ou la raison/phrase incluse dans la ligne de statut HTTP/1.1.
 
 - {{domxref("XMLHttpRequest.timeout")}}
   - : Un entier `unsigned long` qui représente le nombre de millisecondes qu'une requête peut prendre avant d'être terminée automatiquement.
@@ -99,7 +100,8 @@ La plupart des navigateurs récents gère également les évènements via la mé
 - {{domxref("XMLHttpRequest.init()")}}
   - : Initialise l'objet depuis pour une utilisation depuis du code C++.
 
-> **Attention :** Cette méthode ne doit pas être appelée depuis du code JavaScript.
+> [!WARNING]
+> Cette méthode ne doit pas être appelée depuis du code JavaScript.
 
 - {{domxref("XMLHttpRequest.openRequest()")}}
   - : Initialise une requête depuis du code natif. Voir la méthode [`open()`](/fr/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIXMLHttpRequest#open) ci-avant pour initialiser une requête de façon standard en JavaSCript.

--- a/files/fr/web/api/xmlhttprequest/open/index.md
+++ b/files/fr/web/api/xmlhttprequest/open/index.md
@@ -7,7 +7,8 @@ slug: Web/API/XMLHttpRequest/open
 
 La méthode **`open()`** de {{domxref("XMLHttpRequest")}} instancie une nouvelle requête ou réinitialise un déjà existante.
 
-> **Note :** Appeler cette méthode pour une requête déjà active (pour laquelle une méthode `open()` a déjà été appelée) est équivalent à appeler {{domxref("XMLHttpRequest.abort", "abort()")}}.
+> [!NOTE]
+> Appeler cette méthode pour une requête déjà active (pour laquelle une méthode `open()` a déjà été appelée) est équivalent à appeler {{domxref("XMLHttpRequest.abort", "abort()")}}.
 
 ## Syntaxe
 
@@ -28,7 +29,8 @@ XMLHttpRequest.open(method, url, async, user, password);
 
   - : Un booléen optionnel par défaut à `true`, indiquant s'il faut, ou pas, traiter la requête en asynchrone. Si la valeur est à `false`, la méthode `send()` ne retourne rien tant qu'elle n'a pas reçu la réponse. Si la valeur est à `true`, une notification de transaction complétée est fournie en utilisant un gestionnaire d'évènements. Le paramètre doit être sur "true" si l'attribut `multipart` est sur "true" aussi ou une exception sera levée.
 
-    > **Note :** Les requêtes asynchrones sur le "thread" principal peuvent facilement dérouter l'utilisateur et devraient être évitées; En fait, de nombreux navigateurs ont un support XHR obsolète sur la totalité du "thread" principal. Les requêtes synchrones sont acceptées dans {{domxref("Worker")}}.
+    > [!NOTE]
+    > Les requêtes asynchrones sur le "thread" principal peuvent facilement dérouter l'utilisateur et devraient être évitées; En fait, de nombreux navigateurs ont un support XHR obsolète sur la totalité du "thread" principal. Les requêtes synchrones sont acceptées dans {{domxref("Worker")}}.
 
 - `user` {{optional_inline}}
   - : Le nom de l'utilisateur, optionnel, à utiliser dans un but d'authentification. Sa valeur par défaut est `null`.

--- a/files/fr/web/api/xmlhttprequest/readystate/index.md
+++ b/files/fr/web/api/xmlhttprequest/readystate/index.md
@@ -59,7 +59,8 @@ La propriété XMLHttpRequest.readyState renvoie l'état dans lequel se trouve u
 - DONE
   - : L'opération de récupération est terminée. Cela peut signifier que le transfert de données a été effectué avec succès ou a échoué.
 
-> **Note :** Les noms des états sont différents dans les versions d'Internet Explorer antérieures à 11. Au lieu de `UNSENT`, `OPENED`, `HEADERS_RECEIVED`, `LOADING` et `DONE`, les noms `READYSTATE_UNINITIALIZED` (0), `READYSTATE_LOADING` (1), `READYSTATE_LOADED` (2), `READYSTATE_INTERACTIVE` (3) et `READYSTATE_COMPLETE` (4) sont utilisés.
+> [!NOTE]
+> Les noms des états sont différents dans les versions d'Internet Explorer antérieures à 11. Au lieu de `UNSENT`, `OPENED`, `HEADERS_RECEIVED`, `LOADING` et `DONE`, les noms `READYSTATE_UNINITIALIZED` (0), `READYSTATE_LOADING` (1), `READYSTATE_LOADED` (2), `READYSTATE_INTERACTIVE` (3) et `READYSTATE_COMPLETE` (4) sont utilisés.
 
 ## Exemple
 

--- a/files/fr/web/api/xmlhttprequest/readystatechange_event/index.md
+++ b/files/fr/web/api/xmlhttprequest/readystatechange_event/index.md
@@ -7,7 +7,8 @@ slug: Web/API/XMLHttpRequest/readystatechange_event
 
 Un [`EventHandler`](/fr/docs/Web/API/EventHandler) qui réagit aux changements de `readyState`. Le callback est appelé dans le contexte du thread de rendu. La propriété **`XMLHttpRequest.onreadystatechange`** contient le gestionnaire d'évènement appelé lorsque l'évènement [`readystatechange`](/fr/docs/Web/API/Document/readystatechange_event) est déclenché, soit chaque fois que la propriété {{domxref("XMLHttpRequest.readyState", "readyState")}} de {{domxref("XMLHttpRequest")}} est modifiée.
 
-> **Attention :** Ne doit pas être utilisé avec des requêtes synchrone ni avec du code natif.
+> [!WARNING]
+> Ne doit pas être utilisé avec des requêtes synchrone ni avec du code natif.
 
 ## Syntaxe
 

--- a/files/fr/web/api/xmlhttprequest/response/index.md
+++ b/files/fr/web/api/xmlhttprequest/response/index.md
@@ -102,7 +102,8 @@ La propriété `XMLHttpRequest.response` contient le corps de la réponse. Elle 
   </tbody>
 </table>
 
-> **Note :** À partir de Gecko 11.0 et de WebKit build 528, ces navigateurs ne permettent plus l'utilisation de l'attribut `responseType` lors des requêtes synchrones. Cela renvoi l'erreur `NS_ERROR_DOM_INVALID_ACCESS_ERR`. Ce changement a été proposé au W3C afin d'être standardisé.
+> [!NOTE]
+> À partir de Gecko 11.0 et de WebKit build 528, ces navigateurs ne permettent plus l'utilisation de l'attribut `responseType` lors des requêtes synchrones. Cela renvoi l'erreur `NS_ERROR_DOM_INVALID_ACCESS_ERR`. Ce changement a été proposé au W3C afin d'être standardisé.
 
 ## Example
 

--- a/files/fr/web/api/xmlhttprequest/setrequestheader/index.md
+++ b/files/fr/web/api/xmlhttprequest/setrequestheader/index.md
@@ -13,7 +13,8 @@ Si aucun {{HTTPHeader("Accept")}} n'a été configurer avec cette méthode, un `
 
 Pour des raisons de sécurité, certain header ne peuvent être manipulés que par le user agent. Ceux-ci contiennent les paramètres {{Glossary("Forbidden_header_name", "forbidden header names", 1)}} et {{Glossary("Forbidden_response_header_name", "forbidden response header names", 1)}}.
 
-> **Note :** Dans certain cas, vous pourrez rencontrer l'erreur / exception "**not allowed by Access-Control-Allow-Headers in preflight response**" quand vous enverez une requête cross domains. Dans ce cas, vous devrez configurer {{HTTPHeader("Access-Control-Allow-Headers")}} dans votre réponse HTTP coté serveur.
+> [!NOTE]
+> Dans certain cas, vous pourrez rencontrer l'erreur / exception "**not allowed by Access-Control-Allow-Headers in preflight response**" quand vous enverez une requête cross domains. Dans ce cas, vous devrez configurer {{HTTPHeader("Access-Control-Allow-Headers")}} dans votre réponse HTTP coté serveur.
 
 ## Syntaxe
 

--- a/files/fr/web/api/xmlhttprequest/timeout/index.md
+++ b/files/fr/web/api/xmlhttprequest/timeout/index.md
@@ -7,9 +7,11 @@ slug: Web/API/XMLHttpRequest/timeout
 
 La propriété **`XMLHttpRequest.timeout`** est un `unsigned long` (un entier long, non-signé) représentant la durée, en millisecondes, qu'une requête peut prendre avant d'être automatiquement terminée. Par défaut, la valeur est 0 et il n'y pas de _timeout_. Lorsqu'une requête expire, un évènement [`timeout`](/fr/docs/Web/API/XMLHttpRequest/timeout_event) est déclenché.
 
-> **Note :** Pour un exemple, voir [Utiliser la propriété `timeout` avec une requête asynchrone](/fr/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests#Example_using_a_timeout).
+> [!NOTE]
+> Pour un exemple, voir [Utiliser la propriété `timeout` avec une requête asynchrone](/fr/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests#Example_using_a_timeout).
 
-> **Note :** Ces délais d'expiration ne devraient pas être utilisés pour les requêtes `XMLHttpRequest` synchrones dans [un environnement de document](/fr/docs/Glossaire/Environnement_de_document) : ils déclencheront une exception `InvalidAccessError`. On ne peut donc pas utiliser de _timeout_ pour les requêtes synchrones avec une fenêtre parente.
+> [!NOTE]
+> Ces délais d'expiration ne devraient pas être utilisés pour les requêtes `XMLHttpRequest` synchrones dans [un environnement de document](/fr/docs/Glossaire/Environnement_de_document) : ils déclencheront une exception `InvalidAccessError`. On ne peut donc pas utiliser de _timeout_ pour les requêtes synchrones avec une fenêtre parente.
 
 ## Exemples
 

--- a/files/fr/web/api/xmlhttprequest/withcredentials/index.md
+++ b/files/fr/web/api/xmlhttprequest/withcredentials/index.md
@@ -11,9 +11,11 @@ Cette propriété est également utilisée afin d'indiquer lorsque les cookies d
 
 Les cookies tiers obtenus lorsque `withCredentials` vaut `true` continuent de respecter la règle de même origine et ne peuvent donc pas être manipulés en script via [`document.cookie`](/fr/docs/Web/API/Document/cookie) ou depuis les en-têtes de la réponse.
 
-> **Note :** Cette propriété n'a aucun impact pour les requêtes effectuées sur le même site.
+> [!NOTE]
+> Cette propriété n'a aucun impact pour les requêtes effectuées sur le même site.
 
-> **Note :** Les réponses `XMLHttpRequest` provenant d'un domaine différent ne peuvent pas définir de cookies pour ce domaine à moins d'avoir `withCredentials` à `true` avant l'envoi de la requête (quelle que soit la valeur de l'en-tête `Access-Control-`).
+> [!NOTE]
+> Les réponses `XMLHttpRequest` provenant d'un domaine différent ne peuvent pas définir de cookies pour ce domaine à moins d'avoir `withCredentials` à `true` avant l'envoi de la requête (quelle que soit la valeur de l'en-tête `Access-Control-`).
 
 ## Exemples
 

--- a/files/fr/web/api/xmlhttprequest_api/using_formdata_objects/index.md
+++ b/files/fr/web/api/xmlhttprequest_api/using_formdata_objects/index.md
@@ -33,7 +33,8 @@ request.open("POST", "https://example.com/submitform.php");
 request.send(formData);
 ```
 
-> **Note :** Les champs «&nbsp;userfile&nbsp;» et «&nbsp;webmasterfile&nbsp;» contiennent tous deux un fichier. Le numéro attribué au champ «&nbsp;accountnum&nbsp;» est immédiatement converti en chaîne par la méthode [`FormData.append()`](/fr/docs/Web/API/FormData/append) (la valeur du champ peut être un objet [`Blob`](/fr/docs/Web/API/Blob), [`File`](/fr/docs/Web/API/File) ou une chaîne&nbsp;: **s'il ne s'agit ni d'un objet `Blob`, ni d'un objet `File`, la valeur est convertie en chaîne**).
+> [!NOTE]
+> Les champs «&nbsp;userfile&nbsp;» et «&nbsp;webmasterfile&nbsp;» contiennent tous deux un fichier. Le numéro attribué au champ «&nbsp;accountnum&nbsp;» est immédiatement converti en chaîne par la méthode [`FormData.append()`](/fr/docs/Web/API/FormData/append) (la valeur du champ peut être un objet [`Blob`](/fr/docs/Web/API/Blob), [`File`](/fr/docs/Web/API/File) ou une chaîne&nbsp;: **s'il ne s'agit ni d'un objet `Blob`, ni d'un objet `File`, la valeur est convertie en chaîne**).
 
 Dans cet exemple, une instance `FormData` contenant les valeurs des champs «&nbsp;username&nbsp;», «&nbsp;accountnum&nbsp;», «&nbsp;userfile&nbsp;» et «&nbsp;webmasterfile&nbsp;» est créée, puis la méthode [`XMLHttpRequest.send()`](/fr/docs/Web/API/XMLHttpRequest/send) est utilisée pour envoyer les données du formulaire. Le champ «&nbsp;webmasterfile&nbsp;» est un objet [`Blob`](/fr/docs/Web/API/Blob). Un objet `Blob` représente un objet-fichier de données brutes immuables. Les blobs représentent des données qui ne sont pas nécessairement dans un format JavaScript natif. L'interface [`File`](/fr/docs/Web/API/File) se base sur l'objet `Blob`, elle en hérite les fonctionnalités et les étend pour prendre en charge les fichiers du système d'exploitation. Pour construire un `Blob`, vous pouvez invoquer [le constructeur `Blob()`](/fr/docs/Web/API/Blob/Blob).
 
@@ -133,9 +134,11 @@ form.addEventListener(
 );
 ```
 
-> **Note :** Si vous passez une référence dans le formulaire, [la méthode HTTP spécifiée](/fr/docs/Web/HTTP/Methods) dans ce dernier sera utilisée au lieu de celle définie dans l'appel de la méthode `open()`.
+> [!NOTE]
+> Si vous passez une référence dans le formulaire, [la méthode HTTP spécifiée](/fr/docs/Web/HTTP/Methods) dans ce dernier sera utilisée au lieu de celle définie dans l'appel de la méthode `open()`.
 
-> **Attention :** Lors de l'utilisation de `FormData` pour envoyer des requêtes POST à l'aide de [`XMLHttpRequest`](/fr/docs/Web/API/XMLHttpRequest) ou de [l'API <i lang="en">Fetch</i>](/fr/docs/Web/API/Fetch_API) pour du contenu de type `multipart/form-data` (par exemple pour téléverser des fichiers ou des blobs vers le serveur), _il ne faut pas indiquer de façon explicite_ l'en-tête [`Content-Type`](/fr/docs/Web/HTTP/Headers/Content-Type) sur la requête. Si vous le faites, cela empêchera le navigateur de renseigner l'en-tête `Content-Type` avec l'expression de limite qui sera utilisée pour délimiter les champs du formulaire dans le corps de la requête.
+> [!WARNING]
+> Lors de l'utilisation de `FormData` pour envoyer des requêtes POST à l'aide de [`XMLHttpRequest`](/fr/docs/Web/API/XMLHttpRequest) ou de [l'API <i lang="en">Fetch</i>](/fr/docs/Web/API/Fetch_API) pour du contenu de type `multipart/form-data` (par exemple pour téléverser des fichiers ou des blobs vers le serveur), _il ne faut pas indiquer de façon explicite_ l'en-tête [`Content-Type`](/fr/docs/Web/HTTP/Headers/Content-Type) sur la requête. Si vous le faites, cela empêchera le navigateur de renseigner l'en-tête `Content-Type` avec l'expression de limite qui sera utilisée pour délimiter les champs du formulaire dans le corps de la requête.
 
 Vous pouvez également ajouter un objet [`File`](/fr/docs/Web/API/File) ou [`Blob`](/fr/docs/Web/API/Blob) directement dans l'objet [`FormData`](/fr/docs/Web/API/FormData)&nbsp;:
 


### PR DESCRIPTION
This PR converts the noteblocks for the French locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 11. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
