### PR TITLE
[zh-cn]: update the translation of `TypedArray.prototype.byteOffset` property

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/typedarray/byteoffset/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/typedarray/byteoffset/index.md
@@ -1,34 +1,32 @@
 ---
 title: TypedArray.prototype.byteOffset
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/byteOffset
+l10n:
+  sourceCommit: e01fd6206ce2fad2fe09a485bb2d3ceda53a62de
 ---
 
 {{JSRef}}
 
-**`byteOffset`** 访问器属性表示类型化数组距离其{{jsxref("ArrayBuffer")}}起始位置的偏移（字节数）。
-
-## 语法
-
-```plain
-typedarray.byteOffset
-```
+{{jsxref("TypedArray")}} 实例的 **`byteOffset`** 访问器属性返回该类型化数组相对于其 {{jsxref("ArrayBuffer")}} 或 {{jsxref("SharedArrayBuffer")}} 开始位置的（以字节为单位）偏移量。
 
 ## 描述
 
-`byteOffset` 是一个访问器属性，它的 set 访问器函数是`undefined`，意思是你只能够读取这个属性。它的值在*TypedArray*构造时建立，不能被修改。_TypedArray_ 是这里的 [TypedArray 对象](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#TypedArray_objects)之一。
+`byteOffset` 属性是一个访问器属性，其设置函数为 `undefined`，意味着该属性只能读取。该值在构造 _TypedArray_ 时确定，并且不能被更改。
+
+_TypedArray_ 是[类型化数组对象](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_对象)之一。
 
 ## 示例
 
-### 使用`byteOffset` 属性
+### 使用 byteOffset 属性
 
 ```js
-var buffer = new ArrayBuffer(8);
+const buffer = new ArrayBuffer(8);
 
-var uint8 = new Uint8Array(buffer);
-uint8.byteOffset; // 0 (没有指定 oddfet)
+const uint8array1 = new Uint8Array(buffer);
+uint8array1.byteOffset; // 0 （未指定偏移量）
 
-var uint8 = new Uint8Array(buffer, 3);
-uint8.byteOffset; // 3 (在构造 Uint8Array 时指定)
+const uint8array2 = new Uint8Array(buffer, 3);
+uint8array2.byteOffset; // 3 （在构造 Uint8Array 时指定）
 ```
 
 ## 规范
@@ -41,5 +39,5 @@ uint8.byteOffset; // 3 (在构造 Uint8Array 时指定)
 
 ## 参见
 
-- [JavaScript 类型化数组](/zh-CN/docs/Web/JavaScript/Typed_arrays)
+- [JavaScript 类型化数组](/zh-CN/docs/Web/JavaScript/Guide/Typed_arrays)指南
 - {{jsxref("TypedArray")}}

--- a/files/zh-cn/web/javascript/reference/global_objects/typedarray/byteoffset/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/typedarray/byteoffset/index.md
@@ -7,13 +7,11 @@ l10n:
 
 {{JSRef}}
 
-{{jsxref("TypedArray")}} 实例的 **`byteOffset`** 访问器属性返回该类型化数组相对于其 {{jsxref("ArrayBuffer")}} 或 {{jsxref("SharedArrayBuffer")}} 开始位置的（以字节为单位）偏移量。
+{{jsxref("TypedArray")}} 实例的 **`byteOffset`** 访问器属性返回该类型化数组相对于其 {{jsxref("ArrayBuffer")}} 或 {{jsxref("SharedArrayBuffer")}} 开始位置的偏移量（以字节为单位）。
 
 ## 描述
 
-`byteOffset` 属性是一个访问器属性，其设置函数为 `undefined`，意味着该属性只能读取。该值在构造 _TypedArray_ 时确定，并且不能被更改。
-
-_TypedArray_ 是[类型化数组对象](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_对象)之一。
+`byteOffset` 属性是一个访问器属性，其设置访问器函数为 `undefined`，意味着该属性只能读取。该值在构造 _TypedArray_ 时确定，并且不能被更改。_TypedArray_ 是[类型化数组对象](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_对象)之一。
 
 ## 示例
 

--- a/files/zh-cn/web/javascript/reference/global_objects/typedarray/byteoffset/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/typedarray/byteoffset/index.md
@@ -23,10 +23,10 @@ _TypedArray_ 是[类型化数组对象](/zh-CN/docs/Web/JavaScript/Reference/Glo
 const buffer = new ArrayBuffer(8);
 
 const uint8array1 = new Uint8Array(buffer);
-uint8array1.byteOffset; // 0 （未指定偏移量）
+uint8array1.byteOffset; // 0（未指定偏移量）
 
 const uint8array2 = new Uint8Array(buffer, 3);
-uint8array2.byteOffset; // 3 （在构造 Uint8Array 时指定）
+uint8array2.byteOffset; // 3（在构造 Uint8Array 时指定）
 ```
 
 ## 规范


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/byteOffset
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/typedarray/byteoffset/index.md
* Last commit: https://github.com/mdn/content/commit/e01fd6206ce2fad2fe09a485bb2d3ceda53a62de