### PR TITLE
fix(ja): fix two macro invocations

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/encodeuri/index.md
+++ b/files/ja/web/javascript/reference/global_objects/encodeuri/index.md
@@ -118,7 +118,7 @@ console.log(encodeURI("\uD800"));
 console.log(encodeURI("\uDFFF"));
 ```
 
-このエラーを避けるには、孤立サロゲートを Unicode 置換文字 (U+FFFD) に置き換える {{jsxref(String.prototype.toWellFormed())}} を使用することができます。また、文字列を `encodeURI()` に渡す前に、その文字列に孤立サロゲートが含まれているかどうかを調べるには、{{jsxref(String.prototype.isWellFormed())}} を使用することができます。
+このエラーを避けるには、孤立サロゲートを Unicode 置換文字 (U+FFFD) に置き換える {{jsxref("String.prototype.toWellFormed()")}} を使用することができます。また、文字列を `encodeURI()` に渡す前に、その文字列に孤立サロゲートが含まれているかどうかを調べるには、{{jsxref("String.prototype.isWellFormed()")}} を使用することができます。
 
 ### RFC3986 のエンコード
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes two Macro invocations in Japanese that were missing quotes.

### Motivation

These showed up in build: https://github.com/mdn/dex/actions/runs/19721304771/job/56536893288#step:22:131

### Additional details

#### Before

<img width="802" height="198" alt="image" src="https://github.com/user-attachments/assets/f29bc9de-2499-40f0-a032-7e62c10db240" />

#### After

<img width="802" height="198" alt="image" src="https://github.com/user-attachments/assets/797df3dc-6d31-415a-bcb7-87fd4b36cb83" />

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
