### PR TITLE
fix: incorrect description of -0 and +0 equality in map and set docs

### DIFF
--- a/files/ru/web/javascript/guide/keyed_collections/index.md
+++ b/files/ru/web/javascript/guide/keyed_collections/index.md
@@ -153,7 +153,7 @@ mySet2 = new Set([1, 2, 3, 4]);
 Сравнение на равенство ключей в `Map` objects или объектов в `Set` основано на "[same-value-zero algorithm](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-samevaluezero)":
 
 - алгоритм сравнения в целом совпадает с оператором `===`.
-- `-0` и `+0` считаются равными (в отличие от `===`).
+- `-0` и `+0` считаются равными.
 - {{jsxref("NaN")}} считается равным самому себе (в отличие от `===`).
 
 {{PreviousNext("Web/JavaScript/Guide/Indexed_Collections", "Web/JavaScript/Guide/Working_with_Objects")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Removed the incorrect phrase `(в отличие от ===)` (unlike ===) from the description of `-0` and `+0` equality in the SameValueZero algorithm section. 
The original English text is correct, but the Russian translation contains an error. 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This change corrects a misleading translation error, ensuring readers understand that `-0` and `+0` are equal in both `===` and SameValueZero.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
