### PR TITLE
ci(pr-review-companion): access step outputs via env vars

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -104,17 +104,19 @@ jobs:
         if: steps.check.outputs.HAS_ARTIFACT
         env:
           BUILD_OUT_ROOT: ${{ github.workspace }}/build
+          PREFIX: ${{ steps.check.outputs.PREFIX }}
+          PR_NUMBER: ${{ steps.check.outputs.PR_NUMBER }}
         working-directory: content
         run: |
           echo "Pull request:"
           echo "https://github.com/mdn/translated-content/pull/${{ steps.check.outputs.PR_NUMBER }}"
 
           node scripts/analyze-pr-build.js \
-            --prefix="${{ steps.check.outputs.PREFIX }}" \
+            --prefix="$PREFIX" \
             --analyze-flaws \
             --analyze-dangerous-content \
             --github-token="${{ secrets.GITHUB_TOKEN }}" \
             --repo=$GITHUB_REPOSITORY \
-            --pr-number="${{ steps.check.outputs.PR_NUMBER }}" \
+            --pr-number="$PR_NUMBER" \
             --diff-file=$BUILD_OUT_ROOT/DIFF \
             $BUILD_OUT_ROOT


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updates the `pr-review-companion` to access step outputs via environment variables.

### Motivation

Reduces the risk of command injection.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Same as:

- https://github.com/mdn/content/pull/38947

Follow-up of:

- https://github.com/mdn/translated-content/pull/26462