### PR TITLE
fix(ja): correct method name typo in Date.getMonth() docs

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/date/getmonth/index.md
+++ b/files/ja/web/javascript/reference/global_objects/date/getmonth/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{JSRef}}
 
-**`getMinutes()`** は {{jsxref("Date")}} インスタンスのメソッドで、この日付の「月」を表す 0 を基点とした値（すなわち 0 が年の最初の月を示す）を返します。
+**`getMonth()`** は {{jsxref("Date")}} インスタンスのメソッドで、この日付の「月」を表す 0 を基点とした値（すなわち 0 が年の最初の月を示す）を返します。
 
 {{InteractiveExample("JavaScript デモ: Date.prototype.getMonth()", "shorter")}}
 


### PR DESCRIPTION
## Summary

Fix a typo in the Japanese translation of `Date.prototype.getMonth()` documentation.

The method name was incorrectly written as `getMinutes()` instead of `getMonth()` in the description.

## Changes

- `files/ja/web/javascript/reference/global_objects/date/getmonth/index.md`
  - Fixed method name from `getMinutes()` to `getMonth()`
