### PR TITLE
chore(fr): translation of `Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay/valueOf`

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/temporal/plainmonthday/valueof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainmonthday/valueof/index.md
@@ -1,0 +1,69 @@
+---
+title: "Temporal.PlainMonthDay : méthode valueOf()"
+short-title: valueOf()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay/valueOf
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La méthode **`valueOf()`** des instances de {{JSxRef("Temporal.PlainMonthDay")}} lève une {{JSxRef("TypeError")}}, ce qui empêche les instances de `Temporal.PlainMonthDay` d'être [converties implicitement en primitives](/fr/docs/Web/JavaScript/Guide/Data_structures#contrainte_de_primitive) lorsqu'elles sont utilisées dans des opérations arithmétiques ou de comparaison.
+
+## Syntaxe
+
+```js-nolint
+valueOf()
+```
+
+### Paramètres
+
+Aucun.
+
+### Valeur de retour
+
+Aucune.
+
+### Exceptions
+
+- {{JSxRef("TypeError")}}
+  - : Toujours levée.
+
+## Description
+
+Parce que la [conversion en primitive](/fr/docs/Web/JavaScript/Guide/Data_structures#contrainte_de_primitive) et la [conversion en nombre](/fr/docs/Web/JavaScript/Reference/Global_Objects/Number#contrainte_de_nombre) appellent `valueOf()` avant `toString()`, si `valueOf()` est absent, alors une expression comme `monthDay1 > monthDay2` les comparerait implicitement comme des chaînes de caractères, ce qui peut donner des résultats inattendus. En levant une `TypeError`, les instances de `Temporal.PlainMonthDay` empêchent ces conversions implicites. Vous devez les convertir explicitement en chaînes de caractères en utilisant {{JSxRef("Temporal/PlainMonthDay/toString", "Temporal.PlainMonthDay.prototype.toString()")}}.
+
+## Exemples
+
+### Opérations arithmétiques et de comparaison sur `Temporal.PlainMonthDay`
+
+Toutes les opérations arithmétiques et de comparaison sur les instances de `Temporal.PlainMonthDay` doivent utiliser les méthodes dédiées ou les convertir explicitement en primitives.
+
+```js
+const md1 = Temporal.PlainMonthDay.from("01-01");
+const md2 = Temporal.PlainMonthDay.from("07-01");
+md1 > md2; // TypeError: can't convert PlainMonthDay to primitive type
+Temporal.PlainDate.compare(
+  md1.toPlainDate({ year: 2021 }),
+  md2.toPlainDate({ year: 2021 }),
+); // -1
+
+md2 - md1; // TypeError: can't convert PlainMonthDay to primitive type
+md2
+  .toPlainDate({ year: 2021 })
+  .since(md1.toPlainDate({ year: 2021 }))
+  .toString(); // "P181D"
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainMonthDay")}}
+- La méthode {{JSxRef("Temporal/PlainMonthDay/toString", "Temporal.PlainMonthDay.prototype.toString()")}}
+- La méthode {{JSxRef("Temporal/PlainMonthDay/toJSON", "Temporal.PlainMonthDay.prototype.toJSON()")}}
+- La méthode {{JSxRef("Temporal/PlainMonthDay/toLocaleString", "Temporal.PlainMonthDay.prototype.toLocaleString()")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay/valueOf`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_