### PR TITLE
[zh-cn]: update the translation of `Date.prototype.valueOf()` method

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/date/valueof/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/valueof/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{JSRef}}
 
-**`valueOf()`** 方法是 {{jsxref("Date")}} 实例的方法，用于返回自[纪元](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date)（即协调世界时 1970 年 1 月 1 日零点）以来的毫秒数。
+{{jsxref("Date")}} 实例的 **`valueOf()`** 方法用于返回自[纪元](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date#纪元、时间戳和无效日期)（即协调世界时 1970 年 1 月 1 日零点）以来的毫秒数。
 
 {{InteractiveExample("JavaScript Demo: Date.prototype.valueOf()")}}
 

--- a/files/zh-cn/web/javascript/reference/global_objects/date/valueof/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/valueof/index.md
@@ -1,51 +1,55 @@
 ---
 title: Date.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/Date/valueOf
+l10n:
+  sourceCommit: 9645d14f12d9b93da98daaf25a443bb6cac3f2a6
 ---
 
 {{JSRef}}
 
-**`valueOf()`** 方法返回一个 {{jsxref("Date")}} 对象的原始值。
+**`valueOf()`** 方法是 {{jsxref("Date")}} 实例的方法，用于返回自[纪元](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date)（即协调世界时 1970 年 1 月 1 日零点）以来的毫秒数。
 
-{{InteractiveExample("JavaScript Demo: Date.valueOf()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.valueOf()")}}
 
 ```js interactive-example
 const date1 = new Date(Date.UTC(96, 1, 2, 3, 4, 5));
 
 console.log(date1.valueOf());
-// Expected output: 823230245000
+// 预期输出：823230245000
 
 const date2 = new Date("02 Feb 1996 03:04:05 GMT");
 
 console.log(date2.valueOf());
-// Expected output: 823230245000
+// 预期输出：823230245000
 ```
 
 ## 语法
 
-```plain
-dateObj.valueOf()
+```js-nolint
+valueOf()
 ```
+
+### 参数
+
+无。
 
 ### 返回值
 
-从 1970 年 1 月 1 日 0 时 0 分 0 秒（UTC，即协调世界时）到该日期的毫秒数。
+一个数字，表示该日期的[时间戳](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date#纪元、时间戳和无效日期)，单位为毫秒。如果该日期为[无效日期](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date#纪元、时间戳和无效日期)，则返回 `NaN`。
 
 ## 描述
 
-`valueOf` 方法返回以数值格式表示的一个 `Date` 对象的原始值，从 1970 年 1 月 1 日 0 时 0 分 0 秒（UTC，即协调世界时）到该日期对象所代表时间的毫秒数。
+`valueOf()` 方法是[强制类型转换](/zh-CN/docs/Web/JavaScript/Guide/Data_structures#强制类型转换)机制的一部分。由于 `Date` 拥有 [`[Symbol.toPrimitive]()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date/Symbol.toPrimitive) 方法，当 `Date` 对象被隐式[转换为数字](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Number#number_强制转换)时，该方法总是优先于 `valueOf()`。不过，`Date.prototype[Symbol.toPrimitive]()` 在内部仍会调用 `this.valueOf()`。
 
-该方法的功能和 {{jsxref("Date.prototype.getTime()")}} 方法一样。
-
-该方法通常在 JavaScript 内部被调用，而不是在代码中显式调用。
+{{jsxref("Date")}} 对象重写了 {{jsxref("Object/valueOf", "valueOf()")}} 方法（该方法来自 {{jsxref("Object")}}）。`Date.prototype.valueOf()` 返回该日期的时间戳，其功能上等同于 {{jsxref("Date.prototype.getTime()")}} 方法。
 
 ## 示例
 
-### 使用 `valueOf()`
+### 使用 valueOf()
 
 ```js
-var x = new Date(56, 6, 17);
-var myVar = x.valueOf(); // assigns -424713600000 to myVar
+const d = new Date(0); // 1970-01-01T00:00:00.000Z
+console.log(d.valueOf()); // 0
 ```
 
 ## 规范

--- a/files/zh-cn/web/javascript/reference/global_objects/date/valueof/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/date/valueof/index.md
@@ -35,7 +35,7 @@ valueOf()
 
 ### 返回值
 
-一个数字，表示该日期的[时间戳](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date#纪元、时间戳和无效日期)，单位为毫秒。如果该日期为[无效日期](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date#纪元、时间戳和无效日期)，则返回 `NaN`。
+一个数字，表示该日期的[时间戳](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date#纪元、时间戳和无效日期)，单位为毫秒。如果该日期[无效](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date#纪元、时间戳和无效日期)，则返回 `NaN`。
 
 ## 描述
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/date/valueof/index.md
* Last commit: https://github.com/mdn/content/commit/9645d14f12d9b93da98daaf25a443bb6cac3f2a6