### PR TITLE
Fix grammar, terminology, and punctuation in vendor prefixes glossary

### DIFF
--- a/files/pt-br/glossary/vendor_prefix/index.md
+++ b/files/pt-br/glossary/vendor_prefix/index.md
@@ -5,32 +5,32 @@ slug: Glossary/Vendor_Prefix
 
 {{GlossarySidebar}}
 
-Os _fabricantes de browsers_, por vezes, adicionam prefixos às propriedades experimentais ou fora dos padrões CSS, de modo que os desenvolvedores podem experimentá-las, enquanto —em teoria— as mudanças no comportamento dos navegadores não quebrarão o código durante o processo de padonização. Os desenvolvedores devem esperar para incluir a propriedade _não pré-fixada_ até que o comportamento do navegador seja padronizado.
+Os _fabricantes de navegadores_, por vezes, adicionam prefixos às propriedades experimentais ou fora dos padrões CSS, de modo que os desenvolvedores podem experimentá-las, enquanto —em teoria— as mudanças no comportamento dos navegadores não quebrarão o código durante o processo de padronização. Os desenvolvedores devem esperar para incluir a propriedade _não pré-fixada_ até que o comportamento do navegador seja padronizado.
 
 > [!NOTE]
 > Os _fabricantes de browsers_ estão trabalhando para parar de usar prefixos de fornecedores para recursos experimentais. Os desenvolvedores da Web têm vindo a usá-los em sites de produção, apesar de sua natureza experimental. Isso tornou mais difícil para os fornecedores de navegadores garantir a compatibilidade e trabalhar com novos recursos; também foi prejudicial aos navegadores menores que acabam forçados a adicionar prefixos de outros navegadores para carregar sites populares.
 >
-> Ultimamente, a tendência é adicionar recursos experimentais por trás das bandeiras controladas pelo usuário e trabalhar com especificações menores que alcancem a estabilidade muito mais rápido.
+> Ultimamente, a tendência é adicionar recursos experimentais por trás das bandeiras (flags) controladas pelo usuário e trabalhar com especificações menores que alcancem a estabilidade muito mais rápido.
 
-Normalmente, os vendors usam esses prefixos:
+Normalmente, os fornecedores usam esses prefixos:
 
-- `-webkit- (`Chrome, Safari, versões mais recentes do Opera.)
+- `-webkit-` (Chrome, Safari, versões mais recentes do Opera)
 - `-moz-` (Firefox)
-- `-o-` (Versões antigas do Opera)
+- `-o-` (versões antigas do Opera)
 - `-ms-` (Internet Explorer)
 
-Os vendedores também usam prefixos em APIs. Em interfaces, eles normalmente usam:
+Os fornecedores também usam prefixos em APIs. Em interfaces, eles normalmente usam:
 
-- `Webkit (`Chrome, Safari, versões mais recentes do Opera.)
+- `Webkit` (Chrome, Safari, versões mais recentes do Opera)
 - `Moz` (Firefox)
-- `O` (Versões antigas do Opera)
+- `O` (versões antigas do Opera)
 - `MS` (Internet Explorer)
 
 Em propriedades e métodos, eles normalmente usam:
 
-- `webkit (`Chrome, Safari, versões mais recentes do Opera.)
+- `webkit` (Chrome, Safari, versões mais recentes do Opera)
 - `moz` (Firefox)
-- `o` (Versões antigas do Opera)
+- `o` (versões antigas do Opera)
 - `ms` (Internet Explorer)
 
 ## Aprender mais


### PR DESCRIPTION
### Description
Corrected grammar, terminology, and punctuation issues in the Vendor Prefixes glossary page to enhance readability and clarity.

### Motivation

These changes improve the page’s linguistic accuracy and consistency, making it easier for readers to understand. 

### Additional details

Updated terms like “vendors” to “fornecedores” (suppliers) and “browsers” to “navegadores” (browsers) to match Portuguese conventions. Also fixed punctuation and removed redundant language structures that were borrowed from English syntax but awkward in Portuguese.

### Related issues and pull requests

None
