### PR TITLE
[zh-cn]: update the translation of Event `target` property

### DIFF
--- a/files/zh-cn/web/api/event/target/index.md
+++ b/files/zh-cn/web/api/event/target/index.md
@@ -18,7 +18,7 @@ l10n:
 `event.target` 属性可以用于实现**事件委托**。
 
 ```js
-// 列出列表
+// 创建列表
 const ul = document.createElement("ul");
 document.body.appendChild(ul);
 
@@ -28,7 +28,7 @@ ul.appendChild(li1);
 ul.appendChild(li2);
 
 function hide(evt) {
-  // evt.target 指向被点击 <li> 元素
+  // evt.target 指向被点击的 <li> 元素
   // 这与 evt.currentTarget 不同，后者在这个上下文中将指向父级 <ul>
   evt.target.style.visibility = "hidden";
 }

--- a/files/zh-cn/web/api/event/target/index.md
+++ b/files/zh-cn/web/api/event/target/index.md
@@ -1,37 +1,40 @@
 ---
-title: Event.target
+title: Event：target 属性
 slug: Web/API/Event/target
+l10n:
+  sourceCommit: 43bd906206282421a50dcf1347dcfa58ef910c55
 ---
 
-{{ ApiRef("DOM") }}
+{{APIRef("DOM")}}{{AvailableInWorkers}}
 
-{{domxref("Event")}} 接口的 **`target`** 只读属性是对事件分派到的对象的引用。当事件处理器在事件的冒泡或捕获阶段被调用时，它与 {{domxref("event.currentTarget")}} 不同。
+{{domxref("Event")}} 接口的 **`target`** 只读属性是对事件被分派到的对象的引用。当事件处理器在事件的冒泡或捕获阶段被调用时，它与 {{domxref("Event.currentTarget")}} 不同。
 
 ## 值
 
-与 {{domxref("EventTarget")}} 有关。
+关联的 {{domxref("EventTarget")}}。
 
 ## 示例
 
-`event.target` 属性可以用来实现**事件委托** (**event delegation**)。
+`event.target` 属性可以用于实现**事件委托**。
 
 ```js
-// Make a list
-var ul = document.createElement("ul");
+// 列出列表
+const ul = document.createElement("ul");
 document.body.appendChild(ul);
 
-var li1 = document.createElement("li");
-var li2 = document.createElement("li");
+const li1 = document.createElement("li");
+const li2 = document.createElement("li");
 ul.appendChild(li1);
 ul.appendChild(li2);
 
-function hide(e) {
-  // e.target 引用着 <li> 元素
-  // 不像 e.currentTarget 引用着其父级的 <ul> 元素。
-  e.target.style.visibility = "hidden";
+function hide(evt) {
+  // evt.target 指向被点击 <li> 元素
+  // 这与 evt.currentTarget 不同，后者在这个上下文中将指向父级 <ul>
+  evt.target.style.visibility = "hidden";
 }
 
-// 添加监听事件到列表，当每个 <li> 被点击的时候都会触发。
+// 将监听器附加到列表上
+// 点击每个 <li> 时都会触发
 ul.addEventListener("click", hide, false);
 ```
 
@@ -46,4 +49,3 @@ ul.addEventListener("click", hide, false);
 ## 参见
 
 - [事件冒泡](/zh-CN/docs/Learn/JavaScript/Building_blocks/Event_bubbling)
-- {{domxref("Event.currentTarget")}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/Event/target
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/event/target/index.md
* Last commit: https://github.com/mdn/content/commit/43bd906206282421a50dcf1347dcfa58ef910c55