### PR TITLE
chore(fr): translation of `Glossary/Credential`

### DIFF
--- a/files/fr/glossary/credential/index.md
+++ b/files/fr/glossary/credential/index.md
@@ -1,0 +1,21 @@
+---
+title: Identité (credential)
+slug: Glossary/Credential
+l10n:
+  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+---
+
+Une **preuve d'identité** (<i lang="en">credential</i> en anglais) est un objet qui permet à un système de prendre une décision d'{{Glossary("authentication", "authentification")}}&nbsp;: par exemple, décider de connecter un·e utilisateur·ice à un compte.
+
+En sécurité web, les types de preuves d'identité incluent&nbsp;:
+
+- un mot de passe
+- des données biométriques
+- un jeton saisi à partir d'un code SMS à usage unique
+- la clé utilisée pour effectuer des assertions d'authentification dans un système à clé publique comme [Web Authentication](/fr/docs/Web/API/Web_Authentication_API)
+
+L'[API Credential Management](/fr/docs/Web/API/Credential_Management_API) permet aux développeur·euse·s de créer, stocker et récupérer différents types de preuves d'identité.
+
+## Voir aussi
+
+- [Internet Security Glossary (RFC 4949) <sup>(angl.)</sup>](https://datatracker.ietf.org/doc/html/rfc4949)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Glossary/Credential`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_