### PR TITLE
pt-br: Convert noteblocks to GFM Alerts (part 1)

### DIFF
--- a/files/pt-br/conflicting/learn/javascript/asynchronous/introducing/index.md
+++ b/files/pt-br/conflicting/learn/javascript/asynchronous/introducing/index.md
@@ -63,7 +63,8 @@ btn.addEventListener('click', () => {
 
 Quando o exemplo for executado, abra seu console JavaScript e depois clique no botão — você verá qua o parágrafo não aparece até que o programa termine de calcular as datas e imprimir a última no console. O código é executado na ordem em que ele aparece na fonte, e a operação seguinte só é executada depois que a primeira for terminada.
 
-> **Nota:** O exemplo anterior não é muito realistico. Você nunca calcularia 10 milhões de datas em um aplicativo real! Mas isso serve par te dar um apoio sobre o assunto.
+> [!NOTE]
+> O exemplo anterior não é muito realistico. Você nunca calcularia 10 milhões de datas em um aplicativo real! Mas isso serve par te dar um apoio sobre o assunto.
 
 No nosso segundo exemplo [simple-sync-ui-blocking.html](https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/introducing/simple-sync-ui-blocking.html) ([veja aqui](https://mdn.github.io/learning-area/javascript/asynchronous/introducing/simple-sync-ui-blocking.html)), nós simulamos algo mais realistico que você pode encontrar em uma página real. Nós bloqueamos a interatividade do usuário na renderização da UI. Neste exemplo, nós temos dois botões:
 
@@ -89,7 +90,8 @@ alertBtn.addEventListener('click', () =>
 
 Se você clicar no primeiro botão e imediatamente no segundo, você verá que a mensagem de alerta não aparece até que os círculos sejam totalmente renderizados. A primeira operação bloqueia a segunda até a sua finalização.
 
-> **Nota:** OK, no nosso caso, isso é ruim e estamos bloqueando o código de propósito, mas isso é um problema comum que desenvolvedores de aplicativos reais sempre tentam resolver.
+> [!NOTE]
+> OK, no nosso caso, isso é ruim e estamos bloqueando o código de propósito, mas isso é um problema comum que desenvolvedores de aplicativos reais sempre tentam resolver.
 
 E por quê isso acontece? A resposta é que o JavaScript é **single threaded**. E é neste ponto que precisamos introduzir a você o conceito de **threads**.
 

--- a/files/pt-br/conflicting/learn/javascript/asynchronous/promises/index.md
+++ b/files/pt-br/conflicting/learn/javascript/asynchronous/promises/index.md
@@ -316,7 +316,8 @@ Usando `await` aqui podemos obter todos os resultados das três promises retorna
 
 Para tratamento de erros, nós incluímos um bloco `.catch()` no nossa chamada `displayContent()`; isso vai lidar com os erros que ocorrem em ambas as funções.
 
-> **Nota:** Também é possível usar um bloco [`finally`](/pt-BR/docs/Web/JavaScript/Reference/Statements/try...catch#the_finally_clause) síncrono na função assíncrona, no lugar de um bloco assíncrono[`.finally()`](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally), para mostrar um relatório final sobre como foi a operação — você pode ver isso em ação no nosso [exemplo ao vivo](https://mdn.github.io/learning-area/javascript/asynchronous/async-await/promise-finally-async-await.html) (veja também o [código-fonte](https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/async-await/promise-finally-async-await.html)).
+> [!NOTE]
+> Também é possível usar um bloco [`finally`](/pt-BR/docs/Web/JavaScript/Reference/Statements/try...catch#the_finally_clause) síncrono na função assíncrona, no lugar de um bloco assíncrono[`.finally()`](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally), para mostrar um relatório final sobre como foi a operação — você pode ver isso em ação no nosso [exemplo ao vivo](https://mdn.github.io/learning-area/javascript/asynchronous/async-await/promise-finally-async-await.html) (veja também o [código-fonte](https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/async-await/promise-finally-async-await.html)).
 
 ## Tratando lentidão com async/await
 

--- a/files/pt-br/conflicting/learn/javascript/asynchronous_ae5a561b0ec11fc53c167201aa8af5df/index.md
+++ b/files/pt-br/conflicting/learn/javascript/asynchronous_ae5a561b0ec11fc53c167201aa8af5df/index.md
@@ -107,7 +107,8 @@ Finalmente, se um timeout foi criado, você pode cancelá-lo antes que o tempo e
 clearTimeout(myGreeting);
 ```
 
-> **Nota:** Veja [`greeter-app.html`](https://mdn.github.io/learning-area/javascript/asynchronous/loops-and-intervals/greeter-app.html) para uma demonstração mais desenvolvida que te permite colocar o nome da pessoa a dizer oi em um formulário, e cancelar a saudação usando um botão separado ([veja aqui o código fonte](https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/loops-and-intervals/greeter-app.html)).
+> [!NOTE]
+> Veja [`greeter-app.html`](https://mdn.github.io/learning-area/javascript/asynchronous/loops-and-intervals/greeter-app.html) para uma demonstração mais desenvolvida que te permite colocar o nome da pessoa a dizer oi em um formulário, e cancelar a saudação usando um botão separado ([veja aqui o código fonte](https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/loops-and-intervals/greeter-app.html)).
 
 ## setInterval()
 
@@ -166,7 +167,8 @@ Here's a few hints for you:
 - To pause the stopwatch, you'll want to clear the interval. To reset it, you'll want to set the counter back to `0`, clear the interval, and then immediately update the display.
 - You probably ought to disable the start button after pressing it once, and enable it again after you've stopped/reset it. Otherwise multiple presses of the start button will apply multiple `setInterval()`s to the clock, leading to wrong behavior.
 
-> **Nota:** If you get stuck, you can [find our version here](https://mdn.github.io/learning-area/javascript/asynchronous/loops-and-intervals/setinterval-stopwatch.html) (see the [source code](https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/loops-and-intervals/setinterval-stopwatch.html) also).
+> [!NOTE]
+> If you get stuck, you can [find our version here](https://mdn.github.io/learning-area/javascript/asynchronous/loops-and-intervals/setinterval-stopwatch.html) (see the [source code](https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/loops-and-intervals/setinterval-stopwatch.html) also).
 
 ## Coisas para se manter em mente sobre o setTimeout() e o setInterval()
 
@@ -239,7 +241,8 @@ Ela foi criada em resposta à problemas ocorridos com `setInterval()`, que por e
 
 ([Leia mais sobre isso em CreativeJS](http://creativejs.com/resources/requestanimationframe/index.html).)
 
-> **Nota:** Você pode encontrar exemplos do uso de `requestAnimationFrame()` em outros lugares do curso — por exemplo em [Drawing graphics](/pt-BR/docs/Learn/JavaScript/Client-side_web_APIs/Drawing_graphics), e [Object building practice](/pt-BR/docs/Learn/JavaScript/Objects/Object_building_practice).
+> [!NOTE]
+> Você pode encontrar exemplos do uso de `requestAnimationFrame()` em outros lugares do curso — por exemplo em [Drawing graphics](/pt-BR/docs/Learn/JavaScript/Client-side_web_APIs/Drawing_graphics), e [Object building practice](/pt-BR/docs/Learn/JavaScript/Objects/Object_building_practice).
 
 O método toma como argumentos uma callback a ser invocada antes da renovação. Esse é o padrão geral que você verá usado em:
 
@@ -254,7 +257,8 @@ draw();
 
 A ideia é definir uma função em que sua animação é atualizada (e.g. seus spritas se movem, a pontuação é atualizada, dados são recarregados, etc). Depois, você inicia o processo. No final do bloco da função você chama `requestAnimationFrame()` com a referência da função passada como parâmetro, e isso instrui o navegador a chamar a função de novo na próxima renovação. Isso é executado continuamente, já que o código está chamando `requestAnimationFrame()` recursivamente.
 
-> **Nota:** Se você quer realizar algum tipo de animação na DOM constantemente, [Animações CSS](/pt-BR/docs/Web/CSS/CSS_Animations) são provavelemente mais rápidas. elas são calculadas diretamente pelo código interno do navegador, ao invés de JavaScript.
+> [!NOTE]
+> Se você quer realizar algum tipo de animação na DOM constantemente, [Animações CSS](/pt-BR/docs/Web/CSS/CSS_Animations) são provavelemente mais rápidas. elas são calculadas diretamente pelo código interno do navegador, ao invés de JavaScript.
 >
 > Se, no entanto, você está fazendo algo mais complexo e envolvendo objetos que não são diretamente assessados da DOM (como [2D Canvas API](/pt-BR/docs/Web/API/Canvas_API) ou objetos [WebGL](/pt-BR/docs/Web/API/WebGL_API)), `requestAnimationFrame()` é a melhor opção na maioria dos casos
 
@@ -329,7 +333,8 @@ Então, você não precisa dar suporte para versões mais velhas do IE, não há
 
 Enough with the theory! Let's build your own personal `requestAnimationFrame()` example. You're going to create a simple "spinner animation"—the kind you might see displayed in an app when it is busy connecting to the server, etc.
 
-> **Nota:** In a real world example, you should probably use CSS animations to run this kind of simple animation. However, this kind of example is very useful to demonstrate `requestAnimationFrame()` usage, and you'd be more likely to use this kind of technique when doing something more complex such as updating the display of a game on each frame.
+> [!NOTE]
+> In a real world example, you should probably use CSS animations to run this kind of simple animation. However, this kind of example is very useful to demonstrate `requestAnimationFrame()` usage, and you'd be more likely to use this kind of technique when doing something more complex such as updating the display of a game on each frame.
 
 1. Grab a basic HTML template ([such as this one](https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/getting-started/index.html)).
 2. Put an empty {{htmlelement("div")}} element inside the {{htmlelement("body")}}, then add a ↻ character inside it. This is circular arrow character will act as our spinner for this example.
@@ -404,7 +409,8 @@ Enough with the theory! Let's build your own personal `requestAnimationFrame()` 
     rAF = requestAnimationFrame(draw);
     ```
 
-> **Nota:** You can find this [example live on GitHub](https://mdn.github.io/learning-area/javascript/asynchronous/loops-and-intervals/simple-raf-spinner.html). (You can see the [source code](https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/loops-and-intervals/simple-raf-spinner.html), also.)
+> [!NOTE]
+> You can find this [example live on GitHub](https://mdn.github.io/learning-area/javascript/asynchronous/loops-and-intervals/simple-raf-spinner.html). (You can see the [source code](https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/loops-and-intervals/simple-raf-spinner.html), also.)
 
 ### Clearing a requestAnimationFrame() call
 
@@ -425,7 +431,8 @@ Some hints:
 - A `click` event handler can be added to most elements, including the document `<body>`. It makes more sense to put it on the `<body>` element if you want to maximize the clickable area — the event bubbles up to its child elements.
 - You'll want to add a tracking variable to check whether the spinner is spinning or not, clearing the animation frame if it is, and calling it again if it isn't.
 
-> **Nota:** Try this yourself first; if you get really stuck, check out of our [live example](https://mdn.github.io/learning-area/javascript/asynchronous/loops-and-intervals/start-and-stop-spinner.html) and [source code](https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/loops-and-intervals/start-and-stop-spinner.html).
+> [!NOTE]
+> Try this yourself first; if you get really stuck, check out of our [live example](https://mdn.github.io/learning-area/javascript/asynchronous/loops-and-intervals/start-and-stop-spinner.html) and [source code](https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/loops-and-intervals/start-and-stop-spinner.html).
 
 ### Throttling a requestAnimationFrame() animation
 
@@ -556,7 +563,8 @@ Let's work through this:
     }
     ```
 
-    > **Nota:** You'll see this example is calling `setTimeout()` without storing the return value. (So, not `let myTimeout = setTimeout(functionName, interval)`.)
+    > [!NOTE]
+    > You'll see this example is calling `setTimeout()` without storing the return value. (So, not `let myTimeout = setTimeout(functionName, interval)`.)
     >
     > This works just fine, as long as you don't need to clear your interval/timeout at any point. If you do, you'll need to save the returned identifier!
 
@@ -604,7 +612,8 @@ Let's work through this:
 
 That's it—you're all done!
 
-> **Nota:** If you get stuck, check out [our version of the reaction game](https://mdn.github.io/learning-area/javascript/asynchronous/loops-and-intervals/reaction-game.html) (see the [source code](https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/loops-and-intervals/reaction-game.html) also).
+> [!NOTE]
+> If you get stuck, check out [our version of the reaction game](https://mdn.github.io/learning-area/javascript/asynchronous/loops-and-intervals/reaction-game.html) (see the [source code](https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/loops-and-intervals/reaction-game.html) also).
 
 ## Conclusion
 

--- a/files/pt-br/conflicting/learn/javascript/objects/classes_in_javascript/index.md
+++ b/files/pt-br/conflicting/learn/javascript/objects/classes_in_javascript/index.md
@@ -65,7 +65,8 @@ Neste caso, não queremos pessoas genéricas — queremos professores e alunos, 
 
 Isso é realmente útil — professores e alunos compartilham muitos recursos comuns, como nome, sexo e idade, por isso é conveniente definir apenas esses recursos uma vez. Você também pode definir o mesmo recurso separadamente em classes diferentes, já que cada definição desse recurso estará em um namespace diferente. Por exemplo, a saudação de um aluno pode estar no formato "Yo, I'm \[firstName]" (por exemplo, _Yo, I'm Sam_), enquanto um professor pode usar algo mais formal, como "Olá, meu nome é \[Prefixo \[lastName], e eu ensino \[Subject]. " (por exemplo _Olá, Meu nome é Mr Griffiths, e eu ensino Química_).
 
-> **Nota:** A palavra chique para a capacidade de múltiplos tipos de objeto de implementar a mesma funcionalidade é o **polimorfismo**. Apenas no caso de você estar se perguntando.
+> [!NOTE]
+> A palavra chique para a capacidade de múltiplos tipos de objeto de implementar a mesma funcionalidade é o **polimorfismo**. Apenas no caso de você estar se perguntando.
 
 Agora você pode criar instâncias de objetos de suas classes filhas. Por exemplo:
 
@@ -117,7 +118,8 @@ Vamos explorar a criação de classes por meio de construtores e criar instânci
 
 A função de construtor é a versão do JavaScript de uma classe. Você notará que ela tem todos os recursos que você espera em uma função, embora ela não retorne nada ou crie explicitamente um objeto — ela basicamente define propriedades e métodos. Você verá a palavra-chave `this` sendo usada aqui também — é basicamente dizer que sempre que uma dessas instâncias de objeto é criada, a propriedade `name` do objeto será igual ao valor do nome passado à chamada do construtor, e o método `greeting()` usará o valor do nome passado para a chamada do construtor também.
 
-> **Nota:** Um nome de função de construtor geralmente começa com uma letra maiúscula — essa convenção é usada para tornar as funções do construtor mais fáceis de reconhecer no código.
+> [!NOTE]
+> Um nome de função de construtor geralmente começa com uma letra maiúscula — essa convenção é usada para tornar as funções do construtor mais fáceis de reconhecer no código.
 
 Então, como podemos chamar um construtor para criar alguns objetos?
 
@@ -216,7 +218,8 @@ person1.bio()
 // etc.
 ```
 
-> **Nota:** Se você está tendo problemas para fazer isso funcionar, tente comparar seu código com a nossa versão — veja o código em [oojs-class-finished.html](https://github.com/mdn/learning-area/blob/master/javascript/oojs/introduction/oojs-class-finished.html) (também [você pode ve-lo sendo executado aqui](http://mdn.github.io/learning-area/javascript/oojs/introduction/oojs-class-finished.html)).
+> [!NOTE]
+> Se você está tendo problemas para fazer isso funcionar, tente comparar seu código com a nossa versão — veja o código em [oojs-class-finished.html](https://github.com/mdn/learning-area/blob/master/javascript/oojs/introduction/oojs-class-finished.html) (também [você pode ve-lo sendo executado aqui](http://mdn.github.io/learning-area/javascript/oojs/introduction/oojs-class-finished.html)).
 
 ### Exercícios adicionais
 
@@ -224,7 +227,8 @@ Para começar, tente adicionar mais algumas linhas de criação de objetos e ten
 
 Além disso, há alguns problemas com nosso método `bio()` — a saída sempre inclui o pronome "Ele", mesmo que sua pessoa seja do sexo feminino ou alguma outra classificação de gênero preferida. E a biografia incluirá apenas dois interesses, mesmo que mais sejam listados na matriz `interests`. Você pode descobrir como corrigir isso na definição de classe (construtor)? Você pode colocar qualquer código que você gosta dentro de um construtor (você provavelmente precisará de alguns condicionais e um loop). Pense em como as sentenças devem ser estruturadas de maneira diferente dependendo do gênero e dependendo se o número de interesses listados é 1, 2 ou mais de 2.
 
-> **Nota:** If you get stuck, we have provided an [answer inside our GitHub repo](https://github.com/mdn/learning-area/blob/master/javascript/oojs/introduction/oojs-class-further-exercises.html) ([see it live](http://mdn.github.io/learning-area/javascript/oojs/introduction/oojs-class-further-exercises.html)) — try writing it yourself first though!
+> [!NOTE]
+> If you get stuck, we have provided an [answer inside our GitHub repo](https://github.com/mdn/learning-area/blob/master/javascript/oojs/introduction/oojs-class-further-exercises.html) ([see it live](http://mdn.github.io/learning-area/javascript/oojs/introduction/oojs-class-further-exercises.html)) — try writing it yourself first though!
 
 ## Outras maneiras de criar instâncias de objeto
 

--- a/files/pt-br/conflicting/learn/server-side/express_nodejs/displaying_data/index.md
+++ b/files/pt-br/conflicting/learn/server-side/express_nodejs/displaying_data/index.md
@@ -5,7 +5,8 @@ slug: conflicting/Learn/Server-side/Express_Nodejs/Displaying_data
 
 O código da _Controller_, para algumas de nossas páginas dependerá dos resultados de várias solicitações assíncronas, que talvez possam ser necessárias para serem executadas em uma ordem específica ou em paralelo. Para gerenciar o controle do nosso fluxo e renderizar páginas quando tivermos todas as informações necessárias disponíveis, usaremos o popular módulo [async](https://www.npmjs.com/package/async).
 
-> **Nota:** Há várias outras maneiras de gerenciar o comportamento assíncrono e o controle de fluxo em JavaScript, um dos recursos Javascript que pode ser utilizado, são as [Promises](/pt-BR/docs/Mozilla/Add-ons/Techniques/Promises).
+> [!NOTE]
+> Há várias outras maneiras de gerenciar o comportamento assíncrono e o controle de fluxo em JavaScript, um dos recursos Javascript que pode ser utilizado, são as [Promises](/pt-BR/docs/Mozilla/Add-ons/Techniques/Promises).
 
 Async has a lot of useful methods (check out [the documentation](http://caolan.github.io/async/docs.html)). Some of the more important functions are:
 
@@ -79,7 +80,8 @@ async.series({
 );
 ```
 
-> **Nota:** The ECMAScript (JavaScript) language specification states that the order of enumeration of an object is undefined, so it is possible that the functions will not be called in the same order as you specify them on all platforms. If the order really is important, then you should pass an array instead of an object, as shown below.
+> [!NOTE]
+> The ECMAScript (JavaScript) language specification states that the order of enumeration of an object is undefined, so it is possible that the functions will not be called in the same order as you specify them on all platforms. If the order really is important, then you should pass an array instead of an object, as shown below.
 
 ```js
 async.series([

--- a/files/pt-br/conflicting/learn_680f0a64719ec97f557d9b1ef1710826/index.md
+++ b/files/pt-br/conflicting/learn_680f0a64719ec97f557d9b1ef1710826/index.md
@@ -8,7 +8,8 @@ Se você está apenas começando com o desenvolvimento Web ou expandindo seus ho
 
 Para outro conjunto (sobreposto) de links sobre recursos de aprendizado, consulte as [páginas de aprendizado](/pt-BR/docs/) do MDN.
 
-> **Nota:** Os recursos recomendados nesta página estão sujeitos à alterações
+> [!NOTE]
+> Os recursos recomendados nesta página estão sujeitos à alterações
 
 ## Tópicos da documentação
 

--- a/files/pt-br/conflicting/mdn/community/contributing/getting_started/index.md
+++ b/files/pt-br/conflicting/mdn/community/contributing/getting_started/index.md
@@ -159,7 +159,8 @@ Tenha certeza de rodar o comando a seguir para mudar para a branch main antes de
 git switch main
 ```
 
-> **Nota:** Em outros tutoriais você pode ter visto `git checkout` sendo usado para mudar de branches no repo. Isto funciona na maior parte do tempo, mas pode ter efeitos colaterais indesejados, por isso neste tutorial nós estamos recomendando o novo comando `git switch`, que é projetado puramente para trocar de branches e tem menos chance de dar problema. Se você estiver interessado em como estes comandos estão relacionados, e as diferenças entre eles [Destaques do Git 2.23 > Alternativas experimentais para o git checkout](https://github.blog/2019-08-16-highlights-from-git-2-23/#experimental-alternatives-for-git-checkout) tem um bom resumo.
+> [!NOTE]
+> Em outros tutoriais você pode ter visto `git checkout` sendo usado para mudar de branches no repo. Isto funciona na maior parte do tempo, mas pode ter efeitos colaterais indesejados, por isso neste tutorial nós estamos recomendando o novo comando `git switch`, que é projetado puramente para trocar de branches e tem menos chance de dar problema. Se você estiver interessado em como estes comandos estão relacionados, e as diferenças entre eles [Destaques do Git 2.23 > Alternativas experimentais para o git checkout](https://github.blog/2019-08-16-highlights-from-git-2-23/#experimental-alternatives-for-git-checkout) tem um bom resumo.
 
 ### Atualize a sua branch main
 
@@ -348,7 +349,8 @@ Neste momento, volte para a página do fork remoto em github.com. Você deve ver
 
     ![Formulário para abrir um pull request, que inclui os campos de texto para título e descrição](open-pull-request.png)
 
-    > **Aviso:** Sigo os próximos passos apenas se você tiver uma alteração real para ser feito no repo! Por favor, não faça PRs de teste em nossos repos.
+    > [!WARNING]
+    > Sigo os próximos passos apenas se você tiver uma alteração real para ser feito no repo! Por favor, não faça PRs de teste em nossos repos.
 
 2. Neste momento, coloque um título e uma descrição úteis para o seu PR, dizendo exatamente o que você mudou, o porquê disto ser uma coisa boa, e qual a issue que é corrigida, se necessário. Especificamente, inclua uma linha dizendo `Corrige url-issue`. O GitHub automaticamente renderiza isto como um link para o número da issue, e.g. `Corrige #1234` e, além disso, automaticamente fecha a issue relacionada uma vez que o pull request for mesclado.
 3. Uma vez que você esteja pronto para enviar o seu pull request, clique no botão "Criar pull request". Isto fará com que seu pull request apareça na [Lista de pull requests](https://github.com/mdn/content/pulls) do repo na qual ele será revisado pela equipe de revisão, e, com sorte, mesclado na base principal de código.
@@ -410,7 +412,8 @@ Neste ponto, não existe nenhum retorno real, ou forma de rebobinar. Ao invés d
 
 Se você olhar na página do github.com do seu fork remoto novamente, você verá o commit que você queria reverter, juntamente com o commit que reverte ele.
 
-> **Nota:** Outra forma de conseguir se livrar dos arquivos que acabaram entrando no seu pull request e que você não quer que estejam lá é usar a interface do Github. Vá para a página do seu pull request em github.com, vá até a aba "Arquivos alterados", e encontre o arquivo que você quer remover do seu pull request. No canto superior direito do da caixa do arquivo na página, você verá um menu "três pontos" (`...`). Pressione o botão e escolha "Deletar o arquivo". Na página de confirmação, insira um título para o novo commit, tenha certeza de que a caixa de seleção "Fazer commit diretamente..." esteja selecionada, e pressione o botão "Fazer o commit das mudanças".
+> [!NOTE]
+> Outra forma de conseguir se livrar dos arquivos que acabaram entrando no seu pull request e que você não quer que estejam lá é usar a interface do Github. Vá para a página do seu pull request em github.com, vá até a aba "Arquivos alterados", e encontre o arquivo que você quer remover do seu pull request. No canto superior direito do da caixa do arquivo na página, você verá um menu "três pontos" (`...`). Pressione o botão e escolha "Deletar o arquivo". Na página de confirmação, insira um título para o novo commit, tenha certeza de que a caixa de seleção "Fazer commit diretamente..." esteja selecionada, e pressione o botão "Fazer o commit das mudanças".
 >
 > Geralmente é uma boa ideia deixar o resto do pull request exatamente da forma que você deseja antes de fazer as mudanças pela interface do GitHub. Se você fizer algo assim e acabar tendo que fazer mais mudanças, você vai precisar lembrar de puxar as mudanças que você fez para a sua branch remota para a sua branch local (e.g. com `git pull`) antes que você consiga subir mais commits.
 

--- a/files/pt-br/conflicting/web/accessibility/aria_64707ba1917a56654679cbe273e2f4ea/index.md
+++ b/files/pt-br/conflicting/web/accessibility/aria_64707ba1917a56654679cbe273e2f4ea/index.md
@@ -117,6 +117,7 @@ var validate = function () {
 
 Leia como usar [alertas ARIA para melhorar forms](/pt-BR/docs/aria/forms/alerts "aria/forms/alerts").
 
-> **Nota:** A ser decidido: devemos ou combinar em um artigo ou separar em técnicas, ou ambos. Além disso, é ARIA marcação apropriada para mensagens de erro em uma página carregada após a validação do lado do servidor?
+> [!NOTE]
+> A ser decidido: devemos ou combinar em um artigo ou separar em técnicas, ou ambos. Além disso, é ARIA marcação apropriada para mensagens de erro em uma página carregada após a validação do lado do servidor?
 
 Para maiores informações usando ARIA para acessibilidade de forms, veja o documento [Práticas de Cricação de WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/).

--- a/files/pt-br/conflicting/web/api/animationevent/animationevent/index.md
+++ b/files/pt-br/conflicting/web/api/animationevent/animationevent/index.md
@@ -11,7 +11,8 @@ O **`AnimationEvent.initAnimationEvent()`** é um método iniciado com o evento 
 
 `AnimationEvent` criado desse modo não é confiável.
 
-> **Nota:** Durante o processo de padronização, esse método foi removido das especificações. É que ele foi depreciado e esse processo foi removido da maioria das implementações . **Não use este método**; ao invés, use o construtor padrão, {{domxref("AnimationEvent.AnimationEvent", "AnimationEvent()")}}, para criar um sintético {{domxref("AnimationEvent")}}.
+> [!NOTE]
+> Durante o processo de padronização, esse método foi removido das especificações. É que ele foi depreciado e esse processo foi removido da maioria das implementações . **Não use este método**; ao invés, use o construtor padrão, {{domxref("AnimationEvent.AnimationEvent", "AnimationEvent()")}}, para criar um sintético {{domxref("AnimationEvent")}}.
 
 ## Syntax
 

--- a/files/pt-br/conflicting/web/api/customelementregistry/define/index.md
+++ b/files/pt-br/conflicting/web/api/customelementregistry/define/index.md
@@ -9,7 +9,8 @@ slug: conflicting/Web/API/CustomElementRegistry/define
 
 O método **`document.registerElement()`** registra um novo [elemento personalizado](/pt-BR/docs/Web/Web_Components/Custom_Elements) no browser e retorna um construtor para o novo elemento.
 
-> **Nota:** Esta é uma tecnologia experimental. O browser você precisa usar suporte à componentes web. Veja [Habilitando componentes web no Firefox.](/pt-BR/docs/Web/Web_Components#Enabling_Web_Components_in_Firefox)
+> [!NOTE]
+> Esta é uma tecnologia experimental. O browser você precisa usar suporte à componentes web. Veja [Habilitando componentes web no Firefox.](/pt-BR/docs/Web/Web_Components#Enabling_Web_Components_in_Firefox)
 
 ## Sintaxe
 

--- a/files/pt-br/conflicting/web/api/element/click_event/index.md
+++ b/files/pt-br/conflicting/web/api/element/click_event/index.md
@@ -9,7 +9,8 @@ A propriedade **`onclick`** do mixin {{domxref("GlobalEventHandlers")}} é o {{e
 
 O evento `click` acontece quando o usuário clica em um elemento. É disparado após os eventos {{event("mousedown")}} e{{event("mouseup")}} na respectiva ordem.
 
-> **Nota:** Ao usar o evento `click` para disparar uma ação, considere também adicionar essa mesma ação ao evento {{event("keydown")}}, para permitir o uso dessa mesma ação a pessoas que não usam um mouse ou uma touchscreen.
+> [!NOTE]
+> Ao usar o evento `click` para disparar uma ação, considere também adicionar essa mesma ação ao evento {{event("keydown")}}, para permitir o uso dessa mesma ação a pessoas que não usam um mouse ou uma touchscreen.
 
 ## Sintaxe
 

--- a/files/pt-br/conflicting/web/api/element/keyup_event_c3958d9a752bb3f2d72ac974b4e226ea/index.md
+++ b/files/pt-br/conflicting/web/api/element/keyup_event_c3958d9a752bb3f2d72ac974b4e226ea/index.md
@@ -32,7 +32,8 @@ O evento **`keyup`** é acionado quando a tecla é liberada.
 
 Os eventos {{domxref("Document/keydown_event", "keydown")}} e `keyup` fornecem um código indicando quando a tecla é pressionada, enquanto o {{domxref("Document/keypress_event", "keypress")}} indica quando um _character_ é inserido. Por exemplo, a letra minúscula "a", sera reportado como 65 por `keydown` e `keyup`, mas é 95 por `keypress`. Uma letra maiúscula é reportado como 65 por todos os eventos.
 
-> **Nota:** Se você está procurando por uma maneira de reagir a mudanças no valor de um input, você deve usar o [`input` event](/pt-BR/docs/Web/API/HTMLElement/input_event). Algumas mudanças não são detectaveis por `keyup`, por exemplo, colar um texto de um contexto no input de texto.
+> [!NOTE]
+> Se você está procurando por uma maneira de reagir a mudanças no valor de um input, você deve usar o [`input` event](/pt-BR/docs/Web/API/HTMLElement/input_event). Algumas mudanças não são detectaveis por `keyup`, por exemplo, colar um texto de um contexto no input de texto.
 
 ## Exemplos
 

--- a/files/pt-br/conflicting/web/api/fetch_api/using_fetch/index.md
+++ b/files/pt-br/conflicting/web/api/fetch_api/using_fetch/index.md
@@ -8,7 +8,8 @@ original_slug: Web/API/Fetch_API/Basic_concepts
 
 A [Fetch API](/pt-BR/docs/Web/API/Fetch_API) fornece uma interface para buscar recursos (inclusive pela rede). Parecerá familiar para alguém que já tenha usado {{domxref("XMLHttpRequest")}}, mas ela fornece um conjunto de recursos mais poderoso e flexível . Este artigo expõe alguns conceitos básicos da API Fetch.
 
-> **Nota:** Este artigo será incrementado ao longo do tempo. Se você achar um conceito em Fetch que parece precisar de uma explicação melhor, informe alguém em [fórum de discussãMDN](https://discourse.mozilla-community.org/c/mdn), or [Mozilla IRC](https://wiki.mozilla.org/IRC) (#mdn room.)
+> [!NOTE]
+> Este artigo será incrementado ao longo do tempo. Se você achar um conceito em Fetch que parece precisar de uma explicação melhor, informe alguém em [fórum de discussãMDN](https://discourse.mozilla-community.org/c/mdn), or [Mozilla IRC](https://wiki.mozilla.org/IRC) (#mdn room.)
 
 ## Em poucas palavras
 

--- a/files/pt-br/conflicting/web/guide/ajax/index.md
+++ b/files/pt-br/conflicting/web/guide/ajax/index.md
@@ -29,7 +29,8 @@ if (window.XMLHttpRequest) { // Mozilla, Safari, ...
 }
 ```
 
-> **Nota:** Para fins de ilustração, o que precede é uma versão um tanto simplificada do código necessário para criar uma instância XMLHTTP. Para um exemplo mais real, consulte o passo 3 deste artigo.
+> [!NOTE]
+> Para fins de ilustração, o que precede é uma versão um tanto simplificada do código necessário para criar uma instância XMLHTTP. Para um exemplo mais real, consulte o passo 3 deste artigo.
 
 Em seguida, você precisa decidir o que quer fazer depois de receber a resposta do servidor ao seu pedido. Nesta etapa, você somente precisa dizer ao objeto requisição HTTP qual função JavaScript irá manipular o processamento da resposta. Isto é feito definindo a propriedade `onreadystatechange` do objeto para o nome da função JavaScript que deve ser chamada quando o estado da requisição muda, desse jeito:
 
@@ -176,7 +177,8 @@ Neste exemplo:
 - A requisição é realizada e então (`onreadystatechange`) a execução é passada para `alertContents()`;
 - `alertContents()` checa se a resposta foi recebida e se está OK, então `alert()` mostra o conteúdo do arquivo `test.html.`
 
-> **Nota:** Se você está enviando uma solicitação para um pedaço de código que retornará XML, ao invés de um arquivo XML estático, é necessário definir alguns cabeçalhos de resposta se a sua página é para trabalhar com o Internet Explorer e com o Mozilla. Se você não definir cabeçalho `Content-Type: application/xml`, o IE irá lançar um erro JavaScript, "Objeto esperado", após a linha onde você tentar acessar um elemento XML..
+> [!NOTE]
+> Se você está enviando uma solicitação para um pedaço de código que retornará XML, ao invés de um arquivo XML estático, é necessário definir alguns cabeçalhos de resposta se a sua página é para trabalhar com o Internet Explorer e com o Mozilla. Se você não definir cabeçalho `Content-Type: application/xml`, o IE irá lançar um erro JavaScript, "Objeto esperado", após a linha onde você tentar acessar um elemento XML..
 
 > **Nota:** **Nota 2**: Se você não definir cabeçalho `Cache-Control: no-cache` o navegador armazenará em cache a resposta e jamais voltará a submeter o pedido, tornando a depuração "desafiadora". Também é possível acrescentar um parâmetro GET adicional sempre diferente, como o timestamp ou um número aleatório (veja [bypassing the cache](/pt-BR/DOM/XMLHttpRequest/Using_XMLHttpRequest#Bypassing_the_cache)).
 

--- a/files/pt-br/conflicting/web/html/global_attributes/contenteditable/index.md
+++ b/files/pt-br/conflicting/web/html/global_attributes/contenteditable/index.md
@@ -22,7 +22,8 @@ Conteúdo editável é totalmente compatível com os seguintes browsers.
 
 Ainda não é suportato pelo Opera Mini.
 
-> **Nota:** \*A maioria dos elementos HTML não suporta esta funcionalidade
+> [!NOTE]
+> \*A maioria dos elementos HTML não suporta esta funcionalidade
 
 ## Como isso funciona?
 

--- a/files/pt-br/conflicting/web/http/headers/expect-ct/index.md
+++ b/files/pt-br/conflicting/web/http/headers/expect-ct/index.md
@@ -5,7 +5,8 @@ slug: conflicting/Web/HTTP/Headers/Expect-CT
 
 {{HTTPSidebar}}{{deprecated_header}}
 
-> **Nota:** O mecanismo de Fixação de Chaves Públicas (Public Key Pinning) foi depreciado em favor do [Certificado de Transparência](/pt-BR/docs/Web/Security/Certificate_Transparency) e do cabeçalho {{HTTPHeader("Expect-CT")}}.
+> [!NOTE]
+> O mecanismo de Fixação de Chaves Públicas (Public Key Pinning) foi depreciado em favor do [Certificado de Transparência](/pt-BR/docs/Web/Security/Certificate_Transparency) e do cabeçalho {{HTTPHeader("Expect-CT")}}.
 
 O cabeçalho de resposta HTTP **`Public-Key-Pins`** usado para associar uma {{Glossary("key")}} pública criptográfica especifica com um certo servidor web para reduzir o risco de ataques {{Glossary("MITM")}} com certificados forjados, entretanto, ele foi removido em navegadores modernos e não é mais suportado. Use [Certificado de Transparência](/pt-BR/docs/Web/Security/Certificate_Transparency) e o cabeçalho {{HTTPHeader("Expect-CT")}} ao invés disso.
 
@@ -46,7 +47,8 @@ Public-Key-Pins: pin-sha256="<pin-value>";
 
 ## Exemplo
 
-> **Aviso:** HPKP tem o potencial de bloquear usuários por um longo período de tempo de usado incorretamente! O uso de _backup_ de certificados e/ou fixação do Autoridade de Certificados é recomendado.
+> [!WARNING]
+> HPKP tem o potencial de bloquear usuários por um longo período de tempo de usado incorretamente! O uso de _backup_ de certificados e/ou fixação do Autoridade de Certificados é recomendado.
 
 ```
 Public-Key-Pins:

--- a/files/pt-br/conflicting/web/http/headers/expect-ct_63e560324d2c47190db4456d746ba07b/index.md
+++ b/files/pt-br/conflicting/web/http/headers/expect-ct_63e560324d2c47190db4456d746ba07b/index.md
@@ -5,7 +5,8 @@ slug: conflicting/Web/HTTP/Headers/Expect-CT_63e560324d2c47190db4456d746ba07b
 
 {{HTTPSidebar}}{{deprecated_header}}
 
-> **Nota:** O mecanismo de Fixação de Chave Pública (_Public Key Pinning_) foi depreciado em favor do [Certificado de Transparência (Certificate Transparency)](/pt-BR/docs/Web/Security/Certificate_Transparency) e do cabeçalho {{HTTPHeader("Expect-CT")}}.
+> [!NOTE]
+> O mecanismo de Fixação de Chave Pública (_Public Key Pinning_) foi depreciado em favor do [Certificado de Transparência (Certificate Transparency)](/pt-BR/docs/Web/Security/Certificate_Transparency) e do cabeçalho {{HTTPHeader("Expect-CT")}}.
 
 O cabeçalho de resposta HTTP **`Public-Key-Pins-Report-Only`** era utilizado para enviar relatórios de violação de fixação para a `report-uri` especificada em cabeçalho mas, diferente do {{HTTPHeader("Public-Key-Pins")}} que ainda permite os navegadores se conectarem ao servidor se a fixação é violada. O cabeçalho é silenciosamente ignorado em navegadores modernos já que o suporte para HPKP foi removido. Use o [Certificado de Transparência](/pt-BR/docs/Web/Security/Certificate_Transparency) e o cabeçalho {{HTTPHeader("Expect-CT")}} ao invés disso.
 

--- a/files/pt-br/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/pt-br/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -158,7 +158,8 @@ public class Engineer extends WorkerBee {
 
 Usando estas definições, você pode criar instâncias desses objetos que obterão valores padrão para suas propriedades. A próxima imagem mostra o uso destas definições JavaScript para criar novos objetos e mostrar os valores das propriedades dos novos objetos.
 
-> **Nota:** O termo _instancia_ tem significado específicamente técnico em linguagens baseadas em classe. Nessas linguagens, uma instância é uma instanciação individual de uma classe e é fundamentalmente diferente de uma classe. Em JavaScript, "instância" não tem esse significado técnico porque JavaScript não tem essa diferença entre classes e instâncias. No entanto, falando sobre JavaScript, "instância" pode ser usada informalmente para significar um objeto criado usando uma função construtora particular. Então, neste exemplo, você pode informalmente dizer que `jane` é uma instância de `Engineer`. Similarmente, embora os termos **parent*, \_child*, \_ancestor**, e **descendant** não tenham significados formais em JavaScript; você pode usá-los informalmente para referir a objetos altos ou baixos na cadeia de protótipos.
+> [!NOTE]
+> O termo _instancia_ tem significado específicamente técnico em linguagens baseadas em classe. Nessas linguagens, uma instância é uma instanciação individual de uma classe e é fundamentalmente diferente de uma classe. Em JavaScript, "instância" não tem esse significado técnico porque JavaScript não tem essa diferença entre classes e instâncias. No entanto, falando sobre JavaScript, "instância" pode ser usada informalmente para significar um objeto criado usando uma função construtora particular. Então, neste exemplo, você pode informalmente dizer que `jane` é uma instância de `Engineer`. Similarmente, embora os termos **parent*, \_child*, \_ancestor**, e **descendant** não tenham significados formais em JavaScript; você pode usá-los informalmente para referir a objetos altos ou baixos na cadeia de protótipos.
 
 ### Criando objetos com definições simples
 
@@ -338,7 +339,8 @@ this.name = name || "";
 
 The JavaScript logical OR operator (`||`) evaluates its first argument. If that argument converts to true, the operator returns it. Otherwise, the operator returns the value of the second argument. Therefore, this line of code tests to see if `name` has a useful value for the `name` property. If it does, it sets `this.name` to that value. Otherwise, it sets `this.name` to the empty string. This chapter uses this idiom for brevity; however, it can be puzzling at first glance.
 
-> **Nota:** This may not work as expected if the constructor function is called with arguments which convert to `false` (like `0` (zero) and empty string (`""`). In this case the default value will be chosen.
+> [!NOTE]
+> This may not work as expected if the constructor function is called with arguments which convert to `false` (like `0` (zero) and empty string (`""`). In this case the default value will be chosen.
 
 With these definitions, when you create an instance of an object, you can specify values for the locally defined properties. You can use the following statement to create a new `Engineer`:
 
@@ -553,9 +555,11 @@ function instanceOf(object, constructor) {
 }
 ```
 
-> **Nota:** The implementation above checks the type of the object against "xml" in order to work around a quirk of how XML objects are represented in recent versions of JavaScript. See [Firefox bug 634150](https://bugzil.la/634150) if you want the nitty-gritty details.
+> [!NOTE]
+> The implementation above checks the type of the object against "xml" in order to work around a quirk of how XML objects are represented in recent versions of JavaScript. See [Firefox bug 634150](https://bugzil.la/634150) if you want the nitty-gritty details.
 
-> **Nota:** Using the `instanceOf` function defined above, these expressions are true:
+> [!NOTE]
+> Using the `instanceOf` function defined above, these expressions are true:
 
 ```js
 instanceOf (chris, Engineer)

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/error/tostring/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/error/tostring/index.md
@@ -29,7 +29,8 @@ Chamando método `toSource` de uma instância {{jsxref("Error")}} (incluindo *[N
 
 onde estes atributos correspondem as respectivas propriedades da instância do erro.
 
-> **Nota:** Fique alerta que as propriedades usadas pelo método `toSource` na criação da string são mutáveis e podem não refletir precisamente a função utilizada para criar a instância do erro ou nome de arquivo ou número de linha onde o erro atual ocorreu.
+> [!NOTE]
+> Fique alerta que as propriedades usadas pelo método `toSource` na criação da string são mutáveis e podem não refletir precisamente a função utilizada para criar a instância do erro ou nome de arquivo ou número de linha onde o erro atual ocorreu.
 
 ## Especificações
 

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/index.md
@@ -18,7 +18,8 @@ uneval(object)
 - `object`
   - : A JavaScript expression or statement.
 
-> **Nota:** Você não obterá uma representação em JSON válida para o Objeto..
+> [!NOTE]
+> Você não obterá uma representação em JSON válida para o Objeto..
 
 ## Descrição
 

--- a/files/pt-br/conflicting/web/svg/element/animate/index.md
+++ b/files/pt-br/conflicting/web/svg/element/animate/index.md
@@ -5,7 +5,8 @@ slug: conflicting/Web/SVG/Element/animate
 
 {{SVGRef}}{{deprecated_header}}
 
-> **Aviso:** Este elemento ficou obsoleto na Segunda Edição do SVG 1.1 e deverá ser removida das futuras versões do SVG. Este elemento fornece recursos ainda não disponíveis utilizando o elemento {{ SVGElement("animate") }} e não está implementado no Firefox e no Internet Explorer. Os autores devem utilizar o elemento {{ SVGElement("animate") }} em seu lugar.
+> [!WARNING]
+> Este elemento ficou obsoleto na Segunda Edição do SVG 1.1 e deverá ser removida das futuras versões do SVG. Este elemento fornece recursos ainda não disponíveis utilizando o elemento {{ SVGElement("animate") }} e não está implementado no Firefox e no Internet Explorer. Os autores devem utilizar o elemento {{ SVGElement("animate") }} em seu lugar.
 
 O elemento `animateColor` especifica uma transformação de cor ao longo do tempo.
 

--- a/files/pt-br/games/index.md
+++ b/files/pt-br/games/index.md
@@ -13,7 +13,8 @@ Bem-vindas ao centro de desenvolvimento de jogos MDN! Nesta área da página ofe
 
 Também incluímos uma seção de referências para que você possa, facilmente, encontrar informações sobre todas APIs mais usadas no desenvolvimento de jogos, acompanhadas de uma lista de [ferramentas e engines](/pt-BR/docs/Games/Tools) úteis e, [exemplos de jogos](/pt-BR/docs/Games/Examples).
 
-> **Nota:** Você já deve ter um conhecimento básico sobre as principais tecnologias web — tais como HTML, CSS e Javascript — antes de tentar criar jogos web. A [Área de aprendizado](/pt-BR/docs/Learn) é o melhor para você, se você for completamente principiante.
+> [!NOTE]
+> Você já deve ter um conhecimento básico sobre as principais tecnologias web — tais como HTML, CSS e Javascript — antes de tentar criar jogos web. A [Área de aprendizado](/pt-BR/docs/Learn) é o melhor para você, se você for completamente principiante.
 
 ## Leve jogos nativos para a Web
 

--- a/files/pt-br/glossary/base64/index.md
+++ b/files/pt-br/glossary/base64/index.md
@@ -71,7 +71,8 @@ UnicodeDecodeB64("JUUyJTlDJTkzJTIwJUMzJUEwJTIwbGElMjBtb2Rl"); // "✓ à la mode
 
 ### Solution #2 – rewriting `atob()` and `btoa()` using `TypedArray`s and UTF-8
 
-> **Note:** The following code is also useful to get an [ArrayBuffer](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) from a Base64 string and/or vice versa ([see below](#appendix_decode_a_base64_string_to_uint8array_or_arraybuffer)).
+> [!NOTE]
+> The following code is also useful to get an [ArrayBuffer](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) from a Base64 string and/or vice versa ([see below](#appendix_decode_a_base64_string_to_uint8array_or_arraybuffer)).
 
 ```js
 "use strict";
@@ -325,7 +326,8 @@ const myBuffer = base64DecToArr(
 alert(myBuffer.byteLength);
 ```
 
-> **Note:** A função `base64DecToArr(sBase64[, nBlocksSize])` retorna
+> [!NOTE]
+> A função `base64DecToArr(sBase64[, nBlocksSize])` retorna
 > um [uint8Array](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) de bytes.
 > Se o seu objetivo é construir um buffer de dados brutos de 16 bits / 32 bits / 64 bits,
 > use o argumento `nBlocksSize`,

--- a/files/pt-br/glossary/call_stack/index.md
+++ b/files/pt-br/glossary/call_stack/index.md
@@ -35,27 +35,31 @@ O código acima será executado desta forma pelo interpretador:
 1. Todas as funções serão ignoradas, até chegar na chamada da função `saudacao()`.
 2. Adiciona a função `saudacao()` para a pilha de chamadas.
 
-   > **Nota:** Pilha de chamadas:
+   > [!NOTE]
+   > Pilha de chamadas:
    > \- saudacao
 
 3. Executa todas as linhas de código da função `saudacao()`.
 4. Chama a função `digaOi()`.
 5. Adiciona a função `digaOi()` na pilha de chamadas.
 
-   > **Nota:** Pilha de chamadas:
+   > [!NOTE]
+   > Pilha de chamadas:
    > \- `saudacao` > \- digaOi
 
 6. Executa todas as linhas de código da função `digaOi()` até o final.
 7. Retorna a execução na linha onde foi chamada a função `digaOi()` e continua a execução do resto da função `saudacao()`.
 8. Deleta a função `digaOi()` da pilha de chamadas.
 
-   > **Nota:** Pilha de chamadas:
+   > [!NOTE]
+   > Pilha de chamadas:
    > \- `saudacao`
 
 9. Quando todas as linhas da função `saudacao()` forem executadas, retorna para a linha onde a função foi invocada, e continua a execução do resto do código.
 10. Deleta a função `saudacao()` da Pilha de chamadas.
 
-    > **Nota:** Pilha de chamadas:
+    > [!NOTE]
+    > Pilha de chamadas:
     > EMPTY
 
 Começamos com uma pilha de chamadas vazia, e sempre que chamamos uma função, ela é automaticamente adicionada à pilha de chamadas, e depois de todas as linhas serem executadas, é automaticamente removida da pilha de chamadas. No final, a pilha está vazia novamente.

--- a/files/pt-br/glossary/first-class_function/index.md
+++ b/files/pt-br/glossary/first-class_function/index.md
@@ -40,7 +40,8 @@ greeting(sayHello, "JavaScript!");
 
 Nós estamos passando a função `sayHello()` como um argumento pra função `greeting()`, isso explica como estamos tratando a função como um `valor`.
 
-> **Nota:** A função que passamos como um argumento pra outra função, chamou uma **[Função Callback](/pt-BR/docs/Glossary/Callback_function).** _`sayHello` é uma Função Callback._
+> [!NOTE]
+> A função que passamos como um argumento pra outra função, chamou uma **[Função Callback](/pt-BR/docs/Glossary/Callback_function).** _`sayHello` é uma Função Callback._
 
 ## Exemplo | Retornar uma função
 
@@ -56,7 +57,8 @@ function sayHello() {
 
 Neste exemplo; Precisamos retornar uma função de outra função - _Podemos retornar uma função porque tratamos função em JavaScript como um **`valor`**._
 
-> **Nota:** Uma função que retorna uma função é chamada de **Higher-Order Function**
+> [!NOTE]
+> Uma função que retorna uma função é chamada de **Higher-Order Function**
 
 De volta ao nosso exemplo; Agora, precisamos chamar a função `sayHello` e a `Função anônima` retornada. Existem duas maneiras para fazermos isso:
 
@@ -74,7 +76,8 @@ myFunc();
 
 Dessa maneira, ela retorna a mensagem `Hello!`.
 
-> **Nota:** Você tem que usar outra variável. Se você fosse chamar `sayHello` diretamente, ela retornaria a função em si **sem chamar a função retornada**.
+> [!NOTE]
+> Você tem que usar outra variável. Se você fosse chamar `sayHello` diretamente, ela retornaria a função em si **sem chamar a função retornada**.
 
 ### 2- Usando parênteses duplo
 

--- a/files/pt-br/glossary/forbidden_header_name/index.md
+++ b/files/pt-br/glossary/forbidden_header_name/index.md
@@ -34,4 +34,5 @@ Nomes de cabeçalho proibidos começam com `Proxy-`ou `Sec-`, ou são um dos seg
 - `Upgrade`
 - `Via`
 
-> **Nota:** O cabeçalho `User-Agent` não é mais proibido, de [acordo com a especificação](https://fetch.spec.whatwg.org/#terminology-headers) - consulte a lista de nomes de cabeçalhos proibidos (isso foi implementado no Firefox 43) - agora ele pode ser definido em um objeto e busca de [Headers](/pt-BR/docs/Web/API/Headers), ou via XHR [setRequestHeader()](/pt-BR/docs/Web/API/XMLHttpRequest#setRequestHeader%28%29).
+> [!NOTE]
+> O cabeçalho `User-Agent` não é mais proibido, de [acordo com a especificação](https://fetch.spec.whatwg.org/#terminology-headers) - consulte a lista de nomes de cabeçalhos proibidos (isso foi implementado no Firefox 43) - agora ele pode ser definido em um objeto e busca de [Headers](/pt-BR/docs/Web/API/Headers), ou via XHR [setRequestHeader()](/pt-BR/docs/Web/API/XMLHttpRequest#setRequestHeader%28%29).

--- a/files/pt-br/glossary/index.md
+++ b/files/pt-br/glossary/index.md
@@ -10,4 +10,5 @@ Tecnologias da Web contém longas listas de jargões e abreviações usadas em d
 
 Os termos do glossário podem ser selecionados na barra lateral.
 
-> **Nota:** Este glossário é um trabalho interminável em andamento. Você pode ajudar a melhorá-lo [escrevendo novas entradas](/pt-BR/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary) ou melhorando as já existentes.
+> [!NOTE]
+> Este glossário é um trabalho interminável em andamento. Você pode ajudar a melhorá-lo [escrevendo novas entradas](/pt-BR/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary) ou melhorando as já existentes.

--- a/files/pt-br/glossary/vendor_prefix/index.md
+++ b/files/pt-br/glossary/vendor_prefix/index.md
@@ -7,7 +7,8 @@ slug: Glossary/Vendor_Prefix
 
 Os _fabricantes de browsers_, por vezes, adicionam prefixos às propriedades experimentais ou fora dos padrões CSS, de modo que os desenvolvedores podem experimentá-las, enquanto —em teoria— as mudanças no comportamento dos navegadores não quebrarão o código durante o processo de padonização. Os desenvolvedores devem esperar para incluir a propriedade _não pré-fixada_ até que o comportamento do navegador seja padronizado.
 
-> **Nota:** Os _fabricantes de browsers_ estão trabalhando para parar de usar prefixos de fornecedores para recursos experimentais. Os desenvolvedores da Web têm vindo a usá-los em sites de produção, apesar de sua natureza experimental. Isso tornou mais difícil para os fornecedores de navegadores garantir a compatibilidade e trabalhar com novos recursos; também foi prejudicial aos navegadores menores que acabam forçados a adicionar prefixos de outros navegadores para carregar sites populares.
+> [!NOTE]
+> Os _fabricantes de browsers_ estão trabalhando para parar de usar prefixos de fornecedores para recursos experimentais. Os desenvolvedores da Web têm vindo a usá-los em sites de produção, apesar de sua natureza experimental. Isso tornou mais difícil para os fornecedores de navegadores garantir a compatibilidade e trabalhar com novos recursos; também foi prejudicial aos navegadores menores que acabam forçados a adicionar prefixos de outros navegadores para carregar sites populares.
 >
 > Ultimamente, a tendência é adicionar recursos experimentais por trás das bandeiras controladas pelo usuário e trabalhar com especificações menores que alcancem a estabilidade muito mais rápido.
 

--- a/files/pt-br/learn/accessibility/accessibility_troubleshooting/index.md
+++ b/files/pt-br/learn/accessibility/accessibility_troubleshooting/index.md
@@ -52,7 +52,8 @@ O texto é difícil de ler devido ao esquema de cores atual. Você pode fazer um
 2. Você consegue atualizar o texto do artigo para facilitar a navegação de usuários de leitores de telas?
 3. A parte do menu de navegação do site (agrupada em `<div class="nav"></div>`) poderia estar mais acessível se estivesse dentro de um elemento semântico de HTML5 mais adequado. Qual elemento deve ser utilizado? Atualize-o.
 
-> **Nota:** Você precisará atualizar os seletores de CSS que estilizam as respectivas tags para seus equivalentes aos cabeçalhos semânticos. Depois de adicionar elementos de parágrafo, você perceberá que a estilização parecerá bem melhor.
+> [!NOTE]
+> Você precisará atualizar os seletores de CSS que estilizam as respectivas tags para seus equivalentes aos cabeçalhos semânticos. Depois de adicionar elementos de parágrafo, você perceberá que a estilização parecerá bem melhor.
 
 ### As imagens
 

--- a/files/pt-br/learn/accessibility/html/index.md
+++ b/files/pt-br/learn/accessibility/html/index.md
@@ -62,7 +62,8 @@ A semântica do HTML não demora mais para escrever do que a versão não-semân
 
 Então vamos dar uma olhada em como fazer o HTML mais acessível.
 
-> **Nota:** É uma boa ideia ter um leitor de tela instalado no seu computador, dessa forma é possível testar os exemplos que serão mostrados abaixo. Veja o nosso [Guia de Leitores de Tela](/pt-BR/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Screenreaders) para mais detalhes.
+> [!NOTE]
+> É uma boa ideia ter um leitor de tela instalado no seu computador, dessa forma é possível testar os exemplos que serão mostrados abaixo. Veja o nosso [Guia de Leitores de Tela](/pt-BR/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Screenreaders) para mais detalhes.
 
 ## Boa semântica
 
@@ -261,7 +262,8 @@ Se você experimentar ler esse exemplo de estrutura mais moderna com um leitor d
 
 Outra consideração que pode ser feita é criar layouts utilizando a semântica HTML5 nos elementos, como visto no exemplo (veja [content sectioning](/pt-BR/docs/Web/HTML/Element#Content_sectioning)) — você pode criar um layout utilizando apenas elementos aninhados {{htmlelement("div")}}, mas é melhor e mais apropriado seccionar elementos de uma forma que eles envelopem a navegação principal ({{htmlelement("nav")}}), rodapé({{htmlelement("footer")}}), unidades de conteúdo repetidas({{htmlelement("article")}}), etc. Eles trazem semânticas extras para os leitores de tela(e outras ferramentas) para dar aos usuários mais dicas sobre o conteúdo no qual eles estão navegando (veja [Screen Reader Support for new HTML5 Section Elements](https://www.accessibilityoz.com/2020/02/html5-sectioning-elements-and-screen-readers/) para uma ideia do que é suporte de leitor de tela).
 
-> **Nota:** Ao mesmo tempo que seu conteúdo deve ter boa semântica e um layout bonito, deve-se fazer sentido que em sua ordem de fonte — você poderá sempre movimentá-la utilizando CSS depois, mas você deve colocar a ordem de fonte de forma correta desde o começo, para que os usuários que utilizam de leitores de tela possam receber uma leitura que faz sentido.
+> [!NOTE]
+> Ao mesmo tempo que seu conteúdo deve ter boa semântica e um layout bonito, deve-se fazer sentido que em sua ordem de fonte — você poderá sempre movimentá-la utilizando CSS depois, mas você deve colocar a ordem de fonte de forma correta desde o começo, para que os usuários que utilizam de leitores de tela possam receber uma leitura que faz sentido.
 
 ### Controles de UI
 
@@ -273,7 +275,8 @@ Um aspecto chave da acessibilidade de controles Ui é que, por padrão, os naveg
 
 Você pode apertar Enter/Return para seguir um link que está focado ou apertar um botão (nós incluimos um pouco de JavaScript para fazer os botões chamarem uma mensagem), ou começar a escrever para inserir um texto em um formulário de texto (outros elementos possuem controles diferentes, por exemplo o elemento {{htmlelement("select")}} pode ter suas opções visíveis e selecionáveis utilizando as teclas de flecha para cima e para baixo.
 
-> **Nota:** Navegadores diferentes podem ter mais opções de controle pelo teclado. Veja [Using native keyboard accessibility](/pt-BR/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Using_native_keyboard_accessibility) para mais detalhes.
+> [!NOTE]
+> Navegadores diferentes podem ter mais opções de controle pelo teclado. Veja [Using native keyboard accessibility](/pt-BR/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Using_native_keyboard_accessibility) para mais detalhes.
 
 Você essencialmente consegue esse comportamento de graça, só ao utilizar os elementos apropriados, ex.
 
@@ -388,7 +391,8 @@ Porém este, é um exemplo ruim para link:
 </p>
 ```
 
-> **Nota:** Você pode encontrar muito mais sobre implementação de link e melhores práticas no artigo [Criando hyperlinks](/pt-BR/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks). Você também pode ver alguns bons e maus exemplos em [good-links.html](http://mdn.github.io/learning-area/accessibility/html/good-links.html) e [bad-links.html](http://mdn.github.io/learning-area/accessibility/html/bad-links.html).
+> [!NOTE]
+> Você pode encontrar muito mais sobre implementação de link e melhores práticas no artigo [Criando hyperlinks](/pt-BR/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks). Você também pode ver alguns bons e maus exemplos em [good-links.html](http://mdn.github.io/learning-area/accessibility/html/good-links.html) e [bad-links.html](http://mdn.github.io/learning-area/accessibility/html/bad-links.html).
 
 Os rótulos de formulário (labels) também são importantes para dar a você uma ideia sobre o que precisa ser preenchido em cada entrada de formulário. O seguinte exemplo aparentemente é bem razoável:
 
@@ -413,7 +417,8 @@ Com o código assim, o rótulo será claramente associado à entrada; a descriç
 
 Como um bônus adicional, na maioria dos navegadores a associação de um rótulo a uma entrada de formulário significa que você pode clicar no rótulo para selecionar/ativar o elemento de formulário. Isso consequentemente aumenta o tamanho da área clicável dos elementos, facilitando assim a seleção.
 
-> **Nota:** Você pode ver alguns bons e maus exemplos de formulários em [good-form.html](http://mdn.github.io/learning-area/accessibility/html/good-form.html) e [bad-form.html](http://mdn.github.io/learning-area/accessibility/html/bad-form.html).
+> [!NOTE]
+> Você pode ver alguns bons e maus exemplos de formulários em [good-form.html](http://mdn.github.io/learning-area/accessibility/html/good-form.html) e [bad-form.html](http://mdn.github.io/learning-area/accessibility/html/bad-form.html).
 
 ## Tabelas de dados acessíveis
 
@@ -451,7 +456,8 @@ Agora dê uma olhada no exemplo da nossa [tabela de bandas punk](https://github.
 - Os cabeçalhos de tabela são definidos usando elementos {{htmlelement ("th")}} - você também pode especificar se eles são cabeçalhos de linhas ou colunas usando o atributo `scope`. Isso fornece grupos completos de dados que podem ser consumidos pelos leitores de tela como unidades únicas.
 - O elemento {{htmlelement ("caption")}} e o atributo de resumo (`<table>` `summary`) executam tarefas semelhantes - eles funcionam como texto alternativo para uma tabela, fornecendo ao usuário de leitor de telas um resumo rápido e útil do conteúdo da tabela. `<caption>` é geralmente mais adequado, pois torna o seu conteúdo acessível para os usuários com visão também, que também poderão achar isso útil. Você não precisa ter os dois.
 
-> **Nota:** Consulte nossos artigos sobre [Recursos avançados de acessibilidade para tabelas em HTML](/pt-BR/docs/Learn/HTML/Tables/Advanced) para obter mais detalhes sobre tabelas de dados acessíveis.
+> [!NOTE]
+> Consulte nossos artigos sobre [Recursos avançados de acessibilidade para tabelas em HTML](/pt-BR/docs/Learn/HTML/Tables/Advanced) para obter mais detalhes sobre tabelas de dados acessíveis.
 
 ## Alternativas em textos
 
@@ -477,7 +483,8 @@ Temos um exemplo simples escrito, [accessible-image.html](http://mdn.github.io/l
 
 A primeira imagem, quando visualizada por um leitor de tela, não oferece muita ajuda ao usuário - o VoiceOver, por exemplo, lê "/dinosaur.png, image". Ele lê o nome do arquivo para tentar fornecer alguma ajuda. Neste exemplo, o usuário pelo menos saberá que é um tipo de dinossauro, mas muitas vezes os arquivos podem ser carregados com nomes de arquivos gerados por máquina (por exemplo, de uma câmera digital) e esses nomes provavelmente não fornecem nenhum contexto ao conteúdo da imagem.
 
-> **Nota:** É por isso que você nunca deve incluir conteúdo de texto dentro de uma imagem - os leitores de tela simplesmente não podem acessá-lo. Existem outras desvantagens também - você não pode selecioná-lo e copiá-lo/colá-lo. Apenas não faça isso!
+> [!NOTE]
+> É por isso que você nunca deve incluir conteúdo de texto dentro de uma imagem - os leitores de tela simplesmente não podem acessá-lo. Existem outras desvantagens também - você não pode selecioná-lo e copiá-lo/colá-lo. Apenas não faça isso!
 
 Quando um leitor de tela encontra a segunda imagem, ele lê todo o atributo `alt` - "Um tiranossauro Rex vermelho: Um dinossauro de duas patas em pé como um humano, com braços pequenos e uma cabeça grande com muitos dentes afiados".
 
@@ -485,7 +492,8 @@ Isso destaca a importância de não apenas usar nomes de arquivos significativos
 
 Uma coisa a considerar é se as imagens possuem algum significado dentro de seu conteúdo ou se elas são puramente decorativas. Se eles são decorativas, é melhor apenas incluí-las na página como imagens de fundo através de CSS.
 
-> **Nota:** Leia [Imagens em HTML](/pt-BR/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML) e [Imagens Responsivas](/pt-BR/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images) para obter mais informações sobre a implementação de imagens e melhores práticas.
+> [!NOTE]
+> Leia [Imagens em HTML](/pt-BR/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML) e [Imagens Responsivas](/pt-BR/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images) para obter mais informações sobre a implementação de imagens e melhores práticas.
 
 Se você quiser fornecer informações contextuais extras, deverá colocá-las no texto ao redor da imagem ou dentro de um atributo de título (`title`), como mostrado acima. Nesse caso, a maioria dos leitores de tela lerá o texto alternativo, o atributo de título e o nome do arquivo. Além disso, os navegadores exibem o texto do título como dicas de ferramentas quando estão sobre o mouse.
 
@@ -540,7 +548,8 @@ Pode haver momentos em que uma imagem é incluída no design de uma página, mas
 
 A razão para usar um `alt` vazio ao invés de não incluí-lo é porque muitos leitores de tela anunciam o URL da imagem inteira se nenhum `alt` for fornecido. No exemplo acima, a imagem está agindo como uma decoração visual para o título ao qual está associada. Em casos como esse, e nos casos em que uma imagem é apenas decoração e não tem valor de conteúdo, você deve colocar um `alt` vazio em suas imagens. Outra alternativa é usar o atributo ARIA role (role="presentation") - isso também impede que os leitores de telas leiam textos alternativos.
 
-> **Nota:** se possível, você deve usar CSS para exibir imagens que são apenas decorativas.
+> [!NOTE]
+> se possível, você deve usar CSS para exibir imagens que são apenas decorativas.
 
 ## Resumo
 

--- a/files/pt-br/learn/accessibility/index.md
+++ b/files/pt-br/learn/accessibility/index.md
@@ -25,7 +25,8 @@ O recurso **Inspecionar propriedades de acessibilidade** é uma ótima ferrament
 
 Para ter o máximo proveito deste módulo, recomendamos que esteja familiarizados com pelos os dois primeiros módulos de [HTML](/pt-BR/docs/Learn/HTML), [CSS](/pt-BR/docs/Learn/CSS), e [JavaScript](/pt-BR/docs/Learn/JavaScript), ou melhor ainda, com as partes principais do módulo de acessibilidade de cada capítulo, à medida em que vai estudando.
 
-> **Nota:** Se você está estudando em um dispositivo que não pode criar novos arquivos, voce pode testar os exemplos em alguma aplicação de codificação online, como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
+> [!NOTE]
+> Se você está estudando em um dispositivo que não pode criar novos arquivos, voce pode testar os exemplos em alguma aplicação de codificação online, como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/common_questions/design_and_accessibility/thinking_before_coding/index.md
+++ b/files/pt-br/learn/common_questions/design_and_accessibility/thinking_before_coding/index.md
@@ -44,7 +44,8 @@ A técnica é obviamente crítica. Músicos devem dominar seu instrumento. Mas b
 
 Uma hora de discussão com amigos é um bom começo, mas inadequado. Você precisa se sentar e estruturar suas ideias para ter uma visão clara do caminho que deve seguir para tornar suas ideias realidade. Para fazer isso, você precisa apenas de caneta e papel e de algum tempo para responder pelo menos as seguintes perguntas.
 
-> **Nota:** Existem inúmeras maneiras de realizar a ideação do projeto. Não podemos colocá-las todas aqui (um livro inteiro não seria suficiente). O que vamos apresentar aqui é um método simples para lidar com o que os profissionais chamam de [Ideação do Projeto](<http://en.wikipedia.org/wiki/Ideation_(idea_generation)>), [Planejamento do Projeto](http://en.wikipedia.org/wiki/Project_planning), e [Gerenciamento do Projeto](http://en.wikipedia.org/wiki/Project_management).
+> [!NOTE]
+> Existem inúmeras maneiras de realizar a ideação do projeto. Não podemos colocá-las todas aqui (um livro inteiro não seria suficiente). O que vamos apresentar aqui é um método simples para lidar com o que os profissionais chamam de [Ideação do Projeto](<http://en.wikipedia.org/wiki/Ideation_(idea_generation)>), [Planejamento do Projeto](http://en.wikipedia.org/wiki/Project_planning), e [Gerenciamento do Projeto](http://en.wikipedia.org/wiki/Project_management).
 
 ### O que exatamente eu quero realizar?
 

--- a/files/pt-br/learn/common_questions/tools_and_setup/set_up_a_local_testing_server/index.md
+++ b/files/pt-br/learn/common_questions/tools_and_setup/set_up_a_local_testing_server/index.md
@@ -86,7 +86,8 @@ Para fazer isso:
 
 5. Por padrão, isso executará o conteúdo do diretório em um servidor web local, na porta 8000. Você pode ir para esse servidor acessando a URL `localhost:8000` no seu navegador web. Aqui você verá o conteúdo do diretório listado — clique no arquivo HTML que você deseja executar.
 
-> **Nota:** Se você já tiver algo em execução na porta 8000, você poderá escolher outra porta executando o comando do servidor seguido por um número de porta alternativo, por exemplo `python3 -m http.server 7800` (Python 3.x) ou `python -m SimpleHTTPServer 7800` (Python 2.x). Você pode acessar seu conteúdo em `localhost:7800`.
+> [!NOTE]
+> Se você já tiver algo em execução na porta 8000, você poderá escolher outra porta executando o comando do servidor seguido por um número de porta alternativo, por exemplo `python3 -m http.server 7800` (Python 3.x) ou `python -m SimpleHTTPServer 7800` (Python 2.x). Você pode acessar seu conteúdo em `localhost:7800`.
 
 ## Executando linguagens do lado do servidor localmente
 

--- a/files/pt-br/learn/common_questions/tools_and_setup/upload_files_to_a_web_server/index.md
+++ b/files/pt-br/learn/common_questions/tools_and_setup/upload_files_to_a_web_server/index.md
@@ -46,7 +46,8 @@ Se você construiu uma página web básica (veja [HTML basics](/pt-BR/docs/Learn
 
 Existem vários clientes SFTP . Nossa demo cobre o FileZilla, já que é gratuito e está disponível para Windows, macOS e Linux. Para instalar o FileZilla, vá para a página de downloads do FileZilla, clique no botão Download grande e instale a partir do arquivo de instalação da maneira usual.
 
-> **Nota:** Claro que existem outras opções. Consulte [Publishing tools](/en-US/Learn/How_much_does_it_cost#Publishing_tools.3A_FTP_client) para mais informações.
+> [!NOTE]
+> Claro que existem outras opções. Consulte [Publishing tools](/en-US/Learn/How_much_does_it_cost#Publishing_tools.3A_FTP_client) para mais informações.
 
 Abra o FileZilla, você verá algo semelhante a isso:
 
@@ -76,7 +77,8 @@ Primeiramente, olhe em `http://demozilla.examplehostingprovider.net/` — como v
 
 ![Our demozilla personal website, seen in a browser: it's empty](demozilla-empty.png)
 
-> **Nota:** Dependendo do seu provedor de hospedagem, na maioria das vezes você verá uma página dizendo algo como como "Este site é hospedado por \[serviço de hospedagem]".Isso é claro, quando você acessa seu endereço da web pela primeira vez.
+> [!NOTE]
+> Dependendo do seu provedor de hospedagem, na maioria das vezes você verá uma página dizendo algo como como "Este site é hospedado por \[serviço de hospedagem]".Isso é claro, quando você acessa seu endereço da web pela primeira vez.
 
 Para conectar seu cliente SFTP ao servidor, siga estas etapas:
 

--- a/files/pt-br/learn/common_questions/tools_and_setup/what_are_browser_developer_tools/index.md
+++ b/files/pt-br/learn/common_questions/tools_and_setup/what_are_browser_developer_tools/index.md
@@ -5,7 +5,8 @@ slug: Learn/Common_questions/Tools_and_setup/What_are_browser_developer_tools
 
 Todo navegador web moderno inclui um poderoso conjunto de ferramentas para desenvolvedores. Essas ferramentas fazem muitas coisas, desde inspecionar o HTML, CSS e JavaScript recém carregado e quais recursos foram requeridos até mostrar quanto tempo a página precisou para carregar. Este artigo explica como usar as funções básicas das ferramentas para desenvolvedores do seu navegador.
 
-> **Nota:** Antes de você executar os exemplos abaixo, abra o [Beginner's example site](http://mdn.github.io/beginner-html-site-scripted/) (site de exemplos do iniciante) que nós criamos durante o início da série de artigos da Web ( [Getting started with the Web](/en-US/Learn/Getting_started_with_the_web) ). Você poderá abrir isso enquanto segue os passos abaixo.
+> [!NOTE]
+> Antes de você executar os exemplos abaixo, abra o [Beginner's example site](http://mdn.github.io/beginner-html-site-scripted/) (site de exemplos do iniciante) que nós criamos durante o início da série de artigos da Web ( [Getting started with the Web](/en-US/Learn/Getting_started_with_the_web) ). Você poderá abrir isso enquanto segue os passos abaixo.
 
 ## Como abrir o devtools no seu navegador
 

--- a/files/pt-br/learn/common_questions/web_mechanics/how_does_the_internet_work/index.md
+++ b/files/pt-br/learn/common_questions/web_mechanics/how_does_the_internet_work/index.md
@@ -44,7 +44,8 @@ A **Internet** é a espinha dorsal da Web, a infraestrutura técnica que faz a W
 
 Quando dois computadores precisam se comunicar, você precisa conectá-los, seja fisicamente (normalmente com um [Cabo de rede](https://pt.wikipedia.org/wiki/Cabo_de_par_tran%C3%A7ado)) ou de uma forma sem fio (por exemplo com sistemas [WiFi](https://pt.wikipedia.org/wiki/Wi-Fi) ou [Bluetooth](https://pt.wikipedia.org/wiki/Bluetooth)). Todos os computadores modernos suportam alguma(s) dessas conexões.
 
-> **Nota:** Até o final deste artigo nós estaremos falando apenas a respeito de cabos físicos, mas redes sem fio funcionam da mesma forma
+> [!NOTE]
+> Até o final deste artigo nós estaremos falando apenas a respeito de cabos físicos, mas redes sem fio funcionam da mesma forma
 
 ![Dois computadores conectados](internet-schema-1.png)
 

--- a/files/pt-br/learn/common_questions/web_mechanics/what_is_a_domain_name/index.md
+++ b/files/pt-br/learn/common_questions/web_mechanics/what_is_a_domain_name/index.md
@@ -120,7 +120,8 @@ O processo é bastante simples:
 3. Preencher o formulário com todos os detalhes requeridos. Certifique-se especialmente de que você não digitou incorretamente o domain name desejado. Uma vez pago, é tarde demais!
 4. O registrador informará quando o domain name estiver registrado corretamente. Dentro de algumas horas, todos os servidores de DNS receberão suas informações de DNS.
 
-> **Nota:** Este tempo é frequentemente chamado de **tempo de propagação.** No entanto, este termo não é preciso, pois a atualização não está se propagando (top → down). Os servidores DNS consultados pelo seu computador (abaixo) são aqueles que buscam as informações do servidor autoritativo (superior) quando precisam.
+> [!NOTE]
+> Este tempo é frequentemente chamado de **tempo de propagação.** No entanto, este termo não é preciso, pois a atualização não está se propagando (top → down). Os servidores DNS consultados pelo seu computador (abaixo) são aqueles que buscam as informações do servidor autoritativo (superior) quando precisam.
 
 #### Atualização de DNS
 

--- a/files/pt-br/learn/css/building_blocks/cascade_and_inheritance/index.md
+++ b/files/pt-br/learn/css/building_blocks/cascade_and_inheritance/index.md
@@ -80,7 +80,8 @@ Por exemplo, se você definir `color` e `font-family` em um elemento, todos os e
 
 Algumas propriedades não herdam — por exemplo, se você definir um {{cssxref("width")}} de 50% em um elemento, todos os seus descendentes não obterão uma largura de 50% da largura de seu pai. Se fosse esse o caso, seria muito frustrante usar CSS!
 
-> **Nota:** Nas páginas de referência de propriedade MDN CSS, você pode encontrar uma caixa de informações técnicas chamada "Definição formal", que lista vários pontos de dados sobre essa propriedade, incluindo se ela é herdada ou não. Consulte a [seção de definição formal da propriedade de cores](/pt-BR/docs/Web/CSS/color#formal_definition) como exemplo.
+> [!NOTE]
+> Nas páginas de referência de propriedade MDN CSS, você pode encontrar uma caixa de informações técnicas chamada "Definição formal", que lista vários pontos de dados sobre essa propriedade, incluindo se ela é herdada ou não. Consulte a [seção de definição formal da propriedade de cores](/pt-BR/docs/Web/CSS/color#formal_definition) como exemplo.
 
 ## Compreender como os conceitos funcionam juntos
 
@@ -117,7 +118,8 @@ O {{glossary("CSS")}} fornece cinco valores de propriedades universais especiais
 - {{cssxref("unset")}}
   - : Redefine a propriedade para seu valor natural, o que significa que, se a propriedade for herdada naturalmente, ela agirá como `herdar`, caso contrário, agirá como `inicial`.
 
-> **Nota:** Consulte [Tipos de origem](/pt-BR/docs/Web/CSS/Cascade#origin_types) para obter mais informações sobre cada um deles e como eles funcionam.
+> [!NOTE]
+> Consulte [Tipos de origem](/pt-BR/docs/Web/CSS/Cascade#origin_types) para obter mais informações sobre cada um deles e como eles funcionam.
 
 Podemos olhar para uma lista de links e explorar como funcionam os valores universais. O exemplo ao vivo abaixo permite que você jogue com o CSS e veja o que acontece quando você faz alterações. Brincar com código é realmente a melhor maneira de entender melhor HTML e CSS.
 
@@ -178,7 +180,8 @@ A quantidade de especificidade que um seletor tem é medida usando três valores
 - **Classes**: pontue um nesta coluna para cada seletor de classe, seletor de atributo ou pseudoclasse contido no seletor geral.
 - **Elementos**: Pontue um nesta coluna para cada seletor de elemento ou pseudoelemento contido no seletor geral.
 
-> **Nota:** O seletor universal ([`*`](/pt-BR/docs/Web/CSS/Universal_selectors)), [combinators](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Combinators) (`+`, `>`, `~`, ' ') e seletor de ajuste de especificidade ([`:where()`](/pt-BR/docs/Web/CSS/:where)) juntamente com seus parâmetros, não têm efeito na especificidade.
+> [!NOTE]
+> O seletor universal ([`*`](/pt-BR/docs/Web/CSS/Universal_selectors)), [combinators](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Combinators) (`+`, `>`, `~`, ' ') e seletor de ajuste de especificidade ([`:where()`](/pt-BR/docs/Web/CSS/:where)) juntamente com seus parâmetros, não têm efeito na especificidade.
 
 A negação ([`:not()`](/pt-BR/docs/Web/CSS/:not)), seletor relacional ([`:has()`](/pt-BR/docs/Web/CSS /:has)), e as pseudoclasses matches-any ([`:is()`](/pt-BR/docs/Web/CSS/:is)) não têm efeito na especificidade, mas suas parâmetros fazem. A especificidade que cada um contribui para o algoritmo de especificidade é a especificidade do seletor no parâmetro que tem maior peso.
 
@@ -202,7 +205,8 @@ Então, o que está acontecendo aqui? Em primeiro lugar, estamos interessados ap
 - Os seletores 3 e 4 estão competindo pelo estilo da cor do texto do link. O segundo ganha e torna o texto branco porque, embora tenha um seletor de elemento a menos, o seletor ausente é trocado por um seletor de classe, que tem mais peso do que os seletores de elemento infinito. A especificidade vencedora é 1-1-3 vs. 1-0-4.
 - Os seletores de 5 a 7 estão competindo pelo estilo da borda do link ao passar o mouse. O seletor 6 claramente perde para o seletor 5 com uma especificidade de 0-2-3 vs. 0-2-4; ele tem um seletor de elemento a menos na cadeia. O seletor 7, no entanto, supera os seletores 5 e 6 porque tem o mesmo número de subseletores na cadeia que o seletor 5, mas um elemento foi trocado por um seletor de classe. Assim, a especificidade vencedora é 0-3-3 vs. 0-2-3 e 0-2-4.
 
-> **Nota:** Cada tipo de seletor tem seu próprio nível de especificidade que não pode ser substituído por seletores com um nível de especificidade inferior. Por exemplo, um seletor _million_ **class** combinado não seria capaz de sobrescrever a especificidade do seletor _one_ **id**.
+> [!NOTE]
+> Cada tipo de seletor tem seu próprio nível de especificidade que não pode ser substituído por seletores com um nível de especificidade inferior. Por exemplo, um seletor _million_ **class** combinado não seria capaz de sobrescrever a especificidade do seletor _one_ **id**.
 >
 > A melhor forma de avaliar a especificidade é pontuar os níveis de especificidade individualmente começando do mais alto e passando para o mais baixo quando necessário. Somente quando há um empate entre as pontuações do seletor dentro de uma coluna de especificidade, você precisa avaliar a próxima coluna abaixo; caso contrário, você pode desconsiderar os seletores de especificidade mais baixa, pois eles nunca podem sobrescrever os seletores de especificidade mais alta.
 
@@ -214,7 +218,8 @@ Os estilos embutidos, ou seja, a declaração de estilo dentro de um atributo [`
 
 Há um pedaço especial de CSS que você pode usar para anular todos os cálculos acima, até mesmo estilos embutidos - o sinalizador `!important`. No entanto, você deve ter muito cuidado ao usá-lo. Este sinalizador é usado para tornar uma propriedade individual e um par de valores a regra mais específica, substituindo assim as regras normais da cascata, incluindo estilos embutidos normais.
 
-> **Nota:** É útil saber que o sinalizador `!important` existe para que você saiba o que é quando o encontrar no código de outras pessoas. **Entretanto, nós recomendamos fortemente que você nunca o use, a menos que seja absolutamente necessário.** O sinalizador `!important` muda a maneira como a cascata normalmente funciona, então pode tornar os problemas de depuração de CSS muito difíceis de resolver, especialmente em um grande folha de estilo.
+> [!NOTE]
+> É útil saber que o sinalizador `!important` existe para que você saiba o que é quando o encontrar no código de outras pessoas. **Entretanto, nós recomendamos fortemente que você nunca o use, a menos que seja absolutamente necessário.** O sinalizador `!important` muda a maneira como a cascata normalmente funciona, então pode tornar os problemas de depuração de CSS muito difíceis de resolver, especialmente em um grande folha de estilo.
 
 Dê uma olhada neste exemplo onde temos dois parágrafos, um dos quais tem um ID.
 
@@ -227,7 +232,8 @@ Vamos examinar isso para ver o que está acontecendo - tente remover algumas das
 3. Ambos os elementos têm um [`class`](/pt-BR/docs/Web/HTML/Global_attributes#class) de `better`, mas o segundo tem um [`id`](/pt-BR/docs /Web/HTML/Global*attributes#id) de `vencedor` também. Como os IDs têm uma especificidade \_ainda maior* do que as classes (você só pode ter um elemento com cada ID exclusivo em uma página, mas muitos elementos com a mesma classe — os seletores de ID são _muito específicos_ no que visam), a cor de fundo vermelha e o 1px a borda preta deve ser aplicada ao 2º elemento, com o primeiro elemento obtendo a cor de fundo cinza e sem borda, conforme especificado pela classe.
 4. O segundo elemento _fica_ com a cor de fundo vermelha, mas sem borda. Por que? Por causa do sinalizador `!important` na segunda regra. Adicionar o sinalizador `!important` depois de `border: none` significa que esta declaração prevalecerá sobre o valor `border` na regra anterior, mesmo que o seletor de ID tenha maior especificidade.
 
-> **Nota:** A única maneira de substituir uma declaração importante é incluir outra declaração importante com a _mesma especificidade_ posteriormente na ordem de origem, ou uma com maior especificidade, ou incluir uma declaração importante em uma camada em cascata anterior (nós ainda não cobrimos as camadas em cascata).
+> [!NOTE]
+> A única maneira de substituir uma declaração importante é incluir outra declaração importante com a _mesma especificidade_ posteriormente na ordem de origem, ou uma com maior especificidade, ou incluir uma declaração importante em uma camada em cascata anterior (nós ainda não cobrimos as camadas em cascata).
 
 Uma situação em que você pode ter que usar o sinalizador `!important` é quando você está trabalhando em um CMS onde você não pode editar os módulos CSS principais, e você realmente quer sobrescrever um estilo embutido ou uma declaração importante que não pode ser substituído de qualquer outra forma. Mas realmente, não use se puder evitá-lo.
 
@@ -250,7 +256,8 @@ Declarações conflitantes serão aplicadas na seguinte ordem, com as posteriore
 5. Declarações importantes nas folhas de estilo do usuário.
 6. Declarações importantes nas folhas de estilo do agente do usuário.
 
-> **Nota:** A ordem de precedência é invertida para estilos sinalizados com `!important`. Faz sentido que as folhas de estilo dos desenvolvedores da Web substituam as folhas de estilo do usuário, para que o design possa ser mantido como pretendido; no entanto, às vezes os usuários têm boas razões para substituir os estilos de desenvolvedor da Web, como mencionado acima, e isso pode ser feito usando `!important` em suas regras.
+> [!NOTE]
+> A ordem de precedência é invertida para estilos sinalizados com `!important`. Faz sentido que as folhas de estilo dos desenvolvedores da Web substituam as folhas de estilo do usuário, para que o design possa ser mantido como pretendido; no entanto, às vezes os usuários têm boas razões para substituir os estilos de desenvolvedor da Web, como mencionado acima, e isso pode ser feito usando `!important` em suas regras.
 
 ### Ordem das camadas em cascata
 

--- a/files/pt-br/learn/css/building_blocks/index.md
+++ b/files/pt-br/learn/css/building_blocks/index.md
@@ -18,7 +18,8 @@ Antes de iniciar este módulo, você deve ter:
 3. Familiaridade básica com HTML, como foi discutido no módulo [Introdução ao HTML](/pt-BR/docs/Learn/HTML/Introduction_to_HTML).
 4. Um entendimento do básico em CSS, como o mostrado no módulo [Primeiros Passos com CSS](/pt-BR/docs/Learn/CSS/First_steps).
 
-> **Nota:** Se você estiver usando um computador/tablet/outro dispositivo onde você não puder criar seus próprios arquivos, você pode tentar rodar (a maioria) os códigos de exemplo em um programa de codificação online como o [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
+> [!NOTE]
+> Se você estiver usando um computador/tablet/outro dispositivo onde você não puder criar seus próprios arquivos, você pode tentar rodar (a maioria) os códigos de exemplo em um programa de codificação online como o [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/css/building_blocks/selectors/attribute_selectors/index.md
+++ b/files/pt-br/learn/css/building_blocks/selectors/attribute_selectors/index.md
@@ -81,7 +81,8 @@ No exemplo abaixo, o primeiro seletor corresponderá a um valor que começa com 
 
 {{EmbedGHLiveSample("css-examples/learn/selectors/attribute-case.html", '100%', 800)}}
 
-> **Nota:** Há tambem um valor mais novo `s`, que forçará a correspondência com distinção entre maiúsculas e minúsculas em contextos em que a correspondência normalmente não diferencia maiúsculas de minúsculas; no entanto, isso não é bem suportado em navegadores e não é muito útil em um contexto HTML.
+> [!NOTE]
+> Há tambem um valor mais novo `s`, que forçará a correspondência com distinção entre maiúsculas e minúsculas em contextos em que a correspondência normalmente não diferencia maiúsculas de minúsculas; no entanto, isso não é bem suportado em navegadores e não é muito útil em um contexto HTML.
 
 ## Próximos passos
 

--- a/files/pt-br/learn/css/building_blocks/selectors/type_class_and_id_selectors/index.md
+++ b/files/pt-br/learn/css/building_blocks/selectors/type_class_and_id_selectors/index.md
@@ -103,9 +103,11 @@ Um seletor de ID começa com um `#` em vez de um caractere de ponto, mas é usad
 
 {{EmbedGHLiveSample("css-examples/learn/selectors/id.html", '100%', 750)}}
 
-> **Aviso:** usar o mesmo ID várias vezes em um documento pode parecer funcionar para fins de estilo, mas não faça isso. Isso resulta em código inválido e causará um comportamento estranho em muitos lugares.
+> [!WARNING]
+> usar o mesmo ID várias vezes em um documento pode parecer funcionar para fins de estilo, mas não faça isso. Isso resulta em código inválido e causará um comportamento estranho em muitos lugares.
 
-> **Nota:** Como aprendemos na lição sobre especificidade, um ID tem alta especificidade. Ele anulará a maioria dos outros seletores. Na maioria dos casos, é preferível adicionar uma classe a um elemento em vez de um ID. No entanto, se usar o ID for a única maneira de segmentar o elemento — talvez porque você não tenha acesso à marcação e não possa editá-la — isso funcionará.
+> [!NOTE]
+> Como aprendemos na lição sobre especificidade, um ID tem alta especificidade. Ele anulará a maioria dos outros seletores. Na maioria dos casos, é preferível adicionar uma classe a um elemento em vez de um ID. No entanto, se usar o ID for a única maneira de segmentar o elemento — talvez porque você não tenha acesso à marcação e não possa editá-la — isso funcionará.
 
 ## Resumo
 

--- a/files/pt-br/learn/css/building_blocks/the_box_model/index.md
+++ b/files/pt-br/learn/css/building_blocks/the_box_model/index.md
@@ -69,7 +69,8 @@ Caixas possuem também um tipo de display _inner_, que determina como elementos 
 
 Podemos, no entando, alterar o tipo de exibição (display) interna usando valores `display` como `flex`. Se definirmos `display: flex;` em um elemento, o tipo de exibição externo será `block`, mas o tipo de exibição interna será alterada para `flex`. Todos os filhos diretos desta caixa se tornarão itens flexíveis e serão dispostos de acordo com as regras estabelecidas na especificação [Flexbox](/pt-BR/docs/Learn/CSS/CSS_layout/Flexbox), que você aprenderá mais tarde.
 
-> **Nota:** Para ler mais sobre valores de exibição (display) e como caixas funcionam nos layouts `block` e `inline`, dê uma olhada no guia MDN sobre [Block e Inline Layout](/pt-BR/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow)
+> [!NOTE]
+> Para ler mais sobre valores de exibição (display) e como caixas funcionam nos layouts `block` e `inline`, dê uma olhada no guia MDN sobre [Block e Inline Layout](/pt-BR/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow)
 
 Quando aprender sobre CSS Layout você encontrará `flex` e vários outros valores internos que suas caixas podem ter, como por exemplo [`grid`](/pt-BR/docs/Learn/CSS/CSS_layout/Grids).
 
@@ -136,7 +137,8 @@ The space taken up by our box using the standard box model will actually be 410p
 
 ![Showing the size of the box when the standard box model is being used.](standard-box-model.png)
 
-> **Nota:** The margin is not counted towards the actual size of the box — sure, it affects the total space that the box will take up on the page, but only the space outside the box. The box's area stops at the border — it does not extend into the margin.
+> [!NOTE]
+> The margin is not counted towards the actual size of the box — sure, it affects the total space that the box will take up on the page, but only the space outside the box. The box's area stops at the border — it does not extend into the margin.
 
 ### The alternative CSS box model
 
@@ -165,7 +167,8 @@ html {
 }
 ```
 
-> **Nota:** An interesting bit of history — Internet Explorer used to default to the alternative box model, with no mechanism available to switch.
+> [!NOTE]
+> An interesting bit of history — Internet Explorer used to default to the alternative box model, with no mechanism available to switch.
 
 ## Playing with box models
 
@@ -175,7 +178,8 @@ In the below example, you can see two boxes. Both have a class of `.box`, which 
 
 {{EmbedGHLiveSample("css-examples/learn/box-model/box-models.html", '100%', 1000)}}
 
-> **Nota:** You can find a solution for this task [here](https://github.com/mdn/css-examples/blob/master/learn/solutions.md#the-box-model).
+> [!NOTE]
+> You can find a solution for this task [here](https://github.com/mdn/css-examples/blob/master/learn/solutions.md#the-box-model).
 
 ### Use browser DevTools to view the box model
 

--- a/files/pt-br/learn/css/css_layout/flexbox/index.md
+++ b/files/pt-br/learn/css/css_layout/flexbox/index.md
@@ -65,7 +65,8 @@ O resultado disso deve ser algo assim:
 
 Então, esta única declaração nos dá tudo que precisamos — incrivel, certo? Nós temos um layout de múltiplas com tamanhos iguais, e todas as colunas tem a mesma altura. Isto porque o valor padrão dado aos flex items (os filhos do flex container) são configurados para resolver problemas comuns, como este. Voltaremos a este assunto depois.
 
-> **Nota:** Você pode definir também ao {{cssxref("display")}} o valor `inline-flex` se quiser colocar os items em linha como flexible boxes.
+> [!NOTE]
+> Você pode definir também ao {{cssxref("display")}} o valor `inline-flex` se quiser colocar os items em linha como flexible boxes.
 
 ## Um aparte no modelo _flex_
 
@@ -92,7 +93,8 @@ flex-direction: column;
 
 Você verá que isso organiza os elementos no layout de coluna, assim como eles estavam antes de adicionarmos qualquer regra CSS. Antes de você seguir, remova essa declaração do seu exemplo.
 
-> **Nota:** Você também pode arranjar itens flexíveis em direção reversa usando os valores `row-reverse` e `column-reverse`. Experimente usar esses valores no seu exemplo também!
+> [!NOTE]
+> Você também pode arranjar itens flexíveis em direção reversa usando os valores `row-reverse` e `column-reverse`. Experimente usar esses valores no seu exemplo também!
 
 ## Embrulhamento
 
@@ -199,7 +201,8 @@ div {
 
 Atualize a página e você verá que os botões estão agora bem arranjados no centro, horizontalmente e verticalmente. Fizemos isso através de duas novas propriedades.
 
-> **Nota:** Nesse exemplo, o eixo principal é representado horizontalmente e o eixo transversal é o vertical.
+> [!NOTE]
+> Nesse exemplo, o eixo principal é representado horizontalmente e o eixo transversal é o vertical.
 
 {{cssxref("align-items")}} controla onde os elementos _flex_ ficam no eixo transversal:
 

--- a/files/pt-br/learn/css/css_layout/index.md
+++ b/files/pt-br/learn/css/css_layout/index.md
@@ -7,7 +7,7 @@ slug: Learn/CSS/CSS_layout
 
 Neste ponto, vimos os fundamentos do CSS, como estilizar o texto e como estilizar e manipular as caixas dentro das quais seu conteúdo se encontra. Agora é hora de ver como organizar corretamente suas caixas em relação à viewport, bem como umas às outras. Cobrimos os pré-requisitos necessários, então vamos nos aprofundar no layout CSS, examinando vários recursos como: diferentes configurações de exibição, posicionamento, ferramentas de layout modernas como flexbox e grade CSS e algumas das técnicas herdadas que você ainda pode querer saber. cerca de.
 
-> **Callout:**
+> [!CALLOUT]
 >
 > #### Quer se tornar um desenvolvedor web front-end?
 >
@@ -24,7 +24,8 @@ Antes de iniciar este módulo, você já deve:
 2. Esteja familiarizado com os fundamentos do CSS, conforme discutido em [Introdução ao CSS](/pt-BR/docs/Learn/CSS/First_steps).
 3. Entenda como [estilizar caixas](/pt-BR/docs/Learn/CSS/Building_blocks).
 
-> **Nota:** Se você estiver trabalhando em um computador/tablet/outro dispositivo em que não tenha a capacidade de criar seus próprios arquivos, experimente (a maioria) os exemplos de código em um programa de codificação on-line, como como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
+> [!NOTE]
+> Se você estiver trabalhando em um computador/tablet/outro dispositivo em que não tenha a capacidade de criar seus próprios arquivos, experimente (a maioria) os exemplos de código em um programa de codificação on-line, como como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/css/css_layout/introduction/index.md
+++ b/files/pt-br/learn/css/css_layout/introduction/index.md
@@ -68,7 +68,8 @@ Note here how the HTML is displayed in the exact order in which it appears in th
 
 The elements that appear one below the other are described as _block_ elements, in contrast to _inline_ elements, which appear one beside the other, like the individual words in a paragraph.
 
-> **Nota:** The direction in which block element contents are laid out is described as the Block Direction. The Block Direction runs vertically in a language such as English, which has a horizontal writing mode. It would run horizontally in any language with a Vertical Writing Mode, such as Japanese. The corresponding Inline Direction is the direction in which inline contents (such as a sentence) would run.
+> [!NOTE]
+> The direction in which block element contents are laid out is described as the Block Direction. The Block Direction runs vertically in a language such as English, which has a horizontal writing mode. It would run horizontally in any language with a Vertical Writing Mode, such as Japanese. The corresponding Inline Direction is the direction in which inline contents (such as a sentence) would run.
 
 When you use CSS to create a layout, you are moving the elements away from the normal flow, but for many of the elements on your page the normal flow will create exactly the layout you need. This is why starting with a well-structured HTML document is so important, as you can then work with the way things are laid out by default rather than fighting against it.
 
@@ -160,7 +161,8 @@ As a simple example of this, we can add the {{cssxref("flex")}} property to all 
 
 {{ EmbedLiveSample('Flex_2', '300', '200') }}
 
-> **Nota:** This has been a very short introduction to what is possible in Flexbox, to find out more, see our [Flexbox](/pt-BR/docs/Learn/CSS/CSS_layout/Flexbox) article.
+> [!NOTE]
+> This has been a very short introduction to what is possible in Flexbox, to find out more, see our [Flexbox](/pt-BR/docs/Learn/CSS/CSS_layout/Flexbox) article.
 
 ## Grid Layout
 
@@ -250,7 +252,8 @@ Once you have a grid, you can explicitly place your items on it, rather than rel
 
 {{ EmbedLiveSample('Grid_2', '300', '330') }}
 
-> **Nota:** These two examples are just a small part of the power of Grid layout; to find out more see our [Grid Layout](/pt-BR/docs/Learn/CSS/CSS_layout/Grids) article.
+> [!NOTE]
+> These two examples are just a small part of the power of Grid layout; to find out more see our [Grid Layout](/pt-BR/docs/Learn/CSS/CSS_layout/Grids) article.
 
 The rest of this guide covers other layout methods, which are less important for the main layout structures of your page but can still help you achieve specific tasks. By understanding the nature of each layout task, you will soon find that when you look at a particular component of your design the type of layout best suited to it will often be clear.
 
@@ -316,7 +319,8 @@ p {
 
 {{ EmbedLiveSample('Float_1', '100%', 600) }}
 
-> **Nota:** Floats are fully explained in our lesson on the [float and clear](/pt-BR/docs/Learn/CSS/CSS_layout/Floats) properties. Prior to techniques such as Flexbox and Grid Layout floats were used as a method of creating column layouts. You may still come across these methods on the web; we will cover these in the lesson on [legacy layout methods](/pt-BR/docs/Learn/CSS/CSS_layout/Legacy_Layout_Methods).
+> [!NOTE]
+> Floats are fully explained in our lesson on the [float and clear](/pt-BR/docs/Learn/CSS/CSS_layout/Floats) properties. Prior to techniques such as Flexbox and Grid Layout floats were used as a method of creating column layouts. You may still come across these methods on the web; we will cover these in the lesson on [legacy layout methods](/pt-BR/docs/Learn/CSS/CSS_layout/Legacy_Layout_Methods).
 
 ## Positioning techniques
 
@@ -619,7 +623,8 @@ body {
 
 {{ EmbedLiveSample('Sticky_1', '100%', 200) }}
 
-> **Nota:** to find more out about positioning, see our [Positioning](/pt-BR/docs/Learn/CSS/CSS_layout/Positioning) article.
+> [!NOTE]
+> to find more out about positioning, see our [Positioning](/pt-BR/docs/Learn/CSS/CSS_layout/Positioning) article.
 
 ## Table layout
 

--- a/files/pt-br/learn/css/css_layout/responsive_design/index.md
+++ b/files/pt-br/learn/css/css_layout/responsive_design/index.md
@@ -41,15 +41,18 @@ Essas duas abordagens, geralmente, resultavam em um site com a melhor aparência
 
 ![A layout with two columns squashed into a mobile size viewport.](mdn-rwd-liquid.png)
 
-> **Nota:** Veja este layout líquido simples: [exemplo](https://mdn.github.io/css-examples/learn/rwd/liquid-width.html), [código-fonte](https://github.com/mdn/css-examples/blob/master/learn/rwd/liquid-width.html). Ao visualizar o exemplo, arraste a janela do navegador para dentro e para fora para ver como isso fica em tamanhos diferentes.
+> [!NOTE]
+> Veja este layout líquido simples: [exemplo](https://mdn.github.io/css-examples/learn/rwd/liquid-width.html), [código-fonte](https://github.com/mdn/css-examples/blob/master/learn/rwd/liquid-width.html). Ao visualizar o exemplo, arraste a janela do navegador para dentro e para fora para ver como isso fica em tamanhos diferentes.
 
 O site de largura fixa criava uma barra de rolagem horizontal em telas menores que a largura do site (como mostrado abaixo) e muito espaço em branco nas bordas do design em telas maiores.
 
 ![A layout with a horizontal scrollbar in a mobile viewport.](mdn-rwd-fixed.png)
 
-> **Nota:** Veja este layout simples de largura fixa: [exemplo](https://mdn.github.io/css-examples/learn/rwd/fixed-width.html), [código-fonte](https://github.com/mdn/css-examples/blob/master/learn/rwd/fixed-width.html). Observe novamente o resultado ao alterar o tamanho da janela do navegador.
+> [!NOTE]
+> Veja este layout simples de largura fixa: [exemplo](https://mdn.github.io/css-examples/learn/rwd/fixed-width.html), [código-fonte](https://github.com/mdn/css-examples/blob/master/learn/rwd/fixed-width.html). Observe novamente o resultado ao alterar o tamanho da janela do navegador.
 
-> **Nota:** As capturas de tela acima foram tiradas usando o [Responsive Design Mode](/pt-BR/docs/Tools/Responsive_Design_Mode) no Firefox DevTools.
+> [!NOTE]
+> As capturas de tela acima foram tiradas usando o [Responsive Design Mode](/pt-BR/docs/Tools/Responsive_Design_Mode) no Firefox DevTools.
 
 À medida que a Web para dispositivos móveis começava a se tornar realidade com os primeiros telefones com essas características, empresas que desejavam adotar os dispositivos móveis geralmente criavam uma versão mobile do seu site, com uma URL diferente (geralmente algo como m.exemplo.com ou exemplo.mobi) Isso significava que duas versões separadas do site tinham que ser desenvolvidas e mantidas atualizadas.
 
@@ -123,7 +126,8 @@ On wider screens they move to two columns:
 
 ![A desktop view of a layout with two columns.](mdn-rwd-desktop.png)
 
-> **Nota:** You can find the [live example](https://mdn.github.io/css-examples/learn/rwd/float-based-rwd.html) and [source code](https://github.com/mdn/css-examples/blob/master/learn/rwd/float-based-rwd.html) for this example on GitHub.
+> [!NOTE]
+> You can find the [live example](https://mdn.github.io/css-examples/learn/rwd/float-based-rwd.html) and [source code](https://github.com/mdn/css-examples/blob/master/learn/rwd/float-based-rwd.html) for this example on GitHub.
 
 ## Modern layout technologies
 
@@ -163,7 +167,8 @@ In the example below the flex items will each take an equal amount of space in t
 }
 ```
 
-> **Nota:** As an example we have rebuilt the simple responsive layout above, this time using flexbox. You can see how we no longer need to use strange percentage values to calculate the size of the columns: [example](https://mdn.github.io/css-examples/learn/rwd/flex-based-rwd.html), [source code](https://github.com/mdn/css-examples/blob/master/learn/rwd/flex-based-rwd.html).
+> [!NOTE]
+> As an example we have rebuilt the simple responsive layout above, this time using flexbox. You can see how we no longer need to use strange percentage values to calculate the size of the columns: [example](https://mdn.github.io/css-examples/learn/rwd/flex-based-rwd.html), [source code](https://github.com/mdn/css-examples/blob/master/learn/rwd/flex-based-rwd.html).
 
 ### CSS grid
 
@@ -176,7 +181,8 @@ In CSS Grid Layout the `fr` unit allows the distribution of available space acro
 }
 ```
 
-> **Nota:** The grid layout version is even simpler as we can define the columns on the .wrapper: [example](https://mdn.github.io/css-examples/learn/rwd/grid-based-rwd.html), [source code](https://github.com/mdn/css-examples/blob/master/learn/rwd/grid-based-rwd.html).
+> [!NOTE]
+> The grid layout version is even simpler as we can define the columns on the .wrapper: [example](https://mdn.github.io/css-examples/learn/rwd/grid-based-rwd.html), [source code](https://github.com/mdn/css-examples/blob/master/learn/rwd/grid-based-rwd.html).
 
 ## Responsive images
 
@@ -228,7 +234,8 @@ On desktop however we see the larger heading size:
 
 ![A two column layout with a large heading.](mdn-rwd-font-desktop.png)
 
-> **Nota:** See this example in action: [example](https://mdn.github.io/css-examples/learn/rwd/type-rwd.html), [source code](https://github.com/mdn/css-examples/blob/master/learn/rwd/type-rwd.html).
+> [!NOTE]
+> See this example in action: [example](https://mdn.github.io/css-examples/learn/rwd/type-rwd.html), [source code](https://github.com/mdn/css-examples/blob/master/learn/rwd/type-rwd.html).
 
 As this approach to typography shows, you do not need to restrict media queries to only changing the layout of the page. They can be used to tweak any element to make it more usable or attractive at alternate screen sizes.
 
@@ -254,7 +261,8 @@ h1 {
 
 This means that we only need to specify the font size for the heading once, rather than set it up for mobile and redefine it in the media queries. The font then gradually increases as you increase the size of the viewport.
 
-> **Nota:** See an example of this in action: [example](https://mdn.github.io/css-examples/learn/rwd/type-vw.html), [source code](https://github.com/mdn/css-examples/blob/master/learn/rwd/type-vw.html).
+> [!NOTE]
+> See an example of this in action: [example](https://mdn.github.io/css-examples/learn/rwd/type-vw.html), [source code](https://github.com/mdn/css-examples/blob/master/learn/rwd/type-vw.html).
 
 ## The viewport meta tag
 

--- a/files/pt-br/learn/css/first_steps/how_css_is_structured/index.md
+++ b/files/pt-br/learn/css/first_steps/how_css_is_structured/index.md
@@ -204,7 +204,8 @@ h1, h2, .intro
 
 **Tente criar algumas regras CSS que usem os seletores acima e algum HTML para ser estilizado por eles. Se você não souber o que significa alguma das sintaxes acima, tente procurar no MDN!**
 
-> **Nota:** Você aprenderá muito mais sobre seletores em nossos tutoriais [CSS selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors), no próximo módulo.
+> [!NOTE]
+> Você aprenderá muito mais sobre seletores em nossos tutoriais [CSS selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors), no próximo módulo.
 
 ### Especificidade
 
@@ -403,7 +404,8 @@ Não tentaremos ensinar isso exaustivamente agora - você encontrará muitos exe
 
 **Tente adicionar as declarações acima ao seu CSS para ver como elas afetam o estilo do seu HTML. Tente experimentar com alguns valores diferentes.**
 
-> **Aviso:** Embora os atalhos geralmente permitam que você deixe de fora valores, eles então redefinem quaisquer valores que você não incluir para seus valores iniciais. Isso garante que um conjunto sensato de valores seja usado. No entanto, isso pode ser confuso se você estiver esperando que o atalho apenas mude os valores que passou.
+> [!WARNING]
+> Embora os atalhos geralmente permitam que você deixe de fora valores, eles então redefinem quaisquer valores que você não incluir para seus valores iniciais. Isso garante que um conjunto sensato de valores seja usado. No entanto, isso pode ser confuso se você estiver esperando que o atalho apenas mude os valores que passou.
 
 ## Comentários
 

--- a/files/pt-br/learn/css/first_steps/index.md
+++ b/files/pt-br/learn/css/first_steps/index.md
@@ -15,7 +15,8 @@ Antes de iniciar este módulo, você deve ter:
 2. Um ambiente de trabalho básico configurado conforme detalhado em [Instalando Software Básico](/pt-BR/docs/Learn/Getting_started_with_the_web/Installing_basic_software/pt-BR/docs/) e um entendimento de como criar e gerenciar arquivos, conforme detalhado em [Lidando com Arquivos](/pt-BR/docs/Learn/Getting_started_with_the_web/Dealing_with_files).
 3. Familiaridade básica com HTML, como discutido no módulo [Introdução ao HTML](/pt-BR/docs/Learn/HTML/Introduction_to_HTML).
 
-> **Nota:** Se você está trabalhando em um computador/tablet/ou outro dispostivo onde você não tem habilidade para criar seus próprios arquivos, você poderá tentar (a maioria) os exemplos de códigos em um programa online de codificação como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
+> [!NOTE]
+> Se você está trabalhando em um computador/tablet/ou outro dispostivo onde você não tem habilidade para criar seus próprios arquivos, você poderá tentar (a maioria) os exemplos de códigos em um programa online de codificação como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/css/first_steps/styling_a_biography_page/index.md
+++ b/files/pt-br/learn/css/first_steps/styling_a_biography_page/index.md
@@ -31,7 +31,8 @@ Com o que você aprendeu nas últimas lições, você deve perceber que pode for
 
 Você pode trabalhar com editor ao vivo abaixo, ou pode fazer o [download do ponto de partida](https://github.com/mdn/css-examples/blob/master/learn/getting-started/biog-download.html/) para trabalhar em seu próprio editor de texto. Esta é uma única página de HTML, além do ponto de partida no head do documento. Se preferir, você pode transferir este CSS para um arquivo separado quando criar o exemplo no seu computador. Ou ainda, você pode utilizar uma ferramenta online como por exemplo, o [CodePen](https://codepen.io/), [jsFiddle](https://jsfiddle.net/), ou [Glitch](https://glitch.com/) para realizar estas tarefas..
 
-> **Nota:** Se ficar emperrado, nos procure por ajuda — veja a seção [Assessment or further help](/pt-BR/docs/Learn/CSS/First_steps/Using_your_new_knowledge#Assessment_or_further_help) no final da página.
+> [!NOTE]
+> Se ficar emperrado, nos procure por ajuda — veja a seção [Assessment or further help](/pt-BR/docs/Learn/CSS/First_steps/Using_your_new_knowledge#Assessment_or_further_help) no final da página.
 
 ## Trabalhando com CSS
 

--- a/files/pt-br/learn/css/howto/css_faq/index.md
+++ b/files/pt-br/learn/css/howto/css_faq/index.md
@@ -60,7 +60,8 @@ Geralmente é recomendável que se utilize classes sempre que possível, utiliza
 - Classes permitem que você estilize diversos elementos. Sendo assim, classes podem ajudar a desenvolver folhas de estilo menores; mais enchutas, já que regras podem ser facilmente reutilizadas entre elementos. Isso não só ajuda na manutenção da folha de estilo, como também agiliza a renderização de páginas, principalmente em conexões lentas.
 - Seletores de classes tem menor [especificidade](/pt-BR/docs/Learn/CSS/Introduction_to_CSS/Cascade_and_inheritance#Specificity) do que seletores de id, o que torna as regras de estilização mais fáceis de serem sobrepostas.
 
-> **Nota:** Veja [Seletores](/pt-BR/docs/Learn/CSS/Introduction_to_CSS/Selectors) para mais informações.
+> [!NOTE]
+> Veja [Seletores](/pt-BR/docs/Learn/CSS/Introduction_to_CSS/Selectors) para mais informações.
 
 ## Como eu redefino o valor padrão de uma propriedade?
 
@@ -262,9 +263,11 @@ Caso você precise usar propriedades prefixadas em seu trabalho, você deve decl
 transform: rotate(90deg);
 ```
 
-> **Nota:** Para mais informações em como lhe dar com propriedades prefixadas, veja [Lidando com problemas comuns em HTML e CSS — Lidando com prefixos CSS](/pt-BR/docs/Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS#Handling_CSS_prefixes) do nosso módulo [Teste Cross-browsing](/pt-BR/docs/Learn/Tools_and_testing/Cross_browser_testing).
+> [!NOTE]
+> Para mais informações em como lhe dar com propriedades prefixadas, veja [Lidando com problemas comuns em HTML e CSS — Lidando com prefixos CSS](/pt-BR/docs/Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS#Handling_CSS_prefixes) do nosso módulo [Teste Cross-browsing](/pt-BR/docs/Learn/Tools_and_testing/Cross_browser_testing).
 
-> **Nota:** Veja a página [Extenções CSS Mozilla](/pt-BR/docs/CSS/CSS_Reference/Mozilla_Extensions) para mais informações sobre propriedades CSS prefixadas da Mozilla.
+> [!NOTE]
+> Veja a página [Extenções CSS Mozilla](/pt-BR/docs/CSS/CSS_Reference/Mozilla_Extensions) para mais informações sobre propriedades CSS prefixadas da Mozilla.
 
 ## Como `z-index` está relacionado a posicionamento?
 
@@ -272,4 +275,5 @@ A propriedade `z-index` especifica a ordem dos elementos da pilha.
 
 Um elemento com z-index/ordem na pilha maior sempre será renderizado à frente de um elemento com um z-index/ordem de pilha menor. `z-index` funcionará apenas em elementos que tenham uma posição especificada (Ou seja, só funcionará caso o elemento tenha `position:absolute`, `position:relative` ou `position:fixed`).
 
-> **Nota:** Para mais informações, veja nosso artigo de aprendizado sobre [Posicionamento](/pt-BR/docs/Learn/CSS/CSS_layout/Positioning), e em particular a seção [Introduzindo z-index](/pt-BR/docs/Learn/CSS/CSS_layout/Positioning#Introducing_z-index).
+> [!NOTE]
+> Para mais informações, veja nosso artigo de aprendizado sobre [Posicionamento](/pt-BR/docs/Learn/CSS/CSS_layout/Positioning), e em particular a seção [Introduzindo z-index](/pt-BR/docs/Learn/CSS/CSS_layout/Positioning#Introducing_z-index).

--- a/files/pt-br/learn/css/styling_text/index.md
+++ b/files/pt-br/learn/css/styling_text/index.md
@@ -11,7 +11,8 @@ Com o básico de CSS compreendido, o próximo passo para você se concentrar ser
 
 Antes de começar este módulo, você já deverá ter familiaridade básica com HTML, como dissemos no módulos [Introdução ao HTML](/pt-BR/docs/Learn/HTML/Introduction_to_HTML), e estar confortável com os fundamentos de CSS, como discutido em [Introdução ao CSS](/pt-BR/docs/Learn/CSS/Introduction_to_CSS).
 
-> **Nota:** Se você está usando um computador/tablet/outro dispositivo onde não tem a possibilidade de criar seus próprios arquivos, você poderá treinar os códigos-exemplo em um programa de código online como [JSBin](https://jsbin.com/) or [Glitch](https://glitch.com/).
+> [!NOTE]
+> Se você está usando um computador/tablet/outro dispositivo onde não tem a possibilidade de criar seus próprios arquivos, você poderá treinar os códigos-exemplo em um programa de código online como [JSBin](https://jsbin.com/) or [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/forms/form_validation/index.md
+++ b/files/pt-br/learn/forms/form_validation/index.md
@@ -45,7 +45,8 @@ Queremos tornar o preenchimento de formulários da web o mais fácil possível. 
 - **Quemos proteger os dados dos nossos usuários** — Forçarnosos usuários a fornecer senhas seguras facilita na proteção das informações da conta do usuário.
 - **Queremos proteger nos mesmos** — Existem diversas maneiras de um usuário malicioso usar formulários desprotegidos para danificar nossa aplicação (veja [Website security](/pt-BR/docs/Learn/Server-side/First_steps/Website_security)).
 
-  > **Aviso:** Nunca confie nos dados passados do cliente para o servidor. Mesmo que seu formulário seja validado de maneira correta e previna a má formação de inputs no lado do cliente, um usuário malicioso ainda pode roubar o request da conexão.
+  > [!WARNING]
+  > Nunca confie nos dados passados do cliente para o servidor. Mesmo que seu formulário seja validado de maneira correta e previna a má formação de inputs no lado do cliente, um usuário malicioso ainda pode roubar o request da conexão.
 
 ### Diferentes tipos de validação de formulário
 
@@ -170,9 +171,11 @@ Neste exemplo, o elemento {{HTMLElement("input")}} aceita um dos dois valores po
 
 Neste ponto, tente alterar o valor dentro do atributo `pattern` para igualar alguns dos exemplos que você viu anteriormente e veja como isso afeta os valores que você pode inserir para tornar o valor de entrada válido. Tente escrever alguns dos seus próprios, e veja como você se sai! Tente torná-los relacionados a frutas sempre que possível, para que seus exemplos façam sentido!
 
-> **Nota:** Alguns tipos de elemento {{HTMLElement("input")}} não precisam de um atributo [`pattern`](/pt-BR/docs/Web/HTML/Element/input#pattern) para serem validados. Especificar o tipo `email`, por exemplo, valida o valor inserido em relação a uma expressão regular que corresponde a um endereço de e-mail bem formado (ou uma lista de endereços de e-mail separados por vírgula se tiver o [`multiple`](/pt-BR/docs/Web/HTML/Element/input#multiple) atributo). Como outro exemplo, os campos com o tipo `url` requerem automaticamente um URL devidamente formado.
+> [!NOTE]
+> Alguns tipos de elemento {{HTMLElement("input")}} não precisam de um atributo [`pattern`](/pt-BR/docs/Web/HTML/Element/input#pattern) para serem validados. Especificar o tipo `email`, por exemplo, valida o valor inserido em relação a uma expressão regular que corresponde a um endereço de e-mail bem formado (ou uma lista de endereços de e-mail separados por vírgula se tiver o [`multiple`](/pt-BR/docs/Web/HTML/Element/input#multiple) atributo). Como outro exemplo, os campos com o tipo `url` requerem automaticamente um URL devidamente formado.
 
-> **Nota:** O elemento {{HTMLElement("textarea")}} não suporta o atributo [`pattern`](/pt-BR/docs/Web/HTML/Element/input#pattern).
+> [!NOTE]
+> O elemento {{HTMLElement("textarea")}} não suporta o atributo [`pattern`](/pt-BR/docs/Web/HTML/Element/input#pattern).
 
 ### Restringindo o comprimento de suas entradas
 

--- a/files/pt-br/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/pt-br/learn/forms/how_to_structure_a_web_form/index.md
@@ -38,7 +38,8 @@ O elemento {{HTMLElement("form")}} é o elemento que formalmente define o formul
 
 Nós já vimos isto em um artigo anterior:
 
-> **Nota:** É estritamente proíbido aninhar um formulário dentro de outro formulário. Isto pode fazer com que os formulários se comportem de maneira imprevisível baseada no navegador que está sendo utilizado.
+> [!NOTE]
+> É estritamente proíbido aninhar um formulário dentro de outro formulário. Isto pode fazer com que os formulários se comportem de maneira imprevisível baseada no navegador que está sendo utilizado.
 
 Note que, sempre é possível usar um widget de formulário fora de um elemento {{HTMLElement("form")}} mas se o fizer, o widget não terá nada a ver com o formulário. Estes widgets podem ser usados fora de um formulário, mas para tanto você deverá ter um plano especial para eles, pois este não farão nada por si próprios. Você terá de controlar o comportamento deles através de JavaScript.
 
@@ -157,7 +158,8 @@ The paragraph at the top defines the rule for required elements. It must be at t
 - In the second example, things are a bit clearer — the label read out along with the input is "name star name edit text", and the labels are still read out separately. Things are still a bit confusing, but it's a bit better this time because the input has a label associated with it.
 - The third example is best — the actual label is read out all together, and the label read out with the input is "name star edit text".
 
-> **Nota:** You might get slightly different results, depending on your screenreader. This was tested in VoiceOver (and NVDA behaves similarly). We'd love to hear about your experiences too.
+> [!NOTE]
+> You might get slightly different results, depending on your screenreader. This was tested in VoiceOver (and NVDA behaves similarly). We'd love to hear about your experiences too.
 
 **Note**: You can find this example on GitHub as [required-labels.html](https://github.com/mdn/learning-area/blob/master/html/forms/html-form-structure/required-labels.html) ([see it live also](https://mdn.github.io/learning-area/html/forms/html-form-structure/required-labels.html)). don't run the example with 2 or 3 of the versions uncommented — screenreaders will definitely get confused if you have multiple labels AND multiple inputs with the same ID!
 

--- a/files/pt-br/learn/getting_started_with_the_web/css_basics/index.md
+++ b/files/pt-br/learn/getting_started_with_the_web/css_basics/index.md
@@ -114,7 +114,8 @@ Agora que exploramos algumas noções básicas de CSS, vamos começar a adiciona
    }
    ```
 
-   > **Nota:** Qualquer coisa em um documento CSS entre `/*` e `*/` é um **comentário CSS**, que o navegador ignora quando renderiza o código. Este é um lugar para você escrever notas úteis sobre o que você está fazendo.
+   > [!NOTE]
+   > Qualquer coisa em um documento CSS entre `/*` e `*/` é um **comentário CSS**, que o navegador ignora quando renderiza o código. Este é um lugar para você escrever notas úteis sobre o que você está fazendo.
 
 4. Agora definiremos tamanhos de fonte para elementos que contêm texto dentro do corpo HTML ({{htmlelement ("h1")}}, {{htmlelement ("li")}} e {{htmlelement ("p")}}). Também centralizaremos o texto do nosso cabeçalho e definiremos a altura da linha e o espaçamento das letras no conteúdo do corpo para torná-lo um pouco mais legível:
 
@@ -223,9 +224,11 @@ img {
 
 Finalmente, centralizaremos a imagem para melhorar a aparência. Nós poderiamos usar novamente o truque `margin: 0 auto` que aprendemos anteriormente para o corpo, mas também precisamos fazer outra coisa. O elemento {{htmlelement ("body")}} é **em nível de bloco**, o que significa que ocupa espaço na página e pode ter margens e outros valores de espaçamento aplicados a ele. Imagens, por outro lado, são elementos **em linha**, o que significa que não podem ter margens. Então, para aplicar margens a uma imagem, temos que dar o comportamento de nível de bloco a imagem usando `display: block;`.
 
-> **Nota:** As instruções acima assumem que você está usando uma imagem menor que a largura definida no corpo (600 pixels). Se sua imagem for maior, ela irá transbordar o corpo e vazar para o restante da página. Para corrigir isso, você pode 1) reduzir a largura da imagem usando um [editor gráfico](https://en.wikipedia.org/wiki/Raster_graphics_editor) (em inglês) ou 2) dimensionar a imagem usando CSS definindo a propriedade {{cssxref ("width")}} no elemento `<img>` com um valor menor (por exemplo, `400 px;`).
+> [!NOTE]
+> As instruções acima assumem que você está usando uma imagem menor que a largura definida no corpo (600 pixels). Se sua imagem for maior, ela irá transbordar o corpo e vazar para o restante da página. Para corrigir isso, você pode 1) reduzir a largura da imagem usando um [editor gráfico](https://en.wikipedia.org/wiki/Raster_graphics_editor) (em inglês) ou 2) dimensionar a imagem usando CSS definindo a propriedade {{cssxref ("width")}} no elemento `<img>` com um valor menor (por exemplo, `400 px;`).
 
-> **Nota:** Não se preocupe se você ainda não entender `display: block;` ou a distinção entre em nível de bloco / em linha. Você entenderá ao estudar CSS com mais profundidade. Você pode descobrir mais sobre os diferentes valores de exibição disponíveis em nossa [página de referência sobre display](/pt-BR/docs/Web/CSS/display).
+> [!NOTE]
+> Não se preocupe se você ainda não entender `display: block;` ou a distinção entre em nível de bloco / em linha. Você entenderá ao estudar CSS com mais profundidade. Você pode descobrir mais sobre os diferentes valores de exibição disponíveis em nossa [página de referência sobre display](/pt-BR/docs/Web/CSS/display).
 
 ## Conclusão
 

--- a/files/pt-br/learn/getting_started_with_the_web/dealing_with_files/index.md
+++ b/files/pt-br/learn/getting_started_with_the_web/dealing_with_files/index.md
@@ -32,7 +32,8 @@ A seguir, vamos ver qual estrutura seu site teste deve ter. As coisas mais comun
 3. **pasta `estilos`**: Essa pasta vai conter os códigos CSS usados para dar estilo ao seu conteúdo (por exemplo, configurando a cor do texto e do fundo da página). Crie uma pasta chamada `estilos`, dentro da pasta `site-teste`.
 4. **pasta `scripts`**: Essa pasta vai conter todos os códigos JavaScript usados para adicionar funcionalidades interativas para seu site (ex.: botões que carregam dados quando clicados). Crie uma pasta chamada `scripts`, dentro da sua pasta `site-teste`.
 
-> **Nota:** Em computadores com Windows, você deve ter problemas para ver os nomes dos arquivos, porque o Windows tem uma opção chamada **Ocultar as extensões dos tipos de arquivo conhecidos** ativada por padrão. Geralmente você pode desativar essa opção indo no Windows Explorer, selecionando a opção **Opções de pasta...**, desmarque a caixa de seleção **Ocultar as extensões dos tipos de arquivo conhecidos**, e clique em **OK**. Para mais informação sobre sua versão de Windows, procure na web.
+> [!NOTE]
+> Em computadores com Windows, você deve ter problemas para ver os nomes dos arquivos, porque o Windows tem uma opção chamada **Ocultar as extensões dos tipos de arquivo conhecidos** ativada por padrão. Geralmente você pode desativar essa opção indo no Windows Explorer, selecionando a opção **Opções de pasta...**, desmarque a caixa de seleção **Ocultar as extensões dos tipos de arquivo conhecidos**, e clique em **OK**. Para mais informação sobre sua versão de Windows, procure na web.
 
 ## Caminhos de arquivo
 
@@ -69,7 +70,8 @@ Algumas regras gerais para caminhos de arquivo:
 
 Por agora, isso é tudo o que precisamos saber.
 
-> **Nota:** O sistema de arquivos do Windows tende a usar barras invertidas, não barras normais , ex.: `C:\windows`. Isso não importa — mesmo se você estiver desenvolvendo seu site no Windows, você ainda deve usar barras normais no seu código.
+> [!NOTE]
+> O sistema de arquivos do Windows tende a usar barras invertidas, não barras normais , ex.: `C:\windows`. Isso não importa — mesmo se você estiver desenvolvendo seu site no Windows, você ainda deve usar barras normais no seu código.
 
 ## O que mais deve ser feito?
 

--- a/files/pt-br/learn/getting_started_with_the_web/html_basics/index.md
+++ b/files/pt-br/learn/getting_started_with_the_web/html_basics/index.md
@@ -46,7 +46,8 @@ Um atributo sempre deve ter:
 2. O nome do atributo, seguido por um sinal de igual.
 3. Aspas de abertura e fechamento, envolvendo todo o valor do atributo.
 
-> **Nota:** Valores de atributos simples que não contém espaço em branco ASCII (ou qualquer um dos caracteres `"` `'` `` ` `` `=` `<` `>`) podem permanecer sem aspas, mas é recomendável colocar em todos os valores de atributos, pois isso torna o código mais consistente e compreensível.
+> [!NOTE]
+> Valores de atributos simples que não contém espaço em branco ASCII (ou qualquer um dos caracteres `"` `'` `` ` `` `=` `<` `>`) podem permanecer sem aspas, mas é recomendável colocar em todos os valores de atributos, pois isso torna o código mais consistente e compreensível.
 
 ### Aninhando elementos
 
@@ -122,7 +123,8 @@ As palavras-chave para o texto alternativo são "texto descritivo". O texto alte
 
 Tente criar um texto alternativo melhor para sua imagem agora.
 
-> **Nota:** Saiba mais sobre acessibilidade em [módulo de aprendizagem sobre acessibilidade.](/pt-BR/docs/Web/Accessibility)
+> [!NOTE]
+> Saiba mais sobre acessibilidade em [módulo de aprendizagem sobre acessibilidade.](/pt-BR/docs/Web/Accessibility)
 
 ## Marcando o texto
 
@@ -140,11 +142,13 @@ Os elementos de cabeçalhos permitem especificar que certas partes do seu conte�
 <h4>Meu segundo subtítulo</h4>
 ```
 
-> **Nota:** Qualquer coisa em HTML entre `<!--` e `-->` é um **comentário HTML**. O navegador ignora comentários enquanto renderiza o código. Em outras palavras, eles não são visíveis na página – apenas no código. Os comentários HTML são uma forma de escrever notas úteis sobre seu código ou lógica.
+> [!NOTE]
+> Qualquer coisa em HTML entre `<!--` e `-->` é um **comentário HTML**. O navegador ignora comentários enquanto renderiza o código. Em outras palavras, eles não são visíveis na página – apenas no código. Os comentários HTML são uma forma de escrever notas úteis sobre seu código ou lógica.
 
 Agora tente adicionar um título adequado à sua página HTML logo acima do elemento {{htmlelement("img")}}.
 
-> **Nota:** você verá que seu título de nível 1 tem um estilo implícito. Não use elementos de cabeçalho para deixar o texto maior ou em negrito, pois eles são usados para [acessibilidade](/pt-BR/docs/Learn/Accessibility/HTML#text_content) e [outros motivos, como SEO](/pt-BR/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals#why_do_we_need_structure). Tente criar uma sequência significativa de títulos em suas páginas, sem pular níveis.
+> [!NOTE]
+> você verá que seu título de nível 1 tem um estilo implícito. Não use elementos de cabeçalho para deixar o texto maior ou em negrito, pois eles são usados para [acessibilidade](/pt-BR/docs/Learn/Accessibility/HTML#text_content) e [outros motivos, como SEO](/pt-BR/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals#why_do_we_need_structure). Tente criar uma sequência significativa de títulos em suas páginas, sem pular níveis.
 
 ### Parágrafo
 

--- a/files/pt-br/learn/getting_started_with_the_web/installing_basic_software/index.md
+++ b/files/pt-br/learn/getting_started_with_the_web/installing_basic_software/index.md
@@ -39,7 +39,8 @@ Por enquanto, instalaremos alguns navegadores da Web para testar nosso código. 
 
 Antes de continuar, você deve instalar pelo menos dois desses navegadores e tê-los disponíveis para teste.
 
-> **Nota:** O Internet Explorer não é compatível com alguns recursos modernos da web e pode não ser capaz de executar seu projeto.
+> [!NOTE]
+> O Internet Explorer não é compatível com alguns recursos modernos da web e pode não ser capaz de executar seu projeto.
 
 ### Instalando um servidor web local
 

--- a/files/pt-br/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/pt-br/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -32,7 +32,8 @@ JavaScript é uma das tecnologias da web modernas mais populares! À medida que 
 
 No entanto, familiarizar-se com JavaScript é mais desafiador do que familiarizar-se com HTML e CSS. Você pode ter que começar pequeno e progredir gradualmente. Para começar, vamos examinar como adicionar JavaScript à sua página para criar um exemplo _Hello world!_. (_Hello world!_ é [o padrão para exemplos de programação introdutória](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program).)
 
-> **Aviso:** Se você não está acompanhando o restante do nosso curso, [faça o download deste código de exemplo](https://codeload.github.com/mdn/beginner-html-site-styled/zip/refs/heads/gh-pages) e use-o como ponto de partida.
+> [!WARNING]
+> Se você não está acompanhando o restante do nosso curso, [faça o download deste código de exemplo](https://codeload.github.com/mdn/beginner-html-site-styled/zip/refs/heads/gh-pages) e use-o como ponto de partida.
 
 1. Vá para o seu site de teste e crie uma nova pasta chamada `scripts`. Dentro da pasta scripts, crie um novo documento de texto chamado `main.js` e salve-o.
 2. Em seu arquivo `index.html`, insira este código em uma nova linha, logo antes da tag de fechamento `</body>`:
@@ -53,7 +54,8 @@ No entanto, familiarizar-se com JavaScript é mais desafiador do que familiariza
 
 ![Título "hello world" acima de um logotipo do firefox](hello-world.png)
 
-> **Nota:** A razão pela qual as instruções (acima) colocam o elemento {{htmlelement("script")}} perto da parte inferior do arquivo HTML é que o navegador lê o código na ordem em que aparece no arquivo.
+> [!NOTE]
+> A razão pela qual as instruções (acima) colocam o elemento {{htmlelement("script")}} perto da parte inferior do arquivo HTML é que o navegador lê o código na ordem em que aparece no arquivo.
 >
 > Se o JavaScript carregar primeiro e supostamente afetar o HTML que ainda não foi carregado, pode haver problemas. Colocar JavaScript perto da parte inferior de uma página HTML é uma maneira de acomodar essa dependência. Para saber mais sobre abordagens alternativas, consulte [Estratégias de carregamento de script](/pt-BR/docs/Learn/JavaScript/First_steps/What_is_JavaScript#script_loading_strategies).
 
@@ -63,13 +65,15 @@ O texto do cabeçalho mudou para _Hello world!_ usando JavaScript. Você fez iss
 
 Em seguida, o código define o valor da propriedade {{domxref("Node.textContent", "textContent")}} da variável `myHeading` (que representa o conteúdo do cabeçalho) como _Hello world!_.
 
-> **Nota:** Ambos os recursos usados neste exercício são partes do [Modelo de Objeto de Document (DOM)](/pt-BR/docs/Web/API/Document_Object_Model), que tem a capacidade de manipular documentos.
+> [!NOTE]
+> Ambos os recursos usados neste exercício são partes do [Modelo de Objeto de Document (DOM)](/pt-BR/docs/Web/API/Document_Object_Model), que tem a capacidade de manipular documentos.
 
 ## Curso intensivo de fundamentos da linguagem
 
 Para entender melhor como o JavaScript funciona, vamos explicar alguns dos principais recursos da linguagem. Vale a pena notar que esses recursos são comuns a todas as linguagens de programação. Se você dominar esses fundamentos, terá uma vantagem inicial na codificação em outras linguagens também!
 
-> **Aviso:** neste artigo, tente inserir as linhas de código de exemplo em seu console JavaScript para ver o que acontece. Para obter mais detalhes sobre consoles JavaScript, consulte [Descubra as ferramentas de desenvolvedor do navegador](/pt-BR/docs/Learn/Common_questions/What_are_browser_developer_tools).
+> [!WARNING]
+> neste artigo, tente inserir as linhas de código de exemplo em seu console JavaScript para ver o que acontece. Para obter mais detalhes sobre consoles JavaScript, consulte [Descubra as ferramentas de desenvolvedor do navegador](/pt-BR/docs/Learn/Common_questions/What_are_browser_developer_tools).
 
 ### Variáveis
 
@@ -266,7 +270,8 @@ Um `{{Glossary("operator")}}` é um símbolo matemático que produz um resultado
 
 Existem muito mais operadores para explorar, mas isso é o suficiente por enquanto. Consulte [Expressões e operadores](/pt-BR/docs/Web/JavaScript/Reference/Operators) para obter uma lista completa.
 
-> **Nota:** misturar tipos de dados pode levar a alguns resultados estranhos ao realizar cálculos. Tenha cuidado para se referir às suas variáveis corretamente e obter os resultados esperados. Por exemplo, digite `'35' + '25'` em seu console. Por que você não consegue o resultado que esperava? Como as aspas transformam os números em strings, você acabou concatenando strings em vez de adicionar números. Se você inserir `35 + 25`, obterá o total dos dois números.
+> [!NOTE]
+> misturar tipos de dados pode levar a alguns resultados estranhos ao realizar cálculos. Tenha cuidado para se referir às suas variáveis corretamente e obter os resultados esperados. Por exemplo, digite `'35' + '25'` em seu console. Por que você não consegue o resultado que esperava? Como as aspas transformam os números em strings, você acabou concatenando strings em vez de adicionar números. Se você inserir `35 + 25`, obterá o total dos dois números.
 
 ### Condicionais
 
@@ -318,7 +323,8 @@ multiply(20, 20);
 multiply(0.5, 3);
 ```
 
-> **Nota:** A instrução [`return`](/pt-BR/docs/Web/JavaScript/Reference/Statements/return) diz ao navegador para retornar a variável `result` da função para que ela esteja disponível usar. Isso é necessário porque as variáveis definidas dentro das funções só estão disponíveis dentro dessas funções. Isso é chamado de variável {{Glossary("Scope", "scoping")}}. (Leia mais sobre [escopo de variável](/pt-BR/docs/Web/JavaScript/Guide/Grammar_and_types#variable_scope).)
+> [!NOTE]
+> A instrução [`return`](/pt-BR/docs/Web/JavaScript/Reference/Statements/return) diz ao navegador para retornar a variável `result` da função para que ela esteja disponível usar. Isso é necessário porque as variáveis definidas dentro das funções só estão disponíveis dentro dessas funções. Isso é chamado de variável {{Glossary("Scope", "scoping")}}. (Leia mais sobre [escopo de variável](/pt-BR/docs/Web/JavaScript/Guide/Grammar_and_types#variable_scope).)
 
 ### Eventos
 

--- a/files/pt-br/learn/getting_started_with_the_web/publishing_your_website/index.md
+++ b/files/pt-br/learn/getting_started_with_the_web/publishing_your_website/index.md
@@ -65,11 +65,13 @@ Agora vamos mostrar como publicar seu site facilmente por meio das páginas do G
 4. ![](github-create-repo.png)
 5. Arraste e solte o conteúdo da pasta do site no seu repositório e clique em _Commit changes_ (confirmar alterações).
 
-   > **Nota:** Nota: Certifique-se que sua pasta possui um arquivo `index.html`.
+   > [!NOTE]
+   > Nota: Certifique-se que sua pasta possui um arquivo `index.html`.
 
 6. Navegue em seu navegador até _username_.github.io para ver seu site online. Por exemplo, para o usuário _chrisdavidmills_, vá para [_chrisdavidmills_.github.io](http://chrisdavidmills.github.io/).
 
-> **Nota:** Nota: Pode levar alguns minutos para seu site ficar online. Se ele não funcionar imediatamente, talvez seja necessário aguardar alguns minutos e tentar novamente.
+> [!NOTE]
+> Nota: Pode levar alguns minutos para seu site ficar online. Se ele não funcionar imediatamente, talvez seja necessário aguardar alguns minutos e tentar novamente.
 
 Para aprender mais, consulte a [Ajuda do Github Pages](https://help.github.com/en/categories/github-pages-basics) (em inglês).
 

--- a/files/pt-br/learn/getting_started_with_the_web/what_will_your_website_look_like/index.md
+++ b/files/pt-br/learn/getting_started_with_the_web/what_will_your_website_look_like/index.md
@@ -17,7 +17,8 @@ Para começar, você deve responder às seguintes questões:
 2. **Que informação você está apresentando sobre o assunto?** Escreva um título e alguns parágrafos e pense em uma imagem para ilustrar sua página.
 3. **Como será seu site,** em termos simples. Qual é a cor de fundo? Qual é o tipo de fonte apropriado: formal, desenhado, negrito e gritante, sutil?
 
-> **Nota:** Projetos complexos precisam de guias detalhados que abordam todos os detalhes de cores, fontes, espaçamento entre itens de uma página, estilo de escrita apropriado, e por aí vai. Isso é denominado um guia de design, sistema de design ou manual da marca, e você pode ver um exemplo no [Sistema de Design do Firefox Photon](https://design.firefox.com/photon/) (em inglês).
+> [!NOTE]
+> Projetos complexos precisam de guias detalhados que abordam todos os detalhes de cores, fontes, espaçamento entre itens de uma página, estilo de escrita apropriado, e por aí vai. Isso é denominado um guia de design, sistema de design ou manual da marca, e você pode ver um exemplo no [Sistema de Design do Firefox Photon](https://design.firefox.com/photon/) (em inglês).
 
 ## Rascunhando seu design
 
@@ -25,7 +26,8 @@ Em seguida, pegue papel e caneta e faça um rascunho de como você deseja que se
 
 ![](website-drawing-scan.png)
 
-> **Nota:** Mesmo em sites reais e complexos, os times de design geralmente começam pelo rascunho em papel e depois constroem a versão digital usando um editor gráfico ou tecnologias da web.
+> [!NOTE]
+> Mesmo em sites reais e complexos, os times de design geralmente começam pelo rascunho em papel e depois constroem a versão digital usando um editor gráfico ou tecnologias da web.
 >
 > Os times de web geralmente incluem um designer gráfico e um designer de {{Glossary("UX", "experiencia do usuário")}} (UX). Designers gráficos, obviamente, constroem a parte visual do site. UX designers tem uma função de certa forma mais abstrata, direcionando como os usuários vão interagir e experimentar o site.
 

--- a/files/pt-br/learn/html/introduction_to_html/advanced_text_formatting/index.md
+++ b/files/pt-br/learn/html/introduction_to_html/advanced_text_formatting/index.md
@@ -332,7 +332,8 @@ Usamos HTML para estruturar nossos documentos da web.
 
 Acho que o Rev. Green fez isso na cozinha com a motosserra.
 
-> **Nota:** Há outro elemento, {{htmlelement("acronym")}}, que basicamente faz a mesma coisa que `<abbr>`, e foi projetado especificamente para acrônimos, em vez de abreviações. Isso, no entanto, caiu em desuso — não era suportado em navegadores nem o `<abbr>`, e tem uma função semelhante que foi considerado inútil ter os dois. Apenas use `<abbr>`.
+> [!NOTE]
+> Há outro elemento, {{htmlelement("acronym")}}, que basicamente faz a mesma coisa que `<abbr>`, e foi projetado especificamente para acrônimos, em vez de abreviações. Isso, no entanto, caiu em desuso — não era suportado em navegadores nem o `<abbr>`, e tem uma função semelhante que foi considerado inútil ter os dois. Apenas use `<abbr>`.
 
 ### Aprendizado ativo: marcando uma abreviação
 

--- a/files/pt-br/learn/html/introduction_to_html/creating_hyperlinks/index.md
+++ b/files/pt-br/learn/html/introduction_to_html/creating_hyperlinks/index.md
@@ -40,7 +40,8 @@ Os hiperlinks são realmente importantes — são o que torna a Web uma _web_. E
 
 Os hiperlinks são uma das inovações mais interessantes que a Web oferece. Bem, eles são uma característica da Web desde o início, mas são o que torna a Web como ela é — eles nos permitem vincular nossos documentos a qualquer outro documento (ou outro recurso) que queremos. Também podemos vincular para partes específicas de documentos e podemos disponibilizar aplicativos em um endereço web simples (em contraste com aplicativos nativos, que devem ser instalados e tantas outras coisas). Qualquer conteúdo da web pode ser convertido em um link, para que, quando clicado (ou ativado de outra forma) fará com que o navegador vá para outro endereço ({{glossary("URL")}}).
 
-> **Nota:** Um URL pode apontar para arquivos HTML, arquivos de texto, imagens, documentos de texto, arquivos de vídeo e áudio e qualquer outra coisa que possa estar na Web. Se o navegador não souber exibir ou manipular o arquivo, ele perguntará se você deseja abrir o arquivo (nesse caso, o dever de abrir ou manipular o arquivo é passado para um aplicativo nativo adequado no dispositivo) ou fazer o download dele (nesse caso, você pode tentar lidar com isso mais tarde).
+> [!NOTE]
+> Um URL pode apontar para arquivos HTML, arquivos de texto, imagens, documentos de texto, arquivos de vídeo e áudio e qualquer outra coisa que possa estar na Web. Se o navegador não souber exibir ou manipular o arquivo, ele perguntará se você deseja abrir o arquivo (nesse caso, o dever de abrir ou manipular o arquivo é passado para um aplicativo nativo adequado no dispositivo) ou fazer o download dele (nesse caso, você pode tentar lidar com isso mais tarde).
 
 A página inicial da BBC, por exemplo, contém um grande número de links que apontam não apenas para várias notícias, mas também diferentes áreas do site (funcionalidade de navegação), páginas de login/registro (ferramentas do usuário) e muito mais.
 
@@ -80,7 +81,8 @@ Isto nos dá o seguinte resultado (o título aparecerá como uma dica de ferrame
 
 Estou criando um link para [a página inicial da Mozilla](https://www.mozilla.org/pt-BR/).
 
-> **Nota:** Um título de link só é revelado ao passar o mouse sobre ele, o que significa que as pessoas que dependem do teclado ou _touchscreen_ para navegar em páginas web terão dificuldade em acessar a informação do título. Se a informação de um título é realmente importante para a usabilidade da página, então você deve apresentá-la de uma maneira que será acessível a todos os usuários, por exemplo, colocando-o no texto normal.
+> [!NOTE]
+> Um título de link só é revelado ao passar o mouse sobre ele, o que significa que as pessoas que dependem do teclado ou _touchscreen_ para navegar em páginas web terão dificuldade em acessar a informação do título. Se a informação de um título é realmente importante para a usabilidade da página, então você deve apresentá-la de uma maneira que será acessível a todos os usuários, por exemplo, colocando-o no texto normal.
 
 Aprendizagem na prática: criando seu próprio link de exemplo
 
@@ -102,7 +104,8 @@ Como falamos anteriormente, você pode transformar qualquer conteúdo em um link
 </a>
 ```
 
-> **Nota:** Você descobrirá muito mais sobre o uso de imagens na Web em artigo posterior.
+> [!NOTE]
+> Você descobrirá muito mais sobre o uso de imagens na Web em artigo posterior.
 
 ## Um guia rápido sobre URLs e caminhos
 
@@ -145,7 +148,8 @@ Existem também dois diretórios dentro da nossa raiz — `pdfs` e `projects`. C
   </p>
   ```
 
-> **Nota:** Você pode combinar várias instâncias desses recursos em URLs complexas, se necessário, por exemplo`../../../complex/path/to/my/file.html`.
+> [!NOTE]
+> Você pode combinar várias instâncias desses recursos em URLs complexas, se necessário, por exemplo`../../../complex/path/to/my/file.html`.
 
 ### Fragmentos de documento
 
@@ -289,7 +293,8 @@ O exemplo final acabaria por parecer algo assim:
 
 ![An example of a simple HTML navigation menu, with home, pictures, projects, and social menu items](navigation-example.png)
 
-> **Nota:** Se você ficar preso, ou não tem certeza se o fez bem, você pode verificar o diretório de [navegação-menu-marcado](https://github.com/mdn/learning-area/tree/master/html/introduction-to-html/navigation-menu-marked-up) para ver a resposta correta.
+> [!NOTE]
+> Se você ficar preso, ou não tem certeza se o fez bem, você pode verificar o diretório de [navegação-menu-marcado](https://github.com/mdn/learning-area/tree/master/html/introduction-to-html/navigation-menu-marked-up) para ver a resposta correta.
 
 ## Links de e-mail
 
@@ -318,7 +323,8 @@ Aqui está um exemplo que inclui um cc, bcc, assunto e corpo de texto:
 </a>
 ```
 
-> **Nota:** Os valores de cada campo devem ser codificados por URL, ou seja, com caracteres não imprimíveis (caracteres invisíveis, como guias, carriage returns e quebras de página) e espaços com [percent-escaped](http://en.wikipedia.org/wiki/Percent-encoding). Observe também o uso do ponto de interrogação (`?`) Para separar o URL principal dos valores do campo e do _e_ comercial (&) para separar cada campo no `mailto:` URL. Essa é a notação de consulta padrão do URL. Leia [O método GET](/pt-BR/docs/Learn/HTML/Forms/Sending_and_retrieving_form_data#The_GET_method) para entender para que esta notação de consulta é mais comum.
+> [!NOTE]
+> Os valores de cada campo devem ser codificados por URL, ou seja, com caracteres não imprimíveis (caracteres invisíveis, como guias, carriage returns e quebras de página) e espaços com [percent-escaped](http://en.wikipedia.org/wiki/Percent-encoding). Observe também o uso do ponto de interrogação (`?`) Para separar o URL principal dos valores do campo e do _e_ comercial (&) para separar cada campo no `mailto:` URL. Essa é a notação de consulta padrão do URL. Leia [O método GET](/pt-BR/docs/Learn/HTML/Forms/Sending_and_retrieving_form_data#The_GET_method) para entender para que esta notação de consulta é mais comum.
 
 Aqui estão alguns outros exemplos de URLs de `mailto:`
 

--- a/files/pt-br/learn/html/introduction_to_html/debugging_html/index.md
+++ b/files/pt-br/learn/html/introduction_to_html/debugging_html/index.md
@@ -58,7 +58,8 @@ Então, o que queremos dizer com permissivo? Bem, geralmente quando você faz al
 
 O próprio HTML não sofre de erros de sintaxe porque os navegadores o analisam permissivamente, o que significa que a página ainda é exibida mesmo se houver erros de sintaxe. Os navegadores têm regras internas para indicar como interpretar a marcação escrita incorretamente, para que você obtenha algo em execução, mesmo que não seja o esperado. Isso, claro, ainda pode ser um problema!
 
-> **Nota:** O HTML é analisado permissivamente porque, quando a web foi criada, foi decidido que permitir que as pessoas publicassem seus conteúdos era mais importante do que garantir que a sintaxe estivesse absolutamente correta. A web provavelmente não seria tão popular quanto é hoje, se tivesse sido mais rigorosa desde o início.
+> [!NOTE]
+> O HTML é analisado permissivamente porque, quando a web foi criada, foi decidido que permitir que as pessoas publicassem seus conteúdos era mais importante do que garantir que a sintaxe estivesse absolutamente correta. A web provavelmente não seria tão popular quanto é hoje, se tivesse sido mais rigorosa desde o início.
 
 ### Aprendizado Ativo: Estudando código permissivo
 
@@ -156,7 +157,8 @@ As mensagens de erros geralmente são úteis, mas algumas vezes elas não ajudam
   Exemplo: <a href="https://www.mozilla.org/>link para página da Mozilla</a> ↩ </ul>↩ </body>↩</html>
   ```
 
-  > **Nota:** Um atributo faltando uma aspas pode resultar em um elemento aberto porque o resto do documento é interpretado como conteúdo do atributo.
+  > [!NOTE]
+  > Um atributo faltando uma aspas pode resultar em um elemento aberto porque o resto do documento é interpretado como conteúdo do atributo.
 
 - "Unclosed element `ul`": Esta não ajuda em nada, já que o elemento {{htmlelement("ul")}} _está_ fechado corretamente. Este erro aparece porque o elemento {{htmlelement("a")}} não foi fechado, devido a falta de aspas de fechamento.
 

--- a/files/pt-br/learn/html/introduction_to_html/document_and_website_structure/index.md
+++ b/files/pt-br/learn/html/introduction_to_html/document_and_website_structure/index.md
@@ -63,7 +63,8 @@ O exemplo simples mostrado acima não é bonito, mas é perfeitamente aceitável
 
 Isso ocorre porque os visuais não contam toda a história. Usamos cor e tamanho de fonte para chamar a atenção dos usuários para as partes mais úteis do conteúdo, como o menu de navegação e links relacionados, mas sobre pessoas com deficiência visual, por exemplo, que podem não encontrar conceitos como "rosa" e "grande". fonte "muito útil?
 
-> **Nota:** Nota: as pessoas daltônicas representam cerca de 4% da população mundial ou, em outras palavras, aproximadamente 1 em cada 12 homens e 1 em cada 200 mulheres são daltônicas. Cegos e deficientes visuais representam cerca de 4-5% da população mundial (em 2012 havia 285 milhões de pessoas no mundo, enquanto a população total era de cerca de 7 bilhões).
+> [!NOTE]
+> Nota: as pessoas daltônicas representam cerca de 4% da população mundial ou, em outras palavras, aproximadamente 1 em cada 12 homens e 1 em cada 200 mulheres são daltônicas. Cegos e deficientes visuais representam cerca de 4-5% da população mundial (em 2012 havia 285 milhões de pessoas no mundo, enquanto a população total era de cerca de 7 bilhões).
 
 Em seu código HTML, você pode marcar seções de conteúdo com base em sua funcionalidade. Você pode usar elementos que representam as seções de conteúdo descritas acima sem ambigüidade, e tecnologias assistivas, como leitores de tela, podem reconhecer esses elementos e ajudar com tarefas como "localizar a navegação principal". "ou" encontre o conteúdo principal. " Como mencionamos anteriormente no curso, há um número de [consequências de não usar a estrutura de elemento e semâtica certas para o trabalho certo.](/pt-BR/docs/Aprender/HTML/Introducao_ao_HTML/Fundamentos_textuais_HTML#Por_que_precisamos_de_estrutura)
 
@@ -241,7 +242,8 @@ Nesse caso, a nota do editor deve meramente fornecer orientação extra para o d
 
 Este não é realmente um `<aside>`, pois não está necessariamente relacionado ao conteúdo principal da página (você deseja visualizá-lo de qualquer lugar). Nem sequer garante particularmente o uso de uma `<section>`, pois não faz parte do conteúdo principal da página. Portanto, um \<div> é bom neste caso. Incluímos um cabeçalho como orientação para ajudar os usuários de leitores de tela a encontrá-lo.
 
-> **Aviso:** Divs são tão convenientes de usar que é fácil usá-los demais. Como eles não carregam valor semântico, eles apenas confundem seu código HTML. Tome cuidado para usá-los somente quando não houver uma solução semântica melhor e tente reduzir ao mínimo o uso deles, caso contrário, será difícil atualizar e manter seus documentos.
+> [!WARNING]
+> Divs são tão convenientes de usar que é fácil usá-los demais. Como eles não carregam valor semântico, eles apenas confundem seu código HTML. Tome cuidado para usá-los somente quando não houver uma solução semântica melhor e tente reduzir ao mínimo o uso deles, caso contrário, será difícil atualizar e manter seus documentos.
 
 ### Quebras de linha e regras horizontais
 
@@ -295,7 +297,8 @@ Depois de planejar o conteúdo de uma página da Web simples, o próximo passo l
 
 Tente realizar o exercício acima para um site de sua própria criação. Sobre o que você gostaria de criar um site?
 
-> **Nota:** Salve seu trabalho em algum lugar; você pode precisar mais tarde.
+> [!NOTE]
+> Salve seu trabalho em algum lugar; você pode precisar mais tarde.
 
 ## Resumo
 

--- a/files/pt-br/learn/html/introduction_to_html/getting_started/index.md
+++ b/files/pt-br/learn/html/introduction_to_html/getting_started/index.md
@@ -233,11 +233,14 @@ O elemento {{htmlelement("em")}} é inline, então como você pode ver abaixo, o
 
 {{ EmbedLiveSample('Elementos_em_bloco_versus_elementos_inline', 700, 200, "", "") }}
 
-> **Nota:** o HTML5 redefiniu as categorias de elemento em HTML5: veja [Categorias de conteúdo de elementos](http://www.whatwg.org/specs/web-apps/current-work/complete/section-index.html#element-content-categories). Enquanto essas definições são mais precisas e menos ambíguas que as anteriores, elas são muito mais complicadas de entender do que "em bloco" e "inline", então usaremos estas ao longo deste tópico.
+> [!NOTE]
+> o HTML5 redefiniu as categorias de elemento em HTML5: veja [Categorias de conteúdo de elementos](http://www.whatwg.org/specs/web-apps/current-work/complete/section-index.html#element-content-categories). Enquanto essas definições são mais precisas e menos ambíguas que as anteriores, elas são muito mais complicadas de entender do que "em bloco" e "inline", então usaremos estas ao longo deste tópico.
 
-> **Nota:** Os termos "bloco" e "inline", conforme usados neste tópico, não devem ser confundidos com os [tipos de caixas CSS](/pt-BR/docs/Learn/CSS/Introduction_to_CSS/Box_model#Types_of_CSS_boxes) com os mesmos nomes. Embora eles se correlacionem por padrão, alterar o tipo de exibição CSS não altera a categoria do elemento e não afeta em quais elementos ele pode conter e em quais elementos ele pode estar contido. Um dos motivos pelos quais o HTML5 abandonou esses termos foi evitar essa confusão bastante comum.
+> [!NOTE]
+> Os termos "bloco" e "inline", conforme usados neste tópico, não devem ser confundidos com os [tipos de caixas CSS](/pt-BR/docs/Learn/CSS/Introduction_to_CSS/Box_model#Types_of_CSS_boxes) com os mesmos nomes. Embora eles se correlacionem por padrão, alterar o tipo de exibição CSS não altera a categoria do elemento e não afeta em quais elementos ele pode conter e em quais elementos ele pode estar contido. Um dos motivos pelos quais o HTML5 abandonou esses termos foi evitar essa confusão bastante comum.
 
-> **Nota:** Você pode encontrar páginas de referência úteis que incluem uma lista de elementos inline e em bloco — veja [elementos em bloco](/pt-BR/docs/Web/HTML/Block-level_elements) e [elementos inline](/pt-BR/docs/Web/HTML/Inline_elements).
+> [!NOTE]
+> Você pode encontrar páginas de referência úteis que incluem uma lista de elementos inline e em bloco — veja [elementos em bloco](/pt-BR/docs/Web/HTML/Block-level_elements) e [elementos inline](/pt-BR/docs/Web/HTML/Inline_elements).
 
 ### Elementos vazios
 
@@ -252,7 +255,8 @@ Isto exibirá em sua página:
 
 {{ EmbedLiveSample('Elementos_vazios', 700, 300, "", "", "hide-codepen-jsfiddle") }}
 
-> **Nota:** Elementos vazios são também chamados de _void elements_.
+> [!NOTE]
+> Elementos vazios são também chamados de _void elements_.
 
 ## Atributos
 
@@ -536,7 +540,8 @@ Se você quiser experimentar como funciona um documento HTML no seu computador, 
 3. Colar o código no novo arquivo de texto.
 4. Salvar o arquivo com o nome `index.html`.
 
-> **Nota:** Você também pode encontrar o template básico de HTML no [MDN Learning Area Github repo](https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/getting-started/index.html).
+> [!NOTE]
+> Você também pode encontrar o template básico de HTML no [MDN Learning Area Github repo](https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/getting-started/index.html).
 
 Você pode abrir este arquivo no navegador para ver como o código renderizado se apresenta, e então, editar o código e atualizar a página no navegador para ver o resultado com as mudanças. Inicialmente será exibido assim:
 
@@ -726,7 +731,8 @@ Na saída ao vivo abaixo, você pode ver que o primeiro parágrafo deu errado, p
 
 {{EmbedLiveSample('Referências_de_entidades_incluindo_caracteres_especiais_no_HTML', 7700, 200, "", "", "hide-codepen-jsfiddle")}}
 
-> **Nota:** A tabela com todas as referências de caracteres disponíveis em HTML pode ser encontrada na Wikipédia: [List of XML and HTML character entity references](http://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references). Observe que você não precisa usar referências de entidade para outros símbolos, pois os navegadores modernos manipularão os símbolos reais muito bem, desde que a codificação de caracteres do HTML esteja definida como UTF-8.
+> [!NOTE]
+> A tabela com todas as referências de caracteres disponíveis em HTML pode ser encontrada na Wikipédia: [List of XML and HTML character entity references](http://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references). Observe que você não precisa usar referências de entidade para outros símbolos, pois os navegadores modernos manipularão os símbolos reais muito bem, desde que a codificação de caracteres do HTML esteja definida como UTF-8.
 
 ## Comentários no HTML
 
@@ -748,7 +754,8 @@ Como você pode ver abaixo, o primeiro parágrafo fica visível na saída ao viv
 
 Você chegou ao final do artigo — esperamos que tenha gostado do seu tour pelos princípios básicos do HTML! Nesse ponto, você deve entender como é a linguagem, como ela funciona em um nível básico e ser capaz de escrever alguns elementos e atributos. Este é o lugar perfeito para se estar agora, já que os artigos subseqüentes deste módulo abordarão algumas das coisas que você já examinou com mais detalhes e introduzirão alguns novos conceitos da linguagem. Fique ligado!
 
-> **Nota:** Nesse ponto, à medida que você começa a aprender mais sobre HTML, também pode querer explorar os conceitos básicos de Cascading Style Sheets, ou [CSS](/pt-BR/docs/Aprender/CSS). CSS é a linguagem usada para estilizar suas páginas da web (por exemplo, alterando a fonte ou as cores ou alterando o layout da página). HTML e CSS vão muito bem juntos, como você descobrirá em breve.
+> [!NOTE]
+> Nesse ponto, à medida que você começa a aprender mais sobre HTML, também pode querer explorar os conceitos básicos de Cascading Style Sheets, ou [CSS](/pt-BR/docs/Aprender/CSS). CSS é a linguagem usada para estilizar suas páginas da web (por exemplo, alterando a fonte ou as cores ou alterando o layout da página). HTML e CSS vão muito bem juntos, como você descobrirá em breve.
 
 ## Veja também
 

--- a/files/pt-br/learn/html/introduction_to_html/html_text_fundamentals/index.md
+++ b/files/pt-br/learn/html/introduction_to_html/html_text_fundamentals/index.md
@@ -1002,7 +1002,8 @@ Aqui está a melhor regra geral: provavelmente é apropriado usar `<b>`, `<i>` o
 - {{htmlelement("b")}} é usado para transmitir um significado tradicionalmente transmitido por negrito: palavras-chave, nomes de produtos, sentença principal...
 - {{htmlelement("u")}} é usado para transmitir um significado tradicionalmente transmitido pelo sublinhado: nome próprio, erro de ortografia...
 
-> **Nota:** Um aviso amável sobre o sublinhado: **as pessoas associam fortemente o sublinhado com hiperlinks**. Portanto, na Web, é melhor sublinhar apenas os links. Use o elemento `<u>` quando for semanticamente apropriado, mas considere usar o CSS para alterar o sublinhado padrão para algo mais apropriado na Web. O exemplo abaixo ilustra como isso pode ser feito.
+> [!NOTE]
+> Um aviso amável sobre o sublinhado: **as pessoas associam fortemente o sublinhado com hiperlinks**. Portanto, na Web, é melhor sublinhar apenas os links. Use o elemento `<u>` quando for semanticamente apropriado, mas considere usar o CSS para alterar o sublinhado padrão para algo mais apropriado na Web. O exemplo abaixo ilustra como isso pode ser feito.
 
 ```html
 <!-- nomes científicos -->

--- a/files/pt-br/learn/html/introduction_to_html/test_your_skills_colon__html_text_basics/index.md
+++ b/files/pt-br/learn/html/introduction_to_html/test_your_skills_colon__html_text_basics/index.md
@@ -7,7 +7,8 @@ slug: Learn/HTML/Introduction_to_HTML/Test_your_skills:_HTML_text_basics
 
 O objetivo deste teste de habilidades é avaliar se você entendeu nosso artigo [Fundamentos do texto em HTML.](/pt-BR/docs/Aprender/HTML/Introducao_ao_HTML/Fundamentos_textuais_HTML)
 
-> **Nota:** Você pode testar suas soluções nos editores interativos abaixo, entretanto pode ser de ajuda fazer download do código e usar uma ferramenta online como [CodePen](https://codepen.io/), [jsFiddle](https://jsfiddle.net/), ou [Glitch](https://glitch.com/) para trabalhar nas tarefas.
+> [!NOTE]
+> Você pode testar suas soluções nos editores interativos abaixo, entretanto pode ser de ajuda fazer download do código e usar uma ferramenta online como [CodePen](https://codepen.io/), [jsFiddle](https://jsfiddle.net/), ou [Glitch](https://glitch.com/) para trabalhar nas tarefas.
 >
 > Se você ficar travado em alguma tarefa, peça-nos ajuda — veja a seção[Assessment or further help](#assessment_or_further_help) no final desta página.
 

--- a/files/pt-br/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/pt-br/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -110,7 +110,8 @@ Este elemento simplesmente especifica a codificação de caracteres do documento
 
 ![a web page containing English and Japanese characters, with the character encoding set to latin. The Japanese characters don't display correctly](bad-encoding.png)
 
-> **Nota:** Alguns navegadores (como o Chrome) corrigem automaticamente as codificações incorretas, então, dependendo do navegador que você usar, você pode não ver esse problema. Ainda assim, você deve definir uma codificação do `utf-8` em sua página, para evitar problemas em outros navegadores.
+> [!NOTE]
+> Alguns navegadores (como o Chrome) corrigem automaticamente as codificações incorretas, então, dependendo do navegador que você usar, você pode não ver esse problema. Ainda assim, você deve definir uma codificação do `utf-8` em sua página, para evitar problemas em outros navegadores.
 
 ### Aprendizagem ativa: Experimento com a codificação de caracteres
 
@@ -167,9 +168,11 @@ A descrição também é usada nas páginas de resultados do mecanismo de pesqui
 
    ![A Yahoo search result for "Mozilla Developer Network"](search-result.png)
 
-> **Nota:** No Google, você verá algumas subpáginas relevantes do MDN listadas abaixo do principal link da página inicial do MDN — estes são chamados de sitelinks e são configuráveis nas [Ferramentas para webmasters do Google](http://www.google.com/webmasters/tools/) — uma maneira de melhorar os resultados de pesquisa do seu site no mecanismo de pesquisa do Google.
+> [!NOTE]
+> No Google, você verá algumas subpáginas relevantes do MDN listadas abaixo do principal link da página inicial do MDN — estes são chamados de sitelinks e são configuráveis nas [Ferramentas para webmasters do Google](http://www.google.com/webmasters/tools/) — uma maneira de melhorar os resultados de pesquisa do seu site no mecanismo de pesquisa do Google.
 
-> **Nota:** Muitos recursos `<meta>` simplesmente não são mais usados. Por exemplo, a palavra-chave `<meta>` elemento (`<meta name="keywords" content="preencha, suas, palavras-chave, aqui">`) — que é suposto fornecer palavras-chave para os motores de busca para determinar a relevância dessa página para diferentes termos de pesquisa — são ignorados pelos motores de busca, porque os spammers estavam apenas preenchendo a lista de palavras-chave com centenas de palavras-chave, influenciando os resultados.
+> [!NOTE]
+> Muitos recursos `<meta>` simplesmente não são mais usados. Por exemplo, a palavra-chave `<meta>` elemento (`<meta name="keywords" content="preencha, suas, palavras-chave, aqui">`) — que é suposto fornecer palavras-chave para os motores de busca para determinar a relevância dessa página para diferentes termos de pesquisa — são ignorados pelos motores de busca, porque os spammers estavam apenas preenchendo a lista de palavras-chave com centenas de palavras-chave, influenciando os resultados.
 
 ### Outros tipos de metadados
 
@@ -248,7 +251,8 @@ Os comentários explicam onde cada ícone é usado - esses elementos cobrem cois
 
 Não se preocupe muito com a implementação de todos esses tipos de ícone agora — este é um recurso bastante avançado, e você não precisará ter conhecimento disso para avançar no curso. O objetivo principal aqui é permitir que você saiba o que são essas coisas, no caso de você encontrá-las enquanto navega no código-fonte dos outros sites.
 
-> **Nota:** Se o seu site usa uma Política de Segurança de Conteúdo (CSP) para aumentar sua segurança, a política se aplica ao favicon. Se você encontrar problemas com o favicon não carregando, verifique se a diretiva [`img-src`](/pt-BR/docs/Web/HTTP/Headers/Content-Security-Policy/img-src) do cabeçalho [`Content-Security-Policy`](/pt-BR/docs/Web/HTTP/Headers/Content-Security-Policy) não está impedindo o acesso a ele.
+> [!NOTE]
+> Se o seu site usa uma Política de Segurança de Conteúdo (CSP) para aumentar sua segurança, a política se aplica ao favicon. Se você encontrar problemas com o favicon não carregando, verifique se a diretiva [`img-src`](/pt-BR/docs/Web/HTTP/Headers/Content-Security-Policy/img-src) do cabeçalho [`Content-Security-Policy`](/pt-BR/docs/Web/HTTP/Headers/Content-Security-Policy) não está impedindo o acesso a ele.
 
 ## Aplicando CSS e JavaScript ao HTML
 
@@ -266,7 +270,8 @@ Todos os sites que você usar nos dias atuais empregarão o {{glossary("CSS")}} 
   <script src="meu-arquivo-js.js"></script>
   ```
 
-  > **Nota:** O elemento `<script>` pode parecer um elemento vazio, mas não é, e, portanto, precisa de uma tag de fechamento. Em vez de apontar para um arquivo de script externo, você também pode escolher colocar seu script dentro do elemento `<script>`.
+  > [!NOTE]
+  > O elemento `<script>` pode parecer um elemento vazio, mas não é, e, portanto, precisa de uma tag de fechamento. Em vez de apontar para um arquivo de script externo, você também pode escolher colocar seu script dentro do elemento `<script>`.
 
 ### Aprendizagem ativa: aplicar CSS e JavaScript a uma página
 
@@ -281,7 +286,8 @@ Se for feito corretamente, quando você salvar seu HTML e atualizar seu navegado
 - O JavaScript adicionou uma lista vazia à página. Agora, quando você clica em qualquer lugar da lista, uma caixa de diálogo aparecerá pedindo para que você, insira algum texto para um novo item de lista. Quando você pressiona o botão OK, um novo item será adicionado à lista contendo o texto. Quando você clica em um item de lista existente, uma caixa de diálogo será exibida permitindo que você altere o texto do item.
 - O CSS fez com que o plano de fundo ficasse verde e o texto se tornasse maior. Ele também estilizou parte do conteúdo que o JavaScript adicionou à página (a barra vermelha com a borda preta é o estilo que o CSS adicionou à lista gerada por JS).
 
-> **Nota:** Se você ficar preso neste exercício e não conseguir aplicar o CSS/JS, tente verificar nossa página de exemplo [css-and-js.html](https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/the-html-head/css-and-js.html).
+> [!NOTE]
+> Se você ficar preso neste exercício e não conseguir aplicar o CSS/JS, tente verificar nossa página de exemplo [css-and-js.html](https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/the-html-head/css-and-js.html).
 
 ## Definir o idioma principal do documento
 

--- a/files/pt-br/learn/html/multimedia_and_embedding/adding_vector_graphics_to_the_web/index.md
+++ b/files/pt-br/learn/html/multimedia_and_embedding/adding_vector_graphics_to_the_web/index.md
@@ -27,7 +27,8 @@ Vector graphics are very useful in many circumstances — they have small file s
   </tbody>
 </table>
 
-> **Nota:** This article doesn't intend to teach you SVG; just what it is, and how to add it to web pages.
+> [!NOTE]
+> This article doesn't intend to teach you SVG; just what it is, and how to add it to web pages.
 
 ## O que são vetores gráficos?
 
@@ -44,7 +45,8 @@ The difference becomes apparent when you zoom in the page — the PNG image beco
 
 ![Two star images zoomed in, one crisp and the other blurry](raster-vector-zoomed.png)
 
-> **Nota:** The images above are actually all PNGs — with the left-hand star in each case representing a raster image, and the right-hand star representing a vector image. Again, go to the [vector-versus-raster.html](https://mdn.github.io/learning-area/html/multimedia-and-embedding/adding-vector-graphics-to-the-web/vector-versus-raster.html) demo for a real example!
+> [!NOTE]
+> The images above are actually all PNGs — with the left-hand star in each case representing a raster image, and the right-hand star representing a vector image. Again, go to the [vector-versus-raster.html](https://mdn.github.io/learning-area/html/multimedia-and-embedding/adding-vector-graphics-to-the-web/vector-versus-raster.html) demo for a real example!
 
 Moreover, vector image files are much lighter than their raster equivalents, because they only need to hold a handful of algorithms, rather than information on every pixel in the image individually.
 
@@ -85,7 +87,8 @@ So why would anyone want to use raster graphics over SVG? Well, SVG does have so
 
 Raster graphics are arguably better for complex precision images such as photos, for the reasons described above.
 
-> **Nota:** In Inkscape, save your files as Plain SVG to save space. Also, please refer to this [article describing how to prepare SVGs for the Web](http://tavmjong.free.fr/INKSCAPE/MANUAL/html/Web-Inkscape.html).
+> [!NOTE]
+> In Inkscape, save your files as Plain SVG to save space. Also, please refer to this [article describing how to prepare SVGs for the Web](http://tavmjong.free.fr/INKSCAPE/MANUAL/html/Web-Inkscape.html).
 
 ## Adding SVG to your pages
 

--- a/files/pt-br/learn/html/multimedia_and_embedding/images_in_html/index.md
+++ b/files/pt-br/learn/html/multimedia_and_embedding/images_in_html/index.md
@@ -41,7 +41,8 @@ No início a Web era somente texto, e era tedioso. Felizmente, não demorou muit
 
 Para colocar uma única imagem em uma página da web, usamos o elemento {{htmlelement("img")}}. Isso é um elemento vazio (quer dizer que não possui conteúdo de texto ou tag de fechamento) que requer no mínimo um atributo para ser útil — `src` (às vezes pronunciado como seu título completo, _source_). O atributo src contém um caminho apontando para a imagem que você deseja incorporar na página, que pode ser uma URL relativa ou absoluta, da mesma maneira que o valores de atributo `href` no elemento {{htmlelement("a")}}.
 
-> **Nota:** Antes de continuar, você deveria ler [Um guia rápido sobre URLs e caminhos](/pt-BR/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks#A_quick_primer_on_URLs_and_paths) para refrescar sua memória sobre URL relativo e absoluto.
+> [!NOTE]
+> Antes de continuar, você deveria ler [Um guia rápido sobre URLs e caminhos](/pt-BR/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks#A_quick_primer_on_URLs_and_paths) para refrescar sua memória sobre URL relativo e absoluto.
 
 Por exemplo, se sua imagem for chamada `dinossauro.jpg`, e está no mesmo diretório de sua página HTML, você poderia inserir a imagem assim:
 
@@ -57,7 +58,8 @@ Se a imagem estivesse em um subdiretório de `images`, que estivesse dentro do m
 
 E assim por diante.
 
-> **Nota:** Os mecanismos de pesquisa também leem os nomes dos arquivos de imagem e os contam para o SEO. Portanto, dê à sua imagem um nome de arquivo descritivo; `dinosaur.jpg` é melhor que `img835.png`.
+> [!NOTE]
+> Os mecanismos de pesquisa também leem os nomes dos arquivos de imagem e os contam para o SEO. Portanto, dê à sua imagem um nome de arquivo descritivo; `dinosaur.jpg` é melhor que `img835.png`.
 
 Você pode incorporar a imagem usando seu URL absoluto, por exemplo:
 
@@ -67,7 +69,8 @@ Você pode incorporar a imagem usando seu URL absoluto, por exemplo:
 
 Mas isso é inútil, pois apenas faz o navegador trabalhar mais, pesquisando o endereço IP do servidor DNS novamente, etc. Você quase sempre manterá as imagens do seu site no mesmo servidor que o HTML.
 
-> **Aviso:** A maioria das imagens tem direitos autorais. Não exiba uma imagem em sua página da web, a menos que:
+> [!WARNING]
+> A maioria das imagens tem direitos autorais. Não exiba uma imagem em sua página da web, a menos que:
 >
 > 1\) você é o dono da imagem
 > 2\) você recebeu permissão explícita e por escrito do proprietário da imagem, ou
@@ -79,9 +82,11 @@ Nosso código acima nos daria o seguinte resultado:
 
 ![A basic image of a dinosaur, embedded in a browser, with Images in HTML written above it](basic-image.png)
 
-> **Nota:** Elementos como {{htmlelement("img")}} e {{htmlelement("video")}} às vezes são chamados de elementos substituídos. Isso ocorre porque o conteúdo e o tamanho do elemento são definidos por um recurso externo (como uma imagem ou arquivo de vídeo), não pelo conteúdo do próprio elemento.
+> [!NOTE]
+> Elementos como {{htmlelement("img")}} e {{htmlelement("video")}} às vezes são chamados de elementos substituídos. Isso ocorre porque o conteúdo e o tamanho do elemento são definidos por um recurso externo (como uma imagem ou arquivo de vídeo), não pelo conteúdo do próprio elemento.
 
-> **Nota:** Você pode encontrar o exemplo final desta seção [running on Github](https://mdn.github.io/learning-area/html/multimedia-and-embedding/images-in-html/index.html) (Veja o [source code](https://github.com/mdn/learning-area/blob/master/html/multimedia-and-embedding/images-in-html/index.html) também.)
+> [!NOTE]
+> Você pode encontrar o exemplo final desta seção [running on Github](https://mdn.github.io/learning-area/html/multimedia-and-embedding/images-in-html/index.html) (Veja o [source code](https://github.com/mdn/learning-area/blob/master/html/multimedia-and-embedding/images-in-html/index.html) também.)
 
 ### Texto alternativo
 
@@ -115,7 +120,8 @@ O que exatamente você deve escrever dentro do seu atributo `alt`? Depende do _p
 
 Essencialmente, a chave é oferecer uma experiência utilizável, mesmo quando as imagens não podem ser vistas. Isso garante que todos os usuários não estejam perdendo nenhum conteúdo. Tente desativar as imagens no seu navegador e veja como as coisas ficam. Você logo perceberá como o texto alternativo é útil se a imagem não puder ser vista.
 
-> **Nota:** Para mais informações, consulte o nosso guia para [Textos alternativos](/pt-BR/docs/Learn/Accessibility/HTML#Alternativas_em_textos).
+> [!NOTE]
+> Para mais informações, consulte o nosso guia para [Textos alternativos](/pt-BR/docs/Learn/Accessibility/HTML#Alternativas_em_textos).
 
 ### Largura e altura
 
@@ -138,7 +144,8 @@ Isso não resulta em muita diferença para a tela, em circunstâncias normais. M
 
 No entanto, você não deve alterar o tamanho das suas imagens usando atributos HTML. Se você definir o tamanho da imagem muito grande, terá imagens granuladas, confusas ou muito pequenas e desperdiçando largura de banda ao fazer o download de uma imagem que não atenda às necessidades do usuário. A imagem também pode ficar distorcida, se você não mantiver a [proporção de tela](<Proporção de tela>). Você deve usar um editor de imagens para colocar sua imagem no tamanho correto antes de colocá-la em sua página da web.
 
-> **Nota:** Se você precisar alterar o tamanho de uma imagem, use [CSS](/pt-BR/docs/Aprender/CSS) então.
+> [!NOTE]
+> Se você precisar alterar o tamanho de uma imagem, use [CSS](/pt-BR/docs/Aprender/CSS) então.
 
 ### Títulos de imagem
 
@@ -271,7 +278,8 @@ Uma solução melhor, é usar os elementos do HTML5 {{htmlelement("figure")}} e 
 
 O elemento {{htmlelement("figcaption")}} informa aos navegadores e à tecnologia de assistência que a legenda descreve o outro conteúdo do elemento {{htmlelement("figure")}}.
 
-> **Nota:** Do ponto de vista da acessibilidade, legendas e [`alt`](/pt-BR/docs/Web/HTML/Element/img#alt) texto têm papéis distintos. As legendas beneficiam até as pessoas que podem ver a imagem, enquanto [`alt`](/pt-BR/docs/Web/HTML/Element/img#alt) texto fornece a mesma funcionalidade que uma imagem ausente. Portanto, legendas e `alt` texto não deve apenas dizer a mesma coisa, porque ambos aparecem quando a imagem desaparece. Tente desativar as imagens no seu navegador e veja como fica.
+> [!NOTE]
+> Do ponto de vista da acessibilidade, legendas e [`alt`](/pt-BR/docs/Web/HTML/Element/img#alt) texto têm papéis distintos. As legendas beneficiam até as pessoas que podem ver a imagem, enquanto [`alt`](/pt-BR/docs/Web/HTML/Element/img#alt) texto fornece a mesma funcionalidade que uma imagem ausente. Portanto, legendas e `alt` texto não deve apenas dizer a mesma coisa, porque ambos aparecem quando a imagem desaparece. Tente desativar as imagens no seu navegador e veja como fica.
 
 Uma figura não precisa ser uma imagem. É uma unidade de conteúdo independente que:
 
@@ -362,7 +370,8 @@ A imagem incorporada resultante é sem dúvida mais fácil de posicionar e contr
 
 Resumindo: se uma imagem tiver significado, em termos de seu conteúdo, você deverá usar uma imagem HTML. Se uma imagem é puramente decorativa, você deve usar imagens de plano de fundo CSS.
 
-> **Nota:** Você aprenderá muito mais sobre [CSS background images](/pt-BR/docs/Learn/CSS/Styling_boxes/Backgrounds) no nosso tópico de [CSS](/pt-BR/docs/Aprender/CSS).
+> [!NOTE]
+> Você aprenderá muito mais sobre [CSS background images](/pt-BR/docs/Learn/CSS/Styling_boxes/Backgrounds) no nosso tópico de [CSS](/pt-BR/docs/Aprender/CSS).
 
 É tudo por agora. Cobrimos imagens e legendas em detalhes. No próximo artigo, avançaremos, analisando como usar HTML para incorporar vídeo e áudio em páginas da web.
 

--- a/files/pt-br/learn/html/multimedia_and_embedding/index.md
+++ b/files/pt-br/learn/html/multimedia_and_embedding/index.md
@@ -11,7 +11,8 @@ Nós vimos muito sobre texto até aqui nesse curso, mas a internet seria muito c
 
 Antes de iniciar esse módulo, você deve ter um conhecimento razoável de HTML, como previamente abrangido em [introdução a HTML](/pt-BR/docs/Learn/HTML/Introduction_to_HTML). Se você não estudou esse módulo (ou algo similar), estude-o primeiro e depois retorne!
 
-> **Nota:** Se você está trabalhando em um computador/tablet/outro dispositivo onde você não tem a habilidade de criar seus próprios arquivos, você pode testar (maior parte) dos exemplos de códigos em um programa online para codar tais como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
+> [!NOTE]
+> Se você está trabalhando em um computador/tablet/outro dispositivo onde você não tem a habilidade de criar seus próprios arquivos, você pode testar (maior parte) dos exemplos de códigos em um programa online para codar tais como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/pt-br/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -248,7 +248,8 @@ Este exemplo inclui os fundamentos básicos necessários para usar um `<iframe>`
 - [`sandbox`](/pt-BR/docs/Web/HTML/Element/iframe#sandbox)
   - : Esse atributo, que funciona em navegadores um pouco mais modernos que o restante dos `<iframe>`recursos (por exemplo, IE 10 e superior), requer configurações de segurança mais elevadas; falaremos mais sobre isso na próxima seção.
 
-> **Nota:** Para melhorar a velocidade, é uma boa ideia definir o `src`atributo do iframe com JavaScript após o carregamento do conteúdo principal. Isso torna sua página utilizável mais cedo e diminui o tempo de carregamento da página oficial (uma importante métrica de [SEO](/pt-BR/docs/Glossary/SEO) ).
+> [!NOTE]
+> Para melhorar a velocidade, é uma boa ideia definir o `src`atributo do iframe com JavaScript após o carregamento do conteúdo principal. Isso torna sua página utilizável mais cedo e diminui o tempo de carregamento da página oficial (uma importante métrica de [SEO](/pt-BR/docs/Glossary/SEO) ).
 
 ### Preocupações com segurança
 
@@ -287,19 +288,22 @@ Conteúdo fora de uma sandbox pode fazer muito mais que o esperado (executar Jav
 
 Se absolutamente necessário, você pode adicionar permissões uma a uma (dentro do valor do atributo`sandbox=""`) — veja em [`sandbox`](/pt-BR/docs/Web/HTML/Element/iframe#sandbox) as referências de entrada para todas as opções disponíveis. Uma nota importante é que você _nunca_ deve adicionar ambos `allow-scripts` e `allow-same-origin` no atributo de sandbox — neste caso, conteúdo incorporado pode burlar a política de segurança de mesmo destino que impede sites de executarem scripts, e utilizar JavaScript para desativar o sandboxing completamente.
 
-> **Nota:** Sandboxing não fornece nenhuma proteção se atacantes puderem enganar os usuários para que visitem conteúdo malicioso diretamete (fora de um `iframe`). Se existir qualquer chance que certo conteúdo possa ser malicioso (exemplo, conteúdo gerado por usuários), por favor forneça-o em um {{glossary("domain")}} diferente de seu site principal.
+> [!NOTE]
+> Sandboxing não fornece nenhuma proteção se atacantes puderem enganar os usuários para que visitem conteúdo malicioso diretamete (fora de um `iframe`). Se existir qualquer chance que certo conteúdo possa ser malicioso (exemplo, conteúdo gerado por usuários), por favor forneça-o em um {{glossary("domain")}} diferente de seu site principal.
 
 #### Configure directivas CSP
 
 {{Glossary("CSP")}} significa **[política de segurança de conteúdo](/pt-BR/docs/Web/Security/CSP)** e fornece um [conjunto de cabeçalhos HTTP](/pt-BR/docs/Web/Security/CSP/CSP_policy_directives) (metadados enviados junto com suas páginas da web quando são veiculados de um servidor da web) projetados para melhorar a segurança do seu documento HTML. Quando se trata de proteger `<iframe>`'s, você pode _[configurar seu servidor para enviar um cabeçalho `X-Frame-Options` apropriado](/pt-BR/docs/Web/HTTP/X-Frame-Options)_. Isso pode impedir que outros sites incorporem seu conteúdo em suas páginas da Web (o que habilitaria o [clickjacking](https://pt.wikipedia.org/wiki/clickjacking) e vários outros ataques), exatamente o que os desenvolvedores do MDN fizeram, como vimos anteriormente.
 
-> **Nota:** Você pode ler a publicação de Frederik Braun [X-Frame-Options Security Header](https://blog.mozilla.org/security/2013/12/12/on-the-x-frame-options-security-header/) para obter mais informações sobre este tópico. Obviamente, está fora do escopo uma explicação completa neste artigo.
+> [!NOTE]
+> Você pode ler a publicação de Frederik Braun [X-Frame-Options Security Header](https://blog.mozilla.org/security/2013/12/12/on-the-x-frame-options-security-header/) para obter mais informações sobre este tópico. Obviamente, está fora do escopo uma explicação completa neste artigo.
 
 ## The \<embed> and \<object> elements
 
 The {{htmlelement("embed")}} and {{htmlelement("object")}} elements serve a different function to {{htmlelement("iframe")}} — these elements are general purpose embedding tools for embedding multiple types of external content, which include plugin technologies like Java Applets and Flash, PDF (which can be shown in a browser with a PDF plugin), and even content like videos, SVG and images!
 
-> **Nota:** A **plugin**, in this context, refers to software that provides access to content the browser cannot read natively.
+> [!NOTE]
+> A **plugin**, in this context, refers to software that provides access to content the browser cannot read natively.
 
 However, you are unlikely to use these elements very much — Applets haven't been used for years, Flash is no longer very popular, due to a number of reasons (see [The case against plugins](#the_case_against_plugins), below), PDFs tend to be better linked to than embedded, and other content such as images and video have much better, easier elements to handle those. Plugins and these embedding methods are really a legacy technology, and we are mainly mentioning them in case you come across them in certain circumstances like intranets, or enterprise projects.
 

--- a/files/pt-br/learn/html/multimedia_and_embedding/responsive_images/index.md
+++ b/files/pt-br/learn/html/multimedia_and_embedding/responsive_images/index.md
@@ -37,7 +37,8 @@ Você pode pensar que imagens vetorizadas resolveria estes problemas, e elas res
 
 Este tipo de problema não existe quando a web começou a existir, no começo dos anos 1990 - naquele tempo somente desktops e laptops navegavam a Web, então engenheiros de navegadores e programadores nem pensavam em implementar soluções. _Tecnologias de imagens responsivas_ foram implementadas recentemente para resolver os problemas indicados acima, permitindo a você oferecer ao navegador vários arquivos de imagens, todas mostrando a mesma coisa mas contendo diferente número de pixels (mudança de resolução), ou diferentes imagens para diferente espaços de alocação (direção de arte).
 
-> **Nota:** As novas funcionalidades discutidas neste artigo — [`srcset`](/pt-BR/docs/Web/HTML/Element/img#srcset)/[`sizes`](/pt-BR/docs/Web/HTML/Element/img#sizes)/{{htmlelement("picture")}} — são todas suportadas nas versões atuais de navegadores mobile e desktop (incluindo Microsoft Edge, embora não suportada pelo Internet Explorer).
+> [!NOTE]
+> As novas funcionalidades discutidas neste artigo — [`srcset`](/pt-BR/docs/Web/HTML/Element/img#srcset)/[`sizes`](/pt-BR/docs/Web/HTML/Element/img#sizes)/{{htmlelement("picture")}} — são todas suportadas nas versões atuais de navegadores mobile e desktop (incluindo Microsoft Edge, embora não suportada pelo Internet Explorer).
 
 ## Como você faz para criar imagens responsivas?
 
@@ -89,7 +90,8 @@ Os atributos `srcset` e `sizes` parecem complicados, mas não são difíceis de 
 2. Um espaço.
 3. A **largura do slot** que a imagem irá preencher quando a condição de mídia for verdadeira (`440px`).
 
-> **Nota:** Para a largura do slot, você pode fornecer um tamanho absoluto (`px`, `em`) ou um tamanho relativo (como porcentagem). Você pode ter notado que o último slot de largura não tem condição de mídia - isto é o padrão que será escolhido quando nenhuma condição for verdadeira. O navegador ignora tudo depois da primeira condição satisfeita, então tenha cuidado com a ordem de condições.
+> [!NOTE]
+> Para a largura do slot, você pode fornecer um tamanho absoluto (`px`, `em`) ou um tamanho relativo (como porcentagem). Você pode ter notado que o último slot de largura não tem condição de mídia - isto é o padrão que será escolhido quando nenhuma condição for verdadeira. O navegador ignora tudo depois da primeira condição satisfeita, então tenha cuidado com a ordem de condições.
 
 Então, com estes atributos no lugar, o navegador irá:
 
@@ -102,7 +104,8 @@ E é isto! Então neste ponto, se um navegador suportado com uma largurar de 480
 
 Navegadores antigos que não suportam estas funcionalidades serão ignorados, seguiremos e carregaremos a imagem definida no atributo [`src`](/pt-BR/docs/Web/HTML/Element/img#src) como normal.
 
-> **Nota:** No {{htmlelement("head")}} do documento você encontrará a linha `<meta name="viewport" content="width=device-width">`: isto força navegadores de celular adotar a largura real para carregar páginas web (alguns navegadores mobile mentem sobre sua largura da janela, e em vez carregam páginas em uma largura grante e então encolhem a página carregada, o que é de muita ajuda para imagens e design responsivos. Nós iremos ensinar mais sobre isso em um módulo futuro).
+> [!NOTE]
+> No {{htmlelement("head")}} do documento você encontrará a linha `<meta name="viewport" content="width=device-width">`: isto força navegadores de celular adotar a largura real para carregar páginas web (alguns navegadores mobile mentem sobre sua largura da janela, e em vez carregam páginas em uma largura grante e então encolhem a página carregada, o que é de muita ajuda para imagens e design responsivos. Nós iremos ensinar mais sobre isso em um módulo futuro).
 
 ### Ferramentas de desenvolvimento úteis
 
@@ -167,7 +170,8 @@ Este código nos permite mostrar uma imagem adequada em ambas extensas e estreit
 
 ![Our example site as viewed on a wide screen - here the first image works ok, as it is big enough to see the detail in the center.](picture-element-wide.png)![Our example site as viewed on a narrow screen with the picture element used to switch the first image to a portrait close up of the detail, making it a lot more useful on a narrow screen](picture-element-narrow.png)
 
-> **Nota:** Nota: Você deveria usar o atributo `media` somente em cenários de direção de arte; quando você usa `media`, não oferecendo também condições com o atributo `sizes`.
+> [!NOTE]
+> Nota: Você deveria usar o atributo `media` somente em cenários de direção de arte; quando você usa `media`, não oferecendo também condições com o atributo `sizes`.
 
 ### Por que não podemos só fazer isso usando CSS ou JavaScript?
 

--- a/files/pt-br/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
+++ b/files/pt-br/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
@@ -53,7 +53,8 @@ Uma solução nativa resolveria muito disso, se bem feita. Felizmente, alguns an
 
 Não ensinaremos como produzir arquivos de áudio e vídeo - isso requer um conjunto de habilidades completamente diferente. Nós fornecemos a você [amostras de arquivos de áudio e vídeo e exemplos de códigos](https://github.com/mdn/learning-area/tree/master/html/multimedia-and-embedding/video-and-audio-content) para sua própria experimentação, caso você não consiga se apossar.
 
-> **Nota:** Antes de começar aqui, você também deve saber que existem algumas {{glossary("OVP","OVPs")}} (fornecedores de vídeo online) como [YouTube](https://www.youtube.com/), [Dailymotion](http://www.dailymotion.com), e [Vimeo](https://vimeo.com/), e provedores de áudio on-line como [Soundcloud](https://soundcloud.com/). Essas empresas oferecem uma maneira conveniente e fácil de hospedar e consumir vídeos, para que você não precise se preocupar com o enorme consumo de largura de banda. Os OVPs geralmente oferecem código pronto para incorporar vídeo / áudio em suas páginas da web. Se você seguir esse caminho, poderá evitar algumas das dificuldades que discutimos neste artigo. Discutiremos esse tipo de serviço um pouco mais no próximo artigo.
+> [!NOTE]
+> Antes de começar aqui, você também deve saber que existem algumas {{glossary("OVP","OVPs")}} (fornecedores de vídeo online) como [YouTube](https://www.youtube.com/), [Dailymotion](http://www.dailymotion.com), e [Vimeo](https://vimeo.com/), e provedores de áudio on-line como [Soundcloud](https://soundcloud.com/). Essas empresas oferecem uma maneira conveniente e fácil de hospedar e consumir vídeos, para que você não precise se preocupar com o enorme consumo de largura de banda. Os OVPs geralmente oferecem código pronto para incorporar vídeo / áudio em suas páginas da web. Se você seguir esse caminho, poderá evitar algumas das dificuldades que discutimos neste artigo. Discutiremos esse tipo de serviço um pouco mais no próximo artigo.
 
 ### O elemento \<video>
 
@@ -103,7 +104,8 @@ Outra situação é o sempre popular arquivo MP3. Um "arquivo MP3" é na verdade
 
 Um reprodutor de áudio tenderá a reproduzir uma faixa de áudio diretamente, por exemplo um arquivo MP3 ou Ogg. Estes não precisam de contêineres.
 
-> **Nota:** Não é tão simples, como você pode ver no nosso [tabela de compatibilidade de codec de áudio e vídeo](/pt-BR/docs/Web/Media/Formats#Browser_compatibility). Além disso, muitos navegadores de plataforma móvel podem reproduzir um formato não suportado, entregando-o ao reprodutor de mídia do sistema subjacente. Mas isso servirá por enquanto.
+> [!NOTE]
+> Não é tão simples, como você pode ver no nosso [tabela de compatibilidade de codec de áudio e vídeo](/pt-BR/docs/Web/Media/Formats#Browser_compatibility). Além disso, muitos navegadores de plataforma móvel podem reproduzir um formato não suportado, entregando-o ao reprodutor de mídia do sistema subjacente. Mas isso servirá por enquanto.
 
 #### Suporte a arquivos de mídia em navegadores
 
@@ -115,7 +117,8 @@ Devido à complexidade de garantir que a mídia do aplicativo seja visível em t
 
 Um aspecto adicional a ter em mente: os navegadores móveis podem suportar formatos adicionais não compatíveis com seus equivalentes de desktop, assim como podem não suportar os mesmos formatos da versão para desktop. Além disso, os navegadores de desktop e móveis _podem_ ser projetados para descarregar o manuseio da reprodução de mídia (para todas as mídias ou apenas para tipos específicos que não podem ser tratados internamente). Isso significa que o suporte à mídia depende parcialmente do software que o usuário instalou.
 
-> **Nota:** Você pode estar se perguntando por que essa situação existe. **MP3** (para áudio) e **MP4 / H.264** (para vídeo) são amplamente suportados e de boa qualidade. No entanto, eles também são patenteados - as patentes americanas cobrem o MP3 até pelo menos 2017 e o H.264 até 2027, o que significa que os navegadores que não possuem a patente precisam pagar grandes quantias para suportar esses formatos. Além disso, muitas pessoas evitam, por princípio, software restrito, a favor de formatos abertos. É por isso que precisamos fornecer vários formatos para diferentes navegadores.
+> [!NOTE]
+> Você pode estar se perguntando por que essa situação existe. **MP3** (para áudio) e **MP4 / H.264** (para vídeo) são amplamente suportados e de boa qualidade. No entanto, eles também são patenteados - as patentes americanas cobrem o MP3 até pelo menos 2017 e o H.264 até 2027, o que significa que os navegadores que não possuem a patente precisam pagar grandes quantias para suportar esses formatos. Além disso, muitas pessoas evitam, por princípio, software restrito, a favor de formatos abertos. É por isso que precisamos fornecer vários formatos para diferentes navegadores.
 
 Então, como fazemos isso? Dê uma olhada no seguinte [exemplo atualizado](https://github.com/mdn/learning-area/blob/gh-pages/html/multimedia-and-embedding/video-and-audio-content/multiple-video-formats.html)([tente ao vivo aqui](https://mdn.github.io/learning-area/html/multimedia-and-embedding/video-and-audio-content/multiple-video-formats.html), também):
 
@@ -134,7 +137,8 @@ Aqui nós tiramos o atributo `src` (source) do {{HTMLElement("video")}} tag, mas
 
 Cada elemento `<source>` também tem um atributo [`type`](/pt-BR/docs/Web/HTML/Element/source#type). Isso é opcional, mas é recomendável que você os inclua - eles contêm o {{glossary("MIME type","MIME types")}} dos arquivos de vídeo, e os navegadores podem lê-los e pular imediatamente os vídeos que não entendem. Se não estiverem incluídos, os navegadores carregarão e tentarão reproduzir cada arquivo até encontrar um que funcione, consumindo ainda mais tempo e recursos.
 
-> **Nota:** Consulte o nosso [guia sobre tipos e formatos de mídias](/pt-BR/docs/Web/Media/Formats) (inglês) para obter ajuda na seleção dos melhores contêineres e codecs para suas necessidades, bem como procurar os tipos MIME certos para especificar cada
+> [!NOTE]
+> Consulte o nosso [guia sobre tipos e formatos de mídias](/pt-BR/docs/Web/Media/Formats) (inglês) para obter ajuda na seleção dos melhores contêineres e codecs para suas necessidades, bem como procurar os tipos MIME certos para especificar cada
 
 ### Outros recursos de \<video>
 
@@ -201,7 +205,8 @@ Isso produz algo como o seguinte em um navegador:
 
 ![A simple audio player with a play button, timer, volume control, and progress bar](audio-player.png)
 
-> **Nota:** You can [run the audio demo live](http://mdn.github.io/learning-area/html/multimedia-and-embedding/video-and-audio-content/multiple-audio-formats.html) on Github (also see the [audio player source code](https://github.com/mdn/learning-area/blob/gh-pages/html/multimedia-and-embedding/video-and-audio-content/multiple-audio-formats.html).)
+> [!NOTE]
+> You can [run the audio demo live](http://mdn.github.io/learning-area/html/multimedia-and-embedding/video-and-audio-content/multiple-audio-formats.html) on Github (also see the [audio player source code](https://github.com/mdn/learning-area/blob/gh-pages/html/multimedia-and-embedding/video-and-audio-content/multiple-audio-formats.html).)
 
 Isso ocupa menos espaço do que um reprodutor de vídeo, pois não há componente visual - você só precisa exibir controles para reproduzir o áudio. Outras diferenças do vídeo HTML5 são as seguintes:
 
@@ -243,7 +248,8 @@ Agora discutiremos um conceito um pouco mais avançado que é realmente útil pa
 
 Não seria bom poder fornecer a essas pessoas uma transcrição das palavras que estão sendo ditas no áudio / vídeo? Bem, graças ao vídeo HTML5, você pode, com o formato [WebVTT](/pt-BR/docs/Web/API/WebVTT_API) e o elemento {{htmlelement ("track")}}.
 
-> **Nota:** "Transcrever" significa "escrever as palavras faladas como texto". O texto resultante é uma "transcrição".
+> [!NOTE]
+> "Transcrever" significa "escrever as palavras faladas como texto". O texto resultante é uma "transcrição".
 
 O WebVTT é um formato para gravar arquivos de texto contendo várias seqüências de texto, juntamente com metadados, como a que horas do vídeo você deseja que cada sequência de texto seja exibida e até informações limitadas sobre estilo / posicionamento. Essas cadeias de texto são chamadas de **pistas** e existem vários tipos de pistas que são usadas para propósitos diferentes. As dicas mais comuns são:
 
@@ -291,7 +297,8 @@ Isso resultará em um vídeo com legendas exibidas, mais ou menos assim:
 
 Para mais detalhes, leia [Adicionando legendas e legendas ao vídeo HTML5](/en-US/Apps/Build/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video). Você pode [encontrar o exemplo](http://iandevlin.github.io/mdn/video-player-with-captions/) que acompanha este artigo no Github, escrito por Ian Devlin (consulte o [código-fonte](https://github.com/iandevlin/iandevlin.github.io/tree/master/mdn/video-player-with-captions) também.) Este exemplo usa algum JavaScript para permitir que os usuários escolham entre diferentes legendas. Observe que, para ativar as legendas, você precisa pressionar o botão "CC" e selecionar uma opção - inglês, alemão ou espanhol.
 
-> **Nota:** As faixas de texto também ajudam você com o {{glossary ("SEO")}}, pois os mecanismos de pesquisa prosperam especialmente no texto. As trilhas de texto permitem até que os mecanismos de pesquisa sejam vinculados diretamente a um ponto no meio do vídeo.
+> [!NOTE]
+> As faixas de texto também ajudam você com o {{glossary ("SEO")}}, pois os mecanismos de pesquisa prosperam especialmente no texto. As trilhas de texto permitem até que os mecanismos de pesquisa sejam vinculados diretamente a um ponto no meio do vídeo.
 
 ### Aprendizado ativo: incorporando seu próprio áudio e vídeo
 

--- a/files/pt-br/learn/html/tables/basics/index.md
+++ b/files/pt-br/learn/html/tables/basics/index.md
@@ -255,7 +255,8 @@ Isso deve resultar em uma tabela que vai parecer com algo assim:
 | ------------------------ | --------------------- | -------------------- | --------------------- |
 | Second row, first cell.  | Cell 2.               | Cell 3.              | Cell 4.               |
 
-> **Nota:** Você também pode encontrar esse código no GitHub em [simple-table.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/simple-table.html) ([veja ao vivo também](http://mdn.github.io/learning-area/html/tables/basic/simple-table.html)).
+> [!NOTE]
+> Você também pode encontrar esse código no GitHub em [simple-table.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/simple-table.html) ([veja ao vivo também](http://mdn.github.io/learning-area/html/tables/basic/simple-table.html)).
 
 ## Adicionar cabeçalhos com o elemento \<th>
 
@@ -320,13 +321,15 @@ Vamos tentar melhorar essa tabela.
 2. Para reconhecer os cabeçalhos de uma tabela como cabeçalhos, tanto visualmente como semanticamente, podemos usar o elemento **[`<th>`](/pt-BR/docs/Web/HTML/Element/th)** ('th' significa 'cabeçalho da tabela'). Ele funciona da mesma maneira que um `<td>`, exceto que denota um cabeçalho, e não uma célula normal. Abra o arquivo HTML, e mude todos os elementos `<td>` que envolvem os cabeçalhos das tabelas para o elemento `<th>`.
 3. Salve o HTML e abra em um navegador, e veja que os cabeçalhos agora se parecem mais com cabeçalhos.
 
-> **Nota:** Encontre esse exemplo pronto em [dogs-table-fixed.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/dogs-table-fixed.html) no GitHub ([veja ao vivo também](http://mdn.github.io/learning-area/html/tables/basic/dogs-table-fixed.html)).
+> [!NOTE]
+> Encontre esse exemplo pronto em [dogs-table-fixed.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/dogs-table-fixed.html) no GitHub ([veja ao vivo também](http://mdn.github.io/learning-area/html/tables/basic/dogs-table-fixed.html)).
 
 ### Por que os cabeçalhos são úteis?
 
 Já respondemos parcialmente essa pergunta - fica mais fácil encontrar os dados que estamos procurando quando o cabeçalho se destaca claramente, e o design simplesmente aparece mais bonito.
 
-> **Nota:** Cabeçalhos de tabelas têm alguns estilos padronizados — eles são fortes e centralizados mesmo que você não use nenhum estilo para a tabela, para ajudar a destacá-los.
+> [!NOTE]
+> Cabeçalhos de tabelas têm alguns estilos padronizados — eles são fortes e centralizados mesmo que você não use nenhum estilo para a tabela, para ajudar a destacá-los.
 
 Cabeçalhos de tabelas também têm um benefício extra - juntamente com o atributo `scope` (que vamos aprender no próximo artigo), eles permitem tornar as tabelas mais acessíveis associando cada cabeçalho com todos os dados em uma mesma linha ou coluna. Leitores de tela podem então ler em voz alta uma coluna ou linha inteira de dados de uma vez só, o que é muito mais útil.
 
@@ -384,13 +387,15 @@ Vamos usar `colspan` e `rowspan` para melhorar essa tabela.
 3. Por fim, use `rowspan` para fazer "Horse" e "Chicken" se estender por duas linhas.
 4. Salve e abra o código em um navegador para ver a melhoria.
 
-> **Nota:** Encontre o exemplo pronto em [animals-table-fixed.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/animals-table-fixed.html) no GitHub ([veja ao vivo também](http://mdn.github.io/learning-area/html/tables/basic/animals-table-fixed.html)).
+> [!NOTE]
+> Encontre o exemplo pronto em [animals-table-fixed.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/animals-table-fixed.html) no GitHub ([veja ao vivo também](http://mdn.github.io/learning-area/html/tables/basic/animals-table-fixed.html)).
 
 ## Provendo estilos comuns para colunas
 
 Existe uma última característica da qual vamos falar nesse artigo, antes de prosseguir. HTML tem um método de definir informação de estilo para uma coluna inteira de dados de uma só vez — o elemento **[`<col>`](/pt-BR/docs/Web/HTML/Element/col)** e **[`<colgroup>`](/pt-BR/docs/Web/HTML/Element/colgroup)**. Eles existem por que pode ser um pouco entediante e ineficiente ter de especificar o estilo de colunas - temos de especificar as informações de estilo para _cada_ `<td>` ou `<th>` da coluna, ou usar um seletor complexo como o {{cssxref(":nth-child()")}}.
 
-> **Nota:** Estilizar colunas dessa maneira está [limitada para umas poucas propriedades](https://www.w3.org/TR/CSS22/tables.html#columns): [`border`](/pt-BR/docs/Web/CSS/border), [`background`](/pt-BR/docs/Web/CSS/background), [`width`](/pt-BR/docs/Web/CSS/width), e [`visibility`](/pt-BR/docs/Web/CSS/visibility). Para ajustar outras propriedades devemos aplicar o estilo para cada `<td>` ou `<th>` da coluna, ou usar um seletor complexo como um {{cssxref(":nth-child()")}}.
+> [!NOTE]
+> Estilizar colunas dessa maneira está [limitada para umas poucas propriedades](https://www.w3.org/TR/CSS22/tables.html#columns): [`border`](/pt-BR/docs/Web/CSS/border), [`background`](/pt-BR/docs/Web/CSS/background), [`width`](/pt-BR/docs/Web/CSS/width), e [`visibility`](/pt-BR/docs/Web/CSS/visibility). Para ajustar outras propriedades devemos aplicar o estilo para cada `<td>` ou `<th>` da coluna, ou usar um seletor complexo como um {{cssxref(":nth-child()")}}.
 
 Veja o simples exemplo a seguir:
 

--- a/files/pt-br/learn/html/tables/index.md
+++ b/files/pt-br/learn/html/tables/index.md
@@ -11,7 +11,8 @@ Uma tarefa muito comum em HTML é estruturar os dados tabulares, e há vários e
 
 Antes de iniciar este módulo, você deverá ter domínio dos básicos de HTML — consulte [Introdução ao HTML](/pt-BR/docs/Learn/HTML/Introducao_ao_HTML).
 
-> **Nota:** se está utilizando um computador/tablet/outro dispositivo onde não tem a possibilidade de criar os seus próprios arquivos, pode testar a maioria dos exemplos de código num programa de codificação on-line, tais como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
+> [!NOTE]
+> se está utilizando um computador/tablet/outro dispositivo onde não tem a possibilidade de criar os seus próprios arquivos, pode testar a maioria dos exemplos de código num programa de codificação on-line, tais como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/index.md
+++ b/files/pt-br/learn/index.md
@@ -24,7 +24,8 @@ Se você tiver dúvidas sobre os tópicos que gostaria de ver cobertos ou que es
 - Além do básico: Se você já possui um pouco de conhecimento, o próximo passo é aprender {{glossary ("HTML")}} e {{glossary ("CSS")}} em detalhes: comece com o módulo [Introdução ao HTML](/pt-BR/docs/Aprender/HTML/Introducao_ao_HTML) e vá para nosso módulo [Primeiros passos com CSS](/pt-BR/docs/Learn/CSS/First_steps).
 - Passando para o script: Se você já está familiarizado com HTML e CSS ou se interessa principalmente por codificação, deve passar para o {{glossary ("JavaScript")}} ou para o desenvolvimento no servidor. Comece com nossos módulo [Primeiros passos com JavaScript](/pt-BR/docs/Learn/JavaScript/First_steps) e [Primeiros passos programando o site no servidor](/pt-BR/docs/Learn/Server-side/First_steps).
 
-> **Nota:** Nosso [glossário](/pt-BR/docs/Glossario) fornece definições de terminologia.
+> [!NOTE]
+> Nosso [glossário](/pt-BR/docs/Glossario) fornece definições de terminologia.
 
 ## Assuntos abordados
 

--- a/files/pt-br/learn/javascript/asynchronous/index.md
+++ b/files/pt-br/learn/javascript/asynchronous/index.md
@@ -11,7 +11,8 @@ Javascript Assíncrono é um tópico razoavelmente avançado e é aconselhada a 
 
 Se você não estiver familiarizado com os conceitos de programação assíncrona, a sugestão é iniciar com o artigo [Conceitos gerais da programação assíncrona](/pt-BR/docs/Learn/JavaScript/Asynchronous/Conceitos) desse módulo. Caso contrário, você pode provavelmente pular para o módulo [Introdução ao Javascript Assíncrono](/pt-BR/docs/Learn/JavaScript/Asynchronous/Introdu%C3%A7%C3%A3o).
 
-> **Nota:** Se você está estudando a partir de um computador/tablet/ outro dispositivo onde não é capaz de criar seus próprios arquivos, é possível executar os códigos de exemplo (a maioria deles) em plataformas como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com).
+> [!NOTE]
+> Se você está estudando a partir de um computador/tablet/ outro dispositivo onde não é capaz de criar seus próprios arquivos, é possível executar os códigos de exemplo (a maioria deles) em plataformas como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com).
 
 ## Guias
 

--- a/files/pt-br/learn/javascript/asynchronous/promises/index.md
+++ b/files/pt-br/learn/javascript/asynchronous/promises/index.md
@@ -29,7 +29,8 @@ Com uma API baseada em promises, a função assíncrona inicia a operação e re
 
 ## Usando a API fetch()
 
-> **Nota:** Neste artigo, vamos explorar promises copiando exemplos de código desta página dentro do console Javascript do seu navegador. Para configurar isso:
+> [!NOTE]
+> Neste artigo, vamos explorar promises copiando exemplos de código desta página dentro do console Javascript do seu navegador. Para configurar isso:
 >
 > 1. abra o navegador e visite <https://example.org>
 > 2. nesta aba, abra o console Javascript nas [ferramentas de desenvolvimento do navegador](/pt-BR/docs/Learn/Common_questions/What_are_browser_developer_tools)

--- a/files/pt-br/learn/javascript/building_blocks/build_your_own_function/index.md
+++ b/files/pt-br/learn/javascript/building_blocks/build_your_own_function/index.md
@@ -44,13 +44,15 @@ A função `alert` leva um único argumento — a string exibida na caixa de ale
 
 A função `alert` é limitada: você pode alterar a mensagem, mas não pode variar com facilidade nada, como cor, ícone ou qualquer outra coisa. Nós vamos construir um que se mostrará mais divertido.
 
-> **Nota:** Este exemplo deve funcionar bem em todos os navegadores modernos, mas o estilo pode parecer um pouco engraçado em navegadores um pouco mais antigos. Recomendamos que você faça esse exercício em um navegador moderno como o Firefox, o Opera ou o Chrome.
+> [!NOTE]
+> Este exemplo deve funcionar bem em todos os navegadores modernos, mas o estilo pode parecer um pouco engraçado em navegadores um pouco mais antigos. Recomendamos que você faça esse exercício em um navegador moderno como o Firefox, o Opera ou o Chrome.
 
 ## A função básica
 
 Para começar, vamos montar uma função básica.
 
-> **Nota:** Para convenções de nomenclatura de função, você deve seguir as mesmas regras das [convenções de nomenclatura de variáveis](/en-US/Learn/JavaScript/First_steps/Variables#An_aside_on_variable_naming_rules). Algo bom é como você pode diferenciá-los — os nomes das funções aparecem com parênteses depois deles e as variáveis não.
+> [!NOTE]
+> Para convenções de nomenclatura de função, você deve seguir as mesmas regras das [convenções de nomenclatura de variáveis](/en-US/Learn/JavaScript/First_steps/Variables#An_aside_on_variable_naming_rules). Algo bom é como você pode diferenciá-los — os nomes das funções aparecem com parênteses depois deles e as variáveis não.
 
 1. Comece acessando o arquivo [function-start.html](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/functions/function-start.html) e fazendo uma cópia local. Você verá que o HTML é simples — o corpo contém apenas um único botão. Também fornecemos algumas CSS básicas para estilizar a caixa de mensagem personalizada e um elemento {{htmlelement("script")}} vazio para colocar nosso JavaScript.
 2. Em seguida, adicione o seguinte dentro do elemento `<script>` :
@@ -235,7 +237,8 @@ Para o próximo parâmetro. Este vai envolver um pouco mais de trabalho — vamo
 
 1. Primeiro de tudo, baixe os ícones necessários para este exercício ([aviso](https://raw.githubusercontent.com/mdn/learning-area/master/javascript/building-blocks/functions/icons/warning.png) e [batepapo](https://raw.githubusercontent.com/mdn/learning-area/master/javascript/building-blocks/functions/icons/chat.png)) do GitHub. Salve-os em uma nova pasta chamada `icons` no mesmo local que seu arquivo HTML.
 
-   > **Nota:** Os icones [aviso](https://www.iconfinder.com/icons/1031466/alarm_alert_error_warning_icon) e [batepapo](https://www.iconfinder.com/icons/1031441/chat_message_text_icon) são encontrado em iconfinder.com, e desenhados por [Nazarrudin Ansyari](https://www.iconfinder.com/nazarr). Obrigado!
+   > [!NOTE]
+   > Os icones [aviso](https://www.iconfinder.com/icons/1031466/alarm_alert_error_warning_icon) e [batepapo](https://www.iconfinder.com/icons/1031441/chat_message_text_icon) são encontrado em iconfinder.com, e desenhados por [Nazarrudin Ansyari](https://www.iconfinder.com/nazarr). Obrigado!
 
 2. Em seguida, encontre o CSS dentro do seu arquivo HTML. Faremos algumas alterações para abrir caminho para os ícones. Primeiro, atualize a largura do `.msgBox` de:
 
@@ -288,7 +291,8 @@ Para o próximo parâmetro. Este vai envolver um pouco mais de trabalho — vamo
 
    Você pode ver como a nossa pequena função (agora nem tanto) está se tornando útil.
 
-> **Nota:** Se você tiver problemas para fazer o exemplo funcionar, sinta-se à vontade para verificar seu código na [versão finalizada no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/functions/function-stage-4.html) ([veja-a também em execução](http://mdn.github.io/learning-area/javascript/building-blocks/functions/function-stage-4.html)), ou peça nos ajuda.
+> [!NOTE]
+> Se você tiver problemas para fazer o exemplo funcionar, sinta-se à vontade para verificar seu código na [versão finalizada no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/functions/function-stage-4.html) ([veja-a também em execução](http://mdn.github.io/learning-area/javascript/building-blocks/functions/function-stage-4.html)), ou peça nos ajuda.
 
 ## Conclusão
 

--- a/files/pt-br/learn/javascript/building_blocks/conditionals/index.md
+++ b/files/pt-br/learn/javascript/building_blocks/conditionals/index.md
@@ -95,7 +95,8 @@ if (comprasFeitas === true) {
 
 Esse código como mostrado irá sempre resultar na variável `comprasFeitas` retornando `false`, sendo um desapontamento para nossas pobres crianças. Cabe a nós fornecer um mecanismo para o pai definir a variável `comprasFeitas` como `true` se o filho fez as compras.
 
-> **Nota:** Você pode ver a versão completa desse exemplo no [GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/allowance-updater.html) (também veja [live](http://mdn.github.io/learning-area/javascript/building-blocks/allowance-updater.html).)
+> [!NOTE]
+> Você pode ver a versão completa desse exemplo no [GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/allowance-updater.html) (também veja [live](http://mdn.github.io/learning-area/javascript/building-blocks/allowance-updater.html).)
 
 ### else if
 
@@ -150,7 +151,8 @@ function setWeather() {
 3. Quando esta função é executada, primeiro definimos uma variável chamada `choice` para o valor atual selecionado no elemento `<select>`. Em seguida, usamos uma instrução condicional para mostrar um texto diferente dentro do parágrafo, dependendo de qual é o valor de `choice` . Observe como todas as condições são testadas nos blocos `else if() {...}`, com exceção do primeiro, que é testado em um bloco `if() {...}`.
 4. A última escolha, dentro do bloco `else {...}`, é basicamente uma opção de "último recurso" — o código dentro dele será executado se nenhuma das condições for `true`. Nesse caso, ele serve para esvaziar o texto do parágrafo, se nada for selecionado, por exemplo, se um usuário decidir selecionar novamente a opção de espaço reservado "- Make a choice--" mostrada no início.
 
-> **Nota:** Você pode também [encontrar este exemplo no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/simple-else-if.html) ([veja ele sendo executado](http://mdn.github.io/learning-area/javascript/building-blocks/simple-else-if.html) lá também.)
+> [!NOTE]
+> Você pode também [encontrar este exemplo no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/simple-else-if.html) ([veja ele sendo executado](http://mdn.github.io/learning-area/javascript/building-blocks/simple-else-if.html) lá também.)
 
 ### Uma nota sobre os operadores de comparação
 
@@ -160,7 +162,8 @@ Operadores de comparação são usados para testar as condições dentro de noss
 - `<` e `>` — teste se um valor é menor ou maior que outro.
 - `<=` e `>=` — testar se um valor é menor ou igual a, ou maior que ou igual a outro.
 
-> **Nota:** Revise o material no link anterior se quiser atualizar suas memórias sobre eles.
+> [!NOTE]
+> Revise o material no link anterior se quiser atualizar suas memórias sobre eles.
 
 Queríamos fazer uma menção especial do teste de valores boolean (`true`/`false`) , e um padrão comum que você vai encontrar de novo e de novo. Qualquer valor que não seja `false`, `undefined`, `null`, `0`, `NaN`, ou uma string vazia (`''`) retorna `true` quando testado como uma instrução condicional, portanto, você pode simplesmente usar um nome de variável para testar se é verdadeiro , ou mesmo que existe (ou seja, não é indefinido). Por exemplo:
 
@@ -313,7 +316,8 @@ Aqui nós temos:
 6. Como muitos outros casos (marcadores 3 a 5) que você quiser.
 7. A palavra-chave `default`, seguido por exatamente o mesmo padrão de código de um dos casos (marcadores 3 a 5), exceto que o `default` não tem escolha após ele, e você não precisa da instrução `break`, pois não há nada para executar depois disso o bloco de qualquer maneira. Esta é a opção padrão que é executada se nenhuma das opções corresponder.
 
-> **Nota:** Você não precisa incluir a seção `default` — você pode omiti-la com segurança se não houver chance de que a expressão possa se igualar a um valor desconhecido. Se houver uma chance disso, você precisará incluí-lo para lidar com casos desconhecidos.
+> [!NOTE]
+> Você não precisa incluir a seção `default` — você pode omiti-la com segurança se não houver chance de que a expressão possa se igualar a um valor desconhecido. Se houver uma chance disso, você precisará incluí-lo para lidar com casos desconhecidos.
 
 ### Um exemplo de switch
 
@@ -366,7 +370,8 @@ function setWeather() {
 
 {{ EmbedLiveSample('A_switch_example', '100%', 100, "", "", "hide-codepen-jsfiddle") }}
 
-> **Nota:** Você pode [encontrar este exemplo no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/simple-switch.html) (veja-o em [execução](http://mdn.github.io/learning-area/javascript/building-blocks/simple-switch.html) lá também.)
+> [!NOTE]
+> Você pode [encontrar este exemplo no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/simple-switch.html) (veja-o em [execução](http://mdn.github.io/learning-area/javascript/building-blocks/simple-switch.html) lá também.)
 
 ## Operador ternário
 
@@ -423,7 +428,8 @@ Aqui nós temos um elemento {{htmlelement('select')}} para escolher um tema (pre
 
 Finalmente, nós também temos um evento listener [onchange](/pt-BR/docs/Web/API/GlobalEventHandlers/onchange) que serve para executar uma função que contém um operador ternário. Começa com uma condição de teste — `select.value === 'black'`. Se este retornar `true`, nós executamos a função `update()` com parâmetros de preto e branco, o que significa que acabamos com a cor de fundo do preto e cor do texto de branco. Se retornar `false`, nós executamos a função `update()` com parâmetros de branco e preto, o que significa que a cor do site está invertida.
 
-> **Nota:** Você pode também [encontrar este exemplo no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/simple-ternary.html) (veja-o [executando](http://mdn.github.io/learning-area/javascript/building-blocks/simple-ternary.html) lá também.)
+> [!NOTE]
+> Você pode também [encontrar este exemplo no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/simple-ternary.html) (veja-o [executando](http://mdn.github.io/learning-area/javascript/building-blocks/simple-ternary.html) lá também.)
 
 ## Aprendizado ativo: um calendário simples
 

--- a/files/pt-br/learn/javascript/building_blocks/events/index.md
+++ b/files/pt-br/learn/javascript/building_blocks/events/index.md
@@ -49,7 +49,8 @@ Você vai perceber com isso (e dando uma olhada no [Event reference](/pt-BR/docs
 
 Cada evento disponivel possui um **manipulador de eventos** (event handler), que é um bloco de código (geralmente uma função JavaScript definida pelo usuário) que será executado quando o evento for disparado. Quando esse bloco de código é definido para rodar em resposta a um evento que foi disparado, nós dizemos que estamos **registrando um manipulador de eventos**. Note que manipuladores de eventos são, em alguns casos, chamados de **ouvinte de eventos** (event listeners) — eles são praticamente intercambiáveis para nossos propósitos, embora estritamente falando, eles trabalhem juntos. Os ouvintes escutam o evento acontecendo, e o manipulador é o codigo que roda em resposta a este acontecimento.
 
-> **Nota:** É importante notar que eventos web não são parte do core da linguagem JavaScript — elas são definidas como parte das APIs JavaScript incorporadas ao navegador.
+> [!NOTE]
+> É importante notar que eventos web não são parte do core da linguagem JavaScript — elas são definidas como parte das APIs JavaScript incorporadas ao navegador.
 
 ### Um exemplo simples
 
@@ -160,7 +161,8 @@ function bgChange() {
 }
 ```
 
-> **Nota:** Você pode encontrar o [código fonte completo](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/random-color-eventhandlerattributes.html) para este exemplo no GitHub (também [veja isso executando em tempo real](http://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-eventhandlerattributes.html)).
+> [!NOTE]
+> Você pode encontrar o [código fonte completo](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/random-color-eventhandlerattributes.html) para este exemplo no GitHub (também [veja isso executando em tempo real](http://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-eventhandlerattributes.html)).
 
 O método mais antigo de registrar manipuladores de eventos encontrados na Web envolveu **atributos HTML de manipulador de eventos** (também conhecidos como **manipuladores de eventos inline**) como o mostrado acima — o valor do atributo é literalmente o código JavaScript que você deseja executar quando o evento ocorre. O exemplo acima chama uma função definida dentro de um elemento {{htmlelement("script")}} na mesma página, mas você também pode inserir JavaScript diretamente dentro do atributo, por exemplo:
 
@@ -184,7 +186,8 @@ for (var i = 0; i < buttons.length; i++) {
 }
 ```
 
-> **Nota:** Separar sua lógica de programação do seu conteúdo também torna seu site mais amigável aos mecanismos de pesquisa.
+> [!NOTE]
+> Separar sua lógica de programação do seu conteúdo também torna seu site mais amigável aos mecanismos de pesquisa.
 
 ### addEventListener() e removeEventListener()
 
@@ -202,7 +205,8 @@ function bgChange() {
 btn.addEventListener("click", bgChange);
 ```
 
-> **Nota:** Você pode encontrar o [código fonte completo](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/random-color-addeventlistener.html) para este exemplo no GitHub (também [veja isso executando em tempo real](http://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-addeventlistener.html)).
+> [!NOTE]
+> Você pode encontrar o [código fonte completo](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/random-color-addeventlistener.html) para este exemplo no GitHub (também [veja isso executando em tempo real](http://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-addeventlistener.html)).
 
 Dentro da função `addEventListener()`, especificamos dois parâmetros — o nome do evento para o qual queremos registrar esse manipulador, e o código que compreende a função do manipulador que queremos executar em resposta a ele. Note que é perfeitamente apropriado colocar todo o código dentro da função `addEventListener()`, em uma função anônima, assim:
 
@@ -257,7 +261,8 @@ element.onclick = function2;
 etc.
 ```
 
-> **Nota:** Se você for chamado para oferecer suporte a navegadores anteriores ao Internet Explorer 8 em seu trabalho, poderá encontrar dificuldades, pois esses navegadores antigos usam modelos de eventos diferentes dos navegadores mais recentes. Mas não tenha medo, a maioria das bibliotecas JavaScript (por exemplo, `jQuery`) tem funções internas que abstraem as diferenças entre navegadores. Não se preocupe muito com isso neste estágio de sua jornada de aprendizado.
+> [!NOTE]
+> Se você for chamado para oferecer suporte a navegadores anteriores ao Internet Explorer 8 em seu trabalho, poderá encontrar dificuldades, pois esses navegadores antigos usam modelos de eventos diferentes dos navegadores mais recentes. Mas não tenha medo, a maioria das bibliotecas JavaScript (por exemplo, `jQuery`) tem funções internas que abstraem as diferenças entre navegadores. Não se preocupe muito com isso neste estágio de sua jornada de aprendizado.
 
 ## Outros conceitos de evento
 
@@ -278,11 +283,13 @@ function bgChange(e) {
 btn.addEventListener("click", bgChange);
 ```
 
-> **Nota:** Você pode encontrar o [código fonte completo](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/random-color-eventobject.html) para este exemplo no GitHub (também [veja isso executando em tempo real](http://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-eventobject.html)).
+> [!NOTE]
+> Você pode encontrar o [código fonte completo](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/random-color-eventobject.html) para este exemplo no GitHub (também [veja isso executando em tempo real](http://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-eventobject.html)).
 
 Aqui você pode ver que estamos incluindo um objeto de evento, **e**, na função, e na função definindo um estilo de cor de fundo em `e.target` — que é o próprio botão. A propriedade `target` do objeto de evento é sempre uma referência ao elemento em que o evento acabou de ocorrer. Portanto, neste exemplo, estamos definindo uma cor de fundo aleatória no botão, não na página.
 
-> **Nota:** Você pode usar qualquer nome que desejar para o objeto de evento — você só precisa escolher um nome que possa ser usado para referenciá-lo dentro da função de manipulador de eventos. `e`/`evt`/`event` são mais comumente usados pelos desenvolvedores porque são curtos e fáceis de lembrar. É sempre bom manter um padrão.
+> [!NOTE]
+> Você pode usar qualquer nome que desejar para o objeto de evento — você só precisa escolher um nome que possa ser usado para referenciá-lo dentro da função de manipulador de eventos. `e`/`evt`/`event` são mais comumente usados pelos desenvolvedores porque são curtos e fáceis de lembrar. É sempre bom manter um padrão.
 
 `e.target` é incrivelmente útil quando você deseja definir o mesmo manipulador de eventos em vários elementos e fazer algo com todos eles quando ocorre um evento neles. Você pode, por exemplo, ter um conjunto de 16 blocos que desaparecem quando são clicados. É útil poder sempre apenas definir a coisa para desaparecer como `e.target`, ao invés de ter que selecioná-lo de alguma forma mais difícil. No exemplo a seguir (veja [useful-eventtarget.html](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/useful-eventtarget.html) para o código-fonte completo; veja também a [execução ao vivo](http://mdn.github.io/learning-area/javascript/building-blocks/events/useful-eventtarget.html) aqui), criamos 16 elementos {{htmlelement("div")}} usando JavaScript. Em seguida, selecionamos todos eles usando {{domxref("document.querySelectorAll()")}} e, em seguida, percorremos cada um deles, adicionando um manipulador onclick a cada um, de modo que uma cor aleatória seja aplicada a cada um deles quando clicados:
 
@@ -398,7 +405,8 @@ Obviamente, isso é uma validação de forma bastante fraca — ela não impedir
 
 {{ EmbedLiveSample('Preventing_default_behavior', '100%', 140, "", "", "hide-codepen-jsfiddle") }}
 
-> **Nota:** para o código fonte completo, veja [preventdefault-validation.html](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/preventdefault-validation.html) (também veja isso [executando em tempo real](http://mdn.github.io/learning-area/javascript/building-blocks/events/preventdefault-validation.html) aqui.)
+> [!NOTE]
+> para o código fonte completo, veja [preventdefault-validation.html](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/preventdefault-validation.html) (também veja isso [executando em tempo real](http://mdn.github.io/learning-area/javascript/building-blocks/events/preventdefault-validation.html) aqui.)
 
 ### Borbulhamento e captura de eventos
 
@@ -565,9 +573,11 @@ video.onclick = function (e) {
 
 Você pode tentar fazer uma cópia local do código-fonte [show-video-box.html source code](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/show-video-box.html) e tentar corrigi-lo sozinho, ou observar o resultado corrigido em [show-video-box-fixed.html](http://mdn.github.io/learning-area/javascript/building-blocks/events/show-video-box-fixed.html) (veja também o [código-fonte](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/events/show-video-box-fixed.html) aqui).
 
-> **Nota:** Por que se preocupar em capturar e borbulhar? Bem, nos velhos tempos em que os navegadores eram muito menos compatíveis entre si do que são agora, o Netscape usava apenas captura de eventos, e o Internet Explorer usava apenas borbulhamento de eventos. Quando o W3C decidiu tentar padronizar o comportamento e chegar a um consenso, eles acabaram com esse sistema que incluía ambos, que é o único navegador moderno implementado.
+> [!NOTE]
+> Por que se preocupar em capturar e borbulhar? Bem, nos velhos tempos em que os navegadores eram muito menos compatíveis entre si do que são agora, o Netscape usava apenas captura de eventos, e o Internet Explorer usava apenas borbulhamento de eventos. Quando o W3C decidiu tentar padronizar o comportamento e chegar a um consenso, eles acabaram com esse sistema que incluía ambos, que é o único navegador moderno implementado.
 
-> **Nota:** Como mencionado acima, por padrão, todos os manipuladores de eventos são registrados na fase de bubbling, e isso faz mais sentido na maioria das vezes. Se você realmente quiser registrar um evento na fase de captura, registre seu manipulador usando [`addEventListener()`](/pt-BR/docs/Web/API/EventTarget/addEventListener), e defina a propriedade terceira opcional como `true`.
+> [!NOTE]
+> Como mencionado acima, por padrão, todos os manipuladores de eventos são registrados na fase de bubbling, e isso faz mais sentido na maioria das vezes. Se você realmente quiser registrar um evento na fase de captura, registre seu manipulador usando [`addEventListener()`](/pt-BR/docs/Web/API/EventTarget/addEventListener), e defina a propriedade terceira opcional como `true`.
 
 #### Delegação de eventos
 

--- a/files/pt-br/learn/javascript/building_blocks/functions/index.md
+++ b/files/pt-br/learn/javascript/building_blocks/functions/index.md
@@ -68,7 +68,8 @@ var myNumber = Math.random();
 
 ...nós usamos uma função!
 
-> **Nota:** Fique a vontade para inserir essas linhas no console JavaScript do navegador para refamiliarizar-se com suas funcionalidades, se necessário.
+> [!NOTE]
+> Fique a vontade para inserir essas linhas no console JavaScript do navegador para refamiliarizar-se com suas funcionalidades, se necessário.
 
 A linguagem JavaScript tem muitas funções embutidas que o permitem fazer coisas úteis sem que você mesmo tenha que escrever aquele código. De fato, alguns dos códigos que você está chamando quando você **invoca** (uma palavra rebuscada para rodar, ou executar) uma função embutida de navegador não poderia ser escrita em JavaScript — muitas dessa funções são chamadas a partes de código base do navegador, que é escrita grandemente em linguages de sistema de baixo nível como C++, não linguagem Web como JavaScript.
 
@@ -208,7 +209,8 @@ myButton.onclick = function () {
 
 Algumas funções requerem **parâmetros** a ser especificado quando você está invocando-os — esses são valores que precisam ser inclusos dentro dos parênteses da função, o que é necessário para fazer seu trabalho apropriado.
 
-> **Nota:** Parâmetros algumas vezes são chamados de argumentos, propriedades, ou até atributos.
+> [!NOTE]
+> Parâmetros algumas vezes são chamados de argumentos, propriedades, ou até atributos.
 
 Como um exemplo, a função embutida de navegador [Math.random()](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Math/random) não requer nenhum parâmetro. Quando chamada, ela sempre retorna um número aleatório entre 0 e 1:
 
@@ -223,7 +225,8 @@ var myText = "I am a string";
 var newString = myText.replace("string", "sausage");
 ```
 
-> **Nota:** Quando você precisa especificar multiplos parâmetros, eles são separados por vígulas.
+> [!NOTE]
+> Quando você precisa especificar multiplos parâmetros, eles são separados por vígulas.
 
 Nota-se também que algumas vezes os parâmetros são opcionais — você não tem que especificá-los. Se você não o faz, a função geralmente adota algum tipo de comportamento padrão. Como exemplo, a função [join()](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Array/join) tem parâmetro opcional:
 
@@ -274,7 +277,8 @@ function greeting() {
 
 Ambas as funções que você quer chamar são chamadas `greeting()`, mas você só pode acessar o arquivo `second.js` da função `greeting()` — Ele é aplicado no HTML depois no código fonte, então suas variáveis e funções sobrescrevem as de `first.js`.
 
-> **Nota:** Você pode ver este exemplo [rodando no GitHub](http://mdn.github.io/learning-area/javascript/building-blocks/functions/conflict.html) (veja também [o código fonte](https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/functions)).
+> [!NOTE]
+> Você pode ver este exemplo [rodando no GitHub](http://mdn.github.io/learning-area/javascript/building-blocks/functions/conflict.html) (veja também [o código fonte](https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/functions)).
 
 Manter parte de seus código trancada em funções evita tais problemas, e é considerado boa prática.
 
@@ -376,9 +380,11 @@ Vamos observar um exemplo real para mostrar escopo.
 
    Desta vez as chamadas de `a()` e `b()` retornaram o irritante erro "[ReferenceError: z is not defined](/pt-BR/docs/Web/JavaScript/Reference/Errors/Not_defined)" — isto porque a chamada de `output()` e as variáveis que eles estão tentando imprimir não estão definidas dentro do mesmo escopo das funções — as variáveis são efetivamente invisíveis aquelas chamadas de função.
 
-> **Nota:** As mesmas regras de escopo não se aplicam a laços (ex.: `for() { ... }`) e blocos condicionais (ex.: `if() { ... }`) — eles parecem muito semelhantes, mas eles não são a mesma coisa! Tome cuidado para não confudir-se.
+> [!NOTE]
+> As mesmas regras de escopo não se aplicam a laços (ex.: `for() { ... }`) e blocos condicionais (ex.: `if() { ... }`) — eles parecem muito semelhantes, mas eles não são a mesma coisa! Tome cuidado para não confudir-se.
 
-> **Nota:** O erro [ReferenceError: "x" is not defined](/pt-BR/docs/Web/JavaScript/Reference/Errors/Not_defined) é um dos mais comuns que você encontrará. Se você receber este erro e tem certeza que definiu a variável em questão, cheque em que escopo ela está.
+> [!NOTE]
+> O erro [ReferenceError: "x" is not defined](/pt-BR/docs/Web/JavaScript/Reference/Errors/Not_defined) é um dos mais comuns que você encontrará. Se você receber este erro e tem certeza que definiu a variável em questão, cheque em que escopo ela está.
 
 ### Funções dentro de funções
 

--- a/files/pt-br/learn/javascript/building_blocks/index.md
+++ b/files/pt-br/learn/javascript/building_blocks/index.md
@@ -11,7 +11,8 @@ Neste módulo, continuaremos nossa abordagem por todos os recursos-chave fundame
 
 Antes de iniciar este módulo, você deve ter familiaridade com os conceitos básicos de [HTML](/pt-BR/docs/Aprender/HTML/Introducao_ao_HTML) e [CSS](/pt-BR/docs/Aprender/CSS/Introduction_to_CSS), além de ter estudado nosso módulo anterior, [primeiros passos no Javacript](/pt-BR/docs/Learn/JavaScript/First_steps).
 
-> **Nota:** Se você está trabalhando em um computador, tablet ou outro dispositivo onde você não tem a habilidade para criar seus próprios arquivos, você pode testar os exemplos de código (a maioria deles) em um programa de codificação online, tal como [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/) ou [Glitch](https://glitch.com/).
+> [!NOTE]
+> Se você está trabalhando em um computador, tablet ou outro dispositivo onde você não tem a habilidade para criar seus próprios arquivos, você pode testar os exemplos de código (a maioria deles) em um programa de codificação online, tal como [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/javascript/building_blocks/looping_code/index.md
+++ b/files/pt-br/learn/javascript/building_blocks/looping_code/index.md
@@ -236,9 +236,11 @@ Aqui mostra um loop sendo usado para iterar os itens em uma matriz e fazer algo 
 
 4. Quando `i` torna-se igual a `cats.length`, o loop é interrompido e o navegador passará para o próximo trecho de código abaixo do loop.
 
-> **Nota:** :Nós fizemos a condição de saída `i < cats.length`, e não `i <= cats.length`, porque os computadores contam a partir de 0, não 1 - estamos começando `i` em `0`, e indo até `i = 4` (o index do último item do array). `cats.length` retorna 5, pois há 5 itens no array, mas não queremos chegar até `i = 5`, pois isso retornaria `undefined` para o último item (não há nenhum item no índice 5 do array). Então, portanto, queremos ir até 1 a menos de `cats.length` (`i <`), não é o mesmo que `cats.length` (`i <=`).
+> [!NOTE]
+> :Nós fizemos a condição de saída `i < cats.length`, e não `i <= cats.length`, porque os computadores contam a partir de 0, não 1 - estamos começando `i` em `0`, e indo até `i = 4` (o index do último item do array). `cats.length` retorna 5, pois há 5 itens no array, mas não queremos chegar até `i = 5`, pois isso retornaria `undefined` para o último item (não há nenhum item no índice 5 do array). Então, portanto, queremos ir até 1 a menos de `cats.length` (`i <`), não é o mesmo que `cats.length` (`i <=`).
 
-> **Nota:** Um erro comum nas condições de saída é usá-las "igual a" (`===`) em vez de dizer "menor ou igual a" (`<=`). Se quiséssemos executar nosso loop até `i = 5`, a condição de saída precisaria ser `i <= cats.length`. Se nós setarmos para `i === cats.length`, o loop não seria executado em todos, porque `i` não é igual a `5` na primeira iteração do loop, a execução pararia imediatamente.
+> [!NOTE]
+> Um erro comum nas condições de saída é usá-las "igual a" (`===`) em vez de dizer "menor ou igual a" (`<=`). Se quiséssemos executar nosso loop até `i = 5`, a condição de saída precisaria ser `i <= cats.length`. Se nós setarmos para `i === cats.length`, o loop não seria executado em todos, porque `i` não é igual a `5` na primeira iteração do loop, a execução pararia imediatamente.
 
 Um pequeno problema que nos resta é que a sentença de saída final não é muito bem formada:
 
@@ -366,7 +368,8 @@ btn.addEventListener("click", function () {
 
 5. Após `(contacts.length-1)` iterações, se o nome do contato não corresponder à pesquisa inserida, o texto do parágrafo será definido como "Contato não encontrado" e o loop continuará a iterar.
 
-> **Nota:** Você pode encontrar este [código de exemplo no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/loops/contact-search.html) (também [veja em execução](https://mdn.github.io/learning-area/javascript/building-blocks/loops/contact-search.html) ).
+> [!NOTE]
+> Você pode encontrar este [código de exemplo no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/loops/contact-search.html) (também [veja em execução](https://mdn.github.io/learning-area/javascript/building-blocks/loops/contact-search.html) ).
 
 ## Ignorando iterações com continue
 
@@ -435,7 +438,8 @@ Aqui está a saída:
 3. Se a raiz quadrada e a raiz quadrada arredondada não forem iguais (`! ==`), isso significa que a raiz quadrada não é um número inteiro, portanto, não estamos interessados nela. Nesse caso, usamos a instrução `continue` para pular para a próxima iteração de loop sem registrar o número em nenhum lugar.
 4. Se a raiz quadrada é um inteiro, nós pulamos o bloco if inteiramente para que a instrução `continue` não seja executada; em vez disso, concatenamos o valor `i` atual mais um espaço até o final do conteúdo do parágrafo.
 
-> **Nota:** Você pode encontrar este [código de exemplo no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/loops/integer-squares.html) (também [veja em execução](https://mdn.github.io/learning-area/javascript/building-blocks/loops/integer-squares.html) ).
+> [!NOTE]
+> Você pode encontrar este [código de exemplo no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/loops/integer-squares.html) (também [veja em execução](https://mdn.github.io/learning-area/javascript/building-blocks/loops/integer-squares.html) ).
 
 ## while e o do ... while
 
@@ -859,7 +863,8 @@ do {
 
 Nós recomendamos o uso do `for`, pelo menos no começo, já que ele é provavelmente a forma mais fácil de lembrar de tudo — o inicializador, a condição de saída, e a expressão final final tudo fica ordenadamente dentro dos parênteses, então é fácil de ver onde eles estão e para verifcar se você não os esqueceu.
 
-> **Nota:** There are other loop types/features too, which are useful in advanced/specialized situations and beyond the scope of this article. If you want to go further with your loop learning, read our advanced [Loops and iteration guide](/pt-BR/docs/Web/JavaScript/Guide/Loops_and_iteration).
+> [!NOTE]
+> There are other loop types/features too, which are useful in advanced/specialized situations and beyond the scope of this article. If you want to go further with your loop learning, read our advanced [Loops and iteration guide](/pt-BR/docs/Web/JavaScript/Guide/Loops_and_iteration).
 
 ## Conclusion
 

--- a/files/pt-br/learn/javascript/building_blocks/return_values/index.md
+++ b/files/pt-br/learn/javascript/building_blocks/return_values/index.md
@@ -161,7 +161,8 @@ Vamos escrever nossas próprias funções com valores de retorno.
 
 4. Salve seu código, carregue-o em um navegador e experimente.
 
-> **Nota:** Se você tiver problemas para fazer o exemplo funcionar, sinta-se à vontade para verificar seu código na [versão finalizada no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/functions/function-library-finished.html) ([consulte também sua execução](http://mdn.github.io/learning-area/javascript/building-blocks/functions/function-library-finished.html)), ou peça ajuda.
+> [!NOTE]
+> Se você tiver problemas para fazer o exemplo funcionar, sinta-se à vontade para verificar seu código na [versão finalizada no GitHub](https://github.com/mdn/learning-area/blob/master/javascript/building-blocks/functions/function-library-finished.html) ([consulte também sua execução](http://mdn.github.io/learning-area/javascript/building-blocks/functions/function-library-finished.html)), ou peça ajuda.
 
 Neste ponto, gostaríamos que você escrevesse algumas funções e as adicionasse à biblioteca. Como sobre o quadrado ou raiz cúbica do número, ou a circunferência de um círculo com um raio de comprimento `num`?
 

--- a/files/pt-br/learn/javascript/client-side_web_apis/client-side_storage/index.md
+++ b/files/pt-br/learn/javascript/client-side_web_apis/client-side_storage/index.md
@@ -51,7 +51,8 @@ O armazenamento do lado do cliente funciona em princípios semelhantes, mas tem 
 
 Freqüentemente, o armazenamento do lado do cliente e do lado do servidor são usados juntos. Por exemplo, você pode baixar um lote de arquivos de música (talvez usados por um jogo da web ou aplicativo de reprodutor de música), armazená-los em um banco de dados do cliente e reproduzi-los conforme necessário. O usuário só teria que baixar os arquivos de música uma vez - em visitas subsequentes, eles seriam recuperados do banco de dados.
 
-> **Nota:** : Existem limites para a quantidade de dados que você pode armazenar usando APIs de armazenamento do lado do cliente (possivelmente por API individual e cumulativamente); o limite exato varia dependendo do navegador e, possivelmente, com base nas configurações do usuário. Consulte [Limites de armazenamento do navegador e critérios de despejo](/pt-BR/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria) para obter mais informações..
+> [!NOTE]
+> : Existem limites para a quantidade de dados que você pode armazenar usando APIs de armazenamento do lado do cliente (possivelmente por API individual e cumulativamente); o limite exato varia dependendo do navegador e, possivelmente, com base nas configurações do usuário. Consulte [Limites de armazenamento do navegador e critérios de despejo](/pt-BR/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria) para obter mais informações..
 
 ### Old school: Cookies
 
@@ -241,9 +242,11 @@ Let's build up the example, so you can understand how it works.
 
 Your example is finished — well done! All that remains now is to save your code and test your HTML page in a browser. You can see our [finished version running live here](https://mdn.github.io/learning-area/javascript/apis/client-side-storage/web-storage/personal-greeting.html).
 
-> **Nota:** There is another, slightly more complex example to explore at [Using the Web Storage API](/pt-BR/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API).
+> [!NOTE]
+> There is another, slightly more complex example to explore at [Using the Web Storage API](/pt-BR/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API).
 
-> **Nota:** In the line `<script src="index.js" defer></script>` of the source for our finished version, the `defer` attribute specifies that the contents of the {{htmlelement("script")}} element will not execute until the page has finished loading.
+> [!NOTE]
+> In the line `<script src="index.js" defer></script>` of the source for our finished version, the `defer` attribute specifies that the contents of the {{htmlelement("script")}} element will not execute until the page has finished loading.
 
 ## Storing complex data — IndexedDB
 
@@ -300,7 +303,8 @@ Now let's look at what we have to do in the first place, to actually set up a da
 
    To handle this in IndexedDB, you create a request object (which can be called anything you like — we called it `request` so it is obvious what it is for). You then use event handlers to run code when the request completes, fails, etc., which you'll see in use below.
 
-   > **Nota:** The version number is important. If you want to upgrade your database (for example, by changing the table structure), you have to run your code again with an increased version number, different schema specified inside the `onupgradeneeded` handler (see below), etc. We won't cover upgrading databases in this simple tutorial.
+   > [!NOTE]
+   > The version number is important. If you want to upgrade your database (for example, by changing the table structure), you have to run your code again with an increased version number, different schema specified inside the `onupgradeneeded` handler (see below), etc. We won't cover upgrading databases in this simple tutorial.
 
 4. Now add the following event handlers just below your previous addition — again inside the `window.onload` handler:
 
@@ -673,7 +677,8 @@ When it intercepts a request, it can do anything you wish to it (see [use case i
 
 The Cache API is a another client-side storage mechanism, with a bit of a difference — it is designed to save HTTP responses, and so works very well with service workers.
 
-> **Nota:** Service workers and Cache are supported in most modern browsers now. At the time of writing, Safari was still busy implementing it, but it should be there soon.
+> [!NOTE]
+> Service workers and Cache are supported in most modern browsers now. At the time of writing, Safari was still busy implementing it, but it should be there soon.
 
 ### A service worker example
 
@@ -699,7 +704,8 @@ if ("serviceWorker" in navigator) {
 }
 ```
 
-> **Nota:** The given path to the `sw.js` file is relative to the site origin, not the JavaScript file that contains the code. The service worker is at `https://mdn.github.io/learning-area/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js`. The origin is `https://mdn.github.io`, and therefore the given path has to be `/learning-area/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js`. If you wanted to host this example on your own server, you'd have to change this accordingly. This is rather confusing, but it has to work this way for security reasons.
+> [!NOTE]
+> The given path to the `sw.js` file is relative to the site origin, not the JavaScript file that contains the code. The service worker is at `https://mdn.github.io/learning-area/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js`. The origin is `https://mdn.github.io`, and therefore the given path has to be `/learning-area/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js`. If you wanted to host this example on your own server, you'd have to change this accordingly. This is rather confusing, but it has to work this way for security reasons.
 
 #### Installing the service worker
 

--- a/files/pt-br/learn/javascript/client-side_web_apis/introduction/index.md
+++ b/files/pt-br/learn/javascript/client-side_web_apis/introduction/index.md
@@ -50,7 +50,8 @@ _Fonte da imagem: [Overloaded plug socket](https://www.flickr.com/photos/easy-pi
 
 Da mesma forma, caso você queira programar gráficos em 3D, é muito mais fácil usar uma API escrita em linguagem de alto nível como JavaScript ou Python, do que escrever em código de mais baixo nível (C ou C++) que controla diretamente a GPU ou outras funções gráficas.
 
-> **Nota:** para mais informações, consulte o [termo API](/pt-BR/docs/Glossario/API) no glossário.
+> [!NOTE]
+> para mais informações, consulte o [termo API](/pt-BR/docs/Glossario/API) no glossário.
 
 ### APIs JavaScript client-side
 
@@ -96,7 +97,8 @@ APIs de terceiros são bastante variadas. Dentre as mais populares, que você ev
 - The [YouTube API](https://developers.google.com/youtube/), which allows you to embed YouTube videos on your site, search YouTube, build playlists, and more.
 - The [Twilio API](https://www.twilio.com/), which provides a framework for building voice and video call functionality into your app, sending SMS/MMS from your apps, and more.
 
-> **Nota:** Você pode encontrar informações sobre muitas outras APIs de terceiros no [Programmable Web API directory](http://www.programmableweb.com/category/all/apis).
+> [!NOTE]
+> Você pode encontrar informações sobre muitas outras APIs de terceiros no [Programmable Web API directory](http://www.programmableweb.com/category/all/apis).
 
 ## Como as APIs funcionam?
 
@@ -106,7 +108,8 @@ APIs JavaScript possuem pequenas diferenças mas, em geral, possuem funcionalida
 
 Your code interacts with APIs using one or more [JavaScript objects](/pt-BR/docs/Learn/JavaScript/Objects), which serve as containers for the data the API uses (contained in object properties), and the functionality the API makes available (contained in object methods).
 
-> **Nota:** If you are not already familiar with how objects work, you should go back and work through our [JavaScript objects](/pt-BR/docs/Learn/JavaScript/Objects) module before continuing.
+> [!NOTE]
+> If you are not already familiar with how objects work, you should go back and work through our [JavaScript objects](/pt-BR/docs/Learn/JavaScript/Objects) module before continuing.
 
 Let's return to the example of the Geolocation API — this is a very simple API that consists of a few simple objects:
 
@@ -135,7 +138,8 @@ navigator.geolocation.getCurrentPosition(function (position) {
 });
 ```
 
-> **Nota:** When you first load up the above example, you should be given a dialog box asking if you are happy to share your location with this application (see the [They have additional security mechanisms where appropriate](#they_have_additional_security_mechanisms_where_appropriate) section later in the article). You need to agree to this to be able to plot your location on the map. If you still can't see the map, you may need to set your permissions manually; you can do this in various ways depending on what browser you are using; for example in Firefox go to > _Tools_ > _Page Info_ > _Permissions_, then change the setting for _Share Location_; in Chrome go to _Settings_ > _Privacy_ > _Show advanced settings_ > _Content settings_ then change the settings for _Location_.
+> [!NOTE]
+> When you first load up the above example, you should be given a dialog box asking if you are happy to share your location with this application (see the [They have additional security mechanisms where appropriate](#they_have_additional_security_mechanisms_where_appropriate) section later in the article). You need to agree to this to be able to plot your location on the map. If you still can't see the map, you may need to set your permissions manually; you can do this in various ways depending on what browser you are using; for example in Firefox go to > _Tools_ > _Page Info_ > _Permissions_, then change the setting for _Share Location_; in Chrome go to _Settings_ > _Privacy_ > _Show advanced settings_ > _Content settings_ then change the settings for _Location_.
 
 We first want to use the {{domxref("Geolocation.getCurrentPosition()")}} method to return the current location of our device. The browser's {{domxref("Geolocation")}} object is accessed by calling the {{domxref("Navigator.geolocation")}} property, so we start off by using
 
@@ -154,7 +158,8 @@ But we can use the dot syntax to chain our property/method access together, redu
 
 The {{domxref("Geolocation.getCurrentPosition()")}} method only has a single mandatory parameter, which is an anonymous function that will run when the device's current position has been successfully retrieved. This function itself has a parameter, which contains a {{domxref("Position")}} object representing the current position data.
 
-> **Nota:** A function that is taken by another function as an argument is called a [callback function](/pt-BR/docs/Glossary/Callback_function).
+> [!NOTE]
+> A function that is taken by another function as an argument is called a [callback function](/pt-BR/docs/Glossary/Callback_function).
 
 This pattern of invoking a function only when an operation has been completed is very common in JavaScript APIs — making sure one operation has completed before trying to use the data the operation returns in another operation. These are called **[asynchronous](/pt-BR/docs/Glossary/Asynchronous) operations**. Because getting the device's current position relies on an external component (the device's GPS or other geolocation hardware), we can't guarantee that it will be done in time to just immediately use the data it returns. Therefore, something like this wouldn't work:
 
@@ -199,7 +204,8 @@ With this done, our map now renders.
 
 This last block of code highlights two common patterns you'll see across many APIs. First of all, API objects commonly contain constructors, which are invoked to create instances of those objects that you'll use to write your program. Second, API objects often have several options available that can be tweaked to get the exact environment you want for your program. API constructors commonly accept options objects as parameters, which is where you'd set such options.
 
-> **Nota:** Don't worry if you don't understand all the details of this example immediately. We'll cover using third party APIs in a lot more detail in a future article.
+> [!NOTE]
+> Don't worry if you don't understand all the details of this example immediately. We'll cover using third party APIs in a lot more detail in a future article.
 
 ### Possuem pontos de entrada reconhecíveis
 
@@ -232,7 +238,8 @@ Ball.prototype.draw = function () {
 };
 ```
 
-> **Nota:** You can see this code in action in our [bouncing balls demo](https://github.com/mdn/learning-area/blob/master/javascript/apis/introduction/bouncing-balls.html) (see it [running live](http://mdn.github.io/learning-area/javascript/apis/introduction/bouncing-balls.html) also).
+> [!NOTE]
+> You can see this code in action in our [bouncing balls demo](https://github.com/mdn/learning-area/blob/master/javascript/apis/introduction/bouncing-balls.html) (see it [running live](http://mdn.github.io/learning-area/javascript/apis/introduction/bouncing-balls.html) also).
 
 ### Usam eventos para lidar com mudanças de estado
 
@@ -257,7 +264,8 @@ request.onload = function () {
 };
 ```
 
-> **Nota:** You can see this code in action in our [ajax.html](https://github.com/mdn/learning-area/blob/master/javascript/apis/introduction/ajax.html) example ([see it live](http://mdn.github.io/learning-area/javascript/apis/introduction/ajax.html) also).
+> [!NOTE]
+> You can see this code in action in our [ajax.html](https://github.com/mdn/learning-area/blob/master/javascript/apis/introduction/ajax.html) example ([see it live](http://mdn.github.io/learning-area/javascript/apis/introduction/ajax.html) also).
 
 The first five lines specify the location of resource we want to fetch, create a new instance of a request object using the `XMLHttpRequest()` constructor, open an HTTP `GET` request to retrieve the specified resource, specify that the response should be sent in JSON format, then send the request.
 

--- a/files/pt-br/learn/javascript/client-side_web_apis/manipulating_documents/index.md
+++ b/files/pt-br/learn/javascript/client-side_web_apis/manipulating_documents/index.md
@@ -117,7 +117,8 @@ Esta wiki não suporta JavaScript nas páginas, então não é possível mostrar
   </tbody>
 </table>
 
-> **Nota:** Sobre esta demonstração:
+> [!NOTE]
+> Sobre esta demonstração:
 >
 > - O documento HTML tem uma folha de estilo anexada, bem como um arquivo de script.
 > - O script trabalha com elementos individuais no DOM. Ele modifica o square's style diretamente. Ele modifica o estilo dos botões indiretamente mudando um atributo.

--- a/files/pt-br/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/pt-br/learn/javascript/first_steps/a_first_splash/index.md
@@ -31,7 +31,8 @@ Agora você poderá aprender um pouco sobre a Teoria do Javascript e o que você
 
 Nós não esperamos que você entenda todo o código imediatamente - Apenas queremos ensinar-lhe os melhores conceitos por enquanto e dar a você uma idéia de como o JavaScript (e outras linguagens de programação) funcionam. Em artigos posteriores você vai rever todos esses recursos com muito mais detalhes!
 
-> **Nota:** Muitos dos recursos de código que você verá no JavaScript são iguais aos de outra linguagem de programação - funções, loops, etc. A sintaxe do código parece diferente, mas os conceitos ainda são praticamente os mesmos.
+> [!NOTE]
+> Muitos dos recursos de código que você verá no JavaScript são iguais aos de outra linguagem de programação - funções, loops, etc. A sintaxe do código parece diferente, mas os conceitos ainda são praticamente os mesmos.
 
 ## Pensando como um Programador
 
@@ -250,7 +251,8 @@ No nosso exemplo:
 
 - As últimas duas variáveis (contagemPalpites e botaoReinicio) são usadas para armazenar a contagem dos palpites do usuário, e o outro é uma referência para o botão de reset, que não existe ainda (mas irá existir).
 
-> **Nota:** Você irá aprender muito mais sobre variáveis a partir do [próximo artigo](/pt-BR/docs/user:chrisdavidmills/variables).
+> [!NOTE]
+> Você irá aprender muito mais sobre variáveis a partir do [próximo artigo](/pt-BR/docs/user:chrisdavidmills/variables).
 
 ### Funções
 
@@ -276,7 +278,8 @@ conferirPalpite();
 
 Você deverá ver um alerta aparecer dizendo "Eu sou um placeholder"; nós definimos uma função em nosso código que cria um alerta a qualquer hora em que a chamarmos.
 
-> **Nota:** Você irá aprender muito mais sobre funções mais tarde no curso.
+> [!NOTE]
+> Você irá aprender muito mais sobre funções mais tarde no curso.
 
 ### Operadores
 

--- a/files/pt-br/learn/javascript/first_steps/arrays/index.md
+++ b/files/pt-br/learn/javascript/first_steps/arrays/index.md
@@ -175,7 +175,8 @@ Você pode acessar itens individuais em uma array usando a notação de colchete
    // shopping vai retornar agora [ "tahini", "milk", "cheese", "hummus", "noodles" ]
    ```
 
-   > **Nota:** Nós dissemos isto antes, mas como lembrete — computadores começam a contar do 0!
+   > [!NOTE]
+   > Nós dissemos isto antes, mas como lembrete — computadores começam a contar do 0!
 
 3. Note que uma array dentro de uma array é chamada de array multidimensional. Você pode acessar um item dentro de uma array que está localizada dentro de outra array, colocando dois conjuntos de colchetes juntos. Por exemplo, para acessar um dos itens dentro de uma array, que é o terceiro item dentro da array `random` (veja a seção anterior), nós podemos fazer algo tipo isto:
 
@@ -217,7 +218,8 @@ Nesta seção vamos ver alguns métodos relacionados a array úteis que nos perm
 
 Frequentemente você vai se deparar com alguns dados contidos em uma grande e longa string, e você pode querer separar os itens em uma forma mais útil e então manipular eles, como mostrar em uma tabela. Para fazer isto, nós podemos usar o método {{jsxref("String.prototype.split()","split()")}}. Nesta forma mais simples, ela pega um parâmetro solitário, o caracter que você deseja separar da string e retorna o restante antes e depois do item separado na array.
 
-> **Nota:** Ok, isto é tecnicamente um método de string, não um método de array, mas nós podemos colocar em arrays já que cai bem.
+> [!NOTE]
+> Ok, isto é tecnicamente um método de string, não um método de array, mas nós podemos colocar em arrays já que cai bem.
 
 1. Vamos brincar com isto para ver como funciona. Primeiro, crie uma string no seu console:
 
@@ -494,7 +496,8 @@ Um bom uso para os métodos de array como {{jsxref("Array.prototype.push()","pus
 
 Neste exemplo nós vamos mostrar um uso bem mais simples — aqui nós estamos dando a você um falso site de busca, com uma caixa de busca. A idéia é que quando termos são digitados na caixa de busca, os 5 principais termos de busca anterior sejam mostrados na lista. Quando o número de termos passar de 5, o último termo começa sendo deletado. A cada vez um novo termo é adicionado ao topo, então os 5 termos anteriores são sempre mostrados.
 
-> **Nota:** Em um aplicativo de busca real, você seria, provavelmente, habilitado a clicar nos termos anteriores para retornar às pesquisas, e isto iria mostrar o reusltado atual! Nós estamos só mantendo simples, por agora.
+> [!NOTE]
+> Em um aplicativo de busca real, você seria, provavelmente, habilitado a clicar nos termos anteriores para retornar às pesquisas, e isto iria mostrar o reusltado atual! Nós estamos só mantendo simples, por agora.
 
 Para completar o aplicativo, nós precisamos que você:
 

--- a/files/pt-br/learn/javascript/first_steps/index.md
+++ b/files/pt-br/learn/javascript/first_steps/index.md
@@ -15,7 +15,8 @@ Antes de iniciar esse módulo, você não precisa de nenhum conhecimento prévio
 - [Introdução ao HTML](/pt-BR/docs/Learn/HTML/Introduction_to_HTML)
 - [Introdução ao CSS](/pt-BR/docs/Learn/CSS/First_steps)
 
-> **Nota:** Se você está trabalhando em um computador/tablet/outro dispositivo onde você não pode criar os seus próprio arquivos, você pode experimentar (em sua maioria) os códigos de exemplo em um programa de codificação online como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
+> [!NOTE]
+> Se você está trabalhando em um computador/tablet/outro dispositivo onde você não pode criar os seus próprio arquivos, você pode experimentar (em sua maioria) os códigos de exemplo em um programa de codificação online como [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guias
 

--- a/files/pt-br/learn/javascript/first_steps/math/index.md
+++ b/files/pt-br/learn/javascript/first_steps/math/index.md
@@ -86,7 +86,8 @@ São os operadores que utilizamos para fazer as operações aritiméticas básic
 | `/`      | Divisão                                             | Divide o número da esquerda pelo número da direita.                                          | `10 / 5`                                                                    |
 | `%`      | Restante _(Remainder_ - as vezes chamado de modulo) | Retorna o resto da divisão em números inteiros do número da esquerda pelo número da direita. | `8 % 3` (retorna 2; como três cabe duas vezes em 8, deixando 2 como resto.) |
 
-> **Nota:** Você verá algumas vezes números envolvidos em aritimética chamados de {{Glossary("Operando", "operandos")}}.
+> [!NOTE]
+> Você verá algumas vezes números envolvidos em aritimética chamados de {{Glossary("Operando", "operandos")}}.
 
 Nós provavelmente não precisamos ensinar a você como fazer matemática básica, mas gostaríamos de testar seu entendimento da sintaxe envolvida. Tente inserir os exemplos abaixo no seu [console JavaScript](/pt-BR/docs/Learn/Common_questions/What_are_browser_developer_tools), ou use o console incorporado visto anteriormente, se preferir, para familiarizar-se com a sintaxe.
 
@@ -139,7 +140,8 @@ Se você quiser substituir a precedência do operador, poderá colocar parêntes
 
 Tente fazer e veja como fica.
 
-> **Nota:** Uma lista completa de todos os operadores JavaScript e suas precedências pode ser vista em [Expressões e operadores](/pt-BR/docs/Web/JavaScript/Guide/Expressions_and_Operators#Operator_precedence).
+> [!NOTE]
+> Uma lista completa de todos os operadores JavaScript e suas precedências pode ser vista em [Expressões e operadores](/pt-BR/docs/Web/JavaScript/Guide/Expressions_and_Operators#Operator_precedence).
 
 ## Operadores de incremento e decremento
 
@@ -149,7 +151,8 @@ Tente fazer e veja como fica.
 contagemPalpites++;
 ```
 
-> **Nota:** Eles são mais comumente usado em [Laços e iterações](/pt-BR/docs/Web/JavaScript/Guide/Lacos_e_iteracoes), que será visto no curso mais tarde. Por exemplo, digamos que você queira passar por uma lista de preços e adicionar imposto sobre vendas a cada um deles. Você usaria um loop para passar por cada valor e fazer o cálculo necessário para adicionar o imposto sobre vendas em cada caso. O incrementador é usado para mover para o próximo valor quando necessário. Na verdade, fornecemos um exemplo simples mostrando como isso é feito - [verifique ao vivo](https://mdn.github.io/learning-area/javascript/introduction-to-js-1/maths/loop.html) e observe o [código-fonte](https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/maths/loop.html) para ver se consegue identificar os incrementadores! Veremos os _loops_ detalhadamente mais adiante no curso.
+> [!NOTE]
+> Eles são mais comumente usado em [Laços e iterações](/pt-BR/docs/Web/JavaScript/Guide/Lacos_e_iteracoes), que será visto no curso mais tarde. Por exemplo, digamos que você queira passar por uma lista de preços e adicionar imposto sobre vendas a cada um deles. Você usaria um loop para passar por cada valor e fazer o cálculo necessário para adicionar o imposto sobre vendas em cada caso. O incrementador é usado para mover para o próximo valor quando necessário. Na verdade, fornecemos um exemplo simples mostrando como isso é feito - [verifique ao vivo](https://mdn.github.io/learning-area/javascript/introduction-to-js-1/maths/loop.html) e observe o [código-fonte](https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/maths/loop.html) para ver se consegue identificar os incrementadores! Veremos os _loops_ detalhadamente mais adiante no curso.
 
 Vamos tentar brincar com eles no seu console. Para começar, note que você não pode aplicá-las diretamente a um número, o que pode parecer estranho, mas estamos atribuindo a variável um novo valor atualizado, não operando no próprio valor. O seguinte retornará um erro:
 
@@ -178,7 +181,8 @@ num2--;
 num2;
 ```
 
-> **Nota:** Você pode fazer o navegador fazer o contrário - incrementar/decrementar a variável e depois retornar o valor, colocando o operador no início da variável ao invés do final. Tente os exemplos acima novamente, mas desta vez use `++num1` e `--num2`.
+> [!NOTE]
+> Você pode fazer o navegador fazer o contrário - incrementar/decrementar a variável e depois retornar o valor, colocando o operador no início da variável ao invés do final. Tente os exemplos acima novamente, mas desta vez use `++num1` e `--num2`.
 
 ## Operadores de atribuição
 
@@ -209,7 +213,8 @@ var y = 4; // y contém o valor 4
 x *= y; // x agora contém o valor 12
 ```
 
-> **Nota:** Existem muitos [outros operadores de atribuição disponíveis](/pt-BR/docs/Web/JavaScript/Guide/Expressions_and_Operators#operador_atribuicao), mas estes são os básicos que você deve aprender agora.
+> [!NOTE]
+> Existem muitos [outros operadores de atribuição disponíveis](/pt-BR/docs/Web/JavaScript/Guide/Expressions_and_Operators#operador_atribuicao), mas estes são os básicos que você deve aprender agora.
 
 ## Aprendizado ativo: dimensionando uma canvas box
 
@@ -243,7 +248,8 @@ Não se preocupe se você estragar totalmente o código. Você sempre pode press
 | <=       | Menor ou igual que    | Verifica se o valor da esquerda é menor que ou igual ao valor da direita.      | `3 <= 2`      |
 | >=       | Maior ou igual que    | Verifica se o valor da esquerda é maior que ou igual ao valor da direita.      | `5 >= 4`      |
 
-> **Nota:** Talvez você já tenha visto alguém usando `==` e`!=` afim de testar igualdade ou desigualdade em JavaScript. Estes são operadores válidos em JavaScript, mas que diferem de `===`/`!==`. As versões anteriores testam se os valores são os mesmos, mas não se os tipos de dados dos valores são os mesmos. As últimas versões estritas testam a igualdade de ambos os valores e seus tipos de dados. Elas tendem a resultar em menos erros, por isso recomendamos que você as use.
+> [!NOTE]
+> Talvez você já tenha visto alguém usando `==` e`!=` afim de testar igualdade ou desigualdade em JavaScript. Estes são operadores válidos em JavaScript, mas que diferem de `===`/`!==`. As versões anteriores testam se os valores são os mesmos, mas não se os tipos de dados dos valores são os mesmos. As últimas versões estritas testam a igualdade de ambos os valores e seus tipos de dados. Elas tendem a resultar em menos erros, por isso recomendamos que você as use.
 
 Se você tentar inserir alguns desses valores em um console, verá que todos eles retornam `true`/`false` — aqueles booleanos que mencionamos no último artigo. Eles são muito úteis, pois nos permitem tomar decisões em nosso código, e eles são usados toda vez que queremos fazer uma escolha de algum tipo. Por exemplo, booleanos podem ser usados para:
 
@@ -282,7 +288,8 @@ function updateBtn() {
 
 Você pode ver o operador de igualdade sendo usado apenas dentro da função `updateBtn()`. Neste caso, não estamos testando se duas expressões matemáticas têm o mesmo valor, estamos testando se o conteúdo de texto de um botão contém uma certa string , mas ainda é o mesmo princípio em funcionamento. Se o botão estiver dizendo "Iniciar máquina" quando for pressionado, mudaremos o rótulo para "Parar máquina" e atualizaremos o rótulo conforme apropriado. Se o botão estiver dizendo "Parar máquina" quando for pressionado, nós trocamos a tela de volta.
 
-> **Nota:** Esse controle que troca entre dois estados geralmente é chamado de **toggle**. Ele alterna entre um estado e outro - acender, apagar, etc.
+> [!NOTE]
+> Esse controle que troca entre dois estados geralmente é chamado de **toggle**. Ele alterna entre um estado e outro - acender, apagar, etc.
 
 ## Resumo
 
@@ -290,6 +297,7 @@ Neste artigo, cobrimos as informações fundamentais que você precisa saber sob
 
 No próximo artigo, vamos explorar o texto e como o JavaScript nos permite manipulá-lo.
 
-> **Nota:** Se você gosta de matemática e quer saber mais sobre como ela é implementada em JavaScriot, você pode encontrar muito mais detalhes na seção principal de JavaScript do MDN. Ótimos lugares para começar são os artigos [Números e datas](/pt-BR/docs/Web/JavaScript/Guide/Numeros_e_datas) e [Expressões e operadores](/pt-BR/docs/Web/JavaScript/Guide/Expressions_and_Operators) .
+> [!NOTE]
+> Se você gosta de matemática e quer saber mais sobre como ela é implementada em JavaScriot, você pode encontrar muito mais detalhes na seção principal de JavaScript do MDN. Ótimos lugares para começar são os artigos [Números e datas](/pt-BR/docs/Web/JavaScript/Guide/Numeros_e_datas) e [Expressões e operadores](/pt-BR/docs/Web/JavaScript/Guide/Expressions_and_Operators) .
 
 {{PreviousMenuNext("Learn/JavaScript/First_steps/Variables", "Learn/JavaScript/First_steps/Strings", "Learn/JavaScript/First_steps")}}

--- a/files/pt-br/learn/javascript/first_steps/strings/index.md
+++ b/files/pt-br/learn/javascript/first_steps/strings/index.md
@@ -240,7 +240,8 @@ Isto funciona bem. Você pode escapar outros caracteres do mesmo jeito, ex.: `\"
    response;
    ```
 
-> **Nota:** Quando você coloca uma string atual no seu código dentro de aspas simples ou duplas, é chamada uma **string literal**.
+> [!NOTE]
+> Quando você coloca uma string atual no seu código dentro de aspas simples ou duplas, é chamada uma **string literal**.
 
 ### Concatenação em contexto
 

--- a/files/pt-br/learn/javascript/first_steps/test_your_skills_colon__variables/index.md
+++ b/files/pt-br/learn/javascript/first_steps/test_your_skills_colon__variables/index.md
@@ -7,11 +7,13 @@ slug: Learn/JavaScript/First_steps/Test_your_skills:_variables
 
 O objetivo deste teste de habilidade é avaliar se você entendeu nosso artigo [Armazenando as informações que você precisa — Variáveis](/pt-BR/docs/Learn/JavaScript/First_steps/Vari%C3%A1veis).
 
-> **Nota:** Você pode experimentar soluções nos editores interativos abaixo. No entanto, pode ser útil fazer o download do código e usar uma ferramenta on-line como [CodePen](https://codepen.io/), [jsFiddle](https://jsfiddle.net/), ou [Glitch](https://glitch.com/) para realizar as tarefas.
+> [!NOTE]
+> Você pode experimentar soluções nos editores interativos abaixo. No entanto, pode ser útil fazer o download do código e usar uma ferramenta on-line como [CodePen](https://codepen.io/), [jsFiddle](https://jsfiddle.net/), ou [Glitch](https://glitch.com/) para realizar as tarefas.
 >
 > Se você travar, peça ajuda — veja a seção [Assessment or further help](#assessment_or_further_help) na parte inferior desta página.
 
-> **Nota:** Nos exemplos abaixo, se houver um erro no seu código, ele será exibido no painel de resultados da página, para ajudá-lo a tentar descobrir a resposta (ou no console JavaScript do navegador, no caso da versão para download).
+> [!NOTE]
+> Nos exemplos abaixo, se houver um erro no seu código, ele será exibido no painel de resultados da página, para ajudá-lo a tentar descobrir a resposta (ou no console JavaScript do navegador, no caso da versão para download).
 
 ## Variáveis 1
 

--- a/files/pt-br/learn/javascript/first_steps/useful_string_methods/index.md
+++ b/files/pt-br/learn/javascript/first_steps/useful_string_methods/index.md
@@ -214,7 +214,8 @@ browserType.slice(2);
 
 Isso retornará "zilla" — isso é porque a posição de caracter 2 é a letra z, e porque você não incluiu o segundo parametro, a substring retornou todos os caracteres restantes na string.
 
-> **Nota:** O segundo parametro do `slice()` é opcional: Se você não incluir ele, o slice finaliza no fim da string original. Existem outras opções também; estude a {{jsxref("String.prototype.slice()", "slice()")}} pagina para ver o que mais você pode descobrir.
+> [!NOTE]
+> O segundo parametro do `slice()` é opcional: Se você não incluir ele, o slice finaliza no fim da string original. Existem outras opções também; estude a {{jsxref("String.prototype.slice()", "slice()")}} pagina para ver o que mais você pode descobrir.
 
 ### Mudando entre maiúsculas e minúsculas
 
@@ -325,7 +326,8 @@ Neste exercício, temos os nomes das cidades no Reino Unido, mas a capitalizaç�
 3. Usando esta última variável como substring, substitua a primeira letra da string em minúsculas pela primeira letra da string em minúsculas alterada para maiúscula. Armazene o resultado desse procedimento de substituição em outra nova variável.
 4. Altere o valor da variável `result` para igual ao resultado final, não a `input`.
 
-> **Nota:** Uma dica — os parâmetros dos métodos de string não precisam ser literais de string; eles também podem ser variáveis, ou mesmo variáveis com um método sendo invocado nelas.
+> [!NOTE]
+> Uma dica — os parâmetros dos métodos de string não precisam ser literais de string; eles também podem ser variáveis, ou mesmo variáveis com um método sendo invocado nelas.
 
 ```html hidden
 <div class="output" style="min-height: 125px;">

--- a/files/pt-br/learn/javascript/first_steps/variables/index.md
+++ b/files/pt-br/learn/javascript/first_steps/variables/index.md
@@ -64,7 +64,8 @@ Variáveis simplesmente fazem sentido, e a medida que você for aprendendo mais 
 
 Outra coisa especial sobra as variáveis é que elas podem conter praticamente qualquer coisa — não apenas cadeias de texto e números. Variáveis também podem conter dados complexos e até mesmo funções completas para fazer coisas incríveis. Você irá aprender mais sobre isso a medida que continuarmos.
 
-> **Nota:** Perceba que dissemos que as variáveis contém valores. Essa é uma distinção importante a se fazer. Elas não são os valores; e sim os containers para eles. Você pode pensar nelas sendo pequenas caixas de papelão nas quais você pode guardar coisas..
+> [!NOTE]
+> Perceba que dissemos que as variáveis contém valores. Essa é uma distinção importante a se fazer. Elas não são os valores; e sim os containers para eles. Você pode pensar nelas sendo pequenas caixas de papelão nas quais você pode guardar coisas..
 
 ![](boxes.png)
 
@@ -79,7 +80,8 @@ var minhaIdade;
 
 Aqui, estamos criando duas variáveis chamadas `meuNome` e `minhaIdade`. Tente agora digitar essas linhas no console do seu navegador. Depois disso, tente criar uma variável (ou duas) com suas próprias escolhas de nomes.
 
-> **Nota:** No JavaScript, todas as intruções em código deve terminar com um ponto e vírgula (`;`) — seu código pode até funcionar sem o ponto e vírgula em linhas únicas, mas provavelmente não irá funcionar quando estiver escrevendo várias linhas de código juntas. Tente pegar o hábito de sempre incluir o ponto e vírgula.
+> [!NOTE]
+> No JavaScript, todas as intruções em código deve terminar com um ponto e vírgula (`;`) — seu código pode até funcionar sem o ponto e vírgula em linhas únicas, mas provavelmente não irá funcionar quando estiver escrevendo várias linhas de código juntas. Tente pegar o hábito de sempre incluir o ponto e vírgula.
 
 Você pode testar se os valores agora existem no ambiente de execução digitando apenas os nomes das variáveis, ex.:
 
@@ -94,7 +96,8 @@ Elas atualmente não possuem valor; são containers vazios. Quando você insere 
 scoobyDoo;
 ```
 
-> **Nota:** Não confunda uma variável que existe mas não tenho valor definido com uma variável que não existe — são coisas bem diferentes.
+> [!NOTE]
+> Não confunda uma variável que existe mas não tenho valor definido com uma variável que não existe — são coisas bem diferentes.
 
 ## Inicializando uma variável
 
@@ -142,7 +145,8 @@ logNome();
 var meuNome;
 ```
 
-> **Nota:** Isso não funcionará ao digitar linhas individuais em um console JavaScript, apenas ao executar várias linhas de JavaScript em um documento da web.
+> [!NOTE]
+> Isso não funcionará ao digitar linhas individuais em um console JavaScript, apenas ao executar várias linhas de JavaScript em um documento da web.
 
 Isso funciona por causa do **hoisting** — leia [var hoisting](/pt-BR/docs/Web/JavaScript/Reference/Statements/var#var_hoisting) pra mais detalhes.
 
@@ -194,7 +198,8 @@ Você pode chamar uma variável praticamente qualquer nome que queira, mas há l
 - As variáveis diferenciam letras maiúsculas e minúsculas — então `minhaidade` é uma variável diferente de `minhaIdade`.
 - Um último ponto — você também precisa evitar utilizar palavras reservadas pelo JavaScript como nome para suas variáveis — com isso, queremos dizer as palavras que fazem parte da sintaxe do JavaScript! Então você não pode usar palavras como `var`, `function`, `let` e `for` como nome de variáveis. Os navegadores vão reconhecê-las como itens de código diferentes e, portanto, você terá erros.
 
-> **Nota:** Você pode encontrar uma lista bem completa de palavras reservadas para evitar em [Gramática léxica — Palavras-chave](/pt-BR/docs/Web/JavaScript/Reference/Lexical_grammar#Palavras-chave).
+> [!NOTE]
+> Você pode encontrar uma lista bem completa de palavras reservadas para evitar em [Gramática léxica — Palavras-chave](/pt-BR/docs/Web/JavaScript/Reference/Lexical_grammar#Palavras-chave).
 
 Exemplos de bons nomes:
 

--- a/files/pt-br/learn/javascript/first_steps/what_is_javascript/index.md
+++ b/files/pt-br/learn/javascript/first_steps/what_is_javascript/index.md
@@ -107,14 +107,16 @@ Elas geralmente se dividem em duas categorias.
 - As APIs [Canvas](/pt-BR/docs/Web/API/Canvas_API) e [WebGL](/pt-BR/docs/Web/API/WebGL_API) permite a você criar gráficos 2D e 3D animados. Há pessoas fazendo algumas coisas fantásticas usando essas tecnologias web — veja [Chrome Experiments](https://www.chromeexperiments.com/webgl) e [webglsamples](https://webglsamples.org/).
 - [APIs de áudio e vídeo](/pt-BR/docs/Web/Guide/Audio_and_video_delivery) como {{domxref("HTMLMediaElement")}} e [WebRTC](/pt-BR/docs/Web/API/WebRTC_API) permitem a você fazer coisas realmente interessantes com multimídia, tanto tocar música e vídeo em uma página da web, como capturar vídeos com a sua câmera e exibir no computador de outra pessoa (veja [Snapshot demo](http://chrisdavidmills.github.io/snapshot/) para ter uma ideia).
 
-> **Nota:** Muitas demonstrações acima não vão funcionar em navegadores antigos — quando você for experimentar, é uma boa ideia usar browsers modernos como Firefox, Edge ou Opera para ver o código funcionar. Você vai precisar estudar [testes cross browser](/pt-BR/docs/Learn/Tools_and_testing/Cross_browser_testing) com mais detalhes quando você estiver chegando perto de produzir código (código real que as pessoas vão usar).
+> [!NOTE]
+> Muitas demonstrações acima não vão funcionar em navegadores antigos — quando você for experimentar, é uma boa ideia usar browsers modernos como Firefox, Edge ou Opera para ver o código funcionar. Você vai precisar estudar [testes cross browser](/pt-BR/docs/Learn/Tools_and_testing/Cross_browser_testing) com mais detalhes quando você estiver chegando perto de produzir código (código real que as pessoas vão usar).
 
 **APIs de terceiros** não estão implementados no navegador automaticamente, e você geralmente tem que pegar seu código e informações em algum lugar da Web. Por exemplo:
 
 - A [API do Twitter](https://dev.twitter.com/overview/documentation) permite a você fazer coisas como exibir seus últimos tweets no seu website.
 - A [API do Google Maps](https://developers.google.com/maps/) permite a você inserir mapas customizados no seu site e outras diversas funcionalidades.
 
-> **Nota:** Essas APIs são avançadas e nós não vamos falar sobre nenhuma delas nesse módulo. Você pode achar muito mais sobre elas em nosso módulo [APIs web no lado cliente](/pt-BR/docs/Learn/JavaScript/Client-side_web_APIs).
+> [!NOTE]
+> Essas APIs são avançadas e nós não vamos falar sobre nenhuma delas nesse módulo. Você pode achar muito mais sobre elas em nosso módulo [APIs web no lado cliente](/pt-BR/docs/Learn/JavaScript/Client-side_web_APIs).
 
 Tem muito mais coisas disponíveis! Contudo, não fique animado ainda. Você não estará pronto para desenvolver o próximo Facebook, Google Maps ou Instagram depois de estudar JavaScript por 24 horas — há um monte de coisas básicas para estudar primeiro. E é por isso que você está aqui — vamos começar!
 
@@ -132,7 +134,8 @@ Um uso muito comum do JavaScript é modificar dinamicamente HTML e CSS para atua
 
 Cada guia do navegador tem seu próprio espaço para executar código (esses espaços são chamados de "ambientes de execução", em termos técnicos) — isso significa que na maioria dos casos o código em cada guia está sendo executado separadamente, e o código em uma guia não pode afetar diretamente o código de outra guia — ou de outro website. Isso é uma boa medida de segurança — se esse não fosse o caso, então hackers poderiam começar a escrever código para roubar informações de outros websites, e fazer outras coisas más.
 
-> **Nota:** Há muitas maneiras de trocar código e conteúdo entre diferentes websites/guias de uma forma segura, mas são técnicas avançadas que não serão estudadas nesse curso.
+> [!NOTE]
+> Há muitas maneiras de trocar código e conteúdo entre diferentes websites/guias de uma forma segura, mas são técnicas avançadas que não serão estudadas nesse curso.
 
 ### Ordem de execução do JavaScript
 
@@ -153,7 +156,8 @@ Aqui nós estamos selecionando um parágrafo (linha 1) e anexando a ele um _even
 
 Se você inverte a ordem das duas primeiras linhas de código, ele não fucionaria — em vez disso, você receberia um erro no console do navegador — `TypeError: para is undefined`. Isso significa que o objeto `para` não existe ainda, então nós não podemos adicionar _um event listener_ a ele.
 
-> **Nota:** Esse é um erro muito comum — você precisa verificar se os objetos aos quais você se refere no seu código existem antes de você tentar anexar coisas a eles.
+> [!NOTE]
+> Esse é um erro muito comum — você precisa verificar se os objetos aos quais você se refere no seu código existem antes de você tentar anexar coisas a eles.
 
 ### Código interpretado x compilado
 
@@ -211,9 +215,11 @@ O JavaScript é inserido na sua página de uma maneira similar ao CSS. Enquanto 
 
 5. Salve seu arquivo e recarregue a página — agora você deveria ver que quando você clique no botão, um novo parágrafo é gerado e colocado logo abaixo.
 
-> **Nota:** Se seu exemplo não parece funcionar, leia cada passo novamente e confira que você fez tudo certo. Você salvou sua cópia local do código inicial como um arquivo .html? Você adicionou o elemento {{htmlelement("script")}} imediatamente antes da tag `</body>`? Você digitou o código JavaScript exatamente como ele está sendo mostrado? **JavaScript é uma linguagem case sensitive (isso significa que a linguagem vê diferença entre letras maiúsculas e minúsculas) e muito confusa, então você precisa digitar a sintaxe exatamente como foi mostrada, senão não vai funcionar.**
+> [!NOTE]
+> Se seu exemplo não parece funcionar, leia cada passo novamente e confira que você fez tudo certo. Você salvou sua cópia local do código inicial como um arquivo .html? Você adicionou o elemento {{htmlelement("script")}} imediatamente antes da tag `</body>`? Você digitou o código JavaScript exatamente como ele está sendo mostrado? **JavaScript é uma linguagem case sensitive (isso significa que a linguagem vê diferença entre letras maiúsculas e minúsculas) e muito confusa, então você precisa digitar a sintaxe exatamente como foi mostrada, senão não vai funcionar.**
 
-> **Nota:** Você pode ver essa versão no GitHub como [apicando-javascript-interno.html](https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/what-is-js/apply-javascript-internal.html) ([veja funcionar também](https://mdn.github.io/learning-area/javascript/introduction-to-js-1/what-is-js/apply-javascript-internal.html)).
+> [!NOTE]
+> Você pode ver essa versão no GitHub como [apicando-javascript-interno.html](https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/what-is-js/apply-javascript-internal.html) ([veja funcionar também](https://mdn.github.io/learning-area/javascript/introduction-to-js-1/what-is-js/apply-javascript-internal.html)).
 
 ### JavaScript externo
 
@@ -244,7 +250,8 @@ Isso funciona muito bem, mas e se nós quiséssemos colocar nosso JavaScript em 
 
 4. Salve e atualize seu navegador, e você deverá ver a mesma coisa! Funciona igualmente, mas agora nós temos o JavaScript em um arquivo externo. Isso é geralmente uma coisa boa em termos de organização de código, e faz com que seja possível reutilizar o código em múltiplos arquivos HTML. Além disso, o HTML fica mais legível sem grandes pedaços de script no meio dele.
 
-> **Nota:** Você pode ver essa versão no GitHub como [aplicando-javascript-externo.html](https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/what-is-js/apply-javascript-external.html) e [script.js](https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/what-is-js/script.js) ([veja funcionar também](https://mdn.github.io/learning-area/javascript/introduction-to-js-1/what-is-js/apply-javascript-external.html)).
+> [!NOTE]
+> Você pode ver essa versão no GitHub como [aplicando-javascript-externo.html](https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/what-is-js/apply-javascript-external.html) e [script.js](https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/what-is-js/script.js) ([veja funcionar também](https://mdn.github.io/learning-area/javascript/introduction-to-js-1/what-is-js/apply-javascript-external.html)).
 
 ### Manipuladores de JavaScript inline
 
@@ -282,7 +289,8 @@ for (var i = 0; i < botoes.length; i++) {
 
 Isso talvez parece ser mais do que o atributo `onclick`, mas isso vai funcionar para todos os botões, não importa quantos tem na página, e quantos forem adicionados ou removidos. O JavaScript não precisará ser mudado.
 
-> **Nota:** Tente editar a sua versão do arquivo `aplicar-javascript.html`, adicionando alguns botões a mais. Quando você recarregar, você deverá ver que todos os botões, quando clicados, irão criar parágrafos. Agradável, não?
+> [!NOTE]
+> Tente editar a sua versão do arquivo `aplicar-javascript.html`, adicionando alguns botões a mais. Quando você recarregar, você deverá ver que todos os botões, quando clicados, irão criar parágrafos. Agradável, não?
 
 ### Estratégias para o carregamento de scripts
 
@@ -308,7 +316,8 @@ No exemplo externo, nós usamos um recurso moderno do JavaScript para resolver e
 
 Neste caso, ambos script e HTML irão carregar de forma simultânea e o código irá funcionar.
 
-> **Nota:** No caso externo, nós não precisamos utilizar o evento `DOMContentLoaded` porque o atributo `defer` resolve o nosso problema. Nós não utilizamos `defer` como solução para os exemplos internos pois `defer` funciona apenas com scripts externos.
+> [!NOTE]
+> No caso externo, nós não precisamos utilizar o evento `DOMContentLoaded` porque o atributo `defer` resolve o nosso problema. Nós não utilizamos `defer` como solução para os exemplos internos pois `defer` funciona apenas com scripts externos.
 
 Uma solução à moda antiga para esse problema era colocar o elemento script bem no final do body da página (antes da tag `</body>)`. Com isso, os scripts iriam carregar logo após todo o conteúdo HTML. O problema com esse tipo de solução é que o carregamento/renderização do script seria completamente bloqueado até que todo o conteúdo HTML fosse analisado. Em sites de maior escala, com muitos scripts, essa solução causaria um grande problema de performance e deixaria o site lento.
 
@@ -394,7 +403,8 @@ for (var i = 0; i < botoes.length; i++) {
 }
 ```
 
-> **Nota:** Em geral mais comentários são melhores que menos, porém você deve tomar cuidado para não adicionar comentários de mais tentando explicar o que uma variável é (o nome da sua variável deve ser mais intuitivo), ou tentando explicar uma operação simples (talvez seu código seja muito complicado denecessariamente).
+> [!NOTE]
+> Em geral mais comentários são melhores que menos, porém você deve tomar cuidado para não adicionar comentários de mais tentando explicar o que uma variável é (o nome da sua variável deve ser mais intuitivo), ou tentando explicar uma operação simples (talvez seu código seja muito complicado denecessariamente).
 
 ## Sumário
 

--- a/files/pt-br/learn/javascript/first_steps/what_went_wrong/index.md
+++ b/files/pt-br/learn/javascript/first_steps/what_went_wrong/index.md
@@ -71,7 +71,8 @@ Anteriormente no curso, nós fizemos você digitar alguns comandos simples de Ja
 4. O erro diz o seguinte "envioPalpite.addeventListener is not a function", que significa envioPalpite.addeventListener não é uma funçao. Então provavelmente digitamos algo errado. Se você não estiver certo da digitação correta de parte da sintaxe, é uma boa ideia procurar a funcionalidade no MDN docs. A melhor forma de fazer isso atualmente é pesquisar por "mdn _nome-da-funcionalidade_" em seu mecanismo de buscas favorito. Aqui está um atalho para te salvar algum tempo nesse caso: [`addEventListener()`](/pt-BR/docs/Web/API/Element/addEventListener).
 5. Então, olhando nessa essa página, o erro parece ser termos digitado o nome da função errado! Lembre-se de que o JavaScript diferencia letras maiúsculas de minúsculas, então qualquer diferença na digitação ou no uso de letras maiúsculas irá causar um erro. Alterar `addeventListener` para `addEventListener` deverá corrigir esse erro. Faça essa alteração no código do seu arquivo.
 
-> **Nota:** Veja nossa página de referência [TypeError: "x" is not a function](/pt-BR/docs/Web/JavaScript/Reference/Errors/Not_a_function) para mais detalhes sobre esse erro.
+> [!NOTE]
+> Veja nossa página de referência [TypeError: "x" is not a function](/pt-BR/docs/Web/JavaScript/Reference/Errors/Not_a_function) para mais detalhes sobre esse erro.
 
 ### Erros de sintaxe - segundo round
 
@@ -82,7 +83,8 @@ Anteriormente no curso, nós fizemos você digitar alguns comandos simples de Ja
 
    > **Nota:** [`Null`](/pt-BR/docs/Glossary/Null) é um valor especial que significa "nada", ou "sem valor". Então `baixoOuAlto` foi declarado e inicializado, mas não com algum valor significativo — não possui nenhum caractere ou valor.
 
-   > **Nota:** Esse erro não apareceu assim que a página foi carregada porque esse erro ocorreu dentro de uma função (dentro do bloco `conferirPalpite() { ... }` ). Como você irá aprender com mais detalhes no nosso artigo de funções mais tarde, o código localizado dentro de funções roda em um escopo separado do código presente fora das funções. Nesse caso, o código não estava rodando e o erro não estava aparecendo até a função `conferirPalpite()` ser executada na linha 86.
+   > [!NOTE]
+   > Esse erro não apareceu assim que a página foi carregada porque esse erro ocorreu dentro de uma função (dentro do bloco `conferirPalpite() { ... }` ). Como você irá aprender com mais detalhes no nosso artigo de funções mais tarde, o código localizado dentro de funções roda em um escopo separado do código presente fora das funções. Nesse caso, o código não estava rodando e o erro não estava aparecendo até a função `conferirPalpite()` ser executada na linha 86.
 
 4. Dê uma olhada na linha 78, e você verá o seguinte código:
 
@@ -116,7 +118,8 @@ Anteriormente no curso, nós fizemos você digitar alguns comandos simples de Ja
 9. Então nós precisamos de um seletor de classe aqui, que começa com um ponto (.), mas o seletor passado pelo método `querySelector()` na linha 48 não tem o ponto. Esse pode ser o problema! Tente mudar `baixoOuAlto` para `.baixoOuAlto` na linha 48.
 10. Tente salvar o arquivo e atualizá-lo no navegador de novo, e a sua declaração `console.log()` deverá retornar o elemento `<p>` que queremos. Ufa! Outro erro resolvido! Você pode deletar a linha do seu `console.log()` agora, ou mantê-la para referência posterior — a escolha é sua.
 
-> **Nota:** Veja nossa página de referência [TypeError: "x" is (not) "y"](/pt-BR/docs/Web/JavaScript/Reference/Errors/Unexpected_type) para mais detalhes sobre esse erro.
+> [!NOTE]
+> Veja nossa página de referência [TypeError: "x" is (not) "y"](/pt-BR/docs/Web/JavaScript/Reference/Errors/Unexpected_type) para mais detalhes sobre esse erro.
 
 ### Erros de sintaxe - terceiro round
 
@@ -198,7 +201,8 @@ var palpiteUsuario === Number(campoPalpite.value);
 
 Exibe esse erro porque pensa que você está fazendo algo diferente. Você deve se certificar de não misturar o operador de atribuição (`=`) — que configura uma variável para ser igual a determinado valor — com o operador de igualdade restrita (`===`), que testa se um valor é exatamente igual a outro, e retorna um resultado `true`/`false` (verdadeiro ou falso).
 
-> **Nota:** Veja nossa página de referência [SyntaxError: missing ; before statement](/pt-BR/docs/Web/JavaScript/Reference/Errors/Missing_semicolon_before_statement) para mais detalhes sobre esse erro.
+> [!NOTE]
+> Veja nossa página de referência [SyntaxError: missing ; before statement](/pt-BR/docs/Web/JavaScript/Reference/Errors/Missing_semicolon_before_statement) para mais detalhes sobre esse erro.
 
 ### O programa sempre diz que você ganhou, independentemente do palpite que insira
 
@@ -220,7 +224,8 @@ o teste retornaria sempre `true` (verdadeiro), causando o programa a reportar qu
 
 Erro de sintaxe: faltando ")" depois de listar uma declaração. Esse é bem simples — geralmente significa que deixamos de fechar o parênteses no final ao invocar uma função/método.
 
-> **Nota:** Veja nossa página de referência [SyntaxError: missing ) after argument list](/pt-BR/docs/Web/JavaScript/Reference/Errors/Missing_parenthesis_after_argument_list) para mais detalhes sobre o erro.
+> [!NOTE]
+> Veja nossa página de referência [SyntaxError: missing ) after argument list](/pt-BR/docs/Web/JavaScript/Reference/Errors/Missing_parenthesis_after_argument_list) para mais detalhes sobre o erro.
 
 ### _SyntaxError: missing : after property id_
 
@@ -248,7 +253,8 @@ Erro de sintaxe: esperado uma expressão, obtido uma 'string' e Erro de sintaxe:
 
 Para todos esses erros, pense em como nós abordamos os exemplos em que olhamos no passo a passo. Quando um erro surge, olha o número da linha que é informado, vá até essa linha e veja se consegue localizar o que há de errado. Mantenha em mente que o erro não estará necessariamente nessa linha, e também que o erro pode não ter sido causado exatamente pelo mesmo problema que citamos acima!
 
-> **Nota:** Veja nossas páginas de referência [SyntaxError: Unexpected token](/pt-BR/docs/Web/JavaScript/Reference/Errors/Unexpected_token) e [SyntaxError: unterminated string literal](/pt-BR/docs/Web/JavaScript/Reference/Errors/Unterminated_string_literal) para mais detalhes sobre esses erros.
+> [!NOTE]
+> Veja nossas páginas de referência [SyntaxError: Unexpected token](/pt-BR/docs/Web/JavaScript/Reference/Errors/Unexpected_token) e [SyntaxError: unterminated string literal](/pt-BR/docs/Web/JavaScript/Reference/Errors/Unterminated_string_literal) para mais detalhes sobre esses erros.
 
 ## Sumário
 

--- a/files/pt-br/learn/javascript/objects/basics/index.md
+++ b/files/pt-br/learn/javascript/objects/basics/index.md
@@ -91,7 +91,8 @@ pessoa.saudacao();
 
 Agora você tem alguns dados e funcionalidades dentro de seu objeto e é capaz de acessá-los com uma sintaxe simples e agradável!
 
-> **Nota:** Se você está tendo problemas para fazer isto funcionar, tente comparar seu código com a nossa versão — veja [oojs-finished.html](https://github.com/mdn/learning-area/blob/master/javascript/oojs/introduction/oojs-finished.html) (ou [veja um exemplo funcionando](http://mdn.github.io/learning-area/javascript/oojs/introduction/oojs-finished.html)). O exemplo lhe dará uma tela em branco, mas tudo bem — novamente, abra seu devtools e tente digitar os comandos acima para ver a estrutura do objeto.
+> [!NOTE]
+> Se você está tendo problemas para fazer isto funcionar, tente comparar seu código com a nossa versão — veja [oojs-finished.html](https://github.com/mdn/learning-area/blob/master/javascript/oojs/introduction/oojs-finished.html) (ou [veja um exemplo funcionando](http://mdn.github.io/learning-area/javascript/oojs/introduction/oojs-finished.html)). O exemplo lhe dará uma tela em branco, mas tudo bem — novamente, abra seu devtools e tente digitar os comandos acima para ver a estrutura do objeto.
 
 Então, o que está acontecendo? Bem, um objeto é composto de vários membros, cada um com um nome (ex.: `nome` e `idade` vistos acima), e um valor (ex.: `['Bob', 'Smith']` e `32`). Cada par nome/valor deve ser separado por uma vírgula e o nome e valor, em cada caso, separados por dois pontos. A sintaxe sempre segue esse padrão:
 
@@ -301,7 +302,8 @@ var minhaNotificacao = new Notification("Hello!");
 
 Novamente, olharemos constructores num artigo mais na frente.
 
-> **Nota:** É útil pensar sobre como os objetos se comunicam **passando mensagens** - quando um objeto precisa de outro objeto para realizar algum tipo de ação, ele freqüentemente enviará uma mensagem para outro objeto através de um de seus métodos e aguardará uma resposta, que reconhecemos como um valor de retorno.
+> [!NOTE]
+> É útil pensar sobre como os objetos se comunicam **passando mensagens** - quando um objeto precisa de outro objeto para realizar algum tipo de ação, ele freqüentemente enviará uma mensagem para outro objeto através de um de seus métodos e aguardará uma resposta, que reconhecemos como um valor de retorno.
 
 ## Teste suas habilidades !
 


### PR DESCRIPTION
This PR converts the noteblocks for the Portugese Brazilian locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 1. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.

Note: the CI failure is due to existing flaws and is not related to the changes made in this PR.
