### PR TITLE
chore(fr): replace Glossary macros with second argument for `Forbidden header name`

### DIFF
--- a/files/fr/glossary/cors-safelisted_response_header/index.md
+++ b/files/fr/glossary/cors-safelisted_response_header/index.md
@@ -34,6 +34,6 @@ Access-Control-Expose-Headers: X-Custom-Header, Content-Encoding
 - {{HTTPHeader("Access-Control-Expose-Headers")}}
 - Termes de glossaire associés&nbsp;:
   - {{Glossary("CORS")}}
-  - {{Glossary("CORS-safelisted_request_header","En-tête de requête sûr pour le CORS")}}
-  - {{Glossary("Forbidden header name","Noms d'en-tête interdits")}}
-  - {{Glossary("Request header","En-tête de requête")}}
+  - {{Glossary("CORS-safelisted_request_header", "En-tête de requête sûr pour le CORS")}}
+  - {{Glossary("Forbidden request header", "En-tête de requête interdit")}}
+  - {{Glossary("Request header", "En-tête de requête")}}

--- a/files/fr/web/api/headers/index.md
+++ b/files/fr/web/api/headers/index.md
@@ -7,7 +7,7 @@ slug: Web/API/Headers
 
 L'interface `Headers` de l'API Fetch vous permet d'effectuer diverses actions sur les en-têtes de requête et de réponse HTTP. Ces actions incluent la récupération, la configuration, l'ajout et la suppression. Un objet `Headers` a une liste `Headers` associée qui est vide lors de l'initialisation et qui est constituée de zéro ou plusieurs paires de noms et de valeurs. Vous pouvez en ajouter via les méthodes comme{{domxref("Headers.append","append()")}} (voir la section [Exemples](#exemples).) Dans toutes les méthodes de cette interface, les noms des `Headers` sont reliés à une séquence d'octets sensible à la case.
 
-Pour des raisons de sécurité, les `Headers` ci-dessous peuvent être controlés uniquement par l'User Agent : {{Glossary("Forbidden_header_name", "forbidden header names", 1)}} et {{Glossary("Forbidden_response_header_name", "forbidden response header names", 1)}}.
+Pour des raisons de sécurité, les `Headers` ci-dessous peuvent être controlés uniquement par l'User Agent : {{Glossary("Forbidden request header", "en-têtes de requête interdit")}} et {{Glossary("Forbidden response header name", "nom d'en-tête de réponse interdit")}}.
 
 Un objet `Headers` a aussi une garde associée, qui prend la valeur `immutable`, `request`, `request-no-cors`, `reponse`, or `none`. Cela affecte si les méthodes {{domxref("Headers.set","set()")}}, {{domxref("Headers.delete","delete()")}}, et {{domxref("Headers.append","append()")}} vont modifier le `Header`. Pour plus d'informations voir {{Glossary("Guard")}}.
 

--- a/files/fr/web/api/xmlhttprequest/setrequestheader/index.md
+++ b/files/fr/web/api/xmlhttprequest/setrequestheader/index.md
@@ -11,7 +11,7 @@ A chaque fois que vous appellez `setRequestHeader()`, son contenu est ajouté à
 
 Si aucun {{HTTPHeader("Accept")}} n'a été configurer avec cette méthode, un `Accept` header avec le type `"*/*"` sera envoyé avec la requête lorsque {{domxref("XMLHttpRequest.send", "send()")}} sera appellée.
 
-Pour des raisons de sécurité, certain header ne peuvent être manipulés que par le user agent. Ceux-ci contiennent les paramètres {{Glossary("Forbidden_header_name", "forbidden header names", 1)}} et {{Glossary("Forbidden_response_header_name", "forbidden response header names", 1)}}.
+Pour des raisons de sécurité, certain header ne peuvent être manipulés que par le user agent. Ceux-ci contiennent les paramètres {{Glossary("Forbidden request header", "d'en-têtes de requête interdit")}} et de {{Glossary("Forbidden response header name", "nom d'en-tête de réponse interdit")}}.
 
 > [!NOTE]
 > Dans certain cas, vous pourrez rencontrer l'erreur / exception "**not allowed by Access-Control-Allow-Headers in preflight response**" quand vous enverez une requête cross domains. Dans ce cas, vous devrez configurer {{HTTPHeader("Access-Control-Allow-Headers")}} dans votre réponse HTTP coté serveur.


### PR DESCRIPTION
### Description

Additionnal macros fixes with translated argument updated in 3 pages affected by the PR #35029.

### Motivation

_none_

### Additional details

_none_

### Related issues and pull requests

Related to https://github.com/mdn/translated-content/pull/35029
