### PR TITLE
chore(fr): translation of `Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/inLeapYear`

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/temporal/zoneddatetime/inleapyear/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/zoneddatetime/inleapyear/index.md
@@ -1,0 +1,43 @@
+---
+title: "Temporal.ZonedDateTime : propriété inLeapYear"
+short-title: inLeapYear
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/inLeapYear
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La propriété d'accesseur **`inLeapYear`** des instances de {{JSxRef("Temporal.ZonedDateTime")}} retourne un booléen indiquant si cette date se trouve dans une année bissextile. Une année bissextile est une année qui a plus de jours (en raison d'un jour ou d'un mois intercalaire) qu'une année commune. Elle dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+
+Le mutateur d'accesseur de `inLeapYear` est `undefined`. Vous ne pouvez pas modifier cette propriété directement.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainDate/inLeapYear", "Temporal.PlainDate.prototype.inLeapYear")}}.
+
+## Exemples
+
+### Utiliser la propriété `inLeapYear`
+
+```js
+const dt = Temporal.ZonedDateTime.from("2021-07-01[America/New_York]");
+console.log(dt.inLeapYear); // false
+console.log(dt.daysInYear); // 365
+console.log(dt.monthsInYear); // 12
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.ZonedDateTime")}}
+- La méthode {{JSxRef("Temporal/ZonedDateTime/with", "Temporal.ZonedDateTime.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/ZonedDateTime/add", "Temporal.ZonedDateTime.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/ZonedDateTime/subtract", "Temporal.ZonedDateTime.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/ZonedDateTime/year", "Temporal.ZonedDateTime.prototype.year")}}
+- La propriété {{JSxRef("Temporal/ZonedDateTime/daysInYear", "Temporal.ZonedDateTime.prototype.daysInYear")}}
+- La propriété {{JSxRef("Temporal/ZonedDateTime/monthsInYear", "Temporal.ZonedDateTime.prototype.monthsInYear")}}
+- La propriété {{JSxRef("Temporal/PlainDate/inLeapYear", "Temporal.PlainDate.prototype.inLeapYear")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/inLeapYear`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_