### PR TITLE
fix(workflows/pr-check_redirects): validate with `content:legacy`

### DIFF
--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -57,4 +57,4 @@ jobs:
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/files
         working-directory: ${{ github.workspace }}/mdn/content
         run: |
-          yarn content validate-redirects --strict
+          yarn content:legacy validate-redirects --strict


### PR DESCRIPTION
### Description

Validate redirects with `content:legacy` for now.

### Motivation

The subcommand is not yet implemented in rari.

### Additional details

Reported by @bsmth via Discord.

### Related issues and pull requests

Same as https://github.com/mdn/content/pull/37822.

See: https://github.com/mdn/rari/issues/103