### PR TITLE
[zh-cn]: update the translation of SVG `<set>` element

### DIFF
--- a/files/zh-cn/web/svg/element/set/index.md
+++ b/files/zh-cn/web/svg/element/set/index.md
@@ -46,8 +46,7 @@ svg {
 ## 属性
 
 - {{SVGAttr("to")}}
-  - : This attribute defines the value to be applied to the target attribute for the duration of the animation. The value must match the requirements of the target attribute.
-    _值类型_：[**\<anything>**](/zh-CN/docs/Web/SVG/Content_type#anything)；_默认值_：无；_动画性_：**否**
+  - : 此属性定义了在动画持续时间内应用于目标属性的值。该值必须符合目标属性的要求。_值类型_：[**\<anything>**](/zh-CN/docs/Web/SVG/Content_type#anything)；_默认值_：无；_动画性_：**否**
 
 ## 使用上下文
 

--- a/files/zh-cn/web/svg/element/set/index.md
+++ b/files/zh-cn/web/svg/element/set/index.md
@@ -1,38 +1,68 @@
 ---
-title: set
+title: <set>
 slug: Web/SVG/Element/set
+l10n:
+  sourceCommit: da99ca19ae62059f81dbee3f7b4919de784f3510
 ---
 
 {{SVGRef}}
 
-`set`元素可以用来设定一个属性值，并为该值赋予一个持续时间。它支持所有的属性类型，包括那些原理上不能插值的，例如值为字符串和布尔类型的属性。set 元素是非叠加的。无法在其上使用 additive 属性或 accumulate 属性，即使声明了这些属性也会自动被忽略。
+**`<set>`** [SVG](/zh-CN/docs/Web/SVG) 元素提供了一种在指定时间内设置属性值的方法。
+
+它支持所有属性类型，包括那些无法合理插值的类型，例如字符串和布尔值。对于可以合理插值的属性，通常更推荐使用 {{SVGElement('animate')}}。
+
+> **备注：** `<set>` 元素是非累加性的。{{SVGAttr('additive')}} 和 {{SVGAttr('accumulate')}} 属性不被允许，如果指定了这些属性，将会被忽略。
+
+## 示例
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    rect {
+      cursor: pointer;
+    }
+    .round {
+      rx: 5px;
+      fill: green;
+    }
+  </style>
+
+  <rect id="me" width="10" height="10">
+    <set attributeName="class" to="round" begin="me.click" dur="2s" />
+  </rect>
+</svg>
+```
+
+{{EmbedLiveSample('示例', 150, '100%')}}
+
+## 属性
+
+- {{SVGAttr("to")}}
+  - : This attribute defines the value to be applied to the target attribute for the duration of the animation. The value must match the requirements of the target attribute.
+    _值类型_：[**\<anything>**](/zh-CN/docs/Web/SVG/Content_type#anything)；_默认值_：无；_动画性_：**否**
 
 ## 使用上下文
 
 {{svginfo}}
 
-## 示例
+## 规范
 
-## 属性
+{{Specifications}}
 
-### 全局属性
+## 浏览器兼容性
 
-- [条件处理属性](/zh-CN/docs/SVG/Attribute#conditionalproccessing) »
-- [核心属性](/zh-CN/docs/SVG/Attribute#core) »
-- [动画事件属性](/zh-CN/docs/SVG/Attribute#animationevent) »
-- [Xlink 属性](/zh-CN/docs/SVG/Attribute#xlink) »
-- [动画属性目标属性](/zh-CN/docs/SVG/Attribute#animationattributetarget) »
-- [动画定时属性](/zh-CN/docs/SVG/Attribute#animationtiming) »
-- {{ SVGAttr("externalResourcesRequired") }}
-
-### 专有属性
-
-- {{ SVGAttr("to") }}
-
-## DOM 接口
-
-该元素实现了 [`SVGSetElement`](/zh-CN/docs/DOM/SVGSetElement) 接口。
+{{Compat}}
 
 ## 参见
 
-- {{ SVGElement("animate") }}
+- {{SVGAttr("attributeName")}} 属性
+- [动画时间属性](/zh-CN/docs/Web/SVG/Attribute#动画时间属性)，包括 {{SVGAttr("begin")}}、{{SVGAttr("dur")}}、{{SVGAttr("end")}}、{{SVGAttr("min")}}、{{SVGAttr("max")}}、{{SVGAttr("restart")}}、{{SVGAttr("repeatCount")}}、{{SVGAttr("repeatDur")}} 和 {{SVGAttr("fill")}}。
+- {{SVGElement("animate")}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/set
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/svg/element/set/index.md
* Last commit: https://github.com/mdn/content/commit/da99ca19ae62059f81dbee3f7b4919de784f3510


