### PR TITLE
ci: pass data betwen steps via GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get changed files
+        id: check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -36,17 +37,17 @@ jobs:
             --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
           # filter out files that are not markdown
           DIFF_DOCUMENTS=$(echo "${DIFF_DOCUMENTS}" | egrep -i ".*\.md$" | xargs)
-          echo "DIFF_DOCUMENTS=${DIFF_DOCUMENTS}" >> $GITHUB_ENV
+          echo "DIFF_DOCUMENTS=${DIFF_DOCUMENTS}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout HEAD
-        if: env.DIFF_DOCUMENTS
+        if: steps.check.outputs.DIFF_DOCUMENTS
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr_head
 
       - name: Get changed content from HEAD
-        if: env.DIFF_DOCUMENTS
+        if: steps.check.outputs.DIFF_DOCUMENTS
         run: |
           git config --global user.email "108879845+mdn-bot@users.noreply.github.com"
           git config --global user.name "mdn-bot"
@@ -62,13 +63,13 @@ jobs:
           git commit -m "Code from PR head"
 
       - uses: actions/checkout@v4
-        if: env.DIFF_DOCUMENTS
+        if: steps.check.outputs.DIFF_DOCUMENTS
         with:
           repository: mdn/content
           path: mdn/content
 
       - name: Setup Node.js environment
-        if: env.DIFF_DOCUMENTS
+        if: steps.check.outputs.DIFF_DOCUMENTS
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -78,11 +79,11 @@ jobs:
             yarn.lock
 
       - name: Install all yarn packages for mdn/translated-content
-        if: env.DIFF_DOCUMENTS
+        if: steps.check.outputs.DIFF_DOCUMENTS
         run: yarn --frozen-lockfile
 
       - name: Install all yarn packages for mdn/content
-        if: env.DIFF_DOCUMENTS
+        if: steps.check.outputs.DIFF_DOCUMENTS
         working-directory: ${{ github.workspace }}/mdn/content
         run: yarn --frozen-lockfile
         env:
@@ -90,39 +91,42 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint and format markdown files
-        if: env.DIFF_DOCUMENTS
+        id: lint
+        if: steps.check.outputs.DIFF_DOCUMENTS
+        env:
+          DIFF_DOCUMENTS: ${{ steps.check.outputs.DIFF_DOCUMENTS }}
         run: |
           # Generate random delimiter
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           EOF="$(openssl rand -hex 8)"
 
-          files_to_lint="${DIFF_DOCUMENTS}"
+          files_to_lint="$DIFF_DOCUMENTS"
 
           echo "crlf line ending check"
           CRLF_FAILED=true
           CRLF_LOG=$(git ls-files --eol ${files_to_lint} | grep -E 'w/(mixed|crlf)') || CRLF_FAILED=false
-          echo "CRLF_LOG<<${EOF}" >> $GITHUB_ENV
-          echo "${CRLF_LOG}" >> $GITHUB_ENV
-          echo "${EOF}" >> $GITHUB_ENV
-          echo "CRLF_FAILED=${CRLF_FAILED}" >> $GITHUB_ENV
+          echo "CRLF_LOG<<${EOF}" >> "$GITHUB_OUTPUT"
+          echo "${CRLF_LOG}" >> "$GITHUB_OUTPUT"
+          echo "${EOF}" >> "$GITHUB_OUTPUT"
+          echo "CRLF_FAILED=${CRLF_FAILED}" >> "$GITHUB_OUTPUT"
 
           echo "Running markdownlint --fix"
           MD_LINT_FAILED=false
           MD_LINT_LOG=$(yarn markdownlint-cli2 --fix ${files_to_lint} 2>&1) || MD_LINT_FAILED=true
-          echo "MD_LINT_LOG<<${EOF}" >> $GITHUB_ENV
-          echo "${MD_LINT_LOG}" >> $GITHUB_ENV
-          echo "${EOF}" >> $GITHUB_ENV
-          echo "MD_LINT_FAILED=${MD_LINT_FAILED}" >> $GITHUB_ENV
+          echo "MD_LINT_LOG<<${EOF}" >> "$GITHUB_OUTPUT"
+          echo "${MD_LINT_LOG}" >> "$GITHUB_OUTPUT"
+          echo "${EOF}" >> "$GITHUB_OUTPUT"
+          echo "MD_LINT_FAILED=${MD_LINT_FAILED}" >> "$GITHUB_OUTPUT"
 
           echo "Linting front-matter"
           FM_LINT_FAILED=false
           # absolute_paths is needed because front-matter linter is run from mdn/content directory
           absolute_paths=$(echo "${files_to_lint}" | xargs realpath -e | xargs)
           FM_LINT_LOG=$(cd ${{ github.workspace }}/mdn/content && yarn fix:fm --config-file ${{ github.workspace }}/front-matter-config.json ${absolute_paths} 2>&1) || FM_LINT_FAILED=true
