### PR TITLE
chore(fr): removing residual HTMLSidebar macros

### DIFF
--- a/files/fr/web/api/media_source_extensions_api/dash_adaptive_streaming/index.md
+++ b/files/fr/web/api/media_source_extensions_api/dash_adaptive_streaming/index.md
@@ -4,8 +4,6 @@ slug: Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming
 original_slug: Web/Media/DASH_Adaptive_Streaming_for_HTML_5_Video
 ---
 
-{{HTMLSidebar}}
-
 **_Dynamic Adaptive Streaming over HTTP_ (DASH)** est un protocole de _streaming_ adaptatif : il permet de changer le débit de la vidéo en fonction des performances réseau afin que la vidéo ne soit pas interrompue lors de la lecture.
 
 ## Compatibilité des navigateurs

--- a/files/fr/web/html/reference/elements/input/submit/index.md
+++ b/files/fr/web/html/reference/elements/input/submit/index.md
@@ -4,8 +4,6 @@ slug: Web/HTML/Reference/Elements/input/submit
 original_slug: Web/HTML/Element/input/submit
 ---
 
-{{HTMLSidebar}}
-
 Les éléments {{HTMLElement("input")}} dont l'attribut `type` vaut **`"submit"`** sont affichés comme des boutons permettant d'envoyer les données d'un formulaire. Cliquer sur un tel bouton déclenchera l'envoi des données du formulaire vers le serveur.
 
 ## Exemple simple

--- a/files/fr/web/html/reference/elements/input/tel/index.md
+++ b/files/fr/web/html/reference/elements/input/tel/index.md
@@ -4,8 +4,6 @@ slug: Web/HTML/Reference/Elements/input/tel
 original_slug: Web/HTML/Element/input/tel
 ---
 
-{{HTMLSidebar}}
-
 Les éléments [`<input>`](/fr/docs/Web/HTML/Reference/Elements/input) dont l'attribut `type` vaut **`tel`** permettent de saisir un numéro de téléphone. Contrairement aux contrôles utilisés pour [`<input type="email">`](/fr/docs/Web/HTML/Reference/Elements/input/email) et [`<input type="url">`](/fr/docs/Web/HTML/Reference/Elements/input/url), la valeur saisie n'est pas automatiquement validée selon un format donné, car les formats des numéros de téléphone varient à travers le monde.
 
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;tel&quot;&gt;", "tabbed-standard")}}

--- a/files/fr/web/html/reference/elements/input/text/index.md
+++ b/files/fr/web/html/reference/elements/input/text/index.md
@@ -4,8 +4,6 @@ slug: Web/HTML/Reference/Elements/input/text
 original_slug: Web/HTML/Element/input/text
 ---
 
-{{HTMLSidebar}}
-
 Les éléments [`<input>`](/fr/docs/Web/HTML/Reference/Elements/input) dont l'attribut `type` vaut **`text`** permettent de créer des champs de saisie pour du texte sur une seule ligne.
 
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;text&quot;&gt;", "tabbed-shorter")}}

--- a/files/fr/web/html/reference/elements/input/time/index.md
+++ b/files/fr/web/html/reference/elements/input/time/index.md
@@ -4,8 +4,6 @@ slug: Web/HTML/Reference/Elements/input/time
 original_slug: Web/HTML/Element/input/time
 ---
 
-{{HTMLSidebar}}
-
 Les éléments [`<input>`](/fr/docs/Web/HTML/Reference/Elements/input) dont l'attribut `type` vaut **`time`** permettent de créer des contrôles où l'utilisatrice ou l'utilisateur peut saisir une heure (avec des minutes et éventuellement des secondes).
 
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;time&quot;&gt;", "tabbed-standard")}}

--- a/files/fr/web/html/reference/elements/input/url/index.md
+++ b/files/fr/web/html/reference/elements/input/url/index.md
@@ -4,8 +4,6 @@ slug: Web/HTML/Reference/Elements/input/url
 original_slug: Web/HTML/Element/input/url
 ---
 
-{{HTMLSidebar}}
-
 Les éléments [`<input>`](/fr/docs/Web/HTML/Reference/Elements/input) dont l'attribut `type` vaut **`url`** sont employées afin de permettre à une utilisatrice ou un utilisateur de saisir ou d'éditer une URL.
 
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;url&quot;&gt;", "tabbed-shorter")}}

--- a/files/fr/web/html/reference/elements/input/week/index.md
+++ b/files/fr/web/html/reference/elements/input/week/index.md
@@ -4,8 +4,6 @@ slug: Web/HTML/Reference/Elements/input/week
 original_slug: Web/HTML/Element/input/week
 ---
 
-{{HTMLSidebar}}
-
 Les éléments [`<input>`](/fr/docs/Web/HTML/Reference/Elements/input) dont l'attribut `type` vaut **`week`** permettent de créer des champs de saisie où l'on peut saisir une année et le numéro de la semaine pendant cette année (allant de 1 à 52 ou 53, suivant la norme [ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601#Numéro_de_semaine)).
 
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;week&quot;&gt;", "tabbed-shorter")}}


### PR DESCRIPTION
### Description

Following the entire update of the HTML section, the residuals sidebars is not part of the HTML content or is in page to be updated soon. All macros of the old sidebar is gone with this PR.

### Motivation

_none_

### Additional details

_none_

### Related issues and pull requests

_none_