### PR TITLE
[es]: Migrate tabbed CSS interactive examples

### DIFF
--- a/files/es/web/css/_colon_is/index.md
+++ b/files/es/web/css/_colon_is/index.md
@@ -12,7 +12,50 @@ La función [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) de [CSS](/es/docs/We
 > [!NOTE]
 > Originalmente llamado `:matches()` (y `:any()`), este selector pasó a llamarse `:is()` en [CSSWG número 3258](https://github.com/w3c/csswg-drafts/issues/3258).
 
-{{EmbedInteractiveExample("pages/tabbed/pseudo-class-is.html", "tabbed-shorter")}}
+{{InteractiveExample("CSS Demo: :is", "tabbed-shorter")}}
+
+```css interactive-example
+ol {
+  list-style-type: upper-alpha;
+  color: darkblue;
+}
+
+/* stylelint-disable-next-line selector-pseudo-class-no-unknown */
+:is(ol, ul, menu:unsupported) :is(ol, ul) {
+  color: green;
+}
+
+:is(ol, ul) :is(ol, ul) ol {
+  list-style-type: lower-greek;
+  color: chocolate;
+}
+```
+
+```html interactive-example
+<ol>
+  <li>Saturn</li>
+  <li>
+    <ul>
+      <li>Mimas</li>
+      <li>Enceladus</li>
+      <li>
+        <ol>
+          <li>Voyager</li>
+          <li>Cassini</li>
+        </ol>
+      </li>
+      <li>Tethys</li>
+    </ul>
+  </li>
+  <li>Uranus</li>
+  <li>
+    <ol>
+      <li>Titania</li>
+      <li>Oberon</li>
+    </ol>
+  </li>
+</ol>
+```
 
 Los pseudoelementos no son válidos en la lista de selección para `:is()`.
 

--- a/files/es/web/css/_colon_is/index.md
+++ b/files/es/web/css/_colon_is/index.md
@@ -268,6 +268,6 @@ some-element::after {
 
 ## Véase también
 
-- {{CSSxRef(":where", ":where()")}} - Como `:is()`, pero con 0 [especificidad](/es/docs/Web/CSS/Specificity).
+- {{CSSxRef(":where", ":where()")}} - Como `:is()`, pero con 0 [especificidad](/es/docs/Web/CSS/CSS_cascade/Specificity).
 - [Lista de selección](/es/docs/Web/CSS/Selector_list)
 - [Componentes web](/es/docs/Web/API/Web_components)

--- a/files/es/web/css/_doublecolon_file-selector-button/index.md
+++ b/files/es/web/css/_doublecolon_file-selector-button/index.md
@@ -7,7 +7,27 @@ slug: Web/CSS/::file-selector-button
 
 El [pseudoelemento](/es/docs/Web/CSS/Pseudo-elements) [CSS](/es/docs/Web/CSS) **`::file-selector-button`** representa el botón de un {{HTMLElement("input") }} con el atributo [`type="file"`](/es/docs/Web/HTML/Element/input/file).
 
-{{EmbedInteractiveExample("pages/tabbed/pseudo-element-file-selector-button.html", "tabbed-shorter")}}
+{{InteractiveExample("CSS Demo: ::file-selector-button", "tabbed-shorter")}}
+
+```css interactive-example
+input {
+  margin-top: 1rem;
+}
+
+input::file-selector-button {
+  font-weight: bold;
+  color: dodgerblue;
+  padding: 0.5em;
+  border: thin solid grey;
+  border-radius: 3px;
+}
+```
+
+```html interactive-example
+<label for="avatar">Choose a profile picture:</label><br />
+
+<input id="avatar" type="file" name="avatar" accept="image/png, image/jpeg" />
+```
 
 > [!NOTE]
 > Las versiones anteriores de navegadores compatibles con WebKit/Blink como Chrome, Opera y Safari (indicados por el prefijo `-webkit`) admitían un pseudoelemento no estándar `::-webkit-file-upload-button`.

--- a/files/es/web/css/_doublecolon_selection/index.md
+++ b/files/es/web/css/_doublecolon_selection/index.md
@@ -9,7 +9,20 @@ l10n:
 
 El [pseudoelemento](/es/docs/Web/CSS/Pseudo-elements) de CSS **`::selection`** aplica estilos a la parte de un documento que ha sido resaltada por el usuario (como hacer clic y arrastrar el ratón sobre el texto).
 
-{{EmbedInteractiveExample("pages/tabbed/pseudo-element-selection.html", "tabbed-shorter")}}
+{{InteractiveExample("CSS Demo: ::selection", "tabbed-shorter")}}
+
+```css interactive-example
+p::selection {
+  color: red;
+  background-color: yellow;
+}
+```
+
+```html interactive-example
+<p>
+  Select a fragment of this paragraph, to see how its appearance is affected.
+</p>
+```
 
 ## Propiedades permitidas
 


### PR DESCRIPTION
See https://github.com/orgs/mdn/discussions/782 for explanation of the wider effort.

This PR migrates the tabbed CSS interactive examples, reflecting the changes made in en-US in https://github.com/mdn/content/pull/38356

Like we did with HTML, we've tested these examples with a couple of diff tools to ensure they all work and remain the same as before. See the zipfile of the visual diff in en-US in the above PR for the few small changes in default styling we've made.

No full manual review is necessary, but please do flag if anything seems off: you can check the examples in the preview urls.