### PR TITLE
fr: create `MDN/Community/Discussions/*`

### DIFF
--- a/files/fr/mdn/community/discussions/index.md
+++ b/files/fr/mdn/community/discussions/index.md
@@ -1,0 +1,47 @@
+---
+title: Discussions GitHub
+slug: MDN/Community/Discussions
+l10n:
+  sourceCommit: b97dae0887fb02713db610eed4855545a9c81bcd
+---
+
+Sur MDN Web Docs, nous encourageons notre communauté à initier et à participer à des discussions autour des sujets liés au projet.
+Nous vous demandons de garder chaque discussion centrée sur le sujet en question au lieu de couvrir plusieurs sujets dans une seule discussion.
+
+> [!NOTE]
+> N'utilisez pas les Discussions GitHub pour signaler des bogues.
+> Si vous voyez un problème sur MDN Web Docs, ouvrez un ticket GitHub dans un [dépôt MDN GitHub](/fr/docs/MDN/Community/Our_repositories).
+
+Si vous n'êtes pas sûr d'ouvrir un ticket GitHub ou une discussion, voici à quoi chacun sert&nbsp;:
+
+- **Issues** (_Problèmes_) sont pour signaler des bogues ou suivre un élément de travail avec des tâches et des résultats définis et exploitables.
+- **Discussions** sont pour parvenir à un consensus sur notre mode de fonctionnement et pour définir des tâches.
+
+Si votre discussion n'avance pas ou si vous n'êtes pas sûr des prochaines étapes, consultez les [Directives pour la gestion et la résolution des discussions](/fr/docs/MDN/Community/Discussions/Managing_and_resolving_discussions) pour des conseils sur la manière de procéder, y compris les attentes en matière de délais.
+
+Consultez le sujet de chaque catégorie de discussion ci-dessous afin de pouvoir commencer votre discussion au bon endroit.
+
+| Catégorie de discussion                                               | Sujet                                                                                                                                                                                                              |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 📣 [Annonces <sup>(angl.)</sup>][announcements]                       | Réservé pour le personnel de MDN Web Docs. Nous vous demandons de choisir l'une des autres catégories disponibles.                                                                                                 |
+| 🔮 [Données de compatibilité des navigateurs <sup>(angl.)</sup>][bcd] | Le projet [browser-compat-data][bcd-repo] qui documente les données de compatibilité pour les navigateurs.                                                                                                         |
+| ✏️ [Contenu de MDN <sup>(angl.)</sup>][content]                       | Le [dépôt de contenu][content-repo] sur MDN Web Docs. Ne demandez pas d'aide pour le codage ici - si vous êtes bloqué sur un problème, essayez la section [Apprendre le développement Web][learn-web-dev].         |
+| 🌐 [Contenu traduit de MDN][localization]                             | Le [dépôt de contenu traduit][translated-content] couvrant nos [locales prises en charge][locales]. C'est également là que se trouvent les [avis de dépréciation][macro-deprecation].                              |
+| 👾 [MDN Plus <sup>(angl.)</sup>][mdn-plus]                            | Les [fonctionnalités de MDN Plus][mdn-plus-feature] ainsi que vos idées. Pour le support MDN Plus tel que les abonnements, reportez-vous au [canal de support officiel][mdn-plus-support] de Mozilla.              |
+| 🛠️ [Platform <sup>(angl.)</sup>][platform]                            | Le frontend et le système de construction de MDN Web Docs. Si vous trouvez un bogue, signalez-le sur [le dépôt concerné][mdn-repos]. **REMARQUE :** Il existe une catégorie de discussion distincte pour MDN Plus. |
+
+[announcements]: https://github.com/orgs/mdn/discussions/categories/announcements
+[bcd]: https://github.com/orgs/mdn/discussions/categories/browser-compatibility-data
+[bcd-repo]: https://github.com/mdn/browser-compat-data
+[content]: https://github.com/orgs/mdn/discussions/categories/content
+[content-repo]: https://github.com/mdn/content
+[learn-web-dev]: /fr/docs/Learn_web_development
+[localization]: https://github.com/orgs/mdn/discussions/categories/localization
+[translated-content]: https://github.com/mdn/translated-content/
+[locales]: https://github.com/mdn/translated-content/#locales
+[macro-deprecation]: https://github.com/orgs/mdn/discussions/67
+[mdn-plus]: https://github.com/orgs/mdn/discussions/categories/mdn-plus
+[mdn-plus-feature]: /en-US/plus
+[mdn-plus-support]: https://support.mozilla.org/fr/products/mdn-plus
+[platform]: https://github.com/orgs/mdn/discussions/categories/platform
+[mdn-repos]: /fr/docs/MDN/Community/Our_repositories

