### PR TITLE
[ru] update `JSON.stringify` syntax

### DIFF
--- a/files/ru/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/ru/web/javascript/reference/global_objects/json/stringify/index.md
@@ -11,7 +11,7 @@ slug: Web/JavaScript/Reference/Global_Objects/JSON/stringify
 
 ## Синтаксис
 
-```
+```js-nolint
 JSON.stringify(value)
 JSON.stringify(value, replacer)
 JSON.stringify(value, replacer, space)

--- a/files/ru/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/ru/web/javascript/reference/global_objects/json/stringify/index.md
@@ -12,7 +12,9 @@ slug: Web/JavaScript/Reference/Global_Objects/JSON/stringify
 ## Синтаксис
 
 ```
-JSON.stringify(value[, replacer[, space]])
+JSON.stringify(value)
+JSON.stringify(value, replacer)
+JSON.stringify(value, replacer, space)
 ```
 
 ### Параметры


### PR DESCRIPTION

### Description

changed from 
```JavaScript
JSON.stringify(value[, replacer[, space]])
```
 to 
```JavaScript
JSON.stringify(value)
JSON.stringify(value, replacer)
JSON.stringify(value, replacer, space)
```


### Motivation

### Additional details

### Related issues and pull requests
