### PR TITLE
Intl Locale Info API Proposal で提案されているIntl.Localeインスタンスのメソッド群の翻訳追従

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/intl/locale/getcalendars/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/getcalendars/index.md
@@ -8,7 +8,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCalendars
 {{jsxref("Intl.Locale")}} インスタンスの **`getCalendars()`** メソッドは、 `Locale` の 1 つ以上の固有のカレンダー識別子の配列を返します。
 
 > [!NOTE]
-> 一部のブラウザーのあるバージョンでは、このメソッドが `calendars` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.calendars === locale.calendars` が常に `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
+> 一部のブラウザーのあるバージョンでは、このメソッドが `calendars` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.calendars === locale.calendars` が常に `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#ブラウザーの互換性)の表を確認してください。
 
 ## 構文
 
@@ -24,13 +24,13 @@ getCalendars()
 
 `Locale` で一般的に使用されるすべてのカレンダーを、優先度の高い順に並べた文字列の配列。`Locale` にすでに [`calendar`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar) が設定されている場合、返される配列はその値のみになります。
 
-対応している暦の一覧については、[`Intl.supportedValuesOf()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#supported_calendar_types) を参照してください。
+対応している暦の一覧については、[`Intl.supportedValuesOf()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#対応している暦) を参照してください。
 
 ## 例
 
 ### 対応しているカレンダーを取得
 
-`Locale` オブジェクトに `calendar` が設定されていない場合、`getCalendars()` は指定された `Locale` で一般的に使用されるすべてのカレンダーをリストアップします。`calendar` を明示的に設定する例については、[`calendar` の例](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar#examples) を参照してください。
+`Locale` オブジェクトに `calendar` が設定されていない場合、`getCalendars()` は指定された `Locale` で一般的に使用されるすべてのカレンダーをリストアップします。`calendar` を明示的に設定する例については、[`calendar` の例](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar#例) を参照してください。
 
 ```js
 let arEG = new Intl.Locale("ar-EG");

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/getcalendars/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/getcalendars/index.md
@@ -1,64 +1,36 @@
 ---
-title: Intl.Locale.prototype.calendars
+title: Intl.Locale.prototype.getCalendars()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCalendars
 ---
 
 {{JSRef}}
 
-**`Intl.Locale.prototype.calendars`** プロパティは、 `Locale` のカレンダー識別子の配列を返すアクセサープロパティです。
+{{jsxref("Intl.Locale")}} インスタンスの **`getCalendars()`** メソッドは、 `Locale` の 1 つ以上の固有のカレンダー識別子の配列を返します。
 
-## 解説
+> [!NOTE]
+> 一部のブラウザーのあるバージョンでは、このメソッドが `calendars` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.calendars === locale.calendars` が常に `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
 
-`calendar` プロパティは、 `Locale` で対応しているすべてのカレンダーを配列で返します。配列の項目は、 `Locale` オブジェクトの暦年代を表します。以下の表は、有効なすべての Unicode 暦キー文字列と、それらが表す暦の時代の説明を示しています。
+## 構文
 
-### Unicode 暦キー
+```js-nolint
+getCalendars()
+```
 
-- `buddhist`
-  - : タイの仏教暦
-- `chinese`
-  - : 古来の中国の暦
-- `coptic`
-  - : コプト暦
-- `dangi`
-  - : 古来の韓国の暦
-- `ethioaa`
-  - : Ethiopic calendar, Amete Alem (epoch approx. 5493 B.C.E)
-- `ethiopic`
-  - : Ethiopic calendar, Amete Mihret (epoch approx, 8 C.E.)
-- `gregory`
-  - : グレゴリオ暦
-- `hebrew`
-  - : 古来のヘブライ暦
-- `indian`
-  - : インド暦
-- `islamic`
-  - : イスラム暦
-- `islamic-umalqura`
-  - : イスラム暦、ウンムアルクーラ
-- `islamic-tbla`
-  - : イスラム暦、表形式 (閏年 [2,5,7,10,13,16,18,21,24,26,29] - 天体暦)
-- `islamic-civil`
-  - : イスラム暦、表形式 (閏年 [2,5,7,10,13,16,18,21,24,26,29] - 市民暦)
-- `islamic-rgsa`
-  - : イスラム暦、サウジアラビア地方
-- `iso8601`
-  - : ISO カレンダー (ISO 8601 カレンダーの曜日規則を使用したグレゴリオ暦)
-- `japanese`
-  - : 日本の皇紀
-- `persian`
-  - : ペルシャ暦
-- `roc`
-  - : 中華民国暦 (中華民国)
-- `islamicc`
-  - : シビル（アルゴリズム）アラビア暦
-    > [!WARNING]
-    > `islamicc` 暦は非推奨です。 `islamic-civil` を使用してください。
+### 引数
+
+なし。
+
+### 返値
+
+`Locale` で一般的に使用されるすべてのカレンダーを、優先度の高い順に並べた文字列の配列。`Locale` にすでに [`calendar`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar) が設定されている場合、返される配列はその値のみになります。
+
+対応している暦の一覧については、[`Intl.supportedValuesOf()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#supported_calendar_types) を参照してください。
 
 ## 例
 
 ### 対応しているカレンダーを取得
 
-この `Locale` が対応しているカレンダーをリスト出力します。
+`Locale` オブジェクトに `calendar` が設定されていない場合、`getCalendars()` は指定された `Locale` で一般的に使用されるすべてのカレンダーをリストアップします。`calendar` を明示的に設定する例については、[`calendar` の例](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar#examples) を参照してください。
 
 ```js
 let arEG = new Intl.Locale("ar-EG");
@@ -81,4 +53,5 @@ console.log(jaJP.calendars); // logs ["gregory", "japanese"]
 ## 関連情報
 
 - {{jsxref("Intl/Locale", "Intl.Locale")}}
+- {{jsxref("Intl/Locale/calendar", "Intl.Locale.prototype.calendar")}}
 - [Unicode カレンダー識別子](https://www.unicode.org/reports/tr35/#UnicodeCalendarIdentifier)

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/getcollations/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/getcollations/index.md
@@ -1,0 +1,49 @@
+---
+title: Intl.Locale.prototype.getCollations()
+slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCollations
+---
+
+{{jsxref("Intl.Locale")}} インスタンスの **`getCollations()`** メソッドは、このロケールの 1 つ以上の[照合種別](https://www.unicode.org/reports/tr35/tr35-collation.html#CLDR_collation)のリストを返します。
+
+> [!NOTE]
+> 一部のブラウザーのあるバージョンでは、このメソッドが `collations` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.collations === locale.collations` が `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
+
+## 構文
+
+```js-nolint
+getCollations()
+```
+
+### 引数
+
+なし。
+
+### 返値
+
+`Locale` で一般的に使用されるすべての照合種別を、アルファベット順にソートして並べた文字列の配列。`standard` と `search` の値は常に除外されます。`Locale` にすでに [`collation`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/collation) が設定されている場合、返される配列はその単一の値のみを含みます。
+
+対応している照合種別の一覧については、[`Intl.supportedValuesOf()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#supported_collation_types) を参照してください。
+
+## 例
+
+### 対応している照合種別を取得
+
+`Locale` オブジェクトに `collation` が設定されていない場合、`getCollations()` は指定された `Locale` で一般的に使用されるすべての照合種別をリストアップします。`collation` を明示的に設定する例については、[`collation` の例](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/collation#examples) を参照してください。
+
+```js
+const locale = new Intl.Locale("zh");
+console.log(locale.getCollations()); // ["pinyin", "stroke", "zhuyin", "emoji", "eor"]
+```
+
+## 仕様書
+
+{{Specifications}}
+
+## ブラウザーの互換性
+
+{{Compat}}
+
+## 関連情報
+
+- {{jsxref("Intl.Locale")}}
+- [`Intl.Locale.prototype.collation`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/collation)

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/getcollations/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/getcollations/index.md
@@ -6,7 +6,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCollations
 {{jsxref("Intl.Locale")}} インスタンスの **`getCollations()`** メソッドは、このロケールの 1 つ以上の[照合種別](https://www.unicode.org/reports/tr35/tr35-collation.html#CLDR_collation)のリストを返します。
 
 > [!NOTE]
-> 一部のブラウザーのあるバージョンでは、このメソッドが `collations` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.collations === locale.collations` が `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
+> 一部のブラウザーのあるバージョンでは、このメソッドが `collations` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.collations === locale.collations` が `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#ブラウザーの互換性)の表を確認してください。
 
 ## 構文
 
@@ -22,13 +22,13 @@ getCollations()
 
 `Locale` で一般的に使用されるすべての照合種別を、アルファベット順にソートして並べた文字列の配列。`standard` と `search` の値は常に除外されます。`Locale` にすでに [`collation`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/collation) が設定されている場合、返される配列はその単一の値のみを含みます。
 
-対応している照合種別の一覧については、[`Intl.supportedValuesOf()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#supported_collation_types) を参照してください。
+対応している照合種別の一覧については、[`Intl.supportedValuesOf()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#対応している照合型) を参照してください。
 
 ## 例
 
 ### 対応している照合種別を取得
 
-`Locale` オブジェクトに `collation` が設定されていない場合、`getCollations()` は指定された `Locale` で一般的に使用されるすべての照合種別をリストアップします。`collation` を明示的に設定する例については、[`collation` の例](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/collation#examples) を参照してください。
+`Locale` オブジェクトに `collation` が設定されていない場合、`getCollations()` は指定された `Locale` で一般的に使用されるすべての照合種別をリストアップします。`collation` を明示的に設定する例については、[`collation` の例](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/collation#例) を参照してください。
 
 ```js
 const locale = new Intl.Locale("zh");

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
@@ -1,39 +1,54 @@
 ---
-title: Intl.Locale.prototype.hourCycles
+title: Intl.Locale.prototype.getHourCycles()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getHourCycles
 ---
 
-{{JSRef}}
+{{jsxref("Intl.Locale")}} インスタンスの **`getHourCycles()`** メソッドは、`Locale` の 1 つ以上の固有の時制識別子の配列を返します。
 
-**`Intl.Locale.prototype.hourCycles`** プロパティは、この `Locale` に固有の時制識別子のリストを返すアクセサープロパティです。
+> [!NOTE]
+> 一部のブラウザーのあるバージョンでは、このメソッドが `hourCycles` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.hourCycles === locale.hourCycles` が常に `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
 
-## 解説
+## 構文
 
-世界中で使用されている時刻保持規則（時制）には、主に 12 時制と 24 時制の 2 つの種類があります。 `hourCycles` プロパティを使用すると、特定のロケールで利用できるすべての時制に簡単にアクセスできるようになります。他の追加ロケールデータと同様に、時制種別は[拡張サブタグ](https://www.unicode.org/reports/tr35/#u_Extension)であり、ロケール文字列に含まれるデータを拡張したものです。時制種別には、以下の表にある通り、いくつかの異なる値を設定することができます。
+```js-nolint
+getHourCycles()
+```
 
-### 有効な時制種別
+### 引数
 
-| 時制種別 | 説明                                                                                              |
-| -------- | ------------------------------------------------------------------------------------------------- |
-| `h12`    | 1–12 を使用する時制で、パターンの 'h' に対応します。 12 時制で、正子は午前 12:00 から始まります。 |
-| `h23`    | 0–23 を使用する時制で、パターンの 'H' に対応します。 24 時制で、正子は 0:00 から始まります。      |
-| `h11`    | 0–11 を使用する時制で、パターンの 'K' に対応します。 12 時制で、正子は午前 0:00 から始まります。  |
-| `h24`    | 1–24 を使用する時制で、パターンの 'k' に対応します。 24 時制で、正子は 24:00 から始まります。     |
+なし。
+
+### 返値
+
+`Locale` で一般的に使用されるすべての時制種別を、優先度の高い順に並べた文字列の配列。`Locale` にすでに [`hourCycle`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle) が設定されている場合、返される配列はその値のみになります。
+
+以下は対応している時制種別の一覧です。
+
+### 対応している時制種別
+
+- `h12`
+  - : 1–12 を使用する時制で、パターンの 'h' に対応します。 12 時制で、正子は午前 12:00 から始まります。例えば、アメリカ合衆国で使用されています。
+- `h23`
+  - : 0–23 を使用する時制で、パターンの 'H' に対応します。 24 時制で、正子は 0:00 から始まります。
+- `h11`
+  - : 0–11 を使用する時制で、パターンの 'K' に対応します。 12 時制で、正子は午前 0:00 から始まります。主に日本で使用されています。
+- `h24`
+  - : 1–24 を使用する時制で、パターンの 'k' に対応します。 24 時制で、正子は 24:00 から始まります。どこでも使用されていません。
 
 ## 例
 
-### 対応しているカレンダーを取得
+### 対応している時制を取得
 
-指定された `Locale` で対応している時制のリストを出力します。
+`Locale` オブジェクトに `hourCycle` が設定されていない場合、`getHourCycles()` は指定された `Locale` で一般的に使用されるすべての時制識別子をリストアップします。`hourCycle` を明示的に設定する例については、[`hourCycle` の例](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle#examples) を参照してください。
 
 ```js
-let arEG = new Intl.Locale("ar-EG");
-console.log(arEG.hourCycles); // logs ["h12"]
+const arEG = new Intl.Locale("ar-EG");
+console.log(arEG.getHourCycles()); // ["h12"]
 ```
 
 ```js
-let jaJP = new Intl.Locale("ja-JP");
-console.log(jaJP.hourCycles); // logs ["h23"]
+const jaJP = new Intl.Locale("ja-JP");
+console.log(jaJP.getHourCycles()); // ["h23"]
 ```
 
 ## 仕様書
@@ -47,4 +62,5 @@ console.log(jaJP.hourCycles); // logs ["h23"]
 ## 関連情報
 
 - {{jsxref("Intl.Locale")}}
-- [Unicode 時制拡張キー仕様書](https://www.unicode.org/reports/tr35/#UnicodeHourCycleIdentifier)
+- [`Intl.Locale.prototype.hourCycle`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle)
+- [Unicode 時制識別子](https://www.unicode.org/reports/tr35/#UnicodeHourCycleIdentifier)

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/gethourcycles/index.md
@@ -6,7 +6,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getHourCycles
 {{jsxref("Intl.Locale")}} インスタンスの **`getHourCycles()`** メソッドは、`Locale` の 1 つ以上の固有の時制識別子の配列を返します。
 
 > [!NOTE]
-> 一部のブラウザーのあるバージョンでは、このメソッドが `hourCycles` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.hourCycles === locale.hourCycles` が常に `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
+> 一部のブラウザーのあるバージョンでは、このメソッドが `hourCycles` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.hourCycles === locale.hourCycles` が常に `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#ブラウザーの互換性)の表を確認してください。
 
 ## 構文
 
@@ -39,7 +39,7 @@ getHourCycles()
 
 ### 対応している時制を取得
 
-`Locale` オブジェクトに `hourCycle` が設定されていない場合、`getHourCycles()` は指定された `Locale` で一般的に使用されるすべての時制識別子をリストアップします。`hourCycle` を明示的に設定する例については、[`hourCycle` の例](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle#examples) を参照してください。
+`Locale` オブジェクトに `hourCycle` が設定されていない場合、`getHourCycles()` は指定された `Locale` で一般的に使用されるすべての時制識別子をリストアップします。`hourCycle` を明示的に設定する例については、[`hourCycle` の例](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle#例) を参照してください。
 
 ```js
 const arEG = new Intl.Locale("ar-EG");

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/getnumberingsystems/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/getnumberingsystems/index.md
@@ -1,121 +1,43 @@
 ---
-title: Intl.Locale.prototype.numberingSystems
+title: Intl.Locale.prototype.getNumberingSystems()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getNumberingSystems
 ---
 
-{{JSRef}}
+{{jsxref("Intl.Locale")}} インスタンスの **`getNumberingSystems()`** メソッドは、`Locale` の 1 つ以上の固有の[記数法](https://en.wikipedia.org/wiki/Numeral_system)識別子の配列を返します。
 
-**`Intl.Locale.prototype.numberingSystems`** プロパティは、 `Locale` が使用する[記数法](https://en.wikipedia.org/wiki/Numeral_system)に関わる 1 つ以上の識別子を返すアクセサープロパティです。
+> [!NOTE]
+> 一部のブラウザーのあるバージョンでは、このメソッドが `numberingSystems` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.numberingSystems === locale.numberingSystems` が常に `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
 
-## 解説
+## 構文
 
-記数法とは、数値を表現するための体系のことです。 `numberingSystem` プロパティは、世界中のさまざまな国、地域、文化で使用されているさまざまな記数法を表現する支援をします。ほとんどの国際化スキーマと同様に、 `Locale` オブジェクトで `numberingSystem` によって表現できる記数法は、 Unicode で標準化されています。標準的な Unicode の記数法の表を以下に示します。
+```js-nolint
+getNumberingSystems()
+```
 
-| 値       | 説明                                               |
-| -------- | -------------------------------------------------- |
-| adlm     | アドラム数字                                       |
-| ahom     | アコム数字                                         |
-| arab     | アラビア・インド数字                               |
-| arabext  | 拡張アラビア・インド数字                           |
-| armn     | 大文字のアルメニア数字 — アルゴリズム              |
-| armnlow  | 小文字のアルメニア数字 — アルゴリズム              |
-| bali     | Balinese digits                                    |
-| beng     | Bengali digits                                     |
-| bhks     | Bhaiksuki digits                                   |
-| brah     | Brahmi digits                                      |
-| cakm     | Chakma digits                                      |
-| cham     | Cham digits                                        |
-| cyrl     | キリル数字 — アルゴリズム                          |
-| deva     | Devanagari digits                                  |
-| ethi     | エチオピア数字 — アルゴリズム                      |
-| finance  | 金融数字 — アルゴリズムの場合あり                  |
-| fullwide | 全角数字                                           |
-| geor     | ジョージア数字 — アルゴリズム                      |
-| gong     | Gunjala Gondi digits                               |
-| gonm     | Masaram Gondi digits                               |
-| grek     | 大文字のギリシャ数字 — アルゴリズム                |
-| greklow  | 小文字のギリシャ数字 — アルゴリズム                |
-| gujr     | Gujarati digits                                    |
-| guru     | Gurmukhi digits                                    |
-| hanidays | 太陰暦またはその他の旧暦向けの漢字による日付の数字 |
-| hanidec  | 漢数字表意文字による位置決め十進法                 |
-| hans     | 簡体字の漢数字 — アルゴリズム                      |
-| hansfin  | 簡体字の金融用漢数字 — アルゴリズム                |
-| hant     | 繁体字の漢数字 — アルゴリズム                      |
-| hantfin  | 繁体字の金融用漢数字 — アルゴリズム                |
-| hebr     | ヘブライ数字 — アルゴリズム                        |
-| hmng     | Pahawh Hmong digits                                |
-| hmnp     | Nyiakeng Puachue Hmong digits                      |
-| java     | Javanese digits                                    |
-| jpan     | 日本語の漢数字 — アルゴリズム                      |
-| jpanfin  | 日本語の金融用漢数字 — アルゴリズム                |
-| jpanyear | 最初の年を元年とした日本の暦用の記数法             |
-| kali     | Kayah Li digits                                    |
-| khmr     | Khmer digits                                       |
-| knda     | Kannada digits                                     |
-| lana     | Tai Tham Hora (secular) digits                     |
-| lanatham | Tai Tham (ecclesiastical) digits                   |
-| laoo     | Lao digits                                         |
-| latn     | ラテン数字                                         |
-| lepc     | Lepcha digits                                      |
-| limb     | Limbu digits                                       |
-| mathbold | 数学的太数字                                       |
-| mathdbl  | 数学的二重打鍵の数字                               |
-| mathmono | 数学的等幅数字                                     |
-| mathsanb | 数学的三セリフ太字数字                             |
-| mathsans | 数学的サンセリフ数字                               |
-| mlym     | Malayalam digits                                   |
-| modi     | Modi digits                                        |
-| mong     | Mongolian digits                                   |
-| mroo     | Mro digits                                         |
-| mtei     | Meetei Mayek digits                                |
-| mymr     | Myanmar digits                                     |
-| mymrshan | Myanmar Shan digits                                |
-| mymrtlng | Myanmar Tai Laing digits                           |
-| native   | ネイティブの数字                                   |
-| newa     | Newa digits                                        |
-| nkoo     | N'Ko digits                                        |
-| olck     | Ol Chiki digits                                    |
-| orya     | Oriya digits                                       |
-| osma     | Osmanya digits                                     |
-| rohg     | Hanifi Rohingya digits                             |
-| roman    | 大文字のローマ数字 — アルゴリズム                  |
-| romanlow | 小文字のローマ数字 — アルゴリズム                  |
-| saur     | Saurashtra digits                                  |
-| shrd     | Sharada digits                                     |
-| sind     | Khudawadi digits                                   |
-| sinh     | Sinhala Lith digits                                |
-| sora     | Sora_Sompeng digits                                |
-| sund     | Sundanese digits                                   |
-| takr     | Takri digits                                       |
-| talu     | New Tai Lue digits                                 |
-| taml     | タミル数字 — アルゴリズム                          |
-| tamldec  | Modern Tamil decimal digits                        |
-| telu     | Telugu digits                                      |
-| thai     | Thai digits                                        |
-| tirh     | Tirhuta digits                                     |
-| tibt     | Tibetan digits                                     |
-| traditio | 伝統的な数字 — アルゴリズムの場合あり              |
-| vaii     | Vai digits                                         |
-| wara     | Warang Citi digits                                 |
-| wcho     | Wancho digits                                      |
+### 引数
+
+なし。
+
+### 返値
+
+`Locale` で一般的に使用されるすべての記数法を、優先度の高い順に並べた文字列の配列。`Locale` にすでに [`numberingSystem`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem) が設定されている場合、返される配列はその値のみになります。
+
+対応している記数法の種別の一覧については、[`Intl.supportedValuesOf()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#supported_numbering_system_types) を参照してください。
 
 ## 例
 
-### ロケール文字列から `numberingSystem` の値を受け取る
+### 対応している記数法を取得
 
-[Unicode ロケール文字列仕様書](https://www.unicode.org/reports/tr35/)では、 `numberingSystem` が表す値はキー `nu` に対応しています。 `nu` はロケール文字列の「拡張サブタグ」とみなされます。これらのサブタグは、ロケールに関する追加データを追加するもので、拡張キー `-u` を使用してロケール識別子に追加されます。このようして、 `numberingSystem` の値を {{jsxref("Intl/Locale/Locale", "Locale")}} コンストラクターに渡される初期のロケール識別子文字列に追加することができます。 `numeric` の値を設定するには、まず文字列に `-u` 拡張キーを追加します。次に、 `-nu` 拡張キーを追加して、 `numberingSystem` の値を追加していることを示します。最後に、文字列に `numberingSystem` の値を追加します。
-
-指定された `Locale` が対応する記数法の一覧を出力します。
+`Locale` オブジェクトに `numberingSystem` が設定されていない場合、`getNumberingSystems()` は指定された `Locale` で一般的に使用されるすべての記数法をリストアップします。`numberingSystem` を明示的に設定する例については、[`numberingSystem` の例](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem#examples) を参照してください。
 
 ```js
-let arEG = new Intl.Locale("ar-EG");
-console.log(arEG.numberingSystems); // logs ["arab"]
+const arEG = new Intl.Locale("ar-EG");
+console.log(arEG.getNumberingSystems()); // ["arab"]
 ```
 
 ```js
-let ja = new Intl.Locale("ja");
-console.log(ja.numberingSystems); // logs ["latn"]
+const ja = new Intl.Locale("ja");
+console.log(ja.getNumberingSystems()); // ["latn"]
 ```
 
 ## 仕様書
@@ -128,5 +50,6 @@ console.log(ja.numberingSystems); // logs ["latn"]
 
 ## 関連情報
 
-- {{jsxref("Intl/Locale", "Intl.Locale")}}
-- [標準 Unicode 記数法の詳細](https://github.com/unicode-org/cldr/blob/main/common/supplemental/numberingSystems.xml)
+- {{jsxref("Intl.Locale")}}
+- [`Intl.Locale.prototype.numberingSystem`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem)
+- [Unicode 標準における記数法の詳細](https://github.com/unicode-org/cldr/blob/main/common/supplemental/numberingSystems.xml)

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/getnumberingsystems/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/getnumberingsystems/index.md
@@ -6,7 +6,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getNumberingSystems
 {{jsxref("Intl.Locale")}} インスタンスの **`getNumberingSystems()`** メソッドは、`Locale` の 1 つ以上の固有の[記数法](https://en.wikipedia.org/wiki/Numeral_system)識別子の配列を返します。
 
 > [!NOTE]
-> 一部のブラウザーのあるバージョンでは、このメソッドが `numberingSystems` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.numberingSystems === locale.numberingSystems` が常に `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
+> 一部のブラウザーのあるバージョンでは、このメソッドが `numberingSystems` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.numberingSystems === locale.numberingSystems` が常に `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#ブラウザーの互換性)の表を確認してください。
 
 ## 構文
 
@@ -22,13 +22,13 @@ getNumberingSystems()
 
 `Locale` で一般的に使用されるすべての記数法を、優先度の高い順に並べた文字列の配列。`Locale` にすでに [`numberingSystem`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem) が設定されている場合、返される配列はその値のみになります。
 
-対応している記数法の種別の一覧については、[`Intl.supportedValuesOf()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#supported_numbering_system_types) を参照してください。
+対応している記数法の種別の一覧については、[`Intl.supportedValuesOf()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#対応している記数法) を参照してください。
 
 ## 例
 
 ### 対応している記数法を取得
 
-`Locale` オブジェクトに `numberingSystem` が設定されていない場合、`getNumberingSystems()` は指定された `Locale` で一般的に使用されるすべての記数法をリストアップします。`numberingSystem` を明示的に設定する例については、[`numberingSystem` の例](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem#examples) を参照してください。
+`Locale` オブジェクトに `numberingSystem` が設定されていない場合、`getNumberingSystems()` は指定された `Locale` で一般的に使用されるすべての記数法をリストアップします。`numberingSystem` を明示的に設定する例については、[`numberingSystem` の例](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem#例) を参照してください。
 
 ```js
 const arEG = new Intl.Locale("ar-EG");

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/gettextinfo/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/gettextinfo/index.md
@@ -6,7 +6,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo
 {{jsxref("Intl.Locale")}} インスタンスの **`getTextInfo()`** メソッドは、ロケールに対して `ltr` (左書き) または `rtl` (右書き) で示される文字の並び順を返します。
 
 > [!NOTE]
-> 一部のブラウザーのあるバージョンでは、このメソッドが `textInfo` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しいオブジェクトを返すため、`locale.textInfo === locale.textInfo` が `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
+> 一部のブラウザーのあるバージョンでは、このメソッドが `textInfo` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しいオブジェクトを返すため、`locale.textInfo === locale.textInfo` が `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#ブラウザーの互換性)の表を確認してください。
 
 ## 構文
 

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/gettextinfo/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/gettextinfo/index.md
@@ -1,15 +1,29 @@
 ---
-title: Intl.Locale.prototype.textInfo
+title: Intl.Locale.prototype.getTextInfo()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo
 ---
 
-{{JSRef}}
+{{jsxref("Intl.Locale")}} インスタンスの **`getTextInfo()`** メソッドは、ロケールに対して `ltr` (左書き) または `rtl` (右書き) で示される文字の並び順を返します。
 
-**`Intl.Locale.prototype.textInfo`** プロパティは、関連する `Locale` に対して `ltr` （左書き）または `rtl` （右書き）で示される文字の並び順を返すアクセサープロパティです。
+> [!NOTE]
+> 一部のブラウザーのあるバージョンでは、このメソッドが `textInfo` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しいオブジェクトを返すため、`locale.textInfo === locale.textInfo` が `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
 
-## 解説
+## 構文
 
-[UTS 35's Layouts Elements](https://www.unicode.org/reports/tr35/tr35-general.html#Layout_Elements) で定義されているロケールのデータに結び付けた `Locale` 情報を返します。
+```js-nolint
+getTextInfo()
+```
+
+### 引数
+
+なし。
+
+### 返値
+
+[UTS 35 の Layouts Elements](https://www.unicode.org/reports/tr35/tr35-general.html#Layout_Elements) で定義されているロケールデータに結び付けられたテキスト組版情報を表すオブジェクト。このオブジェクトは以下のプロパティを持ちます。
+
+- `direction`
+  - : ロケールのテキストの方向を示す文字列。`"ltr"` (左書き) または `"rtl"` (右書き) のいずれかです。
 
 ## 例
 
@@ -18,15 +32,15 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo
 指定された `Locale` で対応している書字方向を返します。
 
 ```js
-let ar = new Intl.Locale("ar");
-console.log(ar.textInfo); // logs { direction: "rtl" }
-console.log(ar.textInfo.direction); // logs "rtl"
+const ar = new Intl.Locale("ar");
+console.log(ar.getTextInfo()); // { direction: "rtl" }
+console.log(ar.getTextInfo().direction); // "rtl"
 ```
 
 ```js
-let es = new Intl.Locale("es");
-console.log(es.textInfo); // logs { direction: "ltr" }
-console.log(es.textInfo.direction); // logs "ltr"
+const es = new Intl.Locale("es");
+console.log(es.getTextInfo()); // { direction: "ltr" }
+console.log(es.getTextInfo().direction); // "ltr"
 ```
 
 ## 仕様書
@@ -39,4 +53,4 @@ console.log(es.textInfo.direction); // logs "ltr"
 
 ## 関連情報
 
-- {{jsxref("Intl/Locale", "Intl.Locale")}}
+- {{jsxref("Intl.Locale")}}

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/gettimezones/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/gettimezones/index.md
@@ -6,7 +6,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTimeZones
 {{jsxref("Intl.Locale")}} インスタンスの **`getTimeZones()`** メソッドは、このロケールに対応しているタイムゾーンのリストを返します。
 
 > [!NOTE]
-> 一部のブラウザーのあるバージョンでは、このメソッドが `timeZones` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.timeZones === locale.timeZones` が `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
+> 一部のブラウザーのあるバージョンでは、このメソッドが `timeZones` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.timeZones === locale.timeZones` が `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#ブラウザーの互換性y)の表を確認してください。
 
 ## 構文
 

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/gettimezones/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/gettimezones/index.md
@@ -1,18 +1,29 @@
 ---
-title: Intl.Locale.prototype.timeZones
+title: Intl.Locale.prototype.getTimeZones()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTimeZones
 ---
 
-{{JSRef}}
-
-**`Intl.Locale.prototype.timeZones`** プロパティはアクセサープロパティで、選択した `Locale` で対応しているタイムゾーンの配列を返します。
-
-## 解説
-
-関連付けられた `Locale` で対応しているタイムゾーンを配列で返します。返されるタイムゾーンは [IANA タイムゾーン](https://en.wikipedia.org/wiki/Daylight_saving_time#IANA_time_zone_database) を表します。
+{{jsxref("Intl.Locale")}} インスタンスの **`getTimeZones()`** メソッドは、このロケールに対応しているタイムゾーンのリストを返します。
 
 > [!NOTE]
-> Unicode 言語識別子が Unicode 地域サブタグシーケンスの `-` を含んでいない場合、返される値は `undefined` です。
+> 一部のブラウザーのあるバージョンでは、このメソッドが `timeZones` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しい配列を返すため、`locale.timeZones === locale.timeZones` が `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
+
+## 構文
+
+```js-nolint
+getTimeZones()
+```
+
+### 引数
+
+なし。
+
+### 返値
+
+関連する `Locale` で対応しているタイムゾーンを表す文字列の配列。各値は [正規化されたIANA タイムゾーン名](/ja/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime#time_zones_and_offsets)で、アルファベット順にソートされています。ロケール識別子に地域サブタグが含まれていない場合、返される値は `undefined` です。
+
+> [!NOTE]
+> `Temporal` の標準化では、ブラウザーは常に IANA データベースの主識別子を返すことが求められており、これは時間とともに変わる可能性があります。詳細については、[タイムゾーンとオフセット](/ja/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime#time_zones_and_offsets)を参照してください。
 
 ## 例
 
@@ -21,18 +32,18 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTimeZones
 指定された `Locale` で対応しているタイムゾーンをリストアップします。
 
 ```js
-let arEG = new Intl.Locale("ar-EG");
-console.log(arEG.timeZones); // logs ["Africa/Cairo"]
+const arEG = new Intl.Locale("ar-EG");
+console.log(arEG.getTimeZones()); // ["Africa/Cairo"]
 ```
 
 ```js
-let jaJP = new Intl.Locale("ja-JP");
-console.log(jaJP.timeZones); // logs ["Asia/Tokyo"]
+const jaJP = new Intl.Locale("ja-JP");
+console.log(jaJP.getTimeZones()); // ["Asia/Tokyo"]
 ```
 
 ```js
-let ar = new Intl.Locale("ar");
-console.log(ar.timeZones); // logs undefined
+const ar = new Intl.Locale("ar");
+console.log(ar.getTimeZones()); // undefined
 ```
 
 ## 仕様書
@@ -45,5 +56,5 @@ console.log(ar.timeZones); // logs undefined
 
 ## 関連情報
 
-- {{jsxref("Intl/Locale", "Intl.Locale")}}
-- [IANA タイムゾーンデータベース](https://en.wikipedia.org/wiki/Daylight_saving_time#IANA_time_zone_database)
+- {{jsxref("Intl.Locale")}}
+- [IANA タイムゾーンデータベース](https://en.wikipedia.org/wiki/Daylight_saving_time#IANA_time_zone_database) (Wikipedia)

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/getweekinfo/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/getweekinfo/index.md
@@ -1,15 +1,33 @@
 ---
-title: Intl.Locale.prototype.weekInfo
+title: Intl.Locale.prototype.getWeekInfo()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo
 ---
 
-{{JSRef}}
+{{jsxref("Intl.Locale")}} インスタンスの **`getWeekInfo()`** メソッドは、このロケールに対して `firstDay`、`weekend`、`minimalDays` プロパティを持つ `weekInfo` オブジェクトを返します。
 
-**`Intl.Locale.prototype.weekInfo`** プロパティはアクセサープロパティで、関連する `Locale` の `firstDay`, `weekend`, `minimalDays` プロパティを持つ `weekInfo` オブジェクトを返します。
+> [!NOTE]
+> 一部のブラウザーのあるバージョンでは、このメソッドが `weekInfo` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しいオブジェクトを返すため、`locale.weekInfo === locale.weekInfo` が `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
 
-## 解説
+## 構文
 
-[UTS 35's Week Elements](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Patterns_Week_Elements) で指定されたロケールデータに関連する `Locale` 情報を返します。
+```js-nolint
+getWeekInfo()
+```
+
+### 引数
+
+なし。
+
+### 返値
+
+[UTS 35 の Week Elements](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Patterns_Week_Elements) で指定されたロケールデータに関連付けられた週情報を表すオブジェクト。このオブジェクトは以下のプロパティを持ちます。
+
+- `firstDay`
+  - : 1（月曜日）から 7（日曜日）までの整数で、ロケールにおける週の最初の曜日を示します。一般的には 1、5、6、または 7 です。
+- `weekend`
+  - : 1 から 7 までの整数の配列で、ロケールにおける週末の曜日を示します。UTS 35 では代わりに `weekendStart` と `weekendEnd` として格納しているため、通常は連続した値になります。
+- `minimalDays`
+  - : 1 から 7 までの整数（一般的には 1 または 4）で、月または年の最初の週に必要な最小日数を示し、年の週番号または月の週番号の計算（例：年の第 20 週）に使用されます。例えば、[ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) カレンダーでは、年の最初の週はその年に少なくとも 4 日間が含まれている必要があるため、1 月 1 日が金曜日、土曜日、または日曜日の場合、前年の最後の週の一部として番号付けされます。
 
 ## 例
 
@@ -18,17 +36,20 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo
 指定された `Locale` の週情報を返します。
 
 ```js
-let he = new Intl.Locale("he");
-console.log(he.weekInfo); // logs {firstDay: 7, weekend: [5, 6], minimalDays: 1}
+const he = new Intl.Locale("he"); // ヘブライ語（イスラエル）
+console.log(he.getWeekInfo()); // { firstDay: 7, weekend: [5, 6], minimalDays: 1 }
 
-let af = new Intl.Locale("af");
-console.log(af.weekInfo); // logs {firstDay: 7, weekend: [6, 7], minimalDays: 1}
+const af = new Intl.Locale("af"); // アフリカーンス語（南アフリカ）
+console.log(af.getWeekInfo()); // { firstDay: 7, weekend: [6, 7], minimalDays: 1 }
 
-let enGB = new Intl.Locale("en-GB");
-console.log(enGB.weekInfo); // logs {firstDay: 1, weekend: [6, 7], minimalDays: 4}
+const enGB = new Intl.Locale("en-GB"); // 英語（イギリス）
+console.log(enGB.getWeekInfo()); // { firstDay: 1, weekend: [6, 7], minimalDays: 4 }
 
-let msBN = new Intl.Locale("ms-BN");
-console.log(msBN.weekInfo); // logs {firstDay: 7, weekend: [5, 7], minimalDays: 1}  // ブルネイでは週末は金曜日と日曜日ですが、土曜日ではありません
+const arAF = new Intl.Locale("ar-AF"); // アラビア語（アフガニスタン）
+console.log(arAF.getWeekInfo()); // { firstDay: 6, weekend: [4, 5], minimalDays: 1 }
+
+const dvMV = new Intl.Locale("dv-MV"); // ディベヒ語（モルディブ）
+console.log(dvMV.getWeekInfo()); // { firstDay: 5, weekend: [6, 7], minimalDays: 1 }
 ```
 
 ## 仕様書
@@ -41,4 +62,4 @@ console.log(msBN.weekInfo); // logs {firstDay: 7, weekend: [5, 7], minimalDays: 
 
 ## 関連情報
 
-- {{jsxref("Intl/Locale", "Intl.Locale")}}
+- {{jsxref("Intl.Locale")}}

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/getweekinfo/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/getweekinfo/index.md
@@ -6,7 +6,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo
 {{jsxref("Intl.Locale")}} インスタンスの **`getWeekInfo()`** メソッドは、このロケールに対して `firstDay`、`weekend`、`minimalDays` プロパティを持つ `weekInfo` オブジェクトを返します。
 
 > [!NOTE]
-> 一部のブラウザーのあるバージョンでは、このメソッドが `weekInfo` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しいオブジェクトを返すため、`locale.weekInfo === locale.weekInfo` が `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#browser_compatibility)の表を確認してください。
+> 一部のブラウザーのあるバージョンでは、このメソッドが `weekInfo` と呼ばれるアクセサープロパティとして実装されていました。しかしこの実装ではアクセスするたびに新しいオブジェクトを返すため、`locale.weekInfo === locale.weekInfo` が `false` を返してしまい、この状況を防ぐために、現在はメソッドとして実装されています。詳細については、[ブラウザーの互換性](#ブラウザーの互換性)の表を確認してください。
 
 ## 構文
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`Intl.Locale` のインスタンスにあるメソッドのうち、[Intl Locale Info API Proposal](https://github.com/tc39/proposal-intl-locale-info)で追加されたAPI群の記事の日本語訳を英語版に追従しました。

具体的には以下の7つになります。

- `Intl.Locale.prototype.getCalendars()`
- `Intl.Locale.prototype.getCollations()` (こちらは日本語訳がなかったので新規追加)
- `Intl.Locale.prototype.getHourCycles()`
- `Intl.Locale.prototype.getNumberingSystems()`
- `Intl.Locale.prototype.getTextInfo()`
- `Intl.Locale.prototype.getTimeZones()`
- `Intl.Locale.prototype.getWeekInfo()`


### Motivation

[Intl Locale Info API Proposal](https://github.com/tc39/proposal-intl-locale-info)で追加されたAPI群の日本語訳がタイトル含め提案当初のAPIのままになっていました。
- ️当初はアクセサープロパティとして提案されていましたが、その後APIの変更があり現在の`getCalendars()`のようなメソッドの形で承認されています。

2025/11/18でのTC39 Meeting でこの提案がStage4になったこともあり、追従しておくのが良いと考えました。

### Additional details

 - [Intl Locale Info API Proposal](https://github.com/tc39/proposal-intl-locale-info)
   - > [Advance to Stage 4](https://docs.google.com/presentation/d/17FKrRkWCfNdYui9uRQDRYzv2c3cOCp6ZM7Rly9MwGHM) in TC 2025-11 meeting