### PR TITLE
[ja]: バッククオート抜けを修正 (`PerformanceEventTiming.cancelable`)

### DIFF
--- a/files/ja/web/api/performanceeventtiming/cancelable/index.md
+++ b/files/ja/web/api/performanceeventtiming/cancelable/index.md
@@ -18,7 +18,7 @@ l10n:
 
 ### 取り消し不可のイベントを監視
 
-cancelable` プロパティは、イベントタイミング項目 ({{domxref("PerformanceEventTiming")}}) を監視するときに使用することができます。例えば、取り消される可能性のないイベントのみをログ出力して測定する場合などです。
+`cancelable` プロパティは、イベントタイミング項目 ({{domxref("PerformanceEventTiming")}}) を監視するときに使用することができます。例えば、取り消される可能性のないイベントのみをログ出力して測定する場合などです。
 
 ```js
 const observer = new PerformanceObserver((list) => {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

本文中の `cancelable` プロパティの記事でインラインコードのバッククォートが欠けていたため修正しました。


<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

当該記事リンク: https://developer.mozilla.org/ja/docs/Web/API/PerformanceEventTiming/cancelable

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
