### PR TITLE
Update DataView.setUint16 fr reference

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/dataview/setuint16/index.md
+++ b/files/fr/web/javascript/reference/global_objects/dataview/setuint16/index.md
@@ -33,7 +33,7 @@ dataview.setUint16(positionOctet, valeur [, littleEndian])
 - `valeur`
   - : La valeur à enregistrer
 - `littleEndian`
-  - : {{optional_inline}} Indique si la donnée sur 32 bits est enregistrée {{Glossary("Endianness", "dans l'ordre des octets de poids faibles")}}. Si ce paramètre vaut `false` ou `undefined`, l'ordre sera celui des octets de poids forts.
+  - : {{optional_inline}} Indique si la donnée sur 16 bits est enregistrée {{Glossary("Endianness", "dans l'ordre des octets de poids faibles")}}. Si ce paramètre vaut `false` ou `undefined`, l'ordre sera celui des octets de poids forts.
 
 ### Valeur de retour
 
@@ -46,7 +46,7 @@ dataview.setUint16(positionOctet, valeur [, littleEndian])
 
 ## Exemples
 
-### Utilisation de la méthode `setUint1`
+### Utilisation de la méthode `setUint16`
 
 ```js
 var buffer = new ArrayBuffer(8);


### PR DESCRIPTION
- Replace `32` bits occurrence by `16` as setUint16 works with 16 bits values.
- Fix typo in example title.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
