### PR TITLE
fix(workflows/pr-check_redirects): validate with rari

### DIFF
--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -57,4 +57,4 @@ jobs:
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/files
         working-directory: ${{ github.workspace }}/mdn/content
         run: |
-          yarn content:legacy validate-redirects --strict
+          yarn content validate-redirects --strict

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -57,4 +57,4 @@ jobs:
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/files
         working-directory: ${{ github.workspace }}/mdn/content
         run: |
-          yarn content validate-redirects --strict
+          yarn content validate-redirects


### PR DESCRIPTION
Reverts mdn/translated-content#25629 and removes the no longer supported `--strict` option.