### PR TITLE
chore(fr): translation of `Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/millisecond`

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/temporal/plaindatetime/millisecond/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plaindatetime/millisecond/index.md
@@ -1,0 +1,41 @@
+---
+title: "Temporal.PlainDateTime : propriété millisecond"
+short-title: millisecond
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/millisecond
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La propriété d'accesseur **`millisecond`** des instances de {{JSxRef("Temporal.PlainDateTime")}} retourne un entier de 0 à 999 représentant le composant milliseconde (10<sup>-3</sup> seconde) de cette heure.
+
+Le mutateur d'accesseur de `millisecond` est `undefined`. Vous ne pouvez pas modifier cette propriété directement. Utilisez la méthode {{JSxRef("Temporal/PlainDateTime/with", "with()")}} pour créer un nouvel objet `Temporal.PlainDateTime` avec la nouvelle valeur souhaitée.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainTime/millisecond", "Temporal.PlainTime.prototype.millisecond")}}.
+
+## Exemples
+
+### Utiliser la propriété `millisecond`
+
+```js
+const dt = Temporal.PlainDateTime.from("2021-07-01T12:34:56.123456789");
+console.log(dt.millisecond); // 123
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainDateTime")}}
+- La méthode {{JSxRef("Temporal/PlainDateTime/with", "Temporal.PlainDateTime.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/PlainDateTime/add", "Temporal.PlainDateTime.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainDateTime/subtract", "Temporal.PlainDateTime.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/PlainDateTime/second", "Temporal.PlainDateTime.prototype.second")}}
+- La propriété {{JSxRef("Temporal/PlainDateTime/microsecond", "Temporal.PlainDateTime.prototype.microsecond")}}
+- La propriété {{JSxRef("Temporal/PlainDateTime/nanosecond", "Temporal.PlainDateTime.prototype.nanosecond")}}
+- La propriété {{JSxRef("Temporal/PlainTime/millisecond", "Temporal.PlainTime.prototype.millisecond")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/millisecond`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_