### PR TITLE
[zh-tw] fix syntax error in :lang() interactive example

### DIFF
--- a/files/zh-tw/web/css/reference/selectors/_colon_lang/index.md
+++ b/files/zh-tw/web/css/reference/selectors/_colon_lang/index.md
@@ -10,7 +10,7 @@ l10n:
 {{InteractiveExample("CSS Demo: :lang()", "tabbed-shorter")}}
 
 ```css interactive-example
-*:lang(zh_Hant) {
+*:lang(zh-Hant) {
   outline: 2px solid deeppink;
 }
 ```


### PR DESCRIPTION
### Description
Fix CSS syntax error in the `:lang()` interactive example by removing the asterisk before the pseudo-class selector.

### Motivation
The interactive example had invalid CSS syntax with `*:lang(zh_Hant)` which should be `:lang(zh-Hant)`. This correction ensures the example demonstrates proper CSS pseudo-class syntax and works correctly for readers learning about the `:lang()` selector.

### Additional details
Changed line in the interactive example:
- Before: `*:lang(zh_Hant) {`
- After: `:lang(zh-Hant) {`

### Related issues and pull requests
<!-- N/A -->