### PR TITLE
ja:「インド語」 -> 「インド」

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/number/tolocalestring/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/tolocalestring/index.md
@@ -104,7 +104,7 @@ console.log(number.toLocaleString("de-DE"));
 console.log(number.toLocaleString("ar-EG"));
 // ١٢٣٤٥٦٫٧٨٩
 
-// インド語では thousands/lakh/crore の区切りを用いる
+// インドでは thousands/lakh/crore の区切りを用いる
 console.log(number.toLocaleString("en-IN"));
 // 1,23,456.789
 

--- a/files/ja/web/javascript/reference/global_objects/number/tolocalestring/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/tolocalestring/index.md
@@ -104,7 +104,7 @@ console.log(number.toLocaleString("de-DE"));
 console.log(number.toLocaleString("ar-EG"));
 // ١٢٣٤٥٦٫٧٨٩
 
-// インドでは thousands/lakh/crore の区切りを用いる
+// インドでは千/ラーク（十万）/カロール（千万） の区切りを用いる
 console.log(number.toLocaleString("en-IN"));
 // 1,23,456.789
 


### PR DESCRIPTION
### Description

サンプルコードのコメントにおける「インド語」という表現を「インド」に修正

### Motivation

「インド語」という表現は現在あまり一般的ではありません。原文でも「India」と表記しています。詳細は参照しているissueをご覧ください。

### Additional details

### Related issues and pull requests

Fix https://github.com/mozilla-japan/translation/issues/844