### PR TITLE
Fix internal links in index.md

### DIFF
--- a/files/fr/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/fr/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -44,7 +44,7 @@ Le constructeur peut renvoyer des exceptions:
 
 Si une erreur se produit lors de la tentative de connexion, un évènement nommé "error" est d'abord renvoyé à l'objet [`WebSocket`](/fr/docs/Web/API/WebSocket) (invoquant ainsi son gestionnaire d'évènement `onerror`) suivi d'un évènement [`CloseEvent`](/fr/docs/Web/API/CloseEvent) (qui invoque alors son gestionnaire d'évènement `onclose`) indiquant la raison de la clôture.
 
-A partir de Firefox 11, un message d'erreur descriptif est envoyé à la console de la plateforme Mozilla, et un code de fermeture tel que défini dans la [RFC 6455, Section 7.4](http://tools.ietf.org/html/rfc6455#section-7.4) est envoyé à travers l'évènement [`CloseEvent`](/fr/docs/Web/API/CloseEvent).
+A partir de Firefox 11, un message d'erreur descriptif est envoyé à la console de la plateforme Mozilla, et un code de fermeture tel que défini dans la [RFC 6455, Section 7.4](https://datatracker.ietf.org/doc/html/rfc6455#section-7.4) est envoyé à travers l'évènement [`CloseEvent`](/fr/docs/Web/API/CloseEvent).
 
 ### Exemples
 
@@ -76,7 +76,7 @@ Dans les exemples ci-dessus on a remplacé `http` par `ws`, et de la même faço
 
 Une fois la connexion ouverte on peut commencer à tranférer des données vers le serveur en appelant la méthode [`send()`](/fr/docs/Web/API/WebSocket/send) de l'objet `WebSocket` pour chaque message que l'on veut envoyer :
 
-Les données peuvent être envoyées sous forme de chaîne {{ domxref("Blob") }} ou de [`ArrayBuffer`](/fr/docs/Web/API/JavaScript_typed_arrays/ArrayBuffer).
+Les données peuvent être envoyées sous forme de chaîne {{ domxref("Blob") }} ou de [`ArrayBuffer`](/fr/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
 
 > [!NOTE]
 > Avant la version 11, Firefox supportait l'envoi de données uniquement sous forme de chaîne.
@@ -93,7 +93,7 @@ exampleSocket.onopen = function (event) {
 
 ### Utilisation de JSON pour transmettre des objets
 
-Il peut être utile d'utiliser [JSON](/fr/docs/Web/API/JSON) pour envoyer des données complexes au serveur. Par exemple, un programme de chat peut interagir avec un serveur en utilisant un protocole qui implémente l'échange de paquets contenant des données encapsulées en JSON:
+Il peut être utile d'utiliser [JSON](/fr/docs/Web/JavaScript/Reference/Global_Objects/JSON) pour envoyer des données complexes au serveur. Par exemple, un programme de chat peut interagir avec un serveur en utilisant un protocole qui implémente l'échange de paquets contenant des données encapsulées en JSON:
 
 ```js
 // Envoi d'un texte à tous les utilisateurs à travers le serveur
@@ -183,7 +183,7 @@ exampleSocket.onmessage = function (event) {
 };
 ```
 
-Ici nous utilisons [`JSON.parse()`](/fr/docs/Web/API/JavaScript/Reference/Global_Objects/JSON/parse) pour convertir l'objet JSON en l'objet original, avant de l'examiner et le traiter.
+Ici nous utilisons [`JSON.parse()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse) pour convertir l'objet JSON en l'objet original, avant de l'examiner et le traiter.
 
 ### Encodage du texte
 

--- a/files/fr/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/fr/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -74,7 +74,7 @@ Dans les exemples ci-dessus on a remplacé `http` par `ws`, et de la même faço
 
 ## Envoi de données vers le serveur
 
-Une fois la connexion ouverte on peut commencer à tranférer des données vers le serveur en appelant la méthode [`send()`](/fr/docs/Web/API/WebSocket#send) de l'objet `WebSocket` pour chaque message que l'on veut envoyer :
+Une fois la connexion ouverte on peut commencer à tranférer des données vers le serveur en appelant la méthode [`send()`](/fr/docs/Web/API/WebSocket/send) de l'objet `WebSocket` pour chaque message que l'on veut envoyer :
 
 Les données peuvent être envoyées sous forme de chaîne {{ domxref("Blob") }} ou de [`ArrayBuffer`](/fr/docs/Web/API/JavaScript_typed_arrays/ArrayBuffer).
 
@@ -193,7 +193,7 @@ Avant Gecko 9.0, certains charactères spéciaux dans une chaîne UTF-8 provoqua
 
 ## Fermeture de la connexion
 
-Quand on n'a plus besoin de la connexion WebSocket, on appelle la méthode [`close()`](/fr/docs/Web/API/WebSocket#close) de l'objet WebSocket:
+Quand on n'a plus besoin de la connexion WebSocket, on appelle la méthode [`close()`](/fr/docs/Web/API/WebSocket/close) de l'objet WebSocket:
 
 ```js
 exampleSocket.close();

--- a/files/fr/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/fr/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -14,7 +14,7 @@ Les WebSockets représentent une technologie, basée sur le protocole web socket
 
 ## Création d'un objet WebSocket
 
-Pour utiliser le protocole WebSocket, il faut créer un objet [`WebSocket`](/fr/docs/Web/API/WebSockets/WebSockets_reference/WebSocket) ; celui-ci essaiera automatiquement d'ouvrir une connexion avec le server.
+Pour utiliser le protocole WebSocket, il faut créer un objet [`WebSocket`](/fr/docs/Web/API/WebSocket) ; celui-ci essaiera automatiquement d'ouvrir une connexion avec le server.
 
 Le constructeur WebSocket accepte un paramètre obligatoire et un paramètre optionnel :
 
@@ -42,9 +42,9 @@ Le constructeur peut renvoyer des exceptions:
 
 ### Erreurs de connexion
 
-Si une erreur se produit lors de la tentative de connexion, un évènement nommé "error" est d'abord renvoyé à l'objet [`WebSocket`](/fr/docs/Web/API/WebSockets/WebSockets_reference/WebSocket) (invoquant ainsi son gestionnaire d'évènement `onerror`) suivi d'un évènement [`CloseEvent`](/fr/docs/Web/API/WebSockets/WebSockets_reference/CloseEvent) (qui invoque alors son gestionnaire d'évènement `onclose`) indiquant la raison de la clôture.
+Si une erreur se produit lors de la tentative de connexion, un évènement nommé "error" est d'abord renvoyé à l'objet [`WebSocket`](/fr/docs/Web/API/WebSocket) (invoquant ainsi son gestionnaire d'évènement `onerror`) suivi d'un évènement [`CloseEvent`](/fr/docs/Web/API/CloseEvent) (qui invoque alors son gestionnaire d'évènement `onclose`) indiquant la raison de la clôture.
 
-A partir de Firefox 11, un message d'erreur descriptif est envoyé à la console de la plateforme Mozilla, et un code de fermeture tel que défini dans la [RFC 6455, Section 7.4](http://tools.ietf.org/html/rfc6455#section-7.4) est envoyé à travers l'évènement [`CloseEvent`](/fr/docs/Web/API/WebSockets/WebSockets_reference/CloseEvent).
+A partir de Firefox 11, un message d'erreur descriptif est envoyé à la console de la plateforme Mozilla, et un code de fermeture tel que défini dans la [RFC 6455, Section 7.4](http://tools.ietf.org/html/rfc6455#section-7.4) est envoyé à travers l'évènement [`CloseEvent`](/fr/docs/Web/API/CloseEvent).
 
 ### Exemples
 
@@ -74,7 +74,7 @@ Dans les exemples ci-dessus on a remplacé `http` par `ws`, et de la même faço
 
 ## Envoi de données vers le serveur
 
-Une fois la connexion ouverte on peut commencer à tranférer des données vers le serveur en appelant la méthode [`send()`](/fr/docs/Web/API/WebSockets/WebSockets_reference/WebSocket#send) de l'objet `WebSocket` pour chaque message que l'on veut envoyer :
+Une fois la connexion ouverte on peut commencer à tranférer des données vers le serveur en appelant la méthode [`send()`](/fr/docs/Web/API/WebSocket#send) de l'objet `WebSocket` pour chaque message que l'on veut envoyer :
 
 Les données peuvent être envoyées sous forme de chaîne {{ domxref("Blob") }} ou de [`ArrayBuffer`](/fr/docs/Web/API/JavaScript_typed_arrays/ArrayBuffer).
 
@@ -193,7 +193,7 @@ Avant Gecko 9.0, certains charactères spéciaux dans une chaîne UTF-8 provoqua
 
 ## Fermeture de la connexion
 
-Quand on n'a plus besoin de la connexion WebSocket, on appelle la méthode [`close()`](/fr/docs/Web/API/WebSockets/WebSockets_reference/WebSocket#close) de l'objet WebSocket:
+Quand on n'a plus besoin de la connexion WebSocket, on appelle la méthode [`close()`](/fr/docs/Web/API/WebSocket#close) de l'objet WebSocket:
 
 ```js
 exampleSocket.close();


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Internal links to WebSocket and CloseEvent were broken in french translation.

### Motivation

Having an easy to read french documentation.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
