### PR TITLE
chore(fr): translation of `Glossary/Scroll_container`

### DIFF
--- a/files/fr/glossary/scroll_container/index.md
+++ b/files/fr/glossary/scroll_container/index.md
@@ -1,0 +1,25 @@
+---
+title: Conteneur de défilement
+slug: Glossary/Scroll_container
+l10n:
+  sourceCommit: dac1040b19dfd2cd2a09a4aab4f9ffd7dce65e89
+---
+
+Un **conteneur de défilement** (<i lang="en">scroll container</i> en anglais) est une boîte d'élément dans laquelle le contenu peut défiler, que des barres de défilement soient présentes ou non. Un agent utilisateur ajoute des barres de défilement à une boîte d'élément pour en faire un conteneur de défilement lorsque la propriété CSS {{CSSxRef("overflow")}} est définie sur `scroll` ou lorsque `overflow` est défini sur `auto` _et_ que le contenu déborde du conteneur.
+
+Lorsque le contenu d'une boîte d'élément déborde de sa boîte englobante, les utilisateur·ice·s peuvent utiliser les barres de défilement pour faire défiler le contenu masqué qui serait autrement invisible.
+
+Un conteneur de défilement comprend un port de défilement et des barres de défilement.
+
+## Port de défilement
+
+Le port de défilement (<i lang="en">scroll port</i> en anglais) est la partie visible d'un conteneur de défilement et coïncide avec la boîte de remplissage (padding box) du conteneur de défilement. Les barres de défilement servent à déplacer le contenu à l'intérieur ou à l'extérieur du port de défilement afin que le contenu puisse être affiché.
+
+## Voir aussi
+
+- [Apprendre&nbsp;: Contenu débordant](/fr/docs/Learn_web_development/Core/Styling_basics/Overflow)
+- [Alignement de défilement](/fr/docs/Glossary/Scroll_snap), y compris [conteneur d'alignement de défilement](/fr/docs/Glossary/Scroll_snap#scroll_snap_container)
+- [Le module de débordement CSS](/fr/docs/Web/CSS/Guides/Overflow)
+- [Le module de gestion du surdéfilement CSS](/fr/docs/Web/CSS/Guides/Overscroll_behavior)
+- [Le module d'accrochage au défilement CSS](/fr/docs/Web/CSS/Guides/Scroll_snap)
+- [Le module d'animations pilotées par le défilement CSS](/fr/docs/Web/CSS/Guides/Scroll-driven_animations)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Glossary/Scroll_container`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_