### PR TITLE
chore(es): fix flaws in raw HTML links

### DIFF
--- a/files/es/conflicting/learn_web_development/core/css_layout/introduction/index.md
+++ b/files/es/conflicting/learn_web_development/core/css_layout/introduction/index.md
@@ -16,10 +16,10 @@ Este artículo explica el flujo normal, o la forma en que se presentan los eleme
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conceptos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Introducción al CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/conflicting/learn_web_development/core/styling_basics/basic_selectors/index.md
+++ b/files/es/conflicting/learn_web_development/core/styling_basics/basic_selectors/index.md
@@ -15,16 +15,16 @@ En este artículo vamos a echar un vistazo a los selectores más simples de que 
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico instalado</a
         >, conocimientos básicos de
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, HTML básico (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML">Introducción a HTML</a
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >) y nociones de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Primeros pasos con CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/conflicting/learn_web_development/core/styling_basics/getting_started/index.md
+++ b/files/es/conflicting/learn_web_development/core/styling_basics/getting_started/index.md
@@ -15,13 +15,13 @@ Ahora que ya sabes qué es el CSS y conoces sus conceptos básicos, es hora de p
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico instalado</a
         >, conocimientos básicos de
-        <a href="/es/docs/Learn/Getting_started_with_the_web/Dealing_with_files"
+        <a href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajo con archivos</a
         >, conceptos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y una idea de
         <a href="/es/docs/Learn_web_development/Core/Styling_basics/What_is_CSS"

--- a/files/es/conflicting/learn_web_development/core/styling_basics/what_is_css/index.md
+++ b/files/es/conflicting/learn_web_development/core/styling_basics/what_is_css/index.md
@@ -15,15 +15,15 @@ Las hojas de estilo en cascada (**{{Glossary("CSS")}}**, cascading style sheets)
       <td>
         Conocimientos básicos de informática,
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >tener instalado el software básico</a
         >, conocimientos básicos de cómo
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >
         y nociones de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >).
       </td>

--- a/files/es/conflicting/mdn/community/index.md
+++ b/files/es/conflicting/mdn/community/index.md
@@ -96,7 +96,7 @@ Los enlaces en esta sección conducen a guías detalladas que explican cómo rea
         >
       </td>
       <td>
-        Nuestras páginas de <a href="/es/docs/Learn">aprende desarrollo web</a>
+        Nuestras páginas de <a href="/es/docs/Learn_web_development">aprende desarrollo web</a>
         obtienen más de un millón de visitas al mes y tienen
         <a href="https://discourse.mozilla.org/c/mdn/learn/250"
           >foros activos</a

--- a/files/es/learn_web_development/core/accessibility/css_and_javascript/index.md
+++ b/files/es/learn_web_development/core/accessibility/css_and_javascript/index.md
@@ -15,7 +15,7 @@ CSS y JavaScript, cuando se usan correctamente, también tienen el potencial de 
       <td>
         Conocimientos básicos de informática, conocimientos básicos de HTML, CSS
         y JavaScript, y comprensión de
-        <a href="/es/docs/Learn/Accessibility/Qué_es_la_accesibilidad"
+        <a href="/es/docs/Learn_web_development/Core/Accessibility/What_is_accessibility"
           >qué es la accesibilidad</a
         >.
       </td>

--- a/files/es/learn_web_development/core/accessibility/html/index.md
+++ b/files/es/learn_web_development/core/accessibility/html/index.md
@@ -14,10 +14,10 @@ Se puede hacer accesible una gran cantidad de contenido web solo asegurándose d
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimiento básico de informática, entendimiento básico de HTML (ver
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción a HTML</a
         >), y entendimiento de
-        <a href="/es/docs/Learn/Accessibility/What_is_accessibility"
+        <a href="/es/docs/Learn_web_development/Core/Accessibility/What_is_accessibility"
           >¿Qué es accesibilidad?</a
         >.
       </td>

--- a/files/es/learn_web_development/core/accessibility/mobile/index.md
+++ b/files/es/learn_web_development/core/accessibility/mobile/index.md
@@ -15,7 +15,7 @@ Dado que el acceso a la web en dispositivos móviles es tan popular, y las plata
       <td>
         Conocimientos básicos de computación, una comprensión básica de HTML,
         CSS y JavaScript, y una comprensión de los
-        <a href="/es/docs/Learn/Accessibility">artículos previos del curso</a>.
+        <a href="/es/docs/Learn_web_development/Core/Accessibility">artículos previos del curso</a>.
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/css_layout/flexbox/index.md
+++ b/files/es/learn_web_development/core/css_layout/flexbox/index.md
@@ -14,10 +14,10 @@ original_slug: Learn/CSS/CSS_layout/Flexbox
       <th scope="row">Prerrequisitos:</th>
       <td>
         Los conceptos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Introducción al CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/css_layout/floats/index.md
+++ b/files/es/learn_web_development/core/css_layout/floats/index.md
@@ -14,10 +14,10 @@ Originalmente pensada para flotar imágenes dentro de bloques de texto, la propi
       <th scope="row">Requisitos previos:</th>
       <td>
         HTML básico (ver
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >), y una idea de Cómo funciona CSS (ver
-        <a href="/es/docs/Learn/CSS/First_steps">Introducción a CSS</a>.)
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción a CSS</a>.)
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/css_layout/grids/index.md
+++ b/files/es/learn_web_development/core/css_layout/grids/index.md
@@ -14,10 +14,10 @@ La compaginación en cuadrícula con CSS es un método de diseño de páginas we
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conceptos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y una idea de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Introducción al CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/css_layout/introduction/index.md
+++ b/files/es/learn_web_development/core/css_layout/introduction/index.md
@@ -14,10 +14,10 @@ Este artículo resumirá algunas de las características de diseño de páginas 
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conceptos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Introducción al CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/css_layout/responsive_design/index.md
+++ b/files/es/learn_web_development/core/css_layout/responsive_design/index.md
@@ -14,11 +14,11 @@ En los primeros días del diseño web, las páginas se diseñaban para llenar un
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conceptos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Primeros pasos en CSS</a> y
-        <a href="/es/docs/Learn/CSS/Building_blocks"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos en CSS</a> y
+        <a href="/es/docs/Learn_web_development/Core/Styling_basics"
           >Los elementos básicos del CSS</a
         >).
       </td>

--- a/files/es/learn_web_development/core/css_layout/supporting_older_browsers/index.md
+++ b/files/es/learn_web_development/core/css_layout/supporting_older_browsers/index.md
@@ -16,10 +16,10 @@ En este módulo recomendamos utilizar Flexbox y Grid como las herramientas princ
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conceptos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Introducción al CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/frameworks_libraries/react_components/index.md
+++ b/files/es/learn_web_development/core/frameworks_libraries/react_components/index.md
@@ -16,9 +16,9 @@ En este punto, nuestra aplicación es un monolito. Antes de hacer que haga cosas
       <th scope="row">Prerequesitos:</th>
       <td>
         <p>
-          Estar familiarizado con los lenguajes básicos <a href="/es/docs/Learn/HTML">HTML</a>,
-          <a href="/es/docs/Learn/CSS">CSS</a>, y
-          <a href="/es/docs/Learn/JavaScript">JavaScript</a>,
+          Estar familiarizado con los lenguajes básicos <a href="/es/docs/Learn_web_development/Core/Structuring_content">HTML</a>,
+          <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics_b957eec7deaf1ea2b20721d6838ea6e1">CSS</a>, y
+          <a href="/es/docs/conflicting/Learn_web_development/Core/Scripting_41cf930b8cfd2b83c76f8086a5e24792">JavaScript</a>,
           conocimientos de la
           <a
             href="/es/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Command_line"

--- a/files/es/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
+++ b/files/es/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
@@ -15,9 +15,9 @@ En este artículo conoceremos React. Descubriremos algunos detalles sobre su tra
       <td>
         <p>
           Familiaridad con los lenguajes
-          <a href="/es/docs/Learn/HTML">HTML</a>,
-          <a href="/es/docs/Learn/CSS">CSS</a>, y
-          <a href="/es/docs/Learn/JavaScript">JavaScript</a>, conocimiento
+          <a href="/es/docs/Learn_web_development/Core/Structuring_content">HTML</a>,
+          <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics_b957eec7deaf1ea2b20721d6838ea6e1">CSS</a>, y
+          <a href="/es/docs/conflicting/Learn_web_development/Core/Scripting_41cf930b8cfd2b83c76f8086a5e24792">JavaScript</a>, conocimiento
           del
           <a
             href="/es/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Command_line"

--- a/files/es/learn_web_development/core/frameworks_libraries/svelte_getting_started/index.md
+++ b/files/es/learn_web_development/core/frameworks_libraries/svelte_getting_started/index.md
@@ -18,9 +18,9 @@ En este artículo proporcionaremos una breve introducción al [framework Svelte]
       <td>
         <p>
         Se recomienda que como mínimo te sientas familiarizado con lo básico de los lenguajes
-          <a href="/es/docs/Learn/HTML">HTML</a>,
-          <a href="/es/docs/Learn/CSS">CSS</a> y
-          <a href="/es/docs/Learn/JavaScript">JavaScript</a>, además tener conocimiento de la
+          <a href="/es/docs/Learn_web_development/Core/Structuring_content">HTML</a>,
+          <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics_b957eec7deaf1ea2b20721d6838ea6e1">CSS</a> y
+          <a href="/es/docs/conflicting/Learn_web_development/Core/Scripting_41cf930b8cfd2b83c76f8086a5e24792">JavaScript</a>, además tener conocimiento de la
           <a
             href="/es/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Command_line"
             >terminal/línea de comandos</a

--- a/files/es/learn_web_development/core/scripting/events/index.md
+++ b/files/es/learn_web_development/core/scripting/events/index.md
@@ -19,7 +19,7 @@ Este no será un estudio exhaustivo, solo veremos lo que necesitas saber en esta
     <tr>
       <th scope="row">Pre-requisitos:</th>
       <td>
-  Conocimientos básicos de informática, entendimiento básico de HTML y CSS, <a href="/es/docs/Learn/JavaScript/First_steps"
+  Conocimientos básicos de informática, entendimiento básico de HTML y CSS, <a href="/es/docs/conflicting/Learn_web_development/Core/Scripting"
           >Primeros pasos con JavaScript</a
         >.
       </td>

--- a/files/es/learn_web_development/core/scripting/loops/index.md
+++ b/files/es/learn_web_development/core/scripting/loops/index.md
@@ -16,7 +16,7 @@ Los lenguajes de programación son muy útiles para completar rápidamente tarea
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimientos básicos de informática, una comprensión básica de HTML y CSS,
-        <a href="/es/docs/Learn/JavaScript/First_steps"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Scripting"
           > Primeros pasos de JavaScript </a
         >.
       </td>

--- a/files/es/learn_web_development/core/structuring_content/basic_html_syntax/index.md
+++ b/files/es/learn_web_development/core/structuring_content/basic_html_syntax/index.md
@@ -17,11 +17,11 @@ En este artículo, cubrimos los conceptos básicos de HTML. Para empezar, este a
       <td>
         Conocimientos informáticos básicos,
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico instalado</a
         >, y conocimientos básicos de
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Dealing_with_files"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >.
       </td>

--- a/files/es/learn_web_development/core/structuring_content/debugging_html/index.md
+++ b/files/es/learn_web_development/core/structuring_content/debugging_html/index.md
@@ -15,14 +15,14 @@ Escribir HTML es fácil, pero ¿qué pasa si algo va mal y desconocemos dónde e
       <td>
         Estar familiarizado con los principios básicos de HTML, como los vistos
         en el apartado
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML/iniciar"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content/Basic_HTML_syntax"
           >Empezar con el HTML</a
         >,
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML/texto"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content/Headings_and_paragraphs"
           >Conocimientos básicos de aplicación de formato a textos con HTML</a
         >
         y
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML/Creating_hyperlinks"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content/Creating_links"
           >Creación de hiperenlaces</a
         >.
       </td>

--- a/files/es/learn_web_development/core/structuring_content/general_embedding_technologies/index.md
+++ b/files/es/learn_web_development/core/structuring_content/general_embedding_technologies/index.md
@@ -15,14 +15,14 @@ Ahora ya deberías estar acostumbrado a integrar cosas en tus páginas web, incl
       <td>
         Conocimientos básicos de informática,
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico instalado</a
         >, conocimientos básicos de
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >manejo de archivos</a
         >, familiaridad con los fundamentos de HTML (visto en
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML/iniciar"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content/Basic_HTML_syntax"
           >Iniciando en HTML</a
         >) y los artículos previos en este modulo.
       </td>

--- a/files/es/learn_web_development/core/structuring_content/html_images/index.md
+++ b/files/es/learn_web_development/core/structuring_content/html_images/index.md
@@ -17,15 +17,15 @@ Al principio, la web solo era texto y resultaba más bien aburrido. Afortunadame
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico instalado</a
         >, conocimientos básicos de cómo
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, estar familiarizado con los principios básicos de HTML (como se
         describe en
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML/iniciar"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content/Basic_HTML_syntax"
           >Empezar con el HTML</a
         >).
       </td>

--- a/files/es/learn_web_development/core/structuring_content/html_table_basics/index.md
+++ b/files/es/learn_web_development/core/structuring_content/html_table_basics/index.md
@@ -14,7 +14,7 @@ Este artículo te ayudará a comenzar con las tablas HTML. Vamos a exponer conce
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conceptos básicos de HTML (ver
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >).
       </td>

--- a/files/es/learn_web_development/core/structuring_content/html_video_and_audio/index.md
+++ b/files/es/learn_web_development/core/structuring_content/html_video_and_audio/index.md
@@ -22,7 +22,7 @@ Ahora que estamos cómodos añadiendo imágenes simples a una página web, el si
           href="/es/Learn/Getting_started_with_the_web/Dealing_with_files"
           >trabajo con archivos</a
         >, familiaridad con los fundamentos de HTML (como está cubierto en
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML/Getting_started"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content/Basic_HTML_syntax"
           >Empezando con HTML</a
         >) e
         <a href="/es/docs/Learn_web_development/Core/Structuring_content/HTML_images"

--- a/files/es/learn_web_development/core/structuring_content/including_vector_graphics_in_html/index.md
+++ b/files/es/learn_web_development/core/structuring_content/including_vector_graphics_in_html/index.md
@@ -14,11 +14,11 @@ Los gráficos vectoriales son muy útiles en muchas circunstancias — tienen ta
       <th scope="row">Prerequisitos:</th>
       <td>
         Debe conocer los
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >conceptos básicos de HTML</a
         >
         y cómo
-        <a href="/es/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content/HTML_images"
           >insertar imágenes en su documento</a
         >
       </td>

--- a/files/es/learn_web_development/core/structuring_content/marking_up_a_letter/index.md
+++ b/files/es/learn_web_development/core/structuring_content/marking_up_a_letter/index.md
@@ -14,23 +14,23 @@ Todos aprendemos a escribir una carta más tarde o más temprano; es también pr
       <th scope="row">Prerrequisitos:</th>
       <td>
         Antes de intentar este examen deberías haber trabajado los artículos
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML/Getting_started"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content/Basic_HTML_syntax"
           >Getting started with HTML</a
         >,
         <a
-          href="/es/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML"
+          href="/es/docs/Learn_web_development/Core/Structuring_content/Webpage_metadata"
           >What's in the head? Metadata in HTML</a
         >,
         <a
-          href="/es/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals"
+          href="/es/docs/Learn_web_development/Core/Structuring_content/Headings_and_paragraphs"
           >HTML text fundamentals</a
         >,
         <a
-          href="/es/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks"
+          href="/es/docs/Learn_web_development/Core/Structuring_content/Creating_links"
           >Creating hyperlinks</a
         >, y
         <a
-          href="/es/docs/Learn/HTML/Introduction_to_HTML/Advanced_text_formatting"
+          href="/es/docs/Learn_web_development/Core/Structuring_content/Advanced_text_features"
           >Advanced text formatting</a
         >.
       </td>

