### PR TITLE
fix(workflows/pr-review-companion): grant pull-requests: write

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -21,7 +21,7 @@ permissions:
   # Required to download artifact.
   actions: read
   # Required to post comment.
-  issues: write
+  pull-requests: write
 
 jobs:
   review:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Grants the `pr-review-companion` workflow the `pull-requests: write` permission.

### Motivation

This permission is needed to post a comment _on a pull request_.

### Additional details


### Related issues and pull requests

Fixup for:

- https://github.com/mdn/translated-content/pull/25750
- https://github.com/mdn/translated-content/pull/25769
