### PR TITLE
[zh-cn]: update compatibility translation in 204 page

### DIFF
--- a/files/zh-cn/web/http/status/204/index.md
+++ b/files/zh-cn/web/http/status/204/index.md
@@ -19,6 +19,12 @@ HTTP **`204 No Content`** 成功状态响应码，表示该请求已经成功了
 
 {{Specifications}}
 
+## 兼容性说明
+
+尽管此状态码适用于没有响应体的响应，但服务器可能会错误地在标头后面携带数据。这种情况在长连接中尤为常见，因为无效的响应体可能会与后续请求的响应数据混合在一起。HTTP 协议允许浏览器以不同的方式处理此类响应（[HTTPWG `http-core` GitHub 存储库](https://github.com/httpwg/http-core/issues/26) 中正在持续讨论有关规范的内容）。
+
+Apple Safari 拒绝任何此类数据。Google Chrome 和 Microsoft Edge 在得到有效响应之前最多丢弃 4 个无效字节。Firefox 在获得有效响应之前可以容忍超过 1KB 的无效数据。
+
 ## 参见
 
 - [HTTP request methods](/zh-CN/docs/Web/HTTP/Methods)

--- a/files/zh-cn/web/http/status/204/index.md
+++ b/files/zh-cn/web/http/status/204/index.md
@@ -21,7 +21,7 @@ HTTP **`204 No Content`** 成功状态响应码，表示该请求已经成功了
 
 ## 兼容性说明
 
-尽管此状态码适用于没有响应体的响应，但服务器可能会错误地在标头后面携带数据。这种情况在长连接中尤为常见，因为无效的响应体可能会与后续请求的响应数据混合在一起。HTTP 协议允许浏览器以不同的方式处理此类响应（[HTTPWG `http-core` GitHub 存储库](https://github.com/httpwg/http-core/issues/26) 中正在持续讨论有关规范的内容）。
+尽管此状态码适用于没有响应体的响应，但服务器可能会错误地在标头后面携带数据。这种问题在长连接中尤为常见，因为无效的响应体可能会与后续请求的响应数据混合在一起。HTTP 协议允许浏览器以不同的方式处理此类响应（[HTTPWG `http-core` GitHub 仓库](https://github.com/httpwg/http-core/issues/26)中正在持续讨论有关规范文本的内容）。
 
 Apple Safari 拒绝任何此类数据。Google Chrome 和 Microsoft Edge 在得到有效响应之前最多丢弃 4 个无效字节。Firefox 在获得有效响应之前可以容忍超过 1KB 的无效数据。
 

--- a/files/zh-cn/web/http/status/204/index.md
+++ b/files/zh-cn/web/http/status/204/index.md
@@ -19,10 +19,6 @@ HTTP **`204 No Content`** 成功状态响应码，表示该请求已经成功了
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - [HTTP request methods](/zh-CN/docs/Web/HTTP/Methods)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
remove browser compatibility section in 204 page

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
browser compatibility section is removed because it can not render correctly, and there is no browser compatibility section in other pages like [203 Non-Authoritative Information](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Status/203).

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
https://github.com/mdn/translated-content/issues/23180

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
