### PR TITLE
[zh-cn]: update the translation of HTTP `508` status

### DIFF
--- a/files/zh-cn/web/http/status/508/index.md
+++ b/files/zh-cn/web/http/status/508/index.md
@@ -1,20 +1,56 @@
 ---
 title: 508 Loop Detected
 slug: Web/HTTP/Status/508
+l10n:
+  sourceCommit: f584f1b27f9f3b78c95122c560f5135866a87eb0
 ---
 
 {{HTTPSidebar}}
 
-HTTP 协议的 **`508 Loop Detected`** 状态码可以在 WebDAV 协议（基于 Web 的分布式创作和版本控制）中给出。
+HTTP **`508 Loop Detected`** [客户端错误响应](/zh-CN/docs/Web/HTTP/Status#客户端错误响应)状态码表示整个操作失败，因为它在处理带有 `Depth: infinity` 的请求时遇到了无限循环。
 
-508 码表示服务器中断一个操作，因为它在处理具有“Depth: infinity”的请求时遇到了一个无限循环。508 码表示整个操作失败。
+该状态码可能出现在 Web 分布式创作和版本控制（{{Glossary("WebDAV")}}）的上下文中。它被引入作为 WebDAV 客户端不支持 {{HTTPStatus("208", "208 Already Reported")}} 响应（当请求未明确包含 `DAV` 标头时）的备用方案。
 
-## Status
+## 状态
 
-```plain
+```http
 508 Loop Detected
 ```
 
-## Specifications
+## 示例
+
+### WebDAV 搜索中的无限循环
+
+```http
+PROPFIND /Coll/ HTTP/1.1
+Host: example.com
+Depth: infinity
+Content-Type: application/xml; charset="utf-8"
+Content-Length: 125
+
+<?xml version="1.0" encoding="utf-8" ?>
+<D:propfind xmlns:D="DAV:">
+  <D:prop> <D:displayname/> </D:prop>
+</D:propfind>
+```
+
+```http
+HTTP/1.1 508 Loop Detected
+Content-Type: application/json; charset=utf-8
+Server: Microsoft-IIS/8.0
+Date: Wed, 15 May 2013 02:38:57 GMT
+Content-Length: 72
+
+{
+  "Message": "请检查资源是否存在循环引用，然后重试。"
+}
+```
+
+## 规范
 
 {{Specifications}}
+
+## 参见
+
+- [HTTP 响应状态码](/zh-CN/docs/Web/HTTP/Status)
+- {{HTTPStatus("208", "208 Already Reported")}}

--- a/files/zh-cn/web/http/status/508/index.md
+++ b/files/zh-cn/web/http/status/508/index.md
@@ -7,9 +7,9 @@ l10n:
 
 {{HTTPSidebar}}
 
-HTTP **`508 Loop Detected`** [客户端错误响应](/zh-CN/docs/Web/HTTP/Status#客户端错误响应)状态码表示整个操作失败，因为它在处理带有 `Depth: infinity` 的请求时遇到了无限循环。
+HTTP **`508 Loop Detected`** [服务端错误响应](/zh-CN/docs/Web/HTTP/Status#服务端错误响应)状态码表示整个操作失败，因为它在处理带有 `Depth: infinity` 的请求时遇到了无限循环。
 
-该状态码可能出现在 Web 分布式创作和版本控制（{{Glossary("WebDAV")}}）的上下文中。它被引入作为 WebDAV 客户端不支持 {{HTTPStatus("208", "208 Already Reported")}} 响应（当请求未明确包含 `DAV` 标头时）的备用方案。
+该状态码可能出现在基于 Web 的分布式编写与版本控制（{{Glossary("WebDAV")}}）的上下文中。它被引入作为 WebDAV 客户端不支持 {{HTTPStatus("208", "208 Already Reported")}} 响应（当请求未显式包含 `DAV` 标头时）的备用方案。
 
 ## 状态
 

--- a/files/zh-cn/web/http/status/508/index.md
+++ b/files/zh-cn/web/http/status/508/index.md
@@ -2,7 +2,7 @@
 title: 508 Loop Detected
 slug: Web/HTTP/Status/508
 l10n:
-  sourceCommit: f584f1b27f9f3b78c95122c560f5135866a87eb0
+  sourceCommit: e626fb706bfef0d496f0a209554f80a2d9313c0c
 ---
 
 {{HTTPSidebar}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/508
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/http/status/508/index.md
* Last commit: https://github.com/mdn/content/commit/f584f1b27f9f3b78c95122c560f5135866a87eb0

