### PR TITLE
ci(pr-test): qualify files to build properly

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -153,7 +153,8 @@ jobs:
 
           ARGS=()
           for file in "${files_to_build[@]}"; do
-              ARGS+=("-f" "$PWD/$file")
+              file_without_prefix="${file#files/}"
+              ARGS+=("-f" "$CONTENT_TRANSLATED_ROOT/$file_without_prefix")
           done
 
           yarn rari build --no-basic --json-issues --data-issues "${ARGS[@]}"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes the pr-test workflow.

### Motivation

Fix the `pr-test` workflow. Since `$PWD` refers to mdn/content, it doesn't work without changing folders first.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Follow-up of https://github.com/mdn/translated-content/pull/28386.
