### PR TITLE
chore(zh-tw): remove classes setted in `<table>` elements

### DIFF
--- a/files/zh-tw/learn_web_development/core/accessibility/wai-aria_basics/index.md
+++ b/files/zh-tw/learn_web_development/core/accessibility/wai-aria_basics/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Accessibility/WAI-ARIA_basics
 
 接續之前的文章，有時在涉及非語意 HTML 與動態 JavaScript 更新的內容製作複雜的 UI 控制措施將是個難題。WAI-ARIA 即是一個能藉由添加進一步的語意幫助處理這種問題的技術 ，讓瀏覽器與輔助科技可以辨識及用以讓使用者知道發生甚麼事情。這裡我們將展示如何以基本水準的運用來增進無障礙使用。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先決條件：</th>

--- a/files/zh-tw/learn_web_development/core/accessibility/what_is_accessibility/index.md
+++ b/files/zh-tw/learn_web_development/core/accessibility/what_is_accessibility/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Accessibility/What_is_accessibility
 
 這篇文章給「到底什麼是無障礙網頁」的模塊，開了個好起頭：以下將包括我們該考慮什麼樣的用戶以及理由、不同的人要在 web 用什麼工具互動、還有如何令無障礙網頁成為 web 開發的一部分。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先決要求：</th>

--- a/files/zh-tw/learn_web_development/core/frameworks_libraries/angular_building/index.md
+++ b/files/zh-tw/learn_web_development/core/frameworks_libraries/angular_building/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular
 
 這篇文章內容涵蓋，如何建立一個生產版本（production）的應用程式，以及提供後續的學習資源。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識：</th>

--- a/files/zh-tw/learn_web_development/core/frameworks_libraries/angular_filtering/index.md
+++ b/files/zh-tw/learn_web_development/core/frameworks_libraries/angular_filtering/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular
 
 現在讓我們來增加功能，讓使用者篩選待辦事項，這樣他們就可以選擇查看進行中、已完成，或是全部的事項。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識：</th>

--- a/files/zh-tw/learn_web_development/core/frameworks_libraries/angular_getting_started/index.md
+++ b/files/zh-tw/learn_web_development/core/frameworks_libraries/angular_getting_started/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular
 
 現在該看一下 Google 的 Angular 框架了，這是另一個你經常會遇到的前端框架。在本文中，我們將會探索 Angular 所提供的功能、安裝必備工具、建立範例應用程式，並進一步瞭解 Angular 的基本架構。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識：</th>

--- a/files/zh-tw/learn_web_development/core/frameworks_libraries/angular_item_component/index.md
+++ b/files/zh-tw/learn_web_development/core/frameworks_libraries/angular_item_component/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular
 
 元件可以用來幫助你組織你的應用程式。這篇文章會引導你建立一個元件，用來管理清單列表中的個別項目，包含加入核取方塊、編輯和刪除功能。這邊也會介紹 Angular 事件模型。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識：</th>

--- a/files/zh-tw/learn_web_development/core/frameworks_libraries/angular_styling/index.md
+++ b/files/zh-tw/learn_web_development/core/frameworks_libraries/angular_styling/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular
 
 現在，我們已經建立了基本的應用程式結構，並加入了內容，接著我們就要來對應用程式進行樣式的調整，透過本篇文章來學習如何使用樣式點綴我們的 Angular 應用程式。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識：</th>

--- a/files/zh-tw/learn_web_development/core/frameworks_libraries/angular_todo_list_beginning/index.md
+++ b/files/zh-tw/learn_web_development/core/frameworks_libraries/angular_todo_list_beginning/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular
 
 此刻，我們已準備好使用 Angular 來創建我們的待辦事項應用程式。完成後的應用程式將具有顯示待辦項目列表，並包含編輯、刪除與新增項目等功能。在本篇中，你將學到應用程式的結構，以及建立一個可顯示待辦項目的基礎列表。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識：</th>

