### PR TITLE
[zh-cn]: create the translation of ErrorEvent `filename` property

### DIFF
--- a/files/zh-cn/web/api/errorevent/filename/index.md
+++ b/files/zh-cn/web/api/errorevent/filename/index.md
@@ -1,0 +1,30 @@
+---
+title: ErrorEvent：filename 属性
+slug: Web/API/ErrorEvent/filename
+l10n:
+  sourceCommit: 7d6ffd01f66c97c089dc559a636516b932af5ad5
+---
+
+{{APIRef("HTML DOM")}}{{AvailableInWorkers}}
+
+{{domxref("ErrorEvent")}} 接口的 **`filename`** 只读属性返回包含发生错误的脚本文件的名称的字符串。
+
+## 值
+
+字符串
+
+## 示例
+
+```js
+window.addEventListener("error", (ev) => {
+  console.log("文件中出现错误：" + ev.filename);
+});
+```
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}

--- a/files/zh-cn/web/api/errorevent/filename/index.md
+++ b/files/zh-cn/web/api/errorevent/filename/index.md
@@ -17,7 +17,7 @@ l10n:
 
 ```js
 window.addEventListener("error", (ev) => {
-  console.log("文件中出现错误：" + ev.filename);
+  console.log("文件 " + ev.filename + " 中出现错误");
 });
 ```
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent/filename
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/errorevent/filename/index.md
* Last commit: https://github.com/mdn/content/commit/7d6ffd01f66c97c089dc559a636516b932af5ad5
