### PR TITLE
chore(es): remove `{{CSSRef}}` macros

### DIFF
--- a/files/es/conflicting/glossary/flexbox/index.md
+++ b/files/es/conflicting/glossary/flexbox/index.md
@@ -4,8 +4,6 @@ slug: conflicting/Glossary/Flexbox
 original_slug: Web/CSS/CSS_flexible_box_layout/Backwards_compatibility_of_flexbox
 ---
 
-{{CSSRef}}
-
 Flexbox es muy compatible con los navegadores modernos, sin embargo, hay algunos problemas con los que puede encontrarse. En esta guía, veremos qué tan bien se admite flexbox en los navegadores, y veremos algunos posibles problemas, recursos y métodos para crear soluciones y fallos.
 
 ## La historia de flexbox

--- a/files/es/conflicting/web/css/_colon_focus-visible/index.md
+++ b/files/es/conflicting/web/css/_colon_focus-visible/index.md
@@ -4,7 +4,7 @@ slug: conflicting/Web/CSS/:focus-visible
 original_slug: Web/CSS/:-moz-focusring
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/conflicting/web/css/_doublecolon_-webkit-inner-spin-button/index.md
+++ b/files/es/conflicting/web/css/_doublecolon_-webkit-inner-spin-button/index.md
@@ -4,7 +4,7 @@ slug: conflicting/Web/CSS/::-webkit-inner-spin-button
 original_slug: Web/CSS/::-webkit-outer-spin-button
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/conflicting/web/css/css_cascade/value_processing/index.md
+++ b/files/es/conflicting/web/css/css_cascade/value_processing/index.md
@@ -4,8 +4,6 @@ slug: conflicting/Web/CSS/CSS_cascade/Value_processing
 original_slug: Web/CSS/CSS_cascade/actual_value
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El **valor real** (**actual value**) de una propiedad CSS es el valor usado una vez que se aplican todas las aproximaciones. Por ejemplo, tal vez un agente usuario solo puede renderizar bordes con un valor de píxel entero, y se vería forzado a calcular la aproximación de la anchura del borde.

--- a/files/es/conflicting/web/css/css_cascade/value_processing_8a702f25e61d14d8bd6ee6f7e88ca236512427b92b01a92c1d11f9edbb8f5fe1/index.md
+++ b/files/es/conflicting/web/css/css_cascade/value_processing_8a702f25e61d14d8bd6ee6f7e88ca236512427b92b01a92c1d11f9edbb8f5fe1/index.md
@@ -4,8 +4,6 @@ slug: conflicting/Web/CSS/CSS_cascade/Value_processing_8a702f25e61d14d8bd6ee6f7e
 original_slug: Web/CSS/CSS_cascade/specified_value
 ---
 
-{{CSSRef}}
-
 El **valor especificado** (**specified value**) de una propiedad CSS es establecido de una de las siguientes maneras:
 
 1. Si la hoja de estilos del documento tiene un valor especificado para la propiedad, éste será usado. Por ejemplo, si la propiedad {{cssxref("color")}} es establecida con valor `green`, el color del texto del elemento que corresponda será verde.

--- a/files/es/conflicting/web/css/css_cascade/value_processing_a47f4c6da6bce4fc52f8ed2ce27dc58e53fa5bd72bfef0bb04a61adbc5249cc4/index.md
+++ b/files/es/conflicting/web/css/css_cascade/value_processing_a47f4c6da6bce4fc52f8ed2ce27dc58e53fa5bd72bfef0bb04a61adbc5249cc4/index.md
@@ -4,8 +4,6 @@ slug: conflicting/Web/CSS/CSS_cascade/Value_processing_a47f4c6da6bce4fc52f8ed2ce
 original_slug: Web/CSS/resolved_value
 ---
 
-{{cssref}}
-
 El **valor resuelto** (**resolved value**) de una propiedad CSS es el valor devuelto por {{domxref("Window.getComputedStyle", "getComputedStyle()")}}. Para la mayoría de las propiedades, esto es el {{cssxref("computed_value", "valor calculado") }}, pero para algunas propiedades antiguas (incluyendo {{cssxref("width")}} y {{cssxref("height")}}), éste es el {{cssxref("used_value", "valor usado")}}. Véase el enlace a la especificación a continuación para más detalles por propiedad.
 
 ## Especificaciones

--- a/files/es/conflicting/web/css/outline_114f9fa8b3569c03001b69bd5bf197b2/index.md
+++ b/files/es/conflicting/web/css/outline_114f9fa8b3569c03001b69bd5bf197b2/index.md
@@ -4,7 +4,7 @@ slug: conflicting/Web/CSS/outline_114f9fa8b3569c03001b69bd5bf197b2
 original_slug: Web/CSS/-moz-outline-radius-bottomleft
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Summary
 

--- a/files/es/conflicting/web/css/outline_59c3f549fecef9ba8337c3b924fa8ae9/index.md
+++ b/files/es/conflicting/web/css/outline_59c3f549fecef9ba8337c3b924fa8ae9/index.md
@@ -4,7 +4,7 @@ slug: conflicting/Web/CSS/outline_59c3f549fecef9ba8337c3b924fa8ae9
 original_slug: Web/CSS/-moz-outline-radius-bottomright
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Summary
 

--- a/files/es/conflicting/web/css/outline_bfe8e66e2b112d3306d547388792b0af/index.md
+++ b/files/es/conflicting/web/css/outline_bfe8e66e2b112d3306d547388792b0af/index.md
@@ -4,7 +4,7 @@ slug: conflicting/Web/CSS/outline_bfe8e66e2b112d3306d547388792b0af
 original_slug: Web/CSS/-moz-outline-radius-topright
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/conflicting/web/css/outline_cb050209a619bd4beea569386863d484/index.md
+++ b/files/es/conflicting/web/css/outline_cb050209a619bd4beea569386863d484/index.md
@@ -4,7 +4,7 @@ slug: conflicting/Web/CSS/outline_cb050209a619bd4beea569386863d484
 original_slug: Web/CSS/-moz-outline-radius-topleft
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/glossary/layout_mode/index.md
+++ b/files/es/glossary/layout_mode/index.md
@@ -4,8 +4,6 @@ slug: Glossary/Layout_mode
 original_slug: Web/CSS/Layout_mode
 ---
 
-{{cssref}}
-
 Un **modo de diseño** [CSS](/es/docs/Web/CSS)(CSS layout mode), a veces simplemente llamado "_layout_", es un algoritmo que determina la posición y tamaño de cajas basado en la forma en la que interactúan con sus (elementos) hermanos y padres. Hay varios de ellos:
 
 - El _block layout_, diseñado para presentar documentos. El block layout contiene características de documento-centrado, como la capacidad de [flotar](/es/docs/Web/CSS/float)(_float_) elementos o distribuirlos en _[múltiples columnas.](/es/docs/Web/CSS/CSS_multicol_layout/Using_multicol_layouts)_

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -73,7 +73,7 @@ l10n:
 >
 > _Recuerde eliminar este bloque de nota antes de publicar._
 
-{{SeeCompatTable}}{{deprecated_header}}{{CSSRef}}
+{{SeeCompatTable}}{{deprecated_header}}
 
 Comienza el contenido de la página con un párrafo introductorio que nombre la propiedad y diga qué hace. Idealmente, esto debería ser una o dos frases cortas.
 

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
@@ -72,7 +72,7 @@ l10n:
 >
 > _Recuerde eliminar toda esta nota explicativa antes de publicar_
 
-{{CSSRef}}{{SeeCompatTable}}{{Deprecated_Header}}
+{{SeeCompatTable}}{{Deprecated_Header}}
 
 El párrafo de resumen: comience nombrando el selector y diciendo lo que hace. Idealmente, esto debería consistir en 1 o 2 oraciones cortas.
 

--- a/files/es/orphaned/web/css/-moz-context-properties/index.md
+++ b/files/es/orphaned/web/css/-moz-context-properties/index.md
@@ -4,7 +4,7 @@ slug: orphaned/Web/CSS/-moz-context-properties
 original_slug: Web/CSS/-moz-context-properties
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 > [!NOTE]
 > Este recurso esta disponible desde Firefox 55, pero solamente es compatible con imagenes SVG cargadas via `chrome://` o `resource://` URLs. Para experimentar con la caracteristica SVG en la web, es necesario poner `svg.context-properties.content.enabled` en `true`.

--- a/files/es/orphaned/web/css/-webkit-overflow-scrolling/index.md
+++ b/files/es/orphaned/web/css/-webkit-overflow-scrolling/index.md
@@ -4,7 +4,7 @@ slug: orphaned/Web/CSS/-webkit-overflow-scrolling
 original_slug: Web/CSS/-webkit-overflow-scrolling
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 La propiedad CSS `-webkit-overflow-scrolling` controla si los dispositivos táctiles usan el desplazamiento momentum o inercial (momentum-based scroll) para el elemento dado.
 

--- a/files/es/orphaned/web/css/_doublecolon_-moz-page-sequence/index.md
+++ b/files/es/orphaned/web/css/_doublecolon_-moz-page-sequence/index.md
@@ -4,7 +4,7 @@ slug: orphaned/Web/CSS/::-moz-page-sequence
 original_slug: Web/CSS/::-moz-page-sequence
 ---
 
-{{CSSRef}}{{non-standard_header}}
+{{non-standard_header}}
 
 ## Resumen
 

--- a/files/es/orphaned/web/css/_doublecolon_-moz-page/index.md
+++ b/files/es/orphaned/web/css/_doublecolon_-moz-page/index.md
@@ -4,7 +4,7 @@ slug: orphaned/Web/CSS/::-moz-page
 original_slug: Web/CSS/::-moz-page
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/orphaned/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
+++ b/files/es/orphaned/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
@@ -4,7 +4,7 @@ slug: orphaned/Web/CSS/::-moz-scrolled-page-sequence
 original_slug: Web/CSS/::-moz-scrolled-page-sequence
 ---
 
-{{CSSRef}}{{non-standard_header}}
+{{non-standard_header}}
 
 ## Resumen
 

--- a/files/es/orphaned/web/css/css_animations/detecting_css_animation_support/index.md
+++ b/files/es/orphaned/web/css/css_animations/detecting_css_animation_support/index.md
@@ -4,7 +4,7 @@ slug: orphaned/Web/CSS/CSS_Animations/Detecting_CSS_animation_support
 original_slug: Web/CSS/CSS_Animations/Detecting_CSS_animation_support
 ---
 
-{{CSSRef}}
+
 
 Las animaciones de CSS permiten realizar animaciones creativas de contenido usando nada más que CSS. Sin embargo, es posible que hayan momentos en que estas funciones no sean compatibles, y puede que desees manejar ese problema usando código JavaScript. Este artículo, basado en [la publicación](https://hacks.mozilla.org/2011/09/detecting-and-generating-css-animations-in-javascript/) de Chris Heilmann, demuestra una técnica de como hacer esto.
 

--- a/files/es/web/api/web_animations_api/tips/index.md
+++ b/files/es/web/api/web_animations_api/tips/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Web_Animations_API/Tips
 original_slug: Web/CSS/CSS_animations/Tips
 ---
 
-{{cssref}}Las Animaciones con CSS hacen posible crear cosas increíbles con los elementos que forman parte de tus documentos y apps . Sin embargo, hay cosas que deseas hacer que no son evidentes, o soluciones inteligentes que quizás no encuentres de inmediato. Este artículo es una colección de tips y trucos que hemos encontrado que podrían hacer más fácil el trabajo, incluido cómo volver a ejecutar una animación detenida.
+Las Animaciones con CSS hacen posible crear cosas increíbles con los elementos que forman parte de tus documentos y apps . Sin embargo, hay cosas que deseas hacer que no son evidentes, o soluciones inteligentes que quizás no encuentres de inmediato. Este artículo es una colección de tips y trucos que hemos encontrado que podrían hacer más fácil el trabajo, incluido cómo volver a ejecutar una animación detenida.
 
 ## Corriendo una animación de nuevo
 

--- a/files/es/web/css/--_star_/index.md
+++ b/files/es/web/css/--_star_/index.md
@@ -3,8 +3,6 @@ title: "Propiedades personalizadas (--*): variables CSS"
 slug: Web/CSS/--*
 ---
 
-{{CSSRef}}
-
 Los nombres de las propiedades que tiene el prefijo `--`, como `--ejemplo-nombre`, representan las _propiedades personalizadas_ que contienen un valor que puede ser usado en otras declaraciones usando la función {{cssxref("var")}}.
 
 Las propiedades personalizadas tienen como alcance los elementos en los que se declaran y participan en la cascada: el valor de dicha propiedad personalizada es el de la declaración decidida por el algoritmo en cascada.

--- a/files/es/web/css/-moz-float-edge/index.md
+++ b/files/es/web/css/-moz-float-edge/index.md
@@ -3,7 +3,7 @@ title: -moz-float-edge
 slug: Web/CSS/-moz-float-edge
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 La propiedad [CSS](/es/docs/Web/CSS) no estandarizada **`-moz-float-edge`** especifica si las propiedades {{cssxref("height")}} y {{cssxref("width")}} del elemento incluyen el grosor del margen, borde, o relleno.
 

--- a/files/es/web/css/-moz-image-rect/index.md
+++ b/files/es/web/css/-moz-image-rect/index.md
@@ -3,7 +3,7 @@ title: -moz-image-rect
 slug: Web/CSS/-moz-image-rect
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/-moz-image-region/index.md
+++ b/files/es/web/css/-moz-image-region/index.md
@@ -3,7 +3,7 @@ title: -moz-image-region
 slug: Web/CSS/-moz-image-region
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 _Para sistemas que funcionan con cualquier fondo ver {{ Cssxref("-moz-image-rect") }}._
 

--- a/files/es/web/css/-moz-orient/index.md
+++ b/files/es/web/css/-moz-orient/index.md
@@ -3,7 +3,7 @@ title: -moz-orient
 slug: Web/CSS/-moz-orient
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 The `-moz-orient` [CSS](/es/docs/Web/CSS) especifica la orientación del elemento al que se aplica.
 

--- a/files/es/web/css/-moz-user-focus/index.md
+++ b/files/es/web/css/-moz-user-focus/index.md
@@ -3,7 +3,7 @@ title: -moz-user-focus
 slug: Web/CSS/-moz-user-focus
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/-moz-user-input/index.md
+++ b/files/es/web/css/-moz-user-input/index.md
@@ -3,7 +3,7 @@ title: -moz-user-input
 slug: Web/CSS/-moz-user-input
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/-webkit-border-before/index.md
+++ b/files/es/web/css/-webkit-border-before/index.md
@@ -3,7 +3,7 @@ title: -webkit-border-before
 slug: Web/CSS/-webkit-border-before
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/-webkit-box-reflect/index.md
+++ b/files/es/web/css/-webkit-box-reflect/index.md
@@ -3,7 +3,7 @@ title: -webkit-box-reflect
 slug: Web/CSS/-webkit-box-reflect
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/-webkit-mask-position-x/index.md
+++ b/files/es/web/css/-webkit-mask-position-x/index.md
@@ -3,7 +3,7 @@ title: -webkit-mask-position-x
 slug: Web/CSS/-webkit-mask-position-x
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/-webkit-mask-position-y/index.md
+++ b/files/es/web/css/-webkit-mask-position-y/index.md
@@ -3,7 +3,7 @@ title: -webkit-mask-position-y
 slug: Web/CSS/-webkit-mask-position-y
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/-webkit-mask-repeat-x/index.md
+++ b/files/es/web/css/-webkit-mask-repeat-x/index.md
@@ -3,7 +3,7 @@ title: -webkit-mask-repeat-x
 slug: Web/CSS/-webkit-mask-repeat-x
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/-webkit-mask-repeat-y/index.md
+++ b/files/es/web/css/-webkit-mask-repeat-y/index.md
@@ -3,7 +3,7 @@ title: -webkit-mask-repeat-y
 slug: Web/CSS/-webkit-mask-repeat-y
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/-webkit-text-fill-color/index.md
+++ b/files/es/web/css/-webkit-text-fill-color/index.md
@@ -3,7 +3,7 @@ title: -webkit-text-fill-color
 slug: Web/CSS/-webkit-text-fill-color
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/-webkit-text-stroke-color/index.md
+++ b/files/es/web/css/-webkit-text-stroke-color/index.md
@@ -3,7 +3,7 @@ title: -webkit-text-stroke-color
 slug: Web/CSS/-webkit-text-stroke-color
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/-webkit-text-stroke-width/index.md
+++ b/files/es/web/css/-webkit-text-stroke-width/index.md
@@ -3,7 +3,7 @@ title: -webkit-text-stroke-width
 slug: Web/CSS/-webkit-text-stroke-width
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/-webkit-text-stroke/index.md
+++ b/files/es/web/css/-webkit-text-stroke/index.md
@@ -3,7 +3,7 @@ title: -webkit-text-stroke
 slug: Web/CSS/-webkit-text-stroke
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/-webkit-touch-callout/index.md
+++ b/files/es/web/css/-webkit-touch-callout/index.md
@@ -3,7 +3,7 @@ title: -webkit-touch-callout
 slug: Web/CSS/-webkit-touch-callout
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/@charset/index.md
+++ b/files/es/web/css/@charset/index.md
@@ -3,8 +3,6 @@ title: "@charset"
 slug: Web/CSS/@charset
 ---
 
-{{ CSSRef }}
-
 ## Resumen
 
 La [regla-at](/es/docs/Web/CSS/CSS_syntax/At-rule) **`@charset`** de [CSS](/es/docs/Web/CSS) especifica la codificación de caracteres usada en la hoja de estilos. Éste debe ser el primer elemento en la hoja de estilos, y no debe ser precedidad por ningun otro caracter; al no ser una [declaración anidada](/es/docs/Web/CSS/CSS_syntax/Syntax#nested_statements), no puede ser usada dentro de [grupos de reglas-at condicionales](/es/docs/Web/CSS/CSS_syntax/At-rule#conditional_group_rules). Si se definen varias reglas-at `@charset`, solamente se usará la primera. La regla-at `@charset` no puede ser usada dentro de un atributo `style` style en un elemento HTML o dentro del elemento {{ HTMLElement("style") }} , ya que en estos casos se tomará en cuenta la codificación de la página HTML contenedora.

--- a/files/es/web/css/@counter-style/additive-symbols/index.md
+++ b/files/es/web/css/@counter-style/additive-symbols/index.md
@@ -3,8 +3,6 @@ title: additive-symbols
 slug: Web/CSS/@counter-style/additive-symbols
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El descriptor additive-symbols es similar al descriptor {{cssxref('symbols')}}, y permite al usuario especificar símbolos que se usarán para representación de contadores cuando el valor del descriptor {{cssxref('system')}} es _additive_. El descriptor `additive-symbols` define lo que se conoce como tuplas aditivas, cada una de las cuales es un par que contiene un símbolo y su peso como entero no negativo. El sistema aditivo es usado para construir sistemas de [numeración de valores de signos](http://en.wikipedia.org/wiki/Sign-value_notation) como la numeración romana.

--- a/files/es/web/css/@counter-style/index.md
+++ b/files/es/web/css/@counter-style/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 5fea7c9593f5e4b4ef13ec65064acf1eabf01e4e
 ---
 
-{{CSSRef}}
-
 La [regla arroba](/es/docs/Web/CSS/CSS_syntax/At-rule) **`@counter-style`** de [CSS](/es/docs/Web/CSS) le permite definir estilos de contador que no forman parte del conjunto predefinido de estilos. Una regla `@counter-style` define cómo convertir un valor de contador en una representación de cadena.
 
 ```css

--- a/files/es/web/css/@counter-style/symbols/index.md
+++ b/files/es/web/css/@counter-style/symbols/index.md
@@ -3,8 +3,6 @@ title: symbols
 slug: Web/CSS/@counter-style/symbols
 ---
 
-{{CSSRef}}
-
 ## Summary
 
 El descriptor `symbols` es usado para definir los símbolos que usará un sistema de conteo específico para construir una representación de conteo. Un símbolo puede ser un texto, una imagen o un identificador. El descriptor symbols debe ser especificado cuando el valor del descriptor {{cssxref('system')}} es _cyclic_, _numeric_, _alphabetic_, _symbolic_, o _fixed_. Cuando se usa el sistema _additive_, el descriptor {{cssxref('additive-symbols')}} es usado para especificar los símbolos.

--- a/files/es/web/css/@font-face/font-display/index.md
+++ b/files/es/web/css/@font-face/font-display/index.md
@@ -3,8 +3,6 @@ title: font-display
 slug: Web/CSS/@font-face/font-display
 ---
 
-{{CSSRef}}
-
 El descriptor `font-display` determina cómo se muestra una fuente basándose en cuándo está descargada y lista para usarse.
 
 ## La visualización de las fuentes

--- a/files/es/web/css/@font-face/font-family/index.md
+++ b/files/es/web/css/@font-face/font-family/index.md
@@ -3,8 +3,6 @@ title: font-family
 slug: Web/CSS/@font-face/font-family
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El descriptor CSS font-family CSS permite al autor especificar el tipo de fuente para un elemento.

--- a/files/es/web/css/@font-face/font-style/index.md
+++ b/files/es/web/css/@font-face/font-style/index.md
@@ -3,8 +3,6 @@ title: font-style
 slug: Web/CSS/@font-face/font-style
 ---
 
-{{CSSRef}}
-
 ## Summary
 
 La propiedad CSS "font-style" permite a los autores esepcificar estilos de fuente para las fuentes especificadas en la regla "`@font-face`".

--- a/files/es/web/css/@font-face/src/index.md
+++ b/files/es/web/css/@font-face/src/index.md
@@ -3,8 +3,6 @@ title: src
 slug: Web/CSS/@font-face/src
 ---
 
-{{CSSRef}}
-
 El descriptor CSS **`src`** de la regla {{cssxref("@font-face")}} especifica el recurso que contiene a la fuente. Es requerido para que la regla `@font-face` sea válida.
 
 Su valor es una lista de referencias externas o nombres de fuentes instaladas, separadas por coma según su prioridad. Cuando se necesita una fuente, el agente usuario itera sobre el conjunto de referencias, usando la primera que pueda ser activada exitosamente. Fuentes que contienen datos inválidos o fuentes locales que no se encuentren son ignoradas, y el agente usuario cargará la siguiente en la lista.

--- a/files/es/web/css/@font-face/unicode-range/index.md
+++ b/files/es/web/css/@font-face/unicode-range/index.md
@@ -3,8 +3,6 @@ title: unicode-range
 slug: Web/CSS/@font-face/unicode-range
 ---
 
-{{cssref}}
-
 La regla CSS **`unicode-range`** especifica un rango específico de caracteres a ser usados por una fuente definida {{cssxref("@font-face")}} y hacerla disponible para su uso en la página actual. Si la página no usa algún caracter en ese rango, la fuente no es descargada; si usa al menos uno de ellos, la fuente es descargada.
 
 El propósito de esta regla es permitir a las fuente ser segmentados, así el navegador solo necesita descargar la fuente necesitada para el contexto de texto en una página en particular. Por ejemplo, un sitio con muchas localizaciones podría proveer fuentes separadas para el inglés, griego y japonés. Para los usuarios que ven la versión en inglés de la página, las fuentes para el griego y el japonés no son necesarias, y por lo tanto no se descargan, ahorrando ancho de banda.

--- a/files/es/web/css/@font-feature-values/index.md
+++ b/files/es/web/css/@font-feature-values/index.md
@@ -3,8 +3,6 @@ title: "@font-feature-values"
 slug: Web/CSS/@font-feature-values
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La [regla-at](/es/docs/Web/CSS/CSS_syntax/At-rule) [CSS](/es/docs/Web/CSS) **`@font-feature-values`** permite a los autores usar un nombre común de {{cssxref("font-variant-alternates")}} para características activadas de distintas formas en OpenType. Permite simplificar el código CSS cuando se usan distintas fuentes.

--- a/files/es/web/css/@import/index.md
+++ b/files/es/web/css/@import/index.md
@@ -3,8 +3,6 @@ title: "@import"
 slug: Web/CSS/@import
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La regla-at [CSS](/es/docs/Web/CSS) `@import` permite importar reglas desde otras hojas de estilo. Estas reglas deben preceder a todos los otros tipos de reglas, excepto a las reglas {{ cssxref("@charset") }}; como esto no es una [declaración anidada](/es/docs/Web/CSS/CSS_syntax/Syntax#nested_statements), no puede ser usado dentro de [grupos condicionales de reglas-at](/es/docs/Web/CSS/CSS_syntax/At-rule#conditional_group_rules).

--- a/files/es/web/css/@media/color/index.md
+++ b/files/es/web/css/@media/color/index.md
@@ -3,8 +3,6 @@ title: color
 slug: Web/CSS/@media/color
 ---
 
-{{CSSRef}}
-
 **`color`** es una característica CSS relativa al medio de presentación cuyo valor es un [`<integer>`](/es/docs/Web/CSS/integer) que contiene el número de bits por componente de color en el dispositivo de salida, o cero si el dispositivivo no es en color.
 
 ## Especificaciones

--- a/files/es/web/css/@media/display-mode/index.md
+++ b/files/es/web/css/@media/display-mode/index.md
@@ -3,8 +3,6 @@ title: display-mode
 slug: Web/CSS/@media/display-mode
 ---
 
-{{cssref}}
-
 La [característica de medios (media feature) de CSS](/es/docs/Web/CSS/CSS_media_queries/Using_media_queries#media_features) **`display-mode`** puede ser utilizada para probar el modo de visualización de una aplicación. Puede ser usada para proveer de una experiencia de usuario consistente entre el lanzamiento de un sitio desde una URL y desde un ícono del escritorio.
 
 La característica corresponde al miembro [`display`](/es/docs/Web/Progressive_web_apps/Manifest#display) del manifiesto de la aplicación web. Ambos aplican al contexto de navegación de nivel más alto y a cualquier hijo del contexto de navegación. La característica de consulta aplica sin importar si el manifiesto de la aplicación web esta presente

--- a/files/es/web/css/@media/height/index.md
+++ b/files/es/web/css/@media/height/index.md
@@ -3,8 +3,6 @@ title: Altura
 slug: Web/CSS/@media/height
 ---
 
-{{cssref}}
-
 Las [CSS](/es/docs/Web/CSS) [media feature (consulta de medios)](/es/docs/Web/CSS/CSS_media_queries/Using_media_queries#media_features) **`height`** puede ser usada para aplicar estilos basados en la altura del {{glossary("viewport")}} (o la caja de la página, para [paged media](/es/docs/Web/CSS/CSS_paged_media)).
 
 ## Sintáxis

--- a/files/es/web/css/@media/hover/index.md
+++ b/files/es/web/css/@media/hover/index.md
@@ -3,8 +3,6 @@ title: hover
 slug: Web/CSS/@media/hover
 ---
 
-{{cssref}}
-
 La [característica de medios CSS](/es/docs/Web/CSS) **`hover`**, puede se utilizada para probar si el mecanismo de entrada primario de un usuario puede flotar sobre los elementos.
 
 ## Sintaxis

--- a/files/es/web/css/@media/index.md
+++ b/files/es/web/css/@media/index.md
@@ -3,8 +3,6 @@ title: "@media"
 slug: Web/CSS/@media
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La [regla-at](/es/docs/Web/CSS/CSS_syntax/At-rule) [CSS](/es/docs/Web/CSS) `@media` asocia un grupo de declaraciones anidadas, en un bloque CSS delimitado por llaves, con una condición definida por un [media query](/es/docs/Web/CSS/CSS_media_queries). La regla-at `@media` puede ser usada no solo en el nivel superior de la hoja de estilos, sino también dentro de cualquier [grupo de reglas condicionales](/es/docs/Web/CSS/CSS_syntax/At-rule#grupos_de_reglas_condicionales).

--- a/files/es/web/css/@media/pointer/index.md
+++ b/files/es/web/css/@media/pointer/index.md
@@ -3,8 +3,6 @@ title: pointer
 slug: Web/CSS/@media/pointer
 ---
 
-{{cssref}}
-
 La [caracteristica](/es/docs/Web/CSS/CSS_media_queries/Using_media_queries#media_features) **`pointer`** [CSS](/es/docs/Web/CSS) comprueba si el usuario tiene un dispositivo de puntero (como el ratón), y si es así, cuán preciso es el dispositivo de puntero primario.
 
 > [!NOTE]

--- a/files/es/web/css/@media/resolution/index.md
+++ b/files/es/web/css/@media/resolution/index.md
@@ -3,8 +3,6 @@ title: Resolución
 slug: Web/CSS/@media/resolution
 ---
 
-{{CSSRef}}
-
 **`resolución`** es una función de medios de CSS cuyo valor es la densidad de píxeles del dispositivo de salida, como un CSS[`<resolution>`](/es/docs/Web/CSS/resolution).
 
 ## Especificaciones

--- a/files/es/web/css/@media/width/index.md
+++ b/files/es/web/css/@media/width/index.md
@@ -3,8 +3,6 @@ title: width
 slug: Web/CSS/@media/width
 ---
 
-{{cssref}}
-
 El **`width`** [CSS](/es/docs/Web/CSS) {{cssxref("@media")}} media caracteristica puede ser usada para aplicar estilos basados en el ancho de el {{glossary("viewport")}} (o la caja de la pagina, para [paged media](/es/docs/Web/CSS/CSS_paged_media)).
 
 ## Syntax

--- a/files/es/web/css/@namespace/index.md
+++ b/files/es/web/css/@namespace/index.md
@@ -3,8 +3,6 @@ title: "@namespace"
 slug: Web/CSS/@namespace
 ---
 
-{{CSSRef}}
-
 **`@namespace`** es una [regla](/es/docs/Web/CSS/CSS_syntax/At-rule) que define [XML namespace](/es/docs/Namespaces) a ser usados en una [hoja de estilos CSS](/es/docs/Glossary/CSS). Los namespaces definidos pueden utilizarse para restringir [selectores universales](/es/docs/Web/CSS/Universal_selectors), [types](/es/docs/Web/CSS/Type_selectors), y [selectores de atributos](/es/docs/Web/CSS/Attribute_selectors) para seleccionar sólo elementos dentro de ese namespace.La regla `@namespace` generalmente sólo es útil cuando se trata de documents que contienen múltiples namespace—como HTML5 con SVG o MathML, o XML que mezclamúltiplesvocabularios.
 
 ```css

--- a/files/es/web/css/@page/index.md
+++ b/files/es/web/css/@page/index.md
@@ -3,8 +3,6 @@ title: "@page"
 slug: Web/CSS/@page
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La regla @page es usada para modificar algunas propiedades CSS cuando se va a imprimir una página web. No se pueden cambiar todas las propiedades CSS con `@page`, solo los márgenes, las líneas viudas, huérfanas y los saltos de página. Cualquier intento de cambiar otra propiedad será ignorada.

--- a/files/es/web/css/_colon_-moz-broken/index.md
+++ b/files/es/web/css/_colon_-moz-broken/index.md
@@ -3,7 +3,7 @@ title: :-moz-broken
 slug: Web/CSS/:-moz-broken
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-drag-over/index.md
+++ b/files/es/web/css/_colon_-moz-drag-over/index.md
@@ -3,7 +3,7 @@ title: :-moz-drag-over
 slug: Web/CSS/:-moz-drag-over
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-first-node/index.md
+++ b/files/es/web/css/_colon_-moz-first-node/index.md
@@ -3,7 +3,7 @@ title: :-moz-first-node
 slug: Web/CSS/:-moz-first-node
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-last-node/index.md
+++ b/files/es/web/css/_colon_-moz-last-node/index.md
@@ -3,7 +3,7 @@ title: :-moz-last-node
 slug: Web/CSS/:-moz-last-node
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-loading/index.md
+++ b/files/es/web/css/_colon_-moz-loading/index.md
@@ -3,7 +3,7 @@ title: :-moz-loading
 slug: Web/CSS/:-moz-loading
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-locale-dir_ltr/index.md
+++ b/files/es/web/css/_colon_-moz-locale-dir_ltr/index.md
@@ -3,7 +3,7 @@ title: :-moz-locale-dir(ltr)
 slug: Web/CSS/:-moz-locale-dir_ltr
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-locale-dir_rtl/index.md
+++ b/files/es/web/css/_colon_-moz-locale-dir_rtl/index.md
@@ -3,7 +3,7 @@ title: :-moz-locale-dir(rtl)
 slug: Web/CSS/:-moz-locale-dir_rtl
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-only-whitespace/index.md
+++ b/files/es/web/css/_colon_-moz-only-whitespace/index.md
@@ -3,7 +3,7 @@ title: :-moz-only-whitespace
 slug: Web/CSS/:-moz-only-whitespace
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-suppressed/index.md
+++ b/files/es/web/css/_colon_-moz-suppressed/index.md
@@ -3,7 +3,7 @@ title: :-moz-suppressed
 slug: Web/CSS/:-moz-suppressed
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-user-disabled/index.md
+++ b/files/es/web/css/_colon_-moz-user-disabled/index.md
@@ -3,7 +3,7 @@ title: :-moz-user-disabled
 slug: Web/CSS/:-moz-user-disabled
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-window-inactive/index.md
+++ b/files/es/web/css/_colon_-moz-window-inactive/index.md
@@ -3,8 +3,6 @@ title: :-moz-window-inactive
 slug: Web/CSS/:-moz-window-inactive
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) [CSS](/es/docs/Web/CSS) `:-moz-window-inactive` selecciona cualquier elemento mientras está en una ventana inactiva.

--- a/files/es/web/css/_colon_active/index.md
+++ b/files/es/web/css/_colon_active/index.md
@@ -3,8 +3,6 @@ title: :active
 slug: Web/CSS/:active
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) `:active` de [CSS](/es/docs/Web/CSS) representa un elemento (como un botón) que el usuario está activando. Cuando se usa un mouse, la "activación" generalmente comienza cuando el usuario presiona el botón primario del mouse y termina cuando se suelta. La pseudo-clase `:active` se usa comúnmente en los elementos {{HTMLElement("a")}} y {{HTMLElement("button")}}, pero también se puede usar en otros elementos.
 
 ```css

--- a/files/es/web/css/_colon_any-link/index.md
+++ b/files/es/web/css/_colon_any-link/index.md
@@ -3,7 +3,7 @@ title: :any-link
 slug: Web/CSS/:any-link
 ---
 
-{{CSSRef}} {{SeeCompatTable}}La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) `:any-link` de [CSS](/es/docs/Web/CSS) representa a un elemento que actúa como el ancla origen de un hipervínculo independientemente de si ha sido visitado, es decir, coincide con cualquier elemento {{HTMLElement("a")}}, {{HTMLElement("area")}} o {{HTMLElement("link")}} con un atributo `href`. Por lo tanto, coincide con todos los elementos que coincidan con {{cssxref(":link")}} o {{cssxref(":visited")}}.
+{{SeeCompatTable}}La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) `:any-link` de [CSS](/es/docs/Web/CSS) representa a un elemento que actúa como el ancla origen de un hipervínculo independientemente de si ha sido visitado, es decir, coincide con cualquier elemento {{HTMLElement("a")}}, {{HTMLElement("area")}} o {{HTMLElement("link")}} con un atributo `href`. Por lo tanto, coincide con todos los elementos que coincidan con {{cssxref(":link")}} o {{cssxref(":visited")}}.
 
 ```css
 /* Selecciona cualquier elemento que coincida con :link o :visited */

--- a/files/es/web/css/_colon_autofill/index.md
+++ b/files/es/web/css/_colon_autofill/index.md
@@ -3,7 +3,7 @@ title: :-webkit-autofill
 slug: Web/CSS/:autofill
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_blank/index.md
+++ b/files/es/web/css/_colon_blank/index.md
@@ -3,7 +3,7 @@ title: :blank
 slug: Web/CSS/:blank
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 > [!NOTE]
 > El selector `:blank` esta considerado en riesgo, puesto que la CSSWG sigue haciendo cambios.Ver [CSSWG issue #1967](https://github.com/w3c/csswg-drafts/issues/1967).

--- a/files/es/web/css/_colon_defined/index.md
+++ b/files/es/web/css/_colon_defined/index.md
@@ -3,8 +3,6 @@ title: :defined
 slug: Web/CSS/:defined
 ---
 
-{{ CSSRef }}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:defined`** de [CSS](/es/docs/Web/CSS) representa cualquier elemento que se haya definido. Esto incluye cualquier elemento estándar integrado en el navegador y elementos personalizados que se hayan definido correctamente (es decir, con el método {{domxref("CustomElementRegistry.define()")}}).
 
 ```css

--- a/files/es/web/css/_colon_dir/index.md
+++ b/files/es/web/css/_colon_dir/index.md
@@ -3,7 +3,7 @@ title: :dir()
 slug: Web/CSS/:dir
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) `:dir` de [CSS](/es/docs/Web/CSS) coincide con los elementos en función de la direccionalidad del texto contenido en ellos.
 

--- a/files/es/web/css/_colon_disabled/index.md
+++ b/files/es/web/css/_colon_disabled/index.md
@@ -3,8 +3,6 @@ title: :disabled
 slug: Web/CSS/:disabled
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) `:disabled` de [CSS](/es/docs/Web/CSS) representa a cualquier elemento deshabilitado. Un elemento se encuentra deshabilitado si no puede ser activado (por ejemplo ser selecionado, hacer click en él o aceptar texto de entrada) ni aceptar el foco. El elemento tiene además un estado habilitado en el cual puede ser activado o recibir foco.
 
 ```css

--- a/files/es/web/css/_colon_enabled/index.md
+++ b/files/es/web/css/_colon_enabled/index.md
@@ -3,8 +3,6 @@ title: :enabled
 slug: Web/CSS/:enabled
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) `:enabled` [CSS](/es/docs/Web/CSS) representa cualquier elemento habilitado. Un elemento está habilitado si puede ser activado (es decir seleccionado, se puede hacer click en él, acepta que se le introduzca texto, etc.) o si accepta el foco. El elemento también tiene un estado deshabilitado el en cuál, no puede ser activado ni acepta el foco.
 
 ```css

