### PR TITLE
zh-cn: correct the steps of using `prettier`

### DIFF
--- a/files/zh-cn/learn_web_development/getting_started/environment_setup/command_line/index.md
+++ b/files/zh-cn/learn_web_development/getting_started/environment_setup/command_line/index.md
@@ -422,12 +422,8 @@ Stdin is read if it is piped to Prettier and no files are given.
 
 ```js
 const myObj = {
-  a: 1,
-  b: { c: 2 },
-};
-function printMe(obj) {
-  console.log(obj.b.c);
-}
+  a: 1,b: { c: 2 },};
+function printMe(obj) {console.log(obj.b.c);}
 printMe(myObj);
 ```
 

--- a/files/zh-cn/learn_web_development/getting_started/environment_setup/command_line/index.md
+++ b/files/zh-cn/learn_web_development/getting_started/environment_setup/command_line/index.md
@@ -416,78 +416,76 @@ Stdin is read if it is piped to Prettier and no files are given.
 
 让我们快速演示一下 Prettier，这样你就可以看到它是如何工作的。
 
-首先，在文件系统中容易找到的地方创建一个新目录。可能是一个叫做`prettier-test` 在你的 `Desktop`.
+1. 首先，在文件系统中容易找到的地方创建一个新目录。可能是你的 `Desktop` 上的一个叫做 `prettier-test` 的目录。
 
-现在将以下代码保存在一个名为`index.js`, 在测试目录中：
+2. 现在将以下代码保存在测试目录的一个名为 `index.js` 新文件中：
 
-```js
-const myObj = {
-  a: 1,b: { c: 2 },};
-function printMe(obj) {console.log(obj.b.c);}
-printMe(myObj);
-```
+   ```js-nolint
+   const myObj = {
+   a:1,b:{c:2}}
+   function printMe(obj){console.log(obj.b.c)}
+   printMe(myObj)
+   ```
 
-我们可以在代码基上运行得更好，以检查我们的代码是否需要调整。cd 到你的目录中，并尝试运行此命令：
+3. 我们可以在代码基上运行得更好，以检查我们的代码是否需要调整。`cd` 到你的目录中，并尝试运行此命令：
 
-```bash
-prettier --check index.js
-```
+   ```bash
+   npx prettier --check index.js
+   ```
 
-你的产出应该是：
+   你的产出应该是：
 
-```bash
-Checking formatting...
-index.js
-Code style issues found in the above file(s). Forgot to run Prettier?
-```
+   ```bash
+   Checking formatting...
+   index.js
+   Code style issues found in the above file(s). Forgot to run Prettier?
+   ```
 
-有些代码样式是可以修改的。没有问题。添加 `--write` option to the prettier 命令将修复这些问题，让我们专注于实际编写有用的代码。
+4. 有些代码样式是可以修改的。没有问题。为 `prettier` 命令添加 `--write` 选项将修复这些问题，让我们专注于实际编写有用的代码。现在尝试运行这个版本的命令：
 
-现在尝试运行这个版本的命令：
+   ```bash
+   npx prettier --write index.js
+   ```
 
-```bash
-prettier --write index.js
-```
+   你可能得到这样的输出：
 
-你可能得到这样的输出：
+   ```bash
+   Checking formatting...
+   index.js
+   Code style issues fixed in the above file(s).
+   ```
 
-```bash
-Checking formatting...
-index.js
-Code style issues fixed in the above file(s).
-```
+   但更重要的是，如果你回头看你的 JavaScript 文件，你会发现它被重新格式化成这样：
 
-但更重要的是，如果你回头看你的 JavaScript 文件，你会发现它被重新格式化成这样：
+   ```js
+   const myObj = {
+     a: 1,
+     b: { c: 2 },
+   };
+   function printMe(obj) {
+     console.log(obj.b.c);
+   }
+   printMe(myObj);
+   ```
 
