### PR TITLE
chore(fr): translation of `Web/API/HTMLTrackElement/label`

### DIFF
--- a/files/fr/web/api/htmltrackelement/label/index.md
+++ b/files/fr/web/api/htmltrackelement/label/index.md
@@ -1,0 +1,36 @@
+---
+title: "HTMLTrackElement : propriété label"
+short-title: label
+slug: Web/API/HTMLTrackElement/label
+l10n:
+  sourceCommit: e9b6cd1b7fa8612257b72b2a85a96dd7d45c0200
+---
+
+{{APIRef("HTML DOM")}}
+
+La propriété **`label`** de l'interface {{DOMxRef("HTMLTrackElement")}} représente le titre lisible par l'utilisateur·ice affiché lors de l'affichage des sous-titres, légendes et descriptions audio pour une piste. Elle reflète l'attribut [`label`](/fr/docs/Web/HTML/Reference/Elements/track#label) de l'élément HTML {{HTMLElement("track")}}.
+
+## Valeur
+
+Une chaîne de caractères.
+
+## Exemple
+
+```js
+const trackElement = document.getElementById("exampleTrack");
+console.log(`Libellé de la piste : ${trackElement.label}`);
+trackElement.label = "Libellé mis à jour";
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- La propriété {{DOMxRef("HTMLTrackElement.track")}}
+- La propriété {{DOMxRef("HTMLTrackElement.kind")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/HTMLTrackElement/label`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_