### PR TITLE
zh-cn: update the translation of `Array.findLast()`

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/array/findlast/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/array/findlast/index.md
@@ -16,7 +16,7 @@ l10n:
 - 某个值是否*存在*该数组中，请使用 {{jsxref("Array/includes", "includes()")}}。同样地，它会检查每个元素是否与该值相等，而不是使用一个测试函数。
 - 是否有任意一个元素满足给定的测试函数，请使用 {{jsxref("Array/some", "some()")}}。
 
-{{InteractiveExample("JavaScript Demo: Array.prototype.findLast()", "shorter")}}
+{{InteractiveExample("JavaScript 演示：Array.prototype.findLast()", "shorter")}}
 
 ```js interactive-example
 const array = [5, 12, 50, 130, 44];

--- a/files/zh-cn/web/javascript/reference/global_objects/array/findlast/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/array/findlast/index.md
@@ -1,27 +1,30 @@
 ---
 title: Array.prototype.findLast()
+short-title: findLast()
 slug: Web/JavaScript/Reference/Global_Objects/Array/findLast
+l10n:
+  sourceCommit: f9fe909466736b335491bdd866701e4b023057d0
 ---
 
 **`findLast()`** 方法反向迭代数组，并返回满足提供的测试函数的第一个元素的值。如果没有找到对应元素，则返回 {{jsxref("undefined")}}。
 
-如果你需要找到：
+如果你需要查找：
 
-- *第一个*匹配的元素，使用 {{jsxref("Array/find", "find()")}}。
-- 数组中最后一个匹配元素的*索引*，使用 {{jsxref("Array/findLastIndex", "findLastIndex()")}}。
-- _某个值的索引_，使用 {{jsxref("Array/indexOf", "indexOf()")}}。（它类似于 {{jsxref("Array/findIndex", "findIndex()")}}，但是会检查每个元素是否与值相等，而不是使用一个测试函数。）
-- 该数组中是否*存在*一个值，使用 {{jsxref("Array/includes()", "includes()")}}。同样地，它检查每个元素是否和值相等，而不是使用一个测试函数。
-- 是否有任意一个元素满足提供的测试函数，使用 {{jsxref("Array/some()", "some()")}}。
+- *第一个*匹配的元素，请使用 {{jsxref("Array/find", "find()")}}。
+- 数组中最后一个匹配元素的*索引*，请使用 {{jsxref("Array/findLastIndex", "findLastIndex()")}}。
+- _某个值的索引_，请使用 {{jsxref("Array/indexOf", "indexOf()")}}。（它类似于 {{jsxref("Array/findIndex", "findIndex()")}}，但是会检查每个元素是否与值相等，而不是使用一个测试函数。）
+- 某个值是否*存在*该数组中，请使用 {{jsxref("Array/includes", "includes()")}}。同样地，它会检查每个元素是否与该值相等，而不是使用一个测试函数。
+- 是否有任意一个元素满足给定的测试函数，请使用 {{jsxref("Array/some", "some()")}}。
 
-{{InteractiveExample("JavaScript Demo: Array.findLast()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.findLast()", "shorter")}}
 
 ```js interactive-example
-const array1 = [5, 12, 50, 130, 44];
+const array = [5, 12, 50, 130, 44];
 
-const found = array1.findLast((element) => element > 45);
+const found = array.findLast((element) => element > 45);
 
 console.log(found);
