### PR TITLE
chore(fr): remove Interactive example of Atomics

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/atomics/add/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/add/index.md
@@ -3,26 +3,10 @@ title: "Atomics : méthode statique add()"
 short-title: add()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/add
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`add()`** de l'objet {{JSxRef("Atomics")}} ajoute une valeur donnée à un élément du tableau à une position donnée et retourne l'ancienne valeur qui était contenue à cet emplacement. Cette opération atomique garantit qu'aucune autre opération d'écriture n'est appliquée tant que la valeur modifiée n'est pas écrite.
-
-{{InteractiveExample("Démonstration JavaScript&nbsp;: Atomics.add()")}}
-
-```js interactive-example
-// Crée un SharedArrayBuffer avec une taille en octets
-const buffer = new SharedArrayBuffer(16);
-const uint8 = new Uint8Array(buffer);
-uint8[0] = 7;
-
-// 7 + 2 = 9
-console.log(Atomics.add(uint8, 0, 2));
-// Résultat attendu : 7
-
-console.log(Atomics.load(uint8, 0));
-// Résultat attendu : 9
-```
 
 ## Syntaxe
 
@@ -52,14 +36,20 @@ L'ancienne valeur à la position donnée (`typedArray[index]`).
 
 ## Exemples
 
-### Utilisation de `add()`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
+
+### Utiliser `Atomics.add()`
 
 ```js
+// Crée un SharedArrayBuffer avec une taille en octets
 const sab = new SharedArrayBuffer(1024);
+// Crée une vue et définit la valeur de l'index 0
 const ta = new Uint8Array(sab);
+ta[0] = 7;
 
-Atomics.add(ta, 0, 12); // retourne 0, l'ancienne valeur
-Atomics.load(ta, 0); // 12
+// 7 + 12 = 19
+console.log(Atomics.add(ta, 0, 12)); // retourne 7, l'ancienne valeur
+console.log(Atomics.load(ta, 0)); // 19, la nouvelle/valeur actuelle
 ```
 
 ## Spécifications

--- a/files/fr/web/javascript/reference/global_objects/atomics/and/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/and/index.md
@@ -3,26 +3,10 @@ title: "Atomics : méthode statique and()"
 short-title: and()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/and
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`and()`** de l'objet {{JSxRef("Atomics")}} calcule un ET binaire avec une valeur donnée, à un emplacement donné du tableau. Elle renvoie l'ancienne valeur qui était contenue à cet emplacement. Cette opération atomique garantit qu'aucune autre opération d'écriture n'est appliquée tant que la valeur modifiée n'est pas écrite.
-
-{{InteractiveExample("Démonstration JavaScript&nbsp;: Atomics.and()")}}
-
-```js interactive-example
-// Crée un SharedArrayBuffer avec une taille en octets
-const buffer = new SharedArrayBuffer(16);
-const uint8 = new Uint8Array(buffer);
-uint8[0] = 7;
-
-// 7 (0111) AND 2 (0010) = 2 (0010)
-console.log(Atomics.and(uint8, 0, 2));
-// Résultat attendu : 7
-
-console.log(Atomics.load(uint8, 0));
-// Résultat attendu : 2
-```
 
 ## Syntaxe
 
@@ -72,15 +56,20 @@ Ainsi, si on calcule le ET binaire de 5 et 1 avec l'instruction `5 & 1`, cela fo
 
 ## Exemples
 
-### Utilisation de `and()`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
+
+### Utiliser `Atomics.and()`
 
 ```js
+// Crée un SharedArrayBuffer avec une taille en octets
 const sab = new SharedArrayBuffer(1024);
+// Crée une vue et définit la valeur de l'index 0
 const ta = new Uint8Array(sab);
-ta[0] = 5;
+ta[0] = 7;
 
-Atomics.and(ta, 0, 1); // retourne 5, l'ancienne valeur
-Atomics.load(ta, 0); // 1
+// 7 (0111) AND 10 (1010) = 2 (0010)
+console.log(Atomics.and(ta, 0, 10)); // retourne 7, l'ancienne valeur
+console.log(Atomics.load(ta, 0)); // 2, la nouvelle/valeur actuelle
 ```
 
 ## Spécifications

