### PR TITLE
zh-cn: undeprecate navigator.platform

### DIFF
--- a/files/zh-cn/web/api/navigator/platform/index.md
+++ b/files/zh-cn/web/api/navigator/platform/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: 1238ffad886924b20549d0cf3adca735cb0d074f
 ---
 
-{{APIRef("HTML DOM")}}{{Deprecated_Header}}
+{{APIRef("HTML DOM")}}
 
 {{domxref("Navigator")}} 接口的 **`platform`** 只读属性返回一个字符串，用于标识用户浏览器所在的平台。
 


### PR DESCRIPTION
### Description

This change removes the deprecation header in `navigator.platform` page.

### Motivation

According to the discussion in https://github.com/mdn/content/issues/14429, `navigator.platform` has never been deprecated in the web spec, but it was shown as _deprecated_ only on MDN.

The English version of MDN fixed the issue in https://github.com/mdn/content/pull/14452. This PR follows it.

### Related issues and pull requests

- https://github.com/mdn/content/issues/14429
- https://github.com/mdn/content/pull/14452
- https://github.com/mdn/translated-content/pull/33505
- https://github.com/mdn/translated-content/pull/33506