### PR TITLE
fix(fr): sync failing for `Web/SVG/Reference/Element/g`

### DIFF
--- a/files/fr/web/svg/reference/element/g/index.md
+++ b/files/fr/web/svg/reference/element/g/index.md
@@ -1,14 +1,25 @@
 ---
 title: <g>
 slug: Web/SVG/Reference/Element/g
-original_slug: Web/SVG/Element/g
+l10n:
+  sourceCommit: ac806e34aba086be141689c64dc4dd73636fbd62
 ---
 
-{{SVGRef}}
-
-L'élément `g` est un conteneur utilisé pour grouper des objets.
+L'élément [SVG](/fr/docs/Web/SVG) **`<g>`** est un conteneur utilisé pour regrouper d'autres éléments SVG.
 
 Les transformations appliquées à l'élément `g` sont reportées à tous ses éléments enfants. Les attributs appliqués sont également reportés aux éléments enfants. De plus, il peut être utilisé pour définir des objets complexes qui seront référencés ultérieurement avec l'élément {{SVGElement("use")}}.
+
+## Contexte d'utilisation
+
+{{SVGInfo}}
+
+## Attributs
+
+Cet élément inclus uniquement les attributs universels.
+
+## Interface DOM
+
+Cet élément implémente l'interface {{DOMxRef("SVGGElement")}}.
 
 ## Exemple
 
@@ -31,29 +42,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Exemple', 100, '100%')}}
-
-## Attributs
-
-Cet élément n'a que des attributs globaux
-
-### Attributs globaux
-
-- [Attributs de base](/fr/docs/Web/SVG/Reference/Attribute)
-  - : Notamment: {{SVGAttr('id')}}, {{SVGAttr('tabindex')}}
-- [Attributs de style](/fr/docs/Web/SVG/Reference/Attribute)
-  - : {{SVGAttr('class')}}, {{SVGAttr('style')}}
-- [Attributs de traitement conditionnel](/fr/docs/Web/SVG/Reference/Attribute)
-  - : Notamment: {{SVGAttr('requiredExtensions')}}, {{SVGAttr('systemLanguage')}}
-- Attributs d'événement
-  - : [Attributs d'événement globaux](/fr/docs/Web/SVG/Attribute#attributs_d'événement_globaux), [Attributs d'événement graphiques](/fr/docs/Web/SVG/Attribute#attributs_d'événement_graphiques)
-- [Attributs de présentation](/fr/docs/Web/SVG/Reference/Attribute)
-  - : Notamment: {{SVGAttr('clip-path')}}, {{SVGAttr('clip-rule')}}, {{SVGAttr('color')}}, {{SVGAttr('color-interpolation')}}, {{SVGAttr('color-rendering')}}, {{SVGAttr('cursor')}}, {{SVGAttr('display')}}, {{SVGAttr('fill')}}, {{SVGAttr('fill-opacity')}}, {{SVGAttr('fill-rule')}}, {{SVGAttr('filter')}}, {{SVGAttr('mask')}}, {{SVGAttr('opacity')}}, {{SVGAttr('pointer-events')}}, {{SVGAttr('shape-rendering')}}, {{SVGAttr('stroke')}}, {{SVGAttr('stroke-dasharray')}}, {{SVGAttr('stroke-dashoffset')}}, {{SVGAttr('stroke-linecap')}}, {{SVGAttr('stroke-linejoin')}}, {{SVGAttr('stroke-miterlimit')}}, {{SVGAttr('stroke-opacity')}}, {{SVGAttr('stroke-width')}}, {{SVGAttr("transform")}}, {{SVGAttr('vector-effect')}}, {{SVGAttr('visibility')}}
-- Attributs Aria
-  - : `aria-activedescendant`, `aria-atomic`, `aria-autocomplete`, `aria-busy`, `aria-checked`, `aria-colcount`, `aria-colindex`, `aria-colspan`, `aria-controls`, `aria-current`, `aria-describedby`, `aria-details`, `aria-disabled`, `aria-dropeffect`, `aria-errormessage`, `aria-expanded`, `aria-flowto`, `aria-grabbed`, `aria-haspopup`, `aria-hidden`, `aria-invalid`, `aria-keyshortcuts`, `aria-label`, `aria-labelledby`, `aria-level`, `aria-live`, `aria-modal`, `aria-multiline`, `aria-multiselectable`, `aria-orientation`, `aria-owns`, `aria-placeholder`, `aria-posinset`, `aria-pressed`, `aria-readonly`, `aria-relevant`, `aria-required`, `aria-roledescription`, `aria-rowcount`, `aria-rowindex`, `aria-rowspan`, `aria-selected`, `aria-setsize`, `aria-sort`, `aria-valuemax`, `aria-valuemin`, `aria-valuenow`, `aria-valuetext`, `role`
-
-## Contexte d'utilisation
-
-{{svginfo}}
 
 ## Spécifications
 


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/SVG/Reference/Element/g`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

Related to #30755