### PR TITLE
[es]: migrate remaining interactive examples

### DIFF
--- a/files/es/web/css/gradient/index.md
+++ b/files/es/web/css/gradient/index.md
@@ -9,7 +9,7 @@ slug: Web/CSS/gradient
 
 El tipo de datos [CSS](/es/docs/Web/CSS) `<gradient>` indica un tipo de {{cssxref("&lt;image&gt;")}} que consiste de una transición progresiva entre dos o más colores (Degradado).
 
-{{InteractiveExample("CSS Demo: &amp;lt;gradient&amp;gt;")}}
+{{InteractiveExample("CSS Demo: &lt;gradient&gt;")}}
 
 ```css interactive-example-choice
 background: linear-gradient(#f69d3c, #3f87a6);

--- a/files/es/web/css/hyphens/index.md
+++ b/files/es/web/css/hyphens/index.md
@@ -3,7 +3,36 @@ title: hyphens
 slug: Web/CSS/hyphens
 ---
 
-{{CSSRef}}La propiedad [CSS](/es/docs/Web/CSS) **`hyphens`** especifica cómo deben dividirse las palabras cuando el texto se ajusta a través de múltiples líneas. Puede impedir la separación de sílabas por completo, usar guiones manualmente en puntos específicos del texto o dejar que el navegador inserte los guiones automáticamente donde corresponda.{{EmbedInteractiveExample("pages/css/hyphens.html")}}
+{{CSSRef}}La propiedad [CSS](/es/docs/Web/CSS) **`hyphens`** especifica cómo deben dividirse las palabras cuando el texto se ajusta a través de múltiples líneas. Puede impedir la separación de sílabas por completo, usar guiones manualmente en puntos específicos del texto o dejar que el navegador inserte los guiones automáticamente donde corresponda.
+
+{{InteractiveExample("CSS Demo: hyphens")}}
+
+```css interactive-example-choice
+hyphens: none;
+```
+
+```css interactive-example-choice
+hyphens: manual;
+```
+
+```css interactive-example-choice
+hyphens: auto;
+```
+
+```html interactive-example
+<section id="default-example">
+<p id="example-element">An extra­ordinarily long English word!</p>
+</section>
+```
+
+```css interactive-example
+#example-element {
+  border: 2px dashed #999;
+  font-size: 1.5rem;
+  text-align: left;
+  width: 7rem;
+}
+```
 
 Las reglas de separación silábica son específicas del idioma. En HTML, el idioma es determinado por el atributo [`lang`](/es/docs/Web/HTML/Global_attributes/lang) y los navegadores separarán únicamente si este atributo está presente y si existe un diccionario de separación silábica adecuado. En XML debe usarse el atributo `xml:lang.`
 

--- a/files/es/web/css/hyphens/index.md
+++ b/files/es/web/css/hyphens/index.md
@@ -21,7 +21,7 @@ hyphens: auto;
 
 ```html interactive-example
 <section id="default-example">
