### PR TITLE
chore(css): Copy embedlivesamples from en-US content

### DIFF
--- a/files/zh-cn/web/css/basic-shape/circle/index.md
+++ b/files/zh-cn/web/css/basic-shape/circle/index.md
@@ -81,7 +81,36 @@ clip-path: circle(6rem at 12rem 8rem);
 
 在下面的示例中，{{cssxref("shape-outside")}} 属性的值为 `circle(50%)`，用于在浮动元素周围使文本环绕成圆形。
 
-{{EmbedGHLiveSample("css-examples/shapes/overview/circle.html", '100%', 720)}}
+```html live-sample___circle
+<div class="box">
+  <img
+    alt="A hot air balloon"
+    src="https://mdn.github.io/shared-assets/images/examples/round-balloon.png" />
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery. Before that night—a memorable night,
+    as it was to prove—hundreds of millions of people had watched the rising
+    smoke-wreaths of their fires without drawing any special inspiration from
+    the fact.
+  </p>
+</div>
+```
+
+```css live-sample___circle
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+img {
+  float: left;
+  shape-outside: circle(50%);
+}
+```
+
+{{EmbedLiveSample("circle", "", "300px")}}
 
 ## 规范
 

--- a/files/zh-cn/web/css/basic-shape/ellipse/index.md
+++ b/files/zh-cn/web/css/basic-shape/ellipse/index.md
@@ -79,13 +79,73 @@ shape-outside: ellipse(closest-side farthest-side at 30%);
 
 这个示例显示了一个 x 半径为 40%，y 半径为 50% 的椭圆，位置在左边。这意味着椭圆的中心位于框的左边缘，使我们的文本围绕其周围形成一个半椭圆形状。你可以更改这些值来查看椭圆如何变化。
 
-{{EmbedGHLiveSample("css-examples/shapes/basic-shape/ellipse.html", '100%', 800)}}
+```html live-sample___ellipse
+<div class="box">
+  <div class="shape"></div>
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery. Before that night—a memorable night,
+    as it was to prove—hundreds of millions of people had watched the rising
+    smoke-wreaths of their fires without drawing any special inspiration from
+    the fact.
+  </p>
+</div>
+```
+
+```css live-sample___ellipse
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.shape {
+  float: left;
+  shape-outside: ellipse(40% 50% at left);
+  margin: 20px;
+  width: 100px;
+  height: 200px;
+}
+```
+
+{{EmbedLiveSample("ellipse", "", "300px")}}
 
 ### 使用 closest-side / farthest-side 值
 
 `closest-side` 和 `farthest-side` 的关键字值对于基于浮动元素参考框大小创建快速椭圆形状非常有用。
 
-{{EmbedGHLiveSample("css-examples/shapes/basic-shape/ellipse-keywords.html", '100%', 800)}}
+```html live-sample___ellipse-keywords
+<div class="box">
+  <div class="shape"></div>
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery. Before that night—a memorable night,
+    as it was to prove—hundreds of millions of people had watched the rising
+    smoke-wreaths of their fires without drawing any special inspiration from
+    the fact.
+  </p>
+</div>
+```
+
+```css live-sample___ellipse-keywords
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.shape {
+  float: left;
+  shape-outside: ellipse(closest-side farthest-side at 30%);
+  margin: 20px;
+  width: 100px;
+  height: 140px;
+}
+```
+
+{{EmbedLiveSample("ellipse-keywords", "", "300px")}}
 
 ## 规范
 

--- a/files/zh-cn/web/css/css_animations/index.md
+++ b/files/zh-cn/web/css/css_animations/index.md
@@ -11,7 +11,215 @@ CSS 动画模块（CSS Animation）可以让你通过使用关键帧对 CSS 属�
 
 要查看下面方框中的动画，请点击复选框“Play the animation”或将光标悬停在方框上。当动画激活时，顶部的云会改变形状，雪花会落下，底部的雪量会上升。要暂停动画，请取消复选框或将你的光标从盒子上移开。
 
-{{EmbedGHLiveSample("css-examples/modules/animation.html", '100%', 650)}}
+```html hidden live-sample___animation
+<!-- See aria-label: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label -->
+<input
+  type="checkbox"
+  id="animate"
+  aria-label="Toggle the play state of the animation" />
+<label for="animate">the animation</label>
+<div class="root">
+  <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i
+  ><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i
+  ><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i
+  ><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i
+  ><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+  <div class="cloud"></div>
+  <div class="ground"></div>
+</div>
+```
+
+```css hidden live-sample___animation
+i {
+  display: inline-block;
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  animation: falling 3s linear 0s infinite backwards;
+  /* Snowflakes are made with CSS linear gradients (https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients) */
+  background-image:
+    linear-gradient(180deg, transparent 40%, white 40% 60%, transparent 60%),
+    linear-gradient(90deg, transparent 40%, white 40% 60%, transparent 60%),
+    linear-gradient(45deg, transparent 43%, white 43% 57%, transparent 57%),
+    linear-gradient(135deg, transparent 43%, white 43% 57%, transparent 57%);
+}
+i:nth-of-type(4n) {
+  /* Using tree structural pseudo-classes to create randomness - https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-of-type */
+  height: 30px;
+  width: 30px;
+  transform-origin: right -30px;
+}
+i:nth-of-type(4n + 1) {
+  height: 24px;
+  width: 24px;
+  transform-origin: left 30px;
+}
+i:nth-of-type(4n + 2) {
+  height: 10px;
+  width: 10px;
+  transform-origin: -30px 0;
+}
+i:nth-of-type(4n + 3) {
+  height: 40px;
+  width: 40px;
+  transform-origin: -50px 0;
+}
+i:nth-of-type(4n) {
+  animation-duration: 5.3s;
+  animation-iteration-count: 12;
+  transform-origin: -10px -20px;
+}
+i:nth-of-type(4n + 1) {
+  animation-duration: 3.1s;
+  animation-iteration-count: 20;
+  transform-origin: 10px -20px;
+}
+i:nth-of-type(4n + 2) {
+  animation-duration: 1.7s;
+  animation-iteration-count: 35;
+  transform-origin: right -20px;
+}
+i:nth-of-type(3n) {
+  animation-delay: 2.3s;
+}
+i:nth-of-type(3n + 1) {
+  animation-delay: 1.5s;
+}
+i:nth-of-type(3n + 2) {
+  animation-delay: 3.4s;
+}
+i:nth-of-type(5n) {
+  animation-timing-function: ease-in-out;
+}
+i:nth-of-type(5n + 1) {
+  animation-timing-function: ease-out;
+}
+i:nth-of-type(5n + 2) {
+  animation-timing-function: ease;
+}
+i:nth-of-type(5n + 3) {
+  animation-timing-function: ease-in;
+}
+i:nth-of-type(5n + 4) {
+  animation-timing-function: linear;
+}
+i:nth-of-type(11n) {
+  animation-timing-function: cubic-bezier(0.2, 0.3, 0.8, 0.9);
+}
+i:nth-of-type(7n) {
+  opacity: 0.5;
+}
+i:nth-of-type(7n + 2) {
+  opacity: 0.3;
+}
+i:nth-of-type(7n + 4) {
+  opacity: 0.7;
+}
+i:nth-of-type(7n + 6) {
+  opacity: 0.6;
+  animation-timing-function: ease-in;
+  transform-origin: left 10px;
+}
+i:nth-of-type(7n + 1) {
+  opacity: 0.8;
+}
+
+.root {
+  height: 580px;
+  background-color: skyblue;
+  border: 1px solid darkgrey;
+  position: relative;
+  overflow: hidden;
+}
+.ground,
+.cloud {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  background-repeat: no-repeat;
+}
+.cloud {
+  width: 100%;
+  height: 150px;
+  background: #ffffff;
+  border-radius: 0 0 90px 33% / 0 0 45px 50px;
+  box-shadow:
+    5px 15px 15px white,
+    -5px 15px 15px white,
+    0 20px 20px rgb(125 125 125 / 0.5);
+  animation:
+    clouds ease 5s alternate infinite 0.2s,
+    wind ease-out 4s alternate infinite;
+}
+.ground {
+  bottom: 0;
+  background-image: linear-gradient(to top, #fff 97%, 99%, #bbb 100%);
+  background-position: center 580px;
+  animation: snowfall linear 300s forwards;
+  border: 1px solid grey;
+  /* Put the ground into a 3D rendering context (because the snow flakes are in a 3d rendering context) */
+  transform: translate3d(0, 0, 0);
+}
+
+@keyframes snowfall {
+  from {
+    background-position: center 580px;
+  }
+  to {
+    background-position: center 280px;
+  }
+}
+
+@keyframes clouds {
+  from {
+    border-radius: 0 0 90px 33% / 0 0 45px 50px;
+  }
+  to {
+    border-radius: 0 0 40px 50% / 0 0 55px 80px;
+  }
+}
+
+@keyframes wind {
+  from {
+    height: 150px;
+  }
+  to {
+    height: 100px;
+  }
+}
+
+@keyframes falling {
+  from {
+    transform: translate(0, -50px) rotate(0deg) scale(0.9, 0.9);
+  }
+  to {
+    transform: translate(30px, 600px) rotate(360deg) scale(1.1, 1.1);
+  }
+}
+
+/* By default, the animations are paused. */
+i,
+div[class] {
+  animation-play-state: paused;
+}
+/* When the div is hovered, the animation plays. Also,
+when the input is checked, the animation coming after the checked checkbox plays */
+div:hover *,
+input:checked ~ div * {
+  animation-play-state: running;
+}
+
+/* Change the content of the label that comes right after the input. Included aria-label on the label to improve accessibility. */
+input + label::before {
+  content: "Play ";
+}
+input:checked + label::before {
+  content: "Pause ";
+}
+```
+
+{{EmbedLiveSample("animation", "", "610px")}}
 
 这个动画示例使用 {{cssxref("animation-iteration-count")}} 来使雪片反复落下，{{cssxref("animation-direction")}} 使云层来回移动，{{cssxref("animation-fill-mode")}} 根据云层的移动来提高雪层，以及{{cssxref("animation-play-state")}}来暂停动画。
 

--- a/files/zh-cn/web/css/css_backgrounds_and_borders/index.md
+++ b/files/zh-cn/web/css/css_backgrounds_and_borders/index.md
@@ -19,7 +19,60 @@ box-shadow 包括内阴影和外阴影、单个或多个阴影，以及实心或
 
 此边框、背景和阴影示例由线性渐变和径向渐变组成的居中背景图像组成。一系列框阴影使边框看起来像是“弹出”的。左侧元素设置了边框图像。右侧元素具有圆角虚线边框。
 
