### PR TITLE
[zh-cn]: update the translation of Navigator introduction and Navigator `globalPrivacyControl` property

### DIFF
--- a/files/zh-cn/web/api/navigator/globalprivacycontrol/index.md
+++ b/files/zh-cn/web/api/navigator/globalprivacycontrol/index.md
@@ -2,10 +2,10 @@
 title: Navigator：globalPrivacyControl 属性
 slug: Web/API/Navigator/globalPrivacyControl
 l10n:
-  sourceCommit: ec4de01e84cb892379c9130d6fbff1e2abc4f486
+  sourceCommit: c1fd7dc9410c14ec9e00b3ec35b7b94d43296389
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}{{non-standard_header}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 **`Navigator.globalPrivacyControl`** 只读属性返回用户对当前网站的[全球隐私控制](https://globalprivacycontrol.org/)设置。此设置指示用户是否同意网站或服务将其个人信息出售或共享给第三方。
 

--- a/files/zh-cn/web/api/navigator/index.md
+++ b/files/zh-cn/web/api/navigator/index.md
@@ -72,7 +72,7 @@ _不继承任何属性_。
 - {{domxref("Navigator.scheduling")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : 返回一个当前文档的 {{domxref("Scheduling")}} 对象。
 - {{domxref("Navigator.serial")}} {{ReadOnlyInline}} {{Experimental_Inline}} {{SecureContext_Inline}}
-  - : 返回一个 {{domxref("Serial")}} 对象，代表了进入 [Web Serial API](/zh-CN/docs/Web/API/Web_Serial_API) 的入口点，用于控制串行端口。
+  - : 返回一个 {{domxref("Serial")}} 对象，代表了 [Web Serial API](/zh-CN/docs/Web/API/Web_Serial_API) 的入口点，用于控制串行端口。
 - {{domxref("Navigator.serviceWorker")}} {{ReadOnlyInline}} {{SecureContext_Inline}}
   - : 返回一个 {{domxref("ServiceWorkerContainer")}} 对象，它提供了注册、移除、升级以及与[相关文档](https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window)的 {{domxref("ServiceWorker")}} 对象进行通信的功能。
 - {{domxref("Navigator.storage")}} {{ReadOnlyInline}} {{SecureContext_Inline}}
@@ -94,7 +94,7 @@ _不继承任何属性_。
 - {{domxref("Navigator.windowControlsOverlay")}} {{ReadOnlyInline}} {{SecureContext_Inline}}
   - : 返回 {{domxref("WindowControlsOverlay")}} 接口，该接口暴露了桌面渐进式 Web 应用程序标题栏的几何信息，以及在标题栏发生变化时触发的事件。
 - {{domxref("Navigator.xr")}} {{ReadOnlyInline}} {{Experimental_Inline}} {{SecureContext_Inline}}
-  - : 返回 {{domxref("XRSystem")}} 对象，它代表了进入 [WebXR API](/zh-CN/docs/Web/API/WebXR_Device_API) 的入口点。
+  - : 返回 {{domxref("XRSystem")}} 对象，它代表了 [WebXR API](/zh-CN/docs/Web/API/WebXR_Device_API) 的入口点。
 
 ### 非标准的属性
 

--- a/files/zh-cn/web/api/navigator/index.md
+++ b/files/zh-cn/web/api/navigator/index.md
@@ -141,7 +141,7 @@ _不继承任何方法_。
 - {{domxref("Navigator.clearAppBadge()")}} {{SecureContext_Inline}}
   - : 清除当前应用图标的徽标，并返回一个兑现为 {{jsxref("undefined")}} 的 {{jsxref("Promise")}} 对象。
 - {{domxref("Navigator.deprecatedReplaceInURN()")}} {{Experimental_Inline}}
-  - : 针对给定的不透明 URN 或 `FencedFrameConfig` 的内部 `url` 属性，在映射 URL 中替换指定字符串。此方法作为临时措施（标记为“已弃用”）提供，以支持对围栏框架 URL 执行此类替换，帮助广告技术提供商将现有的实现迁移到[隐私沙盒](https://developers.google.cn/privacy-sandbox?hl=zh-cn) API。
+  - : 针对给定的不透明 URN 或 `FencedFrameConfig` 的内部 `url` 属性，在映射 URL 中替换指定字符串。此方法作为临时措施（标记为“已弃用”）提供，以支持对围栏框架 URL 执行此类替换，帮助广告技术提供商将现有的实现迁移到[隐私沙盒](https://developers.google.cn/privacy-sandbox) API。
 - {{domxref("Navigator.getAutoplayPolicy()")}} {{Experimental_Inline}}
   - : 返回一个值，表示指定的媒体元素、音频上下文或媒体特性“类型”是否允许自动播放。
 - {{domxref("Navigator.getBattery()")}} {{SecureContext_Inline}}

--- a/files/zh-cn/web/api/navigator/index.md
+++ b/files/zh-cn/web/api/navigator/index.md
@@ -2,7 +2,7 @@
 title: Navigator
 slug: Web/API/Navigator
 l10n:
-  sourceCommit: 8bb6752a4d3ed3d54ab681636d16602e6bf1d74d
+  sourceCommit: c1fd7dc9410c14ec9e00b3ec35b7b94d43296389
 ---
 
 {{APIRef("DOM")}}
@@ -70,7 +70,7 @@ _不继承任何属性_。
 - {{domxref("Navigator.scheduling")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : 返回一个当前文档的 {{domxref("Scheduling")}} 对象。
 - {{domxref("Navigator.serial")}} {{ReadOnlyInline}} {{Experimental_Inline}} {{SecureContext_Inline}}
-  - : 返回一个 {{domxref("Serial")}} 对象，代表了进入 {{domxref("Web Serial API")}} 的入口点，用于控制串行端口。
+  - : 返回一个 {{domxref("Serial")}} 对象，代表了进入 [Web Serial API](/zh-CN/docs/Web/API/Web_Serial_API) 的入口点，用于控制串行端口。
 - {{domxref("Navigator.serviceWorker")}} {{ReadOnlyInline}} {{SecureContext_Inline}}
   - : 返回一个 {{domxref("ServiceWorkerContainer")}} 对象，它提供了注册、移除、升级以及与[相关文档](https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window)的 {{domxref("ServiceWorker")}} 对象进行通信的功能。
 - {{domxref("Navigator.storage")}} {{ReadOnlyInline}} {{SecureContext_Inline}}
@@ -106,7 +106,7 @@ _不继承任何属性_。
 ### 已弃用的属性
 
 - {{domxref("Navigator.activeVRDisplays")}} {{ReadOnlyInline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
-  - : 返回一个包含所有当前正在呈现（{{domxref("VRDisplay.ispresenting")}} 为 `true`）的 {{domxref("VRDisplay")}} 对象的数组。
+  - : 返回一个包含所有当前正在呈现（{{domxref("VRDisplay.isPresenting")}} 为 `true`）的 {{domxref("VRDisplay")}} 对象的数组。
 - {{domxref("Navigator.appCodeName")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : 在任何浏览器中始终返回 `'Mozilla'`。
 - {{domxref("Navigator.appName")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
@@ -141,7 +141,7 @@ _不继承任何方法_。
 - {{domxref("Navigator.clearAppBadge()")}} {{SecureContext_Inline}}
   - : 清除当前应用图标的徽标，并返回一个兑现为 {{jsxref("undefined")}} 的 {{jsxref("Promise")}} 对象。
 - {{domxref("Navigator.deprecatedReplaceInURN()")}} {{Experimental_Inline}}
-  - : 针对给定的不透明 URN 或 `FencedFrameConfig` 的内部 `url` 属性，在映射 URL 中替换指定字符串。此方法作为临时措施（标记为“已弃用”）提供，以支持对围栏框架 URL 执行此类替换，帮助广告技术提供商将现有的实现迁移到[隐私沙盒](https://developer.google.com/privacy-sandbox) API。
+  - : 针对给定的不透明 URN 或 `FencedFrameConfig` 的内部 `url` 属性，在映射 URL 中替换指定字符串。此方法作为临时措施（标记为“已弃用”）提供，以支持对围栏框架 URL 执行此类替换，帮助广告技术提供商将现有的实现迁移到[隐私沙盒](https://developers.google.cn/privacy-sandbox?hl=zh-cn) API。
 - {{domxref("Navigator.getAutoplayPolicy()")}} {{Experimental_Inline}}
   - : 返回一个值，表示指定的媒体元素、音频上下文或媒体特性“类型”是否允许自动播放。
 - {{domxref("Navigator.getBattery()")}} {{SecureContext_Inline}}

--- a/files/zh-cn/web/api/navigator/index.md
+++ b/files/zh-cn/web/api/navigator/index.md
@@ -31,6 +31,8 @@ _不继承任何属性_。
   - : 返回 {{domxref("CredentialsContainer")}} 接口，该接口暴露了请求凭据及在成功登录或注销等重要事件发生时通知用户代理的方法。
 - {{domxref("Navigator.deviceMemory")}} {{ReadOnlyInline}} {{SecureContext_Inline}}
   - : 返回设备内存的近似值。该值通过向下取整到最接近的 2 的幂，然后将其除以 1024 来近似。
+- {{domxref("Navigator.devicePosture")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : 返回浏览器的 {{domxref("DevicePosture")}} 对象，允许开发者查询设备当前的姿态（即视口是处于平放还是折叠状态），并在姿态变化时执行相应的代码。
 - {{domxref("Navigator.geolocation")}} {{ReadOnlyInline}}
   - : 返回一个 {{domxref("Geolocation")}} 对象，用于访问设备的位置。
 - {{domxref("Navigator.gpu")}} {{ReadOnlyInline}} {{Experimental_Inline}} {{SecureContext_Inline}}
@@ -98,7 +100,7 @@ _不继承任何属性_。
 
 - {{domxref("Navigator.buildID")}} {{ReadOnlyInline}} {{Non-standard_Inline}}
   - : 返回浏览器的构建标识符。在现代浏览器中，为了保护隐私，该属性现在返回一个固定的时间戳，例如 Firefox 64 及更高版本中返回 `20181001000000`。
-- {{domxref("Navigator.globalPrivacyControl")}} {{ReadOnlyInline}} {{Experimental_Inline}} {{non-standard_inline}}
+- {{domxref("Navigator.globalPrivacyControl")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : 返回一个布尔值，表示用户是否同意共享或出售他们的信息。
 - {{domxref("Navigator.standalone")}} {{Non-standard_Inline}}
   - : 返回一个布尔值，表示浏览器是否以独立模式运行。仅在 Apple 的 iOS Safari 上可用。

--- a/files/zh-cn/web/api/navigator/index.md
+++ b/files/zh-cn/web/api/navigator/index.md
@@ -2,7 +2,7 @@
 title: Navigator
 slug: Web/API/Navigator
 l10n:
-  sourceCommit: c1fd7dc9410c14ec9e00b3ec35b7b94d43296389
+  sourceCommit: a3d19af7e3eeb1c40748c80cd6b5143cfa201c54
 ---
 
 {{APIRef("DOM")}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/Navigator
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/globalPrivacyControl
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/navigator/index.md
* Last commit: https://github.com/mdn/content/commit/c1fd7dc9410c14ec9e00b3ec35b7b94d43296389

* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/navigator/globalprivacycontrol/index.md
* Last commit: https://github.com/mdn/content/commit/c1fd7dc9410c14ec9e00b3ec35b7b94d43296389