### PR TITLE
chore(fr): translation of `Glossary/Router`

### DIFF
--- a/files/fr/glossary/router/index.md
+++ b/files/fr/glossary/router/index.md
@@ -1,0 +1,24 @@
+---
+title: Router
+slug: Glossary/Router
+l10n:
+  sourceCommit: 2547f622337d6cbf8c3794776b17ed377d6aad57
+---
+
+Sur le web, le terme **routeur** peut désigner différents concepts selon le contexte&nbsp;:
+
+- Pour la couche réseau, un routeur est un appareil réseau qui décide où diriger les {{Glossary('Packet', 'paquets de données')}}.
+
+- Pour une {{Glossary("SPA", "application monopage (SPA)")}} dans la couche applicative, un routeur est une bibliothèque qui décide quelle page web est présentée pour une {{Glossary('URL')}} donnée. Ce module de middleware est utilisé pour toutes les fonctions liées aux URL, car celles-ci reçoivent un chemin vers un fichier qui est affiché pour ouvrir la page suivante.
+
+  Le concept de routage dans les SPA a beaucoup évolué au fil des années. Voir l'entrée de glossaire du {{Glossary("hash routing", "routage par dièse")}} pour en savoir plus.
+
+- Dans l'implémentation d'une {{Glossary('API')}} dans une couche de service, un routeur est un composant logiciel qui analyse une requête et la dirige ou la route vers différents gestionnaires au sein d'un programme. Le code du routeur accepte généralement une réponse du gestionnaire et facilite son retour vers le demandeur.
+
+## Voir aussi
+
+- Pour le contexte de la couche réseau, voir [Routeur (informatique)](https://fr.wikipedia.org/wiki/Routeur) sur Wikipédia.
+- Dans le contexte de la couche applicative, la plupart des frameworks SPA populaires incluent des bibliothèques de routage intégrées, telles que&nbsp;:
+  - [Angular router <sup>(angl.)</sup>](https://angular.dev/guide/routing/common-router-tasks)
+  - [React router <sup>(angl.)</sup>](https://reactrouter.com/)
+  - [Vue router <sup>(angl.)</sup>](https://router.vuejs.org/)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Glossary/Router`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_