### PR TITLE
zh-cn: correct the output of the example code

### DIFF
--- a/files/zh-cn/learn_web_development/core/scripting/functions/index.md
+++ b/files/zh-cn/learn_web_development/core/scripting/functions/index.md
@@ -157,7 +157,7 @@ const newString = myText.replace("字符串", "香肠");
 const myArray = ["我", "爱", "巧克力", "青蛙"];
 const madeAString = myArray.join(" ");
 console.log(madeAString);
-// 返回 '我爱巧克力青蛙'
+// 返回 '我 爱 巧克力 青蛙'
 
 const madeAnotherString = myArray.join();
 console.log(madeAnotherString);

--- a/files/zh-cn/learn_web_development/core/scripting/functions/index.md
+++ b/files/zh-cn/learn_web_development/core/scripting/functions/index.md
@@ -157,7 +157,7 @@ const newString = myText.replace("字符串", "香肠");
 const myArray = ["我", "爱", "巧克力", "青蛙"];
 const madeAString = myArray.join(" ");
 console.log(madeAString);
-// 返回 '我 爱 巧克力 青蛙'
+// 返回“我 爱 巧克力 青蛙”
 
 const madeAnotherString = myArray.join();
 console.log(madeAnotherString);


### PR DESCRIPTION

### Description
[https://developer.mozilla.org/zh-CN/docs/Learn_web_development/Core/Scripting/Functions](url)
`const myArray = ["我", "爱", "巧克力", "青蛙"];
const madeAString = myArray.join(" ");
console.log(madeAString);
// 返回 '我爱巧克力青蛙'`
修改为正确的版本，此处应该是使用了空格作为分隔符，原来的返回结果并不正确，使学习者感到疑惑，应该是'我 爱 巧克力 青蛙' Revise to the correct version. Here, spaces should be used as separators.The original returned result was incorrect, causing confusion for learners. It should be '我 爱 巧克力 青蛙' 




