### PR TITLE
[zh-cn]: correct the Webkit Bug link releated to "the focus movement issue"

### DIFF
--- a/files/zh-cn/web/api/selection/index.md
+++ b/files/zh-cn/web/api/selection/index.md
@@ -130,7 +130,7 @@ var range = selObj.getRangeAt(0);
 
 选择和输入焦点（由 {{domxref("Document.activeElement")}} 表示）有一个复杂的关系，该关系因浏览器而异。在跨浏览器兼容的代码中，最好分别处理它们。
 
-Safari 和 Chrome（与 Firefox 不同）目前在以编程方式修改 `Selection` 时会将包含选区的元素作为焦点；这可能在将来会发生变化（请参见 [W3C Bug 14383](https://www.w3.org/Bugs/Public/show_bug.cgi?id=14383) 和 [WebKit bug 3869](https://webkit.org/b/3869)）。
+Safari 和 Chrome（与 Firefox 不同）目前在以编程方式修改 `Selection` 时会将包含选区的元素作为焦点；这可能在将来会发生变化（请参见 [W3C Bug 14383](https://www.w3.org/Bugs/Public/show_bug.cgi?id=14383) 和 [WebKit bug 38696](https://webkit.org/b/38696)）。
 
 ### Selection API 在可编辑元素焦点更改方面的行为
 


### PR DESCRIPTION
### Description

[WebKit bug 3869](https://webkit.org/b/3869) is takling about  "use HTML Image element inplace of JS Image object"，it‘s none of business with Selection API。But [WebKit bug 38696](https://webkit.org/b/38696) , which is mention in  [W3C Bug  14383](https://www.w3.org/Bugs/Public/show_bug.cgi?id=14383)，is “WebKit moves focus to where selection is instead of moving selection to the focused element like other browsers”。
I think is a mistake ：）

### Motivation

The incorrect description could mislead readers about the nature of the bug. This correction ensures the issue is accurately represented, helping developers and readers better understand the behavior.

### Additional details
null

### Related issues and pull requests
null

