### PR TITLE
fix(fr): fixing typo of a note `lien` → `link` on role value

### DIFF
--- a/files/fr/web/accessibility/aria/reference/roles/link_role/index.md
+++ b/files/fr/web/accessibility/aria/reference/roles/link_role/index.md
@@ -89,7 +89,7 @@ Les différents rôles sont utilisés pour définir des modèles interactifs com
 Utilisez de préférence l'élément {{HTMLElement("a")}}.
 
 > [!NOTE]
-> Il n'est pas nécessaire d'inclure `role="lien"` sur un lien HTML, car l'élément `<a>`, a ce rôle par défaut.
+> Il n'est pas nécessaire d'inclure `role="link"` sur un lien HTML, car l'élément `<a>`, a ce rôle par défaut.
 
 ## Spécifications
 


### PR DESCRIPTION
Do not translate attribute in code

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The code example translates `role="link"` in french (`role="lien"`).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

To avoid misunderstanding with invalid attribute value.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
