### PR TITLE
zh-cn: update the translation of the `GamePose` interface

### DIFF
--- a/files/zh-cn/web/api/gamepadpose/index.md
+++ b/files/zh-cn/web/api/gamepadpose/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{securecontext_header}}{{APIRef("Gamepad API")}}{{SeeCompatTable}}
 
-[游戏手柄 API](/zh-CN/docs/Web/API/Gamepad_API) 的 **`GamepadPose`** 接口表示 [WebVR](/zh-CN/docs/Web/API/WebVR_API) 控制器在某个给定时间戳的姿势（包括方向、位置、速率、加速度信息）。
+[游戏手柄 API](/zh-CN/docs/Web/API/Gamepad_API) 的 **`GamepadPose`** 接口表示 [WebVR](/zh-CN/docs/Web/API/WebVR_API) 控制器在某个给定时间戳的姿态（包括方向、位置、速率、加速度信息）。
 
 这个接口可通过 {{domxref("Gamepad.pose")}} 属性访问。
 

--- a/files/zh-cn/web/api/gamepadpose/index.md
+++ b/files/zh-cn/web/api/gamepadpose/index.md
@@ -1,46 +1,48 @@
 ---
 title: GamepadPose
 slug: Web/API/GamepadPose
+l10n:
+  sourceCommit: 5e98fd9cfbec6e28044a27c58bffca5ae464ec8b
 ---
 
-{{APIRef("Gamepad API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("Gamepad API")}}{{SeeCompatTable}}
 
-[Gamepad API](/zh-CN/docs/Web/API/Gamepad_API)的接口**`GamepadPose`** 表示 WebVR 的控制者在某个给定时间点的姿势， (包括方向、位置、速率、加速度信息)
+[游戏手柄 API](/zh-CN/docs/Web/API/Gamepad_API) 的 **`GamepadPose`** 接口表示 [WebVR](/zh-CN/docs/Web/API/WebVR_API) 控制器在某个给定时间戳的姿势（包括方向、位置、速率、加速度信息）。
 
-这个接口通过 {{domxref("Gamepad.pose")}} 属性使用。
+这个接口可通过 {{domxref("Gamepad.pose")}} 属性访问。
 
-## 属性
+## 实例属性
 
-- {{domxref("GamepadPose.hasOrientation")}} {{readonlyInline}}
-  - : Returns a boolean indicating whether the gamepad is capable of returning orientation information (`true`) or not (`false`).
-- {{domxref("GamepadPose.hasPosition")}} {{readonlyInline}}
-  - : Returns a boolean indicating whether the gamepad is capable of returning position information (`true`) or not (`false`).
-- {{domxref("GamepadPose.position")}} {{readonlyInline}}
-  - : Returns the position of the {{domxref("Gamepad")}} as a 3D vector.
-- {{domxref("GamepadPose.linearVelocity")}} {{readonlyInline}}
-  - : Returns the linear velocity of the {{domxref("Gamepad")}}, in meters per second.
-- {{domxref("GamepadPose.linearAcceleration")}} {{readonlyInline}}
-  - : Returns the linear acceleration of the {{domxref("Gamepad")}}, in meters per second per second.
-- {{domxref("GamepadPose.orientation")}} {{readonlyInline}}
-  - : Returns the orientation of the {{domxref("Gamepad")}}, as a quarternion value.
-- {{domxref("GamepadPose.angularVelocity")}} {{readonlyInline}}
-  - : Returns the angular velocity of the {{domxref("Gamepad")}}, in radians per second.
-- {{domxref("GamepadPose.angularAcceleration")}} {{readonlyInline}}
-  - : Returns the angular acceleration of the {{domxref("Gamepad")}}, in meters per second per second.
+- {{domxref("GamepadPose.hasOrientation")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : 返回一个表示游戏手柄是否能够返回方向信息的布尔值，能则返回 `true`，否则为 `false`。
+- {{domxref("GamepadPose.hasPosition")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : 返回一个表示游戏手柄能够返回位置信息的布尔值，能则返回 `true`，否则为 `false`。
+- {{domxref("GamepadPose.position")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : 返回以 3D 向量的形式表示的 {{domxref("Gamepad")}} 的位置。
+- {{domxref("GamepadPose.linearVelocity")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : 返回 {{domxref("Gamepad")}} 的线速度（以米每秒为单位）。
+- {{domxref("GamepadPose.linearAcceleration")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : 返回 {{domxref("Gamepad")}} 的线性加速度（以米每二次方秒为单位）
+- {{domxref("GamepadPose.orientation")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : 返回以四元数值的形式表示的 {{domxref("Gamepad")}} 的方向。
+- {{domxref("GamepadPose.angularVelocity")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : 返回 {{domxref("Gamepad")}} 的角速度（以弧度每秒为单位）
+- {{domxref("GamepadPose.angularAcceleration")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : 返回 {{domxref("Gamepad")}} 的角加速度（以米每二次方秒为单位）。
 
-## Examples
+## 示例
 
-TBD.
+待定。
 
-## Specifications
+## 规范
 
 {{Specifications}}
 
-## Browser compatibility
+## 浏览器兼容性
 
 {{Compat}}
 
-## See also
+## 参见
 
 - [WebVR API](/zh-CN/docs/Web/API/WebVR_API)
-- [Gamepad API](/zh-CN/docs/Web/API/Gamepad_API)
+- [游戏手柄 API](/zh-CN/docs/Web/API/Gamepad_API)

--- a/files/zh-cn/web/api/gamepadpose/index.md
+++ b/files/zh-cn/web/api/gamepadpose/index.md
@@ -16,7 +16,7 @@ l10n:
 - {{domxref("GamepadPose.hasOrientation")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : 返回一个表示游戏手柄是否能够返回方向信息的布尔值，能则返回 `true`，否则为 `false`。
 - {{domxref("GamepadPose.hasPosition")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : 返回一个表示游戏手柄能够返回位置信息的布尔值，能则返回 `true`，否则为 `false`。
+  - : 返回一个表示游戏手柄是否能够返回位置信息的布尔值，能则返回 `true`，否则为 `false`。
 - {{domxref("GamepadPose.position")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : 返回以 3D 向量的形式表示的 {{domxref("Gamepad")}} 的位置。
 - {{domxref("GamepadPose.linearVelocity")}} {{ReadOnlyInline}} {{Experimental_Inline}}


### PR DESCRIPTION
### Description

update the translation of the `GamePose` interface

### Related issues and pull requests

The units of Angular velocity/acceleration seem to be wired, an issue has already been created: w3c/gamepad#213

Part of: #17918, #14272
