### PR TITLE
chore(fr): translation of `Temporal.PlainYearMonth`

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/add/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/add/index.md
@@ -1,0 +1,156 @@
+---
+title: "Temporal.PlainYearMonth : méthode add()"
+short-title: add()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/add
+l10n:
+  sourceCommit: 9b86874b5762b52ce0055f58d561004d1a204ad5
+---
+
+La méthode **`add()`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne un nouvel objet `Temporal.PlainYearMonth` représentant cette année et ce mois avancés d'une durée donnée (sous une forme convertible par {{JSxRef("Temporal/Duration/from", "Temporal.Duration.from()")}}).
+
+## Syntaxe
+
+```js-nolint
+add(duration)
+add(duration, options)
+```
+
+### Paramètres
+
+- `duration`
+  - : Une chaîne de caractères, un objet, ou une instance de {{JSxRef("Temporal.Duration")}} représentant la durée à ajouter à ce `PlainYearMonth`. Elle est convertie en `Temporal.Duration` en utilisant le même algorithme que {{JSxRef("Temporal/Duration/from", "Temporal.Duration.from()")}}.
+- `options` {{Optional_Inline}}
+  - : Un objet contenant la propriété suivante&nbsp;:
+    - `overflow` {{Optional_Inline}}
+      - : Une chaîne de caractères définissant le comportement lorsque un composant de date est hors plage. Valeurs possibles&nbsp;:
+        - `"constrain"` (par défaut)
+          - : Le composant de date est [contraint](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate#fixer_les_dates_invalides) à la plage valide.
+        - `"reject"`
+          - : Un objet {{JSxRef("RangeError")}} est levé si le composant de date est hors plage.
+
+### Valeur de retour
+
+Un nouvel objet `Temporal.PlainYearMonth` représentant cette année et ce mois définis par le `PlainYearMonth` d'origine, plus la durée.
+
+### Exceptions
+
+- {{JSxRef("RangeError")}}
+  - : Levée si le résultat n'est pas dans la [plage représentable](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#dates_représentables), qui est ±(10<sup>8</sup> + 1) jours, ou environ ±273 972,6 ans, à partir de l'époque Unix.
+
+## Description
+
+La valeur de `duration` est traitée de la manière suivante&nbsp;:
+
+- Avancer du nombre d'années indiqué, en conservant le même `monthCode`. Si le `monthCode` est invalide dans l'année résultante (impossible pour le calendrier grégorien et ISO 8601, mais possible pour les calendriers avec des mois intercalaires), nous ajustons en fonction de l'option `overflow`&nbsp;: pour `constrain`, nous choisissons un autre mois selon les conventions culturelles des utilisateurs de ce calendrier. Par exemple, comme le mois intercalaire est généralement considéré comme un doublon d'un autre mois, nous pouvons choisir le mois dont il est un doublon.
+- Avancer du nombre de mois indiqué, en ajustant l'année si nécessaire.
+- Pour toutes les unités inférieures à `months` (semaines, jours, heures, minutes, secondes, millisecondes, microsecondes, nanosecondes), elles sont converties en nombre de jours. Tous les calendriers couramment pris en charge utilisent des semaines de longueur fixe, donc le nombre de semaines est simplement converti en nombre de jours. Si la règle est plus complexe, nous pouvons adopter une approche similaire au décalage des mois. Ensuite, nous avançons de ce nombre de jours, en commençant par le premier jour du mois, en ajustant le mois et l'année si nécessaire. Les durées inférieures à la longueur du mois en cours n'ont donc aucun effet.
+
+Le jour de référence interne est ensuite choisi comme étant le premier jour valide du mois, indépendamment du jour de référence d'origine ou du nombre de jours dans la durée. Pour le calendrier grégorien, un dépassement ne peut pas se produire car chaque année a toujours 12 mois, et tout incrément inférieur à un mois est simplement ignoré.
+
+Ajouter une durée est équivalent à [soustraire](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/subtract) sa [négation](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration/negated).
+
+## Exemples
+
+### Ajouter une durée dans le calendrier ISO 8601
+
+```js
+const start = Temporal.PlainYearMonth.from("2021-01");
+const end = start.add({ years: 1, months: 2, weeks: 3, days: 4 });
+console.log(end.toString()); // 2022-03
+
+const end2 = start.add({ years: -1, months: -2, weeks: -3, days: -4 });
+console.log(end2.toString()); // 2019-11
+
+const distance = Temporal.PlainYearMonth.from("2020-01").until("2021-01"); // 366 days
+const end3 = start.add(distance);
+console.log(end3.toString()); // 2022-01
+```
+
+### Ajouter une durée dans un calendrier non ISO
+
+```js
+const start = Temporal.PlainYearMonth.from("2021-02-01[u-ca=chinese]");
+console.log(start.toLocaleString("en-US", { calendar: "chinese" })); // 12/2020
+console.log(start.toString()); // 2021-01-13[u-ca=chinese]
+const end = start.add({ months: 1 });
+console.log(end.toLocaleString("en-US", { calendar: "chinese" })); // 1/2021
+console.log(end.toString()); // 2021-02-12[u-ca=chinese]
+
+// Ajouter un jour supplémentaire n'a aucun effet
+const end2 = start.add({ months: 1, days: 1 });
+console.log(end2.toLocaleString("en-US", { calendar: "chinese" })); // 1/2021
+// Le jour de référence ne change pas, car c'est toujours le premier jour du mois chinois
+console.log(end2.toString()); // 2021-02-12[u-ca=chinese]
+
+// Début dans un mois intercalaire
+const start2 = Temporal.PlainYearMonth.from({
+  year: 5730,
+  monthCode: "M05L",
+  calendar: "hebrew",
+});
+console.log(start2.toLocaleString("en-US", { calendar: "hebrew" })); // Adar I 5730
+// Fin dans un autre mois intercalaire
+const end3 = start2.add({ years: 3 });
+console.log(end3.toLocaleString("en-US", { calendar: "hebrew" })); // Adar I 5733
+```
+
+### Ajouter une durée avec dépassement
+
+Si nous avançons de quelques années et que le mois correspondant est invalide dans cette année, nous ajustons le mois en fonction de l'option `overflow`.
+
+```js
+// Début dans un mois intercalaire
+const start = Temporal.PlainYearMonth.from({
+  year: 5730,
+  monthCode: "M05L",
+  calendar: "hebrew",
+});
+// Les années bissextiles hébraïques se produisent tous les 2 ou 3 ans, et 5731 n'est pas une année bissextile
+const end = start.add({ years: 1 });
+console.log(end.toLocaleString("en-US", { calendar: "hebrew" })); // Adar 5731
+console.log(end.monthCode); // M06
+console.log(end.toString()); // 1971-02-26[u-ca=hebrew]
+
+// Toute addition de mois supplémentaire est basée sur l'année-mois ajustée
+const end2 = start.add({ years: 1, months: 2 });
+console.log(end2.monthCode); // M08
+console.log(end2.toString()); // 1971-04-26[u-ca=hebrew]
+
+// Comparer avec la même addition dans un ordre différent qui ne provoque pas de dépassement :
+const end3 = start.add({ months: 2 }).add({ years: 1 });
+console.log(end3.monthCode); // M07
+console.log(end3.toString()); // 1971-03-27[u-ca=hebrew]
+```
+
+Notez que ce qui suit n'est pas un dépassement, car l'année peut simplement augmenter&nbsp;:
+
+```js
+const start = Temporal.PlainYearMonth.from("2021-01");
+const end = start.add({ months: 100 });
+console.log(end.toString()); // 2029-05
+```
+
+Vous pouvez également générer une erreur si le composant de date est hors de portée&nbsp;:
+
+```js
+const start = Temporal.PlainYearMonth.from({
+  year: 5730,
+  monthCode: "M05L",
+  calendar: "hebrew",
+});
+const end = start.add({ years: 1 }, { overflow: "reject" }); // RangeError: invalid "monthCode" calendar field: M05L
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- L'objet {{JSxRef("Temporal.Duration")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/subtract", "Temporal.PlainYearMonth.prototype.subtract()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/calendarid/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/calendarid/index.md
@@ -1,0 +1,54 @@
+---
+title: "Temporal.PlainYearMonth : propriété calendarId"
+short-title: calendarId
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/calendarId
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La propriété d'accesseur **`calendarId`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne une chaîne de caractères représentant le [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers) utilisé pour interpréter la date ISO 8601 interne.
+
+Voir [`Intl.supportedValuesOf()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#types_de_calendriers_pris_en_charge) pour une liste des types de calendriers couramment pris en charge.
+
+Le mutateur d'accesseur de `calendarId` est `undefined`. Vous ne pouvez pas modifier cette propriété directement. Il n'existe pas de moyen évident de créer un nouvel objet `Temporal.PlainYearMonth` avec un calendrier différent représentant la même année-mois, vous devez donc le convertir d'abord en un objet {{JSxRef("Temporal.PlainDate")}} en utilisant {{JSxRef("Temporal/PlainYearMonth/toPlainDate", "toPlainDate()")}}, changer le calendrier, puis le reconvertir.
+
+## Exemples
+
+### Utiliser la propriété `calendarId`
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-07");
+console.log(ym.calendarId); // "iso8601" ; par défaut
+
+const ym2 = Temporal.PlainYearMonth.from("2021-07-01[u-ca=chinese]");
+console.log(ym2.calendarId); // "chinese"
+```
+
+### Changer la valeur de `calendarId`
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-07");
+const newYM = ym
+  .toPlainDate({ day: 1 })
+  .withCalendar("chinese")
+  .toPlainYearMonth();
+console.log(newYM.year, newYM.monthCode); // 2021 "M05"
+
+const newYM2 = ym
+  .toPlainDate({ day: 31 })
+  .withCalendar("chinese")
+  .toPlainYearMonth();
+console.log(newYM2.year, newYM2.monthCode); // 2021 "M06"
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/compare/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/compare/index.md
@@ -1,0 +1,96 @@
+---
+title: "Temporal.PlainYearMonth : méthode statique compare()"
+short-title: compare()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/compare
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La méthode statique **`Temporal.PlainYearMonth.compare()`** retourne un nombre (-1, 0 ou 1) qui indique si le mois et l'année de la première instance vient avant, est le même que, ou vient après le mois et l'année de la deuxième instance. Elle est équivalente à la comparaison de leurs dates ISO 8601 sous-jacentes. Deux mois et années provenant de calendriers différents peuvent être considérés comme égaux s'ils commencent à la même date ISO.
+
+> [!NOTE]
+> Les objets `PlainYearMonth` gardent une trace d'un jour de référence ISO, qui est également utilisé dans la comparaison. Ce jour est automatiquement défini lors de l'utilisation de la méthode {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}, mais peut être défini manuellement en utilisant le constructeur {{JSxRef("Temporal/PlainYearMonth/PlainYearMonth", "Temporal.PlainYearMonth()")}}, ce qui peut amener deux mois et années équivalents à être considérés comme différents s'ils ont des jours de référence différents. Pour cette raison, vous devriez éviter d'utiliser directement le constructeur et préférer la méthode `from()`.
+
+## Syntaxe
+
+```js-nolint
+Temporal.PlainYearMonth.compare(yearMonth1, yearMonth2)
+```
+
+### Paramètres
+
+- `yearMonth1`
+  - : Une chaîne de caractères, un objet ou une instance de {{JSxRef("Temporal.PlainYearMonth")}} représentant le premier mois de l'année à comparer. Il est converti en un objet `Temporal.PlainYearMonth` en utilisant le même algorithme que {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}.
+- `yearMonth2`
+  - : Le deuxième mois de l'année à comparer, converti en un objet `Temporal.PlainYearMonth` en utilisant le même algorithme que `yearMonth1`.
+
+### Valeur de retour
+
+Retourne `-1` si `yearMonth1` vient avant `yearMonth2`, `0` s'ils sont identiques, et `1` si `yearMonth1` vient après `yearMonth2`. Ils sont comparés par leurs valeurs de date sous-jacentes (généralement le premier jour du mois), en ignorant leurs calendriers.
+
+## Exemples
+
+### Utiliser la méthode `Temporal.PlainYearMonth.compare()`
+
+```js
+const ym1 = Temporal.PlainYearMonth.from("2021-08");
+const ym2 = Temporal.PlainYearMonth.from("2021-09");
+console.log(Temporal.PlainYearMonth.compare(ym1, ym2)); // -1
+
+const ym3 = Temporal.PlainYearMonth.from("2021-07");
+console.log(Temporal.PlainYearMonth.compare(ym1, ym3)); // 1
+```
+
+### Comparer des mois d'années dans différents calendriers
+
+```js
+const ym1 = Temporal.PlainYearMonth.from({ year: 2021, month: 8 });
+const ym2 = Temporal.PlainYearMonth.from({
+  year: 2021,
+  month: 8,
+  calendar: "islamic-umalqura",
+});
+const ym3 = Temporal.PlainYearMonth.from({
+  year: 2021,
+  month: 8,
+  calendar: "hebrew",
+});
+console.log(ym1.toString()); // "2021-08"
+console.log(ym2.toString()); // "2582-12-17[u-ca=islamic-umalqura]"
+console.log(ym3.toString()); // "-001739-04-06[u-ca=hebrew]"
+console.log(Temporal.PlainYearMonth.compare(ym1, ym2)); // -1
+console.log(Temporal.PlainYearMonth.compare(ym1, ym3)); // 1
+```
+
+### Trier un tableau de mois d'années
+
+Le but de cette fonction `compare()` est d'agir comme un comparateur à passer à {{JSxRef("Array.prototype.sort()")}} et aux fonctions associées.
+
+```js
+const months = [
+  Temporal.PlainYearMonth.from({ year: 2021, month: 8 }),
+  Temporal.PlainYearMonth.from({
+    year: 2021,
+    month: 8,
+    calendar: "islamic-umalqura",
+  }),
+  Temporal.PlainYearMonth.from({ year: 2021, month: 8, calendar: "hebrew" }),
+];
+
+months.sort(Temporal.PlainYearMonth.compare);
+console.log(months.map((d) => d.toString()));
+// [ "-001739-04-06[u-ca=hebrew]", "2021-08", "2582-12-17[u-ca=islamic-umalqura]" ]
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/equals", "Temporal.PlainYearMonth.prototype.equals()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/daysinmonth/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/daysinmonth/index.md
@@ -1,0 +1,41 @@
+---
+title: "Temporal.PlainYearMonth : propriété daysInMonth"
+short-title: daysInMonth
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/daysInMonth
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La propriété d'accesseur **`daysInMonth`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne un entier positif représentant le nombre de jours dans le mois de cette date. Elle dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+
+Le mutateur d'accesseur de `daysInMonth` est `undefined`. Vous ne pouvez pas modifier cette propriété directement.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainDate/daysInMonth", "Temporal.PlainDate.prototype.daysInMonth")}}.
+
+## Exemples
+
+### Utiliser la propriété `daysInMonth`
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-07");
+console.log(ym.daysInMonth); // 31
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/with", "Temporal.PlainYearMonth.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/add", "Temporal.PlainYearMonth.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/subtract", "Temporal.PlainYearMonth.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/year", "Temporal.PlainYearMonth.prototype.year")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/month", "Temporal.PlainYearMonth.prototype.month")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/daysInYear", "Temporal.PlainYearMonth.prototype.daysInYear")}}
+- La propriété {{JSxRef("Temporal/PlainDate/daysInMonth", "Temporal.PlainDate.prototype.daysInMonth")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/daysinyear/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/daysinyear/index.md
@@ -1,0 +1,40 @@
+---
+title: "Temporal.PlainYearMonth : propriété daysInYear"
+short-title: daysInYear
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/daysInYear
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La propriété d'accesseur **`daysInYear`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne un entier positif représentant le nombre de jours dans l'année de cette date. Elle dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+
+Le mutateur d'accesseur de `daysInYear` est `undefined`. Vous ne pouvez pas modifier cette propriété directement.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainDate/daysInYear", "Temporal.PlainDate.prototype.daysInYear")}}.
+
+## Exemples
+
+### Utiliser la propriété `daysInYear`
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-07");
+console.log(ym.daysInYear); // 365
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/with", "Temporal.PlainYearMonth.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/add", "Temporal.PlainYearMonth.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/subtract", "Temporal.PlainYearMonth.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/year", "Temporal.PlainYearMonth.prototype.year")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/daysInMonth", "Temporal.PlainYearMonth.prototype.daysInMonth")}}
+- La propriété {{JSxRef("Temporal/PlainDate/daysInYear", "Temporal.PlainDate.prototype.daysInYear")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/equals/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/equals/index.md
@@ -1,0 +1,56 @@
+---
+title: "Temporal.PlainYearMonth : méthode equals()"
+short-title: equals()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/equals
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La méthode **`equals()`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne `true` si la valeur de ce mois et de son année est équivalente à celle de l'autre mois et de son année (sous une forme convertible par {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}), sinon vaut `false`. Elles sont comparées à la fois par leurs valeurs de date ISO sous-jacentes et par leurs calendriers, donc deux mois et années de calendriers différents peuvent être considérées comme égales par {{JSxRef("Temporal/PlainYearMonth/compare", "Temporal.PlainYearMonth.compare()")}} mais pas par `equals()`.
+
+> [!NOTE]
+> Les objets `PlainYearMonth` gardent une trace d'un jour ISO de référence, qui est également utilisé dans la comparaison. Ce jour est automatiquement défini lors de l'utilisation de la méthode {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}, mais peut être défini manuellement en utilisant le constructeur {{JSxRef("Temporal/PlainYearMonth/PlainYearMonth", "Temporal.PlainYearMonth()")}}, ce qui peut amener deux mois et années équivalents à être considérés comme différents s'ils ont des jours de référence différents. Pour cette raison, vous devriez éviter d'utiliser directement le constructeur et préférer la méthode `from()`.
+
+## Syntaxe
+
+```js-nolint
+equals(other)
+```
+
+### Paramètres
+
+- `other`
+  - : Une chaîne de caractères, un objet ou une instance de {{JSxRef("Temporal.PlainYearMonth")}} représentant l'autre mois et année à comparer. Il est converti en un objet `Temporal.PlainYearMonth` en utilisant le même algorithme que {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}.
+
+### Valeur de retour
+
+`true` si ce mois et son année sont égaux à `other` à la fois dans leur valeur de date et leur calendrier, `false` sinon.
+
+## Exemples
+
+### Utiliser la méthode `equals()`
+
+```js
+const ym1 = Temporal.PlainYearMonth.from("2021-08");
+const ym2 = Temporal.PlainYearMonth.from({ year: 2021, month: 8 });
+console.log(ym1.equals(ym2)); // true
+
+const ym3 = Temporal.PlainYearMonth.from("2021-08-01[u-ca=japanese]");
+console.log(ym1.equals(ym3)); // false
+
+const ym4 = Temporal.PlainYearMonth.from("2021-09");
+console.log(ym1.equals(ym4)); // false
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode statique {{JSxRef("Temporal/PlainYearMonth/compare", "Temporal.PlainYearMonth.compare()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/era/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/era/index.md
@@ -1,0 +1,43 @@
+---
+title: "Temporal.PlainYearMonth : propriété era"
+short-title: era
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/era
+l10n:
+  sourceCommit: 9b86874b5762b52ce0055f58d561004d1a204ad5
+---
+
+La propriété d'accesseur **`era`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne une chaîne de caractères en minuscules spécifique au calendrier représentant l'ère de ce mois et de cette année, ou `undefined` si le calendrier n'utilise pas d'ères (par exemple, ISO 8601). `era` et `eraYear` identifient ensemble de manière unique une année dans un calendrier, de la même manière que `year`. Elle dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+
+Le mutateur d'accesseur de `era` est `undefined`. Vous ne pouvez pas modifier cette propriété directement. Utilisez la méthode {{JSxRef("Temporal/PlainYearMonth/with", "with()")}} pour créer un nouvel objet `Temporal.PlainYearMonth` avec la nouvelle valeur souhaitée.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainDate/era", "Temporal.PlainDate.prototype.era")}}.
+
+## Exemples
+
+### Utiliser la propriété `era`
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-07"); // calendrier ISO 8601
+console.log(ym.era); // undefined
+
+const ym2 = Temporal.PlainYearMonth.from("2021-07-01[u-ca=gregory]");
+console.log(ym2.era); // ce
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/with", "Temporal.PlainYearMonth.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/add", "Temporal.PlainYearMonth.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/subtract", "Temporal.PlainYearMonth.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/year", "Temporal.PlainYearMonth.prototype.year")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/eraYear", "Temporal.PlainYearMonth.prototype.eraYear")}}
+- La propriété {{JSxRef("Temporal/PlainDate/era", "Temporal.PlainDate.prototype.era")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/erayear/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/erayear/index.md
@@ -1,0 +1,49 @@
+---
+title: "Temporal.PlainYearMonth : propriété eraYear"
+short-title: eraYear
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/eraYear
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La propriété d'accesseur **`eraYear`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne un entier qui n'est pas négatif représentant l'année de la valeur de mois et d'année dans l'ère, ou `undefined` si le calendrier n'utilise pas d'ères (par exemple, ISO 8601). L'indice de l'année commence généralement à 1 (plus courant) ou 0, et les années dans une ère peuvent diminuer avec le temps (par exemple, Grégorien avant Jésus-Christ). `era` et `eraYear` identifient ensemble de manière unique une année dans un calendrier, de la même manière que `year`. Elle dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+
+Le mutateur d'accesseur de `eraYear` est `undefined`. Vous ne pouvez pas modifier cette propriété directement. Utilisez la méthode {{JSxRef("Temporal/PlainYearMonth/with", "with()")}} pour créer un nouvel objet `Temporal.PlainYearMonth` avec la nouvelle valeur souhaitée.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainDate/eraYear", "Temporal.PlainDate.prototype.eraYear")}}.
+
+## Exemples
+
+### Utiliser la propriété `eraYear`
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-07"); // calendrier ISO 8601
+console.log(ym.eraYear); // undefined
+
+const ym2 = Temporal.PlainYearMonth.from("2021-07-01[u-ca=gregory]");
+console.log(ym2.eraYear); // 2021
+
+const ym3 = Temporal.PlainYearMonth.from("-002021-07-01[u-ca=gregory]");
+console.log(ym3.eraYear); // 2022 ; 0000 est utilisé pour l'année 1 avant Jésus-Christ
+
+const ym4 = Temporal.PlainYearMonth.from("2021-07-01[u-ca=japanese]");
+console.log(ym4.eraYear); // 3
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/with", "Temporal.PlainYearMonth.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/add", "Temporal.PlainYearMonth.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/subtract", "Temporal.PlainYearMonth.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/year", "Temporal.PlainYearMonth.prototype.year")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/era", "Temporal.PlainYearMonth.prototype.era")}}
+- La propriété {{JSxRef("Temporal/PlainDate/eraYear", "Temporal.PlainDate.prototype.eraYear")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/from/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/from/index.md
@@ -1,0 +1,135 @@
+---
+title: "Temporal.PlainYearMonth : méthode statique from()"
+short-title: from()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/from
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La méthode statique **`Temporal.PlainYearMonth.from()`** crée un nouvel objet `Temporal.PlainYearMonth` depuis un autre object `Temporal.PlainYearMonth`, un objet avec les propriétés mois et année, ou une chaîne de caractères [RFC 9557](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth#format_rfc_9557).
+
+## Syntaxe
+
+```js-nolint
+Temporal.PlainYearMonth.from(info)
+Temporal.PlainYearMonth.from(info, options)
+```
+
+### Paramètres
+
+- `info`
+  - : L'un des éléments suivants&nbsp;:
+    - Une instance de {{JSxRef("Temporal.PlainYearMonth")}}, ce qui crée une copie de l'instance.
+    - Une chaîne de caractères [RFC 9557](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth#format_rfc_9557) contenant une date et éventuellement un calendrier. Si le calendrier n'est pas `iso8601`, un jour est requis.
+    - Un objet contenant les propriétés suivantes (dans l'ordre où elles sont récupérées et validées)&nbsp;:
+      - `calendar` {{Optional_Inline}}
+        - : Une chaîne de caractères correspondant à la propriété {{JSxRef("Temporal/PlainYearMonth/calendarId", "calendarId")}}. Voir [`Intl.supportedValuesOf()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#types_de_calendrier_pris_en_charge) pour une liste des types de calendriers couramment pris en charge. Par défaut, `"iso8601"`. Toutes les autres propriétés sont interprétées dans ce système de calendrier (contrairement au constructeur {{JSxRef("Temporal/PlainYearMonth/PlainYearMonth", "Temporal.PlainYearMonth()")}}, qui interprète les valeurs dans le système de calendrier ISO).
+      - `era` et `eraYear`
+        - : Une chaîne de caractères et un entier correspondant aux propriétés {{JSxRef("Temporal/PlainYearMonth/era", "era")}} et {{JSxRef("Temporal/PlainYearMonth/eraYear", "eraYear")}}. Sont utilisés uniquement si le système de calendrier possède des ères. `era` et `eraYear` doivent être fournis simultanément. S'ils ne sont pas fournis, alors `year` doit être fourni. Si `era`, `eraYear` et `year` sont tous fournis, ils doivent être cohérents.
+      - `month`
+        - : Correspond à la propriété {{JSxRef("Temporal/PlainYearMonth/month", "month")}}. Doit être positif indépendamment de l'option `overflow`.
+      - `monthCode`
+        - : Correspond à la propriété {{JSxRef("Temporal/PlainYearMonth/monthCode", "monthCode")}}. Si elle n'est pas fournie, alors `month` doit être fourni. Si `month` et `monthCode` sont tous deux fournis, ils doivent être cohérents.
+      - `year`
+        - : Correspond à la propriété {{JSxRef("Temporal/PlainYearMonth/year", "year")}}.
+
+- `options` {{Optional_Inline}}
+  - : Un objet contenant la propriété suivante&nbsp;:
+    - `overflow` {{Optional_Inline}}
+      - : Une chaîne de caractères définissant le comportement lorsque un composant de date est hors de portée (lors de l'utilisation de l'objet `info`). Les valeurs possibles sont&nbsp;:
+        - `"constrain"` (par défaut)
+          - : Le composant de date est [contraint](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate#fixer_les_dates_invalides) à la plage valide.
+        - `"reject"`
+          - : Un objet {{JSxRef("RangeError")}} est levé si le composant de date est hors de portée.
+
+### Valeur de retour
+
+Un nouvel objet `Temporal.PlainYearMonth`, représentant l'année et le mois définis par `info` dans le calendrier défini.
+
+Chaque `PlainYearMonth` stocke en interne une date ISO 8601 complète, qui a le même mois et la même année dans le calendrier cible que ce qui est exposé. Le jour de référence est visible lors de la conversion en chaîne avec {{JSxRef("Temporal/PlainYearMonth/toString", "toString()")}}, qui retourne une date ISO. Le jour de référence est choisi de manière arbitraire mais cohérente&nbsp;; c'est-à-dire que chaque paire `(année, mois)` correspond toujours au même jour de référence ISO. Il n'utilise pas le jour fourni dans l'entrée. Au lieu de cela, le jour de référence est toujours choisi comme étant le premier jour valide du mois.
+
+Cette canonisation du jour de référence garantit que {{JSxRef("Temporal/PlainYearMonth/equals", "equals()")}} peut comparer directement les dates ISO sous-jacentes sans calcul supplémentaire.
+
+### Exceptions
+
+- {{JSxRef("TypeError")}}
+  - : Levé dans l'un des cas suivants&nbsp;:
+    - `info` n'est pas un objet ou une chaîne de caractères.
+    - `options` n'est pas un objet ou `undefined`.
+    - Les propriétés fournies sont insuffisantes pour déterminer de manière univoque une date. Vous devez généralement fournir une `year` (ou `era` et `eraYear`) et un `month` (ou un `monthCode`).
+- {{JSxRef("RangeError")}}
+  - : Levé dans l'un des cas suivants&nbsp;:
+    - Les propriétés fournies qui spécifient le même composant sont incohérentes.
+    - Les propriétés non numériques fournies ne sont pas valides&nbsp;; par exemple, si `monthCode` n'est jamais un code de mois valide dans ce calendrier.
+    - Les propriétés numériques fournies sont hors de portée, et `options.overflow` est défini sur `"reject"`.
+    - Les informations ne sont pas dans la [plage représentable](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#dates_représentables), qui est ±(10<sup>8</sup> + 1) jours, soit environ ±273 972,6 ans, à partir de l'époque Unix.
+
+## Exemples
+
+### Créer un `PlainYearMonth` à partir d'un objet
+
+```js
+// Année + code du mois
+const ym = Temporal.PlainYearMonth.from({ year: 2021, monthCode: "M05" });
+console.log(ym.toString()); // 2021-05
+
+// Année + mois
+const ym2 = Temporal.PlainYearMonth.from({ year: 2021, month: 7 });
+console.log(ym2.toString()); // 2021-07
+
+// Année + mois dans un calendrier différent
+const ym3 = Temporal.PlainYearMonth.from({
+  year: 5730,
+  month: 6,
+  calendar: "hebrew",
+});
+console.log(ym3.toString()); // 1970-02-07[u-ca=hebrew]
+
+// Année + code du mois dans un calendrier différent
+const ym4 = Temporal.PlainYearMonth.from({
+  year: 5730,
+  monthCode: "M05L",
+  calendar: "hebrew",
+});
+console.log(ym4.toString()); // 1970-02-07[u-ca=hebrew]
+```
+
+### Contrôler le comportement de dépassement
+
+Par défaut, les valeurs hors de portée sont limitées à la plage valide.
+
+```js
+const ym1 = Temporal.PlainYearMonth.from({ year: 2021, month: 13 });
+console.log(ym1.toString()); // 2021-12
+
+// 5732 n'est pas une année bissextile hébraïque, donc un code de mois différent est choisi
+const ym2 = Temporal.PlainYearMonth.from({
+  year: 5732,
+  monthCode: "M05L",
+  calendar: "hebrew",
+});
+console.log(ym2.toLocaleString("en-US", { calendar: "hebrew" })); // Adar 5732
+const underlyingDate = Temporal.PlainDate.from(ym2.toString());
+console.log(underlyingDate.year, underlyingDate.monthCode); // 5732 M06
+```
+
+Vous pouvez changer ce comportement pour lancer une erreur à la place&nbsp;:
+
+```js
+Temporal.PlainYearMonth.from({ year: 2021, month: 13 }, { overflow: "reject" });
+// RangeError: date value "month" not in 1..12: 13
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/PlainYearMonth", "Temporal.PlainYearMonth()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/with", "Temporal.PlainYearMonth.prototype.with()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/index.md
@@ -1,0 +1,113 @@
+---
+title: Temporal.PlainYearMonth
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth
+l10n:
+  sourceCommit: 9b86874b5762b52ce0055f58d561004d1a204ad5
+---
+
+L'objet **`Temporal.PlainYearMonth`** représente l'année et le mois d'une date d'un calendrier, sans jour ni fuseau horaire&nbsp;; par exemple, un évènement sur un calendrier qui se produit pendant tout le mois. Il est fondamentalement représenté comme une date de calendrier ISO 8601, avec des champs pour l'année, le mois et le jour, et un système de calendrier associé. Le jour est utilisé pour faire disparaître l'ambiguïté de l'année et du mois dans les systèmes de calendrier non ISO.
+
+## Description
+
+Un `PlainYearMonth` est essentiellement la partie année et mois d'un objet {{JSxRef("Temporal.PlainDate")}}, sans le jour.
+
+### Format RFC 9557
+
+Les objets `PlainYearMonth` peuvent être sérialisés et analysés en utilisant le format [RFC 9557 <sup>(angl.)</sup>](https://datatracker.ietf.org/doc/html/rfc9557), une extension du format [ISO 8601 / RFC 3339 <sup>(angl.)</sup>](https://datatracker.ietf.org/doc/html/rfc3339). La chaîne de caractères a la forme suivante (les espaces sont uniquement pour la lisibilité et ne doivent pas être présents dans la chaîne de caractères réelle)&nbsp;:
+
+```plain
+YYYY-MM-DD [u-ca=calendar_id]
+```
+
+- `YYYY`
+  - : Soit un nombre à quatre chiffres, soit un nombre à six chiffres avec un signe `+` ou `-`.
+- `MM`
+  - : Un nombre à deux chiffres de `01` à `12`.
+- `DD` {{Optional_Inline}}
+  - : Un nombre à deux chiffres de `01` à `31`. Il est requis pour les calendriers non ISO, et optionnel sinon. S'il est omis, la chaîne de caractères ressemble à `YYYY-MM` ou `YYYYMM`. Notez que le jour de référence réellement stocké peut être différent de celui que vous fournissez, mais l'année et le mois représentés sont les mêmes. Voir {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}} pour plus d'informations. Les composants `YYYY`, `MM` et `DD` peuvent être séparés par `-` ou rien.
+- `[u-ca=calendar_id]` {{Optional_Inline}}
+  - : Remplacez `calendar_id` par le calendrier à utiliser. Voir [`Intl.supportedValuesOf()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#types_de_calendriers_pris_en_charge) pour une liste des types de calendriers couramment pris en charge. Par défaut, `[u-ca=iso8601]`. Peut avoir un _drapeau critique_ en préfixant la clé avec `!`&nbsp;: par exemple, `[!u-ca=iso8601]`. Ce drapeau indique généralement aux autres systèmes qu'il ne peut pas être ignoré s'ils ne le prennent pas en charge. L'analyseur `Temporal` générera une erreur si les annotations contiennent deux annotations de calendrier ou plus et qu'une d'entre elles est critique. Notez que le `YYYY-MM-DD` est toujours interprété comme une date de calendrier ISO 8601, puis converti en calendrier défini.
+
+Comme entrée, vous pouvez éventuellement inclure l'heure, le décalage et l'identifiant du fuseau horaire, dans le même format que [`PlainDateTime`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime#format_rfc_9557), mais ils seront ignorés. Les autres annotations au format `[clé=valeur]` sont également ignorées, et elles ne doivent pas avoir le drapeau critique.
+
+Lors de la sérialisation, vous pouvez configurer l'affichage de l'identifiant du calendrier et l'ajout d'un drapeau critique pour celui-ci.
+
+## Constructeur
+
+- {{JSxRef("Temporal/PlainYearMonth/PlainYearMonth", "Temporal.PlainYearMonth()")}} {{Experimental_Inline}}
+  - : Crée un nouvel objet `Temporal.PlainYearMonth` en fournissant directement les données sous-jacentes.
+
+## Méthodes statiques
+
+- {{JSxRef("Temporal/PlainYearMonth/compare", "Temporal.PlainYearMonth.compare()")}}
+  - : Retourne un nombre (-1, 0 ou 1) indiquant si le premier mois de l'année qui précède, est identique ou suit le second mois de l'année. Équivaut à comparer leurs dates ISO 8601 sous-jacentes. Deux mois de l'année de calendriers différents peuvent être considérés comme égaux s'ils commencent à la même date ISO.
+- {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}
+  - : Crée un nouvel objet `Temporal.PlainYearMonth` à partir d'un autre objet `Temporal.PlainYearMonth`, d'un objet avec des propriétés year et month, ou d'une chaîne [RFC 9557](#rfc_9557_format).
+
+## Propriétés d'instance
+
+Ces propriétés sont définies sur `Temporal.PlainYearMonth.prototype` et partagées par toutes les instances de `Temporal.PlainYearMonth`.
+
+- {{JSxRef("Temporal/PlainYearMonth/calendarId", "Temporal.PlainYearMonth.prototype.calendarId")}}
+  - : Retourne une chaîne de caractères représentant le [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers) utilisé pour interpréter la date ISO 8601 interne.
+- {{JSxRef("Object/constructor", "Temporal.PlainYearMonth.prototype.constructor")}}
+  - : La fonction constructeur qui a créé l'objet instance. Pour les instances de `Temporal.PlainYearMonth`, la valeur initiale est le constructeur {{JSxRef("Temporal/PlainYearMonth/PlainYearMonth", "Temporal.PlainYearMonth()")}}.
+- {{JSxRef("Temporal/PlainYearMonth/daysInMonth", "Temporal.PlainYearMonth.prototype.daysInMonth")}}
+  - : Retourne un entier positif représentant le nombre de jours dans le mois de cette date. Dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+- {{JSxRef("Temporal/PlainYearMonth/daysInYear", "Temporal.PlainYearMonth.prototype.daysInYear")}}
+  - : Retourne un entier positif représentant le nombre de jours dans l'année de cette date. Dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers). Pour le calendrier ISO 8601, c'est 365, ou 366 dans une année bissextile.
+- {{JSxRef("Temporal/PlainYearMonth/era", "Temporal.PlainYearMonth.prototype.era")}}
+  - : Retourne une chaîne de caractères en minuscules spécifique au calendrier représentant l'ère de cette valeur mois et année, ou `undefined` si le calendrier n'utilise pas d'ères (par exemple, ISO 8601). `era` et `eraYear` identifient ensemble de manière unique une année dans un calendrier, de la même manière que `year`. Dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers). Pour le calendrier grégorien, c'est soit `"ce"` soit `"bce"`.
+- {{JSxRef("Temporal/PlainYearMonth/eraYear", "Temporal.PlainYearMonth.prototype.eraYear")}}
+  - : Retourne un entier qui n'est pas négatif représentant l'année de cette valeur mois et année dans l'ère, ou `undefined` si le calendrier n'utilise pas d'ères (par exemple, ISO 8601). L'index de l'année commence généralement à 1 (plus courant) ou 0, et les années dans une ère peuvent diminuer avec le temps (par exemple, BCE grégorien). `era` et `eraYear` identifient ensemble de manière unique une année dans un calendrier, de la même manière que `year`. Dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+- {{JSxRef("Temporal/PlainYearMonth/inLeapYear", "Temporal.PlainYearMonth.prototype.inLeapYear")}}
+  - : Retourne un booléen indiquant si cette valeur mois et année se trouve dans une année bissextile. Une année bissextile est une année qui a plus de jours (en raison d'un jour ou d'un mois intercalaire) qu'une année commune. Dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+- {{JSxRef("Temporal/PlainYearMonth/month", "Temporal.PlainYearMonth.prototype.month")}}
+  - : Retourne un entier positif représentant l'index du mois dans l'année de cette valeur mois et année, basé sur 1. Le premier mois de cette année est `1`, et le dernier mois est le {{JSxRef("Temporal/PlainYearMonth/monthsInYear", "monthsInYear")}}. Dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers). Notez que contrairement à {{JSxRef("Date.prototype.getMonth()")}}, l'index est basé sur 1. Si le calendrier a des mois intercalaires, alors le mois avec le même {{JSxRef("Temporal/PlainDate/monthCode", "monthCode")}} peut avoir des index de `month` différents pour différentes années.
+- {{JSxRef("Temporal/PlainYearMonth/monthCode", "Temporal.PlainYearMonth.prototype.monthCode")}}
+  - : Retourne une chaîne de caractères spécifique au calendrier représentant le mois de cette valeur mois et année. Dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers). Généralement, c'est `M` suivi d'un numéro de mois à deux chiffres. Pour les mois intercalaires, c'est le code du mois précédent suivi de `L`. Si le mois intercalaire est le premier mois de l'année, le code est `M00L`.
+- {{JSxRef("Temporal/PlainYearMonth/monthsInYear", "Temporal.PlainYearMonth.prototype.monthsInYear")}}
+  - : Retourne un entier positif représentant le nombre de mois dans l'année de cette valeur mois et année. Dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers). Pour le calendrier ISO 8601, c'est toujours 12, mais dans d'autres systèmes de calendrier, cela peut varier.
+- {{JSxRef("Temporal/PlainYearMonth/year", "Temporal.PlainYearMonth.prototype.year")}}
+  - : Retourne un entier représentant le nombre d'années de cette valeur mois et année par rapport au début d'une année d'époque spécifique au calendrier. Dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers). Généralement, l'année 1 est soit la première année de la dernière ère, soit l'année ISO 8601 `0001`. Si l'époque est au milieu de l'année, cette année aura la même valeur avant et après la date de début de l'ère.
+- `Temporal.PlainYearMonth.prototype[Symbol.toStringTag]`
+  - : La valeur initiale de la propriété [`[Symbol.toStringTag]`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) est la chaîne de caractères `"Temporal.PlainYearMonth"`. Cette propriété est utilisée dans {{JSxRef("Object.prototype.toString()")}}.
+
+## Méthodes d'instance
+
+- {{JSxRef("Temporal/PlainYearMonth/add", "Temporal.PlainYearMonth.prototype.add()")}}
+  - : Retourne un nouvel objet `Temporal.PlainYearMonth` représentant ce mois et cette année avancés d'une durée donnée (sous une forme convertible par {{JSxRef("Temporal/Duration/from", "Temporal.Duration.from()")}}).
+- {{JSxRef("Temporal/PlainYearMonth/equals", "Temporal.PlainYearMonth.prototype.equals()")}}
+  - : Retourne `true` si ce mois et cette année sont équivalents en valeur à un autre mois et année (sous une forme convertible par {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}), et `false` sinon. Ils sont comparés à la fois par leurs valeurs ISO sous-jacentes et leurs calendriers, donc deux mois et années de calendriers différents peuvent être considérés comme égaux par {{JSxRef("Temporal/PlainYearMonth/compare", "Temporal.PlainYearMonth.compare()")}} mais pas par `equals()`.
+- {{JSxRef("Temporal/PlainYearMonth/since", "Temporal.PlainYearMonth.prototype.since()")}}
+  - : Retourne un nouvel objet {{JSxRef("Temporal.Duration")}} représentant la durée depuis un autre mois et année (sous une forme convertible par {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}) jusqu'à ce mois et cette année. La durée est positive si l'autre mois est avant ce mois, sinon elle est négative.
+- {{JSxRef("Temporal/PlainYearMonth/subtract", "Temporal.PlainYearMonth.prototype.subtract()")}}
+  - : Retourne un nouvel objet `Temporal.PlainYearMonth` représentant ce mois et cette année reculés d'une durée donnée (sous une forme convertible par {{JSxRef("Temporal/Duration/from", "Temporal.Duration.from()")}}).
+- {{JSxRef("Temporal/PlainYearMonth/toJSON", "Temporal.PlainYearMonth.prototype.toJSON()")}}
+  - : Retourne une chaîne de caractères représentant ce mois et cette année dans le même [format RFC 9557](#format_rfc_9557) que l'appel de {{JSxRef("Temporal/PlainYearMonth/toString", "toString()")}}. Destiné à être appelé implicitement par {{JSxRef("JSON.stringify()")}}.
+- {{JSxRef("Temporal/PlainYearMonth/toLocaleString", "Temporal.PlainYearMonth.prototype.toLocaleString()")}}
+  - : Retourne une chaîne de caractères avec une représentation sensible à la langue de ce mois et cette année.
+- {{JSxRef("Temporal/PlainYearMonth/toPlainDate", "Temporal.PlainYearMonth.prototype.toPlainDate()")}}
+  - : Retourne un nouvel objet {{JSxRef("Temporal.PlainDate")}} représentant ce mois et cette année et un jour fourni dans le même système de calendrier.
+- {{JSxRef("Temporal/PlainYearMonth/toString", "Temporal.PlainYearMonth.prototype.toString()")}}
+  - : Retourne une chaîne de caractères représentant ce mois et cette année dans le [format RFC 9557](#format_rfc_9557).
+- {{JSxRef("Temporal/PlainYearMonth/until", "Temporal.PlainYearMonth.prototype.until()")}}
+  - : Retourne un nouvel objet {{JSxRef("Temporal.Duration")}} représentant la durée entre ce mois et cette année et un autre mois et année (sous une forme convertible par {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}). La durée est positive si l'autre mois est après ce mois, et négative si avant.
+- {{JSxRef("Temporal/PlainYearMonth/valueOf", "Temporal.PlainYearMonth.prototype.valueOf()")}}
+  - : Lève une {{JSxRef("TypeError")}}, ce qui empêche les instances de `Temporal.PlainYearMonth` d'être [converties implicitement en primitives](/fr/docs/Web/JavaScript/Guide/Data_structures#contrainte_de_primitive) lorsqu'elles sont utilisées dans des opérations arithmétiques ou de comparaison.
+- {{JSxRef("Temporal/PlainYearMonth/with", "Temporal.PlainYearMonth.prototype.with()")}}
+  - : Retourne un nouvel objet `Temporal.PlainYearMonth` représentant ce mois et cette année avec certains champs remplacés par de nouvelles valeurs.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal")}}
+- L'objet {{JSxRef("Temporal.PlainDate")}}
+- L'objet {{JSxRef("Temporal.PlainMonthDay")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/inleapyear/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/inleapyear/index.md
@@ -1,0 +1,43 @@
+---
+title: "Temporal.PlainYearMonth : propriété inLeapYear"
+short-title: inLeapYear
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/inLeapYear
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La propriété d'accesseur **`inLeapYear`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne un booléen indiquant si le mois et son année se trouvent dans une année bissextile. Une année bissextile est une année qui a plus de jours (en raison d'un jour ou d'un mois intercalaire) qu'une année commune. Cela dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+
+Le motateur d'accesseur de `inLeapYear` est `undefined`. Vous ne pouvez pas modifier cette propriété directement.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainDate/inLeapYear", "Temporal.PlainDate.prototype.inLeapYear")}}.
+
+## Exemples
+
+### Utiliser la propriété `inLeapYear`
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-07");
+console.log(ym.inLeapYear); // false
+console.log(ym.daysInYear); // 365
+console.log(ym.monthsInYear); // 12
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/with", "Temporal.PlainYearMonth.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/add", "Temporal.PlainYearMonth.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/subtract", "Temporal.PlainYearMonth.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/year", "Temporal.PlainYearMonth.prototype.year")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/daysInYear", "Temporal.PlainYearMonth.prototype.daysInYear")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/monthsInYear", "Temporal.PlainYearMonth.prototype.monthsInYear")}}
+- La propriété {{JSxRef("Temporal/PlainDate/inLeapYear", "Temporal.PlainDate.prototype.inLeapYear")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/month/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/month/index.md
@@ -1,0 +1,43 @@
+---
+title: "Temporal.PlainYearMonth : propriété month"
+short-title: month
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/month
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La propriété d'accesseur **`month`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne un entier positif représentant l'indice du mois dans l'année de cet objet de mois et année, basé sur 1. Le premier mois de cette année est `1`, et le dernier mois est le {{JSxRef("Temporal/PlainYearMonth/monthsInYear", "monthsInYear")}}. Cela dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+
+Le motateur d'accesseur de `month` est `undefined`. Vous ne pouvez pas modifier cette propriété directement. Utilisez la méthode {{JSxRef("Temporal/PlainYearMonth/with", "with()")}} pour créer un nouvel objet `Temporal.PlainYearMonth` avec la nouvelle valeur souhaitée.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainDate/month", "Temporal.PlainDate.prototype.month")}}.
+
+## Exemples
+
+### Utiliser la propriété `month`
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-07"); // calendrier ISO 8601
+console.log(ym.monthCode); // "M07"
+console.log(ym.month); // 7
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/with", "Temporal.PlainYearMonth.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/add", "Temporal.PlainYearMonth.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/subtract", "Temporal.PlainYearMonth.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/year", "Temporal.PlainYearMonth.prototype.year")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/monthCode", "Temporal.PlainYearMonth.prototype.monthCode")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/daysInMonth", "Temporal.PlainYearMonth.prototype.daysInMonth")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/monthsInYear", "Temporal.PlainYearMonth.prototype.monthsInYear")}}
+- La propriété {{JSxRef("Temporal/PlainDate/month", "Temporal.PlainDate.prototype.month")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/monthcode/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/monthcode/index.md
@@ -1,0 +1,45 @@
+---
+title: "Temporal.PlainYearMonth : propriété monthCode"
+short-title: monthCode
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/monthCode
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La propriété d'accesseur **`monthCode`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne une chaîne de caractères spécifique au calendrier représentant le mois de cet objet de mois et d'année. Elle dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+
+En général, il s'agit de `M` suivi d'un numéro de mois à deux chiffres. Pour les mois intercalaires, il s'agit du code du mois précédent suivi de `L` (même si c'est conceptuellement un dérivé du mois suivant&nbsp;; par exemple, dans le calendrier hébraïque, Adar I a le code `M05L` mais Adar II a le code `M06`). Si le mois intercalaire est le premier mois de l'année, le code est `M00L`.
+
+Le motateur d'accesseur de `monthCode` est `undefined`. Vous ne pouvez pas modifier cette propriété directement. Utilisez la méthode {{JSxRef("Temporal/PlainYearMonth/with", "with()")}} pour créer un nouvel objet `Temporal.PlainYearMonth` avec la nouvelle valeur souhaitée.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainDate/monthCode", "Temporal.PlainDate.prototype.monthCode")}}.
+
+## Exemples
+
+### Utiliser la propriété `monthCode`
+
+```js
+const date = Temporal.PlainYearMonth.from("2021-07-01"); // calendrier ISO 8601
+console.log(date.monthCode); // "M07"
+console.log(date.month); // 7
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/with", "Temporal.PlainYearMonth.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/add", "Temporal.PlainYearMonth.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/subtract", "Temporal.PlainYearMonth.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/year", "Temporal.PlainYearMonth.prototype.year")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/month", "Temporal.PlainYearMonth.prototype.month")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/daysInMonth", "Temporal.PlainYearMonth.prototype.daysInMonth")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/monthsInYear", "Temporal.PlainYearMonth.prototype.monthsInYear")}}
+- La propriété {{JSxRef("Temporal/PlainDate/monthCode", "Temporal.PlainDate.prototype.monthCode")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/monthsinyear/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/monthsinyear/index.md
@@ -1,0 +1,42 @@
+---
+title: "Temporal.PlainYearMonth : propriété monthsInYear"
+short-title: monthsInYear
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/monthsInYear
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La propriété d'accesseur **`monthsInYear`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne un entier positif représentant le nombre de mois dans l'année de cette date. Elle dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+
+Le mutateur d'accesseur de `monthsInYear` est `undefined`. Vous ne pouvez pas modifier cette propriété directement.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainDate/monthsInYear", "Temporal.PlainDate.prototype.monthsInYear")}}.
+
+## Exemples
+
+### Utiliser la propriété `monthsInYear`
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-07");
+console.log(ym.monthsInYear); // 12
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/with", "Temporal.PlainYearMonth.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/add", "Temporal.PlainYearMonth.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/subtract", "Temporal.PlainYearMonth.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/year", "Temporal.PlainYearMonth.prototype.year")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/month", "Temporal.PlainYearMonth.prototype.month")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/monthCode", "Temporal.PlainYearMonth.prototype.monthCode")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/daysInMonth", "Temporal.PlainYearMonth.prototype.daysInMonth")}}
+- La propriété {{JSxRef("Temporal/PlainDate/monthsInYear", "Temporal.PlainDate.prototype.monthsInYear")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/plainyearmonth/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/plainyearmonth/index.md
@@ -1,0 +1,92 @@
+---
+title: Constructeur Temporal.PlainYearMonth()
+short-title: Temporal.PlainYearMonth()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/PlainYearMonth
+l10n:
+  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
+---
+
+{{SeeCompatTable}}
+
+Le constructeur **`Temporal.PlainYearMonth()`** crée des objets {{JSxRef("Temporal.PlainYearMonth")}}.
+
+Ce constructeur permet de créer des instances en fournissant directement les données sous-jacentes. Comme pour toutes les autres classes `Temporal`, vous devriez généralement construire des objets `Temporal.PlainYearMonth` en utilisant la méthode statique {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}, qui peut gérer une variété de types d'entrée.
+
+## Syntaxe
+
+```js-nolint
+new Temporal.PlainYearMonth(year, month)
+new Temporal.PlainYearMonth(year, month, calendar)
+new Temporal.PlainYearMonth(year, month, calendar, referenceDay)
+```
+
+> [!NOTE]
+> `Temporal.PlainYearMonth()` ne peut être construit qu'avec {{JSxRef("Operators/new", "new")}}. Tenter de l'appeler sans `new` déclenche une {{JSxRef("TypeError")}}.
+
+> [!WARNING]
+> Évitez d'utiliser les paramètres `calendar` et `referenceDay`, car {{JSxRef("Temporal/PlainYearMonth/equals", "equals()")}} et {{JSxRef("Temporal/PlainYearMonth/compare", "compare()")}} prendront en compte le jour de référence pour la comparaison, ce qui peut entraîner que deux mois et années équivalentes soient considérées comme différentes si elles ont des jours de référence différents. Pour créer un objet `Temporal.PlainYearMonth` avec un calendrier non ISO, utilisez la méthode statique {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}.
+
+### Paramètres
+
+- `year` {{Optional_Inline}}
+  - : Un nombre, tronqué à un entier, représentant l'année dans le système de calendrier ISO.
+- `month`
+  - : Un nombre, tronqué à un entier, représentant le mois dans le système de calendrier ISO.
+- `calendar` {{Optional_Inline}}
+  - : Une chaîne de caractères représentant le [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers) à utiliser. Voir [`Intl.supportedValuesOf()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#types_de_calendriers_pris_en_charge) pour une liste des types de calendriers couramment pris en charge. Par défaut, `"iso8601"`. Notez que, quel que soit le `calendar`, `year`, `month` et `referenceDay` doivent être dans le système de calendrier ISO 8601.
+- `referenceDay`
+  - : Un nombre, tronqué à un entier, représentant le jour du mois dans le système de calendrier ISO. Par défaut, `1`. Le même mois son année ISO peut représenter des mois différents selon les jours dans des calendriers non ISO. Par exemple, les jours 2021-07-01 et 2021-07-31 peuvent tomber dans des mois différents dans un calendrier non grégorien, et définir simplement "2021-07" est insuffisant pour déterminer de manière non ambiguë un mois dans le calendrier cible. Par conséquent, vous devez presque toujours définir un `referenceDay` lorsque vous utilisez un calendrier non ISO.
+
+### Valeur de retour
+
+Un nouvel objet `Temporal.PlainYearMonth`, représentant le mois et son année de la date définie par `year`, `month` et `referenceDay` (dans le calendrier ISO), interprété dans le système de calendrier défini par `calendar`.
+
+### Exceptions
+
+- {{JSxRef("TypeError")}}
+  - : Levée si `calendar` n'est pas une chaîne de caractères ou `undefined`.
+- {{JSxRef("RangeError")}}
+  - : Levée dans l'un des cas suivants&nbsp;:
+    - `year`, `month` ou `referenceDay` n'est pas un nombre fini.
+    - La combinaison `year`, `month` et `referenceDay` ne représente pas une date valide dans le système de calendrier ISO, ou n'est pas dans la [plage représentable](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#dates_représentables), qui est de ±(10<sup>8</sup> + 1) jours, soit environ ±273 972,6 ans, à partir de l'époque Unix.
+    - `calendar` n'est pas un identifiant de calendrier valide.
+
+## Exemples
+
+### Utiliser `Temporal.PlainYearMonth()`
+
+```js
+const ym = new Temporal.PlainYearMonth(2021, 7);
+console.log(ym.toString()); // 2021-07
+
+const ym2 = new Temporal.PlainYearMonth(2021, 7, "chinese");
+console.log(ym2.toString()); // 2021-07-01[u-ca=chinese]
+
+const ym3 = new Temporal.PlainYearMonth(2021, 7, "chinese", 31);
+console.log(ym3.toString()); // 2021-07-31[u-ca=chinese]
+```
+
+### Utilisation inappropriée
+
+Vous devriez éviter d'utiliser les paramètres `calendar` et `referenceDay`, sauf si vous savez que le `referenceDay` est le jour de référence canonique qui serait sélectionné par `Temporal.PlainYearMonth.from()` pour la même année-mois.
+
+```js
+const ym = new Temporal.PlainYearMonth(2021, 7, "chinese", 1);
+const ym2 = Temporal.PlainYearMonth.from("2021-07-01[u-ca=chinese]");
+console.log(ym.equals(ym2)); // false
+console.log(ym.toString()); // 2021-07-01[u-ca=chinese]
+console.log(ym2.toString()); // 2021-06-10[u-ca=chinese]
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode statique {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/since/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/since/index.md
@@ -1,0 +1,97 @@
+---
+title: "Temporal.PlainYearMonth : méthode since()"
+short-title: since()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/since
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La méthode **`since()`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne un nouvel objet {{JSxRef("Temporal.Duration")}} représentant la durée entre une autre valeur de mois et son année (sous une forme convertible par {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}) et ce mois avec son année. La durée est positive si l'autre mois est avant ce mois, et négative s'il est après.
+
+Cette méthode effectue `this - other`. Pour effectuer `other - this`, utilisez la méthode {{JSxRef("Temporal/PlainYearMonth/until", "until()")}}.
+
+## Syntaxe
+
+```js-nolint
+since(other)
+since(other, options)
+```
+
+### Paramètres
+
+- `other`
+  - : Une chaîne de caractères, un objet ou une instance de {{JSxRef("Temporal.PlainYearMonth")}} représentant le mois et l'année à soustraire de ce mois et son année. Il est converti en un objet `Temporal.PlainYearMonth` en utilisant le même algorithme que {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}. Il doit avoir le même calendrier que `this`.
+- `options` {{Optional_Inline}}
+  - : Un objet contenant les options pour {{JSxRef("Temporal/Duration/round", "Temporal.Duration.prototype.round()")}}, qui inclut `largestUnit`, `roundingIncrement`, `roundingMode` et `smallestUnit`. `largestUnit` et `smallestUnit` n'acceptent que les unités&nbsp;: `"years"`, `"months"`, ou leurs formes singulières. Pour `largestUnit`, la valeur par défaut `"auto"` signifie `"years"`. Pour `smallestUnit`, la valeur par défaut est `"months"`. La date actuelle est utilisée comme option `relativeTo`.
+
+### Valeur de retour
+
+Un nouvel objet {{JSxRef("Temporal.Duration")}} représentant la durée _depuis_ `other` jusqu'à ce mois et cette année. La durée est positive si `other` est avant ce mois et cette année, et négative si après.
+
+### Exceptions
+
+- {{JSxRef("RangeError")}}
+  - : Levée dans l'un des cas suivants&nbsp;:
+    - `other` a un calendrier différent de `this`.
+    - L'une des options est invalide.
+
+## Exemples
+
+### Utiliser la méthode `since()`
+
+```js
+const lastUpdated = Temporal.PlainYearMonth.from("2022-01");
+const now = Temporal.Now.plainDateISO().toPlainYearMonth();
+const duration = now.since(lastUpdated);
+console.log(`Dernière mise à jour il y a ${duration.toLocaleString("en-US")}`);
+// Sortie attendue : "Dernière mise à jour il y a [number] années, [number] mois"
+
+const duration2 = now.since(lastUpdated, { largestUnit: "months" });
+console.log(`Dernière mise à jour il y a ${duration2.toLocaleString("en-US")}`);
+// Sortie attendue : "Dernière mise à jour il y a [number] mois"
+
+const duration3 = now.since(lastUpdated, { smallestUnit: "years" });
+console.log(`Dernière mise à jour il y a ${duration3.toLocaleString("en-US")}`);
+// Sortie attendue : "Dernière mise à jour il y a [number] années"
+```
+
+### Arrondir le résultat
+
+Par défaut, la partie fractionnaire de `smallestUnit` est tronquée. Vous pouvez l'arrondir en utilisant les options `roundingIncrement` et `roundingMode`.
+
+```js
+const ym1 = Temporal.PlainYearMonth.from("2022-01");
+const ym2 = Temporal.PlainYearMonth.from("2022-11");
+const duration = ym2.since(ym1, {
+  smallestUnit: "years",
+  roundingMode: "ceil",
+});
+console.log(duration.toString()); // "P1Y"
+```
+
+### Obtenir le résultat en jours
+
+Par défaut, la durée résultante ne contient jamais de jours, car `PlainYearMonth` n'offre pas de précision au niveau des jours. Vous pouvez obtenir le résultat en jours en le convertissant d'abord en un {{JSxRef("Temporal.PlainDate")}} avec un jour qui n'est pas ambigu.
+
+```js
+const ym1 = Temporal.PlainYearMonth.from("2022-01");
+const ym2 = Temporal.PlainYearMonth.from("2022-11");
+const duration = ym2.toPlainDate({ day: 1 }).since(ym1.toPlainDate({ day: 1 }));
+console.log(duration.toString()); // "P304D"
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- L'objet {{JSxRef("Temporal.Duration")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/add", "Temporal.PlainYearMonth.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/subtract", "Temporal.PlainYearMonth.prototype.subtract()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/until", "Temporal.PlainYearMonth.prototype.until()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/subtract/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/subtract/index.md
@@ -1,0 +1,72 @@
+---
+title: "Temporal.PlainYearMonth : méthode subtract()"
+short-title: subtract()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/subtract
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La méthode **`subtract()`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne un nouvel objet `Temporal.PlainYearMonth` représentant ce mois et cette année reculés d'une durée donnée (sous une forme convertible par {{JSxRef("Temporal/Duration/from", "Temporal.Duration.from()")}}).
+
+Si vous souhaitez soustraire deux mois et obtenir une durée, utilisez plutôt {{JSxRef("Temporal/PlainYearMonth/since", "since()")}} ou {{JSxRef("Temporal/PlainYearMonth/until", "until()")}}.
+
+## Syntaxe
+
+```js-nolint
+subtract(duration)
+subtract(duration, options)
+```
+
+### Paramètres
+
+- `duration`
+  - : Une chaîne de caractères, un objet ou une instance de {{JSxRef("Temporal.Duration")}} représentant une durée à soustraire de ce mois et cette année. Elle est convertie en un objet `Temporal.Duration` en utilisant le même algorithme que {{JSxRef("Temporal/Duration/from", "Temporal.Duration.from()")}}.
+- `options` {{Optional_Inline}}
+  - : Un objet contenant la propriété suivante&nbsp;:
+    - `overflow` {{Optional_Inline}}
+      - : Une chaîne de caractères définissant le comportement lorsque un composant de date est hors de portée. Les valeurs possibles sont&nbsp;:
+        - `"constrain"` (par défaut)
+          - : Le composant de date est [contraint](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate#fixer_les_dates_invalides) à la plage valide.
+        - `"reject"`
+          - : Un objet {{JSxRef("RangeError")}} est levé si le composant de date est hors de portée.
+
+### Valeur de retour
+
+Un nouvel objet `Temporal.PlainYearMonth` représentant l'année et le mois spécifiés par le `PlainYearMonth` d'origine, moins la durée.
+
+### Exceptions
+
+- {{JSxRef("RangeError")}}
+  - : Levée si le résultat n'est pas dans la [plage représentable](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#dates_représentables), qui est de ±(10<sup>8</sup> + 1) jours, soit environ ±273 972,6 ans, à partir de l'époque Unix.
+
+## Description
+
+Soustraire une durée équivaut à [ajouter](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/add) sa [négation](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration/negated), donc toutes les mêmes considérations s'appliquent. Soustraire une durée positive commence à la fin du mois et de l'année et recule, donc tout incrément inférieur à la longueur du mois est ignoré.
+
+## Exemples
+
+### Soustraire une durée
+
+```js
+const start = Temporal.PlainYearMonth.from("2022-01");
+const end = start.subtract({ years: 1, months: 2, weeks: 3, days: 4 });
+console.log(end.toString()); // 2020-11
+```
+
+Pour plus d'exemples, voir {{JSxRef("Temporal/PlainYearMonth/add", "add()")}}.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- L'objet {{JSxRef("Temporal.Duration")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/add", "Temporal.PlainYearMonth.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/since", "Temporal.PlainYearMonth.prototype.since()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/until", "Temporal.PlainYearMonth.prototype.until()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/tojson/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/tojson/index.md
@@ -1,0 +1,67 @@
+---
+title: "Temporal.PlainYearMonth : méthode toJSON()"
+short-title: toJSON()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/toJSON
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La méthode **`toJSON()`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne une chaîne de caractères représentant ce mois et cette année dans le même [format RFC 9557](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth#format_rfc_9557) que l'appel de {{JSxRef("Temporal/PlainYearMonth/toString", "toString()")}}. Elle est destinée à être appelée implicitement par {{JSxRef("JSON.stringify()")}}.
+
+## Syntaxe
+
+```js-nolint
+toJSON()
+```
+
+### Paramètres
+
+Aucun.
+
+### Valeur de retour
+
+Une chaîne de caractères représentant la date donnée dans le [format RFC 9557](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth#format_rfc_9557), avec l'annotation du calendrier incluse si ce n'est pas `"iso8601"`.
+
+## Description
+
+La méthode `toJSON()` est automatiquement appelée par {{JSxRef("JSON.stringify()")}} lorsqu'un objet `Temporal.PlainYearMonth` est converti en chaîne de caractères JSON. Cette méthode est généralement destinée à sérialiser de manière utile les objets `Temporal.PlainYearMonth` lors de la sérialisation [JSON](/fr/docs/Glossary/JSON), qui peuvent ensuite être désérialisés en utilisant la fonction {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}} comme réactivateur de {{JSxRef("JSON.parse()")}}.
+
+## Exemples
+
+### Utiliser la méthode `toJSON()`
+
+```js
+const ym = Temporal.PlainYearMonth.from({ year: 2021, month: 8 });
+const ymStr = ym.toJSON(); // '2021-08'
+const ym2 = Temporal.PlainYearMonth.from(ymStr);
+```
+
+### Sérialisation et analyse JSON
+
+Cet exemple montre comment `Temporal.PlainYearMonth` peut être sérialisé en JSON sans effort supplémentaire, et comment le réanalyser.
+
+```js
+const ym = Temporal.PlainYearMonth.from({ year: 2021, month: 8 });
+const ymStr = JSON.stringify({ event: ym }); // '{"event":"2021-08"}'
+const obj = JSON.parse(ymStr, (key, value) => {
+  if (key === "event") {
+    return Temporal.PlainYearMonth.from(value);
+  }
+  return value;
+});
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode statique {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/toString", "Temporal.PlainYearMonth.prototype.toString()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/toLocaleString", "Temporal.PlainYearMonth.prototype.toLocaleString()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/tolocalestring/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/tolocalestring/index.md
@@ -1,0 +1,99 @@
+---
+title: "Temporal.PlainYearMonth : méthode toLocaleString()"
+short-title: toLocaleString()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/toLocaleString
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La méthode **`toLocaleString()`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne une chaîne de caractères représentant ce mois et cette année de manière sensible à la langue. Dans les implémentations avec le support de [l'API `Intl.DateTimeFormat`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat), cette méthode délègue à `Intl.DateTimeFormat`.
+
+Chaque fois que `toLocaleString` est appelé, il doit effectuer une recherche dans une grande base de données de chaînes de caractères de localisation, ce qui peut être potentiellement inefficace. Lorsque la méthode est appelée plusieurs fois avec les mêmes arguments, il est préférable de créer un objet {{JSxRef("Intl.DateTimeFormat")}} et d'utiliser sa méthode {{JSxRef("Intl/DateTimeFormat/format", "format()")}}, car un objet `DateTimeFormat` se souvient des arguments qui lui ont été passés et peut décider de mettre en cache une partie de la base de données, de sorte que les appels futurs à `format` peuvent rechercher des chaînes de caractères de localisation dans un contexte plus restreint.
+
+## Syntaxe
+
+```js-nolint
+toLocaleString()
+toLocaleString(locales)
+toLocaleString(locales, options)
+```
+
+### Paramètres
+
+Les paramètres `locales` et `options` personnalisent le comportement de la fonction et permettent aux applications de définir la langue dont les conventions de formatage doivent être utilisées.
+
+Dans les implémentations qui prennent en charge [l'API `Intl.DateTimeFormat`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat), ces paramètres correspondent exactement aux paramètres du constructeur [`Intl.DateTimeFormat()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat). Les implémentations sans support de `Intl.DateTimeFormat` retournent exactement la même chaîne de caractères que {{JSxRef("Temporal/PlainYearMonth/toString", "toString()")}}, en ignorant les deux paramètres.
+
+- `locales` {{Optional_Inline}}
+  - : Une chaîne de caractères avec une {{Glossary("BCP 47 language tag", "balise de langue BCP 47")}}, ou un tableau de telles chaînes de caractères. Correspond au paramètre [`locales`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#locales) du constructeur `Intl.DateTimeFormat()`.
+- `options` {{Optional_Inline}}
+  - : Un objet ajustant le format de sortie. Correspond au paramètre [`options`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options) du constructeur `Intl.DateTimeFormat()`. L'option `calendar` doit être fournie avec la même valeur que le calendrier de ce mois et son année. En ce qui concerne les [options de composant de date et d'heure](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options_des_composants_de_date_et_dheure) et les raccourcis de style (`dateStyle` et `timeStyle`), les options doivent suivre l'une de ces formes&nbsp;:
+    - Ne fournir aucune d'entre elles&nbsp;: `year` et `month` seront par défaut `"numeric"`.
+    - Fournir uniquement `dateStyle`&nbsp;: cela se développe en formats `era`, `year` et `month`.
+    - Fournir certaines options de composant de date et d'heure, où au moins l'une d'entre elles est `year` ou `month`. Seuls les composants de date définis seront inclus dans la sortie.
+
+Voir le [constructeur `Intl.DateTimeFormat()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat) pour plus de détails sur ces paramètres et comment les utiliser.
+
+### Valeur de retour
+
+Une chaîne de caractères représentant le mois et l'année donnés selon les conventions spécifiques à la langue.
+
+Dans les implémentations avec `Intl.DateTimeFormat`, cela équivaut à `new Intl.DateTimeFormat(locales, options).format(yearMonth)`, où `options` a été normalisé comme décrit ci-dessus.
+
+> [!NOTE]
+> La plupart du temps, le formatage retourné par `toLocaleString()` est cohérent. Cependant, la sortie peut varier entre les implémentations, même au sein de la même locale — les variations de sortie sont prévues par la conception et autorisées par la spécification. Elle peut également ne pas être ce à quoi vous vous attendez. Par exemple, la chaîne de caractères peut utiliser des espaces insécables ou être entourée de caractères de contrôle bidirectionnels. Vous ne devez pas comparer les résultats de `toLocaleString()` à des constantes codées en dur.
+
+### Exceptions
+
+- {{JSxRef("RangeError")}}
+  - : Levée si l'une des options est invalide.
+- {{JSxRef("TypeError")}}
+  - : Levée si l'une des options n'est pas du type attendu.
+
+## Exemples
+
+### Utiliser la méthode `toLocaleString()`
+
+Une utilisation simple de cette méthode sans définir de `locale` retourne une chaîne de caractères formatée dans la locale par défaut et avec les options par défaut.
+
+```js
+// On notera que la simple spécification de "2021-08" utilise par défaut
+// le calendrier ISO 8601, ce qui génère une erreur si le calendrier par
+// défaut de la locale n'est pas ISO 8601.
+const ym = Temporal.PlainYearMonth.from("2021-08-01[u-ca=gregory]");
+
+console.log(ym.toLocaleString()); // 08/2021 (en supposant la locale fr-FR et le calendrier grégorien)
+```
+
+Si le calendrier du mois et de son année ne correspond pas au calendrier par défaut de la locale, même lorsque son calendrier est `iso8601`, une option `calendar` explicite doit être fournie avec la même valeur.
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-08");
+ym.toLocaleString("fr-FR", { calendar: "iso8601" }); // 2021-08
+```
+
+### Utiliser la méthode `toLocaleString()` avec des options
+
+Vous pouvez personnaliser les parties du mois et de son année incluses dans la sortie en fournissant le paramètre `options`.
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-08-01[u-ca=gregory]");
+ym.toLocaleString("fr-FR", { dateStyle: "full" }); // août 2021
+ym.toLocaleString("fr-FR", { year: "2-digit" }); // 21
+ym.toLocaleString("fr-FR", { month: "long" }); // août
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- L'objet {{JSxRef("Intl.DateTimeFormat")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/toJSON", "Temporal.PlainYearMonth.prototype.toJSON()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/toString", "Temporal.PlainYearMonth.prototype.toString()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/toplaindate/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/toplaindate/index.md
@@ -1,0 +1,59 @@
+---
+title: "Temporal.PlainYearMonth : méthode toPlainDate()"
+short-title: toPlainDate()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/toPlainDate
+---
+
+La méthode **`toPlainDate()`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne un nouvel objet {{JSxRef("Temporal.PlainDate")}} représentant le mois et son année ainsi qu'un jour fourni dans le même système de calendrier.
+
+## Syntaxe
+
+```js-nolint
+toPlainDate(dayInfo)
+```
+
+### Paramètres
+
+- `dayInfo` {{Optional_Inline}}
+  - : Un objet représentant le composant jour de la `PlainDate` résultante, contenant la propriété suivante&nbsp;:
+    - `day`
+      - : Correspond à la propriété {{JSxRef("Temporal/PlainDate/day", "day")}}.
+
+### Valeur de retour
+
+Un nouvel objet `Temporal.PlainDate` représentant la date définie par ce mois et son année ainsi que le jour dans `dayInfo`, interprété dans le système de calendrier de ce mois et de son année.
+
+### Exceptions
+
+- {{JSxRef("RangeError")}}
+  - : Levée si l'une des options est invalide.
+- {{JSxRef("TypeError")}}
+  - : Levée si `dayInfo` n'est pas un objet.
+
+## Exemples
+
+### Utiliser la méthode `toPlainDate()`
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-07");
+const date = ym.toPlainDate({ day: 1 });
+console.log(date.toString()); // 2021-07-01
+
+const ym2 = Temporal.PlainYearMonth.from("2021-07-01[u-ca=chinese]");
+const date2 = ym2.toPlainDate({ day: 15 });
+console.log(date2.toString()); // 2021-06-24[u-ca=chinese]
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- L'objet {{JSxRef("Temporal.PlainDate")}}
+- La méthode {{JSxRef("Temporal/PlainDate/toPlainYearMonth", "Temporal.PlainDate.prototype.toPlainYearMonth()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/tostring/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/tostring/index.md
@@ -1,0 +1,92 @@
+---
+title: "Temporal.PlainYearMonth : méthode toString()"
+short-title: toString()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/toString
+l10n:
+  sourceCommit: 9b86874b5762b52ce0055f58d561004d1a204ad5
+---
+
+La méthode **`toString()`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne une chaîne de caractères représentant cette année-mois au format [RFC 9557](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth#format_rfc_9557).
+
+## Syntaxe
+
+```js-nolint
+toString()
+toString(options)
+```
+
+### Paramètres
+
+- `options` {{Optional_Inline}}
+  - : Un objet contenant la propriété suivante&nbsp;:
+    - `calendarName` {{Optional_Inline}}
+      - : Indique si l'annotation du calendrier (`[u-ca=calendar_id]`) doit être affichée dans la valeur de retour. Les valeurs possibles sont&nbsp;:
+        - `"auto"` (par défaut)
+          - : Inclut l'annotation du calendrier si le calendrier n'est pas `"iso8601"`. Le jour de référence est inclus si le calendrier n'est pas `"iso8601"`.
+        - `"always"`
+          - : Inclut toujours l'annotation du calendrier. Le jour de référence est toujours inclus également.
+        - `"never"`
+          - : N'inclut jamais l'annotation du calendrier. Cela rend la chaîne de caractères retournée non récupérable en tant que même instance de {{JSxRef("Temporal.PlainYearMonth")}}, bien que la valeur du mois et de son année reste la même. Le jour de référence est inclus si le calendrier n'est pas `"iso8601"`.
+        - `"critical"`
+          - : Inclut toujours l'annotation du calendrier et ajoute un indicateur critique&nbsp;: `[!u-ca=calendar_id]`. Utile lors de l'envoi de la chaîne de caractères à certains systèmes, mais pas utile pour Temporal lui-même. Le jour de référence est toujours inclus également.
+
+### Valeur de retour
+
+Une chaîne de caractères au format [RFC 9557](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth#format_rfc_9557) représentant ce mois et cette année. L'annotation du calendrier est incluse comme défini. Le jour de référence est inclus si une annotation du calendrier est incluse ou si le calendrier n'est pas `"iso8601"`.
+
+### Exceptions
+
+- {{JSxRef("RangeError")}}
+  - : Levée si l'une des options est invalide.
+- {{JSxRef("TypeError")}}
+  - : Levée si `options` n'est pas un objet ou `undefined`.
+
+## Exemples
+
+### Utiliser la méthode `toString()`
+
+```js
+const ym = Temporal.PlainYearMonth.from({ year: 2021, month: 8 });
+console.log(ym.toString()); // '2021-08'
+
+const ym2 = Temporal.PlainYearMonth.from({
+  year: 5781,
+  monthCode: "M08",
+  calendar: "hebrew",
+});
+console.log(ym2.toString()); // '2021-04-13[u-ca=hebrew]'
+```
+
+### Utiliser des options
+
+```js
+const isoYM = Temporal.PlainYearMonth.from({ year: 2021, month: 8 });
+const ym = Temporal.PlainYearMonth.from({
+  year: 5781,
+  monthCode: "M08",
+  calendar: "hebrew",
+});
+console.log(isoYM.toString({ calendarName: "auto" })); // '2021-08'
+console.log(ym.toString({ calendarName: "auto" })); // '2021-04-13[u-ca=hebrew]'
+console.log(isoYM.toString({ calendarName: "always" })); // '2021-08-01[u-ca=iso8601]'
+console.log(ym.toString({ calendarName: "always" })); // '2021-04-13[u-ca=hebrew]'
+console.log(isoYM.toString({ calendarName: "never" })); // '2021-08'
+console.log(ym.toString({ calendarName: "never" })); // '2021-04-13'
+console.log(isoYM.toString({ calendarName: "critical" })); // '2021-08-01[!u-ca=iso8601]'
+console.log(ym.toString({ calendarName: "critical" })); // '2021-04-13[!u-ca=hebrew]'
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode statique {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/toJSON", "Temporal.PlainYearMonth.prototype.toJSON()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/toLocaleString", "Temporal.PlainYearMonth.prototype.toLocaleString()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/until/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/until/index.md
@@ -1,0 +1,67 @@
+---
+title: "Temporal.PlainYearMonth : méthode until()"
+short-title: until()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/until
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La méthode **`until()`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne un nouvel objet {{JSxRef("Temporal.Duration")}} représentant la durée entre de ce mois et son année et d'un autre mois et son année (sous une forme convertible par {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}). La durée est positive si l'autre mois est après ce mois, et négative si avant.
+
+Cette méthode effectue `other - this`. Pour effectuer `this - other`, utilisez la méthode {{JSxRef("Temporal/PlainYearMonth/since", "since()")}}.
+
+## Syntaxe
+
+```js-nolint
+until(other)
+until(other, options)
+```
+
+### Paramètres
+
+- `other`
+  - : Une chaîne de caractères, un objet ou une instance de {{JSxRef("Temporal.PlainYearMonth")}} représentant un mois et une année à soustraire de ce mois et cette année. Il est converti en objet `Temporal.PlainYearMonth` en utilisant le même algorithme que {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}. Il doit avoir le même calendrier que `this`.
+- `options` {{Optional_Inline}}
+  - : Les mêmes options que [`since()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/since#options).
+
+### Valeur de retour
+
+Un nouvel objet {{JSxRef("Temporal.Duration")}} représentant la durée entre ce mois et son année _jusqu'à_ `other`. La durée est positive si `other` est après ce mois et son année, et négative si avant.
+
+### Exceptions
+
+- {{JSxRef("RangeError")}}
+  - : Levée dans l'un des cas suivants&nbsp;:
+    - `other` utilise un calendrier différent de celui de `this`.
+    - Aucune des options n'est valide.
+
+## Exemples
+
+### Utiliser la méthode `until()`
+
+```js
+const launch = Temporal.PlainYearMonth.from("2035-01");
+const now = Temporal.Now.plainDateISO().toPlainYearMonth();
+const duration = now.until(launch);
+console.log(
+  `Il restera ${duration.toLocaleString("fr-FR")} jusqu'au lancement.`,
+);
+```
+
+Pour plus d'exemples, voir {{JSxRef("Temporal/PlainYearMonth/since", "since()")}}.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- L'objet {{JSxRef("Temporal.Duration")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/add", "Temporal.PlainYearMonth.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/subtract", "Temporal.PlainYearMonth.prototype.subtract()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/since", "Temporal.PlainYearMonth.prototype.since()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/valueof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/valueof/index.md
@@ -1,0 +1,63 @@
+---
+title: "Temporal.PlainYearMonth : méthode valueOf()"
+short-title: valueOf()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/valueOf
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La méthode **`valueOf()`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} lève un objet {{JSxRef("TypeError")}}, ce qui empêche les instances de `Temporal.PlainYearMonth` d'être [converties implicitement en primitives](/fr/docs/Web/JavaScript/Guide/Data_structures#contrainte_de_primitive) lorsqu'elles sont utilisées dans des opérations arithmétiques ou de comparaison.
+
+## Syntaxe
+
+```js-nolint
+valueOf()
+```
+
+### Paramètres
+
+Aucun.
+
+### Valeur de retour
+
+Aucune.
+
+### Exceptions
+
+- {{JSxRef("TypeError")}}
+  - : Toujours levée.
+
+## Description
+
+Parce que la [conversion en primitive](/fr/docs/Web/JavaScript/Guide/Data_structures#contrainte_de_primitive) et la [conversion en nombre](/fr/docs/Web/JavaScript/Reference/Global_Objects/Number#contrainte_de_nombre) appellent `valueOf()` avant `toString()`, si `valueOf()` est absent, alors une expression comme `yearMonth1 > yearMonth2` les comparerait implicitement comme des chaînes de caractères, ce qui peut donner des résultats inattendus. En levant un `TypeError`, les instances de `Temporal.PlainYearMonth` empêchent ces conversions implicites. Vous devez les convertir explicitement en chaînes de caractères en utilisant {{JSxRef("Temporal/PlainYearMonth/toString", "Temporal.PlainYearMonth.prototype.toString()")}}, ou utiliser la méthode statique {{JSxRef("Temporal/PlainYearMonth/compare", "Temporal.PlainYearMonth.compare()")}} pour les comparer.
+
+## Exemples
+
+### Opérations arithmétiques et de comparaison sur `Temporal.PlainYearMonth`
+
+Toutes les opérations arithmétiques et de comparaison sur les instances de `Temporal.PlainYearMonth` doivent utiliser les méthodes dédiées ou les convertir explicitement en primitives.
+
+```js
+const ym1 = Temporal.PlainYearMonth.from("2021-01");
+const ym2 = Temporal.PlainYearMonth.from("2021-07");
+ym1 > ym2; // TypeError: can't convert PlainYearMonth to primitive type
+Temporal.PlainYearMonth.compare(ym1, ym2); // -1
+
+ym2 - ym1; // TypeError: can't convert PlainYearMonth to primitive type
+ym2.since(ym1).toString(); // "P6M"
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/toString", "Temporal.PlainYearMonth.prototype.toString()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/toJSON", "Temporal.PlainYearMonth.prototype.toJSON()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/toLocaleString", "Temporal.PlainYearMonth.prototype.toLocaleString()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/with/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/with/index.md
@@ -1,0 +1,73 @@
+---
+title: "Temporal.PlainYearMonth : méthode with()"
+short-title: with()
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/with
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La méthode **`with()`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne un nouvel objet `Temporal.PlainYearMonth` représentant ce mois et son année avec certains champs remplacés par de nouvelles valeurs. Comme tous les objets `Temporal` sont conçus pour être immuables, cette méthode fonctionne essentiellement comme le mutateur des champs de mois et d'année.
+
+Il n'existe pas de moyen évident de créer un nouvel objet `Temporal.PlainYearMonth` représentant le même mois et la même année dans un calendrier différent. Pour remplacer sa propriété `calendarId`, vous devez d'abord le convertir en un objet {{JSxRef("Temporal.PlainDate")}} en utilisant {{JSxRef("Temporal/PlainYearMonth/toPlainDate", "toPlainDate()")}}, changer le calendrier, puis le reconvertir.
+
+## Syntaxe
+
+```js-nolint
+with(info)
+with(info, options)
+```
+
+### Paramètres
+
+- `info`
+  - : Un objet contenant au moins une des propriétés reconnues par {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}} (à l'exception de `calendar`)&nbsp;: `era` et `eraYear`, `month`, `monthCode`, `year`. Les propriétés non définies utilisent les valeurs du mois et de l'année d'origine. Vous n'avez besoin de fournir qu'un seul de `month` ou `monthCode`, et un seul de `era` et `eraYear` ou `year`, et l'autre sera mis à jour en conséquence.
+- `options` {{Optional_Inline}}
+  - : Un objet contenant la propriété suivante&nbsp;:
+    - `overflow` {{Optional_Inline}}
+      - : Une chaîne de caractères définissant le comportement lorsque un composant de date est hors de portée. Les valeurs possibles sont&nbsp;:
+        - `"constrain"` (par défaut)
+          - : Le composant de date est [contraint](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate#ficer_les_dates_invalides) à la plage valide.
+        - `"reject"`
+          - : Un objet {{JSxRef("RangeError")}} est levé si le composant de date est hors de portée.
+
+### Valeur de retour
+
+Un nouvel objet `Temporal.PlainYearMonth`, où les champs définis dans `info` qui ne sont pas `undefined` sont remplacés par les valeurs correspondantes, et le reste des champs est copié à partir de la date d'origine.
+
+### Exceptions
+
+- {{JSxRef("TypeError")}}
+  - : Levée dans l'un des cas suivants&nbsp;:
+    - `info` n'est pas un objet.
+    - `options` n'est pas un objet ou est `undefined`.
+- {{JSxRef("RangeError")}}
+  - : Levée dans l'un des cas suivants&nbsp;:
+    - Les propriétés fournies qui définissent le même composant sont incohérentes.
+    - Les propriétés non numériques fournies ne sont pas valides&nbsp;; par exemple, si `monthCode` n'est jamais un code de mois valide dans ce calendrier.
+    - Les propriétés numériques fournies sont hors de portée, et `options.overflow` est défini sur `"reject"`.
+    - Le résultat n'est pas dans la [plage représentable](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#dates_représentables), qui est ±(10<sup>8</sup> + 1) jours, soit environ ±273 972,6 ans, à partir de l'époque Unix.
+
+## Exemples
+
+### Utiliser la méthode `with()`
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-07");
+const newYM = ym.with({ year: 2024 });
+console.log(newYM.toString()); // "2024-07"
+```
+
+Pour plus d'exemples, consultez la documentation des propriétés individuelles qui peuvent être définies en utilisant `with()`.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode statique {{JSxRef("Temporal/PlainYearMonth/from", "Temporal.PlainYearMonth.from()")}}

--- a/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/year/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/plainyearmonth/year/index.md
@@ -1,0 +1,41 @@
+---
+title: "Temporal.PlainYearMonth : propriété year"
+short-title: year
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/year
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La propriété d'accesseur **`year`** des instances de {{JSxRef("Temporal.PlainYearMonth")}} retourne un entier représentant le nombre d'années de ce mois et son année par rapport au début d'une année d'époque spécifique au calendrier. Elle dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+
+Le mutateur d'accesseur de `year` est `undefined`. Vous ne pouvez pas modifier cette propriété directement. Utilisez la méthode {{JSxRef("Temporal/PlainYearMonth/with", "with()")}} pour créer un nouvel objet `Temporal.PlainYearMonth` avec la nouvelle valeur souhaitée.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainDate/year", "Temporal.PlainDate.prototype.year")}}.
+
+## Exemples
+
+### Utiliser la propriété `year`
+
+```js
+const ym = Temporal.PlainYearMonth.from("2021-07"); // calendrier ISO 8601
+console.log(ym.year); // 2021
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.PlainYearMonth")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/with", "Temporal.PlainYearMonth.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/add", "Temporal.PlainYearMonth.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/PlainYearMonth/subtract", "Temporal.PlainYearMonth.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/era", "Temporal.PlainYearMonth.prototype.era")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/eraYear", "Temporal.PlainYearMonth.prototype.eraYear")}}
+- La propriété {{JSxRef("Temporal/PlainYearMonth/month", "Temporal.PlainYearMonth.prototype.month")}}
+- La propriété {{JSxRef("Temporal/PlainDate/year", "Temporal.PlainDate.prototype.year")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Temporal.PlainYearMonth` pages

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_