### PR TITLE
[ko] docs: 올바르지 않은 기본 뷰 전환 데모 링크 수정 및 MPA 데모 추가

### DIFF
--- a/files/ko/web/api/document/startviewtransition/index.md
+++ b/files/ko/web/api/document/startviewtransition/index.md
@@ -31,7 +31,7 @@ startViewTransition(callback)
 
 ### 기본 사용법
 
-[기본 뷰 전환 데모](https://mdn.github.io/dom-examples/view-transitions/)에서 `updateView()` 함수는 View Transitions API를 지원하는 브라우저와 지원하지 않는 브라우저 모두 처리합니다. 지원 브라우저에서는 반환 값에 대한 걱정없이 `startViewTransition()`을 호출하여 뷰 전환 과정을 설정합니다.
+[기본 뷰 전환 SPA 데모](https://mdn.github.io/dom-examples/view-transitions/spa/)에서 `updateView()` 함수는 View Transitions API를 지원하는 브라우저와 지원하지 않는 브라우저 모두 처리합니다. 지원 브라우저에서는 반환 값에 대한 걱정없이 `startViewTransition()`을 호출하여 뷰 전환 과정을 설정합니다.
 
 ```js
 function updateView(event) {

--- a/files/ko/web/api/view_transition_api/index.md
+++ b/files/ko/web/api/view_transition_api/index.md
@@ -30,7 +30,7 @@ View Transitions API는 필요한 DOM 변경 및 전환 애니메이션을 훨�
 
 ### 기본적인 뷰 전환 만들기
 
-예를 들어, SPA에는 탐색 링크가 클릭되거나 서버에서 업데이트가 푸시되는 등의 이벤트에 대한 응답으로 새 콘텐츠를 가져오고 DOM을 업데이트하는 기능이 포함될 수 있습니다. [기본 뷰 전환 데모](https://mdn.github.io/dom-examples/view-transitions/)에서는 클릭한 섬네일을 기반으로 새로운 전체 크기 이미지를 표시하는 `displayNewImage()` 함수로 이 기능을 단순화했습니다. 브라우저에서 지원하는 경우에만 View Transition API를 호출하는 `updateView()` 함수 안에 이 기능을 캡슐화했습니다.
+예를 들어, SPA에는 탐색 링크가 클릭되거나 서버에서 업데이트가 푸시되는 등의 이벤트에 대한 응답으로 새 콘텐츠를 가져오고 DOM을 업데이트하는 기능이 포함될 수 있습니다. [기본 뷰 전환 SPA 데모](https://mdn.github.io/dom-examples/view-transitions/spa/)에서는 클릭한 섬네일을 기반으로 새로운 전체 크기 이미지를 표시하는 `displayNewImage()` 함수로 이 기능을 단순화했습니다. 브라우저에서 지원하는 경우에만 View Transition API를 호출하는 `updateView()` 함수 안에 이 기능을 캡슐화했습니다.
 
 ```js
 function updateView(event) {
@@ -289,7 +289,8 @@ function spaNavigate(data) {
 
 ## 예제
 
-- [기본 뷰 전환 데모](https://mdn.github.io/dom-examples/view-transitions/): 이전 이미지와 새 이미지, 이전 캡션과 새 캡션 간에 별도의 전환이 있는 기본 이미지 갤러리 데모입니다.
+- [기본 뷰 전환 SPA 데모](https://mdn.github.io/dom-examples/view-transitions/spa/): 이전 이미지와 새 이미지, 이전 캡션과 새 캡션 간에 별도의 전환이 있는 기본 이미지 갤러리 데모입니다.
+- [기본 뷰 전환 MPA 데모](https://mdn.github.io/dom-examples/view-transitions/mpa/): 두 페이지 사이트 간 전환(MPA)의 사용법을 보여주는 샘플로, 두 페이지 사이를 이동할 때 사용자 지정 "위로 스와이프" 전환을 제공합니다.
 - [HTTP 203 playlist](https://http203-playlist.netlify.app/): 다양한 뷰 전환을 제공하는 보다 정교한 동영상 플레이어 데모 앱으로, [View Transitions API를 사용한 부드럽고 간단한 전환](https://developer.chrome.com/docs/web-platform/view-transitions/)에 대해 설명합니다.
 
 ## 명세서


### PR DESCRIPTION
### Description

[View Transitions API](https://developer.mozilla.org/ko/docs/Web/API/View_Transition_API) 문서에 올바르지 않은 데모 링크를 수정하였습니다.

- as-is: `https://mdn.github.io/dom-examples/view-transitions/`
- to-be: `https://mdn.github.io/dom-examples/view-transitions/spa`

예제 섹션을 [영어 문서](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API#examples)와 동일하게 SPA/MPA로 분리하고, 각 데모의 정확한 링크를 추가했습니다.

- as-is:
```
## 예제

- [기본 뷰 전환 데모](https://mdn.github.io/dom-examples/view-transitions/): 이전 이미지와 새 이미지, 이전 캡션과 새 캡션 간에 별도의 전환이 있는 기본 이미지 갤러리 데모입니다.
- [HTTP 203 playlist](https://http203-playlist.netlify.app/): 다양한 뷰 전환을 제공하는 보다 정교한 동영상 플레이어 데모 앱으로, [View Transitions API를 사용한 부드럽고 간단한 전환](https://developer.chrome.com/docs/web-platform/view-transitions/)에 대해 설명합니다.
```


- to-be:
```
## 예제

- [기본 뷰 전환 SPA 데모](https://mdn.github.io/dom-examples/view-transitions/spa/): 이전 이미지와 새 이미지, 이전 캡션과 새 캡션 간에 별도의 전환이 있는 기본 이미지 갤러리 데모입니다.
- [기본 뷰 전환 MPA 데모](https://mdn.github.io/dom-examples/view-transitions/mpa/): 두 페이지 사이트 간 전환(MPA)의 사용법을 보여주는 샘플로, 두 페이지 사이를 이동할 때 사용자 지정 "위로 스와이프" 전환을 제공합니다.
- [HTTP 203 playlist](https://http203-playlist.netlify.app/): 다양한 뷰 전환을 제공하는 보다 정교한 동영상 플레이어 데모 앱으로, [View Transitions API를 사용한 부드럽고 간단한 전환](https://developer.chrome.com/docs/web-platform/view-transitions/)에 대해 설명합니다.
```



### Motivation
- 올바르지 않은 데모 링크를 수정하여 독자가 올바른 데모 링크로 갈 수 있게 수정하였습니다.
- 예제 섹션을 영문 문서와 동일하게 SPA/MPA를 분리해 안내함으로써 독자가 자신의 애플리케이션 유형(SPA/MPA)에 맞는 데모를 참고할 수 있습니다.



### Additional details

| 수정 전 링크 | 수정 후 링크 |
|:------:|:-----:|
|  <img width="1426" height="680" alt="스크린샷 2025-08-30 오후 4 56 01" src="https://github.com/user-attachments/assets/0534d894-b269-4d82-a49b-6790d4b7ec01" /> |   <img width="1518" height="768" alt="스크린샷 2025-08-30 오후 4 56 18" src="https://github.com/user-attachments/assets/42065d41-b248-47ec-9dbb-67faab222f5f" />|