-{{EmbedGHLiveSample("css-examples/modules/backgrounds.html", '100%', 430)}}
+```html hidden live-sample___backgrounds
+<article>
+  <div></div>
+  <div></div>
+</article>
+```
+
+```css hidden live-sample___backgrounds
+article {
+  display: flex;
+  gap: 10px;
+}
+div {
+  color: #58ade3;
+  height: 320px;
+  width: 240px;
+  padding: 20px;
+  margin: 10px;
+  border: dotted 15px; /* defaults to `currentcolor` */
+  border-radius: 100px 0;
+  background-image:
+    radial-gradient(
+      circle,
+      transparent 60%,
+      currentcolor 60% 70%,
+      transparent 70%
+    ),
+    linear-gradient(45deg, currentcolor, white),
+    linear-gradient(transparent, transparent);
+  /* the third transparent background image was added to provide space for the background color to show through */
+  background-color: currentcolor;
+  background-position: center;
+  background-size:
+    60px 60px,
+    120px 120px;
+  background-clip: content-box, content-box, padding-box;
+  box-shadow:
+    inset 5px 5px 5px rgb(0 0 0 / 0.4),
+    inset -5px -5px 5px rgb(0 0 0 / 0.4),
+    5px 5px 5px rgb(0 0 0 / 0.4),
+    -5px -5px 5px rgb(0 0 0 / 0.4);
+}
+div:first-of-type {
+  border-radius: 0;
+  border-image-source: repeating-conic-gradient(
+    from 3deg at 25% 25%,
+    currentColor 0 3deg,
+    transparent 3deg 6deg
+  );
+  border-image-slice: 30;
+}
+```
+
+{{EmbedLiveSample("backgrounds", "", "450px")}}
 
 背景图像使用 {{cssxref("background-image")}} 定义。图像使用 {{cssxref("background-position")}} 居中。为多个背景图像使用 {{cssxref("background-clip")}} 属性的不同值，使背景图像保持在内容框内。背景颜色被裁剪到填充框，防止背景通过 {{cssxref("border-image")}} 和 {{cssxref("border-style", "dotted")}} {{cssxref("border")}} 的透明部分显示出来。右侧元素中的圆角使用 {{cssxref("border-radius")}} 属性创建。使用单个 {{cssxref("box-shadow")}} 声明设置所有阴影，包括内阴影和外阴影。
 

--- a/files/zh-cn/web/css/css_box_alignment/box_alignment_in_block_abspos_tables/index.md
+++ b/files/zh-cn/web/css/css_box_alignment/box_alignment_in_block_abspos_tables/index.md
@@ -46,7 +46,36 @@ slug: Web/CSS/CSS_box_alignment/Box_alignment_in_block_abspos_tables
 
 对于许多使用场景，将块容器转换为弹性项目将为你提供所需的对齐能力。在下面的示例中，含有单个项目的容器已转换为弹性容器，以便能够使用对齐属性。
 
-{{EmbedGHLiveSample("css-examples/flexbox/alignment/intro.html", '100%', 700)}}
+```html live-sample___intro
+<div class="box">
+  <div></div>
+</div>
+```
+
+```css live-sample___intro
+.box {
+  height: 300px;
+  border: 2px dotted rgb(96 139 168);
+}
+
+.box > * {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+}
+.box {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.box div {
+  width: 100px;
+  height: 100px;
+}
+```
+
+{{EmbedLiveSample("intro", "", "320px")}}
 
 ## 参考
 

