### PR TITLE
chore(fr): update of `Web/HTTP/Reference/Methods/CONNECT`

### DIFF
--- a/files/fr/web/http/reference/methods/connect/index.md
+++ b/files/fr/web/http/reference/methods/connect/index.md
@@ -1,44 +1,57 @@
 ---
-title: CONNECT
+title: "Méthode de requête CONNECT"
+short-title: CONNECT
 slug: Web/HTTP/Reference/Methods/CONNECT
 original_slug: Web/HTTP/Methods/CONNECT
+l10n:
+  sourceCommit: ad5b5e31f81795d692e66dadb7818ba8b220ad15
 ---
 
-La **méthode HTTP `CONNECT`** crée une communication bidirectionnelle avec la ressource demandée. Elle peut être utilisée pour ouvrir un tunnel.
+La méthode HTTP **`CONNECT`** demande à un·e {{Glossary("Proxy server", "proxy")}} d'établir un tunnel HTTP vers un serveur de destination et, en cas de succès, de transmettre aveuglément les données dans les deux sens jusqu'à la fermeture du tunnel.
 
-Par exemple, la méthode `CONNECT` peut être utilisée pour accéder à des sites web qui utilisent {{Glossary("SSL")}} ({{Glossary("HTTPS")}}). Le client demande à un serveur Proxy HTTP de créer un tunnel TCP vers la destination désirée. Le serveur poursuit alors afin d'établir la connexion pour le compte du client. Une fois que la connexion a été établie par le serveur, le serveur Proxy continue de gérer le flux TCP à destination et en provenance du client.
+La cible de la requête est unique à cette méthode&nbsp;: elle se compose uniquement de l'hôte et du port de destination du tunnel, séparés par un deux-points (voir la section [Syntaxe](#syntaxe) pour plus de détails).
+Tout [code de statut de réponse 2XX de succès](/fr/docs/Web/HTTP/Reference/Status#réponses_de_succès) signifie que le proxy passe en «&nbsp;mode tunnel&nbsp;» et que toute donnée dans le corps de la réponse provient du serveur identifié par la cible de la requête.
 
-`CONNECT` est une méthode "saut-par-saut".
+Si un site web est derrière un proxy et que des règles réseau imposent que tout le trafic externe passe par ce proxy, la méthode `CONNECT` permet d'établir une connexion {{Glossary("TLS")}} ({{Glossary("HTTPS")}}) avec ce site&nbsp;:
+
+- Le client demande au proxy de créer un tunnel pour la connexion {{Glossary("TCP")}} vers la destination souhaitée.
+- Le serveur proxy établit une connexion sécurisée avec le serveur pour le compte du client.
+- Une fois la connexion établie, le proxy continue de relayer le flux TCP entre le client et le serveur.
+
+En plus de permettre un accès sécurisé à des sites derrière des proxies, un tunnel HTTP permet de faire passer du trafic qui serait autrement restreint (SSH ou FTP) via le protocole HTTP(S).
+
+`CONNECT` est une méthode «&nbsp;hop-by-hop&nbsp;»&nbsp;: les proxies ne transmettent la requête `CONNECT` que s'il y a un autre proxy en amont du serveur d'origine, car la plupart des serveurs d'origine n'implémentent pas `CONNECT`.
+
+> [!WARNING]
+> Si vous exploitez un proxy prenant en charge `CONNECT`, limitez son usage à un ensemble de ports connus ou à une liste configurable de cibles sûres.
+> Il existe des risques importants à établir un tunnel vers des serveurs arbitraires, en particulier lorsque la destination est un port TCP bien connu ou réservé qui n'est pas destiné au trafic Web.
+> Un proxy mal configuré peut être détourné pour relayer du trafic comme SMTP afin de diffuser du courrier indésirable, par exemple.
 
 <table class="properties">
   <tbody>
     <tr>
       <th scope="row">La requête a un corps</th>
-      <td>Oui</td>
-    </tr>
-    <tr>
-      <th scope="row">Une réponse de succès a un corps</th>
-      <td>Oui</td>
-    </tr>
-    <tr>
-      <th scope="row">{{Glossary("Sûre")}}</th>
       <td>Non</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Idempotente")}}</th>
+      <th scope="row">La réponse de succès a un corps</th>
       <td>Non</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Peut être mise en cache")}}</th>
+      <th scope="row">{{Glossary("Safe/HTTP", "Sûre")}}</th>
+      <td>Non</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Idempotent", "Idempotente")}}</th>
+      <td>Non</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Cacheable", "Mis en cache")}}</th>
       <td>Non</td>
     </tr>
     <tr>
       <th scope="row">
-        Autorisée dans les
-        <a
-          href="https://developer.mozilla.org/fr/docs/Web/Guide/HTML/Formulaires"
-          >formulaires HTML</a
-        >
+        Autorisée dans <a href="/fr/docs/Learn_web_development/Extensions/Forms">les formulaires HTML</a>
       </th>
       <td>Non</td>
     </tr>
@@ -47,17 +60,23 @@ Par exemple, la méthode `CONNECT` peut être utilisée pour accéder à des sit
 
 ## Syntaxe
 
+```http
+CONNECT <host>:<port> HTTP/1.1
 ```
-CONNECT www.example.com:443 HTTP/1.1
-```
+
+- `<host>`
+  - : Un hôte qui peut être un nom d'hôte enregistré (par exemple, `exemple.fr`) ou une adresse IP (IPv4, IPv6).
+- `<port>`
+  - : Un numéro de port en décimal (par exemple, `80`, `443`). Il n'y a pas de port par défaut, donc le client **doit** toujours en spécifier un.
 
 ## Exemple
 
-Certains serveurs proxy pourraient avoir besoin d'une autorisation pour créer un tunnel. Voir aussi l'en-tête {{HTTPHeader("Proxy-Authorization")}}.
+Une requête pour les serveurs proxy qui nécessitent une autorisation pour créer un tunnel ressemble à ceci.
+Voir l'en-tête {{HTTPHeader("Proxy-Authorization")}} pour plus d'informations.
 
-```
-CONNECT server.example.com:80 HTTP/1.1
-Host: server.example.com:80
+```http
+CONNECT serveur.exemple.fr:80 HTTP/1.1
+Host: serveur.exemple.fr:80
 Proxy-Authorization: basic aGVsbG86d29ybGQ=
 ```
 
@@ -71,5 +90,9 @@ Proxy-Authorization: basic aGVsbG86d29ybGQ=
 
 ## Voir aussi
 
-- {{Glossary("Proxy server")}}
-- {{HTTPHeader("Proxy-Authorization")}}
+- [Méthodes de requête HTTP](/fr/docs/Web/HTTP/Reference/Methods)
+- [Codes de statut de réponse HTTP](/fr/docs/Web/HTTP/Reference/Status)
+- [En-têtes HTTP](/fr/docs/Web/HTTP/Reference/Headers)
+- L'entrée de glossaire {{Glossary("Proxy server")}}
+- L'en-tête {{HTTPHeader("Proxy-Authorization")}}
+- [Utiliser SSH via un proxy HTTP <sup>(angl.)</sup>](https://www.dimoulis.net/posts/ssh-over-proxy/) sur dimoulis.net (2023)

--- a/files/fr/web/http/reference/methods/connect/index.md
+++ b/files/fr/web/http/reference/methods/connect/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Méthode de requête CONNECT"
+title: Méthode de requête CONNECT
 short-title: CONNECT
 slug: Web/HTTP/Reference/Methods/CONNECT
 original_slug: Web/HTTP/Methods/CONNECT


### PR DESCRIPTION
### Description

Update translation of pages without french version: `Web/HTTP/Reference/Methods/CONNECT`

### Motivation

Update access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_