### PR TITLE
[ko] Array.* `short-title` 추가 외

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/array/array/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/array/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array() 생성자
+short-title: Array()
 slug: Web/JavaScript/Reference/Global_Objects/Array/Array
 l10n:
   sourceCommit: 542ef6cfd82288925e0a9238b47933f03e2dddca

--- a/files/ko/web/javascript/reference/global_objects/array/at/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/at/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.at()
+short-title: at()
 slug: Web/JavaScript/Reference/Global_Objects/Array/at
 l10n:
   sourceCommit: a815a95e4ab4adf391d8a7bc66a3abbce1a686d8
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 **`at()`** 메서드는 정숫값을 받아 해당 인덱스에 있는 항목을 반환하며, 양수와 음수를 사용할 수 있습니다. 음의 정수는 배열의 마지막 항목부터 거슬러 셉니다.
 
-{{InteractiveExample("JavaScript Demo: Array.at()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.at()")}}
 
 ```js interactive-example
 const array1 = [5, 12, 8, 130, 44];

--- a/files/ko/web/javascript/reference/global_objects/array/concat/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/concat/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.concat()
+short-title: concat()
 slug: Web/JavaScript/Reference/Global_Objects/Array/concat
 l10n:
   sourceCommit: b7ca46c94631967ecd9ce0fe36579be334a01275
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 **`concat()`** 메서드는 두 개 이상의 배열을 병합하는 데 사용됩니다. 이 메서드는 기존 배열을 변경하지 않고, 새 배열을 반환합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.concat()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.concat()", "shorter")}}
 
 ```js interactive-example
 const array1 = ["a", "b", "c"];

--- a/files/ko/web/javascript/reference/global_objects/array/copywithin/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/copywithin/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.copyWithin()
+short-title: copyWithin()
 slug: Web/JavaScript/Reference/Global_Objects/Array/copyWithin
 l10n:
   sourceCommit: 6e8ca9ecc4bfd14ea5c46d4817f189eecacb8296
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 **`copyWithin()`** 메서드는 배열의 일부를 같은 배열의 다른 위치로 얕게 복사하며, 배열의 길이를 수정하지 않고 해당 배열을 반환합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.copyWithin()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.copyWithin()")}}
 
 ```js interactive-example
 const array1 = ["a", "b", "c", "d", "e"];

--- a/files/ko/web/javascript/reference/global_objects/array/entries/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/entries/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.entries()
+short-title: entries()
 slug: Web/JavaScript/Reference/Global_Objects/Array/entries
 l10n:
   sourceCommit: 27180875516cc311342e74b596bfb589b7211e0c
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 **`entries()`** 메서드는 배열의 각 인덱스에 대한 키/값 쌍을 포함하는 새 [배열 반복자](/ko/docs/Web/JavaScript/Reference/Global_Objects/Iterator) 객체를 반환합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.entries()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.entries()")}}
 
 ```js interactive-example
 const array1 = ["a", "b", "c"];

--- a/files/ko/web/javascript/reference/global_objects/array/every/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/every/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.every()
+short-title: every()
 slug: Web/JavaScript/Reference/Global_Objects/Array/every
 l10n:
   sourceCommit: b7ca46c94631967ecd9ce0fe36579be334a01275
@@ -7,9 +8,9 @@ l10n:
 
 {{JSRef}}
 
-{{jsxref("Array")}} 인스턴스의 **`every()`** 메서드는 배열의 모든 요소가 제공된 함수로 구현된 테스트를 통과하는지 테스트합니다. 이 메서드는 불리언 값을 반환합니다.
+{{jsxref("Array")}} 인스턴스의 **`every()`** 메서드는 제공된 테스트 함수를 만족시키지 못한 배열 내 요소를 하나 찾으면 `false`를 반환합니다. 그렇지 않으면 `true`를 반환합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.every()", 'shorter')}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.every()", "shorter")}}
 
 ```js interactive-example
 const isBelowThreshold = (currentValue) => currentValue < 40;
@@ -17,7 +18,7 @@ const isBelowThreshold = (currentValue) => currentValue < 40;
 const array1 = [1, 30, 39, 29, 10, 13];
 
 console.log(array1.every(isBelowThreshold));
-// Expected output: true
+// 예상 출력: true
 ```
 
 ## 구문
@@ -42,7 +43,7 @@ every(callbackFn, thisArg)
 
 ### 반환 값
 
-`callbackFn`이 모든 배열 요소에 대해 {{Glossary("truthy", "참")}} 값을 반환하면 `true`입니다. 그렇지 않으면 `false`입니다.
+`callbackFn`이 {{Glossary("falsy", "거짓")}}을 반환하는 경우 `false`를 즉시 반환하며, 그렇지 않으면 `true`를 반환합니다.
 
 ## 설명
 

