### PR TITLE
fix(workflows): unwrap if conditions

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -39,14 +39,14 @@ jobs:
           echo "DIFF_DOCUMENTS=${DIFF_DOCUMENTS}" >> $GITHUB_ENV
 
       - name: Checkout HEAD
-        if: ${{ env.DIFF_DOCUMENTS }}
+        if: env.DIFF_DOCUMENTS
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr_head
 
       - name: Get changed content from HEAD
-        if: ${{ env.DIFF_DOCUMENTS }}
+        if: env.DIFF_DOCUMENTS
         run: |
           git config --global user.email "108879845+mdn-bot@users.noreply.github.com"
           git config --global user.name "mdn-bot"
@@ -62,13 +62,13 @@ jobs:
           git commit -m "Code from PR head"
 
       - uses: actions/checkout@v4
-        if: ${{ env.DIFF_DOCUMENTS }}
+        if: env.DIFF_DOCUMENTS
         with:
           repository: mdn/content
           path: mdn/content
 
       - name: Setup Node.js environment
-        if: ${{ env.DIFF_DOCUMENTS }}
+        if: env.DIFF_DOCUMENTS
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -78,11 +78,11 @@ jobs:
             yarn.lock
 
       - name: Install all yarn packages for mdn/translated-content
-        if: ${{ env.DIFF_DOCUMENTS }}
+        if: env.DIFF_DOCUMENTS
         run: yarn --frozen-lockfile
 
       - name: Install all yarn packages for mdn/content
-        if: ${{ env.DIFF_DOCUMENTS }}
+        if: env.DIFF_DOCUMENTS
         working-directory: ${{ github.workspace }}/mdn/content
         run: yarn --frozen-lockfile
         env:
@@ -90,7 +90,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint and format markdown files
-        if: ${{ env.DIFF_DOCUMENTS }}
+        if: env.DIFF_DOCUMENTS
         run: |
           # Generate random delimiter
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -57,13 +57,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
-        if: ${{ env.GIT_DIFF_CONTENT }} || ${{ env.GIT_DIFF_FILES }}
+        if: env.GIT_DIFF_CONTENT || env.GIT_DIFF_FILES
         with:
           repository: mdn/content
           path: mdn/content
 
       - name: Setup Node.js environment
-        if: ${{ env.GIT_DIFF_CONTENT }} || ${{ env.GIT_DIFF_FILES }}
+        if: env.GIT_DIFF_CONTENT || env.GIT_DIFF_FILES
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -71,7 +71,7 @@ jobs:
           cache-dependency-path: mdn/content/yarn.lock
 
       - name: Install all yarn packages
-        if: ${{ env.GIT_DIFF_CONTENT }} || ${{ env.GIT_DIFF_FILES }}
+        if: env.GIT_DIFF_CONTENT || env.GIT_DIFF_FILES
         working-directory: ${{ github.workspace }}/mdn/content
         run: yarn --frozen-lockfile
         env:
@@ -80,7 +80,7 @@ jobs:
 
       - name: Build changed content
         id: build-content
-        if: ${{ env.GIT_DIFF_CONTENT }}
+        if: env.GIT_DIFF_CONTENT
         env:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/files
@@ -134,7 +134,7 @@ jobs:
           echo "has_assets=true" >> "$GITHUB_OUTPUT"
 
       - name: Merge static assets with built documents
-        if: ${{ env.GIT_DIFF_CONTENT }}
+        if: env.GIT_DIFF_CONTENT
         run: |
           # Exclude the .map files, as they're used for debugging JS and CSS.
           rsync -a --exclude "*.map" ${{ github.workspace }}/mdn/content/node_modules/@mdn/yari/client/build/ ${BUILD_OUT_ROOT}
@@ -142,13 +142,13 @@ jobs:
           du -sh ${BUILD_OUT_ROOT}
 
       - uses: actions/upload-artifact@v4
-        if: ${{ env.GIT_DIFF_CONTENT }}
+        if: env.GIT_DIFF_CONTENT
         with:
           name: build
           path: ${{ env.BUILD_OUT_ROOT }}
 
       - name: Check changed files
-        if: ${{ env.GIT_DIFF_FILES }}
+        if: env.GIT_DIFF_FILES
         env:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/files
@@ -160,7 +160,7 @@ jobs:
 
   review:
     needs: tests
-    if: ${{ needs.tests.outputs.has_assets }}
+    if: needs.tests.outputs.has_assets
     # write permissions are required to create a comment in the corresponding PR
     permissions: write-all
     uses: ./.github/workflows/pr-review-companion.yml


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Unwraps several `if` conditions in workflows.

### Motivation

CodeQL reports these, as the `${{ ... }}` is unnecessary and seem to cause conditions to be evaluated to true inadvertently in some cases.

### Additional details

See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#about-expressions

> You need to use specific syntax to tell GitHub to evaluate an expression rather than treat it as a string.
>
> `${{ <expression> }}`
>
> The exception to this rule is when you are using expressions in an `if` clause, where, optionally, you can usually omit `${{` and `}}`. For more information about `if` conditionals, see [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif).

### Related issues and pull requests

Same as https://github.com/mdn/content/pull/37768.