### PR TITLE
fr: update all `Web/CSS/` ::-moz, ::-webkit and ::pseudo-elements pages

### DIFF
--- a/files/fr/_redirects.txt
+++ b/files/fr/_redirects.txt
@@ -4554,10 +4554,7 @@
 /fr/docs/Web/CSS/:-moz-ui-invalid	/fr/docs/Web/CSS/:user-invalid
 /fr/docs/Web/CSS/:-ms-input-placeholder	/fr/docs/Web/CSS/:placeholder-shown
 /fr/docs/Web/CSS/:-webkit-autofill	/fr/docs/Web/CSS/:autofill
-/fr/docs/Web/CSS/::-moz-page	/fr/docs/orphaned/Web/CSS/::-moz-page
-/fr/docs/Web/CSS/::-moz-page-sequence	/fr/docs/orphaned/Web/CSS/::-moz-page-sequence
 /fr/docs/Web/CSS/::-moz-placeholder	/fr/docs/Web/CSS/::placeholder
-/fr/docs/Web/CSS/::-moz-scrolled-page-sequence	/fr/docs/orphaned/Web/CSS/::-moz-scrolled-page-sequence
 /fr/docs/Web/CSS/::-webkit-file-upload-button	/fr/docs/Web/CSS/::file-selector-button
 /fr/docs/Web/CSS/::-webkit-input-placeholder	/fr/docs/Web/CSS/::placeholder
 /fr/docs/Web/CSS/::cue-region	/fr/docs/Web/CSS/::cue

--- a/files/fr/_redirects.txt
+++ b/files/fr/_redirects.txt
@@ -314,7 +314,6 @@
 /fr/docs/CSS/-moz-zoom-out	/fr/docs/Web/CSS/cursor
 /fr/docs/CSS/:-moz-first-node	/fr/docs/Web/CSS/:-moz-first-node
 /fr/docs/CSS/:-moz-last-node	/fr/docs/Web/CSS/:-moz-last-node
-/fr/docs/CSS/:-moz-locale-dir(ltr)	/fr/docs/Web/CSS/:-moz-locale-dir_ltr
 /fr/docs/CSS/:-moz-only-whitespace	/fr/docs/Web/CSS/:-moz-only-whitespace
 /fr/docs/CSS/:-moz-placeholder	/fr/docs/Web/CSS/:placeholder-shown
 /fr/docs/CSS/::-moz-progress-bar	/fr/docs/Web/CSS/::-moz-progress-bar
@@ -4551,10 +4550,6 @@
 /fr/docs/Web/CSS/-webkit-overflow-scrolling	/fr/docs/orphaned/Web/CSS/-webkit-overflow-scrolling
 /fr/docs/Web/CSS/-webkit-print-color-adjust	/fr/docs/Web/CSS/print-color-adjust
 /fr/docs/Web/CSS/:-moz-focusring	/fr/docs/Web/CSS/:focus-visible
-/fr/docs/Web/CSS/:-moz-list-bullet	/fr/docs/Web/CSS/::-moz-list-bullet
-/fr/docs/Web/CSS/:-moz-list-number	/fr/docs/Web/CSS/::-moz-list-number
-/fr/docs/Web/CSS/:-moz-locale-dir(ltr)	/fr/docs/Web/CSS/:-moz-locale-dir_ltr
-/fr/docs/Web/CSS/:-moz-locale-dir(rtl)	/fr/docs/Web/CSS/:-moz-locale-dir_rtl
 /fr/docs/Web/CSS/:-moz-placeholder	/fr/docs/Web/CSS/:placeholder-shown
 /fr/docs/Web/CSS/:-moz-ui-invalid	/fr/docs/Web/CSS/:user-invalid
 /fr/docs/Web/CSS/:-ms-input-placeholder	/fr/docs/Web/CSS/:placeholder-shown
@@ -4565,7 +4560,7 @@
 /fr/docs/Web/CSS/::-moz-scrolled-page-sequence	/fr/docs/orphaned/Web/CSS/::-moz-scrolled-page-sequence
 /fr/docs/Web/CSS/::-webkit-file-upload-button	/fr/docs/Web/CSS/::file-selector-button
 /fr/docs/Web/CSS/::-webkit-input-placeholder	/fr/docs/Web/CSS/::placeholder
-/fr/docs/Web/CSS/::cue-region	/fr/docs/conflicting/Web/API/WebVTT_API
+/fr/docs/Web/CSS/::cue-region	/fr/docs/Web/CSS/::cue
 /fr/docs/Web/CSS/:after	/fr/docs/Web/CSS/::after
 /fr/docs/Web/CSS/:after_|_::after	/fr/docs/Web/CSS/::after
 /fr/docs/Web/CSS/:any	/fr/docs/Web/CSS/:is
@@ -4574,7 +4569,7 @@
 /fr/docs/Web/CSS/:matches	/fr/docs/Web/CSS/:is
 /fr/docs/Web/CSS/:nth-col	/fr/docs/Web/CSS/:nth-of-type
 /fr/docs/Web/CSS/:nth-last-col	/fr/docs/Web/CSS/:nth-last-of-type
-/fr/docs/Web/CSS/:target-within	/fr/docs/conflicting/Web/CSS_d54dd63012f78ca10cf513755d7aecb96294c42dbd23a285b37ae69a38cbb4dc
+/fr/docs/Web/CSS/:target-within	/fr/docs/Web/CSS/:target
 /fr/docs/Web/CSS/:visited_et_la_vie_privée	/fr/docs/Web/CSS/CSS_selectors/Privacy_and_the_visited_selector
 /fr/docs/Web/CSS/@font-face/font-variant	/fr/docs/Web/CSS/@font-face
 /fr/docs/Web/CSS/@media/aural	/fr/docs/conflicting/Web/CSS/@media
@@ -4877,8 +4872,6 @@
 /fr/docs/Web/CSS/Règles_@	/fr/docs/Web/CSS/CSS_syntax/At-rule
 /fr/docs/Web/CSS/Scaling_of_SVG_backgrounds	/fr/docs/Web/CSS/CSS_backgrounds_and_borders/Scaling_of_SVG_backgrounds
 /fr/docs/Web/CSS/Shorthand_properties	/fr/docs/Web/CSS/CSS_cascade/Shorthand_properties
-/fr/docs/Web/CSS/Specificity	/fr/docs/Web/CSS/CSS_cascade/Specificity
-/fr/docs/Web/CSS/Spécificité	/en-US/docs/Learn_web_development/Core/Styling_basics/Handling_conflicts
 /fr/docs/Web/CSS/Syntax	/fr/docs/Web/CSS/CSS_syntax/Syntax
 /fr/docs/Web/CSS/Syntaxe	/en-US/docs/Learn_web_development/Core/Styling_basics/Getting_started
 /fr/docs/Web/CSS/Syntaxe_de_définition_des_valeurs	/fr/docs/Web/CSS/CSS_Values_and_Units/Value_definition_syntax

--- a/files/fr/web/css/_colon_target/index.md
+++ b/files/fr/web/css/_colon_target/index.md
@@ -2,7 +2,7 @@
 title: :target
 slug: Web/CSS/:target
 l10n:
-  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
+  sourceCommit: b460458fa125f4ee252d01466c1390d16ba19215
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:target`** permet de cibler l'unique élément (s'il existe) dont l'attribut [`id`](/fr/docs/Web/HTML/Reference/Global_attributes#id) correspond au fragment d'identifiant de l'URI du document.

--- a/files/fr/web/css/_colon_target/index.md
+++ b/files/fr/web/css/_colon_target/index.md
@@ -37,7 +37,7 @@ L'élément suivant sera donc ciblé par le sélecteur `:target` avec l'URL pré
 
 ## Description
 
-Quand un document HTML est chargé, le navigateur définit son élément cible. L'élément est identifié à l'aide de l'identifiant de fragment d'URL. Sans l'identifiant de fragment d'URL, le document n'a pas d'élément cible. La pseudo-classe `:target` permet de mettre en forme l'élément cible du document. L'élément peut être mis au point, mis en surbrillance, animé, etc.
+Quand un document HTML est chargé, le navigateur définit son élément cible. L'élément est identifié à l'aide de l'identifiant de fragment d'URL. Sans l'identifiant de fragment d'URL, le document n'a pas d'élément cible. La pseudo-classe `:target` permet de mettre en forme l'élément cible du document. L'élément peut être mis au point, mis en évidence, animé, etc.
 
 L'élément cible est défini au chargement du document et lors des appels de méthodes [`history.back()`](/fr/docs/Web/API/History/back), [`history.forward()`](/fr/docs/Web/API/History/forward) et [`history.go()`](/fr/docs/Web/API/History/forward). Mais il n'est _pas_ modifié lorsque les méthodes [`history.pushState()`](/fr/docs/Web/API/History/pushState) et [`history.replaceState()`](/fr/docs/Web/API/History/replaceState) sont appelées.
 
@@ -48,7 +48,7 @@ L'élément cible est défini au chargement du document et lors des appels de m�
 
 ### Une table des matières
 
-La pseudo-classe `:target` peut être utilisée pour mettre en surbrillance la partie d'une page qui a été liée à partir d'une table des matières.
+La pseudo-classe `:target` peut être utilisée pour mettre en évidence la partie d'une page qui a été liée à partir d'une table des matières.
 
 #### HTML
 
@@ -90,7 +90,7 @@ p:target::before {
   margin-right: 0.25em;
 }
 
-/* Met en surbrillance les éléments en italique dans l'élément cible */
+/* Met en évidence les éléments en italique dans l'élément cible */
 p:target i {
   color: red;
 }
@@ -111,3 +111,4 @@ p:target i {
 ## Voir aussi
 
 - [Utiliser la pseudo-classe `:target` dans les sélecteurs](/fr/docs/Web/CSS/CSS_selectors/Using_the_:target_pseudo-class_in_selectors)
+- {{cssxref("::target-text")}} (pour mettre en évidence les fragments de texte)

--- a/files/fr/web/css/_doublecolon_-moz-color-swatch/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-color-swatch/index.md
@@ -1,18 +1,24 @@
 ---
 title: ::-moz-color-swatch
 slug: Web/CSS/::-moz-color-swatch
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) **`::-moz-color-swatch`** est [un pseudo-élément spécifique à Mozilla](/fr/docs/Web/CSS/Mozilla_Extensions) qui représente la couleur sélectionnée d'un élément {{HTMLElement("input")}} avec `type="color"`.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-moz-color-swatch`** est [une extension de Mozilla](/fr/docs/Web/CSS/Mozilla_Extensions) qui représente la couleur sélectionnée d'un élément {{HTMLElement("input")}} avec `type="color"`.
 
 > [!NOTE]
 > Utiliser `::-moz-color-swatch` sur tout autre élément qu'un `<input type="color">` n'aura aucun effet.
 
 ## Syntaxe
 
-{{csssyntax}}
+```css
+::-moz-color-swatch {
+  /* ... */
+}
+```
 
 ## Exemples
 
@@ -37,7 +43,7 @@ input[type="color"]::-moz-color-swatch {
 
 ## Specifications
 
-Ce pseudo-élément est spécifique à Gecko et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -45,5 +51,5 @@ Ce pseudo-élément est spécifique à Gecko et ne fait partie d'aucune spécifi
 
 ## Voir aussi
 
-- Les pseudo-éléments semblables utilisés par les autres navigateurs :
+- Les pseudo-éléments semblables utilisés par les autres navigateurs&nbsp;:
   - {{cssxref("::-webkit-color-swatch")}} pris en charge par WebKit et Blink (utilisés par Safari, Chrome et Opera)

--- a/files/fr/web/css/_doublecolon_-moz-focus-inner/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-focus-inner/index.md
@@ -2,20 +2,22 @@
 title: ::-moz-focus-inner
 slug: Web/CSS/::-moz-focus-inner
 l10n:
-  sourceCommit: 257486f64b2472dda4996a4ea7b6b5305e46f863
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{non-standard_header}}{{deprecated_header}}
 
-Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-moz-focus-inner`** est [une extension spécifique à Mozilla](/fr/docs/Web/CSS/Mozilla_Extensions) qui représente le contour interne pour le focus sur les éléments [`<button>`](/fr/docs/Web/HTML/Reference/Elements/button), [`<input type="button">`](/fr/docs/Web/HTML/Reference/Elements/input/button), [`<input type="submit">`](/fr/docs/Web/HTML/Reference/Elements/input/submit), [`<input type="reset">`](/fr/docs/Web/HTML/Reference/Elements/input/reset), et [`<input type="color">`](/fr/docs/Web/HTML/Reference/Elements/input/color).
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-moz-focus-inner`** est [une extension de Mozilla](/fr/docs/Web/CSS/Mozilla_Extensions) qui représente le contour interne pour le focus sur l'élément {{HTMLElement("button")}} ainsi que les boutons {{HTMLElement("input/button","button")}}, {{HTMLElement("input/submit","submit")}}, {{HTMLElement("input/reset","reset")}} et {{HTMLElement("input/color","color")}} de l'élément {{HTMLElement("input")}}.
 
 > [!NOTE]
 > Utiliser `::-moz-focus-inner` sur un autre élément que les types de boutons pris en charge n'aura aucun effet.
 
 ## Syntaxe
 
-```
-::-moz-focus-inner
+```css
+::-moz-focus-inner {
+  /* ... */
+}
 ```
 
 ## Exemple
@@ -30,6 +32,9 @@ Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) 
 
 ```css
 button::-moz-focus-inner,
+input[type="color"]::-moz-focus-inner,
+input[type="reset"]::-moz-focus-inner,
+input[type="button"]::-moz-focus-inner,
 input[type="submit"]::-moz-focus-inner {
   padding-block-start: 0px;
   padding-inline-end: 2px;
@@ -45,18 +50,15 @@ input[type="submit"]::-moz-focus-inner {
 
 ## Spécifications
 
-Il s'agit d'un pseudo-élément spécifique, qui n'est spécifié dans aucun standard.
-
-## Compatibilité des navigateurs
-
-{{Compat}}
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Voir aussi
 
 - [Les extensions CSS spécifiques à Mozilla](/fr/docs/Web/CSS/Mozilla_Extensions)
-- [`-moz-user-focus`](/fr/docs/Web/CSS/-moz-user-focus)
-- Les sélecteurs CSS associés
-  - [`:-moz-focusring`](/fr/docs/Web/CSS/:focus-visible)
-  - [`:focus`](/fr/docs/Web/CSS/:focus)
-  - [`:focus-visible`](/fr/docs/Web/CSS/:focus-visible)
-  - [`:focus-within`](/fr/docs/Web/CSS/:focus-within)
+- Propriétés CSS associées&nbsp;:
+  - {{cssxref("-moz-user-focus")}}
+
+- Les sélecteurs CSS associés&nbsp;:
+  - {{cssxref(":focus")}}
+  - {{cssxref(":focus-visible")}}
+  - {{cssxref(":focus-within")}}

--- a/files/fr/web/css/_doublecolon_-moz-list-bullet/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-list-bullet/index.md
@@ -1,16 +1,20 @@
 ---
 title: ::-moz-list-bullet
 slug: Web/CSS/::-moz-list-bullet
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}{{SeeCompatTable}}
 
-Le [pseudo-élément CSS](/fr/docs/Web/CSS/Pseudo-elements) **`::-moz-list-bullet`** est [une extension non-standard de Mozilla](/fr/docs/Web/CSS/Mozilla_Extensions) utilisé pour appliquer un style aux puces des éléments d'une liste non ordonnée (autrement dit, pour un élément [`<li>`](/fr/docs/Web/HTML/Reference/Elements/li)) contenu dans un élément [`<ul>`](/fr/docs/Web/HTML/Reference/Elements/ul)).
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-moz-list-bullet`** est [une extension de Mozilla](/fr/docs/Web/CSS/Mozilla_Extensions) qui représente le marqueur (généralement une puce) d'un élément de liste ({{htmlelement("li")}}) dans une liste non ordonnée ({{htmlelement("ul")}}).
 
 ## Syntaxe
 
 ```css
-li::-moz-list-bullet
+li::-moz-list-bullet {
+  /* ... */
+}
 ```
 
 ## Exemples
@@ -38,13 +42,17 @@ li::-moz-list-bullet
 
 #### Résultat
 
-{{EmbedLiveSample('')}}
+{{EmbedLiveSample('mettre_en_forme_les_puces_de_liste')}}
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à Gecko/Mozilla et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 
-- [`:-moz-list-number`](/fr/docs/Web/CSS/::-moz-list-number)
-- [`::marker`](/fr/docs/Web/CSS/::marker)
+- {{cssxref("::-moz-list-number")}}
+- {{cssxref("::marker")}}

--- a/files/fr/web/css/_doublecolon_-moz-list-number/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-list-number/index.md
@@ -48,5 +48,5 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à Gecko/Mozilla 
 
 ## Voir aussi
 
-- {{cssxref(":-moz-list-bullet")}}
+- {{cssxref("::-moz-list-bullet")}}
 - {{cssxref("::marker")}}

--- a/files/fr/web/css/_doublecolon_-moz-list-number/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-list-number/index.md
@@ -1,28 +1,23 @@
 ---
 title: ::-moz-list-number
 slug: Web/CSS/::-moz-list-number
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}{{SeeCompatTable}}
 
-Le [pseudo-élément CSS](/fr/docs/Web/CSS/Pseudo-elements) **`::-moz-list-number`** permet de personnaliser l'apparence des numéros des éléments de liste ({{HTMLElement("li")}}) au sein des listes numérotées ({{HTMLElement("ol")}}).
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-moz-list-number`** est [une extension de Mozilla](/fr/docs/Web/CSS/Mozilla_Extensions) qui représente le marqueur (généralement un nombre) d'un élément de liste ({{HTMLElement("li")}}) dans une liste ordonnée ({{HTMLElement("ol")}}).
 
 ## Syntaxe
 
-```
-li::-moz-list-number { propriétés de style }
+```css
+li::-moz-list-number {
+  /* ... */
+}
 ```
 
 ## Exemples
-
-### CSS
-
-```css
-li::-moz-list-number {
-  font-style: italic;
-  font-weight: bold;
-}
-```
 
 ### HTML
 
@@ -32,6 +27,15 @@ li::-moz-list-number {
   <li>Second élément</li>
   <li>Troisième élément</li>
 </ol>
+```
+
+### CSS
+
+```css
+li::-moz-list-number {
+  font-style: italic;
+  font-weight: bold;
+}
 ```
 
 ### Résultat

--- a/files/fr/web/css/_doublecolon_-moz-meter-bar/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-meter-bar/index.md
@@ -25,9 +25,7 @@ Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) 
 Normal&nbsp;: <meter min="0" max="10" value="6">Score 6/10</meter>
 <br />
 Mis en forme&nbsp;:
-<meter class="styled" min="0" max="10" value="6">
-  Score 6/10
-</meter>
+<meter class="styled" min="0" max="10" value="6">Score 6/10</meter>
 ```
 
 ### CSS

--- a/files/fr/web/css/_doublecolon_-moz-meter-bar/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-meter-bar/index.md
@@ -1,0 +1,60 @@
+---
+title: ::-moz-meter-bar
+slug: Web/CSS/::-moz-meter-bar
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
+---
+
+{{Non-standard_header}}
+
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-moz-meter-bar`** représente la jauge de mesure dans un élément {{HTMLElement("meter")}}. Il est utilisé pour sélectionner et appliquer des styles à la jauge à l'intérieur d'un élément de mesure.
+
+## Syntaxe
+
+```css
+::-moz-meter-bar {
+  /* ... */
+}
+```
+
+## Exemples
+
+### HTML
+
+```html
+Normal&nbsp;: <meter min="0" max="10" value="6">Score 6/10</meter>
+<br />
+Mis en forme&nbsp;: &nbsp;&nbsp;<meter class="styled" min="0" max="10" value="6">
+  Score 6/10
+</meter>
+```
+
+### CSS
+
+```css
+meter {
+  height: 20px;
+  width: 200px;
+  vertical-align: -0.4rem;
+}
+
+.styled::-moz-meter-bar {
+  background: lime;
+  box-shadow: 0 2px 3px grey inset;
+  border-radius: 5px;
+}
+```
+
+### Résultat
+
+{{ EmbedLiveSample('Exemples') }}
+
+## Spécifications
+
+Ce pseudo-élément ne fait partie d'aucun standard.
+
+## Voir aussi
+
+- {{cssxref("::-webkit-meter-bar")}}
+- {{cssxref("appearance")}}
+- {{cssxref("accent-color")}}

--- a/files/fr/web/css/_doublecolon_-moz-meter-bar/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-meter-bar/index.md
@@ -24,7 +24,8 @@ Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) 
 ```html
 Normal&nbsp;: <meter min="0" max="10" value="6">Score 6/10</meter>
 <br />
-Mis en forme&nbsp;: &nbsp;&nbsp;<meter class="styled" min="0" max="10" value="6">
+Mis en forme&nbsp;:
+<meter class="styled" min="0" max="10" value="6">
   Score 6/10
 </meter>
 ```

--- a/files/fr/web/css/_doublecolon_-moz-progress-bar/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-progress-bar/index.md
@@ -1,30 +1,44 @@
 ---
 title: ::-moz-progress-bar
 slug: Web/CSS/::-moz-progress-bar
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}{{SeeCompatTable}}
 
-Le pseudo-élément **`::-moz-progress-bar`** s'appliquant à la zone d'élément HTML {{HTMLElement("progress")}} représente la valeur de la progression effectuée jusqu'à présent. Vous pourrez par exemple, modifier la couleur de la barre de progression.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-moz-progress-bar`** est [une extension de Mozilla](/fr/docs/Web/CSS/Mozilla_Extensions) qui représente la barre de progression à l'intérieur d'un élément {{HTMLElement("progress")}}. (La barre représente la progression accomplie.)
+
+Si vous souhaitez sélectionner la partie non terminée de {{HTMLElement("progress")}} dans Mozilla, veuillez sélectionner directement l'élément {{HTMLElement("progress")}}.
 
 ## Syntaxe
 
-{{csssyntax}}
-
-## Exemples
-
-### CSS
-
 ```css
-#redbar::-moz-progress-bar {
-  background-color: red;
+::-moz-progress-bar {
+  /* ... */
 }
 ```
+
+## Exemples
 
 ### HTML
 
 ```html
-<progress id="redbar" value="30" max="100">30 %</progress>
+<progress value="30" max="100">30 %</progress>
+<progress max="100">Indéterminé</progress>
+```
+
+### CSS
+
+```css
+::-moz-progress-bar {
+  background-color: red;
+}
+
+/* Force la barre indéterminée à avoir une largeur de zéro */
+:indeterminate::-moz-progress-bar {
+  width: 0;
+}
 ```
 
 ### Résultat
@@ -33,12 +47,16 @@ Le pseudo-élément **`::-moz-progress-bar`** s'appliquant à la zone d'élémen
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à Gecko/Mozilla et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 
+
 - {{HTMLElement("progress")}}
-- {{cssxref("::-ms-fill")}}
-- {{cssxref("::-webkit-progress-bar")}}
-- {{cssxref("::-webkit-progress-value")}}
-- {{cssxref("::-webkit-progress-inner-element")}}
+- {{ cssxref("::-webkit-progress-bar") }}
+- {{ cssxref("::-webkit-progress-value") }}
+- {{ cssxref("::-webkit-progress-inner-element") }}

--- a/files/fr/web/css/_doublecolon_-moz-progress-bar/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-progress-bar/index.md
@@ -55,7 +55,6 @@ Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Voir aussi
 
-
 - {{HTMLElement("progress")}}
 - {{ cssxref("::-webkit-progress-bar") }}
 - {{ cssxref("::-webkit-progress-value") }}

