### PR TITLE
chore(zh-CN): translation of Web/API/Window/requestAnimationFrame

### DIFF
--- a/files/zh-cn/web/api/window/requestanimationframe/index.md
+++ b/files/zh-cn/web/api/window/requestanimationframe/index.md
@@ -1,15 +1,16 @@
 ---
 title: Window：requestAnimationFrame() 方法
+short-title: requestAnimationFrame()
 slug: Web/API/Window/requestAnimationFrame
 l10n:
-  sourceCommit: f9f48866f02963e752717310b76a70d5bdaf554c
+  sourceCommit: 14964f7b946f7e7f19c1a0a2f71e4e8db60ecd4a
 ---
 
 {{APIRef}}
 
 **`window.requestAnimationFrame()`** 方法会告诉浏览器你希望执行一个动画。它要求浏览器在下一次重绘之前，调用用户提供的回调函数。
 
-对回调函数的调用频率通常与显示器的刷新率相匹配。虽然 75hz、120hz 和 144hz 也被广泛使用，但是最常见的刷新率还是 60hz（每秒 60 个周期/帧）。为了提高性能和电池寿命，大多数浏览器都会暂停在后台选项卡或者隐藏的 {{ HTMLElement("iframe") }} 中运行的 `requestAnimationFrame()`。
+对回调函数的调用频率通常与显示器的刷新率相匹配。最常见的刷新率是 60hz（每秒 60 个周期/帧），不过 75hz、120hz 和 144hz 也被广泛使用。为了提高性能和电池寿命，大多数浏览器都会暂停在后台选项卡或者隐藏的 {{ HTMLElement("iframe") }} 中运行的 `requestAnimationFrame()`。
 
 > [!NOTE]
 > 若你想在浏览器下次重绘之前继续更新下一帧动画，那么回调函数自身必须再次调用 `requestAnimationFrame()`。`requestAnimationFrame()` 是一次性的。
@@ -34,10 +35,13 @@ requestAnimationFrame(callback)
 
 ### 返回值
 
-请求 ID 是一个 `long` 类型整数值，是在回调列表里的唯一标识符。这是一个非零值，但你不能对该值做任何其他假设。你可以将此值传递给 {{domxref("window.cancelAnimationFrame()")}} 函数以取消该刷新回调请求。
+一个 `unsigned long` 整数值，即请求 ID，是在回调列表里的唯一标识符。这是一个非零值，但你不能对该值做任何其他假设。你可以将此值传递给 {{domxref("window.cancelAnimationFrame()")}} 函数以取消该刷新回调请求。
 
 > [!WARNING]
-> 请求 ID 通常实现为每个窗口的递增计数器。因此，即使它从 1 开始计数，也可能会溢出并最终达到 0。虽然这不太可能对短期应用程序造成问题，但你应该避免使用 `0` 作为无效请求标识符 ID 的哨兵值，而应该使用无法达到的值，如 `null`。规范没有指定溢出行为，因此浏览器具有不同的行为。溢出时，该值要么回绕到 0，要么变为负值，要么抛出错误。除非溢出会抛出异常，否则请求 ID 也不是真正唯一的，因为对于可能无限多的回调函数，只有有限多个 32 位整数。但请注意，在 60Hz 渲染频率下，每帧调用 100 次 `requestAnimationFrame()`，大约需要 500 天才会出现此问题。
+> 请求 ID 通常实现为每个窗口的递增计数器。因此，即使它从 1 开始计数，也可能会溢出并最终达到 0。虽然这不太可能对短期应用程序造成问题，但你应该避免使用 `0` 作为无效请求标识符 ID 的哨兵值，而应该使用无法达到的值，如 `null`。
+> 规范没有指定溢出行为，因此浏览器具有不同的行为。溢出时，该值要么回绕到 0，要么变为负值，要么抛出错误。
+> 除非溢出会抛出异常，否则请求 ID 也不是真正唯一的，因为对于可能无限多的回调函数，只有有限多个 32 位整数。
+> 但请注意，在 60Hz 渲染频率下，每帧调用一次 `requestAnimationFrame()`，大约需要 800 天才会出现此问题。
 
 ## 示例
 