--- a/files/es/learn_web_development/core/structuring_content/structuring_a_page_of_content/index.md
+++ b/files/es/learn_web_development/core/structuring_content/structuring_a_page_of_content/index.md
@@ -19,10 +19,10 @@ La estructuración de una página de contenido lista para su uso mediante CSS es
             en el resto del curso, con un énfasis particular en la
           </span></span
         ><a
-          href="/es/docs/Learn/HTML/Introduction_to_HTML/Document_and_website_structure"
+          href="/es/docs/Learn_web_development/Core/Structuring_content/Structuring_documents"
           >Estructura del Documento y del Sitio Web.</a
         ><a
-          href="https://developer.mozilla.org/es/docs/Learn/HTML/Introduccion_a_HTML/estructura"
+          href="/es/docs/Learn_web_development/Core/Structuring_content/Structuring_documents"
           >.</a
         >
       </td>

--- a/files/es/learn_web_development/core/structuring_content/table_accessibility/index.md
+++ b/files/es/learn_web_development/core/structuring_content/table_accessibility/index.md
@@ -14,7 +14,7 @@ En el segundo artículo de este módulo, analizamos algunas características má
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conceptos básicos de HTML (ver
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >).
       </td>

--- a/files/es/learn_web_development/core/styling_basics/attribute_selectors/index.md
+++ b/files/es/learn_web_development/core/styling_basics/attribute_selectors/index.md
@@ -15,16 +15,16 @@ Como ya explicamos en los artículos de HTML, los elementos pueden tener atribut
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico instalado</a
         >, conocimientos básicos de
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, HTML básico (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML">Introducción a HTML</a
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >) y nociones de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Primeros pasos con CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/styling_basics/backgrounds_and_borders/index.md
+++ b/files/es/learn_web_development/core/styling_basics/backgrounds_and_borders/index.md
@@ -15,18 +15,18 @@ En este artículo, veremos algunas de las cosas creativas que puedes hacer con l
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico</a
         >
         instalado, conocimientos básicos de
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, conocimientos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Primeros pasos con el CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con el CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/styling_basics/basic_selectors/index.md
+++ b/files/es/learn_web_development/core/styling_basics/basic_selectors/index.md
@@ -15,16 +15,16 @@ En {{Glossary( "CSS")}} los selectores se utilizan para delimitar los elementos 
       <td>
         Nociones básicas de informática, tener el
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico instalado</a
         >, conocimientos básicos de
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, conocimientos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML">Introducción a HTML</a
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >) y una idea de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Primeros pasos con CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/styling_basics/box_model/index.md
+++ b/files/es/learn_web_development/core/styling_basics/box_model/index.md
@@ -15,17 +15,17 @@ Todo en CSS tiene una caja alrededor, y comprender estas cajas es clave para pod
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico</a
         >
         instalado, conocimientos básicos de cómo
-        <a href="/es/docs/Learn/Getting_started_with_the_web/Dealing_with_files"
+        <a href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, conocimientos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Primeros pasos con CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/styling_basics/debugging_css/index.md
+++ b/files/es/learn_web_development/core/styling_basics/debugging_css/index.md
@@ -15,17 +15,17 @@ Al escribir CSS te puedes encontrar que, a veces, alguna parte de tu CSS no hace
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico</a
         >
         instalado, conocimientos básicos de
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, HTML básico (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML">Introducción a HTML</a
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >) y nociones de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Primeros pasos con CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/styling_basics/getting_started/index.md
+++ b/files/es/learn_web_development/core/styling_basics/getting_started/index.md
@@ -15,15 +15,15 @@ En este artículo aplicaremos CSS a un documento HTML sencillo para aprender alg
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico instalado</a
         >, conocimientos básicos de
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajo con archivos</a
         >
         y conceptos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >).
       </td>

--- a/files/es/learn_web_development/core/styling_basics/handling_conflicts/index.md
+++ b/files/es/learn_web_development/core/styling_basics/handling_conflicts/index.md
@@ -17,18 +17,18 @@ A medida que avances en este apartado verás que puede resultar menos relevante 
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico instalado</a
         >, conocimientos básicos de
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, HTML básico (véase
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/HTML/Introduccion_a_HTML"
+          href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción a HTML</a
         >) y una idea de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Primeros pasos con CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/styling_basics/handling_different_text_directions/index.md
+++ b/files/es/learn_web_development/core/styling_basics/handling_different_text_directions/index.md
@@ -17,15 +17,15 @@ Sin embargo, en los últimos años, CSS ha evolucionado para soportar de mejor f
       <td>
         Literatura computacional básica,
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico instalado</a
         >, conocimiento básico de
-        <a href="/es/docs/Learn/Getting_started_with_the_web/Dealing_with_files"
+        <a href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >manejo de archivos</a
-        >, HTML básico (<a href="/es/docs/Learn/HTML/Introduction_to_HTML"
+        >, HTML básico (<a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción a HTML</a
         >), y una idea de cómo funciona CSS (<a
-          href="/es/docs/Learn/CSS/First_steps"
+          href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics"
           >Primeros pasos en CSS</a
         >.)
       </td>

--- a/files/es/learn_web_development/core/styling_basics/images_media_forms/index.md
+++ b/files/es/learn_web_development/core/styling_basics/images_media_forms/index.md
@@ -15,17 +15,17 @@ En este artículo vamos a ver cómo se tratan ciertos elementos especiales en CS
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico</a
         >
         instalado, conocimientos básicos de
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, conocimientos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML">Introducción a HTML</a
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >) y nociones de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Primeros pasos con CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/styling_basics/overflow/index.md
+++ b/files/es/learn_web_development/core/styling_basics/overflow/index.md
@@ -15,17 +15,17 @@ En este artículo veremos otro concepto importante en CSS: el **desbordamiento**
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico</a
         >
         instalado, conocimientos básicos de
-        <a href="/es/docs/Learn/Getting_started_with_the_web/Dealing_with_files"
+        <a href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, conocimientos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Primeros pasos con el CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con el CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/styling_basics/pseudo_classes_and_elements/index.md
+++ b/files/es/learn_web_development/core/styling_basics/pseudo_classes_and_elements/index.md
@@ -15,16 +15,16 @@ El conjunto de selectores que estudiaremos en este artículo se conocen como **p
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico instalado</a
         >, conocimientos básicos de
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, HTML básico (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML">Introducción a HTML</a
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >) y nociones de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Primeros pasos con el CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con el CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/styling_basics/sizing/index.md
+++ b/files/es/learn_web_development/core/styling_basics/sizing/index.md
@@ -15,17 +15,17 @@ En los diversos artículos vistos hasta ahora, has aprendido varias formas de di
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico</a
         >
         instalado, conocimientos básicos de
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, HTML básico (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML">Introducción a HTML</a
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >) y nociones de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Primeros pasos con CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/styling_basics/styling_a_bio_page/index.md
+++ b/files/es/learn_web_development/core/styling_basics/styling_a_bio_page/index.md
@@ -15,7 +15,7 @@ Con las cosas que has aprendido en las últimas lecciones, puedes darle formato 
       <td>
         Antes de intentar esta evaluación, deberías haber trabajado a través del
         módulo de CSS básico, y también comprender HTML básico (estudia la
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción a HTML</a
         >).
       </td>

--- a/files/es/learn_web_development/core/styling_basics/tables/index.md
+++ b/files/es/learn_web_development/core/styling_basics/tables/index.md
@@ -14,11 +14,11 @@ Aplicar estilos a una tabla HTML no es el trabajo más interesante del mundo, pe
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimientos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción a HTML</a
-        >) y <a href="/es/docs/Learn/HTML/Tables">tablas HTML</a>, y nociones de
+        >) y <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content/HTML_table_basics">tablas HTML</a>, y nociones de
         cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Introducción al CSS</a>.)
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>.)
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/styling_basics/values_and_units/index.md
+++ b/files/es/learn_web_development/core/styling_basics/values_and_units/index.md
@@ -15,17 +15,17 @@ Todas las propiedades que se utilizan en CSS tienen un valor o un conjunto de va
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="/es/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico</a
         >
         instalado, conocimientos básicos de
-        <a href="/es/docs/Learn/Getting_started_with_the_web/Dealing_with_files"
+        <a href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, HTML básico (véase
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción a HTML</a
         >) y nociones de cómo funciona el CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Primeros pasos con el CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con el CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/styling_basics/what_is_css/index.md
+++ b/files/es/learn_web_development/core/styling_basics/what_is_css/index.md
@@ -16,16 +16,16 @@ Hemos aprendido los conceptos básicos de CSS, para qué sirve y cómo escribir 
       <td>
         Conocimientos básicos de informática, tener el
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Instalacion_de_software_basico"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
           >software básico</a
         >
         instalado, conocimientos básicos de cómo
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Getting_started_with_the_web/Manejando_los_archivos"
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >
         y conceptos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML">Introducción a HTML</a
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >).
       </td>
     </tr>

--- a/files/es/learn_web_development/core/text_styling/fundamentals/index.md
+++ b/files/es/learn_web_development/core/text_styling/fundamentals/index.md
@@ -15,10 +15,10 @@ En este artículo vas a iniciar tu viaje hacia el dominio la aplicación de esti
       <td>
         Conocimientos básicos de informática, conceptos básicos de HTML (estudio
         de
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >), conceptos básicos de CSS (estudio de
-        <a href="/es/docs/Learn/CSS/First_steps">Introducción al CSS</a>).
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>).
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/core/text_styling/styling_links/index.md
+++ b/files/es/learn_web_development/core/text_styling/styling_links/index.md
@@ -14,11 +14,11 @@ A la hora de dar estilo a los [enlaces](/es/docs/Learn_web_development/Core/Stru
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimientos básicos de informática, conceptos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >), conocimientos básicos de CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Introducción al CSS</a>),
-        <a href="/es/docs/Learn/CSS/Styling_text/Fundamentals"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>),
+        <a href="/es/docs/Learn_web_development/Core/Text_styling/Fundamentals"
           >nociones de aplicación de estilo con CSS a textos y tipos de letra</a
         >.
       </td>

