### PR TITLE
[zh-cn]: remove 'Browser compatibility' from some 'HTTP status code' docs

### DIFF
--- a/files/zh-cn/web/http/status/100/index.md
+++ b/files/zh-cn/web/http/status/100/index.md
@@ -19,10 +19,6 @@ HTTP **`100 Continue`** 信息型状态响应码表示目前为止一切正常�
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - {{HTTPHeader("Expect")}}

--- a/files/zh-cn/web/http/status/200/index.md
+++ b/files/zh-cn/web/http/status/200/index.md
@@ -26,6 +26,6 @@ slug: Web/HTTP/Status/200
 
 {{Specifications}}
 
-## 相关内容
+## 参见
 
 - [HTTP 请求方法](/zh-CN/docs/Web/HTTP/Methods)

--- a/files/zh-cn/web/http/status/200/index.md
+++ b/files/zh-cn/web/http/status/200/index.md
@@ -26,10 +26,6 @@ slug: Web/HTTP/Status/200
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 相关内容
 
 - [HTTP 请求方法](/zh-CN/docs/Web/HTTP/Methods)

--- a/files/zh-cn/web/http/status/201/index.md
+++ b/files/zh-cn/web/http/status/201/index.md
@@ -19,10 +19,6 @@ slug: Web/HTTP/Status/201
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - [HTTP request methods](/zh-CN/docs/Web/HTTP/Methods)

--- a/files/zh-cn/web/http/status/206/index.md
+++ b/files/zh-cn/web/http/status/206/index.md
@@ -58,10 +58,6 @@ Content-Range: bytes 4590-7999/8000
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - {{HTTPHeader("If-Range")}}

--- a/files/zh-cn/web/http/status/301/index.md
+++ b/files/zh-cn/web/http/status/301/index.md
@@ -36,10 +36,6 @@ Location: http://www.example.org/index.asp
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - {{HTTPStatus("308")}}，当使用的请求方法永远不会更改时，等价于此状态代码。

--- a/files/zh-cn/web/http/status/302/index.md
+++ b/files/zh-cn/web/http/status/302/index.md
@@ -21,10 +21,6 @@ HTTP **`302 Found`** 重定向状态码表明请求的资源被暂时的移动�
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - {{HTTPStatus("307")}} `Temporary Redirect`, the equivalent of this status code, but that never changes the method used.

--- a/files/zh-cn/web/http/status/303/index.md
+++ b/files/zh-cn/web/http/status/303/index.md
@@ -17,10 +17,6 @@ HTTP **303 See Other** 重定向状态码，通常作为 {{HTTPMethod("PUT")}} �
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - {{HTTPStatus("302")}} `Found`, the temporary redirect

--- a/files/zh-cn/web/http/status/304/index.md
+++ b/files/zh-cn/web/http/status/304/index.md
@@ -22,10 +22,6 @@ HTTP **`304 Not Modified`** 说明无需再次传输请求的内容，也就是�
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 兼容性提醒
 
 - 如果响应错误的携带了响应体，那么浏览器会有不同的行为，详情请见 [204 No Content](/zh-CN/docs/Web/HTTP/Status/204) 。

--- a/files/zh-cn/web/http/status/307/index.md
+++ b/files/zh-cn/web/http/status/307/index.md
@@ -21,10 +21,6 @@ slug: Web/HTTP/Status/307
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - {{HTTPStatus("302", "302 Found")}}, the equivalent of this status code, but that may change the method used when it is not a {{HTTPMethod("GET")}}.

--- a/files/zh-cn/web/http/status/401/index.md
+++ b/files/zh-cn/web/http/status/401/index.md
@@ -29,10 +29,6 @@ WWW-Authenticate: Basic realm="Access to staging site"
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 相关内容
 
 - [HTTP authentication](/zh-CN/docs/Web/HTTP/Authentication)

--- a/files/zh-cn/web/http/status/401/index.md
+++ b/files/zh-cn/web/http/status/401/index.md
@@ -29,7 +29,7 @@ WWW-Authenticate: Basic realm="Access to staging site"
 
 {{Specifications}}
 
-## 相关内容
+## 参见
 
 - [HTTP authentication](/zh-CN/docs/Web/HTTP/Authentication)
 - {{HTTPHeader("WWW-Authenticate")}}

--- a/files/zh-cn/web/http/status/403/index.md
+++ b/files/zh-cn/web/http/status/403/index.md
@@ -26,10 +26,6 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - {{HTTPStatus("401")}}

--- a/files/zh-cn/web/http/status/404/index.md
+++ b/files/zh-cn/web/http/status/404/index.md
@@ -32,10 +32,6 @@ ErrorDocument 404 /notfound.html
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - {{HTTPStatus("410")}}

--- a/files/zh-cn/web/http/status/406/index.md
+++ b/files/zh-cn/web/http/status/406/index.md
@@ -27,10 +27,6 @@ HTTP 协议中的 **`406 Not Acceptable`** 状态码表示客户端错误，指�
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - {{HTTPHeader("Accept-Language")}}

--- a/files/zh-cn/web/http/status/407/index.md
+++ b/files/zh-cn/web/http/status/407/index.md
@@ -27,10 +27,6 @@ Proxy-Authenticate: Basic realm="Access to internal site"
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 相关内容
 
 - [HTTP authentication](/zh-CN/docs/Web/HTTP/Authentication)

