### PR TITLE
ci(pr-review-companion): use step output via env variable

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -111,7 +111,7 @@ jobs:
         working-directory: content
         run: |
           echo "Pull request:"
-          echo "https://github.com/mdn/translated-content/pull/${{ steps.check.outputs.PR_NUMBER }}"
+          echo "https://github.com/mdn/translated-content/pull/$PR_NUMBER"
 
           node scripts/analyze-pr-build.js \
             --prefix="$PREFIX" \


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Use the defined env variable instead of github parameter directly to prevent potential command injection


