### PR TITLE
[es] Translate ServiceWorker API documentation

### DIFF
--- a/files/es/web/api/serviceworker/error_event/index.md
+++ b/files/es/web/api/serviceworker/error_event/index.md
@@ -3,7 +3,7 @@ title: "ServiceWorker: evento error"
 short-title: error
 slug: Web/API/ServiceWorker/error_event
 l10n:
-  sourceCommit: bc0237f139ee3a9db67a669ae1b6bf45ebba7f94
+  sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
 ---
 
 {{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}

--- a/files/es/web/api/serviceworker/error_event/index.md
+++ b/files/es/web/api/serviceworker/error_event/index.md
@@ -1,0 +1,50 @@
+---
+title: "ServiceWorker: evento error"
+short-title: error
+slug: Web/API/ServiceWorker/error_event
+l10n:
+  sourceCommit: bc0237f139ee3a9db67a669ae1b6bf45ebba7f94
+---
+
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
+
+El evento `error` se dispara cada vez que ocurre un error en el service worker.
+
+## Sintaxis
+
+Usa el nombre del evento en métodos como {{domxref("EventTarget.addEventListener", "addEventListener()")}}, o establece una propiedad de manejador de eventos.
+
+```js
+addEventListener("error", (event) => {});
+
+onerror = (event) => {};
+```
+
+## Tipo de evento
+
+Un {{domxref("Event")}} genérico.
+
+## Ejemplo
+
+El siguiente fragmento de código obtiene una referencia al objeto {{domxref("ServiceWorker")}} a través de {{domxref("ServiceWorkerRegistration.active")}} y establece un manejador `onerror` en el objeto resultante:
+
+```js
+// en la página controlada
+if (navigator.serviceWorker) {
+  navigator.serviceWorker.register("service-worker.js");
+
+  navigator.serviceWorker.ready.then((registration) => {
+    registration.active.onerror = (event) => {
+      console.log("¡Ocurrió un error en el service worker!");
+    };
+  });
+}
+```
+
+## Especificaciones
+
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}

