### PR TITLE
zh-CN: fix wrong translate in `Window.crypto`

### DIFF
--- a/files/zh-cn/web/api/window/crypto/index.md
+++ b/files/zh-cn/web/api/window/crypto/index.md
@@ -9,7 +9,7 @@ l10n:
 
 {{domxref("Window")}} 接口的 **`crypto`** 只读属性返回当前窗口的作用域的 {{domxref("Crypto")}} 对象。此对象允许网页访问某些加密相关的服务。
 
-虽然该属性自身是只读的，但它的所有方法（以及其子对象 {{domxref("SubtleCrypto")}} 的方法）不仅是只读的，因此容易受到 {{glossary("polyfill")}} 的攻击。
+虽然该属性自身是只读的，但它的所有方法（以及其子对象 {{domxref("SubtleCrypto")}} 的方法）并不是只读的，因此容易受到 {{glossary("polyfill")}} 的攻击。
 
 虽然 `crypto` 在所有窗口上均可用，但其返回的 `Crypto` 对象在不安全的上下文中仅有一个可用的特性：{{domxref("Crypto.getRandomValues", "getRandomValues()")}} 方法。通常，你应该仅在安全上下文中使用此 API。
 


### PR DESCRIPTION
Original content:

虽然该属性自身是只读的，但它的所有方法（以及其子对象 {{domxref("SubtleCrypto")}} 的方法）不仅是只读的，因此容易受到 {{glossary("polyfill")}} 的攻击。

“不仅是只读的” means "Not only it is read-only", which distorted the original meaning. The correct translate should be "并非是只读的" or "并不是只读的".

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
<!-- ✍️ Summarize your changes in one or two sentences -->
**Fix a logical error in the Chinese translation of a sentence about read-only properties.** Corrects "不仅是只读的" (not only read-only) to "并不是只读的" (not read-only) to accurately reflect that the methods are writable and thus vulnerable to polyfill attacks.

### Motivation
<!-- ❓ Why are you making these changes and how do they help readers? -->
The original translation "不仅是只读的" distorted the original meaning and created a logical contradiction. The correct meaning is that while the property itself is read-only, its methods are **not** read-only (writable), which is the key reason they are vulnerable to polyfill attacks. This fix ensures the technical accuracy and logical coherence of the documentation for Chinese readers.

### Additional details
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
This is a straightforward linguistic/logic fix. No changes to technical content are made, only a correction of a mistranslation.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
