### PR TITLE
[zh-cn]: migrate remaining interactive examples

### DIFF
--- a/files/zh-cn/web/css/angle/index.md
+++ b/files/zh-cn/web/css/angle/index.md
@@ -9,7 +9,7 @@ l10n:
 
 **`<angle>`** [CSS](/zh-CN/docs/Web/CSS) [数据类型](/zh-CN/docs/Web/CSS/CSS_Values_and_Units/CSS_data_types)表示以度（degrees）、百分度（gradians）、弧度（radians）或圈数（turns）表示的角度值。例如，它在 {{cssxref("&lt;gradient&gt;")}} 和 {{cssxref("transform")}} 的某些函数中被使用。
 
-{{InteractiveExample("CSS Demo: &amp;lt;angle&amp;gt;")}}
+{{InteractiveExample("CSS Demo: &lt;angle&gt;")}}
 
 ```css interactive-example-choice
 transform: rotate(45deg);

--- a/files/zh-cn/web/css/basic-shape/index.md
+++ b/files/zh-cn/web/css/basic-shape/index.md
@@ -9,7 +9,7 @@ l10n:
 
 **`<basic-shape>`** [CSS](/zh-CN/docs/Web/CSS) [数据类型](/zh-CN/docs/Web/CSS/CSS_Values_and_Units/CSS_data_types)表示一种用于 {{cssxref("clip-path")}}、{{cssxref("shape-outside")}} 和 {{cssxref("offset-path")}} 属性的形状。
 
-{{InteractiveExample("CSS Demo: &amp;lt;basic-shape&amp;gt;")}}
+{{InteractiveExample("CSS Demo: &lt;basic-shape&gt;")}}
 
 ```css interactive-example-choice
 clip-path: inset(22% 12% 15px 35px);

--- a/files/zh-cn/web/css/gradient/index.md
+++ b/files/zh-cn/web/css/gradient/index.md
@@ -7,7 +7,7 @@ slug: Web/CSS/gradient
 
 **`<gradient>`** [CSS](/zh-CN/docs/Web/CSS) [数据类型](/zh-CN/docs/Web/CSS/CSS_Values_and_Units/CSS_data_types) 是 {{cssxref("&lt;image&gt;")}} 的一种特殊类型，包含两种或多种颜色的过渡转变。
 
-{{InteractiveExample("CSS Demo: &amp;lt;gradient&amp;gt;")}}
+{{InteractiveExample("CSS Demo: &lt;gradient&gt;")}}
 
 ```css interactive-example-choice
 background: linear-gradient(#f69d3c, #3f87a6);

--- a/files/zh-cn/web/css/height/index.md
+++ b/files/zh-cn/web/css/height/index.md
@@ -5,7 +5,43 @@ slug: Web/CSS/height
 
 {{CSSRef}}
 
-`height` CSS 属性指定了一个元素的高度。默认情况下，这个属性决定的是内容区（ [content area](/zh-CN/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model#content-area)）的高度，但是，如果将 {{cssxref("box-sizing")}} 设置为 `border-box` , 这个属性决定的将是边框区域（[border area](/zh-CN/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model#border-area)）的高度。{{EmbedInteractiveExample("pages/css/height.html")}}{{cssxref("min-height")}} 和 {{cssxref("max-height")}} 属性会覆盖 {{Cssxref("height")}}。
+`height` CSS 属性指定了一个元素的高度。默认情况下，这个属性决定的是内容区（ [content area](/zh-CN/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model#content-area)）的高度，但是，如果将 {{cssxref("box-sizing")}} 设置为 `border-box` , 这个属性决定的将是边框区域（[border area](/zh-CN/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model#border-area)）的高度。
+
+{{InteractiveExample("CSS Demo: height")}}
+
+```css interactive-example-choice
+height: 150px;
+```
+
+```css interactive-example-choice
+height: 6em;
+```
+
+```css interactive-example-choice
+height: 75%;
+```
+
+```css interactive-example-choice
+height: auto;
+```
+
+```html interactive-example
+<section class="default-example" id="default-example">
+<div class="transition-all" id="example-element">This is a box where you can change the height.</div>
+</section>
+```
+
+```css interactive-example
+#example-element {
+  display: flex;
+  flex-direction: column;
+  background-color: #5b6dcd;
+  justify-content: center;
+  color: #ffffff;
+}
+```
+
+{{cssxref("min-height")}} 和 {{cssxref("max-height")}} 属性会覆盖 {{Cssxref("height")}}。
 
 ## 语法
 

--- a/files/zh-cn/web/css/height/index.md
+++ b/files/zh-cn/web/css/height/index.md
@@ -27,7 +27,9 @@ height: auto;
 
 ```html interactive-example
 <section class="default-example" id="default-example">
