### PR TITLE
[zh-CN]: Sync translation for `Window.show*Picker`

### DIFF
--- a/files/zh-cn/web/api/window/showdirectorypicker/index.md
+++ b/files/zh-cn/web/api/window/showdirectorypicker/index.md
@@ -2,7 +2,7 @@
 title: Window：showDirectoryPicker() 方法
 slug: Web/API/Window/showDirectoryPicker
 l10n:
-  sourceCommit: 8f93582ca9008d55db258a017552be486e372382
+  sourceCommit: b58a5b506fdc086f442104ccdee547b9df0cb6a7
 ---
 
 {{APIRef("File System API")}}{{Securecontext_Header}}{{SeeCompatTable}}

--- a/files/zh-cn/web/api/window/showdirectorypicker/index.md
+++ b/files/zh-cn/web/api/window/showdirectorypicker/index.md
@@ -2,7 +2,7 @@
 title: Window：showDirectoryPicker() 方法
 slug: Web/API/Window/showDirectoryPicker
 l10n:
-  sourceCommit: 4458494807b6f4898d504b6c0af0a45f8031cbf3
+  sourceCommit: 8f93582ca9008d55db258a017552be486e372382
 ---
 
 {{APIRef("File System API")}}{{Securecontext_Header}}{{SeeCompatTable}}
@@ -13,6 +13,7 @@ l10n:
 
 ```js-nolint
 showDirectoryPicker()
+showDirectoryPicker(options)
 ```
 
 ### 参数
@@ -26,11 +27,11 @@ showDirectoryPicker()
     - `mode` {{optional_inline}}
       - : 字符串，默认为 `"read"`，用于只读访问，或 `"readwrite"` 用于读写访问。
     - `startIn` {{optional_inline}}
-      - : 一个 `FileSystemHandle` 对象或者代表某个众所周知的目录的字符串（如：`"desktop"`、`"documents"`、`"downloads"`、`"music"`、`"pictures"`、`"videos"`），用于指定选择器的起始目录。
+      - : 一个 {{domxref("FileSystemHandle")}} 对象或者代表某个众所周知的目录的字符串（如：`"desktop"`、`"documents"`、`"downloads"`、`"music"`、`"pictures"`、`"videos"`），用于指定选择器的起始目录。
 
 ### 返回值
 
-一个 {{jsxref("Promise")}} 对象，会兑现一个 {{domxref('FileSystemDirectoryHandle')}} 对象。
+一个 {{jsxref("Promise")}} 对象，其兑现一个 {{domxref('FileSystemDirectoryHandle')}} 对象。
 
 ### 异常
 

--- a/files/zh-cn/web/api/window/showdirectorypicker/index.md
+++ b/files/zh-cn/web/api/window/showdirectorypicker/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{APIRef("File System API")}}{{Securecontext_Header}}{{SeeCompatTable}}
 
-{{domxref("Window")}} 接口的 **`showDirectoryPicker()`** 方法用于显示一个目录选择器，以允许用户选择一个目录。
+{{domxref("Window")}} 接口的 **`showDirectoryPicker()`** 方法用于显示一个允许用户选择一个目录的目录选择器。
 
 ## 语法
 
@@ -23,9 +23,9 @@ showDirectoryPicker(options)
   - : 选项对象，包含以下属性：
 
     - `id` {{optional_inline}}
-      - : 通过指定 ID，浏览器可以为不同的 ID 记住不同的目录。如果相同的 ID 用于另一个选择器，则该选择器将在同一目录中打开。
+      - : 通过指定 ID，浏览器可以记住不同 ID 所对应的目录。如果在另一个选择器中使用了相同的 ID，则选择器将在同一目录中打开。
     - `mode` {{optional_inline}}
-      - : 字符串，默认为 `"read"`，用于只读访问，或 `"readwrite"` 用于读写访问。
+      - : 字符串，默认为 `"read"`，用于只读访问，或 `"readwrite"`，用于读写访问。
     - `startIn` {{optional_inline}}
       - : 一个 {{domxref("FileSystemHandle")}} 对象或者代表某个众所周知的目录的字符串（如：`"desktop"`、`"documents"`、`"downloads"`、`"music"`、`"pictures"`、`"videos"`），用于指定选择器的起始目录。
 

