### PR TITLE
[ru] fix: update Writing Guidelines link in README

### DIFF
--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable-file fqdn-moz-links -->
+
 # Участие в переводе
 
 Для начала ознакомьтесь с [правилами внесения изменений в MDN](https://github.com/mdn/translated-content/blob/main/CONTRIBUTING.md), [информацией о переводе документов MDN](https://github.com/mdn/translated-content/blob/main/docs/README.md) и [руководствами по составлению документации](https://developer.mozilla.org/ru/docs/MDN/Writing_guidelines).

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -1,6 +1,6 @@
 # Участие в переводе
 
-Для начала ознакомьтесь с [правилами внесения изменений в MDN](https://github.com/mdn/translated-content/blob/main/CONTRIBUTING.md), [информацией о переводе документов MDN](https://github.com/mdn/translated-content/blob/main/docs/README.md) и [руководствами по составлению документации](/ru/docs/MDN/Writing_guidelines).
+Для начала ознакомьтесь с [правилами внесения изменений в MDN](https://github.com/mdn/translated-content/blob/main/CONTRIBUTING.md), [информацией о переводе документов MDN](https://github.com/mdn/translated-content/blob/main/docs/README.md) и [руководствами по составлению документации](https://developer.mozilla.org/ru/docs/MDN/Writing_guidelines).
 
 ## Использование ссылок
 

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -1,8 +1,10 @@
-<!-- markdownlint-disable-file fqdn-moz-links -->
-
 # Участие в переводе
 
+<!-- markdownlint-disable search-replace -->
+
 Для начала ознакомьтесь с [правилами внесения изменений в MDN](https://github.com/mdn/translated-content/blob/main/CONTRIBUTING.md), [информацией о переводе документов MDN](https://github.com/mdn/translated-content/blob/main/docs/README.md) и [руководствами по составлению документации](https://developer.mozilla.org/ru/docs/MDN/Writing_guidelines).
+
+<!-- markdownlint-enable search-replace -->
 
 ## Использование ссылок
 


### PR DESCRIPTION
### Description
This PR fixes a broken link to the "Writing Guidelines" in the Russian translation guide (README.md).

`Reviewdog` suggests replacing the absolute link with a relative one, based on the `fqdn-moz-links` rule. However, in this case, the absolute link is necessary because this README file is intended to be read in the GitHub repository.

In addition to fixing the link, I also suggest considering adding an exception for the `docs` directory to the `fqdn-moz-links` rule. This might prevent similar issues in the future where absolute links are required for documents intended to be read outside of the `developer.mozilla.org` context.