### PR TITLE
[zh-cn]: update the translation of `DOMParser` introduction

### DIFF
--- a/files/zh-cn/web/api/domparser/index.md
+++ b/files/zh-cn/web/api/domparser/index.md
@@ -13,10 +13,10 @@ l10n:
 
 对于 HTML 文档，你也可以通过设置 {{domxref("Element.innerHTML")}} 和 {{domxref("Element.outerHTML", "outerHTML")}} 属性的值，将部分 DOM 替换为由 HTML 构建的新 DOM 树。
 
-请注意，{{domxref("XMLHttpRequest")}} 可以直接从一个可通过 URL 访问的资源中解析 XML 和 HTML，并将 {{domxref("XMLHttpRequest.response", "response")}} 返回到其 `Document` 属性中。
+请注意，{{domxref("XMLHttpRequest")}} 可以直接从一个可通过 URL 访问的资源中解析 XML 和 HTML，并将  `Document` 返回到其 {{domxref("XMLHttpRequest.response", "response")}} 属性中。
 
 > [!NOTE]
-> 请注意，如果一个[块级元素](/zh-CN/docs/Glossary/Block-level_content)（例如 `<p>`）内部嵌套了另一个块级元素，则该块级元素会被自动闭合，并且在解析时会先解析嵌套元素，而在闭合 `</p>` 标签之前就已完成解析。
+> 请注意，如果在一个[块级元素](/zh-CN/docs/Glossary/Block-level_content)（例如 `<p>`）内部嵌套了另一个块级元素，并且该嵌套元素在闭合的 `</p>` 标签之前被解析，那么元素将会被自动闭合。
 
 ## 构造函数
 
@@ -45,4 +45,4 @@ l10n:
 - [解析或序列化 XML](/zh-CN/docs/Web/XML/Guides/Parsing_and_serializing_XML)
 - {{domxref("XMLHttpRequest")}}
 - {{domxref("XMLSerializer")}}
-- {{jsxref("JSON.parse()")}}——与 {{jsxref("JSON")}} 文档对应的方法。
+- {{jsxref("JSON.parse()")}}——{{jsxref("JSON")}} 文档的对应方法。

--- a/files/zh-cn/web/api/domparser/index.md
+++ b/files/zh-cn/web/api/domparser/index.md
@@ -13,7 +13,7 @@ l10n:
 
 对于 HTML 文档，你也可以通过设置 {{domxref("Element.innerHTML")}} 和 {{domxref("Element.outerHTML", "outerHTML")}} 属性的值，将部分 DOM 替换为由 HTML 构建的新 DOM 树。
 
-请注意，{{domxref("XMLHttpRequest")}} 可以直接从一个可通过 URL 访问的资源中解析 XML 和 HTML，并将  `Document` 返回到其 {{domxref("XMLHttpRequest.response", "response")}} 属性中。
+请注意，{{domxref("XMLHttpRequest")}} 可以直接从一个可通过 URL 访问的资源中解析 XML 和 HTML，并将 `Document` 返回到其 {{domxref("XMLHttpRequest.response", "response")}} 属性中。
 
 > [!NOTE]
 > 请注意，如果在一个[块级元素](/zh-CN/docs/Glossary/Block-level_content)（例如 `<p>`）内部嵌套了另一个块级元素，并且该嵌套元素在闭合的 `</p>` 标签之前被解析，那么元素将会被自动闭合。

--- a/files/zh-cn/web/api/domparser/index.md
+++ b/files/zh-cn/web/api/domparser/index.md
@@ -1,141 +1,36 @@
 ---
 title: DOMParser
 slug: Web/API/DOMParser
+l10n:
+  sourceCommit: 3e1b5277c6451e7d27ab628f23fb9702947a7a7b
 ---
 
 {{APIRef("DOM")}}
 
-**`DOMParser`** 可以将存储在字符串中的 {{Glossary("XML")}} 或 {{Glossary("HTML")}} 源代码解析为一个 DOM {{domxref("Document")}}。
+**`DOMParser`** 接口提供了将字符串中的 {{Glossary("XML")}} 或 {{Glossary("HTML")}} 源代码解析为 DOM {{domxref("Document")}} 的功能。
 
