### PR TITLE
zh-cn: update invalid image source

### DIFF
--- a/files/zh-cn/learn_web_development/core/css_layout/positioning/index.md
+++ b/files/zh-cn/learn_web_development/core/css_layout/positioning/index.md
@@ -65,7 +65,9 @@ slug: Learn_web_development/Core/CSS_layout/Positioning
   the same line. Overflowing inline elements will
   <span>wrap onto a new line if possible (like this one containing text)</span>,
   or just go on to a new line if not, much like this image will do:
-  <img src="long.jpg" />
+  <img
+    src="https://mdn.github.io/shared-assets/images/examples/long.jpg"
+    alt="snippet of cloth" />
 </p>
 ```
 
@@ -173,7 +175,9 @@ left: 30px;
   the same line. Overflowing inline elements
   <span>wrap onto a new line if possible — like this one containing text</span>,
   or just go on to a new line if not, much like this image will do:
-  <img src="long.jpg" />
+  <img
+    src="https://mdn.github.io/shared-assets/images/examples/long.jpg"
+    alt="snippet of cloth" />
 </p>
 ```
 
@@ -245,7 +249,9 @@ position: absolute;
   the same line. Overflowing inline elements
   <span>wrap onto a new line if possible — like this one containing text</span>,
   or just go on to a new line if not, much like this image will do:
-  <img src="long.jpg" />
+  <img
+    src="https://mdn.github.io/shared-assets/images/examples/long.jpg"
+    alt="snippet of cloth" />
 </p>
 ```
 
@@ -328,7 +334,9 @@ position: relative;
   the same line. Overflowing inline elements
   <span>wrap onto a new line if possible — like this one containing text</span>,
   or just go on to a new line if not, much like this image will do:
-  <img src="long.jpg" />
+  <img
+    src="https://mdn.github.io/shared-assets/images/examples/long.jpg"
+    alt="snippet of cloth" />
 </p>
 ```
 
@@ -419,7 +427,9 @@ z-index: 1;
   the same line. Overflowing inline elements
   <span>wrap onto a new line if possible — like this one containing text</span>,
   or just go on to a new line if not, much like this image will do:
-  <img src="long.jpg" />
+  <img
+    src="https://mdn.github.io/shared-assets/images/examples/long.jpg"
+    alt="snippet of cloth" />
 </p>
 ```
 
@@ -527,7 +537,9 @@ p:nth-of-type(1) {
   the same line. Overflowing inline elements
   <span>wrap onto a new line if possible — like this one containing text</span>,
   or just go on to a new line if not, much like this image will do:
-  <img src="long.jpg" />
+  <img
+    src="https://mdn.github.io/shared-assets/images/examples/long.jpg"
+    alt="snippet of cloth" />
 </p>
 ```
 


### PR DESCRIPTION
### Description

修复代码示例中无法访问的图片链接，并添加 alt 属性

### Motivation

既有 HTML 示例代码中， `<img src="long.jpg" />` 元素引用了目录下不存在的 `long.jpg` 文件，造成显示出错

### Additional details

参考英文版示例页面中的链接地址

### Related issues and pull requests

Fixes #27673
