### PR TITLE
[zh-cn] translation correction

### DIFF
--- a/files/zh-cn/learn_web_development/extensions/performance/javascript/index.md
+++ b/files/zh-cn/learn_web_development/extensions/performance/javascript/index.md
@@ -156,7 +156,7 @@ import("./modules/myModule.js").then((module) => {
 
 当浏览器运行 JavaScript 时，它会将脚本组织成按顺序运行的任务，例如进行 fetch 请求、通过事件处理程序驱动用户交互和输入、运行 JavaScript 驱动的动画等等。
 
-大部分任务都在主线程上运行，其中包括运行在 [Web Worker](/zh-CN/docs/Web/API/Web_Workers_API/Using_web_workers) 中的 JavaScript。主线程一次只能运行一个任务。
+大部分任务都在主线程上运行，但也有例外，比如运行在 [Web Worker](/zh-CN/docs/Web/API/Web_Workers_API/Using_web_workers) 中的 JavaScript。主线程一次只能运行一个任务。
 
 当单个任务的执行时间超过 50 毫秒时，它被归类为长任务。如果用户在长任务正在运行时尝试与页面交互或请求重要的 UI 更新，他们的体验将受到影响。预期的响应或视觉更新将被延迟，导致 UI 看起来迟钝或无响应。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix incorrect Chinese translation in the Performant JavaScript article.
The original English text says:

> “Most of this happens on the main thread, with exceptions including JavaScript that runs in Web Workers.”

The previous Chinese translation was:

> “大部分任务都在主线程上运行，其中包括运行在 Web Worker 中的 JavaScript。”

This is inaccurate because it reverses the meaning of “with exceptions including,” implying that Web Worker code also runs on the main thread.
The corrected translation is:

> “大部分操作都在主线程上执行，但也有例外，比如运行在 Web Worker 中的 JavaScript。”

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

To ensure the Chinese translation accurately reflects the original English meaning.
The previous wording could mislead readers to think that JavaScript in Web Workers runs on the main thread, which is incorrect.
This fix improves technical accuracy and clarity for Chinese readers.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Reference (English version):
[JavaScript performance optimization - Learn web development | MDN](https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Performance/JavaScript#breaking_down_long_tasks)
Original sentence:

> “Most of this happens on the main thread, with exceptions including JavaScript that runs in Web Workers. The main thread can run only one task at a time.”

Reference (Chinese version):
[JavaScript 性能优化 - 学习 Web 开发 | MDN](https://developer.mozilla.org/zh-CN/docs/Learn_web_development/Extensions/Performance/JavaScript#分解长任务)

Original sentence:
> “大部分任务都在主线程上运行，其中包括运行在 Web Worker 中的 JavaScript。主线程一次只能运行一个任务。”

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
