### PR TITLE
[zh-cn]: update the translation of History `back()` method

### DIFF
--- a/files/zh-cn/web/api/history/back/index.md
+++ b/files/zh-cn/web/api/history/back/index.md
@@ -7,9 +7,9 @@ l10n:
 
 {{APIRef("History API")}}
 
-{{domxref("History")}} 接口的 **`back()`** 方法使浏览器在会话历史中返回一页。
+{{domxref("History")}} 接口的 **`back()`** 方法使浏览器在会话历史中后退一页。
 
-它的效果与调用 {{domxref("History.go", "history.go(-1)")}} 相同。如果没有上一页，此方法调用将无效。
+它的效果与调用 {{domxref("History.go", "history.go(-1)")}} 相同。如果没有上一页，此方法调用不执行任何操作。
 
 此方法是{{glossary("asynchronous", "异步")}}的。请添加一个监听器来监听 {{domxref("Window/popstate_event", "popstate")}} 事件，以便确定导航何时完成。
 
@@ -34,12 +34,12 @@ back()
 
 ## 示例
 
-以下简短示例会导致页面上的按钮导航回到会话历史记录中的上一页。
+以下简短示例会导致页面上的按钮导航回到会话历史记录中的上一个条目。
 
 ### HTML
 
 ```html
-<button id="go-back">返回！</button>
+<button id="go-back">后退！</button>
 ```
 
 ### JavaScript

--- a/files/zh-cn/web/api/history/back/index.md
+++ b/files/zh-cn/web/api/history/back/index.md
@@ -1,11 +1,17 @@
 ---
-title: back()
+title: History：back() 方法
 slug: Web/API/History/back
+l10n:
+  sourceCommit: fa980709ec5dd768d46b50b8c4833cc2f8346e21
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("History API")}}
 
-`back()`方法会在会话历史记录中向后移动一页。如果没有上一页，则此方法调用不执行任何操作。
+{{domxref("History")}} 接口的 **`back()`** 方法使浏览器在会话历史中返回一页。
+
+它的效果与调用 {{domxref("History.go", "history.go(-1)")}} 相同。如果没有上一页，此方法调用将无效。
+
+此方法是{{glossary("asynchronous", "异步")}}的。请添加一个监听器来监听 {{domxref("Window/popstate_event", "popstate")}} 事件，以便确定导航何时完成。
 
 ## 语法
 
@@ -13,24 +19,35 @@ slug: Web/API/History/back
 back()
 ```
 
+### 参数
+
+无。
+
+### 返回值
+
+无（{{jsxref("undefined")}}）。
+
+### 异常
+
+- `SecurityError` {{domxref("DOMException")}}
+  - : 如果关联的文档未完全激活，则会抛出此异常。浏览器还会限制导航操作，如果调用过于频繁，可能会抛出此错误、生成警告或忽略该调用。
+
 ## 示例
 
-下述简短示例使页面上的按钮导航页面至会话历史的后一项。
+以下简短示例会导致页面上的按钮导航回到会话历史记录中的上一页。
 
 ### HTML
 
 ```html
-<button id="go-back">Go back!</button>
+<button id="go-back">返回！</button>
 ```
 
 ### JavaScript
 
 ```js
-window.onload = function (e) {
-  document.getElementById("go-back").addEventListener("click", (e) => {
-    window.history.back();
-  });
-};
+document.getElementById("go-back").addEventListener("click", () => {
+  history.back();
+});
 ```
 
 ## 规范
@@ -40,3 +57,8 @@ window.onload = function (e) {
 ## 浏览器兼容性
 
 {{Compat}}
+
+## 参见
+
+- {{domxref("History")}}
+- [使用历史记录 API](/zh-CN/docs/Web/API/History_API/Working_with_the_History_API)


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/History/back
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/history/back/index.md
* Last commit: https://github.com/mdn/content/commit/fa980709ec5dd768d46b50b8c4833cc2f8346e21