### PR TITLE
chore(fr): translation of `Web/JavaScript/Reference/Global_Objects/DataView/getFloat16`

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/dataview/getfloat16/index.md
+++ b/files/fr/web/javascript/reference/global_objects/dataview/getfloat16/index.md
@@ -1,0 +1,71 @@
+---
+title: "DataView : méthode getFloat16()"
+short-title: getFloat16()
+slug: Web/JavaScript/Reference/Global_Objects/DataView/getFloat16
+l10n:
+  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+---
+
+La méthode **`getFloat16()`** des instances de {{JSxRef("DataView")}} lit 2 octets à partir du décalage d'octet défini de cette `DataView` et les interprète comme un nombre flottant sur 16 bits. Il n'y a pas de contrainte d'alignement&nbsp;; les valeurs sur plusieurs octets peuvent être obtenues depuis n'importe quel décalage valide.
+
+{{InteractiveExample("Démonstration JavaScript&nbsp;: DataView.prototype.getFloat16()")}}
+
+```js interactive-example
+// Créer un ArrayBuffer avec une taille en octets
+const buffer = new ArrayBuffer(16);
+
+const view = new DataView(buffer);
+view.setFloat16(1, Math.PI);
+
+console.log(view.getFloat16(1));
+// Résultat attendu : 3.140625
+```
+
+## Syntaxe
+
+```js-nolint
+getFloat16(byteOffset)
+getFloat16(byteOffset, littleEndian)
+```
+
+### Paramètres
+
+- `byteOffset`
+  - : Le décalage, en octets, depuis le début de la vue à partir duquel lire les données.
+- `littleEndian` {{Optional_Inline}}
+  - : Indique si les données sont stockées au format {{Glossary("Endianness", "gros-boutiste ou petit-boutiste")}}. Si la valeur est `false` ou `undefined`, une valeur gros-boutiste est lue.
+
+### Valeur de retour
+
+Un nombre flottant compris entre `-65504` et `65504`.
+
+### Exceptions
+
+- {{JSxRef("RangeError")}}
+  - : Levée si le paramètre `byteOffset` est défini de façon à lire au-delà de la fin de la vue.
+
+## Exemples
+
+### Utiliser la méthode `getFloat16()`
+
+```js
+const { buffer } = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+const dataview = new DataView(buffer);
+console.log(dataview.getFloat16(1)); // 0.00001537799835205078
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- [La prothèse d'émulation de `DataView.prototype.getFloat16` dans `core-js` <sup>(angl.)</sup>](https://github.com/zloirock/core-js#float16-methods)
+- Le guide [des tableaux typés JavaScript](/fr/docs/Web/JavaScript/Guide/Typed_arrays)
+- L'objet {{JSxRef("DataView")}}
+- L'objet {{JSxRef("ArrayBuffer")}}
+- L'objet {{JSxRef("Float16Array")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/JavaScript/Reference/Global_Objects/DataView/getFloat16`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_