### PR TITLE
[ja] sync content with en-US

### DIFF
--- a/files/ja/web/css/-webkit-text-stroke-color/index.md
+++ b/files/ja/web/css/-webkit-text-stroke-color/index.md
@@ -3,9 +3,11 @@ title: -webkit-text-stroke-color
 slug: Web/CSS/-webkit-text-stroke-color
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}
 
 **`-webkit-text-stroke-color`** は CSS のプロパティで、テキストの文字の線の[色](/ja/docs/Web/CSS/color_value)を示します。このプロパティが設定されない場合、 {{cssxref("color")}} プロパティの値が使用されます。
+
+## 構文
 
 ```css
 /* <color> 値 */
@@ -18,8 +20,6 @@ slug: Web/CSS/-webkit-text-stroke-color
 -webkit-text-stroke-color: initial;
 -webkit-text-stroke-color: unset;
 ```
-
-## 構文
 
 ### 値
 

--- a/files/ja/web/css/-webkit-text-stroke-width/index.md
+++ b/files/ja/web/css/-webkit-text-stroke-width/index.md
@@ -3,7 +3,7 @@ title: -webkit-text-stroke-width
 slug: Web/CSS/-webkit-text-stroke-width
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}
 
 **`-webkit-text-stroke-width`** は [CSS](/ja/docs/Web/CSS) のプロパティで、テキストの線の太さを指定します。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

This PR syncs the ja docs with en-US.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The non-standard warnings for `-webkit-text-stroke-color` and `-webkit-text-stroke-width` have been removed in en-US (ref: https://github.com/mdn/content/commit/809327edeb99b7dc23afbbf11d198de3f796395f ).

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

None.

### Related issues and pull requests

PR for removing non-standard warnings for `-webkit-text-stroke-color` and `-webkit-text-stroke-width` in mdn/content: https://github.com/mdn/content/pull/20075

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
