### PR TITLE
[zh-tw]: migrate remaining interactive examples

### DIFF
--- a/files/zh-tw/web/javascript/reference/global_objects/math/random/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/math/random/index.md
@@ -5,7 +5,24 @@ slug: Web/JavaScript/Reference/Global_Objects/Math/random
 
 {{JSRef}}
 
-函數 **`Math.random()`** 會回傳一個偽隨機小數 (pseudo-random) 介於 0 到 1 之間(包含 0，不包含 1) ，大致符合數學與統計上的均勻分佈 (uniform distribution) ，你可以選定想要的數字區間，它會透過演算法被產生並且不允許使用者自行跳選或重設成特定數字。{{EmbedInteractiveExample("pages/js/math-random.html")}}
+函數 **`Math.random()`** 會回傳一個偽隨機小數 (pseudo-random) 介於 0 到 1 之間(包含 0，不包含 1) ，大致符合數學與統計上的均勻分佈 (uniform distribution) ，你可以選定想要的數字區間，它會透過演算法被產生並且不允許使用者自行跳選或重設成特定數字。
+
+{{InteractiveExample("JavaScript Demo: Math.random()")}}
+
+```js interactive-example
+function getRandomInt(max) {
+  return Math.floor(Math.random() * max);
+}
+
+console.log(getRandomInt(3));
+// Expected output: 0, 1 or 2
+
+console.log(getRandomInt(1));
+// Expected output: 0
+
+console.log(Math.random());
+// Expected output: a number from 0 to <1
+```
 
 > **備註：** `Math.random()` 所產生的偽隨機小數不符合加密學安全性要求。_請勿使用於任何加密、資安相關領域。_
 >

--- a/files/zh-tw/web/javascript/reference/global_objects/math/random/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/math/random/index.md
@@ -5,7 +5,9 @@ slug: Web/JavaScript/Reference/Global_Objects/Math/random
 
 {{JSRef}}
 
-函數 **`Math.random()`** 會回傳一個偽隨機小數 (pseudo-random) 介於 0 到 1 之間(包含 0，不包含 1) ，大致符合數學與統計上的均勻分佈 (uniform distribution) ，你可以選定想要的數字區間，它會透過演算法被產生並且不允許使用者自行跳選或重設成特定數字。
+函數 **`Math.random()`** 會回傳一個介於 0 到 1 之間（包含 0，不包含 1）的偽隨機（pseudo-random）小數 ，大致符合數學與統計上的均勻分佈 (uniform distribution) ，你可以選定想要的數字區間，它會透過演算法被產生並且不允許使用者自行跳選或重設成特定數字。
+
+> **備註：** `Math.random()` 所產生的偽隨機小數不符合加密學安全性要求。請勿使用於任何加密、資安相關領域。如有加密需求建議參考 Web Crypto API 的 {{domxref("Crypto.getRandomValues()")}} 方法。
 
 {{InteractiveExample("JavaScript Demo: Math.random()")}}
 
@@ -24,23 +26,19 @@ console.log(Math.random());
 // Expected output: a number from 0 to <1
 ```
 
-> **備註：** `Math.random()` 所產生的偽隨機小數不符合加密學安全性要求。_請勿使用於任何加密、資安相關領域。_
->
-> _如有加密需求建議參考 Web Crypto API_[`window.crypto.getRandomValues()`](/zh-TW/docs/Web/API/Crypto/getRandomValues)
-
 ## 語法
 
-```plain
+```js-nolint
 Math.random()
 ```
 
-### 回傳值 Return value
+### 回傳值
 
-回傳一個偽隨機小數 (pseudo-random)，小數也稱浮點數； 介於 0 到 1 之間(包含 0，不包含 1) 。
+回傳一個偽隨機浮點數，介於 0 到 1 之間（包含 0，不包含 1）。
 
 ## 範例
 
-請留意 JavaScript 中的數字與許多語言一樣使用 IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact. If extremely large bounds are chosen (2^53 or higher), it's possible in _extremely_ rare cases to calculate the usually-excluded upper bound.
+Note that as numbers in JavaScript are IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact. Usually, the claimed upper bound is not attainable, but if `Math.random()` returns a number very close to 1, the tiny difference may not be representable at the requested maximum, therefore causing the upper bound to be attained.
 
 ### Getting a random number between 0 (inclusive) and 1 (exclusive)
 
@@ -66,14 +64,14 @@ This example returns a random _integer_ between the specified values. The value 
 
 ```js
 function getRandomInt(min, max) {
-  min = Math.ceil(min);
-  max = Math.floor(max);
-  return Math.floor(Math.random() * (max - min) + min); //The maximum is exclusive and the minimum is inclusive
+  const minCeiled = Math.ceil(min);
+  const maxFloored = Math.floor(max);
+  return Math.floor(Math.random() * (maxFloored - minCeiled) + minCeiled); // The maximum is exclusive and the minimum is inclusive
 }
 ```
 
 > [!NOTE]
