### PR TITLE
zh-cn: update the description of the `beforeprint` event

### DIFF
--- a/files/zh-cn/web/api/window/beforeprint_event/index.md
+++ b/files/zh-cn/web/api/window/beforeprint_event/index.md
@@ -5,7 +5,7 @@ slug: Web/API/Window/beforeprint_event
 
 {{APIRef}}
 
-当相关联的文档即将打印或关闭打印预览时，将触发 **`beforeprint`** 事件。
+当相关联的文档即将打印或预览打印时，将触发 **`beforeprint`** 事件。
 
 {{domxref("Window.afterprint_event", "afterprint")}} 和 `beforeprint` 事件允许页面在打印开始之前更改其内容（例如，也许是移除 banner）然后在打印完成后还原这些更改。一般来说，你应该更倾向于使用 [`@media print`](/zh-CN/docs/Web/CSS/CSS_media_queries/Using_media_queries) CSS at 规则，但在某些情况下可能有必要使用这些事件。
 

--- a/files/zh-cn/web/api/window/beforeprint_event/index.md
+++ b/files/zh-cn/web/api/window/beforeprint_event/index.md
@@ -5,7 +5,7 @@ slug: Web/API/Window/beforeprint_event
 
 {{APIRef}}
 
-当相关联的文档即将打印或预览打印时，将触发 **`beforeprint`** 事件。
+**`beforeprint`** 事件会在相关联的文档即将打印或预览打印时触发。
 
 {{domxref("Window.afterprint_event", "afterprint")}} 和 `beforeprint` 事件允许页面在打印开始之前更改其内容（例如，也许是移除 banner）然后在打印完成后还原这些更改。一般来说，你应该更倾向于使用 [`@media print`](/zh-CN/docs/Web/CSS/CSS_media_queries/Using_media_queries) CSS at 规则，但在某些情况下可能有必要使用这些事件。
 


### PR DESCRIPTION
The beforeprint event is fired when the associated document is about to be printed or previewed for printing.

当相关联的文档即将打印或关闭打印预览时，将触发 beforeprint 事件。

当相关联的文档即将打印或预览打印时，将触发 beforeprint 事件。

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
