### PR TITLE
fr: broken links of #7319

### DIFF
--- a/files/fr/learn_web_development/extensions/forms/sending_and_retrieving_form_data/index.md
+++ b/files/fr/learn_web_development/extensions/forms/sending_and_retrieving_form_data/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Extensions/Forms/Sending_and_retrieving_form_data
 original_slug: Learn/Forms/Sending_and_retrieving_form_data
 ---
 
-{{LearnSidebar}}{{PreviousMenu("Learn/Forms/Form_validation", "Learn/Forms")}}
+{{PreviousMenu("Learn_web_development/Extensions/Forms/Form_validation", "Learn_web_development/Extensions/Forms")}}
 
 Cet article examine ce qui arrive quand un utilisateur soumet un formulaire — où les données vont-elles et comment les gère-t-on une fois à destination ? Nous examinerons aussi quelques problèmes de sécurité associés à l'envoi des données d'un formulaire.
 
@@ -236,7 +236,7 @@ if __name__ == "__main__":
 
 Les deux prototypes référencés dans le code ci‑dessus sont les suivants&nbsp;:
 
-- [`form.html`](https://github.com/mdn/learning-area/blob/main/html/forms/sending-form-data/templates/form.html)&nbsp;: Le même formulaire que celui vu plus haut dans la section [La méthode POST](#the_post_method) mais avec l'attribut `action` défini à la valeur `\{{url_for('hello')}}`. (C'est un modèle [Jinja2](https://jinja.pocoo.org/docs/2.9/), qui est HTML à la base mais peut contenir des appels à du code Python qui fait tourner le serveur web mis entre accolades. `url_for('hello')` dit en gros «&nbsp;à rediriger sur `/hello` quand le formulaire est soumis&nbsp;».)
+- [`form.html`](https://github.com/mdn/learning-area/blob/main/html/forms/sending-form-data/templates/form.html)&nbsp;: Le même formulaire que celui vu plus haut dans la section [La méthode POST](#la_méthode_post) mais avec l'attribut `action` défini à la valeur `\{{url_for('hello')}}`. C'est un modèle [Jinja2](https://jinja.palletsprojects.com/), qui est HTML à la base mais peut contenir des appels à du code Python qui fait tourner le serveur web mis entre accolades. `url_for('hello')` dit en gros «&nbsp;à rediriger sur `/hello` quand le formulaire est soumis&nbsp;».
 - [greeting.html](https://github.com/mdn/learning-area/blob/main/html/forms/sending-form-data/templates/greeting.html)&nbsp;: Ce modèle contient juste une ligne qui renvoie les deux éléments de donnée qui lui sont passées lors du rendu. Cela est effectué par l'intermédiaire de la fonction `hello()` vue plus haut qui s'exécute quand l'URL `/hello` est chargée dans le navigateur.
 
 > [!NOTE]
@@ -319,4 +319,4 @@ Si vous voulez en savoir plus par rapport aux applications web, vous pouvez cons
 - [Open Web Application Security Project (OWASP)](https://www.owasp.org/index.php/Main_Page) (Projet pour la sécurité des applications dans un Web ouvert)
 - [Blog de Chris Shiflett à propos de la sécurité avec PHP](https://shiflett.org/)
 
-{{PreviousMenu("Learn/Forms/Form_validation", "Learn/Forms")}}
+{{PreviousMenu("Learn_web_development/Extensions/Forms/Form_validation", "Learn_web_development/Extensions/Forms")}}

--- a/files/fr/learn_web_development/extensions/testing/testing_strategies/index.md
+++ b/files/fr/learn_web_development/extensions/testing/testing_strategies/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Extensions/Testing/Testing_strategies
 original_slug: Learn/Tools_and_testing/Cross_browser_testing/Testing_strategies
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Cross_browser_testing/Introduction","Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS", "Learn/Tools_and_testing/Cross_browser_testing")}}
+{{PreviousMenuNext("Learn_web_development/Extensions/Testing/Introduction","Learn_web_development/Extensions/Testing/HTML_and_CSS", "Learn_web_development/Extensions/Testing")}}
 
 Cet article commence en donnant un aperçu sur le sujet des tests sur navigateurs (croisé), répondant aux questions telles que "qu'est-ce que le test en navigateur croisé ?", "Quels sont les problèmes les plus communs que vous allez rencontrer ?", et "quelles sont les principales approches pour tester, identifier, et fixer les problèmes ?"
 
@@ -195,7 +195,7 @@ Certaines grandes entreprises ont des labos d'appareils qui stockent une sélect
 Nous couvrirons chacune des autres options plus bas.
 
 > [!NOTE]
-> Certains efforts ont été effectué afin de créer des labos d'appareils accessibles au public — voir [Open Device Labs](https://opendevicelab.com/).
+> Certains efforts ont été effectué afin de créer des labos d'appareils accessibles au public — voir [Open Device Labs <sup>(angl.)</sup>](https://www.smashingmagazine.com/2016/11/worlds-best-open-device-labs/).
 
 > [!NOTE]
 > Nous devons aussi prendre en considération l'accessibilité — il y a plusieurs outils utiles que vous pouvez installer sur votre machine afin de faciliter les tests d'accessibilité, mais nous les couvrirons dans l'article Gestion des problèmes communs d'accessibilité, plus tard dans le cours.
@@ -307,4 +307,4 @@ Après avoir lu cet article vous devriez maintenant avoir une bonne idée de ce 
 
 La prochaine fois nous tournerons notre attention sur les problèmes concrets de votre code que vos tests peuvent révéler, en commençant avec le HTML et le CSS.
 
-{{PreviousMenuNext("Learn/Tools_and_testing/Cross_browser_testing/Introduction","Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS", "Learn/Tools_and_testing/Cross_browser_testing")}}
+{{PreviousMenuNext("Learn_web_development/Extensions/Testing/Introduction","Learn_web_development/Extensions/Testing/HTML_and_CSS", "Learn_web_development/Extensions/Testing")}}

--- a/files/fr/learn_web_development/howto/design_and_accessibility/design_for_all_types_of_users/index.md
+++ b/files/fr/learn_web_development/howto/design_and_accessibility/design_for_all_types_of_users/index.md
@@ -4,8 +4,6 @@ slug: Learn_web_development/Howto/Design_and_accessibility/Design_for_all_types_
 original_slug: Learn/Common_questions/Design_and_accessibility/Design_for_all_types_of_users
 ---
 
-{{QuicklinksWithSubPages("Learn/Common_questions")}}
-
 Cet article aborde les concepts de bases pour vous aider à construire des sites web accessibles à tous.
 
 <table class="standard-table">
@@ -249,11 +247,4 @@ Il est également nécessaire de fournir des alternatives à du contenu multimé
 
 ### Compression des images
 
-Certains utilisateurs pourraient avoir choisi d'afficher les images mais pourraient disposer d'une connexion instable ou limité (c'est le cas notamment dans les pays en développement et sur les appareils mobiles). Si vous souhaitez que votre site web soit le plus fonctionnel possible, il est nécessaire de compresser les images. Voici quelques outils pour vous aider à cette tâche (logiciels ou services en ligne)&nbsp;:
-
-- **Logiciels à installer&nbsp;:** [ImageOptim](https://imageoptim.com/) (Mac), [OptiPNG](http://optipng.sourceforge.net/) (toutes les plates-formes, [PNGcrush](http://pmt.sourceforge.net/pngcrush/) (DOS, Unix/Linux)
-- **Outils en lignes&nbsp;:** [smushit!](http://smush.it/) de Yahoo!, [Online Image Optimizer](http://tools.dynamicdrive.com/imageoptimizer/) de Dynamic Drive (qui peut convertir d'un format à un autre si cela est plus efficace en termes de bande passante)
-
-## Prochaines étapes
-
-Cet article ne décrit que les bases d'un design accessible et universel. Si vous souhaitez aller plus loin dan ce domaine, vous pouvez poursuivre avec [les bases de l'ergonomie ou UX (_User Experience_ en anglais)](/fr/docs/Learn/Basics_of_UX_Design).
+Certain·e·s utilisateur·ice·s peuvent choisir d'afficher les images, mais disposer d'une bande passante limitée, notamment dans les pays en développement ou sur mobile. Pour un site efficace, compressez vos images. Il existe de nombreux outils pour cela, en ligne ou en local. Les outils locaux sont généralement préférés car ils s'intègrent mieux au flux de travail&nbsp;: [ImageOptim](https://imageoptim.com/api) (Mac), [OptiPNG](https://optipng.sourceforge.net/) (toutes plateformes), et [PNGcrush](https://pmt.sourceforge.io/pngcrush/) (DOS, Unix/Linux).

--- a/files/fr/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -93,7 +93,7 @@ Il est à noter que tous les chemins sont relatifs au fichier manifest.json.
 
 L'extension doit posséder une icône qui sera affichée dans le catalogue des extensions et dans la liste des extensions du navigateur (vous pouvez afficher le gestionnaire en ouvrant l'URL «&nbsp;about:addons&nbsp;»). Le fichier manifest.json a déclaré une icône pour la barre d'outils, `icons/beasts-48.png`.
 
-Créez le répertoire «&nbsp;icons&nbsp;» et enregistrez-y une icône nommée `beasts-48.png`. Vous pouvez utiliser [une image de notre exemple](https://github.com/mdn/webextensions-examples/raw/master/beastify/icons/beasts-48.png), provenant du jeu d'icônes de [Aha-Soft's Free Retina](https://www.iconfinder.com/iconsets/free-retina-icon-set) et utilisable selon les termes de sa [licence](http://www.aha-soft.com/free-icons/free-retina-icon-set/).
+Créez le répertoire «&nbsp;icons&nbsp;» et enregistrez-y une icône nommée `beasts-48.png`. Vous pouvez utiliser [une image de notre exemple](https://github.com/mdn/webextensions-examples/raw/master/beastify/icons/beasts-48.png), provenant du jeu d'icônes de [Aha-Soft's Free Retina](https://www.iconfinder.com/iconsets/free-retina-icon-set) et utilisable selon les termes de sa licence.
 
 Si vous décidez de fournir votre propre icône, sa taille devra être de 48 pixels par 48 pixels. Il vous est aussi possible de fournir une icône de taille 96 pixels par 96 pixels, adaptée aux affichages haute résolution, et, devra dans ce cas, être spécifiée par la propriété `96` de l'objet `icons` du manifeste&nbsp;:
 


### PR DESCRIPTION
### Description

Fixing translation of pages without french version:
- `Learn_web_development/Extensions/Forms/Sending_and_retrieving_form_data`
- `Learn_web_development/Extensions/Testing/Testing_strategies`
- `Learn_web_development/Howto/Design_and_accessibility/Design_for_all_types_of_users`
- `Mozilla/Add-ons/WebExtensions/Your_second_WebExtension`

### Motivation

Fixing access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

Fix #7319