### PR TITLE
[ja] 誤字訂正：Errorクラスのconstructorの誤記を訂正

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/error/index.md
+++ b/files/ja/web/javascript/reference/global_objects/error/index.md
@@ -55,7 +55,7 @@ JavaScript には、一般的な `Error` コンストラクターの他に、中
 これらのプロパティは `Error.prototype` で定義されており、すべての `Error` インスタンスで共有されます。
 
 - {{jsxref("Object/constructor", "Error.prototype.constructor")}}
-  - : このインスタンスオブジェクトを作成したコンストラクター関数です。 `Error` インスタンスの場合、初期値は {{jsxref("Error/Error", "Array")}} コンストラクターです。
+  - : このインスタンスオブジェクトを作成したコンストラクター関数です。 `Error` インスタンスの場合、初期値は {{jsxref("Error/Error", "Error")}} コンストラクターです。
 - {{jsxref("Error.prototype.name")}}
   - : エラーの名称を表します。`Error.prototype.name` の場合、初期値は `"Error"` です。 {{jsxref("TypeError")}} や {{jsxref("SyntaxError")}} のようなサブクラスは各自の `name` プロパティを提供します。
 - {{jsxref("Error.prototype.stack")}} {{non-standard_inline}}


### PR DESCRIPTION
### Description

日本語版の [Error クラス](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Error)で、[インスタンスプロパティ](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Error#%E3%82%A4%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%B3%E3%82%B9%E3%83%97%E3%83%AD%E3%83%91%E3%83%86%E3%82%A3)の `Error.prototype.constructor` の説明の最後で

> `Error` インスタンスの場合、初期値は [Array](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Error/Error) コンストラクターです。

と、リンク先は `Error` になっていますが、表記が `Array` になっています。

英語版の [Error クラス](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) では

> For `Error` instances, the initial value is the [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error) constructor.

のようになっているので、誤記だと判断しました。

お手数ですが、ご確認をお願いします。