-<p id="example-element">An extra­ordinarily long English word!</p>
+  <p id="example-element">An extra­ordinarily long English word!</p>
 </section>
 ```
 

--- a/files/es/web/css/hyphens/index.md
+++ b/files/es/web/css/hyphens/index.md
@@ -3,7 +3,9 @@ title: hyphens
 slug: Web/CSS/hyphens
 ---
 
-{{CSSRef}}La propiedad [CSS](/es/docs/Web/CSS) **`hyphens`** especifica cómo deben dividirse las palabras cuando el texto se ajusta a través de múltiples líneas. Puede impedir la separación de sílabas por completo, usar guiones manualmente en puntos específicos del texto o dejar que el navegador inserte los guiones automáticamente donde corresponda.
+{{CSSRef}}
+
+La propiedad [CSS](/es/docs/Web/CSS) **`hyphens`** especifica cómo deben dividirse las palabras cuando el texto se ajusta a través de múltiples líneas. Puede impedir la separación de sílabas por completo, usar guiones manualmente en puntos específicos del texto o dejar que el navegador inserte los guiones automáticamente donde corresponda.
 
 {{InteractiveExample("CSS Demo: hyphens")}}
 

--- a/files/es/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -7,7 +7,22 @@ slug: Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences
 
 Los grupos y rangos indican grupos y rangos de caracteres de expresión.
 
-{{EmbedInteractiveExample("pages/js/regexp-groups-ranges.html")}}
+{{InteractiveExample("JavaScript Demo: RegExp Groups and backreferences")}}
+
+```js interactive-example
+// Groups
+const imageDescription = "This image has a resolution of 1440×900 pixels.";
+const regexpSize = /([0-9]+)×([0-9]+)/;
+const match = imageDescription.match(regexpSize);
+console.log(`Width: ${match[1]} / Height: ${match[2]}.`);
+// Expected output: "Width: 1440 / Height: 900."
+
+// Backreferences
+const findDuplicates = "foo foo bar";
+const regex = /\b(\w+)\s+\1\b/g;
+console.log(findDuplicates.match(regex));
+// Expected output: Array ["foo foo"]
+```
 
 ## Tipos
 

--- a/files/es/web/javascript/reference/global_objects/array/flat/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/flat/index.md
@@ -7,7 +7,25 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/flat
 
 El método **`flat()`** crea una nueva matriz con todos los elementos de sub-array concatenados recursivamente hasta la profundidad especificada.
 
-\\{{EmbedInteractiveExample("pages/js/array-flat.html")}}
+{{InteractiveExample("JavaScript Demo: Array.flat()")}}
+
+```js interactive-example
+const arr1 = [0, 1, 2, [3, 4]];
+
+console.log(arr1.flat());
+// expected output: Array [0, 1, 2, 3, 4]
+
+const arr2 = [0, 1, [2, [3, [4, 5]]]];
+
+console.log(arr2.flat());
+// expected output: Array [0, 1, 2, Array [3, Array [4, 5]]]
+
+console.log(arr2.flat(2));
+// expected output: Array [0, 1, 2, 3, Array [4, 5]]
+
+console.log(arr2.flat(Infinity));
+// expected output: Array [0, 1, 2, 3, 4, 5]
+```
 
 ## Sintaxis
 

--- a/files/es/web/javascript/reference/global_objects/date/setmonth/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/setmonth/index.md
@@ -8,7 +8,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Date/setMonth
 {{InteractiveExample("JavaScript Demo: Date.setMonth()")}}
 
 ```js interactive-example
-const event = new Date('August 19, 1975 23:15:30');
+const event = new Date("August 19, 1975 23:15:30");
 
 event.setMonth(3);
 

--- a/files/es/web/javascript/reference/global_objects/date/setmonth/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/setmonth/index.md
@@ -3,7 +3,22 @@ title: Date.prototype.setMonth()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setMonth
 ---
 
-{{JSRef}}El método **`setMonth()`** establece el mes para una fecha específica de acuerdo con el año establecido actualmente.{{EmbedInteractiveExample("pages/js/date-setmonth.html")}}
+{{JSRef}}El método **`setMonth()`** establece el mes para una fecha específica de acuerdo con el año establecido actualmente.
+
+{{InteractiveExample("JavaScript Demo: Date.setMonth()")}}
+
+```js interactive-example
+const event = new Date('August 19, 1975 23:15:30');
+
+event.setMonth(3);
+
+console.log(event.getMonth());
+// Expected output: 3
+
+console.log(event);
+// Expected output: "Sat Apr 19 1975 23:15:30 GMT+0100 (CET)"
+// Note: your timezone may vary
+```
 
 ## Sintaxis
 

--- a/files/es/web/javascript/reference/global_objects/date/setmonth/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/setmonth/index.md
@@ -3,7 +3,9 @@ title: Date.prototype.setMonth()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setMonth
 ---
 
-{{JSRef}}El método **`setMonth()`** establece el mes para una fecha específica de acuerdo con el año establecido actualmente.
+{{JSRef}}
+
+El método **`setMonth()`** establece el mes para una fecha específica de acuerdo con el año establecido actualmente.
 
 {{InteractiveExample("JavaScript Demo: Date.setMonth()")}}
 

