### PR TITLE
Replace interactive-examples assets with shared-assets

### DIFF
--- a/files/es/learn_web_development/core/scripting/events/index.md
+++ b/files/es/learn_web_development/core/scripting/events/index.md
@@ -529,9 +529,7 @@ El HTML se ve así:
 
 <div class="hidden">
   <video>
-    <source
-      src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
-      type="video/webm" />
+    <source src="/shared-assets/videos/flower.webm" type="video/webm" />
     <p>
       Su navegador no es compatible con video HTML. Aquí hay un
       <a href="rabbit320.mp4">enlace al video</a> en su lugar.
@@ -625,9 +623,7 @@ Todo lo que estamos haciendo aquí es llamar al método `stopPropagation()` en e
 
 <div class="hidden">
   <video>
-    <source
-      src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
-      type="video/webm" />
+    <source src="/shared-assets/videos/flower.webm" type="video/webm" />
     <p>
       Su navegador no es compatible con video HTML. Aquí hay un
       <a href="rabbit320.mp4">enlace al video</a> en su lugar.

--- a/files/fr/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
+++ b/files/fr/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
@@ -42,8 +42,7 @@ ctx.font = "16px sans-serif";
 ctx.textAlign = "center";
 
 const img = new Image();
-img.src =
-  "https://interactive-examples.mdn.mozilla.net/media/examples/star.png";
+img.src = "/shared-assets/images/examples/big-star.png";
 img.onload = function () {
   const w = img.width,
     h = img.height;

--- a/files/fr/web/css/border-image-slice/index.md
+++ b/files/fr/web/css/border-image-slice/index.md
@@ -170,7 +170,7 @@ div > div {
   height: 200px;
   border-width: 30px;
   border-style: solid;
-  border-image: url(https://interactive-examples.mdn.mozilla.net/media/examples/border-diamonds.png);
+  border-image: url(/shared-assets/images/examples/border-diamonds.png);
   border-image-slice: 30;
   border-image-repeat: round;
 }

--- a/files/ja/learn_web_development/core/scripting/event_bubbling/index.md
+++ b/files/ja/learn_web_development/core/scripting/event_bubbling/index.md
@@ -136,7 +136,7 @@ HTML はこのようになります。
 <div class="hidden">
   <video>
     <source
-      src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
+      src="/shared-assets/videos/flower.webm"
       type="video/webm" />
     <p>
       このブラウザーは HTML の動画に対応していません。
@@ -231,7 +231,7 @@ box.addEventListener("click", () => box.classList.add("hidden"));
 <div class="hidden">
   <video>
     <source
-      src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
+      src="/shared-assets/videos/flower.webm"
       type="video/webm" />
     <p>
       このブラウザーは HTML の動画に対応していません。

--- a/files/ja/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
@@ -41,8 +41,7 @@ ctx.font = "16px sans-serif";
 ctx.textAlign = "center";
 
 const img = new Image();
-img.src =
-  "https://interactive-examples.mdn.mozilla.net/media/examples/star.png";
+img.src = "/shared-assets/images/examples/big-star.png";
 img.onload = () => {
   const w = img.width,
     h = img.height;

--- a/files/ja/web/api/fontfaceset/check/index.md
+++ b/files/ja/web/api/fontfaceset/check/index.md
@@ -37,15 +37,11 @@ check(font, text)
 次の例では、新しい `FontFace` を作成し、それを `FontFaceSet` に追加します。
 
 ```js
-const font = new FontFace(
-  "molot",
-  "url(https://interactive-examples.mdn.mozilla.net/media/fonts/molot.woff2)",
-  {
-    style: "normal",
-    weight: "400",
-    stretch: "condensed",
-  },
-);
+const font = new FontFace("molot", "url(/shared-assets/fonts/molot.woff2)", {
+  style: "normal",
+  weight: "400",
+  stretch: "condensed",
+});
 
 document.fonts.add(font);
 ```

--- a/files/ja/web/api/htmlimageelement/x/index.md
+++ b/files/ja/web/api/htmlimageelement/x/index.md
@@ -45,7 +45,7 @@ l10n:
   <tr>
     <td>12345678</td>
     <td>Johnny Rocket</td>
-    <td><img src="https://interactive-examples.mdn.mozilla.net/media/examples/grapefruit-slice-332-332.jpg"></td>
+    <td><img src="/shared-assets/images/examples/grapefruit-slice.jpg"></td>
   </th>
 </table>
 <pre id="log">

--- a/files/ja/web/api/htmlmediaelement/loadstart_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/loadstart_event/index.md
@@ -100,10 +100,7 @@ loadVideo.addEventListener("click", () => {
   } else {
     loadVideo.textContent = "Reset example";
     source = document.createElement("source");
-    source.setAttribute(
-      "src",
-      "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm",
-    );
+    source.setAttribute("src", "/shared-assets/videos/flower.webm");
     source.setAttribute("type", "video/webm");
 
     video.appendChild(source);

--- a/files/ja/web/api/vttcue/index.md
+++ b/files/ja/web/api/vttcue/index.md
@@ -53,9 +53,7 @@ _このインターフェイスには {{domxref("TextTrackCue")}} から継承�
 次の例は、新しい {{domxref("TextTrack")}} を動画に追加し、次に {{domxref("TextTrack.addCue()")}} メソッドを使用して `VTTCue` オブジェクトを値としてキューを追加します。
 
 ```html
-<video
-  controls
-  src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/friday.mp4"></video>
+<video controls src="/shared-assets/videos/friday.mp4"></video>
 ```
 
 ### CSS

--- a/files/ja/web/api/webvtt_api/index.md
+++ b/files/ja/web/api/webvtt_api/index.md
@@ -79,9 +79,7 @@ WebVTTの最も重要な機能は、ファイル形式またはウェブ API を
 次の例では、新しい {{domxref("TextTrack")}} を動画に追加し、{{domxref("TextTrack.addCue()")}} メソッドを使用して、作成した `VTTCue` オブジェクトを引数としてキューを追加しています。
 
 ```html
-<video
-  controls
-  src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/friday.mp4"></video>
+<video controls src="/shared-assets/videos/friday.mp4"></video>
 ```
 
 #### CSS
@@ -178,9 +176,7 @@ video {
 ```
 
 ```html
-<video
-  controls
-  src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/friday.mp4"></video>
+<video controls src="/shared-assets/videos/friday.mp4"></video>
 ```
 
 #### CSS
@@ -247,9 +243,7 @@ video {
 ```
 
 ```html hidden
-<video
-  controls
-  src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/friday.mp4"></video>
+<video controls src="/shared-assets/videos/friday.mp4"></video>
 ```
 
 #### タグ種別によるスタイル設定

--- a/files/ja/web/css/border-image-slice/index.md
+++ b/files/ja/web/css/border-image-slice/index.md
@@ -173,7 +173,7 @@ div > div {
   height: 200px;
   border-width: 30px;
   border-style: solid;
-  border-image: url(https://interactive-examples.mdn.mozilla.net/media/examples/border-diamonds.png);
+  border-image: url(/shared-assets/images/examples/border-diamonds.png);
   border-image-slice: 30;
   border-image-repeat: round;
 }

--- a/files/ja/web/css/opacity/index.md
+++ b/files/ja/web/css/opacity/index.md
@@ -145,7 +145,7 @@ div {
 ```html
 <div class="wrapper">
   <img
-    src="//interactive-examples.mdn.mozilla.net/media/dino.svg"
+    src="/shared-assets/images/examples/dino.svg"
     alt="MDN Dino"
     width="128"
     height="146"

--- a/files/ja/web/html/guides/cheatsheet/index.md
+++ b/files/ja/web/html/guides/cheatsheet/index.md
@@ -214,7 +214,7 @@ format&#x3C;/code>.</pre
       <td id="audio-example">
         <pre class="brush: html">
 &#x3C;audio controls>
-  &#x3C;source src="https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3" type="audio/mpeg">
+  &#x3C;source src="/shared-assets/audio/t-rex-roar.mp3" type="audio/mpeg">
 &#x3C;/audio>
         </pre>
         {{EmbedLiveSample("audio-example", 100, 80)}}

--- a/files/ja/web/html/reference/elements/object/index.md
+++ b/files/ja/web/html/reference/elements/object/index.md
@@ -62,7 +62,7 @@ l10n:
 ```html
 <object
   type="video/mp4"
-  data="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
+  data="/shared-assets/videos/flower.webm"
   width="600"
   height="140">
   <img src="path/image.jpg" alt="useful image description" />

--- a/files/ko/learn_web_development/core/scripting/event_bubbling/index.md
+++ b/files/ko/learn_web_development/core/scripting/event_bubbling/index.md
@@ -113,9 +113,7 @@ HTML은 다음과 같습니다.
 
 <div class="hidden">
   <video>
-    <source
-      src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
-      type="video/webm" />
+    <source src="/shared-assets/videos/flower.webm" type="video/webm" />
     <p>
       이 브라우저는 HTML 동영상을 지원하지 않습니다. 대신
       <a href="rabbit320.mp4">동영상 링크</a>를 제공합니다.
@@ -208,9 +206,7 @@ box.addEventListener("click", () => box.classList.add("hidden"));
 
 <div class="hidden">
   <video>
-    <source
-      src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
-      type="video/webm" />
+    <source src="/shared-assets/videos/flower.webm" type="video/webm" />
     <p>
       이 브라우저는 HTML 동영상을 지원하지 않습니다. 대신
       <a href="rabbit320.mp4">동영상 링크</a>를 제공합니다.

--- a/files/zh-cn/learn_web_development/core/scripting/event_bubbling/index.md
+++ b/files/zh-cn/learn_web_development/core/scripting/event_bubbling/index.md
@@ -106,9 +106,7 @@ HTML 代码看起来像这样：
 
 <div class="hidden">
   <video>
-    <source
-      src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
-      type="video/webm" />
+    <source src="/shared-assets/videos/flower.webm" type="video/webm" />
     <p>
       你的浏览器不支持 HTML 视频，这里有视频的<a href="rabbit320.mp4"
         >替代链接</a
@@ -201,9 +199,7 @@ box.addEventListener("click", () => box.classList.add("hidden"));
 
 <div class="hidden">
   <video>
-    <source
-      src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
-      type="video/webm" />
+    <source src="/shared-assets/videos/flower.webm" type="video/webm" />
     <p>
       你的浏览器不支持 HTML 视频，这里有视频的<a href="rabbit320.mp4"
         >替代链接</a

--- a/files/zh-cn/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
+++ b/files/zh-cn/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
@@ -40,8 +40,7 @@ ctx.font = "16px sans-serif";
 ctx.textAlign = "center";
 
 const img = new Image();
-img.src =
-  "https://interactive-examples.mdn.mozilla.net/media/examples/star.png";
+img.src = "/shared-assets/images/examples/big-star.png";
 img.onload = () => {
   const w = img.width,
     h = img.height;

--- a/files/zh-cn/web/api/htmlmediaelement/loadstart_event/index.md
+++ b/files/zh-cn/web/api/htmlmediaelement/loadstart_event/index.md
@@ -106,10 +106,7 @@ loadVideo.addEventListener("click", () => {
   } else {
     loadVideo.textContent = "Reset example";
     source = document.createElement("source");
-    source.setAttribute(
-      "src",
-      "https://interactive-examples.mdn.mozilla.net/media/examples/flower.webm",
-    );
+    source.setAttribute("src", "/shared-assets/videos/flower.webm");
     source.setAttribute("type", "video/webm");
 
     video.appendChild(source);

--- a/files/zh-cn/web/css/border-image-slice/index.md
+++ b/files/zh-cn/web/css/border-image-slice/index.md
@@ -171,7 +171,7 @@ div > div {
   height: 200px;
   border-width: 30px;
   border-style: solid;
-  border-image: url(https://interactive-examples.mdn.mozilla.net/media/examples/border-diamonds.png);
+  border-image: url(/shared-assets/images/examples/border-diamonds.png);
   border-image-slice: 30;
   border-image-repeat: round;
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replaces interactive-examples assets with shared-assets.

### Motivation

We're already replaced interactive-examples, and are deprecating the interactive-examples repo.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

* Same as: https://github.com/mdn/content/pull/39440