### PR TITLE
[fr]: migrate remaining interactive examples

### DIFF
--- a/files/fr/web/css/angle/index.md
+++ b/files/fr/web/css/angle/index.md
@@ -7,7 +7,7 @@ slug: Web/CSS/angle
 
 Le type de données CSS **`<angle>`** permet de représenter des angles exprimés en degrés, radians, grades ou tours. Les angles positifs sont des angles allant dans le sens horaire et les valeurs négatives sont des angles allant dans le sens anti-horaire. Les angles sont par exemples utilisés pour les transformations CSS ({{cssxref("transform")}}) ou les dégradés ({{cssxref("&lt;gradient&gt;")}}).
 
-{{InteractiveExample("CSS Demo: &amp;lt;angle&amp;gt;")}}
+{{InteractiveExample("CSS Demo: &lt;angle&lt;")}}
 
 ```css interactive-example-choice
 transform: rotate(45deg);

--- a/files/fr/web/css/angle/index.md
+++ b/files/fr/web/css/angle/index.md
@@ -7,7 +7,7 @@ slug: Web/CSS/angle
 
 Le type de données CSS **`<angle>`** permet de représenter des angles exprimés en degrés, radians, grades ou tours. Les angles positifs sont des angles allant dans le sens horaire et les valeurs négatives sont des angles allant dans le sens anti-horaire. Les angles sont par exemples utilisés pour les transformations CSS ({{cssxref("transform")}}) ou les dégradés ({{cssxref("&lt;gradient&gt;")}}).
 
-{{InteractiveExample("CSS Demo: &lt;angle&lt;")}}
+{{InteractiveExample("CSS Demo: &lt;angle&gt;")}}
 
 ```css interactive-example-choice
 transform: rotate(45deg);

--- a/files/fr/web/css/basic-shape/index.md
+++ b/files/fr/web/css/basic-shape/index.md
@@ -7,7 +7,7 @@ slug: Web/CSS/basic-shape
 
 Le type **`<basic-shape>`** permet de définir une forme simple en utilisant des fonctions et est notamment utilisé pour les propriétés {{cssxref("clip-path")}}, {{cssxref("shape-outside")}} ou {{cssxref("offset-path")}}.
 
