### PR TITLE
[ko] translate learn/common_questions/design_and_accessibility

### DIFF
--- a/files/ko/learn/common_questions/design_and_accessibility/index.md
+++ b/files/ko/learn/common_questions/design_and_accessibility/index.md
@@ -1,0 +1,21 @@
+---
+title: 디자인과 접근성
+slug: Learn/Common_questions/Design_and_accessibility
+l10n:
+  sourceCommit: 751d58669499de0c6ea0d5b356e0e1448418c5d3
+---
+
+{{LearnSidebar}}
+
+다음은 웹사이트의 미적 요소, 페이지 구조, 접근성 기술 등에 관련된 질문들을 다룬 구획입니다.
+
+- [웹사이트 디자인을 어떻게 시작하나요?](/ko/docs/Learn/Common_questions/Design_and_accessibility/Thinking_before_coding)
+  - : 이 글에서는 모든 프로젝트에서 가장 중요한 첫 번째 단계인 '무엇을 달성하고 싶은지 정의하는 것'에 대해 다룹니다.
+- [일반적인 웹 레이아웃에는 무엇이 포함되나요?](/ko/docs/Learn/Common_questions/Design_and_accessibility/Common_web_layouts)
+  - : 웹사이트의 페이지를 디자인할 때, 가장 일반적인 레이아웃을 파악하는 것이 좋습니다. 이 글에서는 일반적인 웹 레이아웃을 살펴보고 각 레이아웃을 구성하는 요소들을 설명합니다.
+- [접근성이란 무엇인가요?](/ko/docs/Learn/Common_questions/Design_and_accessibility/What_is_accessibility)
+  - : 이 글에서는 웹 접근성의 기본 개념을 소개합니다.
+- [모든 유형의 사용자에게 맞춰 디자인하려면 어떻게 해야 하나요?](/ko/docs/Learn/Common_questions/Design_and_accessibility/Design_for_all_types_of_users)
+  - : 이 글에서는 모든 사용자에게 맞춘 웹사이트를 디자인하는 데 도움이 되는 기본 기술을 제공합니다. 빠른 접근성 개선 방법 및 기타 관련 사항들이 포함되어 있습니다.
+- [접근성을 증진시키는 HTML 기능은 무엇이 있나요?](/ko/docs/Learn/Common_questions/Design_and_accessibility/HTML_features_for_accessibility)
+  - : 이 글에서는 장애가 있는 사람들이 웹페이지에 더 쉽게 접근할 수 있도록 HTML의 특정 기능을 사용하는 방법에 대해 설명합니다.

