### PR TITLE
[zh-cn]: create the translation of ErrorEvent `message` property

### DIFF
--- a/files/zh-cn/web/api/errorevent/message/index.md
+++ b/files/zh-cn/web/api/errorevent/message/index.md
@@ -7,11 +7,11 @@ l10n:
 
 {{APIRef("HTML DOM")}}{{AvailableInWorkers}}
 
-{{domxref("ErrorEvent")}} 接口的 **`message`** 只读属性返回包含描述问题的易于理解的错误信息。
+{{domxref("ErrorEvent")}} 接口的 **`message`** 只读属性返回包含描述问题的人类可读的错误信息。
 
 ## 值
 
-字符串
+字符串。
 
 ## 示例
 

--- a/files/zh-cn/web/api/errorevent/message/index.md
+++ b/files/zh-cn/web/api/errorevent/message/index.md
@@ -1,0 +1,30 @@
+---
+title: ErrorEvent：message 属性
+slug: Web/API/ErrorEvent/message
+l10n:
+  sourceCommit: ac29130f454fc961f04bc9133b449771dc2f079e
+---
+
+{{APIRef("HTML DOM")}}{{AvailableInWorkers}}
+
+{{domxref("ErrorEvent")}} 接口的 **`message`** 只读属性返回包含描述问题的易于理解的错误信息。
+
+## 值
+
+字符串
+
+## 示例
+
+```js
+window.addEventListener("error", (ev) => {
+  console.log("错误消息：" + ev.message);
+});
+```
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent/message
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/errorevent/message/index.md
* Last commit: https://github.com/mdn/content/commit/ac29130f454fc961f04bc9133b449771dc2f079e
