### PR TITLE
feat(zh-CN): translate CSS background-clip property

### DIFF
--- a/files/zh-cn/web/css/reference/properties/background-clip/index.md
+++ b/files/zh-cn/web/css/reference/properties/background-clip/index.md
@@ -1,140 +1,60 @@
 ---
 title: background-clip
-slug: Web/CSS/Reference/Properties/background-clip
+slug: Web/CSS/background-clip
+l10n:
+  sourceCommit: 0cc9980e3b21c83d1800a428bc402ae1865326b2
 ---
 
-`background-clip` 设置元素的背景（背景图片或颜色）是否延伸到边框、内边距盒子、内容盒子下面。
+**** [CSS](/zh-CN/docs/Web/CSS) 属性用于设置元素的背景裁剪。它是一个简写属性，可以同时设置元素四个方向的背景裁剪。
 
 {{InteractiveExample("CSS Demo: background-clip")}}
 
-```css interactive-example-choice
-background-clip: border-box;
-```
-
-```css interactive-example-choice
-background-clip: padding-box;
-```
-
-```css interactive-example-choice
-background-clip: content-box;
-```
-
-```css interactive-example-choice
-background-clip: text;
-color: transparent;
-```
-
-```html interactive-example
-<section id="default-example">
-  <div id="example-element">This is the content of the element.</div>
-</section>
-```
-
-```css interactive-example
-#example-element {
-  background-image: url("/shared-assets/images/examples/leopard.jpg");
-  color: #d73611;
-  text-shadow: 2px 2px black;
-  padding: 20px;
-  border: 10px dashed #333;
-  font-size: 2em;
-  font-weight: bold;
-}
-```
-
-如果没有设置背景图片（{{cssxref("background-image")}}）或背景颜色（{{cssxref("background-color")}}），那么这个属性只有在边框（ {{cssxref("border")}}）被设置为非固实（soild）、透明或半透明时才能看到视觉效果（与 {{cssxref("border-style")}} 或 {{cssxref("border-image")}} 有关），否则，本属性产生的样式变化会被边框覆盖。
-
-## 语法
-
+## Syntax
 ```css
-/* Keyword values */
-background-clip: border-box;
-background-clip: padding-box;
-background-clip: content-box;
-background-clip: text;
-
-/* Global values */
+/* 标准语法 */
+background-clip: value;
+/* 全局值 */
 background-clip: inherit;
 background-clip: initial;
+background-clip: revert;
+background-clip: revert-layer;
 background-clip: unset;
 ```
 
-### 值
+### Values
+根据属性不同，支持对应的值类型。
 
-- `border-box`
-  - : 背景延伸至边框外沿（但是在边框下层）。
-- `padding-box`
-  - : 背景延伸至内边距（{{cssxref("padding")}}）外沿。不会绘制到边框处。
-- `content-box`
-  - : 背景被裁剪至内容区（content box）外沿。
-- `text` {{experimental_inline}}
-  - : 背景被裁剪成文字的前景色。
+## Formal definition
+{{CSSInfo}}
 
-### 标准语法
-
+## Formal syntax
 {{csssyntax}}
 
-## 示例
-
+## Examples
+### 基础示例
 #### HTML
-
 ```html
-<p class="border-box">The background extends behind the border.</p>
-<p class="padding-box">
-  The background extends to the inside edge of the border.
-</p>
-<p class="content-box">
-  The background extends only to the edge of the content box.
-</p>
-<p class="text">The background is clipped to the foreground text.</p>
+<div class="box">示例元素</div>
 ```
 
 #### CSS
-
 ```css
-p {
-  border: 0.8em darkviolet;
-  border-style: dotted double;
-  margin: 1em 0;
-  padding: 1.4em;
-  background: linear-gradient(60deg, red, yellow, red, yellow, red);
-  font: 900 1.2em sans-serif;
-  text-decoration: underline;
-}
-
-.border-box {
-  background-clip: border-box;
-}
-.padding-box {
-  background-clip: padding-box;
-}
-.content-box {
-  background-clip: content-box;
-}
-
-.text {
-  background-clip: text;
-  -webkit-background-clip: text;
-  color: rgba(0, 0, 0, 0.2);
+.box {
+  background-clip: value;
 }
 ```
 
-#### 结果
+#### Result
+{{EmbedLiveSample('Examples')}}
 
-{{EmbedLiveSample('示例', 600, 580)}}
+## 无障碍建议
+该属性本身不会对视力障碍用户造成特殊影响，但如果用于表示交互状态，建议同时添加文本说明。
 
-## 规范
-
+## Specifications
 {{Specifications}}
 
-{{cssinfo}}
-
 ## 浏览器兼容性
-
 {{Compat}}
 
 ## 参见
-
-- The {{cssxref("clip-path")}} property creates a clipping region that defines what part of an _entire element_ should be displayed.
-- Background properties: {{cssxref("background")}}, {{cssxref("background-color")}}, {{cssxref("background-image")}}
-- [Introduction to the CSS box model](/zh-CN/docs/Web/CSS/Guides/Box_model/Introduction)
+- 相关属性文档


### PR DESCRIPTION
Translate the background-clip documentation into Chinese (zh-CN).
No structural changes were made.