### PR TITLE
fix(workflows/pr-review-companion): exclude parent from upload

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -126,6 +126,7 @@ jobs:
           destination: "${{ vars.GCP_BUCKET_NAME }}/${{ env.PREFIX }}"
           resumable: false
           concurrency: 500
+          parent: false
           process_gcloudignore: false
 
       - name: Deploy and analyze built content


### PR DESCRIPTION
### Description

Excludes the parent folder (`build`) from the review upload.

### Motivation

Previously, the folder `build` was uploaded inside the target folder.

### Additional details

Same as https://github.com/mdn/content/pull/38452.

### Related issues and pull requests

Part of MP-1889 (Mozilla-internal).

Fixup of https://github.com/mdn/translated-content/pull/26137.
