### PR TITLE
[pt-br]: migrate remaining interactive examples

### DIFF
--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/map/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/map/index.md
@@ -7,7 +7,7 @@ slug: conflicting/Web/JavaScript/Reference/Global_Objects/Map
 
 A propriedade **`Map[@@toStringTag]`** tem o valor inicial do `Map`.
 
-{{EmbedInteractiveExample("pages/js/map-prototype-@@tostringtag.html","shorter")}}{{js_property_attributes(0,0,1)}}
+{{js_property_attributes(0,0,1)}}
 
 ## Sintaxe
 

--- a/files/pt-br/web/css/position/index.md
+++ b/files/pt-br/web/css/position/index.md
@@ -13,12 +13,14 @@ position: static;
 
 ```css interactive-example-choice
 position: relative;
-top: 40px; left: 40px;
+top: 40px;
+left: 40px;
 ```
 
 ```css interactive-example-choice
 position: absolute;
-top: 40px; left: 40px;
+top: 40px;
+left: 40px;
 ```
 
 ```css interactive-example-choice
@@ -28,31 +30,37 @@ top: 20px;
 
 ```html interactive-example
 <section class="default-example" id="default-example">
-<div id="example-element-container">
-<p>In this demo you can control the <code>position</code> property for the yellow box.</p>
-<div class="box"></div>
-<div class="box" id="example-element"></div>
-<div class="box"></div>
-<p class="clear">
-        To see the effect of <code>sticky</code> positioning, select the <code>position: sticky</code> option and scroll
-        this container.
-      </p>
-<p>
-        The element will scroll along with its container, until it is at the top of the container (or reaches the offset
-        specified in <code>top</code>), and will then stop scrolling, so it stays visible.
-      </p>
-<p>
-        The rest of this text is only supplied to make sure the container overflows, so as to enable you to scroll it
-        and see the effect.
-      </p>
-<hr/>
-<p>
-        Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a
-        small unregarded yellow sun. Orbiting this at a distance of roughly ninety-two million miles is an utterly
-        insignificant little blue green planet whose ape-descended life forms are so amazingly primitive that they still
-        think digital watches are a pretty neat idea.
-      </p>
-</div>
+  <div id="example-element-container">
+    <p>
+      In this demo you can control the <code>position</code> property for the
+      yellow box.
+    </p>
+    <div class="box"></div>
+    <div class="box" id="example-element"></div>
+    <div class="box"></div>
+    <p class="clear">
+      To see the effect of <code>sticky</code> positioning, select the
+      <code>position: sticky</code> option and scroll this container.
+    </p>
+    <p>
+      The element will scroll along with its container, until it is at the top
+      of the container (or reaches the offset specified in <code>top</code>),
+      and will then stop scrolling, so it stays visible.
+    </p>
+    <p>
+      The rest of this text is only supplied to make sure the container
+      overflows, so as to enable you to scroll it and see the effect.
+    </p>
+    <hr />
+    <p>
+      Far out in the uncharted backwaters of the unfashionable end of the
+      western spiral arm of the Galaxy lies a small unregarded yellow sun.
+      Orbiting this at a distance of roughly ninety-two million miles is an
+      utterly insignificant little blue green planet whose ape-descended life
+      forms are so amazingly primitive that they still think digital watches are
+      a pretty neat idea.
+    </p>
+  </div>
 </section>
 ```
 

--- a/files/pt-br/web/css/position/index.md
+++ b/files/pt-br/web/css/position/index.md
@@ -3,7 +3,9 @@ title: position
 slug: Web/CSS/position
 ---
 
-{{CSSRef}}A propriedade **`position`**, encontrada no [CSS](/pt-BR/docs/Web/CSS), define como um elemento pode ser posicionado (renderizado) no documento (página). Essa propriedade (**`position`**) pode ser acompanhada de outras, tais como, {{Cssxref("top")}}, {{Cssxref("right")}}, {{Cssxref("bottom")}}, and {{Cssxref("left")}}, que determinam como ficará a localização final do objeto, permitindo seu deslocamento, como será apresentado adiante.
+{{CSSRef}}
+
+A propriedade **`position`**, encontrada no [CSS](/pt-BR/docs/Web/CSS), define como um elemento pode ser posicionado (renderizado) no documento (página). Essa propriedade (**`position`**) pode ser acompanhada de outras, tais como, {{Cssxref("top")}}, {{Cssxref("right")}}, {{Cssxref("bottom")}}, and {{Cssxref("left")}}, que determinam como ficará a localização final do objeto, permitindo seu deslocamento, como será apresentado adiante.
 
 {{InteractiveExample("CSS Demo: position")}}
 

--- a/files/pt-br/web/css/position/index.md
+++ b/files/pt-br/web/css/position/index.md
@@ -3,7 +3,93 @@ title: position
 slug: Web/CSS/position
 ---
 
-{{CSSRef}}A propriedade **`position`**, encontrada no [CSS](/pt-BR/docs/Web/CSS), define como um elemento pode ser posicionado (renderizado) no documento (página). Essa propriedade (**`position`**) pode ser acompanhada de outras, tais como, {{Cssxref("top")}}, {{Cssxref("right")}}, {{Cssxref("bottom")}}, and {{Cssxref("left")}}, que determinam como ficará a localização final do objeto, permitindo seu deslocamento, como será apresentado adiante.{{EmbedInteractiveExample("pages/css/position.html")}}
+{{CSSRef}}A propriedade **`position`**, encontrada no [CSS](/pt-BR/docs/Web/CSS), define como um elemento pode ser posicionado (renderizado) no documento (página). Essa propriedade (**`position`**) pode ser acompanhada de outras, tais como, {{Cssxref("top")}}, {{Cssxref("right")}}, {{Cssxref("bottom")}}, and {{Cssxref("left")}}, que determinam como ficará a localização final do objeto, permitindo seu deslocamento, como será apresentado adiante.
+
+{{InteractiveExample("CSS Demo: position")}}
+
+```css interactive-example-choice
+position: static;
+```
+
+```css interactive-example-choice
+position: relative;
+top: 40px; left: 40px;
+```
+
+```css interactive-example-choice
+position: absolute;
+top: 40px; left: 40px;
+```
+
+```css interactive-example-choice
+position: sticky;
+top: 20px;
+```
+
+```html interactive-example
+<section class="default-example" id="default-example">
+<div id="example-element-container">
+<p>In this demo you can control the <code>position</code> property for the yellow box.</p>
+<div class="box"></div>
+<div class="box" id="example-element"></div>
+<div class="box"></div>
+<p class="clear">
+        To see the effect of <code>sticky</code> positioning, select the <code>position: sticky</code> option and scroll
+        this container.
+      </p>
+<p>
+        The element will scroll along with its container, until it is at the top of the container (or reaches the offset
+        specified in <code>top</code>), and will then stop scrolling, so it stays visible.
+      </p>
+<p>
+        The rest of this text is only supplied to make sure the container overflows, so as to enable you to scroll it
+        and see the effect.
+      </p>
+<hr/>
+<p>
+        Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a
+        small unregarded yellow sun. Orbiting this at a distance of roughly ninety-two million miles is an utterly
+        insignificant little blue green planet whose ape-descended life forms are so amazingly primitive that they still
+        think digital watches are a pretty neat idea.
+      </p>
+</div>
+</section>
+```
+
+```css interactive-example
+section {
+  align-items: flex-start;
+  overflow: auto;
+}
+
+.box {
+  background-color: rgba(0, 0, 255, 0.2);
+  border: 3px solid blue;
+  float: left;
+  width: 65px;
+  height: 65px;
+}
+
+.box + .box {
+  margin-left: 10px;
+}
+
+.clear {
+  clear: both;
+  padding-top: 1em;
+}
+
+#example-element-container {
+  position: relative;
+  text-align: left;
+}
+
+#example-element {
+  background-color: yellow;
+  border: 3px solid red;
+  z-index: 1;
+}
+```
 
 ### Tipos de posicionamentos
 

--- a/files/pt-br/web/html/element/abbr/index.md
+++ b/files/pt-br/web/html/element/abbr/index.md
@@ -17,9 +17,10 @@ O atributo opcional [`title`](/pt-BR/docs/Web/HTML/Global_attributes/title) pode
 
 ```html interactive-example
 <p>
