### PR TITLE
[ko]: migrate remaining interactive examples

### DIFF
--- a/docs/ko/fully_untranslated_files/web/Web_CSS_basic-shape.md
+++ b/docs/ko/fully_untranslated_files/web/Web_CSS_basic-shape.md
@@ -7,7 +7,45 @@ slug: Web/CSS/basic-shape
 
 **`<basic-shape>`** [CSS](/ko/docs/Web/CSS) [자료형](/ko/docs/Web/CSS/CSS_Types)은 {{cssxref("clip-path")}}, {{cssxref("shape-outside")}}, {{cssxref("offset-path")}} 속성이 사용할 형태를 정의합니다.
 
-{{EmbedInteractiveExample("pages/css/type-basic-shape.html")}}
+{{InteractiveExample("CSS Demo: &lt;basic-shape&gt;")}}
+
+```css interactive-example-choice
+clip-path: inset(22% 12% 15px 35px);
+```
+
+```css interactive-example-choice
+clip-path: circle(6rem at 12rem 8rem);
+```
+
+```css interactive-example-choice
+clip-path: ellipse(115px 55px at 50% 40%);
+```
+
+```css interactive-example-choice
+clip-path: polygon(50% 2.4%, 34.5% 33.8%, 0% 38.8%, 25% 63.1%, 19.1% 97.6%, 50% 81.3%, 80.9% 97.6%, 75% 63.1%, 100% 38.8%, 65.5% 33.8%);
+```
+
+```css interactive-example-choice
+clip-path: path('M 50,245 A 160,160 0,0,1 360,120 z')
+```
+
+```html interactive-example
+<section class="default-example" id="default-example">
+<div class="transition-all" id="example-element"></div>
+</section>
+```
+
+```css interactive-example
+#default-example {
+  background: #fe9;
+}
+
+#example-element {
+  background: linear-gradient(to bottom right, #f52, #05f);
+  width: 100%;
+  height: 100%;
+}
+```
 
 ## 구문
 

--- a/docs/ko/fully_untranslated_files/web/Web_CSS_basic-shape.md
+++ b/docs/ko/fully_untranslated_files/web/Web_CSS_basic-shape.md
@@ -22,16 +22,27 @@ clip-path: ellipse(115px 55px at 50% 40%);
 ```
 
 ```css interactive-example-choice
-clip-path: polygon(50% 2.4%, 34.5% 33.8%, 0% 38.8%, 25% 63.1%, 19.1% 97.6%, 50% 81.3%, 80.9% 97.6%, 75% 63.1%, 100% 38.8%, 65.5% 33.8%);
+clip-path: polygon(
+  50% 2.4%,
+  34.5% 33.8%,
+  0% 38.8%,
+  25% 63.1%,
+  19.1% 97.6%,
+  50% 81.3%,
+  80.9% 97.6%,
+  75% 63.1%,
+  100% 38.8%,
+  65.5% 33.8%
+);
 ```
 
 ```css interactive-example-choice
-clip-path: path('M 50,245 A 160,160 0,0,1 360,120 z')
+clip-path: path("M 50,245 A 160,160 0,0,1 360,120 z");
 ```
 
 ```html interactive-example
 <section class="default-example" id="default-example">
