### PR TITLE
ci(pr-check-lint_content): run reviewdog in separate workflow

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -1,40 +1,23 @@
-name: Lint and review content files
+name: Lint content
 
 on:
   pull_request:
     paths:
       - .github/workflows/pr-check-lint_content.yml
-  pull_request_target:
-    branches:
-      - main
-    paths:
       - "**/*.md"
 
 permissions:
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  lint-and-review-docs:
-    # do not run on PRs in forks
-    if: github.repository == 'mdn/translated-content'
+  lint:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check if PR reviews can be posted
-        id: permissions
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          BASE_REPO: ${{ github.repository }}
-        run: |
-          if [[ "${EVENT_NAME}" == "pull_request_target" || "${HEAD_REPO}" == "${BASE_REPO}" ]]; then
-            echo "CAN_POST_REVIEWS=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout BASE
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -261,40 +244,30 @@ jobs:
             echo "FILES_MODIFIED=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Setup reviewdog
-        if: (steps.lint-diff.outputs.FILES_MODIFIED == 'true' || steps.markdownlint.outputs.MD_LINT_FAILED == 'true') && steps.permissions.outputs.CAN_POST_REVIEWS == 'true'
-        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1.5.0
-        with:
-          reviewdog_version: latest
-
-      - name: Suggest changes using diff
-        if: steps.lint-diff.outputs.FILES_MODIFIED == 'true' && steps.permissions.outputs.CAN_POST_REVIEWS == 'true'
+      - name: Collect artifact files
+        if: always() && steps.check.outputs.HAS_FILES == 'true'
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TMPFILE=$(mktemp)
-          git diff >"${TMPFILE}"
-          git stash -u && git stash drop
-          reviewdog \
-            -name="mdn-linter" \
-            -f=diff \
-            -f.diff.strip=1 \
-            -filter-mode=diff_context \
-            -reporter=github-pr-review < "${TMPFILE}"
-
-      - name: Add reviews for markdownlint errors
-        if: steps.markdownlint.outputs.MD_LINT_FAILED == 'true' && steps.permissions.outputs.CAN_POST_REVIEWS == 'true'
-        env:
+          FILES_MODIFIED: ${{ steps.lint-diff.outputs.FILES_MODIFIED }}
+          MD_LINT_FAILED: ${{ steps.markdownlint.outputs.MD_LINT_FAILED }}
           MD_LINT_LOG: ${{ steps.markdownlint.outputs.MD_LINT_LOG }}
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "${MD_LINT_LOG}" | \
-            reviewdog \
-            -efm="%f:%l:%c %m" \
-            -efm="%f:%l %m" \
-            -name="markdownlint" \
-            -diff="git diff" \
-            -reporter="github-pr-review"
+          rm -rf lint-results
+          mkdir -p lint-results
+
+          if [[ "$FILES_MODIFIED" == 'true' ]]; then
+            git diff HEAD > lint-results/lint.diff
+          fi
+
+          if [[ "$MD_LINT_FAILED" == 'true' ]]; then
+            echo "$MD_LINT_LOG" > lint-results/markdownlint.log
+          fi
+
+      - name: Upload artifact
+        if: always() && steps.check.outputs.HAS_FILES == 'true' && hashFiles('lint-results/*') != ''
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: lint-results
+          path: lint-results
 
       - name: Fail if any issues pending
         if: steps.lint-diff.outputs.FILES_MODIFIED == 'true' || steps.crlf.outputs.CRLF_FAILED == 'true' || steps.markdownlint.outputs.MD_LINT_FAILED == 'true' || steps.frontmatter.outputs.FM_LINT_FAILED == 'true'

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -18,12 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout BASE
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # explicitly specify base ref to ensure `pull_request` runs
-          # behave the same as `pull_request_target` runs
-          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
       - name: Get changed files
@@ -53,43 +50,6 @@ jobs:
           else
             echo "HAS_FILES=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Checkout HEAD
