### PR TITLE
[ja]: Web/HTML/Element/audio の誤字・リンク切れを修正

### DIFF
--- a/files/ja/web/html/element/audio/index.md
+++ b/files/ja/web/html/element/audio/index.md
@@ -466,5 +466,5 @@ elem.audioTrackList.onremovetrack = (event) => {
 - {{domxref("HTMLAudioElement")}}
 - {{htmlelement("source")}}
 - {{htmlelement("video")}}
-- [学習りゅいき: 動画及び音声のコンテンツ](/ja/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)
+- [学習領域: 動画及び音声のコンテンツ](/ja/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)
 - [ブラウザーに依存しない音声の基本](/ja/docs/Web/Media/Audio_and_video_delivery/Cross-browser_audio_basics)

--- a/files/ja/web/html/element/audio/index.md
+++ b/files/ja/web/html/element/audio/index.md
@@ -269,7 +269,7 @@ navigator.mediaDevices
 - `<audio>` 要素は `<video>` 要素と同じような方法で字幕を持つことができません。 Ian Devlin による [WebVTT and Audio](https://www.iandevlin.com/blog/2015/12/html5/webvtt-and-audio) で、役立つ情報や作業があります。
 - この要素を対応しているブラウザーで代替コンテンツをテストするには、`<audio>` を `<notanaudio>` のような存在しない要素に置き換えることで行うことができます。
 
-HTML の `<audio>` 要素の使用に関する良い情報源として、[映像および音声コンテンツ](/ja/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)の初心者向けチュートリアルがあります。
+HTML の `<audio>` 要素の使用に関する良い情報源として、[HTML動画および音声](/ja/docs/Learn_web_development/Core/Structuring_content/HTML_video_and_audio)の初心者向けチュートリアルがあります。
 
 ### CSS でのスタイル付け
 

--- a/files/ja/web/html/element/audio/index.md
+++ b/files/ja/web/html/element/audio/index.md
@@ -269,7 +269,7 @@ navigator.mediaDevices
 - `<audio>` 要素は `<video>` 要素と同じような方法で字幕を持つことができません。 Ian Devlin による [WebVTT and Audio](https://www.iandevlin.com/blog/2015/12/html5/webvtt-and-audio) で、役立つ情報や作業があります。
 - この要素を対応しているブラウザーで代替コンテンツをテストするには、`<audio>` を `<notanaudio>` のような存在しない要素に置き換えることで行うことができます。
 
-HTML の `<audio>` 要素の使用に関する良い情報源として、[HTML動画および音声](/ja/docs/Learn_web_development/Core/Structuring_content/HTML_video_and_audio)の初心者向けチュートリアルがあります。
+HTML の `<audio>` 要素の使用に関する良い情報源として、 [HTML 動画および音声](/ja/docs/Learn_web_development/Core/Structuring_content/HTML_video_and_audio)の初心者向けチュートリアルがあります。
 
 ### CSS でのスタイル付け
 
@@ -466,5 +466,5 @@ elem.audioTrackList.onremovetrack = (event) => {
 - {{domxref("HTMLAudioElement")}}
 - {{htmlelement("source")}}
 - {{htmlelement("video")}}
-- [学習領域: HTML動画および音声](/ja/docs/Learn_web_development/Core/Structuring_content/HTML_video_and_audio)
+- [学習領域: HTML 動画および音声](/ja/docs/Learn_web_development/Core/Structuring_content/HTML_video_and_audio)
 - [ブラウザーに依存しない音声の基本](/ja/docs/Web/Media/Audio_and_video_delivery/Cross-browser_audio_basics)

--- a/files/ja/web/html/element/audio/index.md
+++ b/files/ja/web/html/element/audio/index.md
@@ -466,5 +466,5 @@ elem.audioTrackList.onremovetrack = (event) => {
 - {{domxref("HTMLAudioElement")}}
 - {{htmlelement("source")}}
 - {{htmlelement("video")}}
-- [学習領域: HTML動画および音声](/ja/docs/Learn_web_development/Core/Structuring_content/HTML_Video_and_audio)
+- [学習領域: HTML動画および音声](/ja/docs/Learn_web_development/Core/Structuring_content/HTML_video_and_audio)
 - [ブラウザーに依存しない音声の基本](/ja/docs/Web/Media/Audio_and_video_delivery/Cross-browser_audio_basics)

--- a/files/ja/web/html/element/audio/index.md
+++ b/files/ja/web/html/element/audio/index.md
@@ -466,5 +466,5 @@ elem.audioTrackList.onremovetrack = (event) => {
 - {{domxref("HTMLAudioElement")}}
 - {{htmlelement("source")}}
 - {{htmlelement("video")}}
-- [学習領域: HTML動画及び音声](/ja/docs/Learn_web_development/Core/Structuring_content/HTML_Video_and_audio)
+- [学習領域: HTML動画および音声](/ja/docs/Learn_web_development/Core/Structuring_content/HTML_Video_and_audio)
 - [ブラウザーに依存しない音声の基本](/ja/docs/Web/Media/Audio_and_video_delivery/Cross-browser_audio_basics)

--- a/files/ja/web/html/element/audio/index.md
+++ b/files/ja/web/html/element/audio/index.md
@@ -466,5 +466,5 @@ elem.audioTrackList.onremovetrack = (event) => {
 - {{domxref("HTMLAudioElement")}}
 - {{htmlelement("source")}}
 - {{htmlelement("video")}}
-- [学習領域: 動画及び音声のコンテンツ](/ja/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)
+- [学習領域: HTML動画及び音声](/ja/docs/Learn_web_development/Core/Structuring_content/HTML_Video_and_audio)
 - [ブラウザーに依存しない音声の基本](/ja/docs/Web/Media/Audio_and_video_delivery/Cross-browser_audio_basics)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
`Web/HTML/Element/audio`の「学習りゅいき」という表現を「学習領域」に修正しました。
また、en-usドキュメントのパス変更・タイトル変更に合わせて、リンクとリンクテキストの修正を行いました。

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
更新箇所に対応する原文へのリンクは以下の通りです。
https://github.com/mdn/content/blob/8bbce455ad36b4895b2e388c69064a963e0193e2/files/en-us/web/html/element/audio/index.md?plain=1#L283
https://github.com/mdn/content/blob/8bbce455ad36b4895b2e388c69064a963e0193e2/files/en-us/web/html/element/audio/index.md?plain=1#L490

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
