### PR TITLE
chore(fr): translation of `Web/API/HTMLOptGroupElement/label`

### DIFF
--- a/files/fr/web/api/htmloptgroupelement/label/index.md
+++ b/files/fr/web/api/htmloptgroupelement/label/index.md
@@ -1,0 +1,36 @@
+---
+title: "HTMLOptGroupElement : propriété label"
+short-title: label
+slug: Web/API/HTMLOptGroupElement/label
+l10n:
+  sourceCommit: e9b6cd1b7fa8612257b72b2a85a96dd7d45c0200
+---
+
+{{APIRef("HTML DOM")}}
+
+La propriété **`label`** de l'interface {{DOMxRef("HTMLOptGroupElement")}} est une chaîne de caractères qui reflète l'attribut [`label`](/fr/docs/Web/HTML/Reference/Elements/optgroup#label) de l'élément HTML {{HTMLElement("optgroup")}}, lequel fournit une étiquette textuelle au groupe d'options.
+
+## Valeur
+
+Une chaîne de caractères.
+
+## Exemples
+
+```js
+const optionGroup = document.getElementById("groupB");
+console.log(optionGroup.label);
+optionGroup.label = `${optionGroup.label} (${optionGroup.children.length})`;
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'élément HTML {{HTMLElement("optgroup")}}
+- L'attribut HTML [`label`](/fr/docs/Web/HTML/Reference/Elements/optgroup#label)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/HTMLOptGroupElement/label`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_