### PR TITLE
ci(pr-test): fix GIT_DIFF_FILES env

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -154,7 +154,7 @@ jobs:
         env:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/files
-          GIT_DIFF_FILES: steps.check.outputs.GIT_DIFF_FILES
+          GIT_DIFF_FILES: ${{ steps.check.outputs.GIT_DIFF_FILES }}
         working-directory: ${{ github.workspace }}/mdn/content
         run: |
           echo $GIT_DIFF_FILES


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes the `pr-test` workflow, properly setting the `GIT_DIFF_FILES` variable.

### Motivation

It looks like the `filecheck` step of the `pr-test` is broken since https://github.com/mdn/translated-content/pull/26462.

### Additional details

`${{` and `$}}` can only be omitted in `if`.

See: https://docs.github.com/en/actions/reference/evaluate-expressions-in-workflows-and-actions

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
