### PR TITLE
Fix typo in regular expressions example

### DIFF
--- a/files/ja/web/javascript/guide/regular_expressions/character_classes/index.md
+++ b/files/ja/web/javascript/guide/regular_expressions/character_classes/index.md
@@ -187,7 +187,7 @@ console.log(moods.match(regexpEmoticons));
 キャレット記法"
             >キャレット記法</a
           >を使用した制御文字に一致します。 "X" には A–Z の文字が入ります（コードポイント<code>U+0001</code><em>–</em><code>U+001A</code> に対応します）。例えば
-          <code>/\cM\J/</code> は "\r\n" に一致します。
+          <code>/\cM\cJ/</code> は "\r\n" に一致します。
         </p>
       </td>
     </tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
- 原文: https://github.com/mdn/content/blob/04defe50e601cf53adde40c4bd652a7a4e6eae55/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md?plain=1#L221
- `\cM\cJ`の2個目の`c`が日本語版で抜けて`\cM\J`となっていたのを修正

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
