### PR TITLE
[zh-cn]: update the translation of `arguments.length` data property

### DIFF
--- a/files/zh-cn/web/javascript/reference/functions/arguments/length/index.md
+++ b/files/zh-cn/web/javascript/reference/functions/arguments/length/index.md
@@ -56,4 +56,4 @@ function adder(base /*, num1, …, numN */) {
 - [函数](/zh-CN/docs/Web/JavaScript/Guide/Functions)指南
 - [函数](/zh-CN/docs/Web/JavaScript/Reference/Functions)
 - {{jsxref("Functions/arguments", "arguments")}}
-- [`Function`: `length`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Function/length)
+- [`Function`：`length`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Function/length)

--- a/files/zh-cn/web/javascript/reference/functions/arguments/length/index.md
+++ b/files/zh-cn/web/javascript/reference/functions/arguments/length/index.md
@@ -1,32 +1,42 @@
 ---
 title: arguments.length
 slug: Web/JavaScript/Reference/Functions/arguments/length
+l10n:
+  sourceCommit: c6f0f106b9083984dbf597678def6561729bb459
 ---
 
 {{jsSidebar("Functions")}}
 
-本次函数调用时传入函数的实参数量。
+**`arguments.length`** 数据属性包含传递给函数的参数数量。
 
-## Syntax
+## 值
 
-```plain
-arguments.length
-```
+一个非负整数。
+
+{{js_property_attributes(1, 0, 1)}}
 
 ## 描述
 
-arguments.length 表示的是实际上向函数传入了多少个参数，这个数字可以比形参数量大，也可以比形参数量小 (形参数量的值可以通过[Function.length](/zh-CN/docs/JavaScript/Reference/Global_Objects/Function/length)获取到).
+`arguments.length` 属性提供了实际传递给函数的参数数量。传递的参数数量可能多于或少于定义的参数数量（参见 {{jsxref("Function.prototype.length")}}）。例如下面的函数：
+
+```js
+function func1(a, b, c) {
+  console.log(arguments.length);
+}
+```
+
+`func1.length` 返回 `3`，因为 `func1` 声明了三个形式参数。然而，`func1(1, 2, 3, 4, 5)` 会记录 `5`，因为 `func1` 被调用时传递了五个参数。同样地，`func1(1)` 会记录 `1`，因为 `func1` 被调用时传递了一个参数。
 
 ## 示例
 
-### 示例：使用`arguments.length`
+### 使用 arguments.length
 
-这个例中，我们定义了一个可以相加任意个数字的函数。
+在此示例中，我们定义了一个可以将两个或多个数字相加的函数。
 
 ```js
-function adder(base /*, n2, ... */) {
+function adder(base /*, num1, …, numN */) {
   base = Number(base);
-  for (var i = 0; i < arguments.length; i++) {
+  for (let i = 1; i < arguments.length; i++) {
     base += Number(arguments[i]);
   }
   return base;
@@ -43,4 +53,7 @@ function adder(base /*, n2, ... */) {
 
 ## 参见
 
-- [Function.length](/zh-CN/docs/JavaScript/Reference/Global_Objects/Function/length)
+- [函数](/zh-CN/docs/Web/JavaScript/Guide/Functions)指南
+- [函数](/zh-CN/docs/Web/JavaScript/Reference/Functions)
+- {{jsxref("Functions/arguments", "arguments")}}
+- [`Function`: `length`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Function/length)


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/length
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/functions/arguments/length/index.md
* Last commit: https://github.com/mdn/content/commit/c6f0f106b9083984dbf597678def6561729bb459