### PR TITLE
[zh-cn]: update the translation of TextEncoderStream `readable` property

### DIFF
--- a/files/zh-cn/web/api/textencoderstream/readable/index.md
+++ b/files/zh-cn/web/api/textencoderstream/readable/index.md
@@ -2,7 +2,7 @@
 title: TextEncoderStream：readable 属性
 slug: Web/API/TextEncoderStream/readable
 l10n:
-  sourceCommit: 4094b9256ace2d7d805abb6b536e23079aaf9170
+  sourceCommit: 0f42b8ccf6bef96f27e678163954b3a363b9dcf6
 ---
 
 {{APIRef("Encoding API")}}{{AvailableInWorkers}}
@@ -18,7 +18,7 @@ l10n:
 以下示例演示了如何从 `TextEncoderStream` 对象返回一个 `ReadableStream`。
 
 ```js
-stream = new TextEncoderStream();
+const stream = new TextEncoderStream();
 console.log(stream.readable); // 一个 ReadableStream
 ```
 

--- a/files/zh-cn/web/api/textencoderstream/readable/index.md
+++ b/files/zh-cn/web/api/textencoderstream/readable/index.md
@@ -15,7 +15,7 @@ l10n:
 
 ## 示例
 
-以下示例演示了如何从 `TextEncoderStream` 对象返回一个 `ReadableStream`。
+该示例演示了如何从 `TextEncoderStream` 对象返回一个 `ReadableStream`。
 
 ```js
 const stream = new TextEncoderStream();

--- a/files/zh-cn/web/api/textencoderstream/readable/index.md
+++ b/files/zh-cn/web/api/textencoderstream/readable/index.md
@@ -1,23 +1,25 @@
 ---
-title: TextEncoderStream.readable
+title: TextEncoderStream：readable 属性
 slug: Web/API/TextEncoderStream/readable
+l10n:
+  sourceCommit: 4094b9256ace2d7d805abb6b536e23079aaf9170
 ---
 
-{{APIRef("Encoding API")}}
+{{APIRef("Encoding API")}}{{AvailableInWorkers}}
 
-{{domxref("TextEncoderStream")}} 接口的只读属性 **`readable`** 返回一个 {{domxref("ReadableStream")}}。
+{{domxref("TextEncoderStream")}} 接口的 **`readable`** 只读属性返回一个 {{domxref("ReadableStream")}}。
 
 ## 值
 
-一个 {{domxref("ReadableStream")}}。
+{{domxref("ReadableStream")}}。
 
 ## 示例
 
-以下示例演示了如何从一个 `TextEncoderStream` 对象返回一个 `ReadableStream`。
+以下示例演示了如何从 `TextEncoderStream` 对象返回一个 `ReadableStream`。
 
 ```js
 stream = new TextEncoderStream();
-console.log(stream.readable); //a ReadableStream
+console.log(stream.readable); // 一个 ReadableStream
 ```
 
 ## 规范


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/TextEncoderStream/readable
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/textencoderstream/readable/index.md
* Last commit: https://github.com/mdn/content/commit/0f42b8ccf6bef96f27e678163954b3a363b9dcf6