-<div class="transition-all" id="example-element">This is a box where you can change the height.</div>
+  <div class="transition-all" id="example-element">
+    This is a box where you can change the height.
+  </div>
 </section>
 ```
 

--- a/files/zh-cn/web/css/quotes/index.md
+++ b/files/zh-cn/web/css/quotes/index.md
@@ -31,7 +31,10 @@ quotes: "«" "»" "‹" "›";
 
 ```html interactive-example
 <section id="default-example">
-<q id="example-element">Show us the wonder-working <q>Brothers,</q> let them come out publicly—and we will believe in them!</q>
+  <q id="example-element"
+    >Show us the wonder-working <q>Brothers,</q> let them come out publicly—and
+    we will believe in them!</q
+  >
 </section>
 ```
 

--- a/files/zh-cn/web/css/quotes/index.md
+++ b/files/zh-cn/web/css/quotes/index.md
@@ -5,7 +5,41 @@ slug: Web/CSS/quotes
 
 {{CSSRef}}
 
-**`quotes`** [CSS](/zh-CN/docs/Web/CSS) 属性用于设置引号的样式。{{EmbedInteractiveExample("pages/css/quotes.html")}}
+**`quotes`** [CSS](/zh-CN/docs/Web/CSS) 属性用于设置引号的样式
+
+{{InteractiveExample("CSS Demo: quotes")}}
+
+```css interactive-example-choice
+quotes: none;
+```
+
+```css interactive-example-choice
+quotes: initial;
+```
+
+```css interactive-example-choice
+quotes: "'" "'";
+```
+
+```css interactive-example-choice
+quotes: "„" "“" "‚" "‘";
+```
+
+```css interactive-example-choice
+quotes: "«" "»" "‹" "›";
+```
+
+```html interactive-example
+<section id="default-example">
+<q id="example-element">Show us the wonder-working <q>Brothers,</q> let them come out publicly—and we will believe in them!</q>
+</section>
+```
+
+```css interactive-example
+q {
+  font-size: 1.2rem;
+}
+```
 
 ## 语法
 

--- a/files/zh-cn/web/css/shape-outside/index.md
+++ b/files/zh-cn/web/css/shape-outside/index.md
@@ -27,14 +27,21 @@ shape-outside: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
 
 ```html interactive-example
 <section class="default-example" id="default-example">
