### PR TITLE
[zh-cn]: update the translation of SVG `<polygon>` element

### DIFF
--- a/files/zh-cn/web/svg/reference/element/polygon/index.md
+++ b/files/zh-cn/web/svg/reference/element/polygon/index.md
@@ -1,13 +1,30 @@
 ---
-title: polygon
+title: <polygon>
 slug: Web/SVG/Reference/Element/polygon
+l10n:
+  sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
 ---
 
-**`polygon`** 元素定义了一个由一组首尾相连的直线线段构成的闭合多边形形状。最后一点连接到第一点。欲了解开放形状，请看{{SVGElement("polyline")}}元素。
+[SVG](/zh-CN/docs/Web/SVG) 元素 **`<polygon>`** 用于定义由一系列相连直线段组成的闭合图形。最后一个点会与第一个点相连形成封闭形状。
+
+若需要开放形状，请参见 {{SVGElement("polyline")}} 元素。
 
 ## 使用上下文
 
 {{svginfo}}
+
+## 属性
+
+- {{SVGAttr('points')}}
+  - : 此属性定义绘制多边形所需的点列表（由 `x,y` 绝对坐标对组成）。
+    _值类型_：[**\<number>**](/zh-CN/docs/Web/SVG/Guides/Content_type#number)+；_默认值_：`""`；_动画性_：**是**
+- {{SVGAttr("pathLength")}}
+  - : 此属性用于指定路径的总长度，单位为用户单位。
+    _值类型_：[**\<number>**](/zh-CN/docs/Web/SVG/Guides/Content_type#number)；_默认值_：_无_；_动画性_：**是**
+
+## DOM 接口
+
+此元素实现了 {{domxref("SVGPolygonElement")}} 接口。
 
 ## 示例
 
@@ -21,41 +38,31 @@ svg {
 
 ```html
 <svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
-  <!-- 具有默认填充的多边形示例 -->
+  <!-- 带有默认填充色的多边形示例 -->
   <polygon points="0,100 50,25 50,75 100,0" />
 
-  <!-- 具有描边但无填充的相同的多边形形状示例 -->
+  <!-- 相同多边形形状示例：只有描边且无填充色 -->
   <polygon points="100,100 150,25 150,75 200,0" fill="none" stroke="black" />
 </svg>
 ```
 
 {{EmbedLiveSample('示例', 100, 100)}}
 
-## 属性
+## 规范
 
-### 全局属性
-
-- [条件处理属性](/zh-CN/docs/Web/SVG/Reference/Attribute#conditionalproccessing) »
-- [核心属性](/zh-CN/docs/Web/SVG/Reference/Attribute#core) »
-- [图形事件属性](/zh-CN/docs/Web/SVG/Reference/Attribute#graphicalevent) »
-- [外观属性](/zh-CN/docs/Web/SVG/Reference/Attribute#presentation) »
-- {{ SVGAttr("class") }}
-- {{ SVGAttr("style") }}
-- {{ SVGAttr("externalResourcesRequired") }}
-- {{ SVGAttr("transform") }}
-
-### 专有属性
-
-- {{ SVGAttr("points") }}
-
-## DOM 接口
-
-该元素实现了 `SVGPolygonElement` 接口。
+{{Specifications}}
 
 ## 浏览器兼容性
 
 {{Compat}}
 
-## 相关内容
+## 参见
 
-- {{ SVGElement("polyline") }}
+- [SVG 表现属性](/zh-CN/docs/Web/SVG/Reference/Attribute#表现属性)，包括 {{SVGAttr("fill")}} 和 {{SVGAttr("stroke")}}
+
+- **其他 SVG 基本形状：**
+  - {{ SVGElement('circle') }}
+  - {{ SVGElement('ellipse') }}
+  - {{ SVGElement('line') }}
+  - {{ SVGElement('polyline') }}
+  - {{ SVGElement('rect') }}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/polygon
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/svg/reference/element/polygon/index.md
* Last commit: https://github.com/mdn/content/commit/3e543cdfe8dddfb4774a64bf3decdcbab42a4111