--- a/files/ko/web/javascript/reference/global_objects/array/fill/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/fill/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.fill()
+short-title: fill()
 slug: Web/JavaScript/Reference/Global_Objects/Array/fill
 l10n:
   sourceCommit: b7ca46c94631967ecd9ce0fe36579be334a01275
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 **`fill()`** 메서드는 배열의 인덱스 범위 내에 있는 모든 요소를 정적 값으로 변경합니다. 그리고 수정된 배열을 반환합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.fill()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.fill()")}}
 
 ```js interactive-example
 const array1 = [1, 2, 3, 4];

--- a/files/ko/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/filter/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.filter()
+short-title: filter()
 slug: Web/JavaScript/Reference/Global_Objects/Array/filter
 l10n:
   sourceCommit: 57375b77984037c614982a9327bc96101824db89
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 `filter()` 메서드는 주어진 배열의 일부에 대한 [얕은 복사본](/ko/docs/Glossary/Shallow_copy)을 생성하고, 주어진 배열에서 제공된 함수에 의해 구현된 테스트를 통과한 요소로만 필터링 합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.filter()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.filter()", "shorter")}}
 
 ```js interactive-example
 const words = ["spray", "elite", "exuberant", "destruction", "present"];

--- a/files/ko/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/find/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.find()
+short-title: find()
 slug: Web/JavaScript/Reference/Global_Objects/Array/find
 l10n:
   sourceCommit: 6589a6a25a5d2e9a359c3f02f37c670fb7c74259
@@ -16,7 +17,7 @@ l10n:
 - 제공된 테스트 함수를 만족하는 요소가 있는지 찾아야 하는 경우, {{jsxref("Array/some", "some()")}}을 사용하세요.
 - 만약 주어진 테스트 함수를 만족하는 모든 요소를 찾고 싶으면 {{jsxref("Array/filter", "filter()")}}을 사용하세요.
 
-{{InteractiveExample("JavaScript Demo: Array.find()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.find()", "shorter")}}
 
 ```js interactive-example
 const array1 = [5, 12, 8, 130, 44];

--- a/files/ko/web/javascript/reference/global_objects/array/findindex/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/findindex/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.findIndex()
+short-title: findIndex()
 slug: Web/JavaScript/Reference/Global_Objects/Array/findIndex
 l10n:
   sourceCommit: 4074fc09b07902a560b9b321c1f966452b5afc7c
@@ -12,7 +13,7 @@ l10n:
 
 판별 함수를 만족하는 첫번째 인덱스 대신 값을 반환하는 {{jsxref("Array.prototype.find", "find()")}} 메서드도 참고하시기 바랍니다.
 
-{{InteractiveExample("JavaScript Demo: Array.findIndex()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.findIndex()", "shorter")}}
 
 ```js interactive-example
 const array1 = [5, 12, 8, 130, 44];

--- a/files/ko/web/javascript/reference/global_objects/array/findlast/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/findlast/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.findLast()
+short-title: findLast()
 slug: Web/JavaScript/Reference/Global_Objects/Array/findLast
 l10n:
   sourceCommit: 57375b77984037c614982a9327bc96101824db89
@@ -17,7 +18,7 @@ l10n:
   이 역시 테스트 함수를 사용하는 것 대신 각 요소가 값과 동일한지 확인합니다.
 - 제공된 테스트 함수를 만족하는 요소가 있는지 찾아야 하는 경우, {{jsxref("Array/some", "some()")}}을 사용하세요.
 
-{{InteractiveExample("JavaScript Demo: Array.findLast()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.findLast()", "shorter")}}
 
 ```js interactive-example
 const array1 = [5, 12, 50, 130, 44];

--- a/files/ko/web/javascript/reference/global_objects/array/findlastindex/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/findlastindex/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.findLastIndex()
+short-title: findLastIndex()
 slug: Web/JavaScript/Reference/Global_Objects/Array/findLastIndex
 l10n:
   sourceCommit: 57375b77984037c614982a9327bc96101824db89
@@ -12,7 +13,7 @@ l10n:
 
 인덱스 대신 판별 함수를 만족하는 마지막 값을 반환하는 {{jsxref("Array/findLast", "findLast()")}} 메서드도 참고하세요.
 
-{{InteractiveExample("JavaScript Demo: Array.findLastIndex()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.findLastIndex()", "shorter")}}
 
 ```js interactive-example
 const array1 = [5, 12, 50, 130, 44];

--- a/files/ko/web/javascript/reference/global_objects/array/flat/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/flat/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.flat()
+short-title: flat()
 slug: Web/JavaScript/Reference/Global_Objects/Array/flat
 l10n:
   sourceCommit: b7ca46c94631967ecd9ce0fe36579be334a01275
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 **`flat()`** 메서드는 모든 하위 배열 요소가 지정된 깊이까지 재귀적으로 연결된 새 배열을 생성합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.flat()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.flat()")}}
 
 ```js interactive-example
 const arr1 = [0, 1, 2, [3, 4]];

--- a/files/ko/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.flatMap()
+short-title: flatMap()
 slug: Web/JavaScript/Reference/Global_Objects/Array/flatMap
 l10n:
   sourceCommit: b7ca46c94631967ecd9ce0fe36579be334a01275
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 **`flatMap()`** 메서드는 배열의 각 요소에 주어진 콜백 함수를 적용한 다음 그 결과를 한 단계씩 평탄화하여 형성된 새 배열을 반환합니다. 이 메서드는 {{jsxref("Array.prototype.map","map()")}} 뒤에 깊이 1의 {{jsxref("Array.prototype.flat","flat()")}}을 붙이는 것(`arr.map(...args).flat()`)과 동일하지만, 두 메서드를 따로 호출하는 것보다 약간 더 효율적입니다.
 
-{{InteractiveExample("JavaScript Demo: Array.flatMap()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.flatMap()", "shorter")}}
 
 ```js interactive-example
 const arr1 = [1, 2, 1];