-```js
-const myObj = {
-  a: 1,
-  b: { c: 2 },
-};
-function printMe(obj) {
-  console.log(obj.b.c);
-}
-printMe(myObj);
-```
+根据你的工作流（或你选择的工作流），你可以将其作为流程的自动化部分。自动化确实是工具的优势所在;我们的个人偏好是那种无需配置任何东西就能“自动发生”的自动化。
 
-根据你的工作流 (或你选择的工作流)，你可以将其作为流程的自动化部分。自动化确实是工具的优势所在;我们的个人偏好是那种无需配置任何东西就能“自动发生”的自动化。
+使用 Prettier 有许多实现自动化的方法，尽管它们超出了本文的范围，但是有一些很好的在线资源可以提供帮助（已经链接到其中一些）。你可以调用更漂亮的：
 
-使用 Prettier 有许多实现自动化的方法，尽管它们超出了本文的范围，但是有一些很好的在线资源可以提供帮助 (已经链接到其中一些)。你可以调用更漂亮的：
+- 在将代码提交到 git 存储库之前，使用 [Husky](https://github.com/typicode/husky)。
+- 当你在代码编辑器中点击“保存”的时候，无论是 [VS Code](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) 或 [Sublime Text](https://packagecontrol.io/packages/JsPrettier)。
+- 作为持续集成检查的一部分，可以使用例如 [Github Actions](https://github.com/features/actions) 之类的工具。
 
-- 在将代码提交到 git 存储库之前，使用[Husky](https://github.com/typicode/husky).
-- 当你在代码编辑器中点击“保存”的时候，无论是[VS Code](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode), [Atom](https://atom.io/packages/prettier-atom), 或[Sublime Text](https://packagecontrol.io/packages/JsPrettier).
-- 作为持续集成检查的一部分，可以使用以下工具[Github Actions](https://github.com/features/actions).
-
-我们个人的偏好是第二个当使用 say VS 代码时，Prettier 会启动并清理每次我们点击保存时需要做的格式化。关于以不同方式使用 Prettier，你可以在 [Prettier docs](https://prettier.io/docs/en/).
+我们个人的偏好是第二个当使用 VS Code 时，Prettier 会启动并清理每次我们点击保存时需要做的格式化。你可以在 [Prettier 文档](https://prettier.io/docs/)中找到更多有关使用 Prettier 的不同方法。
 
 ## 尝试其他的工具
 
 如果你想尝试更多的工具，这里有一个简短的列表，很有趣的尝试：
 
-- [`bat`](https://github.com/sharkdp/bat) — 一个更好的 `cat` (`cat` 用于打印文件内容）。
-- [`prettyping`](http://denilson.sa.nom.br/prettyping/) — `ping`在命令行上，但是是可视化的 (ping 是检查服务器是否有响应的有用工具)。
-- [`htop`](http://hisham.hm/htop/) —进程查看器，当某些东西使你的 CPU 风扇的行为像一个喷气发动机，并且你想要识别出错的程序时，它非常有用。
-- [`tldr`](https://tldr.sh/#installation) —在本章前面提到的，但是可以作为命令行工具使用。
+- [`bat`](https://github.com/sharkdp/bat)——一个更好的 `cat`（`cat` 用于打印文件内容）。
+- [`prettyping`](http://denilson.sa.nom.br/prettyping/)——命令行中的 `ping` 命令，但是是可视化的（ping 是检查服务器是否有响应的有用工具）。
+- [`htop`](http://hisham.hm/htop/)——进程查看器，当某些东西使你的 CPU 风扇的行为像一个喷气发动机，并且你想要识别出错的程序时，它非常有用。
+- [`tldr`](https://tldr.sh/#installation)——在本章前面提到的，但是可以作为命令行工具使用。
 
 注意，上面的一些建议可能需要使用 npm 进行安装，就像我们使用 Prettier 所做的那样。
 


### PR DESCRIPTION
fix first index.js (it was the same as the version after --write)

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

    The version of index.js before 'prettier --check' already uses the Prettier code style, which is different from the English type. So, I fixed it to make sure that it was a bad code style before.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
