### PR TITLE
fix: 이미지 경로 수정

### DIFF
--- a/files/ko/web/html/reference/elements/figure/index.md
+++ b/files/ko/web/html/reference/elements/figure/index.md
@@ -118,15 +118,15 @@ figcaption {
 <!-- Just an image -->
 <figure>
   <img
-    src="https://developer.mozilla.org/static/img/favicon144.png"
-    alt="A robotic monster over the letters MDN." />
+    src="https://developer.mozilla.org/favicon-48x48.bc390275e955dacb2e65.png"
+    alt="The beautiful MDN logo." />
 </figure>
 
 <!-- Image with a caption -->
 <figure>
   <img
-    src="https://developer.mozilla.org/static/img/favicon144.png"
-    alt="A robotic monster over the letters MDN." />
+    src="https://developer.mozilla.org/favicon-48x48.bc390275e955dacb2e65.png"
+    alt="The beautiful MDN logo." />
   <figcaption>MDN Logo</figcaption>
 </figure>
 ```


### PR DESCRIPTION
기존 이미지가 깨지던 문제수정

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
이미지 경로가 불분명해 이미지 파일이 나타나지 않음

### 미리보기
출처: https://developer.mozilla.org/ko/docs/Web/HTML/Reference/Elements/figure

<img width="842" alt="image" src="https://github.com/user-attachments/assets/7011b5eb-f1dd-4d72-830b-7517ab3492b2" />

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
