### PR TITLE
[ko] double colon grammar error 번역

### DIFF
--- a/files/ko/web/css/_doublecolon_grammar-error/index.md
+++ b/files/ko/web/css/_doublecolon_grammar-error/index.md
@@ -1,0 +1,70 @@
+---
+title: "::grammar-error"
+slug: Web/CSS/::grammar-error
+l10n:
+  sourceCommit: d6defd737678e99d62bf838ad12eba532567fba5
+---
+
+{{CSSRef}}
+
+**`::grammar-error`** [CSS](/ko/docs/Web/CSS) [의사 요소](/ko/docs/Web/CSS/Pseudo-elements)는 {{glossary("user agent", "사용자 에이전트")}} 가 문법적으로 옳지 않다고 표시한 텍스트 부분을 나타냅니다.
+
+## 허용되는 속성
+
+`::grammar-error` 와 그 선택자 규칙은 다음을 포함한 한정적인 수의 CSS 속성만 사용할 수 있습니다..
+
+- {{cssxref("color")}}
+- {{cssxref("background-color")}}
+- {{cssxref("cursor")}}
+- {{cssxref("caret-color")}}
+- {{cssxref("outline")}} 및 하위 속성들
+- {{cssxref("text-decoration")}} 과 이에 연관된 속성들
+- {{cssxref("text-emphasis-color")}}
+- {{cssxref("text-shadow")}}
+
+## 구문
+
+```css
+::grammar-error {
+  /* ... */
+}
+```
+
+## 얘재
+
+### 간단하게 문서의 문법 확인하기
+
+이 예제에서, 지원되는 브라우저는 문법적으로 오류가 있는 부분을 표시되는 스타일로 강조해야 합니다.
+
+#### HTML
+
+```html
+<p contenteditable spellcheck="true">
+  My friends is coming to the party tonight.
+</p>
+```
+
+#### CSS
+
+```css
+::grammar-error {
+  text-decoration: underline red;
+  color: red;
+}
+```
+
+#### 결과
+
+{{EmbedLiveSample('Simple_document_grammar_check', '100%', 60)}}
+
+## 명세서
+
+{{Specifications}}
+
+## 브라우저 호환성
+
+{{Compat}}
+
+## 같이 보기
+
+- {{cssxref("::spelling-error")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

기존에 한국어로 번역되지 않은 문서 [::grammar-error](https://developer.mozilla.org/en-US/docs/Web/CSS/::grammar-error)를 번역합니다.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
