### PR TITLE
ci(auto-merge): migrate to workflows action

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,16 +3,14 @@ name: auto-merge
 on:
   pull_request_target:
 
+# No GITHUB_TOKEN permissions, as we use AUTOMERGE_TOKEN instead.
 permissions: {}
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
-    steps:
-      - uses: ahmadnassri/action-dependabot-auto-merge@45fc124d949b19b6b8bf6645b6c9d55f4f9ac61a # v2.6.6
-        with:
-          github-token: ${{ secrets.AUTOMERGE_TOKEN }}
-          command: "squash and merge"
-          approve: true
-          target: minor
+    uses: mdn/workflows/.github/workflows/auto-merge.yml@main
+    if: github.repository_owner == 'mdn'
+    with:
+      target-repo: ${{ github.workflow }}
+    secrets:
+      GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updates the `auto-merge` workflow to use the reusable mdn/workflows action.

### Motivation

Avoid third-party action, and obsolete "squash and merge" command.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1255.