--- a/files/fr/web/javascript/reference/global_objects/atomics/compareexchange/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/compareexchange/index.md
@@ -3,27 +3,10 @@ title: "Atomics : méthode statique compareExchange()"
 short-title: compareExchange()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`compareExchange()`** de l'objet {{JSxRef("Atomics")}} échange une valeur d'un tableau à un emplacement donné si la valeur qui était dans le tableau correspond à une valeur donnée. Cette méthode renvoie l'ancienne valeur à cet emplacement, qu'il y ait eu remplacement ou non. Cette opération atomique garantit qu'aucune autre opération d'écriture n'est appliquée tant que la valeur modifiée n'est pas écrite.
-
-{{InteractiveExample("Démonstration JavaScript&nbsp;: Atomics.compareExchange()")}}
-
-```js interactive-example
-// Crée un SharedArrayBuffer avec une taille en octets
-const buffer = new SharedArrayBuffer(16);
-const uint8 = new Uint8Array(buffer);
-uint8[0] = 5;
-
-Atomics.compareExchange(uint8, 0, 5, 2); // Retourne 5
-console.log(Atomics.load(uint8, 0));
-// Résultat attendu : 2
-
-Atomics.compareExchange(uint8, 0, 5, 4); // Retourne 2
-console.log(Atomics.load(uint8, 0));
-// Résultat attendu : 2
-```
 
 ## Syntaxe
 
@@ -55,15 +38,19 @@ L'ancienne valeur à la position définie (`typedArray[index]`). Si la valeur re
 
 ## Exemples
 
-### Utilisation de `compareExchange()`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
+
+### Utiliser `Atomics.compareExchange()`
 
 ```js
+// Crée un SharedArrayBuffer avec une taille en octets
 const sab = new SharedArrayBuffer(1024);
+// Crée une vue et définit la valeur de l'index 0
 const ta = new Uint8Array(sab);
 ta[0] = 7;
 
-Atomics.compareExchange(ta, 0, 7, 12); // retourne 7, l'ancienne valeur
-Atomics.load(ta, 0); // 12
+console.log(Atomics.compareExchange(ta, 0, 7, 12)); // retourne 7, l'ancienne valeur
+console.log(Atomics.load(ta, 0)); // 12, la nouvelle/valeur actuelle
 ```
 
 ### Vérification de la valeur de retour

--- a/files/fr/web/javascript/reference/global_objects/atomics/exchange/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/exchange/index.md
@@ -3,26 +3,10 @@ title: "Atomics : méthode statique exchange()"
 short-title: exchange()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/exchange
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`exchange()`** de l'objet {{JSxRef("Atomics")}} permet d'enregistrer une valeur à une position donnée d'un tableau et de renvoyer l'ancienne valeur qui était contenue dans le tableau. Cette opération atomique garantit qu'aucune autre opération d'écriture n'est appliquée tant que la valeur modifiée n'est pas écrite.
-
-{{InteractiveExample("Démonstration JavaScript&nbsp;: Atomics.exchange()")}}
-
-```js interactive-example
-// Crée un SharedArrayBuffer avec une taille en octets
-const buffer = new SharedArrayBuffer(16);
-const uint8 = new Uint8Array(buffer);
-uint8[0] = 5;
-
-console.log(Atomics.load(uint8, 0));
-// Résultat attendu : 5
-
-Atomics.exchange(uint8, 0, 2); // Retourne 5
-console.log(Atomics.load(uint8, 0));
-// Résultat attendu : 2
-```
 
 ## Syntaxe
 
@@ -52,14 +36,19 @@ L'ancienne valeur qui était contenue à (`typedArray[index]`).
 
 ## Exemples
 
-### Utilisation de `exchange()`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
+
+### Utiliser `Atomics.exchange()`
 
 ```js
+// Crée un SharedArrayBuffer avec une taille en octets
 const sab = new SharedArrayBuffer(1024);
+// Crée une vue et définit la valeur de l'index 0
 const ta = new Uint8Array(sab);
+ta[0] = 7;
 
-Atomics.exchange(ta, 0, 12); // retourne 0, l'ancienne valeur
-Atomics.load(ta, 0); // 12
+console.log(Atomics.exchange(ta, 0, 12)); // retourne 7, l'ancienne valeur
+console.log(Atomics.load(ta, 0)); // 12, la nouvelle/valeur actuelle
 ```
 
 ## Spécifications