@@ -45,8 +49,7 @@ requestAnimationFrame(callback)
 
 ```js
 const element = document.getElementById("some-element-you-want-to-animate");
-let start, previousTimeStamp;
-let done = false;
+let start;
 
 function step(timestamp) {
   if (start === undefined) {
@@ -54,38 +57,30 @@ function step(timestamp) {
   }
   const elapsed = timestamp - start;
 
-  if (previousTimeStamp !== timestamp) {
-    // 这里使用 Math.min() 确保元素在恰好位于 200px 时停止运动
-    const count = Math.min(0.1 * elapsed, 200);
-    element.style.transform = `translateX(${count}px)`;
-    if (count === 200) done = true;
-  }
-
-  if (elapsed < 2000) {
-    // 2 秒之后停止动画
-    previousTimeStamp = timestamp;
-    if (!done) {
-      window.requestAnimationFrame(step);
-    }
+  // Math.min() 用于确保元素精确停在 200px
+  const shift = Math.min(0.1 * elapsed, 200);
+  element.style.transform = `translateX(${shift}px)`;
+  if (shift < 200) {
+    requestAnimationFrame(step);
   }
 }
 
-window.requestAnimationFrame(step);
+requestAnimationFrame(step);
 ```
 
-以下三个示例说明了设置时间零点的不同方法，时间零点是计算每帧中动画进度的起点。如果你想同步到外部时钟，例如 {{domxref("BaseAudioContext.currentTime")}}，可用的最高精度是单帧的持续时间（16.67ms @60hz）。回调函数的时间戳参数表示上一帧的结束，因此最快将在下一帧中呈现新计算的值。
+以下三个示例说明了设置时间零点的不同方法，时间零点是计算每帧动画进度的基准。如果你想与外部时钟同步，例如 {{domxref("BaseAudioContext.currentTime")}}，可用的最高精度是单帧的持续时间（60Hz 时为 16.67ms）。回调的时间戳参数表示上一帧的结束时间，因此新计算的值最快会在下一帧中呈现。
 
-此示例会等待第一个回调函数执行时设置 `zero`。如果你的动画在开始时跳转到新值，则必须采用这种结构。如果你无需与任意外部同步（例如音频），则建议使用此方法，因为某些浏览器在首次调用 `requestAnimationFrame()` 和首次调用回调函数之间会有多帧延迟。
+此示例等待第一个回调执行时设置 `zero`。如果你的动画在开始时跳转到新值，则必须采用这种结构。如果你不需要与任何外部内容（如音频）同步，则建议使用此方法，因为某些浏览器在首次调用 `requestAnimationFrame()` 和首次调用回调函数之间会有多帧延迟。
 
 ```js
 let zero;
 requestAnimationFrame(firstFrame);
-function firstFrame(timeStamp) {
-  zero = timeStamp;
-  animate(timeStamp);
+function firstFrame(timestamp) {
+  zero = timestamp;
+  animate(timestamp);
 }
-function animate(timeStamp) {
-  const value = (timeStamp - zero) / duration;
+function animate(timestamp) {
+  const value = (timestamp - zero) / duration;
   if (value < 1) {
     element.style.opacity = value;
     requestAnimationFrame((t) => animate(t));
@@ -93,13 +88,13 @@ function animate(timeStamp) {
 }
 ```
 
-此示例在第一次调用 `requestAnimationFrame` 前使用 {{domxref("AnimationTimeline/currentTime", "document.timeline.currentTime")}} 设置了一个零值。`document.timeline.currentTime` 与 `timeStamp` 参数对齐，因此零值等价于第 0 帧的时间戳。
+此示例在首次调用 `requestAnimationFrame` 之前使用 {{domxref("AnimationTimeline/currentTime", "document.timeline.currentTime")}} 设置零值。`document.timeline.currentTime` 与 `timestamp` 参数对齐，因此零值等同于第 0 帧的时间戳。
 
 ```js
 const zero = document.timeline.currentTime;
 requestAnimationFrame(animate);
-function animate(timeStamp) {
-  const value = (timeStamp - zero) / duration; // animation-timing-function: linear
+function animate(timestamp) {
+  const value = (timestamp - zero) / duration; // animation-timing-function: linear
   if (value < 1) {
     element.style.opacity = value;
     requestAnimationFrame((t) => animate(t));
@@ -107,7 +102,10 @@ function animate(timeStamp) {
 }
 ```
 