--- a/files/zh-cn/web/css/css_conditional_rules/using_feature_queries/index.md
+++ b/files/zh-cn/web/css/css_conditional_rules/using_feature_queries/index.md
@@ -21,7 +21,31 @@ CSS 特性查询是 [CSS Conditional Rules module](https://drafts.csswg.org/css-
 
 比如，若你想检测一个浏览器是否支持 `row-gap` 属性，你应当写下如下的特性查询。大部分情况下这个查询结果与你所使用的值无关——也就是如果你想仅仅检测浏览器是否支持这个 CSS 属性，那么任何有效的属性值都可以。
 
-{{EmbedGHLiveSample("css-examples/feature-queries/simple.html", '100%', 600)}}
+```html live-sample___simple
+<div class="box">
+  If your browser supports the row-gap property, the border will be dashed and
+  text will be red.
+</div>
+```
+
+```css live-sample___simple
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.box {
+  border: 4px solid blue;
+  color: blue;
+  padding: 1em;
+}
+@supports (row-gap: 10px) {
+  .box {
+    border: 4px dashed darkgreen;
+    color: red;
+  }
+}
+```
+
+{{EmbedLiveSample("simple")}}
 
 若你测试的是某个属性的新值，那么属性 - 值对中值的那一部分就更加关键。`display` 属性就是一个很好的例子。所有的浏览器都支持 `display` 属性，这可以追溯到 CSS1 中的 `display: block` 。然而 `display: flex` 和 `display: grid` 这些值是新出现的。CSS 属性经常会有额外的新值加入，所以你必须检测属性与值的事实意味着你可以检测那些值的浏览器支持性。（原文：There are often additional values added to properties in CSS, and so the fact that you have to test for property and value means that you can detect support for these values.）
 
@@ -36,7 +60,31 @@ CSS 特性查询是 [CSS Conditional Rules module](https://drafts.csswg.org/css-
 
 下述特性查询中的 CSS 规则仅会在浏览器不支持 `row-gap` 属性的情况下生效。
 
-{{EmbedGHLiveSample("css-examples/feature-queries/not.html", '100%', 600)}}
+```html live-sample___not
+<div class="box">
+  If your browser does not support row-gap, the content will be darkgreen with a
+  dashed border.
+</div>
+```
+
+```css live-sample___not
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.box {
+  border: 4px solid blue;
+  color: blue;
+  padding: 1em;
+}
+@supports not (row-gap: 10px) {
+  .box {
+    border: 4px dashed darkgreen;
+    color: darkgreen;
+  }
+}
+```
+
+{{EmbedLiveSample("not")}}
 
 ## 测试多个特性
 
@@ -50,7 +98,32 @@ CSS 特性查询是 [CSS Conditional Rules module](https://drafts.csswg.org/css-
 
 比如，若你想要应用的 CSS 需要浏览器支持 CSS Shape 与 CSS Grid，你可以创建可以同时检测这两个特性的规则。下述规则只有在浏览器同时支持 `shape-outside: circle()` 和`display: grid` 的时候才会返回 true。
 
-{{EmbedGHLiveSample("css-examples/feature-queries/and.html", '100%', 600)}}
+```html live-sample___and
+<div class="box">
+  If your browser supports <code>display: grid</code> and
+  <code>shape-outside: circle()</code>, the content will be darkgreen with a
+  dashed border.
+</div>
+```
+
+```css live-sample___and
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.box {
+  border: 4px solid blue;
+  color: blue;
+  padding: 1em;
+}
+@supports (display: grid) and (shape-outside: circle()) {
+  .box {
+    border: 4px dashed darkgreen;
+    color: darkgreen;
+  }
+}
+```
+
+{{EmbedLiveSample("and")}}
 
 你也可以使用 `or`，如果所有规则中有一个规则可以匹配那么你想应用的 CSS 样式就会被启用。
 
@@ -62,7 +135,30 @@ CSS 特性查询是 [CSS Conditional Rules module](https://drafts.csswg.org/css-
 
 你可以在测试时为任何标准属性加上浏览器引擎前缀，然后测试特定引擎的 CSS 支持性，这非常有用。
 
-{{EmbedGHLiveSample("css-examples/feature-queries/or.html", '100%', 600)}}
+```html live-sample___or
+<div class="box">
+  The text and border will be green if your browser supports font smoothing.
+</div>
+```
+
+```css live-sample___or
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.box {
+  border: 4px solid blue;
+  color: blue;
+  padding: 1em;
+}
+@supports (font-smooth: always) or (-webkit-font-smoothing: antialiased) {
+  .box {
+    border: 4px dashed darkgreen;
+    color: darkgreen;
+  }
+}
+```
+
+{{EmbedLiveSample("or")}}
 
 ## 特性查询的局限性
 

--- a/files/zh-cn/web/css/css_grid_layout/auto-placement_in_grid_layout/index.md
+++ b/files/zh-cn/web/css/css_grid_layout/auto-placement_in_grid_layout/index.md
@@ -472,7 +472,81 @@ slug: Web/CSS/CSS_grid_layout/Auto-placement_in_grid_layout
 
 尝试移除 `grid-auto-flow: dense` 这一行，以查看内容重排后在布局中留下的缺口。
 
-{{EmbedGHLiveSample("css-examples/grid/docs/autoplacement.html", '100%', 1200)}}
+```html live-sample___autoplacement
+<ul class="wrapper">
+  <li>
+    <img
+      alt="A colorful hot air balloon against a clear sky"
+      src="https://mdn.github.io/shared-assets/images/examples/balloon.jpg" />
+  </li>
+  <li class="landscape">
+    <img
+      alt="Three hot air balloons against a clear sky, as seen from the ground"
+      src="https://mdn.github.io/shared-assets/images/examples/balloons-small.jpg" />
+  </li>
+  <li class="landscape">
+    <img
+      alt="Three hot air balloons against a clear sky, as seen from the ground"
+      src="https://mdn.github.io/shared-assets/images/examples/balloons-small.jpg" />
+  </li>
+  <li class="landscape">
+    <img
+      alt="Three hot air balloons against a clear sky, as seen from the ground"
+      src="https://mdn.github.io/shared-assets/images/examples/balloons-small.jpg" />
+  </li>
+  <li>
+    <img
+      alt="A colorful hot air balloon against a clear sky"
+      src="https://mdn.github.io/shared-assets/images/examples/balloon.jpg" />
+  </li>
+  <li>
+    <img
+      alt="A colorful hot air balloon against a clear sky"
+      src="https://mdn.github.io/shared-assets/images/examples/balloon.jpg" />
+  </li>
+</ul>
+```
+
+```css hidden live-sample___autoplacement
+body {
+  font: 1.2em sans-serif;
+}
+* {
+  box-sizing: border-box;
+}
+
+.wrapper {
+  list-style: none;
+  margin: 1em auto;
+  padding: 0;
+  max-width: 800px;
+}
+.wrapper li {
+  border: 1px solid #ccc;
+}
+
+.wrapper li img {
+  display: block;
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+}
+```
+
+```css live-sample___autoplacement
+.wrapper {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(120px, 1fr));
+  gap: 10px;
+  grid-auto-flow: dense;
+}
+
+.wrapper li.landscape {
+  grid-column-end: span 2;
+}
+```
+
+{{EmbedLiveSample("autoplacement", "", "500px")}}
 
 自动定位还可以帮你布局有逻辑顺序的界面元素。下面的术语列表就是一个示例。为定义列表添加样式是一个有趣的挑战，即它的结构是扁平的，没有把成组的 `dt` 和 `dd` 元素包装起来。在示例中，我们使用自动定位来定位项目，另外还通过样式类把 `dt` 摆放在第 1 列，把 `dd` 摆放在第 2 列，以便让术语显示在一边，术语的定义显示在另一边，而不用管它们各有多少个。
 

--- a/files/zh-cn/web/css/css_inline_layout/inline_formatting_context/index.md
+++ b/files/zh-cn/web/css/css_inline_layout/inline_formatting_context/index.md
@@ -16,17 +16,95 @@ slug: Web/CSS/CSS_inline_layout/Inline_formatting_context
 
 在下面给出的例子中，带黑色边框的两个 {{HTMLElement("div")}} 元素组成了一个[区块格式化上下文](/zh-CN/docs/Web/CSS/CSS_display/Block_formatting_context)，其中的每一个单词都参与一个行内格式化上下文中。水平书写模式下的各个框水平地排列，垂直书写模式下的各个框垂直地排列。
 
-{{EmbedGHLiveSample("css-examples/inline-formatting/inline.html", '100%', 720)}}
+```html live-sample___inline
+<div class="example horizontal">One Two Three</div>
+<div class="example vertical">Four Five Six</div>
+```
+
+```css live-sample___inline
+body {
+  font: 1.2em sans-serif;
+}
+.example {
+  border: 5px solid black;
+  margin: 20px;
+}
+
+.horizontal {
+  writing-mode: horizontal-tb;
+}
+.vertical {
+  writing-mode: vertical-rl;
+}
+```
+
+{{EmbedLiveSample("inline", "", "220px")}}
 
 各个框组成了一行，而该行位于一个称为“行框（line box）”的矩形区域之中。该行框的大小将足以包含该行中所有的行内框（inline boxes）；当行内方向上没有剩余空间时，将会创建新行。因此，一个段落实际上是一系列行框的集合，这些行框在块的方向上排列。
 
 一个行内框（inline box）被分割到多行中时，margins, borders, 以及 padding 的设定均不会在断裂处生效。下例中有一个 ({{HTMLElement("span")}}) 元素，它包裹了一系列单词，占据了两行。可以看见在断裂处，`<span>` 的 border 同样发生了断裂。
 
-{{EmbedGHLiveSample("css-examples/inline-formatting/break.html", '100%', 720)}}
+```html live-sample___break
+<div class="example">
+  Before that night—
+  <span
+    >a memorable night, as it was to prove— hundreds of millions of people</span
+  >
+  had watched the rising smoke-wreaths of their fires without drawing any
+  special inspiration from the fact.
+</div>
+```
+
+```css live-sample___break
+body {
+  font: 1.2em sans-serif;
+}
+.example {
+  border: 5px solid black;
+  margin: 20px;
+}
+
+span {
+  border: 5px solid rebeccapurple;
+}
+```
+
+{{EmbedLiveSample("break")}}
 
 Margins, borders, 以及 padding 的设置，在行的方向上是生效的。在下例中，可以看见行内元素 `<span>` 的 margin，border 以及 padding 是被加上了的。
 
-{{EmbedGHLiveSample("css-examples/inline-formatting/mbp.html", '100%', 920)}}
+```html live-sample___mbp
+<div class="example horizontal">One <span>Two</span> Three</div>
+<div class="example vertical">Four <span>Five</span> Six</div>
+```
+
+```css live-sample___mbp
+body {
+  font: 1.2em sans-serif;
+}
+
+.example {
+  border: 5px solid black;
+  margin: 20px;
+}
+
+span {
+  border: 5px solid rebeccapurple;
+  padding-inline-start: 20px;
+  padding-inline-end: 40px;
+  margin-inline-start: 30px;
+  margin-inline-end: 10px;
+}
+.horizontal {
+  writing-mode: horizontal-tb;
+}
+
+.vertical {
+  writing-mode: vertical-rl;
+}
+```
+
+{{EmbedLiveSample("mbp", "", "340px")}}
 
 > [!NOTE]
 > 此处使用了 logical, flow-relative properties — {{cssxref("padding-inline-start")}}，而不是 {{cssxref("padding-left")}} — so that they work in the inline dimension whether the text is horizontal or vertical. Read more about these properties in [Logical Properties and Values](/zh-CN/docs/Web/CSS/CSS_logical_properties_and_values).
@@ -35,19 +113,116 @@ Margins, borders, 以及 padding 的设置，在行的方向上是生效的。�
 
 行内框（Inline boxes）可使用{{cssxref("vertical-align")}}属性，以不同的方式在块的方向上进行对齐（因此在垂直书写模式下，`vertical-align` 中的“vertical”根本是名不副实——此时行内框将在水平方向上进行对齐）。下例中，字号较大的文本使得第一个句子的行框变大，因此 `vertical-align` 能让行内框（inline boxes）分布于上侧或下侧。例子里用的值是 `top`, 可以试试 `middle`, `bottom`, 或 `baseline` 这些值。
 
-{{EmbedGHLiveSample("css-examples/inline-formatting/align.html", '100%', 920)}}
+```html live-sample___align
+<div class="example horizontal">
+  Before that night—<span>a memorable night</span>, as it was to prove—hundreds
+  of millions of people had watched the rising smoke-wreaths of their fires
+  without drawing any special inspiration from the fact.
+</div>
+
+<div class="example vertical">
+  Before that night—<span>a memorable night</span>, as it was to prove—hundreds
+  of millions of people had watched the rising smoke-wreaths of their fires
+  without drawing any special inspiration from the fact.
+</div>
+```
+
+```css live-sample___align
+body {
+  font: 1.2em sans-serif;
+}
+
+span {
+  font-size: 200%;
+  vertical-align: top;
+}
+
+.example {
+  border: 5px solid black;
+  margin: 20px;
+  inline-size: 400px;
+}
+
+.horizontal {
+  writing-mode: horizontal-tb;
+}
+
+.vertical {
+  writing-mode: vertical-rl;
+}
+```
+
+{{EmbedLiveSample("align", "", "640px")}}
 
 ## 在行内方向上对齐
 
 如果行内方向上还有额外空间，那么 {{cssxref("text-align")}} 可用于将各行内框（inline boxes）在行框（line box）内对齐。可以试试把 `text-align` 的值改成 `end` 。
 
-{{EmbedGHLiveSample("css-examples/inline-formatting/text-align.html", '100%', 920)}}
+```html live-sample___text-align
+<div class="example horizontal">One Two Three</div>
+<div class="example vertical">Four Five Six</div>
+```
+
+```css hidden live-sample___text-align
+body {
+  font: 1.2em sans-serif;
+}
+
+.example {
+  border: 5px solid black;
+  margin: 20px;
+}
+
+.horizontal {
+  writing-mode: horizontal-tb;
+}
+
+.vertical {
+  writing-mode: vertical-rl;
+}
+```
+
+```css live-sample___text-align
+.example {
+  text-align: center;
+  inline-size: 250px;
+}
+```
+
+{{EmbedLiveSample("text-align", "", "350px")}}
 
 ## 浮动造成的效果
 
 在行内方向上，各行框（Line Boxes）通常具有相同的尺寸，即在水平书写模式下，它们有同样的宽度；在垂直书写模式下，它们有同样的高度。但是，如果同一个块格式化上下文中存在一个 {{cssxref("float")}}，则这个浮动元素将导致包裹了它的各行框变短。
 
-{{EmbedGHLiveSample("css-examples/flow/formatting-contexts/float.html", '100%', 720)}}
+```html live-sample___float
+<div class="box">
+  <div class="float">I am a floated box!</div>
+  <p>I am content inside the container.</p>
+</div>
+```
+
+```css live-sample___float
+body {
+  font: 1.2em sans-serif;
+}
+
+.box {
+  background-color: rgb(224 206 247);
+  border: 5px solid rebeccapurple;
+}
+
+.float {
+  float: left;
+  width: 250px;
+  height: 150px;
+  background-color: white;
+  border: 1px solid black;
+  padding: 10px;
+}
+```
+
+{{EmbedLiveSample("float", "", "200px")}}
 
 ## 参见
 

--- a/files/zh-cn/web/css/css_logical_properties_and_values/basic_concepts_of_logical_properties_and_values/index.md
+++ b/files/zh-cn/web/css/css_logical_properties_and_values/basic_concepts_of_logical_properties_and_values/index.md
@@ -25,7 +25,52 @@ slug: Web/CSS/CSS_logical_properties_and_values/Basic_concepts_of_logical_proper
 
 你可以在下面的运行实例里尝试一下。把 `.grid` 的 `writing-mode` 从 `vertical-rl` 改成 `horizontal-tb`，看看不同的属性是怎么改变布局的。
 
-{{EmbedGHLiveSample("css-examples/logical/intro-grid-example.html", "100%", 700)}}
+```html live-sample___intro-grid-example
+<div class="grid">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+  <div>Four</div>
+</div>
+```
+
+```css hidden live-sample___intro-grid-example
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: minmax(100px, auto);
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+}
+
+.grid > * {
+  border-radius: 5px;
+  border: 2px solid rgb(96 139 168 / 0.4);
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+}
+
+.grid :nth-child(1) {
+  align-self: start;
+}
+
+.grid :nth-child(2) {
+  justify-self: end;
+}
+```
+
+```css live-sample___intro-grid-example
+.grid {
+  writing-mode: vertical-rl;
+  inline-size: 400px;
+}
+```
+
+{{EmbedLiveSample("intro-grid-example", "", "450px")}}
 
 在不是从横排上到下的书写模式里做网站，或者在用书写模式做创意的时候，能够对应到内容的流向上是非常合理的。
 

--- a/files/zh-cn/web/css/css_logical_properties_and_values/floating_and_positioning/index.md
+++ b/files/zh-cn/web/css/css_logical_properties_and_values/floating_and_positioning/index.md
@@ -38,7 +38,58 @@ slug: Web/CSS/CSS_logical_properties_and_values/Floating_and_positioning
 
 在下面的例子里，我有两个盒子——第一个用 `float: left` 设置了浮动，第二个用了 `float: inline-start`。如果把 `writing-mode` 改成 `vertical-rl` 或者把 `direction` 改成 `rtl`，你会看到浮动到左侧的盒子总是贴在左侧，而浮动到 `inline-start` 的元素随着 `direction` 和 `writing-mode` 变动。
 
-{{EmbedGHLiveSample("css-examples/logical/float.html", "100%", 700)}}
+```html live-sample___float
+<div class="container">
+  <div class="inner">
+    <div class="physical box"></div>
+    Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+    kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter
+    purslane kale.
+  </div>
+  <div class="inner">
+    <div class="logical box"></div>
+    Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+    kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter
+    purslane kale.
+  </div>
+</div>
+```
+
+```css hidden live-sample___float
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.container {
+  display: flex;
+}
+
+.box {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+  margin: 10px;
+  width: 100px;
+  height: 100px;
+}
+```
+
+```css live-sample___float
+.inner {
+  /* direction: rtl; */
+  /* writing-mode: vertical-rl; */
+}
+
+.physical {
+  float: left;
+}
+
+.logical {
+  float: inline-start;
+}
+```
+
+{{EmbedLiveSample("float", "", "220px")}}
 
 ## 示例：定位布局的偏移属性
 
@@ -50,7 +101,58 @@ slug: Web/CSS/CSS_logical_properties_and_values/Floating_and_positioning
 
 在下面的例子里，带灰色点状边框的区域设置了 `position: relative`。为了在这个区域里用绝对定位放置蓝色盒子，我用了 `inset-block-start` 和 `inset-inline-end` 属性。把 `writing-mode` 属性改成 `vertical-rl`，或者加上 `direction: rtl`，看看相对于流的盒子是怎么根据文本方向保持位置的。
 
-{{EmbedGHLiveSample("css-examples/logical/positioning-inset.html", "100%", 700)}}
+```html live-sample___positioning-inset
+<div class="container">
+  <div class="inner">
+    <div class="physical box"></div>
+  </div>
+  <div class="inner">
+    <div class="logical box"></div>
+  </div>
+</div>
+```
+
+```css hidden live-sample___positioning-inset
+.container {
+  display: flex;
+}
+
+.inner {
+  width: 200px;
+  height: 200px;
+  position: relative;
+  border: 2px dotted grey;
+}
+
+.box {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+  width: 100px;
+  height: 100px;
+}
+```
+
+```css live-sample___positioning-inset
+.inner {
+  writing-mode: horizontal-tb;
+}
+
+.physical {
+  position: absolute;
+  top: 20px;
+  right: 0;
+}
+
+.logical {
+  position: absolute;
+  inset-block-start: 20px;
+  inset-inline-end: 0;
+}
+```
+
+{{EmbedLiveSample("positioning-inset", "", "250px")}}
 
 ## 新的二值和四值简写属性
 
@@ -66,6 +168,43 @@ slug: Web/CSS/CSS_logical_properties_and_values/Floating_and_positioning
 
 如果把 `direction` 改成 `rtl`，你会看到第一个块还是右对齐的，但是第二个跑到了在左边的逻辑行末。
 
-{{EmbedGHLiveSample("css-examples/logical/text-align.html", "100%", 700)}}
+```html live-sample___text-align
+<div class="container">
+  <div class="inner physical">Aligned text</div>
+  <div class="inner logical">Aligned text</div>
+</div>
+```
+
+```css hidden live-sample___text-align
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.container {
+  display: flex;
+}
+
+.inner {
+  width: 200px;
+  border: 2px dotted grey;
+  padding: 10px;
+}
+```
+
+```css live-sample___text-align
+.inner {
+  direction: ltr;
+}
+
+.physical {
+  text-align: right;
+}
+
+.logical {
+  text-align: end;
+}
+```
+
+{{EmbedLiveSample("text-align")}}
 
 相比用实体方向对齐，在使用盒对齐的时候用首和末得到的效果更一致。

--- a/files/zh-cn/web/css/css_logical_properties_and_values/margins_borders_padding/index.md
+++ b/files/zh-cn/web/css/css_logical_properties_and_values/margins_borders_padding/index.md
@@ -73,7 +73,69 @@ slug: Web/CSS/CSS_logical_properties_and_values/Margins_borders_padding
 
 你也可以试试把 `writing-mode` 从 `horizontal-tb` 改成 `vertical-rl`。注意到第一个盒子的外边距还是保持不动，但是第二个的跟着文本的行内方向四处切换。
 
-{{EmbedGHLiveSample("css-examples/logical/margin-longhands.html", "100%", 700)}}
+```html live-sample___margin-longhands
+<div class="container">
+  <div class="inner">
+    <div class="physical box">
+      margin-top: 5px<br />
+      margin-right: 0<br />
+      margin-bottom: 2em<br />
+      margin-left: 50px
+    </div>
+  </div>
+  <div class="inner">
+    <div class="logical box">
+      margin-block-start: 5px<br />
+      margin-inline-end: 0<br />
+      margin-block-end: 2em<br />
+      margin-inline-start: 50px
+    </div>
+  </div>
+</div>
+```
+
+```css hidden live-sample___margin-longhands
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.container {
+  display: flex;
+}
+.inner {
+  border: 2px dotted grey;
+}
+.box {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+  width: 220px;
+  height: 220px;
+}
+```
+
+```css live-sample___margin-longhands
+.box {
+  writing-mode: horizontal-tb;
+  direction: ltr;
+}
+
+.physical {
+  margin-top: 5px;
+  margin-right: 0;
+  margin-bottom: 2em;
+  margin-left: 50px;
+}
+
+.logical {
+  margin-block-start: 5px;
+  margin-inline-end: 0;
+  margin-block-end: 2em;
+  margin-inline-start: 50px;
+}
+```
+
+{{EmbedLiveSample("margin-longhands", "", "300px")}}
 
 ### 外边距简写属性
 
@@ -97,7 +159,64 @@ slug: Web/CSS/CSS_logical_properties_and_values/Margins_borders_padding
 
 你也可以试试把 `writing-mode` 从 `horizontal-tb` 改成 `vertical-rl`。注意到第一个盒子的内边距还是保持不动，但是第二个的跟着文本的行内方向四处切换。
 
-{{EmbedGHLiveSample("css-examples/logical/padding-longhands.html", "100%", 700)}}
+```html live-sample___padding-longhands
+<div class="container">
+  <div class="physical box">
+    padding-top: 5px<br />
+    padding-right: 0<br />
+    padding-bottom: 2em<br />
+    padding-left: 50px
+  </div>
+
+  <div class="logical box">
+    padding-block-start: 5px<br />
+    padding-inline-end: 0<br />
+    padding-block-end: 2em<br />
+    padding-inline-start: 50px
+  </div>
+</div>
+```
+
+```css hidden live-sample___padding-longhands
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.container {
+  display: flex;
+}
+.box {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  margin: 10px;
+  width: 220px;
+  height: 220px;
+}
+```
+
+```css live-sample___padding-longhands
+.box {
+  writing-mode: horizontal-tb;
+  direction: ltr;
+}
+
+.physical {
+  padding-top: 5px;
+  padding-right: 0;
+  padding-bottom: 2em;
+  padding-left: 50px;
+}
+
+.logical {
+  padding-block-start: 5px;
+  padding-inline-end: 0;
+  padding-block-end: 2em;
+  padding-inline-start: 50px;
+}
+```
+
+{{EmbedLiveSample("padding-longhands", "", "300px")}}
 
 ### 内边距简写属性
 
@@ -117,7 +236,56 @@ slug: Web/CSS/CSS_logical_properties_and_values/Margins_borders_padding
 
 下面的演示用了几个全称属性和三个简写属性。和其他演示一样，试试把 `direction` 属性改成 `rtl`，让盒子显示在从右到左的行内方向里，或者把 `writing-mode` 从 `horizontal-tb` 改成 `vertical-rl`。
 
-{{EmbedGHLiveSample("css-examples/logical/border-longhands.html", "100%", 700)}}
+```html live-sample___border-longhands
+<div class="container">
+  <div class="physical box">Borders using physical properties.</div>
+  <div class="logical box">Borders using logical properties.</div>
+</div>
+```
+
+```css hidden live-sample___border-longhands
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.container {
+  display: flex;
+}
+.box {
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  margin: 10px;
+  width: 220px;
+  height: 220px;
+}
+```
+
+```css live-sample___border-longhands
+.box {
+  writing-mode: horizontal-tb;
+  direction: ltr;
+}
+
+.physical {
+  border-top: 2px solid hotpink;
+  border-right-style: dotted;
+  border-right-color: goldenrod;
+  border-right-width: 5px;
+  border-bottom: 4px double black;
+  border-left: none;
+}
+
+.logical {
+  border-block-start: 2px solid hotpink;
+  border-inline-end-style: dotted;
+  border-inline-end-color: goldenrod;
+  border-inline-end-width: 5px;
+  border-block-end: 4px double black;
+  border-inline-start: none;
+}
+```
+
+{{EmbedLiveSample("border-longhands", "", "260px")}}
 
 ### 新的边框简写属性
 

--- a/files/zh-cn/web/css/css_logical_properties_and_values/sizing/index.md
+++ b/files/zh-cn/web/css/css_logical_properties_and_values/sizing/index.md
@@ -30,7 +30,49 @@ slug: Web/CSS/CSS_logical_properties_and_values/Sizing
 
 在下面的运行实例里，我把书写模式设置成了 `horizontal-tb`。把它改成 `vertical-rl`，你会看到第一个例子——用的 `width` 和 `height`——尽管文本变成竖排，但是在每个方向上的尺寸保持不变。第二个例子——用的 `inline-size` 和 `block-size`——会跟着文本的方向变化，就像旋转了整个块。
 
-{{EmbedGHLiveSample("css-examples/logical/size-inline-block.html", '100%', 500)}}
+```html live-sample___size-inline-block
+<div class="container">
+  <div class="physical box">I have a width of 200px and a height of 100px.</div>
+
+  <div class="logical box">
+    I have an inline-size of 200px and a block-size of 100px.
+  </div>
+</div>
+```
+
+```css hidden live-sample___size-inline-block
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.container {
+  display: flex;
+}
+.box {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+  margin: 10px;
+}
+```
+
+```css live-sample___size-inline-block
+.box {
+  writing-mode: horizontal-tb;
+}
+
+.physical {
+  width: 200px;
+  height: 100px;
+}
+
+.logical {
+  inline-size: 200px;
+  block-size: 100px;
+}
+```
+
+{{EmbedLiveSample("size-inline-block")}}
 
 ## 最小宽度和最小高度的示例
 
@@ -38,13 +80,95 @@ slug: Web/CSS/CSS_logical_properties_and_values/Sizing
 
 试试把下面的例子像第一个例子一样改成 `vertical-rl` 看看效果。我在第一个例子里用了 `min-height`，在第二个里用了 `min-block-size`。
 
-{{EmbedGHLiveSample("css-examples/logical/size-min.html", "100%", 500)}}
+```html live-sample___size-min
+<div class="container">
+  <div class="physical box">
+    I have a width of 200px and a min-height of 5em.
+  </div>
+
+  <div class="logical box">
+    I have an inline-size of 200px and a min-block-size of 5em.
+  </div>
+</div>
+```
+
+```css hidden live-sample___size-min
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.container {
+  display: flex;
+}
+.box {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+  margin: 10px;
+}
+```
+
+```css live-sample___size-min
+.box {
+  writing-mode: horizontal-tb;
+}
+
+.physical {
+  width: 200px;
+  min-height: 5em;
+}
+
+.logical {
+  inline-size: 200px;
+  min-block-size: 5em;
+}
+```
+
+{{EmbedLiveSample("size-min")}}
 
 ## 最大宽度和最大高度的示例
 
 最后你可以用逻辑属性 {{CSSXref("max-inline-size")}} 和 {{CSSXref("max-block-size")}} 替代 {{CSSXref("max-width")}} 和 {{CSSXref("max-height")}}。用和之前一样的方式玩玩下面的例子。
 
-{{EmbedGHLiveSample("css-examples/logical/size-max.html", "100%", 500)}}
+```html live-sample___size-max
+<div class="container">
+  <div class="physical box">I have a max-width of 200px.</div>
+
+  <div class="logical box">I have an max-inline-size of 200px.</div>
+</div>
+```
+
+```css hidden live-sample___size-max
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.container {
+  display: flex;
+}
+.box {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+  margin: 10px;
+}
+```
+
+```css live-sample___size-max
+.box {
+  writing-mode: horizontal-tb;
+}
+
+.physical {
+  max-width: 200px;
+}
+
+.logical {
+  max-inline-size: 200px;
+}
+```
+
+{{EmbedLiveSample("size-max")}}
 
 ## 用于 resize 的逻辑关键词
 
@@ -52,4 +176,53 @@ slug: Web/CSS/CSS_logical_properties_and_values/Sizing
 
 无论你按实体还是按逻辑理解，`resize` 属性的关键词值 `both` 的效果都一样。这个值同时设置两个方向的尺度。玩玩下面的例子。
 
-{{EmbedGHLiveSample("css-examples/logical/size-resize.html", "100%", 700)}}
+```html live-sample___size-resize
+<div class="container">
+  <div class="physical box">
+    I have a width of 200px and a height of 100px. I can be resized
+    horizontally.
+  </div>
+
+  <div class="logical box">
+    I have an inline-size of 200px and a block-size of 100px. I can be resized
+    in the inline direction.
+  </div>
+</div>
+```
+
+```css hidden live-sample___size-resize
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+.container {
+  display: flex;
+}
+.box {
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+  padding: 10px;
+  margin: 10px;
+}
+```
+
+```css live-sample___size-resize
+.box {
+  writing-mode: horizontal-tb;
+  overflow: scroll;
+}
+
+.physical {
+  width: 200px;
+  height: 100px;
+  resize: horizontal;
+}
+
+.logical {
+  inline-size: 200px;
+  block-size: 100px;
+  resize: inline;
+}
+```
+
+{{EmbedLiveSample("size-resize")}}

--- a/files/zh-cn/web/css/css_multicol_layout/basic_concepts/index.md
+++ b/files/zh-cn/web/css/css_multicol_layout/basic_concepts/index.md
@@ -36,7 +36,39 @@ Multicol 与 CSS 中的任何其他布局方法不同，它将内容（包括所
 
 在以下示例中，我们使用 column-count 属性在 `.container` 元素上创建三列。 `.container` 元素的内容包括其子元素都会分裂成三列。
 
-{{EmbedGHLiveSample("css-examples/multicol/basics/column-count.html", '100%', 550)}}
+```html live-sample___column-count
+<div class="container">
+  <p>
+    Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
+    daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+  </p>
+
+  <p>
+    Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette
+    tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato.
+    Dandelion cucumber earthnut pea peanut soko zucchini.
+  </p>
+
+  <p>
+    Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+    kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter
+    purslane kale. Celery potato scallion desert raisin horseradish spinach
+    carrot soko.
+  </p>
+</div>
+```
+
+```css live-sample___column-count
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.container {
+  column-count: 3;
+}
+```
+
+{{EmbedLiveSample("column-count", "", "280px")}}
 
 在上面的例子中内容被段落 p 标签的默认样式包裹。因此，每段都有一个间距。你可以看到这个间距引起第一行文本被推了下来。这是因为 multicol 容器创建了一个新的块格式化上下文（BFC），这意味着子元素的间距不会与父容器的间距互相重叠。
 
@@ -48,7 +80,39 @@ Multicol 与 CSS 中的任何其他布局方法不同，它将内容（包括所
 
 在以下示例中，我们使用 column-width 属性值为 200 px。但最终为了适配容器，列的宽度却大于 200 像素，额外的空间被平均分配了。
 
-{{EmbedGHLiveSample("css-examples/multicol/basics/column-width.html", '100%', 550)}}
+```html hidden live-sample___column-width
+<div class="container">
+  <p>
+    Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
+    daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+  </p>
+
+  <p>
+    Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette
+    tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato.
+    Dandelion cucumber earthnut pea peanut soko zucchini.
+  </p>
+
+  <p>
+    Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+    kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter
+    purslane kale. Celery potato scallion desert raisin horseradish spinach
+    carrot soko.
+  </p>
+</div>
+```
+
+```css live-sample___column-width
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.container {
+  column-width: 200px;
+}
+```
+
+{{EmbedLiveSample("column-width", "", "280px")}}
 
 ### 同时使用 `column-count` 和 `column-width`
 
@@ -58,7 +122,40 @@ Multicol 与 CSS 中的任何其他布局方法不同，它将内容（包括所
 
 在下一个例子中，我们使用 column-width 的值为 200px，column-count 的值为 2。即使有超过两列的空间，我们也得到两个。如果没有足够的空间容纳两列 200px，我们得到一个。
 
-{{EmbedGHLiveSample("css-examples/multicol/basics/column-count-width.html", '100%', 550)}}
+```html hidden live-sample___column-count-width
+<div class="container">
+  <p>
+    Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
+    daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+  </p>
+
+  <p>
+    Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette
+    tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato.
+    Dandelion cucumber earthnut pea peanut soko zucchini.
+  </p>
+
+  <p>
+    Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+    kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter
+    purslane kale. Celery potato scallion desert raisin horseradish spinach
+    carrot soko. .
+  </p>
+</div>
+```
+
+```css live-sample___column-count-width
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.container {
+  column-count: 2;
+  column-width: 200px;
+}
+```
+
+{{EmbedLiveSample("column-count-width", "", "280px")}}
 
 ### `columns` 缩写
 

--- a/files/zh-cn/web/css/css_multicol_layout/handling_overflow_in_multicol_layout/index.md
+++ b/files/zh-cn/web/css/css_multicol_layout/handling_overflow_in_multicol_layout/index.md
@@ -13,13 +13,82 @@ slug: Web/CSS/CSS_multicol_layout/Handling_overflow_in_multicol_layout
 
 在这种情况下，内容溢出（并且是可见的）到下一列，而不是被列框裁切。你可以在下面的示例中看到，在编写本文时，浏览器以不同的方式处理预期的呈现图像。
 
-{{EmbedGHLiveSample("css-examples/multicol/overflow/image.html", '100%', 800)}}
+```html live-sample___image
+<div class="container">
+  <p>
+    Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
+    daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+  </p>
+  <img
+    alt="A close-up of two hot air balloons being inflated."
+    src="https://mdn.github.io/shared-assets/images/examples/balloons3.jpg" />
+  <p>
+    Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette
+    tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato.
+    Dandelion cucumber earthnut pea peanut soko zucchini.
+  </p>
+  <p>
+    Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+    kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter
+    purslane kale. Celery potato scallion desert raisin horseradish spinach
+    carrot soko.
+  </p>
+</div>
+```
+
+```css live-sample___image
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.container {
+  column-width: 250px;
+}
+```
+
+{{EmbedLiveSample("image", "", "440px")}}
 
 ![](image-overflow-multicol.png)
 
 如果你想要一个图像尺寸缩小到适合列框，标准的响应式的解决方案是设置最大宽度:100%。
 
-{{EmbedGHLiveSample("css-examples/multicol/overflow/image-max-width.html", '100%', 800)}}
+```html hidden live-sample___image-max-width
+<div class="container">
+  <p>
+    Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
+    daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+  </p>
+  <img
+    alt="A close-up of two hot air balloons being inflated."
+    src="https://mdn.github.io/shared-assets/images/examples/balloons3.jpg" />
+  <p>
+    Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette
+    tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato.
+    Dandelion cucumber earthnut pea peanut soko zucchini.
+  </p>
+  <p>
+    Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+    kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter
+    purslane kale. Celery potato scallion desert raisin horseradish spinach
+    carrot soko.
+  </p>
+</div>
+```
+
+```css live-sample___image-max-width
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.container {
+  column-width: 250px;
+}
+img {
+  max-width: 100%;
+}
+```
+
+{{EmbedLiveSample("image-max-width", "", "440px")}}
 
 ## 更多的列
 
@@ -29,7 +98,39 @@ slug: Web/CSS/CSS_multicol_layout/Handling_overflow_in_multicol_layout
 
 下面的示例显示了这种溢出行为。multicol 容器有一个高度，列的文本多于空间，因此多出的列会在容器外面出现。
 
-{{EmbedGHLiveSample("css-examples/multicol/overflow/overflow-inline.html", '100%', 800)}}
+```html live-sample___overflow-inline
+<div class="container">
+  <p>
+    Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
+    daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+  </p>
+  <p>
+    Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette
+    tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato.
+    Dandelion cucumber earthnut pea peanut soko zucchini.
+  </p>
+  <p>
+    Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+    kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter
+    purslane kale. Celery potato scallion desert raisin horseradish spinach
+    carrot soko.
+  </p>
+</div>
+```
+
+```css live-sample___overflow-inline
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.container {
+  column-width: 200px;
+  height: 180px;
+  border: 2px dashed;
+}
+```
+
+{{EmbedLiveSample("overflow-inline", "", "240px")}}
 
 本规范的未来版本中，会允许横向溢出的列向下排列，用户能向下滚动鼠标查看溢出的列。
 
@@ -39,6 +140,38 @@ multicol 在 web 上的一个问题：如果你的列比 viewport 高，读者�
 
 在下面的示例中，我们使用了 `min-height`。
 
-{{EmbedGHLiveSample("css-examples/multicol/overflow/min-height.html", '100%', 800)}}
+```html hidden live-sample___min-height
+<div class="container">
+  <p>
+    Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
+    daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+  </p>
+  <p>
+    Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette
+    tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato.
+    Dandelion cucumber earthnut pea peanut soko zucchini.
+  </p>
+  <p>
+    Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+    kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter
+    purslane kale. Celery potato scallion desert raisin horseradish spinach
+    carrot soko.
+  </p>
+</div>
+```
+
+```css live-sample___min-height
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+@media (min-height: 300px) {
+  .container {
+    column-width: 200px;
+  }
+}
+```
+
+{{EmbedLiveSample("min-height", "", "340px")}}
 
 在本系列的最后一篇指南中，我们将看到[片段化下的 Muticol 如何使用](/zh-CN/docs/Web/CSS/CSS_multicol_layout/Handling_content_breaks_in_multicol)的规范，去控制列内容的溢出。

--- a/files/zh-cn/web/css/css_multicol_layout/styling_columns/index.md
+++ b/files/zh-cn/web/css/css_multicol_layout/styling_columns/index.md
@@ -19,7 +19,38 @@ slug: Web/CSS/CSS_multicol_layout/Styling_columns
 
 你可以通过将 `column-gap` 的值设置为任何长度单位来更改间距。在下面的示例中，`column-gap` 设置为 40px。
 
-{{EmbedGHLiveSample("css-examples/multicol/styling/column-gap.html", '100%', 750)}}
+```html live-sample___column-gap
+<div class="container">
+  <p>
+    Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
+    daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+  </p>
+  <p>
+    Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette
+    tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato.
+    Dandelion cucumber earthnut pea peanut soko zucchini.
+  </p>
+  <p>
+    Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+    kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter
+    purslane kale. Celery potato scallion desert raisin horseradish spinach
+    carrot soko.
+  </p>
+</div>
+```
+
+```css live-sample___column-gap
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.container {
+  column-count: 3;
+  column-gap: 40px;
+}
+```
+
+{{EmbedLiveSample("column-gap", "", "300px")}}
 
 `column-gap` 允许的值是 `<length-percentage>`，这意味着允许使用百分比。`column-gap` 的百分比值是根据多列容器宽度的百分比计算的。
 
@@ -31,13 +62,78 @@ slug: Web/CSS/CSS_multicol_layout/Styling_columns
 
 在接下来的示例中，使用长格式值创建了一个宽度为 5px、颜色为 `rebeccapurple` 的点状分栏线条。
 
-{{EmbedGHLiveSample("css-examples/multicol/styling/column-rule.html", '100%', 550)}}
+```html hidden live-sample___column-rule
+<div class="container">
+  <p>
+    Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
+    daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+  </p>
+  <p>
+    Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette
+    tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato.
+    Dandelion cucumber earthnut pea peanut soko zucchini.
+  </p>
+  <p>
+    Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+    kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter
+    purslane kale. Celery potato scallion desert raisin horseradish spinach
+    carrot soko.
+  </p>
+</div>
+```
+
+```css live-sample___column-rule
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.container {
+  column-count: 3;
+  column-rule-width: 5px;
+  column-rule-style: dotted;
+  column-rule-color: rebeccapurple;
+}
+```
+
+{{EmbedLiveSample("column-rule", "", "300px")}}
 
 请注意，分栏线条本身不占用任何空间：宽分栏线条不会将列分开以为分栏线条腾出空间。相反，分栏线条覆盖了间隙。
 
 下面的示例使用了非常宽的 40px 分栏线条和 10px 间距。分栏线条在列内容的下方显示。为了在分栏线条两侧腾出空间，间距需要增加到大于 40px。
 
-{{EmbedGHLiveSample("css-examples/multicol/styling/column-rule-wide.html", '100%', 550)}}
+```html hidden live-sample___column-rule-wide
+<div class="container">
+  <p>
+    Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
+    daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+  </p>
+  <p>
+    Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette
+    tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato.
+    Dandelion cucumber earthnut pea peanut soko zucchini.
+  </p>
+  <p>
+    Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+    kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter
+    purslane kale. Celery potato scallion desert raisin horseradish spinach
+    carrot soko.
+  </p>
+</div>
+```
+
+```css live-sample___column-rule-wide
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.container {
+  column-count: 3;
+  column-gap: 10px;
+  column-rule: 40px solid rebeccapurple;
+}
+```
+
+{{EmbedLiveSample("column-rule-wide", "", "300px")}}
 
 ## 下一步
 

--- a/files/zh-cn/web/css/css_scroll_snap/basic_concepts/index.md
+++ b/files/zh-cn/web/css/css_scroll_snap/basic_concepts/index.md
@@ -23,7 +23,53 @@ slug: Web/CSS/CSS_scroll_snap/Basic_concepts
 
 下列示例演示了由 `scroll-snap-type` 所定义的纵轴方向的滚动吸附。此外，`scroll-snap-align` 被应用于 `<section>` 元素的所有子元素，决定了每个子元素的滚动止点。
 
-{{EmbedGHLiveSample("css-examples/scroll-snap/mandatory-y.html", "100%", 700)}}
+```html live-sample___mandatory-y
+<article class="scroller">
+  <section>
+    <h2>Section one</h2>
+  </section>
+  <section>
+    <h2>Section two</h2>
+  </section>
+  <section>
+    <h2>Section three</h2>
+  </section>
+</article>
+```
+
+```css hidden live-sample___mandatory-y
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.scroller {
+  border: 4px solid #333;
+  width: 300px;
+}
+
+.scroller section {
+  min-height: 100%;
+  padding: 10px;
+}
+
+.scroller section:nth-child(odd) {
+  background-color: #ccc;
+}
+```
+
+```css live-sample___mandatory-y
+.scroller {
+  height: 300px;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+}
+
+.scroller section {
+  scroll-snap-align: start;
+}
+```
+
+{{EmbedLiveSample("mandatory-y", "", "350px")}}
 
 ## 使用 scroll-snap-type
 
@@ -40,7 +86,71 @@ slug: Web/CSS/CSS_scroll_snap/Basic_concepts
 
 在下列示例中，可以在 `mandatory` 和 `proximity` 之间改变取值，看看对滚动产生的效果。
 
-{{EmbedGHLiveSample("css-examples/scroll-snap/mandatory-proximity.html", "100%", 700)}}
+```html live-sample___mandatory-proximity
+<article class="scroller">
+  <section>
+    <h2>Section one</h2>
+    <p>
+      Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+      kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus
+      winter purslane kale. Celery potato scallion desert raisin horseradish
+      spinach carrot soko.
+    </p>
+  </section>
+  <section>
+    <h2>Section two</h2>
+    <p>
+      Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+      kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus
+      winter purslane kale. Celery potato scallion desert raisin horseradish
+      spinach carrot soko.
+    </p>
+  </section>
+  <section>
+    <h2>Section three</h2>
+    <p>
+      Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+      kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus
+      winter purslane kale. Celery potato scallion desert raisin horseradish
+      spinach carrot soko.
+    </p>
+  </section>
+</article>
+```
+
+```css hidden live-sample___mandatory-proximity
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.scroller {
+  border: 4px solid #333;
+  width: 300px;
+}
+
+.scroller section {
+  min-height: 100%;
+  padding: 10px;
+}
+
+.scroller section:nth-child(odd) {
+  background-color: #ccc;
+}
+```
+
+```css live-sample___mandatory-proximity
+.scroller {
+  height: 300px;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+}
+
+.scroller section {
+  scroll-snap-align: start;
+}
+```
+
+{{EmbedLiveSample("mandatory-proximity", "", "350px")}}
 
 在上述示例中的滚动容器上同时设置了 {{CSSXref("height", "height: 300px;")}} 和 {{CSSXref("overflow-y", "overflow-y: scroll;")}}。
 
@@ -50,7 +160,71 @@ slug: Web/CSS/CSS_scroll_snap/Basic_concepts
 
 {{CSSXref("scroll-snap-align")}} 属性的有效值包括 `start`、`end`、`center` 和 `none`。这些值用于标示内容应当吸附到滚动容器中的哪个点。在下列示例中，可以改变 `scroll-snap-align` 的值，看看滚动行为如何变化。
 
-{{EmbedGHLiveSample("css-examples/scroll-snap/align.html", "100%", 700)}}
+```html hidden live-sample___align
+<article class="scroller">
+  <section>
+    <h2>Section one</h2>
+    <p>
+      Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+      kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus
+      winter purslane kale. Celery potato scallion desert raisin horseradish
+      spinach carrot soko.
+    </p>
+  </section>
+  <section>
+    <h2>Section two</h2>
+    <p>
+      Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+      kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus
+      winter purslane kale. Celery potato scallion desert raisin horseradish
+      spinach carrot soko.
+    </p>
+  </section>
+  <section>
+    <h2>Section three</h2>
+    <p>
+      Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce
+      kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus
+      winter purslane kale. Celery potato scallion desert raisin horseradish
+      spinach carrot soko.
+    </p>
+  </section>
+</article>
+```
+
+```css hidden live-sample___align
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.scroller {
+  border: 4px solid #333;
+  width: 300px;
+}
+
+.scroller section {
+  min-height: 100%;
+  padding: 10px;
+}
+
+.scroller section:nth-child(odd) {
+  background-color: #ccc;
+}
+```
+
+```css live-sample___align
+.scroller {
+  height: 200px;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+}
+
+.scroller section {
+  scroll-snap-align: start;
+}
+```
+
+{{EmbedLiveSample("align", "", "250px")}}
 
 如果 `scroll-snap-type` 是 `mandatory` 而且某个子元素上的 `scroll-snap-align` 被设置为 `none` 或者未被设置（此时默认为 `none`），那么用户会无法把这个元素滚入视野。
 
@@ -60,17 +234,174 @@ slug: Web/CSS/CSS_scroll_snap/Basic_concepts
 
 在下列示例中，`scroll-padding` 被设置为 `40px`。当内容吸附到第二和第三节的开头时，滚动会停在离章节开头 40 像素远的位置。试试改变 `scroll-padding` 的值，看看距离如何变化。
 
-{{EmbedGHLiveSample("css-examples/scroll-snap/scroll-padding.html", "100%", 700)}}
+```html live-sample___scroll-padding
+<article class="scroller">
+  <section>
+    <h2>Section one</h2>
+  </section>
+  <section>
+    <h2>Section two</h2>
+  </section>
+  <section>
+    <h2>Section three</h2>
+  </section>
+</article>
+```
+
+```css hidden live-sample___scroll-padding
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.scroller {
+  border: 4px solid #333;
+  width: 300px;
+}
+
+.scroller section {
+  min-height: 100%;
+  padding: 10px;
+}
+
+.scroller section:nth-child(odd) {
+  background-color: #ccc;
+}
+```
+
+```css live-sample___scroll-padding
+.scroller {
+  height: 300px;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+  scroll-padding: 50px;
+}
+
+.scroller section {
+  scroll-snap-align: start;
+}
+```
+
+{{EmbedLiveSample("scroll-padding", "", "350px")}}
 
 如果有像导航栏这种可能遮盖滚动内容的[固定](/zh-CN/docs/Web/CSS/position#固定定位)元素，那么这个属性可以派上用场。使用 `scroll-padding` 可以为固定元素留出空间。例如在下列示例中，当内容在 `<h1>` 元素下方滚动时，`<h1>` 在屏幕上保持不动。如果没有内边距，那么在发生吸附时，标题会遮盖一些内容。
 
-{{EmbedGHLiveSample("css-examples/scroll-snap/scroll-padding-sticky.html", "100%", 700)}}
+```html hidden live-sample___scroll-padding-sticky
+<article class="scroller">
+  <h1>Sticky Heading</h1>
+  <section>
+    <h2>Section one</h2>
+  </section>
+  <section>
+    <h2>Section two</h2>
+  </section>
+  <section>
+    <h2>Section three</h2>
+  </section>
+</article>
+```
+
+```css hidden live-sample___scroll-padding-sticky
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.scroller {
+  border: 4px solid #333;
+  width: 300px;
+}
+
+.scroller section {
+  min-height: 100%;
+  padding: 10px;
+}
+
+.scroller section:nth-child(odd) {
+  background-color: #ccc;
+}
+```
+
+```css live-sample___scroll-padding-sticky
+.scroller h1 {
+  position: sticky;
+  top: 0;
+  min-height: 40px;
+  background-color: #000;
+  color: #fff;
+  margin: 0;
+  padding: 0;
+}
+
+.scroller h2 {
+  margin: 0;
+  padding: 0;
+}
+
+.scroller {
+  height: 300px;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+  scroll-padding: 50px;
+}
+
+.scroller section {
+  scroll-snap-align: start;
+}
+```
+
+{{EmbedLiveSample("scroll-padding-sticky", "", "350px")}}
 
 ## 使用 scroll-margin
 
 在子元素上可以设置 {{CSSXref("scroll-margin")}} 属性或者全称滚动外边距值，用于定义指定盒子的外边距。这可以让不同的子元素有不同大小的空间，而且可以和父元素上的 `scroll-padding` 一起使用。在下列示例中尝试一下。
 
-{{EmbedGHLiveSample("css-examples/scroll-snap/scroll-margin.html", "100%", 700)}}
+```html hidden live-sample___scroll-margin
+<article class="scroller">
+  <section>
+    <h2>Section one</h2>
+  </section>
+  <section>
+    <h2>Section two</h2>
+  </section>
+  <section>
+    <h2>Section three</h2>
+  </section>
+</article>
+```
+
+```css hidden live-sample___scroll-margin
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.scroller {
+  border: 4px solid #333;
+  width: 300px;
+}
+
+.scroller section {
+  min-height: 100%;
+  padding: 10px;
+}
+
+.scroller section:nth-child(odd) {
+  background-color: #ccc;
+}
+```
+
+```css live-sample___scroll-margin
+.scroller {
+  height: 300px;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+}
+
+.scroller section {
+  scroll-snap-align: start;
+  scroll-margin: 40px;
+}
+```
+
+{{EmbedLiveSample("scroll-margin", "", "350px")}}
 
 ## 使用 scroll-snap-stop
 

--- a/files/zh-cn/web/css/css_scroll_snap/index.md
+++ b/files/zh-cn/web/css/css_scroll_snap/index.md
@@ -13,7 +13,228 @@ slug: Web/CSS/CSS_scroll_snap
 
 为在下方的框中查看滚动吸附，可在滚动式视口中上下左右地滚动经过含 45 个带编号盒子的网格。
 
-{{EmbedGHLiveSample("css-examples/modules/scroll_snap.html", "100%", 250)}}
+```js hidden live-sample___scroll_snap
+const positions = ["start", "center", "end"];
+const inlineDirection = document.getElementById("inline");
+const blockDirection = document.getElementById("block");
+const stop = document.getElementById("stop");
+const snap = document.getElementById("snap");
+const all = document.querySelector("article");
+const rules = document.styleSheets[0].cssRules;
+
+inlineDirection.addEventListener("change", () => {
+  setSSA();
+});
+blockDirection.addEventListener("change", () => {
+  setSSA();
+});
+stop.addEventListener("change", () => {
+  setSST();
+});
+window.addEventListener("load", () => {
+  setSST();
+  setSSA();
+});
+snap.addEventListener("change", () => {
+  all.classList.toggle("snapDisabled");
+});
+
+function setSSA() {
+  rules[0].style.scrollSnapAlign = `${positions[blockDirection.value]} ${
+    positions[inlineDirection.value]
+  }`;
+}
+
+function setSST() {
+  if (stop.checked) {
+    rules[0].style.scrollSnapStop = "always";
+  } else {
+    rules[0].style.scrollSnapStop = "normal";
+  }
+}
+```
+
+```html hidden live-sample___scroll_snap
+<article>
+  <ul>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+    <li></li>
+  </ul>
+  <div>
+    <fieldset>
+      <legend>Change the options</legend>
+      <p>
+        <label
+          ><input
+            type="range"
+            min="0"
+            max="2"
+            value="1"
+            list="places"
+            id="block" />
+          block position</label
+        >
+      </p>
+      <p>
+        <label>
+          <input
+            type="range"
+            min="0"
+            max="2"
+            value="1"
+            list="places"
+            id="inline" />
+          inline position
+        </label>
+      </p>
+      <p>
+        <label>
+          <input type="checkbox" id="stop" />
+          Prevent scrolling past boxes
+        </label>
+      </p>
+    </fieldset>
+
+    <p>
+      <label><input type="checkbox" id="snap" /> disable snapping</label>
+    </p>
+
+    <datalist id="places">
+      <option value="0">start</option>
+      <option value="1">center</option>
+      <option value="2">end</option>
+    </datalist>
+  </div>
+</article>
+```
+
+```css hidden live-sample___scroll_snap
+li {
+  /*
+  starts with:
+      scroll-snap-align: center center;
+      scroll-snap-stop: normal (defaults);
+
+  CSS gets changed with JavaScript when you change the controls.
+  the following can be set:
+      scroll-snap-stop: always | normal;
+      scroll-snap-align: start | center | end {2}
+        */
+}
+ul {
+  overflow: auto;
+  scroll-snap-type: both mandatory;
+  overscroll-behavior-x: contain;
+}
+article.snapDisabled fieldset {
+  opacity: 20%;
+  pointer-events: none;
+}
+article.snapDisabled ul {
+  scroll-snap-type: initial;
+  overscroll-behavior-x: initial;
+}
+
+@layer pageSetup {
+  article {
+    display: flex;
+    gap: 2vw;
+  }
+  div {
+    flex: 1;
+  }
+  ul {
+    display: grid;
+    gap: 6.25vw;
+    padding: 12.5vw;
+    box-sizing: border-box;
+    border: 1px solid;
+    grid-template-columns: repeat(5, 1fr);
+    background: conic-gradient(
+      at bottom left,
+      red 0deg,
+      yellow 15deg,
+      green 30deg,
+      blue 45deg,
+      purple 60deg,
+      magenta 75deg
+    );
+    background-attachment: local;
+    margin: auto;
+    width: 20vw;
+    height: 20vw;
+  }
+  li {
+    scroll-snap-align: center;
+    height: 12.5vw;
+    width: 12.5vw;
+    outline: 3px inset;
+    list-style-type: none;
+    background: white;
+    font-family: monospace;
+    font-size: 3rem;
+    line-height: 12vw;
+    text-align: center;
+    counter-increment: items 1;
+  }
+  li::after {
+    content: counter(items);
+  }
+  input {
+    vertical-align: bottom;
+  }
+  p {
+    font-family: monospace;
+  }
+}
+```
+
+{{EmbedLiveSample("scroll_snap", "", "250px")}}
 
 在有滚动吸附时，所滚动的带编号盒子中的一者将吸附至指定位置。初始的 CSS 代码使带编号盒子吸附至视口中心，可使用滑块改变块向和行向的吸附位置。
 

--- a/files/zh-cn/web/css/css_shapes/from_box_values/index.md
+++ b/files/zh-cn/web/css/css_shapes/from_box_values/index.md
@@ -32,7 +32,39 @@ box 值还支持 `border-radius` 值，这意味着你的页面中可以有带�
 
 在下面的示例中，我们有一个圆形的紫色项，它是一个带有高度、宽度和背景色的 {{htmlelement("div")}} 项。通过设置 `border-radius` 属性为 `border-radius: 50%` 属性，创建了一个圆形。由于元素具有外边距，你可以看到内容围绕圆形流动，并且应用了圆形的外边距。
 
-{{EmbedGHLiveSample("css-examples/shapes/box/margin-box.html", '100%', 800)}}
+```html live-sample___margin-box
+<div class="box">
+  <div class="shape"></div>
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+</div>
+```
+
+```css live-sample___margin-box
+body {
+  font: 1.2em sans-serif;
+}
+
+.shape {
+  background-color: rebeccapurple;
+  height: 80px;
+  width: 80px;
+  padding: 20px;
+  margin: 20px;
+  border: 10px solid black;
+  border-radius: 50%;
+  float: left;
+  shape-outside: margin-box;
+}
+```
+
+{{EmbedLiveSample("margin-box", "", "200px")}}
 
 ### border-box
 
@@ -40,19 +72,124 @@ box 值还支持 `border-radius` 值，这意味着你的页面中可以有带�
 
 在下面的示例中，你可以看到文本现在是如何遵循由边框创建的行的。改变边框大小，内容也会随之改变。
 
-{{EmbedGHLiveSample("css-examples/shapes/box/border-box.html", '100%', 800)}}
+```html hidden live-sample___border-box
+<div class="box">
+  <div class="shape"></div>
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+</div>
+```
+
+```css live-sample___border-box
+body {
+  font: 1.2em sans-serif;
+}
+.box {
+  width: 70%;
+}
+
+.shape {
+  background-color: rebeccapurple;
+  height: 80px;
+  width: 80px;
+  padding: 20px;
+  margin: 20px;
+  border: 10px solid black;
+  border-radius: 50%;
+  float: left;
+  shape-outside: border-box;
+}
+```
+
+{{EmbedLiveSample("border-box", "", "240px")}}
 
 ### padding-box
 
 `padding-box` 值定义由外边距边缘包围的形状。此形状遵循边框内部的所有常规边框半径形状规则。如果没有外边距，则 `padding-box` 与 `content-box` 相同。
 
-{{EmbedGHLiveSample("css-examples/shapes/box/padding-box.html", '100%', 800)}}
+```html hidden live-sample___padding-box
+<div class="box">
+  <div class="shape"></div>
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+</div>
+```
+
+```css live-sample___padding-box
+body {
+  font: 1.2em / 1.2 sans-serif;
+}
+.box {
+  width: 70%;
+}
+
+.shape {
+  background-color: rebeccapurple;
+  height: 80px;
+  width: 80px;
+  padding: 20px;
+  margin: 20px;
+  border: 10px solid black;
+  border-radius: 50%;
+  float: left;
+  shape-outside: padding-box;
+}
+```
+
+{{EmbedLiveSample("padding-box", "", "260px")}}
 
 ### content-box
 
 `content-box` 值定义由外部内容边缘包围的形状。此框的每个角半径都是 0 或 border-radius、border-width、padding 中的较大值。这意味着这里不可能有负值。
 
-{{EmbedGHLiveSample("css-examples/shapes/box/content-box.html", '100%', 800)}}
+```html hidden live-sample___content-box
+<div class="box">
+  <div class="shape"></div>
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+</div>
+```
+
+```css live-sample___content-box
+body {
+  font: 1.2em / 1.2 sans-serif;
+}
+.box {
+  width: 70%;
+}
+
+.shape {
+  background-color: rebeccapurple;
+  height: 80px;
+  width: 80px;
+  padding: 20px;
+  margin: 20px;
+  border: 10px solid black;
+  border-radius: 50%;
+  float: left;
+  shape-outside: content-box;
+}
+```
+
+{{EmbedLiveSample("content-box", "", "250px")}}
 
 ## 什么时候使用 box 值
 
@@ -60,6 +197,50 @@ box 值还支持 `border-radius` 值，这意味着你的页面中可以有带�
 
 不过，只需使用这种简单的技术，你就能创造出一些有趣的效果。在本节的最后一个示例中，我左右浮动了两个元素，在最靠近文字的方向上，每个元素的边框半径都是 100%。
 
-{{EmbedGHLiveSample("css-examples/shapes/box/bottom-margin-box.html", '100%', 800)}}
+```html live-sample___bottom-margin-box
+<div class="box">
+  <div class="shape-left"></div>
+  <div class="shape-right"></div>
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery.
+  </p>
+</div>
+```
+
+```css live-sample___bottom-margin-box
+body {
+  font: 1.2em / 1.5 sans-serif;
+}
+
+.box {
+  text-align: justify;
+}
+
+.shape-left,
+.shape-right {
+  height: 100px;
+  width: 100px;
+}
+
+.shape-left {
+  margin: 0 20px 20px 0;
+  border-bottom-right-radius: 100%;
+  float: left;
+  shape-outside: margin-box;
+}
+.shape-right {
+  margin: 0 20px 20px;
+  border-bottom-left-radius: 100%;
+  float: right;
+  shape-outside: margin-box;
+}
+```
+
+{{EmbedLiveSample("bottom-margin-box", "", "240px")}}
 
 对于更复杂的形状，你需要使用[基本形状](/zh-CN/docs/Web/CSS/CSS_shapes/Basic_shapes)中的一种作为值，或者根据本节其他指南中涉及的图像定义你的形状。

--- a/files/zh-cn/web/css/css_shapes/index.md
+++ b/files/zh-cn/web/css/css_shapes/index.md
@@ -17,7 +17,7 @@ l10n:
 
 以下示例显示了一个向左浮动的图像，并应用了值为 `circle(50%)` 的 `shape-outside` 属性。这将创建一个圆形，使得包裹浮动的内容会包裹着这个形状。这将改变包裹文本的行框的长度。
 
-{{EmbedGHLiveSample("css-examples/shapes/overview/circle.html", '100%', 720)}}
+{{EmbedLiveSample("circle", "", "300px")}}
 
 ## 参考
 

--- a/files/zh-cn/web/css/css_shapes/overview_of_shapes/index.md
+++ b/files/zh-cn/web/css/css_shapes/overview_of_shapes/index.md
@@ -25,7 +25,37 @@ Specification 定义了三种新的权限：
 
 下面的例子中，左侧有一幅浮动的图像，然后使用`shape-outside` 权限定义一个`circle(50%)`属性。结果为文字环绕于图像，并且图像不显示为矩形，而显示为圆形。
 
-{{EmbedGHLiveSample("css-examples/shapes/overview/circle.html", '100%', 720)}}
+```html live-sample___circle
+<div class="box">
+  <img
+    alt="An orange hot air balloon as seen from below"
+    src="https://mdn.github.io/shared-assets/images/examples/round-balloon.png" />
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery. Before that night—a memorable night,
+    as it was to prove—hundreds of millions of people had watched the rising
+    smoke-wreaths of their fires without drawing any special inspiration from
+    the fact.
+  </p>
+</div>
+```
+
+```css live-sample___circle
+body {
+  font: 1.2em / 1.4 sans-serif;
+}
+
+img {
+  float: left;
+  shape-outside: circle(50%);
+}
+```
+
+{{EmbedLiveSample("circle", "", "280px")}}
 
 正如这个级别的元素必须被浮动化才能适用`<basic-shape>` 一样，有时候在创建依赖时就会发生副作用。如果在浏览器中不支持形状，那么用户就会看到文本围绕在矩形的图片周围。有了形状支持之后，视觉效果就增强了。
 
@@ -57,7 +87,41 @@ Specification 定义了三种新的权限：
 
 在下面的例子中你可以改变 `border-box` 参数，然后查看形状靠近或者远离 Box 的效果。
 
-{{EmbedGHLiveSample("css-examples/shapes/overview/box.html", '100%', 810)}}
+```html live-sample___box
+<div class="box">
+  <div class="shape"></div>
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery. Before that night—a memorable night,
+    as it was to prove—hundreds of millions of people had watched the rising
+    smoke-wreaths of their fires without drawing any special inspiration from
+    the fact.
+  </p>
+</div>
+```
+
+```css live-sample___box
+body {
+  font: 1.2em / 1.4 sans-serif;
+}
+
+.shape {
+  background-color: rebeccapurple;
+  height: 150px;
+  width: 150px;
+  padding: 20px;
+  margin: 20px;
+  border-radius: 50%;
+  float: left;
+  shape-outside: border-box;
+}
+```
+
+{{EmbedLiveSample("box", "", "320px")}}
 
 详见 [Shapes From Box Values](/zh-CN/docs/Web/CSS/CSS_shapes/From_box_values)。
 
@@ -69,7 +133,37 @@ Specification 定义了三种新的权限：
 
 在下面的例子中，我们有一幅全透明的图像，使用如下 URL，并且指定 `shape-outside`. 属性，创建出一个模糊的形状：一幅气球图像。
 
-{{EmbedGHLiveSample("css-examples/shapes/overview/image.html", '100%', 800)}}
+```html live-sample___image
+<div class="box">
+  <img
+    alt="An orange hot air balloon as seen from below"
+    src="https://mdn.github.io/shared-assets/images/examples/round-balloon.png" />
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery. Before that night—a memorable night,
+    as it was to prove—hundreds of millions of people had watched the rising
+    smoke-wreaths of their fires without drawing any special inspiration from
+    the fact.
+  </p>
+</div>
+```
+
+```css live-sample___image
+body {
+  font: 1.2em / 1.4 sans-serif;
+}
+
+img {
+  float: left;
+  shape-outside: url(https://mdn.github.io/shared-assets/images/examples/round-balloon.png);
+}
+```
+
+{{EmbedLiveSample("image", "", "280px")}}
 
 #### `shape-image-threshold`
 
@@ -77,7 +171,49 @@ Specification 定义了三种新的权限：
 
 如果我们使用图像来创建形状，那么你可以看到阈值在起作用。在这么多例子中，如果你改变了阈值大小，形状会随之变化。
 
-{{EmbedGHLiveSample("css-examples/shapes/overview/threshold.html", '100%', 820)}}
+```html live-sample___threshold
+<div class="box">
+  <div class="shape"></div>
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery. Before that night—a memorable night,
+    as it was to prove—hundreds of millions of people had watched the rising
+    smoke-wreaths of their fires without drawing any special inspiration from
+    the fact.
+  </p>
+</div>
+```
+
+```css live-sample___threshold
+body {
+  font: 1.2em / 1.4 sans-serif;
+}
+
+.shape {
+  float: left;
+  width: 200px;
+  height: 200px;
+  background-image: linear-gradient(
+    45deg,
+    rebeccapurple,
+    transparent 80%,
+    transparent
+  );
+  shape-outside: linear-gradient(
+    45deg,
+    rebeccapurple,
+    transparent 80%,
+    transparent
+  );
+  shape-image-threshold: 0.4;
+}
+```
+
+{{EmbedLiveSample("threshold", "", "280px")}}
 
 下面我们进入更深层次的[Shapes from Images](/zh-CN/docs/Web/CSS/CSS_shapes/Shapes_from_images)学习。
 
@@ -87,7 +223,37 @@ Specification 定义了三种新的权限：
 
 在下面的例子中，我们在基本形状中加入了 `shape-margin` 属性。改变边框的宽度可以将文本的距离增大。
 
-{{EmbedGHLiveSample("css-examples/shapes/overview/shape-margin.html", '100%', 800)}}
+```html live-sample___shape-margin
+<div class="box">
+  <img
+    alt="An orange hot air balloon as seen from below"
+    src="https://mdn.github.io/shared-assets/images/examples/round-balloon.png" />
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery. Before that night—a memorable night,
+    as it was to prove—hundreds of millions of people had watched the rising
+    smoke-wreaths of their fires without drawing any special inspiration from
+    the fact.
+  </p>
+</div>
+```
+
+```css live-sample___shape-margin
+body {
+  font: 1.2em / 1.4 sans-serif;
+}
+img {
+  float: left;
+  shape-outside: circle(50%);
+  shape-margin: 5px;
+}
+```
+
+{{EmbedLiveSample("shape-margin", "", "280px")}}
 
 ## 将创建的元素作为浮动元素
 
@@ -95,7 +261,41 @@ Specification 定义了三种新的权限：
 
 在下面的例子中，我们在创建好的内容中插入一个宽高为 150px 的内容。然后，我们可以使用基本基本形状，Box 参数甚至是 Alpha 通道去创建图形，使得文本可以环绕这个图形。
 
-{{EmbedGHLiveSample("css-examples/shapes/overview/generated-content.html", '100%', 850)}}
+```html live-sample___generated-content
+<div class="box">
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery. Before that night—a memorable night,
+    as it was to prove—hundreds of millions of people had watched the rising
+    smoke-wreaths of their fires without drawing any special inspiration from
+    the fact.
+  </p>
+</div>
+```
+
+```css live-sample___generated-content
+body {
+  font: 1.2em sans-serif;
+}
+
+.box::before {
+  content: "";
+  display: block;
+  height: 150px;
+  width: 150px;
+  padding: 20px;
+  margin: 20px;
+  border-radius: 50%;
+  float: left;
+  shape-outside: border-box;
+}
+```
+
+{{EmbedLiveSample("generated-content", "", "260px")}}
 
 ## 和`clip-path`的关系
 
@@ -103,7 +303,38 @@ Specification 定义了三种新的权限：
 
 下面的图像是一个蓝色背景的方形图像，使用 `shape-outside: ellipse(40% 50%);` 和 `clip-path: ellipse(40% 50%);` 参数去剪去相同的区域，这个区域被定义为形状。
 
-{{EmbedGHLiveSample("css-examples/shapes/overview/clip-path.html", '100%', 800)}}
+```html live-sample___clip-path
+<div class="box">
+  <img
+    alt="An orange hot air balloon as seen from below"
+    src="https://mdn.github.io/shared-assets/images/examples/balloon-small.jpg" />
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery. Before that night—a memorable night,
+    as it was to prove—hundreds of millions of people had watched the rising
+    smoke-wreaths of their fires without drawing any special inspiration from
+    the fact.
+  </p>
+</div>
+```
+
+```css live-sample___clip-path
+body {
+  font: 1.2em / 1.4 sans-serif;
+}
+
+img {
+  float: left;
+  shape-outside: ellipse(40% 50%);
+  clip-path: ellipse(40% 50%);
+}
+```
+
+{{EmbedLiveSample("clip-path", "", "280px")}}
 
 ## 形状的开发工具
 

--- a/files/zh-cn/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/zh-cn/web/css/css_transitions/using_css_transitions/index.md
@@ -235,7 +235,67 @@ document.addEventListener(
 }
 ```
 
-{{EmbedGHLiveSample("css-examples/transitions/js-transitions.html", '100%', 500)}}
+```html live-sample___js-transitions
+<p>Click anywhere to move the ball</p>
+<div id="foo" class="ball"></div>
+
+<script>
+  // Make the ball move to a certain position:
+  const f = document.getElementById("foo");
+  document.addEventListener(
+    "click",
+    (ev) => {
+      f.style.transform = `translateY(${ev.clientY - 25}px)`;
+      f.style.transform += `translateX(${ev.clientX - 25}px)`;
+    },
+    false,
+  );
+</script>
+```
+
+```css hidden live-sample___js-transitions
+body {
+  background-color: #fff;
+  color: #333;
+  font:
+    1.2em / 1.5 Helvetica Neue,
+    Helvetica,
+    Arial,
+    sans-serif;
+  padding: 0;
+  margin: 0;
+}
+
+p {
+  margin-top: 3em;
+}
+
+main {
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  max-width: 660px;
+  height: 400px;
+  border: 1px solid #ccc;
+  padding: 20px;
+}
+```
+
+```css live-sample___js-transitions
+.ball {
+  border-radius: 25px;
+  width: 50px;
+  height: 50px;
+  background: #c00;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transition: transform 1s;
+}
+```
+
+{{EmbedLiveSample("js-transitions", "", "400px")}}
 
 ### 检测渐变的开始和完成
 

--- a/files/zh-cn/web/css/font-variant-numeric/index.md
+++ b/files/zh-cn/web/css/font-variant-numeric/index.md
@@ -137,7 +137,27 @@ font-variant-numeric: unset;
 
 ### 设置序数形式
 
-{{EmbedGHLiveSample("css-examples/font-features/font-variant-numeric-example.html", '100%', 600)}}
+```html live-sample___font-variant-numeric-example
+<p class="ordinal">1st, 2nd, 3rd, 4th, 5th</p>
+```
+
+```css live-sample___font-variant-numeric-example
+@font-face {
+  font-family: "Source Sans Pro";
+  src: url("https://mdn.github.io/shared-assets/fonts/SourceSansPro-Regular.otf")
+    format("opentype");
+  font-weight: 400;
+  font-style: normal;
+}
+
+.ordinal {
+  font-family: "Source Sans Pro";
+  font-size: 2rem;
+  font-variant-numeric: ordinal;
+}
+```
+
+{{EmbedLiveSample("font-variant-numeric-example")}}
 
 ## 规范
 


### PR DESCRIPTION
Part 2 of https://github.com/mdn/translated-content/pull/26618

### Description

I'm porting over some of the embedded examples into translated content.

I look at embeds like `{{embedgh.*css-examples.*}}`

### Motivation

These are already live samples in en-US.

### For reviewers

The easiest way to review is to compare with en-US version in the previews. The actual code is copied across from the content repo, so there's no technical review to do, just a quick verify that it looks okay!

### Additional details

- [x] https://github.com/mdn/mdn/issues/597