### PR TITLE
chore(css): use embedlivesample for css-examples [zh-cn]

### DIFF
--- a/files/zh-cn/web/css/css_display/block_and_inline_layout_in_normal_flow/index.md
+++ b/files/zh-cn/web/css/css_display/block_and_inline_layout_in_normal_flow/index.md
@@ -35,15 +35,89 @@ slug: Web/CSS/CSS_display/Block_and_inline_layout_in_normal_flow
 
 如规范中所定义，外边距使得两个块级盒子分开。这个例子展示了一个非常简单的由两个段落组成的排版，每个段落都加了一个边框。浏览器的默认样式表通过增加外边距（margin）的方式在每个段落的顶部和底部留出一定空间。
 
-{{EmbedGHLiveSample("css-examples/flow/block-inline/normal-flow.html", '100%', 700)}}
+```html live-sample___normal-flow
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+  <p>
+    Before that night—a memorable night, as it was to prove—hundreds of millions
+    of people had watched the rising smoke-wreaths of their fires without
+    drawing any special inspiration from the fact.
+  </p>
+</div>
+```
+
+```css live-sample___normal-flow
+p {
+  border: 2px solid green;
+}
+```
+
+{{EmbedLiveSample("normal-flow", "", "200px")}}
 
 如果我们将 p 元素的边距设置为 0，两个边框会紧贴在一起。
 
-{{EmbedGHLiveSample("css-examples/flow/block-inline/normal-flow-margin-zero.html", '100%', 700)}}
+```html live-sample___normal-flow-margin-zero
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+  <p>
+    Before that night—a memorable night, as it was to prove—hundreds of millions
+    of people had watched the rising smoke-wreaths of their fires without
+    drawing any special inspiration from the fact.
+  </p>
+</div>
+```
+
+```css live-sample___normal-flow-margin-zero
+p {
+  border: 2px solid green;
+  margin: 0;
+}
+```
+
+{{EmbedLiveSample("normal-flow-margin-zero")}}
 
 默认情况下，块级元素将占据这一内联方向的所有空间，因此我们的段落会铺开分布在多行，尽可能排满他的包含块。如果限定了段落元素的宽度，第二个段落仍然会排布在第一个段落的下面——即使有足够空间使它们并排。每个块级元素都会从包含块的起始边开始，因此，在当前书写模式下，所有句子会从包含块的起始边开始。
 
-{{EmbedGHLiveSample("css-examples/flow/block-inline/normal-flow-width.html", '100%', 700)}}
+```html live-sample___normal-flow-width
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+  <p>
+    Before that night—a memorable night, as it was to prove—hundreds of millions
+    of people had watched the rising smoke-wreaths of their fires without
+    drawing any special inspiration from the fact.
+  </p>
+</div>
+```
+
+```css live-sample___normal-flow-width
+p {
+  border: 2px solid green;
+  width: 40%;
+}
+```
+
+{{EmbedLiveSample("normal-flow-width", "", "370px")}}
 
 ### 外边距折叠
 
@@ -51,7 +125,32 @@ slug: Web/CSS/CSS_display/Block_and_inline_layout_in_normal_flow
 
 在下面的例子中，段落的上边距设为`20px`，下边距设为`40px`，而段落之间的间距大小会是`40px`。这是因为第二段中的上边距比较小被折叠，间距跟随了第一个段落更大的下边距。
 
-{{EmbedGHLiveSample("css-examples/flow/block-inline/normal-flow-collapsing.html", '100%', 500)}}
+```html live-sample___normal-flow-collapsing
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+  <p>
+    Before that night—a memorable night, as it was to prove—hundreds of millions
+    of people had watched the rising smoke-wreaths of their fires without
+    drawing any special inspiration from the fact.
+  </p>
+</div>
+```
+
+```css live-sample___normal-flow-collapsing
+p {
+  border: 2px solid green;
+  margin: 20px 0 40px 0;
+}
+```
+
+{{EmbedLiveSample("normal-flow-collapsing", "", "230px")}}
 
 你可以在我们的文章《[掌握外边距折叠](/zh-CN/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)》中阅读更多关于这一部分的内容。
 
@@ -66,13 +165,35 @@ slug: Web/CSS/CSS_display/Block_and_inline_layout_in_normal_flow
 
 在下面的示例中，我们有三个由段落创建的内联框，其中包含一个强元素。
 
-{{EmbedGHLiveSample("css-examples/flow/block-inline/inline.html", '100%', 500)}}
+```html live-sample___inline
+<p>
+  Before that night—<strong>a memorable night</strong>, as it was to
+  prove—hundreds of millions of people had watched the rising smoke-wreaths of
+  their fires without drawing any special inspiration from the fact.
+</p>
+```
+
+{{EmbedLiveSample("inline")}}
 
 在强元素前和强元素后的单词周围的框称为匿名框，引入的框确保所有内容都包装在一个框中，但我们不能直接针对它们。
 
 块方向上的线框大小（以英文工作时的高度为准）由其内部最高的框定义。在下一个示例中，我将强元素 300% 设为内容，该内容现在定义了该行上行框的高度。
 
-{{EmbedGHLiveSample("css-examples/flow/block-inline/line-box.html", '100%', 500)}}
+```html live-sample___line-box
+<p>
+  Before that night—<strong>a memorable night</strong>, as it was to
+  prove—hundreds of millions of people had watched the rising smoke-wreaths of
+  their fires without drawing any special inspiration from the fact.
+</p>
+```
+
+```css live-sample___line-box
+strong {
+  font-size: 300%;
+}
+```
+
+{{EmbedLiveSample("line-box")}}
 
 在我们的视觉格式模型指南中，了解更多关于块和内联框的行为。
 
@@ -84,7 +205,29 @@ slug: Web/CSS/CSS_display/Block_and_inline_layout_in_normal_flow
 
 但是，flex 项正在参与 flex 格式上下文，因为它们的父级是带有 display:flex 的元素，后者具有 flex 的内部显示类型，为直接子级建立 flex 格式上下文。
 
-{{EmbedGHLiveSample("css-examples/flow/block-inline/flex.html", '100%', 500)}}
+```html live-sample___flex
+<div class="container">
+  <div>Flex Item</div>
+  <div>Flex Item</div>
+  <div>
+    <div>Children</div>
+    <div>are in</div>
+    <div>normal flow</div>
+  </div>
+</div>
+```
+
+```css live-sample___flex
+.container {
+  display: flex;
+}
+
+.container > * {
+  border: 1px solid green;
+}
+```
+
+{{EmbedLiveSample("flex")}}
 
 因此，你可以想到 CSS 中的每个框都是以这种方式工作的。盒子本身有一个外部显示类型，所以它知道如何与其他盒子一起工作。然后它有一个内部显示类型，它改变了它的子对象的行为方式。然后，这些子级也有一个外部和内部显示类型。上一个示例中的 flex 项变为 flex 级别框，因此它们的外部显示类型取决于它们是 flex 格式上下文的一部分。然而，他们有一种内在的流动显示类型，这意味着他们的孩子参与正常的流动。嵌套在 flex 项中的项将自己设置为块和内联元素，除非有什么改变了它们的显示类型。
 
@@ -94,7 +237,21 @@ slug: Web/CSS/CSS_display/Block_and_inline_layout_in_normal_flow
 
 浏览器将项目显示为块或内联格式上下文的一部分，根据该元素通常的意义。例如，强元素用于突出显示单词，并在浏览器中显示粗体。一般来说，将该强元素显示为块级元素并中断到新行是没有意义的。如果确实希望所有强元素显示为块元素，可以通过将 display:block 设置为强来实现。这意味着你可以始终使用最语义的 HTML 元素标记内容，然后使用 CSS 更改其显示方式。
 
-{{EmbedGHLiveSample("css-examples/flow/block-inline/change-formatting.html", '100%', 500)}}
+```html live-sample___change-formatting
+<p>
+  Before that night—<strong>a memorable night</strong>, as it was to
+  prove—hundreds of millions of people had watched the rising smoke-wreaths of
+  their fires without drawing any special inspiration from the fact.
+</p>
+```
+
+```css live-sample___change-formatting
+strong {
+  display: block;
+}
+```
+
+{{EmbedLiveSample("change-formatting")}}
 
 ## 总结
 

--- a/files/zh-cn/web/css/css_display/flow_layout/index.md
+++ b/files/zh-cn/web/css/css_display/flow_layout/index.md
@@ -15,7 +15,38 @@ slug: Web/CSS/CSS_display/Flow_layout
 
 第一个句子还包括一个带有蓝色背景的 span 元素。这是行内级别，因此显示在句子的适当位置。
 
-{{EmbedGHLiveSample("css-examples/layout/normal-flow.html", '100%', 720)}}
+```html hidden live-sample___normal-flow
+<div class="box">
+  <p>
+    One <span>November</span> night in the year 1782, so the story runs, two
+    brothers sat over their winter fire in the little French town of Annonay,
+    watching the grey smoke-wreaths from the hearth curl up the wide chimney.
+    Their names were Stephen and Joseph Montgolfier, they were papermakers by
+    trade, and were noted as possessing thoughtful minds and a deep interest in
+    all scientific knowledge and new discovery.
+  </p>
+  <p>
+    Before that night—a memorable night, as it was to prove—hundreds of millions
+    of people had watched the rising smoke-wreaths of their fires without
+    drawing any special inspiration from the fact.
+  </p>
+</div>
+```
+
+```css hidden live-sample___normal-flow
+body {
+  font: 1.2em sans-serif;
+}
+
+p {
+  border: 2px solid green;
+}
+span {
+  background-color: lightblue;
+}
+```
+
+{{EmbedLiveSample("normal-flow", "", "250px")}}
 
 ## 参见
 

--- a/files/zh-cn/web/css/css_display/flow_layout_and_overflow/index.md
+++ b/files/zh-cn/web/css/css_display/flow_layout_and_overflow/index.md
@@ -11,7 +11,40 @@ slug: Web/CSS/CSS_display/Flow_layout_and_overflow
 
 为元素赋予固定的高度和宽度，然后向框中添加重要内容，将创建一个基本的溢出示例：
 
-{{EmbedGHLiveSample("css-examples/flow/overflow/overflow.html", '100%', 700)}}
+```html live-sample___overflow
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney.
+  </p>
+</div>
+<p>
+  Their names were Stephen and Joseph Montgolfier. They were papermakers by
+  trade, and were noted as possessing thoughtful minds and a deep interest in
+  all scientific knowledge and new discovery.
+</p>
+<p>
+  Before that night—a memorable night, as it was to prove—hundreds of millions
+  of people had watched the rising smoke-wreaths of their fires without drawing
+  any special inspiration from the fact.
+</p>
+```
+
+```css live-sample___overflow
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.box {
+  width: 300px;
+  height: 100px;
+  border: 5px solid rebeccapurple;
+  padding: 10px;
+}
+```
+
+{{EmbedLiveSample("overflow", "", "370px")}}
 
 内容将进入框中。一旦填充了该框，它将继续以可见的方式溢出，在框外显示内容，可能在随后的内容下显示。控制溢出行为的属性是初始值为 `visible` 的 [`overflow`](/zh-CN/docs/Web/CSS/overflow) 属性。这就是为什么我们可以看到溢出内容。
 
