### PR TITLE
[zh-cn]: update the translation of `Range.extractContents()` method

### DIFF
--- a/files/zh-cn/web/api/range/extractcontents/index.md
+++ b/files/zh-cn/web/api/range/extractcontents/index.md
@@ -9,11 +9,9 @@ l10n:
 
 **`Range.extractContents()`** 方法将 {{ domxref("Range") }} 的内容从文档树中移到 {{ domxref("DocumentFragment") }} 中。
 
-通过 DOM 事件添加的事件监听器在提取过程中不会被保留。
+通过 DOM 事件添加的事件监听器在提取过程中不会被保留。HTML 属性事件会像 {{domxref("Node.cloneNode()")}} 方法一样被保留或复制。HTML `id` 属性也会被克隆，因此如果提取部分选择的节点并将其附加到文档中，可能会导致文档无效。
 
-HTML 属性事件会像 {{domxref("Node.cloneNode()")}} 方法一样被保留或复制。HTML `id` 属性也会被克隆，如果提取部分选择的节点并附加到文档中，可能会导致文档无效。
-
-部分选中的节点会被克隆，以包括使文档片段有效所需的父标签。
+部分选中的节点会被克隆，以包含使文档片段有效所需的父标签。
 
 ## 语法
 
@@ -40,15 +38,15 @@ const documentFragment = range.extractContents();
 document.body.appendChild(documentFragment);
 ```
 
-### 在容器之间移动项
+### 在容器之间移动项目
 
-此示例可让你在两个容器之间移动项。选择一个或多个项，然后点击“交换”将它们移到相反的容器中。
+此示例可让你在两个容器之间移动项目。选择一个或多个项目，然后点击“交换”将它们移到对面的容器中。
 
 #### HTML
 
 ```html
 <p id="list1">123456</p>
-<button id="swap">交换所选项</button>
+<button id="swap">交换所选项目</button>
 <p id="list2">abcdef</p>
 ```
 
@@ -104,7 +102,7 @@ button.addEventListener("click", (e) => {
 
 #### 结果
 
-{{EmbedLiveSample("在容器之间移动项", 700, 300)}}
+{{EmbedLiveSample("在容器之间移动项目", 700, 300)}}
 
 ## 规范
 

--- a/files/zh-cn/web/api/range/extractcontents/index.md
+++ b/files/zh-cn/web/api/range/extractcontents/index.md
@@ -40,7 +40,7 @@ const documentFragment = range.extractContents();
 document.body.appendChild(documentFragment);
 ```
 
-### 在容器之间移动项目
+### 在容器之间移动项
 
 此示例可让你在两个容器之间移动项。选择一个或多个项，然后点击“交换”将它们移到相反的容器中。
 

--- a/files/zh-cn/web/api/range/extractcontents/index.md
+++ b/files/zh-cn/web/api/range/extractcontents/index.md
@@ -1,39 +1,119 @@
 ---
-title: Range.extractContents()
+title: Range：extractContents() 方法
 slug: Web/API/Range/extractContents
+l10n:
+  sourceCommit: c58e8c1dd6ecbcb63894c7dd17fb9495b9511b4e
 ---
 
 {{ApiRef("DOM")}}
 
-**`Range.extractContents()`** 方法移动了{{ domxref("Range") }} 中的内容从文档树到{{ domxref("DocumentFragment") }}（文档片段对象）。
+**`Range.extractContents()`** 方法将 {{ domxref("Range") }} 的内容从文档树中移到 {{ domxref("DocumentFragment") }} 中。
 
-使用 DOM 事件添加的事件侦听器在提取期间不会保留。HTML 属性事件将按{{domxref("Node.cloneNode()")}}方法的原样保留或复制。HTML id 属性也会被克隆，如果提取了部分选定的节点并将其附加到文档中，则可能导致无效的文档。
+通过 DOM 事件添加的事件监听器在提取过程中不会被保留。
 
-克隆了部分选定的节点，以包括使文档片段有效所需的父标记。
+HTML 属性事件会像 {{domxref("Node.cloneNode()")}} 方法一样被保留或复制。HTML `id` 属性也会被克隆，如果提取部分选择的节点并附加到文档中，可能会导致文档无效。
 
-## Syntax
+部分选中的节点会被克隆，以包括使文档片段有效所需的父标签。
 
-```plain
-documentFragment = range.extractContents();
+## 语法
+
+```js-nolint
+extractContents()
 ```
 
-## Example
+### 参数
+
+无。
+
+### 返回值
+
+{{ domxref("DocumentFragment") }} 对象。
+
+## 示例
+
+### 基本示例
 
 ```js
-var range = document.createRange();
+const range = document.createRange();
 range.selectNode(document.getElementsByTagName("div").item(0));
-var documentFragment = range.extractContents();
+const documentFragment = range.extractContents();
 document.body.appendChild(documentFragment);
 ```
 
-## Specifications
+### 在容器之间移动项目
+
+此示例可让你在两个容器之间移动项。选择一个或多个项，然后点击“交换”将它们移到相反的容器中。
+
+#### HTML
+
+```html
+<p id="list1">123456</p>
+<button id="swap">交换所选项</button>
+<p id="list2">abcdef</p>
+```
+
+#### CSS
+
+```css
+body {
+  pointer-events: none;
+}
+
+p {
+  border: 1px solid;
+  font-size: 2em;
+  padding: 0.3em;
+}
+
+button {
+  font-size: 1.2em;
+  padding: 0.5em;
+  pointer-events: auto;
+}
+```
+
+#### JavaScript
+
+```js
+const list1 = document.getElementById("list1");
+const list2 = document.getElementById("list2");
+const button = document.getElementById("swap");
+
+button.addEventListener("click", (e) => {
+  const selection = window.getSelection();
+
+  for (let i = 0; i < selection.rangeCount; i++) {
+    const range = selection.getRangeAt(i);
+
+    if (
+      range.commonAncestorContainer === list1 ||
+      range.commonAncestorContainer.parentNode === list1
+    ) {
+      const documentFragment = range.extractContents();
+      list2.appendChild(documentFragment);
+    } else if (
+      range.commonAncestorContainer === list2 ||
+      range.commonAncestorContainer.parentNode === list2
+    ) {
+      const documentFragment = range.extractContents();
+      list1.appendChild(documentFragment);
+    }
+  }
+});
+```
+
+#### 结果
+
+{{EmbedLiveSample("在容器之间移动项", 700, 300)}}
+
+## 规范
 
 {{Specifications}}
 
-## Browser compatibility
+## 浏览器兼容性
 
 {{Compat}}
 
-## See also
+## 参见
 
-- [The DOM interfaces index](/zh-CN/docs/DOM/DOM_Reference)
+- [DOM 接口索引](/zh-CN/docs/Web/API/Document_Object_Model)

--- a/files/zh-cn/web/api/range/extractcontents/index.md
+++ b/files/zh-cn/web/api/range/extractcontents/index.md
@@ -2,7 +2,7 @@
 title: Range：extractContents() 方法
 slug: Web/API/Range/extractContents
 l10n:
-  sourceCommit: c58e8c1dd6ecbcb63894c7dd17fb9495b9511b4e
+  sourceCommit: 987c56d6f54bba1bf0430abf06b9a5573c8c289a
 ---
 
 {{ApiRef("DOM")}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/Range/extractContents
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/range/extractcontents/index.md
* Last commit: https://github.com/mdn/content/commit/c58e8c1dd6ecbcb63894c7dd17fb9495b9511b4e