-<div class="example-container">
-<img class="transition-all" id="example-element" src="/shared-assets/images/examples/round-balloon.png" width="150"/>
-      We had agreed, my companion and I, that I should call for him at his house, after dinner, not later than eleven
-      o’clock. This athletic young Frenchman belongs to a small set of Parisian sportsmen, who have taken up
-      “ballooning” as a pastime. After having exhausted all the sensations that are to be found in ordinary sports, even
-      those of “automobiling” at a breakneck speed, the members of the “Aéro Club” now seek in the air, where they
-      indulge in all kinds of daring feats, the nerve-racking excitement that they have ceased to find on earth.
-    </div>
+  <div class="example-container">
+    <img
+      class="transition-all"
+      id="example-element"
+      src="/shared-assets/images/examples/round-balloon.png"
+      width="150" />
+    We had agreed, my companion and I, that I should call for him at his house,
+    after dinner, not later than eleven o’clock. This athletic young Frenchman
+    belongs to a small set of Parisian sportsmen, who have taken up “ballooning”
+    as a pastime. After having exhausted all the sensations that are to be found
+    in ordinary sports, even those of “automobiling” at a breakneck speed, the
+    members of the “Aéro Club” now seek in the air, where they indulge in all
+    kinds of daring feats, the nerve-racking excitement that they have ceased to
+    find on earth.
+  </div>
 </section>
 ```
 

--- a/files/zh-cn/web/css/shape-outside/index.md
+++ b/files/zh-cn/web/css/shape-outside/index.md
@@ -5,7 +5,51 @@ slug: Web/CSS/shape-outside
 
 {{CSSRef}}
 
-**`shape-outside`** 的 [CSS](/zh-CN/docs/Web/CSS) 属性定义了一个可以是非矩形的形状，相邻的内联内容应围绕该形状进行包装。默认情况下，内联内容包围其边距框; `shape-outside`提供了一种自定义此包装的方法，可以将文本包装在复杂对象周围而不是简单的框中。{{EmbedInteractiveExample("pages/css/shape-outside.html")}}
+**`shape-outside`** 的 [CSS](/zh-CN/docs/Web/CSS) 属性定义了一个可以是非矩形的形状，相邻的内联内容应围绕该形状进行包装。默认情况下，内联内容包围其边距框; `shape-outside`提供了一种自定义此包装的方法，可以将文本包装在复杂对象周围而不是简单的框中。
+
+{{InteractiveExample("CSS Demo: shape-outside")}}
+
+```css interactive-example-choice
+shape-outside: circle(50%);
+```
+
+```css interactive-example-choice
+shape-outside: ellipse(130px 140px at 20% 20%);
+```
+
+```css interactive-example-choice
+shape-outside: url(/shared-assets/images/examples/round-balloon.png);
+```
+
+```css interactive-example-choice
+shape-outside: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
+```
+
+```html interactive-example
+<section class="default-example" id="default-example">
+<div class="example-container">
+<img class="transition-all" id="example-element" src="/shared-assets/images/examples/round-balloon.png" width="150"/>
+      We had agreed, my companion and I, that I should call for him at his house, after dinner, not later than eleven
+      o’clock. This athletic young Frenchman belongs to a small set of Parisian sportsmen, who have taken up
+      “ballooning” as a pastime. After having exhausted all the sensations that are to be found in ordinary sports, even
+      those of “automobiling” at a breakneck speed, the members of the “Aéro Club” now seek in the air, where they
+      indulge in all kinds of daring feats, the nerve-racking excitement that they have ceased to find on earth.
+    </div>
+</section>
+```
+
+```css interactive-example
+.example-container {
+  text-align: left;
+  padding: 20px;
+}
+
+#example-element {
+  float: left;
+  width: 150px;
+  margin: 20px;
+}
+```
 
 ## 语法
 

--- a/files/zh-cn/web/css/transform-function/skew/index.md
+++ b/files/zh-cn/web/css/transform-function/skew/index.md
@@ -5,7 +5,31 @@ slug: Web/CSS/transform-function/skew
 
 {{CSSRef}}
 
-**`skew()`** 函数定义了一个元素在二维平面上的倾斜转换。它的结果是一个{{cssxref("&lt;transform-function&gt;")}} 数据类型{{EmbedInteractiveExample("pages/css/function-skew.html")}}
+**`skew()`** 函数定义了一个元素在二维平面上的倾斜转换。它的结果是一个{{cssxref("&lt;transform-function&gt;")}} 数据类型
+
+{{InteractiveExample("CSS Demo: skew()")}}
+
+```css interactive-example-choice
+transform: skew(0);
+```
+
+```css interactive-example-choice
+transform: skew(15deg, 15deg);
+```
+
+```css interactive-example-choice
+transform: skew(-0.06turn, 18deg);
+```
+
+```css interactive-example-choice
+transform: skew(.312rad);
+```
+
+```html interactive-example
+<section id="default-example">
+<img class="transition-all" id="example-element" src="/shared-assets/images/examples/firefox-logo.svg" width="200"/>
+</section>
+```
 
 这种转换是一种剪切映射 (横切)，它在水平和垂直方向上将单元内的每个点扭曲一定的角度。每个点的坐标根据指定的角度以及到原点的距离，进行成比例的值调整；因此，一个点离原点越远，其增加的值就越大。
 

--- a/files/zh-cn/web/css/transform-function/skew/index.md
+++ b/files/zh-cn/web/css/transform-function/skew/index.md
@@ -22,12 +22,16 @@ transform: skew(-0.06turn, 18deg);
 ```
 
 ```css interactive-example-choice
-transform: skew(.312rad);
+transform: skew(0.312rad);
 ```
 
 ```html interactive-example
 <section id="default-example">
-<img class="transition-all" id="example-element" src="/shared-assets/images/examples/firefox-logo.svg" width="200"/>
+  <img
+    class="transition-all"
+    id="example-element"
+    src="/shared-assets/images/examples/firefox-logo.svg"
+    width="200" />
 </section>
 ```
 