--- a/files/es/web/css/_colon_first-child/index.md
+++ b/files/es/web/css/_colon_first-child/index.md
@@ -3,8 +3,6 @@ title: :first-child
 slug: Web/CSS/:first-child
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:first-child`** de [CSS](/es/docs/Web/CSS) representa el primer elemento entre un grupo de elementos hermanos.
 
 ```css

--- a/files/es/web/css/_colon_first-of-type/index.md
+++ b/files/es/web/css/_colon_first-of-type/index.md
@@ -3,8 +3,6 @@ title: :first-of-type
 slug: Web/CSS/:first-of-type
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:first-of-type`** de [CSS](/es/docs/Web/CSS) representa el primer elemento de su tipo entre un grupo de elementos hermanos.
 
 ```css

--- a/files/es/web/css/_colon_first/index.md
+++ b/files/es/web/css/_colon_first/index.md
@@ -3,7 +3,7 @@ title: :first
 slug: Web/CSS/:first
 ---
 
-{{CSSRef}}La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) `:first` de [CSS](/es/docs/Web/CSS), utilizada con la [regla-at](/es/docs/Web/CSS/CSS_syntax/At-rule) {{cssxref("@page")}}, representa la primera página de un documento impreso.
+La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) `:first` de [CSS](/es/docs/Web/CSS), utilizada con la [regla-at](/es/docs/Web/CSS/CSS_syntax/At-rule) {{cssxref("@page")}}, representa la primera página de un documento impreso.
 
 ```css
 /* Selecciona la primera página al imprimir */

--- a/files/es/web/css/_colon_focus-visible/index.md
+++ b/files/es/web/css/_colon_focus-visible/index.md
@@ -3,8 +3,6 @@ title: :focus-visible
 slug: Web/CSS/:focus-visible
 ---
 
-{{CSSRef}}
-
 La pseudo-clase **`:focus-visible`** se aplica mientras un elemento coincide con la pseudo-clase {{CSSxRef(":focus")}} y el UA ([Agente de Usuario](/es/docs/Glossary/User_agent)) determina mediante heurística que el foco debe hacerse evidente en el elemento. (Muchos navegdores muestras un "anillo de enfoque" por defecto en este caso.
 
 Este selector es útil para proporcionar un indicador de enfoque diferente basado en la modalidad de entrada del usuario (ratón vs teclado).

--- a/files/es/web/css/_colon_focus-within/index.md
+++ b/files/es/web/css/_colon_focus-within/index.md
@@ -3,8 +3,6 @@ title: :focus-within
 slug: Web/CSS/:focus-within
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) [CSS](/es/docs/Web/CSS) **`:focus-within`** representa un elemento que ha recibido el foco o que _contiene_ un elemento que ha recibido el foco. En otras palabras, representa un elemento que en sí coincide con la pseudoclase {{cssxref(":focus")}} o tiene descendientes que coincidan con `:focus`. (Esto incluye descendientes en [shadow DOM](/es/docs/Web/API/Web_components/Using_shadow_DOM))
 
 ```css

--- a/files/es/web/css/_colon_focus/index.md
+++ b/files/es/web/css/_colon_focus/index.md
@@ -3,8 +3,6 @@ title: :focus
 slug: Web/CSS/:focus
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:focus`** [CSS](/es/docs/Web/CSS) representa un elemento (como una entrada de formulario) que ha recibido el foco. Generalmente se activa cuando el usuario hace clic, toca un elemento o lo selecciona con la tecla "Tab" del teclado.
 
 ```css

--- a/files/es/web/css/_colon_fullscreen/index.md
+++ b/files/es/web/css/_colon_fullscreen/index.md
@@ -3,7 +3,7 @@ title: :fullscreen
 slug: Web/CSS/:fullscreen
 ---
 
