### PR TITLE
docs(SECURITY): sync security policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,3 +50,4 @@
 
 # Reset until https://github.com/prettier/prettier/issues/11828 is fixed
 /.prettierignore
+/SECURITY.md @mdn/engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,7 @@
 /*.md                @mdn/content-team @mdn/engineering 
 /CONTRIBUTING.md     @mdn/content-team          
 /PEERS_GUIDELINES.md @mdn/content-team
+/SECURITY.md @mdn/engineering
 
 # Reset until https://github.com/prettier/prettier/issues/11828 is fixed
 /.prettierignore
-/SECURITY.md @mdn/engineering

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Overview
+
+This policy applies to MDN's website (`developer.mozilla.org`), backend services, and GitHub repositories in the [`mdn`](https://github.com/mdn) organization. Issues affecting other Mozilla products or services should be reported through the [Mozilla Security Bug Bounty Program](https://www.mozilla.org/en-US/security/bug-bounty/).
+
+For non-security issues, please file a [content bug](https://github.com/mdn/content/issues/new/choose), a [website bug](https://github.com/mdn/fred/issues/new/choose) or a [content/feature suggestion](https://github.com/mdn/mdn/issues/new/choose).
+
+## Reporting a Vulnerability
+
+If you discover a potential security issue, please report it privately via <https://hackerone.com/mozilla>.
+
+If you prefer not to use HackerOne, you can report it via <https://bugzilla.mozilla.org/form.web.bounty>.
+
+## Bounty Program
+
+Vulnerabilities in MDN may qualify for Mozilla's Bug Bounty Program. Eligibility and reward amounts are described on <https://hackerone.com/mozilla>.
+
+Please use the above channels even if you are not interested in a bounty reward.
+
+## Responsible Disclosure
+
+Please do not publicly disclose details until Mozilla's security team and the MDN engineering team have verified and fixed the issue.
+
+We appreciate your efforts to keep MDN and its users safe.


### PR DESCRIPTION
### Description

Syncs the `SECURITY.md` file with the [canonical version from mdn/fred](https://github.com/mdn/fred/blob/main/SECURITY.md).

### Motivation

Ensures consistent security reporting procedures across all MDN repositories.

### Additional details

See: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1068.