### PR TITLE
chore(fr): translation of `Web/API/HTMLTextAreaElement/placeholder`

### DIFF
--- a/files/fr/web/api/htmltextareaelement/placeholder/index.md
+++ b/files/fr/web/api/htmltextareaelement/placeholder/index.md
@@ -1,0 +1,35 @@
+---
+title: "HTMLTextAreaElement : propriété placeholder"
+short-title: placeholder
+slug: Web/API/HTMLTextAreaElement/placeholder
+l10n:
+  sourceCommit: e9b6cd1b7fa8612257b72b2a85a96dd7d45c0200
+---
+
+{{APIRef("HTML DOM")}}
+
+La propriété **`placeholder`** de l'interface {{DOMxRef("HTMLTextAreaElement")}} représente une indication à l'utilisateur·ice sur ce qui peut être saisi dans le contrôle. Elle reflète l'attribut [`placeholder`](/fr/docs/Web/HTML/Reference/Elements/textarea#placeholder) de l'élément HTML {{HTMLElement("textarea")}}.
+
+## Valeur
+
+Une chaîne de caractères.
+
+## Exemples
+
+```js
+const textareaElement = document.getElementById("comment");
+console.log(textareaElement.placeholder);
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'élément HTML {{HTMLElement("textarea")}}
+- La propriété {{DOMxRef("HTMLTextAreaElement.value")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/HTMLTextAreaElement/placeholder`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_