-        if: steps.check.outputs.HAS_FILES == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: pr_head
-          persist-credentials: false
-
-      - name: Get changed content from HEAD
-        if: steps.check.outputs.HAS_FILES == 'true'
-        run: |
-          git config --global user.email "108879845+mdn-bot@users.noreply.github.com"
-          git config --global user.name "mdn-bot"
-
-          # Remove non-Markdown files from BASE.
-          find files -type f ! -name '*.md' -delete
-          find docs -type f ! -name '*.md' -delete
-          git commit --quiet -m "Remove non-Markdown files from PR base" files docs
-
-          # Remove files from BASE.
-          rm -r files docs *.md
-
-          # Remove everything from HEAD, except Markdown files and the Markdownlint config.
-          find pr_head -type f ! -name '*.md' ! -name '.markdownlint.jsonc' -delete
-
-          # Move Markdown files from HEAD into BASE.
-          mv pr_head/files pr_head/docs pr_head/*.md .
-
-          # Remove HEAD checkout.
-          rm -r pr_head
-
-          # To avoid contents of PR getting into the diff that we are going to generate
-          # after running the linters, here we make a dummy commit.
-          # Note, this commit is not getting pushed.
-          git add .
-          git commit -m "Use Markdown files from PR head" .
 
       - name: Checkout (content)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pr-reviewdog.yml
+++ b/.github/workflows/pr-reviewdog.yml
@@ -1,0 +1,96 @@
+name: PR Reviewdog
+
+on:
+  workflow_run:
+    workflows:
+      - "Lint content"
+    types:
+      - completed
+
+permissions:
+  # Download artifact from lint workflow.
+  actions: read
+  # Post inline review comments via reviewdog.
+  pull-requests: write
+
+jobs:
+  reviewdog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Identify PR
+        id: identify-pr
+        env:
+          BASE_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          PR_NUMBER=$(gh api "repos/$HEAD_REPO/commits/$HEAD_SHA/pulls" \
+            --jq ".[] | select(.base.repo.full_name == \"$BASE_REPO\") | .number")
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Download artifact
+        if: steps.identify-pr.outputs.number
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lint-results
+          path: lint-results
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Check for artifact
+        id: check
+        if: steps.identify-pr.outputs.number && hashFiles('lint-results/') != ''
+        run: echo "HAS_ARTIFACT=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.identify-pr.outputs.number
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: mdn-translated-content
+          ref: main
+          persist-credentials: false
+
+      - name: Setup reviewdog
+        if: steps.check.outputs.HAS_ARTIFACT == 'true'
+        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1.5.0
+        with:
+          reviewdog_version: latest
+
+      - name: Add PR review with suggested changes using `git diff` output
+        if: steps.check.outputs.HAS_ARTIFACT == 'true' && hashFiles('lint-results/lint.diff') != ''
+        working-directory: mdn-translated-content
+        env:
+          CI_PULL_REQUEST: ${{ steps.identify-pr.outputs.number }}
+          CI_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          CI_REPO_OWNER: ${{ github.repository_owner }}
+          CI_REPO_NAME: ${{ github.event.repository.name }}
+          CI_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          env -u GITHUB_ACTIONS reviewdog \
+            -guess \
+            -name="mdn-linter" \
+            -f=diff \
+            -f.diff.strip=1 \
+            -filter-mode=diff_context \
+            -reporter=github-pr-review < ../lint-results/lint.diff
+
+      - name: Add PR review with comments for errors in markdownlint output
+        if: steps.check.outputs.HAS_ARTIFACT == 'true' && hashFiles('lint-results/markdownlint.log') != ''
+        working-directory: mdn-translated-content
+        env:
+          CI_PULL_REQUEST: ${{ steps.identify-pr.outputs.number }}
+          CI_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          CI_REPO_OWNER: ${{ github.repository_owner }}
+          CI_REPO_NAME: ${{ github.event.repository.name }}
+          CI_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          env -u GITHUB_ACTIONS reviewdog \
+            -efm="%f:%l:%c %m" \
+            -efm="%f:%l %m" \
+            -name="markdownlint" \
+            -diff="git diff" \
+            -reporter="github-pr-review" < ../lint-results/markdownlint.log

--- a/.github/workflows/pr-reviewdog.yml
+++ b/.github/workflows/pr-reviewdog.yml
@@ -12,11 +12,27 @@ permissions:
   actions: read
   # Post inline review comments via reviewdog.
   pull-requests: write
+  # Report commit status.
+  statuses: write
 
 jobs:
   reviewdog:
     runs-on: ubuntu-latest
+    env:
+      STATUS_PATH: repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}
+      STATUS_CONTEXT: ${{ github.workflow }}
+      STATUS_TARGET: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
+      - name: Mark status as pending
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "$STATUS_PATH" \
+            -f state=pending \
+            -f context="$STATUS_CONTEXT" \
+            -f description='Running' \
+            -f target_url="$STATUS_TARGET"
+
       - name: Identify PR
         id: identify-pr
         env:
@@ -94,3 +110,25 @@ jobs:
             -name="markdownlint" \
             -diff="git diff" \
             -reporter="github-pr-review" < ../lint-results/markdownlint.log
+
+      - name: Mark status as success
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "$STATUS_PATH" \
+            -f state=success \
+            -f context="$STATUS_CONTEXT" \
+            -f description='Successful' \
+            -f target_url="$STATUS_TARGET"
+
+      - name: Mark status as failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "$STATUS_PATH" \
+            -f state=failure \
+            -f context="$STATUS_CONTEXT" \
+            -f description='Failing' \
+            -f target_url="$STATUS_TARGET"


### PR DESCRIPTION
### Description

- Extracts the reviewdog portion of the `pr-check-lint_content` workflow into a separate `pr-reviewdog` workflow (privileged, with status reporting), by passing diff and Markdownlint log as an artifact.
- Makes the `pr-check-lint_content` workflow unprivileged, and simplifies it by removing now-obsolete safeguards.

### Motivation

- Eliminate risk of code injection.
- Make it easier to simplify the lint workflow in the future.

### Related issues and pull requests

Same as:
- https://github.com/mdn/content/pull/43510
- https://github.com/mdn/translated-content-de/pull/237