### PR TITLE
chore(fr): translation of `Web/API/HTMLTextAreaElement/required`

### DIFF
--- a/files/fr/web/api/htmltextareaelement/required/index.md
+++ b/files/fr/web/api/htmltextareaelement/required/index.md
@@ -1,0 +1,36 @@
+---
+title: "HTMLTextAreaElement : propriété required"
+short-title: required
+slug: Web/API/HTMLTextAreaElement/required
+l10n:
+  sourceCommit: e9b6cd1b7fa8612257b72b2a85a96dd7d45c0200
+---
+
+{{APIRef("HTML DOM")}}
+
+La propriété **`required`** de l'interface {{DOMxRef("HTMLTextAreaElement")}} indique que l'utilisateur·ice doit renseigner une valeur avant de soumettre un formulaire. Elle reflète l'attribut [`required`](/fr/docs/Web/HTML/Reference/Elements/textarea#required) de l'élément HTML {{HTMLElement("textarea")}}.
+
+## Valeur
+
+Un booléen.
+
+## Exemples
+
+```js
+const textareaElement = document.getElementById("comment");
+console.log(textareaElement.required);
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'élément HTML {{HTMLElement("textarea")}}
+- La propriété {{DOMxRef("HTMLTextAreaElement.validity")}}
+- La pseudo-classe CSS {{CSSxRef(":required")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/HTMLTextAreaElement/required`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_