### PR TITLE
[zh-cn]: update the translation of Animation `cancel()` method

### DIFF
--- a/files/zh-cn/web/api/animation/cancel/index.md
+++ b/files/zh-cn/web/api/animation/cancel/index.md
@@ -45,4 +45,4 @@ cancel()
 - {{domxref("KeyframeEffect")}}
 - {{domxref("Animation")}}
 - {{domxref("Animation.playState")}}
-- {{domxref("Animation.finished")}} returns the promise this action will reject if the animation's `playState` is not `"idle"`.
+- {{domxref("Animation.finished")}} 返回的 promise，如果动画的 animation `playState` 不是 `"idle"`，将会拒绝。

--- a/files/zh-cn/web/api/animation/cancel/index.md
+++ b/files/zh-cn/web/api/animation/cancel/index.md
@@ -8,7 +8,7 @@ l10n:
 
 {{ APIRef("Web Animations") }}
 
-[Web Animations API](/zh-CN/docs/Web/API/Web_Animations_API) 中 {{domxref("Animation")}} 接口的 **`cancel()`** 方法会清除由该动画产生的所有 {{domxref("KeyframeEffect")}}，并中止其播放。
+[Web 动画 API](/zh-CN/docs/Web/API/Web_Animations_API) 中 {{domxref("Animation")}} 接口的 **`cancel()`** 方法会清除由该动画产生的所有 {{domxref("KeyframeEffect")}}，并中止其播放。
 
 > [!NOTE]
 > 当动画被取消时，{{domxref("Animation.startTime", "startTime")}} 和 {{domxref("Animation.currentTime", "currentTime")}} 会被设为 `null`。
@@ -29,7 +29,7 @@ cancel()
 
 ### 异常
 
-该方法本身不会直接抛出异常；但是，如果在动画被取消时，{{domxref("Animation.playState", "playState")}} 不设为 `"idle"`，则 {{domxref("Animation.finished", "当前的 finished promise", "", 1)}} 会以名为 `AbortError` 的 {{domxref("DOMException")}} 被拒绝。
+该方法本身不会直接抛出异常；但是，如果在动画被取消时，{{domxref("Animation.playState", "playState")}} 不设为 `"idle"`，则{{domxref("Animation.finished", "当前的 finished promise", "", 1)}} 会以名为 `AbortError` 的 {{domxref("DOMException")}} 被拒绝。
 
 ## 规范
 
@@ -41,8 +41,8 @@ cancel()
 
 ## 参见
 
-- [Web Animations API](/zh-CN/docs/Web/API/Web_Animations_API)
+- [Web 动画 API](/zh-CN/docs/Web/API/Web_Animations_API)
 - {{domxref("KeyframeEffect")}}
 - {{domxref("Animation")}}
 - {{domxref("Animation.playState")}}
-- {{domxref("Animation.finished")}} 返回的 promise，如果动画的 animation `playState` 不是 `"idle"`，将会拒绝。
+- {{domxref("Animation.finished")}} 返回的 promise，如果动画的 `playState` 不是 `"idle"`，将会拒绝。

--- a/files/zh-cn/web/api/animation/cancel/index.md
+++ b/files/zh-cn/web/api/animation/cancel/index.md
@@ -1,14 +1,17 @@
 ---
-title: Animation.cancel()
+title: Animation：cancel() 方法
+short-title: cancel()
 slug: Web/API/Animation/cancel
+l10n:
+  sourceCommit: ec1006afdf68a5808a48ab6301f9ccff3cd7ecc2
 ---
 
-{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}
+{{ APIRef("Web Animations") }}
 
-{{domxref("Animation")}} 接口的 Web 动画 API 的 **`cancel()`** 方法将清除此动画造成的所有 {{domxref("KeyframeEffect")}}，并中止其播放。
+[Web Animations API](/zh-CN/docs/Web/API/Web_Animations_API) 中 {{domxref("Animation")}} 接口的 **`cancel()`** 方法会清除由该动画产生的所有 {{domxref("KeyframeEffect")}}，并中止其播放。
 
 > [!NOTE]
-> 当一个动画被取消时，其 {{domxref("Animation.startTime", "startTime")}} 和 {{domxref("Animation.currentTime", "currentTime")}} 被设置为 null。
+> 当动画被取消时，{{domxref("Animation.startTime", "startTime")}} 和 {{domxref("Animation.currentTime", "currentTime")}} 会被设为 `null`。
 
 ## 语法
 
@@ -22,11 +25,11 @@ cancel()
 
 ### 返回值
 
-无。
+无（{{jsxref("undefined")}}）。
 
 ### 异常
 
-这个方法不会直接抛出异常; 但是，如果动画的 {{domxref("Animation.playState", "playState")}} 取消时是除了“空闲”之外的任何东西，{{domxref("Animation.finished", "current finished promise", "", 1)}} 被拒绝与一个 {{domxref("DOMException")}} 命名的`AbortError`.
+该方法本身不会直接抛出异常；但是，如果在动画被取消时，{{domxref("Animation.playState", "playState")}} 不设为 `"idle"`，则 {{domxref("Animation.finished", "当前的 finished promise", "", 1)}} 会以名为 `AbortError` 的 {{domxref("DOMException")}} 被拒绝。
 
 ## 规范
 
@@ -36,7 +39,7 @@ cancel()
 
 {{Compat}}
 
-## 相关内容
+## 参见
 
 - [Web Animations API](/zh-CN/docs/Web/API/Web_Animations_API)
 - {{domxref("KeyframeEffect")}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/Animation/cancel
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/animation/cancel/index.md
* Last commit: https://github.com/mdn/content/commit/ec1006afdf68a5808a48ab6301f9ccff3cd7ecc2
