### PR TITLE
[zh-cn]: create the translation of BluetoothDevice `gatt` property

### DIFF
--- a/files/zh-cn/web/api/bluetoothdevice/gatt/index.md
+++ b/files/zh-cn/web/api/bluetoothdevice/gatt/index.md
@@ -1,0 +1,22 @@
+---
+title: BluetoothDevice：gatt 属性
+slug: Web/API/BluetoothDevice/gatt
+l10n:
+  sourceCommit: 89c435da452257b944b403cc9e45036fcb22590e
+---
+
+{{APIRef("Bluetooth API") }}{{SeeCompatTable}}{{SecureContext_Header}}
+
+**`BluetoothDevice.gatt`** 只读属性返回对设备的 {{DOMxRef("BluetoothRemoteGATTServer")}} 的引用。
+
+## 值
+
+对设备的 {{DOMxRef("BluetoothRemoteGATTServer")}} 的引用。
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}

--- a/files/zh-cn/web/api/bluetoothdevice/gatt/index.md
+++ b/files/zh-cn/web/api/bluetoothdevice/gatt/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: 89c435da452257b944b403cc9e45036fcb22590e
 ---
 
-{{APIRef("Bluetooth API") }}{{SeeCompatTable}}{{SecureContext_Header}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 **`BluetoothDevice.gatt`** 只读属性返回对设备的 {{DOMxRef("BluetoothRemoteGATTServer")}} 的引用。
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/BluetoothDevice/gatt
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/bluetoothdevice/gatt/index.md
* Last commit: https://github.com/mdn/content/commit/89c435da452257b944b403cc9e45036fcb22590e
