### PR TITLE
chore(fr): translation of `Glossary/html_color_codes`

### DIFF
--- a/files/fr/glossary/html_color_codes/index.md
+++ b/files/fr/glossary/html_color_codes/index.md
@@ -1,0 +1,27 @@
+---
+title: Codes couleur HTML
+slug: Glossary/html_color_codes
+l10n:
+  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+---
+
+Les **codes couleur HTML** est un terme général _de facto_ utilisé pour décrire les premières méthodes disponibles pour spécifier des couleurs sur les pages web. Cela inclut les noms de couleurs HTML comme `black`, `purple` et `aqua`, ainsi que les notations hexadécimales comme `#000000`, `#800080` et `#00ffff`. Celles-ci étaient à l'origine définies dans les spécifications HTML — voir par exemple les [définitions de couleurs HTML 3.2 <sup>(angl.)</sup>](https://www.w3.org/TR/2018/SPSD-html32-20180315/#colors) des 16 couleurs HTML d'origine.
+
+Il n'est plus exact de parler de «&nbsp;codes couleur HTML&nbsp;» ou de «&nbsp;noms de couleur HTML&nbsp;» pour le web. Les couleurs sont désormais spécifiées dans le [module CSS des couleurs](/fr/docs/Web/CSS/CSS_colors) et sont généralement appelées couleurs CSS ou couleurs web.
+
+## Voir aussi
+
+### Culture générale
+
+[Couleurs web](https://fr.wikipedia.org/wiki/Couleur_du_Web) sur Wikipédia
+
+### Référence technique
+
+Pour consulter les couleurs web sur MDN, voir la documentation de référence des valeurs CSS {{CSSxRef("&lt;color&gt;")}}, ou plus précisément&nbsp;:
+
+- Noms de couleurs&nbsp;: {{CSSxRef("&lt;named-color&gt;")}}.
+- Notations hexadécimales&nbsp;: {{CSSxRef("&lt;hex-color&gt;")}}.
+- Fonctions de couleur&nbsp;:
+  - Espace colorimétrique [sRGB](/fr/docs/Glossary/Color_space#rgb_color_spaces)&nbsp;: {{CSSxRef("color_value/hsl", "hsl()")}}, {{CSSxRef("color_value/hwb", "hwb()")}} et {{CSSxRef("color_value/rgb", "rgb()")}}.
+  - Espace colorimétrique [CIELAB](/fr/docs/Glossary/Color_space#cielab_color_spaces)&nbsp;: {{CSSxRef("color_value/lab", "lab()")}} et {{CSSxRef("color_value/lch", "lch()")}}, {{CSSxRef("color_value/oklab", "oklab()")}} et {{CSSxRef("color_value/oklch", "oklch()")}}.
+  - Autres espaces colorimétriques&nbsp;: {{CSSxRef("color_value/color", "color()")}}.


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Glossary/html_color_codes`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_