### PR TITLE
[zh-cn]: update the translation of `CredentialsContainer` introduction

### DIFF
--- a/files/zh-cn/web/api/credentialscontainer/index.md
+++ b/files/zh-cn/web/api/credentialscontainer/index.md
@@ -20,7 +20,7 @@ l10n:
 - {{domxref("CredentialsContainer.get()")}}
   - : 返回一个 {{jsxref("Promise")}}，根据提供的参数解析为匹配的 {{domxref("Credential")}} 实例。
 - {{domxref("CredentialsContainer.preventSilentAccess()")}}
-  - : 设置一个标志位用于指定是否允许当前源在后续访问时自动登录，随后返回一个空的 {{jsxref("Promise")}}。例如，当用户从网站注销后调用此方法，可确保其在下次访问时不会自动登录。该方法的早期规范版本曾命名为 `requireUserMediation()`。具体支持情况请参阅[Browser compatibility](#浏览器兼容性)。
+  - : 设置一个标志位用于指定是否允许当前源在后续访问时自动登录，随后返回一个空的 {{jsxref("Promise")}}。例如，当用户从网站注销后调用此方法，可确保其在下次访问时不会自动登录。该方法的早期规范版本曾命名为 `requireUserMediation()`。具体支持情况请参阅[浏览器兼容性](#浏览器兼容性)。
 - {{domxref("CredentialsContainer.store()")}}
   - : 将用户的一组凭证存储到指定的 {{domxref("Credential")}} 实例中，并通过 {{jsxref("Promise")}} 返回该实例。
 

--- a/files/zh-cn/web/api/credentialscontainer/index.md
+++ b/files/zh-cn/web/api/credentialscontainer/index.md
@@ -16,7 +16,7 @@ l10n:
 ## 实例方法
 
 - {{domxref("CredentialsContainer.create()")}}
-  - : 返回一个 {{jsxref("Promise")}}，根据提供的参数解析为一个新的 {{domxref("Credential")}} 实例；如果无法创建 `Credential` 对象，则解析为 `null`。在特殊情况下，该{{jsxref("Promise")}} 可能会被拒绝。
+  - : 返回一个 {{jsxref("Promise")}}，根据提供的参数解析为一个新的 {{domxref("Credential")}} 实例；如果无法创建 `Credential` 对象，则解析为 `null`。在特殊情况下，该 {{jsxref("Promise")}} 可能会被拒绝。
 - {{domxref("CredentialsContainer.get()")}}
   - : 返回一个 {{jsxref("Promise")}}，根据提供的参数解析为匹配的 {{domxref("Credential")}} 实例。
 - {{domxref("CredentialsContainer.preventSilentAccess()")}}

--- a/files/zh-cn/web/api/credentialscontainer/index.md
+++ b/files/zh-cn/web/api/credentialscontainer/index.md
@@ -1,40 +1,30 @@
 ---
 title: CredentialsContainer
 slug: Web/API/CredentialsContainer
+l10n:
+  sourceCommit: c91c87d7da181194f3786abfcb2f27d2b885fb91
 ---
 
-{{SeeCompatTable}}{{APIRef("Credential Management API")}}
+{{APIRef("Credential Management API")}}{{securecontext_header}}
 
-[Credential Management API](/zh-CN/docs/Web/API/Credential_Management_API) 的 **`CredentialsContainer`** 接口提供了请求 credentials 和通知用户代理（当成功登陆或登出事件发生时）的方法。可通过 `Navigator.credentials` 获得该接口。
+[凭证管理 API](/zh-CN/docs/Web/API/Credential_Management_API) 的 **`CredentialsContainer`** 接口提供了一系列方法，用于请求凭证并在登录成功或注销等事件发生时通知用户代理。该接口可通过 {{domxref('Navigator.credentials')}} 访问。
 
-## 属性
+## 实例属性
 
-None.
+无。
 
-### 事件
-
-None.
-
-返回一个带有处理值 [`Credential`](https://w3c.github.io/webappsec-credential-management/#credential)（若它能够使用提供的选项创建的话）的 [`Promise`](https://heycam.github.io/webidl/#idl-promise) ，或返回 `null`（若不能创建 [`Credential`](https://w3c.github.io/webappsec-credential-management/#credential)）。在特殊情况下，返回的 [`Promise`](https://heycam.github.io/webidl/#idl-promise) 对象可能 reject。
-
-## 方法
+## 实例方法
 
 - {{domxref("CredentialsContainer.create()")}}
-  - : Returns a {{jsxref("Promise")}} that resolves with a new {{domxref("Credential")}} instance based on the provided options, or `null` of no `Credential` object can be created.
+  - : 返回一个 {{jsxref("Promise")}}，根据提供的参数解析为一个新的 {{domxref("Credential")}} 实例；如果无法创建 `Credential` 对象，则解析为 `null`。在特殊情况下，该{{jsxref("Promise")}} 可能会被拒绝。
 - {{domxref("CredentialsContainer.get()")}}
-  - : Returns a {{jsxref("Promise")}} that resolves with the {{domxref("Credential")}} instance that matches the provided parameters.
+  - : 返回一个 {{jsxref("Promise")}}，根据提供的参数解析为匹配的 {{domxref("Credential")}} 实例。
 - {{domxref("CredentialsContainer.preventSilentAccess()")}}
-  - : Sets a flag that specifies whether automatic log in is allowed for future visits to the current origin, then returns an empty {{jsxref("Promise")}}. For example, you might call this, after a user signs out of a website to ensure that he/she isn't automatically signed in on the next site visit. Earlier versions of the spec called this method `requireUserMediation()`. See [Browser compatibility](#浏览器兼容性) for support details.
+  - : 设置一个标志位用于指定是否允许当前源在后续访问时自动登录，随后返回一个空的 {{jsxref("Promise")}}。例如，当用户从网站注销后调用此方法，可确保其在下次访问时不会自动登录。该方法的早期规范版本曾命名为 `requireUserMediation()`。具体支持情况请参阅[Browser compatibility](#浏览器兼容性)。
 - {{domxref("CredentialsContainer.store()")}}
-  - : Stores a set of credentials for a user, inside a provided {{domxref("Credential")}} instance and returns that instance in a {{jsxref("Promise")}}.
+  - : 将用户的一组凭证存储到指定的 {{domxref("Credential")}} 实例中，并通过 {{jsxref("Promise")}} 返回该实例。
 
-## 示例
-
-```js
-// TBD
-```
-
-## Specifications
+## 规范
 
 {{Specifications}}
 

--- a/files/zh-cn/web/api/credentialscontainer/index.md
+++ b/files/zh-cn/web/api/credentialscontainer/index.md
@@ -16,11 +16,11 @@ l10n:
 ## 实例方法
 
 - {{domxref("CredentialsContainer.create()")}}
-  - : 返回一个 {{jsxref("Promise")}}，根据提供的参数解析为一个新的 {{domxref("Credential")}} 实例；如果无法创建 `Credential` 对象，则解析为 `null`。在特殊情况下，该 {{jsxref("Promise")}} 可能会被拒绝。
+  - : 返回一个 {{jsxref("Promise")}}，根据提供的参数兑现为一个新的 {{domxref("Credential")}} 实例；如果无法创建 `Credential` 对象，则兑现为 `null`。在特殊情况下，该 {{jsxref("Promise")}} 可能会被拒绝。
 - {{domxref("CredentialsContainer.get()")}}
   - : 返回一个 {{jsxref("Promise")}}，根据提供的参数解析为匹配的 {{domxref("Credential")}} 实例。
 - {{domxref("CredentialsContainer.preventSilentAccess()")}}
-  - : 设置一个标志位用于指定是否允许当前源在后续访问时自动登录，随后返回一个空的 {{jsxref("Promise")}}。例如，当用户从网站注销后调用此方法，可确保其在下次访问时不会自动登录。该方法的早期规范版本曾命名为 `requireUserMediation()`。具体支持情况请参阅[浏览器兼容性](#浏览器兼容性)。
+  - : 设置一个用于指定是否允许当前源在后续访问时自动登录的标志位，随后返回一个空的 {{jsxref("Promise")}}。例如，当用户从网站注销后调用此方法，可确保其在下次访问时不会自动登录。该方法的早期规范版本曾命名为 `requireUserMediation()`。具体支持情况请参阅[浏览器兼容性](#浏览器兼容性)。
 - {{domxref("CredentialsContainer.store()")}}
   - : 将用户的一组凭证存储到指定的 {{domxref("Credential")}} 实例中，并通过 {{jsxref("Promise")}} 返回该实例。
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/credentialscontainer/index.md
* Last commit: https://github.com/mdn/content/commit/c91c87d7da181194f3786abfcb2f27d2b885fb91