-  You can use <abbr>CSS</abbr> (Cascading Style Sheets) to style your <abbr>HTML</abbr> (HyperText Markup Language).
-  Using style sheets, you can keep your <abbr>CSS</abbr> presentation layer and <abbr>HTML</abbr> content layer
-  separate. This is called "separation of concerns."
+  You can use <abbr>CSS</abbr> (Cascading Style Sheets) to style your
+  <abbr>HTML</abbr> (HyperText Markup Language). Using style sheets, you can
+  keep your <abbr>CSS</abbr> presentation layer and <abbr>HTML</abbr> content
+  layer separate. This is called "separation of concerns."
 </p>
 ```
 

--- a/files/pt-br/web/html/element/abbr/index.md
+++ b/files/pt-br/web/html/element/abbr/index.md
@@ -13,7 +13,22 @@ Ao incluir uma abreviação ou acrônimo, forneça uma expansão completa do ter
 
 O atributo opcional [`title`](/pt-BR/docs/Web/HTML/Global_attributes/title) pode fornecer uma expansão para a abreviação ou acrônimo quando uma expansão completa não estiver presente. Isso fornece uma dica para os agentes da pessoa usuária sobre como anunciar/exibir o conteúdo enquanto informa a todas as pessoas usuárias o que a abreviação significa. Se presente, `title` deve conter esta descrição completa e nada mais.
 
-{{EmbedInteractiveExample("pages/tabbed/abbr.html", "tabbed-shorter")}}
+{{InteractiveExample("HTML Demo: &lt;abbr&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<p>
+  You can use <abbr>CSS</abbr> (Cascading Style Sheets) to style your <abbr>HTML</abbr> (HyperText Markup Language).
+  Using style sheets, you can keep your <abbr>CSS</abbr> presentation layer and <abbr>HTML</abbr> content layer
+  separate. This is called "separation of concerns."
+</p>
+```
+
+```css interactive-example
+abbr {
+  font-style: italic;
+  color: chocolate;
+}
+```
 
 ## Atributos
 

