### PR TITLE
正規表現構文早見表における`\w`の説明の誤りを修正

### DIFF
--- a/files/ja/web/javascript/guide/regular_expressions/cheatsheet/index.md
+++ b/files/ja/web/javascript/guide/regular_expressions/cheatsheet/index.md
@@ -99,7 +99,7 @@ l10n:
       <td>
         <p>
           <a href="/ja/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape"><strong>英数文字クラスエスケープ:</strong></a>
-          アンダースコアを含むあらゆる半角英数字（基本ラテンアルファベット）に一致します。 <code>[A-Za-z0-9_]</code> に相当します。例えば <code>/\w/</code> は、"apple" の "a"、"$5.28" の "5"、"3D" の "3"、"Émanuel" の "e" に一致します。
+          アンダースコアを含むあらゆる半角英数字（基本ラテンアルファベット）に一致します。 <code>[A-Za-z0-9_]</code> に相当します。例えば <code>/\w/</code> は、"apple" の "a"、"$5.28" の "5"、"3D" の "3"、"Émanuel" の "m" に一致します。
         </p>
       </td>
     </tr>


### PR DESCRIPTION
### Description

これは、#32476 と同様の問題です。同じ説明の誤りが別のページにも存在します。
`"Émanuel".match(/\w/)` は `m` にマッチしますが、説明では `e` にマッチすることになっています。

### Motivation

説明の誤りを修正します。