### PR TITLE
Fix typo on ja IME event notes in keydown_event documentation

### DIFF
--- a/files/ja/web/api/element/keydown_event/index.md
+++ b/files/ja/web/api/element/keydown_event/index.md
@@ -102,7 +102,7 @@ eventTarget.addEventListener("keydown", (event) => {
 ```
 
 > [!NOTE]
-> IME を開くための最初の文字を入力したときに、 `compositionstart` が `keydown` の後に発行されることがあります。また、 IME を閉じられり最後の文字を入力したときに、 `compositionend` が `keydown` の前に発行されることがあります。これらの場合、イベントが変換の一部であっても、`isComposing` は false となります。しかし、これらの場合でも {{domxref("KeyboardEvent.keyCode")}} は `229` のままなので、非推奨ではあるものの、やはり `keyCode` も調べることをお勧めします。
+> IME を開くための最初の文字を入力したときに、 `compositionstart` が `keydown` の後に発行されることがあります。また、 IME を閉じる最後の文字を入力したときに、 `compositionend` が `keydown` の前に発行されることがあります。これらの場合、イベントが変換の一部であっても、`isComposing` は false となります。しかし、これらの場合でも {{domxref("KeyboardEvent.keyCode")}} は `229` のままなので、非推奨ではあるものの、やはり `keyCode` も調べることをお勧めします。
 
 ## 仕様書
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

SSIA

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

To make a clear sentence. 「閉じられり」 is understandable, but it is grammatically incorrect.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Source text (en-US):

> compositionend may fire before keydown when typing the last character that closes the IME

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

N/A

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
