### PR TITLE
chore(workflows/pr-review-companion): upload to GCS first

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -51,6 +51,8 @@ jobs:
         if: hashFiles('build/') != ''
         run: |
           echo "HAS_ARTIFACT=true" >> "$GITHUB_ENV"
+          PR_NUMBER=`cat build/NR`
+          echo "PREFIX=pr$PR_NUMBER" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@v4
         if: env.HAS_ARTIFACT
@@ -104,6 +106,28 @@ jobs:
           cd yari/deployer
           poetry install --no-interaction
 
+      - name: Authenticate with GCP
+        if: env.HAS_ARTIFACT
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          service_account: deploy-mdn-review-content@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
+          workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+
+      - name: Setup gcloud
+        if: env.HAS_ARTIFACT
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Upload to GCS
+        if: env.HAS_ARTIFACT
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: "build"
+          destination: "${{ vars.GCP_BUCKET_NAME }}/${{ env.PREFIX }}"
+          resumable: false
+          concurrency: 500
+          process_gcloudignore: false
+
       - name: Deploy and analyze built content
         if: env.HAS_ARTIFACT
         env:
@@ -136,23 +160,3 @@ jobs:
             --pr-number=$PR_NUMBER \
             --diff-file=$BUILD_OUT_ROOT/DIFF \
             $BUILD_OUT_ROOT
-
-      - name: Authenticate with GCP
-        if: env.HAS_ARTIFACT
-        uses: google-github-actions/auth@v2
-        with:
-          token_format: access_token
-          service_account: deploy-mdn-review-content@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
-          workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
-
-      - name: Setup gcloud
-        if: env.HAS_ARTIFACT
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Sync build with GCS
-        if: env.HAS_ARTIFACT
-        run: |-
-          PR_NUMBER=`cat build/NR`
-          PREFIX="pr$PR_NUMBER"
-          gsutil -q -m -h "Cache-Control: public, max-age=3600" cp -r build/static "gs://${{ vars.GCP_BUCKET_NAME }}/$PREFIX/"
-          gsutil -q -m -h "Cache-Control: public, max-age=3600" rsync -cdrj html,json,txt -y "^static/" build "gs://${{ vars.GCP_BUCKET_NAME }}/$PREFIX"


### PR DESCRIPTION
Also speeds it up via `google-github-actions/upload-cloud-storage`.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

1. Speed up the GCS upload by switching to [google-github-actions/upload-cloud-storage](https://github.com/google-github-actions/upload-cloud-storage) with optimized parameters.
2. Moves the GSC upload before the AWS upload.

### Motivation

1. Currently, the upload appears to be noticeable slower than AWS S3 upload.
2. Ensures that the GSC upload has finished when the GitHub comment is posted.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Ports these changes from mdn/content:

- https://github.com/mdn/content/pull/38419
- https://github.com/mdn/content/pull/38422