### PR TITLE
fr: create `Web/API/HTMLAnchorElement/protocol`

### DIFF
--- a/files/fr/web/api/htmlanchorelement/protocol/index.md
+++ b/files/fr/web/api/htmlanchorelement/protocol/index.md
@@ -1,0 +1,41 @@
+---
+title: "HTMLAnchorElement : propriété protocol"
+short-title: protocol
+slug: Web/API/HTMLAnchorElement/protocol
+l10n:
+  sourceCommit: 82acf2a065dc00a1bd0cbf5e73de696e1bedee91
+---
+
+{{ApiRef("HTML DOM")}}
+
+La propriété **`protocol`** de l'interface {{domxref("HTMLAnchorElement")}} est une chaîne de caractères contenant le protocole (ou schéma) du `href` de l'élément HTML `<a>`, y compris le caractère `":"` final.
+
+Cette propriété peut être modifiée pour changer le protocole de l'URL. Un `":"` est ajouté à la chaîne fournie si elle ne se termine pas déjà ainsi. Le schéma fourni doit être compatible avec le reste de l'URL pour être considéré comme valide.
+
+Voir {{domxref("URL.protocol")}} pour plus d'informations.
+
+## Valeur
+
+Une chaîne de caractères.
+
+## Exemples
+
+### Obtenir le protocole d'un lien d'ancre
+
+```js
+// Un élément <a id="myAnchor" href="https://developer.mozilla.org/fr/HTMLAnchorElement"> est dans le document
+const anchor = document.getElementById("myAnchor");
+anchor.protocol; // retourne 'https:'
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'interface {{domxref("HTMLAnchorElement")}} à laquelle elle appartient.


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/HTMLAnchorElement/protocol`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

Related to  #29568