--- a/files/ko/learn/common_questions/tools_and_setup/index.md
+++ b/files/ko/learn/common_questions/tools_and_setup/index.md
@@ -1,0 +1,31 @@
+---
+title: 도구 및 설정
+slug: Learn/Common_questions/Tools_and_setup
+l10n:
+  sourceCommit: 751d58669499de0c6ea0d5b356e0e1448418c5d3
+---
+
+{{LearnSidebar}}
+
+다음은 웹사이트를 구축하는 데 필요한 도구 및 설정에 대한 질문들을 다룬 구획입니다
+
+- [웹사이트를 구축하려면 어떤 소프트웨어가 필요하나요?](/ko/docs/Learn/Common_questions/Tools_and_setup/What_software_do_I_need)
+  - : 이 글에서는 웹사이트를 편집, 업로드 또는 보기 위해 필요한 소프트웨어 구성 요소에 대해 설명합니다.
+- [웹에서 무언가를 하려면 비용이 얼마나 드나요?](/ko/docs/Learn/Common_questions/Tools_and_setup/How_much_does_it_cost)
+  - : 웹사이트를 시작할 때 비용이 전혀 들지 않을 수도 있고, 비용이 급격히 증가할 수도 있습니다. 이 글에서는 비용이 얼마나 들며, 지불한 금액(또는 지불하지 않은 금액)에 따라 무엇을 얻을 수 있는지에 대해 논의합니다.
+- [어떤 텍스트 편집기가 있나요?](/ko/docs/Learn/Common_questions/Tools_and_setup/Available_text_editors)
+  - : 이 글에서는 웹 개발을 위해 텍스트 편집기를 선택하고 설치할 때 고려해야 할 사항들을 강조합니다.
+- [브라우저 개발자 도구란 무엇인가요?](/ko/docs/Learn/Common_questions/Tools_and_setup/What_are_browser_developer_tools)
+  - : 모든 브라우저에는 HTML, CSS 및 기타 웹 코드를 디버깅할 수 있는 개발자 도구(DevTools)가 포함되어 있습니다. 이 글에서는 브라우저 개발자 도구의 기본 기능을 사용하는 방법을 설명합니다.
+- [웹사이트가 제대로 작동하는지 어떻게 확인하나요?](/ko/docs/Learn/Common_questions/Tools_and_setup/Checking_that_your_web_site_is_working_properly)
+  - : 웹사이트를 온라인에 게시했다면, 훌륭합니다! 그러나 웹사이트가 제대로 작동하는지 확신할 수 있나요? 이 글에서는 기본적인 문제 해결 단계를 제공합니다.
+- [로컬 테스트 서버를 어떻게 설정하나요?](/ko/docs/Learn/Common_questions/Tools_and_setup/set_up_a_local_testing_server)
+  - : 이 글에서는 로컬 테스트 서버를 컴퓨터에 간단하게 설정하는 방법과 이를 사용하는 기본 사항을 설명합니다.
+- [파일을 웹 서버에 어떻게 업로드하나요?](/ko/docs/Learn/Common_questions/Tools_and_setup/Upload_files_to_a_web_server)
+  - : 이 글에서는 FTP 도구를 사용하여 사이트를 온라인에 게시하는 방법을 보여줍니다. 이는 다른 사람들이 웹사이트에 액세스할 수 있도록 웹사이트를 온라인에 올리는 가장 일반적인 방법 중 하나입니다.
+- [GitHub Pages를 어떻게 사용하나요?](/ko/docs/Learn/Common_questions/Tools_and_setup/Using_GitHub_pages)
+  - : 이 글에서는 GitHub의 gh-pages 기능을 사용하여 콘텐츠를 게시하는 기본 가이드를 제공합니다.
+- [Google App Engine에 웹사이트를 호스팅하려면 어떻게 해야 하나요?](/ko/docs/Learn/Common_questions/Tools_and_setup/How_do_you_host_your_website_on_Google_App_Engine)
+  - : 웹사이트를 호스팅할 장소를 찾고 계신가요? 이 글에서는 Google App Engine에 웹사이트를 호스팅하는 단계별 가이드를 제공합니다.
+- [웹사이트 성능을 디버깅하고 개선할 수 있는 도구는 무엇이 있나요?](https://firefox-source-docs.mozilla.org/devtools-user/performance/index.html)
+  - : 이 일련의 글에서는 Firefox의 개발자 도구를 사용하여 웹사이트의 성능을 디버깅하고 개선하는 방법을 보여줍니다. 메모리 사용량, JavaScript 호출 트리, 렌더링되는 DOM 노드 수 등을 확인하는 도구를 사용하는 방법도 포함되어 있습니다.


### PR DESCRIPTION
Description
ools_and_setup 문서가 번역 되지 않아 번역을 진행하였습니다.

참고사항
`This section lists questions related to aesthetics, page structure, accessibility techniques, etc.`
구문에서 `section`을 [용어 안내서](https://github.com/mdn/translated-content/blob/main/docs/ko/guides/glossary-guide.md)의 정의된 `구획`으로 번역하였습니다.

Additional details
([원문 깃허브 링크](https://github.com/mdn/content/blob/main/files/en-us/learn/common_questions/design_and_accessibility/index.md), [원문 MDN 링크](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Design_and_accessibility))