### PR TITLE
zh-cn: update the translation of `Element.prefix`

### DIFF
--- a/files/zh-cn/web/api/element/prefix/index.md
+++ b/files/zh-cn/web/api/element/prefix/index.md
@@ -1,44 +1,40 @@
 ---
-title: Element.prefix
+title: Element：prefix 属性
 slug: Web/API/Element/prefix
+l10n:
+  sourceCommit: bbf7f25f9cf95fb154e2740a9fdc9c02818981bf
 ---
 
 {{APIRef("DOM")}}
 
-**`Element.prefix`** 只读属性返回指定元素的命名空间前缀，如果未指定前缀，则返回 null。
+**`Element.prefix`** 只读属性返回指定元素的命名空间前缀，如果未指定前缀，则返回 `null`。
 
-> [!NOTE]
-> 在 DOM4 之前，该 API 是在 {{domxref("Node")}} interface 中定义的。
+## 值
 
-## Syntax
+字符串。
 
-```
-string = element.prefix
-```
+## 示例
 
-## Examples
-
-The following logs "x" to the console.
+以下代码在控制台中打印“x”。
 
 ```xml
 <x:div onclick="console.log(this.prefix)"/>
 ```
 
-## Notes
+## 备注
 
-This will only work when a namespace-aware parser is used, i.e. when a document is served with an XML MIME type. This will not work for HTML documents.
+仅当使用可感知命名空间的解析器时（即，当文档以 XML MIME 类型提供时），此属性才有效。对于 HTML 文档，此属性无效。
 
-## Specifications
+## 规范
 
 {{Specifications}}
 
-## Browser compatibility
+## 浏览器兼容性
 
 {{Compat}}
 
-## See also
+## 参见
 
 - {{domxref("Element.namespaceURI")}}
 - {{domxref("Element.localName")}}
 - {{domxref("Attr.prefix")}}
-- {{domxref("Node.prefix")}}


### PR DESCRIPTION
### Description

update the translation of `Element.prefix`

### Additional details

The translation of "namespace-aware" inspired by https://docs.python.org/zh-cn/3/library/xml.etree.elementtree.html#functions
