### PR TITLE
ja: removes deprecated macros for rari compatibility

### DIFF
--- a/files/ja/web/css/-webkit-mask-box-image/index.md
+++ b/files/ja/web/css/-webkit-mask-box-image/index.md
@@ -7,11 +7,11 @@ slug: Web/CSS/-webkit-mask-box-image
 
 `-webkit-mask-box-image` はマスク画像を要素の境界ボックスに設定します。
 
-- {{ Xref_cssinitial() }}: なし
+- [初期値](/ja/docs/Web/CSS/initial_value): なし
 - 適用先: すべての要素
-- {{ Xref_cssinherited() }}: なし
+- [継承](/ja/docs/Web/CSS/inheritance): なし
 - メディア: {{cssxref("Media/Visual", "visual")}}
-- {{ Xref_csscomputed() }}: 指定通り
+- [計算値](/ja/docs/Web/CSS/computed_value): 指定通り
 
 ## 構文
 


### PR DESCRIPTION
### Description

This removes a number of deprecated macros that are not ported over to rari, our new build system. This was generated by an automated process replacing those macros with something sensible.

The macros replaced are these ones:

- `event`: invocations have been replaced by a simple markdown link that does in essence what the macro did, but consulting the local redirects before generating the link.
- `no_tag_omission`: replaced by the localized text
- `page`: for `browser_compatibility` and `specifications` replaced by `{{Compat}}` and `{{Specifications}}`, respectively. Other invocations have been replaced by a HTML comment `<!-- TODO: page macro not supported: {original parameters} -->`
- `xref_css*`: these three have been replaced by a simple link with the localized text, mirroring what the original macro did.
- `todo`: has been replaced by a HTML comment `<! TODO: add content -->`

### Motivation

rari/yari parity
