### PR TITLE
[ja]: Sync and Fix Japanese translations for `Promise.prototype.then()`

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/ja/web/javascript/reference/global_objects/promise/then/index.md
@@ -9,7 +9,7 @@ l10n:
 
 **`then()`** は {{jsxref("Promise")}} インスタンスのメソッドであり、最大 2 つの引数として、この `Promise` が成功した場合と失敗した場合のコールバック関数を取ります。コールバックは、それが呼び出されたプロミス内に格納され、すぐに別の {{jsxref("Promise")}} オブジェクトを返値において返し、他のプロミスのメソッドに対する[連鎖](/ja/docs/Web/JavaScript/Guide/Using_promises#連鎖)呼び出しを行うことができます。
 
-{{InteractiveExample("JavaScript Demo: Promise.then()")}}
+{{InteractiveExample("JavaScript Demo: Promise.prototype.then()")}}
 
 ```js interactive-example
 const promise1 = new Promise((resolve, reject) => {
@@ -116,7 +116,7 @@ Promise.reject(1).then(2, 2).then(console.log, console.log); // 1
 
 `then` メソッドは `Promise` を返すので、メソッド連鎖ができます。
 
-関数が `then` にハンドラーとして渡されると `Promise` を返します。同じ `Promise` がメソッド連鎖の次の `then` に現れます。次のスニペットは、非同期実行をシミュレートする、 `setTimeout` 関数付きのコードです。
+`then` にハンドラーとして渡された関数が `Promise` を返す場合、同じ `Promise` がメソッド連鎖の次の `then` に現れます。次のスニペットは、非同期実行をシミュレートする、 `setTimeout` 関数付きのコードです。
 
 ```js
 Promise.resolve("foo")


### PR DESCRIPTION
英語版と異なった文、異なった意味になった文を修正。

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
- Interactive exampleのタイトルの[英語版](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/promise/then/index.md?plain=1#L12)の修正が[日本語版](https://github.com/mdn/translated-content/blob/main/files/ja/web/javascript/reference/global_objects/promise/then/index.md?plain=1#L12)に反映されていないのを修正。
- "連鎖"セクションの説明が誤訳で、不自然な日本語かつ異なった意味で取られるので修正。下に英語版と、修正前の日本語版を記載します。 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
誤解を招く表現のため。

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
"連鎖"セクションの説明について追記します。現在はこうなっています。  
  
英語版 [Promise.prototype.then() Chaining (L118)](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/promise/then/index.md?plain=1#L118)  
If the function passed as handler to `then` returns a `Promise`, an equivalent `Promise` will be exposed to the subsequent `then` in the method chain.  
  
修正前の日本語版 [Promise.prototype.then() 連鎖 (L119)](https://github.com/mdn/translated-content/blob/main/files/ja/web/javascript/reference/global_objects/promise/then/index.md?plain=1#L119)    
関数が `then` にハンドラーとして渡されると `Promise` を返します。同じ `Promise` がメソッド連鎖の次の `then` に現れます。  

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
