### PR TITLE
[ko] fix broken live samples in rt element

### DIFF
--- a/files/ko/web/html/reference/elements/rt/index.md
+++ b/files/ko/web/html/reference/elements/rt/index.md
@@ -69,6 +69,8 @@ ruby {
 
 다음 예제는 {{htmlelement("ruby")}} 요소를 사용해 한자의 발음을 표기합니다.
 
+### 루비를 지원하는 경우
+
 ```html
 <ruby> 漢 <rt>한</rt> 字 <rt>자</rt> </ruby>
 ```
@@ -81,7 +83,9 @@ body {
 
 결과는 다음과 같습니다.
 
-{{EmbedLiveSample("with-ruby", 600, 60)}}
+{{EmbedLiveSample("루비를 지원하는 경우", 600, 60)}}
+
+### 루비를 지원하지 않는 경우
 
 브라우저가 루비를 지원하지 않는 경우엔 다음처럼 보일 것입니다.
 
@@ -95,7 +99,7 @@ body {
 }
 ```
 
-{{EmbedLiveSample("without-ruby", 600, 60)}}
+{{EmbedLiveSample("루비를 지원하지 않는 경우", 600, 60)}}
 
 ## 명세
 


### PR DESCRIPTION
### Description

This PR fixes the live code examples in the Korean translation of the HTML `<rt>` element documentation. The single "Examples" section was restructured into two distinct subsections, and the `EmbedLiveSample` macro calls were updated to match these new localized headings.

### Motivation

Previously, two separate examples (one with Ruby support, one without) existed within a single markdown section block under the generic heading `## 예제` (Examples).
Because the `EmbedLiveSample` macro fetches all code blocks within the current section scope, it was incorrectly combining the HTML and CSS from both examples. This resulted in both sample boxes displaying identical, broken output.
By introducing explicit subheadings for each scenario (`### 루비를 지원하는 경우` and `### 루비를 지원하지 않는 경우`), I ensured that each `EmbedLiveSample` call correctly scopes to its own block and renders only the relevant code.

### Additional details

#### Before
<img width="730" height="599" alt="고장난 상태" src="https://github.com/user-attachments/assets/e2408e3d-cc5f-4f95-95cd-7fcff189eb88" />

#### After
<img width="729" height="703" alt="수리된 상태" src="https://github.com/user-attachments/assets/38fa5e25-dc65-413d-aa46-20d9c1e20765" />

<!-- ### Related issues and pull requests -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
