### PR TITLE
[ja]: タイポを修正 (`Web/API/PerformanceEntry/startTime`)

### DIFF
--- a/files/ja/web/api/performanceentry/starttime/index.md
+++ b/files/ja/web/api/performanceentry/starttime/index.md
@@ -21,7 +21,7 @@ l10n:
 - `event`
   - : イベントが作成された時刻、すなわちそのイベントの [`timeStamp`](/ja/docs/Web/API/Event/timeStamp) プロパティです。
 - `first-input`
-  - : 最初の入力イベントが作成された時刻、すなわちそのイベtのの [`timeStamp`](/ja/docs/Web/API/Event/timeStamp) プロパティです。
+  - : 最初の入力イベントが作成された時刻、すなわちそのイベントの [`timeStamp`](/ja/docs/Web/API/Event/timeStamp) プロパティです。
 - `largest-contentful-paint`
   - : この項目の {{domxref("LargestContentfulPaint.renderTime", "renderTime")}} の値が `0` でない場合はその値、そうでない場合はこの項目の {{domxref("LargestContentfulPaint.loadTime", "loadTime")}} の値。
 - `layout-shift`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`Web/API/PerformanceEntry/startTime` のタイポを修正


### Additional details

* 当該記事: https://developer.mozilla.org/ja/docs/Web/API/PerformanceEntry/startTime
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