@@ -19,15 +52,114 @@ slug: Web/CSS/CSS_display/Flow_layout_and_overflow
 
 还有其他值控制溢出内容的行为。要隐藏溢出的内容，请使用值 `hidden`。这可能会导致某些内容不可见。
 
-{{EmbedGHLiveSample("css-examples/flow/overflow/hidden.html", '100%', 700)}}
+```html hidden live-sample___hidden
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney.
+  </p>
+</div>
+<p>
+  Their names were Stephen and Joseph Montgolfier. They were papermakers by
+  trade, and were noted as possessing thoughtful minds and a deep interest in
+  all scientific knowledge and new discovery.
+</p>
+<p>
+  Before that night—a memorable night, as it was to prove—hundreds of millions
+  of people had watched the rising smoke-wreaths of their fires without drawing
+  any special inspiration from the fact.
+</p>
+```
+
+```css live-sample___hidden
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.box {
+  width: 300px;
+  height: 100px;
+  border: 5px solid rebeccapurple;
+  padding: 10px;
+  overflow: hidden;
+}
+```
+
+{{EmbedLiveSample("hidden", "", "370px")}}
 
 使用值 `scroll` 包含其框中的内容，并添加滚动条以启用查看。即使内容适合该框，也将添加滚动条。
 
-{{EmbedGHLiveSample("css-examples/flow/overflow/scroll.html", '100%', 700)}}
+```html hidden live-sample___scroll
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney.
+  </p>
+</div>
+<p>
+  Their names were Stephen and Joseph Montgolfier; they were papermakers by
+  trade and were noted as possessing thoughtful minds and a deep interest in all
+  scientific knowledge and new discoveries.
+</p>
+<p>
+  Before that night—a memorable night, as it was to prove—hundreds of millions
+  of people had watched the rising smoke-wreaths of their fires without drawing
+  any special inspiration from the fact.
+</p>
+```
+
+```css live-sample___scroll
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.box {
+  width: 300px;
+  height: 100px;
+  border: 5px solid rebeccapurple;
+  padding: 10px;
+  overflow: scroll;
+}
+```
+
+{{EmbedLiveSample("scroll", "", "370px")}}
 
 如果内容适合方框，则使用值 auto 将显示不带滚动条的内容。如果它不适合，则会添加滚动条。将下一个示例与溢出示例进行比较：当溢出滚动只需要垂直滚动时，你应该看到它有水平滚动条和垂直滚动条。下面的自动示例只在我们需要滚动的直接位置添加滚动条。
 
-{{EmbedGHLiveSample("css-examples/flow/overflow/auto.html", '100%', 700)}}
+```html hidden live-sample___auto
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney.
+  </p>
+</div>
+<p>
+  Their names were Stephen and Joseph Montgolfier, they were papermakers by
+  trade, and were noted as possessing thoughtful minds and a deep interest in
+  all scientific knowledge and new discovery.
+</p>
+<p>
+  Before that night—a memorable night, as it was to prove—hundreds of millions
+  of people had watched the rising smoke-wreaths of their fires without drawing
+  any special inspiration from the fact.
+</p>
+```
+
+```css live-sample___auto
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.box {
+  width: 300px;
+  height: 100px;
+  border: 5px solid rebeccapurple;
+  padding: 10px;
+  overflow: auto;
+}
+```
+
+{{EmbedLiveSample("auto", "", "370px")}}
 
 正如我们已经了解的，使用这些值中的任何一个，而不是默认的 `visible`，都会创建一个新的块级格式化上下文。
 
@@ -35,7 +167,40 @@ slug: Web/CSS/CSS_display/Flow_layout_and_overflow
 
 实际上，overflow 属性是 [`overflow-x`](/zh-CN/docs/Web/CSS/overflow-x) 和 [`overflow-y`](/zh-CN/docs/Web/CSS/overflow-y) 属性的简写。如果只为溢出指定一个值，则此值用于两个轴。但是，你可以指定两个值，在这种情况下，第一个值用于 `overflow-x`，因此是水平方向，第二个值用于 `overflow-y` 和垂直方向。在下面的示例中，我只指定了 `overflow-y: scroll`，这样我们就不会得到不需要的水平滚动条。
 
-{{EmbedGHLiveSample("css-examples/flow/overflow/overflow-y.html", '100%', 700)}}
+```html hidden live-sample___overflow-y
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney.
+  </p>
+</div>
+<p>
+  Their names were Stephen and Joseph Montgolfier, they were papermakers by
+  trade, and were noted as possessing thoughtful minds and a deep interest in
+  all scientific knowledge and new discovery.
+</p>
+<p>
+  Before that night—a memorable night, as it was to prove—hundreds of millions
+  of people had watched the rising smoke-wreaths of their fires without drawing
+  any special inspiration from the fact.
+</p>
+```
+
+```css live-sample___overflow-y
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.box {
+  width: 300px;
+  height: 100px;
+  border: 5px solid rebeccapurple;
+  padding: 10px;
+  overflow-y: scroll;
+}
+```
+
+{{EmbedLiveSample("overflow-y", "", "370px")}}
 
 ## 流相对属性
 
@@ -51,7 +216,45 @@ slug: Web/CSS/CSS_display/Flow_layout_and_overflow
 
 [`text-overflow`](/zh-CN/docs/Web/CSS/text-overflow) 属性处理行方的文本溢出。它采用两个值 `clip` 中的一个值，在这种情况下，内容在溢出时被剪裁，这是初始值，因此是默认行为。我们还有一个省略号，它呈现了一个省略号，可以用一个更好的字符来替换使用中的语言或书写模式。
 
-{{EmbedGHLiveSample("css-examples/flow/overflow/text-overflow.html", '100%', 500)}}
+```html hidden live-sample___text-overflow
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney.
+  </p>
+
+  <p>
+    Their names were Stephen and Joseph Montgolfier, they were papermakers by
+    trade, and were noted as possessing thoughtful minds and a deep interest in
+    all scientific knowledge and new discovery.
+  </p>
+  <p>
+    Before that night—a memorable night, as it was to prove—hundreds of millions
+    of people had watched the rising smoke-wreaths of their fires without
+    drawing any special inspiration from the fact.
+  </p>
+</div>
+```
+
+```css live-sample___text-overflow
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.box {
+  width: 300px;
+  border: 5px solid rebeccapurple;
+  padding: 10px;
+}
+
+.box p {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+```
+
+{{EmbedLiveSample("text-overflow", "", "220px")}}
 
 ### 块轴溢出
 

--- a/files/zh-cn/web/css/css_display/flow_layout_and_writing_modes/index.md
+++ b/files/zh-cn/web/css/css_display/flow_layout_and_writing_modes/index.md
@@ -21,7 +21,31 @@ CSS 编写模式级别 3 规范定义了文档编写模式更改对流式布局�
 
 虽然某些语言将使用特定的书写模式或文本方向，但我们也可以使用这些属性来产生创造性效果，例如垂直运行标题。
 
-{{EmbedGHLiveSample("css-examples/flow/writing-modes/creative-use.html", '100%', 720)}}
+```html live-sample___creative-use
+<div class="box">
+  <h1>A heading</h1>
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+</div>
+```
+
+```css live-sample___creative-use
+body {
+  font: 1.2em sans-serif;
+}
+h1 {
+  writing-mode: vertical-lr;
+  float: left;
+}
+```
+
+{{EmbedLiveSample("creative-use", "", "220px")}}
 
 ## `writing-mode` 属性和块流
 
@@ -29,41 +53,269 @@ CSS 编写模式级别 3 规范定义了文档编写模式更改对流式布局�
 
 下面的示例显示了使用 `horizontal-tb` 的块。
 
-{{EmbedGHLiveSample("css-examples/flow/writing-modes/horizontal-tb.html", '100%', 720)}}
+```html live-sample___horizontal-tb
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+  <p>
+    Before that night—a memorable night, as it was to prove—hundreds of millions
+    of people had watched the rising smoke-wreaths of their fires without
+    drawing any special inspiration from the fact.
+  </p>
+</div>
+```
+
+```css live-sample___horizontal-tb
+body {
+  font: 1.2em sans-serif;
+}
+.box {
+  writing-mode: horizontal-tb;
+}
+```
+
+{{EmbedLiveSample("horizontal-tb", "", "240px")}}
 
 `vertical-rl` 值为你提供了一个从右到左的块向和一个垂直的行向，如下一个示例所示。
 
-{{EmbedGHLiveSample("css-examples/flow/writing-modes/vertical-rl.html", '100%', 720)}}
+```html hidden live-sample___vertical-rl
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+  <p>
+    Before that night—a memorable night, as it was to prove—hundreds of millions
+    of people had watched the rising smoke-wreaths of their fires without
+    drawing any special inspiration from the fact.
+  </p>
+</div>
+```
+
+```css live-sample___vertical-rl
+body {
+  font: 1.2em sans-serif;
+}
+.box {
+  writing-mode: vertical-rl;
+}
+```
+
+{{EmbedLiveSample("vertical-rl", "", "300px")}}
 
 最后一个示例演示了第三个可能的 `writing-mode` 值——`vertical-lr`。这将为你提供一个从左到右的块流方向和一个垂直的行方向。
 
-{{EmbedGHLiveSample("css-examples/flow/writing-modes/vertical-lr.html", '100%', 720)}}
+```html hidden live-sample___vertical-lr
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+  <p>
+    Before that night—a memorable night, as it was to prove—hundreds of millions
+    of people had watched the rising smoke-wreaths of their fires without
+    drawing any special inspiration from the fact.
+  </p>
+</div>
+```
+
+```css live-sample___vertical-lr
+body {
+  font: 1.2em sans-serif;
+}
+.box {
+  writing-mode: vertical-lr;
+}
+```
+
+{{EmbedLiveSample("vertical-lr", "", "300px")}}
 
 ## 对父级具有不同写入模式的框
 
 当一个嵌套框被分配给它的父级的不同的写入模式时，一个行级别的框将显示，就好像它有 `display: inline-block` 一样。
 
