### PR TITLE
[zh-CN]: add translation for `ShadowRoot.fullscreenElement` & sync for other three pages

### DIFF
--- a/files/zh-cn/web/api/document/exitfullscreen/index.md
+++ b/files/zh-cn/web/api/document/exitfullscreen/index.md
@@ -2,7 +2,7 @@
 title: Document：exitFullscreen() 方法
 slug: Web/API/Document/exitFullscreen
 l10n:
-  sourceCommit: 41a8b9c9832359d445d136b6d7a8a28737badc6b
+  sourceCommit: be8f7f155a48e11b30c240f8731afb1845f85378
 ---
 
 {{ApiRef("Fullscreen API")}}

--- a/files/zh-cn/web/api/document/fullscreen/index.md
+++ b/files/zh-cn/web/api/document/fullscreen/index.md
@@ -2,7 +2,7 @@
 title: Document：fullscreen 属性
 slug: Web/API/Document/fullscreen
 l10n:
-  sourceCommit: 41a8b9c9832359d445d136b6d7a8a28737badc6b
+  sourceCommit: be8f7f155a48e11b30c240f8731afb1845f85378
 ---
 
 {{APIRef("Fullscreen API")}}{{Deprecated_Header}}

--- a/files/zh-cn/web/api/document/fullscreenelement/index.md
+++ b/files/zh-cn/web/api/document/fullscreenelement/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{ApiRef("Fullscreen API")}}
 
-只读属性 **`Document.fullscreenElement`** 返回当前页面中以全屏模式呈现的 {{domxref("Element")}}，如果当前页面未使用全屏模式，则返回 `null`。
+**`Document.fullscreenElement`** 只读属性返回当前页面中以全屏模式呈现的 {{domxref("Element")}}，如果当前页面未使用全屏模式，则返回 `null`。
 
 尽管这个属性是只读的，但如果修改它，即使在严格模式下也不会抛出错误；它的 `setter` 方法是空操作将被忽略。
 

--- a/files/zh-cn/web/api/shadowroot/fullscreenelement/index.md
+++ b/files/zh-cn/web/api/shadowroot/fullscreenelement/index.md
@@ -1,0 +1,34 @@
+---
+title: ShadowRoot：fullscreenElement 属性
+slug: Web/API/ShadowRoot/fullscreenElement
+l10n:
+  sourceCommit: f2f9346c0c0e9f6676f2df9f1850933e274401de
+---
+
+{{APIRef("Shadow DOM")}}
+
+{{domxref("ShadowRoot")}} 接口的 **`fullscreenElement`** 只读属性返回影子树中当前全屏显示的元素。
+
+## 值
+
+当前以全屏模式显示的 {{domxref('Element')}}，若无全屏元素则为 `null`。
+
+## 示例
+
+```js
+let customElem = document.querySelector("my-shadow-dom-element");
+let shadow = customElem.shadowRoot;
+let fullscreenElem = shadow.fullscreenElement;
+```
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- {{domxref("Document.fullscreenElement")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

[Document.fullscreen](https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreen)
[Document.fullscreenElement](https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenElement)
[ShadowRoot.fullscreenElement](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/fullscreenElement)
[Document.exitFullscreen()](https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen)

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

part of the https://github.com/mdn/translated-content/issues/23557

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
