### PR TITLE
ja: fix typo in globalThis

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/globalthis/index.md
+++ b/files/ja/web/javascript/reference/global_objects/globalthis/index.md
@@ -18,7 +18,7 @@ console.log(canMakeHTTPRequest());
 // Expected output (in a browser): true
 ```
 
-## 阿智
+## 値
 
 グローバルの `this` オブジェクトです。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

[英語ではValue](https://github.com/mdn/content/blob/4b20a85d35f458a0880ef9de9babe82b42f5dc76/files/en-us/web/javascript/reference/global_objects/globalthis/index.md?plain=1#L22)なので、「値」のtypoであると思われます

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
