### PR TITLE
chore(fr): translation of `Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/eraYear`

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/temporal/zoneddatetime/erayear/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/zoneddatetime/erayear/index.md
@@ -1,0 +1,55 @@
+---
+title: "Temporal.ZonedDateTime : propriété eraYear"
+short-title: eraYear
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/eraYear
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La propriété d'accesseur **`eraYear`** des instances de {{JSxRef("Temporal.ZonedDateTime")}} retourne un entier non négatif représentant l'année de cette date dans l'ère, ou `undefined` si le calendrier n'utilise pas d'ères (par exemple, ISO 8601). L'index de l'année commence généralement à 1 (plus courant) ou 0, et les années dans une ère peuvent diminuer avec le temps (par exemple, avant l'ère commune dans le calendrier grégorien). `era` et `eraYear` identifient ensemble de manière unique une année dans un calendrier, de la même manière que `year`. Elle dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+
+Le mutateur d'accesseur de `eraYear` est `undefined`. Vous ne pouvez pas modifier cette propriété directement. Utilisez la méthode {{JSxRef("Temporal/ZonedDateTime/with", "with()")}} pour créer un nouvel objet `Temporal.ZonedDateTime` avec la nouvelle valeur souhaitée.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainDate/eraYear", "Temporal.PlainDate.prototype.eraYear")}}.
+
+## Exemples
+
+### Utiliser la propriété `eraYear`
+
+```js
+const dt = Temporal.ZonedDateTime.from("2021-07-01[America/New_York]"); // calendrier ISO 8601
+console.log(dt.eraYear); // undefined
+
+const dt2 = Temporal.ZonedDateTime.from(
+  "2021-07-01[America/New_York][u-ca=gregory]",
+);
+console.log(dt2.eraYear); // 2021
+
+const dt3 = Temporal.ZonedDateTime.from(
+  "-002021-07-01[America/New_York][u-ca=gregory]",
+);
+console.log(dt3.eraYear); // 2022 ; 0000 est utilisé pour l'année 1 avant notre ère
+
+const dt4 = Temporal.ZonedDateTime.from(
+  "2021-07-01[America/New_York][u-ca=japanese]",
+);
+console.log(dt4.eraYear); // 3
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.ZonedDateTime")}}
+- La méthode {{JSxRef("Temporal/ZonedDateTime/with", "Temporal.ZonedDateTime.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/ZonedDateTime/add", "Temporal.ZonedDateTime.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/ZonedDateTime/subtract", "Temporal.ZonedDateTime.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/ZonedDateTime/year", "Temporal.ZonedDateTime.prototype.year")}}
+- La propriété {{JSxRef("Temporal/ZonedDateTime/era", "Temporal.ZonedDateTime.prototype.era")}}
+- La propriété {{JSxRef("Temporal/PlainDate/eraYear", "Temporal.PlainDate.prototype.eraYear")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/eraYear`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_