### PR TITLE
[zh-cn]: create the translation of HTMLEmbedElement `type` property and fix HTMLEmbedElement `src` property format

### DIFF
--- a/files/zh-cn/web/api/htmlembedelement/src/index.md
+++ b/files/zh-cn/web/api/htmlembedelement/src/index.md
@@ -7,7 +7,9 @@ l10n:
 
 {{APIRef("HTML DOM")}}
 
-{{domxref("HTMLEmbedElement")}} 接口的 **`src`** 属性返回一个指示嵌入资源的 URL 字符串。它反映 {{HTMLElement("embed")}} 元素的 `src` 属性。
+{{domxref("HTMLEmbedElement")}} 接口的 **`src`** 属性返回一个指示嵌入资源的 URL 字符串。
+
+它反映 {{HTMLElement("embed")}} 元素的 `src` 属性。
 
 ## 值
 

--- a/files/zh-cn/web/api/htmlembedelement/type/index.md
+++ b/files/zh-cn/web/api/htmlembedelement/type/index.md
@@ -2,14 +2,12 @@
 title: HTMLEmbedElement：type 属性
 slug: Web/API/HTMLEmbedElement/type
 l10n:
-  sourceCommit: 64088e3a95e2cc9c8cf44d1338d0be21f1fadfed
+  sourceCommit: 27bceead8e9b1fe9c92df0fa5e418f81bd5b9fdf
 ---
 
 {{APIRef("HTML DOM")}}
 
-{{domxref("HTMLEmbedElement")}} 接口的 **`type`** 属性返回一个反映 {{HTMLElement("embed")}} 元素的 `type` 属性的字符串，用于表示资源的{{glossary("MIME type", "MIME 类型")}}。
-
-它反映 {{htmlelement("embed")}} 元素的 [`type`](/zh-CN/docs/Web/HTML/Element/embed#type) 属性。
+{{domxref("HTMLEmbedElement")}} 接口的 **`type`** 属性返回一个反映 {{HTMLElement("embed")}} 元素的 `type` 属性的字符串，用于表示资源的 {{glossary("MIME type", "MIME 类型")}}。它反映 {{htmlelement("embed")}} 元素的 [`type`](/zh-CN/docs/Web/HTML/Element/embed#type) 属性。
 
 ## 值
 
@@ -34,5 +32,5 @@ console.log(el.type); // 输出：“video/webp”
 
 - {{domxref("HTMLObjectElement.type")}}
 - {{domxref("HTMLSourceElement.type")}}
-- [Web 上常见的媒体类型](/zh-CN/docs/Web/Media/Formats)
+- [Web 上的媒体类型](/zh-CN/docs/Web/Media/Guides/Formats)
 - [对 Web 开发者至关重要的 MIME 类型](/zh-CN/docs/Web/HTTP/MIME_types#对_web_开发者至关重要的_mime_类型)

--- a/files/zh-cn/web/api/htmlembedelement/type/index.md
+++ b/files/zh-cn/web/api/htmlembedelement/type/index.md
@@ -1,0 +1,38 @@
+---
+title: HTMLEmbedElement：type 属性
+slug: Web/API/HTMLEmbedElement/type
+l10n:
+  sourceCommit: 64088e3a95e2cc9c8cf44d1338d0be21f1fadfed
+---
+
+{{APIRef("HTML DOM")}}
+
+{{domxref("HTMLEmbedElement")}} 接口的 **`type`** 属性返回一个反映 {{HTMLElement("embed")}} 元素的 `type` 属性的字符串，用于表示资源的{{glossary("MIME type", "MIME 类型")}}。
+
+它反映 {{htmlelement("embed")}} 元素的 [`type`](/zh-CN/docs/Web/HTML/Element/embed#type) 属性。
+
+## 值
+
+一个字符串，表示资源的 MIME 类型。
+
+## 示例
+
+```js
+const el = document.getElementById("el");
+console.log(el.type); // 输出：“video/webp”
+```
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- {{domxref("HTMLObjectElement.type")}}
+- {{domxref("HTMLSourceElement.type")}}
+- [Web 上常见的媒体类型](/zh-CN/docs/Web/Media/Formats)
+- [对 Web 开发者至关重要的 MIME 类型](/zh-CN/docs/Web/HTTP/MIME_types#对_web_开发者至关重要的_mime_类型)


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/HTMLEmbedElement/src
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/HTMLEmbedElement/type
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/htmlembedelement/type/index.md
* Last commit: https://github.com/mdn/content/commit/64088e3a95e2cc9c8cf44d1338d0be21f1fadfed

* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/htmlembedelement/src/index.md
* Last commit: https://github.com/mdn/content/commit/a0460b9c26f5ad9b8bbc9cc569f4fdd8058aec8f
