### PR TITLE
[ja-JP] Fix typo in responseXML documentation

### DIFF
--- a/files/ja/web/api/xmlhttprequest/responsexml/index.md
+++ b/files/ja/web/api/xmlhttprequest/responsexml/index.md
@@ -21,7 +21,7 @@ l10n:
 
 ### 値
 
-{{domxref("XMLHttpRequest")}} を用いて受け取った XML または HTML を解釈した {{domxref("Document")}}、またはデータを受け取っていなかったり、データが XML/HTML でな買ったりした場合は `null`
+{{domxref("XMLHttpRequest")}} を用いて受け取った XML または HTML を解釈した {{domxref("Document")}}、またはデータを受け取っていなかったり、データが XML/HTML でなかったりした場合は `null`
 
 ### 例外
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

「でな買ったりした」は日本語としておかしいので「でなかったりした」に修正しました。

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

読み手が違和感を感じずに読むことができるようになります。

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://developer.mozilla.org/ja/docs/Web/API/XMLHttpRequest/responseXML#:~:text=%E3%81%8C%20XML/HTML-,%E3%81%A7%E3%81%AA%E8%B2%B7%E3%81%A3%E3%81%9F%E3%82%8A%E3%81%97%E3%81%9F,-%E5%A0%B4%E5%90%88%E3%81%AF%20null

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
