### PR TITLE
[fr] Fix css not being used in `Résultat` section #26672

### DIFF
--- a/files/fr/web/css/fit-content/index.md
+++ b/files/fr/web/css/fit-content/index.md
@@ -25,7 +25,7 @@ block-size: fit-content;
 
 ### Utilisation de `fit-content` pour le dimensionnement des boîtes
 
-#### HTML
+#### HTML et CSS
 
 ```html
 <div class="container">
@@ -37,8 +37,6 @@ block-size: fit-content;
   </div>
 </div>
 ```
-
-#### CSS
 
 ```css
 .container {
@@ -57,7 +55,7 @@ block-size: fit-content;
 
 #### Résultat
 
-{{EmbedLiveSample("utilisation_de_fit-content_pour_le_dimensionnement_des_bo%C3%AEtes", "100%", 230)}}
+{{EmbedLiveSample("utilisation_de_fit-content_pour_le_dimensionnement_des_boites", "100%", 230)}}
 
 ## Spécifications
 


### PR DESCRIPTION
### Description

The CSS above the example wasn't in the style element `css-ouptut`  (as it does in the en-US version).

For the French version to work, I had to cut the CSS Headline 4 (markdown ####). I've merged this headline with html one, which now state : `HTML and CSS`.

### Motivation

The example about fit-content should show the CSS in action.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #26672 
