### PR TITLE
[ko]: Drawing shapes with canvas 오탈자 수정

### DIFF
--- a/files/ko/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/ko/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -253,12 +253,12 @@ function draw() {
 
 ```js
 function draw() {
-  var canvas = document.getElementById('canvas');
+  var canvas = document.getElementById("canvas");
   if (canvas.getContext) {
-    var ctx = canvas.getContext('2d');
+    var ctx = canvas.getContext("2d");
 
-    for (var i = 0; i &#x3C; 4; i++) {
-      for (var j = 0; j &#x3C; 3; j++) {
+    for (var i = 0; i < 4; i++) {
+      for (var j = 0; j < 3; j++) {
         ctx.beginPath();
         var x = 25 + j * 50; // x coordinate
         var y = 25 + i * 50; // y coordinate


### PR DESCRIPTION
### Description

- `ko/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes` 문서의 호(arc) 예제 코드의 잘못된 HTML 엔티티를 올바른 문자로 수정했습니다.

### Motivation

- 예제 코드에 오타가 있어 미리보기가 보이지 않음
- [https://developer.mozilla.org/ko/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes#%ED%98%B8arc](https://developer.mozilla.org/ko/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes#%ED%98%B8arc
)
### Additional details

없음

### Related issues and pull requests

없음
