### PR TITLE
zh: Convert noteblocks to GFM alerts

### DIFF
--- a/files/zh-cn/web/api/canvasrenderingcontext2d/settransform/index.md
+++ b/files/zh-cn/web/api/canvasrenderingcontext2d/settransform/index.md
@@ -9,7 +9,8 @@ l10n:
 
 **`CanvasRenderingContext2D.setTransform()`** 方法用于使用单位矩阵重新设置（覆盖）当前的变换并调用变换，此变换由方法的变量进行描述。这使你能够对上下文进行缩放、旋转、平移（移动）和倾斜操作。
 
-> **备注：** 另请参阅 {{domxref("CanvasRenderingContext2D.transform()", "transform()")}} 方法；它不会覆盖当前的变换矩阵，而是将其与给定的矩阵相乘。
+> [!NOTE]
+> 另请参阅 {{domxref("CanvasRenderingContext2D.transform()", "transform()")}} 方法；它不会覆盖当前的变换矩阵，而是将其与给定的矩阵相乘。
 
 ## 语法
 

--- a/files/zh-cn/web/css/css_shapes/index.md
+++ b/files/zh-cn/web/css/css_shapes/index.md
@@ -7,8 +7,7 @@ slug: Web/CSS/CSS_shapes
 
 **CSS Shapes** 是一个 CSS 模块，用于定义在 CSS 值中使用的几何形状。
 
-> [!NOTE]
-> CSS3 Shapes & CSS3 Regions<https://www.w3.org/TR/css-shapes-1/> > <https://www.w3.org/TR/css-regions-1/>
+> **备注：** ### CSS3 Shapes & CSS3 Regions<https://www.w3.org/TR/css-shapes-1/> > <https://www.w3.org/TR/css-regions-1/>
 
 ## Reference
 

--- a/files/zh-cn/web/css/css_shapes/index.md
+++ b/files/zh-cn/web/css/css_shapes/index.md
@@ -7,7 +7,8 @@ slug: Web/CSS/CSS_shapes
 
 **CSS Shapes** 是一个 CSS 模块，用于定义在 CSS 值中使用的几何形状。
 
-> **备注：** ### CSS3 Shapes & CSS3 Regions<https://www.w3.org/TR/css-shapes-1/> > <https://www.w3.org/TR/css-regions-1/>
+> [!NOTE]
+> CSS3 Shapes & CSS3 Regions<https://www.w3.org/TR/css-shapes-1/> > <https://www.w3.org/TR/css-regions-1/>
 
 ## Reference
 

--- a/files/zh-cn/web/html/global_attributes/lang/index.md
+++ b/files/zh-cn/web/html/global_attributes/lang/index.md
@@ -9,7 +9,8 @@ slug: Web/HTML/Global_attributes/lang
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-lang.html","tabbed-shorter")}}
 
-> **备注：** ## 语言标签语法完整的 BCP47 语法足以标记极其特定的语言方言，但大多数用法都要简单得多。语言标记由连字符分隔的语言子标签组成，其中每个子标签指示该语言的特定属性。3 个最常见的子标签是：
+> [!NOTE]
+> 语言标签语法完整的 BCP47 语法足以标记极其特定的语言方言，但大多数用法都要简单得多。语言标记由连字符分隔的语言子标签组成，其中每个子标签指示该语言的特定属性。3 个最常见的子标签是：
 >
 > - 语言子标签
 >   - : Required。一个 2 或 3 个字符的代码，用于定义基本语言，通常全部用小写编写。例如，English 的语言代码是`en`，Badeshi 的代码是`bdz`。

--- a/files/zh-tw/learn/html/multimedia_and_embedding/images_in_html/index.md
+++ b/files/zh-tw/learn/html/multimedia_and_embedding/images_in_html/index.md
@@ -73,7 +73,7 @@ slug: Learn/HTML/Multimedia_and_embedding/Images_in_HTML
 
 ![A basic image of a dinosaur, embedded in a browser, with "Images in HTML" written above it](basic-image.png)
 
-> **備註：** \<img>和\<video>之類的元素有時也稱為替換元素。 這是因為元素的內容和圖片大小是由外部（例如圖片或影音檔）所定義的，而不是由元素的內容定義。
+> [!NOTE] > \<img>和\<video>之類的元素有時也稱為替換元素。 這是因為元素的內容和圖片大小是由外部（例如圖片或影音檔）所定義的，而不是由元素的內容定義。
 
 > [!NOTE]
 > 你可以從在 [Github](https://mdn.github.io/learning-area/html/multimedia-and-embedding/images-in-html/index.html) 上找到本節完成的示例（參見[開源碼](https://github.com/mdn/learning-area/blob/master/html/multimedia-and-embedding/images-in-html/index.html)。）

--- a/files/zh-tw/learn/html/multimedia_and_embedding/images_in_html/index.md
+++ b/files/zh-tw/learn/html/multimedia_and_embedding/images_in_html/index.md
@@ -73,7 +73,8 @@ slug: Learn/HTML/Multimedia_and_embedding/Images_in_HTML
 
 ![A basic image of a dinosaur, embedded in a browser, with "Images in HTML" written above it](basic-image.png)
 
-> [!NOTE] > \<img>和\<video>之類的元素有時也稱為替換元素。 這是因為元素的內容和圖片大小是由外部（例如圖片或影音檔）所定義的，而不是由元素的內容定義。
+> [!NOTE]
+> 諸如 {{htmlelement("img")}} 和 {{htmlelement("video")}} 等元素有時也稱為替換元素。這是因為元素的內容和圖片大小是由外部（例如圖片或影音檔）所定義的，而不是由元素的內容定義。
 
 > [!NOTE]
 > 你可以從在 [Github](https://mdn.github.io/learning-area/html/multimedia-and-embedding/images-in-html/index.html) 上找到本節完成的示例（參見[開源碼](https://github.com/mdn/learning-area/blob/master/html/multimedia-and-embedding/images-in-html/index.html)。）


### PR DESCRIPTION
This PR converts the noteblocks for the Chinese locales to GFM Alerts syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js).

Note: manual adjustments have also been made to correct some issues, including capitalization, syntax, duplicated keywords and more.
