### PR TITLE
fr: Convert noteblocks to GFM Alerts (part 16)

### DIFF
--- a/files/fr/web/html/element/meta/name/index.md
+++ b/files/fr/web/html/element/meta/name/index.md
@@ -15,7 +15,7 @@ La spécification HTML définit les noms de métadonnées standard suivants&nbsp
 
   - : Le nom de l'application qui s'exécute sur la page web.
 
-    > **Note :**
+    > [!NOTE]
     >
     > - Les navigateurs peuvent utiliser cette information pour identifier l'application. Cette métadonnée est différente de celle fournie par [`<title>`](/fr/docs/Web/HTML/Element/title) qui comprend généralement le nom de l'application, mais qui peut aussi contenir le nom du document ou un état.
     > - Les pages web simples ne devraient pas utiliser `application-name`.
@@ -70,7 +70,7 @@ La spécification HTML définit les noms de métadonnées standard suivants&nbsp
       </tbody>
     </table>
 
-    > **Note :**
+    > [!NOTE]
     >
     > - L'insertion dynamique d'un élément `<meta name="referrer">` (en utilisant [`document.write()`](/fr/docs/Web/API/Document/write) ou [`appendChild()`](/fr/docs/Web/API/Node/appendChild)) rendra imprévisible le comportement du référent.
     > - Lorsque plusieurs règles contradictoires sont définies, c'est la règle `no-referrer` qui est appliquée.
