### PR TITLE
feat(workflows): migrate pr-test to rari

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -13,6 +13,7 @@ on:
   workflow_run:
     workflows:
       - "PR Test"
+      - "PR Test Legacy"
     types:
       - completed
 

--- a/.github/workflows/pr-test-legacy.yml
+++ b/.github/workflows/pr-test-legacy.yml
@@ -1,10 +1,10 @@
 # This is more or less a copy of
-# https://github.com/mdn/content/blob/main/.github/workflows/pr-test.yml
+# https://github.com/mdn/content/blob/main/.github/workflows/pr-test-legacy.yml
 # but done in a way that it first checks out mdn/translated-content (or
 # fork of) and _then_ checks out mdn/content which has the relevant
 # CI related tooling.
 
-name: PR Test
+name: PR Test Legacy
 
 on:
   pull_request:
@@ -21,7 +21,7 @@ jobs:
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      # If we don't do this the built files may end up in
+      # If we don't do this the built files will end up in
       # `node_modules/@mdn/yari/client/build/` and we don't want that
       # to get pushed into the cache.
       BUILD_OUT_ROOT: /tmp/build
@@ -37,7 +37,7 @@ jobs:
             --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
 
           # filter out files that are not markdown files
-          GIT_DIFF_CONTENT=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.(md)$" | xargs)
+          GIT_DIFF_CONTENT=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.md$" | xargs)
           echo "GIT_DIFF_CONTENT=${GIT_DIFF_CONTENT}" >> $GITHUB_ENV
 
           # filter out files that are not attachments
@@ -101,21 +101,13 @@ jobs:
           # Playground
           REACT_APP_PLAYGROUND_BASE_HOST: mdnyalp.dev
 
-          # rari
-          LIVE_SAMPLES_BASE_URL: https://live.mdnyalp.dev
-          INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.mdn.allizom.net
         working-directory: ${{ github.workspace }}/mdn/content
         run: |
           mkdir -p $BUILD_OUT_ROOT
 
-          # The reason this script isn't in `package.json` is because
-          # you don't need that script as a writer. It's only used in CI
-          # and it can't use the default CONTENT_ROOT that gets set in
-          # package.json.
-          echo Y|yarn rari update
-          ARGS=$(echo $GIT_DIFF_CONTENT | sed -E -e "s#(^| )files#\1-f $PWD/files#g")
-          yarn rari build --no-basic --json-issues --data-issues $ARGS
-          yarn yari-render-html
+          # Don't use `yarn build` (from mdn/content) because that one hardcodes
+          # the BUILD_OUT_ROOT and CONTENT_ROOT env vars.
+          node node_modules/@mdn/yari/build/cli.js $GIT_DIFF_CONTENT
 
           echo "Disk usage size of the build"
           du -sh $BUILD_OUT_ROOT


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Migrates the `pr-test` workflow to rari.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

The existing `pr-test` workflow was renamed to `pr-test-legacy`, and disabled.

Both workflows now use the `pull_request` event, while `pr-review-companion` uses the `workflow_run` event.

### Related issues and pull requests

Related content PRs:

- https://github.com/mdn/content/pull/37572
- https://github.com/mdn/content/pull/37576
- https://github.com/mdn/content/pull/37586
- https://github.com/mdn/content/pull/37766
- https://github.com/mdn/content/pull/37771