-> might be tempting to use `Math.round()` to accomplish that, but doing so would cause your random numbers to follow a non-uniform distribution, which may not be acceptable for your needs.
+> It might be tempting to use [`Math.round()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Math/round) to accomplish that, but doing so would cause your random numbers to follow a non-uniform distribution, which may not be acceptable for your needs.
 
 ### Getting a random integer between two values, inclusive
 
@@ -81,9 +79,9 @@ While the `getRandomInt()` function above is inclusive at the minimum, it's excl
 
 ```js
 function getRandomIntInclusive(min, max) {
-  min = Math.ceil(min);
-  max = Math.floor(max);
-  return Math.floor(Math.random() * (max - min + 1) + min); //The maximum is inclusive and the minimum is inclusive
+  const minCeiled = Math.ceil(min);
+  const maxFloored = Math.floor(max);
+  return Math.floor(Math.random() * (maxFloored - minCeiled + 1) + minCeiled); // The maximum is inclusive and the minimum is inclusive
 }
 ```
 
@@ -95,6 +93,6 @@ function getRandomIntInclusive(min, max) {
 
 {{Compat}}
 
-## 其他參考資料
+## 參見
 
-- [`window.crypto.getRandomValues()`](/zh-TW/docs/Web/API/Crypto/getRandomValues)
+- {{domxref("Crypto.getRandomValues()")}}

--- a/files/zh-tw/web/javascript/reference/statements/const/index.md
+++ b/files/zh-tw/web/javascript/reference/statements/const/index.md
@@ -3,7 +3,24 @@ title: const
 slug: Web/JavaScript/Reference/Statements/const
 ---
 
-{{jsSidebar("Statements")}}Constants (常數) 有點像使用 [`let`](/zh-TW/docs/Web/JavaScript/Reference/Statements/let) 所宣告的變數，具有區塊可視範圍。常數不能重複指定值，也不能重複宣告。{{EmbedInteractiveExample("pages/js/statement-const.html")}}
+{{jsSidebar("Statements")}}Constants (常數) 有點像使用 [`let`](/zh-TW/docs/Web/JavaScript/Reference/Statements/let) 所宣告的變數，具有區塊可視範圍。常數不能重複指定值，也不能重複宣告。
+
+{{InteractiveExample("JavaScript Demo: Statement - Const")}}
+
+```js interactive-example
+const number = 42;
+
+try {
+  number = 99;
+} catch (err) {
+  console.log(err);
+  // Expected output: TypeError: invalid assignment to const 'number'
+  // (Note: the exact output may be browser-dependent)
+}
+
+console.log(number);
+// Expected output: 42
+```
 
 ## 語法
 

--- a/files/zh-tw/web/javascript/reference/statements/const/index.md
+++ b/files/zh-tw/web/javascript/reference/statements/const/index.md
@@ -3,9 +3,11 @@ title: const
 slug: Web/JavaScript/Reference/Statements/const
 ---
 
-{{jsSidebar("Statements")}}Constants (常數) 有點像使用 [`let`](/zh-TW/docs/Web/JavaScript/Reference/Statements/let) 所宣告的變數，具有區塊可視範圍。常數不能重複指定值，也不能重複宣告。
+{{jsSidebar("Statements")}}
 
-{{InteractiveExample("JavaScript Demo: Statement - Const")}}
+Constants (常數) 有點像使用 [`let`](/zh-TW/docs/Web/JavaScript/Reference/Statements/let) 所宣告的變數，具有區塊可視範圍。常數不能重複指定值，也不能重複宣告。
+
+{{InteractiveExample("JavaScript Demo: const declaration")}}
 
 ```js interactive-example
 const number = 42;
@@ -24,8 +26,10 @@ console.log(number);
 
 ## 語法
 
-```plain
-const name1 = value1 [, name2 = value2 [, ... [, nameN = valueN]]];
+```js-nolint
+const name1 = value1;
+const name1 = value1, name2 = value2;
+const name1 = value1, name2 = value2, /* …, */ nameN = valueN;
 ```
 
 - `nameN`
@@ -35,11 +39,11 @@ const name1 = value1 [, name2 = value2 [, ... [, nameN = valueN]]];
 
 ## 描述
 
-上述宣告建立一個常數，它的可視範圍可能是全域的，或是在它所宣告的區域區塊中。 和 [`var`](/zh-TW/docs/Web/JavaScript/Reference/Statements/var) 變數不同的是，全域的常數不會變成 window 物件的屬性。常數必須要初始化；也就是說，你必須在宣告常數的同一個敘述式中指定這個常數的值。(這很合理，因為稍後就不能再變更常數的值了)
+上述宣告建立一個常數，它的可視範圍可能是全域的，或是在它所宣告的區域區塊中。和 [`var`](/zh-TW/docs/Web/JavaScript/Reference/Statements/var) 變數不同的是，全域的常數不會變成 window 物件的屬性。常數必須要初始化；也就是說，你必須在宣告常數的同一個敘述式中指定這個常數的值。(這很合理，因為稍後就不能再變更常數的值了)
 
 宣告 **`const`** 會對於它的值建立一個唯讀的參考。並不是說這個值不可變更，而是這個變數不能再一次指定值。例如，假設常數的內容(值)是個物件，那麼此物件的內容(物件的參數)是可以更改的。
 
-所有關於 "[temporal dead zone](/zh-TW/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_and_errors_with_let)" 的狀況，都適用於 [`let`](/zh-TW/docs/Web/JavaScript/Reference/Statements/let) and `const` 。
+所有關於 "[temporal dead zone](/zh-TW/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_and_errors_with_let)" 的狀況，都適用於 [`let`](/zh-TW/docs/Web/JavaScript/Reference/Statements/let) 和 `const` 。
 
 在相同的可視範圍內，常數不能和函數，變數具有相同名稱。
 


### PR DESCRIPTION
These should be the final migrations outside of the kitchensink and writing guidelines, part of the wider project described here: https://github.com/orgs/mdn/discussions/782

We haven't QAed these as thoroughly as the previous migrations (difficult to do, as they weren't detected by our scripts, so we've had to manually migrate these), so I'd suggest a more "hands-on" review compared to the other migrations: thankfully it's only a few examples!