### PR TITLE
remove deprecated CSSAnimatedProperties macro

### DIFF
--- a/files/fr/web/css/css_animated_properties/index.md
+++ b/files/fr/web/css/css_animated_properties/index.md
@@ -1,286 +1,55 @@
 ---
 title: Liste des propriétés CSS animées
 slug: Web/CSS/CSS_animated_properties
+l10n:
+  sourceCommit: 4e508e2f543c0d77c9c04f406ebc8e9db7e965be
 ---
 
 {{CSSRef}}
 
-Certaines propriétés CSS peuvent être animées. Cela signifie que leur valeur change de façon graduelle grâce aux [animations CSS](/fr/docs/Web/CSS/CSS_Animations) ou aux [transitions CSS](/fr/docs/Web/CSS/CSS_Transitions).
+Les [animations](/fr/docs/Web/CSS/CSS_animations) et [transitions CSS](/fr/docs/Web/CSS/CSS_transitions) reposent sur le concept de propriétés pouvant être animées, et toutes les propriétés CSS sont animées, sauf indication contraire. Le type d'_animation_ de chaque propriété détermine la manière dont les valeurs se [combine <sup>angl.</sup>](https://drafts.csswg.org/css-values/#combining-values) — en s'interpolant, et/ou en s'accumulant — pour ces propriétés. Les transitions n'impliquent que l'interpolation, tandis que les animations peuvent utiliser les trois méthodes de combinaison.
 
-Voici la liste des propriétés qui peuvent être animées :
+> [!NOTE]
+> Le type d'animation de chaque propriété CSS est indiqué dans son tableau de «&nbsp;définition formelle&nbsp;» (par exemple&nbsp;: [`color`](/fr/docs/Web/CSS/color#définition_formelle)).
 
-<!-- TODO This used the long-deprecated cssanimatedproperties macro. Please update with a fresh translation. -->
+> [!NOTE]
+> La méthode d'interpolation pour chaque type de données CSS est décrite dans sa section «&nbsp;Interpolation&nbsp;» (par exemple&nbsp;: [`&lt;length&gt;`](/fr/docs/Web/CSS/length#interpolation)).
 
