### PR TITLE
fix(zh-cn): add missing word "statement" to improve translation

### DIFF
--- a/files/zh-cn/web/javascript/guide/working_with_objects/index.md
+++ b/files/zh-cn/web/javascript/guide/working_with_objects/index.md
@@ -194,7 +194,7 @@ function Car(make, model, year) {
 var mycar = new Car("Eagle", "Talon TSi", 1993);
 ```
 
-该语句创建了 `mycar` 并且将指定的值赋给它的属性。因而 `mycar.make` 的值是字符串 "Eagle"， `mycar.year` 的值是整数 1993，依此类推。
+该语句创建了 `mycar` 并且将指定的值赋给它的属性。因而 `mycar.make` 的值是字符串 `"Eagle"`，`mycar.year` 的值是整数 `1993`，依此类推。
 
 你可以通过调用 `new` 创建任意数量的 `car` 对象。例如：
 

--- a/files/zh-cn/web/javascript/guide/working_with_objects/index.md
+++ b/files/zh-cn/web/javascript/guide/working_with_objects/index.md
@@ -194,7 +194,7 @@ function Car(make, model, year) {
 var mycar = new Car("Eagle", "Talon TSi", 1993);
 ```
 
-该创建了 `mycar` 并且将指定的值赋给它的属性。因而 `mycar.make` 的值是字符串 "Eagle"， `mycar.year` 的值是整数 1993，依此类推。
+该语句创建了 `mycar` 并且将指定的值赋给它的属性。因而 `mycar.make` 的值是字符串 "Eagle"， `mycar.year` 的值是整数 1993，依此类推。
 
 你可以通过调用 `new` 创建任意数量的 `car` 对象。例如：
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR corrects a translation issue in the Chinese (zh-CN) content. The sentence was missing the word "statement," which has now been added to improve the accuracy of the translation.

### Motivation

The correction clarifies the description of the code example, ensuring that readers understand the context of the statement being executed. Accurate translations are essential for providing clear and effective documentation.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
