### PR TITLE
[zh-cn] Fix a typo

### DIFF
--- a/files/zh-cn/web/javascript/reference/operators/destructuring/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/destructuring/index.md
@@ -107,7 +107,7 @@ const {
 
 ```js
 const obj = { a: 1, b: { c: 2 } };
-const { a } = obj; // a 未常量
+const { a } = obj; // a 为常量
 let {
   b: { c: d },
 } = obj; // d 可被重新赋值


### PR DESCRIPTION
### Description
Fix a typo. 
‘未常量’ -> ‘为常量’