--- a/files/zh-cn/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/zh-cn/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -7,7 +7,22 @@ slug: Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences
 
 组和范围表示表达式字符的 组和范围
 
-{{EmbedInteractiveExample("pages/js/regexp-groups-ranges.html")}}
+{{InteractiveExample("JavaScript Demo: RegExp Groups and backreferences")}}
+
+```js interactive-example
+// Groups
+const imageDescription = "This image has a resolution of 1440×900 pixels.";
+const regexpSize = /([0-9]+)×([0-9]+)/;
+const match = imageDescription.match(regexpSize);
+console.log(`Width: ${match[1]} / Height: ${match[2]}.`);
+// Expected output: "Width: 1440 / Height: 900."
+
+// Backreferences
+const findDuplicates = "foo foo bar";
+const regex = /\b(\w+)\s+\1\b/g;
+console.log(findDuplicates.match(regex));
+// Expected output: Array ["foo foo"]
+```
 
 ## 类型
 

--- a/files/zh-cn/web/javascript/reference/global_objects/object/groupby/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/object/groupby/index.md
@@ -12,7 +12,25 @@ slug: Web/JavaScript/Reference/Global_Objects/Object/groupBy
 
 当分组名称可以用字符串表示时，应使用此方法。如果你需要使用某个任意值作为键来对元素进行分组，请改用 {{jsxref("Map.groupBy()")}} 方法。
 
-<!-- {{EmbedInteractiveExample("pages/js/object-groupby.html")}} -->
+{{InteractiveExample("JavaScript Demo: Object.groupBy()", "taller")}}
+
+```js interactive-example
+const inventory = [
+  { name: "asparagus", type: "vegetables", quantity: 9 },
+  { name: "bananas", type: "fruit", quantity: 5 },
+  { name: "goat", type: "meat", quantity: 23 },
+  { name: "cherries", type: "fruit", quantity: 12 },
+  { name: "fish", type: "meat", quantity: 22 },
+];
+
+const restock = { restock: true };
+const sufficient = { restock: false };
+const result = Object.groupBy(inventory, ({ quantity }) =>
+  quantity < 6 ? "restock" : "sufficient",
+);
+console.log(result.restock);
+// [{ name: "bananas", type: "fruit", quantity: 5 }]
+```
 
 ## 语法
 

--- a/files/zh-cn/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/spread_syntax/index.md
@@ -1,30 +1,36 @@
 ---
