### PR TITLE
fix typo

### DIFF
--- a/files/zh-cn/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
@@ -6,7 +6,7 @@ slug: Mozilla/Add-ons/WebExtensions/Extending_the_developer_tools
 {{AddonSidebar}}
 
 > [!NOTE]
-> 本页介绍了火狐 Firefox 55 中存在的开发工具接口（devtools API)。虽然该接口 Api 基于 Chrome 开发工具 Api，仍有许多功能尚未实现在火狐中实现，因此未记录在本页内容中。产看当前缺失的功能，请参阅链接[开发工具 Api 的限制](#devtools_api_的局限性)。
+> 本页介绍了火狐 Firefox 55 中存在的开发工具接口（devtools API)。虽然该接口 Api 基于 Chrome 开发工具 Api，仍有许多功能尚未实现在火狐中实现，因此未记录在本页内容中。查看当前缺失的功能，请参阅链接[开发工具 Api 的限制](#devtools_api_的局限性)。
 
 你可以使用 WebExtensions API 扩展浏览器的内置开发人员工具。要创建 devtools 扩展，请在 manifest.json 中包含“devtools_page”键：
 


### PR DESCRIPTION
### Description
There is a typo in chinese version of https://developer.mozilla.org/zh-CN/docs/Mozilla/Add-ons/WebExtensions/Extending_the_developer_tools
![image](https://github.com/user-attachments/assets/caeb80ca-aa39-429f-aa62-00ccdab5d6a1)

### Motivation
I was reviewing this document and noticed this typo, so I fixed it on the spot.