-{{CSSRef}} {{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:fullscreen`** de [CSS](/es/docs/Web/CSS) representa un elemento que se muestra cuando el navegador está en modo de [pantalla completa](/es/docs/Web/API/Fullscreen_API).
 

--- a/files/es/web/css/_colon_host/index.md
+++ b/files/es/web/css/_colon_host/index.md
@@ -3,8 +3,6 @@ title: :host
 slug: Web/CSS/:host
 ---
 
-{{ CSSRef }}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) [CSS](/es/docs/Web/CSS) **`:host`** selecciona la sombra host de [sombra DOM](/es/docs/Web/API/Web_components/Using_shadow_DOM) que contiene el CSS que se usa en el interior — es decir, esto le permite seleccionar un elemento personalizado desde su sombra DOM.
 
 > [!NOTE]

--- a/files/es/web/css/_colon_hover/index.md
+++ b/files/es/web/css/_colon_hover/index.md
@@ -3,8 +3,6 @@ title: :hover
 slug: Web/CSS/:hover
 ---
 
-{{ CSSRef }}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:hover`** de [CSS](/es/docs/Web/CSS) coincide cuando el usuario interactúa con un elemento con un dispositivo señalador, pero no necesariamente lo activa. Generalmente se activa cuando el usuario se desplaza sobre un elemento con el cursor (puntero del mouse).
 
 ```css

--- a/files/es/web/css/_colon_in-range/index.md
+++ b/files/es/web/css/_colon_in-range/index.md
@@ -3,8 +3,6 @@ title: :in-range
 slug: Web/CSS/:in-range
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:in-range`** de [CSS](/es/docs/Web/CSS) representa un elemento {{htmlelement("input")}} cuyo valor actual se encuentra dentro de los límites de rango especificados por los atributos [`min`](/es/docs/Web/HTML/Reference/Elements/input#min) y [`max`](/es/docs/Web/HTML/Reference/Elements/input#max).
 
 ```css

--- a/files/es/web/css/_colon_indeterminate/index.md
+++ b/files/es/web/css/_colon_indeterminate/index.md
@@ -3,8 +3,6 @@ title: :indeterminate
 slug: Web/CSS/:indeterminate
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:indeterminate`** de [CSS](/es/docs/Web/CSS) representa cualquier elemento de formulario cuyo estado sea indeterminado.
 
 ```css

--- a/files/es/web/css/_colon_invalid/index.md
+++ b/files/es/web/css/_colon_invalid/index.md
@@ -3,8 +3,6 @@ title: :invalid
 slug: Web/CSS/:invalid
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:invalid`** de [CSS](/es/docs/Web/CSS) representa cualquier elemento {{HTMLElement("input")}} u otro elemento {{HTMLElement("form")}} cuyos contenidos no se puedan [validar](/es/docs/Web/HTML/Constraint_validation).
 
 ```css

--- a/files/es/web/css/_colon_is/index.md
+++ b/files/es/web/css/_colon_is/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: ac2874857a3de0be38430e58068597edf0afa2b2
 ---
 
-{{CSSRef}}
-
 La función [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) de [CSS](/es/docs/Web/CSS) **`:is()`** toma una lista de selectores como argumento y selecciona cualquier elemento que pueda ser seleccionado por uno de los selectores en esa lista. Esto es útil para escribir selectores grandes en una forma más compacta.
 
 > [!NOTE]

--- a/files/es/web/css/_colon_lang/index.md
+++ b/files/es/web/css/_colon_lang/index.md
@@ -3,8 +3,6 @@ title: :lang
 slug: Web/CSS/:lang
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:lang()`** de [CSS](/es/docs/Web/CSS) es utilizada para modificar elementos en función del idioma en el que se determina que están.
 
 ```css

--- a/files/es/web/css/_colon_last-child/index.md
+++ b/files/es/web/css/_colon_last-child/index.md
@@ -3,8 +3,6 @@ title: :last-child
 slug: Web/CSS/:last-child
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:last-child`** de [CSS](/es/docs/Web/CSS) representa el último elemento entre un grupo de elementos hermanos.
 
 ```css

--- a/files/es/web/css/_colon_last-of-type/index.md
+++ b/files/es/web/css/_colon_last-of-type/index.md
@@ -3,8 +3,6 @@ title: :last-of-type
 slug: Web/CSS/:last-of-type
 ---
 
-{{CSSRef}}
-
 La [pseudo-class](/es/docs/Web/CSS/Pseudo-classes) **`:last-of-type`** de [CSS](/es/docs/Web/CSS) representa el último elemento de su tipo entre un grupo de elementos hermanos.
 
 ```css

--- a/files/es/web/css/_colon_link/index.md
+++ b/files/es/web/css/_colon_link/index.md
@@ -3,8 +3,6 @@ title: :link
 slug: Web/CSS/:link
 ---
 
-{{ CSSRef }}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:link`** [CSS](/es/docs/Web/CSS) representa un elemento que aún no se ha visitado. Coincide con cada elemento no visitado {{HTMLElement("a")}}, {{HTMLElement("area")}}, o {{HTMLElement("link")}} que tiene un atributo `href`.
 
 ```css

--- a/files/es/web/css/_colon_not/index.md
+++ b/files/es/web/css/_colon_not/index.md
@@ -3,8 +3,6 @@ title: :not()
 slug: Web/CSS/:not
 ---
 
-{{CSSRef}}
-
 La [pseudoclase](/es/docs/Web/CSS/Pseudo-classes) **`:not()`** de [CSS](/es/docs/Web/CSS) representa elementos que no coinciden con una lista de selectores. Como evita que se seleccionen elementos específicos, se lo conoce como la _pseudoclase de negación_.
 
 ```css

--- a/files/es/web/css/_colon_nth-child/index.md
+++ b/files/es/web/css/_colon_nth-child/index.md
@@ -3,8 +3,6 @@ title: :nth-child
 slug: Web/CSS/:nth-child
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS) **`:nth-child()`** de [CSS](/es/docs/Web/CSS) coincide con uno o más elementos en función de su posición entre un grupo de hermanos.
 
 ```css

--- a/files/es/web/css/_colon_nth-last-child/index.md
+++ b/files/es/web/css/_colon_nth-last-child/index.md
@@ -3,8 +3,6 @@ title: :nth-last-child
 slug: Web/CSS/:nth-last-child
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:nth-last-child()`** de [CSS](/es/docs/Web/CSS) selecciona uno o más elementos en función de su posición entre un grupo de hermanos, contando desde el final.
 
 ```css

--- a/files/es/web/css/_colon_nth-last-of-type/index.md
+++ b/files/es/web/css/_colon_nth-last-of-type/index.md
@@ -3,8 +3,6 @@ title: :nth-last-of-type()
 slug: Web/CSS/:nth-last-of-type
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:nth-last-of-type()`** [CSS](/es/docs/Web/CSS) coincide con uno o más elementos de un tipo dado, en función de su posición entre un grupo de hermanos, contando desde el final.
 
 ```css

--- a/files/es/web/css/_colon_nth-of-type/index.md
+++ b/files/es/web/css/_colon_nth-of-type/index.md
@@ -3,8 +3,6 @@ title: :nth-of-type
 slug: Web/CSS/:nth-of-type
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:nth-of-type()`** de [CSS](/es/docs/Web/CSS) selecciona uno o más elementos de un tipo dado, en función de su posición entre un grupo de hermanos.
 
 ```css

--- a/files/es/web/css/_colon_only-child/index.md
+++ b/files/es/web/css/_colon_only-child/index.md
@@ -3,8 +3,6 @@ title: :only-child
 slug: Web/CSS/:only-child
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:only-child`** de [CSS](/es/docs/Web/CSS) representa un elemento sin hermanos. Esto es lo mismo que `:first-child:last-child` o `:nth-child(1):nth-last-child(1)`, pero con una especificidad menor.
 
 ```css

--- a/files/es/web/css/_colon_only-of-type/index.md
+++ b/files/es/web/css/_colon_only-of-type/index.md
@@ -3,8 +3,6 @@ title: :only-of-type
 slug: Web/CSS/:only-of-type
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:only-of-type`** [CSS](/es/docs/Web/CSS) representa un elemento que no tiene hermanos del mismo tipo.
 
 ```css

--- a/files/es/web/css/_colon_optional/index.md
+++ b/files/es/web/css/_colon_optional/index.md
@@ -3,8 +3,6 @@ title: :optional
 slug: Web/CSS/:optional
 ---
 
-{{ CSSRef }}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:optional`** de [CSS](/es/docs/Web/CSS) representa cualquier elemento {{HTMLElement("input")}}, {{HTMLElement("select")}}, o {{HTMLElement("textarea")}} que no tenga el atributo [`required`](/es/docs/Web/HTML/Reference/Elements/input#required) establecido en él.
 
 ```css

--- a/files/es/web/css/_colon_out-of-range/index.md
+++ b/files/es/web/css/_colon_out-of-range/index.md
@@ -3,8 +3,6 @@ title: :out-of-range
 slug: Web/CSS/:out-of-range
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:out-of-range`** de [CSS](/es/docs/Web/CSS) representa un elemento {{htmlelement("input")}} cuyo valor actual está fuera de los límites de rango especificados por los atributos [`min`](/es/docs/Web/HTML/Reference/Elements/input#min) y [`max`](/es/docs/Web/HTML/Reference/Elements/input#max).
 
 ```css

--- a/files/es/web/css/_colon_placeholder-shown/index.md
+++ b/files/es/web/css/_colon_placeholder-shown/index.md
@@ -3,7 +3,7 @@ title: :placeholder-shown
 slug: Web/CSS/:placeholder-shown
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:placeholder-shown`** de [CSS](/es/docs/Web/CSS) representa cualquier elemento {{htmlElement("input")}} o {{htmlElement("textarea")}} que esté mostrando actualmente el [texto de marcador de posición (placeholder)](/es/docs/Web/HTML/Reference/Elements/input#attr-placeholder).
 

--- a/files/es/web/css/_colon_read-only/index.md
+++ b/files/es/web/css/_colon_read-only/index.md
@@ -3,8 +3,6 @@ title: :read-only
 slug: Web/CSS/:read-only
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:read-only`** de [CSS](/es/docs/Web/CSS) representa un elemento que ya no es editable por el usuario (como un [input](/es/docs/Web/HTML/Reference/Elements/input)).
 
 ```css

--- a/files/es/web/css/_colon_read-write/index.md
+++ b/files/es/web/css/_colon_read-write/index.md
@@ -3,8 +3,6 @@ title: :read-write
 slug: Web/CSS/:read-write
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:read-write`** de [CSS](/es/docs/Web/CSS) representa un elemento (como un [input](/es/docs/Web/HTML/Reference/Elements/input)) que es editable por el usuario.
 
 ```css

--- a/files/es/web/css/_colon_required/index.md
+++ b/files/es/web/css/_colon_required/index.md
@@ -3,8 +3,6 @@ title: :required
 slug: Web/CSS/:required
 ---
 
-{{ CSSRef }}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:required`** de [CSS](/es/docs/Web/CSS) representa cualquier elemento {{HTMLElement("input")}}, {{HTMLElement("select")}}, o {{HTMLElement("textarea")}} que tenga el atributo [`required`](/es/docs/Web/HTML/Reference/Elements/input#required) establecido en él.
 
 ```css

--- a/files/es/web/css/_colon_root/index.md
+++ b/files/es/web/css/_colon_root/index.md
@@ -3,8 +3,6 @@ title: :root
 slug: Web/CSS/:root
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:root`** de [CSS](/es/docs/Web/CSS) selecciona el elemento raíz de un árbol que representa el documento. En HTML, `:root` representa el elemento {{HTMLElement("html")}} y es idéntico al selector `html`, excepto que su [especificidad](/es/docs/Web/CSS/CSS_cascade/Specificity) es mayor.
 
 ```css

--- a/files/es/web/css/_colon_target/index.md
+++ b/files/es/web/css/_colon_target/index.md
@@ -3,8 +3,6 @@ title: :target
 slug: Web/CSS/:target
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:target`** de [CSS](/es/docs/Web/CSS) representa un elemento único (el _elemento objetivo_) con un [`id`](/es/docs/Web/HTML/Reference/Global_attributes#id) que coincide con el fragmento de la URL.
 
 ```css

--- a/files/es/web/css/_colon_user-invalid/index.md
+++ b/files/es/web/css/_colon_user-invalid/index.md
@@ -3,7 +3,7 @@ title: :-moz-ui-invalid
 slug: Web/CSS/:user-invalid
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_valid/index.md
+++ b/files/es/web/css/_colon_valid/index.md
@@ -3,8 +3,6 @@ title: :valid
 slug: Web/CSS/:valid
 ---
 
-{{CSSRef}}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:valid`** de [CSS](/es/docs/Web/CSS) representa cualquier elemento {{HTMLElement("input")}} u otro elemento {{HTMLElement("form")}} cuyo contenido se [valide](/es/docs/Web/HTML/Constraint_validation) satisfactoriamente. Esto permite que los campos válidos adopten fácilmente una apariencia que ayuda al usuario a confirmar que sus datos están formateados correctamente.
 
 ```css

--- a/files/es/web/css/_colon_visited/index.md
+++ b/files/es/web/css/_colon_visited/index.md
@@ -3,8 +3,6 @@ title: :visited
 slug: Web/CSS/:visited
 ---
 
-{{ CSSRef }}
-
 La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:visited`** de [CSS](/es/docs/Web/CSS) representa enlaces que el usuario ya ha visitado. Por motivos de privacidad, los estilos que se pueden modificar con este selector son muy limitados.
 
 ```css

--- a/files/es/web/css/_doublecolon_-moz-color-swatch/index.md
+++ b/files/es/web/css/_doublecolon_-moz-color-swatch/index.md
@@ -3,7 +3,7 @@ title: ::-moz-color-swatch
 slug: Web/CSS/::-moz-color-swatch
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 El **`::-moz-color-swatch`** [pdseudo-elemento CSS](/es/docs/Web/CSS) es una [extension de Mozilla](/es/docs/Web/CSS/Mozilla_Extensions) que representa el color seleccionado en un {{HTMLElement("input")}} de `type="color"`.
 

--- a/files/es/web/css/_doublecolon_-moz-list-bullet/index.md
+++ b/files/es/web/css/_doublecolon_-moz-list-bullet/index.md
@@ -3,7 +3,7 @@ title: ::-moz-list-bullet
 slug: Web/CSS/::-moz-list-bullet
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 El [pseudoelemento](/es/docs/Web/CSS/Pseudo-elements) [CSS](/es/docs/Web/CSS) **`::-moz-list-bullet`** es una [extensión de Mozilla](/es/docs/Web/CSS/Mozilla_Extensions) que representa el marcador (normalmente una viñeta) de un elemento de lista ({{htmlelement("li")}}) en una lista desordenada ({{htmlelement ("ul")}}).
 

--- a/files/es/web/css/_doublecolon_-moz-list-number/index.md
+++ b/files/es/web/css/_doublecolon_-moz-list-number/index.md
@@ -3,7 +3,7 @@ title: ::-moz-list-number
 slug: Web/CSS/::-moz-list-number
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_-moz-progress-bar/index.md
+++ b/files/es/web/css/_doublecolon_-moz-progress-bar/index.md
@@ -3,7 +3,7 @@ title: ::-moz-progress-bar
 slug: Web/CSS/::-moz-progress-bar
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) **`::-moz-progress-bar`** de [CSS](/es/docs/Web/CSS) es una [extensión de Mozilla](/es/docs/Web/CSS/Mozilla_Extensions) que representa la barra de progreso dentro de un elemento {{HTMLElement("progress")}}. (La barra representa la cantidad de progreso que se ha realizado).
 

--- a/files/es/web/css/_doublecolon_-moz-range-progress/index.md
+++ b/files/es/web/css/_doublecolon_-moz-range-progress/index.md
@@ -3,7 +3,7 @@ title: ::-moz-range-progress
 slug: Web/CSS/::-moz-range-progress
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_-moz-range-thumb/index.md
+++ b/files/es/web/css/_doublecolon_-moz-range-thumb/index.md
@@ -3,7 +3,7 @@ title: ::-moz-range-thumb
 slug: Web/CSS/::-moz-range-thumb
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_-moz-range-track/index.md
+++ b/files/es/web/css/_doublecolon_-moz-range-track/index.md
@@ -3,7 +3,7 @@ title: ::-moz-range-track
 slug: Web/CSS/::-moz-range-track
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_-webkit-inner-spin-button/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-inner-spin-button/index.md
@@ -3,7 +3,7 @@ title: ::-webkit-inner-spin-button
 slug: Web/CSS/::-webkit-inner-spin-button
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-bar/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-bar/index.md
@@ -3,7 +3,7 @@ title: ::-webkit-meter-bar
 slug: Web/CSS/::-webkit-meter-bar
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
@@ -3,7 +3,7 @@ title: ::-webkit-meter-even-less-good-value
 slug: Web/CSS/::-webkit-meter-even-less-good-value
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-inner-element/index.md
@@ -3,7 +3,7 @@ title: ::-webkit-meter-inner-element
 slug: Web/CSS/::-webkit-meter-inner-element
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
@@ -3,7 +3,7 @@ title: ::-webkit-meter-optimum-value
 slug: Web/CSS/::-webkit-meter-optimum-value
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
@@ -3,7 +3,7 @@ title: ::-webkit-meter-suboptimum-value
 slug: Web/CSS/::-webkit-meter-suboptimum-value
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-progress-bar/index.md
@@ -3,7 +3,7 @@ title: ::-webkit-progress-bar
 slug: Web/CSS/::-webkit-progress-bar
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-progress-inner-element/index.md
@@ -3,7 +3,7 @@ title: ::-webkit-progress-inner-element
 slug: Web/CSS/::-webkit-progress-inner-element
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_-webkit-progress-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-progress-value/index.md
@@ -3,7 +3,7 @@ title: ::-webkit-progress-value
 slug: Web/CSS/::-webkit-progress-value
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -3,8 +3,6 @@ title: ::-webkit-scrollbar
 slug: Web/CSS/::-webkit-scrollbar
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) [CSS](/es/docs/Web/CSS) ::-webkit-scrollbar afecta el estilo de la barra de desplazamiento asociada a un elemento.

--- a/files/es/web/css/_doublecolon_-webkit-slider-thumb/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-slider-thumb/index.md
@@ -3,7 +3,7 @@ title: ::-webkit-slider-thumb
 slug: Web/CSS/::-webkit-slider-thumb
 ---
 
-admi{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_doublecolon_after/index.md
+++ b/files/es/web/css/_doublecolon_after/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: be1922d62a0d31e4e3441db0e943aed8df736481
 ---
 
-{{CSSRef}}
-
 En CSS, **`::after`** crea un [pseudoelemento](/es/docs/Web/CSS/Pseudo-elements) que es el último hijo del elemento seleccionado. Es comúnmente usado para añadir contenido cosmético a un elemento con la propiedad {{CSSxRef("content")}}. Está en línea de forma predeterminada.
 
 {{InteractiveExample("CSS Demo: ::after", "tabbed-standard")}}

--- a/files/es/web/css/_doublecolon_backdrop/index.md
+++ b/files/es/web/css/_doublecolon_backdrop/index.md
@@ -3,7 +3,7 @@ title: ::backdrop
 slug: Web/CSS/::backdrop
 ---
 
-{{CSSRef}} {{SeeCompatTable}}
+{{SeeCompatTable}}
 
 Cada uno de los elementos en la pila de la [capa superior](https://fullscreen.spec.whatwg.org/#top-layer) posee un _`::backdrop`_ {{Cssxref("pseudo-elements", "pseudo-element")}}. Este pseudo-elemento es una caja que se muestra inmediatamente debajo del elemento (y sobre el elemento inmediatamente inferior de la pila, si es que hay), dentro de dicha capa superior.
 

--- a/files/es/web/css/_doublecolon_before/index.md
+++ b/files/es/web/css/_doublecolon_before/index.md
@@ -3,8 +3,6 @@ title: ::before (:before)
 slug: Web/CSS/::before
 ---
 
-{{CSSRef}}
-
 En CSS, `::before` crea un [pseudoelemento](/es/docs/Web/CSS/Pseudo-elements) que es el primer hijo del elemento seleccionado. Es usado normalmente para añadir contenido estético a un elemento, usando la propiedad {{cssxref("content")}}. Este elemento se muestra en línea con el texto de forma predeterminada.
 
 ```css

--- a/files/es/web/css/_doublecolon_cue/index.md
+++ b/files/es/web/css/_doublecolon_cue/index.md
@@ -3,8 +3,6 @@ title: ::cue
 slug: Web/CSS/::cue
 ---
 
-{{CSSRef}}
-
 El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) [CSS](/es/docs/Web/CSS) **`::cue`** señala las pistas de texto [WebVTT](/es/docs/Web/API/WebVTT_API) dentro del elemento seleccionado. Esto puede ser usado para [estilizar subtítulos y otras pistas de texto](/es/docs/Web/API/WebVTT_API#Estilizando_anotaciones_WebVTT) multimedia con pistas de texto.
 
 ```css

--- a/files/es/web/css/_doublecolon_file-selector-button/index.md
+++ b/files/es/web/css/_doublecolon_file-selector-button/index.md
@@ -3,8 +3,6 @@ title: ::file-selector-button
 slug: Web/CSS/::file-selector-button
 ---
 
-{{CSSRef}}
-
 El [pseudoelemento](/es/docs/Web/CSS/Pseudo-elements) [CSS](/es/docs/Web/CSS) **`::file-selector-button`** representa el botón de un {{HTMLElement("input") }} con el atributo [`type="file"`](/es/docs/Web/HTML/Reference/Elements/input/file).
 
 {{InteractiveExample("CSS Demo: ::file-selector-button", "tabbed-shorter")}}

--- a/files/es/web/css/_doublecolon_first-letter/index.md
+++ b/files/es/web/css/_doublecolon_first-letter/index.md
@@ -3,8 +3,6 @@ title: ::first-letter (:first-letter)
 slug: Web/CSS/::first-letter
 ---
 
-{{CSSRef}}
-
 El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) **`::first-letter`** aplica estilos a la primera letra de la primera línea un [elemento de bloque](/es/docs/Glossary/Block-level_content), sólo cuando no es precedido de otro contenido (como imágenes o tablas).
 
 ```css

--- a/files/es/web/css/_doublecolon_first-line/index.md
+++ b/files/es/web/css/_doublecolon_first-line/index.md
@@ -3,8 +3,6 @@ title: ::first-line (:first-line)
 slug: Web/CSS/::first-line
 ---
 
-{{CSSRef}}
-
 El [Pseudoelemento](/es/docs/Web/CSS/Pseudo-elements) **`::first-line`** aplica estilos a la primera línea de un [elemento de bloque](/es/docs/Glossary/Block-level_content). Nótese que la longitud de la primera línea depende de muchos factores, incluyendo el ancho del elemento, el ancho del documento y el tamaño de fuente del texto.
 
 ```css

--- a/files/es/web/css/_doublecolon_marker/index.md
+++ b/files/es/web/css/_doublecolon_marker/index.md
@@ -3,7 +3,7 @@ title: ::marker
 slug: Web/CSS/::marker
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) **`::marker`** en [CSS](/es/docs/Web/CSS) selecciona la caja de marcadores de un elemento de la lista, que normalmente contiene una viñeta o un número. Funciona en cualquier elemento o pseudo-elemento configurado para [`display: list-item`](/es/docs/Web/CSS/display), como el elemento {{HTMLElement("li")}} y {{HTMLElement("summary")}}.
 

--- a/files/es/web/css/_doublecolon_part/index.md
+++ b/files/es/web/css/_doublecolon_part/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 5863b9e6635b304b96ef5f70937329e854957f73
 ---
 
-{{CSSRef}}
-
 El [pseudoelemento](/es/docs/Web/CSS/Pseudo-elements) de [CSS](/es/docs/Web/CSS) **`::part`** representa cualquier elemento dentro de un [shadow tree](/es/docs/Web/API/Web_components/Using_shadow_DOM) que tiene un atributo [`part`](/es/docs/Web/HTML/Reference/Global_attributes#part) coincidente.
 
 ```css

--- a/files/es/web/css/_doublecolon_placeholder/index.md
+++ b/files/es/web/css/_doublecolon_placeholder/index.md
@@ -3,8 +3,6 @@ title: ::placeholder
 slug: Web/CSS/::placeholder
 ---
 
-{{CSSRef}}
-
 El [pseudo-elemento CSS](/es/docs/Web/CSS/Pseudo-elements) **`::placeholder`** representa el [texto provisional](/es/docs/Learn_web_development/Extensions/Forms#the_placeholder_attribute) en un elemento {{HTMLElement("input")}} o un elemento {{HTMLElement("textarea")}}.
 
 ```css

--- a/files/es/web/css/_doublecolon_selection/index.md
+++ b/files/es/web/css/_doublecolon_selection/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 5fea7c9593f5e4b4ef13ec65064acf1eabf01e4e
 ---
 
-{{CSSRef}}
-
 El [pseudoelemento](/es/docs/Web/CSS/Pseudo-elements) de CSS **`::selection`** aplica estilos a la parte de un documento que ha sido resaltada por el usuario (como hacer clic y arrastrar el ratón sobre el texto).
 
 {{InteractiveExample("CSS Demo: ::selection", "tabbed-shorter")}}

--- a/files/es/web/css/_doublecolon_spelling-error/index.md
+++ b/files/es/web/css/_doublecolon_spelling-error/index.md
@@ -3,7 +3,7 @@ title: ::spelling-error
 slug: Web/CSS/::spelling-error
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) [CSS](/es/docs/Web/CSS) **`::spelling-error`** representa un segmento de texto que el {{glossary("user agent")}} ha marcado como deletreado incorrectamente.
 

--- a/files/es/web/css/align-content/index.md
+++ b/files/es/web/css/align-content/index.md
@@ -3,8 +3,6 @@ title: align-content
 slug: Web/CSS/align-content
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad [CSS](/es/docs/Web/CSS) `align-content` ajusta las líneas dentro de un contenedor flex cuando hay espacio extra en el eje transversal.

--- a/files/es/web/css/align-items/index.md
+++ b/files/es/web/css/align-items/index.md
@@ -3,8 +3,6 @@ title: align-items
 slug: Web/CSS/align-items
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`align-items`** establece el valor {{cssxref("align-self")}} sobre todos los descendientes directos de un grupo. La propiedad align-self indica la alineación de un elemento dentro del bloque que lo contiene. En Flexbox controla la alineación de los elementos del {{glossary("Cross Axis")}}, en Grid Layout controla la alineación de los elementos en el eje Block dentro de su [área grid](/es/docs/Glossary/Grid_Areas).
 
 El ejemplo interactivo a continuación demuestra algunos de los valores de `align-items` utilizando el sistema grid.

--- a/files/es/web/css/align-self/index.md
+++ b/files/es/web/css/align-self/index.md
@@ -3,8 +3,6 @@ title: align-self
 slug: Web/CSS/align-self
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad [CSS](/es/docs/Web/CSS) **`align-self`** alinea los elementos flexibles de la línea flexible actual, reemplazando el valor de {{cssxref("align-items")}}. Si el límite transversal de alguno de los elementos está definido como `auto`, el valor de `align-self` es ignorado.

--- a/files/es/web/css/all/index.md
+++ b/files/es/web/css/all/index.md
@@ -3,8 +3,6 @@ title: all
 slug: Web/CSS/all
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad de forma reducida **`all`** restaura todas las propiedades, excepto {{cssxref("unicode-bidi")}} y {{cssxref("direction")}}, a su valor inicial o heredado.

--- a/files/es/web/css/animation-name/index.md
+++ b/files/es/web/css/animation-name/index.md
@@ -3,7 +3,7 @@ title: animation-name
 slug: Web/CSS/animation-name
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 ## Resumen
 

--- a/files/es/web/css/animation-play-state/index.md
+++ b/files/es/web/css/animation-play-state/index.md
@@ -3,7 +3,7 @@ title: animation-play-state
 slug: Web/CSS/animation-play-state
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 ## Resumen
 

--- a/files/es/web/css/animation-timing-function/index.md
+++ b/files/es/web/css/animation-timing-function/index.md
@@ -3,7 +3,7 @@ title: animation-timing-function
 slug: Web/CSS/animation-timing-function
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 ## Resumen
 

--- a/files/es/web/css/animation/index.md
+++ b/files/es/web/css/animation/index.md
@@ -3,8 +3,6 @@ title: animation
 slug: Web/CSS/animation
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad `animation` de [CSS](/es/docs/Web/CSS) es una [propiedad abreviada (shorthand property)](/es/docs/Web/CSS/CSS_cascade/Shorthand_properties) para {{ cssxref("animation-name") }}, {{ cssxref("animation-duration") }}, {{ cssxref("animation-timing-function") }}, {{ cssxref("animation-delay") }}, {{ cssxref("animation-iteration-count") }} y {{ cssxref("animation-direction") }}.

--- a/files/es/web/css/appearance/index.md
+++ b/files/es/web/css/appearance/index.md
@@ -3,7 +3,7 @@ title: -moz-appearance (-webkit-appearance)
 slug: Web/CSS/appearance
 ---
 
-{{non-standard_header}}{{CSSRef}}
+{{non-standard_header}}
 
 La propiedad CSS `-moz-appearance` se utiliza en Gecko (Firefox) para visualizar un elemento utilizando una plataforma nativa basada en el estilo del tema del sistema operativo.
 

--- a/files/es/web/css/attribute_selectors/index.md
+++ b/files/es/web/css/attribute_selectors/index.md
@@ -3,8 +3,6 @@ title: Selectores de atributo
 slug: Web/CSS/Attribute_selectors
 ---
 
-{{CSSRef}}
-
 El **selector de atributos** CSS coincide con los elementos en función de la presencia o el valor de un atributo determinado.
 
 ```css

--- a/files/es/web/css/backdrop-filter/index.md
+++ b/files/es/web/css/backdrop-filter/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 84d5320ca6c8d0925995083de66abacb98922ced
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`backdrop-filter`** le permite aplicar efectos gráficos como desenfoque o cambio de color al área detrás de un elemento. Debido a que se aplica a todo lo que hay detrás del elemento, para ver el efecto debe hacer que el elemento o su fondo sean al menos parcialmente transparentes.
 
 {{InteractiveExample("CSS Demo: backdrop-filter()")}}

--- a/files/es/web/css/backface-visibility/index.md
+++ b/files/es/web/css/backface-visibility/index.md
@@ -3,7 +3,7 @@ title: backface-visibility
 slug: Web/CSS/backface-visibility
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 ## Resumen
 

--- a/files/es/web/css/background-attachment/index.md
+++ b/files/es/web/css/background-attachment/index.md
@@ -3,8 +3,6 @@ title: background-attachment
 slug: Web/CSS/background-attachment
 ---
 
-{{CSSRef}}
-
 ### Resumen
 
 La propiedad CSS **`background-attachment`** determina si la posición de la imagen de fondo será **fija** dentro de la pantalla o **se desplazará** con su bloque contenedor.

--- a/files/es/web/css/background-blend-mode/index.md
+++ b/files/es/web/css/background-blend-mode/index.md
@@ -3,8 +3,6 @@ title: background-blend-mode
 slug: Web/CSS/background-blend-mode
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`background-blend-mode`** describe cómo las imágenes de fondo y el color de fondo del elemento deben mezclar entre sí.

--- a/files/es/web/css/background-color/index.md
+++ b/files/es/web/css/background-color/index.md
@@ -3,8 +3,6 @@ title: background-color
 slug: Web/CSS/background-color
 ---
 
-{{CSSRef}}
-
 ### Resumen
 
 `Background-color` es un propiedad de CSS que define el color de fondo de un elemento, puede ser el valor de un color o la palabra clave `transparent`.

--- a/files/es/web/css/background-image/index.md
+++ b/files/es/web/css/background-image/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 642f2385b7cf791b3a40a81a17752f5b0c3208ea
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`background-image`** establece una o más imágenes de fondo para un elemento.
 
 {{InteractiveExample("CSS Demo: background-image")}}

--- a/files/es/web/css/background-origin/index.md
+++ b/files/es/web/css/background-origin/index.md
@@ -3,8 +3,6 @@ title: background-origin
 slug: Web/CSS/background-origin
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad background-origin especifica el área de origen de un fondo o imagen en determinada caja. para que la propiedad [background-position](/es/docs/Web/CSS/background-position) calcule la posición de inicio de un fondo o imagen definida por la propiedad [background-image](/es/docs/Web/CSS/background-image).

--- a/files/es/web/css/background-position/index.md
+++ b/files/es/web/css/background-position/index.md
@@ -3,7 +3,7 @@ title: background-position
 slug: Web/CSS/background-position
 ---
 
-{{CSSRef}}{{ PreviousNext("CSS:background-image", "CSS:background-repeat") }}
+{{ PreviousNext("CSS:background-image", "CSS:background-repeat") }}
 
 ## Resumen
 

--- a/files/es/web/css/background-repeat/index.md
+++ b/files/es/web/css/background-repeat/index.md
@@ -3,8 +3,6 @@ title: background-repeat
 slug: Web/CSS/background-repeat
 ---
 
-{{CSSRef}}
-
 La propiedad de [CSS](/es/docs/Web/CSS) **`background-repeat`** define como se repiten los fondos del documento. Un fondo de imagen puede ser repetido sobre el eje horizontal, el eje vertical, ambos ejes, o no estar repetido.
 
 {{InteractiveExample("CSS Demo: background-repeat")}}

--- a/files/es/web/css/background/index.md
+++ b/files/es/web/css/background/index.md
@@ -3,8 +3,6 @@ title: background
 slug: Web/CSS/background
 ---
 
-{{CSSRef}}
-
 La propiedad `background` es un atajo para definir los valores individuales del fondo en una única regla CSS. Se puede usar `background` para definir los valores de una o de todas las propiedades siguientes: {{ Cssxref("background-attachment") }}, {{ Cssxref("background-color", "color") }}, {{ Cssxref("background-image", "image") }}, {{ Cssxref("background-position", "position") }}, {{ Cssxref("background-repeat", "repeat") }}.
 
 - {{ Cssxref("initial", "Valor inicial") }}: ver propiedades individuales

--- a/files/es/web/css/basic-shape/index.md
+++ b/files/es/web/css/basic-shape/index.md
@@ -3,8 +3,6 @@ title: <basic-shape>
 slug: Web/CSS/basic-shape
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El tipo **`<basic-shape>`** puede ser especificado usando funciones de figura (shape) básicas. Al usar esta sintaxis para definir figuras, la caja de referencia es definida por cada propiedad que usa valores `<basic-shape>`. El sistema de coordenadas para la figura tiene su origen en la esquina superior izquierda de la caja de referencia, con el eje x corriendo hacia la derecha y el eje y, hacia abajo. Todas las longitudes expresadas en porcentajes son resueltas con base en las dimensiones de la caja de referencia.

--- a/files/es/web/css/blend-mode/index.md
+++ b/files/es/web/css/blend-mode/index.md
@@ -3,8 +3,6 @@ title: <blend-mode>
 slug: Web/CSS/blend-mode
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El tipo **`<blend-mode>`** es una coleccion de palabras clave que describen modos de mezcla.

--- a/files/es/web/css/block-size/index.md
+++ b/files/es/web/css/block-size/index.md
@@ -3,7 +3,7 @@ title: block-size
 slug: Web/CSS/block-size
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`block-size`** [CSS](/es/docs/Web/CSS) define el tamaño horizontal o vertical de los elementos en bloque, dependiendo de los modos de escritura. estos corresponden ya sea a la propiedad {{cssxref("width")}} o la propiedad {{cssxref("height")}}, dependiendo de los valores de {{cssxref("writing-mode")}}.
 

--- a/files/es/web/css/border-block-color/index.md
+++ b/files/es/web/css/border-block-color/index.md
@@ -3,7 +3,7 @@ title: border-block-color
 slug: Web/CSS/border-block-color
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-block-color`** define el color del borde de bloque de un elemento, que se asigna al color del borde físico dependiendo de los elementos de modo de escrituro, direccionalidad y la orientación del texto. Esto corresponde a las propiedades {{cssxref("border-top-color")}} y {{cssxref("border-bottom-color")}}, o {{cssxref("border-right-color")}} y {{cssxref("border-left-color")}} dependiendo de los valores definidos para {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-block-end-color/index.md
+++ b/files/es/web/css/border-block-end-color/index.md
@@ -3,7 +3,7 @@ title: border-block-end-color
 slug: Web/CSS/border-block-end-color
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad [CSS](/es/docs/Web/CSS) `border-block-end-color` define el color del borde del final lógico de un elemento, que se mapea a un color de borde físico, dependiendo el modo de escritura, direccionalidad y orientación de texto del elemento. Corresponde a las propiedades {{cssxref("border-top-color")}}, {{cssxref("border-right-color")}}, {{cssxref("border-bottom-color")}}, o {{cssxref("border-left-color")}}, dependiendo de los valores definidos para {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-block-end-style/index.md
+++ b/files/es/web/css/border-block-end-style/index.md
@@ -3,7 +3,7 @@ title: border-block-end-style
 slug: Web/CSS/border-block-end-style
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad [CSS](/es/docs/Web/CSS) **`border-block-end-style`** define el estilo del borde del final lógico del bloque de un elemento, que se mapea a un estilo de borde físico, dependiendo el modo de escritura, direccionalidad y orientación de texto del elemento. Corresponde a las propiedades {{cssxref("border-top-style")}}, {{cssxref("border-right-style")}}, {{cssxref("border-bottom-style")}}, o {{cssxref("border-left-style")}}, dependiendo de los valores definidos para {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-block-end-width/index.md
+++ b/files/es/web/css/border-block-end-width/index.md
@@ -3,7 +3,7 @@ title: border-block-end-width
 slug: Web/CSS/border-block-end-width
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propieda de [CSS](/es/docs/Web/CSS) **`border-block-end-width`** define el ancho del borde final lógico de bloque de un elemento, que se asigna al borde físico que depende del modo de escritura, direccionalidad, y orientación del texto del elemento. Esto corresponde a la propiedad {{cssxref("border-top-width")}}, {{cssxref("border-right-width")}}, {{cssxref("border-bottom-width")}}, o {{cssxref("border-left-width")}} property dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-block-end/index.md
+++ b/files/es/web/css/border-block-end/index.md
@@ -3,7 +3,7 @@ title: border-block-end
 slug: Web/CSS/border-block-end
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad [CSS](/es/docs/Web/CSS) **`border-block-end`** es un atajo para establecer los valores de las propiedades individuales del borde final lógico de un bloque en un solo lugar de la hoja de estilos. `border-block-end` puede ser usada para establecer los valores de una o más de las siguientes propiedades: {{Cssxref("border-block-end-width")}}, {{Cssxref("border-block-end-style")}}, {{Cssxref("border-block-end-color")}}. Se asigna a un borde físico, dependiendo del modo de escritura del elemento, su direccionalidad y orientación de texto. Corresponde a las propiedades {{cssxref("border-top")}}, {{cssxref("border-right")}}, {{cssxref("border-bottom")}}, o {{cssxref("border-left")}}, dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-block-start-color/index.md
+++ b/files/es/web/css/border-block-start-color/index.md
@@ -3,7 +3,7 @@ title: border-block-start-color
 slug: Web/CSS/border-block-start-color
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-block-start-color`** define el color del borde lógico de bloque inicial de un elemento, que se asigna al color de borde físico dependen del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-color")}}, {{cssxref("border-right-color")}}, {{cssxref("border-bottom-color")}}, o {{cssxref("border-left-color")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-block-start-style/index.md
+++ b/files/es/web/css/border-block-start-style/index.md
@@ -3,7 +3,7 @@ title: border-block-start-style
 slug: Web/CSS/border-block-start-style
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-block-start-style`** define el estilo del borde lógico de bloque inicial de un elemento, que se asigna al estilo de borde físicodependen del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-style")}}, {{cssxref("border-right-style")}}, {{cssxref("border-bottom-style")}}, o {{cssxref("border-left-style")}} dependiendo de los valores definidos por{{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-block-start-width/index.md
+++ b/files/es/web/css/border-block-start-width/index.md
@@ -3,7 +3,7 @@ title: border-block-start-width
 slug: Web/CSS/border-block-start-width
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-block-start-width`** define el ancho del borde lógico de bloque inicial de un elemento, que se asigna al estilo de borde físico dependen del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-width")}}, {{cssxref("border-right-width")}}, {{cssxref("border-bottom-width")}}, o {{cssxref("border-left-width")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-block-start/index.md
+++ b/files/es/web/css/border-block-start/index.md
@@ -3,7 +3,7 @@ title: border-block-start
 slug: Web/CSS/border-block-start
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-block-start`** es una [propiedad abreviada](/es/docs/Web/CSS/CSS_cascade/Shorthand_properties) para establecer los valores lógicos individuales del borde de bloque inicial en un solo lugar en la hoja de estilos.
 

--- a/files/es/web/css/border-block-style/index.md
+++ b/files/es/web/css/border-block-style/index.md
@@ -3,7 +3,7 @@ title: border-block-style
 slug: Web/CSS/border-block-style
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-block-style`** [CSS](/es/docs/Web/CSS) property defines the style of the logical block borders of an element, que se asigna al estilo de borde físico dependiendo del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-style")}} y {{cssxref("border-bottom-style")}}, o {{cssxref("border-left-style")}}, y {{cssxref("border-right-style")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-block-width/index.md
+++ b/files/es/web/css/border-block-width/index.md
@@ -3,7 +3,7 @@ title: border-block-width
 slug: Web/CSS/border-block-width
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-block-width`** [CSS](/es/docs/Web/CSS) property defines the width of the logical block borders of an element, que se asigna al estilo de borde físico dependiendo del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-width")}} y {{cssxref("border-bottom-width")}}, o {{cssxref("border-left-width")}}, y {{cssxref("border-right-width")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-block/index.md
+++ b/files/es/web/css/border-block/index.md
@@ -3,7 +3,7 @@ title: border-block
 slug: Web/CSS/border-block
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-block`** es una [propiedad abreviada](/es/docs/Web/CSS/CSS_cascade/Shorthand_properties) para establecer los valores lógicos individuales del borde de bloque en un solo lugar en la hoja de estilos.
 

--- a/files/es/web/css/border-bottom-color/index.md
+++ b/files/es/web/css/border-bottom-color/index.md
@@ -3,8 +3,6 @@ title: border-bottom-color
 slug: Web/CSS/border-bottom-color
 ---
 
-{{CSSRef}}
-
 ### Resumen
 
 La propiedad `border-bottom-color` define el color del borde inferior de un elemento, con la ayuda de un valor de color o con la palabra clave `transparent`.

--- a/files/es/web/css/border-bottom-left-radius/index.md
+++ b/files/es/web/css/border-bottom-left-radius/index.md
@@ -3,8 +3,6 @@ title: border-bottom-left-radius
 slug: Web/CSS/border-bottom-left-radius
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`border-bottom-left-radius`** establece el redondeo de la esquina inferior izquierda del elemento. El redondeo puede ser un círculo o una elipse, o si uno de los valores es `0`, no se redondeará la esquina, dejándola cuadrada.

--- a/files/es/web/css/border-bottom-right-radius/index.md
+++ b/files/es/web/css/border-bottom-right-radius/index.md
@@ -3,8 +3,6 @@ title: border-bottom-right-radius
 slug: Web/CSS/border-bottom-right-radius
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`border-bottom-right-radius`** establece el redondeo de la esquina inferior derecha del elemento. El redondeo puede ser un círculo o una elipse, o si uno de los valores es `0`, no se redondeará la esquina, dejándola cuadrada.

--- a/files/es/web/css/border-bottom-style/index.md
+++ b/files/es/web/css/border-bottom-style/index.md
@@ -3,8 +3,6 @@ title: border-bottom-style
 slug: Web/CSS/border-bottom-style
 ---
 
-{{CSSRef}}
-
 << [Volver](/es/Guía_de_referencia_de_CSS)
 
 ### Resumen

--- a/files/es/web/css/border-bottom-width/index.md
+++ b/files/es/web/css/border-bottom-width/index.md
@@ -3,8 +3,6 @@ title: border-bottom-width
 slug: Web/CSS/border-bottom-width
 ---
 
-{{CSSRef}}
-
 ### Resumen
 
 `border-bottom-width` define el ancho del borde inferior de una caja.

--- a/files/es/web/css/border-bottom/index.md
+++ b/files/es/web/css/border-bottom/index.md
@@ -3,8 +3,6 @@ title: border-bottom
 slug: Web/CSS/border-bottom
 ---
 
-{{CSSRef}}
-
 ### Resumen
 
 La propiedad `border-bottom` permite de definir de una vez todas las propiedades individuales {{ Cssxref("border-bottom-color") }}, {{ Cssxref("border-bottom-style") }}, y {{ Cssxref("border-bottom-width") }}, las cuales describen el color, estilo y ancho del borde inferior de un elementos.

--- a/files/es/web/css/border-collapse/index.md
+++ b/files/es/web/css/border-collapse/index.md
@@ -3,8 +3,6 @@ title: border-collapse
 slug: Web/CSS/border-collapse
 ---
 
-{{CSSRef}}
-
 ### Resumen
 
 La propiedad `border-collapse` se utiliza para fusionar los bordes. Ésto tiene una gran influencia sobre la presentación y el estilo de las celdas de tabla. La representación de los bordes de tabla es dividida en dos categorías en CSS2 - "fusión" y "separación" (collapsed - separated). Esta propiedad especifica que modo de presentación de borde hay que usar.

--- a/files/es/web/css/border-color/index.md
+++ b/files/es/web/css/border-color/index.md
@@ -3,7 +3,7 @@ title: border-color
 slug: Web/CSS/border-color
 ---
 
-{{CSSRef}}{{ PreviousNext("CSS:border", "CSS:border-style") }}
+{{ PreviousNext("CSS:border", "CSS:border-style") }}
 
 ### Resumen
 

--- a/files/es/web/css/border-end-end-radius/index.md
+++ b/files/es/web/css/border-end-end-radius/index.md
@@ -3,7 +3,7 @@ title: border-end-end-radius
 slug: Web/CSS/border-end-end-radius
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-end-end-radius`** define un radio de borde lógico en un elemento, que se asigna a un radio de borde físico que depende de los elementos {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-end-start-radius/index.md
+++ b/files/es/web/css/border-end-start-radius/index.md
@@ -3,7 +3,7 @@ title: border-end-start-radius
 slug: Web/CSS/border-end-start-radius
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-end-start-radius`** define un radio del borde lógico en un elemento, que se asigna a un radio de borde físico que depende de los elementos {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-image-outset/index.md
+++ b/files/es/web/css/border-image-outset/index.md
@@ -3,8 +3,6 @@ title: border-image-outset
 slug: Web/CSS/border-image-outset
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad **`border-image-outset`** describe el monto por el cual se extenderá la imagen de borde más allá del límite de la caja.

--- a/files/es/web/css/border-image-repeat/index.md
+++ b/files/es/web/css/border-image-repeat/index.md
@@ -3,8 +3,6 @@ title: border-image-repeat
 slug: Web/CSS/border-image-repeat
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`border-image-repeat`** define cómo se manejará la parte media de una imagen de borde para que coincida con el tamaño del borde. Tiene sintaxis de un valor, el cual describe el comportamiento de todos los lados, y otra sintaxis de dos valores, que establece diferentes valores para el comportamiento horizontal y vertical.

--- a/files/es/web/css/border-image-slice/index.md
+++ b/files/es/web/css/border-image-slice/index.md
@@ -3,8 +3,6 @@ title: border-image-slice
 slug: Web/CSS/border-image-slice
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`border-image-slice`** divide la imagen especificada por {{cssxref("border-image-source")}} en nueve regiones: las cuatro esquinas, los cuatro bordes y el espacio enmedio. Esto se hace especificando cuatro desplazamientos hacia adentro.

--- a/files/es/web/css/border-image/index.md
+++ b/files/es/web/css/border-image/index.md
@@ -3,8 +3,6 @@ title: border-image
 slug: Web/CSS/border-image
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad de CSS `border-image` permite utilizar una imágen para definir los bordes de los elementos. Esto hace que dibujarlos sea más simple y elimina la necesidad de utilizar muchas cajas en algunos casos.

--- a/files/es/web/css/border-inline-color/index.md
+++ b/files/es/web/css/border-inline-color/index.md
@@ -3,7 +3,7 @@ title: border-inline-color
 slug: Web/CSS/border-inline-color
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-inline-color`** define el color del borde lógico en línea de un elemento, que se asigna al estilo de borde físico dependiendo del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-color")}} y {{cssxref("border-bottom-color")}}, o {{cssxref("border-left-color")}}, y {{cssxref("border-right-color")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-inline-end-color/index.md
+++ b/files/es/web/css/border-inline-end-color/index.md
@@ -3,7 +3,7 @@ title: border-inline-end-color
 slug: Web/CSS/border-inline-end-color
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-inline-end-color`** [CSS](/es/docs/Web/CSS) property defines the color of the logical inline-end border of an element, que se asigna al estilo de borde físico dependiendo del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-color")}} y {{cssxref("border-bottom-color")}}, o {{cssxref("border-left-color")}}, y {{cssxref("border-right-color")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-inline-end-style/index.md
+++ b/files/es/web/css/border-inline-end-style/index.md
@@ -3,7 +3,7 @@ title: border-inline-end-style
 slug: Web/CSS/border-inline-end-style
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-inline-end-style`** [CSS](/es/docs/Web/CSS) property defines the style of the logical inline end border of an element, que se asigna al estilo de borde físico dependiendo del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-style")}} y {{cssxref("border-bottom-style")}}, o {{cssxref("border-left-style")}}, y {{cssxref("border-right-style")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-inline-end-width/index.md
+++ b/files/es/web/css/border-inline-end-width/index.md
@@ -3,7 +3,7 @@ title: border-inline-end-width
 slug: Web/CSS/border-inline-end-width
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-inline-end-width`** [CSS](/es/docs/Web/CSS) property defines the width of the logical inline-end border of an element, que se asigna al estilo de borde físico dependiendo del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-width")}} y {{cssxref("border-bottom-width")}}, o {{cssxref("border-left-width")}}, y {{cssxref("border-right-width")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-inline-end/index.md
+++ b/files/es/web/css/border-inline-end/index.md
@@ -3,7 +3,7 @@ title: border-inline-end
 slug: Web/CSS/border-inline-end
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-inline-end`** es una [propiedad abreviada](/es/docs/Web/CSS/CSS_cascade/Shorthand_properties) para establecer los valores lógicos individuales del borde en línea final en un solo lugar en la hoja de estilos.
 

--- a/files/es/web/css/border-inline-start-color/index.md
+++ b/files/es/web/css/border-inline-start-color/index.md
@@ -3,7 +3,7 @@ title: border-inline-start-color
 slug: Web/CSS/border-inline-start-color
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-inline-start-color`** define el color del borde lógico inicial en línea de un elemento, que se asigna al estilo de borde físico dependiendo del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-color")}} y {{cssxref("border-bottom-color")}}, o {{cssxref("border-left-color")}}, y {{cssxref("border-right-color")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-inline-start-style/index.md
+++ b/files/es/web/css/border-inline-start-style/index.md
@@ -3,7 +3,7 @@ title: border-inline-start-style
 slug: Web/CSS/border-inline-start-style
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-inline-start-style`** define el estilo del borde lógico inicial en línea de un elemento, que se asigna al estilo de borde físico dependiendo del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-style")}} y {{cssxref("border-bottom-style")}}, o {{cssxref("border-left-style")}}, y {{cssxref("border-right-style")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-inline-start-width/index.md
+++ b/files/es/web/css/border-inline-start-width/index.md
@@ -3,7 +3,7 @@ title: border-inline-start-width
 slug: Web/CSS/border-inline-start-width
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-inline-start-width`** define el ancho del borde lógico inicial en línea de un elemento, que se asigna al estilo de borde físico dependiendo del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-width")}} y {{cssxref("border-bottom-width")}}, o {{cssxref("border-left-width")}}, y {{cssxref("border-right-width")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-inline-start/index.md
+++ b/files/es/web/css/border-inline-start/index.md
@@ -3,7 +3,7 @@ title: border-inline-start
 slug: Web/CSS/border-inline-start
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-inline-start`** es una [propiedad abreviada](/es/docs/Web/CSS/CSS_cascade/Shorthand_properties) para establecer los valores de la propiedad inicial del borde individual en línea en un solo lugar en la hoja de estilos.
 

--- a/files/es/web/css/border-inline-style/index.md
+++ b/files/es/web/css/border-inline-style/index.md
@@ -3,7 +3,7 @@ title: border-inline-style
 slug: Web/CSS/border-inline-style
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-inline-style`** define el estilo de los bordes lógicos en línea de un elemento, que se asigna al estilo de borde físico dependiendo del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-style")}} y {{cssxref("border-bottom-style")}}, o {{cssxref("border-left-style")}}, y {{cssxref("border-right-style")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-inline-width/index.md
+++ b/files/es/web/css/border-inline-width/index.md
@@ -3,7 +3,7 @@ title: border-inline-width
 slug: Web/CSS/border-inline-width
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-inline-width`** define al ancho del borde lógico en línea de un elemento, que se asigna al estilo de borde físico dependiendo del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("border-top-width")}} y {{cssxref("border-bottom-width")}}, o {{cssxref("border-left-width")}}, y {{cssxref("border-right-width")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-inline/index.md
+++ b/files/es/web/css/border-inline/index.md
@@ -3,7 +3,7 @@ title: border-inline
 slug: Web/CSS/border-inline
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-inline`** es una [propiedad abreviada](/es/docs/Web/CSS/CSS_cascade/Shorthand_properties) para establecer los valores lógicos individuales del borde de bloque en un solo lugar en la hoja de estilos.
 

--- a/files/es/web/css/border-left-color/index.md
+++ b/files/es/web/css/border-left-color/index.md
@@ -3,8 +3,6 @@ title: border-left-color
 slug: Web/CSS/border-left-color
 ---
 
-{{CSSRef}}
-
 ### Resumen
 
 `border-left-color` pone el color del borde izquierdo de un elemento,con el valor de el color en hexadecimal o con palabras clave, como azul, verde, rojo `transparente`.

--- a/files/es/web/css/border-left/index.md
+++ b/files/es/web/css/border-left/index.md
@@ -3,8 +3,6 @@ title: border-left
 slug: Web/CSS/border-left
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El `borde_izquierdo` es una propiedad rápida para poner el ancho, estilo y color del borde izquierdo de un elemento. Esta propiedad puede ser usada para poner los valores de uno o mas de : {{ Cssxref("border-left-width") }}, {{ Cssxref("border-left-style") }}, {{ Cssxref("border-left-color") }}. Valores omitidos son puestos a su valor inicial.

--- a/files/es/web/css/border-radius/index.md
+++ b/files/es/web/css/border-radius/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 4e508e2f543c0d77c9c04f406ebc8e9db7e965be
 ---
 
-{{CSSRef}}
-
 La propiedad **`border-radius`** [CSS](/es/docs/Web/CSS) redondea las esquinas del borde exterior de un elemento. Puedes establecer un único radio para crear esquinas circulares o dos radios para crear esquinas elípticas.
 
 {{InteractiveExample("CSS Demo: border-radius")}}

--- a/files/es/web/css/border-right/index.md
+++ b/files/es/web/css/border-right/index.md
@@ -3,8 +3,6 @@ title: border-right
 slug: Web/CSS/border-right
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`border-right`** es un a propiedad rápida para dar valores al {{cssxref("border-right-width")}}, {{cssxref("border-right-style")}} y {{cssxref("border-right-color")}}. Estas propiedades establecen un [borde](/es/docs/Web/CSS/border)derecho del elemento.
 
 {{InteractiveExample("CSS Demo: border-right")}}

--- a/files/es/web/css/border-spacing/index.md
+++ b/files/es/web/css/border-spacing/index.md
@@ -3,8 +3,6 @@ title: border-spacing
 slug: Web/CSS/border-spacing
 ---
 
-{{CSSRef}}
-
 ### Resumen
 
 La propiedad de {{ Cssxref("border-spacing", "espaciado de borde") }} especifica la distancia entre los bordes de celdas adyacentes (sólo para el modelo de [separación de borde](/es/docs/Web/CSS/border-collapse)). Es el equivalente al atributo `cellspacing` en HTML.

--- a/files/es/web/css/border-start-end-radius/index.md
+++ b/files/es/web/css/border-start-end-radius/index.md
@@ -3,7 +3,7 @@ title: border-start-end-radius
 slug: Web/CSS/border-start-end-radius
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-start-end-radius`** define al radio del borde lógico de un elemento, que se asigna al radio de borde físico dependiendo del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-start-start-radius/index.md
+++ b/files/es/web/css/border-start-start-radius/index.md
@@ -3,7 +3,7 @@ title: border-start-start-radius
 slug: Web/CSS/border-start-start-radius
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-start-start-radius`** define al radio del borde lógico de un elemento, que se asigna al radio de borde físico dependiendo del modo de escritura, la direccionalidad y la orientación del texto del elemento. Esto corresponde a las propiedades {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/border-style/index.md
+++ b/files/es/web/css/border-style/index.md
@@ -3,8 +3,6 @@ title: border-style
 slug: Web/CSS/border-style
 ---
 
-{{CSSRef}}
-
 La propiedad **`border-style`** [CSS](/es/docs/Web/CSS) es una [shorthand property](/es/docs/Web/CSS/CSS_cascade/Shorthand_properties) (Propiedad abreviada) que establece el estilo de línea para los cuatro lados del borde de un elemento.
 
 {{InteractiveExample("CSS Demo: border-style")}}

--- a/files/es/web/css/border-top-color/index.md
+++ b/files/es/web/css/border-top-color/index.md
@@ -3,8 +3,6 @@ title: border-top-color
 slug: Web/CSS/border-top-color
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`border-top-color`** establece el color superior de un elemento {{cssxref("border")}}. Tenga en cuenta que en la mayoria de los casos las propiedades abreviadas {{cssxref("border-color")}} o {{cssxref("border-top")}} son mas convenientes y preferidas.
 
 ```css

--- a/files/es/web/css/border-top-left-radius/index.md
+++ b/files/es/web/css/border-top-left-radius/index.md
@@ -3,8 +3,6 @@ title: border-top-left-radius
 slug: Web/CSS/border-top-left-radius
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`border-top-left-radius`** establece el redondeo de la esquina superior izquierda del elemento. El redondeo puede ser un círculo o una elipse, o si uno de los valores es `0`, no se redondeará la esquina, dejándola cuadrada.
 
 ![border-radius.png](border-radius.png)

--- a/files/es/web/css/border-top-right-radius/index.md
+++ b/files/es/web/css/border-top-right-radius/index.md
@@ -3,8 +3,6 @@ title: border-top-right-radius
 slug: Web/CSS/border-top-right-radius
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`border-top-right-radius`** establece el redondeo de la esquina superior derecha del elemento. El redondeo puede ser un círculo o una elipse, o si uno de los valores es `0`, no se redondeará la esquina, dejándola cuadrada.

--- a/files/es/web/css/border-top/index.md
+++ b/files/es/web/css/border-top/index.md
@@ -3,8 +3,6 @@ title: border-top
 slug: Web/CSS/border-top
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`border-top`** es una abreviatura que establece los valores de {{Cssxref("border-top-color")}}, {{Cssxref("border-top-style")}}, y {{Cssxref("border-top-width")}}. Estas propiedades las características del borde superior de un elemento.

--- a/files/es/web/css/border-width/index.md
+++ b/files/es/web/css/border-width/index.md
@@ -3,8 +3,6 @@ title: border-width
 slug: Web/CSS/border-width
 ---
 
-{{CSSRef}}
-
 ### Resumen
 
 La propiedad **`border-width`** define el ancho del borde.

--- a/files/es/web/css/border/index.md
+++ b/files/es/web/css/border/index.md
@@ -3,7 +3,7 @@ title: border
 slug: Web/CSS/border
 ---
 
-{{CSSRef}}{{ PreviousNext("Guía de referencia de CSS", "CSS:border-color") }}
+{{ PreviousNext("Guía de referencia de CSS", "CSS:border-color") }}
 
 ### Propiedades Constitutivas
 

--- a/files/es/web/css/bottom/index.md
+++ b/files/es/web/css/bottom/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: e9a39cf29e4d40513b19c79abfe10b6338dde8dd
 ---
 
-{{CSSRef}}
-
 La propiedad **`bottom`** de [CSS](/es/docs/Web/CSS) establece la posición vertical de un [elemento posicionado](/es/docs/Web/CSS/position). No tiene efecto en elementos no posicionados.
 
 {{InteractiveExample("CSS Demo: bottom")}}

--- a/files/es/web/css/box-flex/index.md
+++ b/files/es/web/css/box-flex/index.md
@@ -3,8 +3,6 @@ title: -moz-box-flex
 slug: Web/CSS/box-flex
 ---
 
-{{CSSRef}}
-
 > [!WARNING]
 > Esta propiedad es para controlar parte del modelo de caja XUL. No coincide ni con el antiguo borrador del módulo CSS para el diseño de caja flexibles '`box-flex`' (que se basa en esta propiedad) ni con el comportamiento de '`-webkit-box-flex`' (que se basa en esos borradores).
 

--- a/files/es/web/css/box-ordinal-group/index.md
+++ b/files/es/web/css/box-ordinal-group/index.md
@@ -3,8 +3,6 @@ title: -moz-box-ordinal-group
 slug: Web/CSS/box-ordinal-group
 ---
 
-{{CSSRef}}
-
 > [!WARNING]
 > Esta propiedad pertenece al borrador original del diseño o esquema de la caja CSS flexible, y ha sido reemplazada en borradores posteriores.
 

--- a/files/es/web/css/box-pack/index.md
+++ b/files/es/web/css/box-pack/index.md
@@ -3,8 +3,6 @@ title: -moz-box-pack
 slug: Web/CSS/box-pack
 ---
 
-{{CSSRef}}
-
 > [!WARNING]
 > Esta propiedad es parte del módulo estándar original para el diseño de las cajas CSS Flexible que fue sustituida por un nuevo estándar.
 

--- a/files/es/web/css/box-sizing/index.md
+++ b/files/es/web/css/box-sizing/index.md
@@ -3,8 +3,6 @@ title: box-sizing
 slug: Web/CSS/box-sizing
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`box-sizing`** como el {{glossary("user agent")}} debe calcular el ancho y alto total de un elemento.
 
 {{InteractiveExample("CSS Demo: box-sizing")}}

--- a/files/es/web/css/calc/index.md
+++ b/files/es/web/css/calc/index.md
@@ -3,7 +3,7 @@ title: calc
 slug: Web/CSS/calc
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 ## Sumario
 

--- a/files/es/web/css/caret-color/index.md
+++ b/files/es/web/css/caret-color/index.md
@@ -3,8 +3,6 @@ title: caret-color
 slug: Web/CSS/caret-color
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`caret-color`** especifica el color del cursor de texto, el indicador visible del punto de inserción en un elemento donde el usuario puede introducir texto u otro contenido.
 
 ```css

--- a/files/es/web/css/child_combinator/index.md
+++ b/files/es/web/css/child_combinator/index.md
@@ -3,8 +3,6 @@ title: Selectores de hijo
 slug: Web/CSS/Child_combinator
 ---
 
-{{CSSRef}}
-
 El combinador `>` separa a dos selectores y busca solo a los elementos que coindicen con el segundo selector y que son hijos **directos** del primero. EN contraste, cuando se combinan dos selectores con el [selector de descendiente](/es/docs/Web/CSS/Descendant_combinator), la expresión busca elementos que coinciden con el segundo selector y que tienen algun ancestro que coindice con el primero, sin importar el nivel de separación que tengan dentro del DOM.
 
 ## Sintaxis

--- a/files/es/web/css/class_selectors/index.md
+++ b/files/es/web/css/class_selectors/index.md
@@ -3,8 +3,6 @@ title: Selectores de clase
 slug: Web/CSS/Class_selectors
 ---
 
-{{CSSRef}}
-
 En un documento HTML, los selectores de clase buscan un elemento basado en el contenido de su atributo `class`. El atributo [`class`](/es/docs/Web/HTML/Reference/Global_attributes#class) está definido como una lista de elementos separados por espacio, y uno de esos elementos debe coincidir exactamente con el nombre de clase dado en el selector.
 
 ## Sintaxis

--- a/files/es/web/css/clear/index.md
+++ b/files/es/web/css/clear/index.md
@@ -3,8 +3,6 @@ title: clear
 slug: Web/CSS/clear
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`clear`** especifica si un elemento puede estar al lado de elementos [flotantes](/es/docs/Web/CSS/float) que lo preceden o si debe ser movido (cleared) debajo de ellos. La propiedad `clear` aplica a ambos elementos flotantes y no flotantes.
 
 Cuando es aplicado a bloques no flotantes, mueve el [border edge](/es/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) del elemento hacia abajo hasta que este debajo del [margin edge](/es/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) de todos los floats relevantes. Este movimiento (cuando acontece) causa que [margin collapsing](/es/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing) no ocurra.

--- a/files/es/web/css/clip/index.md
+++ b/files/es/web/css/clip/index.md
@@ -3,7 +3,7 @@ title: clip
 slug: Web/CSS/clip
 ---
 
-{{CSSRef}}{{deprecated_header}}
+{{deprecated_header}}
 
 ## Resumen
 

--- a/files/es/web/css/color/index.md
+++ b/files/es/web/css/color/index.md
@@ -3,8 +3,6 @@ title: color
 slug: Web/CSS/color
 ---
 
-{{CSSRef}}
-
 La propiedad de CSS **`color`** selecciona el [valor de color](/es/docs/Web/CSS/color_value) de primer plano del contenido de elemento de texto y [decoraciones de texto](/es/docs/Web/CSS/text-decoration). Tambien establece el valor {{cssxref("currentcolor")}} que se puede usar como un valor indirecto en otras propiedades, y es el valor predeterminado para otras propiedades de color, como {{cssxref("border-color")}}.
 
 Para obtener una descripción general del uso del color en HTML, consulte [Aplicando color a los elementos HTML mediante CSS](/es/docs/Web/CSS/CSS_colors/Applying_color).

--- a/files/es/web/css/color_value/index.md
+++ b/files/es/web/css/color_value/index.md
@@ -3,8 +3,6 @@ title: <color>
 slug: Web/CSS/color_value
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El tipo de datos [CSS](/es/docs/Web/CSS) **`<color>`** denota un color en el [sRGB color space](http://en.wikipedia.org/wiki/SRGB). Un color puede ser descrito de cualquiera de las siguiente maneras:

--- a/files/es/web/css/column-count/index.md
+++ b/files/es/web/css/column-count/index.md
@@ -3,8 +3,6 @@ title: column-count
 slug: Web/CSS/column-count
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`column-count`** divide el contenido de un elemento en el número de columnas indicado.
 
 {{InteractiveExample("CSS Demo: column-count")}}

--- a/files/es/web/css/column-span/index.md
+++ b/files/es/web/css/column-span/index.md
@@ -3,8 +3,6 @@ title: column-span
 slug: Web/CSS/column-span
 ---
 
-{{CSSRef}}
-
 La propiedad **`column-span`** [CSS](/es/docs/Web/CSS) hace posible que un elemento se extienda sobre todas las columnas cuando su valor se establece a `all`.
 
 {{InteractiveExample("CSS Demo: column-span")}}

--- a/files/es/web/css/content/index.md
+++ b/files/es/web/css/content/index.md
@@ -3,8 +3,6 @@ title: content
 slug: Web/CSS/content
 ---
 
-{{CSSRef}}
-
 << [Volver](/es/Gu%c3%ada_de_referencia_de_CSS)
 
 ### Resumen

--- a/files/es/web/css/css_animations/index.md
+++ b/files/es/web/css/css_animations/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 856b52f634b889084869d2ee0b8bb62c084be04d
 ---
 
-{{CSSRef}}
-
 El módulo **Animaciones CSS** le permite animar los valores de las propiedades CSS, como la posición del fondo y transformaciones, a lo largo del tiempo mediante el uso de fotogramas clave. Cada fotograma clave describe cómo debe renderizarse el elemento animado en un momento dado durante la secuencia de animación. Puede usar las propiedades en el módulo de animaciones para controlar la duración, el número de repeticiones, el inicio retrasado y otros aspectos de una animación.
 
 ### Animaciones en acción

--- a/files/es/web/css/css_animations/using_css_animations/index.md
+++ b/files/es/web/css/css_animations/using_css_animations/index.md
@@ -3,7 +3,7 @@ title: Usando animaciones CSS
 slug: Web/CSS/CSS_animations/Using_CSS_animations
 ---
 
-{{SeeCompatTable}}{{CSSRef}}
+{{SeeCompatTable}}
 
 **Las animaciones CSS3** permiten animar la transición entre un estilo CSS y otro. Las animaciones constan de dos componentes: un estilo que describe la animación CSS y un conjunto de fotogramas que indican su estado inicial y final, así como posibles puntos intermedios en la misma.
 

--- a/files/es/web/css/css_backgrounds_and_borders/border-image_generator/index.md
+++ b/files/es/web/css/css_backgrounds_and_borders/border-image_generator/index.md
@@ -3,8 +3,6 @@ title: Generador Border-image
 slug: Web/CSS/CSS_backgrounds_and_borders/Border-image_generator
 ---
 
-{{CSSRef}}
-
 Esta herramienta permite generar valores para CSS3 {{cssxref("border-image")}}
 
 {{EmbedGHLiveSample("css-examples/tools/border-image-generator/", '100%', 1200)}}

--- a/files/es/web/css/css_backgrounds_and_borders/border-radius_generator/index.md
+++ b/files/es/web/css/css_backgrounds_and_borders/border-radius_generator/index.md
@@ -3,8 +3,6 @@ title: Generador de border-radius
 slug: Web/CSS/CSS_backgrounds_and_borders/Border-radius_generator
 ---
 
-{{CSSRef}}
-
 Esta herramienta puede ser usada para generar efectos de {{cssxref("border-radius")}} de CSS3.
 
 #### Herramienta

--- a/files/es/web/css/css_backgrounds_and_borders/index.md
+++ b/files/es/web/css/css_backgrounds_and_borders/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 856b52f634b889084869d2ee0b8bb62c084be04d
 ---
 
-{{CSSRef}}
-
 El módulo **Fondos y bordes CSS** proporciona propiedades para agregar bordes, esquinas redondeadas y sombras de caja a los elementos.
 
 Puede agregar diferentes tipos de estilos de borde, incluidos bordes hechos de imágenes de cualquier tipo de imagen, desde imágenes rasterizadas hasta degradados CSS. Los bordes pueden ser cuadrados o redondeados, y se puede establecer un radio diferente para cada esquina. Los elementos se pueden redondear tengan o no un borde visible.

--- a/files/es/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
+++ b/files/es/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
@@ -3,8 +3,6 @@ title: Usando múltiples fondos con CSS
 slug: Web/CSS/CSS_backgrounds_and_borders/Using_multiple_backgrounds
 ---
 
-{{CSSRef}}
-
 Con [CSS3](/es/docs/Web/CSS/CSS3), puedes aplicar **múltiple fondos** a los elementos. Estos se presentan uno encima del otro, poniendo el primer fondo definido hasta arriba, y el último, hasta abajo. Sólo el último fondo puede incluir color de fondo.
 
 Especificar fondos múltiples es fácil:

--- a/files/es/web/css/css_box_model/index.md
+++ b/files/es/web/css/css_box_model/index.md
@@ -3,8 +3,6 @@ title: Modelo de Caja de CSS
 slug: Web/CSS/CSS_box_model
 ---
 
-{{CSSRef}}
-
 **El modelo de caja CSS** es un módulo CSS que define cajas rectangulares, incluyendo sus rellenos y márgenes, que son generadas para los elementos y que se disponen de acuerdo al modelo de formato visual.
 
 ## Referencia

--- a/files/es/web/css/css_box_model/introduction_to_the_css_box_model/index.md
+++ b/files/es/web/css/css_box_model/introduction_to_the_css_box_model/index.md
@@ -3,8 +3,6 @@ title: Introducción al modelo de caja básico de CSS
 slug: Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model
 ---
 
-{{CSSRef}}
-
 Al maquetar un documento, el motor de renderizado del navegador representa cada elemento como una caja rectangular, conforme al estándar del **modelo de caja básico de CSS**. CSS determina el tamaño, la posición y las propiedades (color, fondo, tamaño del borde, etc.) de estas cajas.
 
 Cada caja está compuesta de cuatro partes (o _áreas_), definidas por sus respectivos límites: _límite de contenido (content edge)_ , _límite de relleno (padding edge)_ , _límite de borde (border edge)_ y _límite de margen (margin edge)_ .

--- a/files/es/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/es/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -3,8 +3,6 @@ title: Entendiendo el colapso de margen
 slug: Web/CSS/CSS_box_model/Mastering_margin_collapsing
 ---
 
-{{CSSRef}}
-
 Los márgenes [Top](/es/docs/Web/CSS/margin-top) y [bottom](/es/docs/Web/CSS/margin-bottom) de los bloques a veces están combinados (colapsados) en un solo margen cuyo tamaño es el mayor de los márgenes combinados, un comportamiento conocido como **colapso de margen**. Ten en cuenta que los márgenes de [flotantes](/es/docs/Web/CSS/float) y elementos con [posición absoluta](/es/docs/Web/CSS/position) nunca colapsan.
 
 El colapso de margen ocurre en tres casos básicos:

--- a/files/es/web/css/css_cascade/shorthand_properties/index.md
+++ b/files/es/web/css/css_cascade/shorthand_properties/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_cascade/Shorthand_properties
 original_slug: Web/CSS/Shorthand_properties
 ---
 
-{{CSSRef}}
-
 Las **_propiedades abreviadas_** son propiedades CSS que le permiten establecer los valores de varias otras propiedades CSS simultáneamente. Usando una propiedad abreviada, puede escribir hojas de estilo más concisas (y a menudo más legibles), ahorrando tiempo y energía.
 
 La especificación CSS define propiedades abreviadas para agrupar la definición de propiedades comunes que actúan sobre el mismo tema. Por ejemplo, la propiedad CSS {{cssxref("background")}} es una propiedad abreviada que puede definir los valores de {{cssxref("background-color")}}, {{cssxref("background-image") }}, {{cssxref("background-repeat")}} y {{cssxref("background-position")}}. Del mismo modo, las propiedades más comunes relacionadas con la tipografía se pueden definir usando la abreviatura {{cssxref("font")}}, y los diferentes márgenes alrededor de una caja se pueden definir usando la abreviatura {{cssxref("margin")}}.

--- a/files/es/web/css/css_cascade/specificity/index.md
+++ b/files/es/web/css/css_cascade/specificity/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_cascade/Specificity
 original_slug: Web/CSS/Specificity
 ---
 
-{{CSSRef}}
-
 La **especificidad** es la manera mediante la cual los navegadores deciden qué valores de una propiedad CSS son más relevantes para un elemento y, por lo tanto, serán aplicados. La especificidad está basada en las reglas de coincidencia que están compuestas por diferentes tipos de [selectores CSS](/es/docs/Web/CSS/Reference#selectors).
 
 ## ¿Cómo se calcula?

--- a/files/es/web/css/css_cascade/value_processing/index.md
+++ b/files/es/web/css/css_cascade/value_processing/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_cascade/Value_processing
 original_slug: Web/CSS/CSS_cascade/initial_value
 ---
 
-{{CSSRef}}
-
 << [Volver](/es/Gu%c3%ada_de_referencia_de_CSS)
 
 ### Resumen

--- a/files/es/web/css/css_cascading_variables/using_css_custom_properties/index.md
+++ b/files/es/web/css/css_cascading_variables/using_css_custom_properties/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_cascading_variables/Using_CSS_custom_properties
 original_slug: Web/CSS/Using_CSS_custom_properties
 ---
 
-{{cssref}}
-
 En CSS, las **propiedades personalizadas** (también conocidas como **variables**) son entidades definidas por autores de CSS que contienen valores específicos que se pueden volver a utilizar en un documento. Se establecen mediante la notación de propiedades personalizadas (por ejemplo, **`--main-color: black;`**) y se acceden mediante la función {{cssxref("var", "var()")}} (por ejemplo, color: **`var (--main-color);`**).
 
 Sitios web complejos tienen cantidades muy grandes de CSS, a menudo con una gran cantidad de valores repetidos. Por ejemplo, el mismo color se puede utilizar en cientos de lugares diferentes, lo cual requiere buscar y reemplazar globalmente si necesitamos cambiar ese color. Las variables CSS permiten que un valor se almacene en un lugar y luego se haga referencia en varios otros lugares. Un beneficio adicional son los identificadores semánticos. Por ejemplo **`--main-text-color`** es más fácil de entender que **`#00ff00`**, especialmente si este mismo color también se utiliza en otro contexto.

--- a/files/es/web/css/css_colors/color_picker_tool/index.md
+++ b/files/es/web/css/css_colors/color_picker_tool/index.md
@@ -3,8 +3,6 @@ title: Herramienta para seleccionar color
 slug: Web/CSS/CSS_colors/Color_picker_tool
 ---
 
-{{CSSRef}}
-
 Esta herramienta facilita crear, ajustar, y experimentar con colores personalizados para uso web. Además permite facilmente convertir entre varios formatos de color soportados por CSS, incluyendo: HEXA, RGB y HSL. También soporta el control de alpha en los formatos RGB (rgba) y HSL (hsla).
 
 Cada color se presenta en los 3 formatos estándar de CSS mientras se ajusta; además, basada en el color actual, se genera una paleta para HSL y HSV, así como para alpha. El recuadro "eyedropper" se puede cambiar entre los formatos HSL y HSC.

--- a/files/es/web/css/css_colors/index.md
+++ b/files/es/web/css/css_colors/index.md
@@ -3,8 +3,6 @@ title: CSS Colors
 slug: Web/CSS/CSS_colors
 ---
 
-{{CSSRef}}
-
 **Los colores CSS** son un módulo de CSS que trabaja con colores, tipos de colores y transparencias.
 
 ## Referencia

--- a/files/es/web/css/css_conditional_rules/index.md
+++ b/files/es/web/css/css_conditional_rules/index.md
@@ -3,8 +3,6 @@ title: CSS Reglas Condicionales
 slug: Web/CSS/CSS_conditional_rules
 ---
 
-{{CSSRef}}
-
 Las **Reglas Condicionales** (At-rules) es un módulo de CSS que permite definir un conjunto de reglas que solo aplicarán con base en las capacidades del procesador o del documento al cual la hoja de estilos está siendo aplicada.
 
 ## Referencia

--- a/files/es/web/css/css_containment/container_queries/index.md
+++ b/files/es/web/css/css_containment/container_queries/index.md
@@ -3,8 +3,6 @@ title: CSS Container Queries
 slug: Web/CSS/CSS_containment/Container_queries
 ---
 
-{{CSSRef}}
-
 [CSS Containment](/es/docs/Web/CSS/CSS_containment) proporciona una nueva forma para aislar secciones de una página e indicarle al navegador que estas secciones son independientes del resto de la página en términos de estilos y disposición (_layout_).
 
 Si estás creando un [diseño responsivo](/es/docs/Learn_web_development/Core/CSS_layout/Responsive_Design), a menudo usas [_media queries_](/es/docs/Web/CSS/CSS_media_queries) para cambiar la disposición de la página con referencia al {{Glossary("viewport")}}.

--- a/files/es/web/css/css_containment/index.md
+++ b/files/es/web/css/css_containment/index.md
@@ -3,8 +3,6 @@ title: CSS Containment
 slug: Web/CSS/CSS_containment
 ---
 
-{{CSSRef}}
-
 El objetivo de la especificación CSS Containment es mejorar el rendimiento de las páginas web, permitiendo a los desarrolladores aislar un subárbol del resto de la página. Si el navegador sabe si una parte de la página es independiente, se puede optimizar la renderización y el rendimiento mejora. La especificación define una única propiedad CSS {{cssxref("contain")}}. Este documento relata los objetivos básicos de la especificación.
 
 ## Ejemplo básico

--- a/files/es/web/css/css_display/flow_layout/index.md
+++ b/files/es/web/css/css_display/flow_layout/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_display/Flow_layout
 original_slug: Web/CSS/CSS_flow_layout
 ---
 
-{{CSSRef}}
-
 El _Flujo Normal_, o también Flow Layout, es la forma en que los elementos de línea y de bloque son presentados en una página sin que haya cambios en su diseño. El flujo es esencialmente un grupo de elementos que se perciben entre sí e interactúan entre ellos en nuestro diseño. Cuando uno de ellos se encuentra _fuera del flujo_, éste se comporta de manera independiente.
 
 In normal flow, **inline** elements display in the inline direction, that is in the direction words are displayed in a sentence according to the [Writing Mode](/es/docs/Web/CSS/CSS_writing_modes) of the document. **Block** elements display one after the other, as paragraphs do in the Writing Mode of that document. In English therefore, inline elements display one after the other, starting on the left, and block elements start at the top and move down the page.

--- a/files/es/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
+++ b/files/es/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
@@ -3,8 +3,6 @@ title: Aligning Items in a Flex Container
 slug: Web/CSS/CSS_flexible_box_layout/Aligning_items_in_a_flex_container
 ---
 
-{{CSSRef}}
-
 Una de las razones por las que flexbox atrajo rápidamente el interés de los desarrolladores web es que por primera vez en la web se ha conseguido unas posibilidades completas de alineamiento de elementos. Se habilita la alineación vertical, de modo que por fin existe una manera rápida y facil de centrar una caja. A lo largo de esta guía, vamos a desarrollar un exhaustivo recorrido sobre el funcionamiento de las propiedades de alineamiento y justificación en Flexbox.
 
 Para centrar nuestra caja, usamos la propiedad align-items para alinear nuestro artículo en el eje transversal, que en este caso es el eje del bloque que se ejecuta verticalmente. Utilizamos justify-content para alinear el elemento en el eje principal, que en este caso el eje en línea se ejecuta horizontalmente.

--- a/files/es/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/es/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -3,8 +3,6 @@ title: Conceptos Básicos de flexbox
 slug: Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox
 ---
 
-{{CSSRef}}
-
 El Módulo de Caja Flexible, comúnmente llamado flexbox, fue diseñado como un modelo unidimensional de layout, y como un método que pueda ayudar a distribuir el espacio entre los ítems de una interfaz y mejorar las capacidades de alineación. Este artículo hace un repaso de las principales características de flexbox, las que exploraremos con mayor detalle en el resto de estas guías.
 
 Cuando describimos a flexbox como unidimensional destacamos el hecho que flexbox maneja el layout en una sola dimensión a la vez — ya sea como fila o como columna. Esto contrasta con el modelo bidimensional del [Grid Layout de CSS](/es/docs/Web/CSS/CSS_grid_layout), el cual controla columnas y filas a la vez.

--- a/files/es/web/css/css_flexible_box_layout/index.md
+++ b/files/es/web/css/css_flexible_box_layout/index.md
@@ -3,8 +3,6 @@ title: Diseño de caja flexible CSS
 slug: Web/CSS/CSS_flexible_box_layout
 ---
 
-{{CSSRef}}
-
 El diseño **CSS Flexbox** es un módulo de CSS que define un modelo de caja, optimizado para el diseño de interfaces de usuario. En el diseño flex, los nodos hijo se pueden distribuir en dirección vertical u horizontal y se pueden "flexibilizar" sus tamaños, bien sea rellenando el espacio disponible o encogiéndose para evitar salirse del contorno del nodo padre. Se puede manipular fácilmente tanto la alineación horizontal como la vertical, de los nodos hijo. La anidación de estas cajas (horizontal dentro de vertical o vertical dentro de horizontal) se puede usar para construir diseños en dos dimensiones.
 
 ## Ejemplo Básico

--- a/files/es/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
+++ b/files/es/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
@@ -3,8 +3,6 @@ title: Casos de uso típicos de Flexbox
 slug: Web/CSS/CSS_flexible_box_layout/Typical_use_cases_of_flexbox
 ---
 
-{{CSSRef}}
-
 En esta guía, analizaremos algunos de los casos de uso comunes de flexbox, en aquellos lugares donde tiene más sentido que otro método de diseño.
 
 ## ¿Por qué elegir flexbox?

--- a/files/es/web/css/css_fonts/index.md
+++ b/files/es/web/css/css_fonts/index.md
@@ -3,8 +3,6 @@ title: CSS Fonts
 slug: Web/CSS/CSS_fonts
 ---
 
-{{CSSRef}}
-
 **CSS Fonts** es el modulo CSS que define todo lo relacionado con los recursos tipográficos, sus propiedades y como son cargados. Permite definir el estilo de una fuente, su familia tipográfica, tamaño o peso, y las variantes que puede tener la fuente. También permite definir la altura de una línea.
 
 ## Referencia

--- a/files/es/web/css/css_grid_layout/box_alignment_in_grid_layout/index.md
+++ b/files/es/web/css/css_grid_layout/box_alignment_in_grid_layout/index.md
@@ -3,8 +3,6 @@ title: Box alignment in CSS Grid Layout
 slug: Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout
 ---
 
-{{CSSRef}}
-
 Si estás familiarizado con [flexbox](/es/docs/Web/CSS/CSS_flexible_box_layout) Entonces ya habrás encontrado la forma en que los items flexibles pueden ser alineados correctamente dentro de un contendor flex. Estas propiedades de alineación que encontramos por primera vez en la especificación de flexbox se han trasladado a una nueva especificación llamada [Box Alignment Level 3](https://drafts.csswg.org/css-align/). Esta especificación tiene detalles de cómo debería funcionar la alineación en todos los diferentes métodos de diseño.
 
 Cada método de diseño que implemente Box Alignment tendrá algunas diferencias debido a que cada método tiene características y restricciones diferentes (y acciones heredadas), por lo que es imposible hacer la alineación exactamente de la misma forma en todos los ámbitos. La especificación Box Alignment tiene detalles para cada método, sin embargo, te decepcionaría si intentaras alinear en muchos métodos en este momento, pues el soporte aún no está disponible para todos los navegadores. Donde sí tenemos soporte de navegador para las propiedades de alineación y distribución de espacio de la especificación Box Alignment es en grid layout.

--- a/files/es/web/css/css_images/replaced_element_properties/index.md
+++ b/files/es/web/css/css_images/replaced_element_properties/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_images/Replaced_element_properties
 original_slug: Web/CSS/Replaced_element
 ---
 
-{{CSSRef}}
-
 ## Summary
 
 Dentro de CSS tenemos los **elementos de reemplazo**, cuya representación esta fuera del ámbito de propio CSS. Son un tipo de objeto externo, por tanto su representación es independiente de CSS. Algunos objetos que normalmente funcionan como objetos de reemplazo son {{HTMLElement("img")}}, {{HTMLElement("object")}}, {{HTMLElement("video")}} o elementos de formulario como {{HTMLElement("textarea")}}, {{HTMLElement("input")}}. Algunos elementos como {{HTMLElement("audio")}} or {{HTMLElement("canvas")}} ejercen como elementos de reemplazo solo en casos especificos. Los objetos insertados a través de las propiedades CSS {{cssxref("content")}} son _objetos de reemplazo anonimos._.

--- a/files/es/web/css/css_images/using_css_gradients/index.md
+++ b/files/es/web/css/css_images/using_css_gradients/index.md
@@ -3,8 +3,6 @@ title: Usando degradados con CSS
 slug: Web/CSS/CSS_images/Using_CSS_gradients
 ---
 
-{{CSSRef}}
-
 Los **degradados en CSS** están representados por el tipo de dato {{cssxref("&lt;gradient&gt;")}}, un tipo especial de {{cssxref("&lt;image&gt;")}} hecho de una transición progresiva entre dos o más colores. Puede elegir entre tres tipos de degradados: lineal (creado con la función {{cssxref("gradient/linear-gradient", "linear-gradient()")}}), radial (creado con la función {{cssxref("gradient/radial-gradient", "radial-gradient()")}}) y cónica (creada con la función {{cssxref("gradient/conic-gradient", "conic-gradient()")}}). También puede crear degradados repetidos con {{cssxref("gradient/repeating-linear-gradient", "repeating-linear-gradient()")}}, {{cssxref("gradient/repeating-radial-gradient", " repeating-radial-gradient()")}}, y {{cssxref("gradient/repeating-conic-gradient", "repeating-conic-gradient()")}}.
 
 Los degradados se pueden usar en cualquier lugar donde usaría `<image>`, como en los fondos. Debido a que los degradados se generan dinámicamente, pueden anular la necesidad de los archivos de imagen de trama que tradicionalmente se usaban para lograr efectos similares. Además, debido a que los degradados son generados por el navegador, se ven mejor que las imágenes rasterizadas cuando se acercan y se pueden cambiar de tamaño sobre la marcha.

--- a/files/es/web/css/css_logical_properties_and_values/basic_concepts_of_logical_properties_and_values/index.md
+++ b/files/es/web/css/css_logical_properties_and_values/basic_concepts_of_logical_properties_and_values/index.md
@@ -3,8 +3,6 @@ title: Conceptos básicos de las Propiedades y Valores Lógicos
 slug: Web/CSS/CSS_logical_properties_and_values/Basic_concepts_of_logical_properties_and_values
 ---
 
-{{CSSRef}}
-
 La Especificación de Propiedades y Valores Lógicos introduce asignaciones relativas al flujo para muchas de las propiedades y valores en CSS. Este artículo introduce la especificación y explica las propiedades y valores relativos al flujo.
 
 ## ¿Por qué necesitamos propiedades lógicas?

--- a/files/es/web/css/css_logical_properties_and_values/floating_and_positioning/index.md
+++ b/files/es/web/css/css_logical_properties_and_values/floating_and_positioning/index.md
@@ -3,8 +3,6 @@ title: Propiedades lógicas para flotantes y posicionamiento
 slug: Web/CSS/CSS_logical_properties_and_values/Floating_and_positioning
 ---
 
-{{CSSRef}}
-
 La [especificación de Propiedades y Valores Lógicos](https://drafts.csswg.org/css-logical/) contiene una asignación para los valores físicos {{cssxref("float")}} y {{cssxref("clear")}}, y también para las propiedades de posicionamiento usadas con [positioned layout](/es/docs/Web/CSS/CSS_positioned_layout). Esta guía nos permite saber cómo utilizar estas propiedades.
 
 ## Asignando propiedades y valores

--- a/files/es/web/css/css_logical_properties_and_values/index.md
+++ b/files/es/web/css/css_logical_properties_and_values/index.md
@@ -3,8 +3,6 @@ title: Propiedades y Valores Lógicos de CSS
 slug: Web/CSS/CSS_logical_properties_and_values
 ---
 
-{{CSSRef}}
-
 **CSS Logical Properties** (las propiedades lógicas en CSS) son un módulo de [CSS](/es/docs/Web/CSS) que introduce propiedades y valores lógicos, proporcionando la capacidad de controlar el diseño de forma lógica en vez de la asignación de dimensiones físicas de dirección y dimensión.
 
 Este módulo también define propiedades y valores lógicos para propiedades previamente definidas en CSS 2.1. Las propiedades lógicas definen una equivalencia a sus propiedades físicas correspondientes.

--- a/files/es/web/css/css_logical_properties_and_values/margins_borders_padding/index.md
+++ b/files/es/web/css/css_logical_properties_and_values/margins_borders_padding/index.md
@@ -3,8 +3,6 @@ title: Propiedades lógicas para márgenes, bordes y rellenos
 slug: Web/CSS/CSS_logical_properties_and_values/Margins_borders_padding
 ---
 
-{{CSSRef}}
-
 La [especificación de Propiedades y Valores Lógicos](https://drafts.csswg.org/css-logical/) define asignaciones relativas al flujo para las diversas propiedades de margen, borde, relleno y sus abreviaturas. En esta guía echamos un vistazo a estos.
 
 Si ha visto la página principal de [Propiedades y Valores Lógicos de CSS](/es/docs/Web/CSS/CSS_logical_properties_and_values), verá que hay una gran cantidad de propiedades en la lista. Esto se debe principalmente al hecho de que hay cuatro valores a largo plazo para cada margen, borde y lado de relleno, más todos los valores abreviados.

--- a/files/es/web/css/css_logical_properties_and_values/sizing/index.md
+++ b/files/es/web/css/css_logical_properties_and_values/sizing/index.md
@@ -3,8 +3,6 @@ title: Dimensionamiento para propiedades lógicas
 slug: Web/CSS/CSS_logical_properties_and_values/Sizing
 ---
 
-{{CSSRef}}
-
 En esta guía explicaremos las asignaciones relativas al flujo relativo entre las propiedades de dimensionamiento físico y lógico usados para dimensionar elementos en nuestras páginas.
 
 Cuando especificamos el tamaño de un ítem, las [Propiedades y Valores Lógicos](https://drafts.csswg.org/css-logical/) te dan la habilidad de indicar el dimensionamiento en relación al flujo relativo del texto (en línea y bloque) más bien que dimensionamiento físico con relación a las dimensiones físicas: horizontal y vertical (por ejemplo, left y right). Si bien estas asignaciones de flujo relativo pueden convertirse en el valor predeterminado para muchos de nosotros, en un diseño puede usar el tamaño físico y el tamaño lógico. Es posible que desee que algunas características se relacionen siempre con las dimensiones físicas, independientemente del modo de escritura.

--- a/files/es/web/css/css_media_queries/index.md
+++ b/files/es/web/css/css_media_queries/index.md
@@ -3,8 +3,6 @@ title: Media queries
 slug: Web/CSS/CSS_media_queries
 ---
 
-{{CSSRef}}
-
 Las **consultas de medios** le permiten adaptar su sitio o aplicación dependiendo de la presencia o el valor de varias características y parámetros del dispositivo.
 
 Son un componente clave del [responsive design](/es/docs/Learn_web_development/Core/CSS_layout/Responsive_Design). Por ejemplo, una consulta de medios puede reducir el tamaño de la fuente en dispositivos pequeños, aumentar el relleno entre párrafos cuando se ve una página en modo vertical, o aumentar el tamaño de los botones en las pantallas táctiles.

--- a/files/es/web/css/css_media_queries/using_media_queries/index.md
+++ b/files/es/web/css/css_media_queries/using_media_queries/index.md
@@ -3,8 +3,6 @@ title: Uso de media queries
 slug: Web/CSS/CSS_media_queries/Using_media_queries
 ---
 
-{{CSSRef}}
-
 Las **_Media queries_** le permiten aplicar estilos CSS según el tipo general de un dispositivo (como impresión o pantalla) u otras características como la resolución de la pantalla o el ancho del _{{glossary("viewport")}}_ del navegador.
 Las _media queries_ se utilizan para lo siguiente:
 

--- a/files/es/web/css/css_motion_path/index.md
+++ b/files/es/web/css/css_motion_path/index.md
@@ -3,7 +3,7 @@ title: CSS Motion Path
 slug: Web/CSS/CSS_motion_path
 ---
 
-{{CSSRef}}{{seecompattable}}
+{{seecompattable}}
 
 **Motion Path** es un módulo CSS que permite animar cualquier objeto gráfico a lo largo de una ruta personalizada.
 

--- a/files/es/web/css/css_multicol_layout/index.md
+++ b/files/es/web/css/css_multicol_layout/index.md
@@ -3,8 +3,6 @@ title: Columnas CSS
 slug: Web/CSS/CSS_multicol_layout
 ---
 
-{{CSSRef}}
-
 **Columnas CSS** es un módulo de CSS que define un diseño multicolumna, permitiendo indicar cómo debe fluir el contenido a través de las columnas y cómo manejar reglas y separaciones.
 
 ## Referencia

--- a/files/es/web/css/css_multicol_layout/using_multicol_layouts/index.md
+++ b/files/es/web/css/css_multicol_layout/using_multicol_layouts/index.md
@@ -3,8 +3,6 @@ title: Columnas con CSS-3
 slug: Web/CSS/CSS_multicol_layout/Using_multicol_layouts
 ---
 
-{{CSSRef}}
-
 ### Introducción
 
 Cuando leemos un texto, las líneas muy largas resultan incómodas. Si son demasiado largas, al cambiar de línea nuestros ojos pueden perder la pista de la línea en la que estabas (al ir de un extremo al otro de la página). Por ello, pensando en los usuarios con monitores grandes, los autores deben limitar la anchura del texto dividiéndolo en columnas, más o menos, como hacen los periódicos. Por desgracia esto no es posible con HTML y CSS-2, a no ser que fuerces la ruptura de las columnas en puntos fijos, limites en gran medida el código a utilizar, o uses scripts complejos.

--- a/files/es/web/css/css_positioned_layout/index.md
+++ b/files/es/web/css/css_positioned_layout/index.md
@@ -3,8 +3,6 @@ title: Posicionamiento CSS
 slug: Web/CSS/CSS_positioned_layout
 ---
 
-{{CSSRef}}
-
 **Posicionamiento CSS** es un módulo de CSS que define cómo posicionar elementos absoluta y relativamente en la página.
 
 ## Referencia

--- a/files/es/web/css/css_positioned_layout/stacking_context/index.md
+++ b/files/es/web/css/css_positioned_layout/stacking_context/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_positioned_layout/Stacking_context
 original_slug: Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context
 ---
 
-{{CSSRef}}
-
 « [CSS](/es/docs/Web/CSS) « [ENTENDIENDO LA PROPIEDAD CSS Z-INDEX](/es/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index)
 
 El contexto de apilamiento es la conceptualización tridimensional de los elementos HTML a lo largo de un eje-Z imaginario relativo al usuario que se asume está de cara al viewport o página web. Los elementos HTML ocupan este espacio por orden de prioridad basado en sus atributos.

--- a/files/es/web/css/css_positioned_layout/stacking_context/stacking_context_example_1/index.md
+++ b/files/es/web/css/css_positioned_layout/stacking_context/stacking_context_example_1/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_positioned_layout/Stacking_context/Stacking_context_example_1
 original_slug: Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context_example_1
 ---
 
-{{CSSRef}}
-
 « [CSS](/es/docs/Web/CSS) « [ENTENDIENDO LA PROPIEDAD CSS Z-INDEX](/es/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index)
 
 Empecemos con un ejemplo básico. En el contexto de apilamiento raíz tenemos dos DIVs (DIV #1 and DIV #3), ambos con posición relativa, pero sin propiedad z-index. Dentro del DIV #1 se encuentra el DIV #2 de posición absoluta, mientras que en el DIV #3 se encuentra el DIV #4 con posición absoluta, ambos sin propiedad z-index.

--- a/files/es/web/css/css_positioned_layout/stacking_context/stacking_context_example_2/index.md
+++ b/files/es/web/css/css_positioned_layout/stacking_context/stacking_context_example_2/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_positioned_layout/Stacking_context/Stacking_context_example_2
 original_slug: Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context_example_2
 ---
 
-{{CSSRef}}
-
 « [CSS](/es/docs/Web/CSS) « [ENTENDIENDO LA PROPIEDAD CSS Z-INDEX](/es/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index)
 
 Este es un ejemplo muy simple, pero es la clave para entender el concepto de _contexto de apilamiento._ Tenemos los mismos 4 DIVs del ejemplo previo, pero ahora las propiedades z-index son asignadas en ambos niveles de la jerarquía.

--- a/files/es/web/css/css_positioned_layout/stacking_context/stacking_context_example_3/index.md
+++ b/files/es/web/css/css_positioned_layout/stacking_context/stacking_context_example_3/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_positioned_layout/Stacking_context/Stacking_context_example_3
 original_slug: Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context_example_3
 ---
 
-{{CSSRef}}
-
 « [CSS](/es/docs/Web/CSS) « [Understanding CSS z-index](/es/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index)
 
 Este último ejemplo muestra los problemas que surgen cuando se combinan varios elementos posicionados en una jerarquía HTML multi nivel y cuando los valores z-index son asignados usando selectores de clase.

--- a/files/es/web/css/css_positioned_layout/stacking_floating_elements/index.md
+++ b/files/es/web/css/css_positioned_layout/stacking_floating_elements/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_positioned_layout/Stacking_floating_elements
 original_slug: Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_floating_elements
 ---
 
-{{cssref}}
-
 ### Apilamiento y float
 
 Para los bloques flotantes el orden de apilamiento es un poco diferente. Los bloques flotantes son colocados entre bloques no posicionados y bloques posicionados:

--- a/files/es/web/css/css_positioned_layout/stacking_without_z-index/index.md
+++ b/files/es/web/css/css_positioned_layout/stacking_without_z-index/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_positioned_layout/Stacking_without_z-index
 original_slug: Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_without_z-index
 ---
 
-{{CSSRef}}
-
 « [CSS](/es/docs/Web/CSS) « [ENTENDIENDO LA PROPIEDAD CSS Z-INDEX](/es/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index)
 
 Cuando ningún elemento tiene z-index, los elementos son apilados en este orden (de abajo hacia arriba):

--- a/files/es/web/css/css_positioned_layout/understanding_z-index/index.md
+++ b/files/es/web/css/css_positioned_layout/understanding_z-index/index.md
@@ -3,8 +3,6 @@ title: Entendiendo la propiedad CSS z-index
 slug: Web/CSS/CSS_positioned_layout/Understanding_z-index
 ---
 
-{{CSSRef}}
-
 Usualmente se puede considerar que las páginas HTML tienen dos dimensiones, porque el texto, las imágenes y otros elementos son organizados en la página sin superponerse. Hay un solo flujo de renderizado, y todos los elementos son concientes del espacio ocupado por otros. El atributo {{cssxref("z-index")}} te permite ajustar el orden de las capas de los objetos cuando el contenido está siendo renderizado.
 
 > En CSS 2.1, cada caja tiene una posición en tres dimensiones. Adicionalmente a sus posiciones horizontales y verticales, las cajas caen a lo largo de un "eje-z" y son formadas una encima de la otra. Las posiciones eje-Z son particularmente relevantes cuando las cajas se superponen visualmente.

--- a/files/es/web/css/css_positioned_layout/using_z-index/index.md
+++ b/files/es/web/css/css_positioned_layout/using_z-index/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_positioned_layout/Using_z-index
 original_slug: Web/CSS/CSS_positioned_layout/Understanding_z-index/Using_z-index
 ---
 
-{{CSSRef}}
-
 « [CSS](/es/docs/Web/CSS) « [ENTENDIENDO LA PROPIEDAD CSS Z-INDEX](/es/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index)
 
 ### Agregando {{ cssxref("z-index") }}

--- a/files/es/web/css/css_selectors/index.md
+++ b/files/es/web/css/css_selectors/index.md
@@ -3,8 +3,6 @@ title: Selectores CSS
 slug: Web/CSS/CSS_selectors
 ---
 
-{{CSSRef}}
-
 Los **selectores** definen sobre qué elementos se aplicará un conjunto de reglas CSS.
 
 ## Selectores básicos

--- a/files/es/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.md
+++ b/files/es/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.md
@@ -3,7 +3,7 @@ title: Usando la pseudo-clase :target en selectores
 slug: Web/CSS/CSS_selectors/Using_the_:target_pseudo-class_in_selectors
 ---
 
-When a URL points at a specific piece of a document, it can be difficult to ascertain. Find out how you can use some simple CSS to draw attention to the target of a URL and improve the user's experience. {{CSSRef}}
+When a URL points at a specific piece of a document, it can be difficult to ascertain. Find out how you can use some simple CSS to draw attention to the target of a URL and improve the user's experience.
 
 Como ayuda para identificar el destino de un enlace que apunta a una parte específica de un documento, los [Selectores CSS3](https://www.w3.org/TR/css3-selectors/#target-pseudo) incluyen la [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) {{ Cssxref(":target") }}.
 

--- a/files/es/web/css/css_shadow_parts/index.md
+++ b/files/es/web/css/css_shadow_parts/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 835d6632d59993861a0458510402787f8a2c3cb3
 ---
 
-{{CSSRef}}
-
 El módulo **shadow parts de CSS** define el pseudoelemento {{CSSXref("::part", "::part()")}} que se puede establecer en un [shadow host](/es/docs/Glossary/Shadow_tree). Al usar este pseudoelemento, puedes habilitar shadow hosts para exponer el elemento seleccionado en el shadow tree al exterior de la página para poder estilarlo.
 
 Por defecto, los elementos en un shadow tree solo se pueden estilar dentro de sus respectivos shadow roots. El módulo shadow parts de CSS habilita la inclusión de un atributo [`part`](/es/docs/Web/HTML/Reference/Global_attributes#part) en los descendientes de {{HTMLElement("template")}} que componen el elemento personalizado, exponiendo el nodo shadow tree para estilarlo usando el pseudoelemento `::part()`.

--- a/files/es/web/css/css_syntax/at-rule/index.md
+++ b/files/es/web/css/css_syntax/at-rule/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_syntax/At-rule
 original_slug: Web/CSS/At-rule
 ---
 
-{{cssref}}
-
 Una **regla-at** es una [declaración CSS](/es/docs/Web/CSS/CSS_syntax/Syntax#css_statements) que comienza con el símbolo arroba, '@' (U+0040 COMMERCIAL AT), seguido por un identificador, e incluye todo el contenido hasta el siguiente punto y coma, ';' (U+003B SEMICOLON), o el siguiente [bloque CSS](/es/docs/Web/CSS/CSS_syntax/Syntax#css_declarations_blocks), lo que sea primero.
 
 Hay varias reglas-at, designadas por sus identificadores, cada una con sintaxis distinta:

--- a/files/es/web/css/css_syntax/comments/index.md
+++ b/files/es/web/css/css_syntax/comments/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_syntax/Comments
 original_slug: Web/CSS/Comments
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 Los comentarios son usados para añadir notas explicatorias o prevenir que el navegador interprete partes de la hoja de estilos.

--- a/files/es/web/css/css_syntax/syntax/index.md
+++ b/files/es/web/css/css_syntax/syntax/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_syntax/Syntax
 original_slug: Web/CSS/Syntax
 ---
 
-{{cssref}}
-
 La meta básica del lenguaje Cascading Stylesheet (CSS) es permitir al motor del navegador pintar elementos de la página con características específicas, como colores, posición o decoración. La sintaxis CSS refleja estas metas y estos son los bloques básicos de construcción.
 
 - La **propiedad** que es un identificador, un _nombre_ leíble por humanos, que define qué característica es considerada.

--- a/files/es/web/css/css_text/index.md
+++ b/files/es/web/css/css_text/index.md
@@ -3,8 +3,6 @@ title: Texto CSS
 slug: Web/CSS/CSS_text
 ---
 
-{{CSSRef}}
-
 **Texto CSS** es el módulo de CSS que define cómo realizar la manipulación de elementos de texto como los saltos de línea, la justificación, la alineación, la gestión de espacios en blanco y las transformaciones de texto.
 
 ## Referencia

--- a/files/es/web/css/css_transforms/index.md
+++ b/files/es/web/css/css_transforms/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: e1b6d7d2d02a07f7e86268c81678713fad4d9a5d
 ---
 
-{{CSSRef}}
-
 El módulo **Transformaciones CSS** define cómo los elementos diseñados con CSS se pueden transformar en un espacio bidimensional o tridimensional.
 
 ## Referencia

--- a/files/es/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/es/web/css/css_transforms/using_css_transforms/index.md
@@ -3,8 +3,6 @@ title: Uso de CSS transforms
 slug: Web/CSS/CSS_transforms/Using_CSS_transforms
 ---
 
-{{CSSRef}}
-
 Al modificar las coordenadas del espacio, las transformaciones CSS permiten cambiar la posición del contenido afectado sin interrumpir el flujo normal. Se implementan haciendo uso de un conjunto de propiedades CSS que permiten aplicar transformaciones lineales a elementos HTML. Estas transformaciones incluyen rotar, torcer, escalar y desplazar en plano o en un espacio 3D.
 
 ## Propiedades de las transformaciones CSS

--- a/files/es/web/css/css_transitions/index.md
+++ b/files/es/web/css/css_transitions/index.md
@@ -3,7 +3,7 @@ title: CSS Transitions
 slug: Web/CSS/CSS_transitions
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 **Transiciones CSS** es un módulo de CSS que define cómo crear transiciones suaves entre diferentes valores de las propiedades CSS. Permite tanto crearlas como definir su evolución usando funciones relacionadas con el tiempo.
 

--- a/files/es/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/es/web/css/css_transitions/using_css_transitions/index.md
@@ -3,7 +3,7 @@ title: Transiciones de CSS
 slug: Web/CSS/CSS_transitions/Using_CSS_transitions
 ---
 
-{{CSSRef}}{{ SeeCompatTable() }}
+{{ SeeCompatTable() }}
 
 Las transiciones CSS, parte del borrador de la especificación CSS3, proporcionan una forma de animar los cambios de las propiedades CSS, en lugar de que los cambios surtan efecto de manera instantánea. Por ejemplo, si cambias el color de un elemento de blanco a negro, normalmente el cambio es instantáneo. Al habilitar las transiciones CSS, el cambio sucede en un intervalo de tiempo que puedes especificar, siguiendo una curva de aceleración que puedes personalizar.
 

--- a/files/es/web/css/css_values_and_units/css_data_types/index.md
+++ b/files/es/web/css/css_values_and_units/css_data_types/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_Values_and_Units/CSS_data_types
 original_slug: Web/CSS/CSS_Types
 ---
 
-{{CssRef}}
-
 Los **tipos de datos básicos de CSS** definen los valores típicos (incluidas las palabras clave y las unidades) aceptados por las propiedades y funciones de CSS. Son un tipo especial de [valor de componente](https://www.w3.org/TR/css3-values/#component-types).
 
 En sintaxis formal, los tipos de datos se denotan con una palabra clave colocada entre los signos de desigualdad "<" y ">".

--- a/files/es/web/css/css_values_and_units/value_definition_syntax/index.md
+++ b/files/es/web/css/css_values_and_units/value_definition_syntax/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/CSS_Values_and_Units/Value_definition_syntax
 original_slug: Web/CSS/Value_definition_syntax
 ---
 
-{{CSSRef}}
-
 **La sintaxis de definición de valores CSS**, una gramática formal, se utiliza para definir el conjunto de valores válidos para una propiedad o función CSS. Además de esta sintaxis, el conjunto de valores válidos puede restringirse aún más mediante restricciones semánticas (por ejemplo, para que un número sea estrictamente positivo).
 
 La sintaxis de definición describe qué valores están permitidos y las interacciones entre ellos. Un componente puede ser una _palabra clave_, algunos caracteres _literales_, ó un valor de tipo de dato de CSS o propiedad CSS.

--- a/files/es/web/css/css_writing_modes/index.md
+++ b/files/es/web/css/css_writing_modes/index.md
@@ -3,8 +3,6 @@ title: CSS Writing Modes
 slug: Web/CSS/CSS_writing_modes
 ---
 
-{{CSSRef}}
-
 **CSS Writing Modes** es un modulo CSS que define varios modos internacionales de escritura, como izquierda-derecha (e.g. usado por Latin y textos Indic), de derecha-zquierda (e.g. usado por textos Hebreos o Árabes), bidireccional (usado cuando se mezcla izquierda-derecha y derecha-izquierda) y vertical (e.g. usado por algunos textos Asiaticos).
 
 ## Referencia

--- a/files/es/web/css/display/index.md
+++ b/files/es/web/css/display/index.md
@@ -3,8 +3,6 @@ title: display
 slug: Web/CSS/display
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`display`** especifica si un elemento es tratado como [block or inline element](/es/docs/Web/CSS/CSS_display/Flow_layout) y el diseño usado por sus hijos, como [flow layout](/es/docs/Web/CSS/CSS_display/Flow_layout)(Diseño de Flujo), [grid](/es/docs/Web/CSS/CSS_grid_layout)(Cuadricula) o [flex](/es/docs/Web/CSS/CSS_flexible_box_layout)(Flexible).
 
 Formalmente la propiedad `display` establece los tipos de visualización interna y externa de un elemento. La tipo externa establece la participacion de un elemento en [flow layout](/es/docs/Web/CSS/CSS_display/Flow_layout); la tipo interna establece el layout(Diseño) de los hijos. Algunos valores de `display` estan totalmente definidos con sus especificaciones propias; por ejemplo el detalle de que pasa cuando `display: flex` es declarado y definido en la especificacion de Modelo Flexible de Caja(Flexible Box Model specification) de CSS. **Vea** la siguientes tablas para mas especificaciones individuales.

--- a/files/es/web/css/env/index.md
+++ b/files/es/web/css/env/index.md
@@ -3,8 +3,6 @@ title: env()
 slug: Web/CSS/env
 ---
 
-{{CSSRef}}
-
 La función [CSS](/es/docs/Web/CSS) **`env()`** puede ser utilizada para insertar el valor de una variable de entorno, que sea global para un documento en particular, al contrario de una [propiedad personalizada](/es/docs/Web/CSS/--_). Entonces, la funcion env() puede ser utilizada para remplazar el valor en ubicaciones arbitrarias, de la misma manera que la función [var()](/es/docs/Web/CSS/var).
 
 La función env() puede ser utilizada en el lugar de cualquier parte de un valor en cualquier propiedad de cualquier elemento, o de cualquier parte de un valor en cualquier descriptor de cualquier regla @, y en varios otros lugares donde los valores CSS están permitidos.

--- a/files/es/web/css/filter-function/blur/index.md
+++ b/files/es/web/css/filter-function/blur/index.md
@@ -3,8 +3,6 @@ title: blur()
 slug: Web/CSS/filter-function/blur
 ---
 
-{{cssref}}
-
 La función CSS **`blur()`** aplica un [desenfoque Gaussiano](https://en.wikipedia.org/wiki/Gaussian_blur) a la imagen de entrada. El resultado es un {{cssxref("&lt;filter-function&gt;")}}.
 
 {{InteractiveExample("CSS Demo: blur()")}}

--- a/files/es/web/css/filter-function/brightness/index.md
+++ b/files/es/web/css/filter-function/brightness/index.md
@@ -3,8 +3,6 @@ title: brightness()
 slug: Web/CSS/filter-function/brightness
 ---
 
-{{cssref}}
-
 La función **`brightness()`** [CSS](/es/docs/Web/CSS) aplica un multiplicador linear a la imagen, haciendo que su apariencia sea más brallante u oscura. Su resultado es un {{cssxref("&lt;filter-function&gt;")}}.
 
 {{InteractiveExample("CSS Demo: brightness()")}}

--- a/files/es/web/css/filter-function/index.md
+++ b/files/es/web/css/filter-function/index.md
@@ -3,8 +3,6 @@ title: <filter-function>
 slug: Web/CSS/filter-function
 ---
 
-{{cssref}}
-
 El [tipo de datos](/es/docs/Web/CSS/CSS_Values_and_Units/CSS_data_types) [CSS](/es/docs/Web/CSS) **`<filter-function>`** representa un efecto gráfico que puede cambiar la apariencia de una imagen de entrada. Se usa en las propiedades {{cssxref("filter")}} y {{cssxref("backdrop-filter")}}.
 
 ## Sintaxis

--- a/files/es/web/css/filter/index.md
+++ b/files/es/web/css/filter/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 856b52f634b889084869d2ee0b8bb62c084be04d
 ---
 
-{{CSSRef}}
-
 La propiedad **`filter`** de [CSS](/es/docs/Web/CSS) aplica efectos gráficos como desenfoque o cambio de color a un elemento. Los filtros se usan comúnmente para ajustar la representación de imágenes, fondos y bordes.
 
 Varias [funciones](#funciones), como `blur()` y `contrast()`, están disponibles para ayudarte a lograr efectos predefinidos.

--- a/files/es/web/css/fit-content/index.md
+++ b/files/es/web/css/fit-content/index.md
@@ -3,7 +3,7 @@ title: fit-content()
 slug: Web/CSS/fit-content
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La función [CSS](/es/docs/Web/CSS) **`fit-content()`** ajusta un tamaño dado a un tamaño disponible de acuerdo a la fórmula: `min(maximum size, max(minimum size, argument))`.
 

--- a/files/es/web/css/flex-basis/index.md
+++ b/files/es/web/css/flex-basis/index.md
@@ -3,8 +3,6 @@ title: flex-basis
 slug: Web/CSS/flex-basis
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`flex-basis`** especifíca la base flexible, la cual es el **tamaño inicial** de un elemento flexible. Ésta propiedad determina el tamaño de una caja de contenidos a no ser que se haya especificado de otra forma usando {{Cssxref("box-sizing")}}.

--- a/files/es/web/css/flex-direction/index.md
+++ b/files/es/web/css/flex-direction/index.md
@@ -3,8 +3,6 @@ title: flex-direction
 slug: Web/CSS/flex-direction
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`flex-direction`** especifica cómo colocar los objetos flexibles en el contenedor flexible definiendo el eje principal y la dirección (normal o al revés).
 
 {{InteractiveExample("CSS Demo: flex-direction")}}

--- a/files/es/web/css/flex-flow/index.md
+++ b/files/es/web/css/flex-flow/index.md
@@ -3,8 +3,6 @@ title: flex-flow
 slug: Web/CSS/flex-flow
 ---
 
-{{ CSSRef}}
-
 ## Resumen
 
 La propiedad [CSS](/es/docs/Web/CSS) **`flex-flow`** es una propiedad atajo para las propiedades individuales `flex-direction` y `flex-wrap`.

--- a/files/es/web/css/flex-grow/index.md
+++ b/files/es/web/css/flex-grow/index.md
@@ -3,8 +3,6 @@ title: flex-grow
 slug: Web/CSS/flex-grow
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad **`flex-grow`** de [CSS](/es/docs/Web/CSS) especifica el factor de crecimiento de un elemento flexible (que tiene asignado display:flex), en su dirección principal. El factor de crecimiento especifica qué cantidad del espacio restante dentro del contenedor flexible, debería ocupar el item en cuestión.

--- a/files/es/web/css/flex-shrink/index.md
+++ b/files/es/web/css/flex-shrink/index.md
@@ -3,8 +3,6 @@ title: flex-shrink
 slug: Web/CSS/flex-shrink
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`flex-shrink`** especifica el factor de contracción de un flex item. Los flex items se encogerán para llenar el contenedor de acuerdo a su número `flex-shrink` , cuando el tamaño por defecto de los flex items sea mayor al de su contenedor flex container.
 
 #### Ejemplo

--- a/files/es/web/css/flex-wrap/index.md
+++ b/files/es/web/css/flex-wrap/index.md
@@ -3,8 +3,6 @@ title: flex-wrap
 slug: Web/CSS/flex-wrap
 ---
 
-{{ CSSRef("CSS Flexible Boxes") }}
-
 ## Resumen
 
 La propiedad **`flex-wrap`** de [CSS](/es/docs/Web/CSS) especifica si los elementos "hijos" son obligados a permanecer en una misma línea o pueden fluir en varias líneas. Si la cobertura (wrap) está permitida, esta propiedad también te permite controlar la dirección en la cual serán apilados los elementos.

--- a/files/es/web/css/flex/index.md
+++ b/files/es/web/css/flex/index.md
@@ -3,8 +3,6 @@ title: flex
 slug: Web/CSS/flex
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS flex es una propiedad resumida que indica la capacidad de un elemento flexible para alterar sus dimensiones y llenar el espacio disponible. Los elementos flexibles pueden ser estirados para utilizar el espacio disponible proporcional a su factor de crecimiento flexible o su factor de contracción flexible para evitar desbordamiento.

--- a/files/es/web/css/float/index.md
+++ b/files/es/web/css/float/index.md
@@ -3,8 +3,6 @@ title: float
 slug: Web/CSS/float
 ---
 
-{{CSSRef}}
-
 La propiedad CSS `float` ubica un elemento al lado izquierdo o derecho de su contenedor, permitiendo a los elementos de texto y en línea aparecer a su costado. El elemento es removido del normal flujo de la página, aunque aún sigue siendo parte del flujo (a diferencia del [posicionamiento absoluto](/es/docs/Web/CSS/position#absolute_positioning)).
 
 {{InteractiveExample("CSS Demo: float")}}

--- a/files/es/web/css/font-family/index.md
+++ b/files/es/web/css/font-family/index.md
@@ -3,8 +3,6 @@ title: font-family
 slug: Web/CSS/font-family
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad `font-family` define una lista de fuentes o familias de fuentes, con un orden de prioridad, para utilizar en un elemento seleccionado. A diferencia de la mayoría de las propiedades CSS, los valores se separan con comas (",") para indicar que son valores alternativos.

--- a/files/es/web/css/font-language-override/index.md
+++ b/files/es/web/css/font-language-override/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: c77cfcd17e85db6c1b93160c70668f2ff6c2809c
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`font-language-override`** controla el uso de glifos específicos del idioma en un tipo de letra (tipografía).
 
 De forma predeterminada, el atributo `lang` de HTML le dice a los navegadores que muestren glifos diseñados específicamente para ese idioma. Por ejemplo, muchas tipografías tienen un carácter especial para el dígrafo `fi` que fusiona el punto de la "i" con la "f". Sin embargo, si el idioma está configurado en turco, es probable que el tipo de letra sepa que no debe usar el glifo fusionado; El turco tiene dos versiones de la "i", una con un punto (`i`) y otra sin (`ı`), y usar la ligadura transformaría incorrectamente una "i" con punto en una "i" sin punto.

--- a/files/es/web/css/font-size/index.md
+++ b/files/es/web/css/font-size/index.md
@@ -3,8 +3,6 @@ title: font-size
 slug: Web/CSS/font-size
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad `font-size` especifica la dimensión de la letra. Este tamaño puede, a su vez, alterar el aspecto de alguna otra cosa, ya que se usa para calcular la longitud de las unidades `em` y `ex`.

--- a/files/es/web/css/font-style/index.md
+++ b/files/es/web/css/font-style/index.md
@@ -3,8 +3,6 @@ title: font-style
 slug: Web/CSS/font-style
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad `font-style` permite definir el aspecto de una familia tipográfica entre los valores: `normal`, italic (cursiva) y `oblique`.

--- a/files/es/web/css/font-variant-alternates/index.md
+++ b/files/es/web/css/font-variant-alternates/index.md
@@ -3,8 +3,6 @@ title: font-variant-alternates
 slug: Web/CSS/font-variant-alternates
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`font-variant-alternates`** controla el uso de glifos alternos. Estos glifos alternos pueden ser referenciados por nombres alternativos en {{cssxref("@font-feature-values")}}.

--- a/files/es/web/css/font-variant/index.md
+++ b/files/es/web/css/font-variant/index.md
@@ -3,8 +3,6 @@ title: font-variant
 slug: Web/CSS/font-variant
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad `font-variant` selecciona entre los aspectos `normal` y `small-caps` para la {{ Cssxref("font-family", "familia de fuente") }} determinado.

--- a/files/es/web/css/font-weight/index.md
+++ b/files/es/web/css/font-weight/index.md
@@ -3,8 +3,6 @@ title: font-weight
 slug: Web/CSS/font-weight
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad **`font-weight`** de [CSS](/es/docs/Web/CSS) especifica el peso o grueso de la letra. Algunos tipos de letra sólo están disponibles en `normal` y `bold`.

--- a/files/es/web/css/font/index.md
+++ b/files/es/web/css/font/index.md
@@ -3,8 +3,6 @@ title: font
 slug: Web/CSS/font
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad {{ Cssxref("font") }} permite establecer de una sola vez los valores para todas las propiedades: {{ Cssxref("font-style") }}, {{ Cssxref("font-variant") }}, {{ Cssxref("font-weight") }}, {{ Cssxref("font-size") }}, {{ Cssxref("line-height") }} y {{ Cssxref("font-family") }} en una hoja de estilo.

--- a/files/es/web/css/frequency/index.md
+++ b/files/es/web/css/frequency/index.md
@@ -3,8 +3,6 @@ title: <frequency>
 slug: Web/CSS/frequency
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El tipo de dato [CSS](/es/docs/Web/CSS) `<frequency>` denota una dimensión en frecuencia, como el tono de una voz hablando. Consisste en un valor {{cssxref("&lt;number&gt;")}} seguido inmediatamente por la unidad. Como en cualquier dimensión CSS, no hay espacio entre la unidad literal y el número.

--- a/files/es/web/css/gap/index.md
+++ b/files/es/web/css/gap/index.md
@@ -3,8 +3,6 @@ title: grid-gap
 slug: Web/CSS/gap
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS `grid-gap` es una propiedad abreviada [shorthand](/es/docs/Web/CSS/CSS_cascade/Shorthand_properties) para {{cssxref("grid-row-gap")}} y {{cssxref("grid-column-gap")}} que especifica los canales entre las filas y las columnas de la cuadrícula.

--- a/files/es/web/css/gradient/index.md
+++ b/files/es/web/css/gradient/index.md
@@ -3,8 +3,6 @@ title: <gradient>
 slug: Web/CSS/gradient
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El tipo de datos [CSS](/es/docs/Web/CSS) `<gradient>` indica un tipo de {{cssxref("&lt;image&gt;")}} que consiste de una transición progresiva entre dos o más colores (Degradado).

--- a/files/es/web/css/gradient/linear-gradient/index.md
+++ b/files/es/web/css/gradient/linear-gradient/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 14515827c44f3cb814261a1c6bd487ae8bfcde1b
 ---
 
-{{CSSRef}}
-
 La [función](/es/docs/Web/CSS/CSS_Functions) [CSS](/es/docs/Web/CSS) **`linear-gradient()`** crea una imagen que consiste en una transición progresiva entre dos o más colores a lo largo de una línea recta. Su resultado es un objeto del tipo de datos {{CSSxRef("&lt;gradient&gt;")}}, que es un tipo especial de {{CSSxRef("&lt;image&gt;")}}.
 
 {{InteractiveExample("CSS Demo: linear-gradient()")}}

--- a/files/es/web/css/grid-auto-columns/index.md
+++ b/files/es/web/css/grid-auto-columns/index.md
@@ -3,8 +3,6 @@ title: grid-auto-columns
 slug: Web/CSS/grid-auto-columns
 ---
 
-{{CSSRef}}
-
 La propiedad de css **`grid-auto-columns`** especifíca el tamaño de una columna de cuadrícula creada implícitamente {{glossary("grid tracks", "track")}}.
 
 {{InteractiveExample("CSS Demo: grid-auto-columns")}}

--- a/files/es/web/css/grid-auto-rows/index.md
+++ b/files/es/web/css/grid-auto-rows/index.md
@@ -3,8 +3,6 @@ title: grid-auto-rows
 slug: Web/CSS/grid-auto-rows
 ---
 
-{{CSSRef}}
-
 La propiedad **`grid-auto-rows`** de CSS especifíca el tamaño de una nueva fila creada de forma implícita.
 
 ```css

--- a/files/es/web/css/grid-template-areas/index.md
+++ b/files/es/web/css/grid-template-areas/index.md
@@ -3,8 +3,6 @@ title: grid-template-areas
 slug: Web/CSS/grid-template-areas
 ---
 
-{{CSSRef}}
-
 `La propiedad CSS grid-template-areas` especifica nombres para cada una de las {{glossary("grid areas")}}.
 
 ```css

--- a/files/es/web/css/grid-template-columns/index.md
+++ b/files/es/web/css/grid-template-columns/index.md
@@ -3,8 +3,6 @@ title: grid-template-columns
 slug: Web/CSS/grid-template-columns
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`grid-template-columns`** define el nombre de las líneas y las funciones de tamaño de línea de {{glossary("grid column", "grid columns")}}.
 
 ```css

--- a/files/es/web/css/grid-template-rows/index.md
+++ b/files/es/web/css/grid-template-rows/index.md
@@ -3,8 +3,6 @@ title: grid-template-rows
 slug: Web/CSS/grid-template-rows
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`grid-template-rows`** define el nombre de las líneas y las funciones de tamaño de línea de {{glossary("grid rows", "grid rows")}}.
 
 {{InteractiveExample("CSS Demo: grid-template-rows")}}

--- a/files/es/web/css/grid/index.md
+++ b/files/es/web/css/grid/index.md
@@ -3,8 +3,6 @@ title: grid
 slug: Web/CSS/grid
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`grid`** es un [shorthand](/es/docs/Web/CSS/CSS_cascade/Shorthand_properties) que permite definir todas las propiedades _grid_ explícitas ({{cssxref("grid-template-rows")}}, {{cssxref("grid-template-columns")}}, y {{cssxref("grid-template-areas")}}), implícitas ({{cssxref("grid-auto-rows")}}, {{cssxref("grid-auto-columns")}}, y {{cssxref("grid-auto-flow")}}), y relativas a _gutter_ ({{cssxref("grid-column-gap")}} y {{cssxref("grid-row-gap")}}) en una sola declaración.
 
 ```css

--- a/files/es/web/css/height/index.md
+++ b/files/es/web/css/height/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: abcebf471d56ef12239e2565f26d952e8a8cab2e
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`height`** especifica la altura de un elemento. Por defecto, la propiedad define la altura del [área de contenido](/es/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model#content_area). Sin embargo, si {{cssxref("box-sizing")}} está configurado como `border-box`, determina la altura del [área de borde](/es/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model#border_area).
 
 {{InteractiveExample("CSS Demo: height")}}

--- a/files/es/web/css/hyphens/index.md
+++ b/files/es/web/css/hyphens/index.md
@@ -3,8 +3,6 @@ title: hyphens
 slug: Web/CSS/hyphens
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`hyphens`** especifica cómo deben dividirse las palabras cuando el texto se ajusta a través de múltiples líneas. Puede impedir la separación de sílabas por completo, usar guiones manualmente en puntos específicos del texto o dejar que el navegador inserte los guiones automáticamente donde corresponda.
 
 {{InteractiveExample("CSS Demo: hyphens")}}

--- a/files/es/web/css/id_selectors/index.md
+++ b/files/es/web/css/id_selectors/index.md
@@ -3,8 +3,6 @@ title: Selectores de ID
 slug: Web/CSS/ID_selectors
 ---
 
-{{CSSRef}}
-
 En un documento HTML, los **selectores de ID** de CSS buscan un elemento basado en el contenido del atributo [`ID`](/es/docs/Web/HTML/Reference/Global_attributes#id). El atributo `ID` del elemento seleccionado debe coincidir exactamente con el valor dado en el selector.
 
 ```css

--- a/files/es/web/css/image-rendering/index.md
+++ b/files/es/web/css/image-rendering/index.md
@@ -3,7 +3,7 @@ title: image-rendering
 slug: Web/CSS/image-rendering
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad [CSS](/es/docs/Web/CSS) **`image-rendering`** provee una sugerencia al navegador acerca del algoritmo que debe usar para escalar imágenes.
 

--- a/files/es/web/css/image/index.md
+++ b/files/es/web/css/image/index.md
@@ -3,8 +3,6 @@ title: <image>
 slug: Web/CSS/image
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El tipo de dato [CSS](/es/docs/Web/CSS) `<image>` representa una imagen 2D. Hay dos tipos de imágenes en CSS: imágenes planas estáticas, generalmente referenciadas usando una URL, e imágenes dinámicamente generadas, como degradados o representaciones de partes del árbol.

--- a/files/es/web/css/index.md
+++ b/files/es/web/css/index.md
@@ -3,8 +3,6 @@ title: CSS
 slug: Web/CSS
 ---
 
-{{CSSRef}}
-
 **Hojas de Estilo en Cascada** (del inglés _**C**ascading **S**tyle **S**heets_) o **CSS** es el lenguaje de [estilos](/es/docs/Web/API/StyleSheet) utilizado para describir la presentación de documentos [HTML](/es/docs/Web/HTML) o [XML](/es/docs/Web/XML) (incluyendo varios lenguajes basados en XML como [SVG](/es/docs/Web/SVG), [MathML](/es/docs/Web/MathML) o {{Glossary("XHTML")}}). CSS describe cómo debe ser renderizado el elemento estructurado en la pantalla, en papel, en el habla o en otros medios.
 
 **CSS** es uno de los lenguajes base de la _Open Web_ y posee una [especificación estandarizada](https://www.w3.org/Style/CSS/#specs) por parte del W3C. Anteriormente , el desarrollo de varias partes de las especificaciones de CSS era realizado de manera sincrónica, lo que permitía el versionado de las recomendaciones. Probablemente habrás escuchado acerca de CSS1, CSS2.1, CSS3. Sin embargo, CSS4 nunca se ha lanzado como una versión oficial.

--- a/files/es/web/css/inherit/index.md
+++ b/files/es/web/css/inherit/index.md
@@ -3,8 +3,6 @@ title: inherit
 slug: Web/CSS/inherit
 ---
 
-{{CSSRef}}
-
 << [Volver](/es/Gu%c3%ada_de_referencia_de_CSS)
 
 ### Resumen

--- a/files/es/web/css/initial/index.md
+++ b/files/es/web/css/initial/index.md
@@ -3,8 +3,6 @@ title: initial
 slug: Web/CSS/initial
 ---
 
-{{CSSRef}}
-
 [Guía de referencia de CSS](/es/Gu%c3%ada_de_referencia_de_CSS)
 
 ### Resumen

--- a/files/es/web/css/inline-size/index.md
+++ b/files/es/web/css/inline-size/index.md
@@ -3,7 +3,7 @@ title: inline-size
 slug: Web/CSS/inline-size
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`inline-size`** define el tamaño horizontal o vertical de un bloque de elementos, dependiendo del modo de escritura. Esto corresponde ya sea a la propiedad {{cssxref("width")}} o {{cssxref("height")}}, dependiendo del valor de {{cssxref("writing-mode")}}.
 

--- a/files/es/web/css/inset-block-end/index.md
+++ b/files/es/web/css/inset-block-end/index.md
@@ -3,7 +3,7 @@ title: inset-block-end
 slug: Web/CSS/inset-block-end
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`inset-block-end`** define el desplazamiento de final de bloque lógico de un elemento, que se asigna a una inserción física en función del modo de escritura, la direccionalidad y la orientación del texto del elemento. Corresponde a la propiedad {{cssxref ("top")}}, {{cssxref ("right")}}, {{cssxref ("bottom")}}, o {{cssxref ("left")}} dependiendo de la propiedad en los valores definidos para {{cssxref ("modo de escritura")}}, {{cssxref ("dirección")}} y {{cssxref ("orientación de texto")}}.
 

--- a/files/es/web/css/inset-block-start/index.md
+++ b/files/es/web/css/inset-block-start/index.md
@@ -3,7 +3,7 @@ title: inset-block-start
 slug: Web/CSS/inset-block-start
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`inset-block-start`** define el desplazamiento de inicio de bloque lógico de un elemento, que se asigna a una inserción física en función del modo de escritura, la direccionalidad y la orientación del texto del elemento. Corresponde a la propiedad {{cssxref ("top")}}, {{cssxref ("right")}}, {{cssxref ("bottom")}}, o {{cssxref ("left")}} dependiendo de la propiedad en los valores definidos para {{cssxref ("modo de escritura")}}, {{cssxref ("dirección")}} y {{cssxref ("orientación de texto")}}.
 

--- a/files/es/web/css/inset-block/index.md
+++ b/files/es/web/css/inset-block/index.md
@@ -3,7 +3,7 @@ title: inset-block
 slug: Web/CSS/inset-block
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`inset-block`** define los bloques lógicos de inicio y fin de las compensaciones de un elemento, que se asignan a las compensaciones físicas en función del modo de escritura del elemento, la direccionalidad y la orientación del texto. Corresponde a las propiedades {{cssxref ("top")}} y {{cssxref ("bottom")}}, o {{cssxref ("right")}} y {{cssxref ("left")}} dependiendo de las propiedades en los valores definidos para {{cssxref ("modo de escritura")}}, {{cssxref ("dirección")}} y {{cssxref ("orientación de texto")}}.
 

--- a/files/es/web/css/inset-inline-end/index.md
+++ b/files/es/web/css/inset-inline-end/index.md
@@ -3,7 +3,7 @@ title: inset-inline-end
 slug: Web/CSS/inset-inline-end
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`inset-inline-end`** define la inserción final lógica en línea de un elemento, que se asigna a una inserción física en función del modo de escritura, la direccionalidad y la orientación del texto del elemento. Corresponde a la propiedad {{cssxref ("top")}}, {{cssxref ("right")}}, {{cssxref ("bottom")}}, o {{cssxref ("left")}} dependiendo de la propiedad en los valores definidos para {{cssxref ("modo de escritura")}}, {{cssxref ("dirección")}} y {{cssxref ("orientación de texto")}}.
 

--- a/files/es/web/css/inset-inline-start/index.md
+++ b/files/es/web/css/inset-inline-start/index.md
@@ -3,7 +3,7 @@ title: inset-inline-start
 slug: Web/CSS/inset-inline-start
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`inset-inline-start`** define la inserción de inicio en línea lógica de un elemento, que se asigna a un desplazamiento físico en función del modo de escritura, la direccionalidad y la orientación del texto del elemento. Corresponde a la propiedad {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}}, o {{cssxref("left")}} dependiendo de la propiedad en los valores definidos para {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/inset-inline/index.md
+++ b/files/es/web/css/inset-inline/index.md
@@ -3,7 +3,7 @@ title: inset-inline
 slug: Web/CSS/inset-inline
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`inset-inline`** define los bloques lógicos de inicio y fin de las compensaciones de un elemento, que se asignan a las compensaciones físicas en función del modo de escritura del elemento, la direccionalidad y la orientación del texto. Corresponde a las propiedades {{cssxref ("top")}} y {{cssxref ("bottom")}}, o {{cssxref ("right")}} y {{cssxref ("left")}} dependiendo de las propiedades en los valores definidos para {{cssxref ("modo de escritura")}}, {{cssxref ("dirección")}} y {{cssxref ("orientación de texto")}}.
 

--- a/files/es/web/css/inset/index.md
+++ b/files/es/web/css/inset/index.md
@@ -3,8 +3,6 @@ title: inset
 slug: Web/CSS/inset
 ---
 
-{{CSSRef}}
-
 La propiedad de [CSS](/es/docs/Web/CSS) **`inset`** define el bloque lógico y las compensaciones de inicio y finalización en línea de un elemento, que se asignan a las compensaciones físicas en función del modo de escritura, la direccionalidad y la orientación del texto del elemento. Corresponde a las propiedades {{cssxref ("top")}} y {{cssxref ("bottom")}}, o {{cssxref ("right")}} y {{cssxref ("left")}} dependiendo de las propiedades en los valores definidos para {{cssxref ("modo de escritura")}}, {{cssxref ("dirección")}} y {{cssxref ("orientación de texto")}}.
 
 ```css

--- a/files/es/web/css/isolation/index.md
+++ b/files/es/web/css/isolation/index.md
@@ -3,8 +3,6 @@ title: Isolation
 slug: Web/CSS/isolation
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`isolation`** define si el elemento debe crear un nuevo {{glossary("stacking context")}}.

--- a/files/es/web/css/justify-content/index.md
+++ b/files/es/web/css/justify-content/index.md
@@ -3,8 +3,6 @@ title: justify-content
 slug: Web/CSS/justify-content
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad [CSS](/es/docs/Web/CSS) **`justify-content`** define cómo el navegador distribuye el espacio entre y alrededor de los items flex, a lo largo del eje principal de su contenedor.

--- a/files/es/web/css/layout_cookbook/index.md
+++ b/files/es/web/css/layout_cookbook/index.md
@@ -3,8 +3,6 @@ title: Libro de recetas de maquetación CSS
 slug: Web/CSS/Layout_cookbook
 ---
 
-{{CSSRef}}
-
 El libro de recetas de maquetación CSS tiene como objetivo reunir recetas para patrones de diseño comunes, cosas que podrías necesitar para implementar en tus propios sitios. Además de proporcionar código que puedes utilizar como punto de partida en tus proyectos, estas recetas resaltan las diferentes formas en que se pueden utilizar las especificaciones de diseño y las opciones que puedes tomar como desarrollador.
 
 > [!NOTE]

--- a/files/es/web/css/left/index.md
+++ b/files/es/web/css/left/index.md
@@ -3,8 +3,6 @@ title: left
 slug: Web/CSS/left
 ---
 
-{{CSSRef}}
-
 La propiedad `left` especifica parte de la posición de un elemento (posicionado - es decir, con una posición determinada por código).
 
 Para los elementos con una posición absoluta (aquellos que tienen la propiedad {{ Cssxref("position") }}`: absolute` ó `position: fixed`), la propiedad left determina la distancia entre el margen izquierdo del elemento y el borde izquierdo de su bloque contenedor.

--- a/files/es/web/css/length/index.md
+++ b/files/es/web/css/length/index.md
@@ -3,8 +3,6 @@ title: <length>
 slug: Web/CSS/length
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El tipo de dato [CSS](/es/docs/Web/CSS) `<length>` denota medidas de distancia. Es un valor {{cssxref("&lt;number&gt;")}} seguido por una unidad de longitud (`px`, `em`, `pc`, `in`, `mm`, …). Al igual que en cualquier dimensión CSS, no debe haber espacio entre la unidad y el número. La unidad de longitud es opcional después del valor {{cssxref("&lt;number&gt;")}} `0`.

--- a/files/es/web/css/margin-block-start/index.md
+++ b/files/es/web/css/margin-block-start/index.md
@@ -3,7 +3,7 @@ title: margin-block-start
 slug: Web/CSS/margin-block-start
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`margin-block-start`** [CSS](/es/docs/Web/CSS) property defines the logical block start margin of an element, which maps to a physical margin depending on the element's writing mode, directionality, and text orientation.
 

--- a/files/es/web/css/margin-block/index.md
+++ b/files/es/web/css/margin-block/index.md
@@ -3,7 +3,7 @@ title: margin-block
 slug: Web/CSS/margin-block
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`margin-block`** define el bloque lógico de inicio y fin de las márgenes de un elemento, que se asigna a las márgenes físicas en función del modo de escritura del elemento, la direccionalidad y la orientación del texto.
 

--- a/files/es/web/css/margin-bottom/index.md
+++ b/files/es/web/css/margin-bottom/index.md
@@ -3,8 +3,6 @@ title: margin-bottom
 slug: Web/CSS/margin-bottom
 ---
 
-{{CSSRef}}
-
 ## Summary
 
 ![The effect of the CSS margin-bottom property on the element box](/files/4045/margin-bottom.svg)El `margin-bottom` [CSS](/es/docs/Web/CSS) (_margen-inferior_) es la propiedad de un elemento que establece el espacio requerido en la parte inferior de un elemento. Tambien se permiten valores negativos.

--- a/files/es/web/css/margin-inline-end/index.md
+++ b/files/es/web/css/margin-inline-end/index.md
@@ -3,7 +3,7 @@ title: margin-inline-end
 slug: Web/CSS/margin-inline-end
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`margin-inline-end`** define el margen final lógico en línea de un elemento, que se asigna a un margen físico en función del modo de escritura, la direccionalidad y la orientación del texto del elemento. En otras palabras, corresponde a las propiedades {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}} o {{cssxref("margin-left")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/margin-inline-start/index.md
+++ b/files/es/web/css/margin-inline-start/index.md
@@ -3,7 +3,7 @@ title: margin-inline-start
 slug: Web/CSS/margin-inline-start
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 The **`margin-inline-start`** define el margen de inicio en línea lógico de un elemento, que se asigna a un margen físico según el modo de escritura, la direccionalidad y la orientación del texto del elemento. Corresponde a la las propiedades {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, o {{cssxref("margin-left")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/margin-inline/index.md
+++ b/files/es/web/css/margin-inline/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 5e7d1f9ae2cce0cb3f7693dfb8dc6e8d375b2231
 ---
 
-{{CSSRef}}
-
 La [propiedad abreviada](/es/docs/Web/CSS/CSS_cascade/Shorthand_properties) de [CSS](/es/docs/Web/CSS) **`margin-inline`** es una propiedad abreviada que define los márgenes lógicos de inicio y final en línea de un elemento, que se asignan a márgenes físicos según el modo de escritura, la direccionalidad y la orientación del texto del elemento.
 
 {{InteractiveExample("CSS Demo: margin-inline")}}

--- a/files/es/web/css/margin-right/index.md
+++ b/files/es/web/css/margin-right/index.md
@@ -3,8 +3,6 @@ title: margin-right
 slug: Web/CSS/margin-right
 ---
 
-{{CSSRef}}
-
 ### Definicion
 
 El margen derecho de propiedad establece el margen derecho de un elemento.

--- a/files/es/web/css/margin/index.md
+++ b/files/es/web/css/margin/index.md
@@ -3,8 +3,6 @@ title: margin
 slug: Web/CSS/margin
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`margin`** establece el margen para los cuatro lados. Es una abreviación para evitar tener que establecer cada lado por separado con las otras propiedades de margen: {{ cssxref("margin-top") }}, {{ cssxref("margin-right") }}, {{ cssxref("margin-bottom") }} y {{ cssxref("margin-left") }}.

--- a/files/es/web/css/mask-image/index.md
+++ b/files/es/web/css/mask-image/index.md
@@ -3,7 +3,7 @@ title: -webkit-mask-image
 slug: Web/CSS/mask-image
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/mask-origin/index.md
+++ b/files/es/web/css/mask-origin/index.md
@@ -3,7 +3,7 @@ title: -webkit-mask-origin
 slug: Web/CSS/mask-origin
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 La propiedad [CSS](/es/docs/Web/CSS) `-webkit-mask-origin` determina el origen de una imagen de máscara. El valor de la propiedad {{cssxref("-webkit-mask-position")}} se interpreta en relación al valor de esta propiedad. No se aplica cuando `-webkit-mask-attachment` es `fixed`.
 

--- a/files/es/web/css/mask-position/index.md
+++ b/files/es/web/css/mask-position/index.md
@@ -3,7 +3,7 @@ title: -webkit-mask-position
 slug: Web/CSS/mask-position
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Sumario
 

--- a/files/es/web/css/mask-repeat/index.md
+++ b/files/es/web/css/mask-repeat/index.md
@@ -3,7 +3,7 @@ title: -webkit-mask-repeat
 slug: Web/CSS/mask-repeat
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/mask/index.md
+++ b/files/es/web/css/mask/index.md
@@ -3,7 +3,7 @@ title: -webkit-mask
 slug: Web/CSS/mask
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/max-block-size/index.md
+++ b/files/es/web/css/max-block-size/index.md
@@ -3,8 +3,6 @@ title: max-block-size
 slug: Web/CSS/max-block-size
 ---
 
-{{CSSRef}}
-
 La propiedad **`max-block-size`** [CSS](/es/docs/Web/CSS) especifica el tamaño máximo de un elemento en la dirección opuesta a la escritura dirigida como se especifica por {{cssxref("writing-mode")}}. Es decir, si la dirección de escritura es horizontal, entonces `max-block-size` es equivalente a {{cssxref("max-height")}}; si la dirección de escritura es vertical, `max-block-size` es el mismo que {{cssxref("max-width")}}.
 
 El tamaño máximo de la otra dimensión se especifica usando la propiedad {{cssxref("max-inline-size")}}.

--- a/files/es/web/css/max-height/index.md
+++ b/files/es/web/css/max-height/index.md
@@ -3,8 +3,6 @@ title: max-height
 slug: Web/CSS/max-height
 ---
 
-{{CSSRef}}
-
 ### Resumen
 
 La propiedad `max-height` se utiliza para definir la altura máxima de un elemento dado. Impide que el valor de la {{ Cssxref("height", "altura") }} pueda llegar a ser más grande que la de `max-height`.

--- a/files/es/web/css/max-inline-size/index.md
+++ b/files/es/web/css/max-inline-size/index.md
@@ -3,7 +3,7 @@ title: max-inline-size
 slug: Web/CSS/max-inline-size
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`max-inline-size`** define el tamaño máximo horizontal o vertical de un elemento bloque dependiendo del modo de escritura. Esto corresponde a las propiedades {{cssxref("max-width")}} o {{cssxref("max-height")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}. Si el modo de escritura esta orientado verticalmente, el valor de `max-inline-size` relacionado al alto máximo del elemento, de lo contrario, se relaciona con el ancho máximo del elemento. Se relaciona con {{cssxref("max-block-size")}}, que define la otra dimensión del elemento.
 

--- a/files/es/web/css/min-block-size/index.md
+++ b/files/es/web/css/min-block-size/index.md
@@ -3,7 +3,7 @@ title: min-block-size
 slug: Web/CSS/min-block-size
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`min-block-size`** define el tamaño mínimo horizontal o vertical de un elemento de bloque, dependiendo de los modos de escritura. Esto corresponde ya sea a la propiedad {{cssxref("min-width")}} o a la propiedad {{cssxref("min-height")}}, dependiendo del valor de {{cssxref("writing-mode")}}.
 

--- a/files/es/web/css/min-height/index.md
+++ b/files/es/web/css/min-height/index.md
@@ -3,8 +3,6 @@ title: min-height
 slug: Web/CSS/min-height
 ---
 
-{{CSSRef}}
-
 ### Resumen
 
 La propiedad `min-height` se utiliza para definir la altura mínima de un elemento dado. Impide que el valor de la propiedad {{ Cssxref("height") }} llegue a ser más pequeña que la especificada en la altura mínima (`min-height`).

--- a/files/es/web/css/min-inline-size/index.md
+++ b/files/es/web/css/min-inline-size/index.md
@@ -3,7 +3,7 @@ title: min-inline-size
 slug: Web/CSS/min-inline-size
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`min-inline-size`** define el tamaño mínimo horizontal o vertical de los elementos en bloque, dependiendo del modo de escritura. Esto corresponde ya sea a la propiedad {{cssxref("min-width")}} o la propiedad {{cssxref("min-height")}}, dependiendo del valor de {{cssxref("writing-mode")}}.
 

--- a/files/es/web/css/min/index.md
+++ b/files/es/web/css/min/index.md
@@ -3,8 +3,6 @@ title: min()
 slug: Web/CSS/min
 ---
 
-{{CSSRef}}
-
 La [función](/es/docs/Web/CSS/CSS_Functions) [CSS](/es/docs/Web/CSS) **`min()`** permite establecer el valor mas pequeño (mas negativo) de una lista de expresiones separadas por coma como el valor de una propiedad CSS. La función `min()` puede ser usada donde quiera que {{CSSxRef("&lt;length&gt;")}}, {{CSSxRef("&lt;frequency&gt;")}}, {{CSSxRef("&lt;angle&gt;")}}, {{CSSxRef("&lt;time&gt;")}}, {{CSSxRef("&lt;percentage&gt;")}}, {{CSSxRef("&lt;number&gt;")}}, o {{CSSxRef("&lt;integer&gt;")}} esté permitido.
 
 {{InteractiveExample("CSS Demo: min()")}}

--- a/files/es/web/css/minmax/index.md
+++ b/files/es/web/css/minmax/index.md
@@ -3,8 +3,6 @@ title: minmax()
 slug: Web/CSS/minmax
 ---
 
-{{CSSRef}}
-
 La función **`minmax()`** [en CSS](/es/docs/Web/CSS) define un rango de tamaño mayor o igual que _min_ y menor o igual que _max_. Se emplea con [rejillas CSS](/es/docs/Web/CSS/CSS_grid_layout).
 
 ```css

--- a/files/es/web/css/mix-blend-mode/index.md
+++ b/files/es/web/css/mix-blend-mode/index.md
@@ -3,8 +3,6 @@ title: mix-blend-mode
 slug: Web/CSS/mix-blend-mode
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`mix-blend-mode`** describe cómo el contenido de un elemento debe mezclarse con el contenido del elemento que está tras él y con el fondo del elemento.
 
 {{InteractiveExample("CSS Demo: mix-blend-mode")}}

--- a/files/es/web/css/mozilla_extensions/index.md
+++ b/files/es/web/css/mozilla_extensions/index.md
@@ -3,8 +3,6 @@ title: Extensiones CSS de Mozilla
 slug: Web/CSS/Mozilla_Extensions
 ---
 
-{{CSSRef}}
-
 Mozilla soporta ciertas extensiones de [CSS](/es/docs/Web/CSS) con el prefijo`-moz-`.
 
 Algunas de estas propiedades han sido incluidas en una especificación de CSS en borrador para incluirlas en la recomendación final, pero aún están en proceso experimental. La propiedad final estándar puede ser diferente de la implementación actual con prefijo. Algunas de estas propiedades no estándares solo son aplicables en elementos XUL.

--- a/files/es/web/css/next-sibling_combinator/index.md
+++ b/files/es/web/css/next-sibling_combinator/index.md
@@ -3,8 +3,6 @@ title: Selectores de hermanos adyacentes
 slug: Web/CSS/Next-sibling_combinator
 ---
 
-{{CSSRef}}
-
 Se hace referencia a este selector como selector adyacente o selector del próximo hermano. Sólo seleccionará un elemento especificado que esté inmediatamente después de otro elemento especificado.
 
 ## Síntaxis

--- a/files/es/web/css/object-fit/index.md
+++ b/files/es/web/css/object-fit/index.md
@@ -3,8 +3,6 @@ title: object-fit
 slug: Web/CSS/object-fit
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`object-fit`** indica cómo el contenido de un [elemento reemplazado](/es/docs/Web/CSS/CSS_images/Replaced_element_properties), por ejemplo un {{HTMLElement("img")}} o {{HTMLElement("video")}}, debería redimensionarse para ajustarse a su contenedor.
 
 Se puede alterar la alineación del contenido del elemento reemplazado utilizando la propiedad {{cssxref("object-position")}}.

--- a/files/es/web/css/object-position/index.md
+++ b/files/es/web/css/object-position/index.md
@@ -3,8 +3,6 @@ title: object-position
 slug: Web/CSS/object-position
 ---
 
-{{CSSRef}}
-
 ## Summary
 
 La propiedad **`object-position`** determina el alineamiento del elemento dentro de la caja.

--- a/files/es/web/css/order/index.md
+++ b/files/es/web/css/order/index.md
@@ -3,8 +3,6 @@ title: order
 slug: Web/CSS/order
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad [CSS](/es/docs/Web/CSS) **`order`** especifica el orden utilizado para disponer los elementos en su contenedor flexible. Los elementos estarán dispuestos en orden ascendente según el valor de `order`. Los elementos con el mismo valor de `order` se dispondrán en el orden en el cual aparecen en el código fuente.

--- a/files/es/web/css/outline-color/index.md
+++ b/files/es/web/css/outline-color/index.md
@@ -3,8 +3,6 @@ title: outline-color
 slug: Web/CSS/outline-color
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`outline-color`** establece el color del contorno de un elemento.
 
 {{InteractiveExample("CSS Demo: outline-color")}}

--- a/files/es/web/css/outline-offset/index.md
+++ b/files/es/web/css/outline-offset/index.md
@@ -3,8 +3,6 @@ title: outline-offset
 slug: Web/CSS/outline-offset
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`outline-offset`** es usada para establecer el espacio entre un contorno {{ cssxref("outline") }} y el límite o borde de un elemento. Un contorno es una línea que se dibuja al rededor de los elementos, fuera de los límites de su borde.

--- a/files/es/web/css/outline-style/index.md
+++ b/files/es/web/css/outline-style/index.md
@@ -3,8 +3,6 @@ title: outline-style
 slug: Web/CSS/outline-style
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`outline-style`** es usada para establecer el estilo del contorno de un elemento. Un contorno es una línea que se dibuja al rededor de elementos, fuera de los límites del borde, para resaltar un elemento.

--- a/files/es/web/css/outline-width/index.md
+++ b/files/es/web/css/outline-width/index.md
@@ -3,8 +3,6 @@ title: outline-width
 slug: Web/CSS/outline-width
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`outline-width`** es usada para establecer el grosor del contorno de un elemento. Un contorno es una línea que se dibuja al rededor de los elementos, fuera de los límites del borde, para resaltar al elemento:

--- a/files/es/web/css/outline/index.md
+++ b/files/es/web/css/outline/index.md
@@ -3,8 +3,6 @@ title: outline
 slug: Web/CSS/outline
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`outline`** es una [forma reducida](/es/docs/Web/CSS/CSS_cascade/Shorthand_properties) para establecer una o más de las propiedades individuales de contorno {{cssxref("outline-style")}}, {{cssxref("outline-width")}} y {{cssxref("outline-color")}} en una sola declaración. En la mayoría de los casos el uso de este atajo es preferible y más conveniente.
 
 {{InteractiveExample("CSS Demo: outline")}}

--- a/files/es/web/css/overflow-y/index.md
+++ b/files/es/web/css/overflow-y/index.md
@@ -3,8 +3,6 @@ title: overflow-y
 slug: Web/CSS/overflow-y
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`overflow-y`** define qué se debe mostrar cuando el contenido se desborda de los extremos superior e inferior de un elemento en bloque.
 
 > [!NOTE]

--- a/files/es/web/css/padding-block-end/index.md
+++ b/files/es/web/css/padding-block-end/index.md
@@ -3,7 +3,7 @@ title: padding-block-end
 slug: Web/CSS/padding-block-end
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`padding-block-end`** define el relleno de final de bloque lógico de un elemento, que se asigna a un relleno físico en función del modo de escritura, la direccionalidad y la orientación del texto del elemento. Corresponde a las propiedades {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, o {{cssxref("padding-left")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/padding-block-start/index.md
+++ b/files/es/web/css/padding-block-start/index.md
@@ -3,7 +3,7 @@ title: padding-block-start
 slug: Web/CSS/padding-block-start
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`padding-block-start`** define el bloque lógico de inicio de relleno de un elemento, que se asigna a un relleno físico en función del modo de escritura, la direccionalidad y la orientación del texto del elemento. Corresponde a las propiedades {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, or {{cssxref("padding-left")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/padding-block/index.md
+++ b/files/es/web/css/padding-block/index.md
@@ -3,7 +3,7 @@ title: padding-block
 slug: Web/CSS/padding-block
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`padding-block`** define el relleno lógico de inicio y final del bloque de un elemento, que se asigna a las propiedades físicas del relleno según el modo de escritura del elemento, la direccionalidad y la orientación del texto.
 

--- a/files/es/web/css/padding-bottom/index.md
+++ b/files/es/web/css/padding-bottom/index.md
@@ -3,8 +3,6 @@ title: padding-bottom
 slug: Web/CSS/padding-bottom
 ---
 
-{{CSSRef}}
-
 ## Sumario
 
 La propiedad **`padding-bottom`** [CSS](/es/docs/Web/CSS) establece el espacio de relleno requerido en la parte inferior del elemento. El [área de padding](/es/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model#padding) es el espacio entre el contenido del elemento y su borde. Contrariamente de la propiedad **`margin-bottom`**, valores negativos no son válidos.

--- a/files/es/web/css/padding-inline-end/index.md
+++ b/files/es/web/css/padding-inline-end/index.md
@@ -3,7 +3,7 @@ title: padding-inline-end
 slug: Web/CSS/padding-inline-end
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`padding-inline-end`** define el relleno final lógico en línea de un elemento, que se asigna a un relleno físico en función del modo de escritura, la direccionalidad y la orientación del texto del elemento. Corresponde a las propiedades {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, o {{cssxref("padding-left")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/padding-inline-start/index.md
+++ b/files/es/web/css/padding-inline-start/index.md
@@ -3,7 +3,7 @@ title: padding-inline-start
 slug: Web/CSS/padding-inline-start
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`padding-inline-start`** define el relleno de inicio lógico en línea de un elemento, que se asigna a un relleno físico en función del modo de escritura, la direccionalidad y la orientación del texto del elemento. Corresponde a las propiedades {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, or {{cssxref("padding-left")}} dependiendo de los valores definidos por {{cssxref("writing-mode")}}, {{cssxref("direction")}}, y {{cssxref("text-orientation")}}.
 

--- a/files/es/web/css/padding-inline/index.md
+++ b/files/es/web/css/padding-inline/index.md
@@ -3,7 +3,7 @@ title: padding-inline
 slug: Web/CSS/padding-inline
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La propiedad de [CSS](/es/docs/Web/CSS) **`padding-inline`** define el relleno en línea lógico de inicio y final de un elemento, que asigna las propiedades de relleno físicas dependiendo del modo de escritura del elemento, direccionalidad, y orientación del texto.
 

--- a/files/es/web/css/padding-top/index.md
+++ b/files/es/web/css/padding-top/index.md
@@ -3,8 +3,6 @@ title: padding-top
 slug: Web/CSS/padding-top
 ---
 
-{{CSSRef}}
-
 ## Sumario
 
 La propiedad **`padding-top`** [CSS](/es/docs/Web/CSS) establece el espacio de relleno requerido en la parte superior del elemento. El [área de padding](/es/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model#padding) es el espacio entre el contenido del elemento y su borde. Contrariamente de la propiedad **`margin-top`**, valores negativos no son válidos.

--- a/files/es/web/css/padding/index.md
+++ b/files/es/web/css/padding/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 3c09214457e67106a16594c333dbae8b2be67e6f
 ---
 
-{{CSSRef}}
-
 La [propiedad abreviada](/es/docs/Web/CSS/CSS_cascade/Shorthand_properties) de [CSS](/es/docs/Web/CSS) **`padding`** establece el área de relleno en los cuatro lados de un elemento a la vez.
 
 {{InteractiveExample("CSS Demo: padding")}}

--- a/files/es/web/css/percentage/index.md
+++ b/files/es/web/css/percentage/index.md
@@ -3,8 +3,6 @@ title: <percentage>
 slug: Web/CSS/percentage
 ---
 
-{{CSSRef}}
-
 ## Sumario
 
 Los tipos de dato `<porcentaje>` de [CSS](/es/docs/Web/CSS) representan un valor en forma de porcentaje. Muchas [propiedades de CSS](/en-US/CSS_Reference) pueden tomar valores porcentuales, siempre para definir longitudes con respecto al tamaño de los elementos padre. Los porcentajes estan formados por un [\<numero>](/es/docs/Web/CSS/number) seguido por el signo de porcentaje `%`. No hay un espacio entre el '%' y el numero.

--- a/files/es/web/css/perspective/index.md
+++ b/files/es/web/css/perspective/index.md
@@ -3,7 +3,7 @@ title: perspective
 slug: Web/CSS/perspective
 ---
 
-{{ CSSRef("CSS Transforms") }} {{ SeeCompatTable() }}
+{{ SeeCompatTable() }}
 
 ## Resumen
 

--- a/files/es/web/css/position/index.md
+++ b/files/es/web/css/position/index.md
@@ -3,8 +3,6 @@ title: position
 slug: Web/CSS/position
 ---
 
-{{CSSRef}}
-
 La propiedad **`position`** de [CSS](/es/docs/Web/CSS) especifica cómo un elemento es posicionado en el documento. Las propiedades {{Cssxref("top")}}, {{Cssxref("right")}}, {{Cssxref("bottom")}}, y {{Cssxref("left")}} determinan la ubicación final de los elementos posicionados.
 
 {{InteractiveExample("CSS Demo: position")}}

--- a/files/es/web/css/print-color-adjust/index.md
+++ b/files/es/web/css/print-color-adjust/index.md
@@ -3,7 +3,7 @@ title: -webkit-print-color-adjust
 slug: Web/CSS/print-color-adjust
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/quotes/index.md
+++ b/files/es/web/css/quotes/index.md
@@ -3,8 +3,6 @@ title: quotes
 slug: Web/CSS/quotes
 ---
 
-{{CSSRef}}
-
 ## Sumario
 
 La propiedad [CSS](/es/docs/Web/CSS) `quotes` indica cómo debe renderizar las citas el navegador.

--- a/files/es/web/css/reference/index.md
+++ b/files/es/web/css/reference/index.md
@@ -3,8 +3,6 @@ title: Referencia CSS
 slug: Web/CSS/Reference
 ---
 
-{{CSSRef}}
-
 Esta _Referencia CSS_ muestra la sintáxis básica de una regla CSS; lista todas las propiedades estándares [CSS](/es/docs/Web/CSS), [pseudo-classes](/es/docs/Web/CSS/Pseudo-classes) y [pseudo-elementos](/es/docs/Web/CSS/Pseudo-elements), [reglas-at](/es/docs/Web/CSS/CSS_syntax/At-rule), [unidades](/es/docs/Web/CSS/length), y [selectores](/es/docs/Web/CSS/Introducci%C3%B3n/Selectors), todos juntos en [orden alfabético](#keyword_index), así como los [selectores por tipo](#selectors); y le permitirá acceso rápido a la información detallada de cada uno de ellos. No solo lista las propiedades de CSS 1 y CSS 2.1, sino que también es una referencia de CSS3 que enlaza cualquier propiedad y concepto de [CSS3](/es/docs/Web/CSS/CSS3) estandarizado, o ya establecido. También incluye una breve [referencia DOM-CSS / CSSOM](#dom_css).
 
 Tenga en cuenta que las definiciones de reglas CSS son completamente [basadas en texto](https://www.w3.org/TR/css-syntax-3/#intro) (ASCII), mientras que DOM-CSS / CSSOM, el sistema de gestión de reglas, está [basado en objetos](https://www.w3.org/TR/cssom/#introduction).

--- a/files/es/web/css/repeat/index.md
+++ b/files/es/web/css/repeat/index.md
@@ -3,8 +3,6 @@ title: repeat()
 slug: Web/CSS/repeat
 ---
 
-{{cssref}}
-
 La función [CSS](/es/docs/Web/CSS) **`repeat()`** representa un fragmento repetido de la lista de la pista, permitiendo un gran número de columnas o renglones que exhiben un patrón recurrente para ser escrito de una forma más compacta.
 
 Esta función puede ser usada en las propiedades CSS Grid {{cssxref("grid-template-columns")}} y {{cssxref("grid-template-rows")}}.

--- a/files/es/web/css/resize/index.md
+++ b/files/es/web/css/resize/index.md
@@ -3,8 +3,6 @@ title: resize
 slug: Web/CSS/resize
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad resize de CSS permite controlar la capacidad de cambio de tamaño de un elemento.

--- a/files/es/web/css/resolution/index.md
+++ b/files/es/web/css/resolution/index.md
@@ -3,8 +3,6 @@ title: <resolution>
 slug: Web/CSS/resolution
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El tipo de dato [CSS](/es/docs/Web/CSS) `<resolution>`, usado en [media queries](/es/docs/Web/CSS/CSS_media_queries/Using_media_queries), define la densidad de píxeles de un dispositivo de salida, su resolución. Es un {{cssxref("&lt;number&gt;")}} inmediatamente seguido por una unidad de resolución (`dpi`, `dpcm`, ...). Como para cualquier dimensión CSS, no hay espacio entre la unidad literal y el número.

--- a/files/es/web/css/scroll-behavior/index.md
+++ b/files/es/web/css/scroll-behavior/index.md
@@ -3,8 +3,6 @@ title: scroll-behavior
 slug: Web/CSS/scroll-behavior
 ---
 
-{{ CSSRef }}
-
 La propiedad CSS **`scroll-behavior`** especifica el comportamiento del desplazamiento para un elemento con desplazamiento, cuando éste se produce debido a la navegación o a APIs CSSOM. Otros desplazamientos, p.ej. aquellos realizados por el usuario, no se ven afectados por esta propiedad. Cuando esta propiedad está especificada en el elemento raíz, se aplica al viewport.
 
 Esta propiedad puede ser ignorada por los agentes de usuario.

--- a/files/es/web/css/subsequent-sibling_combinator/index.md
+++ b/files/es/web/css/subsequent-sibling_combinator/index.md
@@ -3,8 +3,6 @@ title: Selectores de hermanos generales
 slug: Web/CSS/Subsequent-sibling_combinator
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 El combinador `~` separa dos selectores y selecciona el segundo elemento sólo si está precedido por el primero y ambos comparten un padre común.

--- a/files/es/web/css/text-align/index.md
+++ b/files/es/web/css/text-align/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: b82ff59aab7883b7bb2222cf9f9f9b6eed818e08
 ---
 
-{{CSSRef}}
-
 La propiedad **`text-align`** de [CSS](/es/docs/Web/CSS) establece la alineación horizontal del contenido a nivel de línea dentro de un elemento de bloque o caja de celda-tabla. Esto significa que funciona como {{cssxref("vertical-align")}} pero en dirección horizontal.
 
 {{InteractiveExample("CSS Demo: text-align")}}

--- a/files/es/web/css/text-decoration-color/index.md
+++ b/files/es/web/css/text-decoration-color/index.md
@@ -3,8 +3,6 @@ title: text-decoration-color
 slug: Web/CSS/text-decoration-color
 ---
 
-{{ CSSRef }}
-
 ## Resumen
 
 La propiedad **`text-decoration-color`** establece el color usado cuando se dibujan subrayados o líneas a través del texto, especificadas por la propiedad {{ cssxref("text-decoration-line") }}. El color especificado será el mismo para los tres tipos de línea.

--- a/files/es/web/css/text-decoration-line/index.md
+++ b/files/es/web/css/text-decoration-line/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 37163d27e0625a83a3f8633fe58b9041867adeaa
 ---
 
-{{CSSRef}}
-
 La propiedad **`text-decoration-line`** de [CSS](/es/docs/Web/CSS) establece el tipo de decoración que se utiliza en el texto de un elemento, como un subrayado o un sobrerayado.
 
 {{InteractiveExample("CSS Demo: text-decoration-line")}}

--- a/files/es/web/css/text-decoration-style/index.md
+++ b/files/es/web/css/text-decoration-style/index.md
@@ -3,8 +3,6 @@ title: text-decoration-style
 slug: Web/CSS/text-decoration-style
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`text-decoration-style`** define el estilo de las líneas especificadas por {{ cssxref("text-decoration-line") }}. El estilo aplica a todas las líneas, no hay manera de establecer diferentes estilos para cada línea definida por `text-decoration-line`.

--- a/files/es/web/css/text-decoration/index.md
+++ b/files/es/web/css/text-decoration/index.md
@@ -3,8 +3,6 @@ title: text-decoration
 slug: Web/CSS/text-decoration
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`text-decoration`** se usa para establecer el formato de texto a subrayado (`underline`) y suprarrayado (`overline`), tachado (`line-through`) o parpadeo (`blink`). El subrayado y el suprarrayado son posicionados bajo el texto, mientras la línea a través de éste se posiciona por encima.
 
 Las decoraciones de texto se dibujan a través de los elementos descendientes. Esto significa que no es posible deshabilitar la decoración en un descendiente si la propiedad se especifica en un elemento ancestro. Por ejemplo, en el código `<p>Este texto tiene <em>algunas palabras enfatizadas</em> en él.</p>`, la regla de estilos `p { text-decoration: underline; }` causará que el párrafo entero tenga subrayado. La regla `em { text-decoration: none; }` no causará ningún cambio; el párrafo entero seguirá subrayado. Sin embargo, la regla `em { text-decoration: overline; }` causará una segunda decoración que aparecerá sobre "algunas palabras enfatizadas".

--- a/files/es/web/css/text-emphasis-color/index.md
+++ b/files/es/web/css/text-emphasis-color/index.md
@@ -3,8 +3,6 @@ title: text-emphasis-color
 slug: Web/CSS/text-emphasis-color
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`text-emphasis-color`** (que podría traducirse como color del texto con énfasis) define el color de las marcas de énfasis. Este valor también puede definirse usando el atajo {{cssxref("text-emphasis")}}
 
 ```css

--- a/files/es/web/css/text-emphasis/index.md
+++ b/files/es/web/css/text-emphasis/index.md
@@ -3,8 +3,6 @@ title: text-emphasis
 slug: Web/CSS/text-emphasis
 ---
 
-{{CSSRef}}
-
 La **propiedad** **[CSS](/es/docs/Web/CSS)** de **text-emphasis**, es una propiedad _abreviada_ para establecer los valores de [text-empahasis-style](/es/docs/Web/CSS/text-emphasis-style) y [text-emphasis-color](/es/docs/Web/CSS/text-emphasis-color), en una sola declaración.
 
 Esta **propiedad** aplicara el énfasis a cada carácter especificado en el texto del elemento, a excepción de caracteres separados como espacios y caracteres de control .

--- a/files/es/web/css/text-orientation/index.md
+++ b/files/es/web/css/text-orientation/index.md
@@ -3,8 +3,6 @@ title: text-orientation
 slug: Web/CSS/text-orientation
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS)**`text-orientation`** define la orientación del texto en una línea de escritura. Ésta propiedad sólo tiene efecto en modo vertical, ésto es, cuando {{cssxref("writing-mode")}} no está establecido cómo `horizontal-tb`. Ésta propiedad CSS es util para controlar la forma en que se muestran los lenguajes que utilizan escritura vertical, y tambien para construir encabezados verticales para tablas.
 
 ```css

--- a/files/es/web/css/text-overflow/index.md
+++ b/files/es/web/css/text-overflow/index.md
@@ -3,8 +3,6 @@ title: text-overflow
 slug: Web/CSS/text-overflow
 ---
 
-{{CSSRef}}
-
 La propiedad de [CSS](/es/docs/Web/CSS) **`text-overflow`** determina como el contenido que se desborda y que no es mostrado, va a hacérsele notar a los usuarios. Puede ser cortado, mostrar una elipsis ('`…`', `U+2026 Horizontal Ellipsis`), o mostrar una cadena de texto personalizada.
 
 {{InteractiveExample("CSS Demo: text-overflow")}}

--- a/files/es/web/css/text-shadow/index.md
+++ b/files/es/web/css/text-shadow/index.md
@@ -3,8 +3,6 @@ title: text-shadow
 slug: Web/CSS/text-shadow
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad **`text-shadow`** agrega sombra al texto. Acepta una lista de sombras separadas por coma, para aplicarlas al texto y a la propiedad {{cssxref("text-decoration","text-decorations")}} del elemento.

--- a/files/es/web/css/text-transform/index.md
+++ b/files/es/web/css/text-transform/index.md
@@ -3,8 +3,6 @@ title: text-transform
 slug: Web/CSS/text-transform
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS **`text-transform`** especifica el cambio entre mayúsculas y minúsculas del texto de un elemento. Puede ser usada para que un texto aparezca completamente en mayúsculas, en minúsculas, o con la primera letra de cada palabra en mayúscula.

--- a/files/es/web/css/text-wrap/index.md
+++ b/files/es/web/css/text-wrap/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 4ecbac9e89961a132c1e7f5493ec94f60dcb1ee4
 ---
 
-{{CSSRef}}
-
 La propiedad abreviada de CSS **`text-wrap`** controla cómo se envuelve el texto dentro de un elemento. Los diferentes valores proporcionan:
 
 - Mejoras tipográficas, por ejemplo, longitudes de línea más equilibradas en títulos divididos.

--- a/files/es/web/css/time/index.md
+++ b/files/es/web/css/time/index.md
@@ -3,8 +3,6 @@ title: <time>
 slug: Web/CSS/time
 ---
 
-{{CSSRef}}
-
 El [tipo de dato](/es/docs/Web/CSS/CSS_Values_and_Units/CSS_data_types) **`<time>`** de [CSS](/es/docs/Web/CSS) representa un valor de tiempo expresado en segundos o milisegundos. Se usa en {{cssxref("animation")}}, {{cssxref("transition")}} y propiedades relacionadas.
 
 ## Sintaxis

--- a/files/es/web/css/transform-function/index.md
+++ b/files/es/web/css/transform-function/index.md
@@ -3,8 +3,6 @@ title: transform-function
 slug: Web/CSS/transform-function
 ---
 
-{{CSSRef}}
-
 El tipo de dato CSS `<transform-function>` denota una función por aplicar a la representación de un elemento para modificarlo. Generalmente, dicha transformación puede ser expresada por matrices, y la imagen resultante puede ser determinada usando multiplicación de matrices en cada punto.
 
 ## Coordenadas para graficos 2D

--- a/files/es/web/css/transform-function/rotate/index.md
+++ b/files/es/web/css/transform-function/rotate/index.md
@@ -3,8 +3,6 @@ title: rotate()
 slug: Web/CSS/transform-function/rotate
 ---
 
-{{CSSRef}}
-
 La función [CSS](/es/docs/Web) **`rotate()`** define una transformación que gira un elemento alrededor de un punto fijo en un plano 2D sin deformarlo.
 
 El punto fijo alrededor del cual gira el elemento, mencionado anteriormente, también se conoce como el **origen de transformación**. Se establece de manera predeterminada en el centro del elemento, pero se puede personalizar utilizando la propiedad {{ cssxref("transform-origin") }}.

--- a/files/es/web/css/transform-function/rotate3d/index.md
+++ b/files/es/web/css/transform-function/rotate3d/index.md
@@ -3,8 +3,6 @@ title: rotate3d()
 slug: Web/CSS/transform-function/rotate3d
 ---
 
-{{CSSRef}}
-
 La [función](/es/docs/Web/CSS/CSS_Functions) **`rotate3d()`** de [CSS](/es/docs/Web/CSS) define una transformación que mueve el elemento alrededor de un eje fijo sin deformarlo. Su resultado es un tipo de dato {{cssxref("&lt;transform-function&gt;")}}.
 
 {{InteractiveExample("CSS Demo: rotate3d()")}}

--- a/files/es/web/css/transform-function/scale/index.md
+++ b/files/es/web/css/transform-function/scale/index.md
@@ -3,8 +3,6 @@ title: scale()
 slug: Web/CSS/transform-function/scale
 ---
 
-{{CSSRef}}
-
 La función CSS `scale()` define una transformación que modifica el tamaño de un elemento en el plano 2D. Debido a que la cantidad de escalado está definida por un vector, puede cambiar el tamaño de la dimensiones horizontal y vertical a diferentes escalas. Su resultado es un dato tipo {{cssxref("transform-function")}}.
 
 Esta transformación de escalado se caracteriza por un vector bidimensional. Sus coordenadas definen cuanto escalamiento se realiza en cada dirección. Sí ambas coordenadas son iguales, la escala es uniforme (isotrópica) y la relación de aspecto del elemento se conserva (esta es una transformación homotética).

--- a/files/es/web/css/transform-function/translate/index.md
+++ b/files/es/web/css/transform-function/translate/index.md
@@ -3,8 +3,6 @@ title: translate()
 slug: Web/CSS/transform-function/translate
 ---
 
-{{CSSRef}}
-
 La function de [CSS](/es/docs/Web/CSS) **`translate()`** recoloca un elemento en el eje horizontal y/o vertical. Su resultado es de tipo {{cssxref("&lt;transform-function&gt;")}}.
 
 Esta transformacion esta compuesta por un vector bidimensional cuyas coordenadas definen cuanto se movera el elemente en cada dirección.

--- a/files/es/web/css/transform-function/translatey/index.md
+++ b/files/es/web/css/transform-function/translatey/index.md
@@ -3,8 +3,6 @@ title: translateY()
 slug: Web/CSS/transform-function/translateY
 ---
 
-{{CSSRef}}
-
 La función **`translateY()`** de [CSS](/es/docs/Web/CSS) reposiciona un elemento verticalmente dentro del plano bidimensional. Su resultado es de tipo {{cssxref("&lt;transform-function&gt;")}}.
 
 > [!NOTE]

--- a/files/es/web/css/transform-function/translatez/index.md
+++ b/files/es/web/css/transform-function/translatez/index.md
@@ -3,8 +3,6 @@ title: translateZ()
 slug: Web/CSS/transform-function/translateZ
 ---
 
-{{CSSRef}}
-
 La función **`translateZ()`** [CSS](/es/docs/Web/CSS) reposiciona un elemento a lo largo del eje-z (z-axis) en el espacio 3D, es decir, más cerca o mas lejos del espectador. Su resultado es un {{cssxref("&lt;transform-function&gt;")}} tipo de dato.
 
 {{InteractiveExample("CSS Demo: translateZ()")}}

--- a/files/es/web/css/transform-origin/index.md
+++ b/files/es/web/css/transform-origin/index.md
@@ -3,7 +3,7 @@ title: transform-origin
 slug: Web/CSS/transform-origin
 ---
 
-{{ CSSRef("CSS Transforms") }} {{ SeeCompatTable() }}
+{{ SeeCompatTable() }}
 
 ## Resumen
 

--- a/files/es/web/css/transform-style/index.md
+++ b/files/es/web/css/transform-style/index.md
@@ -81,5 +81,3 @@ transform-style: unset;
 ## See also
 
 - [Using CSS transforms](/es/docs/Web/CSS/CSS_transforms/Using_CSS_transforms)
-
-{{CSSRef}}

--- a/files/es/web/css/transform/index.md
+++ b/files/es/web/css/transform/index.md
@@ -3,8 +3,6 @@ title: transform
 slug: Web/CSS/transform
 ---
 
-{{CSSRef}}
-
 La propiedad CSS `transform` te permite modificar el espacio de coordenadas del modelo de formato visual CSS. Usándola, los elementos pueden ser trasladados, rotados, escalados o sesgados de acuerdo a los valores establecidos.
 
 {{InteractiveExample("CSS Demo: transform")}}

--- a/files/es/web/css/transition-duration/index.md
+++ b/files/es/web/css/transition-duration/index.md
@@ -3,8 +3,6 @@ title: transition-duration
 slug: Web/CSS/transition-duration
 ---
 
-{{CSSRef}}
-
 La propiedad de [CSS](/es/docs/Web/CSS) **`transition-duration`** establece el tiempo que debe tardar una animación de transición en completarse. Por defecto, el valor es de `0s`, esto quiere decir que no se producirá ninguna animación.
 
 {{InteractiveExample("CSS Demo: transition-duration")}}

--- a/files/es/web/css/transition-property/index.md
+++ b/files/es/web/css/transition-property/index.md
@@ -3,8 +3,6 @@ title: transition-property
 slug: Web/CSS/transition-property
 ---
 
-{{CSSRef}}
-
 La propiedad CSS **`transition-property`** se usa para definir los nombres de las propiedades CSS en las que el efecto de la transición debe aplicarse.
 
 ```css

--- a/files/es/web/css/transition/index.md
+++ b/files/es/web/css/transition/index.md
@@ -3,8 +3,6 @@ title: transition
 slug: Web/CSS/transition
 ---
 
-{{ CSSRef("CSS Transitions") }}
-
 {{ SeeCompatTable() }}
 
 ## Sumario

--- a/files/es/web/css/tutorials/index.md
+++ b/files/es/web/css/tutorials/index.md
@@ -3,8 +3,6 @@ title: CSS Tutorials
 slug: Web/CSS/Tutorials
 ---
 
-{{CSSRef}}
-
 Aprender CSS puede ser una tarea desalentadora. Para ayudarte, hemos escrito numerosos **tutoriales acerca de CSS.** Algunos estan dirigidos a principiantes, y mientras que otros presentan complejas características para ser usadas por usuarios mas avanzados.
 
 Esta página enlista todo el contenido, con una descripción corta. Estan agrupados por grado de complejidad, para que escogas lo mas apropiado para tu nivel.

--- a/files/es/web/css/type_selectors/index.md
+++ b/files/es/web/css/type_selectors/index.md
@@ -3,7 +3,7 @@ title: Selectores de tipo
 slug: Web/CSS/Type_selectors
 ---
 
-{{CSSRef}}El selector de tipo CSS selecciona elementos por nombre de nodo. En otras palabras, selecciona todos los elementos del tipo dado dentro de un documento.
+El selector de tipo CSS selecciona elementos por nombre de nodo. En otras palabras, selecciona todos los elementos del tipo dado dentro de un documento.
 
 ```css
 /* Todos los elementos <a> */

--- a/files/es/web/css/universal_selectors/index.md
+++ b/files/es/web/css/universal_selectors/index.md
@@ -3,8 +3,6 @@ title: Selectores universales
 slug: Web/CSS/Universal_selectors
 ---
 
-{{CSSRef}}
-
 El **selector universal** CSS (`*`) coincide con elementos de cualquier tipo.
 
 ```css

--- a/files/es/web/css/url_value/index.md
+++ b/files/es/web/css/url_value/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/url_value
 original_slug: Web/CSS/url
 ---
 
-{{cssref}}
-
 La función de [CSS](/es/docs/Web/CSS) **`url()`** usa un [filtro SVG](/es/docs/Web/SVG/Element/filter) para cambiar la apariencia en la imagen de entrada.
 
 ## Sintaxis

--- a/files/es/web/css/user-modify/index.md
+++ b/files/es/web/css/user-modify/index.md
@@ -3,7 +3,7 @@ title: -moz-user-modify
 slug: Web/CSS/user-modify
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/user-select/index.md
+++ b/files/es/web/css/user-select/index.md
@@ -3,8 +3,6 @@ title: user-select
 slug: Web/CSS/user-select
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`user-select`** controla si el usuario puede seleccionar el texto. Esto no tiene ningún efecto en el contenido cargado bajo {{Glossary("Chrome", "chrome")}}, excepto en cuadros de texto.
 
 ```css

--- a/files/es/web/css/var/index.md
+++ b/files/es/web/css/var/index.md
@@ -3,7 +3,7 @@ title: var()
 slug: Web/CSS/var
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La función **`var()`** puede ser utilizada como valor en cualquier propiedad de un elemento. La función var() no puede ser usada como nombre de una propiedad, selector o cualquier cosa que no sea un valor de propiedad. (Hacerlo provoca normalmente una sintaxis erronea o bien un valor que no tiene conexión con la variable).
 

--- a/files/es/web/css/white-space/index.md
+++ b/files/es/web/css/white-space/index.md
@@ -3,8 +3,6 @@ title: white-space
 slug: Web/CSS/white-space
 ---
 
-{{CSSRef}}
-
 La propiedad **`white-space`** de CSS, determina cómo se maneja el espacio en blanco dentro de un elemento. Para hacer que las palabras se dividan _en sí mismas_, usa {{cssxref("overflow-wrap")}}, {{cssxref("word-break")}}, o {{cssxref("hyphens")}} en su lugar.
 
 #### Ejemplo

--- a/files/es/web/css/widows/index.md
+++ b/files/es/web/css/widows/index.md
@@ -3,8 +3,6 @@ title: widows
 slug: Web/CSS/widows
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`widows`** especifica el número minimo de lineas en un contenedor de bloques que se deben mostrar en la parte superior de la [pagina](/es/docs/Web/CSS/CSS_paged_media), region o [columna](/es/docs/Web/CSS/CSS_multicol_layout). Esta propiedad se usa normalmente para controlar como se producen las pausas.
 
 ```css

--- a/files/es/web/css/width/index.md
+++ b/files/es/web/css/width/index.md
@@ -3,8 +3,6 @@ title: width
 slug: Web/CSS/width
 ---
 
-{{CSSRef}}
-
 La propiedad [CSS](/es/docs/Web/CSS) **`width`** establece el ancho de un elemento.
 Por defecto, establece el ancho del [área de contenido](/es/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model#content_area),
 pero si el {{cssxref("box-sizing")}} se establece en `border-box`,

--- a/files/es/web/css/writing-mode/index.md
+++ b/files/es/web/css/writing-mode/index.md
@@ -3,7 +3,7 @@ title: writing-mode
 slug: Web/CSS/writing-mode
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 ## Resumen
 

--- a/files/es/web/css/z-index/index.md
+++ b/files/es/web/css/z-index/index.md
@@ -3,8 +3,6 @@ title: z-index
 slug: Web/CSS/z-index
 ---
 
-{{CSSRef}}
-
 ## Resumen
 
 La propiedad CSS `z-index` indica el orden de un elemento [posicionado](/es/docs/Web/CSS/position) y sus descendientes. Cuando varios elementos se superponen, los elementos con mayor valor z-index cubren aquellos con menor valor.

--- a/files/es/web/css/zoom/index.md
+++ b/files/es/web/css/zoom/index.md
@@ -3,7 +3,7 @@ title: zoom
 slug: Web/CSS/zoom
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
 La propiedad no estándar de [CSS](/es/docs/Web/CSS) **`zoom`** se puede usar para controlar el aumento de escala de un elemento. Si es posible, se debe usar {{cssxref("transform-function/scale", "transform: scale()")}} en lugar de esta propiedad. Sin embargo, a diferencia de los CSS Transforms, `zoom` afecta el tamaño del diseño del elemento.
 


### PR DESCRIPTION
### Description

remove `{{CSSRef}}` macros. Note that, I have not remove the description of `{{CSSRef}}` in page templates:

- MDN/Writing_guidelines/Page_structures/Page_types/CSS_module_landing_page_template
- MDN/Writing_guidelines/Page_structures/Page_types/CSS_property_page_template
- MDN/Writing_guidelines/Page_structures/Page_types/CSS_selector_page_template

Used regexp: `\{\{\s*CSSRef\s*(?:\(\s*['"][^'"]*['"]\s*\)\s*)?\s*\}\}\s*`

### Related issues and pull requests

Upstream PR: mdn/content#40356
