### PR TITLE
Fix CSS syntax ( → ) and improve Korean spacing

### DIFF
--- a/files/ko/learn_web_development/getting_started/your_first_website/styling_the_content/index.md
+++ b/files/ko/learn_web_development/getting_started/your_first_website/styling_the_content/index.md
@@ -114,7 +114,7 @@ h1 {
    html {
      font-size: 10px; /* px 은 'pixels' 를 의미합니다: 기본 글자 크기는 현재 10 pixels 높이입니다. */
      font-family:
-      "Open Sans", sans-serif; /* 구글 폰트로부터 여러분이 얻은 마지막 결과가 있어야 합니다. */
+       "Open Sans", sans-serif; /* 구글 폰트로부터 여러분이 얻은 마지막 결과가 있어야 합니다. */
    }
    ```
 

--- a/files/ko/learn_web_development/getting_started/your_first_website/styling_the_content/index.md
+++ b/files/ko/learn_web_development/getting_started/your_first_website/styling_the_content/index.md
@@ -113,7 +113,7 @@ h1 {
    ```css
    html {
      font-size: 10px; /* px 은 'pixels' 를 의미합니다: 기본 글자 크기는 현재 10 pixels 높이입니다. */
-     font-family: placeholder; /* 구글 폰트로부터 여러분이 얻은 마지막 결과가 있어야 합니다. */
+     font-family: "Open Sans", sans-serif; /* 구글 폰트로부터 여러분이 얻은 마지막 결과가 있어야 합니다. */
    }
    ```
 

--- a/files/ko/learn_web_development/getting_started/your_first_website/styling_the_content/index.md
+++ b/files/ko/learn_web_development/getting_started/your_first_website/styling_the_content/index.md
@@ -113,7 +113,7 @@ h1 {
    ```css
    html {
      font-size: 10px; /* px 은 'pixels' 를 의미합니다: 기본 글자 크기는 현재 10 pixels 높이입니다. */
-     font-family: placeholder: 구글 폰트로부터 여러분이 얻은 마지막 결과가 있어야합니다.
+     font-family: placeholder; /* 구글 폰트로부터 여러분이 얻은 마지막 결과가 있어야 합니다. */
    }
    ```
 

--- a/files/ko/learn_web_development/getting_started/your_first_website/styling_the_content/index.md
+++ b/files/ko/learn_web_development/getting_started/your_first_website/styling_the_content/index.md
@@ -113,7 +113,8 @@ h1 {
    ```css
    html {
      font-size: 10px; /* px 은 'pixels' 를 의미합니다: 기본 글자 크기는 현재 10 pixels 높이입니다. */
-     font-family: "Open Sans", sans-serif; /* 구글 폰트로부터 여러분이 얻은 마지막 결과가 있어야 합니다. */
+     font-family:
+      "Open Sans", sans-serif; /* 구글 폰트로부터 여러분이 얻은 마지막 결과가 있어야 합니다. */
    }
    ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Fixed a CSS syntax issue (`:` → `;`) in the `font-family` property and improved Korean spacing in a comment.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This change corrects an incorrect CSS syntax (`font-family: placeholder:` → `font-family: placeholder;`)  
and ensures proper Korean spacing for better readability.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
N/A

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #26448 
