### PR TITLE
[zh-cn]: fix description of viewport meta attributes

### DIFF
--- a/files/zh-cn/web/html/guides/viewport_meta_element/index.md
+++ b/files/zh-cn/web/html/guides/viewport_meta_element/index.md
@@ -30,9 +30,9 @@ slug: Web/HTML/Guides/Viewport_meta_element
 "viewport" `<meta>` 标签的基本属性如下所示：
 
 - `width`
-  - : 控制视口的大小。这可以设置为特定像素数（如'width=600'），也可以设置为特殊值`device-width`，即 [100vw](/zh-CN/docs/Web/CSS/length#视口_viewport_比例的长度)，100% 的视口宽度。最小值为 `1`。最大值为 `10000`。负值会被忽略。
+  - : 控制视口的大小。这可以设置为特定像素数（如 `width=600`），也可以设置为特殊值`device-width`，即 [100vw](/zh-CN/docs/Web/CSS/length#视口_viewport_比例的长度)，100% 的视口宽度。最小值为 `1`。最大值为 `10000`。负值会被忽略。
 - `height`
-  - : 控制视口的大小。这可以设置为特定像素数（如 `width=600`），也可以设置为特殊值 `device-height`，即 [100vh](/zh-CN/docs/Web/CSS/length#视口_viewport_比例的长度)，100% 的视口高度。最小值为 `1`。最大值为 `10000`。负值会被忽略。
+  - : 控制视口的大小。这可以设置为特定像素数（如 `height=400`），也可以设置为特殊值 `device-height`，即 [100vh](/zh-CN/docs/Web/CSS/length#视口_viewport_比例的长度)，100% 的视口高度。最小值为 `1`。最大值为 `10000`。负值会被忽略。
 - `initial-scale`
   - : 控制页面首次加载时显示的缩放倍数。最小值是 `0.1`。最大值是 `10`。默认值为 `1`。负值会被忽略。
 - `minimum-scale`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
1. 'width' -> `width`
2. height value example: width=600 -> height=400

### Motivation
1. it causes display issue
2. height value example use width value may cause misunderstanding, and  English version use height=400 example.

### Additional details
English version:
Controls the (minimum) size of the viewport (see [viewport width and screen width](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Viewport_meta_element#viewport_width_and_screen_width)). It can be set to a specific number of pixels like height=400 or to the special value device-height, which is the physical size of the device screen in CSS pixels.


### Related issues and pull requests
none
