### PR TITLE
[zh-cn] fix wrong order

### DIFF
--- a/files/zh-cn/web/html/reference/elements/table/index.md
+++ b/files/zh-cn/web/html/reference/elements/table/index.md
@@ -240,12 +240,12 @@ tfoot td {
     <th>名</th>
   </tr>
   <tr>
-    <td>John</td>
     <td>Doe</td>
+    <td>John</td>
   </tr>
   <tr>
-    <td>Jane</td>
     <td>Doe</td>
+    <td>Jane</td>
   </tr>
 </table>
 


### PR DESCRIPTION
In the original John Doe / Jane Doe table with headers in the more basic tables part, the first name and family name order was messed up.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
I changed the order from:
|姓|名|
|---|---|
|John|Doe|
|Jane|Doe|  

to this:

|姓|名|
|---|---|
|Doe|John|
|Doe|Jane|  

since 姓 means family name, and 名 means first name in Chinese..

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
As a native Chinese speaker, I find the order very strange, and wish to improve it so others don't get confused.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Original MDN Doc: https://developer.mozilla.org/zh-CN/docs/Web/HTML/Reference/Elements/table#%E6%9B%B4%E5%A4%9A%E7%AE%80%E5%8D%95%E7%A4%BA%E4%BE%8B

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

I didn't see any related issues and/or pull requests.
