### PR TITLE
[zh-cn]: create the translation of HTMLEmbedElement `getSVGDocument()` method

### DIFF
--- a/files/zh-cn/web/api/htmlembedelement/getsvgdocument/index.md
+++ b/files/zh-cn/web/api/htmlembedelement/getsvgdocument/index.md
@@ -1,0 +1,33 @@
+---
+title: HTMLEmbedElement：getSVGDocument() 方法
+slug: Web/API/HTMLEmbedElement/getSVGDocument
+l10n:
+  sourceCommit: 64088e3a95e2cc9c8cf44d1338d0be21f1fadfed
+---
+
+{{APIRef("HTML DOM")}}
+
+{{domxref("HTMLEmbedElement")}} 接口的 **`getSVGDocument()`** 方法返回嵌入的 SVG 的 {{domxref("Document")}} 对象。
+
+## 值
+
+{{domxref("Document")}}。
+
+## 示例
+
+```js
+const svg = document.getElementById("el").getSVGDocument();
+```
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- {{domxref("HTMLIFrameElement.getSVGDocument")}}
+- {{domxref("HTMLObjectElement.getSVGDocument")}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/HTMLEmbedElement/getSVGDocument
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/htmlembedelement/getsvgdocument/index.md
* Last commit: https://github.com/mdn/content/commit/64088e3a95e2cc9c8cf44d1338d0be21f1fadfed
