### PR TITLE
chore: remove reference to polyfill

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/string/padend/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/padend/index.md
@@ -42,7 +42,6 @@ Uma {{jsxref("String")}} cuja composição vem da string original, completada po
 Rodando o seguinte código antes de qualquer código irá criar o método `String.prototype.padEnd()` caso ele não esteja disponível nativamente:
 
 ```js
-// https://github.com/uxitten/polyfill/blob/master/string.polyfill.js
 // https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd
 if (!String.prototype.padEnd) {
   String.prototype.padEnd = function padEnd(targetLength, padString) {

--- a/files/pt-br/web/javascript/reference/global_objects/string/padstart/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/padstart/index.md
@@ -43,7 +43,6 @@ Uma {{jsxref("String")}} de comprimento específico com uma string de preenchime
 Ao executar o seguinte código antes de qualquer outro código é criado o método `String.prototype.padStart()`, em casos onde ele não está disponível nativamente:
 
 ```js
-// https://github.com/uxitten/polyfill/blob/master/string.polyfill.js
 // https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/String/padStart
 if (!String.prototype.padStart) {
   String.prototype.padStart = function padStart(targetLength, padString) {

--- a/files/ru/web/javascript/reference/global_objects/string/padstart/index.md
+++ b/files/ru/web/javascript/reference/global_objects/string/padstart/index.md
@@ -39,7 +39,6 @@ str.padStart(targetLength [, padString])
 Запуск данного кода перед любым другим кодом будет создавать `String.prototype.padStart()`, если он нативно не поддерживается.
 
 ```js
-// https://github.com/uxitten/polyfill/blob/master/string.polyfill.js
 // https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/String/padStart
 if (!String.prototype.padStart) {
   String.prototype.padStart = function padStart(targetLength, padString) {


### PR DESCRIPTION
### Description

Polyfill repository doesn't exist anymore and padEnd/Start is baseline by now.

### Motivation

We had this flagged as it links to removed github account and this could be maliciously taken over.