### PR TITLE
[zn-cn] correct incorrect Chinese translation of sort

### DIFF
--- a/files/zh-cn/web/api/urlsearchparams/sort/index.md
+++ b/files/zh-cn/web/api/urlsearchparams/sort/index.md
@@ -29,7 +29,7 @@ sort()
 // 创建一个测试用的 URLSearchParams 对象
 const searchParams = new URLSearchParams("c=4&a=2&b=3&a=1");
 
-// 对键/值对进行派寻
+// 对键/值对进行排序
 searchParams.sort();
 
 // 显示排序后的查询字符串

--- a/files/zh-cn/web/api/urlsearchparams/sort/index.md
+++ b/files/zh-cn/web/api/urlsearchparams/sort/index.md
@@ -2,12 +2,12 @@
 title: URLSearchParams：sort() 方法
 slug: Web/API/URLSearchParams/sort
 l10n:
-  sourceCommit: 4de6f76bbfd76229db78ffb7d52cf6b4cb9f31f8
+  sourceCommit: 3e097148b4c6cb9c6d8824275599f855ca63827b
 ---
 
 {{ApiRef("URL API")}} {{AvailableInWorkers}}
 
-**`URLSearchParams.sort()`** 方法对包含在此对象中的所有键/值对进行排序，并返回 `undefined`。排序顺序是根据键的 Unicode 码位。该方法使用稳定的排序算法（即，将保留具有相等键的键/值对之间的相对顺序）。
+**`URLSearchParams.sort()`** 方法对包含在此对象中的所有键/值对进行排序，并返回 `undefined`。键/值对按照键的 {{glossary("UTF-16", "UTF-16 码位")}}值排序。该方法使用稳定的排序算法（即，将保留具有相等键的键/值对之间的相对顺序）。
 
 ## 语法
 


### PR DESCRIPTION
fix #29764 

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

correct incorrect Chinese translation of sort

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

correct incorrect Chinese translation of sort

“派寻” -> "排序"

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

“派寻” -> "排序"

https://developer.mozilla.org/zh-CN/docs/Web/API/URLSearchParams/sort#%E7%A4%BA%E4%BE%8B

<img width="819" height="385" alt="Image" src="https://github.com/user-attachments/assets/1a3c9a64-203f-4f85-9816-0f8e8715fb05" />

对应英文版

https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/sort#examples

<img width="799" height="403" alt="Image" src="https://github.com/user-attachments/assets/c5db8abc-6d6f-47ce-89f5-f535f744d7c9" />

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->


