### PR TITLE
chore(fr): translation of `Web/API/AbortController/AbortController`

### DIFF
--- a/files/fr/web/api/abortcontroller/abortcontroller/index.md
+++ b/files/fr/web/api/abortcontroller/abortcontroller/index.md
@@ -1,0 +1,39 @@
+---
+title: "AbortController : constructeur AbortController()"
+short-title: AbortController()
+slug: Web/API/AbortController/AbortController
+l10n:
+  sourceCommit: a4fd602696976d79d8690f9c86a2a1c1f2b9b9eb
+---
+
+{{APIRef("DOM")}}{{AvailableInWorkers}}
+
+Le constructeur **`AbortController()`** crée une nouvelle instance de l'objet {{DOMxRef("AbortController")}}.
+
+## Syntaxe
+
+```js-nolint
+new AbortController()
+```
+
+### Paramètres
+
+Aucun.
+
+## Exemples
+
+Voir la [page `AbortSignal`](/fr/docs/Web/API/AbortSignal#exemples) pour des exemples d'utilisation.
+
+Vous pouvez trouver un [exemple complet et fonctionnel sur GitHub <sup>(angl.)</sup>](https://github.com/mdn/dom-examples/tree/main/abort-api)&nbsp;; vous pouvez aussi le voir [en ligne <sup>(angl.)</sup>](https://mdn.github.io/dom-examples/abort-api/).
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- [L'API Fetch](/fr/docs/Web/API/Fetch_API)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/AbortController/AbortController`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_