### PR TITLE
chore(deps): set packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint:yml": "prettier -c \"**/*.yml\"",
     "prepare": "node scripts/npm-check.js"
   },
+  "packageManager": "npm@11.6.2",
   "engines": {
     "node": ">=24"
   },
@@ -43,6 +44,5 @@
   },
   "devDependencies": {
     "lefthook": "^2.0.9"
-  },
-  "packageManager": "npm@11.6.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -43,5 +43,6 @@
   },
   "devDependencies": {
     "lefthook": "^2.0.9"
-  }
+  },
+  "packageManager": "npm@11.6.2"
 }


### PR DESCRIPTION
### Description

Sets the `packageManager` field in the `package.json`.

### Motivation

Prevents contributors from running `yarn`.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/mdn/issues/772.