### PR TITLE
zh-cn: update the translation of the `WebSocket` API

### DIFF
--- a/files/zh-cn/web/api/websocket/index.md
+++ b/files/zh-cn/web/api/websocket/index.md
@@ -12,7 +12,7 @@ l10n:
 使用 [`WebSocket()`](/zh-CN/docs/Web/API/WebSocket/WebSocket) 构造函数来构造一个 `WebSocket`。
 
 > [!NOTE]
-> `WebSocket` API 无法应用[背压](/zh-CN/docs/Web/API/Streams_API/Concepts#背压（backpressure）)，因此当消息到达速度超过应用程序的处理速度时，应用程序要么因缓冲这些消息而耗尽设备内存，要么因 100% CPU 使用率而变得无响应，甚至可能同时出现这两种情况。如需一种能提供自动背压的替代方案，请参阅 {{domxref("WebSocketStream")}}。
+> `WebSocket` API 无法应用[背压](/zh-CN/docs/Web/API/Streams_API/Concepts#背压（backpressure）)，因此当消息到达速度超过应用程序的处理速度时，应用程序要么因缓冲这些消息而耗尽设备内存，要么因 100% CPU 使用率而变得无响应，甚至可能同时出现这两种情况。如需一种能提供自动背压的替代方案，请参见 {{domxref("WebSocketStream")}}。
 
 {{InheritanceDiagram}}
 
@@ -26,7 +26,7 @@ l10n:
 - {{domxref("WebSocket.binaryType")}}
   - : 使用二进制的数据类型连接。
 - {{domxref("WebSocket.bufferedAmount")}} {{ReadOnlyInline}}
-  - : 未发送至服务器的字节数。
+  - : 队列中数据的字节数。
 - {{domxref("WebSocket.extensions")}} {{ReadOnlyInline}}
   - : 服务器选择的扩展。
 - {{domxref("WebSocket.protocol")}} {{ReadOnlyInline}}
@@ -50,7 +50,7 @@ l10n:
 - {{domxref("WebSocket/close_event", "close")}}
   - : 当一个 `WebSocket` 连接被关闭时触发。也可以通过 `onclose` 属性使用。
 - {{domxref("WebSocket/error_event", "error")}}
-  - : 当一个 `WebSocket` 连接因错误而关闭时触发，例如无法发送数据时。也可以通过 `onerror` 属性使用。
+  - : 当一个 `WebSocket` 连接因错误（例如无法发送数据）而关闭时触发。也可以通过 `onerror` 属性使用。
 - {{domxref("WebSocket/message_event", "message")}}
   - : 当通过 `WebSocket` 收到数据时触发。也可以通过 `onmessage` 属性使用。
 - {{domxref("WebSocket/open_event", "open")}}
@@ -64,12 +64,12 @@ const socket = new WebSocket("ws://localhost:8080");
 
 // 连接打开
 socket.addEventListener("open", (event) => {
-  socket.send("Hello Server!");
+  socket.send("你好，服务器！");
 });
 
 // 监听消息
 socket.addEventListener("message", (event) => {
-  console.log("Message from server ", event.data);
+  console.log("来自服务器的消息：", event.data);
 });
 ```
 

--- a/files/zh-cn/web/api/websocket/index.md
+++ b/files/zh-cn/web/api/websocket/index.md
@@ -1,88 +1,74 @@
 ---
 title: WebSocket
 slug: Web/API/WebSocket
+l10n:
+  sourceCommit: fb311d7305937497570966f015d8cc0eb1a0c29c
 ---
 
-{{APIRef("Web Sockets API")}}
+{{APIRef("WebSockets API")}}{{AvailableInWorkers}}
 
-`WebSocket` 对象提供了用于创建和管理 [WebSocket](/zh-CN/docs/Web/API/WebSockets_API) 连接，以及可以通过该连接发送和接收数据的 API。
+`WebSocket` 对象提供了用于创建和管理与服务器的 [WebSocket](/zh-CN/docs/Web/API/WebSockets_API) 连接，以及可以通过该连接发送和接收数据的 API。
 
 使用 [`WebSocket()`](/zh-CN/docs/Web/API/WebSocket/WebSocket) 构造函数来构造一个 `WebSocket`。
 
+> [!NOTE]
+> `WebSocket` API 无法应用[背压](/zh-CN/docs/Web/API/Streams_API/Concepts#背压（backpressure）)，因此当消息到达速度超过应用程序的处理速度时，应用程序要么因缓冲这些消息而耗尽设备内存，要么因 100% CPU 使用率而变得无响应，甚至可能同时出现这两种情况。如需一种能提供自动背压的替代方案，请参阅 {{domxref("WebSocketStream")}}。
+
+{{InheritanceDiagram}}
+
 ## 构造函数
 
-- {{domxref("WebSocket.WebSocket", "WebSocket(url[, protocols])")}}
-  - : 返回一个 `WebSocket` 对象。
+- {{domxref("WebSocket.WebSocket", "WebSocket()")}}
+  - : 返回一个新创建的 `WebSocket` 对象。
 
-## 常量
-
-| **Constant**           | **Value** |
-| ---------------------- | --------- |
-| `WebSocket.CONNECTING` | `0`       |
-| `WebSocket.OPEN`       | `1`       |
-| `WebSocket.CLOSING`    | `2`       |
-| `WebSocket.CLOSED`     | `3`       |
-
-## 属性
+## 实例属性
 
 - {{domxref("WebSocket.binaryType")}}
   - : 使用二进制的数据类型连接。
-- {{domxref("WebSocket.bufferedAmount")}} {{readonlyinline}}
+- {{domxref("WebSocket.bufferedAmount")}} {{ReadOnlyInline}}
   - : 未发送至服务器的字节数。
-- {{domxref("WebSocket.extensions")}} {{readonlyinline}}
+- {{domxref("WebSocket.extensions")}} {{ReadOnlyInline}}
   - : 服务器选择的扩展。
-- {{domxref("WebSocket.onclose")}}
-  - : 用于指定连接关闭后的回调函数。
-- {{domxref("WebSocket.onerror")}}
-  - : 用于指定连接失败后的回调函数。
-- {{domxref("WebSocket.onmessage")}}
-  - : 用于指定当从服务器接受到信息时的回调函数。
-- {{domxref("WebSocket.onopen")}}
-  - : 用于指定连接成功后的回调函数。
-- {{domxref("WebSocket.protocol")}} {{readonlyinline}}
-  - : 服务器选择的下属协议。
-- {{domxref("WebSocket.readyState")}} {{readonlyinline}}
-  - : 当前的链接状态。
-- {{domxref("WebSocket.url")}} {{readonlyinline}}
+- {{domxref("WebSocket.protocol")}} {{ReadOnlyInline}}
+  - : 服务器选择的子协议。
+- {{domxref("WebSocket.readyState")}} {{ReadOnlyInline}}
+  - : 连接的当前状态。
+- {{domxref("WebSocket.url")}} {{ReadOnlyInline}}
   - : WebSocket 的绝对路径。
 
-## 方法
+## 实例方法
 
-- {{domxref("WebSocket.close", "WebSocket.close([code[, reason]])")}}
-  - : 关闭当前链接。
-- {{domxref("WebSocket.send", "WebSocket.send(data)")}}
-  - : 对要传输的数据进行排队。
+- {{domxref("WebSocket.close()")}}
+  - : 关闭连接。
+- {{domxref("WebSocket.send()")}}
+  - : 将待传输的数据加入队列。
 
 ## 事件
 
 使用 `addEventListener()` 或将一个事件监听器赋值给本接口的 `oneventname` 属性，来监听下面的事件。
 
 - {{domxref("WebSocket/close_event", "close")}}
-  - : 当一个 `WebSocket` 连接被关闭时触发。
-    也可以通过 {{domxref("WebSocket/onclose", "onclose")}} 属性来设置。
+  - : 当一个 `WebSocket` 连接被关闭时触发。也可以通过 `onclose` 属性使用。
 - {{domxref("WebSocket/error_event", "error")}}
-  - : 当一个 `WebSocket` 连接因错误而关闭时触发，例如无法发送数据时。
-    也可以通过 {{domxref("WebSocket/onerror", "onerror")}} 属性来设置。
+  - : 当一个 `WebSocket` 连接因错误而关闭时触发，例如无法发送数据时。也可以通过 `onerror` 属性使用。
 - {{domxref("WebSocket/message_event", "message")}}
-  - : 当通过 `WebSocket` 收到数据时触发。
-    也可以通过 {{domxref("WebSocket/onmessage", "onmessage")}} 属性来设置。
+  - : 当通过 `WebSocket` 收到数据时触发。也可以通过 `onmessage` 属性使用。
 - {{domxref("WebSocket/open_event", "open")}}
-  - : 当一个 `WebSocket` 连接成功时触发。
-    也可以通过 {{domxref("WebSocket/onopen", "onopen")}} 属性来设置。
+  - : 当一个 `WebSocket` 连接成功时触发。也可以通过 `onopen` 属性使用。
 
 ## 示例
 
 ```js
-// Create WebSocket connection.
+// 创建 WebSocket 连接。
 const socket = new WebSocket("ws://localhost:8080");
 
-// Connection opened
-socket.addEventListener("open", function (event) {
+// 连接打开
+socket.addEventListener("open", (event) => {
   socket.send("Hello Server!");
 });
 
-// Listen for messages
-socket.addEventListener("message", function (event) {
+// 监听消息
+socket.addEventListener("message", (event) => {
   console.log("Message from server ", event.data);
 });
 ```
@@ -97,4 +83,4 @@ socket.addEventListener("message", function (event) {
 
 ## 参见
 
-- [Writing WebSocket client applications](/zh-CN/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications)
+- [编写 WebSocket 客户端应用](/zh-CN/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications)

--- a/files/zh-cn/web/api/websocket/index.md
+++ b/files/zh-cn/web/api/websocket/index.md
@@ -9,7 +9,7 @@ l10n:
 
 `WebSocket` 对象提供了用于创建和管理与服务器的 [WebSocket](/zh-CN/docs/Web/API/WebSockets_API) 连接，以及可以通过该连接发送和接收数据的 API。
 
-使用 [`WebSocket()`](/zh-CN/docs/Web/API/WebSocket/WebSocket) 构造函数来构造一个 `WebSocket`。
+使用 [`WebSocket()`](/zh-CN/docs/Web/API/WebSocket/WebSocket) 构造函数来构造 `WebSocket`。
 
 > [!NOTE]
 > `WebSocket` API 无法应用[背压](/zh-CN/docs/Web/API/Streams_API/Concepts#背压（backpressure）)，因此当消息到达速度超过应用程序的处理速度时，应用程序要么因缓冲这些消息而耗尽设备内存，要么因 100% CPU 使用率而变得无响应，甚至可能同时出现这两种情况。如需一种能提供自动背压的替代方案，请参见 {{domxref("WebSocketStream")}}。
@@ -24,7 +24,7 @@ l10n:
 ## 实例属性
 
 - {{domxref("WebSocket.binaryType")}}
-  - : 使用二进制的数据类型连接。
+  - : 由连接所使用的二进制数据类型。
 - {{domxref("WebSocket.bufferedAmount")}} {{ReadOnlyInline}}
   - : 队列中数据的字节数。
 - {{domxref("WebSocket.extensions")}} {{ReadOnlyInline}}
@@ -34,7 +34,7 @@ l10n:
 - {{domxref("WebSocket.readyState")}} {{ReadOnlyInline}}
   - : 连接的当前状态。
 - {{domxref("WebSocket.url")}} {{ReadOnlyInline}}
-  - : WebSocket 的绝对路径。
+  - : WebSocket 的绝对 URL。
 
 ## 实例方法
 
@@ -45,16 +45,16 @@ l10n:
 
 ## 事件
 
-使用 `addEventListener()` 或将一个事件监听器赋值给本接口的 `oneventname` 属性，来监听下面的事件。
+使用 `addEventListener()` 或将事件监听器赋值给此接口的 `oneventname` 属性，来监听下面的事件。
 
 - {{domxref("WebSocket/close_event", "close")}}
-  - : 当一个 `WebSocket` 连接被关闭时触发。也可以通过 `onclose` 属性使用。
+  - : 当 `WebSocket` 连接被关闭时触发。也可以通过 `onclose` 属性使用。
 - {{domxref("WebSocket/error_event", "error")}}
-  - : 当一个 `WebSocket` 连接因错误（例如无法发送数据）而关闭时触发。也可以通过 `onerror` 属性使用。
+  - : 当 `WebSocket` 连接因错误（例如无法发送数据）而关闭时触发。也可以通过 `onerror` 属性使用。
 - {{domxref("WebSocket/message_event", "message")}}
   - : 当通过 `WebSocket` 收到数据时触发。也可以通过 `onmessage` 属性使用。
 - {{domxref("WebSocket/open_event", "open")}}
-  - : 当一个 `WebSocket` 连接成功时触发。也可以通过 `onopen` 属性使用。
+  - : 当 `WebSocket` 连接成功时触发。也可以通过 `onopen` 属性使用。
 
 ## 示例
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

同步更新 `WebSocket` 文档的中文翻译：

- 添加 `sourceCommit` 元数据
- 添加 `{{AvailableInWorkers}}` 和 `{{InheritanceDiagram}}` 宏
- 新增关于 WebSocket 无法应用背压的重要 NOTE 提示框
- 删除"常量"章节（英文原文已删除）
- 删除 `onclose`、`onerror`、`onmessage`、`onopen` 属性（英文原文已删除）
- 章节标题更新：`属性` → `实例属性`，`方法` → `实例方法`
- 翻译代码示例中的注释
- 更新片段标识为中文标题 ID

### Motivation

英文原文有较大更新，包括删除常量章节、删除事件处理属性、新增背压说明等，需要同步翻译以便中文读者了解最新内容。

### Additional details

**英文原文**：
- 文档名称：https://developer.mozilla.org/en-US/docs/Web/API/WebSocket

**上游提交**：
- 文档名称：fb311d7305937497570966f015d8cc0eb1a0c29c

**验证 URL**（GitHub 提交历史）：
- https://github.com/mdn/content/commits/main/files/en-us/web/api/websocket/index.md

### Related issues and pull requests

N/A
