### PR TITLE
zh-cn: update the translation of `Event.stopImmediatePropagation()`

### DIFF
--- a/files/zh-cn/web/api/event/stopimmediatepropagation/index.md
+++ b/files/zh-cn/web/api/event/stopimmediatepropagation/index.md
@@ -1,87 +1,128 @@
 ---
-title: event.stopImmediatePropagation
+title: "Event: stopImmediatePropagation() 方法"
+short-title: stopImmediatePropagation()
 slug: Web/API/Event/stopImmediatePropagation
+l10n:
+  sourceCommit: bc9f7bec1ab48f29d241e38a9f1598f783f6b60a
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("DOM")}}{{AvailableInWorkers}}
 
 {{domxref("Event")}} 接口的 **`stopImmediatePropagation()`** 方法阻止监听同一事件的其他事件监听器被调用。
 
-如果多个事件监听器被附加到相同元素的相同事件类型上，当此事件触发时，它们会按其被添加的顺序被调用。如果在其中一个事件监听器中执行 `stopImmediatePropagation()` ，那么剩下的事件监听器都不会被调用。
-
-> [!NOTE]
-> 注意与 `event.stopPropagation()` 之间的区别
+如果多个事件监听器被附加到相同元素的相同事件类型上，当此事件触发时，它们会按其被添加的顺序被调用。如果在其中一个事件监听器中执行 `stopImmediatePropagation()`，则该元素上以及任何其他元素上的剩余监听器都不会被调用。
 
 ## 语法
 
 ```js-nolint
-event.stopImmediatePropagation()
+stopImmediatePropagation()
 ```
+
+### 参数
+
+无。
+
+### 返回值
+
+无（{{jsxref("undefined")}}）。
 
 ## 示例
 
+### 比较事件阻止函数
+
+下面的示例包含三个嵌套的 div 元素，每个 div 内都有一个按钮。每个按钮都注册了三个 click 事件监听器，每个 div 也注册了一个 click 事件监听器。
+
+- 顶部按钮允许正常的事件传播。
+- 中间按钮在其第一个事件处理程序中调用 `stopPropagation()`。
+- 底部按钮在其第一个事件处理程序中调用 `stopImmediatePropagation()`。
+
+#### HTML
+
 ```html
-<!doctype html>
-<html>
-  <head>
-    <style>
-      p {
-        height: 30px;
-        width: 150px;
-        background-color: #ccf;
-      }
-      div {
-        height: 30px;
-        width: 150px;
-        background-color: #cfc;
-      }
-    </style>
-  </head>
-  <body>
+<h2>点击按钮</h2>
+<div>
+  外层 div<br />
+  <div>
+    中层 div<br />
     <div>
-      <p>paragraph</p>
+      内层 div<br />
+      <button>允许传播</button><br />
+      <button id="stopPropagation">停止传播</button><br />
+      <button id="stopImmediatePropagation">立即停止传播</button>
     </div>
-    <script>
-      const p = document.querySelector("p");
-      p.addEventListener(
-        "click",
-        (event) => {
-          alert("我是 p 元素上被绑定的第一个监听函数");
-        },
-        false,
-      );
-
-      p.addEventListener(
-        "click",
-        (event) => {
-          alert("我是 p 元素上被绑定的第二个监听函数");
-          event.stopImmediatePropagation();
-          // 执行 stopImmediatePropagation 方法，阻止 click 事件冒泡，并且阻止 p 元素上绑定的其他 click 事件的事件监听函数的执行。
-        },
-        false,
-      );
-
-      p.addEventListener(
-        "click",
-        (event) => {
-          alert("我是 p 元素上被绑定的第三个监听函数");
-          // 该监听函数排在上个函数后面，该函数不会被执行
-        },
-        false,
-      );
-
-      document.querySelector("div").addEventListener(
-        "click",
-        (event) => {
-          alert("我是 div 元素，我是 p 元素的上层元素");
-          // p 元素的 click 事件没有向上冒泡，该函数不会被执行
-        },
-        false,
-      );
-    </script>
-  </body>
-</html>
+  </div>
+</div>
+<pre></pre>
 ```
+
+#### CSS
+
+```css
+div {
+  display: inline-block;
+  padding: 10px;
+  background-color: white;
+  border: 2px solid black;
+  margin: 10px;
+}
+
+button {
+  width: 100px;
+  color: #000088;
+  padding: 5px;
+  background-color: white;
+  border: 2px solid black;
+  border-radius: 30px;
+  margin: 5px;
+}
+```
+
+#### JavaScript
+
+```js
+const outElem = document.querySelector("pre");
+
+/* 清空输出 */
+document.addEventListener(
+  "click",
+  () => {
+    outElem.textContent = "";
+  },
+  true,
+);
+
+/* 为按钮设置事件监听器 */
+document.querySelectorAll("button").forEach((elem) => {
+  for (let i = 1; i <= 3; i++) {
+    elem.addEventListener("click", (evt) => {
+      /* 在第一个事件处理程序中进行传播停止操作 */
+      if (i === 1 && elem.id) {
+        evt[elem.id]();
+        outElem.textContent += `事件处理程序 1 调用了 ${elem.id}()\n`;
+      }
+
+      outElem.textContent += `在"${elem.textContent}"按钮上处理了 click 事件 ${i}\n`;
+    });
+  }
+});
+
+/* 为 div 设置事件监听器 */
+document
+  .querySelectorAll("div")
+  .forEach((elem) =>
+    elem.addEventListener(
+      "click",
+      (evt) =>
+        (outElem.textContent += `在"${elem.firstChild.data.trim()}"上处理了 click 事件\n`),
+    ),
+  );
+```
+
+#### 结果
+
+每个 click 事件处理程序在被调用时都会显示一条状态消息。如果你按下中间的按钮，你会看到 `stopPropagation()` 允许在该按钮上注册的所有 click 事件处理程序执行，但阻止了 div 的 click 事件处理程序执行（通常情况下会执行）。然而，如果你按下底部的按钮，`stopImmediatePropagation()` 会停止调用该方法的事件之后的所有事件传播。
+
+{{ EmbedLiveSample("比较事件阻止函数", 500, 550) }}
 
 ## 规范
 

