### PR TITLE
[ru]: Migrate tabbed CSS interactive examples

### DIFF
--- a/files/ru/web/css/@layer/index.md
+++ b/files/ru/web/css/@layer/index.md
@@ -9,7 +9,32 @@ l10n:
 
 [CSS](/ru/docs/Web/CSS) [@-правило](/ru/docs/Web/CSS/At-rule) **`@layer`** используется для объявления каскадного слоя, а также позволяет задать приоритеты при наличии нескольких каскадных слоёв.
 
-{{EmbedInteractiveExample("pages/tabbed/at-rule-layer.html", "tabbed-standard")}}
+{{InteractiveExample("CSS Demo: @layer", "tabbed-standard")}}
+
+```css interactive-example
+@layer module, state;
+
+@layer state {
+  .alert {
+    background-color: brown;
+  }
+  p {
+    border: medium solid limegreen;
+  }
+}
+
+@layer module {
+  .alert {
+    border: medium solid violet;
+    background-color: yellow;
+    color: white;
+  }
+}
+```
+
+```html interactive-example
+<p class="alert">Beware of the zombies</p>
+```
 
 ## Синтаксис
 

--- a/files/ru/web/css/@layer/index.md
+++ b/files/ru/web/css/@layer/index.md
@@ -33,7 +33,7 @@ l10n:
 ```
 
 ```html interactive-example
-<p class="alert">Beware of the zombies</p>
+<p class="alert">Остерегайтесь зомби!</p>
 ```
 
 ## Синтаксис

--- a/files/ru/web/css/_colon_only-of-type/index.md
+++ b/files/ru/web/css/_colon_only-of-type/index.md
@@ -9,7 +9,37 @@ l10n:
 
 CSS [псевдокласс](/ru/docs/Web/CSS/Pseudo-classes) **`:only-of-type`** выбирает элемент, который является единственным потомком своего типа.
 
-{{EmbedInteractiveExample("pages/tabbed/pseudo-class-only-of-type.html", "tabbed-shorter")}}
+{{InteractiveExample("CSS Demo: :only-of-type", "tabbed-shorter")}}
+
+```css interactive-example
+a:only-of-type {
+  color: fuchsia;
+}
+
+dd:only-of-type {
+  background-color: bisque;
+}
+```
+
+```html interactive-example
+<p>
+  To find out more about <b>QUIC</b>, check <a href="#">RFC 9000</a> and
+  <a href="#">RFC 9114</a>.
+</p>
+
+<dl>
+  <dt>Published</dt>
+  <dd>2021</dd>
+  <dd>2022</dd>
+</dl>
+
+<p>Details about <b>QPACK</b> can be found in <a href="#">RFC 9204</a>.</p>
+
+<dl>
+  <dt>Published</dt>
+  <dd>2022</dd>
+</dl>
+```
 
 ## Синтаксис
 

--- a/files/ru/web/css/_colon_only-of-type/index.md
+++ b/files/ru/web/css/_colon_only-of-type/index.md
@@ -22,7 +22,10 @@ dd:only-of-type {
 ```
 
 ```html interactive-example
-<p>Чтобы узнать больше о <b>QUIC</b>, ознакомьтесь с <a href="#">RFC 9000</a> и <a href="#">RFC 9114</a>.</p>
+<p>
+  Чтобы узнать больше о <b>QUIC</b>, ознакомьтесь с <a href="#">RFC 9000</a> и
+  <a href="#">RFC 9114</a>.
+</p>
 
 <dl>
   <dt>Опубликовано</dt>
@@ -30,7 +33,9 @@ dd:only-of-type {
   <dd>2022</dd>
 </dl>
 
-<p>Подробную информацию о <b>QPACK</b> можно найти в <a href="#">RFC 9204</a>.</p>
+<p>
+  Подробную информацию о <b>QPACK</b> можно найти в <a href="#">RFC 9204</a>.
+</p>
 
 <dl>
   <dt>Опубликовано</dt>

--- a/files/ru/web/css/_colon_only-of-type/index.md
+++ b/files/ru/web/css/_colon_only-of-type/index.md
@@ -22,21 +22,18 @@ dd:only-of-type {
 ```
 
 ```html interactive-example
-<p>
-  To find out more about <b>QUIC</b>, check <a href="#">RFC 9000</a> and
-  <a href="#">RFC 9114</a>.
-</p>
+<p>Чтобы узнать больше о <b>QUIC</b>, ознакомьтесь с <a href="#">RFC 9000</a> и <a href="#">RFC 9114</a>.</p>
 
 <dl>
-  <dt>Published</dt>
+  <dt>Опубликовано</dt>
   <dd>2021</dd>
   <dd>2022</dd>
 </dl>
 
-<p>Details about <b>QPACK</b> can be found in <a href="#">RFC 9204</a>.</p>
+<p>Подробную информацию о <b>QPACK</b> можно найти в <a href="#">RFC 9204</a>.</p>
 
 <dl>
-  <dt>Published</dt>
+  <dt>Опубликовано</dt>
   <dd>2022</dd>
 </dl>
 ```


### PR DESCRIPTION
See https://github.com/orgs/mdn/discussions/782 for explanation of the wider effort.

This PR migrates the tabbed CSS interactive examples, reflecting the changes made in en-US in https://github.com/mdn/content/pull/38356

Like we did with HTML, we've tested these examples with a couple of diff tools to ensure they all work and remain the same as before. See the zipfile of the visual diff in en-US in the above PR for the few small changes in default styling we've made.

No full manual review is necessary, but please do flag if anything seems off: you can check the examples in the preview urls.