--- a/files/es/web/javascript/reference/global_objects/string/match/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/match/index.md
@@ -10,7 +10,7 @@ El método **`match()`** devuelve todas las ocurrencias de una [expresión regul
 {{InteractiveExample("JavaScript Demo: String.match()", 'shorter')}}
 
 ```js interactive-example
-const paragraph = 'The quick brown fox jumps over the lazy dog. It barked.';
+const paragraph = "The quick brown fox jumps over the lazy dog. It barked.";
 const regex = /[A-Z]/g;
 const found = paragraph.match(regex);
 

--- a/files/es/web/javascript/reference/global_objects/string/match/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/match/index.md
@@ -7,7 +7,16 @@ slug: Web/JavaScript/Reference/Global_Objects/String/match
 
 El método **`match()`** devuelve todas las ocurrencias de una [expresión regular](/es/docs/Web/JavaScript/Guide/Regular_expressions) dentro de una _cadena_.
 
-{{EmbedInteractiveExample('pages/js/string-match.html', 'shorter')}}
+{{InteractiveExample("JavaScript Demo: String.match()", 'shorter')}}
+
+```js interactive-example
+const paragraph = 'The quick brown fox jumps over the lazy dog. It barked.';
+const regex = /[A-Z]/g;
+const found = paragraph.match(regex);
+
+console.log(found);
+// Expected output: Array ["T", "I"]
+```
 
 ## Sintaxis
 

--- a/files/es/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
@@ -3,7 +3,9 @@ title: String.prototype.toLocaleLowerCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase
 ---
 
-{{JSRef}}El método **`toLocaleLowerCase()`** retorna la cadena de texto desde la que se llama convertida en minúsculas, de acuerdo con cualquier localización específica de correspondencia de mayúsculas y minúsculas.
+{{JSRef}}
+
+El método **`toLocaleLowerCase()`** retorna la cadena de texto desde la que se llama convertida en minúsculas, de acuerdo con cualquier localización específica de correspondencia de mayúsculas y minúsculas.
 
 {{InteractiveExample("JavaScript Demo: String.toLocaleLowerCase()")}}
 

--- a/files/es/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
@@ -3,7 +3,19 @@ title: String.prototype.toLocaleLowerCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase
 ---
 
-{{JSRef}}El método **`toLocaleLowerCase()`** retorna la cadena de texto desde la que se llama convertida en minúsculas, de acuerdo con cualquier localización específica de correspondencia de mayúsculas y minúsculas.{{EmbedInteractiveExample("pages/js/string-tolocalelowercase.html")}}
+{{JSRef}}El método **`toLocaleLowerCase()`** retorna la cadena de texto desde la que se llama convertida en minúsculas, de acuerdo con cualquier localización específica de correspondencia de mayúsculas y minúsculas.
+
+{{InteractiveExample("JavaScript Demo: String.toLocaleLowerCase()")}}
+
+```js interactive-example
+const dotted = 'İstanbul';
+
+console.log(`EN-US: ${dotted.toLocaleLowerCase('en-US')}`);
+// Expected output: "i̇stanbul"
+
+console.log(`TR: ${dotted.toLocaleLowerCase('tr')}`);
+// Expected output: "istanbul"
+```
 
 Los fuentes para este ejemplo interactivo están almacenados en un repositorio GitHub. Si quieres contribuir en el proyecto de ejemplos interactivos, por favor clona `https://github.com/mdn/interactive-examples` y envíanos un pull request.
 

--- a/files/es/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
@@ -8,12 +8,12 @@ slug: Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase
 {{InteractiveExample("JavaScript Demo: String.toLocaleLowerCase()")}}
 
 ```js interactive-example
-const dotted = 'İstanbul';
+const dotted = "İstanbul";
 
-console.log(`EN-US: ${dotted.toLocaleLowerCase('en-US')}`);
+console.log(`EN-US: ${dotted.toLocaleLowerCase("en-US")}`);
 // Expected output: "i̇stanbul"
 
-console.log(`TR: ${dotted.toLocaleLowerCase('tr')}`);
+console.log(`TR: ${dotted.toLocaleLowerCase("tr")}`);
 // Expected output: "istanbul"
 ```
 

--- a/files/es/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/es/web/javascript/reference/operators/spread_syntax/index.md
@@ -3,7 +3,9 @@ title: Sintaxis Spread
 slug: Web/JavaScript/Reference/Operators/Spread_syntax
 ---
 
-{{jsSidebar("Operators")}}**La sintaxis extendida o spread** **syntax** permite a un elemento iterable tal como un arreglo o cadena ser expandido en lugares donde cero o más argumentos (para llamadas de función) o elementos (para [Array literales](/es/docs/Web/JavaScript/Guide/Grammar_and_types#literales_array)) son esperados, o a un objeto ser expandido en lugares donde cero o más pares de valores clave (para [literales Tipo Objeto](/es/docs/Web/JavaScript/Guide/Grammar_and_types#literales)) son esperados.
+{{jsSidebar("Operators")}}
+
+**La sintaxis extendida o spread** **syntax** permite a un elemento iterable tal como un arreglo o cadena ser expandido en lugares donde cero o más argumentos (para llamadas de función) o elementos (para [Array literales](/es/docs/Web/JavaScript/Guide/Grammar_and_types#literales_array)) son esperados, o a un objeto ser expandido en lugares donde cero o más pares de valores clave (para [literales Tipo Objeto](/es/docs/Web/JavaScript/Guide/Grammar_and_types#literales)) son esperados.
 
 {{InteractiveExample("JavaScript Demo: Expressions - Spread syntax")}}
 

--- a/files/es/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/es/web/javascript/reference/operators/spread_syntax/index.md
@@ -3,7 +3,23 @@ title: Sintaxis Spread
 slug: Web/JavaScript/Reference/Operators/Spread_syntax
 ---
 
-{{jsSidebar("Operators")}}**La sintaxis extendida o spread** **syntax** permite a un elemento iterable tal como un arreglo o cadena ser expandido en lugares donde cero o más argumentos (para llamadas de función) o elementos (para [Array literales](/es/docs/Web/JavaScript/Guide/Grammar_and_types#literales_array)) son esperados, o a un objeto ser expandido en lugares donde cero o más pares de valores clave (para [literales Tipo Objeto](/es/docs/Web/JavaScript/Guide/Grammar_and_types#literales)) son esperados.{{EmbedInteractiveExample("pages/js/expressions-spreadsyntax.html")}}
+{{jsSidebar("Operators")}}**La sintaxis extendida o spread** **syntax** permite a un elemento iterable tal como un arreglo o cadena ser expandido en lugares donde cero o más argumentos (para llamadas de función) o elementos (para [Array literales](/es/docs/Web/JavaScript/Guide/Grammar_and_types#literales_array)) son esperados, o a un objeto ser expandido en lugares donde cero o más pares de valores clave (para [literales Tipo Objeto](/es/docs/Web/JavaScript/Guide/Grammar_and_types#literales)) son esperados.
+
+{{InteractiveExample("JavaScript Demo: Expressions - Spread syntax")}}
+
+```js interactive-example
+function sum(x, y, z) {
+  return x + y + z;
+}
+
+const numbers = [1, 2, 3];
+
+console.log(sum(...numbers));
+// Expected output: 6
+
+console.log(sum.apply(null, numbers));
+// Expected output: 6
+```
 
 La fuente para este ejemplo interactivo está almacenada en el repositorio de GitHub. Si quieres contribuir al proyecto interactivo de ejemplos, por favor clona <https://github.com/mdn/interactive-examples> y envíanos una solicitud de descarga (pull).
 


### PR DESCRIPTION
These should be the final migrations outside of the kitchensink and writing guidelines, part of the wider project described here: https://github.com/orgs/mdn/discussions/782

We haven't QAed these as thoroughly as the previous migrations (difficult to do, as they weren't detected by our scripts, so we've had to manually migrate these), so I'd suggest a more "hands-on" review compared to the other migrations: thankfully it's only a few examples!