-{{EmbedGHLiveSample("css-examples/flow/writing-modes/inline-change-mode.html", '100%', 720)}}
+```html live-sample___inline-change-mode
+<div class="box">
+  <p>
+    One <span>November</span> night in the year 1782, so the story runs, two
+    brothers sat over their winter fire in the little French town of Annonay,
+    watching the grey smoke-wreaths from the hearth curl up the wide chimney.
+    Their names were Stephen and Joseph Montgolfier, they were papermakers by
+    trade, and were noted as possessing thoughtful minds and a deep interest in
+    all scientific knowledge and new discovery.
+  </p>
+</div>
+```
+
+```css live-sample___inline-change-mode
+body {
+  font: 1.2em sans-serif;
+}
+.box {
+  writing-mode: vertical-rl;
+}
+.box span {
+  writing-mode: horizontal-tb;
+  padding: 10px;
+  border: 1px solid rebeccapurple;
+}
+```
+
+{{EmbedLiveSample("inline-change-mode", "", "240px")}}
 
 块级别的框将建立一个新的块格式上下文，这意味着如果其内部显示类型为 `flow`，则它将获得 `flow-root` 的计算显示类型。这在下一个示例中显示，其中显示为 `horizontal-tb` 的框包含一个浮动，该浮动是由于其父级建立了一个新的 BFC 而包含的。
 
-{{EmbedGHLiveSample("css-examples/flow/writing-modes/block-change-mode.html", '100%', 720)}}
+```html live-sample___block-change-mode
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney.
+  </p>
+
+  <div>
+    <div class="float"></div>
+    This box should establish a new BFC.
+  </div>
+
+  <p>
+    Their names were Stephen and Joseph Montgolfier, they were papermakers by
+    trade, and were noted as possessing thoughtful minds and a deep interest in
+    all scientific knowledge and new discovery.
+  </p>
+</div>
+```
+
+```css live-sample___block-change-mode
+body {
+  font: 1.2em sans-serif;
+}
+.box {
+  writing-mode: vertical-rl;
+}
+.box > div {
+  writing-mode: horizontal-tb;
+  padding: 10px;
+  border: 1px solid rebeccapurple;
+}
+.float {
+  width: 100px;
+  height: 150px;
+  background-color: rebeccapurple;
+  float: left;
+}
+```
+
+{{EmbedLiveSample("block-change-mode", "", "500px")}}
 
 ## 替换的元素
 
 替换的元素（如图像）不会根据“写入模式”属性更改其方向。但是，替换的元素（如包含文本的表单控件）应与使用中的写入模式匹配。
 
-{{EmbedGHLiveSample("css-examples/flow/writing-modes/replaced.html", '100%', 720)}}
+```html live-sample___replaced
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney.
+  </p>
+
+  <img
+    alt="a colorful hot air balloon against a clear sky"
+    src="https://mdn.github.io/shared-assets/images/examples/balloon.jpg" />
+
+  <p>
+    Their names were Stephen and Joseph Montgolfier, they were papermakers by
+    trade, and were noted as possessing thoughtful minds and a deep interest in
+    all scientific knowledge and new discovery.
+  </p>
+</div>
+```
+
+```css live-sample___replaced
+body {
+  font: 1.2em sans-serif;
+}
+.box {
+  writing-mode: vertical-rl;
+}
+```
+
+{{EmbedLiveSample("replaced", "", "340px")}}
 
 ## 逻辑属性和值
 
 一旦你在书写模式（而不是 `horizontal-tb`）时，许多映射到屏幕物理维度的属性和值看起来很奇怪。例如，如果为一个框提供 100px 的宽度，以水平 tb 表示，它将控制行方向的大小。在 `vertical-lr` 中，它控制块方向的大小，因为它不随文本旋转。
 
-{{EmbedGHLiveSample("css-examples/flow/writing-modes/width.html", '100%', 720)}}
+```html live-sample___width
+<div class="box">
+  <div class="box1">Box 1</div>
+  <div class="box2">Box 2</div>
+</div>
+```
+
+```css live-sample___width
+body {
+  font: 1.2em sans-serif;
+}
+.box1 {
+  writing-mode: horizontal-tb;
+  border: 5px solid rebeccapurple;
+  width: 100px;
+  margin: 10px;
+}
+.box2 {
+  writing-mode: vertical-lr;
+  border: 5px solid rebeccapurple;
+  width: 100px;
+  margin: 10px;
+}
+```
+
+{{EmbedLiveSample("width")}}
 
 因此，我们有了 {{cssxref("block-size")}} 和 {{cssxref("inline-size")}} 的新属性。如果我们给块一个 100px 的 `inline-size`，不管我们是处于水平还是垂直写入模式，`inline-size` 总是指行方向的大小。
 
-{{EmbedGHLiveSample("css-examples/flow/writing-modes/inline-size.html", '100%', 720)}}
+```html live-sample___inline-size
+<div class="box">
+  <div class="box1">Box 1</div>
+  <div class="box2">Box 2</div>
+</div>
+```
+
+```css live-sample___inline-size
+body {
+  font: 1.2em sans-serif;
+}
+.box1 {
+  writing-mode: horizontal-tb;
+  border: 5px solid rebeccapurple;
+  inline-size: 100px;
+  margin: 10px;
+}
+.box2 {
+  writing-mode: vertical-lr;
+  border: 5px solid rebeccapurple;
+  inline-size: 100px;
+  margin: 10px;
+}
+```
+
+{{EmbedLiveSample("inline-size", "", "200px")}}
 
 [CSS 逻辑属性和值](/zh-CN/docs/Web/CSS/CSS_logical_properties_and_values)规范包括用于控制页边距、填充和边框的属性的逻辑版本，以及用于我们通常使用物理方向指定的内容的其他映射。
 

--- a/files/zh-cn/web/css/css_display/in_flow_and_out_of_flow/index.md
+++ b/files/zh-cn/web/css/css_display/in_flow_and_out_of_flow/index.md
@@ -9,7 +9,45 @@ slug: Web/CSS/CSS_display/In_flow_and_out_of_flow
 
 在下面的例子中，我新建了一个标题（h1 元素），一个段落（p 元素），一个无序列表（ul 元素）和一个包含 strong 元素的段落（p 元素），标题和段落都是块级（block level），strong 元素为行级（inline）。列表中的项通过弹性盒布局排成一行，但是列表本身仍然处于块和内联布局中 - 他的 display 属性为 block。
 
-{{EmbedGHLiveSample("css-examples/flow/in-flow/in-flow.html", '100%', 800)}}
+```html live-sample___in-flow
+<div class="box">
+  <h1>A heading</h1>
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney.
+  </p>
+
+  <ul>
+    <li>One</li>
+    <li>Two</li>
+    <li>Three</li>
+  </ul>
+  <p>
+    Their names were <strong>Stephen and Joseph Montgolfier</strong>, they were
+    papermakers by trade, and were noted as possessing thoughtful minds and a
+    deep interest in all scientific knowledge and new discovery.
+  </p>
+</div>
+```
+
+```css live-sample___in-flow
+body {
+  font: 1.2em sans-serif;
+}
+.box > * {
+  border: 1px solid green;
+}
+
+ul {
+  display: flex;
+  justify-content: space-around;
+  list-style: none;
+  margin: 0;
+}
+```
+
+{{EmbedLiveSample("in-flow", "", "300px")}}
 
 可以说，示例中的所有元素都属于常规流，按照源代码中的顺序渲染到页面中。
 
@@ -29,7 +67,43 @@ slug: Web/CSS/CSS_display/In_flow_and_out_of_flow
 
 作为一个浮动的元素，它首先根据正常 flow 布局，然后从流动中取出并尽可能地向左移动
 
-{{EmbedGHLiveSample("css-examples/flow/in-flow/float.html", '100%', 800)}}
+```html live-sample___float
+<div class="box">
+  <div class="float">I am a floated box!</div>
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+  <p>
+    Before that night—a memorable night, as it was to prove—hundreds of millions
+    of people had watched the rising smoke-wreaths of their fires without
+    drawing any special inspiration from the fact.
+  </p>
+</div>
+```
+
+```css live-sample___float
+body {
+  font: 1.2em sans-serif;
+}
+p {
+  background-color: #ccc;
+}
+
+.float {
+  float: left;
+  font-weight: bold;
+  width: 200px;
+  border: 2px dotted black;
+  padding: 10px;
+}
+```
+
+{{EmbedLiveSample("float", "", "260px")}}
 
 你可以看到下面段落的背景颜色在下面运行，只是该段落的行框已被缩短以导致在浮动周围包裹内容的效果。我们段落的方框仍然按照正常流程规则显示。这就是为什么要在浮动项目周围留出空间，必须为项目添加边距，以便将线框推离它。你无法对以下内插内容应用任何内容来实现此目的。
 
@@ -37,7 +111,48 @@ slug: Web/CSS/CSS_display/In_flow_and_out_of_flow
 
 设置元素属性为 `position: absolute` 或者 `position: fixed` 会使此元素脱离文档流，他本来占据的空间也会被移除。在下面的例子中，我定义了三个 p 元素，并且将第二个 p 元素设置为 `position` `absolute`, `top: 30px` , `right: 30px`. 使其脱离文档流。
 
-{{EmbedGHLiveSample("css-examples/flow/in-flow/abspos.html", '100%', 700)}}
+```html live-sample___abspos
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney.
+  </p>
+  <p class="abspos">
+    Their names were Stephen and Joseph Montgolfier, they were papermakers by
+    trade, and were noted as possessing thoughtful minds and a deep interest in
+    all scientific knowledge and new discovery.
+  </p>
+  <p>
+    Before that night—a memorable night, as it was to prove—hundreds of millions
+    of people had watched the rising smoke-wreaths of their fires without
+    drawing any special inspiration from the fact.
+  </p>
+</div>
+```
+
+```css live-sample___abspos
+body {
+  font: 1.2em sans-serif;
+}
+.box {
+  width: 70%;
+}
+p {
+  border: 2px solid green;
+}
+
+.abspos {
+  position: absolute;
+  background-color: green;
+  color: #fff;
+  top: 30px;
+  right: 30px;
+  width: 400px;
+}
+```
+
+{{EmbedLiveSample("abspos", "", "240px")}}
 
 设置 `position: fixed` 也能使元素脱离文档流，但是偏移量会根据视口而不是父元素来定。
 
@@ -47,7 +162,48 @@ slug: Web/CSS/CSS_display/In_flow_and_out_of_flow
 
 如果你给一个元素开启相对定位，那该元素依然会位于文档流中，然而你可以通过设置偏移值的方式来移动他。正如下面的例子所展示的，该元素的原先占据的空间仍然会被保留。
 