--- a/files/ko/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/foreach/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.forEach()
+short-title: forEach()
 slug: Web/JavaScript/Reference/Global_Objects/Array/forEach
 l10n:
   sourceCommit: 27180875516cc311342e74b596bfb589b7211e0c
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 **`forEach()`** 메서드는 각 배열 요소에 대해 제공된 함수를 한 번씩 실행합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.forEach()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.forEach()")}}
 
 ```js interactive-example
 const array1 = ["a", "b", "c"];

--- a/files/ko/web/javascript/reference/global_objects/array/from/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/from/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.from()
+short-title: from()
 slug: Web/JavaScript/Reference/Global_Objects/Array/from
 l10n:
   sourceCommit: fb85334ffa4a2c88d209b1074909bee0e0abd57a

--- a/files/ko/web/javascript/reference/global_objects/array/fromasync/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/fromasync/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.fromAsync()
+short-title: fromAsync()
 slug: Web/JavaScript/Reference/Global_Objects/Array/fromAsync
 l10n:
   sourceCommit: e01fd6206ce2fad2fe09a485bb2d3ceda53a62de

--- a/files/ko/web/javascript/reference/global_objects/array/includes/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/includes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.includes()
+short-title: includes()
 slug: Web/JavaScript/Reference/Global_Objects/Array/includes
 l10n:
   sourceCommit: e01fd6206ce2fad2fe09a485bb2d3ceda53a62de
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 **`includes()`** 메서드는 배열의 항목에 특정 값이 포함되어 있는지를 판단하여 적절히 `true` 또는 `false`를 반환합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.includes()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.includes()")}}
 
 ```js interactive-example
 const array1 = [1, 2, 3];

--- a/files/ko/web/javascript/reference/global_objects/array/indexof/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/indexof/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.indexOf()
+short-title: indexOf()
 slug: Web/JavaScript/Reference/Global_Objects/Array/indexOf
 l10n:
   sourceCommit: d9e66eca59d82c65166c65e7946332650da8f48f
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 **`indexOf()`** 메서드는 배열에서 주어진 요소를 찾을 수 있는 첫 번째 인덱스를 반환하고, 찾을 수 없는 경우 -1을 반환합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.indexOf()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.indexOf()")}}
 
 ```js interactive-example
 const beasts = ["ant", "bison", "camel", "duck", "bison"];

--- a/files/ko/web/javascript/reference/global_objects/array/isarray/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/isarray/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.isArray()
+short-title: isArray()
 slug: Web/JavaScript/Reference/Global_Objects/Array/isArray
 l10n:
   sourceCommit: e01fd6206ce2fad2fe09a485bb2d3ceda53a62de

--- a/files/ko/web/javascript/reference/global_objects/array/join/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/join/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.join()
+short-title: join()
 slug: Web/JavaScript/Reference/Global_Objects/Array/join
 l10n:
   sourceCommit: d9e66eca59d82c65166c65e7946332650da8f48f
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 **`Join()`** 메서드는 배열의 모든 요소를 쉼표나 지정된 구분 문자열로 구분하여 연결한 새 문자열을 만들어 반환합니다. 배열에 항목이 하나만 있는 경우, 해당 항목은 구분 기호를 사용하지 않고 반환됩니다.
 
-{{InteractiveExample("JavaScript Demo: Array.join()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.join()")}}
 
 ```js interactive-example
 const elements = ["Fire", "Air", "Water"];

--- a/files/ko/web/javascript/reference/global_objects/array/keys/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/keys/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.keys()
+short-title: keys()
 slug: Web/JavaScript/Reference/Global_Objects/Array/keys
 l10n:
   sourceCommit: 6fbdb78c1362fae31fbd545f4b2d9c51987a6bca
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 **`keys()`** 메서드는 배열의 각 인덱스에 대한 키를 포함하는 새로운 [배열 반복자](/ko/docs/Web/JavaScript/Reference/Global_Objects/Iterator) 객체를 반환합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.keys()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.keys()")}}
 
 ```js interactive-example
 const array1 = ["a", "b", "c"];

--- a/files/ko/web/javascript/reference/global_objects/array/lastindexof/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/lastindexof/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.lastIndexOf()
+short-title: lastIndexOf()
 slug: Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf
 l10n:
   sourceCommit: fb85334ffa4a2c88d209b1074909bee0e0abd57a
@@ -9,7 +10,7 @@ l10n:
 
 {{jsxref("Array")}} 인스턴스의 `lastIndexOf()` 메서드는 배열에서 특정 요소를 찾을 수 있는 마지막 인덱스를 반환하거나, 해당 요소가 없으면 `-1`을 반환합니다. 배열은 `fromIndex`에서 시작하여 역방향으로 검색됩니다.
 
-{{InteractiveExample("JavaScript Demo: Array.lastIndexOf()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.lastIndexOf()")}}
 
 ```js interactive-example
 const animals = ["Dodo", "Tiger", "Penguin", "Dodo"];

--- a/files/ko/web/javascript/reference/global_objects/array/length/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/length/index.md
@@ -1,5 +1,6 @@
 ---
