### PR TITLE
[zh-CN]: fix the broken link to the `path()` CSS function

### DIFF
--- a/files/zh-cn/web/css/clip-path/index.md
+++ b/files/zh-cn/web/css/clip-path/index.md
@@ -65,7 +65,7 @@ clip-path: unset;
       - : 定义一个椭圆（使用两个半径和一个圆心位置）。
     - {{cssxref("basic-shape/polygon","polygon()")}}
       - : 定义一个多边形（使用一个 SVG 填充规则和一组顶点）。
-    - {{cssxref("path","path()")}}
+    - {{cssxref("basic-shape/path","path()")}}
       - : 定义一个任意形状（使用一个可选的 SVG 填充规则和一个 SVG 路径定义）。
 
 - `<geometry-box>`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
update `path` reference link to Chinese on `clip-path` page
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
I noticed that the `path` reference link on the `clip-path` page points to an English link, but actually `path` has a Chinese page.

![image](https://github.com/user-attachments/assets/61292b87-a3dc-4b60-a378-a28ee05d0eda)
![image](https://github.com/user-attachments/assets/25e11e4f-7696-4154-a4a7-223b8a11c432)

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
