### PR TITLE
[es] remove 404 link

### DIFF
--- a/files/es/learn_web_development/core/scripting/math/index.md
+++ b/files/es/learn_web_development/core/scripting/math/index.md
@@ -43,8 +43,6 @@ La segunda parte de las buenas noticias es que, a diferencia de otros lenguajes 
 
 Juguemos un poco con algunos números para ponernos al día con la sintaxis básica que necesitamos. Coloca los comandos listados abajo en la [consola JavaScript de tus herramientas para desarrolladores](/es/docs/Learn/Common_questions/Tools_and_setup/What_are_browser_developer_tools), o utiliza la sencilla consola integrada que verás abajo si lo prefieres.
 
-**[Abrir en una ventana nueva](https://mdn.github.io/learning-area/javascript/introduction-to-js-1/variables/)**
-
 1. Primero que todo, declara un par de variables e inicializalas con un entero y un flotante, respectivamente, luego escribe los nombres de esas variables para chequear que todo esté en orden:
 
    ```js


### PR DESCRIPTION
### Description

Remove a dead link: https://mdn.github.io/learning-area/javascript/introduction-to-js-1/variables/

### Additional details

This error was caused by removed content in learning-area repository.

Related commit for reference: https://github.com/mdn/learning-area/commit/5a07e52de587b173ec05cf9dd3f741ecea86e52a

### Do you have any supporting links, references, or citations?

from: https://developer.mozilla.org/es/docs/Learn_web_development/Core/Scripting/Math#para_m%C3%AD_todo_son_n%C3%BAmeros

### Related issues and pull requests

Refs: #25011