### PR TITLE
[zh-cn]: create the translation of CSS `:-moz-handler-disabled` property

### DIFF
--- a/files/zh-cn/web/css/_colon_-moz-handler-blocked/index.md
+++ b/files/zh-cn/web/css/_colon_-moz-handler-blocked/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{Non-standard_header}}
 
-[CSS](/zh-CN/docs/Web/CSS) [伪类](/zh-CN/docs/Web/CSS/Pseudo-classes) **`:-moz-handler-blocked`** 是一个 [Mozilla 扩展](/zh-CN/docs/Web/CSS/Mozilla_Extensions)，用于匹配那些由于其处理程序被阻止而无法显示的元素。
+[CSS](/zh-CN/docs/Web/CSS) [伪类](/zh-CN/docs/Web/CSS/Pseudo-classes) **`:-moz-handler-blocked`** 是一个用于匹配那些由于其处理器被阻止而无法显示的元素的 [Mozilla 扩展](/zh-CN/docs/Web/CSS/Mozilla_Extensions)。
 
 > [!NOTE]
 > 这个选择器主要是供主题开发者使用的。

--- a/files/zh-cn/web/css/_colon_-moz-handler-blocked/index.md
+++ b/files/zh-cn/web/css/_colon_-moz-handler-blocked/index.md
@@ -1,0 +1,30 @@
+---
+title: :-moz-handler-blocked
+slug: Web/CSS/:-moz-handler-blocked
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
+---
+
+{{Non-standard_header}}
+
+[CSS](/zh-CN/docs/Web/CSS) [伪类](/zh-CN/docs/Web/CSS/Pseudo-classes) **`:-moz-handler-blocked`** 是一个 [Mozilla 扩展](/zh-CN/docs/Web/CSS/Mozilla_Extensions)，用于匹配那些由于其处理程序被阻止而无法显示的元素。
+
+> [!NOTE]
+> 这个选择器主要是供主题开发者使用的。
+
+## 语法
+
+```css
+:-moz-handler-blocked {
+  /* ... */
+}
+```
+
+## 规范
+
+不属于任何标准。
+
+## 参见
+
+- {{ cssxref(":-moz-handler-crashed") }}
+- {{ cssxref(":-moz-handler-disabled") }}

--- a/files/zh-cn/web/css/_colon_-moz-handler-crashed/index.md
+++ b/files/zh-cn/web/css/_colon_-moz-handler-crashed/index.md
@@ -1,0 +1,30 @@
+---
+title: :-moz-handler-crashed
+slug: Web/CSS/:-moz-handler-crashed
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
+---
+
+{{Non-standard_header}}
+
+[CSS](/zh-CN/docs/Web/CSS) [伪类](/zh-CN/docs/Web/CSS/Pseudo-classes) **`:-moz-handler-crashed`** 是一个 [Mozilla 扩展](/zh-CN/docs/Web/CSS/Mozilla_Extensions)，用于匹配那些因负责绘制它们的插件崩溃而无法显示的元素。
+
+> [!NOTE]
+> 这个选择器主要是供主题开发者使用的。
+
+## 语法
+
+```css
+:-moz-handler-crashed {
+  /* ... */
+}
+```
+
+## 规范
+
+不属于任何标准。
+
+## 参见
+
+- {{ cssxref(":-moz-handler-blocked") }}
+- {{ cssxref(":-moz-handler-disabled") }}

--- a/files/zh-cn/web/css/_colon_-moz-handler-crashed/index.md
+++ b/files/zh-cn/web/css/_colon_-moz-handler-crashed/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{Non-standard_header}}
 
-[CSS](/zh-CN/docs/Web/CSS) [伪类](/zh-CN/docs/Web/CSS/Pseudo-classes) **`:-moz-handler-crashed`** 是一个 [Mozilla 扩展](/zh-CN/docs/Web/CSS/Mozilla_Extensions)，用于匹配那些因负责绘制它们的插件崩溃而无法显示的元素。
+[CSS](/zh-CN/docs/Web/CSS) [伪类](/zh-CN/docs/Web/CSS/Pseudo-classes) **`:-moz-handler-crashed`** 是一个用于匹配那些因负责绘制它们的插件崩溃而无法显示的元素的 [Mozilla 扩展](/zh-CN/docs/Web/CSS/Mozilla_Extensions)。
 
 > [!NOTE]
 > 这个选择器主要是供主题开发者使用的。

--- a/files/zh-cn/web/css/_colon_-moz-handler-disabled/index.md
+++ b/files/zh-cn/web/css/_colon_-moz-handler-disabled/index.md
@@ -1,0 +1,30 @@
+---
+title: :-moz-handler-disabled
+slug: Web/CSS/:-moz-handler-disabled
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
+---
+
+{{Non-standard_header}}
+
+[CSS](/zh-CN/docs/Web/CSS) [伪类](/zh-CN/docs/Web/CSS/Pseudo-classes) **`:-moz-handler-disabled`** 是一个 [Mozilla 扩展](/zh-CN/docs/Web/CSS/Mozilla_Extensions)，用于匹配那些由于其处理程序被用户禁用而无法显示的元素。
+
+> [!NOTE]
+> 这个选择器主要是供主题开发者使用的。
+
+## 语法
+
+```css
+:-moz-handler-disabled {
+  /* ... */
+}
+```
+
+## 规范
+
+不属于任何标准。
+
+## 参见
+
+- {{ cssxref(":-moz-handler-blocked") }}
+- {{ cssxref(":-moz-handler-crashed") }}

--- a/files/zh-cn/web/css/_colon_-moz-handler-disabled/index.md
+++ b/files/zh-cn/web/css/_colon_-moz-handler-disabled/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{Non-standard_header}}
 
-[CSS](/zh-CN/docs/Web/CSS) [伪类](/zh-CN/docs/Web/CSS/Pseudo-classes) **`:-moz-handler-disabled`** 是一个 [Mozilla 扩展](/zh-CN/docs/Web/CSS/Mozilla_Extensions)，用于匹配那些由于其处理程序被用户禁用而无法显示的元素。
+[CSS](/zh-CN/docs/Web/CSS) [伪类](/zh-CN/docs/Web/CSS/Pseudo-classes) **`:-moz-handler-disabled`** 是一个用于匹配那些由于其处理程序被用户禁用而无法显示的元素的 [Mozilla 扩展](/zh-CN/docs/Web/CSS/Mozilla_Extensions)。
 
 > [!NOTE]
 > 这个选择器主要是供主题开发者使用的。


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-handler-crashed
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/css/_colon_-moz-handler-crashed/index.md
* Last commit: https://github.com/mdn/content/commit/0cc9980e3b21c83d1800a428bc402ae1865326b2