--- a/files/es/learn_web_development/core/text_styling/styling_lists/index.md
+++ b/files/es/learn_web_development/core/text_styling/styling_lists/index.md
@@ -15,9 +15,9 @@ Las [listas](/es/docs/Learn_web_development/Core/Structuring_content/Headings_an
       <td>
         Conocimientos básicos de informática, conocimientos básicos de HTML
         (estudio
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML">introducción a HTML</a
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">introducción a HTML</a
         >), nociones de cómo trabaja con CSS (estudio
-        <a href="/es/docs/Learn/CSS/First_steps">introducción a CSS</a>),
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">introducción a CSS</a>),
         <a href="/es/docs/Learn_web_development/Core/Text_styling/Fundamentals"
           >Conocimientos básicos de CSS para texto y tipos de letra</a
         >.

--- a/files/es/learn_web_development/core/text_styling/web_fonts/index.md
+++ b/files/es/learn_web_development/core/text_styling/web_fonts/index.md
@@ -14,11 +14,11 @@ En el primer artículo del módulo, exploramos las características básicas del
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimientos básicos de informática, conceptos básicos de HTML (véase
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y de CSS (véase
-        <a href="/es/docs/Learn/CSS/First_steps">Introducción al CSS</a>),
-        <a href="/es/docs/Learn/CSS/Styling_text/Fundamentals"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>),
+        <a href="/es/docs/Learn_web_development/Core/Text_styling/Fundamentals"
           >texto CSS y los fundamentos de la fuente</a
         >.
       </td>

--- a/files/es/learn_web_development/extensions/advanced_javascript_objects/classes_in_javascript/index.md
+++ b/files/es/learn_web_development/extensions/advanced_javascript_objects/classes_in_javascript/index.md
@@ -17,7 +17,7 @@ También hablamos acerca de cómo podemos usar [prototipos](/es/docs/Learn_web_d
     <tr>
       <th scope="row">Prerequisitos:</th>
       <td>
-        Conocimientos básicos de informática, comprensión básica de HTML y CSS, familiaridad con conceptos básicos de Javascript (mira <a href="/es/docs/Learn/JavaScript/First_steps">Primeros pasos</a> y <a href="/es/docs/Learn/JavaScript/Building_blocks">Construyendo con bloques</a>) y lo esencial de JSOO (Javascript orientado a objetos)(mira <a href="/es/docs/Learn/JavaScript/Objects/Basics">Introducción a los objetos</a> y <a href="/es/docs/Learn/JavaScript/Objects/Object-oriented_programming">Programación orientada a objetos</a>)
+        Conocimientos básicos de informática, comprensión básica de HTML y CSS, familiaridad con conceptos básicos de Javascript (mira <a href="/es/docs/conflicting/Learn_web_development/Core/Scripting">Primeros pasos</a> y <a href="/es/docs/Learn_web_development/Core/Scripting">Construyendo con bloques</a>) y lo esencial de JSOO (Javascript orientado a objetos)(mira <a href="/es/docs/Learn_web_development/Core/Scripting/Object_basics">Introducción a los objetos</a> y <a href="/es/docs/Learn/JavaScript/Objects/Object-oriented_programming">Programación orientada a objetos</a>)
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/extensions/forms/basic_native_form_controls/index.md
+++ b/files/es/learn_web_development/extensions/forms/basic_native_form_controls/index.md
@@ -14,7 +14,7 @@ En el [artículo anterior](/es/docs/Learn_web_development/Extensions/Forms/How_t
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimientos básicos de informática y de
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML">lenguaje HTML</a>.
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">lenguaje HTML</a>.
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/extensions/forms/form_validation/index.md
+++ b/files/es/learn_web_development/extensions/forms/form_validation/index.md
@@ -14,9 +14,9 @@ Antes de enviar datos al servidor, es importante asegurarse de que se completan 
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimientos básicos de informática, y entender cómo funcionan el
-        <a href="/es/docs/Learn/HTML">HTML</a>, el
-        <a href="/es/docs/Learn/CSS">CSS</a> y el
-        <a href="/es/docs/Learn/JavaScript">JavaScript</a>.
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">HTML</a>, el
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics_b957eec7deaf1ea2b20721d6838ea6e1">CSS</a> y el
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Scripting_41cf930b8cfd2b83c76f8086a5e24792">JavaScript</a>.
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
+++ b/files/es/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
@@ -14,7 +14,7 @@ Una vez examinados los conceptos básicos, vamos a ver más en detalle los eleme
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimientos básicos de informática y de
-        <a href="/es/docs/Learn/HTML/Introduccion_a_HTML">lenguajes HTML</a>.
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">lenguajes HTML</a>.
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/extensions/forms/html5_input_types/index.md
+++ b/files/es/learn_web_development/extensions/forms/html5_input_types/index.md
@@ -14,7 +14,7 @@ En el [artículo anterior](/es/docs/Learn_web_development/Extensions/Forms/Basic
       <th scope="row">Requisitos previos:</th>
       <td>
         Formación básica en informática, y una
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >comprensión básica de HTML</a
         >.
       </td>

--- a/files/es/learn_web_development/extensions/forms/sending_and_retrieving_form_data/index.md
+++ b/files/es/learn_web_development/extensions/forms/sending_and_retrieving_form_data/index.md
@@ -14,12 +14,12 @@ En este artículo se analiza lo que sucede cuando un usuario envía un formulari
       <th scope="row">Requisitos previos:</th>
       <td>
         Conocimientos básicos de informática, una
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML"
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >comprensión de HTML</a
         >
         , y conocimientos básicos de
-        <a href="/es/docs/Web/HTTP/Basics_of_HTTP">HTTP</a> y
-        <a href="/es/docs/Learn/Server-side/First_steps"
+        <a href="/es/docs/conflicting/Web/HTTP">HTTP</a> y
+        <a href="/es/docs/Learn_web_development/Extensions/Server-side/First_steps"
           >programación del lado del servidor</a
         >
         .

--- a/files/es/learn_web_development/extensions/forms/styling_web_forms/index.md
+++ b/files/es/learn_web_development/extensions/forms/styling_web_forms/index.md
@@ -14,8 +14,8 @@ En los artículos anteriores vimos todo el HTML que necesitas para crear y estru
       <th scope="row">Requisitos previos:</th>
       <td>
         Conocimientos básicos de informática y una comprensión básica de
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML">HTML</a> y
-        <a href="/es/docs/Learn/CSS/First_steps">CSS</a>.
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">HTML</a> y
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">CSS</a>.
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/extensions/forms/your_first_form/index.md
+++ b/files/es/learn_web_development/extensions/forms/your_first_form/index.md
@@ -14,7 +14,7 @@ El primer artículo de nuestra serie te proporciona una primera experiencia de c
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimientos básicos de informática y de
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML">lenguaje HTML</a>.
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">lenguaje HTML</a>.
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/extensions/server-side/django/admin_site/index.md
+++ b/files/es/learn_web_development/extensions/server-side/django/admin_site/index.md
@@ -15,7 +15,7 @@ Ahora que hemos creado modelos para el sitio web de la [BibliotecaLocal](/es/doc
       <td>
         Primero completa:
         <a
-          href="https://developer.mozilla.org/es/docs/Learn_web_development/Extensions/Server-side/Django/Models"
+          href="/es/docs/Learn_web_development/Extensions/Server-side/Django/Models"
           >Tutorial Django Parte 3: Uso de modelos</a
         >.
       </td>

--- a/files/es/learn_web_development/extensions/server-side/django/generic_views/index.md
+++ b/files/es/learn_web_development/extensions/server-side/django/generic_views/index.md
@@ -16,7 +16,7 @@ Este tutorial extiende nuestro sitio web de la [BibliotecaLocal](/es/docs/Learn_
         <p>
           Completa todos los tópicos anteriores del tutorial, incluyendo
           <a
-            href="https://developer.mozilla.org/es/docs/Learn_web_development/Extensions/Server-side/Django/Home_page"
+            href="/es/docs/Learn_web_development/Extensions/Server-side/Django/Home_page"
             >Tutorial de Django Parte 5: Creación de tu página de inicio</a
           >.
         </p>

--- a/files/es/learn_web_development/extensions/server-side/django/home_page/index.md
+++ b/files/es/learn_web_development/extensions/server-side/django/home_page/index.md
@@ -19,7 +19,7 @@ Estamos listos ahora para añadir el código para mostrar nuestra primera págin
           >Introducción a Django</a
         >. Completa los tópicos previos del tutorial (incluyendo
         <a
-          href="https://developer.mozilla.org/es/docs/Learn_web_development/Extensions/Server-side/Django/Admin_site"
+          href="/es/docs/Learn_web_development/Extensions/Server-side/Django/Admin_site"
           >Tutorial de Django Parte 4: Sitio de administración de Django</a
         >).
       </td>

--- a/files/es/learn_web_development/extensions/server-side/django/introduction/index.md
+++ b/files/es/learn_web_development/extensions/server-side/django/introduction/index.md
@@ -15,11 +15,11 @@ En este primer artículo de Django responderemos la pregunta ¿Qué es Django? y
       <td>
         Conocimientos basicos en informatica. Una comprensión general de
         <a
-          href="/es/docs/Learn/Server-side/First_steps"
+          href="/es/docs/Learn_web_development/Extensions/Server-side/First_steps"
           >programación del lado del servidor</a
         >, y en particular de los mecanimos de
         <a
-          href="/es/docs/Learn/Server-side/First_steps/Client-Server_overview"
+          href="/es/docs/Learn_web_development/Extensions/Server-side/First_steps/Client-Server_overview"
           >interacciones cliente-servidor en los sitios web</a
         >.
       </td>

--- a/files/es/learn_web_development/extensions/server-side/django/models/index.md
+++ b/files/es/learn_web_development/extensions/server-side/django/models/index.md
@@ -14,7 +14,7 @@ Este artículo muestra cómo definir modelos para el sitio web de la [Biblioteca
       <th scope="row">Pre-requisitos:</th>
       <td>
         <a
-          href="https://developer.mozilla.org/es/docs/Learn_web_development/Extensions/Server-side/Django/skeleton_website"
+          href="/es/docs/Learn_web_development/Extensions/Server-side/Django/skeleton_website"
           >Tutorial Django Parte 2: Creación del esqueleto del sitio web</a
         >.
       </td>

--- a/files/es/learn_web_development/extensions/server-side/django/skeleton_website/index.md
+++ b/files/es/learn_web_development/extensions/server-side/django/skeleton_website/index.md
@@ -14,7 +14,7 @@ Este segundo artículo de nuestro [Tutorial Django](/es/docs/Learn_web_developme
       <th scope="row">Pre-requisitos:</th>
       <td>
         <a
-          href="https://developer.mozilla.org/es/docs/Learn/Server-side/Django/development_environment"
+          href="/es/docs/Learn_web_development/Extensions/Server-side/Django/development_environment"
           >Poner en marcha un entorno de desarrollo Django</a
         >. Repasar el
         <a

--- a/files/es/learn_web_development/extensions/server-side/django/tutorial_local_library_website/index.md
+++ b/files/es/learn_web_development/extensions/server-side/django/tutorial_local_library_website/index.md
@@ -20,7 +20,7 @@ El primer artículo de nuestra serie de tutoriales prácticos explica qué puede
             >Introducción a Django</a
           >. Durante los siguientes artículos necesitarás tener
           <a
-            href="https://developer.mozilla.org/es/docs/Learn_web_development/Extensions/Server-side/Django/development_environment"
+            href="/es/docs/Learn_web_development/Extensions/Server-side/Django/development_environment"
             >levantado un entorno de desarrollo Django</a
           >.
         </p>

--- a/files/es/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
+++ b/files/es/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
@@ -16,11 +16,11 @@ En este primer articulo de Express resolveremos las preguntas "¿Qué es Node?" 
         <p>
           Conocimientos básicos de informática. Noción general sobre
           <a
-            href="https://developer.mozilla.org/es/docs/Learn/Server-side/Primeros_pasos"
+            href="/es/docs/Learn_web_development/Extensions/Server-side/First_steps"
             >programación lado servidor de sitios web</a
           >, y en particular los mecanismos de las interacciones
           <a
-            href="/es/docs/Learn/Server-side/Primeros_pasos/Vision_General_Cliente_Servidor"
+            href="/es/docs/Learn_web_development/Extensions/Server-side/First_steps/Client-Server_overview"
             >cliente-servidor en sitios web</a
           >.
         </p>

--- a/files/es/learn_web_development/extensions/server-side/express_nodejs/skeleton_website/index.md
+++ b/files/es/learn_web_development/extensions/server-side/express_nodejs/skeleton_website/index.md
@@ -16,7 +16,7 @@ Este segundo artículo de nuestro [Tutorial Express](/es/docs/Learn_web_developm
       <th scope="row">Prerequisitos:</th>
       <td>
         <a
-          href="/es/docs/Learn/Server-side/Express_Nodejs/development_environment"
+          href="/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/development_environment"
           >Configurar un entorno de desarrollo de Node</a
         >. Revise el Tutorial Express.
       </td>

--- a/files/es/learn_web_development/extensions/server-side/express_nodejs/tutorial_local_library_website/index.md
+++ b/files/es/learn_web_development/extensions/server-side/express_nodejs/tutorial_local_library_website/index.md
@@ -14,7 +14,7 @@ El primer artículo de nuestra serie de tutoriales prácticos explica lo que apr
       <th scope="row">Prerequisitos:</th>
       <td>
         Leer la
-        <a href="/es/docs/Learn/Server-side/Express_Nodejs/Introduction"
+        <a href="/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/Introduction"
           >Introducción a Express</a
         >.
         <span id="result_box" lang="es"

--- a/files/es/learn_web_development/extensions/server-side/first_steps/web_frameworks/index.md
+++ b/files/es/learn_web_development/extensions/server-side/first_steps/web_frameworks/index.md
@@ -18,7 +18,7 @@ El artículo anterior te mostró que pinta tiene la comunicación entre los clie
           cómo gestiona y responde a las peticiones HTTP el código de lado
           servidor (ver
           <a
-            href="https://developer.mozilla.org/es/docs/Learn/Server-side/Primeros_pasos/Vision_General_Cliente_Servidor"
+            href="/es/docs/Learn_web_development/Extensions/Server-side/First_steps/Client-Server_overview"
             >Visión general Cliente-Servidor</a
           >).
         </p>

--- a/files/es/learn_web_development/getting_started/environment_setup/browsing_the_web/index.md
+++ b/files/es/learn_web_development/getting_started/environment_setup/browsing_the_web/index.md
@@ -16,7 +16,7 @@ En este artículo se describen varios conceptos referidos a la web: Páginas web
       <th scope="row">Prerrequisitos:</th>
       <td>
         Debes saber
-        <a href="/es/docs/Learn/Common_questions/How_does_the_Internet_work"
+        <a href="/es/docs/Learn_web_development/Howto/Web_mechanics/How_does_the_Internet_work"
           >¿Cómo funciona internet?</a
         >.
       </td>

--- a/files/es/learn_web_development/howto/design_and_accessibility/common_web_layouts/index.md
+++ b/files/es/learn_web_development/howto/design_and_accessibility/common_web_layouts/index.md
@@ -16,7 +16,7 @@ Cuando diseñas páginas para tú sitio web es bueno tener una idea de los dise�
       <th scope="row">Prerrequisitos:</th>
       <td>
         Asegúrate haber pensado
-        <a href="/es/docs/Learn/Common_questions/Design_and_accessibility/Thinking_before_coding"
+        <a href="/es/docs/Learn_web_development/Howto/Design_and_accessibility/Thinking_before_coding"
           >lo que quieres lograr</a
         >
         con tú proyecto web.

--- a/files/es/learn_web_development/howto/web_mechanics/what_is_a_url/index.md
+++ b/files/es/learn_web_development/howto/web_mechanics/what_is_a_url/index.md
@@ -14,14 +14,14 @@ Este artículo habla sobre las Uniform Resource Locators (URLs), explicando qué
       <th scope="row">Prerequisitos:</th>
       <td>
         Primero necesitas saber
-        <a href="/es/docs/Learn/Common_questions/Web_mechanics/How_does_the_Internet_work"
+        <a href="/es/docs/Learn_web_development/Howto/Web_mechanics/How_does_the_Internet_work"
           >Cómo funciona Internet</a
         >,
-        <a href="/es/docs/Learn/Common_questions/Web_mechanics/What_is_a_web_server"
+        <a href="/es/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_web_server"
           >qué es un servidor Web</a
         >
         y
-        <a href="/es/docs/Learn/Common_questions/Web_mechanics/What_are_hyperlinks"
+        <a href="/es/docs/Learn_web_development/Howto/Web_mechanics/What_are_hyperlinks"
           >los conceptos detrás de los enlaces en la web</a
         >.
       </td>

--- a/files/es/learn_web_development/howto/web_mechanics/what_is_a_web_server/index.md
+++ b/files/es/learn_web_development/howto/web_mechanics/what_is_a_web_server/index.md
@@ -14,10 +14,10 @@ En este articulo veremos que son los servidores, cómo funcionan y por qué son 
       <th scope="row">Prerequisitos:</th>
       <td>
         Debes saber
-        <a href="/es/docs/Learn/Common_questions/Web_mechanics/How_does_the_Internet_work"
+        <a href="/es/docs/Learn_web_development/Howto/Web_mechanics/How_does_the_Internet_work"
           >cómo funciona internet</a
         >, y
-        <a href="/es/docs/Learn/Common_questions/Web_mechanics/Pages_sites_servers_and_search_engines"
+        <a href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Browsing_the_web"
           >entender la diferencia entre página web, sitio web, servidor y
           motor de búsqueda</a
         >

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
@@ -79,7 +79,7 @@ Idealmente, esto debería ser una o dos oraciones cortas.
         Incluye la categoría de la cabecera (o categorías), por ejemplo,
         {{Glossary("Request header", "Cabecera de solicitud")}},
         {{Glossary("Response header", "Cabecera de respuesta")}},
-        <a href="/es/docs/Web/HTTP/Headers">Cabecera de pista del cliente</a>
+        <a href="/es/docs/Web/HTTP/Reference/Headers">Cabecera de pista del cliente</a>
       </td>
     </tr>
     <tr>

--- a/files/es/mozilla/add-ons/webextensions/user_interface/index.md
+++ b/files/es/mozilla/add-ons/webextensions/user_interface/index.md
@@ -24,7 +24,7 @@ Las extensiones que usan las API de WebExtension se proporcionan con varias opci
     <tr>
       <td>
         <a
-          href="/es/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_action"
+          href="/es/docs/Mozilla/Add-ons/WebExtensions/user_interface/Toolbar_button"
           >Botón de la barra de herramientas</a
         >
         (acción del navegador)

--- a/files/es/web/accessibility/aria/guides/techniques/index.md
+++ b/files/es/web/accessibility/aria/guides/techniques/index.md
@@ -12,8 +12,8 @@ l10n:
     <li><a href="/es/docs/Web/Accessibility/ARIA/ARIA_Guides">Guías ARIA</a></li>
     <li><a href="/es/docs/Web/Accessibility/ARIA/ARIA_Live_Regions">Regiones en vivo de ARIA</a></li>
     <li><a href="/es/docs/Web/Accessibility/ARIA/ARIA_Screen_Reader_Implementors_Guide">Guía de implementadores del lector de pantalla ARIA</a></li>
-    <li><a href="/es/docs/Web/Accessibility/ARIA/ARIA_Techniques">Uso de ARIA: roles, estados y propiedades</a></li>
-    <li><a href="/es/docs/Web/Accessibility/ARIA/Multipart_labels">Etiquetas de varias partes</a></li>
+    <li><a href="/es/docs/Web/Accessibility/ARIA/Guides/Techniques">Uso de ARIA: roles, estados y propiedades</a></li>
+    <li><a href="/es/docs/Web/Accessibility/ARIA/Guides/Multipart_labels">Etiquetas de varias partes</a></li>
     <li><a href="/es/docs/Web/Accessibility/ARIA/How_to_file_ARIA-related_bugs">Cómo registrar errores relacionados con ARIA</a></li>
     <li class="toggle">
       <details><summary>Estados y propiedades de ARIA</summary>

--- a/files/es/web/accessibility/guides/understanding_wcag/perceivable/index.md
+++ b/files/es/web/accessibility/guides/understanding_wcag/perceivable/index.md
@@ -31,7 +31,7 @@ La clave aquí es convertir el texto a otros formatos que puedan ser entendidos 
         alternativo.
       </td>
       <td>
-        <a href="/es/docs/Learn/Accessibility/HTML#Text_alternatives"
+        <a href="/es/docs/Learn_web_development/Core/Accessibility/HTML#Text_alternatives"
           >Texto alternativo.</a
         >
       </td>
@@ -47,12 +47,12 @@ La clave aquí es convertir el texto a otros formatos que puedan ser entendidos 
       <td>
         <p>
           Una alternativa textual o una tabla puede resolverlo (ver
-          <a href="/es/docs/Learn/HTML/Tables/Advanced"
+          <a href="/es/docs/Learn_web_development/Core/Structuring_content/Table_accessibility"
             >HTML table advanced features and accessibility</a
           >
           y
           <a
-            href="/es/docs/Learn/Accessibility/HTML#Other_text_alternative_mechanisms"
+            href="/es/docs/Learn_web_development/Core/Accessibility/HTML#Other_text_alternative_mechanisms"
             >Other text alternative mechanisms</a
           >
           para leer sobre el argumento en contra de <code>longdesc</code>.
@@ -67,7 +67,7 @@ La clave aquí es convertir el texto a otros formatos que puedan ser entendidos 
       <td>
         <p>
           Ver
-          <a href="/es/docs/Learn/Accessibility/HTML#Text_alternatives"
+          <a href="/es/docs/Learn_web_development/Core/Accessibility/HTML#Text_alternatives"
             >alternativas de texto</a
           >
           para opciones de captions, y
@@ -95,7 +95,7 @@ La clave aquí es convertir el texto a otros formatos que puedan ser entendidos 
         Deberás asegurarte de que los botones describan su función (por ejemplo,
         <code>&#x3C;button>Subir imagen&#x3C;/button></code>). Para más
         información ver
-        <a href="/es/docs/Learn/Accessibility/HTML#UI_controls"
+        <a href="/es/docs/Learn_web_development/Core/Accessibility/HTML#UI_controls"
           >UI controls</a
         >.
       </td>
@@ -177,11 +177,11 @@ Esta pauta hace referencia a la posibilidad de que todo contenido pueda ser cons
         </ul>
       </td>
       <td>The whole of
-        <p><a href="/es/docs/Learn/Accessibility/HTML">HTML: A good basis for accessibility</a> is packed
+        <p><a href="/es/docs/Learn_web_development/Core/Accessibility/HTML">HTML: A good basis for accessibility</a> is packed
           with information about this, but you should particularly refer to <a
-            href="/es/docs/Learn/Accessibility/HTML#Good_semantics">Good semantics</a>, <a
-            href="/es/docs/Learn/Accessibility/HTML#UI_controls">UI controls</a>, and <a
-            href="/es/docs/Learn/Accessibility/HTML#Text_alternatives">Text alternatives</a>.</p>
+            href="/es/docs/Learn_web_development/Core/Accessibility/HTML#Good_semantics">Good semantics</a>, <a
+            href="/es/docs/Learn_web_development/Core/Accessibility/HTML#UI_controls">UI controls</a>, and <a
+            href="/es/docs/Learn_web_development/Core/Accessibility/HTML#Text_alternatives">Text alternatives</a>.</p>
       </td>
     </tr>
     <tr>
@@ -190,7 +190,7 @@ Esta pauta hace referencia a la posibilidad de que todo contenido pueda ser cons
         presented in an unusual way. The order should be made obvious by use of correct semantic elements (e.g.
         headings, paragraphs), with CSS being used to create any unusual layout styles, irrespective of the
         markup.</td>
-      <td>Again, refer to <a href="/es/docs/Learn/Accessibility/HTML">HTML: A good basis for accessibility</a>.
+      <td>Again, refer to <a href="/es/docs/Learn_web_development/Core/Accessibility/HTML">HTML: A good basis for accessibility</a>.
       </td>
     </tr>
     <tr>
@@ -271,8 +271,8 @@ Esta pauta tiene como objetivo la creación de contenido que sea fácil de difer
           required fields purely with a color (like red). Instead (or as well as), something like an asterisk with a
           label of "required" would be more appropriate.</p>
       </td>
-      <td>See <a href="/es/docs/Learn/Accessibility/CSS_and_JavaScript#Color_and_color_contrast">Color and color
-          contrast</a> and <a href="/es/docs/Learn/HTML/Forms/How_to_structure_an_HTML_form#Multiple_labels">Multiple
+      <td>See <a href="/es/docs/Learn_web_development/Core/Accessibility/CSS_and_JavaScript#Color_and_color_contrast">Color and color
+          contrast</a> and <a href="/es/docs/Learn_web_development/Extensions/Forms/How_to_structure_a_web_form#Multiple_labels">Multiple
           labels</a>.</td>
     </tr>
     <tr>
@@ -294,7 +294,7 @@ Esta pauta tiene como objetivo la creación de contenido que sea fácil de difer
             18pt, or 14pt bold.</li>
         </ul>
       </td>
-      <td>See <a href="/es/docs/Learn/Accessibility/CSS_and_JavaScript#Color_and_color_contrast">Color and color
+      <td>See <a href="/es/docs/Learn_web_development/Core/Accessibility/CSS_and_JavaScript#Color_and_color_contrast">Color and color
           contrast</a>.</td>
     </tr>
     <tr>

--- a/files/es/web/api/htmlelement/change_event/index.md
+++ b/files/es/web/api/htmlelement/change_event/index.md
@@ -25,7 +25,7 @@ El evento `change` se dispara para elementos {{HTMLElement("input")}}, {{HTMLEle
       <th scope="row">Propiedad del manejador del evento</th>
       <td>
         <code
-          ><a href="/es/docs/Web/API/GlobalEventHandlers/onchange"
+          ><a href="/es/docs/conflicting/Web/API/HTMLElement/change_event"
             >onchange</a
           ></code
         >

--- a/files/es/web/css/guides/grid_layout/auto-placement/index.md
+++ b/files/es/web/css/guides/grid_layout/auto-placement/index.md
@@ -578,55 +578,55 @@ Puede ser que se te ocurran tus propios casos de uso para la colocación automá
 <ol>
  <li><a href="/es/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/es/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>
- <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout">CSS Grid Layout</a></li>
+ <li><a href="/es/docs/Web/CSS/Guides/Grid_layout">CSS Grid Layout</a></li>
  <li data-default-state="open"><a href="#"><strong>Guides</strong></a>
   <ol>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basics concepts of grid layout</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout">Relationship to other layout methods</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Basic_concepts">Basics concepts of grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Relationship_with_other_layout_methods">Relationship to other layout methods</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid">Line-based placement</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">Grid template areas</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">Layout using named grid lines</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout">Auto-placement in grid layout</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Box alignment in grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Auto-placement">Auto-placement in grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Box_alignment">Box alignment in grid layout</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid,_Logical_Values_and_Writing_Modes">Grids, logical values and writing modes</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility">CSS Grid Layout and Accessibility</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement">CSS Grid Layout and Progressive Enhancement</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout">Realizing common layouts using grids</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Common_grid_layouts">Realizing common layouts using grids</a></li>
   </ol>
  </li>
  <li data-default-state="open"><a href="#"><strong>Properties</strong></a>
   <ol>
-   <li><a href="/es/docs/Web/CSS/grid">grid</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid">grid</a></li>
    <li><a href="/es/docs/Web/CSS/grid-area">grid-area</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-auto-columns">grid-auto-columns</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-auto-columns">grid-auto-columns</a></li>
    <li><a href="/es/docs/Web/CSS/grid-auto-flow">grid-auto-flow</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-auto-rows">grid-auto-rows</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-auto-rows">grid-auto-rows</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column">grid-column</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column-end">grid-column-end</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-column-gap">grid-column-gap</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/column-gap">grid-column-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column-start">grid-column-start</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-gap">grid-gap</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/gap">grid-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row">grid-row</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-end">grid-row-end</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-gap">grid-row-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-start">grid-row-start</a></li>
    <li><a href="/es/docs/Web/CSS/grid-template">grid-template</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-areas">grid-template-areas</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-columns">grid-template-columns</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-rows">grid-template-rows</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-areas">grid-template-areas</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-columns">grid-template-columns</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-rows">grid-template-rows</a></li>
   </ol>
  </li>
  <li data-default-state="open"><a href="#"><strong>Glossary</strong></a>
   <ol>
    <li><a href="/es/docs/Glossary/Grid">Grid</a></li>
-   <li><a href="/es/docs/Glossary/Grid_lines">Grid lines</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Lines">Grid lines</a></li>
    <li><a href="/es/docs/Glossary/Grid_tracks">Grid tracks</a></li>
    <li><a href="/es/docs/Glossary/Grid_cell">Grid cell</a></li>
-   <li><a href="/es/docs/Glossary/Grid_areas">Grid areas</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Areas">Grid areas</a></li>
    <li><a href="/es/docs/Glossary/Gutters">Gutters</a></li>
    <li><a href="/es/docs/Glossary/Grid_Axis">Grid Axis</a></li>
-   <li><a href="/es/docs/Glossary/Grid_rows">Grid row</a></li>
-   <li><a href="/es/docs/Glossary/Grid_column">Grid column</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Row">Grid row</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Column">Grid column</a></li>
   </ol>
  </li>
 </ol>

--- a/files/es/web/css/guides/grid_layout/basic_concepts/index.md
+++ b/files/es/web/css/guides/grid_layout/basic_concepts/index.md
@@ -757,55 +757,55 @@ En este artículo hemos tenido una mirada muy rápida a través de la Especifica
 <ol>
  <li><a href="/es/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/es/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>
- <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout">CSS Grid Layout</a></li>
+ <li><a href="/es/docs/Web/CSS/Guides/Grid_layout">CSS Grid Layout</a></li>
  <li data-default-state="open"><a href="#"><strong>Guías</strong></a>
   <ol>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Conceptos básicos del posicionamiento con cuadrículas</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout">Relación con otros métodos de posicionamiento</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Basic_concepts">Conceptos básicos del posicionamiento con cuadrículas</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Relationship_with_other_layout_methods">Relación con otros métodos de posicionamiento</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid">Posicionamiento basado en líneas</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">Áreas de una plantilla de cuadrícula</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">Posicionamiento usando líneas de cuadrícula con nombres</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout">Posicionamiento automático en grid layout</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Alineación de cajas en grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Auto-placement">Posicionamiento automático en grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Box_alignment">Alineación de cajas en grid layout</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid,_Logical_Values_and_Writing_Modes">cuadrículas, valores lógicos y modos de escritura</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility">CSS Grid Layout y Accesibilidad</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement">CSS Grid Layout y Mejora Progresiva</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout">Layouts comunes utilizando CSS Grid</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Common_grid_layouts">Layouts comunes utilizando CSS Grid</a></li>
   </ol>
  </li>
  <li data-default-state="open"><a href="#"><strong>Properties</strong></a>
   <ol>
-   <li><a href="/es/docs/Web/CSS/grid">grid</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid">grid</a></li>
    <li><a href="/es/docs/Web/CSS/grid-area">grid-area</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-auto-columns">grid-auto-columns</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-auto-columns">grid-auto-columns</a></li>
    <li><a href="/es/docs/Web/CSS/grid-auto-flow">grid-auto-flow</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-auto-rows">grid-auto-rows</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-auto-rows">grid-auto-rows</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column">grid-column</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column-end">grid-column-end</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-column-gap">grid-column-gap</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/column-gap">grid-column-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column-start">grid-column-start</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-gap">grid-gap</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/gap">grid-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row">grid-row</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-end">grid-row-end</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-gap">grid-row-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-start">grid-row-start</a></li>
    <li><a href="/es/docs/Web/CSS/grid-template">grid-template</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-areas">grid-template-areas</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-columns">grid-template-columns</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-rows">grid-template-rows</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-areas">grid-template-areas</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-columns">grid-template-columns</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-rows">grid-template-rows</a></li>
   </ol>
  </li>
  <li data-default-state="open"><a href="#"><strong>Glossary</strong></a>
   <ol>
    <li><a href="/es/docs/Glossary/Grid">cuadrícula</a></li>
-   <li><a href="/es/docs/Glossary/Grid_lines">Líneas de cuadrícula</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Lines">Líneas de cuadrícula</a></li>
    <li><a href="/es/docs/Glossary/Grid_tracks">Pistas de cuadrícula</a></li>
    <li><a href="/es/docs/Glossary/Grid_cell">Celda de cuadrícula</a></li>
-   <li><a href="/es/docs/Glossary/Grid_areas">Áreas de cuadrícula</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Areas">Áreas de cuadrícula</a></li>
    <li><a href="/es/docs/Glossary/Gutters">Canaletas</a></li>
    <li><a href="/es/docs/Glossary/Grid_Axis">Ejes de cuadrícula</a></li>
-   <li><a href="/es/docs/Glossary/Grid_rows">Fila de cuadrícula</a></li>
-   <li><a href="/es/docs/Glossary/Grid_column">Columna de cuadrícula</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Row">Fila de cuadrícula</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Column">Columna de cuadrícula</a></li>
   </ol>
  </li>
 </ol>

--- a/files/es/web/css/guides/grid_layout/common_grid_layouts/index.md
+++ b/files/es/web/css/guides/grid_layout/common_grid_layouts/index.md
@@ -593,55 +593,55 @@ La mejor manera de aprender a usar el diseño de la cuadrícula es continuar con
 <ol>
  <li><a href="/es/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/es/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>
- <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout">CSS Grid Layout</a></li>
+ <li><a href="/es/docs/Web/CSS/Guides/Grid_layout">CSS Grid Layout</a></li>
  <li data-default-state="open"><a href="#"><strong>Guías</strong></a>
   <ol>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Conceptos básicos del posicionamiento con rejillas</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout">Relación con otros métodos de posicionamiento</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Basic_concepts">Conceptos básicos del posicionamiento con rejillas</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Relationship_with_other_layout_methods">Relación con otros métodos de posicionamiento</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid">Posicionamiento basado en líneas</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">Áreas de una plantilla de rejilla</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">Posicionamiento usando líneas de rejilla con nombres</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout">Posicionamiento automático en grid layout</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Alineación de cajas en grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Auto-placement">Posicionamiento automático en grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Box_alignment">Alineación de cajas en grid layout</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid,_Logical_Values_and_Writing_Modes">Rejillas, valores lógicos y modos de escritura</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility">CSS Grid Layout y Accesibilidad</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement">CSS Grid Layout y Mejora Progresiva</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout">Layouts comunes utilizando CSS Grid</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Common_grid_layouts">Layouts comunes utilizando CSS Grid</a></li>
   </ol>
  </li>
  <li data-default-state="open"><a href="#"><strong>Properties</strong></a>
   <ol>
-   <li><a href="/es/docs/Web/CSS/grid">grid</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid">grid</a></li>
    <li><a href="/es/docs/Web/CSS/grid-area">grid-area</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-auto-columns">grid-auto-columns</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-auto-columns">grid-auto-columns</a></li>
    <li><a href="/es/docs/Web/CSS/grid-auto-flow">grid-auto-flow</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-auto-rows">grid-auto-rows</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-auto-rows">grid-auto-rows</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column">grid-column</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column-end">grid-column-end</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-column-gap">grid-column-gap</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/column-gap">grid-column-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column-start">grid-column-start</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-gap">grid-gap</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/gap">grid-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row">grid-row</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-end">grid-row-end</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-gap">grid-row-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-start">grid-row-start</a></li>
    <li><a href="/es/docs/Web/CSS/grid-template">grid-template</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-areas">grid-template-areas</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-columns">grid-template-columns</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-rows">grid-template-rows</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-areas">grid-template-areas</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-columns">grid-template-columns</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-rows">grid-template-rows</a></li>
   </ol>
  </li>
  <li data-default-state="open"><a href="#"><strong>Glossary</strong></a>
   <ol>
    <li><a href="/es/docs/Glossary/Grid">Rejilla</a></li>
-   <li><a href="/es/docs/Glossary/Grid_lines">Líneas de rejilla</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Lines">Líneas de rejilla</a></li>
    <li><a href="/es/docs/Glossary/Grid_tracks">Pistas de rejilla</a></li>
    <li><a href="/es/docs/Glossary/Grid_cell">Celda de rejilla</a></li>
-   <li><a href="/es/docs/Glossary/Grid_areas">Áreas de rejilla</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Areas">Áreas de rejilla</a></li>
    <li><a href="/es/docs/Glossary/Gutters">Canaletas</a></li>
    <li><a href="/es/docs/Glossary/Grid_Axis">Ejes de rejilla</a></li>
-   <li><a href="/es/docs/Glossary/Grid_rows">Fila de rejilla</a></li>
-   <li><a href="/es/docs/Glossary/Grid_column">Columna de rejilla</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Row">Fila de rejilla</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Column">Columna de rejilla</a></li>
   </ol>
  </li>
 </ol>

--- a/files/es/web/css/guides/grid_layout/index.md
+++ b/files/es/web/css/guides/grid_layout/index.md
@@ -157,55 +157,55 @@ CSS
 <ol>
  <li><a href="/es/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/es/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>
- <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout">CSS Grid Layout</a></li>
+ <li><a href="/es/docs/Web/CSS/Guides/Grid_layout">CSS Grid Layout</a></li>
  <li data-default-state="open"><a href="#"><strong>Guías</strong></a>
   <ol>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basics concepts of grid layout</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout">Relationship to other layout methods</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Basic_concepts">Basics concepts of grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Relationship_with_other_layout_methods">Relationship to other layout methods</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid">Line-based placement</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">Grid template areas</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">Layout using named grid lines</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout">Auto-placement in grid layout</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Box alignment in grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Auto-placement">Auto-placement in grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Box_alignment">Box alignment in grid layout</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid,_Logical_Values_and_Writing_Modes">Grids, logical values and writing modes</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility">CSS Grid Layout and Accessibility</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement">CSS Grid Layout and Progressive Enhancement</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout">Realizing common layouts using grids</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Common_grid_layouts">Realizing common layouts using grids</a></li>
   </ol>
  </li>
  <li data-default-state="open"><a href="#"><strong>Propiedades</strong></a>
   <ol>
-   <li><a href="/es/docs/Web/CSS/grid">grid</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid">grid</a></li>
    <li><a href="/es/docs/Web/CSS/grid-area">grid-area</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-auto-columns">grid-auto-columns</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-auto-columns">grid-auto-columns</a></li>
    <li><a href="/es/docs/Web/CSS/grid-auto-flow">grid-auto-flow</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-auto-rows">grid-auto-rows</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-auto-rows">grid-auto-rows</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column">grid-column</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column-end">grid-column-end</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-column-gap">grid-column-gap</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/column-gap">grid-column-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column-start">grid-column-start</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-gap">grid-gap</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/gap">grid-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row">grid-row</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-end">grid-row-end</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-gap">grid-row-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-start">grid-row-start</a></li>
    <li><a href="/es/docs/Web/CSS/grid-template">grid-template</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-areas">grid-template-areas</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-columns">grid-template-columns</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-rows">grid-template-rows</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-areas">grid-template-areas</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-columns">grid-template-columns</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-rows">grid-template-rows</a></li>
   </ol>
  </li>
  <li data-default-state="open"><a href="#"><strong>Glosario</strong></a>
   <ol>
    <li><a href="/es/docs/Glossary/Grid">Grid</a></li>
-   <li><a href="/es/docs/Glossary/Grid_lines">Grid lines</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Lines">Grid lines</a></li>
    <li><a href="/es/docs/Glossary/Grid_tracks">Grid tracks</a></li>
    <li><a href="/es/docs/Glossary/Grid_cell">Grid cell</a></li>
-   <li><a href="/es/docs/Glossary/Grid_areas">Grid areas</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Areas">Grid areas</a></li>
    <li><a href="/es/docs/Glossary/Gutters">Gutters</a></li>
    <li><a href="/es/docs/Glossary/Grid_Axis">Grid Axis</a></li>
-   <li><a href="/es/docs/Glossary/Grid_rows">Grid row</a></li>
-   <li><a href="/es/docs/Glossary/Grid_column">Grid column</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Row">Grid row</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Column">Grid column</a></li>
   </ol>
  </li>
 </ol>

--- a/files/es/web/css/guides/grid_layout/relationship_with_other_layout_methods/index.md
+++ b/files/es/web/css/guides/grid_layout/relationship_with_other_layout_methods/index.md
@@ -596,55 +596,55 @@ Como puedes ver en esta guía, CSS Grid Layout es sólo una parte de tu kit de h
 <ol>
  <li><a href="/es/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/es/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>
- <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout">CSS Grid Layout</a></li>
+ <li><a href="/es/docs/Web/CSS/Guides/Grid_layout">CSS Grid Layout</a></li>
  <li data-default-state="open"><a href="#"><strong>Guías</strong></a>
   <ol>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Conceptos básicos del posicionamiento con rejillas</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout">Relación con otros métodos de posicionamiento</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Basic_concepts">Conceptos básicos del posicionamiento con rejillas</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Relationship_with_other_layout_methods">Relación con otros métodos de posicionamiento</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid">Posicionamiento basado en líneas</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">Áreas de una plantilla de rejilla</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">Posicionamiento usando líneas de rejilla con nombres</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout">Posicionamiento automático en grid layout</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Alineación de cajas en grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Auto-placement">Posicionamiento automático en grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Box_alignment">Alineación de cajas en grid layout</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid,_Logical_Values_and_Writing_Modes">Rejillas, valores lógicos y modos de escritura</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility">CSS Grid Layout y Accesibilidad</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement">CSS Grid Layout y Mejora Progresiva</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout">Layouts comunes utilizando CSS Grid</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Common_grid_layouts">Layouts comunes utilizando CSS Grid</a></li>
   </ol>
  </li>
  <li data-default-state="open"><a href="#"><strong>Properties</strong></a>
   <ol>
-   <li><a href="/es/docs/Web/CSS/grid">grid</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid">grid</a></li>
    <li><a href="/es/docs/Web/CSS/grid-area">grid-area</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-auto-columns">grid-auto-columns</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-auto-columns">grid-auto-columns</a></li>
    <li><a href="/es/docs/Web/CSS/grid-auto-flow">grid-auto-flow</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-auto-rows">grid-auto-rows</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-auto-rows">grid-auto-rows</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column">grid-column</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column-end">grid-column-end</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-column-gap">grid-column-gap</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/column-gap">grid-column-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column-start">grid-column-start</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-gap">grid-gap</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/gap">grid-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row">grid-row</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-end">grid-row-end</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-gap">grid-row-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-start">grid-row-start</a></li>
    <li><a href="/es/docs/Web/CSS/grid-template">grid-template</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-areas">grid-template-areas</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-columns">grid-template-columns</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-rows">grid-template-rows</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-areas">grid-template-areas</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-columns">grid-template-columns</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-rows">grid-template-rows</a></li>
   </ol>
  </li>
  <li data-default-state="open"><a href="#"><strong>Glossary</strong></a>
   <ol>
    <li><a href="/es/docs/Glossary/Grid">Rejilla</a></li>
-   <li><a href="/es/docs/Glossary/Grid_lines">Líneas de rejilla</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Lines">Líneas de rejilla</a></li>
    <li><a href="/es/docs/Glossary/Grid_tracks">Pistas de rejilla</a></li>
    <li><a href="/es/docs/Glossary/Grid_cell">Celda de rejilla</a></li>
-   <li><a href="/es/docs/Glossary/Grid_areas">Áreas de rejilla</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Areas">Áreas de rejilla</a></li>
    <li><a href="/es/docs/Glossary/Gutters">Canaletas</a></li>
    <li><a href="/es/docs/Glossary/Grid_Axis">Ejes de rejilla</a></li>
-   <li><a href="/es/docs/Glossary/Grid_rows">Fila de rejilla</a></li>
-   <li><a href="/es/docs/Glossary/Grid_column">Columna de rejilla</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Row">Fila de rejilla</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Column">Columna de rejilla</a></li>
   </ol>
  </li>
 </ol>

--- a/files/es/web/css/reference/properties/column-gap/index.md
+++ b/files/es/web/css/reference/properties/column-gap/index.md
@@ -84,53 +84,53 @@ CSS
 <ol>
  <li><a href="/es/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><strong> <a href="/es/docs/Web/CSS/Reference">Referencia CSS</a></strong></li>
- <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout">Diseño CSS Grid</a></li>
+ <li><a href="/es/docs/Web/CSS/Guides/Grid_layout">Diseño CSS Grid</a></li>
  <li data-default-state="open"><a href="#"><strong>Guías</strong></a>
   <ol>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Conceptos básicos sobre Diseño CSS Grid </a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout">Relación con otros métodos de diseño</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Basic_concepts">Conceptos básicos sobre Diseño CSS Grid </a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Relationship_with_other_layout_methods">Relación con otros métodos de diseño</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid">Posicionamiento basado en línea</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">Grid template areas</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">Layout using named grid lines</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout">Auto-placement in grid layout</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Box alignment in grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Auto-placement">Auto-placement in grid layout</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Box_alignment">Box alignment in grid layout</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid,_Logical_Values_and_Writing_Modes">Grids, logical values and writing modes</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility">CSS Grid Layout and Accessibility</a></li>
    <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement">CSS Grid Layout and Progressive Enhancement</a></li>
-   <li><a href="/es/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout">Realizing common layouts using grids</a></li>
+   <li><a href="/es/docs/Web/CSS/Guides/Grid_layout/Common_grid_layouts">Realizing common layouts using grids</a></li>
   </ol>
  </li>
  <li data-default-state="open"><a href="#"><strong>Propiedades</strong></a>
   <ol>
-   <li><a href="/es/docs/Web/CSS/grid">grid</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid">grid</a></li>
    <li><a href="/es/docs/Web/CSS/grid-area">grid-area</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-auto-columns">grid-auto-columns</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-auto-columns">grid-auto-columns</a></li>
    <li><a href="/es/docs/Web/CSS/grid-auto-flow">grid-auto-flow</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-auto-rows">grid-auto-rows</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-auto-rows">grid-auto-rows</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column">grid-column</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column-end">grid-column-end</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-column-gap">grid-column-gap</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/column-gap">grid-column-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-column-start">grid-column-start</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-gap">grid-gap</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/gap">grid-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row">grid-row</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-end">grid-row-end</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-gap">grid-row-gap</a></li>
    <li><a href="/es/docs/Web/CSS/grid-row-start">grid-row-start</a></li>
    <li><a href="/es/docs/Web/CSS/grid-template">grid-template</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-areas">grid-template-areas</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-columns">grid-template-colunms</a></li>
-   <li><a href="/es/docs/Web/CSS/grid-template-rows">grid-template-rows</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-areas">grid-template-areas</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-columns">grid-template-colunms</a></li>
+   <li><a href="/es/docs/Web/CSS/Reference/Properties/grid-template-rows">grid-template-rows</a></li>
   </ol>
  </li>
  <li data-default-state="open"><a href="#"><strong>Glosario</strong></a>
   <ol>
-   <li><a href="/es/docs/Glossary/Grid_lines">Grid lines</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Lines">Grid lines</a></li>
    <li><a href="/es/docs/Glossary/Grid_tracks">Grid tracks</a></li>
    <li><a href="/es/docs/Glossary/Grid_cell">Grid cell</a></li>
-   <li><a href="/es/docs/Glossary/Grid_areas">Grid areas</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Areas">Grid areas</a></li>
    <li><a href="/es/docs/Glossary/Gutters">Gutters</a></li>
-   <li><a href="/es/docs/Glossary/Grid_rows">Grid row</a></li>
-   <li><a href="/es/docs/Glossary/Grid_column">Grid column</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Row">Grid row</a></li>
+   <li><a href="/es/docs/Glossary/Grid_Column">Grid column</a></li>
   </ol>
  </li>
 </ol>

--- a/files/es/web/html/guides/responsive_images/index.md
+++ b/files/es/web/html/guides/responsive_images/index.md
@@ -16,9 +16,9 @@ Las imágenes adaptables son solo una parte del diseño web responsivo, un tema 
       <th scope="row">Prerrequisitos:</th>
       <td>
         Deberías tener un conocimiento
-        <a href="/es/docs/Learn/HTML/Introduction_to_HTML">básico de HTML</a>
+        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">básico de HTML</a>
         y cómo
-        <a href="/es/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content/HTML_images"
           >agregar imágenes estáticas a un sitio web</a
         >.
       </td>
@@ -29,7 +29,7 @@ Las imágenes adaptables son solo una parte del diseño web responsivo, un tema 
       </th>
       <td>
         Aprende a usar características como
-        <a href="/es/docs/Web/HTML/Element/img#srcset"><code>srcset</code></a> y el elemento
+        <a href="/es/docs/Web/HTML/Reference/Elements/img#srcset"><code>srcset</code></a> y el elemento
         {{htmlelement("picture")}} para implementar soluciones de
         imágenes adaptables a sitios web.
       </td>

--- a/files/es/web/html/reference/attributes/index.md
+++ b/files/es/web/html/reference/attributes/index.md
@@ -31,7 +31,7 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>accesskey</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_Globales" title="/es/docs/Web/HTML/Atributos_Globales">Atributos Globales</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos_Globales">Atributos Globales</a></td>
       <td>Define una tecla que activa o agrega un foco al elemento.</td>
      </tr>
      <tr>
@@ -116,7 +116,7 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>class</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Usualmente empleado con CSS para aplicar estilos a elementos con propiedades en comun.</td>
      </tr>
      <tr>
@@ -146,12 +146,12 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>contenteditable</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Indica si el contenido del elemento es editable.</td>
      </tr>
      <tr>
       <td><code>contextmenu</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Define el ID del elemento {{ HTMLElement("menu") }} que servira como menú de contexto para otro elemento.</td>
      </tr>
      <tr>
@@ -171,7 +171,7 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>data-*</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Permite asociar atributos presonalizados a un elemento HTML.</td>
      </tr>
      <tr>
@@ -191,7 +191,7 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>dir</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Define la dirección del texto. Los valores permitidos son ltr (Izquierda-a-Derecha) o rtl (Derecha-a-Izquierda).</td>
      </tr>
      <tr>
@@ -211,12 +211,12 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>draggable</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Define si el elemento puede ser arrastrado.</td>
      </tr>
      <tr>
       <td><code>dropzone</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Indica que el elemento acepta contenido soltado en el mismo.</td>
      </tr>
      <tr>
@@ -256,7 +256,7 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>hidden</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Evita la prestación del elemento dado, manteniendo los elementos secundarios, p.ej. los elementos de script</td>
      </tr>
      <tr>
@@ -291,7 +291,7 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>id</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Identificador el elemento para acceder al mismo desde CSS o Javascript, este indicador debe ser unico para cada elemento.</td>
      </tr>
      <tr>
@@ -301,7 +301,7 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>itemprop</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Indica que el elemento contiene el valor de la propiedad especificada de un conjunto.</td>
      </tr>
      <tr>
@@ -316,7 +316,7 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>lang</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Define el lenguaje utilizado en el elemento.</td>
      </tr>
      <tr>
@@ -516,7 +516,7 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>spellcheck</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Indica si se permite la corrección ortográfica para el elemento.</td>
      </tr>
      <tr>
@@ -551,7 +551,7 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>style</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Define los estilos CSS que anulan los estilos establecidos previamente.</td>
      </tr>
      <tr>
@@ -564,7 +564,7 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>tabindex</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Sobrescribe el orden de tabulacion del navegador y usa el especificado.</td>
      </tr>
      <tr>
@@ -577,7 +577,7 @@ Los elementos en HTML tienen **atributos**; estos son valores adicionales que co
      </tr>
      <tr>
       <td><code>title</code></td>
-      <td><a href="/es/docs/Web/HTML/Atributos_globales" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Global_attributes" title="/es/docs/Web/HTML/Atributos globales">Atributo Global</a></td>
       <td>Texto a ser mostrado cuando el cursor esté sobre el elemento.</td>
      </tr>
      <tr>

--- a/files/es/web/html/reference/attributes/rel/index.md
+++ b/files/es/web/html/reference/attributes/rel/index.md
@@ -23,13 +23,13 @@ En HTML, los siguientes tipos de enlaces indican la relación entre dos document
       <td><code>alternate</code></td>
       <td>
        <ul>
-        <li>Si el elemento es {{HTMLElement("link")}} y el atributo <a href="/es/docs/Web/HTML/Element/link#rel"><code>rel</code></a> tambien contiene el tipo <code>stylesheet</code>, el enlace define una <a href="/es/docs/Alternative_style_sheets">hoja de estilo alternativa</a>; en ese caso el atributo <a href="/es/docs/Web/HTML/Element/link#title"><code>title</code></a> deberá estar presente y no ser una cadena vacia.</li>
-        <li>Si el atributo <a href="/es/docs/Web/HTML/Element/link#type"><code>type</code></a> es puesto a <code>application/rss+xml</code> o <code>application/atom+xml</code>, el enlace define un <a href="/es/docs/RSS/Getting_Started/Syndicating">feed de distribución</a>. El primero de ellos definido en la pagina es el tomado por default.</li>
+        <li>Si el elemento es {{HTMLElement("link")}} y el atributo <a href="/es/docs/Web/HTML/Reference/Elements/link#rel"><code>rel</code></a> tambien contiene el tipo <code>stylesheet</code>, el enlace define una <a href="/es/docs/Alternative_style_sheets">hoja de estilo alternativa</a>; en ese caso el atributo <a href="/es/docs/Web/HTML/Reference/Elements/link#title"><code>title</code></a> deberá estar presente y no ser una cadena vacia.</li>
+        <li>Si el atributo <a href="/es/docs/Web/HTML/Reference/Elements/link#type"><code>type</code></a> es puesto a <code>application/rss+xml</code> o <code>application/atom+xml</code>, el enlace define un <a href="/es/docs/RSS/Getting_Started/Syndicating">feed de distribución</a>. El primero de ellos definido en la pagina es el tomado por default.</li>
         <li>De otra forma, el enlace define una pagina alternativa, de uno de los siguientes tipos:
          <ul>
-          <li>para otros medios, como un dispositivo portatil (si el atributo <a href="/es/docs/Web/HTML/Element/link#media"><code>media</code></a> esta indicado)</li>
-          <li>en otro lenguaje (si el atributo <a href="/es/docs/Web/HTML/Element/link#hreflang"><code>hreflang</code></a> esta indicado),</li>
-          <li>en otro formato, como un PDF (si el atributo <a href="/es/docs/Web/HTML/Element/link#type"><code>type</code></a> esta indicado)</li>
+          <li>para otros medios, como un dispositivo portatil (si el atributo <a href="/es/docs/Web/HTML/Reference/Elements/link#media"><code>media</code></a> esta indicado)</li>
+          <li>en otro lenguaje (si el atributo <a href="/es/docs/Web/HTML/Reference/Elements/link#hreflang"><code>hreflang</code></a> esta indicado),</li>
+          <li>en otro formato, como un PDF (si el atributo <a href="/es/docs/Web/HTML/Reference/Elements/link#type"><code>type</code></a> esta indicado)</li>
           <li>una combinacion de los anteriores.</li>
          </ul>
         </li>
@@ -52,7 +52,7 @@ En HTML, los siguientes tipos de enlaces indican la relación entre dos document
        <br>
        <strong>Nota:</strong> Este puede ser un hipervinculo <code>mailto:</code>, pero esto no es recomendable en paginas públicas por que robots cosechadores podrian rápidamente llevar una gran cantidad de span a esa dirección. En ese caso, es mejor mandarlos a una página con un formulario de contacto.<br>
        <br>
-       Aunque reconocido, el atributo <a href="/es/docs/Web/HTML/Element/link#rev"><code>rev</code></a> en elementos {{HTMLElement("a")}}, {{HTMLElement("area")}} o {{HTMLElement("link")}} con un enlace de tipo <code>made</code> es incorrecto y debiera ser reemplazado por el atributo <a href="/es/docs/Web/HTML/Element/link#rel"><code>rel</code></a> con este tipo de enlace.</td>
+       Aunque reconocido, el atributo <a href="/es/docs/Web/HTML/Reference/Elements/link#rev"><code>rev</code></a> en elementos {{HTMLElement("a")}}, {{HTMLElement("area")}} o {{HTMLElement("link")}} con un enlace de tipo <code>made</code> es incorrecto y debiera ser reemplazado por el atributo <a href="/es/docs/Web/HTML/Reference/Elements/link#rel"><code>rel</code></a> con este tipo de enlace.</td>
       <td>{{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("link")}}</td>
       <td><em>None.</em></td>
      </tr>
@@ -96,9 +96,9 @@ En HTML, los siguientes tipos de enlaces indican la relación entre dos document
       <td><code>icon</code></td>
       <td>Defines a resource for representing the page in the user interface, usually an icon (auditory or visual).<br>
        <br>
-       The <a href="/es/docs/Web/HTML/Element/link#media"><code>media</code></a>, <a href="/es/docs/Web/HTML/Element/link#type"><code>type</code></a> and <a href="/es/docs/Web/HTML/Element/link#sizes"><code>sizes</code></a> attributes allow the browser to select the most appropriate icon for its context. If several resources match, the browser will select the last one declared, in tree order. As these attributes are merely hints, and the resources may be inappropriate upon further inspection, the browser will then select another one, if appropriate.<br>
+       The <a href="/es/docs/Web/HTML/Reference/Elements/link#media"><code>media</code></a>, <a href="/es/docs/Web/HTML/Reference/Elements/link#type"><code>type</code></a> and <a href="/es/docs/Web/HTML/Reference/Elements/link#sizes"><code>sizes</code></a> attributes allow the browser to select the most appropriate icon for its context. If several resources match, the browser will select the last one declared, in tree order. As these attributes are merely hints, and the resources may be inappropriate upon further inspection, the browser will then select another one, if appropriate.<br>
        <br>
-       <strong>Note:</strong> Apple's iOS does not use this link type, nor the <a href="/es/docs/Web/HTML/Element/link#sizes"><code>sizes</code></a> attribute, like others mobile browsers do, to select a webpage icon for Web Clip or a start-up placeholder. Instead it uses the non-standard <a href="http://edr.euro.apple.com/library/safari/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW4"><code>apple-touch-icon</code></a> and <a href="http://edr.euro.apple.com/library/safari/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW6"><code>apple-touch-startup-image</code></a> respectively.<br>
+       <strong>Note:</strong> Apple's iOS does not use this link type, nor the <a href="/es/docs/Web/HTML/Reference/Elements/link#sizes"><code>sizes</code></a> attribute, like others mobile browsers do, to select a webpage icon for Web Clip or a start-up placeholder. Instead it uses the non-standard <a href="http://edr.euro.apple.com/library/safari/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW4"><code>apple-touch-icon</code></a> and <a href="http://edr.euro.apple.com/library/safari/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW6"><code>apple-touch-startup-image</code></a> respectively.<br>
        <br>
        The <code>shortcut</code> link type is often seen before <code>icon</code>, but this link type is non-conforming, ignored and <strong>web authors must not use it anymore</strong>.</td>
       <td>{{HTMLElement("link")}}</td>
@@ -203,7 +203,7 @@ En HTML, los siguientes tipos de enlaces indican la relación entre dos document
       <td><code>search</code></td>
       <td>Indicates that the hyperlink reference a document whose interface is specially designing for searching in this document, or site, and its resources.<br>
        <br>
-       If the <a href="/es/docs/Web/HTML/Element/link#type"><code>type</code></a> attribute is set to <code>application/opensearchdescription+xml </code>the resource is an <a href="/es/docs/Creating_OpenSearch_plugins_for_Firefox">OpenSearch plugin</a> that can be easily added to the interface of some browsers like Firefox or Internet Explorer.</td>
+       If the <a href="/es/docs/Web/HTML/Reference/Elements/link#type"><code>type</code></a> attribute is set to <code>application/opensearchdescription+xml </code>the resource is an <a href="/es/docs/Creating_OpenSearch_plugins_for_Firefox">OpenSearch plugin</a> that can be easily added to the interface of some browsers like Firefox or Internet Explorer.</td>
       <td>{{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("link")}}</td>
       <td><em>None.</em></td>
      </tr>
@@ -211,7 +211,7 @@ En HTML, los siguientes tipos de enlaces indican la relación entre dos document
       <td><code>stylesheet</code></td>
       <td>Defines an external resource to be used as a stylesheet. If the <code>type</code> is not set, the browser should assume it is a <code>text/css</code> stylesheet until further inspection.<br>
        <br>
-       If used in combination with the <code>alternate</code> keyword, it defines an <a href="/es/docs/Alternative_style_sheets">alternative style sheet</a>; in that case the <a href="/es/docs/Web/HTML/Element/link#title"><code>title</code></a> attribute must be present and not be the empty string.</td>
+       If used in combination with the <code>alternate</code> keyword, it defines an <a href="/es/docs/Alternative_style_sheets">alternative style sheet</a>; in that case the <a href="/es/docs/Web/HTML/Reference/Elements/link#title"><code>title</code></a> attribute must be present and not be the empty string.</td>
       <td>{{HTMLElement("link")}}</td>
       <td>{{HTMLElement("a")}}, {{HTMLElement("area")}}</td>
      </tr>

--- a/files/es/web/html/reference/elements/area/index.md
+++ b/files/es/web/html/reference/elements/area/index.md
@@ -150,11 +150,11 @@ Los atributos de este elemento incluyen los [atributos globales](/es/docs/Web/HT
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/HTML/Content_categories">Categorias de Contenido</a>
+        <a href="/es/docs/Web/HTML/Guides/Content_categories">Categorias de Contenido</a>
       </th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#flow_content">Contenido de flujo</a>,
-        <a href="/es/docs/Web/HTML/Content_categories#phrasing_content">contenido de redacción</a>.
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#flow_content">Contenido de flujo</a>,
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#phrasing_content">contenido de redacción</a>.
       </td>
     </tr>
     <tr>
@@ -168,13 +168,13 @@ Los atributos de este elemento incluyen los [atributos globales](/es/docs/Web/HT
     <tr>
       <th scope="row">Elementos padre permitidos</th>
       <td>
-        Cualquier elemento que acepte <a href="/es/docs/Web/HTML/Content_categories#phrasing_content">contenido redactable</a>. El elemento <code>&#x3C;area></code> debe tener como ancestro un elemento {{HTMLElement("map")}}, pero no es necesario que este sea el padre directo.
+        Cualquier elemento que acepte <a href="/es/docs/Web/HTML/Guides/Content_categories#phrasing_content">contenido redactable</a>. El elemento <code>&#x3C;area></code> debe tener como ancestro un elemento {{HTMLElement("map")}}, pero no es necesario que este sea el padre directo.
       </td>
     </tr>
     <tr>
       <th scope="row">Rol ARIA implícito</th>
       <td>
-        <a href="/es/docs/Web/Accessibility/ARIA/Roles/link_role"><code>link</code></a> cuando el atributo <a href="/es/docs/Web/HTML/Element/area#href"><code>href</code></a> esta presente, si no lo esta es
+        <a href="/es/docs/Web/Accessibility/ARIA/Roles/link_role"><code>link</code></a> cuando el atributo <a href="/es/docs/Web/HTML/Reference/Elements/area#href"><code>href</code></a> esta presente, si no lo esta es
         <a href="/es/docs/Web/Accessibility/ARIA/Roles/generic_role"><code>generic</code></a>
       </td>
     </tr>

--- a/files/es/web/html/reference/elements/article/index.md
+++ b/files/es/web/html/reference/elements/article/index.md
@@ -63,19 +63,19 @@ Un mismo documento puede tener varios artículos; por ejemplo, en un blog en el 
     <tr>
       <th scope="row">
         <dfn
-          ><a href="/es/docs/Web/Guide/HTML/Content_categories"
+          ><a href="/es/docs/Web/HTML/Guides/Content_categories"
             >Categorías de contenido</a
           ></dfn
         >
       </th>
       <td>
-        <a href="/es/docs/Web/Guide/HTML/Content_categories#flujo_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#flujo_de_contenido"
           >Contenido de flujo</a
         >,
-        <a href="/es/docs/Web/Guide/HTML/Content_categories#contenido_de_sección"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#contenido_de_sección"
           >contenido de sección</a
         >,
-        <a href="/es/docs/Web/Guide/HTML/Content_categories#contenido_palpable"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#contenido_palpable"
           >contenido palpable</a
         >.
       </td>
@@ -83,7 +83,7 @@ Un mismo documento puede tener varios artículos; por ejemplo, en un blog en el 
     <tr>
       <th scope="row">Contenido permitido</th>
       <td>
-        <a href="/es/docs/Web/Guide/HTML/Content_categories#flujo_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#flujo_de_contenido"
           >Contenido de flujo</a
         >.
       </td>
@@ -98,11 +98,11 @@ Un mismo documento puede tener varios artículos; por ejemplo, en un blog en el 
       <th scope="row">Padres permitidos</th>
       <td>
         Todo elemento que permita
-        <a href="/es/docs/Web/Guide/HTML/Content_categories#flujo_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#flujo_de_contenido"
           >contenido de flujo</a
         >. Un elemento <code>&#x3C;article></code> no puede ser hijo de
         un elemento
-        <a href="/es/docs/Web/HTML/Element/address"
+        <a href="/es/docs/Web/HTML/Reference/Elements/address"
           ><code>&#x3C;address></code></a
         >.
       </td>

--- a/files/es/web/html/reference/elements/base/index.md
+++ b/files/es/web/html/reference/elements/base/index.md
@@ -20,7 +20,7 @@ La dirección URL base de un documento puede ser consultado a partir de una secu
     <tr>
       <th>
         <a
-          href="https://developer.mozilla.org/es/docs/Web/Guide/HTML/categorias_de_contenido"
+          href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de Contenido</a
         >
       </th>

--- a/files/es/web/html/reference/elements/body/index.md
+++ b/files/es/web/html/reference/elements/body/index.md
@@ -12,7 +12,7 @@ El **elemento `<body>` de HTML** representa el contenido de un documento HTML. S
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/HTML/Content_categories"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>
@@ -26,7 +26,7 @@ El **elemento `<body>` de HTML** representa el contenido de un documento HTML. S
     <tr>
       <th scope="row">Contenido permitido</th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Flow_content"
           >Flujo de contenido</a
         >.
       </td>

--- a/files/es/web/html/reference/elements/button/index.md
+++ b/files/es/web/html/reference/elements/button/index.md
@@ -264,7 +264,7 @@ Es el elemento crea botones marcadores.
       </td>
       <td>
         Define una tecla de acceso rápido. Importante para la
-        <a href="/es/docs/Accesibilidad" title="Accesibilidad">Accesibilidad</a
+        <a href="/es/docs/Web/Accessibility" title="Accesibilidad">Accesibilidad</a
         >.
       </td>
       <td>

--- a/files/es/web/html/reference/elements/dd/index.md
+++ b/files/es/web/html/reference/elements/dd/index.md
@@ -45,7 +45,7 @@ dd {
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/Guide/HTML/categorias_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>
@@ -55,7 +55,7 @@ dd {
       <th scope="row">Contenido permitido</th>
       <td>
         <a
-          href="/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_dinámico"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Contenido_dinámico"
           >Contenido de flujo</a
         >
       </td>

--- a/files/es/web/html/reference/elements/details/index.md
+++ b/files/es/web/html/reference/elements/details/index.md
@@ -14,12 +14,12 @@ El elemento HTML Details **\<details>** es usado como un widget de revelación a
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/Guide/HTML/categorias_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>
       <td>
-        <a href="/es/docs/Web/Guide/HTML/categorias_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Contenido dinámico</a
         >
         , contenido de seccionamiento, contenido interactivo, contenido palpable
@@ -30,7 +30,7 @@ El elemento HTML Details **\<details>** es usado como un widget de revelación a
       <th scope="row">Contenido permitido</th>
       <td>
         Un elemento {{HTMLElement("summary")}} seguido de
-        <a href="/es/docs/Web/Guide/HTML/categorias_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >contenido dinámico</a
         >
       </td>
@@ -43,7 +43,7 @@ El elemento HTML Details **\<details>** es usado como un widget de revelación a
       <th scope="row">Elementos padres permitidos</th>
       <td>
         Cualquier elemento que acepte
-        <a href="/es/docs/Web/Guide/HTML/categorias_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >contenido dinámico</a
         >.
       </td>

--- a/files/es/web/html/reference/elements/dialog/index.md
+++ b/files/es/web/html/reference/elements/dialog/index.md
@@ -12,10 +12,10 @@ El **elemento** **HTML `<dialog>`** representa una caja de diálogo u otro compo
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/HTML/Content_categories">Content categories</a>
+        <a href="/es/docs/Web/HTML/Guides/Content_categories">Content categories</a>
       </th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Flow_content"
           >Flow content</a
         >,
         <a
@@ -27,7 +27,7 @@ El **elemento** **HTML `<dialog>`** representa una caja de diálogo u otro compo
     <tr>
       <th scope="row">Permitted content</th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Flow_content"
           >Flow content</a
         >
       </td>
@@ -40,7 +40,7 @@ El **elemento** **HTML `<dialog>`** representa una caja de diálogo u otro compo
       <th scope="row">Permitted parent elements</th>
       <td>
         Any element that accepts
-        <a href="/es/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Flow_content"
           >flow content</a
         >
       </td>

--- a/files/es/web/html/reference/elements/div/index.md
+++ b/files/es/web/html/reference/elements/div/index.md
@@ -110,20 +110,20 @@ Este ejemplo crea un cuadro sombreado aplicando un estilo al `<div>` usando CSS.
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/HTML/Content_categories"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#flujo_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#flujo_de_contenido"
           >Flujo de contenido</a
-        >, <a href="/es/docs/Web/HTML/Content_categories#contenido_palpable">contenido palpable</a>.
+        >, <a href="/es/docs/Web/HTML/Guides/Content_categories#contenido_palpable">contenido palpable</a>.
       </td>
     </tr>
     <tr>
       <th scope="row">Contenido permitido</th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#flujo_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#flujo_de_contenido"
           >Flujo de contenido</a
         >.<br />O (en {{glossary("WHATWG")}} HTML): Si el padre es un
         elemento {{HTMLElement("dl")}}: uno o más
@@ -140,7 +140,7 @@ Este ejemplo crea un cuadro sombreado aplicando un estilo al `<div>` usando CSS.
       <th scope="row">Padres permitidos</th>
       <td>
         Cualquier elemento que acepte
-        <a href="/es/docs/Web/HTML/Content_categories#flujo_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#flujo_de_contenido"
           >flujo de contenido</a
         >.<br />O (en {{glossary("WHATWG")}} HTML):
         Elemento {{HTMLElement("dl")}}.

--- a/files/es/web/html/reference/elements/dl/index.md
+++ b/files/es/web/html/reference/elements/dl/index.md
@@ -45,13 +45,13 @@ dd {
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/Guide/HTML/categorias_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>
       <td>
         <a
-          href="/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_dinámico"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Contenido_dinámico"
           >Contenido de flujo</a
         >, y si los elementos hijos de <code>&#x3C;dl></code> incluyen un grupo
         nombre-valor, contenido palpable.
@@ -81,7 +81,7 @@ dd {
       <td>
         Cualquier elemento que acepte
         <a
-          href="/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_dinámico"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Contenido_dinámico"
           >contenido de flujo</a
         >.
       </td>

--- a/files/es/web/html/reference/elements/dt/index.md
+++ b/files/es/web/html/reference/elements/dt/index.md
@@ -47,7 +47,7 @@ dd {
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/Guide/HTML/categorias_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>
@@ -57,7 +57,7 @@ dd {
       <th scope="row">Contenido permitido</th>
       <td>
         <a
-          href="/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_dinámico"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Contenido_dinámico"
           >Contenido de flujo</a
         >, pero sin {{HTMLElement("header")}},
         {{HTMLElement("footer")}}, contenido seccionado o encabezados

--- a/files/es/web/html/reference/elements/iframe/index.md
+++ b/files/es/web/html/reference/elements/iframe/index.md
@@ -36,21 +36,21 @@ Cada elemento `<iframe>` tiene su propio [historial de sesión](/es/docs/Web/API
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/Guide/HTML/categorias_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenidos</a
         >
       </th>
       <td>
         <a
-          href="/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_dinámico"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Contenido_dinámico"
           >Contenido dinámico</a
         >,
         <a
-          href="/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_textual_o_estático"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Contenido_textual_o_estático"
           >contenido textual o estático</a
         >, contenido incrustado, contenido interactivo,
         <a
-          href="/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_tangible"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Contenido_tangible"
           >contenido tangible</a
         >.
       </td>

--- a/files/es/web/html/reference/elements/img/index.md
+++ b/files/es/web/html/reference/elements/img/index.md
@@ -30,7 +30,7 @@ El elemento de imagen HTML **`<img>`** representa una imagen en el documento.
           >contenido estático</a
         >,
         <a
-          href="/es/docs/Web/Guide/HTML/Content_categories#Embedded_content"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Embedded_content"
           >contenido incrustado</a
         >, contenido palpable. Si el elemento tiene un atributo
         <code>usemap</code>, it also is a part of the

--- a/files/es/web/html/reference/elements/input/date/index.md
+++ b/files/es/web/html/reference/elements/input/date/index.md
@@ -59,10 +59,10 @@ La IU de la entrada generalmente varía entre navegadores; véase [Compatibiidad
     <tr>
       <td><strong>Atributos comunes soportados</strong></td>
       <td>
-        <a href="/es/docs/Web/HTML/Element/input#autocomplete"><code>autocomplete</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#list"><code>list</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#readonly"><code>readonly</code></a> y
-        <a href="/es/docs/Web/HTML/Element/input#step"><code>step</code></a>
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#autocomplete"><code>autocomplete</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#list"><code>list</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#readonly"><code>readonly</code></a> y
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#step"><code>step</code></a>
       </td>
     </tr>
     <tr>

--- a/files/es/web/html/reference/elements/input/email/index.md
+++ b/files/es/web/html/reference/elements/input/email/index.md
@@ -53,17 +53,17 @@ En los navegadores que no sopartan el tipo `email`, la entrada `email` se degrad
     <tr>
       <td><strong>Atributos comunes soprtados</strong></td>
       <td>
-        <a href="/es/docs/Web/HTML/Element/input#autocomplete"><code>autocomplete</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#list"><code>list</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#maxlength"><code>maxlength</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#minlength"><code>minlength</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#multiple"><code>multiple</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#name"><code>name</code></a>, <a href="/es/docs/Web/HTML/Element/input#pattern"><code>pattern</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#placeholder"><code>placeholder</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#readonly"><code>readonly</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#required"><code>required</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#size"><code>size</code></a> y
-        <a href="/es/docs/Web/HTML/Element/input#type"><code>type</code></a>
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#autocomplete"><code>autocomplete</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#list"><code>list</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#maxlength"><code>maxlength</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#minlength"><code>minlength</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#multiple"><code>multiple</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#name"><code>name</code></a>, <a href="/es/docs/Web/HTML/Reference/Elements/input#pattern"><code>pattern</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#placeholder"><code>placeholder</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#readonly"><code>readonly</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#required"><code>required</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#size"><code>size</code></a> y
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#type"><code>type</code></a>
       </td>
     </tr>
     <tr>

--- a/files/es/web/html/reference/elements/input/file/index.md
+++ b/files/es/web/html/reference/elements/input/file/index.md
@@ -461,7 +461,7 @@ El ejemplo se ve así; juegue:
     </tr>
     <tr>
       <td><strong>Atributos comunes soportados</strong></td>
-      <td><a href="/es/docs/Web/HTML/Element/input#required"><code>required</code></a></td>
+      <td><a href="/es/docs/Web/HTML/Reference/Elements/input#required"><code>required</code></a></td>
     </tr>
     <tr>
       <td><strong>Atributos adicionales</strong></td>

--- a/files/es/web/html/reference/elements/input/index.md
+++ b/files/es/web/html/reference/elements/input/index.md
@@ -14,19 +14,19 @@ El elemento HTML `<input>` se usa para crear controles interactivos para formula
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/Guide/HTML/categorias_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>
       <td>
         <a
-          href="/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_dinámico"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Contenido_dinámico"
           >Contenido dinámico</a
         >, enlistado, presentable, reajustable, elemento asociado a formulario,
         <a
-          href="/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_textual_o_estático"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Contenido_textual_o_estático"
           >contenido textual</a
-        >. Si su atributo <a href="/es/docs/Web/HTML/Element/input#type"><code>type</code></a> no es
+        >. Si su atributo <a href="/es/docs/Web/HTML/Reference/Elements/input#type"><code>type</code></a> no es
         <code>hidden</code>, entonces contenido etiquetable, contenido palpable.
       </td>
     </tr>
@@ -48,7 +48,7 @@ El elemento HTML `<input>` se usa para crear controles interactivos para formula
       <td>
         Cualquier elemento que acepte
         <a
-          href="/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_textual_o_estático"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Contenido_textual_o_estático"
           >contenido textual</a
         >.
       </td>

--- a/files/es/web/html/reference/elements/input/number/index.md
+++ b/files/es/web/html/reference/elements/input/number/index.md
@@ -46,7 +46,7 @@ En navegadores que no soportan entradas de tipo `number`, una entrada `number` r
   </tr>
   <tr>
    <td><strong>Atributos comunes que soporta</strong></td>
-   <td><a href="/es/docs/Web/HTML/Element/input#autocomplete"><code>autocomplete</code></a>, <a href="/es/docs/Web/HTML/Element/input#list"><code>list</code></a>, <a href="/es/docs/Web/HTML/Element/input#placeholder"><code>placeholder</code></a>, <a href="/es/docs/Web/HTML/Element/input#readonly"><code>readonly</code></a></td>
+   <td><a href="/es/docs/Web/HTML/Reference/Elements/input#autocomplete"><code>autocomplete</code></a>, <a href="/es/docs/Web/HTML/Reference/Elements/input#list"><code>list</code></a>, <a href="/es/docs/Web/HTML/Reference/Elements/input#placeholder"><code>placeholder</code></a>, <a href="/es/docs/Web/HTML/Reference/Elements/input#readonly"><code>readonly</code></a></td>
   </tr>
   <tr>
    <td><strong>Atributos IDL</strong></td>

--- a/files/es/web/html/reference/elements/input/range/index.md
+++ b/files/es/web/html/reference/elements/input/range/index.md
@@ -38,11 +38,11 @@ Si el navegador del usuario no soporta el tipo `"range"`, será tratado como un 
     <tr>
       <td><strong>Atributos comunes soportados</strong></td>
       <td>
-        <a href="/es/docs/Web/HTML/Element/input#autocomplete"><code>autocomplete</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#list"><code>list</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#max"><code>max</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#min"><code>min</code></a> y
-        <a href="/es/docs/Web/HTML/Element/input#step"><code>step</code></a>
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#autocomplete"><code>autocomplete</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#list"><code>list</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#max"><code>max</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#min"><code>min</code></a> y
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#step"><code>step</code></a>
       </td>
     </tr>
     <tr>

--- a/files/es/web/html/reference/elements/input/text/index.md
+++ b/files/es/web/html/reference/elements/input/text/index.md
@@ -55,21 +55,21 @@ label {
     <tr>
       <td><strong>Atributos comunes admitidos</strong></td>
       <td>
-        <a href="/es/docs/Web/HTML/Element/input#autocomplete"><code>autocomplete</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#list"><code>list</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#maxlength"><code>maxlength</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#minlength"><code>minlength</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#pattern"><code>pattern</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#placeholder"><code>placeholder</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#readonly"><code>readonly</code></a>,
-        <a href="/es/docs/Web/HTML/Element/input#required"><code>required</code></a> y
-        <a href="/es/docs/Web/HTML/Element/input#size"><code>size</code></a>
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#autocomplete"><code>autocomplete</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#list"><code>list</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#maxlength"><code>maxlength</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#minlength"><code>minlength</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#pattern"><code>pattern</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#placeholder"><code>placeholder</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#readonly"><code>readonly</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#required"><code>required</code></a> y
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#size"><code>size</code></a>
       </td>
     </tr>
     <tr>
       <td><strong>IDL attributes</strong></td>
       <td>
-        <a href="/es/docs/Web/HTML/Element/input#list"><code>list</code></a>,
+        <a href="/es/docs/Web/HTML/Reference/Elements/input#list"><code>list</code></a>,
         <code>value</code>
       </td>
     </tr>

--- a/files/es/web/html/reference/elements/menu/index.md
+++ b/files/es/web/html/reference/elements/menu/index.md
@@ -105,18 +105,18 @@ button {
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/HTML/Content_categories"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>
       <td>
         <p>
-          <a href="/es/docs/Web/HTML/Content_categories#flow_content"
+          <a href="/es/docs/Web/HTML/Guides/Content_categories#flow_content"
             >Contenido de flujo</a
           >. Si los hijos del elemento incluyen al menos un
            elemento {{HTMLElement("li")}}:
           <a
-            href="/es/docs/Web/HTML/Content_categories#palpable_content"
+            href="/es/docs/Web/HTML/Guides/Content_categories#palpable_content"
             >contenido palpable</a
           >.
         </p>
@@ -140,7 +140,7 @@ button {
       <th scope="row">Padres permitidos</th>
       <td>
         Cualquier elemento que acepte
-        <a href="/es/docs/Web/HTML/Content_categories#flow_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#flow_content"
           >contenido de flujo</a
         >.
       </td>

--- a/files/es/web/html/reference/elements/object/index.md
+++ b/files/es/web/html/reference/elements/object/index.md
@@ -22,29 +22,29 @@ El **elemento HTML `<object>`** representa un recurso externo, que puede ser tra
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/HTML/Content_categories">Content categories</a>
+        <a href="/es/docs/Web/HTML/Guides/Content_categories">Content categories</a>
       </th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Flow_content"
           >Flow content</a
         >;
-        <a href="/es/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Phrasing_content"
           >phrasing content</a
         >;
-        <a href="/es/docs/Web/HTML/Content_categories#Embedded_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Embedded_content"
           >embedded content</a
         >, palpable content; if the element has a
-        <a href="/es/docs/Web/HTML/Element/object#usemap"><code>usemap</code></a> attribute,
-        <a href="/es/docs/Web/HTML/Content_categories#Interactive_content"
+        <a href="/es/docs/Web/HTML/Reference/Elements/object#usemap"><code>usemap</code></a> attribute,
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Interactive_content"
           >interactive content</a
         >;
-        <a href="/es/docs/Web/HTML/Content_categories#Form_listed">listed</a
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Form_listed">listed</a
         >,
-        <a href="/es/docs/Web/HTML/Content_categories#Form_submittable"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Form_submittable"
           >submittable</a
         >
         <a
-          href="/es/docs/Web/HTML/Content_categories#Form-associated_content"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Form-associated_content"
           >form-associated</a
         >
         element.
@@ -55,7 +55,7 @@ El **elemento HTML `<object>`** representa un recurso externo, que puede ser tra
       <td>
         cero o más elementos {{HTMLElement("param")}} , luego
         <a
-          href="/es/docs/Web/HTML/Content_categories#Transparent_content_model"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Transparent_content_model"
           >transparent</a
         >.
       </td>
@@ -68,7 +68,7 @@ El **elemento HTML `<object>`** representa un recurso externo, que puede ser tra
       <th scope="row">Padres permitidos</th>
       <td>
         Cualquier elemento que acepte
-        <a href="/es/docs/Web/HTML/Content_categories#Embedded_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Embedded_content"
           >embedded content</a
         >
         (contenido incrustado).

--- a/files/es/web/html/reference/elements/param/index.md
+++ b/files/es/web/html/reference/elements/param/index.md
@@ -32,7 +32,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Reference/Globa
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/HTML/Content_categories">Categorías de contenido</a>
+        <a href="/es/docs/Web/HTML/Guides/Content_categories">Categorías de contenido</a>
       </th>
       <td>Ninguno</td>
     </tr>
@@ -50,7 +50,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Reference/Globa
       <th scope="row">Elementos padre permitidos</th>
       <td>
         Un {{HTMLElement("object")}} antes de cualquier
-        <a href="/es/docs/Web/HTML/Content_categories#flow_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#flow_content"
           >contenido de flujo</a
         >.
       </td>

--- a/files/es/web/html/reference/elements/q/index.md
+++ b/files/es/web/html/reference/elements/q/index.md
@@ -30,15 +30,15 @@ q {
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/HTML/Content_categories"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Flow_content"
           >Flujo de contenido</a
         >,
-        <a href="/es/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Phrasing_content"
           >redacción de contenido</a
         >, contenido palpable.
       </td>
@@ -46,7 +46,7 @@ q {
     <tr>
       <th scope="row">Contenido permitido</th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Phrasing_content"
           >Redacción de contenido</a
         >.
       </td>
@@ -59,7 +59,7 @@ q {
       <th scope="row">Padres autorizados</th>
       <td>
         Cualquier elemento que acepte
-        <a href="/es/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Phrasing_content"
           >redacción de contenido</a
         >.
       </td>

--- a/files/es/web/html/reference/elements/script/index.md
+++ b/files/es/web/html/reference/elements/script/index.md
@@ -301,12 +301,12 @@ para que el script no bloquee el análisis pero se garantiza que será evaluado 
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/HTML/Content_categories">Categorías de contenido</a>
+        <a href="/es/docs/Web/HTML/Guides/Content_categories">Categorías de contenido</a>
       </th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#metadata_content">Contenido de metadatos</a>,
-        <a href="/es/docs/Web/HTML/Content_categories#flow_content">Contenido de flujo</a>,
-        <a href="/es/docs/Web/HTML/Content_categories#phrasing_content">Contenido de fraseo</a>.
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#metadata_content">Contenido de metadatos</a>,
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#flow_content">Contenido de flujo</a>,
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#phrasing_content">Contenido de fraseo</a>.
       </td>
     </tr>
     <tr>
@@ -320,8 +320,8 @@ para que el script no bloquee el análisis pero se garantiza que será evaluado 
     <tr>
       <th scope="row">Padres permitidos</th>
       <td>
-        Cualquier elemento que acepte <a href="/es/docs/Web/HTML/Content_categories#metadata_content">contenido de metadatos</a>,
-        o cualquier elemento que acepte <a href="/es/docs/Web/HTML/Content_categories#phrasing_content">contenido de fraseo</a>.
+        Cualquier elemento que acepte <a href="/es/docs/Web/HTML/Guides/Content_categories#metadata_content">contenido de metadatos</a>,
+        o cualquier elemento que acepte <a href="/es/docs/Web/HTML/Guides/Content_categories#phrasing_content">contenido de fraseo</a>.
       </td>
     </tr>
     <tr>

--- a/files/es/web/html/reference/elements/section/index.md
+++ b/files/es/web/html/reference/elements/section/index.md
@@ -121,24 +121,24 @@ Dependiendo del contenido, incluir un encabezado también podría ser bueno para
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/HTML/Content_categories"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#flujo_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#flujo_de_contenido"
           >Flujo de contenido</a
         >,
         <a
-          href="/es/docs/Web/HTML/Content_categories#contenido_de_sección"
+          href="/es/docs/Web/HTML/Guides/Content_categories#contenido_de_sección"
           >contenido de sección</a
-        >, <a href="/es/docs/Web/HTML/Content_categories#contenido_palpable">contenido palpable</a>.
+        >, <a href="/es/docs/Web/HTML/Guides/Content_categories#contenido_palpable">contenido palpable</a>.
       </td>
     </tr>
     <tr>
       <th scope="row">Contenido permitido</th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#flujo_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#flujo_de_contenido"
           >Flujo de contenido</a
         >.
       </td>
@@ -151,7 +151,7 @@ Dependiendo del contenido, incluir un encabezado también podría ser bueno para
       <th scope="row">Padres permitidos</th>
       <td>
         Cualquier elemento que acepte
-        <a href="/es/docs/Web/HTML/Content_categories#flujo_de_contenido"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#flujo_de_contenido"
           >flujo de contenido</a
         >. Ten en cuenta que un elemento <code>&#x3C;section></code> no debe ser un
         descendiente de un elemento {{HTMLElement("address")}}.
@@ -180,7 +180,7 @@ Dependiendo del contenido, incluir un encabezado también podría ser bueno para
     <tr>
       <th scope="row">Roles ARIA permitidos</th>
       <td>
-        <a href="/es/docs/Web/Accessibility/ARIA/Roles/alert_role"><code>alert</code></a>, <a href="/es/docs/Web/Accessibility/ARIA/Roles/alertdialog_role"><code>alertdialog</code></a>,
+        <a href="/es/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role"><code>alert</code></a>, <a href="/es/docs/Web/Accessibility/ARIA/Reference/Roles/alertdialog_role"><code>alertdialog</code></a>,
         <a href="/es/docs/Web/Accessibility/ARIA/Roles/application_role"><code>application</code></a>, <a href="/es/docs/Web/Accessibility/ARIA/Roles/banner_role"><code>banner</code></a>,
         <a href="/es/docs/Web/Accessibility/ARIA/Roles/complementary_role"><code>complementary</code></a>,
         <a href="/es/docs/Web/Accessibility/ARIA/Roles/contentinfo_role"><code>contentinfo</code></a>, <a href="/es/docs/Web/Accessibility/ARIA/Roles/dialog_role"><code>dialog</code></a>,

--- a/files/es/web/html/reference/elements/slot/index.md
+++ b/files/es/web/html/reference/elements/slot/index.md
@@ -12,15 +12,15 @@ original_slug: Web/HTML/Element/slot
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/HTML/Content_categories"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorias de contenido</a
         >
       </th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Flow_content"
           >Contenido de flujo</a
         >,
-        <a href="/es/docs/Web/Guide/HTML/Content_categories#Phrasing_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Phrasing_content"
           >contenido de fraseo</a
         >
       </td>

--- a/files/es/web/html/reference/elements/source/index.md
+++ b/files/es/web/html/reference/elements/source/index.md
@@ -24,7 +24,7 @@ El **elemento HTML `<source>`** especifica recursos de medios múltiples para lo
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/HTML/Content_categories"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>

--- a/files/es/web/html/reference/elements/sup/index.md
+++ b/files/es/web/html/reference/elements/sup/index.md
@@ -18,11 +18,11 @@ El **elemento HTML** \<sup> define un fragmento de texto que se debe mostrar, po
       </th>
       <td>
         <a
-          href="https://developer.mozilla.org/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_din%C3%A1mico"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Contenido_din%C3%A1mico"
           >Contenido dinamíco</a
         >(Flow content) y
         <a
-          href="https://developer.mozilla.org/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_est%C3%A1tico_o_de_texto"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Contenido_est%C3%A1tico_o_de_texto"
           >contenido estático o de texto</a
         >(phrasing content)
       </td>
@@ -31,7 +31,7 @@ El **elemento HTML** \<sup> define un fragmento de texto que se debe mostrar, po
       <th scope="row">Contenido permitido</th>
       <td>
         <a
-          href="https://developer.mozilla.org/es/docs/Web/Guide/HTML/categorias_de_contenido#Contenido_est%C3%A1tico_o_de_texto"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Contenido_est%C3%A1tico_o_de_texto"
           >contenido estático o de texto</a
         >
       </td>
@@ -71,7 +71,7 @@ El **elemento HTML** \<sup> define un fragmento de texto que se debe mostrar, po
         <font
           ><font
             ><a
-              href="https://developer.mozilla.org/es/docs/Web/API/HTMLElement"
+              href="/es/docs/Web/API/HTMLElement"
               title="The HTMLElement interface represents any HTML element. Some elements directly implement this interface, others implement it via an interface that inherits it."
               ><code>HTMLElement</code></a
             ></font

--- a/files/es/web/html/reference/elements/time/index.md
+++ b/files/es/web/html/reference/elements/time/index.md
@@ -38,12 +38,12 @@ time {
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/HTML/Content_categories"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>
       <td>
-        <a href="/es/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Flow_content"
           >Contenido de flujo</a
         >,
         <a href="/es/docs/HTML/Content_categories#Phrasing_content"

--- a/files/es/web/html/reference/elements/title/index.md
+++ b/files/es/web/html/reference/elements/title/index.md
@@ -16,12 +16,12 @@ El elemento **`<title>`** [HTML](/es/docs/Web/HTML) define el título del docume
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/Guide/HTML/Content_categories"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>
       <td>
-        <a href="/es/docs/Web/Guide/HTML/Content_categories#contenido_de_metadatos"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#contenido_de_metadatos"
           >Contenido de metadatos</a
         >.
       </td>

--- a/files/es/web/html/reference/elements/track/index.md
+++ b/files/es/web/html/reference/elements/track/index.md
@@ -38,7 +38,7 @@ video::cue {
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/es/docs/Web/Guide/HTML/Content_categories"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories"
           >Categorías de contenido</a
         >
       </th>

--- a/files/es/web/http/reference/methods/delete/index.md
+++ b/files/es/web/http/reference/methods/delete/index.md
@@ -32,7 +32,7 @@ El **método de solicitud HTTP `DELETE`** elimina el recurso especificado.
     </tr>
     <tr>
       <th scope="row">
-        Permitido en <a href="/es/docs/Learn/Forms">formularios HTML</a>
+        Permitido en <a href="/es/docs/Learn_web_development/Extensions/Forms">formularios HTML</a>
       </th>
       <td>No</td>
     </tr>

--- a/files/es/web/javascript/guide/inheritance_and_the_prototype_chain/index.md
+++ b/files/es/web/javascript/guide/inheritance_and_the_prototype_chain/index.md
@@ -627,7 +627,7 @@ const filledRectangle = new FilledRectangle(5, 10, "blue");
     <tr>
       <th scope="row">Pro(s)</th>
       <td>
-         Compatible con todos los motores modernos. Muy alta legibilidad y mantenibilidad. <a href="/es/docs/Web/JavaScript/Reference/Classes/Private_properties">Propiedades privadas</a> son una característica sin reemplazo trivial en la herencia prototípica.
+         Compatible con todos los motores modernos. Muy alta legibilidad y mantenibilidad. <a href="/es/docs/Web/JavaScript/Reference/Classes/Private_elements">Propiedades privadas</a> son una característica sin reemplazo trivial en la herencia prototípica.
        </td>
     </tr>
     <tr>

--- a/files/es/web/javascript/guide/regular_expressions/cheatsheet/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/cheatsheet/index.md
@@ -123,7 +123,7 @@ Si deseas contribuir a este documento, edita también [el artículo original](/e
         <li>Para los caracteres que generalmente se tratan literalmente, indica que el siguiente caracter es especial y no se debe interpretar literalmente. Por ejemplo, <code>/b/</code> reconoce el caracter "b". Al colocar una barra invertida delante de "b", es decir, usando <code>/\b/</code>, el caracter se vuelve especial para significar que concuerda con el límite de una palabra.</li>
         <li>Para los caracteres que generalmente se tratan de manera especial, indica que el siguiente caracter no es especial y se debe interpretar literalmente. Por ejemplo, "*" es un caracter especial que significa que deben reconocer 0 o más ocurrencias del caracter anterior; por ejemplo, <code>/a*/</code> significa reconocer 0 o más "a"s. Para emparejar el <code>*</code> literal, precédelo con una barra invertida; por ejemplo, <code>/a\*/</code> concuerda con "a*".</li>
        </ul>
-       <p>Ten en cuenta que algunos caracteres como <code>:</code>, <code>-</code>, <code>@</code>, etc. no tienen un significado especial cuando se escapan ni cuando no se escapan. Las secuencias de escape como <code>\:</code>, <code>\-</code>, <code>\@</code> serán equivalentes a sus equivalentes de caracteres literales sin escapar en expresiones regulares. Sin embargo, en las expresiones regulares con <a href="/es/docs/Web/JavaScript/Guide/Regular_Expressions#Advanced_searching_with_flags_2">indicador Unicode</a>, esto provocará un error de <em>escape de identidad no válido</em>. Esto se hace para asegurar la compatibilidad con el código existente que usa nuevas secuencias de escape como <code>\p</code> o <code>\k</code>.</p>
+       <p>Ten en cuenta que algunos caracteres como <code>:</code>, <code>-</code>, <code>@</code>, etc. no tienen un significado especial cuando se escapan ni cuando no se escapan. Las secuencias de escape como <code>\:</code>, <code>\-</code>, <code>\@</code> serán equivalentes a sus equivalentes de caracteres literales sin escapar en expresiones regulares. Sin embargo, en las expresiones regulares con <a href="/es/docs/Web/JavaScript/Guide/Regular_expressions#Advanced_searching_with_flags_2">indicador Unicode</a>, esto provocará un error de <em>escape de identidad no válido</em>. Esto se hace para asegurar la compatibilidad con el código existente que usa nuevas secuencias de escape como <code>\p</code> o <code>\k</code>.</p>
        <div class="blockIndicator note">
        <p>Para reconocer este caracter literalmente, escápalo consigo mismo. En otras palabras, para buscar <code>\</code> usa <code>/\\/</code>.</p>
        </div>
@@ -151,7 +151,7 @@ Si deseas contribuir a este documento, edita también [el artículo original](/e
       <td>
        <p>Coincide con el comienzo de la entrada. Si el indicador multilínea se establece en <code>true</code>, también busca inmediatamente después de un caracter de salto de línea. Por ejemplo, <code>/^A/</code> no reconoce la "A" en "an A", pero encuentra la primera "A" en "An A".</p>
        <div class="blockIndicator note">
-       <p>Este caracter tiene un significado diferente cuando aparece al comienzo de un <a href="/es/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges">grupo</a>.</p>
+       <p>Este caracter tiene un significado diferente cuando aparece al comienzo de un <a href="/es/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences">grupo</a>.</p>
        </div>
       </td>
      </tr>
@@ -172,7 +172,7 @@ Si deseas contribuir a este documento, edita también [el artículo original](/e
         <li><code>/oon\b/</code> encuentra "oon" en "moon", porque "oon" es el final de la cadena, por lo que no va seguido de un caracter de palabra.</li>
         <li><code>/\w\b\w/</code> nunca encontrará nada, porque un caracter de palabra nunca puede ir seguido de un caracter que no sea de palabra y otro de palabra.</li>
        </ul>
-       <p>Para encontrar un caracter de retroceso (<code>[\b]</code>), consulta <a href="/es/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes">Clases de caracteres</a>.</p>
+       <p>Para encontrar un caracter de retroceso (<code>[\b]</code>), consulta <a href="/es/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes">Clases de caracteres</a>.</p>
       </td>
      </tr>
      <tr>

--- a/files/es/web/svg/reference/element/script/index.md
+++ b/files/es/web/svg/reference/element/script/index.md
@@ -15,24 +15,24 @@ Los scripts sin atributo `async` o `defer`, así como las secuencias de comandos
     <tr>
       <th scope="row">
         <a
-          href="/es/docs/Web/HTML/Content_categories"
+          href="/es/docs/Web/HTML/Guides/Content_categories"
           title="HTML/Content_categories"
           >Content categories</a
         >
       </th>
       <td>
         <a
-          href="/es/docs/Web/HTML/Content_categories#Metadata_content"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Metadata_content"
           title="HTML/Content_categories#Metadata_content"
           >Metadata content</a
         >,
         <a
-          href="/es/docs/Web/HTML/Content_categories#Flow_content"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Flow_content"
           title="HTML/Content_categories#Flow_content"
           >Flow content</a
         >,
         <a
-          href="/es/docs/Web/HTML/Content_categories#Phrasing_content"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Phrasing_content"
           title="HTML/Content_categories#Phrasing_content"
           >Phrasing content</a
         >.
@@ -51,11 +51,11 @@ Los scripts sin atributo `async` o `defer`, así como las secuencias de comandos
       <td>
         Cualquier elemento que acepte
         <a
-          href="/es/docs/Web/HTML/Content_categories#Metadata_content"
+          href="/es/docs/Web/HTML/Guides/Content_categories#Metadata_content"
           title="HTML/Content_categories#Metadata_content"
           >metadata content</a
         >, o cualquier elemento que acepte
-        <a href="/es/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/es/docs/Web/HTML/Guides/Content_categories#Phrasing_content"
           >phrasing content</a
         >.
       </td>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix flaws in raw HTML links, applying redirects and case changes.

### Motivation

Resolve flaws reported by rari.

### Additional details

Ran `cargo run -- content fix-flaws --content` with rari from https://github.com/mdn/rari/pull/615, which adds Markdown source position tracking for raw HTML links.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.

_(Split from https://github.com/mdn/translated-content/pull/35032.)_