### PR TITLE
[ko] Web/API/BeforeUnloadEvent  - 신규 번역

### DIFF
--- a/files/ko/web/api/beforeunloadevent/index.md
+++ b/files/ko/web/api/beforeunloadevent/index.md
@@ -18,7 +18,7 @@ l10n:
 _부모인 {{DOMxRef("Event")}}로부터 속성을 상속받습니다._
 
 - {{domxref("BeforeUnloadEvent.returnValue", "returnValue")}} {{Deprecated_Inline}}
-  - : [참 같은 값(Truthy)](/ko/docs/Glossary/Truthy)  값으로 설정하면, 사용자가 페이지를 닫거나 새로 고치려고 할 때 페이지를 떠나겠는지 확인하는 브라우저 제어 확인 대화 상자가 표시됩니다. 이 방식은 레거시 기능으로 권장되는 방법은 `event.preventDefault()`를 호출하여 대화 상자를 트리거하고, 레거시 사례를 지원하기 위해 `returnValue` 도 함께 설정하는 것입니다.
+  - : [참 같은 값(Truthy)](/ko/docs/Glossary/Truthy)  값으로 설정하면, 사용자가 페이지를 닫거나 새로 고치려고 할 때 페이지를 떠나겠는지 확인하는 브라우저 제어 확인 대화 상자가 표시됩니다. 이 방식은 레거시 기능으로 권장되는 방법은 `event.preventDefault()`를 호출하여 대화 상자를 트리거하는 동시에 레거시 환경 호환을 위해 `returnValue` 도 함께 설정하는 것입니다.
 
 ## 메서드
 

--- a/files/ko/web/api/beforeunloadevent/index.md
+++ b/files/ko/web/api/beforeunloadevent/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{APIRef("HTML DOM")}}
 
-**`BeforeUnloadEvent`** 인터페이스는 {{domxref("Window/beforeunload_event", "beforeunload")}} 이벤트의 이벤트 객체를 나타냅니다. 이 이벤트는 현재 창, 그 안에 포함된 문서, 그리고 관련 리소스들이 언로드(해제)되기 직전에 발생합니다.
+**`BeforeUnloadEvent`** 인터페이스는 {{domxref("Window/beforeunload_event", "beforeunload")}} 이벤트의 이벤트 객체를 나타냅니다. 이 이벤트는 현재 창과 그 안에 포함된 문서 및 관련 리소스가 언로드되기 직전에 발생합니다.
 
 이 이벤트를 사용하는 방법에 대한 자세한 안내는 {{domxref("Window/beforeunload_event", "beforeunload")}} 이벤트 참고서를 확인하세요.
 
@@ -18,7 +18,7 @@ l10n:
 _부모인 {{DOMxRef("Event")}}로부터 속성을 상속받습니다._
 
 - {{domxref("BeforeUnloadEvent.returnValue", "returnValue")}} {{Deprecated_Inline}}
-  - : [참 같은 값(Truthy)](/ko/docs/Glossary/Truthy)  값으로 설정하면, 사용자가 페이지를 닫거나 새로 고치려고 할 때 페이지를 떠나겠는지 확인하는 브라우저 제어 확인 대화 상자가 표시됩니다. 이 방식은 레거시 기능으로 권장되는 방법은 `event.preventDefault()`를 호출하여 대화 상자를 트리거하는 동시에 레거시 환경 호환을 위해 `returnValue` 도 함께 설정하는 것입니다.
+  - : [참 같은 값(Truthy)](/ko/docs/Glossary/Truthy) 값으로 설정하면, 사용자가 페이지를 닫거나 새로 고치려고 할 때 페이지를 떠나겠는지 확인하는 브라우저 제어 확인 대화 상자가 표시됩니다. 이 방식은 레거시 기능으로 권장되는 방법은 `event.preventDefault()` 를 호출하여 대화 상자를 트리거하는 동시에 레거시 환경 호환을 위해 `returnValue` 도 함께 설정하는 것입니다.
 
 ## 메서드
 

