### PR TITLE
[ja] Fix typo in Object page.

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/object/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/index.md
@@ -86,7 +86,7 @@ nullProtoObj.constructor; // "undefined" と表示
 `toString` メソッドを null プロトタイプオブジェクトに割り当てることで追加することができます。
 
 ```js
-nullProtoObj.toString = Object.prototype.toString; // 新しいオブジェクトに toString が書けているため、元の汎用的なものを追加しなおす
+nullProtoObj.toString = Object.prototype.toString; // 新しいオブジェクトに toString が欠けているため、元の汎用的なものを追加しなおす
 
 console.log(nullProtoObj.toString()); // "[object Object]" と表示
 console.log(`nullProtoObj is: ${nullProtoObj}`); // "nullProtoObj is: [object Object]" と表示


### PR DESCRIPTION
Object ページの誤字修正

誤: 書けている
正: 欠けている

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`書けている` is `Written`, and `欠けている` is `Missing`.
In this case, I think `Missing` is correct.

### Motivation

fix typo.

### Additional details

nothing

### Related issues and pull requests

nothing