### PR TITLE
[zh-cn]: update the translation of HTTP `Content-Length` header

### DIFF
--- a/files/zh-cn/web/http/headers/content-length/index.md
+++ b/files/zh-cn/web/http/headers/content-length/index.md
@@ -1,26 +1,45 @@
 ---
 title: Content-Length
 slug: Web/HTTP/Headers/Content-Length
+l10n:
+  sourceCommit: 92b03e46cef6be37de60799363e3e33e3415b491
 ---
 
 {{HTTPSidebar}}
 
-**`Content-Length`** 是一个实体消息首部，用来指明发送给接收方的消息主体的大小，即用十进制数字表示的八位元组的数目。
+HTTP **`Content-Length`** 标头表示发送给接收方的消息体的大小（以字节为单位）。
 
-| Header type                           | {{Glossary("Entity header")}} |
-| ------------------------------------- | ----------------------------- |
-| {{Glossary("Forbidden header name")}} | yes                           |
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">标头类型</th>
+      <td>
+        {{Glossary("Request header", "请求标头")}}、{{Glossary("Response header", "响应标头")}}、{{Glossary("Content header", "内容标头")}}
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name", "禁止修改的标头")}}</th>
+      <td>是</td>
+    </tr>
+    <tr>
+      <th scope="row">
+        {{Glossary("CORS-safelisted response header", "列入 CORS 白名单的响应标头")}}
+      </th>
+      <td>是</td>
+    </tr>
+  </tbody>
+</table>
 
 ## 语法
 
-```plain
+```http
 Content-Length: <length>
 ```
 
 ## 指令
 
-- \<length>
-  - : 消息的长度，用十进制数字表示的八位字节的数目。
+- `<length>`
+  - : 以字节为单位的长度。
 
 ## 规范
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/http/headers/content-length/index.md
* Last commit: https://github.com/mdn/content/commit/92b03e46cef6be37de60799363e3e33e3415b491