### PR TITLE
fr: removes deprecated macros for rari compatibility

### DIFF
--- a/files/fr/web/api/window/index.md
+++ b/files/fr/web/api/window/index.md
@@ -193,13 +193,13 @@ _Cette interface hérite des méthodes de l'interface {{domxref("EventTarget")}}
 - {{domxref("Window.confirm()")}}
   - : Affiche une boîte de dialogue avec un message auquel l'utilisateur doit répondre.
 - {{domxref("Window.disableExternalCapture()")}} {{deprecated_inline}}
-  - : <! TODO: add content -->
+  - : <!-- TODO: add content -->
 - {{domxref("Window.dispatchEvent()")}}
   - : Utilisé pour déclencher un évènement.
 - {{domxref("Window.dump()")}} {{Non-standard_inline}}
   - : Écrit un message à la console.
 - {{domxref("Window.enableExternalCapture()")}} {{deprecated_inline}}
-  - : <! TODO: add content -->
+  - : <!-- TODO: add content -->
 - {{domxref("Window.find()")}}
   - : Recherche la chaîne de caractères donnée dans une fenêtre.
 - {{domxref("Window.focus()")}}
@@ -209,7 +209,7 @@ _Cette interface hérite des méthodes de l'interface {{domxref("EventTarget")}}
 - {{domxref("Window.getAttention()")}} {{Non-standard_inline}} {{deprecated_inline}}
   - : Fait flasher l'icône de l'application.
 - {{domxref("Window.getAttentionWithCycleCount()")}}
-  - : <! TODO: add content -->
+  - : <!-- TODO: add content -->
 - {{domxref("Window.getComputedStyle()")}}
   - : Récupère un style calculé pour l'élément donné. Un style calculé indique les valeurs de toutes les propriétés CSS de l'élément.
 - {{domxref("Window.getDefaultComputedStyle()")}} {{Non-standard_inline}}
@@ -221,7 +221,7 @@ _Cette interface hérite des méthodes de l'interface {{domxref("EventTarget")}}
 - {{domxref("Window.matchMedia()")}}
   - : Renvoie un objet {{domxref("MediaQueryList")}} représentant la chaîne d'interrogation de média spécifiée.
 - {{domxref("Window.maximize()")}}
-  - : <! TODO: add content -->
+  - : <!-- TODO: add content -->
 - {{domxref("Window.minimize()")}} (top-level XUL windows only)
   - : Minimize la fenêtre.
 - {{domxref("Window.moveBy()")}}
@@ -249,9 +249,9 @@ _Cette interface hérite des méthodes de l'interface {{domxref("EventTarget")}}
 - {{domxref("Window.resizeTo()")}}
   - : Redimensionne dynamiquement la fenêtre.
 - {{domxref("Window.restore()")}} {{Non-standard_inline}} {{deprecated_inline}}
-  - : <! TODO: add content -->
+  - : <!-- TODO: add content -->
 - {{domxref("Window.routeEvent()")}} {{deprecated_inline}}
-  - : <! TODO: add content -->
+  - : <!-- TODO: add content -->
 - {{domxref("Window.scroll()")}}
   - : Fait défiler la fenêtre à un endroit particulier dans le document.
 - {{domxref("Window.scrollBy()")}}
