### PR TITLE
[FR] Fix: Update code example (Fixes #22940)

### DIFF
--- a/files/fr/web/javascript/reference/operators/logical_and/index.md
+++ b/files/fr/web/javascript/reference/operators/logical_and/index.md
@@ -125,7 +125,7 @@ bCondition1 || (bCondition2 && bCondition3);
 
 sera toujours égale à :
 
-```js
+```js-nolint
 bCondition1 || bCondition2 && bCondition3;
 ```
 

--- a/files/fr/web/javascript/reference/operators/logical_and/index.md
+++ b/files/fr/web/javascript/reference/operators/logical_and/index.md
@@ -126,7 +126,7 @@ bCondition1 || (bCondition2 && bCondition3);
 sera toujours égale à :
 
 ```js
-bCondition1 || (bCondition2 && bCondition3);
+bCondition1 || bCondition2 && bCondition3;
 ```
 
 ## Spécifications


### PR DESCRIPTION
### Description

Update to the code example given in the ‘Removing nested brackets’ section.

> L'opération composite suivant, qui utilise des booléens :
> `bCondition1 || (bCondition2 && bCondition3);`
> sera toujours égale à :
> `bCondition1 || (bCondition2 && bCondition3);`

to 

> L'opération composite suivant, qui utilise des booléens :
> `bCondition1 || (bCondition2 && bCondition3);`
> sera toujours égale à :
> `bCondition1 || bCondition2 && bCondition3;`

as in the example given on the [original English page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND#removing_nested_parentheses).

### Motivation

Error correction

### Additional details

N/A

### Related issues and pull requests

- Fixes #22940
