### PR TITLE
Replace favicon assets with shared-assets where applicable

### DIFF
--- a/files/es/learn_web_development/core/structuring_content/webpage_metadata/index.md
+++ b/files/es/learn_web_development/core/structuring_content/webpage_metadata/index.md
@@ -221,25 +221,23 @@ Hoy día hay un montón de otros tipos de iconos a tener presentes. Por ejemplo,
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="https://developer.mozilla.org/static/img/favicon144.png" />
+  href="/shared-assets/images/examples/favicon144.png" />
 <!-- iPhone con pantalla de alta resolución: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="https://developer.mozilla.org/static/img/favicon114.png" />
+  href="/shared-assets/images/examples/favicon114.png" />
 <!-- iPad de primera y segunda generación: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="72x72"
-  href="https://developer.mozilla.org/static/img/favicon72.png" />
+  href="/shared-assets/images/examples/favicon72.png" />
 <!-- Dispositivos iPhone sin pantalla Retina, iPod Touch y Android 2.1+: -->
 <link
   rel="apple-touch-icon-precomposed"
-  href="https://developer.mozilla.org/static/img/favicon57.png" />
+  href="/shared-assets/images/examples/favicon57.png" />
 <!-- favicon básico -->
-<link
-  rel="shortcut icon"
-  href="https://developer.mozilla.org/static/img/favicon32.png" />
+<link rel="shortcut icon" href="/shared-assets/images/examples/favicon32.png" />
 ```
 
 Los comentarios explican para qué se usa cada icono (estos elementos abarcan situaciones como aportar un buen icono de alta resolución para usarlo cuando la página web se guarda en la página de inicio de un iPad).

--- a/files/es/learn_web_development/core/structuring_content/webpage_metadata/index.md
+++ b/files/es/learn_web_development/core/structuring_content/webpage_metadata/index.md
@@ -221,23 +221,18 @@ Hoy día hay un montón de otros tipos de iconos a tener presentes. Por ejemplo,
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="/shared-assets/images/examples/favicon144.png" />
+  href="favicon144.png" />
 <!-- iPhone con pantalla de alta resolución: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="/shared-assets/images/examples/favicon114.png" />
+  href="favicon114.png" />
 <!-- iPad de primera y segunda generación: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  sizes="72x72"
-  href="/shared-assets/images/examples/favicon72.png" />
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="favicon72.png" />
 <!-- Dispositivos iPhone sin pantalla Retina, iPod Touch y Android 2.1+: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  href="/shared-assets/images/examples/favicon57.png" />
+<link rel="apple-touch-icon-precomposed" href="favicon57.png" />
 <!-- favicon básico -->
-<link rel="shortcut icon" href="/shared-assets/images/examples/favicon32.png" />
+<link rel="shortcut icon" href="favicon32.png" />
 ```
 
 Los comentarios explican para qué se usa cada icono (estos elementos abarcan situaciones como aportar un buen icono de alta resolución para usarlo cuando la página web se guarda en la página de inicio de un iPad).

