### PR TITLE
fix(fr): using same wording for HTML pages

### DIFF
--- a/files/fr/web/html/reference/elements/em/index.md
+++ b/files/fr/web/html/reference/elements/em/index.md
@@ -7,7 +7,7 @@ l10n:
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<em>`** marque le texte qui reçoit une emphase. L'élément `<em>` peut être imbriqué, chaque niveau d'imbrication indiquant un degré d'emphase plus élevé.
 
-{{InteractiveExample("HTML Demo: &lt;em&gt;", "tabbed-shorter")}}
+{{InteractiveExample("Démonstration HTML&nbsp;: &lt;em&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
 <p>Sors du lit <em>maintenant</em>&nbsp;!</p>

--- a/files/fr/web/html/reference/elements/hr/index.md
+++ b/files/fr/web/html/reference/elements/hr/index.md
@@ -48,7 +48,7 @@ Historiquement, il était présenté comme une règle ou une ligne horizontale. 
 
 Cet élément prend en charge [les attributs universels](/fr/docs/Web/HTML/Reference/Global_attributes).
 
-### Attributs dépréciés, obsolètes ou non-standard
+### Attributs obsolètes ou non-standard
 
 - `align` {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Définit l'alignement de la ligne horizontale sur la page. Si aucune valeur n'est renseignée, la valeur prise par défaut est `left`.

--- a/files/fr/web/html/reference/elements/iframe/index.md
+++ b/files/fr/web/html/reference/elements/iframe/index.md
@@ -154,7 +154,7 @@ Cet élément inclut les [attributs universels](/fr/docs/Web/HTML/Reference/Glob
 - `width`
   - : La largeur du cadre en pixels CSS. La valeur par défaut est `300`.
 
-### Attributs dépréciés
+### Attributs obsolètes
 
 - `align` {{Deprecated_Inline}}
   - : Cet attribut obsolète permettait de définir l'alignement de l'_iframe_ par rapport à son contexte englobant.

--- a/files/fr/web/html/reference/elements/img/index.md
+++ b/files/fr/web/html/reference/elements/img/index.md
@@ -257,7 +257,7 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Reference/Glob
     > [!NOTE]
     > Cet attribut est invalide si l'élément `<img>` est à l'intérieur d'un élément {{htmlelement("a")}} ou d'un élément {{htmlelement("button")}}.
 
-### Attributs dépréciés
+### Attributs obsolètes
 
 - `align` {{deprecated_inline}}
   - : Aligne l'image au sein de son contexte englobant. À la place de cet attribut, on privilégiera les propriétés {{glossary("CSS")}} {{cssxref('float')}} et/ou {{cssxref('vertical-align')}}. Les valeurs autorisées pour cet attribut sont&nbsp;:

--- a/files/fr/web/html/reference/elements/mark/index.md
+++ b/files/fr/web/html/reference/elements/mark/index.md
@@ -7,7 +7,7 @@ l10n:
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<mark>`** représente du texte qui est **marqué** ou **surligné** à des fins de référence ou de notation, en raison de la pertinence du passage marqué dans le contexte qui l'entoure.
 
-{{InteractiveExample("HTML Demo: &lt;mark&gt;", "tabbed-shorter")}}
+{{InteractiveExample("Démonstration HTML&nbsp;: &lt;mark&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
 <p>Résultats de recherche pour «&nbsp;salamandre&nbsp;»&nbsp;:</p>

--- a/files/fr/web/html/reference/elements/script/index.md
+++ b/files/fr/web/html/reference/elements/script/index.md
@@ -136,7 +136,7 @@ Cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Reference/Glob
         Les développeur·euse·s doivent utiliser un type MIME valide qui n'est pas un type MIME JavaScript pour indiquer des blocs de données.
         Tous les autres attributs seront ignorés, y compris l'attribut `src`.
 
-### Attributs dépréciés
+### Attributs obsolètes
 
 - `charset` {{Deprecated_Inline}}
   - : Si présent, sa valeur doit correspondre (sans tenir compte de la casse) à `utf-8` selon {{Glossary("ASCII")}}. Il est inutile de définir l'attribut `charset`, car les documents doivent utiliser UTF-8 et l'élément `script` hérite de l'encodage du document.

--- a/files/fr/web/html/reference/elements/style/index.md
+++ b/files/fr/web/html/reference/elements/style/index.md
@@ -59,7 +59,7 @@ Cet élément inclut les [attributs universels](/fr/docs/Web/HTML/Reference/Glob
 - `title`
   - : Cet attribut indique un ensemble [de feuilles de style alternatif](/fr/docs/Web/HTML/Reference/Attributes/rel/alternate_stylesheet).
 
-### Attributs dépréciés ou obsolètes
+### Attributs obsolètes
 
 - `type` {{Deprecated_Inline}}
   - : Cet attribut définit le langage de la feuille de style sous la forme d'un type MIME (le jeu de caractères ne doit pas être indiqué). Cet attribut est optionnel, la valeur par défaut est `text/css`.

--- a/files/fr/web/html/reference/elements/table/index.md
+++ b/files/fr/web/html/reference/elements/table/index.md
@@ -7,7 +7,7 @@ l10n:
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<table>`** représente des données tabulaires, c'est-à-dire des informations présentées dans un tableau à deux dimensions composé de lignes et de colonnes de cellules contenant des données.
 
-{{InteractiveExample("HTML Demo: &lt;table&gt;", "tabbed-taller")}}
+{{InteractiveExample("Démonstration HTML&nbsp;: &lt;table&gt;", "tabbed-taller")}}
 
 ```html interactive-example
 <table>

--- a/files/fr/web/html/reference/elements/tr/index.md
+++ b/files/fr/web/html/reference/elements/tr/index.md
@@ -84,7 +84,7 @@ La construction de tableau peut parfois demander un peu de pratique. Au-delà de
 
 À l'instar de tous les éléments HTML, cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Reference/Global_attributes). Il existe également plusieurs attributs dépréciés à éviter désormais, mais qui peuvent être utiles pour comprendre du code ancien.
 
-### Attributs dépréciés ou obsolètes
+### Attributs obsolètes
 
 - **`align`**{{deprecated_inline}}
   - : Une chaîne de caractère qui définit l'alignement horizontal pour le contenu de chaque cellule. C'est un raccourci pour définir l'alignement sur l'ensemble de la ligne plutôt que pour chaque cellule. Les valeurs possibles sont :

--- a/files/fr/web/html/reference/elements/ul/index.md
+++ b/files/fr/web/html/reference/elements/ul/index.md
@@ -37,7 +37,7 @@ li li {
 
 À l'instar des différents éléments HTML, cet élément inclut [les attributs universels](/fr/docs/Web/HTML/Reference/Global_attributes).
 
-### Attributs dépréciés ou obsolètes
+### Attributs obsolètes
 
 - `compact`{{Deprecated_inline}}
   - : Cet attribut booléen fournit une indication pour afficher la liste en mode compact. L'interprétation de cet attribut est laissée à la discrétion de l'agent utilisateur et ne fonctionne pas pour tous les navigateurs.


### PR DESCRIPTION
### Description

Fixing wording on pages using wrong words or missing translations

### Motivation

Update access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_