### PR TITLE
fix(fr): sync failing for `Web/SVG/Reference/Element/symbol`

### DIFF
--- a/files/fr/web/svg/reference/element/symbol/index.md
+++ b/files/fr/web/svg/reference/element/symbol/index.md
@@ -1,14 +1,51 @@
 ---
 title: <symbol>
 slug: Web/SVG/Reference/Element/symbol
-original_slug: Web/SVG/Element/symbol
+l10n:
+  sourceCommit: a9063bb88f28dc2a9b32e39f060ab6930663da52
 ---
 
-{{SVGRef}}
+L'élément [SVG](/fr/docs/Web/SVG) **`<symbol>`** est utilisé pour définir des objets graphiques modèles pouvant être instanciés par un élément SVG {{SVGElement("use")}}.
 
-L'élément **`<symbol>`** est utilisé pour définir un template de graphique pouvant être instancié par un élément {{SVGElement("use")}}.
+L'utilisation d'éléments `<symbol>` pour des graphiques réutilisés plusieurs fois dans un même document ajoute de la structure et de la sémantique. Des documents riches en structure peuvent être rendus graphiquement, sous forme parlée ou en braille, et favorisent ainsi l'accessibilité.
 
-L'utilisation d'éléments `symbol` pour les graphiques qui sont utilisés de multiples fois dans le même document permet d'améliorer la structure et la sémantique du document. Les documents fortement structurés peuvent plus facilement être rendus sous forme graphique, vocale, ou Braille, et ainsi favoriser leur accessibilité.
+> [!NOTE]
+> Un élément `<symbol>` n'est pas destiné à être rendu lui-même. Seules les instances d'un élément `<symbol>` (c.-à-d. une référence à un `<symbol>` par un élément {{SVGElement("use")}}) sont rendues. Cela signifie que certains navigateurs peuvent refuser d'afficher directement un élément `<symbol>` même si la propriété CSS {{CSSxRef('display')}} indique le contraire.
+
+## Contexte d'utilisation
+
+{{SVGInfo}}
+
+## Attributs
+
+- {{SVGAttr("height")}}
+  - : Cet attribut détermine la hauteur du symbole.
+    _Type de valeur_&nbsp;: [**\<length>**](/fr/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/fr/docs/Web/SVG/Guides/Content_type#percentage)&nbsp;; _Valeur par défaut_&nbsp;: `auto`; _Animation_&nbsp;: **oui**
+- {{SVGAttr("preserveAspectRatio")}}
+  - : Cet attribut définit comment le fragment svg doit être déformé s'il est inclus dans un conteneur ayant un ratio d'affichage (largeur:hauteur) différent.
+    _Type de valeur_&nbsp;: (`none`| `xMinYMin`| `xMidYMin`| `xMaxYMin`| `xMinYMid`| `xMidYMid`| `xMaxYMid`| `xMinYMax`| `xMidYMax`| `xMaxYMax`) (`meet`|`slice`)?&nbsp;; _Valeur par défaut_&nbsp;: `xMidYMid meet`; _Animation_&nbsp;: **oui**
+- {{SVGAttr("refX")}}
+  - : Cet attribut détermine la coordonnée x du point de référence du symbole.
+    _Type de valeur_&nbsp;: [**\<length>**](/fr/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/fr/docs/Web/SVG/Guides/Content_type#percentage)|`left`|`center`|`right`&nbsp;; _Valeur par défaut_&nbsp;: `0`; _Animation_&nbsp;: **oui**
+- {{SVGAttr("refY")}}
+  - : Cet attribut détermine la coordonnée y du point de référence du symbole.
+    _Type de valeur_&nbsp;: [**\<length>**](/fr/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/fr/docs/Web/SVG/Guides/Content_type#percentage)|`top`|`center`|`bottom`&nbsp;; _Valeur par défaut_&nbsp;: `0`; _Animation_&nbsp;: **oui**
+- {{SVGAttr("viewBox")}}
+  - : Cet attribut définit les limites de la zone d'affichage du symbole.
+    _Type de valeur_&nbsp;: **[\<list-of-numbers>](/fr/docs/Web/SVG/Guides/Content_type#list-of-ts)**&nbsp;; _Valeur par défaut_&nbsp;: aucune; _Animation_&nbsp;: **oui**
+- {{SVGAttr("width")}}
+  - : Cet attribut définit la largeur du symbole.
+    _Type de valeur_&nbsp;: [**\<length>**](/fr/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/fr/docs/Web/SVG/Guides/Content_type#percentage)&nbsp;; _Valeur par défaut_&nbsp;: `auto`; _Animation_&nbsp;: **oui**
+- {{SVGAttr("x")}}
+  - : Cet attribut détermine la coordonnée x du symbole.
+    _Type de valeur_&nbsp;: [**\<length>**](/fr/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/fr/docs/Web/SVG/Guides/Content_type#percentage)&nbsp;; _Valeur par défaut_&nbsp;: `0`; _Animation_&nbsp;: **oui**
+- {{SVGAttr("y")}}
+  - : Cet attribut détermine la coordonnée y du symbole.
+    _Type de valeur_&nbsp;: [**\<length>**](/fr/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/fr/docs/Web/SVG/Guides/Content_type#percentage)&nbsp;; _Valeur par défaut_&nbsp;: `0`; _Animation_&nbsp;: **oui**
+
+## Interface DOM
+
+Cet élément implémente l'interface {{DOMxRef("SVGSymbolElement")}}.
 
 ## Exemple
 
@@ -46,53 +83,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Exemple', 150, '100%')}}
-
-## Attributs
-
-- {{SVGAttr("height")}}
-  - : Cet attribut détermine la hauteur du symbole.
-    _Type de valeur_: [**\<length>**](/fr/docs/Web/SVG/Content_type#Length)|[**\<percentage>**](/fr/docs/Web/SVG/Content_type#Percentage) ; _Valeur par défaut_: `auto`; _Animation_: **oui**
-- {{SVGAttr("preserveAspectRatio")}}
-  - : Cet attribut définit comment le fragment svg doit être déformé s'il est inclus dans un conteneur ayant un ratio d'affichage (largeur:hauteur) différent.
-    _Type de valeur_: (`none`| `xMinYMin`| `xMidYMin`| `xMaxYMin`| `xMinYMid`| `xMidYMid`| `xMaxYMid`| `xMinYMax`| `xMidYMax`| `xMaxYMax`) (`meet`|`slice`)? ; _Valeur par défaut_: `xMidYMid meet`; _Animation_: **oui**
-- {{SVGAttr("refX")}}
-  - : Cet attribut détermine la coordonnée x du point de référence du symbole.
-    _Type de valeur_: [**\<length>**](/fr/docs/Web/SVG/Content_type#Length)|[**\<percentage>**](/fr/docs/Web/SVG/Content_type#Percentage)|`left`|`center`|`right` ; _Valeur par défaut_: `0`; _Animation_: **oui**
-- {{SVGAttr("refY")}}
-  - : Cet attribut détermine la coordonnée y du point de référence du symbole.
-    _Type de valeur_: [**\<length>**](/fr/docs/Web/SVG/Content_type#Length)|[**\<percentage>**](/fr/docs/Web/SVG/Content_type#Percentage)|`top`|`center`|`bottom` ; _Valeur par défaut_: `0`; _Animation_: **oui**
-- {{SVGAttr("viewBox")}}
-  - : Cet attribut définit les limites de la zone d'affichage du symbole.
-    _Type de valeur_: **[\<list-of-numbers>](/fr/docs/Web/SVG/Content_type#List-of-Ts)** ; _Valeur par défaut_: aucune; _Animation_: **oui**
-- {{SVGAttr("width")}}
-  - : Cet attribut définit la largeur du symbole.
-    _Type de valeur_: [**\<length>**](/fr/docs/Web/SVG/Content_type#Length)|[**\<percentage>**](/fr/docs/Web/SVG/Content_type#Percentage) ; _Valeur par défaut_: `auto`; _Animation_: **oui**
-- {{SVGAttr("x")}}
-  - : Cet attribut détermine la coordonnée x du symbole.
-    _Type de valeur_: [**\<length>**](/fr/docs/Web/SVG/Content_type#Length)|[**\<percentage>**](/fr/docs/Web/SVG/Content_type#Percentage) ; _Valeur par défaut_: `0`; _Animation_: **oui**
-- {{SVGAttr("y")}}
-  - : Cet attribut détermine la coordonnée y du symbole.
-    _Type de valeur_: [**\<length>**](/fr/docs/Web/SVG/Content_type#Length)|[**\<percentage>**](/fr/docs/Web/SVG/Content_type#Percentage) ; _Valeur par défaut_: `0`; _Animation_: **oui**
-
-### Attributs globaux
-
-- [Attributs de base](/fr/docs/Web/SVG/Reference/Attribute)
-  - : Notamment: {{SVGAttr('id')}}
-- [Attributs de style](/fr/docs/Web/SVG/Reference/Attribute)
-  - : {{SVGAttr('class')}}, {{SVGAttr('style')}}
-- Attributs d'événement
-  - : [Attributs d'événement globaux](/fr/docs/Web/SVG/Attribute#attributs_d'événement_globaux), [Attributs d'événement des éléments du document](/fr/docs/Web/SVG/Attribute#attributs_d'événement_des_éléments_du_document), [Attributs d'événement graphiques](/fr/docs/Web/SVG/Attribute#attributs_d'événement_graphiques)
-- [Atttributs de présentation](/fr/docs/Web/SVG/Reference/Attribute)
-  - : Notamment: {{SVGAttr('clip-path')}}, {{SVGAttr('clip-rule')}}, {{SVGAttr('color')}}, {{SVGAttr('color-interpolation')}}, {{SVGAttr('color-rendering')}}, {{SVGAttr('cursor')}}, {{SVGAttr('display')}}, {{SVGAttr('fill')}}, {{SVGAttr('fill-opacity')}}, {{SVGAttr('fill-rule')}}, {{SVGAttr('filter')}}, {{SVGAttr('mask')}}, {{SVGAttr('opacity')}}, {{SVGAttr('pointer-events')}}, {{SVGAttr('shape-rendering')}}, {{SVGAttr('stroke')}}, {{SVGAttr('stroke-dasharray')}}, {{SVGAttr('stroke-dashoffset')}}, {{SVGAttr('stroke-linecap')}}, {{SVGAttr('stroke-linejoin')}}, {{SVGAttr('stroke-miterlimit')}}, {{SVGAttr('stroke-opacity')}}, {{SVGAttr('stroke-width')}}, {{SVGAttr("transform")}}, {{SVGAttr('vector-effect')}}, {{SVGAttr('visibility')}}
-- Attributs Aria
-  - : `aria-activedescendant`, `aria-atomic`, `aria-autocomplete`, `aria-busy`, `aria-checked`, `aria-colcount`, `aria-colindex`, `aria-colspan`, `aria-controls`, `aria-current`, `aria-describedby`, `aria-details`, `aria-disabled`, `aria-dropeffect`, `aria-errormessage`, `aria-expanded`, `aria-flowto`, `aria-grabbed`, `aria-haspopup`, `aria-hidden`, `aria-invalid`, `aria-keyshortcuts`, `aria-label`, `aria-labelledby`, `aria-level`, `aria-live`, `aria-modal`, `aria-multiline`, `aria-multiselectable`, `aria-orientation`, `aria-owns`, `aria-placeholder`, `aria-posinset`, `aria-pressed`, `aria-readonly`, `aria-relevant`, `aria-required`, `aria-roledescription`, `aria-rowcount`, `aria-rowindex`, `aria-rowspan`, `aria-selected`, `aria-setsize`, `aria-sort`, `aria-valuemax`, `aria-valuemin`, `aria-valuenow`, `aria-valuetext`, `role`
-
-## Notes d'utilisation
-
-{{svginfo}}
-
-> [!NOTE]
-> Un élément `<symbol>` n'est pas destiné à être affiché par lui-même. Seules les instances d'un élément `<symbol>` (c'est à dire une référence vers un `<symbol>` par un élément {{SVGElement("use")}}) sont affichées. Cela signifie que certains navigateurs peuvent refuser d'afficher directement un élément `<symbol>` quand bien même la propriété CSS {{cssxref('display')}} indique le contraire.
 
 ## Spécifications
 


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/SVG/Reference/Element/symbol`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

Related to #30755