### PR TITLE
zh-tw: replace the polyfill with the link to `core-js`

### DIFF
--- a/files/zh-tw/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/array/filter/index.md
@@ -171,7 +171,7 @@ console.log(filterItems("an")); // ['banana', 'mango', 'orange']
 if (!Array.prototype.filter)
   Array.prototype.filter = function (func, thisArg) {
     "use strict";
-    if (!(typeof func === "Function" && this)) throw new TypeError();
+    if (!(typeof func === "function" && this)) throw new TypeError();
 
     var len = this.length >>> 0,
       res = new Array(len), // 預先配置陣列

--- a/files/zh-tw/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/array/filter/index.md
@@ -163,36 +163,6 @@ console.log(filterItems("ap")); // ['apple', 'grapes']
 console.log(filterItems("an")); // ['banana', 'mango', 'orange']
 ```
 
-## Polyfill
-
-`filter()` 在 ECMA-262 第五版時被納入標準；它也許不會出現在該標準的所有實作引擎之中。你可以在你的腳本最前面加入下面的程式碼作為替代方案，讓不支援 `filter()` 的 ECMA-262 實作引擎能夠使用它。假設 `fn.call` 是採用 {{jsxref("Function.prototype.bind()")}} 的原始值，這個演算法完全和 ECMA-262 第五版定義的規格相同。
-
-```js
-if (!Array.prototype.filter)
-  Array.prototype.filter = function (func, thisArg) {
-    "use strict";
-    if (!(typeof func === "function" && this)) throw new TypeError();
-
-    var len = this.length >>> 0,
-      res = new Array(len), // 預先配置陣列
-      c = 0,
-      i = -1;
-    if (thisArg === undefined)
-      while (++i !== len)
-        // 確認物件的鍵值i是否有被設置
-        if (i in this)
-          if (func(t[i], i, t)) res[c++] = t[i];
-          else
-            while (++i !== len)
-              // 確認物件的鍵值i是否有被設置
-              if (i in this)
-                if (func.call(thisArg, t[i], i, t)) res[c++] = t[i];
-
-    res.length = c; // 將陣列縮至適當大小
-    return res;
-  };
-```
-
 ## 規範
 
 {{Specifications}}
@@ -203,6 +173,7 @@ if (!Array.prototype.filter)
 
 ## 參見
 
+- [`core-js` 中 `Array.prototype.filter` 的 polyfill](https://github.com/zloirock/core-js#ecmascript-array)
 - {{jsxref("Array.prototype.forEach()")}}
 - {{jsxref("Array.prototype.every()")}}
 - {{jsxref("Array.prototype.some()")}}


### PR DESCRIPTION
When using typeof func(){}, the result should display as "function" instead of "Function".


