### PR TITLE
chore(css): Move CSS examples - CSS values and units

### DIFF
--- a/files/ko/learn/css/building_blocks/values_and_units/index.md
+++ b/files/ko/learn/css/building_blocks/values_and_units/index.md
@@ -11,7 +11,7 @@ CSS 규칙은 [선언](/ko/docs/Web/CSS/Syntax#css_declarations)으로 구성되
 CSS에서 사용되는 각 속성은 어떤 종류의 값을 가질 수 있는지를 설명하는 **값 유형을** 가지고 있습니다.
 이번 학습에서는 자주 사용되는 값 유형이 무엇인지, 그리고 그것이 어떻게 작동하는지를 살펴보겠습니다.
 
-> [!NOTE] 
+> [!NOTE]
 > 각 [CSS 속성 페이지](/ko/docs/Web/CSS/Reference#index)에는 해당 속성에 사용할 수 있는 값 유형이 나열된 구문 섹션이 있습니다.
 
 <table class="learn-box standard-table">

--- a/files/ko/learn/css/building_blocks/values_and_units/index.md
+++ b/files/ko/learn/css/building_blocks/values_and_units/index.md
@@ -54,7 +54,7 @@ CSS 사양과 MDN의 속성 페이지에서 [`<color>`](/ko/docs/Web/CSS/color_v
 
 > [!NOTE]
 > CSS 값은 CSS 속성과 구별하기 위해, 꺾쇠괄호(`<`, `>`)를 사용하여 표시되는 경향이 있습니다.
-> 예를 들어, {{cssxref("color")}} 속성과 [`<color>`](/ko/docs/Web/CSS/color_value) 데이터 형식이 있습니다. 
+> 예를 들어, {{cssxref("color")}} 속성과 [`<color>`](/ko/docs/Web/CSS/color_value) 데이터 형식이 있습니다.
 > CSS 데이터 형식과 HTML 요소도 꺾쇠괄호를 사용하므로 혼동될 수 있지만, 이는 매우 다른 상황에서 사용됩니다.
 
 다음 예제에서는 키워드를 사용하여 머리글의 색상을 설정하고, `rgb()` 함수를 사용하여 배경을 설정했습니다.

--- a/files/ko/learn/css/building_blocks/values_and_units/index.md
+++ b/files/ko/learn/css/building_blocks/values_and_units/index.md
@@ -2,25 +2,29 @@
 title: CSS 값과 단위
 slug: Learn/CSS/Building_blocks/Values_and_units
 l10n:
-  sourceCommit: 751d58669499de0c6ea0d5b356e0e1448418c5d3
+  sourceCommit: ff2893c6e14249c44e54c67102ca4218f08b70d1
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Overflowing_content", "Learn/CSS/Building_blocks/Sizing_items_in_CSS", "Learn/CSS/Building_blocks")}}
 
-CSS에 사용된 모든 속성에는 해당 속성에 허용되는 값이 있으며, MDN의 속성 페이지를 보면 특성 속성에 유효한 값을 이해하는 데 도움이 됩니다. 이 레슨에서는 가장 일반적인 값과 사용 단위를 살펴보겠습니다.
+CSS 규칙은 [선언](/ko/docs/Web/CSS/Syntax#css_declarations)으로 구성되어 있으며, 이는 다시 속성과 값으로 이루어져 있습니다.
+CSS에서 사용되는 각 속성은 어떤 종류의 값을 가질 수 있는지를 설명하는 **값 유형을** 가지고 있습니다.
+이번 학습에서는 자주 사용되는 값 유형이 무엇인지, 그리고 그것이 어떻게 작동하는지를 살펴보겠습니다.
+
+> [!NOTE] 
+> 각 [CSS 속성 페이지](/ko/docs/Web/CSS/Reference#index)에는 해당 속성에 사용할 수 있는 값 유형이 나열된 구문 섹션이 있습니다.
 
 <table class="learn-box standard-table">
   <tbody>
     <tr>
-      <th scope="row">전제조건:</th>
+      <th scope="row">선행 지식:</th>
       <td>
-        기본 컴퓨터 활용 능력,
         <a
-          href="https://developer.mozilla.org/en-US/Learn/Getting_started_with_the_web/Installing_basic_software"
+          href="/ko/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
           >기본 소프트웨어 설치</a
         >,
         <a
-          href="https://developer.mozilla.org/en-US/Learn/Getting_started_with_the_web/Dealing_with_files"
+          href="/ko/docs/Learn/Getting_started_with_the_web/Dealing_with_files"
           >파일 작업</a
         >
         에 대한 기본 지식, HTML 기본 사항 (<a
@@ -49,7 +53,9 @@ CSS 사양과 MDN의 속성 페이지에서 [`<color>`](/ko/docs/Web/CSS/color_v
 > CSS 값을 _데이터 유형_ 이라고 합니다. 용어는 기본적으로 상호 교환이 가능합니다. CSS에서 데이터 유형이라고 하는 것을 볼 때, 실제로 가치를 말하는 멋진 방법입니다.
 
 > [!NOTE]
-> 예, CSS 값은 CSS 속성과 구별하기 위해, 꺾쇠괄호를 사용하여 표시되는 경향이 있습니다 (예: {{cssxref("color")}} 속성, [`<color>`](/ko/docs/Web/CSS/color_value) 데이터 형식). CSS 데이터 형식과 HTML 요소도 꺾쇠괄호를 사용하므로 혼동될 수 있지만, 이는 매우 다른 상황에서 사용됩니다.
+> CSS 값은 CSS 속성과 구별하기 위해, 꺾쇠괄호(`<`, `>`)를 사용하여 표시되는 경향이 있습니다.
+> 예를 들어, {{cssxref("color")}} 속성과 [`<color>`](/ko/docs/Web/CSS/color_value) 데이터 형식이 있습니다. 
+> CSS 데이터 형식과 HTML 요소도 꺾쇠괄호를 사용하므로 혼동될 수 있지만, 이는 매우 다른 상황에서 사용됩니다.
 
 다음 예제에서는 키워드를 사용하여 머리글의 색상을 설정하고, `rgb()` 함수를 사용하여 배경을 설정했습니다.
 
@@ -127,13 +133,46 @@ CSS에서 사용할 수 있는 다양한 숫자 데이터 형식이 있습니다
 
 위의 지침을 따른 후 다른 방법으로 값을 실습하여 얻은 것을 확인하세요.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/length.html", '100%', 820)}}
+```html live-sample___length
+<div class="wrapper">
+  <div class="box px">I am 200px wide</div>
+  <div class="box vw">I am 10vw wide</div>
+  <div class="box em">I am 10em wide</div>
+</div>
+```
+
+```css live-sample___length
+.box {
+  background-color: lightblue;
+  border: 5px solid darkblue;
+  padding: 10px;
+  margin: 1em 0;
+}
+
+.wrapper {
+  font-size: 1em;
+}
+
+.px {
+  width: 200px;
+}
+
+.vw {
+  width: 10vw;
+}
+
+.em {
+  width: 10em;
+}
+```
+
+{{EmbedLiveSample("length", "", "250px")}}
 
 #### ems 및 rems
 
 `em` 과 `rem`은 박스에서 텍스트로 크기를 조정할 때 가장 자주 발생하는 두 개의 상대 길이입니다. [텍스트 스타일링](/ko/docs/Learn/CSS/Styling_text) 또는 [CSS 레이아웃](/ko/docs/Learn/CSS/CSS_layout) 과 같은 보다 복잡한 주제를 시작할 때, 이러한 작동 방식과 차이점을 이해하는 것이 좋습니다. 아래 예제는 데모를 제공합니다.
 
-HTML은 중첩된 목록의 집합입니다. 총 3개의 목록이 있으며 두 예제 모두 동일한 HTML을 갖습니다. 유일한 차이점은 첫 번째는 **_ems_** class이고 두 번째는 **_rems_** class입니다.
+HTML은 중첩된 목록의 집합입니다. 총 2개의 목록이 있으며 두 예제 모두 동일한 HTML을 갖습니다. 유일한 차이점은 첫 번째는 **_ems_** class이고 두 번째는 **_rems_** class입니다.
 
 먼저, `<html>` 요소에서 글꼴 크기로 16px 를 설정합니다.
 
@@ -143,7 +182,57 @@ HTML은 중첩된 목록의 집합입니다. 총 3개의 목록이 있으며 두
 
 그러나, CSS에서 `<html>` `font-size` 를 변경하면 다른 모든 텍스트가 변경되는 것을 볼 수 있습니다. `rem` 및 `em` 크기 텍스트.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/em-rem.html", '100%', 1000)}}
+```html live-sample___em-rem
+<ul class="ems">
+  <li>One</li>
+  <li>Two</li>
+  <li>
+    Three
+    <ul>
+      <li>Three A</li>
+      <li>
+        Three B
+        <ul>
+          <li>Three B 2</li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>
+
+<ul class="rems">
+  <li>One</li>
+  <li>Two</li>
+  <li>
+    Three
+    <ul>
+      <li>Three A</li>
+      <li>
+        Three B
+        <ul>
+          <li>Three B 2</li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>
+```
+
+```css live-sample___em-rem
+html {
+  font-size: 16px;
+}
+
+.ems li {
+  font-size: 1.3em;
+}
+
+.rems li {
+  font-size: 1.3rem;
+}
+```
+
+{{EmbedLiveSample("em-rem", "", "400px")}}
 
 ### 백분율
 
@@ -153,13 +242,68 @@ HTML은 중첩된 목록의 집합입니다. 총 3개의 목록이 있으며 두
 
 차이점은 두 박스의 두 번째 세트가 너비가 400 픽셀 안에 있다는 것입니다. 두 번째 200px 너비의 박스는 첫 번째 너비와 동일한 너비이지만, 두 번째 40% 박스는 이제 400px의 40%이므로 첫 번째 박스보다 훨씬 좁습니다!
 
-**너비 또는 백분율 값을 변경하여 작동 방식을 확인합니다.**
+너비 또는 백분율 값을 변경하여 작동 방식을 확인합니다.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/percentage.html", '100%', 850)}}
+```html live-sample___percentage
+<div class="box px">I am 200px wide</div>
+<div class="box percent">I am 40% wide</div>
+<div class="wrapper">
+  <div class="box px">I am 200px wide</div>
+  <div class="box percent">I am 40% wide</div>
+</div>
+```
+
+```css live-sample___percentage
+.box {
+  background-color: lightblue;
+  border: 5px solid darkblue;
+  padding: 10px;
+  margin: 1em 0;
+}
+.wrapper {
+  width: 400px;
+  border: 5px solid rebeccapurple;
+}
+
+.px {
+  width: 200px;
+}
+
+.percent {
+  width: 40%;
+}
+```
+
+{{EmbedLiveSample("percentage", "", "350px")}}
 
 다음 예제에서는 글꼴 크기가 백분율로 설정되어 있습니다. 각 `<li>` 의 `font-size` 는 80%이므로, 중첩된 목록 항목은 부모로부터 크기를 상속함에 따라 점차 작아집니다.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/percentage-fonts.html", '100%', 650)}}
+```html live-sample___percentage-fonts
+<ul>
+  <li>One</li>
+  <li>Two</li>
+  <li>
+    Three
+    <ul>
+      <li>Three A</li>
+      <li>
+        Three B
+        <ul>
+          <li>Three B 2</li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>
+```
+
+```css live-sample___percentage-fonts
+li {
+  font-size: 80%;
+}
+```
+
+{{EmbedLiveSample("percentage-fonts")}}
 
 많은 값이 길이 또는 백분율을 허용하지만, 길이만 허용하는 값도 있습니다. MDN 속성 참조 페이지에서 어떤 값이 허용되는지 확인할 수 있습니다. 허용된 값에 [`<length-percentage>`](/ko/docs/Web/CSS/length-percentage) 가 포함된 경우 길이 또는 백분율을 사용할 수 있습니다. 허용된 값에 `<length>` 만 포함된 경우, 백분율을 사용할 수 없습니다.
 
@@ -167,9 +311,33 @@ HTML은 중첩된 목록의 집합입니다. 총 3개의 목록이 있으며 두
 
 일부 값은 단위를 추가하지 않고 숫자를 허용합니다. 단위가 없는 숫자를 허용하는 속성의 예는 요소의 불투명도 (투명한 정도)를 제어하는 `opacity` 속성입니다. 이 속성은 `0` (완전 투명)과 `1` (완전 불투명) 사이의 숫자를 허용합니다.
 
-**아래 예제에서, `opacity` 값을 `0` 과 `1` 사이의 다양한 10진수 값으로 변경하고 박스와 그 내용이 어떻게 붙투명하게 되는지 확인하세요.**
+아래 예제에서, `opacity` 값을 `0` 과 `1` 사이의 다양한 10진수 값으로 변경하고 박스와 그 내용이 어떻게 붙투명하게 되는지 확인하세요.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/opacity.html", '100%', 500)}}
+```html live-sample___opacity
+<div class="wrapper">
+  <div class="box">I am a box with opacity</div>
+</div>
+```
+
+```css live-sample___opacity
+.wrapper {
+  background-image: url(https://mdn.github.io/shared-assets/images/examples/balloons.jpg);
+  background-repeat: no-repeat;
+  background-position: bottom left;
+  padding: 20px;
+}
+
+.box {
+  margin: 40px auto;
+  width: 200px;
+  background-color: lightblue;
+  border: 5px solid darkblue;
+  padding: 10px;
+  opacity: 0.6;
+}
+```
+
+{{EmbedLiveSample("opacity", "", "210px")}}
 
 > [!NOTE]
 > CSS에서 숫자를 값으로 사용하는 경우 따옴표로 묶지 않아야합니다.
@@ -185,21 +353,75 @@ CSS에서 색상을 지정하는 방법은 여러 가지가 있으며, 그중 �
 
 ### 색상 키워드
 
-여기의 학습 섹션이나 MDN 의 다른 예에서 색상 키워드를 지정하는 간단하고 이해하기 쉬운 방법인 색상 키워드를 볼 수 있습니다. 이 키워드에는 여러 가지가 있으며 그중 일부는 상당히 재미있는 이름을 가지고 있습니다! [`<color>`](/ko/docs/Web/CSS/color_value) 값에 대한 전체 목록을 페이지에서 볼 수 있습니다.
+여기의 학습 섹션이나 MDN 의 다른 예에서 색상 키워드를 지정하는 직관적인 방법인 색상 키워드를 볼 수 있습니다. 이 키워드에는 여러 가지가 있으며 그중 일부는 상당히 재미있는 이름을 가지고 있습니다! [`<color>`](/ko/docs/Web/CSS/color_value) 값에 대한 전체 목록을 페이지에서 볼 수 있습니다.
 
-**아래의 라이브 예제에서 다른 색상 값을 사용하여 작동하는 방법에 대한 아이디어를 얻으십시오.**
+아래의 라이브 예제에서 다른 색상 값을 사용하여 작동하는 방법에 대한 아이디어를 얻으십시오.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/color-keywords.html", '100%', 800)}}
+```html live-sample___color-keywords
+<div class="wrapper">
+  <div class="box one">antiquewhite</div>
+  <div class="box two">blueviolet</div>
+  <div class="box three">greenyellow</div>
+</div>
+```
+
+```css live-sample___color-keywords
+.box {
+  padding: 10px;
+  margin: 0.5em 0;
+  border-radius: 0.5em;
+}
+.one {
+  background-color: antiquewhite;
+}
+
+.two {
+  background-color: blueviolet;
+}
+
+.three {
+  background-color: greenyellow;
+}
+```
+
+{{EmbedLiveSample("color-keywords")}}
 
 ### 16진수 RGB 값
 
 다음 형식의 색상 값은 16진수 코드입니다. 각 16진수 값은 hash/pound 기호 (#) 와 6개의 16진수로 구성되며, 각 16진수는 0과 f (15를 나타냄) 사이의 16개 값 중 하나를 사용할 수 있으므로 `0123456789abcdef` 입니다. 각 값 쌍은 채널 중 하나 빨강, 녹색 및 파랑을 나타내며 각각에 대해 256개의 사용 가능한 값 (16 x 16 = 256) 을 지정할 수 있습니다.
-
 이 값은 좀 더 복잡하고 이해하기 쉽지 않지만, 키워드보다 훨씬 더 다양합니다. 16진수 값을 사용하여 색상표에 사용하려는 색상을 나타낼 수 있습니다.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/color-hex.html", '100%', 800)}}
+다시 한번, 값을 변경하여 색상이 어떻게 다른지 확인하세요.
 
-**다시 한번, 값을 변경하여 색상이 어떻게 다른지 확인하세요.**
+```html live-sample___color-hex
+<div class="wrapper">
+  <div class="box one">#02798b</div>
+  <div class="box two">#c55da1</div>
+  <div class="box three">#128a7d</div>
+</div>
+```
+
+```css live-sample___color-hex
+.box {
+  padding: 10px;
+  margin: 0.5em 0;
+  border-radius: 0.5em;
+}
+
+.one {
+  background-color: #02798b;
+}
+
+.two {
+  background-color: #c55da1;
+}
+
+.three {
+  background-color: #128a7d;
+}
+```
+
+{{EmbedLiveSample("color-hex")}}
 
 ### RGB 및 RGBA 값
 
@@ -207,7 +429,34 @@ CSS에서 색상을 지정하는 방법은 여러 가지가 있으며, 그중 �
 
 RGB 색상들을 사용하기 위해 우리의 마지막 예시를 다시 작성해봅시다.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/color-rgb.html", '100%', 800)}}
+```html live-sample___color-rgb
+<div class="wrapper">
+  <div class="box one">rgb(2 121 139)</div>
+  <div class="box two">rgb(197 93 161)</div>
+  <div class="box three">rgb(18 138 125)</div>
+</div>
+```
+
+```css live-sample___color-rgb
+.box {
+  padding: 10px;
+  margin: 0.5em 0;
+  border-radius: 0.5em;
+}
+.one {
+  background-color: rgb(2 121 139);
+}
+
+.two {
+  background-color: rgb(197 93 161);
+}
+
+.three {
+  background-color: rgb(18 138 125);
+}
+```
+
+{{EmbedLiveSample("color-rgb")}}
 
 RGBA 색상을 사용할 수도 있습니다. 이 색상은 RGB 색상과 정확히 같은 방식으로 작동하므로 RGB 값을 사용할 수 있지만, 색상의 알파 채널을 나타내는 네 번째 값이 있어 불투명도 (opacity)를 제어합니다. 이 값을 `0`으로 설정하면 색상이 완전히 투명해지는 반면, `1`이면 완전히 불투명하게 됩니다. 그 사이의 값은 다른 수준의 투명성을 제공합니다.
 
@@ -215,10 +464,42 @@ RGBA 색상을 사용할 수도 있습니다. 이 색상은 RGB 색상과 정확
 > 색상에 알파 채널을 설정하면 앞에서 살펴본 {{cssxref("opacity")}} 속성을 사용하는 것과 한 가지 중요한 차이점이 있습니다. 불투명도를 사용하면 요소와 그 안에 있는 모든 것을 불투명하게 만드는 반면, RGBA 색상을 사용하면 불투명하게 지정한 색상만 만들어집니다.
 
 아래 예제에서 나는 색상 박스가 포함된 블록에 배경 이미지를 추가했습니다. 그런 다음 박스에 다른 불투명도 값을 갖도록 설정했습니다. 알파 채널 값이 작을 때 배경이 더 잘 나타나는지 확인하세요.
+이 예에서는, 알파 채널 값을 변경하여 색상 출력에 어떤 영향을 미치는지 확인하세요.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/color-rgba.html", '100%', 900)}}
+```html live-sample___color-rgba
+<div class="wrapper">
+  <div class="box one">rgb(2 121 139 / .3)</div>
+  <div class="box two">rgb(197 93 161 / .7)</div>
+  <div class="box three">rgb(18 138 125 / .9)</div>
+</div>
+```
 
-**이 예에서는, 알파 채널 값을 변경하여 색상 출력에 어떤 영향을 미치는지 확인하세요.**
+```css live-sample___color-rgba
+.wrapper {
+  background-image: url(https://mdn.github.io/shared-assets/images/examples/balloons.jpg);
+  padding: 40px 20px;
+}
+
+.box {
+  padding: 10px;
+  margin: 0.5em 0;
+  border-radius: 0.5em;
+}
+
+.one {
+  background-color: rgb(2 121 139 / 0.3);
+}
+
+.two {
+  background-color: rgb(197 93 161 / 0.7);
+}
+
+.three {
+  background-color: rgb(18 138 125 / 0.9);
+}
+```
+
+{{EmbedLiveSample("color-rgba", "", "250px")}}
 
 > [!NOTE]
 > 구형 버전의 CSS에서는 `rgb()` 문법이 알파 매개변수를 지원하지 않았기 때문에 `rgba()` 라는 다른 함수를 호출해야 했습니다. 요즘에는 알파 매개변수를 `rgb()`에 넘길 수 있습니다. 하지만 구형 웹사이트와의 하위 호환성을위해 여전히 `rgba()` 문법은 지원되고 있습니다. 그리고 `rgb()`와 정확히 같은 동작을 수행합니다.
@@ -233,11 +514,72 @@ RGB보다 약간 덜 지원되는 HSL 색상은 (이전 버전의 IE에서는 �
 
 다음과 같이 HSL 색상을 사용하도록 RGB 예제를 업데이트할 수 있습니다.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/color-hsl.html", '100%', 800)}}
+```html live-sample___color-hsl
+<div class="wrapper">
+  <div class="box one">hsl(188 97% 28%)</div>
+  <div class="box two">hsl(321 47% 57%)</div>
+  <div class="box three">hsl(174 77% 31%)</div>
+</div>
+```
+
+```css live-sample___color-hsl
+.box {
+  padding: 10px;
+  margin: 0.5em 0;
+  border-radius: 0.5em;
+}
+
+.one {
+  background-color: hsl(188 97% 28%);
+}
+
+.two {
+  background-color: hsl(321 47% 57%);
+}
+
+.three {
+  background-color: hsl(174 77% 31%);
+}
+```
+
+{{EmbedLiveSample("color-hsl")}}
 
 `rgb()`처럼 불투명도를 명시하기 위해 `hsl()`에 알파 매개변수를 넘길 수 있습니다.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/color-hsla.html", '100%', 900)}}
+```html live-sample___color-hsla
+<div class="wrapper">
+  <div class="box one">hsl(188 97% 28% / .3)</div>
+  <div class="box two">hsl(321 47% 57% / .7)</div>
+  <div class="box three">hsl(174 77% 31% / .9)</div>
+</div>
+```
+
+```css live-sample___color-hsla
+.wrapper {
+  background-image: url(https://mdn.github.io/shared-assets/images/examples/balloons.jpg);
+  padding: 40px 20px;
+}
+
+.box {
+  padding: 10px;
+  margin: 0.5em 0;
+  border-radius: 0.5em;
+}
+
+.one {
+  background-color: hsl(188 97% 28% / 0.3);
+}
+
+.two {
+  background-color: hsl(321 47% 57% / 0.7);
+}
+
+.three {
+  background-color: hsl(174 77% 31% / 0.9);
+}
+```
+
+{{EmbedLiveSample("color-hsla", "", "250px")}}
 
 > [!NOTE]
 > 구형 버전의 CSS에서는 `hsl()` 문법이 알파 매개변수를 지원하지 않았기 때문에 `hsla()` 라는 다른 함수를 호출해야 했습니다. 요즘에는 알파 매개변수를 `hsl()`에 넘길 수 있습니다. 하지만 구형 웹사이트와의 하위 호환성을위해 여전히 `hsla()` 문법은 지원되고 있습니다. 그리고 `hsl()`와 정확히 같은 동작을 수행합니다.
@@ -250,7 +592,32 @@ RGB보다 약간 덜 지원되는 HSL 색상은 (이전 버전의 IE에서는 �
 
 아래 예제에서 CSS `background-image` 속성의 값으로 사용되는 이미지와 gradient를 보여주었습니다.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/image.html", '100%', 740)}}
+```html live-sample___image
+<div class="box image"></div>
+<div class="box gradient"></div>
+```
+
+```css live-sample___image
+.box {
+  height: 150px;
+  width: 300px;
+  margin: 20px auto;
+  border-radius: 0.5em;
+}
+.image {
+  background-image: url(https://mdn.github.io/shared-assets/images/examples/big-star.png);
+}
+
+.gradient {
+  background-image: linear-gradient(
+    90deg,
+    rgb(119 0 255 / 39%),
+    rgb(0 212 255 / 100%)
+  );
+}
+```
+
+{{EmbedLiveSample("image", "", "380px")}}
 
 > **참고:** `<image>` 에 대해 가능한 다른 값이 있지만 이 값은 최신이며 최신 브라우저 지원이 좋지 않습니다. \<image> 데이터 형식을 읽으려면 MDN 페이지에서 [`<image>`](/ko/docs/Web/CSS/image) 데이터 형식을 확인하세요.
 
@@ -261,10 +628,26 @@ RGB보다 약간 덜 지원되는 HSL 색상은 (이전 버전의 IE에서는 �
 일반적인 position 값은 두 가지 값으로 구성됩니다. 첫 번째는 위치를 가로로 설정하고, 두 번째는 세로로 설정합니다. 한 축의 값만 지정하면 다른 축은 `center` 으로 설정됩니다.
 
 다음 예제에서는 키워드를 사용하여 컨테이너의 위쪽과 오른쪽에서 40px의 배경 이미지를 배치했습니다.
+이 값을 가지고 놀면서 이미지를 어떻게 밀어낼 수 있는지 확인하세요.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/position.html", '100%', 720)}}
+```html live-sample___position
+<div class="box"></div>
+```
 
-**이 값을 가지고 놀면서 이미지를 어떻게 밀어낼 수 있는지 확인하세요.**
+```css live-sample___position
+.box {
+  height: 100px;
+  width: 400px;
+  background-image: url(https://mdn.github.io/shared-assets/images/examples/big-star.png);
+  background-repeat: no-repeat;
+  background-position: right 40px;
+  margin: 20px auto;
+  border-radius: 0.5em;
+  border: 5px solid rebeccapurple;
+}
+```
+
+{{EmbedLiveSample("position")}}
 
 ## 문자열 및 식별자 (identifiers)
 
@@ -272,7 +655,25 @@ RGB보다 약간 덜 지원되는 HSL 색상은 (이전 버전의 IE에서는 �
 
 CSS에서 문자열을 사용하는 장소가 있습니다. 예를 들면, [생성된 콘텐츠를 지정할 때](/ko/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements#Generating_content_with_before_and_after). 이 경우 값은 문자열임을 보여주기 위해 인용됩니다. 아래 예제에서는 인용되지 않은 색상 키워드와 인용된 생성된 콘텐츠 문자열을 사용합니다.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/strings-idents.html", '100%', 550)}}
+```html live-sample___strings-idents
+<div class="box"></div>
+```
+
+```css live-sample___strings-idents
+.box {
+  width: 400px;
+  padding: 1em;
+  border-radius: 0.5em;
+  border: 5px solid rebeccapurple;
+  background-color: lightblue;
+}
+
+.box::after {
+  content: "This is a string. I know because it is quoted in the CSS.";
+}
+```
+
+{{EmbedLiveSample("strings-idents")}}
 
 ## 함수 (Functions)
 
@@ -282,7 +683,26 @@ CSS에서 문자열을 사용하는 장소가 있습니다. 예를 들면, [생�
 
 예를 들어, 아래에서는 `calc()` 를 사용하여 박스를 `20% + 100px` 너비로 만듭니다. 20% 는 부모 container `.wrapper` 의 너비에서 계산되므로 너비가 변경되면 변경됩니다. 우리는 부모 요소의 20% 가 무엇인지 알지 못하기 때문에, 이 계산을 미리 수행할 수 없으므로 `calc()` 를 사용하여 브라우저에 지시합니다.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/calc.html", '100%', 500)}}
+```html live-sample___calc
+<div class="wrapper">
+  <div class="box">My width is calculated.</div>
+</div>
+```
+
+```css live-sample___calc
+.wrapper {
+  width: 400px;
+}
+.box {
+  padding: 1em;
+  border-radius: 0.5em;
+  border: 5px solid rebeccapurple;
+  background-color: lightblue;
+  width: calc(20% + 100px);
+}
+```
+
+{{EmbedLiveSample("calc")}}
 
 ## 스킬을 테스트하세요!
 


### PR DESCRIPTION
### Description

As part of an initiative to reduce repo maintenance & code duplication, this PR moves some external examples into content. This PR converts the following macros to live samples:

``` markdown
{{EmbedGHLiveSample("css-examples/learn/values-units/length.html", '100%', 900)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/em-rem.html", '100%', 1100)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/percentage.html", '100%', 1000)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/percentage-fonts.html", '100%', 800)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/opacity.html", '100%', 600)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/color-keywords.html", '100%', 800)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/color-hex.html", '100%', 800)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/color-rgb.html", '100%', 800)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/color-rgba.html", '100%', 900)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/color-hsl.html", '100%', 800)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/color-hsla.html", '100%', 900)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/image.html", '100%', 900)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/position.html", '100%', 800)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/strings-idents.html", '100%', 600)}}
{{EmbedGHLiveSample("css-examples/learn/values-units/calc.html", '100%', 500)}}
```

### Motivation
Motivation is described in the project issue.

### Related issues and pull requests
- https://github.com/mdn/mdn/issues/597