--- a/files/zh-tw/learn_web_development/core/frameworks_libraries/introduction/index.md
+++ b/files/zh-tw/learn_web_development/core/frameworks_libraries/introduction/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Introdu
 
 我們從整體概述來探討框架、提供 JavaScript 與框架的簡要歷史、框架存在的理由、他們提供什麼東西、如何決定選擇哪個框架、以及前端框架的的替代方案。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先決條件：</th>

--- a/files/zh-tw/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
+++ b/files/zh-tw/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_g
 
 在本文中，我們將向 React 打個招呼。我們將探索其背後與範例的一些細節，在自己電腦設置基本的 React 工具鏈環境，並建立一個簡單入門的應用程式——好瞭解 React 基本架構。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識：</th>

--- a/files/zh-tw/learn_web_development/core/frameworks_libraries/react_todo_list_beginning/index.md
+++ b/files/zh-tw/learn_web_development/core/frameworks_libraries/react_todo_list_beginning/index.md
@@ -11,7 +11,7 @@ original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_t
 > [!NOTE]
 > 如果你需要檢查自己的程式碼與範例之間的差異，可以連到 [todo-react repository](https://github.com/mdn/todo-react)，這裡有我們完整的程式碼。 Todo list 作品示範：<https://mdn.github.io/todo-react-build/>。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識：</th>

--- a/files/zh-tw/learn_web_development/core/frameworks_libraries/svelte_getting_started/index.md
+++ b/files/zh-tw/learn_web_development/core/frameworks_libraries/svelte_getting_started/index.md
@@ -9,7 +9,7 @@ original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_
 
 此篇文章我們將摘要說明 [Svelte 框架](https://svelte.dev/)。我們將會看到 Svelte 如何運作，以及它與其它框架和工具的不同之處。接著我們將學習如何設置我們的開發環境並建立一個範例應用程式，了解其專案結構及如何在本地運行，最後可以將其建置於正式環境。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識：</th>

--- a/files/zh-tw/learn_web_development/core/frameworks_libraries/svelte_todo_list_beginning/index.md
+++ b/files/zh-tw/learn_web_development/core/frameworks_libraries/svelte_todo_list_beginning/index.md
@@ -11,7 +11,7 @@ original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_
 
 我們想要讓使用者們能夠瀏覽、新增和刪除任務，也能註記它們以視為完成。這將是我們在走這個教學系列時會開發到的基本功能，此外，在開發過程中我們將會看到一些更進階的概念。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識：</th>

--- a/files/zh-tw/learn_web_development/core/frameworks_libraries/vue_first_component/index.md
+++ b/files/zh-tw/learn_web_development/core/frameworks_libraries/vue_first_component/index.md
@@ -11,7 +11,7 @@ original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_fir
 > [!NOTE]
 > 如果你需要根據我們的版本來檢查你的程式碼，你可以從 [todo-vue 存放庫](https://github.com/mdn/todo-vue)找到 Vue 範例應用程式最終版本的程式碼。有關實際運行的版本，請看 <https://mdn.github.io/todo-vue/dist/> 。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識：</th>

--- a/files/zh-tw/learn_web_development/core/frameworks_libraries/vue_getting_started/index.md
+++ b/files/zh-tw/learn_web_development/core/frameworks_libraries/vue_getting_started/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_get
 
 現在來介紹我們的第三個框架 Vue 。在這篇文章中，我們會介紹 Vue 的背景，如何安裝 Vue 及建立一個新專案，學習整個 Vue 專案的高階架構及一個獨立的元件，學習如何在本地端運行專案，以及開始建構我們的範例。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識</th>

--- a/files/zh-tw/learn_web_development/core/scripting/arrays/index.md
+++ b/files/zh-tw/learn_web_development/core/scripting/arrays/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/First_steps/Arrays
 
 在本單元的最後一篇文章中，我們將介紹陣列——一種在單個變數名下儲存資料項列表的簡潔方法。在這裡，我們看看為什麼這很有用，然後探討如何建立陣列，檢索、增加和刪除儲存在陣列中的項目等等。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先備知識：</th>

--- a/files/zh-tw/learn_web_development/core/scripting/conditionals/index.md
+++ b/files/zh-tw/learn_web_development/core/scripting/conditionals/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/Building_blocks/conditionals
 
 在任何編程語言中，代碼都需要根據不同的輸入做出決策並相應地執行操作。 例如，在遊戲中，如果玩家的生命數量為 0，則遊戲結束。 在天氣應用程序中，如果在早上查看，則顯示日出圖形; 如果是夜晚，則顯示星星和月亮。 在本文中，我們將探討條件結構如何在 JavaScript 中工作。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">Prerequisites:</th>

--- a/files/zh-tw/learn_web_development/core/scripting/functions/index.md
+++ b/files/zh-tw/learn_web_development/core/scripting/functions/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/Building_blocks/Functions
 
 程式設計的另一個基本概念是函數，它允許你儲存一段程式碼，該程式碼在定義的區塊內執行單個任務，然後在需要時使用一個簡短命令調用該程式碼區塊，而不必多次輸入相同的程式碼。 在本文中，我們將探索函數背後的基本概念，例如基本語法、如何調用和定義它們、作用域範圍與參數。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先備知識：</th>

--- a/files/zh-tw/learn_web_development/core/scripting/image_gallery/index.md
+++ b/files/zh-tw/learn_web_development/core/scripting/image_gallery/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/Building_blocks/Image_gallery
 
 現在我們已經看過了基本的 JavaScript 組建，我們將讓你做一個測試，從建立一個在很多網站上常見的事物 — JavaScript 基礎的影像圖庫，來測試你對迴圈、函數、條件式及事件的知識。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先修課程：</th>

--- a/files/zh-tw/learn_web_development/core/scripting/json/index.md
+++ b/files/zh-tw/learn_web_development/core/scripting/json/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/Objects/JSON
 
 JavaScript Object Notation (JSON) 為將結構化資料 (structured data) 呈現為 JavaScript 物件的標準格式，常用於網站上的資料呈現、傳輸 (例如將資料從伺服器送至用戶端，以利顯示網頁)。你應該會常常遇到，因此本文將說明 JavaScript 搭配 JSON 時所應知道的觀念，包含如何在 JSON 物件中存取資料項目，並寫出你自己的 JSON。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">必要條件：</th>

--- a/files/zh-tw/learn_web_development/core/scripting/loops/index.md
+++ b/files/zh-tw/learn_web_development/core/scripting/loops/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/Building_blocks/Looping_code
 
 編程語言對於快速完成重複性任務非常有用，從多個基本計算到幾乎任何其他需要完成大量類似工作的情況。 在這裡，我們將看看 JavaScript 中可用於處理此類需求的循環結構。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">Prerequisites:</th>

--- a/files/zh-tw/learn_web_development/core/scripting/object_basics/index.md
+++ b/files/zh-tw/learn_web_development/core/scripting/object_basics/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/Objects/Basics
 
 第一篇談到 JavaScript 物件的文章中，我們了解到基本的 JavaScript 物件語法，複習了某些先前提過的 JavaScript 功能，也再次強調你現正使用中的許多功能其實就是物件。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">必要條件：</th>

--- a/files/zh-tw/learn_web_development/core/scripting/silly_story_generator/index.md
+++ b/files/zh-tw/learn_web_development/core/scripting/silly_story_generator/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/First_steps/Silly_story_generator
 
 在本次評估中，你被賦予的任務內容將與本單元學習到的知識息息相關，並將其應用於創建一個能隨機生成傻故事的有趣應用程式。 祝玩的開心！
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">事先具備:</th>

--- a/files/zh-tw/learn_web_development/core/scripting/strings/index.md
+++ b/files/zh-tw/learn_web_development/core/scripting/strings/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/First_steps/Strings
 
 接下來我們將把注意力轉向字串——這就是程式設計中調用的文字片段。在本文中，我們將介紹在學習 JavaScript 時你應該了解所有有關字串的常見事項，例如建立字串，跳脫字串中的引號以及將字串連接在一起。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先備知識：</th>

--- a/files/zh-tw/learn_web_development/core/scripting/useful_string_methods/index.md
+++ b/files/zh-tw/learn_web_development/core/scripting/useful_string_methods/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/First_steps/Useful_string_methods
 
 現在我們已經了解了字符串的基礎知識，讓我們開始思考我們可以使用內置方法對字符串執行哪些有用的操作，例如查找文本字符串的長度，連接和拆分字符串 ，將字符串中的一個字符替換為另一個字符，等等。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先備知識:</th>

--- a/files/zh-tw/learn_web_development/core/scripting/what_is_javascript/index.md
+++ b/files/zh-tw/learn_web_development/core/scripting/what_is_javascript/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/First_steps/What_is_JavaScript
 
 歡迎來到 MDN 的 JavaScript 初學者課程！我們將在這個章節綜觀 JavaScript ，回答一些像是「它什麼？」和「可以使用它作什麼？」之的問題，並確保你了解 JavaScript 的特性。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先備條件：</th>

--- a/files/zh-tw/learn_web_development/core/scripting/what_went_wrong/index.md
+++ b/files/zh-tw/learn_web_development/core/scripting/what_went_wrong/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/First_steps/What_went_wrong
 
 當你在練習撰寫上一節的「猜數字」遊戲時，你可能會發現它無法運作。不用擔心，本文將會把你從快被拔光的頭髮中拯救出來，並且給你一些小提示，讓你知道怎麼找出及修正 Javascript 的程式運行錯誤。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先備：</th>

--- a/files/zh-tw/learn_web_development/core/structuring_content/basic_html_syntax/index.md
+++ b/files/zh-tw/learn_web_development/core/structuring_content/basic_html_syntax/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/HTML/Introduction_to_HTML/Getting_started
 
 本文將探討 HTML 最基本的部分。首先，我們將會定義元素（element）、屬性（attribute）以及其它你可能聽過的重要名詞，然後講解該如何使用它們。我們也會告訴你典型的 HTML 頁面以及其中的元素是如何構成的，以及解釋其他重要的基礎語言特性。在此過程中，我們會撰寫一些 HTML 來引發你的興趣！
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">需求：</th>

--- a/files/zh-tw/learn_web_development/core/structuring_content/creating_links/index.md
+++ b/files/zh-tw/learn_web_development/core/structuring_content/creating_links/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/HTML/Introduction_to_HTML/Creating_hyperlinks
 
 超連結(Hyperlinks)真的超級重要 — 它造就了我們現今所熟知的網路。這篇文章將會介紹超連結的使用語法，並且探討建立它們的最佳實踐方法。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">需求：</th>

--- a/files/zh-tw/learn_web_development/core/structuring_content/headings_and_paragraphs/index.md
+++ b/files/zh-tw/learn_web_development/core/structuring_content/headings_and_paragraphs/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals
 
 HTML 的其中一件核心工作，就是給出文件的結構和含義（又稱{{glossary("semantics")}}），以便瀏覽器正確顯示。本文章旨在說明 {{glossary("HTML")}} 可透過增加標題、章節、強調、建立清單等，建立結構化的頁面。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">需求：</th>

--- a/files/zh-tw/learn_web_development/core/structuring_content/structuring_documents/index.md
+++ b/files/zh-tw/learn_web_development/core/structuring_content/structuring_documents/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/HTML/Introduction_to_HTML/Document_and_website_structure
 
 {{glossary("HTML")}} 不僅能夠定義網頁的單獨部分（例如「段落」或「圖片」），還可以使用區塊級元素（例如「標題欄」、「導覽選單」、「主內容列」）來定義網站中的複合區域。本文將探討如何規劃基本的網站結構，並根據規劃的結構來編寫 HTML。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識:</th>

--- a/files/zh-tw/learn_web_development/core/structuring_content/webpage_metadata/index.md
+++ b/files/zh-tw/learn_web_development/core/structuring_content/webpage_metadata/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML
 
 HTML 文件的 {{glossary("Head", "head")}} 是網頁在加載完畢之後，不會顯示在瀏覽器上的部分。其中包含一些資訊，如頁面的標題({{htmlelement("title")}})、{{glossary("CSS")}} 的連結 (當你想利用 CSS 來妝點你的頁面 HTML 時，你會用到它們)、網頁圖示(favicon)的連結，以及 metadata (裡頭承載了有關於該 HTML 的資料，如作者、描述該文件的關鍵詞等)。在這一章節裡，我們會討論以上的內容，甚至更多，藉此替你打下標記網頁的根基。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">需求：</th>

--- a/files/zh-tw/learn_web_development/core/styling_basics/getting_started/index.md
+++ b/files/zh-tw/learn_web_development/core/styling_basics/getting_started/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/CSS/First_steps/Getting_started
 
 在這個主題中，我們將 CSS 套用到一個簡單的 HTML 文件上，在過程中學習這個語言一些實際的東西。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先備知識：</th>

--- a/files/zh-tw/learn_web_development/core/styling_basics/what_is_css/index.md
+++ b/files/zh-tw/learn_web_development/core/styling_basics/what_is_css/index.md
@@ -9,7 +9,7 @@ original_slug: Learn/CSS/First_steps/How_CSS_works
 
 我們已經學會基本 CSS 的用途與用法了，這堂課我們就來看看瀏覽器是如何將 CSS 和 HTML 變化成網頁的吧。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">需求：</th>

--- a/files/zh-tw/learn_web_development/extensions/advanced_javascript_objects/adding_bouncing_balls_features/index.md
+++ b/files/zh-tw/learn_web_development/extensions/advanced_javascript_objects/adding_bouncing_balls_features/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/Objects/Adding_bouncing_balls_features
 
 在本文中，你將繼續使用前一篇文章的彈跳彩球展示程式，另外加入幾項有趣的新功能。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">必備條件：</th>

--- a/files/zh-tw/learn_web_development/extensions/advanced_javascript_objects/classes_in_javascript/index.md
+++ b/files/zh-tw/learn_web_development/extensions/advanced_javascript_objects/classes_in_javascript/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/Objects/Classes_in_JavaScript
 
 在解釋過大部分的 OOJS 細節之後，本文將說明該如何建立「子」物件類別 (建構子)，並從其「母」類別繼承功能。此外，也將建議開發者應於何時、於何處使用 OOJS。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">必備條件：</th>

--- a/files/zh-tw/learn_web_development/extensions/advanced_javascript_objects/object_building_practice/index.md
+++ b/files/zh-tw/learn_web_development/extensions/advanced_javascript_objects/object_building_practice/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/Objects/Object_building_practice
 
 我們解說完必要的 JavaScript 物件理論以及語法細節，想先幫你把根紮好。接著就透過實作範例，讓你實際建立自己有趣又多彩的 JavaScript 物件。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">必備條件：</th>

--- a/files/zh-tw/learn_web_development/extensions/advanced_javascript_objects/object_prototypes/index.md
+++ b/files/zh-tw/learn_web_development/extensions/advanced_javascript_objects/object_prototypes/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/Objects/Object_prototypes
 
 JavaScript 的物件即透過原型 (Prototype) 機制相互繼承功能，且與典型的物件導向 (OO) 程式語言相較，其運作方式有所差異。我們將透過本文說明相異之處、解釋原型鍊 (Prototype chain) 運作的方式，並了解原型屬性是如何將函式新增至現有的建構子 (Constructor) 之中。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">必備條件：</th>

--- a/files/zh-tw/learn_web_development/extensions/async_js/introducing/index.md
+++ b/files/zh-tw/learn_web_development/extensions/async_js/introducing/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/JavaScript/Asynchronous/Introducing
 
 在本篇文章中我們會先簡短回顧在同步的 JavaScript 中所遭遇到的問題，並預先看看往後將會使用哪些非同步的 JavaScript 技巧來解決此問題。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先備知識：</th>

--- a/files/zh-tw/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
+++ b/files/zh-tw/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Forms/How_to_structure_a_web_form
 
 有了基礎後，我們就能探討表單元素，所提供的結構與文意之詳細資訊；還有各表單部份的相異之處。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先決條件：</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/django/admin_site/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/django/admin_site/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Django/Admin_site
 
 現在，我們已經為本地圖書館網站 [LocalLibrary](/zh-TW/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website) 創建了模型，我們接下來使用 Django 管理網站，去添加 一些 「真實的」 書本數據。首先，我們展示如何用管理網站註冊模型，然後展示如何登錄和創建一些數據。本文最後，我們介紹可以進一步改進管理網站的建議。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">前提:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/django/authentication/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/django/authentication/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Django/Authentication
 
 在本教程中，我們將會展示如何允許用戶使用自己的帳戶登入到你的網站，以及如何根據用戶是否已登入和權限的不同來控制他們可以執行和查看的內容。作為展示的一部分，我們會擴展[本地圖書館](/zh-TW/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website)網站，添加登入頁面和登出頁面，以及用來查看已借閱的圖書的頁面——分為用戶與員工兩種不同頁面。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">前提:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/django/development_environment/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/django/development_environment/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Django/development_environment
 
 現在，你知道什麼是 Django。那麼我們將向你展示如何在 Windows，Linux（Ubuntu）和 Mac OSX 上設置和測試 Django 開發環境—無論你常用哪種操作系統，本文應該都能讓你開始開發 Django 應用程序。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先備知識:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/django/django_assessment_blog/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/django/django_assessment_blog/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Django/django_assessment_blog
 
 在這個評估中，你將使用你在 [Django Web Framework (Python)](/zh-TW/docs/Learn_web_development/Extensions/Server-side/Django) 模組中獲得的知識，來創建一個非常基本的部落格。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row"><p>前提:</p></th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/django/forms/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/django/forms/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Django/Forms
 
 在本教程中，我們將向你展示，如何在 Django 中使用 HTML 表單，特別是編寫表單以創建，更新和刪除模型實例的最簡單方法。作為本演示的一部分，我們將擴展 [LocalLibrary](/zh-TW/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website) 網站，以便圖書館員，可以使用我們自己的表單（而不是使用管理員應用程序）更新圖書，創建，更新和刪除作者。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">前提:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/django/home_page/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/django/home_page/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Django/Home_page
 
 我們現在可以添加代碼，來顯示我們的第一個完整頁面 - [LocalLibrary](/zh-TW/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website) 網站的主頁，顯示每個模型類型有多少條記錄，並提供我們其他頁面的側邊欄導航鏈接。一路上，我們將獲得編寫基本 URL 地圖和視圖、從數據庫獲取記錄、以及使用模板的實踐經驗。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">前提:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/django/models/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/django/models/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Django/Models
 
 本文介紹如何為 [LocalLibrary](/zh-TW/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website) 網站定義模型。它解釋了模型是什麼、聲明的方式以及一些主要字段類型。它還簡要展示了你可以訪問模型數據的幾個主要方法。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">前提:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/django/sessions/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/django/sessions/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Django/Sessions
 
 本教程擴展了我們的[LocalLibrary](/zh-TW/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website) 網站，為主頁添加了一個基於會話的訪問計數器。這是一個相對簡單的例子，但它確實顯示了，如何使用會話框架，為匿名用戶提供持久的行為。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">Prerequisites:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/django/skeleton_website/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/django/skeleton_website/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Django/skeleton_website
 
 Django 教學的第二篇文章，會展示怎樣創建一個網站的"框架"，在這個框架的基礎上，你可以繼續填充整站使用的 settings， urls，模型(models)，視圖(views)和模板(templates )。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">前提:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/django/tutorial_local_library_website/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/django/tutorial_local_library_website/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Django/Tutorial_local_library_website
 
 我們實戰教學系列的第一篇，會解釋你將學到什麼。並提供一個「本地圖書館」 的例子，作為概述。在接下來的教學裡，我們會不斷完善和改進這個網站。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">前提:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/deployment/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/deployment/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Express_Nodejs/deployment
 
 現在你已經創建（並測試）了一個不錯的 本地圖書館 網站了，你打算把它發佈到一個公共網絡服務器，這樣圖書館管理員和網路上的其他成員就可以訪問它了。這篇文章總結了你可以怎樣找到一台主機部署你的網站，以及你需要為網站準備好佈署到生產環境該做什麼。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">預備知識:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Express_Nodejs/development_environment
 
 現在你已經了解 Express 的目的了，接下來繼續說明如何設定和測試 Windows、Linux (Ubuntu)和 Mac OS X 上的 Node/Express 開發環境。不管你用的是什麼作業系統，你都能在本文中找到開發 Express 應用的入門需知。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">前置需求:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/displaying_data/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/displaying_data/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Express_Nodejs/Displaying_data
 
 我們現在準備好要新增網頁，以顯示本地圖書館網站的書本與其它資料。這些網頁將包括一個主頁 ，顯示我們每個模型的型態有多少筆紀錄，以及我們所有模型的清單與細節頁面。藉此，我們將得到從數據庫取得紀錄、以及使用樣版的實務經驗。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">前置條件:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/forms/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/forms/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Express_Nodejs/forms
 
 在此教程中，我們會教你如何使用 Express ，並且結合 Pug 來實現 HTML 表單，並且如何從數據庫中創建、更新、和刪除文檔。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">前提條件:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/mongoose/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/mongoose/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Express_Nodejs/mongoose
 
 本文簡短介紹數據庫，以及如何搭配 Node / Express 應用，使用數據庫。接下來會演示我們如何使用 [Mongoose](http://mongoosejs.com/)，為本地圖書館提供數據庫存取。本文說明物件要求與模型如何宣告，主要的欄位型態，以及基本驗證。本文也簡短演示一些存取模型數據的主要方法。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">前置條件:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/routes/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/routes/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Express_Nodejs/routes
 
 在本教程中，我們將為最終在 本地圖書館 網站中需要的所有資源端點，搭配 "空殼" 處理函式來配置路由 (URL handling code) 。完成後，我們的路由處理源碼將會有模組化結構，在接下來的文章中，我們可以用真實的處理函式加以擴充。我們也會對如何使用 Express 創建模組化路由，有更好的理解。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先備知識:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/skeleton_website/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/skeleton_website/index.md
@@ -10,7 +10,7 @@ original_slug: Learn/Server-side/Express_Nodejs/skeleton_website
 
 在 [Express 教程](/zh-TW/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/Tutorial_local_library_website)的第二篇文章，演示如何創建一個 "骨架" 網站項目，你可以接著在裡面加入網站特定的路由、模板/視圖、和數据庫調用。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">前置條件:</th>

--- a/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/tutorial_local_library_website/index.md
+++ b/files/zh-tw/learn_web_development/extensions/server-side/express_nodejs/tutorial_local_library_website/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Server-side/Express_Nodejs/Tutorial_local_library_website
 
 我們實作教程系列的第一篇文章，會說明將學到什麼東西，並提供「本地圖書館」範例網站的概述 。我們將在接下來的文章中一步一步完成這個網站。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">前置條件:</th>

--- a/files/zh-tw/learn_web_development/extensions/testing/automated_testing/index.md
+++ b/files/zh-tw/learn_web_development/extensions/testing/automated_testing/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Tools_and_testing/Cross_browser_testing/Automated_testing
 
 每天在好幾個瀏覽器與設備上，運行手動測試數次，既乏味又浪費時間。要有效率的處理這種事，就要開始熟悉自動化工具。我們會在這篇文章看看有哪些可用的工具、如何使用它們、以及如何使用如 Sauce Labs 與 Browser Stack 的商業化瀏覽器測試程式之基本講述。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">先決條件：</th>

--- a/files/zh-tw/learn_web_development/howto/web_mechanics/what_is_a_web_server/index.md
+++ b/files/zh-tw/learn_web_development/howto/web_mechanics/what_is_a_web_server/index.md
@@ -8,7 +8,7 @@ original_slug: Learn/Common_questions/Web_mechanics/What_is_a_web_server
 
 本文章將講解網路伺服器是什麼、如何運作、還有他們的重要性。
 
-<table class="learn-box standard-table">
+<table>
   <tbody>
     <tr>
       <th scope="row">要求：</th>


### PR DESCRIPTION
### Description

remove classes (`learn-box standard-table`) setted in `<table>` elements

### Motivation

en-US docs did not have the classes set anymore.

### Related issues and pull requests

The same as: #25202