--- a/files/pt-br/web/html/element/figcaption/index.md
+++ b/files/pt-br/web/html/element/figcaption/index.md
@@ -3,7 +3,9 @@ title: "<figcaption>: O elemento de legenda da figura"
 slug: Web/HTML/Element/figcaption
 ---
 
-{{HTMLSidebar}}O **Elemento HTML Figcaption** (`<figcaption>`) representa uma legenda ou uma legenda associada com uma figura ou ilustração descrita pelo resto dos dados do elemento {{ HTMLElement("figure") }} que seu elemento pai.
+{{HTMLSidebar}}
+
+O **Elemento HTML Figcaption** (`<figcaption>`) representa uma legenda ou uma legenda associada com uma figura ou ilustração descrita pelo resto dos dados do elemento {{ HTMLElement("figure") }} que seu elemento pai.
 
 {{InteractiveExample("HTML Demo: &lt;figcaption&gt;", "tabbed-shorter")}}
 

--- a/files/pt-br/web/html/element/figcaption/index.md
+++ b/files/pt-br/web/html/element/figcaption/index.md
@@ -3,7 +3,40 @@ title: "<figcaption>: O elemento de legenda da figura"
 slug: Web/HTML/Element/figcaption
 ---
 
-{{HTMLSidebar}}O **Elemento HTML Figcaption** (`<figcaption>`) representa uma legenda ou uma legenda associada com uma figura ou ilustração descrita pelo resto dos dados do elemento {{ HTMLElement("figure") }} que seu elemento pai.{{EmbedInteractiveExample("pages/tabbed/figcaption.html","tabbed-shorter")}}
+{{HTMLSidebar}}O **Elemento HTML Figcaption** (`<figcaption>`) representa uma legenda ou uma legenda associada com uma figura ou ilustração descrita pelo resto dos dados do elemento {{ HTMLElement("figure") }} que seu elemento pai.
+
+{{InteractiveExample("HTML Demo: &lt;figcaption&gt;", "tabbed-shorter")}}
+
+```html interactive-example
+<figure>
+  <img src="/shared-assets/images/examples/elephant.jpg" alt="Elephant at sunset" />
+  <figcaption>An elephant at sunset</figcaption>
+</figure>
+```
+
+```css interactive-example
+figure {
+  border: thin #c0c0c0 solid;
+  display: flex;
+  flex-flow: column;
+  padding: 5px;
+  max-width: 220px;
+  margin: auto;
+}
+
+img {
+  max-width: 220px;
+  max-height: 150px;
+}
+
+figcaption {
+  background-color: #222;
+  color: #fff;
+  font: italic smaller sans-serif;
+  padding: 3px;
+  text-align: center;
+}
+```
 
 <table class="properties">
   <tbody>

