### PR TITLE
[zh-cn]: update the translation of Touch `pageX` property and fix typo to `XSLTProcessor()` constructor

### DIFF
--- a/files/zh-cn/web/api/touch/pagex/index.md
+++ b/files/zh-cn/web/api/touch/pagex/index.md
@@ -17,7 +17,7 @@ l10n:
 
 此示例展示了如何访问 {{domxref("Touch")}} 对象的 `Touch.pageX` 和 {{domxref("Touch.pageY")}} 属性。`Touch.pageX` 属性表示触摸点相对于屏幕的水平坐标（以 CSS 像素为单位），包括任何滚动偏移量。{{domxref("Touch.pageY")}} 属性表示触摸点相对于屏幕的垂直坐标（以 CSS 像素为单位），包括任何滚动偏移量。
 
-在以下简单的代码片段中，我们假设用户在 `source` 元素上发起一个或多个触摸点接触，移动触摸点，然后释放与表面的接触。当触发 {{domxref("Element/touchmove_event", "touchmove")}} 事件处理器时，可以通过事件的 {{domxref("TouchEvent.changedTouches")}} 列表访问每个触控点的 `Touch.pageX` 和 {{domxref("Touch.pageY")}} 坐标。 
+在以下简单的代码片段中，我们假设用户在 `source` 元素上发起一个或多个触摸点接触，移动触摸点，然后释放与表面的接触。当触发 {{domxref("Element/touchmove_event", "touchmove")}} 事件处理器时，可以通过事件的 {{domxref("TouchEvent.changedTouches")}} 列表访问每个触控点的 `Touch.pageX` 和 {{domxref("Touch.pageY")}} 坐标。
 
 ```js
 // 为“source”元素注册一个 touchmove 监听器。

--- a/files/zh-cn/web/api/touch/pagex/index.md
+++ b/files/zh-cn/web/api/touch/pagex/index.md
@@ -1,31 +1,45 @@
 ---
-title: Touch.pageX
+title: Touch：pageX 属性
 slug: Web/API/Touch/pageX
+l10n:
+  sourceCommit: b71d118ffc6d72b77efad9661110fcc9ede464eb
 ---
 
-{{ ApiRef() }}
+{{ APIRef("Touch Events") }}
 
-### 概述
+**`Touch.pageX`** 只读属性返回触摸点相对于屏幕的 X 坐标，包括任何滚动偏移。
 
-触点相对于 HTML 文档左边沿的 X 坐标。和 `clientX` 属性不同，这个值是相对于整个 html 文档的坐标，和用户滚动位置无关。因此当存在水平滚动的偏移时，这个值包含了水平滚动的偏移。
+## 值
 
-### 语法
+`double` 类型的浮点值，表示触摸点相对于屏幕的 X 坐标，包括任何滚动偏移。
 
-```plain
-var x = touchItem.pageX;
+## 示例
+
+此示例展示了如何访问 {{domxref("Touch")}} 对象的 `Touch.pageX` 和 {{domxref("Touch.pageY")}} 属性。`Touch.pageX` 属性表示触摸点相对于屏幕的水平坐标（以 CSS 像素为单位），包括任何滚动偏移量。{{domxref("Touch.pageY")}} 属性表示触摸点相对于屏幕的垂直坐标（以 CSS 像素为单位），包括任何滚动偏移量。
+
+在以下简单的代码片段中，我们假设用户在 `source` 元素上发起一个或多个触摸点接触，移动触摸点，然后释放与表面的接触。当触发 {{domxref("Element/touchmove_event", "touchmove")}} 事件处理器时，可以通过事件的 {{domxref("TouchEvent.changedTouches")}} 列表访问每个触控点的 `Touch.pageX` 和 {{domxref("Touch.pageY")}} 坐标。 
+
+```js
+// 为“source”元素注册一个 touchmove 监听器。
+const src = document.getElementById("source");
+
+src.addEventListener(
+  "touchmove",
+  (e) => {
+    // 遍历已移动的触摸点，并记录每个 pageX 和 pageY 的坐标。每个坐标的单位是 CSS 像素。
+    for (let i = 0; i < e.changedTouches.length; i++) {
+      console.log(`touchpoint[${i}].pageX = ${e.changedTouches[i].pageX}`);
+      console.log(`touchpoint[${i}].pageY = ${e.changedTouches[i].pageY}`);
+    }
+  },
+  false,
+);
 ```
 
-### 返回值
+## 规范
 
-- `x`
-  - : 触点相对于 HTML 文档左边沿的 X 坐标。当存在水平滚动的偏移时，这个值包含了水平滚动的偏移。
+{{Specifications}}
 
-### 标准定义
+## 浏览器兼容性
 
-[Touch Events Specification](http://www.w3.org/TR/touch-events/)
-
-### 相关链接
-
-- {{ domxref("Touch.pageY") }}
-- {{ domxref("Touch.screenX") }}
-- {{ domxref("Touch.clientX") }}
+{{Compat}}

--- a/files/zh-cn/web/api/xsltprocessor/xsltprocessor/index.md
+++ b/files/zh-cn/web/api/xsltprocessor/xsltprocessor/index.md
@@ -1,5 +1,5 @@
 ---
-title: XSLTProcessor：XSLTProcessor() 构建函数
+title: XSLTProcessor：XSLTProcessor() 构造函数
 slug: Web/API/XSLTProcessor/XSLTProcessor
 l10n:
   sourceCommit: 6788d086c530ae04793a497d12863db3d8adf040


### PR DESCRIPTION
### Description
* XSLTProcessor
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/XSLTProcessor/XSLTProcessor
* pageX
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/Touch/pageX
### Related issues and pull requests
* pageX
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/touch/pagex/index.md
* Last commit: https://github.com/mdn/content/commit/b71d118ffc6d72b77efad9661110fcc9ede464eb
* XSLTProcessor
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/xsltprocessor/xsltprocessor/index.md
* Last commit: https://github.com/mdn/content/commit/6788d086c530ae04793a497d12863db3d8adf040