### PR TITLE
docs(ko): Add Korean translation of fit-content

### DIFF
--- a/files/ko/web/css/fit-content/index.md
+++ b/files/ko/web/css/fit-content/index.md
@@ -9,7 +9,7 @@ l10n:
 
 **`fit-content`** 키워드는 {{cssxref("fit-content_function", "fit-content(stretch)")}}와 동일합니다. 실제로 이는 박스가 사용 가능한 공간을 사용하되, 절대 {{cssxref("max-content")}}보다 크지는 않음을 의미합니다.
 
-{{cssxref("width")}}, {{cssxref("height")}}, {{cssxref("min-width")}}, {{cssxref("min-height")}}, {{cssxref("max-width")}} 및 {{cssxref("max-height")}}에 대해 박스 크기로 사용될 때, 최대 및 최소 크기는 콘텐츠의 크기를 의미합니다.
+{{cssxref("width")}}, {{cssxref("height")}}, {{cssxref("min-width")}}, {{cssxref("min-height")}}, {{cssxref("max-width")}} 및 {{cssxref("max-height")}} 의 박스 크기로 사용할 경우, 최대 및 최소 크기는 콘텐츠의 크기를 참조합니다.
 
 > [!NOTE]
 > CSS Sizing 명세는 {{cssxref("fit-content_function", "fit-content()")}} 함수도 정의합니다. 이 페이지에서는 해당 키워드에 대해 설명합니다.
@@ -23,7 +23,7 @@ block-size: fit-content;
 
 ## 예제
 
-### 박스 크기에 fit-content 사용하기
+### fit-content를 사용해 박스 크기 설정하기
 
 #### HTML
 
@@ -57,7 +57,7 @@ block-size: fit-content;
 
 #### 결과
 
-{{EmbedLiveSample("박스 크기에 fit-content 사용하기", "100%", 200)}}
+{{EmbedLiveSample("fit-content를 사용해 박스 크기 설정하기", "100%", 200)}}
 
 ## 명세
 
@@ -69,5 +69,5 @@ block-size: fit-content;
 
 ## 함께 보기
 
-- 연관된 크기 키워드: {{cssxref("min-content")}}, {{cssxref("max-content")}}
+- 연관된 크기 설정 키워드: {{cssxref("min-content")}}, {{cssxref("max-content")}}
 - [CSS box sizing](/ko/docs/Web/CSS/CSS_box_sizing) 모듈

--- a/files/ko/web/css/fit-content/index.md
+++ b/files/ko/web/css/fit-content/index.md
@@ -29,11 +29,11 @@ block-size: fit-content;
 
 ```html
 <div class="container">
-  <div class="item">Item</div>
-  <div class="item">Item with more text in it.</div>
+  <div class="item">항목</div>
+  <div class="item">더 많은 텍스트가 포함된 항목입니다.</div>
   <div class="item">
-    Item with more text in it, hopefully we have added enough text so the text
-    will start to wrap.
+    텍스트가 더 많이 포함된 항목입니다. 텍스트가 줄바꿈되기를 기대하며 충분한
+    양의 텍스트를 추가했습니다.
   </div>
 </div>
 ```

--- a/files/ko/web/css/fit-content/index.md
+++ b/files/ko/web/css/fit-content/index.md
@@ -9,7 +9,7 @@ l10n:
 
 **`fit-content`** 키워드는 {{cssxref("fit-content_function", "fit-content(stretch)")}}와 동일합니다. 실제로 이는 박스가 사용 가능한 공간을 사용하되, 절대 {{cssxref("max-content")}}보다 크지는 않음을 의미합니다.
 
-{{cssxref("width")}}, {{cssxref("height")}}, {{cssxref("min-width")}}, {{cssxref("min-height")}}, {{cssxref("max-width")}} 및 {{cssxref("max-height")}} 가 레이아웃된 박스의 크기로 사용될 경우, 최대 크기와 최소 크기는 콘텐츠의 크기를 참조합니다.
+{{cssxref("width")}}, {{cssxref("height")}}, {{cssxref("min-width")}}, {{cssxref("min-height")}}, {{cssxref("max-width")}} 및 {{cssxref("max-height")}} 가 레이아웃된 박스의 크기로 사용된 경우, 최대 크기와 최소 크기는 콘텐츠의 크기를 참조합니다.
 
 > [!NOTE]
 > CSS Sizing 명세는 {{cssxref("fit-content_function", "fit-content()")}} 함수도 정의합니다. 이 페이지에서는 해당 키워드에 대해 설명합니다.

--- a/files/ko/web/css/fit-content/index.md
+++ b/files/ko/web/css/fit-content/index.md
@@ -23,7 +23,7 @@ block-size: fit-content;
 
 ## 예제
 
-### Using fit-content for box sizing
+### 박스 크기에 fit-content 사용하기
 
 #### HTML
 
@@ -57,7 +57,7 @@ block-size: fit-content;
 
 #### 결과
 
