### PR TITLE
fix: typo さh勝→参照

### DIFF
--- a/files/ja/web/accessibility/aria/reference/roles/none_role/index.md
+++ b/files/ja/web/accessibility/aria/reference/roles/none_role/index.md
@@ -8,7 +8,7 @@ l10n:
 
 `none` ロールは [`presentation`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/presentation_role) ロールの別名です。どちらも、要素の暗黙の ARIA の意味づけを除去し、アクセシビリティツリーに公開されないようにします。
 
-詳しくは [`presentation`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/presentation_role) ロールをさh勝してください。
+詳しくは [`presentation`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/presentation_role) ロールを参照してください。
 
 <section id="Quick_links">
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This pull request includes a minor correction to the Japanese localization file for ARIA roles documentation. The change fixes a typo in the description of the `none` role.

* [`files/ja/web/accessibility/aria/reference/roles/none_role/index.md`](diffhunk://#diff-06cdce01392ee8215240ed4da85918b01a1fe11ef40ce9a32321e8f9d851394aL11-R11): Corrected a typo in the phrase "ロールをさh勝してください" to "ロールを参照してください" for improved clarity and accuracy.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

MDN Links: https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Reference/Roles/none_role

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