-{{EmbedGHLiveSample("css-examples/flow/in-flow/relative.html", '100%', 800)}}
+```html live-sample___relative
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney.
+  </p>
+  <p class="relative">
+    Their names were Stephen and Joseph Montgolfier, they were papermakers by
+    trade, and were noted as possessing thoughtful minds and a deep interest in
+    all scientific knowledge and new discovery.
+  </p>
+  <p>
+    Before that night—a memorable night, as it was to prove—hundreds of millions
+    of people had watched the rising smoke-wreaths of their fires without
+    drawing any special inspiration from the fact.
+  </p>
+</div>
+```
+
+```css live-sample___relative
+body {
+  font: 1.2em sans-serif;
+}
+.box {
+  width: 70%;
+}
+p {
+  border: 2px solid green;
+}
+
+.relative {
+  position: relative;
+  background-color: green;
+  color: #fff;
+  bottom: 50px;
+  left: 50px;
+  width: 400px;
+}
+```
+
+{{EmbedLiveSample("relative", "", "360px")}}
 
 当你移动一个元素或者使元素脱离文档流，为防止重叠，你可能需要对元素内容和元素周围的内容做一些管理，要么清除浮动，要么保证相对定位不会覆盖其他元素。
 

--- a/files/zh-cn/web/css/css_display/introduction_to_formatting_contexts/index.md
+++ b/files/zh-cn/web/css/css_display/introduction_to_formatting_contexts/index.md
@@ -40,11 +40,65 @@ slug: Web/CSS/CSS_display/Introduction_to_formatting_contexts
 
 在下面的示例中，我们在应用了边框的 `<div>` 中有一个浮动元素。该 `div` 的内容与浮动元素一起浮动。由于 float 的内容比它旁边的内容高，所以现在 DIV 的边框贯穿了 float。如[应用或脱离流式布局](/zh-CN/docs/Web/CSS/CSS_display/In_flow_and_out_of_flow)中所述，浮动已脱离文档流，因此 DIV 的背景和边框仅包含内容，而不包含浮动。
 
-{{EmbedGHLiveSample("css-examples/flow/formatting-contexts/float.html", '100%', 720)}}
+```html live-sample___float
+<div class="box">
+  <div class="float">I am a floated box!</div>
+  <p>I am content inside the container.</p>
+</div>
+```
+
+```css live-sample___float
+body {
+  font: 1.2em sans-serif;
+}
+
+.box {
+  background-color: rgb(224 206 247);
+  border: 5px solid rebeccapurple;
+}
+
+.float {
+  float: left;
+  width: 200px;
+  height: 100px;
+  background-color: white;
+  border: 1px solid black;
+  padding: 10px;
+}
+```
+
+{{EmbedLiveSample("float")}}
 
 创建一个新的 BFC 将包含该浮动。在过去，一种典型的方法是设置 `overflow: auto` 或设置其他不是 `overflow: visible` 的值。
 
-{{EmbedGHLiveSample("css-examples/flow/formatting-contexts/bfc-overflow.html", '100%', 720)}}
+```html hidden live-sample___bfc-overflow
+<div class="box">
+  <div class="float">I am a floated box!</div>
+  <p>I am content inside the container.</p>
+</div>
+```
+
+```css live-sample___bfc-overflow
+body {
+  font: 1.2em sans-serif;
+}
+.box {
+  background-color: rgb(224 206 247);
+  border: 5px solid rebeccapurple;
+  overflow: auto;
+}
+
+.float {
+  float: left;
+  width: 200px;
+  height: 150px;
+  background-color: white;
+  border: 1px solid black;
+  padding: 10px;
+}
+```
+
+{{EmbedLiveSample("bfc-overflow", "", "220px")}}
 设置 `overflow: auto` 会自动创建包含浮动的新 BFC。现在，我们的 DIV 在布局中变成了一个迷你布局。任何子元素都将包含在其中。
 
 使用 `overflow` 创建新的 BFC 的问题在于， `overflow` 属性用于告诉浏览器你希望如何处理溢出的内容。在某些情况下，当你纯粹使用此属性创建 BFC 时，你会发现不需要的滚动条或剪切阴影。另外，对于未来的开发人员来说，它可能不太可读，因为不能显式地表明为什么要使用溢出来实现这一目的。如果你使用了这个方法，最好对代码进行注释以便他人理解。
@@ -53,7 +107,36 @@ slug: Web/CSS/CSS_display/Introduction_to_formatting_contexts
 
 使用 `display: flow-root` （或 `display: flow-root list-item`）将创建一个新的 BFC，而不会产生任何其他潜在的问题副作用。
 
-{{EmbedGHLiveSample("css-examples/flow/formatting-contexts/bfc-flow-root.html", '100%', 720)}}
+```html hidden live-sample___bfc-flow-root
+<div class="box">
+  <div class="float">I am a floated box!</div>
+  <p>I am content inside the container.</p>
+</div>
+```
+
+```css live-sample___bfc-flow-root
+body {
+  font: 1.2em sans-serif;
+}
+.box {
+  background-color: rgb(224 206 247);
+  border: 5px solid rebeccapurple;
+  display: flow-root;
+}
+```
+
+```css hidden live-sample___bfc-flow-root
+.float {
+  float: left;
+  width: 200px;
+  height: 100px;
+  background-color: white;
+  border: 1px solid black;
+  padding: 10px;
+}
+```
+
+{{EmbedLiveSample("bfc-flow-root")}}
 
 使用 {{HTMLElement("div")}}上的 `display: flow-root` ，该容器内的所有内容都参与该容器的块格式上下文，并且浮动不会从元素底部弹出。
 
@@ -65,7 +148,29 @@ slug: Web/CSS/CSS_display/Introduction_to_formatting_contexts
 
 box model 不完全适用于参与内联格式上下文。在水平书写模式行中，水平填充、边框和边距将应用于元素，并左右移动文本。但是，元素上方和下方边距将不适用。应用垂直填充和边框可能会在内容的上方和下方重叠，因为在内联格式上下文中，填充和边框不会将行框撑开。
 
-{{EmbedGHLiveSample("css-examples/flow/formatting-contexts/inline.html", '100%', 720)}}
+```html live-sample___inline
+<p>
+  Before that night—<strong>a memorable night</strong>, as it was to
+  prove—hundreds of millions of people had watched the rising smoke-wreaths of
+  their fires without drawing any special inspiration from the fact.
+</p>
+```
+
+```css live-sample___inline
+body {
+  font: 1.2em sans-serif;
+}
+p {
+  margin-top: 2em;
+}
+strong {
+  margin: 20px;
+  padding: 20px;
+  border: 5px solid rebeccapurple;
+}
+```
+
+{{EmbedLiveSample("inline")}}
 
 ## 其他格式上下文
 

--- a/files/zh-cn/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/zh-cn/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -73,7 +73,28 @@ Flexible Box 模型，通常被称为 flexbox，是一种一维的布局模型�
 
 这会让你的元素呈线形排列，并且把自己的大小作为主轴上的大小。如果有太多元素超出容器，它们会溢出而不会换行。如果一些元素比其他元素高，那么元素会沿交叉轴被拉伸来填满它的大小。
 
-{{EmbedGHLiveSample("css-examples/flexbox/basics/the-flex-container.html", '100%', 480)}}
+```html live-sample___the-flex-container
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three <br />has <br />extra <br />text</div>
+</div>
+```
+
+```css live-sample___the-flex-container
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+}
+
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+}
+```
+
+{{EmbedLiveSample("the-flex-container")}}
 
 ### 更改 flex 方向 flex-direction
 
@@ -83,7 +104,29 @@ Flexible Box 模型，通常被称为 flexbox，是一种一维的布局模型�
 
 下面的例子中，`flex-direction` 值为 `row-reverse`。尝试使用其他的值 `row` ，`column`，`column-reverse`，看看内容会发生什么改变。
 
-{{EmbedGHLiveSample("css-examples/flexbox/basics/flex-direction.html", '100%', 350)}}
+```html live-sample___flex-direction
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+</div>
+```
+
+```css live-sample___flex-direction
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+}
+
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  flex-direction: row-reverse;
+}
+```
+
+{{EmbedLiveSample("flex-direction")}}
 
 ## 用 flex-wrap 实现多行 Flex 容器
 
@@ -91,7 +134,31 @@ Flexible Box 模型，通常被称为 flexbox，是一种一维的布局模型�
 
 为了实现多行效果，请为属性{{cssxref("flex-wrap")}}添加一个属性值`wrap`。现在，如果你的项目太大而无法全部显示在一行中，则会换行显示。下面的实时例子包含已给出宽度的项目，对于`flex`容器，项目的子元素总宽度大于容器最大宽度。由于`flex-wrap`的值设置为`wrap`，所以项目的子元素换行显示。若将其设置为`nowrap`，这也是初始值，它们将会缩小以适应容器，因为它们使用的是允许缩小的初始`Flexbox`值。如果项目的子元素无法缩小，使用`nowrap`会导致溢出，或者缩小程度还不够小。
 
-{{EmbedGHLiveSample("css-examples/flexbox/basics/flex-wrap.html", '100%', 400)}}
+```html live-sample___flex-wrap
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+</div>
+```
+
+```css live-sample___flex-wrap
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  width: 200px;
+}
+
+.box {
+  width: 500px;
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  flex-wrap: wrap;
+}
+```
+
+{{EmbedLiveSample("flex-wrap")}}
 
 参见[掌握弹性物件的包装](/zh-CN/docs/Web/CSS/CSS_flexible_box_layout/Mastering_wrapping_of_flex_items)指南，以了解更多有关弹性物件包装的信息。
 
@@ -101,7 +168,31 @@ Flexible Box 模型，通常被称为 flexbox，是一种一维的布局模型�
 
 在下面的例子中，尝试将第一个值修改为 `flex-direction` 的允许取值之一，即 `row`, `row-reverse`, `column` 或 `column-reverse`, 并尝试将第二个指定值修改为 `wrap` 或 `nowrap`。
 
-{{EmbedGHLiveSample("css-examples/flexbox/basics/flex-flow.html", '100%', 400)}}
+```html live-sample___flex-flow
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+</div>
+```
+
+```css live-sample___flex-flow
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  width: 200px;
+}
+
+.box {
+  width: 500px;
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  flex-flow: row wrap;
+}
+```
+
+{{EmbedLiveSample("flex-flow")}}
 
 ## flex 元素上的属性
 
@@ -150,7 +241,40 @@ flex-grow 属性可以按比例分配空间。如果第一个元素 `flex-grow` 
 
 你可以在下面的实例中尝试把 flex 简写形式中的数值更改为不同数值，但要记得第一个数值是 `flex-grow`。赋值为正数的话是让元素增加所占空间。第二个数值是`flex-shrink` — 正数可以让它缩小所占空间，但是只有在 flex 元素总和超出主轴才会生效。最后一个数值是 `flex-basis`；flex 元素是在这个基准值的基础上缩放的。
 
