### PR TITLE
chore(fr): translation of `Web/API/HTMLDataListElement/options`

### DIFF
--- a/files/fr/web/api/htmldatalistelement/options/index.md
+++ b/files/fr/web/api/htmldatalistelement/options/index.md
@@ -1,0 +1,30 @@
+---
+title: "HTMLDataListElement : propriété options"
+short-title: options
+slug: Web/API/HTMLDataListElement/options
+l10n:
+  sourceCommit: 2a13e9f2f20cc8845ed232de91d2627233b8dbcb
+---
+
+{{APIRef("HTML DOM")}}
+
+La propriété en lecture seule **`options`** de l'interface {{DOMxRef("HTMLDataListElement")}} retourne un objet {{DOMxRef("HTMLCollection")}} composé des éléments {{DOMxRef("HTMLOptionElement")}} contenus dans un élément HTML {{HTMLElement("datalist")}}. Les éléments descendants {{HTMLElement("option")}} fournissent des options prédéfinies pour le contrôle {{HTMLElement("input")}} associé au `<datalist>`.
+
+## Valeur
+
+Un objet {{DOMxRef("HTMLCollection")}} de plusieurs éléments {{DOMxRef("HTMLOptionElement")}}.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'interface {{DOMxRef("HTMLDataListElement")}}
+- L'interface {{DOMxRef("HTMLOptionElement")}}
+- L'élément HTML {{HTMLElement("datalist")}}
+- L'élément HTML {{HTMLElement("option")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/HTMLDataListElement/options`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_