### PR TITLE
chore(fr): updating BDC of pages for interest and attribution

### DIFF
--- a/files/fr/web/api/document/index.md
+++ b/files/fr/web/api/document/index.md
@@ -2,7 +2,7 @@
 title: Document
 slug: Web/API/Document
 l10n:
-  sourceCommit: 87440643d71bf81a5bf4b8fa21db9e3d56ead395
+  sourceCommit: ee03b8deb5423c80e1cb8f6930a6f52e3f49e678
 ---
 
 {{APIRef("DOM")}}
@@ -184,7 +184,7 @@ _Cette interface hérite également des interfaces {{DOMxRef("Node")}} et {{DOMx
   - : Insère un ensemble d'objets [`Node`](/fr/docs/Web/API/Node) ou d'objets [`DOMString`](/fr/docs/Web/JavaScript/Reference/Global_Objects/String) après le dernier enfant du document.
 - {{DOMxRef("Document.ariaNotify()")}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Définit qu'une chaîne de caractères donnée doit être annoncée par un lecteur d'écran.
-- {{DOMxRef("Document.browsingTopics()")}} {{Experimental_Inline}} {{Non-standard_Inline}}
+- {{DOMxRef("Document.browsingTopics()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Retourne une promesse qui se résout avec un tableau d'objets représentant les sujets principaux pour l'utilisateur·ice, un pour chacune des trois dernières époques. Par défaut, la méthode fait aussi enregistrer par le navigateur la visite de la page courante telle qu'observée par l'appelant·e, afin que le nom d'hôte de la page puisse ensuite être utilisé dans le calcul des sujets. Voir la [Topics API](/fr/docs/Web/API/Topics_API) pour plus de détails.
 - `Document.captureEvents()` {{Deprecated_Inline}}
   - : Voir {{DOMxRef("Window.captureEvents")}}.

--- a/files/fr/web/api/htmlanchorelement/attributionsrc/index.md
+++ b/files/fr/web/api/htmlanchorelement/attributionsrc/index.md
@@ -3,14 +3,14 @@ title: "HTMLAnchorElement : propriété attributionSrc"
 short-title: attributionSrc
 slug: Web/API/HTMLAnchorElement/attributionSrc
 l10n:
-  sourceCommit: a84b606ffd77c40a7306be6c932a74ab9ce6ab96
+  sourceCommit: e936e7271df947f25184a5ba8a21445bbd4d056c
 ---
 
-{{APIRef("Attribution Reporting API")}}{{securecontext_header}}{{SeeCompatTable}}
+{{APIRef("Attribution Reporting API")}}{{SecureContext_Header}}{{Deprecated_Header}}
 
-La propriété **`attributionSrc`** de l'interface {{domxref("HTMLAnchorElement")}} permet d'obtenir et de définir l'attribut [`attributionsrc`](/fr/docs/Web/HTML/Reference/Elements/a#attributionsrc) sur un élément HTML {{htmlelement("a")}} de façon programmatique, reflétant la valeur de cet attribut. `attributionsrc` indique que vous souhaitez que le navigateur envoie un en-tête {{httpheader("Attribution-Reporting-Eligible")}}. Côté serveur, cela sert à déclencher l'envoi d'un en-tête {{httpheader("Attribution-Reporting-Register-Source")}} dans la réponse, afin d'enregistrer une [source d'attribution basée sur la navigation](/fr/docs/Web/API/Attribution_Reporting_API/Registering_sources#navigation-based_attribution_sources).
+La propriété **`attributionSrc`** de l'interface {{DOMxRef("HTMLAnchorElement")}} permet d'obtenir et de définir l'attribut [`attributionsrc`](/fr/docs/Web/HTML/Reference/Elements/a#attributionsrc) sur un élément HTML {{HTMLElement("a")}} de façon programmatique, reflétant la valeur de cet attribut. `attributionsrc` indique que vous souhaitez que le navigateur envoie un en-tête {{HTTPHeader("Attribution-Reporting-Eligible")}}. Côté serveur, cela sert à déclencher l'envoi d'un en-tête {{HTTPHeader("Attribution-Reporting-Register-Source")}} dans la réponse, afin d'enregistrer une [source d'attribution basée sur la navigation](/fr/docs/Web/API/Attribution_Reporting_API/Registering_sources#navigation-based_attribution_sources).
 
-Le navigateur stocke les données de la source associée à la source d'attribution basée sur la navigation (telles que fournies dans l'en-tête de réponse {{httpheader("Attribution-Reporting-Register-Source")}}) lorsqu'il reçoit la réponse de navigation.
+Le navigateur stocke les données de la source associée à la source d'attribution basée sur la navigation (telles que fournies dans l'en-tête de réponse {{HTTPHeader("Attribution-Reporting-Register-Source")}}) lorsqu'il reçoit la réponse de navigation.
 
 Voir l'[API Attribution Reporting](/fr/docs/Web/API/Attribution_Reporting_API) pour plus de détails.
 
@@ -21,7 +21,7 @@ Voir l'[API Attribution Reporting](/fr/docs/Web/API/Attribution_Reporting_API) p
 
 Une chaîne de caractères. Il existe deux versions de cette propriété que vous pouvez obtenir et définir&nbsp;:
 
-- Chaîne vide, c'est-à-dire `aElem.attributionSrc=""`. Cela indique que vous souhaitez que l'en-tête {{httpheader("Attribution-Reporting-Eligible")}} soit envoyé au même serveur que celui indiqué par l'attribut `href`. Cela convient lorsque vous gérez l'enregistrement de la source d'attribution sur le même serveur.
+- Chaîne vide, c'est-à-dire `aElem.attributionSrc=""`. Cela indique que vous souhaitez que l'en-tête {{HTTPHeader("Attribution-Reporting-Eligible")}} soit envoyé au même serveur que celui indiqué par l'attribut `href`. Cela convient lorsque vous gérez l'enregistrement de la source d'attribution sur le même serveur.
 - Valeur contenant une ou plusieurs URL, par exemple&nbsp;:
 
   ```js
@@ -29,7 +29,7 @@ Une chaîne de caractères. Il existe deux versions de cette propriété que vou
     "https://a.exemple/register-source https://b.exemple/register-source";
   ```
 
-  Ceci est utile dans les cas où la ressource demandée n'est pas sur un serveur que vous contrôlez, ou si vous souhaitez simplement gérer l'enregistrement de la source d'attribution sur un autre serveur. Dans ce cas, vous pouvez définir une ou plusieurs URL comme valeur de `attributionSrc`. Lorsque la requête de ressource a lieu, l'en-tête {{httpheader("Attribution-Reporting-Eligible")}} sera envoyé à l'(aux) URL(s) spécifiée(s) dans `attributionSrc` en plus de l'origine de la ressource. Ces URL peuvent alors répondre avec {{httpheader("Attribution-Reporting-Register-Source")}} pour compléter l'enregistrement.
+  Ceci est utile dans les cas où la ressource demandée n'est pas sur un serveur que vous contrôlez, ou si vous souhaitez simplement gérer l'enregistrement de la source d'attribution sur un autre serveur. Dans ce cas, vous pouvez définir une ou plusieurs URL comme valeur de `attributionSrc`. Lorsque la requête de ressource a lieu, l'en-tête {{HTTPHeader("Attribution-Reporting-Eligible")}} sera envoyé à l'(aux) URL(s) spécifiée(s) dans `attributionSrc` en plus de l'origine de la ressource. Ces URL peuvent alors répondre avec {{HTTPHeader("Attribution-Reporting-Register-Source")}} pour compléter l'enregistrement.
 
   > [!NOTE]
   > Définir plusieurs URL signifie que plusieurs sources d'attribution peuvent être enregistrées sur la même fonctionnalité. Par exemple, vous pouvez avoir différentes campagnes dont vous souhaitez mesurer le succès, ce qui implique de générer différents rapports sur différentes données.

--- a/files/fr/web/api/htmlanchorelement/index.md
+++ b/files/fr/web/api/htmlanchorelement/index.md
@@ -2,7 +2,7 @@
 title: HTMLAnchorElement
 slug: Web/API/HTMLAnchorElement
 l10n:
-  sourceCommit: e00212a2a707a57b49b58b37a6a6c978aaef2bbd
+  sourceCommit: e936e7271df947f25184a5ba8a21445bbd4d056c
 ---
 
 {{APIRef("HTML DOM")}}
@@ -15,7 +15,7 @@ L'interface **`HTMLAnchorElement`** représente les éléments d'hyperlien et fo
 
 _Hérite des propriétés de son parent, {{DOMxRef("HTMLElement")}}._
 
-- {{DOMxRef("HTMLAnchorElement.attributionSrc")}} {{SecureContext_Inline}} {{Experimental_Inline}}
+- {{DOMxRef("HTMLAnchorElement.attributionSrc")}} {{SecureContext_Inline}} {{Deprecated_Inline}}
   - : Obtient et définit l'attribut [`attributionsrc`](/fr/docs/Web/HTML/Reference/Elements/a#attributionsrc) sur un élément {{HTMLElement("a")}} de façon programmatique, reflétant la valeur de cet attribut. `attributionsrc` indique que vous souhaitez que le navigateur envoie un en-tête {{HTTPHeader("Attribution-Reporting-Eligible")}}. Côté serveur, cela sert à déclencher l'envoi d'un en-tête {{HTTPHeader("Attribution-Reporting-Register-Source")}} dans la réponse, afin d'enregistrer une source d'attribution basée sur la navigation.
 - {{DOMxRef("HTMLAnchorElement.download")}}
   - : Une chaîne de caractères indiquant que la ressource liée doit être téléchargée plutôt qu'affichée dans le navigateur. La valeur représente le nom de fichier proposé. Si ce nom n'est pas valide pour le système d'exploitation sous-jacent, le navigateur l'adaptera.
@@ -29,7 +29,7 @@ _Hérite des propriétés de son parent, {{DOMxRef("HTMLElement")}}._
   - : Une chaîne de caractères résultant de l'analyse de l'attribut HTML [`href`](/fr/docs/Web/HTML/Reference/Elements/a#href) relativement au document, contenant une URL valide de la ressource liée.
 - {{DOMxRef("HTMLAnchorElement.hreflang")}}
   - : Une chaîne de caractères reflétant l'attribut HTML [`hreflang`](/fr/docs/Web/HTML/Reference/Elements/a#hreflang), indiquant la langue de la ressource liée.
-- {{DOMxRef("HTMLAnchorElement.interestForElement")}} {{Experimental_Inline}}
+- {{DOMxRef("HTMLAnchorElement.interestForElement")}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Obtient ou définit l'élément cible d'un invocateur d'intérêt, dans les cas où l'élément HTML {{HTMLElement("a")}} associé est défini comme un [invocateur d'intérêt](/fr/docs/Web/API/Popover_API/Using_interest_invokers#création_dun_invocateur_dinteret).
 - {{DOMxRef("HTMLAnchorElement.origin")}} {{ReadOnlyInline}}
   - : Retourne une chaîne de caractères contenant l'origine de l'URL, c'est-à-dire son schéma, son domaine et son port.

--- a/files/fr/web/api/htmlanchorelement/interestforelement/index.md
+++ b/files/fr/web/api/htmlanchorelement/interestforelement/index.md
@@ -3,10 +3,10 @@ title: "HTMLAnchorElement : propriété interestForElement"
 short-title: interestForElement
 slug: Web/API/HTMLAnchorElement/interestForElement
 l10n:
-  sourceCommit: e00212a2a707a57b49b58b37a6a6c978aaef2bbd
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
 ---
 
-{{APIRef("HTML DOM")}}
+{{APIRef("HTML DOM")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 La propriété **`interestForElement`** de l'interface {{DOMxRef("HTMLAnchorElement")}} obtient ou définit l'élément cible d'un invocateur d'intérêt (<i lang="en">interest invoker</i> en anglais), lorsque l'élément HTML {{HTMLElement("a")}} associé est défini comme invocateur d'intérêt.
 

--- a/files/fr/web/api/htmlareaelement/index.md
+++ b/files/fr/web/api/htmlareaelement/index.md
@@ -2,7 +2,7 @@
 title: HTMLAreaElement
 slug: Web/API/HTMLAreaElement
 l10n:
-  sourceCommit: e00212a2a707a57b49b58b37a6a6c978aaef2bbd
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
 ---
 
 {{APIRef("HTML DOM")}}
@@ -29,7 +29,7 @@ _Hérite des propriétés de son parent {{DOMxRef("HTMLElement")}}._
   - : Une chaîne de caractères contenant le nom d'hôte dans l'URL référencée.
 - {{DOMxRef("HTMLAreaElement.href")}}
   - : Une chaîne de caractères qui reflète l'attribut HTML [`href`](/fr/docs/Web/HTML/Reference/Elements/area#href), contenant une URL valide de la ressource liée.
-- {{DOMxRef("HTMLAreaElement.interestForElement")}} {{Experimental_Inline}}
+- {{DOMxRef("HTMLAreaElement.interestForElement")}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Obtient ou définit l'élément cible d'un invocateur d'intérêt, dans les cas où l'élément HTML {{HTMLElement("area")}} associé est défini comme un [invocateur d'intérêt](/fr/docs/Web/API/Popover_API/Using_interest_invokers#création_dun_invocateur_dinteret).
 - {{DOMxRef("HTMLAreaElement.noHref")}} {{Deprecated_Inline}}
   - : Un booléen indiquant si la zone est inactive (`true`) ou active (`false`).

--- a/files/fr/web/api/htmlareaelement/index.md
+++ b/files/fr/web/api/htmlareaelement/index.md
@@ -31,7 +31,7 @@ _Hérite des propriétés de son parent {{DOMxRef("HTMLElement")}}._
   - : Une chaîne de caractères qui reflète l'attribut HTML [`href`](/fr/docs/Web/HTML/Reference/Elements/area#href), contenant une URL valide de la ressource liée.
 - {{DOMxRef("HTMLAreaElement.interestForElement")}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Obtient ou définit l'élément cible d'un invocateur d'intérêt, dans les cas où l'élément HTML {{HTMLElement("area")}} associé est défini comme un [invocateur d'intérêt](/fr/docs/Web/API/Popover_API/Using_interest_invokers#création_dun_invocateur_dinteret).
-- {{DOMxRef("HTMLAreaElement.noHref")}} {{Deprecated_Inline}}
+- `HTMLAreaElement.noHref` {{Deprecated_Inline}}
   - : Un booléen indiquant si la zone est inactive (`true`) ou active (`false`).
 - {{DOMxRef("HTMLAreaElement.origin")}} {{ReadOnlyInline}}
   - : Retourne une chaîne de caractères contenant l'origine de l'URL, c'est-à-dire son schéma, son domaine et son port.

--- a/files/fr/web/api/htmlareaelement/interestforelement/index.md
+++ b/files/fr/web/api/htmlareaelement/interestforelement/index.md
@@ -3,10 +3,10 @@ title: "HTMLAreaElement : propriété interestForElement"
 short-title: interestForElement
 slug: Web/API/HTMLAreaElement/interestForElement
 l10n:
-  sourceCommit: e00212a2a707a57b49b58b37a6a6c978aaef2bbd
+  sourceCommit: 995f8bcede5aa8ca40921b030deef7524ce9e1a3
 ---
 
-{{APIRef("HTML DOM")}}
+{{APIRef("HTML DOM")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 La propriété **`interestForElement`** de l'interface {{DOMxRef("HTMLAreaElement")}} obtient ou définit l'élément cible d'un invocateur d'intérêt (<i lang="en">interest invoker</i>), lorsque l'élément HTML {{HTMLElement("area")}} associé est défini comme invocateur d'intérêt.
 

--- a/files/fr/web/api/htmlbuttonelement/index.md
+++ b/files/fr/web/api/htmlbuttonelement/index.md
@@ -2,7 +2,7 @@
 title: HTMLButtonElement
 slug: Web/API/HTMLButtonElement
 l10n:
-  sourceCommit: e00212a2a707a57b49b58b37a6a6c978aaef2bbd
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
 ---
 
 {{APIRef("HTML DOM")}}
@@ -34,7 +34,7 @@ _Hérite des propriétés de son parent, {{DOMxRef("HTMLElement")}}._
   - : Un booléen indiquant que le formulaire ne doit pas être validé lors de sa soumission. Si défini, cet attribut remplace l'attribut [`novalidate`](/fr/docs/Web/HTML/Reference/Elements/form#novalidate) de l'élément HTML {{HTMLElement("form")}} qui possède ce bouton.
 - {{DOMxRef("HTMLButtonElement.formTarget")}}
   - : Une chaîne de caractères représentant un nom ou un mot-clé indiquant où afficher la réponse reçue après la soumission du formulaire. Si défini, cet attribut remplace l'attribut [`target`](/fr/docs/Web/HTML/Reference/Elements/form#target) de l'élément HTML {{HTMLElement("form")}} qui possède ce bouton.
-- {{DOMxRef("HTMLButtonElement.interestForElement")}} {{Experimental_Inline}}
+- {{DOMxRef("HTMLButtonElement.interestForElement")}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Obtient ou définit l'élément cible d'un invocateur d'intérêt, dans les cas où l'élément HTML {{HTMLElement("button")}} associé est défini comme un [invocateur d'intérêt](/fr/docs/Web/API/Popover_API/Using_interest_invokers#création_dun_invocateur_dinteret).
 - {{DOMxRef("HTMLButtonElement.labels")}} {{ReadOnlyInline}}
   - : Un objet {{DOMxRef("NodeList")}} représentant une liste d'éléments {{HTMLElement("label")}} qui sont des étiquettes pour ce bouton.

--- a/files/fr/web/api/htmlbuttonelement/interestforelement/index.md
+++ b/files/fr/web/api/htmlbuttonelement/interestforelement/index.md
@@ -3,10 +3,10 @@ title: "HTMLButtonElement : propriété interestForElement"
 short-title: interestForElement
 slug: Web/API/HTMLButtonElement/interestForElement
 l10n:
-  sourceCommit: e00212a2a707a57b49b58b37a6a6c978aaef2bbd
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
 ---
 
-{{APIRef("HTML DOM")}}
+{{APIRef("HTML DOM")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 La propriété **`interestForElement`** de l'interface {{DOMxRef("HTMLButtonElement")}} obtient ou définit l'élément cible d'un invocateur d'intérêt (<i lang="en">interest invoker</i>), lorsque l'élément HTML {{HTMLElement("button")}} associé est défini comme invocateur d'intérêt.
 

--- a/files/fr/web/api/interestevent/index.md
+++ b/files/fr/web/api/interestevent/index.md
@@ -2,10 +2,10 @@
 title: InterestEvent
 slug: Web/API/InterestEvent
 l10n:
-  sourceCommit: e00212a2a707a57b49b58b37a6a6c978aaef2bbd
+  sourceCommit: 0563b7d83916b234fa637483211889e573df9440
 ---
 
-{{APIRef("Popover API")}}
+{{APIRef("Popover API")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 L'interface **`InterestEvent`** représente un événement qui se déclenche lorsque l'intérêt est montré ou perdu sur un [invocateur d'intérêt](/fr/docs/Web/API/Popover_API/Using_interest_invokers) (<i lang="en">interest invoker</i>).
 
@@ -15,14 +15,14 @@ Il s'agit de l'objet événement pour les événements {{DOMxRef("HTMLElement.in
 
 ## Constructeur
 
-- {{DOMxRef("InterestEvent.InterestEvent", "InterestEvent()")}}
+- {{DOMxRef("InterestEvent.InterestEvent", "InterestEvent()")}} {{Experimental_Inline}}
   - : Crée un objet `InterestEvent`.
 
 ## Propriétés d'instance
 
 _Cette interface hérite des propriétés de son parent, {{DOMxRef("Event")}}._
 
-- {{DOMxRef("InterestEvent.source")}} {{ReadOnlyInline}}
+- {{DOMxRef("InterestEvent.source")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Une instance d'objet {{DOMxRef("Element")}} représentant l'élément invocateur d'intérêt sur lequel l'intérêt a été montré ou perdu, déclenchant l'événement.
 
 ## Exemples

--- a/files/fr/web/api/interestevent/interestevent/index.md
+++ b/files/fr/web/api/interestevent/interestevent/index.md
@@ -3,10 +3,10 @@ title: "InterestEvent : constructeur InterestEvent()"
 short-title: InterestEvent()
 slug: Web/API/InterestEvent/InterestEvent
 l10n:
-  sourceCommit: e00212a2a707a57b49b58b37a6a6c978aaef2bbd
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
 ---
 
-{{APIRef("Popover API")}}
+{{APIRef("Popover API")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 Le constructeur **`InterestEvent()`** crée un nouvel objet {{DOMxRef("InterestEvent")}}.
 

--- a/files/fr/web/api/interestevent/source/index.md
+++ b/files/fr/web/api/interestevent/source/index.md
@@ -3,10 +3,10 @@ title: "InterestEvent : propriété source"
 short-title: source
 slug: Web/API/InterestEvent/source
 l10n:
-  sourceCommit: e00212a2a707a57b49b58b37a6a6c978aaef2bbd
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
 ---
 
-{{APIRef("Popover API")}}
+{{APIRef("Popover API")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 La propriété en lecture seule **`source`** de l'interface {{DOMxRef("InterestEvent")}} est une instance d'objet {{DOMxRef("Element")}} qui représente l'élément invocateur d'intérêt sur lequel l'intérêt a été montré ou perdu, entraînant le déclenchement de l'événement.
 

--- a/files/fr/web/api/window/index.md
+++ b/files/fr/web/api/window/index.md
@@ -2,405 +2,405 @@
 title: Window
 slug: Web/API/Window
 l10n:
-  sourceCommit: 7860297e91985460147c2bd6ced2bfa8cab5aba7
+  sourceCommit: e936e7271df947f25184a5ba8a21445bbd4d056c
 ---
 
 {{APIRef("DOM")}}
 
 L'interface **`Window`** représente une fenêtre contenant un document {{Glossary("DOM")}}&nbsp;; la propriété `document` pointe vers le [document DOM](/fr/docs/Web/API/Document) chargé dans cette fenêtre.
 
-Vous pouvez obtenir la fenêtre d'un document donné à l'aide de la propriété {{domxref("document.defaultView")}}.
+Vous pouvez obtenir la fenêtre d'un document donné à l'aide de la propriété {{DOMxRef("document.defaultView")}}.
 
 Une variable globale, `window`, représentant la fenêtre dans laquelle le script s'exécute, est exposée au code JavaScript.
 
 L'interface `Window` regroupe de nombreuses fonctions, espaces de noms, objets et constructeurs qui ne sont pas forcément liés directement à la notion de fenêtre d'interface utilisateur. Cependant, c'est l'endroit approprié pour inclure ces éléments qui doivent être disponibles globalement. Beaucoup d'entre eux sont documentés dans la [Référence JavaScript](/fr/docs/Web/JavaScript/Reference) et la [Référence DOM](/fr/docs/Web/API/Document_Object_Model).
 
-Dans un navigateur à onglets, chaque onglet est représenté par son propre objet `Window`&nbsp;; la variable globale `window` vue par le code JavaScript exécuté dans un onglet représente toujours cet onglet. Cela dit, même dans un navigateur à onglets, certaines propriétés et méthodes s'appliquent à la fenêtre globale qui contient l'onglet, comme {{Domxref("Window.resizeTo", "resizeTo()")}} et {{Domxref("Window.innerHeight", "innerHeight")}}. De manière générale, tout ce qui ne peut pas raisonnablement concerner un onglet concerne la fenêtre elle-même.
+Dans un navigateur à onglets, chaque onglet est représenté par son propre objet `Window`&nbsp;; la variable globale `window` vue par le code JavaScript exécuté dans un onglet représente toujours cet onglet. Cela dit, même dans un navigateur à onglets, certaines propriétés et méthodes s'appliquent à la fenêtre globale qui contient l'onglet, comme {{DOMxRef("Window.resizeTo", "resizeTo()")}} et {{DOMxRef("Window.innerHeight", "innerHeight")}}. De manière générale, tout ce qui ne peut pas raisonnablement concerner un onglet concerne la fenêtre elle-même.
 
 {{InheritanceDiagram}}
 
 ## Propriétés d'instance
 
-_Cette interface hérite des propriétés de l'interface {{domxref("EventTarget")}}._
+_Cette interface hérite des propriétés de l'interface {{DOMxRef("EventTarget")}}._
 
 Notez que les propriétés qui sont des objets (par exemple, pour surcharger le prototype d'éléments natifs) sont listées dans une section séparée ci-dessous.
 
-- {{domxref("Window.caches")}} {{ReadOnlyInline}} {{SecureContext_Inline}}
-  - : Retourne l'objet {{domxref("CacheStorage")}} associé au contexte courant. Cet objet permet, par exemple, de stocker des ressources pour une utilisation hors ligne et de générer des réponses personnalisées aux requêtes.
-- {{domxref("Window.navigator", "Window.clientInformation")}} {{ReadOnlyInline}}
-  - : Un alias pour {{domxref("Window.navigator")}}.
-- {{domxref("Window.closed")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.caches")}} {{ReadOnlyInline}} {{SecureContext_Inline}}
+  - : Retourne l'objet {{DOMxRef("CacheStorage")}} associé au contexte courant. Cet objet permet, par exemple, de stocker des ressources pour une utilisation hors ligne et de générer des réponses personnalisées aux requêtes.
+- {{DOMxRef("Window.navigator", "Window.clientInformation")}} {{ReadOnlyInline}}
+  - : Un alias pour {{DOMxRef("Window.navigator")}}.
+- {{DOMxRef("Window.closed")}} {{ReadOnlyInline}}
   - : Indique si la fenêtre courante est fermée ou non.
-- {{domxref("Window.cookieStore")}} {{ReadOnlyInline}} {{SecureContext_Inline}}
-  - : Retourne une référence à l'objet {{domxref("CookieStore")}} pour le contexte du document courant.
-- {{domxref("Window.credentialless")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Retourne un booléen indiquant si le document courant a été chargé dans une {{htmlelement("iframe")}} sans identifiants. Voir [IFrame credentialless](/fr/docs/Web/Security/IFrame_credentialless) pour plus de détails.
-- {{domxref("Window.crossOriginIsolated")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.cookieStore")}} {{ReadOnlyInline}} {{SecureContext_Inline}}
+  - : Retourne une référence à l'objet {{DOMxRef("CookieStore")}} pour le contexte du document courant.
+- {{DOMxRef("Window.credentialless")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : Retourne un booléen indiquant si le document courant a été chargé dans une {{HTMLElement("iframe")}} sans identifiants. Voir [IFrame credentialless](/fr/docs/Web/Security/IFrame_credentialless) pour plus de détails.
+- {{DOMxRef("Window.crossOriginIsolated")}} {{ReadOnlyInline}}
   - : Retourne un booléen indiquant si le site web est en état d'isolation inter-origine.
-- {{domxref("Window.crypto")}} {{ReadOnlyInline}}
-  - : Retourne l'objet {{domxref("Crypto")}} associé à l'objet global.
-- {{domxref("Window.customElements")}} {{ReadOnlyInline}}
-  - : Retourne une référence à l'objet {{domxref("CustomElementRegistry")}}, qui permet d'enregistrer de nouveaux [éléments personnalisés](/fr/docs/Web/API/Web_components/Using_custom_elements) et d'obtenir des informations sur ceux déjà enregistrés.
-- {{domxref("Window.devicePixelRatio")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.crypto")}} {{ReadOnlyInline}}
+  - : Retourne l'objet {{DOMxRef("Crypto")}} associé à l'objet global.
+- {{DOMxRef("Window.customElements")}} {{ReadOnlyInline}}
+  - : Retourne une référence à l'objet {{DOMxRef("CustomElementRegistry")}}, qui permet d'enregistrer de nouveaux [éléments personnalisés](/fr/docs/Web/API/Web_components/Using_custom_elements) et d'obtenir des informations sur ceux déjà enregistrés.
+- {{DOMxRef("Window.devicePixelRatio")}} {{ReadOnlyInline}}
   - : Retourne le rapport entre les pixels physiques et les pixels indépendants du périphérique sur l'affichage courant.
-- {{domxref("Window.document")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.document")}} {{ReadOnlyInline}}
   - : Retourne une référence vers le document contenu dans la fenêtre.
-- {{domxref("Window.documentPictureInPicture")}} {{ReadOnlyInline}} {{experimental_inline}} {{SecureContext_Inline}}
+- {{DOMxRef("Window.documentPictureInPicture")}} {{ReadOnlyInline}} {{Experimental_Inline}} {{SecureContext_Inline}}
   - : Retourne une référence vers la fenêtre [Picture-in-Picture du document](/fr/docs/Web/API/Document_Picture-in-Picture_API) pour le contexte du document courant.
-- {{domxref("Window.fence")}} {{ReadOnlyInline}} {{experimental_inline}}
-  - : Retourne une instance de l'objet {{domxref("Fence")}} pour le contexte du document courant. Disponible uniquement pour les documents intégrés dans une {{htmlelement("fencedframe")}}.
-- {{domxref("Window.frameElement")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.fence")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : Retourne une instance de l'objet {{DOMxRef("Fence")}} pour le contexte du document courant. Disponible uniquement pour les documents intégrés dans une {{HTMLElement("fencedframe")}}.
+- {{DOMxRef("Window.frameElement")}} {{ReadOnlyInline}}
   - : Retourne l'élément dans lequel la fenêtre est intégrée, ou null si la fenêtre n'est pas intégrée.
-- {{domxref("Window.frames")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.frames")}} {{ReadOnlyInline}}
   - : Retourne un tableau des sous-fenêtres (frames) de la fenêtre courante.
-- {{domxref("Window.fullScreen")}} {{Non-standard_Inline}}
+- {{DOMxRef("Window.fullScreen")}} {{Non-standard_Inline}}
   - : Indique si la fenêtre est affichée en plein écran ou non.
-- {{domxref("Window.history")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.history")}} {{ReadOnlyInline}}
   - : Retourne une référence à l'objet d'historique.
-- {{domxref("Window.indexedDB")}} {{ReadOnlyInline}}
-  - : Fournit un mécanisme permettant aux applications d'accéder de façon asynchrone aux bases de données indexées&nbsp;; Retourne un objet {{domxref("IDBFactory")}}.
-- {{domxref("Window.innerHeight")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.indexedDB")}} {{ReadOnlyInline}}
+  - : Fournit un mécanisme permettant aux applications d'accéder de façon asynchrone aux bases de données indexées&nbsp;; Retourne un objet {{DOMxRef("IDBFactory")}}.
+- {{DOMxRef("Window.innerHeight")}} {{ReadOnlyInline}}
   - : Obtient la hauteur de la zone de contenu de la fenêtre du navigateur, y compris, si elle est affichée, la barre de défilement horizontale.
-- {{domxref("Window.innerWidth")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.innerWidth")}} {{ReadOnlyInline}}
   - : Obtient la largeur de la zone de contenu de la fenêtre du navigateur, y compris, si elle est affichée, la barre de défilement verticale.
-- {{domxref("Window.isSecureContext")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.isSecureContext")}} {{ReadOnlyInline}}
   - : Retourne un booléen indiquant si le contexte courant est sécurisé (`true`) ou non (`false`).
-- {{domxref("Window.launchQueue")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Lorsqu'une [application web progressive](/fr/docs/Web/Progressive_web_apps) (PWA) est lancée avec une valeur `client_mode` de [`launch_handler`](/fr/docs/Web/Progressive_web_apps/Manifest/Reference/launch_handler) égale à `focus-existing`, `navigate-new` ou `navigate-existing`, alors `launchQueue` donne accès à la classe {{domxref("LaunchQueue")}}, permettant d'implémenter une gestion personnalisée de la navigation au lancement de la PWA.
-- {{domxref("Window.length")}} {{ReadOnlyInline}}
-  - : Retourne le nombre de frames dans la fenêtre. Voir aussi {{domxref("window.frames")}}.
-- {{domxref("Window.localStorage")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.launchQueue")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : Lorsqu'une [application web progressive](/fr/docs/Web/Progressive_web_apps) (PWA) est lancée avec une valeur `client_mode` de [`launch_handler`](/fr/docs/Web/Progressive_web_apps/Manifest/Reference/launch_handler) égale à `focus-existing`, `navigate-new` ou `navigate-existing`, alors `launchQueue` donne accès à la classe {{DOMxRef("LaunchQueue")}}, permettant d'implémenter une gestion personnalisée de la navigation au lancement de la PWA.
+- {{DOMxRef("Window.length")}} {{ReadOnlyInline}}
+  - : Retourne le nombre de frames dans la fenêtre. Voir aussi {{DOMxRef("window.frames")}}.
+- {{DOMxRef("Window.localStorage")}} {{ReadOnlyInline}}
   - : Retourne une référence à l'objet de stockage local utilisé pour stocker des données accessibles uniquement par l'origine qui les a créées.
-- {{domxref("Window.location")}}
+- {{DOMxRef("Window.location")}}
   - : Obtient ou définit l'emplacement (URL courante) de l'objet window.
-- {{domxref("Window.locationbar")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.locationbar")}} {{ReadOnlyInline}}
   - : Retourne l'objet locationbar.
-- {{domxref("Window.menubar")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.menubar")}} {{ReadOnlyInline}}
   - : Retourne l'objet menubar.
-- {{domxref("Window.mozInnerScreenX")}} {{ReadOnlyInline}} {{Non-standard_Inline}}
+- {{DOMxRef("Window.mozInnerScreenX")}} {{ReadOnlyInline}} {{Non-standard_Inline}}
   - : Retourne la coordonnée horizontale (X) du coin supérieur gauche de la zone d'affichage (<i lang="en">viewport</i> en anglais) de la fenêtre, en coordonnées écran. Cette valeur est exprimée en pixels CSS. Voir `mozScreenPixelsPerCSSPixel` dans `nsIDOMWindowUtils` pour convertir en pixels écran si besoin.
-- {{domxref("Window.mozInnerScreenY")}} {{ReadOnlyInline}} {{Non-standard_Inline}}
+- {{DOMxRef("Window.mozInnerScreenY")}} {{ReadOnlyInline}} {{Non-standard_Inline}}
   - : Retourne la coordonnée verticale (Y) du coin supérieur gauche de la zone d'affichage (<i lang="en">viewport</i> en anglais) de la fenêtre, en coordonnées écran. Cette valeur est exprimée en pixels CSS. Voir `mozScreenPixelsPerCSSPixel` pour convertir en pixels écran si besoin.
-- {{domxref("Window.name")}}
+- {{DOMxRef("Window.name")}}
   - : Obtient ou définit le nom de la fenêtre.
-- {{domxref("Window.navigation")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Retourne l'objet {{domxref("Navigation")}} associé à la fenêtre courante. Point d'entrée de l'[API Navigation](/fr/docs/Web/API/Navigation_API).
-- {{domxref("Window.navigator")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.navigation")}} {{ReadOnlyInline}}
+  - : Retourne l'objet {{DOMxRef("Navigation")}} associé à la fenêtre courante. Point d'entrée de l'[API Navigation](/fr/docs/Web/API/Navigation_API).
+- {{DOMxRef("Window.navigator")}} {{ReadOnlyInline}}
   - : Retourne une référence à l'objet navigator.
-- {{domxref("Window.opener")}}
+- {{DOMxRef("Window.opener")}}
   - : Retourne une référence à la fenêtre qui a ouvert la fenêtre courante.
-- {{domxref("Window.origin")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.origin")}} {{ReadOnlyInline}}
   - : Retourne l'origine de l'objet global, sous forme de chaîne de caractères.
-- {{domxref("Window.originAgentCluster")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.originAgentCluster")}} {{ReadOnlyInline}}
   - : Retourne `true` si cette fenêtre appartient à un cluster d'agent lié à une origine.
-- {{domxref("Window.outerHeight")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.outerHeight")}} {{ReadOnlyInline}}
   - : Obtient la hauteur extérieure de la fenêtre du navigateur.
-- {{domxref("Window.outerWidth")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.outerWidth")}} {{ReadOnlyInline}}
   - : Obtient la largeur extérieure de la fenêtre du navigateur.
-- {{domxref("Window.scrollX","Window.pageXOffset")}} {{ReadOnlyInline}}
-  - : Un alias pour {{domxref("window.scrollX")}}.
-- {{domxref("Window.scrollY","Window.pageYOffset")}} {{ReadOnlyInline}}
-  - : Un alias pour {{domxref("window.scrollY")}}.
-- {{domxref("Window.parent")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.scrollX","Window.pageXOffset")}} {{ReadOnlyInline}}
+  - : Un alias pour {{DOMxRef("window.scrollX")}}.
+- {{DOMxRef("Window.scrollY","Window.pageYOffset")}} {{ReadOnlyInline}}
+  - : Un alias pour {{DOMxRef("window.scrollY")}}.
+- {{DOMxRef("Window.parent")}} {{ReadOnlyInline}}
   - : Retourne une référence au parent de la fenêtre ou sous-fenêtre courante.
-- {{domxref("Window.performance")}} {{ReadOnlyInline}}
-  - : Retourne un objet {{domxref("Performance")}}, qui inclut les attributs {{domxref("Performance.timing", "timing")}} et {{domxref("Performance.navigation", "navigation")}}, chacun fournissant des données [liées aux performances](/fr/docs/Web/API/Performance_API/Navigation_timing). Voir aussi [Utiliser Navigation Timing](/fr/docs/Web/API/Performance_API/Navigation_timing) pour plus d'informations et d'exemples.
-- {{domxref("Window.personalbar")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.performance")}} {{ReadOnlyInline}}
+  - : Retourne un objet {{DOMxRef("Performance")}}, qui inclut les attributs {{DOMxRef("Performance.timing", "timing")}} et {{DOMxRef("Performance.navigation", "navigation")}}, chacun fournissant des données [liées aux performances](/fr/docs/Web/API/Performance_API/Navigation_timing). Voir aussi [Utiliser Navigation Timing](/fr/docs/Web/API/Performance_API/Navigation_timing) pour plus d'informations et d'exemples.
+- {{DOMxRef("Window.personalbar")}} {{ReadOnlyInline}}
   - : Retourne l'objet personalbar.
-- {{domxref("Window.scheduler")}} {{ReadOnlyInline}}
-  - : Retourne l'objet {{domxref("Scheduler")}} associé au contexte courant. Point d'entrée pour utiliser l'[API Prioritized Task Scheduling](/fr/docs/Web/API/Prioritized_Task_Scheduling_API).
-- {{domxref("Window.screen")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.scheduler")}} {{ReadOnlyInline}}
+  - : Retourne l'objet {{DOMxRef("Scheduler")}} associé au contexte courant. Point d'entrée pour utiliser l'[API Prioritized Task Scheduling](/fr/docs/Web/API/Prioritized_Task_Scheduling_API).
+- {{DOMxRef("Window.screen")}} {{ReadOnlyInline}}
   - : Retourne une référence à l'objet screen associé à la fenêtre.
-- {{domxref("Window.screenX")}} and {{domxref("Window.screenLeft")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.screenX")}} and {{DOMxRef("Window.screenLeft")}} {{ReadOnlyInline}}
   - : Les deux propriétés Retournent la distance horizontale entre le bord gauche de la zone d'affichage (<i lang="en">viewport</i> en anglais) du navigateur de l'utilisateur·ice et le bord gauche de l'écran.
-- {{domxref("Window.screenY")}} and {{domxref("Window.screenTop")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.screenY")}} and {{DOMxRef("Window.screenTop")}} {{ReadOnlyInline}}
   - : Les deux propriétés Retournent la distance verticale entre le bord supérieur de la zone d'affichage (<i lang="en">viewport</i> en anglais) du navigateur de l'utilisateur·ice et le bord supérieur de l'écran.
-- {{domxref("Window.scrollbars")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.scrollbars")}} {{ReadOnlyInline}}
   - : Retourne l'objet scrollbars.
-- {{domxref("Window.scrollMaxX")}} {{Non-standard_Inline}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.scrollMaxX")}} {{Non-standard_Inline}} {{ReadOnlyInline}}
   - : Le décalage maximal auquel la fenêtre peut être défilée horizontalement, c'est-à-dire la largeur du document moins la largeur de la zone d'affichage (<i lang="en">viewport</i> en anglais).
-- {{domxref("Window.scrollMaxY")}} {{Non-standard_Inline}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.scrollMaxY")}} {{Non-standard_Inline}} {{ReadOnlyInline}}
   - : Le décalage maximal auquel la fenêtre peut être défilée verticalement (c'est-à-dire la hauteur du document moins la hauteur de la zone d'affichage (<i lang="en">viewport</i> en anglais)).
-- {{domxref("Window.scrollX")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.scrollX")}} {{ReadOnlyInline}}
   - : Retourne le nombre de pixels déjà défilés horizontalement dans le document.
-- {{domxref("Window.scrollY")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.scrollY")}} {{ReadOnlyInline}}
   - : Retourne le nombre de pixels déjà défilés verticalement dans le document.
-- {{domxref("Window.self")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.self")}} {{ReadOnlyInline}}
   - : Retourne une référence à l'objet window lui-même.
-- {{domxref("Window.sessionStorage")}}
+- {{DOMxRef("Window.sessionStorage")}}
   - : Retourne une référence à l'objet de stockage de session utilisé pour stocker des données accessibles uniquement par l'origine qui les a créées.
-- {{domxref("Window.sharedStorage")}} {{ReadOnlyInline}} {{experimental_inline}} {{SecureContext_Inline}}
-  - : Retourne l'objet {{domxref("WindowSharedStorage")}} pour l'origine courante. Point d'entrée principal pour écrire des données dans le stockage partagé avec l'[API Shared Storage](/fr/docs/Web/API/Shared_Storage_API).
-- {{domxref("Window.speechSynthesis")}} {{ReadOnlyInline}}
-  - : Retourne un objet {{domxref("SpeechSynthesis")}}, point d'entrée pour utiliser la synthèse vocale de l'[API Web Speech](/fr/docs/Web/API/Web_Speech_API).
-- {{domxref("Window.statusbar")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.sharedStorage")}} {{ReadOnlyInline}} {{Experimental_Inline}} {{SecureContext_Inline}}
+  - : Retourne l'objet {{DOMxRef("WindowSharedStorage")}} pour l'origine courante. Point d'entrée principal pour écrire des données dans le stockage partagé avec l'[API Shared Storage](/fr/docs/Web/API/Shared_Storage_API).
+- {{DOMxRef("Window.speechSynthesis")}} {{ReadOnlyInline}}
+  - : Retourne un objet {{DOMxRef("SpeechSynthesis")}}, point d'entrée pour utiliser la synthèse vocale de l'[API Web Speech](/fr/docs/Web/API/Web_Speech_API).
+- {{DOMxRef("Window.statusbar")}} {{ReadOnlyInline}}
   - : Retourne l'objet statusbar.
-- {{domxref("Window.toolbar")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.toolbar")}} {{ReadOnlyInline}}
   - : Retourne l'objet toolbar.
-- {{domxref("Window.top")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.top")}} {{ReadOnlyInline}}
   - : Retourne une référence à la fenêtre la plus haute dans la hiérarchie des fenêtres. Cette propriété est en lecture seule.
-- {{domxref("Window.trustedTypes")}} {{ReadOnlyInline}}
-  - : Retourne l'objet {{domxref("TrustedTypePolicyFactory")}} associé à l'objet global, point d'entrée pour utiliser l'{{domxref("Trusted Types API", "API Trusted Types", "", "nocode")}}.
-- {{domxref("Window.viewport")}} {{Experimental_inline}} {{ReadOnlyInline}}
-  - : Retourne une instance d'objet {{domxref("Viewport")}}, qui fournit des informations sur l'état courant de la zone d'affichage (<i lang="en">viewport</i> en anglais) du périphérique.
-- {{domxref("Window.visualViewport")}} {{ReadOnlyInline}}
-  - : Retourne un objet {{domxref("VisualViewport")}} représentant la zone d'affichage visuelle (<i lang="en">visual viewport</i> en anglais) pour une fenêtre donnée.
-- {{domxref("Window.window")}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.trustedTypes")}} {{ReadOnlyInline}}
+  - : Retourne l'objet {{DOMxRef("TrustedTypePolicyFactory")}} associé à l'objet global, point d'entrée pour utiliser l'{{DOMxRef("Trusted Types API", "API Trusted Types", "", "nocode")}}.
+- {{DOMxRef("Window.viewport")}} {{Experimental_Inline}} {{ReadOnlyInline}}
+  - : Retourne une instance d'objet {{DOMxRef("Viewport")}}, qui fournit des informations sur l'état courant de la zone d'affichage (<i lang="en">viewport</i> en anglais) du périphérique.
+- {{DOMxRef("Window.visualViewport")}} {{ReadOnlyInline}}
+  - : Retourne un objet {{DOMxRef("VisualViewport")}} représentant la zone d'affichage visuelle (<i lang="en">visual viewport</i> en anglais) pour une fenêtre donnée.
+- {{DOMxRef("Window.window")}} {{ReadOnlyInline}}
   - : Retourne une référence à la fenêtre courante.
 - `window[0]`, `window[1]`, etc.
-  - : Retourne une référence à l'objet `window` dans les frames. Voir {{domxref("Window.frames")}} pour plus de détails.
+  - : Retourne une référence à l'objet `window` dans les frames. Voir {{DOMxRef("Window.frames")}} pour plus de détails.
 - Propriétés nommées
   - : Certains éléments du document sont également exposés comme propriétés de window&nbsp;:
     - Pour chaque élément {{HTMLElement("embed")}}, {{HTMLElement("form")}}, {{HTMLElement("iframe")}}, {{HTMLElement("img")}} et {{HTMLElement("object")}}, son `name` (s'il n'est pas vide) est exposé.
       Par exemple, si le document contient `<form name="my_form">`, alors `window["my_form"]` (et son équivalent `window.my_form`) renverra une référence vers cet élément.
     - Pour chaque élément HTML, son `id` (s'il n'est pas vide) est exposé.
 
-  Si une propriété correspond à un seul élément, cet élément est directement renvoyé. Si la propriété correspond à plusieurs éléments, alors un objet {{domxref("HTMLCollection")}} contenant tous ces éléments est renvoyé. Si l'un des éléments est une `<iframe>` ou un `<object>` navigable, alors la propriété {{domxref("HTMLIFrameElement/contentWindow", "contentWindow")}} du premier iframe de ce type est renvoyée à la place.
+  Si une propriété correspond à un seul élément, cet élément est directement renvoyé. Si la propriété correspond à plusieurs éléments, alors un objet {{DOMxRef("HTMLCollection")}} contenant tous ces éléments est renvoyé. Si l'un des éléments est une `<iframe>` ou un `<object>` navigable, alors la propriété {{DOMxRef("HTMLIFrameElement/contentWindow", "contentWindow")}} du premier iframe de ce type est renvoyée à la place.
 
 ### Propriétés dépréciées
 
-- {{domxref("Window.event")}} {{Deprecated_Inline}} {{ReadOnlyInline}}
-  - : Retourne l'**événement courant**, c'est-à-dire l'événement actuellement traité par le contexte du code JavaScript, ou `undefined` si aucun événement n'est en cours de traitement. Il est recommandé d'utiliser l'objet {{domxref("Event")}} passé directement aux gestionnaires d'événements.
-- {{domxref("Window.external")}} {{Deprecated_Inline}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.event")}} {{Deprecated_Inline}} {{ReadOnlyInline}}
+  - : Retourne l'**événement courant**, c'est-à-dire l'événement actuellement traité par le contexte du code JavaScript, ou `undefined` si aucun événement n'est en cours de traitement. Il est recommandé d'utiliser l'objet {{DOMxRef("Event")}} passé directement aux gestionnaires d'événements.
+- {{DOMxRef("Window.external")}} {{Deprecated_Inline}} {{ReadOnlyInline}}
   - : Retourne un objet avec des fonctions permettant d'ajouter des fournisseurs de recherche externes au navigateur.
-- {{domxref("Window.orientation")}} {{Deprecated_Inline}} {{ReadOnlyInline}}
+- {{DOMxRef("Window.orientation")}} {{Deprecated_Inline}} {{ReadOnlyInline}}
   - : Retourne l'orientation, en degrés (par incréments de 90°), de la zone d'affichage (<i lang="en">viewport</i> en anglais) par rapport à l'orientation naturelle du périphérique.
-- {{domxref("Window.status")}} {{Deprecated_Inline}}
+- {{DOMxRef("Window.status")}} {{Deprecated_Inline}}
   - : Obtient ou définit le texte affiché dans la barre d'état en bas du navigateur.
 
 ## Méthodes d'instance
 
-_Cette interface hérite des méthodes de l'interface {{domxref("EventTarget")}}._
+_Cette interface hérite des méthodes de l'interface {{DOMxRef("EventTarget")}}._
 
-- {{domxref("Window.atob()")}}
+- {{DOMxRef("Window.atob()")}}
   - : Décode une chaîne de données encodée en base 64.
-- {{domxref("Window.alert()")}}
+- {{DOMxRef("Window.alert()")}}
   - : Affiche une boîte de dialogue d'alerte.
-- {{domxref("Window.blur()")}} {{deprecated_inline}}
+- {{DOMxRef("Window.blur()")}} {{Deprecated_Inline}}
   - : Retire la sélection de la fenêtre.
-- {{domxref("Window.btoa()")}}
+- {{DOMxRef("Window.btoa()")}}
   - : Crée une chaîne ASCII encodée en base 64 à partir d'une chaîne de données binaires.
-- {{domxref("Window.cancelAnimationFrame()")}}
-  - : Permet d'annuler un rappel précédemment planifié avec {{domxref("Window.requestAnimationFrame")}}.
-- {{domxref("Window.cancelIdleCallback()")}}
-  - : Permet d'annuler un rappel précédemment planifié avec {{domxref("Window.requestIdleCallback")}}.
-- {{domxref("Window.clearInterval()")}}
-  - : Annule l'exécution répétée définie avec {{domxref("Window.setInterval()")}}.
-- {{domxref("Window.clearTimeout()")}}
-  - : Annule l'exécution différée définie avec {{domxref("Window.setTimeout()")}}.
-- {{domxref("Window.close()")}}
+- {{DOMxRef("Window.cancelAnimationFrame()")}}
+  - : Permet d'annuler un rappel précédemment planifié avec {{DOMxRef("Window.requestAnimationFrame")}}.
+- {{DOMxRef("Window.cancelIdleCallback()")}}
+  - : Permet d'annuler un rappel précédemment planifié avec {{DOMxRef("Window.requestIdleCallback")}}.
+- {{DOMxRef("Window.clearInterval()")}}
+  - : Annule l'exécution répétée définie avec {{DOMxRef("Window.setInterval()")}}.
+- {{DOMxRef("Window.clearTimeout()")}}
+  - : Annule l'exécution différée définie avec {{DOMxRef("Window.setTimeout()")}}.
+- {{DOMxRef("Window.close()")}}
   - : Ferme la fenêtre courante.
-- {{domxref("Window.confirm()")}}
+- {{DOMxRef("Window.confirm()")}}
   - : Affiche une boîte de dialogue avec un message auquel l'utilisateur·ice doit répondre.
-- {{domxref("Window.createImageBitmap()")}}
-  - : Accepte différentes sources d'images et Retourne une promesse {{jsxref("Promise")}} résolue avec un objet {{domxref("ImageBitmap")}}. La source peut être recadrée à un rectangle de pixels d'origine _(sx, sy)_ de largeur sw et hauteur sh.
-- {{domxref("Window.dump()")}} {{Non-standard_Inline}}
+- {{DOMxRef("Window.createImageBitmap()")}}
+  - : Accepte différentes sources d'images et Retourne une promesse {{JSxRef("Promise")}} résolue avec un objet {{DOMxRef("ImageBitmap")}}. La source peut être recadrée à un rectangle de pixels d'origine _(sx, sy)_ de largeur sw et hauteur sh.
+- {{DOMxRef("Window.dump()")}} {{Non-standard_Inline}}
   - : Écrit un message dans la console.
-- {{domxref("Window.fetch()")}}
+- {{DOMxRef("Window.fetch()")}}
   - : Démarre le processus de récupération d'une ressource sur le réseau.
-- {{domxref("Window.fetchLater()")}} {{experimental_inline}}
+- {{DOMxRef("Window.fetchLater()")}} {{Experimental_Inline}}
   - : Crée une récupération différée, envoyée lorsque la page est quittée (détruite ou placée dans le {{Glossary("bfcache")}}, ou après un délai `activateAfter` fourni — selon ce qui arrive en premier.
-- {{domxref("Window.find()")}} {{Non-standard_Inline}}
+- {{DOMxRef("Window.find()")}} {{Non-standard_Inline}}
   - : Recherche dans une chaîne de caractères donnée dans une fenêtre.
-- {{domxref("Window.focus()")}}
+- {{DOMxRef("Window.focus()")}}
   - : Donne la sélection à la fenêtre courante.
-- {{domxref("Window.getComputedStyle()")}}
+- {{DOMxRef("Window.getComputedStyle()")}}
   - : Obtient le style calculé pour l'élément spécifié. Le style calculé indique les valeurs calculées de toutes les propriétés CSS de l'élément.
-- {{domxref("Window.getDefaultComputedStyle()")}} {{Non-standard_Inline}}
+- {{DOMxRef("Window.getDefaultComputedStyle()")}} {{Non-standard_Inline}}
   - : Obtient le style calculé par défaut pour l'élément spécifié, en ignorant les feuilles de style de l'auteur·ice.
-- {{domxref("Window.getScreenDetails()")}} {{experimental_inline}} {{securecontext_inline}}
-  - : Retourne une promesse {{jsxref("Promise")}} résolue avec une instance de l'objet {{domxref("ScreenDetails")}} représentant les détails de tous les écrans disponibles sur le périphérique de l'utilisateur·ice.
-- {{domxref("Window.getSelection()")}}
+- {{DOMxRef("Window.getScreenDetails()")}} {{Experimental_Inline}} {{SecureContext_Inline}}
+  - : Retourne une promesse {{JSxRef("Promise")}} résolue avec une instance de l'objet {{DOMxRef("ScreenDetails")}} représentant les détails de tous les écrans disponibles sur le périphérique de l'utilisateur·ice.
+- {{DOMxRef("Window.getSelection()")}}
   - : Retourne l'objet de sélection représentant l'élément ou les éléments sélectionnés.
-- {{domxref("Window.matchMedia()")}}
-  - : Retourne un objet {{domxref("MediaQueryList")}} représentant la chaîne de requête média spécifiée.
-- {{domxref("Window.moveBy()")}}
+- {{DOMxRef("Window.matchMedia()")}}
+  - : Retourne un objet {{DOMxRef("MediaQueryList")}} représentant la chaîne de requête média spécifiée.
+- {{DOMxRef("Window.moveBy()")}}
   - : Déplace la fenêtre courante d'une certaine distance.
-- {{domxref("Window.moveTo()")}}
+- {{DOMxRef("Window.moveTo()")}}
   - : Déplace la fenêtre aux coordonnées spécifiées.
-- {{domxref("Window.open()")}}
+- {{DOMxRef("Window.open()")}}
   - : Ouvre une nouvelle fenêtre.
-- {{domxref("Window.postMessage()")}}
+- {{DOMxRef("Window.postMessage()")}}
   - : Permet à une fenêtre d'envoyer de façon sécurisée une chaîne de données à une autre fenêtre, même si elle n'est pas du même domaine.
-- {{domxref("Window.print()")}}
+- {{DOMxRef("Window.print()")}}
   - : Ouvre la boîte de dialogue d'impression pour imprimer le document courant.
-- {{domxref("Window.prompt()")}}
+- {{DOMxRef("Window.prompt()")}}
   - : Retourne le texte saisi par l'utilisateur·ice dans une boîte de dialogue de saisie.
 - {{DOMxRef("Window.queryLocalFonts()")}} {{Experimental_Inline}} {{SecureContext_Inline}}
-  - : Retourne une promesse {{jsxref("Promise")}} résolue avec un tableau d'objets {{domxref("FontData")}} représentant les polices disponibles localement.
-- {{domxref("Window.queueMicrotask()")}}
+  - : Retourne une promesse {{JSxRef("Promise")}} résolue avec un tableau d'objets {{DOMxRef("FontData")}} représentant les polices disponibles localement.
+- {{DOMxRef("Window.queueMicrotask()")}}
   - : Place une micro-tâche dans la file d'attente pour exécution à un moment sûr avant que le contrôle ne revienne à la boucle d'événements du navigateur.
-- {{domxref("Window.reportError()")}}
+- {{DOMxRef("Window.reportError()")}}
   - : Signale une erreur dans un script, simulant une exception non gérée.
-- {{domxref("Window.requestAnimationFrame()")}}
+- {{DOMxRef("Window.requestAnimationFrame()")}}
   - : Indique au navigateur qu'une animation est en cours et demande de planifier un rafraîchissement de la fenêtre pour la prochaine image d'animation.
-- {{domxref("Window.requestIdleCallback()")}}
+- {{DOMxRef("Window.requestIdleCallback()")}}
   - : Permet de planifier des tâches pendant les périodes d'inactivité du navigateur.
-- {{domxref("Window.resizeBy()")}}
+- {{DOMxRef("Window.resizeBy()")}}
   - : Redimensionne la fenêtre courante d'une certaine valeur.
-- {{domxref("Window.resizeTo()")}}
+- {{DOMxRef("Window.resizeTo()")}}
   - : Redimensionne dynamiquement la fenêtre.
-- {{domxref("Window.scroll()")}}
+- {{DOMxRef("Window.scroll()")}}
   - : Fait défiler la fenêtre à un endroit particulier du document.
-- {{domxref("Window.scrollBy()")}}
+- {{DOMxRef("Window.scrollBy()")}}
   - : Fait défiler le document dans la fenêtre de la valeur indiquée.
-- {{domxref("Window.scrollByLines()")}} {{Non-standard_Inline}}
+- {{DOMxRef("Window.scrollByLines()")}} {{Non-standard_Inline}}
   - : Fait défiler le document du nombre de lignes indiqué.
-- {{domxref("Window.scrollByPages()")}} {{Non-standard_Inline}}
+- {{DOMxRef("Window.scrollByPages()")}} {{Non-standard_Inline}}
   - : Fait défiler le document courant du nombre de pages spécifié.
-- {{domxref("Window.scrollTo()")}}
+- {{DOMxRef("Window.scrollTo()")}}
   - : Fait défiler le document jusqu'aux coordonnées spécifiées.
-- {{domxref("Window.setInterval()")}}
+- {{DOMxRef("Window.setInterval()")}}
   - : Planifie l'exécution d'une fonction à chaque intervalle de temps donné en millisecondes.
-- {{domxref("Window.setTimeout()")}}
+- {{DOMxRef("Window.setTimeout()")}}
   - : Planifie l'exécution d'une fonction après un certain délai.
-- {{domxref("Window.showDirectoryPicker()")}} {{Experimental_Inline}} {{SecureContext_Inline}}
+- {{DOMxRef("Window.showDirectoryPicker()")}} {{Experimental_Inline}} {{SecureContext_Inline}}
   - : Affiche un sélecteur de dossier permettant à l'utilisateur·ice de choisir un dossier.
-- {{domxref("Window.showOpenFilePicker()")}} {{Experimental_Inline}} {{SecureContext_Inline}}
+- {{DOMxRef("Window.showOpenFilePicker()")}} {{Experimental_Inline}} {{SecureContext_Inline}}
   - : Affiche un sélecteur de fichiers permettant à l'utilisateur·ice de choisir un ou plusieurs fichiers.
-- {{domxref("Window.showSaveFilePicker()")}} {{Experimental_Inline}} {{SecureContext_Inline}}
+- {{DOMxRef("Window.showSaveFilePicker()")}} {{Experimental_Inline}} {{SecureContext_Inline}}
   - : Affiche un sélecteur permettant à l'utilisateur·ice d'enregistrer un fichier.
-- {{domxref("Window.sizeToContent()")}} {{Non-standard_Inline}}
+- {{DOMxRef("Window.sizeToContent()")}} {{Non-standard_Inline}}
   - : Ajuste la taille de la fenêtre en fonction de son contenu.
-- {{domxref("Window.stop()")}}
+- {{DOMxRef("Window.stop()")}}
   - : Cette méthode arrête le chargement de la fenêtre.
-- {{domxref("Window.structuredClone()")}}
+- {{DOMxRef("Window.structuredClone()")}}
   - : Crée une [copie profonde](/fr/docs/Glossary/Deep_copy) d'une valeur donnée à l'aide de l'[algorithme de clonage structuré](/fr/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 
 ### Méthodes dépréciées
 
-- {{domxref("Window.captureEvents()")}} {{Deprecated_Inline}}
+- {{DOMxRef("Window.captureEvents()")}} {{Deprecated_Inline}}
   - : Enregistre la fenêtre pour capturer tous les événements du type spécifié.
-- {{domxref("Window.clearImmediate()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
+- {{DOMxRef("Window.clearImmediate()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Annule l'exécution répétée définie avec `setImmediate()`.
-- {{domxref("Window.releaseEvents()")}} {{Deprecated_Inline}}
+- {{DOMxRef("Window.releaseEvents()")}} {{Deprecated_Inline}}
   - : Libère la fenêtre de la capture d'événements d'un type spécifique.
-- {{domxref("Window.requestFileSystem()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
+- {{DOMxRef("Window.requestFileSystem()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Permet à un site web ou une application d'accéder à un système de fichiers isolé pour son propre usage.
-- {{domxref("Window.setImmediate()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
+- {{DOMxRef("Window.setImmediate()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Exécute une fonction après que le navigateur a terminé d'autres tâches lourdes.
-- {{domxref("Window.setResizable()")}} {{Non-standard_Inline}} {{deprecated_inline}}
+- {{DOMxRef("Window.setResizable()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Ne fait rien (no-op). Conservé pour la compatibilité avec Netscape 4.x.
-- {{domxref("Window.webkitConvertPointFromNodeToPage()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
-  - : Transforme un {{domxref("WebKitPoint")}} du système de coordonnées du nœud vers celui de la page.
-- {{domxref("Window.webkitConvertPointFromPageToNode()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
-  - : Transforme un {{domxref("WebKitPoint")}} du système de coordonnées de la page vers celui du nœud.
+- {{DOMxRef("Window.webkitConvertPointFromNodeToPage()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
+  - : Transforme un {{DOMxRef("WebKitPoint")}} du système de coordonnées du nœud vers celui de la page.
+- {{DOMxRef("Window.webkitConvertPointFromPageToNode()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
+  - : Transforme un {{DOMxRef("WebKitPoint")}} du système de coordonnées de la page vers celui du nœud.
 
 ## Événements
 
-Écoutez ces événements à l'aide de [`addEventListener()`](/fr/docs/Web/API/EventTarget/addEventListener) ou en assignant un écouteur d'événement à la propriété `oneventname` de cette interface. En plus des événements listés ci-dessous, de nombreux événements peuvent remonter depuis le {{domxref("Document")}} contenu dans l'objet window.
+Écoutez ces événements à l'aide de [`addEventListener()`](/fr/docs/Web/API/EventTarget/addEventListener) ou en assignant un écouteur d'événement à la propriété `oneventname` de cette interface. En plus des événements listés ci-dessous, de nombreux événements peuvent remonter depuis le {{DOMxRef("Document")}} contenu dans l'objet window.
 
-- {{domxref("Window/error_event", "error")}}
+- {{DOMxRef("Window/error_event", "error")}}
   - : Se déclenche lorsqu'une ressource n'a pas pu être chargée ou utilisée. Par exemple, si un script rencontre une erreur d'exécution ou si une image est introuvable ou invalide.
-- {{domxref("Window/languagechange_event", "languagechange")}}
+- {{DOMxRef("Window/languagechange_event", "languagechange")}}
   - : Se déclenche sur l'objet global lorsque la langue préférée de l'utilisateur·ice change.
-- {{domxref("Window/resize_event", "resize")}}
+- {{DOMxRef("Window/resize_event", "resize")}}
   - : Se déclenche lorsque la fenêtre a été redimensionnée.
-- {{domxref("Window/storage_event", "storage")}}
+- {{DOMxRef("Window/storage_event", "storage")}}
   - : Se déclenche lorsqu'une zone de stockage (`localStorage` ou `sessionStorage`) a été modifiée dans le contexte d'un autre document.
 
 ### Événements de connexion
 
-- {{domxref("Window/offline_event", "offline")}}
+- {{DOMxRef("Window/offline_event", "offline")}}
   - : Se déclenche lorsque le navigateur perd l'accès au réseau et que la valeur de `navigator.onLine` passe à `false`.
-- {{domxref("Window/online_event", "online")}}
+- {{DOMxRef("Window/online_event", "online")}}
   - : Se déclenche lorsque le navigateur retrouve l'accès au réseau et que la valeur de `navigator.onLine` passe à `true`.
 
 ### Événements d'orientation de l'appareil
 
-- {{domxref("Window.devicemotion_event", "devicemotion")}} {{SecureContext_Inline}}
+- {{DOMxRef("Window.devicemotion_event", "devicemotion")}} {{SecureContext_Inline}}
   - : Se déclenche à intervalles réguliers, indiquant la force d'accélération physique reçue par le périphérique et, si disponible, le taux de rotation.
-- {{domxref("Window.deviceorientation_event", "deviceorientation")}} {{SecureContext_Inline}}
+- {{DOMxRef("Window.deviceorientation_event", "deviceorientation")}} {{SecureContext_Inline}}
   - : Se déclenche lorsque de nouvelles données du capteur d'orientation du magnétomètre sont disponibles concernant l'orientation actuelle du périphérique par rapport au repère terrestre.
-- {{domxref("Window.deviceorientationabsolute_event", "deviceorientationabsolute")}} {{SecureContext_Inline}}
+- {{DOMxRef("Window.deviceorientationabsolute_event", "deviceorientationabsolute")}} {{SecureContext_Inline}}
   - : Se déclenche lorsque de nouvelles données du capteur d'orientation du magnétomètre sont disponibles concernant l'orientation absolue du périphérique par rapport au repère terrestre.
 
 ### Événements de ciblage
 
-- {{domxref("Window/blur_event", "blur")}}
+- {{DOMxRef("Window/blur_event", "blur")}}
   - : Se déclenche lorsqu'un élément perd la sélection.
-- {{domxref("Window/focus_event", "focus")}}
+- {{DOMxRef("Window/focus_event", "focus")}}
   - : Se déclenche lorsqu'un élément reçoit la sélection.
 
 ### Événements de manette de jeu
 
-- {{domxref("Window/gamepadconnected_event", "gamepadconnected")}}
+- {{DOMxRef("Window/gamepadconnected_event", "gamepadconnected")}}
   - : Se déclenche lorsque le navigateur détecte qu'une manette de jeu a été connectée ou lors de la première utilisation d'un bouton ou axe de la manette.
-- {{domxref("Window/gamepaddisconnected_event", "gamepaddisconnected")}}
+- {{DOMxRef("Window/gamepaddisconnected_event", "gamepaddisconnected")}}
   - : Se déclenche lorsque le navigateur détecte qu'une manette de jeu a été déconnectée.
 
 ### Événements d'historique
 
-- {{domxref("Window/hashchange_event", "hashchange")}}
+- {{DOMxRef("Window/hashchange_event", "hashchange")}}
   - : Se déclenche lorsque l'identifiant de fragment de l'URL a changé (la partie de l'URL commençant par et suivant le symbole `#`).
-- {{domxref("Window/pagehide_event", "pagehide")}}
+- {{DOMxRef("Window/pagehide_event", "pagehide")}}
   - : Se déclenche lorsque le navigateur masque le document courant lors du passage à un autre document de l'historique de session (par exemple, lors d'un clic sur le bouton Précédent ou Suivant).
-- {{domxref("Window.pagereveal_event", "pagereveal")}}
+- {{DOMxRef("Window.pagereveal_event", "pagereveal")}}
   - : Se déclenche lorsqu'un document est affiché pour la première fois, soit lors du chargement depuis le réseau, soit lors de l'activation depuis le {{Glossary("bfcache")}} ou le {{Glossary("Prerender", "prérendu")}}.
-- {{domxref("Window/pageshow_event", "pageshow")}}
+- {{DOMxRef("Window/pageshow_event", "pageshow")}}
   - : Se déclenche lorsque le navigateur rend le document visible à la suite d'une navigation, que ce soit lors du premier chargement ou lors d'un retour sur la page dans le même onglet.
-- {{domxref("Window.pageswap_event", "pageswap")}}
+- {{DOMxRef("Window.pageswap_event", "pageswap")}}
   - : Se déclenche lorsqu'un document va être déchargé à cause d'une navigation.
-- {{domxref("Window/popstate_event", "popstate")}}
+- {{DOMxRef("Window/popstate_event", "popstate")}}
   - : Se déclenche lorsque l'entrée d'historique active change.
 
 ### Événements de chargement et de déchargement
 
-- {{domxref("Window/beforeunload_event", "beforeunload")}}
+- {{DOMxRef("Window/beforeunload_event", "beforeunload")}}
   - : Se déclenche lorsque la fenêtre, le document et ses ressources vont être déchargés.
-- {{domxref("Window/load_event", "load")}}
+- {{DOMxRef("Window/load_event", "load")}}
   - : Se déclenche lorsque la page entière a été chargée, y compris toutes les ressources dépendantes comme les feuilles de style et les images.
-- {{domxref("Window/unload_event", "unload")}} {{deprecated_inline}}
+- {{DOMxRef("Window/unload_event", "unload")}} {{Deprecated_Inline}}
   - : Se déclenche lorsque le document ou une ressource enfant est en cours de déchargement.
 
 ### Événements du manifeste
 
-- {{domxref("Window/appinstalled_event", "appinstalled")}}
+- {{DOMxRef("Window/appinstalled_event", "appinstalled")}}
   - : Se déclenche lorsque le navigateur a installé une page en tant qu'application.
-- {{domxref("Window/beforeinstallprompt_event", "beforeinstallprompt")}}
+- {{DOMxRef("Window/beforeinstallprompt_event", "beforeinstallprompt")}}
   - : Se déclenche lorsqu'un·e utilisateur·ice va être invité·e à installer une application web.
 
 ### Événements de messagerie
 
-- {{domxref("Window/message_event", "message")}}
-  - : Se déclenche lorsque la fenêtre reçoit un message, par exemple via {{domxref("Window/postMessage", "Window.postMessage()")}} depuis un autre contexte de navigation.
-- {{domxref("Window/messageerror_event", "messageerror")}}
+- {{DOMxRef("Window/message_event", "message")}}
+  - : Se déclenche lorsque la fenêtre reçoit un message, par exemple via {{DOMxRef("Window/postMessage", "Window.postMessage()")}} depuis un autre contexte de navigation.
+- {{DOMxRef("Window/messageerror_event", "messageerror")}}
   - : Se déclenche lorsqu'un objet `Window` reçoit un message qui ne peut pas être désérialisé.
 
 ### Événements d'impression
 
-- {{domxref("Window/afterprint_event", "afterprint")}}
+- {{DOMxRef("Window/afterprint_event", "afterprint")}}
   - : Se déclenche après le début de l'impression du document associé ou la fermeture de l'aperçu avant impression.
-- {{domxref("Window/beforeprint_event", "beforeprint")}}
+- {{DOMxRef("Window/beforeprint_event", "beforeprint")}}
   - : Se déclenche lorsque le document associé va être imprimé ou affiché en aperçu avant impression.
 
 ### Événements de rejet de promesse
 
-- {{domxref("Window/rejectionhandled_event", "rejectionhandled")}}
-  - : Se déclenche chaque fois qu'une promesse {{jsxref("Promise")}} JavaScript est rejetée, qu'il y ait ou non un gestionnaire pour intercepter ce rejet.
-- {{domxref("Window/unhandledrejection_event", "unhandledrejection")}}
-  - : Se déclenche lorsqu'une promesse {{jsxref("Promise")}} JavaScript est rejetée sans gestionnaire pour intercepter ce rejet.
+- {{DOMxRef("Window/rejectionhandled_event", "rejectionhandled")}}
+  - : Se déclenche chaque fois qu'une promesse {{JSxRef("Promise")}} JavaScript est rejetée, qu'il y ait ou non un gestionnaire pour intercepter ce rejet.
+- {{DOMxRef("Window/unhandledrejection_event", "unhandledrejection")}}
+  - : Se déclenche lorsqu'une promesse {{JSxRef("Promise")}} JavaScript est rejetée sans gestionnaire pour intercepter ce rejet.
 
 ### Événements de défilement
 
-- {{domxref("Window/scrollsnapchange_event", "scrollsnapchange")}} {{experimental_inline}}
+- {{DOMxRef("Window/scrollsnapchange_event", "scrollsnapchange")}} {{Experimental_Inline}}
   - : Se déclenche sur le conteneur de défilement à la fin d'une opération de défilement lorsqu'une nouvelle cible d'ancrage a été sélectionnée.
-- {{domxref("Window/scrollsnapchanging_event", "scrollsnapchanging")}} {{experimental_inline}}
+- {{DOMxRef("Window/scrollsnapchanging_event", "scrollsnapchanging")}} {{Experimental_Inline}}
   - : Se déclenche sur le conteneur de défilement lorsque le navigateur détermine qu'une nouvelle cible d'ancrage est en attente, c'est-à-dire qu'elle sera sélectionnée à la fin du geste de défilement en cours.
 
 ### Événements dépréciés
 
-- {{domxref("Window/orientationchange_event", "orientationchange")}} {{Deprecated_Inline}}
+- {{DOMxRef("Window/orientationchange_event", "orientationchange")}} {{Deprecated_Inline}}
   - : Se déclenche lorsque l'orientation du périphérique a changé.
-- {{domxref("Window/vrdisplayactivate_event", "vrdisplayactivate")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
+- {{DOMxRef("Window/vrdisplayactivate_event", "vrdisplayactivate")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Se déclenche lorsqu'un affichage peut être présenté.
-- {{domxref("Window/vrdisplayconnect_event", "vrdisplayconnect")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
+- {{DOMxRef("Window/vrdisplayconnect_event", "vrdisplayconnect")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Se déclenche lorsqu'un périphérique VR compatible a été connecté à l'ordinateur.
-- {{domxref("Window/vrdisplaydisconnect_event", "vrdisplaydisconnect")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
+- {{DOMxRef("Window/vrdisplaydisconnect_event", "vrdisplaydisconnect")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Se déclenche lorsqu'un périphérique VR compatible a été déconnecté de l'ordinateur.
-- {{domxref("Window/vrdisplaydeactivate_event", "vrdisplaydeactivate")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
+- {{DOMxRef("Window/vrdisplaydeactivate_event", "vrdisplaydeactivate")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Se déclenche lorsqu'un affichage ne peut plus être présenté.
-- {{domxref("Window/vrdisplaypresentchange_event", "vrdisplaypresentchange")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
+- {{DOMxRef("Window/vrdisplaypresentchange_event", "vrdisplaypresentchange")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Se déclenche lorsque l'état de présentation d'un périphérique VR change (passe de présenté à non présenté, ou inversement).
 
 ### Événements propagés
@@ -408,70 +408,70 @@ _Cette interface hérite des méthodes de l'interface {{domxref("EventTarget")}}
 Tous les événements qui remontent ne peuvent pas atteindre l'objet `Window`. Seuls les événements suivants le peuvent et peuvent être écoutés sur l'objet `Window`&nbsp;:
 
 - `abort`
-- {{domxref("Element/auxclick_event", "auxclick")}}
-- {{domxref("Element/beforeinput_event", "beforeinput")}}
-- {{domxref("Element/beforematch_event", "beforematch")}}
-- {{domxref("HTMLElement/beforetoggle_event", "beforetoggle")}}
+- {{DOMxRef("Element/auxclick_event", "auxclick")}}
+- {{DOMxRef("Element/beforeinput_event", "beforeinput")}}
+- {{DOMxRef("Element/beforematch_event", "beforematch")}}
+- {{DOMxRef("HTMLElement/beforetoggle_event", "beforetoggle")}}
 - `cancel`
-- {{domxref("HTMLMediaElement/canplay_event", "canplay")}}
-- {{domxref("HTMLMediaElement/canplaythrough_event", "canplaythrough")}}
-- {{domxref("HTMLElement/change_event", "change")}}
-- {{domxref("Element/click_event", "click")}}
-- {{domxref("HTMLDialogElement/close_event", "close")}}
-- {{domxref("HTMLCanvasElement/contextlost_event", "contextlost")}}
-- {{domxref("Element/contextmenu_event", "contextmenu")}}
-- {{domxref("HTMLCanvasElement/contextrestored_event", "contextrestored")}}
-- {{domxref("Element/copy_event", "copy")}}
-- {{domxref("HTMLTrackElement/cuechange_event", "cuechange")}}
-- {{domxref("Element/cut_event", "cut")}}
-- {{domxref("Element/dblclick_event", "dblclick")}}
-- {{domxref("HTMLElement/drag_event", "drag")}}
-- {{domxref("HTMLElement/dragend_event", "dragend")}}
-- {{domxref("HTMLElement/dragenter_event", "dragenter")}}
-- {{domxref("HTMLElement/dragleave_event", "dragleave")}}
-- {{domxref("HTMLElement/dragover_event", "dragover")}}
-- {{domxref("HTMLElement/dragstart_event", "dragstart")}}
-- {{domxref("HTMLElement/drop_event", "drop")}}
-- {{domxref("HTMLMediaElement/durationchange_event", "durationchange")}}
-- {{domxref("HTMLMediaElement/emptied_event", "emptied")}}
-- {{domxref("HTMLMediaElement/ended_event", "ended")}}
-- {{domxref("HTMLFormElement/formdata_event", "formdata")}}
-- {{domxref("Element/input_event", "input")}}
-- {{domxref("HTMLInputElement/invalid_event", "invalid")}}
-- {{domxref("Element/keydown_event", "keydown")}}
-- {{domxref("Element/keypress_event", "keypress")}}
-- {{domxref("Element/keyup_event", "keyup")}}
-- {{domxref("HTMLMediaElement/loadeddata_event", "loadeddata")}}
-- {{domxref("HTMLMediaElement/loadedmetadata_event", "loadedmetadata")}}
-- {{domxref("HTMLMediaElement/loadstart_event", "loadstart")}}
-- {{domxref("Element/mousedown_event", "mousedown")}}
-- {{domxref("Element/mouseenter_event", "mouseenter")}}
-- {{domxref("Element/mouseleave_event", "mouseleave")}}
-- {{domxref("Element/mousemove_event", "mousemove")}}
-- {{domxref("Element/mouseout_event", "mouseout")}}
-- {{domxref("Element/mouseover_event", "mouseover")}}
-- {{domxref("Element/mouseup_event", "mouseup")}}
-- {{domxref("Element/paste_event", "paste")}}
-- {{domxref("HTMLMediaElement/pause_event", "pause")}}
-- {{domxref("HTMLMediaElement/play_event", "play")}}
-- {{domxref("HTMLMediaElement/playing_event", "playing")}}
-- {{domxref("HTMLMediaElement/progress_event", "progress")}}
-- {{domxref("HTMLMediaElement/ratechange_event", "ratechange")}}
-- {{domxref("HTMLFormElement/reset_event", "reset")}}
-- {{domxref("Element/scrollend_event", "scrollend")}}
-- {{domxref("Element/securitypolicyviolation_event", "securitypolicyviolation")}}
-- {{domxref("HTMLMediaElement/seeked_event", "seeked")}}
-- {{domxref("HTMLMediaElement/seeking_event", "seeking")}}
-- {{domxref("HTMLInputElement/select_event", "select")}}
-- {{domxref("HTMLSlotElement/slotchange_event", "slotchange")}}
-- {{domxref("HTMLMediaElement/stalled_event", "stalled")}}
-- {{domxref("HTMLFormElement/submit_event", "submit")}}
-- {{domxref("HTMLMediaElement/suspend_event", "suspend")}}
-- {{domxref("HTMLMediaElement/timeupdate_event", "timeupdate")}}
-- {{domxref("HTMLElement/toggle_event", "toggle")}}
-- {{domxref("HTMLMediaElement/volumechange_event", "volumechange")}}
-- {{domxref("HTMLMediaElement/waiting_event", "waiting")}}
-- {{domxref("Element/wheel_event", "wheel")}}
+- {{DOMxRef("HTMLMediaElement/canplay_event", "canplay")}}
+- {{DOMxRef("HTMLMediaElement/canplaythrough_event", "canplaythrough")}}
+- {{DOMxRef("HTMLElement/change_event", "change")}}
+- {{DOMxRef("Element/click_event", "click")}}
+- {{DOMxRef("HTMLDialogElement/close_event", "close")}}
+- {{DOMxRef("HTMLCanvasElement/contextlost_event", "contextlost")}}
+- {{DOMxRef("Element/contextmenu_event", "contextmenu")}}
+- {{DOMxRef("HTMLCanvasElement/contextrestored_event", "contextrestored")}}
+- {{DOMxRef("Element/copy_event", "copy")}}
+- {{DOMxRef("HTMLTrackElement/cuechange_event", "cuechange")}}
+- {{DOMxRef("Element/cut_event", "cut")}}
+- {{DOMxRef("Element/dblclick_event", "dblclick")}}
+- {{DOMxRef("HTMLElement/drag_event", "drag")}}
+- {{DOMxRef("HTMLElement/dragend_event", "dragend")}}
+- {{DOMxRef("HTMLElement/dragenter_event", "dragenter")}}
+- {{DOMxRef("HTMLElement/dragleave_event", "dragleave")}}
+- {{DOMxRef("HTMLElement/dragover_event", "dragover")}}
+- {{DOMxRef("HTMLElement/dragstart_event", "dragstart")}}
+- {{DOMxRef("HTMLElement/drop_event", "drop")}}
+- {{DOMxRef("HTMLMediaElement/durationchange_event", "durationchange")}}
+- {{DOMxRef("HTMLMediaElement/emptied_event", "emptied")}}
+- {{DOMxRef("HTMLMediaElement/ended_event", "ended")}}
+- {{DOMxRef("HTMLFormElement/formdata_event", "formdata")}}
+- {{DOMxRef("Element/input_event", "input")}}
+- {{DOMxRef("HTMLInputElement/invalid_event", "invalid")}}
+- {{DOMxRef("Element/keydown_event", "keydown")}}
+- {{DOMxRef("Element/keypress_event", "keypress")}}
+- {{DOMxRef("Element/keyup_event", "keyup")}}
+- {{DOMxRef("HTMLMediaElement/loadeddata_event", "loadeddata")}}
+- {{DOMxRef("HTMLMediaElement/loadedmetadata_event", "loadedmetadata")}}
+- {{DOMxRef("HTMLMediaElement/loadstart_event", "loadstart")}}
+- {{DOMxRef("Element/mousedown_event", "mousedown")}}
+- {{DOMxRef("Element/mouseenter_event", "mouseenter")}}
+- {{DOMxRef("Element/mouseleave_event", "mouseleave")}}
+- {{DOMxRef("Element/mousemove_event", "mousemove")}}
+- {{DOMxRef("Element/mouseout_event", "mouseout")}}
+- {{DOMxRef("Element/mouseover_event", "mouseover")}}
+- {{DOMxRef("Element/mouseup_event", "mouseup")}}
+- {{DOMxRef("Element/paste_event", "paste")}}
+- {{DOMxRef("HTMLMediaElement/pause_event", "pause")}}
+- {{DOMxRef("HTMLMediaElement/play_event", "play")}}
+- {{DOMxRef("HTMLMediaElement/playing_event", "playing")}}
+- {{DOMxRef("HTMLMediaElement/progress_event", "progress")}}
+- {{DOMxRef("HTMLMediaElement/ratechange_event", "ratechange")}}
+- {{DOMxRef("HTMLFormElement/reset_event", "reset")}}
+- {{DOMxRef("Element/scrollend_event", "scrollend")}}
+- {{DOMxRef("Element/securitypolicyviolation_event", "securitypolicyviolation")}}
+- {{DOMxRef("HTMLMediaElement/seeked_event", "seeked")}}
+- {{DOMxRef("HTMLMediaElement/seeking_event", "seeking")}}
+- {{DOMxRef("HTMLInputElement/select_event", "select")}}
+- {{DOMxRef("HTMLSlotElement/slotchange_event", "slotchange")}}
+- {{DOMxRef("HTMLMediaElement/stalled_event", "stalled")}}
+- {{DOMxRef("HTMLFormElement/submit_event", "submit")}}
+- {{DOMxRef("HTMLMediaElement/suspend_event", "suspend")}}
+- {{DOMxRef("HTMLMediaElement/timeupdate_event", "timeupdate")}}
+- {{DOMxRef("HTMLElement/toggle_event", "toggle")}}
+- {{DOMxRef("HTMLMediaElement/volumechange_event", "volumechange")}}
+- {{DOMxRef("HTMLMediaElement/waiting_event", "waiting")}}
+- {{DOMxRef("Element/wheel_event", "wheel")}}
 
 ## Interfaces
 
@@ -481,7 +481,7 @@ Voir la [Référence DOM](/fr/docs/Web/API/Document_Object_Model).
 
 Les éléments HTML offrent trois façons d'écouter des événements&nbsp;:
 
-- Ajouter un écouteur d'événement à l'élément avec la méthode {{domxref("EventTarget.addEventListener")}}.
+- Ajouter un écouteur d'événement à l'élément avec la méthode {{DOMxRef("EventTarget.addEventListener")}}.
 - Assigner un gestionnaire d'événement à la propriété `oneventname` de l'élément en JavaScript.
 - Ajouter un attribut préfixé par `on` à l'élément dans le HTML.
 

--- a/files/fr/web/html/reference/elements/a/index.md
+++ b/files/fr/web/html/reference/elements/a/index.md
@@ -3,7 +3,7 @@ title: "<a> : l'élément d'ancre"
 slug: Web/HTML/Reference/Elements/a
 original_slug: Web/HTML/Element/a
 l10n:
-  sourceCommit: e00212a2a707a57b49b58b37a6a6c978aaef2bbd
+  sourceCommit: e936e7271df947f25184a5ba8a21445bbd4d056c
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<a>`** (ou élément d'_ancre_), avec [son attribut `href`](#href), crée un hyperlien vers des pages web, des fichiers, des adresses e-mail, des emplacements dans la même page ou toute autre ressource accessible par une URL.
@@ -87,7 +87,7 @@ Cet élément inclut les [attributs universels](/fr/docs/Web/HTML/Reference/Glob
   - : Donne des indications sur le langage humain de l'URL liée. Aucune fonctionnalité intégrée. Les valeurs autorisées sont les mêmes que [l'attribut universel `lang`](/fr/docs/Web/HTML/Reference/Global_attributes/lang).
 - `ping`
   - : Contient une liste d'URL séparées par des espaces vers lesquelles sont envoyées des requêtes {{HTTPMethod("POST")}} avec le corps `PING` lorsque l'utilisateur·ice suit le lien. Cet attribut est généralement utilisé pour tracer un·e utilisateur·ice.
-- `interestfor` {{Experimental_Inline}}
+- `interestfor` {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Définit l'élément `<a>` comme un **invocateur d'intérêt** (<i lang="en">interest invoker</i>). Sa valeur est l'`id` de l'élément cible, qui sera affecté d'une manière ou d'une autre (généralement affiché ou masqué) lorsque l'intérêt est montré ou perdu sur l'élément invocateur (par exemple au survol/fin de survol ou à la sélection/perte de sélection). Voir [Utilisation des invocateurs d'intérêt](/fr/docs/Web/API/Popover_API/Using_interest_invokers) pour plus de détails et d'exemples.
 - `referrerpolicy`
   - : Détermine la quantité d'informations du [référent](/fr/docs/Web/HTTP/Reference/Headers/Referer) à envoyer lors du suivi du lien.

--- a/files/fr/web/html/reference/elements/area/index.md
+++ b/files/fr/web/html/reference/elements/area/index.md
@@ -2,7 +2,7 @@
 title: "<area> : l'élément de zone"
 slug: Web/HTML/Reference/Elements/area
 l10n:
-  sourceCommit: e00212a2a707a57b49b58b37a6a6c978aaef2bbd
+  sourceCommit: 995f8bcede5aa8ca40921b030deef7524ce9e1a3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<area>`** définit une zone à l'intérieur d'une image qui possède des zones cliquables prédéfinies. Une _image_ permet d'associer des zones géométriques d'une image à des {{Glossary("Hyperlink", "liens hypertextes")}}.
@@ -82,7 +82,7 @@ Les attributs de cet élément incluent les [attributs universels](/fr/docs/Web/
   - : La cible du lien hypertexte pour la zone.
     Sa valeur est une URL valide.
     Cet attribut peut être omis&nbsp;; dans ce cas, l'élément `<area>` ne représente pas un lien hypertexte.
-- `interestfor` {{Experimental_Inline}}
+- `interestfor` {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Définit l'élément `<area>` comme un **invocateur d'intérêt** (<i lang="en">interest invoker</i>). Sa valeur est l'`id` de l'élément cible, qui sera affecté d'une manière ou d'une autre (généralement affiché ou masqué) lorsque l'intérêt est montré ou perdu sur l'élément invocateur (par exemple au survol/fin de survol ou à la sélection/perte de sélection). Voir [Utilisation des invocateurs d'intérêt](/fr/docs/Web/API/Popover_API/Using_interest_invokers) pour plus de détails et d'exemples.
 - `ping`
   - : Contient une liste d'URL séparées par des espaces vers lesquelles, lors du suivi du lien, des requêtes {{HTTPMethod("POST")}} avec le corps `PING` seront envoyées par le navigateur (en arrière-plan).

--- a/files/fr/web/html/reference/elements/button/index.md
+++ b/files/fr/web/html/reference/elements/button/index.md
@@ -2,7 +2,7 @@
 title: "<button> : l'élément représentant un bouton"
 slug: Web/HTML/Reference/Elements/button
 l10n:
-  sourceCommit: e00212a2a707a57b49b58b37a6a6c978aaef2bbd
+  sourceCommit: 995f8bcede5aa8ca40921b030deef7524ce9e1a3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<button>`** est un élément interactif qui peut être activé avec une souris, un clavier, un doigt, une commande vocale ou tout autre technologie d'assistance. Une fois activé, il peut déclencher une action tel qu'envoyer un [formulaire](/fr/docs/Learn_web_development/Extensions/Forms) ou ouvrir une boite de dialogue.
@@ -111,7 +111,7 @@ Cet élément inclut les [attributs universels](/fr/docs/Web/HTML/Reference/Glob
     - `_parent`&nbsp;: Charge la réponse dans le contexte de navigation parent de celui en cours. S'il n'y a pas de parent, cette option se comporte de la même manière que `_self`.
     - `_top`&nbsp;: Charge la réponse dans le contexte de navigation de niveau supérieur (c'est-à-dire le contexte de navigation qui est un ancêtre du contexte actuel, et qui n'a pas de parent). S'il n'y a pas de parent, cette option se comporte de la même manière que `_self`.
 
-- `interestfor` {{Experimental_Inline}}
+- `interestfor` {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Définit l'élément `<button>` comme un **invocateur d'intérêt** (<i lang="en">interest invoker</i>). Sa valeur est l'`id` de l'élément cible, qui sera affecté d'une manière ou d'une autre (généralement affiché ou masqué) lorsque l'intérêt est montré ou perdu sur l'élément invocateur (par exemple au survol/fin de survol ou à la sélection/perte de sélection). Voir [Utilisation des invocateurs d'intérêt](/fr/docs/Web/API/Popover_API/Using_interest_invokers) pour plus de détails et d'exemples.
 
 - `name`

--- a/files/fr/web/html/reference/elements/iframe/index.md
+++ b/files/fr/web/html/reference/elements/iframe/index.md
@@ -2,7 +2,7 @@
 title: "<iframe> : l'élément de cadre intégré"
 slug: Web/HTML/Reference/Elements/iframe
 l10n:
-  sourceCommit: dd868507df863ab4f37d53c960c76e20e9ee365f
+  sourceCommit: da2d33b62be6362222d83dae5ce1f381d263a51c
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<iframe>`** représente un {{Glossary("Browsing context", "contexte de navigation")}} imbriqué, intégrant une autre page HTML dans la page courante.
@@ -55,7 +55,7 @@ Cet élément inclut les [attributs universels](/fr/docs/Web/HTML/Reference/Glob
     > [!NOTE]
     > Cet attribut est considéré comme historique et a été redéfini avec `allow="payment"`.
 
-- `browsingtopics` {{Experimental_Inline}} {{Non-standard_Inline}}
+- `browsingtopics` {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Un attribut booléen qui, s'il est présent, indique que les sujets sélectionnés pour l'utilisateur·ice courant·e doivent être envoyés avec la requête pour la source de l'`<iframe>`. Voir [Utilisation de l'API Topics](/fr/docs/Web/API/Topics_API/Using) pour plus de détails.
 
 - `credentialless` {{Experimental_Inline}}


### PR DESCRIPTION
### Description

A normal chore update of documentation to apply latest BDC informations on pages and links as "deprecated" or "non-standard"

### Motivation

Keep recent pages up to date

### Additional details

_none_

### Related issues and pull requests

_none_