-title: 展开语法
+title: 展开语法（...）
 slug: Web/JavaScript/Reference/Operators/Spread_syntax
 ---
 
-{{jsSidebar("Operators")}}**展开语法 (Spread syntax),** 可以在函数调用/数组构造时，将数组表达式或者 string 在语法层面展开；还可以在构造字面量对象时，将对象表达式按 key-value 的方式展开。(**译者注**: 字面量一般指 `[1, 2, 3]` 或者 `{name: "mdn"}` 这种简洁的构造方式)
+{{jsSidebar("Operators")}}
 
-("pages/js/expressions-spreadsyntax.html")}}
+**spread (`...`)** 语法允许迭代数组或字符串等可迭代字符串在预期有零个或更多参数（用于函数调用）或元素（用于数组字面量）的地方进行扩展。在对象字面量中，扩展语法枚举对象的属性，并将键值对添加到正在创建的对象中。
+
+展开语法看起来与剩余参数语法一模一样。在某种程度上，扩展语法与剩余参数语法正好相反。扩展语法是将数组“扩展”为元素，而其余语法是将多个元素收集起来，然后“浓缩”为一个元素。请参阅[剩余参数](/zh-CN/docs/Web/JavaScript/Reference/Functions/rest_parameters)和[剩余属性](/zh-CN/docs/Web/JavaScript/Reference/Operators/Destructuring#剩余属性和剩余元素) 。
+
+{{InteractiveExample("JavaScript Demo: Spread syntax (...)")}}
+
+```js interactive-example
+function sum(x, y, z) {
+  return x + y + z;
+}
+
+const numbers = [1, 2, 3];
+
+console.log(sum(...numbers));
+// Expected output: 6
+
+console.log(sum.apply(null, numbers));
+// Expected output: 6
+```
 
 ## 语法
 
-函数调用：
-
-```plain
-myFunction(...iterableObj);
-```
-
-字面量数组构造或字符串：
-
-```plain
-[...iterableObj, '4', ...'hello', 6];
-```
-
-构造字面量对象时，进行克隆或者属性拷贝（ECMAScript 2018 规范新增特性）：
-
-```plain
-let objClone = { ...obj };
+```js-nolint
+myFunction(a, ...iterableObj, b)
+[1, ...iterableObj, '4', 'five', 6]
+{ ...obj, key: 'value' }
 ```
 
 ## 示例

--- a/files/zh-cn/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/spread_syntax/index.md
@@ -3,7 +3,9 @@ title: 展开语法
 slug: Web/JavaScript/Reference/Operators/Spread_syntax
 ---
 
-{{jsSidebar("Operators")}}**展开语法 (Spread syntax),** 可以在函数调用/数组构造时，将数组表达式或者 string 在语法层面展开；还可以在构造字面量对象时，将对象表达式按 key-value 的方式展开。(**译者注**: 字面量一般指 `[1, 2, 3]` 或者 `{name: "mdn"}` 这种简洁的构造方式){{EmbedInteractiveExample("pages/js/expressions-spreadsyntax.html")}}
+{{jsSidebar("Operators")}}**展开语法 (Spread syntax),** 可以在函数调用/数组构造时，将数组表达式或者 string 在语法层面展开；还可以在构造字面量对象时，将对象表达式按 key-value 的方式展开。(**译者注**: 字面量一般指 `[1, 2, 3]` 或者 `{name: "mdn"}` 这种简洁的构造方式)
+
+("pages/js/expressions-spreadsyntax.html")}}
 
 ## 语法
 


### PR DESCRIPTION
These should be the final migrations outside of the kitchensink and writing guidelines, part of the wider project described here: https://github.com/orgs/mdn/discussions/782

We haven't QAed these as thoroughly as the previous migrations (difficult to do, as they weren't detected by our scripts, so we've had to manually migrate these), so I'd suggest a more "hands-on" review compared to the other migrations: thankfully it's only a few examples!