### PR TITLE
[ru] replace old noteblock syntax with GFM syntax in `web/progressive_web_apps` folder

### DIFF
--- a/files/ru/web/progressive_web_apps/tutorials/js13kgames/installable_pwas/index.md
+++ b/files/ru/web/progressive_web_apps/tutorials/js13kgames/installable_pwas/index.md
@@ -30,7 +30,8 @@ slug: Web/Progressive_web_apps/Tutorials/js13kGames/Installable_PWAs
 <link rel="manifest" href="js13kpwa.webmanifest" />
 ```
 
-> **Примечание:** Существует несколько расширений, используемых в прошлом: `manifest.webapp` был популярен в манифестах приложений Firefox OS, также многие используют `manifest.json` потому что содержание организовано по структуре JSON. Однако, расширение `.webmanifest` явно упоминается в [W3C manifest specification](https://w3c.github.io/manifest/), поэтому давайте придерживаться именно этого стандарта.
+> [!NOTE]
+> Многие используют `manifest.json` потому что содержание организовано по структуре JSON. Однако расширение `.webmanifest` явно упоминается в [W3C manifest specification](https://w3c.github.io/manifest/), поэтому мы будем использовать его.
 
 Содержимое файла может выглядеть так:
 


### PR DESCRIPTION
### Description

This PR replaces old noteblock syntax with GFM syntax in `web/progressive_web_apps` folder for `ru` locale.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/35105