### PR TITLE
feat(workflows/pr-review-companion): sync build to GCS as well

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -17,14 +17,24 @@ on:
     types:
       - completed
 
+  workflow_call:
+    secrets:
+      GCP_PROJECT_NAME:
+        required: true
+      WIP_PROJECT_ID:
+        required: true
+
 permissions:
   # Required to download artifact.
   actions: read
   # Required to post comment.
   pull-requests: write
+  # Authenticate with GCP.
+  id-token: write
 
 jobs:
   review:
+    environment: review
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     steps:
@@ -126,3 +136,23 @@ jobs:
             --pr-number=$PR_NUMBER \
             --diff-file=$BUILD_OUT_ROOT/DIFF \
             $BUILD_OUT_ROOT
+
+      - name: Authenticate with GCP
+        if: env.HAS_ARTIFACT
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          service_account: deploy-mdn-review-content@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
+          workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+
+      - name: Setup gcloud
+        if: env.HAS_ARTIFACT
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Sync build with GCS
+        if: env.HAS_ARTIFACT
+        run: |-
+          PR_NUMBER=`cat build/NR`
+          PREFIX="pr$PR_NUMBER"
+          gsutil -q -m -h "Cache-Control: public, max-age=3600" cp -r build/static "gs://${{ vars.GCP_BUCKET_NAME }}/$PREFIX/"
+          gsutil -q -m -h "Cache-Control: public, max-age=3600" rsync -cdrj html,json,txt -y "^static/" build "gs://${{ vars.GCP_BUCKET_NAME }}/$PREFIX"


### PR DESCRIPTION
### Description

Syncs PR Review Companion builds to GCS in addition to AWS.

### Motivation

Prepares for the upcoming Review environment in GCP.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of MP-1889 (Mozilla-internal).

Bundles the changes from these content PRs:

- https://github.com/mdn/content/pull/38380
- https://github.com/mdn/content/pull/38381
- https://github.com/mdn/content/pull/38382
- https://github.com/mdn/content/pull/38383
