### PR TITLE
fix: `PerformanceNavigationTiming`画像の404を解消

### DIFF
--- a/files/ja/web/api/performancenavigationtiming/index.md
+++ b/files/ja/web/api/performancenavigationtiming/index.md
@@ -15,7 +15,7 @@ l10n:
 
 以下は `PerformanceNavigationTiming` で定義するタイムスタンププロパティをすべて表示させたものです。
 
-![文書内の取得したタイムスタンプを記録順に並べたタイムスタンプ図](timestamp-diagram.svg)
+![文書内の取得したタイムスタンプを記録順に並べたタイムスタンプ図](https://mdn.github.io/shared-assets/images/diagrams/api/performance/timestamp-diagram.svg)
 
 ## インスタンスプロパティ
 

--- a/files/ja/web/api/performanceresourcetiming/index.md
+++ b/files/ja/web/api/performanceresourcetiming/index.md
@@ -50,7 +50,7 @@ l10n:
 
 このインターフェイスは、以下のタイムスタンププロパティに対応しています。図に示すように、リソースのフェッチに記録される順番で掲載されています。アルファベット順の一覧は、左のナビゲーションに掲載されています。
 
-![リソースのフェッチに記録された順にタイムスタンプを掲載しているタイムスタンプ図](timestamp-diagram.svg)
+![リソースのフェッチに記録された順にタイムスタンプを掲載しているタイムスタンプ図](https://mdn.github.io/shared-assets/images/diagrams/api/performance/timestamp-diagram.svg)
 
 - {{domxref('PerformanceResourceTiming.redirectStart')}} {{ReadOnlyInline}}
   - : リダイレクトを開始するフェッチの開始時刻を表す {{domxref("DOMHighResTimeStamp")}} です。


### PR DESCRIPTION
### Description

- 日本語版の以下のページの画像が404となっている状況を改善しました。
  - https://developer.mozilla.org/ja/docs/Web/API/PerformanceNavigationTiming
  - https://developer.mozilla.org/ja/docs/Web/API/PerformanceResourceTiming 
- いずれも英語ページの対象箇所で表示している画像のURLに更新しています。

### Motivation

- ページ情報の拡充のため。

### Additional details

- 特になし

### Related issues and pull requests

- 特になし
