### PR TITLE
chore(fr): translation of `Web/API/AbortSignal/aborted`

### DIFF
--- a/files/fr/web/api/abortsignal/aborted/index.md
+++ b/files/fr/web/api/abortsignal/aborted/index.md
@@ -1,0 +1,45 @@
+---
+title: "AbortSignal : propriété aborted"
+short-title: aborted
+slug: Web/API/AbortSignal/aborted
+l10n:
+  sourceCommit: 15f0b5552bc9c2ea1f32b0cd5ee840a7d43c887e
+---
+
+{{APIRef("DOM")}}{{AvailableInWorkers}}
+
+La propriété en lecture seule **`aborted`** de l'interface {{DOMxRef("AbortSignal")}} retourne une valeur qui indique si les opérations asynchrones avec lesquelles le signal communique sont annulées (`true`) ou non (`false`).
+
+## Valeur
+
+`true` (annulée) ou `false`
+
+## Exemples
+
+Dans l'extrait suivant, nous créons un nouvel objet `AbortController` et récupérons son {{DOMxRef("AbortSignal")}} (disponible via la propriété `signal`).
+Ensuite, à l'aide de la propriété `aborted`, nous vérifions si le signal a été annulé et envoyons un message approprié dans la console.
+
+```js
+const controller = new AbortController();
+const signal = controller.signal;
+
+// …
+
+if (signal.aborted) {
+  console.log("La requête a été annulée");
+} else {
+  console.log("La requête n'a pas été annulée");
+}
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- [L'API Fetch](/fr/docs/Web/API/Fetch_API)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/AbortSignal/aborted`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_