-<div class="transition-all" id="example-element"></div>
+  <div class="transition-all" id="example-element"></div>
 </section>
 ```
 

--- a/docs/ko/fully_untranslated_files/web/Web_CSS_box-shadow.md
+++ b/docs/ko/fully_untranslated_files/web/Web_CSS_box-shadow.md
@@ -7,7 +7,45 @@ slug: Web/CSS/box-shadow
 
 `box-shadow` CSS 속성은 요소의 테두리를 감싼 그림자 효과를 추가합니다. 쉼표로 구문해서 여러 그림자 효과를 입힐 수 있습니다. 박스 그림자는 요소에서의 수평수직 거리(오프셋), 흐릿함과 확산 정도, 색상으로 이루어집니다.
 
-{{EmbedInteractiveExample("pages/css/box-shadow.html")}}
+{{InteractiveExample("CSS Demo: box-shadow")}}
+
+```css interactive-example-choice
+box-shadow: 10px 5px 5px red;
+```
+
+```css interactive-example-choice
+box-shadow: 60px -16px teal;
+```
+
+```css interactive-example-choice
+box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, .2);
+```
+
+```css interactive-example-choice
+box-shadow: inset 5em 1em gold;
+```
+
+```css interactive-example-choice
+box-shadow: 3px 3px red, -1em 0 .4em olive;
+```
+
+```html interactive-example
+<section id="default-example">
+<div class="transition-all" id="example-element">
+<p>This is a box with a box-shadow around it.</p>
+</div>
+</section>
+```
+
+```css interactive-example
+#example-element {
+  margin: 20px auto;
+  padding: 0;
+  border: 2px solid #333;
+  width: 80%;
+  text-align: center;
+}
+```
 
 `box-shadow` 속성은 거의 모든 요소의 테두리에서 그림자를 드리울 수 있도록 도와줍니다. {{cssxref("border-radius")}}가 요소에 함께 적용됐다면 박스 그림자의 모서리도 똑같이 둥근 모서리를 갖게 됩니다. 여러 그림자의 z축 순서는 {{cssxref("text-shadow")}}와 동일하게 처음 그림자일수록 위로 올라옵니다.
 

--- a/docs/ko/fully_untranslated_files/web/Web_CSS_box-shadow.md
+++ b/docs/ko/fully_untranslated_files/web/Web_CSS_box-shadow.md
@@ -18,7 +18,7 @@ box-shadow: 60px -16px teal;
 ```
 
 ```css interactive-example-choice
-box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, .2);
+box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, 0.2);
 ```
 
 ```css interactive-example-choice
@@ -26,14 +26,16 @@ box-shadow: inset 5em 1em gold;
 ```
 
 ```css interactive-example-choice
-box-shadow: 3px 3px red, -1em 0 .4em olive;
+box-shadow:
+  3px 3px red,
+  -1em 0 0.4em olive;
 ```
 
 ```html interactive-example
 <section id="default-example">
-<div class="transition-all" id="example-element">
-<p>This is a box with a box-shadow around it.</p>
-</div>
+  <div class="transition-all" id="example-element">
+    <p>This is a box with a box-shadow around it.</p>
+  </div>
 </section>
 ```
 

--- a/docs/ko/fully_untranslated_files/web/Web_CSS_font-family.md
+++ b/docs/ko/fully_untranslated_files/web/Web_CSS_font-family.md
@@ -35,12 +35,13 @@ font-family: system-ui;
 
 ```html interactive-example
 <section id="default-example">
-<p id="example-element">
-      London. Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November
-      weather. As much mud in the streets as if the waters had but newly retired from the face of the earth, and it
-      would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine lizard up
-      Holborn Hill.
-    </p>
+  <p id="example-element">
+    London. Michaelmas term lately over, and the Lord Chancellor sitting in
+    Lincoln's Inn Hall. Implacable November weather. As much mud in the streets
+    as if the waters had but newly retired from the face of the earth, and it
+    would not be wonderful to meet a Megalosaurus, forty feet long or so,
+    waddling like an elephantine lizard up Holborn Hill.
+  </p>
 </section>
 ```
 

--- a/docs/ko/fully_untranslated_files/web/Web_CSS_font-family.md
+++ b/docs/ko/fully_untranslated_files/web/Web_CSS_font-family.md
@@ -7,7 +7,48 @@ slug: Web/CSS/font-family
 
 CSS **`font-family`** 속성은 선택된 요소에 우선 순위가 지정된 font family 이름과 generic family 이름을 지정할 수 있게 해줍니다.
 