-> **备注：** {{domxref("XMLHttpRequest")}} 支持从 URL 可寻址资源解析 XML 和 HTML，在其{{domxref("XMLHttpRequest.response", "response")}} 属性中返回`Document`。
+你可以使用 {{domxref("XMLSerializer")}} 接口执行相反的操作——将 DOM 树转换为 XML 或 HTML 源代码。
 
-你可以使用{{domxref("XMLSerializer")}} 接口执行相反的操作 - 将 DOM 树转换为 XML 或 HTML 源。
+对于 HTML 文档，你也可以通过设置 {{domxref("Element.innerHTML")}} 和 {{domxref("Element.outerHTML", "outerHTML")}} 属性的值，将部分 DOM 替换为由 HTML 构建的新 DOM 树。
 
-对于 HTML 文档，你还可以通过设置 {{domxref("Element.innerHTML")}} 和{{domxref("Element.outerHTML", "outerHTML")}} 属性的值，将部分 DOM 替换为从 HTML 构建的新 DOM 树。还可以读取这些属性以获取对应于相应 DOM 子树的 HTML 片段。
+请注意，{{domxref("XMLHttpRequest")}} 可以直接从一个可通过 URL 访问的资源中解析 XML 和 HTML，并将 {{domxref("XMLHttpRequest.response", "response")}} 返回到其 `Document` 属性中。
 
-## 语法
+> [!NOTE]
+> 请注意，如果一个[块级元素](/zh-CN/docs/Glossary/Block-level_content)（例如 `<p>`）内部嵌套了另一个块级元素，则该块级元素会被自动闭合，并且在解析时会先解析嵌套元素，而在闭合 `</p>` 标签之前就已完成解析。
 
-```js
-let domparser = new DOMParser();
-```
+## 构造函数
 
-## 方法
+- {{domxref("DOMParser.DOMParser","DOMParser()")}}
+  - : 创建一个新的 `DOMParser` 对象。
 
-{{domxref("DOMParser.parseFromString()")}}
+## 实例方法
 
-### 语法
+- {{domxref("DOMParser.parseFromString()")}}
+  - : 使用 HTML 解析器或 XML 解析器解析字符串，并返回一个 {{domxref("HTMLDocument")}} 或 {{domxref("XMLDocument")}}。
 
-```js
-let doc = domparser.parseFromString(string, mimeType);
-```
+## 示例
 
