### PR TITLE
fix(workflows/pr-review-companion): grant `issues: write` permission

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -18,7 +18,10 @@ on:
       - completed
 
 permissions:
+  # Required to download artifact.
   actions: read
+  # Required to post comment.
+  issues: write
 
 jobs:
   review:


### PR DESCRIPTION
### Description

Grants the `pr-review-companion` workflow the `issues: write` permission.

### Motivation

This permission is needed to post a comment.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixup for:

- https://github.com/mdn/translated-content/pull/25750