--- a/files/pt-br/web/html/element/figcaption/index.md
+++ b/files/pt-br/web/html/element/figcaption/index.md
@@ -9,7 +9,9 @@ slug: Web/HTML/Element/figcaption
 
 ```html interactive-example
 <figure>
-  <img src="/shared-assets/images/examples/elephant.jpg" alt="Elephant at sunset" />
+  <img
+    src="/shared-assets/images/examples/elephant.jpg"
+    alt="Elephant at sunset" />
   <figcaption>An elephant at sunset</figcaption>
 </figure>
 ```

--- a/files/pt-br/web/html/element/input/checkbox/index.md
+++ b/files/pt-br/web/html/element/input/checkbox/index.md
@@ -29,7 +29,7 @@ slug: Web/HTML/Element/input/checkbox
 p,
 label {
   font:
-    1rem 'Fira Sans',
+    1rem "Fira Sans",
     sans-serif;
 }
 

--- a/files/pt-br/web/html/element/input/checkbox/index.md
+++ b/files/pt-br/web/html/element/input/checkbox/index.md
@@ -7,7 +7,36 @@ slug: Web/HTML/Element/input/checkbox
 
 {{htmlelement ("input")}} elementos do tipo **`checkbox`** são renderizados por padrão como caixas quadradas que são marcadas (com uma marca de verificação) quando ativadas, como as que você veria em um formulário do governo. A aparência exata depende de da configuração de sistema operacional sobre o qual o navegador está sendo executado. Caixas de seleção permitem que você selecione valores únicos para envio em um formulário (ou não).
 
-{{EmbedInteractiveExample ("pages/tabbed/input-checkbox.html", "tabbed-standard")}}
+{{InteractiveExample("HTML Demo: &lt;input type=&quot;checkbox&quot;&gt;", "tabbed-standard")}}
+
+```html interactive-example
+<fieldset>
+  <legend>Choose your monster's features:</legend>
+
+  <div>
+    <input type="checkbox" id="scales" name="scales" checked />
+    <label for="scales">Scales</label>
+  </div>
+
+  <div>
+    <input type="checkbox" id="horns" name="horns" />
+    <label for="horns">Horns</label>
+  </div>
+</fieldset>
+```
+
+```css interactive-example
+p,
+label {
+  font:
+    1rem 'Fira Sans',
+    sans-serif;
+}
+
+input {
+  margin: 0.4rem;
+}
+```
 
 > **Note:** **Nota** : [Os botões de opção](/pt-BR/docs/Web/HTML/Element/input/radio) são semelhantes às caixas de seleção, mas com uma distinção importante: os botões de opção são agrupados em um conjunto no qual apenas um botão pode ser selecionado por vez, enquanto as caixas de seleção permitem ativar e desativar valores únicos. Quando existem vários controles, os botões de opção permitem que um seja selecionado de todos, enquanto as caixas de seleção permitem que vários valores sejam selecionados.
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/settime/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/settime/index.md
@@ -3,7 +3,25 @@ title: Date.prototype.setTime()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setTime
 ---
 
