### PR TITLE
chore(zh-tw): fix URLs that neither exist nor redirect

### DIFF
--- a/files/zh-tw/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
+++ b/files/zh-tw/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: 14acf1aa7885157debdf1b6111f4bd10c064ec60
 ---
 
-{{PreviousNext("Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls")}}
+{{PreviousNext("Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball", "Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls")}}
 
 這是 [Gamedev Canvas 教程](/zh-TW/docs/Games/Tutorials/2D_Breakout_game_pure_JavaScript)的**第 3 步**（共 10 步）。你可以在 [Gamedev-Canvas-workshop/lesson3.html](https://github.com/end3r/Gamedev-Canvas-workshop/blob/gh-pages/lesson03.html) 找到課後完整的原始碼。
 
@@ -164,4 +164,4 @@ runButton.addEventListener("click", () => {
 
 我們現在已經到了球既移動又保持在遊戲板上的階段。在第四章中，我們將看看如何實現可控的球拍——請參見[球拍和鍵盤控制](/zh-TW/docs/Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls)。
 
-{{PreviousNext("Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls")}}
+{{PreviousNext("Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball", "Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls")}}

--- a/files/zh-tw/learn_web_development/core/structuring_content/html_table_basics/index.md
+++ b/files/zh-tw/learn_web_development/core/structuring_content/html_table_basics/index.md
@@ -3,7 +3,7 @@ title: HTML表格的基礎
 slug: Learn_web_development/Core/Structuring_content/HTML_table_basics
 ---
 
-{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Mozilla_splash_page", "Learn_web_development/Core/Structuring_content/Table_accessibility", "Learn_web_development/Core/Structuring_content")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Splash_page", "Learn_web_development/Core/Structuring_content/Table_accessibility", "Learn_web_development/Core/Structuring_content")}}
 
 這篇文章將帶你從列、格、標頭，以及將各格以數欄、數列的方式合併等基礎開始探索 HTML 表格。
 
@@ -535,4 +535,4 @@ See how you get on with the example. If you get stuck, or want to check your wor
 
 That just about wraps up the basics of HTML Tables. In the next article we will look at some slightly more advanced table features, and start to think how accessible they are for visually impaired people.
 
-{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Mozilla_splash_page", "Learn_web_development/Core/Structuring_content/Table_accessibility", "Learn_web_development/Core/Structuring_content")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Splash_page", "Learn_web_development/Core/Structuring_content/Table_accessibility", "Learn_web_development/Core/Structuring_content")}}

--- a/files/zh-tw/mozilla/add-ons/webextensions/manifest.json/index.md
+++ b/files/zh-tw/mozilla/add-ons/webextensions/manifest.json/index.md
@@ -100,6 +100,6 @@ browser.runtime.getManifest().version;
 
 ## 瀏覽器相容性
 
-若想對所有的 manifest 鍵值及其子健有個完整的概念，可參見 [完整 manifest.json 瀏覽器相容表](/zh-TW/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json)。
+若想對所有的 manifest 鍵值及其子健有個完整的概念，可參見 [完整 manifest.json 瀏覽器相容表](/zh-TW/docs/Mozilla/Add-ons/WebExtensions/manifest.json)。
 
 {{Compat}}

--- a/files/zh-tw/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/zh-tw/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -343,4 +343,4 @@ function draw() {
 - [iGrapher](http://igrapher.com/)
   - : 股票市場圖
 
-{{PreviousNext("Web/API/Canvas_API/Tutorial/Compositing", "Web/Guide/HTML/Canvas_tutorial/Optimizing_canvas")}}
+{{PreviousNext("Web/API/Canvas_API/Tutorial/Compositing", "Web/API/Canvas_API/Tutorial/Optimizing_canvas")}}

--- a/files/zh-tw/web/api/canvas_api/tutorial/optimizing_canvas/index.md
+++ b/files/zh-tw/web/api/canvas_api/tutorial/optimizing_canvas/index.md
@@ -17,4 +17,4 @@ slug: Web/API/Canvas_API/Tutorial/Optimizing_canvas
 - 使用{{domxref("window.requestAnimationFrame()")}}
 - 用[JSPerf](https://jsperf.com/)測試效能
 
-{{PreviousNext("Web/Guide/HTML/Canvas_tutorial/Basic_animations")}}
+{{PreviousNext("Web/API/Canvas_API/Tutorial/Basic_animations")}}

--- a/files/zh-tw/web/javascript/guide/regular_expressions/index.md
+++ b/files/zh-tw/web/javascript/guide/regular_expressions/index.md
@@ -3,7 +3,7 @@ title: 正規表達式
 slug: Web/JavaScript/Guide/Regular_expressions
 ---
 
-{{PreviousNext("Web/JavaScript/Guide/Text_formatting", "Web/JavaScript/Guide/Indexed_collections")}}
+{{PreviousNext("Web/JavaScript/Guide/Numbers_and_strings", "Web/JavaScript/Guide/Indexed_collections")}}
 
 正規表達式是被用來匹配字串中字元組合的模式。在 JavaScript 中，正規表達式也是物件，這些模式在 {{jsxref("RegExp")}} 的 {{jsxref("RegExp.exec", "exec")}} 和 {{jsxref("RegExp.test", "test")}} 方法中，以及 {{jsxref("String")}} 的 {{jsxref("String.match", "match")}}、{{jsxref("String.replace", "replace")}}、{{jsxref("String.search", "search")}}、{{jsxref("String.split", "split")}} 等方法中被運用。這一章節將解說 JavaScript 中的正規表達式。
 
@@ -408,4 +408,4 @@ The `Change` event activated when the user presses Enter sets the value of `RegE
 </html>
 ```
 
-{{PreviousNext("Web/JavaScript/Guide/Text_formatting", "Web/JavaScript/Guide/Indexed_collections")}}
+{{PreviousNext("Web/JavaScript/Guide/Numbers_and_strings", "Web/JavaScript/Guide/Indexed_collections")}}


### PR DESCRIPTION
### Description

Fixes links to pages that moved in mdn/content, but don't exist or redirect in a the locale.

### Motivation

Resolve broken links, and resolve flaws.

### Additional details

Ran `cargo run -- content fix-flaws --content` with rari from https://github.com/mdn/rari/pull/618, which resolves these broken links using the en-US redirect.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.

_(Split from https://github.com/mdn/translated-content/pull/35051.)_