### PR TITLE
[zh-cn]: update the translation of svg `<g>` element

### DIFF
--- a/files/zh-cn/web/svg/element/g/index.md
+++ b/files/zh-cn/web/svg/element/g/index.md
@@ -1,55 +1,45 @@
 ---
-title: g
+title: <g>
 slug: Web/SVG/Element/g
+l10n:
+  sourceCommit: 2f43f506240fa6c866cc3bc2d018364ae49421d9
 ---
 
 {{SVGRef}}
 
-元素`g`是用来组合对象的容器。添加到`g`元素上的变换会应用到其所有的子元素上。添加到`g`元素的属性会被其所有的子元素继承。此外，`g`元素也可以用来定义复杂的对象，之后可以通过{{SVGElement("use")}}元素来引用它们。
+**`<g>`** [SVG](/zh-CN/docs/Web/SVG) 元素是一个容器，用于将其他 SVG 元素进行分组。
+
+对 `<g>` 元素应用的变换会作用于其子元素，并且其属性会被子元素继承。它还可以将多个元素分组，以便后续通过 {{SVGElement("use")}} 元素引用。
+
+## 示例
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- 使用 g 继承呈现属性 -->
+  <g fill="white" stroke="green" stroke-width="5">
+    <circle cx="40" cy="40" r="25" />
+    <circle cx="60" cy="60" r="25" />
+  </g>
+</svg>
+```
+
+{{EmbedLiveSample('示例', 100, '100%')}}
 
 ## 使用上下文
 
 {{svginfo}}
 
-## 示例
+## 规范
 
-```html
-<svg
-  width="100%"
-  height="100%"
-  viewBox="0 0 95 50"
-  xmlns="http://www.w3.org/2000/svg">
-  <g stroke="green" fill="white" stroke-width="5">
-    <circle cx="25" cy="25" r="15" />
-    <circle cx="40" cy="25" r="15" />
-    <circle cx="55" cy="25" r="15" />
-    <circle cx="70" cy="25" r="15" />
-  </g>
-</svg>
-```
-
-{{EmbedLiveSample("示例",220,130)}}
-
-## 属性
-
-### 全局属性
-
-- [条件处理属性](/zh-CN/docs/Web/SVG/Attribute#conditionalproccessing) »
-- [核心属性](/zh-CN/docs/Web/SVG/Attribute#core) »
-- [图形事件属性](/zh-CN/docs/Web/SVG/Attribute#graphicalevent) »
-- [外观属性](/zh-CN/docs/Web/SVG/Attribute#presentation) »
-- {{SVGAttr("class")}}
-- {{SVGAttr("style")}}
-- {{SVGAttr("externalResourcesRequired")}}
-- {{SVGAttr("transform")}}
-
-### 专有属性
-
-_没有专有属性。_
-
-## DOM 接口
-
-该元素实现了 `SVGGElement` 的所有接口。
+{{Specifications}}
 
 ## 浏览器兼容性
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/svg/element/g/index.md
* Last commit: https://github.com/mdn/content/commit/2f43f506240fa6c866cc3bc2d018364ae49421d9