-{{EmbedGHLiveSample("css-examples/flexbox/basics/flex-properties.html", '100%', 510)}}
+```html live-sample___flex-properties
+<div class="box">
+  <div class="one">One</div>
+  <div class="two">Two</div>
+  <div class="three">Three</div>
+</div>
+```
+
+```css live-sample___flex-properties
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+}
+
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+}
+
+.one {
+  flex: 1 1 auto;
+}
+
+.two {
+  flex: 1 1 auto;
+}
+
+.three {
+  flex: 1 1 auto;
+}
+```
+
+{{EmbedLiveSample("flex-properties")}}
 
 大多数情况下可以用预定义的简写形式。在这个教程中你可能经常会看到这种写法，许多情况下你都可以这么使用。下面是几种预定义的值：
 
@@ -169,7 +293,40 @@ flex-grow 属性可以按比例分配空间。如果第一个元素 `flex-grow` 
 
 尝试在下面的实例中应用这些简写值。
 
-{{EmbedGHLiveSample("css-examples/flexbox/basics/flex-shorthands.html", '100%', 510)}}
+```html live-sample___flex-shorthands
+<div class="box">
+  <div class="one">One</div>
+  <div class="two">Two</div>
+  <div class="three">Three</div>
+</div>
+```
+
+```css live-sample___flex-shorthands
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+}
+
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+}
+
+.one {
+  flex: 1;
+}
+
+.two {
+  flex: 1;
+}
+
+.three {
+  flex: 1;
+}
+```
+
+{{EmbedLiveSample("flex-shorthands")}}
 
 ## 元素间的对齐和空间分配
 
@@ -188,7 +345,31 @@ Flexbox 的一个关键特性是能够设置 flex 元素沿主轴方向和交叉
 - `flex-end`
 - `center`
 
-{{EmbedGHLiveSample("css-examples/flexbox/basics/align-items.html", '100%', 520)}}
+```html live-sample___align-items
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three <br />has <br />extra <br />text</div>
+</div>
+```
+
+```css live-sample___align-items
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+}
+
+.box {
+  width: 500px;
+  height: 130px;
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  align-items: flex-start;
+}
+```
+
+{{EmbedLiveSample("align-items")}}
 
 ### `justify-content`
 
@@ -205,7 +386,29 @@ Flexbox 的一个关键特性是能够设置 flex 元素沿主轴方向和交叉
 - `space-around`
 - `space-between`
 
-{{EmbedGHLiveSample("css-examples/flexbox/basics/justify-content.html", '100%', 380)}}
+```html live-sample___justify-content
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+</div>
+```
+
+```css live-sample___justify-content
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+}
+
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  justify-content: flex-start;
+}
+```
+
+{{EmbedLiveSample("justify-content")}}
 
 在以后的文章中，为了更好的理解它们怎么使用，我们会更深入的探索这些属性。然而，这些简单的例子对大多数应用都很有帮助。
 

--- a/files/zh-cn/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_axis/index.md
+++ b/files/zh-cn/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_axis/index.md
@@ -39,7 +39,29 @@ slug: Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the
 
 第二段设置了 `max-content` 值，其与前者相反。它会变得尽可能大，没有自动换行的机会。如果容器太窄，它就会溢出其自身的盒子。
 
-{{EmbedGHLiveSample("css-examples/flexbox/ratios/min-max-content.html", '100%', 750)}}
+```html live-sample___min-max-content
+<p class="min-content">
+  I am sized with min-content and so I will take all of the soft-wrapping
+  opportunities.
+</p>
+<p class="max-content">
+  I am sized with max-content and so I will take none of the soft-wrapping
+  opportunities.
+</p>
+```
+
+```css live-sample___min-max-content
+.min-content {
+  width: min-content;
+  border: 2px dotted rgb(96 139 168);
+}
+.max-content {
+  width: max-content;
+  border: 2px dotted rgb(96 139 168);
+}
+```
+
+{{EmbedLiveSample("min-max-content", "", "260px")}}
 
 记住这种行为，以及 `min-content` 和 `max-content` 所产生的影响，我们将在后文中探索 `flex-grow` 和 `flex-shrink`。
 
@@ -65,7 +87,34 @@ slug: Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the
 
 在这个示例中我们创建了一些固定的盒子，它们的 `flex-grow` 和`flex-shrink` 都设置为 `0`。这里我们看看第一个元素，显式地设置其宽度为 150px，作为主尺寸，即设置 `flex-basis` 为 150px，而另外两个元素没有设置宽度而是根据它们内容的宽度设置尺寸。
 
-{{EmbedGHLiveSample("css-examples/flexbox/ratios/flex-basis.html", '100%', 500)}}
+```html live-sample___flex-basis
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+</div>
+```
+
+```css live-sample___flex-basis
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  flex: 0 0 auto;
+}
+
+.box {
+  width: 500px;
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+}
+
+.box :first-child {
+  width: 150px;
+}
+```
+
+{{EmbedLiveSample("flex-basis")}}
 
 除了 `auto` 关键字以外，你还可以使用 `content` 关键字作为 `flex-basis` 的值。这会导致即使元素设置了宽度，`flex-basis` 还是会根据内容大小进行设置。你也可以通过设置 flex-basis 为 `auto` 并确保你的元素没有设置宽度来达到相同的效果，以便它能自动调整大小。
 
@@ -99,7 +148,30 @@ slug: Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the
 
 尝试在这个实例中将 `flex-grow` 的值从 1 更改为 0 以查看不同的行为：
 
-{{EmbedGHLiveSample("css-examples/flexbox/ratios/flex-grow.html", '100%', 520)}}
+```html live-sample___flex-grow
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three has more content</div>
+</div>
+```
+
+```css live-sample___flex-grow
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  flex: 1 1 0;
+}
+
+.box {
+  width: 400px;
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+}
+```
+
+{{EmbedLiveSample("flex-grow")}}
 
 ### 为元素设置不同的 flex-grow 因子
 
@@ -111,7 +183,41 @@ slug: Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the
 
 `flex-basis` 值为 `0` 意味着可用空间会根据以下规则分配。我们需要将弹性增长因子相加，然后将弹性容器的正可用空间总量除以该值，在这个例子中为 4。而后我们就可以根据每一个的值分配空间——第一个元素得到一个单位、第二个元素得到一个单位、第三个元素得到二个单位。也就是说第三个元素是第一个和第二个元素的两倍。
 
-{{EmbedGHLiveSample("css-examples/flexbox/ratios/flex-grow-ratios.html", '100%', 520)}}
+```html live-sample___flex-grow-ratios
+<div class="box">
+  <div class="one">One</div>
+  <div class="two">Two</div>
+  <div class="three">Three</div>
+</div>
+```
+
+```css live-sample___flex-grow-ratios
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  flex: 1 1 0;
+}
+
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+}
+
+.one {
+  flex: 1 1 0;
+}
+
+.two {
+  flex: 1 1 0;
+}
+
+.three {
+  flex: 2 1 0;
+}
+```
+
+{{EmbedLiveSample("flex-grow-ratios")}}
 
 记住你要在这里使用正值。这是一个元素和其他元素之间的比例。你还可以使用更大的数字或者更小的数字——这由你自己决定。把上例中分配的值更改为 `.25`、`.25` 和 `.50` 并去测试——你会得到相同的结果。
 
@@ -125,7 +231,31 @@ slug: Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the
 
 下一个示例中我们的弹性容器有三个元素，我们已经给它们每一个设置了 200px 的宽度，并且设置容器为 500px 宽。设置 `flex-shrink` 为 `0` 的元素不允许收缩，以使它们溢出了盒子。
 
-{{EmbedGHLiveSample("css-examples/flexbox/ratios/flex-shrink.html", '100%', 500)}}
+```html live-sample___flex-shrink
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three has more content</div>
+</div>
+```
+
+```css live-sample___flex-shrink
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  flex: 0 0 auto;
+  width: 200px;
+}
+
+.box {
+  width: 500px;
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+}
+```
+
+{{EmbedLiveSample("flex-shrink")}}
 
 改变 `flex-shrink` 值为 `1` 你会发现每个元素都收缩了同样大小的量，现在所有元素都适应盒子。这样做后它们已变得比它们的初始宽度还小。
 
@@ -141,7 +271,30 @@ slug: Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the
 
 在下面的例子中，在 `flex-basis` 解析为内容大小的位置你会看到 `min-content` 的铺设。如果你改变弹性容器的宽度——比如增加到 700px 宽，再减少弹性元素的宽度，你会看到前两个元素将换行，但是它们绝不会小于 `min-content` 的大小。随着盒子变得越来越小，第三个元素随后从空间中溢出。
 
-{{EmbedGHLiveSample("css-examples/flexbox/ratios/flex-shrink-min-content.html", '100%', 500)}}
+```html live-sample___flex-shrink-min-content
+<div class="box">
+  <div>Item One</div>
+  <div>Item Two</div>
+  <div>Item Three has more content and so has a larger size</div>
+</div>
+```
+
+```css live-sample___flex-shrink-min-content
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  flex: 1 1 auto;
+}
+
+.box {
+  border: 2px dotted rgb(96 139 168);
+  width: 500px;
+  display: flex;
+}
+```
+
+{{EmbedLiveSample("flex-shrink-min-content")}}
 
 在实践中，收缩行为会倾向于给你合理的结果。你通常不希望自己的内容完全消失，或者文本框比自己的最小内容要小，因此上述规则对于需要缩小以适应容器的内容的合理行为而言是有意义的。
 
@@ -151,7 +304,42 @@ slug: Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the
 
 在下面的示例中第一个元素设置 `flex-shrink` 的值为 1、第二个为 `0`（因此它将不会收缩）、第三个为 `4`。第三个元素比第一个收缩的更快。任意设置不同的值——你可以给 `flex-grow` 使用小数或者大一点的数。选择对于你来说任意合理的数。
 
-{{EmbedGHLiveSample("css-examples/flexbox/ratios/flex-shrink-ratios.html", '100%', 570)}}
+```html live-sample___flex-shrink-ratios
+<div class="box">
+  <div class="one">One</div>
+  <div class="two">Two</div>
+  <div class="three">Three</div>
+</div>
+```
+
+```css live-sample___flex-shrink-ratios
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  width: 200px;
+}
+
+.box {
+  display: flex;
+  width: 500px;
+  border: 2px dotted rgb(96 139 168);
+}
+
+.one {
+  flex: 1 1 auto;
+}
+
+.two {
+  flex: 1 0 auto;
+}
+
+.three {
+  flex: 2 4 auto;
+}
+```
+
+{{EmbedLiveSample("flex-shrink-ratios")}}
 
 ## 掌握弹性元素的大小
 

