### PR TITLE
translate japanese for Source map

### DIFF
--- a/files/ja/glossary/source_map/index.md
+++ b/files/ja/glossary/source_map/index.md
@@ -5,16 +5,16 @@ l10n:
   sourceCommit: 7d4f930455a349e3c73836500add3d4840c76f5d
 ---
 
-A **source map** is a {{Glossary("JSON")}} file format that maps between minified or transformed code received by the browser and its original unmodified form, allowing the original code to be reconstructed and used when debugging.
+**ソースマップ** は、ブラウザーが受信した縮小または変換されたコードと元の変更されていない形式をマッピングする {{Glossary("JSON")}} ファイル形式です。これにより、デバッグ時に元のコードを再構築して使用できるようになります。
 
-Code executed by the browser is often transformed in some way from the original source created by a developer. There are several reasons for this:
+ブラウザで実行されるコードは、開発者が作成した元のソースコードから何らかの形で変換されることがよくあります。これにはいくつかの理由があります。
 
-- To make delivering code from the server more efficient by combining and minifying source files.
-- To support older browsers by transforming modern features into older equivalents.
-- To use languages that browsers don't support, like {{Glossary("TypeScript")}} or [Sass](https://sass-lang.com/).
+- ソースファイルを結合および縮小することで、サーバーからのコード配信をより効率的にするため。
+- 最新の機能を古いバージョンの同等の機能に変換することで、古いブラウザをサポートするため。
+- {{Glossary("TypeScript")}} や [Sass](https://sass-lang.com/) など、ブラウザがサポートしていない言語を使用するため。
 
-In these situations, debugging the original source is more intuitive than the source in the transformed state that the browser has downloaded.
-Browsers detect a source map via the {{HTTPHeader("SourceMap")}} HTTP header for a resource, or a `sourceMappingURL` annotation in the generated code.
+このような状況では、ブラウザがダウンロードした変換後の状態のソースよりも、元のソースをデバッグする方が直感的です。
+ブラウザは、リソースの {{HTTPHeader("SourceMap")}} HTTP ヘッダー、または生成されたコード内の `sourceMappingURL` アノテーションを介してソースマップを検出します。
 
 ## Example
 

--- a/files/ja/glossary/source_map/index.md
+++ b/files/ja/glossary/source_map/index.md
@@ -62,8 +62,8 @@ ul li {
 
 ![Firefox DevTools with the index.scss file opened in the style editor. The editor is focused on the source code's third line in SCSS format with nesting.](style-editor.png)
 
-## See also
+## 関連情報
 
-- [Source map format specification](https://tc39.es/ecma426/2024/)
-- HTTP {{HTTPHeader("SourceMap")}} response header
-- [Firefox Developer Tools: using a source map](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html)
+- [ソースマップ形式の仕様](https://tc39.es/ecma426/2024/)
+- HTTP {{HTTPHeader("SourceMap")}} レスポンスヘッダー
+- [Firefox 開発ツール: ソースマップの使用](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html)

--- a/files/ja/glossary/source_map/index.md
+++ b/files/ja/glossary/source_map/index.md
@@ -16,9 +16,9 @@ l10n:
 このような状況では、ブラウザがダウンロードした変換後の状態のソースよりも、元のソースをデバッグする方が直感的です。
 ブラウザは、リソースの {{HTTPHeader("SourceMap")}} HTTP ヘッダー、または生成されたコード内の `sourceMappingURL` アノテーションを介してソースマップを検出します。
 
-## Example
+## 例
 
-For example, consider this SCSS syntax of Sass:
+たとえば、Sass の次の SCSS 構文を考えてみましょう。
 
 ```scss
 ul {
@@ -29,8 +29,8 @@ ul {
 }
 ```
 
-During the build process, the SCSS is transformed into CSS.
-A source map file `index.css.map` is generated and linked to from the CSS in a comment at the end:
+ビルドプロセス中に、 SCSS は CSS に変換されます。
+ソースマップファイル `index.css.map` が生成され、末尾のコメントで CSS からリンクされます。
 
 ```css
 ul {
@@ -43,7 +43,7 @@ ul li {
 /*# sourceMappingURL=index.css.map */
 ```
 
-This map file contains not only mappings between the original SCSS and the generated CSS but also the original SCSS source code in encoded form. It's ignored by the browser's CSS parser but used by browser's DevTools:
+このマップファイルには、元の SCSS と生成された CSS のマッピングだけでなく、エンコードされた元の SCSS ソースコードも含まれています。ブラウザの CSS パーサーでは無視されますが、ブラウザの DevTools では使用されます。
 
 ```json
 {
@@ -56,7 +56,7 @@ This map file contains not only mappings between the original SCSS and the gener
 }
 ```
 
-The source map allows the browser's DevTools to link to specific lines in the original SCSS file and display the source code:
+ソースマップを使用すると、ブラウザの DevTools で元の SCSS ファイル内の特定の行にリンクし、ソースコードを表示できます。
 
 ![Firefox DevTools focused on the li element in the DOM inspector. The style panel shows transformed CSS without nesting and a link to the third line of the index.scss file.](inspector.png)
 

--- a/files/ja/glossary/source_map/index.md
+++ b/files/ja/glossary/source_map/index.md
@@ -1,0 +1,69 @@
+---
+title: Source map
+slug: Glossary/Source_map
+page-type: glossary-definition
+sidebar: glossarysidebar
+---
+
+A **source map** is a {{Glossary("JSON")}} file format that maps between minified or transformed code received by the browser and its original unmodified form, allowing the original code to be reconstructed and used when debugging.
+
+Code executed by the browser is often transformed in some way from the original source created by a developer. There are several reasons for this:
+
+- To make delivering code from the server more efficient by combining and minifying source files.
+- To support older browsers by transforming modern features into older equivalents.
+- To use languages that browsers don't support, like {{Glossary("TypeScript")}} or [Sass](https://sass-lang.com/).
+
+In these situations, debugging the original source is more intuitive than the source in the transformed state that the browser has downloaded.
+Browsers detect a source map via the {{HTTPHeader("SourceMap")}} HTTP header for a resource, or a `sourceMappingURL` annotation in the generated code.
+
+## Example
+
+For example, consider this SCSS syntax of Sass:
+
+```scss
+ul {
+  list-style: none;
+  li {
+    display: inline;
+  }
+}
+```
+
+During the build process, the SCSS is transformed into CSS.
+A source map file `index.css.map` is generated and linked to from the CSS in a comment at the end:
+
+```css
+ul {
+  list-style: none;
+}
+ul li {
+  display: inline;
+}
+
+/*# sourceMappingURL=index.css.map */
+```
+
+This map file contains not only mappings between the original SCSS and the generated CSS but also the original SCSS source code in encoded form. It's ignored by the browser's CSS parser but used by browser's DevTools:
+
+```json
+{
+  "version": 3,
+  "sourceRoot": "",
+  "sources": ["index.scss"],
+  "names": [],
+  "mappings": "AAAA;EACC;;AACA;EACC",
+  "file": "index.css"
+}
+```
+
+The source map allows the browser's DevTools to link to specific lines in the original SCSS file and display the source code:
+
+![Firefox DevTools focused on the li element in the DOM inspector. The style panel shows transformed CSS without nesting and a link to the third line of the index.scss file.](inspector.png)
+
+![Firefox DevTools with the index.scss file opened in the style editor. The editor is focused on the source code's third line in SCSS format with nesting.](style-editor.png)
+
+## See also
+
+- [Source map format specification](https://tc39.es/ecma426/2024/)
+- HTTP {{HTTPHeader("SourceMap")}} response header
+- [Firefox Developer Tools: using a source map](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html)

--- a/files/ja/glossary/source_map/index.md
+++ b/files/ja/glossary/source_map/index.md
@@ -1,8 +1,8 @@
 ---
-title: Source map
+title: Source map（ソースマップ）
 slug: Glossary/Source_map
-page-type: glossary-definition
-sidebar: glossarysidebar
+l10n:
+  sourceCommit: 7d4f930455a349e3c73836500add3d4840c76f5d
 ---
 
 A **source map** is a {{Glossary("JSON")}} file format that maps between minified or transformed code received by the browser and its original unmodified form, allowing the original code to be reconstructed and used when debugging.


### PR DESCRIPTION
@hmatrjp @potappo @mfuji09

### issue
- [ 用語集 - Source map の翻訳 #851 ](https://github.com/mozilla-japan/translation/issues/851)  のPRです。

### translated-content
#### 以下の作業単位毎にコミットしてあります。

- feat: add file 53598703ad6
- feat: translate title af331c9521a
- feat: translate source map 846f0805d25
- feat: translate Example 4206cef5c0f
- feat: translate See also f5c8223bf24
