### PR TITLE
chore(fr): translation of `MDN/Community/Roles_teams`

### DIFF
--- a/files/fr/mdn/community/roles_teams/index.md
+++ b/files/fr/mdn/community/roles_teams/index.md
@@ -1,0 +1,307 @@
+---
+title: MDN Web Docs les rôles et les équipes
+short-title: Rôles et équipes
+slug: MDN/Community/Roles_teams
+l10n:
+  sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
+---
+
+Le succès et la croissance du projet MDN Web Docs sont en grande partie dus à notre communauté de contributeur·ice·s. Certain·e·s contributeur·ice·s consacrent une partie de leur temps pour aider aux tâches quotidiennes liées à MDN Web Docs. Les modifications du site, y compris les tâches de maintenance, sont réalisées par des employé·e·s, des prestataires et un réseau de partenaires, tous·tes engagé·e·s pour la santé, la croissance et la maintenance de MDN Web Docs. Le projet s'appuie fortement sur les [rôles](#roles) et les [équipes](#equipes) de l'[organisation MDN sur GitHub <sup>(angl.)</sup>](https://github.com/mdn) pour gérer et intégrer les changements de ces différents groupes. La liste des membres actuels de l'organisation est disponible sur [github.com/orgs/mdn <sup>(angl.)</sup>](https://github.com/orgs/mdn/people).
+
+Les contributions de la communauté aident énormément ce projet libre.
+Les contributeur·ice·s peuvent valoriser leur travail sur MDN Web Docs pour démontrer leurs compétences rédactionnelles, techniques, de collaboration, ainsi que leur capacité à travailler avec des personnes issues de milieux divers. Cette section décrit les rôles que vous pouvez occuper en tant que bénévole sur le projet MDN Web Docs.
+
+## Rôles
+
+Dans le projet MDN Web Docs, vous pouvez occuper le rôle de [contributeur·ice](#contributeur·ice), de [membre de l'organisation](#membre_de_lorganisation), de [mainteneur·euse](#mainteneur·euse) ou de [propriétaire](#proprietaire). La progression d'un rôle à l'autre se fait étape par étape.
+Avec l'évolution de vos responsabilités, vous pouvez cumuler plusieurs rôles en même temps.
+Des rôles comme [expert·e invité·e](#expert·e_invite·e) peuvent être obtenus directement si vous démontrez une expertise dans un domaine particulier.
+
+Quel que soit le rôle que vous occupez dans ce projet, vous êtes toujours [contributeur·ice](#contributeur·ice).
+Le rôle de **contributeur·ice** est la base, tous les autres rôles s'y ajoutent.
+Aussi, quelle que soit votre implication dans ce projet, vous devez satisfaire aux exigences du rôle de contributeur·ice.
+
+### Contributeur·ice
+
+Les contributeur·ice·s, ou _participant·e·s à la communauté_, apportent au projet leur temps, leurs compétences, leurs avis et leurs idées.
+Les contributeur·ice·s travaillent directement sur le projet et y apportent de la valeur.
+Outre la rédaction et les tests de code, les contributions incluent la création et la mise à jour de la documentation, la recherche, la correction de bogues et l'aide aux autres membres de la communauté.
+
+Selon la fréquence de vos contributions, vous pouvez être un·e contributeur·ice occasionnel·le ou actif·ive.
+Si votre impact sur le projet est important, vous pouvez être nommé·e [contributeur·ice à la une](#contributeur·ice_a_la_une) ou promu·e [membre de l'organisation](#membre_de_lorganisation).
+
+Si vous débutez ici et souhaitez devenir contributeur·ice, consultez notre [guide de démarrage](/fr/docs/MDN/Community/Getting_started) et les [dépôts de l'organisation MDN sur GitHub <sup>(angl.)</sup>](https://github.com/orgs/mdn/repositories).
+
+En tant que contributeur·ice, vous pouvez participer au projet par les activités suivantes&nbsp;:
+
+- Participer aux discussions communautaires sur les [canaux de communication](/fr/docs/MDN/Community/Communication_channels).
+- Aider d'autres contributeur·ice·s avec leurs requêtes de tirage et signalements ou accompagner les nouveaux·elles.
+- Soumettre des signalements de bogues. Consultez [les dépôts principaux](/fr/docs/MDN/Community/Our_repositories) pour plus d'informations.
+- Commenter les signalements pour faire avancer les discussions vers une résolution constructive.
+- Traiter les signalements ouverts (par exemple, dans le dépôt [`translated-content` <sup>(angl.)</sup>](https://github.com/mdn/translated-content/issues)) en soumettant des [propositions de modification](/fr/docs/MDN/Community/Pull_requests).
+- Participer aux événements communautaires.
+- Aider à promouvoir le projet MDN.
+
+**Exigences&nbsp;:**
+
+Pour être contributeur·ice, vous devez respecter&nbsp;:
+
+- [Le code de conduite de Mozilla](https://www.mozilla.org/fr/about/governance/policies/participation/)
+- Les consignes spécifiques à chaque dépôt. Si des indications ou règles spécifiques existent pour un projet, elles sont dans un fichier `CONTRIBUTING.md` à la racine du dépôt.
+
+**Privilèges&nbsp;:**
+
+Les contributeur·ice·s bénéficient des privilèges suivants&nbsp;:
+
+- Invitations à des événements pour les contributeur·ice·s.
+- Éligibilité pour devenir [membre de l'organisation](#membre_de_lorganisation).
+
+### Membre de l'organisation
+
+Les [membres de l'organisation <sup>(angl.)</sup>](https://github.com/orgs/mdn/people) sont des [contributeur·ice·s](#contributeur·ice) confirmé·e·s qui participent régulièrement au projet MDN Web Docs.
+Ils·Elles sont tenu·e·s d'agir dans l'intérêt du projet.
+
+**Exigences&nbsp;:**
+
+Pour devenir membre de l'organisation, vous devez remplir au moins une des conditions suivantes&nbsp;:
+
+- Avoir ouvert au moins deux requêtes de tirage fusionnées qui résolvent deux signalements différents.
+- Avoir contribué à des projets MDN Web Docs pendant au moins deux mois.
+- Avoir contribué activement à au moins un domaine du projet.
+
+Les deux conditions suivantes sont obligatoires&nbsp;:
+
+- Avoir activé l'[authentification à deux facteurs](https://docs.github.com/fr/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication) sur votre compte GitHub.
+- Avoir activé la [signature des commits](https://docs.github.com/fr/authentication/managing-commit-signature-verification/signing-commits).
+
+**Privilèges&nbsp;:**
+
+Les membres de l'organisation disposent de privilèges au [niveau de l'organisation <sup>(angl.)</sup>](https://github.com/mdn) sur GitHub.
+
+### Mainteneur·euse
+
+Les mainteneur·euse·s sont des [contributeur·ice·s](#contributeur·ice) confirmé·e·s responsables d'un ou plusieurs projets sur MDN.
+Ils·Elles participent aux décisions concernant les règles et priorités du projet. Voir le [processus](#nomination_dun·e_mainteneur·euse) pour proposer quelqu'un comme mainteneur·euse.
+
+En tant que mainteneur·euse, vous effectuez les activités suivantes&nbsp;:
+
+- Déterminer les priorités pour le projet dont vous êtes responsable.
+- Participer aux réunions communautaires.
+- Accompagner et guider les nouveaux·elles et les contributeur·ice·s existant·e·s dans tous les autres rôles.
+- Selon vos compétences, proposer, approuver ou mettre en œuvre dans votre domaine&nbsp;:
+  - Des améliorations du code et de l'infrastructure
+  - Des améliorations du contenu
+  - Des améliorations des processus
+
+**Exigences&nbsp;:**
+
+Pour être éligible au rôle de mainteneur·euse, vous devez remplir au moins une des conditions suivantes&nbsp;:
+
+- Avoir acquis de l'expérience en tant qu'[expert·e invité·e](#expert·e_invite·e) pendant au moins six mois.
+- Avoir démontré une connaissance large du projet sur plusieurs domaines.
+- Avoir démontré la capacité à agir dans l'intérêt du projet, indépendamment de l'influence d'autres membres.
+- Avoir montré des qualités d'accompagnement d'autres contributeur·ice·s.
+- S'être engagé·e à consacrer au moins 16 heures par mois au projet.
+- Avoir assisté à la réunion communautaire qui a lieu tous les deux mois.
+
+> [!NOTE]
+> Si vous pensez que quelqu'un est éligible à ce rôle, vous pouvez [proposer un·e mainteneur·euse](#nomination_dun·e_mainteneur·euse).
+
+**Privilèges&nbsp;:**
+
+Les mainteneur·euse·s ont le droit d'approuver et de fusionner des requêtes de tirage.
+
+### Propriétaire
+
+Les propriétaires disposent de droits étendus pour gérer les utilisateur·ice·s et les [équipes GitHub <sup>(angl.)</sup>](https://github.com/orgs/mdn/teams), gérer l'accès aux différents dépôts de l'[organisation MDN <sup>(angl.)</sup>](https://github.com/mdn), modifier les paramètres des dépôts et déployer en production.
+Les propriétaires doivent respecter toutes les exigences des autres rôles de contributeur·ice.
+
+> [!NOTE]
+> Le rôle de propriétaire est actuellement limité au personnel Mozilla.
+
+**Exigences&nbsp;:**
+
+En plus des responsabilités des autres rôles, les propriétaires ont les responsabilités suivantes&nbsp;:
+
+- Respecter et faire respecter les normes de l'équipe MDN, y compris les [règles de participation à la communauté](https://www.mozilla.org/fr/about/governance/policies/participation/) et les [politiques Mozilla](https://www.mozilla.org/fr/about/governance/policies/).
+- Suivre les politiques de l'organisation MDN et montrer l'exemple.
+- Proposer, documenter et mettre en œuvre de nouvelles politiques via le [processus de requête de tirage](/fr/docs/MDN/Community/Pull_requests).
+- Suivre et contribuer aux signalements et discussions dans toute l'organisation MDN.
+- S'assurer qu'un signalement ou une requête de tirage reçoive un retour d'un·e ou plusieurs membres sous une semaine.
+- [Archiver](https://docs.github.com/fr/repositories/archiving-a-github-repository/archiving-repositories) ou supprimer les dépôts non maintenus.
+- Discuter des fonctionnalités GitHub, choisir celles à utiliser et documenter les décisions.
+
+**Privilèges&nbsp;:**
+
+Les propriétaires peuvent&nbsp;:
+
+- Ajouter et retirer des propriétaires et membres de l'organisation selon les besoins.
+- Ajouter et retirer des collaborateur·ice·s à des dépôts spécifiques selon les besoins.
+- Ajouter des dépôts (nouveaux projets ou transferts) selon les besoins.
+
+### Récapitulatif des rôles
+
+| Rôle                                                     | Exigences                                                                                                                                                                                                                                                                                                                     | Privilèges                                                                                                        |
+| :------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------- |
+| [**Contributeur·ice**](#contributeur·ice)                | Respecter le code de conduite et les consignes de contribution                                                                                                                                                                                                                                                                | - Invitations à des événements pour les contributeur·ice·s<br>- Éligibilité pour devenir membre de l'organisation |
+| [**Membre de l'organisation**](#membre_de_lorganisation) | - Activer la 2FA sur le compte GitHub<br>- Activer la signature des commits<br><br>Au moins une des conditions suivantes&nbsp;:<br>- Résoudre deux signalements ou plus<br>- Contribuer pendant au moins deux mois<br>- Contribution active dans un domaine du projet                                                         | Droits d'accès au niveau de l'organisation                                                                        |
+| [**Mainteneur·euse**](#mainteneur·euse)                  | Au moins une des conditions suivantes&nbsp;:<br>- Expert·e invité·e pendant au moins six mois<br>- Connaissance de plusieurs domaines du projet<br>- Agir pour la santé globale du projet<br>- Accompagner d'autres contributeur·ice·s<br>- Consacrer au moins 16h/mois au projet<br>- Participer aux réunions communautaires | Approuver et fusionner des requêtes de tirage                                                                     |
+| [**Propriétaire**](#proprietaire)                        | Limité au personnel Mozilla                                                                                                                                                                                                                                                                                                   | - Gérer l'accès des différents rôles aux dépôts<br>- Ajouter ou archiver des dépôts et projets                    |
+
+## Rôles spéciaux
+
+Certains rôles de contributeur·ice·s comportent des responsabilités plus nuancées et des conditions d'éligibilité particulières. Cela inclut les [contributeur·ice·s à la une](#contributeurice_a_la_une), les [expert·e·s invité·e·s](#experte_invitee) et les [community managers](#community_manager).
+
+### Contributeur·ice à la une
+
+Les contributeur·ice·s à la une sont des personnes qui se sont particulièrement illustrées par leurs contributions à MDN Web Docs.
+Leurs contributions prennent la forme de requêtes de tirage pour améliorer le projet, d'aide aux membres de la communauté sur les [canaux de communication](/fr/docs/MDN/Community/Communication_channels) ou les forums, ou de retours sur les signalements et requêtes de tirage GitHub.
+
+Un·e contributeur·ice à la une est mis·e en avant sur le [site MDN](/fr/) chaque mois.
+Voir le [processus](#nomination_dun·e_contributeur·ice_à_la_une) pour proposer quelqu'un à ce rôle.
+
+### Expert·e invité·e
+
+Les expert·e·s invité·e·s ont un historique de contributions, de participation aux discussions et aux relectures, ou ont prouvé leur expertise sur un domaine particulier de MDN.
+Ils·Elles sont responsables d'un domaine ou d'un composant du projet MDN.
+Ils·Elles relisent et approuvent les requêtes de tirage dans leur domaine, répondent aux questions techniques et veillent à la bonne santé de leur projet. Voir le [processus](#nomination_dun·e_expert·e_invité·e) pour proposer quelqu'un à ce rôle.
+
+En plus des responsabilités d'un·e [membre de l'organisation](#membre_de_lorganisation), les expert·e·s invité·e·s doivent&nbsp;:
+
+- Suivre le [guide de relecture <sup>(angl.)</sup>](https://github.com/mdn/translated-content/blob/main/REVIEWING.md).
+- Relire les requêtes de tirage dans leur domaine.
+- Aider d'autres contributeur·ice·s à devenir relecteur·ice·s.
+
+Les expert·e·s invité·e·s sont automatiquement assigné·e·s à la relecture des requêtes de tirage dans leur domaine.
+S'il y a plusieurs expert·e·s dans un domaine, l'assignation se fait selon une [stratégie d'équilibrage de charge](https://docs.github.com/fr/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#about-auto-assignment).
+
+**Exigences&nbsp;:**
+
+Pour être éligible au rôle d'expert·e invité·e, vous devez remplir au moins une des conditions suivantes&nbsp;:
+
+- Avoir démontré une connaissance approfondie d'un domaine particulier.
+- S'engager à être responsable de son domaine.
+- Avoir accompagné de nouveaux·elles ou occasionnel·le·s contributeur·ice·s et aidé à préparer des requêtes de tirage prêtes à fusionner.
+- Avoir assisté à la réunion communautaire qui a lieu tous les deux mois.
+
+**Privilèges&nbsp;:**
+
+Les expert·e·s invité·e·s sont ajouté·e·s à l'[équipe des expert·e·s invité·e·s <sup>(angl.)</sup>](https://github.com/orgs/mdn/teams/invited-experts-and-co-maintainers) et à l'équipe du domaine ou projet concerné. Ils·Elles peuvent&nbsp;:
+
+- Accéder au dépôt pour approuver et fusionner des requêtes de tirage.
+- Recommander et voter pour d'autres membres pour devenir expert·e invité·e.
+- Participer à l'appel éditorial hebdomadaire MDN Web Docs.
+
+### Community manager
+
+Les community managers ont un rôle particulier à plusieurs égards.
+Ils·Elles partagent de nombreuses responsabilités avec les [mainteneur·euse·s](#mainteneur·euse).
+En plus, ils·elles doivent&nbsp;:
+
+- Traiter les signalements de violation du [code de conduite <sup>(angl.)</sup>](https://github.com/mdn/mdn-community/blob/main/CODE_OF_CONDUCT.md) qui correspond aux [règles de participation de la communauté Mozilla](https://www.mozilla.org/fr/about/governance/policies/participation/) et décider des actions appropriées.
+- Organiser et animer des événements communautaires.
+- Organiser des réunions de projet liées à la communauté.
+- Définir des stratégies médias pour promouvoir le projet MDN.
+- Définir et mettre en place l'expérience d'intégration des contributeur·ice·s.
+- Accueillir les nouveaux·elles contributeur·ice·s et utilisateur·ice·s.
+- Veiller à la santé et au bien-être du projet MDN et de ses participant·e·s.
+- Identifier et aider à la mise en place d'automatisations pour améliorer la pérennité du projet.
+- Maintenir une relation saine avec les contributeur·ice·s et partenaires.
+- Aider à la gestion des signalements et à la relecture des requêtes de tirage si besoin.
+- Surveiller tous les [canaux de communication](/fr/docs/MDN/Community/Communication_channels).
+- Mettre en avant les contributeur·ice·s qui se sont illustré·e·s ou ont montré un engagement particulier pour le projet MDN.
+
+## Processus
+
+### Nomination d'un·e mainteneur·euse
+
+Voir qui peut être [mainteneur·euse](#mainteneur·euse).
+
+Pour proposer quelqu'un comme mainteneur·euse, ouvrez un ticket sur GitHub&nbsp;:
+
+1. Dans l'onglet `Issues` du dépôt `mdn/mdn`, cliquez sur le bouton [**New issue**](https://github.com/mdn/mdn/issues/new/choose) à droite.
+2. Sous «&nbsp;Nominate a maintainer&nbsp;», cliquez sur le bouton **Get started**.
+3. Remplissez le formulaire avec les détails des contributions de la personne proposée et soumettez-le.
+
+### Nomination d'un·e contributeur·ice à la une
+
+Voir qui peut être [contributeur·ice à la une](#contributeur·ice_a_la_une).
+
+Pour proposer quelqu'un comme contributeur·ice à la une, ouvrez un ticket sur GitHub&nbsp;:
+
+1. Dans l'onglet `Issues` du dépôt `mdn/mdn`, cliquez sur le bouton [**New issue**](https://github.com/mdn/mdn/issues/new/choose) à droite.
+2. Sous «&nbsp;Nominate a spotlight contributor&nbsp;», cliquez sur le bouton **Get started**.
+3. Remplissez le formulaire avec les détails des contributions de la personne proposée et soumettez-le.
+
+L'équipe MDN contactera la personne nominée pour recueillir les informations à publier sur le [site](/fr/) dans la section «&nbsp;Contributeur·ice à la une&nbsp;».
+
+### Nomination d'un·e expert·e invité·e
+
+Voir qui peut être [expert·e invité·e](#expert·e_invité·e).
+
+Pour proposer quelqu'un comme expert·e invité·e, ouvrez un ticket sur GitHub&nbsp;:
+
+1. Dans l'onglet `Issues` du dépôt `mdn/mdn`, cliquez sur le bouton [**New issue**](https://github.com/mdn/mdn/issues/new/choose) à droite.
+2. Sous «&nbsp;Nominate an invited expert&nbsp;», cliquez sur le bouton **Get started**.
+3. Remplissez le formulaire avec les détails des contributions de la personne proposée et soumettez-le.
+
+### Se retirer ou demander le statut émérite
+
+La vie évolue et votre engagement en tant que contributeur·ice peut changer au fil du temps. Selon votre situation, vous pouvez&nbsp;:
+
+- Prendre temporairement du recul sur le projet.
+- Passer à un rôle moins exigeant.
+- Quitter complètement le projet (demander le statut émérite).
+
+Dans tous ces cas, n'hésitez pas à discuter de votre situation et de votre engagement actuel avec l'[équipe MDN](#contacter_léquipe_mdn).
+
+### Rétrograder ou retirer des contributeur·ice·s inactif·ive·s
+
+Un·e contributeur·ice peut être rétrogradé·e ou retiré·e si les responsabilités et exigences ne sont pas respectées, notamment en cas d'inactivité répétée ou de violation du [code de conduite <sup>(angl.)</sup>](https://github.com/mdn/mdn-community/blob/main/CODE_OF_CONDUCT.md).
+
+La rétrogradation ou le retrait est proposé·e par un·e participant·e lors d'une réunion des mainteneur·euse·s.
+La personne proposeuse fournit des éléments pour justifier la demande.
+Après discussion, les mainteneur·euse·s et community managers votent pour prendre une décision.
+
+Retirer les contributeur·ice·s inactif·ive·s protège le projet et ses livrables, et ouvre aussi des opportunités pour de nouveaux·elles contributeur·ice·s.
+
+Nous définissons l'inactivité comme suit&nbsp;:
+
+- Aucune contribution au projet depuis au moins six mois.
+- Aucune réponse aux sollicitations depuis au moins trois mois.
+
+L'inactivité nuit au projet&nbsp;: elle peut entraîner des retards, une perte de contributeur·ice·s et une perte de confiance. Les contributeur·ice·s doivent rester actif·ive·s pour montrer l'exemple et leur engagement.
+
+Merci de communiquer avec l'équipe communauté pour éviter une rétrogradation ou un retrait si votre disponibilité change&nbsp;; vous pouvez aussi choisir de [vous retirer temporairement ou demander le statut émérite](#stepping_down_or_applying_for_emeritus_status).
+
+## Équipes
+
+Nous gérons les équipes à l'aide de la fonctionnalité [équipes GitHub(https://docs.github.com/fr/organizations/organizing-members-into-teams/about-teams). Être ajouté·e à une équipe signifie que vous avez exprimé votre volonté de vous impliquer davantage dans le projet. Cela implique aussi des responsabilités et droits supplémentaires, détaillés ci-dessous&nbsp;:
+
+- Une personne membre d'une équipe est généralement ajoutée au fichier [CODEOWNERS <sup>(angl.)</sup>](https://github.com/mdn/content/blob/main/.github/CODEOWNERS) pour son ou ses domaines d'intérêt.
+
+- Lorsqu'une requête de tirage concerne des fichiers de votre domaine de responsabilité (selon le fichier CODEOWNERS), vous serez automatiquement ajouté·e comme relecteur·ice grâce à l'[algorithme d'équilibrage de charge de GitHub](https://docs.github.com/fr/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#routing-algorithms).
+
+- Les membres d'une équipe disposent d'un accès de niveau supérieur aux dépôts. Les droits sont accordés uniquement sur les dépôts nécessaires.
+
+Les équipes de l'[organisation MDN sur GitHub <sup>(angl.)</sup>](https://github.com/orgs/mdn/teams) incluent&nbsp;:
+
+- `@Core`&nbsp;: équipe principale MDN Web Docs
+- `@mdn-community-engagement`&nbsp;: personnes responsables de l'engagement communautaire sur nos dépôts
+- `@mdn-product`&nbsp;: personnes responsables du produit MDN Plus
+- `@localization-team-leads`&nbsp;: responsables des équipes de localisation
+- `@OWD`&nbsp;: contributeur·ice·s de l'organisation à but non lucratif Open Web Docs
+- `@sre`&nbsp;: ingénieur·e·s fiabilité du site MDN Web Docs
+- `@content`&nbsp;: équipe principale de relecture du contenu MDN Web Docs
+  - Il existe des sous-équipes pour chaque domaine (accessibilité, modules complémentaires, CSS, HTML, HTTP, JavaScript, SVG, Web API, WebAssembly). Par exemple, `@content-css` et `@content-svg`.
+  - Il existe aussi des sous-équipes pour chaque langue (portugais brésilien, chinois, français, japonais, coréen, russe, espagnol). Par exemple, `@content-fr` et `@content-ko`.
+
+Pour devenir membre d'une équipe, vous devez&nbsp;:
+
+- Accepter de respecter nos [règles de participation à la communauté](https://www.mozilla.org/fr/about/governance/policies/participation/).
+- Accepter les [exigences d'accès aux dépôts Mozilla](https://www.mozilla.org/fr/about/governance/policies/commit/requirements/).
+- Activer la [double authentification](https://docs.github.com/fr/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication) (2FA) sur votre compte GitHub.
+
+## Contacter l'équipe MDN
+
+Pour toute question ou retour, contactez mdn-web-docs-community (at) mozilla (.com).


### PR DESCRIPTION
### Description

Create translation of pages without french version: `MDN/Community/Roles_teams`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_