### PR TITLE
ci(pr-check-lint_content): keep markdownlint config file

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -93,7 +93,7 @@ jobs:
           # Remove files from BASE.
           rm -r files docs *.md
 
-          # Remove non-Markdown files from HEAD, but keep .markdownlint.jsonc.
+          # Remove everything from HEAD, except Markdown files and the Markdownlint config.
           find pr_head -type f ! -name '*.md' ! -name '.markdownlint.jsonc' -delete
 
           # Move Markdown files from HEAD into BASE.

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -93,8 +93,8 @@ jobs:
           # Remove files from BASE.
           rm -r files docs *.md
 
-          # Remove non-Markdown files from HEAD.
-          find pr_head -type f ! -name '*.md' -delete
+          # Remove non-Markdown files from HEAD, but keep .markdownlint.jsonc.
+          find pr_head -type f ! -name '*.md' ! -name '.markdownlint.jsonc' -delete
 
           # Move Markdown files from HEAD into BASE.
           mv pr_head/files pr_head/docs pr_head/*.md .


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Keep markdownlint config file to use, to use locale-specific markdown lint configuration.

### Motivation

The refactoring in #34013 breaks the content lint with locale-specific markdown lint configuration. As the [`.markdownlint.jsonc`](https://github.com/mdn/translated-content/blob/main/files/zh-cn/.markdownlint.jsonc) file has been removed.

See the workflow run in #34262:

- https://github.com/mdn/translated-content/actions/runs/23180534463/job/67352352023
- https://github.com/mdn/translated-content/actions/runs/23230845412/job/67523825577