--- a/files/zh-cn/web/css/css_flexible_box_layout/index.md
+++ b/files/zh-cn/web/css/css_flexible_box_layout/index.md
@@ -11,7 +11,34 @@ slug: Web/CSS/CSS_flexible_box_layout
 
 在以下示例中，已将容器设置为 `display: flex` ，这意味着三个子项成为弹性项。`justify-content` 的值已设置为 `space-between` ，以便在主轴上均匀地分隔项目。在每个项目之间放置等量的空间，左侧和右侧项目与 Flex 容器的边缘齐平。你还能看到项目在十字轴上拉伸，因为 `align-items` 的默认值为 `stretch`。这些项目伸展到 Flex 容器的高度，使它们看起来都像最高的项目一样高。
 
-{{EmbedGHLiveSample("css-examples/flexbox/basics/simple-example.html", '100%', 500)}}
+```html live-sample___simple-example
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three <br />has <br />extra <br />text</div>
+</div>
+```
+
+```css live-sample___simple-example
+body {
+  font-family: sans-serif;
+}
+
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  justify-content: space-between;
+}
+
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 1em;
+}
+```
+
+{{EmbedLiveSample("simple-example")}}
 
 ## 参考
 

--- a/files/zh-cn/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
+++ b/files/zh-cn/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
@@ -13,17 +13,110 @@ Flexbox 被设计为一维的布局工具，这意味着在处理元素布局方
 
 物件接着就会在容器内换行。在接下来的例子里，我有 10 个`160px`的`flex-basis`物件，它们都具备伸展和收缩能力。一旦第一行达到了没有足够空间放置额外 160 像素物件的点，一个新的弹性行就会被建立，一直这样直到所有的物件被放置。因为物件可以伸展，它们会扩展大于 160 像素从而完整地填充一行。如果在最后一行只有 1 个物件，它就将拉长了充满整行。
 
-{{EmbedGHLiveSample("css-examples/flexbox/wrapping/row-wrap.html", '100%', 650)}}
+```html live-sample___row-wrap
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+  <div>Four</div>
+  <div>Five</div>
+  <div>Six</div>
+  <div>Seven</div>
+  <div>Eight</div>
+  <div>Nine</div>
+  <div>Ten</div>
+</div>
+```
+
+```css live-sample___row-wrap
+.box {
+  width: 500px;
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  flex: 1 1 160px;
+}
+```
+
+{{EmbedLiveSample("row-wrap")}}
 
 我们可以看到相同的事情也发生在列上。容器会需要有一个高度让物件可以开始换行并且制造新的列，并且物件会拉伸高度来填满每一个列。
 
-{{EmbedGHLiveSample("css-examples/flexbox/wrapping/column-wrap.html", '100%', 810)}}
+```html live-sample___column-wrap
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+  <div>Four</div>
+  <div>Five</div>
+  <div>Six</div>
+  <div>Seven</div>
+  <div>Eight</div>
+  <div>Nine</div>
+  <div>Ten</div>
+</div>
+```
+
+```css live-sample___column-wrap
+.box {
+  border: 2px dotted rgb(96 139 168);
+  height: 300px;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+}
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  flex: 1 1 80px;
+}
+```
+
+{{EmbedLiveSample("column-wrap", "", "320px")}}
 
 ## 包装和弹性方向
 
 当结合 `flex-direction` 属性，包装就如你所期待的方式工作。如果 `flex-direction` 被设置成 row-reverse 那么物件就会从容器的底边开始并且以行的反向顺序堆叠自身。
 
-{{EmbedGHLiveSample("css-examples/flexbox/wrapping/row-reverse-wrap.html", '100%', 750)}}
+```html live-sample___row-reverse-wrap
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+  <div>Four</div>
+  <div>Five</div>
+  <div>Six</div>
+  <div>Seven</div>
+  <div>Eight</div>
+  <div>Nine</div>
+  <div>Ten</div>
+</div>
+```
+
+```css live-sample___row-reverse-wrap
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row-reverse;
+  width: 500px;
+}
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  flex: 1 1 160px;
+}
+```
+
+{{EmbedLiveSample("row-reverse-wrap")}}
 
 注意反向只能发生在行内、行的方向。我们从右面开始然后跳到第二行再从右边开始。我们没有在两个方向上都反向，从容器底部上来的反向！
 
@@ -35,7 +128,37 @@ Flexbox 被设计为一维的布局工具，这意味着在处理元素布局方
 
 如果你想在二维方向上布局，那么你很可能想要网格布局。我们可以比较我们上面的行换行例子和 CSS 网格版本的布局来看一下区别。一下实时的例子使用 CSS 网格布局来构建一个布局，它具有至少 160 像素的列的布局，在所有列之间分配额外的空间。
 
-{{EmbedGHLiveSample("css-examples/flexbox/wrapping/grid-example.html", '100%', 700)}}
+```html live-sample___grid-example
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+  <div>Four</div>
+  <div>Five</div>
+  <div>Six</div>
+  <div>Seven</div>
+  <div>Eight</div>
+  <div>Nine</div>
+  <div>Ten</div>
+</div>
+```
+
+```css live-sample___grid-example
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  width: 500px;
+}
+
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+}
+```
+
+{{EmbedLiveSample("grid-example")}}
 
 这就是一维和二维布局的区别。在一维的方式里就像弹性盒子，我们仅仅控制行或者列。在二维布局里就像网格，我们同时控制两个。如果你想按行分布空间，使用弹性盒子。如果不是，使用网格。
 
@@ -45,7 +168,42 @@ Flexbox 被设计为一维的布局工具，这意味着在处理元素布局方
 
 这里我有设置 `flex-grow` 和 `flex-shrink` 为 `0` 来使固定弹性物件，并且接着使用百分比来控制弹性，正如我们在浮动布局里所使用的那样。
 
-{{EmbedGHLiveSample("css-examples/flexbox/wrapping/flex-grid.html", '100%', 650)}}
+```html live-sample___flex-grid
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+  <div>Four</div>
+  <div>Five</div>
+  <div>Six</div>
+  <div>Seven</div>
+  <div>Eight</div>
+  <div>Nine</div>
+  <div>Ten</div>
+</div>
+```
+
+```css live-sample___flex-grid
+* {
+  box-sizing: border-box;
+}
+
+.box {
+  width: 500px;
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  flex: 0 0 33.3333%;
+}
+```
+
+{{EmbedLiveSample("flex-grid")}}
 
 如果你需要弹性物件在坐标轴上对齐，用这样的方法来控制宽度就能达到这个效果。在大多数的情况下，向弹性物件增加款宽度的做法演示了你可能会比将组件切换成网格布局提供的更好体验。
 
@@ -57,7 +215,42 @@ Flexbox 被设计为一维的布局工具，这意味着在处理元素布局方
 
 正是这个间隔属性的需求，一旦实现，将为我们解决问题。适当的间隙只发生在物件的内边缘。
 
-{{EmbedGHLiveSample("css-examples/flexbox/wrapping/gaps.html", '100%', 830)}}
+```html live-sample___gaps
+<div class="wrapper">
+  <div class="box">
+    <div>One</div>
+    <div>Two</div>
+    <div>Three</div>
+    <div>Four</div>
+    <div>Five</div>
+    <div>Six</div>
+    <div>Seven</div>
+    <div>Eight</div>
+    <div>Nine</div>
+    <div>Ten</div>
+  </div>
+</div>
+```
+
+```css live-sample___gaps
+.wrapper {
+  border: 2px dotted rgb(96 139 168);
+  width: 500px;
+}
+.box {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.box > * {
+  flex: 1 1 160px;
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+}
+```
+
+{{EmbedLiveSample("gaps", "", "220px")}}
 
 ## 折叠物件
 
@@ -72,7 +265,44 @@ Flexbox 被设计为一维的布局工具，这意味着在处理元素布局方
 > [!NOTE]
 > 对下面的两个例子使用 Firefox 浏览器，因为 Chrome 和 Safari 会把折叠处理为隐藏。
 
-{{EmbedGHLiveSample("css-examples/flexbox/wrapping/visibility-collapse.html", '100%', 650)}}
+```html hidden live-sample___visibility-collapse
+<p>
+  <label><input type="checkbox" /> Toggle <code>visibility</code> value</label>
+</p>
+```
+
+```html live-sample___visibility-collapse
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div class="collapse">Three <br />has <br />extra <br />text</div>
+</div>
+```
+
+```css live-sample___visibility-collapse
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  width: 600px;
+}
+.box > * {
+  flex: 1 1 200px;
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+}
+.collapse {
+  visibility: collapse;
+}
+```
+
+```css hidden live-sample___visibility-collapse
+p:has(:checked) + div .collapse {
+  visibility: visible;
+}
+```
+
+{{EmbedLiveSample("visibility-collapse")}}
 
 当处理多行弹性容器时你会需要理解包装会在折叠*后*被重做。所以浏览器需要重做包装的行为来计算新的还留在行内方向里的被折叠物件的空间。
 
@@ -80,7 +310,55 @@ Flexbox 被设计为一维的布局工具，这意味着在处理元素布局方
 
 我已经在下一个实时例子里构建了这样的表现。你可以看到基于折叠物件的位置，伸展改变了它们所在的行。如果你加入更多的内容到第二个物件里，一旦获得了足够多的内容它就改变了行。然后首行仅仅成为和单行文本一样的高度。
 
-{{EmbedGHLiveSample("css-examples/flexbox/wrapping/wrapped-visibility-collapse.html", '100%', 750)}}
+```html hidden live-sample___wrapped-visibility-collapse
+<p>
+  <label><input type="checkbox" /> Toggle <code>visibility</code> value</label>
+</p>
+```
+
+```html live-sample___wrapped-visibility-collapse
+<div class="box">
+  <div>One</div>
+  <div>Two is the width of this sentence.</div>
+  <div class="collapse">Three <br />is <br />five <br />lines <br />tall.</div>
+  <div>Four</div>
+  <div>Five<br />Five</div>
+  <div>Six</div>
+  <div>Seven</div>
+  <div>Eight</div>
+  <div>Nine</div>
+  <div>Ten</div>
+  <div>Eleven is longer</div>
+</div>
+```
+
+```css live-sample___wrapped-visibility-collapse
+.box {
+  border: 2px dotted rgb(96 139 168);
+  width: 500px;
+  display: flex;
+  flex-wrap: wrap;
+}
+.box > * {
+  padding: 10px;
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  flex: 1 1 auto;
+  min-width: 50px;
+}
+.collapse {
+  visibility: collapse;
+}
+```
+
+```css hidden live-sample___wrapped-visibility-collapse
+p:has(:checked) + div .collapse {
+  visibility: visible;
+}
+```
+
+{{EmbedLiveSample("wrapped-visibility-collapse", "", "300")}}
 
 如果这对你的布局造成了麻烦，可能就需要重新考虑这个结构，比如，将每一行放置到分开的弹性容器里从而它们不会跨行。
 