-          echo "FM_LINT_LOG<<${EOF}" >> $GITHUB_ENV
-          echo "${FM_LINT_LOG}" >> $GITHUB_ENV
-          echo "${EOF}" >> $GITHUB_ENV
-          echo "FM_LINT_FAILED=${FM_LINT_FAILED}" >> $GITHUB_ENV
+          echo "FM_LINT_LOG<<${EOF}" >> "$GITHUB_OUTPUT"
+          echo "${FM_LINT_LOG}" >> "$GITHUB_OUTPUT"
+          echo "${EOF}" >> "$GITHUB_OUTPUT"
+          echo "FM_LINT_FAILED=${FM_LINT_FAILED}" >> "$GITHUB_OUTPUT"
 
           echo "Running url locale checker"
           node ./scripts/check-url-locale.js --fix ${files_to_lint}
@@ -133,14 +137,14 @@ jobs:
           echo "Running Prettier"
           PRETTIER_FAILED=false
           PRETTIER_LOG=$(yarn prettier --check ${files_to_lint} 2>&1) || PRETTIER_FAILED=true
-          echo "PRETTIER_LOG<<${EOF}" >> $GITHUB_ENV
-          echo "${PRETTIER_LOG}" >> $GITHUB_ENV
-          echo "${EOF}" >> $GITHUB_ENV
-          echo "PRETTIER_FAILED=${PRETTIER_FAILED}" >> $GITHUB_ENV
+          echo "PRETTIER_LOG<<${EOF}" >> "$GITHUB_OUTPUT"
+          echo "${PRETTIER_LOG}" >> "$GITHUB_OUTPUT"
+          echo "${EOF}" >> "$GITHUB_OUTPUT"
+          echo "PRETTIER_FAILED=${PRETTIER_FAILED}" >> "$GITHUB_OUTPUT"
           yarn prettier -w ${files_to_lint}
 
           if [[ -n $(git diff) ]]; then
-            echo "FILES_MODIFIED=true" >> $GITHUB_ENV
+            echo "FILES_MODIFIED=true" >> "$GITHUB_OUTPUT"
           fi
 
           # info for troubleshooting
@@ -151,13 +155,13 @@ jobs:
           git diff
 
       - name: Setup reviewdog
-        if: env.FILES_MODIFIED == 'true' || env.MD_LINT_FAILED == 'true'
+        if: steps.lint.outputs.FILES_MODIFIED == 'true' || steps.lint.outputs.MD_LINT_FAILED == 'true'
         uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
         with:
           reviewdog_version: latest
 
       - name: Suggest changes using diff
-        if: env.FILES_MODIFIED == 'true'
+        if: steps.lint.outputs.FILES_MODIFIED == 'true'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -172,8 +176,9 @@ jobs:
             -reporter=github-pr-review < "${TMPFILE}"
 
       - name: Add reviews for markdownlint errors
-        if: env.MD_LINT_FAILED == 'true'
+        if: steps.lint.outputs.MD_LINT_FAILED == 'true'
         env:
+          MD_LINT_LOG: ${{ steps.lint.outputs.MD_LINT_LOG }}
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "${MD_LINT_LOG}" | \
@@ -185,16 +190,16 @@ jobs:
             -reporter="github-pr-review"
 
       - name: Fail if any issues pending
-        if: env.FILES_MODIFIED == 'true' || env.CRLF_FAILED == 'true' || env.MD_LINT_FAILED == 'true' || env.FM_LINT_FAILED == 'true'
+        if: steps.lint.outputs.FILES_MODIFIED == 'true' || steps.lint.outputs.CRLF_FAILED == 'true' || steps.lint.outputs.MD_LINT_FAILED == 'true' || steps.lint.outputs.FM_LINT_FAILED == 'true'
         env:
