### PR TITLE
HTMLElementのinvalidイベントをリダイレクト設定

### DIFF
--- a/files/ja/_redirects.txt
+++ b/files/ja/_redirects.txt
@@ -2844,6 +2844,7 @@
 /ja/docs/Web/API/HTMLElement/contextMenu	/ja/docs/orphaned/Web/API/HTMLElement/contextMenu
 /ja/docs/Web/API/HTMLElement/gotpointercapture_event	/ja/docs/Web/API/Element/gotpointercapture_event
 /ja/docs/Web/API/HTMLElement/input_event	/ja/docs/Web/API/Element/input_event
+/ja/docs/Web/API/HTMLElement/invalid_event	/ja/docs/Web/API/HTMLInputElement/invalid_event
 /ja/docs/Web/API/HTMLElement/lostpointercapture_event	/ja/docs/Web/API/Element/lostpointercapture_event
 /ja/docs/Web/API/HTMLElement/oncopy	/ja/docs/Web/API/HTMLElement/copy_event
 /ja/docs/Web/API/HTMLElement/oncut	/ja/docs/Web/API/HTMLElement/cut_event


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

HTMLElementのinvalidイベントをリダイレクトを設定。

### Motivation

HTMLTextAreaElement などの記事でエラーが発生するため。

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