-{{EmbedLiveSample("Using_fit-content_for_box_sizing", "100%", 200)}}
+{{EmbedLiveSample("박스 크기에 fit-content 사용하기", "100%", 200)}}
 
 ## 명세
 

--- a/files/ko/web/css/fit-content/index.md
+++ b/files/ko/web/css/fit-content/index.md
@@ -67,7 +67,7 @@ block-size: fit-content;
 
 {{Compat}}
 
-## 함께 보기
+## 같이 보기
 
 - 연관된 크기 설정 키워드: {{cssxref("min-content")}}, {{cssxref("max-content")}}
 - [CSS box sizing](/ko/docs/Web/CSS/CSS_box_sizing) 모듈

--- a/files/ko/web/css/fit-content/index.md
+++ b/files/ko/web/css/fit-content/index.md
@@ -59,7 +59,7 @@ block-size: fit-content;
 
 {{EmbedLiveSample("fit-content를 사용해 박스 크기 설정하기", "100%", 200)}}
 
-## 명세
+## 명세서
 
 {{Specifications}}
 

--- a/files/ko/web/css/fit-content/index.md
+++ b/files/ko/web/css/fit-content/index.md
@@ -9,7 +9,7 @@ l10n:
 
 **`fit-content`** 키워드는 {{cssxref("fit-content_function", "fit-content(stretch)")}}와 동일합니다. 실제로 이는 박스가 사용 가능한 공간을 사용하되, 절대 {{cssxref("max-content")}}보다 크지는 않음을 의미합니다.
 
-{{cssxref("width")}}, {{cssxref("height")}}, {{cssxref("min-width")}}, {{cssxref("min-height")}}, {{cssxref("max-width")}} 및 {{cssxref("max-height")}} 의 박스 크기로 사용할 경우, 최대 및 최소 크기는 콘텐츠의 크기를 참조합니다.
+{{cssxref("width")}}, {{cssxref("height")}}, {{cssxref("min-width")}}, {{cssxref("min-height")}}, {{cssxref("max-width")}} 및 {{cssxref("max-height")}} 가 레이아웃된 박스의 크기로 사용될 경우, 최대 크기와 최소 크기는 콘텐츠의 크기를 참조합니다.
 
 > [!NOTE]
 > CSS Sizing 명세는 {{cssxref("fit-content_function", "fit-content()")}} 함수도 정의합니다. 이 페이지에서는 해당 키워드에 대해 설명합니다.

--- a/files/ko/web/css/fit-content/index.md
+++ b/files/ko/web/css/fit-content/index.md
@@ -1,0 +1,73 @@
+---
+title: fit-content
+slug: Web/CSS/fit-content
+l10n:
+  sourceCommit: 14515827c44f3cb814261a1c6bd487ae8bfcde1b
+---
+
+{{CSSRef}}
+
+**`fit-content`** 키워드는 {{cssxref("fit-content_function", "fit-content(stretch)")}}와 동일합니다. 실제로 이는 박스가 사용 가능한 공간을 사용하되, 절대 {{cssxref("max-content")}}보다 크지는 않음을 의미합니다.
+
+{{cssxref("width")}}, {{cssxref("height")}}, {{cssxref("min-width")}}, {{cssxref("min-height")}}, {{cssxref("max-width")}} 및 {{cssxref("max-height")}}에 대해 박스 크기로 사용될 때, 최대 및 최소 크기는 콘텐츠의 크기를 의미합니다.
+
+> [!NOTE]
+> CSS Sizing 명세는 {{cssxref("fit-content_function", "fit-content()")}} 함수도 정의합니다. 이 페이지에서는 해당 키워드에 대해 설명합니다.
+
+## 구문
+
+```css
+width: fit-content;
+block-size: fit-content;
+```
+
+## 예제
+
+### Using fit-content for box sizing
+
+#### HTML
+
+```html
+<div class="container">
+  <div class="item">Item</div>
+  <div class="item">Item with more text in it.</div>
+  <div class="item">
+    Item with more text in it, hopefully we have added enough text so the text
+    will start to wrap.
+  </div>
+</div>
+```
+
+#### CSS
+
+```css
+.container {
+  border: 2px solid #ccc;
+  padding: 10px;
+  width: 20em;
+}
+
+.item {
+  width: fit-content;
+  background-color: #8ca0ff;
+  padding: 5px;
+  margin-bottom: 1em;
+}
+```
+
+#### 결과
+
+{{EmbedLiveSample("Using_fit-content_for_box_sizing", "100%", 200)}}
+
+## 명세
+
+{{Specifications}}
+
+## 브라우저 호환성
+
+{{Compat}}
+
+## 함께 보기
+
+- 연관된 크기 키워드: {{cssxref("min-content")}}, {{cssxref("max-content")}}
+- [CSS box sizing](/ko/docs/Web/CSS/CSS_box_sizing) 모듈


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- CSS 키워드 중 [fit-content](https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content) 문서의 한글 번역을 추가합니다.

### Additional details

- [SourceCommit 링크](https://github.com/mdn/content/blob/main/files/en-us/web/css/fit-content/index.md?plain=1)

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
