### PR TITLE
[zh-cn]: update the translation of HTTP `Accept` header and Object.getPrototypeOf()

### DIFF
--- a/files/zh-cn/web/http/reference/headers/accept/index.md
+++ b/files/zh-cn/web/http/reference/headers/accept/index.md
@@ -59,7 +59,7 @@ Accept: text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*
 
 ### 使用默认的 Accept 请求标头
 
-使用命令行工具（例如 [curl](https://curl.se/) 个 [wget](https://www.gnu.org/software/wget/)）发起的 HTTP 请求，其默认的 `Accept` 值为 `*/*`：
+使用命令行工具（例如 [curl](https://curl.se/) 和 [wget](https://www.gnu.org/software/wget/)）发起的 HTTP 请求，其默认的 `Accept` 值为 `*/*`：
 
 ```http
 GET / HTTP/1.1

--- a/files/zh-cn/web/http/reference/headers/accept/index.md
+++ b/files/zh-cn/web/http/reference/headers/accept/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: ad5b5e31f81795d692e66dadb7818ba8b220ad15
 ---
 
-HTTP 的 **`Accept`** {{Glossary("request header", "请求")}}和{{Glossary("response header", "响应标头")}}用于指示发送方能够理解的内容类型，这些类型以 [MIME 类型](/zh-CN/docs/Web/HTTP/Guides/MIME_types)的形式表示。在请求中，服务器会使用[内容协商](/zh-CN/docs/Web/HTTP/Guides/Content_negotiation)机制，从客户端提议的内容类型中选择一种，并通过 {{HTTPHeader("Content-Type")}} 响应标头告知客户端所选择的类型。在响应中，该标头则用于指示服务器能够理解哪些内容类型，以便客户端在后续对同一资源的请求中使用合适的内容类型。
+HTTP **`Accept`** {{Glossary("request header", "请求")}}和{{Glossary("response header", "响应标头")}}用于指示发送方能够理解的内容类型，这些类型以 [MIME 类型](/zh-CN/docs/Web/HTTP/Guides/MIME_types)的形式表示。在请求中，服务器会使用[内容协商](/zh-CN/docs/Web/HTTP/Guides/Content_negotiation)机制，从客户端提议的内容类型中选择一种，并通过 {{HTTPHeader("Content-Type")}} 响应标头告知客户端所选择的类型。在响应中，该标头则用于指示服务器能够理解哪些内容类型，以便客户端在后续对同一资源的请求中使用合适的内容类型。
 
 浏览器会根据请求的上下文自动为该标头设置所需的值。例如，当请求获取 CSS 样式表、图像、视频或脚本时，浏览器会使用不同的取值。
 

--- a/files/zh-cn/web/http/reference/headers/accept/index.md
+++ b/files/zh-cn/web/http/reference/headers/accept/index.md
@@ -105,7 +105,7 @@ Accept: application/json
 ## 参见
 
 - HTTP [内容协商](/zh-CN/docs/Web/HTTP/Guides/Content_negotiation)
-- [默认 Accept 值列表](/zh-CN/docs/Web/HTTP/Guides/Content_negotiation/List_of_default_Accept_values)
+- [Accept 默认值列表](/zh-CN/docs/Web/HTTP/Guides/Content_negotiation/List_of_default_Accept_values)
 - [列入 CORS 白名单的请求标头的限制](/zh-CN/docs/Glossary/CORS-safelisted_request_header#附加限制)
 - 表示内容协商结果的消息标头：{{HTTPHeader("Content-Type")}}
 - 其他相似标头：{{HTTPHeader("TE")}}、{{HTTPHeader("Accept-Encoding")}}、{{HTTPHeader("Accept-Language")}}

--- a/files/zh-cn/web/http/reference/headers/accept/index.md
+++ b/files/zh-cn/web/http/reference/headers/accept/index.md
@@ -71,7 +71,7 @@ Accept: */*
 浏览器在进行页面导航请求时，通常会使用如下的 `Accept` 请求标头值：
 
 ```http
-GET /en-US/ HTTP/2
+GET /zh-CN/ HTTP/2
 Host: developer.mozilla.org
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
 …

--- a/files/zh-cn/web/http/reference/headers/accept/index.md
+++ b/files/zh-cn/web/http/reference/headers/accept/index.md
@@ -1,20 +1,23 @@
 ---
-title: Accept
+title: Accept 标头
+short-title: Accept
 slug: Web/HTTP/Reference/Headers/Accept
 l10n:
-  sourceCommit: f75b2c86ae4168e59416aed4c7121f222afc201d
+  sourceCommit: ad5b5e31f81795d692e66dadb7818ba8b220ad15
 ---
 
-**`Accept`** 请求 HTTP 标头表示客户端能够理解的内容类型，以 [MIME 类型](/zh-CN/docs/Web/HTTP/Guides/MIME_types)的形式表达。借助[内容协商机制](/zh-CN/docs/Web/HTTP/Guides/Content_negotiation), 服务器可以从诸多备选项中选择一项进行应用，并使用 {{HTTPHeader("Content-Type")}} 响应标头通知客户端它的选择。浏览器会基于请求的上下文来为这个请求标头设置合适的值，比如，获取一个 CSS 层叠样式表时的值与获取图片、视频或脚本文件时的值是不同的。
+HTTP 的 **`Accept`** {{Glossary("request header", "请求")}}和{{Glossary("response header", "响应标头")}}用于指示发送方能够理解的内容类型，这些类型以 [MIME 类型](/zh-CN/docs/Web/HTTP/Guides/MIME_types)的形式表示。在请求中，服务器会使用[内容协商](/zh-CN/docs/Web/HTTP/Guides/Content_negotiation)机制，从客户端提议的内容类型中选择一种，并通过 {{HTTPHeader("Content-Type")}} 响应标头告知客户端所选择的类型。在响应中，该标头则用于指示服务器能够理解哪些内容类型，以便客户端在后续对同一资源的请求中使用合适的内容类型。
+
+浏览器会根据请求的上下文自动为该标头设置所需的值。例如，当请求获取 CSS 样式表、图像、视频或脚本时，浏览器会使用不同的取值。
 
 <table class="properties">
   <tbody>
     <tr>
       <th scope="row">标头类型</th>
-      <td>{{Glossary("Request header", "请求标头")}}</td>
+      <td>{{Glossary("Request header", "请求标头")}}、{{Glossary("Response header", "响应标头")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name", "禁止修改的标头")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header", "禁止修改的请求标头")}}</th>
       <td>否</td>
     </tr>
     <tr>
@@ -22,46 +25,73 @@ l10n:
         {{Glossary("CORS-safelisted request header", "列入 CORS 白名单的请求标头")}}
       </th>
       <td>
-        是，但有额外的限制，即值中不能包含 <em>CORS 不安全请求标头字节</em>：0x00-0x1F（除了 0x09（制表符，HT）），<code>"():&#x3C;>?@[\]{}</code> 以及 0x7F（DEL）。
+        是*
       </td>
     </tr>
   </tbody>
 </table>
 
+\* 即值中不能包含 [CORS 不安全请求标头字节](https://fetch.spec.whatwg.org/#cors-unsafe-request-header-byte)，包括 `"():<>?@[\]{},`、删除符 `0x7F`，以及控制字符 `0x00` 到 `0x19`（制表符 `0x09` 除外）。
+
 ## 语法
 
 ```http
-Accept: <MIME_type>/<MIME_subtype>
-Accept: <MIME_type>/*
+Accept: <media-type>/<MIME_subtype>
+Accept: <media-type>/*
 Accept: */*
 
-// 多种类型，采用权重值语法区分：
+// 多种类型，采用权重值语法区分
 Accept: text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8
 ```
 
 ## 指令
 
-- `<MIME_type>/<MIME_subtype>`
-  - : 一个单一且精确的 [MIME 类型](/zh-CN/docs/Web/HTTP/Guides/MIME_types)，例如 `text/html`。
-- `<MIME_type>/*`
-  - : 一个 MIME 类型，但不包含子类型。`image/*` 对应于 `image/png`、`image/svg`、`image/gif` 以及其他图像类型。
+- `<media-type>/<subtype>`
+  - : 一个单一且精确的[媒体类型](/zh-CN/docs/Web/HTTP/Guides/MIME_types)，例如 `text/html`。
+- `<media-type>/*`
+  - : 没有指定子类型的媒体类型。例如，`image/*` 可对应 `image/png`、`image/svg`、`image/gif` 等多种图像类型。
 - `*/*`
-  - : 任何 MIME 类型
+  - : 任意媒体类型。
 - `;q=`（q 因子加权）
-  - : 使用的值根据一个称为*权重*的相对[质量价值](/zh-CN/docs/Glossary/Quality_values)来排序，表达了优先级顺序。
+  - : 使用的值根据一个称为*权重*的相对{{Glossary("quality values", "质量价值")}}来排序，表达了优先级顺序。
 
 ## 示例
 
+### 使用默认的 Accept 请求标头
+
+使用命令行工具（例如 [curl](https://curl.se/) 个 [wget](https://www.gnu.org/software/wget/)）发起的 HTTP 请求，其默认的 `Accept` 值为 `*/*`：
+
 ```http
-Accept: text/html
-
-Accept: image/*
-
-// 一般默认值
+GET / HTTP/1.1
+Host: example.com
+User-Agent: curl/8.7.1
 Accept: */*
+```
 
-// 导航请求的默认值
-Accept: text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8
+浏览器在进行页面导航请求时，通常会使用如下的 `Accept` 请求标头值：
+
+```http
+GET /en-US/ HTTP/2
+Host: developer.mozilla.org
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+…
+```
+
+在接收到文档后，对 `Accept` 示例页面中的图像发起的请求，其默认的 `developer.mozilla.org` 值如下所示：
+
+```http
+Accept: image/avif,image/webp,image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5
+```
+
+### 为 JSON 响应配置 Accept 请求标头
+
+在涉及 API 交互的系统中，通常会请求返回 `application/json` 格式的响应。以下是一个客户端明确请求 JSON 响应的 {{HTTPMethod("GET")}} 请求示例：
+
+```http
+GET /users/123 HTTP/1.1
+Host: example.com
+Authorization: Bearer abcd123
+Accept: application/json
 ```
 
 ## 规范
@@ -75,6 +105,7 @@ Accept: text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8
 ## 参见
 
 - HTTP [内容协商](/zh-CN/docs/Web/HTTP/Guides/Content_negotiation)
-- [Accept 默认值](/zh-CN/docs/Web/HTTP/Guides/Content_negotiation/List_of_default_Accept_values)
+- [默认 Accept 值列表](/zh-CN/docs/Web/HTTP/Guides/Content_negotiation/List_of_default_Accept_values)
+- [列入 CORS 白名单的请求标头的限制](/zh-CN/docs/Glossary/CORS-safelisted_request_header#附加限制)
 - 表示内容协商结果的消息标头：{{HTTPHeader("Content-Type")}}
 - 其他相似标头：{{HTTPHeader("TE")}}、{{HTTPHeader("Accept-Encoding")}}、{{HTTPHeader("Accept-Language")}}

--- a/files/zh-cn/web/javascript/reference/global_objects/object/getprototypeof/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/object/getprototypeof/index.md
@@ -1,18 +1,21 @@
 ---
 title: Object.getPrototypeOf()
+short-title: getPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf
+l10n:
+  sourceCommit: cd22b9f18cf2450c0cc488379b8b780f0f343397
 ---
 
 **`Object.getPrototypeOf()`** 静态方法返回指定对象的原型（即内部 `[[Prototype]]` 属性的值）。
 
-{{InteractiveExample("JavaScript Demo: Object.getPrototypeOf()", "shorter")}}
+{{InteractiveExample("JavaScript 演示：Object.getPrototypeOf()", "shorter")}}
 
 ```js interactive-example
-const prototype1 = {};
-const object1 = Object.create(prototype1);
+const prototype = {};
+const object = Object.create(prototype);
 
-console.log(Object.getPrototypeOf(object1) === prototype1);
-// Expected output: true
+console.log(Object.getPrototypeOf(object) === prototype);
+// 预期输出：true
 ```
 
 ## 语法
@@ -46,9 +49,9 @@ Object.getPrototypeOf(obj) === proto; // true
 
 ```js
 Object.getPrototypeOf("foo");
-// TypeError: "foo" is not an object (ES5 code)
+// TypeError: "foo" is not an object（ES5 代码）
 Object.getPrototypeOf("foo");
-// String.prototype                  (ES2015 code)
+// String.prototype（ES2015 代码）
 ```
 
 ## 规范
@@ -62,8 +65,9 @@ Object.getPrototypeOf("foo");
 ## 参见
 
 - [`core-js` 中 `Object.getPrototypeOf` 的 polyfill](https://github.com/zloirock/core-js#ecmascript-object)
+- [`Object.getPrototypeOf` 的 es-shims polyfill 实现](https://www.npmjs.com/package/object.getprototypeof)
 - {{jsxref("Object.prototype.isPrototypeOf()")}}
 - {{jsxref("Object.setPrototypeOf()")}}
 - [`Object.prototype.__proto__`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)
-- John Resig 关于 [getPrototypeOf](https://johnresig.com/blog/objectgetprototypeof/) 的博文。
 - {{jsxref("Reflect.getPrototypeOf()")}}
+- John Resig（2008）撰写的 [Object.getPrototypeOf](https://johnresig.com/blog/objectgetprototypeof/)

--- a/files/zh-cn/web/javascript/reference/global_objects/object/getprototypeof/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/object/getprototypeof/index.md
@@ -70,4 +70,4 @@ Object.getPrototypeOf("foo");
 - {{jsxref("Object.setPrototypeOf()")}}
 - [`Object.prototype.__proto__`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)
 - {{jsxref("Reflect.getPrototypeOf()")}}
-- John Resig（2008）撰写的 [Object.getPrototypeOf](https://johnresig.com/blog/objectgetprototypeof/)
+- John Resig 撰写的 [Object.getPrototypeOf](https://johnresig.com/blog/objectgetprototypeof/)（2008）


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf

* MDN URL: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.md
* Last commit: https://github.com/mdn/content/commit/cd22b9f18cf2450c0cc488379b8b780f0f343397

* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/http/reference/headers/accept/index.md
* Last commit: https://github.com/mdn/content/commit/ad5b5e31f81795d692e66dadb7818ba8b220ad15