-title: Array.length
+title: "Array: length"
+short-title: length
 slug: Web/JavaScript/Reference/Global_Objects/Array/length
 l10n:
   sourceCommit: 5c3c25fd4f2fbd7a5f01727a65c2f70d73f1880a

--- a/files/ko/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/map/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.map()
+short-title: map()
 slug: Web/JavaScript/Reference/Global_Objects/Array/map
 l10n:
   sourceCommit: 57375b77984037c614982a9327bc96101824db89
@@ -11,7 +12,7 @@ l10n:
 호출한 배열의 모든 요소에 주어진 함수를 호출한 결과로 채운
 새로운 배열을 생성합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.map()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.map()")}}
 
 ```js interactive-example
 const array1 = [1, 4, 9, 16];

--- a/files/ko/web/javascript/reference/global_objects/array/of/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/of/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.of()
+short-title: of()
 slug: Web/JavaScript/Reference/Global_Objects/Array/of
 l10n:
   sourceCommit: e01fd6206ce2fad2fe09a485bb2d3ceda53a62de

--- a/files/ko/web/javascript/reference/global_objects/array/pop/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/pop/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.pop()
+short-title: pop()
 slug: Web/JavaScript/Reference/Global_Objects/Array/pop
 l10n:
   sourceCommit: e01fd6206ce2fad2fe09a485bb2d3ceda53a62de
@@ -11,7 +12,7 @@ l10n:
 배열에서 마지막 요소를 제거하고 그 요소를 반환합니다.
 이 메서드는 배열의 길이를 변경합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.pop()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.pop()")}}
 
 ```js interactive-example
 const plants = ["broccoli", "cauliflower", "cabbage", "kale", "tomato"];

--- a/files/ko/web/javascript/reference/global_objects/array/push/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/push/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.push()
+short-title: push()
 slug: Web/JavaScript/Reference/Global_Objects/Array/push
 l10n:
   sourceCommit: 2d337c37fb3ae7d7a32b5c372366bc7f97ff2602
@@ -10,7 +11,7 @@ l10n:
 {{jsxref("Array")}} 인스턴스의 **`push()`** 메서드는 배열의 끝에
 명시된 요소를 추가하고 배열의 새로운 길이를 반환합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.push()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.push()")}}
 
 ```js interactive-example
 const animals = ["pigs", "goats", "sheep"];

--- a/files/ko/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/reduce/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.reduce()
+short-title: reduce()
 slug: Web/JavaScript/Reference/Global_Objects/Array/reduce
 ---
 
@@ -7,7 +8,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/reduce
 
 **`reduce()`** 메서드는 배열의 각 요소에 대해 주어진 리듀서 (reducer) 함수를 실행하고, 하나의 결과값을 반환합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.reduce()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.reduce()")}}
 
 ```js interactive-example
 const array1 = [1, 2, 3, 4];

--- a/files/ko/web/javascript/reference/global_objects/array/reduceright/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/reduceright/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.reduceRight()
+short-title: reduceRight()
 slug: Web/JavaScript/Reference/Global_Objects/Array/reduceRight
 ---
 
@@ -7,7 +8,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/reduceRight
 
 **`reduceRight()`** 메서드는 누적기에 대해 함수를 적용하고 배열의 각 값 (오른쪽에서 왼쪽으로)은 값을 단일 값으로 줄여야합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.reduceRight()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.reduceRight()")}}
 
 ```js interactive-example
 const array1 = [

--- a/files/ko/web/javascript/reference/global_objects/array/reverse/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/reverse/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.reverse()
+short-title: reverse()
 slug: Web/JavaScript/Reference/Global_Objects/Array/reverse
 ---
 
@@ -7,7 +8,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/reverse
 
 **`reverse()`** 메서드는 배열의 순서를 반전합니다. 첫 번째 요소는 마지막 요소가 되며 마지막 요소는 첫 번째 요소가 됩니다.
 
-{{InteractiveExample("JavaScript Demo: Array.reverse()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.reverse()")}}
 
 ```js interactive-example
 const array1 = ["one", "two", "three"];

--- a/files/ko/web/javascript/reference/global_objects/array/shift/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/shift/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.shift()
+short-title: shift()
 slug: Web/JavaScript/Reference/Global_Objects/Array/shift
 ---
 
@@ -7,7 +8,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/shift
 
 **`shift()`** 메서드는 배열에서 첫 번째 요소를 제거하고, 제거된 요소를 반환합니다. 이 메서드는 배열의 길이를 변하게 합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.shift()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.shift()")}}
 
 ```js interactive-example
 const array1 = [1, 2, 3];

--- a/files/ko/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/slice/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.slice()
+short-title: slice()
 slug: Web/JavaScript/Reference/Global_Objects/Array/slice
 ---
 
@@ -7,7 +8,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/slice
 
 **`slice()`** 메서드는 어떤 배열의 `begin` 부터 `end` 까지(`end` 미포함)에 대한 얕은 복사본을 새로운 배열 객체로 반환합니다. 원본 배열은 바뀌지 않습니다.
 
-{{InteractiveExample("JavaScript Demo: Array.slice()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.slice()")}}
 
 ```js interactive-example
 const animals = ["ant", "bison", "camel", "duck", "elephant"];

--- a/files/ko/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/some/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.some()
+short-title: some()
 slug: Web/JavaScript/Reference/Global_Objects/Array/some
 ---
 
