### PR TITLE
[zh-cn] fix dataview getfloat64 example code error

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/dataview/getfloat64/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/dataview/getfloat64/index.md
@@ -47,9 +47,9 @@ dataview.getFloat64(byteOffset [, littleEndian])
 ## 示例
 
 ```js
-var buffer = new ArrayBuffer(8);
-var dataview = new DataView(buffer);
-dataview.getFloat64(1); // 0
+const { buffer } = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+const dataview = new DataView(buffer);
+console.log(dataview.getFloat64(1)); // 8.20788039913184e-304
 ```
 
 ## 规范


### PR DESCRIPTION
Updated example to demonstrate getFloat64 with a Uint8Array.

同步英文的示例代码，目前中文文档的代码，执行会报错。

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
