### PR TITLE
[zh-cn]: update the translation of WindowClient `navigate()` method

### DIFF
--- a/files/zh-cn/web/api/windowclient/navigate/index.md
+++ b/files/zh-cn/web/api/windowclient/navigate/index.md
@@ -8,7 +8,7 @@ l10n:
 
 {{APIRef("Service Workers API")}}{{AvailableInWorkers("service")}}
 
-{{domxref("WindowClient")}} 接口的 **`navigate()`** 方法会将指定的 URL 加载到受控的客户端页面中，然后返回一个 {{jsxref("Promise")}}，该 Promise 兑现后得到现有的 {{domxref("WindowClient")}}。
+{{domxref("WindowClient")}} 接口的 **`navigate()`** 方法会将指定的 URL 加载到受控的客户端页面中，然后返回一个 {{jsxref("Promise")}}，其兑现为现有的 {{domxref("WindowClient")}}。
 
 ## 语法
 
@@ -23,7 +23,7 @@ navigate(url)
 
 ### 返回值
 
-如果该 URL 与 service worker 同源，则返回一个{{jsxref("Promise")}}，其兑现结果为现有的 {{domxref("WindowClient")}}；否则返回 {{jsxref("Operators/null", "null")}}。
+如果该 URL 与 service worker 同源，则返回一个兑现为现有 {{domxref("WindowClient")}} 的 {{jsxref("Promise")}}；否则返回 {{jsxref("Operators/null", "null")}}。
 
 ## 规范
 

--- a/files/zh-cn/web/api/windowclient/navigate/index.md
+++ b/files/zh-cn/web/api/windowclient/navigate/index.md
@@ -1,30 +1,31 @@
 ---
-title: WindowClient.navigate()
+title: WindowClient：navigate() 方法
+short-title: navigate()
 slug: Web/API/WindowClient/navigate
+l10n:
+  sourceCommit: 2ef36a6d6f380e79c88bc3a80033e1d3c4629994
 ---
 
-{{SeeCompatTable}}{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{AvailableInWorkers("service")}}
 
-{{domxref("WindowClient")}} 接口的 **`navigate()`** 方法加载特定的 URL 地址到一个被控制的浏览器页面，并返回一个当前 {{domxref("WindowClient")}} 议的 {{jsxref("Promise")}} 对象。
+{{domxref("WindowClient")}} 接口的 **`navigate()`** 方法会将指定的 URL 加载到受控的客户端页面中，然后返回一个 {{jsxref("Promise")}}，该 Promise 兑现后得到现有的 {{domxref("WindowClient")}}。
 
 ## 语法
 
-```plain
-WindowClient.navigate(url).then(function(WindowClient) {
-  // do something with your WindowClient after navigation
-});
+```js-nolint
+navigate(url)
 ```
 
 ### 参数
 
 - `url`
-  - : 跳转地址
+  - : 要导航到的位置。
 
 ### 返回值
 
-一个 {{domxref("WindowClient")}}决议的{{jsxref("Promise")}}对象。
+如果该 URL 与 service worker 同源，则返回一个{{jsxref("Promise")}}，其兑现结果为现有的 {{domxref("WindowClient")}}；否则返回 {{jsxref("Operators/null", "null")}}。
 
-## Specifications
+## 规范
 
 {{Specifications}}
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/WindowClient/navigate
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/windowclient/navigate/index.md
* Last commit: https://github.com/mdn/content/commit/2ef36a6d6f380e79c88bc3a80033e1d3c4629994

