### PR TITLE
fr: update `MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros`

### DIFF
--- a/files/fr/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/fr/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -258,7 +258,6 @@ Les macros suivantes sont incluses sur toutes les pages de référence, mais son
 - `\{{Specifications}}`
   - : Ajoute un [tableau de spécifications](/fr/docs/MDN/Writing_guidelines/Page_structures/Specification_tables) pour la ou les fonctionnalités définies par `spec-urls` dans le front-matter, si présent, ou à partir de la spécification listée dans les données de compatibilité définies par `browser-compat` dans le front-matter.
 
-
 ## Voir aussi
 
 - [Macros de barre latérale](/fr/docs/MDN/Writing_guidelines/Page_structures/Sidebars)

--- a/files/fr/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/fr/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -1,252 +1,268 @@
 ---
-title: Macros usuelles
+title: Macros couramment utilisées
 slug: MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros
+l10n:
+  sourceCommit: 7819249f906dcfc59a2c4cb702b80a35b7964842
 ---
 
-{{MDNSidebar}}
-
-Cette page énumère les différentes macros utilisées sur MDN. Pour plus d'informations sur leur utilisation, voir [Utiliser les macros](/fr/docs/MDN/Writing_guidelines/Page_structures).
-
-Voir la page [Autres macros](/fr/docs/MDN/Writing_guidelines/Page_structures/Macros/Other) pour plus d'informations quant aux macros moins usitées ou uniquement utilisées dans certains contextes ou qui sont dépréciées.
+Cette page liste de nombreuses macros générales créées pour être utilisées sur MDN.
+Pour des informations pratiques sur leur utilisation dans le contenu MDN, voir [Utiliser les macros](/fr/docs/MDN/Writing_guidelines/Page_structures/Macros).
 
 ## Liens
 
-MDN fournit plusieurs macros pour former des liens entre les pages de référence, le glossaire, etc.
+MDN propose plusieurs macros de lien pour faciliter la création de liens vers des pages de référence, des entrées de glossaire et d'autres sujets.
 
-> [!WARNING]
-> Toutes les macros de lien devraient être remplacées dans le contenu en français par des liens écrit en Markdown. En effet, on souhaite réduire l'utilisation des macros «&nbsp;simples&nbsp;» qui peuvent être facilement remplacées par du HTML/Markdown.
+Les macros de lien sont recommandées à la place des liens Markdown classiques car elles sont concises et adaptées à la traduction.
+Par exemple, un lien de glossaire ou de référence créé avec une macro n'a pas besoin d'être traduit&nbsp;: dans d'autres langues, il pointera automatiquement vers la bonne version du fichier.
 
 ### Liens vers le glossaire
 
