### PR TITLE
[zh-cn]: update the translation of `SpeechGrammar`

### DIFF
--- a/files/zh-cn/web/api/speechgrammar/index.md
+++ b/files/zh-cn/web/api/speechgrammar/index.md
@@ -1,38 +1,40 @@
 ---
 title: SpeechGrammar
 slug: Web/API/SpeechGrammar
+l10n:
+  sourceCommit: 10313e7be178b2af803c902d4f91e4ccc31b09e7
 ---
 
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}{{deprecated_header}}{{non-standard_header}}
 
-[Web Speech API](/zh-CN/docs/Web/API/Web_Speech_API) 的 **`SpeechGrammar`** 接口 表示了语音识别对象服务想要识别的一系列词语或模式。
+[Web Speech API](/zh-CN/docs/Web/API/Web_Speech_API) 的 **`SpeechGrammar`** 接口表示一组希望识别服务识别的单词或单词模式。
 
-文法通过 [JSpeech Grammar Format](https://www.w3.org/TR/jsgf/) (**JSGF**.) 来定义，其他格式的文法会在以后支持。
+语法使用 [JSpeech 语法格式](https://www.w3.org/TR/jsgf/)（**JSGF**）定义。未来可能还会支持其他格式。
 
 ## 构造函数
 
-- {{domxref("SpeechGrammar.SpeechGrammar()")}}
+- {{domxref("SpeechGrammar.SpeechGrammar()", "SpeechGrammar()")}} {{Non-standard_Inline}} {{deprecated_inline}}
   - : 创建一个新的 `SpeechGrammar` 对象。
 
-## 属性
+## 实例属性
 
-- {{domxref("SpeechGrammar.src")}}
-  - : 设置或返回 `SpeechGrammar` 对象实例中包含文法的字符串。
-- {{domxref("SpeechGrammar.weight")}} {{optional_inline}}
-  - : 设置或返回 `SpeechGrammar` 对象的权重。
+- {{domxref("SpeechGrammar.src")}} {{deprecated_inline}} {{non-standard_inline}}
+  - : 设置并返回一个包含 `SpeechGrammar` 对象实例中的语法字符串。
+- {{domxref("SpeechGrammar.weight")}} {{Optional_Inline}} {{deprecated_inline}} {{non-standard_inline}}
+  - : 设置并返回 `SpeechGrammar` 对象的权重。
 
 ## 示例
 
 ```js
-var grammar =
+const grammar =
   "#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;";
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 
-console.log(speechRecognitionList[0].src); // 应该返回和上面语法变量一样的内容
-console.log(speechRecognitionList[0].weight); // 应该返回 1 - 与上面第四行所设置的权重一致
+console.log(speechRecognitionList[0].src); // 应返回与 grammar 变量的内容相同的结果。
+console.log(speechRecognitionList[0].weight); // 应返回 1 - 与 addFromString 中设置的权重相同。
 ```
 
 ## 规范
@@ -43,6 +45,6 @@ console.log(speechRecognitionList[0].weight); // 应该返回 1 - 与上面第�
 
 {{Compat}}
 
-## 相关链接
+## 参见
 
 - [Web Speech API](/zh-CN/docs/Web/API/Web_Speech_API)

--- a/files/zh-cn/web/api/speechgrammar/speechgrammar/index.md
+++ b/files/zh-cn/web/api/speechgrammar/speechgrammar/index.md
@@ -2,10 +2,10 @@
 title: SpeechGrammar：SpeechGrammar() 构造函数
 slug: Web/API/SpeechGrammar/SpeechGrammar
 l10n:
-  sourceCommit: f2f9346c0c0e9f6676f2df9f1850933e274401de
+  sourceCommit: 706cbf21987296c604cc96b7f95095ed7aba6bb8
 ---
 
-{{APIRef("Web Speech API")}}{{Non-standard_Header}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}{{Non-standard_Header}}{{deprecated_header}}
 
 {{domxref("SpeechGrammar")}} 接口的 **`SpeechGrammar()`** 构造函数创建一个新的 `SpeechGrammar` 对象实例。
 

--- a/files/zh-cn/web/api/speechgrammar/src/index.md
+++ b/files/zh-cn/web/api/speechgrammar/src/index.md
@@ -2,10 +2,10 @@
 title: SpeechGrammar：src 属性
 slug: Web/API/SpeechGrammar/src
 l10n:
-  sourceCommit: 5ccd2f0e0565ec9b3539cc067cdae369adc307b8
+  sourceCommit: 706cbf21987296c604cc96b7f95095ed7aba6bb8
 ---
 
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}{{deprecated_header}}{{non-standard_header}}
 
 {{domxref("SpeechGrammar")}} 接口的 **`src`** 属性用于获取或设置 `SpeechGrammar` 对象中包含语法的字符串。
 

--- a/files/zh-cn/web/api/speechgrammar/weight/index.md
+++ b/files/zh-cn/web/api/speechgrammar/weight/index.md
@@ -2,10 +2,10 @@
 title: SpeechGrammar：weight 属性
 slug: Web/API/SpeechGrammar/weight
 l10n:
-  sourceCommit: 23e1a97d50050a3b3518a4b2f67ccf42e5fd75b7
+  sourceCommit: 706cbf21987296c604cc96b7f95095ed7aba6bb8
 ---
 
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}{{deprecated_header}}{{non-standard_header}}
 
 {{domxref("SpeechGrammar")}} 接口的 **`weight`** 可选属性用于设置和返回 `SpeechGrammar` 对象的权重。
 


### PR DESCRIPTION
### Related issues and pull requests
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/SpeechGrammar
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/speechgrammar/index.md
* Last commit: https://github.com/mdn/content/commit/10313e7be178b2af803c902d4f91e4ccc31b09e7

* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/SpeechGrammar/SpeechGrammar
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/speechgrammar/speechgrammar/index.md
* Last commit: https://github.com/mdn/content/commit/706cbf21987296c604cc96b7f95095ed7aba6bb8

* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/SpeechGrammar/src
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/speechgrammar/src/index.md
* Last commit: https://github.com/mdn/content/commit/706cbf21987296c604cc96b7f95095ed7aba6bb8

* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/SpeechGrammar/weight
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/speechgrammar/weight/index.md
* Last commit: https://github.com/mdn/content/commit/706cbf21987296c604cc96b7f95095ed7aba6bb8