### PR TITLE
fix(dark-theme): fix color contrast in dark mode

### DIFF
--- a/files/ru/web/javascript/guide/regular_expressions/index.md
+++ b/files/ru/web/javascript/guide/regular_expressions/index.md
@@ -254,8 +254,7 @@ slug: Web/JavaScript/Guide/Regular_expressions
         Соответствует 'x' но не запоминает соответствие. Это называется
         не-захватывающие скобки. Сопоставленная строка не может быть получена из
         элементов результирующего массива
-        <code style="font-size: 14px; color: rgb(51, 51, 51)">[1]</code>, ...,
-        <code style="font-size: 14px; color: rgb(51, 51, 51)">[n]</code>.
+        <code>[1]</code>, ..., <code>[n]</code>.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
### Description
I fixed the color of an element in dark mode.

Before:
<img width="793" alt="изображение" src="https://github.com/user-attachments/assets/9468f020-87d6-420d-a91b-cc05df15ce03" />
After:
<img width="806" alt="изображение" src="https://github.com/user-attachments/assets/275772b5-7731-4c37-bf33-df7ff7667090" />