### PR TITLE
chore(fr): translation of `Web/API/HTMLFormElement/autocomplete`

### DIFF
--- a/files/fr/web/api/htmlformelement/autocomplete/index.md
+++ b/files/fr/web/api/htmlformelement/autocomplete/index.md
@@ -1,0 +1,37 @@
+---
+title: "HTMLFormElement : propriété autocomplete"
+short-title: autocomplete
+slug: Web/API/HTMLFormElement/autocomplete
+l10n:
+  sourceCommit: e9b6cd1b7fa8612257b72b2a85a96dd7d45c0200
+---
+
+{{APIRef("HTML DOM")}}
+
+La propriété **`autocomplete`** de l'interface {{DOMxRef("HTMLFormElement")}} indique si la valeur des contrôles du formulaire peut être complétée automatiquement par le navigateur. Elle reflète l'attribut [`autocomplete`](/fr/docs/Web/HTML/Reference/Attributes/autocomplete) de l'élément HTML {{HTMLElement("form")}}.
+
+## Valeur
+
+Une chaîne de caractères&nbsp;; la valeur `"off"` si elle est explicitement définie à `"off"`, et sinon toujours `"on"`.
+
+## Exemples
+
+```js
+const formElement = document.getElementById("name");
+console.log(formElement.autocomplete);
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'élément HTML {{HTMLElement("form")}}
+- L'attribut HTML [`autocomplete`](/fr/docs/Web/HTML/Reference/Attributes/autocomplete)
+- L'attribut ARIA [`aria-autocomplete`](/fr/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-autocomplete)
+- [Désactiver la complétion automatique](/fr/docs/Web/Security/Practical_implementation_guides/Turning_off_form_autocompletion)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/HTMLFormElement/autocomplete`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_