--- a/files/es/web/api/serviceworker/index.md
+++ b/files/es/web/api/serviceworker/index.md
@@ -47,7 +47,6 @@ _La interfaz `ServiceWorker` hereda métodos de su padre, {{domxref("EventTarget
 ## Eventos
 
 - {{domxref("ServiceWorker.statechange_event", "statechange")}}
-
   - : Se dispara cuando {{domxref("ServiceWorker.state")}} cambia.
 
 - {{domxref("ServiceWorker.error_event", "error")}}

--- a/files/es/web/api/serviceworker/index.md
+++ b/files/es/web/api/serviceworker/index.md
@@ -47,6 +47,7 @@ _La interfaz `ServiceWorker` hereda métodos de su padre, {{domxref("EventTarget
 ## Eventos
 
 - {{domxref("ServiceWorker.statechange_event", "statechange")}}
+
   - : Se dispara cuando {{domxref("ServiceWorker.state")}} cambia.
 
 - {{domxref("ServiceWorker.error_event", "error")}}

--- a/files/es/web/api/serviceworker/index.md
+++ b/files/es/web/api/serviceworker/index.md
@@ -2,7 +2,7 @@
 title: ServiceWorker
 slug: Web/API/ServiceWorker
 l10n:
-  sourceCommit: 5d29bef0815f8cc4b5b152b9ee1ab53f002ee617
+  sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
 ---
 
 {{securecontext_header}}{{APIRef("Service Workers API")}}{{AvailableInWorkers}}

--- a/files/es/web/api/serviceworker/index.md
+++ b/files/es/web/api/serviceworker/index.md
@@ -1,0 +1,108 @@
+---
+title: ServiceWorker
+slug: Web/API/ServiceWorker
+l10n:
+  sourceCommit: 5d29bef0815f8cc4b5b152b9ee1ab53f002ee617
+---
+
+{{securecontext_header}}{{APIRef("Service Workers API")}}{{AvailableInWorkers}}
+
+La interfaz **`ServiceWorker`** de la [API de Service Worker](/es/docs/Web/API/Service_Worker_API) proporciona una referencia a un service worker. Múltiples {{glossary("browsing context", "contextos de navegación")}} (por ejemplo, páginas, workers, etc.) pueden estar asociados con el mismo service worker, cada uno a través de un objeto `ServiceWorker` único.
+
+Se puede acceder a un objeto `ServiceWorker` a través de varias propiedades:
+
+- {{domxref("ServiceWorkerRegistration.active")}}
+- {{domxref("ServiceWorkerGlobalScope.serviceWorker")}}
+- {{domxref("ServiceWorkerContainer.controller")}} — cuando el service worker está en estado `activating` o `activated`
+- {{domxref("ServiceWorkerRegistration.installing")}} — cuando el service worker está en estado `installing`
+- {{domxref("ServiceWorkerRegistration.waiting")}} — cuando el service worker está en estado `installed`
+
+La propiedad {{domxref("ServiceWorker.state")}} y el evento [`statechange`](/es/docs/Web/API/ServiceWorker/statechange_event) se pueden usar para comprobar y observar los cambios en el estado del ciclo de vida del service worker asociado al objeto.
+Los eventos relacionados del ciclo de vida, como [`install`](/es/docs/Web/API/ServiceWorkerGlobalScope/install_event) y [`activate`](/es/docs/Web/API/ServiceWorkerGlobalScope/activate_event), se disparan en el propio service worker.
+
+Los service workers permiten la importación estática de [módulos ECMAScript](/es/docs/Web/JavaScript/Guide/Modules), si son compatibles, usando [`import`](/es/docs/Web/JavaScript/Reference/Statements/import).
+La importación dinámica no está permitida por la especificación; llamar a [`import()`](/es/docs/Web/JavaScript/Reference/Operators/import) lanzará una excepción.
+
+Los service workers solo se pueden registrar en el ámbito Window en algunos o todos los navegadores, ya que el objeto `ServiceWorker` no está expuesto en {{domxref("DedicatedWorkerGlobalScope")}} ni en {{domxref("SharedWorkerGlobalScope")}}.
+Consulta la [compatibilidad con navegadores](#compatibilidad_con_navegadores) para más información.
+
+{{InheritanceDiagram}}
+
+## Propiedades de instancia
+
+_La interfaz `ServiceWorker` hereda propiedades de su padre, {{domxref("EventTarget")}}._
+
+- {{domxref("ServiceWorker.scriptURL")}} {{ReadOnlyInline}}
+  - : Devuelve la URL del script serializado del `ServiceWorker` definido como parte de {{domxref("ServiceWorkerRegistration")}}. La URL debe tener el mismo origen que el documento que registra el `ServiceWorker`.
+- {{domxref("ServiceWorker.state")}} {{ReadOnlyInline}}
+  - : Devuelve el estado del service worker. Retorna uno de los siguientes valores: `parsed`, `installing`, `installed`, `activating`, `activated`, o `redundant`.
+
+## Métodos de instancia
+
+_La interfaz `ServiceWorker` hereda métodos de su padre, {{domxref("EventTarget")}}._
+
+- {{domxref("ServiceWorker.postMessage()")}}
+  - : Envía un mensaje — que consiste en cualquier objeto JavaScript [clonable de forma estructurada](/es/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) — al service worker. El mensaje se transmite al service worker mediante un evento {{domxref("ServiceWorkerGlobalScope.message_event", "message")}} en su ámbito global.
+
+## Eventos
+
+- {{domxref("ServiceWorker.statechange_event", "statechange")}}
+
+  - : Se dispara cuando {{domxref("ServiceWorker.state")}} cambia.
+
+- {{domxref("ServiceWorker.error_event", "error")}}
+  - : Se dispara cuando ocurre un error dentro del objeto `ServiceWorker`.
+
+## Ejemplos
+
+Este fragmento de código proviene del [ejemplo de eventos de registro de service worker](https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/registration-events/index.html) ([demo en vivo](https://googlechrome.github.io/samples/service-worker/registration-events/)). El código escucha cualquier cambio en {{domxref("ServiceWorker.state")}} y devuelve su valor.
+
+```js
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker
+    .register("service-worker.js", {
+      scope: "./",
+    })
+    .then((registration) => {
+      let serviceWorker;
+      if (registration.installing) {
+        serviceWorker = registration.installing;
+        document.querySelector("#kind").textContent = "installing";
+      } else if (registration.waiting) {
+        serviceWorker = registration.waiting;
+        document.querySelector("#kind").textContent = "waiting";
+      } else if (registration.active) {
+        serviceWorker = registration.active;
+        document.querySelector("#kind").textContent = "active";
+      }
+      if (serviceWorker) {
+        // logState(serviceWorker.state);
+        serviceWorker.addEventListener("statechange", (e) => {
+          // logState(e.target.state);
+        });
+      }
+    })
+    .catch((error) => {
+      // Algo salió mal durante el registro. El archivo service-worker.js
+      // podría no estar disponible o contener un error de sintaxis.
+    });
+} else {
+  // El navegador actual no soporta service workers.
+  // Quizás es demasiado antiguo o no estamos en un Contexto Seguro.
+}
+```
+
+## Especificaciones
+
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
+
+## Véase también
+
+- [The Offline Cookbook](https://web.dev/articles/offline-cookbook) (service workers)
+- [Uso de Service Workers](/es/docs/Web/API/Service_Worker_API/Using_Service_Workers)
+- [Ejemplo básico de código de service worker](https://github.com/mdn/dom-examples/tree/main/service-worker/simple-service-worker)
+- [Uso de web workers](/es/docs/Web/API/Web_Workers_API/Using_web_workers)

--- a/files/es/web/api/serviceworker/postmessage/index.md
+++ b/files/es/web/api/serviceworker/postmessage/index.md
@@ -23,7 +23,6 @@ postMessage(message, options)
 ### Parámetros
 
 - `message`
-
   - : El objeto a entregar al worker; estará en el campo `data` del evento entregado al evento {{domxref("ServiceWorkerGlobalScope.message_event", "message")}}. Puede ser cualquier objeto JavaScript procesado por el [algoritmo de clonación estructurada](/es/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 
     El parámetro `message` es obligatorio. Si los datos a pasar al worker no son importantes, se debe pasar `null` o `undefined` explícitamente.

--- a/files/es/web/api/serviceworker/postmessage/index.md
+++ b/files/es/web/api/serviceworker/postmessage/index.md
@@ -3,7 +3,7 @@ title: "ServiceWorker: método postMessage()"
 short-title: postMessage()
 slug: Web/API/ServiceWorker/postMessage
 l10n:
-  sourceCommit: e0310b3f565d3147fa80d9e63ace41e0fc244fa6
+  sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
 ---
 
 {{APIRef("Service Workers API")}}{{securecontext_header}}{{AvailableInWorkers}}

--- a/files/es/web/api/serviceworker/postmessage/index.md
+++ b/files/es/web/api/serviceworker/postmessage/index.md
@@ -1,0 +1,83 @@
+---
+title: "ServiceWorker: método postMessage()"
+short-title: postMessage()
+slug: Web/API/ServiceWorker/postMessage
+l10n:
+  sourceCommit: e0310b3f565d3147fa80d9e63ace41e0fc244fa6
+---
+
+{{APIRef("Service Workers API")}}{{securecontext_header}}{{AvailableInWorkers}}
+
+El método **`postMessage()`** de la interfaz {{domxref("ServiceWorker")}} envía un mensaje al worker. El primer parámetro son los datos a enviar al worker. Los datos pueden ser cualquier objeto JavaScript que pueda ser procesado por el [algoritmo de clonación estructurada](/es/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+
+El service worker puede enviar información de vuelta a sus clientes usando el método {{domxref("Client.postMessage", "postMessage()")}}. El mensaje no se enviará de vuelta a este objeto `ServiceWorker`, sino al {{domxref("ServiceWorkerContainer")}} asociado disponible a través de {{domxref("navigator.serviceWorker")}}.
+
+## Sintaxis
+
+```js-nolint
+postMessage(message)
+postMessage(message, transfer)
+postMessage(message, options)
+```
+
+### Parámetros
+
+- `message`
+
+  - : El objeto a entregar al worker; estará en el campo `data` del evento entregado al evento {{domxref("ServiceWorkerGlobalScope.message_event", "message")}}. Puede ser cualquier objeto JavaScript procesado por el [algoritmo de clonación estructurada](/es/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+
+    El parámetro `message` es obligatorio. Si los datos a pasar al worker no son importantes, se debe pasar `null` o `undefined` explícitamente.
+
+- `transfer` {{optional_inline}}
+  - : Un [arreglo](/es/docs/Web/JavaScript/Reference/Global_Objects/Array) opcional de [objetos transferibles](/es/docs/Web/API/Web_Workers_API/Transferable_objects) para transferir su propiedad. La propiedad de estos objetos se transfiere al lado destino y ya no se pueden usar en el lado emisor. Estos objetos transferibles deben estar adjuntos al mensaje; de lo contrario, se moverían pero no serían accesibles en el extremo receptor.
+- `options` {{optional_inline}}
+  - : Un objeto opcional que contiene las siguientes propiedades:
+    - `transfer` {{optional_inline}}
+      - : Tiene el mismo significado que el parámetro `transfer`.
+
+### Valor de retorno
+
+Ninguno ({{jsxref("undefined")}}).
+
+### Excepciones
+
+- {{jsxref("SyntaxError")}}
+  - : Se lanza si no se proporciona el parámetro `message`.
+
+## Ejemplos
+
+En este ejemplo se crea un {{domxref("ServiceWorker")}} y se envía un mensaje inmediatamente:
+
+```js
+navigator.serviceWorker.register("service-worker.js");
+
+navigator.serviceWorker.ready.then((registration) => {
+  registration.active.postMessage(
+    "Mensaje de prueba enviado inmediatamente después de la creación",
+  );
+});
+```
+
+Para recibir el mensaje, el service worker, en `service-worker.js`, debe escuchar el evento {{domxref("ServiceWorkerGlobalScope.message_event", "message")}} en su ámbito global.
+
+```js
+// Esto debe estar en `service-worker.js`
+addEventListener("message", (event) => {
+  console.log(`Mensaje recibido: ${event.data}`);
+});
+```
+
+Ten en cuenta que el service worker puede enviar mensajes de vuelta al hilo principal usando el método {{domxref("Client.postMessage()", "postMessage()")}}. Para recibirlo, el hilo principal necesita escuchar un evento {{domxref("ServiceWorkerContainer.message_event", "message")}} en el objeto {{domxref("ServiceWorkerContainer")}}.
+
+## Especificaciones
+
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
+
+## Véase también
+
+- La interfaz {{domxref("ServiceWorker")}} a la que pertenece.
+- Su contraparte, el método {{domxref("Client.postMessage()", "postMessage()")}} que un service worker debe usar para enviar un mensaje de vuelta al {{domxref("ServiceWorkerContainer")}} asociado.

--- a/files/es/web/api/serviceworker/scripturl/index.md
+++ b/files/es/web/api/serviceworker/scripturl/index.md
@@ -1,0 +1,32 @@
+---
+title: "ServiceWorker: propiedad scriptURL"
+short-title: scriptURL
+slug: Web/API/ServiceWorker/scriptURL
+l10n:
+  sourceCommit: bc0237f139ee3a9db67a669ae1b6bf45ebba7f94
+---
+
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
+
+Devuelve la URL del script serializado del `ServiceWorker` definido como parte de [`ServiceWorkerRegistration`](/es/docs/Web/API/ServiceWorkerRegistration).
+Debe tener el mismo origen que el documento que registra el `ServiceWorker`.
+
+## Valor
+
+Una cadena de texto.
+
+## Ejemplos
+
+```js
+const sw = navigator.serviceWorker.controller;
+console.log(sw.scriptURL);
+// https://example.com/scripts/service-worker.js
+```
+
+## Especificaciones
+
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}

--- a/files/es/web/api/serviceworker/scripturl/index.md
+++ b/files/es/web/api/serviceworker/scripturl/index.md
@@ -3,7 +3,7 @@ title: "ServiceWorker: propiedad scriptURL"
 short-title: scriptURL
 slug: Web/API/ServiceWorker/scriptURL
 l10n:
-  sourceCommit: bc0237f139ee3a9db67a669ae1b6bf45ebba7f94
+  sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
 ---
 
 {{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}

--- a/files/es/web/api/serviceworker/state/index.md
+++ b/files/es/web/api/serviceworker/state/index.md
@@ -1,0 +1,62 @@
+---
+title: "ServiceWorker: propiedad state"
+short-title: state
+slug: Web/API/ServiceWorker/state
+l10n:
+  sourceCommit: c29cee3dcb0d0e66093dd0c18aa82e0eab9d6d14
+---
+
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
+
+La propiedad de solo lectura **`state`** de la interfaz {{domxref("ServiceWorker")}} devuelve una cadena de texto que representa el estado actual del service worker. Puede ser uno de los siguientes valores: `parsed`, `installing`, `installed`, `activating`, `activated`, o `redundant`.
+
+## Valor
+
+Un {{jsxref("String")}} que puede tomar uno de los siguientes valores:
+
+- `"parsed"`
+  - : El estado inicial de un service worker después de ser descargado y confirmado que es ejecutable.
+    Un service worker nunca se actualiza a este estado, por lo que este nunca será el valor del evento {{DOMxRef("ServiceWorker.statechange_event", "statechange")}}.
+- `"installing"`
+  - : El service worker en este estado se considera un worker en instalación. Durante este estado, se puede llamar a {{DOMxRef("ExtendableEvent.waitUntil()")}} dentro del manejador del evento `install` para extender la vida del worker en instalación hasta que la promesa pasada se resuelva exitosamente. Esto se usa principalmente para asegurar que el service worker no esté activo hasta que todas las cachés principales se hayan poblado.
+- `"installed"`
+  - : El service worker en este estado se considera un worker en espera.
+- `"activating"`
+  - : El service worker en este estado se considera un worker activo. Durante este estado, se puede llamar a {{DOMxRef("ExtendableEvent.waitUntil()")}} dentro del manejador del evento `onactivate` para extender la vida del worker activo hasta que la promesa pasada se resuelva exitosamente. No se dispatchan eventos funcionales hasta que el estado pase a activado.
+- `"activated"`
+  - : El service worker en este estado se considera un worker activo listo para manejar eventos funcionales.
+- `"redundant"`
+  - : Un nuevo service worker está reemplazando al service worker actual, o el service worker actual está siendo descartado debido a un fallo de instalación.
+
+## Ejemplos
+
+Este fragmento de código proviene del [ejemplo de eventos de registro de service worker](https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/registration-events/index.html) ([demo en vivo](https://googlechrome.github.io/samples/service-worker/registration-events/)). El código escucha cualquier cambio en `ServiceWorker.state` y devuelve su valor.
+
+```js
+let serviceWorker;
+if (registration.installing) {
+  serviceWorker = registration.installing;
+  document.querySelector("#kind").textContent = "installing";
+} else if (registration.waiting) {
+  serviceWorker = registration.waiting;
+  document.querySelector("#kind").textContent = "waiting";
+} else if (registration.active) {
+  serviceWorker = registration.active;
+  document.querySelector("#kind").textContent = "active";
+}
+
+if (serviceWorker) {
+  logState(serviceWorker.state);
+  serviceWorker.addEventListener("statechange", (e) => {
+    logState(e.target.state);
+  });
+}
+```
+
+## Especificaciones
+
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}

--- a/files/es/web/api/serviceworker/state/index.md
+++ b/files/es/web/api/serviceworker/state/index.md
@@ -3,7 +3,7 @@ title: "ServiceWorker: propiedad state"
 short-title: state
 slug: Web/API/ServiceWorker/state
 l10n:
-  sourceCommit: c29cee3dcb0d0e66093dd0c18aa82e0eab9d6d14
+  sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
 ---
 
 {{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}

--- a/files/es/web/api/serviceworker/statechange_event/index.md
+++ b/files/es/web/api/serviceworker/statechange_event/index.md
@@ -3,7 +3,7 @@ title: "ServiceWorker: evento statechange"
 short-title: statechange
 slug: Web/API/ServiceWorker/statechange_event
 l10n:
-  sourceCommit: bc0237f139ee3a9db67a669ae1b6bf45ebba7f94
+  sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
 ---
 
 {{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}

--- a/files/es/web/api/serviceworker/statechange_event/index.md
+++ b/files/es/web/api/serviceworker/statechange_event/index.md
@@ -1,0 +1,72 @@
+---
+title: "ServiceWorker: evento statechange"
+short-title: statechange
+slug: Web/API/ServiceWorker/statechange_event
+l10n:
+  sourceCommit: bc0237f139ee3a9db67a669ae1b6bf45ebba7f94
+---
+
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
+
+El evento `statechange` se dispara cada vez que cambia {{domxref("ServiceWorker.state")}}.
+
+## Sintaxis
+
+Usa el nombre del evento en métodos como {{domxref("EventTarget.addEventListener", "addEventListener()")}}, o establece una propiedad de manejador de eventos.
+
+```js
+addEventListener("statechange", (event) => {});
+
+onstatechange = (event) => {};
+```
+
+## Tipo de evento
+
+Un {{domxref("Event")}} genérico.
+
+## Ejemplos
+
+Este fragmento de código proviene del [ejemplo de eventos de registro de service worker](https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/registration-events/index.html) ([demo en vivo](https://googlechrome.github.io/samples/service-worker/registration-events/)). El código escucha cualquier cambio en {{domxref("ServiceWorker.state")}} y devuelve su valor.
+
+```js
+let serviceWorker;
+if (registration.installing) {
+  serviceWorker = registration.installing;
+  document.querySelector("#kind").textContent = "installing";
+} else if (registration.waiting) {
+  serviceWorker = registration.waiting;
+  document.querySelector("#kind").textContent = "waiting";
+} else if (registration.active) {
+  serviceWorker = registration.active;
+  document.querySelector("#kind").textContent = "active";
+}
+
+if (serviceWorker) {
+  logState(serviceWorker.state);
+  serviceWorker.addEventListener("statechange", (e) => {
+    logState(e.target.state);
+  });
+}
+```
+
+Ten en cuenta que cuando se dispara `statechange`, las referencias del service worker pueden haber cambiado. Por ejemplo:
+
+```js
+navigator.serviceWorker.register("/sw.js").then((swr) => {
+  swr.installing.state = "installing";
+  swr.installing.onstatechange = () => {
+    swr.installing = null;
+    // En este punto, swr.waiting O swr.active podrían ser true. Esto se debe a que el evento statechange
+    // se encola, mientras tanto el worker subyacente puede haber pasado al estado waiting
+    // y será activado inmediatamente si es posible.
+  };
+});
+```
+
+## Especificaciones
+
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}


### PR DESCRIPTION
## Summary

- Adds Spanish translation of the `ServiceWorker` API page (`Web/API/ServiceWorker`)
- Translated from the English source at commit `5d29bef0815f8cc4b5b152b9ee1ab53f002ee617`

## Test plan

- [ ] Verify front matter matches guidelines (title, slug, l10n.sourceCommit only)
- [ ] Verify internal links point to `/es/` locale where Spanish versions exist
- [ ] Verify terminology follows Spanish conventions (contextos de navegación, se dispara, Véase también, etc.)
- [ ] Verify code comments are translated per code block localization rules