--- a/files/zh-cn/web/css/css_flexible_box_layout/ordering_flex_items/index.md
+++ b/files/zh-cn/web/css/css_flexible_box_layout/ordering_flex_items/index.md
@@ -47,7 +47,47 @@ Flexbox 和 Grid 等新的布局方法为内容的顺序控制提供了可能。
 
 在下面的实时示例中，我添加了一种焦点样式，以便当你从一个链接到另一个标签时，可以看到突出显示的样式。如果使用`flex-direction`更改顺序，则可以看到制表符顺序如何继续遵循源中列出的项目的顺序。
 
-{{EmbedGHLiveSample("css-examples/flexbox/order/order.html", '100%', 500)}}
+```html live-sample___order
+<div class="box">
+  <div><a href="#">1</a></div>
+  <div><a href="#">2</a></div>
+  <div><a href="#">3</a></div>
+  <div><a href="#">4</a></div>
+  <div><a href="#">5</a></div>
+</div>
+```
+
+```css live-sample___order
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+}
+
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  flex-direction: row;
+}
+.box :nth-child(1) {
+  order: 2;
+}
+.box :nth-child(2) {
+  order: 3;
+}
+.box :nth-child(3) {
+  order: 1;
+}
+.box :nth-child(4) {
+  order: 3;
+}
+.box :nth-child(5) {
+  order: 1;
+}
+```
+
+{{EmbedLiveSample("order")}}
 
 与更改`flex-direction`的值不会更改项目导航到的顺序相同，更改此值不会更改绘制顺序。它仅是项目的视觉反转。
 
@@ -77,7 +117,35 @@ Flexbox 和 Grid 等新的布局方法为内容的顺序控制提供了可能。
 
 你可以在下面的实时示例中使用这些值，并查看如何更改顺序。另外，尝试将`flex-direction`更改为`row-reverse`，看看会发生什么—切换了起始行，以便从相反的一侧开始排序。
 
-{{EmbedGHLiveSample("css-examples/flexbox/order/flex-direction.html", '100%', 440)}}
+```html live-sample___flex-direction
+<div class="box">
+  <div><a href="#">One</a></div>
+  <div><a href="#">Two</a></div>
+  <div><a href="#">Three</a></div>
+</div>
+```
+
+```css live-sample___flex-direction
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+}
+
+.box > * a:focus {
+  background-color: yellow;
+  color: black;
+}
+
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  flex-direction: row-reverse;
+}
+```
+
+{{EmbedLiveSample("flex-direction")}}
 
 弹性项目默认 `order` 值为 `0`, 因此整数值大于 0 的项目，将会显示在那些未指定 `order` 值的项目之后。
 
@@ -85,7 +153,43 @@ Flexbox 和 Grid 等新的布局方法为内容的顺序控制提供了可能。
 
 在下面的实时代码示例中，我使用 Flexbox 布置了项目。通过更改在 HTML 中为其分配了类`active`，你可以更改首先显示的项目，你可以更改首先显示哪个项目，因此在布局顶部变为全宽，而在其下方显示其他项目。
 
-{{EmbedGHLiveSample("css-examples/flexbox/order/negative-order.html", '100%', 520)}}
+```html live-sample___negative-order
+<div class="box">
+  <div><a href="#">1</a></div>
+  <div><a href="#">2</a></div>
+  <div class="active"><a href="#">3</a></div>
+  <div><a href="#">4</a></div>
+  <div><a href="#">5</a></div>
+</div>
+```
+
+```css live-sample___negative-order
+* {
+  box-sizing: border-box;
+}
+
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+}
+
+.box {
+  width: 500px;
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+}
+
+.active {
+  order: -1;
+  flex: 1 0 100%;
+}
+```
+
+{{EmbedLiveSample("negative-order")}}
 
 这些项目以规范中描述的顺序修改的文档顺序显示。在显示项目之前，将考虑 order 属性的值。
 
@@ -115,6 +219,47 @@ The card is going to be our flex container, with `flex-direction` set to column.
 
 该卡将成为我们的伸缩容器，`flex-direction`设置为 column。然后，我将日期定为`-1`。这将其拉到标题上方。
 
-{{EmbedGHLiveSample("css-examples/flexbox/order/usecase-order.html", '100%', 730)}}
+```html live-sample___usecase-order
+<div class="wrapper">
+  <div class="card">
+    <h3>News item title</h3>
+    <div class="date">1 Nov 2017</div>
+    <p>This is the content of my news item. Very newsworthy.</p>
+  </div>
+  <div class="card">
+    <h3>Another title</h3>
+    <div class="date">6 Nov 2017</div>
+    <p>This is the content of my news item. Very newsworthy.</p>
+  </div>
+</div>
+```
+
+```css live-sample___usecase-order
+body {
+  font-family: sans-serif;
+}
+
+.wrapper {
+  display: flex;
+  flex: 1 1 200px;
+  gap: 1em;
+}
+
+.card {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 1em;
+  display: flex;
+  flex-direction: column;
+}
+
+.date {
+  order: -1;
+  text-align: right;
+}
+```
+
+{{EmbedLiveSample("usecase-order", "", "220px")}}
 
 这些小的调整是`order`属性有意义的情况。保持逻辑顺序为文档的阅读和制表符顺序，并以最易于访问和结构化的方式进行维护。然后使用`order`进行纯粹的视觉设计调整。这样做时，请注意不要重新排序在用户四处浏览时可能由键盘访问的项目。尤其是在使用较新的布局方法时，应确保浏览器测试包括仅使用键盘而不是鼠标或触摸屏来测试站点。你将快速查看你的开发选择是否使绕过内容变得困难。

--- a/files/zh-cn/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
+++ b/files/zh-cn/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
@@ -40,7 +40,30 @@ l10n:
 - `sideways-rl`
 - `sideways-lr`
 
-{{EmbedGHLiveSample("css-examples/flexbox/relationship/writing-modes.html", '100%', 360)}}
+```html live-sample___writing-modes
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+</div>
+```
+
+```css live-sample___writing-modes
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+}
+
+.box {
+  width: 500px;
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  writing-mode: horizontal-tb;
+}
+```
+
+{{EmbedLiveSample("writing-modes")}}
 
 请注意目前只有 Firefox 支持 `sideways-rl` 和 `sideways-lr`。关于 `writing-mode` 和弹性盒子还有一些已知的问题。你可以在 [MDN 有关 writing-mode 的文档](/zh-CN/docs/Web/CSS/writing-mode)中查看有关浏览器支持的更多信息。然而，如果你打算在你的布局中使用书写模式，我们建议仔细测试结果——尤其是因为它很容易使内容变得难以阅读！
 
@@ -56,7 +79,30 @@ l10n:
 
 在下面的实时示例中，子元素应用了浮动，而它们的容器应用了 `display: flex`。如果你移除 `display: flex`，你应该会看到 `.box` 元素会折叠，因为我们没有清除浮动。这证明了浮动的存在。重新应用 `display: flex`，折叠就不会发生。这是因为元素不再浮动——它们已经变成了弹性元素。
 
-{{EmbedGHLiveSample("css-examples/flexbox/relationship/floats.html", '100%', 430)}}
+```html live-sample___floats
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+</div>
+```
+
+```css live-sample___floats
+.box {
+  width: 500px;
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+}
+
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  float: left;
+}
+```
+
+{{EmbedLiveSample("floats")}}
 
 ## 弹性盒子和网格布局
 
@@ -70,11 +116,68 @@ l10n:
 
 这个问题最直接的答案定义在规范中。弹性盒子是一维布局方法，而网格布局是二维布局方法。下面的示例使用了弹性布局。正如在[基本概念](/zh-CN/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox)文章中描述的那样，弹性元素允许换行，但是一旦这样做，每一行都会变成一个新的弹性容器。当空间被分配时，弹性盒子不会参考其他行中的元素的位置，而只是将元素彼此对齐。
 
-{{EmbedGHLiveSample("css-examples/flexbox/relationship/flex-layout.html", '100%', 750)}}
+```html live-sample___flex-layout
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+  <div>Four</div>
+  <div>Five</div>
+  <div>Six</div>
+  <div>Seven</div>
+</div>
+```
+
+```css live-sample___flex-layout
+.box {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  flex-wrap: wrap;
+  padding: 1em;
+}
+
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 1em;
+  flex: 1 1 200px;
+}
+```
+
+{{EmbedLiveSample("flex-layout", "", "300px")}}
 
 如果我们使用网格布局创建一个非常相似的布局，我们可以控制行和列的布局。
 
-{{EmbedGHLiveSample("css-examples/flexbox/relationship/grid-layout.html", '100%', 700)}}
+```html live-sample___grid-layout
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+  <div>Four</div>
+  <div>Five</div>
+  <div>Six</div>
+  <div>Seven</div>
+</div>
+```
+
+```css live-sample___grid-layout
+.box {
+  border: 2px dotted rgb(96 139 168);
+  padding: 1em;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, auto));
+}
+
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  padding: 1em;
+  background-color: rgb(96 139 168 / 0.2);
+}
+```
+
+{{EmbedLiveSample("grid-layout", "", "300px")}}
 
 这些示例指出了两个布局方法之间的另一个关键区别。在网格布局中，你需要在容器上设置大部分尺寸规范，设置轨道然后将元素放入其中。在弹性盒子中，虽然你创建了弹性容器并设置了该级别的方向，但是对元素大小的任何控制都需要在元素本身之上进行。
 
@@ -103,6 +206,37 @@ l10n:
 
 此外，删除了盒子后，你就无法使用它来——例如——为嵌套的子元素添加背景色。如果你在该实时示例中删除 `display: contents`，你会看到我们要删除属性的元素的直接子元素的背景色为橙色。当盒子消失时，这个背景色也会消失。
 
-{{EmbedGHLiveSample("css-examples/flexbox/relationship/display-contents.html", '100%', 650)}}
+```html live-sample___display-contents
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div class="nested">
+    <div>Sub-item 1</div>
+    <div>Sub-item 2</div>
+  </div>
+</div>
+```
+
+```css live-sample___display-contents
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  padding: 1em;
+  background-color: rgb(96 139 168 / 0.2);
+}
+
+.box {
+  border: 2px dotted rgb(96 139 168);
+  padding: 1em;
+  display: flex;
+}
+
+.nested {
+  background-color: orange;
+  display: contents;
+}
+```
+
+{{EmbedLiveSample("display-contents")}}
 
 浏览器对 `display:contents` 的支持是有限的，这个示例需要相应支持才能正常工作。Firefox 已经支持了 `display: contents`，而 Chrome 正在实现该值。一旦有了更好的浏览器支持，这个特性在需要语义标记但又不想显示默认生成的盒子的情况下将非常有用。

