### PR TITLE
[zh-cn]: translate CommandEvent command property

### DIFF
--- a/files/zh-cn/web/api/commandevent/command/index.md
+++ b/files/zh-cn/web/api/commandevent/command/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{APIRef("Invoker Commands API")}}
 
-{{domxref("CommandEvent")}} 接口的只读属性 **`command`** 返回一个字符串，表示派发该事件的元素的 {{domxref("HTMLButtonElement.command", "command")}} 属性的值。
+{{domxref("CommandEvent")}} 接口的只读属性 **`command`** 返回一个表示派发该事件的元素的 {{domxref("HTMLButtonElement.command", "command")}} 属性值的字符串。
 
 ## 值
 
@@ -15,7 +15,7 @@ l10n:
 
 ## 示例
 
-在下面的简单示例中，我们设置了一个事件监听器来监听 `show-modal` 命令：
+在下面的简单示例中，我们设置了一个事件监听器来监听“show-modal”命令：
 
 ```js
 document.body.addEventListener(
@@ -24,7 +24,7 @@ document.body.addEventListener(
     const theAction = event.command;
 
     if (theAction === "show-modal") {
-      console.log("Showing modal dialog");
+      console.log("展示模态对话框");
     }
   },
   { capture: true },

--- a/files/zh-cn/web/api/commandevent/command/index.md
+++ b/files/zh-cn/web/api/commandevent/command/index.md
@@ -1,0 +1,46 @@
+---
+title: CommandEvent：command 属性
+slug: Web/API/CommandEvent/command
+l10n:
+  sourceCommit: ffa6f5871f50856c60983a125cef7de267be7aeb
+---
+
+{{APIRef("Invoker Commands API")}}
+
+{{domxref("CommandEvent")}} 接口的只读属性 **`command`** 返回一个字符串，表示派发该事件的元素的 {{domxref("HTMLButtonElement.command", "command")}} 属性的值。
+
+## 值
+
+字符串。
+
+## 示例
+
+在下面的简单示例中，我们设置了一个事件监听器来监听 `show-modal` 命令：
+
+```js
+document.body.addEventListener(
+  "command",
+  (event) => {
+    const theAction = event.command;
+
+    if (theAction === "show-modal") {
+      console.log("Showing modal dialog");
+    }
+  },
+  { capture: true },
+);
+```
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- {{domxref("Invoker Commands API", "调用者命令 API", "", "nocode")}}
+- {{domxref("HTMLButtonElement.command")}}
+- {{domxref("HTMLButtonElement.commandForElement")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

translate CommandEvent command property

### Motivation

Learning and translating.

### Additional details

None.

### Related issues and pull requests

Relates to https://github.com/mdn/translated-content/pull/28500
