### PR TITLE
ci(pr-test): use PWD instead of CONTENT_TRANSLATED_ROOT

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -153,7 +153,9 @@ jobs:
 
           ARGS=()
           for file in "${files_to_build[@]}"; do
-            ARGS+=("-f" "$CONTENT_TRANSLATED_ROOT/$file")
+              # Remove the 'files/' prefix from the path (bash-ism, removes shortest match from beginning)
+              file_without_prefix="${file#files/}"
+              ARGS+=("-f" "$CONTENT_TRANSLATED_ROOT/$file_without_prefix")
           done
 
           yarn rari build --no-basic --json-issues --data-issues "${ARGS[@]}"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -153,9 +153,7 @@ jobs:
 
           ARGS=()
           for file in "${files_to_build[@]}"; do
-              # Remove the 'files/' prefix from the path (bash-ism, removes shortest match from beginning)
-              file_without_prefix="${file#files/}"
-              ARGS+=("-f" "$CONTENT_TRANSLATED_ROOT/$file_without_prefix")
+              ARGS+=("-f" "$PWD/$file")
           done
 
           yarn rari build --no-basic --json-issues --data-issues "${ARGS[@]}"


### PR DESCRIPTION
### Description

Fixes a double `files/` path component introduced in the last change

