### PR TITLE
fix(ko): escape macro-like code

### DIFF
--- a/files/ko/learn_web_development/extensions/server-side/django/forms/index.md
+++ b/files/ko/learn_web_development/extensions/server-side/django/forms/index.md
@@ -589,7 +589,7 @@ Create the template file **locallibrary/catalog/templates/catalog/author_form.ht
   <form action="" method="post">
     {% csrf_token %}
     <table>
-      {{ form.as_table }}
+      \{{ form.as_table }}
     </table>
     <input type="submit" value="Submit" />
   </form>

--- a/files/ko/learn_web_development/extensions/server-side/django/generic_views/index.md
+++ b/files/ko/learn_web_development/extensions/server-side/django/generic_views/index.md
@@ -493,7 +493,7 @@ class BookListView(generic.ListView):
 
 만약 현재 페이지에 pagination이 사용중이라면, `page_obj` 가 [Paginator](https://docs.djangoproject.com/en/2.0/topics/pagination/#paginator-objects) 오브젝트 로서 존재합니다. 해당 오브젝트는 현재 페이지, 전 페이지, 페이지 수는 얼마나 되는 지등의 모든 정보를 제공합니다.
 
-pagination 링크를 만들기 위해 우리는 `{{ request.path }}` 를 이용하여 현재 페이지의 URL을 가져오도록 할 겁니다. 우리가 pagination을 하는 객체와 독립적이기 때문에 유용합니다.
+pagination 링크를 만들기 위해 우리는 `\{{ request.path }}` 를 이용하여 현재 페이지의 URL을 가져오도록 할 겁니다. 우리가 pagination을 하는 객체와 독립적이기 때문에 유용합니다.
 
 다됬네요!
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Escapes macro-like code on two Korean pages, e.g. `\{{ request.path }}` instead of `{{ request.path }}`.

### Motivation

Avoid it from being recognized as a macro in rari, see: https://github.com/mdn/dex/actions/runs/19721304771/job/56536893288#step:22:132

### Additional details

#### Before

<img width="802" height="198" alt="image" src="https://github.com/user-attachments/assets/f55b4fed-fc07-45c7-9483-e99c0a3e336a" />

#### After

<img width="802" height="198" alt="image" src="https://github.com/user-attachments/assets/fd5fc432-07c0-4f8c-aad3-de87da1f6a01" />

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
