### PR TITLE
ci(system-file-changes): pass actor/author via env

### DIFF
--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -23,10 +23,11 @@ jobs:
     steps:
       - name: Block if author/actor is not an admin
         env:
+          ACTOR: ${{ github.actor }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
           GH_TOKEN: ${{ github.token }}
         run: |
           # Check author.
-          AUTHOR="${{ github.event.pull_request.user.login }}"
           AUTHOR_PERMISSION=$(gh api https://api.github.com/repos/${{ github.repository }}/collaborators/$AUTHOR/permission --jq .permission)
 
           if [ "$AUTHOR_PERMISSION" != "admin" ]; then
@@ -35,7 +36,6 @@ jobs:
           fi
 
           # Check actor.
-          ACTOR="${{ github.actor }}"
           if [ "$ACTOR" != "$AUTHOR" ]; then
             ACTOR_PERMISSION=$(gh api https://api.github.com/repos/${{ github.repository }}/collaborators/$ACTOR/permission --jq .permission)  
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updates the `system-file-changes` workflow to treat GitHub author and actor as untrusted, passing them via environment variable.

### Motivation

Apply best practices.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/872:

> Treat all `github.event.*` parameters as untrusted input: Sanitize before use in shell command

Same as: https://github.com/mdn/content/pull/41433