-{{EmbedInteractiveExample("pages/css/font-family.html")}}
+{{InteractiveExample("CSS Demo: font-family")}}
+
+```css interactive-example-choice
+font-family: Georgia, serif;
+```
+
+```css interactive-example-choice
+font-family: "Gill Sans", sans-serif;
+```
+
+```css interactive-example-choice
+font-family: sans-serif;
+```
+
+```css interactive-example-choice
+font-family: serif;
+```
+
+```css interactive-example-choice
+font-family: cursive;
+```
+
+```css interactive-example-choice
+font-family: system-ui;
+```
+
+```html interactive-example
+<section id="default-example">
+<p id="example-element">
+      London. Michaelmas term lately over, and the Lord Chancellor sitting in Lincoln's Inn Hall. Implacable November
+      weather. As much mud in the streets as if the waters had but newly retired from the face of the earth, and it
+      would not be wonderful to meet a Megalosaurus, forty feet long or so, waddling like an elephantine lizard up
+      Holborn Hill.
+    </p>
+</section>
+```
+
+```css interactive-example
+section {
+  font-size: 1.2em;
+}
+```
 
 값은 콤마로 구분하여 대체가 될 수 있음을 나타냅니다. 브라우저는 폰트 목록에서 컴퓨터에 설치되어 있거나 {{cssxref("@font-face")}} 규칙을 이용하여 다운로드 받을 수 있는 폰트 중 가장 첫번째 폰트를 선택할 것입니다.
 

--- a/docs/ko/fully_untranslated_files/web/Web_HTML_Element_area.md
+++ b/docs/ko/fully_untranslated_files/web/Web_HTML_Element_area.md
@@ -37,7 +37,10 @@ slug: Web/HTML/Element/area
     href="https://developer.mozilla.org/docs/Web/CSS"
     alt="CSS" />
 </map>
-<img usemap="#infographic" src="/shared-assets/images/examples/mdn-info.png" alt="MDN infographic" />
+<img
+  usemap="#infographic"
+  src="/shared-assets/images/examples/mdn-info.png"
+  alt="MDN infographic" />
 ```
 
 ```css interactive-example

--- a/docs/ko/fully_untranslated_files/web/Web_HTML_Element_area.md
+++ b/docs/ko/fully_untranslated_files/web/Web_HTML_Element_area.md
@@ -7,7 +7,47 @@ slug: Web/HTML/Element/area
 
 **HTML `<area>` 요소**는 이미지의 핫스팟 영역을 정의하고 {{glossary("hyperlink", "하이퍼링크")}}를 추가할 수 있습니다. {{htmlelement("map")}} 요소 안에서만 사용할 수 있습니다.
 
-{{EmbedInteractiveExample("pages/tabbed/area.html", "tabbed-taller")}}
+{{InteractiveExample("HTML Demo: &lt;area&gt;", "tabbed-taller")}}
+
+```html interactive-example
+<map name="infographic">
+  <area
+    shape="poly"
+    coords="129,0,260,95,129,138"
+    href="https://developer.mozilla.org/docs/Web/HTTP"
+    alt="HTTP" />
+  <area
+    shape="poly"
+    coords="260,96,209,249,130,138"
+    href="https://developer.mozilla.org/docs/Web/HTML"
+    alt="HTML" />
+  <area
+    shape="poly"
+    coords="209,249,49,249,130,139"
+    href="https://developer.mozilla.org/docs/Web/JavaScript"
+    alt="JavaScript" />
+  <area
+    shape="poly"
+    coords="48,249,0,96,129,138"
+    href="https://developer.mozilla.org/docs/Web/API"
+    alt="Web APIs" />
+  <area
+    shape="poly"
+    coords="0,95,128,0,128,137"
+    href="https://developer.mozilla.org/docs/Web/CSS"
+    alt="CSS" />
+</map>
+<img usemap="#infographic" src="/shared-assets/images/examples/mdn-info.png" alt="MDN infographic" />
+```
+
+```css interactive-example
+img {
+  display: block;
+  margin: 0 auto;
+  width: 260px;
+  height: 260px;
+}
+```
 
 <table class="properties">
   <tbody>