-          CRLF_FAILED: ${{ env.CRLF_FAILED }}
-          MD_LINT_FAILED: ${{ env.MD_LINT_FAILED }}
-          FM_LINT_FAILED: ${{ env.FM_LINT_FAILED }}
-          PRETTIER_FAILED: ${{ env.PRETTIER_FAILED }}
-          CRLF_LOG: ${{ env.CRLF_LOG }}
-          MD_LINT_LOG: ${{ env.MD_LINT_LOG }}
-          FM_LINT_LOG: ${{ env.FM_LINT_LOG }}
-          PRETTIER_LOG: ${{ env.PRETTIER_LOG }}
+          CRLF_FAILED: ${{ steps.lint.outputs.CRLF_FAILED }}
+          MD_LINT_FAILED: ${{ steps.lint.outputs.MD_LINT_FAILED }}
+          FM_LINT_FAILED: ${{ steps.lint.outputs.FM_LINT_FAILED }}
+          PRETTIER_FAILED: ${{ steps.lint.outputs.PRETTIER_FAILED }}
+          CRLF_LOG: ${{ steps.lint.outputs.CRLF_LOG }}
+          MD_LINT_LOG: ${{ steps.lint.outputs.MD_LINT_LOG }}
+          FM_LINT_LOG: ${{ steps.lint.outputs.FM_LINT_LOG }}
+          PRETTIER_LOG: ${{ steps.lint.outputs.PRETTIER_LOG }}
         run: |
           echo -e "\nPlease fix all the linting issues mentioned in the following logs and in the PR review comments."
 

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -48,14 +48,16 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Check for artifacts
+        id: check
         if: hashFiles('build/') != ''
         run: |
-          echo "HAS_ARTIFACT=true" >> "$GITHUB_ENV"
-          PR_NUMBER=`cat build/NR`
-          echo "PREFIX=pr$PR_NUMBER" >> "$GITHUB_ENV"
+          echo "HAS_ARTIFACT=true" >> "$GITHUB_OUTPUT"
+          PR_NUMBER=`cat build/NR | tr -dc '0-9'`
+          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "PREFIX=pr$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate with GCP
-        if: env.HAS_ARTIFACT
+        if: steps.check.outputs.HAS_ARTIFACT
         uses: google-github-actions/auth@v2
         with:
           token_format: access_token
@@ -63,15 +65,15 @@ jobs:
           workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
 
       - name: Setup gcloud
-        if: env.HAS_ARTIFACT
+        if: steps.check.outputs.HAS_ARTIFACT
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Upload to GCS
-        if: env.HAS_ARTIFACT
+        if: steps.check.outputs.HAS_ARTIFACT
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: "build"
-          destination: "${{ vars.GCP_BUCKET_NAME }}/${{ env.PREFIX }}"
+          destination: "${{ vars.GCP_BUCKET_NAME }}/${{ steps.check.outputs.PREFIX }}"
           resumable: false
           concurrency: 500
           parent: false
@@ -79,19 +81,19 @@ jobs:
 
       - name: Checkout (mdn/content)
         uses: actions/checkout@v4
-        if: env.HAS_ARTIFACT
+        if: steps.check.outputs.HAS_ARTIFACT
         with:
           repository: mdn/content
           path: content
 
       - name: Setup (mdn/content)
         uses: actions/setup-node@v4
-        if: env.HAS_ARTIFACT
+        if: steps.check.outputs.HAS_ARTIFACT
         with:
           node-version-file: "content/.nvmrc"
 
       - name: Install (mdn/content)
-        if: env.HAS_ARTIFACT
+        if: steps.check.outputs.HAS_ARTIFACT
         env:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,22 +101,20 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Analyze PR build
-        if: env.HAS_ARTIFACT
+        if: steps.check.outputs.HAS_ARTIFACT
         env:
           BUILD_OUT_ROOT: ${{ github.workspace }}/build
         working-directory: content
         run: |
-          PR_NUMBER=`cat "$BUILD_OUT_ROOT/NR"`
-
           echo "Pull request:"
-          echo "https://github.com/mdn/translated-content/pull/$PR_NUMBER"
+          echo "https://github.com/mdn/translated-content/pull/${{ steps.check.outputs.PR_NUMBER }}"
 
           node scripts/analyze-pr-build.js \
-            --prefix="pr$PR_NUMBER" \
+            --prefix="${{ steps.check.outputs.PREFIX }}" \
             --analyze-flaws \
             --analyze-dangerous-content \
-            --github-token="${{secrets.GITHUB_TOKEN}}" \
+            --github-token="${{ secrets.GITHUB_TOKEN }}" \
             --repo=$GITHUB_REPOSITORY \
-            --pr-number="$PR_NUMBER" \
+            --pr-number="${{ steps.check.outputs.PR_NUMBER }}" \
             --diff-file=$BUILD_OUT_ROOT/DIFF \
             $BUILD_OUT_ROOT

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Get changed files
+        id: check
         run: |
           # Use the GitHub API to get the list of changed files
           # documentation: https://docs.github.com/rest/commits/commits#compare-two-commits
@@ -38,23 +39,23 @@ jobs:
 
           # filter out files that are not markdown files
           GIT_DIFF_CONTENT=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.(md)$" | xargs)
