### PR TITLE
[zh-cn]: update the translation of CSS `:dir()` pseudo classes

### DIFF
--- a/files/zh-cn/web/css/_colon_dir/index.md
+++ b/files/zh-cn/web/css/_colon_dir/index.md
@@ -14,7 +14,7 @@ l10n:
 }
 ```
 
-`:dir()` 伪类仅使用文本方向的*语义*值，即文档中定义的方向性。它不会考虑由 CSS 属性（例如 {{cssxref("direction")}} ）设置的*样式*方向。
+`:dir()` 伪类仅使用文本方向的*语义*值，即文档中定义的方向性。它不会考虑由 CSS 属性（例如 {{cssxref("direction")}}）设置的*样式*方向。
 
 > [!NOTE]
 > 请注意，`:dir()` 伪类的行为与 `[dir=…]` [属性选择器](/zh-CN/docs/Web/CSS/Attribute_selectors)并不相同。后者仅匹配具有 HTML [`dir`](/zh-CN/docs/Web/HTML/Reference/Global_attributes/dir) 属性的元素，并会忽略那些虽然从父元素继承了方向但自身没有该属性的元素。（同样，`[dir=rtl]` 和 `[dir=ltr]` 也不会匹配 `auto` 值。）相比之下，`:dir()` 会匹配由{{glossary("user agent", "用户代理")}}计算得出的方向值，即使该值是继承而来的。

--- a/files/zh-cn/web/css/_colon_dir/index.md
+++ b/files/zh-cn/web/css/_colon_dir/index.md
@@ -1,37 +1,73 @@
 ---
 title: :dir()
 slug: Web/CSS/:dir
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-{{ SeeCompatTable() }}
+[CSS](/zh-CN/docs/Web/CSS) [伪类](/zh-CN/docs/Web/CSS/Pseudo-classes) **`:dir()`** 根据元素中文本的书写方向匹配元素。
 
-## 总结
+```css
+/* 选择任何文本方向为从右到左的元素 */
+:dir(rtl) {
+  background-color: red;
+}
+```
 
-`:dir()`伪类匹配特定文字书写方向的元素。在 HTML 中，文字方向由[`dir`](/zh-CN/docs/Web/HTML/Reference/Elements/html#dir)属性决定。其他的文档类型可能有其他定义文字方向的方法。
+`:dir()` 伪类仅使用文本方向的*语义*值，即文档中定义的方向性。它不会考虑由 CSS 属性（例如 {{cssxref("direction")}} ）设置的*样式*方向。
 
-值得注意的是用 CSS 伪类 `:dir()` 并不等于使用 `[dir=…]` 属性选择器。后者匹配 [`dir`](/zh-CN/docs/Web/HTML/Reference/Elements/html#dir) 的值且不会匹配到未定义此属性的元素，即使该元素继承了父元素的属性；类似的， `[dir=rtl]` 或 `[dir=ltr]` 不会匹配到 dir 属性的值为 auto 的元素。而 `:dir()`会匹配经过客户端计算后的属性，不管是继承的 dir 值还是 dir 值为 auto 的。
+> [!NOTE]
+> 请注意，`:dir()` 伪类的行为与 `[dir=…]` [属性选择器](/zh-CN/docs/Web/CSS/Attribute_selectors)并不相同。后者仅匹配具有 HTML [`dir`](/zh-CN/docs/Web/HTML/Reference/Global_attributes/dir) 属性的元素，并会忽略那些虽然从父元素继承了方向但自身没有该属性的元素。（同样，`[dir=rtl]` 和 `[dir=ltr]` 也不会匹配 `auto` 值。）相比之下，`:dir()` 会匹配由{{glossary("user agent", "用户代理")}}计算得出的方向值，即使该值是继承而来的。
 
-另外，:dir() 伪类仅考虑文档（大多数情况是 HTML）中定义的文字方向的语义值 (semantic value)，并不会考虑格式值 (styling value)，如 CSS 属性 {{ cssxref("direction") }} 的值。
+> [!NOTE]
+> 在 HTML 中，文本方向由 [`dir`](/zh-CN/docs/Web/HTML/Reference/Global_attributes/dir) 属性决定。其他类型的文档可能使用不同的方法来确定方向。
 
 ## 语法
 
-```plain
-元素:dir(文字书写方向) { style properties } 文字书写方向为 ltr 或 rtl
+```css-nolint
+:dir([ltr | rtl]) {
+  /* ... */
+}
 ```
+
+### 参数
+
+`:dir()` 伪类需要一个参数，用于表示要匹配的文本方向。
+
+- `ltr`
+  - : 匹配从左到右的元素。
+- `rtl`
+  - : 匹配从右到左的元素。
 
 ## 示例
 
+### HTML
+
 ```html
 <div dir="rtl">
-  <span>test1</span>
+  <span>测试 1</span>
   <div dir="ltr">
-    test2
+    测试 2
     <div dir="auto">עִבְרִית</div>
   </div>
 </div>
 ```
 
-本例中 `:dir(rtl)` 会匹配最外层的 div，内容为`test1 的 span，`和有希伯来字符的 div。`:dir(ltr)` 会匹配到内容为`test2 的 div.`
+### CSS
+
+```css
+:dir(ltr) {
+  background-color: yellow;
+}
+
+:dir(rtl) {
+  background-color: powderblue;
+}
+```
+
+### 结果
+
+{{ EmbedLiveSample('示例') }}
 
 ## 规范
 
@@ -43,4 +79,6 @@ slug: Web/CSS/:dir
 
 ## 参见
 
-- 语言相关伪类：{{ cssxref(":lang") }}, {{ cssxref(":dir") }}
+- 语言相关伪类：{{cssxref(":lang")}}
+- HTML [`lang`](/zh-CN/docs/Web/HTML/Reference/Global_attributes/lang) 属性
+- HTML [`translate`](/zh-CN/docs/Web/HTML/Reference/Global_attributes/translate) 属性


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/CSS/:dir
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/css/_colon_dir/index.md
* Last commit: https://github.com/mdn/content/commit/0cc9980e3b21c83d1800a428bc402ae1865326b2
