### PR TITLE
[zh-cn]: update the translation of HTTP `DNT` header

### DIFF
--- a/files/zh-cn/web/http/reference/headers/dnt/index.md
+++ b/files/zh-cn/web/http/reference/headers/dnt/index.md
@@ -73,5 +73,5 @@ navigator.doNotTrack; // “0”、“1”或 null
 - DNT 浏览器设置帮助：
   - [Firefox](https://support.mozilla.org/zh-CN/kb/如何停止让网站追踪我)
   - [Chrome](https://support.google.com/chrome/answer/2790761)
-- [GPC —— 全局隐私控制](https://globalprivacycontrol.org/)
-  - [在 Firefox 中启用 GPC](https://support.mozilla.org/en-US/kb/global-privacy-control?as=u&utm_source=inproduct)
+- [GPC——全局隐私控制](https://globalprivacycontrol.org/)
+  - [在 Firefox 中启用 GPC](https://support.mozilla.org/zh-CN/kb/全球隐私控制?as=u&utm_source=inproduct)

--- a/files/zh-cn/web/http/reference/headers/dnt/index.md
+++ b/files/zh-cn/web/http/reference/headers/dnt/index.md
@@ -47,9 +47,9 @@ DNT: null
 
 ## 示例
 
-### Reading Do Not Track status from JavaScript
+### 从 JavaScript 读取请勿追踪状态
 
-The user's DNT preference can also be read from JavaScript using the {{domxref("Navigator.doNotTrack")}} property:
+可以通过 JavaScript 使用 {{domxref("Navigator.doNotTrack")}} 属性读取用户的 DNT（请勿追踪）偏好设置：
 
 ```js
 navigator.doNotTrack; // “0”、“1”或 null

--- a/files/zh-cn/web/http/reference/headers/dnt/index.md
+++ b/files/zh-cn/web/http/reference/headers/dnt/index.md
@@ -1,41 +1,63 @@
 ---
-title: DNT
+title: DNT 标头
+short-title: DNT
 slug: Web/HTTP/Reference/Headers/DNT
+l10n:
+  sourceCommit: ad5b5e31f81795d692e66dadb7818ba8b220ad15
 ---
 
-请求首部 **`DNT`** (**D**o **N**ot **T**rack) 表明了用户对于网站追踪的偏好。它允许用户指定自己是否更注重个人隐私还是定制化内容。
+{{Deprecated_header}}{{non-standard_header}}
 
-| Header type                           | {{Glossary("Request header")}} |
-| ------------------------------------- | ------------------------------ |
-| {{Glossary("Forbidden header name")}} | yes                            |
+> [!NOTE]
+> DNT（请勿追踪）规范已被废弃。更多信息请参阅 {{domxref("Navigator.doNotTrack")}}。
+
+HTTP **`DNT`**（请勿追踪）{{Glossary("request header","请求标头")}}用于表示用户的跟踪偏好。它使用户能够表明自己更倾向于保护隐私，而非接收个性化内容。
+
+DNT 已被弃用，推荐使用[全局隐私控制](https://globalprivacycontrol.org/)，该机制通过 {{HTTPHeader("Sec-GPC")}} 标头与服务器通信，客户端可通过 {{domxref("navigator.globalPrivacyControl")}} 访问该设置。
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">标头类型</th>
+      <td>{{Glossary("Request header", "请求标头")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden request header", "禁止修改的请求标头")}}</th>
+      <td>是</td>
+    </tr>
+  </tbody>
+</table>
 
 ## 语法
 
-```plain
+```http
 DNT: 0
 DNT: 1
+DNT: null
 ```
 
 ## 指令
 
-- 0
-  - : 表示用户愿意目标站点追踪用户个人信息。
-- 1
-  - : 表示用户不愿意目标站点追踪用户个人信息。
+- `0`
+  - : 用户倾向于允许目标网站进行跟踪。
+- `1`
+  - : 用户倾向于不被目标网站跟踪。
+- `null`
+  - : 用户未指定关于跟踪的偏好。
 
 ## 示例
 
-### 使用 JavaScript 读取“不追踪”（Do Not Track）状态
+### Reading Do Not Track status from JavaScript
 
-用户对 DNT 的设置还可以使用 {{domxref("Navigator.doNotTrack")}} 属性进行读取：
+The user's DNT preference can also be read from JavaScript using the {{domxref("Navigator.doNotTrack")}} property:
 
 ```js
-navigator.doNotTrack; // "0" or "1"
+navigator.doNotTrack; // “0”、“1”或 null
 ```
 
 ## 规范
 
-{{Specifications}}
+此属性属于已废弃的[跟踪偏好表达（DNT）](https://w3c.github.io/dnt/drafts/tracking-dnt.html#dnt-header-field)规范。
 
 ## 浏览器兼容性
 
@@ -44,10 +66,12 @@ navigator.doNotTrack; // "0" or "1"
 ## 参见
 
 - {{domxref("Navigator.doNotTrack")}}
-- {{HTTPHeader("Tk")}} header
-- [Do Not Track on Wikipedia](https://en.wikipedia.org/wiki/Do_Not_Track)
-- ["Do Not Track"中的"Track"指什么？– EFF](https://www.eff.org/deeplinks/2011/02/what-does-track-do-not-track-mean)
-- [donottrack.us](http://donottrack.us/)
+- {{HTTPHeader("Tk")}} 标头
+- [维基百科上的请勿追踪](https://zh.wikipedia.org/wiki/请勿追踪)
+- [“Do Not Track”中的“Track”是什么意思？——EFF](https://www.eff.org/deeplinks/2011/02/what-does-track-do-not-track-mean)
+- [电子前哨基金会（EFF）上的 DNT 页面](https://www.eff.org/issues/do-not-track)
 - DNT 浏览器设置帮助：
-  - [Firefox](https://www.mozilla.org/en-US/firefox/dnt/)
+  - [Firefox](https://support.mozilla.org/zh-CN/kb/如何停止让网站追踪我)
   - [Chrome](https://support.google.com/chrome/answer/2790761)
+- [GPC —— 全局隐私控制](https://globalprivacycontrol.org/)
+  - [在 Firefox 中启用 GPC](https://support.mozilla.org/en-US/kb/global-privacy-control?as=u&utm_source=inproduct)


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/DNT
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/http/reference/headers/dnt/index.md
* Last commit: https://github.com/mdn/content/commit/ad5b5e31f81795d692e66dadb7818ba8b220ad15
