### PR TITLE
[ja] Web/Performance/Guides/Navigation_and_resource_timings のtypoを修正

### DIFF
--- a/files/ja/web/performance/guides/navigation_and_resource_timings/index.md
+++ b/files/ja/web/performance/guides/navigation_and_resource_timings/index.md
@@ -178,7 +178,7 @@ let time = window.performance.timing;
         {{domxref("PerformanceTiming.domContentLoadedEventStart","domContentLoadedEventStart")}}
       </td>
       <td>
-        パーサーが <code><a href="/ja/docs/Web/API/Document/DOMContentLoaded_event">DOMContentLoaded</a><//code> イベントを送信する直前、つまり解釈直後に実行できるスクリプトがすべて実行された直後。
+        パーサーが <code><a href="/ja/docs/Web/API/Document/DOMContentLoaded_event">DOMContentLoaded</a></code> イベントを送信する直前、つまり解釈直後に実行できるスクリプトがすべて実行された直後。
       </td>
     </tr>
     <tr>
@@ -194,7 +194,7 @@ let time = window.performance.timing;
         {{domxref("PerformanceTiming.domComplete","domComplete")}}
       </td>
       <td>
-        パーサーがメイン文書での作業を完了した時点、すなわち <a href="/ja/docs/Web/API/Document/readyState"><code>Document.readyState</code></a> が <code>'complete'</code> に変わり、対応する <code><a href="/ja/docs/Web/API/Document/readystatechange_event">readystatechange</a><//code> イベントが発生した時点。
+        パーサーがメイン文書での作業を完了した時点、すなわち <a href="/ja/docs/Web/API/Document/readyState"><code>Document.readyState</code></a> が <code>'complete'</code> に変わり、対応する <code><a href="/ja/docs/Web/API/Document/readystatechange_event">readystatechange</a></code> イベントが発生した時点。
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

日本語版の「ナビゲーションおよびリソースタイミング」で一部の`<code>`の閉じタグが`<//code>`になっていたため`</code>`修正しました。
このtypoにより、現在`<code>`で囲われていないテキストまでコード表記で表示されています。

https://developer.mozilla.org/ja/docs/Web/Performance/Guides/Navigation_and_resource_timings

<img width="778" height="261" alt="image" src="https://github.com/user-attachments/assets/cca14be3-dede-42fb-8418-5fcebeff4919" />

ご確認お願い致します。

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
