### PR TITLE
pt-br: Convert noteblocks to GFM Alerts (part 4)

### DIFF
--- a/files/pt-br/web/css/_colon_hover/index.md
+++ b/files/pt-br/web/css/_colon_hover/index.md
@@ -13,7 +13,8 @@ A pseudo-class `:hover` pode ser aplicada a qualquer [pseudo-elemento.](/pt-BR/d
 
 User agents visuais como Firefox, Internet Explorer, Safari, Opera ou Chrome, aplicam o estilo associado quando o cursor(mouse pointer) passa sobre um elemento.
 
-> **Nota:** Em telas de toque (touch screens) :hover é impossível ou problemático. Dependendo do navegador a pseudo-classe :hover pode nunca funcionar, ou funcionar apenas por um curto momento depois de "tocar" um elemento, ou podem continuar a funcionar mesmo depois que o usuário pare de "tocar" o elemento até que o usuário toque outro elemento. Como dispositivos touchscreen são comuns, é importante para desenvolvedores web não terem conteúdos acessíveis apenas quando passamos sobre ele, uma vez que esse conteúdo é mais complicado ou impossível de acessar para usuários desses dispositivos.
+> [!NOTE]
+> Em telas de toque (touch screens) :hover é impossível ou problemático. Dependendo do navegador a pseudo-classe :hover pode nunca funcionar, ou funcionar apenas por um curto momento depois de "tocar" um elemento, ou podem continuar a funcionar mesmo depois que o usuário pare de "tocar" o elemento até que o usuário toque outro elemento. Como dispositivos touchscreen são comuns, é importante para desenvolvedores web não terem conteúdos acessíveis apenas quando passamos sobre ele, uma vez que esse conteúdo é mais complicado ou impossível de acessar para usuários desses dispositivos.
 
 ## Exemplos
 
@@ -79,7 +80,8 @@ Veja nosso [exemplo de menu dropdown baseado em CSS](css_dropdown_menu.html) par
 
 Você pode usar a pseudo-classe `:hover` para construir uma galeria de imagem, exibindo imagens full-size apenas quando o mouse passa sobre as imagens. Veja [esse exemplo](css-gallery.zip) para uma possível dica.
 
-> **Nota:** Para efeitos análogos, mas baseado na pseudo-classe [`:checked`](/pt-BR/CSS/%3Achecked) (aplicada para esconder radioboxes), veja [esse demo](css-checked-gallery.zip), tirado desta página [En/CSS/:checked.](/pt-BR/CSS/%3Achecked)
+> [!NOTE]
+> Para efeitos análogos, mas baseado na pseudo-classe [`:checked`](/pt-BR/CSS/%3Achecked) (aplicada para esconder radioboxes), veja [esse demo](css-checked-gallery.zip), tirado desta página [En/CSS/:checked.](/pt-BR/CSS/%3Achecked)
 
 ## Especificações
 

--- a/files/pt-br/web/css/_colon_optional/index.md
+++ b/files/pt-br/web/css/_colon_optional/index.md
@@ -16,7 +16,8 @@ input:optional {
 
 Esta pseudo-classe é utilizada para estilizar campos do formulário que não são requeridos para sumissão.
 
-> **Nota:** A pseudo-classe {{cssxref(":required")}} seleciona campos do fumulário _requeridos_.
+> [!NOTE]
+> A pseudo-classe {{cssxref(":required")}} seleciona campos do fumulário _requeridos_.
 
 ## Sintaxe
 

--- a/files/pt-br/web/css/_colon_out-of-range/index.md
+++ b/files/pt-br/web/css/_colon_out-of-range/index.md
@@ -17,7 +17,8 @@ input:out-of-range {
 
 Essa pseudo classe é muito útil por dar ao usuario uma indicacão visual de que o valor atual esta fora dos limites permitidos
 
-> **Nota:** Esta pseudo classe se aplica somente a elementos que tem (ou podem ter) uma limitacao. Na falta dessa de algo como essa limitacao, o elemento nao tera como ficar "in-range"(dentro dos limites) ou "out-of-range" (fora dos limites).
+> [!NOTE]
+> Esta pseudo classe se aplica somente a elementos que tem (ou podem ter) uma limitacao. Na falta dessa de algo como essa limitacao, o elemento nao tera como ficar "in-range"(dentro dos limites) ou "out-of-range" (fora dos limites).
 
 ## Sintaxe
 

--- a/files/pt-br/web/css/_colon_required/index.md
+++ b/files/pt-br/web/css/_colon_required/index.md
@@ -16,7 +16,8 @@ input:required {
 
 Esta pseudo-classe é utilizada para destacar campos que devem ter dados válidos antes do formulário ser submetido.
 
-> **Nota:** A pseudo-classe {{cssxref(":optional")}} seleciona campos do formulário que são _opcionais_.
+> [!NOTE]
+> A pseudo-classe {{cssxref(":optional")}} seleciona campos do formulário que são _opcionais_.
 
 ## Sintaxe
 

--- a/files/pt-br/web/css/_colon_target/index.md
+++ b/files/pt-br/web/css/_colon_target/index.md
@@ -90,7 +90,8 @@ p:target i {
 
 Você pode usar a pseudo-classe `:target` para criar uma lightbox sem usar JavaScript. Essa técnica requer que os links apontem para os elementos que inicialmente estavam escondidas na página. Uma vez designado, o CSS muda o `display` então, assim o conteúdo pode ser mostrado.
 
-> **Nota:** Uma lightbox com CSS puro mais completo usando a pseudo-classe `:target` [está disponível no GitHub](https://github.com/madmurphy/takefive.css/) ([demo](https://madmurphy.github.io/takefive.css/)).
+> [!NOTE]
+> Uma lightbox com CSS puro mais completo usando a pseudo-classe `:target` [está disponível no GitHub](https://github.com/madmurphy/takefive.css/) ([demo](https://madmurphy.github.io/takefive.css/)).
 
 #### HTML
 

--- a/files/pt-br/web/css/_colon_visited/index.md
+++ b/files/pt-br/web/css/_colon_visited/index.md
@@ -36,7 +36,8 @@ Por razões de privacidade, navegadores limitam estritamente quais estilos você
 - Os componentes alpha permitidos de estilos seram ignorados. Ao invés disso, o componente alpha do elemento de estado non-`:visited` será usado, exceto quando o componente é `0`, no qual o estilo definido em `:visited` será inteiramente ignorado.
 - Embora esses estilos podem mudar como as cores serão mostradas ao usuário, o método {{domxref("window.getComputedStyle")}} vai mentir e sempre retornar o valor da cor em non-`:visited.`
 
-> **Nota:** Para mais informações quanto a essas limitações e as razões por trás delas, veja [Privacy and the :visited selector](/pt-BR/docs/CSS/Privacy_and_the_:visited_selector). Obs: No momento estará apenas disponível em inglês.
+> [!NOTE]
+> Para mais informações quanto a essas limitações e as razões por trás delas, veja [Privacy and the :visited selector](/pt-BR/docs/CSS/Privacy_and_the_:visited_selector). Obs: No momento estará apenas disponível em inglês.
 
 ## Syntaxe
 

--- a/files/pt-br/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/pt-br/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/::-webkit-scrollbar
 
 O pseudo-elemento CSS `:-webkit-scrollbar` afeta o estilo de um elemento referente a barra de rolagem quando se tem por definido `overflow:scroll;`.
 
-> **Nota:** Se o `overflow:scroll;` não estiver definido nenhuma barra de rolagem será exibida.
+> [!NOTE]
+> Se o `overflow:scroll;` não estiver definido nenhuma barra de rolagem será exibida.
 
 > **Nota:** `::-webkit-scrollbar` está disponível somente em navegadores baseados em [Blink](https://www.chromium.org/blink) - e [WebKit](https://webkit.org) - (Chrome, Edge, Opera, Safari, todos os navegadores para iOS, e [outros](https://en.wikipedia.org/wiki/List_of_web_browsers#WebKit-based)). Um método padronizado para estilização de barras de rolagem está disponível com {{cssxref("scrollbar-color")}} e {{cssxref("scrollbar-width")}}.
 

--- a/files/pt-br/web/css/_doublecolon_after/index.md
+++ b/files/pt-br/web/css/_doublecolon_after/index.md
@@ -18,7 +18,8 @@ a::after {
 
 {{csssyntax}}
 
-> **Nota:** O CSS3 introduziu a notação `::after` (com dois sinais de dois pontos) para distinguir [pseudo-classes](/pt-BR/docs/Web/CSS/Pseudo-classes) dos [pseudo-elementos](/pt-BR/docs/Web/CSS/Pseudo-elements). Os navegadores também aceitam `:after`, introduzido no CSS2.
+> [!NOTE]
+> O CSS3 introduziu a notação `::after` (com dois sinais de dois pontos) para distinguir [pseudo-classes](/pt-BR/docs/Web/CSS/Pseudo-classes) dos [pseudo-elementos](/pt-BR/docs/Web/CSS/Pseudo-elements). Os navegadores também aceitam `:after`, introduzido no CSS2.
 
 ## Exemplos
 

--- a/files/pt-br/web/css/_doublecolon_backdrop/index.md
+++ b/files/pt-br/web/css/_doublecolon_backdrop/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/::backdrop
 
 Cada elemento na [camada superior](https://fullscreen.spec.whatwg.org/#top-layer) de uma pilha de elementos possui um {{Cssxref("pseudo-elementos", "pseudo-elemento")}} _`::backdrop`_. Esse pseudo-elemento é uma caixa renderizada imediatamente abaixo do elemento superior (e acima do elemento logo abaixo desse elemento, caso exista algum), dentro da camada superior.
 
-> **Nota:** O pseudo-elemento `::backdrop` pode ser utilizado para criar um pano de fundo que esconde o conteúdo por trás de um elemento posicionado no topo de uma pilha de elementos. Por exemplo, para o elemento que é mostrado em tela cheia conforme descrito nessa especificação.
+> [!NOTE]
+> O pseudo-elemento `::backdrop` pode ser utilizado para criar um pano de fundo que esconde o conteúdo por trás de um elemento posicionado no topo de uma pilha de elementos. Por exemplo, para o elemento que é mostrado em tela cheia conforme descrito nessa especificação.
 
 Ele não herda de nenhum elemento e também não é herdado. Não há restrição de propriedades que podem ser aplicadas a esse pseudo-elemento.
 

--- a/files/pt-br/web/css/_doublecolon_first-letter/index.md
+++ b/files/pt-br/web/css/_doublecolon_first-letter/index.md
@@ -29,7 +29,8 @@ Somente um pequeno subconjunto de todas as propriedades CSS pode ser usado dentr
 
 Como toda essa lista será estendida no futuro, é recomendado que você não use qualquer propriedade dentro da declaração do bloco, afim de manter o CSS a qualquer prova.
 
-> **Nota:** No CSS 2, os pseudoelementos eram prefixados com um caractere de dois pontos (`:`). Como as pseudo-classes também estavam seguindo a mesma convenção, elas eram indistinguíveis. Para resolver isso, o CSS 2.1 mudou a convenção para pseudoelementos. Agora, um pseudoelemento é prefixado com dois caracteres de dois pontos (`::`) e uma pseudo-classe ainda é prefixado com um único dois pontos (`:`).
+> [!NOTE]
+> No CSS 2, os pseudoelementos eram prefixados com um caractere de dois pontos (`:`). Como as pseudo-classes também estavam seguindo a mesma convenção, elas eram indistinguíveis. Para resolver isso, o CSS 2.1 mudou a convenção para pseudoelementos. Agora, um pseudoelemento é prefixado com dois caracteres de dois pontos (`::`) e uma pseudo-classe ainda é prefixado com um único dois pontos (`:`).
 >
 > Exemplo de **pseudoclasse**:
 > `.classedoelemento:hover { ... }`
@@ -38,7 +39,8 @@ Como toda essa lista será estendida no futuro, é recomendado que você não us
 >
 > Como vários navegadores já implementaram a versão CSS 2 em uma versão de lançamento, todos os navegadores que suportam a sintaxe de dois pontos também suportam a antiga sintaxe de dois pontos.
 >
-> > **Aviso:** Mas isso pode mudar, portanto use SEMPRE `::` para pseudolementos
+> > [!WARNING]
+> > Mas isso pode mudar, portanto use SEMPRE `::` para pseudolementos
 > >
 > > ...a não se que você **precise muito** que seu código seja compatível com Internet Explore 8, então use um carectere de dois pontos.
 

--- a/files/pt-br/web/css/_doublecolon_first-line/index.md
+++ b/files/pt-br/web/css/_doublecolon_first-line/index.md
@@ -14,7 +14,8 @@ p::first-line {
 }
 ```
 
-> **Nota:** O CSS3 introduziu a notação `::first-line`(com dois pontos) para distinguir pseudo-classes de pseudo-elementos. Os navegadores também aceitam `:first-line` introduzida no CSS2.
+> [!NOTE]
+> O CSS3 introduziu a notação `::first-line`(com dois pontos) para distinguir pseudo-classes de pseudo-elementos. Os navegadores também aceitam `:first-line` introduzida no CSS2.
 
 ## Propriedades permitidas
 

--- a/files/pt-br/web/css/_doublecolon_selection/index.md
+++ b/files/pt-br/web/css/_doublecolon_selection/index.md
@@ -26,7 +26,8 @@ Apenas certas propriedades podem ser usadas com o `::selection`:
 - {{CSSxRef("text-emphasis-color")}}
 - {{CSSxRef("text-shadow")}}
 
-> **Warning:** Em particular, {{CSSxRef("background-image")}} é ignorada.
+> [!WARNING]
+> Em particular, {{CSSxRef("background-image")}} é ignorada.
 
 ## Sintaxe
 

--- a/files/pt-br/web/css/animation-delay/index.md
+++ b/files/pt-br/web/css/animation-delay/index.md
@@ -33,7 +33,8 @@ Muitas vezes é conveniente usar a propriedade abreviada {{cssxref("animation")}
 
     Um valor negativo faz com que a animação comece imediatamente, mas parcialmente através do seu ciclo. Por exemplo, se você específicar `-1s` como tempo da animation-delay , a animação vai começar imediatamente, mas começará 1 segundo na sequência de animação. Se você específicar um valor negativo para a animation-delay, mas o valor inicial é implícito, o valor inicial é retirado do momento em que a animação é aplicada ao elemento.
 
-> **Nota:** Quando você especifica vários valores separados por vírgula em uma propriedade `animation-*` , eles serão atribuídos às animações especificadas na propriedade {{cssxref("animation-name")}} em diferentes modos, dependendo de quantos existam. Para mais informações veja [Setting multiple animation property values](/pt-BR/docs/Web/CSS/CSS_Animations/Using_CSS_animations#Setting_multiple_animation_property_values).
+> [!NOTE]
+> Quando você especifica vários valores separados por vírgula em uma propriedade `animation-*` , eles serão atribuídos às animações especificadas na propriedade {{cssxref("animation-name")}} em diferentes modos, dependendo de quantos existam. Para mais informações veja [Setting multiple animation property values](/pt-BR/docs/Web/CSS/CSS_Animations/Using_CSS_animations#Setting_multiple_animation_property_values).
 
 ### Sintaxe formal
 

--- a/files/pt-br/web/css/animation/index.md
+++ b/files/pt-br/web/css/animation/index.md
@@ -99,7 +99,8 @@ Considere fornecer um mecanismo para pausar ou desabilitar a animação, bem com
 
 ## Exemplos
 
-> **Nota:** A animação das propriedades do [CSS Box Model](/pt-BR/docs/Web/CSS/CSS_Box_Model) não é recomendada. A animação de qualquer propriedade de box model é inerentemente para a CPU; considere animar a propriedade [transform](/pt-BR/docs/Web/CSS/transform).
+> [!NOTE]
+> A animação das propriedades do [CSS Box Model](/pt-BR/docs/Web/CSS/CSS_Box_Model) não é recomendada. A animação de qualquer propriedade de box model é inerentemente para a CPU; considere animar a propriedade [transform](/pt-BR/docs/Web/CSS/transform).
 
 ### Nascer do Sol
 

--- a/files/pt-br/web/css/attr/index.md
+++ b/files/pt-br/web/css/attr/index.md
@@ -24,7 +24,8 @@ attr(data-width px, inherit);
 attr(data-something, 'default');
 ```
 
-> **Nota:** A função `attr()` pode ser utilizada com qualquer propriedade CSS, mas o suporte para propriedades que não sejam {{cssxref("content")}} é experimental.
+> [!NOTE]
+> A função `attr()` pode ser utilizada com qualquer propriedade CSS, mas o suporte para propriedades que não sejam {{cssxref("content")}} é experimental.
 
 ## Sintaxe
 

--- a/files/pt-br/web/css/background-origin/index.md
+++ b/files/pt-br/web/css/background-origin/index.md
@@ -11,7 +11,8 @@ A propriedade [CSS](/pt-BR/docs/Web/CSS) **`background-origin`** define _a área
 
 Note que `background-origin` é ignorado quando {{cssxref("background-attachment")}} é `fixed`.
 
-> **Nota:** A taquigrafia {{cssxref("background")}} redefine o valor desta propriedade para seu valor inicial se esta não foi específicada.
+> [!NOTE]
+> A taquigrafia {{cssxref("background")}} redefine o valor desta propriedade para seu valor inicial se esta não foi específicada.
 
 ## Sintaxe
 

--- a/files/pt-br/web/css/background-size/index.md
+++ b/files/pt-br/web/css/background-size/index.md
@@ -85,7 +85,8 @@ Esses atributos são os seguintes:
 - O {{cssxref("&lt;gradient&gt;")}} do CSS não têm dimensões intrínsecas ou proporções intrínsecas.
 - Imagens de plano de fundo criados com a função {{cssxref("element", "element()")}} usam as dimensões e proporções intrínsecas do elemento gerador.
 
-> **Nota:** No Gecko, imagens de fundo criadas usando a função [`elemen()`](/pt-BR/docs/Web/CSS/element) são atualmente tratadas como imagens com as dimensões do elemento, ou da área de posicionamento do fundo se o elemento é SVG, com a proporção intrínseca correspondente. Este é um comportamento fora do padrão.
+> [!NOTE]
+> No Gecko, imagens de fundo criadas usando a função [`elemen()`](/pt-BR/docs/Web/CSS/element) são atualmente tratadas como imagens com as dimensões do elemento, ou da área de posicionamento do fundo se o elemento é SVG, com a proporção intrínseca correspondente. Este é um comportamento fora do padrão.
 
 Com base nas dimensões e proporções intrínsecas, o tamanho renderizado da imagem de fundo é calculado da seguinte forma:
 
@@ -101,7 +102,8 @@ Com base nas dimensões e proporções intrínsecas, o tamanho renderizado da im
     A outra dimensão é calculada usando a dimensão especificada e as proporções intrínsecas.
   - Se a imagem tiver apenas uma dimensão intrínseca, mas não tiver proporções intrínsecas, ela será renderizada usando a dimensão especificada e a outra dimensão da área de posicionamento do plano de fundo.
 
-  > **Nota:** Imagens SVG têm um atributo [preserveAspectRatio](/pt-BR/docs/Web/SVG/Attribute/preserveAspectRatio) que é equivalente ao `contain`; um `background-size` explícito faz com que `preserveAspectRatio` seja ignorado.
+  > [!NOTE]
+  > Imagens SVG têm um atributo [preserveAspectRatio](/pt-BR/docs/Web/SVG/Attribute/preserveAspectRatio) que é equivalente ao `contain`; um `background-size` explícito faz com que `preserveAspectRatio` seja ignorado.
 
 - **Se o `background-size` tem um componente `auto` e um componente não `auto`:**
 
@@ -111,7 +113,8 @@ Com base nas dimensões e proporções intrínsecas, o tamanho renderizado da im
     A dimensão não especificada é calculada usando a dimensão intrínseca correspondente da imagem, se houver.
     Se não houver essa dimensão intrínseca, ela se tornará a dimensão correspondente da área de posicionamento do plano de fundo
 
-> **Nota:** O dimensionamento do plano de fundo para imagens vetoriais que não possuem dimensões ou proporções intrínsecas ainda não foi totalmente implementado em todos os navegadores.
+> [!NOTE]
+> O dimensionamento do plano de fundo para imagens vetoriais que não possuem dimensões ou proporções intrínsecas ainda não foi totalmente implementado em todos os navegadores.
 > Tenha cuidado ao confiar no comportamento descrito acima e teste em vários navegadores para garantir que os resultados sejam aceitáveis.
 
 ### Definição formal

--- a/files/pt-br/web/css/background/index.md
+++ b/files/pt-br/web/css/background/index.md
@@ -29,7 +29,8 @@ background: border-box red;
 background: no-repeat center/80% url( "../img/image.png");
 ```
 
-> **Nota:** O {{cssxref ( "background-color")}} só pode ser definido no último fundo, como há apenas uma cor de fundo para todo o elemento.
+> [!NOTE]
+> O {{cssxref ( "background-color")}} só pode ser definido no último fundo, como há apenas uma cor de fundo para todo o elemento.
 
 ### Valores
 

--- a/files/pt-br/web/css/box-ordinal-group/index.md
+++ b/files/pt-br/web/css/box-ordinal-group/index.md
@@ -5,7 +5,8 @@ slug: Web/CSS/box-ordinal-group
 
 {{CSSRef}}
 
-> **Aviso:** Essa propriedade é parte do projeto do módulo original do CSS Flexible Box Layout, e foi substituído em projetos recentes.
+> [!WARNING]
+> Essa propriedade é parte do projeto do módulo original do CSS Flexible Box Layout, e foi substituído em projetos recentes.
 
 Veja [Flexbox](/pt-BR/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes) para mais informações do que você deveria usar ao invés dessa propriedade.
 

--- a/files/pt-br/web/css/clear/index.md
+++ b/files/pt-br/web/css/clear/index.md
@@ -15,7 +15,8 @@ As margens verticais entre dois elementos flutuantes não irão sofrer esse cola
 
 Os elementos flutuantes que devem ser limpos (clear) são os elementos anteriores dentro do mesmo contexto de bloco ([block formatting context](/pt-BR/docs/Web/Guide/CSS/Block_formatting_context)).
 
-> **Nota:** se um elemento possuir apenas elementos flutuantes, sua altura é zerada. Se você quiser que o mesmo seja redimensionado, de modo que contenha elementos flutuantes dentro dele, você precisa limpar(clear) seus filhos automaticamente. Isso é chamado clearfix, e uma maneira de fazê-lo é adicionando um {{cssxref("::after")}} pseudo-elemento com a propriedade `clear.`
+> [!NOTE]
+> se um elemento possuir apenas elementos flutuantes, sua altura é zerada. Se você quiser que o mesmo seja redimensionado, de modo que contenha elementos flutuantes dentro dele, você precisa limpar(clear) seus filhos automaticamente. Isso é chamado clearfix, e uma maneira de fazê-lo é adicionando um {{cssxref("::after")}} pseudo-elemento com a propriedade `clear.`
 >
 > ```css
 > #container::after {

--- a/files/pt-br/web/css/color_value/index.md
+++ b/files/pt-br/web/css/color_value/index.md
@@ -19,7 +19,8 @@ Associado à cor no espaço sRGB, um valor \<color> também pode consistir de um
 
 Embora os valores de cores CSS sejam definidos com precisão, eles podem aparecer de forma diferente em dispositivos de saída diferentes. A maioria deles não está calibrada e alguns navegadores não suportam o [perfil de cores](https://pt.wikipedia.org/wiki/Perfil_de_cores_ICC) dos dispositivos de saída. Sem estes, a renderização de cores pode variar muito.
 
-> **Nota:** A recomendação [WCAG 2.0](https://www.w3.org/TR/WCAG/#visual-audio-contrast) do W3C aconselha fortemente aos autores web não usarem cor como o único meio para transmitir uma mensagem específica, ação ou resultado. Alguns usuários têm problemas em distinguir cores e as informações transmitidas podem não ser compreendidas. Claro, isso não impede o uso da cor, mas o seu uso apenas como o único meio para descrever certas coisas (veja [Cor e contraste de cor](/pt-BR/docs/Learn/Accessibility/CSS_and_JavaScript#Color_and_color_contrast) para mais informações).
+> [!NOTE]
+> A recomendação [WCAG 2.0](https://www.w3.org/TR/WCAG/#visual-audio-contrast) do W3C aconselha fortemente aos autores web não usarem cor como o único meio para transmitir uma mensagem específica, ação ou resultado. Alguns usuários têm problemas em distinguir cores e as informações transmitidas podem não ser compreendidas. Claro, isso não impede o uso da cor, mas o seu uso apenas como o único meio para descrever certas coisas (veja [Cor e contraste de cor](/pt-BR/docs/Learn/Accessibility/CSS_and_JavaScript#Color_and_color_contrast) para mais informações).
 
 ## Interpolação
 
@@ -1001,7 +1002,8 @@ A cor da linha (uma div preenchida com cor) se adapta à cor de sua propriedade 
 
 ### `rgb()`
 
-> **Nota:** Na especificação Módulo de cor CSS Color nível 4, a rgba() foi definida como uma função herdada com gramática e comportamento idênticos à rgb(); na verdade, um apelido. Mais para frente, ambas podem aceitar exatamente os mesmos parâmetros.
+> [!NOTE]
+> Na especificação Módulo de cor CSS Color nível 4, a rgba() foi definida como uma função herdada com gramática e comportamento idênticos à rgb(); na verdade, um apelido. Mais para frente, ambas podem aceitar exatamente os mesmos parâmetros.
 
 RGB colors can be expressed through both hexadecimal (prefixed with `#`) and functional (`rgb()`, `rgba()`) notations.
 
@@ -1036,7 +1038,8 @@ rgb(255 0 0 / 40%)  /* 40% opaque red with percentage value for alpha */
 
 ### `hsl()`
 
-> **Nota:** In the CSS Color Module Level 4 spec, `hsla()` has been defined as a legacy function with identical grammar and behaviour to `hsl()`; in effect, an alias. Going forward, both can accept exactly the same parameters.
+> [!NOTE]
+> In the CSS Color Module Level 4 spec, `hsla()` has been defined as a legacy function with identical grammar and behaviour to `hsl()`; in effect, an alias. Going forward, both can accept exactly the same parameters.
 
 Colors can also be defined via hue, saturation, and lightness, or HSL, by using the `hsl()` functional notation. The advantage of HSL over RGB is that it is far more intuitive: you can guess at the colors you want, and then tweak. It is also easier to create sets of matching colors (by keeping the hue the same and varying the lightness/darkness, and saturation).
 
@@ -1111,7 +1114,8 @@ rgba(255 0 0 / 0.4)  /* 40% opaque red */
 rgba(255 0 0 / 40%)  /* 40% opaque red */
 ```
 
-> **Nota:** In the CSS Color Module Level 4 spec, `rgba()` has been defined as a legacy function with identical grammar and behaviour to `rgb()`; in effect, an alias. Going forward, both can accept exactly the same parameters.
+> [!NOTE]
+> In the CSS Color Module Level 4 spec, `rgba()` has been defined as a legacy function with identical grammar and behaviour to `rgb()`; in effect, an alias. Going forward, both can accept exactly the same parameters.
 
 ### `hsla()`
 
@@ -1135,7 +1139,8 @@ hsla(240deg 100% 50% / 5%) /* 5% opaque blue */
 hsla(240deg,100%,50%, 0.4)  /* 40% opaque blue */
 ```
 
-> **Nota:** In the CSS Color Module Level 4 spec, `hsla()` has been defined as a legacy function with identical grammar and behaviour to `hsl()`; in effect, an alias. Going forward, both can accept exactly the same parameters.
+> [!NOTE]
+> In the CSS Color Module Level 4 spec, `hsla()` has been defined as a legacy function with identical grammar and behaviour to `hsl()`; in effect, an alias. Going forward, both can accept exactly the same parameters.
 
 ### System Colors
 

--- a/files/pt-br/web/css/css_animations/using_css_animations/index.md
+++ b/files/pt-br/web/css/css_animations/using_css_animations/index.md
@@ -46,7 +46,8 @@ Você pode opcionalmente incluir keyframes adicionais que descrevem passos inter
 
 ## Exemplos
 
-> **Nota:** Os exemplos aqui não usam nenhum prefixo nas propriedades de animação CSS. Navegadores mais antigos podem precisar de prefixos; os exemplos ao vivo que você pode clicar pra ver em seu navegadores também incluem as versões prefixadas -webkit.
+> [!NOTE]
+> Os exemplos aqui não usam nenhum prefixo nas propriedades de animação CSS. Navegadores mais antigos podem precisar de prefixos; os exemplos ao vivo que você pode clicar pra ver em seu navegadores também incluem as versões prefixadas -webkit.
 
 ### Fazendo o texto deslizar através da janela do navegador
 

--- a/files/pt-br/web/css/css_colors/applying_color/index.md
+++ b/files/pt-br/web/css/css_colors/applying_color/index.md
@@ -208,7 +208,8 @@ th {
 
 {{EmbedLiveSample("HSL_functional_notation", 300, 260)}}
 
-> **Nota:** Quando você omite a unidade do matiz, assume-se que está em graus (`deg`).
+> [!NOTE]
+> Quando você omite a unidade do matiz, assume-se que está em graus (`deg`).
 
 ### Notação funcional HWB
 
@@ -324,7 +325,8 @@ A classe `.boxLeft` — que, inteligentemente, é usada para estilizar a caixa �
 }
 ```
 
-> **Nota:** ao tentar mostrá-lo no Safari, ele não será exibido corretamente. Porque o Safari não suporta `text-decoration: underline wavy #88ff88`.
+> [!NOTE]
+> ao tentar mostrá-lo no Safari, ele não será exibido corretamente. Porque o Safari não suporta `text-decoration: underline wavy #88ff88`.
 
 Finalmente, a classe `.boxRight` descreve as propriedades únicas da caixa que é desenhada à direita. Ele está configurado para flutuar a caixa para a direita para que ela apareça ao lado da caixa anterior. Em seguida, as seguintes cores são estabelecidas:
 
@@ -346,7 +348,8 @@ Vejamos um exemplo simples, no qual o usuário pode escolher uma cor. Conforme o
 
 {{EmbedLiveSample("Example_Picking_a_color", 525, 275)}}
 
-> **Nota:** no macOS, você indica que finalizou a seleção da cor fechando a janela do seletor de cores.
+> [!NOTE]
+> no macOS, você indica que finalizou a seleção da cor fechando a janela do seletor de cores.
 
 #### HTML
 
@@ -428,7 +431,8 @@ O primeiro passo é escolher sua **cor base**. Esta é a cor que de alguma forma
 
 Ao tentar decidir sobre uma cor base, você pode descobrir que as extensões do navegador que permitem selecionar cores do conteúdo da Web podem ser particularmente úteis. Alguns deles são projetados especificamente para ajudar nesse tipo de trabalho. Por exemplo, o site [ColorZilla](https://www.colorzilla.com/) oferece uma extensão ([Chrome](https://www.colorzilla.com/chrome/) / [Firefox](https:// www.colorzilla.com/firefox/)) que oferece uma ferramenta conta-gotas para escolher cores da web. Também pode obter médias das cores dos pixels em áreas de vários tamanhos ou até mesmo em uma área selecionada da página.
 
-> **Nota:** A vantagem da média de cores pode ser que, muitas vezes, o que parece uma cor sólida é, na verdade, um número surpreendentemente variado de cores relacionadas, todas usadas em conjunto, misturando-se para criar o efeito desejado. Escolher apenas um desses pixels pode resultar na obtenção de uma cor que, por si só, parece muito fora do lugar.
+> [!NOTE]
+> A vantagem da média de cores pode ser que, muitas vezes, o que parece uma cor sólida é, na verdade, um número surpreendentemente variado de cores relacionadas, todas usadas em conjunto, misturando-se para criar o efeito desejado. Escolher apenas um desses pixels pode resultar na obtenção de uma cor que, por si só, parece muito fora do lugar.
 
 #### Confeccionando a paleta
 
@@ -442,7 +446,8 @@ Alguns exemplos (todos gratuitos para uso a partir do momento em que esta lista 
 
 Ao projetar sua paleta, lembre-se de que, além das cores que essas ferramentas normalmente geram, você provavelmente também precisará adicionar algumas cores neutras centrais, como branco (ou quase branco), preto (ou quase preto), e algum número de tons de cinza.
 
-> **Nota:** Normalmente, é muito melhor usar o menor número de cores possível. Ao usar cores para acentuar em vez de adicionar cores a tudo na página, você mantém seu conteúdo fácil de ler e as cores que você usa têm muito mais impacto.
+> [!NOTE]
+> Normalmente, é muito melhor usar o menor número de cores possível. Ao usar cores para acentuar em vez de adicionar cores a tudo na página, você mantém seu conteúdo fácil de ler e as cores que você usa têm muito mais impacto.
 
 ### Recursos da teoria das cores
 
@@ -459,7 +464,8 @@ Existem várias maneiras pelas quais a cor pode ser um problema {{Glossary("acce
 
 Você deve fazer pelo menos uma pesquisa básica sobre [daltonismo](https://en.wikipedia.org/wiki/Color_blindness). Existem vários tipos; o mais comum é o daltonismo vermelho-verde, que faz com que as pessoas não consigam diferenciar entre as cores vermelho e verde. Existem outras, também, que vão desde a incapacidade de distinguir certas cores até a total incapacidade de ver as cores.
 
-> **Nota:** A regra mais importante: nunca use a cor como a única maneira de saber algo. Se, por exemplo, você indicar sucesso ou falha de uma operação alterando a cor de uma forma de branco para verde para sucesso e vermelho para falha, os usuários com daltonismo vermelho-verde não poderão usar seu site corretamente. Em vez disso, talvez use texto e cor juntos, para que todos possam entender o que está acontecendo.
+> [!NOTE]
+> A regra mais importante: nunca use a cor como a única maneira de saber algo. Se, por exemplo, você indicar sucesso ou falha de uma operação alterando a cor de uma forma de branco para verde para sucesso e vermelho para falha, os usuários com daltonismo vermelho-verde não poderão usar seu site corretamente. Em vez disso, talvez use texto e cor juntos, para que todos possam entender o que está acontecendo.
 
 Para obter mais informações sobre daltonismo, consulte os seguintes artigos:
 
@@ -510,7 +516,8 @@ O valor padrão de `print-color-adjust`, `economy`, indica que o navegador tem p
 Você pode definir `print-color-adjust` como `exact` para informar ao navegador que o elemento ou elementos nos quais você o usa foram projetados especificamente para funcionar melhor com as cores e imagens deixadas como estão.
 Com este conjunto, o navegador não alterará a aparência do elemento e o desenhará conforme indicado pelo seu CSS.
 
-> **Nota:** Não há garantia, porém, de que `print-color-adjust: exact` resultará em seu CSS sendo usado exatamente como fornecido.
+> [!NOTE]
+> Não há garantia, porém, de que `print-color-adjust: exact` resultará em seu CSS sendo usado exatamente como fornecido.
 > Se o navegador fornecer as preferências do usuário para alterar a saída (como uma caixa de seleção "não imprimir fundos" em uma caixa de diálogo de impressão), isso substituirá o valor de `print-color-adjust`.
 
 ## Veja também

--- a/files/pt-br/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
+++ b/files/pt-br/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
@@ -26,7 +26,8 @@ As propriedades que nós veremos neste guia são as seguintes.
 
 Nós também descobriremos como margens automáticas podem ser utilizadas para o alinhamento no flexbox.
 
-> **Nota:** The alignment properties in Flexbox have been placed into their own specification — [CSS Box Alignment Level 3](https://www.w3.org/TR/css-align-3/). It is expected that this spec will ultimately supersede the properties as defined in Flexbox Level One.
+> [!NOTE]
+> The alignment properties in Flexbox have been placed into their own specification — [CSS Box Alignment Level 3](https://www.w3.org/TR/css-align-3/). It is expected that this spec will ultimately supersede the properties as defined in Flexbox Level One.
 
 ## The Cross Axis
 
@@ -100,7 +101,8 @@ Once again we can switch our `flex-direction` to `column` in order to see how th
 
 {{EmbedGHLiveSample("css-examples/flexbox/alignment/align-content-column.html", '100%', 860)}}
 
-> **Nota:** the value `space-evenly` is not defined in the flexbox specification and is a later addition to the Box Alignment specification. Browser support for this value is not as good as that of the values defined in the flexbox spec.
+> [!NOTE]
+> the value `space-evenly` is not defined in the flexbox specification and is a later addition to the Box Alignment specification. Browser support for this value is not as good as that of the values defined in the flexbox spec.
 
 See the [documentation for `justify-content` on MDN](/pt-BR/docs/Web/CSS/justify-content) for more details on all of these values and browser support.
 

--- a/files/pt-br/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/pt-br/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -143,7 +143,8 @@ Enquanto a propriedade `flex-grow` permite aumentar a largura dos elementos dent
 
 O tamanho mínimo do elemento será levado em consideração ao se calcular a quantidade real de encolhimento que ocorrerá, o que significa que a propriedade flex-shrink se comporta de modo potencialmente menos consistente do que a propriedade flex-grow. Examinar-se-á mais detalhadamente o funcionamento desse algoritmo no artigo Taxas de Controle de Elementos Flex ao Longo do Eixo Principal.
 
-> **Nota:** Note que os valores para as propriedades `flex-grow` e `flex-shrink` são proporcionais. Particularmente, se tivermos todos os nossos elementos definidos como flex: `1 1 200px` e então quisermos que um deles cresça o dobro, temos de definir o elemento como flex: `2 1 200px`. Entretanto, podemos escrever flex: `10 1 200px` e flex: `20 1 200px` se quisermos.
+> [!NOTE]
+> Note que os valores para as propriedades `flex-grow` e `flex-shrink` são proporcionais. Particularmente, se tivermos todos os nossos elementos definidos como flex: `1 1 200px` e então quisermos que um deles cresça o dobro, temos de definir o elemento como flex: `2 1 200px`. Entretanto, podemos escrever flex: `10 1 200px` e flex: `20 1 200px` se quisermos.
 
 ### Abreviatura para os valores das propriedades flex
 

--- a/files/pt-br/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/pt-br/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -553,7 +553,8 @@ Nesse caso o grid aninhado não possui relação com o pai. Como é possível pe
 
 No nível das especificações do grid tem uma _feature_ chamada _subgrid_ que nos permitiria criar grids aninhados que usa aquilo que foi definido no grid pai.
 
-> **Nota:** Subgrids ainda não foram implementados em nenhum browser, e as especificações são sujeitas a mudanças.
+> [!NOTE]
+> Subgrids ainda não foram implementados em nenhum browser, e as especificações são sujeitas a mudanças.
 
 Na especificação atual, no exemplo acima editaríamos o grid aninhado usando `display: subgrid` ao invés de `display: grid`, e remover o que havia sido definido. O grid aninhado vai usar as propriedades definidas no pai para dispor os itens.
 

--- a/files/pt-br/web/css/css_grid_layout/index.md
+++ b/files/pt-br/web/css/css_grid_layout/index.md
@@ -5,7 +5,8 @@ slug: Web/CSS/CSS_grid_layout
 
 {{CSSRef}}
 
-> **Nota:** CSS Grid será suportado por vários navegadores até meados de 2017. O suporte em navegadores antigos pode ser obtido habilitando-se uma flag que permite o uso da API. Nesse caso não se esqueça de consultar e fazer referência a cada propriedade e funcionalidade da especificação para certificar-se da sua compatibilidade, bem como para obter maiores informações.
+> [!NOTE]
+> CSS Grid será suportado por vários navegadores até meados de 2017. O suporte em navegadores antigos pode ser obtido habilitando-se uma flag que permite o uso da API. Nesse caso não se esqueça de consultar e fazer referência a cada propriedade e funcionalidade da especificação para certificar-se da sua compatibilidade, bem como para obter maiores informações.
 
 **CSS Grid layout** é uma especificação do W3C projetada para proporcionar um método bi-dimensional para criação de layout CSS que oferece a possibilidade de "layoutar" itens da página com uso de linhas e colunas. CSS grid poderá ser usado para obter uma infinidade de diferentes layouts. O diferencial desse método de criação de layouts reside na possibilidade de se dividir uma página em grandes regiões e de se definir o relacionamento em termos de medidas, posicionamento e camadas entre os diferentes componentes da marcação HTML.
 

--- a/files/pt-br/web/css/css_images/implementing_image_sprites_in_css/index.md
+++ b/files/pt-br/web/css/css_images/implementing_image_sprites_in_css/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/CSS_images/Implementing_image_sprites_in_CSS
 
 **Sprites de imagens** são utilizados em diversas aplicações web onde várias imagens são usadas. Ao invés de incluir cada arquivo de imagem separadamente, é mais amigável com a memória e largura de banda enviar tudo como uma única imagem, diminuindo o número de pedidos em HTTP.
 
-> **Nota:** Quando usando HTTP/2, é mais amigável com a largura de banda usar vários pequenos pedidos.
+> [!NOTE]
+> Quando usando HTTP/2, é mais amigável com a largura de banda usar vários pequenos pedidos.
 
 ## Implementação
 

--- a/files/pt-br/web/css/css_media_queries/printing/index.md
+++ b/files/pt-br/web/css/css_media_queries/printing/index.md
@@ -26,7 +26,8 @@ Adicione o seguinte código dentro da tag {{HTMLElement("head")}}.
 
 Alguns navegadores (incluindo o Firefox 6 e versões mais antigas do Internet Explorer) enviam eventos `beforeprint` e `afterprint` para permitir que o conteúdo determine quando a impressão deve ocorrer. Você pode usar isto para ajustar a interface presente durante a impressão (como a exibição ou ocultação de elementos de interface do usuário durante o processo de impressão).
 
-> **Nota:** Você também pode usar [`window.onbeforeprint`](/pt-BR/docs/DOM/window.onbeforeprint) e [`window.onafterprint`](/pt-BR/docs/DOM/window.onafterprint) para atribuir manipuladores para esses eventos, mas usando {{domxref("EventTarget.addEventListener()")}} é preferível.
+> [!NOTE]
+> Você também pode usar [`window.onbeforeprint`](/pt-BR/docs/DOM/window.onbeforeprint) e [`window.onafterprint`](/pt-BR/docs/DOM/window.onafterprint) para atribuir manipuladores para esses eventos, mas usando {{domxref("EventTarget.addEventListener()")}} é preferível.
 
 ## Exemplos
 
@@ -121,7 +122,8 @@ If you want to be able to print an external page without opening it, you can uti
 </html>
 ```
 
-> **Nota:** Older versions of Internet Explorer cannot print the contents of a hidden {{HTMLElement("iframe")}}.
+> [!NOTE]
+> Older versions of Internet Explorer cannot print the contents of a hidden {{HTMLElement("iframe")}}.
 
 ## Veja também
 

--- a/files/pt-br/web/css/css_media_queries/using_media_queries/index.md
+++ b/files/pt-br/web/css/css_media_queries/using_media_queries/index.md
@@ -131,13 +131,15 @@ media_feature: width | min-width | max-width
 
 _Media queries_ são _case insensitive_. _Media queries_ envolvidas em _media types_ desconhecidos serão sempre falsas.
 
-> **Nota:** Parenteses são obrigatórios em volta de expressões; a falta deles é um erro.
+> [!NOTE]
+> Parenteses são obrigatórios em volta de expressões; a falta deles é um erro.
 
 ## Características de mídia
 
 A maioria das _media features_ podem ter prefixo "min-" ou "max-" para expressar as restrições "maior ou igual" ou "menor ou igual". Isto evita o uso dos símbolos "<" e ">" , que entrem em conflito com HTML e XML. Se você usar uma _media feature_ sem especificar um valor, a expressão retorna verdadeiro, se o valor da _feature_ for diferente de zero.
 
-> **Nota:** Se uma media feature não se aplicar ao dispositivo onde o navegador esta sendo executado, as expressões que envolvem essa media feature são sempre falsas. Por exemplo, consultar um aspecto de um dispositivo sonoro, sempre resulta em falso.
+> [!NOTE]
+> Se uma media feature não se aplicar ao dispositivo onde o navegador esta sendo executado, as expressões que envolvem essa media feature são sempre falsas. Por exemplo, consultar um aspecto de um dispositivo sonoro, sempre resulta em falso.
 
 ### cor
 
@@ -147,7 +149,8 @@ A maioria das _media features_ podem ter prefixo "min-" ou "max-" para expressar
 
 Indica o número de bits por componente de cor no dispositivo de saída. Se o dispositivo não é um dispositivo de cor, o valor é zero.
 
-> **Nota:** Se os componentes de cor têm diferentes números de bits por componente de cor, o menor valor é utilizado. Por exemplo, se o display usa 5 bits para azul e vermelho e 6 bits para verde, então o dispositivo considera 5 bits por componente de cor. Se o dispositivo usar cores indexadas, o menor número de bits por componente de cor na tabela de cores é usado.
+> [!NOTE]
+> Se os componentes de cor têm diferentes números de bits por componente de cor, o menor valor é utilizado. Por exemplo, se o display usa 5 bits para azul e vermelho e 6 bits para verde, então o dispositivo considera 5 bits por componente de cor. Se o dispositivo usar cores indexadas, o menor número de bits por componente de cor na tabela de cores é usado.
 
 #### Exemplos
 
@@ -272,7 +275,8 @@ Para aplicar um estilo a dispositivos postáteis com 15-carácteres ou uma tela 
 @media handheld and (grid) and (max-width: 15em) { ... }
 ```
 
-> **Nota:** A unidade "em" tem um significado especial para dispositivos de grade, uma vez que a exata largura de um "em" não pode ser determinada, 1em é assumido para ser a largura de uma célula da grade horizontalmente, e a altura de uma célula verticalmente.
+> [!NOTE]
+> A unidade "em" tem um significado especial para dispositivos de grade, uma vez que a exata largura de um "em" não pode ser determinada, 1em é assumido para ser a largura de uma célula da grade horizontalmente, e a altura de uma célula verticalmente.
 
 ### height
 
@@ -282,7 +286,8 @@ Para aplicar um estilo a dispositivos postáteis com 15-carácteres ou uma tela 
 
 A característica `height` descreve a altura da superfície de renderização do dispositivo de saída (tal como a altura do viewport ou da caixa de página em uma impressora).
 
-> **Nota:** Como o usuário redimensiona a janela, o Firefox muda as folhas de estilo como apropriado, com base nas media queries, usando as media features `width` e `height`.
+> [!NOTE]
+> Como o usuário redimensiona a janela, o Firefox muda as folhas de estilo como apropriado, com base nas media queries, usando as media features `width` e `height`.
 
 ### monochrome
 
@@ -322,7 +327,8 @@ Para aplicar a folha de estilo apenas em orientação _portrait_:
 @media all and (orientation: portrait) { ... }
 ```
 
-> **Nota:** Este valor não corresponde com a orientação real do dispositivo. Abrindo o teclado virtual na maioria dos dispositivos na orientação retrato fará com que o viewport torne-se mais largo do que alto, fazendo assim que o navegador use estilos de paisagem em vez de retrato.
+> [!NOTE]
+> Este valor não corresponde com a orientação real do dispositivo. Abrindo o teclado virtual na maioria dos dispositivos na orientação retrato fará com que o viewport torne-se mais largo do que alto, fazendo assim que o navegador use estilos de paisagem em vez de retrato.
 
 ### resolution
 
@@ -453,7 +459,8 @@ Exemplo:
 
 Veja este artigo [CSSWG](https://www.w3.org/blog/CSS/2012/06/14/unprefix-webkit-device-pixel-ratio/) para ccompatibilidade de boas práticas em relação a _`resolution`_ e _`dppx`_.
 
-> **Nota:** Esta _media feature_ é também implementada pelo Webkit e pelo [IE 11 para Windows Phone 8.1](<https://msdn.microsoft.com/en-us/library/ie/dn760733(v=vs.85).aspx>)como -webkit-device-pixel-ratio. Os prefixos min e max implementados pelo Gecko são nomeados min--moz-device-pixel-ratio e max--moz-device-pixel-ratio; mas os mesmos prefixos implementados pelo Webkit são chamados -webkit-min-device-pixel-ratio e -webkit-max-device-pixel-ratio.
+> [!NOTE]
+> Esta _media feature_ é também implementada pelo Webkit e pelo [IE 11 para Windows Phone 8.1](<https://msdn.microsoft.com/en-us/library/ie/dn760733(v=vs.85).aspx>)como -webkit-device-pixel-ratio. Os prefixos min e max implementados pelo Gecko são nomeados min--moz-device-pixel-ratio e max--moz-device-pixel-ratio; mas os mesmos prefixos implementados pelo Webkit são chamados -webkit-min-device-pixel-ratio e -webkit-max-device-pixel-ratio.
 
 ### -moz-os-version
 

--- a/files/pt-br/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/pt-br/web/css/css_transitions/using_css_transitions/index.md
@@ -17,9 +17,11 @@ Animações CSS permitem que você decida quais propriedades animar (listando-os
 
 Você mesmo pode definir qual propriedade será transicionada e de qual maneira. E isso permite a criação de transições complexas. Como não faz sentido animar algumas propriedades, existe uma lista finita [com propriedades que podem ser transicionadas](/pt-BR/docs/Web/CSS/CSS_animated_properties).
 
-> **Nota:** A lista de propriedades que podem ser animadas sofre alterações a medida que a especificação se desenvolve.
+> [!NOTE]
+> A lista de propriedades que podem ser animadas sofre alterações a medida que a especificação se desenvolve.
 
-> **Nota:** O valor `automatico` , geralmente é complexo. A especificação recomenda não animar com valores automaticos. Alguns [user agents](/pt-BR/docs/Web/HTTP/Headers/User-Agent), como aqueles baseados no Genko, implementam esse requisito, como aqueles baseados no WebKit, são menos rigosos. Animações CSS que utlizam o valor `automatico`, podem levar resultados imprevisiveis, dependendo do Browser e da versão, e isso pode ser evitado.
+> [!NOTE]
+> O valor `automatico` , geralmente é complexo. A especificação recomenda não animar com valores automaticos. Alguns [user agents](/pt-BR/docs/Web/HTTP/Headers/User-Agent), como aqueles baseados no Genko, implementam esse requisito, como aqueles baseados no WebKit, são menos rigosos. Animações CSS que utlizam o valor `automatico`, podem levar resultados imprevisiveis, dependendo do Browser e da versão, e isso pode ser evitado.
 
 ## Definindo transições
 
@@ -1050,7 +1052,8 @@ Este CSS estabelece a aparência do menu, com as cores de fundo e texto mudando 
 
 ## Exemplos JavaScript
 
-> **Nota:** Cuidados devem ser tomados ao usar uma transição imediatamente após:
+> [!NOTE]
+> Cuidados devem ser tomados ao usar uma transição imediatamente após:
 >
 > - adding the element to the DOM using `.appendChild()`
 > - removing an element's `display: none;` property.

--- a/files/pt-br/web/css/display/index.md
+++ b/files/pt-br/web/css/display/index.md
@@ -66,7 +66,8 @@ Os valores de palavra-chave podem ser agrupados em seis categorias de valor.
     - `inline`
       - : O elemento gera uma ou mais caixas de elemento em linha que não geram quebras de linha antes ou depois de si mesmas. No fluxo normal, o próximo elemento estará na mesma linha se houver espaço.
 
-> **Nota:** Navegadores que suportam a sintaxe de dois valores, ao localizar apenas o valor externo, como quando `display: block` ou `display: inline` é especificado, definirão o valor interno como `flow`.
+> [!NOTE]
+> Navegadores que suportam a sintaxe de dois valores, ao localizar apenas o valor externo, como quando `display: block` ou `display: inline` é especificado, definirão o valor interno como `flow`.
 > Isso resultará no comportamento esperado; por exemplo, se você especificar um elemento para ser bloco, você esperaria que os filhos desse elemento participassem do bloco e do layout de fluxo normal embutido.
 
 ### Lado de dentro
@@ -94,7 +95,8 @@ Os valores de palavra-chave podem ser agrupados em seis categorias de valor.
     - `ruby` {{Experimental_Inline}}
       - : O elemento se comporta como um elemento inline e apresenta seu conteúdo de acordo com o modelo de formatação ruby. Ele se comporta como os elementos HTML {{HTMLElement("ruby")}} correspondentes.
 
-> **Nota:** Navegadores que suportam a sintaxe de dois valores, ao encontrar apenas o valor interno, como quando `display: flex` ou `display: grid` é especificado, definirão seu valor externo como `block`.
+> [!NOTE]
+> Navegadores que suportam a sintaxe de dois valores, ao encontrar apenas o valor interno, como quando `display: flex` ou `display: grid` é especificado, definirão seu valor externo como `block`.
 > Isso resultará no comportamento esperado; por exemplo, se você especificar um elemento como `display: grid`, você esperaria que a caixa criada no contêiner da grade fosse uma caixa de nível de bloco.
 
 ### Item de lista
@@ -107,7 +109,8 @@ Isso pode ser usado junto com {{CSSxRef("list-style-type")}} e {{CSSxRef("list-s
 
 `list-item` também pode ser combinado com qualquer palavra-chave {{CSSxRef("&lt;display-outside&gt;")}} e `flow` ou `flow-root` {{CSSxRef("&lt;display-inside&gt;" )}} palavras-chave.
 
-> **Nota:** Em navegadores que suportam a sintaxe de dois valores, se nenhum valor interno for especificado, o padrão será `flow`.
+> [!NOTE]
+> Em navegadores que suportam a sintaxe de dois valores, se nenhum valor interno for especificado, o padrão será `flow`.
 > Se nenhum valor externo for especificado, a caixa principal terá um tipo de exibição externa de `bloco`.
 
 ### Interno
@@ -297,7 +300,8 @@ Neste exemplo, temos dois elementos de contêiner em nível de bloco, cada um co
 
 Incluímos {{cssxref("padding")}} e {{cssxref("background-color")}} nos contêineres e seus filhos, para que seja mais fácil ver o efeito que os valores de exibição estão tendo.
 
-> **Nota:** não incluímos nenhuma sintaxe moderna de dois valores, pois o suporte a ela ainda é bastante limitado.
+> [!NOTE]
+> não incluímos nenhuma sintaxe moderna de dois valores, pois o suporte a ela ainda é bastante limitado.
 
 #### HTML
 
@@ -383,7 +387,8 @@ updateDisplay();
 
 {{EmbedLiveSample('display_value_comparison','100%', 440)}}
 
-> **Nota:** você pode encontrar mais exemplos nas páginas para cada tipo de dados de exibição separado, linkado acima.
+> [!NOTE]
+> você pode encontrar mais exemplos nas páginas para cada tipo de dados de exibição separado, linkado acima.
 
 ## Especificações
 

--- a/files/pt-br/web/css/env/index.md
+++ b/files/pt-br/web/css/env/index.md
@@ -39,7 +39,8 @@ env(safe-area-inset-left, 1.4rem);
 - `safe-area-inset-top`, `safe-area-inset-right`, `safe-area-inset-bottom`, `safe-area-inset-left`
   - : As variáveis `safe-area-inset-*` são quatro variáveis de ambiente que definem um retângulo por seus valores de inserção: _top, right, bottom_ e _left_ a partir da borda da janela de visualização, no qual é seguro colocar o conteúdo sem o risco de ser cortado pela forma de um visor não retangular. Para janelas de visualização retangulares, como o monitor de um laptop comum, seu valor é igual a zero. Para telas não retangulares - como um visor de um relógio redondo - os quatro valores definidos pelo agente do usuário formam um retângulo de modo que todo o conteúdo dentro do retângulo seja visível.
 
-> **Nota:** Ao contrário de outras propriedades CSS, os nomes de propriedades definidos pelo agente do usuário fazem distinção entre maiúsculas e minúsculas.
+> [!NOTE]
+> Ao contrário de outras propriedades CSS, os nomes de propriedades definidos pelo agente do usuário fazem distinção entre maiúsculas e minúsculas.
 
 ### Sintaxe formal
 
@@ -95,7 +96,8 @@ padding: env(
 
 A sintaxe _fallback_, como de propriedades customizadas, permite vírgulas. Mas se o valor da propriedade não suportar vírgulas, o valor não é válido.
 
-> **Nota:** As propriedades do agente do usuário não são redefinidas pela propriedade [all](/pt-BR/docs/Web/CSS/all).
+> [!NOTE]
+> As propriedades do agente do usuário não são redefinidas pela propriedade [all](/pt-BR/docs/Web/CSS/all).
 
 ## Especificações
 

--- a/files/pt-br/web/css/filter-function/opacity/index.md
+++ b/files/pt-br/web/css/filter-function/opacity/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/filter-function/opacity
 
 A função [CSS](/pt-BR/docs/Web/CSS) **`opacity()`** aplica transparência às amostras na imagem inputada. Seu resultado é uma {{cssxref("&lt;filter-function&gt;")}}.
 
-> **Nota:** Essa função é similar à propriedade {{Cssxref("opacity")}} mais estabelecida. A diferença é que com filtros, alguns browsers fornecem aceleração de hardware para uma melhor performance.
+> [!NOTE]
+> Essa função é similar à propriedade {{Cssxref("opacity")}} mais estabelecida. A diferença é que com filtros, alguns browsers fornecem aceleração de hardware para uma melhor performance.
 
 ## Sintaxe
 

--- a/files/pt-br/web/css/float/index.md
+++ b/files/pt-br/web/css/float/index.md
@@ -32,7 +32,8 @@ Como `float` implica o uso the _block layout,_ ele modifica o valor computado de
 | `inline-flex`        | `inline-flex`, porém `float` não produz efeito em tais elementos |
 | _other_              | _unchanged_                                                      |
 
-> **Nota:** Se você está se referindo a essa propriedade do Javascript como um membro do objeto {{domxref("element.style")}}, você deve referir-se a `cssFloat`. Observe também que as versões 8 e posteriores referem-se a `styleFloat`. Esta é uma exceção à regra de que o nome do membro DOM é o nome em estilo _camel-case_ do nome CSS separado por traço (e se deve ao fato de que "float" é uma palavra reservada em Javascript, tal qual a necessidade de especificar "class" como "className" e "for" como "htmlFor").
+> [!NOTE]
+> Se você está se referindo a essa propriedade do Javascript como um membro do objeto {{domxref("element.style")}}, você deve referir-se a `cssFloat`. Observe também que as versões 8 e posteriores referem-se a `styleFloat`. Esta é uma exceção à regra de que o nome do membro DOM é o nome em estilo _camel-case_ do nome CSS separado por traço (e se deve ao fato de que "float" é uma palavra reservada em Javascript, tal qual a necessidade de especificar "class" como "className" e "for" como "htmlFor").
 
 ## Sintaxe
 
@@ -125,7 +126,8 @@ p.withRedBoxes {
 }
 ```
 
-> **Nota:** Atribuir `overflow` para `scroll` irá conter também qualquer elemento filho flutuante, mas mostrará as barras de rolagem não importando o comprimento vertical do elemento. Aqui nós estamos atribuindo `height` como `auto` mesmo sendo este o padrão para indicar que o containêr deve crescer para acomodar seu conteúdo.
+> [!NOTE]
+> Atribuir `overflow` para `scroll` irá conter também qualquer elemento filho flutuante, mas mostrará as barras de rolagem não importando o comprimento vertical do elemento. Aqui nós estamos atribuindo `height` como `auto` mesmo sendo este o padrão para indicar que o containêr deve crescer para acomodar seu conteúdo.
 
 ## Especificações
 

--- a/files/pt-br/web/css/font-family/index.md
+++ b/files/pt-br/web/css/font-family/index.md
@@ -13,7 +13,8 @@ Programadores WEB devem sempre adicionar pelo menos uma família genérica para 
 
 É também conveniente usar de antemão a propriedade {{cssxref("font")}} para definir a `font-size` e outras propriedades relacionadas a fonte todas de uma só vez.
 
-> **Nota:** A propriedade `font-family` especifica a lista de fontes, da prioridade mais alta para a mais baixa.```
+> [!NOTE]
+> A propriedade `font-family` especifica a lista de fontes, da prioridade mais alta para a mais baixa.```
 > A seleção de fontes não para simplesmente na primeira fonte nomeada na lista que está no sistema do usuário. Em vez disso, a seleção de fontes é feita um caractere de cada vez, para que, se uma fonte disponível não tiver um glifo que possa exibir um caracter necessário, as fontes disponíveis mais tarde sejam tentadas. No entanto, isso não funciona no Internet Explorer 6 ou anterior.
 >
 > Quando uma fonte está disponível apenas em alguns estilos, variantes ou tamanhos, essas propriedades também podem influenciar qual família de fontes é escolhida.

--- a/files/pt-br/web/css/font-feature-settings/index.md
+++ b/files/pt-br/web/css/font-feature-settings/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/font-feature-settings
 
 A propriedade **`font-feature-settings`** do CSS te dá controle sobre tipografia avançada nas fontes do tipo OpenType.
 
-> **Nota:** Sempre que possível, deve usar o {{cssxref("font-variant")}} propriedade abreviada ou uma propriedade extensa associada, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-east-asian")}}, {{cssxref("font-variant-alternates")}}, {{cssxref("font-variant-numeric")}} ou {{cssxref("font-variant-position")}}.
+> [!NOTE]
+> Sempre que possível, deve usar o {{cssxref("font-variant")}} propriedade abreviada ou uma propriedade extensa associada, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-east-asian")}}, {{cssxref("font-variant-alternates")}}, {{cssxref("font-variant-numeric")}} ou {{cssxref("font-variant-position")}}.
 >
 > Esta propriedade é um recurso de baixo nível projetado para lidar com casos especiais onde não existe outra maneira de habilitar ou acessar um recurso de fonte OpenType.
 >

--- a/files/pt-br/web/css/font-size/index.md
+++ b/files/pt-br/web/css/font-size/index.md
@@ -60,7 +60,8 @@ The `font-size` property is specified in one of the following ways:
 - {{cssxref("&lt;percentage&gt;")}}
   - : A positive {{cssxref("&lt;percentage&gt;")}} value, relative to the parent element's font size.
 
-> **Nota:** To maximize accessibility, it is generally best to use values that are relative to the user's default font size.
+> [!NOTE]
+> To maximize accessibility, it is generally best to use values that are relative to the user's default font size.
 
 ### Formal syntax
 
@@ -80,7 +81,8 @@ Setting the font size in pixel values (`px`) is a good choice when you need pixe
 
 Font sizing settings can also be used in combination. For example, if a parent element is set to `16px` and its child element is set to `larger`, the child element displays larger than the parent element in the page.
 
-> **Nota:** Defining font sizes in `px` is _[not accessible](https://en.wikipedia.org/wiki/Web_accessibility)_, because the user cannot change the font size from the browser. For example, users with limited vision may wish to set the font size much larger than the size chosen by a web designer. Avoid using them for font sizes if you wish to create an inclusive design.
+> [!NOTE]
+> Defining font sizes in `px` is _[not accessible](https://en.wikipedia.org/wiki/Web_accessibility)_, because the user cannot change the font size from the browser. For example, users with limited vision may wish to set the font size much larger than the size chosen by a web designer. Avoid using them for font sizes if you wish to create an inclusive design.
 
 ### Ems
 

--- a/files/pt-br/web/css/font-variation-settings/index.md
+++ b/files/pt-br/web/css/font-variation-settings/index.md
@@ -9,9 +9,11 @@ A propriedade CSS **`font-variation-settings`** fornece controle de baixo nível
 
 {{EmbedInteractiveExample("pages/css/font-variation-settings.html")}}
 
-> **Nota:** This property is a low-level mechanism designed to set variable font features where no other way to enable or access those features exist. You should only use it when no basic properties exist to set those features (e.g. {{cssxref("font-weight")}}, {{cssxref("font-style")}}).
+> [!NOTE]
+> This property is a low-level mechanism designed to set variable font features where no other way to enable or access those features exist. You should only use it when no basic properties exist to set those features (e.g. {{cssxref("font-weight")}}, {{cssxref("font-style")}}).
 
-> **Nota:** font characteristics set using `font-variation-settings` will always override those set using the corresponding basic font properties, e.g. `font-weight`, no matter where they appear in the cascade. In some browsers, this is currently only true when the `@font-face` declaration includes a `font-weight` range.
+> [!NOTE]
+> font characteristics set using `font-variation-settings` will always override those set using the corresponding basic font properties, e.g. `font-weight`, no matter where they appear in the cascade. In some browsers, this is currently only true when the `@font-face` declaration includes a `font-weight` range.
 
 ## Sintaxe
 
@@ -57,7 +59,8 @@ Aqui estão os eixos registrados, juntamente com suas propriedades CSS correspon
 
 Os eixos personalizados podem ser qualquer coisa que o designer da fonte deseje variar em sua fonte, por exemplo, alturas ascendentes ou descendentes, o tamanho das serifas ou qualquer outra coisa que possam imaginar. Qualquer eixo pode ser usado desde que seja dado um eixo exclusivo de 4 caracteres. Alguns acabam se tornando mais comuns e podem até se registrar com o tempo.
 
-> **Nota:** As tags de eixo registrados são identificadas usando tags minúsculas, enquanto os eixos personalizados devem receber tags maiúsculas. Observe que os designers de fontes não são forçados a seguir essa prática de maneira alguma, e alguns não o fazem. O ponto importante aqui é que as tags de eixo diferenciam maiúsculas de minúsculas.
+> [!NOTE]
+> As tags de eixo registrados são identificadas usando tags minúsculas, enquanto os eixos personalizados devem receber tags maiúsculas. Observe que os designers de fontes não são forçados a seguir essa prática de maneira alguma, e alguns não o fazem. O ponto importante aqui é que as tags de eixo diferenciam maiúsculas de minúsculas.
 
 ## Exemplos
 

--- a/files/pt-br/web/css/grid/index.md
+++ b/files/pt-br/web/css/grid/index.md
@@ -7,7 +7,8 @@ A propriedade **`grid`** do CSS é uma [abreviação](/pt-BR/docs/Web/CSS/Shorth
 
 {{EmbedInteractiveExample("pages/css/grid.html")}}
 
-> **Nota:** Você pode especificar apenas as propriedades explícitas _ou_ implícitas da grade em uma única declaração `grid`. As subpropriedades que você não especifica são definidas como seu valor inicial, como é normal para abreviações. Além disso, as propriedades da medianiz NÃO são redefinidas por essa abreviação.
+> [!NOTE]
+> Você pode especificar apenas as propriedades explícitas _ou_ implícitas da grade em uma única declaração `grid`. As subpropriedades que você não especifica são definidas como seu valor inicial, como é normal para abreviações. Além disso, as propriedades da medianiz NÃO são redefinidas por essa abreviação.
 
 ## Sintaxe
 

--- a/files/pt-br/web/css/hyphens/index.md
+++ b/files/pt-br/web/css/hyphens/index.md
@@ -18,7 +18,8 @@ hyphens: unset;
 
 Regras de hifenização são específicas para cada idioma. Em HTML, o idioma é determinado pelo atributo `lang`, e os navegadores irão utilizar hífen apenas caso este atributo esteja presente e se houver um dicionário de hifenização disponível. Em XML, deve ser usado o atributo `xml:lang.`
 
-> **Nota:** As regras que definem como a hifenização é realizada não são explicitamente definidas pela especificação, então a hifenização exata pode variar de navegador para navegador.
+> [!NOTE]
+> As regras que definem como a hifenização é realizada não são explicitamente definidas pela especificação, então a hifenização exata pode variar de navegador para navegador.
 
 {{cssinfo}}
 
@@ -35,7 +36,8 @@ A propriedade `hyphens` é especificada como uma única palavra-chave escolhida 
 - `auto`
   - : O navegador é livre para quebrar palavras automaticamente nos pontos apropriados de hifenização, seguindo quaisquer regras que ele escolher. Entretanto, oportunidades sugeridas de quebras de linha (veja [Oportunidades sugeridas de quebra de linha](#suggesting_line_break_opportunities) abaixo) irão sobrepor a seleção automática de pontos de quebra quando presentes.
 
-> **Nota:** O comportamento da configuração `auto` requer que a propriedade idioma seja indicada corretamente para que as regras de hifenização sejam selecionadas. Você deve especificar o idioma utilizando o atributo HTML `lang` para garantir que a hifenização automática seja aplicada na linguagem de sua escolha.
+> [!NOTE]
+> O comportamento da configuração `auto` requer que a propriedade idioma seja indicada corretamente para que as regras de hifenização sejam selecionadas. Você deve especificar o idioma utilizando o atributo HTML `lang` para garantir que a hifenização automática seja aplicada na linguagem de sua escolha.
 
 ## Oportunidades sugeridas de quebra de linha
 

--- a/files/pt-br/web/css/image/index.md
+++ b/files/pt-br/web/css/image/index.md
@@ -36,7 +36,8 @@ O tamanho do objeto concreto é calculado usando o seguinte algoritimo:
 - Se o tamanho especificado define apenas a largura ou a altura, o valor que falta é determind se o valor espeficiado ado usando a relação intrínseca, se existir algum, as dimensões intrínsecas se o valoer espeficicado combinar, ou o tamanho do objeto padrão para esse valor ausente.
 - Se o tamanho especificado define nem largura ou altura, o tamanho concreto é calculado de modo que corresponda à proporção intrínseca da imagem mas sem exceder o tamanho padrão do objeto em qualquer dimensão. Se a imagem não tiver relação de aspecto intrínseco, o relação de aspecto intrínseco do objeto é aplicado para ser usado; se esse objeto for vazio, a largura ou altura que faltam são retirados do tamanho de objeto padrão.
 
-> **Nota:** Não são todos os navegadores que suportam cada tipo de imagem em cada propriedade. Veja a seção [compatibilidade dos navegadores](/pt-BR/docs/Web/CSS/image#Browser_compatibility) para mais detalhes.
+> [!NOTE]
+> Não são todos os navegadores que suportam cada tipo de imagem em cada propriedade. Veja a seção [compatibilidade dos navegadores](/pt-BR/docs/Web/CSS/image#Browser_compatibility) para mais detalhes.
 
 ## Sintaxe
 

--- a/files/pt-br/web/css/initial/index.md
+++ b/files/pt-br/web/css/initial/index.md
@@ -9,7 +9,8 @@ A palavra-chave CSS **`initial`** CSS se aplica ao [valor inicial (ou padrão)](
 
 Isto inclui também o atalho CSS {{cssxref("all")}}, no qual o `initial` pode ser utilizado para restaurar todas as propriedades CSS para o seu estado inicial.
 
-> **Nota:** Em [propriedades herdadas](/pt-BR/docs/Web/CSS/inheritance#propriedades_herdadas), O valor inicial pode ser inesperado. Neste caso, considere o uso dos termos {cssxref("inherit")}}, {{cssxref("unset")}}, ou {{cssxref("revert")}}.
+> [!NOTE]
+> Em [propriedades herdadas](/pt-BR/docs/Web/CSS/inheritance#propriedades_herdadas), O valor inicial pode ser inesperado. Neste caso, considere o uso dos termos {cssxref("inherit")}}, {{cssxref("unset")}}, ou {{cssxref("revert")}}.
 
 ## Exemplo
 

--- a/files/pt-br/web/css/initial_value/index.md
+++ b/files/pt-br/web/css/initial_value/index.md
@@ -10,7 +10,8 @@ O **Valor inicial** de uma propriedade [CSS](/pt-BR/docs/Web/CSS) é o seu valor
 - Para [propriedades herdadas](/pt-BR/docs/Web/CSS/inheritance#Propriedades_herdadas), o valor inicial é usado apenas em seu elemento raíz, desde que nenhum [valor especificado](/pt-BR/docs/Web/CSS/valor_espeficifco) seja fornecido.
 - Para [propriedades não-herdadas](/pt-BR/docs/Web/CSS/inheritance#Propriedades_nao_herdadas), o valor inicial é usado em todos os elementos, enquanto nenhum [valor especificado](/pt-BR/docs/Web/CSS/valor_espeficifco) é fornecido
 
-> **Nota:** Você pode especificar explicitamente um valor inicial, utilizando a palavra-chave {{cssxref("initial")}}
+> [!NOTE]
+> Você pode especificar explicitamente um valor inicial, utilizando a palavra-chave {{cssxref("initial")}}
 
 ## Veja Também
 

--- a/files/pt-br/web/css/layout_cookbook/index.md
+++ b/files/pt-br/web/css/layout_cookbook/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/Layout_cookbook
 
 O livro de receitas (Cookbook) de layout CSS visa reunir receitas para padrões de layout comuns, coisas que você pode precisar implementar em seus próprios sites. Além de fornecer código que você pode usar como ponto de partida em seus projetos, essas receitas destacam as diferentes maneiras pelas quais as especificações de layout podem ser usadas e as escolhas que você pode fazer como desenvolvedor.
 
-> **Nota:** Se você é novo no layout CSS, então primeiro você pode dar uma olhada em nosso módulo de aprendizado de layout CSS, pois isso lhe dará o básico de que você precisa para usar as receitas aqui.
+> [!NOTE]
+> Se você é novo no layout CSS, então primeiro você pode dar uma olhada em nosso módulo de aprendizado de layout CSS, pois isso lhe dará o básico de que você precisa para usar as receitas aqui.
 
 ## As Receitas
 

--- a/files/pt-br/web/css/layout_mode/index.md
+++ b/files/pt-br/web/css/layout_mode/index.md
@@ -12,4 +12,5 @@ O modelo de layout [CSS](/pt-BR/docs/Web/CSS), às vezes abreviado por _layout_,
 - [_Flexible box layout_](/pt-BR/docs/Web/CSS/CSS_Flexible_Box_Layout), designed for laying out complex pages that can be resized smoothly.
 - [_Grid layout_](/pt-BR/docs/Web/CSS/CSS_Grid_Layout), designed for laying out elements relative to a fixed grid.
 
-> **Nota:** Not all [CSS properties](/pt-BR/docs/Web/CSS/Reference) apply to all _layout modes_. Most of them apply to one or two of them and have no effect if they are set on an element participating in another layout mode.
+> [!NOTE]
+> Not all [CSS properties](/pt-BR/docs/Web/CSS/Reference) apply to all _layout modes_. Most of them apply to one or two of them and have no effect if they are set on an element participating in another layout mode.

--- a/files/pt-br/web/css/offset/index.md
+++ b/files/pt-br/web/css/offset/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/offset
 
 A propriedade CSS **`offset`** é uma propriedade abreviada para animar um elemento ao longo de um caminho definido.
 
-> **Nota:** As primeiras versões da especificação chamam essa propriedade de `motion`.
+> [!NOTE]
+> As primeiras versões da especificação chamam essa propriedade de `motion`.
 
 {{cssinfo}}
 

--- a/files/pt-br/web/css/overflow-wrap/index.md
+++ b/files/pt-br/web/css/overflow-wrap/index.md
@@ -9,7 +9,8 @@ slug: Web/CSS/overflow-wrap
 
 A propriedade [CSS](/pt-BR/CSS) `word-wrap` é utilizada para especificar se o navegador pode ou não quebrar linhas dentro das palavras, afim de prevenir o vazamento quando do contrário uma sequencia de caracteres é muito longa para caber na caixa que o contém.
 
-> **Nota:** Originalmente uma extensão proprietária da Microsoft (não prefixada), a propriedade `word-wrap` foi renomeada para `overflow-wrap` no rascunho atual do texto de especificações do CSS3. Compilações estáveis do Google Chrome e do Opera têm suporte a nova sintaxe.
+> [!NOTE]
+> Originalmente uma extensão proprietária da Microsoft (não prefixada), a propriedade `word-wrap` foi renomeada para `overflow-wrap` no rascunho atual do texto de especificações do CSS3. Compilações estáveis do Google Chrome e do Opera têm suporte a nova sintaxe.
 
 {{cssinfo}}
 

--- a/files/pt-br/web/css/overflow/index.md
+++ b/files/pt-br/web/css/overflow/index.md
@@ -11,7 +11,8 @@ A propriedade `overflow` especifica quando o conteúdo de um elemento de nível 
 
 O uso da propriedade `overflow` com valor diferente de `visible` (seu valor padrão), criará um novo [contexto de formatação de bloco](/pt-BR/docs/CSS/block_formatting_context). Isto é tecnicamente necessário para evitar que um conteúdo flutuante que entre em contato com o objeto dentro da área de rolamento e quebre as linhas do conteúdo para ajustar a disposição do texto. A quebra das linhas ocorre sempre que a barra de rolagem é utilizada, tornando a experiência de rolagem lenta.
 
-> **Nota:** Ao definir a propredade `scrollTop` para o `elemento` HTML relevante, mesmo que o valor de `overflow` seja `hidden`, o conteúdo ainda pode precisar rolar.
+> [!NOTE]
+> Ao definir a propredade `scrollTop` para o `elemento` HTML relevante, mesmo que o valor de `overflow` seja `hidden`, o conteúdo ainda pode precisar rolar.
 
 {{cssinfo}}
 

--- a/files/pt-br/web/css/page-break-before/index.md
+++ b/files/pt-br/web/css/page-break-before/index.md
@@ -5,7 +5,8 @@ slug: Web/CSS/page-break-before
 
 {{CSSRef}}
 
-> **Warning:** Esta propriedade foi substituída pela propriedade {{cssxref("break-before")}}.
+> [!WARNING]
+> Esta propriedade foi substituída pela propriedade {{cssxref("break-before")}}.
 
 A propriedade CSS **`page-break-before`** ajusta as "quebras de páginas" _antes_ do elemento atual.
 

--- a/files/pt-br/web/css/pseudo-classes/index.md
+++ b/files/pt-br/web/css/pseudo-classes/index.md
@@ -16,7 +16,8 @@ button:hover {
 
 Pseudo-classes permitem que você aplique um estilo a um elemento não apenas em relação ao conteúdo da árvore do documento, mas também em relação a fatores externos como o histórico de navegação ({{CSSxRef(":visited")}}, por exemplo), o status do seu conteúdo (como {{ CSSxRef(":checked")}} em certos elementos de um formulário), ou a posição do mouse (como {{CSSxRef(":hover")}}, que permite saber se o mouse está sobre um elemento ou não).
 
-> **Nota:** Diferentemente das pseudo-classes, [pseudo-elementos](/pt-BR/docs/Web/CSS/Pseudo-elementos) podem ser usados para estilizar uma _parte específica_ de um elemento.
+> [!NOTE]
+> Diferentemente das pseudo-classes, [pseudo-elementos](/pt-BR/docs/Web/CSS/Pseudo-elementos) podem ser usados para estilizar uma _parte específica_ de um elemento.
 
 ## Sintaxe
 

--- a/files/pt-br/web/css/pseudo-elements/index.md
+++ b/files/pt-br/web/css/pseudo-elements/index.md
@@ -13,7 +13,8 @@ p::first-line {
 }
 ```
 
-> **Nota:** Diferentemente dos pseudo-elementos, {{cssxref("pseudo-classes")}} podem ser utilizadas para estilizar um elemento baseado em seu _estado_.
+> [!NOTE]
+> Diferentemente dos pseudo-elementos, {{cssxref("pseudo-classes")}} podem ser utilizadas para estilizar um elemento baseado em seu _estado_.
 
 ## Sintaxe
 
@@ -25,7 +26,8 @@ seletor::pseudo-elemento {
 
 Você pode utilizar apenas um pseudo-elemento em um seletor. Ele deve aparecer depois da declaração de um elemento simples.
 
-> **Nota:** Como regra, os dois pontos devem ser usados duas vezes (`::`) ao invés de uma única vez (`:`). Isso distingue pseudo-classes de pseudo-elementos. Apesar disso, devido a essa distinção não estar presente em versões mais antigas da especificação da W3C, a maioria dos navegadores suportam ambas as sintaxes para os pseudo-elementos originais.
+> [!NOTE]
+> Como regra, os dois pontos devem ser usados duas vezes (`::`) ao invés de uma única vez (`:`). Isso distingue pseudo-classes de pseudo-elementos. Apesar disso, devido a essa distinção não estar presente em versões mais antigas da especificação da W3C, a maioria dos navegadores suportam ambas as sintaxes para os pseudo-elementos originais.
 
 ## Índice de pseudo-elementos comuns
 

--- a/files/pt-br/web/css/scrollbar-color/index.md
+++ b/files/pt-br/web/css/scrollbar-color/index.md
@@ -43,7 +43,8 @@ scrollbar-color: unset;
     | `light`           | Mostra uma scrollbar mais clara, podendo ser um estilo padrão definido pelo navegador, ou personalizado com cores escuras.  |
     | `<color> <color>` | A primeira cor é aplicada à **thumb**, a segunda cor ao **track**                                                           |
 
-    > **Nota:** User Agents must apply any `scrollbar-color` value set on the root element to the viewport.
+    > [!NOTE]
+    > User Agents must apply any `scrollbar-color` value set on the root element to the viewport.
 
 ### Sintaxe formal
 

--- a/files/pt-br/web/css/syntax/index.md
+++ b/files/pt-br/web/css/syntax/index.md
@@ -28,7 +28,8 @@ Esses blocos são chamados de **blocos de declaração** e as declarações dent
 
 ![css syntax - declarations block.png](css_syntax_-_declarations_block.png)
 
-> **Nota:** O conteúdo de um bloco de declaração, que é uma lista separada por pontos e vírgulas, sem as chaves, pode ser posto dentro da tag HTML [`style`](/pt-BR/HTML/Global_attributes#style).
+> [!NOTE]
+> O conteúdo de um bloco de declaração, que é uma lista separada por pontos e vírgulas, sem as chaves, pode ser posto dentro da tag HTML [`style`](/pt-BR/HTML/Global_attributes#style).
 
 ## Regras CSS
 
@@ -38,7 +39,8 @@ O CSS associa as condições com os blocos de declaração. Cada bloco (válido)
 
 Um elemento pode ser modificado por diversos seletores, e por isso por diversas regras que potencialmente podem conter diversas propriedades, com diferentes valores, o CSS padrão define aquele que possui a precedência e que será aplicado: esse é o tal algoritmo em [cascata](/pt-BR/docs/Web/CSS/Getting_Started/Cascading_and_inheritance).
 
-> **Nota:** É importante perceber que quando uma regra é caracterizada por um grupo de seletores que são algum tipo de atalho com cada um sendo um simples seletor isso não se aplica a validade da regra por si só.
+> [!NOTE]
+> É importante perceber que quando uma regra é caracterizada por um grupo de seletores que são algum tipo de atalho com cada um sendo um simples seletor isso não se aplica a validade da regra por si só.
 >
 > Isso leva a uma importante consequência: se apenas um dos seletores for inválido, como usar uma pseudo-classe ou pseudo-elemento desconhecido, todo o _seletor_ é inválido e por isso toda a regra é ignorada (invalidada também).
 

--- a/files/pt-br/web/css/text-decoration/index.md
+++ b/files/pt-br/web/css/text-decoration/index.md
@@ -11,7 +11,8 @@ A propriedade **`text-decoration`** do CSS é usada para definir a formatação 
 
 A propriedade text-decoration desenha em elementos descendentes. Isso significa que não é possivel desabilitar em um descendente uma decoração que foi especificada em um de seus antecessores. Por exemplo, no markup `<p>Esse texto tem <em>alguns elementos enfatizados</em> nele.</p>`, a regra de estilo `p { text-decoration: underline; }` faria com que todo o parágrafo fosse sublinhado. A regra `em { text-decoration: none; }` não causaria qualquer mudanca; o parágrafo inteiro ainda estaria sublinhado. Entretanto, a regra `em { text-decoration: overline; }` iria decorar o trecho "alguns elementos enfatizados".
 
-> **Nota:** CSS 3 transformou a propriedade Text-Decoration para forma reduzida, usando as seguintes propriedades: {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-line")}}, e {{cssxref("text-decoration-style")}}. Como em outras propriedades reduzidas, isso significa que ele reseta o valor de cada uma para padrão se não for explicitamente especificada na forma reduzida.
+> [!NOTE]
+> CSS 3 transformou a propriedade Text-Decoration para forma reduzida, usando as seguintes propriedades: {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-line")}}, e {{cssxref("text-decoration-style")}}. Como em outras propriedades reduzidas, isso significa que ele reseta o valor de cada uma para padrão se não for explicitamente especificada na forma reduzida.
 
 {{cssinfo}}
 

--- a/files/pt-br/web/css/text-shadow/index.md
+++ b/files/pt-br/web/css/text-shadow/index.md
@@ -48,7 +48,8 @@ text-shadow: unset;
 
   - : Opcional. Pode ser especificado tanto antes quanto depois dos valores de deslocamento. Se a cor não é especificada, uma cor UA-chosen será usada.
 
-    > **Nota:** Se voce quer garantir a consistência entre os navegadores, especifique explicitamente uma cor.
+    > [!NOTE]
+    > Se voce quer garantir a consistência entre os navegadores, especifique explicitamente uma cor.
 
 - \<offset-x> \<offset-y>
   - : Obrigatório. These `<length>` values specify the shadow's offset from the text. `<offset-x>` specifies the horizontal distance; a negative value places the shadow to the left of the text. `<offset-y>` specifies the vertical distance; a negative value places the shadow above the text. If both values are `0`, then the shadow is placed behind the text (and may generate a blur effect when `<blur-radius>` is set).

--- a/files/pt-br/web/css/text-transform/index.md
+++ b/files/pt-br/web/css/text-transform/index.md
@@ -42,9 +42,11 @@ Support for these specific cases vary from one browser to the other, so check th
 
   - : Is a keyword forcing the first _letter_ of each word to be converted to uppercase. Other characters are unchanged; that is, they retain their original case as written in the element's text. A letter is any Unicode character part of the Letter or Number general categories {{experimental_inline}} : it excludes any punctuation marks or symbols at the beginning of the word.
 
-    > **Nota:** Authors should not expect `capitalize` to follow language-specific title casing conventions (such as skipping articles in English).
+    > [!NOTE]
+    > Authors should not expect `capitalize` to follow language-specific title casing conventions (such as skipping articles in English).
 
-    > **Nota:** The `capitalize` keyword was under-specified in CSS 1 and CSS 2.1. There were differences between browsers in the way the first letter was calculated (Firefox considered - and \_ as letters, but not the others. Both Webkit and Gecko incorrectly considered letter-based symbols like `ⓐ` to be real letters. Internet Explorer 9 was the closest to the CSS 2 definition, but with some weird cases). By precisely defining the correct behavior, CSS Text Level 3 cleans this mess up. The `capitalize` line in the browser compatibility table contains the version the different engines started to support this now precisely defined behavior.
+    > [!NOTE]
+    > The `capitalize` keyword was under-specified in CSS 1 and CSS 2.1. There were differences between browsers in the way the first letter was calculated (Firefox considered - and \_ as letters, but not the others. Both Webkit and Gecko incorrectly considered letter-based symbols like `ⓐ` to be real letters. Internet Explorer 9 was the closest to the CSS 2 definition, but with some weird cases). By precisely defining the correct behavior, CSS Text Level 3 cleans this mess up. The `capitalize` line in the browser compatibility table contains the version the different engines started to support this now precisely defined behavior.
 
 - `uppercase`
   - : Is a keyword forcing all characters to be converted to uppercase.

--- a/files/pt-br/web/css/time/index.md
+++ b/files/pt-br/web/css/time/index.md
@@ -11,7 +11,8 @@ O tipo de dado CSS **`<time>`** representa um valor de tempo expresso em segundo
 
 O tipo dado `<time>` consiste de um elemento {{cssxref("&lt;number&gt;")}} seguido por uma das unidades listadas abaixo. Opcionalmente, pode ser precedido por um sinal de `+` ou `-`. Como em todas as dimensões, não há espaço entre uma unidade literal e o número.
 
-> **Nota:** Embora o número `0` seja sempre o mesmo, independente da unidade, essa última não pode ser omitida. Em outras palavras, `0` é invalido e não representa `0s` ou `0ms`.
+> [!NOTE]
+> Embora o número `0` seja sempre o mesmo, independente da unidade, essa última não pode ser omitida. Em outras palavras, `0` é invalido e não representa `0s` ou `0ms`.
 
 ### Unidades
 
@@ -20,7 +21,8 @@ O tipo dado `<time>` consiste de um elemento {{cssxref("&lt;number&gt;")}} segui
 - **`ms`**
   - : Representa um tempo em milissegundos. Exemplos: `0ms`, `150.25ms`, `-60000ms`.
 
-> **Nota:** A conversão entre `s` e `ms` segue a proporção `1s = 1000ms`.
+> [!NOTE]
+> A conversão entre `s` e `ms` segue a proporção `1s = 1000ms`.
 
 ## Exemplos
 

--- a/files/pt-br/web/css/transform-function/rotate3d/index.md
+++ b/files/pt-br/web/css/transform-function/rotate3d/index.md
@@ -9,7 +9,8 @@ A função [CSS](/pt-BR/docs/Web/CSS) **`rotate3d()`** define uma transformaçã
 
 No espaço 3D, rotações têm três graus de liberdade que, juntos, descrevem um único eixo de rotação. O eixo de rotação é definido por um vetor \[x, y, z] e passado pela origem (como definido pela propriedade {{ cssxref("transform-origin") }}). Se, como especificado, o vetor não for _normalizado_ (isto é, se a soma dos quadrados das suas três coordenadas não for 1), o {{glossary("user agent")}} irá normalizá-lo internamente. Um vetor não-normalizável, como o vetor nulo \[0, 0, 0], fará com que a rotação seja ignorada, mas sem invalidar toda a propriedade CSS.
 
-> **Nota:** Diferente de rotações no plano 2D, a composição de rotações 3D normalmente não é comutativa. Em outras palavras, a ordem na qual as rotações são aplicadas impacta o resultado.
+> [!NOTE]
+> Diferente de rotações no plano 2D, a composição de rotações 3D normalmente não é comutativa. Em outras palavras, a ordem na qual as rotações são aplicadas impacta o resultado.
 
 ## Sintaxe
 

--- a/files/pt-br/web/css/transform-function/scale/index.md
+++ b/files/pt-br/web/css/transform-function/scale/index.md
@@ -13,7 +13,8 @@ Essa transformação de redimensionamento é caracterizada por um vetor bidimens
 
 Quando o valor de uma coordenada está fora do alcance \[-1, 1], o elemento cresce ao longo daquela dimensão; quando está dentro, ele encolhe. Se for negativo, o resultado é um [ponto de reflexão](https://en.wikipedia.org/wiki/Point_reflection) naquela dimensão. O valor 1 não tem efeito.
 
-> **Nota:** A função `scale()` apenas redimensiona em 2D Para redimensionar em 3D, use [`scale3d()`](/pt-BR/docs/Web/CSS/transform-function/scale3d) ao invés.
+> [!NOTE]
+> A função `scale()` apenas redimensiona em 2D Para redimensionar em 3D, use [`scale3d()`](/pt-BR/docs/Web/CSS/transform-function/scale3d) ao invés.
 
 ## Sintaxe
 

--- a/files/pt-br/web/css/transform-origin/index.md
+++ b/files/pt-br/web/css/transform-origin/index.md
@@ -117,7 +117,8 @@ As palavras-chave são atalhos convenientes e correspondem aos seguintes valores
 
 {{CSSInfo}}
 
-> **Nota:** O valor inicial de `transform-origin` é `0 0` para todos os elementos SVG, exceto para elementos `<svg>` raiz e elementos `<svg>` que são filhos diretos de um elemento [foreignObject](/pt-BR/docs/Web/SVG/Element/foreignObject), cujo `transform-origin` é `50% 50%`, assim como outros elementos CSS. Consulte o atributo [transform-origin](/pt-BR/docs/Web/SVG/Attribute/transform-origin) do SVG para obter mais informações.
+> [!NOTE]
+> O valor inicial de `transform-origin` é `0 0` para todos os elementos SVG, exceto para elementos `<svg>` raiz e elementos `<svg>` que são filhos diretos de um elemento [foreignObject](/pt-BR/docs/Web/SVG/Element/foreignObject), cujo `transform-origin` é `50% 50%`, assim como outros elementos CSS. Consulte o atributo [transform-origin](/pt-BR/docs/Web/SVG/Attribute/transform-origin) do SVG para obter mais informações.
 
 ## Sintaxe formal
 

--- a/files/pt-br/web/css/transform/index.md
+++ b/files/pt-br/web/css/transform/index.md
@@ -97,7 +97,8 @@ transform:  matrix(a, c, b, d, tx, ty)
 
 Specifies a 2D transformation matrix comprised of the specified six values. This is the equivalent to applying the transformation **matrix \[a b c d tx ty]**.
 
-> **Nota:** Gecko (Firefox) accepts a {{cssxref("&lt;length&gt;")}} value for **tx** and **ty**. Webkit (Safari, Chrome) and Opera currently support a unitless {{cssxref("&lt;number&gt;")}} for **tx** and **ty**.
+> [!NOTE]
+> Gecko (Firefox) accepts a {{cssxref("&lt;length&gt;")}} value for **tx** and **ty**. Webkit (Safari, Chrome) and Opera currently support a unitless {{cssxref("&lt;number&gt;")}} for **tx** and **ty**.
 
 #### Live examples
 
@@ -166,7 +167,8 @@ transform:  skew(ax[, ay])       /* one or two <angle>s, e.g.  skew(30deg,-10deg
 
 Skews the element around the X and Y axes by the specified angles. If `ay` isn't provided, no skew is performed on the Y axis.
 
-> **Nota:** The `skew()` function was present in early drafts. It has been removed but is still present in some implementations. Do not use it.
+> [!NOTE]
+> The `skew()` function was present in early drafts. It has been removed but is still present in some implementations. Do not use it.
 >
 > To achieve the same effect, use `skewX()` if you were using `skew()` with one parameter or `matrix(1, tan(ax)`_,_ `tan(ay), 1, 0, 0)` for the general way. Note that _tan()_ isn't a CSS function and you have to precalculate it yourself.
 

--- a/files/pt-br/web/css/using_css_custom_properties/index.md
+++ b/files/pt-br/web/css/using_css_custom_properties/index.md
@@ -31,7 +31,8 @@ Observe que o seletor fornecido ao conjunto de regras define o escopo no qual a 
 
 No entanto, isso nem sempre precisa ser o caso: talvez você tenha um bom motivo para limitar o escopo de suas propriedades personalizadas.
 
-> **Nota:** Os nomes das propriedades personalizadas diferenciam maiúsculas de minúsculas — `--my-color` será tratado como uma propriedade personalizada separada de `--My-color`.
+> [!NOTE]
+> Os nomes das propriedades personalizadas diferenciam maiúsculas de minúsculas — `--my-color` será tratado como uma propriedade personalizada separada de `--My-color`.
 
 Conforme mencionado anteriormente, você usa o valor da propriedade personalizada especificando o nome da propriedade personalizada dentro da função {{cssxref("var", "var()")}}, no lugar de um valor de propriedade regular:
 
@@ -189,7 +190,8 @@ Lembre-se de que essas são propriedades personalizadas, não variáveis reais, 
 
 Usando a função [`var()`](/pt-BR/docs/Web/CSS/var), você pode definir vários **valores alternativos** quando a variável dada ainda não está definida; isso pode ser útil ao trabalhar com [Elementos personalizados](/pt-BR/docs/Web/Web_Components/Using_custom_elements) e [Shadow DOM](/pt-BR/docs/Web/Web_Components/Using_shadow_DOM).
 
-> **Nota:** os valores alternativos não são usados para corrigir a compatibilidade do navegador. Se o navegador não oferecer suporte a propriedades personalizadas de CSS, o valor de fallback não ajudará. É apenas um backup para o navegador que suporta propriedades personalizadas CSS para escolher um valor diferente se a variável fornecida não estiver definida ou tiver um valor inválido.
+> [!NOTE]
+> os valores alternativos não são usados para corrigir a compatibilidade do navegador. Se o navegador não oferecer suporte a propriedades personalizadas de CSS, o valor de fallback não ajudará. É apenas um backup para o navegador que suporta propriedades personalizadas CSS para escolher um valor diferente se a variável fornecida não estiver definida ou tiver um valor inválido.
 
 O primeiro argumento para a função é o nome da [propriedade personalizada](https://www.w3.org/TR/css-variables/#custom-property) a ser substituída. O segundo argumento para a função, se fornecido, é um valor de fallback, que é usado como valor de substituição quando a [propriedade personalizada](https://www.w3.org/TR/css-variables/#custom-property) referenciada é inválido. A função aceita apenas dois parâmetros, atribuindo tudo o que segue a primeira vírgula como segundo parâmetro. Se esse segundo parâmetro for inválido, o fallback falhará. Por exemplo:
 
@@ -212,7 +214,8 @@ O primeiro argumento para a função é o nome da [propriedade personalizada](ht
 
 Incluir uma propriedade personalizada como fallback, conforme visto no segundo exemplo acima, é a maneira correta de fornecer mais de um fallback. A técnica pode causar problemas de desempenho, pois leva mais tempo para analisar as variáveis.
 
-> **Nota:** A sintaxe do fallback, como a de [propriedades personalizadas](https://www.w3.org/TR/css-variables/#custom-property), permite vírgulas. Por exemplo, `var(--foo, red, blue)` define um fallback de `red, blue` — qualquer coisa entre a primeira vírgula e o final da função é considerado um valor fallback.
+> [!NOTE]
+> A sintaxe do fallback, como a de [propriedades personalizadas](https://www.w3.org/TR/css-variables/#custom-property), permite vírgulas. Por exemplo, `var(--foo, red, blue)` define um fallback de `red, blue` — qualquer coisa entre a primeira vírgula e o final da função é considerado um valor fallback.
 
 ## Tratamento de propriedades personalizadas inválidas
 

--- a/files/pt-br/web/css/var/index.md
+++ b/files/pt-br/web/css/var/index.md
@@ -19,7 +19,8 @@ O primeiro argumento da função é o nome da propriedade personalizada a ser su
 
 {{csssyntax}}
 
-> **Nota:** A sintaxe do argumento alternativo, assim como as propriedades personalizadas, permite o uso de vírgulas. Por exemplo, `var(--foo, red, blue)` define como argumento alternativo `red, blue`; isto é, qualquer coisa entre a primeira vírgula e o fim da função é considerado como valor do como argumento alternativo.
+> [!NOTE]
+> A sintaxe do argumento alternativo, assim como as propriedades personalizadas, permite o uso de vírgulas. Por exemplo, `var(--foo, red, blue)` define como argumento alternativo `red, blue`; isto é, qualquer coisa entre a primeira vírgula e o fim da função é considerado como valor do como argumento alternativo.
 
 ### Valores
 

--- a/files/pt-br/web/css/visibility/index.md
+++ b/files/pt-br/web/css/visibility/index.md
@@ -19,7 +19,8 @@ visibility: initial;
 visibility: unset;
 ```
 
-> **Nota:** Para ocultar um elemento ou removê-lo do layout do documento, defina a propriedade {{cssxref("display")}} como `none` em vez de usar `visibility`.
+> [!NOTE]
+> Para ocultar um elemento ou removê-lo do layout do documento, defina a propriedade {{cssxref("display")}} como `none` em vez de usar `visibility`.
 
 {{cssinfo}}
 

--- a/files/pt-br/web/css/word-break/index.md
+++ b/files/pt-br/web/css/word-break/index.md
@@ -9,7 +9,8 @@ A propriedade CSS **`word-break`** é usada para especificar se o navegador deve
 
 {{EmbedInteractiveExample("pages/css/word-break.html")}}
 
-> **Nota:** comparando com {{cssxref("overflow-wrap")}}, `word-break` criará uma quebra de linha no ponto exato em que o texto vazaria, mesmo que uma palavra pudesse ser colocada por completo em uma nova linha sem a necessidade de quebra da palavra.
+> [!NOTE]
+> comparando com {{cssxref("overflow-wrap")}}, `word-break` criará uma quebra de linha no ponto exato em que o texto vazaria, mesmo que uma palavra pudesse ser colocada por completo em uma nova linha sem a necessidade de quebra da palavra.
 
 ## Sintaxe
 

--- a/files/pt-br/web/html/content_categories/index.md
+++ b/files/pt-br/web/html/content_categories/index.md
@@ -38,7 +38,8 @@ Os elementos pertencentes ao modelo de conteúdo de seccionamento criam uma [se�
 
 Elementos pertencentes a essa categoria são {{HTMLElement("article")}}, {{HTMLElement("aside")}}, {{HTMLElement("nav")}} e {{HTMLElement("section")}}.
 
-> **Nota:** Não confunda esse modelo de conteúdo com a categoria de [seccionamento raiz](/pt-BR/docs/Sections_and_Outlines_of_an_HTML5_document#sectioning_root) que isola seus conteúdos dos esboços regulares.
+> [!NOTE]
+> Não confunda esse modelo de conteúdo com a categoria de [seccionamento raiz](/pt-BR/docs/Sections_and_Outlines_of_an_HTML5_document#sectioning_root) que isola seus conteúdos dos esboços regulares.
 
 ### Conteúdo do cabeçalho
 
@@ -46,7 +47,8 @@ O conteúdo do cabeçalho define o título de uma seção, se é marcada por um 
 
 Os elementos pertencentes a essa categoria são {{HTMLElement("h1")}}, {{HTMLElement("h2")}}, {{HTMLElement("h3")}}, {{HTMLElement("h4")}}, {{HTMLElement("h5")}}, {{HTMLElement("h6")}} e {{HTMLElement("hgroup")}}.
 
-> **Nota:** Embora provavelmente contenha algum conteúdo do cabeçalho, o {{HTMLElement("header")}} não faz parte do conteúdo do cabeçalho em si.
+> [!NOTE]
+> Embora provavelmente contenha algum conteúdo do cabeçalho, o {{HTMLElement("header")}} não faz parte do conteúdo do cabeçalho em si.
 
 ### Conteúdo fraseado
 

--- a/files/pt-br/web/html/element/a/index.md
+++ b/files/pt-br/web/html/element/a/index.md
@@ -56,7 +56,8 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
     - `_parent`: the parent browsing context of the current one. If no parent, behaves as `_self`.
     - `_top`: the topmost browsing context (the "highest" context that's an ancestor of the current one). If no ancestors, behaves as `_self`.
 
-    > **Note:** Quando usando `target`, adicione `rel="noreferrer noopener"` para evitar "exploit" para `window.opener` API;
+    > [!NOTE]
+    > Quando usando `target`, adicione `rel="noreferrer noopener"` para evitar "exploit" para `window.opener` API;
 
     > **Warning:** **Note:** Linking to another page with `target="_blank"` will run the new page in the same process as your page. If the new page executes JavaScript, your page's performance may suffer. This can also be avoided by using `rel="noreferrer noopener"`.
 
@@ -69,7 +70,8 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
 
   - : Hinted at the {{Glossary("character encoding")}} of the linked URL.
 
-    > **Note:** This attribute is obsolete and **should not be used by authors**. Use the HTTP {{HTTPHeader("Content-Type")}} header on the linked URL.
+    > [!NOTE]
+    > This attribute is obsolete and **should not be used by authors**. Use the HTTP {{HTTPHeader("Content-Type")}} header on the linked URL.
 
 - `coords`
   - : Used with [the `shape` attribute](#shape). A comma-separated list of coordinates.
@@ -77,7 +79,8 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
 
   - : Was required to define a possible target location in a page. In HTML 4.01, `id` and `name` could both be used on `<a>`, as long as they had identical values.
 
-    > **Note:** Use the global attribute [`id`](/pt-BR/docs/Web/HTML/Global_attributes#id) instead.
+    > [!NOTE]
+    > Use the global attribute [`id`](/pt-BR/docs/Web/HTML/Global_attributes#id) instead.
 
 - `rev`
   - : Specified a reverse link; the opposite of [the `rel` attribute](#rel). Deprecated for being very confusing.
@@ -85,7 +88,8 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
 
   - : The shape of the hyperlink's region in an image map.
 
-    > **Note:** Use the {{HTMLElement("area")}} element for image maps instead.
+    > [!NOTE]
+    > Use the {{HTMLElement("area")}} element for image maps instead.
 
 ## Properties
 
@@ -226,7 +230,8 @@ a {
 <h2 id="Section_further_down">Section further down</h2>
 ```
 
-> **Note:** You can use `href="#top"` or the empty fragment (`href="#"`) to link to the top of the current page, [as defined in the HTML specification](https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier).
+> [!NOTE]
+> You can use `href="#top"` or the empty fragment (`href="#"`) to link to the top of the current page, [as defined in the HTML specification](https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier).
 
 ### Linking to an email address
 

--- a/files/pt-br/web/html/element/abbr/index.md
+++ b/files/pt-br/web/html/element/abbr/index.md
@@ -5,9 +5,10 @@ slug: Web/HTML/Element/abbr
 
 ## Sumário
 
-O _Elemento_ _HTML `<abbr>` _(ou Elemento de Abreviação HTML) representa uma abreviação e opcionalmente fornece uma descrição completa para ela. Se presente, o atributo **`title`** deve conter a descrição completa e apenas ela.
+O _Elemento HTML `<abbr>`_ (ou Elemento de Abreviação HTML) representa uma abreviação e opcionalmente fornece uma descrição completa para ela. Se presente, o atributo **`title`** deve conter a descrição completa e apenas ela.
 
-> **Note:** Quando presente, o número gramatical (singular/plural) do texto no atributo **`title`** deve ser correspondente ao do conteúdo do elemento `<abbr>`. Isso também deve ocorrer no caso das linguagens com mais de dois números gramaticais (por exemplo, em árabe não há somente palavras no singular e plural, mas tem também uma categoria dual).
+> [!NOTE]
+> Quando presente, o número gramatical (singular/plural) do texto no atributo **`title`** deve ser correspondente ao do conteúdo do elemento `<abbr>`. Isso também deve ocorrer no caso das linguagens com mais de dois números gramaticais (por exemplo, em árabe não há somente palavras no singular e plural, mas tem também uma categoria dual).
 
 - _[Categorias de conteúdo](/pt-BR/docs/HTML/Content_categories)_ [Conteúdo de fluxo](/pt-BR/docs/HTML/Content_categories#Flow_content), [conteúdo de fraseamento](/pt-BR/docs/HTML/Content_categories#Phrasing_content), conteúdo palpável
 - _Conteúdo permitido_[Conteúdo de fraseamento](/pt-BR/docs/HTML/Content_categories#Phrasing_content).

--- a/files/pt-br/web/html/element/acronym/index.md
+++ b/files/pt-br/web/html/element/acronym/index.md
@@ -7,7 +7,8 @@ slug: Web/HTML/Element/acronym
 
 O Elemento HTML Acrônimo (`<acronym>)` permite à autores claramente indicar que uma seqüência de caracteres compõe um acrônimo ou uma abreviação de uma palavra.
 
-> **Note:** Este elemento foi removido no HTML5 e não deve ser usado mais. Ao invés dele, desenvolvedores devem usar o elemento {{HTMLElement("abbr")}}.
+> [!NOTE]
+> Este elemento foi removido no HTML5 e não deve ser usado mais. Ao invés dele, desenvolvedores devem usar o elemento {{HTMLElement("abbr")}}.
 
 ## Atributos
 

--- a/files/pt-br/web/html/element/audio/index.md
+++ b/files/pt-br/web/html/element/audio/index.md
@@ -57,7 +57,8 @@ Como todos os elementos HTML, este elemento suporta os [global attributes](/pt-B
 
 O tempo de compensação (time offset) entre o áudio e o vídeo está especificado como um valor de ponto flutuante (float) representando o número de segundos da compensação.
 
-> **Nota:** A definição de valor de tempo de compensação ainda não foi completada na especificação do HTML 5 e está sujeita a mudança.
+> [!NOTE]
+> A definição de valor de tempo de compensação ainda não foi completada na especificação do HTML 5 e está sujeita a mudança.
 
 ## Examples
 

--- a/files/pt-br/web/html/element/base/index.md
+++ b/files/pt-br/web/html/element/base/index.md
@@ -7,7 +7,8 @@ slug: Web/HTML/Element/base
 
 O _elemento HTML Base_ (**\<base>**) especifica o endereço (URL) utilizada por todos os endereços relativos contidos dentro de um documento. Há um número máximo de 1 (um) elemento _Base_ \<base> do documento.
 
-> **Note:** Se multiplos elementos `<base>` forem especificados, apenas o primeiro valor de **href** e **target** serão utilizados, os demais serão ignorados.
+> [!NOTE]
+> Se multiplos elementos `<base>` forem especificados, apenas o primeiro valor de **href** e **target** serão utilizados, os demais serão ignorados.
 
 - _[Content categories](/pt-BR/docs/HTML/Content_categories)_ Metadata content.
 - _Permitted content_ None, it is an {{Glossary("empty element")}}.

--- a/files/pt-br/web/html/element/br/index.md
+++ b/files/pt-br/web/html/element/br/index.md
@@ -65,7 +65,8 @@ Este elemento inclue os [Atributos globais](/pt-BR/docs/HTML/Global_attributes).
 
   - : Indica onde começar a próxima linha depois da quebra.
 
-    > **Nota:** Este atributo está obsoleto em HTML 5 e **Não deve ser usado por autores**. Use a propriedade CSS {{CSSxref('clear')}} em vez disso.
+    > [!NOTE]
+    > Este atributo está obsoleto em HTML 5 e **Não deve ser usado por autores**. Use a propriedade CSS {{CSSxref('clear')}} em vez disso.
 
 ## Exemplo
 

--- a/files/pt-br/web/html/element/canvas/index.md
+++ b/files/pt-br/web/html/element/canvas/index.md
@@ -26,7 +26,8 @@ Como qualquer outro elemento HTML, este também tem [global attributes](/pt-BR/H
 - `height`
   - : A altura do espaço em pixels CSS. O padrão é 150.
 
-> **Nota:** The displayed size of the canvas can be changed using a stylesheet. The image is scaled during rendering to fit the styled size.
+> [!NOTE]
+> The displayed size of the canvas can be changed using a stylesheet. The image is scaled during rendering to fit the styled size.
 
 ## Interface DOM
 

--- a/files/pt-br/web/html/element/caption/index.md
+++ b/files/pt-br/web/html/element/caption/index.md
@@ -80,7 +80,8 @@ Os seguintes atributos são obsoletos e não devem ser usados. Estão documentad
     - `bottom`
       - : A legenda é exibida abaixo da tabela.
 
-    > **Aviso:** Não use este atributo já que ele foi depreciado: O elemento {{HTMLElement("caption")}} deve ser estilizado usando as propriedades [CSS](/pt-BR/docs/Web/CSS). Para dar um efeito similar ao atributo `align`, use as propriedades [CSS](/pt-BR/docs/Web/CSS) {{cssxref("caption-side")}} e {{cssxref("text-align")}}.
+    > [!WARNING]
+    > Não use este atributo já que ele foi depreciado: O elemento {{HTMLElement("caption")}} deve ser estilizado usando as propriedades [CSS](/pt-BR/docs/Web/CSS). Para dar um efeito similar ao atributo `align`, use as propriedades [CSS](/pt-BR/docs/Web/CSS) {{cssxref("caption-side")}} e {{cssxref("text-align")}}.
 
 ## Notas de uso
 

--- a/files/pt-br/web/html/element/dir/index.md
+++ b/files/pt-br/web/html/element/dir/index.md
@@ -5,7 +5,8 @@ slug: Web/HTML/Element/dir
 
 O elemento de diretório HTML obsoleto (**`<dir>`**) é usado como um contêiner para um diretório de arquivos e/ou pastas, potencialmente com estilos e ícones aplicados pelo {{Glossary("user agent")}}. Não use este elemento obsoleto; em vez disso, você deve usar o {{HTMLElement("ul")}} elemento para listas, incluindo listas de arquivos.
 
-> **Note:** Não use este elemento. Embora presente nas primeiras especificações do HTML, foi descontinuado no HTML 4 e, desde então, foi totalmente removido. Nenhum dos principais navegadores suporta esse elemento.
+> [!NOTE]
+> Não use este elemento. Embora presente nas primeiras especificações do HTML, foi descontinuado no HTML 4 e, desde então, foi totalmente removido. Nenhum dos principais navegadores suporta esse elemento.
 
 ## DOM interface
 
@@ -19,7 +20,8 @@ Como todos os outros elementos HTML, este elemento suporta os [global attributes
 
   - : Este atributo booleano indica que a lista deve ser renderizada em um estilo compacto. A interpretação deste atributo depende do agente do usuário e não funciona em todos os navegadores.
 
-    > **Note:** Não use este atributo, pois ele foi descontinuado: o {{HTMLElement("dir")}} elemento deve ser estilizado usando [CSS](/pt-BR/docs/CSS). Para dar um efeito semelhante ao alcançado com o atributo `compact`, a propriedade [CSS](/pt-BR/docs/CSS) {{cssxref("line-height")}} pode ser usado com um valor de `80%`.
+    > [!NOTE]
+    > Não use este atributo, pois ele foi descontinuado: o {{HTMLElement("dir")}} elemento deve ser estilizado usando [CSS](/pt-BR/docs/CSS). Para dar um efeito semelhante ao alcançado com o atributo `compact`, a propriedade [CSS](/pt-BR/docs/CSS) {{cssxref("line-height")}} pode ser usado com um valor de `80%`.
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/html/element/embed/index.md
+++ b/files/pt-br/web/html/element/embed/index.md
@@ -9,7 +9,8 @@ O **elemento HTML `<embed>`** incorpora conteúdo externo no ponto especificado 
 
 {{EmbedInteractiveExample("pages/tabbed/embed.html", "tabbed-standard")}}
 
-> **Nota:** Este tópico documenta apenas o elemento definido como parte do HTML5. Ele não trata da implementação anterior e não padronizada do elemento.
+> [!NOTE]
+> Este tópico documenta apenas o elemento definido como parte do HTML5. Ele não trata da implementação anterior e não padronizada do elemento.
 
 Lembre-se de que a maioria dos navegadores modernos descontinuou e removeu o suporte para plug-ins de navegador. Portanto, confiar no `<embed>` geralmente não é aconselhável se você deseja que seu site funcione no navegador do usuário comum.
 
@@ -44,7 +45,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 
 ## Compatibilidade com navegadores
 
-> **Nota:** Atualmente existe uma diferença na implementação pelos navegadores. Enquanto carrega, no Chrome e no Opera, aparece o conteúdo do recurso em HTML, no Firefox, mostra uma mensagem genérica falando que o conteúdo precisa de um _plug-in_ (veja o [Erro do Firefox 730768](https://bugzil.la/730768)). É recomendado que se use os elementos {{HTMLElement("object")}} ou {{HTMLElement("iframe")}}.
+> [!NOTE]
+> Atualmente existe uma diferença na implementação pelos navegadores. Enquanto carrega, no Chrome e no Opera, aparece o conteúdo do recurso em HTML, no Firefox, mostra uma mensagem genérica falando que o conteúdo precisa de um _plug-in_ (veja o [Erro do Firefox 730768](https://bugzil.la/730768)). É recomendado que se use os elementos {{HTMLElement("object")}} ou {{HTMLElement("iframe")}}.
 
 {{Compat}}
 

--- a/files/pt-br/web/html/element/fieldset/index.md
+++ b/files/pt-br/web/html/element/fieldset/index.md
@@ -54,7 +54,8 @@ O **elemento HTML `<fieldset>`** é usado para agrupar elementos, assim como lab
   </tbody>
 </table>
 
-> **Note:** diferente de quase todo outro elemento, a especificação do WHATWG HTML Rendering sugere `{{cssxref("min-width")}}: min-content` como parte do padrão de estilo para {{HTMLElement("fieldset")}}, e muitos navegadores implementam tal estilização (ou algo que se aproxima disto).
+> [!NOTE]
+> diferente de quase todo outro elemento, a especificação do WHATWG HTML Rendering sugere `{{cssxref("min-width")}}: min-content` como parte do padrão de estilo para {{HTMLElement("fieldset")}}, e muitos navegadores implementam tal estilização (ou algo que se aproxima disto).
 
 ## Atributos
 
@@ -68,7 +69,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 
   - : O nome associado com o grupo.
 
-    > **Note:** O label para o fieldset é dado pelo primeiro elemento {{HTMLElement("legend")}} que é um filho do fieldset.
+    > [!NOTE]
+    > O label para o fieldset é dado pelo primeiro elemento {{HTMLElement("legend")}} que é um filho do fieldset.
 
 ## Exemplos
 

--- a/files/pt-br/web/html/element/hgroup/index.md
+++ b/files/pt-br/web/html/element/hgroup/index.md
@@ -53,7 +53,8 @@ Esse elemento admite apenas os [global attributes](/pt-BR/docs/HTML/Global_attri
 
 ## Notas sobre o uso
 
-> **Note:** O elemento `<hgroup>` foi removido da especificação do W3C para a HTML5, mas ainda se encontra na especificação HTML do WHATWG. Foi parcialmente implementado na maioria dos navegadores, contudo é pouco provável que seja incluído na especificação.
+> [!NOTE]
+> O elemento `<hgroup>` foi removido da especificação do W3C para a HTML5, mas ainda se encontra na especificação HTML do WHATWG. Foi parcialmente implementado na maioria dos navegadores, contudo é pouco provável que seja incluído na especificação.
 > Considerando que a finalidade do elemento `<hgroup>` é a de definir a maneira como os títulos serão mostrados pelo [outline algorithm definido na especificação da HTML](/pt-BR/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#The_HTML5_outline_algorithm) e considerando ainda que o **outline algorithm da HTML não está implementado em nenhum navegador**, conclui-se que, na prática, a semântica do elemento `<hgroup>` é meramente teórica.
 > A especificação do W3C para a HTML5 fornece algumas sugestões para a marcação de [Subheadings, subtitles, alternative titles and taglines](https://www.w3.org/TR/html52/common-idioms-without-dedicated-elements.html#common-idioms-without-dedicated-elements) sem que se use o elemento `<hgroup>`.
 

--- a/files/pt-br/web/html/element/iframe/index.md
+++ b/files/pt-br/web/html/element/iframe/index.md
@@ -60,7 +60,9 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
     - `allow-scripts`: Allows the embedded browsing context to run scripts (but not create pop-up windows). If this keyword is not used, this operation is not allowed.
     - `allow-pointer-lock`: Allows the embedded browsing context to use the [Pointer Lock API](/pt-BR/docs/WebAPI/Pointer_Lock).
 
-    > **Note:**
+    > [!NOTE]
+    >
+    > >
     >
     > - When the embedded document has the same origin as the main page, it is strongly discouraged to use both `allow-scripts` and `allow-same-origin` at the same time, as that allows the embedded document to programmatically remove the `sandbox` attribute. Although it is accepted, this case is no more secure than not using the `sandbox` attribute.
     > - Sandboxing in general is only of minimal help if the attacker can arrange for the potentially hostile content to be displayed in the user's browser outside a sandboxed `iframe`. It is recommended that such content should be served from a _separate dedicated domain_, to limit the potential damage.
@@ -127,7 +129,8 @@ Scripts trying to access a frame's content are subject to the [same-origin polic
 
 ## Notas
 
-> **Note:** Starting in Gecko 6.0, rendering of inline frames correctly respects the borders of their containing element when they're rounded using {{cssxref("border-radius")}}.
+> [!NOTE]
+> Starting in Gecko 6.0, rendering of inline frames correctly respects the borders of their containing element when they're rounded using {{cssxref("border-radius")}}.
 
 ## Especificações
 

--- a/files/pt-br/web/html/element/input/button/index.md
+++ b/files/pt-br/web/html/element/input/button/index.md
@@ -9,7 +9,8 @@ Elementos {{HTMLElement("input")}} do tipo **`button`** são renderizados como u
 
 {{EmbedInteractiveExample("pages/tabbed/input-button.html", "tabbed-shorter")}}
 
-> **Nota:** Enquanto elementos `<input>` do tipo `button` ainda são perfeitamente válidos, os novos elementos {{HTMLElement("button")}} são agora os favoráveis meios para criar botões. Uma etiqueta de texto (label) para um {{HTMLElement("button")}} pode ser inserida entre uma tag de abertura e outra de fechamento, podendo ser incluídas até imagens.
+> [!NOTE]
+> Enquanto elementos `<input>` do tipo `button` ainda são perfeitamente válidos, os novos elementos {{HTMLElement("button")}} são agora os favoráveis meios para criar botões. Uma etiqueta de texto (label) para um {{HTMLElement("button")}} pode ser inserida entre uma tag de abertura e outra de fechamento, podendo ser incluídas até imagens.
 
 <table class="properties">
   <tbody>
@@ -129,7 +130,8 @@ function updateButton() {
 
 {{EmbedLiveSample("Adding_keyboard_shortcuts_to_buttons", 650, 100)}}
 
-> **Note:** The problem with the above example of course is that the user will not know what the access key is! In a real site, you'd have to provide this information in a way that doesn't intefere with the site design (for example by providing an easily accessible link that points to information on what the site accesskeys are).
+> [!NOTE]
+> The problem with the above example of course is that the user will not know what the access key is! In a real site, you'd have to provide this information in a way that doesn't intefere with the site design (for example by providing an easily accessible link that points to information on what the site accesskeys are).
 
 ### Desativando e ativando um botão
 
@@ -191,7 +193,8 @@ function disableButton() {
 
 {{EmbedLiveSample("Hidden_code_2", 650, 60)}}
 
-> **Note:** Firefox will, unlike other browsers, by default, [persist the dynamic disabled state](http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) of a {{HTMLElement("button")}} across page loads. Use the [`autocomplete`](/pt-BR/docs/Web/HTML/Element/button#autocomplete) attribute to control this feature.
+> [!NOTE]
+> Firefox will, unlike other browsers, by default, [persist the dynamic disabled state](http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) of a {{HTMLElement("button")}} across page loads. Use the [`autocomplete`](/pt-BR/docs/Web/HTML/Element/button#autocomplete) attribute to control this feature.
 
 ## Validação
 

--- a/files/pt-br/web/html/element/input/index.md
+++ b/files/pt-br/web/html/element/input/index.md
@@ -181,7 +181,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Atributos_globais).
 
   - : Uma dica para o usuário do que ele pode inserir no controle. O texto do atributo não deve conter quebras de linha. Este atributo é aplicado quando o valor do atributo **type** é `text`, `search`, `tel`, `url` ou `email`; caso contrário, ele é ignorado.
 
-    > **Nota:** Não use o atributo `placeholder` no lugar de um elemento {{HTMLElement("label")}}. Os propósitos de cada um são diferentes: o atributo {{HTMLElement("label")}} descreve o papel o elemento do formulário, isto é, ele indica que tipo de informação é esperada. Já o atributo `placeholder` é uma dica sobre o formato que o conteúdo deveria ter. Há casos em que o atributo `placeholder` nunca é exibido para o usuário, portanto o formulário deve ser inteligível sem ele.
+    > [!NOTE]
+    > Não use o atributo `placeholder` no lugar de um elemento {{HTMLElement("label")}}. Os propósitos de cada um são diferentes: o atributo {{HTMLElement("label")}} descreve o papel o elemento do formulário, isto é, ele indica que tipo de informação é esperada. Já o atributo `placeholder` é uma dica sobre o formato que o conteúdo deveria ter. Há casos em que o atributo `placeholder` nunca é exibido para o usuário, portanto o formulário deve ser inteligível sem ele.
 
 - `readonly`
 
@@ -215,7 +216,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Atributos_globais).
 
 ### Entradas de arquivo
 
-> **Nota:** a partir do Gecko 2.0, chamar o método `click()` num elemento {{HTMLElement("input")}} do tipo `file` abre o seletor de arquivos e permite que o usuário selecione arquivos. Veja [Usando arquivos a partir de aplicações web](/pt-BR/docs/Usando_arquivos_a_partir_de_aplicações_web) para um exemplo e mais detalhes.
+> [!NOTE]
+> a partir do Gecko 2.0, chamar o método `click()` num elemento {{HTMLElement("input")}} do tipo `file` abre o seletor de arquivos e permite que o usuário selecione arquivos. Veja [Usando arquivos a partir de aplicações web](/pt-BR/docs/Usando_arquivos_a_partir_de_aplicações_web) para um exemplo e mais detalhes.
 
 Você não pode definir o valor de um seletor de arquivos a partir de um script; fazer algo como o seguinte não tem efeito:
 

--- a/files/pt-br/web/html/element/input/password/index.md
+++ b/files/pt-br/web/html/element/input/password/index.md
@@ -11,7 +11,8 @@ Elementos `<input>` do tipo **`"password"`** são uma maneira do usuário digita
 
 Os detalhes de como o processo de inserção do texto funciona podem variar dependendo do navegador. Dispositivos móveis, por exemplo, frequentemente mostram o caractere digitado por um breve momento antes de ser ocultado, de forma que o usuário possa verificar se realmente digitou o caractere pretendido. Isso é útil devido ao tamanho reduzido das teclas e a facilidade de se pressionar a tecla errada, principalmente em teclados virtuais.
 
-> **Note:** Todo formulário que envolve informações sensíveis tais como senhas (ex.: formulários de login) deve ser servido usando HTTPS. Vários navegadores implementam mecanismos que avisam sobre formulários não protegidos - veja [Senhas não Protegidas](/pt-BR/docs/Security/SenhasNãoProtegidas).
+> [!NOTE]
+> Todo formulário que envolve informações sensíveis tais como senhas (ex.: formulários de login) deve ser servido usando HTTPS. Vários navegadores implementam mecanismos que avisam sobre formulários não protegidos - veja [Senhas não Protegidas](/pt-BR/docs/Security/SenhasNãoProtegidas).
 
 <table class="properties">
   <tbody>
@@ -66,7 +67,8 @@ O atributo [`value`](/pt-BR/docs/Web/HTML/Element/input#value) contém uma {{dom
 
 Se o atributo [`pattern`](/pt-BR/docs/Web/HTML/Element/input#pattern) for especificado, o conteúdo de um controle `"password"` só é considerado válido se o valor passar na validação; veja [Validação](#validação) para mais informações.
 
-> **Note:** Os caracteres de quebra de linha _line feed_ (U+000A) e _carriage return_ (U+000D) não são permitidos em valores de `"password"`. Quando o valor de um campo de senha é definido, os caracteres acima são removidos do valor.
+> [!NOTE]
+> Os caracteres de quebra de linha _line feed_ (U+000A) e _carriage return_ (U+000D) não são permitidos em valores de `"password"`. Quando o valor de um campo de senha é definido, os caracteres acima são removidos do valor.
 
 ## Usando campos de senha
 

--- a/files/pt-br/web/html/element/input/range/index.md
+++ b/files/pt-br/web/html/element/input/range/index.md
@@ -233,7 +233,8 @@ Você pode adicionar rótulos para seu controle usando o atributo [`label`](/pt-
   </tbody>
 </table>
 
-> **Nota:** Atualmente nenhum navegador suporta estes recursos totalmente. Firefox não suporta pontos e rótulos, por exemplo, enquanto o Chrome suporta as marcações de pontos, porém não suporta as etiquetas.
+> [!NOTE]
+> Atualmente nenhum navegador suporta estes recursos totalmente. Firefox não suporta pontos e rótulos, por exemplo, enquanto o Chrome suporta as marcações de pontos, porém não suporta as etiquetas.
 
 ### Criando controles de intervalo vertical
 

--- a/files/pt-br/web/html/element/input/time/index.md
+++ b/files/pt-br/web/html/element/input/time/index.md
@@ -155,7 +155,8 @@ O elemento `<input type="time">` não é compatível com atributos de dimensiona
 
 Você pode usar o atributo [`step`](/pt-BR/docs/Web/HTML/Element/input#step) para variar a quantidade de tempo pulada sempre que o horário for incrementado/decrementado (por exemplo, para fazer com que o horário avançe ou volte em 10 minutos ao clicar nas setinhas ao lado do campo).
 
-> **Note:** Esta propriedade pode se comportar de maneira inesperada em alguns navegadores. Por isso, ela não é 100% confiável.
+> [!NOTE]
+> Esta propriedade pode se comportar de maneira inesperada em alguns navegadores. Por isso, ela não é 100% confiável.
 
 O atributo recebe um valor igual ao número de segundos que você quer que o valor seja incrementado - o valor padrão é 60 segundos, ou 1 minuto. Se você especificar um valor menor que 60 segundos (1 minuto), o campo `time` vai mostrar uma área de inserção de segundos junto com as de hora e minuto:
 
@@ -174,7 +175,8 @@ No Firefox, não são mostrados botões de setas; logo, o valor de `step` não �
 
 O valor de `step` parece não ter efeito no Edge.
 
-> **Note:** Ao que parece, usar o atributo `step` faz com que a validação não funcione adequadamente (como podemos ver na seção seguinte).
+> [!NOTE]
+> Ao que parece, usar o atributo `step` faz com que a validação não funcione adequadamente (como podemos ver na seção seguinte).
 
 ## Validação
 

--- a/files/pt-br/web/html/element/label/index.md
+++ b/files/pt-br/web/html/element/label/index.md
@@ -23,7 +23,8 @@ A tecla de atalho para acessar este elemento a partir do teclado.
 
   - : O ID de um elemento de formulário relacionados com labelable no mesmo documento como o elemento label. O primeiro elemento tal no documento com uma ID correspondente ao valor do atributo é o controle marcado for este elemento etiqueta.
 
-    > **Nota:** Um elemento etiqueta pode ter tanto um for o atributo e um elemento de controlo continham, enquanto os pontos de atributo para o elemento de controlo contido.
+    > [!NOTE]
+    > Um elemento etiqueta pode ter tanto um for o atributo e um elemento de controlo continham, enquanto os pontos de atributo para o elemento de controlo contido.
 
 - `form`
   - : O elemento de forma que o elemento label está associado a (seu proprietário formulário). O valor do atributo deve ser uma identificação de um {{HTMLElement ("form")}} elemento no mesmo documento. Se este atributo não for especificado, este elemento \<label> deve ser um descendente de uma {{HTMLElement ("form")}} elemento. Este atributo permite que você coloque elementos do rótulo em qualquer lugar dentro de um documento, e não apenas como descendentes de seus elementos de formulário.

--- a/files/pt-br/web/html/element/li/index.md
+++ b/files/pt-br/web/html/element/li/index.md
@@ -21,9 +21,11 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
   - : Este atributo de número inteiro indica o valor ordinal atual do item na lista, definido pelo elemento {{HTMLElement("ol")}}. O único valor possível para este atributo é um número, ainda que a lista seja exibida com algarismos romanos, ou letras. A lista de itens que virá em seguida continuará a ser numerada a partir desta posição. O atributo **value** não tem significado para listas desordenadas ({{HTMLElement("ul")}}), nem para menus ({{HTMLElement("menu")}}).
 
-    > **Nota:** Este atributo, abandonado na HTML4, foi reintroduzido na HTML5.
+    > [!NOTE]
+    > Este atributo, abandonado na HTML4, foi reintroduzido na HTML5.
 
-    > **Nota:** Antes de Gecko 9.0, os valores negativos eram, incorretamente, convertidos a 0. A partir de Gecko 9.0 todos os valores inteiros são analisados corretamente.
+    > [!NOTE]
+    > Antes de Gecko 9.0, os valores negativos eram, incorretamente, convertidos a 0. A partir de Gecko 9.0 todos os valores inteiros são analisados corretamente.
 
 - `type` {{Deprecated_inline}}
 

--- a/files/pt-br/web/html/element/link/index.md
+++ b/files/pt-br/web/html/element/link/index.md
@@ -23,7 +23,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
   - : Este atributo define a codificação de caracteres do recurso vinculado. O valor é umespaço e/ou lista delimitada por vírgulas de conjuntos de caracteres, conformedefinido na RFC 2045. O valor padrão é ISO-8859-1.
 
-    > **Nota:** Este atributo é obsoleto em HTML5 e **não deve ser usada por autores**. Para atingir seu efeito, use o cabeçalho HTTP Content-Type sobre o recurso vinculado.
+    > [!NOTE]
+    > Este atributo é obsoleto em HTML5 e **não deve ser usada por autores**. Para atingir seu efeito, use o cabeçalho HTTP Content-Type sobre o recurso vinculado.
 
 - `crossorigin`
 
@@ -40,7 +41,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
   - : Este atributo é usado para desativa uma relação com o link. Em conjunto com o script, esse atributo poderia ser usado para ligar e desligar várias relações com stylesheets.
 
-    > **Nota:** Embora, não haja nenhum atributo desativado no padrão HTML, há um atributo desabilitado no `HTMLLinkElement` DOM object.
+    > [!NOTE]
+    > Embora, não haja nenhum atributo desativado no padrão HTML, há um atributo desabilitado no `HTMLLinkElement` DOM object.
     >
     > The use of `disabled` as an HTML attribute is non-standard and only used by some browsers ([W3 #27677](https://www.w3.org/Bugs/Public/show_bug.cgi?id=27677)). **Do not use it**. To achieve a similar effect, use one of the following techniques:
     >
@@ -55,7 +57,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
   - : This attribute specifies the media which the linked resource applies to. Its value must be a [media query](/pt-BR/docs/CSS/Media_queries). This attribute is mainly useful when linking to external stylesheets by allowing the user agent to pick the best adapted one for the device it runs on.
 
-    > **Nota:** In HTML 4, this can only be a simple white-space-separated list of media description literals, i.e., [media types and groups](/pt-BR/docs/CSS/@media), where defined and allowed as values for this attribute, such as `print`, `screen`, `aural`, `braille`. HTML5 extended this to any kind of [media queries](/pt-BR/docs/CSS/Media_queries), which are a superset of the allowed values of HTML 4.
+    > [!NOTE]
+    > In HTML 4, this can only be a simple white-space-separated list of media description literals, i.e., [media types and groups](/pt-BR/docs/CSS/@media), where defined and allowed as values for this attribute, such as `print`, `screen`, `aural`, `braille`. HTML5 extended this to any kind of [media queries](/pt-BR/docs/CSS/Media_queries), which are a superset of the allowed values of HTML 4.
     >
     > - Browsers not supporting the [CSS3 Media Queries](/pt-BR/docs/CSS/Media_queries) won't necessarily recognize the adequate link; do not forget to set fallback links, the restricted set of media queries defined in HTML 4.
 
@@ -67,7 +70,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
   - : The value of this attribute shows the relationship of the current document to the linked document, as defined by the [`href`](/pt-BR/docs/Web/HTML/Element/link#href) attribute. The attribute thus defines the reverse relationship compared to the value of the **rel** attribute. [Link types values](/pt-BR/docs/Web/HTML/Link_types) for the attribute are similar to the possible values for [`rel`](/pt-BR/docs/Web/HTML/Element/link#rel).
 
-    > **Nota:** This attribute is obsolete in HTML5. **Do not use it**. To achieve its effect, use the [`rel`](/pt-BR/docs/Web/HTML/Element/link#rel) attribute with the opposite [link types values](/pt-BR/docs/Web/HTML/Link_types), e.g. made should be replaced by author. Also this attribute doesn't mean _revision_ and must not be used with a version number, which is unfortunately the case on numerous sites.
+    > [!NOTE]
+    > This attribute is obsolete in HTML5. **Do not use it**. To achieve its effect, use the [`rel`](/pt-BR/docs/Web/HTML/Element/link#rel) attribute with the opposite [link types values](/pt-BR/docs/Web/HTML/Link_types), e.g. made should be replaced by author. Also this attribute doesn't mean _revision_ and must not be used with a version number, which is unfortunately the case on numerous sites.
 
 - `sizes`
 
@@ -76,7 +80,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
     - `any`, meaning that the icon can be scaled to any size as it is in a vector format, like `image/svg+xml`.
     - a white-space separated list of sizes, each in the format `<width in pixels>x<height in pixels>` or `<width in pixels>X<height in pixels>`. Each of these sizes must be contained in the resource.
 
-    > **Nota:** Most icon formats are only able to store one single icon; therefore most of the time the [`sizes`](/pt-BR/docs/Web/HTML/Global_attributes#sizes) attribute contains only one entry.
+    > [!NOTE]
+    > Most icon formats are only able to store one single icon; therefore most of the time the [`sizes`](/pt-BR/docs/Web/HTML/Global_attributes#sizes) attribute contains only one entry.
     > MS's ICO format does, as well as Apple's ICNS. ICO is more ubiquitous, so you should use this format if cross-browser support is a concern (especially for old IE versions).
 
 - `target`{{Non-standard_inline}}
@@ -128,7 +133,8 @@ Você pode determinar quando um stylesheet foi carregado observando um `load` ev
   onerror="sheetError()" />
 ```
 
-> **Nota:** O `load` event é carregado quando a stylesheet e quando todo o conteúdo importado foi carregado e analisado, e imediatamente antes que styles comecem a ser aplicados ao conteúdo.
+> [!NOTE]
+> O `load` event é carregado quando a stylesheet e quando todo o conteúdo importado foi carregado e analisado, e imediatamente antes que styles comecem a ser aplicados ao conteúdo.
 
 ## Notas
 

--- a/files/pt-br/web/html/element/meta/index.md
+++ b/files/pt-br/web/html/element/meta/index.md
@@ -63,7 +63,8 @@ O elemento **HTML `<meta>` **define qualquer informação de metadados que não 
 
 Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attributes).
 
-> **Nota:** o atributo global [`name`](/pt-BR/docs/Web/HTML/Element/meta#name) tem um significado específico para o elemento {{HTMLElement("meta")}}, e o atributo [`itemprop`](/pt-BR/docs/Web/HTML/Element/meta#itemprop) não deve ser definido no mesmo elemento`<meta>` que tem algum desses atributos existentes: [`name`](/pt-BR/docs/Web/HTML/Element/meta#name), [`http-equiv`](/pt-BR/docs/Web/HTML/Element/meta#http-equiv) ou [`charset`](/pt-BR/docs/Web/HTML/Element/meta#charset).
+> [!NOTE]
+> o atributo global [`name`](/pt-BR/docs/Web/HTML/Element/meta#name) tem um significado específico para o elemento {{HTMLElement("meta")}}, e o atributo [`itemprop`](/pt-BR/docs/Web/HTML/Element/meta#itemprop) não deve ser definido no mesmo elemento`<meta>` que tem algum desses atributos existentes: [`name`](/pt-BR/docs/Web/HTML/Element/meta#name), [`http-equiv`](/pt-BR/docs/Web/HTML/Element/meta#http-equiv) ou [`charset`](/pt-BR/docs/Web/HTML/Element/meta#charset).
 
 - `charset`
 
@@ -75,7 +76,9 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
     - Autores não devem usar CESU-8, UTF-7, BOCU-1 e SCSU, also falling in that category and not intended to be used on the web. Cross-scripting attacks with some of these encodings have been documented.
     - Autores não devem usar UTF-32 pois nem todos algorítimos de codificação HTML5 conseguem distingui-lo do UTF-16.
 
-    > **Nota:**
+    > [!NOTE]
+    >
+    > >
     >
     > - O conjunto de caracteres declarado deve corresponder ao da página. Não há motivo válido para declarar um conjunto de caracteres imprecisos.
     > - Esse elemento {{HTMLElement ("meta")}} deve estar dentro do elemento {{HTMLElement ("head")}} e dentro dos primeiros 1024 bytes da página, pois alguns navegadores só olham para esses primeiros bytes antes de escolher um caractere definido para a página.
@@ -93,7 +96,8 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
       - : este pragma define a linguagem default da página
 
-        > **Nota:** não use este pragma, ele esta obsoleto. use o atributo global `lang` no {{HTMLElement("html")}} ao invés deste.
+        > [!NOTE]
+        > não use este pragma, ele esta obsoleto. use o atributo global `lang` no {{HTMLElement("html")}} ao invés deste.
 
     - `"Content-Security-Policy"`
       - : Este valor permite os administradores do web site definam uma [política de conteúdo](/pt-BR/docs/Web/Security/CSP/CSP_policy_directives) para a página atual. Com algumas exceções, politicas de conteúdo envolvem especificar origens de servidores e endpoints de scripts permitidos, isso ajuda na defesa de cross-server scripting attacks.
@@ -101,7 +105,9 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
       - : Esse atributo define o [MIME type](/pt-BR/docs/MIME) e o conjunto de caracteres do documento. Isso segue a mesma sintaxe como o HTTP `content-type` entity-header field, mas isto esta dentro de um elemento HTML, a maioria dos valores não é possível. Sendo assim a sintaxe válida para este conteúdo é a literal string '`text/html`' eventualmente seguido por estes caracteres com a seguinte sintaxe: '`; charset=`_`IANAcharset`_' onde `IANAcharset` é o _MIME preferido nome para um conjunto de caracteres como_ [definido pela IANA.](https://www.iana.org/assignments/character-sets)
 
-        > **Nota:**
+        > [!NOTE]
+        >
+        > >
         >
         > - Nao use esta pragma ela esta obsoleta. use [`charset`](/pt-BR/docs/Web/HTML/Element/meta#charset) atributo {{HTMLElement("meta")}} element instead.
         > - como o {{HTMLElement("meta")}} pode nao ser usado para mudar o tipo de documento no XHTML, ou em um documento de HTML5 seguindo uma syntax de XHTML, nunca marque MIME type para um XHTML MIME type desta forma. isso sera incoerente.
@@ -120,7 +126,8 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
       - : este pragma define um [cookie](/pt-BR/docs/cookie) para a página. este conteúdo deve seguir a sintaxe definida em [IETF HTTP Cookie Specification](https://tools.ietf.org/html/draft-ietf-httpstate-cookie-14).
 
-        > **Nota:** não use este pragma está obsoleto. Use HTTP header set-cookie instead.
+        > [!NOTE]
+        > não use este pragma está obsoleto. Use HTTP header set-cookie instead.
 
 - `name`
 
@@ -129,7 +136,9 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
     - `application-name`, define o nome da aplicação que esta rodando na página;
 
-      > **Nota:**
+      > [!NOTE]
+      >
+      > >
       >
       > - Browsers podem usar isso para identificar a aplicação. isso é diferente do elemento {{HTMLElement("title")}}, que geralmente constituí no nome da aplicação, mas também contém informações específicas como o nome do documento ou status;
       > - Webpages simples não deveriam definir application-name meta.
@@ -147,9 +156,11 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
       | `origin-when-crossorigin`    | Envia uma URL completa (sem parâmetros) ao executar uma solicitação de mesma origem, mas envie apenas a origem do documento para outros casos.                                                            |
       | `unsafe-URL`                 | Envia um URL completo (sem parâmetros) ao executar uma solicitação de mesma origem ou origem cruzada.                                                                                                     |
 
-      > **Nota:** alguns browsers suportam keywords `always`, `default`, e `never` para referenciar. estes valores estão descontinuados.
+      > [!NOTE]
+      > alguns browsers suportam keywords `always`, `default`, e `never` para referenciar. estes valores estão descontinuados.
 
-      > **Nota:** dinamicamente inseridos `<meta name="referrer">` (por document.write ou appendChild) cria um nao-determinismo quando isso vem para enviar referências ou não. Note também quando muitas politicas conflitantes são definidas, o No-referrer politia é aplicada.
+      > [!NOTE]
+      > dinamicamente inseridos `<meta name="referrer">` (por document.write ou appendChild) cria um nao-determinismo quando isso vem para enviar referências ou não. Note também quando muitas politicas conflitantes são definidas, o No-referrer politia é aplicada.
 
     o atributo também pode ter um valor retirado de uma extensa lista definida em [WHATWG Wiki MetaExtensions page](https://wiki.whatwg.org/wiki/MetaExtensions). Embora nenhum tenha sido formalmente aceito ainda, alguns nomes comumente usados estão entre as propostas:
 
@@ -170,7 +181,9 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
       | `noimageindex` | previne esta página de aparecer como referencia de alguma imagem indexada                                                                              | [Google](https://www.google.com/support/webmasters/bin/answer.py?hl=en&answer=79812)                                                                                                                                                                                                                                                                         |
       | `nocache`      | sinônimo de `noarchive`                                                                                                                                | [Bing](https://www.bing.com/toolbox/blogs/webmaster/archive/2008/06/03/robots-exclusion-protocol-joining-together-to-provide-better-documentation.aspx)                                                                                                                                                                                                      |
 
-      > **Nota:**
+      > [!NOTE]
+      >
+      > >
       >
       > - Somente robôs cooperativos seguirão as regras definidas pelo nome do robô. Não espere manter as colheitadeiras de e-mail à distância com isso.
       > - O robô ainda precisa acessar a página para ler o valor meta. Se você quiser mantê-los sob controle, por exemplo, para evitar o consumo de largura de banda, use um arquivo robots.txt (ou em complemento).
@@ -193,7 +206,9 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
       | `minimum-scale` | um numero positivo entre `0.0` e `10.0`                 | define o valor mínimo do zoom; deve ser menor ou igual ao `maximum-scale` ou o comportamento sera indeterminado                                                           |
       | `user-scalable` | um valor booleano (`yes` ou `no`)                       | se setado `no`, o usuário não poderá usar zoom na página. o valor padrão é `yes`.                                                                                         |
 
-      > **Nota:**
+      > [!NOTE]
+      >
+      > >
       >
       > - Embora não seja padronizado, esse atributo é usado por diferentes navegadores móveis, como o Safari Mobile, o Firefox para celular ou o Opera Mobile.
       > - Os valores padrão podem mudar de um dispositivo e navegador para outro.
@@ -203,7 +218,8 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
   - : Este atributo define o esquema no qual os metadados são descritos. Um esquema é um contexto que leva às interpretações corretas dos [`content`](/pt-BR/docs/Web/HTML/Element/meta#content) valores, como um formato.
 
-    > **Nota:** Não use este atributo pois esta obsoleto.Não há substituto para isso, pois não houve uso real para isso. Omitir completamente.
+    > [!NOTE]
+    > Não use este atributo pois esta obsoleto.Não há substituto para isso, pois não houve uso real para isso. Omitir completamente.
 
 ## Notes
 

--- a/files/pt-br/web/html/element/meter/index.md
+++ b/files/pt-br/web/html/element/meter/index.md
@@ -7,7 +7,8 @@ slug: Web/HTML/Element/meter
 
 O elemento HTML _meter_ (`<meter>`) pode representar um valor escalar dentro de um intervalo conhecido ou um valor fracionário.
 
-> **Note:** A não ser que o atributo **value** esteja entre 0 e 1(inclusive), o atributo **min** e o atributo **max** devem definir o intervalo de modo que o valor do atributo **value** esteja dentro dele.
+> [!NOTE]
+> A não ser que o atributo **value** esteja entre 0 e 1(inclusive), o atributo **min** e o atributo **max** devem definir o intervalo de modo que o valor do atributo **value** esteja dentro dele.
 
 ## Contexto de uso
 

--- a/files/pt-br/web/html/element/ol/index.md
+++ b/files/pt-br/web/html/element/ol/index.md
@@ -9,7 +9,8 @@ O **Elemento HTML \<ol>** (ou _Elemento HTML de lista ordenada_) representa uma 
 
 Não há limitação para a profundidade e a imbricação das listas definidas com os elementos {{HTMLElement("ol")}} e {{HTMLElement("ul")}}.
 
-> **Nota:** Ambos os elementos {{HTMLElement("ol")}} e {{HTMLElement("ul")}}, representam uma lista de itens. Diferem porque, com o elemento {{HTMLElement("ol")}}, a ordem é significativa. Como regra de ouro para determinar qual deles usar, tente mudar a ordem dos itens da lista; se a significação for alterada, o elemento {{HTMLElement("ol")}} deve ser utilizado, senão o elemento {{HTMLElement("ul")}} é adequado.
+> [!NOTE]
+> Ambos os elementos {{HTMLElement("ol")}} e {{HTMLElement("ul")}}, representam uma lista de itens. Diferem porque, com o elemento {{HTMLElement("ol")}}, a ordem é significativa. Como regra de ouro para determinar qual deles usar, tente mudar a ordem dos itens da lista; se a significação for alterada, o elemento {{HTMLElement("ol")}} deve ser utilizado, senão o elemento {{HTMLElement("ul")}} é adequado.
 
 - _[Categorias de conteúdo](/pt-BR/docs/HTML/Content_categories)_[Flutuante](/pt-BR/docs/HTML/Content_categories#Flow_content) e no caso dos elementos filhos de `<ol>` incluirem pelo menos um elemento de conteúdo {{HTMLElement("li")}} evidente.
 - _Conteúdo permitido_ Zero ou mais elementos {{HTMLElement("li")}}
@@ -25,7 +26,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 
   - : Este atributo boleano sugere que a lista deve ser renderizada em um estilo compacto. A interpretação deste atributo depende do perfil de navegação (_user agent_) e não funciona em todos os navegadores.
 
-    > **Nota:** Não utilize este atributo, pois ele se tornou obsoleto. O elemento {{HTMLElement("ol")}} deve ser estilizado usando [CSS](/pt-BR/docs/CSS). Para dar um efeito semelhante ao do atributo compacto, a propriedade [CSS](/pt-BR/docs/CSS) {{cssxref("line-height")}} pode ser utilizada com o valor de 80%.
+    > [!NOTE]
+    > Não utilize este atributo, pois ele se tornou obsoleto. O elemento {{HTMLElement("ol")}} deve ser estilizado usando [CSS](/pt-BR/docs/CSS). Para dar um efeito semelhante ao do atributo compacto, a propriedade [CSS](/pt-BR/docs/CSS) {{cssxref("line-height")}} pode ser utilizada com o valor de 80%.
 
 - `reversed`
   - : Este atributo boleano especifica que as partes desta lista serão especificadas em ordem reversa, isto é, a menos importante será listada primeiro.
@@ -33,7 +35,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 
   - : Este atributo inteiro especifica o valor inicial para a numeração dos itens da lista. Embora o tipo de ordenação dos elementos possa ser com algarismos romanos, tal como XXXI, ou letras, o valor inicial sempre é representado como um inteiro. Para iniciar a contagem a partir da letra "C", utilize \<ol start="3">.
 
-    > **Nota:** Este atributo, obsoleto na HTML4, foi reintroduzido na HTML5.
+    > [!NOTE]
+    > Este atributo, obsoleto na HTML4, foi reintroduzido na HTML5.
 
 - `type`
 
@@ -47,7 +50,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 
     O tipo de marcação é usado na lista inteira, a menos que um atributo [`type`](/pt-BR/docs/Web/HTML/Element/li#type) diferente seja utilizado dentro do elemento {{HTMLElement("li")}}.
 
-    > **Nota:** Este atributo, obsoleto na HTML4, foi reintroduzido na HTML5. A menos que o valor do número na lista seja importante, a propriedade CSS {{cssxref("list-style-type")}} deve ser usada em seu lugar.
+    > [!NOTE]
+    > Este atributo, obsoleto na HTML4, foi reintroduzido na HTML5. A menos que o valor do número na lista seja importante, a propriedade CSS {{cssxref("list-style-type")}} deve ser usada em seu lugar.
 
 ## Exemplos
 

--- a/files/pt-br/web/html/element/optgroup/index.md
+++ b/files/pt-br/web/html/element/optgroup/index.md
@@ -13,7 +13,8 @@ Em um Formulário Web, o elemento HTML `<optgroup>` cria um agrupamento de opç�
 - _Elemento pai permitido_ Um elemento {{HTMLElement("select")}}.
 - _Interface DOM_ {{domxref("HTMLOptGroupElement")}}
 
-> **Nota:** Elementos do tipo <strong>optgroup</strong> não podem ser aninhados.
+> [!NOTE]
+> Elementos do tipo <strong>optgroup</strong> não podem ser aninhados.
 
 ## Atributos
 

--- a/files/pt-br/web/html/element/option/index.md
+++ b/files/pt-br/web/html/element/option/index.md
@@ -23,7 +23,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Atributos_globa
 
   - : Este atributo é o texto para o rótulo indicando o significado da opção. Se o atributo **label** não estiver definido, seu valor é o conteúdo de texto do elemento.
 
-    > **Note:** O atributo **label** é projetado para conter um rótulo curto tipicamente usado num menu hierárquico. O atributo **value** descreve descreve um rótulo maior, designado para ser usado perto de um botão de escolha, por exemplo.
+    > [!NOTE]
+    > O atributo **label** é projetado para conter um rótulo curto tipicamente usado num menu hierárquico. O atributo **value** descreve descreve um rótulo maior, designado para ser usado perto de um botão de escolha, por exemplo.
 
 - `selected`
   - : Se presente, este atributo booleano indica que a opção está selecionada inicialmente. Se o elemento `<option>` for descendente de um elemento {{HTMLElement("select")}} cujo atributo [`multiple`](/pt-BR/docs/Web/HTML/Element/select#multiple) não está definido, apenas um único `<option>` deste elemento {{HTMLElement("select")}} pode ter o atributo **selected**.
@@ -31,7 +32,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Atributos_globa
 
   - : O conteúdo textual deste atributo representa o rótulo que explica a opção. Se ele não estiver definido, seu valor padrão é o texto contido no elemento.
 
-    > **Note:** O atributo **label** é projetado para conter um rótulo curto tipicamente usado num menu hierárquico. O atributo **value** descreve descreve um rótulo maior, designado para ser usado perto de um botão de escolha, por exemplo.
+    > [!NOTE]
+    > O atributo **label** é projetado para conter um rótulo curto tipicamente usado num menu hierárquico. O atributo **value** descreve descreve um rótulo maior, designado para ser usado perto de um botão de escolha, por exemplo.
 
 ## Exemplos
 

--- a/files/pt-br/web/html/element/q/index.md
+++ b/files/pt-br/web/html/element/q/index.md
@@ -52,7 +52,8 @@ slug: Web/HTML/Element/q
   </tbody>
 </table>
 
-> **Nota:** A maioria dos browsers modernos adicionará automaticamente marcas de citação em volta do texto dentro de um elemento `<q>`. Talvez seja necessário criar uma regra de estilo para adicionar marcas de citação em browsers antigos.
+> [!NOTE]
+> A maioria dos browsers modernos adicionará automaticamente marcas de citação em volta do texto dentro de um elemento `<q>`. Talvez seja necessário criar uma regra de estilo para adicionar marcas de citação em browsers antigos.
 
 ## Atributos
 

--- a/files/pt-br/web/html/element/script/index.md
+++ b/files/pt-br/web/html/element/script/index.md
@@ -64,7 +64,8 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
   - : Um atributo booleano indicando que o navegador deve, se possível, executar o script assíncronamente.
 
-    > **Warning:** Esse atributo não deve ser utilizado se o atributo `src` estiver ausente (ex. scripts embutidos). Se incluído, nesse caso, ele não terá nenhum efeito.
+    > [!WARNING]
+    > Esse atributo não deve ser utilizado se o atributo `src` estiver ausente (ex. scripts embutidos). Se incluído, nesse caso, ele não terá nenhum efeito.
 
     Scripts inseridos dinamicamente (usando `document.createElement`) são executados assincronamente por padrão, então para torná-lo uma execução síncrona (ex. executar scripts na ordem que eles foram carregados) atribua `async=false`.
 
@@ -78,7 +79,8 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
     Scripts com o atributo `defer` vão impedir que o evento DOMContentLoaded seja disparado até que o script seja carregado e tenha terminado de ser _avaliado_.
 
-    > **Warning:** Esse atributo não deve ser usado se o atibuto `src` estiver ausente (ex. scripts inline), nesse caso ele não vai ter efeito.
+    > [!WARNING]
+    > Esse atributo não deve ser usado se o atibuto `src` estiver ausente (ex. scripts inline), nesse caso ele não vai ter efeito.
 
     Para conseguir um efeito similar para scripts inseridos dinamicamente use `async=false`. Scripts com o atributo `defer` vão ser executados na ordem em que aparecem no `document`.
 

--- a/files/pt-br/web/html/element/summary/index.md
+++ b/files/pt-br/web/html/element/summary/index.md
@@ -7,7 +7,8 @@ slug: Web/HTML/Element/summary
 
 O elemento HTML _summary_ (`<summary>`) é utilizado como um sumário ou legenda para o conteúdo de um elemento {{ HTMLElement("details") }}.
 
-> **Nota:** Se o elemento `<summary>` for omitido, o cabeçalho "details" será utilizado.
+> [!NOTE]
+> Se o elemento `<summary>` for omitido, o cabeçalho "details" será utilizado.
 
 ## Contexto de uso
 

--- a/files/pt-br/web/html/element/table/index.md
+++ b/files/pt-br/web/html/element/table/index.md
@@ -315,7 +315,8 @@ document
 
 O exemplo a seguir adiciona um manipulador de eventos a cada elemento `<th>` de cada `<table>` no `document`; ele ordena todas as linhas do `<tbody>`, baseando a ordenação nas células `td` contidas nas linhas.
 
-> **Nota:** Esta solução assume que os elementos `<td>` são preenchidos por texto bruto sem elementos descendentes.
+> [!NOTE]
+> Esta solução assume que os elementos `<td>` são preenchidos por texto bruto sem elementos descendentes.
 
 ##### HTML
 

--- a/files/pt-br/web/html/element/tfoot/index.md
+++ b/files/pt-br/web/html/element/tfoot/index.md
@@ -91,19 +91,22 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
     |     | `purple` = "#800080"  |     | `teal` = "#008080"   |
     |     | `fuchsia` = "#FF00FF" |     | `aqua` = "#00FFFF"   |
 
-    > **Note:** Não use este atributo, como não é mais padrão ele não foi implementado em algumas versões do Microsoft Internet Explorer: o elemento {{HTMLElement("tfoot")}} pode ser estilizando com [CSS](/pt-BR/docs/Web/CSS). Para conseguir simular efeitos do atributo **bgcolor** use a propriedade {{cssxref("background-color")}} do [CSS](/pt-BR/docs/Web/CSS) , nos elementos {{HTMLElement("td")}} ou {{HTMLElement("th")}}.
+    > [!NOTE]
+    > Não use este atributo, como não é mais padrão ele não foi implementado em algumas versões do Microsoft Internet Explorer: o elemento {{HTMLElement("tfoot")}} pode ser estilizando com [CSS](/pt-BR/docs/Web/CSS). Para conseguir simular efeitos do atributo **bgcolor** use a propriedade {{cssxref("background-color")}} do [CSS](/pt-BR/docs/Web/CSS) , nos elementos {{HTMLElement("td")}} ou {{HTMLElement("th")}}.
 
 - `char` {{Deprecated_inline}}
 
   - : O elemento é usado para alinhar as células em uma columa. Valores típicos para isso inclui o periódico (.) quando se alinha valores monetários. Se [`align`](/pt-BR/docs/Web/HTML/Element/tfoot#align) não é definido para `char`, este atributo é ignorado
 
-    > **Nota:** Não use esté atributo, ele é obsoleto (e não é mais suportado) desde da última versão padrão. Em vez disso use [`char`](/pt-BR/docs/Web/HTML/Element/tfoot#char) no CSS3, você pode usar o atributo [`char`](/pt-BR/docs/Web/HTML/Element/tfoot#char) com a propriedade {{cssxref("text-align")}}.
+    > [!NOTE]
+    > Não use esté atributo, ele é obsoleto (e não é mais suportado) desde da última versão padrão. Em vez disso use [`char`](/pt-BR/docs/Web/HTML/Element/tfoot#char) no CSS3, você pode usar o atributo [`char`](/pt-BR/docs/Web/HTML/Element/tfoot#char) com a propriedade {{cssxref("text-align")}}.
 
 - `charoff` {{Deprecated_inline}}
 
   - : O atributo é usado para indicar um número de caracteres para compensar os dados da coluna dos caracteres de alinhamento especificados pelo atributo **char**.
 
-    > **Nota:** Não use esse atributo o mesmo está obsoleto (e não é mais suportado) na última versão padrão.
+    > [!NOTE]
+    > Não use esse atributo o mesmo está obsoleto (e não é mais suportado) na última versão padrão.
 
 - `valign` {{Deprecated_inline}}
 
@@ -114,7 +117,8 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
     - `middle`, centraliza o texto na célula;
     - e `top`, coloca o texto o mais próximo possível do topo da célula.
 
-    > **Nota:** Não use este atributo eles está obsoleto (e não é suportado) no último padrão: em vez disso use a propriedade {{cssxref("vertical-align")}} do CSS.
+    > [!NOTE]
+    > Não use este atributo eles está obsoleto (e não é suportado) no último padrão: em vez disso use a propriedade {{cssxref("vertical-align")}} do CSS.
 
 ## Exemplos
 

--- a/files/pt-br/web/html/element/th/index.md
+++ b/files/pt-br/web/html/element/th/index.md
@@ -101,7 +101,8 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
   - : Este atributo contém uma lista de palavras separadas por espaço. Cada palavra é o `id` de um grupo de células às quais este cabeçalho se aplica.
 
-    > **Note:** Não use esse atributo, pois ele está obsoleto no padrão mais recente: use o atributo [`scope`](/pt-BR/docs/Web/HTML/Element/th#scope).
+    > [!NOTE]
+    > Não use esse atributo, pois ele está obsoleto no padrão mais recente: use o atributo [`scope`](/pt-BR/docs/Web/HTML/Element/th#scope).
 
 - `bgcolor` {{Non-standard_inline}}
 
@@ -117,13 +118,15 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
     |     | `purple` = "#800080"  |     | `teal` = "#008080"   |
     |     | `fuchsia` = "#FF00FF" |     | `aqua` = "#00FFFF"   |
 
-    > **Note:** Não use esse atributo como padrão pois não é implementado em algumas versões do Microsoft Internet Explorer: O elemento {{HTMLElement("th")}} deve ser estilizado usando [CSS](/pt-BR/docs/Web/CSS). Para criar um efeito semelhante, use a propriedade {{cssxref("background-color")}} do [CSS](/pt-BR/docs/Web/CSS).
+    > [!NOTE]
+    > Não use esse atributo como padrão pois não é implementado em algumas versões do Microsoft Internet Explorer: O elemento {{HTMLElement("th")}} deve ser estilizado usando [CSS](/pt-BR/docs/Web/CSS). Para criar um efeito semelhante, use a propriedade {{cssxref("background-color")}} do [CSS](/pt-BR/docs/Web/CSS).
 
 - `char`
 
   - : O conteúdo da célula está alinhado a um caractere. Os valores típicos incluem um ponto (.) para alinhar números ou valores monetários. Se [`align`](/pt-BR/docs/Web/HTML/Element/th#align) não está definido no `char`, o atributo é ignorado.
 
-    > **Nota:** Não use esse atributo, pois ele está obsoleto no padrão mais recente. Para obter o mesmo efeito, você pode especificar o caractere como o primeiro valor da propriedade {{cssxref("text-align")}}.
+    > [!NOTE]
+    > Não use esse atributo, pois ele está obsoleto no padrão mais recente. Para obter o mesmo efeito, você pode especificar o caractere como o primeiro valor da propriedade {{cssxref("text-align")}}.
 
 - `charoff`
 
@@ -148,13 +151,15 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
     - `middle`: Centraliza o texto na célula.
     - `top`: Posiciona o texto próximo à parte superior da célula.
 
-    > **Note:** Não use esse atributo, pois ele está obsoleto no padrão mais recente: use a propriedade CSS {{cssxref("vertical-align")}}.
+    > [!NOTE]
+    > Não use esse atributo, pois ele está obsoleto no padrão mais recente: use a propriedade CSS {{cssxref("vertical-align")}}.
 
 - `width` {{Deprecated_inline}}
 
   - : Este atributo é usado para definir uma largura de célula recomendada. Espaço adicional pode ser adicionado com as propriedades {{domxref("HTMLTableElement.cellSpacing", "cellspacing")}} e {{domxref("HTMLTableElement.cellPadding", "cellpadding")}}, e a largura do elemento {{HTMLElement("col")}} pode criar largura extra. Mas, se a largura de uma coluna for muito estreita para mostrar uma célula específica corretamente, ela será ampliada quando exibida.
 
-    > **Note:** Não use esse atributo, pois ele está obsoleto no padrão mais recente: use a propriedade CSS {{cssxref("width")}}.
+    > [!NOTE]
+    > Não use esse atributo, pois ele está obsoleto no padrão mais recente: use a propriedade CSS {{cssxref("width")}}.
 
 ## Exemplos
 

--- a/files/pt-br/web/html/element/video/index.md
+++ b/files/pt-br/web/html/element/video/index.md
@@ -21,7 +21,8 @@ Como qualquer elemento HTML, este elemento suporta os [atributos globais](/pt-BR
 
   - : Um atributo Booleano; se especificado, o video vai ser executado assim que possível sem precisar de carregar todo o arquivo.
 
-    > **Nota:** Sites que reproduzem automaticamente áudio (ou vídeos com uma faixa de áudio) podem proporcionar uma experiência desagradável para os usuários, portanto, devem ser evitados sempre que possível. Se você precisar oferecer a funcionalidade de reprodução automática, é recomendável torná-la opcional (exigindo que o usuário a habilite especificamente). No entanto, isso pode ser útil ao criar elementos de mídia cuja fonte será definida posteriormente, sob controle do usuário. Consulte nosso [guia sobre reprodução automática](/pt-BR/docs/Web/Media/Autoplay_guide) para obter informações adicionais sobre como usar a reprodução automática corretamente.
+    > [!NOTE]
+    > Sites que reproduzem automaticamente áudio (ou vídeos com uma faixa de áudio) podem proporcionar uma experiência desagradável para os usuários, portanto, devem ser evitados sempre que possível. Se você precisar oferecer a funcionalidade de reprodução automática, é recomendável torná-la opcional (exigindo que o usuário a habilite especificamente). No entanto, isso pode ser útil ao criar elementos de mídia cuja fonte será definida posteriormente, sob controle do usuário. Consulte nosso [guia sobre reprodução automática](/pt-BR/docs/Web/Media/Autoplay_guide) para obter informações adicionais sobre como usar a reprodução automática corretamente.
 
     Para desativar a reprodução automática, `autoplay="false"` não vai funcionar; o vídeo será reproduzido automaticamente se o atributo estiver presente na tag `<video>`. Para remover a reprodução automática, o atributo deve ser removido por completo.
 
@@ -77,7 +78,9 @@ Como qualquer elemento HTML, este elemento suporta os [atributos globais](/pt-BR
 
     Se não definido, seu valor padrão será definido pelo navegador (isto é, cada navegador pode escolher seu valor padrão), embora a especificação recomende que seja definido para o `metadata`.
 
-    > **Nota:**
+    > [!NOTE]
+    >
+    > >
     >
     > - O atributo `autoplay` tem precedência sobre o `preload`, pois se é necessário executar o vídeo automaticamente, o navegador obviamente o baixará. Definindo ambos `autoplay` e `preload` é permitido pela especificação.
     > - O navegador não é forçado pela especifição a seguir o valor desse atributo; é apenas uma sugestão.


### PR DESCRIPTION
This PR converts the noteblocks for the Portugese Brazilian locale to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 4. Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
