### PR TITLE
chore(fr): update of `Web/HTTP/Reference/Headers/Origin`

### DIFF
--- a/files/fr/web/http/reference/headers/origin/index.md
+++ b/files/fr/web/http/reference/headers/origin/index.md
@@ -1,22 +1,22 @@
 ---
-title: Origin
+title: En-tête Origin
+short-title: Origin
 slug: Web/HTTP/Reference/Headers/Origin
-original_slug: Web/HTTP/Headers/Origin
 l10n:
-  sourceCommit: 7fa992e30717e0b46b87385f16e174bcc36f45e3
+  sourceCommit: ca26363fcc6fc861103d40ac0205e5c5b79eb2fa
 ---
 
-L'en-tête de requête **`Origin`** indique [l'origine](/fr/docs/Glossary/Origin) (c'est-à-dire le schéma, le nom d'hôte et le port) qui a _déclenché_ la requête.
-Ainsi, si un agent utilisateur doit demander les ressources incluses dans une page ou récupérer les scripts exécutés sur cette page, l'origine de la page courante peut alors être incluse dans la requête.
+L'{{Glossary("request header", "en-tête de requête")}} HTTP **`Origin`** indique {{Glossary("origin", "l'origine")}} ([schéma](/fr/docs/Web/URI/Reference/Schemes), nom d'hôte et port) à l'origine de la requête.
+Par exemple, si un agent utilisateur doit demander des ressources incluses dans une page, ou récupérées par des scripts qu'il exécute, alors l'origine de la page peut être incluse dans la requête.
 
 <table class="properties">
   <tbody>
     <tr>
       <th scope="row">Type d'en-tête</th>
-      <td><a href="/fr/docs/Glossary/Request_header">En-tête de requête</a></td>
+      <td>{{Glossary("Request header", "En-tête de requête")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden_request_header", "En-tête de requête interdit")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header", "En-tête de requête interdit")}}</th>
       <td>Oui</td>
     </tr>
   </tbody>
@@ -26,43 +26,46 @@ Ainsi, si un agent utilisateur doit demander les ressources incluses dans une pa
 
 ```http
 Origin: null
-Origin: <schema>://<nomhote>
-Origin: <schema>://<nomhote>:<port>
+Origin: <scheme>://<hostname>
+Origin: <scheme>://<hostname>:<port>
 ```
 
 ## Directives
 
 - `null`
-  - : L'origine doit être protégée pour des raisons de confidentialité ou il s'agit d'une _origine opaque_, telle que définie par la spécification HTML (les cas correspondants sont décrits dans la section [description](#description) ci-après).
-- `<schema>`
+  - : L'origine doit être protégée pour des raisons de confidentialité ou il s'agit d'une [origine opaque](/fr/docs/Glossary/Origin#origine_opaque) (les cas correspondants sont décrits dans la section [description](#description) ci-après).
+- `<scheme>`
   - : Le protocole utilisé. Il s'agit généralement de HTTP ou de HTTPS.
-- `<nomhote>`
+- `<hostname>`
   - : Le nom de domaine ou l'adresse IP du serveur d'origine.
-- `<port>` {{optional_inline}}
+- `<port>` {{Optional_Inline}}
   - : Le numéro de port sur lequel écoute le serveur. Si aucun port n'est donné, c'est le port par défaut pour le protocole correspondant qui est utilisé (par exemple `443` pour une URL qui utiliserait le protocole HTTPS).
 
 ## Description
 
-L'en-tête `Origin` est semblable à l'en-tête [`Referer`](/fr/docs/Web/HTTP/Reference/Headers/Referer), mais ne contient pas le chemin de la ressource et peut valoir `null`. On l'utilise pour fournir le «&nbsp;contexte de sécurité&nbsp;» de la requête d'origine, sauf dans les cas où l'information de l'origine est superflue ou sensible pour des questions de vie privée.
+L'en-tête `Origin` est semblable à l'en-tête {{HTTPHeader("Referer")}}, mais ne contient pas le chemin de la ressource et peut valoir `null`.
+Il est utilisé pour fournir le contexte de sécurité de la requête d'origine, sauf dans les cas où l'information de l'origine serait sensible ou superflue.
 
-Au sens large, les agents utilisateurs envoient l'en-tête `Origin` avec les requêtes&nbsp;:
+De façon générale, les agents utilisateurs ajoutent l'en-tête de requête `Origin` aux&nbsp;:
 
-- [D'origines multiples](/fr/docs/Glossary/CORS) (<i lang="en">cross origin</i> en anglais).
-- [De même origine](/fr/docs/Web/Security/Defenses/Same-origin_policy), sauf pour les requêtes utilisant les méthodes [`GET`](/fr/docs/Web/HTTP/Reference/Methods/GET) ou [`HEAD`](/fr/docs/Web/HTTP/Reference/Methods/HEAD) (autrement dit, cet en-tête est utilisé pour les requêtes avec la méthode [`POST`](/fr/docs/Web/HTTP/Reference/Methods/POST), [`OPTIONS`](/fr/docs/Web/HTTP/Reference/Methods/OPTIONS), [`PUT`](/fr/docs/Web/HTTP/Reference/Methods/PUT), [`PATCH`](/fr/docs/Web/HTTP/Reference/Methods/PATCH), et [`DELETE`](/fr/docs/Web/HTTP/Reference/Methods/DELETE)).
+- Requêtes {{Glossary("CORS", "inter-origine")}}.
+- Requêtes [de même origine](/fr/docs/Web/Security/Defenses/Same-origin_policy), sauf pour les requêtes {{HTTPMethod("GET")}} ou {{HTTPMethod("HEAD")}} (c'est-à-dire qu'il est ajouté aux requêtes de même origine {{HTTPMethod("POST")}}, {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("PUT")}}, {{HTTPMethod("PATCH")}} et {{HTTPMethod("DELETE")}}).
 
