### PR TITLE
chore: cache Prettier runs in lintstaged config

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,9 +1,9 @@
 {
-  "!*.md": "prettier --ignore-unknown --write",
+  "!*.md": "prettier --ignore-unknown --write --cache",
   "*.md": [
     "markdownlint-cli2 --fix",
     "node ./scripts/check-url-locale.js --fix",
     "autocorrect --fix",
-    "prettier --write"
+    "prettier --write --cache"
   ]
 }


### PR DESCRIPTION
### Description

Caching precommit check runs

### Motivation

Making it faster for authors to commit changes.

### Related issues and pull requests

- [x] https://github.com/mdn/content/pull/38574
