### PR TITLE
[ko] Fix: typo in access-control-allow-credentials page

### DIFF
--- a/files/ko/web/http/reference/headers/access-control-allow-credentials/index.md
+++ b/files/ko/web/http/reference/headers/access-control-allow-credentials/index.md
@@ -4,9 +4,9 @@ slug: Web/HTTP/Reference/Headers/Access-Control-Allow-Credentials
 original_slug: Web/HTTP/Headers/Access-Control-Allow-Credentials
 ---
 
-응답헤더 **`Access-Control-Allow-Credentials`** 는 요청의 자격증명 모드({{domxref("Request.credentials")}})가 "`include`" 일때, 브라우저들이 응답을 프로트엔드 자바스트립트 코드에 노출할지에 대해 알려줍니다.
+응답헤더 **`Access-Control-Allow-Credentials`** 는 요청의 자격증명 모드({{domxref("Request.credentials")}})가 "`include`" 일때, 브라우저들이 응답을 프런트엔드 자바스트립트 코드에 노출할지에 대해 알려줍니다.
 
-요청의 자격증명 모드가 ({{domxref("Request.credentials")}})가 "`include`" 일 때, `Access-Control-Allow-Credentials` 값이 `true` 일 경우에만 브라우저들은 프로트엔드 자바스트립트에 응답을 노출 할 것입니다.
+요청의 자격증명 모드가 ({{domxref("Request.credentials")}})가 "`include`" 일 때, `Access-Control-Allow-Credentials` 값이 `true` 일 경우에만 브라우저들은 프런트엔드 자바스트립트에 응답을 노출 할 것입니다.
 
 자격증명들은 쿠키, authorization 헤더들 또는 TLS 클라이언트 인증서입니다.
 


### PR DESCRIPTION
### Description
프로트엔드로 오기입된 용어를 국립국어원 기준에 따라 프런트엔드로 수정했습니다

### Motivation
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
