### PR TITLE
[ru] update `Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma` translation

### DIFF
--- a/files/ru/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
+++ b/files/ru/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
@@ -1,13 +1,17 @@
 ---
 title: "SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //# instead"
 slug: Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma
+l10n:
+  sourceCommit: e03b13c7e157ec7b7bb02a6c7c4854b862195905
 ---
 
 {{jsSidebar("Errors")}}
 
+Предупреждение JavaScript «Using `//@` to indicate sourceURL pragmas is deprecated. Use `//#` instead» появляется, когда в JavaScript-коде присутствует устаревший синтаксис карт исходного кода.
+
 ## Сообщение
 
-```
+```plain
 Warning: SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //# instead
 
 Warning: SyntaxError: Using //@ to indicate sourceMappingURL pragmas is deprecated. Use //# instead
@@ -15,21 +19,21 @@ Warning: SyntaxError: Using //@ to indicate sourceMappingURL pragmas is deprecat
 
 ## Тип ошибки
 
-Предупреждение о том, что произошла ошибка {{jsxref("SyntaxError")}}. Выполнение скрипта не будет остановлено.
+Предупреждение о том, что произошла ошибка {{jsxref("SyntaxError")}}. Выполнение JavaScript не будет остановлено.
 
 ## Что пошло не так?
 
-Есть устаревший синтаксис карты кода в исходном коде JavaScript.
+В исходном JavaScript-коде присутствует устаревший синтаксис карт кода.
 
-Файлы JavaScript нередко объединяются и сокращаются, чтобы доставлять их с сервера более эффективно. С [картой кода](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/), отладчик может сопоставить код выполнения для исходных файлов.
+Файлы JavaScript часто объединяются и минифицируются, чтобы доставлять их с сервера более эффективно. С [картами исходного кода](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html), отладчик может сопоставить выполняемый код с исходными файлами.
 
-Спецификация карты кода меняет синтаксис из-за конфликта с IE всякий раз, когда он был найден в странице после `//@cc_on` было интерпретировано для включения условной компиляции в IE JScript engine. [Комментарий условной компиляции](https://msdn.microsoft.com/en-us/library/8ka90k2e%28v=vs.94%29.aspx) для IE малоизвестен, и это разбивает карты кода [jQuery](https://bugs.jquery.com/ticket/13274) и других библиотек.
+Спецификация карт исходного кода была изменена из-за конфликта с Internet Explorer, который при обнаружении на странице `//@cc_on` включал условную компиляцию в движке IE JScript. [Комментарий условной компиляции](https://stackoverflow.com/questions/24473882/what-does-this-comment-cc-on-0-do-inside-an-if-statement-in-javascript) в IE — малоизвестная функция, но она нарушала работу карт исходного кода [jQuery](https://bugs.jquery.com/ticket/13274) и других библиотек.
 
 ## Примеры
 
 ### Устаревший синтаксис
 
-Синтаксис с использованием знака "@" устарел.
+Синтаксис с использованием символа `@` устарел.
 
 ```js example-bad
 //@ sourceMappingURL=http://example.com/path/to/your/sourcemap.map
@@ -37,19 +41,20 @@ Warning: SyntaxError: Using //@ to indicate sourceMappingURL pragmas is deprecat
 
 ### Стандартный синтаксис
 
-Используйте знак "#".
+Следует использовать символ `#`.
 
 ```js example-good
 //# sourceMappingURL=http://example.com/path/to/your/sourcemap.map
 ```
 
-Или, в качестве альтернативы, вы можете установить заголовок для вашего JavaScript-файла чтобы избежать комментирования:
+Или можно установить заголовок {{HTTPHeader("SourceMap")}} для нужного JavaScript-файла, чтобы отключить комментирование:
 
-```js example-good
-X-SourceMap: /path/to/file.js.map
+```http example-good
+SourceMap: /path/to/file.js.map
 ```
 
 ## Смотрите также
 
-- [Как использовать карты кода – документация Firefox Tools](/ru/docs/Tools/Debugger/How_to/Use_a_source_map)
-- [Введение в карты кода – HTML5 rocks](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/)
+- [Use a source map](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html) в документации исходного кода Firefox
+- [Introduction to JavaScript source maps](https://developer.chrome.com/blog/sourcemaps/) на developer.chrome.com (2012)
+- {{HTTPHeader("SourceMap")}}


### PR DESCRIPTION
### Description

This PR updates `Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma` translation for `ru` locale.

### Related issues and pull requests

Fixes https://github.com/mdn/translated-content/issues/25319