-// Expected output: 130
+// 期望输出：130
 ```
 
 ## 语法
@@ -133,6 +136,43 @@ console.log([4, 5, 7, 8, 9, 11, 12].findLast(isPrime)); // 11
 > [!NOTE]
 > `isPrime()` 实现仅供演示。在实际应用中，为了避免重复计算，会使用大量记忆化的算法，例如[埃拉托斯特尼筛法](https://zh.wikipedia.org/wiki/埃拉托斯特尼筛法)。
 
+### 查找最近完成的任务
+
+此示例演示了在处理按时间排序的数据时 `findLast()` 的一个实际应用场景。它从已按 `timestamp` 排序的列表中查找最近完成的任务。
+
+```js
+const tasks = [
+  { name: "搭建项目", completed: true, timestamp: 1609459200000 },
+  { name: "编写测试", completed: false, timestamp: 1609545600000 },
+  { name: "修复 bug #42", completed: true, timestamp: 1609632000000 },
+  { name: "部署到预发环境", completed: true, timestamp: 1609718400000 },
+  { name: "审查 PR", completed: false, timestamp: 1609804800000 },
+];
+
+const lastCompletedTask = tasks.findLast((task) => task.completed);
+
+console.log(lastCompletedTask.name); // 部署到预发环境
+```
+
+这比对倒序数据使用 `find()` 更高效，因为它避免了创建新数组。
+
+### 使用回调函数的第三个参数
+
+如果你需要访问数组中的另一个元素，`array` 参数会非常有用，尤其是在没有现有的变量引用该数组时。以下示例首先使用 `filter()` 提取正数，然后使用 `findLast()` 查找小于其相邻元素的最后一个元素。
+
+```js
+const numbers = [3, -1, 1, 4, 1, 5, 9, 2, 6];
+const lastTrough = numbers
+  .filter((num) => num > 0)
+  .findLast((num, idx, arr) => {
+    // 如果没有 arr 参数，就无法轻松访问中间数组，除非将其保存到变量中。
+    if (idx > 0 && num >= arr[idx - 1]) return false;
+    if (idx < arr.length - 1 && num >= arr[idx + 1]) return false;
+    return true;
+  });
+console.log(lastTrough); // 2
+```
+
 ### 在稀疏数组上使用 findLast()
 
 稀疏数组中的空槽*被*访问，并被视为 `undefined`。
@@ -144,6 +184,7 @@ const array = [0, 1, , , , 5, 6];
 // 显示所有的索引（不只包括那些被赋值的）
 array.findLast((value, index) => {
   console.log(`访问索引 ${index}，值为 ${value}`);
+  return false;
 });
 // 访问索引 6，值为 6
 // 访问索引 5，值为 5
@@ -162,6 +203,7 @@ array.findLast((value, index) => {
   }
   // 元素 5 在被删除后，仍会被访问
   console.log(`访问索引 ${index}，值为 ${value}`);
+  return false;
 });
 // 删除值为 array[5]，其值为 5
 // 访问索引 6，值为 6
@@ -183,6 +225,7 @@ const arrayLike = {
   0: 2,
   1: 7.3,
   2: 4,
+  3: 3, // 被 findLast() 忽略，因为 length 是 3
 };
 console.log(
   Array.prototype.findLast.call(arrayLike, (x) => Number.isInteger(x)),
@@ -199,7 +242,8 @@ console.log(
 
 ## 参见
 
-- [`core-js` 中 `Array.prototype.findLast` 的 polyfill](https://github.com/zloirock/core-js#ecmascript-array)
+- [`core-js` 中 `Array.prototype.findLast` 的 polyfill](https://github.com/zloirock/core-js#array-find-from-last)
+- [`Array.prototype.findLast` 的 es-shims polyfill](https://www.npmjs.com/package/array.prototype.findlast)
 - [索引集合](/zh-CN/docs/Web/JavaScript/Guide/Indexed_collections)
 - {{jsxref("Array")}}
 - {{jsxref("Array.prototype.find()")}}

--- a/files/zh-cn/web/javascript/reference/global_objects/array/findlast/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/array/findlast/index.md
@@ -57,15 +57,6 @@ findLast(callbackFn, thisArg)
 
 `callbackFn` 会被数组中的*每个*元素调用，而不仅仅是那些被赋值的元素。对于[稀疏数组](/zh-CN/docs/Web/JavaScript/Guide/Indexed_collections#稀疏数组)来说，空槽行为和 `undefined` 相同。
 
-`findLast()` 方法不会改变调用它的数组，但是提供的 `callbackFn` 可以。但是请注意，数组的长度是在第一次调用 `callbackFn` *之前*保存的。因此：
-
-- `callbackFn` 不会访问在调用 `findLast()` 开始后才添加到数组中的任何元素。
-- 给已访问过的索引重新赋值将不会被 `callbackFn` 重新访问。
-- 如果 `callbackFn` 更改了数组中现有的、尚未访问的元素，则其传递给 `callbackFn` 的值将是 `findLast()` 访问该元素索引时的值。[已删除](/zh-CN/docs/Web/JavaScript/Reference/Operators/delete)的元素会被当做 `undefined` 来访问。
-
-> [!WARNING]
-> 上一段描述的并发修改的情况经常导致难以理解的代码，通常应该避免（特殊情况除外）。
-
 `findLast()` 方法是[通用的](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Array#通用数组方法)。它只期望 `this` 值具有 `length` 属性和整数键的属性。
 
 ## 示例
@@ -217,7 +208,7 @@ array.findLast((value, index) => {
 
 ### 在非数组对象上调用 findLast()
 
-`findLast()` 方法读取 `this` 的 `length` 属性，然后访问每个整数索引。
+`findLast()` 方法读取 `this` 的 `length` 属性，然后访问每个键为小于 `length` 的非负整数的属性。
 
 ```js
 const arrayLike = {
@@ -244,7 +235,7 @@ console.log(
 
 - [`core-js` 中 `Array.prototype.findLast` 的 polyfill](https://github.com/zloirock/core-js#array-find-from-last)
 - [`Array.prototype.findLast` 的 es-shims polyfill](https://www.npmjs.com/package/array.prototype.findlast)
-- [索引集合](/zh-CN/docs/Web/JavaScript/Guide/Indexed_collections)
+- [索引集合](/zh-CN/docs/Web/JavaScript/Guide/Indexed_collections)指南
 - {{jsxref("Array")}}
 - {{jsxref("Array.prototype.find()")}}
 - {{jsxref("Array.prototype.findIndex()")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

同步更新 `Array.prototype.findLast()` 文档的中文翻译：

- 添加 `short-title` 和 `sourceCommit` 元数据
- 新增两个示例：
  - 查找最近完成的任务（时间排序数据的实际用例）
  - 使用回调函数的第三个参数
- 翻译代码示例中的字符串和注释
- 补充稀疏数组示例中缺失的 `return false;`
- 在 See also 中添加 es-shims polyfill 链接

### Motivation

英文原文新增了实用示例，需要同步翻译以便中文读者了解 `findLast()` 的实际应用场景。

### Additional details

**英文原文**：
- 文档名称：https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast

**上游提交**：
- 文档名称：f9fe909466736b335491bdd866701e4b023057d0

**验证 URL**（GitHub 提交历史）：
- https://github.com/mdn/content/commits/main/files/en-us/web/javascript/reference/global_objects/array/findlast/index.md

### Related issues and pull requests

N/A
