### PR TITLE
[ja] Translate GamepadPose

### DIFF
--- a/files/ja/web/api/gamepadpose/angularacceleration/index.md
+++ b/files/ja/web/api/gamepadpose/angularacceleration/index.md
@@ -1,0 +1,33 @@
+---
+title: "GamepadPose: angularAcceleration プロパティ"
+slug: Web/API/GamepadPose/angularAcceleration
+l10n:
+  sourceCommit: b6984118ac9482e683a654edfefa4b426ca3c7ca
+---
+
+{{APIRef("WebVR API")}}{{SeeCompatTable}}
+
+{{domxref("GamepadPose")}} インターフェイスの読み取り専用プロパティ **`angularAcceleration`** は、{{domxref("Gamepad")}} の角加速度ベクトル (メートル毎秒毎秒) を表す配列を返します。
+
+言い換えると、センサーの `x` 軸・`y` 軸・`z` 軸のまわりの回転の現在の加速度です。
+
+## 値
+
+{{jsxref("Float32Array")}}、もしくはゲームパッドが角加速度の情報を提供できないときは `null` です。
+
+## 例
+
+TBD
+
+## 仕様書
+
+{{Specifications}}
+
+## ブラウザーの互換性
+
+{{Compat}}
+
+## 関連情報
+
+- [WebVR API](/ja/docs/Web/API/WebVR_API)
+- [Gamepad API](/ja/docs/Web/API/Gamepad_API)

--- a/files/ja/web/api/gamepadpose/angularvelocity/index.md
+++ b/files/ja/web/api/gamepadpose/angularvelocity/index.md
@@ -1,0 +1,33 @@
+---
+title: "GamepadPose: angularVelocity プロパティ"
+slug: Web/API/GamepadPose/angularVelocity
+l10n:
+  sourceCommit: b6984118ac9482e683a654edfefa4b426ca3c7ca
+---
+
+{{APIRef("WebVR API")}}{{SeeCompatTable}}
+
+{{domxref("GamepadPose")}} インターフェイスの読み取り専用プロパティ **`angularVelocity`** は、{{domxref("Gamepad")}} の角速度ベクトル (ラジアン毎秒) を表す配列を返します。
+
+言い換えると、センサーが `x` 軸・`y` 軸・`z` 軸のまわりを回っている現在の速度です。
+
+## 値
+
+{{jsxref("Float32Array")}}、もしくはゲームパッドが角速度の情報を提供できないときは `null` です。
+
+## 例
+
+TBD
+
+## 仕様書
+
+{{Specifications}}
+
+## ブラウザーの互換性
+
+{{Compat}}
+
+## 関連情報
+
+- [WebVR API](/ja/docs/Web/API/WebVR_API)
+- [Gamepad API](/ja/docs/Web/API/Gamepad_API)

--- a/files/ja/web/api/gamepadpose/hasposition/index.md
+++ b/files/ja/web/api/gamepadpose/hasposition/index.md
@@ -1,0 +1,31 @@
+---
+title: "GamepadPose: hasPosition プロパティ"
+slug: Web/API/GamepadPose/hasPosition
+l10n:
+  sourceCommit: b6984118ac9482e683a654edfefa4b426ca3c7ca
+---
+
+{{APIRef("WebVR API")}}{{SeeCompatTable}}
+
+{{domxref("GamepadPose")}} インターフェイスの読み取り専用プロパティ **`hasPosition`** は、{{domxref("Gamepad")}} が位置の情報を追跡して返すことができるかを表す真理値を返します。
+
+## 値
+
+真理値です。
+
+## 例
+
+TBD
+
+## 仕様書
+
+{{Specifications}}
+
+## ブラウザーの互換性
+
+{{Compat}}
+
+## 関連情報
+
+- [WebVR API](/ja/docs/Web/API/WebVR_API)
+- [Gamepad API](/ja/docs/Web/API/Gamepad_API)

