### PR TITLE
zh-cn: fix the typo in JavaScript `static` keyword

### DIFF
--- a/files/zh-cn/web/javascript/reference/classes/static/index.md
+++ b/files/zh-cn/web/javascript/reference/classes/static/index.md
@@ -142,7 +142,7 @@ console.log(Triple.calculate(6)); // 18
 
 let tp = new Triple();
 
-console.log(SquaredTriple.tripple(3)); // 81（不会受父类实例化的影响）
+console.log(SquaredTriple.calculate(3)); // 81（不会受父类实例化的影响）
 console.log(SquaredTriple.description); // '我可以让你提供的任何数变为其三倍的平方'
 console.log(SquaredTriple.longDescription); // undefined
 console.log(SquaredTriple.customName); // '三倍器'


### PR DESCRIPTION
Fix: methods call with wrong name, should be SquaredTriple.calculate(3) rather than SquaredTriple.tripple(3)


### Description

Typo: Change `SquaredTriple.tripple(3)` to  `SquaredTriple.calculate(3)`