### PR TITLE
chore(fr): translation of `Web/API/AbortController/signal`

### DIFF
--- a/files/fr/web/api/abortcontroller/signal/index.md
+++ b/files/fr/web/api/abortcontroller/signal/index.md
@@ -1,0 +1,33 @@
+---
+title: "AbortController : propriété signal"
+short-title: signal
+slug: Web/API/AbortController/signal
+l10n:
+  sourceCommit: a4fd602696976d79d8690f9c86a2a1c1f2b9b9eb
+---
+
+{{APIRef("DOM")}}{{AvailableInWorkers}}
+
+La propriété en lecture seule **`signal`** de l'interface {{DOMxRef("AbortController")}} retourne une instance de l'objet {{DOMxRef("AbortSignal")}}, qui peut être utilisée pour communiquer avec ou annuler une opération asynchrone à volonté.
+
+## Valeur
+
+Une instance de l'objet {{DOMxRef("AbortSignal")}}.
+
+## Exemples
+
+Voir la [page `AbortSignal`](/fr/docs/Web/API/AbortSignal#exemples) pour des exemples d'utilisation.
+
+Vous pouvez trouver un [exemple complet et fonctionnel sur GitHub <sup>(angl.)</sup>](https://github.com/mdn/dom-examples/tree/main/abort-api)&nbsp;; vous pouvez aussi le voir [en ligne <sup>(angl.)</sup>](https://mdn.github.io/dom-examples/abort-api/).
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- [L'API Fetch](/fr/docs/Web/API/Fetch_API)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/AbortController/signal`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_