--- a/files/fr/mdn/community/discussions/managing_and_resolving_discussions/index.md
+++ b/files/fr/mdn/community/discussions/managing_and_resolving_discussions/index.md
@@ -2,7 +2,7 @@
 title: Gestion et résolution des discussions
 slug: MDN/Community/Discussions/Managing_and_resolving_discussions
 l10n:
-   sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
+  sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
 ---
 
 La communauté MDN est encouragée à [initier et à participer à des discussions](/fr/docs/MDN/Community/Discussions) autour de la documentation du MDN Web Docs. Certaines discussions n'ont pas besoin de résolution ou d'accord, mais si c'est le cas, il est naturel que ceux qui lancent la discussion s'attendent à ce que leurs idées proposées atteignent une conclusion logique. La plupart de ces discussions parviennent rapidement à un large consensus. Cependant, certaines discussions risquent de devenir bloquées en raison d'un chemin peu clair vers une résolution, souvent en raison d'opinions divergentes. Ce document propose des directives&nbsp;; suggérant des processus et des stratégies pour vous aider à progresser vers une résolution dans un délai raisonnable sans que la conversation ne soit bloquée.

--- a/files/fr/mdn/community/discussions/managing_and_resolving_discussions/index.md
+++ b/files/fr/mdn/community/discussions/managing_and_resolving_discussions/index.md
@@ -1,0 +1,57 @@
+---
+title: Gestion et résolution des discussions
+slug: MDN/Community/Discussions/Managing_and_resolving_discussions
+l10n:
+   sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
+---
+
+La communauté MDN est encouragée à [initier et à participer à des discussions](/fr/docs/MDN/Community/Discussions) autour de la documentation du MDN Web Docs. Certaines discussions n'ont pas besoin de résolution ou d'accord, mais si c'est le cas, il est naturel que ceux qui lancent la discussion s'attendent à ce que leurs idées proposées atteignent une conclusion logique. La plupart de ces discussions parviennent rapidement à un large consensus. Cependant, certaines discussions risquent de devenir bloquées en raison d'un chemin peu clair vers une résolution, souvent en raison d'opinions divergentes. Ce document propose des directives&nbsp;; suggérant des processus et des stratégies pour vous aider à progresser vers une résolution dans un délai raisonnable sans que la conversation ne soit bloquée.
+
+## Faire avancer une discussion vers une résolution
+
+La plupart des discussions n'ont pas besoin d'un processus de résolution formel. Ces directives de discussion MDN sont là pour les discussions qui ont besoin d'une résolution rapide, qui sont bloquées, qui risquent de devenir bloquées ou qui ne progressent pas vers une conclusion et qui bénéficieraient d'un processus formel&nbsp;:
+
+1. Chaque discussion est ancrée dans une [discussion sur GitHub <sup>(angl.)</sup>](https://github.com/orgs/mdn/discussions). Cette discussion GitHub sert de «&nbsp;source de vérité&nbsp;» pour le sujet.
+   - Pour maintenir la continuité, n'oubliez pas de capturer les résumés et les notes de toutes les réunions et discussions asynchrones dans ce fil de discussion GitHub.
+
+2. Chaque sujet de discussion a besoin d'un responsable. Le responsable est souvent l'auteur de la discussion, mais peut être une autre personne engagée à résoudre la discussion. Le responsable est responsable de&nbsp;:
+   - Guider la conversation.
+   - Faire en sorte que les gens soient au courant de l'existence de la discussion.
+   - Définir les retours, le calendrier, en informer les gens, modifier le calendrier si nécessaire et s'y tenir de manière appropriée.
+   - Informer tous les canaux appropriés - Slack, Discord, taguer des personnes sur GitHub et d'autres canaux si nécessaire - des retours nécessaires avant des dates spécifiques.
+   - Aborder le sujet lors des réunions communautaires et hebdomadaires.
+   - Organiser une réunion en face à face en ligne synchrone si nécessaire (s'il y a désaccord). Les réunions en face à face doivent être rares et uniquement si nécessaire (voir #3).
+   - Résumer les conclusions des réunions en face à face dans la discussion pertinente sur [Discussions <sup>(angl.)</sup>](https://github.com/orgs/mdn/discussions).
+   - Guider la mise en œuvre des résultats de la discussion ou travailler avec le responsable d'équipe approprié pour s'assurer que les résultats sont mis en œuvre.
+
+3. Les réunions en face à face concernant une discussion ne doivent être convoquées que s'il y a désaccord.
+   - Les réunions en face à face doivent être annoncées dans tous les [canaux de communication](/fr/docs/MDN/Community/Communication_channels) pertinents, tels que Slack, Discord, discussion GitHub, etc.
+   - Les conclusions de chaque réunion en face à face doivent être saisies dans la discussion GitHub, qui est la source de vérité pour la discussion.
+   - Le responsable est responsable de la convocation de la réunion, d'informer toutes les parties et de faire rapport des résultats dans la discussion GitHub.
+
+Une fois qu'un accord a été atteint, la résolution peut être annoncée, la discussion peut être clôturée et le plan de mise en œuvre de la résolution peut être mis en action&nbsp;!
+
+## Progression et calendrier des discussions
+
+Chaque discussion aura un calendrier différent en fonction de la complexité du sujet et des niveaux de consensus. Idéalement, la plupart des discussions devraient être résolues dans un délai de deux mois, permettant ainsi d'aborder le sujet lors de diverses réunions internes. Ce délai garantit que des points de vue divers sont pris en compte et que toutes les personnes intéressées ont la possibilité de contribuer à la discussion.
+
+1. Publiez la discussion.
+2. Assignez un responsable. Déterminez le responsable s'il n'est pas le même que l'auteur de la discussion.
+3. Identifiez les parties prenantes clés et les parties prenantes nécessaires (les personnes qui doivent peser sur le sujet et donner leur approbation), le cas échéant.
+4. Informez les parties prenantes et d'autres voix essentielles de la discussion et de votre calendrier proposé. Si nécessaire, contactez-les à nouveau après 2 semaines, puis chaque semaine par la suite, jusqu'à ce qu'ils fournissent des commentaires.
+5. Ajoutez le sujet de la discussion aux ordres du jour des réunions pertinentes.
+6. Après un mois, triez les commentaires, les discussions et les accords, et formulez un plan initial fusionnant les commentaires dans un plan d'action possible.
+7. Ré-informez et redemandez des commentaires à toutes les parties intéressées, y compris tous ceux qui ont participé à la discussion de quelque manière que ce soit.
+8. Au cours du deuxième mois, continuez à solliciter la communauté pour obtenir des commentaires sur le plan proposé, en apportant des mises à jour au plan à la lumière de tout nouveau retour. Rincez. Répétez.
+9. S'il y a des points de désaccord, organisez une réunion en ligne, synchrone et en face à face pour résoudre tout désaccord restant (tel que capturé dans le fil de discussion).
+10. Gardez les fils de discussion actifs pendant le deuxième mois alors que vous travaillez avec la communauté vers la résolution.
+11. [Créez le problème (_Issue_)](/fr/docs/MDN/Community/Issues) pour le plan de mise en œuvre de la résolution et mettez-le en action. ([Directives de signalement des problèmes](/fr/docs/MDN/Community/Issues#guidelines_for_reporting_an_issue))
+12. Fermez la discussion.
+
+Si la discussion implique de contacter et de recevoir des commentaires d'experts, le calendrier ci-dessus peut être prolongé si nécessaire.
+
+### Résolutions non concluantes
+
+Il est important d'arriver à une résolution, mais il est également important de se rappeler que toutes les discussions ne parviendront pas à une résolution pouvant être mise en œuvre. La résolution d'une discussion peut être «&nbsp;aucune décision n'est prise&nbsp;» ou «&nbsp;revisitons cela dans un an&nbsp;». Ce sont toutes deux des résolutions valides&nbsp;!
+
+Lorsqu'une discussion se termine sans résolution pouvant être mise en œuvre, notez-le dans la discussion, puis fermez la discussion en tant que résolue.


### PR DESCRIPTION
### Description

Create translation of pages without french version:
-`MDN/Community/Discussions`
-`MDN/Community/Discussions/Managing_and_resolving_discussions`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_