-Il existe certaines exceptions aux règles précédentes. Par exemple, lorsqu'une requête [`GET`](/fr/docs/Web/HTTP/Reference/Methods/GET) ou [`HEAD`](/fr/docs/Web/HTTP/Reference/Methods/HEAD) est effectuée en mode [`no-cors`](/fr/docs/Web/API/Request/mode#value), l'en-tête `Origin` ne sera pas ajouté.
+Il existe quelques exceptions à ces règles&nbsp;; par exemple, si une requête {{HTTPMethod("GET")}} ou {{HTTPMethod("HEAD")}} d'origine croisée est effectuée en [mode no-cors](/fr/docs/Web/API/Request/mode#value), l'en-tête `Origin` ne sera pas ajouté.
 
-L'en-tête `Origin` peut valoir `null` dans certains cas (la liste qui suit n'est pas exhaustive)&nbsp;:
+La valeur de l'en-tête `Origin` peut être `null` dans un certain nombre de cas, notamment (liste non exhaustive)&nbsp;:
 
-- Le schéma de l'origine n'est pas `http`, `https`, `ftp`, `ws`, `wss`, ou `gopher` (y compris `blob`, `file` et `data`).
-- La requête porte sur des médias d'origines multiples, par exemple via les éléments [`<img>`](/fr/docs/Web/HTML/Reference/Elements/img), [`<video>`](/fr/docs/Web/HTML/Reference/Elements/video) et [`<audio>`](/fr/docs/Web/HTML/Reference/Elements/audio).
-- Pour les documents créés via un programme à l'aide de [`createDocument()`](/fr/docs/Web/API/DOMImplementation/createDocument), ou générés à partir d'une URL `data:`, ou qui n'ont pas de contexte de navigation créateur.
-- Pour les redirections entre les origines.
-- Pour les éléments [`<iframe>`](/fr/docs/Web/HTML/Reference/Elements/iframe) dont l'attribut `sandox` ne contient pas la valeur `allow-same-origin`.
-- Pour les réponses qui sont des erreurs réseau.
+- Les origines dont le [schéma](/fr/docs/Web/URI/Reference/Schemes) n'est pas `http`, `https`, `ftp`, `ws`, `wss` ou `gopher` (y compris `blob`, `file` et `data`).
+- Les images et données multimédias d'origine croisée, y compris celles dans les éléments HTML {{HTMLElement("img")}}, {{HTMLElement("video")}} et {{HTMLElement("audio")}}.
+- Les documents créés par programme à l'aide de {{DOMxRef("DOMImplementation.createDocument", "createDocument()")}}, générés à partir d'une URL `data:`, ou qui n'ont pas de contexte de navigation créateur.
+- Les redirections entre origines.
+- Les documents servis avec la directive `sandbox` de {{HTTPHeader("Content-Security-Policy")}} dont la valeur n'inclut pas `allow-same-origin`.
+- Les {{HTMLElement("iframe", "cadres intégrés")}} avec un attribut sandbox dont la valeur n'inclut pas `allow-same-origin`.
+- Les réponses qui sont des erreurs réseau.
+- {{HTTPHeader("Referrer-Policy")}} défini à `no-referrer` pour les modes de requête non-`cors` (par exemple, les envois de formulaires basiques).
 
 > [!NOTE]
-> Une liste plus détaillée de ces cas avec `null` est présentée sur Stack Overflow&nbsp;: [Quand les navigateurs envoient-ils l'en-tête `Origin`&nbsp;? Quand l'origine est-elle mise à `null`&nbsp;? (en anglais)](https://stackoverflow.com/questions/42239643/when-do-browsers-send-the-origin-header-when-do-browsers-set-the-origin-to-null/42242802)
+> Une liste plus détaillée de ces cas avec `null` est présentée sur Stack Overflow&nbsp;: [Quand les navigateurs envoient-ils l'en-tête d'origine&nbsp;? Quand l'origine est-elle mise à nul&nbsp;? <sup>(angl.)</sup>](https://stackoverflow.com/questions/42239643/when-do-browsers-send-the-origin-header-when-do-browsers-set-the-origin-to-null/42242802)
 
 ## Exemples
 
@@ -84,7 +87,7 @@ Origin: https://developer.mozilla.org:80
 
 ## Voir aussi
 
-- [`Host`](/fr/docs/Web/HTTP/Reference/Headers/Host)
-- [`Referer`](/fr/docs/Web/HTTP/Reference/Headers/Referer)
+- L'en-tête {{HTTPHeader("Host")}}
+- L'en-tête {{HTTPHeader("Referer")}}
 - [Politique de même origine](/fr/docs/Web/Security/Defenses/Same-origin_policy)
-- [Quand les navigateurs envoient-ils l'en-tête `Origin`&nbsp;? Quand l'origine est-elle mise à `null`&nbsp;? (question Stack Overflow, en anglais)](https://stackoverflow.com/questions/42239643/when-do-browsers-send-the-origin-header-when-do-browsers-set-the-origin-to-null/42242802)
+- [Quand les navigateurs envoient-ils l'en-tête d'origine&nbsp;? Quand l'origine est-elle mise à nul&nbsp;? <sup>(angl.)</sup>](https://stackoverflow.com/questions/42239643/when-do-browsers-send-the-origin-header-when-do-browsers-set-the-origin-to-null/42242802)


### PR DESCRIPTION
### Description

Update translation of pages without french version: `Web/HTTP/Reference/Headers/Origin`

### Motivation

Update access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_