### PR TITLE
[zh-cn]: update the translation of HTTP `102` Status

### DIFF
--- a/files/zh-cn/web/http/reference/status/102/index.md
+++ b/files/zh-cn/web/http/reference/status/102/index.md
@@ -2,7 +2,7 @@
 title: 102 Processing
 slug: Web/HTTP/Reference/Status/102
 l10n:
-  sourceCommit:
+  sourceCommit: 4d929bb0a021c7130d5a71a4bf505bcb8070378d
 ---
 
 {{HTTPSidebar}}{{deprecated_header}}

--- a/files/zh-cn/web/http/reference/status/102/index.md
+++ b/files/zh-cn/web/http/reference/status/102/index.md
@@ -30,4 +30,4 @@ HTTP **`102 Processing`** [信息响应](/zh-CN/docs/Web/HTTP/Reference/Status#�
 
 - [HTTP 响应状态码](/zh-CN/docs/Web/HTTP/Reference/Status)
 - {{HTTPStatus("100")}}
-- [rfc4918 “102 Processing”移除说明](https://www.rfc-editor.org/rfc/rfc4918#section-21.4)
+- [rfc4918“102 Processing”移除说明](https://www.rfc-editor.org/rfc/rfc4918#section-21.4)

--- a/files/zh-cn/web/http/reference/status/102/index.md
+++ b/files/zh-cn/web/http/reference/status/102/index.md
@@ -2,7 +2,7 @@
 title: 102 Processing
 slug: Web/HTTP/Reference/Status/102
 l10n:
-  sourceCommit: 975650c2f6ea843d6f7cbc721aee5dbc1db907b2
+  sourceCommit: 67a409e7944352612272e095a26bf325ecfae822
 ---
 
 {{HTTPSidebar}}{{deprecated_header}}

--- a/files/zh-cn/web/http/reference/status/102/index.md
+++ b/files/zh-cn/web/http/reference/status/102/index.md
@@ -24,10 +24,10 @@ HTTP **`102 Processing`** [信息响应](/zh-CN/docs/Web/HTTP/Reference/Status#�
 
 ## 浏览器兼容性
 
-该功能已被弃用，浏览器会忽略此响应标头。
+该特性已被弃用，浏览器会忽略此响应状态码。
 
 ## 参见
 
 - [HTTP 响应状态码](/zh-CN/docs/Web/HTTP/Reference/Status)
 - {{HTTPStatus("100")}}
-- [rfc4918 '102 Processing' 移除说明](https://www.rfc-editor.org/rfc/rfc4918#section-21.4)
+- [rfc4918 “102 Processing”移除说明](https://www.rfc-editor.org/rfc/rfc4918#section-21.4)

--- a/files/zh-cn/web/http/reference/status/102/index.md
+++ b/files/zh-cn/web/http/reference/status/102/index.md
@@ -2,21 +2,19 @@
 title: 102 Processing
 slug: Web/HTTP/Reference/Status/102
 l10n:
-  sourceCommit: 592f6ec42e54981b6573b58ec0343c9aa8cbbda8
+  sourceCommit:
 ---
 
 {{HTTPSidebar}}{{deprecated_header}}
 
-在 HTTP 协议中，**`102 Processing`** 状态码向客户端表示已收到完整请求，并且服务器正在处理该请求。
-
-仅当服务器预计请求需要很长时间时会发送此状态码，以告知客户端请求尚未终止。
+HTTP **`102 Processing`** [信息响应](/zh-CN/docs/Web/HTTP/Reference/Status#信息响应)状态码用于告知客户端请求已被完整接收，服务器正在处理中。此状态码仅在服务器预期该请求将耗费较长时间时才会发送。
 
 > [!NOTE]
-> 此状态码已被弃用，不应再发送。客户端可能仍然接受并简单地忽略该状态码。
+> 常规的 Web 服务器不会返回该响应。此状态码最初在基于 Web 的分布式编写与版本控制（{{Glossary("WebDAV")}}）的 {{RFC("2518")}} 中引入，但在 {{RFC("4918")}} 中已被移除。
 
 ## 状态
 
-```plain
+```http
 102 Processing
 ```
 
@@ -24,7 +22,12 @@ l10n:
 
 {{Specifications}}
 
+## 浏览器兼容性
+
+该功能已被弃用，浏览器会忽略此响应标头。
+
 ## 参见
 
-- {{HTTPHeader("Expect")}}
+- [HTTP 响应状态码](/zh-CN/docs/Web/HTTP/Reference/Status)
 - {{HTTPStatus("100")}}
+- [rfc4918 '102 Processing' 移除说明](https://www.rfc-editor.org/rfc/rfc4918#section-21.4)

--- a/files/zh-cn/web/http/reference/status/102/index.md
+++ b/files/zh-cn/web/http/reference/status/102/index.md
@@ -2,15 +2,15 @@
 title: 102 Processing
 slug: Web/HTTP/Reference/Status/102
 l10n:
-  sourceCommit: 4d929bb0a021c7130d5a71a4bf505bcb8070378d
+  sourceCommit: 975650c2f6ea843d6f7cbc721aee5dbc1db907b2
 ---
 
 {{HTTPSidebar}}{{deprecated_header}}
 
-HTTP **`102 Processing`** [信息响应](/zh-CN/docs/Web/HTTP/Reference/Status#信息响应)状态码用于告知客户端请求已被完整接收，服务器正在处理中。此状态码仅在服务器预期该请求将耗费较长时间时才会发送。
+HTTP **`102 Processing`** [信息响应](/zh-CN/docs/Web/HTTP/Reference/Status#信息响应)状态码用于告知客户端已接收到完整的请求，并且服务器正在处理中。此状态码仅在服务器预期该请求将耗费较长时间处理时才会发送。
 
 > [!NOTE]
-> 常规的 Web 服务器不会返回该响应。此状态码最初在基于 Web 的分布式编写与版本控制（{{Glossary("WebDAV")}}）的 {{RFC("2518")}} 中引入，但在 {{RFC("4918")}} 中已被移除。
+> 常规的 Web 服务器不会返回该响应。此状态码最初在基于 Web 的分布式编写与版本控制（{{Glossary("WebDAV")}}）的 {{RFC("2518")}} 中引入，但已在 {{RFC("4918")}} 中从 WebDAV 中被移除。
 
 ## 状态
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/102
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/http/reference/status/102/index.md
* Last commit: https://github.com/mdn/content/commit/975650c2f6ea843d6f7cbc721aee5dbc1db907b2
