### PR TITLE
[zh-cn]: update the translation of HTMLElement `lang` property

### DIFF
--- a/files/zh-cn/web/api/htmlelement/lang/index.md
+++ b/files/zh-cn/web/api/htmlelement/lang/index.md
@@ -1,30 +1,25 @@
 ---
-title: HTMLElement.lang
+title: "HTMLElement: lang 属性"
+short-title: lang
 slug: Web/API/HTMLElement/lang
+l10n:
+  sourceCommit: e7bc0ed5466f5834641d75d416fa81886cf6b37e
 ---
 
-{{ APIRef() }}
+{{ APIRef("HTML DOM") }}
 
-**`HTMLElement.lang`** 属性用来获取或设置元素属性值或文本内容的基语言（base language）。
+{{domxref("HTMLElement")}} 接口的 **`lang`** 属性表示元素属性值和文本内容的基础语言，其格式为 {{glossary("BCP 47 language tag" , "BCP 47 语言标签")}}。它反映元素的 [`lang`](/zh-CN/docs/Web/HTML/Reference/Global_attributes/lang) 属性；`xml:lang` 属性不会影响此属性的值。
 
-该属性返回的语言代码（language code）被定义在 [RFC 1766](https://tools.ietf.org/html/rfc1766)。通常，"en" 表示英语（English）、"ja" 表示（Japanese）、"zh-cn" 表示简体中文等等。该属性的默认值未知（`unknown`）。尽管该属性可以应用在单独的元素上，但是通常在文档的根元素（html）上指定。
+请注意，如果未指定 `lang` 属性，元素本身仍可能从其父元素继承语言。但是，这种继承的语言不会反映在此属性的值中。
 
-该属性只对 `lang` 属性（attribute）有效，不适用于 `xml:lang`。
+## 值
 
-## 语法
-
-```plain
-var languageUsed = elementNodeReference.lang; // 获取 lang 值
-elementNodeReference.lang = NewLanguage; // 为 lang 设置新值
-```
-
-`languageUsed` 是一个字符串变量，可以获取当前元素的文本是用什么语言写的。`NewLanguage` 是一个字符串变量，其值用来作为当前元素的文本的语言。
+一个字符串。常见示例包括“en”表示英语、“ja”表示日语、“es”表示西班牙语等。如果未指定，该值为空字符串。
 
 ## 示例
 
 ```js
-// 该代码比较了基语言（base language），然后
-// 重定向到了基于该语言的 url
+// 此代码片段用于比较基础语言，并根据语言将用户重定向到另一个 URL。
 if (document.documentElement.lang === "en") {
   window.location.href = "Some_document.html.en";
 } else if (document.documentElement.lang === "ru") {
@@ -35,3 +30,7 @@ if (document.documentElement.lang === "en") {
 ## 规范
 
 {{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}

--- a/files/zh-cn/web/api/htmlelement/lang/index.md
+++ b/files/zh-cn/web/api/htmlelement/lang/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTMLElement: lang 属性"
+title: "HTMLElement：lang 属性"
 short-title: lang
 slug: Web/API/HTMLElement/lang
 l10n:

--- a/files/zh-cn/web/api/htmlelement/lang/index.md
+++ b/files/zh-cn/web/api/htmlelement/lang/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTMLElement：lang 属性"
+title: HTMLElement：lang 属性
 short-title: lang
 slug: Web/API/HTMLElement/lang
 l10n:


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/lang
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/htmlelement/lang/index.md
* Last commit: https://github.com/mdn/content/commit/e7bc0ed5466f5834641d75d416fa81886cf6b37e

