### PR TITLE
ci(pr-review-companion): identify PR via API + report status

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -30,6 +30,8 @@ permissions:
   pull-requests: write
   # Authenticate with GCP.
   id-token: write
+  # Report commit status.
+  statuses: write
 
 jobs:
   identify-pr:
@@ -57,6 +59,9 @@ jobs:
     env:
       PR_NUMBER: ${{ needs.identify-pr.outputs.pr-number }}
       PREFIX: pr${{ needs.identify-pr.outputs.pr-number }}
+      STATUS_PATH: repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}
+      STATUS_CONTEXT: pr-review-companion
+      STATUS_TARGET: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: "Download artifact"
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -71,6 +76,17 @@ jobs:
         id: check
         if: hashFiles('build/') != ''
         run: echo "HAS_ARTIFACT=true" >> "$GITHUB_OUTPUT"
+
+      - name: Mark status as pending
+        if: steps.check.outputs.HAS_ARTIFACT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "$STATUS_PATH" \
+            -f state=pending \
+            -f context="$STATUS_CONTEXT" \
+            -f description='Review deployment pending' \
+            -f target_url="$STATUS_TARGET"
 
       - name: Authenticate with GCP
         if: steps.check.outputs.HAS_ARTIFACT
@@ -138,3 +154,25 @@ jobs:
             --pr-number="$PR_NUMBER" \
             --diff-file=$BUILD_OUT_ROOT/DIFF \
             $BUILD_OUT_ROOT
+
+      - name: Mark status as success
+        if: steps.check.outputs.HAS_ARTIFACT && success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "$STATUS_PATH" \
+            -f state=success \
+            -f context="$STATUS_CONTEXT" \
+            -f description='Review deployment succeeded' \
+            -f target_url="$STATUS_TARGET"
+
+      - name: Mark status as failure
+        if: steps.check.outputs.HAS_ARTIFACT && failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "$STATUS_PATH" \
+            -f state=failure \
+            -f context="$STATUS_CONTEXT" \
+            -f description='Review deployment failed' \
+            -f target_url="$STATUS_TARGET"

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -33,10 +33,31 @@ permissions:
   id-token: write
 
 jobs:
+  identify-pr:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      pr-number: ${{ steps.identify-pr.outputs.number }}
+    steps:
+      - name: Identify PR
+        id: identify-pr
+        run: |
+          PR_NUMBER=$(gh api "repos/$HEAD_REPO/commits/$HEAD_SHA/pulls" --jq ".[] | select(.base.repo.full_name == \"$BASE_REPO\") | .number")
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+        env:
+          BASE_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+
   review:
+    needs: identify-pr
     environment: review
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: needs.identify-pr.outputs.pr-number
+    env:
+      PR_NUMBER: ${{ needs.identify-pr.outputs.pr-number }}
+      PREFIX: pr${{ needs.identify-pr.outputs.pr-number }}
     steps:
       - name: "Download artifact"
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -50,11 +71,7 @@ jobs:
       - name: Check for artifacts
         id: check
         if: hashFiles('build/') != ''
-        run: |
-          echo "HAS_ARTIFACT=true" >> "$GITHUB_OUTPUT"
-          PR_NUMBER=`cat build/NR | tr -dc '0-9'`
-          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "PREFIX=pr$PR_NUMBER" >> "$GITHUB_OUTPUT"
+        run: echo "HAS_ARTIFACT=true" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate with GCP
         if: steps.check.outputs.HAS_ARTIFACT
@@ -73,7 +90,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
           path: "build"
-          destination: "${{ vars.GCP_BUCKET_NAME }}/${{ steps.check.outputs.PREFIX }}"
+          destination: "${{ vars.GCP_BUCKET_NAME }}/${{ env.PREFIX }}"
           resumable: false
           headers: |-
             cache-control: no-store
@@ -108,8 +125,6 @@ jobs:
         if: steps.check.outputs.HAS_ARTIFACT
         env:
           BUILD_OUT_ROOT: ${{ github.workspace }}/build
-          PREFIX: ${{ steps.check.outputs.PREFIX }}
-          PR_NUMBER: ${{ steps.check.outputs.PR_NUMBER }}
         working-directory: content
         run: |
           echo "Pull request:"

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -13,7 +13,6 @@ on:
   workflow_run:
     workflows:
       - "PR Test"
-      - "PR Test Legacy"
     types:
       - completed
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -160,9 +160,6 @@ jobs:
           echo "Disk usage size of the build"
           du -sh $BUILD_OUT_ROOT
 
-          # Save the PR number into the build
-          echo ${{ github.event.number }} > ${BUILD_OUT_ROOT}/NR
-
           # Download the raw diff blob and store that inside the build
           # directory.
           # The purpose of this is for the PR Review Companion to later


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Refines the `pr-review-companion` workflow:

1. Identifies the PR number via the GitHub API, instead of using the `NR` file in the build artifact.
2. Reports the review deployment status on PRs.

### Motivation

1. Improve the security of the workflow.
2. Make review deployment status visible on PRs.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Same as:

- https://github.com/mdn/content/pull/41017
- https://github.com/mdn/content/pull/43072