### PR TITLE
ci(pr-check-lint_content): handle egrep not matching any line

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -39,7 +39,7 @@ jobs:
           # Get files as newline-separated list
           FILTERED_FILES=$(gh api repos/{owner}/{repo}/compare/${BASE_SHA}...${HEAD_SHA} \
             --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename' | \
-            egrep -i "^files/.*\.md$")
+            egrep -i "^files/.*\.md$" || true)
 
           # Store as multiline output
           EOF="$(openssl rand -hex 8)"


### PR DESCRIPTION
### Description

Fixes the `pr-check-lint_content` workflow, preventing it from failing when `egrep` doesn't match any line (e.g. if `.nvmrc` is changed).

### Motivation

The workflow failed on https://github.com/mdn/translated-content/pull/30757.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Same as:

- https://github.com/mdn/content/pull/42189
- https://github.com/mdn/translated-content-de/pull/167
