### PR TITLE
Remove reference to old amo-admins mailing list

### DIFF
--- a/files/ja/mozilla/add-ons/contact_us/index.md
+++ b/files/ja/mozilla/add-ons/contact_us/index.md
@@ -26,7 +26,7 @@ slug: Mozilla/Add-ons/Contact_us
 
 #### セキュリティ欠陥
 
-アドオンのセキュリティ欠陥を見つけた場合は、それが Mozilla のサイトで提供しているものでなくても、私たちまでお知らせ下さい。私たちは開発者と協力して問題を修正します。 連絡は[非公開で](https://www.mozilla.org/projects/security/security-bugs-policy.html)、 [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Add-on%20Security&maketemplate=Add-on%20Security%20Bug&bit-23=1&rep_platform=All&op_sys=All) または [amo-admins@mozilla.com 宛てのメール](mailto:amo-admins@mozilla.com)でお願いします。
+アドオンのセキュリティ欠陥を見つけた場合は、それが Mozilla のサイトで提供しているものでなくても、私たちまでお知らせ下さい。私たちは開発者と協力して問題を修正します。 連絡は[非公開で](https://www.mozilla.org/projects/security/security-bugs-policy.html)、 [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Add-on%20Security&maketemplate=Add-on%20Security%20Bug&bit-23=1&rep_platform=All&op_sys=All)。
 
 #### サイト addons.mozilla.org (AMO)のバグ
 

--- a/files/ja/mozilla/add-ons/contact_us/index.md
+++ b/files/ja/mozilla/add-ons/contact_us/index.md
@@ -26,7 +26,7 @@ slug: Mozilla/Add-ons/Contact_us
 
 #### セキュリティ欠陥
 
-アドオンのセキュリティ欠陥を見つけた場合は、それが Mozilla のサイトで提供しているものでなくても、私たちまでお知らせ下さい。私たちは開発者と協力して問題を修正します。 連絡は[非公開で](https://www.mozilla.org/projects/security/security-bugs-policy.html)、 [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Add-on%20Security&maketemplate=Add-on%20Security%20Bug&bit-23=1&rep_platform=All&op_sys=All)。
+アドオンのセキュリティ欠陥を見つけた場合は、それが Mozilla のサイトで提供しているものでなくても、私たちまでお知らせ下さい。私たちは開発者と協力して問題を修正します。 連絡は[非公開で](https://www.mozilla.org/projects/security/security-bugs-policy.html)、 [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Add-on%20Security&maketemplate=Add-on%20Security%20Bug&bit-23=1&rep_platform=All&op_sys=All) にお願いします。
 
 #### サイト addons.mozilla.org (AMO)のバグ
 

--- a/files/zh-cn/mozilla/add-ons/contact_us/index.md
+++ b/files/zh-cn/mozilla/add-ons/contact_us/index.md
@@ -24,7 +24,7 @@ slug: Mozilla/Add-ons/Contact_us
 
 #### 安全漏洞
 
-如果你发现了一个附加组件的安全漏洞，即使该附加组件未托管在 Mozilla 站点上，也请通知我们。我们将与开发人员一起解决此问题。请向 [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Add-on%20Security&maketemplate=Add-on%20Security%20Bug&bit-23=1&rep_platform=All&op_sys=All) 提交或向 <amo-admins@mozilla.com> 发送邮件以[秘密地](https://www.mozilla.org/en-US/about/governance/policies/security-group/bugs/)报告安全漏洞。
+如果你发现了一个附加组件的安全漏洞，即使该附加组件未托管在 Mozilla 站点上，也请通知我们。我们将与开发人员一起解决此问题。请向 [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Add-on%20Security&maketemplate=Add-on%20Security%20Bug&bit-23=1&rep_platform=All&op_sys=All) 发送邮件以[秘密地](https://www.mozilla.org/en-US/about/governance/policies/security-group/bugs/)报告安全漏洞。
 
 #### addons.mozilla.org (AMO) 的问题
 

--- a/files/zh-cn/mozilla/add-ons/contact_us/index.md
+++ b/files/zh-cn/mozilla/add-ons/contact_us/index.md
@@ -24,7 +24,7 @@ slug: Mozilla/Add-ons/Contact_us
 
 #### 安全漏洞
 
-如果你发现了一个附加组件的安全漏洞，即使该附加组件未托管在 Mozilla 站点上，也请通知我们。我们将与开发人员一起解决此问题。请向 [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Add-on%20Security&maketemplate=Add-on%20Security%20Bug&bit-23=1&rep_platform=All&op_sys=All) 发送邮件以[秘密地](https://www.mozilla.org/en-US/about/governance/policies/security-group/bugs/)报告安全漏洞。
+如果你发现了一个附加组件的安全漏洞，即使该附加组件未托管在 Mozilla 站点上，也请通知我们。我们将与开发人员一起解决此问题。请向 [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Add-on%20Security&maketemplate=Add-on%20Security%20Bug&bit-23=1&rep_platform=All&op_sys=All) [秘密地](https://www.mozilla.org/en-US/about/governance/policies/security-group/bugs/)报告安全漏洞。
 
 #### addons.mozilla.org (AMO) 的问题
 


### PR DESCRIPTION
### Description

This removes references to an old mailing list in a few locales where the corresponding page hasn't been updated in a long time. Since I don't speak any of those languages, I didn't want to make large changes to sync the more up-to-date content from en-US. I verified with Google Translate that I didn't completely break the changed sentences.

### Motivation

The mailing list referenced is old and not well maintained and we are aiming to close it permanently.

### Additional details

### Related issues and pull requests