-### 返回值
-
-基于 **[`mimeType`](#argument02)** 参数，返回 {{domxref("Document")}} 或 {{domxref("XMLDocument")}} 或其他文档类型。
-
-### 参数
-
-该方法接收 2 个必要参数：
-
-- `string`
-  - : 要解析的 {{domxref("DOMString")}}。它必须包含 {{Glossary("HTML")}}、{{Glossary("xml")}}、{{Glossary("xhtml+xml")}} 或 {{Glossary("svg")}} 文档。
-- `mimeType`
-
-  - : 一个 {{domxref("DOMString")}}。这个字符串决定方法返回值的类。可能的取值有：
-
-| `mimeType`              | doc.constructor            |
-| ----------------------- | -------------------------- |
-| `text/html`             | {{domxref("Document")}}    |
-| `text/xml`              | {{domxref("XMLDocument")}} |
-| `application/xml`       | {{domxref("XMLDocument")}} |
-| `application/xhtml+xml` | {{domxref("XMLDocument")}} |
-| `image/svg+xml`         | {{domxref("XMLDocument")}} |
-
-## 解析 XML
-
-一旦建立了一个解析对象以后，你就可以使用它的 `parseFromString` 方法来解析一个 XML 字符串：
-
-```js
-let parser = new DOMParser(),
-  doc = parser.parseFromString(stringContainingXMLSource, "application/xml");
-```
-
-#### 错误处理
-
-如果解析失败，`DOMParser` 不会抛出任何异常，而是会返回一个给定的错误文档：
-
-```xml
-<parsererror xmlns="http://www.mozilla.org/newlayout/xml/parsererror.xml">
-(error description)
-<sourcetext>(a snippet of the source XML)</sourcetext>
-</parsererror>
-```
-
-解析错误会显示在[错误控制台](/zh-CN/docs/Error_Console)，包括文档的地址和错误的源代码。
-
-## 解析 SVG 或者 HTML 文档
-
-`DOMParser` 也可以用来解析 SVG 文档或者 HTML 文档。根据给定的 MIME 类型不同，`parseFromString` 方法可能返回三种不同类型的文档。如果 MIME 类型是 `text/xml`，则返回一个 `XMLDocument`，如果 MIME 类型是 `text/svg+xml`，则返回一个 `SVGDocument`，如果 MIME 类型是 `text/html`，则返回一个 `HTMLDocument`。
-
-```js
-let parser = new DOMParser();
-let doc = parser.parseFromString(stringContainingXMLSource, "application/xml");
-// 返回一个 Document 对象，但不是 SVGDocument，也不是 HTMLDocument
-
-parser = new DOMParser();
-doc = parser.parseFromString(stringContainingXMLSource, "image/svg+xml");
-// 返回一个 SVGDocument 对象，同时也是一个 Document 对象。
-
-parser = new DOMParser();
-doc = parser.parseFromString(stringContainingHTMLSource, "text/html");
-// 返回一个 HTMLDocument 对象，同时也是一个 Document 对象。
-```
-
-## DOMParser HTML 扩展
-
-```js
-/*
- * DOMParser HTML extension
- * 2012-09-04
- *
- * By Eli Grey, http://eligrey.com
- * Public domain.
- * NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
- */
-
-/*! @source https://gist.github.com/1129031 */
-/*global document, DOMParser*/
-
-(function (DOMParser) {
-  "use strict";
-
-  var proto = DOMParser.prototype,
-    nativeParse = proto.parseFromString;
-
-  // Firefox/Opera/IE throw errors on unsupported types
-  try {
-    // WebKit returns null on unsupported types
-    if (new DOMParser().parseFromString("", "text/html")) {
-      // text/html parsing is natively supported
-      return;
-    }
-  } catch (ex) {}
-
-  proto.parseFromString = function (markup, type) {
-    if (/^\s*text\/html\s*(?:;|$)/i.test(type)) {
-      var doc = document.implementation.createHTMLDocument("");
-      if (markup.toLowerCase().indexOf("<!doctype") > -1) {
-        doc.documentElement.innerHTML = markup;
-      } else {
-        doc.body.innerHTML = markup;
-      }
-      return doc;
-    } else {
-      return nativeParse.apply(this, arguments);
-    }
-  };
-})(DOMParser);
-```
+{{domxref("DOMParser.parseFromString()")}} 是该接口的唯一方法，其文档中包含了用于解析 XML、SVG 和 HTML 字符串的示例。
 
 ## 规范
 
@@ -147,7 +42,7 @@ doc = parser.parseFromString(stringContainingHTMLSource, "text/html");
 
 ## 参见
 
-- [Parsing and serializing XML](/zh-CN/docs/Web/XML/Guides/Parsing_and_serializing_XML)
+- [解析或序列化 XML](/zh-CN/docs/Web/XML/Guides/Parsing_and_serializing_XML)
 - {{domxref("XMLHttpRequest")}}
 - {{domxref("XMLSerializer")}}
-- {{jsxref("JSON.parse()")}} - counterpart for {{jsxref("JSON")}} documents.
+- {{jsxref("JSON.parse()")}}——与 {{jsxref("JSON")}} 文档对应的方法。

--- a/files/zh-cn/web/api/domparser/index.md
+++ b/files/zh-cn/web/api/domparser/index.md
@@ -16,7 +16,7 @@ l10n:
 请注意，{{domxref("XMLHttpRequest")}} 可以直接从一个可通过 URL 访问的资源中解析 XML 和 HTML，并将 `Document` 返回到其 {{domxref("XMLHttpRequest.response", "response")}} 属性中。
 
 > [!NOTE]
-> 请注意，如果在一个[块级元素](/zh-CN/docs/Glossary/Block-level_content)（例如 `<p>`）内部嵌套了另一个块级元素，并且该嵌套元素在闭合的 `</p>` 标签之前被解析，那么元素将会被自动闭合。
+> 请注意，如果在一个[块级元素](/zh-CN/docs/Glossary/Block-level_content)（例如 `<p>`）内部嵌套了另一个块级元素，因而该嵌套元素在闭合的 `</p>` 标签之前被解析，那么元素将会被自动闭合。
 
 ## 构造函数
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/domparser/index.md
* Last commit: https://github.com/mdn/content/commit/3e1b5277c6451e7d27ab628f23fb9702947a7a7b
* fixed: https://github.com/mdn/translated-content/issues/26777