### PR TITLE
Element: setHTML() を新規翻訳

### DIFF
--- a/files/ja/_redirects.txt
+++ b/files/ja/_redirects.txt
@@ -3006,7 +3006,6 @@
 /ja/docs/Web/API/Element/pointerlockchange_event	/ja/docs/Web/API/Document/pointerlockchange_event
 /ja/docs/Web/API/Element/pointerlockerror_event	/ja/docs/Web/API/Document/pointerlockerror_event
 /ja/docs/Web/API/Element/select_event	/ja/docs/Web/API/HTMLInputElement/select_event
-/ja/docs/Web/API/Element/setHTML	/ja/docs/Web/API/Element
 /ja/docs/Web/API/Element/show_event	/ja/docs/orphaned/Web/API/Element/show_event
 /ja/docs/Web/API/Event/Comparison_of_Event_Targets	/ja/docs/Learn_web_development/Core/Scripting/Event_bubbling
 /ja/docs/Web/API/Event/button	/ja/docs/Web/API/MouseEvent/button

--- a/files/ja/web/api/element/index.md
+++ b/files/ja/web/api/element/index.md
@@ -2,7 +2,7 @@
 title: Element
 slug: Web/API/Element
 l10n:
-  sourceCommit: 17f6285a31667b55f6964cef45e4e6db7222e2dd
+  sourceCommit: cf16851e73da29823438198c4f0efcb7026b7d10
 ---
 
 {{APIRef("DOM")}}
@@ -55,10 +55,6 @@ _`Element` は、親インターフェイスである {{DOMxRef("Node")}}、お�
   - : 文字列で、この要素の修飾名のローカル部分を表します。
 - {{DOMxRef("Element.namespaceURI")}} {{ReadOnlyInline}}
   - : この要素の名前空間の URI。名前空間がない場合は `null` になります。