--- a/files/fr/web/css/_doublecolon_-moz-range-progress/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-range-progress/index.md
@@ -1,18 +1,24 @@
 ---
 title: ::-moz-range-progress
 slug: Web/CSS/::-moz-range-progress
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-moz-range-progress`** représente la portion de la piste d'un élément [`<input>`](/fr/docs/Web/HTML/Reference/Elements/input) de type `range`, qui correspond aux valeurs inférieures à la valeur sélectionnée par le curseur.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-moz-range-progress`** est [une extension de Mozilla](/fr/docs/Web/CSS/Mozilla_Extensions) qui représente la partie inférieure de la _piste_ (c'est-à-dire la rainure) dans laquelle l'indicateur glisse dans un élément {{HTMLElement("input")}} de type `range`. Cette partie correspond aux valeurs inférieures à la valeur actuellement sélectionnée par le _curseur_ (c'est-à-dire le bouton virtuel).
 
 > [!NOTE]
 > Si `::-moz-range-progress` est utilisé sur autre chose qu'un élément `<input type="range">`, il n'aura aucun effet.
 
 ## Syntaxe
 
-{{csssyntax}}
+```css
+::-moz-range-progress {
+  /* ... */
+}
+```
 
 ## Exemples
 
@@ -33,15 +39,15 @@ input[type="range"]::-moz-range-progress {
 
 ### Résultat
 
-{{EmbedLiveSample("", 300, 50)}}
+{{EmbedLiveSample("Exemples", 300, 50)}}
 
 Une barre de progression mise en forme avec cette déclaration devrait ressembler à&nbsp;:
 
-![](screen_shot_2015-12-04_at_20.14.48.png)
+![La barre de progression est un carré vert épais à gauche du curseur et une fine ligne grise à droite. Le curseur est un cercle dont le diamètre correspond à la hauteur de la zone verte.](screen_shot_2015-12-04_at_20.14.48.png)
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à Gecko/Mozilla et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -49,10 +55,9 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à Gecko/Mozilla 
 
 ## Voir aussi
 
-- Les pseudo-éléments de Gecko qui permettent de mettre en forme les autres parties des éléments [`<input>`](/fr/docs/Web/HTML/Reference/Elements/input) de type `range`&nbsp;:
-  - [`::-moz-range-thumb`](/fr/docs/Web/CSS/::-moz-range-thumb)
-  - [`::-moz-range-track`](/fr/docs/Web/CSS/::-moz-range-track)
+- Les pseudo-éléments utilisés par Gecko qui permettent de mettre en forme les autres parties d'un élément {{HTMLElement("input")}} de type `range`&nbsp;:
+  - {{cssxref("::-moz-range-thumb")}} représente l'indicateur qui glisse dans la rainure.
+  - {{cssxref("::-moz-range-track")}} représente la rainure dans laquelle le curseur glisse.
 
-- [`::-ms-fill-upper`](/fr/docs/Web/CSS/::-ms-fill-upper) pris en charge par Internet Explorer
-- [CSS-Tricks&nbsp;: Gérer des champs `input` de type `range` de façon compatible entre les navigateurs (en anglais)](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
-- [QuirksMode&nbsp;: Mettre en forme les pistes et curseurs (en anglais)](https://www.quirksmode.org/blog/archives/2015/11/styling_and_scr.html)
+- [CSS-Tricks&nbsp;: Gérer des champs `input` de type `range` de façon compatible entre les navigateurs <sup>(angl.)</sup>](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
+- [QuirksMode&nbsp;: Mettre en forme les pistes et curseurs <sup>(angl.)</sup>](https://www.quirksmode.org/blog/archives/2015/11/styling_and_scr.html)

--- a/files/fr/web/css/_doublecolon_-moz-range-thumb/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-range-thumb/index.md
@@ -1,18 +1,24 @@
 ---
 title: ::-moz-range-thumb
 slug: Web/CSS/::-moz-range-thumb
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-moz-range-thumb`** représente le curseur qui se déplace le long de la piste dans un élément [`<input>`](/fr/docs/Web/HTML/Reference/Elements/input) de type `range` et qui permet de modifier la valeur numérique associée.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-moz-range-thumb`** est [une extension de Mozilla](/fr/docs/Web/CSS/Mozilla_Extensions) qui représente le curseur qui se déplace le long de la piste dans un élément [`<input>`](/fr/docs/Web/HTML/Reference/Elements/input) de type `range` et qui permet de modifier la valeur numérique associée.
 
 > [!NOTE]
 > Utiliser `::-moz-range-thumb` avec un autre élément que `<input type="range">` n'aura aucun effet.
 
 ## Syntaxe
 
-{{csssyntax}}
+```css
+::-moz-range-thumb {
+  /* ... */
+}
+```
 
 ## Exemples
 
@@ -40,7 +46,7 @@ Une barre de progression mise en forme avec ces règles devrait ressembler à&nb
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à Gecko/Mozilla et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -48,13 +54,12 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à Gecko/Mozilla 
 
 ## Voir aussi
 
-- Les pseudo-éléments de Gecko qui permettent de mettre en forme les autres parties des éléments [`<input>`](/fr/docs/Web/HTML/Reference/Elements/input) de type `range`&nbsp;:
-  - [`::-moz-range-track`](/fr/docs/Web/CSS/::-moz-range-track)
-  - [`::-moz-range-progress`](/fr/docs/Web/CSS/::-moz-range-progress)
+- Les pseudo-éléments utilisés par Gecko qui permettent de mettre en forme les autres parties des éléments {{HTMLElement("input")}} de type `range`&nbsp;:
+  - {{cssxref("::-moz-range-track")}} représente la rainure dans laquelle le curseur glisse.
+  - {{cssxref("::-moz-range-progress")}} représente la partie inférieure de la rainure.
 
 - Les pseudo-éléments utilisés par les autres navigateurs&nbsp;:
-  - [`::-webkit-slider-thumb`](/fr/docs/Web/CSS/::-webkit-slider-thumb) pour WebKit/Blink (Safari, Chrome et Opera).
-  - [`::-ms-thumb`](/fr/docs/Web/CSS/::-ms-thumb) pour Internet Explorer/Edge.
+  - {{cssxref("::-webkit-slider-thumb")}}, pseudo-élément pris en charge par WebKit et Blink (Safari, Chrome et Opera)
 
-- [CSS-Tricks&nbsp;: Gérer des champs `input` de type `range` de façon compatible entre les navigateurs (en anglais)](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
-- [QuirksMode&nbsp;: Mettre en forme les pistes et curseurs (en anglais)](https://www.quirksmode.org/blog/archives/2015/11/styling_and_scr.html)
+- [CSS-Tricks&nbsp;: Gérer des champs `input` de type `range` de façon compatible entre les navigateurs <sup>(angl.)</sup>](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
+- [QuirksMode&nbsp;: Mettre en forme les pistes et curseurs <sup>(angl.)</sup>](https://www.quirksmode.org/blog/archives/2015/11/styling_and_scr.html)

--- a/files/fr/web/css/_doublecolon_-moz-range-track/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-range-track/index.md
@@ -1,17 +1,23 @@
 ---
 title: ::-moz-range-track
 slug: Web/CSS/::-moz-range-track
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-moz-range-track`** est un pseudo-élément spécifique à Mozilla et représente la piste d'un élément [`<input>`](/fr/docs/Web/HTML/Reference/Elements/input) de type `range`.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-moz-range-track`** est [une extension de Mozilla](/fr/docs/Web/CSS/Mozilla_Extensions) qui représente la _piste_ (c'est-à-dire la rainure) dans laquelle l'indicateur glisse dans un élément {{HTMLElement("input")}} de type `range`.
 
 > **Note :** `::-moz-range-track` n'aura aucun effet s'il est utilisé sur autre chose qu'un élément `<input type="range">`.
 
 ## Syntaxe
 
-{{csssyntax}}
+```css
+::-moz-range-track {
+  /* ... */
+}
+```
 
 ## Exemples
 
@@ -31,7 +37,7 @@ input[type="range"]::-moz-range-track {
 
 ### Résultat
 
-{{EmbedLiveSample("", 300, 50)}}
+{{EmbedLiveSample(Exemples", 300, 50)}}
 
 Une barre de progression mise en forme de cette façon devrait ressembler à&nbsp;:
 
@@ -39,7 +45,7 @@ Une barre de progression mise en forme de cette façon devrait ressembler à&nbs
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à Gecko/Mozilla et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -47,12 +53,12 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à Gecko/Mozilla 
 
 ## Voir aussi
 
-- Les pseudo-éléments de Gecko qui permettent de mettre en forme les autres parties des éléments [`<input>`](/fr/docs/Web/HTML/Reference/Elements/input) de type `range`&nbsp;:
-  - [`::-moz-range-thumb`](/fr/docs/Web/CSS/::-moz-range-thumb) qui représente le curseur qui se déplace le long de la piste.
-  - [`::-moz-range-progress`](/fr/docs/Web/CSS/::-moz-range-progress) qui représente la partie inférieure de la piste (ce qui est déjà «&nbsp;couvert&nbsp;»).
+- Les pseudo-éléments utilisés par Gecko qui permettent de mettre en forme les autres parties des éléments {{HTMLElement("input")}} de type `range`&nbsp;:
+  - {{cssxref("::-moz-range-thumb")}} représente le curseur qui se déplace le long de la piste.
+  - {{cssxref("::-moz-range-progress")}} représente la partie inférieure de la rainure.
 
 - Les pseudo-éléments utilisés par les autres navigateurs&nbsp;:
-  - [`::-webkit-slider-runnable-track`](/fr/docs/Web/CSS/::-webkit-slider-runnable-track) pour WebKit/Blink (Safari, Chrome et Opera).
-  - [`::-ms-track`](/fr/docs/Web/CSS/::-ms-track) pour Internet Explorer/Edge.
+  - {{cssxref("::-webkit-slider-runnable-track")}}, pseudo-élément pris en charge par WebKit et Blink (Safari, Chrome et Opera).
 
-- [CSS-Tricks&nbsp;: Gérer des champs `input` de type `range` de façon compatible entre les navigateurs (en anglais)](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
+- [CSS-Tricks&nbsp;: Gérer des champs `input` de type `range` de façon compatible entre les navigateurs <sup>(angl.)</sup>](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
+- [QuirksMode&nbsp;: Mettre en forme les pistes et curseurs <sup>(angl.)</sup>](https://www.quirksmode.org/blog/archives/2015/11/styling_and_scr.html)

--- a/files/fr/web/css/_doublecolon_-webkit-inner-spin-button/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-inner-spin-button/index.md
@@ -2,18 +2,18 @@
 title: ::-webkit-inner-spin-button
 slug: Web/CSS/::-webkit-inner-spin-button
 l10n:
-  sourceCommit: 13d979ec8bc1daf315fc6a17e38cb855cf2e4ef1
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément CSS **`::-webkit-inner-spin-button`** permet de mettre en forme la partie intérieure de la roulette qui permet de choisir la valeur d'un élément [`<input type="number">`](/fr/docs/Web/HTML/Reference/Elements/input/number).
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-inner-spin-button`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui permet de mettre en forme la partie intérieure de la roulette qui permet de choisir la valeur d'un élément {{HTMLElement("input/number", '&lt;input type="number"&gt;')}}.
 
-## Syntaxr
+## Syntaxe
 
 ```css
 ::-webkit-inner-spin-button {
-  /* … */
+  /* ... */
 }
 ```
 
@@ -21,7 +21,17 @@ Le pseudo-élément CSS **`::-webkit-inner-spin-button`** permet de mettre en fo
 
 Ces exemples fonctionnent uniquement pour les navigateurs basés sur WebKit et Blink.
 
-### CSS
+### Changer le curseur dans les contrôles de spin
+
+Dans cet exemple, la propriété CSS {{cssxref("cursor")}} est changée en `pointer` chaque fois que le curseur est positionné sur la partie intérieure des contrôles de défilement de l'input.
+
+#### HTML
+
+```html
+<input type="number" />
+```
+
+#### CSS
 
 ```css
 input[type="number"]::-webkit-inner-spin-button {
@@ -29,19 +39,13 @@ input[type="number"]::-webkit-inner-spin-button {
 }
 ```
 
-### HTML
+#### Résultat
 
-```html
-<input type="number" />
-```
-
-### Résultat
-
-{{EmbedLiveSample('', 200, 30)}}
+{{EmbedLiveSample('changer_le_curseur_dans_les_contrôles_de_spin', 200, 30)}}
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification standard.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -49,4 +53,5 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Voir aussi
 
-- [Mettre en forme les contrôles de formulaires - WebKit (en anglais)](https://trac.webkit.org/wiki/Styling%20Form%20Controls#inputelement)
+- {{cssxref("::-webkit-textfield-decoration-container")}}
+- [Mettre en forme les contrôles de formulaires - WebKit <sup>(angl.)</sup>](https://trac.webkit.org/wiki/Styling%20Form%20Controls#inputelement)

--- a/files/fr/web/css/_doublecolon_-webkit-meter-bar/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-bar/index.md
@@ -1,47 +1,81 @@
 ---
 title: ::-webkit-meter-bar
 slug: Web/CSS/::-webkit-meter-bar
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}{{deprecated_header}}
 
-Le pseudo-élément **`::-webkit-meter-bar`** est un pseudo-élément spécifique à WebKit et permet de mettre en forme l'arrière-plan d'un élément {{HTMLElement("meter")}}.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-meter-bar`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui permet de mettre en forme l'arrière-plan d'un élément {{HTMLElement("meter")}}. Elle est utilisée pour sélectionner et appliquer des styles au conteneur d'un indicateur de mesure.
 
-## Exemples
-
-### CSS
+## Syntaxe
 
 ```css
-meter {
-  /* On réinitialise l'apparence par défaut */
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-meter::-webkit-meter-bar {
-  background: #eee;
-  box-shadow: 0 2px 3px rgba (0, 0, 0, 0.2) inset;
-  border-radius: 3px;
+::-webkit-meter-bar {
+  /* ... */
 }
 ```
+
+## Exemples
 
 ### HTML
 
 ```html
-<meter min="0" max="10" value="6">Score sur 10</meter>
+Normal&nbsp;: <meter min="0" max="10" value="6">Score 6/10</meter>
+<br />
+Mis en forme&nbsp;: <meter id="styled" min="0" max="10" value="6">
+  Score 6/10
+</meter>
+```
+
+### CSS
+
+```css hidden
+meter {
+  height: 30px;
+  width: 200px;
+  vertical-align: -0.8rem;
+}
+```
+
+```css
+.safari meter {
+  /* On réinitialise l'apparence par défaut */
+  -webkit-appearance: none;
+}
+
+#styled::-webkit-meter-bar {
+  background: lime;
+  box-shadow: 0 10px 20px grey inset;
+  border-radius: 10px;
+}
+```
+
+### JavaScript
+
+```js
+// Safari veut que les éléments <meter> aient une `appearance` de `none` pour un
+// style personnalisé utilisant les sélecteurs `::-webkit-meter-*`, mais
+// `appearance: none` casse le rendu sur Chrome.
+// Par conséquent, nous devons vérifier si le navigateur est basé sur Safari.
+
+const is_safari =
+  navigator.userAgent.includes("AppleWebKit/") &&
+  !navigator.userAgent.includes("Chrome/");
+
+if (is_safari) {
+  document.body.classList.add("safari");
+}
 ```
 
 ### Résultat
 
 {{EmbedLiveSample('Exemples')}}
 
-> [!NOTE]
-> Cela fonctionnera uniquement pour les navigateurs Webkit/Blink.
-
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -49,7 +83,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Voir aussi
 
-- Les pseudo-éléments utilisés par WebKit/Blink pour mettre en forme les autres parties d'un élément {{htmlelement("meter")}} :
+- Les pseudo-éléments utilisés par WebKit/Blink pour mettre en forme les autres parties d'un élément {{htmlelement("meter")}}&nbsp;:
   - {{cssxref("::-webkit-meter-inner-element")}}
   - {{cssxref("::-webkit-meter-even-less-good-value")}}
   - {{cssxref("::-webkit-meter-optimum-value")}}

--- a/files/fr/web/css/_doublecolon_-webkit-meter-bar/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-bar/index.md
@@ -24,9 +24,8 @@ Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) 
 ```html
 Normal&nbsp;: <meter min="0" max="10" value="6">Score 6/10</meter>
 <br />
-Mis en forme&nbsp;: <meter id="styled" min="0" max="10" value="6">
-  Score 6/10
-</meter>
+Mis en forme&nbsp;:
+<meter id="styled" min="0" max="10" value="6">Score 6/10</meter>
 ```
 
 ### CSS

--- a/files/fr/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
@@ -1,40 +1,90 @@
 ---
 title: ::-webkit-meter-even-less-good-value
 slug: Web/CSS/::-webkit-meter-even-less-good-value
+l10n:
+  sourceCommit: e82803beedb7f1d8a8e918c1071752f18e1e3f28
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-webkit-meter-even-less-good-value`** donne une couleur rouge à l'élément {{HTMLElement("meter")}} lorsque les valeurs de `value` et d'optimum sont dans des intervalles opposés (par exemple : `value` < `low` < `high` < `optimum` ou `value` > `high` > `low` > `optimum`).
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-meter-even-less-good-value`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui met en forme l'élément {{HTMLElement("meter")}} lorsque les attributs `value` et `optimum` se situent en dehors de la plage basse-haute, mais dans des zones opposées. À titre d'illustration, cela s'applique lorsque `value` < `low` < `high` < `optimum` ou `value` > `high` > `low` > `optimum`.
+
+Rouge est la couleur par défaut.
+
+## Syntaxe
+
+```css
+::-webkit-meter-even-less-good-value {
+  /* ... */
+}
+```
 
 ## Exemples
+
+### HTML
+
+```html
+Normal&nbsp;:
+<meter min="0" max="10" low="3" high="7" optimum="8" value="2">
+  Score 2/10
+</meter>
+<br />
+Mis en forme&nbsp;:
+<meter id="styled" min="0" max="10" low="3" high="7" optimum="8" value="2">
+  Score 2/10
+</meter>
+```
 
 ### CSS
 
 ```css
-meter::-webkit-meter-even-less-good-value {
-  background: linear-gradient(to bottom, #f77, #d44 45%, #d44 55%, #f77);
+body {
+  font-family: monospace;
+}
+
+.safari meter {
+  /* Réinitialiser l'apparence par défaut pour Safari uniquement */
+  /* La classe .safari est ajoutée via JavaScript */
+  -webkit-appearance: none;
+}
+
+#styled::-webkit-meter-even-less-good-value {
+  background: linear-gradient(
+    to bottom,
+    #ff7777,
+    #990000 45%,
+    #990000 55%,
+    #ff7777
+  );
   height: 100%;
   box-sizing: border-box;
 }
 ```
 
-### HTML
+### JavaScript
 
-```html
-<meter min="0" max="10" value="6">Score out of 10</meter>
+```js
+// Safari veut que les éléments <meter> aient une `appearance` de `none` pour un
+// style personnalisé utilisant les sélecteurs `::-webkit-meter-*`, mais
+// `appearance: none` casse le rendu sur Chrome.
+// Par conséquent, nous devons vérifier si le navigateur est basé sur Safari.
+
+const is_safari =
+  navigator.userAgent.includes("AppleWebKit/") &&
+  !navigator.userAgent.includes("Chrome/");
+
+if (is_safari) {
+  document.body.classList.add("safari");
+}
 ```
 
 ### Résultat
 
 {{EmbedLiveSample('Exemples', '100%', 50)}}
 
-> [!NOTE]
-> Cela fonctionnera uniquement pour les navigateurs Webkit/Blink.
-
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -42,7 +92,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Voir aussi
 
-Les pseudo-éléments utilisés par WebKit/Blink pour mettre en forme les autres parties d'un élément {{htmlelement("meter")}} :
+Les pseudo-éléments utilisés par WebKit/Blink pour mettre en forme les autres parties d'un élément {{htmlelement("meter")}}&nbsp;:
 
 - {{cssxref("::-webkit-meter-inner-element")}}
 - {{cssxref("::-webkit-meter-bar")}}

--- a/files/fr/web/css/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-inner-element/index.md
@@ -24,7 +24,8 @@ Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) 
 ```html
 Normal&nbsp;: <meter min="0" max="10" value="6">Score 6/10</meter>
 <br />
-Mis en forme&nbsp;: <meter id="styled" min="0" max="10" value="6">Score 6/10</meter>
+Mis en forme&nbsp;:
+<meter id="styled" min="0" max="10" value="6">Score 6/10</meter>
 ```
 
 ### CSS

--- a/files/fr/web/css/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-inner-element/index.md
@@ -1,47 +1,76 @@
 ---
 title: ::-webkit-meter-inner-element
 slug: Web/CSS/::-webkit-meter-inner-element
+l10n:
+  sourceCommit: e82803beedb7f1d8a8e918c1071752f18e1e3f28
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-webkit-meter-inner-element`** est un pseudo-élément qui permet de sélectionner et d'appliquer des styles au conteneur d'un élément {{htmlelement("meter")}}.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-meter-inner-element`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui permet de sélectionner et appliquer des styles à l'élément conteneur externe d'un élément {{htmlelement("meter")}}. C'est une balise supplémentaire pour afficher l'élément `<meter>` en lecture seule.
 
-## Exemples
-
-### CSS
+## Syntaxe
 
 ```css
-meter {
-  /* Réinitialise l'apparence par défaut */
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-meter::-webkit-meter-inner-element {
-  -webkit-appearance: inherit;
-  box-sizing: inherit;
-  border: 1px solid #aaa;
+::-webkit-meter-inner-element {
+  /* ... */
 }
 ```
+
+## Exemples
 
 ### HTML
 
 ```html
-<meter min="0" max="10" value="6">Score out of 10</meter>
+Normal&nbsp;: <meter min="0" max="10" value="6">Score 6/10</meter>
+<br />
+Mis en forme&nbsp;: <meter id="styled" min="0" max="10" value="6">Score 6/10</meter>
+```
+
+### CSS
+
+```css
+body {
+  font-family: monospace;
+}
+
+.safari meter {
+  /* Réinitialiser l'apparence par défaut pour Safari uniquement */
+  /* La classe .safari est ajoutée via JavaScript */
+  -webkit-appearance: none;
+}
+
+#styled::-webkit-meter-inner-element {
+  -webkit-appearance: inherit;
+  box-sizing: inherit;
+  border: 1px dashed #aaaaaa;
+}
+```
+
+### JavaScript
+
+```js
+// Safari veut que les éléments <meter> aient une `appearance` de `none` pour un
+// style personnalisé utilisant les sélecteurs `::-webkit-meter-*`, mais
+// `appearance: none` casse le rendu sur Chrome.
+// Par conséquent, nous devons vérifier si le navigateur est basé sur Safari.
+
+const is_safari =
+  navigator.userAgent.includes("AppleWebKit/") &&
+  !navigator.userAgent.includes("Chrome/");
+
+if (is_safari) {
+  document.body.classList.add("safari");
+}
 ```
 
 ### Résultat
 
 {{EmbedLiveSample('Exemples', '100%', 50)}}
 
-> [!NOTE]
-> Cela ne fonctionne que pour les navigateurs Webkit/Blink.
-
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -49,7 +78,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Voir aussi
 
-Les pseudo-éléments utilisés par WebKit/Blink pour mettre en forme les autres parties d'un élément {{htmlelement("meter")}} :
+Les pseudo-éléments utilisés par WebKit/Blink pour mettre en forme les autres parties d'un élément {{htmlelement("meter")}}&nbsp;:
 
 - {{cssxref("::-webkit-meter-bar")}}
 - {{cssxref("::-webkit-meter-even-less-good-value")}}

--- a/files/fr/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
@@ -1,32 +1,81 @@
 ---
 title: ::-webkit-meter-optimum-value
 slug: Web/CSS/::-webkit-meter-optimum-value
+l10n:
+  sourceCommit: e82803beedb7f1d8a8e918c1071752f18e1e3f28
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-webkit-meter-optimum-value`** permet de mettre en forme l'élément {{HTMLElement("meter")}} lorsque la valeur de son attribut tombe dans l'intervalle haut. La couleur appliquée par défaut est le vert.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-meter-optimum-value`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui permet de mettre en forme l'élément {{HTMLElement("meter")}} lorsque sa valeur se situe dans la plage basse-haute ou lorsque la valeur est équivalente à la valeur optimale.
 
-## Exemples
+Vert est la couleur par défaut.
 
-### CSS
+## Syntaxe
 
 ```css
-meter::-webkit-meter-bar {
-  background: none;
-  background-color: whiteSmoke;
-  box-shadow: 0 5px 5px -5px #333 inset;
-}
-
-meter::-webkit-meter-optimum-value {
-  box-shadow: 0 5px 5px -5px #999 inset;
+::-webkit-meter-optimum-value {
+  /* ... */
 }
 ```
+
+## Exemples
 
 ### HTML
 
 ```html
-<meter min="0" max="10" value="6">Score out of 10</meter>
+Normal&nbsp;:
+<meter min="0" max="10" low="3" high="7" optimum="6" value="6">
+  Score 6/10
+</meter>
+<br />
+Mis en forme&nbsp;:
+<meter id="styled" min="0" max="10" low="3" high="7" optimum="6" value="6">
+  Score 6/10
+</meter>
+```
+
+### CSS
+
+```css
+body {
+  font-family: monospace;
+}
+
+.safari meter {
+  /* Réinitialiser l'apparence par défaut pour Safari uniquement */
+  /* La classe .safari est ajoutée via JavaScript */
+  -webkit-appearance: none;
+}
+
+#styled::-webkit-meter-optimum-value {
+  background: linear-gradient(
+    to bottom,
+    #77ff77,
+    #009900 45%,
+    #009900 55%,
+    #77ff77
+  );
+  height: 100%;
+  box-sizing: border-box;
+}
+```
+
+### JavaScript
+
+```js
+// Safari veut que les éléments <meter> aient une `appearance` de `none` pour un
+// style personnalisé utilisant les sélecteurs `::-webkit-meter-*`, mais
+// `appearance: none` casse le rendu sur Chrome.
+// Par conséquent, nous devons vérifier si le navigateur est basé sur Safari.
+
+const is_safari =
+  navigator.userAgent.includes("AppleWebKit/") &&
+  !navigator.userAgent.includes("Chrome/");
+
+if (is_safari) {
+  document.body.classList.add("safari");
+}
 ```
 
 ### Résultat
@@ -35,7 +84,7 @@ meter::-webkit-meter-optimum-value {
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -43,7 +92,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Voir aussi
 
-Les pseudo-éléments utilisés par WebKit/Blink pour mettre en forme les autres parties d'un élément {{htmlelement("meter")}} :
+Les pseudo-éléments utilisés par WebKit/Blink pour mettre en forme les autres parties d'un élément {{htmlelement("meter")}}&nbsp;:
 
 - {{cssxref("::-webkit-meter-inner-element")}}
 - {{cssxref("::-webkit-meter-bar")}}

--- a/files/fr/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
@@ -1,43 +1,90 @@
 ---
 title: ::-webkit-meter-suboptimum-value
 slug: Web/CSS/::-webkit-meter-suboptimum-value
+l10n:
+  sourceCommit: e82803beedb7f1d8a8e918c1071752f18e1e3f28
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-webkit-meter-suboptimum-value`** donne une couleur jaune à l'élément {{HTMLElement("meter")}} lorsque la valeur de l'attribut est en dehors de l'intervalle haut des valeurs.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-meter-suboptimum-value`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui donne une couleur jaune à l'élément {{HTMLElement("meter")}} lorsque la valeur de l'attribut est en dehors de l'intervalle haut des valeurs.
+
+Jaune est la couleur par défaut.
+
+## Syntaxe
+
+```css
+::-webkit-meter-suboptimum-value {
+  /* ... */
+}
+```
 
 ## Exemples
+
+### HTML
+
+```html
+Normal&nbsp;:
+<meter min="0" max="10" low="3" high="7" optimum="6" value="2">
+  Score 2/10
+</meter>
+<br />
+Mis en forme&nbsp;:
+<meter id="styled" min="0" max="10" low="3" high="7" optimum="6" value="2">
+  Score 2/10
+</meter>
+```
 
 ### CSS
 
 ```css
-meter::-webkit-meter-suboptimum-value {
-  background:
-    -webkit-gradient linear,
-    left top,
-    left bottom;
+body {
+  font-family: monospace;
+}
+
+.safari meter {
+  /* Réinitialiser l'apparence par défaut pour Safari uniquement */
+  /* La classe .safari est ajoutée via JavaScript */
+  -webkit-appearance: none;
+}
+
+#styled::-webkit-meter-suboptimum-value {
+  background: linear-gradient(
+    to bottom,
+    #ffff77,
+    #999900 45%,
+    #999900 55%,
+    #ffff77
+  );
   height: 100%;
   box-sizing: border-box;
 }
 ```
 
-### HTML
+### JavaScript
 
-```html
-<meter min="0" max="10" value="6">Score sur 10</meter>
+```js
+// Safari veut que les éléments <meter> aient une `appearance` de `none` pour un
+// style personnalisé utilisant les sélecteurs `::-webkit-meter-*`, mais
+// `appearance: none` casse le rendu sur Chrome.
+// Par conséquent, nous devons vérifier si le navigateur est basé sur Safari.
+
+const is_safari =
+  navigator.userAgent.includes("AppleWebKit/") &&
+  !navigator.userAgent.includes("Chrome/");
+
+if (is_safari) {
+  document.body.classList.add("safari");
+}
 ```
 
 ### Résultat
 
 {{EmbedLiveSample('Exemples', '100%', 50)}}
 
-> [!NOTE]
-> Cette fonctionnalité ne sera visible que depuis un navigateur WebKit/Blink.
-
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -45,7 +92,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Voir aussi
 
-Les pseudo-éléments utilisés par WebKit/Blink pour mettre en forme les autres parties d'un élément {{htmlelement("meter")}} :
+Les pseudo-éléments utilisés par WebKit/Blink pour mettre en forme les autres parties d'un élément {{htmlelement("meter")}}&nbsp;:
 
 - {{cssxref("::-webkit-meter-inner-element")}}
 - {{cssxref("::-webkit-meter-bar")}}

--- a/files/fr/web/css/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-progress-bar/index.md
@@ -1,16 +1,32 @@
 ---
 title: ::-webkit-progress-bar
 slug: Web/CSS/::-webkit-progress-bar
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-webkit-progress-bar`** représente l'ensemble de la barre d'un élément {{HTMLElement("progress")}}. Normalement, celui-ci n'est visible que pour la partie de la barre qui n'est pas remplie car, par défaut, il est affiché sous le pseudo-élément {{cssxref("::-webkit-progress-value")}}. C'est un pseudo-élément fils du pseudo-élément {{cssxref("::-webkit-progress-inner-element")}} et c'est le pseudo-élément parent du pseudo-élément {{cssxref("::-webkit-progress-value")}}.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-progress-bar`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui représente l'ensemble de la barre d'un élément {{HTMLElement("progress")}}. Normalement, celui-ci n'est visible que pour la partie de la barre qui n'est pas remplie car, par défaut, il est affiché sous le pseudo-élément {{cssxref("::-webkit-progress-value")}}. C'est un pseudo-élément fils du pseudo-élément {{cssxref("::-webkit-progress-inner-element")}} et c'est le pseudo-élément parent du pseudo-élément {{cssxref("::-webkit-progress-value")}}.
 
 > [!NOTE]
 > Afin que `::-webkit-progress-value` ait un effet, il faut que {{cssxref("appearance")}} vaille `none` sur l'élément `<progress>`.
 
+## Syntaxe
+
+```css
+::-webkit-progress-bar {
+  /* ... */
+}
+```
+
 ## Exemples
+
+### HTML
+
+```html
+<progress value="10" max="50"></progress>
+```
 
 ### CSS
 
@@ -24,23 +40,17 @@ progress {
 }
 ```
 
-### HTML
-
-```html
-<progress value="10" max="50"></progress>
-```
-
 ### Résultat
 
 {{EmbedLiveSample("Exemples", 200, 50)}}
 
-Une barre de progression avec la mise en forme ci-avant sera affichée de cette façon :
+Une barre de progression avec la mise en forme ci-avant sera affichée de cette façon&nbsp;:
 
-![](progress-bar.png)
+![La barre de progression est une barre horizontale d'environ la hauteur d'une lettre. Les 20 % à gauche sont verts. Les 80 % à droite sont orange.](progress-bar.png)
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -48,9 +58,8 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Voir aussi
 
-- Les pseudo-éléments relatifs à WebKit/Blink qui permettent de mettre en forme les autres parties des éléments {{HTMLElement("progress")}} :
+- Les pseudo-éléments relatifs à WebKit/Blink qui permettent de mettre en forme les autres parties des éléments {{HTMLElement("progress")}}&nbsp;:
   - {{cssxref("::-webkit-progress-value")}}
   - {{cssxref("::-webkit-progress-inner-element")}}
 
 - {{cssxref("::-moz-progress-bar")}}
-- {{cssxref("::-ms-fill")}}

--- a/files/fr/web/css/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-progress-inner-element/index.md
@@ -1,16 +1,38 @@
 ---
 title: ::-webkit-progress-inner-element
 slug: Web/CSS/::-webkit-progress-inner-element
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-webkit-progress-inner-element`** représente le cadre extérieur de l'élément [`<progress>`](/fr/docs/Web/HTML/Reference/Elements/progress). C'est un pseudo-élément parent du pseudo-élément [`::-webkit-progress-bar`](/fr/docs/Web/CSS/::-webkit-progress-bar).
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-progress-inner-element`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui représente le cadre extérieur de l'élément {{HTMLElement("progress")}}. C'est un pseudo-élément parent du pseudo-élément {{cssxref("::-webkit-progress-bar")}}.
 
 > [!NOTE]
-> Afin que `::-webkit-progress-value` ait un effet, il faut que [`-webkit-appearance`](/fr/docs/Web/CSS/appearance) vaille `none` sur l'élément `<progress>`.
+> Afin que `::-webkit-progress-value` ait un effet, il faut que {{cssxref("appearance")}} vaille `none` sur l'élément `<progress>`.
+
+## Syntaxe
+
+```css
+::-webkit-progress-inner-element {
+  /* ... */
+}
+```
 
 ## Exemples
+
+Ces exemples ne fonctionnent que sur Blink et WebKit.
+
+### Ajouter une bordure noire autour de la barre de progression
+
+Dans cet exemple, une bordure noire de 2px est ajoutée autour de la barre de progression.
+
+### HTML
+
+```html
+<progress value="10" max="50"></progress>
+```
 
 ### CSS
 
@@ -24,23 +46,17 @@ progress {
 }
 ```
 
-### HTML
-
-```html
-<progress value="10" max="50"></progress>
-```
-
 ### Résultat
 
-{{EmbedLiveSample("", 200, 50)}}
+{{EmbedLiveSample("ajouter_une_bordure_noire_autour_de_la_barre_de_progression", 200, 50)}}
 
 Une barre de progression avec la mise en forme ci-avant sera affichée de cette façon&nbsp;:
 
-![](-webkit-progress-inner-element_example.png)
+![La barre de progression est une longue boîte verte et grise avec une bordure noire. Les 20 % gauches de la boîte sont verts. Les 80 % droits sont gris.](-webkit-progress-inner-element_example.png)
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -48,9 +64,8 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Voir aussi
 
-- Les pseudo-éléments relatifs à WebKit/Blink qui permettent de mettre en forme les autres parties des éléments [`<progress>`](/fr/docs/Web/HTML/Reference/Elements/progress)
-  - [`::-webkit-progress-bar`](/fr/docs/Web/CSS/::-webkit-progress-bar)
-  - [`::-webkit-progress-value`](/fr/docs/Web/CSS/::-webkit-progress-value)
+- Les pseudo-éléments relatifs à WebKit/Blink qui permettent de mettre en forme les autres parties des éléments {{HTMLElement("progress")}}&nbsp;:
+  - {{cssxref("::-webkit-progress-bar")}}
+  - {{cssxref("::-webkit-progress-value")}}
 
-- [`::-moz-progress-bar`](/fr/docs/Web/CSS/::-moz-progress-bar)
-- [`::-ms-fill`](/fr/docs/Web/CSS/::-ms-fill)
+- {{cssxref("::-moz-progress-bar")}}

--- a/files/fr/web/css/_doublecolon_-webkit-progress-value/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-progress-value/index.md
@@ -1,16 +1,32 @@
 ---
 title: ::-webkit-progress-value
 slug: Web/CSS/::-webkit-progress-value
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-webkit-progress-value`** permet de représenter la portion « remplie » de la barre d'un élément {{HTMLElement("progress")}}. C'est un pseudo-élément fils du pseudo-élément {{cssxref("::-webkit-progress-bar")}}.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-progress-value`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui permet de représenter la portion «&nbsp;remplie&nbsp;» de la barre d'un élément {{HTMLElement("progress")}}. C'est un pseudo-élément enfant du pseudo-élément {{cssxref("::-webkit-progress-bar")}}.
 
 > [!NOTE]
 > Afin que `::-webkit-progress-value` ait un effet, il faut que {{cssxref("-webkit-appearance")}} vaille `none` sur l'élément `<progress>`.
 
+## Syntaxe
+
+```css
+::-webkit-progress-value {
+  /* ... */
+}
+```
+
 ## Exemples
+
+### HTML
+
+```html
+<progress value="10" max="50"></progress>
+```
 
 ### CSS
 
@@ -24,23 +40,17 @@ progress {
 }
 ```
 
-### HTML
-
-```html
-<progress value="10" max="50"></progress>
-```
-
 ### Résultat
 
 {{EmbedLiveSample("Exemples", 200, 50)}}
 
-Une barre de progression avec la mise en forme ci-avant sera affichée de cette façon :
+Une barre de progression avec la mise en forme ci-avant sera affichée de cette façon&nbsp;:
 
-![](progress-value.png)
+![Une longue boîte orange et grise. Les 20 % de gauche sont orange. Les 80 % de droite sont gris.](progress-value.png)
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -48,9 +58,8 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Voir aussi
 
-- Les pseudo-éléments relatifs à WebKit/Blink qui permettent de mettre en forme les autres parties des éléments {{HTMLElement("progress")}} :
+- Les pseudo-éléments relatifs à WebKit/Blink qui permettent de mettre en forme les autres parties des éléments {{HTMLElement("progress")}}&nbsp;:
   - {{cssxref("::-webkit-progress-bar")}}
   - {{cssxref("::-webkit-progress-inner-element")}}
 
 - {{cssxref("::-moz-progress-bar")}}
-- {{cssxref("::-ms-fill")}}

--- a/files/fr/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -1,17 +1,17 @@
 ---
 title: ::-webkit-scrollbar
 slug: Web/CSS/::-webkit-scrollbar
+l10n:
+  sourceCommit: e82803beedb7f1d8a8e918c1071752f18e1e3f28
 ---
 
-{{CSSRef}}{{Non-standard_header}}Le pseudo-élément **`::-webkit-scrollbar`** permet de modifier le style de la barre de défilement associée à un élément. Il s'agit d'un pseudo-élément propriétaire, uniquement disponible pour les navigateurs WebKit.
+{{Non-standard_header}}
 
-## Syntaxe
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-scrollbar`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui permet de modifier le style de la barre de défilement associée à un élément. Il s'agit d'un pseudo-élément propriétaire, uniquement disponible pour les navigateurs WebKit.
 
-{{CSSSyntax}}
+## Sélecteurs de barre de défilement
 
-## Sélecteurs de _scrollbars_
-
-You can use the following pseudo elements to customize various parts of the scrollbar for webkit browsers:
+Vous pouvez utiliser les pseudo-éléments suivants pour personnaliser différentes parties de la barre de défilement (<i lang="en">scrollbar</i>) pour les navigateurs WebKit&nbsp;:
 
 - `::-webkit-scrollbar` — la barre entière.
 - `::-webkit-scrollbar-button` — les boutons de la barre de défilement (les flèches vers le bas ou le haut)
@@ -21,33 +21,15 @@ You can use the following pseudo elements to customize various parts of the scro
 - `::-webkit-scrollbar-corner` — le coin inférieur de la barre où les barres horizontales et verticales se rencontrent.
 - `::-webkit-resizer` — le bouton qui apparaît dans le coin inférieur de certains éléments et qui permet de les redimensionner.
 
+## Accessibilité
+
+Les auteur·ice·s doivent éviter de mettre en forme les barres de défilement, car le changement de l'apparence des barres de défilement par rapport à la valeur par défaut [perturbe la cohérence externe <sup>(angl.)</sup>](https://inclusivedesignprinciples.info/#be-consistent), ce qui a un impact négatif sur l'utilisabilité. Si vous mettez en forme les barres de défilement, assurez-vous qu'il y a suffisamment de contraste de couleur et que les cibles tactiles mesurent au moins 44px de large et de haut. Voir [Techniques pour WCAG 2.0 : G183 : Utiliser un rapport de contraste de 3:1 <sup>(angl.)</sup>](https://www.w3.org/TR/WCAG20-TECHS/G183.html) et [Comprendre WCAG 2.1 : Taille de la cible <sup>(angl.)</sup>](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html).
+
 ## Exemples
 
-```css
-.visible-scrollbar,
-.invisible-scrollbar,
-.mostly-customized-scrollbar {
-  display: block;
-  width: 10em;
-  overflow: auto;
-  height: 2em;
-}
-.invisible-scrollbar::-webkit-scrollbar {
-  display: none;
-}
+### Mettre en forme les barres de défilement en utilisant `-webkit-scrollbar`
 
-/* Demonstrate a "mostly customized" scrollbar
- * (won't be visible otherwise if width/height is specified) */
-.mostly-customized-scrollbar::-webkit-scrollbar {
-  width: 5px;
-  height: 8px;
-  background-color: #aaa; /* or add it to the track */
-}
-/* Add a thumb */
-.mostly-customized-scrollbar::-webkit-scrollbar-thumb {
-  background: #000;
-}
-```
+#### HTML
 
 ```html
 <div class="visible-scrollbar">
@@ -63,21 +45,120 @@ You can use the following pseudo elements to customize various parts of the scro
   Aliquam at enim ligula.
 </div>
 <div class="invisible-scrollbar">
-  Thisisaveeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeerylongword
+  C'estuntrèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèslongmot<br />
 </div>
 <div class="mostly-customized-scrollbar">
-  Thisisaveeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeerylongword<br />
-  And pretty tall<br />
-  thing with weird scrollbars.<br />
-  Who thought scrollbars could be made weeeeird?
+  C'estuntrèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèèslongmot<br />
+  Et une très grande<br />
+  chose avec des barres de défilement étranges.<br />
+  Qui aurait pensé que les barres de défilement pouvaient être rendues
+  étranges&nbsp;?
 </div>
 ```
 
-{{EmbedLiveSample('Exemples')}}
+#### CSS
+
+```css
+.visible-scrollbar,
+.invisible-scrollbar,
+.mostly-customized-scrollbar {
+  display: block;
+  width: 10em;
+  overflow: auto;
+  height: 2em;
+  padding: 1em;
+  margin: 1em auto;
+  outline: 2px dashed cornflowerblue;
+}
+
+.invisible-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+/* Demonstrate a "mostly customized" scrollbar
+ * (won't be visible otherwise if width/height is specified) */
+.mostly-customized-scrollbar::-webkit-scrollbar {
+  width: 5px;
+  height: 8px;
+  background-color: #aaaaaa; /* or add it to the track */
+}
+/* Add a thumb */
+.mostly-customized-scrollbar::-webkit-scrollbar-thumb {
+  background: black;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("mettre_en_forme_les_barres_de_défilement_en_utilisant_-webkit-scrollbar", 600, 300)}}
+
+### Ajouter une solution de repli pour les styles de barre de défilement
+
+Vous pouvez utiliser une règle {{cssxref("@supports")}} pour détecter si un navigateur prend en charge les propriétés standard {{cssxref("scrollbar-color")}} et {{cssxref("scrollbar-width")}}, et sinon utiliser une solution de repli avec les pseudo-éléments `::-webkit-scrollbar-*`.
+L'exemple suivant montre comment appliquer des couleurs aux barres de défilement en utilisant {{cssxref("scrollbar-color")}} si pris en charge et les pseudo-éléments `::-webkit-scrollbar-*` si ce n'est pas le cas.
+
+#### HTML
+
+```html
+<div class="scroll-box">
+  <h1>Yoshi</h1>
+  <p>
+    Yoshi est un dinosaure fictif qui apparaît dans des jeux vidéo publiés par
+    Nintendo. Yoshi a fait ses débuts dans Super Mario World (1990) sur la SNES en tant qu'acolyte de Mario et
+    Luigi.
+  </p>
+  <p>
+    Tout au long de la série principale de Super Mario, Yoshi sert généralement de
+    monture de confiance à Mario.
+  </p>
+  <p>
+    Avec un appétit glouton, Yoshi peut gober des ennemis avec sa longue langue,
+    et pondre des œufs qui fonctionnent également comme projectiles.
+  </p>
+</div>
+```
+
+#### CSS
+
+```css hidden
+.scroll-box {
+  overflow: auto;
+  width: 20rem;
+  height: 5rem;
+  border: 2px solid cornflowerblue;
+  margin: 2rem auto;
+  font-family: monospace;
+}
+```
+
+```css
+/* Pour les navigateurs qui prennent en charge les propriétés `scrollbar-*` */
+@supports (scrollbar-color: auto) {
+  .scroll-box {
+    scrollbar-color: aquamarine cornflowerblue;
+  }
+}
+
+/* Sinon, utilisez les pseudo-éléments `::-webkit-scrollbar-*` */
+@supports selector(::-webkit-scrollbar) {
+  .scroll-box::-webkit-scrollbar {
+    background: aquamarine;
+  }
+  .scroll-box::-webkit-scrollbar-thumb {
+    background: cornflowerblue;
+  }
+}
+```
+
+#### Résultat
+
+Dans l'exemple ci-dessous, vous pouvez faire défiler la boîte bordée verticalement pour voir l'effet de la mise en forme de la barre de défilement.
+
+{{EmbedLiveSample("ajouter_une_solution_de_repli_pour_les_styles_de_barre_de_défilement")}}
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -85,6 +166,8 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Voir aussi
 
-- Billet du blog WebKit [sur la mise en forme des barres de défilement](https://webkit.org/blog/363/styling-scrollbars/)
-- {{cssxref('-ms-overflow-style')}}
 - {{CSSxRef("scrollbar-width")}}
+- {{CSSxRef("scrollbar-color")}}
+- Billet du blog Eric W. Bailey [N'utilisez pas de barres de défilement personnalisées <sup>(angl.)</sup>](https://ericwbailey.website/published/dont-use-custom-css-scrollbars/) (2023)
+- Billet du blog Chrome [Mettre en forme les barres de défilement](https://developer.chrome.com/docs/css-ui/scrollbar-styling) (2024)
+- Billet du blog WebKit [sur la mise en forme des barres de défilement <sup>(angl.)</sup>](https://webkit.org/blog/363/styling-scrollbars/) (2009)

--- a/files/fr/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -104,12 +104,12 @@ L'exemple suivant montre comment appliquer des couleurs aux barres de défilemen
   <h1>Yoshi</h1>
   <p>
     Yoshi est un dinosaure fictif qui apparaît dans des jeux vidéo publiés par
-    Nintendo. Yoshi a fait ses débuts dans Super Mario World (1990) sur la SNES en tant qu'acolyte de Mario et
-    Luigi.
+    Nintendo. Yoshi a fait ses débuts dans Super Mario World (1990) sur la SNES
+    en tant qu'acolyte de Mario et Luigi.
   </p>
   <p>
-    Tout au long de la série principale de Super Mario, Yoshi sert généralement de
-    monture de confiance à Mario.
+    Tout au long de la série principale de Super Mario, Yoshi sert généralement
+    de monture de confiance à Mario.
   </p>
   <p>
     Avec un appétit glouton, Yoshi peut gober des ennemis avec sa longue langue,

--- a/files/fr/web/css/_doublecolon_-webkit-search-cancel-button/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-search-cancel-button/index.md
@@ -1,21 +1,25 @@
 ---
 title: ::-webkit-search-cancel-button
 slug: Web/CSS/::-webkit-search-cancel-button
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-webkit-search-cancel-button`** représente le bouton d'annulation présenté au bout d'un champ {{HTMLElement("input")}} de type `search` et qui permet d'effacer la valeur actuellement saisie dans l'élément {{HTMLElement("input")}}. Ce bouton et ce pseudo-élément ne sont pas standards et ne sont pris en charge que par WebKit et Blink. Ce bouton est uniquement affiché pour les éléments {{HTMLElement("input")}} qui ne sont pas vides.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-search-cancel-button`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui représente le bouton d'annulation présenté au bout d'un champ {{HTMLElement("input")}} de type `search` et qui permet d'effacer la valeur actuellement saisie dans l'élément {{HTMLElement("input")}}. Ce bouton et ce pseudo-élément ne sont pas standards et ne sont pris en charge que par WebKit et Blink. Ce bouton est uniquement affiché pour les éléments {{HTMLElement("input")}} qui ne sont pas vides.
 
 ## Syntaxe
 
 ```css
-selecteur::-webkit-search-cancel-button
+selector::-webkit-search-cancel-button {
+  /* ... */
+}
 ```
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -23,5 +27,4 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Voir aussi
 
-- {{cssxref('::-ms-clear')}}
 - {{cssxref('::-webkit-search-results-button')}}

--- a/files/fr/web/css/_doublecolon_-webkit-search-results-button/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-search-results-button/index.md
@@ -1,21 +1,25 @@
 ---
 title: ::-webkit-search-results-button
 slug: Web/CSS/::-webkit-search-results-button
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-webkit-search-results-button`** représente le bouton affiché sur le bord gauche d'un élément {{HTMLElement("input")}} de type `"search"` qui affiche un menu proposant les dernières recherches effectuées à l'utilisateur. Ce bouton et ce pseudo-élément ne sont pas standards et sont uniquement pris en charge par WebKit/Blink. Le bouton des résultats de recherche est uniquement affiché pour les éléments {{HTMLElement("input")}} qui possèdent [un attribut `results`](/fr/docs/Web/HTML/Reference/Elements/input).
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-search-results-button`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui représente le bouton affiché sur le bord gauche d'un élément {{HTMLElement("input")}} de type `type="search"` qui affiche un menu proposant les dernières recherches effectuées à l'utilisateur. Ce bouton et ce pseudo-élément ne sont pas standards et sont uniquement pris en charge par WebKit/Blink. Le bouton des résultats de recherche est uniquement affiché pour les éléments {{HTMLElement("input")}} qui possèdent [un attribut `results`](/fr/docs/Web/HTML/Reference/Elements/input#results).
 
 ## Syntaxe
 
 ```css
-selecteur::-webkit-search-results-button
+selector::-webkit-search-results-button {
+  /* ... */
+}
 ```
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
@@ -1,15 +1,25 @@
 ---
 title: ::-webkit-slider-runnable-track
 slug: Web/CSS/::-webkit-slider-runnable-track
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-webkit-slider-runnable-track`** représente la piste utilisée par un élément {{HTMLElement("input")}} de type `"range"` (cf. {{HTMLElement("input/range", '&lt;input type="range"&gt;')}}).
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-slider-runnable-track`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui représente la piste utilisée par un élément {{HTMLElement("input/range", '&lt;input type="range"&gt;')}}.
+
+## Syntaxe
+
+```css
+::-webkit-slider-runnable-track {
+  /* ... */
+}
+```
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -18,8 +28,8 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 ## Voir aussi
 
 - {{cssxref("::-webkit-slider-thumb")}}
-- Similar pseudo-elements used by other browsers:
-  - {{cssxref("::-ms-track")}}
+- Pseudo-éléments similaires utilisés par d'autres navigateurs&nbsp;:
   - {{cssxref("::-moz-range-track")}}
 
-- [CSS-Tricks : Gérer des champs `input` de type `range` de façon compatible entre les navigateurs (en anglais)](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
+- [CSS-Tricks : Gérer des champs `input` de type `range` de façon compatible entre les navigateurs <sup>(angl.)</sup>](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
+- Le billet de blog [QuirksMode&nbsp;: Stylisation et script des barres de défilement <sup>(angl.)</sup>](https://www.quirksmode.org/blog/archives/2015/11/styling_and_scr.html)

--- a/files/fr/web/css/_doublecolon_-webkit-slider-thumb/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-slider-thumb/index.md
@@ -1,15 +1,25 @@
 ---
 title: ::-webkit-slider-thumb
 slug: Web/CSS/::-webkit-slider-thumb
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{Non-standard_header}}
 
-Le pseudo-élément **`::-webkit-slider-thumb`** représente le curseur que peut déplacer l'utilisateur le long de la piste d'un élément {{HTMLElement("input")}} de type "`range"` afin de modifier la valeur numérique associée.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::-webkit-slider-thumb`** est une [extension de WebKit](/fr/docs/Web/CSS/WebKit_Extensions) qui représente le curseur que peut déplacer l'utilisateur le long de la piste d'un élément {{HTMLElement("input")}} de type "`range"` afin de modifier la valeur numérique associée.
+
+## Syntaxe
+
+```css
+::-webkit-slider-thumb {
+  /* ... */
+}
+```
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+Ce pseudo-élément ne fait partie d'aucun standard.
 
 ## Compatibilité des navigateurs
 
@@ -18,8 +28,9 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 ## Voir aussi
 
 - {{cssxref("::-webkit-slider-runnable-track")}}
-- Les pseudo-éléments analogues utilisés par les autres navigateurs :
+- Les pseudo-éléments analogues utilisés par les autres navigateurs&nbsp;:
   - {{cssxref("::-moz-range-thumb")}}
-  - {{cssxref("::-ms-thumb")}}
 
-- [CSS-Tricks : Gérer des champs `input` de type `range` de façon compatible entre les navigateurs (en anglais)](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
+- [CSS-Tricks : Gérer des champs `input` de type `range` de façon compatible entre les navigateurs <sup>(angl.)</sup>](https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/)
+- Le billet de blog [QuirksMode&nbsp;: Stylisation et script des barres de défilement <sup>(angl.)</sup>](https://www.quirksmode.org/blog/archives/2015/11/styling_and_scr.html)
+- [Quelques pièges à éviter <sup>(angl.)</sup>](https://brennaobrien.com/blog/2014/05/style-input-type-range-in-every-browser.html)

--- a/files/fr/web/css/_doublecolon_after/index.md
+++ b/files/fr/web/css/_doublecolon_after/index.md
@@ -154,7 +154,8 @@ On peut également aider les personnes qui naviguent au clavier avec cette techn
   <span tabindex="0" data-description="collection de mots et de ponctuation"
     >texte</span
   >
-  ici avec quelques  <span
+  ici avec quelques
+  <span
     tabindex="0"
     data-description="petites fenêtres surgissantes qui se cachent aussi"
     >bulles d'information</span

--- a/files/fr/web/css/_doublecolon_after/index.md
+++ b/files/fr/web/css/_doublecolon_after/index.md
@@ -151,9 +151,12 @@ On peut également aider les personnes qui naviguent au clavier avec cette techn
 <p>
   Voici l'exemple en action du code ci-dessus.<br />
   Nous avons un peu de
-  <span tabindex="0" data-description="collection de mots et de ponctuation">texte</span>
-  ici avec quelques
-  <span tabindex="0" data-description="petites fenêtres surgissantes qui se cachent aussi"
+  <span tabindex="0" data-description="collection de mots et de ponctuation"
+    >texte</span
+  >
+  ici avec quelques  <span
+    tabindex="0"
+    data-description="petites fenêtres surgissantes qui se cachent aussi"
     >bulles d'information</span
   >
   .
@@ -163,16 +166,16 @@ On peut également aider les personnes qui naviguent au clavier avec cette techn
 #### CSS
 
 ```css
-span[ data-description] {
+span[data-description] {
   position: relative;
   text-decoration: underline;
   color: blue;
   cursor: help;
 }
 
-span[ data-description]:hover::after,
-span[ data-description]:focus::after {
-  content: attr( data-description);
+span[data-description]:hover::after,
+span[data-description]:focus::after {
+  content: attr(data-description);
   position: absolute;
   left: 0;
   top: 24px;

--- a/files/fr/web/css/_doublecolon_after/index.md
+++ b/files/fr/web/css/_doublecolon_after/index.md
@@ -2,14 +2,12 @@
 title: ::after
 slug: Web/CSS/::after
 l10n:
-  sourceCommit: b7821748a66d5c581c17ddf62a74edf83638623e
+  sourceCommit: 7f460077d6f16c939718e9482a8270166f6d9abd
 ---
 
-{{CSSRef}}
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::after`** crée un pseudo-élément qui sera le dernier enfant de l'élément ciblé. Généralement utilisé pour ajouter du contenu esthétique à un élément via la propriété CSS {{cssxref("content")}}. Par défaut, l'élément créé est de type en-ligne (<i lang="en">inline</i> en anglais).
 
-En CSS, **`::after`** crée un [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) qui sera le dernier enfant de l'élément sélectionné. Il est souvent utilisé pour ajouter du contenu esthétique à un élément, en utilisant la propriété CSS [`content`](/fr/docs/Web/CSS/content). Par défaut, ce contenu est de type [en ligne (<i lang="en">inline</i> en anglais)](/fr/docs/Glossary/Inline-level_content).
-
-{{InteractiveExample("CSS Demo: ::after", "tabbed-standard")}}
+{{InteractiveExample("Démonstration CSS&nbsp;: ::after", "tabbed-standard")}}
 
 ```css interactive-example
 a::after {
@@ -30,17 +28,18 @@ a::after {
 
 ```html interactive-example
 <p>
-  The sailfish is named for its sail-like dorsal fin and is widely considered
-  the fastest fish in the ocean.
-  <a href="https://en.wikipedia.org/wiki/Sailfish"
-    >You can read more about it here</a
+  Le voilier tire son nom de sa nageoire dorsale en forme de voile et est
+  largement considéré comme le poisson le plus rapide de l'océan.
+  <a href="https://fr.wikipedia.org/wiki/Istiophorus"
+    >Vous pouvez en lire plus à ce sujet ici</a
   >.
 </p>
 
 <p>
-  The red lionfish is a predatory scorpionfish that lives on coral reefs of the
-  Indo-Pacific Ocean and more recently in the western Atlantic.
-  <a href="" class="dead-link">You can read more about it here</a>.
+  Le poisson-lion rouge est un poisson scorpion prédateur qui vit sur les récifs
+  coralliens de l'océan Indo-Pacifique et plus récemment dans l'Atlantique
+  occidental.
+  <a href="" class="dead-link">Vous pouvez en lire plus à ce sujet ici</a>.
 </p>
 ```
 
@@ -56,10 +55,24 @@ a::after {
 }
 ```
 
-Si la propriété [`content`](/fr/docs/Web/CSS/content) n'est pas indiquée, contient une valeur invalide, vaut `normal`, ou vaut `none`, le pseudo-élément `::after` ne sera pas rendu à l'écran. Il se comportera comme si `display: none` avait été appliqué.
+## Description
+
+Le pseudo-élément `::after` est un bloc en ligne (<i lang="en">inline box</i> en anglais) générée en tant qu'enfant immédiat de l'élément auquel il est associé, ou l'«&nbsp;élément d'origine&nbsp;». Il est souvent utilisé pour ajouter du contenu esthétique à un élément via la propriété {{CSSxRef("content")}}, comme des icônes, des guillemets ou d'autres décorations.
+
+Les pseudo-éléments `::after` ne peuvent pas être appliqués aux _{{ glossary("replaced elements", "éléments remplacés")}}_ tels que {{htmlelement("img")}}, dont le contenu est déterminé par des ressources externes et n'est pas affecté par les styles du document actuel.
+
+Un pseudo-élément `::after` avec une valeur {{cssxref("display")}} de `list-item` se comporte comme un élément de liste et peut donc générer un pseudo-élément {{cssxref("::marker")}}, tout comme un élément {{htmlelement("li")}} le fait.
+
+Si la propriété {{CSSxRef("content")}} n'est pas indiquée, contient une valeur invalide, vaut `normal`, ou vaut `none`, le pseudo-élément `::after` ne sera pas rendu à l'écran. Il se comportera comme si `display: none` avait été appliqué.
 
 > [!NOTE]
 > CSS a introduit la notation `::after` (avec deux deux-points) pour distinguer les [pseudo-classes](/fr/docs/Web/CSS/Pseudo-classes) des [pseudo-éléments](/fr/docs/Web/CSS/Pseudo-elements). Les navigateurs acceptent aussi la notation `:after`, introduite précédemment, à des fins de rétro-compatibilité.
+
+Par défaut, les pseudo-éléments `::before` et `::after` partagent le même contexte d'empilement que leur parent. Si aucun {{cssxref("z-index")}} n'est explicitement défini, le contenu généré par le pseudo-élément `::after` apparaîtra au-dessus du contenu généré par le pseudo-élément `::before` parce que `::after` est rendu plus tard dans le flux DOM.
+
+## Accessibilité
+
+Utiliser un pseudo-élément `::after` afin d'ajouter du contenu est déconseillé, car ce dernier n'est pas accessible de façon fiable pour les lecteurs d'écrans.
 
 ## Exemples
 
@@ -82,22 +95,24 @@ Nous allons ici créer deux classes&nbsp;: une pour les paragraphes ennuyeux et 
 ```css
 .texte-interessant::after {
   content: "<- cela est intéressant";
-  color: green;
+  color: darkgreen;
+  font-weight: bolder;
 }
 
 .texte-ennuyeux::after {
   content: "<- un peu ennuyeux";
-  color: red;
+  color: darkviolet;
+  font-weight: bolder;
 }
 ```
 
 #### Résultat
 
-{{EmbedLiveSample('', 500, 150)}}
+{{EmbedLiveSample('utilisation_simple', 500, 150)}}
 
 ### Exemple décoratif
 
-On peut mettre en forme du texte ou des images avec la propriété [`content`](/fr/docs/Web/CSS/content) à peu près de quelque manière que nous le voulions&nbsp;:
+On peut mettre en forme du texte ou des images avec la propriété {{CSSxRef("content")}} à peu près de quelque manière que nous le voulions&nbsp;:
 
 #### HTML
 
@@ -122,7 +137,7 @@ On peut mettre en forme du texte ou des images avec la propriété [`content`](/
 
 #### Résultat
 
-{{EmbedLiveSample('', 450, 20)}}
+{{EmbedLiveSample('exemple_décoratif', 450, 20)}}
 
 ### Bulles d'information
 
@@ -136,9 +151,9 @@ On peut également aider les personnes qui naviguent au clavier avec cette techn
 <p>
   Voici l'exemple en action du code ci-dessus.<br />
   Nous avons un peu de
-  <span data-descr="collection de mots et de ponctuation">texte</span>
+  <span tabindex="0" data-description="collection de mots et de ponctuation">texte</span>
   ici avec quelques
-  <span data-descr="petites fenêtres surgissantes qui se cachent aussi"
+  <span tabindex="0" data-description="petites fenêtres surgissantes qui se cachent aussi"
     >bulles d'information</span
   >
   .
@@ -148,16 +163,16 @@ On peut également aider les personnes qui naviguent au clavier avec cette techn
 #### CSS
 
 ```css
-span[data-descr] {
+span[ data-description] {
   position: relative;
   text-decoration: underline;
-  color: #00f;
+  color: blue;
   cursor: help;
 }
 
-span[data-descr]:hover::after,
-span[data-descr]:focus::after {
-  content: attr(data-descr);
+span[ data-description]:hover::after,
+span[ data-description]:focus::after {
+  content: attr( data-description);
   position: absolute;
   left: 0;
   top: 24px;
@@ -166,7 +181,7 @@ span[data-descr]:focus::after {
   border-radius: 10px;
   background-color: #ffffcc;
   padding: 12px;
-  color: #000000;
+  color: black;
   font-size: 14px;
   z-index: 1;
 }
@@ -174,11 +189,57 @@ span[data-descr]:focus::after {
 
 #### Résultat
 
-{{EmbedLiveSample('', 450, 120)}}
+{{EmbedLiveSample('bulles_dinformation', 450, 120)}}
 
-## Accessibilité
+### Les pseudo-éléments imbriqués `::after::marker`
 
-Utiliser un pseudo-élément `::after` afin d'ajouter du contenu est déconseillé, car ce dernier n'est pas accessible de façon fiable pour les lecteurs d'écrans.
+Les [pseudo-éléments imbriqués](/fr/docs/Web/CSS/Pseudo-elements#nesting_pseudo-elements) `::after::marker` sélectionnent la liste {{CSSxRef("::marker")}} d'un `::after` pseudo-élément qui est lui-même un élément de liste, c'est-à-dire qu'il a sa {{CSSxRef("display")}} propriété définie sur `list-item`.
+
+Dans cette présentation, nous générons des éléments de liste supplémentaires avant et après un menu de navigation en liste à l'aide de `::before` et `::after` (en les définissant sur `display: list-item` afin qu'ils se comportent comme des éléments de liste). Nous utilisons ensuite `ul::before::marker` et `ul::after::marker` pour donner à leurs marqueurs de liste une couleur différente.
+
+#### HTML
+
+```html
+<ul>
+  <li><a href="#">Introduction</a></li>
+  <li><a href="#">Débuter</a></li>
+  <li><a href="#">Comprendre les bases</a></li>
+</ul>
+```
+
+#### CSS
+
+```css
+ul {
+  font-size: 1.5rem;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+ul::before,
+ul::after {
+  display: list-item;
+  color: orange;
+}
+
+ul::before {
+  content: "Début";
+}
+
+ul::after {
+  content: "Fin";
+}
+
+ul::before::marker,
+ul::after::marker {
+  color: red;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample('les_pseudo-éléments_imbriqués_aftermarker', 450, 200)}}
+
+Lorsqu'on utilise des pseudo-éléments imbriqués, les puces de liste des trois éléments de navigation sont générées car ce sont des éléments `<li>`, «&nbsp;Début&nbsp;» et «&nbsp;Fin&nbsp;» ont été insérés via des pseudo-éléments et `::marker` est utilisé pour styliser leurs puces.
 
 ## Spécifications
 
@@ -190,5 +251,5 @@ Utiliser un pseudo-élément `::after` afin d'ajouter du contenu est déconseill
 
 ## Voir aussi
 
-- [`::before`](/fr/docs/Web/CSS/::before)
-- [`content`](/fr/docs/Web/CSS/content)
+- {{CSSxRef("::before")}}
+- {{CSSxRef("content")}}

--- a/files/fr/web/css/_doublecolon_backdrop/index.md
+++ b/files/fr/web/css/_doublecolon_backdrop/index.md
@@ -1,48 +1,145 @@
 ---
 title: ::backdrop
 slug: Web/CSS/::backdrop
+l10n:
+  sourceCommit: e82803beedb7f1d8a8e918c1071752f18e1e3f28
 ---
 
-{{CSSRef}}
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::backdrop`** est une boîte de la taille de la {{Glossary("viewport", "zone d'affichage")}}, qui est rendue immédiatement sous tout élément présenté dans la {{glossary("top layer", "couche supérieure")}}.
 
-Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) **`::backdrop`** est une boîte de la taille de la zone d'affichage (_viewport_) qui est affichée immédiatement sous un élément lorsque ce dernier est affiché en plein écran. Cela correspond aux éléments passés en plein écran via l'[API Fullscreen](/fr/docs/Web/API/Fullscreen_API) et aux éléments {{HTMLElement("dialog")}}.
+{{InteractiveExample("Démonstration CSS&nbsp;: ::backdrop", "tabbed-shorter")}}
 
-Lorsque plusieurs éléments sont en plein écran, ce pseudo-élément est dessiné derrière l'élément qui est le plus en avant et par dessus les autres éléments.
+```css interactive-example
+button {
+  font-size: 1.2rem;
+  padding: 5px 15px;
+}
 
-```css
-// Cette ombre n'est affichée que lorsque la boîte de dialogue
-// est ouverte avec dialog.showModal()
 dialog::backdrop {
-  background: rgba(255,0,0,.25);
+  background-color: salmon;
 }
 ```
 
-> [!NOTE]
-> L'élément `::backdrop` peut être utilisé comme un arrière-plan/masque pour l'élément afin de cacher le document en-dessous lorsque l'élément est affiché en plein écran selon la spécification.
+```html interactive-example
+<button id="showDialogBtn">Afficher la boîte de dialogue</button>
 
-Ce pseudo-élément n'hérite d'aucun autre élément et aucun autre élément n'hérite de ce pseudo-élément. Aucune restriction ne s'applique pour les propriétés qui peuvent être appliquées à ce pseudo-élément.
+<dialog id="favDialog">
+  <form method="dialog">
+    <p>
+      Le fond affiché en dehors de cette boîte de dialogue est un arrière-plan.
+    </p>
+    <button id="confirmBtn">Fermer la boîte de dialogue</button>
+  </form>
+</dialog>
+```
 
-## Syntaxe
+```js interactive-example
+const showDialogBtn = document.getElementById("showDialogBtn");
+const favDialog = document.getElementById("favDialog");
 
-{{CSSSyntax}}
+showDialogBtn.addEventListener("click", () => favDialog.showModal());
+```
+
+## Syntax
+
+```css
+::backdrop {
+  /* ... */
+}
+```
+
+## Description
+
+Les arrière-plans apparaissent dans les cas suivants&nbsp;:
+
+- Les éléments qui ont été placés en mode plein écran à l'aide de la méthode [Fullscreen API](/fr/docs/Web/API/Fullscreen_API) {{domxref("Element.requestFullscreen()")}}.
+- Les éléments {{HTMLElement("dialog")}} qui ont été affichés dans la couche supérieure via un appel à {{domxref("HTMLDialogElement.showModal()")}}.
+- Les éléments {{domxref("Popover API", "Popover", "", "nocode")}} qui ont été affichés dans la couche supérieure via un appel à {{domxref("HTMLElement.showPopover()")}}.
+
+Lorsque plusieurs éléments ont été placés dans la couche supérieure, chacun d'eux a son propre pseudo-élément `::backdrop`.
+
+```css
+/* L'arrière-plan ne s'affiche que lorsque la boîte de dialogue est ouverte avec
+   dialog.showModal() */
+dialog::backdrop {
+  background: rgb(255 0 0 / 25%);
+}
+```
+
+Les éléments sont placés dans une pile last-in/first-out (LIFO) dans la couche supérieure. Le pseudo-élément `::backdrop` permet d'obscurcir, de styliser ou de cacher complètement tout ce qui se trouve en dessous d'un élément de la couche supérieure.
+
+`::backdrop` n'hérite ni n'est hérité par d'autres éléments. Aucune restriction n'est imposée sur les propriétés qui s'appliquent à ce pseudo-élément.
 
 ## Exemples
 
-Dans cet exemple, on indique que l'ombre derrière la vidéo en plein écran doit être bleu-gris plutôt que noire.
+### Mettre en forme l'arrière-plan d'une boîte de dialogue
+
+Dans cet exemple, nous utilisons le pseudo-élément `::backdrop` pour styliser l'arrière-plan utilisé lorsqu'un modal {{htmlelement("dialog")}} est affiché.
+
+#### HTML
+
+Nous incluons un {{htmlelement("button")}} qui, lorsqu'il est cliqué, ouvrira le `<dialog>` inclus. Lorsque le `<dialog>` est ouvert, nous donnons le focus au bouton qui ferme la boîte de dialogue&nbsp;:
+
+```html
+<dialog>
+  <button autofocus>Fermer</button>
+  <p>Cette boîte de dialogue a un bel arrière-plan&nbsp;!</p>
+</dialog>
+<button>Afficher la boîte de dialogue</button>
+```
+
+#### CSS
+
+Nous ajoutons un arrière-plan à l'arrière-plan, créant un donut coloré à l'aide de [dégradés CSS](/fr/docs/Web/CSS/gradient)&nbsp;:
 
 ```css
-video::backdrop {
-  background-color: #448;
+::backdrop {
+  background-image:
+    radial-gradient(
+      circle,
+      white 0 5vw,
+      transparent 5vw 20vw,
+      white 20vw 22.5vw,
+      #eeeeee 22.5vw
+    ),
+    conic-gradient(
+      #272b66 0 50grad,
+      #2d559f 50grad 100grad,
+      #9ac147 100grad 150grad,
+      #639b47 150grad 200grad,
+      #e1e23b 200grad 250grad,
+      #f7941e 250grad 300grad,
+      #662a6c 300grad 350grad,
+      #9a1d34 350grad 400grad,
+      #43a1cd 100grad 150grad,
+      #ba3e2e
+    );
 }
 ```
 
-Voici le résultat obtenu :
+#### JavaScript
 
-![](bbb-backdrop.png)
+La boîte de dialogue est ouverte à l'aide de la méthode [`.showModal()`](/fr/docs/Web/API/HTMLDialogElement/showModal) et fermée à l'aide de la méthode [`.close()`](/fr/docs/Web/API/HTMLDialogElement/close).
 
-On peut voir ici les bandes bleu-gris au dessus et en dessous de la vidéo alors que la zone est normalement noire.
+```js
+const dialog = document.querySelector("dialog");
+const showButton = document.querySelector("dialog + button");
+const closeButton = document.querySelector("dialog button");
 
-Vous pouvez [voir cette démonstration en _live_](https://fullscreen-requestfullscreen-demo.glitch.me/) ou [voir et modifier le code sur Glitch](https://glitch.com/edit/#!/fullscreen-requestfullscreen-demo).
+// Le bouton "Afficher la boîte de dialogue" ouvre la boîte de dialogue
+showButton.addEventListener("click", () => {
+  dialog.showModal();
+});
+
+// Le bouton "Fermer" ferme la boîte de dialogue
+closeButton.addEventListener("click", () => {
+  dialog.close();
+});
+```
+
+#### Résultat
+
+{{EmbedLiveSample("mettre_en_forme_larrière-plan_dune_boîte_de_dialogue", 450, 300)}}
 
 ## Spécifications
 
@@ -56,4 +153,6 @@ Vous pouvez [voir cette démonstration en _live_](https://fullscreen-requestfull
 
 - La pseudo-classe {{cssxref(":fullscreen")}}
 - L'élément HTML {{HTMLElement("dialog")}}
-- [L'API Fullscreen](/fr/docs/Web/API/Fullscreen_API)
+- L'[API Fullscreen](/fr/docs/Web/API/Fullscreen_API)
+- L'attribut HTML global [`popover`](/fr/docs/Web/HTML/Reference/Global_attributes/popover)
+- L'[API Popover](/fr/docs/Web/API/Popover_API)

--- a/files/fr/web/css/_doublecolon_before/index.md
+++ b/files/fr/web/css/_doublecolon_before/index.md
@@ -1,33 +1,76 @@
 ---
-title: ::before (:before)
+title: ::before
 slug: Web/CSS/::before
+l10n:
+  sourceCommit: e006f2c1533c7942e5a5569f6c0e9a419ea98f46
 ---
 
-{{CSSRef}}
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::before`** crée un pseudo-élément qui sera le premier enfant de l'élément ciblé. Généralement utilisé pour ajouter du contenu esthétique à un élément via la propriété CSS {{cssxref("content")}}. Par défaut, l'élément créé est de type en-ligne (<i lang="en">inline</i> en anglais).
 
-**`::before`** crée un [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) qui sera le premier enfant de l'élément ciblé. Généralement utilisé pour ajouter du contenu esthétique à un élément via la propriété CSS {{cssxref("content")}}. Par défaut, l'élément créé est de type en-ligne (_inline_).
+{{InteractiveExample("Démonstration CSS&nbsp;: ::before", "tabbed-standard")}}
 
-```css
-/* On ajoute un coeur avant les liens */
+```css interactive-example
+a {
+  color: blue;
+  text-decoration: none;
+}
+
 a::before {
-  content: "♥";
+  content: "🔗";
+}
+
+.local-link::before {
+  content: url("/shared-assets/images/examples/firefox-logo.svg");
+  display: inline-block;
+  width: 15px;
+  height: 15px;
+  margin-right: 5px;
 }
 ```
 
-> [!NOTE]
-> Les pseudo-éléments générés par `::before` et `::after` sont contenus dans la boîte de mise en forme de l'élément. Aussi, `::before` et `::after` ne s'appliquent pas [aux éléments remplacés](/fr/docs/Web/CSS/CSS_images/Replaced_element_properties) tels que {{HTMLElement("img")}} ou {{HTMLElement("br")}}.
+```html interactive-example
+<p>
+  Des ressources d'apprentissage pour les développeurs web sont disponibles
+  partout sur Internet. Essayez-les !
+  <a href="https://web.dev/">web.dev</a>,
+  <a href="https://www.w3schools.com/">w3schools.com</a> ou le
+  <a href="https://developer.mozilla.org/" class="local-link">MDN web docs</a>.
+</p>
+```
 
 ## Syntaxe
 
-{{csssyntax}}
+```css-nolint
+::before {
+  content: /* valeur */;
+  /* propriétés */
+}
+```
 
-La notation `::before` a été introduite par CSS 3 pour différencier les [pseudo-classes](/fr/docs/Web/CSS/Pseudo-classes) et les [pseudo-éléments](/fr/docs/Web/CSS/Pseudo-elements). Les navigateurs acceptent aussi la notation `:before` introduite par CSS 2.
+## Description
+
+Le pseudo-élément `::before` est un bloc en ligne (<i lang="en">inline box</i> en anglais) générée en tant qu'enfant immédiat de l'élément auquel il est associé, ou l'«&nbsp;élément d'origine&nbsp;». Il est souvent utilisé pour ajouter du contenu esthétique à un élément via la propriété {{CSSxRef("content")}}, comme des icônes, des guillemets ou d'autres décorations.
+
+Les pseudo-éléments `::before` ne peuvent pas être appliqués aux _{{ glossary("replaced elements", "éléments remplacés")}}_ tels que {{htmlelement("img")}}, dont le contenu est déterminé par des ressources externes et n'est pas affecté par les styles du document actuel.
+
+Un pseudo-élément `::before` avec une valeur {{cssxref("display")}} de `list-item` se comporte comme un élément de liste et peut donc générer un pseudo-élément {{cssxref("::marker")}}, tout comme un élément {{htmlelement("li")}} le fait.
+
+Si la propriété [`content`](/fr/docs/Web/CSS/content) n'est pas spécifiée, a une valeur invalide, ou a `normal` ou `none` comme valeur, alors le pseudo-élément `::before` n'est pas rendu. Il se comporte comme si `display: none` était défini.
+
+> [!NOTE]
+> La spécification [Selectors Level 3](https://drafts.csswg.org/selectors-3/#gen-content) a introduit la notation à double deux-points `::before` pour distinguer les [pseudo-classes](/fr/docs/Web/CSS/Pseudo-classes) des [pseudo-éléments](/fr/docs/Web/CSS/Pseudo-elements). Les navigateurs acceptent également la notation à un seul deux-points `:before`, introduite dans CSS2.
+
+Par défaut, les pseudo-éléments `::before` et `::after` partagent le même contexte d'empilement que leur parent. Si aucun {{cssxref("z-index")}} n'est explicitement défini, le contenu généré par le pseudo-élément `::after` apparaîtra au-dessus du contenu généré par le pseudo-élément `::before` parce que `::after` est rendu plus tard dans le flux DOM.
+
+## Accessibility
+
+Using a `::before` pseudo-element to add content is discouraged, as it is not reliably accessible to screen readers.
 
 ## Exemples
 
 ### Ajouter des guillemets
 
-Un exemple simple utilisant les pseudo-éléments pour ajouter des guillemets. Ici nous avons `::before` et {{cssxref("::after")}} pour effectuer l'insertion.
+Un exemple d'utilisation des pseudo-éléments `::before` est de fournir des guillemets. Ici, nous utilisons à la fois `::before` et {{Cssxref("::after")}} pour insérer des caractères de citation.
 
 #### HTML
 
@@ -42,6 +85,7 @@ q::before {
   content: "«";
   color: blue;
 }
+
 q::after {
   content: "»";
   color: red;
@@ -50,16 +94,16 @@ q::after {
 
 #### Résultat
 
-{{EmbedLiveSample('Ajouter_des_guillemets', '500', '50', '')}}
+{{EmbedLiveSample('ajouter_des_guillemets', '500', '50')}}
 
 ### Exemple décoratif
 
-Il est possible de mettre du style à du texte ou des images, dans la propriété {{cssxref("content")}} , quasiment de n'importe quelle manière.
+On peut mettre en forme du texte ou des images avec la propriété {{CSSxRef("content")}} à peu près de quelque manière que nous le voulions&nbsp;:
 
 #### HTML
 
 ```html
-<span class="ribbon">Observez où est placée la boite orange.</span>
+<span class="ribbon">Observez où est placée la boîte orange.</span>
 ```
 
 #### CSS
@@ -70,7 +114,7 @@ Il est possible de mettre du style à du texte ou des images, dans la propriét�
 }
 
 .ribbon::before {
-  content: "Regardez cette boite orange.";
+  content: "Regardez cette boîte orange.";
   background-color: #ffba10;
   border-color: black;
   border-style: dotted;
@@ -79,11 +123,11 @@ Il est possible de mettre du style à du texte ou des images, dans la propriét�
 
 #### Résultat
 
-{{EmbedLiveSample('Exemple_décoratif', 450, 60)}}
+{{EmbedLiveSample('exemple_décoratif', 450, 60)}}
 
 ### Liste de choses à faire
 
-Dans cet exemple, nous allons créer une simple liste de choses à faire en utilisant les pseudo-éléments. Cette méthode peut être utilisée pour ajouter une petite touche à l'interface utilisateur et améliorer l'expérience utilisateur.
+Dans cet exemple, nous allons créer une liste de choses à faire en utilisant des pseudo-éléments. Cette méthode peut souvent être utilisée pour ajouter des touches subtiles à l'interface utilisateur et améliorer l'expérience utilisateur.
 
 #### HTML
 
@@ -104,7 +148,7 @@ Dans cet exemple, nous allons créer une simple liste de choses à faire en util
 li {
   list-style-type: none;
   position: relative;
-  margin: 1px;
+  margin: 2px;
   padding: 0.5em 0.5em 0.5em 2em;
   background: lightgrey;
   font-family: sans-serif;
@@ -132,10 +176,10 @@ li.done::before {
 #### JavaScript
 
 ```js
-var list = document.querySelector("ul");
+const list = document.querySelector("ul");
 list.addEventListener(
   "click",
-  function (ev) {
+  (ev) => {
     if (ev.target.tagName === "LI") {
       ev.target.classList.toggle("done");
     }
@@ -144,9 +188,104 @@ list.addEventListener(
 );
 ```
 
+Voici le code ci-dessus en action. Notez qu'aucune icône n'est utilisée, et que la coche est en fait le `::before` qui a été stylisé en CSS. Allez-y et terminez quelques tâches.
+
 #### Résultat
 
-{{EmbedLiveSample('Liste_de_choses_à_faire', '400', '300', '')}}
+{{EmbedLiveSample('liste_de_choses_a_faire', 400, 300)}}
+
+### Séquences d'échappement Unicode
+
+Comme le contenu généré est CSS, et non HTML, vous **ne pouvez pas** utiliser d'entités de balisage dans les valeurs de contenu. Si vous devez utiliser un caractère spécial et que vous ne pouvez pas l'entrer littéralement dans votre chaîne de contenu CSS, utilisez une séquence d'échappement unicode. Cela consiste en un antislash suivi de la valeur unicode hexadécimale du caractère.
+
+#### HTML
+
+```html
+<ul>
+  <li>Cracker des œufs dans un bol</li>
+  <li>Ajouter du lait</li>
+  <li>Ajouter de la farine</li>
+  <li aria-current="step"
+    >Mélanger soigneusement jusqu'à obtenir une pâte lisse<
+  /li>
+  <li>Verser une louche de pâte dans une poêle plate chaude et graissée</li>
+  <li>Faire frémir jusqu'à ce que le dessus de la crêpe perde son éclat</li>
+  <li>La retourner et faire frémir encore quelques minutes</li>
+  <li>Servir avec votre garniture préférée</li>
+</ul>
+```
+
+#### CSS
+
+```css
+li {
+  padding: 0.5em;
+}
+
+li[aria-current="step"] {
+  font-weight: bold;
+}
+
+li[aria-current="step"]::before {
+  content: "\21E8 "; /* Séquence d'échappement Unicode pour une "Flèche blanche
+                        vers la droite" */
+  display: inline;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('séquences_déchappement_unicode', 400, 200)}}
+
+### Les pseudo-éléments imbriqués `::before::marker`
+
+Le [pseudo-élément imbriqué](/fr/docs/Web/CSS/Pseudo-elements#pseudo-éléments_imbriqués) `::before::marker` sélectionne le marqueur de liste {{CSSxRef("::marker")}} d'un pseudo-élément `::before` qui est lui-même un élément de liste, c'est-à-dire qu'il a sa propriété {{CSSxRef("display")}} définie sur `list-item`.
+
+Dans cette démo, nous générons des [éléments de liste](/fr/docs/Web/HTML/Reference/Elements/li) supplémentaires avant et après un menu de navigation en liste à l'aide de `::before` et `::after` (en les définissant sur `display: list-item` afin qu'ils se comportent comme des éléments de liste). Nous utilisons ensuite `ul::before::marker` et `ul::after::marker` pour donner à leurs marqueurs de liste une couleur différente.
+
+#### HTML
+
+```html
+<ul>
+  <li><a href="#">Introduction</a></li>
+  <li><a href="#">Débuter</a></li>
+  <li><a href="#">Comprendre les bases</a></li>
+</ul>
+```
+
+#### CSS
+
+```css
+ul {
+  font-size: 1.5rem;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+ul::before,
+ul::after {
+  display: list-item;
+  color: orange;
+}
+
+ul::before {
+  content: "Début";
+}
+
+ul::after {
+  content: "Fin";
+}
+
+ul::before::marker,
+ul::after::marker {
+  color: red;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample('les_pseudo-éléments_imbriqués', 450, 200)}}
+
+Bien que les puces de liste des trois éléments de navigation soient générées parce qu'il s'agit d'éléments `<li>`, «&nbsp;Début&nbsp;» et «&nbsp;Fin&nbsp;» ont été insérés via des pseudo-éléments et `::marker` est utilisé pour styliser leurs puces.
 
 ## Spécifications
 

--- a/files/fr/web/css/_doublecolon_before/index.md
+++ b/files/fr/web/css/_doublecolon_before/index.md
@@ -205,9 +205,9 @@ Comme le contenu généré est CSS, et non HTML, vous **ne pouvez pas** utiliser
   <li>Cracker des œufs dans un bol</li>
   <li>Ajouter du lait</li>
   <li>Ajouter de la farine</li>
-  <li aria-current="step"
-    >Mélanger soigneusement jusqu'à obtenir une pâte lisse</li
-  >
+  <li aria-current="step">
+    Mélanger soigneusement jusqu'à obtenir une pâte lisse
+  </li>
   <li>Verser une louche de pâte dans une poêle plate chaude et graissée</li>
   <li>Faire frémir jusqu'à ce que le dessus de la crêpe perde son éclat</li>
   <li>La retourner et faire frémir encore quelques minutes</li>

--- a/files/fr/web/css/_doublecolon_before/index.md
+++ b/files/fr/web/css/_doublecolon_before/index.md
@@ -206,8 +206,8 @@ Comme le contenu généré est CSS, et non HTML, vous **ne pouvez pas** utiliser
   <li>Ajouter du lait</li>
   <li>Ajouter de la farine</li>
   <li aria-current="step"
-    >Mélanger soigneusement jusqu'à obtenir une pâte lisse<
-  /li>
+    >Mélanger soigneusement jusqu'à obtenir une pâte lisse</li
+  >
   <li>Verser une louche de pâte dans une poêle plate chaude et graissée</li>
   <li>Faire frémir jusqu'à ce que le dessus de la crêpe perde son éclat</li>
   <li>La retourner et faire frémir encore quelques minutes</li>

--- a/files/fr/web/css/_doublecolon_checkmark/index.md
+++ b/files/fr/web/css/_doublecolon_checkmark/index.md
@@ -1,0 +1,133 @@
+---
+title: ::checkmark
+slug: Web/CSS/::checkmark
+l10n:
+  sourceCommit: e82803beedb7f1d8a8e918c1071752f18e1e3f28
+---
+
+{{SeeCompatTable}}
+
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::checkmark`** cible la coche (<i lang="en">checkmark</i>) placée à l'intérieur de l'élément {{htmlelement("option")}} actuellement sélectionné d'un [élément de sélection personnalisable](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select). Il peut être utilisé pour fournir une indication visuelle de l'option sélectionnée.
+
+{{InteractiveExample("Démonstration CSS &nbsp;: ::checkmark")}}
+
+```html-nolint interactive-example
+<label for="pet-select">
+  Sélectionnez un animal&nbsp;:
+</label>
+<br />
+<select id="pet-select">
+  <option value="cat">Chat</option>
+  <option value="dog">Chien</option>
+  <option value="chicken">
+    Poule
+  </option>
+</select>
+```
+
+```css interactive-example
+option::checkmark {
+  color: orange;
+  font-size: 1.5rem;
+}
+
+select,
+::picker(select) {
+  appearance: base-select;
+  width: 200px;
+}
+
+select {
+  border: 2px solid #dddddd;
+  background: #eeeeee;
+  padding: 10px;
+}
+
+::picker(select) {
+  border: none;
+}
+
+option {
+  border: 2px solid #dddddd;
+  background: #eeeeee;
+  padding: 10px;
+}
+
+option:first-of-type {
+  border-radius: 8px 8px 0 0;
+}
+
+option:last-of-type {
+  border-radius: 0 0 8px 8px;
+}
+
+option:nth-of-type(odd) {
+  background: white;
+}
+
+option:not(option:last-of-type) {
+  border-bottom: none;
+}
+```
+
+## Syntax
+
+```css-nolint
+::checkmark {
+  /* ... */
+}
+```
+
+## Description
+
+Le pseudo-élément `::checkmark` cible la coche placée à l'intérieur de l'élément `<option>` actuellement sélectionné d'un [élément de sélection personnalisable](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select).
+
+Il n'est disponible pour le ciblage que lorsque l'élément d'origine a un sélecteur et a une apparence de base définie sur lui via la propriété {{cssxref("appearance")}} avec la valeur `base-select`. Sa boîte générée apparaît avant toutes les boîtes générées par le pseudo-élément {{cssxref("::before")}}. L'icône peut être personnalisée à l'aide de la propriété {{cssxref("content")}}.
+
+Le sélecteur `::checkmark` est utile par exemple si vous souhaitez masquer la coche, utiliser une icône personnalisée ou ajuster la position de rendu de la coche à l'intérieur des éléments `<option>`.
+
+> [!NOTE]
+> Le pseudo-élément `::checkmark` n'est pas inclus dans l'arbre d'accessibilité, donc tout {{cssxref("content")}} généré qui lui est appliqué ne sera pas annoncé par les technologies d'assistance. Vous devez toujours vous assurer que toute nouvelle icône que vous définissez a un sens visuel pour son objectif prévu.
+
+## Exemples
+
+### Personnalisation de la coche
+
+Pour activer la fonctionnalité de sélection personnalisable, l'élément `<select>` et son sélecteur doivent tous deux avoir une valeur {{cssxref("appearance")}} de `base-select` définie sur eux&nbsp;:
+
+```css
+select,
+::picker(select) {
+  appearance: base-select;
+}
+```
+
+En considérant que [flexbox](/fr/docs/Web/CSS/CSS_flexible_box_layout) est utilisé pour disposer les éléments `<option>` (ce qui est vrai dans **les implémentations actuelles** des sélections personnalisables), vous pourriez alors déplacer la coche du début de la ligne à la fin en définissant une valeur {{cssxref("order")}} supérieure à `0`, et en l'alignant à la fin de la ligne en utilisant une valeur {{cssxref("margin-left")}} `auto` (voir l'[Alignement et les marges automatiques](/fr/docs/Web/CSS/CSS_box_alignment/Box_alignment_in_flexbox#alignement_et_marges_automatiques)).
+
+La valeur de la propriété {{cssxref("content")}} pourrait également être définie sur un emoji différent pour changer l'icône affichée.
+
+```css
+option::checkmark {
+  order: 1;
+  margin-left: auto;
+  content: "☑️";
+}
+```
+
+Lisez la [Mise en forme de la coche de sélection actuelle](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select#mise_en_forme_de_la_coche_de_sélection_actuelle) pour un exemple complet qui utilise ce code, ainsi qu'un rendu d'exemple en direct.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- Les éléments HTML {{htmlelement("select")}}, {{htmlelement("option")}}, {{htmlelement("optgroup")}}, {{htmlelement("label")}}, {{htmlelement("button")}}, {{htmlelement("selectedcontent")}}
+- La propriété {{cssxref("appearance")}}
+- Les pseudos-éléments {{cssxref("::picker()", "::picker(select)")}}, {{cssxref("::picker-icon")}}
+- Les pseudo-classes {{cssxref(":open")}}, {{cssxref(":checked")}}
+- Les [éléments de sélection personnalisables](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select)

--- a/files/fr/web/css/_doublecolon_column/index.md
+++ b/files/fr/web/css/_doublecolon_column/index.md
@@ -1,0 +1,236 @@
+---
+title: ::column
+slug: Web/CSS/::column
+l10n:
+  sourceCommit: 601a0178d9b45121b72638d18e4e509644bd9258
+---
+
+{{SeeCompatTable}}
+
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::column`** représente les colonnes individuelles générées lorsqu'un conteneur est configuré pour afficher son contenu dans plusieurs colonnes via une [mise en page CSS multi-colonnes](/fr/docs/Web/CSS/CSS_multicol_layout). Le pseudo-élément `::column` permet d'appliquer des styles qui n'affectent pas la mise en page à ces fragments générés.
+
+## Syntaxe
+
+```css-nolint
+::column {
+  /* ... */
+}
+```
+
+## Description
+
+Quand une mise en page CSS multi-colonnes est utilisée pour disposer le contenu d'un conteneur en plusieurs colonnes (par exemple, en utilisant la propriété {{cssxref("column-count")}}), des pseudo-éléments `::column` sont générés pour contenir chaque colonne individuelle.
+
+Le pseudo-élément `::column` n'accepte que les propriétés de défilement qui s'appliquent aux éléments à l'intérieur d'un conteneur de défilement, y compris {{cssxref("scroll-margin")}}, {{cssxref("scroll-snap-align")}} et {{cssxref("scroll-snap-stop")}}.
+
+Le pseudo-élément `::column` peut avoir un pseudo-élément {{cssxref("::scroll-marker")}}. D'autres pseudo-éléments comme {{cssxref("::before")}} et {{cssxref("::after")}} ne sont pas générés sur `::column`. L'application de `::column::scroll-marker` crée un marqueur pour chaque colonne du [conteneur de défilement](/fr/docs/Glossary/Scroll_container) d'origine, les pseudo-éléments `::scroll-marker` héritant de l'élément d'origine du pseudo-élément `::column` plutôt que du `::column` lui-même.
+
+Cela est utile pour les [carrousels CSS](/fr/docs/Web/CSS/CSS_overflow/CSS_carousels)&nbsp;: `::column` peut être utilisé pour générer des pseudo-éléments `::scroll-marker` pour chaque colonne, et les définir comme [cibles de défilement](/fr/docs/Glossary/Scroll_snap#snap_target) en utilisant [accrochage de défilement CSS](/fr/docs/Web/CSS/CSS_scroll_snap).
+
+Bien que le style qui peut être appliqué à `::column` soit très limité, il pourrait être étendu à l'avenir. Toutes les propriétés et valeurs prises en charge à l'avenir seront limitées à celles qui n'affectent pas la mise en page.
+
+## Examples
+
+### Mise en page de colonnes défilantes
+
+Cette démo crée un conteneur réactif qui ajuste chaque "page" de contenu en place. Elle utilise la propriété {{cssxref("columns")}} et le pseudo-élément `::column` pour créer des colonnes de contenu qui s'étendent sur toute la largeur de leur conteneur {{glossary("scroll container")}} parent, qui peut être défilé horizontalement. Chaque colonne contient un ou plusieurs éléments de liste, dont le nombre varie en fonction de la largeur de la fenêtre d'affichage.
+
+#### HTML
+
+Le code HTML suivant consiste en une [liste non ordonnée](/fr/docs/Web/HTML/Reference/Elements/ul), chaque [élément de liste](/fr/docs/Web/HTML/Reference/Elements/li) contenant un contenu d'exemple&nbsp;:
+
+```html-nolint
+<ul>
+...
+  <li>
+    <h2>Élément 1</h2>
+  </li>
+...
+</ul>
+```
+
+```html hidden live-sample___mise_en_page_de_colonnes_défilantes live-sample___carousel_basé_sur_les_colonnes_avec_des_marqueurs_de_défilement
+<ul>
+  <li>
+    <h2>Élément 1</h2>
+  </li>
+  <li>
+    <h2>Élément 2</h2>
+  </li>
+  <li>
+    <h2>Élément 3</h2>
+  </li>
+  <li>
+    <h2>Élément 4</h2>
+  </li>
+  <li>
+    <h2>Élément 5</h2>
+  </li>
+  <li>
+    <h2>Élément 6</h2>
+  </li>
+  <li>
+    <h2>Élément 7</h2>
+  </li>
+  <li>
+    <h2>Élément 8</h2>
+  </li>
+  <li>
+    <h2>Élément 9</h2>
+  </li>
+  <li>
+    <h2>Élément 10</h2>
+  </li>
+  <li>
+    <h2>Élément 11</h2>
+  </li>
+  <li>
+    <h2>Élément 12</h2>
+  </li>
+  <li>
+    <h2>Élément 13</h2>
+  </li>
+  <li>
+    <h2>Élément 14</h2>
+  </li>
+  <li>
+    <h2>Élément 15</h2>
+  </li>
+</ul>
+```
+
+#### CSS
+
+La liste est donnée avec une hauteur ({{cssxref("height")}}) fixe et une largeur ({{cssxref("width")}}) de `100vw` pour s'étendre sur toute la largeur de la fenêtre d'affichage. Une valeur {{cssxref("overflow-x")}} de `scroll` est ensuite définie afin que le contenu défile horizontalement, et [CSS scroll snap](/fr/docs/Web/CSS/CSS_scroll_snap) est utilisé pour s'accrocher à chaque élément ou «&nbsp;page&nbsp;» — une valeur {{cssxref("scroll-snap-type")}} de `x mandatory` est utilisée pour faire de la liste un [scroll snap container](/fr/docs/Glossary/Scroll_snap#scroll_snap_container). Enfin, une valeur {{cssxref("columns")}} de `1` est définie pour forcer le contenu de la liste à s'afficher comme une seule colonne. Une valeur {{cssxref("text-align")}} de `center` est également appliquée, pour aligner le contenu avec le centre de la liste.
+
+```css hidden live-sample___mise_en_page_de_colonnes_défilantes live-sample___carousel_basé_sur_les_colonnes_avec_des_marqueurs_de_défilement
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+}
+```
+
+```css live-sample___mise_en_page_de_colonnes_défilantes live-sample___carousel_basé_sur_les_colonnes_avec_des_marqueurs_de_défilement
+ul {
+  width: 100vw;
+  height: 300px;
+  padding: 10px;
+
+  overflow-x: scroll;
+  scroll-snap-type: x mandatory;
+
+  columns: 1;
+  text-align: center;
+}
+```
+
+Les éléments de la liste sont ensuite mis en forme&nbsp;:
+
+- Une valeur {{cssxref("display")}} de `inline-block` est définie pour faire en sorte que les éléments de la liste s'alignent les uns à côté des autres et que la liste défile horizontalement.
+- Une {{cssxref("width")}} et une {{cssxref("height")}} fixes ont été définies sur eux.
+- Une valeur de `text-align` de `left` est définie sur eux pour remplacer le `text-align: center` défini sur le conteneur parent, de sorte que le contenu de l'élément sera aligné à gauche.
+- Chaque élément de liste de numéro pair se voit attribuer une couleur de fond différente via {{cssxref(":nth-child()")}}, afin qu'il soit plus facile de voir l'effet de défilement.
+
+```css live-sample___mise_en_page_de_colonnes_défilantes live-sample___carousel_basé_sur_les_colonnes_avec_des_marqueurs_de_défilement
+li {
+  list-style-type: none;
+
+  display: inline-block;
+  height: 100%;
+  width: 200px;
+  text-align: left;
+
+  background-color: #eeeeee;
+  outline: 1px solid #dddddd;
+  padding: 0 20px;
+  margin: 0 10px;
+}
+
+li:nth-child(even) {
+  background-color: cyan;
+}
+```
+
+La propriété {{cssxref("scroll-snap-align")}} est définie sur les pseudo-éléments `::column` — qui représentent les colonnes de contenu générées par la propriété `columns` — de sorte que lorsqu'elles sont défilées, une colonne soit centrée dans le conteneur de défilement.
+
+```css live-sample___mise_en_page_de_colonnes_défilantes live-sample___carousel_basé_sur_les_colonnes_avec_des_marqueurs_de_défilement
+ul::column {
+  scroll-snap-align: center;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("mise_en_page_de_colonnes_défilantes", "100%", "400px")}}
+
+### Carousel basé sur les colonnes avec des marqueurs de défilement
+
+En s'appuyant sur l'exemple précédent, nous allons créer des marqueurs de défilement pour permettre une navigation directe vers différentes colonnes en appliquant un {{cssxref("scroll-marker-group")}} au conteneur et un {{cssxref("::scroll-marker")}} à chaque pseudo-élément `::column`. Le HTML reste inchangé.
+
+#### CSS
+
+Nous créons un groupe de marqueurs de défilement avec la propriété {{cssxref("scroll-marker-group")}}, plaçant le groupe après tout le contenu&nbsp;:
+
+```css live-sample___carousel_basé_sur_les_colonnes_avec_des_marqueurs_de_défilement
+ul {
+  scroll-marker-group: after;
+}
+```
+
+Nous appliquons ensuite des styles au pseudo-élément {{cssxref("::scroll-marker-group")}} pour disposer les marqueurs de défilement au centre de la ligne avec un écart de `0.4em` entre chacun d'eux&nbsp;:
+
+```css live-sample___carousel_basé_sur_les_colonnes_avec_des_marqueurs_de_défilement
+::scroll-marker-group {
+  display: flex;
+  gap: 0.4em;
+  place-content: center;
+}
+```
+
+Enfin, nous utilisons le pseudo-élément {{cssxref("::scroll-marker")}} pour créer un marqueur rond et transparent pour chaque élément de liste avec une bordure noire, puis nous stylisons le marqueur de l'élément actuellement défilé différemment des autres, en ciblant le marqueur avec la pseudo-classe {{cssxref(":target-current")}}&nbsp;:
+
+```css live-sample___carousel_basé_sur_les_colonnes_avec_des_marqueurs_de_défilement
+ul::column::scroll-marker {
+  content: "";
+  width: 16px;
+  height: 16px;
+  background-color: transparent;
+  border: 2px solid black;
+  border-radius: 10px;
+}
+
+ul::column::scroll-marker:target-current {
+  background-color: black;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("carousel_basé_sur_les_colonnes_avec_des_marqueurs_de_défilement", "100%", "400px")}}
+
+Essayez d'appuyer sur les marqueurs de défilement pour sauter directement à chaque page. Notez comment le marqueur actuel est mis en surbrillance afin que vous puissiez voir où vous en êtes dans la pagination. Essayez également de tabuler vers le groupe de marqueurs de défilement, puis utilisez les touches de direction pour faire défiler chaque page.
+
+Voir la [création de carrousels CSS](/fr/docs/Web/CSS/CSS_overflow/CSS_carousels) pour plus d'exemples de carrousels.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- {{cssxref("columns")}}
+- {{cssxref("::scroll-marker")}}
+- {{cssxref("::scroll-marker-group")}}
+- {{cssxref(":target-current")}}
+- [Création de carrousels CSS](/fr/docs/Web/CSS/CSS_overflow/CSS_carousels)
+- Le module de [Mise en page multi-colonnes CSS](/fr/docs/Web/CSS/CSS_multicol_layout)
+- Le module de [Débordement CSS](/fr/docs/Web/CSS/CSS_overflow)
+- [Galerie CSS de carrousels <sup>(angl.)</sup>](https://chrome.dev/carousel/) sur chrome.dev (2025)

--- a/files/fr/web/css/_doublecolon_cue/index.md
+++ b/files/fr/web/css/_doublecolon_cue/index.md
@@ -1,50 +1,120 @@
 ---
 title: ::cue
 slug: Web/CSS/::cue
+l10n:
+  sourceCommit: 7f460077d6f16c939718e9482a8270166f6d9abd
 ---
 
-{{CSSRef}}
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::cue`** permet de cibler les indications textuelles [WebVTT](/fr/docs/Web/API/WebVTT_API) d'un élément. Ce pseudo-élément peut être utilisé afin de mettre en forme [les légendes et autres indications textuelles](/fr/docs/Web/API/WebVTT_API#styling_webtt_cues) pour les médias avec des pistes VTT.
 
-Le pseudo-élément CSS **`::cue`** permet de cibler les indications textuelles [WebVTT](/fr/docs/Web/API/WebVTT_API) d'un élément. Ce pseudo-élément peut être utilisé afin de mettre en forme [les légendes et autres indications textuelles](/fr/docs/Web/API/WebVTT_API#styling_webtt_cues) pour les médias avec des pistes VTT.
+{{InteractiveExample("Démonstration CSS&nbsp;: ::cue", "tabbed-shorter")}}
 
-```css
-::cue {
+```css interactive-example
+video {
+  width: 100%;
+}
+
+video::cue {
+  font-size: 1rem;
   color: yellow;
-  font-weight: bold;
+}
+
+::cue(u) {
+  color: red;
+}
+```
+
+```html interactive-example
+<video controls src="/shared-assets/videos/friday.mp4">
+  <track
+    default
+    kind="captions"
+    srclang="en"
+    src="/shared-assets/misc/friday.vtt" />
+  Désolé, votre navigateur ne prend pas en charge les vidéos intégrées.
+</video>
+```
+
+Les propriétés sont appliquées à l'ensemble des indications (comme si celles-ci formaient un seul ensemble). Seule `background` (ou les propriétés raccourcies associées) s'appliquent à chaque indication séparément (afin d'éviter de créer des boîtes qui masqueraient de grandes zones sur le média).
+
+Dans l'exemple ci-dessus, le sélecteur `::cue(u)` sélectionne tous les éléments [`<u>`](/fr/docs/Web/HTML/Reference/Elements/u) à l'intérieur [du texte de l'indication](https://raw.githubusercontent.com/mdn/interactive-examples/main/live-examples/media/examples/friday.vtt).
+
+## Syntaxe
+
+```css-nolint
+::cue | ::cue(<selector>) {
+  /* ... */
 }
 ```
 
 ## Propriétés autorisées
 
-Seul un sous-ensemble des propriétés CSS peut être utilisé avec le pseudo-élément `::cue` :
+Les règles dont les sélecteurs incluent cet élément ne peuvent utiliser que les propriétés CSS suivantes&nbsp;:
 
-- {{CSSxRef("background")}} et les propriétés détaillées associées
+- {{CSSxRef("background")}}
+- {{CSSxRef("background-attachment")}}
+- {{CSSxRef("background-clip")}}
+- {{CSSxRef("background-color")}}
+- {{CSSxRef("background-image")}}
+- {{CSSxRef("background-origin")}}
+- {{CSSxRef("background-position")}}
+- {{CSSxRef("background-repeat")}}
+- {{CSSxRef("background-size")}}
 - {{CSSxRef("color")}}
-- {{CSSxRef("font")}} et les propriétés détaillées associées
+- {{CSSxRef("font")}}
+- {{CSSxRef("font-family")}}
+- {{CSSxRef("font-size")}}
+- {{CSSxRef("font-stretch")}}
+- {{CSSxRef("font-style")}}
+- {{CSSxRef("font-variant")}}
+- {{CSSxRef("font-weight")}}
 - {{CSSxRef("line-height")}}
 - {{CSSxRef("opacity")}}
-- {{CSSxRef("outline")}} et les propriétés détaillées associées
+- {{CSSxRef("outline")}}
+- {{CSSxRef("outline-color")}}
+- {{CSSxRef("outline-style")}}
+- {{CSSxRef("outline-width")}}
 - {{CSSxRef("ruby-position")}}
 - {{CSSxRef("text-combine-upright")}}
-- {{CSSxRef("text-decoration")}} et les propriétés détaillées associées
+- {{CSSxRef("text-decoration")}}
+- {{CSSxRef("text-decoration-color")}}
+- {{CSSxRef("text-decoration-line")}}
+- {{CSSxRef("text-decoration-style")}}
+- {{CSSxRef("text-decoration-thickness")}}
 - {{CSSxRef("text-shadow")}}
 - {{CSSxRef("visibility")}}
 - {{CSSxRef("white-space")}}
 
-Les propriétés sont appliquées à l'ensembles des indications (comme si celles-ci formaient un seul ensemble). Seule `background` (ou les propriétés raccourcies associées) s'appliquent à chaque indication séparément (afin d'éviter de créer des boîtes qui masqueraient de grandes zones sur le média).
-
-## Syntaxe
-
-{{csssyntax}}
-
 ## Exemples
 
-La règle CSS suivante permet d'avoir les indications textuelles dans un texte blanc et sur un arrière-plan qui est une boîte noire transparent.
+### Mettre en forme les repères WebVTT en blanc sur fond noir
+
+Le CSS suivant définit le style de la repère afin que le texte soit blanc et que l'arrière-plan soit une boîte noire translucide.
 
 ```css
 ::cue {
-  color: #fff;
-  background-color: rgba(0, 0, 0, 0.6);
+  color: white;
+  background-color: rgb(0 0 0 / 60%);
+}
+```
+
+### Mettre en forme les objets de nœud internes WebVTT
+
+Le texte des repères peut inclure des _objets de nœud internes_ sous forme de balises (similaires aux éléments HTML) `<c>`, `<i>`, `<b>`, `<u>`, `<ruby>`, `<rt>`, `<v>`, et `<lang>`.
+Le sélecteur `::cue()` peut être utilisé pour appliquer des styles au contenu à l'intérieur de ces balises afin de personnaliser l'affichage de la piste WebVTT.
+Considérons le texte de repère suivant qui utilise la balise `<u>` pour souligner un texte :
+
+```plain
+00:00:01.500 --> 00:00:02.999 line:80%
+Dites-moi, le <u>seigneur de l'univers</u> est ici ?
+```
+
+La règle CSS suivante personnalise le texte à l'intérieur de la balise `<u>` avec une couleur et un {{CSSxRef("text-decoration")}}&nbsp;:
+
+```css
+::cue(u) {
+  color: red;
+  text-decoration: wavy overline lime;
 }
 ```
 
@@ -58,4 +128,5 @@ La règle CSS suivante permet d'avoir les indications textuelles dans un texte b
 
 ## Voir aussi
 
-- [Web Video Tracks Format (WebVTT)](/fr/docs/Web/API/WebVTT_API)
+- [Format des pistes vidéo Web (WebVTT)](/fr/docs/Web/API/WebVTT_API)
+- Les éléments {{HTMLElement("track")}}, {{HTMLElement("video")}}

--- a/files/fr/web/css/_doublecolon_details-content/index.md
+++ b/files/fr/web/css/_doublecolon_details-content/index.md
@@ -31,7 +31,9 @@ details[open]::details-content {
 ## Syntaxe
 
 ```css
-selector::details-content
+selector::details-content {
+  /* ... */
+}
 ```
 
 ## Exemples

--- a/files/fr/web/css/_doublecolon_details-content/index.md
+++ b/files/fr/web/css/_doublecolon_details-content/index.md
@@ -1,0 +1,110 @@
+---
+title: ::details-content
+slug: Web/CSS/::details-content
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
+---
+
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::details-content`** représente le contenu extensible/collapsible d'un élément {{HTMLElement("details")}}.
+
+{{InteractiveExample("Démonstration CSS&nbsp;: ::details-content", "tabbed-shorter")}}
+
+```css interactive-example
+details[open]::details-content {
+  color: dodgerblue;
+  padding: 0.5em;
+  border: thin solid grey;
+}
+```
+
+```html interactive-example
+<details open>
+  <summary>Exemple de résumé</summary>
+  <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+  <p>
+    Architecto cupiditate ea optio modi quas sequi, esse libero asperiores
+    debitis eveniet commodi hic ad.
+  </p>
+</details>
+```
+
+## Syntaxe
+
+```css
+selector::details-content
+```
+
+## Exemples
+
+### Exemple simple
+
+Dans cet exemple, le pseudo-élément `::details-content` est utilisé pour définir une {{cssxref("background-color")}} sur le contenu de l'élément {{HTMLElement("details")}}.
+
+#### HTML
+
+```html
+<details>
+  <summary>Cliquez ici</summary>
+  <p>Voici un contenu</p>
+</details>
+```
+
+#### CSS
+
+```css
+details::details-content {
+  background-color: #a29bfe;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("exemple_simple", "100%", 150)}}
+
+### Exemple de transition
+
+Dans cet exemple, le pseudo-élément `::details-content` est utilisé pour définir une {{cssxref("transition")}} sur le contenu de l'élément {{HTMLElement("details")}} afin qu'il s'affiche en douceur lorsqu'il est développé, et disparaisse à nouveau lorsqu'il est réduit. Pour ce faire, deux transitions distinctes sont spécifiées à l'intérieur de la propriété abrégée `transition`&nbsp;:
+
+- La propriété {{cssxref("opacity")}} reçoit une transition de base de `600ms` pour créer l'effet de fondu en entrée/sortie.
+- La propriété {{cssxref("content-visibility")}} (qui est basculée entre `hidden` et `visible` lorsque le contenu `<details>` est développé/réduit) reçoit également une transition de base de `600ms`, mais avec la valeur {{cssxref("transition-behavior")}} `allow-discrete` spécifiée. Cela permet au navigateur de démarrer une transition sur `content-visibility`, dont le comportement d'animation est [discret](/fr/docs/Web/CSS/CSS_animated_properties#discrète). L'effet est que le contenu est visible pendant toute la durée de la transition, permettant aux autres transitions d'être vues. Si cette transition n'était pas incluse, le contenu disparaîtrait immédiatement lorsque le contenu `<details>` serait réduit — vous ne verriez pas le fondu en douceur.
+
+#### HTML
+
+```html
+<details>
+  <summary>Cliquez ici</summary>
+  <p>Voici un contenu</p>
+</details>
+```
+
+#### CSS
+
+```css
+details::details-content {
+  opacity: 0;
+  transition:
+    opacity 600ms,
+    content-visibility 600ms allow-discrete;
+}
+
+details[open]::details-content {
+  opacity: 1;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("exemple_de_transition", "100%", 150)}}
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- {{HTMLElement("details")}}
+- {{HTMLElement("summary")}}

--- a/files/fr/web/css/_doublecolon_file-selector-button/index.md
+++ b/files/fr/web/css/_doublecolon_file-selector-button/index.md
@@ -52,7 +52,6 @@ input::file-selector-button {
 
 #### CSS
 
-
 ```css hidden
 form {
   display: flex;

--- a/files/fr/web/css/_doublecolon_file-selector-button/index.md
+++ b/files/fr/web/css/_doublecolon_file-selector-button/index.md
@@ -1,53 +1,147 @@
 ---
-title: ::-webkit-file-upload-button
+title: ::file-selector-button
 slug: Web/CSS/::file-selector-button
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::file-upload-button`** représente le bouton d'un élément {{HTMLElement("input")}} de type `file`.
 
-Le pseudo-élément **`::-webkit-file-upload-button`** représente le bouton d'un élément {{HTMLElement("input")}} de type `file`.
+{{InteractiveExample("Démonstration CSS&nbsp;: ::file-selector-button", "tabbed-shorter")}}
 
-Ce pseudo-élément n'est pas standard et est uniquement pris en charge par les navigateurs basés sur WebKit/Blink.
+```css interactive-example
+input {
+  margin-top: 1rem;
+}
+
+input::file-selector-button {
+  font-weight: bold;
+  color: dodgerblue;
+  padding: 0.5em;
+  border: thin solid grey;
+  border-radius: 3px;
+}
+```
+
+```html interactive-example
+<label for="avatar">Choisissez une photo de profil&nbsp;:</label><br />
+
+<input id="avatar" type="file" name="avatar" accept="image/png, image/jpeg" />
+```
 
 ## Syntaxe
 
 ```css
-selecteur::-webkit-file-upload-button
+::file-selector-button {
+  /* ... */
+}
 ```
 
 ## Exemples
 
-### CSS
+### Exemple simple
 
-```css
-input,
-label {
-  display: block;
-}
-
-input[type="file"]::-webkit-file-upload-button {
-  border: 1px solid grey;
-  background: #fffaaa;
-}
-```
-
-### HTML
+#### HTML
 
 ```html
 <form>
-  <label for="fileUpload">Uploader un fichier</label><br />
+  <label for="fileUpload">Uploader un fichier</label>
   <input type="file" id="fileUpload" />
 </form>
 ```
 
-### Résultat
+#### CSS
 
-{{EmbedLiveSample('Exemples')}}
+
+```css hidden
+form {
+  display: flex;
+  gap: 1em;
+  align-items: center;
+}
+```
+
+```css
+input[type="file"]::file-selector-button {
+  border: 2px solid #6c5ce7;
+  padding: 0.2em 0.4em;
+  border-radius: 0.2em;
+  background-color: #a29bfe;
+  transition: 1s;
+}
+
+input[type="file"]::file-selector-button:hover {
+  background-color: #81ecec;
+  border: 2px solid #00cec9;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample('exemple_simple', "100%", 150)}}
+
+Notez que `::file-selector-button` est un élément entier, et en tant que tel, il correspond aux règles de la feuille de style de l'agent utilisateur. En particulier, les polices et les couleurs ne seront pas nécessairement héritées de l'élément `input`.
+
+### Exemple de repli
+
+#### HTML
+
+```html
+<form>
+  <label for="fileUpload">Uploader un fichier</label>
+  <input type="file" id="fileUpload" />
+</form>
+```
+
+#### CSS
+
+```css hidden
+form {
+  display: flex;
+  gap: 1em;
+  align-items: center;
+}
+```
+
+```css
+input[type="file"]::file-selector-button {
+  border: 2px solid #6c5ce7;
+  padding: 0.2em 0.4em;
+  border-radius: 0.2em;
+  background-color: #a29bfe;
+  transition: 1s;
+}
+
+input[type="file"]::-ms-browse:hover {
+  background-color: #81ecec;
+  border: 2px solid #00cec9;
+}
+
+input[type="file"]::-webkit-file-upload-button:hover {
+  background-color: #81ecec;
+  border: 2px solid #00cec9;
+}
+
+input[type="file"]::file-selector-button:hover {
+  background-color: #81ecec;
+  border: 2px solid #00cec9;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("exemple_de_repli", "100%", 150)}}
 
 ## Spécifications
 
-Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink et ne fait partie d'aucune spécification.
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
 {{Compat}}
+
+## Voir aussi
+
+- Les [extensions CSS WebKit](/fr/docs/Web/CSS/WebKit_Extensions)
+- L'[API d'entrées de fichiers et de répertoires](/fr/docs/Web/API/File_and_Directory_Entries_API)
+- [`<input type="file">`](/fr/docs/Web/HTML/Reference/Elements/input/file)

--- a/files/fr/web/css/_doublecolon_first-letter/index.md
+++ b/files/fr/web/css/_doublecolon_first-letter/index.md
@@ -1,109 +1,122 @@
 ---
 title: ::first-letter
 slug: Web/CSS/::first-letter
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::first-letter`** sélectionne la première lettre de la première ligne d'un bloc, si elle n'est pas précédée par un quelconque autre contenu (comme une image ou un tableau en ligne) sur sa ligne.
 
-Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) **`::first-letter`** sélectionne la première lettre de la première ligne d'un bloc, si elle n'est pas précédée par un quelconque autre contenu (comme une image ou un tableau en ligne) sur sa ligne.
+{{InteractiveExample("Démonstration CSS&nbsp;: ::first-letter", "tabbed-shorter")}}
 
-```css
-/* Sélectionne la première lettre */
-/* d'un élément <p> */
+```css interactive-example
 p::first-letter {
-  color: red;
-  font-size: 130%;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: brown;
 }
 ```
 
-La première lettre d'un élément n'est pas forcément évidente à identifier :
+```html interactive-example
+<p>
+  Des scientifiques explorant les profondeurs de la baie de Monterey ont fait la
+  découverte inattendue d'une espèce rare et unique de poisson dragon. Cette
+  espèce est la plus rare de son genre.
+</p>
 
-- La ponctuation, c'est-à-dire n'importe quel caractère défini dans une des classes Unicode
+<p>
+  Lorsque Robison et une équipe de chercheurs ont découvert ce poisson, ils
+  participaient à une expédition d'une semaine.
+</p>
+```
 
-  <i lang="en">open</i>
+La première lettre d'un élément n'est pas toujours triviale à identifier&nbsp;:
 
-  (Ps),
-
-  <i lang="en">close</i>
-
-  (Pe),
-
-  <i lang="en">initial quote</i>
-
-  (Pi),
-
-  <i lang="en">final quote</i>
-
-  (Pf) et
-
-  <i lang="en">other punctuation</i>
-
-  (Po) , précédant ou suivant immédiatement la première lettre est aussi sélectionnée par ce pseudo-élément.
-
-- D'autre part, certaines langues possèdent des digraphes qui sont mis en majuscule ensemble, comme le `IJ` en néerlandais. Dans ces rares cas, les deux lettres du digraphes doivent être sélectionnées par le pseudo-élément `::first-letter`. (Ceci est mal supporté par les navigateurs, reportez vous au [tableau de compatibilité des navigateurs](#compatibilité_des_navigateurs)).
-- Enfin, une combinaison du pseudo-élément {{cssxref("::before")}} et de la propriété {{cssxref("content")}} peut injecter du texte au début de l'élément. Dans ce cas, `::first-letter` sélectionnera la première lettre du contenu inséré.
-
-Une première lettre n'a de signification que dans une [boîte englobante](/fr/docs/Web/CSS/CSS_display/Visual_formatting_model#les_éléments_de_bloc_et_les_boîtes_de_bloc), ainsi le pseudo-élément `::first-letter` n'a un effet que sur les éléments ayant une valeur {{cssxref("display")}} correspondant à `block`, `inline-block`, `table-cell`, `list-item` ou `table-caption`. Dans tous les autres cas, `::first-letter` n'a pas d'effet.
-
-## Propriétés utilisables
-
-Seul un petit sous-groupe de propriétés CSS peuvent être utilisées dans un bloc déclaratif contenant un sélecteur utilisant le pseudo-élément `::first-letter` :
-
-- Toutes les propriétés liées aux polices de caractère : {{cssxref("font")}}, {{cssxref("font-style")}}, {{cssxref("font-feature-settings")}}, {{cssxref("font-kerning")}}, {{cssxref("font-language-override")}}, {{cssxref("font-stretch")}}, {{cssxref("font-synthesis")}}, {{cssxref("font-variant")}}, {{cssxref("font-variant-alternates")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-east-asian")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-weight")}}, {{cssxref("font-size")}}, {{cssxref("font-size-adjust")}}, {{cssxref("line-height")}} et {{cssxref("font-family")}}.
-- Toutes les propriétés liées à l'arrière-plan : {{cssxref("background")}},{{cssxref("background-color")}}, {{cssxref("background-image")}}, {{cssxref("background-clip")}}, {{cssxref("background-origin")}}, {{cssxref("background-position")}}, {{cssxref("background-repeat")}}, {{cssxref("background-size")}}, {{cssxref("background-attachment")}} et {{cssxref("background-blend-mode")}}.
-- Toutes les propriétés liées à `margin` : {{cssxref("margin")}}, {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, {{cssxref("margin-left")}}.
-- Toutes les propriétés liées à `padding` : {{cssxref("padding")}}, {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, {{cssxref("padding-left")}}.
-- Toutes les propriétés liées aux bordures : les raccourcis {{cssxref("border")}}, {{cssxref("border-style")}}, {{cssxref("border-color")}}, {{cssxref("border-width")}}, {{cssxref("border-radius")}}, {{cssxref("border-image")}}, et les propriétés détaillées.
-- La propriété {{cssxref("color")}} .
-- Les propriétés {{cssxref("text-decoration")}}, {{cssxref("text-shadow")}}, {{cssxref("text-transform")}}, {{cssxref("letter-spacing")}}, {{cssxref("word-spacing")}} (lorsqu'approprié), {{cssxref("line-height")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-style")}}, {{cssxref("box-shadow")}}, {{cssxref("float")}}, {{cssxref("vertical-align")}} (seulement si `float` vaut `none`).
-
-Puisque cette liste sera complétée dans l'avenir, il est recommandé de ne pas utiliser d'autres propriétés dans un bloc de déclaration, de manière à concevoir un CSS pérenne.
+- La ponctuation qui précède ou suit immédiatement la première lettre est incluse dans la correspondance. La ponctuation comprend tout caractère Unicode défini dans les classes _open_ (Ps), _close_ (Pe), _initial quote_ (Pi), _final quote_ (Pf) et _other punctuation_ (Po).
+- Certaines langues ont des digraphes qui sont toujours capitalisés ensemble, comme le `IJ` en néerlandais. Dans ces cas, les deux lettres du digraphe doivent être correspondantes par le pseudo-élément `::first-letter`.
+- Une combinaison du pseudo-élément {{ cssxref("::before") }} et de la propriété {{ cssxref("content") }} peut injecter du texte au début de l'élément. Dans ce cas, `::first-letter` correspondra à la première lettre de ce contenu généré.
 
 > [!NOTE]
-> Dans CSS 2, les pseudo-éléments étaient précédés d'un seul caractère deux-points. Puisque les pseudo-classes suivaient elles aussi cette convention, la distinction était impossible. Afin de résoudre ce problème, CSS 2.1 a modifié la convention des pseudo-éléments. Désormais un pseudo-élément est précédé de deux caractères deux-points, et une pseudo-classe est toujours précédée d'un seul caractère deux-points.
+> CSS a introduit la notation `::first-letter` (avec deux deux-points) pour distinguer [pseudo-classes](/fr/docs/Web/CSS/Pseudo-classes) des [pseudo-elements](/fr/docs/Web/CSS/Pseudo-elements). Pour des raisons de compatibilité, les navigateurs acceptent également `:first-letter`, introduit plus tôt.
 >
-> Du fait que de nombreux navigateurs avaient déjà implémentés la syntaxe CSS 2 dans une version publique, tous les navigateurs supportant la syntaxe à deux caractères deux-points peuvent aussi supporter l'ancienne syntaxe à un caractère deux-points.
->
-> Si les navigateurs anciens doivent être supportés, `:first-letter` est le seul choix viable. Sinon, la syntaxe `::first-letter` doit être privilégiée.
+> La prise en charge des digraphes tels que `IJ` en néerlandais est faible. Consultez le tableau de compatibilité ci-dessous pour voir l'état actuel de la prise en charge.
+
+## Propriétés autorisées
+
+Seul un petit sous-ensemble de propriétés CSS peut être utilisé avec le pseudo-élément `::first-letter`&nbsp;:
+
+- Toutes les propriétés de police&nbsp;: {{ Cssxref("font") }}, {{ Cssxref("font-style") }}, {{cssxref("font-feature-settings")}}, {{cssxref("font-kerning")}}, {{cssxref("font-language-override")}}, {{cssxref("font-stretch")}}, {{cssxref("font-synthesis")}}, {{ Cssxref("font-variant") }}, {{cssxref("font-variant-alternates")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-east-asian")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-position")}}, {{ Cssxref("font-weight") }}, {{ Cssxref("font-size") }}, {{cssxref("font-size-adjust")}}, {{ Cssxref("line-height") }} et {{ Cssxref("font-family") }}
+- Toutes les propriétés d'arrière-plan&nbsp;: {{ Cssxref("background") }}, {{ Cssxref("background-color") }}, {{ Cssxref("background-image") }}, {{cssxref("background-clip")}}, {{cssxref("background-origin")}}, {{ Cssxref("background-position") }}, {{ Cssxref("background-repeat") }}, {{ cssxref("background-size") }}, {{ Cssxref("background-attachment") }} et {{cssxref("background-blend-mode")}}
+- Toutes les propriétés de marge&nbsp;: {{ Cssxref("margin") }}, {{ Cssxref("margin-top") }}, {{ Cssxref("margin-right") }}, {{ Cssxref("margin-bottom") }}, {{ Cssxref("margin-left") }}
+- Toutes les propriétés de remplissage&nbsp;: {{ Cssxref("padding") }}, {{ Cssxref("padding-top") }}, {{ Cssxref("padding-right") }}, {{ Cssxref("padding-bottom") }}, {{ Cssxref("padding-left") }}
+- Toutes les propriétés de bordure&nbsp;: les raccourcis {{ Cssxref("border") }}, {{ Cssxref("border-style") }}, {{ Cssxref("border-color") }}, {{ cssxref("border-width") }}, {{ cssxref("border-radius") }}, {{cssxref("border-image")}} et les propriétés longues
+- La propriété {{ cssxref("color") }}
+- Les propriétés CSS {{ cssxref("text-decoration") }}, {{cssxref("text-shadow")}}, {{ cssxref("text-transform") }}, {{ cssxref("letter-spacing") }}, {{ cssxref("word-spacing") }} (le cas échéant), {{ cssxref("line-height") }}, {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-style")}}, {{cssxref("box-shadow")}}, {{ cssxref("float") }}, {{ cssxref("vertical-align") }} (uniquement si la valeur de `float` est `none`)
 
 ## Syntaxe
 
-{{csssyntax}}
-
-## Exemples
-
-Dans cet exemple, on prend la première lettre de chaque paragraphe et on l'affiche en rouge et en gros.
-
-### CSS
-
 ```css
-p::first-letter {
-  color: red;
-  font-size: 130%;
+::first-letter {
+  /* ... */
 }
 ```
 
-### HTML
+## Exemples
+
+### Lettre en tête de ligne
+
+Dans cet exemple, nous allons utiliser le pseudo-élément `::first-letter` pour créer un effet de lettrine sur la première lettre du paragraphe qui suit immédiatement le `<h2>`.
+
+#### HTML
 
 ```html
+<h2>Mon titre</h2>
 <p>
   Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
   eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
   voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita
-  kasd gubergren, no sea takimata sanctus est. Lorem ipsum dolor sit amet. Lorem
-  ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy amet.
+  kasd gubergren, no sea takimata sanctus est.
 </p>
 <p>
   Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie
   consequat.
 </p>
+```
+
+#### CSS
+
+```css
+p {
+  width: 500px;
+  line-height: 1.5;
+}
+
+h2 + p::first-letter {
+  color: white;
+  background-color: black;
+  border-radius: 2px;
+  box-shadow: 3px 3px 0 red;
+  font-size: 250%;
+  padding: 6px 3px;
+  margin-right: 6px;
+  float: left;
+}
+```
+
+#### Résultat
+
+{{ EmbedLiveSample('lettre_en_tête_de_ligne', '100%', 350) }}
+
+### Effet sur la ponctuation spéciale et les caractères non latins
+
+Cet exemple illustre l'effet de `::first-letter` sur la ponctuation spéciale et les caractères non latins.
+
+#### HTML
+
+```html
 <p>
-  Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit
-  lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure
-  dolor in hendrerit in vulputate velit esse molestie consequat, vel illum
-  dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio
-  dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te
-  feugait nulla facilisi.
+  Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie
+  consequat.
 </p>
 <p>-The beginning of a special punctuation mark.</p>
 <p>_The beginning of a special punctuation mark.</p>
@@ -113,12 +126,56 @@ p::first-letter {
 <p>#The beginning of a special punctuation mark.</p>
 <p>「特殊的汉字标点符号开头。</p>
 <p>《特殊的汉字标点符号开头。</p>
-<p>“特殊的汉字标点符号开头。</p>
+<p>"特殊的汉字标点符号开头。</p>
 ```
 
-### Résultat
+#### CSS
 
-{{EmbedLiveSample('Exemples', '80%', 420)}}
+```css
+p::first-letter {
+  color: red;
+  font-size: 150%;
+}
+```
+
+#### Résultat
+
+{{ EmbedLiveSample('effet_sur_la_ponctuation_spéciale_et_les_caractères_non_latins', '100%', 350) }}
+
+### Mise en forme de la première lettre dans un élément de texte SVG
+
+Dans cet exemple, nous utilisons le pseudo-élément `::first-letter` pour styliser la première lettre d'un élément SVG {{SVGElement("text")}}.
+
+> [!NOTE]
+> Au moment de la rédaction, cette fonctionnalité a un [support limité](#compatibilité_des_navigateurs).
+
+#### HTML
+
+```html
+<svg viewBox="0 0 300 40">
+  <text y="30">Première lettre dans un &lt;text&gt; SVG</text>
+</svg>
+```
+
+#### CSS
+
+```css
+text {
+  font-family: sans-serif;
+}
+
+text::first-letter {
+  font-family: serif;
+  font-size: 2rem;
+  font-weight: 600;
+  fill: tomato;
+  stroke: indigo;
+}
+```
+
+#### Résultat
+
+{{ EmbedLiveSample("mise_en_forme_de_la_première_lettre_dans_un_élément_de_texte_SVG", "100%", "100") }}
 
 ## Spécifications
 

--- a/files/fr/web/css/_doublecolon_first-line/index.md
+++ b/files/fr/web/css/_doublecolon_first-line/index.md
@@ -23,15 +23,15 @@ p::first-line {
   spectacle étrange&nbsp;: un poisson bondissant hors de l'eau et planant à des
   dizaines de mètres avant de retourner dans les profondeurs de l'océan. Les
   premiers marins méditerranéens pensaient que ces poissons volants revenaient
-  sur le rivage la nuit pour dormir et ont donc appelé cette famille de
-  poissons marins Exocoetidae.
+  sur le rivage la nuit pour dormir et ont donc appelé cette famille de poissons
+  marins Exocoetidae.
 </p>
 ```
 
 Les effets de `::first-line` sont limités par la longueur et le contenu de la première ligne de texte dans l'élément. La longueur de la première ligne dépend de nombreux facteurs, notamment la largeur de l'élément, la largeur du document et la taille de la police du texte. `::first-line` n'a aucun effet lorsque le premier enfant de l'élément, qui serait la première partie de la première ligne, est un élément de bloc en ligne, tel qu'un tableau en ligne.
 
 > [!NOTE]
-> [Selectors Level 3](https://drafts.csswg.org/selectors-3/#first-line) a introduit la notation à double deux-points (`::`) pour distinguer les [pseudo-éléments](/en-US/docs/Web/CSS/Pseudo-elements) des [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) à deux points simples (`:`). Les navigateurs acceptent à la fois `::first-line` et `:first-line`, qui a été introduit dans CSS2.
+> Le standard [Sélecteurs de Niveau 3 <sup>(angl.)</sup>](https://drafts.csswg.org/selectors-3/#first-line) a introduit la notation à double deux-points (`::`) pour distinguer les [pseudo-éléments](/fr/docs/Web/CSS/Pseudo-elements) des [pseudo-classes](/fr/docs/Web/CSS/Pseudo-classes) à deux points simples (`:`). Les navigateurs acceptent à la fois `::first-line` et `:first-line`, qui a été introduit dans CSS2.
 
 Aux fins de {{CSSXref("background")}}, le pseudo-élément `::first-line` est comme un élément de niveau en ligne, ce qui signifie que dans une première ligne justifiée à gauche, l'arrière-plan peut ne pas s'étendre jusqu'à la marge droite.
 

--- a/files/fr/web/css/_doublecolon_first-line/index.md
+++ b/files/fr/web/css/_doublecolon_first-line/index.md
@@ -1,122 +1,148 @@
 ---
-title: ::first-line (:first-line)
+title: ::first-line
 slug: Web/CSS/::first-line
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::first-line`** applique la décoration à la première ligne d'un élément. La quantité de texte sur la première ligne dépend de nombreux facteurs, comme la largeur des éléments ou du document, mais aussi de la taille du texte. Comme tous les pseudo-éléments, les sélecteurs contenant `::first-line` ne ciblent pas un élément HTML réel.
 
-Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) **`::first-line`** applique la décoration à la première ligne d'un élément. La quantité de texte sur la première ligne dépend de nombreux facteurs, comme la largeur des éléments ou du document, mais aussi de la taille du texte. Comme tous les pseudo-éléments, les sélecteurs contenant `::first-line` ne ciblent pas un élément HTML réel.
+{{InteractiveExample("Démonstration CSS&nbsp;: ::first-line", "tabbed-shorter")}}
 
-```css
-/* Sélectionne la première ligne */
-/*  d'un élément <p> */
-::first-line {
-  color: red;
-  text-transform: uppercase;
+```css interactive-example
+p::first-line {
+  font-size: 1.2rem;
+  font-weight: bold;
+  text-decoration: underline;
 }
 ```
 
-Une première ligne n'a de sens que dans une [boîte de type bloc](/fr/docs/Web/CSS/CSS_display/Visual_formatting_model#block-level_elements_and_block_boxes), et ainsi le pseudo-élément `::first-line` n'a d'effet que sur les éléments dont {{cssxref("display")}} à une valeur de `block`, `inline-block`, `table-cell` ou `table-caption`. Dans tous les autres cas, `::first-line` n'a pas d'effet.
+```html interactive-example
+<p>
+  Dans les eaux chaudes des océans du monde entier, vous pouvez être témoin d'un
+  spectacle étrange&nbsp;: un poisson bondissant hors de l'eau et planant à des
+  dizaines de mètres avant de retourner dans les profondeurs de l'océan. Les
+  premiers marins méditerranéens pensaient que ces poissons volants revenaient
+  sur le rivage la nuit pour dormir et ont donc appelé cette famille de
+  poissons marins Exocoetidae.
+</p>
+```
 
-## Propriétés utilisables
+Les effets de `::first-line` sont limités par la longueur et le contenu de la première ligne de texte dans l'élément. La longueur de la première ligne dépend de nombreux facteurs, notamment la largeur de l'élément, la largeur du document et la taille de la police du texte. `::first-line` n'a aucun effet lorsque le premier enfant de l'élément, qui serait la première partie de la première ligne, est un élément de bloc en ligne, tel qu'un tableau en ligne.
 
-Seul un sous-ensemble de propriétés CSS peut être utilisé dans un bloc de déclaration contenant un sélecteur CSS utilisant le pseudo-élément `::first-line` :
+> [!NOTE]
+> [Selectors Level 3](https://drafts.csswg.org/selectors-3/#first-line) a introduit la notation à double deux-points (`::`) pour distinguer les [pseudo-éléments](/en-US/docs/Web/CSS/Pseudo-elements) des [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) à deux points simples (`:`). Les navigateurs acceptent à la fois `::first-line` et `:first-line`, qui a été introduit dans CSS2.
 
-- Toutes les propriétés liées aux polices de caractères : {{cssxref("font")}}, {{cssxref("font-kerning")}}, {{cssxref("font-style")}}, {{cssxref("font-variant")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-variant-east-asian")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-alternates")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-synthesis")}}, {{cssxref("font-feature-settings")}}, {{cssxref("font-language-override")}}, {{cssxref("font-weight")}}, {{cssxref("font-size")}}, {{cssxref("font-size-adjust")}}, {{cssxref("font-stretch")}} et {{cssxref("font-family")}}
+Aux fins de {{CSSXref("background")}}, le pseudo-élément `::first-line` est comme un élément de niveau en ligne, ce qui signifie que dans une première ligne justifiée à gauche, l'arrière-plan peut ne pas s'étendre jusqu'à la marge droite.
+
+## Propriétés autorisées
+
+Seul un petit sous-ensemble de propriétés CSS peut être utilisé avec le pseudo-élément `::first-line`&nbsp;:
+
+- Toutes les propriétés liées à la police&nbsp;: {{Cssxref("font")}}, {{cssxref("font-kerning")}}, {{Cssxref("font-style")}}, {{Cssxref("font-variant")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-variant-east-asian")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-alternates")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-synthesis")}}, {{cssxref("font-feature-settings")}}, {{cssxref("font-language-override")}}, {{Cssxref("font-weight")}}, {{Cssxref("font-size")}}, {{cssxref("font-size-adjust")}}, {{cssxref("font-stretch")}} et {{Cssxref("font-family")}}
+- Toutes les propriétés liées à l'arrière-plan&nbsp;: {{Cssxref("background-color")}}, {{cssxref("background-clip")}}, {{Cssxref("background-image")}}, {{cssxref("background-origin")}}, {{cssxref("background-position")}}, {{cssxref("background-repeat")}}, {{cssxref("background-size")}}, {{Cssxref("background-attachment")}} et {{cssxref("background-blend-mode")}}
 - La propriété {{cssxref("color")}}
-- Toutes les propriétés liées à l'arrière-plan : {{cssxref("background-color")}}, {{cssxref("background-clip")}}, {{cssxref("background-image")}}, {{cssxref("background-origin")}}, {{cssxref("background-position")}}, {{cssxref("background-repeat")}}, {{cssxref("background-size")}}, {{cssxref("background-attachment")}} et {{cssxref("background-blend-mode")}}
 - {{cssxref("word-spacing")}}, {{cssxref("letter-spacing")}}, {{cssxref("text-decoration")}}, {{cssxref("text-transform")}} et {{cssxref("line-height")}}
 - {{cssxref("text-shadow")}}, {{cssxref("text-decoration")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-style")}} et {{cssxref("vertical-align")}}.
 
-Comme cette liste sera étendue dans le futur, il est recommandé de ne pas utiliser d'autres propriétés dans un bloc de déclaration, de manière à ce que le CSS reste pérenne.
-
-> [!NOTE]
-> Dans CSS 2, les pseudo-éléments étaient précédés d'un seul caractère deux-points. Comme les pseudo-classes utilisaient aussi la même convention, ils n'était pas possible de les distinguer. Afin de résoudre cela, CSS 2.1 à changé la convention des pseudo-éléments. Désormais, un pseudo-élément est précédé de deux caractères deux-points, et une pseudo-classe d'un seul.
->
-> Puisque de nombreux navigateurs avaient déjà mis en place la version CSS 2 dans une version publique, tous les navigateurs supportent les deux syntaxes.
->
-> Si les navigateurs anciens doivent être supportés, `:first-line` est le seul choix viable ; sinon`,::first-line` est préféré.
-
 ## Syntaxe
 
-{{csssyntax}}
+```css
+::first-line {
+  /* ... */
+}
+```
 
 ## Exemples
 
-### `text-transform`
-
-Toutes les lettres de la première ligne de chaque paragraphe sont en majuscules.
-
-#### CSS
-
-```css
-p::first-line {
-  text-transform: uppercase;
-}
-```
+### Mise en forme de la première ligne d'un paragraphe
 
 #### HTML
 
 ```html
 <p>
-  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-  tempor incididunt ut labore.
+  Les styles ne seront appliqués qu'à la première ligne de ce paragraphe.
+  Ensuite, tout le texte sera formaté normalement. Vous voyez ce que je veux
+  dire&nbsp;?
 </p>
+
+<span>
+  La première ligne de ce texte ne bénéficiera pas d'un style particulier, car
+  il ne s'agit pas d'un élément de niveau bloc.
+</span>
 ```
-
-#### Résultat
-
-{{EmbedLiveSample('text-transform', 250, 100)}}
-
-### `margin-left`
-
-Ici, l'effet est nul car `margin-left` ne peut pas être appliquée sur ce pseudo-élément.
 
 #### CSS
 
+```css hidden
+* {
+  font-size: 20px;
+  font-family: sans-serif;
+}
+```
+
 ```css
-p::first-line {
+::first-line {
+  color: blue;
+  font-weight: bold;
+
+  /* AVERTISSEMENT : NE PAS UTILISER CES ÉLÉMENTS */
+  /* De nombreuses propriétés ne sont pas valides dans les pseudo-éléments
+     ::first-line */
   margin-left: 20px;
-}
-```
-
-#### HTML
-
-```html
-<p>
-  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-  tempor incididunt ut labore.
-</p>
-```
-
-#### Résultat
-
-{{EmbedLiveSample('margin-left', 250, 100)}}
-
-### `text-indent`
-
-Là encore, l'effet est nul, `text-indent` ne peut pas être appliqué sur ce pseudo-élément.
-
-#### CSS
-
-```css
-p::first-line {
   text-indent: 20px;
 }
 ```
 
+### Résultat
+
+{{EmbedLiveSample('mise_en_forme_de_la_première_ligne_dun_paragraphe', 350, 130)}}
+
+### Mise en forme de la première ligne d'un élément de texte SVG
+
+Dans cet exemple, nous stylisons la première ligne d'un élément SVG {{SVGElement("text")}} en utilisant le pseudo-élément `::first-line`.
+
+> [!NOTE]
+> Au moment de la rédaction, cette fonctionnalité a un [support limité](#compatibilité_des_navigateurs).
+
 #### HTML
 
-```html
-<p>
-  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-  tempor incididunt ut labore.
-</p>
+```html-nolint
+<svg viewBox="0 0 320 150">
+  <text y="20">Voici un paragraphe en anglais
+qui est divisé en plusieurs lignes
+dans le code source afin qu'il puisse
+être plus facilement lu et modifié
+dans un éditeur de texte.
+  </text>
+</svg>
+```
+
+#### CSS
+
+Dans cet exemple, nous utilisons la propriété CSS {{cssxref("white-space", "", "#lignes_multiples_dans_un_élément_de_texte_svg")}} pour faire en sorte que l'élément SVG `<text>` se divise en plusieurs lignes. Nous sélectionnons ensuite la première ligne à l'aide du pseudo-élément `::first-line`.
+
+```css hidden
+text {
+  font-size: 20px;
+  font-family: sans-serif;
+}
+```
+
+```css
+text {
+  white-space: break-spaces;
+}
+
+text::first-line {
+  fill: blue;
+  font-weight: bold;
+}
 ```
 
 #### Résultat
 
-{{EmbedLiveSample('text-indent', 250, 100)}}
+{{EmbedLiveSample("mise_en_forme_de_la_première_ligne_dun_élément_de_texte_svg", "100%", 150)}}
 
 ## Spécifications
 
@@ -129,3 +155,4 @@ p::first-line {
 ## Voir aussi
 
 - {{cssxref("::first-letter")}}
+- {{cssxref("white-space")}}

--- a/files/fr/web/css/_doublecolon_grammar-error/index.md
+++ b/files/fr/web/css/_doublecolon_grammar-error/index.md
@@ -1,21 +1,17 @@
 ---
 title: ::grammar-error
 slug: Web/CSS/::grammar-error
+l10n:
+  sourceCommit: 37482c6bb0894d047a225c24f102352f89788523
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::grammar-error`** représente une portion de texte que le navigateur signale comme contenant une ou plusieurs erreurs de grammaire.
 
-Le pseudo-élément CSS **`::grammar-error`** représente une portion de texte que le navigateur signale comme contenant une ou plusieurs erreurs de grammaire.
-
-```css
-::grammar-error {
-  color: green;
-}
-```
+Le pseudo-élément `::grammar-error` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en évidence. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments de surlignage](/fr/docs/Web/CSS/Pseudo-elements#héritage_des_pseudo-éléments_de_surlignage).
 
 ## Propriétés autorisées
 
-Seul un sous-ensemble restreint de propriétés CSS peut être utilisé dans une règle contenant `::grammar-error` :
+Seul un sous-ensemble restreint de propriétés CSS peut être utilisé dans une règle contenant `::grammar-error`&nbsp;:
 
 - {{cssxref("background-color")}},
 - {{cssxref("caret-color")}},
@@ -30,30 +26,36 @@ Seul un sous-ensemble restreint de propriétés CSS peut être utilisé dans une
 
 ```css
 ::grammar-error {
+  /* ... */
 }
 ```
 
 ## Exemples
 
-### CSS
+### Vérification grammaticale de base des documents
+
+Dans cet exemple, les navigateurs prenant en charge cette fonctionnalité devraient mettre en surbrillance toute erreur grammaticale signalée avec les styles indiqués.
+
+#### HTML
+
+```html
+<p contenteditable spellcheck="true">
+  Mes amis vienent à la fête ce soir.
+</p>
+```
+
+#### CSS
 
 ```css
-p::grammar-error {
+::grammar-error {
+  text-decoration: underline red;
   color: red;
 }
 ```
 
-### HTML
+#### Résultat
 
-```html
-<p>
-  Alice devina tout de suite qu’il chercher l’éventail et la paire de gants.
-</p>
-```
-
-### Résultat
-
-{{EmbedLiveSample("Exemples","250","100")}}
+{{EmbedLiveSample('vérification_grammaticale_de_base_des_documents', '100%', 60)}}
 
 ## Spécifications
 
@@ -66,3 +68,4 @@ p::grammar-error {
 ## Voir aussi
 
 - {{cssxref("::spelling-error")}}
+- {{cssxref("text-decoration-line")}}

--- a/files/fr/web/css/_doublecolon_grammar-error/index.md
+++ b/files/fr/web/css/_doublecolon_grammar-error/index.md
@@ -7,7 +7,7 @@ l10n:
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::grammar-error`** représente une portion de texte que le navigateur signale comme contenant une ou plusieurs erreurs de grammaire.
 
-Le pseudo-élément `::grammar-error` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en évidence. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments de surlignage](/fr/docs/Web/CSS/Pseudo-elements#héritage_des_pseudo-éléments_de_surlignage).
+Le pseudo-élément `::grammar-error` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en évidence. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments mise en évidence](/fr/docs/Web/CSS/Pseudo-elements#héritage_des_pseudo-éléments_de_mise_en_évidence).
 
 ## Propriétés autorisées
 

--- a/files/fr/web/css/_doublecolon_grammar-error/index.md
+++ b/files/fr/web/css/_doublecolon_grammar-error/index.md
@@ -39,9 +39,7 @@ Dans cet exemple, les navigateurs prenant en charge cette fonctionnalité devrai
 #### HTML
 
 ```html
-<p contenteditable spellcheck="true">
-  Mes amis vienent à la fête ce soir.
-</p>
+<p contenteditable spellcheck="true">Mes amis vienent à la fête ce soir.</p>
 ```
 
 #### CSS

--- a/files/fr/web/css/_doublecolon_grammar-error/index.md
+++ b/files/fr/web/css/_doublecolon_grammar-error/index.md
@@ -34,7 +34,7 @@ Seul un sous-ensemble restreint de propriétés CSS peut être utilisé dans une
 
 ### Vérification grammaticale de base des documents
 
-Dans cet exemple, les navigateurs prenant en charge cette fonctionnalité devraient mettre en surbrillance toute erreur grammaticale signalée avec les styles indiqués.
+Dans cet exemple, les navigateurs prenant en charge cette fonctionnalité devraient mettre en évidence toute erreur grammaticale signalée avec les styles indiqués.
 
 #### HTML
 

--- a/files/fr/web/css/_doublecolon_highlight/index.md
+++ b/files/fr/web/css/_doublecolon_highlight/index.md
@@ -9,7 +9,7 @@ La fonction de [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/do
 
 Une mise en surbrillance personnalisée est une collection d'objets {{domxref("Range")}} et est enregistrée sur une page Web à l'aide de {{domxref("HighlightRegistry")}}.
 
-Le pseudo-élément `::highlight()` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en surbrillance. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments de surlignage](/fr/docs/Web/CSS/Pseudo-elements#highlight_pseudo-elements_inheritance).
+Le pseudo-élément `::highlight()` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en surbrillance. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments mise en évidence](/fr/docs/Web/CSS/Pseudo-elements#héritage_des_pseudo-éléments_de_mise_en_évidence).
 
 ## Propriétés autorisées
 

--- a/files/fr/web/css/_doublecolon_highlight/index.md
+++ b/files/fr/web/css/_doublecolon_highlight/index.md
@@ -1,0 +1,133 @@
+---
+title: ::highlight()
+slug: Web/CSS/::highlight
+l10n:
+  sourceCommit: 37482c6bb0894d047a225c24f102352f89788523
+---
+
+La fonction de [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::highlight()`** applique des styles à une mise en surbrillance personnalisée.
+
+Une mise en surbrillance personnalisée est une collection d'objets {{domxref("Range")}} et est enregistrée sur une page Web à l'aide de {{domxref("HighlightRegistry")}}.
+
+Le pseudo-élément `::highlight()` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en surbrillance. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments de surlignage](/fr/docs/Web/CSS/Pseudo-elements#highlight_pseudo-elements_inheritance).
+
+## Propriétés autorisées
+
+Seules certaines propriétés CSS peuvent être utilisées avec `::highlight()`&nbsp;:
+
+- {{CSSxRef("color")}}
+- {{CSSxRef("background-color")}}
+- {{CSSxRef("text-decoration")}} et ses propriétés associées
+- {{CSSxRef("text-shadow")}}
+- {{CSSxRef("-webkit-text-stroke-color")}}, {{CSSxRef("-webkit-text-fill-color")}} et {{CSSxRef("-webkit-text-stroke-width")}}
+
+En particulier, {{CSSxRef("background-image")}} est ignoré.
+
+## Syntaxe
+
+```css-nolint
+::highlight(nom-de-mise-en-evidence-personnalisee)
+```
+
+## Exemples
+
+### Mise en surbrillance des caractères
+
+#### HTML
+
+```html
+<p id="rainbow-text">
+  API CSS personnalisée pour la mise en surbrillance arc-en-ciel
+</p>
+```
+
+#### CSS
+
+```css
+#rainbow-text {
+  font-family: monospace;
+  font-size: 1.5rem;
+}
+
+::highlight(rainbow-color-1) {
+  color: violet;
+  text-decoration: underline;
+}
+::highlight(rainbow-color-2) {
+  color: purple;
+  text-decoration: underline;
+}
+::highlight(rainbow-color-3) {
+  color: blue;
+  text-decoration: underline;
+}
+::highlight(rainbow-color-4) {
+  color: green;
+  text-decoration: underline;
+}
+::highlight(rainbow-color-5) {
+  color: yellow;
+  text-decoration: underline;
+}
+::highlight(rainbow-color-6) {
+  color: orange;
+  text-decoration: underline;
+}
+::highlight(rainbow-color-7) {
+  color: red;
+  text-decoration: underline;
+}
+```
+
+#### JavaScript
+
+```js
+const textNode = document.getElementById("rainbow-text").firstChild;
+
+if (!CSS.highlights) {
+  textNode.textContent =
+    "L'API CSS Custom Highlight n'est pas prise en charge dans ce" +
+    "navigateur&nbsp;!";
+}
+
+// Créez et enregistrez des surlignages pour chaque couleur de l'arc-en-ciel.
+const highlights = [];
+for (let i = 0; i < 7; i++) {
+  // Créez un nouveau surlignage pour cette couleur.
+  const colorHighlight = new Highlight();
+  highlights.push(colorHighlight);
+
+  // Enregistrez ce surlignage sous un nom personnalisé.
+  CSS.highlights.set(`rainbow-color-${i + 1}`, colorHighlight);
+}
+
+// Itérer sur le texte, caractère par caractère.
+for (let i = 0; i < textNode.textContent.length; i++) {
+  // Créez un nouveau champ juste pour ce caractère.
+  const range = new Range();
+  range.setStart(textNode, i);
+  range.setEnd(textNode, i + 1);
+
+  // Ajoutez le champ au surlignage disponible suivant,
+  // en revenant au premier une fois que nous avons atteint le 7ème.
+  highlights[i % 7].add(range);
+}
+```
+
+#### Résultat
+
+{{ EmbedLiveSample("mise_en_surbrillance_des_caractères") }}
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- Le module CSS de [Mise en évidence personnalisée](/fr/docs/Web/CSS/CSS_custom_highlight_API)
+- L'[API CSS de mise en évidence personnalisée](/fr/docs/Web/API/CSS_Custom_Highlight_API)
+- Le module de [pseudo-éléments CSS](/fr/docs/Web/CSS/CSS_pseudo-elements)

--- a/files/fr/web/css/_doublecolon_highlight/index.md
+++ b/files/fr/web/css/_doublecolon_highlight/index.md
@@ -5,11 +5,11 @@ l10n:
   sourceCommit: 37482c6bb0894d047a225c24f102352f89788523
 ---
 
-La fonction de [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::highlight()`** applique des styles à une mise en surbrillance personnalisée.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::highlight()`** applique des styles à une mise en évidence personnalisée.
 
-Une mise en surbrillance personnalisée est une collection d'objets {{domxref("Range")}} et est enregistrée sur une page Web à l'aide de {{domxref("HighlightRegistry")}}.
+Une mise en évidence personnalisée est une collection d'objets {{domxref("Range")}} et est enregistrée sur une page Web à l'aide de {{domxref("HighlightRegistry")}}.
 
-Le pseudo-élément `::highlight()` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en surbrillance. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments mise en évidence](/fr/docs/Web/CSS/Pseudo-elements#héritage_des_pseudo-éléments_de_mise_en_évidence).
+Le pseudo-élément `::highlight()` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en évidence. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments mise en évidence](/fr/docs/Web/CSS/Pseudo-elements#héritage_des_pseudo-éléments_de_mise_en_évidence).
 
 ## Propriétés autorisées
 
@@ -31,13 +31,13 @@ En particulier, {{CSSxRef("background-image")}} est ignoré.
 
 ## Exemples
 
-### Mise en surbrillance des caractères
+### Mise en évidence des caractères
 
 #### HTML
 
 ```html
 <p id="rainbow-text">
-  API CSS personnalisée pour la mise en surbrillance arc-en-ciel
+  API CSS personnalisée pour la mise en évidence arc-en-ciel
 </p>
 ```
 
@@ -116,7 +116,7 @@ for (let i = 0; i < textNode.textContent.length; i++) {
 
 #### Résultat
 
-{{ EmbedLiveSample("mise_en_surbrillance_des_caractères") }}
+{{ EmbedLiveSample("mise_en_évidence_des_caractères") }}
 
 ## Spécifications
 

--- a/files/fr/web/css/_doublecolon_marker/index.md
+++ b/files/fr/web/css/_doublecolon_marker/index.md
@@ -1,57 +1,80 @@
 ---
 title: ::marker
 slug: Web/CSS/::marker
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::marker`** représente le marqueur d'un élément d'une liste à puces ou numérotée. Il fonctionne sur tout élément ou pseudo-élément défini avec [`display: list-item`](/fr/docs/Web/CSS/display), tel que les éléments {{htmlelement("li")}} et {{htmlelement("summary")}}.
 
-Le pseudo-élément **`::marker`** représente le marqueur d'un élément d'une liste (par exemple la puce ou le numéro de l'élément d'un élément {{HTMLElement("li")}}). Ce pseudo-élément ne fonctionne que pour les éléments ou pseudo-éléments pour lesquels {{cssxref("display")}} vaut `list-item` (par défaut c'est le cas des éléments {{htmlelement("li")}} et {{htmlelement("summary")}}).
+{{InteractiveExample("Démonstration CSS&nbsp;: ::marker", "tabbed-shorter")}}
 
-```css
-::marker {
-  color: red;
-  font-size: 1.5em;
+```css interactive-example
+li::marker {
+  content: "✝ ";
+  font-size: 1.2em;
 }
+```
+
+```html interactive-example
+<p>Groupe connu sous le nom de «&nbsp;Mercury Seven&nbsp;»&nbsp;:</p>
+<ul>
+  <li>Malcolm Scott Carpenter</li>
+  <li>Leroy Gordon (Gordo) Cooper Jr.</li>
+  <li>John Herschel Glenn Jr.</li>
+  <li>Virgil Ivan (Gus) Grissom</li>
+  <li>Walter Marty (Wally) Schirra Jr.</li>
+  <li>Alan Bartlett Shepard Jr.</li>
+  <li>Donald Kent (Deke) Slayton</li>
+</ul>
 ```
 
 ## Propriétés autorisées
 
-Seul un sous-ensemble de propriétés CSS peuvent être utilisées pour une règle qui utilise `::marker` :
+Seul un sous-ensemble de propriétés CSS peuvent être utilisées pour une règle qui utilise `::marker`&nbsp;:
 
-- {{cssxref("color")}},
-- {{cssxref("text-combine-upright")}}, {{cssxref("unicode-bidi")}} et {{cssxref("direction")}}
-- {{cssxref("content")}}
-- [Toutes les propriétés liées aux polices (font).](/fr/docs/Web/CSS/CSS_fonts)
+- Toutes les [propriétés de police](/fr/docs/Web/CSS/CSS_fonts)
+- La propriété {{CSSxRef("white-space")}}
+- {{CSSxRef("color")}}
+- Les propriétés {{CSSxRef("text-combine-upright")}}, {{CSSxRef("unicode-bidi")}} et {{CSSxRef("direction")}}
+- La propriété {{CSSxRef("content")}}
+- Toutes les propriétés d'[animation](/fr/docs/Web/CSS/CSS_animations#propriétés_css) et de [transition](/fr/docs/Web/CSS/CSS_transitions#propriétés_css)
 
 > [!NOTE]
 > La spécification indique que d'autres propriétés CSS pourraient être prises en charge à l'avenir.
 
 ## Syntaxe
 
-{{CSSSyntax}}
-
-## Exemples
-
-### CSS
-
 ```css
-li::marker {
-  color: red;
+::marker {
+  /* ... */
 }
 ```
+
+## Exemples
 
 ### HTML
 
 ```html
-<ol>
-  <li>Savoir lacer ses chaussures</li>
-  <li>Et compter deux par deux.</li>
-</ol>
+<ul>
+  <li>Pêches</li>
+  <li>Pommes</li>
+  <li>Prunes</li>
+</ul>
+```
+
+### CSS
+
+```css
+ul li::marker {
+  color: red;
+  font-size: 1.5em;
+}
 ```
 
 ### Résultat
 
-{{EmbedLiveSample("Exemples","200","150")}}
+{{EmbedLiveSample('exemples')}}
 
 ## Spécifications
 
@@ -63,9 +86,10 @@ li::marker {
 
 ## Voir aussi
 
-- Les éléments HTML relatifs aux listes :
-  - {{htmlelement("ul")}}
+- Les éléments HTML comportant un marqueur par défaut&nbsp;:
   - {{htmlelement("ol")}}
   - {{htmlelement("li")}}
-
-- {{htmlelement("summary")}}
+  - {{htmlelement("summary")}}
+- Le module [Contenu généré par CSS](/fr/docs/Web/CSS/CSS_generated_content)
+- Le module [Listes et compteurs CSS](/fr/docs/Web/CSS/CSS_lists)
+- Le module [Styles de compteur CSS](/fr/docs/Web/CSS/CSS_counter_styles)

--- a/files/fr/web/css/_doublecolon_part/index.md
+++ b/files/fr/web/css/_doublecolon_part/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-La fonction de [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::part()`** représente n'importe quel élément dans un [arbre fantôme](/fr/docs/Web/API/Web_components/Using_shadow_DOM) qui a un attribut [`part`](/fr/docs/Web/HTML/Reference/Global_attributes#part) correspondant.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::part()`** représente n'importe quel élément dans un [arbre fantôme (<i lang="en">shadow tree</i>)](/fr/docs/Web/API/Web_components/Using_shadow_DOM) qui a un attribut [`part`](/fr/docs/Web/HTML/Reference/Global_attributes#part) correspondant.
 
 ```css
 custom-element::part(foo) {

--- a/files/fr/web/css/_doublecolon_part/index.md
+++ b/files/fr/web/css/_doublecolon_part/index.md
@@ -1,11 +1,11 @@
 ---
 title: ::part()
 slug: Web/CSS/::part
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
-
-Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::part`** représente n'importe quel élément dans un [arbre fantôme](/fr/docs/Web/API/Web_components/Using_shadow_DOM) qui a un attribut [`part`](/fr/docs/Web/HTML/Reference/Global_attributes#part) correspondant.
+La fonction de [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::part()`** représente n'importe quel élément dans un [arbre fantôme](/fr/docs/Web/API/Web_components/Using_shadow_DOM) qui a un attribut [`part`](/fr/docs/Web/HTML/Reference/Global_attributes#part) correspondant.
 
 ```css
 custom-element::part(foo) {
@@ -13,62 +13,86 @@ custom-element::part(foo) {
 }
 ```
 
+## Description
+
+L'attribut global [`part`](/fr/docs/Web/HTML/Reference/Global_attributes/part) permet de rendre un élément d'un arbre fantôme visible pour son DOM parent. Les noms de parties déclarés à l'aide de l'attribut `part` sont utilisés comme paramètres du pseudo-élément `::part()`. De cette manière, vous pouvez appliquer des styles CSS aux éléments de l'arbre fantôme depuis l'extérieur.
+
+Les noms de parties sont similaires aux classes CSS&nbsp;: plusieurs éléments peuvent avoir le même nom de partie, et un seul élément peut avoir plusieurs noms de parties. Tous les noms de parties utilisés dans le pseudo-élément `::part()` doivent être présents dans la valeur `part` déclarée sur l'élément de l'arbre fantôme, mais l'ordre des noms de parties n'a pas d'importance, c'est-à-dire que les sélecteurs `::part(tab active)` et `::part(active tab)` sont identiques.
+
+Le pseudo-élément `::part()` n'est visible que pour le DOM parent. Cela signifie que lorsqu'un arbre fantôme est imbriqué, les parties ne sont visibles pour aucun ancêtre autre que le parent direct. L'attribut [`exportparts`](/fr/docs/Web/HTML/Reference/Global_attributes/exportparts) résout cette limitation en exportant explicitement les noms de parties déjà définis, les rendant ainsi stylables globalement.
+
+Les [pseudo-classes](/fr/docs/Web/CSS/Pseudo-classes) (comme `::part(label):hover`) peuvent être ajoutées au sélecteur `::part()`, mais les [pseudo-classes structurelles](/fr/docs/Web/CSS/Pseudo-classes#pseudo-classes_structurelles_darbre) qui correspondent en fonction des informations de l'arbre, telles que `:empty` et `:last-child`, ne peuvent pas être ajoutées.
+
+Des pseudo-éléments supplémentaires, tels que `::before`, peuvent être ajoutés au sélecteur `::part()`, mais des éléments `::part()` supplémentaires ne peuvent pas être ajoutés. Par exemple, `::part(confirm-button)::part(active)` ne correspond jamais à rien, c'est-à-dire qu'il n'est pas identique à `::part(confirm-button active)`. Cela est dû au fait que cela exposerait plus d'informations structurelles que prévu.
+
 ## Syntaxe
 
-{{CSSSyntax}}
+```css
+::part(<ident>+) {
+  /* ... */
+}
+```
 
 ## Exemples
 
-### `<tabbed-custom-element>`
-
-#### Arbre fantôme `<tabbed-custom-element>`
+### HTML
 
 ```html
-<style type="text/css">
-  *,
-  ::before,
-  ::after {
-    box-sizing: border-box;
-  }
+<template id="tabbed-custom-element">
+  <style>
+    *,
+    ::before,
+    ::after {
+      box-sizing: border-box;
+      padding: 1rem;
+    }
+    :host {
+      display: flex;
+    }
+  </style>
+  <div part="tab active">Onglet A</div>
+  <div part="tab">Onglet B</div>
+  <div part="tab">Onglet C</div>
+</template>
 
-  :host {
-    display: flex;
-  }
-</style>
-<div part="tab active">Tab 1</div>
-<div part="tab">Tab 2</div>
-<div part="tab">Tab 3</div>
+<tabbed-custom-element></tabbed-custom-element>
 ```
 
-#### Feuille de style chargée dans un arbre léger
+### CSS
 
 ```css
 tabbed-custom-element::part(tab) {
-  color: #0c0c0dcc;
-  border-bottom: transparent solid 2px;
+  color: blue;
+  border-bottom: transparent solid 4px;
 }
 
 tabbed-custom-element::part(tab):hover {
-  background-color: #0c0c0d19;
-  border-color: #0c0c0d33;
+  background-color: black;
+  color: white;
 }
 
-tabbed-custom-element::part(tab):hover:active {
-  background-color: #0c0c0d33;
-}
-
-tabbed-custom-element::part(tab):focus {
-  box-shadow:
-    0 0 0 1px #0a84ff inset,
-    0 0 0 1px #0a84ff,
-    0 0 0 4px rgba(10, 132, 255, 0.3);
-}
-
-tabbed-custom-element::part(active tab) {
-  color: #0060df;
-  border-color: #0a84ff !important;
+tabbed-custom-element::part(tab active) {
+  border-color: blue !important;
 }
 ```
+
+### JavaScript
+
+```js
+const template = document.querySelector("#tabbed-custom-element");
+globalThis.customElements.define(
+  template.id,
+  class extends HTMLElement {
+    constructor() {
+      super().attachShadow({ mode: "open" }).append(template.content);
+    }
+  },
+);
+```
+
+### Résultat
+
+{{EmbedLiveSample('exemples')}}
 
 ## Spécifications
 
@@ -80,6 +104,7 @@ tabbed-custom-element::part(active tab) {
 
 ## Voir aussi
 
-- L'attribut [`part`](/fr/docs/Web/HTML/Reference/Global_attributes#part) - Utilisé pour définir des parties qui peuvent être sélectionnées par le sélecteur `::part()`
-- L'attribut [`exportparts`](/fr/docs/Web/HTML/Reference/Global_attributes#exportparts) qui est utilisé pour exporter les parties d'un arbre _shadow_ imbriqué vers un arbre classique
-- [Utilisation de CSS Shadow : `::part` et `::theme`](https://github.com/fergald/docs/blob/master/explainers/css-shadow-parts-1.md)
+- L'attribut [`part`](/fr/docs/Web/HTML/Reference/Global_attributes#part)
+- La fonction de pseudo-classe {{CSSxRef(":state",":state()")}}
+- L'attribut [`exportparts`](/fr/docs/Web/HTML/Reference/Global_attributes#exportparts)
+- Le module des [parties fantômes CSS](/fr/docs/Web/CSS/CSS_shadow_parts)

--- a/files/fr/web/css/_doublecolon_picker-icon/index.md
+++ b/files/fr/web/css/_doublecolon_picker-icon/index.md
@@ -1,0 +1,77 @@
+---
+title: ::picker-icon
+slug: Web/CSS/::picker-icon
+l10n:
+  sourceCommit: e82803beedb7f1d8a8e918c1071752f18e1e3f28
+---
+
+{{SeeCompatTable}}
+
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::picker-icon`** cible l'icône de sélection à l'intérieur des contrôles de formulaire qui ont une icône associée. Dans le cas d'un [élément `<select>` personnalisable](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select), il sélectionne l'icône de flèche affichée sur l'élément `<select>` qui pointe vers le bas lorsqu'il est fermé.
+
+## Syntaxe
+
+```css-nolint
+::picker-icon {
+  /* ... */
+}
+```
+
+## Description
+
+Le pseudo-élément `::picker-icon` cible l'icône de sélection des contrôles de formulaire, c'est-à-dire l'icône affichée sur le bouton du contrôle. Il n'est disponible que si l'élément d'origine possède un sélecteur et que l'apparence de base lui est appliquée via la propriété {{cssxref("appearance")}} avec la valeur `base-select`. Sa boîte générée apparaît après celles générées par le pseudo-élément {{cssxref("::after")}}, avec l'icône définie dans la feuille de style par défaut du navigateur. Vous pouvez la personnaliser à l'aide de la propriété {{cssxref("content")}}.
+
+Le sélecteur `::picker-icon` peut être utilisé pour cibler la flèche orientée vers le bas du côté en ligne de fin d'un [élément select personnalisable](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select). Cela est utile, par exemple, si vous souhaitez personnaliser la couleur ou la taille de l'icône, utiliser une autre icône (en utilisant {{cssxref("content")}} ou [SVG](/fr/docs/Web/SVG)), ou l'animer à l'ouverture et à la fermeture du sélecteur.
+
+La sélection des icônes de sélecteur des éléments `<select>` personnalisables est actuellement le seul cas d'utilisation de `::picker-icon`, mais d'autres pourraient être ajoutés à l'avenir.
+
+> [!NOTE]
+> Le pseudo-élément `::picker-icon` n'est pas inclus dans l'arbre d'accessibilité, de sorte que tout {{cssxref("content")}} généré qui lui est appliqué ne sera pas annoncé par les technologies d'assistance. Vous devez néanmoins vous assurer que toute nouvelle icône définie a un sens visuel par rapport à l'objectif prévu.
+
+## Exemples
+
+### Animer l'icône du sélecteur
+
+Pour activer la fonctionnalité de `<select>` personnalisable, l'élément `<select>` et son sélecteur doivent tous deux avoir une valeur {{cssxref("appearance")}} de `base-select` appliquée&nbsp;:
+
+```css
+select,
+::picker(select) {
+  appearance: base-select;
+}
+```
+
+Vous pouvez ensuite cibler le `::picker-icon` et lui appliquer une {{cssxref("color")}} personnalisée et une {{cssxref("transition")}} afin que les changements de sa propriété {{cssxref("rotate")}} soient animés en douceur&nbsp;:
+
+```css
+select::picker-icon {
+  color: #999999;
+  transition: 0.4s rotate;
+}
+```
+
+Dans la règle suivante, `::picker-icon` est combiné avec la pseudo-classe {{cssxref(":open")}} — qui cible l'icône uniquement lorsque le sélecteur est ouvert — pour la faire pivoter à une valeur de `180deg` lorsque l'élément `<select>` est ouvert.
+
+```css
+select:open::picker-icon {
+  rotate: 180deg;
+}
+```
+
+Voir [Mettre en forme l'icône du sélecteur](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select#mettre_en_forme_licone_du_selecteur) pour un exemple complet utilisant ce code, accompagné d'un exemple interactif.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- Les éléments {{htmlelement("select")}}, {{htmlelement("option")}}, {{htmlelement("optgroup")}}, {{htmlelement("label")}}, {{htmlelement("button")}} et {{htmlelement("selectedcontent")}}
+- La propriété {{cssxref("appearance")}}
+- {{cssxref("::picker()", "::picker(select)")}}, {{cssxref("::checkmark")}}
+- {{cssxref(":open")}}, {{cssxref(":checked")}}
+- [Éléments `<select>` personnalisables](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select)

--- a/files/fr/web/css/_doublecolon_picker/index.md
+++ b/files/fr/web/css/_doublecolon_picker/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{SeeCompatTable}}
 
-La fonction de [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::picker()`** cible la partie sélecteur (<i lang="en">picker</i>) d'un élément, par exemple la liste déroulante d'un [élément `<select>` personnalisable](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select).
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::picker()`** cible la partie sélecteur (<i lang="en">picker</i>) d'un élément, par exemple la liste déroulante d'un [élément `<select>` personnalisable](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select).
 
 ## Syntaxe
 

--- a/files/fr/web/css/_doublecolon_picker/index.md
+++ b/files/fr/web/css/_doublecolon_picker/index.md
@@ -1,0 +1,105 @@
+---
+title: ::picker()
+slug: Web/CSS/::picker
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
+---
+
+{{SeeCompatTable}}
+
+La fonction de [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::picker()`** cible la partie sélecteur (<i lang="en">picker</i>) d'un élément, par exemple la liste déroulante d'un [élément `<select>` personnalisable](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select).
+
+## Syntaxe
+
+```css-nolint
+::picker(<ident>) {
+  /* ... */
+}
+```
+
+### Paramètres
+
+- {{cssxref("ident")}}
+  - : Une chaîne représentant l'élément dont vous souhaitez cibler le sélecteur. Les valeurs suivantes sont disponibles&nbsp;:
+    - `select`
+      - : La liste déroulante des éléments `<select>` personnalisables.
+
+## Description
+
+Le pseudo-élément `::picker()` cible la partie sélecteur d'un contrôle de formulaire, c'est‑à‑dire la partie contextuelle qui apparaît pour permettre une sélection lorsque l'on presse le bouton de contrôle. Il n'est disponible à la sélection que lorsque l'élément d'origine possède un sélecteur et que l'apparence de base lui est appliquée via la valeur `base-select` de la propriété {{cssxref("appearance")}}.
+
+Le sélecteur `::picker(select)` cible tous les descendants d'un élément `<select>` personnalisable à l'exception du premier enfant `<button>`&nbsp;; ces descendants sont groupés par le navigateur et rendus comme le sélecteur. Le premier `<button>` enfant représente le bouton de contrôle qui ouvre le sélecteur lorsqu'il est pressé.
+
+Cela permet de cibler l'ensemble du contenu du sélecteur comme une seule entité, par exemple pour personnaliser sa {{cssxref("border", "bordure")}}, l'animer lorsqu'il apparaît et disparaît, ou le positionner ailleurs que sa position par défaut. Notre guide [éléments `<select>` personnalisables](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select) montre de nombreux exemples d'utilisation de `::picker(select)`.
+
+### Comportement du sélecteur en tant que popover
+
+L'élément `<select>` et le sélecteur ont automatiquement une relation implicite invocateur/popover, telle que définie par l'[API Popover](/fr/docs/Web/API/Popover_API). Voir [Utiliser l'API Popover](/fr/docs/Web/API/Popover_API/Using) pour plus de détails sur le comportement des popovers, et voir [Animer le menu du sélecteur à l'aide des états de popover](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select#animating_the_picker_using_popover_states) pour un cas d'usage typique rendu possible par cette association implicite.
+
+### Positionnement par ancre du sélecteur
+
+Autre effet de la relation implicite invocateur/popover évoquée ci‑dessus&nbsp;: l'élément `<select>` et le sélecteur ont aussi une ancre implicite en référence, ce qui signifie que le sélecteur est automatiquement à l'élément via le [positionnement par ancrage en CSS](/fr/docs/Web/CSS/CSS_anchor_positioning). Cela présente plusieurs avantages, notamment&nbsp;:
+
+- Les styles par défaut du navigateur positionnent le sélecteur relativement au bouton (l'ancre) et vous pouvez personnaliser cette position comme expliqué dans [Positionner des éléments relativement à leur ancre](/fr/docs/Web/CSS/CSS_anchor_positioning/Using#positioning_elements_relative_to_their_anchor). À titre de référence, les styles par défaut associés sont les suivants&nbsp;:
+
+  ```css
+  inset: auto;
+  margin: 0;
+  min-inline-size: anchor-size(self-inline);
+  min-block-size: 1lh;
+  /* Aller jusqu'au bord de la fenêtre et ajouter des barres de défilement si
+     nécessaire. */
+  max-block-size: stretch;
+  overflow: auto;
+  /* En dessous et étendu vers la droite, par défaut. */
+  position-area: block-end span-inline-end;
+  ```
+
+- Les styles par défaut du navigateur définissent aussi des alternatives de repli avec `position-try` qui repositionnent le sélecteur s'il risque de déborder de la fenêtre d'affichage. Les options de repli sont expliquées dans [Options de repli et masquage conditionnel en cas de débordement](/fr/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding). À titre de référence, les styles de repli par défaut associés sont les suivants&nbsp;:
+
+  ```css
+  position-try-order: most-block-size;
+  position-try-fallbacks:
+    /* D'abord au-dessus et étendu vers la droite, */
+    /* puis en dessous mais étendu vers la gauche, */
+    /* puis au-dessus et étendu vers la gauche. */
+    block-start span-inline-end,
+    block-end span-inline-start,
+    block-start span-inline-start;
+  ```
+
+## Exemples
+
+### Usage de base avec un sélecteur personnalisé
+
+Pour activer la fonctionnalité de sélecteur personnalisable et les styles de base minimaux du navigateur (et retirer le style fourni par l'OS), il faut définir la valeur `base-select` d'{{cssxref("appearance")}} à la fois sur l'élément `<select>` et sur son sélecteur&nbsp;:
+
+```css
+select,
+::picker(select) {
+  appearance: base-select;
+}
+```
+
+On peut ensuite, par exemple, retirer la {{cssxref("border", "bordure")}} noire par défaut du sélecteur&nbsp;:
+
+```css
+::picker(select) {
+  border: none;
+}
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- Les éléments {{htmlelement("select")}}, {{htmlelement("option")}}, {{htmlelement("optgroup")}}, {{htmlelement("label")}}, {{htmlelement("button")}} et {{htmlelement("selectedcontent")}}
+- {{cssxref("::picker-icon")}}, {{cssxref("::checkmark")}}
+- {{cssxref(":open")}}, {{cssxref(":checked")}}
+- [Éléments `<select>` personnalisables](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select)

--- a/files/fr/web/css/_doublecolon_placeholder/index.md
+++ b/files/fr/web/css/_doublecolon_placeholder/index.md
@@ -59,7 +59,7 @@ Il est important de veiller à ce que le rapport de contraste entre la couleur d
 La valeur du contraste est déterminée en comparant la luminosité de la couleur du texte de substitution et celle de l'arrière-plan. Afin de respecter les recommandations d'accessibilité&nbsp;: [Web Content Accessibility Guidelines (WCAG) <sup>(angl.)</sup>](https://www.w3.org/WAI/intro/wcag), un ratio de 4.5:1 est nécessaire pour le contenu textuel normal et un ratio de 3:1 est nécessaire pour les textes plus grands ou en gras. Un texte de grande taille est défini comme étant de 18,66 pixels et en gras ou plus grand, ou de 24 pixels ou plus.
 
 - [WebAIM&nbsp;: vérificateur de contraste <sup>(angl.)</sup>](https://webaim.org/resources/contrastchecker/)
-- [Explications des recommendation WCAG 1.4 <sup>(angl.)</sup>](/fr/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
+- [Explications des recommendation WCAG 1.4](/fr/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
 - [Comprendre le critère de succès 1.4.3 | W3C Comprendre les WCAG 2.0 <sup>(angl.)</sup>](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
 
 #### Utilisabilité

--- a/files/fr/web/css/_doublecolon_placeholder/index.md
+++ b/files/fr/web/css/_doublecolon_placeholder/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-La fonction de [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::placeholder`** représente [le texte de substitution](/fr/docs/Web/HTML/Reference/Elements/input#placeholder) pour un élément {{HTMLElement("input")}} ou {{HTMLElement("textarea")}}.
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::placeholder`** représente [le texte de substitution](/fr/docs/Web/HTML/Reference/Elements/input#placeholder) pour un élément {{HTMLElement("input")}} ou {{HTMLElement("textarea")}}.
 
 {{InteractiveExample("Démonstration CSS&nbsp;: ::placeholder", "tabbed-shorter")}}
 

--- a/files/fr/web/css/_doublecolon_placeholder/index.md
+++ b/files/fr/web/css/_doublecolon_placeholder/index.md
@@ -1,53 +1,50 @@
 ---
 title: ::placeholder
 slug: Web/CSS/::placeholder
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}
+La fonction de [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::placeholder`** représente [le texte de substitution](/fr/docs/Web/HTML/Reference/Elements/input#placeholder) pour un élément {{HTMLElement("input")}} ou {{HTMLElement("textarea")}}.
 
-Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) **`::placeholder`** représente [le texte de substitution](/fr/docs/conflicting/Learn_web_development/Extensions/Forms#the_placeholder_attribute) pour un élément {{HTMLElement("input")}} ou {{HTMLElement("textarea")}}. Cela permet aux développeurs web de personnaliser l'apparence de ce texte.
+{{InteractiveExample("Démonstration CSS&nbsp;: ::placeholder", "tabbed-shorter")}}
 
-```css
-::placeholder {
-  color: blue;
-  font-size: 1.5em;
+```css interactive-example
+input {
+  margin-top: 0.5rem;
+}
+
+input::placeholder {
+  font-weight: bold;
+  opacity: 0.5;
+  color: red;
 }
 ```
 
-Seul un sous-ensemble des propriétés CSS peut être utilisé avec un sélecteur respectant ce pseudo-élément :
+```html interactive-example
+<label for="phone-number">Votre numéro de téléphone&nbsp;:</label><br />
 
-- Toutes les propriétés liées aux polices de caractères : {{cssxref("font")}}, {{cssxref("font-kerning")}}, {{cssxref("font-style")}}, {{cssxref("font-variant")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-variant-east-asian")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-alternates")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-synthesis")}}, {{cssxref("font-feature-settings")}}, {{cssxref("font-language-override")}}, {{cssxref("font-weight")}}, {{cssxref("font-size")}}, {{cssxref("font-size-adjust")}}, {{cssxref("font-stretch")}} et {{cssxref("font-family")}}
-- La propriété {{cssxref("color")}}
-- Toutes les propriétés liées à l'arrière-plan : {{cssxref("background-color")}}, {{cssxref("background-clip")}}, {{cssxref("background-image")}}, {{cssxref("background-origin")}}, {{cssxref("background-position")}}, {{cssxref("background-repeat")}}, {{cssxref("background-size")}}, {{cssxref("background-attachment")}} et {{cssxref("background-blend-mode")}}
-- {{cssxref("word-spacing")}}, {{cssxref("letter-spacing")}}, {{cssxref("text-decoration")}}, {{cssxref("text-transform")}} et {{cssxref("line-height")}}
-- {{cssxref("text-shadow")}}, {{cssxref("text-decoration")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-style")}} et {{cssxref("vertical-align")}}.
+<input
+  id="phone-number"
+  type="tel"
+  name="phone"
+  minlength="10"
+  maxlength="10"
+  placeholder="Il doit comporter 10 chiffres" />
+```
+
+Seul le sous-ensemble des propriétés CSS qui s'appliquent au pseudo-élément {{cssxref("::first-line")}} peut être utilisé dans une règle utilisant `::placeholder` dans son sélecteur.
 
 > [!NOTE]
 > Par défaut, dans la plupart des navigateurs, le texte de substitution est écrit en gris clair.
 
 ## Syntaxe
 
-{{csssyntax}}
-
-## Exemples
-
-### CSS
-
 ```css
-input::placeholder {
-  color: red;
+::placeholder {
+  /* ... */
 }
 ```
-
-### HTML
-
-```html
-<input type="email" placeholder="toto@exemple.com" />
-```
-
-### Résultat
-
-{{EmbedLiveSample("Exemples","200","150")}}
 
 ## Accessibilité
 
@@ -55,33 +52,28 @@ input::placeholder {
 
 #### Taux de contraste
 
-Le texte de substitution est généralement représenté avec une couleur plus claire afin d'indiquer qu'il s'agit d'un suggestion et que ce contenu n'a pas été saisi par l'utilisateur ou par le site même.
+Le texte de substitution est généralement affiché dans une couleur plus claire afin d'indiquer qu'il s'agit d'une suggestion quant au type de saisie valide, et non d'une saisie réelle.
 
-Il est important de vérifier que le contraste entre la couleur de ce texte et celle de l'arrière-plan est suffisament élevé afin que les personnes avec des conditions de vision faibles puissent les lire.
+Il est important de veiller à ce que le rapport de contraste entre la couleur du texte de substitution et l'arrière-plan du champ de saisie soit suffisamment élevé pour que les personnes malvoyantes puissent le lire, tout en s'assurant qu'il y ait une différence suffisante entre la couleur du texte de substitution et celle du texte saisi afin que les utilisateur·ice·s ne confondent pas le texte de substitution avec les données saisies.
 
-La valeur du contraste est déterminée en comparant la luminosité de la couleur du texte de substitution et celle de l'arrière-plan. Afin de respecter les recommandations d'accessibilité : [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/intro/wcag), un ratio de 4.5:1 est nécessaire pour le contenu textuel normal et un ratio de 3:1 est nécessaire pour les textes plus grands ou en gras. Le seuil entre ces deux tailles est défini de la façon suivante :
+La valeur du contraste est déterminée en comparant la luminosité de la couleur du texte de substitution et celle de l'arrière-plan. Afin de respecter les recommandations d'accessibilité&nbsp;: [Web Content Accessibility Guidelines (WCAG) <sup>(angl.)</sup>](https://www.w3.org/WAI/intro/wcag), un ratio de 4.5:1 est nécessaire pour le contenu textuel normal et un ratio de 3:1 est nécessaire pour les textes plus grands ou en gras. Un texte de grande taille est défini comme étant de 18,66 pixels et en gras ou plus grand, ou de 24 pixels ou plus.
 
-- Si le texte est en gras : 18.66px ou plus grand
-- Sinon 24px ou plus grand
-
-Autres ressources :
-
-- [WebAIM : vérificateur de contraste](https://webaim.org/resources/contrastchecker/)
-- [Explications des recommendation WCAG 1.4](/fr/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
-- [Understanding Success Criterion 1.4.3 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
+- [WebAIM&nbsp;: vérificateur de contraste <sup>(angl.)</sup>](https://webaim.org/resources/contrastchecker/)
+- [Explications des recommendation WCAG 1.4 <sup>(angl.)</sup>](/fr/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
+- [Comprendre le critère de succès 1.4.3 | W3C Comprendre les WCAG 2.0 <sup>(angl.)</sup>](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
 
 #### Utilisabilité
 
-Les textes de substitution avec un contraste suffisamment élevé peuvent être pris pour des textes saisis par l'utilisateur. De plus, les textes de substitution disparaissent lorsqu'une personne saisit du contenu dans l'élément {{htmlelement("input")}}. Pour ces deux raisons, les textes de subsitution peuvent gêner la complétion du formulaire, notamment pour les personnes souffrant de troubles cognitifs.
+Les textes de substitution avec un contraste suffisamment élevé peuvent être pris pour des textes saisis par l'utilisateur·ice. De plus, les textes de substitution disparaissent lorsqu'une personne saisit du contenu dans l'élément {{htmlelement("input")}}. Pour ces deux raisons, les textes de subsitution peuvent gêner la complétion du formulaire, notamment pour les personnes souffrant de troubles cognitifs.
 
-Une autre méthode consiste à fournir cette information en l'incluant à proximité du champ mais en dehors et d'utiliser l'attribut [`aria-describedby`](/fr/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute) afin de relier l'élément {{HTMLElement("input")}} à l'indication associée.
+Une autre méthode consiste à fournir cette information en l'incluant à proximité du champ mais en dehors et d'utiliser l'attribut [`aria-describedby`](/fr/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) afin de relier l'élément {{HTMLElement("input")}} à l'indication associée.
 
-Avec cette méthode, le contenu indicatif est disponible à tout moment (même lorsqu'une information a été saisie par l'utilisateur) et le champ est vide lorsque la page est chargée. La plupart des lecteurs d'écran utiliseront `aria-describedby` afin de lire l'indication lorsque le libellé du champ aura été annoncé. La personne utilisant le lecteur d'écran pourra arrêter les annonces si elle estime que les informations supplémentaires ne sont pas nécessaires.
+Avec cette méthode, le contenu de l'indication est disponible même si des informations sont saisies dans le champ, et la saisie apparaît sans aucune entrée préexistante lorsque la page est chargée. La plupart des technologies de lecture d'écran utilisent `aria-describedby` pour lire l'indication après l'annonce du texte de l'étiquette de la saisie, et la personne qui utilise le lecteur d'écran peut la désactiver si elle juge ces informations supplémentaires inutiles.
 
 ```html
 <label for="user-email">Votre adresse mail</label>
 <span id="user-email-hint" class="input-hint"
-  >Exemple : johndoe@example.com</span
+  >Exemple : toto@exemple.fr</span
 >
 <input
   id="user-email"
@@ -90,21 +82,83 @@ Avec cette méthode, le contenu indicatif est disponible à tout moment (même l
   type="email" />
 ```
 
-- [_Placeholders in Form Fields Are Harmful_ — Nielsen Norman Group (en anglais)](https://www.nngroup.com/articles/form-design-placeholders/)
+- [_Placeholders in Form Fields Are Harmful_ — Nielsen Norman Group <sup>(angl.)</sup>](https://www.nngroup.com/articles/form-design-placeholders/)
 
 ### Mode « contraste élevé » de Windows
 
-Lorsque le [mode de contraste élevé de Windows](/fr/docs/Web/CSS/@media/-ms-high-contrast) est actif, les textes de substitution apparaîtront avec la même mise en forme que les textes saisis par l'utilisateur. Il est alors impossible de distinguer un texte saisi d'un texte indicatif.
+Le texte de substitution apparaîtra avec le même style que le contenu textuel saisi par l'utilisateur·ice lorsqu'il sera affiché en [mode de contraste élevé de Windows <sup>(angl.)</sup>](https://www.smashingmagazine.com/2022/06/guide-windows-high-contrast-mode/). Il est alors impossible de distinguer un texte saisi d'un texte de substitution.
 
-- [Greg Whitworth — Comment utiliser `-ms-high-contrast` (en anglais)](https://www.gwhitworth.com/blog/2017/04/how-to-use-ms-high-contrast)
-- {{cssxref("@media/-ms-high-contrast")}}
-
-### Libellés ({{HTMLElement("&lt;label&gt;")}})
+### Libellés
 
 Les textes de substitution ne doivent pas remplacer les éléments {{htmlelement("label")}}. Sans libellé associé grâce à [`for`](/fr/docs/Web/HTML/Reference/Elements/label#for) et à [`id`](/fr/docs/Web/HTML/Reference/Global_attributes#id), les outils d'assistance tels que les lecteurs d'écran ne peuvent pas correctement analyser les éléments {{htmlelement("input")}}.
 
-- [Fournir des indications simples dans un formulaire](/fr/docs/Web/Accessibility/ARIA)
-- [_Placeholders in Form Fields Are Harmful_ — Nielsen Norman Group (en anglais)](https://www.nngroup.com/articles/form-design-placeholders/)
+- [_Placeholders in Form Fields Are Harmful_ — Nielsen Norman Group <sup>(angl.)</sup>](https://www.nngroup.com/articles/form-design-placeholders/)
+
+## Exemples
+
+### Changer l'apparence du texte de substitution
+
+Cet exemple montre quelques-unes des modifications que vous pouvez apporter aux styles du texte de substitution.
+
+#### HTML
+
+```html
+<input placeholder="Écrire ici" />
+```
+
+#### CSS
+
+```css
+input::placeholder {
+  color: red;
+  font-size: 1.2em;
+  font-style: italic;
+  opacity: 0.5;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("changer_lapparence_du_texte_de_substitution", 200, 60)}}
+
+### Texte opaque
+
+Certains navigateurs rendent le texte de substitution moins opaque. Si vous souhaitez un texte entièrement opaque, définissez explicitement la valeur de la propriété {{CSSXref("color")}}. La valeur [`currentColor`](/fr/docs/Web/CSS/color_value#currentcolor_keyword) peut être utilisée pour avoir la même couleur que l'élément d'entrée correspondant.
+
+#### HTML
+
+```html
+<input placeholder="Couleur définie par le navigateur" />
+<input placeholder="Même couleur que l'entrée" class="explicit-color" />
+<input placeholder="Couleur de texte semi-opaque" class="opacity-change" />
+```
+
+#### CSS
+
+```css
+input {
+  font-weight: bold;
+  color: green;
+}
+
+.explicit-color::placeholder {
+  /* utiliser la même couleur que l'élément d'entrée pour éviter la couleur par
+     défaut définie par le navigateur */
+  color: currentColor;
+}
+
+.opacity-change::placeholder {
+  /* texte moins opaque */
+  color: color-mix(in srgb, currentColor 70%, transparent);
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("texte_opaque", 200, 60)}}
+
+> [!NOTE]
+> Notez que les navigateurs utilisent différentes couleurs par défaut pour le texte de substitution. Par exemple, Firefox utilise la couleur de l'élément d'entrée avec 54&nbsp;% d'opacité, et Chrome utilise la couleur `darkgray`. Si vous souhaitez une couleur de texte de substitution cohérente dans tous les navigateurs, définissez explicitement la `color`.
 
 ## Spécifications
 
@@ -116,12 +170,8 @@ Les textes de substitution ne doivent pas remplacer les éléments {{htmlelement
 
 ## Voir aussi
 
-- {{cssxref(":placeholder-shown")}} qui permet de mettre en forme un élément qui possède un _placeholder_ actif
-
-- [Les formulaires HTML](/fr/docs/conflicting/Learn_web_development/Extensions/Forms)
-- {{HTMLElement("input")}}
-- {{HTMLElement("textarea")}}
-- Les équivalents **non-standards** :
-  - {{cssxref("::-webkit-input-placeholder")}}
-  - {{cssxref("::placeholder")}}
-  - {{cssxref(":-ms-input-placeholder")}}
+- La pseudo-classe {{cssxref(":placeholder-shown")}} de mise en forme d'un élément qui _a_ un texte de substitution actif.
+- Les éléments HTML associés&nbsp;:
+  - {{HTMLElement("input")}}
+  - {{HTMLElement("textarea")}}
+- Les [formulaires HTML](/fr/docs/Learn_web_development/Extensions/Forms)

--- a/files/fr/web/css/_doublecolon_placeholder/index.md
+++ b/files/fr/web/css/_doublecolon_placeholder/index.md
@@ -72,9 +72,7 @@ Avec cette méthode, le contenu de l'indication est disponible même si des info
 
 ```html
 <label for="user-email">Votre adresse mail</label>
-<span id="user-email-hint" class="input-hint"
-  >Exemple : toto@exemple.fr</span
->
+<span id="user-email-hint" class="input-hint">Exemple : toto@exemple.fr</span>
 <input
   id="user-email"
   aria-describedby="user-email-hint"

--- a/files/fr/web/css/_doublecolon_scroll-button/index.md
+++ b/files/fr/web/css/_doublecolon_scroll-button/index.md
@@ -1,0 +1,226 @@
+---
+title: ::scroll-button()
+slug: Web/CSS/::scroll-button
+l10n:
+  sourceCommit: e82803beedb7f1d8a8e918c1071752f18e1e3f28
+---
+
+{{SeeCompatTable}}
+
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::scroll-button()`** représente un bouton permettant de contrôler le défilement d'un {{glossary("scroll container","conteneur de défilement")}}. Ces boutons sont générés sur les conteneurs de défilement lorsque leur propriété {{cssxref("content")}} n'est pas définie à `none`. La direction du défilement est déterminée par la valeur du paramètre.
+
+## Syntaxe
+
+```css-nolint
+::scroll-button(<scroll-button-direction>) {
+  /* ... */
+}
+```
+
+### Paramètres
+
+- `<scroll-button-direction>`
+  - : Une valeur représentant la direction du bouton de défilement à sélectionner. Les valeurs suivantes sont disponibles&nbsp;:
+    - `*`
+      - : Sélectionne tous les boutons de défilement de l'élément d'origine, ce qui permet de leur appliquer des mises en évidence dans une seule règle.
+    - `down`
+      - : Sélectionne le bouton qui fera défiler le contenu vers le bas.
+    - `left`
+      - : Sélectionne le bouton qui fera défiler le contenu vers la gauche.
+    - `right`
+      - : Sélectionne le bouton qui fera défiler le contenu vers la droite.
+    - `up`
+      - : Sélectionne le bouton qui fera défiler le contenu vers le haut.
+    - `block-end`
+      - : Sélectionne le bouton qui fera défiler le contenu vers la fin du bloc.
+    - `block-start`
+      - : Sélectionne le bouton qui fera défiler le contenu vers le début du bloc.
+    - `inline-end`
+      - : Sélectionne le bouton qui fera défiler le contenu vers la fin de l'axe en ligne.
+    - `inline-start`
+      - : Sélectionne le bouton qui fera défiler le contenu vers le début de l'axe en ligne.
+
+    La spécification définit également deux autres valeurs — `next` et `prev` — mais elles ne sont actuellement prises en charge par aucun navigateur.
+
+## Description
+
+Les pseudo-éléments `::scroll-button()` sont générés à l'intérieur d'un {{glossary("scroll container","conteneur de défilement")}} uniquement lorsque leurs propriétés {{cssxref("content")}} sont définies sur une valeur autre que `none`. Ils sont générés comme des éléments frères des enfants DOM du conteneur de défilement, immédiatement avant ceux-ci et avant tout {{cssxref("::scroll-marker-group")}} généré sur le conteneur.
+
+Vous pouvez générer jusqu'à quatre boutons de défilement par conteneur, qui feront défiler le contenu vers le début et la fin des axes de bloc et en ligne. L'argument du sélecteur précise la direction de défilement sélectionnée. Vous pouvez aussi utiliser la valeur `*` pour cibler tous les pseudo-éléments `::scroll-button()` et leur appliquer des mises en évidence dans une seule règle.
+
+Les boutons générés se comportent comme de véritables éléments {{htmlelement("button")}}, y compris leurs styles par défaut spécifiques au navigateur. Ils sont focalisables, accessibles et peuvent être activés comme des boutons classiques. Lorsqu'un bouton de défilement est activé, le contenu du conteneur est défilé dans la direction spécifiée d'une «&nbsp;page&nbsp;», soit environ la dimension du conteneur, de manière similaire à la pression des touches <kbd>PgUp</kbd> et <kbd>PgDn</kbd>.
+
+Il est recommandé de configurer le [verrouillage du défilement CSS](/fr/docs/Web/CSS/CSS_scroll_snap) sur le conteneur de défilement et de définir chaque élément de contenu que vous souhaitez défiler comme une [cible d'ancrage](/fr/docs/Glossary/Scroll_snap#cible_dancrage). Ainsi, l'activation d'un bouton de défilement fera défiler le contenu jusqu'à la cible d'ancrage située à une «&nbsp;page&nbsp;» de distance. Bien que les boutons de défilement fonctionnent sans verrouillage du défilement, l'effet obtenu risque de ne pas être optimal.
+
+Lorsqu'il n'est pas possible de défiler davantage dans une direction donnée, le bouton correspondant est automatiquement désactivé, sinon il est activé. Vous pouvez mettre en évidence les boutons de défilement dans leurs états activé et désactivé en utilisant les pseudo-classes {{cssxref(":enabled")}} et {{cssxref(":disabled")}}.
+
+## Exemples
+
+Voir [Créer des carrousels en CSS](/fr/docs/Web/CSS/CSS_overflow/CSS_carousels) pour d'autres exemples.
+
+### Créer des boutons de défilement
+
+Dans cet exemple, nous montrons comment créer des boutons de défilement sur un carrousel en CSS.
+
+#### HTML
+
+Nous avons une liste {{htmlelement("ul")}} HTML de base avec plusieurs éléments {{htmlelement("li")}}.
+
+```html live-sample___créer_des_boutons_de_défilement live-sample___positionner_les_boutons_de_défilement
+<ul>
+  <li>Élément 1</li>
+  <li>Élément 2</li>
+  <li>Élément 3</li>
+  <li>Élément 4</li>
+  <li>Élément 5</li>
+  <li>Élément 6</li>
+  <li>Élément 7</li>
+  <li>Élément 8</li>
+</ul>
+```
+
+#### CSS
+
+##### Mettre en évidence le carrousel
+
+Nous transformons notre `<ul>` en carrousel en définissant {{cssxref("display")}} sur `flex`, créant une seule ligne non enroulée d'éléments `<li>`. La propriété {{cssxref("overflow-x")}} est définie sur `auto`, ce qui signifie que si les éléments débordent de leur conteneur sur l'axe x, le contenu défile horizontalement. Nous convertissons ensuite le `<ul>` en [conteneur d'ancrage au défilement](/fr/docs/Glossary/Scroll_snap#conteneur_dancrage_au_défilement), garantissant que les éléments s'alignent toujours lorsqu'on fait défiler le conteneur, grâce à une valeur {{cssxref("scroll-snap-type")}} de `mandatory`.
+
+```css live-sample___créer_des_boutons_de_défilement live-sample___positionner_les_boutons_de_défilement
+ul {
+  display: flex;
+  gap: 4vw;
+  padding-left: 0;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
+}
+```
+
+Ensuite, nous mettons en évidence les éléments `<li>`, en utilisant la propriété {{cssxref("flex")}} pour les rendre égaux à 100&nbsp;% de la largeur du conteneur. La valeur {{cssxref("scroll-snap-align")}} `start` permet d'aligner le côté gauche de l'élément visible le plus à gauche avec le bord gauche du conteneur.
+
+```css live-sample___créer_des_boutons_de_défilement live-sample___positionner_les_boutons_de_défilement
+li {
+  list-style-type: none;
+  background-color: #eeeeee;
+  flex: 0 0 100%;
+  height: 100px;
+  padding-top: 20px;
+  scroll-snap-align: start;
+  text-align: center;
+}
+```
+
+##### Créer les boutons de défilement
+
+Tout d'abord, tous les boutons de défilement sont ciblés avec des styles rudimentaires, ainsi qu'avec des mises en évidence selon différents états. Il est important de définir des styles {{cssxref(":focus")}} pour les utilisateur·ice·s utilisant un clavier. De plus, comme les boutons de défilement sont automatiquement mis en état [`disabled`](/fr/docs/Web/HTML/Reference/Attributes/disabled) lorsqu'il n'est plus possible de défiler dans une direction, nous utilisons la pseudo-classe {{cssxref(":disabled")}} pour cibler cet état.
+
+```css live-sample___créer_des_boutons_de_défilement live-sample___positionner_les_boutons_de_défilement
+ul::scroll-button(*) {
+  border: 0;
+  font-size: 2rem;
+  background: none;
+  color: black;
+  opacity: 0.7;
+  cursor: pointer;
+}
+
+ul::scroll-button(*):hover,
+ul::scroll-button(*):focus {
+  opacity: 1;
+}
+
+ul::scroll-button(*):active {
+  translate: 1px 1px;
+}
+
+ul::scroll-button(*):disabled {
+  opacity: 0.2;
+  cursor: unset;
+}
+```
+
+> [!NOTE]
+> Nous définissons aussi une valeur {{cssxref("cursor")}} `pointer` sur les boutons de défilement afin de rendre plus évident qu'ils sont interactifs (une amélioration pour l'[UX](/fr/docs/Glossary/UX) générale et l'[accessibilité cognitive](/fr/docs/Web/Accessibility/Guides/Cognitive_accessibility)), puis nous la supprimons lorsque les boutons sont en état `:disabled`.
+
+Ensuite, une icône adaptée est définie sur les boutons gauche et droit via la propriété `content`, ce qui déclenche également la génération des boutons&nbsp;:
+
+```css live-sample___créer_des_boutons_de_défilement live-sample___positionner_les_boutons_de_défilement
+ul::scroll-button(left) {
+  content: "◄";
+}
+
+ul::scroll-button(right) {
+  content: "►";
+}
+```
+
+Il n'est pas nécessaire de définir de [texte alternatif](/fr/docs/Web/CSS/content#texte_alternatif_string_counter) pour les icônes de `content`, car le navigateur fournit automatiquement des {{glossary("accessible name","noms accessibles")}} appropriés.
+
+#### Résultat
+
+{{EmbedLiveSample("créer_des_boutons_de_défilement", '', '220')}}
+
+Notez que les boutons de défilement apparaissent en bas à gauche du carrousel. Essayez de les activer pour voir comment le contenu défile.
+
+### Positionner les boutons de défilement
+
+L'exemple précédent fonctionne, mais les boutons ne sont pas idéalement placés. Dans cette section, nous ajoutons du CSS pour les positionner en utilisant [le positionnement par ancrage](/fr/docs/Web/CSS/CSS_anchor_positioning).
+
+#### CSS
+
+Tout d'abord, une référence {{cssxref("anchor-name")}} est définie sur le `<ul>` pour l'identifier comme ancre nommée. Ensuite, chaque bouton de défilement a sa propriété {{cssxref("position")}} définie à `absolute` et sa propriété {{cssxref("position-anchor")}} définie sur le `anchor-name` de la liste, afin de [les associer](/fr/docs/Web/CSS/CSS_anchor_positioning/Using#associer_des_éléments_dancrage_et_des_éléments_positionnés).
+
+```css live-sample___positionner_les_boutons_de_défilement
+ul {
+  anchor-name: --mon-carousel;
+}
+
+ul::scroll-button(*) {
+  position: absolute;
+  position-anchor: --mon-carousel;
+}
+```
+
+Pour positionner réellement chaque bouton de défilement, nous commençons par définir une valeur {{cssxref("align-self")}} `anchor-center` sur chacun, afin de les centrer verticalement sur le carrousel&nbsp;:
+
+```css live-sample___positionner_les_boutons_de_défilement
+ul::scroll-button(*) {
+  align-self: anchor-center;
+}
+```
+
+Nous définissons ensuite des valeurs sur leurs {{glossary("inset properties","propriétés d'insertion")}} pour gérer le positionnement horizontal. Nous utilisons les fonctions {{cssxref("anchor()")}} pour positionner les côtés des boutons par rapport aux côtés du carrousel. Dans chaque cas, la fonction {{cssxref("calc()")}} est utilisée pour ajouter un espace entre le bord du bouton et celui du carrousel. Par exemple, le bord droit du bouton gauche est placé 45 pixels à droite du bord gauche du carrousel.
+
+```css live-sample___positionner_les_boutons_de_défilement
+ul::scroll-button(left) {
+  right: calc(anchor(left) - 45px);
+}
+
+ul::scroll-button(right) {
+  left: calc(anchor(right) - 45px);
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("positionner_les_boutons_de_défilement", '', '220')}}
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- {{cssxref("scroll-marker-group")}}
+- {{cssxref("::scroll-marker-group")}}
+- {{cssxref("::scroll-marker")}}
+- {{cssxref("::column")}}
+- {{cssxref(":target-current")}}
+- [Créer des carrousels en CSS](/fr/docs/Web/CSS/CSS_overflow/CSS_carousels)
+- Le module de [débordement CSS](/fr/docs/Web/CSS/CSS_overflow)
+- Le module de [positionnement par ancrage CSS](/fr/docs/Web/CSS/CSS_anchor_positioning)
+- [Galerie de carrousels CSS <sup>(angl.)</sup>](https://chrome.dev/carousel/) par chrome.dev (2025)

--- a/files/fr/web/css/_doublecolon_scroll-marker-group/index.md
+++ b/files/fr/web/css/_doublecolon_scroll-marker-group/index.md
@@ -1,0 +1,192 @@
+---
+title: ::scroll-marker-group
+slug: Web/CSS/::scroll-marker-group
+l10n:
+  sourceCommit: e82803beedb7f1d8a8e918c1071752f18e1e3f28
+---
+
+{{SeeCompatTable}}
+
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::scroll-marker-group`** est généré à l'intérieur d'un {{glossary("scroll container","conteneur de défilement")}} et contient tout pseudo-élément {{cssxref("::scroll-marker")}} généré sur les descendants de ce conteneur.
+
+## Syntaxe
+
+```css-nolint
+::scroll-marker-group {
+  /* ... */
+}
+```
+
+## Description
+
+Le pseudo-élément **`::scroll-marker-group`** d'un conteneur de défilement représente un **groupe de marqueurs de défilement**. Il s'agit d'un conteneur qui inclut automatiquement tout pseudo-élément {{cssxref("::scroll-marker")}} généré sur lui-même ou ses descendants. Cela permet de les positionner et de les disposer comme un groupe et s'utilise généralement lors de la création d'un carrousel CSS pour fournir un indicateur de position de défilement. Les marqueurs individuels peuvent être utilisés pour naviguer vers leurs éléments de contenu associés.
+
+Le conteneur de défilement doit avoir une valeur {{cssxref("scroll-marker-group")}} différente de `none` afin que le pseudo-élément `::scroll-marker-group` soit généré. La valeur de {{cssxref("scroll-marker-group")}} détermine l'endroit où le groupe de marqueurs apparaît dans l'ordre d'onglet et l'ordre de disposition des boîtes du carrousel (mais pas dans la structure du DOM)&nbsp;: `before` le place au début, tandis que `after` le place à la fin.
+
+Il est recommandé d'aligner la position de rendu visuelle du groupe de marqueurs avec l'ordre d'onglet. Lorsque vous positionnez le groupe au début du contenu, placez-le au début de l'ordre d'onglet avec `before`. Lorsque vous positionnez le groupe à la fin du contenu, placez-le à la fin de l'ordre d'onglet avec `after`.
+
+En termes d'accessibilité, le groupe de marqueurs de défilement et les marqueurs qu'il contient sont rendus avec les sémantiques [`tablist`](/fr/docs/Web/Accessibility/ARIA/Reference/Roles/tablist_role)/[`tab`](/fr/docs/Web/Accessibility/ARIA/Reference/Roles/tab_role). Lorsque vous utilisez <kbd>Tab</kbd> pour atteindre le groupe, il se comporte comme un seul élément (c'est-à-dire qu'une autre pression sur la touche <kbd>Tab</kbd> passera au prochain élément), et vous pouvez vous déplacer entre les différents marqueurs avec les flèches gauche et droite (ou haut et bas).
+
+## Exemples
+
+Voir [Créer des carrousels en CSS](/fr/docs/Web/CSS/CSS_overflow/CSS_carousels) pour d'autres exemples qui utilisent le pseudo-élément `::scroll-marker`.
+
+### Créer des marqueurs de défilement pour un carrousel
+
+Cette démonstration est un carrousel de pages uniques, chaque élément occupant toute la page. Nous avons inclus des marqueurs de défilement afin de permettre à l'utilisateur·ice de naviguer vers n'importe quelle page en cliquant sur un marqueur.
+
+#### HTML
+
+Le HTML se compose d'une [liste non ordonnée](/fr/docs/Web/HTML/Reference/Elements/ul), chaque [élément de liste](/fr/docs/Web/HTML/Reference/Elements/li) contenant un contenu d'exemple&nbsp;:
+
+```html live-sample___créer_des_marqueurs_de_défilement_pour_un_carrousel live-sample___positionner_le_groupe_de_marqueurs_avec_le_positionnement_par_ancrage
+<ul>
+  <li>
+    <h2>Page 1</h2>
+  </li>
+  <li>
+    <h2>Page 2</h2>
+  </li>
+  <li>
+    <h2>Page 3</h2>
+  </li>
+  <li>
+    <h2>Page 4</h2>
+  </li>
+</ul>
+```
+
+#### CSS
+
+Nous convertissons d'abord notre `<ul>` en carrousel en définissant {{cssxref("display")}} sur `flex`, créant une seule ligne non enroulée d'éléments `<li>`. La propriété {{cssxref("overflow-x")}} est définie sur `auto`, ce qui signifie que si les éléments débordent de leur conteneur sur l'axe x, le contenu défile horizontalement. Nous convertissons ensuite le `<ul>` en [conteneur d'ancrage au défilement](/fr/docs/Glossary/Scroll_snap#conteneur_dancrage_au_défilement), garantissant que les éléments s'alignent toujours lorsque le conteneur est défilé avec une valeur {{cssxref("scroll-snap-type")}} de `mandatory`.
+
+```css hidden live-sample___créer_des_marqueurs_de_défilement_pour_un_carrousel live-sample___positionner_le_groupe_de_marqueurs_avec_le_positionnement_par_ancrage
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+}
+```
+
+```css live-sample___créer_des_marqueurs_de_défilement_pour_un_carrousel live-sample___positionner_le_groupe_de_marqueurs_avec_le_positionnement_par_ancrage
+ul {
+  display: flex;
+  gap: 4vw;
+  padding-left: 0;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
+}
+```
+
+Ensuite, nous mettons en évidence les éléments `<li>`, en utilisant la propriété {{cssxref("flex")}} pour les rendre à `100%` de la largeur du conteneur. La valeur {{cssxref("scroll-snap-align")}} `start` fait s'accrocher le côté gauche de l'élément visible le plus à gauche au bord gauche du conteneur lorsque le contenu est défilé.
+
+```css live-sample___créer_des_marqueurs_de_défilement_pour_un_carrousel live-sample___positionner_le_groupe_de_marqueurs_avec_le_positionnement_par_ancrage
+li {
+  list-style-type: none;
+  background-color: #eeeeee;
+  flex: 0 0 100%;
+  height: 200px;
+  padding-top: 20px;
+  scroll-snap-align: start;
+  text-align: center;
+}
+```
+
+Ensuite, la propriété {{cssxref("scroll-marker-group")}} de la liste est définie sur `after`, de sorte que le pseudo-élément `::scroll-marker-group` est placé après le contenu DOM de la liste dans l'ordre de tabulation et l'ordre de disposition des boîtes&nbsp;; cela signifie qu'il vient après les boutons de défilement.
+
+```css live-sample___créer_des_marqueurs_de_défilement_pour_un_carrousel live-sample___positionner_le_groupe_de_marqueurs_avec_le_positionnement_par_ancrage
+ul {
+  scroll-marker-group: after;
+}
+```
+
+Ensuite, le pseudo-élément `::scroll-marker-group` de la liste est disposé avec Flexbox, avec une valeur de {{cssxref("justify-content")}} à `center` et un {{cssxref("gap")}} de `20px` afin que ses enfants (les pseudo-éléments {{cssxref("::scroll-marker")}}) soient centrés à l'intérieur du `::scroll-marker-group` avec un espacement entre chacun.
+
+```css live-sample___créer_des_marqueurs_de_défilement_pour_un_carrousel live-sample___positionner_le_groupe_de_marqueurs_avec_le_positionnement_par_ancrage
+ul::scroll-marker-group {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+}
+```
+
+Ensuite, les marqueurs de défilement eux-mêmes sont mis en évidence. Leur apparence est gérée par {{cssxref("width")}}, {{cssxref("height")}}, {{cssxref("background-color")}}, {{cssxref("border")}} et {{cssxref("border-radius")}}. Il faut aussi définir une valeur de {{cssxref("content")}} différente de `none` afin qu'ils soient effectivement générés.
+
+```css live-sample___créer_des_marqueurs_de_défilement_pour_un_carrousel live-sample___positionner_le_groupe_de_marqueurs_avec_le_positionnement_par_ancrage
+li::scroll-marker {
+  width: 16px;
+  height: 16px;
+  background-color: transparent;
+  border: 2px solid black;
+  border-radius: 50%;
+  content: "";
+}
+```
+
+> [!NOTE]
+> Le contenu généré est en ligne (<i lang="en">inline</i> en anglais) par défaut&nbsp;; nous pouvons appliquer `width` et `height` à nos marqueurs car ils sont disposés en éléments flexibles.
+
+Enfin, la pseudo-classe {{cssxref(":target-current")}} est utilisée pour sélectionner le marqueur de défilement correspondant à la «&nbsp;page&nbsp;» visible, afin de mettre en évidence la progression de défilement. Ici, nous définissons `background-color` sur `black` pour obtenir un disque plein.
+
+```css live-sample___créer_des_marqueurs_de_défilement_pour_un_carrousel live-sample___positionner_le_groupe_de_marqueurs_avec_le_positionnement_par_ancrage
+li::scroll-marker:target-current {
+  background-color: black;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("carousel-example", "100%", "280px")}}
+
+### Positionner le groupe de marqueurs avec le positionnement par ancrage
+
+Cet exemple étend le précédent en montrant l'utilisation du [positionnement par ancrage en CSS](/fr/docs/Web/CSS/CSS_anchor_positioning) pour positionner le groupe de marqueurs par rapport au carrousel.
+
+#### CSS
+
+Le pseudo-élément `::scroll-marker-group` de la liste est positionné par rapport au carrousel en utilisant le positionnement par ancrage, en donnant au groupe une valeur {{cssxref("position-anchor")}} qui correspond au {{cssxref("anchor-name")}} de l'élément `<ul>`. Nous positionnons ensuite ce groupe par rapport au conteneur de défilement dans la direction de bloc en définissant une valeur de {{cssxref("top")}} qui inclut une fonction {{cssxref("anchor()")}}. Nous ajoutons aussi une valeur {{cssxref("justify-self")}} `anchor-center`, qui aligne le groupe au centre du conteneur de défilement dans la direction en ligne.
+
+```css live-sample___positionner_le_groupe_de_marqueurs_avec_le_positionnement_par_ancrage
+ul {
+  anchor-name: --mon-carousel;
+}
+
+ul::scroll-marker-group {
+  /* Depuis l'exemple précédent */
+  display: flex;
+  gap: 20px;
+
+  position: absolute;
+  position-anchor: --mon-carousel;
+  top: calc(anchor(bottom) - 70px);
+  justify-self: anchor-center;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("positionner_le_groupe_de_marqueurs_avec_le_positionnement_par_ancrage", "100%", "260px")}}
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- {{cssxref("scroll-marker-group")}}
+- {{cssxref("::scroll-button()")}}
+- {{cssxref("::scroll-marker")}}
+- {{cssxref("::column")}}
+- {{cssxref(":target-current")}}
+- [Créer des carrousels en CSS](/fr/docs/Web/CSS/CSS_overflow/CSS_carousels)
+- Le module de [positionnement par ancrage CSS](/fr/docs/Web/CSS/CSS_anchor_positioning)
+- Le module de [débordement CSS](/fr/docs/Web/CSS/CSS_overflow)
+- [Galerie de carrousels CSS <sup>(angl.)</sup>](https://chrome.dev/carousel/) par chrome.dev (2025)

--- a/files/fr/web/css/_doublecolon_scroll-marker/index.md
+++ b/files/fr/web/css/_doublecolon_scroll-marker/index.md
@@ -1,0 +1,195 @@
+---
+title: ::scroll-marker
+slug: Web/CSS/::scroll-marker
+l10n:
+  sourceCommit: e82803beedb7f1d8a8e918c1071752f18e1e3f28
+---
+
+{{SeeCompatTable}}
+
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::scroll-marker`** peut être généré à l'intérieur de n'importe quel élément et représente son marqueur de défilement. Il est placé dans le {{cssxref("::scroll-marker-group")}} de l'ancêtre du {{glossary("scroll container","conteneur de défilement")}} le plus proche. Un marqueur de défilement se comporte comme une ancre (élément {{htmlelement("a")}}) dont la cible de défilement est l'élément d'origine du marqueur — et fait défiler le conteneur de défilement jusqu'à cet élément lorsqu'il est activé.
+
+## Syntaxe
+
+```css-nolint
+::scroll-marker {
+  /* ... */
+}
+```
+
+## Description
+
+Un `::scroll-marker` est généré sur un élément lorsque la propriété {{cssxref("content")}} de `::scroll-marker` est définie sur une valeur différente de `none`, et que l'élément possède un ancêtre, conteneur de défilement, avec une valeur {{cssxref("scroll-marker-group")}} différente de `none` (ce qui signifie qu'il générera un pseudo-élément {{cssxref("::scroll-marker-group")}}).
+
+Le pseudo-élément `::scroll-marker-group` du conteneur de défilement contient automatiquement tout pseudo-élément `::scroll-marker` généré sur le conteneur ou ses descendants. Cela permet de les positionner et de les disposer comme un groupe, généralement utilisé lors de la création d'un carrousel CSS pour générer un indicateur de position de défilement. Les marqueurs individuels peuvent être utilisés pour naviguer vers leurs éléments de contenu associés.
+
+En termes d'accessibilité, le groupe de marqueurs de défilement et les marqueurs qu'il contient sont rendus avec les sémantiques [`tablist`](/fr/docs/Web/Accessibility/ARIA/Reference/Roles/tablist_role)/[`tab`](/fr/docs/Web/Accessibility/ARIA/Reference/Roles/tab_role). Lorsque vous utilisez <kbd>Tab</kbd> pour atteindre le groupe, il se comporte comme un seul élément (c'est-à-dire qu'une autre pression sur la touche <kbd>Tab</kbd> passera au prochain élément), et vous pouvez naviguer entre les différents marqueurs à l'aide des flèches gauche et droite (ou haut et bas).
+
+## Exemples
+
+Voir [Créer des carrousels en CSS](/fr/docs/Web/CSS/CSS_overflow/CSS_carousels) pour d'autres exemples utilisant le pseudo-élément `::scroll-marker`.
+
+### Créer des marqueurs de défilement de carrousel
+
+Dans cet exemple, nous montrons comment créer des marqueurs de défilement sur un carrousel CSS.
+
+#### HTML
+
+Nous avons une liste {{htmlelement("ul")}} HTML de base avec plusieurs éléments {{htmlelement("li")}}.
+
+```html live-sample___créer_des_marqueurs_de_défilement_de_carrousel live-sample___numérotation_et_style_personnalisés_des_marqueurs_de_défilement
+<ul>
+  <li>Élément 1</li>
+  <li>Élément 2</li>
+  <li>Élément 3</li>
+  <li>Élément 4</li>
+  <li>Élément 5</li>
+  <li>Élément 6</li>
+  <li>Élément 7</li>
+  <li>Élément 8</li>
+</ul>
+```
+
+#### CSS
+
+Nous transformons notre `<ul>` en conteneur de défilement avec accrochage en définissant {{cssxref("display")}} sur `flex`, créant une seule ligne non enroulée d'éléments `<li>`. La propriété {{cssxref("overflow-x")}} est définie sur `auto`, ce qui signifie que si les éléments débordent de leur conteneur sur l'axe x, le contenu défile horizontalement. Nous convertissons ensuite le `<ul>` en [conteneur d'ancrage au défilement](/fr/docs/Glossary/Scroll_snap#conteneur_dancrage_au_défilement), garantissant que les éléments s'alignent toujours lorsqu'on fait défiler le conteneur avec une valeur {{cssxref("scroll-snap-type")}} de `mandatory`.
+
+Nous créons un groupe de marqueurs de défilement avec la propriété `scroll-marker-group`, en plaçant le groupe après tout le contenu.
+
+```css live-sample___créer_des_marqueurs_de_défilement_de_carrousel live-sample___numérotation_et_style_personnalisés_des_marqueurs_de_défilement
+ul {
+  display: flex;
+  gap: 4vw;
+  padding-left: 0;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
+  scroll-marker-group: after;
+}
+```
+
+Ensuite, nous mettons en évidence les éléments `<li>`, en utilisant la propriété {{cssxref("flex")}} pour les rendre à `33%` de la largeur du conteneur. La valeur {{cssxref("scroll-snap-align")}} `start` permet d'aligner le côté gauche de l'élément visible le plus à gauche avec le bord gauche du conteneur.
+
+```css live-sample___créer_des_marqueurs_de_défilement_de_carrousel live-sample___numérotation_et_style_personnalisés_des_marqueurs_de_défilement
+li {
+  list-style-type: none;
+  background-color: #eeeeee;
+  flex: 0 0 33%;
+  height: 100px;
+  padding-top: 20px;
+  scroll-snap-align: start;
+  text-align: center;
+}
+```
+
+Nous utilisons ensuite le pseudo-élément `::scroll-marker` pour créer un marqueur carré pour chaque élément de liste avec une bordure rouge&nbsp;:
+
+```css live-sample___créer_des_marqueurs_de_défilement_de_carrousel
+li::scroll-marker {
+  content: "";
+  border: 1px solid red;
+  height: 1em;
+  width: 1em;
+}
+```
+
+Nous appliquons également des mises en évidence au pseudo-élément {{cssxref("::scroll-marker-group")}} afin de disposer les marqueurs de défilement au centre de la ligne, avec un espacement de `0.4em` entre chacun&nbsp;:
+
+```css live-sample___créer_des_marqueurs_de_défilement_de_carrousel live-sample___numérotation_et_style_personnalisés_des_marqueurs_de_défilement
+::scroll-marker-group {
+  display: flex;
+  gap: 0.4em;
+  place-content: center;
+}
+```
+
+Enfin, nous mettons en évidence différemment le marqueur de l'élément actuellement défilé, en ciblant ce marqueur avec la pseudo-classe {{cssxref(":target-current")}}.
+
+```css live-sample___créer_des_marqueurs_de_défilement_de_carrousel
+::scroll-marker:target-current {
+  background: red;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("créer_des_marqueurs_de_défilement_de_carrousel", '', '200')}}
+
+### Numérotation et style personnalisés des marqueurs de défilement
+
+Cet exemple est identique au précédent, sauf que nous avons appliqué un style différent aux marqueurs de défilement et utilisé des [compteurs CSS](/fr/docs/Web/CSS/CSS_lists) pour incrémenter le numéro affiché sur chaque marqueur. Les différences CSS sont expliquées dans la section suivante.
+
+### CSS
+
+Dans cet exemple, nous définissons un compteur nommé `markers` que nous voulons incrémenter sur chaque `<li>`, grâce à la propriété {{cssxref("counter-increment")}}&nbsp;:
+
+```css live-sample___numérotation_et_style_personnalisés_des_marqueurs_de_défilement
+li {
+  counter-increment: markers;
+}
+```
+
+Nous définissons ensuite la propriété {{cssxref("content")}} du pseudo-élément `::scroll-marker` sur la fonction {{cssxref("counter()")}}, en lui passant le nom du compteur `markers` en argument. Cela insère un numéro dans chaque marqueur, qui s'incrémente automatiquement. Le reste du style est rudimentaire, mais il illustre comment les marqueurs peuvent être entièrement mis en évidence.
+
+```css live-sample___numérotation_et_style_personnalisés_des_marqueurs_de_défilement
+li::scroll-marker {
+  content: counter(markers);
+  font-family: sans-serif;
+  width: fit-content;
+  height: 1em;
+  padding: 5px;
+  color: black;
+  text-decoration: none;
+  border: 2px solid rgb(0 0 0 / 0.15);
+  border-radius: 0.5em;
+  background-color: #eeeeee;
+}
+```
+
+Pour une autre personnalisation intéressante, nous incluons deux règles pour sélectionner le marqueur du premier et du dernier élément de la liste, en insérant respectivement {{cssxref(":first-child")}} et {{cssxref(":last-child")}} dans le sélecteur. Nous donnons au premier marqueur le texte «&nbsp;Premier&nbsp;» et au dernier le texte «&nbsp;Dernier&nbsp;».
+
+```css live-sample___numérotation_et_style_personnalisés_des_marqueurs_de_défilement
+li:first-child::scroll-marker {
+  content: "Premier";
+}
+
+li:last-child::scroll-marker {
+  content: "Dernier";
+}
+```
+
+Pour améliorer l'expérience utilisateur, nous appliquons une couleur différente aux marqueurs au survol ({{cssxref(":hover")}}) et utilisons la pseudo-classe `:target-current` pour définir une {{cssxref("color")}} et une {{cssxref("background-color")}} différentes sur le marqueur de l'élément actuellement affiché, afin que les utilisateur·ice·s sachent quel élément est visible&nbsp;:
+
+```css live-sample___numérotation_et_style_personnalisés_des_marqueurs_de_défilement
+::scroll-marker:hover {
+  background-color: #ddcccc;
+}
+
+::scroll-marker:target-current {
+  background-color: purple;
+  color: white;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("numérotation_et_style_personnalisés_des_marqueurs_de_défilement", '', '220')}}
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- {{cssxref("scroll-marker-group")}}
+- {{cssxref("::scroll-button()")}}
+- {{cssxref("::scroll-marker-group")}}
+- {{cssxref(":target-current")}}
+- [Créer des carrousels en CSS](/fr/docs/Web/CSS/CSS_overflow/CSS_carousels)
+- Le module de [listes et compteurs CSS](/fr/docs/Web/CSS/CSS_lists)
+- Le module de [débordement CSS](/fr/docs/Web/CSS/CSS_overflow)
+- [Galerie de carrousels CSS <sup>(angl.)</sup>](https://chrome.dev/carousel/) par chrome.dev (2025)

--- a/files/fr/web/css/_doublecolon_selection/index.md
+++ b/files/fr/web/css/_doublecolon_selection/index.md
@@ -3,9 +3,9 @@ title: ::selection
 slug: Web/CSS/::selection
 ---
 
-{{CSSRef}}
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::selection`** permet d'appliquer des règles CSS à une portion du document qui a été sélectionnée par l'utilisateur (via la souris ou un autre dispositif de pointage).
 
-Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) **`::selection`** permet d'appliquer des règles CSS à une portion du document qui a été sélectionnée par l'utilisateur (via la souris ou un autre dispositif de pointage).
+Le pseudo-élément `::selection` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en surbrillance. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments mise en évidence](/fr/docs/Web/CSS/Pseudo-elements#héritage_des_pseudo-éléments_de_mise_en_évidence).
 
 ```css
 ::selection {

--- a/files/fr/web/css/_doublecolon_selection/index.md
+++ b/files/fr/web/css/_doublecolon_selection/index.md
@@ -1,69 +1,63 @@
 ---
 title: ::selection
 slug: Web/CSS/::selection
+l10n:
+  sourceCommit: 37482c6bb0894d047a225c24f102352f89788523
 ---
 
-Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::selection`** permet d'appliquer des règles CSS à une portion du document qui a été sélectionnée par l'utilisateur (via la souris ou un autre dispositif de pointage).
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::selection`** permet d'appliquer des règles CSS à une portion du document qui a été sélectionnée par l'utilisateur·ice (par exemple en cliquant et en faisant glisser la souris sur le texte).
 
-Le pseudo-élément `::selection` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en surbrillance. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments mise en évidence](/fr/docs/Web/CSS/Pseudo-elements#héritage_des_pseudo-éléments_de_mise_en_évidence).
+Le pseudo-élément `::selection` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en évidence. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments mise en évidence](/fr/docs/Web/CSS/Pseudo-elements#héritage_des_pseudo-éléments_de_mise_en_évidence).
 
-```css
-::selection {
-  background-color: cyan;
+{{InteractiveExample("Démonstration CSS&nbsp;: ::selection", "tabbed-shorter")}}
+
+```css interactive-example
+p::selection {
+  color: red;
+  background-color: yellow;
 }
+```
+
+```html interactive-example
+<p>
+  Sélectionnez un fragment de ce paragraphe pour voir comment son apparence est
+  modifiée.
+</p>
 ```
 
 ## Propriétés autorisées
 
-Seul un sous-ensemble des propriétés CSS peut être utilisé pour une règle dont le sélecteur contient `::selection` :
+Seul un sous-ensemble des propriétés CSS peut être utilisé pour une règle dont le sélecteur contient `::selection`&nbsp;:
 
-- {{cssxref("color")}},
-- {{cssxref("background-color")}},
-- {{cssxref("cursor")}},
-- {{cssxref("caret-color")}},
-- {{cssxref("outline")}} ainsi que les propriétés détaillées associées,
-- {{cssxref("text-decoration")}} ainsi que les propriétés détaillées associées,
-- {{cssxref("text-emphasis-color")}},
-- {{cssxref("text-shadow")}}.
+- {{CSSxRef("color")}}
+- {{CSSxRef("background-color")}}
+- {{CSSxRef("text-decoration")}} ainsi que les propriétés détaillées associées
+- {{CSSxRef("text-shadow")}}
+- {{CSSxRef("-webkit-text-stroke-color")}}, {{CSSxRef("-webkit-text-fill-color")}} et {{CSSxRef("-webkit-text-stroke-width")}}
 
-On notera que {{cssxref("background-image")}} est ignorée, comme les autres propriétés.
+En particulier, {{CSSxRef("background-image")}} est ignorée.
 
 ## Syntaxe
 
 ```css
-/*Syntaxe propre à Firefox (61 et antérieur) */
-::-moz-selection
-{{csssyntax}}
+::selection {
+  /* ... */
+}
 ```
+
+## Accessibilité
+
+Il est recommandé de **ne pas surcharger la police par défaut fournie par le système d'exploitation à des fins esthétiques** et notamment si l'utilisateur·ice a personnalisé ces polices pour ses besoins. Pour les personnes qui connaissent moins les technologies, cette modification peut modifier leur compréhension des fonctionnalités du site.
+
+Si la police est surchargée, il faut s'assurer que **le contraste** entre la couleur du texte sélectionné et celle de l'arrière-plan est suffisamment élevé afin que les personnes disposant de faibles conditions de vision puissent lire le texte lorsqu'il est sélectionné.
+
+La valeur du contraste est déterminée en comparant la luminosité de la couleur du texte de substitution et celle de l'arrière-plan. Afin de respecter les recommandations d'accessibilité : [Web Content Accessibility Guidelines (WCAG) <sup>(angl.)</sup>](https://www.w3.org/WAI/intro/wcag), un ratio de 4.5:1 est nécessaire pour le contenu textuel normal et un ratio de 3:1 est nécessaire pour les textes plus grands ou en gras. Un texte de grande taille est défini comme étant de 18,66 pixels et en gras ou plus grand, ou de 24 pixels ou plus.
+
+- [WebAIM&nbsp;: vérificateur de contraste <sup>(angl.)</sup>](https://webaim.org/resources/contrastchecker/)
+- [Explications des recommendation WCAG 1.4](/fr/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
+- [Comprendre le critère de succès 1.4.3 | W3C Comprendre les WCAG 2.0 <sup>(angl.)</sup>](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
 
 ## Exemples
-
-### CSS
-
-```css
-/* du texte sélectionné sera jaune sur fond rouge */
-::-moz-selection {
-  color: gold;
-  background-color: red;
-}
-
-::selection {
-  color: gold;
-  background-color: red;
-}
-
-/* le texte sélectionné dans un paragraphe */
-/* sera blanc sur noir                     */
-p::-moz-selection {
-  color: white;
-  background-color: black;
-}
-
-p::selection {
-  color: white;
-  background-color: black;
-}
-```
 
 ### HTML
 
@@ -72,26 +66,37 @@ p::selection {
 <p>Essayez également de sélectionner du texte dans ce &lt;p&gt;</p>
 ```
 
+### CSS
+
+```css hidden
+::-moz-selection {
+  color: gold;
+  background-color: red;
+}
+
+p::-moz-selection {
+  color: white;
+  background-color: blue;
+}
+```
+
+```css
+/* le texte sélectionné sera or sur fond rouge */
+::selection {
+  color: gold;
+  background-color: red;
+}
+
+/* le texte sélectionné dans un paragraphe sera blanc sur fond bleu */
+p::selection {
+  color: white;
+  background-color: blue;
+}
+```
+
 ### Résultat
 
 {{EmbedLiveSample('Exemples')}}
-
-## Accessibilité
-
-Il est recommandé de **ne pas surcharger la police par défaut fournie par le système d'exploitation à des fins esthétiques** et notamment si l'utilisateur a personnalisé ces polices pour ses besoins. Pour les personnes qui connaissent moins les technologies, cette modification peut modifier leur compréhension des fonctionnalités du site.
-
-Si la police est surchargée, il faut s'assurer que le contraste entre la couleur du texte sélectionné et celle de l'arrière-plan est suffisamment élevé afin que les personnes disposant de faibles conditions de vision puissent lire le texte lorsqu'il est sélectionné.
-
-La valeur du contraste est déterminée en comparant la luminosité de la couleur du texte de substitution et celle de l'arrière-plan. Afin de respecter les recommandations d'accessibilité : [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/intro/wcag), un ratio de 4.5:1 est nécessaire pour le contenu textuel normal et un ratio de 3:1 est nécessaire pour les textes plus grands ou en gras. Le seuil entre ces deux tailles est défini de la façon suivante :
-
-- Si le texte est en gras : 18.66px ou plus grand
-- Sinon 24px ou plus grand
-
-Quelques ressources :
-
-- [WebAIM : vérificateur de contraste](https://webaim.org/resources/contrastchecker/)
-- [Explications des recommendation WCAG 1.4](/fr/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
-- [Understanding Success Criterion 1.4.3 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
 
 ## Spécifications
 

--- a/files/fr/web/css/_doublecolon_slotted/index.md
+++ b/files/fr/web/css/_doublecolon_slotted/index.md
@@ -1,13 +1,13 @@
 ---
 title: ::slotted()
 slug: Web/CSS/::slotted
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{CSSRef}}
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::slotted()`** représente n'importe quel élément ayant été placé à l'intérieur d'un emplacement (_slot_) au sein d'un gabarit (_template_) HTML (cf. [Utiliser les gabarits et les emplacements](/fr/docs/Web/API/Web_components/Using_templates_and_slots) pour plus d'informations).
 
-Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) CSS **`::slotted()`** représente n'importe quel élément ayant été placé à l'intérieur d'un emplacement (_slot_) au sein d'un gabarit (_template_) HTML (cf. [Utiliser les gabarits et les emplacements](/fr/docs/Web/API/Web_components/Using_templates_and_slots) pour plus d'informations).
-
-Cela ne fonctionne que pour du CSS placé à l'intérieur d'un élément {{htmlelement("template")}} et/ou dans le _[shadow DOM](/fr/docs/Web/API/Web_components/Using_shadow_DOM)_. On notera également que ce sélecteur ne sélectionnera pas les noeuds texte placés dans les emplacements, il ne cible que les éléments.
+Cela ne fonctionne que pour du CSS placé à l'intérieur d'un élément {{htmlelement("template")}} et/ou dans le [le DOM fantôme (<i lang="en">shadow DOM</i>)](/fr/docs/Web/API/Web_components/Using_shadow_DOM). On notera également que ce sélecteur ne sélectionnera pas les noeuds texte placés dans les emplacements, il ne cible que les éléments.
 
 ```css
 /* Cible n'importe quel élément placé dans un emplacement */
@@ -27,14 +27,14 @@ Cela ne fonctionne que pour du CSS placé à l'intérieur d'un élément {{htmle
 
 ## Exemples
 
-Les fragments de code suivants sont tirés du dépôt [`slotted-pseudo-element`](https://github.com/mdn/web-components-examples/tree/master/slotted-pseudo-element) ([voir le résultat en _live_](https://mdn.github.io/web-components-examples/slotted-pseudo-element/)).
+### Mise en évidence des éléments dans les emplacements
 
-Dans cette démonstration, on utilise un gabarit avec trois emplacements :
+Dans cette démonstration, on utilise un gabarit avec trois emplacements&nbsp;:
 
 ```html
 <template id="person-template">
   <div>
-    <h2>Carte d'identité d'une personne</h2>
+    <h2>Carte d'identité</h2>
     <slot name="person-name">NOM ABSENT</slot>
     <ul>
       <li><slot name="person-age">AGE ABSENT</slot></li>
@@ -44,7 +44,7 @@ Dans cette démonstration, on utilise un gabarit avec trois emplacements :
 </template>
 ```
 
-Un élément personnalisé — `<person-details>` — est défini de la façon suivante :
+Nous définissons l'élément personnalisé `<person-details>`. Dans ce cas, nous ajoutons des styles avec JavaScript, mais nous aurions pu les ajouter dans un bloc {{HTMLElement("style")}} au sein du {{HTMLElement("template")}} avec le même effet&nbsp;:
 
 ```js
 customElements.define(
@@ -74,15 +74,31 @@ customElements.define(
 
 On voit ici que, lorsqu'on renseigne le `style` de l'élément, on sélectionne tous les éléments présents dans les emplacements (`::slotted(*)`) afin de leur fournir différentes polices et couleurs. Cela permet d'avoir une meilleur vision des emplacements qui ne sont pas encore occupés.
 
-Voici ce à quoi ressemblera l'élément lorsqu'il sera inséré dans la page :
+Notre balisage comprend trois éléments personnalisés, dont un élément personnalisé avec un nom de `slot` invalide dans un ordre source différent de celui du `<template>`&nbsp;:
 
 ```html
 <person-details>
-  <p slot="person-name">Dr. Shazaam</p>
-  <span slot="person-age">Immortel</span>
-  <span slot="person-occupation">Super-héros</span>
+  <p slot="person-name">Wonder Woman</p>
+  <span slot="person-age">Immortelle</span>
+  <span slot="person-occupation">Super-héroïne</span>
+</person-details>
+
+<person-details>
+  <p slot="person-name">Malala Yousafzai</p>
+  <span slot="person-age">17</span>
+  <span slot="person-occupation">Activiste</span>
+</person-details>
+
+<person-details>
+  <span slot="person-age">44</span>
+  <span slot="nom-demplacement-invalide">Voyageur temporel</span>
+  <p slot="person-name">Dr. Who</p>
 </person-details>
 ```
+
+#### Result
+
+{{EmbedLiveSample('mise_en_évidence_des_éléments_dans_les_emplacements', 500, 500)}}
 
 ## Spécifications
 
@@ -94,4 +110,12 @@ Voici ce à quoi ressemblera l'élément lorsqu'il sera inséré dans la page :
 
 ## Voir aussi
 
+- {{cssxref(":host")}}
+- {{cssxref(":host_function", ":host()")}}
+- {{cssxref(":host-context", ":host-context()")}}
+- {{cssxref(":has-slotted")}}
+- Le module de [définition de la portée CSS](/fr/docs/Web/CSS/CSS_scoping)
+- L'attribut HTML [`slot`](/fr/docs/Web/HTML/Reference/Global_attributes/slot)
+- L'élément HTML {{HTMLElement("slot")}}
+- L'élément HTML {{HTMLElement("template")}}
 - [Les composants web](/fr/docs/Web/API/Web_components)

--- a/files/fr/web/css/_doublecolon_slotted/index.md
+++ b/files/fr/web/css/_doublecolon_slotted/index.md
@@ -9,6 +9,66 @@ Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) 
 
 Cela ne fonctionne que pour du CSS placé à l'intérieur d'un élément {{htmlelement("template")}} et/ou dans le [le DOM fantôme (<i lang="en">shadow DOM</i>)](/fr/docs/Web/API/Web_components/Using_shadow_DOM). On notera également que ce sélecteur ne sélectionnera pas les noeuds texte placés dans les emplacements, il ne cible que les éléments.
 
+{{InteractiveExample("Démonstration CSS&nbsp;: ::slotted()", "tabbed-shorter")}}
+
+```css interactive-example
+/* Ce CSS est appliqué à l'intérieur du shadow DOM. */
+
+::slotted(.content) {
+  background-color: aqua;
+}
+
+h2 ::slotted(span) {
+  background: silver;
+}
+```
+
+```html interactive-example
+<template id="card-template">
+  <div>
+    <h2><slot name="caption">le titre va ici</slot></h2>
+    <slot name="content">le contenu va ici</slot>
+  </div>
+</template>
+
+<my-card>
+  <span slot="caption">Erreur</span>
+  <p class="content" slot="content">Échec de la construction !</p>
+</my-card>
+```
+
+```js interactive-example
+customElements.define(
+  "my-card",
+  class extends HTMLElement {
+    constructor() {
+      super();
+
+      const template = document.getElementById("card-template");
+      const shadow = this.attachShadow({ mode: "open" });
+      shadow.appendChild(template.content.cloneNode(true));
+
+      const elementStyle = document.createElement("style");
+      elementStyle.textContent = `
+        div {
+          width: 200px;
+          border: 2px dotted red;
+          border-radius: 4px;
+        }`;
+      shadow.appendChild(elementStyle);
+
+      const cssTab = document.querySelector("#css-output");
+      const editorStyle = document.createElement("style");
+      editorStyle.textContent = cssTab.textContent;
+      shadow.appendChild(editorStyle);
+      cssTab.addEventListener("change", () => {
+        editorStyle.textContent = cssTab.textContent;
+      });
+    }
+  },
+);
+```
+
 ```css
 /* Cible n'importe quel élément placé dans un emplacement */
 ::slotted(*) {
@@ -23,7 +83,11 @@ Cela ne fonctionne que pour du CSS placé à l'intérieur d'un élément {{htmle
 
 ## Syntaxe
 
-{{csssyntax}}
+```css-nolint
+::slotted(<compound-selector>) {
+  /* ... */
+}
+```
 
 ## Exemples
 

--- a/files/fr/web/css/_doublecolon_spelling-error/index.md
+++ b/files/fr/web/css/_doublecolon_spelling-error/index.md
@@ -1,57 +1,60 @@
 ---
 title: ::spelling-error
 slug: Web/CSS/::spelling-error
+l10n:
+  sourceCommit: 37482c6bb0894d047a225c24f102352f89788523
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::spelling-error`** représente une portion de texte que l'{{glossary("user agent", "agent utilisateur")}} signale comme étant mal orthographiée.
 
-Le pseudo-élément **`::spelling-error`** représente une portion de texte que le navigateur signale comme étant mal orthographiée.
-
-```css
-::spelling-error {
-  color: red;
-}
-```
+Le pseudo-élément `::spelling-error` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de surlignage. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments de mise en évidence](/fr/docs/Web/CSS/Pseudo-elements#héritage_des_pseudo-éléments_de_mise_en_évidence).
 
 ## Propriétés autoriséees
 
-Seul un sous-ensemble restreint de propriétés CSS peut être utilisé dans une règle dont le sélecteur contient `::spelling-error` :
+Seul un sous-ensemble restreint de propriétés CSS peut être utilisé dans une règle dont le sélecteur contient `::spelling-error`&nbsp;:
 
-- {{cssxref("color")}},
-- {{cssxref("background-color")}},
-- {{cssxref("cursor")}},
+- {{cssxref("color")}}
+- {{cssxref("background-color")}}
+- {{cssxref("cursor")}}
 - {{cssxref("caret-color")}}
-- {{cssxref("outline")}} et les propriétés détaillées correspondantes,
+- {{cssxref("outline")}} et les propriétés détaillées correspondantes.
 - {{cssxref("text-decoration")}} et les propriétés détaillées correspondantes.
-- {{cssxref("text-emphasis-color")}},
+- {{cssxref("text-emphasis-color")}}
 - {{cssxref("text-shadow")}}
 
 ## Syntaxe
 
 ```css
 ::spelling-error {
+  /* ... */
 }
 ```
 
 ## Exemples
 
-### CSS
+### Vérification orthographique de base
+
+Dans cet exemple, les navigateurs éventuellement compatibles devraient mettre en évidence toute erreur d'orthographe signalée avec les styles affichés.
+
+#### HTML
+
+```html
+<p contenteditable spellcheck="true">
+  Alice devina tout de suite qu'il cherch l'éventail et la paire de gants.
+</p>
+```
+
+#### CSS
 
 ```css
-p::spelling-error {
-  color: red;
+::spelling-error {
+  text-decoration: wavy red underline;
 }
 ```
 
-### HTML
+#### Résultat
 
-```html
-<p>Alice devina tout de suite qu’il cherch l’éventail et la paire de gants.</p>
-```
-
-### Résultat
-
-{{EmbedLiveSample("Exemples","250","100")}}
+{{EmbedLiveSample("vérification_orthographique_de_base", '100%', 60)}}
 
 ## Spécifications
 
@@ -64,3 +67,4 @@ p::spelling-error {
 ## Voir aussi
 
 - {{cssxref("::grammar-error")}}
+- {{cssxref("text-decoration-line")}}

--- a/files/fr/web/css/_doublecolon_target-text/index.md
+++ b/files/fr/web/css/_doublecolon_target-text/index.md
@@ -7,7 +7,7 @@ l10n:
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::target-text`** représente le texte vers lequel l'écran vient de défiler, dans le cas où le navigateur prend en charge les [fragments de texte](/fr/docs/Web/URI/Reference/Fragment/Text_fragments). Il permet aux auteur·ice·s de mettre en évidence cette section de texte.
 
-Le pseudo-élément `::target-text` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en évidence. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments de mise en évidence](/en-US/docs/Web/CSS/Pseudo-elements#héritage_des_pseudo-éléments_de_mise_en_évidence).
+Le pseudo-élément `::target-text` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en évidence. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments de mise en évidence](/fr/docs/Web/CSS/Pseudo-elements#héritage_des_pseudo-éléments_de_mise_en_évidence).
 
 ## Syntaxe
 

--- a/files/fr/web/css/_doublecolon_target-text/index.md
+++ b/files/fr/web/css/_doublecolon_target-text/index.md
@@ -1,31 +1,30 @@
 ---
 title: ::target-text
 slug: Web/CSS/::target-text
+l10n:
+  sourceCommit: b460458fa125f4ee252d01466c1390d16ba19215
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::target-text`** représente le texte vers lequel l'écran vient de défiler, dans le cas où le navigateur prend en charge les [fragments de texte](/fr/docs/Web/URI/Reference/Fragment/Text_fragments). Il permet aux auteur·ice·s de mettre en évidence cette section de texte.
 
-Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::target-text`** représente le texte vers lequel l'écran vient de défiler, dans le cas où le navigateur prend en charge les fragments `scroll-to-text`. Il permet aux auteurs de mettre en valeur cette section de texte.
-
-```css
-::target-text {
-  background-color: pink;
-}
-```
+Le pseudo-élément `::target-text` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en évidence. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments de mise en évidence](/en-US/docs/Web/CSS/Pseudo-elements#héritage_des_pseudo-éléments_de_mise_en_évidence).
 
 ## Syntaxe
 
-{{csssyntax}}
+```css
+::target-text {
+  /* ... */
+}
+```
 
 ## Exemples
 
-### Mise en valeur de scroll-to-text
+### Mise en évidence de scroll-to-text
 
 ```css
 ::target-text {
   background-color: rebeccapurple;
   color: white;
-  font-weight: bold;
 }
 ```
 
@@ -41,4 +40,5 @@ Pour voir ce code CSS en action, suivez ce lien vers la [démonstration de scrol
 
 ## Voir aussi
 
-- [Text fragments (en anglais)](https://web.dev/text-fragments/)
+- [Text fragments <sup>(angl.)</sup>](https://web.dev/text-fragments/)
+- {{cssxref(":target")}} (pour mettre en évidence les éléments cibles)

--- a/files/fr/web/css/_doublecolon_view-transition-group/index.md
+++ b/files/fr/web/css/_doublecolon_view-transition-group/index.md
@@ -1,0 +1,80 @@
+---
+title: ::view-transition-group()
+slug: Web/CSS/::view-transition-group
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
+---
+
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::view-transition-group()`** représente un groupe instantané de transition de vue.
+
+Lors d'une transition de vue, `::view-transition-group()` est inclus dans l'arbre des pseudo-éléments associés comme expliqué dans [L'arbre des pseudo-éléments de transition de vue](/fr/docs/Web/API/View_Transition_API/Using#larbre_des_pseudo-éléments_de_transition_de_vue). Il est uniquement un enfant de {{cssxref("::view-transition")}}, et a un {{cssxref("::view-transition-image-pair()")}} comme enfant.
+
+`::view-transition-group()` reçoit le style par défaut suivant dans la feuille de style de l'agent utilisateur&nbsp;:
+
+```css
+:root::view-transition-group(*) {
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  animation-duration: 0.25s;
+  animation-fill-mode: both;
+}
+```
+
+Par défaut, les éléments sélectionnés reflètent initialement la taille et la position du pseudo-élément {{cssxref("::view-transition-old()")}} représentant l'état de vue «&nbsp;<i lang="en">old</i>&nbsp;» ou du pseudo-élément {{cssxref("::view-transition-new()")}} représentant l'état de vue «&nbsp;<i lang="en">new</i>&nbsp;» s'il n'y a pas d'état de vue «&nbsp;<i lang="en">old</i>&nbsp;».
+
+S'il y a, à la fois, un état de vue «&nbsp;<i lang="en">old</i>&nbsp;» et un état de vue «&nbsp;<i lang="en">new</i>&nbsp;», les styles dans la feuille de style de transition de vue animent la largeur ({{cssxref("width")}}) et la hauteur ({{cssxref("height")}}) de ce pseudo-élément de la taille de la boîte de bord de l'état de vue «&nbsp;<i lang="en">old</i>&nbsp;» à celle de l'état de vue «&nbsp;<i lang="en">new</i>&nbsp;».
+
+> [!NOTE]
+> Les styles de transition de vue sont générés dynamiquement pendant la transition de vue&nbsp;; voir les sections [configurer les pseudo-éléments de transition <sup>(angl.)</sup>](https://drafts.csswg.org/css-view-transitions-1/#setup-transition-pseudo-elements) et [mettre à jour les styles des pseudo-éléments <sup>(angl.)</sup>](https://drafts.csswg.org/css-view-transitions-1/#update-pseudo-element-styles) de la spécification pour plus de détails.
+
+De plus, la transformation de l'élément est animée de la transformation de l'espace écran de l'état de vue «&nbsp;<i lang="en">old</i>&nbsp;» à celle de l'état de vue «&nbsp;<i lang="en">new</i>&nbsp;». Ce style est généré dynamiquement puisque les valeurs des propriétés animées sont déterminées au moment où la transition commence.
+
+## Syntaxe
+
+```css-nolint
+::view-transition-group([ <pt-name-selector> <pt-class-selector>? ] | <pt-class-selector>) {
+  /* ... */
+}
+```
+
+### Paramètres
+
+- `*`
+  - : Le [sélecteur universel (`*`)](/fr/docs/Web/CSS/Universal_selectors)&nbsp;; sélectionne tous les groupes de transition de vue sur une page.
+- `root`
+  - : Le {{cssxref("view-transition-name")}} appliqué à {{cssxref(":root")}} fait correspondre le pseudo-élément au groupe de transition de vue par défaut `root`. C'est le groupe de capture d'écran créé par l'agent utilisateur pour contenir la transition de vue pour l'ensemble de la page. Ce groupe inclut tout élément non affecté à son propre groupe de capture d'écran de transition de vue spécifique via la propriété `view-transition-name`.
+- `<pt-name-selector>`
+  - : Le {{cssxref("custom-ident")}} défini comme valeur de la propriété {{cssxref("view-transition-name")}}.
+- `<pt-class-selector>`
+  - : Le {{cssxref("custom-ident")}} défini comme valeur de la propriété {{cssxref("view-transition-class")}}, précédé d'un point (`.`).
+
+La {{cssxref("specificity")}} du pseudo-élément de transition de vue nommé est égale à la [spécificité du sélecteur de type](/fr/docs/Web/CSS/CSS_cascade/Specificity#type_column), à moins que le sélecteur universel ne soit utilisé, auquel cas la spécificité est nulle.
+
+## Exemples
+
+```css
+::view-transition-group(embed-container) {
+  animation-duration: 0.3s;
+  animation-timing-function: ease;
+  z-index: 1;
+}
+
+::view-transition-group(.card) {
+  animation-duration: 1s;
+}
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'[API de transition de vue](/fr/docs/Web/API/View_Transition_API)
+- [Transitions fluides avec l'API de transition de vue <sup>(angl.)</sup>](https://developer.chrome.com/docs/web-platform/view-transitions/)

--- a/files/fr/web/css/_doublecolon_view-transition-image-pair/index.md
+++ b/files/fr/web/css/_doublecolon_view-transition-image-pair/index.md
@@ -1,0 +1,69 @@
+---
+title: ::view-transition-image-pair()
+slug: Web/CSS/::view-transition-image-pair
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
+---
+
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::view-transition-image-pair()`** représente un conteneur pour les états de vue «&nbsp;<i lang="en">old</i>&nbsp;» et «&nbsp;<i lang="en">new</i>&nbsp;» d'une [transition de vue](/fr/docs/Web/API/View_Transition_API) — avant et après la transition.
+
+Durant une transition de vue, `::view-transition-image-pair()` est inclus dans l'arbre des pseudo-éléments associés comme expliqué dans [L'arbre des pseudo-éléments de transition de vue](/fr/docs/Web/API/View_Transition_API/Using#larbre_des_pseudo-éléments_de_transition_de_vue). Il est seulement un enfant d'un {{cssxref("::view-transition-group()")}}. En termes d'enfants, il peut avoir un {{cssxref("::view-transition-new()")}} ou un {{cssxref("::view-transition-old()")}}, ou les deux.
+
+`::view-transition-image-pair()` est donné le style par défaut suivant dans la feuille de style l'agent utilisateur&nbsp;:
+
+```css
+:root::view-transition-image-pair(*) {
+  position: absolute;
+  inset: 0;
+
+  animation-duration: inherit;
+  animation-fill-mode: inherit;
+  animation-delay: inherit;
+}
+```
+
+Durant une transition de vue, `::view-transition-image-pair()` a {{cssxref("isolation", "isolation: isolate")}} défini sur lui dans la feuille de style de transition de vue afin que ses enfants puissent être mélangés avec des modes de fusion non normaux sans affecter d'autres sorties visuelles.
+
+## Syntax
+
+```css-nolint
+::view-transition-image-pair([ <pt-name-selector> <pt-class-selector>? ] | <pt-class-selector>) {
+  /* ... */
+}
+```
+
+### Parameters
+
+- `*`
+  - : Le [sélecteur universel (`*`)](/fr/docs/Web/CSS/Universal_selectors)&nbsp;; sélectionne tous les groupes de transition de vue sur une page.
+- `root`
+  - : Fait correspondre le pseudo-élément au groupe de capture d'instantané de transition de vue `root` par défaut créé par l'agent utilisateur pour contenir la transition de vue pour l'ensemble de la page. Ce groupe inclut tout élément non assigné à son propre groupe d'instantané de transition de vue spécifique via la propriété {{cssxref("view-transition-name")}}.
+- `<pt-name-selector>`
+  - : Le {{cssxref("custom-ident")}} défini comme valeur de la propriété {{cssxref("view-transition-name")}}.
+- `<pt-class-selector>`
+  - : Le {{cssxref("custom-ident")}} défini comme valeur de la propriété {{cssxref("view-transition-class")}} précédé d'un point (`.`).
+
+## Examples
+
+```css
+::view-transition-image-pair(root) {
+  isolation: auto;
+}
+
+::view-transition-image-pair(.card) {
+  isolation: isolate;
+}
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'[API de transition de vue](/fr/docs/Web/API/View_Transition_API)
+- [Transitions fluides avec l'API de transition de vue <sup>(angl.)</sup>](https://developer.chrome.com/docs/web-platform/view-transitions/)

--- a/files/fr/web/css/_doublecolon_view-transition-new/index.md
+++ b/files/fr/web/css/_doublecolon_view-transition-new/index.md
@@ -1,0 +1,121 @@
+---
+title: ::view-transition-new()
+slug: Web/CSS/::view-transition-new
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
+---
+
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::view-transition-new()`** représente l'état de vue «&nbsp;<i lang="en">new</i>&nbsp;» d'une transition de vue — une représentation instantanée en direct de l'état après la transition.
+
+Lors d'une transition de vue, `::view-transition-new()` est inclus dans l'arbre des pseudo-éléments associés comme expliqué dans [L'arbre des pseudo-éléments de transition de vue](/fr/docs/Web/API/View_Transition_API/Using#larbre_des_pseudo-éléments_de_transition_de_vue). Il est seulement un enfant d'un {{cssxref("::view-transition-image-pair()")}}, et n'a jamais d'enfants.
+
+C'est un élément remplacé et peut donc être manipulé avec des propriétés telles que {{cssxref("object-fit")}} et {{cssxref("object-position")}}. Il a des dimensions naturelles égales à la taille du contenu.
+
+Le style par défaut suivant est inclus dans la feuille de style de l'agent utilisateur&nbsp;:
+
+```css
+:root::view-transition-old(*),
+:root::view-transition-new(*) {
+  position: absolute;
+  inset-block-start: 0;
+  inline-size: 100%;
+  block-size: auto;
+
+  animation-duration: inherit;
+  animation-fill-mode: inherit;
+  animation-delay: inherit;
+}
+
+/* Keyframes pour le mélange lorsqu'il y a 2 images */
+@keyframes -ua-mix-blend-mode-plus-lighter {
+  from {
+    mix-blend-mode: plus-lighter;
+  }
+  to {
+    mix-blend-mode: plus-lighter;
+  }
+}
+
+@keyframes -ua-view-transition-fade-in {
+  from {
+    opacity: 0;
+  }
+}
+```
+
+> [!NOTE]
+> Des styles de transition de vue supplémentaires sont également configurés pour animer `::view-transition-new()`. Ceux-ci sont générés dynamiquement pendant la transition de vue&nbsp;; voir les sections [configurer les pseudo-éléments de transition <sup>(angl.)</sup>](https://drafts.csswg.org/css-view-transitions-1/#setup-transition-pseudo-elements) et [mettre à jour les styles des pseudo-éléments <sup>(angl.)</sup>](https://drafts.csswg.org/css-view-transitions-1/#update-pseudo-element-styles) de la spécification pour plus de détails.
+
+## Syntaxe
+
+```css-nolint
+::view-transition-new([ <pt-name-selector> <pt-class-selector>? ] | <pt-class-selector>) {
+  /* ... */
+}
+```
+
+### Paramètres
+
+- `*`
+  - : Le [sélecteur universel (`*`)](/fr/docs/Web/CSS/Universal_selectors)&nbsp;; sélectionne tous les groupes de transition de vue sur une page.
+- `root`
+  - : Fait correspondre le pseudo-élément au groupe de transition de vue par défaut `root` créé par l'agent utilisateur pour contenir la transition de vue pour l'ensemble de la page. Ce groupe inclut tout élément non affecté à son propre groupe de capture d'écran de transition de vue spécifique via la propriété `view-transition-name`.
+- `<pt-name-selector>`
+  - : Le {{cssxref("custom-ident")}} défini comme valeur de la propriété {{cssxref("view-transition-name")}}.
+- `<pt-class-selector>`
+  - : Le {{cssxref("custom-ident")}} défini comme valeur de la propriété {{cssxref("view-transition-class")}} précédé d'un point (`.`).
+
+## Exemples
+
+```css
+figcaption {
+  view-transition-name: figure-caption;
+}
+
+@keyframes grow-x {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes shrink-x {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
+::view-transition-old(figure-caption),
+::view-transition-new(figure-caption) {
+  height: auto;
+  right: 0;
+  left: auto;
+  transform-origin: right center;
+}
+
+::view-transition-old(figure-caption) {
+  animation: 0.25s linear both shrink-x;
+}
+
+::view-transition-new(figure-caption) {
+  animation: 0.25s 0.25s linear both grow-x;
+}
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'[API de transition de vue](/fr/docs/Web/API/View_Transition_API)
+- [Transitions fluides avec l'API de transition de vue <sup>(angl.)</sup>](https://developer.chrome.com/docs/web-platform/view-transitions/)

--- a/files/fr/web/css/_doublecolon_view-transition-old/index.md
+++ b/files/fr/web/css/_doublecolon_view-transition-old/index.md
@@ -1,0 +1,121 @@
+---
+title: ::view-transition-old()
+slug: Web/CSS/::view-transition-old
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
+---
+
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::view-transition-old()`** représente l'état de vue «&nbsp;<i lang="en">old</i>&nbsp;» d'une transition de vue — une représentation instantanée de l'état avant la transition.
+
+Lors d'une transition de vue, `::view-transition-old()` est inclus dans l'arbre des pseudo-éléments associés comme expliqué dans [L'arbre des pseudo-éléments de transition de vue](/fr/docs/Web/API/View_Transition_API/Using#larbre_des_pseudo-éléments_de_transition_de_vue), à condition qu'il y ait un état de vue «&nbsp;<i lang="en">old</i>&nbsp;» à représenter. Il est seulement un enfant d'un {{cssxref("::view-transition-image-pair()")}}, et n'a jamais d'enfants.
+
+C'est un élément remplacé et peut donc être manipulé avec des propriétés telles que {{cssxref("object-fit")}} et {{cssxref("object-position")}}. Il a des dimensions naturelles égales à la taille du contenu.
+
+Le style par défaut suivant est inclus dans la feuille de style de l'agent utilisateur&nbsp;:
+
+```css
+:root::view-transition-old(*),
+:root::view-transition-new(*) {
+  position: absolute;
+  inset-block-start: 0;
+  inline-size: 100%;
+  block-size: auto;
+
+  animation-duration: inherit;
+  animation-fill-mode: inherit;
+  animation-delay: inherit;
+}
+
+/* Keyframes pour le mélange lorsqu'il y a 2 images */
+@keyframes -ua-mix-blend-mode-plus-lighter {
+  from {
+    mix-blend-mode: plus-lighter;
+  }
+  to {
+    mix-blend-mode: plus-lighter;
+  }
+}
+
+@keyframes -ua-view-transition-fade-out {
+  to {
+    opacity: 0;
+  }
+}
+```
+
+> [!NOTE]
+> Des styles de transition de vue supplémentaires sont également configurés pour animer `::view-transition-old()`. Ceux-ci sont générés dynamiquement pendant la transition de vue&nbsp;; voir les sections [configurer les pseudo-éléments de transition <sup>(angl.)</sup>](https://drafts.csswg.org/css-view-transitions-1/#setup-transition-pseudo-elements) et [mettre à jour les styles des pseudo-éléments <sup>(angl.)</sup>](https://drafts.csswg.org/css-view-transitions-1/#update-pseudo-element-styles) de la spécification pour plus de détails.
+
+## Syntaxe
+
+```css-nolint
+::view-transition-old([ <pt-name-selector> <pt-class-selector>? ] | <pt-class-selector>) {
+  /* ... */
+}
+```
+
+### Paramètres
+
+- `*`
+  - : Le sélecteur universel (`*`) sélectionne tous les groupes de transition de vue sur une page.
+- `root`
+  - : Fait correspondre le pseudo-élément au groupe de transition de vue par défaut `root` créé par l'agent utilisateur pour contenir la transition de vue pour l'ensemble de la page. Ce groupe inclut tout élément non affecté à son propre groupe de capture d'écran de transition de vue spécifique via la propriété `view-transition-name`.
+- `<pt-name-selector>`
+  - : Le {{cssxref("custom-ident")}} défini comme valeur de la propriété {{cssxref("view-transition-name")}}.
+- `<pt-class-selector>`
+  - : Le {{cssxref("custom-ident")}} défini comme valeur de la propriété {{cssxref("view-transition-class")}} précédé d'un point (`.`).
+
+## Exemples
+
+```css
+figcaption {
+  view-transition-name: figure-caption;
+}
+
+@keyframes grow-x {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes shrink-x {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
+::view-transition-old(figure-caption),
+::view-transition-new(figure-caption) {
+  height: auto;
+  right: 0;
+  left: auto;
+  transform-origin: right center;
+}
+
+::view-transition-old(figure-caption) {
+  animation: 0.25s linear both shrink-x;
+}
+
+::view-transition-new(figure-caption) {
+  animation: 0.25s 0.25s linear both grow-x;
+}
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'[API de transition de vue](/fr/docs/Web/API/View_Transition_API)
+- [Transitions fluides avec l'API de transition de vue <sup>(angl.)</sup>](https://developer.chrome.com/docs/web-platform/view-transitions/)

--- a/files/fr/web/css/_doublecolon_view-transition/index.md
+++ b/files/fr/web/css/_doublecolon_view-transition/index.md
@@ -1,0 +1,50 @@
+---
+title: ::view-transition
+slug: Web/CSS/::view-transition
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
+---
+
+Le [pseudo-élément](/fr/docs/Web/CSS/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::view-transition`** représente la racine de la superposition des [transitions de vue](/fr/docs/Web/API/View_Transition_API), qui contient tous les groupes de vue instantanées de transition de vue et se trouve au-dessus de tout le reste du contenu de la page.
+
+Lors d'une transition de vue, `::view-transition` est inclus dans l'arbre des pseudo-éléments associés comme expliqué dans [L'arbre des pseudo-éléments de transition de vue](/fr/docs/Web/API/View_Transition_API/Using#larbre_des_pseudo-éléments_de_transition_de_vue). C'est le nœud de niveau supérieur de cet arbre, et il a un ou plusieurs {{cssxref("::view-transition-group()")}} comme enfants.
+
+`::view-transition` reçoit le style par défaut suivant dans la feuille de style de l'agent utilisateur&nbsp;:
+
+```css
+:root::view-transition {
+  position: fixed;
+  inset: 0;
+}
+```
+
+Tous les pseudo-éléments {{cssxref("::view-transition-group()")}} sont positionnés par rapport à la racine de la transition de vue.
+
+## Syntaxe
+
+```css
+::view-transition {
+  /* ... */
+}
+```
+
+## Exemples
+
+```css
+::view-transition {
+  background-color: rgb(0 0 0 / 25%);
+}
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'[API de transition de vue](/fr/docs/Web/API/View_Transition_API)
+- [Transitions fluides avec l'API de transition de vue <sup>(angl.)</sup>](https://developer.chrome.com/docs/web-platform/view-transitions/)

--- a/files/fr/web/css/pseudo-elements/index.md
+++ b/files/fr/web/css/pseudo-elements/index.md
@@ -45,7 +45,7 @@ Un pseudo-élément peut être sélectionné en fonction de l'état actuel de l'
     Cela peut être utilisé pour [mettre en forme les sous-titres et autres répliques](/fr/docs/Web/API/WebVTT_API#mettre_en_forme_les_sous-titres_webvtt) dans les médias avec des pistes VTT.
     Le module [CSS pseudo-éléments](/fr/docs/Web/CSS/CSS_pseudo-elements) définit également les sous-pseudo-éléments `::postfix` et `::prefix`. Ceux-ci ne sont pas encore pris en charge par aucun navigateur.
 
-## Les pseudo-éléments de surlignage
+## Les pseudo-éléments de mise en évidence
 
 Sélectionne des sections de document en fonction du contenu et de l'état du document, permettant à ces zones d'être mises en forme différemment pour indiquer cet état à l'utilisateur·ice.
 
@@ -58,7 +58,7 @@ Sélectionne des sections de document en fonction du contenu et de l'état du do
 - {{CSSxRef("::grammar-error")}}
   - : Une portion de texte que le navigateur pense être grammaticalement incorrecte.
 - {{CSSxRef("::highlight()")}}
-  - : Les éléments dans le [registre de surlignage](/fr/docs/Web/API/CSS/highlights_static). Il est utilisé pour créer des surlignages personnalisés.
+  - : Les éléments dans le [registre de mise en évidence](/fr/docs/Web/API/CSS/highlights_static). Il est utilisé pour créer des surlignages personnalisés.
 
 ## Les pseudo-éléments conformes à l'arborescence
 
@@ -187,16 +187,16 @@ Vous pouvez chaîner certains sélecteurs de pseudo-éléments pour mettre en fo
 
 Consultez les pages de référence des pseudo-éléments individuels pour des exemples et des informations sur la compatibilité des navigateurs.
 
-## Héritage des pseudo-éléments de surlignage
+## Héritage des pseudo-éléments de mise en évidence
 
-[Les pseudo-éléments de surlignage](#les_pseudo-éléments_de_surlignage), tels que {{CSSxref("::selection")}}, {{CSSxref("::target-text")}}, {{CSSxref("::highlight()")}}, {{CSSxref("::spelling-error")}}, et {{CSSxref("::grammar-error")}}, suivent un modèle d'héritage cohérent qui diffère de [l'héritage des éléments réguliers](/fr/docs/Web/CSS/CSS_cascade/Inheritance).
+[Les pseudo-éléments de mise en évidence](#les_pseudo-éléments_de_mise_en_évidence), tels que {{CSSxref("::selection")}}, {{CSSxref("::target-text")}}, {{CSSxref("::highlight()")}}, {{CSSxref("::spelling-error")}}, et {{CSSxref("::grammar-error")}}, suivent un modèle d'héritage cohérent qui diffère de [l'héritage des éléments réguliers](/fr/docs/Web/CSS/CSS_cascade/Inheritance).
 
-Lorsque vous appliquez des styles aux pseudo-éléments de surlignage, ils héritent à la fois de&nbsp;:
+Lorsque vous appliquez des styles aux pseudo-éléments de mise en évidence, ils héritent à la fois de&nbsp;:
 
 1. Leurs éléments parents (suivant l'héritage normal).
-2. Les pseudo-éléments de surlignage de leurs éléments parents (suivant l'héritage des surlignages).
+2. Les pseudo-éléments de mise en évidence de leurs éléments parents (suivant l'héritage des surlignages).
 
-Cela signifie que si vous mettez en forme à la fois le pseudo-élément de surlignage d'un élément parent et le pseudo-élément de surlignage d'un élément enfant, le texte surligné de l'enfant combinera les propriétés des deux sources.
+Cela signifie que si vous mettez en forme à la fois le pseudo-élément de mise en évidence d'un élément parent et le pseudo-élément de mise en évidence d'un élément enfant, le texte surligné de l'enfant combinera les propriétés des deux sources.
 
 Voici un exemple concret.
 
@@ -245,9 +245,9 @@ Essayez de sélectionner le texte dans les éléments parent et enfant. Remarque
    - Le fond orange de `.child::selection`.
    - La couleur de texte rouge héritée du pseudo-élément `::selection` du parent.
 
-Cela démontre comment le pseudo-élément de surlignage de l'enfant hérite à la fois de son élément parent et du pseudo-élément de surlignage du parent.
+Cela démontre comment le pseudo-élément mise en évidence de l'enfant hérite à la fois de son élément parent et du pseudo-élément mise en évidence du parent.
 
-[Les propriétés CSS personnalisées (variables)](/fr/docs/Web/CSS/CSS_cascading_variables/Using_CSS_custom_properties) dans les pseudo-éléments de surlignage héritent de leur élément d'origine (l'élément auquel elles sont appliquées), et non par le biais de la chaîne d'héritage des surlignages. Par exemple&nbsp;:
+[Les propriétés CSS personnalisées (variables)](/fr/docs/Web/CSS/CSS_cascading_variables/Using_CSS_custom_properties) dans les pseudo-éléments mise en évidence héritent de leur élément d'origine (l'élément auquel elles sont appliquées), et non par le biais de la chaîne d'héritage des surlignages. Par exemple&nbsp;:
 
 ```css
 :root {
@@ -263,7 +263,7 @@ Cela démontre comment le pseudo-élément de surlignage de l'enfant hérite à 
 }
 ```
 
-Lorsque vous utilisez le sélecteur universel avec des pseudo-éléments de surlignage, cela empêche l'héritage des surlignages. Par exemple&nbsp;:
+Lorsque vous utilisez le sélecteur universel avec des pseudo-éléments mise en évidence, cela empêche l'héritage des surlignages. Par exemple&nbsp;:
 
 ```css
 /* Cela empêche l'héritage des surlignages */
@@ -287,4 +287,4 @@ Lorsque vous utilisez le sélecteur universel avec des pseudo-éléments de surl
 - Les [pseudo-classes](/fr/docs/Web/CSS/Pseudo-classes)
 - Le module des [sélecteurs CSS](/fr/docs/Web/CSS/CSS_selectors)
 - [Apprendre&nbsp;: Pseudo-classes et pseudo-éléments](/fr/docs/Learn_web_development/Core/Styling_basics/Pseudo_classes_and_elements)
-- [Changements d'héritage pour le style de sélection CSS <sup>(angl.)</sup>](https://developer.chrome.com/blog/selection-styling) — Explication détaillée des changements du modèle d'héritage des pseudo-éléments de surlignage dans Chrome 134
+- [Changements d'héritage pour le style de sélection CSS <sup>(angl.)</sup>](https://developer.chrome.com/blog/selection-styling) — Explication détaillée des changements du modèle d'héritage des pseudo-éléments mise en évidence dans Chrome 134


### PR DESCRIPTION
### Description

Adding/Updating pages from CSS content concerning multiples issues:

- CSSRef: to be removed
- CSSSyntax: to be replaced
- Content: Fix sentences or adding examples
- Adding new CSS Interactive Demo Macro (when available)
- Fixing bottom elements (Compat, Specs, Links)

### Motivation

Keep content updated on MDN.

### Additional details

#### Cleaning pages
- [x] ::-moz
- [x] ::-webkit
- [x] ::pseudo-elements
#### Removing flaws
- [x] ::-moz
- [x] ::-webkit
- [x] ::pseudo-elements

### Related issues and pull requests

Related to https://github.com/mdn/translated-content/issues/18265