--- a/files/ja/web/api/gamepadpose/index.md
+++ b/files/ja/web/api/gamepadpose/index.md
@@ -1,0 +1,48 @@
+---
+title: GamepadPose
+slug: Web/API/GamepadPose
+l10n:
+  sourceCommit: 5e98fd9cfbec6e28044a27c58bffca5ae464ec8b
+---
+
+{{securecontext_header}}{{APIRef("Gamepad API")}}{{SeeCompatTable}}
+
+[Gamepad API](/ja/docs/Web/API/Gamepad_API) の **`GamepadPose`** インターフェイスは、指定のタイムスタンプにおける [WebVR](/ja/docs/Web/API/WebVR_API) コントローラーの姿勢を表します。これには、向き・位置・速度・加速度の情報が含まれます。
+
+このインターフェイスは、{{domxref("Gamepad.pose")}} プロパティからアクセスできます。
+
+## インスタンスプロパティ
+
+- {{domxref("GamepadPose.hasOrientation")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : ゲームパッドが向きの情報を返すことができる (`true`) か否 (`false`) かを表す真理値を返します。
+- {{domxref("GamepadPose.hasPosition")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : ゲームパッドが位置の情報を返すことができる (`true`) か否 (`false`) かを表す真理値を返します。
+- {{domxref("GamepadPose.position")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : {{domxref("Gamepad")}} の位置を 3 次元ベクトルで返します。
+- {{domxref("GamepadPose.linearVelocity")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : {{domxref("Gamepad")}} の線速度 (メートル毎秒) を返します。
+- {{domxref("GamepadPose.linearAcceleration")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : {{domxref("Gamepad")}} の線加速度 (メートル毎秒毎秒) を返します。
+- {{domxref("GamepadPose.orientation")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : {{domxref("Gamepad")}} の向きをクォータニオン値で返します。
+- {{domxref("GamepadPose.angularVelocity")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : {{domxref("Gamepad")}} の角速度 (ラジアン毎秒) を返します。
+- {{domxref("GamepadPose.angularAcceleration")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : {{domxref("Gamepad")}} の角加速度 (メートル毎秒毎秒) を返します。
+
+## 例
+
+TBD
+
+## 仕様書
+
+{{Specifications}}
+
+## ブラウザーの互換性
+
+{{Compat}}
+
+## 関連情報
+
+- [WebVR API](/ja/docs/Web/API/WebVR_API)
+- [Gamepad API](/ja/docs/Web/API/Gamepad_API)

--- a/files/ja/web/api/gamepadpose/linearacceleration/index.md
+++ b/files/ja/web/api/gamepadpose/linearacceleration/index.md
@@ -1,0 +1,33 @@
+---
+title: "GamepadPose: linearAcceleration プロパティ"
+slug: Web/API/GamepadPose/linearAcceleration
+l10n:
+  sourceCommit: b6984118ac9482e683a654edfefa4b426ca3c7ca
+---
+
+{{APIRef("WebVR API")}}{{SeeCompatTable}}
+
+{{domxref("GamepadPose")}} インターフェイスの読み取り専用プロパティ **`linearAcceleration`** は、{{domxref("Gamepad")}} の線加速度ベクトル (メートル毎秒毎秒) を表す配列を返します。
+
+言い換えると、センサーの `x` 軸・`y` 軸・`z` 軸方向の現在の加速度です。
+
+## 値
+
+{{jsxref("Float32Array")}}、もしくはゲームパッドが線加速度データを提供できないときは `null` です。
+
+## 例
+
+TBD
+
+## 仕様書
+
+{{Specifications}}
+
+## ブラウザーの互換性
+
+{{Compat}}
+
+## 関連情報
+
+- [WebVR API](/ja/docs/Web/API/WebVR_API)
+- [Gamepad API](/ja/docs/Web/API/Gamepad_API)

--- a/files/ja/web/api/gamepadpose/linearvelocity/index.md
+++ b/files/ja/web/api/gamepadpose/linearvelocity/index.md
@@ -1,0 +1,33 @@
+---
+title: "GamepadPose: linearVelocity プロパティ"
+slug: Web/API/GamepadPose/linearVelocity
+l10n:
+  sourceCommit: b6984118ac9482e683a654edfefa4b426ca3c7ca
+---
+
+{{APIRef("WebVR API")}}{{SeeCompatTable}}
+
+{{domxref("GamepadPose")}} インターフェイスの読み取り専用プロパティ **`linearVelocity`** は、{{domxref("Gamepad")}} の線速度ベクトル (メートル毎秒) を表す配列を返します。
+
+言い換えると、センサーが `x` 軸・`y` 軸・`z` 軸方向に現在動いている速度です。
+
+## 値
+
+{{jsxref("Float32Array")}}、もしくはゲームパッドが線速度データを提供できないときは `null` です。
+
+## 例
+
+TBD
+
+## 仕様書
+
+{{Specifications}}
+
+## ブラウザーの互換性
+
+{{Compat}}
+
+## 関連情報
+
+- [WebVR API](/ja/docs/Web/API/WebVR_API)
+- [Gamepad API](/ja/docs/Web/API/Gamepad_API)

--- a/files/ja/web/api/gamepadpose/orientation/index.md
+++ b/files/ja/web/api/gamepadpose/orientation/index.md
@@ -1,0 +1,43 @@
+---
+title: "GamepadPose: orientation プロパティ"
+slug: Web/API/GamepadPose/orientation
+l10n:
+  sourceCommit: d8f04d843dd81ab8cea1cfc0577ae3c5c9b77d5c
+---
+
+{{APIRef("WebVR API")}}{{SeeCompatTable}}
+
+{{domxref("GamepadPose")}} の読み取り専用プロパティ **`orientation`** は、{{domxref("Gamepad")}} の向きをクォータニオン値で返します。
+
+値は、以下の値からなる {{jsxref("Float32Array")}} です。
+
+- ピッチ: X 軸のまわりの回転です。
+- ヨー: Y 軸のまわりの回転です。
+- ロール: Z 軸のまわりの回転です。
+- w: 4 次元目 (通常は 1) です。
+
+向きのうちヨー (y 軸のまわりの回転) は、センサーから値を最初に取得したときのヨーの初期値からの相対値です。
+
+## 値
+
+{{jsxref("Float32Array")}}、もしくは VR センサーが向きデータを提供できない場合は `null` です。
+
+## 例
+
+TBD
+
+> [!NOTE]
+> 向き `{ x: 0, y: 0, z: 0, w: 1 }` が「前」とみなされます。
+
+## 仕様書
+
+{{Specifications}}
+
+## ブラウザーの互換性
+
+{{Compat}}
+
+## 関連情報
+
+- [WebVR API](/ja/docs/Web/API/WebVR_API)
+- [Gamepad API](/ja/docs/Web/API/Gamepad_API)

--- a/files/ja/web/api/gamepadpose/position/index.md
+++ b/files/ja/web/api/gamepadpose/position/index.md
@@ -1,0 +1,42 @@
+---
+title: "GamepadPose: position プロパティ"
+slug: Web/API/GamepadPose/position
+l10n:
+  sourceCommit: d8f04d843dd81ab8cea1cfc0577ae3c5c9b77d5c
+---
+
+{{APIRef("WebVR API")}}{{SeeCompatTable}}
+
+{{domxref("GamepadPose")}} インターフェイスの読み取り専用プロパティ **`position`** は、{{domxref("Gamepad")}} の位置を 3 次元ベクトルで返します。
+
+座標系は以下の通りです。
+
+- X の正の方向はユーザーの右方向です。
+- Y の正の方向は上です。
+- Z の正の方向はユーザーの後ろです。
+
+位置は原点 (センサーから値が最初に取得された時の位置) からのメートル単位で計測されます。
+
+## 値
+
+{{jsxref("Float32Array")}}、もしくはゲームパッドが位置データを提供できないときは `null` です。
+
+> [!NOTE]
+> ユーザーエージェントは、いくつかの方法でエミュレートされた位置の値を提供する可能性があります。そうする場合でも、{{domxref("GamepadPose.hasPosition")}} は `false` を報告するべきです。
+
+## 例
+
+TBD
+
+## 仕様書
+
+{{Specifications}}
+
+## ブラウザーの互換性
+
+{{Compat}}
+
+## 関連情報
+
+- [WebVR API](/ja/docs/Web/API/WebVR_API)
+- [Gamepad API](/ja/docs/Web/API/Gamepad_API)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
`GamepadPose` を新規翻訳。  
(`GamepadPose.hasOrientation` は元からページがあったので、今回は対象外です)

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
角加速度の単位が**メートル**毎秒毎秒というのはおかしい感じがしますが、[もとの仕様書](https://w3c.github.io/gamepad/extensions.html#gamepadpose-interface)を確認すると加速度・角速度・角加速度の単位がすべて meters per second になっており、もっとおかしい感じがしたので、とりあえずそのまま訳しました。

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Relates to w3c/gamepad#213

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