--- a/files/fr/web/javascript/reference/global_objects/atomics/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/index.md
@@ -2,7 +2,7 @@
 title: Atomics
 slug: Web/JavaScript/Reference/Global_Objects/Atomics
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 L'objet de l'espace de noms **`Atomics`** contient des méthodes statiques permettant d'effectuer des opérations atomiques. Elles sont utilisées avec les objets {{JSxRef("SharedArrayBuffer")}} et {{JSxRef("ArrayBuffer")}}.
@@ -57,7 +57,9 @@ Les méthodes `wait()` et `notify()` sont modélisées sur les futex Linux «&nb
 
 ## Exemples
 
-### Utilisation de `Atomics`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
+
+### Utiliser `Atomics`
 
 ```js
 const sab = new SharedArrayBuffer(1024);

--- a/files/fr/web/javascript/reference/global_objects/atomics/islockfree/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/islockfree/index.md
@@ -3,7 +3,7 @@ title: "Atomics : méthode statique isLockFree()"
 short-title: isLockFree()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`isLockFree()`** de l'objet {{JSxRef("Atomics")}} est utilisée afin de déterminer si on doit utiliser des verrous (<i lang="en">locks</i> en anglais) ou des opérations atomiques. Elle sert de primitive d'optimisation, afin que des algorithmes hautement performants puissent déterminer s'ils doivent utiliser des verrous ou des opérations atomiques dans les sections critiques. Si une primitive atomique n'est pas sans verrou, il est souvent plus efficace qu'un algorithme mette en œuvre son propre mécanisme de verrouillage.
@@ -40,7 +40,7 @@ Une valeur `true` ou `false` indiquant si l'opération s'exécute sans verrou.
 
 ## Exemples
 
-### Utilisation de `isLockFree()`
+### Utiliser `Atomics.isLockFree()`
 
 ```js
 Atomics.isLockFree(1); // true (dépend de la plateforme)

--- a/files/fr/web/javascript/reference/global_objects/atomics/load/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/load/index.md
@@ -3,26 +3,10 @@ title: "Atomics : méthode statique load()"
 short-title: load()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/load
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`load()`** de l'objet {{JSxRef("Atomics")}} retourne une valeur située à une position donnée du tableau.
-
-{{InteractiveExample("Démonstration JavaScript&nbsp;: Atomics.load()")}}
-
-```js interactive-example
-// Crée un SharedArrayBuffer avec une taille en octets
-const buffer = new SharedArrayBuffer(16);
-const uint8 = new Uint8Array(buffer);
-uint8[0] = 5;
-
-// 5 + 2 = 7
-console.log(Atomics.add(uint8, 0, 2));
-// Résultat attendu : 5
-
-console.log(Atomics.load(uint8, 0));
-// Résultat attendu : 7
-```
 
 ## Syntaxe
 
@@ -50,14 +34,19 @@ La valeur à la position indiquée (`typedArray[index]`).
 
 ## Exemples
 
-### Utilisation de `load()`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
+
+### Utiliser `Atomics.load()`
 
 ```js
+// Crée un SharedArrayBuffer avec une taille en octets
 const sab = new SharedArrayBuffer(1024);
+// Crée une vue et définit la valeur de l'index 0
 const ta = new Uint8Array(sab);
+ta[0] = 7;
 
-Atomics.add(ta, 0, 12);
-Atomics.load(ta, 0); // 12
+console.log(Atomics.add(ta, 0, 12)); // Ajoute 12 à l'index 0
+console.log(Atomics.load(ta, 0)); // 19, la nouvelle/valeur actuelle
 ```
 
 ## Spécifications

--- a/files/fr/web/javascript/reference/global_objects/atomics/notify/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/notify/index.md
@@ -3,7 +3,7 @@ title: "Atomics : méthode statique notify()"
 short-title: notify()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/notify
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`notify()`** de l'objet {{JSxRef("Atomics")}} permet de réveiller des agents dormants qui sont dans la file d'attente.
@@ -40,7 +40,9 @@ Retourne le nombre d'agents réveillés, ou `0` si `typedArray` est une vue sur 
 
 ## Exemples
 
-### Utilisation de `notify()`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
+
+### Utiliser `Atomics.notify()`
 
 Étant donné un `Int32Array` partagé&nbsp;:
 

