### PR TITLE
chore(fr): translation of `Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/yearOfWeek`

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/temporal/zoneddatetime/yearofweek/index.md
+++ b/files/fr/web/javascript/reference/global_objects/temporal/zoneddatetime/yearofweek/index.md
@@ -1,0 +1,34 @@
+---
+title: "Temporal.ZonedDateTime : propriété yearOfWeek"
+short-title: yearOfWeek
+slug: Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/yearOfWeek
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+La propriété accesseur **`yearOfWeek`** des instances de {{JSxRef("Temporal.ZonedDateTime")}} retourne un entier représentant l'année à associer à la {{JSxRef("Temporal/ZonedDateTime/weekOfYear", "weekOfYear")}} de cette date, ou `undefined` si le calendrier n'a pas de système de semaines bien défini. Cela dépend du [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Temporal#calendriers).
+
+L'accesseur de définition de `yearOfWeek` est `undefined`. Vous ne pouvez pas modifier cette propriété directement.
+
+Pour des informations générales et plus d'exemples, voir {{JSxRef("Temporal/PlainDate/yearOfWeek", "Temporal.PlainDate.prototype.yearOfWeek")}}.
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'objet {{JSxRef("Temporal.ZonedDateTime")}}
+- La méthode {{JSxRef("Temporal/ZonedDateTime/with", "Temporal.ZonedDateTime.prototype.with()")}}
+- La méthode {{JSxRef("Temporal/ZonedDateTime/add", "Temporal.ZonedDateTime.prototype.add()")}}
+- La méthode {{JSxRef("Temporal/ZonedDateTime/subtract", "Temporal.ZonedDateTime.prototype.subtract()")}}
+- La propriété {{JSxRef("Temporal/ZonedDateTime/year", "Temporal.ZonedDateTime.prototype.year")}}
+- La propriété {{JSxRef("Temporal/ZonedDateTime/weekOfYear", "Temporal.ZonedDateTime.prototype.weekOfYear")}}
+- La propriété {{JSxRef("Temporal/ZonedDateTime/dayOfWeek", "Temporal.ZonedDateTime.prototype.dayOfWeek")}}
+- La propriété {{JSxRef("Temporal/ZonedDateTime/daysInWeek", "Temporal.ZonedDateTime.prototype.daysInWeek")}}
+- La propriété {{JSxRef("Temporal/ZonedDateTime/daysInYear", "Temporal.ZonedDateTime.prototype.daysInYear")}}
+- La propriété {{JSxRef("Temporal/PlainDate/yearOfWeek", "Temporal.PlainDate.prototype.yearOfWeek")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/yearOfWeek`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_