-{{JSRef}}O método **`setTime()`** atribui ao objecto {{jsxref("Date")}} a hora representada pelo número de milisegundos desde 1 de janeiro de 1970 as 00:00:00 UTC.{{EmbedInteractiveExample("pages/js/date-settime.html")}}
+{{JSRef}}O método **`setTime()`** atribui ao objecto {{jsxref("Date")}} a hora representada pelo número de milisegundos desde 1 de janeiro de 1970 as 00:00:00 UTC.
+
+{{InteractiveExample("JavaScript Demo: Date.setTime()")}}
+
+```js interactive-example
+const launchDate = new Date('July 1, 1999, 12:00:00');
+const futureDate = new Date();
+futureDate.setTime(launchDate.getTime());
+
+console.log(futureDate);
+// Expected output: "Thu Jul 01 1999 12:00:00 GMT+0200 (CEST)"
+
+const fiveMinutesInMillis = 5 * 60 * 1000;
+futureDate.setTime(futureDate.getTime() + fiveMinutesInMillis);
+
+console.log(futureDate);
+// Expected output: "Thu Jul 01 1999 12:05:00 GMT+0200 (CEST)"
+// Note: your timezone may vary
+```
 
 ## Sintáxe
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/settime/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/settime/index.md
@@ -8,7 +8,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Date/setTime
 {{InteractiveExample("JavaScript Demo: Date.setTime()")}}
 
 ```js interactive-example
-const launchDate = new Date('July 1, 1999, 12:00:00');
+const launchDate = new Date("July 1, 1999, 12:00:00");
 const futureDate = new Date();
 futureDate.setTime(launchDate.getTime());
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/settime/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/settime/index.md
@@ -3,7 +3,9 @@ title: Date.prototype.setTime()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setTime
 ---
 
-{{JSRef}}O método **`setTime()`** atribui ao objecto {{jsxref("Date")}} a hora representada pelo número de milisegundos desde 1 de janeiro de 1970 as 00:00:00 UTC.
+{{JSRef}}
+
+O método **`setTime()`** atribui ao objecto {{jsxref("Date")}} a hora representada pelo número de milisegundos desde 1 de janeiro de 1970 as 00:00:00 UTC.
 
 {{InteractiveExample("JavaScript Demo: Date.setTime()")}}
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
@@ -3,7 +3,9 @@ title: Date.prototype.toLocaleTimeString()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 ---
 
-{{JSRef}}O método **`toLocaleTimeString()`** retorna uma string com uma representação sensível ao idioma de uma porção de tempo desta data. Os novos argumentos `locales` e `options` possibilitam aplicações especificarem que formato de linguagem deve ser usado, podendo customizar o comportamento da função. Em implementações antigas, que ignoram os argumentos `locales` e `options`, o local utilizado e o formato retornado da string são implementações completamente dependentes.
+{{JSRef}}
+
+O método **`toLocaleTimeString()`** retorna uma string com uma representação sensível ao idioma de uma porção de tempo desta data. Os novos argumentos `locales` e `options` possibilitam aplicações especificarem que formato de linguagem deve ser usado, podendo customizar o comportamento da função. Em implementações antigas, que ignoram os argumentos `locales` e `options`, o local utilizado e o formato retornado da string são implementações completamente dependentes.
 
 {{InteractiveExample("JavaScript Demo: Date.toLocaleTimeString()")}}
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
@@ -3,7 +3,23 @@ title: Date.prototype.toLocaleTimeString()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 ---
 
-{{JSRef}}O método **`toLocaleTimeString()`** retorna uma string com uma representação sensível ao idioma de uma porção de tempo desta data. Os novos argumentos `locales` e `options` possibilitam aplicações especificarem que formato de linguagem deve ser usado, podendo customizar o comportamento da função. Em implementações antigas, que ignoram os argumentos `locales` e `options`, o local utilizado e o formato retornado da string são implementações completamente dependentes.{{EmbedInteractiveExample("pages/js/date-tolocaletimestring.html")}}
+{{JSRef}}O método **`toLocaleTimeString()`** retorna uma string com uma representação sensível ao idioma de uma porção de tempo desta data. Os novos argumentos `locales` e `options` possibilitam aplicações especificarem que formato de linguagem deve ser usado, podendo customizar o comportamento da função. Em implementações antigas, que ignoram os argumentos `locales` e `options`, o local utilizado e o formato retornado da string são implementações completamente dependentes.
+
+{{InteractiveExample("JavaScript Demo: Date.toLocaleTimeString()")}}
+
+```js interactive-example
+// Depending on timezone, your results will vary
+const event = new Date('August 19, 1975 23:15:30 GMT+00:00');
+
+console.log(event.toLocaleTimeString('en-US'));
+// Expected output: "1:15:30 AM"
+
+console.log(event.toLocaleTimeString('it-IT'));
+// Expected output: "01:15:30"
+
+console.log(event.toLocaleTimeString('ar-EG'));
+// Expected output: "١٢:١٥:٣٠ ص"
+```
 
 ## Sintaxe
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
@@ -9,15 +9,15 @@ slug: Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 
 ```js interactive-example
 // Depending on timezone, your results will vary
