### PR TITLE
ja/web/css/reference/properties/font-variant: 不要な文字を削除

### DIFF
--- a/files/ja/web/css/reference/properties/font-variant/index.md
+++ b/files/ja/web/css/reference/properties/font-variant/index.md
@@ -8,7 +8,7 @@ l10n:
 
 **`font-variant`** は CSS の[一括指定プロパティ](/ja/docs/Web/CSS/Guides/Cascade/Shorthand_properties)で、フォントのすべての変化形を設定することができます。
 
-CSS Level 2 (Revision 1) で定義されたにおける `font-variant` の `<font-variant-css2>` 値（つまり、 `normal` や `small-caps`）は、一括指定の [`font`](/ja/docs/Web/CSS/Reference/Properties/font) を用いて設定することもできます。
+CSS Level 2 (Revision 1) で定義された `font-variant` の `<font-variant-css2>` 値（つまり、 `normal` や `small-caps`）は、一括指定の [`font`](/ja/docs/Web/CSS/Reference/Properties/font) を用いて設定することもできます。
 
 {{InteractiveExample("CSS デモ: font-variant")}}
 


### PR DESCRIPTION
### Description

cssのfont-variantでtypoがあったので修正しました。

定義されたにおける→定義された

### Motivation

typoがあったため
