### PR TITLE
ci(pr-test): run fred-ssr with npx

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -155,7 +155,7 @@ jobs:
           # Workaround, as fred-ssr doesn't copy assets.
           cp -vR node_modules/@mdn/fred/out/. "$BUILD_OUT_ROOT"
 
-          npm run fred-ssr
+          npx fred-ssr
 
           echo "Disk usage size of the build"
           du -sh $BUILD_OUT_ROOT


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fixes the `pr-test` workflow, running `fred-ssr` with `npx` instead of `npm`.

### Motivation

`fred-ssr` is a binary provided by fred, not a script, so it cannot be run with `npm`.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Follow-up of:

- https://github.com/mdn/content/pull/42149.

Same as:

- https://github.com/mdn/content/pull/42186