### PR TITLE
fr: Convert noteblocks to GFM Alerts (part 14)

### DIFF
--- a/files/fr/web/css/flex/index.md
+++ b/files/fr/web/css/flex/index.md
@@ -173,7 +173,8 @@ La propriété `flex` peut être définie avec une, deux ou trois valeurs.
 - `<'flex-basis'>`
   - : Voir {{cssxref("flex-basis")}}. Une valeur valide pour {{cssxref("width")}} et {{cssxref("height")}}. La valeur par défaut est `0`.
 
-> **Note :** Lorsqu'on utilise une ou deux valeurs sans unité dans la règle, `flex-basis` vaudra 0. Pour plus d'informations, voir [le brouillon de spécification du module des boîtes flexibles](https://drafts.csswg.org/css-flexbox/#flex-common).
+> [!NOTE]
+> Lorsqu'on utilise une ou deux valeurs sans unité dans la règle, `flex-basis` vaudra 0. Pour plus d'informations, voir [le brouillon de spécification du module des boîtes flexibles](https://drafts.csswg.org/css-flexbox/#flex-common).
 
 ## Définition formelle
 

--- a/files/fr/web/css/float/index.md
+++ b/files/fr/web/css/float/index.md
@@ -32,7 +32,8 @@ Un **élément flottant** est un élément pour lequel [la valeur calculée](/fr
 | `inline-grid`                                        | `grid`                                             |
 | _autre_                                              | _inchangée_                                        |
 
-> **Note :** Si vous utilisez cette propriété via JavaScript, comme propriété de l'objet [`HTMLElement.style`](/fr/docs/Web/API/HTMLElement/style), la plupart des navigateurs récents permettront d'utiliser `float`, mais il faudra utiliser `cssFloat` (attention à la casse) pour les navigateurs plus anciens. Pour Internet Explorer 8 et les versions antérieures, elle était appelée `styleFloat`. Le terme `float` étant réservé en JavaScript, ce cas de figure était une exception à la règle qui définit que le nom de la propriété DOM est une version [CamelCase](https://fr.wikipedia.org/wiki/CamelCase) de la propriété CSS construite avec des tirets. De même, `class` sera échappée en `className` et le `for` des éléments \<label> sera converti en `htmlFor`).
+> [!NOTE]
+> Si vous utilisez cette propriété via JavaScript, comme propriété de l'objet [`HTMLElement.style`](/fr/docs/Web/API/HTMLElement/style), la plupart des navigateurs récents permettront d'utiliser `float`, mais il faudra utiliser `cssFloat` (attention à la casse) pour les navigateurs plus anciens. Pour Internet Explorer 8 et les versions antérieures, elle était appelée `styleFloat`. Le terme `float` étant réservé en JavaScript, ce cas de figure était une exception à la règle qui définit que le nom de la propriété DOM est une version [CamelCase](https://fr.wikipedia.org/wiki/CamelCase) de la propriété CSS construite avec des tirets. De même, `class` sera échappée en `className` et le `for` des éléments \<label> sera converti en `htmlFor`).
 
 ## Syntaxe
 

--- a/files/fr/web/css/font-family/index.md
+++ b/files/fr/web/css/font-family/index.md
@@ -15,7 +15,8 @@ Pour fixer `font-family` et d'autres propriétés liées aux polices de caractè
 
 Les auteurs doivent toujours inclure une famille de police générique dans cette liste car il n'y a aucune certitude qu'une police donnée aura été installée sur l'ordinateur ni qu'elle pourra être téléchargée grâce à {{cssxref("@font-face")}}. L'utilisation d'une famille de police générique permet au navigateur d'utiliser une police acceptable en recours si besoin.
 
-> **Note :** La propriété `font-family` définit une liste de police, ordonnée par priorité, de la plus haute à la plus basse. La sélection de la police ne se fait pas pour l'ensemble du texte mais **caractère par caractère**. Ainsi si une police ne dispose pas du caractère à représenter, ce sera la police suivante qui sera utilisée pour représenter le caractère. Pour Internet Explorer, cela ne fonctionne pas avec la version 6 et les version antérieures.
+> [!NOTE]
+> La propriété `font-family` définit une liste de police, ordonnée par priorité, de la plus haute à la plus basse. La sélection de la police ne se fait pas pour l'ensemble du texte mais **caractère par caractère**. Ainsi si une police ne dispose pas du caractère à représenter, ce sera la police suivante qui sera utilisée pour représenter le caractère. Pour Internet Explorer, cela ne fonctionne pas avec la version 6 et les version antérieures.
 >
 > Les propriétés {{cssxref("font-style")}}, {{cssxref("font-variant")}} et {{cssxref("font-size")}} permettront d'influencer le choix en fonction du style, de la variante ou de la taille disponible parmi les polices de la liste.
 

--- a/files/fr/web/css/font-feature-settings/index.md
+++ b/files/fr/web/css/font-feature-settings/index.md
@@ -9,7 +9,8 @@ La propriété **`font-feature-settings`** permet de contrôler les fonctionnali
 
 {{EmbedInteractiveExample("pages/css/font-feature-settings.html")}}
 
-> **Note :** Lorsque c'est possible, les auteurs devraient utiliser la propriété raccourcie {{cssxref("font-variant")}} ou l'une des propriétés détaillées correspondantes parmi {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-east-asian")}}, {{cssxref("font-variant-alternates")}}, {{cssxref("font-variant-numeric")}} ou {{cssxref("font-variant-position")}}.
+> [!NOTE]
+> Lorsque c'est possible, les auteurs devraient utiliser la propriété raccourcie {{cssxref("font-variant")}} ou l'une des propriétés détaillées correspondantes parmi {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-east-asian")}}, {{cssxref("font-variant-alternates")}}, {{cssxref("font-variant-numeric")}} ou {{cssxref("font-variant-position")}}.
 >
 > Cette propriété est une fonctionnalité bas-niveau permettant de gérer des cas particuliers où il n'y a aucun moyen d'accéder à une fonctionnalité OpenType donnée. Cette propriété CSS ne devrait notamment pas être utilisée pour activer les petites majuscules.
 

--- a/files/fr/web/css/font-optical-sizing/index.md
+++ b/files/fr/web/css/font-optical-sizing/index.md
@@ -9,7 +9,8 @@ La propriété CSS **`font-optical-sizing`** permet de contrôler la façon dont
 
 Par exemple, les textes de petites tailles sont généralement affichés avec des traits plus épais et des empattements (_serifs_) plus grands. En revanche, les textes plus grands sont souvent plus fins et utilisent plus de contrastes entre les traits fins et épais.
 
-> **Note :** L'axe de variation pour la taille optique est représenté par `opsz` dans {{cssxref("font-variation-settings")}}.
+> [!NOTE]
+> L'axe de variation pour la taille optique est représenté par `opsz` dans {{cssxref("font-variation-settings")}}.
 
 ## Syntaxe
 
@@ -75,7 +76,8 @@ p {
 </p>
 ```
 
-> **Note :** La police utilisée dans cet exemple possède un dimensionnement optique et est disponible sous licence libre [en téléchargement sur GitHub](https://github.com/TypeNetwork/Amstelvar/releases).
+> [!NOTE]
+> La police utilisée dans cet exemple possède un dimensionnement optique et est disponible sous licence libre [en téléchargement sur GitHub](https://github.com/TypeNetwork/Amstelvar/releases).
 
 ## Spécifications
 

--- a/files/fr/web/css/font-size/index.md
+++ b/files/fr/web/css/font-size/index.md
@@ -56,7 +56,8 @@ La propriété `font-size` peut être définie de deux façons :
 - `<percentage>`
   - : Les valeurs exprimées en pourcentages (type {{cssxref("&lt;percentage&gt;")}}) sont proportionnelles à la taille de fonte de l'élément parent.
 
-> **Note :** Il est généralement préférable d'utiliser des valeurs relatives à la taille par défaut choisie par l'utilisateur.
+> [!NOTE]
+> Il est généralement préférable d'utiliser des valeurs relatives à la taille par défaut choisie par l'utilisateur.
 
 ## Définition formelle
 

--- a/files/fr/web/css/font-smooth/index.md
+++ b/files/fr/web/css/font-smooth/index.md
@@ -19,14 +19,16 @@ font-smooth: always;
 font-smooth: 2em;
 ```
 
-> **Note :** Webkit implémente **`-webkit-font-smoothing`** avec d'autres valeurs, **là aussi c'est une propriété non-standard qui ne devrait pas être utilisée**.
+> [!NOTE]
+> Webkit implémente **`-webkit-font-smoothing`** avec d'autres valeurs, **là aussi c'est une propriété non-standard qui ne devrait pas être utilisée**.
 >
 > - `auto` : c'est le navigateur qui décide la meilleure approche
 > - `none` - l'anti-crénelage est désactivé.
 > - `antialiased` - lisse les caractères au niveau du pixel (et non par sous-échantillonnage). Pour des textes clairs sur fonds sombres, cette méthode fait paraître le texte plus clair.
 > - `subpixel-antialiased` - sur la plupart des affichages non-Retina, cela donnera le texte le plus lisse.
 
-> **Note :** Firefox implémente **`-moz-osx-font-smoothing`** avec d'autres valeurs, **là aussi c'est une propriété non-standard qui ne devrait pas être utilisée**.
+> [!NOTE]
+> Firefox implémente **`-moz-osx-font-smoothing`** avec d'autres valeurs, **là aussi c'est une propriété non-standard qui ne devrait pas être utilisée**.
 >
 > - `auto` - le choix est laissé au navigateur. Cela correspond généralement à `grayscale`.
 > - `grayscale` - On applique un anti-crénelage par niveau de gris (et non par sous-échantillonnage). Pour des textes clairs sur fonds sombres, cette méthode fait paraître le texte plus clair.

--- a/files/fr/web/css/font-stretch/index.md
+++ b/files/fr/web/css/font-stretch/index.md
@@ -138,7 +138,8 @@ Le tableau qui suit illustre l'effet des différents pourcentages avec deux poli
 
 {{Specifications}}
 
-> **Note :** La propriété CSS `font-stretch` fut d'abord définie par CSS 2, mais elle a été abandonnée avec CSS 2.1 par manque d'implémentation. Elle fut redéfinie avec CSS 3.
+> [!NOTE]
+> La propriété CSS `font-stretch` fut d'abord définie par CSS 2, mais elle a été abandonnée avec CSS 2.1 par manque d'implémentation. Elle fut redéfinie avec CSS 3.
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/web/css/font-style/index.md
+++ b/files/fr/web/css/font-style/index.md
@@ -51,7 +51,8 @@ Les polices variables permettent d'obtenir un contrôle fin sur la pente appliqu
 
 Pour les polices variables TrueType ou OpenType, c'est l'axe de variation `"slnt"` qui est utilisé afin d'implémenter les variations de pente. C'est l'axe `"ital"` qui est utilisé avec une valeur de 1 pour implémenter les fontes italiques. Voir [`font-variation-settings`](/fr/docs/Web/CSS/font-variation-settings).
 
-> **Note :** Afin que l'exemple suivant fonctionne, votre navigateur doit prendre en charge la syntaxe _CSS Fonts Level 4_ qui permet d'utiliser `font-style: oblique` suivi d'un angle. Le code de démarrage utilise `font-style: oblique 23deg;` — modifiez la valeur `<angle>` pour changer la pente du texte.
+> [!NOTE]
+> Afin que l'exemple suivant fonctionne, votre navigateur doit prendre en charge la syntaxe _CSS Fonts Level 4_ qui permet d'utiliser `font-style: oblique` suivi d'un angle. Le code de démarrage utilise `font-style: oblique 23deg;` — modifiez la valeur `<angle>` pour changer la pente du texte.
 
 {{EmbedGHLiveSample("css-examples/variable-fonts/oblique.html", '100%', 860)}}
 

--- a/files/fr/web/css/font-variant-alternates/index.md
+++ b/files/fr/web/css/font-variant-alternates/index.md
@@ -56,7 +56,8 @@ Cette propriété peut être définie selon deux formes&nbsp;:
 
   - : Cette fonction active l'affichage des ornements tels que les [fleurons](<https://fr.wikipedia.org/wiki/Fleuron_(typographie)>) et autres casseaux. Le paramètre passé à la fonction est un nom lié à la fonte auquel est associé un nombre. Cette valeur correspond à la valeur OpenType `ornm` (par exemple `ornm 2`).
 
-    > **Note :** Afin de préserver la sémantique de la fonte, les fondeurs sont invités à ne pas créer de casseaux qui correspondent aux caractères Unicode déjà définis comme variantes d'ornement pour la puce (`U+2022`). De nombreuses fontes passent outre cette règle et perdent ainsi en qualité.
+    > [!NOTE]
+    > Afin de préserver la sémantique de la fonte, les fondeurs sont invités à ne pas créer de casseaux qui correspondent aux caractères Unicode déjà définis comme variantes d'ornement pour la puce (`U+2022`). De nombreuses fontes passent outre cette règle et perdent ainsi en qualité.
 
 - `annotation()`
   - : Cette fonction active l'affichage des annotations (telles que les chiffres entourés ou les caractères inversés). Le paramètre est un nom lié à la fonte auquel est associé un nombre. Cette valeur correspond à la valeur OpenType `nalt` (par exemple `nalt 2`).
@@ -101,7 +102,8 @@ p {
 
 #### Résultat
 
-> **Note :** Pour que cet exemple fonctionne, il faut avoir installé la fonte Open Type Leitura Display Swashes. Une version de test est disponible sur [fontsgeek.com](https://fontsgeek.com).
+> [!NOTE]
+> Pour que cet exemple fonctionne, il faut avoir installé la fonte Open Type Leitura Display Swashes. Une version de test est disponible sur [fontsgeek.com](https://fontsgeek.com).
 
 {{EmbedLiveSample('')}}
 

--- a/files/fr/web/css/font-variation-settings/index.md
+++ b/files/fr/web/css/font-variation-settings/index.md
@@ -11,9 +11,11 @@ La propriété CSS **`font-variation-settings`** permet de contrôler les caract
 
 Cette propriété fonctionne à un niveau plus bas que {{cssxref("font-feature-settings")}} qui permet de définir les valeurs et les étiquettes (_tags_) pour les caractéristiques des polices.
 
-> **Note :** Si possible, les auteurs web devraient utiliser d'autres méthodes pour contrôler l'affichage des polices de caractères et notamment la propriété raccourcie {{cssxref("font-variant")}} ou une des propriétés détaillée associée. Cette propriété est une fonctionnalité de bas niveau destinée à gérer les cas spécifiques pour lesquels il est autrement impossible d'activer ou de paramétrer une caractéristique OpenType existante.
+> [!NOTE]
+> Si possible, les auteurs web devraient utiliser d'autres méthodes pour contrôler l'affichage des polices de caractères et notamment la propriété raccourcie {{cssxref("font-variant")}} ou une des propriétés détaillée associée. Cette propriété est une fonctionnalité de bas niveau destinée à gérer les cas spécifiques pour lesquels il est autrement impossible d'activer ou de paramétrer une caractéristique OpenType existante.
 
-> **Note :** Les caractéristiques définies avec `font-variation-settings` l'emporteront sur celles définies par les autres propriétés relatives aux polices (ex. `font-weight`), où qu'elles soient dans la cascade. Pour certains navigateurs, cela se vérifie uniquement lorsque la déclaration `@font-face` inclut un intervalle `font-weight`.
+> [!NOTE]
+> Les caractéristiques définies avec `font-variation-settings` l'emporteront sur celles définies par les autres propriétés relatives aux polices (ex. `font-weight`), où qu'elles soient dans la cascade. Pour certains navigateurs, cela se vérifie uniquement lorsque la déclaration `@font-face` inclut un intervalle `font-weight`.
 
 ## Syntaxe
 
@@ -92,11 +94,13 @@ Voici la liste des axes enregistrés et les propriétés CSS correspondantes, qu
 
 Les axes spécifiques peuvent correspondre à n'importe quel axe que le concepteur de la police souhaite faire varier (ce peut par exemple être la hauteur des hampes et des jambages, la taille des empattements ou tout autre chose). N'importe quel axe peut être utilisé tant qu'il a une étiquette unique sur quatre caractères. Il est possible que, si des axes spécifiques deviennent majoritairement présents, ils soient intégrés parmi les axes enregistrés.
 
-> **Note :** Les étiquettes des axes enregistrés sont écrits en minuscules et les axes spécifiques doivent être écrits en majuscules. On notera que rien n'oblige à suivre cette règle et qu'il est tout à fait possible que des concepteurs de polices donnent des étiquettes en minuscules à des axes spécifiques. Quoiqu'il en soit, on retiendra que les étiquettes des axes sont sensibles à la casse.
+> [!NOTE]
+> Les étiquettes des axes enregistrés sont écrits en minuscules et les axes spécifiques doivent être écrits en majuscules. On notera que rien n'oblige à suivre cette règle et qu'il est tout à fait possible que des concepteurs de polices donnent des étiquettes en minuscules à des axes spécifiques. Quoiqu'il en soit, on retiendra que les étiquettes des axes sont sensibles à la casse.
 
 ## Exemples
 
-> **Attention :** Afin de pouvoir utiliser les polices variables, votre système d'exploitation doit être à jour et votre navigateur doit prendre en charge ces fonctionnalités. Ainsi, les systèmes basés sur Linux requièrent la dernière version de Linux Freetype et les systèmes macOS antérieurs à 10.13 ne prennent pas en charge les polices variables.
+> [!WARNING]
+> Afin de pouvoir utiliser les polices variables, votre système d'exploitation doit être à jour et votre navigateur doit prendre en charge ces fonctionnalités. Ainsi, les systèmes basés sur Linux requièrent la dernière version de Linux Freetype et les systèmes macOS antérieurs à 10.13 ne prennent pas en charge les polices variables.
 
 ### Graisse (`wght`)
 

--- a/files/fr/web/css/gradient/conic-gradient/index.md
+++ b/files/fr/web/css/gradient/conic-gradient/index.md
@@ -47,7 +47,8 @@ background: conic-gradient(
 - `<color-hint>`
   - : Une indication d'[interpolation](/fr/docs/Glossary/Interpolation) qui définit la façon dont le dégradé progresse entre deux arrêts de couleur adjacents. La longueur définit le point auquel la couleur du dégradé doit être la couleur intermédiaire entre les deux couleurs d'arrêt. Si cette valeur est absente, la valeur intermédiaire est située à mi-parcours entre les deux arrêts de couleur.
 
-> **Note :** Le rendu des arrêts de couleurs des dégradés CSS suit les mêmes règles que les [arrêts de couleur pour les dégradés SVG](/fr/docs/Web/SVG/Tutorial/Gradients).
+> [!NOTE]
+> Le rendu des arrêts de couleurs des dégradés CSS suit les mêmes règles que les [arrêts de couleur pour les dégradés SVG](/fr/docs/Web/SVG/Tutorial/Gradients).
 
 ## Description
 
@@ -57,7 +58,8 @@ Pour créer un dégradé conique qui se répète afin de couvrir 360° (un tour 
 
 Les dégradés (`<gradient>`) sont un type d'image (`<image>`) et ne peuvent être utilisés qu'aux endroits où les images peuvent être utilisées. Aussi, `conic-gradient()` ne fonctionnera pas pour la propriété [`background-color`](/fr/docs/Web/CSS/background-color) ou pour les autres propriétés qui utilisent les données de type [`<color>`](/fr/docs/Web/CSS/color_value).
 
-> **Note :** Un tel dégradé est appelé conique car, vu du dessus, la répartition des couleurs fait apparaître un cône.
+> [!NOTE]
+> Un tel dégradé est appelé conique car, vu du dessus, la répartition des couleurs fait apparaître un cône.
 
 ### Composition d'un dégradé conique
 

--- a/files/fr/web/css/gradient/linear-gradient/index.md
+++ b/files/fr/web/css/gradient/linear-gradient/index.md
@@ -56,7 +56,8 @@ linear-gradient(45deg, red 0 50%, blue 50% 100%);
 - `<color-hint>`
   - : Une indication d'interpolation qui définit la progression du dégradé entre deux arrêts de couleur adjacents. La longueur définit à quel point entre les deux arrêts le dégradé doit atteindre la couleur intermédiaire. Si cette valeur est absente, la valeur intermédiaire sera atteinte à mi-parcours entre les deux arrêts.
 
-> **Note :** Le rendu des [arrêts de couleur pour les dégradés CSS](#dégradé_avec_plusieurs_arrêts_de_couleur) suit les mêmes règles que [celui des arrêts de couleur pour les dégradés SVG](/fr/docs/Web/SVG/Tutorial/Gradients).
+> [!NOTE]
+> Le rendu des [arrêts de couleur pour les dégradés CSS](#dégradé_avec_plusieurs_arrêts_de_couleur) suit les mêmes règles que [celui des arrêts de couleur pour les dégradés SVG](/fr/docs/Web/SVG/Tutorial/Gradients).
 
 ## Description
 

--- a/files/fr/web/css/gradient/repeating-conic-gradient/index.md
+++ b/files/fr/web/css/gradient/repeating-conic-gradient/index.md
@@ -33,7 +33,8 @@ background: repeating-conic-gradient(
 - `<color-hint>`
   - : Une indication d'[interpolation](/fr/docs/Glossary/Interpolation) qui définit la façon dont le dégradé progresse entre deux arrêts de couleurs adjacents. Cette indication indique l'emplacement où la couleur doit être la couleur intermédiaire entre les deux arrêts environnant. Si cette valeur est absente, la moitié de la transition entre les couleurs sera atteinte à la moitié de l'arc entre les deux arrêts.
 
-> **Note :** Le rendu des arrêts de couleur pour les dégradés CSS suit les mêmes règles que celui des arrêts de couleur pour [les dégradés SVG](/fr/docs/Web/SVG/Tutorial/Gradients).
+> [!NOTE]
+> Le rendu des arrêts de couleur pour les dégradés CSS suit les mêmes règles que celui des arrêts de couleur pour [les dégradés SVG](/fr/docs/Web/SVG/Tutorial/Gradients).
 
 ## Description
 

--- a/files/fr/web/css/gradient/repeating-linear-gradient/index.md
+++ b/files/fr/web/css/gradient/repeating-linear-gradient/index.md
@@ -56,7 +56,8 @@ repeating-linear-gradient(to right, red 0%, green 10%, red 20%);
 - `<color-hint>`
   - : L'indication de couleur est une indication pour l'interpolation des couleurs le long du dégradé et entre deux points d'arrêt de couleur. La longueur définit à quel point, entre deux arrêts de couleur, la couleur du dégradé doit atteindre le point médian de la transition de couleur. Si cette valeur est absente, le niveau intermédiaire de la transition se situera à équidistance des deux points d'arrêt de couleur.
 
-> **Note :** Le rendu des arrêts de couleurs des dégradés CSS suit les mêmes règles que [les arrêts de couleur pour les dégradés SVG](/fr/docs/Web/SVG/Tutorial/Gradients).
+> [!NOTE]
+> Le rendu des arrêts de couleurs des dégradés CSS suit les mêmes règles que [les arrêts de couleur pour les dégradés SVG](/fr/docs/Web/SVG/Tutorial/Gradients).
 
 ### Syntaxe formelle
 
@@ -117,7 +118,8 @@ body {
 
 Le dernier arrêt de couleur étant situé à 10% et le dégradé étant vertical, chaque dégradé unitaire occupe 10% de la hauteur totale, ce qui permet d'avoir 10 barres horizontales.
 
-> **Note :** Voir [la page Utiliser les dégradés CSS](/fr/docs/Web/CSS/CSS_images/Using_CSS_gradients) pour plus d'exemples.
+> [!NOTE]
+> Voir [la page Utiliser les dégradés CSS](/fr/docs/Web/CSS/CSS_images/Using_CSS_gradients) pour plus d'exemples.
 
 ## Spécifications
 

--- a/files/fr/web/css/gradient/repeating-radial-gradient/index.md
+++ b/files/fr/web/css/gradient/repeating-radial-gradient/index.md
@@ -47,7 +47,8 @@ repeating-radial-gradient(farthest-corner at 20% 20%, red 0, green, red 20%);
     | `farthest-side`   | Cette valeur fonctionne de façon semblable à `closest-side`, sauf que ce seront les côtés les plus éloignés qui seront utilisés.                                                                   |
     | `farthest-corner` | La valeur par défaut. Cette valeur fonctionne de façon semblable à `closest-corner`, sauf que ce sera le coin le plus éloigné du centre qui sera utilisé.                                          |
 
-    > **Note :** Les premières implémentations de cette fonction incluaient d'autres mots-clés (`cover` et `contain`) qui sont des synonymes respectifs des mots-clés standards `farthest-corner` et `closest-side`. Seuls les mots-clés standards doivent être utilisés, certaines implémentations ayant déjà abandonné ces anciennes variantes.
+    > [!NOTE]
+    > Les premières implémentations de cette fonction incluaient d'autres mots-clés (`cover` et `contain`) qui sont des synonymes respectifs des mots-clés standards `farthest-corner` et `closest-side`. Seuls les mots-clés standards doivent être utilisés, certaines implémentations ayant déjà abandonné ces anciennes variantes.
 
 - `<color-stop>`
   - : Une valeur d'arrêt de couleur, composée d'une valeur [`<color>`](/fr/docs/Web/CSS/color_value), suivie d'une ou deux positions d'arrêt optionnelles (définies par une valeur [`<percentage>`](/fr/docs/Web/CSS/percentage) ou [`<length>`](/fr/docs/Web/CSS/length) le long de l'axe du dégradé). Un pourcentage à `0%`, ou une longueur de `0`, représentera le centre du dégradé&nbsp;; la valeur `100%` représentera l'intersection de la forme du contour avec la ligne d'évolution du dégradé. Les valeurs de pourcentages intermédiaire sont positionnées linéairement le long du dégradé.
@@ -118,7 +119,8 @@ repeating-radial-gradient(farthest-corner at 20% 20%, red 0, green, red 20%);
 
 Le dégradé elliptique a son centre situé à 20% du coin supérieur gauche et se répètera 10 fois entre le centre et le coin le plus éloigné (situé donc dans le coin inférieur droit). Les navigateurs qui prennent en charge les arrêts de couleur multiples afficheront des bandes elliptiques rouges et vertes. Les navigateurs qui n'implémentent pas cette fonctionnalité afficheront un dégradé qui va du rouge au noir puis du bleu au vert.
 
-> **Note :** Voir [la page Utiliser les dégradés CSS](/fr/docs/Web/CSS/CSS_Images/Using_CSS_gradients) pour plus d'exemples.
+> [!NOTE]
+> Voir [la page Utiliser les dégradés CSS](/fr/docs/Web/CSS/CSS_Images/Using_CSS_gradients) pour plus d'exemples.
 
 ## Spécifications
 

--- a/files/fr/web/css/grid-area/index.md
+++ b/files/fr/web/css/grid-area/index.md
@@ -55,7 +55,8 @@ grid-area: unset;
 
   - : S'il existe une ligne nommée avec '\<custom-ident>-start', la première ligne correspondante contribue au placement de l'élément sur la grille.
 
-    > **Note :** Les noms des zones de grille sont générés implicitement. Ainsi, en utilisant `grid-area: foo;` cela sélectionnera le début de la grille nommée correspondante (sauf si une autre ligne `foo-start` a été explicitement déclarée).
+    > [!NOTE]
+    > Les noms des zones de grille sont générés implicitement. Ainsi, en utilisant `grid-area: foo;` cela sélectionnera le début de la grille nommée correspondante (sauf si une autre ligne `foo-start` a été explicitement déclarée).
 
     Sinon, la valeur est traitée comme si on avait utilisé `<custom-ident>` et la valeur `1`.
 

--- a/files/fr/web/css/grid-auto-columns/index.md
+++ b/files/fr/web/css/grid-auto-columns/index.md
@@ -83,7 +83,8 @@ grid-auto-columns: unset;
 
   - : Un mot-clé qui est identique au contenu maximal si c'est un maximum. Si c'est un minimum, il représente la plus grande des plus petites tailles (définie par {{cssxref("min-width")}}/{{cssxref("min-height")}})) des objets de la grilles qui occupe cette piste de la grille.
 
-    > **Note :** Les pistes de taille `auto` (et uniquement celles-ci) peuvent être étirées grâce aux propriétés {{cssxref("align-content")}} et {{cssxref("justify-content")}}.
+    > [!NOTE]
+    > Les pistes de taille `auto` (et uniquement celles-ci) peuvent être étirées grâce aux propriétés {{cssxref("align-content")}} et {{cssxref("justify-content")}}.
 
 ## Définition formelle
 

--- a/files/fr/web/css/grid-auto-rows/index.md
+++ b/files/fr/web/css/grid-auto-rows/index.md
@@ -75,7 +75,8 @@ grid-auto-rows: unset;
 
   - : Un mot-clé qui est identique au contenu maximal si c'est un maximum. Si c'est un minimum, il représente la plus grande des plus petites tailles (définie par {{cssxref("min-width")}}/{{cssxref("min-height")}})) des objets de la grilles qui occupe cette piste de la grille.
 
-    > **Note :** Les pistes de taille `auto` (et uniquement celles-ci) peuvent être étirées grâce aux propriétés {{cssxref("align-content")}} et {{cssxref("justify-content")}}.
+    > [!NOTE]
+    > Les pistes de taille `auto` (et uniquement celles-ci) peuvent être étirées grâce aux propriétés {{cssxref("align-content")}} et {{cssxref("justify-content")}}.
 
 ## Définition formelle
 

--- a/files/fr/web/css/grid-column-end/index.md
+++ b/files/fr/web/css/grid-column-end/index.md
@@ -41,7 +41,8 @@ grid-column-end: unset;
 
   - : S'il existe une ligne nommée '\<custom-ident>-end', cela placera l'élément sur la première ligne correspondante..
 
-    > **Note :** Les noms de zones génèrent automatiquement les noms de colonnes sous cette forme. Ainsi, `grid-column-end: foo;` permettra de désigner l'extrêmité (à la fin) de la zone nommée (sauf si une autre colonne a explicitement été nommée avec `foo-end`).
+    > [!NOTE]
+    > Les noms de zones génèrent automatiquement les noms de colonnes sous cette forme. Ainsi, `grid-column-end: foo;` permettra de désigner l'extrêmité (à la fin) de la zone nommée (sauf si une autre colonne a explicitement été nommée avec `foo-end`).
 
     Si aucune zone ne correspond, la valeur est traitée comme la combinaison de l'entier 1 et de `<custom-ident>` (cf. définition suivante).
 

--- a/files/fr/web/css/grid-column-start/index.md
+++ b/files/fr/web/css/grid-column-start/index.md
@@ -55,7 +55,8 @@ La valeur de cette propriété prend la forme d'une seule valeur `<grid-line>`. 
 
   - : S'il existe une ligne nommée avec '\<custom-ident>-start', le début de l'élément coincide avec la première ligne correspondante.
 
-    > **Note :** Les noms des zones de grille sont générés implicitement. Ainsi, en utilisant `grid-column-start: toto;` cela sélectionnera le bord de la zone de grille nommée correspondante (sauf si une autre ligne `toto-start` a explicitement été déclarée).
+    > [!NOTE]
+    > Les noms des zones de grille sont générés implicitement. Ainsi, en utilisant `grid-column-start: toto;` cela sélectionnera le bord de la zone de grille nommée correspondante (sauf si une autre ligne `toto-start` a explicitement été déclarée).
 
     Sinon, la valeur est traitée comme si on avait utilisé `<custom-ident>` et la valeur `1`.
 

--- a/files/fr/web/css/grid-column/index.md
+++ b/files/fr/web/css/grid-column/index.md
@@ -58,7 +58,8 @@ Une valeur `<grid-line>` peut être définie avec :
 
   - : S'il existe une ligne nommée avec '\<custom-ident>-start'/'\<custom-ident>-end', la première colonne correspondante contribue au placement de l'élément sur la grille.
 
-    > **Note :** Les noms des zones de grille sont générés implicitement. Ainsi, en utilisant `grid-column-start: foo;` cela sélectionnera le début de la grille nommée correspondante (sauf si une autre colonne `foo-start`/`foo-end` a été explicitement déclarée).
+    > [!NOTE]
+    > Les noms des zones de grille sont générés implicitement. Ainsi, en utilisant `grid-column-start: foo;` cela sélectionnera le début de la grille nommée correspondante (sauf si une autre colonne `foo-start`/`foo-end` a été explicitement déclarée).
 
     Sinon, la valeur est traitée comme si on avait utilisé `<custom-ident>` et la valeur `1`.
 

--- a/files/fr/web/css/grid-row-end/index.md
+++ b/files/fr/web/css/grid-row-end/index.md
@@ -41,7 +41,8 @@ grid-row-end: unset;
 
   - : S'il existe une ligne nommée '\<custom-ident>-end', cela placera l'élément sur la première ligne correspondante..
 
-    > **Note :** Les noms de zones génèrent automatiquement les noms de lignes sous cette forme. Ainsi, `grid-row-end: foo;` permettra de désigner l'extrêmité (à la fin) de la zone nommée (sauf si une autre ligne a explicitement été nommée avec `foo-end`).
+    > [!NOTE]
+    > Les noms de zones génèrent automatiquement les noms de lignes sous cette forme. Ainsi, `grid-row-end: foo;` permettra de désigner l'extrêmité (à la fin) de la zone nommée (sauf si une autre ligne a explicitement été nommée avec `foo-end`).
 
     Si aucune zone ne correspond, la valeur est traitée comme la combinaison de l'entier 1 et de `<custom-ident>` (cf. définition suivante).
 

--- a/files/fr/web/css/grid-row-start/index.md
+++ b/files/fr/web/css/grid-row-start/index.md
@@ -47,7 +47,8 @@ La valeur de cette propriété prend la forme d'une seule valeur `<grid-line>`. 
 
   - : S'il existe une ligne nommée avec '\<custom-ident>-start', la première ligne correspondante contribue au placement de l'élément sur la grille.
 
-    > **Note :** Les noms des zones de grille sont générés implicitement. Ainsi, en utilisant `grid-row-start: foo;` cela sélectionnera le début de la grille nommée correspondante (sauf si une autre ligne `foo-start` a été explicitement déclarée).
+    > [!NOTE]
+    > Les noms des zones de grille sont générés implicitement. Ainsi, en utilisant `grid-row-start: foo;` cela sélectionnera le début de la grille nommée correspondante (sauf si une autre ligne `foo-start` a été explicitement déclarée).
 
     Sinon, la valeur est traitée comme si on avait utilisé `<custom-ident>` et la valeur `1`.
 

--- a/files/fr/web/css/grid-row/index.md
+++ b/files/fr/web/css/grid-row/index.md
@@ -48,7 +48,8 @@ grid-row: unset;
 
   - : S'il existe une ligne nommée avec '\<custom-ident>-start'/'\<custom-ident>-end', la première ligne correspondante contribue au placement de l'élément sur la grille.
 
-    > **Note :** Les noms des zones de grille sont générés implicitement. Ainsi, en utilisant `grid-row-start: foo;` cela sélectionnera le début de la grille nommée correspondante (sauf si une autre ligne `foo-start`/`foo-end` a été explicitement déclarée).
+    > [!NOTE]
+    > Les noms des zones de grille sont générés implicitement. Ainsi, en utilisant `grid-row-start: foo;` cela sélectionnera le début de la grille nommée correspondante (sauf si une autre ligne `foo-start`/`foo-end` a été explicitement déclarée).
 
     Sinon, la valeur est traitée comme si on avait utilisé `<custom-ident>` et la valeur `1`.
 

--- a/files/fr/web/css/grid-template-columns/index.md
+++ b/files/fr/web/css/grid-template-columns/index.md
@@ -66,7 +66,8 @@ grid-template-columns: unset;
 
   - : Un mot-clé qui est identique au contenu maximal si c'est un maximum. Si c'est un minimum, il représente la plus grande des plus petites tailles (définie par {{cssxref("min-width")}}/{{cssxref("min-height")}})) des objets de la grilles qui occupe cette piste de la grille.
 
-    > **Note :** Les pistes de taille `auto` (et uniquement celles-ci) peuvent être étirées grâce aux propriétés {{cssxref("align-content")}} et {{cssxref("justify-content")}}.
+    > [!NOTE]
+    > Les pistes de taille `auto` (et uniquement celles-ci) peuvent être étirées grâce aux propriétés {{cssxref("align-content")}} et {{cssxref("justify-content")}}.
 
 - {{cssxref("fit-content", "fit-content( [ &lt;length&gt; | &lt;percentage&gt; ] )")}}
   - : Cette notation représente la formule `min(max-content, max(auto, argument))` qui est calculée comme pour `auto` (i.e. `minmax(auto, max-content)`) sauf que la taille de la piste est ramenée à _argument_ si elle est plus grande que le minimum fourni par `auto`.

--- a/files/fr/web/css/grid-template-rows/index.md
+++ b/files/fr/web/css/grid-template-rows/index.md
@@ -69,7 +69,8 @@ Cette propriété peut être définie avec le mot-clé `none` ou avec une valeur
 
   - : Un mot-clé qui est identique au contenu maximal si c'est un maximum. Si c'est un minimum, il représente la plus grande des plus petites tailles (définie par {{cssxref("min-width")}}/{{cssxref("min-height")}})) des objets de la grilles qui occupe cette piste de la grille.
 
-    > **Note :** Les pistes de taille `auto` (et uniquement celles-ci) peuvent être étirées grâce aux propriétés {{cssxref("align-content")}} et {{cssxref("justify-content")}}.
+    > [!NOTE]
+    > Les pistes de taille `auto` (et uniquement celles-ci) peuvent être étirées grâce aux propriétés {{cssxref("align-content")}} et {{cssxref("justify-content")}}.
 
 - {{cssxref("fit-content", "fit-content( [ &lt;length&gt; | &lt;percentage&gt; ] )")}}
   - : Cette notation représente la formule `min(max-content, max(auto, argument))` qui est calculée comme pour `auto` (i.e. `minmax(auto, max-content)`) sauf que la taille de la piste est ramenée à _argument_ si elle est plus grande que le minimum fourni par `auto`.

--- a/files/fr/web/css/grid-template/index.md
+++ b/files/fr/web/css/grid-template/index.md
@@ -51,9 +51,11 @@ grid-template: unset;
 
   - : {{cssxref("grid-template-areas")}} est définie avec les chaînes listées, {{cssxref("grid-template-rows")}} est définie avec les tailles de piste suivant chaque chaîne (`auto` sera utilisé pour les tailles manquantes), les lignes seront découpées selon les noms avant et après chaque taille. {{cssxref("grid-template-columns")}} sera définie avec la valeur listée après la barre oblique (ou `none` sinon).
 
-    > **Note :** La fonction {{cssxref("repeat()")}} n'est pas autorisée parmi les listes de pistes car les pistes sont conçues pour correspondre à la disposition finale (à la façon d'un dessin en ASCII).
+    > [!NOTE]
+    > La fonction {{cssxref("repeat()")}} n'est pas autorisée parmi les listes de pistes car les pistes sont conçues pour correspondre à la disposition finale (à la façon d'un dessin en ASCII).
 
-> **Note :** La propriété raccourcie {{cssxref("grid")}} accepte la même syntaxe mais réinitialise également les propriétés implicites avec leurs valeurs initiales. On pourra utiliser `grid` (plutôt que `grid-template`) pour empêcher les valeurs de suivre la cascade de façon séparée.
+> [!NOTE]
+> La propriété raccourcie {{cssxref("grid")}} accepte la même syntaxe mais réinitialise également les propriétés implicites avec leurs valeurs initiales. On pourra utiliser `grid` (plutôt que `grid-template`) pour empêcher les valeurs de suivre la cascade de façon séparée.
 
 ## Définition formelle
 

--- a/files/fr/web/css/grid/index.md
+++ b/files/fr/web/css/grid/index.md
@@ -9,7 +9,8 @@ La propriété **`grid`** est une propriété raccourcie qui permet de définir 
 
 {{EmbedInteractiveExample("pages/css/grid.html")}}
 
-> **Note :** Une seule déclaration `grid` permettra uniquement de définir les propriétés explicites ou implicites. Les propriétés qui ne sont pas définies via la propriété raccourcie prendront leurs valeurs initiales. Les propriétés d'espacement ne sont pas surchargées par cette propriété raccourcie.
+> [!NOTE]
+> Une seule déclaration `grid` permettra uniquement de définir les propriétés explicites ou implicites. Les propriétés qui ne sont pas définies via la propriété raccourcie prendront leurs valeurs initiales. Les propriétés d'espacement ne sont pas surchargées par cette propriété raccourcie.
 
 ## Syntaxe
 

--- a/files/fr/web/css/hyphens/index.md
+++ b/files/fr/web/css/hyphens/index.md
@@ -11,7 +11,8 @@ La propriété **`hyphens`** indique au navigateur comment gérer les traits d'u
 
 Les règles relatives aux traits d'union en fin de ligne dépendent de la langue utilisée. En HTML, la langue est définie grâce à l'attribut [`lang`](/fr/docs/Web/HTML/Global_attributes/lang) et les navigateurs n'appliqueront les règles que si cet attribut est présent et que le dictionnaire correspondant (pour la gestion des traits d'union et des fins de ligne) est disponible. Pour des documents XML, on utilisera l'attribut [`xml:lang`](/fr/docs/Web/SVG/Attribute/xml:lang).
 
-> **Note :** Les règles exactes qui définissent l'application des traits d'union en fin de ligne ne sont pas explicitement définies par la spécification, aussi, le comportement peut varier entre les navigateurs.
+> [!NOTE]
+> Les règles exactes qui définissent l'application des traits d'union en fin de ligne ne sont pas explicitement définies par la spécification, aussi, le comportement peut varier entre les navigateurs.
 
 ## Syntaxe
 
@@ -36,7 +37,8 @@ hyphens: unset;
 - `auto`
   - : Le navigateur est libre de couper les mots là où il l'estime approprié selon les règles qu'il choisit. Les emplacements de coupe suggérés par certains caractères devraient être privilégiés par rapport aux coupes automatiques.
 
-> **Note :** Le comportement défini par `auto` dépend de la langue indiquée par le document. Aussi, il faut indiquer la langue via l'attribut HTML `lang` pour s'assurer que les fins de ligne et les traits d'union sont bien gérés selon la langue indiquée.
+> [!NOTE]
+> Le comportement défini par `auto` dépend de la langue indiquée par le document. Aussi, il faut indiquer la langue via l'attribut HTML `lang` pour s'assurer que les fins de ligne et les traits d'union sont bien gérés selon la langue indiquée.
 
 ## Définition formelle
 

--- a/files/fr/web/css/id_selectors/index.md
+++ b/files/fr/web/css/id_selectors/index.md
@@ -20,7 +20,8 @@ Un sélecteur d'identifiant (_ID selector_) permet, pour un document HTML, de ci
 #valeur_identifiant { déclarations }
 ```
 
-> **Note :** Cela est équivalent à la notation suivante qui utilise un {{cssxref("Sélecteurs_d_attribut", "sélecteur d'attribut")}}:
+> [!NOTE]
+> Cela est équivalent à la notation suivante qui utilise un {{cssxref("Sélecteurs_d_attribut", "sélecteur d'attribut")}}:
 >
 > ```
 > [id=valeur_identifiant] { déclarations }

--- a/files/fr/web/css/image-rendering/index.md
+++ b/files/fr/web/css/image-rendering/index.md
@@ -39,7 +39,8 @@ image-rendering: unset;
 - `smooth` {{Experimental_inline}}
   - : L'algorithme utilisé pour le redimensionnement doit maximiser l'apparence de l'image. Les algorithmes qui adoucissent les couleurs (l'interpolation bilinéaire par exemple) sont acceptables. Cette valeur est destinée aux images telles que les photos.
 
-> **Note :** Les valeurs `optimizeQuality` et `optimizeSpeed` qui étaient présentes dans un brouillon de la spécification (et qui provenaient de la spécification équivalente pour SVG) sont synonymes respectifs de `smooth` et `pixelated`.
+> [!NOTE]
+> Les valeurs `optimizeQuality` et `optimizeSpeed` qui étaient présentes dans un brouillon de la spécification (et qui provenaient de la spécification équivalente pour SVG) sont synonymes respectifs de `smooth` et `pixelated`.
 
 ## Définition formelle
 

--- a/files/fr/web/css/image-resolution/index.md
+++ b/files/fr/web/css/image-resolution/index.md
@@ -33,7 +33,8 @@ image-resolution: unset;
 - `snap`
   - : Si le mot-clé `snap` est fourni, la résolution calculée sera la résolution spécifiée arrondie à la valeur la plus proche correspondant à un pixel image défini sous la forme d'un nombre entier de pixels de l'appareil. Si la résolution est récupérée à partir de l'image, alors la résolution intrinsèque utilisée est la résolution native de l'image, arrondie de la même façon.
 
-> **Note :** Les formats vectoriels tels que SVG n'ont pas de résolution intrinsèque, cette propriété n'a aucun effet sur les images vectorielles.
+> [!NOTE]
+> Les formats vectoriels tels que SVG n'ont pas de résolution intrinsèque, cette propriété n'a aucun effet sur les images vectorielles.
 
 ## Définition formelle
 

--- a/files/fr/web/css/image/image-set/index.md
+++ b/files/fr/web/css/image/image-set/index.md
@@ -38,7 +38,8 @@ Dans cet exemple, on montre comment utiliser `image-set()` afin de fournir deux 
 
 {{EmbedGHLiveSample("css-examples/images/image-set.html", '100%', 600)}}
 
-> **Note :** Dans cet exemple, la version préfixée avec `-webkit` est également utilisée pour prendre en charge Chrome et Safari. Dans Firefox 90, l'implémentation permet d'avoir `-webkit-image-set()` comme alias pour `image-set()` (afin de fournir une compatibilité si la propriété standard n'avait pas été ajoutée à la feuille de style).
+> [!NOTE]
+> Dans cet exemple, la version préfixée avec `-webkit` est également utilisée pour prendre en charge Chrome et Safari. Dans Firefox 90, l'implémentation permet d'avoir `-webkit-image-set()` comme alias pour `image-set()` (afin de fournir une compatibilité si la propriété standard n'avait pas été ajoutée à la feuille de style).
 
 ### Utiliser `image-set()` pour fournir des formats d'image alternatifs
 

--- a/files/fr/web/css/image/image/index.md
+++ b/files/fr/web/css/image/image/index.md
@@ -9,7 +9,8 @@ l10n:
 
 La [fonction](/fr/docs/Web/CSS/CSS_Functions) [CSS](/fr/docs/Web/CSS) **`image()`** définit une image (type [`<image>`](/fr/docs/Web/CSS/image)) à la façon de la fonction [`url()`](/fr/docs/Web/CSS/url) mais avec des fonctionnalités supplémentaires comme la définition de la directionnalité, la possibilité d'indiquer une image par défaut si l'image initiale n'est pas prise en charge, l'affichage d'une partie de l'image ou le choix de la couleur à utiliser par défaut si aucune des images indiquées ne peut être affichée.
 
-> **Note :** Attention à ne pas confondre cette notation fonctionnelle CSS avec le constructeur du DOM [`Image()` pour `HTMLImageElement`](/fr/docs/Web/API/HTMLImageElement/Image).
+> [!NOTE]
+> Attention à ne pas confondre cette notation fonctionnelle CSS avec le constructeur du DOM [`Image()` pour `HTMLImageElement`](/fr/docs/Web/API/HTMLImageElement/Image).
 
 ## Syntaxe
 

--- a/files/fr/web/css/image/index.md
+++ b/files/fr/web/css/image/index.md
@@ -53,7 +53,8 @@ La taille effective d'un objet est calculée avec l'algorithme suivant&nbsp;:
 2. Si la taille indiquée définit _uniquement la largeur ou la hauteur_, la valeur manquante est déterminée à l'aide des proportions intrinsèques si elles existent, de la dimension intrinsèque correspondante si la valeur correspond ou de la taille par défaut de l'objet pour la valeur manquante.
 3. Si la taille indiquée ne définit _ni la largeur, ni la hauteur_, la taille effective de l'objet est calculée afin de respecter les proportions intrinsèques de l'image sans dépasser la taille par défaut de l'objet sur aucun des deux axes. Si l'image n'a pas de proportions intrinsèques, ce sont celles de l'objet auquel elle s'applique qui sont utilisées et si l'objet n'en a pas non plus, la largeur ou la hauteur manquante est déterminée à partir de la taille par défaut de l'objet.
 
-> **Note :** Tous les navigateurs ne prennent pas en charge tous les types d'image pour chaque propriété. Voir [le tableau de compatibilité](#compatibilité_des_navigateurs) pour plus de détails.
+> [!NOTE]
+> Tous les navigateurs ne prennent pas en charge tous les types d'image pour chaque propriété. Voir [le tableau de compatibilité](#compatibilité_des_navigateurs) pour plus de détails.
 
 ## Accessibilité
 

--- a/files/fr/web/css/initial/index.md
+++ b/files/fr/web/css/initial/index.md
@@ -9,7 +9,8 @@ Le mot-clé **`initial`** applique la valeur initiale d'une propriété à un é
 
 La propriété {{cssxref("all")}} peut être utilisée avec cette valeur afin de réinitialiser l'ensemble des propriétés CSS.
 
-> **Note :** Pour [les propriétés héritées](/fr/docs/Web/CSS/Héritage#Propriétés_héritées), la valeur initiale peut donner des résultats étranges et mieux vaudra utiliser les mots-clés {{cssxref("inherit")}}, {{cssxref("unset")}} ou {{cssxref("revert")}}. Attention également à ne pas confondre la valeur initiale avec la valeur décrite dans la feuille de style portée par le navigateur.
+> [!NOTE]
+> Pour [les propriétés héritées](/fr/docs/Web/CSS/Héritage#Propriétés_héritées), la valeur initiale peut donner des résultats étranges et mieux vaudra utiliser les mots-clés {{cssxref("inherit")}}, {{cssxref("unset")}} ou {{cssxref("revert")}}. Attention également à ne pas confondre la valeur initiale avec la valeur décrite dans la feuille de style portée par le navigateur.
 
 ## Exemples
 

--- a/files/fr/web/css/inline_formatting_context/index.md
+++ b/files/fr/web/css/inline_formatting_context/index.md
@@ -28,7 +28,8 @@ Les marges, les bordures et le remplissage (_padding_) le long de la direction e
 
 {{EmbedGHLiveSample("css-examples/inline-formatting/mbp.html", '100%', 920)}}
 
-> **Note :** Dans ces exemples, on utilise les propriétés logiques (relatives à la direction du flux avec le mode d'écriture et la directionnalité) (ex. {{cssxref("padding-inline-start")}} plutôt que {{cssxref("padding-left")}}) afin qu'elles s'appliquent le long de la direction en ligne, que le texte soit horizontal ou vertical. Pour en savoir plus sur ces propriétés, voir [les propriétés et les valeurs logiques en CSS](/fr/docs/Web/CSS/CSS_Logical_Properties).
+> [!NOTE]
+> Dans ces exemples, on utilise les propriétés logiques (relatives à la direction du flux avec le mode d'écriture et la directionnalité) (ex. {{cssxref("padding-inline-start")}} plutôt que {{cssxref("padding-left")}}) afin qu'elles s'appliquent le long de la direction en ligne, que le texte soit horizontal ou vertical. Pour en savoir plus sur ces propriétés, voir [les propriétés et les valeurs logiques en CSS](/fr/docs/Web/CSS/CSS_Logical_Properties).
 
 ## Alignement sur la direction de bloc (_block_)
 

--- a/files/fr/web/css/inset-block-end/index.md
+++ b/files/fr/web/css/inset-block-end/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/inset-block-end
 
 La propriété **`inset-block-end`** définit la fin du décalage logique en bloc (_block_) d'un élément, selon le mode d'écriture, la directionnalité et l'orientation. Elle correspond à une des propriétés parmi {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}} ou {{cssxref("left")}} selon les valeurs des propriétés {{cssxref("writing-mode")}}, {{cssxref("direction")}} et {{cssxref("text-orientation")}}.
 
-> **Note :** Avant Firefox 63, cette propriété était implémentée avec le nom `offset-block-end`. Firefox 63 a mis à jour le nom de la propriété afin de s'accorder avec les modifications apportées à la spécification.
+> [!NOTE]
+> Avant Firefox 63, cette propriété était implémentée avec le nom `offset-block-end`. Firefox 63 a mis à jour le nom de la propriété afin de s'accorder avec les modifications apportées à la spécification.
 
 ```css
 /* Valeurs de longueur */

--- a/files/fr/web/css/inset-block-start/index.md
+++ b/files/fr/web/css/inset-block-start/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/inset-block-start
 
 La propriété **`inset-block-start`** définit le début du décalage logique en bloc (_block_) d'un élément, selon le mode d'écriture, la directionnalité et l'orientation. Elle correspond à une des propriétés parmi {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}} ou {{cssxref("left")}} selon les valeurs des propriétés {{cssxref("writing-mode")}}, {{cssxref("direction")}} et {{cssxref("text-orientation")}}.
 
-> **Note :** Avant Firefox 63, cette propriété était implémentée avec le nom `offset-block-start`. Firefox 63 a mis à jour son implémentation afin de suivre les modifications apportées à la spécification.
+> [!NOTE]
+> Avant Firefox 63, cette propriété était implémentée avec le nom `offset-block-start`. Firefox 63 a mis à jour son implémentation afin de suivre les modifications apportées à la spécification.
 
 ```css
 /* Valeurs de longueur */

--- a/files/fr/web/css/inset-inline-end/index.md
+++ b/files/fr/web/css/inset-inline-end/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/inset-inline-end
 
 La propriété **`inset-inline-end`** définit la fin du décalage logique en ligne (_inline_) d'un élément, selon le mode d'écriture, la directionnalité et l'orientation. Elle correspond à une des propriétés parmi {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}} ou {{cssxref("left")}} selon les valeurs des propriétés {{cssxref("writing-mode")}}, {{cssxref("direction")}} et {{cssxref("text-orientation")}}.
 
-> **Note :** Avant Firefox 63, cette propriété était implémentée avec le nom `offset-inline-end`. Firefox 63 a mis à jour son implémentation afin de suivre les modifications apportées à la spécification.
+> [!NOTE]
+> Avant Firefox 63, cette propriété était implémentée avec le nom `offset-inline-end`. Firefox 63 a mis à jour son implémentation afin de suivre les modifications apportées à la spécification.
 
 ```css
 /* Valeurs de longueur */

--- a/files/fr/web/css/inset-inline-start/index.md
+++ b/files/fr/web/css/inset-inline-start/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/inset-inline-start
 
 La propriété **`inset-inline-start`** définit le début du décalage logique en ligne (_inline_) d'un élément, selon le mode d'écriture, la directionnalité et l'orientation. Elle correspond à une des propriétés parmi {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}} ou {{cssxref("left")}} selon les valeurs des propriétés {{cssxref("writing-mode")}}, {{cssxref("direction")}} et {{cssxref("text-orientation")}}.
 
-> **Note :** Avant Firefox 63, cette propriété était implémentée avec le nom `offset-inline-start`. Firefox 63 a mis à jour son implémentation afin de suivre les modifications apportées à la spécification.
+> [!NOTE]
+> Avant Firefox 63, cette propriété était implémentée avec le nom `offset-inline-start`. Firefox 63 a mis à jour son implémentation afin de suivre les modifications apportées à la spécification.
 
 ```css
 /* Valeurs de longueur */

--- a/files/fr/web/css/integer/index.md
+++ b/files/fr/web/css/integer/index.md
@@ -13,7 +13,8 @@ Un entier se compose d'un ou de plusieurs chiffres, de 0 à 9, éventuellement p
 
 Toutes les valeurs de type `<integer>` sont également des valeurs de type {{cssxref("&lt;number&gt;")}}, bien que l'inverse ne soit pas vrai.
 
-> **Note :** Il n'y a pas de bornes à l'ensemble des valeurs de type `<entier>` valides. Opera supporte des valeurs jusqu'à 2^15-1, IE jusqu'à 2^20-1 et d'autres navigateurs des valeurs encore plus hautes. Durant le cycle CSS3 Values, il y a eu de nombreuses discussions pour définir une valeur minimale à supporter : la dernière décision, en date d'avril 2012 pendant la phase LC, était \[-2^27-1; 2^27-1] [#](https://lists.w3.org/Archives/Public/www-style/2012Apr/0633.html) mais d'autres valeurs comme 2^24-1 et 2^30-1 ont aussi été proposées [#](https://lists.w3.org/Archives/Public/www-style/2012Apr/0530.html) [#](https://lists.w3.org/Archives/Public/www-style/2012Apr/0530.html). Le dernier brouillon ne fait plus apparaître de limite.
+> [!NOTE]
+> Il n'y a pas de bornes à l'ensemble des valeurs de type `<entier>` valides. Opera supporte des valeurs jusqu'à 2^15-1, IE jusqu'à 2^20-1 et d'autres navigateurs des valeurs encore plus hautes. Durant le cycle CSS3 Values, il y a eu de nombreuses discussions pour définir une valeur minimale à supporter : la dernière décision, en date d'avril 2012 pendant la phase LC, était \[-2^27-1; 2^27-1] [#](https://lists.w3.org/Archives/Public/www-style/2012Apr/0633.html) mais d'autres valeurs comme 2^24-1 et 2^30-1 ont aussi été proposées [#](https://lists.w3.org/Archives/Public/www-style/2012Apr/0530.html) [#](https://lists.w3.org/Archives/Public/www-style/2012Apr/0530.html). Le dernier brouillon ne fait plus apparaître de limite.
 
 ## Interpolation
 

--- a/files/fr/web/css/layout_cookbook/card/index.md
+++ b/files/fr/web/css/layout_cookbook/card/index.md
@@ -38,7 +38,8 @@ La piste pour le titre est définie avec {{cssxref("max-content")}} ce qui empê
 
 Si la carte possède un pied de page, celui-ci sera dimensionné automatiquement car les lignes ajoutées sur la grille implicite sont dimensionnés automatiquement. Aussi, le pied de page sera suffisamment grand pour contenir l'ensemble de son texte.
 
-> **Note :** Les éléments de différentes cartes ne seront pas alignés les uns avec les autres car chaque carte est une grille indépendante. La fonctionnalité de sous-grille (_subgrid_), proposée pour la version de niveau 2 du module de spécification CSS Grid, pourrait apporter une solution à ce problème.
+> [!NOTE]
+> Les éléments de différentes cartes ne seront pas alignés les uns avec les autres car chaque carte est une grille indépendante. La fonctionnalité de sous-grille (_subgrid_), proposée pour la version de niveau 2 du module de spécification CSS Grid, pourrait apporter une solution à ce problème.
 
 ## Méthodes alternatives
 

--- a/files/fr/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
+++ b/files/fr/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
@@ -5,7 +5,8 @@ slug: Web/CSS/Layout_cookbook/Contribute_a_recipe/Cookbook_template
 
 {{CSSRef}}
 
-> **Note :** Voici un modèle de contenu pour les pages de « recette » CSS. Vous êtes invité⋅e à utiliser cette page comme modèle lorsque vous créez une nouvelle recette.
+> [!NOTE]
+> Voici un modèle de contenu pour les pages de « recette » CSS. Vous êtes invité⋅e à utiliser cette page comme modèle lorsque vous créez une nouvelle recette.
 >
 > _Les commentaires en italiques sont des informations sur l'utilisation de telle ou telle partie du modèle._
 

--- a/files/fr/web/css/layout_cookbook/contribute_a_recipe/index.md
+++ b/files/fr/web/css/layout_cookbook/contribute_a_recipe/index.md
@@ -11,7 +11,8 @@ Si vous souhaitez contribuer en ajoutant une recette à celles présentées dans
 
 **Une bonne recette consiste en la version la plus simple possible d'un motif utile pour concevoir une page web.** Chaque ligne de CSS écrite dans la recette doit servir à illustrer le motif. Tout ce qui est purement décoratif pour l'exemple doit être exclus. L'idée est que la recette puisse servir de base à n'importe qui et de pouvoir appliquer ses propres styles sur l'exemple si besoin.
 
-> **Note :** Quant à la traduction et aux recettes en anglais, une recette (l'exemple interactif, la version téléchargeable et la page MDN) doit d'abord être créée en anglais avant de pouvoir être mise à disposition en français. La suite de ce guide explique en français ce qu'il faut réaliser mais la majeure partie du contenu produit devra être en anglais.
+> [!NOTE]
+> Quant à la traduction et aux recettes en anglais, une recette (l'exemple interactif, la version téléchargeable et la page MDN) doit d'abord être créée en anglais avant de pouvoir être mise à disposition en français. La suite de ce guide explique en français ce qu'il faut réaliser mais la majeure partie du contenu produit devra être en anglais.
 
 ## Les étapes pour la publication
 
@@ -75,7 +76,8 @@ Une fois l'exemple fusionné, vous pouvez créer l'article correspondant sur MDN
 
 Le modèle explique le contenu de chaque section. Vous pouvez également consulter les recettes existantes comme références. Si vous cliquez sur le bouton d'édition en haut de page, vous pourrez ainsi accéder au contenu « brut » de la page et voir comment les macros sont utilisées afin d'intégrer les données de compatibilité ou les exemples interactifs.
 
-> **Note :** Si vous souhaitez effectuer la traduction d'une recette existante, vous pouvez consulter [la page modèle en français](/fr/docs/Web/CSS/Layout_cookbook/Contribute_a_recipe/Cookbook_template).
+> [!NOTE]
+> Si vous souhaitez effectuer la traduction d'une recette existante, vous pouvez consulter [la page modèle en français](/fr/docs/Web/CSS/Layout_cookbook/Contribute_a_recipe/Cookbook_template).
 
 Si vous avez besoin d'une aide générale sur l'utilisation de MDN, vous pouvez consulter les pages d'aide.
 

--- a/files/fr/web/css/layout_cookbook/index.md
+++ b/files/fr/web/css/layout_cookbook/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/Layout_cookbook
 
 Le livre de recettes CSS vise à illustrer différents motifs qu'on retrouve fréquemment sur le Web et qu'on pourrait souhaiter implémenter pour son propre site. En plus de fournir du code qui peut servir de point de départ, ces recettes mettent en avant les différents outils et dispositions qui peuvent être utilisées et les choix à effectuer lors du développement.
 
-> **Note :** Si vous débutez en CSS, nous vous conseillons de consulter [notre module sur l'apprentissage de la disposition en CSS](/fr/docs/Apprendre/CSS/CSS_layout). Ce guide vous fournira les informations de base pour comprendre le fonctionnement de chacune de ces recettes.
+> [!NOTE]
+> Si vous débutez en CSS, nous vous conseillons de consulter [notre module sur l'apprentissage de la disposition en CSS](/fr/docs/Apprendre/CSS/CSS_layout). Ce guide vous fournira les informations de base pour comprendre le fonctionnement de chacune de ces recettes.
 
 ## Les recettes
 

--- a/files/fr/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/fr/web/css/layout_cookbook/sticky_footers/index.md
@@ -22,7 +22,8 @@ Voici les spécifications rapides pour décrire le résultat qu'on souhaite obte
 
 > **Note :** [Télécharger cet exemple](https://github.com/mdn/css-examples/blob/master/css-cookbook/sticky-footer--download.html)
 
-> **Note :** Dans cet exemple, ainsi que dans le suivant, on utilise un élément enveloppant avec `min-height: 100%` afin que l'exemple intégré à la page fonctionne. Pour reproduire cela sur une page complète, on peut utiliser {{cssxref("min-height")}} avec la valeur `100vh` sur l'élément {{htmlelement("body")}} qu'on utilise comme conteneur de grille.
+> [!NOTE]
+> Dans cet exemple, ainsi que dans le suivant, on utilise un élément enveloppant avec `min-height: 100%` afin que l'exemple intégré à la page fonctionne. Pour reproduire cela sur une page complète, on peut utiliser {{cssxref("min-height")}} avec la valeur `100vh` sur l'élément {{htmlelement("body")}} qu'on utilise comme conteneur de grille.
 
 ## Choix effectués
 

--- a/files/fr/web/css/length/index.md
+++ b/files/fr/web/css/length/index.md
@@ -17,7 +17,8 @@ On notera que bien que les valeurs {{cssxref("&lt;percentage&gt;")}} soient auss
 
 Une longueur est un nombre (type {{cssxref("&lt;number&gt;")}}) immédiatement suivi d'une unité de longueur (`px`, `em`, `pc`, `in`, `mm`…). Comme toutes les dimensions CSS, il n'y aucun espace entre le nombre et l'unité. L'unité est optionnelle pour la valeur nulle.
 
-> **Note :** Certaines propriétés permettent d'utiliser des longueurs négatives alors que d'autres n'acceptent que des valeurs positives.
+> [!NOTE]
+> Certaines propriétés permettent d'utiliser des longueurs négatives alors que d'autres n'acceptent que des valeurs positives.
 
 ### Unités
 
@@ -37,7 +38,8 @@ Les unités relatives aux polices de caractères permettent d'obtenir des longue
 
   - : Cette unité représente la {{cssxref("font-size")}} calculée de l'élément. Si utilisée avec la propriété {{cssxref("font-size")}}, elle représente la taille de police _héritée_ de l'élément.
 
-    > **Note :** Cette unité est souvent utilisée pour créer des mises en page s'adaptant à la taille des contenus, qui gardent le [rythme vertical de la page](http://24ways.org/2006/compose-to-a-vertical-rhythm/), même lorsque l'utilisateur change la taille des polices. Les propriétés CSS {{cssxref("line-height")}}, {{cssxref("font-size")}}, {{cssxref("margin-bottom")}} et {{cssxref("margin-top")}} ont souvent des dimensions exprimées en **em**.
+    > [!NOTE]
+    > Cette unité est souvent utilisée pour créer des mises en page s'adaptant à la taille des contenus, qui gardent le [rythme vertical de la page](http://24ways.org/2006/compose-to-a-vertical-rhythm/), même lorsque l'utilisateur change la taille des polices. Les propriétés CSS {{cssxref("line-height")}}, {{cssxref("font-size")}}, {{cssxref("margin-bottom")}} et {{cssxref("margin-top")}} ont souvent des dimensions exprimées en **em**.
 
 - `ex`
   - : Cette unité représente la [hauteur d'x](https://fr.wikipedia.org/wiki/Hauteur_d%27x) de la {{cssxref("font")}} de l'élément. Il peut s'agir généralement de la hauteur des lettres bas de casse de la police. `1ex ≈ 0.5em` dans de nombreuses polices.
@@ -49,7 +51,8 @@ Les unités relatives aux polices de caractères permettent d'obtenir des longue
 
   - : Cette unité représente la {{cssxref("font-size")}} de l'élément racine (par exemple la taille de la police de l'élément {{HTMLElement("html")}}). Quand utilisée avec {{cssxref("font-size")}} sur l'élément racine, elle représente sa valeur initiale.
 
-    > **Note :** Cette unité est utile pour la création de mises en page s'adaptant à la taille des contenus. Si elle n'est pas supportée par les navigateurs ciblés, ces mises en pages peuvent être réalisées en utilisant l'unité **em**, mais la réalisation est un petit peu plus complexe.
+    > [!NOTE]
+    > Cette unité est utile pour la création de mises en page s'adaptant à la taille des contenus. Si elle n'est pas supportée par les navigateurs ciblés, ces mises en pages peuvent être réalisées en utilisant l'unité **em**, mais la réalisation est un petit peu plus complexe.
 
 - `rlh`
   - : Cette unité représente la valeur calculée de la propriété {{cssxref("line-height")}} de l'élément racine, convertie en longueur absolue. Lorsque cette unité est utilisée pour les propriétés {{cssxref("font-size")}} ou {{cssxref("line-height")}} de l'élément racine, l'unité `rlh` fait référence aux valeurs initiales des propriétés.
@@ -104,7 +107,8 @@ Pour les périphériques ayant un faible nombre de points par pouce, l'unité **
 
 Pour les périphériques ayant un nombre de points par pouce élevé, les pouces (`in`), centimètres (`cm`) et millimètres (`mm`) sont définis comme leur équivalent physique. Par conséquent, l'unité **px** est définie comme étant relavite à eux (1/96 de pouce).
 
-> **Note :** Les utilisateurs peuvent augmenter la taille des polices pour des raisons d'accessibilité. Pour permettre des mises en page adaptées quelque soit la taille des polices, utilisez uniquement des unités de longueur quand les caractéristiques physiques du média de sortie sont connues, telles que les images matricielles (bitmap) et sinon, privilégiez les unités relatives telles que `em` et `rem` (notamment pour {{cssxref("font-size")}}).
+> [!NOTE]
+> Les utilisateurs peuvent augmenter la taille des polices pour des raisons d'accessibilité. Pour permettre des mises en page adaptées quelque soit la taille des polices, utilisez uniquement des unités de longueur quand les caractéristiques physiques du média de sortie sont connues, telles que les images matricielles (bitmap) et sinon, privilégiez les unités relatives telles que `em` et `rem` (notamment pour {{cssxref("font-size")}}).
 
 - `px`
   - : Pour l'affichage sur écran, correspond typiquement à un pixel de l'affichage. Pour les écrans en haute résolution et les imprimantes, un pixel CSS correspond à plusieurs pixels du périphérique, de sorte que le nombre de pixels par pouce (ppi) reste aux alentours de 96.
@@ -143,7 +147,8 @@ Pour les périphériques ayant un nombre de points par pouce élevé, les pouces
 
 ## Unités CSS et points par pouce
 
-> **Note :** L'unité `in` ne représente pas un pouce physique de l'écran, mais `96px`. Celà signifie que quelque soit la densité de pixel réelle de l'écran, elle est supposée correspondre à `96dpi`. Sur les périphériques dotés d'une plus grande densité de pixel, `1in` fera moins d'1 pouce physique. De la même manière, `mm`, `cm`, et `pt` ne sont pas des longueurs absolues.
+> [!NOTE]
+> L'unité `in` ne représente pas un pouce physique de l'écran, mais `96px`. Celà signifie que quelque soit la densité de pixel réelle de l'écran, elle est supposée correspondre à `96dpi`. Sur les périphériques dotés d'une plus grande densité de pixel, `1in` fera moins d'1 pouce physique. De la même manière, `mm`, `cm`, et `pt` ne sont pas des longueurs absolues.
 
 Quelques exemples particuliers :
 

--- a/files/fr/web/css/list-style-image/index.md
+++ b/files/fr/web/css/list-style-image/index.md
@@ -11,7 +11,8 @@ On peut également utiliser la propriété raccourcie [`list-style`](/fr/docs/We
 
 {{EmbedInteractiveExample("pages/css/list-style-image.html")}}
 
-> **Note :** Cette propriété s'applique aux éléments d'une liste (c'est-à-dire aux éléments pour lesquels [`display`](/fr/docs/Web/CSS/display) vaut `list-item`). Par défaut, cela inclut les éléments [`<li>`](/fr/docs/Web/HTML/Element/li). Cette propriété peut être héritée par les éléments et si on veut donc gérer une liste de façon uniforme, on pourra appliquer la propriété à l'élément parent (qui correspond en général à [`<ol>`](/fr/docs/Web/HTML/Element/ol) ou à [`<ul>`](/fr/docs/Web/HTML/Element/ul)).
+> [!NOTE]
+> Cette propriété s'applique aux éléments d'une liste (c'est-à-dire aux éléments pour lesquels [`display`](/fr/docs/Web/CSS/display) vaut `list-item`). Par défaut, cela inclut les éléments [`<li>`](/fr/docs/Web/HTML/Element/li). Cette propriété peut être héritée par les éléments et si on veut donc gérer une liste de façon uniforme, on pourra appliquer la propriété à l'élément parent (qui correspond en général à [`<ol>`](/fr/docs/Web/HTML/Element/ol) ou à [`<ul>`](/fr/docs/Web/HTML/Element/ul)).
 
 ## Syntaxe
 

--- a/files/fr/web/css/list-style-position/index.md
+++ b/files/fr/web/css/list-style-position/index.md
@@ -11,7 +11,8 @@ La propriété **`list-style-position`** permet de définir la position du marqu
 
 Pour définir cette propriété, on pourra aussi utiliser la propriété raccourcie [`list-style`](/fr/docs/Web/CSS/list-style).
 
-> **Note :** Cette propriété s'applique aux éléments d'une liste (c'est-à-dire aux éléments pour lesquels [`display`](/fr/docs/Web/CSS/display) vaut `list-item`). [Par défaut](https://www.w3.org/TR/html5/rendering.html#lists), cela inclut les éléments [`<li>`](/fr/docs/Web/HTML/Element/li). Cette propriété peut être héritée par les éléments et si on veut donc gérer une liste de façon uniforme, on pourra appliquer la propriété à l'élément parent (qui correspond en général à [`<ol>`](/fr/docs/Web/HTML/Element/ol) ou à [`<ul>`](/fr/docs/Web/HTML/Element/ul)).
+> [!NOTE]
+> Cette propriété s'applique aux éléments d'une liste (c'est-à-dire aux éléments pour lesquels [`display`](/fr/docs/Web/CSS/display) vaut `list-item`). [Par défaut](https://www.w3.org/TR/html5/rendering.html#lists), cela inclut les éléments [`<li>`](/fr/docs/Web/HTML/Element/li). Cette propriété peut être héritée par les éléments et si on veut donc gérer une liste de façon uniforme, on pourra appliquer la propriété à l'élément parent (qui correspond en général à [`<ol>`](/fr/docs/Web/HTML/Element/ol) ou à [`<ul>`](/fr/docs/Web/HTML/Element/ul)).
 
 Une différence de comportement existe entre les navigateurs lorsqu'un élément de bloc est placé en premier au sein d'un élément de liste avec `list-style-position: inside`. Chrome et Safari placent l'élément sur la même ligne que la boîte du marqueur. En revanche, Firefox, Internet Explorer et Opera placent l'élément sur la ligne suivante. Voir [le bug 36854 de Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=36854) pour plus d'informations.
 

--- a/files/fr/web/css/list-style/index.md
+++ b/files/fr/web/css/list-style/index.md
@@ -9,7 +9,8 @@ La propriété **`list-style`** est une [propriété raccourcie](/fr/docs/Web/CS
 
 {{EmbedInteractiveExample("pages/css/list-style.html")}}
 
-> **Note :** Cette propriété s'applique aux éléments d'une liste (c'est-à-dire aux éléments pour lesquels [`display`](/fr/docs/Web/CSS/display) vaut `list-item`). [Par défaut](https://www.w3.org/TR/html5/rendering.html#lists), cela inclut les éléments [`<li>`](/fr/docs/Web/HTML/Element/li). Cette propriété peut être héritée par les éléments et si on veut donc gérer une liste de façon uniforme, on pourra appliquer la propriété à l'élément parent (qui correspond en général à [`<ol>`](/fr/docs/Web/HTML/Element/ol) ou à [`<ul>`](/fr/docs/Web/HTML/Element/ul)).
+> [!NOTE]
+> Cette propriété s'applique aux éléments d'une liste (c'est-à-dire aux éléments pour lesquels [`display`](/fr/docs/Web/CSS/display) vaut `list-item`). [Par défaut](https://www.w3.org/TR/html5/rendering.html#lists), cela inclut les éléments [`<li>`](/fr/docs/Web/HTML/Element/li). Cette propriété peut être héritée par les éléments et si on veut donc gérer une liste de façon uniforme, on pourra appliquer la propriété à l'élément parent (qui correspond en général à [`<ol>`](/fr/docs/Web/HTML/Element/ol) ou à [`<ul>`](/fr/docs/Web/HTML/Element/ul)).
 
 ## Propriétés détaillées correspondantes
 

--- a/files/fr/web/css/margin/index.md
+++ b/files/fr/web/css/margin/index.md
@@ -13,7 +13,8 @@ Il est possible d'utiliser des valeurs négatives pour chacun des côtés.
 
 Les marges haute et basse n'ont aucun effet sur les élements en ligne (_inline_) qui ne sont pas [remplacés](/fr/docs/Web/CSS/Élément_remplacé) (par exemple les {{HTMLElement("span")}} ou {{HTMLElement("code")}}).
 
-> **Note :** Les marges créent un espace supplémentaire à l'extérieur de l'élément. Le _« remplissage »_ ({{cssxref("padding")}}) permet quant à lui de créer un espace supplémentaire à l'intérieur de l'élément.
+> [!NOTE]
+> Les marges créent un espace supplémentaire à l'extérieur de l'élément. Le _« remplissage »_ ({{cssxref("padding")}}) permet quant à lui de créer un espace supplémentaire à l'intérieur de l'élément.
 
 ## Syntaxe
 

--- a/files/fr/web/css/mask-size/index.md
+++ b/files/fr/web/css/mask-size/index.md
@@ -42,7 +42,8 @@ mask-size: revert;
 mask-size: unset;
 ```
 
-> **Note :** Si la valeur de cette propriété n'est pas définie avec la propriété raccourcie [`mask`](/fr/docs/Web/CSS/mask) et que celle-ci est appliquée après `mask-size`, la valeur sera réinitialisée avec sa valeur initiale à cause de la propriété raccourcie.
+> [!NOTE]
+> Si la valeur de cette propriété n'est pas définie avec la propriété raccourcie [`mask`](/fr/docs/Web/CSS/mask) et que celle-ci est appliquée après `mask-size`, la valeur sera réinitialisée avec sa valeur initiale à cause de la propriété raccourcie.
 
 ## Syntaxe
 

--- a/files/fr/web/css/mask/index.md
+++ b/files/fr/web/css/mask/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/mask
 
 La propriété **`mask`** permet de masquer un élément partiellement ou complètement en utilisant un masque apposé sur l'image ou en rognant l'image aux positions données. Cette propriété est une propriété raccourcie pour les propriétés {{cssxref("mask-image")}}, {{cssxref("mask-mode")}}, {{cssxref("mask-repeat")}}, {{cssxref("mask-position")}}, {{cssxref("mask-clip")}}, {{cssxref("mask-origin")}}, {{cssxref("mask-size")}} et {{cssxref("mask-composite ")}}.
 
-> **Note :** La propriété raccourcie réinitialise également {{cssxref("mask-border")}} avec sa valeur initiale. Il est donc recommandé d'utiliser la propriété raccourcie à travers les feuilles de style plutôt que les propriétés raccourcies (sauf en cas d'héritage complexe).
+> [!NOTE]
+> La propriété raccourcie réinitialise également {{cssxref("mask-border")}} avec sa valeur initiale. Il est donc recommandé d'utiliser la propriété raccourcie à travers les feuilles de style plutôt que les propriétés raccourcies (sauf en cas d'héritage complexe).
 
 ## Syntaxe
 

--- a/files/fr/web/css/max-block-size/index.md
+++ b/files/fr/web/css/max-block-size/index.md
@@ -67,9 +67,11 @@ La valeur de `writing-mode` détermine la propriété physique correspondant à 
 | `horizontal-tb`, `lr` {{deprecated_inline}}, `lr-tb` {{deprecated_inline}}, `rl` {{deprecated_inline}}, `rb` {{deprecated_inline}}, `rb-rl` {{deprecated_inline}}     | [`max-height`](/fr/docs/Web/CSS/max-height)       |
 | `vertical-rl`, `vertical-lr`, `sideways-rl` {{experimental_inline}}, `sideways-lr` {{experimental_inline}}, `tb` {{deprecated_inline}}, `tb-rl` {{deprecated_inline}} | [`max-width`](/fr/docs/Web/CSS/max-width)         |
 
-> **Note :** Les valeurs `sideways-lr` et `sideways-rl` pour `writing-mode` ont été retirées du module de spécification CSS sur les modes d'écriture de niveau 3 en fin de processus et pourraient être réintroduites dans la spécification de niveau 4.
+> [!NOTE]
+> Les valeurs `sideways-lr` et `sideways-rl` pour `writing-mode` ont été retirées du module de spécification CSS sur les modes d'écriture de niveau 3 en fin de processus et pourraient être réintroduites dans la spécification de niveau 4.
 
-> **Note :** Les modes d'écriture `lr`, `lr-tb`, `rl`, `rb` et `rb-tl` ne sont plus autorisés pour les contextes [HTML](/fr/docs/Glossary/HTML) et peuvent uniquement être utilisés dans des contextes [SVG](/fr/docs/Glossary/SVG) 1.x.
+> [!NOTE]
+> Les modes d'écriture `lr`, `lr-tb`, `rl`, `rb` et `rb-tl` ne sont plus autorisés pour les contextes [HTML](/fr/docs/Glossary/HTML) et peuvent uniquement être utilisés dans des contextes [SVG](/fr/docs/Glossary/SVG) 1.x.
 
 ## Définition formelle
 

--- a/files/fr/web/css/mozilla_extensions/index.md
+++ b/files/fr/web/css/mozilla_extensions/index.md
@@ -9,7 +9,8 @@ Les applications Mozilla, telles que Firefox, prennent en charge un certain nomb
 
 ## Propriétés et pseudo-classes spécifiques à Mozilla (ne pas utiliser sur le Web)
 
-> **Note :** Ces propriétés et pseudo-classes ne fonctionneront que pour les applications Mozilla (Firefox par exemple) et ne sont pas en voie de standardisation. Certaines ne s'applique qu'aux éléments [XUL](/fr/docs/Mozilla/Tech/XUL).
+> [!NOTE]
+> Ces propriétés et pseudo-classes ne fonctionneront que pour les applications Mozilla (Firefox par exemple) et ne sont pas en voie de standardisation. Certaines ne s'applique qu'aux éléments [XUL](/fr/docs/Mozilla/Tech/XUL).
 
 ### B
 
@@ -65,7 +66,8 @@ Les applications Mozilla, telles que Firefox, prennent en charge un certain nomb
 
 ## Anciennes propriétés spécifiques, désormais standardisées
 
-> **Note :** Afin d'obtenir la meilleure compatibilité possible, vous devriez utiliser les versions standards, non-préfixées, de ces propriétés plutôt que les versions spécifiques. Généralement, lorsqu'une propriété est standardisée et implémentée, la version préfixée est généralement abandonnée ensuite.
+> [!NOTE]
+> Afin d'obtenir la meilleure compatibilité possible, vous devriez utiliser les versions standards, non-préfixées, de ces propriétés plutôt que les versions spécifiques. Généralement, lorsqu'une propriété est standardisée et implémentée, la version préfixée est généralement abandonnée ensuite.
 
 ### A
 

--- a/files/fr/web/css/object-fit/index.md
+++ b/files/fr/web/css/object-fit/index.md
@@ -11,7 +11,8 @@ La propriété CSS **`object-fit`** définit la façon dont le contenu d'un [él
 
 Selon la valeur utilisée pour `object-fit`, l'élément peut être rogné, mis à l'échelle ou étiré, afin de remplir la boîte qui le contient.
 
-> **Note :** Il est possible de modifier l'alignement du contenu de l'élément remplacé au sein de la boîte de l'élément grâce à la propriété [`object-position`](/fr/docs/Web/CSS/object-position).
+> [!NOTE]
+> Il est possible de modifier l'alignement du contenu de l'élément remplacé au sein de la boîte de l'élément grâce à la propriété [`object-position`](/fr/docs/Web/CSS/object-position).
 
 ## Syntaxe
 

--- a/files/fr/web/css/object-position/index.md
+++ b/files/fr/web/css/object-position/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/object-position
 
 La propriété **`object-position`** détermine l'alignement d'un [élément remplacé](/fr/docs/Web/CSS/Replaced_element) au sein de sa boîte. Les zones de la boîte qui ne sont pas recouvertes par le contenu de l'élément remplacé montreront l'arrière-plan de l'élément.
 
-> **Note :** Il est possible d'ajuster la taille de l'élément remplacé au sein de la boîte de l'élément grâce à la propriété [`object-fit`](/fr/docs/Web/CSS/object-fit).
+> [!NOTE]
+> Il est possible d'ajuster la taille de l'élément remplacé au sein de la boîte de l'élément grâce à la propriété [`object-fit`](/fr/docs/Web/CSS/object-fit).
 
 {{EmbedInteractiveExample("pages/css/object-position.html")}}
 

--- a/files/fr/web/css/offset-path/index.md
+++ b/files/fr/web/css/offset-path/index.md
@@ -13,7 +13,8 @@ Cette propriété sert à définir un chemin qu'un élément va suivre lors d'un
 
 La position exacte de l'élément sur ce tracé est déterminée grâce à la propriété {{cssxref("offset-distance")}}. Le tracé d'un mouvement peut être défini grâce à un chemin ou à plusieurs chemins successifs ou encore grâce à la géométrie d'une forme. Chaque forme ou chemin doit définir une position initiale pour la valeur calculée `0` de {{cssxref("offset-distance")}} ainsi qu'une direction initiale qui définit la rotation de l'objet dans sa position initiale.
 
-> **Note :** Dans des versions antérieures des spécifications, cette propriété était intitulée `motion-path`. Le nom a été modifié en `offset-path` afin de décrire un chemin statique plutôt qu'un chemin en mouvement.
+> [!NOTE]
+> Dans des versions antérieures des spécifications, cette propriété était intitulée `motion-path`. Le nom a été modifié en `offset-path` afin de décrire un chemin statique plutôt qu'un chemin en mouvement.
 
 ## Syntaxe
 
@@ -45,7 +46,8 @@ offset-path: unset;
 
 ### Valeurs
 
-> **Attention :** À l'heure actuelle, seule la notation `path()` est prise en charge par les navigateurs.
+> [!WARNING]
+> À l'heure actuelle, seule la notation `path()` est prise en charge par les navigateurs.
 
 - `ray()`
   - : Cette notation fonctionnelle prend jusqu'à trois valeurs et définit un chemin qui est un ligne commençant à la position de la boîte et qui suit la direction de l'angle indiqué (la valeur 0deg correspond à une direction verticale, vers le haut et les angles allant dans le sens horaire). La valeur de la taille est définie de façon semblable à celle utilisée pour les dégradés entre `closest-side` et `farthest-corner` avec le mot-clé `contain`.

--- a/files/fr/web/css/offset/index.md
+++ b/files/fr/web/css/offset/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/offset
 
 La propriété **`offset`** est une propriété raccourcie pour les propriétés {{cssxref("offset-path")}}, {{cssxref("offset-position")}}, {{cssxref("offset-distance")}}, {{cssxref("offset-rotate")}} et {{cssxref("offset-anchor")}}. Elle permet d'animer un élément sur un tracé défini.
 
-> **Note :** Dans les premières versions de la spécification, cette propriété était intitulée `motion`.
+> [!NOTE]
+> Dans les premières versions de la spécification, cette propriété était intitulée `motion`.
 
 ## Syntaxe
 

--- a/files/fr/web/css/orphans/index.md
+++ b/files/fr/web/css/orphans/index.md
@@ -17,7 +17,8 @@ orphans: initial;
 orphans: unset;
 ```
 
-> **Note :** En typographie, un orphelin (_orphan_ en anglais) est la première ligne d'un paragraphe qui apparaît isolée en bas d'une page (le paragraphe poursuivant sur la page suivante).
+> [!NOTE]
+> En typographie, un orphelin (_orphan_ en anglais) est la première ligne d'un paragraphe qui apparaît isolée en bas d'une page (le paragraphe poursuivant sur la page suivante).
 
 ## Syntaxe
 

--- a/files/fr/web/css/outline/index.md
+++ b/files/fr/web/css/outline/index.md
@@ -39,7 +39,8 @@ outline: unset;
 
 La propriété `outline` peut être définie avec une, deux ou trois valeurs parmi celles listées ci-après. L'ordre de ces valeurs n'a pas d'importance.
 
-> **Note :** Si aucun style n'est défini, le contour sera invisible (car le style par défaut vaut `none`).
+> [!NOTE]
+> Si aucun style n'est défini, le contour sera invisible (car le style par défaut vaut `none`).
 
 ### Valeurs
 

--- a/files/fr/web/css/overflow-anchor/guide_to_scroll_anchoring/index.md
+++ b/files/fr/web/css/overflow-anchor/guide_to_scroll_anchoring/index.md
@@ -42,7 +42,8 @@ Pour désactiver cette fonctionnalité sur une certaine partie du document, on c
 }
 ```
 
-> **Note :** Dans la spécification, il est indiqué qu'il n'est pas possible de « revenir » avec l'ancrage dans un élément fils si l'ancrage a été désactivé sur un élément parent. Ainsi, si on désactive l'ancrage pour l'ensemble du document, on ne pourra pas appliquer (avec succès) `overflow-anchor: auto` à un autre endroit du document.
+> [!NOTE]
+> Dans la spécification, il est indiqué qu'il n'est pas possible de « revenir » avec l'ancrage dans un élément fils si l'ancrage a été désactivé sur un élément parent. Ainsi, si on désactive l'ancrage pour l'ensemble du document, on ne pourra pas appliquer (avec succès) `overflow-anchor: auto` à un autre endroit du document.
 
 ### Supression triggers
 

--- a/files/fr/web/css/overflow-block/index.md
+++ b/files/fr/web/css/overflow-block/index.md
@@ -9,7 +9,8 @@ l10n:
 
 La propriété [CSS](/fr/docs/Web/CSS) **`overflow-block`** est une propriété logique qui définit ce qu'il faut afficher quand le contenu dépasse d'un élément de bloc sur les bords de bloc (ceux orthogonaux au sens d'écriture). On peut choisir d'afficher rien, une barre de défilement ou de laisser le contenu dépasser.
 
-> **Note :** La propriété `overflow-block` correspond à [`overflow-y`](/fr/docs/Web/CSS/overflow-y) ou [`overflow-x`](/fr/docs/Web/CSS/overflow-x) selon le mode d'écriture du document.
+> [!NOTE]
+> La propriété `overflow-block` correspond à [`overflow-y`](/fr/docs/Web/CSS/overflow-y) ou [`overflow-x`](/fr/docs/Web/CSS/overflow-x) selon le mode d'écriture du document.
 
 ## Syntaxe
 

--- a/files/fr/web/css/overflow-inline/index.md
+++ b/files/fr/web/css/overflow-inline/index.md
@@ -9,7 +9,8 @@ l10n:
 
 La propriété [CSS](/fr/docs/Web/CSS) **`overflow-inline`** est une propriété logique qui définit ce qu'il faut afficher quand le contenu dépasse d'une boîte sur les bords en ligne (ceux parallèles au sens d'écriture). On peut choisir d'afficher rien, une barre de défilement ou de laisser le contenu dépasser.
 
-> **Note :** La propriété `overflow-inline` correspond à [`overflow-y`](/fr/docs/Web/CSS/overflow-y) ou [`overflow-x`](/fr/docs/Web/CSS/overflow-x) selon le mode d'écriture du document.
+> [!NOTE]
+> La propriété `overflow-inline` correspond à [`overflow-y`](/fr/docs/Web/CSS/overflow-y) ou [`overflow-x`](/fr/docs/Web/CSS/overflow-x) selon le mode d'écriture du document.
 
 ## Syntaxe
 

--- a/files/fr/web/css/overflow-wrap/index.md
+++ b/files/fr/web/css/overflow-wrap/index.md
@@ -9,7 +9,8 @@ La propriété **`overflow-wrap`** s'applique aux éléments en ligne (_inline_)
 
 {{EmbedInteractiveExample("pages/css/overflow-wrap.html")}}
 
-> **Note :** À la différence de {{cssxref("word-break")}}, `overflow-wrap` créera uniquement un saut de ligne si un mot entier ne peut pas être placé sur sa propre ligne sans dépasser.
+> [!NOTE]
+> À la différence de {{cssxref("word-break")}}, `overflow-wrap` créera uniquement un saut de ligne si un mot entier ne peut pas être placé sur sa propre ligne sans dépasser.
 
 À l'origine, cette propriété était une extension non-standard sans préfixe de Microsoft et intitulée `word-wrap`. Implémentée sous ce nom par la plupart des navigateurs depuis, elle a été renommée en `overflow-wrap` et `word-wrap` est devenu un alias.
 

--- a/files/fr/web/css/overflow-x/index.md
+++ b/files/fr/web/css/overflow-x/index.md
@@ -46,7 +46,8 @@ Si [`overflow-y`](/fr/docs/Web/CSS/overflow-y) vaut `hidden`, `scroll` ou `auto`
 - `auto`
   - : Le contenu qui dépasse est rogné dans la boîte de contenu et on peut le faire défiler pour le faire apparaître. À la différence de `scroll`, les agents utilisateur afficheront les ascenseurs uniquement si le contenu dépasse et les masqueront par défaut. Si le contenu tient dans la boîte de remplissage de l'élément, cette valeur aura le même effet que `visible` et établira un nouveau contexte de formatage de bloc. Les navigateurs de bureau fournissent des barres de défilement si le contenu dépasse.
 
-> **Note :** La valeur `overlay` est un synonyme historique de `auto`. Avec `overlay`, les barres de défilement étaient dessinées au-dessus du contenu plutôt que de prendre de l'espace.
+> [!NOTE]
+> La valeur `overlay` est un synonyme historique de `auto`. Avec `overlay`, les barres de défilement étaient dessinées au-dessus du contenu plutôt que de prendre de l'espace.
 
 ## Définition formelle
 

--- a/files/fr/web/css/overflow-y/index.md
+++ b/files/fr/web/css/overflow-y/index.md
@@ -46,7 +46,8 @@ Si [`overflow-x`](/fr/docs/Web/CSS/overflow-y) vaut `hidden`, `scroll` ou `auto`
 - `auto`
   - : Le contenu qui dépasse est rogné dans la boîte de contenu et on peut le faire défiler pour le faire apparaître. À la différence de `scroll`, les agents utilisateur afficheront les ascenseurs uniquement si le contenu dépasse et les masqueront par défaut. Si le contenu tient dans la boîte de remplissage de l'élément, cette valeur aura le même effet que `visible` et établira un nouveau contexte de formatage de bloc. Les navigateurs de bureau fournissent des barres de défilement si le contenu dépasse.
 
-> **Note :** La valeur `overlay` est un synonyme historique de `auto`. Avec `overlay`, les barres de défilement étaient dessinées au-dessus du contenu plutôt que de prendre de l'espace.
+> [!NOTE]
+> La valeur `overlay` est un synonyme historique de `auto`. Avec `overlay`, les barres de défilement étaient dessinées au-dessus du contenu plutôt que de prendre de l'espace.
 
 ## Définition formelle
 

--- a/files/fr/web/css/overflow/index.md
+++ b/files/fr/web/css/overflow/index.md
@@ -13,9 +13,11 @@ Lorsqu'on utilise la propriété `overflow` avec une autre valeur que `visible` 
 
 Afin que la propriété `overflow` puisse avoir un effet, le conteneur de niveau de bloc doit avoir une hauteur limite (définie grâce à {{cssxref("height")}} ou {{cssxref("max-height")}}) ou avoir `white-space` avec la valeur `nowrap.`
 
-> **Note :** Si on définit un axe avec `visible` (la valeur par défaut) et qu'on définit l'autre axe avec une valeur différente, alors la valeur du premier axe (`visible`) sera considérée comme `auto`.
+> [!NOTE]
+> Si on définit un axe avec `visible` (la valeur par défaut) et qu'on définit l'autre axe avec une valeur différente, alors la valeur du premier axe (`visible`) sera considérée comme `auto`.
 
-> **Note :** Lorsqu'on définit, via un script, la propriété `scrollTop` sur les éléments HTML pertinents, même lorsque `overflow` vaut `hidden`, il faut parfois faire défiler l'élément.
+> [!NOTE]
+> Lorsqu'on définit, via un script, la propriété `scrollTop` sur les éléments HTML pertinents, même lorsque `overflow` vaut `hidden`, il faut parfois faire défiler l'élément.
 
 ## Syntaxe
 

--- a/files/fr/web/css/overscroll-behavior-x/index.md
+++ b/files/fr/web/css/overscroll-behavior-x/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/overscroll-behavior-x
 
 La propriété CSS **`overscroll-behavior-x`** définit le comportement de l'agent utilisateur lorsqu'on atteint la limite de la zone de défilement sur l'axe horizontal.
 
-> **Note :** Voir {{cssxref("overscroll-behavior")}} pour plus de détails.
+> [!NOTE]
+> Voir {{cssxref("overscroll-behavior")}} pour plus de détails.
 
 ## Syntaxe
 

--- a/files/fr/web/css/overscroll-behavior-y/index.md
+++ b/files/fr/web/css/overscroll-behavior-y/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/overscroll-behavior-y
 
 La propriété CSS **`overscroll-behavior-y`** permet de contrôler le comportement de l'agent utilisateur lorsqu'on atteint la limite de la zone de défilement sur l'axe vertical.
 
-> **Note :** Voir {{cssxref("overscroll-behavior")}} pour plus de détails.
+> [!NOTE]
+> Voir {{cssxref("overscroll-behavior")}} pour plus de détails.
 
 ## Syntaxe
 

--- a/files/fr/web/css/padding-right/index.md
+++ b/files/fr/web/css/padding-right/index.md
@@ -9,7 +9,8 @@ La propriété **`padding-right`** d'un élément correspond à l'espace nécess
 
 {{EmbedInteractiveExample("pages/css/padding-right.html")}}
 
-> **Note :** La propriété raccourcie {{cssxref("padding")}} permet de paramétrer les dimensions des quatre côtés de cette boîte (y compris `padding-right` donc).
+> [!NOTE]
+> La propriété raccourcie {{cssxref("padding")}} permet de paramétrer les dimensions des quatre côtés de cette boîte (y compris `padding-right` donc).
 
 ## Syntaxe
 

--- a/files/fr/web/css/padding/index.md
+++ b/files/fr/web/css/padding/index.md
@@ -11,7 +11,8 @@ La propriété **`padding`** est [une propriété raccourcie](/fr/docs/Web/CSS/P
 
 La [zone de remplissage](/fr/docs/Learn/CSS/Building_blocks/The_box_model) correspond à l'espace entre le contenu de l'élément et sa bordure. Les valeurs négatives ne sont pas autorisées.
 
-> **Note :** Le _padding_ permet de créer un espace supplémentaire à l'intérieur d'un élément. La marge ({{cssxref("margin")}}) permet quant à elle de créer un espace supplémentaire à l'extérieur de l'élément.
+> [!NOTE]
+> Le _padding_ permet de créer un espace supplémentaire à l'intérieur d'un élément. La marge ({{cssxref("margin")}}) permet quant à elle de créer un espace supplémentaire à l'extérieur de l'élément.
 
 ## Syntaxe
 

--- a/files/fr/web/css/page-break-after/index.md
+++ b/files/fr/web/css/page-break-after/index.md
@@ -5,7 +5,8 @@ slug: Web/CSS/page-break-after
 
 {{CSSRef}}
 
-> **Attention :** Cette propriété a été remplacée par la propriété {{cssxref("break-after")}}.
+> [!WARNING]
+> Cette propriété a été remplacée par la propriété {{cssxref("break-after")}}.
 
 La propriété CSS **`page-break-after`** permet d'ajuster les sauts de page placés _après_ l'élément courant.
 

--- a/files/fr/web/css/page-break-before/index.md
+++ b/files/fr/web/css/page-break-before/index.md
@@ -5,7 +5,8 @@ slug: Web/CSS/page-break-before
 
 {{CSSRef}}
 
-> **Attention :** Cette propriété a été remplacée par la propriété {{cssxref("break-before")}}.
+> [!WARNING]
+> Cette propriété a été remplacée par la propriété {{cssxref("break-before")}}.
 
 La propriété CSS **`page-break-before`** permet d'ajuster les sauts de page placés _avant_ l'élément courant.Cette propriété s'applique aux éléments de blocs qui génèrent une boîte. Elle ne s'appliquera pas à un {{HTMLElement("div")}} qui ne génère pas de boîte.
 

--- a/files/fr/web/css/page-break-inside/index.md
+++ b/files/fr/web/css/page-break-inside/index.md
@@ -5,7 +5,8 @@ slug: Web/CSS/page-break-inside
 
 {{CSSRef}}
 
-> **Attention :** Cette propriété a été remplacée par la propriété {{cssxref("break-inside")}}.
+> [!WARNING]
+> Cette propriété a été remplacée par la propriété {{cssxref("break-inside")}}.
 
 La propriété **`page-break-inside`** ajuste la façon dont sont appliqués les sauts de page au sein de l'élément courant.
 

--- a/files/fr/web/css/paint-order/index.md
+++ b/files/fr/web/css/paint-order/index.md
@@ -34,7 +34,8 @@ La valeur par défaut, utilisée si aucune valeur n'est fournie, sera `fill`, `s
 
 Lorsqu'une seule valeur est indiquée, c'est celle-ci qui est appliquée par défaut suivi des deux autres selon l'ordre par défaut. Lorsque deux valeurs sont indiquées, elles sont appliquées dans cet ordre puis suivi de la troisième.
 
-> **Note :** Pour cette propriété, les marqueurs sont uniquement utilisés dans le cas de formes SVG qui utilisent les propriétés `marker-*` (e.g. [`marker-start`](/fr/docs/Web/SVG/Attribute/marker-start)) ou l'élément [`<marker>`](/fr/docs/Web/SVG/Element/marker). Les marqueurs ne sont pas appliqués sur le texte HTML, dans ce cas, seul l'ordre entre `stroke` et `fill` importe.
+> [!NOTE]
+> Pour cette propriété, les marqueurs sont uniquement utilisés dans le cas de formes SVG qui utilisent les propriétés `marker-*` (e.g. [`marker-start`](/fr/docs/Web/SVG/Attribute/marker-start)) ou l'élément [`<marker>`](/fr/docs/Web/SVG/Element/marker). Les marqueurs ne sont pas appliqués sur le texte HTML, dans ce cas, seul l'ordre entre `stroke` et `fill` importe.
 
 ### Valeurs
 

--- a/files/fr/web/css/percentage/index.md
+++ b/files/fr/web/css/percentage/index.md
@@ -9,7 +9,8 @@ Le type de données CSS **`<percentage>`** représente une valeur exprimée en p
 
 De nombreuses propriétés CSS utilisent des pourcentages : {{cssxref("width")}}, {{cssxref("margin")}}, {{cssxref("padding")}}, etc.. Les pourcentages peuvent aussi être vus avec {{cssxref("font-size")}}, où la taille du texte est directement en relation avec celle de son parent.
 
-> **Note :** Seules les valeurs calculées sont héritées. Ainsi, même si une valeur en pourcentage est utilisée sur la propriété parent, une valeur réelle, comme une largeur en pixel pour une valeur {{cssxref("&lt;length&gt;")}}, sera accessible sur la propriété héritée, pas la valeur en pourcentage.
+> [!NOTE]
+> Seules les valeurs calculées sont héritées. Ainsi, même si une valeur en pourcentage est utilisée sur la propriété parent, une valeur réelle, comme une largeur en pixel pour une valeur {{cssxref("&lt;length&gt;")}}, sera accessible sur la propriété héritée, pas la valeur en pourcentage.
 
 ## Syntaxe
 

--- a/files/fr/web/css/place-content/index.md
+++ b/files/fr/web/css/place-content/index.md
@@ -38,7 +38,8 @@ place-content: unset;
 
 La première valeur utilisée sera celle qui correspond à {{cssxref("align-content")}} et la seconde valeur correspondra à {{cssxref("justify-content")}}. Si la deuxième valeur n'est pas présente, la première valeur indiquée sera également utilisée pour `justify-content`.
 
-> **Attention :** Si une seule valeur est fournie et que celle-ci est invalide pour l'une ou l'autre des propriétés détaillées, c'est la déclaration entière qui sera invalide.
+> [!WARNING]
+> Si une seule valeur est fournie et que celle-ci est invalide pour l'une ou l'autre des propriétés détaillées, c'est la déclaration entière qui sera invalide.
 
 ### Valeurs
 

--- a/files/fr/web/css/position_value/index.md
+++ b/files/fr/web/css/position_value/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/position_value
 
 Le type de donnée [CSS](/fr/docs/Web/CSS) **`<position>`** (ou **`<bg-position>`**) définit une paire de coordonnées dans l'espace (bidimensionnel) afin de définir la position relative d'une boîte. Ce type de donnée est notamment utilisé avec les propriétés [`background-position`](/fr/docs/Web/CSS/background-position) et [`offset-anchor`](/fr/docs/Web/CSS/offset-anchor).
 
-> **Note :** La position finale obtenue, décrite par la valeur `<position>`, n'est pas nécessairement située à l'intérieur de la boîte de l'élément.
+> [!NOTE]
+> La position finale obtenue, décrite par la valeur `<position>`, n'est pas nécessairement située à l'intérieur de la boîte de l'élément.
 
 ## Syntaxe
 
@@ -52,7 +53,8 @@ mot-clé valeur mot-clé valeur /* Chaque valeur indique le décalage par rappor
 ]
 ```
 
-> **Note :** La propriété [`background-position`](/fr/docs/Web/CSS/background-position) accepte également une syntaxe avec trois valeurs. Celle-ci n'est pas autorisée pour les autres propriétés qui utilisent une valeur `<position>`.
+> [!NOTE]
+> La propriété [`background-position`](/fr/docs/Web/CSS/background-position) accepte également une syntaxe avec trois valeurs. Celle-ci n'est pas autorisée pour les autres propriétés qui utilisent une valeur `<position>`.
 
 ## Interpolation
 

--- a/files/fr/web/css/pseudo-classes/index.md
+++ b/files/fr/web/css/pseudo-classes/index.md
@@ -15,7 +15,8 @@ div:hover {
 
 Les pseudo-classes permettent d'appliquer un style à un élément non seulement en fonction de son contenu dans l'arbre du document mais aussi en fonction de facteurs externes (l'historique de navigation par exemple avec {{cssxref(":visited")}} ; le statut du contenu avec {{cssxref(":checked")}} ; la position de la souris {{cssxref(":hover")}}).
 
-> **Note :** À la différence des pseudo-classes, [les pseudo-éléments](/fr/docs/Web/CSS/Pseudo-éléments) peuvent être utilisés afin d'appliquer un style sur une certaine partie d'un élément.
+> [!NOTE]
+> À la différence des pseudo-classes, [les pseudo-éléments](/fr/docs/Web/CSS/Pseudo-éléments) peuvent être utilisés afin d'appliquer un style sur une certaine partie d'un élément.
 
 ## Syntaxe
 

--- a/files/fr/web/css/pseudo-elements/index.md
+++ b/files/fr/web/css/pseudo-elements/index.md
@@ -15,7 +15,8 @@ p::first-line {
 }
 ```
 
-> **Note :** À la différence des pseudo-éléments, [les pseudo-classes](/fr/docs/Web/CSS/Pseudo-classes) peuvent être utilisées afin de mettre en forme un élément en fonction de son état.
+> [!NOTE]
+> À la différence des pseudo-éléments, [les pseudo-classes](/fr/docs/Web/CSS/Pseudo-classes) peuvent être utilisées afin de mettre en forme un élément en fonction de son état.
 
 ## Syntaxe
 

--- a/files/fr/web/css/reference/index.md
+++ b/files/fr/web/css/reference/index.md
@@ -51,7 +51,8 @@ Comme la structure des règles @ varie grandement, veuillez consulter [règle @]
 
 ## Index des mots-clés
 
-> **Note :** Les noms de propriétés de cet index n'incluent **pas** les [noms de l'API DOM JavaScript](/fr/docs/Web/CSS/CSS_Properties_Reference) lorsqu'ils sont différents des noms standards CSS.
+> [!NOTE]
+> Les noms de propriétés de cet index n'incluent **pas** les [noms de l'API DOM JavaScript](/fr/docs/Web/CSS/CSS_Properties_Reference) lorsqu'ils sont différents des noms standards CSS.
 
 {{CSS_Ref}}
 
@@ -96,7 +97,7 @@ Les combinateurs sont des sélecteurs qui établissent une relation entre deux s
 - [Pseudo-éléments](/fr/docs/Web/CSS/Pseudo-elements) `::`
   - : Représente des entités qui ne sont pas incluses en HTML.
 
-> **Remarque :**
+> [!CALLOUT]
 >
 > See also [Selectors in the Selectors Level 4 specification](https://www.w3.org/TR/selectors/#overview).
 

--- a/files/fr/web/css/resolution/index.md
+++ b/files/fr/web/css/resolution/index.md
@@ -26,7 +26,8 @@ Bien que toutes les unités représentent la même chose pour la valeur `0`, l'u
 - `x`
   - : Un alias pour `dppx`.
 
-> **Note :** Bien que le nombre `0` représente la même mesure pour ces différentes unités. Si la valeur est écrite sans unité, elle sera considérée comme invalide. Autrement dit, `0` est invalide et ne représente pas `0dpi`, `0dpcm` ou `0dppx`.
+> [!NOTE]
+> Bien que le nombre `0` représente la même mesure pour ces différentes unités. Si la valeur est écrite sans unité, elle sera considérée comme invalide. Autrement dit, `0` est invalide et ne représente pas `0dpi`, `0dpcm` ou `0dppx`.
 
 ## Exemples
 

--- a/files/fr/web/css/revert/index.md
+++ b/files/fr/web/css/revert/index.md
@@ -21,7 +21,8 @@ Le mot-clé `revert` fonctionne comme `unset` pour de nombreux cas. Les seules d
 
 > **Note :** `revert` est une simple valeur, il est toujours possible de la surcharger par une autre avec une règle d'une [spécificité](/fr/docs/Apprendre/CSS/Introduction_à_CSS/La_cascade_et_l_héritage#Spécificité) supérieure.
 
-> **Note :** Le mot-clé `revert` est différent de {{cssxref("initial")}} et ne doit pas être confondu avec ce dernier. {{cssxref("initial")}} utilise [la valeur initiale](/fr/docs/Web/CSS/Valeur_initiale), définie pour chaque propriété par les spécifications CSS. En revanche, les feuilles de style des agents utilisateurs définissent des valeurs par défaut selon les sélecteurs CSS. Par exemple, [la valeur initiale](/fr/docs/Web/CSS/Valeur_initiale) de {{cssxref("display")}} est `inline` mais un agent utilisateur pourra définir les valeurs par défaut suivante dans sa feuille de style : `block` pour {{HTMLElement("div")}}, `table` pour {{HTMLElement("table")}} etc.
+> [!NOTE]
+> Le mot-clé `revert` est différent de {{cssxref("initial")}} et ne doit pas être confondu avec ce dernier. {{cssxref("initial")}} utilise [la valeur initiale](/fr/docs/Web/CSS/Valeur_initiale), définie pour chaque propriété par les spécifications CSS. En revanche, les feuilles de style des agents utilisateurs définissent des valeurs par défaut selon les sélecteurs CSS. Par exemple, [la valeur initiale](/fr/docs/Web/CSS/Valeur_initiale) de {{cssxref("display")}} est `inline` mais un agent utilisateur pourra définir les valeurs par défaut suivante dans sa feuille de style : `block` pour {{HTMLElement("div")}}, `table` pour {{HTMLElement("table")}} etc.
 
 ## Exemples
 

--- a/files/fr/web/css/scaling_of_svg_backgrounds/index.md
+++ b/files/fr/web/css/scaling_of_svg_backgrounds/index.md
@@ -62,7 +62,8 @@ Cette image n'indique pas de hauteur ou de largeur mais un ratio intrinsèque de
 
 Appliquons maintenant différents redimensionnements sur ces images. Pour chacun des exemples qui suivent, les rectangles dessinés font 300 pixels de large et 200 pixels de haut. De plus, on utilise {{cssxref("background-repeat")}} avec `no-repeat` pour plus de clarté..
 
-> **Note :** Les images montrées ci-après illustrent le rendu **attendu**. Les navigateurs peuvent ne pas produire le bon résultat.
+> [!NOTE]
+> Les images montrées ci-après illustrent le rendu **attendu**. Les navigateurs peuvent ne pas produire le bon résultat.
 
 ### Indiquer des dimensions fixées sur les deux axes
 

--- a/files/fr/web/css/scrollbar-color/index.md
+++ b/files/fr/web/css/scrollbar-color/index.md
@@ -72,9 +72,11 @@ scrollbar-color: unset;
       </tbody>
     </table>
 
-    > **Note :** Pour toute valeur de `scrollbar-color`, les agents utilisateur doivent appliquer la valeur sur l'élément racine de la zone d'affichage (_viewport_).
+    > [!NOTE]
+    > Pour toute valeur de `scrollbar-color`, les agents utilisateur doivent appliquer la valeur sur l'élément racine de la zone d'affichage (_viewport_).
 
-    > **Note :** Si la couleur d'une partie de la barre de défilement est indiquée, les implémentations peuvent afficher une barre de défilement simple (plutôt que celle provenant du système) afin de la colorer avec la/les couleur(s) indiquée(s).
+    > [!NOTE]
+    > Si la couleur d'une partie de la barre de défilement est indiquée, les implémentations peuvent afficher une barre de défilement simple (plutôt que celle provenant du système) afin de la colorer avec la/les couleur(s) indiquée(s).
 
 ## Définition formelle
 

--- a/files/fr/web/css/scrollbar-width/index.md
+++ b/files/fr/web/css/scrollbar-width/index.md
@@ -57,9 +57,11 @@ scrollbar-width: unset;
       </tbody>
     </table>
 
-    > **Note :** Toute valeur de `scrollbar-width` doit être appliquée sur l'élément racine de la zone d'affichage (_viewport_) par les agents utilisateur.
+    > [!NOTE]
+    > Toute valeur de `scrollbar-width` doit être appliquée sur l'élément racine de la zone d'affichage (_viewport_) par les agents utilisateur.
 
-    > **Note :** L'utilisation des longueurs pour `scrollbar-width` est une fonctionnalité qui sera potentiellement abandonnée de la spécification (voir [l'_issue_ 1958](https://github.com/w3c/csswg-drafts/issues/1958)).
+    > [!NOTE]
+    > L'utilisation des longueurs pour `scrollbar-width` est une fonctionnalité qui sera potentiellement abandonnée de la spécification (voir [l'_issue_ 1958](https://github.com/w3c/csswg-drafts/issues/1958)).
 
 ## Définition formelle
 

--- a/files/fr/web/css/shorthand_properties/index.md
+++ b/files/fr/web/css/shorthand_properties/index.md
@@ -96,7 +96,8 @@ background: #000 url(images/bg.gif) no-repeat left top;
 
 Voir [`background`](/fr/docs/Web/CSS/background) pour plus d'informations.
 
-> **Note :** La forme raccourcie correspond plus précisément aux propriétés détaillées indiquées ici avec également, `background-attachment: scroll` et d'autres propriétés supplémentaires.
+> [!NOTE]
+> La forme raccourcie correspond plus précisément aux propriétés détaillées indiquées ici avec également, `background-attachment: scroll` et d'autres propriétés supplémentaires.
 
 ## Propriétés typographiques
 
@@ -120,7 +121,8 @@ font:
 
 Voir [`font`](/fr/docs/Web/CSS/font) pour plus d'informations sur cette propriété.
 
-> **Note :** Cette déclaration raccourcie avec [`font`](/fr/docs/Web/CSS/font) est en réalité équivalente aux déclarations détaillées présentes ici, avec en plus `font-variant: normal`, `font-size-adjust: none`, et `font-stretch: normal`.
+> [!NOTE]
+> Cette déclaration raccourcie avec [`font`](/fr/docs/Web/CSS/font) est en réalité équivalente aux déclarations détaillées présentes ici, avec en plus `font-variant: normal`, `font-size-adjust: none`, et `font-stretch: normal`.
 
 ## Propriétés pour les bordures
 

--- a/files/fr/web/css/string/index.md
+++ b/files/fr/web/css/string/index.md
@@ -17,7 +17,8 @@ Les nouvelles lignes ne sont pas acceptées, sauf si elles sont échappées à l
 
 Les caractères peuvent être décrits en utilisant leur [point de code Unicode](https://fr.wikipedia.org/wiki/Unicode#Partitionnement) hexadécimal, qui doit alors être échappé à l'aide du caractère `\`. `\27` représente par exemple le guillemet droit simple (`'`) et `\A9` le symbole du _copyright_ ©.
 
-> **Note :** Les [entités](/fr/docs/Glossary/Entity) telles que `&nbsp;` ou `&#8212;` ne peuvent pas être utilisées pour les chaînes de caractères CSS.
+> [!NOTE]
+> Les [entités](/fr/docs/Glossary/Entity) telles que `&nbsp;` ou `&#8212;` ne peuvent pas être utilisées pour les chaînes de caractères CSS.
 
 ## Exemples
 
@@ -34,7 +35,8 @@ de caractères"
 "Une grande chaîne de caractères"
 ```
 
-> **Note :** on peut également échapper des doubles quotes avec `\22` et les simples quotes avec `\27`.
+> [!NOTE]
+> On peut également échapper des doubles quotes avec `\22` et les simples quotes avec `\27`.
 
 ## Spécifications
 

--- a/files/fr/web/css/syntax/index.md
+++ b/files/fr/web/css/syntax/index.md
@@ -34,7 +34,8 @@ Un bloc de déclaration CSS est visualisé dans le schéma ci-dessous.
 
 ![css syntax - declarations block.png](declaration-block.png)
 
-> **Note :** Le contenu d'un bloc de déclaration CSS, c'est-à-dire une liste de déclarations séparées par des points-virgules, sans les accolades d'ouverture et de fermeture, peut être placé dans un attribut HTML [`style`](/fr/docs/Web/HTML/Global_attributes#attr-style).
+> [!NOTE]
+> Le contenu d'un bloc de déclaration CSS, c'est-à-dire une liste de déclarations séparées par des points-virgules, sans les accolades d'ouverture et de fermeture, peut être placé dans un attribut HTML [`style`](/fr/docs/Web/HTML/Global_attributes#attr-style).
 
 ## Ensembles de règles CSS
 
@@ -48,7 +49,8 @@ Une règle CSS est visualisé dans le diagramme ci-dessous.
 
 Comme un élément de la page peut correspondre à plusieurs sélecteurs, et donc par plusieurs règles contenant potentiellement plusieurs fois une même propriété, avec des valeurs différentes, la norme CSS définit laquelle a priorité sur l'autre et doit être appliquée&nbsp;: c'est ce qu'on appelle la [cascade](/fr/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance).
 
-> **Note :** Même si on peut utiliser une règle utilisant un groupe de sélecteurs afin d'éviter de dupliquer une même règle pour chaque sélecteur distinct de ce groupe, cela n'a pas exactement le même effet. En effet, si on utilise un groupe de sélecteurs contenant un sélecteur invalide, c'est tout le groupe qui sera invalide et la règle sera ignoré. Si on utilise plusieurs règles pour chacun des sélecteurs individuels, seule celle du sélecteur invalide ne sera pas appliquée.
+> [!NOTE]
+> Même si on peut utiliser une règle utilisant un groupe de sélecteurs afin d'éviter de dupliquer une même règle pour chaque sélecteur distinct de ce groupe, cela n'a pas exactement le même effet. En effet, si on utilise un groupe de sélecteurs contenant un sélecteur invalide, c'est tout le groupe qui sera invalide et la règle sera ignoré. Si on utilise plusieurs règles pour chacun des sélecteurs individuels, seule celle du sélecteur invalide ne sera pas appliquée.
 
 ## Instructions CSS
 

--- a/files/fr/web/css/text-decoration-color/index.md
+++ b/files/fr/web/css/text-decoration-color/index.md
@@ -11,11 +11,13 @@ La propriété raccourcie {{cssxref("text-decoration")}} permet de paramétrer c
 
 {{EmbedInteractiveExample("pages/css/text-decoration-color.html")}}
 
-> **Note :** Lorsqu'on définit plusieurs décorations à la fois, il peut être plus pratique d'utiliser la propriété raccourcie {{cssxref("text-decoration")}}.
+> [!NOTE]
+> Lorsqu'on définit plusieurs décorations à la fois, il peut être plus pratique d'utiliser la propriété raccourcie {{cssxref("text-decoration")}}.
 
 Il est préférable d'utiliser cette propriété pour colorer ces décorations plutôt que d'utiliser d'autres éléments HTML.
 
-> **Note :** CSS ne fournit pas de mécanisme spécifique pour définir une couleur par type de ligne. On peut toutefois y parvenir en imbriquant des éléments mis en forme différemment.
+> [!NOTE]
+> CSS ne fournit pas de mécanisme spécifique pour définir une couleur par type de ligne. On peut toutefois y parvenir en imbriquant des éléments mis en forme différemment.
 
 ## Syntaxe
 

--- a/files/fr/web/css/text-decoration-skip/index.md
+++ b/files/fr/web/css/text-decoration-skip/index.md
@@ -26,7 +26,8 @@ text-decoration-skip: initial;
 text-decoration-skip: unset;
 ```
 
-> **Note :** La valeur `ink` initialement définie pour cette propriété a été déplacée vers la propriété {{cssxref("text-decoration-skip-ink")}}.
+> [!NOTE]
+> La valeur `ink` initialement définie pour cette propriété a été déplacée vers la propriété {{cssxref("text-decoration-skip-ink")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/css/text-decoration-style/index.md
+++ b/files/fr/web/css/text-decoration-style/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/text-decoration-style
 
 La propriété **`text-decoration-style`** définit le style appliqué sur les lignes visées par {{cssxref("text-decoration-line")}}. Le style s'applique à toutes les lignes définies avec `text-decoration-line`.
 
-> **Note :** Il n'existe pas de méthode permettant de mettre en forme les lignes décorées différemment les unes des autres.
+> [!NOTE]
+> Il n'existe pas de méthode permettant de mettre en forme les lignes décorées différemment les unes des autres.
 
 {{EmbedInteractiveExample("pages/css/text-decoration-style.html")}}
 

--- a/files/fr/web/css/text-decoration/index.md
+++ b/files/fr/web/css/text-decoration/index.md
@@ -9,7 +9,8 @@ La propriété **`text-decoration`** est utilisée pour « décorer » le texte 
 
 {{EmbedInteractiveExample("pages/css/text-decoration.html")}}Ces décorations se propagent sur les différents éléments enfants. Cela signifie qu'il n'est pas possible de désactiver la décoration d'un élément descendant pour lequel un ancêtre est décoré. Par exemple, avec ce fragment de HTML `<p>Ce texte a <em> des mots mis en avant</em> dedans.</p>`, et cette règle CSS `p { text-decoration: underline; }`, on aura tout le paragraphe souligné, même si on applique la règle `em { text-decoration: none; }`, cela n'aurait aucun impact. En revanche, ajouter la règle `em { text-decoration: overline; }` entraînerait un cumul des décorations pour « des mots mis en avant ».
 
-> **Note :** La spécification CSS Text Decoration de niveau 3 indique que cette propriété est une propriété raccourcie pour les trois propriétés {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-line")}} et {{cssxref("text-decoration-style")}}. Comme pour les autres propriétés raccourcies, cela signifie que la valeur de chaque « sous-propriété » est réinitialisée avec sa valeur par défaut si elle n'est pas explicitement définie dans la propriété raccourcie.
+> [!NOTE]
+> La spécification CSS Text Decoration de niveau 3 indique que cette propriété est une propriété raccourcie pour les trois propriétés {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-line")}} et {{cssxref("text-decoration-style")}}. Comme pour les autres propriétés raccourcies, cela signifie que la valeur de chaque « sous-propriété » est réinitialisée avec sa valeur par défaut si elle n'est pas explicitement définie dans la propriété raccourcie.
 
 ## Syntaxe
 

--- a/files/fr/web/css/text-emphasis-position/index.md
+++ b/files/fr/web/css/text-emphasis-position/index.md
@@ -83,7 +83,8 @@ La position des marques d'emphase varie en fonction du langage. Par exemple, en 
   </tbody>
 </table>
 
-> **Note :** La propriété `text-emphasis-position` ne peut pas être définie (et donc ne peut pas être redéfinie) avec la propriété raccourcie {{cssxref("text-emphasis")}}.
+> [!NOTE]
+> La propriété `text-emphasis-position` ne peut pas être définie (et donc ne peut pas être redéfinie) avec la propriété raccourcie {{cssxref("text-emphasis")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/css/text-rendering/index.md
+++ b/files/fr/web/css/text-rendering/index.md
@@ -22,7 +22,8 @@ text-rendering: initial;
 text-rendering: unset;
 ```
 
-> **Note :** La propriété `text-rendering` est une propriété SVG qui n'est définie dans aucun standard CSS. Toutefois, les navigateurs utilisant Gecko et WebKit permettent d'appliquer cette propriété à du contenu HTML ou XML sur Windows, Mac OS X et Linux.
+> [!NOTE]
+> La propriété `text-rendering` est une propriété SVG qui n'est définie dans aucun standard CSS. Toutefois, les navigateurs utilisant Gecko et WebKit permettent d'appliquer cette propriété à du contenu HTML ou XML sur Windows, Mac OS X et Linux.
 
 Un effet très visible est : `text-rendering : optimizeLegibility;` qui active les ligatures (ff, fi, fl etc.) dans les textes en dessous de 20px pour certains polices (par exemple, _Calibri, Candara, Constantia_ et _Corbel_ de Microsoft, ou la famille _DejaVu_).
 

--- a/files/fr/web/css/text-transform/index.md
+++ b/files/fr/web/css/text-transform/index.md
@@ -44,7 +44,8 @@ text-transform: unset;
 
   - : En utilisant ce mot-clé, la première lettre de chaque mot sera affichée en capitale. Les autres caractères ne seront pas modifiés et conserveront ainsi la forme originale, contenue dans le texte de l'élément. Ici, une lettre peut être n'importe quel caractère Unicode qui fait partie des catégories génériques Lettre. Cela exclue donc les symboles de ponctuations qui peuvent être utilisés en début de mot.
 
-    > **Note :** Le mot-clé capitalize n'était pas complètement spécifié avec CSS 1 et CSS 2.1. Il y avait certaines différences entre les navigateurs : Firefox considèrait que - et \_ étaient des lettres ; Webkit et Gecko considéraient que les symboles lettrés comme ⓐ étaient de vraies lettres ; Internet Explorer 9 était le plus proche de la définition donnée par CSS2 mais il y avait certains cas étranges. Grâce à CSS Text Level 3, ces ambiguités sont levées. Dans le tableau, la ligne capitalize traduit le support de cette spécification.
+    > [!NOTE]
+    > Le mot-clé capitalize n'était pas complètement spécifié avec CSS 1 et CSS 2.1. Il y avait certaines différences entre les navigateurs : Firefox considèrait que - et \_ étaient des lettres ; Webkit et Gecko considéraient que les symboles lettrés comme ⓐ étaient de vraies lettres ; Internet Explorer 9 était le plus proche de la définition donnée par CSS2 mais il y avait certains cas étranges. Grâce à CSS Text Level 3, ces ambiguités sont levées. Dans le tableau, la ligne capitalize traduit le support de cette spécification.
 
 - `uppercase`
   - : En utilisant ce mot-clé, tous les caractères seront écrits en capitales.

--- a/files/fr/web/css/touch-action/index.md
+++ b/files/fr/web/css/touch-action/index.md
@@ -32,7 +32,8 @@ On utilise parfois cette propriété pour désactiver les interactions tactiles 
 
 Lorsqu'une interaction tactile a lieu, le navigateur inspecte les valeurs de `touch-action` pour l'élément et ses ancêtres jusqu'à atteindre l'élément qui implémente le geste (c'est-à-dire celui qui peut défiler/zoomer). En pratique, `touch-action` est généralement uniquement appliquée aux éléments de plus haut niveau ayant besoin d'un comportement spécifique. Il n'est pas nécessaire de redéfinir `touch-action` sur les descendants.
 
-> **Note :** Lorsqu'un geste est déjà initié, tout changement sur `touch-action` n'aura aucun impact sur le geste en cours.
+> [!NOTE]
+> Lorsqu'un geste est déjà initié, tout changement sur `touch-action` n'aura aucun impact sur le geste en cours.
 
 ## Syntaxe
 
@@ -100,7 +101,8 @@ ul > li {
 
 {{EmbedLiveSample('Exemples')}}
 
-> **Note :** La propriété `touch-action` est également utilisée afin de supprimer le délai donné à l'évènement `click` pour prendre en charge le zoom via la double-touche.
+> [!NOTE]
+> La propriété `touch-action` est également utilisée afin de supprimer le délai donné à l'évènement `click` pour prendre en charge le zoom via la double-touche.
 
 ## Accessibilité
 


### PR DESCRIPTION
This PR converts the noteblocks for the French locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 14. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
