### PR TITLE
[pt-BR]: add sidebar to Web/HTML/Element/article

### DIFF
--- a/files/pt-br/web/html/reference/elements/article/index.md
+++ b/files/pt-br/web/html/reference/elements/article/index.md
@@ -4,6 +4,8 @@ slug: Web/HTML/Reference/Elements/article
 original_slug: Web/HTML/Element/article
 ---
 
+{{HTMLSidebar}}
+
 ## Resumo
 
 O _Elemento HTML Article_ (\<article>) representa uma composição independente em um documento, página, aplicação, ou site, ou que é destinado a ser distribuido de forma independente ou reutilizável, por exemplo, em sindicação. Este poderia ser o post de um fórum, um artigo de revista ou jornal, um post de um blog, um comentário enviado por um usuário, um gadget ou widget interativos, ou qualquer outra forma de conteúdo independente.


### PR DESCRIPTION
### Description

Just add the sidebar menu to the `<article>` element documentation in the portuguese (Brazil) translation.

Inspired by the [headings element code](https://github.com/mdn/translated-content/blob/9e4304745c85204eb85d64d7c7469451556e080d/files/pt-br/web/html/element/heading_elements/index.md?plain=1#L6).

### Motivation

To be able to navigate the site as any other pages.

### Additional details

Image of the current page without the sidebar:

![print of the article tag documentation in portuguese](https://github.com/user-attachments/assets/9bfd8f5d-3d2f-4659-9832-69f628b143e2)


### Related issues and pull requests

I just want to point out that I identified other errors in the page like the **heading links** in "Veja também" section which are not functioning. 
Other thing is the **use of the term "em sindicação"** which I thought it's very uncommon in portuguese. Seems to be a popular term in digital marketing, but even in this area it's presented as "sindicação de conteúdo", being a direct translation of "content syndication". I confess that I didn't made a full research on that.

I want to make issues relating this, but I do not have the time right now, so if someone else has, that would be cool!

Obs.: This is my first contribution to this project and my first contribution to a translating project. If anything in this PR could be improved, I'm open to learning! Probably too much unrelated text in the "related issues" section might be seen as problematic, sorry for that.