### PR TITLE
[zh-CN]: Sync translation for `MessagePort.{message, messageerror}_event`

### DIFF
--- a/files/zh-cn/web/api/messageport/message_event/index.md
+++ b/files/zh-cn/web/api/messageport/message_event/index.md
@@ -2,12 +2,12 @@
 title: MessagePort：message 事件
 slug: Web/API/MessagePort/message_event
 l10n:
-  sourceCommit: e4c0939929e1b3e1fa3fd3da82b827fca3ed4c79
+  sourceCommit: ec8d6cfcaae740f7dfad264b797eebe448085a2b
 ---
 
 {{APIRef("Channel Messaging API")}} {{AvailableInWorkers}}
 
-当有消息到达该 channel 时，{{domxref('MessagePort')}} 对象上会触发 **`message`** 事件。
+{{domxref('MessagePort')}} 对象上的 **`message`** 事件在有消息到达该消息频道时触发。
 
 此事件不可取消，也不会冒泡。
 
@@ -23,7 +23,7 @@ onmessage = (event) => {};
 
 ## 事件类型
 
-一个 {{domxref("MessageEvent")}}。继承于 {{domxref("Event")}}。
+一个 {{domxref("MessageEvent")}}。继承自 {{domxref("Event")}}。
 
 {{InheritanceDiagram("MessageEvent")}}
 
@@ -40,7 +40,7 @@ _此接口还继承了其父接口 {{domxref("Event")}} 的属性。_
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
   - : 一个 `MessageEventSource`（可以是 {{glossary("WindowProxy")}}、{{domxref("MessagePort")}} 或 {{domxref("ServiceWorker")}} 对象），表示消息发送者。
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
-  - : 一个 {{domxref("MessagePort")}} 对象数组，表示与消息通过的 channel 关联的端口（在适当的情况下，例如在 channel 消息传递或向 shared worker 发送消息时）。
+  - : 一个按顺序包含随消息发送的所有 {{domxref("MessagePort")}} 对象的数组。
 
 ## 示例
 
@@ -99,4 +99,4 @@ window.addEventListener("message", (event) => {
 ## 参见
 
 - 相关事件：[`messageerror`](/zh-CN/docs/Web/API/MessagePort/messageerror_event)
-- [使用 channel messaging](/zh-CN/docs/Web/API/Channel_Messaging_API/Using_channel_messaging)
+- [使用频道传递消息](/zh-CN/docs/Web/API/Channel_Messaging_API/Using_channel_messaging)

--- a/files/zh-cn/web/api/messageport/messageerror_event/index.md
+++ b/files/zh-cn/web/api/messageport/messageerror_event/index.md
@@ -2,12 +2,12 @@
 title: MessagePort：messageerror 事件
 slug: Web/API/MessagePort/messageerror_event
 l10n:
-  sourceCommit: e4c0939929e1b3e1fa3fd3da82b827fca3ed4c79
+  sourceCommit: ec8d6cfcaae740f7dfad264b797eebe448085a2b
 ---
 
 {{APIRef("Channel Messaging API")}} {{AvailableInWorkers}}
 
-当 {{domxref('MessagePort')}} 对象接收到无法反序列化的消息时，会触发 **`messageerror`** 事件。
+{{domxref('MessagePort')}} 对象的 **`messageerror`** 事件在接收到无法反序列化的消息时触发。
 
 此事件不可取消，也不会冒泡。
 
@@ -23,7 +23,7 @@ onmessageerror = (event) => {};
 
 ## 事件类型
 
-一个 {{domxref("MessageEvent")}}。继承于 {{domxref("Event")}}。
+一个 {{domxref("MessageEvent")}}。继承自 {{domxref("Event")}}。
 
 {{InheritanceDiagram("MessageEvent")}}
 
@@ -40,7 +40,7 @@ _此接口还继承了其父接口 {{domxref("Event")}} 的属性。_
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
   - : 一个 `MessageEventSource`（可以是 {{glossary("WindowProxy")}}、{{domxref("MessagePort")}} 或 {{domxref("ServiceWorker")}} 对象），表示消息发送者。
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
-  - : 一个 {{domxref("MessagePort")}} 对象数组，表示与消息通过的 channel 关联的端口（在适当的情况下，例如在 channel 消息传递或向 shared worker 发送消息时）。
+  - : 一个按顺序包含随消息发送的所有 {{domxref("MessagePort")}} 对象的数组。
 
 ## 示例
 
@@ -106,5 +106,5 @@ window.addEventListener("message", (event) => {
 
 ## 参见
 
-- 相关事件：[`message`](/zh-CN/docs/Web/API/MessagePort/message_event).
-- [使用 channel messaging](/zh-CN/docs/Web/API/Channel_Messaging_API/Using_channel_messaging)
+- 相关事件：[`message`](/zh-CN/docs/Web/API/MessagePort/message_event)
+- [使用频道传递消息](/zh-CN/docs/Web/API/Channel_Messaging_API/Using_channel_messaging)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/message_event
https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/messageerror_event

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
