### PR TITLE
chore(fr): translation of `Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/with`

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/temporal/plaindate/with/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plaindate/with/index.md
@@ -1,0 +1,78 @@
+---
+title: "Temporal.PlainDate : méthode with()"
+short-title: with()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/with
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La méthode **`with()`** des instances de {{JSxRef("Temporal.PlainDate")}} retourne un nouvel objet `Temporal.PlainDate` représentant cette date avec certains champs remplacés par de nouvelles valeurs. Comme tous les objets `Temporal` sont conçus pour être immuables, cette méthode fonctionne essentiellement comme le setter des champs de la date.
+
+Pour remplacer la propriété {{JSxRef("Temporal/PlainDate/calendarId", "calendarId")}}, utilisez plutôt la méthode {{JSxRef("Temporal/PlainDate/withCalendar", "withCalendar()")}}.
+
+## Syntaxe
+
+```js-nolint
+with(info)
+with(info, options)
+```
+
+### Paramètres
+
+- `info`
+  - : Un objet contenant au moins une des propriétés reconnues par {{JSxRef("Temporal/PlainDate/from", "Temporal.PlainDate.from()")}} (sauf `calendar`)&nbsp;: `day`, `era` et `eraYear`, `month`, `monthCode`, `year`. Les propriétés non définies utilisent les valeurs de la date d'origine. Vous n'avez besoin de fournir qu'un seul de `month` ou `monthCode`, et un seul de `era` et `eraYear` ou `year`, et l'autre sera mis à jour en conséquence.
+- `options` {{Optional_Inline}}
+  - : Un objet contenant la propriété suivante&nbsp;:
+    - `overflow` {{Optional_Inline}}
+      - : Une chaîne de caractères définissant le comportement lorsque un composant de date est hors de portée. Les valeurs possibles sont&nbsp;:
+        - `"constrain"` (par défaut)
+          - : Le composant de date est [contraint](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate#fixer_les_dates_invalides) à la plage valide.
+        - `"reject"`
+          - : Un objet {{JSxRef("RangeError")}} est levé si le composant de date est hors de portée.
+
+### Valeur de retour
+
+Un nouvel objet `Temporal.PlainDate`, où les champs définis dans `info` qui ne sont pas `undefined` sont remplacés par les valeurs correspondantes, et le reste des champs est copié à partir de la date d'origine.
+
+### Exceptions
+
+- {{JSxRef("TypeError")}}
+  - : Levée dans l'un des cas suivants&nbsp;:
+    - `info` n'est pas un objet.
+    - `options` n'est pas un objet ou est `undefined`.
+- {{JSxRef("RangeError")}}
+  - : Levée dans l'un des cas suivants&nbsp;:
+    - Les propriétés fournies qui définissent le même composant sont incohérentes.
+    - Les propriétés non numériques fournies ne sont pas valides&nbsp;; par exemple, si `monthCode` n'est jamais un code de mois valide dans ce calendrier.
+    - Les propriétés numériques fournies sont hors de portée, et `options.overflow` est défini sur `"reject"`.
+    - Le résultat n'est pas dans la [plage représentable](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#dates_représentables), qui est ±(10<sup>8</sup> + 1) jours, soit environ ±273 972,6 ans, à partir de l'époque Unix.
+
+## Exemples
+
+### Utiliser la méthode `with()`
+
+```js
+const date = Temporal.PlainDate.from("2021-07-06");
+const newDate = date.with({ day: date.daysInMonth });
+console.log(newDate.toString()); // 2021-07-31
+const nextDecade = date.with({ year: date.year + 10 });
+console.log(nextDecade.toString()); // 2031-07-06
+```
+
+Pour plus d'exemples, consultez la documentation des propriétés individuelles qui peuvent être définies en utilisant `with()`.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainDate")}}
+- La méthode {{JSxRef("Temporal/PlainDate/withCalendar", "Temporal.PlainDate.prototype.withCalendar()")}}
+- La méthode statique {{JSxRef("Temporal/PlainDate/from", "Temporal.PlainDate.from()")}}
+- La méthode {{JSxRef("Temporal/PlainDate/add", "Temporal.PlainDate.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainDate/subtract", "Temporal.PlainDate.prototype.subtract()")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/with`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_