### PR TITLE
refactor(lefthook): use only option for post-merge

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -27,15 +27,11 @@ pre-commit:
             stage_fixed: true
 
 post-merge:
+  only:
+    - ref: main
   commands:
-    yarn-install-post-merge-main:
-      run: |
-        BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-        if [ "$BRANCH" != "main" ]; then
-          exit 0
-        else
-          yarn install
-        fi
+    yarn-install:
+      run: yarn install
 
 # For condensed output
 output:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

use only option for post-merge (see upstream PR: mdn/content#38820)

This PR also fixed the problem that the lefthook script `"$(git rev-parse --abbrev-ref HEAD)"` can only be run on unix-like system, that is the git hook will become invalid after executing git pull on Windows.

![image](https://github.com/user-attachments/assets/0274cffd-83cf-4df9-aff9-b45971af0281)

### Related issues and pull requests

Upstream: mdn/content#38820
