### PR TITLE
[ko] ImageData 문서 번역 업데이트 및 최신화

### DIFF
--- a/files/ko/web/api/imagedata/index.md
+++ b/files/ko/web/api/imagedata/index.md
@@ -11,17 +11,21 @@ slug: Web/API/ImageData
 
 ## Constructors
 
-- {{domxref("ImageData.ImageData", "ImageData()")}} {{experimental_inline}}
-  - : 인자로 주어진 {{jsxref("Uint8ClampedArray")}}로 부터 해당 크기에 맞는 ImageData객체를 생성합니다. 만약 인자가 주어지지 않으면 검정색 사각형 이미지를 생성합니다. {{domxref("CanvasRenderingContext2D.createImageData", "createImageData()")}}는 worker에서 사용할 수 없기 때문에, ImageData의 생성자를 이용하는 것이 가장 일반적인 방법입니다.
+- {{domxref("ImageData.ImageData", "ImageData()")}}
+  - : 주어진 {{jsxref("Uint8ClampedArray")}} 또는 {{jsxref("Float16Array")}} 와 해당 배열이 포함하는 이미지의 크기로 `ImageData` 객체를 생성합니다. 배열이 주어지지 않으면, 투명한 검은색 사각형 이미지를 생성합니다. {{domxref("CanvasRenderingContext2D.createImageData", "createImageData()")}} 는 워커에서 사용할 수 없으므로 워커에서 이러한 객체를 생성하는 가장 일반적인 방법임을 유의해야합니다.
 
 ## Properties
 
-- {{domxref("ImageData.data")}} {{readonlyInline}}
-  - : {{jsxref("Uint8ClampedArray")}}형식이며 1차원 배열로 RGBA순서로 정의된 이미지 데이터를 나타내니다. 각 원소는 정수값으로 0에서 255사이의 값을 갖습니다.
-- {{domxref("ImageData.height")}} {{readonlyInline}}
-  - : unsigned long형식으로 ImageData의 pixel기준의 실제 높이값입니다.
-- {{domxref("ImageData.width")}} {{readonlyInline}}
-  - : unsigned long형식으로 ImageData의 pixel기준의 실제 가로값입니다.
+- {{domxref("ImageData.data")}} {{ReadOnlyInline}}
+  - : RGBA 순서로 데이터를 포함하는 1차원 배열을 나타내는 {{jsxref("Uint8ClampedArray")}} 또는 {{jsxref("Float16Array")}} 입니다. 순서는 왼쪽 상단 픽셀부터 오른쪽 하단까지 행 단위로 진행됩니다.
+- {{domxref("ImageData.colorSpace")}} {{ReadOnlyInline}}
+  - : 이미지 데이터의 색 공간을 나타내는 문자열.
+- {{domxref("ImageData.height")}} {{ReadOnlyInline}}
+  - : `ImageData` 의 픽셀 단위 실제 높이를 나타내는 `unsigned long`.
+- {{domxref("ImageData.width")}} {{ReadOnlyInline}}
+  - : `ImageData` 의 픽셀 단위 실제 너비를 나타내는 `unsigned long`.
+- {{domxref("ImageData.pixelFormat")}} {{ReadOnlyInline}} {{experimental_inline}}
+  - : `ImageData` 에 사용할 형식을 나타내는 문자열.
 
 ## 명세서
 
@@ -31,7 +35,7 @@ slug: Web/API/ImageData
 
 {{Compat}}
 
-## See also
+## 같이 보기
 
 - {{domxref("CanvasRenderingContext2D")}}
-- The {{HTMLElement("canvas")}} element and its associated interface, {{domxref("HTMLCanvasElement")}}.
+- {{HTMLElement("canvas")}} 관련 요소와 관련 인터페이스, {{domxref("HTMLCanvasElement")}}.

--- a/files/ko/web/api/imagedata/index.md
+++ b/files/ko/web/api/imagedata/index.md
@@ -1,6 +1,8 @@
 ---
 title: ImageData
 slug: Web/API/ImageData
+l10n:
+  sourceCommit: eba7ce08cf50c5d9e344652748f6bcfb19f3a396
 ---
 
 {{APIRef("Canvas API")}}

