### PR TITLE
chore(fr): translation of `Web/API/HTMLObjectElement/validationMessage`

### DIFF
--- a/files/fr/web/api/htmlobjectelement/validationmessage/index.md
+++ b/files/fr/web/api/htmlobjectelement/validationmessage/index.md
@@ -1,0 +1,23 @@
+---
+title: "HTMLObjectElement : propriété validationMessage"
+short-title: validationMessage
+slug: Web/API/HTMLObjectElement/validationMessage
+l10n:
+  sourceCommit: 595cba0e07c70eda7f08a12890e00ea0281933d3
+---
+
+{{APIRef("HTML DOM")}}
+
+La propriété en lecture seule **`validationMessage`** de l'interface {{DOMxRef("HTMLObjectElement")}} retourne une chaîne de caractères représentant un message localisé décrivant les contraintes de validation non satisfaites (le cas échéant). Il s'agit d'une chaîne vide si le contrôle n'est pas candidat à la validation de contraintes (`willValidate` est `false`), ou s'il satisfait ses contraintes.
+
+## Valeur
+
+Une chaîne de caractères.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/HTMLObjectElement/validationMessage`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_