### PR TITLE
[zh-TW]: migrate HTML interactive examples

### DIFF
--- a/files/zh-tw/web/html/element/a/index.md
+++ b/files/zh-tw/web/html/element/a/index.md
@@ -9,7 +9,23 @@ slug: Web/HTML/Element/a
 
 每個 `<a>` 元素內的內容*應該*指示連結的目的地。如果存在 `href` 屬性，則在焦點位於 `<a>` 元素上時按下 Enter 鍵將激活它。
 
-{{EmbedInteractiveExample("pages/tabbed/a.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;a&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<p>You can reach Michael at:</p>
+
+<ul>
+  <li><a href="https://example.com">Website</a></li>
+  <li><a href="mailto:m.bluth@example.com">Email</a></li>
+  <li><a href="tel:+123456789">Phone</a></li>
+</ul>
+```
+
+```css interactive-example
+li {
+  margin-bottom: 0.5rem;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/abbr/index.md
+++ b/files/zh-tw/web/html/element/abbr/index.md
@@ -11,7 +11,23 @@ slug: Web/HTML/Element/abbr
 
 可選的 [`title`](/zh-TW/docs/Web/HTML/Global_attributes#title) 屬性可在未提供完整展開時提供縮寫或縮略語的展開。這可為用戶代理提供如何宣布/顯示內容的提示，同時告知所有使用者該縮寫的含義。若存在，`title` 必須包含該完整描述，不能包含其他內容。
 
-{{EmbedInteractiveExample("pages/tabbed/abbr.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;abbr&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<p>
+  You can use <abbr>CSS</abbr> (Cascading Style Sheets) to style your
+  <abbr>HTML</abbr> (HyperText Markup Language). Using style sheets, you can
+  keep your <abbr>CSS</abbr> presentation layer and <abbr>HTML</abbr> content
+  layer separate. This is called "separation of concerns."
+</p>
+```
+
+```css interactive-example
+abbr {
+  font-style: italic;
+  color: chocolate;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/address/index.md
+++ b/files/zh-tw/web/html/element/address/index.md
@@ -7,7 +7,26 @@ slug: Web/HTML/Element/address
 
 **`<address>`** [HTML](/zh-TW/docs/Web/HTML) 元素表示所包含的 HTML 提供了一個人、一組人或一個組織的聯絡資訊。
 
-{{EmbedInteractiveExample("pages/tabbed/address.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;address&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<p>Contact the author of this page:</p>
+
+<address>
+  <a href="mailto:jim@example.com">jim@example.com</a><br />
+  <a href="tel:+14155550132">+1 (415) 555‑0132</a>
+</address>
+```
+
+```css interactive-example
+a[href^="mailto"]::before {
+  content: "📧 ";
+}
+
+a[href^="tel"]::before {
+  content: "📞 ";
+}
+```
 
 `<address>` 元素內容提供的聯絡資訊可以根據上下文而定，可能包含任何需要的聯絡資訊，例如實際地址、URL、電子郵件地址、電話號碼、社交媒體帳號、地理座標等等。`<address>` 元素應包含所述聯絡資訊所指的人、人群或組織的名稱。
 

--- a/files/zh-tw/web/html/element/area/index.md
+++ b/files/zh-tw/web/html/element/area/index.md
@@ -9,7 +9,50 @@ slug: Web/HTML/Element/area
 
 此元素僅在 {{HTMLElement("map")}} 元素內使用。
 
-{{EmbedInteractiveExample("pages/tabbed/area.html", "tabbed-taller")}}
+{{InteractiveExample("HTML Demo: &lt;area&gt;", "tabbed-taller")}}
+
+```html interactive-example
+<map name="infographic">
+  <area
+    shape="poly"
+    coords="129,0,260,95,129,138"
+    href="https://developer.mozilla.org/docs/Web/HTTP"
+    alt="HTTP" />
+  <area
+    shape="poly"
+    coords="260,96,209,249,130,138"
+    href="https://developer.mozilla.org/docs/Web/HTML"
+    alt="HTML" />
+  <area
+    shape="poly"
+    coords="209,249,49,249,130,139"
+    href="https://developer.mozilla.org/docs/Web/JavaScript"
+    alt="JavaScript" />
+  <area
+    shape="poly"
+    coords="48,249,0,96,129,138"
+    href="https://developer.mozilla.org/docs/Web/API"
+    alt="Web APIs" />
+  <area
+    shape="poly"
+    coords="0,95,128,0,128,137"
+    href="https://developer.mozilla.org/docs/Web/CSS"
+    alt="CSS" />
+</map>
+<img
+  usemap="#infographic"
+  src="/shared-assets/images/examples/mdn-info.png"
+  alt="MDN infographic" />
+```
+
+```css interactive-example
+img {
+  display: block;
+  margin: 0 auto;
+  width: 260px;
+  height: 260px;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/article/index.md
+++ b/files/zh-tw/web/html/element/article/index.md
@@ -7,7 +7,51 @@ slug: Web/HTML/Element/article
 
 **`<article>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表文件、頁面、應用程式或站點中的一個獨立組成部分，該部分旨在獨立分發或重複使用（例如，在聯合編輯中）。例如：論壇帖子、雜誌或報紙文章、部落格文章、產品卡片、用戶提交的評論、互動小工具或小裝置，或任何其他獨立的內容項目。
 
-{{EmbedInteractiveExample("pages/tabbed/article.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;article&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<article class="forecast">
+  <h1>Weather forecast for Seattle</h1>
+  <article class="day-forecast">
+    <h2>03 March 2018</h2>
+    <p>Rain.</p>
+  </article>
+  <article class="day-forecast">
+    <h2>04 March 2018</h2>
+    <p>Periods of rain.</p>
+  </article>
+  <article class="day-forecast">
+    <h2>05 March 2018</h2>
+    <p>Heavy rain.</p>
+  </article>
+</article>
+```
+
+```css interactive-example
+.forecast {
+  margin: 0;
+  padding: 0.3rem;
+  background-color: #eee;
+}
+
+.forecast > h1,
+.day-forecast {
+  margin: 0.5rem;
+  padding: 0.3rem;
+  font-size: 1.2rem;
+}
+
+.day-forecast {
+  background: right/contain content-box border-box no-repeat
+    url("/shared-assets/images/examples/rain.svg") white;
+}
+
+.day-forecast > h2,
+.day-forecast > p {
+  margin: 0.2rem;
+  font-size: 1rem;
+}
+```
 
 一個文件可以包含多個文章；例如，在一個按讀者滾動顯示每篇文章文本的部落格上，每篇文章都可以包含在 `<article>` 元素中，可能包含一個或多個 `<section>`。
 

--- a/files/zh-tw/web/html/element/aside/index.md
+++ b/files/zh-tw/web/html/element/aside/index.md
@@ -7,7 +7,41 @@ slug: Web/HTML/Element/aside
 
 **`<aside>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表文件中只間接相關於主要內容的部分。側邊欄常常被呈現為側邊欄或呼叫框。
 
-{{EmbedInteractiveExample("pages/tabbed/aside.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;aside&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<p>
+  Salamanders are a group of amphibians with a lizard-like appearance, including
+  short legs and a tail in both larval and adult forms.
+</p>
+
+<aside>
+  <p>The Rough-skinned Newt defends itself with a deadly neurotoxin.</p>
+</aside>
+
+<p>
+  Several species of salamander inhabit the temperate rainforest of the Pacific
+  Northwest, including the Ensatina, the Northwestern Salamander and the
+  Rough-skinned Newt. Most salamanders are nocturnal, and hunt for insects,
+  worms and other small creatures.
+</p>
+```
+
+```css interactive-example
+aside {
+  width: 40%;
+  padding-left: 0.5rem;
+  margin-left: 0.5rem;
+  float: right;
+  box-shadow: inset 5px 0 5px -5px #29627e;
+  font-style: italic;
+  color: #29627e;
+}
+
+aside > p {
+  margin: 0.5rem;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/audio/index.md
+++ b/files/zh-tw/web/html/element/audio/index.md
@@ -7,7 +7,21 @@ slug: Web/HTML/Element/audio
 
 **`<audio>`** [HTML](/zh-TW/docs/Web/HTML) 元素是用來在文件中嵌入音訊內容。它可以包含一個或多個音訊來源，使用 `src` 屬性或 {{HTMLElement("source")}} 元素來表示：瀏覽器將選擇最適合的音訊來源。它還可以是串流媒體的目的地，使用 {{domxref("MediaStream")}}。
 
-{{EmbedInteractiveExample("pages/tabbed/audio.html","tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;audio&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<figure>
+  <figcaption>Listen to the T-Rex:</figcaption>
+  <audio controls src="/shared-assets/audio/t-rex-roar.mp3"></audio>
+  <a href="/shared-assets/audio/t-rex-roar.mp3"> Download audio </a>
+</figure>
+```
+
+```css interactive-example
+figure {
+  margin: 0;
+}
+```
 
 上面的範例展示了 `<audio>` 元素的簡單用法。與 {{htmlelement("img")}} 元素類似，我們在 `src` 屬性中包含要嵌入的媒體的路徑；我們可以包含其他屬性來指定信息，例如我們是否要自動播放和循環播放，是否要顯示瀏覽器的默認音訊控制項等。
 

--- a/files/zh-tw/web/html/element/b/index.md
+++ b/files/zh-tw/web/html/element/b/index.md
@@ -7,7 +7,22 @@ slug: Web/HTML/Element/b
 
 **`<b>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於引起讀者對其內容的注意，但該內容並非特別重要。這曾被稱為粗體元素，而大多數瀏覽器仍會以粗體顯示其文字。然而，你不應該使用 `<b>` 來設置文字樣式或賦予重要性。如果你希望使文字變成粗體，應該使用 CSS {{cssxref("font-weight")}} 屬性。如果你希望表示某個元素具有特殊重要性，應該使用 {{HTMLElement("strong")}} 元素。
 
-{{EmbedInteractiveExample("pages/tabbed/b.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;b&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<p>
+  The two most popular science courses offered by the school are
+  <b class="term">chemistry</b> (the study of chemicals and the composition of
+  substances) and <b class="term">physics</b> (the study of the nature and
+  properties of matter and energy).
+</p>
+```
+
+```css interactive-example
+/* stylelint-disable-next-line block-no-empty */
+b {
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/bdi/index.md
+++ b/files/zh-tw/web/html/element/bdi/index.md
@@ -7,7 +7,33 @@ slug: Web/HTML/Element/bdi
 
 **`<bdi>`** [HTML](/zh-TW/docs/Web/HTML) 元素告訴瀏覽器的雙向算法，要將其包含的文本與周圍的文本隔離處理。當網站動態插入某些文本但不知道插入文本的方向性時，這尤其有用。
 
-{{EmbedInteractiveExample("pages/tabbed/bdi.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;bdi&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<h1>World wrestling championships</h1>
+
+<ul>
+  <li><bdi class="name">Evil Steven</bdi>: 1st place</li>
+  <li><bdi class="name">François fatale</bdi>: 2nd place</li>
+  <li><span class="name">سما</span>: 3rd place</li>
+  <li><bdi class="name">الرجل القوي إيان</bdi>: 4th place</li>
+  <li><span class="name" dir="auto">سما</span>: 5th place</li>
+</ul>
+```
+
+```css interactive-example
+html {
+  font-family: sans-serif;
+}
+
+/* stylelint-disable-next-line block-no-empty */
+bdi {
+}
+
+.name {
+  color: red;
+}
+```
 
 雙向文本是可能包含從左到右（LTR）排列的字符序列和從右到左（RTL）排列的字符序列的文本，例如嵌入在英文字符串中的阿拉伯引用。瀏覽器實現了 [Unicode 雙向算法](https://www.w3.org/International/articles/inline-bidi-markup/uba-basics)來處理這一問題。在這個算法中，字符被賦予隱式方向性：例如，拉丁字符被視為 LTR，而阿拉伯字符被視為 RTL。一些其他字符（例如空格和一些標點符號）被視為中性，其方向性基於周圍字符的方向性而分配。
 

--- a/files/zh-tw/web/html/element/bdo/index.md
+++ b/files/zh-tw/web/html/element/bdo/index.md
@@ -7,7 +7,33 @@ slug: Web/HTML/Element/bdo
 
 **`<bdo>`** [HTML](/zh-TW/docs/Web/HTML) 元素覆蓋了文本的當前方向性，使其中的文本以不同的方向呈現。
 
-{{EmbedInteractiveExample("pages/tabbed/bdo.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;bdo&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<h1>Famous seaside songs</h1>
+
+<p>The English song "Oh I do like to be beside the seaside"</p>
+
+<p>
+  Looks like this in Hebrew:
+  <span dir="rtl">אה, אני אוהב להיות ליד חוף הים</span>
+</p>
+
+<p>
+  In the computer's memory, this is stored as
+  <bdo dir="ltr">אה, אני אוהב להיות ליד חוף הים</bdo>
+</p>
+```
+
+```css interactive-example
+html {
+  font-family: sans-serif;
+}
+
+/* stylelint-disable-next-line block-no-empty */
+bdo {
+}
+```
 
 文本的字符從給定方向的起點繪製；個別字符的方向不受影響（例如，字符不會倒置繪製）。
 

--- a/files/zh-tw/web/html/element/blockquote/index.md
+++ b/files/zh-tw/web/html/element/blockquote/index.md
@@ -7,7 +7,40 @@ slug: Web/HTML/Element/blockquote
 
 **`<blockquote>`** [HTML](/zh-TW/docs/Web/HTML) 元素表示所包含的文本是擴展引用。通常，這通過縮進在視覺上呈現（有關如何更改，請參見[注意事項](#使用注意事項)）。可以使用 `cite` 屬性提供引用信息的源文檔或消息的 URL，而使用 {{HTMLElement("cite")}} 元素可以提供源的文本表示。
 
-{{EmbedInteractiveExample("pages/tabbed/blockquote.html","tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;blockquote&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<div>
+  <blockquote cite="https://www.huxley.net/bnw/four.html">
+    <p>
+      Words can be like X-rays, if you use them properly—they’ll go through
+      anything. You read and you’re pierced.
+    </p>
+  </blockquote>
+  <p>—Aldous Huxley, <cite>Brave New World</cite></p>
+</div>
+```
+
+```css interactive-example
+div:has(> blockquote) {
+  background-color: #ededed;
+  margin: 10px auto;
+  padding: 15px;
+  border-radius: 5px;
+}
+
+blockquote p::before {
+  content: "\201C";
+}
+
+blockquote p::after {
+  content: "\201D";
+}
+
+blockquote + p {
+  text-align: right;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/br/index.md
+++ b/files/zh-tw/web/html/element/br/index.md
@@ -7,7 +7,28 @@ slug: Web/HTML/Element/br
 
 **`<br>`** [HTML](/zh-TW/docs/Web/HTML) 元素可在文字中插入換行（回車）。在寫詩或地址時，這很有用，因為行的分隔是重要的。
 
-{{EmbedInteractiveExample("pages/tabbed/br.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;br&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<p>
+  O’er all the hilltops<br />
+  Is quiet now,<br />
+  In all the treetops<br />
+  Hearest thou<br />
+  Hardly a breath;<br />
+  The birds are asleep in the trees:<br />
+  Wait, soon like these<br />
+  Thou too shalt rest.
+</p>
+```
+
+```css interactive-example
+p {
+  font-size: 1rem;
+  font-family: sans-serif;
+  margin: 20px;
+}
+```
 
 如上例所示，每當我們希望文字換行時，都會包含一個 `<br>` 元素。 `<br>` 後的文本將重新開始於文本塊的下一行的開頭。
 

--- a/files/zh-tw/web/html/element/button/index.md
+++ b/files/zh-tw/web/html/element/button/index.md
@@ -9,7 +9,44 @@ slug: Web/HTML/Element/button
 
 預設情況下，HTML 按鈕會呈現為與{{Glossary("user agent", "使用者代理")}}所在平台類似的樣式，但你可以使用 [CSS](/zh-TW/docs/Web/CSS) 更改按鈕的外觀。
 
-{{EmbedInteractiveExample("pages/tabbed/button.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;button&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<button class="favorite styled" type="button">Add to favorites</button>
+```
+
+```css interactive-example
+.styled {
+  border: 0;
+  line-height: 2.5;
+  padding: 0 20px;
+  font-size: 1rem;
+  text-align: center;
+  color: #fff;
+  text-shadow: 1px 1px 1px #000;
+  border-radius: 10px;
+  background-color: rgba(220, 0, 0, 1);
+  background-image: linear-gradient(
+    to top left,
+    rgba(0, 0, 0, 0.2),
+    rgba(0, 0, 0, 0.2) 30%,
+    rgba(0, 0, 0, 0)
+  );
+  box-shadow:
+    inset 2px 2px 3px rgba(255, 255, 255, 0.6),
+    inset -2px -2px 3px rgba(0, 0, 0, 0.6);
+}
+
+.styled:hover {
+  background-color: rgba(255, 0, 0, 1);
+}
+
+.styled:active {
+  box-shadow:
+    inset -2px -2px 3px rgba(255, 255, 255, 0.6),
+    inset 2px 2px 3px rgba(0, 0, 0, 0.6);
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/caption/index.md
+++ b/files/zh-tw/web/html/element/caption/index.md
@@ -7,7 +7,88 @@ slug: Web/HTML/Element/caption
 
 **`<caption>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於指定表格的標題或標題，為表格提供了一個{{glossary("accessible description", "無障礙描述")}}。
 
-{{EmbedInteractiveExample("pages/tabbed/caption.html", "tabbed-taller")}}
+{{InteractiveExample("HTML Demo: &lt;caption&gt;", "tabbed-taller")}}
+
+```html interactive-example
+<table>
+  <caption>
+    He-Man and Skeletor facts
+  </caption>
+  <tr>
+    <td></td>
+    <th scope="col" class="heman">He-Man</th>
+    <th scope="col" class="skeletor">Skeletor</th>
+  </tr>
+  <tr>
+    <th scope="row">Role</th>
+    <td>Hero</td>
+    <td>Villain</td>
+  </tr>
+  <tr>
+    <th scope="row">Weapon</th>
+    <td>Power Sword</td>
+    <td>Havoc Staff</td>
+  </tr>
+  <tr>
+    <th scope="row">Dark secret</th>
+    <td>Expert florist</td>
+    <td>Cries at romcoms</td>
+  </tr>
+</table>
+```
+
+```css interactive-example
+caption {
+  caption-side: bottom;
+  padding: 10px;
+  font-weight: bold;
+}
+
+table {
+  border-collapse: collapse;
+  border: 2px solid rgb(140 140 140);
+  font-family: sans-serif;
+  font-size: 0.8rem;
+  letter-spacing: 1px;
+}
+
+th,
+td {
+  border: 1px solid rgb(160 160 160);
+  padding: 8px 10px;
+}
+
+th {
+  background-color: rgb(230 230 230);
+}
+
+td {
+  text-align: center;
+}
+
+tr:nth-child(even) td {
+  background-color: rgb(250 250 250);
+}
+
+tr:nth-child(odd) td {
+  background-color: rgb(240 240 240);
+}
+
+.heman {
+  font: 1.4rem molot;
+  text-shadow:
+    1px 1px 1px #fff,
+    2px 2px 1px #000;
+}
+
+.skeletor {
+  font: 1.7rem rapscallion;
+  letter-spacing: 3px;
+  text-shadow:
+    1px 1px 0 #fff,
+    0 0 9px #000;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/cite/index.md
+++ b/files/zh-tw/web/html/element/cite/index.md
@@ -7,7 +7,32 @@ slug: Web/HTML/Element/cite
 
 **`<cite>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於標記被引用的創意作品的標題。引用可能根據與引用後設資料相關的上下文適當的慣例而以縮寫形式表示。
 
-{{EmbedInteractiveExample("pages/tabbed/cite.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;cite&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<figure>
+  <blockquote>
+    <p>
+      It was a bright cold day in April, and the clocks were striking thirteen.
+    </p>
+  </blockquote>
+  <figcaption>
+    First sentence in
+    <cite
+      ><a href="http://www.george-orwell.org/1984/0.html"
+        >Nineteen Eighty-Four</a
+      ></cite
+    >
+    by George Orwell (Part 1, Chapter 1).
+  </figcaption>
+</figure>
+```
+
+```css interactive-example
+/* stylelint-disable-next-line block-no-empty */
+cite {
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/code/index.md
+++ b/files/zh-tw/web/html/element/code/index.md
@@ -7,7 +7,23 @@ slug: Web/HTML/Element/code
 
 **`<code>`** [HTML](/zh-TW/docs/Web/HTML) 元素以一種樣式顯示其內容，意在指示該文字是一小段電腦程式碼。預設情況下，內容文字以{{Glossary("user agent", "使用者代理")}}的預設的等寬字體顯示。
 
-{{EmbedInteractiveExample("pages/tabbed/code.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;code&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<p>
+  The <code>push()</code> method adds one or more elements to the end of an
+  array and returns the new length of the array.
+</p>
+```
+
+```css interactive-example
+code {
+  background-color: #eee;
+  border-radius: 3px;
+  font-family: courier, monospace;
+  padding: 0 3px;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/col/index.md
+++ b/files/zh-tw/web/html/element/col/index.md
@@ -7,7 +7,67 @@ slug: Web/HTML/Element/col
 
 **`<col>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於定義由其父元素 {{HTMLElement("colgroup")}} 表示的欄組中的一個或多個欄。`<col>` 元素僅在未定義 [`span`](/zh-TW/docs/Web/HTML/Element/colgroup#span) 屬性的 {{HTMLElement("colgroup")}} 元素的情況下作為其子元素有效。
 
-{{EmbedInteractiveExample("pages/tabbed/col.html","tabbed-taller")}}
+{{InteractiveExample("HTML Demo: &lt;col&gt;", "tabbed-taller")}}
+
+```html interactive-example
+<table>
+  <caption>
+    Superheros and sidekicks
+  </caption>
+  <colgroup>
+    <col />
+    <col span="2" class="batman" />
+    <col span="2" class="flash" />
+  </colgroup>
+  <tr>
+    <td></td>
+    <th scope="col">Batman</th>
+    <th scope="col">Robin</th>
+    <th scope="col">The Flash</th>
+    <th scope="col">Kid Flash</th>
+  </tr>
+  <tr>
+    <th scope="row">Skill</th>
+    <td>Smarts, strong</td>
+    <td>Dex, acrobat</td>
+    <td>Super speed</td>
+    <td>Super speed</td>
+  </tr>
+</table>
+```
+
+```css interactive-example
+.batman {
+  background-color: #d7d9f2;
+}
+
+.flash {
+  background-color: #ffe8d4;
+}
+
+table {
+  border-collapse: collapse;
+  border: 2px solid rgb(140 140 140);
+  font-family: sans-serif;
+  font-size: 0.8rem;
+  letter-spacing: 1px;
+}
+
+caption {
+  caption-side: bottom;
+  padding: 10px;
+}
+
+th,
+td {
+  border: 1px solid rgb(160 160 160);
+  padding: 8px 6px;
+}
+
+td {
+  text-align: center;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/colgroup/index.md
+++ b/files/zh-tw/web/html/element/colgroup/index.md
@@ -7,7 +7,67 @@ slug: Web/HTML/Element/colgroup
 
 **`<colgroup>`** [HTML](/zh-TW/docs/Web/HTML) 中定義表格內的一組欄的元素。
 
-{{EmbedInteractiveExample("pages/tabbed/colgroup.html","tabbed-taller")}}
+{{InteractiveExample("HTML Demo: &lt;colgroup&gt;", "tabbed-taller")}}
+
+```html interactive-example
+<table>
+  <caption>
+    Superheros and sidekicks
+  </caption>
+  <colgroup>
+    <col />
+    <col span="2" class="batman" />
+    <col span="2" class="flash" />
+  </colgroup>
+  <tr>
+    <td></td>
+    <th scope="col">Batman</th>
+    <th scope="col">Robin</th>
+    <th scope="col">The Flash</th>
+    <th scope="col">Kid Flash</th>
+  </tr>
+  <tr>
+    <th scope="row">Skill</th>
+    <td>Smarts, strong</td>
+    <td>Dex, acrobat</td>
+    <td>Super speed</td>
+    <td>Super speed</td>
+  </tr>
+</table>
+```
+
+```css interactive-example
+.batman {
+  background-color: #d7d9f2;
+}
+
+.flash {
+  background-color: #ffe8d4;
+}
+
+table {
+  border-collapse: collapse;
+  border: 2px solid rgb(140 140 140);
+  font-family: sans-serif;
+  font-size: 0.8rem;
+  letter-spacing: 1px;
+}
+
+caption {
+  caption-side: bottom;
+  padding: 10px;
+}
+
+th,
+td {
+  border: 1px solid rgb(160 160 160);
+  padding: 8px 6px;
+}
+
+td {
+  text-align: center;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/data/index.md
+++ b/files/zh-tw/web/html/element/data/index.md
@@ -7,7 +7,23 @@ slug: Web/HTML/Element/data
 
 **`<data>`** [HTML](/zh-TW/docs/Web/HTML) 元素將給定的內容與可機器讀取的翻譯相關聯。如果內容與時間或日期有關，則必須使用 {{HTMLElement("time")}} 元素。
 
-{{EmbedInteractiveExample("pages/tabbed/data.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;data&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<p>New Products:</p>
+<ul>
+  <li><data value="398">Mini Ketchup</data></li>
+  <li><data value="399">Jumbo Ketchup</data></li>
+  <li><data value="400">Mega Jumbo Ketchup</data></li>
+</ul>
+```
+
+```css interactive-example
+data:hover::after {
+  content: " (ID " attr(value) ")";
+  font-size: 0.7em;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/datalist/index.md
+++ b/files/zh-tw/web/html/element/datalist/index.md
@@ -7,7 +7,27 @@ slug: Web/HTML/Element/datalist
 
 **`<datalist>`** [HTML](/zh-TW/docs/Web/HTML) 元素包含一組 {{HTMLElement("option")}} 元素，這些元素代表其他控制項中可選擇的允許或推薦選項。
 
-{{EmbedInteractiveExample("pages/tabbed/datalist.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;datalist&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<label for="ice-cream-choice">Choose a flavor:</label>
+<input list="ice-cream-flavors" id="ice-cream-choice" name="ice-cream-choice" />
+
+<datalist id="ice-cream-flavors">
+  <option value="Chocolate"></option>
+  <option value="Coconut"></option>
+  <option value="Mint"></option>
+  <option value="Strawberry"></option>
+  <option value="Vanilla"></option>
+</datalist>
+```
+
+```css interactive-example
+label {
+  display: block;
+  margin-bottom: 10px;
+}
+```
 
 要將 `<datalist>` 元素綁定到控制項，我們在 [`id`](/zh-TW/docs/Web/HTML/Global_attributes/id) 屬性中給予它一個唯一標識符，然後在具有相同標識符值的 {{HTMLElement("input")}} 元素中添加 [`list`](/zh-TW/docs/Web/HTML/Element/input#list) 屬性。只有某些類型的 {{HTMLElement("input")}} 支援此行為，並且在不同的瀏覽器中可能也會有所不同。
 

--- a/files/zh-tw/web/html/element/dd/index.md
+++ b/files/zh-tw/web/html/element/dd/index.md
@@ -7,7 +7,38 @@ slug: Web/HTML/Element/dd
 
 **`<dd>`** [HTML](/zh-TW/docs/Web/HTML) 元素提供描述、定義或前一個術語（{{HTMLElement("dt")}}）在描述清單（{{HTMLElement("dl")}}）中的值。
 
-{{EmbedInteractiveExample("pages/tabbed/dd.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;dd&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<p>Cryptids of Cornwall:</p>
+
+<dl>
+  <dt>Beast of Bodmin</dt>
+  <dd>A large feline inhabiting Bodmin Moor.</dd>
+
+  <dt>Morgawr</dt>
+  <dd>A sea serpent.</dd>
+
+  <dt>Owlman</dt>
+  <dd>A giant owl-like creature.</dd>
+</dl>
+```
+
+```css interactive-example
+p,
+dt {
+  font-weight: bold;
+}
+
+dl,
+dd {
+  font-size: 0.9rem;
+}
+
+dd {
+  margin-bottom: 1em;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/del/index.md
+++ b/files/zh-tw/web/html/element/del/index.md
@@ -7,7 +7,33 @@ slug: Web/HTML/Element/del
 
 **`<del>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表從文件中刪除的文字範圍。例如，這可用於渲染「跟踪更改」或源代碼差異信息。{{HTMLElement("ins")}} 元素可用於相反的目的：指示已添加到文檔中的文字。
 
-{{EmbedInteractiveExample("pages/tabbed/del.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;del&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<blockquote>
+  There is <del>nothing</del> <ins>no code</ins> either good or bad, but
+  <del>thinking</del> <ins>running it</ins> makes it so.
+</blockquote>
+```
+
+```css interactive-example
+del {
+  text-decoration: line-through;
+  background-color: #fbb;
+  color: #555;
+}
+
+ins {
+  text-decoration: none;
+  background-color: #d4fcbc;
+}
+
+blockquote {
+  padding-left: 15px;
+  border-left: 3px solid #d7d7db;
+  font-size: 1rem;
+}
+```
 
 此元素通常（但不一定）通過對文本應用刪除線樣式來呈現。
 

--- a/files/zh-tw/web/html/element/details/index.md
+++ b/files/zh-tw/web/html/element/details/index.md
@@ -9,7 +9,37 @@ slug: Web/HTML/Element/details
 
 通常，揭露小部件在螢幕上以小三角形呈現，該三角形旋轉（或扭曲）以指示開啟/關閉狀態，並帶有三角形旁邊的標籤。`<summary>` 元素的內容用作揭露小部件的標籤。`<details>` 的內容提供了 `<summary>` 的{{glossary("accessible description", "無障礙描述")}}。
 
-{{EmbedInteractiveExample("pages/tabbed/details.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;details&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<details>
+  <summary>Details</summary>
+  Something small enough to escape casual notice.
+</details>
+```
+
+```css interactive-example
+details {
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  padding: 0.5em 0.5em 0;
+}
+
+summary {
+  font-weight: bold;
+  margin: -0.5em -0.5em 0;
+  padding: 0.5em;
+}
+
+details[open] {
+  padding: 0.5em;
+}
+
+details[open] summary {
+  border-bottom: 1px solid #aaa;
+  margin-bottom: 0.5em;
+}
+```
 
 `<details>` 小部件可以處於兩種狀態之一。默認的「關閉」狀態僅顯示三角形和 `<summary>` 內的標籤（或如果沒有 `<summary>`，則是{{Glossary("user agent", "使用者代理")}}定義的默認字串）。
 

--- a/files/zh-tw/web/html/element/dfn/index.md
+++ b/files/zh-tw/web/html/element/dfn/index.md
@@ -7,7 +7,20 @@ slug: Web/HTML/Element/dfn
 
 **`<dfn>`** [HTML](/zh-TW/docs/Web/HTML) 元素表示要定義的術語。`<dfn>` 元素應該在完整的定義語句中使用，其中 `<dfn>` 元素的祖先 {{HTMLElement("p")}} 元素、{{HTMLElement("dt")}}/{{HTMLElement("dd")}} 配對或 `<dfn>` 元素的最近 {{HTMLElement("section")}} 祖先被認為是該術語的完整定義。
 
-{{EmbedInteractiveExample("pages/tabbed/dfn.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;dfn&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<p>
+  A <dfn id="def-validator">validator</dfn> is a program that checks for syntax
+  errors in code or documents.
+</p>
+```
+
+```css interactive-example
+/* stylelint-disable-next-line block-no-empty */
+dfn {
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/div/index.md
+++ b/files/zh-tw/web/html/element/div/index.md
@@ -7,7 +7,35 @@ slug: Web/HTML/Element/div
 
 **`<div>`** [HTML](/zh-TW/docs/Web/HTML) 元素是流內容的通用容器。除非以某種方式使用 {{glossary("CSS")}} 進行樣式化（例如直接應用樣式或應用某種佈局模型，如 [Flexbox](/zh-TW/docs/Web/CSS/CSS_flexible_box_layout) 到其父元素上），否則它對內容或佈局沒有影響。
 
-{{EmbedInteractiveExample("pages/tabbed/div.html","tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;div&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<div class="warning">
+  <img
+    src="/shared-assets/images/examples/leopard.jpg"
+    alt="An intimidating leopard." />
+  <p>Beware of the leopard</p>
+</div>
+```
+
+```css interactive-example
+.warning {
+  border: 10px ridge #f00;
+  background-color: #ff0;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.warning img {
+  width: 100%;
+}
+
+.warning p {
+  font: small-caps bold 1.2rem sans-serif;
+  text-align: center;
+}
+```
 
 作為「純粹」的容器，`<div>` 元素本身並不具有代表性。相反，它用於將內容分組，以便可以輕鬆地使用 [`class`](/zh-TW/docs/Web/HTML/Global_attributes#class) 或 [`id`](/zh-TW/docs/Web/HTML/Global_attributes#id) 屬性進行樣式化，標記文件的某一部分為使用不同語言編寫（使用 [`lang`](/zh-TW/docs/Web/HTML/Global_attributes#lang) 屬性），等等。
 

--- a/files/zh-tw/web/html/element/dl/index.md
+++ b/files/zh-tw/web/html/element/dl/index.md
@@ -7,7 +7,38 @@ slug: Web/HTML/Element/dl
 
 **`<dl>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表一個描述清單。該元素包含一組術語（使用 {{HTMLElement("dt")}} 元素指定）和描述（由 {{HTMLElement("dd")}} 元素提供）。此元素的常見用途包括實現詞彙表或顯示後設資料（一組鍵值對的串列）。
 
-{{EmbedInteractiveExample("pages/tabbed/dl.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;dl&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<p>Cryptids of Cornwall:</p>
+
+<dl>
+  <dt>Beast of Bodmin</dt>
+  <dd>A large feline inhabiting Bodmin Moor.</dd>
+
+  <dt>Morgawr</dt>
+  <dd>A sea serpent.</dd>
+
+  <dt>Owlman</dt>
+  <dd>A giant owl-like creature.</dd>
+</dl>
+```
+
+```css interactive-example
+p,
+dt {
+  font-weight: bold;
+}
+
+dl,
+dd {
+  font-size: 0.9rem;
+}
+
+dd {
+  margin-bottom: 1em;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/dt/index.md
+++ b/files/zh-tw/web/html/element/dt/index.md
@@ -9,7 +9,38 @@ slug: Web/HTML/Element/dt
 
 隨後的 {{HTMLElement("dd")}}（描述詳細資訊）元素提供了使用 `<dt>` 指定的術語的定義或其他相關文字。
 
-{{EmbedInteractiveExample("pages/tabbed/dt.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;dt&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<p>Please use the following paint colors for the new house:</p>
+
+<dl>
+  <dt>Denim (semigloss finish)</dt>
+  <dd>Ceiling</dd>
+
+  <dt>Denim (eggshell finish)</dt>
+  <dt>Evening Sky (eggshell finish)</dt>
+  <dd>Layered on the walls</dd>
+</dl>
+```
+
+```css interactive-example
+p,
+dl {
+  font:
+    1rem "Fira Sans",
+    sans-serif;
+}
+
+dl > dt {
+  font-weight: normal;
+  font-style: oblique;
+}
+
+dd {
+  margin-bottom: 1rem;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/em/index.md
+++ b/files/zh-tw/web/html/element/em/index.md
@@ -7,7 +7,21 @@ slug: Web/HTML/Element/em
 
 **`<em>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於標記具有強調重點的文字。`<em>` 元素可以進行嵌套，每個嵌套層級表示更大程度的強調。
 
-{{EmbedInteractiveExample("pages/tabbed/em.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;em&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<p>Get out of bed <em>now</em>!</p>
+
+<p>We <em>had</em> to do something about it.</p>
+
+<p>This is <em>not</em> a drill!</p>
+```
+
+```css interactive-example
+/* stylelint-disable-next-line block-no-empty */
+em {
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/embed/index.md
+++ b/files/zh-tw/web/html/element/embed/index.md
@@ -7,7 +7,15 @@ slug: Web/HTML/Element/embed
 
 **`<embed>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於在文件中指定的位置嵌入外部內容。這個內容是由外部應用程序或其他互動內容來源（如瀏覽器插件）提供的。
 
-{{EmbedInteractiveExample("pages/tabbed/embed.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;embed&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<embed
+  type="video/mp4"
+  src="/shared-assets/videos/flower.mp4"
+  width="250"
+  height="200" />
+```
 
 > [!NOTE]
 > 本主題僅記錄了作為 [HTML Living Standard](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element) 一部分所定義的元素。它不涉及元素的早期、非標準化實現。

--- a/files/zh-tw/web/html/element/fieldset/index.md
+++ b/files/zh-tw/web/html/element/fieldset/index.md
@@ -7,7 +7,36 @@ slug: Web/HTML/Element/fieldset
 
 **`<fieldset>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於在網頁表單中將多個控件以及標籤（{{HTMLElement("label")}}）分組。
 
-{{EmbedInteractiveExample("pages/tabbed/fieldset.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;fieldset&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<form>
+  <fieldset>
+    <legend>Choose your favorite monster</legend>
+
+    <input type="radio" id="kraken" name="monster" value="K" />
+    <label for="kraken">Kraken</label><br />
+
+    <input type="radio" id="sasquatch" name="monster" value="S" />
+    <label for="sasquatch">Sasquatch</label><br />
+
+    <input type="radio" id="mothman" name="monster" value="M" />
+    <label for="mothman">Mothman</label>
+  </fieldset>
+</form>
+```
+
+```css interactive-example
+legend {
+  background-color: #000;
+  color: #fff;
+  padding: 3px 6px;
+}
+
+input {
+  margin: 0.4rem;
+}
+```
 
 正如上面的範例所示，`<fieldset>` 元素為 HTML 表單的一部分提供了分組功能，其中嵌套的 {{htmlelement("legend")}} 元素為 `<fieldset>` 提供了標題。它有一些屬性，其中最顯著的是 `form`，它可以包含同一頁面上的 {{htmlelement("form")}} 的 `id`，這允許你將 `<fieldset>` 作為該 `<form>` 的一部分，即使它不在其中，以及 `disabled`，它允許你一次性禁用 `<fieldset>` 及其所有內容。
 

--- a/files/zh-tw/web/html/element/figcaption/index.md
+++ b/files/zh-tw/web/html/element/figcaption/index.md
@@ -7,7 +7,40 @@ slug: Web/HTML/Element/figcaption
 
 **`<figcaption>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表其父級 {{HTMLElement("figure")}} 元素餘下內容的標題或圖例，提供 `<figure>` 一個{{glossary("accessible description", "無障礙描述")}}。
 
-{{EmbedInteractiveExample("pages/tabbed/figcaption.html","tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;figcaption&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<figure>
+  <img
+    src="/shared-assets/images/examples/elephant.jpg"
+    alt="Elephant at sunset" />
+  <figcaption>An elephant at sunset</figcaption>
+</figure>
+```
+
+```css interactive-example
+figure {
+  border: thin #c0c0c0 solid;
+  display: flex;
+  flex-flow: column;
+  padding: 5px;
+  max-width: 220px;
+  margin: auto;
+}
+
+img {
+  max-width: 220px;
+  max-height: 150px;
+}
+
+figcaption {
+  background-color: #222;
+  color: #fff;
+  font: italic smaller sans-serif;
+  padding: 3px;
+  text-align: center;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/figure/index.md
+++ b/files/zh-tw/web/html/element/figure/index.md
@@ -7,7 +7,40 @@ slug: Web/HTML/Element/figure
 
 **`<figure>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表自成一體的內容，可能具有非必填的圖片說明（使用 {{HTMLElement("figcaption")}} 元素指定）。圖片、其圖片說明和其內容被作為一個單一單位被引用。
 
-{{EmbedInteractiveExample("pages/tabbed/figure.html","tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;figure&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<figure>
+  <img
+    src="/shared-assets/images/examples/elephant.jpg"
+    alt="Elephant at sunset" />
+  <figcaption>An elephant at sunset</figcaption>
+</figure>
+```
+
+```css interactive-example
+figure {
+  border: thin #c0c0c0 solid;
+  display: flex;
+  flex-flow: column;
+  padding: 5px;
+  max-width: 220px;
+  margin: auto;
+}
+
+img {
+  max-width: 220px;
+  max-height: 150px;
+}
+
+figcaption {
+  background-color: #222;
+  color: #fff;
+  font: italic smaller sans-serif;
+  padding: 3px;
+  text-align: center;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/footer/index.md
+++ b/files/zh-tw/web/html/element/footer/index.md
@@ -7,7 +7,37 @@ slug: Web/HTML/Element/footer
 
 **`<footer>`** [HTML](/zh-TW/docs/Web/HTML) 元素表示其最近的[章節型內容](/zh-TW/docs/Web/HTML/Content_categories#章節型內容)或[章節根](/zh-TW/docs/Web/HTML/Element/Heading_Elements#章節根)元素的頁尾。`<footer>` 通常包含有關該章節作者的信息、版權數據或與相關文檔的鏈接。
 
-{{EmbedInteractiveExample("pages/tabbed/footer.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;footer&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<article>
+  <h1>How to be a wizard</h1>
+  <ol>
+    <li>Grow a long, majestic beard.</li>
+    <li>Wear a tall, pointed hat.</li>
+    <li>Have I mentioned the beard?</li>
+  </ol>
+  <footer>
+    <p>© 2018 Gandalf</p>
+  </footer>
+</article>
+```
+
+```css interactive-example
+article {
+  min-height: 100%;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+}
+
+footer {
+  display: flex;
+  justify-content: center;
+  padding: 5px;
+  background-color: #45a1ff;
+  color: #fff;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/form/index.md
+++ b/files/zh-tw/web/html/element/form/index.md
@@ -7,7 +7,43 @@ slug: Web/HTML/Element/form
 
 **`<form>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表了一個包含用於提交信息的交互式控制項的文件章節。
 
-{{EmbedInteractiveExample("pages/tabbed/form.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;form&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<form action="" method="get" class="form-example">
+  <div class="form-example">
+    <label for="name">Enter your name: </label>
+    <input type="text" name="name" id="name" required />
+  </div>
+  <div class="form-example">
+    <label for="email">Enter your email: </label>
+    <input type="email" name="email" id="email" required />
+  </div>
+  <div class="form-example">
+    <input type="submit" value="Subscribe!" />
+  </div>
+</form>
+```
+
+```css interactive-example
+form.form-example {
+  display: table;
+}
+
+div.form-example {
+  display: table-row;
+}
+
+label,
+input {
+  display: table-cell;
+  margin-bottom: 10px;
+}
+
+label {
+  padding-right: 10px;
+}
+```
 
 可以使用 {{cssxref(':valid')}} 和 {{cssxref(':invalid')}} CSS [偽類](/zh-TW/docs/Web/CSS/Pseudo-classes)根據表單內的{{domxref("HTMLFormElement.elements", "元素", "", 1)}}是否有效來設置 `<form>` 元素的樣式。
 

--- a/files/zh-tw/web/html/element/header/index.md
+++ b/files/zh-tw/web/html/element/header/index.md
@@ -7,7 +7,48 @@ slug: Web/HTML/Element/header
 
 **`<header>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表導言內容，通常是一組導言或導航輔助元素。它可能包含一些標題元素，也可能包含標誌、搜索表單、作者名稱和其他元素。
 
-{{EmbedInteractiveExample("pages/tabbed/header.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;header&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<header>
+  <a class="logo" href="#">Cute Puppies Express!</a>
+</header>
+
+<article>
+  <header>
+    <h1>Beagles</h1>
+    <time>08.12.2014</time>
+  </header>
+  <p>
+    I love beagles <em>so</em> much! Like, really, a lot. They’re adorable and
+    their ears are so, so snugly soft!
+  </p>
+</article>
+```
+
+```css interactive-example
+.logo {
+  background: left / cover
+    url("/shared-assets/images/examples/puppy-header.jpg");
+  display: flex;
+  height: 120px;
+  align-items: center;
+  justify-content: center;
+  font:
+    bold calc(1em + 2 * (100vw - 120px) / 100) "Dancing Script",
+    fantasy;
+  color: #ff0083;
+  text-shadow: #000 2px 2px 0.2rem;
+}
+
+header > h1 {
+  margin-bottom: 0;
+}
+
+header > time {
+  font: italic 0.7rem sans-serif;
+}
+```
 
 ## 使用注意事項
 

--- a/files/zh-tw/web/html/element/heading_elements/index.md
+++ b/files/zh-tw/web/html/element/heading_elements/index.md
@@ -7,7 +7,46 @@ slug: Web/HTML/Element/Heading_Elements
 
 **`<h1>`** 到 **`<h6>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表六個級別的章節標題。`<h1>` 是最高的章節級別，`<h6>` 是最低的。默認情況下，所有標題元素在佈局中創建一個[區塊級](/zh-TW/docs/Glossary/Block-level_content)區域，從新行開始並佔據其包含區塊中可用的全部寬度。
 
-{{EmbedInteractiveExample("pages/tabbed/h1-h6.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;h1-h6&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<h1>Beetles</h1>
+<h2>External morphology</h2>
+<h3>Head</h3>
+<h4>Mouthparts</h4>
+<h3>Thorax</h3>
+<h4>Prothorax</h4>
+<h4>Pterothorax</h4>
+```
+
+```css interactive-example
+h1,
+h2,
+h3,
+h4 {
+  margin: 0.1rem 0;
+}
+
+h1 {
+  font-size: 2rem;
+}
+
+h2 {
+  font-size: 1.5rem;
+  padding-left: 20px;
+}
+
+h3 {
+  font-size: 1.2rem;
+  padding-left: 40px;
+}
+
+h4 {
+  font-size: 1rem;
+  font-style: italic;
+  padding-left: 60px;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/hgroup/index.md
+++ b/files/zh-tw/web/html/element/hgroup/index.md
@@ -7,7 +7,37 @@ slug: Web/HTML/Element/hgroup
 
 **`<hgroup>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表一個標題及相關內容。它將一個單獨的 [`<h1>–<h6>`](/zh-TW/docs/Web/HTML/Element/Heading_Elements) 元素與一個或多個 [`<p>`](/zh-TW/docs/Web/HTML/Element/p) 元素分組。
 
-{{EmbedInteractiveExample("pages/tabbed/hgroup.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;hgroup&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<hgroup>
+  <h1>Frankenstein</h1>
+  <p>Or: The Modern Prometheus</p>
+</hgroup>
+<p>
+  Victor Frankenstein, a Swiss scientist, has a great ambition: to create
+  intelligent life. But when his creature first stirs, he realizes he has made a
+  monster. A monster which, abandoned by his master and shunned by everyone who
+  sees it, follows Dr Frankenstein to the very ends of the earth.
+</p>
+```
+
+```css interactive-example
+hgroup {
+  text-align: right;
+  padding-right: 16px;
+  border-right: 10px solid #00c8d7;
+}
+
+hgroup h1 {
+  margin-bottom: 0;
+}
+
+hgroup p {
+  margin: 0;
+  font-weight: bold;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/i/index.md
+++ b/files/zh-tw/web/html/element/i/index.md
@@ -7,7 +7,27 @@ slug: Web/HTML/Element/i
 
 **`<i>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表一段文字，由於某些原因與正常文字有所區分，例如成語、專業術語、分類設計等。歷史上，這些元素通常以斜體字來呈現，這也是這個元素被命名為 `<i>` 的原因。
 
-{{EmbedInteractiveExample("pages/tabbed/i.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;i&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<p>I looked at it and thought <i>This can't be real!</i></p>
+
+<p>
+  <i>Musa</i> is one of two or three genera in the family <i>Musaceae</i>; it
+  includes bananas and plantains.
+</p>
+
+<p>
+  The term <i>bandwidth</i> describes the measure of how much information can
+  pass through a data connection in a given amount of time.
+</p>
+```
+
+```css interactive-example
+/* stylelint-disable-next-line block-no-empty */
+i {
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/ins/index.md
+++ b/files/zh-tw/web/html/element/ins/index.md
@@ -7,7 +7,55 @@ slug: Web/HTML/Element/ins
 
 **`<ins>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表已添加到文件的一段文字範圍。你可以使用 {{HTMLElement("del")}} 元素來類似地表示已從文件中刪除的文字範圍。
 
-{{EmbedInteractiveExample("pages/tabbed/ins.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;ins&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<p>&ldquo;You're late!&rdquo;</p>
+<del>
+  <p>&ldquo;I apologize for the delay.&rdquo;</p>
+</del>
+<ins cite="../howtobeawizard.html" datetime="2018-05">
+  <p>&ldquo;A wizard is never late &hellip;&rdquo;</p>
+</ins>
+```
+
+```css interactive-example
+del,
+ins {
+  display: block;
+  text-decoration: none;
+  position: relative;
+}
+
+del {
+  background-color: #fbb;
+}
+
+ins {
+  background-color: #d4fcbc;
+}
+
+del::before,
+ins::before {
+  position: absolute;
+  left: 0.5rem;
+  font-family: monospace;
+}
+
+del::before {
+  content: "−";
+}
+
+ins::before {
+  content: "+";
+}
+
+p {
+  margin: 0 1.8rem 0;
+  font-family: Georgia, serif;
+  font-size: 1rem;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/map/index.md
+++ b/files/zh-tw/web/html/element/map/index.md
@@ -7,7 +7,40 @@ slug: Web/HTML/Element/map
 
 **`<map>`** [HTML](/zh-TW/docs/Web/HTML) 元素與 {{HTMLElement("area")}} 元素一同使用，用於定義圖像映射（可點擊的鏈接區域）。
 
-{{EmbedInteractiveExample("pages/tabbed/map.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;map&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<map name="infographic">
+  <area
+    shape="poly"
+    coords="130,147,200,107,254,219,130,228"
+    href="https://developer.mozilla.org/docs/Web/HTML"
+    alt="HTML" />
+  <area
+    shape="poly"
+    coords="130,147,130,228,6,219,59,107"
+    href="https://developer.mozilla.org/docs/Web/CSS"
+    alt="CSS" />
+  <area
+    shape="poly"
+    coords="130,147,200,107,130,4,59,107"
+    href="https://developer.mozilla.org/docs/Web/JavaScript"
+    alt="JavaScript" />
+</map>
+<img
+  usemap="#infographic"
+  src="/shared-assets/images/examples/mdn-info2.png"
+  alt="MDN infographic" />
+```
+
+```css interactive-example
+img {
+  display: block;
+  margin: 0 auto;
+  width: 260px;
+  height: 232px;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/p/index.md
+++ b/files/zh-tw/web/html/element/p/index.md
@@ -9,7 +9,27 @@ slug: Web/HTML/Element/p
 
 段落是[區塊級元素](/zh-TW/docs/Glossary/Block-level_content)，特別是在解析了結束的 `</p>` 標記之前，如果解析了另一個區塊級元素，則段落會自動關閉。參見下面的「標籤省略」。
 
-{{EmbedInteractiveExample("pages/tabbed/p.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;p&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<p>
+  Geckos are a group of usually small, usually nocturnal lizards. They are found
+  on every continent except Antarctica.
+</p>
+
+<p>
+  Some species live in houses where they hunt insects attracted by artificial
+  light.
+</p>
+```
+
+```css interactive-example
+p {
+  margin: 10px 0;
+  padding: 5px;
+  border: 1px solid #999;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/picture/index.md
+++ b/files/zh-tw/web/html/element/picture/index.md
@@ -9,7 +9,18 @@ slug: Web/HTML/Element/picture
 
 瀏覽器將會考慮每個 `<source>` 元素，並且在其中選出最適當的選項。如果沒有找到最適當的選項——或是瀏覽器不支援 `<picture>` 元素——則 `<img>` 屬性的 URL 會被選擇。被選擇的圖片將會在 `<img>` 元素存在的位置顯示。
 
-{{EmbedInteractiveExample("pages/tabbed/picture.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;picture&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<!--Change the browser window width to see the image change.-->
+
+<picture>
+  <source
+    srcset="/shared-assets/images/examples/surfer.jpg"
+    media="(orientation: portrait)" />
+  <img src="/shared-assets/images/examples/painted-hand.jpg" alt="" />
+</picture>
+```
 
 為了決定載入哪一個 URL，{{Glossary("user agent")}} 會檢視每一個 `<source>` 的 [`srcset`](/zh-TW/docs/Web/HTML/Element/source#srcset)、[`media`](/zh-TW/docs/Web/HTML/Element/source#media) 以及 [`type`](/zh-TW/docs/Web/HTML/Element/source#type) 屬性，以選出最適合當前版面以及顯示裝置支援度的圖片。
 

--- a/files/zh-tw/web/html/element/pre/index.md
+++ b/files/zh-tw/web/html/element/pre/index.md
@@ -9,7 +9,35 @@ slug: Web/HTML/Element/pre
 
 預設情況下，`<pre>` 是[區塊級](/zh-TW/docs/Glossary/Block-level_content)元素，即其預設的 {{cssxref("display")}} 值為 `block`。
 
-{{EmbedInteractiveExample("pages/tabbed/pre.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;pre&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<pre>
+  L          TE
+    A       A
+      C    V
+       R A
+       DOU
+       LOU
+      REUSE
+      QUE TU
+      PORTES
+    ET QUI T'
+    ORNE O CI
+     VILISÉ
+    OTE-  TU VEUX
+     LA    BIEN
+    SI      RESPI
+            RER       - Apollinaire
+</pre>
+```
+
+```css interactive-example
+pre {
+  font-size: 0.7rem;
+  margin: 0;
+}
+```
 
 如果你需要在 `<pre>` 標籤內顯示保留字元，如 `<`、`>`、`&` 和 `"`，這些字元必須使用相應的 [HTML 實體](/zh-TW/docs/Glossary/Entity)進行轉義。
 

--- a/files/zh-tw/web/html/element/progress/index.md
+++ b/files/zh-tw/web/html/element/progress/index.md
@@ -7,7 +7,20 @@ slug: Web/HTML/Element/progress
 
 **`<progress>`** [HTML](/zh-TW/docs/Web/HTML) 元素顯示顯示任務完成進度的指示器，通常呈現為進度條。
 
-{{EmbedInteractiveExample("pages/tabbed/progress.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;progress&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<label for="file">File progress:</label>
+
+<progress id="file" max="100" value="70">70%</progress>
+```
+
+```css interactive-example
+label {
+  padding-right: 10px;
+  font-size: 1rem;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/rp/index.md
+++ b/files/zh-tw/web/html/element/rp/index.md
@@ -7,7 +7,19 @@ slug: Web/HTML/Element/rp
 
 **`<rp>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於為不支援使用 {{HTMLElement("ruby")}} 元素顯示 ruby 注釋的瀏覽器提供回退括號。每個 `<rp>` 元素應該包裹著包含注釋文字的 {{HTMLElement("rt")}} 元素的開始和結束括號。
 
-{{EmbedInteractiveExample("pages/tabbed/rp.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;rp&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<ruby>
+  漢 <rp>(</rp><rt>kan</rt><rp>)</rp> 字 <rp>(</rp><rt>ji</rt><rp>)</rp>
+</ruby>
+```
+
+```css interactive-example
+ruby {
+  font-size: 2em;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/rt/index.md
+++ b/files/zh-tw/web/html/element/rt/index.md
@@ -7,7 +7,19 @@ slug: Web/HTML/Element/rt
 
 **`<rt>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於指定 ruby 注釋的 ruby 文本部分，用於為東亞排版提供發音、翻譯或音譯信息。`<rt>` 元素必須始終包含在一個 {{HTMLElement("ruby")}} 元素中。
 
-{{EmbedInteractiveExample("pages/tabbed/rt.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;rt&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<ruby>
+  漢 <rp>(</rp><rt>kan</rt><rp>)</rp> 字 <rp>(</rp><rt>ji</rt><rp>)</rp>
+</ruby>
+```
+
+```css interactive-example
+ruby {
+  font-size: 2em;
+}
+```
 
 請參見 {{HTMLElement("ruby")}} 元素的文章以獲取更多範例。
 

--- a/files/zh-tw/web/html/element/ruby/index.md
+++ b/files/zh-tw/web/html/element/ruby/index.md
@@ -7,7 +7,17 @@ slug: Web/HTML/Element/ruby
 
 **HTML `<ruby>` 元素**的意思是旁註標記。旁註標記用於標示東亞文字的發音。
 
-{{EmbedInteractiveExample("pages/tabbed/ruby.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;ruby&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<ruby> 明日 <rp>(</rp><rt>Ashita</rt><rp>)</rp> </ruby>
+```
+
+```css interactive-example
+ruby {
+  font-size: 2em;
+}
+```
 
 | [內容類型](/zh-TW/docs/Web/HTML/Content_categories) | [流內容](/zh-TW/docs/Web/HTML/Content_categories#flow_content)、[段落型內容](/zh-TW/docs/Web/HTML/Content_categories#phrasing_content)、捫及內容 |
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/files/zh-tw/web/html/element/samp/index.md
+++ b/files/zh-tw/web/html/element/samp/index.md
@@ -7,7 +7,21 @@ slug: Web/HTML/Element/samp
 
 **`<samp>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於封裝代表電腦程式的樣本（或引用）輸出的內嵌文本。其內容通常使用瀏覽器的預設等寬字體呈現（如 [Courier](https://zh.wikipedia.org/wiki/Courier) 或 Lucida Console）。
 
-{{EmbedInteractiveExample("pages/tabbed/samp.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;samp&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<p>I was trying to boot my computer, but I got this hilarious message:</p>
+
+<p>
+  <samp>Keyboard not found <br />Press F1 to continue</samp>
+</p>
+```
+
+```css interactive-example
+samp {
+  font-weight: bold;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/section/index.md
+++ b/files/zh-tw/web/html/element/section/index.md
@@ -7,7 +7,33 @@ slug: Web/HTML/Element/section
 
 **`<section>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表文件中的通用獨立區段，它沒有更具體的語義元素來代表它。區段應始終具有標題，幾乎沒有例外。
 
-{{EmbedInteractiveExample("pages/tabbed/section.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;section&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<h1>Choosing an Apple</h1>
+<section>
+  <h2>Introduction</h2>
+  <p>
+    This document provides a guide to help with the important task of choosing
+    the correct Apple.
+  </p>
+</section>
+
+<section>
+  <h2>Criteria</h2>
+  <p>
+    There are many different criteria to be considered when choosing an Apple —
+    size, color, firmness, sweetness, tartness...
+  </p>
+</section>
+```
+
+```css interactive-example
+h1,
+h2 {
+  margin: 0;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/small/index.md
+++ b/files/zh-tw/web/html/element/small/index.md
@@ -7,7 +7,29 @@ slug: Web/HTML/Element/small
 
 **`<small>`** [HTML](/zh-TW/docs/Web/HTML) 元素表示側注和小字印刷，如版權和法律文本，獨立於其風格化呈現。默認情況下，它以比其中的文本小一號的字體大小呈現，例如從 `small` 到 `x-small`。
 
-{{EmbedInteractiveExample("pages/tabbed/small.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;small&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<p>
+  MDN Web Docs is a learning platform for Web technologies and the software that
+  powers the Web.
+</p>
+
+<hr />
+
+<p>
+  <small
+    >The content is licensed under a Creative Commons Attribution-ShareAlike 2.5
+    Generic License.</small
+  >
+</p>
+```
+
+```css interactive-example
+small {
+  font-size: 0.7em;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/span/index.md
+++ b/files/zh-tw/web/html/element/span/index.md
@@ -7,7 +7,26 @@ slug: Web/HTML/Element/span
 
 **`<span>`** [HTML](/zh-TW/docs/Web/HTML) 元素是一個通用的行級容器，用於包裹詞組內容，本身並不代表任何特定含義。它可用於為樣式目的（使用 [`class`](/zh-TW/docs/Web/HTML/Global_attributes#class) 或 [`id`](/zh-TW/docs/Web/HTML/Global_attributes#id) 屬性）對元素進行分組，或因它們共享屬性值（如 [`lang`](/zh-TW/docs/Web/HTML/Global_attributes#lang)）而使用。僅在沒有其他語義元素適用時應使用 `<span>`。`<span>` 非常類似於 {{HTMLElement("div")}} 元素，但 {{HTMLElement("div")}} 是一個[塊級元素](/zh-TW/docs/Glossary/Block-level_content)，而 `<span>` 是一個[行級元素](/zh-TW/docs/Glossary/Inline-level_content)。
 
-{{EmbedInteractiveExample("pages/tabbed/span.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;span&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<p>
+  Add the <span class="ingredient">basil</span>,
+  <span class="ingredient">pine nuts</span> and
+  <span class="ingredient">garlic</span> to a blender and blend into a paste.
+</p>
+
+<p>
+  Gradually add the <span class="ingredient">olive oil</span> while running the
+  blender slowly.
+</p>
+```
+
+```css interactive-example
+span.ingredient {
+  color: #f00;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/table/index.md
+++ b/files/zh-tw/web/html/element/table/index.md
@@ -7,7 +7,93 @@ slug: Web/HTML/Element/table
 
 **HTML `<table>` 元件**代表表格數據 ── 換句話說，就是透過二維資料表來呈現資訊。
 
-{{EmbedInteractiveExample("pages/tabbed/table.html","tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;table&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<table>
+  <caption>
+    Front-end web developer course 2021
+  </caption>
+  <thead>
+    <tr>
+      <th scope="col">Person</th>
+      <th scope="col">Most interest in</th>
+      <th scope="col">Age</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Chris</th>
+      <td>HTML tables</td>
+      <td>22</td>
+    </tr>
+    <tr>
+      <th scope="row">Dennis</th>
+      <td>Web accessibility</td>
+      <td>45</td>
+    </tr>
+    <tr>
+      <th scope="row">Sarah</th>
+      <td>JavaScript frameworks</td>
+      <td>29</td>
+    </tr>
+    <tr>
+      <th scope="row">Karen</th>
+      <td>Web performance</td>
+      <td>36</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <th scope="row" colspan="2">Average age</th>
+      <td>33</td>
+    </tr>
+  </tfoot>
+</table>
+```
+
+```css interactive-example
+table {
+  border-collapse: collapse;
+  border: 2px solid rgb(140 140 140);
+  font-family: sans-serif;
+  font-size: 0.8rem;
+  letter-spacing: 1px;
+}
+
+caption {
+  caption-side: bottom;
+  padding: 10px;
+  font-weight: bold;
+}
+
+thead,
+tfoot {
+  background-color: rgb(228 240 245);
+}
+
+th,
+td {
+  border: 1px solid rgb(160 160 160);
+  padding: 8px 10px;
+}
+
+td:last-of-type {
+  text-align: center;
+}
+
+tbody > tr:nth-of-type(even) {
+  background-color: rgb(237 238 242);
+}
+
+tfoot th {
+  text-align: right;
+}
+
+tfoot td {
+  font-weight: bold;
+}
+```
 
 <table class="properties">
   <tbody>

--- a/files/zh-tw/web/html/element/ul/index.md
+++ b/files/zh-tw/web/html/element/ul/index.md
@@ -7,7 +7,30 @@ slug: Web/HTML/Element/ul
 
 **`<ul>`** [HTML](/zh-TW/docs/Web/HTML) 元素表示項目的無序清單，通常呈現為項目符號清單。
 
-{{EmbedInteractiveExample("pages/tabbed/ul.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;ul&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<ul>
+  <li>Milk</li>
+  <li>
+    Cheese
+    <ul>
+      <li>Blue cheese</li>
+      <li>Feta</li>
+    </ul>
+  </li>
+</ul>
+```
+
+```css interactive-example
+li {
+  list-style-type: circle;
+}
+
+li li {
+  list-style-type: square;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/var/index.md
+++ b/files/zh-tw/web/html/element/var/index.md
@@ -7,7 +7,21 @@ slug: Web/HTML/Element/var
 
 **`<var>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於表示數學表達式或編程上下文中的變數名稱。通常使用斜體版本的當前字型呈現，儘管該行為依賴於瀏覽器。
 
-{{EmbedInteractiveExample("pages/tabbed/var.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;var&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<p>
+  The volume of a box is <var>l</var> × <var>w</var> × <var>h</var>, where
+  <var>l</var> represents the length, <var>w</var> the width and
+  <var>h</var> the height of the box.
+</p>
+```
+
+```css interactive-example
+var {
+  font-weight: bold;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/element/wbr/index.md
+++ b/files/zh-tw/web/html/element/wbr/index.md
@@ -7,7 +7,25 @@ slug: Web/HTML/Element/wbr
 
 **`<wbr>`** [HTML](/zh-TW/docs/Web/HTML) 元素代表換行機會，即文本中的位置，瀏覽器可以選擇在該位置斷行，儘管其斷行規則在該位置本身不會創建斷行。
 
-{{EmbedInteractiveExample("pages/tabbed/wbr.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;wbr&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<div id="example-paragraphs">
+  <p>Fernstraßenbauprivatfinanzierungsgesetz</p>
+  <p>Fernstraßen<wbr />bau<wbr />privat<wbr />finanzierungs<wbr />gesetz</p>
+  <p>Fernstraßen&shy;bau&shy;privat&shy;finanzierungs&shy;gesetz</p>
+</div>
+```
+
+```css interactive-example
+#example-paragraphs {
+  background-color: white;
+  overflow: hidden;
+  resize: horizontal;
+  width: 9rem;
+  border: 2px dashed #999;
+}
+```
 
 ## 屬性
 

--- a/files/zh-tw/web/html/global_attributes/style/index.md
+++ b/files/zh-tw/web/html/global_attributes/style/index.md
@@ -9,7 +9,16 @@ l10n:
 
 **`style`** [全域屬性](/zh-TW/docs/Web/HTML/Global_attributes) 包含要應用於此元素的 [CSS](/zh-TW/docs/Web/CSS) 樣式宣告。請注意，建議將樣式定義在單獨的檔案中。此屬性和 {{HTMLElement("style")}} 元素主要目的是允許快速設定樣式，例如用於測試目的。
 
-{{EmbedInteractiveExample("pages/tabbed/attribute-style.html","tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: style", "tabbed-shorter")}}
+
+```html interactive-example
+<div style="background: #ffe7e8; border: 2px solid #e66465">
+  <p style="margin: 15px; line-height: 1.5; text-align: center">
+    Well, I am the slime from your video<br />
+    Oozin' along on your livin' room floor.
+  </p>
+</div>
+```
 
 > [!NOTE]
 > 此屬性不得用於傳達語義資訊。即使所有樣式都被移除，頁面也應該保持語義正確。通常不應該使用它來隱藏不相關的資訊；這應該使用 [`hidden`](/zh-TW/docs/Web/HTML/Global_attributes/hidden) 屬性來完成。

--- a/files/zh-tw/web/html/global_attributes/title/index.md
+++ b/files/zh-tw/web/html/global_attributes/title/index.md
@@ -9,7 +9,29 @@ l10n:
 
 [全域屬性](/zh-TW/docs/Web/HTML/Global_attributes) **`title`** 包含表示與其所屬元素相關的建議資訊的文字。
 
-{{EmbedInteractiveExample("pages/tabbed/attribute-title.html","tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: title", "tabbed-shorter")}}
+
+```html interactive-example
+<p>
+  Use the <code>title</code> attribute on an <code>iframe</code> to clearly
+  identify the content of the <code>iframe</code> to screen readers.
+</p>
+
+<iframe
+  title="Wikipedia page for the HTML language"
+  src="https://en.m.wikipedia.org/wiki/HTML"></iframe>
+<iframe
+  title="Wikipedia page for the CSS language"
+  src="https://en.m.wikipedia.org/wiki/CSS"></iframe>
+```
+
+```css interactive-example
+iframe {
+  height: 200px;
+  margin-bottom: 24px;
+  width: 100%;
+}
+```
 
 `title` 屬性的主要用途是為輔助技術標記 {{HTMLElement("iframe")}} 元素。
 

--- a/files/zh-tw/web/media/guides/formats/containers/index.md
+++ b/files/zh-tw/web/media/guides/formats/containers/index.md
@@ -1018,7 +1018,19 @@ To do this, you create a `<video>` (or `<audio>`) element with no [`src`](/zh-TW
 
 In the example shown here, a video is offered to the browser in two formats: WebM and MP4.
 
-{{EmbedInteractiveExample("pages/tabbed/source.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;source&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<video controls width="250" height="200" muted>
+  <source src="/shared-assets/videos/flower.webm" type="video/webm" />
+  <source src="/shared-assets/videos/flower.mp4" type="video/mp4" />
+  Download the
+  <a href="/shared-assets/videos/flower.webm">WEBM</a>
+  or
+  <a href="/shared-assets/videos/flower.mp4">MP4</a>
+  video.
+</video>
+```
 
 The video is offered first in WebM format (with the [`type`](/zh-TW/docs/Web/HTML/Element/video#type) attribute set to `video/webm`). If the {{Glossary("user agent")}} can't play that, it moves on to the next option, whose `type` is specified as `video/mp4`. If neither of those can be played, the text "This browser does not support the HTML5 video element." is presented.
 


### PR DESCRIPTION
See https://github.com/orgs/mdn/discussions/782 for explanation of the wider effort.

This PR migrates the HTML interactive examples, reflecting the changes made in en-US in https://github.com/mdn/content/pull/38257.

Like we did with JS, we've tested these examples with a couple of diff tools to ensure they all work and remain the same as before. See the zipfile of the visual diff in en-US in the above PR for the few small changes in default styling we've made.

No full manual review is necessary, but please do flag if anything seems off. Unlike before, the examples do work in the preview urls created by the bot.