@@ -452,21 +452,21 @@ Voir aussi les [Interfaces DOM](/fr/docs/Web/API/Document_Object_Model).
 - {{domxref("DOMParser")}}
   - : `DOMParser` peut analyser un source XML ou HTML stocké dans une chaîne de caractères en un [Document](/fr/docs/Web/API/Document) DOM. `DOMParser` est spécifié dans [DOM Parsing et Serialization](https://w3c.github.io/DOM-Parsing/).
 - {{domxref("Window.GeckoActiveXObject")}}
-  - : <! TODO: add content -->
+  - : <!-- TODO: add content -->
 - {{domxref("Image")}}
   - : Used for creating an {{domxref("HTMLImageElement")}}.
 - {{domxref("Option")}}
   - : Used for creating an {{domxref("HTMLOptionElement")}}
 - {{domxref("Window.QueryInterface")}}
-  - : <! TODO: add content -->
+  - : <!-- TODO: add content -->
 - {{domxref("Window.XMLSerializer")}}
-  - : <! TODO: add content -->
+  - : <!-- TODO: add content -->
 - {{domxref("Worker")}}
   - : Used for creating a [Web worker](/fr/docs/DOM/Using_web_workers)
 - {{domxref("Window.XPCNativeWrapper")}}
-  - : <! TODO: add content -->
+  - : <!-- TODO: add content -->
 - {{domxref("Window.XPCSafeJSObjectWrapper")}}
-  - : <! TODO: add content -->
+  - : <!-- TODO: add content -->
 
 ## Interfaces
 

--- a/files/fr/web/api/window/index.md
+++ b/files/fr/web/api/window/index.md
@@ -193,13 +193,13 @@ _Cette interface hérite des méthodes de l'interface {{domxref("EventTarget")}}
 - {{domxref("Window.confirm()")}}
   - : Affiche une boîte de dialogue avec un message auquel l'utilisateur doit répondre.
 - {{domxref("Window.disableExternalCapture()")}} {{deprecated_inline}}
-  - : {{todo("NeedsContents")}}
+  - : <! TODO: add content -->
 - {{domxref("Window.dispatchEvent()")}}
   - : Utilisé pour déclencher un évènement.
 - {{domxref("Window.dump()")}} {{Non-standard_inline}}
   - : Écrit un message à la console.
 - {{domxref("Window.enableExternalCapture()")}} {{deprecated_inline}}
-  - : {{todo("NeedsContents")}}
+  - : <! TODO: add content -->
 - {{domxref("Window.find()")}}
   - : Recherche la chaîne de caractères donnée dans une fenêtre.
 - {{domxref("Window.focus()")}}
@@ -209,7 +209,7 @@ _Cette interface hérite des méthodes de l'interface {{domxref("EventTarget")}}
 - {{domxref("Window.getAttention()")}} {{Non-standard_inline}} {{deprecated_inline}}
   - : Fait flasher l'icône de l'application.
 - {{domxref("Window.getAttentionWithCycleCount()")}}
-  - : {{todo("NeedsContents")}}
+  - : <! TODO: add content -->
 - {{domxref("Window.getComputedStyle()")}}
   - : Récupère un style calculé pour l'élément donné. Un style calculé indique les valeurs de toutes les propriétés CSS de l'élément.
 - {{domxref("Window.getDefaultComputedStyle()")}} {{Non-standard_inline}}
@@ -221,7 +221,7 @@ _Cette interface hérite des méthodes de l'interface {{domxref("EventTarget")}}
 - {{domxref("Window.matchMedia()")}}
   - : Renvoie un objet {{domxref("MediaQueryList")}} représentant la chaîne d'interrogation de média spécifiée.
 - {{domxref("Window.maximize()")}}
-  - : {{todo("NeedsContents")}}
+  - : <! TODO: add content -->
 - {{domxref("Window.minimize()")}} (top-level XUL windows only)
   - : Minimize la fenêtre.
 - {{domxref("Window.moveBy()")}}
@@ -249,9 +249,9 @@ _Cette interface hérite des méthodes de l'interface {{domxref("EventTarget")}}
 - {{domxref("Window.resizeTo()")}}
   - : Redimensionne dynamiquement la fenêtre.
 - {{domxref("Window.restore()")}} {{Non-standard_inline}} {{deprecated_inline}}
-  - : {{todo("NeedsContents")}}
+  - : <! TODO: add content -->
 - {{domxref("Window.routeEvent()")}} {{deprecated_inline}}
-  - : {{todo("NeedsContents")}}
+  - : <! TODO: add content -->
 - {{domxref("Window.scroll()")}}
   - : Fait défiler la fenêtre à un endroit particulier dans le document.
 - {{domxref("Window.scrollBy()")}}
@@ -452,21 +452,21 @@ Voir aussi les [Interfaces DOM](/fr/docs/Web/API/Document_Object_Model).
 - {{domxref("DOMParser")}}
   - : `DOMParser` peut analyser un source XML ou HTML stocké dans une chaîne de caractères en un [Document](/fr/docs/Web/API/Document) DOM. `DOMParser` est spécifié dans [DOM Parsing et Serialization](https://w3c.github.io/DOM-Parsing/).
 - {{domxref("Window.GeckoActiveXObject")}}
-  - : {{todo("NeedsContents")}}
+  - : <! TODO: add content -->
 - {{domxref("Image")}}
   - : Used for creating an {{domxref("HTMLImageElement")}}.
 - {{domxref("Option")}}
   - : Used for creating an {{domxref("HTMLOptionElement")}}
 - {{domxref("Window.QueryInterface")}}
-  - : {{todo("NeedsContents")}}
+  - : <! TODO: add content -->
 - {{domxref("Window.XMLSerializer")}}
-  - : {{todo("NeedsContents")}}
+  - : <! TODO: add content -->
 - {{domxref("Worker")}}
   - : Used for creating a [Web worker](/fr/docs/DOM/Using_web_workers)
 - {{domxref("Window.XPCNativeWrapper")}}
-  - : {{todo("NeedsContents")}}
+  - : <! TODO: add content -->
 - {{domxref("Window.XPCSafeJSObjectWrapper")}}
-  - : {{todo("NeedsContents")}}
+  - : <! TODO: add content -->
 
 ## Interfaces
 

--- a/files/fr/web/api/window/innerheight/index.md
+++ b/files/fr/web/api/window/innerheight/index.md
@@ -42,7 +42,7 @@ var intOuterFramesetHeight = top.innerHeight;
 // retournera la hauteur de la partie visible du frameset le plus éloigné
 ```
 
-{{todo("ajouter ici un lien vers une démo interactive")}}
+<! TODO: add content -->
 
 - Pour modifier les dimensions d'une fenêtre, voir {{domxref("window.resizeBy()")}} et {{domxref("window.resizeTo()")}}.
 - Pour récupérer la hauteur extérieure d'une fenêtre, c'est-à-dire la hauteur de la fenêtre du navigateur dans sa totalité, voir {{domxref("window.outerHeight")}}.

--- a/files/fr/web/api/window/innerheight/index.md
+++ b/files/fr/web/api/window/innerheight/index.md
@@ -42,7 +42,7 @@ var intOuterFramesetHeight = top.innerHeight;
 // retournera la hauteur de la partie visible du frameset le plus éloigné
 ```
 
-<! TODO: add content -->
+<!-- TODO: add content -->
 
 - Pour modifier les dimensions d'une fenêtre, voir {{domxref("window.resizeBy()")}} et {{domxref("window.resizeTo()")}}.
 - Pour récupérer la hauteur extérieure d'une fenêtre, c'est-à-dire la hauteur de la fenêtre du navigateur dans sa totalité, voir {{domxref("window.outerHeight")}}.

--- a/files/fr/web/html/element/i/index.md
+++ b/files/fr/web/html/element/i/index.md
@@ -77,7 +77,7 @@ C'est une bonne pratique que d'utiliser l'attribut **`class`** pour identifier l
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/kbd/index.md
+++ b/files/fr/web/html/element/kbd/index.md
@@ -186,7 +186,7 @@ On voit ici différentes imbrications. La description de l'option du menu est in
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/label/index.md
+++ b/files/fr/web/html/element/label/index.md
@@ -178,7 +178,7 @@ Un élément {{HTMLElement("input")}} avec `type="button"` et un attribut `value
     </tr>
     <tr>
       <th scope="row">Omission de balise</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/map/index.md
+++ b/files/fr/web/html/element/map/index.md
@@ -79,7 +79,7 @@ _Pour le lien `right.html`&nbsp;:_
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/mark/index.md
+++ b/files/fr/web/html/element/mark/index.md
@@ -124,7 +124,7 @@ Certaines personnes qui utilisent des lecteurs d'écran désactivent sciemment c
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/meter/index.md
+++ b/files/fr/web/html/element/meter/index.md
@@ -111,7 +111,7 @@ On remarquera ici que l'attribut `min` est absent (ce qui est autorisé), la val
     </tr>
     <tr>
       <th scope="row"><dfn>Omission de balises</dfn></th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row"><dfn>Parents autorisés</dfn></th>

--- a/files/fr/web/html/element/nav/index.md
+++ b/files/fr/web/html/element/nav/index.md
@@ -72,7 +72,7 @@ Cet élément ne possède que [les attributs universels](/fr/docs/Web/HTML/Globa
     </tr>
     <tr>
       <th scope="row"><dfn>Omission de balises</dfn></th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row"><dfn>Parents autorisés</dfn></th>

--- a/files/fr/web/html/element/noscript/index.md
+++ b/files/fr/web/html/element/noscript/index.md
@@ -80,7 +80,7 @@ Elle est où, la poulette&nbsp;?
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/output/index.md
+++ b/files/fr/web/html/element/output/index.md
@@ -73,7 +73,7 @@ Le formulaire qui suit fournit un curseur dont la valeur peut aller de 0 à 100 
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/picture/index.md
+++ b/files/fr/web/html/element/picture/index.md
@@ -87,7 +87,7 @@ L'attribut `type` d'un élément {{HTMLElement("source")}} permet d'indiquer le 
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/progress/index.md
+++ b/files/fr/web/html/element/progress/index.md
@@ -71,7 +71,7 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/q/index.md
+++ b/files/fr/web/html/element/q/index.md
@@ -72,7 +72,7 @@ Comme tous les autres éléments HTML, cet élément inclut [les attributs unive
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/ruby/index.md
+++ b/files/fr/web/html/element/ruby/index.md
@@ -77,7 +77,7 @@ Cet élément inclut uniquement les [attributs globaux](/fr/docs/Web/HTML/Global
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/s/index.md
+++ b/files/fr/web/html/element/s/index.md
@@ -85,7 +85,7 @@ Certaines personnes qui utilisent des lecteurs d'écran désactivent sciemment c
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/script/index.md
+++ b/files/fr/web/html/element/script/index.md
@@ -129,7 +129,7 @@ Les navigateurs qui prennent en charge le type `module` prennent également en c
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/section/index.md
+++ b/files/fr/web/html/element/section/index.md
@@ -71,7 +71,7 @@ Cet élément inclut uniquement [les attributs universels](/fr/docs/Web/HTML/Att
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/select/index.md
+++ b/files/fr/web/html/element/select/index.md
@@ -214,7 +214,7 @@ Les utilisateurs du clavier pourront sélectionner des options non-contigües de
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/slot/index.md
+++ b/files/fr/web/html/element/slot/index.md
@@ -102,7 +102,7 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Attributs_univ
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/span/index.md
+++ b/files/fr/web/html/element/span/index.md
@@ -66,7 +66,7 @@ p span {
     </tr>
     <tr>
       <th scope="row"><dfn>Omission de balises</dfn></th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row"><dfn>Parents autorisés</dfn></th>

--- a/files/fr/web/html/element/sup/index.md
+++ b/files/fr/web/html/element/sup/index.md
@@ -120,7 +120,7 @@ Bien que, techniquement, le lettrage supérieur ne corresponde pas à la mise en
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/table/index.md
+++ b/files/fr/web/html/element/table/index.md
@@ -342,7 +342,7 @@ Si le tableau ne peut pas être subdivisé, on pourra utiliser les attributs [`i
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/template/index.md
+++ b/files/fr/web/html/element/template/index.md
@@ -123,7 +123,7 @@ table td {
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/textarea/index.md
+++ b/files/fr/web/html/element/textarea/index.md
@@ -209,7 +209,7 @@ Je suis en lecture seule</textarea
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/time/index.md
+++ b/files/fr/web/html/element/time/index.md
@@ -109,7 +109,7 @@ La valeur exploitable informatiquement est la valeur de l'attribut `datetime` de
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/tt/index.md
+++ b/files/fr/web/html/element/tt/index.md
@@ -103,7 +103,7 @@ Bien que cet élément n'ait pas été officiellement déprécié en HTML 4.01, 
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/u/index.md
+++ b/files/fr/web/html/element/u/index.md
@@ -150,7 +150,7 @@ Les titres de livres doivent être indiqués avec un élément {{HTMLElement("ci
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/ul/index.md
+++ b/files/fr/web/html/element/ul/index.md
@@ -151,7 +151,7 @@ L'élément HTML **`<ul>`** représente une liste d'éléments sans ordre partic
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/var/index.md
+++ b/files/fr/web/html/element/var/index.md
@@ -116,7 +116,7 @@ var {
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>

--- a/files/fr/web/html/element/video/index.md
+++ b/files/fr/web/html/element/video/index.md
@@ -315,7 +315,7 @@ Les sous-titres ne doivent pas masquer le sujet principal de la vidéo. Ils peuv
     </tr>
     <tr>
       <th scope="row">Omission de balises</th>
-      <td>{{no_tag_omission}}</td>
+      <td>Aucune, la balise d'ouverture et la balise de fermeture sont obligatoires.</td>
     </tr>
     <tr>
       <th scope="row">Parents autorisés</th>


### PR DESCRIPTION
### Description

This removes a number of deprecated macros that are not ported over to rari, our new build system. This was generated by an automated process replacing those macros with something sensible.

The macros replaced are these ones:

- `event`: invocations have been replaced by a simple markdown link that does in essence what the macro did, but consulting the local redirects before generating the link.
- `no_tag_omission`: replaced by the localized text
- `page`: for `browser_compatibility` and `specifications` replaced by `{{Compat}}` and `{{Specifications}}`, respectively. Other invocations have been replaced by a HTML comment `<!-- TODO: page macro not supported: {original parameters} -->`
- `xref_css*`: these three have been replaced by a simple link with the localized text, mirroring what the original macro did.
- `todo`: has been replaced by a HTML comment `<! TODO: add content -->`

### Motivation

rari/yari parity
