### PR TITLE
Fix typo: change 'proque' to 'porque'

### DIFF
--- a/files/es/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/es/web/javascript/reference/global_objects/proxy/index.md
@@ -61,7 +61,7 @@ Aquí hemos provisto una implementación del manipulador
 intentos de acceder a las propiedades del objeto envuelto.
 
 Las funciones manipuladoras son llamadas a menudo _trampas_, probablemente
-proque atrapan las llamadas al objeto envuelto. La trampa simple de arriba en
+porque atrapan las llamadas al objeto envuelto. La trampa simple de arriba en
 `handler2` redefine todos los accesores de propiedades:
 
 ```js


### PR DESCRIPTION
### Description
Fix typo: change "proque" to "porque" in the documentation.

### Motivation
The change corrects a common typo in the Spanish language, improving readability and accuracy for Spanish-speaking developers.

### Additional details
This change was made to ensure that the documentation is clear and free of errors for all readers.

### Related issues and pull requests
No related issues.