@@ -7,7 +8,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/some
 
 **`some()`** 메서드는 배열 안의 어떤 요소라도 주어진 판별 함수를 적어도 하나라도 통과하는지 테스트합니다. 만약 배열에서 주어진 함수가 true을 반환하면 true를 반환합니다. 그렇지 않으면 false를 반환합니다. 이 메서드는 배열을 변경하지 않습니다.
 
-{{InteractiveExample("JavaScript Demo: Array.some()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.some()")}}
 
 ```js interactive-example
 const array = [1, 2, 3, 4, 5];

--- a/files/ko/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/sort/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.sort()
+short-title: sort()
 slug: Web/JavaScript/Reference/Global_Objects/Array/sort
 ---
 
@@ -9,7 +10,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/sort
 
 정렬 속도와 복잡도는 각 구현방식에 따라 다를 수 있습니다.
 
-{{InteractiveExample("JavaScript Demo: Array.sort()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.sort()")}}
 
 ```js interactive-example
 const months = ["March", "Jan", "Feb", "Dec"];

--- a/files/ko/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/splice/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.splice()
+short-title: splice()
 slug: Web/JavaScript/Reference/Global_Objects/Array/splice
 ---
 
@@ -7,7 +8,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/splice
 
 **`splice()`** 메서드는 배열의 기존 요소를 삭제 또는 교체하거나 새 요소를 추가하여 배열의 내용을 변경합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.splice()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.splice()")}}
 
 ```js interactive-example
 const months = ["Jan", "March", "April", "June"];

--- a/files/ko/web/javascript/reference/global_objects/array/symbol.iterator/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/symbol.iterator/index.md
@@ -1,14 +1,14 @@
 ---
-title: Array.prototype[@@iterator]()
+title: Array.prototype[Symbol.iterator]()
+short-title: "[Symbol.iterator]()"
 slug: Web/JavaScript/Reference/Global_Objects/Array/Symbol.iterator
-original_slug: Web/JavaScript/Reference/Global_Objects/Array/@@iterator
 l10n:
   sourceCommit: 27180875516cc311342e74b596bfb589b7211e0c
 ---
 
 {{JSRef}}
 
-{{jsxref("Array")}} 인스턴스의 **`[@@iterator]()`** 메서드는 [순회 가능 프로토콜](/ko/docs/Web/JavaScript/Reference/Iteration_protocols)을 구현하며, 배열을 [전개 구문](/ko/docs/Web/JavaScript/Reference/Operators/Spread_syntax)이나 {{jsxref("Statements/for...of", "for...of")}} 루프와 같이 순회 가능을 기대하는 대부분의 구문에서 사용할 수 있도록 합니다. 이 메서드는 배열의 각 인덱스 값을 산출하는 [배열 순회자 객체](/ko/docs/Web/JavaScript/Reference/Global_Objects/Iterator)를 반환합니다.
+{{jsxref("Array")}} 인스턴스의 **`[Symbol.iterator]()`** 메서드는 [순회 가능 프로토콜](/ko/docs/Web/JavaScript/Reference/Iteration_protocols)을 구현하며, 배열을 [전개 구문](/ko/docs/Web/JavaScript/Reference/Operators/Spread_syntax)이나 {{jsxref("Statements/for...of", "for...of")}} 루프와 같이 순회 가능을 기대하는 대부분의 구문에서 사용할 수 있도록 합니다. 이 메서드는 배열의 각 인덱스 값을 산출하는 [배열 순회자 객체](/ko/docs/Web/JavaScript/Reference/Global_Objects/Iterator)를 반환합니다.
 
 이 속성의 초기 값은 {{jsxref("Array.prototype.values")}} 속성의 초기 값과 동일한 함수 객체입니다.
 
@@ -45,7 +45,7 @@ array[Symbol.iterator]()
 
 ### for...of 루프를 사용한 순회
 
-이 메서드를 직접 호출할 필요는 거의 없습니다. `@@iterator` 메서드가 있으면 배열을 [순회 가능](/ko/docs/Web/JavaScript/Reference/Iteration_protocols#순회_가능_프로토콜)으로 만들 수 있으며, `for...of` 루프와 같은 순회 구문은 이 메서드를 자동으로 호출하여 반복할 순회자를 얻습니다.
+이 메서드를 직접 호출할 필요는 거의 없습니다. `[Symbol.iterator]` 메서드가 있으면 배열을 [순회 가능](/ko/docs/Web/JavaScript/Reference/Iteration_protocols#순회_가능_프로토콜)으로 만들 수 있으며, `for...of` 루프와 같은 순회 구문은 이 메서드를 자동으로 호출하여 반복할 순회자를 얻습니다.
 
 #### HTML
 
@@ -67,7 +67,7 @@ for (const letter of arr) {
 
 #### 결과
 
-{{EmbedLiveSample('for...of_루프를_사용한_순회', '', '')}}
+{{EmbedLiveSample("Iteration_using_for...of_loop", "", "")}}
 
 ### 순회자를 수동으로 부르기
 
@@ -125,13 +125,13 @@ logIterable(123);
 
 ## 같이 보기
 
-- [`core-js`의 `Array.prototype[@@iterator]` 폴리필](https://github.com/zloirock/core-js#ecmascript-array)
+- [`core-js`의 `Array.prototype[Symbol.iterator]` 폴리필](https://github.com/zloirock/core-js#ecmascript-array)
 - [인덱스된 컬렉션](/ko/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array")}}
 - {{jsxref("Array.prototype.keys()")}}
 - {{jsxref("Array.prototype.entries()")}}
 - {{jsxref("Array.prototype.values()")}}
-- [`TypedArray.prototype[@@iterator]()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/Symbol.iterator)
-- [`String.prototype[@@iterator]()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/Symbol.iterator)
+- [`TypedArray.prototype[Symbol.iterator]()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/Symbol.iterator)
+- [`String.prototype[Symbol.iterator]()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/Symbol.iterator)
 - {{jsxref("Symbol.iterator")}}
 - [순회 프로토콜](/ko/docs/Web/JavaScript/Reference/Iteration_protocols)

--- a/files/ko/web/javascript/reference/global_objects/array/symbol.species/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/symbol.species/index.md
@@ -1,17 +1,17 @@
 ---
-title: Array[@@species]
+title: Array[Symbol.species]
+short-title: "[Symbol.species]"
 slug: Web/JavaScript/Reference/Global_Objects/Array/Symbol.species
-original_slug: Web/JavaScript/Reference/Global_Objects/Array/@@species
 l10n:
   sourceCommit: 34a34bee83fb4accf073ebc0c8cfc8eff956dc9b
 ---
 
 {{JSRef}}
 
-**`Array[@@species]`** 정적 접근자 속성은 배열 메서드에서 반환 값을 구성하는 데 사용되는 생성자를 반환합니다.
+**`Array[Symbol.species]`** 정적 접근자 속성은 배열 메서드에서 반환 값을 구성하는 데 사용되는 생성자를 반환합니다.
 
 > [!WARNING]
-> `@@species`가 존재하면 임의 코드가 실행될 수 있어 보안 취약점이 발생할 수 있습니다. 또한 특정 최적화를 훨씬 더 어렵게 만듭니다. 엔진 구현자는 [이 기능을 제거할지 검토](https://github.com/tc39/proposal-rm-builtin-subclassing)하고 있습니다. 가능하면 이 기능에 의존하지 마십시오. {{jsxref("Array/toReversed", "toReversed()")}}와 같은 최신 배열 메서드는 `@@species`를 사용하지 않으며, 항상 새 `Array` 기반 클래스 인스턴스를 반환합니다.
+> `[Symbol.species]`가 존재하면 임의 코드가 실행될 수 있어 보안 취약점이 발생할 수 있습니다. 또한 특정 최적화를 훨씬 더 어렵게 만듭니다. 엔진 구현자는 [이 기능을 제거할지 검토](https://github.com/tc39/proposal-rm-builtin-subclassing)하고 있습니다. 가능하면 이 기능에 의존하지 마십시오. {{jsxref("Array/toReversed", "toReversed()")}}와 같은 최신 배열 메서드는 `[Symbol.species]`를 사용하지 않으며, 항상 새 `Array` 기반 클래스 인스턴스를 반환합니다.
 
 ## 구문
 
@@ -21,11 +21,11 @@ Array[Symbol.species]
 
 ### 반환 값
 
-`get @@species`가 호출된 생성자(`this`)의 값입니다. 반환값은 새 배열을 생성하는 배열 메서드에서 반환값을 구성하는 데 사용됩니다.
+`get [Symbol.species]`가 호출된 생성자(`this`)의 값입니다. 반환값은 새 배열을 생성하는 배열 메서드에서 반환값을 구성하는 데 사용됩니다.
 
 ## 설명
 
-`@@species` 접근자 속성은 `Array` 객체에 대한 기본 생성자를 반환합니다. 하위 클래스 생성자가 이를 재정의하여 생성자 할당을 변경할 수 있습니다. 기본 구현은 기본적으로 다음과 같습니다.
+`[Symbol.species]` 접근자 속성은 `Array` 객체에 대한 기본 생성자를 반환합니다. 하위 클래스 생성자가 이를 재정의하여 생성자 할당을 변경할 수 있습니다. 기본 구현은 기본적으로 다음과 같습니다.
 
 ```js
 // 설명을 위한 가상의 내부 구현
@@ -36,14 +36,14 @@ class Array {
 }
 ```
 
-이 다형성 구현으로 인해 파생된 하위 클래스의 `@@species`도 기본적으로 생성자 자체를 반환합니다.
+이 다형성 구현으로 인해 파생된 하위 클래스의 `[Symbol.species]`도 기본적으로 생성자 자체를 반환합니다.
 
 ```js
 class SubArray extends Array {}
 SubArray[Symbol.species] === SubArray; // true
 ```
 
-기존 배열을 변경하지 않고 새 배열 인스턴스를 반환하는 배열 메서드(예: [`filter()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/filter), [`map()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/map))를 호출하면, 배열의 `constructor[@@species]`에 접근합니다. 반환된 생성자는 배열 메서드의 반환값을 구성하는 데 사용됩니다. 이렇게 하면 배열 메서드가 배열과 관련이 없는 객체를 반환하도록 만드는 것이 기술적으로 가능합니다.
+기존 배열을 변경하지 않고 새 배열 인스턴스를 반환하는 배열 메서드(예: [`filter()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/filter), [`map()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/map))를 호출하면, 배열의 `constructor[Symbol.species]`에 접근합니다. 반환된 생성자는 배열 메서드의 반환값을 구성하는 데 사용됩니다. 이렇게 하면 배열 메서드가 배열과 관련이 없는 객체를 반환하도록 만드는 것이 기술적으로 가능합니다.
 
 ```js
 class NotAnArray {
@@ -63,7 +63,7 @@ arr.concat([1, 2]); // NotAnArray { '0': 0, '1': 1, '2': 2, '3': 1, '4': 2, leng
 
 ### 일반 객체의 species
 
-`@@species` 속성은 기본 생성자 함수, 즉 `Array`의 `Array` 생성자를 반환합니다.
+`[Symbol.species]` 속성은 기본 생성자 함수, 즉 `Array`의 `Array` 생성자를 반환합니다.
 
 ```js
 Array[Symbol.species]; // [Function: Array]
@@ -92,7 +92,7 @@ class MyArray extends Array {
 
 ## 같이 보기
 
-- [`Array[@@species]` 폴리필과 `core-js`의 영향을 받는 모든 `Array` 메서드에서의 `@@species` 지원](https://github.com/zloirock/core-js#ecmascript-array)
+- [`Array[Symbol.species]` 폴리필과 `core-js`의 영향을 받는 모든 `Array` 메서드에서의 `[Symbol.species]` 지원](https://github.com/zloirock/core-js#ecmascript-array)
 - [인덱스된 컬렉션](/ko/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array")}}
 - {{jsxref("Symbol.species")}}

--- a/files/ko/web/javascript/reference/global_objects/array/symbol.unscopables/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/symbol.unscopables/index.md
@@ -1,14 +1,14 @@
 ---
-title: Array.prototype[@@unscopables]
+title: Array.prototype[Symbol.unscopables]
+short-title: "[Symbol.unscopables]"
 slug: Web/JavaScript/Reference/Global_Objects/Array/Symbol.unscopables
-original_slug: Web/JavaScript/Reference/Global_Objects/Array/@@unscopables
 l10n:
   sourceCommit: 34a34bee83fb4accf073ebc0c8cfc8eff956dc9b
 ---
 
 {{JSRef}}
 
-`Array.prototype`의 **`@@unscopable`** 데이터 속성은 모든 {{jsxref("Array")}} 인스턴스에서 공유됩니다. 여기에는 ES2015 버전 이전에는 ECMAScript 표준에 포함되지 않았고, [`with`](/ko/docs/Web/JavaScript/Reference/Statements/with) 문 바인딩을 위해 무시되는 속성 이름이 포함되어 있습니다.
+`Array.prototype`의 **`[Symbol.unscopables]`** 데이터 속성은 모든 {{jsxref("Array")}} 인스턴스에서 공유됩니다. 여기에는 ES2015 버전 이전에는 ECMAScript 표준에 포함되지 않았고, [`with`](/ko/docs/Web/JavaScript/Reference/Statements/with) 문 바인딩을 위해 무시되는 속성 이름이 포함되어 있습니다.
 
 ## 값
 
@@ -37,7 +37,7 @@ l10n:
 - [`toSpliced()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced)
 - [`values()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/values)
 
-`Array.prototype[@@unscopables]`는 위의 모든 속성 이름과 `true` 값만 포함하는 빈 객체입니다. 이 [객체의 프로토타입은 `null`](/ko/docs/Web/JavaScript/Reference/Global_Objects/Object#null_프로토타입_객체)이므로 실수로 [`toString`](/ko/docs/Web/JavaScript/Reference/Global_Objects/Object/toString)과 같은 `Object.prototype` 속성은 범위 지정이 불가능해지지 않으며, `with` 문 내의 `toString()`은 배열에서 계속 호출됩니다.
+`Array.prototype[Symbol.unscopables]`는 위의 모든 속성 이름과 `true` 값만 포함하는 빈 객체입니다. 이 [객체의 프로토타입은 `null`](/ko/docs/Web/JavaScript/Reference/Global_Objects/Object#null_프로토타입_객체)이므로 실수로 [`toString`](/ko/docs/Web/JavaScript/Reference/Global_Objects/Object/toString)과 같은 `Object.prototype` 속성은 범위 지정이 불가능해지지 않으며, `with` 문 내의 `toString()`은 배열에서 계속 호출됩니다.
 
 객체에 범위 지정 불가능 속성을 설정하는 방법은 {{jsxref("Symbol.unscopables")}}를 참조하세요.
 
@@ -53,9 +53,9 @@ with (Array.prototype) {
 }
 ```
 
-ECMAScript 2015에 {{jsxref("Array.prototype.keys()")}} 메서드가 도입되었을 때, `@@unscopables` 데이터 속성이 함께 도입되지 않았다면, JavaScript 런타임이 `keys`를 예제 코드에 정의된 `keys` 배열이 아닌 {{jsxref("Array.prototype.keys()")}} 메서드로 해석하기 때문에 해당 `keys.push('something')` 호출이 중단될 수 있었습니다.
+ECMAScript 2015에 {{jsxref("Array.prototype.keys()")}} 메서드가 도입되었을 때, `[Symbol.unscopables]` 데이터 속성이 함께 도입되지 않았다면, JavaScript 런타임이 `keys`를 예제 코드에 정의된 `keys` 배열이 아닌 {{jsxref("Array.prototype.keys()")}} 메서드로 해석하기 때문에 해당 `keys.push('something')` 호출이 중단될 수 있었습니다.
 
-따라서 `Array.prototype`에 대한 `@@unscopables` 데이터 속성을 사용하면 ECMAScript 2015에 도입된 `Array` 속성이 `with` 문 바인딩 목적으로 무시되므로 ECMAScript 2015 이전에 작성된 코드가 중단되지 않고 예상대로 계속 작동할 수 있습니다.
+따라서 `Array.prototype`에 대한 `[Symbol.unscopables]` 데이터 속성을 사용하면 ECMAScript 2015에 도입된 `Array` 속성이 `with` 문 바인딩 목적으로 무시되므로 ECMAScript 2015 이전에 작성된 코드가 중단되지 않고 예상대로 계속 작동할 수 있습니다.
 
 ## 명세서
 
@@ -67,7 +67,7 @@ ECMAScript 2015에 {{jsxref("Array.prototype.keys()")}} 메서드가 도입되�
 
 ## 같이 보기
 
-- [`core-js`의 `Array.prototype[@@unscopables]` 폴리필](https://github.com/zloirock/core-js#ecmascript-array)
+- [`core-js`의 `Array.prototype[Symbol.unscopables]` 폴리필](https://github.com/zloirock/core-js#ecmascript-array)
 - [인덱스된 콜렉션](/ko/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array")}}
 - {{jsxref("Statements/with", "with")}}

--- a/files/ko/web/javascript/reference/global_objects/array/tolocalestring/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/tolocalestring/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.toLocaleString()
+short-title: toLocaleString()
 slug: Web/JavaScript/Reference/Global_Objects/Array/toLocaleString
 l10n:
   sourceCommit: 9645d14f12d9b93da98daaf25a443bb6cac3f2a6

--- a/files/ko/web/javascript/reference/global_objects/array/toreversed/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/toreversed/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.toReversed()
+short-title: toReversed()
 slug: Web/JavaScript/Reference/Global_Objects/Array/toReversed
 l10n:
   sourceCommit: e01fd6206ce2fad2fe09a485bb2d3ceda53a62de

--- a/files/ko/web/javascript/reference/global_objects/array/tosorted/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/tosorted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.toSorted()
+short-title: toSorted()
 slug: Web/JavaScript/Reference/Global_Objects/Array/toSorted
 l10n:
   sourceCommit: e46c58e6ed948e8c35c206762eb14a2e68616ed1

--- a/files/ko/web/javascript/reference/global_objects/array/tospliced/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/tospliced/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.toSpliced()
+short-title: toSpliced()
 slug: Web/JavaScript/Reference/Global_Objects/Array/toSpliced
 l10n:
   sourceCommit: 88d71e500938fa8ca969fe4fe3c80a5abe23d767

--- a/files/ko/web/javascript/reference/global_objects/array/tostring/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/tostring/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.toString()
+short-title: toString()
 slug: Web/JavaScript/Reference/Global_Objects/Array/toString
 l10n:
   sourceCommit: 5c3c25fd4f2fbd7a5f01727a65c2f70d73f1880a
@@ -10,7 +11,7 @@ l10n:
 {{jsxref("Array")}} 인스턴스의 **`toString()`** 메서드는
 지정된 배열 및 그 요소를 나타내는 문자열을 반환합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.toString()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.toString()", "shorter")}}
 
 ```js interactive-example
 const array1 = [1, 2, "a", "1a"];

--- a/files/ko/web/javascript/reference/global_objects/array/unshift/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/unshift/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.unshift()
+short-title: unshift()
 slug: Web/JavaScript/Reference/Global_Objects/Array/unshift
 ---
 
@@ -7,7 +8,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/unshift
 
 **`unshift()`** 메서드는 새로운 요소를 배열의 맨 앞쪽에 추가하고, 새로운 길이를 반환합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.unshift()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.unshift()")}}
 
 ```js interactive-example
 const array1 = [1, 2, 3];

--- a/files/ko/web/javascript/reference/global_objects/array/values/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/values/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.values()
+short-title: values()
 slug: Web/JavaScript/Reference/Global_Objects/Array/values
 ---
 
@@ -7,7 +8,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/values
 
 **`values()`** 메서드는 배열에서 각 인덱스에 대한 값을 순회하는 _array [iterator](/ko/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol)_ 객체를 반환합니다.
 
-{{InteractiveExample("JavaScript Demo: Array.values()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.values()")}}
 
 ```js interactive-example
 const array1 = ["a", "b", "c"];

--- a/files/ko/web/javascript/reference/global_objects/array/with/index.md
+++ b/files/ko/web/javascript/reference/global_objects/array/with/index.md
@@ -1,5 +1,6 @@
 ---
 title: Array.prototype.with()
+short-title: with()
 slug: Web/JavaScript/Reference/Global_Objects/Array/with
 l10n:
   sourceCommit: 85d7482697cc2bf407c58e809a2a754180d6714c


### PR DESCRIPTION
- `short-title` 추가(사이드바에서 예를 들어 `Array.prototype.at()` 대신 `at()`형태로 축약해서 보임. `ja`는 이미 적용 완료)
- InteractiveExample 수정
- symbol 관련 메서드 일부 긴급 수정(@@ 표기)
- Array.prototype.every 일부 수정
