### PR TITLE
chore(fr): removing residual GlossarySidebar macros

### DIFF
--- a/files/fr/web/security/attacks/clickjacking/index.md
+++ b/files/fr/web/security/attacks/clickjacking/index.md
@@ -4,8 +4,6 @@ slug: Web/Security/Attacks/Clickjacking
 original_slug: Glossary/Clickjacking
 ---
 
-{{GlossarySidebar}}
-
 Le détournement de clic (ou <i lang="en">clickjacking</i>) est une attaque basée sur l'interface qui incite les utilisatrices et utilisateurs de sites web à cliquer involontairement sur des liens malveillants. Pour le détournement de clics, les attaquants intègrent leurs liens malveillants dans des boutons ou des pages légitimes d'un site web. Dans un [site](/fr/docs/Glossary/Site) infecté, chaque fois qu'une personne clique sur un lien légitime, l'attaquant obtient les informations confidentielles de cette personne, ce qui compromet en fin de compte sa vie privée sur Internet.
 
 Le détournement de clic peut être évité en implémentant une [politique de sécurité du contenu avec la directive `frame-ancestors`](/fr/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-ancestors) et en implémentant des [attributs `Set-Cookie`](/fr/docs/Web/HTTP/Reference/Headers/Set-Cookie#attributs).


### PR DESCRIPTION
### Description

Following the entire update of the Glossary section, the residuals sidebars is not part of the Glossary content. All macros of the old sidebar is gone with this PR.

### Motivation

_none_

### Additional details

_none_

### Related issues and pull requests

_none_