### PR TITLE
[zh-cn]: update the translation of phrase `double struck glyphs`

### DIFF
--- a/files/zh-cn/web/css/font-family/index.md
+++ b/files/zh-cn/web/css/font-family/index.md
@@ -104,7 +104,7 @@ font-family: "Gill Sans Extrabold", sans-serif;
     - `ui-rounded`
       - : 默认用户界面的圆体。
     - `math`
-      - : 针对显示数学相关字符的特殊样式问题而设计的字体：支持上标和下标、跨行括号、嵌套表达式和具有不同含义的 double struck glyphs。
+      - : 针对显示数学相关字符的特殊样式问题而设计的字体：支持上标和下标、跨行括号、嵌套表达式和具有不同含义的双线体字形。
     - `emoji`
       - : 专门用于呈现 Emoji 表情符号的字体。
     - `fangsong`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
更新 `double struck glyphs` 的翻译。

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

双线体（double struck）又称为黑板粗体（[blackboard bold](https://en.wikipedia.org/wiki/Blackboard_bold)），在原先的字母上添加了一些特定的线条，多用于表示数学中的集合。

相关链接：
- https://en.wikipedia.org/wiki/Blackboard_bold
- https://www.zhihu.com/question/590831193

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
