### PR TITLE
fix(typo): リクエストヘッダー使用します → リクエストヘッダーを使用します

### DIFF
--- a/files/ja/glossary/preflight_request/index.md
+++ b/files/ja/glossary/preflight_request/index.md
@@ -9,7 +9,7 @@ l10n:
 
 CORS のプリフライトリクエストは {{Glossary("CORS")}} のリクエストの一つであり、サーバーが CORS プロトコルを理解していて準備がされていることを、特定のメソッドとヘッダーを使用してチェックします。
 
-これは {{HTTPMethod("OPTIONS")}} リクエストであり、 {{HTTPHeader("Access-Control-Request-Method")}},{{HTTPHeader("Access-Control-Request-Headers")}}, {{HTTPHeader("Origin")}} の 3 つの HTTP リクエストヘッダー使用します。
+これは {{HTTPMethod("OPTIONS")}} リクエストであり、 {{HTTPHeader("Access-Control-Request-Method")}},{{HTTPHeader("Access-Control-Request-Headers")}}, {{HTTPHeader("Origin")}} の 3 つの HTTP リクエストヘッダーを使用します。
 
 プリフライトリクエストはブラウザーが自動的に発行するものであり、通常は、フロントエンドの開発者が自分でそのようなリクエストを作成する必要はありません。これはリクエストが ["to be preflighted"](/ja/docs/Web/HTTP/CORS#プリフライトリクエスト) と修飾されている場合に現れ、[単純リクエスト](/ja/docs/Web/HTTP/CORS#単純リクエスト)の場合は省略されます。
 


### PR DESCRIPTION
### Description

「リクエストヘッダー使用します」を「リクエストヘッダーを使用します」に修正しました。

### Motivation

格助詞「を」が抜けており不自然だと思いました。

### Additional details

なし

### Related issues and pull requests

Fixes: https://github.com/mozilla-japan/translation/issues/824