### PR TITLE
[ru] replace old noteblock syntax with GFM syntax in `web/mathml` folder

### DIFF
--- a/files/ru/web/mathml/element/math/index.md
+++ b/files/ru/web/mathml/element/math/index.md
@@ -7,7 +7,8 @@ slug: Web/MathML/Element/math
 
 Элементом верхнего уровня в [MathML](/ru/docs/Web/MathML) является тэг `<math>`, используемый для представления одной математической формулы. Он может находится в HTML-контенте, где разрешено [потоковое содержимое](/ru/docs/Web/HTML/Content_categories#фразовый_контент).
 
-> **Примечание:** Посмотрите страницу [«Разработка MathML»](/ru/docs/Web/MathML/Authoring#using_mathml) с советами по правильной интеграции MathML-формул на ваши веб-страницы и [примеры использования MathML](/ru/docs/Web/MathML/Examples).
+> [!NOTE]
+> Посмотрите страницу [«Разработка MathML»](/ru/docs/Web/MathML/Authoring#using_mathml) с советами по правильной интеграции MathML-формул на ваши веб-страницы и [примеры использования MathML](/ru/docs/Web/MathML/Examples).
 
 ## Атрибуты
 


### PR DESCRIPTION
### Description

This PR replaces old noteblock syntax with GFM syntax in `web/mathml` folder for `ru` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/35098