-此示例使用 {{domxref("performance.now()")}} 而不是回调的时间戳值去设置动画。你可以使用它来实现稍高的同步精度，尽管附加精确度是易变的且增长不大。备注：此示例不能让你可靠地同步动画回调函数。
+此示例使用 {{domxref("performance.now()")}} 而非回调的时间戳值来进行动画。你可以使用此方法实现稍高的同步精度，尽管额外精度是可变的且提升不大。
+
+> [!NOTE]
+> 此示例不允许你可靠地同步动画回调。
 
 ```js
 const zero = performance.now();
@@ -116,7 +114,7 @@ function animate() {
   const value = (performance.now() - zero) / duration;
   if (value < 1) {
     element.style.opacity = value;
-    requestAnimationFrame((t) => animate(t));
+    requestAnimationFrame(animate);
   } else element.style.opacity = 1;
 }
 ```
@@ -134,4 +132,5 @@ function animate() {
 - {{domxref("Window.cancelAnimationFrame()")}}
 - {{domxref("DedicatedWorkerGlobalScope.requestAnimationFrame()")}}
 - [用 JavaScript 做动画：从 setInterval 到 requestAnimationFrame](https://hacks.mozilla.org/2011/08/animating-with-javascript-from-setinterval-to-requestanimationframe/)——博文
-- [TestUFO：测试你的 web 浏览器 requestAnimationFrame() 的时间偏差](https://www.testufo.com/#test=animation-time-graph)
+- [TestUFO：测试你的 web 浏览器 requestAnimationFrame() 的时间偏差](https://testufo.com/#test=animation-time-graph)
+- [Firefox 切换到 uint32_t 作为 requestAnimationFrame 请求 ID](https://phabricator.services.mozilla.com/rMOZILLACENTRAL149722297f033d5c3ad126d0c72edcb1cb96d72e)

--- a/files/zh-cn/web/api/window/requestanimationframe/index.md
+++ b/files/zh-cn/web/api/window/requestanimationframe/index.md
@@ -29,7 +29,7 @@ requestAnimationFrame(callback)
 - `callback`
   - : 该函数会在下一次重绘更新你的动画时被调用到。这个回调函数只会传递一个参数：
     - `timestamp`
-      - : 一个 {{domxref("DOMHighResTimeStamp")}} 参数，用于表示上一帧渲染的结束时间（从[起始时间](/zh-CN/docs/Web/API/Performance/timeOrigin)开始的毫秒数）。时间戳是一个以毫秒为单位的十进制数字，最小精度为 1 毫秒。对于 `Window` 对象（而非 `worker`）来说，它等同于 {{domxref("AnimationTimeline/currentTime", "document.timeline.currentTime")}}。此时间戳在同一代理上（所有同源的 `window`，更重要的是同源的 `iframe`）运行的所有窗口之间共享——它允许在多个 `requestAnimationFrame` 回调函数中执行同步动画。此时间戳值也近似于在回调函数开始时调用 {{domxref('performance.now()')}}，但它们永远都不会是相同的值。
+      - : 一个 {{domxref("DOMHighResTimeStamp")}} 参数，用于表示上一帧渲染的结束时间（从[起始时间](/zh-CN/docs/Web/API/Performance/timeOrigin)开始的毫秒数）。时间戳是一个以毫秒为单位的十进制数字，最小精度为 1 毫秒。对于 `Window`（而非 `Workers`）对象来说，它等同于 {{domxref("AnimationTimeline/currentTime", "document.timeline.currentTime")}}。此时间戳在同一代理上（所有同源的 `window`，更重要的是同源的 `iframe`）运行的所有窗口之间共享——它允许在多个 `requestAnimationFrame` 回调函数中执行同步动画。此时间戳值也近似于在回调函数开始时调用 {{domxref('performance.now()')}}，但它们永远都不会是相同的值。
 
         当 `requestAnimationFrame()` 队列中的多个回调开始在同一帧中触发时，它们都会收到相同的时间戳，即便在计算前一个回调函数工作量时这一帧的时间已经过去。
 
@@ -130,4 +130,4 @@ function animate() {
 - {{domxref("DedicatedWorkerGlobalScope.requestAnimationFrame()")}}
 - [用 JavaScript 做动画：从 setInterval 到 requestAnimationFrame](https://hacks.mozilla.org/2011/08/animating-with-javascript-from-setinterval-to-requestanimationframe/)——博文
 - [TestUFO：测试你的 web 浏览器 requestAnimationFrame() 的时间偏差](https://testufo.com/#test=animation-time-graph)
-- [Firefox 将 requestAnimationFrame 的请求 ID 改为 uint32_t 类型](https://phabricator.services.mozilla.com/rMOZILLACENTRAL149722297f033d5c3ad126d0c72edcb1cb96d72e)
+- [Firefox 将 requestAnimationFrame 的请求 ID 切换为 uint32_t 类型](https://phabricator.services.mozilla.com/rMOZILLACENTRAL149722297f033d5c3ad126d0c72edcb1cb96d72e)

--- a/files/zh-cn/web/api/window/requestanimationframe/index.md
+++ b/files/zh-cn/web/api/window/requestanimationframe/index.md
@@ -3,7 +3,7 @@ title: Window：requestAnimationFrame() 方法
 short-title: requestAnimationFrame()
 slug: Web/API/Window/requestAnimationFrame
 l10n:
-  sourceCommit: 14964f7b946f7e7f19c1a0a2f71e4e8db60ecd4a
+  sourceCommit: 90c1d8efd51c2f82d26e6b79e442f9dbcfafd048
 ---
 
 {{APIRef}}
@@ -35,13 +35,10 @@ requestAnimationFrame(callback)
 
 ### 返回值
 
-一个 `unsigned long` 整数值，即请求 ID，是在回调列表里的唯一标识符。这是一个非零值，但你不能对该值做任何其他假设。你可以将此值传递给 {{domxref("window.cancelAnimationFrame()")}} 函数以取消该刷新回调请求。
+一个 `unsigned long` 整数值，即请求 ID，用于唯一标识回调列表中的条目。不应该对该值做任何假设。你可以将此值传递给 {{domxref("window.cancelAnimationFrame()")}} 函数以取消该刷新回调请求。
 
 > [!WARNING]
-> 请求 ID 通常实现为每个窗口的递增计数器。因此，即使它从 1 开始计数，也可能会溢出并最终达到 0。虽然这不太可能对短期应用程序造成问题，但你应该避免使用 `0` 作为无效请求标识符 ID 的哨兵值，而应该使用无法达到的值，如 `null`。
-> 规范没有指定溢出行为，因此浏览器具有不同的行为。溢出时，该值要么回绕到 0，要么变为负值，要么抛出错误。
-> 除非溢出会抛出异常，否则请求 ID 也不是真正唯一的，因为对于可能无限多的回调函数，只有有限多个 32 位整数。
-> 但请注意，在 60Hz 渲染频率下，每帧调用一次 `requestAnimationFrame()`，大约需要 800 天才会出现此问题。
+> 请求 ID 通常实现为每个窗口的递增计数器。因此，即使它从 1 开始计数，也可能会溢出并最终达到 0。虽然这不太可能对短期应用程序造成问题，但你应该避免使用 `0` 作为无效请求标识符 ID 的哨兵值，而应该使用无法达到的值，如 `null`。规范没有指定溢出行为，因此浏览器具有不同的行为。溢出时，该值要么回绕到 0，要么变为负值，要么抛出错误。除非溢出会抛出异常，否则请求 ID 也不是真正唯一的，因为对于可能无限多的回调函数，只有有限多个 32 位整数。但请注意，在 60Hz 渲染频率下，每帧调用一次 `requestAnimationFrame()`，大约需要 800 天才会出现此问题。
 
 ## 示例
 
@@ -70,7 +67,7 @@ requestAnimationFrame(step);
 
 以下三个示例说明了设置时间零点的不同方法，时间零点是计算每帧动画进度的基准。如果你想与外部时钟同步，例如 {{domxref("BaseAudioContext.currentTime")}}，可用的最高精度是单帧的持续时间（60Hz 时为 16.67ms）。回调的时间戳参数表示上一帧的结束时间，因此新计算的值最快会在下一帧中呈现。
 
-此示例等待第一个回调执行时设置 `zero`。如果你的动画在开始时跳转到新值，则必须采用这种结构。如果你不需要与任何外部内容（如音频）同步，则建议使用此方法，因为某些浏览器在首次调用 `requestAnimationFrame()` 和首次调用回调函数之间会有多帧延迟。
+此示例等待第一个回调执行后设置时间零点 `zero`。如果你的动画在开始时跳转到新值，则必须采用这种结构。如果你不需要与任何外部内容（如音频）同步，则建议使用此方法，因为某些浏览器在首次调用 `requestAnimationFrame()` 和首次调用回调函数之间会有多帧延迟。
 
 ```js
 let zero;
@@ -105,7 +102,7 @@ function animate(timestamp) {
 此示例使用 {{domxref("performance.now()")}} 而非回调的时间戳值来进行动画。你可以使用此方法实现稍高的同步精度，尽管额外精度是可变的且提升不大。
 
 > [!NOTE]
-> 此示例不允许你可靠地同步动画回调。
+> 此示例无法可靠地同步动画回调。
 
 ```js
 const zero = performance.now();
@@ -133,4 +130,4 @@ function animate() {
 - {{domxref("DedicatedWorkerGlobalScope.requestAnimationFrame()")}}
 - [用 JavaScript 做动画：从 setInterval 到 requestAnimationFrame](https://hacks.mozilla.org/2011/08/animating-with-javascript-from-setinterval-to-requestanimationframe/)——博文
 - [TestUFO：测试你的 web 浏览器 requestAnimationFrame() 的时间偏差](https://testufo.com/#test=animation-time-graph)
-- [Firefox 切换到 uint32_t 作为 requestAnimationFrame 请求 ID](https://phabricator.services.mozilla.com/rMOZILLACENTRAL149722297f033d5c3ad126d0c72edcb1cb96d72e)
+- [Firefox 将 requestAnimationFrame 的请求 ID 切换为 uint32_t 类型](https://phabricator.services.mozilla.com/rMOZILLACENTRAL149722297f033d5c3ad126d0c72edcb1cb96d72e)

--- a/files/zh-cn/web/api/window/requestanimationframe/index.md
+++ b/files/zh-cn/web/api/window/requestanimationframe/index.md
@@ -10,7 +10,7 @@ l10n:
 
 **`window.requestAnimationFrame()`** 方法会告诉浏览器你希望执行一个动画。它要求浏览器在下一次重绘之前，调用用户提供的回调函数。
 
-对回调函数的调用频率通常与显示器的刷新率相匹配。最常见的刷新率是 60hz（每秒 60 个周期/帧），不过 75hz、120hz 和 144hz 也被广泛使用。为了提高性能和电池寿命，大多数浏览器都会暂停在后台选项卡或者隐藏的 {{ HTMLElement("iframe") }} 中运行的 `requestAnimationFrame()`。
+对回调函数的调用频率通常与显示器的刷新率相匹配。虽然 75hz、120hz 和 144hz 也被广泛使用，但是最常见的刷新率还是 60hz（每秒 60 个周期/帧）。为了提高性能和电池寿命，大多数浏览器都会暂停在后台选项卡或者隐藏的 {{ HTMLElement("iframe") }} 中运行的 `requestAnimationFrame()`。
 
 > [!NOTE]
 > 若你想在浏览器下次重绘之前继续更新下一帧动画，那么回调函数自身必须再次调用 `requestAnimationFrame()`。`requestAnimationFrame()` 是一次性的。
@@ -65,9 +65,9 @@ function step(timestamp) {
 requestAnimationFrame(step);
 ```
 
-以下三个示例说明了设置时间零点的不同方法，时间零点是计算每帧动画进度的基准。如果你想与外部时钟同步，例如 {{domxref("BaseAudioContext.currentTime")}}，可用的最高精度是单帧的持续时间（60Hz 时为 16.67ms）。回调的时间戳参数表示上一帧的结束时间，因此新计算的值最快会在下一帧中呈现。
+以下三个示例演示了设置时间零点（即每帧计算动画进度时的基准点）的不同方法。如果你想与外部时钟同步，例如 {{domxref("BaseAudioContext.currentTime")}}，可用的最高精度是单帧时长，即 60Hz 下为 16.67ms。回调的时间戳参数表示上一帧的结束时间，因此新计算的值最快会在下一帧中呈现。
 
-此示例等待第一个回调执行后设置时间零点 `zero`。如果你的动画在开始时跳转到新值，则必须采用这种结构。如果你不需要与任何外部内容（如音频）同步，则建议使用此方法，因为某些浏览器在首次调用 `requestAnimationFrame()` 和首次调用回调函数之间会有多帧延迟。
+此示例会等待第一个回调执行后再设置时间零点 `zero`。如果你的动画在开始时需要跳转到新值，则必须采用这种结构。如果你无需与任何外部元素（如音频）进行同步，则建议采用此方法，因为某些浏览器在首次调用 `requestAnimationFrame()` 和首次调用回调函数之间会存在多帧的延迟。
 
 ```js
 let zero;
@@ -85,7 +85,7 @@ function animate(timestamp) {
 }
 ```
 
-此示例在首次调用 `requestAnimationFrame` 之前使用 {{domxref("AnimationTimeline/currentTime", "document.timeline.currentTime")}} 设置零值。`document.timeline.currentTime` 与 `timestamp` 参数对齐，因此零值等同于第 0 帧的时间戳。
+此示例使用 {{domxref("AnimationTimeline/currentTime", "document.timeline.currentTime")}} 在首次调用 `requestAnimationFrame` 之前设置零值。`document.timeline.currentTime` 与 `timestamp` 参数保持一致，因此该零值等同于第 0 帧的时间戳。
 
 ```js
 const zero = document.timeline.currentTime;
@@ -99,7 +99,7 @@ function animate(timestamp) {
 }
 ```
 
-此示例使用 {{domxref("performance.now()")}} 而非回调的时间戳值来进行动画。你可以使用此方法实现稍高的同步精度，尽管额外精度是可变的且提升不大。
+此示例使用 {{domxref("performance.now()")}} 而非回调的时间戳值来实现动画效果。你可以使用这种方法来获得略高的同步精度，不过这种额外的精度提升程度不一，且增幅不大。
 
 > [!NOTE]
 > 此示例无法可靠地同步动画回调。
@@ -130,4 +130,4 @@ function animate() {
 - {{domxref("DedicatedWorkerGlobalScope.requestAnimationFrame()")}}
 - [用 JavaScript 做动画：从 setInterval 到 requestAnimationFrame](https://hacks.mozilla.org/2011/08/animating-with-javascript-from-setinterval-to-requestanimationframe/)——博文
 - [TestUFO：测试你的 web 浏览器 requestAnimationFrame() 的时间偏差](https://testufo.com/#test=animation-time-graph)
-- [Firefox 将 requestAnimationFrame 的请求 ID 切换为 uint32_t 类型](https://phabricator.services.mozilla.com/rMOZILLACENTRAL149722297f033d5c3ad126d0c72edcb1cb96d72e)
+- [Firefox 将 requestAnimationFrame 的请求 ID 改为 uint32_t 类型](https://phabricator.services.mozilla.com/rMOZILLACENTRAL149722297f033d5c3ad126d0c72edcb1cb96d72e)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

根据 review 评论修复 `Window.requestAnimationFrame()` 文档的中文翻译问题：

- 修正 sourceCommit SHA 为 `90c1d8efd51c2f82d26e6b79e442f9dbcfafd048`
- 修复中文段落分行问题（WARNING 块不应分行）
- 修正返回值描述："是在回调列表里的唯一标识符" → "用于唯一标识回调列表中的条目"
- 修正翻译表述："此示例等待第一个回调执行时设置 zero" → "此示例等待第一个回调执行后设置时间零点 zero"
- 修正 NOTE 翻译："此示例不允许你可靠地同步动画回调" → "此示例无法可靠地同步动画回调"
- 翻译链接标题："Firefox 切换到 uint32_t 作为 requestAnimationFrame 请求 ID" → "Firefox 将 requestAnimationFrame 的请求 ID 切换为 uint32_t 类型"

### Motivation

根据维护者 review 反馈，修复翻译质量问题，确保译文准确、流畅、符合中文表达习惯。

### Additional details

**英文原文**：
- Window.requestAnimationFrame(): https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame

**上游提交**：
- requestAnimationFrame: 90c1d8efd51c2f82d26e6b79e442f9dbcfafd048

**验证 URL**（GitHub 提交历史）：
- requestAnimationFrame: https://github.com/mdn/content/commits/main/files/en-us/web/api/window/requestanimationframe/index.md

**Review 感谢**：
- 感谢 @PassionPenguin 和 @jasonren0403 的详细审查和宝贵建议

### Related issues and pull requests
