### PR TITLE
Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby の微修正

### DIFF
--- a/files/ja/web/accessibility/aria/reference/attributes/aria-labelledby/index.md
+++ b/files/ja/web/accessibility/aria/reference/attributes/aria-labelledby/index.md
@@ -95,8 +95,8 @@ l10n:
 
 `aria-labelledby`属性は以下の場所では対応していません。
 
-- [`code`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`caption`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
+- [`code`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`deletion`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`emphasis`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`generic`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/generic_role)
@@ -106,8 +106,8 @@ l10n:
 - [`presentation`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/presentation_role) / [`none`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/none_role)
 - [`strong`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`subscript`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
-- [`superscript`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`suggestion`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/suggestion_role)
+- [`superscript`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`term`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/term_role)
 - [`time`](/ja/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 

--- a/files/ja/web/accessibility/aria/reference/attributes/aria-labelledby/index.md
+++ b/files/ja/web/accessibility/aria/reference/attributes/aria-labelledby/index.md
@@ -75,7 +75,7 @@ l10n:
 
 4. `aria-labelledby` プロパティはその値の中で `id` が繰り返されると無視します。要素が複数の時点で参照された場合、最初の参照のみが処理されます。 `aria-labelledby="attr attr rm13 rm13">` は `aria-labelledby="attr rm13">` として扱われます。
 
-5. `aria-labelledby` プロパティの値は、表示されていない要素のコンテンツを含めることができます。支援技術のユーザーには、他のすべてのユーザーと同じコンテンツを提供すべきですが、HTML の [`hidden`](/ja/docs/Web/HTML/Reference/Global_attributes/hidden) 属性、CSS の [`display: none`](/ja/docs/Web/CSS/Reference/Properties/display) 属性、CSS の [`visibility: hidden`](/ja/docs/Web/CSS/Reference/Properties/visibility) 属性を持つ要素のコンテンツを計算された名前の文字列に含めることができます。
+5. `aria-labelledby` プロパティの値は、表示されていない要素のコンテンツを含めることができます。支援技術のユーザーには、他のすべてのユーザーと同じコンテンツを提供すべきですが、HTML の [`hidden`](/ja/docs/Web/HTML/Reference/Global_attributes/hidden) 属性、CSS の [`display: none`](/ja/docs/Web/CSS/Reference/Properties/display) 、CSS の [`visibility: hidden`](/ja/docs/Web/CSS/Reference/Properties/visibility) を持つ要素のコンテンツを計算された名前の文字列に含めることができます。
 
 6. `aria-labelledby` プロパティは入力要素の値を取り込みます。値が `<input>` を参照している場合、あるフォームコントロールの現在の値が計算された名前文字列に含まれ、値が更新されると変更されます。
 


### PR DESCRIPTION
### Description

- CSS プロパティに「属性」の表現があったのを削除
- 「関連付けられたロール」のリストのソートを修正

### Motivation

英語版との差異解消
