### PR TITLE
chore(fr): translation of `Web/API/HTMLObjectElement/contentWindow`

### DIFF
--- a/files/fr/web/api/htmlobjectelement/contentwindow/index.md
+++ b/files/fr/web/api/htmlobjectelement/contentwindow/index.md
@@ -1,0 +1,23 @@
+---
+title: "HTMLObjectElement : propriété contentWindow"
+short-title: contentWindow
+slug: Web/API/HTMLObjectElement/contentWindow
+l10n:
+  sourceCommit: 09b358ad5d39e36065e51a1ad65358c7d00c19e8
+---
+
+{{APIRef("HTML DOM")}}
+
+La propriété **`contentWindow`** en lecture seule de l'interface {{DOMxRef("HTMLObjectElement")}} retourne un {{Glossary("WindowProxy")}} représentant le mandataire de fenêtre du contexte de navigation imbriqué de l'élément HTML {{HTMLElement("object")}}, le cas échéant&nbsp;; sinon, retourne `null`.
+
+## Valeur
+
+Un objet {{DOMxRef('Window')}}, ou `null` s'il n'y en a pas.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/HTMLObjectElement/contentWindow`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_