### PR TITLE
[ko] fillStyle 예제 draw 함수의 누락된 중괄호 추가

### DIFF
--- a/files/ko/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/ko/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -52,6 +52,8 @@ function draw() {
         Math.floor(255 - 42.5 * j) +
         ", 0)";
       ctx.fillRect(j * 25, i * 25, 25, 25);
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
- [fillStyle 예제](https://developer.mozilla.org/ko/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors#fillstyle_%EC%98%88%EC%A0%9C)의 draw 함수에서 누락된 중괄호 닫기 문자를 추가했습니다.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
- 예제를 실행해보다가 오류로 실행되지 않는 것을 발견하여 중괄호가 누락된 것을 발견하였습니다.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
