### PR TITLE
Add ja control mechanisms

### DIFF
--- a/files/ja/games/techniques/control_mechanisms/desktop_with_gamepad/index.md
+++ b/files/ja/games/techniques/control_mechanisms/desktop_with_gamepad/index.md
@@ -1,0 +1,388 @@
+---
+title: デスクトップゲームパッド制御
+slug: Games/Techniques/Control_mechanisms/Desktop_with_gamepad
+l10n:
+  sourceCommit: 0f41789370f1744c3d77efb697991d514a32b6c6
+---
+
+{{PreviousMenuNext("Games/Techniques/Control_mechanisms/Desktop_with_mouse_and_keyboard", "Games/Techniques/Control_mechanisms/Other", "Games/Techniques/Control_mechanisms")}}
+
+次に、何か追加のものを見ていきます。Gamepad API を介したゲームパッド制御のサポートです。これにより、ウェブゲームにコンソールのような体験がもたらされます。
+
+Gamepad API は、ゲームパッドをコンピューターに接続し、ブラウザーがそのような機能を実装しているおかげで、JavaScript コードから直接押されたボタンを検出する機能を提供します。API は、ゲームのロジックをフックし、ユーザーインターフェイスとゲームプレイを正常に制御するために必要なすべての情報を公開します。
+
+## API のステータス、ブラウザーとハードウェアのサポート
+
+[Gamepad API](/ja/docs/Web/API/Gamepad_API) はまだ Working Draft ステータスですが、ブラウザーのサポートはすでに非常に良好です。[caniuse.com](https://caniuse.com/#search=gamepad) によると、グローバルカバレッジは約 63% です。サポートされているデバイスのリストも非常に広範です。最も人気のあるゲームパッド（例えば、XBox 360 または PS3）は、ウェブ実装に適しているはずです。
+
+## 純粋な JavaScript アプローチ
+
+まず、[小さな制御デモ](https://github.com/end3r/JavaScript-Game-Controls/)で純粋な JavaScript ゲームパッド制御を実装することを考えて、どのように機能するかを見てみましょう。まず、新しいデバイスの接続をリッスンするイベントリスナーが必要です。
+
+```js
+window.addEventListener("gamepadconnected", gamepadHandler);
+```
+
+これは一度実行されるため、後で必要になるコントローラー情報と押されたボタンを格納するためのいくつかの変数を作成できます。
+
+```js
+let controller = {};
+let buttonsPressed = [];
+function gamepadHandler(e) {
+  controller = e.gamepad;
+  output.textContent = `Gamepad: ${controller.id}`;
+}
+```
+
+`gamepadHandler` 関数の 2 行目は、デバイスが接続されたときに画面に表示されます。
+
+![Captain Rogers ゲームの下にゲームパッド接続メッセージ - ワイヤレス XBox 360 コントローラー。](controls-gamepadtext.png)
+
+デバイスの `id` も表示できます。上記の場合、XBox 360 ワイヤレスコントローラーを使用しています。
+
+ゲームパッドの現在押されているボタンの状態を更新するには、すべてのフレームでまさにそれを行う関数が必要です。
+
+```js
+function gamepadUpdateHandler() {
+  buttonsPressed = [];
+  if (controller.buttons) {
+    for (const [i, button] of controller.buttons.entries()) {
+      if (button.pressed) {
+        buttonsPressed.push(i);
+      }
+    }
+  }
+}
+```
+
+まず、`buttonsPressed` 配列をリセットして、現在のフレームから書き込む最新の情報を受け取る準備をします。次に、ボタンが利用可能な場合はループします。`pressed` プロパティが `true` に設定されている場合は、後で処理するために `buttonsPressed` 配列に追加します。次に、`gamepadButtonPressedHandler()` 関数を検討します。
+
+```js
+function gamepadButtonPressedHandler(button) {
+  return buttonsPressed.includes(button);
+}
+```
+
+この関数は、ボタンインデックスをパラメーターとして受け取ります。`buttonsPressed` に探しているボタンが含まれているかどうかをチェックし、含まれている場合は `true` を返します。これにより、ボタンが押されているかどうかがチェックされます。
+
+次に、`draw()` 関数で 2 つのことを行います。`gamepadUpdateHandler()` 関数を実行して、すべてのフレームで押されたボタンの現在の状態を取得し、`gamepadButtonPressedHandler()` 関数を使用して、関心のあるボタンをチェックして、押されているかどうかを確認し、押されている場合は何かを実行します。
+
+```js
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  // …
+
+  gamepadUpdateHandler();
+  if (gamepadButtonPressedHandler(0)) {
+    playerY -= 5;
+  } else if (gamepadButtonPressedHandler(1)) {
+    playerY += 5;
+  }
+  if (gamepadButtonPressedHandler(2)) {
+    playerX -= 5;
+  } else if (gamepadButtonPressedHandler(3)) {
+    playerX += 5;
+  }
+  if (gamepadButtonPressedHandler(11)) {
+    alert("BOOM!");
+  }
+
+  // …
+
+  ctx.drawImage(img, playerX, playerY);
+  requestAnimationFrame(draw);
+}
+```
+
+この場合、4 つの D-Pad ボタン（0-3）と A ボタン（11）をチェックしています。
+
+> [!NOTE]
+> 異なるデバイスは異なるキーマッピングを持つ可能性があることを覚えておいてください。つまり、D-Pad Right ボタンはワイヤレス XBox 360 でインデックス 3 を持っていますが、別のデバイスでは異なる可能性があります。
+
+リストされたボタンに適切な名前を割り当てるヘルパー関数を作成することもできます。例えば、`gamepadButtonPressedHandler(3)` が押されているかどうかをチェックする代わりに、より説明的なチェック `gamepadButtonPressedHandler('DPad-Right')` を実行できます。
+
+[ライブデモ](https://end3r.github.io/JavaScript-Game-Controls/)を実際に見ることができます。ゲームパッドを接続してボタンを押してみてください。
+
+## Phaser アプローチ
+
+Phaser で作成した [Captain Rogers: Battle at Andromeda](https://rogers2.enclavegames.com/demo/) ゲームでの最終的な Gamepad API 実装に移りましょう。これも純粋な JavaScript コードですが、使用されたフレームワークに関係なく、他のプロジェクトで使用できます。
+
+まず、入力を処理するための小さなライブラリを作成します。有用な変数と関数を含む `GamepadAPI` オブジェクトは次のとおりです。
+
+```js
+const GamepadAPI = {
+  active: false,
+  controller: {},
+  connect(event) {},
+  disconnect(event) {},
+  update() {},
+  buttons: {
+    layout: [],
+    cache: [],
+    status: [],
+    pressed(button, state) {},
+  },
+  axes: {
+    status: [],
+  },
+};
+```
+
+`controller` 変数は接続されたゲームパッドに関する情報を格納し、コントローラーが接続されているかどうかを知るために使用できる `active` ブール変数があります。`connect()` と `disconnect()` 関数は次のイベントにバインドされています。
+
+```js
+window.addEventListener("gamepadconnected", GamepadAPI.connect);
+window.addEventListener("gamepaddisconnected", GamepadAPI.disconnect);
+```
+
+これらは、ゲームパッドが接続および切断されたときにそれぞれ発行されます。次の関数は `update()` で、押されたボタンと軸に関する情報を更新します。
+
+`buttons` 変数には、特定のコントローラーの `layout`（例えば、ボタンがどこにあるか、XBox 360 レイアウトは一般的なものとは異なる場合があります）、前のフレームからのボタンに関する情報を含む `cache`、現在のフレームからの情報を含む `status` が含まれています。
+
+`pressed()` 関数は入力データを取得し、オブジェクトに関する情報を設定します。`axes` プロパティは、`x` と `y` 方向で軸が押されている量を表す値を含む配列を格納し、`(-1, 1)` 範囲の浮動小数点数で表されます。
+
+ゲームパッドが接続されると、コントローラーに関する情報がオブジェクトに格納されます。
+
+```js
+const GamepadAPI = {
+  // …
+  connect(event) {
+    GamepadAPI.controller = event.gamepad;
+    GamepadAPI.active = true;
+  },
+  // …
+};
+```
+
+`disconnect` 関数はオブジェクトから情報を削除します。
+
+```js
+const GamepadAPI = {
+  // …
+  disconnect(event) {
+    delete GamepadAPI.controller;
+    GamepadAPI.active = false;
+  },
+};
+```
+
+`update()` 関数は、ゲームの更新ループですべてのフレームで実行されるため、押されたボタンに関する最新の情報が含まれています。
+
+```js
+const GamepadAPI = {
+  // …
+  update() {
+    GamepadAPI.buttons.cache = [];
+    for (let k = 0; k < GamepadAPI.buttons.status.length; k++) {
+      GamepadAPI.buttons.cache[k] = GamepadAPI.buttons.status[k];
+    }
+    GamepadAPI.buttons.status = [];
+    const c = GamepadAPI.controller || {};
+    const pressed = [];
+    if (c.buttons) {
+      for (let b = 0; b < c.buttons.length; b++) {
+        if (c.buttons[b].pressed) {
+          pressed.push(GamepadAPI.buttons.layout[b]);
+        }
+      }
+    }
+    const axes = [];
+    if (c.axes) {
+      for (const ax of c.axes) {
+        axes.push(ax.toFixed(2));
+      }
+    }
+    GamepadAPI.axes.status = axes;
+    GamepadAPI.buttons.status = pressed;
+    return pressed;
+  },
+  // …
+};
+```
+
+上記の関数は、ボタンキャッシュをクリアし、前のフレームからのステータスをキャッシュにコピーします。次に、ボタンステータスがクリアされ、新しい情報が追加されます。軸の情報についても同じことが行われます。ループして軸に値を追加します。受信した値は適切なオブジェクトに割り当てられ、デバッグ目的で押された情報を返します。
+
+`button.pressed()` 関数は実際のボタン押下を検出します。
+
+```js
+const GamepadAPI = {
+  // …
+  buttons: {
+    // …
+    pressed(button, hold) {
+      let newPress = false;
+      if (GamepadAPI.buttons.status.includes(button)) {
+        newPress = true;
+      }
+      if (!hold && GamepadAPI.buttons.cache.includes(button)) {
+        newPress = false;
+      }
+      return newPress;
+    },
+    // …
+  },
+  // …
+};
+```
+
+探しているボタンが押されているかどうかをチェックし、そうであれば、対応するブール変数が `true` に設定されます。ボタンがすでに保持されていないかどうかをチェックしたい場合（つまり、新しい押下である場合）、前のフレームからキャッシュされた状態をチェックすることで実行できます。ボタンがすでに押されていた場合、新しい押下を無視し、`false` に設定します。
+
+## 実装
+
+`GamepadAPI` オブジェクトがどのように見えるか、どの変数と関数が含まれているかがわかったので、これがすべてゲームで実際にどのように使用されるかを学びましょう。ゲームパッドコントローラーがアクティブであることを示すために、ゲームのメインメニュー画面でユーザーにカスタムテキストを表示できます。
+
+`textGamepad` オブジェクトは、ゲームパッドが接続されたことを示すテキストを保持し、デフォルトでは非表示になっています。新しい状態が作成されたときに一度実行される `create()` 関数で準備したコードは次のとおりです。
+
+```js
+function create() {
+  // …
+  const message = "Gamepad connected! Press Y for controls";
+  const textGamepad = this.add.text(0, 0, message);
+  textGamepad.visible = false;
+}
+```
+
+すべてのフレームで実行される `update()` 関数では、コントローラーが実際に接続されるまで待つことができるため、適切なテキストを表示できます。次に、`Gamepad.update()` メソッドを使用して押されたボタンに関する情報を追跡し、指定された情報に反応できます。
+
+```js
+function update() {
+  // …
+  if (GamepadAPI.active) {
+    this.textGamepad.visible = true;
+
+    GamepadAPI.update();
+    if (GamepadAPI.buttons.pressed("Start")) {
+      // ゲームを開始
+    }
+    if (GamepadAPI.buttons.pressed("X")) {
+      // サウンドをオン/オフ
+    }
+
+    this.screenGamepadHelp.visible = GamepadAPI.buttons.pressed("Y", "hold");
+  }
+}
+```
+
+`Start` ボタンが押されると、関連する関数が呼び出されてゲームが開始され、オーディオのオン/オフにも同じアプローチが使用されます。すべてのボタン制御が説明された画像を保持する `screenGamepadHelp` を表示するオプションが接続されています。`Y` ボタンが押されて保持されている場合、ヘルプが表示されます。リリースされると、ヘルプが消えます。
+
+![利用可能なすべてのキーが説明されたゲームパッド情報。](controls-gamepadinfo.png)
+
+## 画面上の指示
+
+ゲームが開始されると、利用可能な制御を示す紹介テキストが表示されます。ゲームがデスクトップまたはモバイルで起動されているかどうかをすでに検出しているため、デバイスに関連するメッセージを表示していますが、さらに進んで、ゲームパッドの存在を許可できます。
+
+```js
+function create() {
+  // …
+  if (this.game.device.desktop) {
+    if (GamepadAPI.active) {
+      moveText = "DPad or left Stick\nto move";
+      shootText = "A to shoot,\nY for controls";
+    } else {
+      moveText = "Arrow keys\nor WASD to move";
+      shootText = "X or Space\nto shoot";
+    }
+  } else {
+    moveText = "Tap and hold to move";
+    shootText = "Tap to shoot";
+  }
+}
+```
+
+デスクトップの場合、コントローラーがアクティブかどうかをチェックし、ゲームパッド制御を表示できます。そうでない場合は、キーボード制御が表示されます。
+
+## ゲームプレイ制御
+
+プレイヤーにメインと代替のゲームパッド移動制御を提供することで、さらに柔軟性を提供できます。
+
+```js
+if (GamepadAPI.buttons.pressed("DPad-Up", "hold")) {
+  // プレイヤーを上に移動
+} else if (GamepadAPI.buttons.pressed("DPad-Down", "hold")) {
+  // プレイヤーを下に移動
+}
+
+if (GamepadAPI.buttons.pressed("DPad-Left", "hold")) {
+  // プレイヤーを左に移動
+}
+
+if (GamepadAPI.buttons.pressed("DPad-Right", "hold")) {
+  // プレイヤーを右に移動
+}
+
+if (GamepadAPI.axes.status) {
+  if (GamepadAPI.axes.status[0] > 0.5) {
+    // プレイヤーを上に移動
+  } else if (GamepadAPI.axes.status[0] < -0.5) {
+    // プレイヤーを下に移動
+  }
+
+  if (GamepadAPI.axes.status[1] > 0.5) {
+    // プレイヤーを左に移動
+  } else if (GamepadAPI.axes.status[1] < -0.5) {
+    // プレイヤーを右に移動
+  }
+}
+```
+
+これで、`DPad` ボタンまたは左スティックの軸を使用して画面上の船を移動できるようになりました。
+
+軸の現在の値が `0.5` に対して評価されていることに気づきましたか？これは、軸が浮動小数点値を持つのに対し、ボタンはブール値を持つためです。特定のしきい値に達すると、入力がユーザーによって意図的に行われたと想定でき、それに応じて動作できます。
+
+射撃制御には、`A` ボタンを使用しました。押されたままにすると、新しい弾丸が生成され、残りはすべてゲームによって処理されます。
+
+```js
+if (GamepadAPI.buttons.pressed("A", "hold")) {
+  this.spawnBullet();
+}
+```
+
+すべての制御を含む画面の表示は、メインメニューとまったく同じです。
+
+```js
+this.screenGamepadHelp.visible = GamepadAPI.buttons.pressed("Y", "hold");
+```
+
+`B` ボタンが押されると、ゲームが一時停止されます。
+
+```js
+if (gamepadAPI.buttonPressed("B")) {
+  this.managePause();
+}
+```
+
+## 一時停止とゲームオーバー状態
+
+ゲームのライフサイクル全体を制御する方法をすでに学びました。ゲームプレイを一時停止したり、再起動したり、メインメニューに戻ったりします。モバイルとデスクトップでスムーズに動作し、ゲームパッド制御の追加も同様に簡単です。`update()` 関数で、現在の状態ステータスが「一時停止」であるかどうかをチェックします。そうであれば、関連するアクションが有効になります。
+
+```js
+if (GamepadAPI.buttons.pressed("Start")) {
+  this.managePause();
+}
+
+if (GamepadAPI.buttons.pressed("Back")) {
+  this.stateBack();
+}
+```
+
+同様に、「ゲームオーバー」状態ステータスがアクティブな場合、ユーザーはゲームを続行する代わりに再起動できます。
+
+```js
+if (GamepadAPI.buttons.pressed("Start")) {
+  this.stateRestart();
+}
+if (GamepadAPI.buttons.pressed("Back")) {
+  this.stateBack();
+}
+```
+
+ゲームオーバー画面が表示されているとき、`Start` ボタンはゲームを再起動し、`Back` ボタンはメインメニューに戻ります。ゲームが一時停止されている場合も同じです。`Start` ボタンはゲームの一時停止を解除し、`Back` ボタンは前と同じように戻ります。
+
+## まとめ
+
+以上です！ゲームにゲームパッド制御を正常に実装しました。XBox 360 などの人気のあるコントローラーを接続して、ゲームパッドで小惑星を避けてエイリアンを撃つのがどれほど楽しいかを自分で確かめてください。
+
+これで、ラップトップの前で手を振ったり、マイクに向かって叫んだりするなど、さらに型破りな方法で HTML ゲームを制御する新しい方法を探求できます。
+
+{{PreviousMenuNext("Games/Techniques/Control_mechanisms/Desktop_with_mouse_and_keyboard", "Games/Techniques/Control_mechanisms/Other", "Games/Techniques/Control_mechanisms")}}

--- a/files/ja/games/techniques/control_mechanisms/desktop_with_mouse_and_keyboard/index.md
+++ b/files/ja/games/techniques/control_mechanisms/desktop_with_mouse_and_keyboard/index.md
@@ -1,0 +1,266 @@
+---
+title: デスクトップマウスとキーボード制御
+slug: Games/Techniques/Control_mechanisms/Desktop_with_mouse_and_keyboard
+l10n:
+  sourceCommit: 0f41789370f1744c3d77efb697991d514a32b6c6
+---
+
+{{PreviousMenuNext("Games/Techniques/Control_mechanisms/Mobile_touch", "Games/Techniques/Control_mechanisms/Desktop_with_gamepad", "Games/Techniques/Control_mechanisms")}}
+
+モバイル制御が配置され、ゲームがタッチ対応デバイスでプレイ可能になったので、マウスとキーボードのサポートを追加して、ゲームをデスクトップでもプレイできるようにすることをお勧めします。そうすれば、サポートされているプラットフォームのリストを広げることができます。以下でこれを見ていきます。
+
+デスクトップで開発する場合、ゲームプレイなどの制御に依存しない機能をテストする方が簡単なので、ソースコードを変更するたびにファイルをモバイルデバイスにプッシュする必要はありません。
+
+> [!NOTE]
+> [Captain Rogers: Battle at Andromeda](https://rogers2.enclavegames.com/demo/) は Phaser で構築されており、制御の管理は Phaser ベースですが、純粋な JavaScript でも実行できます。Phaser を使用する良い点は、より高速な開発のためのヘルパー変数と関数を提供することですが、どのアプローチを選択するかは完全にあなた次第です。
+
+## 純粋な JavaScript アプローチ
+
+まず、ゲームで純粋な JavaScript キーボード/マウス制御を実装することを考えて、どのように機能するかを見てみましょう。まず、押されたキーをリッスンするイベントリスナーが必要です。
+
+```js
+document.addEventListener("keydown", keyDownHandler);
+document.addEventListener("keyup", keyUpHandler);
+```
+
+キーが押されるたびに `keyDownHandler` 関数を実行し、押下が終了すると `keyUpHandler` 関数を実行するため、押されなくなったことがわかります。そのためには、関心のあるキーが押されているかどうかに関する情報を保持します。
+
+```js
+let rightPressed = false;
+let leftPressed = false;
+let upPressed = false;
+let downPressed = false;
+```
+
+次に、`keydown` と `keyup` イベントをリッスンし、両方のハンドラー関数で適切に動作します。それらの内部で、イベントオブジェクトの [`code`](/ja/docs/Web/API/KeyboardEvent/code) プロパティから押されたキーのコードを取得し、どのキーであるかを確認して、適切な変数を設定できます。コードはすべて読みやすい文字列名ですが、確認するために[調べる](/ja/docs/Web/API/UI_Events/Keyboard_event_code_values)ことができます。`"ArrowLeft"` は左矢印です。
+
+```js
+function keyDownHandler(event) {
+  if (event.code === "ArrowRight") {
+    rightPressed = true;
+  } else if (event.code === "ArrowLeft") {
+    leftPressed = true;
+  }
+  if (event.code === "ArrowDown") {
+    downPressed = true;
+  } else if (event.code === "ArrowUp") {
+    upPressed = true;
+  }
+}
+```
+
+`keyUpHandler` は上記の `keyDownHandler` とほぼ同じに見えますが、押された変数を `true` に設定する代わりに、`false` に設定します。左矢印が押されている場合（<kbd>⬅︎</kbd>; `"ArrowLeft"`）、`leftPressed` 変数を `true` に設定し、`draw` 関数でそれに割り当てられたアクション（船を左に移動）を実行できます。
+
+```js
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  if (rightPressed) {
+    playerX += 5;
+  } else if (leftPressed) {
+    playerX -= 5;
+  }
+
+  if (downPressed) {
+    playerY += 5;
+  } else if (upPressed) {
+    playerY -= 5;
+  }
+
+  ctx.drawImage(img, playerX, playerY);
+  requestAnimationFrame(draw);
+}
+```
+
+`draw` 関数は最初に Canvas 全体をクリアします。すべてのフレームでゼロからすべてを描画します。次に、押されたキー変数がチェックされ、船の位置を保持する `playerX` と `playerY` 変数（`leftPressed` などの後に早期に定義します）が、例えば 5 ピクセルなどの指定された量だけ調整されます。次に、プレイヤーの船が画面に描画され、[requestAnimationFrame](/ja/docs/Web/API/Window/requestAnimationFrame) 内から次の描画が呼び出されます。
+
+![キーボードとマウスで制御できるプレイヤーの船（背景に星）を含む純粋な JavaScript デモ。](controls-purejsgame.png)
+
+この例は [end3r.github.io/JavaScript-Game-Controls](https://end3r.github.io/JavaScript-Game-Controls/) でオンラインで動作しているのを見ることができ、完全なソースコードは [github.com/end3r/JavaScript-Game-Controls](https://github.com/end3r/JavaScript-Game-Controls/) で入手できます。
+
+## Phaser アプローチ
+
+前述したように、すべてを独自に記述することもできますが、Phaser のようなフレームワークの組み込み関数を利用することもできます。これにより、開発がはるかに高速になります。ブラウザーの実装の違いなど、すべてのエッジケースはフレームワークによって処理されるため、実行したい実際のタスクに集中できます。
+
+### マウス
+
+ゲームでのマウスのインタラクションは、ボタンのクリックに焦点を当てています。Phaser では、作成するボタンは、モバイルでのタッチでもデスクトップでのクリックでも、あらゆる種類の入力を受け取ります。そのため、[モバイルタッチ制御](/ja/docs/Games/Techniques/Control_mechanisms/Mobile_touch)の記事で示されているようにボタンをすでに実装している場合、デスクトップでも箱から出してすぐに機能します。
+
+```js
+const buttonEnclave = this.add.button(
+  10,
+  10,
+  "logo-enclave",
+  this.clickEnclave,
+  this,
+);
+```
+
+ボタンは画面の左上隅から 10 ピクセルの位置に配置され、`logo-enclave` 画像を使用し、クリックされると `clickEnclave()` 関数を実行します。ボタンに直接アクションを割り当てることができます。
+
+```js
+this.buttonShoot = this.add.button(
+  this.world.width * 0.5,
+  0,
+  "button-alpha",
+  null,
+  this,
+);
+this.buttonShoot.onInputDown.add(this.shootingPressed, this);
+this.buttonShoot.onInputUp.add(this.shootingReleased, this);
+```
+
+射撃に使用されるボタンは、モバイルとデスクトップの両方のアプローチで完璧に機能します。
+
+マウスのカーソルの位置を画面上で使用したい場合は、`this.game.input.mousePointer` を使用して実行できます。画面の右半分がマウスでクリックされたときに弾丸を撃ちたいとしましょう。次のようになります。
+
+```js
+if (this.game.input.mousePointer.isDown) {
+  if (this.game.input.mousePointer.x > this.world.width * 0.5) {
+    // 撃つ
+  }
+}
+```
+
+押されているマウスボタンを区別したい場合は、選択できるデフォルトが 3 つあります。
+
+```js
+this.game.input.mousePointer.leftButton.isDown;
+this.game.input.mousePointer.middleButton.isDown;
+this.game.input.mousePointer.rightButton.isDown;
+```
+
+モバイルタッチインタラクションのサポートを維持したい場合は、`mousePointer` の代わりに `activePointer` を使用する方が、プラットフォームに依存しない入力に適しています。
+
+### キーボード
+
+ゲーム全体をキーボードだけで制御でき、他には何も必要ありません。組み込みの `this.game.input.keyboard` オブジェクトはキーボードからの入力を管理し、`addKey()` や `isDown()` などの[いくつかの便利なメソッド](https://phaser.io/docs/2.6.1/Phaser.Keyboard.html#methods)があります。また、利用可能なすべてのキーボードキーを含む [Phaser.KeyCode](https://phaser.io/docs/2.6.1/Phaser.KeyCode.html#members) オブジェクトもあります。
+
+![ゲーム内で利用可能な Phaser キーコードの完全なリスト。](controls-keycodes.png)
+
+ゲームのメインメニューでは、プレイを開始する追加の方法を追加できます。スタートボタンをクリックして実行できますが、<kbd>Enter</kbd> キーを使用して同じことを実行できます。
+
+```js
+const keyEnter = this.game.input.keyboard.addKey(Phaser.KeyCode.ENTER);
+keyEnter.onDown.add(this.clickStart, this);
+```
+
+`addKey()` を使用して、`Phaser.KeyCode` オブジェクトが提供する任意のキーを追加できます。`onDown()` 関数は、<kbd>Enter</kbd> キーが押されるたびに実行されます。新しいゲームを開始する `clickStart()` メソッドを起動します。
+
+マウスを使用せずにデスクトップでゲームをプレイするオプションを提供すると便利です。そうすれば、キーボードから手を離す必要がありません。
+
+### ゲームの制御
+
+Phaser で構築されたゲームでキーボード入力をサポートするには、`create()` 関数で `createCursorKeys()` 関数を使用して基本的なカーソルキーを有効にします。
+
+```js
+this.cursors = this.input.keyboard.createCursorKeys();
+```
+
+これにより、4 つの方向矢印キーが作成されます。
+
+```js
+this.cursors.left;
+this.cursors.right;
+this.cursors.up;
+this.cursors.down;
+```
+
+独自にキーを定義し、代替の <kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> 制御メカニズムを提供することもできます。例えば：
+
+```js
+this.keyLeft = this.input.keyboard.addKey(Phaser.KeyCode.A);
+this.keyRight = this.input.keyboard.addKey(Phaser.KeyCode.D);
+this.keyUp = this.input.keyboard.addKey(Phaser.KeyCode.W);
+this.keyDown = this.input.keyboard.addKey(Phaser.KeyCode.S);
+```
+
+カーソルと <kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> キーの両方をサポートするには、次のようにする必要があります。
+
+```js
+if (this.cursors.left.isDown || this.keyLeft.isDown) {
+  // 左に移動
+} else if (this.cursors.right.isDown || this.keyRight.isDown) {
+  // 右に移動
+}
+
+if (this.cursors.up.isDown || this.keyUp.isDown) {
+  // 上に移動
+} else if (this.cursors.down.isDown || this.keyDown.isDown) {
+  // 下に移動
+}
+```
+
+`update()` 関数で、2 つの移動キーオプションのいずれかを使用して、プレイヤーの船を任意の方向に移動できるようになりました。
+
+射撃制御の代替も提供できます。カーソルキーの場合、自然な射撃ボタンはキーボードの反対側にあるため、プレイヤーは他の手を使用できます。例えば <kbd>X</kbd> キーです。<kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> キーの場合、スペースバーにすることができます。
+
+```js
+this.keyFire1 = this.input.keyboard.addKey(Phaser.KeyCode.X);
+this.keyFire2 = this.input.keyboard.addKey(Phaser.KeyCode.SPACEBAR);
+```
+
+`update()` 関数で、各フレームでこれら 2 つのいずれかが押されたかどうかを簡単に確認できます。
+
+```js
+if (this.keyFire1.isDown || this.keyFire2.isDown) {
+  // 武器を発射
+}
+```
+
+はいの場合、弾丸を撃つ時間です！
+
+秘密のチートボタンを定義することもできます。
+
+```js
+this.keyCheat = this.input.keyboard.addKey(Phaser.KeyCode.C);
+```
+
+次に、`update()` 関数で、<kbd>C</kbd> が押されるたびに次のようにします。
+
+```js
+if (this.keyCheat.isDown) {
+  this.player.health = this.player.maxHealth;
+}
+```
+
+プレイヤーの体力を最大に設定できます。覚えておいてください：これは秘密なので、_誰にも言わないでください_！
+
+### プレイ方法
+
+制御を実装したので、プレイヤーにゲームを制御するオプションについて通知する必要があります。そうでなければ、彼らはそれらについて知らないでしょう！ゲームで船を制御するさまざまな方法が表示されるプレイ方法画面を表示する場合、すべてをすべての人に表示する代わりに、ゲームがデスクトップまたはモバイルで起動されているかどうかを検出し、デバイスに適した制御のみを表示できます。
+
+```js
+if (this.game.device.desktop) {
+  moveText = "Arrow keys or WASD to move";
+  shootText = "X or Space to shoot";
+} else {
+  moveText = "Tap and hold to move";
+  shootText = "Tap to shoot";
+}
+```
+
+ゲームがデスクトップで実行されている場合、カーソルと <kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> キーのメッセージが表示されます。そうでない場合は、モバイルタッチ制御メッセージが表示されます。
+
+![キーボードとマウスで制御できるプレイヤーの船（背景に星）のプレイ方法画面、表示されているメッセージ：「矢印キーまたは WASD で移動」および「X またはスペースで射撃」。](controls-howtoplay.png)
+
+プレイ方法画面をスキップするには、任意のキーが押されるのをリッスンして先に進むことができます。
+
+```js
+this.input.keyboard.onDownCallback = function () {
+  if (this.stateStatus === "intro") {
+    this.hideIntro();
+  }
+};
+```
+
+これにより、イントロが非表示になり、これだけのために別の新しいキー制御を設定することなく、実際のゲームが開始されます。
+
+### 一時停止とゲームオーバー画面
+
+ゲームをキーボードで完全にプレイできるようにするには、一時停止とゲームオーバー画面からメインメニューに戻る、プレイを続ける、またはゲームを再開できる必要があります。以前とまったく同じように、キーコードをキャプチャしてアクションを実行することで実行できます。例えば、`Phaser.KeyCode.Backspace` または `Phaser.KeyCode.Delete` を指定することで、`Delete/Backspace` ボタンが押されたときに発火するアクションをフックできます。
+
+## まとめ
+
+タッチ、キーボード、マウスの制御を扱いました。次に、[Gamepad API](/ja/docs/Web/API/Gamepad_API) を使用してコンソールゲームパッドで制御されるようにゲームを設定する方法を見ていきましょう。
+
+{{PreviousMenuNext("Games/Techniques/Control_mechanisms/Mobile_touch", "Games/Techniques/Control_mechanisms/Desktop_with_gamepad", "Games/Techniques/Control_mechanisms")}}

--- a/files/ja/games/techniques/control_mechanisms/mobile_touch/index.md
+++ b/files/ja/games/techniques/control_mechanisms/mobile_touch/index.md
@@ -1,0 +1,190 @@
+---
+title: モバイルタッチ制御
+slug: Games/Techniques/Control_mechanisms/Mobile_touch
+l10n:
+  sourceCommit: 0f41789370f1744c3d77efb697991d514a32b6c6
+---
+
+{{NextMenu("Games/Techniques/Control_mechanisms/Desktop_with_mouse_and_keyboard", "Games/Techniques/Control_mechanisms")}}
+
+モバイルゲームの未来は間違いなくウェブであり、多くの開発者はゲーム開発プロセスで[モバイルファースト](/ja/docs/Glossary/Mobile_First)アプローチを選択しています。現代の世界では、これは一般的にタッチ制御の実装も含まれます。このチュートリアルでは、HTML ゲームにモバイル制御を実装し、モバイルタッチ対応デバイスでプレイを楽しむ方法を説明します。
+
+> [!NOTE]
+> ゲーム [Captain Rogers: Battle at Andromeda](https://rogers2.enclavegames.com/demo/) は Phaser で構築されており、制御の管理は Phaser ベースですが、純粋な JavaScript でも実行できます。Phaser を使用する良い点は、より高速な開発のためのヘルパー変数と関数を提供することですが、どのアプローチを選択するかは完全にあなた次第です。
+
+## 純粋な JavaScript アプローチ
+
+タッチイベントを独自に実装できます。イベントリスナーを設定し、関連する関数を割り当てることは非常に簡単です。
+
+```js
+const el = document.querySelector("canvas");
+el.addEventListener("touchstart", handleStart);
+el.addEventListener("touchmove", handleMove);
+el.addEventListener("touchend", handleEnd);
+el.addEventListener("touchcancel", handleCancel);
+```
+
+このようにして、モバイル画面でゲームの {{htmlelement("canvas")}} にタッチするとイベントが発行され、ゲームを好きなように操作できます（例えば、宇宙船を動かすなど）。イベントは次のとおりです。
+
+- [touchstart](/ja/docs/Web/API/Element/touchstart_event) は、ユーザーが画面に指を置いたときに発行されます。
+- [touchmove](/ja/docs/Web/API/Element/touchmove_event) は、画面にタッチしながら指を動かしたときに発行されます。
+- [touchend](/ja/docs/Web/API/Element/touchend_event) は、ユーザーが画面へのタッチを停止したときに発行されます。
+- [touchcancel](/ja/docs/Web/API/Element/touchcancel_event) は、タッチがキャンセルされたとき、例えばユーザーが指を画面の外に移動したときに発行されます。
+
+> [!NOTE]
+> [タッチイベント](/ja/docs/Web/API/Touch_events)のリファレンス記事には、より多くの例と情報が記載されています。
+
+### 純粋な JavaScript デモ
+
+[GitHub で利用可能な小さなデモ](https://github.com/end3r/JavaScript-Game-Controls/)にモバイルサポートを実装して、モバイルデバイスで画面にタッチしてプレイヤーの船を動かせるようにしましょう。
+
+2 つのイベント `touchstart` と `touchmove` を使用し、両方とも 1 つの関数で処理します。なぜでしょうか？`touchHandler` 関数は船の位置に適切な変数を割り当てるため、プレイヤーが画面にタッチしても動かさない場合（`touchstart`）と、画面上で指を動かす場合（`touchmove`）の両方のケースで使用できます。
+
+```js
+document.addEventListener("touchstart", touchHandler);
+document.addEventListener("touchmove", touchHandler);
+```
+
+`touchHandler` 関数は次のようになります。
+
+```js
+function touchHandler(e) {
+  if (e.touches) {
+    playerX = e.touches[0].pageX - canvas.offsetLeft - playerWidth / 2;
+    playerY = e.touches[0].pageY - canvas.offsetTop - playerHeight / 2;
+    output.textContent = `Touch:\nx: ${playerX}, y: ${playerY}`;
+    e.preventDefault();
+  }
+}
+```
+
+タッチが発生した場合（`touches` オブジェクトが空でない場合）、そのオブジェクトに必要なすべての情報があります。最初のタッチ（`e.touches[0]`、この例はマルチタッチ対応ではありません）を取得し、`pageX` と `pageY` 変数を抽出し、Canvas のオフセット（Canvas と画面の端との距離）とプレイヤーの幅と高さの半分を引いて、画面上のプレイヤーの船の位置を設定できます。
+
+![プレイヤーの船のタッチ制御、x と y の位置の出力が表示されています。](controls-touch.png)
+
+正しく動作しているかどうかを確認するために、`output` 要素を使用して `x` と `y` の位置を出力できます。`preventDefault()` 関数は、ブラウザーの移動を防ぐために必要です。これがないと、デフォルトの動作が発生し、Canvas がページの周りにドラッグされ、ブラウザーのスクロールバーが表示されて乱雑に見えます。
+
+## Phaser でのタッチイベント
+
+独自に実行する必要はありません。Phaser のようなフレームワークは、タッチイベントを管理するシステムを提供します。[タッチイベントの管理](https://phaser.io/docs/2.6.1/Phaser.Touch.html)を参照してください。
+
+### ポインターの理論
+
+[ポインター](https://phaser.io/docs/2.6.1/Phaser.Pointer.html)は、タッチスクリーン上の単一の指を表します。Phaser はデフォルトで 2 つのポインターを開始するため、2 本の指が同時にアクションを実行できます。Captain Rogers はシンプルなゲームです。2 本の指で制御でき、左の指が船を動かし、右の指が船の銃を制御します。マルチタッチやジェスチャーはありません。すべてが単一のポインター入力で処理されます。
+
+`this.game.input.addPointer` を使用してゲームにポインターを追加できます。最大 10 個のポインターを同時に管理できます。最近使用されたポインターは `this.game.input.activePointer` オブジェクトで利用できます。画面上で最近アクティブな指です。
+
+特定のポインターにアクセスする必要がある場合は、`this.game.input.pointer1`、`this.game.input.pointer2` などですべて利用できます。これらは動的に割り当てられるため、画面に 3 本の指を置くと、`pointer1`、`pointer2`、`pointer3` がアクティブになります。例えば 2 番目の指を削除しても、他の 2 つには影響せず、再度設定すると、最初に利用可能なプロパティが使用されるため、`pointer2` が再度使用されます。
+
+最近アクティブなポインターの座標は、`this.game.input.x` と `this.game.input.y` 変数を介して素早く取得できます。
+
+### 入力イベント
+
+ポインターを直接使用する代わりに、`this.game.input` イベント（`onDown`、`onUp`、`onTap`、`onHold` など）をリッスンすることもできます。
+
+```js
+this.game.input.onDown.add(itemTouched, this);
+
+function itemTouched(pointer) {
+  // 何かを実行
+}
+```
+
+`itemTouched()` 関数は、画面にタッチして `onDown` イベントがディスパッチされたときに実行されます。`pointer` 変数には、イベントをアクティブにしたポインターに関する情報が含まれます。
+
+このアプローチは、一般的に利用可能な `this.game.input` オブジェクトを使用しますが、スプライトやボタンなどのゲームオブジェクトで `onInputOver`、`onInputOut`、`onInputDown`、`onInputUp`、`onDragStart`、`onDragStop` を使用してアクションを検出することもできます。
+
+```js
+this.button.events.onInputOver.add(itemTouched, this);
+
+function itemTouched(button, pointer) {
+  // 何かを実行
+}
+```
+
+このようにして、プレイヤーの船など、ゲーム内の任意のオブジェクトにイベントをアタッチし、ユーザーが実行するアクションに反応できます。
+
+Phaser を使用するもう 1 つの利点は、作成するボタンがモバイルでのタッチでもデスクトップでのクリックでも、あらゆる種類の入力を受け取ることです。フレームワークがバックグラウンドでこれを処理します。
+
+### 実装
+
+ユーザー入力をリッスンするインタラクティブなオブジェクトを追加する最も簡単な方法は、ボタンを作成することです。
+
+```js
+const buttonEnclave = this.add.button(
+  10,
+  10,
+  "logo-enclave",
+  this.clickEnclave,
+  this,
+);
+```
+
+これは `MainMenu` 状態で形成されます。画面の左上隅から 10 ピクセルの位置に配置され、`logo-enclave` 画像を使用し、タッチされると `clickEnclave()` 関数を実行します。これはモバイルとデスクトップの両方で箱から出してすぐに機能します。メインメニューにはいくつかのボタンがあり、ゲームを開始するボタンも含まれています。
+
+実際のゲームプレイでは、より多くのボタンを作成して小さなモバイル画面をそれらで覆う代わりに、少し異なるものを使用できます。特定のアクションに応答する見えない領域を作成します。デザインの観点から、画面の半分をボタン画像で覆うことなく、アクティビティのフィールドを大きくする方が良いです。例えば、画面の右側をタップすると武器が発射されます。
+
+```js
+this.buttonShoot = this.add.button(
+  this.world.width * 0.5,
+  0,
+  "button-alpha",
+  null,
+  this,
+);
+this.buttonShoot.onInputDown.add(this.goShootPressed, this);
+this.buttonShoot.onInputUp.add(this.goShootReleased, this);
+```
+
+上記のコードは、画面の右半分をカバーする透明な画像を使用して新しいボタンを作成します。より複雑なアクションを実行したい場合は、入力ダウンと入力アップで個別に関数を割り当てることができますが、このゲームでは画面の右側にタッチすると右に弾丸が発射されます。これがこのケースで必要なすべてです。
+
+プレイヤーの移動は、4 つの方向ボタンを作成することで管理できますが、タッチスクリーンの利点を活用して、プレイヤーの船をドラッグすることもできます。
+
+```js
+const player = this.game.add.sprite(30, 30, "ship");
+player.inputEnabled = true;
+player.input.enableDrag();
+player.events.onDragStart.add(onDragStart, this);
+player.events.onDragStop.add(onDragStop, this);
+
+function onDragStart(sprite, pointer) {
+  // ドラッグ中に何かを実行
+}
+```
+
+船を引っ張って、その間に何かを実行し、ドラッグが停止したときに反応できます。Phaser でのドラッグは、有効にすると箱から出してすぐに機能します。スプライトの位置を手動で設定する必要はないため、`onDragStart()` 関数を空のままにするか、デバッグ出力を配置して正しく動作しているかどうかを確認できます。`pointer` 要素には、ドラッグされた要素の現在の位置を格納する `x` と `y` 変数が含まれています。
+
+### 専用プラグイン
+
+仮想ゲームパッドやジョイスティックなど、さまざまな方法でタッチイベントを処理し、UI コントロールをレンダリングする専用プラグインを使用できます。
+仮想ゲームパッドとジョイスティックを使用するプラグインの例を次に示します。
+
+- [phaser-plugin-virtual-gamepad](https://github.com/ShawnHymel/phaser-plugin-virtual-gamepad) (Phaser 2)
+- [Virtual joystick](https://rexrainbow.github.io/phaser3-rex-notes/docs/site/virtualjoystick/) (Phaser 3)
+
+仮想ゲームパッドのような基本的なプラグインの場合、スクリプトをダウンロードしてページで利用できるようにすることができます。
+
+```html
+<script src="js/phaser.min.js"></script>
+<!-- https://github.com/ShawnHymel/phaser-plugin-virtual-gamepad -->
+<script src="js/phaser-plugin-virtual-gamepad.js"></script>
+```
+
+次に、スクリプトに含めて、次のスニペットと同様に使用できます。
+
+```js
+// Phaser 2 ゲームに VirtualGamepad プラグインを追加
+this.gamepad = this.game.plugins.add(Phaser.Plugin.VirtualGamepad);
+// ゲームにジョイスティックを追加
+this.joystick = this.gamepad.addJoystick(100, 420, 1.2, "gamepad");
+// ゲームにボタンを追加
+this.button = this.gamepad.addButton(400, 420, 1.0, "gamepad");
+```
+
+詳細については、[Phaser プラグインの非公式カタログ](https://phaserplugins.com/)を参照して、ニーズに合うものがあるかどうかを確認してください。
+
+## まとめ
+
+これでモバイル用のタッチ制御の追加について説明しました。次の記事では、キーボードとマウスのサポートを追加する方法を見ていきます。
+
+{{NextMenu("Games/Techniques/Control_mechanisms/Desktop_with_mouse_and_keyboard", "Games/Techniques/Control_mechanisms")}}

--- a/files/ja/games/techniques/control_mechanisms/other/index.md
+++ b/files/ja/games/techniques/control_mechanisms/other/index.md
@@ -1,0 +1,188 @@
+---
+title: 型破りな制御
+slug: Games/Techniques/Control_mechanisms/Other
+l10n:
+  sourceCommit: 0f41789370f1744c3d77efb697991d514a32b6c6
+---
+
+{{PreviousMenu("Games/Techniques/Control_mechanisms/Desktop_with_gamepad", "Games/Techniques/Control_mechanisms")}}
+
+ゲームにさまざまな制御メカニズムを持つことは、より幅広いオーディエンスにリーチするのに役立ちます。モバイルとデスクトップの制御を実装することは必須であり、ゲームパッド制御はその追加の体験を提供します。しかし、さらに進むことを想像してみてください。この記事では、ウェブゲームを制御するさまざまな型破りな方法を探求します。いくつかは他のものよりも型破りです。
+
+## TV リモコン
+
+TV 画面でゲームをプレイすることは、必ずしもコンソールを通じて行う必要はありません。デスクトップコンピューターではすでに Gamepad API が動作しているため、体験を模倣できますが、さらに進むことができます。最新のスマート TV は HTML ゲームを処理できます。なぜなら、ゲームプラットフォームとして使用できる組み込みブラウザーがあるためです。スマート TV にはリモコンが付属しており、使い方を知っていればゲームの制御に使用できます。
+
+[Captain Rogers: Battle at Andromeda](https://rogers2.enclavegames.com/demo/) の最初のデモは、巨大な TV で動作するように調整されました。興味深いことに、最初の Captain Rogers ゲーム（Asteroid Belt of Sirius）は、Firefox OS を実行するローエンド、小画面、安価なスマートフォン向けに最適化されていたため、3 年間でどれだけの違いがあるかがわかります。[Building games for Firefox OS TV](https://hacks.mozilla.org/2016/01/building-games-for-firefox-os-tv/) Hacks の投稿で全体のストーリーを読むことができます。
+
+![ゲーム Captain Rogers: Battle at Andromeda 用の Panasonic TV リモコン。](controls-tvremote.png)
+
+TV リモコンを使用してゲームを制御することは、驚くほど簡単でした。コントローラーによって発行されるイベントは従来のキーボードキーをエミュレートしているためです。Captain Rogers にはすでにキーボード制御が実装されていました。
+
+```js
+this.cursors = this.input.keyboard.createCursorKeys();
+// …
+if (this.cursors.right.isDown) {
+  // プレイヤーを右に移動
+}
+```
+
+これはそのまま動作します。カーソルはキーボードの 4 つの方向矢印キーであり、これらはリモコンの矢印キーとまったく同じキーコードを持っています。他のリモコンキーのコードをどのように知るのでしょうか？コンソールに応答を出力することで確認できます。
+
+```js
+window.addEventListener("keydown", (event) => {
+  console.log(event.keyCode);
+});
+```
+
+リモコンで押されたすべてのキーは、コンソールにキーコードを表示します。Firefox OS を実行している Panasonic TV で作業している場合は、以下に示す便利なチートシートを確認することもできます。
+
+![Panasonic TV のリモコンキーコード。](controls-tvkeys.png)
+
+状態間の移動、新しいゲームの開始、船の制御と爆破、ゲームの一時停止と再起動を追加できます。必要なのは、キー押下をチェックすることだけです。
+
+```js
+window.addEventListener("keydown", (event) => {
+  switch (event.keyCode) {
+    case 8: {
+      // ゲームを一時停止
+      break;
+    }
+    case 588: {
+      // 爆弾を爆発させる
+      break;
+    }
+    // …
+  }
+});
+```
+
+[このビデオ](https://www.youtube.com/watch?v=Bh11sP0bcTY)を見ることで、実際の動作を確認できます。
+
+## Leap Motion
+
+手だけでゲームを制御することを考えたことはありますか？[Leap Motion](https://www.ultraleap.com/) を使用すれば可能です。これは、ゲームやアプリ用のイマーシブコントローラーです。
+
+Leap Motion は、VR ヘッドセットとの非常に優れた統合により、ますます人気が高まっています。Leap Motion を取り付けた Oculus Rift で [Rainbow Membrane](https://mozilla.github.io/rainbow/) をデモすることは、世界中の会議でデモブースを訪れた JavaScript 開発者によって、最高の WebVR 体験の 1 つに選ばれました。
+
+仮想インターフェイスに最適であるだけでなく、カジュアルな 2D ゲーム体験にも使用できます。手だけですべてを行うのは非常に難しいですが、シンプルな Captain Roger のゲームプレイ（船の操縦と弾丸の発射）には完全に実行可能です。
+
+コンピューターで Leap Motion を動作させるには、まず [docs.ultraleap.com](https://docs.ultraleap.com/hand-tracking/getting-started.html#installation-guides) の手順に従ってインストールする必要があります。すべてがインストールされ、コントローラーがコンピューターに接続されたら、[小さなデモ](https://github.com/end3r/JavaScript-Game-Controls/)でのサポートの実装に進むことができます。まず、`https://js.leapmotion.com/leap-0.6.4.min.js` を指す `url` を持つ `<script>` タグを追加し、診断情報を出力するために閉じる `</body>` タグの直前に `<div id="output"></div>` を追加します。
+
+コードが動作するためには、いくつかのヘルパー変数が必要です。ラジアンから度を計算する目的のもの、コントローラーの上で手が傾いている水平および垂直の度数を保持する 2 つ、その傾きのしきい値のもの、手のグラブステータスの状態のものです。次に、キーボードとマウスのすべてのイベントリスナーの後、`draw` メソッドの前にこれらの行を追加します。
+
+```js
+const toDegrees = 1 / (Math.PI / 180);
+let horizontalDegree = 0;
+let verticalDegree = 0;
+const degreeThreshold = 30;
+let grabStrength = 0;
+```
+
+その直後に、Leap の `loop` メソッドを使用して、すべてのフレームで `hand` 変数に保持されている情報を取得します。
+
+```js
+Leap.loop({
+  hand(hand) {
+    horizontalDegree = Math.round(hand.roll() * toDegrees);
+    verticalDegree = Math.round(hand.pitch() * toDegrees);
+    grabStrength = hand.grabStrength;
+    output.innerText = `Leap Motion:
+  roll: ${horizontalDegree}°
+  pitch: ${verticalDegree}°
+  strength: ${grabStrength}
+`;
+  },
+});
+```
+
+上記のコードは、後で使用する `horizontalDegree`、`verticalDegree`、`grabStrength` の値を計算して割り当て、HTML に出力して実際の値を確認できるようにします。これらの変数が最新の状態になったら、`draw()` 関数で使用して船を移動できます。
+
+```js
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  // …
+
+  if (horizontalDegree > degreeThreshold) {
+    playerX -= 5;
+  } else if (horizontalDegree < -degreeThreshold) {
+    playerX += 5;
+  }
+  if (verticalDegree > degreeThreshold) {
+    playerY += 5;
+  } else if (verticalDegree < -degreeThreshold) {
+    playerY -= 5;
+  }
+  if (grabStrength === 1) {
+    alert("BOOM!");
+  }
+
+  ctx.drawImage(img, playerX, playerY);
+  requestAnimationFrame(draw);
+}
+```
+
+`horizontalDegree` 値が `degreeThreshold`（この場合は 30）より大きい場合、船はすべてのフレームで左に 5 ピクセル移動します。その値がしきい値の負の値よりも低い場合、船は右に移動します。上下の移動も同じように機能します。最後の値は `grabStrength` で、0 から 1 の間の浮動小数点数です。1 に達すると（拳が完全に握られると）、今のところアラートが表示されます（完全なゲームでは、これを射撃ロジックに置き換えることができます）。
+
+![ゲームでの Leap Motion コントローラーのサポート。roll、pitch、strength の可視出力付き。](controls-leapmotion.png)
+
+以上です。JavaScript での動作する Leap Motion の例に必要なものはすべてここにあります。`hand` のプロパティを探索し、ゲーム内で好きな動作を実装できます。
+
+## ドップラー効果
+
+[ドップラー効果を使用したモーション検出](https://danielrapp.github.io/doppler/)に関する非常に興味深い記事があります。これは、手を振ることとマイクを使用することを組み合わせたものです。今回は、音波が物体に跳ね返ってマイクに戻ることを検出することです。
+
+![ハンドジェスチャーを使用してラップトップ上の記事のスクロールを制御する方法としてのドップラー効果。](controls-doppler.png)
+
+跳ね返った音の周波数が元の周波数からシフトしている場合、その物体の動きが発生したことを検出できます。そうすれば、組み込みマイクだけを使用して手の動きを検出できます！
+
+これは、Daniel Rapp によって作成された[小さなライブラリ](https://github.com/DanielRapp/doppler)を使用して実現できます。2 つの周波数の差を計算するのと同じくらい簡単です。
+
+```js
+doppler.init((bandwidth) => {
+  const diff = bandwidth.left - bandwidth.right;
+});
+```
+
+`diff` は、手の初期位置と最終位置の差になります。
+
+このアプローチでは、ゲームパッドや Leap Motion を使用するほどの完全な柔軟性は得られませんが、確かに興味深い型破りな代替手段です。ハンズフリーでページをスクロールしたり、テルミンを演奏したりするために使用できますが、正しく実装されていれば、画面上で船を上下に移動するのにも十分なはずです。
+
+## Makey Makey
+
+完全にクレイジーになりたい場合は、[Makey Makey](https://makeymakey.com/) を使用できます。これは、何でもコントローラーに変えることができるボードです。現実世界の導電性オブジェクトをコンピューターに接続し、タッチインターフェイスとして使用することがすべてです。
+
+![Makey Makey を使用してバナナピアノを制御。](controls-banana.png)
+
+[バナナピアノのビデオ](https://www.youtube.com/watch?v=_DWQ6ce2Ags)をチェックし、必要なすべての情報については[クイックスタートガイド](https://learn.sparkfun.com/tutorials/makey-makey-quickstart-guide)を必ず訪問してください。
+
+Makey Makey ボードに触発された Makey Button 機能をサポートする Cylon.js さえあるため、Arduino または Raspberry Pi での実験に人気のある Cylon ロボティクスフレームワークを使用できます。ボードを接続して使用すると、次のようになります。
+
+```js
+const Cylon = require("cylon");
+
+Cylon.robot({
+  connections: {
+    arduino: { adaptor: "firmata", port: "/dev/ttyACM0" },
+  },
+  devices: {
+    makey: { driver: "makey-button", pin: 2 },
+  },
+  work(my) {
+    my.makey.on("push", () => {
+      console.log("Button pushed!");
+    });
+  },
+}).start();
+```
+
+説明にあるように、この GPIO ドライバーを使用すると、Arduino または Raspberry Pi のデジタルピンに 10 MOhm 抵抗を接続して、バナナ、粘土、または描画可能な回路でロボットを制御できます。
+
+## まとめ
+
+実験を楽しんでいただけたことを願っています。他の人が興味を持つと思われる他のものがある場合は、ここに詳細を追加してください。
+
+そして、ゲーム作りを楽しむことを忘れないでください！
+
+{{PreviousMenu("Games/Techniques/Control_mechanisms/Desktop_with_gamepad", "Games/Techniques/Control_mechanisms")}}


### PR DESCRIPTION
### Summary
This PR adds Japanese translations for 4 game control mechanisms documentation pages.

### Pages translated:
- `games/techniques/control_mechanisms/mobile_touch/index.md`
- `games/techniques/control_mechanisms/desktop_with_mouse_and_keyboard/index.md`
- `games/techniques/control_mechanisms/desktop_with_gamepad/index.md`
- `games/techniques/control_mechanisms/other/index.md`

### Details:
- Translations follow existing Japanese MDN terminology and style
- All code comments translated to Japanese
- Navigation links properly configured
- Formatted with Prettier