--- a/files/zh-cn/web/api/window/showopenfilepicker/index.md
+++ b/files/zh-cn/web/api/window/showopenfilepicker/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{APIRef("File System API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
-{{domxref("Window")}} 接口的 **`showOpenFilePicker()`** 方法用于显示一个文件选择器，以允许用户选择一个或多个文件并返回这些文件的句柄。
+{{domxref("Window")}} 接口的 **`showOpenFilePicker()`** 方法用于显示一个允许用户选择一个或多个文件的文件选择器，并返回这些文件的句柄。
 
 ## 语法
 
@@ -25,7 +25,7 @@ showOpenFilePicker(options)
     - `excludeAcceptAllOption` {{Optional_Inline}}
       - : 布尔值，默认为 `false`。默认情况下，选择器应包含一个不应用任何文件类型过滤器的选项（通过下面的类型选项启动）。将此选项设置为 `true` 意味着该选项*不*可用。
     - `id` {{Optional_Inline}}
-      - : 通过指定 ID，浏览器可以为不同的 ID 记住不同的目录。如果相同的 ID 用于另一个选择器，则该选择器将在同一目录中打开。
+      - : 通过指定 ID，浏览器可以记住不同 ID 所对应的目录。如果在另一个选择器中使用了相同的 ID，则选择器将在同一目录中打开。
     - `multiple` {{Optional_Inline}}
       - : 布尔值，默认为 `false`。当设置为 `true` 时，可以选择多个文件。
     - `startIn` {{Optional_Inline}}

--- a/files/zh-cn/web/api/window/showopenfilepicker/index.md
+++ b/files/zh-cn/web/api/window/showopenfilepicker/index.md
@@ -2,7 +2,7 @@
 title: Window：showOpenFilePicker() 方法
 slug: Web/API/Window/showOpenFilePicker
 l10n:
-  sourceCommit: f75b2c86ae4168e59416aed4c7121f222afc201d
+  sourceCommit: 4d929bb0a021c7130d5a71a4bf505bcb8070378d
 ---
 
 {{APIRef("File System API")}}{{SecureContext_Header}}{{SeeCompatTable}}
@@ -13,6 +13,7 @@ l10n:
 
 ```js-nolint
 showOpenFilePicker()
+showOpenFilePicker(options)
 ```
 
 ### 参数
@@ -28,17 +29,17 @@ showOpenFilePicker()
     - `multiple` {{Optional_Inline}}
       - : 布尔值，默认为 `false`。当设置为 `true` 时，可以选择多个文件。
     - `startIn` {{Optional_Inline}}
-      - : 一个 `FileSystemHandle` 对象或一个众所周知的目录（`"desktop"`、`"documents"`、`"downloads"`、`"music"`、`"pictures"` 或 `"videos"`）以指定打开选择器的起始目录。
+      - : 一个 {{domxref("FileSystemHandle")}} 对象或一个众所周知的目录（`"desktop"`、`"documents"`、`"downloads"`、`"music"`、`"pictures"` 或 `"videos"`）以指定打开选择器的起始目录。
     - `types` {{Optional_Inline}}
-      - : 允许选择的文件类型的{{jsxref('Array', '数组', '', 'nocode')}}。每个项目都是一个具有以下选项的对象：
+      - : 允许选择的文件类型的{{jsxref('Array', '数组', '', 1)}}。每个项目都是一个具有以下选项的对象：
         - `description` {{Optional_Inline}}
           - : 允许的文件类型类别的可选描述。默认为空字符串。
         - `accept`
-          - : 一个 {{jsxref('Object')}}，其键设置为 [MIME 类型](/zh-CN/docs/Web/HTTP/Guides/MIME_types/Common_types)，值设置为文件扩展名的{{jsxref('Array', '数组', '', 'nocode')}}（参见下面的示例）。
+          - : 一个 {{jsxref('Object')}}，其键设置为 [MIME 类型](/zh-CN/docs/Web/HTTP/Guides/MIME_types/Common_types)，值设置为文件扩展名的{{jsxref('Array', '数组', '', 1)}}（参见下面的示例）。
 
 ### 返回值
 
-一个 {{jsxref("Promise")}} 对象，会兑现一个包含 {{domxref('FileSystemFileHandle')}} 对象的{{jsxref('Array', '数组', '', 'nocode')}}。
+一个 {{jsxref("Promise")}} 对象，其兑现一个包含 {{domxref('FileSystemFileHandle')}} 对象的{{jsxref('Array', '数组', '', 1)}}。
 
 ### 异常
 
@@ -47,7 +48,7 @@ showOpenFilePicker()
 - `SecurityError` {{domxref("DOMException")}}
   - : 如果调用被[同源策略](/zh-CN/docs/Web/Security/Same-origin_policy)阻止，或者不是通过用户交互（例如按下按钮）调用，则抛出该异常。
 - {{jsxref("TypeError")}}
-  - : 如果无法处理接受类型，则抛出该异常，如果出现以下情况，则可能会发生这种情况：
+  - : 如果无法处理接受类型，则抛出该异常，它可能会在出现以下情况时发生：
     - `types` 选项中任何项目的 `accept` 选项的任何键字符串都无法解析为有效的 MIME 类型。
     - `types` 选项中任何项目的 `accept` 选项的任何值字符串都是无效的，例如，如果它不以 `.` 开头，或者它以 `.` 结尾，或者它包含任何无效的值码点且长度大于 16。
     - `types` 选项为空，`excludeAcceptAllOption` 选项为 `true`。

--- a/files/zh-cn/web/api/window/showopenfilepicker/index.md
+++ b/files/zh-cn/web/api/window/showopenfilepicker/index.md
@@ -2,7 +2,7 @@
 title: Window：showOpenFilePicker() 方法
 slug: Web/API/Window/showOpenFilePicker
 l10n:
-  sourceCommit: 4d929bb0a021c7130d5a71a4bf505bcb8070378d
+  sourceCommit: b58a5b506fdc086f442104ccdee547b9df0cb6a7
 ---
 
 {{APIRef("File System API")}}{{SecureContext_Header}}{{SeeCompatTable}}

--- a/files/zh-cn/web/api/window/showsavefilepicker/index.md
+++ b/files/zh-cn/web/api/window/showsavefilepicker/index.md
@@ -2,7 +2,7 @@
 title: Window：showSaveFilePicker() 方法
 slug: Web/API/Window/showSaveFilePicker
 l10n:
-  sourceCommit: 4d929bb0a021c7130d5a71a4bf505bcb8070378d
+  sourceCommit: b58a5b506fdc086f442104ccdee547b9df0cb6a7
 ---
 
 {{APIRef("File System API")}}{{SecureContext_Header}}{{SeeCompatTable}}

--- a/files/zh-cn/web/api/window/showsavefilepicker/index.md
+++ b/files/zh-cn/web/api/window/showsavefilepicker/index.md
@@ -2,7 +2,7 @@
 title: Window：showSaveFilePicker() 方法
 slug: Web/API/Window/showSaveFilePicker
 l10n:
-  sourceCommit: f75b2c86ae4168e59416aed4c7121f222afc201d
+  sourceCommit: 4d929bb0a021c7130d5a71a4bf505bcb8070378d
 ---
 
 {{APIRef("File System API")}}{{SecureContext_Header}}{{SeeCompatTable}}
@@ -13,6 +13,7 @@ l10n:
 
 ```js-nolint
 showSaveFilePicker()
+showSaveFilePicker(options)
 ```
 
 ### 参数
@@ -26,21 +27,21 @@ showSaveFilePicker()
     - `id` {{Optional_Inline}}
       - : 通过指定 ID，浏览器可以为不同的 ID 记住不同的目录。如果相同的 ID 用于另一个选择器，则该选择器将在同一目录中打开。
     - `startIn` {{Optional_Inline}}
-      - : 一个 `FileSystemHandle` 对象或一个众所周知的目录（`"desktop"`、`"documents"`、`"downloads"`、`"music"`、`"pictures"` 或 `"videos"`）以指定打开选择器的起始目录。
+      - : 一个 {{domxref("FileSystemHandle")}} 对象或一个众所周知的目录（`"desktop"`、`"documents"`、`"downloads"`、`"music"`、`"pictures"` 或 `"videos"`）以指定打开选择器的起始目录。
     - `suggestedName` {{Optional_Inline}}
-      - : 一个{{jsxref('String', '字符串', '', 'nocode')}}。建议的文件名。
+      - : 一个{{jsxref('String', '字符串', '', 1)}}。建议的文件名。
     - `types` {{Optional_Inline}}
 
-      - : 允许选择的文件类型的{{jsxref('Array', '数组', '', 'nocode')}}。每个项目都是一个具有以下选项的对象：
+      - : 允许选择的文件类型的{{jsxref('Array', '数组', '', 1)}}。每个项目都是一个具有以下选项的对象：
 
         - `description` {{Optional_Inline}}
           - : 允许的文件类型类别的可选描述。默认为空字符串。
         - `accept`
-          - : 一个 {{jsxref('Object')}}，其键设置为 [MIME 类型](/zh-CN/docs/Web/HTTP/Guides/MIME_types/Common_types)，值设置为文件扩展名的{{jsxref('Array', '数组', '', 'nocode')}}（参见下面的示例）。
+          - : 一个 {{jsxref('Object')}}，其键设置为 [MIME 类型](/zh-CN/docs/Web/HTTP/Guides/MIME_types/Common_types)，值设置为文件扩展名的{{jsxref('Array', '数组', '', 1)}}（参见下面的示例）。
 
 ### 返回值
 
-一个 {{jsxref("Promise")}} 对象，会兑现一个 {{domxref('FileSystemFileHandle')}} 对象。
+一个 {{jsxref("Promise")}} 对象，其兑现一个 {{domxref('FileSystemFileHandle')}} 对象。
 
 ### 异常
 
@@ -49,7 +50,7 @@ showSaveFilePicker()
 - `SecurityError` {{domxref("DOMException")}}
   - : 如果调用被[同源策略](/zh-CN/docs/Web/Security/Same-origin_policy)阻止，或者不是通过用户交互（例如按下按钮）调用，则抛出该异常。
 - {{jsxref("TypeError")}}
-  - : 如果无法处理接受类型，则抛出该异常，如果出现以下情况，则可能会发生这种情况：
+  - : 如果无法处理接受类型，则抛出该异常，它可能会在出现以下情况时发生：
     - `types` 选项中任何项目的 `accept` 选项的任何键字符串都无法解析为有效的 MIME 类型。
     - `types` 选项中任何项目的 `accept` 选项的任何值字符串都是无效的，例如，如果它不以 `.` 开头，或者它以 `.` 结尾，或者它包含任何无效的值码点且长度大于 16。
     - `types` 选项为空，`excludeAcceptAllOption` 选项为 `true`。

--- a/files/zh-cn/web/api/window/showsavefilepicker/index.md
+++ b/files/zh-cn/web/api/window/showsavefilepicker/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{APIRef("File System API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
-{{domxref("Window")}} 接口的 **`showSaveFilePicker()`** 方法用于显示一个文件选择器，以允许用户保存一个文件。可以选择一个已有文件覆盖保存，也可以输入名字新建一个文件。
+{{domxref("Window")}} 接口的 **`showSaveFilePicker()`** 方法用于显示允许用户保存一个文件的文件选择器。用户可以选择一个已有文件覆盖保存，也可以输入名字新建一个文件。
 
 ## 语法
 
@@ -25,7 +25,7 @@ showSaveFilePicker(options)
     - `excludeAcceptAllOption` {{Optional_Inline}}
       - : 布尔值，默认为 `false`。默认情况下，选择器应包含一个不应用任何文件类型过滤器的选项（通过下面的类型选项启动）。将此选项设置为 `true` 意味着该选项*不*可用。
     - `id` {{Optional_Inline}}
-      - : 通过指定 ID，浏览器可以为不同的 ID 记住不同的目录。如果相同的 ID 用于另一个选择器，则该选择器将在同一目录中打开。
+      - : 通过指定 ID，浏览器可以记住不同 ID 所对应的目录。如果在另一个选择器中使用了相同的 ID，则选择器将在同一目录中打开。
     - `startIn` {{Optional_Inline}}
       - : 一个 {{domxref("FileSystemHandle")}} 对象或一个众所周知的目录（`"desktop"`、`"documents"`、`"downloads"`、`"music"`、`"pictures"` 或 `"videos"`）以指定打开选择器的起始目录。
     - `suggestedName` {{Optional_Inline}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

https://developer.mozilla.org/en-US/docs/Web/API/Window/showDirectoryPicker
https://developer.mozilla.org/en-US/docs/Web/API/Window/showOpenFilePicker
https://developer.mozilla.org/en-US/docs/Web/API/Window/showSaveFilePicker
majorly about https://github.com/mdn/content/commit/8f93582ca9008d55db258a017552be486e372382 and https://github.com/mdn/content/commit/4d929bb0a021c7130d5a71a4bf505bcb8070378d (except for showDirectoryPicker), and https://github.com/mdn/content/commit/b58a5b506fdc086f442104ccdee547b9df0cb6a7 for https://github.com/mdn/content/pull/38634

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

~**Depends on:** https://github.com/mdn/content/pull/38634~

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
