### PR TITLE
fix: typo(match→matchAll)

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/regexp/symbol.matchall/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/symbol.matchall/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{JSRef}}
 
-**`[Symbol.match]()`** は {{jsxref("RegExp")}} インスタンスのメソッドで、 [`String.prototype.matchAll`](/ja/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll) がどのように動作するのかを指定します。
+**`[Symbol.matchAll]()`** は {{jsxref("RegExp")}} インスタンスのメソッドで、 [`String.prototype.matchAll`](/ja/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll) がどのように動作するのかを指定します。
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype[Symbol.matchAll]()", "taller")}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/matchall/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/matchall/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{JSRef}}
 
-**`Symbol.matchAll`** は静的データプロパティで、[ウェルノウンシンボル](/ja/docs/Web/JavaScript/Reference/Global_Objects/Symbol#ウェルノウンシンボル)である `Symbol.match` を表します。{{jsxref("String.prototype.matchAll()")}} メソッドは最初の引数に対して、文字列に対する現在のオブジェクトの照合を行うイテレーターを返すメソッドを、このシンボルで探します。
+**`Symbol.matchAll`** は静的データプロパティで、[ウェルノウンシンボル](/ja/docs/Web/JavaScript/Reference/Global_Objects/Symbol#ウェルノウンシンボル)である `Symbol.matchAll` を表します。{{jsxref("String.prototype.matchAll()")}} メソッドは最初の引数に対して、文字列に対する現在のオブジェクトの照合を行うイテレーターを返すメソッドを、このシンボルで探します。
 
 詳しくは、[`RegExp.prototype[Symbol.matchAll]()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.matchAll) および {{jsxref("String.prototype.matchAll()")}} を参照してください。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

以下の`matchAll`について言及している箇所において、`match`と表記されている部分がありますが、原文を確認すると`matchAll`が正しいようでした。そのため`matchAll`に修正します。

- `Symbol.matchAll`
- `RegExp.prototype[Symbol.matchAll]()`

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

ページタイトルとコンテンツで齟齬が発生しており、混乱を招くため。

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
