### PR TITLE
chore(fr): translation of `Web/API/HTMLElement/accessKeyLabel`

### DIFF
--- a/files/fr/web/api/htmlelement/accesskeylabel/index.md
+++ b/files/fr/web/api/htmlelement/accesskeylabel/index.md
@@ -1,0 +1,50 @@
+---
+title: "HTMLElement : propriété accessKeyLabel"
+short-title: accessKeyLabel
+slug: Web/API/HTMLElement/accessKeyLabel
+l10n:
+  sourceCommit: e9b6cd1b7fa8612257b72b2a85a96dd7d45c0200
+---
+
+{{APIRef("HTML DOM")}}
+
+La propriété en lecture seule **`accessKeyLabel`** de l'interface {{DOMxRef("HTMLElement")}} retourne une chaîne de caractères contenant la touche d'accès attribuée par le navigateur à l'élément (si elle existe)&nbsp;; sinon, elle retourne une chaîne vide.
+
+## Exemples
+
+### JavaScript
+
+```js
+const btn = document.getElementById("btn1");
+const shortcutLabel = btn.accessKeyLabel || btn.accessKey;
+btn.title += ` [${shortcutLabel.toUpperCase()}]`;
+
+btn.onclick = () => {
+  const feedback = document.createElement("output");
+  feedback.textContent = "Pressé !";
+  btn.insertAdjacentElement("afterend", feedback);
+};
+```
+
+### HTML
+
+```html
+<button accesskey="h" title="Légende" id="btn1">Survolez-moi</button>
+```
+
+### Résultat
+
+{{EmbedLiveSample('Exemples')}}
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- La propriété {{DOMxRef("HTMLElement.accessKey")}}
+- L'attribut universel [`accesskey`](/fr/docs/Web/HTML/Reference/Global_attributes/accesskey)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/HTMLElement/accessKeyLabel`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_