### PR TITLE
fix(ja): clarify debounce behavior in search event description

### DIFF
--- a/files/ja/web/api/htmlinputelement/search_event/index.md
+++ b/files/ja/web/api/htmlinputelement/search_event/index.md
@@ -10,7 +10,7 @@ l10n:
 
 **`search`** イベントは、 {{HTMLElement("input")}} 要素の `type="search"` にて検索が開始されたときに発生します。
 
-検索を開始する方法はいくつかあり、例えば、 {{HTMLElement("input")}} にフォーカスがある時に <kbd>Enter</kbd> を押したり、[`incremental`](/ja/docs/Web/HTML/Reference/Elements/input#attr-incremental) 属性が存在すれば、最も新しいキー入力から UA 定義のタイムアウト時間が経過してから検索が開始されます（新しくキー入力をするとタイムアウトがリセットされるので、イベントが繰り返して発生します）。
+検索を開始する方法はいくつかあり、例えば、 {{HTMLElement("input")}} にフォーカスがある時に <kbd>Enter</kbd> を押したり、[`incremental`](/ja/docs/Web/HTML/Reference/Elements/input#attr-incremental) 属性が存在すれば、最も新しいキー入力から UA 定義のタイムアウト時間が経過してから検索が開始されます（新しくキー入力をするとタイムアウトがリセットされるので、新しくキー入力をするとタイムアウトがリセットされるため、イベントの発生はデバウンスされます。つまり、最後の入力から一定時間経過後に1回だけイベントが発生します。）。
 
 現在 UA が `<input type="search">` を実装している方法では、フィールド内をクリアするために追加のコントロールを置きます。このコントロールを使用しても `search` イベントが発生します。この場合、 {{HTMLElement("input")}} 要素の `value` は空文字列になります。
 


### PR DESCRIPTION
### Description

Clarified the behavior of the `search` event in the Japanese documentation to correctly reflect debounce behavior. Updated wording to avoid misinterpretation that the event fires repeatedly.

### Motivation

The previous translation could be misunderstood as the event firing multiple times with each keystroke. However, according to the specification and English documentation, the event is debounced and only fires once after the user stops typing. This change improves accuracy and helps readers better understand the actual behavior.

### Additional details

Reference (English version):
https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/search_event

Reference (Debounce explanation):
https://developer.mozilla.org/en-US/docs/Glossary/Debounce

### Related issues and pull requests

Fixes #30141