### PR TITLE
Fix typo: change '浩渺' to '毫秒'

### DIFF
--- a/files/zh-cn/web/api/window/setimmediate/index.md
+++ b/files/zh-cn/web/api/window/setimmediate/index.md
@@ -29,7 +29,7 @@ var immediateID = setImmediate(func);
 
 - {{DOMxRef("Window.postMessage", "postMessage()")}} 可以被用来触发一个 immediate 但会产生回调。请注意，Internet Explorer 8 包含 postMessage 的同步版本，这意味着它不能被用来作为代替品。
 - [MessageChannel](/zh-CN/docs/Web/API/MessageChannel) 可以在 Web Workers 内部很好的被使用，而 postMessage 的语义意味着它不能在那使用。
-- `setTimeout(fn, 0)` *可以*使用，然而按照 [HTML 规范](https://html.spec.whatwg.org/multipage/webappapis.html#timers)，嵌套深度超过 5 级的定时器，会被限制在 4 浩渺，它没有为 `setImmediate` 的天然及时性提供合适的 polyfill。
+- `setTimeout(fn, 0)` *可以*使用，然而按照 [HTML 规范](https://html.spec.whatwg.org/multipage/webappapis.html#timers)，嵌套深度超过 5 级的定时器，会被限制在 4 毫秒，它没有为 `setImmediate` 的天然及时性提供合适的 polyfill。
 
 所有这些技术都被纳入 [robust setImmediate polyfill](https://github.com/NobleJS/setImmediate) 中。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Here is a typo, 'ms' should be translated to '毫秒', not '浩渺'.

### Motivation

This change can help Chinese readers better understand the text.