### PR TITLE
[zh-cn]: update the translation of TypedArray.prototype.slice()

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/typedarray/slice/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/typedarray/slice/index.md
@@ -1,18 +1,21 @@
 ---
 title: TypedArray.prototype.slice()
+short-title: slice()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/slice
+l10n:
+  sourceCommit: cd22b9f18cf2450c0cc488379b8b780f0f343397
 ---
 
-**`slice()`** 方法将一个类型化数组的一部分浅拷贝到一个新的类型化数组对象中并返回。此方法采用与 {{jsxref("Array.prototype.slice()")}} 相同的算法。_TypedArray_ 指[类型化数组的类型](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_对象)中的一员。
+{{jsxref("TypedArray")}} 实例的 **`slice()`** 方法返回一个新的类型化数组对象，包含原类型化数组中从 `start` 到 `end`（不包括 `end`）索引位置的一部分拷贝。`start` 和 `end` 参数表示要提取的项的索引。原始类型化数组不会被修改。此方法的算法与 {{jsxref("Array.prototype.slice()")}} 相同。
 
-{{InteractiveExample("JavaScript Demo: TypedArray.slice()")}}
+{{InteractiveExample("JavaScript 演示：TypedArray.prototype.slice()", "shorter")}}
 
 ```js interactive-example
-const uint8 = new Uint8Array([10, 20, 30, 40, 50]);
-const array1 = uint8.slice(1, 3);
+const bytes = new Uint8Array([10, 20, 30, 40, 50]);
+const byteSlice = bytes.slice(1, 3);
 
-console.log(array1);
-// Expected output: Uint8Array [20, 30]
+console.log(byteSlice);
+// 预期输出：Uint8Array [20, 30]
 ```
 
 ## 语法
@@ -23,33 +26,31 @@ slice(start)
 slice(start, end)
 ```
 
-## 参数
+### 参数
 
-- `begin` {{optional_inline}}
-  - : 从 0 开始的索引位置。可以使用负值索引，表示从数组末尾往前的偏移量。`slice(-2)` 表示提取数组中的末尾两个元素。如果没有设定起始位置，则将从开始位置开始截取。
+- `start` {{optional_inline}}
+  - : 要开始提取的位置（从 0 开始计数），会被[转换为整数](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Number#整数转换)。
 - `end` {{optional_inline}}
-  - : 从 0 开始到尾元素前的索引值。 `slice` 取出的元素到此位置之前，不包含该位置。例，`slice(1,4)` 表示读取第 2 个元素到第 4 个元素 (元素索引：1, 2, 3)。可以使用负值索引，表示从数组末尾往前的偏移量。 `slice(2,-1)` 表示取出数组中的第 3 个到倒数第 2 个元素。如果没有设定结束位置，则将从开始位置截取到序列尾部。(默认值为`typedarray.length`).
+  - : 要结束提取的位置（从 0 开始计数），会被[转换为整数](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Number#整数转换)。`slice()` 会提取到 `end`（但不包括）该位置。
 
 ### 返回值
 
-包含取出元素的新 typed array。
+一个包含提取元素的新类型化数组。
 
 ## 描述
 
-`slice`方法并不会改变原数组的内容，它只是返回从原数组中取出的元素的浅复制集合。
-
-如果一个新元素被添加到它们任何一个数组中去，另外一个数组不会受到影响。
+更多详细信息请参见 {{jsxref("Array.prototype.slice()")}} 此方法不是通用方法，只能在类型化数组实例上调用。
 
 ## 示例
 
-### 返回已存在类型数组的一部分片段
+### 返回现有类型化数组的一部分
 
 ```js
-const uint8 = new Uint8Array([1, 2, 3]);
-uint8.slice(1); // Uint8Array [ 2, 3 ]
-uint8.slice(2); // Uint8Array [ 3 ]
-uint8.slice(-2); // Uint8Array [ 2, 3 ]
-uint8.slice(0, 1); // Uint8Array [ 1 ]
+const bytes = new Uint8Array([1, 2, 3]);
+bytes.slice(1); // Uint8Array [ 2, 3 ]
+bytes.slice(2); // Uint8Array [ 3 ]
+bytes.slice(-2); // Uint8Array [ 2, 3 ]
+bytes.slice(0, 1); // Uint8Array [ 1 ]
 ```
 
 ## 规范
@@ -63,6 +64,7 @@ uint8.slice(0, 1); // Uint8Array [ 1 ]
 ## 参见
 
 - [`core-js` 中 `TypedArray.prototype.slice` 的 polyfill](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
+- [`TypedArray.prototype.slice` 的 es-shims polyfill 实现](https://www.npmjs.com/package/typedarray.prototype.slice)
 - [JavaScript 类型化数组](/zh-CN/docs/Web/JavaScript/Guide/Typed_arrays)指南
 - {{jsxref("TypedArray")}}
 - {{jsxref("Array.prototype.slice()")}}

--- a/files/zh-cn/web/javascript/reference/global_objects/typedarray/slice/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/typedarray/slice/index.md
@@ -31,7 +31,7 @@ slice(start, end)
 - `start` {{optional_inline}}
   - : 要开始提取的位置（从 0 开始计数），会被[转换为整数](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Number#整数转换)。
 - `end` {{optional_inline}}
-  - : 要结束提取的位置（从 0 开始计数），会被[转换为整数](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Number#整数转换)。`slice()` 会提取到 `end`（但不包括）该位置。
+  - : 要结束提取的位置（从 0 开始计数），会被[转换为整数](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Number#整数转换)。`slice()` 会提取到（但不包括）`end` 为止的位置。
 
 ### 返回值
 
@@ -39,7 +39,7 @@ slice(start, end)
 
 ## 描述
 
-更多详细信息请参见 {{jsxref("Array.prototype.slice()")}} 此方法不是通用方法，只能在类型化数组实例上调用。
+更多详细信息请参见 {{jsxref("Array.prototype.slice()")}}。此方法不是通用方法，只能在类型化数组实例上调用。
 
 ## 示例
 
@@ -64,7 +64,7 @@ bytes.slice(0, 1); // Uint8Array [ 1 ]
 ## 参见
 
 - [`core-js` 中 `TypedArray.prototype.slice` 的 polyfill](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
-- [`TypedArray.prototype.slice` 的 es-shims polyfill 实现](https://www.npmjs.com/package/typedarray.prototype.slice)
+- [`TypedArray.prototype.slice` 的 es-shims polyfill](https://www.npmjs.com/package/typedarray.prototype.slice)
 - [JavaScript 类型化数组](/zh-CN/docs/Web/JavaScript/Guide/Typed_arrays)指南
 - {{jsxref("TypedArray")}}
 - {{jsxref("Array.prototype.slice()")}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.md
* Last commit: https://github.com/mdn/content/commit/cd22b9f18cf2450c0cc488379b8b780f0f343397