--- a/files/es/web/css/background-repeat/index.md
+++ b/files/es/web/css/background-repeat/index.md
@@ -178,7 +178,8 @@ div {
 
 /* Multiple images */
 .seven {
-  background-image: url(star-solid.gif), url(favicon32.png);
+  background-image:
+    url(star-solid.gif), url(/shared-assets/images/examples/favicon32.png);
   background-repeat: repeat-x, repeat-y;
   height: 144px;
 }

--- a/files/es/web/html/reference/elements/img/index.md
+++ b/files/es/web/html/reference/elements/img/index.md
@@ -178,7 +178,7 @@ Dependiendo de su tipo, una imagen puede tener ancho y alto intrínseco, pero no
 <img src="mdn-logo-sm.png" alt="MDN" />
 ```
 
-![MDN](/static/img/favicon144.png)
+![MDN](/shared-assets/images/examples/favicon144.png)
 
 ## Ejemplo 2: Enlace con imagen
 
@@ -188,7 +188,7 @@ Dependiendo de su tipo, una imagen puede tener ancho y alto intrínseco, pero no
 /></a>
 ```
 
-[![MDN](/static/img/favicon144.png)](/)
+[![MDN](/shared-assets/images/examples/favicon144.png)](/)
 
 ## Ejemplo 3: Uso del atributo `srcset`
 

--- a/files/fr/conflicting/web/html/element/index.md
+++ b/files/fr/conflicting/web/html/element/index.md
@@ -52,7 +52,7 @@ Cet élément inclut également [les attributs universels](/fr/docs/Web/HTML/Glo
   <menuitem
     type="command"
     label="Cette commande ne fait rien"
-    icon="https://developer.mozilla.org/static/img/favicon144.png">
+    icon="/shared-assets/images/examples/favicon144.png">
     Les commandes n'affichent pas leurs contenus.
   </menuitem>
   <menuitem

--- a/files/fr/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/fr/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -223,23 +223,18 @@ Il existe de nombreux autres types d'icônes à considérer aussi actuellement. 
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="/shared-assets/images/examples/favicon144.png" />
+  href="favicon144.png" />
 <!-- iPhone avec haute-résolution Retina display: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="/shared-assets/images/examples/favicon114.png" />
+  href="favicon114.png" />
 <!-- iPad de première et deuxième génération : -->
-<link
-  rel="apple-touch-icon-precomposed"
-  sizes="72x72"
-  href="/shared-assets/images/examples/favicon72.png" />
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="favicon72.png" />
 <!-- iPhone non-Retina, iPod Touch et appareils Android 2.1+: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  href="/shared-assets/images/examples/favicon57.png" />
+<link rel="apple-touch-icon-precomposed" href="favicon57.png" />
 <!-- favicône de base -->
-<link rel="shortcut icon" href="/shared-assets/images/examples/favicon32.png" />
+<link rel="shortcut icon" href="favicon32.png" />
 ```
 
 Les commentaires expliquent ce à quoi chaque icône est utilisée — ces éléments incluent des fonctionnalités telles que la fourniture d'une icône haute résolution à utiliser lorsque le site Web est enregistré sur l'écran d'accueil d'un iPad.

--- a/files/fr/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/fr/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -223,25 +223,23 @@ Il existe de nombreux autres types d'icônes à considérer aussi actuellement. 
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="https://developer.mozilla.org/static/img/favicon144.png" />
+  href="/shared-assets/images/examples/favicon144.png" />
 <!-- iPhone avec haute-résolution Retina display: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="https://developer.mozilla.org/static/img/favicon114.png" />
+  href="/shared-assets/images/examples/favicon114.png" />
 <!-- iPad de première et deuxième génération : -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="72x72"
-  href="https://developer.mozilla.org/static/img/favicon72.png" />
+  href="/shared-assets/images/examples/favicon72.png" />
 <!-- iPhone non-Retina, iPod Touch et appareils Android 2.1+: -->
 <link
   rel="apple-touch-icon-precomposed"
-  href="https://developer.mozilla.org/static/img/favicon57.png" />
+  href="/shared-assets/images/examples/favicon57.png" />
 <!-- favicône de base -->
-<link
-  rel="shortcut icon"
-  href="https://developer.mozilla.org/static/img/favicon32.png" />
+<link rel="shortcut icon" href="/shared-assets/images/examples/favicon32.png" />
 ```
 
 Les commentaires expliquent ce à quoi chaque icône est utilisée — ces éléments incluent des fonctionnalités telles que la fourniture d'une icône haute résolution à utiliser lorsque le site Web est enregistré sur l'écran d'accueil d'un iPad.

--- a/files/fr/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
@@ -45,10 +45,10 @@ Copiez une image distante :
 
 ```js
 // requires:
-// * the host permission for "https://cdn.mdn.mozilla.net/*"
+// * the host permission for "https://mdn.github.io/*"
 // * the API permission "clipboardWrite"
 
-fetch("https://cdn.mdn.mozilla.net/static/img/favicon144.png")
+fetch("https://mdn.github.io/shared-assets/images/examples/favicon144.png")
   .then((response) => response.arrayBuffer())
   .then((buffer) => browser.clipboard.setImageData(buffer, "png"));
 ```

--- a/files/fr/web/css/background-repeat/index.md
+++ b/files/fr/web/css/background-repeat/index.md
@@ -209,7 +209,8 @@ div {
 
 /* Plusieurs images */
 .sept {
-  background-image: url(star-solid.gif), url(favicon32.png);
+  background-image:
+    url(star-solid.gif), url(/shared-assets/images/examples/favicon32.png);
   background-repeat: repeat-x, repeat-y;
   height: 144px;
 }

--- a/files/fr/web/css/mask-repeat/index.md
+++ b/files/fr/web/css/mask-repeat/index.md
@@ -140,8 +140,8 @@ Une ou plusieurs valeurs `<repeat-style>`, séparées par des virgules.
   -webkit-mask-clip: content;
   mask-clip: content;
 
-  -webkit-mask-image: url("https://developer.mozilla.org/static/img/favicon32.png");
-  mask-image: url("https://developer.mozilla.org/static/img/favicon32.png");
+  -webkit-mask-image: url("/shared-assets/images/examples/favicon32.png");
+  mask-image: url("/shared-assets/images/examples/favicon32.png");
 
   -webkit-mask-repeat: repeat-x;
   mask-repeat: repeat-x;

--- a/files/fr/web/css/max/index.md
+++ b/files/fr/web/css/max/index.md
@@ -49,7 +49,7 @@ Il est tout à fait possible de combiner des valeurs avec différentes unités d
 
 ```html
 <img
-  src="https://developer.mozilla.org/static/img/web-docs-sprite.svg"
+  src="/shared-assets/images/examples/web-docs-sprite.svg"
   alt="MDN Web Docs"
   class="logo" />
 ```

--- a/files/fr/web/html/attributes/rel/index.md
+++ b/files/fr/web/html/attributes/rel/index.md
@@ -198,23 +198,21 @@ S'il existe plusieurs `<link rel="icon">`, le navigateur utilise leur attribut [
     <link
       rel="apple-touch-icon-precomposed"
       sizes="144x144"
-      href="/static/img/favicon144.e7e21ca263ca.png" />
+      href="favicon144.png" />
     <!-- iPhone avec écran Retina haute résolution : -->
     <link
       rel="apple-touch-icon-precomposed"
       sizes="114x114"
-      href="/static/img/favicon114.d526f38b09c5.png" />
+      href="favicon114.png" />
     <!-- première et deuxième génération d'iPad: -->
     <link
       rel="apple-touch-icon-precomposed"
       sizes="72x72"
-      href="/static/img/favicon72.cc65d1d762a0.png" />
+      href="favicon72.png" />
     <!-- Appareils iPhone non Retina, iPod Touch et Android 2.1+ : -->
-    <link
-      rel="apple-touch-icon-precomposed"
-      href="/static/img/favicon57.de33179910ae.png" />
+    <link rel="apple-touch-icon-precomposed" href="favicon57.png" />
     <!-- favicône de base -->
-    <link rel="shortcut icon" href="/static/img/favicon32.7f3da72dcea1.png" />
+    <link rel="shortcut icon" href="favicon32.png" />
     ```
 
 ## Spécifications

--- a/files/fr/web/html/element/img/index.md
+++ b/files/fr/web/html/element/img/index.md
@@ -309,7 +309,7 @@ Selon son type, une image peut avoir une largeur et une hauteur intrinsèque. Po
 Dans l'exemple qui suit, l'image est accompagnée d'un texte alternatif qui sert l'accessibilité.
 
 ```html
-<img src="favicon144.png" alt="Logo de MDN" />
+<img src="/shared-assets/images/examples/favicon144.png" alt="Logo de MDN" />
 ```
 
 {{EmbedLiveSample('fournir_un_texte_alternatif', '100%', '160')}}
@@ -320,7 +320,9 @@ Cet exemple intègre l'image précédente et la transforme en lien. Pour cela, l
 
 ```html
 <a href="https://developer.mozilla.org">
-  <img src="favicon144.png" alt="Visiter le site MDN" />
+  <img
+    src="/shared-assets/images/examples/favicon144.png"
+    alt="Visiter le site MDN" />
 </a>
 ```
 
@@ -331,7 +333,10 @@ Cet exemple intègre l'image précédente et la transforme en lien. Pour cela, l
 Dans cet exemple, on utilise l'attribut `srcset` avec une référence vers une version du logo en haute résolution. Pour les appareils avec une haute résolution, celle-ci sera chargée à la place à la place de l'image indiquée par `src`. Pour les agents utilisateurs qui prennent en charge l'attribut `srcset`, l'image référencée par l'attribut `src` sera considérée comme une candidate avec le descripteur `1x`.
 
 ```html
-<img src="favicon72.png" alt="Logo MDN" srcset="favicon144.png 2x" />
+<img
+  src="/shared-assets/images/examples/favicon72.png"
+  alt="Logo MDN"
+  srcset="/shared-assets/images/examples/favicon144.png 2x" />
 ```
 
 {{EmbedLiveSample("utiliser_lattribut_srcset", "100%", "160")}}

--- a/files/fr/web/html/element/link/index.md
+++ b/files/fr/web/html/element/link/index.md
@@ -38,7 +38,7 @@ Il existe différents types de relations pour préciser les icônes et qui perme
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="apple-icon-114.png"
+  href="favicon114.png"
   type="image/png" />
 ```
 

--- a/files/ja/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
@@ -47,10 +47,10 @@ browser.clipboard.setImageData(imageData, imageType)
 
 ```js
 // requires:
-// * the host permission for "https://cdn.mdn.mozilla.net/*"
+// * the host permission for "https://mdn.github.io/*"
 // * the API permission "clipboardWrite"
 
-fetch("https://cdn.mdn.mozilla.net/static/img/favicon144.png")
+fetch("https://mdn.github.io/shared-assets/images/examples/favicon144.png")
   .then((response) => response.arrayBuffer())
   .then((buffer) => browser.clipboard.setImageData(buffer, "png"));
 ```

--- a/files/ja/web/api/htmlelement/load_event/index.md
+++ b/files/ja/web/api/htmlelement/load_event/index.md
@@ -36,7 +36,11 @@ elt.onload = (event) => { ... };
 ### HTML
 
 ```html
-<img id="image" src="favicon144.png" alt="MDN logo" width="72" />
+<img
+  id="image"
+  src="/shared-assets/images/examples/favicon144.png"
+  alt="MDN logo"
+  width="72" />
 <div><button onclick="reload()">Reload</button></div>
 ```
 
@@ -50,7 +54,7 @@ image.onload = () => {
 };
 
 function reload() {
-  image.src = "favicon144.png";
+  image.src = "/shared-assets/images/examples/favicon144.png";
 }
 ```
 

--- a/files/ja/web/css/background-repeat/index.md
+++ b/files/ja/web/css/background-repeat/index.md
@@ -211,7 +211,8 @@ div {
 
 /* 複数の画像 */
 .seven {
-  background-image: url(star-solid.gif), url(favicon32.png);
+  background-image:
+    url(star-solid.gif), url(/shared-assets/images/examples/favicon32.png);
   background-repeat: repeat-x, repeat-y;
   height: 144px;
 }

--- a/files/ja/web/html/reference/elements/img/index.md
+++ b/files/ja/web/html/reference/elements/img/index.md
@@ -350,7 +350,7 @@ SVG は、異なるサイズでも正確に描画する必要がある画像に�
 以下の簡単な例では、ページに画像を埋め込み、アクセシビリティを向上させるために代替テキストを含めています。
 
 ```html
-<img src="favicon144.png" alt="MDN" />
+<img src="/shared-assets/images/examples/favicon144.png" alt="MDN" />
 ```
 
 {{ EmbedLiveSample('Alternative_text', '100%', '160') }}
@@ -361,7 +361,9 @@ SVG は、異なるサイズでも正確に描画する必要がある画像に�
 
 ```html
 <a href="https://developer.mozilla.org">
-  <img src="favicon144.png" alt="MDN サイトにおいでください" />
+  <img
+    src="/shared-assets/images/examples/favicon144.png"
+    alt="MDN サイトにおいでください" />
 </a>
 ```
 
@@ -372,7 +374,10 @@ SVG は、異なるサイズでも正確に描画する必要がある画像に�
 この例では、 `srcset` 属性によって高解像度版のロゴの参照を指定しています。これで、高解像度の端末では `src` 画像の代わりにこちらが読み込まれます。 `src` で参照される画像は、 `srcset` に対応している{{glossary("User agent", "ユーザーエージェント")}}では、 `1x` の候補としてカウントされます。
 
 ```html
-<img src="favicon72.png" alt="MDN ロゴ" srcset="favicon144.png 2x" />
+<img
+  src="/shared-assets/images/examples/favicon72.png"
+  alt="MDN ロゴ"
+  srcset="/shared-assets/images/examples/favicon144.png 2x" />
 ```
 
 {{EmbedLiveSample("Using_the_srcset_attribute", "100%", "160")}}

--- a/files/ja/web/html/reference/elements/link/index.md
+++ b/files/ja/web/html/reference/elements/link/index.md
@@ -318,26 +318,15 @@ l10n:
 
 ```html
 <!-- 高解像度ディスプレイの第 3 世代 iPad -->
-<link
-  rel="apple-touch-icon"
-  sizes="144x144"
-  href="/shared-assets/images/examples/favicon144.png" />
+<link rel="apple-touch-icon" sizes="144x144" href="favicon144.png" />
 <!-- 高解像度ディスプレイの iPhone -->
-<link
-  rel="apple-touch-icon"
-  sizes="114x114"
-  href="/shared-assets/images/examples/favicon114.png" />
+<link rel="apple-touch-icon" sizes="114x114" href="favicon114.png" />
 <!-- 第 1、第 2 世代の iPad: -->
-<link
-  rel="apple-touch-icon"
-  sizes="72x72"
-  href="/shared-assets/images/examples/favicon72.png" />
+<link rel="apple-touch-icon" sizes="72x72" href="favicon72.png" />
 <!-- 高解像度でない iPhone, iPod Touch, Android 2.1 以降の端末 -->
-<link
-  rel="apple-touch-icon"
-  href="/shared-assets/images/examples/favicon57.png" />
+<link rel="apple-touch-icon" href="favicon57.png" />
 <!-- 基本的なファビコン -->
-<link rel="icon" href="/shared-assets/images/examples/favicon32.png" />
+<link rel="icon" href="favicon32.png" />
 ```
 
 ### メディアクエリーのついた条件付きのリソース読み込み

--- a/files/ja/web/html/reference/elements/link/index.md
+++ b/files/ja/web/html/reference/elements/link/index.md
@@ -318,15 +318,26 @@ l10n:
 
 ```html
 <!-- 高解像度ディスプレイの第 3 世代 iPad -->
-<link rel="apple-touch-icon" sizes="144x144" href="favicon144.png" />
+<link
+  rel="apple-touch-icon"
+  sizes="144x144"
+  href="/shared-assets/images/examples/favicon144.png" />
 <!-- 高解像度ディスプレイの iPhone -->
-<link rel="apple-touch-icon" sizes="114x114" href="favicon114.png" />
+<link
+  rel="apple-touch-icon"
+  sizes="114x114"
+  href="/shared-assets/images/examples/favicon114.png" />
 <!-- 第 1、第 2 世代の iPad: -->
-<link rel="apple-touch-icon" sizes="72x72" href="favicon72.png" />
+<link
+  rel="apple-touch-icon"
+  sizes="72x72"
+  href="/shared-assets/images/examples/favicon72.png" />
 <!-- 高解像度でない iPhone, iPod Touch, Android 2.1 以降の端末 -->
-<link rel="apple-touch-icon" href="favicon57.png" />
+<link
+  rel="apple-touch-icon"
+  href="/shared-assets/images/examples/favicon57.png" />
 <!-- 基本的なファビコン -->
-<link rel="icon" href="favicon32.png" />
+<link rel="icon" href="/shared-assets/images/examples/favicon32.png" />
 ```
 
 ### メディアクエリーのついた条件付きのリソース読み込み

--- a/files/ko/learn_web_development/core/structuring_content/webpage_metadata/index.md
+++ b/files/ko/learn_web_development/core/structuring_content/webpage_metadata/index.md
@@ -217,25 +217,23 @@ favicon은 다음과 같이 너의 사이트에 추가할 수 있다:
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="https://developer.mozilla.org/static/img/favicon144.png" />
+  href="/shared-assets/images/examples/favicon144.png" />
 <!-- iPhone with high-resolution Retina display: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="https://developer.mozilla.org/static/img/favicon114.png" />
+  href="/shared-assets/images/examples/favicon114.png" />
 <!-- first- and second-generation iPad: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="72x72"
-  href="https://developer.mozilla.org/static/img/favicon72.png" />
+  href="/shared-assets/images/examples/favicon72.png" />
 <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
 <link
   rel="apple-touch-icon-precomposed"
-  href="https://developer.mozilla.org/static/img/favicon57.png" />
+  href="/shared-assets/images/examples/favicon57.png" />
 <!-- basic favicon -->
-<link
-  rel="shortcut icon"
-  href="https://developer.mozilla.org/static/img/favicon32.png" />
+<link rel="shortcut icon" href="/shared-assets/images/examples/favicon32.png" />
 ```
 
 주석은 각 아이콘의 용도를 설명한다. 웹사이트가 iPad의 홈 화면에 저장 될 때 사용할 고해상도 아이콘을 제공하는 것 등을 포함한다.

--- a/files/ko/learn_web_development/core/structuring_content/webpage_metadata/index.md
+++ b/files/ko/learn_web_development/core/structuring_content/webpage_metadata/index.md
@@ -217,23 +217,18 @@ favicon은 다음과 같이 너의 사이트에 추가할 수 있다:
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="/shared-assets/images/examples/favicon144.png" />
+  href="favicon144.png" />
 <!-- iPhone with high-resolution Retina display: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="/shared-assets/images/examples/favicon114.png" />
+  href="favicon114.png" />
 <!-- first- and second-generation iPad: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  sizes="72x72"
-  href="/shared-assets/images/examples/favicon72.png" />
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="favicon72.png" />
 <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  href="/shared-assets/images/examples/favicon57.png" />
+<link rel="apple-touch-icon-precomposed" href="favicon57.png" />
 <!-- basic favicon -->
-<link rel="shortcut icon" href="/shared-assets/images/examples/favicon32.png" />
+<link rel="shortcut icon" href="favicon32.png" />
 ```
 
 주석은 각 아이콘의 용도를 설명한다. 웹사이트가 iPad의 홈 화면에 저장 될 때 사용할 고해상도 아이콘을 제공하는 것 등을 포함한다.

--- a/files/ko/web/css/background-repeat/index.md
+++ b/files/ko/web/css/background-repeat/index.md
@@ -219,7 +219,8 @@ div {
 
 /* Multiple images */
 .seven {
-  background-image: url(star-solid.gif), url(favicon32.png);
+  background-image:
+    url(star-solid.gif), url(/shared-assets/images/examples/favicon32.png);
   background-repeat: repeat-x, repeat-y;
   height: 144px;
 }

--- a/files/ko/web/html/reference/elements/figure/index.md
+++ b/files/ko/web/html/reference/elements/figure/index.md
@@ -118,14 +118,14 @@ figcaption {
 <!-- Just an image -->
 <figure>
   <img
-    src="https://developer.mozilla.org/static/img/favicon144.png"
+    src="/shared-assets/images/examples/favicon144.png"
     alt="A robotic monster over the letters MDN." />
 </figure>
 
 <!-- Image with a caption -->
 <figure>
   <img
-    src="https://developer.mozilla.org/static/img/favicon144.png"
+    src="/shared-assets/images/examples/favicon144.png"
     alt="A robotic monster over the letters MDN." />
   <figcaption>MDN Logo</figcaption>
 </figure>

--- a/files/ko/web/html/reference/elements/img/index.md
+++ b/files/ko/web/html/reference/elements/img/index.md
@@ -211,7 +211,7 @@ HTML 표준은 지원해야 하는 이미지 형식을 명시하고 있지 않�
 페이지에 이미지를 삽입하고, 접근성을 높이기 위해 대체 텍스트를 제공하는 간단한 예제입니다.
 
 ```html
-<img src="favicon144.png" alt="MDN logo" />
+<img src="/shared-assets/images/examples/favicon144.png" alt="MDN logo" />
 ```
 
 {{ EmbedLiveSample('Alternative_text', '100%', '160') }}
@@ -222,7 +222,9 @@ HTML 표준은 지원해야 하는 이미지 형식을 명시하고 있지 않�
 
 ```html
 <a href="https://developer.mozilla.org">
-  <img src="favicon144.png" alt="Visit the MDN site" />
+  <img
+    src="/shared-assets/images/examples/favicon144.png"
+    alt="Visit the MDN site" />
 </a>
 ```
 
@@ -233,7 +235,10 @@ HTML 표준은 지원해야 하는 이미지 형식을 명시하고 있지 않�
 이번 예제에서는 [`srcset`](#srcset) 특성에 고해상도 버전 로고를 추가했습니다. 그러면 고해상도 장치에서는 일반 `src` 이미지 대신 고해상도 이미지를 사용합니다. `srcset` 특성을 지원하는 {{glossary("user agent", "사용자 에이전트")}}는 `src` 특성을 `srcset` `1x` 로 간주합니다.
 
 ```html
-<img src="favicon72.png" alt="MDN logo" srcset="favicon144.png 2x" />
+<img
+  src="/shared-assets/images/examples/favicon72.png"
+  alt="MDN logo"
+  srcset="/shared-assets/images/examples/favicon144.png 2x" />
 ```
 
 {{EmbedLiveSample("Using_the_srcset_attribute", "100%", "160")}}

--- a/files/ko/web/html/reference/elements/link/index.md
+++ b/files/ko/web/html/reference/elements/link/index.md
@@ -304,23 +304,18 @@ l10n:
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="/shared-assets/images/examples/favicon144.png" />
+  href="favicon144.png" />
 <!-- iPhone with high-resolution Retina display: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="/shared-assets/images/examples/favicon114.png" />
+  href="favicon114.png" />
 <!-- first- and second-generation iPad: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  sizes="72x72"
-  href="/shared-assets/images/examples/favicon72.png" />
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="favicon72.png" />
 <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  href="/shared-assets/images/examples/favicon57.png" />
+<link rel="apple-touch-icon-precomposed" href="favicon57.png" />
 <!-- basic favicon -->
-<link rel="icon" href="/shared-assets/images/examples/favicon32.png" />
+<link rel="icon" href="favicon32.png" />
 ```
 
 ### 미디어 쿼리를 이용하여 조건에 맞는 리소스 로드하기

--- a/files/ko/web/html/reference/elements/link/index.md
+++ b/files/ko/web/html/reference/elements/link/index.md
@@ -304,18 +304,23 @@ l10n:
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="favicon144.png" />
+  href="/shared-assets/images/examples/favicon144.png" />
 <!-- iPhone with high-resolution Retina display: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="favicon114.png" />
+  href="/shared-assets/images/examples/favicon114.png" />
 <!-- first- and second-generation iPad: -->
-<link rel="apple-touch-icon-precomposed" sizes="72x72" href="favicon72.png" />
+<link
+  rel="apple-touch-icon-precomposed"
+  sizes="72x72"
+  href="/shared-assets/images/examples/favicon72.png" />
 <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-<link rel="apple-touch-icon-precomposed" href="favicon57.png" />
+<link
+  rel="apple-touch-icon-precomposed"
+  href="/shared-assets/images/examples/favicon57.png" />
 <!-- basic favicon -->
-<link rel="icon" href="favicon32.png" />
+<link rel="icon" href="/shared-assets/images/examples/favicon32.png" />
 ```
 
 ### 미디어 쿼리를 이용하여 조건에 맞는 리소스 로드하기

--- a/files/pt-br/learn_web_development/core/structuring_content/webpage_metadata/index.md
+++ b/files/pt-br/learn_web_development/core/structuring_content/webpage_metadata/index.md
@@ -227,23 +227,18 @@ Há muitos outros tipos de ícones para considerar nestes dias também. Por exem
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="/shared-assets/images/examples/favicon144.png" />
+  href="favicon144.png" />
 <!-- iPhone com tela retina de alta resolução: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="/shared-assets/images/examples/favicon114.png" />
+  href="favicon114.png" />
 <!-- iPad de primeira e segunda geração: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  sizes="72x72"
-  href="/shared-assets/images/examples/favicon72.png" />
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="favicon72.png" />
 <!-- iPhone não-Retina, iPod Touch e dispositivos Android 2.1+: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  href="/shared-assets/images/examples/favicon57.png" />
+<link rel="apple-touch-icon-precomposed" href="favicon57.png" />
 <!-- favicon básico -->
-<link rel="shortcut icon" href="/shared-assets/images/examples/favicon32.png" />
+<link rel="shortcut icon" href="favicon32.png" />
 ```
 
 Os comentários explicam onde cada ícone é usado - esses elementos cobrem coisas como fornecer um ícone de alta resolução agradável para usar quando o site é salvo na tela inicial do iPad.

--- a/files/pt-br/learn_web_development/core/structuring_content/webpage_metadata/index.md
+++ b/files/pt-br/learn_web_development/core/structuring_content/webpage_metadata/index.md
@@ -227,25 +227,23 @@ Há muitos outros tipos de ícones para considerar nestes dias também. Por exem
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="https://developer.mozilla.org/static/img/favicon144.png" />
+  href="/shared-assets/images/examples/favicon144.png" />
 <!-- iPhone com tela retina de alta resolução: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="https://developer.mozilla.org/static/img/favicon114.png" />
+  href="/shared-assets/images/examples/favicon114.png" />
 <!-- iPad de primeira e segunda geração: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="72x72"
-  href="https://developer.mozilla.org/static/img/favicon72.png" />
+  href="/shared-assets/images/examples/favicon72.png" />
 <!-- iPhone não-Retina, iPod Touch e dispositivos Android 2.1+: -->
 <link
   rel="apple-touch-icon-precomposed"
-  href="https://developer.mozilla.org/static/img/favicon57.png" />
+  href="/shared-assets/images/examples/favicon57.png" />
 <!-- favicon básico -->
-<link
-  rel="shortcut icon"
-  href="https://developer.mozilla.org/static/img/favicon32.png" />
+<link rel="shortcut icon" href="/shared-assets/images/examples/favicon32.png" />
 ```
 
 Os comentários explicam onde cada ícone é usado - esses elementos cobrem coisas como fornecer um ícone de alta resolução agradável para usar quando o site é salvo na tela inicial do iPad.

--- a/files/pt-br/web/html/element/img/index.md
+++ b/files/pt-br/web/html/element/img/index.md
@@ -114,9 +114,7 @@ Depending of its type, an _image_ may have an intrinsic dimension, but this is n
 O exemplo a seguir insere uma imagem na página e inclui o texto alternativo para acessibilidade, de forma que ele possa ser lido por programas leitores de tela ou exibido caso a imagem não carregue.
 
 ```html
-<img
-  src="https://developer.mozilla.org/static/img/favicon144.png"
-  alt="MDN logo" />
+<img src="/shared-assets/images/examples/favicon144.png" alt="MDN logo" />
 ```
 
 {{ EmbedLiveSample('Alternative_text', '100%', '160') }}
@@ -128,7 +126,7 @@ Esse exemplo mostra como transformar uma imagem em um link. Para isso, insira a 
 ```html
 <a href="https://developer.mozilla.org">
   <img
-    src="https://developer.mozilla.org/static/img/favicon144.png"
+    src="/shared-assets/images/examples/favicon144.png"
     alt="Visit the MDN site" />
 </a>
 ```

--- a/files/ru/learn_web_development/core/structuring_content/webpage_metadata/index.md
+++ b/files/ru/learn_web_development/core/structuring_content/webpage_metadata/index.md
@@ -199,25 +199,23 @@ slug: Learn_web_development/Core/Structuring_content/Webpage_metadata
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="https://developer.mozilla.org/static/img/favicon144.png" />
+  href="/shared-assets/images/examples/favicon144.png" />
 <!-- Для iPhone с Retina-экраном высокого разрешения: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="https://developer.mozilla.org/static/img/favicon114.png" />
+  href="/shared-assets/images/examples/favicon114.png" />
 <!-- Для iPad первого и второго поколения: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="72x72"
-  href="https://developer.mozilla.org/static/img/favicon72.png" />
+  href="/shared-assets/images/examples/favicon72.png" />
 <!-- Для iPhone, iPod Touch без Retina и устройств с Android 2.1+: -->
 <link
   rel="apple-touch-icon-precomposed"
-  href="https://developer.mozilla.org/static/img/favicon57.png" />
+  href="/shared-assets/images/examples/favicon57.png" />
 <!-- Для других случаев - обычный favicon -->
-<link
-  rel="shortcut icon"
-  href="https://developer.mozilla.org/static/img/favicon32.png" />
+<link rel="shortcut icon" href="/shared-assets/images/examples/favicon32.png" />
 ```
 
 В комментариях указано, для чего используется каждая иконка — например, при добавлении страницы на домашний экран iPad будет использована иконка в высоком разрешении.

--- a/files/ru/learn_web_development/core/structuring_content/webpage_metadata/index.md
+++ b/files/ru/learn_web_development/core/structuring_content/webpage_metadata/index.md
@@ -199,23 +199,18 @@ slug: Learn_web_development/Core/Structuring_content/Webpage_metadata
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="/shared-assets/images/examples/favicon144.png" />
+  href="favicon144.png" />
 <!-- Для iPhone с Retina-экраном высокого разрешения: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="/shared-assets/images/examples/favicon114.png" />
+  href="favicon114.png" />
 <!-- Для iPad первого и второго поколения: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  sizes="72x72"
-  href="/shared-assets/images/examples/favicon72.png" />
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="favicon72.png" />
 <!-- Для iPhone, iPod Touch без Retina и устройств с Android 2.1+: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  href="/shared-assets/images/examples/favicon57.png" />
+<link rel="apple-touch-icon-precomposed" href="favicon57.png" />
 <!-- Для других случаев - обычный favicon -->
-<link rel="shortcut icon" href="/shared-assets/images/examples/favicon32.png" />
+<link rel="shortcut icon" href="favicon32.png" />
 ```
 
 В комментариях указано, для чего используется каждая иконка — например, при добавлении страницы на домашний экран iPad будет использована иконка в высоком разрешении.

--- a/files/ru/web/css/background-repeat/index.md
+++ b/files/ru/web/css/background-repeat/index.md
@@ -152,7 +152,8 @@ div {
 
 /* Несколько изображений */
 .five {
-  background-image: url(star-solid.gif), url(favicon32.png);
+  background-image:
+    url(star-solid.gif), url(/shared-assets/images/examples/favicon32.png);
   background-repeat: repeat-x, repeat-y;
   height: 144px;
 }

--- a/files/ru/web/html/reference/elements/figure/index.md
+++ b/files/ru/web/html/reference/elements/figure/index.md
@@ -68,14 +68,14 @@ figcaption {
 <!-- Just an image -->
 <figure>
   <img
-    src="https://developer.mozilla.org/static/img/favicon144.png"
+    src="/shared-assets/images/examples/favicon144.png"
     alt="The beautiful MDN logo." />
 </figure>
 
 <!-- Image with a caption -->
 <figure>
   <img
-    src="https://developer.mozilla.org/static/img/favicon144.png"
+    src="/shared-assets/images/examples/favicon144.png"
     alt="The beautiful MDN logo." />
   <figcaption>MDN Logo</figcaption>
 </figure>

--- a/files/ru/web/html/reference/elements/img/index.md
+++ b/files/ru/web/html/reference/elements/img/index.md
@@ -170,7 +170,7 @@ slug: Web/HTML/Reference/Elements/img
 
 ```html
 <img
-  src="https://developer.mozilla.org/static/img/web-docs-sprite.22a6a085cf14.svg"
+  src="/shared-assets/images/examples/web-docs-sprite.svg"
   alt="Логотип MDN - изображение динозавра с текстом MDN web docs" />
 ```
 
@@ -183,7 +183,7 @@ slug: Web/HTML/Reference/Elements/img
 ```html
 <a href="https://developer.mozilla.org">
   <img
-    src="https://developer.mozilla.org/static/img/web-docs-sprite.22a6a085cf14.svg"
+    src="/shared-assets/images/examples/web-docs-sprite.svg"
     alt="Посетить сайт MDN" />
 </a>
 ```

--- a/files/ru/web/html/reference/elements/link/index.md
+++ b/files/ru/web/html/reference/elements/link/index.md
@@ -183,18 +183,23 @@ HTML-элемент **`<link>`** определяет отношения меж�
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="favicon144.png" />
+  href="/shared-assets/images/examples/favicon144.png" />
 <!-- iPhone with high-resolution Retina display: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="favicon114.png" />
+  href="/shared-assets/images/examples/favicon114.png" />
 <!-- first- and second-generation iPad: -->
-<link rel="apple-touch-icon-precomposed" sizes="72x72" href="favicon72.png" />
+<link
+  rel="apple-touch-icon-precomposed"
+  sizes="72x72"
+  href="/shared-assets/images/examples/favicon72.png" />
 <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-<link rel="apple-touch-icon-precomposed" href="favicon57.png" />
+<link
+  rel="apple-touch-icon-precomposed"
+  href="/shared-assets/images/examples/favicon57.png" />
 <!-- basic favicon -->
-<link rel="icon" href="favicon32.png" />
+<link rel="icon" href="/shared-assets/images/examples/favicon32.png" />
 ```
 
 ### Условная загрузка ресурсов с медиавыражениями

--- a/files/ru/web/html/reference/elements/link/index.md
+++ b/files/ru/web/html/reference/elements/link/index.md
@@ -38,7 +38,7 @@ HTML-элемент **`<link>`** определяет отношения меж�
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="apple-icon-114.png"
+  href="favicon114.png"
   type="image/png" />
 ```
 
@@ -183,23 +183,18 @@ HTML-элемент **`<link>`** определяет отношения меж�
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="/shared-assets/images/examples/favicon144.png" />
+  href="favicon144.png" />
 <!-- iPhone with high-resolution Retina display: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="/shared-assets/images/examples/favicon114.png" />
+  href="favicon114.png" />
 <!-- first- and second-generation iPad: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  sizes="72x72"
-  href="/shared-assets/images/examples/favicon72.png" />
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="favicon72.png" />
 <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  href="/shared-assets/images/examples/favicon57.png" />
+<link rel="apple-touch-icon-precomposed" href="favicon57.png" />
 <!-- basic favicon -->
-<link rel="icon" href="/shared-assets/images/examples/favicon32.png" />
+<link rel="icon" href="favicon32.png" />
 ```
 
 ### Условная загрузка ресурсов с медиавыражениями

--- a/files/ru/web/svg/tutorials/svg_from_scratch/other_content_in_svg/index.md
+++ b/files/ru/web/svg/tutorials/svg_from_scratch/other_content_in_svg/index.md
@@ -26,7 +26,7 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/Other_content_in_SVG
     width="128"
     height="146"
     transform="rotate(45)"
-    xlink:href="https://developer.mozilla.org/static/img/favicon144.png" />
+    xlink:href="/shared-assets/images/examples/favicon144.png" />
 </svg>
 ```
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
@@ -47,10 +47,10 @@ browser.clipboard.setImageData(imageData, imageType)
 
 ```js
 // 需要：
-// * "https://cdn.mdn.mozilla.net/*" 的主机权限
+// * "https://mdn.github.io/*" 的主机权限
 // * API 权限 "clipboardWrite"
 
-fetch("https://cdn.mdn.mozilla.net/static/img/favicon144.png")
+fetch("https://mdn.github.io/shared-assets/images/examples/favicon144.png")
   .then((response) => response.arrayBuffer())
   .then((buffer) => browser.clipboard.setImageData(buffer, "png"));
 ```

--- a/files/zh-cn/web/css/background-repeat/index.md
+++ b/files/zh-cn/web/css/background-repeat/index.md
@@ -155,7 +155,8 @@ div {
 
 /* Multiple images */
 .five {
-  background-image: url(star-solid.gif), url(favicon32.png);
+  background-image:
+    url(star-solid.gif), url(/shared-assets/images/examples/favicon32.png);
   background-repeat: repeat-x, repeat-y;
   height: 144px;
 }

--- a/files/zh-cn/web/css/min/index.md
+++ b/files/zh-cn/web/css/min/index.md
@@ -44,7 +44,7 @@ width: min(1vw, 4em, 80px);
 
 ```html
 <img
-  src="https://developer.mozilla.org/static/img/web-docs-sprite.svg"
+  src="/shared-assets/images/examples/web-docs-sprite.svg"
   alt="MDN Web Docs"
   class="logo" />
 ```

--- a/files/zh-cn/web/html/reference/elements/img/index.md
+++ b/files/zh-cn/web/html/reference/elements/img/index.md
@@ -250,7 +250,7 @@ Web 最常用的图像格式是：
 下面的示例将图像嵌入到页面中，且包含用于改善无障碍的备用文本。
 
 ```html
-<img src="favicon144.png" alt="MDN logo" />
+<img src="/shared-assets/images/examples/favicon144.png" alt="MDN logo" />
 ```
 
 {{ EmbedLiveSample('备用文字', '100%', '160') }}
@@ -261,7 +261,9 @@ Web 最常用的图像格式是：
 
 ```html
 <a href="https://developer.mozilla.org">
-  <img src="favicon144.png" alt="Visit the MDN site" />
+  <img
+    src="/shared-assets/images/examples/favicon144.png"
+    alt="Visit the MDN site" />
 </a>
 ```
 
@@ -272,7 +274,10 @@ Web 最常用的图像格式是：
 在这个例子中，我们包含了一个 `srcset` 属性，它引用了 MDN 标志高清版本；在高分辨率设备上，它将被优先加载，取代 `src` 属性中的图像。在支持 `srcset` 的{{glossary("User agent", "用户代理")}}中，`src` 属性中的图片被作为 `1x` 候选项。
 
 ```html
-<img src="favicon72.png" alt="MDN logo" srcset="favicon144.png 2x" />
+<img
+  src="/shared-assets/images/examples/favicon72.png"
+  alt="MDN logo"
+  srcset="/shared-assets/images/examples/favicon144.png 2x" />
 ```
 
 {{EmbedLiveSample("使用 srcset 属性", "100%", "160")}}

--- a/files/zh-tw/learn_web_development/core/structuring_content/webpage_metadata/index.md
+++ b/files/zh-tw/learn_web_development/core/structuring_content/webpage_metadata/index.md
@@ -213,23 +213,18 @@ There are lots of other icon types to consider these days as well. For example, 
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="/shared-assets/images/examples/favicon144.png" />
+  href="favicon144.png" />
 <!-- iPhone with high-resolution Retina display: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="/shared-assets/images/examples/favicon114.png" />
+  href="favicon114.png" />
 <!-- first- and second-generation iPad: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  sizes="72x72"
-  href="/shared-assets/images/examples/favicon72.png" />
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="favicon72.png" />
 <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-<link
-  rel="apple-touch-icon-precomposed"
-  href="/shared-assets/images/examples/favicon57.png" />
+<link rel="apple-touch-icon-precomposed" href="favicon57.png" />
 <!-- basic favicon -->
-<link rel="shortcut icon" href="/shared-assets/images/examples/favicon32.png" />
+<link rel="shortcut icon" href="favicon32.png" />
 ```
 
 The comments explain what each icon is used for — these elements cover things like providing a nice high resolution icon to use when the website is saved to an iPad's home screen.

--- a/files/zh-tw/learn_web_development/core/structuring_content/webpage_metadata/index.md
+++ b/files/zh-tw/learn_web_development/core/structuring_content/webpage_metadata/index.md
@@ -213,25 +213,23 @@ There are lots of other icon types to consider these days as well. For example, 
 <link
   rel="apple-touch-icon-precomposed"
   sizes="144x144"
-  href="https://developer.mozilla.org/static/img/favicon144.png" />
+  href="/shared-assets/images/examples/favicon144.png" />
 <!-- iPhone with high-resolution Retina display: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="114x114"
-  href="https://developer.mozilla.org/static/img/favicon114.png" />
+  href="/shared-assets/images/examples/favicon114.png" />
 <!-- first- and second-generation iPad: -->
 <link
   rel="apple-touch-icon-precomposed"
   sizes="72x72"
-  href="https://developer.mozilla.org/static/img/favicon72.png" />
+  href="/shared-assets/images/examples/favicon72.png" />
 <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
 <link
   rel="apple-touch-icon-precomposed"
-  href="https://developer.mozilla.org/static/img/favicon57.png" />
+  href="/shared-assets/images/examples/favicon57.png" />
 <!-- basic favicon -->
-<link
-  rel="shortcut icon"
-  href="https://developer.mozilla.org/static/img/favicon32.png" />
+<link rel="shortcut icon" href="/shared-assets/images/examples/favicon32.png" />
 ```
 
 The comments explain what each icon is used for — these elements cover things like providing a nice high resolution icon to use when the website is saved to an iPad's home screen.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replaces favicon assets with shared-assets.

### Motivation

Mainly replaces one occurrence pointing to the no longer served cdn.mdn.mozilla.net host.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

- Same as: https://github.com/mdn/content/pull/39442
- Blocked by: https://github.com/mdn/shared-assets/pull/50
