### PR TITLE
fix: correct the translation of summary in "WebRTC protocol introduction"

### DIFF
--- a/files/zh-cn/web/api/webrtc_api/protocols/index.md
+++ b/files/zh-cn/web/api/webrtc_api/protocols/index.md
@@ -5,7 +5,7 @@ slug: Web/API/WebRTC_API/Protocols
 
 {{DefaultAPISidebar("WebRTC")}}
 
-本文介绍了基于 WebRTC API 构建的协议。
+本文介绍了构建 WebRTC API 的协议。
 
 ## ICE
 


### PR DESCRIPTION
I noticed that maybe a chinese translation mistake in summary of WebRTC.

Fixes: #23233