### PR TITLE
[zh-cn]: update the translation of `Range.surroundContents()` method

### DIFF
--- a/files/zh-cn/web/api/range/surroundcontents/index.md
+++ b/files/zh-cn/web/api/range/surroundcontents/index.md
@@ -1,42 +1,48 @@
 ---
-title: Range.surroundContents
+title: Range：surroundContents() 方法
 slug: Web/API/Range/surroundContents
+l10n:
+  sourceCommit: 1a91b0b63f0cbaca9125bd48d4e5bc8afed2a7a3
 ---
 
-{{ ApiRef("Range") }}
+{{ApiRef("DOM")}}
 
-**`Range.surroundContents()`** 方法将 {{ domxref("Range") }} 对象的内容移动到一个新的节点，并将新节点放到这个范围的起始处。
+**`Range.surroundContents()`** 方法将 {{ domxref("Range") }} 的内容移动到一个新节点，并将该新节点放置在指定的起始位置。
 
-这个方法与 `newNode.appendChild(range.extractContents()); range.insertNode(newNode)` 等价。应用以后， `newNode` 包含在 `range` 的边界点中。
+此方法几乎等同于 `newNode.appendChild(range.extractContents()); range.insertNode(newNode)`。在包围操作之后，`range` 的边界点将包含 `newNode`。
 
-然而，如果 {{ domxref("Range") }} 断开了一个非 {{ domxref("Text") }} 节点，只包含了节点的其中一个边界点，就会抛出异常。也就是说，不像上述的等价方法，如果节点仅有一部分被选中，则不会被克隆，整个操作会失败。
+如果 {{ domxref("Range") }} 只用其中一个边界点分割了一个非 {{domxref("Text") }} 节点，则会抛出异常。也就是说，与上述方案不同的是，如果有部分节点被选中，它们将不会被克隆，相反，操作会失败。
 
 ## 语法
 
-```plain
-range.surroundContents(newParent);
+```js-nolint
+surroundContents(newParent)
 ```
 
 ### 参数
 
 - `newParent`
-  - : 一个包含内容的 {{ domxref("Node") }}。
+  - : 用于包围内容的 {{ domxref("Node") }}。
+
+### 返回值
+
+无（{{jsxref("undefined")}}）。
 
 ## 示例
 
 ### HTML
 
-```plain
-<span class="header-text">Put this in a headline</span>
+```html
+<span class="header-text">在标题中写道</span>
 ```
 
 ### JavaScript
 
-```plain
+```js
 const range = document.createRange();
-const newParent = document.createElement('h1');
+const newParent = document.createElement("h1");
 
-range.selectNode(document.querySelector('.header-text'));
+range.selectNode(document.querySelector(".header-text"));
 range.surroundContents(newParent);
 ```
 
@@ -54,4 +60,4 @@ range.surroundContents(newParent);
 
 ## 参见
 
-- [The DOM interfaces index](/zh-CN/docs/DOM/DOM_Reference)
+- [DOM 接口索引](/zh-CN/docs/Web/API/Document_Object_Model)

--- a/files/zh-cn/web/api/range/surroundcontents/index.md
+++ b/files/zh-cn/web/api/range/surroundcontents/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{ApiRef("DOM")}}
 
-**`Range.surroundContents()`** 方法将 {{ domxref("Range") }} 的内容移动到一个新节点，并将该新节点放置在指定的起始位置。
+**`Range.surroundContents()`** 方法将 {{ domxref("Range") }} 的内容移动到一个新节点，并将该新节点放置在范围所指定的起始位置。
 
 此方法几乎等同于 `newNode.appendChild(range.extractContents()); range.insertNode(newNode)`。在包围操作之后，`range` 的边界点将包含 `newNode`。
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/Range/surroundContents
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/range/surroundcontents/index.md
* Last commit: https://github.com/mdn/content/commit/1a91b0b63f0cbaca9125bd48d4e5bc8afed2a7a3