### PR TITLE
fix: wrong term translation in zh-tw

### DIFF
--- a/files/zh-tw/mozilla/add-ons/webextensions/your_first_webextension/index.md
+++ b/files/zh-tw/mozilla/add-ons/webextensions/your_first_webextension/index.md
@@ -65,9 +65,9 @@ cd borderify
 
 ### icons/border-48.png
 
-附加元件要有一個圖示。它會在附加元件管理員的附加元件清單旁邊列出來。我們的 manifest.json 已經說好了，要在 "icons/border-48.png" 那邊會有個圖示。
+附加元件要有一個圖示。它會在附加元件管理員的附加元件清單旁邊列出來。我們的 manifest.json 已經說好了，要在「icons/border-48.png」那邊會有個圖示。
 
-在 "borderify" 目錄下直接建立 "icons" 目錄，並儲存一個叫 "border-48.png" 的圖示檔。你可以用[範例的這張圖示](https://github.com/mdn/webextensions-examples/blob/master/borderify/icons/border-48.png)，它是從 Google Material Design 圖示集抓下來的，並使用[創用 CC：姓名標示-相同方式分享](https://creativecommons.org/licenses/by-sa/3.0/deed.zh_TW)授權。
+在「borderify」目錄下直接建立「icons」目錄，並儲存一個叫「border-48.png」的圖示檔。你可以用[範例的這張圖示](https://github.com/mdn/webextensions-examples/blob/master/borderify/icons/border-48.png)，它是從 Google Material Design 圖示集抓下來的，並使用[創用 CC：姓名標示-相同方式分享](https://creativecommons.org/licenses/by-sa/3.0/deed.zh_TW)授權。
 
 如果你要用自己的圖示，它應該是 48x48 像素。你也可以針對高解析度提供 96x96 像素的圖示，這樣的話它在 manifest.json 會被指定為 `icons` 物件內的 `96` property：
 

--- a/files/zh-tw/mozilla/add-ons/webextensions/your_first_webextension/index.md
+++ b/files/zh-tw/mozilla/add-ons/webextensions/your_first_webextension/index.md
@@ -65,11 +65,11 @@ cd borderify
 
 ### icons/border-48.png
 
-附加元件要有一個圖標。它會在附加元件管理員的附加元件清單旁邊列出來。我們的 manifest.json 已經說好了，要在 "icons/border-48.png" 那邊會有個圖標。
+附加元件要有一個圖示。它會在附加元件管理員的附加元件清單旁邊列出來。我們的 manifest.json 已經說好了，要在 "icons/border-48.png" 那邊會有個圖示。
 
-在 "borderify" 目錄下直接建立 "icons" 目錄，並儲存一個叫 "border-48.png" 的圖標檔。你可以用[範例的這張圖標](https://github.com/mdn/webextensions-examples/blob/master/borderify/icons/border-48.png)，它是從 Google Material Design 圖標集抓下來的，並使用[創用 CC：姓名標示-相同方式分享](https://creativecommons.org/licenses/by-sa/3.0/deed.zh_TW)授權。
+在 "borderify" 目錄下直接建立 "icons" 目錄，並儲存一個叫 "border-48.png" 的圖示檔。你可以用[範例的這張圖示](https://github.com/mdn/webextensions-examples/blob/master/borderify/icons/border-48.png)，它是從 Google Material Design 圖示集抓下來的，並使用[創用 CC：姓名標示-相同方式分享](https://creativecommons.org/licenses/by-sa/3.0/deed.zh_TW)授權。
 
-如果你要用自己的圖標，它應該是 48x48 像素。你也可以針對高解析度提供 96x96 像素的圖標，這樣的話它在 manifest.json 會被指定為 `icons` 物件內的 `96` property：
+如果你要用自己的圖示，它應該是 48x48 像素。你也可以針對高解析度提供 96x96 像素的圖示，這樣的話它在 manifest.json 會被指定為 `icons` 物件內的 `96` property：
 
 ```json
 "icons": {
@@ -80,7 +80,7 @@ cd borderify
 
 要不然，你也能提供 SVG 檔，它就會等比縮放。
 
-- [深入理解指定圖標。](/zh-TW/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons)
+- [深入理解指定圖示。](/zh-TW/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons)
 
 ### borderify.js
 


### PR DESCRIPTION
### Description

"icon" is "圖示" in Taiwan, not "圖標" (used in China).

### Motivation

Correct translation is good for everyone :)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
