### PR TITLE
chore(fr): translation of `Glossary/Snap_positions`

### DIFF
--- a/files/fr/glossary/snap_positions/index.md
+++ b/files/fr/glossary/snap_positions/index.md
@@ -1,0 +1,14 @@
+---
+title: Positions d'accrochage
+slug: Glossary/Snap_positions
+l10n:
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+---
+
+Les positions d'accrochage sont des points où le {{Glossary("scroll container", "conteneur de défilement")}} s'arrête de bouger une fois l'opération de défilement terminée. Définir des positions d'accrochage permet de créer une expérience de défilement par pages dans le contenu, au lieu de devoir faire glisser le contenu dans la vue.
+
+Les positions d'accrochage sont définies sur un {{Glossary("scroll container", "conteneur de défilement")}}. Voir les propriétés [d'accrochage au défilement CSS](/fr/docs/Web/CSS/Guides/Scroll_snap).
+
+## Voir aussi
+
+- {{Glossary("Scroll snap", "Accrochage au défilement")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Glossary/Snap_positions`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_