### PR TITLE
fr: fix template literals syntax formatting

### DIFF
--- a/files/fr/web/javascript/reference/template_literals/index.md
+++ b/files/fr/web/javascript/reference/template_literals/index.md
@@ -13,14 +13,20 @@ Les littéraux de gabarits sont des littéraux de chaînes de caractères permet
 ## Syntaxe
 
 ```js
-`texte`
+`texte`;
+```
 
+```js
 `ligne de texte 1
-  ligne de texte 2`
+  ligne de texte 2`;
+```
 
-`texte ${expression} texte`
+```js
+`texte ${expression} texte`;
+```
 
-etiquette`texte ${expression} texte`
+```js
+etiquette`texte ${expression} texte`;
 ```
 
 ## Description

--- a/files/fr/web/javascript/reference/template_literals/index.md
+++ b/files/fr/web/javascript/reference/template_literals/index.md
@@ -12,21 +12,12 @@ Les littéraux de gabarits sont des littéraux de chaînes de caractères permet
 
 ## Syntaxe
 
-```js
-`texte`;
-```
-
-```js
+```js-nolint
+`texte`
 `ligne de texte 1
-  ligne de texte 2`;
-```
-
-```js
-`texte ${expression} texte`;
-```
-
-```js
-etiquette`texte ${expression} texte`;
+  ligne de texte 2`
+`texte ${expression} texte`
+etiquette`texte ${expression} texte`
 ```
 
 ## Description

--- a/files/fr/web/javascript/reference/template_literals/index.md
+++ b/files/fr/web/javascript/reference/template_literals/index.md
@@ -13,10 +13,14 @@ Les littéraux de gabarits sont des littéraux de chaînes de caractères permet
 ## Syntaxe
 
 ```js
-`texte``ligne de texte 1
-  ligne de texte 2``texte ${expression} texte`;
+`texte`
 
-etiquette`texte ${expression} texte`;
+`ligne de texte 1
+  ligne de texte 2`
+
+`texte ${expression} texte`
+
+etiquette`texte ${expression} texte`
 ```
 
 ## Description


### PR DESCRIPTION
- Separate concatenated template literals into individual examples
- Add proper spacing between each template literal example
- Fixes #29387

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixed the syntax section formatting in the French translation of Template literals documentation. The template literals were incorrectly concatenated together instead of being displayed as separate examples.

### Motivation

The current formatting made it confusing for French readers to understand the different ways template literals can be used. Separating them into individual examples with proper spacing improves readability and makes the syntax clearer.

### Additional details

This addresses the specific formatting issue reported in GitHub issue #29387 where the template literals were concatenated like `texte``ligne de texte 1` instead of being separate examples.

### Related issues and pull requests
Fixes #29387
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
