### PR TITLE
[zh-CN]: fix a broken link in "font-size" page

### DIFF
--- a/files/zh-cn/web/css/font-size/index.md
+++ b/files/zh-cn/web/css/font-size/index.md
@@ -5,7 +5,7 @@ slug: Web/CSS/font-size
 
 {{CSSRef}}
 
-**`font-size`** [CSS](/zh-CN/docs/Web/docs/CSS) 属性设置字体大小。更改字体大小还会更新字体大小相关的 {{cssxref("&lt;length&gt;")}} 单位，例如 `em`、`ex` 等。
+**`font-size`** [CSS](/zh-CN/docs/Web/CSS) 属性设置字体大小。更改字体大小还会更新字体大小相关的 {{cssxref("&lt;length&gt;")}} 单位，例如 `em`、`ex` 等。
 
 {{InteractiveExample("CSS Demo: font-size")}}
 


### PR DESCRIPTION
### Description

`[CSS](/zh-CN/docs/Web/docs/CSS)`, which directs to a page that does not exist, should be `[CSS](/zh-CN/docs/Web/CSS)`.
