### PR TITLE
[ja] 翻訳漏れを修正 (`Window.top`)

### DIFF
--- a/files/ja/web/api/window/top/index.md
+++ b/files/ja/web/api/window/top/index.md
@@ -12,7 +12,7 @@ l10n:
 
 ## 値
 
-The reference to the topmost window.
+最上位のウィンドウへの参照です。
 
 ## 注記
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`Window.top` の記事に、英語の原文のままで翻訳漏れしている箇所があったため、当該箇所を日本語訳しました。


### Additional details

記事へのリンク: https://developer.mozilla.org/ja/docs/Web/API/Window/parent