--- a/files/zh-cn/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
+++ b/files/zh-cn/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
@@ -27,7 +27,42 @@ l10n:
 
 在下面的示例中，我们通过使用 `justify-content: space-between` 使元素之间拥有相同的空间，让各元素都以其自身的尺寸展示。你可以通过 `space-around`（或 `space-evenly`，如果支持）值来改变分布空间的方式。你也可以使用 `flex-start` 让空间排布在所有元素末尾。使用 `flex-end` 让空间排布在所有元素之前，`center` 可以居中导航元素。
 
-{{EmbedGHLiveSample("css-examples/flexbox/use-cases/navigation.html", '100%', 550)}}
+```html live-sample___navigation
+<nav>
+  <ul>
+    <li><a href="#">Page 1</a></li>
+    <li><a href="#">Page 2</a></li>
+    <li><a href="#">Page 3 is longer</a></li>
+    <li><a href="#">Page 4</a></li>
+  </ul>
+</nav>
+```
+
+```css live-sample___navigation
+nav {
+  border: 2px solid #eeeeee;
+}
+
+nav a {
+  text-decoration: none;
+  color: #000;
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+  display: block;
+}
+
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: space-between;
+}
+```
+
+{{EmbedLiveSample("navigation")}}
 
 ### 让元素自己处理空间分布
 
@@ -37,7 +72,44 @@ l10n:
 
 尝试将以下实时示例中的 `flex: auto` 修改为 `flex: 1`。这是 `flex: 1 1 0` 的简写，会导致所有的元素变得等宽，因为它们都基于 flex-basis 为 0 的情况（允许所有的空间被均匀分配）。
 
-{{EmbedGHLiveSample("css-examples/flexbox/use-cases/navigation-flex.html", '100%', 550)}}
+```html live-sample___navigation-flex
+<nav>
+  <ul>
+    <li><a href="#">Page 1</a></li>
+    <li><a href="#">Page 2</a></li>
+    <li><a href="#">Page 3 is longer</a></li>
+    <li><a href="#">Page 4</a></li>
+  </ul>
+</nav>
+```
+
+```css live-sample___navigation-flex
+nav {
+  border: 2px solid #eeeeee;
+}
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+}
+
+nav a {
+  text-decoration: none;
+  color: #000;
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+  display: block;
+}
+
+nav li {
+  flex: auto;
+}
+```
+
+{{EmbedLiveSample("navigation-flex")}}
 
 ## 拆分导航
 
@@ -45,7 +117,46 @@ l10n:
 
 元素在主轴上按照弹性盒子的初始行为 `flex-start` 进行对齐。使用 [`gap`](/zh-CN/docs/Web/CSS/gap) 属性以在元素之间创建间隔。同时我们为最后需要右对齐的元素添加自动左边距以对齐它们。你可以将那个类转移到其他元素上以改变分割作用的位置。
 
-{{EmbedGHLiveSample("css-examples/flexbox/use-cases/split-navigation.html", '100%', 550)}}
+```html live-sample___split-navigation
+<nav>
+  <ul>
+    <li><a href="#">Page 1</a></li>
+    <li><a href="#">Page 2</a></li>
+    <li><a href="#">Page 3 is longer</a></li>
+    <li class="push-right"><a href="#">Page 4</a></li>
+  </ul>
+</nav>
+```
+
+```css live-sample___split-navigation
+nav {
+  border: 2px solid #eeeeee;
+}
+
+nav a {
+  text-decoration: none;
+  color: #000;
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+  display: block;
+}
+
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 20px;
+}
+
+.push-right {
+  margin-left: auto;
+}
+```
+
+{{EmbedLiveSample("split-navigation")}}
 
 ## 元素居中
 
@@ -53,7 +164,31 @@ l10n:
 
 你可以修改对齐方式，用 `flex-start` 使元素在开头对齐或者用 `flex-end` 使元素在末端对齐。
 
-{{EmbedGHLiveSample("css-examples/flexbox/use-cases/center.html", '100%', 700)}}
+```html live-sample___center
+<div class="box">
+  <div></div>
+</div>
+```
+
+```css live-sample___center
+.box {
+  height: 300px;
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.box div {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  width: 100px;
+  height: 100px;
+}
+```
+
+{{EmbedLiveSample("center", "", "320px")}}
 
 在未来，我们可能不需要仅为了元素的居中而将容器转变为弹性盒容器，因为盒对齐属性最终会在块布局中实现。但是现在，假如你想在一个元素中居中另一个元素，弹性盒布局是一个很好的选择。在上面的例子中，将一个容器放入弹性盒容器之后，要么在父级元素上使用 `align-items`，要么对弹性元素本身使用 `align-self`。
 
@@ -65,7 +200,56 @@ l10n:
 
 弹性盒就能解决这个问题。我们为卡片创建一个弹性容器，并启用 {{cssxref("flex-direction")}}`: column`。然后我们在为内容区域启用 `flex: 1`（`flex: 1 1 0` 的缩略形式），这个元素就可以在 `flex-basis` 为 0 的基础上伸缩。因为这是唯一一个可以伸展的元素，它会占据所有在弹性容器中可以占据的空间，同时将页脚推至底部。如果你移除示例中的 `flex` 属性你就会看见页脚回到了内容的底部。
 
-{{EmbedGHLiveSample("css-examples/flexbox/use-cases/cards.html", '100%', 800)}}
+```html live-sample___cards
+<div class="cards">
+  <div class="card">
+    <div class="content">
+      <p>This card doesn't have much content.</p>
+    </div>
+    <footer>Card footer</footer>
+  </div>
+  <div class="card">
+    <div class="content">
+      <p>
+        This card has a lot more content which means that it defines the height
+        of the container the cards are in. I've laid the cards out using grid
+        layout, so the cards themselves will stretch to the same height.
+      </p>
+    </div>
+    <footer>Card footer</footer>
+  </div>
+</div>
+```
+
+```css live-sample___cards
+body {
+  font-family: sans-serif;
+}
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-gap: 10px;
+}
+
+.card {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+}
+
+.card .content {
+  padding: 10px;
+  flex: 1 1 auto;
+}
+
+.card footer {
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+}
+```
+
+{{EmbedLiveSample("cards", "", "280px")}}
 
 ## 媒体对象
 
@@ -75,7 +259,39 @@ l10n:
 
 在下面的实时示例中，你可以看到我们的媒体对象。使用对齐属性来将交叉轴上的元素对齐到 `flex-start`，然后为 `.content` 弹性元素设置为 `flex: 1`。与上面的列布局卡片模式一样，启用 `flex: 1` 表示这部分卡片可以延伸。
 
-{{EmbedGHLiveSample("css-examples/flexbox/use-cases/media.html", '100%', 600)}}
+```html live-sample___media
+<div class="media">
+  <div class="image">
+    <img
+      alt="A colorful balloon against a blue sky"
+      src="https://mdn.github.io/shared-assets/images/examples/balloon.jpg" />
+  </div>
+  <div class="content">
+    This is the content of my media object. Items directly inside the flex
+    container will be aligned to flex-start.
+  </div>
+</div>
+```
+
+```css live-sample___media
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.media {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  align-items: flex-start;
+}
+
+.media .content {
+  flex: 1;
+  padding: 10px;
+}
+```
+
+{{EmbedLiveSample("media", "", "320px")}}
 
 在这个实例中，你可能想要尝试的一些事情与你想在设计中约束媒体对象的不同方式有关。
 
@@ -117,7 +333,43 @@ l10n:
 
 要切换媒体对象的显示方式——使图像位于右侧，内容位于左侧，我们可以将 `flex-direction` 属性设置为 `row-reverse`。媒体对象现在以另一种方式显示。我在实时示例中通过在现有的 `.media` 类旁边添加一个 `flipped` 类来实现这一点。这意味着你可以通过从 HTML 中删除该类来查看显示方式的变化。
 
-{{EmbedGHLiveSample("css-examples/flexbox/use-cases/media-flipped.html", '100%', 650)}}
+```html live-sample___media-flipped
+<div class="media flipped">
+  <div class="image">
+    <img
+      alt="A colorful balloon against a blue sky"
+      src="https://mdn.github.io/shared-assets/images/examples/balloon.jpg" />
+  </div>
+  <div class="content">
+    This is the content of my media object. Items directly inside the flex
+    container will be aligned to flex-start.
+  </div>
+</div>
+```
+
+```css live-sample___media-flipped
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.media {
+  border: 2px dotted rgb(96 139 168);
+  display: flex;
+  align-items: flex-start;
+}
+
+.flipped {
+  flex-direction: row-reverse;
+}
+
+.media .content {
+  flex: 1;
+  padding: 10px;
+}
+```
+
+{{EmbedLiveSample("media-flipped", "", "320px")}}
 
 ## 表单控件
 
@@ -129,7 +381,45 @@ l10n:
 
 你可以像我们将按钮放在右侧一样轻松地在左侧添加标签或图标。我们添加了一个标签，除了一些背景颜色的样式外，我们不需要改变布局。现在，可伸缩的输入字段有了更少的空间，但它使用了两个项目占据空间后剩下的空间。
 
-{{EmbedGHLiveSample("css-examples/flexbox/use-cases/label-input-button.html", '100%', 550)}}
+```html live-sample___label-input-button
+<form class="example">
+  <div class="wrapper">
+    <label for="text">Label</label>
+    <input id="text" type="text" />
+    <input type="submit" value="Send" />
+  </div>
+</form>
+```
+
+```css live-sample___label-input-button
+* {
+  font: 1.1em sans-serif;
+}
+
+.wrapper {
+  display: flex;
+  border: 1px solid rgb(96 139 168);
+}
+.wrapper > * {
+  padding: 10px;
+  border: none;
+  color: #fff;
+}
+.wrapper > input[type="text"] {
+  background-color: rgb(96 139 168 / 0.5);
+  border-right: 1px solid rgb(96 139 168);
+  flex: 1 1 auto;
+}
+.wrapper input[type="submit"] {
+  background-color: rgb(96 139 168);
+  color: #fff;
+}
+.wrapper label {
+  background-color: #666;
+}
+```
+
+{{EmbedLiveSample("label-input-button")}}
 
 像这样的模式可以让你更容易地为你的设计创建一系列表单元素，这些元素可以轻松地适应额外的元素的添加。你可以将不可增长的元素和可增长的元素混合在一起以充分利用弹性盒的灵活性。
 


### PR DESCRIPTION
### Description

I'm porting over some of the embedded examples into translated content.

I look at embeds like `{{embedgh.*css-examples.*}}`

### Motivation

These are already live samples in en-US.

### For reviewers

The easiest way to review is to compare with en-US version in the previews. The actual code is copied across from the content repo, so there's no technical review to do, just a quick verify that it looks okay!

### Additional details

- [x] https://github.com/mdn/mdn/issues/597