### PR TITLE
chore(deps-dev): bump npm from 11.6.2 to 11.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,15 @@
     "lint:yml": "prettier -c \"**/*.yml\"",
     "prepare": "node scripts/npm-check.js"
   },
-  "packageManager": "npm@11.6.2",
+  "packageManager": "npm@11.9.0",
   "engines": {
     "node": ">=24"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.8.0"
+    }
   },
   "devDependencies": {
     "autocorrect-node": "2.14.0",


### PR DESCRIPTION
### Description

Bumps npm from 11.6.2 to 11.9.0:

- Updates `packageManager` field to `npm@11.9.0`.
- Adds `devEngines.packageManager` field with `{ "name": "npm", "version": ">=11.8.0" }`.

Also updates the `package-lock.json` file.

### Motivation

Avoids accidental `package-lock.json` files by contributors (npm 11.6.2 and 11.8.0 produce different lock files, due to a bug in npm 11.6.2).

### Additional details

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1205.