### PR TITLE
ci(system-file-changes): pass if author/actor is an admin

### DIFF
--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -11,22 +11,36 @@ on:
       - package.json
       - yarn.lock
 
+# No GITHUB_TOKEN permissions, as we don't use it.
 permissions: {}
 
 jobs:
   block:
-    # This make sure it only runs on our origin repo
-    # and make an exception for Dependabot.
+    # This makes sure it only runs on our origin repo
+    # and makes an exception for Dependabot.
     if: github.repository_owner == 'mdn' && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Stop anything and everything
+      - name: Block if author/actor is not an admin
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # It would be nice if we could disable this workflow if the PR
-          # was made from a branch within the origin repo. But it seems you
-          # can'd do that :(
-          # See https://github.community/t/how-do-you-figure-out-if-a-pr-is-from-a-work-in-pull-request-target-workflows/170001
+          # Check author.
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          AUTHOR_PERMISSION=$(gh api https://api.github.com/repos/${{ github.repository }}/collaborators/$AUTHOR/permission --jq .permission)
 
-          echo "If you're an admin, you have you use your admin privileges to override."
-          echo "If you're not an admin, please ping someone for a review."
-          exit 1
+          if [ "$AUTHOR_PERMISSION" != "admin" ]; then
+            echo "PR author ($AUTHOR) is not an admin, please ping someone for a review."
+            exit 1
+          fi
+
+          # Check actor.
+          ACTOR="${{ github.actor }}"
+          if [ "$ACTOR" != "$AUTHOR" ]; then
+            ACTOR_PERMISSION=$(gh api https://api.github.com/repos/${{ github.repository }}/collaborators/$ACTOR/permission --jq .permission)  
+
+            if [ "$ACTOR_PERMISSION" != "admin" ]; then
+              echo "PR actor ($ACTOR) is not an admin, please ping someone for a review."
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Prevents the `system-file-changes` workflow from failing, if both PR author and actor are admin.

### Motivation

Reduces noise when admins update system files, and reduces the chances of missing other failing workflows.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Same as:

- https://github.com/mdn/content/pull/38610
