### PR TITLE
zh-CN: removes deprecated macros for rari compatibility

### DIFF
--- a/files/zh-cn/learn/tools_and_testing/client-side_javascript_frameworks/vue_computed_properties/index.md
+++ b/files/zh-cn/learn/tools_and_testing/client-side_javascript_frameworks/vue_computed_properties/index.md
@@ -41,10 +41,9 @@ slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_computed_pro
 
 ```html
 <h2>
-  \<! TODO: add content --> out of
-  \<! TODO: add content --> items completed
-</h2>
-```
+  \{{ToDoItems.filter(item =&gt; item.done).length}} out of
+  \{{ToDoItems.length}} items completed
+</h2>```
 
 这个值将在每次渲染时重新计算。对于像当前这样较小的应用程序，这可能并不不会产生什么影响。但是对于更大的应用程序，或者当表达式更复杂时，这可能会导致严重的性能问题。
 

--- a/files/zh-cn/learn/tools_and_testing/client-side_javascript_frameworks/vue_computed_properties/index.md
+++ b/files/zh-cn/learn/tools_and_testing/client-side_javascript_frameworks/vue_computed_properties/index.md
@@ -41,8 +41,8 @@ slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_computed_pro
 
 ```html
 <h2>
-  \{{ToDoItems.filter(item =&gt; item.done).length}} out of
-  \{{ToDoItems.length}} items completed
+  \<! TODO: add content --> out of
+  \<! TODO: add content --> items completed
 </h2>
 ```
 

--- a/files/zh-cn/learn/tools_and_testing/client-side_javascript_frameworks/vue_computed_properties/index.md
+++ b/files/zh-cn/learn/tools_and_testing/client-side_javascript_frameworks/vue_computed_properties/index.md
@@ -43,7 +43,8 @@ slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_computed_pro
 <h2>
   \{{ToDoItems.filter(item =&gt; item.done).length}} out of
   \{{ToDoItems.length}} items completed
-</h2>```
+</h2>
+```
 
 这个值将在每次渲染时重新计算。对于像当前这样较小的应用程序，这可能并不不会产生什么影响。但是对于更大的应用程序，或者当表达式更复杂时，这可能会导致严重的性能问题。
 

--- a/files/zh-cn/web/api/window/innerheight/index.md
+++ b/files/zh-cn/web/api/window/innerheight/index.md
@@ -38,7 +38,7 @@ var intOuterFramesetHeight = top.innerHeight;
 // 返回最外部 frameset 的视口的高度
 ```
 
-<! TODO: add content -->
+<! TODO: link to an interactive demo here -->
 
 改变一个窗口的大小，可以查看 {{domxref("window.resizeBy()")}} 和 {{domxref("window.resizeTo()")}}。
 

--- a/files/zh-cn/web/api/window/innerheight/index.md
+++ b/files/zh-cn/web/api/window/innerheight/index.md
@@ -38,7 +38,7 @@ var intOuterFramesetHeight = top.innerHeight;
 // 返回最外部 frameset 的视口的高度
 ```
 
-{{todo("link to an interactive demo here")}}
+<! TODO: add content -->
 
 改变一个窗口的大小，可以查看 {{domxref("window.resizeBy()")}} 和 {{domxref("window.resizeTo()")}}。
 

--- a/files/zh-cn/web/api/window/innerheight/index.md
+++ b/files/zh-cn/web/api/window/innerheight/index.md
@@ -38,8 +38,6 @@ var intOuterFramesetHeight = top.innerHeight;
 // 返回最外部 frameset 的视口的高度
 ```
 
-<! TODO: link to an interactive demo here -->
-
 改变一个窗口的大小，可以查看 {{domxref("window.resizeBy()")}} 和 {{domxref("window.resizeTo()")}}。
 
 想获取窗口的外层高度（outer height），即整个浏览器窗口的高度，请查看 {{domxref("window.outerHeight")}}。


### PR DESCRIPTION
### Description

This removes a number of deprecated macros that are not ported over to rari, our new build system. This was generated by an automated process replacing those macros with something sensible.

The macros replaced are these ones:

- `event`: invocations have been replaced by a simple markdown link that does in essence what the macro did, but consulting the local redirects before generating the link.
- `no_tag_omission`: replaced by the localized text
- `page`: for `browser_compatibility` and `specifications` replaced by `{{Compat}}` and `{{Specifications}}`, respectively. Other invocations have been replaced by a HTML comment `<!-- TODO: page macro not supported: {original parameters} -->`
- `xref_css*`: these three have been replaced by a simple link with the localized text, mirroring what the original macro did.
- `todo`: has been replaced by a HTML comment `<! TODO: add content -->`

### Motivation

rari/yari parity