--- a/files/fr/web/javascript/reference/global_objects/atomics/or/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/or/index.md
@@ -3,26 +3,10 @@ title: "Atomics : méthode statique or()"
 short-title: or()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/or
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`or()`** de l'objet {{JSxRef("Atomics")}} calcule un OU binaire entre une valeur donnée et la valeur présente à une position donnée du tableau, et retourne l'ancienne valeur à cette position. Cette opération atomique garantit qu'aucune autre écriture n'intervient tant que la valeur modifiée n'a pas été réinscrite.
-
-{{InteractiveExample("Démonstration JavaScript&nbsp;: Atomics.or()")}}
-
-```js interactive-example
-// Crée un SharedArrayBuffer avec une taille en octets
-const buffer = new SharedArrayBuffer(16);
-const uint8 = new Uint8Array(buffer);
-uint8[0] = 5;
-
-// 5 (0101) OR 2 (0010) = 7 (0111)
-console.log(Atomics.or(uint8, 0, 2));
-// Résultat attendu : 5
-
-console.log(Atomics.load(uint8, 0));
-// Résultat attendu : 7
-```
 
 ## Syntaxe
 
@@ -72,15 +56,20 @@ Par exemple, un OU binaire de `5 | 1` retourne `0101`, ce qui correspond à 5 en
 
 ## Exemples
 
-### Utilisation de `or()`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
+
+### Utiliser `Atomics.or()`
 
 ```js
+// Crée un SharedArrayBuffer avec une taille en octets
 const sab = new SharedArrayBuffer(1024);
+// Crée une vue et définit la valeur de l'index 0
 const ta = new Uint8Array(sab);
-ta[0] = 2;
+ta[0] = 7;
 
-Atomics.or(ta, 0, 1); // retourne 2, l'ancienne valeur
-Atomics.load(ta, 0); // 3
+// 7 (0111) OR 10 (1010) = 15 (1111)
+console.log(Atomics.or(ta, 0, 10)); // 7, l'ancienne valeur
+console.log(Atomics.load(ta, 0)); // 15, la nouvelle/valeur actuelle
 ```
 
 ## Spécifications

