### PR TITLE
chore(fr): translation of `Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/era`

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/temporal/zoneddatetime/era/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/zoneddatetime/era/index.md
@@ -1,0 +1,45 @@
+---
+title: "Temporal.ZonedDateTime : propriété era"
+short-title: era
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/era
+l10n:
+  sourceCommit: 9b86874b5762b52ce0055f58d561004d1a204ad5
+---
+
+La propriété d'accesseur **`era`** des instances de {{JSxRef("Temporal.ZonedDateTime")}} retourne une chaîne de caractères en minuscules spécifique au calendrier représentant l'ère de cette date, ou `undefined` si le calendrier n'utilise pas d'ères (par exemple, ISO 8601). `era` et `eraYear` identifient ensemble de manière unique une année dans un calendrier, de la même manière que `year`. Elle dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+
+Le mutateur d'accesseur de `era` est `undefined`. Vous ne pouvez pas modifier cette propriété directement. Utilisez la méthode {{JSxRef("Temporal/ZonedDateTime/with", "with()")}} pour créer un nouvel objet `Temporal.ZonedDateTime` avec la nouvelle valeur souhaitée.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainDate/era", "Temporal.PlainDate.prototype.era")}}.
+
+## Exemples
+
+### Utiliser la propriété `era`
+
+```js
+const dt = Temporal.ZonedDateTime.from("2021-07-01[America/New_York]"); // ISO 8601 calendar
+console.log(dt.era); // undefined
+
+const dt2 = Temporal.ZonedDateTime.from(
+  "2021-07-01[America/New_York][u-ca=gregory]",
+);
+console.log(dt2.era); // ce
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.ZonedDateTime")}}
+- La méthode {{JSxRef("Temporal/ZonedDateTime/with", "Temporal.ZonedDateTime.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/ZonedDateTime/add", "Temporal.ZonedDateTime.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/ZonedDateTime/subtract", "Temporal.ZonedDateTime.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/ZonedDateTime/year", "Temporal.ZonedDateTime.prototype.year")}}
+- La propriété {{JSxRef("Temporal/ZonedDateTime/eraYear", "Temporal.ZonedDateTime.prototype.eraYear")}}
+- La propriété {{JSxRef("Temporal/PlainDate/era", "Temporal.PlainDate.prototype.era")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/era`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_