--- a/files/ko/web/api/beforeunloadevent/index.md
+++ b/files/ko/web/api/beforeunloadevent/index.md
@@ -1,0 +1,37 @@
+---
+title: BeforeUnloadEvent
+slug: Web/API/BeforeUnloadEvent
+l10n:
+  sourceCommit: a7265fc3effa7c25b9997135104370c057a65293
+---
+
+{{APIRef("HTML DOM")}}
+
+**`BeforeUnloadEvent`** 인터페이스는 {{domxref("Window/beforeunload_event", "beforeunload")}} 이벤트의 이벤트 객체를 나타냅니다. 이 이벤트는 현재 창, 그 안에 포함된 문서, 그리고 관련 리소스들이 언로드(해제)되기 직전에 발생합니다.
+
+이 이벤트를 사용하는 방법에 대한 자세한 안내는 {{domxref("Window/beforeunload_event", "beforeunload")}} 이벤트 참고서를 확인하세요.
+
+{{InheritanceDiagram}}
+
+## 속성
+
+_부모인 {{DOMxRef("Event")}}로부터 속성을 상속받습니다._
+
+- {{domxref("BeforeUnloadEvent.returnValue", "returnValue")}} {{Deprecated_Inline}}
+  - : [참 같은 값(Truthy)](/ko/docs/Glossary/Truthy)  값으로 설정하면, 사용자가 페이지를 닫거나 새로 고치려고 할 때 페이지를 떠나겠는지 확인하는 브라우저 제어 확인 대화 상자가 표시됩니다. 이 방식은 레거시 기능으로 권장되는 방법은 `event.preventDefault()`를 호출하여 대화 상자를 트리거하고, 레거시 사례를 지원하기 위해 `returnValue` 도 함께 설정하는 것입니다.
+
+## 메서드
+
+_부모인 {{DOMxRef("Event")}}로부터 메서드를 상속받습니다._
+
+## 명세서
+
+{{Specifications}}
+
+## 브라우저 호환성
+
+{{Compat}}
+
+## 같이 보기
+
+- {{domxref("Window/beforeunload_event", "beforeunload")}} 이벤트

--- a/files/ko/web/api/beforeunloadevent/index.md
+++ b/files/ko/web/api/beforeunloadevent/index.md
@@ -15,14 +15,14 @@ l10n:
 
 ## 속성
 
-_부모인 {{DOMxRef("Event")}}로부터 속성을 상속받습니다._
+부모인 {{DOMxRef("Event")}}로부터 속성을 상속받습니다.
 
 - {{domxref("BeforeUnloadEvent.returnValue", "returnValue")}} {{Deprecated_Inline}}
   - : [참 같은 값(Truthy)](/ko/docs/Glossary/Truthy) 값으로 설정하면, 사용자가 페이지를 닫거나 새로 고치려고 할 때 페이지를 떠나겠는지 확인하는 브라우저 제어 확인 대화 상자가 표시됩니다. 이 방식은 레거시 기능으로 권장되는 방법은 `event.preventDefault()` 를 호출하여 대화 상자를 트리거하는 동시에 레거시 환경 호환을 위해 `returnValue` 도 함께 설정하는 것입니다.
 
 ## 메서드
 
-_부모인 {{DOMxRef("Event")}}로부터 메서드를 상속받습니다._
+부모인 {{DOMxRef("Event")}}로부터 메서드를 상속받습니다.
 
 ## 명세서
 


### PR DESCRIPTION


### Description

Web/API/BeforeUnloadEvent 의 내용을 한국어로 신규 번역하였습니다.

원문 페이지 : https://developer.mozilla.org/en-US/docs/Web/API/BeforeUnloadEvent

### Motivation

[2025 OSSCA 체험형-2차] MDN 문서 한글화에 참여하고 있는 중입니다!
