### PR TITLE
CSSのjustify-contentのタイポ修正

### DIFF
--- a/files/ja/web/css/justify-content/index.md
+++ b/files/ja/web/css/justify-content/index.md
@@ -13,7 +13,7 @@ l10n:
 
 {{EmbedInteractiveExample("pages/css/justify-content.html")}}
 
-配置は長さや auto マージンが適用された後に行われますので、[フレックスボックスレイアウト](/ja/docs/Web/CSS/CSS_flexible_box_layout)で {{cssxref("flex-grow")}} が `0` ではないフレックス要素が 1 つ移譲ある場合は利用可能な空間がなくなりますので、このプロパティの効果はなくなります。
+配置は長さや auto マージンが適用された後に行われますので、[フレックスボックスレイアウト](/ja/docs/Web/CSS/CSS_flexible_box_layout)で {{cssxref("flex-grow")}} が `0` ではないフレックス要素が 1 つ以上ある場合は利用可能な空間がなくなりますので、このプロパティの効果はなくなります。
 
 ## 構文
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

下記ページのタイポ修正
https://developer.mozilla.org/ja/docs/Web/CSS/justify-content#%E8%A9%A6%E3%81%97%E3%81%A6%E3%81%BF%E3%81%BE%E3%81%97%E3%82%87%E3%81%86

> フレックス要素が 1 つ移譲ある場合は
> ↓
> フレックス要素が 1 つ以上ある場合は