--- a/files/zh-cn/web/api/event/stopimmediatepropagation/index.md
+++ b/files/zh-cn/web/api/event/stopimmediatepropagation/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Event: stopImmediatePropagation() 方法"
+title: Event：stopImmediatePropagation() 方法
 short-title: stopImmediatePropagation()
 slug: Web/API/Event/stopImmediatePropagation
 l10n:
@@ -8,9 +8,9 @@ l10n:
 
 {{APIRef("DOM")}}{{AvailableInWorkers}}
 
-{{domxref("Event")}} 接口的 **`stopImmediatePropagation()`** 方法阻止监听同一事件的其他事件监听器被调用。
+{{domxref("Event")}} 接口的 **`stopImmediatePropagation()`** 方法阻止监听同一事件的其他监听器被调用。
 
-如果多个事件监听器被附加到相同元素的相同事件类型上，当此事件触发时，它们会按其被添加的顺序被调用。如果在其中一个事件监听器中执行 `stopImmediatePropagation()`，则该元素上以及任何其他元素上的剩余监听器都不会被调用。
+如果多个监听器被附加到相同元素的相同事件类型上，当此事件触发时，它们会按其被添加的顺序被调用。如果在其中一个监听器中执行 `stopImmediatePropagation()`，则该元素上以及任何其他元素上的剩余监听器都不会被调用。
 
 ## 语法
 
@@ -33,8 +33,8 @@ stopImmediatePropagation()
 下面的示例包含三个嵌套的 div 元素，每个 div 内都有一个按钮。每个按钮都注册了三个 click 事件监听器，每个 div 也注册了一个 click 事件监听器。
 
 - 顶部按钮允许正常的事件传播。
-- 中间按钮在其第一个事件处理程序中调用 `stopPropagation()`。
-- 底部按钮在其第一个事件处理程序中调用 `stopImmediatePropagation()`。
+- 中间按钮在其第一个事件处理器中调用 `stopPropagation()`。
+- 底部按钮在其第一个事件处理器中调用 `stopImmediatePropagation()`。
 
 #### HTML
 
@@ -95,13 +95,13 @@ document.addEventListener(
 document.querySelectorAll("button").forEach((elem) => {
   for (let i = 1; i <= 3; i++) {
     elem.addEventListener("click", (evt) => {
-      /* 在第一个事件处理程序中进行传播停止操作 */
+      /* 在第一个事件处理器中进行传播停止操作 */
       if (i === 1 && elem.id) {
         evt[elem.id]();
-        outElem.textContent += `事件处理程序 1 调用了 ${elem.id}()\n`;
+        outElem.textContent += `事件处理器 1 调用了 ${elem.id}()\n`;
       }
 
-      outElem.textContent += `在"${elem.textContent}"按钮上处理了 click 事件 ${i}\n`;
+      outElem.textContent += `在“${elem.textContent}”按钮上处理了 click 事件 ${i}\n`;
     });
   }
 });
@@ -113,14 +113,14 @@ document
     elem.addEventListener(
       "click",
       (evt) =>
-        (outElem.textContent += `在"${elem.firstChild.data.trim()}"上处理了 click 事件\n`),
+        (outElem.textContent += `在“${elem.firstChild.data.trim()}”上处理了 click 事件\n`),
     ),
   );
 ```
 
 #### 结果
 
-每个 click 事件处理程序在被调用时都会显示一条状态消息。如果你按下中间的按钮，你会看到 `stopPropagation()` 允许在该按钮上注册的所有 click 事件处理程序执行，但阻止了 div 的 click 事件处理程序执行（通常情况下会执行）。然而，如果你按下底部的按钮，`stopImmediatePropagation()` 会停止调用该方法的事件之后的所有事件传播。
+每个 click 事件处理器在被调用时都会显示一条状态消息。如果你按下中间的按钮，你会看到 `stopPropagation()` 允许在该按钮上注册的所有 click 事件处理器执行，但阻止了 div 的 click 事件处理器执行（通常情况下会执行）。然而，如果你按下底部的按钮，`stopImmediatePropagation()` 会停止调用该方法的事件之后的所有事件传播。
 
 {{ EmbedLiveSample("比较事件阻止函数", 500, 550) }}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

同步更新 `Event.stopImmediatePropagation()` 文档的中文翻译：

- 更新 `title` 格式为标准格式
- 添加 `short-title` 和 `sourceCommit` 元数据
- 添加 `{{AvailableInWorkers}}` 宏
- 新增 `### 参数` 和 `### 返回值` 章节
- 替换示例为英文原文的交互式示例，比较 `stopPropagation()` 和 `stopImmediatePropagation()` 的区别
- 添加 `{{EmbedLiveSample}}` 宏
- 翻译所有代码注释和字符串

### Motivation

英文原文有较大更新，包括新增交互式示例展示两种方法的区别，需要同步翻译以便中文读者了解最新内容。

### Additional details

**英文原文**：
- 文档名称：https://developer.mozilla.org/en-US/docs/Web/API/Event/stopImmediatePropagation

**上游提交**：
- 文档名称：bc9f7bec1ab48f29d241e38a9f1598f783f6b60a

**验证 URL**（GitHub 提交历史）：
- https://github.com/mdn/content/commits/main/files/en-us/web/api/event/stopimmediatepropagation/index.md

### Related issues and pull requests

N/A
