### PR TITLE
[ja] fix "return value" translation in Array.prototype.toSpliced()

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/array/tospliced/index.md
+++ b/files/ja/web/javascript/reference/global_objects/array/tospliced/index.md
@@ -41,7 +41,7 @@ toSpliced(start, skipCount, item1, item2, /* …, */ itemN)
 
 ### 返値
 
-`start`, `item1`, `item2`, …, `itemN` より前のすべての要素と、 `start + skipCount` より後のすべての要素からなる新しい配列です。
+`start` より前のすべての要素、 `item1`, `item2`, …, `itemN` と、 `start + skipCount` 以降のすべての要素からなる新しい配列です。
 
 ## 解説
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Array.prototype.toSpliced() の返値の翻訳ミスを修正します。

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

[原文](https://github.com/mdn/content/blob/c148812e0874220770cab62c16f33f48ceb98e99/files/en-us/web/javascript/reference/global_objects/array/tospliced/index.md?plain=1#L45)

> A new array that consists of all elements before `start`, `item1`, `item2`, …, `itemN`, and all elements after `start + skipCount`.

は

* A new array that consists of all elements before `start`, `item1`, `item2`, …, `itemN`
* all elements after `start + skipCount`

ではなく、

* A new array that consists of all elements before `start`,
* `item1`
* ...
* `itemN`
* all elements after `start + skipCount`

が正しそうです。

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

原文にはニュアンスが有りませんが、「before `start`」は `start` の要素を含まない一方、「after `start + skipCount`」は `start + skipCount` の要素を含むと認識しているので、翻訳を「より後」から「以降」に変更しています。

```
[0,1,2,3,4].toSpliced(2, 2, "x")
-> [ 0, 1, "x", 4 ]
//   ^~~^ 2 (start) より前の要素
//         ^^^ item1
//              ^ 4 (start + skipCount) 以降の要素
[0,1,2,3,4].toSpliced(2, 0, "x", "y")
-> [ 0, 1, "x", "y", 2, 3, 4 ]
//   ^~~^ 2 (start) より前の要素
//         ^^^ item1
//              ^^^ item2
//                   ^~~~~~^ 2 (start + skipCount) 以降の要素
```
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
