### PR TITLE
zh-cn: translate CSSKeyframeRule keyText property

### DIFF
--- a/files/zh-cn/web/api/csskeyframerule/keytext/index.md
+++ b/files/zh-cn/web/api/csskeyframerule/keytext/index.md
@@ -16,12 +16,11 @@ l10n:
 ### 异常
 
 - {{jsxref("SyntaxError")}}
-  - : 如果 `keyText` 被更新为无效的关键帧选择器，则会抛出此异常，此时 `keyText` 保持不变。
+  - : 如果 `keyText` 被更新为无效的关键帧选择器，则会抛出此异常，这种情况下 `keyText` 将保持不变。
 
 ## 示例
 
-以下 CSS 包含一个关键帧规则。该代码将返回 `document.styleSheets[0].cssRules` 的第一个 {{domxref("CSSRule")}}。
-`myRules[0]` 返回一个 {{domxref("CSSKeyframesRule")}} 对象，其中包含每个关键帧的 {{domxref("CSSKeyFrameRule")}} 对象。
+以下 CSS 包含一个关键帧规则。其会是 `document.styleSheets[0].cssRules` 返回的第一个 {{domxref("CSSRule")}}。`myRules[0]` 返回一个 {{domxref("CSSKeyframesRule")}} 对象，其中包含每个关键帧的 {{domxref("CSSKeyFrameRule")}} 对象。
 
 ```css
 @keyframes slide-in {
@@ -37,7 +36,7 @@ l10n:
 
 ```js
 let myRules = document.styleSheets[0].cssRules;
-let keyframes = myRules[0]; // 一个 CSSKeyframesRule
+let keyframes = myRules[0]; // CSSKeyframesRule
 console.log(keyframes[0].keyText); // 包含 0% 的字符串
 ```
 

--- a/files/zh-cn/web/api/csskeyframerule/keytext/index.md
+++ b/files/zh-cn/web/api/csskeyframerule/keytext/index.md
@@ -1,0 +1,50 @@
+---
+title: CSSKeyframeRule：keyText 属性
+slug: Web/API/CSSKeyframeRule/keyText
+l10n:
+  sourceCommit: f3c4fc42e8817d0b8f703cf83957c33cd5342019
+---
+
+{{APIRef("CSSOM") }}
+
+{{domxref("CSSKeyframeRule")}} 接口的 **`keyText`** 属性表示关键帧选择器，以逗号分隔的百分比值列表形式呈现。关键字 `from` 和 `to` 分别映射到 0% 和 100%。
+
+## 值
+
+一个字符串。
+
+### 异常
+
+- {{jsxref("SyntaxError")}}
+  - : 如果 `keyText` 被更新为无效的关键帧选择器，则会抛出此异常，此时 `keyText` 保持不变。
+
+## 示例
+
+以下 CSS 包含一个关键帧规则。该代码将返回 `document.styleSheets[0].cssRules` 的第一个 {{domxref("CSSRule")}}。
+`myRules[0]` 返回一个 {{domxref("CSSKeyframesRule")}} 对象，其中包含每个关键帧的 {{domxref("CSSKeyFrameRule")}} 对象。
+
+```css
+@keyframes slide-in {
+  from {
+    transform: translateX(0%);
+  }
+
+  to {
+    transform: translateX(100%);
+  }
+}
+```
+
+```js
+let myRules = document.styleSheets[0].cssRules;
+let keyframes = myRules[0]; // 一个 CSSKeyframesRule
+console.log(keyframes[0].keyText); // 包含 0% 的字符串
+```
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
translate CSSKeyframeRule keyText property to zh-CN

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Learning and translating.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
_None._

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
_None._
<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
