### PR TITLE
[zh-cn]: update the translation of WebSocket `readyState` property

### DIFF
--- a/files/zh-cn/web/api/websocket/readystate/index.md
+++ b/files/zh-cn/web/api/websocket/readystate/index.md
@@ -1,37 +1,31 @@
 ---
-title: WebSocket.readyState
+title: WebSocket：readyState 属性
 slug: Web/API/WebSocket/readyState
+l10n:
+  sourceCommit: fb311d7305937497570966f015d8cc0eb1a0c29c
 ---
 
-{{APIRef("Web Sockets API")}}
+{{APIRef("WebSockets API")}}{{AvailableInWorkers}}
 
-## 概要
-
-返回当前 {{domxref("WebSocket")}} 的链接状态，只读。
-
-## 语法
-
-```plain
-var readyState = WebSocket.readyState;
-```
+**`WebSocket.readyState`** 只读属性返回 {{domxref("WebSocket")}} 连接的当前状态。
 
 ## 值
 
-以下其中之一
+一个数字，是 {{domxref("WebSocket")}} 接口定义的四个可能状态常量之一：
 
-- 0 (`WebSocket.CONNECTING`)
-  - : 正在链接中
-- 1 (`WebSocket.OPEN`)
-  - : 已经链接并且可以通讯
-- 2 (`WebSocket.CLOSING`)
-  - : 连接正在关闭
-- 3 (`WebSocket.CLOSED`)
-  - : 连接已关闭或者没有链接成功
+- `WebSocket.CONNECTING`（0）
+  - : 套接字已创建，但连接尚未打开。
+- `WebSocket.OPEN`（1）
+  - : 连接已打开，准备进行通信。
+- `WebSocket.CLOSING`（2）
+  - : 连接正在关闭中。
+- `WebSocket.CLOSED`（3）
+  - : 连接已关闭或无法打开。
 
-## Specifications
+## 规范
 
 {{Specifications}}
 
-## Browser compatibility
+## 浏览器兼容性
 
 {{Compat}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/websocket/readystate/index.md
* Last commit: https://github.com/mdn/content/commit/fb311d7305937497570966f015d8cc0eb1a0c29c