### PR TITLE
zh-cn: force the format of bold format

### DIFF
--- a/files/zh-cn/.markdownlint.jsonc
+++ b/files/zh-cn/.markdownlint.jsonc
@@ -103,9 +103,9 @@
         "searchScope": "text",
       },
       {
-        "name": "gfm-alert",
-        "message": "Use the GFM syntax: https://developer.mozilla.org/zh-CN/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#备注、警告和标注",
-        "searchPattern": "/^ *> \\*\\*(备注|警告|标注)：\\*\\*/gm",
+        "name": "bad-bold-format",
+        "message": "Please check the bold format",
+        "searchPattern": "[^\\*—、_`“，”\\[（。：\\s]+\\*\\*`",
         "searchScope": "text",
       },
       {

--- a/files/zh-tw/.markdownlint.jsonc
+++ b/files/zh-tw/.markdownlint.jsonc
@@ -110,12 +110,6 @@
         "searchScope": "text",
       },
       {
-        "name": "gfm-alert",
-        "message": "Use the GFM syntax: https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#notes_warnings_and_callouts",
-        "searchPattern": "/^ *> \\*\\*(備註|警告|標註)：\\*\\*/gm",
-        "searchScope": "text",
-      },
-      {
         "name": "bad-gfm-alert",
         "message": "Use the correct GFM syntax: `> [!NOTE]`",
         // TODO this should use the modifier syntax; until it has better Node support


### PR DESCRIPTION
### Description

Force the format of bold format. This PR also remove the `gfm-alert` check, as we have removed the support of old note card format: mdn/rari#350.

### Related issues and pull requests

Fixes: #17918
