### PR TITLE
chore(fr): translation of `Glossary/Identity_provider`

### DIFF
--- a/files/fr/glossary/identity_provider/index.md
+++ b/files/fr/glossary/identity_provider/index.md
@@ -1,0 +1,19 @@
+---
+title: Fournisseur d'identité (IdP)
+slug: Glossary/Identity_provider
+l10n:
+  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+---
+
+Un **fournisseur d'identité** (ou <abbr>IdP</abbr> pour <i lang="en">Identity Provider</i> en anglais) est une entité dans un système d'{{Glossary("federated identity", "identité fédérée")}} qui gère les {{Glossary("credential", "identifiants")}} d'un·e utilisateur·ice et peut {{Glossary("authentication", "authentifier")}} les utilisateur·ice·s.
+
+Dans les systèmes d'identité fédérée, les {{Glossary("relying party", "parties de confiance")}} qui doivent contrôler l'accès à une ressource (par exemple, un site web décidant de connecter un·e utilisateur·ice) délèguent l'acte d'authentification à un tiers, en qui elles ont confiance pour prendre la décision d'authentification. Ces tiers sont appelés fournisseurs d'identité.
+
+Des exemples de fournisseurs d'identité sur le web incluent Google, Microsoft et Facebook. Cela permet aux sites web d'autoriser les utilisateur·ice·s à se connecter avec leur compte Google, Microsoft ou Facebook.
+
+## Voir aussi
+
+- Termes associés du glossaire&nbsp;:
+  - {{Glossary("Federated identity", "Identité fédérée")}}
+  - {{Glossary("Relying party", "Partie de confiance")}}
+- [L'API Federated Credential Management (FedCM)](/fr/docs/Web/API/FedCM_API)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Glossary/Identity_provider`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_