### PR TITLE
[ko] fix typo in Promises document

### DIFF
--- a/files/ko/learn_web_development/extensions/async_js/promises/index.md
+++ b/files/ko/learn_web_development/extensions/async_js/promises/index.md
@@ -228,7 +228,7 @@ Promise는 이벤트 리스너와 유사하지만 몇 가지 다른점이 있습
    document.body.appendChild(image);
    ```
 
-   여기서 우리는 두 번째 Promise가 fulfills일 때 반횐된 Blob을 매개변수로 전달받는 {{domxref("URL.createObjectURL()")}} 메서드를 실행하고 있습니다. 이렇게 하면 오브젝트가 가지고있는 URL이 반환됩니다. 그 다음 {{htmlelement("img")}} 엘리먼트를 만들고, 반환된 URL을 `src` 속성에 지정하여 DOM에 추가합니다. 이렇게 하면 페이지에 그림이 표시됩니다.
+   여기서 우리는 두 번째 Promise가 fulfills일 때 반환된 Blob을 매개변수로 전달받는 {{domxref("URL.createObjectURL()")}} 메서드를 실행하고 있습니다. 이렇게 하면 오브젝트가 가지고있는 URL이 반환됩니다. 그 다음 {{htmlelement("img")}} 엘리먼트를 만들고, 반환된 URL을 `src` 속성에 지정하여 DOM에 추가합니다. 이렇게 하면 페이지에 그림이 표시됩니다.
 
 If you save the HTML file you've just created and load it in your browser, you'll see that the image is displayed in the page as expected. Good work!
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Corrected a typo in the MDN official documentation. Changed '반횐' to '반환'.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

- This change improves the readability and accuracy of the document by correcting a typo.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details


<img width="360" height="180" alt="image" src="https://github.com/user-attachments/assets/1531987c-5928-4a60-9219-1ac9cf1c8872" />


<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

- none

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
