### PR TITLE
Fix typo in learning outcomes section

### DIFF
--- a/files/ja/learn_web_development/core/structuring_content/html_images/index.md
+++ b/files/ja/learn_web_development/core/structuring_content/html_images/index.md
@@ -28,7 +28,7 @@ l10n:
       <th scope="row">学習成果:</th>
       <td>
         <ul>
-          <li>「置換要素」という耀g。どういう意味でしょう。</li>
+          <li>「置換要素」という用語。どういう意味でしょう。</li>
           <li>基本的な <code>&lt;img&gt;</code> タグの構文</li>
           <li><code>src</code> を使用してリソースを指すこと。</li>
           <li><code>width</code> と <code>height</code> を使用して、例えば、画像の読み込みが完了して表示された後に、 UI が不快でぎこちない動きで更新されるのを避けることができること。</li>


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

ページ上部の学習成果の一項目目の

「置換要素」という耀g。どういう意味でしょう。となっていたタイポを耀g から用語に修正しました。

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

タイポを発見したため。
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
[該当ページ](https://developer.mozilla.org/ja/docs/Learn_web_development/Core/Structuring_content/HTML_images)

### Related issues and pull requests

[リクエスト:HTML の画像 - ウェブ開発の学習の更新 #863](https://github.com/mozilla-japan/translation/issues/863#issue-4104557436)
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
