### PR TITLE
[ko] docs: glossary-guide에 Command line(명령줄), Editor(편집기) 용어 추가

### DIFF
--- a/docs/ko/guides/glossary-guide.md
+++ b/docs/ko/guides/glossary-guide.md
@@ -103,6 +103,7 @@
 | Boolean             | 불리언          |                                                                                |
 | Capture             | 캡처            |                                                                                |
 | Class               | 클래스          |                                                                                |
+| Command line        | 명령줄          |                                                                                |
 | Content(s)          | 콘텐츠          |                                                                                |
 | Context             | 맥락            |                                                                                |
 | Control             | 컨트롤          |                                                                                |
@@ -110,6 +111,7 @@
 | Custom              | 사용자 정의     |                                                                                |
 | Decoding            | 디코딩          | [링크](https://github.com/mdn/translated-content/issues/12452)                 |
 | Document            | 문서            |                                                                                |
+| Editor              | 편집기          |                                                                                |
 | Element             | 요소            |                                                                                |
 | Encoding            | 인코딩          | [링크](https://github.com/mdn/translated-content/issues/12452)                 |
 | Entity              | 개체            |                                                                                |


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
- glossary-guide에 command line, editor 용어를 추가했습니다.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
- command line의 경우, 영어에는 띄어쓰기가 있으나, 위키백과 검색 결과에 의하면 한국어에는 없어야 한다고 생각되어 추가해봤습니다.
- editor의 경우, 텍스트 편집기, 코드 편집기, 문서 편집기, 코드 에디터, 텍스트 에디터 등 다양하게 표현됨에 따라, 제 머릿속에 떠오로는 단어의 빈도와 구글 검색 추천에 의하면 편집기가 좀 더 많았습니다.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
