### PR TITLE
[ko]: fix link reference in isNaN documentation

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/isnan/index.md
+++ b/files/ko/web/javascript/reference/global_objects/isnan/index.md
@@ -5,7 +5,7 @@ slug: Web/JavaScript/Reference/Global_Objects/isNaN
 
 {{jsSidebar("Objects")}}
 
-**`isNaN()`** 함수는 어떤 값이 {{jsxref("NaN")}}인지 판별합니다. `isNaN` 함수는 몇몇 [혼란스러운 케이스](special-behavior)을 가지고 있으므로, ECMAScript 2015에서 추가한 {{jsxref("Number.isNaN()")}}으로 바꾸는 편이 좋을 수도 있습니다.
+**`isNaN()`** 함수는 어떤 값이 {{jsxref("NaN")}}인지 판별합니다. `isNaN` 함수는 몇몇 [혼란스러운 케이스](#설명)을 가지고 있으므로, ECMAScript 2015에서 추가한 {{jsxref("Number.isNaN()")}}으로 바꾸는 편이 좋을 수도 있습니다.
 
 {{InteractiveExample("JavaScript Demo: Standard built-in objects - isNaN()")}}
 


### PR DESCRIPTION
### Description

isNaN() 메서드 설명 페이지에서 올바르지 못한 링크를 수정했습니다.

### Motivation

isNaN() 메서드 docs 에서 기존에 "혼란 스러운 케이스" 를 클릭하게 되면 pecial-behavior 페이지로 이동하면서 `page not found` 에러가 발생했습니다. 

mdn/content 와 다른 언어로 번역된 파일을 비교해본 결과 `#설명` 으로 변경하여 에러를 수정하여 유저가 올바른 정보를 얻을 수 있도록 수정하였습니다.

### Additional details

에러 영상 첨부합니다.


https://github.com/user-attachments/assets/441fb0bd-3af6-4055-99c2-a7aa13bee68f



### Related issues and pull requests

- #26793 
