### PR TITLE
ci(workflows): use latest compatible node version

### DIFF
--- a/.github/workflows/auto-cleanup-bot.yml
+++ b/.github/workflows/auto-cleanup-bot.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: mdn/content/.nvmrc
+          check-latest: true
           package-manager-cache: false
 
       - name: Install

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           cache: npm
 
       - name: Install
@@ -77,6 +78,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           cache: npm
 
       - name: Install
@@ -102,6 +104,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           cache: npm
 
       - name: Install
@@ -140,6 +143,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           cache: npm
 
       - name: Install

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -91,6 +91,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: mdn/content/.nvmrc
+          check-latest: true
           cache: npm
           cache-dependency-path: |
             mdn/content/package-lock.json

--- a/.github/workflows/pr-check_json.yml
+++ b/.github/workflows/pr-check_json.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           cache: npm
 
       - name: Install

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: mdn/content/.nvmrc
+          check-latest: true
           cache: npm
           cache-dependency-path: mdn/content/package-lock.json
 

--- a/.github/workflows/pr-check_yml.yml
+++ b/.github/workflows/pr-check_yml.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: ".nvmrc"
+          check-latest: true
           cache: npm
 
       - name: Install

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -126,6 +126,7 @@ jobs:
         if: steps.check.outputs.HAS_ARTIFACT
         with:
           node-version-file: "content/.nvmrc"
+          check-latest: true
           package-manager-cache: false
 
       - name: Install (mdn/content)

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -90,6 +90,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: mdn/content/.nvmrc
+          check-latest: true
           cache: npm
           cache-dependency-path: mdn/content/package-lock.json
 

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -50,6 +50,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: mdn/content/.nvmrc
+          check-latest: true
           package-manager-cache: false
 
       - name: Install


### PR DESCRIPTION
### Description

Updates all workflow steps using `actions/setup-node`, setting `check-latest: true`.

### Motivation

Ensures the latest compatible Node version is used consistently, with the corresponding npm version.

### Additional details


### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1309.