-const event = new Date('August 19, 1975 23:15:30 GMT+00:00');
+const event = new Date("August 19, 1975 23:15:30 GMT+00:00");
 
-console.log(event.toLocaleTimeString('en-US'));
+console.log(event.toLocaleTimeString("en-US"));
 // Expected output: "1:15:30 AM"
 
-console.log(event.toLocaleTimeString('it-IT'));
+console.log(event.toLocaleTimeString("it-IT"));
 // Expected output: "01:15:30"
 
-console.log(event.toLocaleTimeString('ar-EG'));
+console.log(event.toLocaleTimeString("ar-EG"));
 // Expected output: "١٢:١٥:٣٠ ص"
 ```
 

--- a/files/pt-br/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/pt-br/web/javascript/reference/operators/spread_syntax/index.md
@@ -3,7 +3,9 @@ title: Sintaxe de Espalhamento
 slug: Web/JavaScript/Reference/Operators/Spread_syntax
 ---
 
-{{jsSidebar("Operators")}}**Sintaxe de Espalhamento (Spread syntax)** permite que um objeto iterável, como uma expressão de array ou uma string seja expandido para ser usado onde zero ou mais argumentos (para chamadas de funções) ou elementos (para arrays _literais_) são esperados, ou que um objeto seja expandido onde zero ou mais pares _propriedade:valor_ (para objetos _literais_) são esperados.
+{{jsSidebar("Operators")}}
+
+**Sintaxe de Espalhamento (Spread syntax)** permite que um objeto iterável, como uma expressão de array ou uma string seja expandido para ser usado onde zero ou mais argumentos (para chamadas de funções) ou elementos (para arrays _literais_) são esperados, ou que um objeto seja expandido onde zero ou mais pares _propriedade:valor_ (para objetos _literais_) são esperados.
 
 {{InteractiveExample("JavaScript Demo: Expressions - Spread syntax")}}
 

--- a/files/pt-br/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/pt-br/web/javascript/reference/operators/spread_syntax/index.md
@@ -3,7 +3,23 @@ title: Sintaxe de Espalhamento
 slug: Web/JavaScript/Reference/Operators/Spread_syntax
 ---
 
-{{jsSidebar("Operators")}}**Sintaxe de Espalhamento (Spread syntax)** permite que um objeto iterável, como uma expressão de array ou uma string seja expandido para ser usado onde zero ou mais argumentos (para chamadas de funções) ou elementos (para arrays _literais_) são esperados, ou que um objeto seja expandido onde zero ou mais pares _propriedade:valor_ (para objetos _literais_) são esperados.{{EmbedInteractiveExample("pages/js/expressions-spreadsyntax.html")}}
+{{jsSidebar("Operators")}}**Sintaxe de Espalhamento (Spread syntax)** permite que um objeto iterável, como uma expressão de array ou uma string seja expandido para ser usado onde zero ou mais argumentos (para chamadas de funções) ou elementos (para arrays _literais_) são esperados, ou que um objeto seja expandido onde zero ou mais pares _propriedade:valor_ (para objetos _literais_) são esperados.
+
+{{InteractiveExample("JavaScript Demo: Expressions - Spread syntax")}}
+
+```js interactive-example
+function sum(x, y, z) {
+  return x + y + z;
+}
+
+const numbers = [1, 2, 3];
+
+console.log(sum(...numbers));
+// Expected output: 6
+
+console.log(sum.apply(null, numbers));
+// Expected output: 6
+```
 
 ## Sintaxe
 


### PR DESCRIPTION
These should be the final migrations outside of the kitchensink and writing guidelines, part of the wider project described here: https://github.com/orgs/mdn/discussions/782

We haven't QAed these as thoroughly as the previous migrations (difficult to do, as they weren't detected by our scripts, so we've had to manually migrate these), so I'd suggest a more "hands-on" review compared to the other migrations: thankfully it's only a few examples!