### PR TITLE
zh-cn: fix the typo in Symbol.keyFor description

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/symbol/index.md
@@ -120,7 +120,7 @@ typeof symObj; // "object"
 - {{jsxref("Symbol.for()", "Symbol.for(key)")}}
   - : 使用给定的 key 搜索现有的 symbol，如果找到则返回该 symbol。否则将使用给定的 key 在全局 symbol 注册表中创建一个新的 symbol。
 - {{jsxref("Symbol.keyFor", "Symbol.keyFor(sym)")}}
-  - : 从全局 symbol 注册表中，为给定的 symbol 检索一个共享的？symbol key。
+  - : 从全局 symbol 注册表中，为给定的 symbol 检索一个共享的 symbol key。
 
 ## Symbol 原型
 


### PR DESCRIPTION
## Summary
Remove a stray question mark in the Symbol.keyFor method description.

## Changes
- Change "共享的？symbol key" to "共享的 symbol key"

## Related
Part of ongoing documentation cleanup for Symbol.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