-{{InteractiveExample("CSS Demo: &amp;lt;basic-shape&amp;gt;")}}
+{{InteractiveExample("CSS Demo: &lt;basic-shape&gt;")}}
 
 ```css interactive-example-choice
 clip-path: inset(22% 12% 15px 35px);

--- a/files/fr/web/css/gradient/index.md
+++ b/files/fr/web/css/gradient/index.md
@@ -7,7 +7,7 @@ slug: Web/CSS/gradient
 
 Le type de donnée CSS **`<gradient>`** permet de représenter une {{cssxref("&lt;image&gt;")}} contenant un dégradé entre deux ou plusieurs couleurs. Un dégradé CSS n'est pas une couleur CSS (type {{cssxref("&lt;color&gt;")}}) mais une image [sans dimension intrinsèque](/fr/docs/Web/CSS/image) (elle n'a aucune taille naturelle ou ratio), sa taille réelle sera celle de l'élément auquel elle est appliquée.
 
-{{InteractiveExample("CSS Demo: &amp;lt;gradient&amp;gt;")}}
+{{InteractiveExample("CSS Demo: &lt;gradient&gt;")}}
 
 ```css interactive-example-choice
 background: linear-gradient(#f69d3c, #3f87a6);

--- a/files/fr/web/html/global_attributes/accesskey/index.md
+++ b/files/fr/web/html/global_attributes/accesskey/index.md
@@ -3,7 +3,20 @@ title: accesskey
 slug: Web/HTML/Global_attributes/accesskey
 ---
 
-{{HTMLSidebar("Global_attributes")}}L'[attribut universel](/fr/docs/Web/HTML/Global_attributes) **`accesskey`** fournit une indication afin de générer un raccourci clavier pour l'élément courant. La valeur de cet attribut est une liste de caractères (un caractère étant ici un seul point de code Unicode) séparés par des espaces. Le navigateur utilisera le premier caractère qui est disponible selon la disposition du clavier utilisée.{{EmbedInteractiveExample("pages/tabbed/attribute-accesskey.html","tabbed-shorter")}}
+{{HTMLSidebar("Global_attributes")}}L'[attribut universel](/fr/docs/Web/HTML/Global_attributes) **`accesskey`** fournit une indication afin de générer un raccourci clavier pour l'élément courant. La valeur de cet attribut est une liste de caractères (un caractère étant ici un seul point de code Unicode) séparés par des espaces. Le navigateur utilisera le premier caractère qui est disponible selon la disposition du clavier utilisée.
+
+{{InteractiveExample("HTML Demo: accesskey", "tabbed-shorter")}}
+
+```html interactive-example
+<p>If you need to relax, press the <b>S</b>tress reliever!</p>
+<button accesskey="s">Stress reliever</button>
+```
+
+```css interactive-example
+b {
+  text-decoration: underline;
+}
+```
 
 La combinaison de touches utilisée pour le raccourci clavier dépend du navigateur et du système d'exploitation utilisés.
 

--- a/files/fr/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/fr/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -7,7 +7,22 @@ slug: Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences
 
 Les groupes permettent de regrouper différents motifs ensemble et les groupes de capture permettent d'extraire des informations supplémentaires quant aux correspondances entre une expression rationnelle et une chaîne de caractères. Les références arrière correspondent au groupe précédemment capturé dans la même expression rationnelle.
 
-{{EmbedInteractiveExample("pages/js/regexp-groups-ranges.html")}}
+{{InteractiveExample("JavaScript Demo: RegExp Groups and backreferences")}}
+
+```js interactive-example
+// Groups
+const imageDescription = "This image has a resolution of 1440×900 pixels.";
+const regexpSize = /([0-9]+)×([0-9]+)/;
+const match = imageDescription.match(regexpSize);
+console.log(`Width: ${match[1]} / Height: ${match[2]}.`);
+// Expected output: "Width: 1440 / Height: 900."
+
+// Backreferences
+const findDuplicates = "foo foo bar";
+const regex = /\b(\w+)\s+\1\b/g;
+console.log(findDuplicates.match(regex));
+// Expected output: Array ["foo foo"]
+```
 
 ## Types
 

--- a/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.md
@@ -3,7 +3,22 @@ title: Intl.RelativeTimeFormat.prototype.format()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/format
 ---
 
-{{JSRef}}La méthode **`Intl.RelativeTimeFormat.prototype.format()`** permet de formater une valeur avec une unité selon des options de locale et de formatage stockées dans l'objet {{jsxref("RelativeTimeFormat")}}.{{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-format.html")}}
+{{JSRef}}La méthode **`Intl.RelativeTimeFormat.prototype.format()`** permet de formater une valeur avec une unité selon des options de locale et de formatage stockées dans l'objet {{jsxref("RelativeTimeFormat")}}.
+
+{{InteractiveExample("JavaScript Demo: Intl.RelativeTimeFormat.prototype.format")}}
+
+```js interactive-example
+const rtf1 = new Intl.RelativeTimeFormat('en', { style: 'short' });
+
+console.log(rtf1.format(3, 'quarter'));
+// Expected output: "in 3 qtrs."
+
+console.log(rtf1.format(-1, 'day'));
+// Expected output: "1 day ago"
+
+console.log(rtf1.format(10, 'seconds'));
+// Expected output: "in 10 sec."
+```
 
 ## Syntaxe
 

--- a/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.md
@@ -8,15 +8,15 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/format
 {{InteractiveExample("JavaScript Demo: Intl.RelativeTimeFormat.prototype.format")}}
 
 ```js interactive-example
-const rtf1 = new Intl.RelativeTimeFormat('en', { style: 'short' });
+const rtf1 = new Intl.RelativeTimeFormat("en", { style: "short" });
 
-console.log(rtf1.format(3, 'quarter'));
+console.log(rtf1.format(3, "quarter"));
 // Expected output: "in 3 qtrs."
 
-console.log(rtf1.format(-1, 'day'));
+console.log(rtf1.format(-1, "day"));
 // Expected output: "1 day ago"
 
-console.log(rtf1.format(10, 'seconds'));
+console.log(rtf1.format(10, "seconds"));
 // Expected output: "in 10 sec."
 ```
 

--- a/files/fr/web/javascript/reference/global_objects/intl/segmenter/segment/segments/containing/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/segmenter/segment/segments/containing/index.md
@@ -7,7 +7,18 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/co
 
 La méthode **`Intl.Segments.containing()`** renvoie un objet décrivant le segment de la chaîne de caractères contenant le codet situé à l'indice passé en argument.
 
-{{EmbedInteractiveExample("pages/js/intl-segments-prototype-containing.html")}}
+{{InteractiveExample("JavaScript Demo: Segments.prototype.containing()")}}
+
+```js interactive-example
+const segmenterFr = new Intl.Segmenter("fr", { granularity: "word" });
+const string1 = "Que ma joie demeure";
+
+const segments = segmenterFr.segment(string1);
+
+console.log(segments.containing(5));
+// Expected output:
+// Object {segment: 'ma', index: 4, input: 'Que ma joie demeure', isWordLike: true}
+```
 
 ## Syntaxe
 

--- a/files/fr/web/javascript/reference/global_objects/intl/segmenter/segment/segments/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/segmenter/segment/segments/index.md
@@ -7,8 +7,6 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments
 
 Une instance **`Intl.Segments`** est une collection itérable des segments d'une chaîne de caractères. On obtient un tel objet en appelant la méthode [`segment()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment) d'un objet [`Intl.Segmenter`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter).
 
-{{EmbedInteractiveExample("pages/js/intl-segments-prototype-containing.html")}}
-
 ## Méthodes des instances
 
 - [`Segments.prototype.containing()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/containing)

--- a/files/fr/web/javascript/reference/global_objects/map/groupby/index.md
+++ b/files/fr/web/javascript/reference/global_objects/map/groupby/index.md
@@ -7,8 +7,6 @@ slug: Web/JavaScript/Reference/Global_Objects/Map/groupBy
 
 La méthode **`groupToMap()`** permet de grouper les éléments du tableau appelant selon les valeurs renvoyées par la fonction de test passée en argument. L'objet [`Map`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Map) renvoyé utilise les valeurs uniques fournies par la fonction de test comme clés, et les valeurs correspondantes sont des tableaux avec les éléments du groupe correspondant.
 
-<!-- {{EmbedInteractiveExample("pages/js/array-groupbytomap.html")}} -->
-
 Cette méthode est notamment utile lorsqu'on veut grouper des éléments associés avec un objet, notamment lorsque cet objet évolue avec le temps. Si cet objet ne varie, vous pouvez à la place utiliser une chaîne de caractères comme clé de regroupement et utiliser la méthode [`Array.prototype.group()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy).
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/object/groupby/index.md
+++ b/files/fr/web/javascript/reference/global_objects/object/groupby/index.md
@@ -14,7 +14,25 @@ La méthode statique **`Object.groupBy()`** groupe les éléments d'un itérable
 
 Cette méthode devrait être utilisée lorsque les noms des groupes peuvent être représentés par des chaînes de caractères. S'il vous faut grouper des éléments selon une clé qui peut être une valeur arbitraire, privilégiez la méthode [`Map.groupBy()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy).
 
-<!-- {{EmbedInteractiveExample("pages/js/object-groupby.html")}} -->
+{{InteractiveExample("JavaScript Demo: Object.groupBy()", "taller")}}
+
+```js interactive-example
+const inventory = [
+  { name: "asparagus", type: "vegetables", quantity: 9 },
+  { name: "bananas", type: "fruit", quantity: 5 },
+  { name: "goat", type: "meat", quantity: 23 },
+  { name: "cherries", type: "fruit", quantity: 12 },
+  { name: "fish", type: "meat", quantity: 22 },
+];
+
+const restock = { restock: true };
+const sufficient = { restock: false };
+const result = Object.groupBy(inventory, ({ quantity }) =>
+  quantity < 6 ? "restock" : "sufficient",
+);
+console.log(result.restock);
+// [{ name: "bananas", type: "fruit", quantity: 5 }]
+```
 
 ## Syntaxe
 

--- a/files/fr/web/javascript/reference/global_objects/string/symbol.iterator/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/symbol.iterator/index.md
@@ -8,7 +8,20 @@ original_slug: Web/JavaScript/Reference/Global_Objects/String/@@iterator
 
 La méthode **`[@@iterator]()`** renvoie un nouvel objet [`Iterator`](/fr/docs/Web/JavaScript/Reference/Iteration_protocols) qui itère sur les points de code (codets) d'une chaîne de caractères, en renvoyant chaque point de code sous forme d'une chaîne de caractères.
 
-{{EmbedInteractiveExample("pages/js/string-iterator.html")}}
+{{InteractiveExample("JavaScript Demo: Symbol.iterator")}}
+
+```js interactive-example
+const iterable1 = {};
+
+iterable1[Symbol.iterator] = function* () {
+  yield 1;
+  yield 2;
+  yield 3;
+};
+
+console.log([...iterable1]);
+// Expected output: Array [1, 2, 3]
+```
 
 ## Syntaxe
 


### PR DESCRIPTION
These should be the final migrations outside of the kitchensink and writing guidelines, part of the wider project described here: https://github.com/orgs/mdn/discussions/782

We haven't QAed these as thoroughly as the previous migrations (difficult to do, as they weren't detected by our scripts, so we've had to manually migrate these), so I'd suggest a more "hands-on" review compared to the other migrations: thankfully it's only a few examples!