### PR TITLE
[zh-cn]: update the translation of `Boolean.prototype.valueOf()` method

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/boolean/valueof/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/boolean/valueof/index.md
@@ -27,7 +27,7 @@ valueOf()
 
 ## 描述
 
-{{jsxref("Boolean")}} 的 `valueOf()` 方法返回 `Boolean` 对象或字面量 `Boolean` 的原始值作为布尔数据类型。
+{{jsxref("Boolean")}} 的 `valueOf()` 方法返回 `Boolean` 对象或 `Boolean` 字面量的原始值作为布尔数据类型。
 
 该方法通常在 JavaScript 内部调用，而不是在代码中显式调用。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/boolean/valueof/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/boolean/valueof/index.md
@@ -2,7 +2,7 @@
 title: Boolean.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/Boolean/valueOf
 l10n:
-  sourceCommit: 27180875516cc311342e74b596bfb589b7211e0c
+  sourceCommit: 86aba12ebfdca9fb1de77afb08cc78a0c9e44d45
 ---
 
 {{JSRef}}

--- a/files/zh-cn/web/javascript/reference/global_objects/boolean/valueof/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/boolean/valueof/index.md
@@ -27,7 +27,7 @@ valueOf()
 
 ## 描述
 
-{{jsxref("Boolean")}} 的 `valueOf()` 方法返回 `Boolean` 对象或 `Boolean` 字面量的原始值作为布尔数据类型。
+{{jsxref("Boolean")}} 的 `valueOf()` 方法以布尔数据类型返回 `Boolean` 对象或 `Boolean` 字面量的原始值。
 
 该方法通常在 JavaScript 内部调用，而不是在代码中显式调用。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/boolean/valueof/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/boolean/valueof/index.md
@@ -1,37 +1,43 @@
 ---
 title: Boolean.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/Boolean/valueOf
+l10n:
+  sourceCommit: 27180875516cc311342e74b596bfb589b7211e0c
 ---
 
 {{JSRef}}
 
-**`valueOf()`** 方法返回一个{{jsxref("Boolean")}}对象的原始值。
+{{jsxref("Boolean")}} 值的 **`valueOf()`** 方法返回 {{jsxref("Boolean")}} 对象的原始值。
 
 {{EmbedInteractiveExample("pages/js/boolean-valueof.html")}}
 
 ## 语法
 
-```plain
-bool.valueOf()
+```js-nolint
+valueOf()
 ```
+
+### 参数
+
+无。
 
 ### 返回值
 
-给定{{jsxref("Boolean")}}对象的原始值
+给定 {{jsxref("Boolean")}} 对象的原始值。
 
 ## 描述
 
-{{jsxref("Boolean")}}的 `valueOf` 方法返回一个{{jsxref("Boolean")}}对象或{{jsxref("Boolean")}}字面量的原始值作为布尔数据类型。
+{{jsxref("Boolean")}} 的 `valueOf()` 方法返回 `Boolean` 对象或字面量 `Boolean` 的原始值作为布尔数据类型。
 
 该方法通常在 JavaScript 内部调用，而不是在代码中显式调用。
 
 ## 示例
 
-### 使用 `valueOf`
+### 使用 `valueOf()`
 
 ```js
-x = new Boolean();
-myVar = x.valueOf(); // assigns false to myVar
+const x = new Boolean();
+const myVar = x.valueOf(); // 给 myVar 赋值 false
 ```
 
 ## 规范


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/valueOf
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/boolean/valueof/index.md
* Last commit: https://github.com/mdn/content/commit/86aba12ebfdca9fb1de77afb08cc78a0c9e44d45
