### PR TITLE
zh-cn: update the translation of `Object.is()`

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/object/is/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/object/is/index.md
@@ -1,6 +1,9 @@
 ---
 title: Object.is()
+short-title: is()
 slug: Web/JavaScript/Reference/Global_Objects/Object/is
+l10n:
+  sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166
 ---
 
 **`Object.is()`** 静态方法确定两个值是否为[相同值](/zh-CN/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness#使用_object.is_进行同值相等比较)。
@@ -101,4 +104,5 @@ Object.is(NaN, Number.NaN); // true
 ## 参见
 
 - [`core-js` 中 `Object.is` 的 Polyfill](https://github.com/zloirock/core-js#ecmascript-object)
+- [`Object.is` 的 es-shims polyfill](https://www.npmjs.com/package/object.is)
 - [JavaScript 中的相等性判断](/zh-CN/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness)——三种内置相等性工具的比较

--- a/files/zh-cn/web/javascript/reference/global_objects/object/is/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/object/is/index.md
@@ -8,21 +8,21 @@ l10n:
 
 **`Object.is()`** 静态方法确定两个值是否为[相同值](/zh-CN/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness#使用_object.is_进行同值相等比较)。
 
-{{InteractiveExample("JavaScript Demo: Object.is()")}}
+{{InteractiveExample("JavaScript 演示：Object.is()")}}
 
 ```js interactive-example
 console.log(Object.is("1", 1));
-// Expected output: false
+// 期望输出：false
 
 console.log(Object.is(NaN, NaN));
-// Expected output: true
+// 期望输出：true
 
 console.log(Object.is(-0, 0));
-// Expected output: false
+// 期望输出：false
 
 const obj = {};
 console.log(Object.is(obj, {}));
-// Expected output: false
+// 期望输出：false
 ```
 
 ## 语法


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

更新 `Object.is()` 文档的中文翻译：

- 添加 `short-title: is()` 元数据
- 添加 `sourceCommit: 544b843570cb08d1474cfc5ec03ffb9f4edc0166`
- 添加 es-shims polyfill 链接到参见部分

### Motivation

同步英文原文更新，补充缺失的元数据和内容。

### Additional details

**英文原文**：
- Object.is(): https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is

**上游提交**：
- Object.is(): 544b843570cb08d1474cfc5ec03ffb9f4edc0166

**验证 URL**（GitHub 提交历史）：
- Object.is(): https://github.com/mdn/content/commits/main/files/en-us/web/javascript/reference/global_objects/object/is/index.md

### Related issues and pull requests

N/A
