### PR TITLE
[zh-cn]: update the translation of SVG `<glyphRef>` element

### DIFF
--- a/files/zh-cn/web/svg/element/glyphref/index.md
+++ b/files/zh-cn/web/svg/element/glyphref/index.md
@@ -1,11 +1,13 @@
 ---
-title: glyphRef
+title: <glyphRef>
 slug: Web/SVG/Element/glyphRef
+l10n:
+  sourceCommit: da99ca19ae62059f81dbee3f7b4919de784f3510
 ---
 
 {{SVGRef}}{{deprecated_header}}
 
-`glyphRef` 元素为引用的 `<altGlyph>` 替代物提供了一个唯一可能的字形。
+**`<glyphRef>`** [SVG](/zh-CN/docs/Web/SVG) 元素为引用的 `<altGlyph>` 替换提供了一个可能的字形。
 
 ## 使用上下文
 
@@ -13,27 +15,21 @@ slug: Web/SVG/Element/glyphRef
 
 ## 属性
 
-### 全局属性
-
-- [核心属性](/zh-CN/docs/Web/SVG/Attribute#核心属性)
-- [表现属性](/zh-CN/docs/Web/SVG/Attribute#表现属性)
-- [XLink 属性](/zh-CN/docs/Web/SVG/Attribute#xlink_属性)
-- {{ SVGAttr("class") }}
-- {{ SVGAttr("style") }}
-
-### 专有属性
-
 - {{SVGAttr("x")}} {{Deprecated_Inline}}
 - {{SVGAttr("y")}} {{Deprecated_Inline}}
 - {{SVGAttr("dx")}} {{Deprecated_Inline}}
 - {{SVGAttr("dy")}} {{Deprecated_Inline}}
 - {{SVGAttr("glyphRef")}} {{Deprecated_Inline}}
 - {{SVGAttr("format")}} {{Deprecated_Inline}}
-- {{SVGAttr("xlink:href")}}
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
 
 ## DOM 接口
 
-该元素实现了 [`SVGGlyphRefElement`](/zh-CN/docs/DOM/SVGGlyphRefElement) 接口。
+该元素实现了 [`SVGGlyphRefElement`](/zh-CN/docs/Web/API/SVGGlyphRefElement) 接口。
+
+## 规范
+
+{{Specifications}}
 
 ## 浏览器兼容性
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/glyphRef
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/svg/element/glyphref/index.md
* Last commit: https://github.com/mdn/content/commit/da99ca19ae62059f81dbee3f7b4919de784f3510