--- a/docs/ko/fully_untranslated_files/web/Web_HTML_Element_audio.md
+++ b/docs/ko/fully_untranslated_files/web/Web_HTML_Element_audio.md
@@ -7,7 +7,21 @@ slug: Web/HTML/Element/audio
 
 **HTML `<audio>` 요소**는 문서에 소리 콘텐츠를 포함할 때 사용합니다. `src` 특성 또는 {{htmlelement("source")}} 요소를 사용해 한 개 이상의 오디오 소스를 지정할 수 있으며, 다수를 지정한 경우 가장 적절한 소스를 브라우저가 고릅니다. {{domxref("MediaStream")}}을 사용하면 미디어 스트림을 바라볼 수도 있습니다.
 
-{{EmbedInteractiveExample("pages/tabbed/audio.html","tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;audio&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<figure>
+  <figcaption>Listen to the T-Rex:</figcaption>
+  <audio controls src="/shared-assets/audio/t-rex-roar.mp3"></audio>
+  <a href="/shared-assets/audio/t-rex-roar.mp3"> Download audio </a>
+</figure>
+```
+
+```css interactive-example
+figure {
+  margin: 0;
+}
+```
 
 ## 특성
 

--- a/docs/ko/fully_untranslated_files/web/Web_HTML_Element_input.md
+++ b/docs/ko/fully_untranslated_files/web/Web_HTML_Element_input.md
@@ -7,7 +7,27 @@ slug: Web/HTML/Element/input
 
 **HTML `<input>` 요소**는 웹 기반 양식에서 사용자의 데이터를 받을 수 있는 대화형 컨트롤을 생성합니다. {{glossary("user agent", "사용자 에이전트")}}에 따라서 다양한 종류의 입력 데이터 유형과 컨트롤 위젯이 존재합니다. 입력 유형과 특성의 다양한 조합 가능성으로 인해, `<input>` 요소는 HTML에서 제일 강력하고 복잡한 요소 중 하나입니다.
 
-{{EmbedInteractiveExample("pages/tabbed/input-text.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;input type=&quot;text&quot;&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<label for="name">Name (4 to 8 characters):</label>
+
+<input type="text" id="name" name="name" required minlength="4" maxlength="8" size="10" />
+```
+
+```css interactive-example
+label {
+  display: block;
+  font:
+    1rem 'Fira Sans',
+    sans-serif;
+}
+
+input,
+label {
+  margin: 0.4rem 0;
+}
+```
 
 ## `<input>` 유형
 

--- a/docs/ko/fully_untranslated_files/web/Web_HTML_Element_input.md
+++ b/docs/ko/fully_untranslated_files/web/Web_HTML_Element_input.md
@@ -12,14 +12,21 @@ slug: Web/HTML/Element/input
 ```html interactive-example
 <label for="name">Name (4 to 8 characters):</label>
 
-<input type="text" id="name" name="name" required minlength="4" maxlength="8" size="10" />
+<input
+  type="text"
+  id="name"
+  name="name"
+  required
+  minlength="4"
+  maxlength="8"
+  size="10" />
 ```
 
 ```css interactive-example
 label {
   display: block;
   font:
-    1rem 'Fira Sans',
+    1rem "Fira Sans",
     sans-serif;
 }
 

--- a/docs/ko/fully_untranslated_files/web/Web_HTML_Element_select.md
+++ b/docs/ko/fully_untranslated_files/web/Web_HTML_Element_select.md
@@ -7,7 +7,34 @@ slug: Web/HTML/Element/select
 
 **HTML `<select>` 요소**는 옵션 메뉴를 제공하는 컨트롤을 나타냅니다.
 
-{{EmbedInteractiveExample("pages/tabbed/select.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;select&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<label for="pet-select">Choose a pet:</label>
+
+<select name="pets" id="pet-select">
+  <option value="">--Please choose an option--</option>
+  <option value="dog">Dog</option>
+  <option value="cat">Cat</option>
+  <option value="hamster">Hamster</option>
+  <option value="parrot">Parrot</option>
+  <option value="spider">Spider</option>
+  <option value="goldfish">Goldfish</option>
+</select>
+```
+
+```css interactive-example
+label {
+  font-family: sans-serif;
+  font-size: 1rem;
+  padding-right: 10px;
+}
+
+select {
+  font-size: 0.9rem;
+  padding: 2px 5px;
+}
+```
 
 위의 예제는 일반적인 `<select>` 사용법을 시연합니다. {{htmlelement("label")}}과 연결해 접근성을 향상할 수 있도록 [`id`](/ko/docs/Web/HTML/Global_attributes#id) 특성을, 서버로 전송할 데이터의 이름을 위해 [`name`](/ko/docs/Web/HTML/Element/select#name) 특성을 적용했습니다. 메뉴의 각 옵션은 `<select>` 안의 {{htmlelement("option")}}으로 정의합니다.
 

--- a/docs/ko/fully_untranslated_files/web/Web_HTML_Element_tbody.md
+++ b/docs/ko/fully_untranslated_files/web/Web_HTML_Element_tbody.md
@@ -7,7 +7,72 @@ slug: Web/HTML/Element/tbody
 
 **HTML** **`<tbody>`** 요소는 표의 여러 행({{htmlelement("tr")}})을 묶어서 표 본문을 구성합니다.
 
-{{EmbedInteractiveExample("pages/tabbed/tbody.html","tabbed-taller")}}
+{{InteractiveExample("HTML Demo: &lt;tbody&gt;", "tabbed-taller")}}
+
+```html interactive-example
+<table>
+  <caption>
+    Council budget (in £) 2018
+  </caption>
+  <thead>
+    <tr>
+      <th scope="col">Items</th>
+      <th scope="col">Expenditure</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Donuts</th>
+      <td>3,000</td>
+    </tr>
+    <tr>
+      <th scope="row">Stationery</th>
+      <td>18,000</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <th scope="row">Totals</th>
+      <td>21,000</td>
+    </tr>
+  </tfoot>
+</table>
+```
+
+```css interactive-example
+thead,
+tfoot {
+  background-color: #2c5e77;
+  color: #fff;
+}
+
+tbody {
+  background-color: #e4f0f5;
+}
+
+table {
+  border-collapse: collapse;
+  border: 2px solid rgb(140 140 140);
+  font-family: sans-serif;
+  font-size: 0.8rem;
+  letter-spacing: 1px;
+}
+
+caption {
+  caption-side: bottom;
+  padding: 10px;
+}
+
+th,
+td {
+  border: 1px solid rgb(160 160 160);
+  padding: 8px 10px;
+}
+
+td {
+  text-align: center;
+}
+```
 
 `<tbody>` 요소와 그 사촌인 {{HTMLElement("thead")}}, {{HTMLElement("tfoot")}} 요소는 화면과 프린터에 렌더링 할 때 뿐만 아니라 {{Glossary("accessibility", "접근성")}} 차원에서도 유용한 의미를 표의 행에 부여합니다.
 

--- a/docs/ko/fully_untranslated_files/web/Web_JavaScript_Reference_Global_Objects_RegExp_exec.md
+++ b/docs/ko/fully_untranslated_files/web/Web_JavaScript_Reference_Global_Objects_RegExp_exec.md
@@ -16,8 +16,8 @@ JavaScript {{jsxref("RegExp")}} 객체는 {{jsxref("RegExp.global", "global")}} 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.exec()")}}
 
 ```js interactive-example
-const regex1 = RegExp('foo*', 'g');
-const str1 = 'table football, foosball';
+const regex1 = RegExp("foo*", "g");
+const str1 = "table football, foosball";
 let array1;
 
 while ((array1 = regex1.exec(str1)) !== null) {

--- a/docs/ko/fully_untranslated_files/web/Web_JavaScript_Reference_Global_Objects_RegExp_exec.md
+++ b/docs/ko/fully_untranslated_files/web/Web_JavaScript_Reference_Global_Objects_RegExp_exec.md
@@ -13,7 +13,19 @@ JavaScript {{jsxref("RegExp")}} 객체는 {{jsxref("RegExp.global", "global")}} 
 
 단순히 `true`/`false`가 필요한 경우 {{jsxref("RegExp.prototype.test()")}} 메서드 혹은 {{jsxref("String.prototype.search()")}}를 사용하세요.
 
-{{EmbedInteractiveExample("pages/js/regexp-prototype-exec.html")}}
+{{InteractiveExample("JavaScript Demo: RegExp.prototype.exec()")}}
+
+```js interactive-example
+const regex1 = RegExp('foo*', 'g');
+const str1 = 'table football, foosball';
+let array1;
+
+while ((array1 = regex1.exec(str1)) !== null) {
+  console.log(`Found ${array1[0]}. Next starts at ${regex1.lastIndex}.`);
+  // Expected output: "Found foo. Next starts at 9."
+  // Expected output: "Found foo. Next starts at 19."
+}
+```
 
 ## 구문
 

--- a/docs/ko/fully_untranslated_files/web/Web_JavaScript_Reference_Operators_delete.md
+++ b/docs/ko/fully_untranslated_files/web/Web_JavaScript_Reference_Operators_delete.md
@@ -11,8 +11,8 @@ slug: Web/JavaScript/Reference/Operators/delete
 
 ```js interactive-example
 const Employee = {
-  firstname: 'Maria',
-  lastname: 'Sanchez',
+  firstname: "Maria",
+  lastname: "Sanchez",
 };
 
 console.log(Employee.firstname);

--- a/docs/ko/fully_untranslated_files/web/Web_JavaScript_Reference_Operators_delete.md
+++ b/docs/ko/fully_untranslated_files/web/Web_JavaScript_Reference_Operators_delete.md
@@ -7,7 +7,22 @@ slug: Web/JavaScript/Reference/Operators/delete
 
 **`delete`** **연산자** 는 객체의 속성을 제거합니다. 제거한 객체의 참조를 어디에서도 사용하지 않는다면 나중에 자원을 회수합니다.
 
-{{EmbedInteractiveExample("pages/js/expressions-deleteoperator.html")}}
+{{InteractiveExample("JavaScript Demo: Expressions - delete operator")}}
+
+```js interactive-example
+const Employee = {
+  firstname: 'Maria',
+  lastname: 'Sanchez',
+};
+
+console.log(Employee.firstname);
+// Expected output: "Maria"
+
+delete Employee.firstname;
+
+console.log(Employee.firstname);
+// Expected output: undefined
+```
 
 ## 구문
 

--- a/docs/ko/fully_untranslated_files/web/Web_JavaScript_Reference_Statements_trycatch.md
+++ b/docs/ko/fully_untranslated_files/web/Web_JavaScript_Reference_Statements_trycatch.md
@@ -7,7 +7,17 @@ slug: Web/JavaScript/Reference/Statements/try...catch
 
 **`try...catch`** 문은 실행할 코드블럭을 표시하고 예외(exception)가 발생(throw)할 경우의 응답을 지정합니다.
 
-{{EmbedInteractiveExample("pages/js/statement-trycatch.html")}}
+{{InteractiveExample("JavaScript Demo: Statement - Try...Catch")}}
+
+```js interactive-example
+try {
+  nonExistentFunction();
+} catch (error) {
+  console.error(error);
+  // Expected output: ReferenceError: nonExistentFunction is not defined
+  // (Note: the exact output may be browser-dependent)
+}
+```
 
 ## 문법
 

--- a/files/ko/web/css/angle/index.md
+++ b/files/ko/web/css/angle/index.md
@@ -7,7 +7,7 @@ slug: Web/CSS/angle
 
 [CSS](/ko/docs/Web/CSS) **`<angle>`** [자료형](/ko/docs/Web/CSS/CSS_Types)은 각도의 값을 도, 그레이드, 라디안 또는 회전수로 표현합니다. {{cssxref("&lt;gradient&gt;")}}나 일부 {{cssxref("transform")}} 함수에서 사용합니다..
 
-{{InteractiveExample("CSS Demo: &amp;lt;angle&amp;gt;")}}
+{{InteractiveExample("CSS Demo: &lt;angle&gt;")}}
 
 ```css interactive-example-choice
 transform: rotate(45deg);

--- a/files/ko/web/css/gradient/index.md
+++ b/files/ko/web/css/gradient/index.md
@@ -7,7 +7,7 @@ slug: Web/CSS/gradient
 
 **`<gradient>`** [CSS](/ko/docs/Web/CSS) [자료형](/ko/docs/Web/CSS/CSS_Types)은 {{cssxref("&lt;image&gt;")}}의 특별한 종류로 여러 색의 점진적인 변화를 나타냅니다.
 
-{{InteractiveExample("CSS Demo: &amp;lt;gradient&amp;gt;")}}
+{{InteractiveExample("CSS Demo: &lt;gradient&gt;")}}
 
 ```css interactive-example-choice
 background: linear-gradient(#f69d3c, #3f87a6);

--- a/files/ko/web/javascript/reference/global_objects/math/pow/index.md
+++ b/files/ko/web/javascript/reference/global_objects/math/pow/index.md
@@ -4,7 +4,24 @@ slug: Web/JavaScript/Reference/Global_Objects/Math/pow
 ---
 
 {{JSRef}}**`Math.pow()`**함수는`base^exponent`처럼
-`base` 에 `exponent`를 제곱한 값을 반환합니다.{{EmbedInteractiveExample("pages/js/math-pow.html")}}
+`base` 에 `exponent`를 제곱한 값을 반환합니다.
+
+{{InteractiveExample("JavaScript Demo: Math.pow()")}}
+
+```js interactive-example
+console.log(Math.pow(7, 3));
+// Expected output: 343
+
+console.log(Math.pow(4, 0.5));
+// Expected output: 2
+
+console.log(Math.pow(7, -2));
+// Expected output: 0.02040816326530612
+//                  (1/49)
+
+console.log(Math.pow(-7, 0.5));
+// Expected output: NaN
+```
 
 ## 문법
 

--- a/files/ko/web/javascript/reference/global_objects/object/groupby/index.md
+++ b/files/ko/web/javascript/reference/global_objects/object/groupby/index.md
@@ -14,7 +14,25 @@ l10n:
 
 이 메서드는 그룹 이름을 문자열로 표현할 수 있을 때 사용해야 합니다. 만약 임의의 값을 키로 사용하여 요소들을 그룹화해야 한다면, 대신 {{jsxref("Map.groupBy()")}}를 사용하세요.
 
-<!-- {{EmbedInteractiveExample("pages/js/object-groupby.html")}} -->
+{{InteractiveExample("JavaScript Demo: Object.groupBy()", "taller")}}
+
+```js interactive-example
+const inventory = [
+  { name: "asparagus", type: "vegetables", quantity: 9 },
+  { name: "bananas", type: "fruit", quantity: 5 },
+  { name: "goat", type: "meat", quantity: 23 },
+  { name: "cherries", type: "fruit", quantity: 12 },
+  { name: "fish", type: "meat", quantity: 22 },
+];
+
+const restock = { restock: true };
+const sufficient = { restock: false };
+const result = Object.groupBy(inventory, ({ quantity }) =>
+  quantity < 6 ? "restock" : "sufficient",
+);
+console.log(result.restock);
+// [{ name: "bananas", type: "fruit", quantity: 5 }]
+```
 
 ## 구문
 


### PR DESCRIPTION
These should be the final migrations outside of the kitchensink and writing guidelines, part of the wider project described here: https://github.com/orgs/mdn/discussions/782

We haven't QAed these as thoroughly as the previous migrations (difficult to do, as they weren't detected by our scripts, so we've had to manually migrate these), so I'd suggest a more "hands-on" review compared to the other migrations: thankfully it's only a few examples!