### PR TITLE
[pt-br] Typofix for `background-attachment` page

### DIFF
--- a/files/pt-br/web/css/background-attachment/index.md
+++ b/files/pt-br/web/css/background-attachment/index.md
@@ -36,7 +36,7 @@ background-attachment: inherit;
 
 ## Exemplos
 
-### Exemplo simpes
+### Exemplo simples
 
 #### CSS
 
@@ -59,7 +59,7 @@ p {
 
 #### Resultado
 
-{{EmbedLiveSample("Exemplo_simpes")}}
+{{EmbedLiveSample("Exemplo_simples")}}
 
 ### Suporte de múltiplas imagem de background
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Fixes a typo that @leon-win noticed [in another PR](https://github.com/mdn/translated-content/pull/24765#discussion_r1909430311): `Exemplo simpes -> Exemplo simples`.

