### PR TITLE
chore(fr): translation of `Web/API/HTMLSelectElement/form`

### DIFF
--- a/files/fr/web/api/htmlselectelement/form/index.md
+++ b/files/fr/web/api/htmlselectelement/form/index.md
@@ -1,0 +1,31 @@
+---
+title: "HTMLSelectElement : propriété form"
+short-title: form
+slug: Web/API/HTMLSelectElement/form
+l10n:
+  sourceCommit: 1ff044ac87e406eb23ae7181dd171bad87421b79
+---
+
+{{APIRef("HTML DOM")}}
+
+La propriété en lecture seule **`form`** de l'interface {{DOMxRef("HTMLSelectElement")}} retourne un objet {{DOMxRef("HTMLFormElement")}} qui possède cet élément {{HTMLElement("select")}}, ou `null` si ce sélecteur n'appartient à aucun formulaire.
+
+## Valeur
+
+Un objet {{DOMxRef("HTMLFormElement")}} ou `null`.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'interface {{DOMxRef("HTMLSelectElement")}}
+- L'interface {{DOMxRef("HTMLFormElement")}}
+- L'élément HTML {{HTMLElement("select")}}
+- L'attribut HTML [`form`](/fr/docs/Web/HTML/Reference/Attributes/form)
+- [Guide des formulaires HTML](/fr/docs/Learn_web_development/Extensions/Forms)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/HTMLSelectElement/form`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_