-La macro [`Glossary`](https://github.com/mdn/yari/blob/main/kumascript/macros/Glossary.ejs) crée un lien vers la page d'un terme du [glossaire](/fr/docs/Glossary). Elle prend un argument obligatoire et un autre optionnel&nbsp;:
+La macro [`Glossary`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/glossary.rs) crée un lien vers l'entrée d'un terme dans le [glossaire](/fr/docs/Glossary) MDN.
+Cette macro accepte un paramètre obligatoire et un paramètre optionnel&nbsp;:
 
-1. Le nom du terme (par exemple `"HTML"`)&nbsp;: `\{{Glossary("HTML")}}`
-2. Un paramètre optionnel indiquant le texte à afficher à la place du terme&nbsp;: `\{{Glossary("CSS", "Cascading Style Sheets")}}`
+1. Le nom du terme (par exemple «&nbsp;HTML&nbsp;»)&nbsp;: `\{{Glossary("HTML")}}` donne {{Glossary("HTML")}}
+2. Optionnel&nbsp;: le texte à afficher dans l'article à la place du nom du terme&nbsp;: `\{{Glossary("CSS", "Feuilles de style en cascade")}}` donne {{Glossary("CSS", "Feuilles de style en cascade")}}
 
-> [!WARNING]
-> Pour remplacer cette macro, on écrira plutôt&nbsp;: `[le texte à afficher](/fr/docs/Glossary/MonTerme)`.
+### Lien vers des pages de référence
 
-### Liens vers des pages de référence
+Il existe des macros pour créer des liens indépendants de la langue vers des pages de référence spécifiques de MDN&nbsp;: JavaScript, CSS, éléments HTML, SVG, etc.
 
-D'autres macros permettent de créer des liens vers des pages des différentes références de MDN&nbsp;: JavaScript, CSS, éléments HTML, SVG, etc.
-
-Elles utilisent généralement un premier paramètre indiquant le nom de l'élément vers lequel lier. La plupart utilisent un deuxième argument qui permet de modifier le texte affiché.
+Les macros sont simples à utiliser.
+Il suffit de spécifier le nom de l'élément à lier en premier argument.
+La plupart des macros acceptent aussi un second argument pour personnaliser le texte affiché (voir la documentation dans la colonne de gauche du tableau ci-dessous).
 
 <table class="standard-table">
   <thead>
     <tr>
       <th>Macro</th>
-      <th>Pointe vers une page située sous</th>
-      <th>À remplacer par</th>
+      <th>Liens vers la page sous-jacente</th>
+      <th>Exemple</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>
-        <a href="https://github.com/mdn/yari/tree/main/kumascript/macros/cssxref.ejs">CSSxRef</a>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/cssxref.rs">CSSxRef</a>
       </td>
       <td>
-        <a href="/fr/docs/Web/CSS/Reference">La référence CSS</a> (/Web/CSS/Reference)
+        <a href="/fr/docs/Web/CSS/Reference">Référence CSS</a> (/Web/CSS/Reference)
       </td>
       <td>
-        <code>\{{CSSxRef("cursor")}}</code> devra être remplacé par <code>[`cursor`](/fr/docs/Web/CSS/cursor)</code>.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <a href="https://github.com/mdn/yari/tree/main/kumascript/macros/DOMxRef.ejs">DOMxRef</a>
-      </td>
-      <td><a href="/fr/docs/Web/API">La référence du DOM</a> (/Web/API)</td>
-      <td>
-        <code>\{{DOMxRef("Document")}}</code> devra être remplacé par <code>[`Document`](/fr/docs/Web/API/Document)</code>.
-        S'il y a un deuxième paramètre&nbsp;: <code>\{{DOMxRef("document.getElementsByName()","getElementsByName()")}}</code> devra être remplacé par <code>[`getElementsByName()`](/fr/docs/Web/API/Document/getElementsByName)</code>.
+        <code>\{{CSSxRef("cursor")}}</code> donnera {{CSSxRef("cursor")}}.
       </td>
     </tr>
     <tr>
       <td>
-        <a href="https://github.com/mdn/yari/tree/main/kumascript/macros/HTMLElement.ejs">HTMLElement</a>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/domxref.rs">DOMxRef</a>
       </td>
+      <td><a href="/fr/docs/Web/API">Référence DOM</a> (/Web/API)</td>
       <td>
-        <a href="/fr/docs/Web/HTML/Element">Référence des éléments HTML</a> (/Web/HTML/Element)
-      </td>
-      <td>
-        <code>\{{HTMLElement("select")}}</code> devra être remplacé par <code>[`&lt;select&gt;`](/fr/docs/Web/HTML/Element/select)</code>.
+        <code>\{{DOMxRef("Document")}}</code> ou <code>\{{DOMxRef("document")}}</code> donne {{DOMxRef("Document")}},<br />
+        <code>\{{DOMxRef("document.getElementsByName()")}}</code> donne {{DOMxRef("document.getElementsByName()")}},<br />
+        <code>\{{DOMxRef("Node")}}</code> donne {{DOMxRef("Node")}}.<br />
+        Vous pouvez changer le texte affiché en utilisant un second paramètre&nbsp;: <code>\{{DOMxRef("document.getElementsByName()","getElementsByName()")}}</code> donne {{DOMxRef("document.getElementsByName()","getElementsByName()")}}.
       </td>
     </tr>
     <tr>
       <td>
-        <a href="https://github.com/mdn/yari/tree/main/kumascript/macros/jsxref.ejs">JSxRef</a>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/htmlxref.rs">HTMLElement</a>
+      </td>
+      <td>
+        <a href="/fr/docs/Web/HTML/Reference/Elements">Référence des éléments HTML</a> (/Web/HTML/Reference/Elements)
+      </td>
+      <td>
+        <code>\{{HTMLElement("select")}}</code> donne {{HTMLElement("select")}}
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/jsxref.rs">JSxRef</a>
       </td>
       <td>
         <a href="/fr/docs/Web/JavaScript/Reference">Référence JavaScript</a> (/Web/JavaScript/Reference).
       </td>
       <td>
-        <code>\{{JSxRef("Promise")}}</code> devra être remplacé par <code>[`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise)</code>
+        <code>\{{JSxRef("Promise")}}</code> donne {{JSxRef("Promise")}}
       </td>
     </tr>
     <tr>
       <td>
-        <a href="https://github.com/mdn/yari/tree/main/kumascript/macros/SVGAttr.ejs">SVGAttr</a>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/svgattr.rs">SVGAttr</a>
       </td>
       <td>
-        <a href="/fr/docs/Web/SVG/Attribute">Référence des attributs SVG</a> (/Web/SVG/Attribute).
+        <a href="/fr/docs/Web/SVG/Reference/Attribute">Référence des attributs SVG</a> (/Web/SVG/Reference/Attribute).
       </td>
       <td>
-        <code>\{{SVGAttr("d")}}</code> devra être remplacé par <code>[`d`](/fr/docs/Web/SVG/Attribute/d)</code>
+        <code>\{{SVGAttr("d")}}</code> donne {{SVGAttr("d")}}
       </td>
     </tr>
     <tr>
       <td>
         <a
-          href="https://github.com/mdn/yari/tree/main/kumascript/macros/SVGElement.ejs">SVGElement</a>
+          href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/svgxref.rs">SVGElement</a>
       </td>
       <td>
-        <a href="/fr/docs/Web/SVG/Attribute">Référence des éléments SVG</a> (/Web/SVG/Element).
+        <a href="/fr/docs/Web/SVG/Reference/Element">Référence des éléments SVG</a> (/Web/SVG/Reference/Element).
       </td>
       <td>
-        <code>\{{SVGElement("view")}}</code> devra être remplacé par <code>[`&lt;view&gt;`](/fr/docs/Web/SVG/Element/view)</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code><a href="https://github.com/mdn/yari/blob/main/kumascript/macros/httpheader.ejs">HTTPHeader</a></code>
-      </td>
-      <td>
-        <a href="/fr/docs/Web/HTTP/Headers">Référence des en-têtes HTTP</a> (/Web/HTTP/Headers).
-      </td>
-      <td>
-        <code>\{{HTTPHeader("ACCEPT")}}</code> devra être remplacé par <code>[`ACCEPT`](/fr/docs/Web/HTTP/Headers/ACCEPT)</code>
+        <code>\{{SVGElement("view")}}</code> donne {{SVGElement("view")}}
       </td>
     </tr>
     <tr>
       <td>
-        <a href="https://github.com/mdn/yari/tree/main/kumascript/macros/HTTPMethod.ejs">HTTPMethod</a>
+        <code><a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/http.rs">HTTPHeader</a></code>
       </td>
       <td>
-        <a href="/fr/docs/Web/HTTP/Methods">Référence des méthodes de requête HTTP</a> (/Web/HTTP/Methods).
+        <a href="/fr/docs/Web/HTTP/Reference/Headers">En-têtes HTTP</a> (/Web/HTTP/Reference/Headers).
       </td>
       <td>
-        <code>\{{HTTPMethod("HEAD")}}</code> devra être remplacé par <code>[`HEAD`](/fr/docs/Web/HTTP/Methods/HEAD)</code>
+        <code>\{{HTTPHeader("ACCEPT")}}</code> donne {{HTTPHeader("ACCEPT")}}
       </td>
     </tr>
     <tr>
       <td>
-        <a href="https://github.com/mdn/yari/tree/main/kumascript/macros/HTTPStatus.ejs">HTTPStatus</a>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/http.rs">HTTPMethod</a>
       </td>
       <td>
-        <a href="/fr/docs/Web/HTTP/Status">Référence des codes de statut HTTP</a> (/Web/HTTP/Status)
+        <a href="/fr/docs/Web/HTTP/Reference/Methods">Méthodes de requête HTTP</a> (/Web/HTTP/Reference/Methods).
       </td>
       <td>
-        <code>\{{HTTPStatus("404")}}</code> devra être remplacé par <code>[`404`](/fr/docs/Web/HTTP/Status/404)</code>
+        <code>\{{HTTPMethod("HEAD")}}</code> donne {{HTTPMethod("HEAD")}}
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/http.rs">HTTPStatus</a>
+      </td>
+      <td>
+        <a href="/fr/docs/Web/HTTP/Reference/Status">Codes d'état de réponse HTTP</a> (/Web/HTTP/Reference/Status)
+      </td>
+      <td>
+        <code>\{{HTTPStatus("404")}}</code> donne {{HTTPStatus("404")}}
       </td>
     </tr>
   </tbody>
 </table>
 
-### Navigation entre les pages de chapitre d'un guide
+### Aides à la navigation pour les guides multi-pages
 
-[`Previous`](https://github.com/mdn/yari/blob/main/kumascript/macros/Previous.ejs), [`Next`](https://github.com/mdn/yari/blob/main/kumascript/macros/Next.ejs), et [`PreviousNext`](https://github.com/mdn/yari/blob/main/kumascript/macros/PreviousNext.ejs) permettent d'afficher des contrôles de navigation pour des articles qui forment une série.
-
-Pour les deux premières macros, le seul paramètre nécessaire est l'emplacement de l'article cible.
-
-Pour la macro [`PreviousNext`](https://github.com/mdn/yari/blob/main/kumascript/macros/PreviousNext.ejs), le premier paramètre correspond à la cible de l'article précédent dans la série et le deuxième paramètre correspond à la cible du prochain article.
+[`Previous`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/previous_menu_next.rs), [`Next`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/previous_menu_next.rs) et [`PreviousNext`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/previous_menu_next.rs) fournissent des contrôles de navigation pour les articles faisant partie d'une séquence.
+Pour les modèles à sens unique, il suffit d'indiquer l'emplacement wiki de l'article précédent ou suivant.
+Pour [`PreviousNext`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/previous_menu_next.rs), il faut deux paramètres&nbsp;: l'emplacement wiki de l'article précédent puis celui de l'article suivant.
 
 ## Exemples de code
 
-- [`EmbedLiveSample`](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedLiveSample.ejs) permet d'embarquer le résultat d'un exemple de code de la page (voir [les exemples intégrés](/fr/docs/MDN/Writing_guidelines/Page_structures)).
-- [`LiveSampleLink`](https://github.com/mdn/yari/blob/main/kumascript/macros/LiveSampleLink.ejs) crée un lien vers une page contenant le résultat d'un exemple de code de la page (voir [les exemples intégrés](/fr/docs/MDN/Writing_guidelines/Page_structures)).
-- [`EmbedGHLiveSample`](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedGHLiveSample.ejs) permet d'embarquer des exemples interactifs depuis des pages GitHub (voir [exemples interactifs depuis GitHub](/fr/docs/MDN/Writing_guidelines/Page_structures/Code_examples#github_live_samples)).
+### Exemples interactifs
 
-## Barres latérales de navigation
+- [`EmbedLiveSample`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/embeds/embed_live_sample.rs) permet d'intégrer le résultat d'un exemple de code sur une page, comme expliqué dans [Exemples interactifs](/fr/docs/MDN/Writing_guidelines/Page_structures/Live_samples).
+- [`LiveSampleLink`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/embeds/live_sample_link.rs) crée un lien vers une page contenant le résultat d'un exemple de code, comme expliqué dans [Exemples interactifs](/fr/docs/MDN/Writing_guidelines/Page_structures/Live_samples).
+- [`EmbedGHLiveSample`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/embeds/embed_gh_live_sample.rs) permet d'intégrer des exemples interactifs depuis des pages GitHub.
+  Plus d'informations dans [Exemples interactifs GitHub](/fr/docs/MDN/Writing_guidelines/Page_structures/Code_examples#github_live_samples).
 
-Pour chaque grand ensemble de pages, on a des macros qui aident à la navigation sous la forme d'une barre à gauche. Elles permettent généralement de remonter à la page racine de la référence/du guide/du tutoriel et placent l'article dans la catégorie correspondante au sein de cette barre.
+## Mise en forme générale
 
-- [`CSSRef`](https://github.com/mdn/yari/blob/main/kumascript/macros/CSSRef.ejs) génère la barre latérale pour les pages de la référence CSS.
-- [`HTMLSidebar`](https://github.com/mdn/yari/blob/main/kumascript/macros/HTMLSidebar.ejs) génère la barre latérale pour les pages de la référence HTML.
-- [`APIRef`](https://github.com/mdn/yari/blob/main/kumascript/macros/APIRef.ejs) génère la barre latérale pour les pages des références des API web.
+### Indicateurs en ligne pour la documentation API
 
-## Mise en forme
+[`Optional_Inline`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/badges.rs) et [`ReadOnlyInline`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/badges.rs) sont utilisés dans la documentation API, généralement pour décrire la liste des propriétés d'un objet ou les paramètres d'une fonction.
 
-### Indicateurs en ligne pour les documentations d'API
-
-[`optional_inline`](https://github.com/mdn/yari/blob/main/kumascript/macros/optional_inline.ejs) et [`ReadOnlyInline`](https://github.com/mdn/yari/blob/main/kumascript/macros/ReadOnlyInline.ejs) sont utilisées dans les documentations d'API pour décrire la liste des propriétés d'un objet ou les paramètres d'une fonction.
-
-#### Syntaxe
-
-`\{{Optional_Inline}}`
-
-ou
-
-`\{{ReadOnlyInline}}`.
-
-#### Exemples
+Utilisation&nbsp;: `\{{Optional_Inline}}` ou `\{{ReadOnlyInline}}`.
+Exemple&nbsp;:
 
 - `isCustomObject` {{ReadOnlyInline}}
-  - : Un booléen qui indique, s'il vaut `true`, que l'objet est spécifique.
-- `parameterX` {{Optional_Inline}}
+  - : Indique, si `true`, que l'objet est personnalisé.
+- `parameterX` {{optional_inline}}
   - : Bla bla bla…
 
 ## Indicateurs de statut et de compatibilité
 
-### Indicateurs en ligne sans paramètre
+### Indicateurs en ligne sans paramètre supplémentaire
 
-#### Non-standard
+#### Non standard
 
-[`non-standard_inline`](https://github.com/mdn/yari/blob/main/kumascript/macros/Non-standard_Inline.ejs) insère une marque sur la ligne, indiquant que l'API n'a pas été standardisée et n'est pas en voie de standardisation.
+[\`Non-standard_Inline\`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/badges.rs) insère une marque en ligne indiquant que l'API n'est pas standardisée et n'est pas en cours de normalisation.
 
 ##### Syntaxe
 
 `\{{Non-standard_Inline}}`
 
-##### Exemples
+##### Exemple
 
 - Icône&nbsp;: {{Non-standard_Inline}}
 
 #### Expérimental
 
-[`experimental_inline`](https://github.com/mdn/yari/blob/main/kumascript/macros/experimental_inline.ejs) insère une marque sur la ligne, indiquant que l'API n'est pas largement implémentée et peut évoluer.
+[\`Experimental_Inline\`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/badges.rs) insère une marque en ligne indiquant que l'API n'est pas largement implémentée et peut évoluer à l'avenir.
+Pour plus d'informations sur la définition **expérimental**, voir la documentation [Expérimental, déprécié et obsolète](/fr/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete).
 
 ##### Syntaxe
 
 `\{{Experimental_Inline}}`
 
-##### Exemples
+##### Exemple
 
 - Icône&nbsp;: {{Experimental_Inline}}
 
-#### Dépréciation
+### Indicateurs en ligne avec technologie précisée
 
-[`deprecated_inline`](https://github.com/mdn/yari/blob/main/kumascript/macros/Deprecated_Inline.ejs) insère une marque sur la ligne, indiquant que l'API ne devrait pas être utilisée, car elle a officiellement été dépréciée ou supprimée.
+#### Déprécié
+
+[\`Deprecated_Inline\`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/badges.rs) insère une marque en ligne de dépréciation ({{Deprecated_Inline}}) pour déconseiller l'utilisation d'une API officiellement dépréciée (ou supprimée).
+Pour plus d'informations sur la définition **déprécié**, voir la documentation [Expérimental, déprécié et obsolète](/fr/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete).
 
 ##### Syntaxe
 
 `\{{Deprecated_Inline}}`
 
-##### Exemples
+##### Exemple
 
 - Icône&nbsp;: {{Deprecated_Inline}}
 
-### Indicateurs pour les pages ou les sections
+### Indicateurs d'en-tête de page ou de section
 
-Les macros qui suivent possèdent la même sémantique que les équivalents en ligne abordés avant. Ces macros doivent être placées directement après le préambule de la page. On peut aussi les utiliser pour marquer une section donnée d'une page.
+Ces modèles ont la même signification que leurs équivalents en ligne ci-dessus.
+Ils doivent être placés juste sous le titre principal de la page (ou le fil d'Ariane si présent) dans une page de référence.
+Ils peuvent aussi servir à marquer une section d'une page.
 
-- [`non-standard_header`](https://github.com/mdn/yari/blob/main/kumascript/macros/Non-standard_Header.ejs). Exemple&nbsp;: `\{{Non-standard_Header}}` {{Non-standard_Header}}
-- [`SeeCompatTable`](https://github.com/mdn/yari/blob/main/kumascript/macros/SeeCompatTable.ejs) devrait être utilisée sur les pages documentant [des fonctionnalités expérimentales](/fr/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental). Exemple&nbsp;: `\{{SeeCompatTable}}` {{SeeCompatTable}}
-- [`deprecated_header`](https://github.com/mdn/yari/blob/main/kumascript/macros/Deprecated_Header.ejs). Exemple&nbsp;: `\{{Deprecated_Header}}` {{Deprecated_Header}}
-- [`secureContext_header`](https://github.com/mdn/yari/blob/main/kumascript/macros/secureContext_header.ejs) devrait être utilisée sur les pages principales des interfaces ou d'aperçu des API, mais pas sur les sous-pages décrivant les méthodes ou les propriétés. Exemple&nbsp;: `\{{SecureContext_Header}}` {{SecureContext_Header}}
+- [`Non-standard_Header`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs)&nbsp;: `\{{Non-standard_Header}}` {{Non-standard_Header}}
+- [`SeeCompatTable`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs) utilisé sur les pages documentant des [fonctionnalités expérimentales](/fr/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#expérimental).
+  Exemple&nbsp;: `\{{SeeCompatTable}}` {{SeeCompatTable}}
+- [`Deprecated_Header`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs)&nbsp;: `\{{Deprecated_Header}}` {{Deprecated_Header}}
+- [`SecureContext_Header`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs).
+  À utiliser sur les pages principales comme les pages d'interface, d'API ou d'entrée d'API (ex.&nbsp;: `navigator.xyz`), mais généralement pas sur les sous-pages de méthodes ou propriétés.
+  Exemple&nbsp;: `\{{SecureContext_Header}}` {{SecureContext_Header}}
 
-### Indiquer qu'une fonctionnalité est disponible pour les <i lang="en">web workers</i>
+#### Indiquer qu'une fonctionnalité est disponible dans les web workers
 
-La macro [`AvailableInWorkers`](https://github.com/mdn/yari/blob/main/kumascript/macros/AvailableInWorkers.ejs) insère une note localisée qui indique qu'une fonctionnalité est disponible dans le contexte d'un [<i lang="en">web worker</i>](/fr/docs/Web/API/Web_Workers_API). L'argument `notservice` peut être utilisé afin d'indiquer qu'une fonctionnalité est disponible pour les <i lang="en">web workers</i> mais pas pour les <i lang="en">service workers</i>.
+La macro [`AvailableInWorkers`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs) insère un encadré localisé indiquant qu'une fonctionnalité est disponible dans un [contexte worker](/fr/docs/Web/API/Web_Workers_API).
+Vous pouvez aussi passer des arguments pour indiquer qu'une fonctionnalité fonctionne dans un contexte worker spécifique.
 
 ##### Syntaxe
 
 ```plain
 \{{AvailableInWorkers}}
-\{{AvailableInWorkers("notservice")}}
+\{{AvailableInWorkers("window_and_worker_except_service")}}
 ```
 
 ##### Exemples
 
 {{AvailableInWorkers}}
-{{AvailableInWorkers("notservice")}}
+
+{{AvailableInWorkers("window_and_worker_except_service")}}
+
+## Macros de compatibilité navigateur et de spécification
+
+Les macros suivantes sont incluses sur toutes les pages de référence, mais sont aussi utilisables sur tous les types de pages&nbsp;:
+
+- `\{{Compat}}`
+  - : Génère un [tableau de compatibilité](/fr/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables) pour la ou les fonctionnalités définies par `browser-compat` dans le front-matter.
+- `\{{Specifications}}`
+  - : Ajoute un [tableau de spécifications](/fr/docs/MDN/Writing_guidelines/Page_structures/Specification_tables) pour la ou les fonctionnalités définies par `spec-urls` dans le front-matter, si présent, ou à partir de la spécification listée dans les données de compatibilité définies par `browser-compat` dans le front-matter.
+
+
+## Voir aussi
+
+- [Macros de barre latérale](/fr/docs/MDN/Writing_guidelines/Page_structures/Sidebars)
+- [Modèles de page](/fr/docs/MDN/Writing_guidelines/Page_structures/Page_types#page_templates)
+- [Composants de page](/fr/docs/MDN/Writing_guidelines/Writing_style_guide#page_components)
+- [Macros de statut de fonctionnalité](/fr/docs/MDN/Writing_guidelines/Page_structures/Feature_status)
+- [Autres macros](/fr/docs/MDN/Writing_guidelines/Page_structures/Macros/Other)&nbsp;: macros rarement utilisées ou dépréciées


### PR DESCRIPTION
### Description

Update translation of pages without french version: `MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros`

### Motivation

Update access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_