### PR TITLE
[翻訳修正] コンストラクタの戻り値について

### DIFF
--- a/files/ja/web/javascript/reference/classes/constructor/index.md
+++ b/files/ja/web/javascript/reference/classes/constructor/index.md
@@ -155,7 +155,7 @@ new (class C extends class B {
 })();
 ```
 
-`constructor` メソッドは返値を持つことができます。基底クラスはコンストラクターから何らかの値を返すことができますが、派生クラスはオブジェクトまたは `undefined` を返すか、 {{jsxref("TypeError")}} を発生させなければなりません。
+`constructor` メソッドは返値を持つことができます。基底クラスではコンストラクターからどんな値を返しても構いませんが、派生クラスではオブジェクトまたは `undefined` を返さなければならず、さもなければ {{jsxref("TypeError")}} が発生します。
 
 ```js
 class ParentClass {
@@ -173,7 +173,7 @@ class ChildClass extends ParentClass {
   }
 }
 
-console.log(new ChildClass()); // TypeError: Derived constructors may only return object or undefined
+console.log(new ChildClass()); // TypeError: 派生クラスのコンストラクタが返してよいのはオブジェクトかundefinedのみ
 ```
 
 親クラスのコンストラクターがオブジェクトを返した場合、そのオブジェクトは派生クラスの[クラスフィールド](/ja/docs/Web/JavaScript/Reference/Classes/Public_class_fields)を定義する際の値として使用します。このトリックは[「返値の上書き」](/ja/docs/Web/JavaScript/Reference/Classes/Private_elements#オーバーライドしたオブジェクトの返却)と呼ばれ、派生クラスのフィールド（[プライベート](/ja/docs/Web/JavaScript/Reference/Classes/Private_elements)なものも含む）を無関係なオブジェクトに定義することができます。


### PR DESCRIPTION
原文: While the base class may return anything from its constructor, the derived class must return an object or undefined, or a TypeError will be thrown.

or: 〜さもないと、という意味があります。
https://www.try-it.jp/chapters-4047/lessons-4052/challenge-3/

TypeErrorはコンストラクタ自身が投げるのではなく、will be 〜 なのでJavaScriptエンジンが勝手に投げます。

ついでにコード内のコメントも翻訳しておきました。

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
