### PR TITLE
ko: removes deprecated macros for rari compatibility

### DIFF
--- a/files/ko/web/api/document/adoptnode/index.md
+++ b/files/ko/web/api/document/adoptnode/index.md
@@ -20,7 +20,7 @@ node = document.adoptNode(externalNode);
 
 ## 예제
 
-<! TODO: add content -->
+<!-- TODO: add content -->
 
 ## 알아두기
 

--- a/files/ko/web/api/document/adoptnode/index.md
+++ b/files/ko/web/api/document/adoptnode/index.md
@@ -20,7 +20,7 @@ node = document.adoptNode(externalNode);
 
 ## 예제
 
-{{todo}}
+<! TODO: add content -->
 
 ## 알아두기
 


### PR DESCRIPTION
### Description

This removes a number of deprecated macros that are not ported over to rari, our new build system. This was generated by an automated process replacing those macros with something sensible.

The macros replaced are these ones:

- `event`: invocations have been replaced by a simple markdown link that does in essence what the macro did, but consulting the local redirects before generating the link.
- `no_tag_omission`: replaced by the localized text
- `page`: for `browser_compatibility` and `specifications` replaced by `{{Compat}}` and `{{Specifications}}`, respectively. Other invocations have been replaced by a HTML comment `<!-- TODO: page macro not supported: {original parameters} -->`
- `xref_css*`: these three have been replaced by a simple link with the localized text, mirroring what the original macro did.
- `todo`: has been replaced by a HTML comment `<! TODO: add content -->`

### Motivation

rari/yari parity