-
-    > [!NOTE]
-    > Firefox 3.5 および以前のバージョンでは、HTML 要素の名前空間はありません。以降のバージョンでは、HTML 要素は HTML ツリーおよび XML ツリーで [`http://www.w3.org/1999/xhtml`](https://www.w3.org/1999/xhtml) 名前空間内に存在します。
-
 - {{DOMxRef("Element.nextElementSibling")}} {{ReadOnlyInline}}
   - : `Element` で、ツリー上で自身の直後の要素を表します。兄弟ノードがなければ `null` になります。
 - {{DOMxRef("Element.outerHTML")}}
@@ -124,6 +120,8 @@ _`Element` インターフェイスには、以下のプロパティもありま
   - : 文字列で、[`aria-haspopup`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-haspopup) 属性を反映し、この要素によって引き起こされるメニューやダイアログのような対話型のポップアップ要素の有無と種類を示します。
 - {{domxref("Element.ariaHidden")}}
   - : 文字列で、[`aria-hidden`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden) 属性を反映し、この要素がアクセシビリティ API に公開されているかどうかを示します。
+- {{domxref("Element.ariaInvalid")}}
+  - : 文字列で、[`aria-invalid`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-invalid) 属性を反映し、入力された値がアプリケーションが期待する書式に適合していないことを示します。
 - {{domxref("Element.ariaKeyShortcuts")}}
   - : 文字列で、[`aria-keyshortcuts`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts) 属性を反映し、要素を活性化したりフォーカスを与えたりするために作者が実装したキーボードショートカットを示します。
 - {{domxref("Element.ariaLabel")}}
@@ -176,6 +174,38 @@ _`Element` インターフェイスには、以下のプロパティもありま
   - : 文字列で、[`aria-valueNow`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuenow) 属性を反映し、 range ウィジェットの現在の値を定義します。
 - {{domxref("Element.ariaValueText")}}
   - : 文字列で、[`aria-valuetext`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuetext) 属性を反映し、 range ウィジェットの aria-valuenow の代替となる人間が読めるテキストを定義します。
+- {{domxref("Element.role")}}
+  - : 明示的に設定された [`role`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles) 属性をを反映する文字列。要素の意味的役割を提供します。
+
+#### ARIA 要素参照から反映されるインスタンスプロパティ
+
+これらのプロパティは、対応する属性内の `id` の参照によって指定された要素を反映しますが、いくつかの注意点があります。詳細は属性の反映ガイドの[要素の参照の反映](/ja/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)を参照してください。
+
+- {{domxref("Element.ariaActiveDescendantElement")}}
+  - : フォーカスが [`composite`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/composite_role) ウィジェット、[`combobox`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role)、[`textbox`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/textbox_role)、[`group`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/group_role)、[`application`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/application_role) のいずれかにあるときの、現在のアクティブな要素を表します。
+    [`aria-activedescendant`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant) 属性を反映します。
+- {{domxref("Element.ariaControlsElements")}}
+  - : 適用される要素がそのコンテンツまたは存在をコントロールする要素の配列です。
+    [`aria-controls`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) 属性を反映します。
+- {{domxref("Element.ariaDescribedByElements")}}
+  - : 適用対象の要素に対するアクセシブル説明が含まれている要素の配列です。
+    [`aria-describedby`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) 属性を反映します。
+- {{domxref("Element.ariaDetailsElements")}}
+  - : 適用された要素に対してアクセシブルな詳細を提供する要素の配列です。
+    [`aria-details`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) 属性を反映します。
+- {{domxref("Element.ariaErrorMessageElements")}}
+  - : 適用された要素に対してエラーメッセージを提供する要素の配列です。
+    [`aria-errormessage`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) 属性を反映します。
+- {{domxref("Element.ariaFlowToElements")}}
+  - : コンテンツを読む順における次の要素（または要素群）を識別する要素の配列。ユーザーの裁量により、一般的な既定の読む順をオーバーライドする。
+    [`aria-flowto`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) 属性を反映します。
+- {{domxref("Element.ariaLabelledByElements")}}
+  - : 適用された要素のアクセシブル名を提供する要素の配列です。
+    [`aria-labelledby`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) 属性を反映します。
+- {{domxref("Element.ariaOwnsElements")}}
+  - : この要素が適用される要素が自分自身で所有する要素の配列です。
+    これは、 DOM 階層を用いて関係を表すことのできない場合に、親要素とその子要素の間の視覚的、機能的、文脈的な関係を定義するために使用されています。
+    [`aria-owns`](/ja/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) 属性を反映します。
 
 ## インスタンスメソッド
 
@@ -239,6 +269,8 @@ _`Element` は親である {{DOMxRef("Node")}}、およびその親である {{D
   - : メソッドを実行した要素に対して相対的な指定位置に、テキストノードを挿入します。
 - {{DOMxRef("Element.matches()")}}
   - : 要素が指定されたセレクター文字列で選択されるか否かを示す論理値を返します。
+- {{DOMxRef("Element.moveBefore()")}}
+  - : 指定された {{domxref("Node")}} を、呼び出し元ノード内で直接の子として、指定された参照ノードの前に移動します。ノードは除去される前に再挿入されることはありません。
 - {{DOMxRef("Element.prepend()")}}
   - : この要素の最初の子の前に、一連の {{domxref("Node")}} オブジェクトまたは文字列を挿入します。
 - {{DOMxRef("Element.querySelector()")}}
@@ -283,8 +315,10 @@ _`Element` は親である {{DOMxRef("Node")}}、およびその親である {{D
   - : 現在ノードに、指定された名前と名前空間を持つ属性値を設定します。
 - {{DOMxRef("Element.setCapture()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : マウスイベントキャプチャーを設定し、すべてのマウスイベントをこの要素にリダイレクトします。
+- {{DOMxRef("Element.setHTML()")}} {{SecureContext_Inline}} {{experimental_inline}}
+  - : HTML の文字列を解釈し、[サニタイズ](/ja/docs/Web/API/HTML_Sanitizer_API)して文書フラグメントに変換し、 DOM 内の要素の元のサブツリーを置き換えます。
 - {{DOMxRef("Element.setHTMLUnsafe()")}}
-  - : HTML の文字列を無害化せずに構文解析して文書フラグメントに入れ、DOM 内の要素の元サブツリーを置き換えます。HTML 文字列は宣言的なシャドウルートを入れることができますが、[`Element.innerHTML`](#element.innerhtml) を使用して HTML を設定した場合は、テンプレート要素として解釈されます。
+  - : HTML の文字列を無害化せずに構文解析して文書フラグメントに入れ、DOM 内の要素の元サブツリーを置き換えます。HTML 文字列は宣言的なシャドウルートを入れることができますが、[`Element.innerHTML`](/ja/docs/Web/API/Element/innerHTML) を使用して HTML を設定した場合は、テンプレート要素として解釈されます。
 - {{DOMxRef("Element.setPointerCapture()")}}
   - : 指定された要素を、以降の[ポインターイベント](/ja/docs/Web/API/Pointer_events)のキャプチャー対象として指定します。
 - {{DOMxRef("Element.toggleAttribute()")}}
@@ -294,13 +328,13 @@ _`Element` は親である {{DOMxRef("Node")}}、およびその親である {{D
 
 これらのイベントを待ち受けするには、 `addEventListener()` を使用するか、イベントリスナーをこのインターフェイスの `onイベント名` プロパティに代入するかしてください。
 
-- {{domxref("Element/afterscriptexecute_event","afterscriptexecute")}} {{Non-standard_Inline}}
+- {{domxref("Element/afterscriptexecute_event","afterscriptexecute")}} {{Non-standard_Inline}} {{deprecated_inline}}
   - : スクリプトが実行されたときに発行されます。
 - {{domxref("Element/beforeinput_event", "beforeinput")}}
   - : 入力要素の値が変更されようとすると発行されます。
 - {{domxref("Element/beforematch_event", "beforematch")}} {{Experimental_Inline}}
   - : [見つかるまでの間は非表示](/ja/docs/Web/HTML/Reference/Global_attributes/hidden)状態にある要素で、ユーザーが「ページ内検索」機能やフラグメントナビゲーションによってコンテンツを見つけたため、ブラウザーがそのコンテンツを公開しようとしているときに発行されます。
-- {{domxref("Element/beforescriptexecute_event","beforescriptexecute")}} {{Non-standard_Inline}}
+- {{domxref("Element/beforescriptexecute_event","beforescriptexecute")}} {{Non-standard_Inline}} {{deprecated_inline}}
   - : スクリプトが実行されそうになったときに発行されます。
 - {{domxref("Element/beforexrselect_event", "beforexrselect")}} {{Experimental_Inline}}
   - : WebXR の選択イベント ({{domxref("XRSession/select_event", "select")}}, {{domxref("XRSession/selectstart_event", "selectstart")}}, {{domxref("XRSession/selectend_event", "selectend")}}) の前に発行されます。
@@ -430,7 +464,7 @@ _`Element` は親である {{DOMxRef("Node")}}、およびその親である {{D
   - : ポインターが（何らかの理由で）要素のヒットテスト境界の外に移動されたときに発行されます。
 - {{domxref("Element/pointerover_event", "pointerover")}}
   - : ポインターが要素のヒットテスト境界内に移動されたときに発行されます。
-- {{domxref("Element/pointerrawupdate_event", "pointerrawupdate")}} {{Experimental_Inline}}
+- {{domxref("Element/pointerrawupdate_event", "pointerrawupdate")}}
   - : ポインターが {{domxref("Element/pointerdown_event", "pointerdown")}} または {{domxref("Element/pointerup_event", "pointerup")}} イベントを発行しないプロパティを変更したときに発行されます。
 - {{domxref("Element/pointerup_event", "pointerup")}}
   - : ポインターがアクティブでなくなったときに発行されます。

--- a/files/ja/web/api/element/sethtml/index.md
+++ b/files/ja/web/api/element/sethtml/index.md
@@ -1,0 +1,216 @@
+---
+title: "Element: setHTML() メソッド"
+short-title: setHTML()
+slug: Web/API/Element/setHTML
+l10n:
+  sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
+---
+
+{{APIRef("HTML Sanitizer API")}}{{SeeCompatTable}}
+
+**`setHTML()`** は {{domxref("Element")}} インターフェイスのメソッドで、HTML の文字列を構文解析・サニタイズして {{domxref("DocumentFragment")}} に変換、それを要素のサブツリーとして DOM に挿入する、XSS 対策済みの安全な方法を提供します。
+
+## 構文
+
+```js-nolint
+setHTML(input)
+setHTML(input, options)
+```
+
+### 引数
+
+- `input`
+  - : 文字列で、サニタイズされ要素に挿入される HTML を定義します。
+- `options` {{optional_inline}}
+  - : 以下のオプション引数を持つオプションオブジェクトです。
+    - `sanitizer`
+      - : {{domxref("Sanitizer")}} または {{domxref("SanitizerConfig")}} オブジェクトで、入力のどの要素が許可されたり削除されたりするかを定義します。文字列 `"default"` で既定の構成になります。
+        一般的に、設定を再利用する場合、`SanitizerConfig`よりも`Sanitizer`の方が効率的であることが期待されます。
+        指定しなかった場合、既定のサニタイザー設定が使用されます。
+
+### 返値
+
+なし (`undefined`)。
+
+### 例外
+
+- `TypeError`
+  - : `options.sanitizer` に次のようなものが渡された場合に例外が発生します。
+    - 正規化されていない {{domxref("SanitizerConfig")}}（"allowed" と "removed" の両方の設定を含むもの）
+    - 値が `"default"` ではない文字列
+    - {{domxref("Sanitizer")}}、{{domxref("SanitizerConfig")}}、文字列のどれでもない値。
+
+## 解説
+
+**`setHTML()`** メソッドは、HTML の文字列を構文解析・サニタイズして {{domxref("DocumentFragment")}} に変換、それを要素のサブツリーとして DOM に挿入する、XSS 対策済みの安全な方法を提供します。
+
+`setHTML()` は、現在の要素のコンテキストで不正な要素（例：{{htmlelement("table")}} 要素の外にある {{htmlelement("col")}} 要素）を HTML 入力文字列から除去します。
+その後、サニタイザー設定で許可されていない HTML エンティティを削除し、さらに XSS 対策上安全でない要素や属性を除去します。これらはサニタイザー設定でできるかどうかにかかわらず除去対象となります。
+
+`options.sanitizer` 引数でサニタイザーの構成が指定されていない場合、`setHTML()` は既定の {{domxref("Sanitizer")}} 構成で実行されます。
+この構成では、XSS に安全と見なされるすべての要素と属性が許可され、安全でないと見なされるエンティティは許可されません。
+独自のサニタイザーまたはサニタイザー設定を指定することで、許可または除去される要素、属性、コメントを選択できます。
+なお、サニタイザー設定で安全でないオプションが許可されている場合でも、このメソッドを使用すると（暗黙的に {{domxref('Sanitizer.removeUnsafe()')}} が呼び出されるため）、それらは除去されます。
+
+信頼できない HTML 文字列を要素に挿入する際は、{{domxref("Element.innerHTML")}} の代わりに `setHTML()` を使用しましょう。
+また、安全でない要素や属性が仕様上できる必要がある場合を除き、{{domxref("Element.setHTMLUnsafe()")}} の代わりに使用しましょう。
+
+なお、このメソッドは入力文字列を常に XSS 攻撃に脆弱なエンティティからサニタイズするため、[信頼型 API](/ja/docs/Web/API/Trusted_Types_API) によるセキュリティ保護や検証は行われません。
+
+## 例
+
+### 基本的な使い方
+
+この例は、`setHTML()` を使用して HTML 文字列をサニタイズし、挿入するいくつかの方法を示します。
+
+```js
+// HTML のサニタイズされていない文字列を定義
+const unsanitizedString = "abc <script>alert(1)<" + "/script> def";
+// ID が "target" の対象要素を取得
+const target = document.getElementById("target");
+
+// setHTML() を既定のサニタイザーで実行
+target.setHTML(unsanitizedString);
+
+// 独自のサニタイザーを定義し、 setHTML() で使用
+// これは要素のみを許可します。 div, p, button （script は安全ではないので削除される）
+const sanitizer1 = new Sanitizer({
+  elements: ["div", "p", "button", "script"],
+});
+target.setHTML(unsanitizedString, { sanitizer: sanitizer1 });
+
+// 独自の SanitizerConfig を setHTML() 内で定義
+// これにより、div、p、button、script、およびその他の安全でない要素/属性が除去される
+target.setHTML(unsanitizedString, {
+  sanitizer: { removeElements: ["div", "p", "button", "script"] },
+});
+```
+
+### `setHTML()` ライブサンプル
+
+この例では、異なるサニタイザーで呼び出される際のメソッドの「ライブ」デモを提供します。
+コードでは、既定のサニタイザーと独自のサニタイザーを使用して、それぞれ HTML 文字列をサニタイズおよび挿入するためのボタンを定義しています。
+元の文字列とサニタイズされた HTML はログに記録されるため、それぞれの結果を確認できます。
+
+#### HTML
+
+この HTML では、異なるサニタイザーを適用するための 2 つの {{htmlelement("button")}} 要素、例をリセットするための別のボタン、および文字列を挿入するための {{htmlelement("div")}} 要素を定義しています。
+
+```html
+<button id="buttonDefault" type="button">既定</button>
+<button id="buttonAllowScript" type="button">allowScript</button>
+
+<button id="reload" type="button">再読み込み</button>
+<div id="target">ターゲット要素の元のコンテンツ</div>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 220px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+  margin: 5px;
+}
+```
+
+#### JavaScript
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.textContent += text;
+}
+```
+
+```js hidden
+if ("Sanitizer" in window) {
+```
+
+まず、すべてのケースで共通となる、サニタイズ対象の文字列を定義します。
+これには {{htmlelement("script")}} 要素と `onclick` ハンドラーが含まれており、いずれも XSS に対して安全でないとされています。
+同時に、再読み込みボタンのハンドラーも定義します。
+
+```js
+// HTML の安全でない文字列を定義
+const unsanitizedString = `
+  <div>
+    <p>This is a paragraph. <button onclick="alert('You clicked the button!')">Click me</button></p>
+    <script src="path/to/a/module.js" type="module"><script>
+  </div>
+`;
+
+const reload = document.querySelector("#reload");
+reload.addEventListener("click", () => document.location.reload());
+```
+
+次に、既定のサニタイザーで HTML を設定するボタンのクリックハンドラーを定義します。
+これにより、HTML 文字列を挿入する前に、すべて的安全でないエンティティが除去されます。
+[`Sanitizer()` コンストラクターの例](/ja/docs/Web/API/Sanitizer/Sanitizer#creating_the_default_sanitizer)で、どの要素が除去されるかを正確に確認できます。
+
+```js
+const defaultSanitizerButton = document.querySelector("#buttonDefault");
+defaultSanitizerButton.addEventListener("click", () => {
+  // 要素のコンテンツを既定のサニタイザーを使用して設定
+  target.setHTML(unsanitizedString);
+
+  // サニタイズ前と挿入後の HTML をログ出力する
+  logElement.textContent =
+    "Default sanitizer: remove script element and onclick attribute\n\n";
+  log(`\nunsanitized: ${unsanitizedString}`);
+  log(`\nsanitized: ${target.innerHTML}`);
+});
+```
+
+次のクリックハンドラーは、独自のサニタイザーを使ってターゲット HTML を設定します。このサニタイザーは、{{htmlelement("div")}}、{{htmlelement("p")}}、{{htmlelement("script")}} 要素のみが許可されるように設定します。
+`setHTML` メソッドを使用しているため、 `<script>` も同時に除去されることに注意してください。
+
+```js
+const allowScriptButton = document.querySelector("#buttonAllowScript");
+allowScriptButton.addEventListener("click", () => {
+  // 独自のサニタイザーを使用して要素のコンテンツを設定
+  const sanitizer1 = new Sanitizer({
+    elements: ["div", "p", "script"],
+  });
+  target.setHTML(unsanitizedString, { sanitizer: sanitizer1 });
+
+  // サニタイズ前と挿入後の HTML をログ出力
+  logElement.textContent =
+    "Sanitizer: {elements: ['div', 'p', 'script']}\n Script removed even though allowed\n";
+  log(`\nunsanitized: ${unsanitizedString}`);
+  log(`\nsanitized: ${target.innerHTML}`);
+});
+```
+
+```js hidden
+} else {
+  log("HTML サニタイザー API はこのブラウザーは対応していません。");
+  // フォールバックまたは代替動作を指定
+}
+```
+
+#### 結果
+
+「既定」と「allowScript」ボタンをクリックすると、それぞれ既定のサニタイザーと独自のサニタイザーの効果を確認できます。
+いずれの場合も、サニタイザーで明示的に許可した場合でも、`<script>` 要素と `onclick` ハンドラーは除去されることに注意してください。
+
+{{EmbedLiveSample("setHTML() live example","100","350px")}}
+
+## 仕様書
+
+{{Specifications}}
+
+## ブラウザーの互換性
+
+{{Compat}}
+
+## 関連情報
+
+- {{domxref("Element.setHTMLUnsafe()")}}
+- {{domxref("ShadowRoot.setHTML()")}} および {{domxref("ShadowRoot.setHTMLUnsafe()")}}
+- {{domxref("Document.parseHTML_static", "Document.parseHTML()")}} および {{domxref("Document.parseHTMLUnsafe_static", "Document.parseHTMLUnsafe()")}}
+- [HTML サニタイザー API](/ja/docs/Web/API/HTML_Sanitizer_API)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Element.setHTML() を新規翻訳。
同時に、Element要素の記事も更新。
リダイレクトの解除が必要であるため、同時にコミットします。

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
