### PR TITLE
Fix links in zh-TW cookie glossary entry

### DIFF
--- a/files/zh-tw/glossary/cookie/index.md
+++ b/files/zh-tw/glossary/cookie/index.md
@@ -7,7 +7,7 @@ Cookie 是一個網站通過瀏覽器訪問在訪客電腦裏留下的一小段�
 
 Cookies 被網站用於個性化用戶個人的網頁體驗。訪問該網站時它可能覆蓋了用戶的喜好或輸入。用戶可以自定義他們的瀏覽器是個接受或是刪除 cookies.
 
-Cookies 可以設置和修改，在伺服器級別使用`Set-Cookie` [HTTP header](/zh-TW/docs/Web/HTTP/Guides/Cookies), 或在 JavaScript 使用 [`document.cookie`](/zh-TW/docs/Web/API/Document/cookie).
+Cookies 可以設置和修改，在伺服器級別使用`Set-Cookie` [HTTP header](/zh-tw/web/http/guides/cookies), 或在 JavaScript 使用 [`document.cookie`](/zh-TW/docs/Web/API/Document/cookie).
 
 ## 了解更多
 

--- a/files/zh-tw/glossary/cookie/index.md
+++ b/files/zh-tw/glossary/cookie/index.md
@@ -7,7 +7,7 @@ Cookie 是一個網站通過瀏覽器訪問在訪客電腦裏留下的一小段�
 
 Cookies 被網站用於個性化用戶個人的網頁體驗。訪問該網站時它可能覆蓋了用戶的喜好或輸入。用戶可以自定義他們的瀏覽器是個接受或是刪除 cookies.
 
-Cookies 可以設置和修改，在伺服器級別使用`Set-Cookie` [HTTP header](/zh-tw/web/http/guides/cookies), 或在 JavaScript 使用 [`document.cookie`](/zh-TW/docs/Web/API/Document/cookie).
+Cookies 可以設置和修改，在伺服器級別使用`Set-Cookie` [HTTP header](/files/zh-tw/web/http/guides/cookies), 或在 JavaScript 使用 [`document.cookie`](/zh-TW/docs/Web/API/Document/cookie).
 
 ## 了解更多
 


### PR DESCRIPTION
### Description
Updated broken or plain text references in the zh-TW cookie glossary entry.  
Replaced raw text mentions of **Set-Cookie** and **document.cookie** with proper Markdown links to MDN Web Docs.

### Motivation
This change improves readability and usability for readers.  
By linking to authoritative MDN documentation, users can directly access detailed references instead of searching manually.

### Additional details
- Updated link: `files/zh-tw/glossary/cookie/index.md`  

### Related issues and pull requests
No related issues found.  
This PR is a standalone fix to improve documentation quality.
