### PR TITLE
chore(fr): translation of `Web/API/HTMLOutputElement/willValidate`

### DIFF
--- a/files/fr/web/api/htmloutputelement/willvalidate/index.md
+++ b/files/fr/web/api/htmloutputelement/willvalidate/index.md
@@ -1,0 +1,31 @@
+---
+title: "HTMLOutputElement : propriété willValidate"
+short-title: willValidate
+slug: Web/API/HTMLOutputElement/willValidate
+l10n:
+  sourceCommit: e9b6cd1b7fa8612257b72b2a85a96dd7d45c0200
+---
+
+{{APIRef("HTML DOM")}}
+
+La propriété en lecture seule **`willValidate`** de l'interface {{DOMxRef("HTMLOutputElement")}} retourne `false`, car les éléments HTML {{HTMLElement("output")}} ne sont pas candidats à la [validation de contraintes](/fr/docs/Web/HTML/Guides/Constraint_validation).
+
+## Valeur
+
+La valeur booléenne `false`.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- La propriété {{DOMxRef("HTMLOutputElement.checkValidity()")}}
+- L'élément HTML {{HTMLElement("output")}}
+- L'élément HTML {{HTMLElement("form")}}
+- [Apprendre&nbsp;: Validation de formulaire côté client](/fr/docs/Learn_web_development/Extensions/Forms/Form_validation)
+- [Guide&nbsp;: Validation de contraintes](/fr/docs/Web/HTML/Guides/Constraint_validation)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/HTMLOutputElement/willValidate`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_