### PR TITLE
text-emphasis-colorのページの例にHTMLが含まれていない

### DIFF
--- a/files/ja/web/css/text-emphasis-color/index.md
+++ b/files/ja/web/css/text-emphasis-color/index.md
@@ -50,7 +50,7 @@ text-emphasis-color: unset;
 
 #### CSS
 
-```css
+```css live-sample___emphasis_with_a_color_and_custom_character
 em {
   text-emphasis-color: green;
   text-emphasis-style: "*";
@@ -59,7 +59,7 @@ em {
 
 #### HTML
 
-```html
+```html live-sample___emphasis_with_a_color_and_custom_character
 <p>例:</p>
 
 <em>これには圏点があります！</em>
@@ -67,7 +67,7 @@ em {
 
 #### 結果
 
-{{EmbedLiveSample("色と固有の文字で強調", 450, 100)}}
+{{EmbedLiveSample("Emphasis_with_a_color_and_custom_character", 450, 100)}}
 
 ## 仕様書
 

--- a/files/ja/web/css/text-emphasis-color/index.md
+++ b/files/ja/web/css/text-emphasis-color/index.md
@@ -67,7 +67,7 @@ em {
 
 #### 結果
 
-{{EmbedLiveSample("Emphasis_with_a_color_and_custom_character", 450, 100)}}
+{{EmbedLiveSample("色と固有の文字で強調", 450, 100)}}
 
 ## 仕様書
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
text-emphasis-positionの「圏点の位置を追加」の例でHTMLが反映されていない。

https://developer.mozilla.org/ja/docs/Web/CSS/text-emphasis-color#%E8%89%B2%E3%81%A8%E5%9B%BA%E6%9C%89%E3%81%AE%E6%96%87%E5%AD%97%E3%81%A7%E5%BC%B7%E8%AA%BF

翻訳後の題目を`EmbedLiveSample`の引数に渡す。

### Motivation

正しいサンプルを表示させたい

### Additional details

[text-emphasisの例](https://developer.mozilla.org/ja/docs/Web/CSS/text-emphasis#%E5%BC%B7%E8%AA%BF%E3%81%97%E3%81%A6%E8%89%B2%E3%82%92%E4%BB%98%E3%81%91%E3%81%9F%E8%A6%8B%E5%87%BA%E3%81%97)、[text-emphasis-positionの例](https://developer.mozilla.org/ja/docs/Web/CSS/text-emphasis-position)でも同様の問題が起きると考えていましたが、正しく表示されていました。問題が起きている・いないに関わらず日本語で引数を渡すのが正確になるのでしょうか？

その他`EmbedLiveSample`を利用する箇所は同様の問題が起きている箇所があると考えられますが、全体的な修正の方針等あれば教えていただきたいです。同様の問題を見つけるたびにPRを立てても良いのかも気になっています。

### Related issues and pull requests
