### PR TITLE
chore(fr): update Glossary pages A-L (chore(ia) and chore(macro))

### DIFF
--- a/files/fr/glossary/accessible_description/index.md
+++ b/files/fr/glossary/accessible_description/index.md
@@ -2,7 +2,7 @@
 title: Description accessible
 slug: Glossary/Accessible_description
 l10n:
-  sourceCommit: fd2acb039cc1caee4af10f76ffb839c8da7da5b8
+  sourceCommit: 96a73163513476fe49bfba695acedb7622135354
 ---
 
 Une **description accessible** (<i lang="en">accessible description</i> en anglais) est la description d'un élément d'interface utilisateur qui fournit des informations supplémentaires pour aider les utilisateur·ice·s de technologies d'assistance à comprendre l'élément UI et son contexte. Elle est associée à un élément HTML ou SVG et donne aux utilisateur·ice·s un contexte supplémentaire sur son but au-delà de ce qui est fourni par le {{Glossary("Accessible_name", "nom accessible")}} de l'élément. C'est particulièrement important pour les utilisateur·ice·s qui se servent de technologies d'assistance telles que {{Glossary("Screen_reader", "lecteurs d'écrans")}}. La description accessible d'un élément fait partie de {{Glossary("Accessibility_tree", "l'arbre d'accessibilité")}}.
