### PR TITLE
[zh-cn]: fix typo in `WebGLRenderingContext.readPixels()` method

### DIFF
--- a/files/zh-cn/web/api/webglrenderingcontext/readpixels/index.md
+++ b/files/zh-cn/web/api/webglrenderingcontext/readpixels/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{APIRef("WebGL")}}{{AvailableInWorkers}}
 
-[WebGL API](/zh-CN/docs/Web/API/WebGL_API) 的 **`WebGLRenderingContext.readPixels()`** 方法从当前的颜色帧缓冲（framebuffer）中读取指定矩形的像素矩阵并转换为 {{jsxref("TypedArray")}} 或 {{jsxref("DataView")}} 对象中。
+[WebGL API](/zh-CN/docs/Web/API/WebGL_API) 的 **`WebGLRenderingContext.readPixels()`** 方法从当前的颜色帧缓冲（framebuffer）中读取指定矩形的像素矩阵并转换为 {{jsxref("TypedArray")}} 或 {{jsxref("DataView")}} 对象。
 
 ## 语法
 

--- a/files/zh-cn/web/api/webglrenderingcontext/readpixels/index.md
+++ b/files/zh-cn/web/api/webglrenderingcontext/readpixels/index.md
@@ -1,11 +1,13 @@
 ---
-title: WebGLRenderingContext.readPixels()
+title: WebGLRenderingContext：readPixels() 方法
 slug: Web/API/WebGLRenderingContext/readPixels
+l10n:
+  sourceCommit: 2b942f0d8f84641c233d701cb5d1f4e6c23120ff
 ---
 
-{{APIRef("WebGL")}}
+{{APIRef("WebGL")}}{{AvailableInWorkers}}
 
-[WebGL API](/zh-CN/docs/Web/API/WebGL_API) 的 **`WebGLRenderingContext.readPixels()`** 方法从当前的颜色帧缓冲（framebuffer）中读取指定矩形的像素矩阵并转换为 {{jsxref("TypedArray")}} 或 {{jsxref("DataView")}} 对象。
+[WebGL API](/zh-CN/docs/Web/API/WebGL_API) 的 **`WebGLRenderingContext.readPixels()`** 方法从当前的颜色帧缓冲（framebuffer）中读取指定矩形的像素矩阵并转换为 {{jsxref("TypedArray")}} 或 {{jsxref("DataView")}} 对象中。
 
 ## 语法
 
@@ -91,7 +93,7 @@ readPixels(x, y, width, height, format, type, pixels, dstOffset)
 - `gl.INVALID_ENUM`：如果 `format` 或 `type` 不是可接受的值，则会引发此错误。
 - `gl.INVALID_OPERATION`：抛出此错误可能的原因：
 
-  - `type` 是 `gl.UNSIGNED_SHORT_5_6_5` 且 `format` 不是 `gl.RGB` 。
+  - `type` 是 `gl.UNSIGNED_SHORT_5_6_5` 且 `format` 不是 `gl.RGB`。
   - `type` 是 `gl.UNSIGNED_SHORT_4_4_4_4` 且 `format` 不是 `gl.RGBA`。
   - `type` 与类型化数组 `pixels` 的类型不匹配。
 
@@ -127,4 +129,4 @@ console.log(pixels); // Uint8Array
 
 ## 参见
 
-- [类型化数组](/zh-CN/docs/Web/JavaScript/Typed_arrays)
+- [类型化数组](/zh-CN/docs/Web/JavaScript/Guide/Typed_arrays)


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/webglrenderingcontext/readpixels/index.md
* Last commit: https://github.com/mdn/content/commit/2b942f0d8f84641c233d701cb5d1f4e6c23120ff

