### PR TITLE
Correcting an error of http caching

### DIFF
--- a/files/zh-cn/web/http/caching/index.md
+++ b/files/zh-cn/web/http/caching/index.md
@@ -33,7 +33,11 @@ Cache-Control: private
 
 个性化内容通常由 cookie 控制，但 cookie 的存在并不能表明它是私有的，因此单独的 cookie 不会使响应成为私有的。
 
-请注意，如果响应具有 `Authorization` 标头，则不能将其存储在私有缓存（或共享缓存，除非 Cache-Control 指定的是 `public`）中。
+请注意，如果响应具有 `Authorization` 标头，则不能将其存储在共享缓存中，即使设置了 `max-age` 也不能，需明确指定 `public` 指令。
+
+```http
+Cache-Control: public, max-age=604800
+```
 
 ### 共享缓存
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Correcting an error about http caching when http response has `Authorization` head. The response can be stored in private cache, but the doc currently says it can't. And U can find the right answer in the [english doc of cache-control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#directives), at directives `public` section. 

Here is the screenshot:

<img width="787" alt="image" src="https://github.com/user-attachments/assets/ffae175c-92c0-46ac-bc2e-a0a1fc3c9817">

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
