### PR TITLE
fix(zh-cn): correct the description of the `endOffset` parameter of `Range.setEnd()`

### DIFF
--- a/files/zh-cn/web/api/range/setend/index.md
+++ b/files/zh-cn/web/api/range/setend/index.md
@@ -1,35 +1,35 @@
 ---
-title: Range.setEnd()
+title: Range：setEnd() 方法
 slug: Web/API/Range/setEnd
 ---
 
 {{ApiRef("DOM")}}
 
-**`Range.setEnd()`**方法用于设置 [`Range`](/zh-CN/docs/Web/API/Range)的结束位置。
-
-如果结束节点类型是 `Text`、`Comment` 或 `CDATASection`之一，那么 `endOffset` 指的是从结束节点算起字符的偏移量。对于其他 `Node` 类型节点，`endOffset` 是指从结束结点开始算起子节点的偏移量。
-
-如果设置的结束点在起始点之上（在文档中的位置），将会导致选区折叠，起始点和结束点都会被设置为指定的结束位置。
+**`Range.setEnd()`** 方法用于将 {{domxref("Range")}} 的结束位置设置为指定节点中给定偏移量处。如果将结束点设置在起始点之上（即文档结构中更高的位置），则会导致范围折叠，起始点和结束点都会被设置为指定的结束位置。
 
 ## 语法
 
-```plain
-range.setEnd(endNode, endOffset);
+```js-nolint
+setEnd(endNode, endOffset)
 ```
 
 ### 参数
 
-- _endNode_
-  - : *endNode*用于设定 [`Range`](/zh-CN/docs/Web/API/Range)的结束位置。
-- _endOffset_
-  - : 一个大于或等于零的整数，表示 [`Range`](/zh-CN/docs/Web/API/Range) 的结束位置相对于 *endNode* 起始点的偏移量。
+- `endNode`
+  - : 应当作为 {{ domxref("Range") }} 结束位置的 {{ domxref("Node") }}。
+- `endOffset`
+  - : 一个大于或等于零的整数，表示 `Range` 的结束位置相对于 `endNode` 起始点的偏移量。
 
-## 例子
+### 返回值
+
+无（{{jsxref("undefined")}}）。
+
+## 示例
 
 ```js
-var range = document.createRange();
-var endNode = document.getElementsByTagName("p").item(3);
-var endOffset = endNode.childNodes.length;
+const range = document.createRange();
+const endNode = document.getElementsByTagName("p").item(3);
+const endOffset = endNode.childNodes.length;
 range.setEnd(endNode, endOffset);
 ```
 
@@ -43,4 +43,4 @@ range.setEnd(endNode, endOffset);
 
 ## 参见
 
-- [The DOM interfaces index](/zh-CN/docs/Web/API/Document_Object_Model)
+- [DOM 接口索引](/zh-CN/docs/Web/API/Document_Object_Model)

--- a/files/zh-cn/web/api/range/setend/index.md
+++ b/files/zh-cn/web/api/range/setend/index.md
@@ -22,7 +22,7 @@ range.setEnd(endNode, endOffset);
 - _endNode_
   - : *endNode*用于设定 [`Range`](/zh-CN/docs/Web/API/Range)的结束位置。
 - _endOffset_
-  - : 必须为不小于 0 的整数。表示从*endNode*的结束位置算起的偏移量。
+  - : 一个大于或等于零的整数，表示 [`Range`](/zh-CN/docs/Web/API/Range) 的结束位置相对于 *endNode* 起始点的偏移量。
 
 ## 例子
 


### PR DESCRIPTION
endOffset 是从节点的起始位置开始计算的偏移量，而非结束位置。

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Corrects the mistranslation of the endOffset parameter for the Range.setEnd() method in the Chinese (zh-CN) documentation.
This change updates the description of endOffset from "the offset from the end of endNode" to "the offset for the end of the Range relative to the start of endNode".
This aligns the Chinese translation strictly with the original English documentation ("from the start of endNode").

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The current Chinese documentation for endOffset contains a critical error, incorrectly stating that the offset is calculated from the node's "end position" when the correct behavior is from the "start position".
This mistranslation can severely mislead Chinese-speaking developers, potentially causing them to write incorrect code when using the Range API and waste significant time on unnecessary debugging.
This PR aims to fix this critical error, ensuring the accuracy and reliability of the Chinese documentation and providing correct guidance to the large Chinese-speaking developer community.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
