### PR TITLE
fix mistyped macro call

### DIFF
--- a/files/ko/web/api/event/type/index.md
+++ b/files/ko/web/api/event/type/index.md
@@ -9,7 +9,7 @@ slug: Web/API/Event/type
 
 ## 값
 
-{{domxref("Event")}}의 유형을 나타내는 {{jdxref("String")}}입니다.
+{{domxref("Event")}}의 유형을 나타내는 {{jsxref("String")}}입니다.
 
 ## 예제
 


### PR DESCRIPTION
### Description

Fixes a a typo in a `jsxref` macro call

### Motivation

discovered by rari/yari parity checks

