### PR TITLE
es: agrega módulo de fundamentos de estándares web

### DIFF
--- a/files/es/learn_web_development/getting_started/web_standards/index.md
+++ b/files/es/learn_web_development/getting_started/web_standards/index.md
@@ -1,0 +1,30 @@
+---
+title: Estándares web
+slug: Learn_web_development/Getting_started/Web_standards
+page-type: landing-page
+---
+
+{{LearnSidebar}}
+
+{{PreviousMenuNext("Learn_web_development/Getting_started/Your_first_website/Publishing_your_website", "Learn_web_development/Getting_started/Web_standards/How_the_web_works", "Learn_web_development/Getting_started")}}
+
+Este módulo abarca los fundamentos de cómo funciona la web a un nivel general, incluyendo el modelo utilizado para la comunicación, las tecnologías centrales involucradas, cómo se crean estas tecnologías y cómo un navegador web renderiza y muestra los sitios web a un usuario.
+
+Recursos generales:
+
+- [Diseño Web Resiliente](https://resilientwebdesign.com/), Jeremy Keith
+
+## Requisitos previos
+
+Este módulo es principalmente teórico y no asume un conocimiento práctico específico de las tecnologías web. Sin embargo, lo comprenderás mejor y le sacarás más provecho si entiendes los conceptos básicos de para qué se utilizan las principales tecnologías web. Sugerimos que primero trabajes en el módulo [Tu primer sitio web](/en-US/docs/Learn_web_development/Getting_started/Your_first_website), si aún no lo has hecho.
+
+## Tutoriales
+
+- [Cómo funciona la web](/en-US/docs/Learn_web_development/Getting_started/Web_standards/How_the_web_works)
+  - : Este artículo proporciona una descripción general de lo que sucede cuando utilizas un navegador web para navegar a una página web, explicando la magia que ocurre entre bastidores para entregar el código relevante a tu ordenador para que el navegador lo ensamble en algo que puedas ver.
+- [El modelo de estándares web](/en-US/docs/Learn_web_development/Getting_started/Web_standards/The_web_standards_model)
+  - : Este artículo proporciona información útil sobre la web y los estándares web: cómo surgieron, qué son las tecnologías de estándares web y cómo funcionan en conjunto.
+- [Cómo los navegadores cargan los sitios web](/en-US/docs/Learn_web_development/Getting_started/Web_standards/How_browsers_load_websites)
+  - : En este artículo, hablaremos sobre el proceso de renderizado de un sitio web: cuando un navegador ha recibido los archivos y recursos que componen un sitio web, ¿cómo se juntan para crear la experiencia final con la que interactúa el usuario?
+
+{{PreviousMenuNext("Learn_web_development/Getting_started/Your_first_website/Publishing_your_website", "Learn_web_development/Getting_started/Web_standards/How_the_web_works", "Learn_web_development/Getting_started")}}

--- a/files/es/learn_web_development/getting_started/web_standards/index.md
+++ b/files/es/learn_web_development/getting_started/web_standards/index.md
@@ -1,7 +1,6 @@
 ---
 title: Estándares web
 slug: Learn_web_development/Getting_started/Web_standards
-page-type: landing-page
 ---
 
 {{LearnSidebar}}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node": ">=20"
   },
   "dependencies": {
+    "autocorrect": "^1.2.0",
     "autocorrect-node": "2.13.0",
     "fdir": "^6.4.3",
     "franc-min": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,6 +147,14 @@ autocorrect-node@2.13.0:
     autocorrect-node-linux-x64-musl "2.13.0"
     autocorrect-node-win32-x64-msvc "2.13.0"
 
+autocorrect@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/autocorrect/-/autocorrect-1.2.0.tgz#f88eced11d3ceca616b376e93d61a5e7c034b2bb"
+  integrity sha512-+RbvUM8d/V1e8xSOEW3oi0kWFe+T5WD+hGyqPaVKngEZW7vTFGSJOy+vvEa9PZeqIq5U9WHd9gX7hlsFKonaRg==
+  dependencies:
+    leven "^2.0.0"
+    word-list "^1.0.1"
+
 braces@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
@@ -582,6 +590,11 @@ leac@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/leac/-/leac-0.6.0.tgz#dcf136e382e666bd2475f44a1096061b70dc0912"
   integrity sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==
+
+leven@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+  integrity sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==
 
 lilconfig@^3.1.3:
   version "3.1.3"
@@ -1319,6 +1332,11 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+word-list@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/word-list/-/word-list-1.0.1.tgz#84c4fe3b9187acd310f53c91b40c16f859d013bb"
+  integrity sha512-f9TaupdTMV4Rmf6l2vw1O7P6nSqE8mOdIbGWddjcWQ11JoIdn+IMu8yCxeSp0LrCMJG2Qi1KE3ZcVN/QEPiE7Q==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Este commit añade un nuevo módulo sobre los fundamentos de los estándares web, traducido al español. Cubre los mismos temas que la versión en inglés, pero con explicaciones y ejemplos en español.
https://developer.mozilla.org/en-US/docs/Learn_web_development/Getting_started/Web_standards

