### PR TITLE
Corrected code on the note "¿Como React usa JavaScript?"

### DIFF
--- a/files/es/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
+++ b/files/es/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
@@ -85,11 +85,10 @@ const header = (
 > [!NOTE]
 > Los paréntesis en el fragmento anterior no son exclusivos de JSX y no tienen ningún efecto en la aplicación. Son una señal para ti (y tu computadora) de que las múltiples líneas de código que contiene forman parte de una misma expresión. También podríamos escribir la expresión del encabezado de esta manera:
 >
-> ```jsx
-> const header = 
->   <header>
->     <h1>Mozilla Developer Network</h1>
->   </header>;
+> ```jsx-nolint
+> const header = <header>
+>   <h1>Mozilla Developer Network</h1>
+> </header>;
 >
 > ```
 >

--- a/files/es/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
+++ b/files/es/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
@@ -89,7 +89,6 @@ const header = (
 > const header = <header>
 >   <h1>Mozilla Developer Network</h1>
 > </header>;
->
 > ```
 >
 > Sin embargo, esto luce un poco raro, ya que la etiqueta [`<header>`](/es/docs/Web/HTML/Element/header) que inicia la expresión no tiene sangría en la misma posición que su correspondiente etiqueta de cierre.

--- a/files/es/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
+++ b/files/es/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
@@ -86,11 +86,11 @@ const header = (
 > Los paréntesis en el fragmento anterior no son exclusivos de JSX y no tienen ningún efecto en la aplicación. Son una señal para ti (y tu computadora) de que las múltiples líneas de código que contiene forman parte de una misma expresión. También podríamos escribir la expresión del encabezado de esta manera:
 >
 > ```jsx
-> const header = (
+> const header = 
 >   <header>
 >     <h1>Mozilla Developer Network</h1>
->   </header>
-> );
+>   </header>;
+>
 > ```
 >
 > Sin embargo, esto luce un poco raro, ya que la etiqueta [`<header>`](/es/docs/Web/HTML/Element/header) que inicia la expresión no tiene sangría en la misma posición que su correspondiente etiqueta de cierre.


### PR DESCRIPTION
### Description
On the note, the code is identical to the JSX above. When I first saw it, I found it confusing because the explanation mentioned that the code differed, but it didn't. Upon reviewing the English documentation, I discovered that the difference was in the use of parentheses.





<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I think people that arrives to the first steps on React in spanish will also be confused as me. Therefore this changes are going to help new people to understand why the use of the parenthensis in the jsx in the fastest way possible, as it is wanted for the guide itself.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
The guide and the part that I refer to is https://developer.mozilla.org/es/docs/Learn_web_development/Core/Frameworks_libraries/React_getting_started#%C2%BFc%C3%B3mo_react_usa_javascript
### Related
Couldn't find any issue or pr related to

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