@@ -196,7 +196,7 @@ Désactiver la possibilité de zoomer en utilisant `user-scalable` avec la valeu
     | `noimageindex` | Demande à ce que cette page n'apparaisse pas comme page référente d'une image indexée.        | [Google](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag)                                                                                                                                                                    |
     | `nocache`      | Synonyme de `noarchive`.                                                                      | [Bing](https://www.bing.com/webmasters/help/which-robots-metatags-does-bing-support-5198d240)                                                                                                                                                          |
 
-  > **Note :**
+  > [!NOTE]
   >
   > - Ces règles ne sont pas contraignantes dans l'absolu. Seuls les robots suivants les bonnes pratiques les respecteront. Il ne faut pas s'attendre à ce qu'un acteur malveillant les suive.
   > - Le robot doit avoir accès à la page afin de lire ces règles. Pour éviter une consommation de bande passante, utilisez un fichier [`robots.txt`](/fr/docs/Glossary/Robots.txt).

--- a/files/fr/web/html/element/meter/index.md
+++ b/files/fr/web/html/element/meter/index.md
@@ -29,7 +29,8 @@ Comme pour les autres éléments HTML, cet élément inclut également [les attr
 
   - : Cette attribut représente la valeur courante de la mesure. Cet attribut est obligatoire.
 
-    > **Note :** il est recommandé aux auteurs de dupliquer les valeurs des attributs **`min`,** **`max`** et **`value`** dans le contenu de cet élément de façon à permettre aux navigateurs ne supportant pas l'élément {{ HTMLElement("meter") }} de transmettre ces informations aux utilisateurs. Par exemple :
+    > [!NOTE]
+    > Il est recommandé aux auteurs de dupliquer les valeurs des attributs **`min`,** **`max`** et **`value`** dans le contenu de cet élément de façon à permettre aux navigateurs ne supportant pas l'élément {{ HTMLElement("meter") }} de transmettre ces informations aux utilisateurs. Par exemple :
     >
     > ```html
     > Utilisation de l'espace de stockage:

--- a/files/fr/web/html/element/nobr/index.md
+++ b/files/fr/web/html/element/nobr/index.md
@@ -7,7 +7,8 @@ slug: Web/HTML/Element/nobr
 
 L'élément HTML **`<nobr>`** évite qu'un texte soit coupé par un retour à la ligne automatique ; il est donc affiché sur une seule ligne. Il peut être alors nécessaire d'utiliser les barres de défilement pour lire le texte en intégralité.
 
-> **Attention :** Cet élément n'est pas standard en HTML et ne doit donc pas être utilisé. **C'est la propriété CSS {{cssxref("white-space")}} doit être utilisée à la place**, de cette manière :
+> [!WARNING]
+> Cet élément n'est pas standard en HTML et ne doit donc pas être utilisé. **C'est la propriété CSS {{cssxref("white-space")}} doit être utilisée à la place**, de cette manière :
 
 ```html
 <span style="white-space: nowrap">Un texte long sans retour à la ligne.</span>

--- a/files/fr/web/html/element/noembed/index.md
+++ b/files/fr/web/html/element/noembed/index.md
@@ -8,7 +8,8 @@ slug: Web/HTML/Element/noembed
 L'élément **`<noembed>`** est une façon obsolète et non standardisée de fournir une alternative de contenu pour les navigateurs ne supportant pas l'élément {{HTMLElement("embed")}} ou des [catégories de contenu](/fr/docs/Web/HTML/Catégorie_de_contenu) qu'un auteur aimerait utiliser.
 Cet élément a été rendu obsolète à partir de la version HTML 4.01 et a été remplacé par {{HTMLElement("object")}}. Le contenu alternatif doit être inséré entre la balise d'ouverture et celle de fermeture de {{HTMLElement("object")}}
 
-> **Note :** Bien que cet élément soit toujours supporté dans plusieurs navigateurs, il a été rendu obsolète et ne devrait pas être utilisé. Utilisez plutôt {{HTMLElement("object")}}
+> [!NOTE]
+> Bien que cet élément soit toujours supporté dans plusieurs navigateurs, il a été rendu obsolète et ne devrait pas être utilisé. Utilisez plutôt {{HTMLElement("object")}}
 
 ## Spécifications
 

--- a/files/fr/web/html/element/noframes/index.md
+++ b/files/fr/web/html/element/noframes/index.md
@@ -11,7 +11,8 @@ L'élément HTML obsolète **`<noframes>`** est utilisé par les navigateurs qui
 
 Cet élément pouvait être utilisé afin d'afficher un message explicatif, destiné à l'utilisateur. Idéalement, le contenu devait présenter des fonctionnalités analogues à la _frame_ qui n'était pas prise en charge.
 
-> **Note :** Cet élément est aussi entièrement obsolète en HTML5, et doit être evité pour se conformer au standard.
+> [!NOTE]
+> Cet élément est aussi entièrement obsolète en HTML5, et doit être evité pour se conformer au standard.
 
 ## Attributs
 

--- a/files/fr/web/html/element/ol/index.md
+++ b/files/fr/web/html/element/ol/index.md
@@ -122,7 +122,8 @@ L'élément HTML **`<ol>`** représente une liste ordonnée. Les éléments d'un
 
     Le type spécifié est utilisé pour l'ensemble de la liste, sauf si un attribut différent [`type`](/fr/docs/Web/HTML/Element/li#attr-type) est utilisé sur un élément [`<li>`](/fr/docs/Web/HTML/Element/li) fermé.
 
-    > **Note :** À moins que le type du numéro de la liste n'ait de l'importance (comme dans les documents juridiques ou techniques où les éléments sont référencés par leur numéro/lettre), utilisez plutôt la propriété CSS [`list-style-type`](/fr/docs/Web/CSS/list-style-type).
+    > [!NOTE]
+    > À moins que le type du numéro de la liste n'ait de l'importance (comme dans les documents juridiques ou techniques où les éléments sont référencés par leur numéro/lettre), utilisez plutôt la propriété CSS [`list-style-type`](/fr/docs/Web/CSS/list-style-type).
 
 ## Note d'utilisation
 

--- a/files/fr/web/html/element/optgroup/index.md
+++ b/files/fr/web/html/element/optgroup/index.md
@@ -9,7 +9,8 @@ L'élément HTML **`<optgroup>`**, utilisé dans un formulaire, permet de créer
 
 {{EmbedInteractiveExample("pages/tabbed/optgroup.html", "tabbed-standard")}}
 
-> **Note :** Il n'est pas possible d'imbriquer plusieurs éléments `<optgroup>` entre eux.
+> [!NOTE]
+> Il n'est pas possible d'imbriquer plusieurs éléments `<optgroup>` entre eux.
 
 ## Attributs
 

--- a/files/fr/web/html/element/output/index.md
+++ b/files/fr/web/html/element/output/index.md
@@ -103,7 +103,8 @@ Le formulaire qui suit fournit un curseur dont la valeur peut aller de 0 à 100 
 
 {{Compat}}
 
-> **Note :** La plupart des navigateurs implémente cet élément comme s'il avait l'attribut `aria-live` par défaut. Les outils d'assistance annonceront donc les résultats des interactions avec l'interface utilisateur qui arrivent sur cet élément sans demander à avoir passé le focus depuis un autre contrôle. Toutefois, ce comportement n'est pas précisément décrit dans les spécifications actuelles.
+> [!NOTE]
+> La plupart des navigateurs implémente cet élément comme s'il avait l'attribut `aria-live` par défaut. Les outils d'assistance annonceront donc les résultats des interactions avec l'interface utilisateur qui arrivent sur cet élément sans demander à avoir passé le focus depuis un autre contrôle. Toutefois, ce comportement n'est pas précisément décrit dans les spécifications actuelles.
 
 ## Voir aussi
 

--- a/files/fr/web/html/element/p/index.md
+++ b/files/fr/web/html/element/p/index.md
@@ -11,13 +11,15 @@ L'élément HTML **`<p>`** représente un paragraphe de texte. Les paragraphes s
 
 Étant des éléments de bloc, les paragraphes se fermeront automatiquement si un autre élément de bloc est analysé avant la balise de fermeture `</p>` (voir Omission de balises dans le tableau qui suit).
 
-> **Note :** Pour modifier l'espacement entre les paragraphes, il faudra utiliser la propriété CSS {{cssxref("margin")}}. _Il ne faut pas insérer de paragraphes vides ou d'éléments {{HTMLElement("br")}} afin de créer un espace_.
+> [!NOTE]
+> Pour modifier l'espacement entre les paragraphes, il faudra utiliser la propriété CSS {{cssxref("margin")}}. _Il ne faut pas insérer de paragraphes vides ou d'éléments {{HTMLElement("br")}} afin de créer un espace_.
 
 ## Attributs
 
 Cet élément, comme les autres éléments HTML, inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_universels).
 
-> **Note :** L'attribut `align` pour les balises `<p>` est obsolète et ne doit plus être utilisé.
+> [!NOTE]
+> L'attribut `align` pour les balises `<p>` est obsolète et ne doit plus être utilisé.
 
 ## Exemples
 

--- a/files/fr/web/html/element/picture/index.md
+++ b/files/fr/web/html/element/picture/index.md
@@ -26,7 +26,8 @@ Cet élément inclut uniquement [les attributs universels](/fr/docs/Web/HTML/Att
 
 Il est possible d'utiliser la propriété CSS {{cssxref("object-position")}} afin d'ajuster le positionnement de l'image dans le cadre de l'élément. La propriété {{cssxref("object-fit")}} permet quant à elle de contrôler la façon dont la taille de l'image est ajustée.
 
-> **Note :** Ces propriétés doivent être utilisées sur les éléments `<img>` fils et pas sur l'élément `<picture>`.
+> [!NOTE]
+> Ces propriétés doivent être utilisées sur les éléments `<img>` fils et pas sur l'élément `<picture>`.
 
 ## Exemples
 

--- a/files/fr/web/html/element/plaintext/index.md
+++ b/files/fr/web/html/element/plaintext/index.md
@@ -7,7 +7,8 @@ slug: Web/HTML/Element/plaintext
 
 L'élément HTML **`<plaintext>`** permet d'afficher du texte qui n'est pas interprété comme du HTML. Il ne possède pas de balise de fermeture, car tout ce qui suit n'est plus considéré comme du HTML.
 
-> **Note :** Ne pas utiliser cet élément.
+> [!NOTE]
+> Ne pas utiliser cet élément.
 >
 > - Il est déprécié depuis HTML 2, et n'a jamais été implementé par tous les navigateurs d'une manière cohérente. De plus, il est obsolète depuis HTML5, et pourra être rendu par les agents-utilisateurs qui l'acceptent comme un élément {{HTMLElement("pre")}}, qui interprètera le HTML contenu même si ce n'est pas ce qui est souhaité !
 > - Si l'élément {{HTMLElement("plaintext")}} est le premier élément de la page (sauf éléments non affichés), n'utilisez pas de HTML. Configurez votre serveur pour servir la page avec le [type MIME](/fr/docs/Properly_Configuring_Server_MIME_Types) `text/plain`.
@@ -22,7 +23,8 @@ Cet élément n'a aucun autre attribut en dehors des [attributs universels](/fr/
 
 Cet élément implémente l'interface {{domxref('HTMLElement')}}.
 
-> **Note :** Jusqu'à Gecko 1.9.2 inclus, Firefox implémente l'interface {{domxref('HTMLSpanElement')}} pour cet élément.
+> [!NOTE]
+> Jusqu'à Gecko 1.9.2 inclus, Firefox implémente l'interface {{domxref('HTMLSpanElement')}} pour cet élément.
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/web/html/element/progress/index.md
+++ b/files/fr/web/html/element/progress/index.md
@@ -18,7 +18,8 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
 - `value`
   - : Cet attribut indique l'état actuel de complétion de la tâche avec une valeur numérique. La valeur de l'attribut doit être un nombre décimal compris entre 0 et `max` (ou entre 0 et 1 si l'attribut `max` est absent). Si l'attribut `value` est absent, la barre de progression traduit un état indéterminé (la tâche est en cours et on ne sait pas la durée qu'elle prendra).
 
-> **Note :** La valeur minimale est toujours 0 et il n'existe pas d'attribut `min` pour l'élément `progress`. La propriété CSS {{cssxref("-moz-orient")}} peut être utilisée afin d'indiquer si barre de progression doit être affichée horizontalement (le comportement par défaut) ou verticalement.
+> [!NOTE]
+> La valeur minimale est toujours 0 et il n'existe pas d'attribut `min` pour l'élément `progress`. La propriété CSS {{cssxref("-moz-orient")}} peut être utilisée afin d'indiquer si barre de progression doit être affichée horizontalement (le comportement par défaut) ou verticalement.
 > La pseudo-classe CSS {{cssxref(":indeterminate")}} permet quant à elle de cibler les barres de progression indéterminées. Pour qu'une barre d'avancement retrouve un état indéterminé après qu'elle ait eu une valeur, on pourra utiliser `element.removeAttribute("value")`.
 
 ## Exemples

--- a/files/fr/web/html/element/q/index.md
+++ b/files/fr/web/html/element/q/index.md
@@ -9,7 +9,8 @@ L'élément HTML **`<q>`** indique que le texte qu'il contient est une citation 
 
 {{EmbedInteractiveExample("pages/tabbed/q.html", "tabbed-shorter")}}
 
-> **Note :** La plupart des navigateurs récents ajoutent automatiquement des guillemets autours du contenu d'un élément `<q>` mais il peut être nécessaire d'ajouter une règle CSS pour les ajouter dans les anciens navigateurs.
+> [!NOTE]
+> La plupart des navigateurs récents ajoutent automatiquement des guillemets autours du contenu d'un élément `<q>` mais il peut être nécessaire d'ajouter une règle CSS pour les ajouter dans les anciens navigateurs.
 
 ## Attributs
 

--- a/files/fr/web/html/element/rb/index.md
+++ b/files/fr/web/html/element/rb/index.md
@@ -81,7 +81,8 @@ body {
 
 {{EmbedLiveSample("", "100%", 60)}}
 
-> **Note :** Voir l'article sur l'élément {{HTMLElement("ruby")}} pour de plus amples exemples.
+> [!NOTE]
+> Voir l'article sur l'élément {{HTMLElement("ruby")}} pour de plus amples exemples.
 
 ## Résumé technique
 

--- a/files/fr/web/html/element/samp/index.md
+++ b/files/fr/web/html/element/samp/index.md
@@ -67,7 +67,8 @@ samp {
 }
 ```
 
-> **Note :** S'il vous faut un élément qui serve de conteneur pour une valeur produite par le site ou l'application, vous devriez utiliser [`<output>`](/fr/docs/Web/HTML/Element/output) plutôt que `<samp>`.
+> [!NOTE]
+> S'il vous faut un élément qui serve de conteneur pour une valeur produite par le site ou l'application, vous devriez utiliser [`<output>`](/fr/docs/Web/HTML/Element/output) plutôt que `<samp>`.
 
 ## Exemples
 

--- a/files/fr/web/html/element/script/index.md
+++ b/files/fr/web/html/element/script/index.md
@@ -62,7 +62,8 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
     - **`module` :** Le code sera traité comme un module JavaScript. Le traitement du script n'est pas affecté par les attributs `charset` et `defer`. Pour plus d'informations sur l'utilisation des modules, voir le guide sur [les modules JavaScript](/fr/docs/Web/JavaScript/Guide/Modules).
     - **Toute autre valeur :** Le contenu embarqué est considéré comm un bloc de donnée et ne sera pas traité par le navigateur. Les développeurs doivent utiliser un type MIME valide qui n'est pas un type MIME JavaScript afin d'indiquer de tels blocs de donnée. Dans ce cas, l'attribut `src` sera ignoré.
 
-    > **Note :** Avec Firefox, on pouvait indiquer la version JavaScript d'un élément `<script>` en incluant un paramètre non-standard `version` à l'intérieur de `type` (ex. `type="text/javascript;version=1.8"`). Cette spécificité a été retirée avec Firefox 59 (cf. [bug Firefox 1428745](https://bugzil.la/1428745)).
+    > [!NOTE]
+    > Avec Firefox, on pouvait indiquer la version JavaScript d'un élément `<script>` en incluant un paramètre non-standard `version` à l'intérieur de `type` (ex. `type="text/javascript;version=1.8"`). Cette spécificité a été retirée avec Firefox 59 (cf. [bug Firefox 1428745](https://bugzil.la/1428745)).
 
 ### Attributs dépréciés
 

--- a/files/fr/web/html/element/script/type/index.md
+++ b/files/fr/web/html/element/script/type/index.md
@@ -22,7 +22,8 @@ La valeur de cet attribut indique le type de données représenté par le script
 - Toute autre valeur
   - : Le contenu embarqué est traité comme un bloc de données et ne sera pas traité par le navigateur. Afin d'indiquer des blocs de données, les développeuses et développeurs doivent utiliser un type MIME valide qui n'est pas un type MIME JavaScript. Tous les autres attributs seront ignorés, y compris l'attribut `src`.
 
-> **Note :** Dans les navigateurs antérieurs, le type identifiait le langage de script du code embarqué ou importé (à travers l'attribut `src`).
+> [!NOTE]
+> Dans les navigateurs antérieurs, le type identifiait le langage de script du code embarqué ou importé (à travers l'attribut `src`).
 
 ## Spécifications
 

--- a/files/fr/web/html/element/section/index.md
+++ b/files/fr/web/html/element/section/index.md
@@ -11,7 +11,8 @@ L'élément HTML **`<section>`** représente une section générique d'un docume
 
 Ainsi, un menu de navigation devrait être délimité par un élément {{htmlelement("nav")}} mais une liste de résultat de recherche, qui ne dispose pas d'élément spécifique pour être représentée, pourrait être englobée dans un élément `<section>`.
 
-> **Note :** Si le contenu de l'élément devrait être considéré comme un fragment indépendant (qui puisse être séparée du reste du contenu), l'élément {{HTMLElement("article")}} sera plus pertinent.
+> [!NOTE]
+> Si le contenu de l'élément devrait être considéré comme un fragment indépendant (qui puisse être séparée du reste du contenu), l'élément {{HTMLElement("article")}} sera plus pertinent.
 
 ## Attributs
 

--- a/files/fr/web/html/element/select/index.md
+++ b/files/fr/web/html/element/select/index.md
@@ -106,7 +106,8 @@ Vous pourrez voir que :
 - Les éléments `<optgroup>` ont été utilisés pour diviser les choix en différents groupes. Cela applique un effet simplement visuel (avec le nom en gras et les options indentées).
 - Le choix "Hamster" est présent avec l'attribut `disabled` et ne peut donc pas être sélectionné.
 
-> **Note :** Sur un ordinateur de bureau, on pourra maintenir les touches <kbd>Ctrl</kbd>, <kbd>Command</kbd>, ou <kbd>Shift</kbd> en cliquant afin de sélectionner/déselectionner plusieurs options.
+> [!NOTE]
+> Sur un ordinateur de bureau, on pourra maintenir les touches <kbd>Ctrl</kbd>, <kbd>Command</kbd>, ou <kbd>Shift</kbd> en cliquant afin de sélectionner/déselectionner plusieurs options.
 
 ### Sélectionner plusieurs options
 
@@ -114,7 +115,8 @@ Sur un ordinateur de bureau, il existe différentes façons de sélectionner plu
 
 Pour les personnes qui utilisent la souris, il est possible de maintenir les touches <kbd>Ctrl</kbd>, <kbd>Command</kbd> ou <kbd>Shift</kbd> (selon le système d'exploitation utilisé) et de cliquer sur les différentes options afin de les sélectionner/déselectionner.
 
-> **Attention :** Les moyens décrits ci-après pour sélectionner des options qui ne sont pas contigües semblent ne fonctionner qu'avec Firefox. On notera également que sur macOS, les raccourcis <kbd>Ctrl</kbd> + <kbd>Bas</kbd> et <kbd>Ctrl</kbd> + <kbd>Haut</kbd> sont utilisées par défaut par le système d'exploitation et qu'il faut les désactiver si on souhaite qu'ils fonctionnent dans le navigateurs.
+> [!WARNING]
+> Les moyens décrits ci-après pour sélectionner des options qui ne sont pas contigües semblent ne fonctionner qu'avec Firefox. On notera également que sur macOS, les raccourcis <kbd>Ctrl</kbd> + <kbd>Bas</kbd> et <kbd>Ctrl</kbd> + <kbd>Haut</kbd> sont utilisées par défaut par le système d'exploitation et qu'il faut les désactiver si on souhaite qu'ils fonctionnent dans le navigateurs.
 
 Les utilisateurs du clavier pourront sélectionner des options contigües de la façon suivante :
 

--- a/files/fr/web/html/element/slot/index.md
+++ b/files/fr/web/html/element/slot/index.md
@@ -65,7 +65,8 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
 </template>
 ```
 
-> **Note :** Vous pouvez retrouver cet exemple sur [ce dépôt GitHub](https://github.com/mdn/web-components-examples/tree/master/element-details) et observer [son fonctionnement en live ici](https://mdn.github.io/web-components-examples/element-details/). Une explication plus détaillée est également disponible avec l'article [Manipuler `template` et `slot`](/fr/docs/Web/Web_Components/Using_templates_and_slots).
+> [!NOTE]
+> Vous pouvez retrouver cet exemple sur [ce dépôt GitHub](https://github.com/mdn/web-components-examples/tree/master/element-details) et observer [son fonctionnement en live ici](https://mdn.github.io/web-components-examples/element-details/). Une explication plus détaillée est également disponible avec l'article [Manipuler `template` et `slot`](/fr/docs/Web/Web_Components/Using_templates_and_slots).
 
 ## Résumé technique
 

--- a/files/fr/web/html/element/strike/index.md
+++ b/files/fr/web/html/element/strike/index.md
@@ -7,7 +7,8 @@ slug: Web/HTML/Element/strike
 
 L'élément HTML **`<strike>`** permet de représenter du texte barré ou avec une ligne le traversant.
 
-> **Note :** Comme tous les éléments se limitant à la présentation, {{HTMLElement("strike")}} a été déprécié en HTML 4 et XHTML 1, et rendu obsolète dans HTML5. Si on souhaite représente du contenu _supprimé_, on utilisera l'élément {{HTMLElement("del")}} ; dans les autres cas, on utilisera un élément {{HTMLElement("s")}}.
+> [!NOTE]
+> Comme tous les éléments se limitant à la présentation, {{HTMLElement("strike")}} a été déprécié en HTML 4 et XHTML 1, et rendu obsolète dans HTML5. Si on souhaite représente du contenu _supprimé_, on utilisera l'élément {{HTMLElement("del")}} ; dans les autres cas, on utilisera un élément {{HTMLElement("s")}}.
 
 ## Attributs
 
@@ -17,7 +18,8 @@ Cet élément n'a aucun autre attribut en dehors [des attributs universels](/fr/
 
 Cet élément implémente l'interface {{domxref("HTMLElement")}}.
 
-> **Note :** Jusqu'à Gecko 1.9.2 inclus, Firefox implémente l'interface {{domxref("HTMLSpanElement")}} pour cet élément.
+> [!NOTE]
+> Jusqu'à Gecko 1.9.2 inclus, Firefox implémente l'interface {{domxref("HTMLSpanElement")}} pour cet élément.
 
 ## Exemples
 

--- a/files/fr/web/html/element/table/index.md
+++ b/files/fr/web/html/element/table/index.md
@@ -23,7 +23,7 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
     - `center`, signifiant que la table doit être affichée centrée dans le document ;
     - `right`, signifiant que la table doit être affichée à droite du document.
 
-    > **Note :**
+    > [!NOTE]
     >
     > - **Cet attribut ne doit pas être utilisé** car il a été déprécié : l'élément {{HTMLElement("table")}} devrait être stylisé en utilisant [CSS](/fr/docs/CSS). Pour obtenir un effet similaire à celui réalisé par l'attribut align, les propriétés [CSS](/fr/docs/CSS) {{cssxref("text-align")}} et {{cssxref("vertical-align")}} devraient être utilisées.
     > - Avant Firefox 4, Firefox supportait également, en mode quirks uniquement, les valeurs `middle`, `absmiddle`, et `abscenter` comme synonymes de `center`_._
@@ -32,25 +32,29 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
 
   - : Cet attribut définit la couleur d'arrière-plan de toutes les cellules. C'est un code à 6 chiffres hexadécimaux comme défini par le [sRGB](https://www.w3.org/Graphics/Color/sRGB). Il est précédé d'un '#'. Un des [mots-clés préfédinis pour les couleurs](/fr/docs/Web/CSS/color_value#color_keywords) peut également être utilisé.
 
-    > **Note :** Il est fortement conseillé de ne pas utiliser cet attribut car celui-ci a été déprécié. La mise en forme d'un tableau doit se faire en utilisant CSS. Il est possible d'utiliser la propriété CSS {{cssxref("background-color")}} pour cet effet.
+    > [!NOTE]
+    > Il est fortement conseillé de ne pas utiliser cet attribut car celui-ci a été déprécié. La mise en forme d'un tableau doit se faire en utilisant CSS. Il est possible d'utiliser la propriété CSS {{cssxref("background-color")}} pour cet effet.
 
 - `border` {{Deprecated_inline}}
 
   - : Cet attribut entier définit, en pixels, la taille de la bordure entourant le tableau. S'il vaut 0, cela implique que l'attribut [`frame`](/fr/docs/Web/HTML/Element/table#frame) est vide.
 
-    > **Note :** Cet attribut ayant été déprécié, il ne doit pas être utilisé. La mise en forme d'un tableau doit s'effectuer en utilisant CSS. Les propriétés CSS {{cssxref("border")}}, {{cssxref("border-color")}}, {{cssxref("border-width")}} et {{cssxref("border-style")}} devraient être utilisées à la place.
+    > [!NOTE]
+    > Cet attribut ayant été déprécié, il ne doit pas être utilisé. La mise en forme d'un tableau doit s'effectuer en utilisant CSS. Les propriétés CSS {{cssxref("border")}}, {{cssxref("border-color")}}, {{cssxref("border-width")}} et {{cssxref("border-style")}} devraient être utilisées à la place.
 
 - `cellpadding` {{Deprecated_inline}}
 
   - : Cet attribut définit la taille de l'espace entre le contenu d'une cellule et sa bordure, qu'lle soit affichée ou non. Si cet attribut est exprimé en pixels, le décalage sera appliqué sur les quatre côtés. S'il est exprimé en pourcents, le contenu sera centré verticalement et la somme des espaces en haut et en bas représentera le pourcentage, il en va de même pour l'espace horizontal (droite et gauche).
 
-    > **Note :** Cet attribut ayant été déprécié, il ne doit pas être utilisé. La mise en forme d'un tableau doit s'effectuer en utilisant CSS. Pour réaliser un effet similaire, la propriété {{cssxref("border-collapse")}} avec la valeur collapse doit être utilisée sur l'élément {{HTMLElement("table")}} et la propriété {{cssxref("padding")}} sur l'élément {{HTMLElement("td")}}.
+    > [!NOTE]
+    > Cet attribut ayant été déprécié, il ne doit pas être utilisé. La mise en forme d'un tableau doit s'effectuer en utilisant CSS. Pour réaliser un effet similaire, la propriété {{cssxref("border-collapse")}} avec la valeur collapse doit être utilisée sur l'élément {{HTMLElement("table")}} et la propriété {{cssxref("padding")}} sur l'élément {{HTMLElement("td")}}.
 
 - `cellspacing` {{Deprecated_inline}}
 
   - : Cet attribut définit la taille (en pourcents ou pixels) de l'espace (vertical et horizontal) entre deux cellules, entre la haut du tableau et les cellules de la première ligne, la gauche du tableau et les cellules de la première colonne, puis de la même manière pour le bas et le côté droit du tableau.
 
-    > **Note :** Cet attribut ayant été déprécié, il ne doit pas être utilisé. La mise en forme d'un tableau doit s'effectuer en utilisant CSS. Pour réaliser un effet similaire, la propriété {{cssxref("border-collapse")}} avec la valeur collapse doit être utilisée sur l'élément {{HTMLElement("table")}} et la propriété {{cssxref("margin")}} sur l'élément {{HTMLElement("td")}}.
+    > [!NOTE]
+    > Cet attribut ayant été déprécié, il ne doit pas être utilisé. La mise en forme d'un tableau doit s'effectuer en utilisant CSS. Pour réaliser un effet similaire, la propriété {{cssxref("border-collapse")}} avec la valeur collapse doit être utilisée sur l'élément {{HTMLElement("table")}} et la propriété {{cssxref("margin")}} sur l'élément {{HTMLElement("td")}}.
 
 <!---->
 
@@ -58,7 +62,8 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
 
   - : Cet attribut à valeurs multiples définit les côtés du tableau sur lesquels dessiner une bordure. Il peut prendre les valeurs suivantes : `above, hsides, lhs, border, void, below, vsides, rhs, box`.
 
-    > **Note :** Cet attribut ayant été déprécié, il ne doit pas être utilisé. La mise en forme d'un tableau doit s'effectuer en utilisant CSS. Pour réaliser un effet similaire, les propriétés {{cssxref("border-style")}} et {{cssxref("border-width")}} doivent être utilisées.
+    > [!NOTE]
+    > Cet attribut ayant été déprécié, il ne doit pas être utilisé. La mise en forme d'un tableau doit s'effectuer en utilisant CSS. Pour réaliser un effet similaire, les propriétés {{cssxref("border-style")}} et {{cssxref("border-width")}} doivent être utilisées.
 
 <!---->
 
@@ -72,7 +77,7 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
     - `columns`, les lignes seront affichées entre les colonnes du tableau
     - `all`, tous les traits seront affichés (entre les lignes et entre les colonnes).
 
-    > **Note :**
+    > [!NOTE]
     >
     > - L'apparence de ces traits dépend du navigateur utilisé et ne peut être modifiée.
     > - Cet attribut ayant été déprécié, il ne doit pas être utilisé. La propriété CSS {{cssxref("border")}} doit être appliquée sur les éléments {{HTMLElement("thead")}}, {{HTMLElement("tbody")}}, {{HTMLElement("tfoot")}}, {{HTMLElement("col")}} ou {{HTMLElement("colgroup")}} adéquats.
@@ -83,7 +88,8 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
 
   - : Cet attribut définit un texte alternatif à utiliser afin de décrire le tableau. Un tel texte peut être utilisé par un agent utilisateur qui ne pourrait pas afficher le tableau. Il est généralement utilisé pour les personnes souffrant d'une déficience visuelle, comme par exemple les aveugles qui navigueront sur des pages web en utilisant un écran Braille. Si l'information contenue dans cet attribut serait également utile aux autres utilisateurs, il faudra plutôt utiliser l'élément {{HTMLElement("caption")}}. L'attribut **`summary`** n'est pas obligatoire et peut être omis lorsqu'un élément {{HTMLElement("caption")}} remplit ce rôle.
 
-    > **Note :** Cet attribut ayant été déprécié, il ne doit pas être utilisé. Les façons suivantes peuvent être envisagées pour cette expression :
+    > [!NOTE]
+    > Cet attribut ayant été déprécié, il ne doit pas être utilisé. Les façons suivantes peuvent être envisagées pour cette expression :
     >
     > - Grâce à un texte entourant le tableau, cette manière est la plus faible du point de vue de la sémantique
     > - Grâce à l'élément {{HTMLElement("caption")}}
@@ -98,7 +104,8 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
 
   - : Cet attribut définit la largeur du tableau. Elle peut être exprimée en pixels ou en pourcent (représentant alors la fraction du conteneur que le tableau peut occuper).
 
-    > **Note :** Cet attribut ayant été déprécié, il ne doit pas être utilisé. La propriété CSS {{cssxref("width")}} doit être utilisée à la place.
+    > [!NOTE]
+    > Cet attribut ayant été déprécié, il ne doit pas être utilisé. La propriété CSS {{cssxref("width")}} doit être utilisée à la place.
 
 ## Exemples
 

--- a/files/fr/web/html/element/tbody/index.md
+++ b/files/fr/web/html/element/tbody/index.md
@@ -75,7 +75,8 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
 
     Cet attribut étant déprécié, on utilisera la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align) à la place.
 
-    > **Note :** Le comportement de la propriété `text-align` équivalent à `align="char"` n'est pas implémenté par les navigateurs à l'heure actuelle. Voir [le tableau de compatibilité des navigateurs `text-align`](/fr/docs/Web/CSS/text-align#browser_compatibility) à propos de l'alignement basé sur les une valeur `<string>`.
+    > [!NOTE]
+    > Le comportement de la propriété `text-align` équivalent à `align="char"` n'est pas implémenté par les navigateurs à l'heure actuelle. Voir [le tableau de compatibilité des navigateurs `text-align`](/fr/docs/Web/CSS/text-align#browser_compatibility) à propos de l'alignement basé sur les une valeur `<string>`.
 
 - `bgcolor` {{Deprecated_inline}}
 

--- a/files/fr/web/html/element/td/index.md
+++ b/files/fr/web/html/element/td/index.md
@@ -71,7 +71,8 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
 
   - : Cet attribut contient une description courte et abrégée du contenu de la cellule. Certains outils utilisateurs, comme la synthèse vocale, peuvent décrire cette information avant le contenu lui-même.
 
-    > **Note :** Cet attribut est obsolète dans le dernier standard et ne doit donc plus être utilisé. Il faut dans ces cas introduire la description au sein de la cellule comme un élément [`<abbr>`](/fr/docs/Web/HTML/Element/abbr) indépendant ou utiliser l'attribut `title` de la cellule pour représenter le contenu et la cellule elle-même pour représenter le contenu abrégé.
+    > [!NOTE]
+    > Cet attribut est obsolète dans le dernier standard et ne doit donc plus être utilisé. Il faut dans ces cas introduire la description au sein de la cellule comme un élément [`<abbr>`](/fr/docs/Web/HTML/Element/abbr) indépendant ou utiliser l'attribut `title` de la cellule pour représenter le contenu et la cellule elle-même pour représenter le contenu abrégé.
 
 - `align` {{deprecated_inline}}
 
@@ -90,7 +91,8 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
 
     Si cet attribut n'est pas renseigné, la valeur `left` est prise par défaut.
 
-    > **Note :** Cet attribut est devenu obsolète dans le dernier standard et ne doit donc plus être utilisé.
+    > [!NOTE]
+    > Cet attribut est devenu obsolète dans le dernier standard et ne doit donc plus être utilisé.
     >
     > - Pour réaliser les mêmes effets que les valeurs `left`, `center`, `right` ou `justify`, il faut utiliser la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align) sur l'élément
     > - Pour réaliser le même effet qu'avec la valeur `char`. Il est possible, en CSS3, d'utiliser la valeur de l'attribut `char` comme valeur de la propriété [`text-align`](/fr/docs/Web/CSS/text-align) (non implémenté à date).

--- a/files/fr/web/html/element/textarea/index.md
+++ b/files/fr/web/html/element/textarea/index.md
@@ -156,7 +156,8 @@ Dans cet exemple, on utilise l'attribut `placeholder` afin d'afficher une indica
 
 {{EmbedLiveSample('','600','80')}}
 
-> **Note :** Les indications ne remplacent pas les éléments {{HTMLElement("label")}}.
+> [!NOTE]
+> Les indications ne remplacent pas les éléments {{HTMLElement("label")}}.
 
 ### Lecture seule et contrôle désactivé
 

--- a/files/fr/web/html/element/tfoot/index.md
+++ b/files/fr/web/html/element/tfoot/index.md
@@ -75,7 +75,8 @@ Les attributs qui suivent sont dépréciés et ne devraient pas être utilisés.
 
     Si cet attribut n'est pas renseigné, la valeur `left` est prise par défaut.
 
-    > **Note :** Pour réaliser le même effet qu'avec les valeurs `left`, `center`, `right` ou `justify`, utilisez la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align) sur cet élément.
+    > [!NOTE]
+    > Pour réaliser le même effet qu'avec les valeurs `left`, `center`, `right` ou `justify`, utilisez la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align) sur cet élément.
     >
     > - Pour réaliser le même effet qu'avec `char`, vous pouvez, en CSS3, utiliser la valeur de `char` comme valeur pour la propriété [`text-align`](/fr/docs/Web/CSS/text-align) (non implémenté à date).
 
@@ -106,7 +107,8 @@ Les attributs qui suivent sont dépréciés et ne devraient pas être utilisés.
     - `top`
       - : Place le texte au plus haut de la cellule.
 
-    > **Note :** Cet attribut étant maintenant obsolète (et n'étant plus pris en charge), il est fortement déconseillé de l'utiliser. La propriété CSS [`vertical-align`](/fr/docs/Web/CSS/vertical-align) doit être utilisée à la place.
+    > [!NOTE]
+    > Cet attribut étant maintenant obsolète (et n'étant plus pris en charge), il est fortement déconseillé de l'utiliser. La propriété CSS [`vertical-align`](/fr/docs/Web/CSS/vertical-align) doit être utilisée à la place.
 
 ## Exemples
 

--- a/files/fr/web/html/element/th/index.md
+++ b/files/fr/web/html/element/th/index.md
@@ -104,7 +104,8 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
 
     Si cet attribut n'est pas renseigné, la valeur `left` est prise par défaut.
 
-    > **Note :** Cet attribut est devenu obsolète dans le dernier standard et ne doit donc plus être utilisé.
+    > [!NOTE]
+    > Cet attribut est devenu obsolète dans le dernier standard et ne doit donc plus être utilisé.
     >
     > - Pour réaliser les mêmes effets que les valeurs `left`, `center`, `right` ou `justify`, il faut utiliser la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align) sur l'élément
     > - Pour réaliser le même effet qu'avec la valeur `char`. Il est possible d'utiliser la valeur de l'attribut `char` comme valeur de la propriété [`text-align`](/fr/docs/Web/CSS/text-align).
@@ -113,7 +114,8 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
 
   - : Cet attribut contient une liste de chaînes de caractères (séparées par des espaces). Chaque chaîne de caractère est l'identifiant d'un groupe de cellule auquel cet en-tête s'applique.
 
-    > **Note :** Cet attribut est obsolète dans le dernier standard et ne doit donc plus être utilisé. L'attribut `scope` doit être utilisé pour le remplacer.
+    > [!NOTE]
+    > Cet attribut est obsolète dans le dernier standard et ne doit donc plus être utilisé. L'attribut `scope` doit être utilisé pour le remplacer.
 
 - `bgcolor` {{Non-standard_inline}}
 
@@ -125,19 +127,22 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
 
   - : Cet attribut est utilisé pour définir le caractère sur lequel aligner les cellules d'une colonne. Les valeurs de cet attribut contiennent généralement un point (.) pour aligner des nombres ou des valeurs monétaires. Si l'attribut `align` ne vaut pas `char`, l'attribut est ignoré.
 
-    > **Note :** Cet attribut est obsolète et il est donc fortement déconseillé de l'utiliser. De fait, il n'est pas supporté par le dernier standard. Pour réaliser le même effet qu'avec `char`, on peut utiliser la même valeur sur la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align).
+    > [!NOTE]
+    > Cet attribut est obsolète et il est donc fortement déconseillé de l'utiliser. De fait, il n'est pas supporté par le dernier standard. Pour réaliser le même effet qu'avec `char`, on peut utiliser la même valeur sur la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align).
 
 - `charoff` {{deprecated_inline}}
 
   - : Cet attribut est utilisé pour indiquer le décalage, en nombre de caractères, depuis le caractère défini par l'attribut `char` à appliquer au contenu des cellules.
 
-    > **Note :** Cet attribut ne doit plus être utilisé, car il est maintenant obsolète.
+    > [!NOTE]
+    > Cet attribut ne doit plus être utilisé, car il est maintenant obsolète.
 
 - `height` {{deprecated_inline}}
 
   - : Cet attribut est utilisé afin de définir une hauteur recommandée pour la cellule.
 
-    > **Note :** Cet attribut est désormais obsolète. On utilisera plutôt la propriété CSS [`height`](/fr/docs/Web/CSS/height) à la place.
+    > [!NOTE]
+    > Cet attribut est désormais obsolète. On utilisera plutôt la propriété CSS [`height`](/fr/docs/Web/CSS/height) à la place.
 
 - `valign` {{Deprecated_inline}}
 
@@ -152,13 +157,15 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Global_attribu
     - `top`
       - : Place le texte au plus haut de la cellule.
 
-    > **Note :** Cet attribut est obsolète dans le dernier standard, la propriété CSS [`vertical-align`](/fr/docs/Web/CSS/vertical-align) doit être utilisée à la place.
+    > [!NOTE]
+    > Cet attribut est obsolète dans le dernier standard, la propriété CSS [`vertical-align`](/fr/docs/Web/CSS/vertical-align) doit être utilisée à la place.
 
 - `width` {{deprecated_inline}}
 
   - : Cet attribut est utilisé afin de définir une largeur de cellule recommandée. Un espace supplémentaire peut être ajouté via les propriétés [`cellspacing`](/fr/docs/Web/API/HTMLTableElement/cellSpacing) et [`cellpadding`](/fr/docs/Web/API/HTMLTableElement/cellPadding) et en modifiant la largeur de l'élément [`<col>`](/fr/docs/Web/HTML/Element/col). Si la largeur de la colonne est trop étroite pour afficher une cellule donnée correctement, elle sera élargie lors de l'affichage.
 
-    > **Note :** Cet attribut est désormais obsolète et il faut donc éviter de l'utiliser. On utilisera plutôt la propriété CSS [`width`](/fr/docs/Web/CSS/width) à la place.
+    > [!NOTE]
+    > Cet attribut est désormais obsolète et il faut donc éviter de l'utiliser. On utilisera plutôt la propriété CSS [`width`](/fr/docs/Web/CSS/width) à la place.
 
 ## Exemples
 

--- a/files/fr/web/html/element/thead/index.md
+++ b/files/fr/web/html/element/thead/index.md
@@ -73,7 +73,8 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
 
     Si cet attribut n'est pas renseigné, la valeur `left` est prise par défaut.
 
-    > **Attention :** Cet attribut est devenu obsolète dans le dernier standard.
+    > [!WARNING]
+    > Cet attribut est devenu obsolète dans le dernier standard.
     >
     > - Pour réaliser le même effet qu'avec les valeurs `left`, `center`, `right` ou `justify`, utilisez la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align) sur cet élément.
     > - Pour réaliser le même effet qu'avec `char`, vous pouvez utiliser la valeur de `char` comme valeur pour la propriété [`text-align`](/fr/docs/Web/CSS/text-align).
@@ -88,13 +89,15 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
 
   - : Cet attribut est utilisé pour définir le caractère sur lequel aligner les cellules d'une colonne. Les valeurs de cet attribut contiennent généralement un point (.) pour aligner des nombres ou des valeurs monétaires. Si l'attribut `align` ne vaut pas `char`, l'attribut est ignoré.
 
-    > **Note :** Cet attribut est obsolète et il est donc fortement déconseillé de l'utiliser. De fait, il n'est pas supporté par le dernier standard. Pour réaliser le même effet qu'avec `char`, on peut utiliser la même valeur sur la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align).
+    > [!NOTE]
+    > Cet attribut est obsolète et il est donc fortement déconseillé de l'utiliser. De fait, il n'est pas supporté par le dernier standard. Pour réaliser le même effet qu'avec `char`, on peut utiliser la même valeur sur la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align).
 
 - `charoff` {{Deprecated_inline}}
 
   - : Cet attribut est utilisé pour indiquer le décalage, en nombre de caractères, depuis le caractère définit par l'attribut `char` à appliquer au contenu des cellules.
 
-    > **Note :** Cet attribut ne doit plus être utilisé, car il est maintenant obsolète et n'est plus supporté dans le dernier standard.
+    > [!NOTE]
+    > Cet attribut ne doit plus être utilisé, car il est maintenant obsolète et n'est plus supporté dans le dernier standard.
 
 - `valign` {{Deprecated_inline}}
 
@@ -109,7 +112,8 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
     - `top`
       - : Place le texte au plus haut de la cellule.
 
-    > **Note :** Cet attribut étant maintenant obsolète (et n'étant plus supporté), il est fortement déconseillé de l'utiliser. La propriété CSS [`vertical-align`](/fr/docs/Web/CSS/vertical-align) doit être utilisée à la place.
+    > [!NOTE]
+    > Cet attribut étant maintenant obsolète (et n'étant plus supporté), il est fortement déconseillé de l'utiliser. La propriété CSS [`vertical-align`](/fr/docs/Web/CSS/vertical-align) doit être utilisée à la place.
 
 ## Exemples
 

--- a/files/fr/web/html/element/tr/index.md
+++ b/files/fr/web/html/element/tr/index.md
@@ -36,7 +36,8 @@ La construction de tableau peut parfois demander un peu de pratique. Au-delà de
 
     Si cet attribut n'est pas renseigné, la valeur est héritée du nœud parent.
 
-    > **Note :** Cet attribut est devenu obsolète dans le dernier standard et ne doit donc plus être utilisé.
+    > [!NOTE]
+    > Cet attribut est devenu obsolète dans le dernier standard et ne doit donc plus être utilisé.
     >
     > - Pour réaliser les mêmes effets que les valeurs `left`, `center`, `right` ou `justify`, il faut utiliser la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align) sur l'élément
     > - Pour réaliser le même effet qu'avec la valeur `char`. Il est possible d'utiliser la valeur de l'attribut [`char`](#attr-char) comme valeur de la propriété [`text-align`](/fr/docs/Web/CSS/text-align).
@@ -45,19 +46,22 @@ La construction de tableau peut parfois demander un peu de pratique. Au-delà de
 
   - : Une chaîne de caractères qui définit la couleur d'arrière-plan de toutes les cellules de la colonne. Il peut s'agit d'une [notation hexadécimale #RRGGGBB ou #RGB](</fr/docs/Web/CSS/color_value#rgb()>) ou bien d'un [mot-clé](/fr/docs/Web/CSS/color_value#color_keywords) pour une couleur. L'absence de cet attribut (ou sa déclaration à `null` en JavaScript) fera que la couleur des cellules de la ligne sera héritée de la couleur d'arrière-plan de l'élément parent.
 
-    > **Note :** L'élément `<tr>` doit être mis en forme grâce au [CSS](/fr/docs/Web/CSS). Pour fournir un effet semblable à celui achevé par l'attribut `bgcolor`, il est possible d'utiliser la propriété CSS [`background-color`](/fr/docs/Web/CSS/background-color).
+    > [!NOTE]
+    > L'élément `<tr>` doit être mis en forme grâce au [CSS](/fr/docs/Web/CSS). Pour fournir un effet semblable à celui achevé par l'attribut `bgcolor`, il est possible d'utiliser la propriété CSS [`background-color`](/fr/docs/Web/CSS/background-color).
 
 - **`char`**{{deprecated_inline}}
 
   - : Une chaîne de caractère qui définit le caractère sur lequel aligner les cellules d'une colonne. Les valeurs de cet attribut contiennent généralement un point ou une virgule pour aligner des nombres ou des valeurs monétaires. Si l'attribut [`align`](#attr-align) ne vaut pas `char`, l'attribut est ignoré.
 
-    > **Note :** Cet attribut est obsolète et peu implémenté : il est donc fortement déconseillé de l'utiliser. Pour réaliser le même effet qu'avec [`char`](#attr-char), il faut utiliser la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align).
+    > [!NOTE]
+    > Cet attribut est obsolète et peu implémenté : il est donc fortement déconseillé de l'utiliser. Pour réaliser le même effet qu'avec [`char`](#attr-char), il faut utiliser la propriété CSS [`text-align`](/fr/docs/Web/CSS/text-align).
 
 - **`charoff`** {{deprecated_inline}}
 
   - : Une chaîne de caractères utilisée pour indiquer le nombre de caractères à afficher après le caractère défini par l'attribut `char`. Cela peut par exemple servir à indiquer qu'on souhaite afficher deux chiffres après la virgule pour les valeurs monétaires afin d'indiquer les centimes.
 
-    > **Note :** Cet attribut ne doit plus être utilisé, car il est maintenant obsolète et que sa compatibilité n'était pas répandue.
+    > [!NOTE]
+    > Cet attribut ne doit plus être utilisé, car il est maintenant obsolète et que sa compatibilité n'était pas répandue.
 
 - **`valign`** {{deprecated_inline}}
 
@@ -72,7 +76,8 @@ La construction de tableau peut parfois demander un peu de pratique. Au-delà de
     - `top`
       - : Place le texte au plus haut de la cellule.
 
-    > **Note :** Cet attribut est obsolète dans le dernier standard, la propriété CSS [`vertical-align`](/fr/docs/Web/CSS/vertical-align) doit être utilisée à la place.
+    > [!NOTE]
+    > Cet attribut est obsolète dans le dernier standard, la propriété CSS [`vertical-align`](/fr/docs/Web/CSS/vertical-align) doit être utilisée à la place.
 
 ## Exemples
 

--- a/files/fr/web/html/element/tt/index.md
+++ b/files/fr/web/html/element/tt/index.md
@@ -9,7 +9,8 @@ L'élément HTML **`<tt>`** (pour _Teletype Text_) crée un élément en ligne, 
 
 Cet élément est désormais obsolète et un élément {{HTMLElement("code")}}, {{HTMLElement("kbd")}}, {{HTMLElement("samp")}} ou {{HTMLElement("var")}} pourra être utilisé à la place s'il faut afficher du texte en incise avec une police à chasse fixe. On pourra utiliser l'élément {{HTMLElement("pre")}} pour afficher un bloc de contenu préformaté (également généralement affiché dans une police à chasse fixe).
 
-> **Note :** Si aucun de ces éléments ne correspond à la sémantique portée par votre contenu (lorsque, par exemple, il ne s'agit que d'un effet de mise en forme), vous pouvez utiliser un élément {{HTMLElement("span")}} mis en forme avec CSS (par exemple la propriété {{cssxref("font-family")}}).
+> [!NOTE]
+> Si aucun de ces éléments ne correspond à la sémantique portée par votre contenu (lorsque, par exemple, il ne s'agit que d'un effet de mise en forme), vous pouvez utiliser un élément {{HTMLElement("span")}} mis en forme avec CSS (par exemple la propriété {{cssxref("font-family")}}).
 
 ## Attributs
 
@@ -65,7 +66,8 @@ tt {
 
 Par défaut, le contenu de l'élément `<tt>` est affiché avec la police à chasse fixe par défaut du navigateur. Comme vu dans l'exemple précédent, il est possible de surcharger cette police.
 
-> **Note :** Les règles de style propres à l'utilisateur sont prioritaires par rapport aux feuilles de style d'un site ou d'une application web.
+> [!NOTE]
+> Les règles de style propres à l'utilisateur sont prioritaires par rapport aux feuilles de style d'un site ou d'une application web.
 
 Bien que cet élément n'ait pas été officiellement déprécié en HTML 4.01, son utilisation a été déconseillée pour privilégier d'autres éléments HTML ou une mise en forme via CSS. L'élément `<tt>` est désormais obsolète en HTML5.
 

--- a/files/fr/web/html/element/u/index.md
+++ b/files/fr/web/html/element/u/index.md
@@ -7,7 +7,8 @@ slug: Web/HTML/Element/u
 
 L'élément HTML **`<u>`** permet d'afficher un fragment de texte qui est annoté avec des éléments non textuels. Par défaut, le contenu de l'élément est souligné. Cela pourra par exemple être le cas pour marquer un texte comme étant un nom propre chinois, ou pour marquer un texte qui a été mal orthographié.
 
-> **Attention :** Cet élément était auparavant appelé _underline_ pour les anciennes versions des spécifications HTML. Si on souhaite simplement souligner du texte, il ne faudra pas utiliser cet élément mais la propriété CSS {{cssxref("text-decoration")}} avec la valeur `"underline"`.
+> [!WARNING]
+> Cet élément était auparavant appelé _underline_ pour les anciennes versions des spécifications HTML. Si on souhaite simplement souligner du texte, il ne faudra pas utiliser cet élément mais la propriété CSS {{cssxref("text-decoration")}} avec la valeur `"underline"`.
 
 {{EmbedInteractiveExample("pages/tabbed/u.html", "tabbed-shorter")}}
 
@@ -21,7 +22,8 @@ Cet élément inclut uniquement [les attributs universels](/fr/docs/Web/HTML/Att
 
 La spécification rappelle que dans la majorité des cas, d'autres éléments que `<u>` doivent être utilisés.
 
-> **Note :** Attention à la mise en forme par défaut d'un élément `<u>` qui le souligne. Cela peut être source de confusion entre un tel texte et un lien hypertexte (également souligné par défaut).
+> [!NOTE]
+> Attention à la mise en forme par défaut d'un élément `<u>` qui le souligne. Cela peut être source de confusion entre un tel texte et un lien hypertexte (également souligné par défaut).
 
 ### Cas d'utilisation
 

--- a/files/fr/web/html/element/ul/index.md
+++ b/files/fr/web/html/element/ul/index.md
@@ -19,7 +19,8 @@ L'élément HTML **`<ul>`** représente une liste d'éléments sans ordre partic
 
   - : Cet attribut booléen fournit une indication pour afficher la liste en mode compact. L'interprétation de cet attribut est laissée à la discrétion de l'agent utilisateur et ne fonctionne pas pour tous les navigateurs.
 
-    > **Attention :** Cet attribut a été déprécié et ne doit pas être utilisé. Pour obtenir le même effet, on pourra utiliser la propriété {{cssxref("line-height")}} avec la valeur `80%` pour l'élément `<ul>`.
+    > [!WARNING]
+    > Cet attribut a été déprécié et ne doit pas être utilisé. Pour obtenir le même effet, on pourra utiliser la propriété {{cssxref("line-height")}} avec la valeur `80%` pour l'élément `<ul>`.
 
 - `type`{{Deprecated_inline}}
 
@@ -31,7 +32,8 @@ L'élément HTML **`<ul>`** représente une liste d'éléments sans ordre partic
 
     Un quatrième type a été défini dans l'interface WebTV : `triangle` mais tous les navigateurs ne l'implémentent pas.
 
-    > **Attention :** Cet attribut a été déprécié et ne doit pas être utilisé. Pour obtenir le même effet, on pourra utiliser la propriété CSS {{cssxref("list-style-type")}} à la place.
+    > [!WARNING]
+    > Cet attribut a été déprécié et ne doit pas être utilisé. Pour obtenir le même effet, on pourra utiliser la propriété CSS {{cssxref("list-style-type")}} à la place.
 
 ## Notes d'utilisation
 

--- a/files/fr/web/html/element/video/index.md
+++ b/files/fr/web/html/element/video/index.md
@@ -43,11 +43,14 @@ Pour apprendre les bases concernant `<video>`, nous vous conseillons de consulte
 
   - : Un attribut booléen qui indique que la vidéo doit automatiquement être lancée dès qu'elle peut être jouée sans être arrêtée par le chargement des données.
 
-    > **Note :** la lecture automatique peut être source de nuisance pour les utilisateurs. Mieux vaut l'éviter lorsque c'est possible ou proposer à l'utilisateur de choisir cette option. Cette valeur peut être utile lors de la création de vidéos dont la source sera définie _a posteriori_.
+    > [!NOTE]
+    > La lecture automatique peut être source de nuisance pour les utilisateurs. Mieux vaut l'éviter lorsque c'est possible ou proposer à l'utilisateur de choisir cette option. Cette valeur peut être utile lors de la création de vidéos dont la source sera définie _a posteriori_.
 
-    > **Note :** Cet attribut est un attribut booléen et indiquer `autoplay="false"` ne suffira pas à retirer la lecture automatique. Pour ce faire, il faut complètement retirer l'attribut.
+    > [!NOTE]
+    > Cet attribut est un attribut booléen et indiquer `autoplay="false"` ne suffira pas à retirer la lecture automatique. Pour ce faire, il faut complètement retirer l'attribut.
 
-    > **Note :** Pour certains navigateurs (ex. Chrome 70), l'attribut `autoplay` ne fonctionne pas si aucun attribut `mute` n'est présent.
+    > [!NOTE]
+    > Pour certains navigateurs (ex. Chrome 70), l'attribut `autoplay` ne fonctionne pas si aucun attribut `mute` n'est présent.
 
 - `buffered`
   - : Un attribut qui peut être lu afin de déterminer l'intervalle temporel mis en mémoire tampon. Cet attribut contient un objet {{domxref("TimeRanges")}}.
@@ -93,7 +96,7 @@ Pour apprendre les bases concernant `<video>`, nous vous conseillons de consulte
 
     La valeur par défaut peut être différente selon le navigateur. La spécification conseille d'utiliser la valeur `metadata`.
 
-    > **Note :**
+    > [!NOTE]
     >
     > - L'attribut `autoplay` a la priorité sur `preload`. Si `autoplay` est défini, le navigateur doit nécessairement télécharger la vidéo pour la lancer.
     > - Cet attribut est simplement une indication, la spécification ne force pas le navigateur à respecter la valeur de cet attribut.

--- a/files/fr/web/html/element/xmp/index.md
+++ b/files/fr/web/html/element/xmp/index.md
@@ -7,7 +7,8 @@ slug: Web/HTML/Element/xmp
 
 L'élément HTML **`<xmp>`** (pour _example_) affiche le texte entre les balises d'ouverture et de fermeture sans interpréter le HTML qu'il contient et en utilisant une police à chasse fixe. La spécification HTML 2 recommande un affichage suffisamment large pour contenir 80 caractères par ligne.
 
-> **Note :** Ne pas utiliser cet élément.
+> [!NOTE]
+> Ne pas utiliser cet élément.
 >
 > - Il a été déprécié depuis HTML3.2 et n'a pas été implémenté d'une manière cohérente. Il a été complètement retiré du langage dans HTML5.
 > - Utilisez l'élément {{HTMLElement("pre")}} ou, si sémantiquement approprié, l'élément {{HTMLElement("code")}}. Notez qu'il vous faudra échapper les caractères '`<`' et '`>`' pour qu'ils ne soient pas interprétés.
@@ -21,7 +22,8 @@ Cet élément n'a aucun autre attribut en dehors [des attributs universels](/fr/
 
 Cet élément implémente l'interface {{domxref('HTMLElement')}}.
 
-> **Note :** Jusqu'à Gecko 1.9.2 inclus, Firefox implémentait l'interface {{domxref('HTMLSpanElement')}} pour cet élément.
+> [!NOTE]
+> Jusqu'à Gecko 1.9.2 inclus, Firefox implémentait l'interface {{domxref('HTMLSpanElement')}} pour cet élément.
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/web/html/global_attributes/accesskey/index.md
+++ b/files/fr/web/html/global_attributes/accesskey/index.md
@@ -7,7 +7,8 @@ slug: Web/HTML/Global_attributes/accesskey
 
 La combinaison de touches utilisée pour le raccourci clavier dépend du navigateur et du système d'exploitation utilisés.
 
-> **Note :** La spécification WHATWG indique qu'il est possible d'indiquer des caractères séparés par plusieurs espaces, auquel cas le navigateur considèrera le premier qu'il prend en charge. Toutefois, cela ne fonctionne pas dans la plupart des navigateurs. Pour IE/Edge, c'est la première valeur prise en charge qui sera utilisée si celle-ci n'entre pas en conflit avec d'autres commandes.
+> [!NOTE]
+> La spécification WHATWG indique qu'il est possible d'indiquer des caractères séparés par plusieurs espaces, auquel cas le navigateur considèrera le premier qu'il prend en charge. Toutefois, cela ne fonctionne pas dans la plupart des navigateurs. Pour IE/Edge, c'est la première valeur prise en charge qui sera utilisée si celle-ci n'entre pas en conflit avec d'autres commandes.
 
 <table class="standard-table">
   <thead>

--- a/files/fr/web/html/global_attributes/autofocus/index.md
+++ b/files/fr/web/html/global_attributes/autofocus/index.md
@@ -13,7 +13,8 @@ slug: Web/HTML/Global_attributes/autofocus
 
 L'attribut `autofocus` ne devrait pas être placé sur plus d'un élément au sein du document. S'il est placé sur plusieurs éléments, c'est le premier qui recevra le focus.
 
-> **Note :** L'attribut `autofocus` s'applique à tous les éléments, et pas seulement aux contrôles de formulaires. Par exemple, il peut être utilisé sur une zone [contenteditable](/fr/docs/Web/HTML/Global_attributes/contenteditable).
+> [!NOTE]
+> L'attribut `autofocus` s'applique à tous les éléments, et pas seulement aux contrôles de formulaires. Par exemple, il peut être utilisé sur une zone [contenteditable](/fr/docs/Web/HTML/Global_attributes/contenteditable).
 
 ## Remarques sur l'accessibilité de la fonctionnalité
 

--- a/files/fr/web/html/global_attributes/dir/index.md
+++ b/files/fr/web/html/global_attributes/dir/index.md
@@ -15,7 +15,8 @@ Les valeurs autorisées pour cet attribut sont :
 - `rtl` : qui signifie _right to left_ (droite à gauche), utilisé pour les langages écrits de droite à gauche (comme l'arabe par exemple)
 - `auto` : qui délègue la décision à l'agent utilisateur. L'algorithme utilisé est relativement simple : le contenu textuel est analysé et lorsque le premier caractère possédant une direction « forte » est rencontré, cette direction est prise pour l'ensemble de l'élément.
 
-> **Note :** Cet attribut est obligatoire pour l'élément {{HTMLElement("bdo")}}, pour lequel l'attribut a une sémantique différente.
+> [!NOTE]
+> Cet attribut est obligatoire pour l'élément {{HTMLElement("bdo")}}, pour lequel l'attribut a une sémantique différente.
 >
 > - La valeur de l'attribut n'est pas héritée par l'élément {{HTMLElement("bdi")}}. S'il n'est pas défini, la valeur par défaut sera `auto`.
 > - Cet attribut peut être surchargé par les propriétés CSS {{cssxref("direction")}} et {{cssxref("unicode-bidi")}}, (qui sont appliquées si une page CSS est active et que l'élément courant prend en charge ces propriétés).

--- a/files/fr/web/html/global_attributes/hidden/index.md
+++ b/files/fr/web/html/global_attributes/hidden/index.md
@@ -15,7 +15,8 @@ Les éléments cachés avec `hidden` ne devraient pas avoir de lien qui pointent
 
 Par exemple, on peut utiliser l'attribut ARIA `aria-describedby` pour faire référence à une description qui serait cachée (si cette dernière n'est pas pertinente seule). De même un élément {{HTMLElement("canvas")}} caché peut être utilisé comme un _buffer_ hors champ par moteur graphique scripté.
 
-> **Note :** Cet attribut sera surchargé par la propriété CSS {{cssxref("display")}}. Ainsi, un élément dont le style a `display: flex` sera affiché à l'écran, même si l'attribut `hidden` est présent.
+> [!NOTE]
+> Cet attribut sera surchargé par la propriété CSS {{cssxref("display")}}. Ainsi, un élément dont le style a `display: flex` sera affiché à l'écran, même si l'attribut `hidden` est présent.
 
 ## Spécifications
 

--- a/files/fr/web/html/global_attributes/id/index.md
+++ b/files/fr/web/html/global_attributes/id/index.md
@@ -9,11 +9,13 @@ L'[attribut universel](/fr/docs/Web/HTML/Attributs_universels) **`id`** définit
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-id.html","tabbed-shorter")}}
 
-> **Attention :** La valeur de cet attribut est une chaîne de caractère « opaque ». Cela signifie que cet attribut ne doit pas être utilisé pour transporter de l'information. Les informations sur la signification de l'élément dans le document ne doivent pas être portées par la valeur de cet attribut.
+> [!WARNING]
+> La valeur de cet attribut est une chaîne de caractère « opaque ». Cela signifie que cet attribut ne doit pas être utilisé pour transporter de l'information. Les informations sur la signification de l'élément dans le document ne doivent pas être portées par la valeur de cet attribut.
 
 La valeur de cet attribut ne doit pas contenir de blancs (espaces, tabulation, etc.). Les navigateurs interprèteront les identifiants avec des espaces comme si l'espace faisait partie de l'identifiant. Ce comportement est différent de celui de l'attribut [`class`](/fr/docs/Web/HTML/Global_attributes#class) qui permet d'avoir des valeurs séparées par des espaces. Les éléments ne peuvent avoir qu'un seul identifiant défini via l'attribut **`id`**.
 
-> **Note :** L'utilisation de caractères non-ASCII ou qui ne sont pas des chiffres latins ou`'_'`, `'-'` et `'.'` peut entraîner des problèmes de compatibilité car ils n'étaient pas autorisé avec HTML 4. Bien que cette restriction n'existe plus avec HTML 5, un identifiant devrait toujours commencer par une lettre pour une meilleure compatibilité.
+> [!NOTE]
+> L'utilisation de caractères non-ASCII ou qui ne sont pas des chiffres latins ou`'_'`, `'-'` et `'.'` peut entraîner des problèmes de compatibilité car ils n'étaient pas autorisé avec HTML 4. Bien que cette restriction n'existe plus avec HTML 5, un identifiant devrait toujours commencer par une lettre pour une meilleure compatibilité.
 
 ## Spécifications
 

--- a/files/fr/web/html/global_attributes/inert/index.md
+++ b/files/fr/web/html/global_attributes/inert/index.md
@@ -25,7 +25,8 @@ L'attribut `inert` peut être ajouté à des sections de contenu qui ne devraien
 
 L'attribut `inert` peut également être placé sur des éléments masqués ou en dehors de l'écran. En effet, un tel élément (avec ses descendants) est retiré de la navigation au clavier et de l'arbre d'accessibilité.
 
-> **Note :** Bien qu'`inert` soit un attribut universel qui puisse être appliqué à n'importe quel élément, on l'utilisera généralement pour des sections de contenu. Pour neutraliser des contrôles de façon individuelle, mieux vaudra utiliser l'attribut HTML [`disabled`](/fr/docs/Web/HTML/Attributes/disabled) et la pseudo-classe CSS [`:disabled`](/fr/docs/Web/CSS/:disabled).
+> [!NOTE]
+> Bien qu'`inert` soit un attribut universel qui puisse être appliqué à n'importe quel élément, on l'utilisera généralement pour des sections de contenu. Pour neutraliser des contrôles de façon individuelle, mieux vaudra utiliser l'attribut HTML [`disabled`](/fr/docs/Web/HTML/Attributes/disabled) et la pseudo-classe CSS [`:disabled`](/fr/docs/Web/CSS/:disabled).
 
 ## Accessibilité
 

--- a/files/fr/web/html/global_attributes/itemid/index.md
+++ b/files/fr/web/html/global_attributes/itemid/index.md
@@ -17,7 +17,8 @@ La signification exacte d'un identifiant global est déterminée par la spécifi
 itemid="URN"
 ```
 
-> **Note :** Selon la définition du WHATWG, un `itemid` doit être une URL. Dans l'exemple qui suit, on utilise plutôt une URN, plus appropriée pour définir un identifiant unique comme `itemid`. Cette incohérence reflète l'état actuellement incomplet de la spécification sur les microdonnées.
+> [!NOTE]
+> Selon la définition du WHATWG, un `itemid` doit être une URL. Dans l'exemple qui suit, on utilise plutôt une URN, plus appropriée pour définir un identifiant unique comme `itemid`. Cette incohérence reflète l'état actuellement incomplet de la spécification sur les microdonnées.
 
 ## Exemple
 

--- a/files/fr/web/html/global_attributes/itemprop/index.md
+++ b/files/fr/web/html/global_attributes/itemprop/index.md
@@ -278,7 +278,8 @@ Une propriété est un ensemble non-ordonné de composants uniques sensibles à 
 
    1. Une chaîne qui ne contient pas de caractères "**.**" (U+002E FULL STOP) ou "**:**" (U+003A COLON) et qui est utilisée comme un nom « propriétaire » pour la propriété (c'est-à-dire avec un nom qui n'est pas défini dans une spécification publique).
 
-> **Note :** Les caractères « : » sont interdits pour les valeurs qui ne sont pas des URL afin de pouvoir distinguer les URL du reste. Les valeurs avec les caractères « . » sont réservés pour de futurs ajouts et les blancs ne sont pas autorisés car les valeurs seraient analysées comme plusieurs valeurs distinctes.
+> [!NOTE]
+> Les caractères « : » sont interdits pour les valeurs qui ne sont pas des URL afin de pouvoir distinguer les URL du reste. Les valeurs avec les caractères « . » sont réservés pour de futurs ajouts et les blancs ne sont pas autorisés car les valeurs seraient analysées comme plusieurs valeurs distinctes.
 
 ## Valeurs
 

--- a/files/fr/web/html/global_attributes/itemref/index.md
+++ b/files/fr/web/html/global_attributes/itemref/index.md
@@ -9,7 +9,8 @@ L'[attribut universel](/fr/docs/Web/HTML/Attributs_universels) **`itemref`** per
 
 L'attribut `itemref` peut uniquement être défini sur des éléments pour lesquels un attribut `itemscope` a été défini.
 
-> **Note :** L'attribut `itemref` ne fait pas partie du modèle de données des micro-données. Il s'agit purement d'une construction syntaxique pour aider les auteurs à annoter une page où les données ne suivent pas une structure arborescente claire.
+> [!NOTE]
+> L'attribut `itemref` ne fait pas partie du modèle de données des micro-données. Il s'agit purement d'une construction syntaxique pour aider les auteurs à annoter une page où les données ne suivent pas une structure arborescente claire.
 
 ## Syntaxe
 

--- a/files/fr/web/html/global_attributes/itemscope/index.md
+++ b/files/fr/web/html/global_attributes/itemscope/index.md
@@ -177,7 +177,8 @@ Directions: <br>
   </tbody>
 </table>
 
-> **Note :** Pour extraire des micro-données d'un document HTML, vous pouvez utiliser [l'outil d'extraction de Google pour les micro-données.](https://developers.google.com/structured-data/testing-tool/) Vous pouvez par exemple utiliser le document HTML précédent.
+> [!NOTE]
+> Pour extraire des micro-données d'un document HTML, vous pouvez utiliser [l'outil d'extraction de Google pour les micro-données.](https://developers.google.com/structured-data/testing-tool/) Vous pouvez par exemple utiliser le document HTML précédent.
 
 ## Spécifications
 

--- a/files/fr/web/html/global_attributes/itemtype/index.md
+++ b/files/fr/web/html/global_attributes/itemtype/index.md
@@ -15,7 +15,8 @@ L'attribut `itemtype` peut uniquement être défini pour les éléments qui ont 
 
 Google et les autres moteurs de recherche participent au vocabulaire défini par [schema.org](http://schema.org/) pour structurer les données. Ce vocabulaire définit un ensemble standard de types et de noms de propriétés. Par exemple [`MusicEvent`](http://schema.org/MusicEvent) indique un événement musical dont les propriétés [`startDate`](http://schema.org/startDate) et [`location`](http://schema.org/location) utilisées pour définir les détails du concert. Dans ce cas, l'URL [`http://schema.org/MusicEvent`](http://schema.org/MusicEvent) sera l'URL utilisée pour l'attribut `itemtype` et les propriétés `startDate` et `location` seront les propriétés utilisées, définies par [`http://schema.org/MusicEvent`](http://schema.org/MusicEvent).
 
-> **Note :** Vous pourrez trouver plus d'informations sur l'attribut itemtype sur <http://schema.org/Thing>
+> [!NOTE]
+> Vous pourrez trouver plus d'informations sur l'attribut itemtype sur <http://schema.org/Thing>
 
 ## Syntaxe
 

--- a/files/fr/web/html/global_attributes/popover/index.md
+++ b/files/fr/web/html/global_attributes/popover/index.md
@@ -24,7 +24,8 @@ Ce qui suit affichera un bouton qui ouvrira un élément se superposant par-dess
 <div popover id="my-popover">Bonjour tout le monde !</div>
 ```
 
-> **Note :** Voir [la page listant des exemples d'utilisation de l'API <i lang="en">Popover</i>](https://mdn.github.io/dom-examples/popover-api/) pour accéder à l'ensemble des exemples MDN sur ce sujet.
+> [!NOTE]
+> Voir [la page listant des exemples d'utilisation de l'API <i lang="en">Popover</i>](https://mdn.github.io/dom-examples/popover-api/) pour accéder à l'ensemble des exemples MDN sur ce sujet.
 
 ## Spécifications
 

--- a/files/fr/web/html/global_attributes/style/index.md
+++ b/files/fr/web/html/global_attributes/style/index.md
@@ -9,7 +9,8 @@ L'[attribut universel](/fr/docs/Web/HTML/Attributs_universels) **`style`** conti
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-style.html","tabbed-shorter")}}
 
-> **Note :** Cet attribut ne doit pas être utilisé à des fins sémantiques. En effet, si toute mise en forme est retirée, toute page doit rester correcte d'un point de vue sémantique. On ne devrait pas, notamment, utiliser cet attribut afin de cacher des informations qui ne seraient pas pertinentes (cela devrait être réalisé avec l'attribut [`hidden`](/fr/docs/Web/HTML/Global_attributes#hidden).
+> [!NOTE]
+> Cet attribut ne doit pas être utilisé à des fins sémantiques. En effet, si toute mise en forme est retirée, toute page doit rester correcte d'un point de vue sémantique. On ne devrait pas, notamment, utiliser cet attribut afin de cacher des informations qui ne seraient pas pertinentes (cela devrait être réalisé avec l'attribut [`hidden`](/fr/docs/Web/HTML/Global_attributes#hidden).
 
 ## Exemples
 

--- a/files/fr/web/html/global_attributes/tabindex/index.md
+++ b/files/fr/web/html/global_attributes/tabindex/index.md
@@ -13,19 +13,23 @@ Cet attribut peut prendre l'une des valeurs suivantes :
 
 - Une valeur négative : l'élément peut capturer le focus mais ne peut pas être atteint via la navigation au clavier ;
 
-  > **Note :** Cette valeur peut être utile lorsqu'on a un contenu situé en dehors de l'écran qui doit apparaître lors d'un évènement donné. Il ne sera pas possible d'y passer le focus au clavier mais on pourra le faire avec [la méthode `focus()`](/fr/docs/Web/API/HTMLElement/focus).
+  > [!NOTE]
+  > Cette valeur peut être utile lorsqu'on a un contenu situé en dehors de l'écran qui doit apparaître lors d'un évènement donné. Il ne sera pas possible d'y passer le focus au clavier mais on pourra le faire avec [la méthode `focus()`](/fr/docs/Web/API/HTMLElement/focus).
 
 - `0` : l'élément peut capturer le focus et être atteint via la navigation au clavier, cependant son ordre relatif est défini par la plateforme, généralement selon l'ordre des éléments du DOM ;
 
-  > **Attention :** Le positionnement CSS n'aura pas d'impact sur le `taborder`. Le positionnement n'a qu'un impact visuel, l'ordre des tabulations correspond à l'ordre du DOM.
+  > [!WARNING]
+  > Le positionnement CSS n'aura pas d'impact sur le `taborder`. Le positionnement n'a qu'un impact visuel, l'ordre des tabulations correspond à l'ordre du DOM.
 
 - Une valeur positive : l'élément peut capturer le focus et peut être atteint via la navigation au clavier, l'ordre relatif dans la navigation est défini par la valeur de l'attribut. Les navigations seront parcourues dans l'ordre croissant.
 
-  > **Attention :** Il n'est pas recommandé de fournir des valeurs positives pour les éléments car cela peut être source de confusion, notamment pour les personnes qui utilisent des technologies d'assistance. Il est préférable d'organiser les éléments dans un ordre correct au niveau du DOM.
+  > [!WARNING]
+  > Il n'est pas recommandé de fournir des valeurs positives pour les éléments car cela peut être source de confusion, notamment pour les personnes qui utilisent des technologies d'assistance. Il est préférable d'organiser les éléments dans un ordre correct au niveau du DOM.
 
 Si on utilise l'attribut `tabindex` sur un élément {{HTMLElement("div")}}, on ne pourra pas naviguer dans le contenu de cet élément avec les flèches du clavier, sauf si `tabindex` est également utilisé sur le contenu. Pour observer ce comportement, vous pouvez utiliser [cet exemple JSFiddle](https://jsfiddle.net/jainakshay/0b2q4Lgv/).
 
-> **Note :** La valeur maximale pour `tabindex` est fixée à 32767 par HTML4. Sa valeur par défaut est 0 pour les éléments qui peuvent recevoir le focus et -1 pour les autres.
+> [!NOTE]
+> La valeur maximale pour `tabindex` est fixée à 32767 par HTML4. Sa valeur par défaut est 0 pour les éléments qui peuvent recevoir le focus et -1 pour les autres.
 
 ## Exemples
 

--- a/files/fr/web/html/global_attributes/translate/index.md
+++ b/files/fr/web/html/global_attributes/translate/index.md
@@ -10,7 +10,8 @@ L'[attribut universel](/fr/docs/Web/HTML/Attributs_universels) **`translate`** e
 - `"yes"` (ou une chaîne vide), qui indique que l'élément devrait être traduit lorsque la page est localisée ;
 - `"no"`, qui indique que l'élément ne doit pas être traduit.
 
-> **Note :** Bien que la prise en charge de cet attribut ne soit pas homogène pour les navigateurs, celui-ci est pris en compte par les outils de traduction automatique (Google Translate par exemple) et les outils de traduction utilisés par les traducteurs. Aussi, cet attribut doit être utilisé par les auteurs web afin d'indiquer correctement le contenu qui ne devrait pas être traduit.
+> [!NOTE]
+> Bien que la prise en charge de cet attribut ne soit pas homogène pour les navigateurs, celui-ci est pris en compte par les outils de traduction automatique (Google Translate par exemple) et les outils de traduction utilisés par les traducteurs. Aussi, cet attribut doit être utilisé par les auteurs web afin d'indiquer correctement le contenu qui ne devrait pas être traduit.
 
 ## Exemples
 

--- a/files/fr/web/html/index.md
+++ b/files/fr/web/html/index.md
@@ -24,7 +24,7 @@ Les articles suivants fournissent des éléments de référence utiles au dével
 - Référence HTML
   - : Dans notre [référence exhaustive](/fr/docs/Web/HTML/Reference), vous trouverez le détail de chaque élément et attribut constituant HTML.
 
-> **Remarque :**
+> [!CALLOUT]
 >
 > #### Vous cherchez à devenir un développeur web front-end ?
 >

--- a/files/fr/web/html/microdata/index.md
+++ b/files/fr/web/html/microdata/index.md
@@ -14,7 +14,8 @@ Les microdonnées sont des groupes de paires nom-valeur. Ces groupes sont appel�
 
 Google et les autres moteurs de recherches participent au vocabulaire défini par [schema.org](https://schema.org/) pour structurer les données. Ce vocabulaire définit un ensemble standard de types et de noms de propriétés. Par exemple [`MusicEvent`](https://schema.org/MusicEvent) indique un événement musical dont les propriétés [`startDate`](https://schema.org/startDate) et [`location`](https://schema.org/location) utilisées pour définir les détails du concert. Dans ce cas, l'URL [`https://schema.org/MusicEvent`](https://schema.org/MusicEvent) sera l'URL utilisée pour l'attribut `itemtype` et les propriétés `startDate` et `location` seront les propriétés utilisées, définies par [`https://schema.org/MusicEvent`](https://schema.org/MusicEvent).
 
-> **Note :** Pour en savoir plus sur les attributs `itemtype`, consultez le site <http://schema.org/Thing>.
+> [!NOTE]
+> Pour en savoir plus sur les attributs `itemtype`, consultez le site <http://schema.org/Thing>.
 
 Les vocabulaires de microdonnées fournissent la sémantique ou la signification d'un élément. Les développeurs Web peuvent concevoir un vocabulaire personnalisé ou utiliser des vocabulaires disponibles sur le Web, tels que le vocabulaire largement utilisé [schema.org](http://schema.org). Une collection de vocabulaires de balisage couramment utilisés est fournie par Schema.org.
 
@@ -143,7 +144,8 @@ Dans certains cas, les moteurs de recherche couvrent un public régional. Certai
 
 {{EmbedLiveSample("HTML", "", "100")}}
 
-> **Note :** Un outil pratique pour extraire les structures de microdonnées du HTML est l'[outil de test des données structurées](https://developers.google.com/search/docs/guides/intro-structured-data) de Google. Essayez-le sur le HTML présenté ci-dessus.
+> [!NOTE]
+> Un outil pratique pour extraire les structures de microdonnées du HTML est l'[outil de test des données structurées](https://developers.google.com/search/docs/guides/intro-structured-data) de Google. Essayez-le sur le HTML présenté ci-dessus.
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/web/html/microformats/index.md
+++ b/files/fr/web/html/microformats/index.md
@@ -126,7 +126,8 @@ Cela fournira le JSON suivant :
 }
 ```
 
-> **Note :** Le h-card imbriqué récupère des valeurs implicites pour `name` et `url`.
+> [!NOTE]
+> Le h-card imbriqué récupère des valeurs implicites pour `name` et `url`.
 
 ### h-entry
 

--- a/files/fr/web/html/viewport_meta_tag/index.md
+++ b/files/fr/web/html/viewport_meta_tag/index.md
@@ -31,7 +31,8 @@ La propriété `width` contrôle la taille de la zone d'affichage. Elle peut êt
 
 La propriété `initial-scale` contrôle le niveau de zoom lors du premier chargement de la page. Les propriétés `maximum-scale`, `minimum-scale` et `user-scalable` contrôlent la manière dont les utilisateurs et utilisatrices sont autorisé·e·s à zoomer ou dézoomer la page.
 
-> **Attention :** L'utilisation du `user-scalable=no` peut causer des problèmes d'accessibilité aux utilisateurs et utilisatrices ayant des déficiences visuelles telles qu'une vision faible.
+> [!WARNING]
+> L'utilisation du `user-scalable=no` peut causer des problèmes d'accessibilité aux utilisateurs et utilisatrices ayant des déficiences visuelles telles qu'une vision faible.
 
 ## Un pixel n'est pas un pixel
 

--- a/files/fr/web/http/basics_of_http/data_urls/index.md
+++ b/files/fr/web/http/basics_of_http/data_urls/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Basics_of_HTTP/Data_URLs
 
 **Les URLs de données**, les URLs préfixées par le schéma `data:`, permettent aux créateurs de contenu d'intégrer de petits fichiers dans des documents.
 
-> **Note :** Les URLs de données sont traitées comme des origines opaques uniques par les navigateurs modernes, ainsi, contrairement aux autres objets classiques, ces URLs n'héritent pas des propriétés de l'objet ayant mené à cette URL.
+> [!NOTE]
+> Les URLs de données sont traitées comme des origines opaques uniques par les navigateurs modernes, ainsi, contrairement aux autres objets classiques, ces URLs n'héritent pas des propriétés de l'objet ayant mené à cette URL.
 
 ## Syntaxe
 

--- a/files/fr/web/http/basics_of_http/mime_types/index.md
+++ b/files/fr/web/http/basics_of_http/mime_types/index.md
@@ -67,7 +67,8 @@ Il s'agit de la valeur par défaut pour un fichier binaire. Etant donné qu'il s
 
 Il s'agit de la valeur par défaut pour les fichiers texte. Bien qu'il signifie fichier texte de format inconnu, les navigateurs prendront pour hypothèse qu'ils peuvent l'afficher.
 
-> **Note :** Il est important de noter que `text/plain` ne signifie pas _tous les formats de fichiers textuels_. Si le client s'attend à recevoir un format particulier de données textuelles, il est vraisemblable que le type `text/plain` ne soit pas considéré comme valide à la réception. Par exemple, si le client télécharge un fichier `text/plain` à partir d'un {{HTMLElement("link")}} déclarant des fichiers CSS, ce dernier ne sera pas considéré comme un CSS, le type MIME à utiliser étant `text/css`.
+> [!NOTE]
+> Il est important de noter que `text/plain` ne signifie pas _tous les formats de fichiers textuels_. Si le client s'attend à recevoir un format particulier de données textuelles, il est vraisemblable que le type `text/plain` ne soit pas considéré comme valide à la réception. Par exemple, si le client télécharge un fichier `text/plain` à partir d'un {{HTMLElement("link")}} déclarant des fichiers CSS, ce dernier ne sera pas considéré comme un CSS, le type MIME à utiliser étant `text/css`.
 
 ### `text/css`
 

--- a/files/fr/web/http/basics_of_http/resource_urls/index.md
+++ b/files/fr/web/http/basics_of_http/resource_urls/index.md
@@ -45,7 +45,8 @@ Auparavant, les sites web étaient capables d'accéder à n'importe quelle URI `
 
 Firefox nécessite néanmoins le chargement des ressources au sein d'un contenu web dans certains cas. Ainsi lorsque l'on souhaite accéder au code source d'une page à l'aide de "Code source de la page", un appel à `viewsource.css` via une URI `resource:` est nécessaire. Les ressources auxquelles le contenu web a besoin d'accéder ont été déplacées sous `resource://content-accessible/`, une partie isolée et ne contenant que des ressources n'étant pas confidentielles. De cette manière, il est possible d'exposer des ressources tout en réduisant la plupart des menaces.
 
-> **Note :** Il est recommandé de ne plus utiliser les URLs de type ressource lors du développement web ou de celui d'un module. Leur utilisation était peu fiable et la plupart ne fonctionnent plus.
+> [!NOTE]
+> Il est recommandé de ne plus utiliser les URLs de type ressource lors du développement web ou de celui d'un module. Leur utilisation était peu fiable et la plupart ne fonctionnent plus.
 
 ## Spécifications
 

--- a/files/fr/web/http/browser_detection_using_the_user_agent/index.md
+++ b/files/fr/web/http/browser_detection_using_the_user_agent/index.md
@@ -9,7 +9,8 @@ Afficher des pages web ou des services en fonction du navigateur est généralem
 
 Les navigateurs et les standards ne sont cependant pas parfaits, il reste certains cas limites pour lesquels connaître le navigateur utilisé peut s'avérer utile. Utiliser la chaîne de caractères fournie par l'en-tête HTTP [`User-Agent`](/fr/docs/Web/HTTP/Headers/User-Agent) et disponible en JavaScript via la propriété [`navigator.userAgent`](/fr/docs/Web/API/Navigator/userAgent) dans ce but paraît simple, mais le faire de manière fiable est en réalité très difficile. Ce document va vous guider pour le faire aussi correctement que possible.
 
-> **Note :** Il est important de rappeler qu'utiliser le contenu de l'en-tête `User-Agent` est rarement une bonne idée. Il est presque toujours possible de trouver une solution plus générique et compatible avec un plus grand nombre de navigateurs et d'appareils&nbsp;!
+> [!NOTE]
+> Il est important de rappeler qu'utiliser le contenu de l'en-tête `User-Agent` est rarement une bonne idée. Il est presque toujours possible de trouver une solution plus générique et compatible avec un plus grand nombre de navigateurs et d'appareils&nbsp;!
 
 ## Considérations à prendre en compte avant d'identifier le navigateur
 
@@ -262,4 +263,5 @@ Le tableau suivant résume de quelle façon les principaux navigateurs indiquent
 
 En résumé, nous recommandons de chercher la chaîne `Mobi` dans la chaîne `User-Agent` pour détecter un appareil mobile.
 
-> **Note:** Si l'appareil est suffisamment grand pour ne pas être indiqué `Mobi`, il est préférable de servir la version du site pour ordinateur. De toute manière, supporter les interactions tactiles pour un site «&nbsp;pour ordinateur&nbsp;» est une bonne pratique. En effet, de plus en plus d'ordinateurs sont équipés d'écrans tactiles.
+> [!NOTE]
+> Si l'appareil est suffisamment grand pour ne pas être indiqué `Mobi`, il est préférable de servir la version du site pour ordinateur. De toute manière, supporter les interactions tactiles pour un site «&nbsp;pour ordinateur&nbsp;» est une bonne pratique. En effet, de plus en plus d'ordinateurs sont équipés d'écrans tactiles.

--- a/files/fr/web/http/client_hints/index.md
+++ b/files/fr/web/http/client_hints/index.md
@@ -17,7 +17,8 @@ Accept-CH: Width, Viewport-Width, Downlink
 
 Le serveur peut alors utiliser ces informations du client pour déterminer les ressources à lui envoyer.
 
-> **Note :** Les indications du client peuvent aussi être formulées en HTML à l'aide de l'élément [`<meta>`](/fr/docs/Web/HTML/Element/meta) avec l'attribut [`http-equiv`](/fr/docs/Web/HTML/Element/meta#attr-http-equiv) :
+> [!NOTE]
+> Les indications du client peuvent aussi être formulées en HTML à l'aide de l'élément [`<meta>`](/fr/docs/Web/HTML/Element/meta) avec l'attribut [`http-equiv`](/fr/docs/Web/HTML/Element/meta#attr-http-equiv) :
 >
 > ```html
 > <meta http-equiv="Accept-CH" content="Width, Viewport-Width, Downlink" />

--- a/files/fr/web/http/compression/index.md
+++ b/files/fr/web/http/compression/index.md
@@ -26,7 +26,8 @@ Certains formats peuvent être utilisés à la fois pour une compression sans pe
 
 Les algorithmes de compression avec pertes sont généralement plus performants que les algorithmes de compression sans perte.
 
-> **Note :** Puisque certains types de fichiers gèrent nativement la compression, il est souvent inutile de les compresser une seconde fois. En réalité, cela s'avère souvent contre-productif de par la taille induite par les données additionnelles nécessaires (lors de la compression, un dictionnaire de données est généré) le fichier en sortie est alors plus gros que celui avant compression. Veillez à ne pas utiliser les techniques suivantes pour les fichiers au format compressé.
+> [!NOTE]
+> Puisque certains types de fichiers gèrent nativement la compression, il est souvent inutile de les compresser une seconde fois. En réalité, cela s'avère souvent contre-productif de par la taille induite par les données additionnelles nécessaires (lors de la compression, un dictionnaire de données est généré) le fichier en sortie est alors plus gros que celui avant compression. Veillez à ne pas utiliser les techniques suivantes pour les fichiers au format compressé.
 
 ## Compression de bout en bout
 

--- a/files/fr/web/http/content_negotiation/index.md
+++ b/files/fr/web/http/content_negotiation/index.md
@@ -48,7 +48,8 @@ L'en-tête `Accept` est défini par le navigateur (ou tout autre agent utilisate
 
 ### L'en-tête `Accept-CH` {{experimental_inline}}
 
-> **Note :** Cet en-tête fait partie de la technologie **expérimentale** des _indications client_ (<i lang="en">client hints</i>). La prise en charge initiale est arrivée avec Chrome 46 et celle de la valeur `Device-Memory` avec Chrome 61.
+> [!NOTE]
+> Cet en-tête fait partie de la technologie **expérimentale** des _indications client_ (<i lang="en">client hints</i>). La prise en charge initiale est arrivée avec Chrome 46 et celle de la valeur `Device-Memory` avec Chrome 61.
 
 L'en-tête expérimental [`Accept-CH`](/fr/docs/Web/HTTP/Headers/Accept-CH) expose les données de configuration que le serveur peut utiliser afin de déterminer une réponse appropriée. Les valeurs valides sont&nbsp;:
 
@@ -60,7 +61,8 @@ L'en-tête expérimental [`Accept-CH`](/fr/docs/Web/HTTP/Headers/Accept-CH) expo
 
 ### L'en-tête `Accept-CH-Lifetime` {{experimental_inline}}
 
-> **Note :** Cet en-tête fait partie de la technologie **expérimentale** des _indications client_ (<i lang="en">client hints</i>) et est uniquement disponible pour Chrome, à partir de Chrome 61.
+> [!NOTE]
+> Cet en-tête fait partie de la technologie **expérimentale** des _indications client_ (<i lang="en">client hints</i>) et est uniquement disponible pour Chrome, à partir de Chrome 61.
 
 L'en-tête [`Accept-CH-Lifetime`](/fr/docs/Web/HTTP/Headers/Accept-CH-Lifetime) est utilisé de concert avec la valeur `Device-Memory` de l'en-tête `Accept-CH` et indique la durée pendant laquelle l'appareil devrait partager sa quantité de mémoire vive. La valeur est exprimée en millisecondes et est optionnelle.
 
@@ -81,7 +83,8 @@ En raison de [l'entropie croissante déduite de la configuration](https://www.ef
 
 ### L'en-tête `User-Agent`
 
-> **Note :** Bien qu'il existe certains cas d'usage légitimes pour cet en-tête afin de sélectionner du contenu, [il s'agit d'une mauvaise pratique](/fr/docs/Web/HTTP/Browser_detection_using_the_user_agent) quand il s'agit de déterminer les fonctionnalités prises en charge ou non par l'agent utilisateur.
+> [!NOTE]
+> Bien qu'il existe certains cas d'usage légitimes pour cet en-tête afin de sélectionner du contenu, [il s'agit d'une mauvaise pratique](/fr/docs/Web/HTTP/Browser_detection_using_the_user_agent) quand il s'agit de déterminer les fonctionnalités prises en charge ou non par l'agent utilisateur.
 
 L'en-tête [`User-Agent`](/fr/docs/Web/HTTP/Headers/User-Agent) identifie le navigateur qui envoie la requête. Cette chaîne de caractères peut contenir une liste de _jetons produits_ et de _commentaires_ séparés par des espaces.
 

--- a/files/fr/web/http/cookies/index.md
+++ b/files/fr/web/http/cookies/index.md
@@ -25,7 +25,8 @@ Les cookies ont été un outil général de stockage côté client. Bien que cel
 - [L'API Web Storage](/fr/docs/Web/API/Web_Storage_API) (`localStorage` et `sessionStorage`)
 - [IndexedDB](/fr/docs/Web/API/IndexedDB_API).
 
-> **Note :** Pour observer les cookies enregistrés (et les autres types de stockage utilisés par une page web), vous pouvez activer [l'inspecteur de stockage](https://firefox-source-docs.mozilla.org/devtools-user/storage_inspector/index.html) dans les outils de développement de Firefox et ouvrir le niveau Cookies dans la hiérarchie de l'onglet Stockage.
+> [!NOTE]
+> Pour observer les cookies enregistrés (et les autres types de stockage utilisés par une page web), vous pouvez activer [l'inspecteur de stockage](https://firefox-source-docs.mozilla.org/devtools-user/storage_inspector/index.html) dans les outils de développement de Firefox et ouvrir le niveau Cookies dans la hiérarchie de l'onglet Stockage.
 
 ## Créer un cookie
 
@@ -58,7 +59,8 @@ Host: www.example.org
 Cookie: delicieux_cookie=choco; savoureux_cookie=menthe
 ```
 
-> **Note :** Voici différents guides pour utiliser l'en-tête `Set-Cookie` avec différentes technologies côté serveur&nbsp;:
+> [!NOTE]
+> Voici différents guides pour utiliser l'en-tête `Set-Cookie` avec différentes technologies côté serveur&nbsp;:
 >
 > - [PHP](https://www.php.net/manual/en/function.setcookie.php)
 > - [Node.JS](https://nodejs.org/dist/latest/docs/api/http.html#http_response_setheader_name_value)
@@ -78,7 +80,8 @@ Par exemple&nbsp;:
 Set-Cookie: id=a3fWa; Expires=Thu, 31 Oct 2021 07:28:00 GMT;
 ```
 
-> **Note :** Lorsqu'une date et une heure sont indiquées dans l'attribut `Expires`, elles sont relatives au client qui enregistre le cookie et pas au serveur.
+> [!NOTE]
+> Lorsqu'une date et une heure sont indiquées dans l'attribut `Expires`, elles sont relatives au client qui enregistre le cookie et pas au serveur.
 
 Si votre site permet d'authentifier des utilisatrices ou utilisateurs, il devrait régénérer et renvoyer les cookies de session à chaque fois que la personne s'authentifie, y compris pour ceux qui existent déjà. Cette approche permet d'éviter [les attaques par fixation de session](/fr/docs/Web/Security/Types_of_attacks#fixation_de_session), où une tierce partie peut réutiliser des cookies de session.
 
@@ -148,7 +151,8 @@ Voici un exemple&nbsp;:
 Set-Cookie: macle=mavaleur; SameSite=Strict
 ```
 
-> **Note :** La spécification concernant `SameSite` a changé (MDN documente le comportement actuel). Voir [le tableau de compatibilité pour `SameSite`](/fr/docs/Web/HTTP/Headers/Set-Cookie/SameSite#compatibilité_des_navigateurs) pour plus d'informations dont l'attribut est géré selon les versions des navigateurs&nbsp;:
+> [!NOTE]
+> La spécification concernant `SameSite` a changé (MDN documente le comportement actuel). Voir [le tableau de compatibilité pour `SameSite`](/fr/docs/Web/HTTP/Headers/Set-Cookie/SameSite#compatibilité_des_navigateurs) pour plus d'informations dont l'attribut est géré selon les versions des navigateurs&nbsp;:
 >
 > - `SameSite=Lax` est désormais la valeur par défaut si `SameSite` n'est pas indiqué. Auparavant, les cookies étaient par défaut envoyés pour toutes les requêtes.
 > - Les cookies avec `SameSite=None` doivent désormais utiliser l'attribut `Secure` (autrement dit, le contexte doit être sécurisé).
@@ -174,7 +178,8 @@ Comme [mesure de défense en profondeur](https://fr.wikipedia.org/wiki/Défense_
 
 Le navigateur rejettera les cookies avec ces préfixes et qui ne respectent pas ces contraintes. On notera qu'ainsi, les cookies créés par les sous-domaines et avec ces préfixes sont confinés au sous-domaine en question ou ignorés complètement. Comme le serveur d'application vérifie uniquement le nom d'un cookie donné pour l'authentification ou la validité d'un jeton CSRF, cela sert de mesure contre les fixations de session.
 
-> **Attention :** Sur le serveur d'application, l'application web _doit_ vérifier le nom complet du cookie, incluant le préfixe. Les agents utilisateurs ne suppriment pas le préfixe avant de l'envoyer dans l'en-tête [`Cookie`](/fr/docs/Web/HTTP/Headers/Cookie) de la réponse.
+> [!WARNING]
+> Sur le serveur d'application, l'application web _doit_ vérifier le nom complet du cookie, incluant le préfixe. Les agents utilisateurs ne suppriment pas le préfixe avant de l'envoyer dans l'en-tête [`Cookie`](/fr/docs/Web/HTTP/Headers/Cookie) de la réponse.
 
 Pour plus d'informations sur les préfixes et la compatibilité des navigateurs associée, voir [la section sur les préfixes de la page sur l'article de référence `Set-Cookie`](/fr/docs/Web/HTTP/Headers/Set-Cookie#préfixes_de_cookie).
 
@@ -195,7 +200,8 @@ Voir la section qui suit sur [la sécurité](#sécurité)&nbsp;: les cookies dis
 
 ## Sécurité
 
-> **Note :** Quand des informations sont enregistrées dans des cookies, elles sont visibles et éditables par l'utilisatrice ou l'utilisateur final·e. Selon le cas d'usage de l'application, vous pouvez utiliser un identifiant opaque qui sera utilisé par le serveur ou utiliser d'autres mécanismes d'authentification ou de confidentialité comme [les JSON Web Tokens](https://jwt.io/introduction).
+> [!NOTE]
+> Quand des informations sont enregistrées dans des cookies, elles sont visibles et éditables par l'utilisatrice ou l'utilisateur final·e. Selon le cas d'usage de l'application, vous pouvez utiliser un identifiant opaque qui sera utilisé par le serveur ou utiliser d'autres mécanismes d'authentification ou de confidentialité comme [les JSON Web Tokens](https://jwt.io/introduction).
 
 Plusieurs mécanismes existent pour prévenir les attaques utilisant les cookies&nbsp;:
 
@@ -214,7 +220,8 @@ Si le domaine et schéma sont différents, le cookie n'est pas considéré comme
 
 Un serveur tiers peut créer un profil d'une personne à partir des habitudes et parcours de navigation grâce aux cookies qui lui sont envoyés par le navigateur lors de l'accès à différents sites. Par défaut, Firefox et Safari bloquent les cookies tiers connus pour le pistage. Ces cookies peuvent aussi être bloqués en utilisant les paramètres des autres navigateurs ou des extensions. Le blocage des cookies peut parfois empêcher le bon fonctionnement de composants tiers (comme les intégrations de réseaux sociaux).
 
-> **Note :** Les serveurs peuvent (et devraient) définir [l'attribut `SameSite`](/fr/docs/Web/HTTP/Headers/Set-Cookie/SameSite) pour indiquer si un cookie peut être envoyé ou non à un site tierce.
+> [!NOTE]
+> Les serveurs peuvent (et devraient) définir [l'attribut `SameSite`](/fr/docs/Web/HTTP/Headers/Set-Cookie/SameSite) pour indiquer si un cookie peut être envoyé ou non à un site tierce.
 
 ### Régulations relatives aux cookies
 

--- a/files/fr/web/http/cors/errors/corsmissingalloworigin/index.md
+++ b/files/fr/web/http/cors/errors/corsmissingalloworigin/index.md
@@ -35,7 +35,8 @@ Vous pouvez aussi configurer le serveur pour autoriser tous les domaines à acc�
 Access-Control-Allow-Origin: *
 ```
 
-> **Attention :** Autoriser n'importe quel site à accéder à une API privée est une mauvaise idée.
+> [!WARNING]
+> Autoriser n'importe quel site à accéder à une API privée est une mauvaise idée.
 
 Pour autoriser n'importe quel site à faire des requêtes CORS _sans_ utiliser le caractère générique `*` (par exemple, pour fournir des authentifiants), votre serveur doit lire la valeur de l'en-tête `Origin` de la requête et l'utiliser dans `Access-Control-Allow-Origin`, tout en ajoutant un en-tête `Vary: Origin` pour indiquer que certains en-têtes sont définis dynamiquement selon leur origine.
 

--- a/files/fr/web/http/cors/errors/corsrequestnothttp/index.md
+++ b/files/fr/web/http/cors/errors/corsrequestnothttp/index.md
@@ -40,7 +40,8 @@ Les développeuses et développeurs qui doivent réaliser des tests en local doi
 
 De cette façon, l'ensemble des fichiers est servi depuis le même domaine (`localhost`) et avec le même schéma&nbsp;: ils ont la même origine et ne déclenchent plus d'erreurs liées à la multiplicité des origines.
 
-> **Note :** Ce changement est en accord avec [la spécification sur les URL](https://url.spec.whatwg.org/#origin), qui laisse l'implémentation libre du comportement quant à l'origine des fichiers, mais qui recommande, en cas de doute, de considérer les origines des fichiers comme opaques.
+> [!NOTE]
+> Ce changement est en accord avec [la spécification sur les URL](https://url.spec.whatwg.org/#origin), qui laisse l'implémentation libre du comportement quant à l'origine des fichiers, mais qui recommande, en cas de doute, de considérer les origines des fichiers comme opaques.
 
 ## Voir aussi
 

--- a/files/fr/web/http/cors/errors/index.md
+++ b/files/fr/web/http/cors/errors/index.md
@@ -28,7 +28,8 @@ reading the remote resource at https://some-url-here. (Reason:
 additional information here).
 ```
 
-> **Note :** Pour des raisons de sécurité, il _est impossible_ d'analyser les causes de l'erreur CORS via JavaScript. Seule une indication de l'échec de la requête sera fournie. Il faut donc absolument regarder manuellement les messages d'erreur de la console pour débugger.
+> [!NOTE]
+> Pour des raisons de sécurité, il _est impossible_ d'analyser les causes de l'erreur CORS via JavaScript. Seule une indication de l'échec de la requête sera fournie. Il faut donc absolument regarder manuellement les messages d'erreur de la console pour débugger.
 
 ## Messages d'erreur CORS
 

--- a/files/fr/web/http/cors/index.md
+++ b/files/fr/web/http/cors/index.md
@@ -74,9 +74,11 @@ Certaines requêtes ne nécessitent pas de [requête CORS préliminaire](#prefli
 - Aucun gestionnaire d'évènement n'est enregistré sur aucun des objets {{domxref("XMLHttpRequestUpload")}} utilisés pour la requête, on y accède via la propriété {{domxref("XMLHttpRequest.upload")}}.
 - Aucun objet {{domxref("ReadableStream")}} n'est utilisé dans la requête.
 
-> **Note :** Cela correspond aux classes de requêtes généralement produites par du contenu web. Aucune donnée de réponse n'est envoyée au client qui a lancé la requête sauf si le serveur envoie un en-tête approprié. Aussi, les sites qui empêchent les requêtes étrangères falsifiées ne craignent rien de nouveau.
+> [!NOTE]
+> Cela correspond aux classes de requêtes généralement produites par du contenu web. Aucune donnée de réponse n'est envoyée au client qui a lancé la requête sauf si le serveur envoie un en-tête approprié. Aussi, les sites qui empêchent les requêtes étrangères falsifiées ne craignent rien de nouveau.
 
-> **Note :** WebKit Nightly et Safari Technology Preview ajoutent des restrictions supplémentaires pour les valeurs autorisées des en-têtes {{HTTPHeader("Accept")}}, {{HTTPHeader("Accept-Language")}} et {{HTTPHeader("Content-Language")}}. Si l'un de ces en-têtes a une valeur non-standard, WebKit/Safari considère que la requête ne correspond pas à une requête simple. Les valeurs considérées comme non-standard par WebKit/Safari ne sont pas documentées en dehors de ces bugs WebKit : _[Require preflight for non-standard CORS-safelisted request headers Accept, Accept-Language, and Content-Language](https://bugs.webkit.org/show_bug.cgi?id=165178)_, _[Allow commas in Accept, Accept-Language, and Content-Language request headers for simple CORS](https://bugs.webkit.org/show_bug.cgi?id=165566)_ et _[Switch to a blacklist model for restricted Accept headers in simple CORS requests](https://bugs.webkit.org/show_bug.cgi?id=166363)_. Aucun autre navigateur n'implémente ces restrictions supplémentaires, car elles ne font pas partie de la spécification.
+> [!NOTE]
+> WebKit Nightly et Safari Technology Preview ajoutent des restrictions supplémentaires pour les valeurs autorisées des en-têtes {{HTTPHeader("Accept")}}, {{HTTPHeader("Accept-Language")}} et {{HTTPHeader("Content-Language")}}. Si l'un de ces en-têtes a une valeur non-standard, WebKit/Safari considère que la requête ne correspond pas à une requête simple. Les valeurs considérées comme non-standard par WebKit/Safari ne sont pas documentées en dehors de ces bugs WebKit : _[Require preflight for non-standard CORS-safelisted request headers Accept, Accept-Language, and Content-Language](https://bugs.webkit.org/show_bug.cgi?id=165178)_, _[Allow commas in Accept, Accept-Language, and Content-Language request headers for simple CORS](https://bugs.webkit.org/show_bug.cgi?id=165566)_ et _[Switch to a blacklist model for restricted Accept headers in simple CORS requests](https://bugs.webkit.org/show_bug.cgi?id=166363)_. Aucun autre navigateur n'implémente ces restrictions supplémentaires, car elles ne font pas partie de la spécification.
 
 Si, par exemple, on a un contenu web situé sous le domaine `http://toto.example` qui souhaite invoquer du contenu situé sous le domaine `http://truc.autre`, on pourrait utiliser du code JavaScript semblable à ce qui suit sur `toto.example` :
 
@@ -168,7 +170,8 @@ Une requête devra être précédée d'une requête préliminaire si **une** des
 - **Ou si** un ou plusieurs gestionnaires d'évènements sont enregistrés sur l'objet {{domxref("XMLHttpRequestUpload")}} utilisé dans la requête.
 - **Ou si** un objet {{domxref("ReadableStream")}} est utilisé dans la requête.
 
-> **Note :** WebKit Nightly et Safari Technology Preview ajoutent des restrictions supplémentaires pour les valeurs autorisées des en-têtes {{HTTPHeader("Accept")}}, {{HTTPHeader("Accept-Language")}} et {{HTTPHeader("Content-Language")}}. Si l'un de ces en-têtes a une valeur non-standard, WebKit/Safari considère que la requête ne correspond pas à une requête simple. Les valeurs considérées comme non-standard par WebKit/Safari ne sont pas documentées en dehors de ces bugs WebKit : _[Require preflight for non-standard CORS-safelisted request headers Accept, Accept-Language, and Content-Language](https://bugs.webkit.org/show_bug.cgi?id=165178)_, _[Allow commas in Accept, Accept-Language, and Content-Language request headers for simple CORS](https://bugs.webkit.org/show_bug.cgi?id=165566)_ et _[Switch to a blacklist model for restricted Accept headers in simple CORS requests](https://bugs.webkit.org/show_bug.cgi?id=166363)_. Aucun autre navigateur n'implémente ces restrictions supplémentaires, car elles ne font pas partie de la spécification.
+> [!NOTE]
+> WebKit Nightly et Safari Technology Preview ajoutent des restrictions supplémentaires pour les valeurs autorisées des en-têtes {{HTTPHeader("Accept")}}, {{HTTPHeader("Accept-Language")}} et {{HTTPHeader("Content-Language")}}. Si l'un de ces en-têtes a une valeur non-standard, WebKit/Safari considère que la requête ne correspond pas à une requête simple. Les valeurs considérées comme non-standard par WebKit/Safari ne sont pas documentées en dehors de ces bugs WebKit : _[Require preflight for non-standard CORS-safelisted request headers Accept, Accept-Language, and Content-Language](https://bugs.webkit.org/show_bug.cgi?id=165178)_, _[Allow commas in Accept, Accept-Language, and Content-Language request headers for simple CORS](https://bugs.webkit.org/show_bug.cgi?id=165566)_ et _[Switch to a blacklist model for restricted Accept headers in simple CORS requests](https://bugs.webkit.org/show_bug.cgi?id=166363)_. Aucun autre navigateur n'implémente ces restrictions supplémentaires, car elles ne font pas partie de la spécification.
 
 Voici un exemple d'une requête qui devra être précédée d'une requête préliminaire :
 
@@ -195,7 +198,8 @@ Dans le fragment de code ci-avant, à la ligne 3, on crée un corps XML envoyé 
 
 ![](preflight_correct.png)
 
-> **Note :** Comme décrit après, la vraie requête POST n'inclut pas les en-têtes `Access-Control-Request-*` qui sont uniquement nécessaires pour la requête OPTIONS.
+> [!NOTE]
+> Comme décrit après, la vraie requête POST n'inclut pas les en-têtes `Access-Control-Request-*` qui sont uniquement nécessaires pour la requête OPTIONS.
 
 Voyons ce qui se passe entre le client et le serveur. Le premier échange est la requête/réponse préliminaire :
 

--- a/files/fr/web/http/headers/accept-charset/index.md
+++ b/files/fr/web/http/headers/accept-charset/index.md
@@ -9,7 +9,8 @@ L'en-tête HTTP de la requête **`Accept-Charset`** indique le jeu de caractère
 
 Si le serveur ne peut servir aucun jeu de caractères correspondant, il peut théoriquement renvoyer un code d'erreur {{HTTPStatus ("406")}} (non acceptable). Cependant, pour une meilleure expérience utilisateur, cela est rarement fait et le moyen le plus courant consiste à ignorer l'en-tête `Accept-Charset` dans ce cas.
 
-> **Note :** Dans les premières versions de HTTP / 1.1, un jeu de caractères par défaut (ISO-8859-1) était défini. Ce n'est plus le cas et maintenant chaque type de contenu peut avoir sa propre valeur par défaut.
+> [!NOTE]
+> Dans les premières versions de HTTP / 1.1, un jeu de caractères par défaut (ISO-8859-1) était défini. Ce n'est plus le cas et maintenant chaque type de contenu peut avoir sa propre valeur par défaut.
 
 <table class="properties">
   <tbody>

--- a/files/fr/web/http/headers/accept-encoding/index.md
+++ b/files/fr/web/http/headers/accept-encoding/index.md
@@ -14,7 +14,7 @@ Même si le client et le serveur supportent deux algorithmes de compressions com
 
 Dès lors que l'usage d'`identity`, signifiant l'absence de compression, n'est pas explicitement interdite, que ce soit par `identity;q=0` ou `*;q=0` (sans l'usage d'une autre valeur pour `identity`), le serveur ne doit jamais renvoyer une erreur [`406`](/fr/docs/Web/HTTP/Status/406) `Not Acceptable.`
 
-> **Note :**
+> [!NOTE]
 >
 > - Un dépôt IANA garde à jour [une liste complète des encodages de contenu](https://www.iana.org/assignments/http-parameters/http-parameters.xml#http-parameters-1).
 > - Deux autres encodages, `bzip` et `bzip2`, sont parfois utilisés, bien que non-standards. Ils implémentent l'algorithme utilisé par les deux programmes UNIX respectifs. À noter que le premier n'est plus maintenu suite à des problèmes de licence.

--- a/files/fr/web/http/headers/authorization/index.md
+++ b/files/fr/web/http/headers/authorization/index.md
@@ -45,7 +45,8 @@ Authorization: <type> <credentials>
     - L'identifiant de l'utilisateur et le mot de passe sont combinés avec deux-points : (`aladdin:sesameOuvreToi`).
     - Cette chaîne de caractères est ensuite encodée en [base64](/fr/docs/Web/API/WindowBase64/Décoder_encoder_en_base64) (`YWxhZGRpbjpzZXNhbWVPdXZyZVRvaQ==`).
 
-    > **Note :** L'encodage en Base64 n'est pas un chiffrement ou un hachage ! Cette méthode est aussi peu sûre que d'envoyer les identifiants en clair (l'encodage base64 est un encodage réversible). Il faudra privilégier HTTPS lorsqu'on emploie une authentification "basique".
+    > [!NOTE]
+    > L'encodage en Base64 n'est pas un chiffrement ou un hachage ! Cette méthode est aussi peu sûre que d'envoyer les identifiants en clair (l'encodage base64 est un encodage réversible). Il faudra privilégier HTTPS lorsqu'on emploie une authentification "basique".
 
 ## Exemples
 

--- a/files/fr/web/http/headers/content-language/index.md
+++ b/files/fr/web/http/headers/content-language/index.md
@@ -54,7 +54,8 @@ Content-Language: de-DE, en-CA
 - `language-tag`
   - : Plusieurs tags de langue sont séparés par paragraphe. Chaque tag de langue est une séquence d'un ou plusieurs sous-tags insensibles à la casse, chacun séparé par un tiret ("`-`", `%x2D`). Dans la plupart des cas, un tag de langue se compose d'un sous-tag de langue principal qui identifie une large famille de langues connexes (par exemple, «en» = anglais), suivi éventuellement d'une série de sous-tags qui affinent ou réduisent la variété de langue. (par exemple, "en-CA" = la variété d'anglais telle que communiquée au Canada).
 
-> **Note :** Les tags de langues sont formellement définis dans la RFC 5646, qui repose sur la norme ISO 639 (très souvent la liste de codes ISO 639-1) pour les codes de langue à utiliser.
+> [!NOTE]
+> Les tags de langues sont formellement définis dans la RFC 5646, qui repose sur la norme ISO 639 (très souvent la liste de codes ISO 639-1) pour les codes de langue à utiliser.
 
 ## Exemples
 

--- a/files/fr/web/http/headers/content-security-policy/block-all-mixed-content/index.md
+++ b/files/fr/web/http/headers/content-security-policy/block-all-mixed-content/index.md
@@ -9,7 +9,8 @@ La directive HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`block-all-m
 
 Toutes les requêtes vers des [contenus mixtes](/fr/docs/Sécurité/MixedContent) sont alors bloquées, y compris les ressources actives et passives. Cela s'applique aussi aux documents {{HTMLElement("iframe")}}, assurant que la page est complètement protégée contre les contenus mixtes.
 
-> **Note :** La directive {{CSP("upgrade-insecure-requests")}} est évaluée avant `block-all-mixed-content`. Si elle est définie, alors `block-all-mixed-content` n'est pas nécessaire, à moins que vous souhaitiez forcer HTTPS sur les anciens navigateurs qui ne le font pas après une redirection vers HTTP.
+> [!NOTE]
+> La directive {{CSP("upgrade-insecure-requests")}} est évaluée avant `block-all-mixed-content`. Si elle est définie, alors `block-all-mixed-content` n'est pas nécessaire, à moins que vous souhaitiez forcer HTTPS sur les anciens navigateurs qui ne le font pas après une redirection vers HTTP.
 
 ## Syntaxe
 

--- a/files/fr/web/http/headers/content-security-policy/form-action/index.md
+++ b/files/fr/web/http/headers/content-security-policy/form-action/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Headers/Content-Security-Policy/form-action
 
 La directive HTTP [`Content-Security-Policy`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy) **`form-action`** restreint les URL pouvant être utilisées comme cibles d'envoi de formulaire depuis un contexte donné.
 
-> **Attention :** La question de savoir si `form-action` doit bloquer les redirections après une soumission de formulaire est encore [débattue](https://github.com/w3c/webappsec-csp/issues/8) et les implémentations des navigateurs sur cet aspect sont hétérogènes (par exemple Firefox 57 ne les bloque pas, contrairement à Chrome 63).
+> [!WARNING]
+> La question de savoir si `form-action` doit bloquer les redirections après une soumission de formulaire est encore [débattue](https://github.com/w3c/webappsec-csp/issues/8) et les implémentations des navigateurs sur cet aspect sont hétérogènes (par exemple Firefox 57 ne les bloque pas, contrairement à Chrome 63).
 
 <table class="properties">
   <tbody>

--- a/files/fr/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/fr/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -45,7 +45,8 @@ Content-Security-Policy: frame-ancestors <source> <source>;
 
 La \<source> peut être une des suivantes :
 
-> **Note :** The `frame-ancestors` directive's syntax is similar to a source list of other directives (e.g. {{CSP("default-src")}}), but doesn't allow `'unsafe-eval'` or `'unsafe-inline'` for example. It will also not fall back to a `default-src` setting. Only the sources listed below are allowed:
+> [!NOTE]
+> The `frame-ancestors` directive's syntax is similar to a source list of other directives (e.g. {{CSP("default-src")}}), but doesn't allow `'unsafe-eval'` or `'unsafe-inline'` for example. It will also not fall back to a `default-src` setting. Only the sources listed below are allowed:
 
 - \<host-source>
 
@@ -56,7 +57,8 @@ La \<source> peut être une des suivantes :
     - `mail.example.com:443`: correspondra à toutes les tentatives d'accès sur le port 443 de mail.example.com.
     - `https://store.example.com`: correspondra à toutes les tentatives d'accès à store.example.com via le protocole `https:`.
 
-    > **Attention :** Si aucun schéma d'URL n'est spécifié comme `host-source` et que l'{{HTMLElement("iframe")}} est chargée via une URL `https:`, la page chargeant l'iframe doit aussi être chargée en `https:`, selon la spécification du W3C sur [les correspondances de valeurs de sources](https://w3c.github.io/webappsec-csp/2/#match-source-expression).
+    > [!WARNING]
+    > Si aucun schéma d'URL n'est spécifié comme `host-source` et que l'{{HTMLElement("iframe")}} est chargée via une URL `https:`, la page chargeant l'iframe doit aussi être chargée en `https:`, selon la spécification du W3C sur [les correspondances de valeurs de sources](https://w3c.github.io/webappsec-csp/2/#match-source-expression).
 
 - \<scheme-source>
 

--- a/files/fr/web/http/headers/content-security-policy/index.md
+++ b/files/fr/web/http/headers/content-security-policy/index.md
@@ -37,7 +37,8 @@ Les directives de récupération (ou _fetch directives_ en anglais) contrôlent 
 - {{CSP("child-src")}}
   - : Définit les sources valides pour les [web workers](/fr/docs/Web/API/Web_Workers_API) et les éléments qui représentent des contextes de navigation imbriqués tels que {{HTMLElement("frame")}} et {{HTMLElement("iframe")}}.
 
-> **Attention :** Plutôt que la directive **`child-src`**, si vous souhaitez réguler les contextes de navigation imbriqués et les workers séparément, vous pouvez utiliser respectivement les directives {{CSP("frame-src")}} et {{CSP("worker-src")}}.
+> [!WARNING]
+> Plutôt que la directive **`child-src`**, si vous souhaitez réguler les contextes de navigation imbriqués et les workers séparément, vous pouvez utiliser respectivement les directives {{CSP("frame-src")}} et {{CSP("worker-src")}}.
 
 - {{CSP("connect-src")}}
   - : Restreint les URL qui peuvent être chargées via des scripts.
@@ -56,7 +57,8 @@ Les directives de récupération (ou _fetch directives_ en anglais) contrôlent 
 - {{CSP("object-src")}}
   - : Définit les sources valides pour les ressources des éléments {{HTMLElement("object")}}, {{HTMLElement("embed")}} et {{HTMLElement("applet")}}.
 
-> **Note :** Les éléments contrôlés pa ar `object-src` sont considérés peut-être par coïcidence comme des éléments HTML du passé et ne recevront de nouvelles fonctionnalités normalisées (comme les attributs de sécurité `sandbox` et `allow` pour `<iframe>`). De ce fait, il est **recommandé** de restreindre cette directive, c'est-à-dire la définir explicitement à `object-src 'none'` dans la mesure du possible.
+> [!NOTE]
+> Les éléments contrôlés pa ar `object-src` sont considérés peut-être par coïcidence comme des éléments HTML du passé et ne recevront de nouvelles fonctionnalités normalisées (comme les attributs de sécurité `sandbox` et `allow` pour `<iframe>`). De ce fait, il est **recommandé** de restreindre cette directive, c'est-à-dire la définir explicitement à `object-src 'none'` dans la mesure du possible.
 
 - {{CSP("prefetch-src")}}
   - : Définit .
@@ -104,7 +106,8 @@ Les directives de rapport permettent de contrôler ce qui se passe lorsqu'une r�
 - {{CSP("report-uri")}}{{deprecated_inline}}
   - : Indique à l'agent utilisateur de rapporter les tentatives d'enfreintes du CSP. Un rapport d'enfreinte est un ensemble de documents JSON envoyés via une requête HTTP `POST` à l'URI indiquée.
 
-> **Attention :** Bien que la directive [`report-to`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy/report-to) est prévue remplacer la directive **`report-uri`** maintenant dépréciée, [`report-to`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy/report-to) n'est pas encore supportée par la plupart des navigateurs modernes. Par rétrocompatibilité avec les navigateurs courants et tout en prévoyant une compatibilité future quand les navigateurs supporteront [`report-to`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy/report-to), vous pouvez spécifier les deux directives **`report-uri`** et [`report-to`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy/report-to):
+> [!WARNING]
+> Bien que la directive [`report-to`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy/report-to) est prévue remplacer la directive **`report-uri`** maintenant dépréciée, [`report-to`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy/report-to) n'est pas encore supportée par la plupart des navigateurs modernes. Par rétrocompatibilité avec les navigateurs courants et tout en prévoyant une compatibilité future quand les navigateurs supporteront [`report-to`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy/report-to), vous pouvez spécifier les deux directives **`report-uri`** et [`report-to`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy/report-to):
 >
 > ```
 > Content-Security-Policy: ...; report-uri https://endpoint.com; report-to groupname

--- a/files/fr/web/http/headers/content-security-policy/object-src/index.md
+++ b/files/fr/web/http/headers/content-security-policy/object-src/index.md
@@ -9,7 +9,8 @@ La directive HTTP [`Content-Security-Policy`](/fr/docs/Web/HTTP/Headers/Content-
 
 Pour définir des types autorisés pour les éléments [`<object>`](/fr/docs/Web/HTML/Element/object), [`<embed>`](/fr/docs/Web/HTML/Element/embed) et [`<applet>`](/fr/docs/Web/HTML/Element/applet), voir la directive [`plugin-types`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types).
 
-> **Note :** Les éléments contrôlés par `object-src` sont considérés comme des éléments HTML historiques et qui ne recevront pas de nouvelles fonctionnalités standardisées (comme les attributs de sécurité `sandbox` et `allow` pour `<iframe>`). Ainsi, il est [recommandé](https://csp.withgoogle.com/docs/strict-csp.html) de restreindre cette directive en définissant `object-src 'none'`.
+> [!NOTE]
+> Les éléments contrôlés par `object-src` sont considérés comme des éléments HTML historiques et qui ne recevront pas de nouvelles fonctionnalités standardisées (comme les attributs de sécurité `sandbox` et `allow` pour `<iframe>`). Ainsi, il est [recommandé](https://csp.withgoogle.com/docs/strict-csp.html) de restreindre cette directive en définissant `object-src 'none'`.
 
 <table class="properties">
   <tbody>

--- a/files/fr/web/http/headers/content-security-policy/referrer/index.md
+++ b/files/fr/web/http/headers/content-security-policy/referrer/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Headers/Content-Security-Policy/referrer
 
 La directive HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`referrer`** spécifie des informations dans l'en-tête HTTP {{HTTPHeader("Referer")}} (avec un seul r) pour les liens externes d'une page. Cette API est dépréciée et supprimée des navigateurs.
 
-> **Note :** Utilisez plutôt l'en-tête HTTP {{HTTPHeader("Referrer-Policy")}}.
+> [!NOTE]
+> Utilisez plutôt l'en-tête HTTP {{HTTPHeader("Referrer-Policy")}}.
 
 ## Syntaxe
 

--- a/files/fr/web/http/headers/content-security-policy/report-uri/index.md
+++ b/files/fr/web/http/headers/content-security-policy/report-uri/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Headers/Content-Security-Policy/report-uri
 
 La directive HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`report-uri`** demande à l'agent utilisateur de rapporter les violations de règles CSP. Ces rapports de violation sont constituées d'un document JSON envoyé via une requête HTTP POST à l'URI fournie.
 
-> **Attention :** Bien que la directive {{CSP("report-to")}} est prévue remplacer la directive **`report-uri`** maintenant dépréciée, {{CSP("report-to")}} n'est pas encore supportée par la plupart des navigateurs modernes. Par rétrocompatibilité avec les navigateurs courants et tout en prévoyant une compatibilité future quand les navigateurs supporteront {{CSP("report-to")}}, vous pouvez spécifier les deux directives **`report-uri`** et {{CSP("report-to")}}:
+> [!WARNING]
+> Bien que la directive {{CSP("report-to")}} est prévue remplacer la directive **`report-uri`** maintenant dépréciée, {{CSP("report-to")}} n'est pas encore supportée par la plupart des navigateurs modernes. Par rétrocompatibilité avec les navigateurs courants et tout en prévoyant une compatibilité future quand les navigateurs supporteront {{CSP("report-to")}}, vous pouvez spécifier les deux directives **`report-uri`** et {{CSP("report-to")}}:
 >
 > ```
 > Content-Security-Policy: ...; report-uri https://endpoint.com; report-to groupname

--- a/files/fr/web/http/headers/content-security-policy/script-src/index.md
+++ b/files/fr/web/http/headers/content-security-policy/script-src/index.md
@@ -71,7 +71,8 @@ document.getElementById("btn").addEventListener("click", faireQuelqueChose);
 
 ### Scripts embarqués non fiables
 
-> **Note :** Bloquer les styles et scripts embarqués est l'une des stratégies de sécurité principales que CSP propose. Toutefois, si vous en avez absolument besoin, il existe des mécanismes qui vous permettront de les autoriser.
+> [!NOTE]
+> Bloquer les styles et scripts embarqués est l'une des stratégies de sécurité principales que CSP propose. Toutefois, si vous en avez absolument besoin, il existe des mécanismes qui vous permettront de les autoriser.
 
 Vous pouvez autoriser les scripts embarqués et les gestionnaires d'évènements par attributs en spécifiant la valeur `'unsafe-inline'`, des nonces ou des empreintes correspondant au script.
 

--- a/files/fr/web/http/headers/content-security-policy/style-src/index.md
+++ b/files/fr/web/http/headers/content-security-policy/style-src/index.md
@@ -99,7 +99,8 @@ Ce genre de manipulations peut être bloqué en désactivant JavaScript au moyen
 
 ### Styles embarqués non fiables
 
-> **Note :** Bloquer les styles et scripts embarqués est l'une des stratégies de sécurité principales que CSP propose. Toutefois, si vous en avez absolument besoin, il existe des mécanismes qui vous permettront de les autoriser.
+> [!NOTE]
+> Bloquer les styles et scripts embarqués est l'une des stratégies de sécurité principales que CSP propose. Toutefois, si vous en avez absolument besoin, il existe des mécanismes qui vous permettront de les autoriser.
 
 Vous pouvez autoriser les styles embarqués en spécifiant la valeur `'unsafe-inline'`, des nonces ou des empreintes correspondant à la feuille de style.
 

--- a/files/fr/web/http/headers/content-security-policy/upgrade-insecure-requests/index.md
+++ b/files/fr/web/http/headers/content-security-policy/upgrade-insecure-requests/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests
 
 La directive HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`upgrade-insecure-requests`** informe l'agent utilisateur de traiter toutes les URL non sécurisées d'un site (servies avec HTTP) comme si elles avaient été remplacées par des URL sécurisées (servies avec HTTPS). Cette directive est prévue pour les sites web ayant un grand nombre d'URL non sécurisées héritées du passé et qui ont besoin d'être récrites.
 
-> **Note :** La directive `upgrade-insecure-requests` est évaluée avant la directive {{CSP("block-all-mixed-content")}} et si cette elle est définie, cette dernière est effectivement ignorée. Il est recommendé de ne définir que l'une des deux directives mais non les deux, à moins que vous souhaitiez forcer HTTPS sur les anciens navigateurs qui ne le font pas après une redirection vers HTTP.
+> [!NOTE]
+> La directive `upgrade-insecure-requests` est évaluée avant la directive {{CSP("block-all-mixed-content")}} et si cette elle est définie, cette dernière est effectivement ignorée. Il est recommendé de ne définir que l'une des deux directives mais non les deux, à moins que vous souhaitiez forcer HTTPS sur les anciens navigateurs qui ne le font pas après une redirection vers HTTP.
 
 The `upgrade-insecure-requests` directive will not ensure that users visiting your site via links on third-party sites will be upgraded to HTTPS for the top-level navigation and thus does not replace the {{HTTPHeader("Strict-Transport-Security")}} ({{Glossary("HSTS")}}) header, which should still be set with an appropriate `max-age` to ensure that users are not subject to SSL stripping attacks.
 

--- a/files/fr/web/http/headers/origin/index.md
+++ b/files/fr/web/http/headers/origin/index.md
@@ -62,7 +62,8 @@ L'en-tête `Origin` peut valoir `null` dans certains cas (la liste qui suit n'es
 - Pour les éléments [`<iframe>`](/fr/docs/Web/HTML/Element/iframe) dont l'attribut `sandox` ne contient pas la valeur `allow-same-origin`.
 - Pour les réponses qui sont des erreurs réseau.
 
-> **Note :** Une liste plus détaillée de ces cas avec `null` est présentée sur Stack Overflow&nbsp;: [Quand les navigateurs envoient-ils l'en-tête `Origin`&nbsp;? Quand l'origine est-elle mise à `null`&nbsp;? (en anglais)](https://stackoverflow.com/questions/42239643/when-do-browsers-send-the-origin-header-when-do-browsers-set-the-origin-to-null/42242802)
+> [!NOTE]
+> Une liste plus détaillée de ces cas avec `null` est présentée sur Stack Overflow&nbsp;: [Quand les navigateurs envoient-ils l'en-tête `Origin`&nbsp;? Quand l'origine est-elle mise à `null`&nbsp;? (en anglais)](https://stackoverflow.com/questions/42239643/when-do-browsers-send-the-origin-header-when-do-browsers-set-the-origin-to-null/42242802)
 
 ## Exemples
 

--- a/files/fr/web/http/headers/permissions-policy/index.md
+++ b/files/fr/web/http/headers/permissions-policy/index.md
@@ -5,7 +5,8 @@ slug: Web/HTTP/Headers/Permissions-Policy
 
 {{HTTPSidebar}}{{SeeCompatTable}}
 
-> **Attention :** Cet en-tête a maintenant été renommé `Permissions-Policy` dans la spécification, et cet article sera mis à jour pour refléter ce changement.
+> [!WARNING]
+> Cet en-tête a maintenant été renommé `Permissions-Policy` dans la spécification, et cet article sera mis à jour pour refléter ce changement.
 
 L'en-tête HTTP **`Feature-Policy`** fournit un mécanisme pour permettre ou interdire l'utilisation de fonctionnalités du navigateur pour le document courant et le contenu que ce dernier embarquerait via des éléments [`<iframe>`](/fr/docs/Web/HTML/Element/iframe).
 
@@ -40,7 +41,8 @@ Feature-Policy: <directive> <allowlist>
     - `'self'`&nbsp;: La fonctionnalité sera autorisée dans ce document et pour tous les contextes de navigation imbriqués de la même origine. La fonctionnalité n'est pas autorisée pour les contextes de navigation d'autres origines.
     - `'src'`&nbsp;: Pour l'attribut `allow` d'une <i lang="en">iframe</i> uniquement. La fonctionnalité sera autorisée pour cette <i lang="en">iframe</i> uniquement si le document qui y est chargé provient de la même origine que celle indiquée par l'attribut [`src`](/fr/docs/Web/HTML/Element/iframe#attributs) de l'élément HTML.
 
-      > **Note :** L'origine `'src'` est uniquement utilisée pour la liste `allow` d'une <i lang="en">iframe</i>. Pour ces éléments, il s'agit de la valeur par défaut pour `allowlist`.
+      > [!NOTE]
+      > L'origine `'src'` est uniquement utilisée pour la liste `allow` d'une <i lang="en">iframe</i>. Pour ces éléments, il s'agit de la valeur par défaut pour `allowlist`.
 
     - `'none'`&nbsp;: La fonctionnalité est désactivée pour le document (niveau le plus haut) et les contextes de navigation imbriqués.
     - `<origin(s)>`&nbsp;: La fonctionnalité est autorisée pour des origines distinctes (par exemple, `https://example.com`). Lorsqu'on indique plusieurs origines, celles-ci doivent être séparées par un espace.

--- a/files/fr/web/http/headers/referer/index.md
+++ b/files/fr/web/http/headers/referer/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Headers/Referer
 
 L'en-tête de requête **`Referer`** contient l'adresse de la page web précédente à partir de laquelle un lien a été suivi pour demander la page courante. L'en-tête `Referer` permet aux serveurs d'identifier la provenance des visiteurs d'une page et cette information peut être utilisée à des fins d'analyse, de journalisation ou pour améliorer la politique de cache par exemple.
 
-> **Attention :** Bien que cet en-tête puisse être utilisé à de nombreuses fins légitimes, il peut avoir des effets indésirables sur la sécurité et la vie privée. Voir la page [Questions de sécurité et de vie privée : quid de l'en-tête `referer`](/fr/docs/Web/Security/Referer_header:_privacy_and_security_concerns) pour plus d'informations et des méthodes d'atténuation.
+> [!WARNING]
+> Bien que cet en-tête puisse être utilisé à de nombreuses fins légitimes, il peut avoir des effets indésirables sur la sécurité et la vie privée. Voir la page [Questions de sécurité et de vie privée : quid de l'en-tête `referer`](/fr/docs/Web/Security/Referer_header:_privacy_and_security_concerns) pour plus d'informations et des méthodes d'atténuation.
 
 Note : le terme `referer` est orthographié ainsi bien qu'il s'agisse d'une erreur à partir du mot anglais "_referrer_". Voir [la page Wikipédia sur le référent et la note sur la graphie de <i lang="en">referer</i>](<https://fr.wikipedia.org/wiki/Référent_(informatique)#cite_ref-3>) pour plus de détails.
 

--- a/files/fr/web/http/headers/referrer-policy/index.md
+++ b/files/fr/web/http/headers/referrer-policy/index.md
@@ -22,7 +22,8 @@ L'en-tête {{glossary("HTTP header")}} **`Referrer-Policy`** contrôle la quanti
 
 ## Syntaxe
 
-> **Note :** Le nom originel de l'en-tête, {{HTTPHeader("Referer")}}, est une faute de frappe du mot anglais "referrer". L'en-tête `Referrer-Policy` ne comporte pas cette erreur.
+> [!NOTE]
+> Le nom originel de l'en-tête, {{HTTPHeader("Referer")}}, est une faute de frappe du mot anglais "referrer". L'en-tête `Referrer-Policy` ne comporte pas cette erreur.
 
 ```
 Referrer-Policy: no-referrer
@@ -56,7 +57,8 @@ Referrer-Policy: unsafe-url
 
   - : Envoie l'origine, le chemin et les paramètres de requête pour toutes les requêtes sans tenir compte du niveau de sécurité.
 
-    > **Attention :** Cette valeur divulgera des informations potentiellement confidentielles de la part des URL de ressources HTTPS vers des origines non sécurisées. Considérez les conséquences de ce paramétrage avant de vous en servir.
+    > [!WARNING]
+    > Cette valeur divulgera des informations potentiellement confidentielles de la part des URL de ressources HTTPS vers des origines non sécurisées. Considérez les conséquences de ce paramétrage avant de vous en servir.
 
 ## Intégration avec HTML
 
@@ -78,7 +80,8 @@ Autrement, une [relation de lien](/fr/docs/Web/HTML/Attributes/rel) définie à 
 <a href="http://example.com" rel="noreferrer"></a>
 ```
 
-> **Attention :** Comme vu précédemment, la relation de lien `noreferrer` s'écrit sans trait d'union. Toutefois, quand la règle de référent est spécifiée pour le document entier avec un élément {{HTMLElement("meta")}}, il faut mettre le trait d'union : `<meta name="referrer" content="no-referrer">`.
+> [!WARNING]
+> Comme vu précédemment, la relation de lien `noreferrer` s'écrit sans trait d'union. Toutefois, quand la règle de référent est spécifiée pour le document entier avec un élément {{HTMLElement("meta")}}, il faut mettre le trait d'union : `<meta name="referrer" content="no-referrer">`.
 
 ## Intégration avec CSS
 
@@ -197,7 +200,8 @@ Referrer-Policy: no-referrer, strict-origin-when-cross-origin
 
 Ici, `no-referrer` ne sera utilisée que si `strict-origin-when-cross-origin` n'est pas supportée par le navigateur.
 
-> **Note :** Spécifier plusieurs valeurs n'est supporté que dans l'en-tête HTTP `Referrer-Policy` et non dans l'attribut `referrerpolicy`.
+> [!NOTE]
+> Spécifier plusieurs valeurs n'est supporté que dans l'en-tête HTTP `Referrer-Policy` et non dans l'attribut `referrerpolicy`.
 
 ## Spécifications
 

--- a/files/fr/web/http/headers/set-cookie/index.md
+++ b/files/fr/web/http/headers/set-cookie/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Headers/Set-Cookie
 
 L'en-tête de réponse HTTP **`Set-Cookie`** est utilisé pour envoyer un cookie depuis le serveur à l'agent utilisateur afin qu'il puisse le renvoyer dans l'avenir. Pour envoyer plusieurs cookies, on enverra plusieurs en-têtes `Set-Cookie` dans la même réponse.
 
-> **Attention :** Les navigateurs empêchent le code JavaScript _front-end_ d'accéder à l'en-tête `Set-Cookie`, comme l'exige la spécification Fetch, qui définit `Set-Cookie` comme un [nom d'en-tête de réponse interdit](https://fetch.spec.whatwg.org/#forbidden-response-header-name) qui [doit être filtré](https://fetch.spec.whatwg.org/#ref-for-forbidden-response-header-name%E2%91%A0) de toute réponse exposée au code _front-end_.
+> [!WARNING]
+> Les navigateurs empêchent le code JavaScript _front-end_ d'accéder à l'en-tête `Set-Cookie`, comme l'exige la spécification Fetch, qui définit `Set-Cookie` comme un [nom d'en-tête de réponse interdit](https://fetch.spec.whatwg.org/#forbidden-response-header-name) qui [doit être filtré](https://fetch.spec.whatwg.org/#ref-for-forbidden-response-header-name%E2%91%A0) de toute réponse exposée au code _front-end_.
 
 Pour plus d'information, voir le [guide sur les cookies HTTP](/fr/docs/Web/HTTP/Cookies).
 
@@ -73,7 +74,8 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
     Si non spécifié, le cookie devient un **cookie de session**. Une session finit quand le client s'arrête, les cookies de sessions sont alors supprimés à ce moment.
 
-    > **Attention :** Plusieurs navigateurs ont un système de récupération de session qui enregistre les onglets et les restaure quand le navigateur redémarre. Les cookies de session seront aussi restaurés comme si le navigateur ne s'était jamais arrêté.
+    > [!WARNING]
+    > Plusieurs navigateurs ont un système de récupération de session qui enregistre les onglets et les restaure quand le navigateur redémarre. Les cookies de session seront aussi restaurés comme si le navigateur ne s'était jamais arrêté.
 
     Quand une telle date de péremption est indiquée, elle est relative au _client_ et pas au serveur.
 
@@ -93,7 +95,8 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
   - : Un cookie sécurisé est envoyé uniquement si la requête est faite en `https:` (sauf pour _localhost_). Cependant des informations confidentielles ne devraient jamais être enregistrées dans un cookie classique, en effet le mécanique est non sécurisé et ne chiffre aucune information.
 
-    > **Note :** Les sites non sécurisés (`http:`) ne peuvent plus définir des cookies `Secure` désormais (depuis Chrome 52+ et Firefox 52+). Depuis Firefox 75, cette restriction ne s'applique pas pour _localhost_.
+    > [!NOTE]
+    > Les sites non sécurisés (`http:`) ne peuvent plus définir des cookies `Secure` désormais (depuis Chrome 52+ et Firefox 52+). Depuis Firefox 75, cette restriction ne s'applique pas pour _localhost_.
 
 - `HttpOnly` {{optional_inline}}
   - : Empêche JavaScript d'accéder au cookie; par exemple, au travers de la propriété [`Document.cookie`](/fr/docs/Web/API/Document/cookie), de l'API [`XMLHttpRequest`](/fr/docs/Web/API/XMLHttpRequest) ou de l'API [`Request`](/fr/docs/Web/API/Request). Cela protège des attaques _cross-site scripting_ ([XSS](/fr/docs/Glossary/XSS)).
@@ -101,7 +104,8 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
   - : Contrôle si un cookie est envoyé avec les requêtes d'origine croisée, offrant ainsi une certaine protection contre les attaques de falsification de requêtes inter-sites ([CSRF](/fr/docs/Glossary/CSRF)).
 
-    > **Note :** Les normes relatives aux [Cookies SameSite](/fr/docs/Web/HTTP/Headers/Set-Cookie/SameSite) ont récemment changé de telle sorte que :
+    > [!NOTE]
+    > Les normes relatives aux [Cookies SameSite](/fr/docs/Web/HTTP/Headers/Set-Cookie/SameSite) ont récemment changé de telle sorte que :
     >
     > 1. Le comportement d'envoi des cookies si `SameSite` n'est pas spécifié est `SameSite=Lax`. Auparavant, le comportement par défaut était que les cookies étaient envoyés pour toutes les requêtes.
     > 2. Les cookies avec `SameSite=None` doivent désormais également spécifier l'attribut `Secure` (c'est-à-dire qu'ils nécessitent un contexte sécurisé).
@@ -160,7 +164,8 @@ Les cookies préfixés par `__Secure-` ou `__Host-` peuvent être utilisés seul
 
 De plus, les cookies avec le préfixe `__Host-` doivent avoir un `path` qui vaut `/` (donc tous les chemins de l'hôte) et ne doivent pas avoir d'attribut `Domain`.
 
-> **Attention :** Pour les clients qui n'implémentent pas les préfixes de cookies, vous ne pouvez pas compter sur ces contraintes, les cookies avec un préfixe seront toujours acceptés.
+> [!WARNING]
+> Pour les clients qui n'implémentent pas les préfixes de cookies, vous ne pouvez pas compter sur ces contraintes, les cookies avec un préfixe seront toujours acceptés.
 
 ```
 // Les deux sont acceptés s'ils viennent d'une origine sécurisée (HTTPS)

--- a/files/fr/web/http/headers/trailer/index.md
+++ b/files/fr/web/http/headers/trailer/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Headers/Trailer
 
 L'en-tête **Trailer** permet à l'expéditeur d'inclure des champs supplémentaires à la fin des blocs de messages pour fournir des métadonnées supplémentaires qui peuvent être générées de manière dynamique pendant que le corps du message sera envoyé, il peut s'agir de la vérification de l'intégrité du message, une signature numérique, ou encore un statut après le traitement.
 
-> **Note :** L'en-tête {{HTTPHeader("TE")}} de la requête devra être définie en tant que "trailers" pour autoriser les champs de type "trailer".
+> [!NOTE]
+> L'en-tête {{HTTPHeader("TE")}} de la requête devra être définie en tant que "trailers" pour autoriser les champs de type "trailer".
 
 <table class="properties">
   <tbody>

--- a/files/fr/web/http/headers/upgrade/index.md
+++ b/files/fr/web/http/headers/upgrade/index.md
@@ -9,7 +9,8 @@ l10n:
 
 L'en-tête HTTP **`Upgrade`**, réservé à HTTP/1.1, peut être utilisé pour basculer une connexion client/serveur déjà établie sur un autre protocole (en conservant le même protocole de transport). Un client pourra par exemple utiliser cet en-tête pour demander la mise à niveau de la connexion HTTP/1.1 en HTTP/2 ou le passage d'une connexion HTTP ou HTTPS à une connexion WebSocket.
 
-> **Attention :** HTTP/2 interdit explicitement l'usage de cet en-tête et de ce mécanisme. Il est réservé à HTTP/1.1.
+> [!WARNING]
+> HTTP/2 interdit explicitement l'usage de cet en-tête et de ce mécanisme. Il est réservé à HTTP/1.1.
 
 <table class="properties">
   <tbody>
@@ -37,7 +38,8 @@ Connection: upgrade
 Upgrade: exemple/1, toto/2
 ```
 
-> **Note :** L'en-tête [`Connection: upgrade`](/fr/docs/Web/HTTP/Headers/Connection) doit être présent lorsqu'`Upgrade` est envoyé.
+> [!NOTE]
+> L'en-tête [`Connection: upgrade`](/fr/docs/Web/HTTP/Headers/Connection) doit être présent lorsqu'`Upgrade` est envoyé.
 
 Le serveur est libre d'ignorer la requête et répondre alors comme si l'en-tête `Upgrade` n'avait pas été envoyé (par exemple avec [un statut `200 OK`](/fr/docs/Web/HTTP/Status/200)).
 

--- a/files/fr/web/http/headers/x-frame-options/index.md
+++ b/files/fr/web/http/headers/x-frame-options/index.md
@@ -9,7 +9,8 @@ L'en-tête de réponse [HTTP](/fr/docs/Web/HTTP) **`X-Frame-Options`** peut êtr
 
 Ce complément de sécurité est uniquement valable lorsque l'utilisateur final visite le document avec un navigateur prenant en charge `X-Frame-Options`.
 
-> **Note :** L'en-tête [`Content-Security-Policy`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy) possède une directive [`frame-ancestors`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) qui [supplante](https://www.w3.org/TR/CSP2/#frame-ancestors-and-frame-options) cet en-tête pour les navigateurs compatibles.
+> [!NOTE]
+> L'en-tête [`Content-Security-Policy`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy) possède une directive [`frame-ancestors`](/fr/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) qui [supplante](https://www.w3.org/TR/CSP2/#frame-ancestors-and-frame-options) cet en-tête pour les navigateurs compatibles.
 
 <table class="properties">
   <tbody>
@@ -50,7 +51,8 @@ Si on utilise `DENY`, le chargement de la page dans une _frame_ échouera sur un
 
 ## Exemples
 
-> **Note :** La balise `<meta>` est inutile ici&nbsp;! `<meta http-equiv="X-Frame-Options" content="deny">` n'aura aucun effet et mieux vaut donc ne pas l'utiliser. L'en-tête `X-FRAME-OPTIONS` ne fonctionne que si vous l'utilisez dans la configuration HTTP comme dans les exemples ci-dessous.
+> [!NOTE]
+> La balise `<meta>` est inutile ici&nbsp;! `<meta http-equiv="X-Frame-Options" content="deny">` n'aura aucun effet et mieux vaut donc ne pas l'utiliser. L'en-tête `X-FRAME-OPTIONS` ne fonctionne que si vous l'utilisez dans la configuration HTTP comme dans les exemples ci-dessous.
 
 ### Configurer Apache
 

--- a/files/fr/web/http/permissions_policy/index.md
+++ b/files/fr/web/http/permissions_policy/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Permissions_Policy
 
 Feature Policy ("réglementation des fonctionnalités" en français) permet aux développeurs web d'activer, de modifier ou de désactiver spécifiquement le comportement de certaines fonctionnalités et API dans le navigateur. Elle est similaire à {{Glossary("CSP", "Content Security Policy")}} mais contrôle les fonctionnalités plus que la sécurité.
 
-> **Note :** L'en-tête `Feature-Policy` a maintenant été renommé `Permissions-Policy` dans la spécification, et cet article va possiblement être modifié en conséquence.
+> [!NOTE]
+> L'en-tête `Feature-Policy` a maintenant été renommé `Permissions-Policy` dans la spécification, et cet article va possiblement être modifié en conséquence.
 
 ## En résumé
 

--- a/files/fr/web/http/protocol_upgrade_mechanism/index.md
+++ b/files/fr/web/http/protocol_upgrade_mechanism/index.md
@@ -42,7 +42,8 @@ webSocket = new WebSocket("wss://destination.server.ext", "optionalProtocol");
 
 Le constructeur [`WebSocket()`](/fr/docs/Web/API/WebSocket/WebSocket) s'occupe de la création de la connexion HTTP/1.1 initiale, puis de la bascule et de la poignée de main avec le serveur.
 
-> **Note :** Le schéma d'URL `"wss://"` permet d'ouvrir une connexion WebSocket sécurisée (contrairement à `"ws://"`).
+> [!NOTE]
+> Le schéma d'URL `"wss://"` permet d'ouvrir une connexion WebSocket sécurisée (contrairement à `"ws://"`).
 
 Si vous devez créer une connexion WebSocket de zéro, vous devrez gérer la poignée de main avec le serveur. Après avoir créé la session HTTP/1.1 initiale, demandez la mise à niveau de la connexion en ajoutant les en-têtes [`Upgrade`](/fr/docs/Web/HTTP/Headers/Upgrade) et [`Connection`](/fr/docs/Web/HTTP/Headers/Connection) comme suit&nbsp;:
 

--- a/files/fr/web/http/redirections/index.md
+++ b/files/fr/web/http/redirections/index.md
@@ -63,7 +63,8 @@ L'attribut [`content`](/fr/docs/Web/HTML/Global_attributes#content) commence ave
 
 Bien entendu, cette méthode ne fonctionne qu'avec des pages HTML (ou similaires) et ne peut être utilisée pour des images ou tout autre type de contenu.
 
-> **Note :** Ces redirections cassent le bouton de retour dans un navigateur : vous pouvez revenir à une page avec cet en-tête mais vous serez de nouveau instantanément redirigé.
+> [!NOTE]
+> Ces redirections cassent le bouton de retour dans un navigateur : vous pouvez revenir à une page avec cet en-tête mais vous serez de nouveau instantanément redirigé.
 
 ### Redirections JavaScript
 
@@ -103,7 +104,8 @@ Un alias de domaine peut être fait pour plusieurs raisons:
 
 Lorsque vous restructurez des sites Web, les URL des ressources changent. Même si vous pouvez mettre à jour les liens internes de votre site Web pour qu'ils correspondent au nouveau schéma de nommage, vous n'avez aucun contrôle sur les URL utilisées par les ressources externes. Vous ne voulez pas briser ces liens, car ils vous apportent des utilisateurs précieux (et aident votre référencement), donc vous configurez des redirections depuis les anciennes URL vers les nouvelles.
 
-> **Note :** Même si cette technique fonctionne également pour les liens internes, vous devriez éviter d'avoir des redirections internes. Une redirection a un coût significatif sur les performances (car une requête HTTP supplémentaire est faite) et si vous pouvez l'éviter en corrigeant les liens internes, vous devez corriger ces liens.
+> [!NOTE]
+> Même si cette technique fonctionne également pour les liens internes, vous devriez éviter d'avoir des redirections internes. Une redirection a un coût significatif sur les performances (car une requête HTTP supplémentaire est faite) et si vous pouvez l'éviter en corrigeant les liens internes, vous devez corriger ces liens.
 
 ### Réponses temporaires aux requêtes non sécurisées
 

--- a/files/fr/web/http/session/index.md
+++ b/files/fr/web/http/session/index.md
@@ -19,7 +19,8 @@ Dans les protocoles client-serveur, c'est le client qui établit la connexion. L
 
 Avec TCP, le port par défaut, pour un serveur HTTP sur un ordinateur, est le port 80. D'autres ports peuvent également être utilisés, comme 8000 ou 8080. L'URL d'une page à récupérer contient à la fois le nom de domaine et le numéro de port, Ce dernier peut être omis s'il en est à 80. Voir [Identifying resources on the Web](/fr/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web) pour plus de details.
 
-> **Note :** Le modèle client-serveur n'autorise pas le serveur à envoyer des données au client sans une demande explicite. Pour contourner ce problème, les développeurs Web utilisent plusieurs techniques: effectuer un ping sur le serveur périodiquement via le {{domxref("XMLHTTPRequest")}}, {{domxref("Fetch")}} API, en utilisant le HTML [WebSockets API](/fr/WebSockets), ou des protocoles similaires.
+> [!NOTE]
+> Le modèle client-serveur n'autorise pas le serveur à envoyer des données au client sans une demande explicite. Pour contourner ce problème, les développeurs Web utilisent plusieurs techniques: effectuer un ping sur le serveur périodiquement via le {{domxref("XMLHTTPRequest")}}, {{domxref("Fetch")}} API, en utilisant le HTML [WebSockets API](/fr/WebSockets), ou des protocoles similaires.
 
 ## Envoi d'une demande client
 

--- a/files/fr/web/http/status/301/index.md
+++ b/files/fr/web/http/status/301/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Status/301
 
 Le code de statut de réponse de redirection **`301 Moved Permanently`** indique que la ressource a définitivement été déplacée à l'URL contenue dans l'en-tête [`Location`](/fr/docs/Web/HTTP/Headers/Location). Un navigateur redirigera vers cette page et les moteurs de recherche mettront à jour leurs liens vers la ressource.
 
-> **Note :** Même si la spécification impose que la méthode et le corps ne soient pas altérés lors d'une redirection, tous les agents utilisateurs ne s'y conforment pas et il est possible de trouver des logiciels bogués sur ce point. Il est donc recommandé d'utiliser le code `301` uniquement pour répondre à une requête [`GET`](/fr/docs/Web/HTTP/Methods/GET) ou [`HEAD`](/fr/docs/Web/HTTP/Methods/HEAD), et de privilégier le code [`308 Permanent Redirect`](/fr/docs/Web/HTTP/Status/308) pour répondre à [`POST`](/fr/docs/Web/HTTP/Methods/POST) puisque le changement de méthode est explicitement interdit avec ce statut.
+> [!NOTE]
+> Même si la spécification impose que la méthode et le corps ne soient pas altérés lors d'une redirection, tous les agents utilisateurs ne s'y conforment pas et il est possible de trouver des logiciels bogués sur ce point. Il est donc recommandé d'utiliser le code `301` uniquement pour répondre à une requête [`GET`](/fr/docs/Web/HTTP/Methods/GET) ou [`HEAD`](/fr/docs/Web/HTTP/Methods/HEAD), et de privilégier le code [`308 Permanent Redirect`](/fr/docs/Web/HTTP/Status/308) pour répondre à [`POST`](/fr/docs/Web/HTTP/Methods/POST) puisque le changement de méthode est explicitement interdit avec ce statut.
 
 ## Statut
 

--- a/files/fr/web/http/status/304/index.md
+++ b/files/fr/web/http/status/304/index.md
@@ -9,7 +9,8 @@ Le code de réponse de redirection **`304 Not Modified`** indique qu'il n'y a pa
 
 La réponse [`200 OK`](/fr/docs/Web/HTTP/Status/200) équivalente aurait inclus les en-têtes [`Cache-Control`](/fr/docs/Web/HTTP/Headers/Cache-Control), [`Content-Location`](/fr/docs/Web/HTTP/Headers/Content-Location), [`Date`](/fr/docs/Web/HTTP/Headers/Date), [`ETag`](/fr/docs/Web/HTTP/Headers/ETag), [`Expires`](/fr/docs/Web/HTTP/Headers/Expires), et [`Vary`](/fr/docs/Web/HTTP/Headers/Vary).
 
-> **Note :** Dans les navigateurs, [les outils de développement réseau](/fr/docs/Tools/Network_Monitor) créent des requêtes supplémentaires qui conduisent à des réponses `304`. Ainsi l'accès au cache local est visible par les développeurs.
+> [!NOTE]
+> Dans les navigateurs, [les outils de développement réseau](/fr/docs/Tools/Network_Monitor) créent des requêtes supplémentaires qui conduisent à des réponses `304`. Ainsi l'accès au cache local est visible par les développeurs.
 
 ## Statut
 

--- a/files/fr/web/http/status/308/index.md
+++ b/files/fr/web/http/status/308/index.md
@@ -9,7 +9,8 @@ Le code de statut de réponse de redirection **`308 Permanent Redirect`** indiqu
 
 La méthode de requête et son corps ne sont pas modifiés, toutefois [`301`](/fr/docs/Web/HTTP/Status/301) peut parfois changer la méthode vers [`GET`](/fr/docs/Web/HTTP/Methods/GET).
 
-> **Note :** Certaines applications Web peuvent utiliser `308 Permanent Redirect` de façon non standard et pour d'autres usages. Par exemple, Google Drive utilise la réponse `308 Resume Incomplete` pour indiquer au client un chargement incomplet qui est bloqué ([source](https://developers.google.com/drive/v3/web/manage-uploads#resumable)).
+> [!NOTE]
+> Certaines applications Web peuvent utiliser `308 Permanent Redirect` de façon non standard et pour d'autres usages. Par exemple, Google Drive utilise la réponse `308 Resume Incomplete` pour indiquer au client un chargement incomplet qui est bloqué ([source](https://developers.google.com/drive/v3/web/manage-uploads#resumable)).
 
 ## Statut
 

--- a/files/fr/web/http/status/400/index.md
+++ b/files/fr/web/http/status/400/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Status/400
 
 Le code de statut de réponse HTTP **`400 Bad Request`** indique que le serveur ne peut pas comprendre ou traiter la requête en raison d'une erreur côté client (par exemple une requête dont la syntaxe ou le contenu est invalide).
 
-> **Attention :** Le client ne devrait pas répéter la requête sans modification.
+> [!WARNING]
+> Le client ne devrait pas répéter la requête sans modification.
 
 ## Statut
 

--- a/files/fr/web/http/status/404/index.md
+++ b/files/fr/web/http/status/404/index.md
@@ -25,7 +25,8 @@ ErrorDocument 404 /notfound.html
 
 Vous pouvez aussi vous inspirer de [la page 404 de MDN](/fr/404).
 
-> **Note :** Le style des pages 404 est [une source d'inspiration infinie](https://www.google.fr/search?q=awesome+404+pages), mais sachez qu'il existe également un [ensemble de meilleurs pratiques](https://alistapart.com/article/perfect404) pour que cette page particulière soit utile pour les utilisateurs.
+> [!NOTE]
+> Le style des pages 404 est [une source d'inspiration infinie](https://www.google.fr/search?q=awesome+404+pages), mais sachez qu'il existe également un [ensemble de meilleurs pratiques](https://alistapart.com/article/perfect404) pour que cette page particulière soit utile pour les utilisateurs.
 
 ## Spécifications
 

--- a/files/fr/web/http/status/408/index.md
+++ b/files/fr/web/http/status/408/index.md
@@ -11,7 +11,8 @@ Un serveur doit envoyer l'en-tête [`Connection`](/fr/docs/Web/HTTP/Headers/Conn
 
 Cette réponse est plus utilisée depuis que certains navigateurs, comme Chrome, Firefox 27+ ou IE9, utilisent le mécanisme HTTP de pré-connexion qui permet d'accélérer la navigation.
 
-> **Note :** Certains serveurs ferment purement et simplement la connexion, sans renvoyer ce message.
+> [!NOTE]
+> Certains serveurs ferment purement et simplement la connexion, sans renvoyer ce message.
 
 ## Statut
 

--- a/files/fr/web/http/status/410/index.md
+++ b/files/fr/web/http/status/410/index.md
@@ -9,7 +9,8 @@ Le code de statut de réponse HTTP **`410 Gone`** est une erreur côté client q
 
 Si vous ne savez pas si cette absence est temporaire ou permanente, il est préférable de renvoyer un code de statut [`404`](/fr/docs/Web/HTTP/Status/404).
 
-> **Note :** Par défaut, une réponse 410 peut être mise en cache.
+> [!NOTE]
+> Par défaut, une réponse 410 peut être mise en cache.
 
 ## Statut
 

--- a/files/fr/web/http/status/411/index.md
+++ b/files/fr/web/http/status/411/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Status/411
 
 Le code de réponse d'erreur HTTP **`411 Length Required`** indique que le serveur refuse d'accepter la requête si celle-ci ne contient pas d'en-tête [`Content-Length`](/fr/docs/Web/HTTP/Headers/Content-Length).
 
-> **Note :** Selon la spécification, lors de l'envoi de données en plusieurs fragments, l'en-tête `Content-Length` est absent et il est nécessaire d'ajouter la longueur du fragment courant au format hexadécimal. Pour plus de détails, se référer à la page sur l'en-tête [`Transfer-Encoding`](/fr/docs/Web/HTTP/Headers/Transfer-Encoding).
+> [!NOTE]
+> Selon la spécification, lors de l'envoi de données en plusieurs fragments, l'en-tête `Content-Length` est absent et il est nécessaire d'ajouter la longueur du fragment courant au format hexadécimal. Pour plus de détails, se référer à la page sur l'en-tête [`Transfer-Encoding`](/fr/docs/Web/HTTP/Headers/Transfer-Encoding).
 
 ## Statut
 

--- a/files/fr/web/http/status/422/index.md
+++ b/files/fr/web/http/status/422/index.md
@@ -7,7 +7,8 @@ slug: Web/HTTP/Status/422
 
 Le code de statut de réponse HTTP **`422 Unprocessable Entity`** indique que le serveur a compris le type de contenu de la requête et que la syntaxe de la requête est correcte mais que le serveur n'a pas été en mesure de réaliser les instructions demandées.
 
-> **Attention :** Le client ne doit pas renvoyer cette requête sans modification.
+> [!WARNING]
+> Le client ne doit pas renvoyer cette requête sans modification.
 
 ## Statut
 


### PR DESCRIPTION
This PR converts the noteblocks for the French locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 16. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
