### PR TITLE
Change not found video for images

### DIFF
--- a/files/es/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/es/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -428,11 +428,11 @@ Comenzando con Firefox 45, pueden instalar temporalmente una extensión desde el
 
 Abre "about:debugging" en Firefox, de clic en "Cargar complemento temporalmente", y seleccione el archivo manifest.json. Entonces, debería de ver el ícono de la extensión aparecer en la barra de herramientas de Firefox:
 
-{{EmbedYouTube("sAM78GU4P34")}}
+![The beastify icon in the Firefox toolbar](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension/beastify_icon.png)
 
 Abra una página web, luego haga clic sobre el ícono, seleccione una bestia, y vea cómo cambia la página web:
 
-{{EmbedYouTube("YMQXyAQSiE8")}}
+![A page replaced with the image of a turtle](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension/beastify_page.png)
 
 ## Desarrollo desde la línea de comandos
 

--- a/files/es/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/es/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -428,7 +428,7 @@ Comenzando con Firefox 45, pueden instalar temporalmente una extensión desde el
 
 Abre "about:debugging" en Firefox, de clic en "Cargar complemento temporalmente", y seleccione el archivo manifest.json. Entonces, debería de ver el ícono de la extensión aparecer en la barra de herramientas de Firefox:
 
-![The beastify icon in the Firefox toolbar](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension/beastify_icon.png)
+![The beastify icon in the Firefox toolbar](/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension/beastify_icon.png)
 
 Abra una página web, luego haga clic sobre el ícono, seleccione una bestia, y vea cómo cambia la página web:
 

--- a/files/es/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/es/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -432,7 +432,7 @@ Abre "about:debugging" en Firefox, de clic en "Cargar complemento temporalmente"
 
 Abra una página web, luego haga clic sobre el ícono, seleccione una bestia, y vea cómo cambia la página web:
 
-![A page replaced with the image of a turtle](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension/beastify_page.png)
+![A page replaced with the image of a turtle](/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension/beastify_page.png)
 
 ## Desarrollo desde la línea de comandos
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The videos were inaccessible, so I suggest replacing them with the original images. Although the images aren’t translated into Spanish, at least the instructions are preserved clearly.

### Motivation

I'm glad to help!

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

🔨 Fixes #24208

Before: 

![image](https://github.com/user-attachments/assets/4aad8747-b526-4bf0-b2d9-7321d0d569b4)
After: 

![image](https://github.com/user-attachments/assets/dddc0684-6281-47c0-82e1-d8d1418826b5)