-<div class="index">
-  <ul>
-     <li><a href="/fr/docs/Web/CSS/outline"><code>-moz-outline-radius</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/outline"><code>-moz-outline-radius-bottomleft</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/outline"><code>-moz-outline-radius-bottomright</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/outline"><code>-moz-outline-radius-topleft</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/outline"><code>-moz-outline-radius-topright</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/grid-template-columns"><code>-ms-grid-columns</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/grid-template-rows"><code>-ms-grid-rows</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/-webkit-line-clamp"><code>-webkit-line-clamp</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/-webkit-text-fill-color"><code>-webkit-text-fill-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/-webkit-text-stroke"><code>-webkit-text-stroke</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/-webkit-text-stroke-color"><code>-webkit-text-stroke-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/accent-color"><code>accent-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/all"><code>all</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/animation-range"><code>animation-range</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/aspect-ratio"><code>aspect-ratio</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/backdrop-filter"><code>backdrop-filter</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/background"><code>background</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/background-clip"><code>background-clip</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/background-color"><code>background-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/background-origin"><code>background-origin</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/background-position"><code>background-position</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/background-position-x"><code>background-position-x</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/background-position-y"><code>background-position-y</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/background-size"><code>background-size</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/block-size"><code>block-size</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border"><code>border</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-block"><code>border-block</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-block-color"><code>border-block-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-block-end"><code>border-block-end</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-block-end-color"><code>border-block-end-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-block-end-width"><code>border-block-end-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-block-start"><code>border-block-start</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-block-start-color"><code>border-block-start-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-block-start-width"><code>border-block-start-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-block-width"><code>border-block-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-bottom"><code>border-bottom</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-bottom-color"><code>border-bottom-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-bottom-left-radius"><code>border-bottom-left-radius</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-bottom-right-radius"><code>border-bottom-right-radius</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-bottom-width"><code>border-bottom-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-color"><code>border-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-end-end-radius"><code>border-end-end-radius</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-end-start-radius"><code>border-end-start-radius</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-image"><code>border-image</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-image-outset"><code>border-image-outset</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-image-slice"><code>border-image-slice</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-image-width"><code>border-image-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-inline"><code>border-inline</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-inline-color"><code>border-inline-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-inline-end"><code>border-inline-end</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-inline-end-color"><code>border-inline-end-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-inline-end-width"><code>border-inline-end-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-inline-start"><code>border-inline-start</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-inline-start-color"><code>border-inline-start-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-inline-start-width"><code>border-inline-start-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-inline-width"><code>border-inline-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-left"><code>border-left</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-left-color"><code>border-left-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-left-width"><code>border-left-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-radius"><code>border-radius</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-right"><code>border-right</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-right-color"><code>border-right-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-right-width"><code>border-right-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-start-end-radius"><code>border-start-end-radius</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-start-start-radius"><code>border-start-start-radius</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-top"><code>border-top</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-top-color"><code>border-top-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-top-left-radius"><code>border-top-left-radius</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-top-right-radius"><code>border-top-right-radius</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-top-width"><code>border-top-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/border-width"><code>border-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/bottom"><code>bottom</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/box-shadow"><code>box-shadow</code></a></li>
-     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>caret</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/caret-color"><code>caret-color</code></a></li>
-     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>caret-shape</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/clip"><code>clip</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/clip-path"><code>clip-path</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/color"><code>color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/column-count"><code>column-count</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/column-gap"><code>column-gap</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/column-rule"><code>column-rule</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/column-rule-color"><code>column-rule-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/column-rule-width"><code>column-rule-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/column-width"><code>column-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/columns"><code>columns</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/contain-intrinsic-block-size"><code>contain-intrinsic-block-size</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/contain-intrinsic-height"><code>contain-intrinsic-height</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/contain-intrinsic-inline-size"><code>contain-intrinsic-inline-size</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/contain-intrinsic-size"><code>contain-intrinsic-size</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/contain-intrinsic-width"><code>contain-intrinsic-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/container"><code>container</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/container-type"><code>container-type</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/content-visibility"><code>content-visibility</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/counter-increment"><code>counter-increment</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/counter-reset"><code>counter-reset</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/counter-set"><code>counter-set</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/cx"><code>cx</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/cy"><code>cy</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/d"><code>d</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/display"><code>display</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/fill"><code>fill</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/fill-opacity"><code>fill-opacity</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/filter"><code>filter</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/flex"><code>flex</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/flex-basis"><code>flex-basis</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/flex-flow"><code>flex-flow</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/flex-grow"><code>flex-grow</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/flex-shrink"><code>flex-shrink</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/font"><code>font</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/font-palette"><code>font-palette</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/font-size"><code>font-size</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/font-size-adjust"><code>font-size-adjust</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/font-stretch"><code>font-stretch</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/font-style"><code>font-style</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/font-variation-settings"><code>font-variation-settings</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/font-weight"><code>font-weight</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/gap"><code>gap</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/grid"><code>grid</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/grid-auto-columns"><code>grid-auto-columns</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/grid-auto-rows"><code>grid-auto-rows</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/column-gap"><code>grid-column-gap</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/gap"><code>grid-gap</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/row-gap"><code>grid-row-gap</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/grid-template"><code>grid-template</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/grid-template-columns"><code>grid-template-columns</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/grid-template-rows"><code>grid-template-rows</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/height"><code>height</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/hyphenate-limit-chars"><code>hyphenate-limit-chars</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/initial-letter"><code>initial-letter</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/inline-size"><code>inline-size</code></a></li>
-     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>input-security</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/inset"><code>inset</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/inset-block"><code>inset-block</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/inset-block-end"><code>inset-block-end</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/inset-block-start"><code>inset-block-start</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/inset-inline"><code>inset-inline</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/inset-inline-end"><code>inset-inline-end</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/inset-inline-start"><code>inset-inline-start</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/left"><code>left</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/letter-spacing"><code>letter-spacing</code></a></li>
-     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>line-clamp</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/line-height"><code>line-height</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/line-height-step"><code>line-height-step</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/list-style"><code>list-style</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/margin"><code>margin</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/margin-block"><code>margin-block</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/margin-block-end"><code>margin-block-end</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/margin-block-start"><code>margin-block-start</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/margin-bottom"><code>margin-bottom</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/margin-inline"><code>margin-inline</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/margin-inline-end"><code>margin-inline-end</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/margin-inline-start"><code>margin-inline-start</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/margin-left"><code>margin-left</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/margin-right"><code>margin-right</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/margin-top"><code>margin-top</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/mask"><code>mask</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/mask-border"><code>mask-border</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/mask-position"><code>mask-position</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/mask-size"><code>mask-size</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/max-block-size"><code>max-block-size</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/max-height"><code>max-height</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/max-inline-size"><code>max-inline-size</code></a></li>
-     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>max-lines</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/max-width"><code>max-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/min-block-size"><code>min-block-size</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/min-height"><code>min-height</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/min-inline-size"><code>min-inline-size</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/min-width"><code>min-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/object-position"><code>object-position</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/offset"><code>offset</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/offset-anchor"><code>offset-anchor</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/offset-distance"><code>offset-distance</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/offset-path"><code>offset-path</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/offset-position"><code>offset-position</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/offset-rotate"><code>offset-rotate</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/opacity"><code>opacity</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/order"><code>order</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/orphans"><code>orphans</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/outline"><code>outline</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/outline-color"><code>outline-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/outline-offset"><code>outline-offset</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/outline-style"><code>outline-style</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/outline-width"><code>outline-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/overlay"><code>overlay</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/padding"><code>padding</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/padding-block"><code>padding-block</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/padding-block-end"><code>padding-block-end</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/padding-block-start"><code>padding-block-start</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/padding-bottom"><code>padding-bottom</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/padding-inline"><code>padding-inline</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/padding-inline-end"><code>padding-inline-end</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/padding-inline-start"><code>padding-inline-start</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/padding-left"><code>padding-left</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/padding-right"><code>padding-right</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/padding-top"><code>padding-top</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/perspective"><code>perspective</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/perspective-origin"><code>perspective-origin</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/position-try"><code>position-try</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/r"><code>r</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/right"><code>right</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/rotate"><code>rotate</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/row-gap"><code>row-gap</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/ruby-align"><code>ruby-align</code></a></li>
-     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>ruby-merge</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/rx"><code>rx</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/ry"><code>ry</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scale"><code>scale</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-margin"><code>scroll-margin</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-margin-block"><code>scroll-margin-block</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-margin-block-end"><code>scroll-margin-block-end</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-margin-block-start"><code>scroll-margin-block-start</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-margin-bottom"><code>scroll-margin-bottom</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-margin-inline"><code>scroll-margin-inline</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-margin-inline-end"><code>scroll-margin-inline-end</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-margin-inline-start"><code>scroll-margin-inline-start</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-margin-left"><code>scroll-margin-left</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-margin-right"><code>scroll-margin-right</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-margin-top"><code>scroll-margin-top</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-padding"><code>scroll-padding</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-padding-block"><code>scroll-padding-block</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-padding-block-end"><code>scroll-padding-block-end</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-padding-block-start"><code>scroll-padding-block-start</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-padding-bottom"><code>scroll-padding-bottom</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-padding-inline"><code>scroll-padding-inline</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-padding-inline-end"><code>scroll-padding-inline-end</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-padding-inline-start"><code>scroll-padding-inline-start</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-padding-left"><code>scroll-padding-left</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-padding-right"><code>scroll-padding-right</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-padding-top"><code>scroll-padding-top</code></a></li>
-     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>scroll-snap-coordinate</code></a></li>
-     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>scroll-snap-destination</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scroll-timeline"><code>scroll-timeline</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scrollbar-color"><code>scrollbar-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/scrollbar-width"><code>scrollbar-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/shape-image-threshold"><code>shape-image-threshold</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/shape-margin"><code>shape-margin</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/shape-outside"><code>shape-outside</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/stroke"><code>stroke</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/stroke-dasharray"><code>stroke-dasharray</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/stroke-dashoffset"><code>stroke-dashoffset</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/stroke-miterlimit"><code>stroke-miterlimit</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/stroke-opacity"><code>stroke-opacity</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/stroke-width"><code>stroke-width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/tab-size"><code>tab-size</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/text-decoration"><code>text-decoration</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/text-decoration-color"><code>text-decoration-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/text-decoration-thickness"><code>text-decoration-thickness</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/text-emphasis"><code>text-emphasis</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/text-emphasis-color"><code>text-emphasis-color</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/text-indent"><code>text-indent</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/text-shadow"><code>text-shadow</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/text-size-adjust"><code>text-size-adjust</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/text-underline-offset"><code>text-underline-offset</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/text-wrap"><code>text-wrap</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/top"><code>top</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/transform"><code>transform</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/transform-origin"><code>transform-origin</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/translate"><code>translate</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/vertical-align"><code>vertical-align</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/view-timeline"><code>view-timeline</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/view-timeline-inset"><code>view-timeline-inset</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/visibility"><code>visibility</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/widows"><code>widows</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/width"><code>width</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/word-spacing"><code>word-spacing</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/x"><code>x</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/y"><code>y</code></a></li>
-     <li><a href="/fr/docs/Web/CSS/z-index"><code>z-index</code></a></li>
-  </ul>
-</div>
+## Types d'animations
+
+Il existe principalement quatre types d'animation tels que définis dans la spécification [Web Animations <sup>angl.</sup>](https://drafts.csswg.org/web-animations-1/#animating-properties)&nbsp;:
+
+- Ne pouvant être animée
+
+  - : La propriété n'est pas animée. Elle n'est pas traitée lorsqu'elle est listée dans une image-clé d'animation et n'est pas affectée par les transitions.
+
+    > [!NOTE]
+    > Un effet d'animation ciblant uniquement des propriétés qui ne sont pas animées présentera toujours le comportement habituel d'un effet d'animation (par exemple, déclenchement de l'événement [`animationstart`](/fr/docs/Web/API/Element/animationstart_event)).
+
+- Discrète
+
+  - : Les valeurs de la propriété ne sont pas cumulées et l'interpolation passe de la valeur initiale à la valeur finale à `50%`. Plus précisément, on désigne par `p` la valeur de progression&nbsp;:
+
+    - Si `p < 0.5`, alors `V_resultat = V_debut`&nbsp;;
+    - Si `p ≥ 0.5`, alors `V_resultat = V_fin`.
+
+- Par valeur ajoutée
+
+  - : Les composantes individuelles correspondantes des valeurs calculées sont combinées à l'aide de la procédure indiquée pour ce type de valeur. Si le nombre de composants ou les types de composants correspondants ne concordent pas, ou si une valeur de composant utilise une animation discrète et que les deux valeurs correspondantes ne concordent pas, les valeurs de propriété sont combinées comme des valeurs discrètes.
+
+- Liste répétable
+
+  - : Identique à la valeur calculée, sauf que si les deux listes ont des nombres différents d'éléments, elles sont d'abord répétées jusqu'au plus petit nombre commun d'éléments. Chaque élément est ensuite combiné par valeur calculée. Si une paire de valeurs ne peut pas être combinée ou si l'une des valeurs composantes utilise une animation discrète, les valeurs de la propriété sont combinées comme des valeurs discrètes.
+
+Certaines propriétés ont un comportement d'interpolation spécifique qui n'est pas couvert par ces quatre types. Dans ce cas, reportez-vous à la section « Interpolation » de la propriété (par exemple&nbsp;: [`visibility`](/fr/docs/Web/CSS/visibility#interpolation)).
+
+## Animer les propriétés personnalisées
+
+Pour les propriétés personnalisées enregistrées à l'aide de la méthode [`registerProperty()`](/fr/docs/Web/API/CSS/registerProperty_static), le type d'animation est par valeur calculée, le type de valeur calculée étant [déterminé <sup>angl.</sup>](https://drafts.css-houdini.org/css-properties-values-api/#calculation-of-computed-values) par la définition syntaxique de la propriété.
+
+Pour les propriétés personnalisées non enregistrées, le type d'animation est discret.
+
+## Voir aussi
+
+- [Utilisation des animations CSS](/fr/docs/Web/CSS/CSS_animations/Using_CSS_animations)
+- [Utilisation des transitions CSS](/fr/docs/Web/CSS/CSS_transitions/Using_CSS_transitions)

--- a/files/fr/web/css/css_animated_properties/index.md
+++ b/files/fr/web/css/css_animated_properties/index.md
@@ -9,4 +9,278 @@ Certaines propriétés CSS peuvent être animées. Cela signifie que leur valeur
 
 Voici la liste des propriétés qui peuvent être animées :
 
-{{CSSAnimatedProperties}}
+<!-- TODO This used the long-deprecated cssanimatedproperties macro. Please update with a fresh translation. -->
+
+<div class="index">
+  <ul>
+     <li><a href="/fr/docs/Web/CSS/outline"><code>-moz-outline-radius</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/outline"><code>-moz-outline-radius-bottomleft</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/outline"><code>-moz-outline-radius-bottomright</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/outline"><code>-moz-outline-radius-topleft</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/outline"><code>-moz-outline-radius-topright</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/grid-template-columns"><code>-ms-grid-columns</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/grid-template-rows"><code>-ms-grid-rows</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/-webkit-line-clamp"><code>-webkit-line-clamp</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/-webkit-text-fill-color"><code>-webkit-text-fill-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/-webkit-text-stroke"><code>-webkit-text-stroke</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/-webkit-text-stroke-color"><code>-webkit-text-stroke-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/accent-color"><code>accent-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/all"><code>all</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/animation-range"><code>animation-range</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/aspect-ratio"><code>aspect-ratio</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/backdrop-filter"><code>backdrop-filter</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/background"><code>background</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/background-clip"><code>background-clip</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/background-color"><code>background-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/background-origin"><code>background-origin</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/background-position"><code>background-position</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/background-position-x"><code>background-position-x</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/background-position-y"><code>background-position-y</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/background-size"><code>background-size</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/block-size"><code>block-size</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border"><code>border</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-block"><code>border-block</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-block-color"><code>border-block-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-block-end"><code>border-block-end</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-block-end-color"><code>border-block-end-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-block-end-width"><code>border-block-end-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-block-start"><code>border-block-start</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-block-start-color"><code>border-block-start-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-block-start-width"><code>border-block-start-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-block-width"><code>border-block-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-bottom"><code>border-bottom</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-bottom-color"><code>border-bottom-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-bottom-left-radius"><code>border-bottom-left-radius</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-bottom-right-radius"><code>border-bottom-right-radius</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-bottom-width"><code>border-bottom-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-color"><code>border-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-end-end-radius"><code>border-end-end-radius</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-end-start-radius"><code>border-end-start-radius</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-image"><code>border-image</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-image-outset"><code>border-image-outset</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-image-slice"><code>border-image-slice</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-image-width"><code>border-image-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-inline"><code>border-inline</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-inline-color"><code>border-inline-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-inline-end"><code>border-inline-end</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-inline-end-color"><code>border-inline-end-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-inline-end-width"><code>border-inline-end-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-inline-start"><code>border-inline-start</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-inline-start-color"><code>border-inline-start-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-inline-start-width"><code>border-inline-start-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-inline-width"><code>border-inline-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-left"><code>border-left</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-left-color"><code>border-left-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-left-width"><code>border-left-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-radius"><code>border-radius</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-right"><code>border-right</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-right-color"><code>border-right-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-right-width"><code>border-right-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-start-end-radius"><code>border-start-end-radius</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-start-start-radius"><code>border-start-start-radius</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-top"><code>border-top</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-top-color"><code>border-top-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-top-left-radius"><code>border-top-left-radius</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-top-right-radius"><code>border-top-right-radius</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-top-width"><code>border-top-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/border-width"><code>border-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/bottom"><code>bottom</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/box-shadow"><code>box-shadow</code></a></li>
+     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>caret</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/caret-color"><code>caret-color</code></a></li>
+     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>caret-shape</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/clip"><code>clip</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/clip-path"><code>clip-path</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/color"><code>color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/column-count"><code>column-count</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/column-gap"><code>column-gap</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/column-rule"><code>column-rule</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/column-rule-color"><code>column-rule-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/column-rule-width"><code>column-rule-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/column-width"><code>column-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/columns"><code>columns</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/contain-intrinsic-block-size"><code>contain-intrinsic-block-size</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/contain-intrinsic-height"><code>contain-intrinsic-height</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/contain-intrinsic-inline-size"><code>contain-intrinsic-inline-size</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/contain-intrinsic-size"><code>contain-intrinsic-size</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/contain-intrinsic-width"><code>contain-intrinsic-width</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/container"><code>container</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/container-type"><code>container-type</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/content-visibility"><code>content-visibility</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/counter-increment"><code>counter-increment</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/counter-reset"><code>counter-reset</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/counter-set"><code>counter-set</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/cx"><code>cx</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/cy"><code>cy</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/d"><code>d</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/display"><code>display</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/fill"><code>fill</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/fill-opacity"><code>fill-opacity</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/filter"><code>filter</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/flex"><code>flex</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/flex-basis"><code>flex-basis</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/flex-flow"><code>flex-flow</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/flex-grow"><code>flex-grow</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/flex-shrink"><code>flex-shrink</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/font"><code>font</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/font-palette"><code>font-palette</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/font-size"><code>font-size</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/font-size-adjust"><code>font-size-adjust</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/font-stretch"><code>font-stretch</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/font-style"><code>font-style</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/font-variation-settings"><code>font-variation-settings</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/font-weight"><code>font-weight</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/gap"><code>gap</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/grid"><code>grid</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/grid-auto-columns"><code>grid-auto-columns</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/grid-auto-rows"><code>grid-auto-rows</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/column-gap"><code>grid-column-gap</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/gap"><code>grid-gap</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/row-gap"><code>grid-row-gap</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/grid-template"><code>grid-template</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/grid-template-columns"><code>grid-template-columns</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/grid-template-rows"><code>grid-template-rows</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/height"><code>height</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/hyphenate-limit-chars"><code>hyphenate-limit-chars</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/initial-letter"><code>initial-letter</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/inline-size"><code>inline-size</code></a></li>
+     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>input-security</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/inset"><code>inset</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/inset-block"><code>inset-block</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/inset-block-end"><code>inset-block-end</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/inset-block-start"><code>inset-block-start</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/inset-inline"><code>inset-inline</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/inset-inline-end"><code>inset-inline-end</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/inset-inline-start"><code>inset-inline-start</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/left"><code>left</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/letter-spacing"><code>letter-spacing</code></a></li>
+     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>line-clamp</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/line-height"><code>line-height</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/line-height-step"><code>line-height-step</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/list-style"><code>list-style</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/margin"><code>margin</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/margin-block"><code>margin-block</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/margin-block-end"><code>margin-block-end</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/margin-block-start"><code>margin-block-start</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/margin-bottom"><code>margin-bottom</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/margin-inline"><code>margin-inline</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/margin-inline-end"><code>margin-inline-end</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/margin-inline-start"><code>margin-inline-start</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/margin-left"><code>margin-left</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/margin-right"><code>margin-right</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/margin-top"><code>margin-top</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/mask"><code>mask</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/mask-border"><code>mask-border</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/mask-position"><code>mask-position</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/mask-size"><code>mask-size</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/max-block-size"><code>max-block-size</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/max-height"><code>max-height</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/max-inline-size"><code>max-inline-size</code></a></li>
+     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>max-lines</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/max-width"><code>max-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/min-block-size"><code>min-block-size</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/min-height"><code>min-height</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/min-inline-size"><code>min-inline-size</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/min-width"><code>min-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/object-position"><code>object-position</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/offset"><code>offset</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/offset-anchor"><code>offset-anchor</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/offset-distance"><code>offset-distance</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/offset-path"><code>offset-path</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/offset-position"><code>offset-position</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/offset-rotate"><code>offset-rotate</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/opacity"><code>opacity</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/order"><code>order</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/orphans"><code>orphans</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/outline"><code>outline</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/outline-color"><code>outline-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/outline-offset"><code>outline-offset</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/outline-style"><code>outline-style</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/outline-width"><code>outline-width</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/overlay"><code>overlay</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/padding"><code>padding</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/padding-block"><code>padding-block</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/padding-block-end"><code>padding-block-end</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/padding-block-start"><code>padding-block-start</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/padding-bottom"><code>padding-bottom</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/padding-inline"><code>padding-inline</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/padding-inline-end"><code>padding-inline-end</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/padding-inline-start"><code>padding-inline-start</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/padding-left"><code>padding-left</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/padding-right"><code>padding-right</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/padding-top"><code>padding-top</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/perspective"><code>perspective</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/perspective-origin"><code>perspective-origin</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/position-try"><code>position-try</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/r"><code>r</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/right"><code>right</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/rotate"><code>rotate</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/row-gap"><code>row-gap</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/ruby-align"><code>ruby-align</code></a></li>
+     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>ruby-merge</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/rx"><code>rx</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/ry"><code>ry</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scale"><code>scale</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-margin"><code>scroll-margin</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-margin-block"><code>scroll-margin-block</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-margin-block-end"><code>scroll-margin-block-end</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-margin-block-start"><code>scroll-margin-block-start</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-margin-bottom"><code>scroll-margin-bottom</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-margin-inline"><code>scroll-margin-inline</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-margin-inline-end"><code>scroll-margin-inline-end</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-margin-inline-start"><code>scroll-margin-inline-start</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-margin-left"><code>scroll-margin-left</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-margin-right"><code>scroll-margin-right</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-margin-top"><code>scroll-margin-top</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-padding"><code>scroll-padding</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-padding-block"><code>scroll-padding-block</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-padding-block-end"><code>scroll-padding-block-end</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-padding-block-start"><code>scroll-padding-block-start</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-padding-bottom"><code>scroll-padding-bottom</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-padding-inline"><code>scroll-padding-inline</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-padding-inline-end"><code>scroll-padding-inline-end</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-padding-inline-start"><code>scroll-padding-inline-start</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-padding-left"><code>scroll-padding-left</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-padding-right"><code>scroll-padding-right</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-padding-top"><code>scroll-padding-top</code></a></li>
+     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>scroll-snap-coordinate</code></a></li>
+     <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>scroll-snap-destination</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scroll-timeline"><code>scroll-timeline</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scrollbar-color"><code>scrollbar-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/scrollbar-width"><code>scrollbar-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/shape-image-threshold"><code>shape-image-threshold</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/shape-margin"><code>shape-margin</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/shape-outside"><code>shape-outside</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/stroke"><code>stroke</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/stroke-dasharray"><code>stroke-dasharray</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/stroke-dashoffset"><code>stroke-dashoffset</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/stroke-miterlimit"><code>stroke-miterlimit</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/stroke-opacity"><code>stroke-opacity</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/stroke-width"><code>stroke-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/tab-size"><code>tab-size</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/text-decoration"><code>text-decoration</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/text-decoration-color"><code>text-decoration-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/text-decoration-thickness"><code>text-decoration-thickness</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/text-emphasis"><code>text-emphasis</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/text-emphasis-color"><code>text-emphasis-color</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/text-indent"><code>text-indent</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/text-shadow"><code>text-shadow</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/text-size-adjust"><code>text-size-adjust</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/text-underline-offset"><code>text-underline-offset</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/text-wrap"><code>text-wrap</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/top"><code>top</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/transform"><code>transform</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/transform-origin"><code>transform-origin</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/translate"><code>translate</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/vertical-align"><code>vertical-align</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/view-timeline"><code>view-timeline</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/view-timeline-inset"><code>view-timeline-inset</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/visibility"><code>visibility</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/widows"><code>widows</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/width"><code>width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/word-spacing"><code>word-spacing</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/x"><code>x</code></a></li>
+     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/y"><code>y</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/z-index"><code>z-index</code></a></li>
+  </ul>
+</div>

--- a/files/fr/web/css/css_animated_properties/index.md
+++ b/files/fr/web/css/css_animated_properties/index.md
@@ -1,5 +1,5 @@
 ---
-title: Liste des propriétés CSS animées
+title: Animation des propriétés en CSS
 slug: Web/CSS/CSS_animated_properties
 l10n:
   sourceCommit: 4e508e2f543c0d77c9c04f406ebc8e9db7e965be
@@ -7,13 +7,13 @@ l10n:
 
 {{CSSRef}}
 
-Les [animations](/fr/docs/Web/CSS/CSS_animations) et [transitions CSS](/fr/docs/Web/CSS/CSS_transitions) reposent sur le concept de propriétés pouvant être animées, et toutes les propriétés CSS sont animées, sauf indication contraire. Le type d'_animation_ de chaque propriété détermine la manière dont les valeurs se [combine <sup>angl.</sup>](https://drafts.csswg.org/css-values/#combining-values) — en s'interpolant, et/ou en s'accumulant — pour ces propriétés. Les transitions n'impliquent que l'interpolation, tandis que les animations peuvent utiliser les trois méthodes de combinaison.
+Les [animations](/fr/docs/Web/CSS/CSS_animations) et [transitions CSS](/fr/docs/Web/CSS/CSS_transitions) reposent sur le concept de propriétés pouvant être animées. Sauf indication contraire, toutes les propriétés CSS peuvent être animées. Le type d'_animation_ de chaque propriété détermine la manière dont les valeurs se [combinent <sup>angl.</sup>](https://drafts.csswg.org/css-values/#combining-values) en s'interpolant, s'additionnant, ou en s'accumulant. Les transitions n'impliquent que l'interpolation, tandis que les animations peuvent utiliser les trois méthodes de combinaison.
 
 > [!NOTE]
 > Le type d'animation de chaque propriété CSS est indiqué dans son tableau de «&nbsp;définition formelle&nbsp;» (par exemple&nbsp;: [`color`](/fr/docs/Web/CSS/color#définition_formelle)).
 
 > [!NOTE]
-> La méthode d'interpolation pour chaque type de données CSS est décrite dans sa section «&nbsp;Interpolation&nbsp;» (par exemple&nbsp;: [`&lt;length&gt;`](/fr/docs/Web/CSS/length#interpolation)).
+> La méthode d'interpolation pour chaque type de données CSS est décrite dans sa section «&nbsp;Interpolation&nbsp;» (par exemple&nbsp;: [`<length>`](/fr/docs/Web/CSS/length#interpolation)).
 
 ## Types d'animations
 
@@ -24,7 +24,7 @@ Il existe principalement quatre types d'animation tels que définis dans la spé
   - : La propriété n'est pas animée. Elle n'est pas traitée lorsqu'elle est listée dans une image-clé d'animation et n'est pas affectée par les transitions.
 
     > [!NOTE]
-    > Un effet d'animation ciblant uniquement des propriétés qui ne sont pas animées présentera toujours le comportement habituel d'un effet d'animation (par exemple, déclenchement de l'événement [`animationstart`](/fr/docs/Web/API/Element/animationstart_event)).
+    > Un effet d'animation ciblant uniquement des propriétés qui ne sont pas animées présentera toujours le comportement habituel d'un effet d'animation (par exemple, déclenchement de l'évènement [`animationstart`](/fr/docs/Web/API/Element/animationstart_event)).
 
 - Discrète
 
@@ -33,7 +33,7 @@ Il existe principalement quatre types d'animation tels que définis dans la spé
     - Si `p < 0.5`, alors `V_resultat = V_debut`&nbsp;;
     - Si `p ≥ 0.5`, alors `V_resultat = V_fin`.
 
-- Par valeur ajoutée
+- Par valeur calculée
 
   - : Les composantes individuelles correspondantes des valeurs calculées sont combinées à l'aide de la procédure indiquée pour ce type de valeur. Si le nombre de composants ou les types de composants correspondants ne concordent pas, ou si une valeur de composant utilise une animation discrète et que les deux valeurs correspondantes ne concordent pas, les valeurs de propriété sont combinées comme des valeurs discrètes.
 
@@ -41,7 +41,7 @@ Il existe principalement quatre types d'animation tels que définis dans la spé
 
   - : Identique à la valeur calculée, sauf que si les deux listes ont des nombres différents d'éléments, elles sont d'abord répétées jusqu'au plus petit nombre commun d'éléments. Chaque élément est ensuite combiné par valeur calculée. Si une paire de valeurs ne peut pas être combinée ou si l'une des valeurs composantes utilise une animation discrète, les valeurs de la propriété sont combinées comme des valeurs discrètes.
 
-Certaines propriétés ont un comportement d'interpolation spécifique qui n'est pas couvert par ces quatre types. Dans ce cas, reportez-vous à la section « Interpolation » de la propriété (par exemple&nbsp;: [`visibility`](/fr/docs/Web/CSS/visibility#interpolation)).
+Certaines propriétés ont un comportement d'interpolation spécifique qui n'est pas couvert par ces quatre types. Dans ce cas, reportez-vous à la section «&nbsp;Interpolation&nbsp;» de la propriété (par exemple&nbsp;: [`visibility`](/fr/docs/Web/CSS/visibility#interpolation)).
 
 ## Animer les propriétés personnalisées
 

--- a/files/fr/web/css/css_animated_properties/index.md
+++ b/files/fr/web/css/css_animated_properties/index.md
@@ -18,15 +18,15 @@ Voici la liste des propriétés qui peuvent être animées :
      <li><a href="/fr/docs/Web/CSS/outline"><code>-moz-outline-radius-bottomright</code></a></li>
      <li><a href="/fr/docs/Web/CSS/outline"><code>-moz-outline-radius-topleft</code></a></li>
      <li><a href="/fr/docs/Web/CSS/outline"><code>-moz-outline-radius-topright</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/grid-template-columns"><code>-ms-grid-columns</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/grid-template-rows"><code>-ms-grid-rows</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/grid-template-columns"><code>-ms-grid-columns</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/grid-template-rows"><code>-ms-grid-rows</code></a></li>
      <li><a href="/fr/docs/Web/CSS/-webkit-line-clamp"><code>-webkit-line-clamp</code></a></li>
      <li><a href="/fr/docs/Web/CSS/-webkit-text-fill-color"><code>-webkit-text-fill-color</code></a></li>
      <li><a href="/fr/docs/Web/CSS/-webkit-text-stroke"><code>-webkit-text-stroke</code></a></li>
      <li><a href="/fr/docs/Web/CSS/-webkit-text-stroke-color"><code>-webkit-text-stroke-color</code></a></li>
      <li><a href="/fr/docs/Web/CSS/accent-color"><code>accent-color</code></a></li>
      <li><a href="/fr/docs/Web/CSS/all"><code>all</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/animation-range"><code>animation-range</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/animation-range"><code>animation-range</code></a></li>
      <li><a href="/fr/docs/Web/CSS/aspect-ratio"><code>aspect-ratio</code></a></li>
      <li><a href="/fr/docs/Web/CSS/backdrop-filter"><code>backdrop-filter</code></a></li>
      <li><a href="/fr/docs/Web/CSS/background"><code>background</code></a></li>
@@ -99,23 +99,23 @@ Voici la liste des propriétés qui peuvent être animées :
      <li><a href="/fr/docs/Web/CSS/column-rule-width"><code>column-rule-width</code></a></li>
      <li><a href="/fr/docs/Web/CSS/column-width"><code>column-width</code></a></li>
      <li><a href="/fr/docs/Web/CSS/columns"><code>columns</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/contain-intrinsic-block-size"><code>contain-intrinsic-block-size</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/contain-intrinsic-height"><code>contain-intrinsic-height</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/contain-intrinsic-inline-size"><code>contain-intrinsic-inline-size</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/contain-intrinsic-block-size"><code>contain-intrinsic-block-size</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/contain-intrinsic-height"><code>contain-intrinsic-height</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/contain-intrinsic-inline-size"><code>contain-intrinsic-inline-size</code></a></li>
      <li><a href="/fr/docs/Web/CSS/contain-intrinsic-size"><code>contain-intrinsic-size</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/contain-intrinsic-width"><code>contain-intrinsic-width</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/container"><code>container</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/container-type"><code>container-type</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/contain-intrinsic-width"><code>contain-intrinsic-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/container"><code>container</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/container-type"><code>container-type</code></a></li>
      <li><a href="/fr/docs/Web/CSS/content-visibility"><code>content-visibility</code></a></li>
      <li><a href="/fr/docs/Web/CSS/counter-increment"><code>counter-increment</code></a></li>
      <li><a href="/fr/docs/Web/CSS/counter-reset"><code>counter-reset</code></a></li>
      <li><a href="/fr/docs/Web/CSS/counter-set"><code>counter-set</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/cx"><code>cx</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/cy"><code>cy</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/d"><code>d</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/cx"><code>cx</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/cy"><code>cy</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/d"><code>d</code></a></li>
      <li><a href="/fr/docs/Web/CSS/display"><code>display</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/fill"><code>fill</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/fill-opacity"><code>fill-opacity</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/fill"><code>fill</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/fill-opacity"><code>fill-opacity</code></a></li>
      <li><a href="/fr/docs/Web/CSS/filter"><code>filter</code></a></li>
      <li><a href="/fr/docs/Web/CSS/flex"><code>flex</code></a></li>
      <li><a href="/fr/docs/Web/CSS/flex-basis"><code>flex-basis</code></a></li>
@@ -123,7 +123,7 @@ Voici la liste des propriétés qui peuvent être animées :
      <li><a href="/fr/docs/Web/CSS/flex-grow"><code>flex-grow</code></a></li>
      <li><a href="/fr/docs/Web/CSS/flex-shrink"><code>flex-shrink</code></a></li>
      <li><a href="/fr/docs/Web/CSS/font"><code>font</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/font-palette"><code>font-palette</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/font-palette"><code>font-palette</code></a></li>
      <li><a href="/fr/docs/Web/CSS/font-size"><code>font-size</code></a></li>
      <li><a href="/fr/docs/Web/CSS/font-size-adjust"><code>font-size-adjust</code></a></li>
      <li><a href="/fr/docs/Web/CSS/font-stretch"><code>font-stretch</code></a></li>
@@ -141,7 +141,7 @@ Voici la liste des propriétés qui peuvent être animées :
      <li><a href="/fr/docs/Web/CSS/grid-template-columns"><code>grid-template-columns</code></a></li>
      <li><a href="/fr/docs/Web/CSS/grid-template-rows"><code>grid-template-rows</code></a></li>
      <li><a href="/fr/docs/Web/CSS/height"><code>height</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/hyphenate-limit-chars"><code>hyphenate-limit-chars</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/hyphenate-limit-chars"><code>hyphenate-limit-chars</code></a></li>
      <li><a href="/fr/docs/Web/CSS/initial-letter"><code>initial-letter</code></a></li>
      <li><a href="/fr/docs/Web/CSS/inline-size"><code>inline-size</code></a></li>
      <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>input-security</code></a></li>
@@ -197,7 +197,7 @@ Voici la liste des propriétés qui peuvent être animées :
      <li><a href="/fr/docs/Web/CSS/outline-offset"><code>outline-offset</code></a></li>
      <li><a href="/fr/docs/Web/CSS/outline-style"><code>outline-style</code></a></li>
      <li><a href="/fr/docs/Web/CSS/outline-width"><code>outline-width</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/overlay"><code>overlay</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/overlay"><code>overlay</code></a></li>
      <li><a href="/fr/docs/Web/CSS/padding"><code>padding</code></a></li>
      <li><a href="/fr/docs/Web/CSS/padding-block"><code>padding-block</code></a></li>
      <li><a href="/fr/docs/Web/CSS/padding-block-end"><code>padding-block-end</code></a></li>
@@ -211,15 +211,15 @@ Voici la liste des propriétés qui peuvent être animées :
      <li><a href="/fr/docs/Web/CSS/padding-top"><code>padding-top</code></a></li>
      <li><a href="/fr/docs/Web/CSS/perspective"><code>perspective</code></a></li>
      <li><a href="/fr/docs/Web/CSS/perspective-origin"><code>perspective-origin</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/position-try"><code>position-try</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/r"><code>r</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/position-try"><code>position-try</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/r"><code>r</code></a></li>
      <li><a href="/fr/docs/Web/CSS/right"><code>right</code></a></li>
      <li><a href="/fr/docs/Web/CSS/rotate"><code>rotate</code></a></li>
      <li><a href="/fr/docs/Web/CSS/row-gap"><code>row-gap</code></a></li>
      <li><a href="/fr/docs/Web/CSS/ruby-align"><code>ruby-align</code></a></li>
      <li><a class="page-not-created" title="Cette documentation n'a pas encore été rédigée, vous pouvez aider en contribuant!"><code>ruby-merge</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/rx"><code>rx</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/ry"><code>ry</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/rx"><code>rx</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/ry"><code>ry</code></a></li>
      <li><a href="/fr/docs/Web/CSS/scale"><code>scale</code></a></li>
      <li><a href="/fr/docs/Web/CSS/scroll-margin"><code>scroll-margin</code></a></li>
      <li><a href="/fr/docs/Web/CSS/scroll-margin-block"><code>scroll-margin-block</code></a></li>
@@ -251,12 +251,12 @@ Voici la liste des propriétés qui peuvent être animées :
      <li><a href="/fr/docs/Web/CSS/shape-image-threshold"><code>shape-image-threshold</code></a></li>
      <li><a href="/fr/docs/Web/CSS/shape-margin"><code>shape-margin</code></a></li>
      <li><a href="/fr/docs/Web/CSS/shape-outside"><code>shape-outside</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/stroke"><code>stroke</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/stroke-dasharray"><code>stroke-dasharray</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/stroke-dashoffset"><code>stroke-dashoffset</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/stroke-miterlimit"><code>stroke-miterlimit</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/stroke-opacity"><code>stroke-opacity</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/stroke-width"><code>stroke-width</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/stroke"><code>stroke</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/stroke-dasharray"><code>stroke-dasharray</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/stroke-dashoffset"><code>stroke-dashoffset</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/stroke-miterlimit"><code>stroke-miterlimit</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/stroke-opacity"><code>stroke-opacity</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/stroke-width"><code>stroke-width</code></a></li>
      <li><a href="/fr/docs/Web/CSS/tab-size"><code>tab-size</code></a></li>
      <li><a href="/fr/docs/Web/CSS/text-decoration"><code>text-decoration</code></a></li>
      <li><a href="/fr/docs/Web/CSS/text-decoration-color"><code>text-decoration-color</code></a></li>
@@ -267,20 +267,20 @@ Voici la liste des propriétés qui peuvent être animées :
      <li><a href="/fr/docs/Web/CSS/text-shadow"><code>text-shadow</code></a></li>
      <li><a href="/fr/docs/Web/CSS/text-size-adjust"><code>text-size-adjust</code></a></li>
      <li><a href="/fr/docs/Web/CSS/text-underline-offset"><code>text-underline-offset</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/text-wrap"><code>text-wrap</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/text-wrap"><code>text-wrap</code></a></li>
      <li><a href="/fr/docs/Web/CSS/top"><code>top</code></a></li>
      <li><a href="/fr/docs/Web/CSS/transform"><code>transform</code></a></li>
      <li><a href="/fr/docs/Web/CSS/transform-origin"><code>transform-origin</code></a></li>
      <li><a href="/fr/docs/Web/CSS/translate"><code>translate</code></a></li>
      <li><a href="/fr/docs/Web/CSS/vertical-align"><code>vertical-align</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/view-timeline"><code>view-timeline</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/view-timeline-inset"><code>view-timeline-inset</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/view-timeline"><code>view-timeline</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/view-timeline-inset"><code>view-timeline-inset</code></a></li>
      <li><a href="/fr/docs/Web/CSS/visibility"><code>visibility</code></a></li>
      <li><a href="/fr/docs/Web/CSS/widows"><code>widows</code></a></li>
      <li><a href="/fr/docs/Web/CSS/width"><code>width</code></a></li>
      <li><a href="/fr/docs/Web/CSS/word-spacing"><code>word-spacing</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/x"><code>x</code></a></li>
-     <li><a class="only-in-en-us" title="Cette page est actuellement disponible uniquement en anglais" href="/en-US/docs/Web/CSS/y"><code>y</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/x"><code>x</code></a></li>
+     <li><a href="/fr/docs/Web/CSS/y"><code>y</code></a></li>
      <li><a href="/fr/docs/Web/CSS/z-index"><code>z-index</code></a></li>
   </ul>
 </div>


### PR DESCRIPTION
### Description

Removing the last instance of the deprecated `CssAnimatedProperties` macro

### Motivation

rari/yari parity, sunset of deprecated macros

### Additional details

Replaced with static HTML content, so things look as before. The page in question is in need for a translation refresh, the english source does not have this list any more.

<img width="1011" alt="image" src="https://github.com/user-attachments/assets/c8f66e1d-12aa-4aef-8f17-8c1add6a39a8">


### Related issues and pull requests

(MP-1708)
