### PR TITLE
ja/web/css/reference/properties/text-wrap: typoの修正

### DIFF
--- a/files/ja/web/css/reference/properties/text-wrap/index.md
+++ b/files/ja/web/css/reference/properties/text-wrap/index.md
@@ -137,7 +137,7 @@ text-wrap: unset;
 </h2>
 
 <h2 class="balance" contenteditable="true">
-  この場合、この見出しのテキストは各行のバランスがうまくれます。
+  この場合、この見出しのテキストは各行のバランスがうまく取れます。
 </h2>
 ```
 


### PR DESCRIPTION
### Description

typoがあったため修正を行いました

バランスがうまくれます→バランスがうまく取れます

### Motivation

typoがあったため