### PR TITLE
[ES] Translating Wikipedia link to Spanish

### DIFF
--- a/files/es/glossary/ux/index.md
+++ b/files/es/glossary/ux/index.md
@@ -13,4 +13,4 @@ El sistema puede ser cualquier tipo de producto o aplicación con el que un usua
 
 ### Conocimiento general
 
-- [User experience](https://es.wikipedia.org/wiki/User_experience) on Wikipedia
+- [Experiencia de usuario](https://es.wikipedia.org/wiki/Experiencia_de_usuario) en Wikipedia


### PR DESCRIPTION
### Description

I fixed the Wikipedia link to link to the correct article on the Spanish Wikipedia.
Arreglé el enlace al artículo correcto en la Wikipedia en español.

### Motivation

The previous link used the English title which doesn't have an article on the Spanish Wikipedia.
El enlace anterior usaba el título de inglés que no existe en la Wikipedia de español.

### Additional details

https://en.wikipedia.org/wiki/User_experience
https://es.wikipedia.org/wiki/Experiencia_de_usuario

### Related issues and pull requests

Fixes #27477 