--- a/files/ko/web/api/imagedata/index.md
+++ b/files/ko/web/api/imagedata/index.md
@@ -16,7 +16,7 @@ l10n:
 - {{domxref("ImageData.ImageData", "ImageData()")}}
   - : 주어진 {{jsxref("Uint8ClampedArray")}} 또는 {{jsxref("Float16Array")}} 와 해당 배열이 포함하는 이미지의 크기로 `ImageData` 객체를 생성합니다. 배열이 주어지지 않으면, 투명한 검은색 사각형 이미지를 생성합니다. {{domxref("CanvasRenderingContext2D.createImageData", "createImageData()")}} 는 워커에서 사용할 수 없으므로 워커에서 이러한 객체를 생성하는 가장 일반적인 방법임을 유의해야합니다.
 
-## Properties
+## Instance properties
 
 - {{domxref("ImageData.data")}} {{ReadOnlyInline}}
   - : RGBA 순서로 데이터를 포함하는 1차원 배열을 나타내는 {{jsxref("Uint8ClampedArray")}} 또는 {{jsxref("Float16Array")}} 입니다. 순서는 왼쪽 상단 픽셀부터 오른쪽 하단까지 행 단위로 진행됩니다.

--- a/files/ko/web/api/imagedata/index.md
+++ b/files/ko/web/api/imagedata/index.md
@@ -5,7 +5,9 @@ slug: Web/API/ImageData
 
 {{APIRef("Canvas API")}}
 
-**`ImageData`** 인터페이스는 {{HTMLElement("canvas")}} 엘리먼트 영역의 기저의 픽셀데이터를 나타냅니다{{domxref("ImageData.ImageData", "ImageData()")}}생성자나 canvas객체에 연결된 {{domxref("CanvasRenderingContext2D")}}객체의 {{domxref("CanvasRenderingContext2D.createImageData", "createImageData()")}}나 {{domxref("CanvasRenderingContext2D.getImageData", "getImageData()")}}메소드로 생성할 수 있습니다. **ImageData**는 {{domxref("CanvasRenderingContext2D.putImageData", "putImageData()")}}의 인자로 전달할 수 있으며, 이를 통해 canvas의 일부로 반영할 수 있습니다.
+**`ImageData`** 인터페이스는 {{HTMLElement("canvas")}} 요소 영역의 기본 픽셀 데이터를 나타냅니다.
+
+캔버스와 연결된 {{domxref("CanvasRenderingContext2D")}} 객체의 {{domxref("ImageData.ImageData", "ImageData()")}} 생성자 또는 생성자 메서드인 {{domxref("CanvasRenderingContext2D.createImageData", "createImageData()")}} 및 {{domxref("CanvasRenderingContext2D.getImageData", "getImageData()")}} 를 사용하여 생성됩니다. {{domxref("CanvasRenderingContext2D.putImageData", "putImageData()")}} 를 사용하여 캔버스의 일부를 설정하는 데에도 사용할 수 있습니다.
 
 ## Constructors
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

[ImageData 문서 번역](https://developer.mozilla.org/ko/docs/Web/API/ImageData) 업데이트 및 [영어 문서](https://developer.mozilla.org/en-US/docs/Web/API/ImageData#browser_compatibility)에 맞춰 최신화를 진행했습니다.
작업 사항은 다음과 같습니다.

1. `Constructors` 한국어 번역을 영어 원문에 맞게 업데이트
2. `Constructors` ImageData 우측에 기재된 experimental_inline 마크 삭제
3.  영어 원문의 기재된 heading `Instance properties` 으로 업데이트 (한국어 번역은 `Properties`)
4. `Instance properties` 내 누락된 properties 업데이트


### Motivation

Canvas 관련 작업을 진행하면서 해당 문서를 참고하게 되었고,
한국어 번역 문서와 영어 원본 문서 간 차이도 있고, 번역도 업데이트가 필요해보여 참여하게 되었습니다.

### Additional details

영어 문서 기준 커밋: https://github.com/mdn/content/commit/eba7ce08cf50c5d9e344652748f6bcfb19f3a396

### Related issues and pull requests

Fixes: #29047 