### PR TITLE
fix(ci): use rari from npm

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -112,7 +112,6 @@ jobs:
           # you don't need that script as a writer. It's only used in CI
           # and it can't use the default CONTENT_ROOT that gets set in
           # package.json.
-          echo Y|yarn rari update
           ARGS=$(echo $GIT_DIFF_CONTENT | sed -E -e "s#(^| )files#\1-f $CONTENT_TRANSLATED_ROOT#g")
           yarn rari build --no-basic --json-issues --data-issues $ARGS
           yarn yari-render-html


### PR DESCRIPTION
### Description

CI is failing during noop rari update: https://github.com/mdn/content/actions/runs/13037975468/job/36374540346?pr=37158#step:6:45

Downstreams:

- [x] https://github.com/mdn/content/pull/37870