-          echo "GIT_DIFF_CONTENT=${GIT_DIFF_CONTENT}" >> $GITHUB_ENV
+          echo "GIT_DIFF_CONTENT=${GIT_DIFF_CONTENT}" >> "$GITHUB_OUTPUT"
 
           # filter out files that are not attachments
           # note that we should get the absolute path of the changed attachments
           GIT_DIFF_FILES=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.(png|jpeg|jpg|gif|svg|webp)$" | xargs readlink -e | xargs)
-          echo "GIT_DIFF_FILES=${GIT_DIFF_FILES}" >> $GITHUB_ENV
+          echo "GIT_DIFF_FILES=${GIT_DIFF_FILES}" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
-        if: env.GIT_DIFF_CONTENT || env.GIT_DIFF_FILES
+        if: steps.check.outputs.GIT_DIFF_CONTENT || steps.check.outputs.GIT_DIFF_FILES
         with:
           repository: mdn/content
           path: mdn/content
 
       - name: Setup Node.js environment
-        if: env.GIT_DIFF_CONTENT || env.GIT_DIFF_FILES
+        if: steps.check.outputs.GIT_DIFF_CONTENT || steps.check.outputs.GIT_DIFF_FILES
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -62,7 +63,7 @@ jobs:
           cache-dependency-path: mdn/content/yarn.lock
 
       - name: Install all yarn packages
-        if: env.GIT_DIFF_CONTENT || env.GIT_DIFF_FILES
+        if: steps.check.outputs.GIT_DIFF_CONTENT || steps.check.outputs.GIT_DIFF_FILES
         working-directory: ${{ github.workspace }}/mdn/content
         run: yarn --frozen-lockfile
         env:
@@ -71,8 +72,10 @@ jobs:
 
       - name: Build changed content
         id: build-content
-        if: env.GIT_DIFF_CONTENT
+        if: steps.check.outputs.GIT_DIFF_CONTENT
         env:
+          GIT_DIFF_CONTENT: ${{ steps.check.outputs.GIT_DIFF_CONTENT }}
+
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/files
 
@@ -129,7 +132,7 @@ jobs:
           wget https://github.com/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}.diff -O ${BUILD_OUT_ROOT}/DIFF
 
       - name: Merge static assets with built documents
-        if: env.GIT_DIFF_CONTENT
+        if: steps.check.outputs.GIT_DIFF_CONTENT
         run: |
           # Exclude the .map files, as they're used for debugging JS and CSS.
           rsync -a --exclude "*.map" ${{ github.workspace }}/mdn/content/node_modules/@mdn/yari/client/build/ $BUILD_OUT_ROOT
@@ -137,16 +140,17 @@ jobs:
           du -sh $BUILD_OUT_ROOT
 
       - uses: actions/upload-artifact@v4
-        if: env.GIT_DIFF_CONTENT
+        if: steps.check.outputs.GIT_DIFF_CONTENT
         with:
           name: build
           path: ${{ env.BUILD_OUT_ROOT }}
 
       - name: Check changed files
-        if: env.GIT_DIFF_FILES
+        if: steps.check.outputs.GIT_DIFF_FILES
         env:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/files
+          GIT_DIFF_FILES: steps.check.outputs.GIT_DIFF_FILES
         working-directory: ${{ github.workspace }}/mdn/content
         run: |
           echo $GIT_DIFF_FILES

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -63,6 +63,7 @@ jobs:
         run: yarn content sync-translated-content ${{ matrix.lang }}
 
       - name: Gather related upstream commits
+        id: gather
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -83,14 +84,14 @@ jobs:
           FILE_COMMIT_URLS=$(echo -e "${FILE_COMMIT_URLS}" | grep -v '^$' | sort | uniq)
           echo -e "commit urls:\n${FILE_COMMIT_URLS}"
 
-          # set multiline string to env
+          # set multiline string to output
           # https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           # as the commit urls would not contain 'EOF', we can use it as a delimiter
           {
             echo 'COMMIT_URLS<<EOF'
             echo "${FILE_COMMIT_URLS}"
             echo EOF
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create PR with sync for ${{ matrix.lang }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
@@ -100,7 +101,7 @@ jobs:
           title: "[${{ matrix.lang }}] sync translated content"
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           committer: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
-          body: "Rari generated sync. Related upstream commits:\n\n${{ env.COMMIT_URLS }}"
+          body: "Rari generated sync. Related upstream commits:\n\n${{ steps.gather.outputs.COMMIT_URLS }}"
           labels: |
             automated pr
           token: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Ensures workflows pass data between steps via `GITHUB_OUTPUT`.

### Motivation

Avoids unintended side-effects of using `GITHUB_ENV`.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Same as:

- https://github.com/mdn/content/pull/38702