--- a/files/zh-cn/web/http/status/407/index.md
+++ b/files/zh-cn/web/http/status/407/index.md
@@ -27,7 +27,7 @@ Proxy-Authenticate: Basic realm="Access to internal site"
 
 {{Specifications}}
 
-## 相关内容
+## 参见
 
 - [HTTP authentication](/zh-CN/docs/Web/HTTP/Authentication)
 - {{HTTPHeader("WWW-Authenticate")}}

--- a/files/zh-cn/web/http/status/410/index.md
+++ b/files/zh-cn/web/http/status/410/index.md
@@ -20,10 +20,6 @@ HTTP **`410 Gone`** 说明请求的目标资源在原服务器上不存在了，
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - {{HTTPStatus(404)}}

--- a/files/zh-cn/web/http/status/412/index.md
+++ b/files/zh-cn/web/http/status/412/index.md
@@ -17,10 +17,6 @@ slug: Web/HTTP/Status/412
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - {{HTTPStatus("304")}}

--- a/files/zh-cn/web/http/status/416/index.md
+++ b/files/zh-cn/web/http/status/416/index.md
@@ -21,7 +21,7 @@ HTTP **`416 Range Not Satisfiable`** 错误状态码意味着服务器无法处�
 
 {{Specifications}}
 
-## 更多内容
+## 参见
 
 - {{HTTPStatus(206)}} `Partial Content`
 - {{HTTPHeader("Content-Range")}}

--- a/files/zh-cn/web/http/status/416/index.md
+++ b/files/zh-cn/web/http/status/416/index.md
@@ -21,10 +21,6 @@ HTTP **`416 Range Not Satisfiable`** 错误状态码意味着服务器无法处�
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 更多内容
 
 - {{HTTPStatus(206)}} `Partial Content`

--- a/files/zh-cn/web/http/status/418/index.md
+++ b/files/zh-cn/web/http/status/418/index.md
@@ -21,10 +21,6 @@ HTTP **`418 I'm a teapot`** 客户端错误响应状态码表示服务器拒绝�
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - [维基百科：超文本咖啡壶控制协议](https://zh.wikipedia.org/wiki/超文本咖啡壶控制协议)

--- a/files/zh-cn/web/http/status/451/index.md
+++ b/files/zh-cn/web/http/status/451/index.md
@@ -40,10 +40,6 @@ operated by the People's Front of Judea.</p>
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 相关内容
 
 - [Wikipedia: HTTP 451](https://zh.wikipedia.org/wiki/HTTP_451)

--- a/files/zh-cn/web/http/status/451/index.md
+++ b/files/zh-cn/web/http/status/451/index.md
@@ -40,7 +40,7 @@ operated by the People's Front of Judea.</p>
 
 {{Specifications}}
 
-## 相关内容
+## 参见
 
 - [Wikipedia: HTTP 451](https://zh.wikipedia.org/wiki/HTTP_451)
 - [Wikipedia: Fahrenheit 451](https://zh.wikipedia.org/wiki/Fahrenheit_451) (which gave this status code its number)

--- a/files/zh-cn/web/http/status/500/index.md
+++ b/files/zh-cn/web/http/status/500/index.md
@@ -19,10 +19,6 @@ slug: Web/HTTP/Status/500
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - [HTTP/1.1: Status Code Definitions](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)

--- a/files/zh-cn/web/http/status/501/index.md
+++ b/files/zh-cn/web/http/status/501/index.md
@@ -21,7 +21,3 @@ HTTP **`501 Not Implemented`** 服务器错误响应码表示请求的方法不�
 ## 规范
 
 {{Specifications}}
-
-## 浏览器兼容性
-
-{{Compat}}

--- a/files/zh-cn/web/http/status/502/index.md
+++ b/files/zh-cn/web/http/status/502/index.md
@@ -19,10 +19,6 @@ slug: Web/HTTP/Status/502
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - {{HTTPStatus(504)}}

--- a/files/zh-cn/web/http/status/503/index.md
+++ b/files/zh-cn/web/http/status/503/index.md
@@ -21,6 +21,6 @@ slug: Web/HTTP/Status/503
 
 {{Specifications}}
 
-## 相关内容
+## 参见
 
 - {{HTTPHeader("Retry-After")}}

--- a/files/zh-cn/web/http/status/503/index.md
+++ b/files/zh-cn/web/http/status/503/index.md
@@ -21,10 +21,6 @@ slug: Web/HTTP/Status/503
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 相关内容
 
 - {{HTTPHeader("Retry-After")}}

--- a/files/zh-cn/web/http/status/504/index.md
+++ b/files/zh-cn/web/http/status/504/index.md
@@ -19,10 +19,6 @@ slug: Web/HTTP/Status/504
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 相关内容
 
 - {{HTTPStatus(502)}}

--- a/files/zh-cn/web/http/status/504/index.md
+++ b/files/zh-cn/web/http/status/504/index.md
@@ -19,6 +19,6 @@ slug: Web/HTTP/Status/504
 
 {{Specifications}}
 
-## 相关内容
+## 参见
 
 - {{HTTPStatus(502)}}


### PR DESCRIPTION
### Description

参考原文文档，移除一些 HTTP 响应状态码文档中的“浏览器兼容性”部分。

大部分状态码无需考虑此项。

:D