### PR TITLE
[zh-CN]: fix `fit-content` example

### DIFF
--- a/files/zh-cn/web/css/fit-content/index.md
+++ b/files/zh-cn/web/css/fit-content/index.md
@@ -49,7 +49,7 @@ block-size: fit-content;
 }
 
 .item {
-  width: -moz-fit-content;
+  width: fit-content;
   background-color: #8ca0ff;
   padding: 5px;
   margin-bottom: 1em;


### PR DESCRIPTION

### Description

Remove the `-moz-` prefix in `fit-content` example for zh-cn.

### Motivation

Keep it consistent with the English version. No prefix is needed.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
