### PR TITLE
[zh-tw]: Migrate tabbed CSS interactive examples

### DIFF
--- a/files/zh-tw/web/css/@namespace/index.md
+++ b/files/zh-tw/web/css/@namespace/index.md
@@ -7,7 +7,35 @@ slug: Web/CSS/@namespace
 
 **`@namespace`** 是一個 [at-rule](/zh-TW/docs/Web/CSS/CSS_syntax/At-rule)，它決定要在 [CSS](/zh-TW/docs/Glossary/CSS) [樣式表](/zh-TW/docs/Web/API/StyleSheet)中要使用的 XML [命名空間](/zh-TW/docs/Glossary/Namespaces)。
 
-{{EmbedInteractiveExample("pages/tabbed/at-rule-namespace.html", "tabbed-shorter")}}
+{{InteractiveExample("CSS Demo: @namespace", "tabbed-shorter")}}
+
+```css interactive-example
+@namespace svg url("http://www.w3.org/2000/svg");
+
+a {
+  color: orangered;
+  text-decoration: underline dashed;
+  font-weight: bold;
+}
+
+svg|a {
+  fill: blueviolet;
+  text-decoration: underline solid;
+  text-transform: uppercase;
+}
+```
+
+```html interactive-example
+<p>
+  <a href="#">This is an ordinary HTML link</a>
+</p>
+
+<svg width="250px" viewBox="0 0 250 20" xmlns="http://www.w3.org/2000/svg">
+  <a href="#">
+    <text x="0" y="15">This is a link created in SVG</text>
+  </a>
+</svg>
+```
 
 ## 語法
 

--- a/files/zh-tw/web/css/_doublecolon_first-letter/index.md
+++ b/files/zh-tw/web/css/_doublecolon_first-letter/index.md
@@ -9,7 +9,28 @@ l10n:
 
 **`::first-letter`** [CSS](/zh-TW/docs/Web/CSS) [偽元素](/zh-TW/docs/Web/CSS/Pseudo-elements)用來對[區塊容器](/zh-TW/docs/Web/CSS/Visual_formatting_model#區塊容器)中第一行的第一個字母進行樣式設定，但僅限於前面沒有其他內容（如圖片或內嵌表格）時。
 
-{{EmbedInteractiveExample("pages/tabbed/pseudo-element-first-letter.html", "tabbed-shorter")}}
+{{InteractiveExample("CSS Demo: ::first-letter", "tabbed-shorter")}}
+
+```css interactive-example
+p::first-letter {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: brown;
+}
+```
+
+```html interactive-example
+<p>
+  Scientists exploring the depths of Monterey Bay unexpectedly encountered a
+  rare and unique species of dragonfish. This species is the rarest of its
+  species.
+</p>
+
+<p>
+  When Robison and a team of researchers discovered this fish, they were aboard
+  a week-long expedition.
+</p>
+```
 
 識別一個元素的第一個字母並不總是那麼簡單：
 


### PR DESCRIPTION
See https://github.com/orgs/mdn/discussions/782 for explanation of the wider effort.

This PR migrates the tabbed CSS interactive examples, reflecting the changes made in en-US in https://github.com/mdn/content/pull/38356

Like we did with HTML, we've tested these examples with a couple of diff tools to ensure they all work and remain the same as before. See the zipfile of the visual diff in en-US in the above PR for the few small changes in default styling we've made.

No full manual review is necessary, but please do flag if anything seems off: you can check the examples in the preview urls.