### PR TITLE
[zh-cn]: update the translation of HashChangeEvent `oldURL` and `newURL` property

### DIFF
--- a/files/zh-cn/web/api/hashchangeevent/newurl/index.md
+++ b/files/zh-cn/web/api/hashchangeevent/newurl/index.md
@@ -1,30 +1,31 @@
 ---
-title: HashChangeEvent.newURL
+title: HashChangeEvent：newURL 属性
+short-title: newURL
 slug: Web/API/HashChangeEvent/newURL
+l10n:
+  sourceCommit: b6984118ac9482e683a654edfefa4b426ca3c7ca
 ---
 
 {{APIRef("HTML DOM")}}
 
-**`newURL`** 为 {{domxref("HashChangeEvent")}} 接口的只读属性，其值为窗口导航改变后的 URL。
+{{domxref("HashChangeEvent")}} 接口的 **`newURL`** 只读属性返回窗口正在导航到的新 URL。
 
-## 语法
+## 值
 
-```plain
-let newEventUrl = event.newURL;
-```
-
-### 返回值
-
-{{domxref("DOMString")}}.
+字符串。
 
 ## 示例
 
 ```js
-window.addEventListener("hashchange", function (event) {
-  console.log("Hash changed to " + event.newURL);
+window.addEventListener("hashchange", (event) => {
+  console.log(`哈希已从 ${event.newURL} 更改`);
 });
 ```
 
 ## 规范
 
 {{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}

--- a/files/zh-cn/web/api/hashchangeevent/oldurl/index.md
+++ b/files/zh-cn/web/api/hashchangeevent/oldurl/index.md
@@ -1,30 +1,31 @@
 ---
-title: HashChangeEvent.oldURL
+title: HashChangeEvent：oldURL 属性
+short-title: oldURL
 slug: Web/API/HashChangeEvent/oldURL
+l10n:
+  sourceCommit: b6984118ac9482e683a654edfefa4b426ca3c7ca
 ---
 
 {{APIRef("HTML DOM")}}
 
-**`oldURL`** 为 {{domxref("HashChangeEvent")}} 接口的只读属性，其值为窗口导航改变前的 URL。
+{{domxref("HashChangeEvent")}} 接口的 **`oldURL`** 只读属性返回窗口导航前的先前 URL。
 
-## 语法
+## 值
 
-```plain
-let oldEventUrl = event.oldURL;
-```
-
-### 返回值
-
-{{domxref("DOMString")}}.
+字符串。
 
 ## 示例
 
 ```js
-window.addEventListener("hashchange", function (event) {
-  console.log("Hash changed from " + event.oldURL);
+window.addEventListener("hashchange", (event) => {
+  console.log(`哈希已从 ${event.oldURL} 更改`);
 });
 ```
 
 ## 规范
 
 {{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/HashChangeEvent/oldURL
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/HashChangeEvent/newURL
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/hashchangeevent/oldurl/index.md
* Last commit: https://github.com/mdn/content/commit/b6984118ac9482e683a654edfefa4b426ca3c7ca
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/hashchangeevent/newurl/index.md
* Last commit: https://github.com/mdn/content/commit/b6984118ac9482e683a654edfefa4b426ca3c7ca