@@ -24,7 +24,7 @@ Pour les éléments HTML, s'il n'a pas de description accessible, celle‑ci doi
 3. Les caractéristiques spécifiques à la langue qui participent au calcul de la description si la caractéristique n'est pas déjà utilisée pour définir le {{Glossary("Accessible_name", "nom accessible")}}. Par exemple&nbsp;:
    - Un {{HTMLElement("summary")}} est décrit par le contenu du {{HTMLElement("details")}} dans lequel il est imbriqué.
    - Les boutons {{HTMLElement("input")}} (avec l'attribut type `button`, `submit` ou `reset`) sont décrits par la valeur de leur attribut `value`.
-   - En SVG, le contenu de l'élément [`<desc>`](/fr/docs/Web/SVG/Reference/Element/desc), s'il est présent, sinon, le texte contenu dans les éléments descendants contenant du texte (c'est‑à‑dire [`<text>`](/fr/docs/Web/SVG/Reference/Element/text)), s'ils ne sont pas déjà utilisés pour le {{Glossary("Accessible_name", "nom accessible")}}.
+   - En SVG, le contenu de l'élément {{SVGElement("desc")}} est utilisé s'il est présent, sinon, le texte contenu dans les éléments descendants contenant du texte (c'est‑à‑dire {{SVGElement("text")}}), s'ils ne sont pas déjà utilisés pour le {{Glossary("Accessible_name", "nom accessible")}}.
 4. Si aucune des options précédentes ne fournit une description, l'attribut [`title`](/fr/docs/Web/HTML/Reference/Global_attributes/title) est utilisé, si le `title` n'est pas le {{Glossary("Accessible_name", "nom accessible")}} de cet élément.
 5. Si aucune des options précédentes ne définit une description accessible, la description accessible est vide.
 
@@ -41,7 +41,7 @@ Les étapes de définition de la description accessible en HTML sont décrites d
 - [Initiative W3C pour l'accessibilité Web (WAI) <sup>(angl.)</sup>](https://www.w3.org/WAI/)
 - [Applications Riches d'Internet Accessible (WAI-ARIA) <sup>(angl.)</sup>](https://w3c.github.io/aria/)
 - Termes associés du glossaire&nbsp;:
-- {{Glossary("Accessibility", "Accessibilité")}}
-- {{Glossary("Accessibility_tree", "Arbre d'accessibilité")}}
-- {{Glossary("Accessible_name", "Nom accessible")}}
-- {{Glossary("ARIA")}}
+  - {{Glossary("Accessibility", "Accessibilité")}}
+  - {{Glossary("Accessibility_tree", "Arbre d'accessibilité")}}
+  - {{Glossary("Accessible_name", "Nom accessible")}}
+  - {{Glossary("ARIA")}}

--- a/files/fr/glossary/advance_measure/index.md
+++ b/files/fr/glossary/advance_measure/index.md
@@ -2,7 +2,7 @@
 title: Chasse (Avance)
 slug: Glossary/Advance_measure
 l10n:
-  sourceCommit: ada5fa5ef15eadd44b549ecf906423b4a2092f34
+  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
 ---
 
 La **chasse** (ou **avance**) est l'espace total occupé par le glyphe, horizontalement ou verticalement, selon la direction d'écriture actuelle. Elle est égale à la distance parcourue par le curseur, placé directement devant puis décalé derrière le caractère.

--- a/files/fr/glossary/alignment_container/index.md
+++ b/files/fr/glossary/alignment_container/index.md
@@ -2,7 +2,7 @@
 title: Alignment container
 slug: Glossary/Alignment_Container
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Le **bloc d'alignement** est le rectangle avec lequel le {{Glossary("alignment subject", "sujet d'alignement")}} est aligné avec. Cela est défini par le mode de disposition&nbsp;; généralement, le bloc d'alignement contient le sujet d'alignement et il adopte le mode d'ecriture de la boîte qui établit le bloc conteneur.

--- a/files/fr/glossary/alignment_subject/index.md
+++ b/files/fr/glossary/alignment_subject/index.md
@@ -2,7 +2,7 @@
 title: Alignment subject
 slug: Glossary/Alignment_Subject
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Dans le [module d'alignement des boîtes CSS](/fr/docs/Web/CSS/Guides/Box_alignment), le **sujet d'alignement** est l'élément (ou les éléments) qui sont alignés à l'intérieur du {{Glossary("alignment container", "conteneur d'alignement")}} par la propriété.

--- a/files/fr/glossary/alpha/index.md
+++ b/files/fr/glossary/alpha/index.md
@@ -2,7 +2,7 @@
 title: Alpha (canal alpha)
 slug: Glossary/Alpha
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Le **canal alpha** spécifie le degré d'opacité d'une couleur ({{CSSxRef("&lt;color&gt;")}}). Les couleurs sont représentées sous forme numérique comme un ensemble de nombres, chacun représentant la force ou le niveau d'intensité d'un composant donné de la couleur. Chacun de ces composants est appelé un **canal**. Dans un fichier d'image typique, les canaux de couleur décrivent la quantité de rouge, de vert et de bleu utilisée pour composer la couleur finale. Pour représenter une couleur à travers laquelle le fond peut être vu dans une certaine mesure, un quatrième canal est ajouté à la couleur&nbsp;: le canal alpha.

--- a/files/fr/glossary/aspect_ratio/index.md
+++ b/files/fr/glossary/aspect_ratio/index.md
@@ -2,7 +2,7 @@
 title: Rapport d'aspect (Aspect ratio)
 slug: Glossary/Aspect_ratio
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Un **rapport d'aspect** est la relation proportionnelle entre la largeur et la hauteur d'un élément ou de la {{Glossary("viewport", "zone d'affichage")}}. Il s'exprime comme un {{CSSxRef("ratio")}} de deux nombres.
@@ -41,8 +41,8 @@ myTrack.applyConstraints(constraints);
 ## Voir aussi
 
 - La propriété CSS {{CSSxRef("aspect-ratio")}}
-- [Comprendre les rapports d'aspect](/fr/docs/Web/CSS/CSS_box_sizing/Understanding_aspect-ratio)
-- Le module de [taille de boîte CSS](/fr/docs/Web/CSS/CSS_box_sizing)
+- [Comprendre les rapports d'aspect](/fr/docs/Web/CSS/Guides/Box_sizing/Aspect_ratios)
+- Le module de [taille de boîte CSS](/fr/docs/Web/CSS/Guides/Box_sizing)
 - Termes associés du glossaire&nbsp;:
   - {{Glossary("intrinsic size")}}
 - Valeurs de propriété CSS {{CSSxRef("min-content")}}, {{CSSxRef("max-content")}} et {{CSSxRef("fit-content")}}.

--- a/files/fr/glossary/baseline/typography/index.md
+++ b/files/fr/glossary/baseline/typography/index.md
@@ -2,7 +2,7 @@
 title: Ligne de base (typographie)
 slug: Glossary/Baseline/Typography
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Une **ligne de base** est une ligne imaginaire le long de l'axe en ligne d'une boîte de ligne, sur laquelle les glyphes individuels du texte sont alignés. Les lignes de base guident la conception des glyphes dans une police et l'alignement des glyphes de différentes polices ou tailles lors de la composition.
@@ -13,6 +13,6 @@ D'autres systèmes d'écriture ont des lignes de base différentes. Par exemple,
 
 ## Voir aussi
 
-- [Alignement des boîtes CSS](/fr/docs/Web/CSS/Guides/Box_alignment#types_dalignement)
-- Le module [de disposition en ligne CSS](/fr/docs/Web/CSS/CSS_inline_layout)
+- [Alignement des boîtes CSS](/fr/docs/Web/CSS/Guides/Box_alignment/Overview#types_dalignement)
+- Le module [de disposition en ligne CSS](/fr/docs/Web/CSS/Guides/Inline_layout)
 - [La page Wikipédia sur la ligne de base](<https://fr.wikipedia.org/wiki/Ligne_de_base_(typographie)>)

--- a/files/fr/glossary/bezier_curve/index.md
+++ b/files/fr/glossary/bezier_curve/index.md
@@ -2,10 +2,8 @@
 title: Courbe de Bézier
 slug: Glossary/Bezier_curve
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
 ---
-
-{{GlossarySidebar}}
 
 Une **courbe de Bézier** (prononcé \[bezje]) est une courbe décrite mathématiquement utilisée en infographie et en animation. Pour les images vectorielles, elles sont utilisées afin de modéliser des courbes lisses qui peuvent être redimensionnées indéfiniment.
 

--- a/files/fr/glossary/blink_element/index.md
+++ b/files/fr/glossary/blink_element/index.md
@@ -3,7 +3,7 @@ title: L'élément de clignotement (balise <blink>)
 short-title: Élément <blink>
 slug: Glossary/blink_element
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 L'élément **`<blink>`** (balise blink) est une fonctionnalité HTML obsolète qui n'est plus prise en charge par les navigateurs web et n'est plus documentée sur MDN. Il servait à faire clignoter du texte (affichage/disparition en boucle).

--- a/files/fr/glossary/block-level_content/index.md
+++ b/files/fr/glossary/block-level_content/index.md
@@ -2,7 +2,7 @@
 title: Éléments de niveau bloc
 slug: Glossary/Block-level_content
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 96a73163513476fe49bfba695acedb7622135354
 ---
 
 En CSS, le contenu qui participe à la mise en page en bloc est appelé **contenu de niveau bloc**.

--- a/files/fr/glossary/block/css/index.md
+++ b/files/fr/glossary/block/css/index.md
@@ -2,7 +2,7 @@
 title: Bloc (CSS)
 slug: Glossary/Block/CSS
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Sur une page web, un **bloc** est un {{Glossary("Element","élément")}} {{Glossary("HTML")}} qui apparaît sous l'élément précédent et au-dessus du suivant (communément connu comme un _block-level element_). Par exemple, {{HTMLElement("p")}} est par défaut un élément de type bloc, alors que {{HTMLElement("a")}} est un _inline element_ — vous pouvez placer plusieurs liens les uns à côté des autres dans votre source HTML et ils seront placés sur la même ligne dans la sortie rendue.

--- a/files/fr/glossary/breadcrumb/index.md
+++ b/files/fr/glossary/breadcrumb/index.md
@@ -2,7 +2,7 @@
 title: Fil d'ariane (Breadcrumb)
 slug: Glossary/Breadcrumb
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: f3bf4e2bd456159093d3820253be9f266ace070a
 ---
 
 Un **<i lang="en">breadcrumb</i>**, ou fil d'Ariane, est une aide à la navigation qui est généralement placée entre l'en-tête d'un site et le contenu principal, affichant soit une hiérarchie de la page actuelle par rapport à la structure du site, du niveau supérieur à la page actuelle, soit une liste des liens suivis par l'utilisateur·ice pour accéder à la page en cours, dans l'ordre visité.

--- a/files/fr/glossary/canonical_order/index.md
+++ b/files/fr/glossary/canonical_order/index.md
@@ -2,7 +2,7 @@
 title: Ordre canonique
 slug: Glossary/Canonical_order
 l10n:
-  sourceCommit: 70285e396b5c97675e90b85d573be42078e0168e
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 En CSS, la locution «&nbsp;**ordre canonique**&nbsp;» est utilisée pour désigner l'ordre dans lequel des valeurs séparées doivent être définies (ou {{Glossary("parse", "analysées")}}) ou doivent être {{Glossary("serialization", "sérialisées")}} dans le cadre d'une valeur de propriété CSS. Il est défini par la {{Glossary ("Syntax", "syntaxe")}} formelle de la propriété et se réfère normalement à l'ordre dans lequel les valeurs longues doivent être définies dans le cadre d'une seule valeur raccourcie.

--- a/files/fr/glossary/code_point/index.md
+++ b/files/fr/glossary/code_point/index.md
@@ -1,6 +1,8 @@
 ---
 title: Point de code
 slug: Glossary/Code_point
+l10n:
+  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
 ---
 
 Un **point de code** est un nombre attribué pour représenter un caractère abstrait dans un système de représentation de texte (tel que Unicode). En Unicode, un point de code est exprimé sous la forme `U+1234` où `1234` est le numéro attribué. Par exemple, le caractère «&nbsp;A&nbsp;» se voit attribuer un point de code `U+0041`.

--- a/files/fr/glossary/color_space/index.md
+++ b/files/fr/glossary/color_space/index.md
@@ -2,14 +2,14 @@
 title: Espace de couleur
 slug: Glossary/Color_space
 l10n:
-  sourceCommit: a6d1fd388b053e6fc6ce21003348f34d0ef8115f
+  sourceCommit: 5ba55a6939c0aaf988fc4d34ad7e51c52373a2a6
 ---
 
 Les **espaces de couleur** (<i lang="en">color spaces</i> en anglais) sont des organisations nommées de couleurs pour des modèles de couleur sous-jacents basés sur des coordonnées. Un modèle de couleur définit comment les composants d'une couleur (par exemple, les canaux `h`, `w`, et `b` d'une couleur {{CSSxRef("color_value/hwb", "hwb()")}}) se rapportent à un espace de couleur. La plupart des espaces de couleur sont des grilles tridimensionnelles ou quadridimensionnelles qui représentent les couleurs. Chaque dimension (ou axe) correspond à un canal différent. Les couleurs peuvent être exprimées dans plusieurs espaces de couleur, et peuvent être transformées d'un espace de couleur à un autre, tout en conservant la même apparence.
 
 Les espaces de couleur catégorisent et définissent des gammes spécifiques de couleurs. Chaque espace de couleur est défini par un modèle mathématique et un ensemble de règles associées. Chaque espace de couleur a un {{Glossary("Gamut", "gamut")}} défini, qui fait référence à la gamme spécifique de couleurs qu'il peut représenter. Ces règles permettent une représentation cohérente et reproductible des couleurs sur différents appareils et logiciels.
 
-L'espace de couleur _sRGB_ (rouge, vert et bleu standard) a été créé pour le web, mais nous ne sommes plus limités à cet espace de couleur. Le [Module de couleur CSS de niveau 4](https://drafts.csswg.org/css-color-4) spécifie plusieurs espaces de couleur prédéfinis, et le [Module de couleur CSS de niveau 5](https://drafts.csswg.org/css-color-5/) va plus loin, spécifiant des fonctionnalités pour définir des espaces de couleur personnalisés.
+L'espace de couleur _sRGB_ (rouge, vert et bleu standard) a été créé pour le web, mais nous ne sommes plus limités à cet espace de couleur. Le [Module de couleur CSS de niveau 4 <sup>(angl.)</sup>](https://drafts.csswg.org/css-color-4) spécifie plusieurs espaces de couleur prédéfinis, et le [Module de couleur CSS de niveau 5 <sup>(angl.)</sup>](https://drafts.csswg.org/css-color-5/) va plus loin, spécifiant des fonctionnalités pour définir des espaces de couleur personnalisés.
 
 ## Espaces de couleur nommés
 
@@ -27,7 +27,7 @@ Les valeurs CSS `<color>` dans les espaces de couleur sRGB incluent {{CSSxRef("h
 
 L'espace de couleur HSV (teinte, saturation et valeur), et son synonyme HSB (teinte, saturation et luminosité), sont représentés en CSS comme {{CSSxRef("color_value/hwb", "hwb()")}}. Les couleurs nommées sont simplement des mots-clés mappés à des valeurs hexadécimales spécifiques. La conversion de ces diverses notations de couleur vers sRGB est mathématiquement simple. Notez que {{CSSxRef("&lt;color&gt;","currentColor","#mot-clé_currentcolor")}} peut être n'importe quelle couleur — elle n'est pas restreinte à sRGB.
 
-La fonction de couleur `rgb()` n'est pas la seule fonction de couleur qui peut représenter l'espace de couleur _sRGB_. Les systèmes de coordonnées cylindriques comme les modèles de couleur [`HSL`](/fr/docs/Web/CSS/Reference/Values/color_value/hsl) (_teinte-saturation-luminosité_) ou [`HWB`](/fr/docs/Web/CSS/Reference/Values/color_value/hwb) (_teinte-blancheur-noirceur_) sont également utilisés pour représenter une couleur sRGB sur le web.
+La fonction de couleur `rgb()` n'est pas la seule fonction de couleur qui peut représenter l'espace de couleur _sRGB_. Les systèmes de coordonnées cylindriques comme les modèles de couleur {{CSSxRef("color_value/hsl", "HSL")}} (_teinte-saturation-luminosité_) ou {{CSSxRef("color_value/hwb", "HWB")}} (_teinte-blancheur-noirceur_) sont également utilisés pour représenter une couleur sRGB sur le web.
 
 - Espace de couleur `srgb`
   - : L'espace de couleur sRGB, ou «&nbsp;RGB standard&nbsp;», est l'espace de couleur RGB (rouge, vert, bleu) standard. Il a été créé pour être utilisé sur les moniteurs, imprimantes et le Web. C'est l'espace de couleur le plus largement utilisé et il est pris en charge par la plupart des systèmes d'exploitation, programmes logiciels, moniteurs et imprimantes. sRGB est basé sur `r`, `g`, et `b`, avec des valeurs dans le gamut allant de `0` à `1`. Le point blanc est D65.

--- a/files/fr/glossary/color_wheel/index.md
+++ b/files/fr/glossary/color_wheel/index.md
@@ -2,12 +2,12 @@
 title: Cercle chromatique
 slug: Glossary/Color_wheel
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 5ba55a6939c0aaf988fc4d34ad7e51c52373a2a6
 ---
 
 Un **cercle chromatique** (<i lang="en">color wheel</i> en anglais), est un graphique représentant une palette de couleurs dans un cercle. Un cercle chromatique peut afficher des couleurs identifiées par deux coordonnées polaires, l'_angle_ et la _distance_ depuis l'origine, le centre du cercle.
 
-Les cercles chromatiques sont pratiques pour comparer les couleurs exprimées en coordonnées polaires ou cylindriques, comme [`hsl()`](/fr/docs/Web/CSS/Reference/Values/color_value/hsl), [`hwb()`](/fr/docs/Web/CSS/Reference/Values/color_value/hwb) ou [`lch()`](/fr/docs/Web/CSS/Reference/Values/color_value/lch).
+Les cercles chromatiques sont pratiques pour comparer les couleurs exprimées en coordonnées polaires ou cylindriques, comme {{CSSxRef("color_value/hsl", "hsl()")}}, {{CSSxRef("color_value/hwb", "hwb()")}} ou {{CSSxRef("color_value/lch", "lch()")}}.
 
 Dans de tels cas, les _couleurs complémentaires_ sont diamétralement opposées sur le cercle. De même, les _couleurs monochromatiques_ — des couleurs du même _ton_ mais de _nuances_ différentes — sont situées sur le même rayon, et les _couleurs triadiques_ — trois couleurs régulièrement espacées autour de la roue chromatique qui conduisent à des couleurs qui fonctionnent bien ensemble — sont également faciles à trouver.
 
@@ -15,7 +15,7 @@ Les roues chromatiques sont utilisées dans la vraie vie lorsque nous voulons ch
 
 Dans le monde numérique, les cercles chromatiques sont utilisées dans les _sélecteurs de couleurs_, comme celui disponible par défaut sur macOS&nbsp;:
 
-[![Le sélecteur de couleur par défaut pour macOS Monterey](color_wheel_macos.png)](files/fr/glossary/cercle_chromatique/color_wheel_macos.png)
+![Le sélecteur de couleur par défaut pour macOS Monterey](color_wheel_macos.png)
 
 ## Voir aussi
 

--- a/files/fr/glossary/composite_operation/index.md
+++ b/files/fr/glossary/composite_operation/index.md
@@ -2,7 +2,7 @@
 title: Opération composite
 slug: Glossary/Composite_operation
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 96a73163513476fe49bfba695acedb7622135354
 ---
 
 En CSS, la valeur d'une propriété dans une règle CSS est la _valeur sous-jacente_ de cette propriété, pour cette même propriété, la valeur dans [une étape d'animation (<i lang="en">keyframe</i>)](/fr/docs/Web/CSS/Reference/At-rules/@keyframes) est sa _valeur effective_.

--- a/files/fr/glossary/continuous_integration/index.md
+++ b/files/fr/glossary/continuous_integration/index.md
@@ -2,7 +2,7 @@
 title: Intégration continue
 slug: Glossary/Continuous_integration
 l10n:
-  sourceCommit: 79f65d8322a4e55e9f3f4c91441c9188dbe670e0
+  sourceCommit: 7d4f930455a349e3c73836500add3d4840c76f5d
 ---
 
 L'**intégration continue** (<i lang="en">continuous integration</i> ou <abbr>CI</abbr> en anglais) est une pratique de développement logiciel qui consiste à intégrer fréquemment les modifications du code source dans la base de code principale.

--- a/files/fr/glossary/cors/index.md
+++ b/files/fr/glossary/cors/index.md
@@ -2,7 +2,7 @@
 title: CORS
 slug: Glossary/CORS
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: ca26363fcc6fc861103d40ac0205e5c5b79eb2fa
 ---
 
 **CORS** (Partage de ressource cross-origin) est un mécanisme qui consiste à transmettre des {{Glossary("HTTP_header", "entêtes HTTP")}}, qui déterminent s'il faut ou non bloquer les requêtes à des ressources restreintes sur une page web qui se trouve sur un domaine externe au domaine dont la ressource est originaire.

--- a/files/fr/glossary/cross_axis/index.md
+++ b/files/fr/glossary/cross_axis/index.md
@@ -2,7 +2,7 @@
 title: Axe transversal
 slug: Glossary/Cross_Axis
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 L'**axe transversal** d'une {{Glossary("flexbox")}} traverse l'{{Glossary("Main Axis", "axe principal")}}, donc si la {{CSSxRef("flex-direction")}} et l'axe principal sont `row` (_ligne_) ou `row-reverse` l'axe transversal est en colonne.

--- a/files/fr/glossary/css_descriptor/index.md
+++ b/files/fr/glossary/css_descriptor/index.md
@@ -2,7 +2,7 @@
 title: Descripteur (CSS)
 slug: Glossary/CSS_Descriptor
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Un **descripteur CSS** définit les caractéristiques des [règles @](/fr/docs/Web/CSS/Guides/Syntax/At-rules). Celles-ci autorisent les valeurs sous la forme de descripteurs. Chaque règle est composée d'un sélecteur et d'un descripteur. Le descripteur a&nbsp;:

--- a/files/fr/glossary/css_pixel/index.md
+++ b/files/fr/glossary/css_pixel/index.md
@@ -2,10 +2,10 @@
 title: Pixel CSS
 slug: Glossary/CSS_pixel
 l10n:
-  sourceCommit: 70285e396b5c97675e90b85d573be42078e0168e
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
-Le terme **pixel CSS** est synonyme de l'unité CSS de longueur absolue _px_ — qui est [définie de façon normative](/fr/docs/Web/CSS/Guides/Values_and_units/Numeric_data_types#absolute_length_units) comme étant exactement 1/96<sup>e</sup> d'un pouce CSS (_in_).
+Le terme **pixel CSS** est synonyme de l'unité CSS de longueur absolue _px_ — qui est [définie de façon normative](/fr/docs/Web/CSS/Guides/Values_and_units/Numeric_data_types#unités_de_longueur_absolue) comme étant exactement 1/96<sup>e</sup> d'un pouce CSS (_in_).
 
 ## Voir aussi
 

--- a/files/fr/glossary/css_preprocessor/index.md
+++ b/files/fr/glossary/css_preprocessor/index.md
@@ -2,12 +2,12 @@
 title: Préprocesseur CSS
 slug: Glossary/CSS_preprocessor
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 7d4f930455a349e3c73836500add3d4840c76f5d
 ---
 
 Un **préprocesseur** **CSS** est un programme qui vous permet de générer des {{Glossary("CSS")}} à partir d'un unique préprocesseur propriétaire {{Glossary("Syntax")}}.
 
-Il existe de nombreux préprocesseurs CSS, mais la plupart ajoutent des fonctionnalités qui n'existent pas en CSS pur, comme les mixins, les sélecteurs imbriqués, les sélecteurs d'héritage, etc. Ces fonctionnalités rendent la structure CSS plus lisible et plus facile à maintenir.
+Il existe de nombreux préprocesseurs CSS, mais la plupart ajoutent des fonctionnalités qui n'existent pas en CSS pur, comme les mixins, les sélecteurs imbriqués, les sélecteurs d'héritage, etc. Ces fonctionnalités rendent la structure CSS plus lisible et maintenable.
 
 Pour utiliser un préprocesseur CSS, vous devez installer un compilateur CSS sur votre {{Glossary("server", "serveur")}} web&nbsp;; ou utiliser le préprocesseur CSS pour compiler dans l'environnement de développement, puis téléverser le fichier CSS compilé sur le serveur web.
 

--- a/files/fr/glossary/css_selector/index.md
+++ b/files/fr/glossary/css_selector/index.md
@@ -2,7 +2,7 @@
 title: Sélecteur (CSS)
 slug: Glossary/CSS_Selector
 l10n:
-  sourceCommit: 7615562a3689a3e23a2b6b623597f4391740a53e
+  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
 ---
 
 Un **sélecteur CSS** est la partie de la règle CSS qui désigne les éléments d'un document ciblés par cette règle. Les éléments correspondants se verront appliquer la mise en forme indiquée par la règle.
@@ -53,7 +53,7 @@ Nous pouvons ensuite appliquer ce CSS à du HTML, comme&nbsp;:
 </div>
 ```
 
-Le contenu de la page résultant ressemble à ceci:
+Le contenu de la page résultant ressemble à ceci&nbsp;:
 
 {{EmbedLiveSample("Exemple", 640, 240)}}
 

--- a/files/fr/glossary/database/index.md
+++ b/files/fr/glossary/database/index.md
@@ -2,10 +2,10 @@
 title: Base de données
 slug: Glossary/Database
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 7d4f930455a349e3c73836500add3d4840c76f5d
 ---
 
-Une **base de données** est un système de stockage qui collecte des données organisées, pour faciliter certains travaux comme la recherche, la structure et l'extension.
+Une **base de données** est un système de stockage qui collecte des données organisées, ce qui facilite la recherche, la structure et l'extension.
 
 Dans le développement web, la plupart des bases de données utilisent le système de gestion de base de données relationnelle (SGBDR) pour organiser les données et la programmation en {{Glossary("SQL")}}. Cependant, certaines bases de données appelées NoSQL ne suivent pas l'ancien mécanisme de données organisées.
 

--- a/files/fr/glossary/escape_character/index.md
+++ b/files/fr/glossary/escape_character/index.md
@@ -2,13 +2,13 @@
 title: Caractère d'échappement
 slug: Glossary/Escape_character
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
 ---
 
 Un **caractère d'échappement** est un {{Glossary("character", "caractère")}} qui fait que le ou les caractères qui le suivent sont interprétés différemment. Cela forme une **séquence d'échappement**, qui est souvent utilisée pour représenter un caractère ayant une signification alternative lorsqu'il est affiché littéralement, comme le guillemet dans une chaîne de caractères littérale. Les séquences d'échappement peuvent aussi avoir d'autres usages, notamment dans les [expressions régulières](/fr/docs/Web/JavaScript/Reference/Regular_expressions#séquences_déchappement).
 
 - En JavaScript, dans les [expressions régulières](/fr/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape), les [littéraux de chaîne de caractères](/fr/docs/Web/JavaScript/Reference/Lexical_grammar#chaînes_de_caractère_littérales) et les [identifiants](/fr/docs/Web/JavaScript/Reference/Lexical_grammar#identifiants), on peut utiliser la barre oblique inverse (`\`) pour échapper des caractères comme `\'`, `\"`, `\u0026`, etc.
-- Dans les identifiants CSS, on peut utiliser la barre oblique inverse (`\`) pour échapper des caractères comme `\\`, `\n`, `\26`, etc. Voir [caractères d'échappement](/fr/docs/Web/CSS/Reference/Values/ident#escaping_characters) pour plus d'informations.
+- Dans les identifiants CSS, on peut utiliser la barre oblique inverse (`\`) pour échapper des caractères comme `\\`, `\n`, `\26`, etc. Voir [caractères d'échappement](/fr/docs/Web/CSS/Reference/Values/ident#échappement_de_caractères) pour plus d'informations.
 - Dans le contenu textuel HTML et les valeurs d'attributs, on peut utiliser des {{Glossary("character reference", "références de caractères")}} comme `&lt;`, `&#60;` ou `&#x3C;`.
 - Dans les {{Glossary("URL")}}, on peut utiliser le signe pour cent (`%`) pour échapper des caractères comme `%20`, `%3C`, `%3E`, etc.
 

--- a/files/fr/glossary/extrinsic_size/index.md
+++ b/files/fr/glossary/extrinsic_size/index.md
@@ -2,7 +2,7 @@
 title: Taille extrinsèque
 slug: Glossary/Extrinsic_size
 l10n:
-  sourceCommit: 6afda999d054c2ba12d13d129b13eb35952b4fbe
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 En CSS, la **taille extrinsèque** d'un élément est déterminée par son contexte de mise en page, c'est-à-dire par des contraintes imposées de l'extérieur de l'élément, sans tenir compte de son contenu. C'est l'opposé de la {{Glossary("intrinsic size", "taille intrinsèque")}} d'un élément, qui est basée sur son contenu.
@@ -19,5 +19,5 @@ Les éléments de type bloc sont dimensionnés de manière extrinsèque. Lorsqu'
 
 - Terme associé du glossaire&nbsp;:
   - {{Glossary("Intrinsic size", "Taille intrinsèque")}}
-- Le module [dimensionnement des boîtes CSS](/fr/docs/Web/CSS/CSS_box_sizing)
+- Le module [dimensionnement des boîtes CSS](/fr/docs/Web/CSS/Guides/Box_sizing)
 - La spécification [CSS Box Sizing Module Level 3 <sup>(angl.)</sup>](https://drafts.csswg.org/css-sizing-3/#extrinsic)

--- a/files/fr/glossary/fallback_alignment/index.md
+++ b/files/fr/glossary/fallback_alignment/index.md
@@ -2,7 +2,7 @@
 title: Alignement de repli
 slug: Glossary/Fallback_Alignment
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Dans [le module CSS sur l'alignement des boîtes](/fr/docs/Web/CSS/Guides/Box_alignment), un alignement de repli (<i lang="en">fallback alignement</i>) est indiqué afin de traiter les cas où l'alignement demandé ne peut être respecté. Par exemple, si on indique `justify-content: space-between`, il doit y avoir plus d'un {{Glossary("alignment subject", "sujet d'alignement")}}. Si ce n'est pas le cas, c'est l'alignement de repli qui est utilisé. Cet alignement diffère selon la méthode d'alignement voulue, comme suit&nbsp;:

--- a/files/fr/glossary/first_paint/index.md
+++ b/files/fr/glossary/first_paint/index.md
@@ -2,14 +2,14 @@
 title: First Paint (FP)
 slug: Glossary/First_paint
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 2d78abb3e793352e24e976ce0e68c08d817bd7f3
 ---
 
-Le **premier rendu** (ou <i lang="en">first paint</i> en anglais) correspond au temps entre la navigation et le moment où le navigateur affiche les premiers pixels à l'écran, rendant à l'écran tout ce qui est visuellement différent de la [couleur d'arrière-plan](/fr/docs/Web/CSS/Reference/Properties/background-color) par défaut du [body](/fr/docs/Web/API/Document/body). C'est le premier moment clé du chargement de la page et il répond à la question&nbsp;: «&nbsp;Le navigateur a-t-il commencé à afficher la page&nbsp;?&nbsp;»
+Le **premier rendu** (ou <i lang="en">first paint</i> en anglais) correspond au temps entre la navigation et le moment où le navigateur affiche les premiers pixels à l'écran, rendant à l'écran tout ce qui est visuellement différent de la [couleur d'arrière-plan](/fr/docs/Web/CSS/Reference/Properties/background-color) par défaut du [corps](/fr/docs/Web/API/Document/body). C'est le premier moment clé du chargement de la page et il répond à la question&nbsp;: «&nbsp;Le navigateur a-t-il commencé à afficher la page&nbsp;?&nbsp;»
 
 ## Voir aussi
 
-- [`PerformancePaintTiming`](/fr/docs/Web/API/PerformancePaintTiming)
+- L'interface {{DOMxRef("PerformancePaintTiming")}}
 - Termes associés du glossaire&nbsp;:
   - {{Glossary("First Contentful Paint", "Premier rendu de contenu")}}
   - {{Glossary("Largest Contentful Paint", "Plus grand rendu de contenu")}}

--- a/files/fr/glossary/flex/index.md
+++ b/files/fr/glossary/flex/index.md
@@ -2,7 +2,7 @@
 title: Flex
 slug: Glossary/Flex
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 5ba55a6939c0aaf988fc4d34ad7e51c52373a2a6
 ---
 
 `flex` est une nouvelle valeur ajoutée à la propriété CSS {{CSSxRef("display")}}. De même qu'`inline-flex`, elle transforme l'élément auquel elle s'applique en un {{Glossary("Flex Container","conteneur flexible")}} et les enfants de l'élément en {{Glossary("Flex Item","éléments flexible")}}. Les éléments participent alors à la mise en page flexible, et toutes les propriétés définies dans [le module de mise en page de boîte flexible CSS](/fr/docs/Web/CSS/Guides/Flexible_box_layout) peuvent être appliquées.

--- a/files/fr/glossary/flex_container/index.md
+++ b/files/fr/glossary/flex_container/index.md
@@ -2,7 +2,7 @@
 title: Conteneur flexible
 slug: Glossary/Flex_Container
 l10n:
-  sourceCommit: 13839b2979cc244034ffb1fe243240778b0cd23f
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Une mise en page {{Glossary("flexbox")}} est définie en utilisant les valeurs `flex` ou `inline-flex` de la propriété `display` sur l'élément parent. Cet élément devient alors un **conteneur flexible** et chacun de ses enfants un {{Glossary("flex item", "élément flexible")}}.

--- a/files/fr/glossary/flex_item/index.md
+++ b/files/fr/glossary/flex_item/index.md
@@ -2,7 +2,7 @@
 title: Éléments flexibles
 slug: Glossary/Flex_Item
 l10n:
-  sourceCommit: 13839b2979cc244034ffb1fe243240778b0cd23f
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Les enfants directs d'un {{Glossary("Flex Container","conteneur flexible")}} (éléments définis avec `display: flex` ou `display: inline-flex`) deviennent des **éléments flexibles** (_flex items_).

--- a/files/fr/glossary/flexbox/index.md
+++ b/files/fr/glossary/flexbox/index.md
@@ -2,7 +2,7 @@
 title: Flexbox
 slug: Glossary/Flexbox
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Flexbox (qu'on peut traduire par «&nbsp;boîte flexible&nbsp;») est le nom communément utilisé pour le [module de mise en page des boîtes flexibles CSS](/fr/docs/Web/CSS/Guides/Flexible_box_layout), un modèle de disposition pour afficher des éléments dans une seule dimension, comme une ligne ou une colonne.

--- a/files/fr/glossary/flow_relative_values/index.md
+++ b/files/fr/glossary/flow_relative_values/index.md
@@ -2,7 +2,7 @@
 title: Valeurs relatives au flux
 slug: Glossary/Flow_relative_values
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 En CSS, les **valeurs relatives au flux** sont des mots-clés directionnels relatifs aux axes de bloc et en ligne d'un élément. Ces valeurs incluent `block-start`, `block-end`, `inline-start`, `inline-end`, `start` et `end`.

--- a/files/fr/glossary/fps/index.md
+++ b/files/fr/glossary/fps/index.md
@@ -2,7 +2,7 @@
 title: Fréquence d'images (FPS)
 slug: Glossary/FPS
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Une **fréquence d'images** est la vitesse à laquelle le navigateur est capable de recalculer, de mettre en page et de peindre le contenu à l'écran. Les **images par seconde**, ou **fps** («&nbsp;_frames per second_&nbsp;» en anglais), correspondent au nombre d'images pouvant être affichées en une seconde. La fréquence d'images de l'objectif pour l'infographie du site web est de 60fps.

--- a/files/fr/glossary/fragmentainer/index.md
+++ b/files/fr/glossary/fragmentainer/index.md
@@ -2,10 +2,10 @@
 title: Fragmenteur
 slug: Glossary/Fragmentainer
 l10n:
-  sourceCommit: ab0cab3b1b674b6c873af6a7d3d2c53adf9599e3
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
-Un **fragmenteur** (ou <i lang="en">fragmentainer</i> en anglais) est défini dans la [spécification de fragmentation CSS](https://drafts.csswg.org/css-break/) (en anglais) comme suit&nbsp;:
+Un **fragmenteur** (ou <i lang="en">fragmentainer</i> en anglais) est défini dans la [spécification de fragmentation CSS <sup>(angl.)</sup>](https://drafts.csswg.org/css-break/) (en anglais) comme suit&nbsp;:
 
 > Une boîte, telle qu'une boîte de page, de colonne ou une région, qui contient une partie (ou la totalité) d'un flux fragmenté. Les fragmenteurs peuvent être prédéfinis ou générés selon les besoins. Lorsqu'un contenu fragmentable déborde d'un fragmenteur dans la dimension de bloc, il se brise dans le conteneur suivant de son contexte de fragmentation à la place.
 

--- a/files/fr/glossary/function/index.md
+++ b/files/fr/glossary/function/index.md
@@ -9,7 +9,7 @@ Une **fonction** est une portion de code qui peut être appelée par d'autres co
 
 Un nom de fonction est un {{Glossary("identifier", "identifiant")}} déclaré dans le cadre d'une déclaration de fonction ou d'une expression de fonction. Le fait que le nom de fonction soit déclaré ou exprimé impacte {{Glossary("scope", "la portée")}} du nom de fonction.
 
-### Différents types de fonctions
+## Différents types de fonctions
 
 Une **fonction anonyme** est une fonction sans nom de fonction. Seules les expressions de fonction peuvent être anonymes. Les déclarations de fonctions doivent avoir un nom&nbsp;:
 

--- a/files/fr/glossary/gamut/index.md
+++ b/files/fr/glossary/gamut/index.md
@@ -2,7 +2,7 @@
 title: Gamut
 slug: Glossary/Gamut
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 5ba55a6939c0aaf988fc4d34ad7e51c52373a2a6
 ---
 
 Un **gamut** ou encore appelé une **gamme de couleurs** est un sous-ensemble de couleurs, représentant généralement les couleurs qu'un écran ou qu'un périphérique d'impression peut afficher.
@@ -13,7 +13,7 @@ Traditionnellement, dans le développement web, la seule gamme utilisée était 
 
 Depuis 2021, les navigateurs ont commencé à fournir des fonctionnalités pour d'autres gamuts, comme _[P3](https://fr.wikipedia.org/wiki/DCI-P3)_, largement utilisé dans l'industrie du cinéma, et _[rec2020](https://fr.wikipedia.org/wiki/Rec._2020)_.
 
-Les développeur·euse·s peuvent définir différents jeux de couleurs pour les périphériques prenant en charge des gamuts plus larges à l'aide de la [fonctionnalité média `color-gamut`](/fr/docs/Web/CSS/Reference/At-rules/@media/color-gamut) ou de la [fonctionnalité média](/fr/docs/Web/CSS/Guides/Media_queries/Using). On peut décrire des couleurs en dehors du gamut RVB à l'aide de fonctions CSS spécifiques comme [`lch()`](/fr/docs/Web/CSS/Reference/Values/color_value/lch) pour le système de coordonnées cylindriques LCH, ou [`lab()`](/fr/docs/Web/CSS/Reference/Values/color_value/lab) pour le système de coordonnées Lab.
+Les développeur·euse·s peuvent définir différents jeux de couleurs pour les périphériques prenant en charge des gamuts plus larges à l'aide de la [fonctionnalité média `color-gamut`](/fr/docs/Web/CSS/Reference/At-rules/@media/color-gamut) ou de la [fonctionnalité média](/fr/docs/Web/CSS/Guides/Media_queries/Using). On peut décrire des couleurs en dehors du gamut RVB à l'aide de fonctions CSS spécifiques comme {{CSSxRef("color_value/lch", "lch()")}} pour le système de coordonnées cylindriques LCH, ou {{CSSxRef("color_value/lab", "lab()")}} pour le système de coordonnées Lab.
 
 ## Voir aussi
 

--- a/files/fr/glossary/grid/index.md
+++ b/files/fr/glossary/grid/index.md
@@ -2,7 +2,7 @@
 title: Grille
 slug: Glossary/Grid
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Une **grille CSS** est définie en utilisant la valeur `grid` de la propriété {{CSSxRef("display")}}&nbsp;; vous pouvez définir les colonnes et les lignes de votre grille en utilisant les propriétés {{CSSxRef("grid-template-rows")}} et {{CSSxRef("grid-template-columns")}}.

--- a/files/fr/glossary/grid_areas/index.md
+++ b/files/fr/glossary/grid_areas/index.md
@@ -2,7 +2,7 @@
 title: Zone de grille
 slug: Glossary/Grid_Areas
 l10n:
-  sourceCommit: 13839b2979cc244034ffb1fe243240778b0cd23f
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Une **zone de grille** se compose d'une ou plusieurs {{Glossary("grid cell", "cellules de grille")}} formant une zone rectangulaire sur la grille. Les zones de grille sont créées lors du placement d'un élément en utilisant [le placement basé sur les lignes](/fr/docs/Web/CSS/Guides/Grid_layout/Line-based_placement) ou lors de la définition de zones avec [les zones de grille nommées](/fr/docs/Web/CSS/Guides/Grid_layout/Grid_template_areas).

--- a/files/fr/glossary/grid_axis/index.md
+++ b/files/fr/glossary/grid_axis/index.md
@@ -2,7 +2,7 @@
 title: Axe de grille
 slug: Glossary/Grid_Axis
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 La mise en page en grille CSS (<i lang="en">CSS grid layout</i> en anglais) est une méthode de disposition bidimensionnelle permettant de disposer le contenu en _lignes_ et en _colonnes_. Ainsi, dans toute grille, nous avons deux axes. L'_axe de bloc_ ou axe des colonnes, et l'_axe en ligne_ ou axe des lignes.

--- a/files/fr/glossary/grid_cell/index.md
+++ b/files/fr/glossary/grid_cell/index.md
@@ -2,7 +2,7 @@
 title: Cellule de grille
 slug: Glossary/Grid_Cell
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Dans une [grille CSS](/fr/docs/Web/CSS/Guides/Grid_layout), une **cellule de grille** est la plus petite unité de la grille. C'est l'espace créé entre 4 intersections de {{Glossary("grid lines", "lignes de grille")}}. D'une certaine façon, une cellule de grille est assimilable à une cellule de tableau.

--- a/files/fr/glossary/grid_column/index.md
+++ b/files/fr/glossary/grid_column/index.md
@@ -2,7 +2,7 @@
 title: Colonne de grille
 slug: Glossary/Grid_Column
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Une **colonne de grille** est une piste verticale dans une [grille CSS](/fr/docs/Web/CSS/Guides/Grid_layout), et est l'espace entre deux lignes de grille verticales. Elle est définie par la propriété {{CSSxRef("grid-template-columns")}} ou les propriétés raccourcies {{CSSxRef("grid")}} ou {{CSSxRef("grid-template")}}.

--- a/files/fr/glossary/grid_container/index.md
+++ b/files/fr/glossary/grid_container/index.md
@@ -2,7 +2,7 @@
 title: Conteneur de grille
 slug: Glossary/Grid_Container
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Utiliser la valeur `grid` ou `inline-grid` sur un élément le transforme en un **conteneur de grille** utilisant les [grilles CSS](/fr/docs/Web/CSS/Guides/Grid_layout), et les enfants directs de celui-ci deviennent un élément de cette grille.

--- a/files/fr/glossary/grid_lines/index.md
+++ b/files/fr/glossary/grid_lines/index.md
@@ -2,7 +2,7 @@
 title: Lignes de grille (grid lines)
 slug: Glossary/Grid_Lines
 l10n:
-  sourceCommit: 13839b2979cc244034ffb1fe243240778b0cd23f
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Les **lignes de grille** sont créées chaque fois que vous utilisez une [grille CSS](/fr/docs/Web/CSS/Guides/Grid_layout).

--- a/files/fr/glossary/grid_row/index.md
+++ b/files/fr/glossary/grid_row/index.md
@@ -2,7 +2,7 @@
 title: Ligne de grille (grid row)
 slug: Glossary/Grid_Row
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Une **ligne de grille** (row) est une piste horizontale dans une [grille CSS](/fr/docs/Web/CSS/Guides/Grid_layout), qui se situe dans l'espace entre deux lignes (lines) horizontales de lignes (rows). Elle est définie par la propriété {{CSSxRef("grid-template-rows")}} ou les propriétés raccourcies {{CSSxRef("grid")}} ou {{CSSxRef("grid-template")}}.

--- a/files/fr/glossary/grid_tracks/index.md
+++ b/files/fr/glossary/grid_tracks/index.md
@@ -2,7 +2,7 @@
 title: Piste de grille
 slug: Glossary/Grid_Tracks
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Une **piste de grille** est l'espace entre deux {{Glossary("grid lines", "lignes de grille")}}. Elle est définie dans la _grille explicite_ avec les propriétés {{CSSxRef("grid-template-columns")}} et {{CSSxRef("grid-template-rows")}} ou les propriétés raccourcies {{CSSxRef("grid")}} ou {{CSSxRef("grid-template")}}. Les pistes sont aussi créées dans une _grille implicite_ en positionnant un élément de grille en dehors des pistes créées dans la grille explicite.

--- a/files/fr/glossary/hmac/index.md
+++ b/files/fr/glossary/hmac/index.md
@@ -1,6 +1,8 @@
 ---
 title: HMAC
 slug: Glossary/HMAC
+l10n:
+  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
 ---
 
 Le **code d'authentification de message basé sur un hachage** (_HMAC_) est un mécanisme utilisé pour authentifier des messages de façon {{Glossary("cryptography", "cryptographique")}}.

--- a/files/fr/glossary/html_color_codes/index.md
+++ b/files/fr/glossary/html_color_codes/index.md
@@ -22,6 +22,6 @@ Pour consulter les couleurs web sur MDN, voir la documentation de référence de
 - Noms de couleurs&nbsp;: {{CSSxRef("&lt;named-color&gt;")}}.
 - Notations hexadécimales&nbsp;: {{CSSxRef("&lt;hex-color&gt;")}}.
 - Fonctions de couleur&nbsp;:
-  - Espace colorimétrique [sRGB](/fr/docs/Glossary/Color_space#rgb_color_spaces)&nbsp;: {{CSSxRef("color_value/hsl", "hsl()")}}, {{CSSxRef("color_value/hwb", "hwb()")}} et {{CSSxRef("color_value/rgb", "rgb()")}}.
-  - Espace colorimétrique [CIELAB](/fr/docs/Glossary/Color_space#cielab_color_spaces)&nbsp;: {{CSSxRef("color_value/lab", "lab()")}} et {{CSSxRef("color_value/lch", "lch()")}}, {{CSSxRef("color_value/oklab", "oklab()")}} et {{CSSxRef("color_value/oklch", "oklch()")}}.
+  - Espace colorimétrique [sRGB](/fr/docs/Glossary/Color_space#espaces_de_couleur_rgb)&nbsp;: {{CSSxRef("color_value/hsl", "hsl()")}}, {{CSSxRef("color_value/hwb", "hwb()")}} et {{CSSxRef("color_value/rgb", "rgb()")}}.
+  - Espace colorimétrique [CIELAB](/fr/docs/Glossary/Color_space#espaces_de_couleur_cielab)&nbsp;: {{CSSxRef("color_value/lab", "lab()")}} et {{CSSxRef("color_value/lch", "lch()")}}, {{CSSxRef("color_value/oklab", "oklab()")}} et {{CSSxRef("color_value/oklch", "oklch()")}}.
   - Autres espaces colorimétriques&nbsp;: {{CSSxRef("color_value/color", "color()")}}.

--- a/files/fr/glossary/http_header/index.md
+++ b/files/fr/glossary/http_header/index.md
@@ -2,7 +2,7 @@
 title: En-tête HTTP
 slug: Glossary/HTTP_header
 l10n:
-  sourceCommit: d212f70edcac07927902d76d39eec86765ab063b
+  sourceCommit: bd348e521463e3d0d0bdc4c91d35c1de82a0f5c3
 ---
 
 Un **en-tête HTTP** est un champ de requête ou de réponse HTTP permettant de transmettre des informations supplémentaires modifiant ou précisant la sémantique du message ou de son contenu. Les en-têtes ne sont pas sensibles à la casse, commencent au début d'une ligne et sont immédiatement suivis d'un `':'` et d'une valeur dépendant de l'en-tête en question. La valeur se termine au retour chariot suivant ou à la fin du message.

--- a/files/fr/glossary/https/index.md
+++ b/files/fr/glossary/https/index.md
@@ -2,10 +2,10 @@
 title: HTTPS
 slug: Glossary/HTTPS
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: ca26363fcc6fc861103d40ac0205e5c5b79eb2fa
 ---
 
-**HTTPS** (_HTTP Sécurisé_) est une version chiffrée du protocole {{Glossary("HTTP")}}. Il utilise généralement {{Glossary("TLS")}} ou {{Glossary("SSL")}} pour chiffrer l'intégralité des communications entre un client et un serveur. La connexion sécurisée permet aux clients d'échanger de manière sûre des données sensibles avec un serveur, par exemple pour des transactions bancaires ou du commerce en ligne.
+**HTTPS** (_HTTP Sécurisé_) est une version chiffrée du protocole {{Glossary("HTTP")}}. Il utilise généralement {{Glossary("TLS")}} pour chiffrer l'intégralité des communications entre un client et un serveur. La connexion sécurisée permet aux clients d'échanger de manière sûre des données sensibles avec un serveur, par exemple pour des transactions bancaires ou du commerce en ligne.
 
 ## Voir aussi
 

--- a/files/fr/glossary/https_rr/index.md
+++ b/files/fr/glossary/https_rr/index.md
@@ -2,7 +2,7 @@
 title: HTTPS RR
 slug: Glossary/HTTPS_RR
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 0c81cbce5f95a0be935724bcd936f5592774eb3a
 ---
 
 **HTTPS RR** (**_HTTPS Resource Records_**) est un type d'enregistrement DNS qui fournit des informations de configuration et des paramètres pour accéder à un service via {{Glossary("HTTPS")}}.
@@ -10,7 +10,7 @@ l10n:
 Un _HTTPS RR_ peut être utilisé pour optimiser le processus de connexion à un service utilisant HTTPS.
 De plus, la présence d'un _HTTPS RR_ indique que toutes les ressources {{Glossary("HTTP")}} utiles sur l'origine sont accessibles via HTTPS, ce qui signifie qu'un navigateur peut mettre à niveau en toute sécurité les connexions du domaine de HTTP vers HTTPS.
 
-### Voir aussi
+## Voir aussi
 
 - {{RFC(9460, "Spécification de liaison de service et de paramètres via le DNS (SVCB et enregistrements de ressource HTTPS)")}}
 - [Sécurité stricte du transport face aux enregistrements de ressource HTTPS&nbsp;: le duel <sup>(angl.)</sup>](https://emilymstark.com/2020/10/24/strict-transport-security-vs-https-resource-records-the-showdown.html) (blog d'Emily M. Stark)

--- a/files/fr/glossary/ink_overflow/index.md
+++ b/files/fr/glossary/ink_overflow/index.md
@@ -2,7 +2,7 @@
 title: Débordement d'encre (ink overflow)
 slug: Glossary/Ink_overflow
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Le **débordement d'encre** (<i lang="en">ink overflow</i> en anglais) d'une boîte désigne la partie de la boîte et de son contenu qui crée un effet visuel en dehors de la boîte englobante (<i lang="en">border box</i>). Purement visuel, le débordement d'encre n'affecte pas la mise en page car il n'a aucun impact sur les propriétés du modèle de boîte.

--- a/files/fr/glossary/inline-level_content/index.md
+++ b/files/fr/glossary/inline-level_content/index.md
@@ -2,12 +2,12 @@
 title: Éléments en ligne
 slug: Glossary/Inline-level_content
 l10n:
-  sourceCommit: 2530db14de9ac226cf06f84540fa0101e804ca9b
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 En CSS, le contenu qui participe à la mise en page en ligne est appelé **contenu de niveau en ligne**. La plupart des séquences de texte, des éléments remplacés et du contenu généré sont, par défaut, de niveau en ligne.
 
-Dans la mise en page en ligne, un flux mixte de texte, d'{{ Glossary("replaced elements", "éléments remplacés") }} et d'autres boîtes en ligne est disposé en les fragmentant dans une pile de boîtes de ligne. À l'intérieur de chaque boîte de ligne, les boîtes de niveau en ligne sont alignées entre elles verticalement ou horizontalement, selon le mode d'écriture. En général, elles sont alignées sur les lignes de base de leur texte. Cela peut être modifié avec le CSS.
+Dans la mise en page en ligne, un flux mixte de texte, d'{{Glossary("replaced elements", "éléments remplacés")}} et d'autres boîtes en ligne est disposé en les fragmentant dans une pile de boîtes de ligne. À l'intérieur de chaque boîte de ligne, les boîtes de niveau en ligne sont alignées entre elles verticalement ou horizontalement, selon le mode d'écriture. En général, elles sont alignées sur les lignes de base de leur texte. Cela peut être modifié avec le CSS.
 
 ![mise en page en ligne](inline_layout.png)
 

--- a/files/fr/glossary/inset_properties/index.md
+++ b/files/fr/glossary/inset_properties/index.md
@@ -2,7 +2,7 @@
 title: Propriétés inset
 slug: Glossary/Inset_properties
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 En CSS, les **propriétés inset** contrôlent la position des éléments positionnés en spécifiant des décalages par rapport à leur position par défaut. Il existe des propriétés inset physiques, logiques et des raccourcis.
@@ -11,11 +11,11 @@ Les propriétés inset incluent les propriétés physiques {{CSSxRef("top")}}, {
 
 Les **propriétés physiques** font référence à des côtés physiques spécifiques d'un élément. Les propriétés logiques utilisent des mots-clés directionnels relatifs aux axes de bloc et d'inline. L'**axe de bloc** correspond à l'axe qui définit l'ordre d'empilement des éléments dans une disposition en bloc. L'**axe d'inline** est perpendiculaire à l'axe de bloc et représente la direction dans laquelle le contenu en ligne, comme le texte, s'écoule dans un bloc. La correspondance dépend des propriétés {{CSSxRef("writing-mode")}}, {{CSSxRef("direction")}} et {{CSSxRef("text-orientation")}} de l'élément.
 
-L'interprétation des propriétés inset dépend de la valeur de la propriété {{CSSxRef("position")}}. Lorsque `position: absolute` est utilisé, elles représentent les décalages depuis le [bloc englobant](/fr/docs/Web/CSS/Guides/Display/Containing_block) ou l'[élément d'ancrage](/fr/docs/Web/CSS/CSS_anchor_positioning/Using). Avec `position: relative`, elles représentent les décalages depuis la position par défaut du bord de la marge de la boîte. Avec `sticky`, elles représentent les décalages depuis le bord du {{Glossary("scroll container", "conteneur de défilement")}}. La valeur `fixed` est similaire à `absolute`, sauf que l'élément est positionné et dimensionné par rapport à son bloc de positionnement fixe, qui est souvent la zone d'affichage (<i lang="en">viewport</i> en anglais).
+L'interprétation des propriétés inset dépend de la valeur de la propriété {{CSSxRef("position")}}. Lorsque `position: absolute` est utilisé, elles représentent les décalages depuis le [bloc englobant](/fr/docs/Web/CSS/Guides/Display/Containing_block) ou l'[élément d'ancrage](/fr/docs/Web/CSS/Guides/Anchor_positioning/Using). Avec `position: relative`, elles représentent les décalages depuis la position par défaut du bord de la marge de la boîte. Avec `sticky`, elles représentent les décalages depuis le bord du {{Glossary("scroll container", "conteneur de défilement")}}. La valeur `fixed` est similaire à `absolute`, sauf que l'élément est positionné et dimensionné par rapport à son bloc de positionnement fixe, qui est souvent la zone d'affichage (<i lang="en">viewport</i> en anglais).
 
 ## Voir aussi
 
 - [Disposition et bloc englobant](/fr/docs/Web/CSS/Guides/Display/Containing_block)
 - Le module [de positionnement CSS](/fr/docs/Web/CSS/Guides/Positioned_layout)
 - Le module [des propriétés logiques et valeurs CSS](/fr/docs/Web/CSS/Guides/Logical_properties_and_values)
-- Le module [d'ancrage CSS](/fr/docs/Web/CSS/CSS_anchor_positioning)
+- Le module [d'ancrage CSS](/fr/docs/Web/CSS/Guides/Anchor_positioning)

--- a/files/fr/glossary/interpolation/index.md
+++ b/files/fr/glossary/interpolation/index.md
@@ -2,7 +2,7 @@
 title: Interpolation
 slug: Glossary/Interpolation
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
 ---
 
 L'**interpolation** est une méthode permettant d'estimer de nouvelles valeurs à partir d'un ensemble de points de données connus.

--- a/files/fr/glossary/intrinsic_size/index.md
+++ b/files/fr/glossary/intrinsic_size/index.md
@@ -2,7 +2,7 @@
 title: Taille intrinsèque
 slug: Glossary/Intrinsic_Size
 l10n:
-  sourceCommit: bbff081938f76bdd6c6fdbf59d2e25e0a7a1cf2a
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 En CSS, la **taille intrinsèque** d'un élément est la taille qu'il aurait uniquement en fonction de son contenu, sans tenir compte des effets du contexte de mise en page dans lequel il apparaît. C'est l'opposé de la {{Glossary("extrinsic size", "taille extrinsèque")}} d'un élément, qui est déterminée par des contraintes externes comme la taille du conteneur. Les tailles intrinsèques d'un élément sont représentées par ses tailles {{CSSxRef("min-content")}} et {{CSSxRef("max-content")}}.
@@ -66,5 +66,5 @@ p {
 - La propriété CSS {{CSSxRef("interpolate-size")}}
 - La propriété CSS {{CSSxRef("aspect-ratio")}}
 - La fonction CSS {{CSSxRef("calc-size()")}}
-- [Module de dimensionnement des boîtes CSS](/fr/docs/Web/CSS/CSS_box_sizing)
+- [Module de dimensionnement des boîtes CSS](/fr/docs/Web/CSS/Guides/Box_sizing)
 - Spécification du module CSS [de dimensionnement des boîtes niveau 3 <sup>(angl.)</sup>](https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes)

--- a/files/fr/glossary/largest_contentful_paint/index.md
+++ b/files/fr/glossary/largest_contentful_paint/index.md
@@ -2,7 +2,7 @@
 title: Largest Contentful Paint (LCP)
 slug: Glossary/Largest_contentful_paint
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 96a73163513476fe49bfba695acedb7622135354
 ---
 
 La mesure de performance **Largest Contentful Paint** (<abbr>LCP</abbr>) indique le temps de rendu de la plus grande image ou du plus grand bloc de texte visible dans la zone d'affichage (<i lang="en">viewport</i> en anglais), mesuré à partir du début du chargement de la page.
@@ -17,7 +17,7 @@ Les éléments suivants sont pris en compte pour déterminer le LCP&nbsp;:
 
 ## Voir aussi
 
-- L'interface [`LargestContentfulPaint`](/fr/docs/Web/API/LargestContentfulPaint)
+- L'interface {{DOMxRef("LargestContentfulPaint")}}
 - Termes associés du glossaire&nbsp;:
   - {{Glossary("First Contentful Paint", "Premier rendu de contenu")}}
   - {{Glossary("First Paint", "Premier rendu")}}

--- a/files/fr/glossary/layout_mode/index.md
+++ b/files/fr/glossary/layout_mode/index.md
@@ -2,7 +2,7 @@
 title: Mode de disposition
 slug: Glossary/Layout_mode
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
 Un **mode de disposition CSS** (_layout mode_), parfois raccourci en «&nbsp;disposition&nbsp;» est un algorithme qui détermine la position et la taille des boîtes des éléments en fonction des interactions avec leurs voisins et leurs ancêtres.
@@ -13,7 +13,7 @@ Il existe plusieurs modes de disposition&nbsp;:
   - : Tous les éléments font partie du flux normal jusqu'à ce qu'une propriété les en sorte. Le flux normal inclut&nbsp;:
     - **[Disposition en bloc](/fr/docs/Web/CSS/Guides/Display/Block_and_inline_layout)**
       - : Conçue pour organiser des boîtes comme les paragraphes.
-    - **[Disposition en ligne](/fr/docs/Web/CSS/CSS_inline_layout)**
+    - **[Disposition en ligne](/fr/docs/Web/CSS/Guides/Inline_layout)**
       - : Conçue pour organiser des éléments en ligne comme le texte.
 
 - **[Disposition en tableau](/fr/docs/Web/CSS/Guides/Table)**

--- a/files/fr/glossary/layout_viewport/index.md
+++ b/files/fr/glossary/layout_viewport/index.md
@@ -2,7 +2,7 @@
 title: Zone d'affichage pour la disposition
 slug: Glossary/Layout_viewport
 l10n:
-  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+  sourceCommit: 9be502ee0f8b030908e59d30884190281acb8054
 ---
 
 La **zone d'affichage pour la disposition** ({{Glossary("viewport", "zone d'affichage")}}) est la surface sur laquelle le navigateur dessine la page web. Il s'agit de la surface totale disponible à l'affichage. La **zone d'affichage visuelle** ({{Glossary("visual viewport", "zone d'affichage visuelle")}}) correspond à la partie de la zone d'affichage pour la disposition effectivement visible à l'écran de l'utilisateur·ice.


### PR DESCRIPTION
### Description

Updated all Glossary pages recently updated on en-US with CSS links changes (chore(ia)) and macros changes (chore(macro)).

### Motivation

Keeping pages up-to-date.

### Additional details

_none_

### Related issues and pull requests

_none_