--- a/files/fr/web/javascript/reference/global_objects/atomics/pause/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/pause/index.md
@@ -3,7 +3,7 @@ title: "Atomics : méthode statique pause()"
 short-title: pause()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/pause
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`pause()`** de l'objet {{JSxRef("Atomics")}} fournit une primitive de micro‑attente qui indique au processeur que l'appelant effectue une boucle d'attente active en attendant l'accès à une ressource partagée. Cela permet au système de réduire les ressources allouées au cœur (par exemple la consommation d'énergie) ou au processus, sans céder l'exécution du processus courant.
@@ -33,7 +33,9 @@ Aucune ({{JSxRef("undefined")}}).
 
 ## Exemples
 
-### Utilisation de `pause()`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
+
+### Utiliser `Atomics.pause()`
 
 Appeler {{JSxRef("Atomics.wait()")}} ou {{JSxRef("Atomics.waitAsync()")}} pour attendre l'accès à une mémoire partagée entraîne la mise hors du cœur du fil d'exécution, puis son retour après l'attente. Cela est efficace en période de forte contention, où l'accès à la mémoire partagée peut prendre un certain temps. Lorsque la contention est faible, il est souvent plus efficace de sonder le verrou sans céder le fil d'exécution&nbsp;: cette approche est connue sous le nom d'[attente active](https://fr.wikipedia.org/wiki/Attente_active) ou de [verrou tournant](https://fr.wikipedia.org/wiki/Spinlock). La méthode `pause()` permet d'effectuer l'attente active de manière plus efficace en fournissant au processeur un indice sur ce que fait le fil d'exécution, et donc sur son faible besoin en ressources.
 

--- a/files/fr/web/javascript/reference/global_objects/atomics/store/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/store/index.md
@@ -3,25 +3,10 @@ title: "Atomics : méthode statique store()"
 short-title: store()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/store
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`store()`** de l'objet {{JSxRef("Atomics")}} enregistre une valeur donnée à un emplacement donné du tableau partagé et retourne cette valeur.
-
-{{InteractiveExample("Démonstration JavaScript&nbsp;: Atomics.store()")}}
-
-```js interactive-example
-// Crée un SharedArrayBuffer avec une taille en octets
-const buffer = new SharedArrayBuffer(16);
-const uint8 = new Uint8Array(buffer);
-uint8[0] = 5;
-
-console.log(Atomics.store(uint8, 0, 2));
-// Résultat attendu : 2
-
-console.log(Atomics.load(uint8, 0));
-// Résultat attendu : 2
-```
 
 ## Syntaxe
 
@@ -51,13 +36,17 @@ La valeur qui a été enregistrée.
 
 ## Exemples
 
-### Utilisation de `store()`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
+
+### Utiliser `Atomics.store()`
 
 ```js
+// Crée un SharedArrayBuffer avec une taille en octets
 const sab = new SharedArrayBuffer(1024);
 const ta = new Uint8Array(sab);
 
-Atomics.store(ta, 0, 12); // 12
+console.log(Atomics.store(ta, 0, 12)); // 12, la nouvelle/valeur actuelle
+console.log(Atomics.load(ta, 0)); // 12, la nouvelle/valeur actuelle
 ```
 
 ## Spécifications
@@ -72,3 +61,4 @@ Atomics.store(ta, 0, 12); // 12
 
 - L'objet {{JSxRef("Atomics")}}
 - La méthode {{JSxRef("Atomics.load()")}}
+- La méthode {{JSxRef("Atomics.exchange()")}}

--- a/files/fr/web/javascript/reference/global_objects/atomics/sub/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/sub/index.md
@@ -3,26 +3,10 @@ title: "Atomics : méthode statique sub()"
 short-title: sub()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/sub
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`sub()`** de l'objet {{JSxRef("Atomics")}} soustrait une valeur donnée à une position donnée du tableau et retourne l'ancienne valeur à cette position. Cette opération atomique garantit qu'aucune autre écriture n'intervient tant que la valeur modifiée n'a pas été réécrite.
-
-{{InteractiveExample("Démonstration JavaScript&nbsp;: Atomics.sub()")}}
-
-```js interactive-example
-// Crée un SharedArrayBuffer avec une taille en octets
-const buffer = new SharedArrayBuffer(16);
-const uint8 = new Uint8Array(buffer);
-uint8[0] = 7;
-
-// 7 - 2 = 5
-console.log(Atomics.sub(uint8, 0, 2));
-// Résultat attendu : 7
-
-console.log(Atomics.load(uint8, 0));
-// Résultat attendu : 5
-```
 
 ## Syntaxe
 
@@ -52,15 +36,20 @@ L'ancienne valeur qui était contenue à (`typedArray[index]`).
 
 ## Exemples
 
-### Utilisation de `sub()`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
+
+### Utiliser `Atomics.sub()`
 
 ```js
+// Crée un SharedArrayBuffer avec une taille en octets
 const sab = new SharedArrayBuffer(1024);
+// Crée une vue et définit la valeur de l'index 0
 const ta = new Uint8Array(sab);
 ta[0] = 48;
 
+// 48 - 12 = 36
 Atomics.sub(ta, 0, 12); // retourne 48, l'ancienne valeur
-Atomics.load(ta, 0); // 36
+Atomics.load(ta, 0); // 36, la nouvelle/valeur actuelle
 ```
 
 ## Spécifications

--- a/files/fr/web/javascript/reference/global_objects/atomics/wait/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/wait/index.md
@@ -3,7 +3,7 @@ title: "Atomics : méthode statique wait()"
 short-title: wait()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/wait
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`wait()`** de l'objet {{JSxRef("Atomics")}} vérifie qu'un emplacement de mémoire partagée contient une valeur donnée et, si c'est le cas, se met en sommeil en attendant une notification de réveil ou l'expiration d'un délai. Elle retourne une chaîne de caractères valant `"not-equal"` si l'emplacement mémoire ne correspond pas à la valeur donnée, `"ok"` si elle est réveillée par {{JSxRef("Atomics.notify()")}}, ou `"timed-out"` si le délai expire.
@@ -49,11 +49,14 @@ Une chaîne de caractères qui vaut `"ok"`, `"not-equal"` ou `"timed-out"` selon
 
 ## Exemples
 
-### Utilisation de `wait()`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
+
+### Utiliser `Atomics.wait()`
 
 Étant donné un `Int32Array` partagé&nbsp;:
 
 ```js
+// Crée un SharedArrayBuffer avec une taille en octets
 const sab = new SharedArrayBuffer(1024);
 const int32 = new Int32Array(sab);
 ```

--- a/files/fr/web/javascript/reference/global_objects/atomics/waitasync/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/waitasync/index.md
@@ -3,7 +3,7 @@ title: "Atomics : méthode statique waitAsync()"
 short-title: waitAsync()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`waitAsync()`** de l'objet {{JSxRef("Atomics")}} vérifie qu'un emplacement de mémoire partagée contient une valeur donnée, retournant immédiatement un objet dont la propriété `value` contient la chaîne de caractères `"not-equal"` si l'emplacement de mémoire ne correspond pas à la valeur donnée, ou `"timed-out"` si le délai d'attente a été fixé à zéro. Sinon, la méthode renvoie un objet dont la propriété `value` est une {{JSxRef("Promise")}} qui s'exécute avec `"ok"` lorsque {{JSxRef("Atomics.notify()")}} est appelée, ou `"timed-out"` si le délai d'attente a expiré.
@@ -48,11 +48,14 @@ Un objet ({{JSxRef("Object")}}) avec les propriétés suivantes&nbsp;:
 
 ## Exemples
 
-### Utilisation de `waitAsync()`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
 
-Soit un tableau de mémoire partagée `Int32Array`.
+### Utiliser `Atomics.waitAsync()`
+
+Soit un tableau de mémoire partagée `Int32Array`&nbsp;:
 
 ```js
+// Crée un SharedArrayBuffer avec une taille en octets
 const sab = new SharedArrayBuffer(1024);
 const int32 = new Int32Array(sab);
 ```

--- a/files/fr/web/javascript/reference/global_objects/atomics/xor/index.md
+++ b/files/fr/web/javascript/reference/global_objects/atomics/xor/index.md
@@ -3,26 +3,10 @@ title: "Atomics : méthode statique xor()"
 short-title: xor()
 slug: Web/JavaScript/Reference/Global_Objects/Atomics/xor
 l10n:
-  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+  sourceCommit: 48f29758dbe9036bd04baf519b8e35d1f989e532
 ---
 
 La méthode statique **`Atomics.xor()`** calcule un OU Exclusif binaire (ou «&nbsp;XOR&nbsp;») avec une valeur donnée à une position donnée dans le tableau, et retourne l'ancienne valeur à cette position. Cette opération atomique garantit qu'aucune autre écriture n'a lieu avant que la valeur modifiée ne soit réécrite.
-
-{{InteractiveExample("Démonstration JavaScript&nbsp;: Atomics.xor()")}}
-
-```js interactive-example
-// Crée un SharedArrayBuffer avec une taille en octets
-const buffer = new SharedArrayBuffer(16);
-const uint8 = new Uint8Array(buffer);
-uint8[0] = 7;
-
-// 7 (0111) XOR 2 (0010) = 5 (0101)
-console.log(Atomics.xor(uint8, 0, 2));
-// Résultat attendu : 7
-
-console.log(Atomics.load(uint8, 0));
-// Résultat attendu : 5
-```
 
 ## Syntaxe
 
@@ -72,15 +56,20 @@ Par exemple, le calcul d'un OU exclusif binaire `5 ^ 1` retourne `0100`, qui cor
 
 ## Exemples
 
-### Utilisation de `xor(s)`
+Notez que ces exemples ne peuvent pas être exécutés directement depuis la console ou une page web arbitraire, car `SharedArrayBuffer` n'est pas défini à moins que [ses exigences de sécurité](/fr/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#contraintes_de_sécurité) ne soient respectées.
+
+### Utiliser `Atomics.xor()`
 
 ```js
+// Crée un SharedArrayBuffer avec une taille en octets
 const sab = new SharedArrayBuffer(1024);
+// Crée une vue et définit la valeur de l'index 0
 const ta = new Uint8Array(sab);
-ta[0] = 5;
+ta[0] = 7;
 
-Atomics.xor(ta, 0, 1); // retourne 5, l'ancienne valeur
-Atomics.load(ta, 0); // 4
+// 7 (0111) XOR 2 (0010) = 5 (0101)
+console.log(Atomics.xor(ta, 0, 2)); // retourne , l'ancienne valeur
+console.log(Atomics.load(ta, 0)); // 5, la nouvelle/valeur actuelle
 ```
 
 ## Spécifications


### PR DESCRIPTION
### Description

Update translation of pages without french version: `Web/JavaScript/Reference/Global_Objects/Atomics/*`

### Motivation

Update access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

Related to https://github.com/mdn/content/pull/43060