### PR TITLE
ci(pr-test): use fred

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -158,7 +158,11 @@ jobs:
           done
 
           yarn rari build --no-basic --json-issues --data-issues "${ARGS[@]}"
-          yarn yari-render-html
+
+          # Workaround, as fred-ssr doesn't copy assets.
+          cp -vR node_modules/@mdn/fred/out/. "$BUILD_OUT_ROOT"
+
+          yarn fred-ssr
 
           echo "Disk usage size of the build"
           du -sh $BUILD_OUT_ROOT


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updates the `pr-test` workflow to use fred instead of yari.

### Motivation

Ensures that PR reviewers have an experience that is consistent with the deployed MDN site.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/667.

Same as:

- https://github.com/mdn/content/pull/40961
