### PR TITLE
[es] Update Service Worker API translations

### DIFF
--- a/files/es/web/api/service_worker_api/index.md
+++ b/files/es/web/api/service_worker_api/index.md
@@ -1,127 +1,151 @@
 ---
 title: Service Worker API
 slug: Web/API/Service_Worker_API
+l10n:
+  sourceCommit: 73ca80b86a348f88f51fdb8f9441c114b76e94f1
 ---
 
-{{DefaultAPISidebar}}
+{{DefaultAPISidebar("Service Workers API")}}{{AvailableInWorkers}}
 
-Los Service workers actúan esencialmente como proxy servers asentados entre las aplicaciones web, el navegador y la red (cuando está accesible). Están destinados, entre otras cosas, a permitir la creación de experiencias offline efectivas, interceptando peticiones de red y realizando la acción apropiada si la conexión de red está disponible y hay disponibles contenidos actualizados en el servidor. También permitirán el acceso a notificaciones tipo push y APIs de sincronización en segundo plano.
-
-## Conceptos y uso de Service worker
-
-Un service worker es un [worker](/es/docs/Web/API/Worker) manejado por eventos registrado para una fuente y una ruta. Consiste en un fichero JavaScript que controla la página web (o el sitio) con el que está asociado, interceptando y modificando la navegación y las peticiones de recursos, y cacheando los recursos de manera muy granular para ofrecer un control completo sobre cómo la aplicación debe comportarse en ciertas situaciones (la mas obvia es cuando la red no está disponible).
-
-Un service worker se ejecuta en un contexto worker: por lo tanto no tiene acceso al DOM, y se ejecuta en un hilo distinto al JavaScript principal de la aplicación, de manera que no es bloqueante. Está diseñado para ser completamente asíncrono, por lo que APIs como el [XHR](/es/docs/Web/API/XMLHttpRequest) asíncrono y [localStorage](/es/docs/Web/API/Web_Storage_API) no se pueden usar dentro de un service worker.
-
-Los service workers solo funcionan sobre HTTPS, por razones de seguridad. Modificar las peticiones de red en abierto permitiría ataques man in the middle realmente peligrosos. En Firefox, las APIs de service worker se ocultan y no pueden ser empleadas cuando el usuario está en [modo de navegación en privado](https://support.mozilla.org/en-US/kb/private-browsing-use-firefox-without-history).
+Los service workers actúan esencialmente como servidores proxy que se sitúan entre las aplicaciones web, el navegador y la red (cuando está disponible). Están destinados, entre otras cosas, a permitir la creación de experiencias offline efectivas, interceptar peticiones de red y realizar la acción apropiada según si la red está disponible y si hay contenidos actualizados en el servidor. También permiten el acceso a notificaciones push y APIs de sincronización en segundo plano.
 
 > [!NOTE]
-> Los Service Workers mejoran los intentos anteriores en este área tal como [AppCache](https://alistapart.com/article/application-cache-is-a-douchebag) puesto que no hacen suposiciones sobre qué se está intentando hacer para luego tener que cortar cuando las suposiciones no son correctas; hay control granular sobre todos los aspectos.
+> Los service workers son un tipo de web worker. Consulte [Web workers](/es/docs/Web/API/Web_Workers_API) para información general sobre los tipos de workers y casos de uso.
+
+## Conceptos y uso de service workers
+
+Un service worker es un [worker](/es/docs/Web/API/Worker) controlado por eventos, registrado para un origen y una ruta. Consiste en un archivo JavaScript que puede controlar la página web o sitio con el que está asociado, interceptando y modificando las peticiones de navegación y recursos, y almacenando en caché los recursos de manera muy granular para ofrecer un control completo sobre cómo se comporta la aplicación en ciertas situaciones (la más obvia es cuando la red no está disponible).
+
+Los service workers se ejecutan en un contexto worker: por lo tanto, no tienen acceso al DOM y se ejecutan en un hilo distinto al JavaScript principal que alimenta la aplicación. Son no bloqueantes y están diseñados para ser completamente asíncronos. Como consecuencia, APIs como [XHR](/es/docs/Web/API/XMLHttpRequest) síncrono y [Web Storage](/es/docs/Web/API/Web_Storage_API) no se pueden usar dentro de un service worker.
+
+Los service workers no pueden importar módulos JavaScript dinámicamente, y [`import()`](/es/docs/Web/JavaScript/Reference/Operators/import) lanzará un error si se invoca en el ámbito global de un service worker. Las importaciones estáticas usando la sentencia [`import`](/es/docs/Web/JavaScript/Reference/Statements/import) sí están permitidas.
+
+Los service workers solo están disponibles en [contextos seguros](/es/docs/Web/Security/Defenses/Secure_Contexts): esto significa que su documento se sirve sobre HTTPS, aunque los navegadores también tratan `http://localhost` como un contexto seguro para facilitar el desarrollo local. Las conexiones HTTP son susceptibles a inyección de código malicioso mediante ataques de {{Glossary("MitM", "intermediario")}}, y tales ataques podrían ser peores si se permitiera acceso a estas potentes APIs.
 
 > [!NOTE]
-> Los Service workers hace un uso intensivo de las [promesas](/es/docs/Web/JavaScript/Reference/Global_Objects/Promise), por lo que generalmente esperarán a que lleguen las respuestasas correspondientes, tras lo cual responderán con una acción de éxito o de fracaso. La arquitectura de promesas es ideal en este caso.
+> En Firefox, para realizar pruebas se pueden ejecutar service workers sobre HTTP (de forma insegura); simplemente marque la opción **Habilitar Service Workers sobre HTTP (cuando la caja de herramientas esté abierta)** en el menú de opciones/engranaje de las herramientas de desarrollo de Firefox.
+
+> [!NOTE]
+> A diferencia de intentos anteriores en esta área como [AppCache](https://alistapart.com/article/application-cache-is-a-douchebag/), los service workers no hacen suposiciones sobre lo que se intenta hacer para luego fallar cuando esas suposiciones no son exactamente correctas. En su lugar, los service workers ofrecen un control mucho más granular.
+
+> [!NOTE]
+> Los service workers hacen un uso intensivo de las [promesas](/es/docs/Web/JavaScript/Reference/Global_Objects/Promise), ya que generalmente esperarán a que lleguen las respuestas y luego responderán con una acción de éxito o fracaso. La arquitectura de promesas es ideal para esto.
 
 ### Registro
 
-Un service worker se registra primero mediante el método {{domxref("ServiceWorkerContainer.register()")}}. Si ha habido éxito, el service worker se descargará al cliente e intentará la instalación/activación (ver más abajo) de las URLs accedidas por el usuario dentro de todo su origen de datos, o dentro de algún subconjunto especificado por el autor.
+Un service worker se registra primero mediante el método {{DOMxRef("ServiceWorkerContainer.register()")}}. Si tiene éxito, el service worker se descargará en el cliente e intentará la instalación/activación (ver más abajo) para las URLs accedidas por el usuario dentro de todo el origen, o un subconjunto especificado.
 
 ### Descarga, instalación y activación
 
-En este punto, su service worker observará el siguiente ciclo de vida:
+En este punto, el service worker seguirá el siguiente ciclo de vida:
 
 1. Descarga
 2. Instalación
 3. Activación
 
-El service worker se descaga inmediatamente cuando un usuario accede por primera vez a un sitio controlado por el mismo.
+El service worker se descarga inmediatamente cuando un usuario accede por primera vez a un sitio/página controlados por un service worker.
 
-Después de esto se descarga cada 24 horas aproximadamente. Se puede descargar con más frecuencia, pero **debe** ser descargado cada 24 horas para prevenir que una mala programación sea molesta durante mucho tiempo.
+Después de eso, se actualiza cuando:
 
-La instalación se realiza cuando el fichero descargado es nuevo, es decir, diferente a otro service worker existente (comparado byte a byte), o si es el primero descargado para esta página/sitio.
+- Se produce una navegación a una página dentro del alcance.
+- Se dispara un evento en el service worker y no se ha descargado en las últimas 24 horas.
 
-Si es la primera vez que el service worker está disponible se intenta la instalación, y tras una instalación satisfactoria se activa.
+La instalación se intenta cuando el archivo descargado resulta ser nuevo, ya sea diferente a un service worker existente (comparado byte a byte), o el primer service worker encontrado para esta página/sitio.
 
-Si ya existe un service worker disponible la nueva versión se instala en segundo plano, pero no se activa -en ese momento se llama _worker in waiting._ Sólo se activa cuando ya no hay más páginas cargadas que utilicen el antiguo service worker. En cuanto no hay más páginas de este estilo cargadas, el nuevo service worker se activa (pasando a ser el _active worker)._ La activación se puede realizar antes mediante {{domxref("ServiceWorkerGlobalScope.skipWaiting()")}} y las páginas existentes se pueden llamar por el active worker usando {{domxref("Clients.claim()")}}.
+Si es la primera vez que un service worker está disponible, se intenta la instalación; tras una instalación exitosa, se activa.
 
-Presta atención a {{domxref("InstallEvent")}}; es habitual preparar tu service worker para usarlo cuando se dispara, por ejemplo creando una caché que utilice la API incorporada de almacenamiento, y colocando los contenidos dentro de ella para poder usarlos con la aplicación offline.
+Si ya hay un service worker existente disponible, la nueva versión se instala en segundo plano, pero aún no se activa; en ese momento se le llama _worker en espera_. Solo se activa cuando ya no hay páginas cargadas que aún usen el service worker antiguo. En cuanto no quedan más páginas por cargar, el nuevo service worker se activa (convirtiéndose en el _worker activo_). La activación puede ocurrir antes usando {{DOMxRef("ServiceWorkerGlobalScope.skipWaiting()")}} y las páginas existentes pueden ser reclamadas por el worker activo usando {{DOMxRef("Clients.claim()")}}.
 
-También hay un evento `activate`. El momento en el que este evento se activa es, en general, un bueno momento para limpiar viejas cachés y demás cosas asociadas con la versión previa de tu service worker.
+Se puede escuchar el evento {{domxref("ServiceWorkerGlobalScope/install_event", "install")}}; una acción estándar es preparar el service worker para su uso cuando se dispara, por ejemplo creando una caché usando la API de almacenamiento incorporada, y colocando dentro los recursos que se necesitarán para ejecutar la aplicación sin conexión.
 
-Tu service worker puede responder a las peticiones usando el evento {{domxref("FetchEvent")}}. Puedes modificar la respuesta a estas peticiones de la manera que quieras, usando el método {{domxref("FetchEvent.respondWith") }}.
+También existe un evento {{domxref("ServiceWorkerGlobalScope/activate_event", "activate")}}. El momento en que se dispara este evento es generalmente un buen momento para limpiar cachés antiguas y otras cosas asociadas con la versión anterior del service worker.
+
+El service worker puede responder a peticiones usando el evento {{DOMxRef("FetchEvent")}}. Se puede modificar la respuesta a estas peticiones de cualquier manera deseada, usando el método {{DOMxRef("FetchEvent.respondWith()")}}.
 
 > [!NOTE]
-> Dado que `oninstall`/`onactivate` puede tardar un poco en completarse, la especificación de service worker spec provee un método `waitUntil` que, cuando es llamado `oninstall` o `onactivate`, pasa una promesa. Los eventos funcionales no se envían al service worker hasta que la promesa se resuelve con éxito.
+> Dado que los eventos `install`/`activate` pueden tardar un tiempo en completarse, la especificación de service workers proporciona un método {{domxref("ExtendableEvent.waitUntil", "waitUntil()")}}. Una vez invocado en eventos `install` o `activate` con una promesa, los eventos funcionales como `fetch` y `push` esperarán hasta que la promesa se resuelva exitosamente.
 
-Para un tutorial completo que muestra cómo construir tu primer ejemplo básico, lee [Using Service Workers](/es/docs/Web/API/Service_Worker_API/Using_Service_Workers).
+Para un tutorial completo que muestra cómo construir un primer ejemplo básico, lea [Uso de Service Workers](/es/docs/Web/API/Service_Worker_API/Using_Service_Workers).
 
-## Otras posibilidades
+### Uso de enrutamiento estático para controlar cómo se obtienen los recursos
 
-Los service workers también pueden usarse para cosas como:
+Los service workers pueden incurrir en un costo de rendimiento innecesario: cuando una página se carga por primera vez después de un tiempo, el navegador tiene que esperar a que el service worker se inicie y ejecute para saber qué contenido cargar y si debe provenir de una caché o de la red.
 
-- Sincronización de datos en background
-- Responder a peticiones de recursos desde otros orígenes
-- Recibir actualizaciones centralizadas de datos costosos de calcular tales como geolocalización o giroscopio, de manera que muchas páginas puedan hacer uso de un mismo conjunto de datos
-- Compilación Client-side y gestión de dependencias de CoffeeScript, less, CJS/AMD modules, etc. para desarrollo
-- Enlace para servicios en background
-- Plantillas personalizadas basadas en ciertos patrones URL
-- Mejoras de rendimiento, por ejemplo pre-fetching de recursos que es probable que el usuario requiera en un futuro próximo, como las próximas imágenes de un album de fotos.
+Si ya se sabe de antemano de dónde deben obtenerse ciertos contenidos, se puede omitir el service worker por completo y obtener los recursos de forma inmediata. El método {{domxref("InstallEvent.addRoutes()")}} se puede usar para implementar este caso de uso y más.
 
-En el futuro, los service workers podrán hacer una cantidad de cosas útiles para la plataforma web que estarán muy próximos a las aplicaciones nativas. Interesantement, otras especificacions pueden comenzar y lo harán a hacer uso del contexto de service worker, por ejemplo:
+## Otras ideas de casos de uso
 
-- [Sincronización en background](https://github.com/slightlyoff/BackgroundSync): Pone en marcha un service worker aunque el usuario no esté en el sitio de manera que las cachés se puedan actualizar, etc.
-- [Reacción a mensajes tipo push](/es/docs/Web/API/Push_API): Pone en marcha un service worker para enviar a los usuarios un mensaje para notificarles de que hay disponible nuevos contenidos.
-- Reacción ante una fecha y hora determinados.
-- Creación de geo-fronteras
+Los service workers también están pensados para usarse en cosas como:
+
+- Sincronización de datos en segundo plano.
+- Responder a peticiones de recursos desde otros orígenes.
+- Recibir actualizaciones centralizadas de datos costosos de calcular, como geolocalización o giroscopio, de manera que múltiples páginas puedan usar un mismo conjunto de datos.
+- Compilación del lado del cliente y gestión de dependencias de CoffeeScript, Less, módulos CJS/AMD, etc., para desarrollo.
+- Hooks para servicios en segundo plano.
+- Plantillas personalizadas basadas en ciertos patrones de URL.
+- Mejoras de rendimiento, por ejemplo, pre-obtención de recursos que el usuario probablemente necesitará pronto, como las siguientes imágenes de un álbum de fotos.
+- Simulación de APIs.
+
+En el futuro, los service workers podrán hacer varias cosas útiles para la plataforma web que la acercarán a la viabilidad de aplicaciones nativas. Resulta interesante que otras especificaciones pueden y van a empezar a hacer uso del contexto de service workers, por ejemplo:
+
+- [Sincronización en segundo plano](https://github.com/WICG/background-sync): Iniciar un service worker aunque no haya usuarios en el sitio, para que las cachés se puedan actualizar, etc.
+- [Reacción a mensajes push](/es/docs/Web/API/Push_API): Iniciar un service worker para enviar a los usuarios un mensaje indicando que hay nuevo contenido disponible.
+- Reacción ante una fecha y hora determinadas.
+- Entrada en una geocerca.
 
 ## Interfaces
 
-- {{domxref("Cache") }}
-  - : Representa el almacenamiento para un par de objetos {{domxref("Request")}} / {{domxref("Response")}} que son cacheados como parte del ciclo de vida de {{domxref("ServiceWorker")}}.
-- {{domxref("CacheStorage") }}
-  - : Representa el almacenamiento de objetos {{domxref("Cache")}}. Proporciona un directorio maestro de todos los nombres de caché a los que puede acceder un {{domxref("ServiceWorker")}} y mantiene un mapa de nombres (strings) correspondientes a objetos {{domxref("Cache")}}.
-- {{domxref("Client") }}
-  - : Representa el ámbito de un cliente service worker. Un cliente service worker es bien un documento en un contexto de navador, bien un {{domxref("SharedWorker")}}, que está controlado por un worker activo.
-- {{domxref("Clients") }}
-  - : Representa un contenedor para una lista de objetos {{domxref("Client")}}; principal vía de acceso de los clientes service worker al origen actual.
-- {{domxref("ExtendableEvent") }}
-  - : Extiende el tiempo de vida de los eventos `install` y `activate` lanzados en {{domxref("ServiceWorkerGlobalScope")}} como parte del ciclo de vida del service worker. Esto asegura que cualquier evento funcional (como {{domxref("FetchEvent")}}) no se despachan al {{domxref("ServiceWorker")}} hasta que actualiza los esquemas de base de datos, borra entradas de caché antiguas, etc.
-- {{domxref("ExtendableMessageEvent") }}
-  - : Es el objeto evento de un [`message`](</es/docs/Web/Reference/Events/message_(ServiceWorker)>) lanzado en un service worker (cuando se recibe un mensaje en el {{domxref("ServiceWorkerGlobalScope")}} desde otro contexto) — extiende el tiempo de vida de tales eventos.
-- {{domxref("FetchEvent") }}
-  - : Parametro pasado en el controlador {{domxref("ServiceWorkerGlobalScope.onfetch")}}, `FetchEvent` representa una acción de consulta (fetch) despachada en el {{domxref("ServiceWorkerGlobalScope")}} de un {{domxref("ServiceWorker")}}. Contiene información sobre la petición y respuesta resultante, y proporciona el método {{domxref("FetchEvent.respondWith", "FetchEvent.respondWith()")}}, que nos permite proporcionar una respuesta arbitraria a la página controlada.
-- {{domxref("InstallEvent") }}
-  - : Parámetro pasado en el controlador {{domxref("ServiceWorkerGlobalScope.oninstall", "oninstall")}}, el interfaz `InstallEvent` representa una acctión de instalación realizada en el {{domxref("ServiceWorkerGlobalScope")}} de un {{domxref("ServiceWorker")}}. Como hijo de {{domxref("ExtendableEvent")}}, asegura que los eventos funcionales como {{domxref("FetchEvent")}} no se llevan a cabo durante la instalación.
-- {{domxref("Navigator.serviceWorker") }}
-  - : Devuelve un objeto {{domxref("ServiceWorkerContainer")}}, que proporciona acceso al registro, eliminación, actualización y comunicación con los objetos {{domxref("ServiceWorker")}} para el [documento asociado](https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window).
-- {{domxref("NotificationEvent") }}
-  - : Parámetro pasado en el controlador {{domxref("ServiceWorkerGlobalScope.onnotificationclick", "onnotificationclick")}}, el interfaz `NotificationEvent` representa una notificación del evento click ejecutado en {{domxref("ServiceWorkerGlobalScope")}} de un {{domxref("ServiceWorker")}}.
-- {{domxref("ServiceWorker") }}
-  - : Representa un service worker. Multiples contextos de navegación (e.g. pages, workers, etc.) se pueden asociar con el mismo objeto `ServiceWorker`.
-- {{domxref("ServiceWorkerContainer") }}
-  - : Proporciona un objeto que representa el service worker como una unidad en el ecosistema de red, incluyendo servicios para registrar, eliminar y actualizar los service workers, y acceder al estado de los service workers y sus registros.
-- {{domxref("ServiceWorkerGlobalScope") }}
-  - : Representa el contexto global de ejecución de un service worker.
-- {{domxref("ServiceWorkerMessageEvent")}} {{deprecated_inline}}
-  - : Representa un mensaje envaido a un{{domxref("ServiceWorkerGlobalScope")}}. Observese que este interfaz está considerado obsoleto en navegadores modernos. Los mensajes de service worker no podrán utilizar el interfaz {{domxref("MessageEvent")}}, por consistencia con otras características de mensajería web.
-- {{domxref("ServiceWorkerRegistration") }}
-  - : Representa un registro service worker.
-- {{domxref("SyncEvent")}} {{non-standard_inline}}
-  - : El interfaz SyncEvent representa una acción sync ejecutada en el {{domxref("ServiceWorkerGlobalScope")}} de un ServiceWorker.
-- {{domxref("SyncManager")}} {{non-standard_inline}}
-  - : Proporciona un interfaz para registrar y listar registros sync.
-- {{domxref("WindowClient") }}
-  - : Representa el ámbito de un cliente service worker que es un documento en un contexto de navegador, controlado por un worker activo. Es un tipo especial de objeto {{domxref("Client")}}, con algunos métodos y propiedades adicionales disponibles.
+- {{DOMxRef("Cache")}}
+  - : Representa el almacenamiento para pares de objetos {{DOMxRef("Request")}} / {{DOMxRef("Response")}} que se almacenan en caché como parte del ciclo de vida del {{DOMxRef("ServiceWorker")}}.
+- {{DOMxRef("CacheStorage")}}
+  - : Representa el almacenamiento para objetos {{DOMxRef("Cache")}}. Proporciona un directorio maestro de todas las cachés nombradas a las que puede acceder un {{DOMxRef("ServiceWorker")}}, y mantiene una correspondencia de nombres de cadena a los objetos {{DOMxRef("Cache")}} correspondientes.
+- {{DOMxRef("Client")}}
+  - : Representa el ámbito de un cliente de service worker. Un cliente de service worker es un documento en un contexto de navegador o un {{DOMxRef("SharedWorker")}}, controlado por un worker activo.
+- {{DOMxRef("Clients")}}
+  - : Representa un contenedor para una lista de objetos {{DOMxRef("Client")}}; la vía principal para acceder a los clientes de service worker activos en el origen actual.
+- {{DOMxRef("ExtendableEvent")}}
+  - : Extiende el tiempo de vida de los eventos `install` y `activate` despachados en el {{DOMxRef("ServiceWorkerGlobalScope")}}, como parte del ciclo de vida del service worker. Esto asegura que los eventos funcionales (como {{DOMxRef("FetchEvent")}}) no se despachan al {{DOMxRef("ServiceWorker")}} hasta que actualiza los esquemas de base de datos, elimina entradas de caché obsoletas, etc.
+- {{DOMxRef("ExtendableMessageEvent")}}
+  - : El objeto de evento de un evento {{domxref("ServiceWorkerGlobalScope/message_event", "message")}} disparado en un service worker (cuando se recibe un mensaje de canal en el {{DOMxRef("ServiceWorkerGlobalScope")}} desde otro contexto), extiende el tiempo de vida de tales eventos.
+- {{DOMxRef("FetchEvent")}}
+  - : El parámetro pasado al controlador {{DOMxRef("ServiceWorkerGlobalScope.fetch_event", "onfetch")}}, `FetchEvent` representa una acción de fetch despachada en el {{DOMxRef("ServiceWorkerGlobalScope")}} de un {{DOMxRef("ServiceWorker")}}. Contiene información sobre la petición y la respuesta resultante, y proporciona el método {{DOMxRef("FetchEvent.respondWith", "FetchEvent.respondWith()")}}, que permite proporcionar una respuesta arbitraria a la página controlada.
+- {{DOMxRef("InstallEvent")}}
+  - : El parámetro pasado a la función controladora de un evento {{DOMxRef("ServiceWorkerGlobalScope.install_event", "install")}}, la interfaz `InstallEvent` representa una acción de instalación despachada en el {{DOMxRef("ServiceWorkerGlobalScope")}} de un {{DOMxRef("ServiceWorker")}}. Como hijo de {{DOMxRef("ExtendableEvent")}}, asegura que los eventos funcionales como {{DOMxRef("FetchEvent")}} no se despachan durante la instalación.
+- {{DOMxRef("NavigationPreloadManager")}}
+  - : Proporciona métodos para gestionar la precarga de recursos con un service worker.
+- {{DOMxRef("ServiceWorker")}}
+  - : Representa un service worker. Múltiples contextos de navegación (por ejemplo, páginas, workers, etc.) pueden estar asociados con el mismo objeto `ServiceWorker`.
+- {{DOMxRef("ServiceWorkerContainer")}}
+  - : Proporciona un objeto que representa el service worker como una unidad global en el ecosistema de red, incluyendo servicios para registrar, dar de baja y actualizar service workers, y acceder al estado de los service workers y sus registros.
+- {{DOMxRef("ServiceWorkerGlobalScope")}}
+  - : Representa el contexto de ejecución global de un service worker.
+- {{DOMxRef("ServiceWorkerRegistration")}}
+  - : Representa un registro de service worker.
+- {{DOMxRef("WindowClient")}}
+  - : Representa el ámbito de un cliente de service worker que es un documento en un contexto de navegador, controlado por un worker activo. Es un tipo especial de objeto {{DOMxRef("Client")}}, con algunos métodos y propiedades adicionales disponibles.
+
+### Extensiones a otras interfaces
+
+- {{DOMxRef("Window.caches")}} y {{domxref("WorkerGlobalScope.caches")}}
+  - : Devuelve el objeto {{domxref("CacheStorage")}} asociado al contexto actual.
+- {{DOMxRef("Navigator.serviceWorker")}} y {{DOMxRef("WorkerNavigator.serviceWorker")}}
+  - : Devuelve un objeto {{DOMxRef("ServiceWorkerContainer")}}, que proporciona acceso al registro, eliminación, actualización y comunicación con los objetos {{DOMxRef("ServiceWorker")}} para el [documento asociado](https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window).
 
 ## Especificaciones
 
 {{Specifications}}
 
-## Ver también
+## Véase también
 
-- [ServiceWorker Cookbook](https://github.com/mdn/serviceworker-cookbook)
-- [Using Service Workers](/es/docs/Web/API/Service_Worker_API/Using_Service_Workers)
-- [Service workers basic code example](https://github.com/mdn/sw-test)
-- [Is ServiceWorker ready?](https://jakearchibald.github.io/isserviceworkerready/)
-- [Promises](/es/docs/Web/JavaScript/Reference/Global_Objects/Promise)
-- [Using web workers](/es/docs/Web/API/Web_Workers_API/Using_web_workers)
-- [Best Practices for using the VARY header](https://www.fastly.com/blog/best-practices-for-using-the-vary-header)
+- [Uso de Service Workers](/es/docs/Web/API/Service_Worker_API/Using_Service_Workers)
+- [Ciclo de vida de Service Worker](https://web.dev/articles/service-worker-lifecycle)
+- [Ejemplo básico de código de service worker](https://github.com/mdn/dom-examples/tree/main/service-worker/simple-service-worker)
+- APIs web relacionadas con Service Worker API:
+  - {{domxref("Background Fetch API", "", "", "nocode")}}
+  - {{domxref("Background Synchronization API", "", "", "nocode")}}
+  - {{domxref("Content Index API", "", "", "nocode")}}
+  - {{domxref("Cookie Store API", "", "", "nocode")}}
+  - {{domxref("Notifications API", "", "", "nocode")}}
+  - {{domxref("Web-based Payment Handler API", "", "", "nocode")}}
+  - {{domxref("Push API", "", "", "nocode")}}
+  - {{domxref("Web Periodic Background Synchronization API", "", "", "nocode")}}

--- a/files/es/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/es/web/api/service_worker_api/using_service_workers/index.md
@@ -1,56 +1,60 @@
 ---
-title: Usar Service Workers
+title: Uso de Service Workers
 slug: Web/API/Service_Worker_API/Using_Service_Workers
+l10n:
+  sourceCommit: 09d8ff096be97b28ea415fc4c68fb1cff0ff8af9
 ---
 
-{{DefaultAPISidebar}}
+{{DefaultAPISidebar("Service Workers API")}}
 
-Este artículo brinda información sobre cómo comenzar con el _service worker_, incluida la arquitectura básica, el registro de un _service worker_, el proceso de instalación y activación de un nuevo _service worker_, la actualización de tu _service worker_, el control de caché y las respuestas personalizadas, todo en el contexto de una aplicación simple, con funcionalidad fuera de línea.
+Este artículo proporciona información sobre cómo comenzar con los service workers, incluyendo la arquitectura básica, el registro de un service worker, el proceso de instalación y activación de un nuevo service worker, la actualización del service worker, el control de caché y las respuestas personalizadas, todo en el contexto de una aplicación con funcionalidad sin conexión.
 
-## La premisa del service worker
+## La premisa de los service workers
 
-Un problema primordial del que los usuarios de la web han adolecido durante años es la pérdida de conectividad. La mejor aplicación web del mundo proporcionará una experiencia de usuario terrible si no la puedes descargar. Ha habido varios intentos de crear tecnologías para resolver este problema, y algunos de los problemas se han resuelto. Pero el problema primordial es que todavía no existe un buen mecanismo de control general para el almacenamiento en caché de activos y las solicitudes de red personalizadas.
+Un problema predominante que los usuarios web han sufrido durante años es la pérdida de conectividad. La mejor aplicación web del mundo proporcionará una experiencia de usuario terrible si no se puede descargar. Ha habido varios intentos de crear tecnologías para resolver este problema, y algunos de los problemas se han resuelto. Pero el problema predominante es que no existía un buen mecanismo de control general para el almacenamiento en caché de recursos y las solicitudes de red personalizadas.
 
-El intento anterior, _AppCache_, parecía ser una buena idea porque te permitía especificar activos para almacenar en caché con mucha facilidad. Sin embargo, hizo muchas suposiciones sobre lo que estabas tratando de hacer y luego se rompió horriblemente cuando tu aplicación no siguió exactamente esas suposiciones. Lee el documento de Jake Archibald (desafortunadamente mal titulado pero bien escrito) [Application Cache is a Douchebag](https://alistapart.com/article/application-cache-is-a-douchebag/) para obtener más detalles.
+Los service workers solucionan estos problemas. Usando un service worker se puede configurar una aplicación para usar recursos almacenados en caché primero, proporcionando así una experiencia predeterminada incluso sin conexión, antes de obtener más datos de la red (comúnmente conocido como "offline first"). Esto ya está disponible con las aplicaciones nativas, que es una de las principales razones por las que las aplicaciones nativas se eligen a menudo en lugar de las aplicaciones web.
 
-> [!NOTE]
-> A partir de Firefox 84, se eliminó _AppCache_ ([Error 1619673 en Firefox](https://bugzil.la/1619673)). También se ha [eliminado](https://bugs.chromium.org/p/chromium/issues/detail?id=582750) de Chromium 95 y está obsoleto en Safari.
+Un service worker funciona como un servidor proxy, permitiendo modificar las solicitudes y respuestas reemplazándolas con elementos de su propia caché.
 
-El _service worker_ finalmente debería solucionar estos problemas. La sintaxis del _service worker_ es más compleja que la de _AppCache_, pero la compensación es que puedes usar JavaScript para controlar su comportamiento implícito en _AppCache_ con un buen grado de fina granularidad, lo que te permite manejar este problema y muchos más. Al usar un _service worker_, puedes configurar fácilmente una aplicación para usar activos almacenados en caché primero, proporcionando así una experiencia predeterminada incluso cuando estás desconectado, antes de obtener más datos de la red (comúnmente conocido como [Primero sin conexión](https://offlinefirst.org/)). Esto ya está disponible con las aplicaciones nativas, que es una de las principales razones por las que las aplicaciones nativas a menudo se eligen en lugar de las aplicaciones web.
+## Configuración para trabajar con service workers
 
-## Configuración para jugar con el service worker
-
-En estos días, el _service worker_ está habilitado de forma predeterminada en todos los navegadores modernos. Para ejecutar código con el _service worker_, deberás entregar tu código a través de HTTPS: el _service worker_, por razones de seguridad, está restringido a ejecutarse a través de HTTPS. Por lo tanto, GitHub es un buen lugar para alojar experimentos, ya que admite HTTPS. Para facilitar el desarrollo local, los navegadores también consideran `localhost` como un origen seguro.
+Los service workers están habilitados de forma predeterminada en todos los navegadores modernos. Para ejecutar código que use service workers, se necesita servir el código a través de HTTPS, ya que los service workers están restringidos a ejecutarse sobre HTTPS por razones de seguridad. Es necesario un servidor que soporte HTTPS. Para alojar experimentos, se puede usar un servicio como GitHub, Netlify, Vercel, etc. Para facilitar el desarrollo local, los navegadores también consideran `localhost` como un origen seguro.
 
 ## Arquitectura básica
 
-Con el _service worker_, generalmente se observan los siguientes pasos para la configuración básica:
+Con los service workers, generalmente se observan los siguientes pasos para la configuración básica:
 
-1. La URL del _service worker_ se obtiene y registra a través de {{domxref("serviceWorkerContainer.register()")}}.
-2. Si tiene éxito, el _service worker_ se ejecuta en {{domxref("ServiceWorkerGlobalScope") }}; esto es básicamente un tipo especial de contexto de trabajo, que se ejecuta fuera del hilo principal de ejecución del script, sin acceso al DOM.
-3. El _service worker_ ahora está listo para procesar eventos.
-4. Se intenta la instalación del _worker_ cuando se accede posteriormente a las páginas controladas por el _service worker_. Un evento de instalación siempre es el primero que se envía a un _service worker_ (esto se puede usar para iniciar el proceso de completar una IndexedDB «base de datos indexada» y almacenar en caché los activos del sitio). Este es realmente el mismo tipo de procedimiento que instalar una aplicación nativa o Firefox OS: hace que todo esté disponible para usar sin conexión.
-5. Cuando se completa el controlador `oninstall`, se considera que el _service worker_ está instalado.
-6. Lo siguiente es la activación. Cuando se instala el _service worker_, recibe un evento de activación. El uso principal de `onactivate` es para la limpieza de los recursos utilizados en versiones anteriores de un script del _service worker_.
-7. El _service worker_ ahora controlará las páginas, pero solo aquellas que se abran después de que `register()` tenga éxito. En otras palabras, los documentos se deberán volver a cargar para controlarlos realmente, porque un documento comienza con o sin un _service worker_ y lo mantiene durante toda su vida.
+1. Se obtiene el código del service worker y se registra usando [`serviceWorkerContainer.register()`](/es/docs/Web/API/ServiceWorkerContainer/register). Si tiene éxito, el service worker se ejecuta en un [`ServiceWorkerGlobalScope`](/es/docs/Web/API/ServiceWorkerGlobalScope); esto es básicamente un tipo especial de contexto worker, que se ejecuta fuera del hilo principal de ejecución del script, sin acceso al DOM. El service worker ahora está listo para procesar eventos.
+2. Se lleva a cabo la instalación. Un evento `install` siempre es el primero enviado a un service worker (esto se puede usar para iniciar el proceso de llenar un IndexedDB y almacenar en caché los recursos del sitio). Durante este paso, la aplicación se prepara para tener todo disponible para uso sin conexión.
+3. Cuando el controlador de `install` se completa, el service worker se considera instalado. En este punto, una versión anterior del service worker puede estar activa y controlando páginas abiertas. Como no se desea tener dos versiones diferentes del mismo service worker ejecutándose al mismo tiempo, la nueva versión aún no está activa.
+4. Una vez que todas las páginas controladas por la versión anterior del service worker se han cerrado, es seguro retirar la versión anterior, y el service worker recién instalado recibe un evento `activate`. El uso principal de `activate` es limpiar los recursos utilizados en versiones anteriores del service worker. El nuevo service worker puede llamar a [`skipWaiting()`](/es/docs/Web/API/ServiceWorkerGlobalScope/skipWaiting) para solicitar ser activado inmediatamente sin esperar a que se cierren las páginas abiertas. El nuevo service worker recibirá entonces `activate` inmediatamente y tomará el control de cualquier página abierta.
+5. Después de la activación, el service worker controlará las páginas, pero solo aquellas que se abrieron después de que `register()` tenga éxito. En otras palabras, los documentos tendrán que recargarse para ser controlados realmente, porque un documento comienza su vida con o sin un service worker y lo mantiene durante toda su vida. Para anular este comportamiento predeterminado y adoptar las páginas abiertas, un service worker puede llamar a [`clients.claim()`](/es/docs/Web/API/Clients/claim).
+6. Cada vez que se obtiene una nueva versión de un service worker, este ciclo se repite y los restos de la versión anterior se limpian durante la activación de la nueva versión.
 
-![](sw-lifecycle.png)
+![diagrama de ciclo de vida](sw-lifecycle.svg)
 
-El siguiente gráfico muestra un resumen de los eventos de _service worker_ disponibles:
+Este es un resumen de los eventos de service worker disponibles:
 
-![install, activate, message, fetch, sync, push](sw-events.png)
+- [`install`](/es/docs/Web/API/ServiceWorkerGlobalScope/install_event)
+- [`activate`](/es/docs/Web/API/ServiceWorkerGlobalScope/activate_event)
+- [`message`](/es/docs/Web/API/ServiceWorkerGlobalScope/message_event)
+- Eventos funcionales
+  - [`fetch`](/es/docs/Web/API/ServiceWorkerGlobalScope/fetch_event)
+  - [`sync`](/es/docs/Web/API/ServiceWorkerGlobalScope/sync_event)
+  - [`push`](/es/docs/Web/API/ServiceWorkerGlobalScope/push_event)
 
-## Demostración del service worker
+## Demostración
 
-Para demostrar los conceptos básicos de registro e instalación de un _service worker_, hemos creado una demostración simple llamada [_service worker_ simple](https://github.com/mdn/dom-examples/tree/main/service-worker/simple-service-worker), que es una simple galería de imágenes de Star Wars Lego. Utiliza una función impulsada por promesas para leer datos de imagen de un objeto JSON y cargar las imágenes usando Ajax, antes de mostrar las imágenes en una línea hacia abajo en la página. Hemos mantenido las cosas estáticas y simples por ahora. También registra, instala y activa un _service worker_, y cuando los navegadores admiten más especificaciones, almacenará en caché todos los archivos necesarios para que funcione sin conexión.
+Para demostrar los conceptos básicos de registro e instalación de un service worker, se ha creado una demostración simple llamada [simple service worker](https://github.com/mdn/dom-examples/tree/main/service-worker/simple-service-worker), que es una galería de imágenes de Star Wars Lego. Utiliza una función basada en promesas para leer datos de imagen de un objeto JSON y cargar las imágenes usando [`fetch()`](/es/docs/Web/API/Fetch_API/Using_Fetch), antes de mostrar las imágenes en línea en la página. Se ha mantenido estático por ahora. También registra, instala y activa un service worker.
 
 ![Las palabras Star Wars seguidas de una imagen de una versión Lego del personaje Darth Vader](demo-screenshot.png)
 
-Puedes ver el [código fuente en GitHub](https://github.com/mdn/dom-examples/tree/main/service-worker/simple-service-worker) y el [Sencillo _service worker_ ejecutándose en vivo](https://bncb2v.csb.app/).
+Se puede ver el [código fuente en GitHub](https://github.com/mdn/dom-examples/tree/main/service-worker/simple-service-worker) y el [simple service worker ejecutándose en vivo](https://bncb2v.csb.app/).
 
-### Registra a tu worker
+### Registrar el worker
 
-El primer bloque de código en el archivo JavaScript de nuestra aplicación, `app.js`, es el siguiente. Este es nuestro punto de entrada en el uso del _service worker_.
+El primer bloque de código en el archivo JavaScript de la aplicación, `app.js`, es el siguiente. Este es el punto de entrada para usar service workers.
 
 ```js
 const registerServiceWorker = async () => {
@@ -60,14 +64,14 @@ const registerServiceWorker = async () => {
         scope: "/",
       });
       if (registration.installing) {
-        console.log("Instalando el Service worker");
+        console.log("Service worker instalándose");
       } else if (registration.waiting) {
         console.log("Service worker instalado");
       } else if (registration.active) {
         console.log("Service worker activo");
       }
     } catch (error) {
-      console.error(`Falló el registro con el ${error}`);
+      console.error(`El registro falló con ${error}`);
     }
   }
 };
@@ -77,44 +81,41 @@ const registerServiceWorker = async () => {
 registerServiceWorker();
 ```
 
-1. El bloque if realiza una prueba de detección de características para asegurarse de que el _service worker_ sea compatible antes de intentar registrar uno.
-2. A continuación, usamos la función {{domxref("ServiceWorkerContainer.register()") }} para registrar el _service worker_ para este sitio, que solo es un archivo JavaScript que reside dentro de nuestra aplicación (ten en cuenta que esta es la URL del archivo relativa al origen , no el archivo JS que hace referencia a él).
-3. El parámetro `scope` es opcional y se puede usar para especificar el subconjunto de tu contenido que deseas controle el _service worker_. En este caso, hemos especificado `'/'`, lo cual significa todo el contenido bajo el origen de la aplicación. Si lo omites, tendrá este valor predeterminado de todos modos, pero lo especificamos aquí con fines ilustrativos.
+1. El bloque `if` realiza una prueba de detección de características para asegurarse de que los service workers sean compatibles antes de intentar registrar uno.
+2. A continuación, se usa la función [`ServiceWorkerContainer.register()`](/es/docs/Web/API/ServiceWorkerContainer/register) para registrar el service worker para este sitio. El código del service worker es un archivo JavaScript que reside dentro de la aplicación (nótese que esta es la URL del archivo relativa al origen, no al archivo JS que lo referencia).
+3. El parámetro `scope` es opcional y se puede usar para especificar el subconjunto del contenido que se desea que el service worker controle. En este caso, se ha especificado `'/'`, lo que significa todo el contenido bajo el origen de la aplicación. Si se omite, tomará este valor predeterminado de todos modos, pero se ha especificado aquí con fines ilustrativos.
 
-Esto registra un _service worker_, que se ejecuta en un contexto de trabajador y, por lo tanto, no tiene acceso al DOM. Luego ejecuta el código en el _service worker_ fuera de tus páginas normales para controlar su carga.
+Esto registra un service worker, que se ejecuta en un contexto worker y, por lo tanto, no tiene acceso al DOM.
 
-Un solo _service worker_ puede controlar muchas páginas. Cada vez que se carga una página dentro de su alcance, el _service worker_ se instala en esa página y opera en ella. Por lo tanto, ten en cuenta que debes tener cuidado con las variables globales en el script del _service worker_: cada página no tiene su propio trabajador único.
-
-> [!NOTE]
-> Tu _service worker_ funciona como un servidor proxy, lo que te permite modificar solicitudes y respuestas, reemplazarlas con elementos de su propio caché y más.
+Un solo service worker puede controlar muchas páginas. Cada vez que se carga una página dentro de su alcance, el service worker se instala para esa página y opera en ella. Por lo tanto, es necesario tener cuidado con las variables globales en el script del service worker: cada página no tiene su propio worker único.
 
 > [!NOTE]
-> Una gran cosa acerca del _service worker_ es que si usas la detección de funciones como se muestra arriba, los navegadores que no son compatibles con los _service workers_ pueden usar tu aplicación en línea de la manera normal esperada. Además, si usas _AppCache_ y <abbr title="ServiceWorker">SW</abbr> en una página, los navegadores que no admiten <abbr title="ServiceWorker">SW</abbr> pero sí _AppCache_ lo usarán, y los navegadores que admiten ambos ignorarán _AppCache_ y dejarán que <abbr title="ServiceWorker">SW</abbr> tome el control.
+> Una gran ventaja de los service workers es que si se usa la detección de características como se muestra arriba, los navegadores que no soportan service workers pueden simplemente usar la aplicación en línea de la manera normal esperada.
 
-#### ¿Por qué mi service worker no se registra?
+#### ¿Por qué falla el registro de mi service worker?
 
-Esto se podría deber a las siguientes razones:
+Un service worker falla en registrarse por una de las siguientes razones:
 
-1. No estás ejecutando tu aplicación a través de HTTPS.
-2. La ruta a tu archivo del _service worker_ no está escrita correctamente — se debe escribir en relación con el origen, no con el directorio raíz de tu aplicación. En nuestro ejemplo, el trabajador está en `https://bncb2v.csb.app/sw.js` y la raíz de la aplicación es `https://bncb2v.csb.app/`. Pero la ruta se debe escribir como `/sw.js`.
-3. Tampoco está permitido apuntar a un _service worker_ de un origen diferente al de tu aplicación.
+- No se está ejecutando la aplicación en un [contexto seguro](/es/docs/Web/Security/Defenses/Secure_Contexts) (sobre HTTPS).
+- La ruta del archivo del service worker es incorrecta.
+  La ruta debe ser relativa al origen, no al directorio raíz de la aplicación.
+  En el ejemplo, el worker está en `https://bncb2v.csb.app/sw.js` y la raíz de la aplicación es `https://bncb2v.csb.app/`, por lo que el service worker debe especificarse como `/sw.js`.
+- La ruta del service worker apunta a un service worker de un origen diferente al de la aplicación.
+- El registro del service worker contiene una opción `scope` más amplia de lo permitido por la ruta del worker.
+  El alcance predeterminado para un service worker es el directorio donde se encuentra el worker.
+  En otras palabras, si el script `sw.js` está ubicado en `/js/sw.js`, solo puede controlar URLs en (o anidadas dentro de) la ruta `/js/` de forma predeterminada.
+  El alcance de un service worker se puede ampliar (o reducir) con el encabezado {{HTTPHeader("Service-Worker-Allowed")}}.
+- Hay configuraciones específicas del navegador habilitadas, como bloquear todas las cookies, modo de navegación privada, eliminación automática de cookies al cerrar, etc.
+  Consulte la [compatibilidad de navegadores de `serviceWorker.register()`](/es/docs/Web/API/ServiceWorkerContainer/register#browser_compatibility) para más información.
 
-![](important-notes.png)
+### Instalación y activación: llenar la caché
 
-También ten en cuenta:
+Después de que el service worker se registra, el navegador intentará instalar y luego activar el service worker para la página/sitio.
 
-- El _service worker_ solo capturará las solicitudes de los clientes bajo el alcance del _service worker_.
-- El alcance máximo para un _service worker_ es la ubicación del trabajador.
-- Si tu _service worker_ está activo en un cliente al que se atiende con el encabezado `Service-Worker-Allowed`, puedes especificar una lista de alcances máximos para ese trabajador.
-- En Firefox, las APIs de _Service Worker_ están ocultas y no se pueden usar cuando el usuario está en [modo de navegación privada](https://support.mozilla.org/es/kb/private-browsing-use-firefox-without-history).
+El evento `install` es el primer evento que se dispara en la instalación o actualización del service worker.
+Se emite una sola vez, inmediatamente después de que el registro se completa exitosamente, y se usa generalmente para llenar las capacidades de almacenamiento en caché sin conexión del navegador con los recursos necesarios para ejecutar la aplicación sin conexión. Para esto, se usa la API de almacenamiento del Service Worker, [`cache`](/es/docs/Web/API/Cache), un objeto global en el service worker que permite almacenar recursos entregados por respuestas, indexados por sus solicitudes. Esta API funciona de manera similar a la caché estándar del navegador, pero es específica para el dominio. Los contenidos de la caché se mantienen hasta que se limpien.
 
-### Instalar y activar: llena tu caché
-
-Después de que tu _service worker_ esté registrado, el navegador intentará instalar y luego activar el _service worker_ para tu página/sitio.
-
-El evento `install` se activa cuando una instalación se completa con éxito. El evento `install` generalmente se usa para llenar las capacidades de almacenamiento en caché sin conexión de tu navegador con los activos que necesita para ejecutar tu aplicación sin conexión. Para hacer esto, usamos la API de almacenamiento de _Service Worker_: {{domxref("cache")}} — un objeto global en _Service Worker_ que nos permite almacenar los activos entregados por las respuestas y con clave de sus solicitudes. Esta API funciona de manera similar a la memoria caché estándar del navegador, pero es específica para tu dominio. Persiste hasta que le dices que no lo haga — nuevamente, tienes el control total.
-
-Así es como nuestro _service worker_ maneja el evento `install`:
+Así es como el service worker maneja el evento `install`:
 
 ```js
 const addResourcesToCache = async (resources) => {
@@ -139,91 +140,48 @@ self.addEventListener("install", (event) => {
 });
 ```
 
-1. Aquí agregamos un detector de eventos `install` al _service worker_ (por lo tanto, `self`), y luego encadenamos un método {{domxref("ExtendableEvent.waitUntil()") }} al evento; esto garantiza que el _service worker_ no se instale hasta que el código dentro de `waitUntil()` haya ocurrido con éxito.
-2. Dentro de `addResourcesToCache` usamos el método [`caches.open()`](/es/docs/Web/API/CacheStorage/open) para crear un nuevo caché llamado `v1`, que será la versión 1 de nuestro caché de recursos del sitio. Luego llamamos a una función que llama a `addAll()` en el caché creado, que para su parámetro toma un arreglo de URLs relativas al origen de todos los recursos que deseas almacenar en caché.
-3. Si se rechaza la promesa, la instalación falla y el trabajador no hará nada. Esto está bien, ya que puedes corregir tu código y luego intentarlo de nuevo la próxima vez que se registre.
-4. Después de una instalación exitosa, el _service worker_ se activa. Esto no tiene mucho de un uso distinto la primera vez que se instala/activa tu _service worker_, pero significa más cuando se actualiza el _service worker_ (consulta la sección [Actualizar tu _service worker_](#actualizar_tu_service_worker) más adelante).
+1. Se agrega un detector de eventos `install` al service worker (por lo tanto `self`), y luego se encadena un método [`ExtendableEvent.waitUntil()`](/es/docs/Web/API/ExtendableEvent/waitUntil) al evento, esto asegura que el service worker no se instalará hasta que el código dentro de `waitUntil()` se haya ejecutado exitosamente.
+2. Dentro de `addResourcesToCache()` se usa el método [`caches.open()`](/es/docs/Web/API/CacheStorage/open) para crear una nueva caché llamada `v1`, que será la versión 1 de la caché de recursos del sitio. Luego se llama a la función `addAll()` en la caché creada, que toma como parámetro un arreglo de URLs relativas al {{domxref("WorkerGlobalScope.location", "location", "", 1)}} del worker para todos los recursos que se desea almacenar en caché.
+3. Si la promesa se rechaza, la instalación falla y el worker no hará nada. Esto está bien, ya que se puede corregir el código e intentar de nuevo la próxima vez que ocurra el registro.
+4. Después de una instalación exitosa, el service worker se activa. Esto no tiene mucho uso distinto la primera vez que se instala/activa el service worker, pero significa más cuando se actualiza el service worker (ver la sección [Actualizar el service worker](#actualizar_el_service_worker) más adelante).
 
 > [!NOTE]
-> [localStorage](/es/docs/Web/API/Web_Storage_API) funciona de manera similar a la memoria caché del _service worker_, pero es síncrono, por lo que no está permitido en el _service worker_.
+> [La API Web Storage (`localStorage`)](/es/docs/Web/API/Web_Storage_API) funciona de manera similar a la caché del service worker, pero es síncrona, por lo que no está permitida en service workers.
 
 > [!NOTE]
-> [IndexedDB](/es/docs/Web/API/IndexedDB_API) se puede usar dentro de un _service worker_ para el almacenamiento de datos si lo requieres.
+> [IndexedDB](/es/docs/Web/API/IndexedDB_API) se puede usar dentro de un service worker para almacenamiento de datos si se requiere.
 
 ### Respuestas personalizadas a solicitudes
 
-Ahora que tienes los activos de tu sitio almacenados en caché, debes decir al _service worker_ que haga algo con el contenido almacenado en caché. Esto se hace fácilmente con el evento `fetch`.
+Ahora que los recursos del sitio están almacenados en caché, se necesita indicar a los service workers que hagan algo con el contenido almacenado en caché. Esto se hace con el evento `fetch`.
 
-![](sw-fetch.png)
+1. Un evento `fetch` se dispara cada vez que se obtiene cualquier recurso controlado por un service worker, lo que incluye los documentos dentro del alcance especificado y cualquier recurso referenciado en esos documentos (por ejemplo, si `index.html` hace una solicitud de origen cruzado para incrustar una imagen, eso también pasa por su service worker).
 
-Un evento `fetch` se activa cada vez que se recupera cualquier recurso controlado por un _service worker_, lo que incluye los documentos dentro del alcance especificado y cualquier recurso al que se haga referencia en esos documentos (por ejemplo, si `index.html` hace una solicitud de origen cruzado para incrustar una imagen, que todavía pasa por su _service worker_).
-
-Puedes adjuntar un detector de eventos `fetch` al _service worker_, luego llamar al método `respondWith()` en el evento para capturar nuestras respuestas HTTP y actualizarlas con tu propia magia.
-
-```js
-self.addEventListener("fetch", (event) => {
-  event
-    .respondWith
-    // la magia va aquí
-    ();
-});
-```
-
-Podríamos empezar respondiendo con el recurso cuya URL coincida con la de la solicitud de red, en cada caso:
-
-```js
-self.addEventListener("fetch", (event) => {
-  event.respondWith(caches.match(event.request));
-});
-```
-
-`caches.match(event.request)` nos permite hacer coincidir cada recurso solicitado de la red con el recurso equivalente disponible en caché, si hay uno coincidente disponible. La coincidencia se realiza a través de URL y varios encabezados, al igual que con las solicitudes HTTP normales.
-
-Veamos algunas otras opciones que tenemos al definir nuestra magia (consulta nuestra [documentación de la API Fetch](/es/docs/Web/API/Fetch_API) para obtener más información sobre los objetos {{domxref("Request")}} y {{domxref("Response")}}.)
-
-1. El constructor {{domxref("Response.Response","Response()")}} te permite crear una respuesta personalizada. En este caso, solo estamos devolviendo una cadena de texto simple:
+2. Se puede adjuntar un detector de eventos `fetch` al service worker, luego llamar al método `respondWith()` en el evento para interceptar las respuestas HTTP y actualizarlas con contenido propio.
 
    ```js
-   new Response("¡Hola desde tu amigable vecindario del service worker!");
+   self.addEventListener("fetch", (event) => {
+     event.respondWith(/* el contenido personalizado va aquí */);
+   });
    ```
 
-2. Esta `Response` más compleja a continuación muestra que, opcionalmente, puedes pasar un conjunto de encabezados con tu respuesta, emulando los encabezados de respuesta HTTP estándar. Aquí solo le estamos diciendo al navegador cuál es el tipo de contenido de nuestra respuesta sintética:
+3. Se podría empezar respondiendo con el recurso cuya URL coincida con la de la solicitud de red, en cada caso:
 
    ```js
-   new Response(
-     "<p>¡Hola desde tu amigable vecindario del service worker!</p>",
-     {
-       headers: { "Content-Type": "text/html" },
-     },
-   );
+   self.addEventListener("fetch", (event) => {
+     event.respondWith(caches.match(event.request));
+   });
    ```
 
-3. Si no se encontró una coincidencia en caché, le puedes decir al navegador que {{domxref("fetch()")}} la solicitud de red predeterminada para ese recurso, para obtener el nuevo recurso de la red si está disponible:
+   `caches.match(event.request)` permite hacer coincidir cada recurso solicitado de la red con el recurso equivalente disponible en la caché, si hay uno coincidente disponible. La coincidencia se realiza a través de URL y varios encabezados, al igual que con las solicitudes HTTP normales.
 
-   ```js
-   fetch(event.request);
-   ```
-
-4. Si no se encontró una coincidencia en caché y la red no está disponible, puedes hacer coincidir la solicitud con algún tipo de página de respaldo predeterminada como respuesta usando {{domxref("CacheStorage.match","match() ")}}, como esta:
-
-   ```js
-   caches.match("./fallback.html");
-   ```
-
-5. Puedes recuperar mucha información sobre cada solicitud llamando a los parámetros del objeto {{domxref("Request")}} devuelto por {{domxref("FetchEvent")}}:
-
-   ```js
-   event.request.url;
-   event.request.method;
-   event.request.headers;
-   event.request.body;
-   ```
+![Diagrama de evento fetch](sw-fetch.svg)
 
 ## Recuperar solicitudes fallidas
 
-Entonces `caches.match(event.request)` es excelente cuando hay una coincidencia en caché del _service worker_, pero ¿qué pasa con los casos en los que no hay una coincidencia? Si no proporcionamos ningún tipo de manejo de fallas, nuestra promesa se resolvería con `undefined` y no tendríamos nada devuelto.
+`caches.match(event.request)` es excelente cuando hay una coincidencia en la caché del service worker, pero ¿qué pasa con los casos en los que no hay coincidencia? Si no se proporciona ningún tipo de manejo de fallos, la promesa se resolvería con `undefined` y no se obtendría nada.
 
-Afortunadamente, la estructura basada en promesas del _service worker_ hace que sea trivial brindar más opciones hacia el éxito. Podríamos hacer esto:
+Después de probar la respuesta de la caché, se puede recurrir a una solicitud de red regular:
 
 ```js
 const cacheFirst = async (request) => {
@@ -239,9 +197,9 @@ self.addEventListener("fetch", (event) => {
 });
 ```
 
-Si los recursos no están en la memoria caché, se solicitan desde la red.
+Si los recursos no están en la caché, se solicitan de la red.
 
-Si fuéramos realmente inteligentes, no solo solicitaríamos el recurso de la red; ¡también lo guardaríamos en caché para que las solicitudes posteriores de ese recurso también se puedan recuperar sin conexión! Esto significaría que si se agregaran imágenes adicionales a la galería de Star Wars, nuestra aplicación podría capturarlas automáticamente y almacenarlas en caché. Lo siguiente haría el truco:
+Usando una estrategia más elaborada, se podría no solo solicitar el recurso de la red, sino también guardarlo en la caché para que las solicitudes posteriores de ese recurso también se puedan recuperar sin conexión. Esto significaría que si se añadieran imágenes adicionales a la galería de Star Wars, la aplicación podría capturarlas automáticamente y almacenarlas en caché. El siguiente fragmento implementa tal estrategia:
 
 ```js
 const putInCache = async (request, response) => {
@@ -249,28 +207,28 @@ const putInCache = async (request, response) => {
   await cache.put(request, response);
 };
 
-const cacheFirst = async (request) => {
+const cacheFirst = async (request, event) => {
   const responseFromCache = await caches.match(request);
   if (responseFromCache) {
     return responseFromCache;
   }
   const responseFromNetwork = await fetch(request);
-  putInCache(request, responseFromNetwork.clone());
+  event.waitUntil(putInCache(request, responseFromNetwork.clone()));
   return responseFromNetwork;
 };
 
 self.addEventListener("fetch", (event) => {
-  event.respondWith(cacheFirst(event.request));
+  event.respondWith(cacheFirst(event.request, event));
 });
 ```
 
-Si la URL de la solicitud no está disponible en la memoria caché, solicitamos el recurso de la solicitud de red con `await fetch(request)`. Después de eso, colocamos en caché un clon de la respuesta. La función `putInCache` usa `caches.open('v1')` y `cache.put()` para agregar el recurso a la caché. La respuesta original se devuelve al navegador para que se proporcione a la página que la llamó.
+Si la URL de la solicitud no está disponible en la caché, se solicita el recurso de la red con `await fetch(request)`. Después de eso, se coloca un clon de la respuesta en la caché. La función `putInCache()` usa `caches.open('v1')` y `cache.put()` para agregar el recurso a la caché. La respuesta original se devuelve al navegador para entregarse a la página que la solicitó.
 
-La clonación de la respuesta es necesaria porque los flujos de solicitud y respuesta solo se pueden leer una vez. Para devolver la respuesta al navegador y ponerla en caché la tenemos que clonar. Entonces, el original se devuelve al navegador y el clon se envía a caché. Cada uno se lee una vez.
+Clonar la respuesta es necesario porque los flujos de solicitud y respuesta solo se pueden leer una vez. Para devolver la respuesta al navegador y ponerla en la caché, es necesario clonarla. Así el original se devuelve al navegador y el clon se envía a la caché. Cada uno se lee una vez.
 
-Lo que puede parecer un poco extraño es que no se espera la promesa devuelta por `putInCache`. Pero la razón es que no queremos esperar hasta que el clon de respuesta se haya agregado a la caché antes de devolver una respuesta.
+Lo que puede parecer un poco extraño es que la promesa devuelta por `putInCache()` no se espera. La razón es que no se desea esperar hasta que el clon de respuesta se haya agregado a la caché antes de devolver una respuesta. Sin embargo, es necesario llamar a `event.waitUntil()` con la promesa, para asegurar que el service worker no se detenga antes de que la caché se haya llenado.
 
-El único problema que tenemos ahora es que si la solicitud no coincide con nada en caché y la red no está disponible, nuestra solicitud seguirá fallando. Proporcionemos un respaldo predeterminado para que, pase lo que pase, el usuario al menos obtenga algo:
+El único problema ahora es que si la solicitud no coincide con nada en la caché y la red no está disponible, la solicitud seguirá fallando. Se puede proporcionar un respaldo predeterminado para que, pase lo que pase, el usuario al menos obtenga algo:
 
 ```js
 const putInCache = async (request, response) => {
@@ -278,20 +236,20 @@ const putInCache = async (request, response) => {
   await cache.put(request, response);
 };
 
-const cacheFirst = async ({ request, preloadResponsePromise, fallbackUrl }) => {
-  // Primero intenta obtener el recurso desde caché
+const cacheFirst = async ({ request, fallbackUrl, event }) => {
+  // Primero intentar obtener el recurso de la caché
   const responseFromCache = await caches.match(request);
   if (responseFromCache) {
     return responseFromCache;
   }
 
-  // A continuación, intenta obtener el recurso desde la red
+  // Luego intentar obtener el recurso de la red
   try {
     const responseFromNetwork = await fetch(request);
     // la respuesta solo se puede usar una vez
-    // necesitamos guardar el clon para poner una copia en caché
-    // y servir el segundo
-    putInCache(request, responseFromNetwork.clone());
+    // se necesita guardar el clon para poner una copia en caché
+    // y servir la segunda
+    event.waitUntil(putInCache(request, responseFromNetwork.clone()));
     return responseFromNetwork;
   } catch (error) {
     const fallbackResponse = await caches.match(fallbackUrl);
@@ -299,7 +257,7 @@ const cacheFirst = async ({ request, preloadResponsePromise, fallbackUrl }) => {
       return fallbackResponse;
     }
     // cuando incluso la respuesta alternativa no está disponible,
-    // no hay nada que podamos hacer, pero siempre debemos
+    // no hay nada que se pueda hacer, pero siempre se debe
     // devolver un objeto Response
     return new Response("Ocurrió un error de red", {
       status: 408,
@@ -313,44 +271,35 @@ self.addEventListener("fetch", (event) => {
     cacheFirst({
       request: event.request,
       fallbackUrl: "/gallery/myLittleVader.jpg",
+      event,
     }),
   );
 });
 ```
 
-Hemos optado por esta imagen alternativa porque las únicas actualizaciones que probablemente fallarán son las imágenes nuevas, ya que todo lo demás depende de la instalación en el detector de eventos `install` que vimos anteriormente.
+Se ha optado por esta imagen alternativa porque las únicas actualizaciones que probablemente fallarán son las imágenes nuevas, ya que todo lo demás depende de la instalación en el detector de eventos `install` visto anteriormente.
 
 ## Precarga de navegación del service worker
 
-Si está habilitada, la función de [precarga de navegación](/es/docs/Web/API/NavigationPreloadManager) comienza a descargar recursos tan pronto como se realiza la solicitud de recuperación y en paralelo con el inicio del _service worker_.
-Esto garantiza que la descarga comience de inmediato al navegar a una página, en lugar de tener que esperar hasta que se inicie el _service worker_.
-Ese retraso ocurre en muy raras ocasiones, pero es inevitable cuando ocurre y puede ser significativo.
+Si está habilitada, la función de [precarga de navegación](/es/docs/Web/API/NavigationPreloadManager) comienza a descargar recursos tan pronto como se realiza la solicitud de fetch, y en paralelo con la activación del service worker. Esto asegura que la descarga comience inmediatamente al navegar a una página, en lugar de tener que esperar hasta que el service worker esté activado. Ese retraso ocurre relativamente rara vez, pero es inevitable cuando sucede y puede ser significativo.
 
-Primero, la función debe estar habilitada durante la activación del _service worker_, usando {{domxref("NavigationPreloadManager.enable()", "registration.navigationPreload.enable()")}}:
+Primero, la función debe habilitarse durante la activación del service worker, usando [`registration.navigationPreload.enable()`](/es/docs/Web/API/NavigationPreloadManager/enable):
 
 ```js
-const enableNavigationPreload = async () => {
-  if (self.registration.navigationPreload) {
-    // ¡Habilitar precargas de navegación!
-    await self.registration.navigationPreload.enable();
-  }
-};
-
 self.addEventListener("activate", (event) => {
-  event.waitUntil(enableNavigationPreload());
+  event.waitUntil(self.registration?.navigationPreload.enable());
 });
 ```
 
-Luego usa {{domxref("FetchEvent.preloadResponse", "event.preloadResponse")}} para esperar a que el recurso precargado se termine de descargar en el controlador de eventos `fetch`.
+Luego se usa [`event.preloadResponse`](/es/docs/Web/API/FetchEvent/preloadResponse) para esperar a que el recurso precargado termine de descargarse en el controlador de eventos `fetch`.
 
-Continuando con el ejemplo de las secciones anteriores, insertamos el código para esperar el recurso precargado después de la verificación de la caché y antes de recuperarlo de la red si eso no tiene éxito.
+Continuando con el ejemplo de las secciones anteriores, se inserta el código para esperar el recurso precargado después de la verificación de caché, y antes de obtenerlo de la red si eso no tiene éxito.
 
 El nuevo proceso es:
 
-1. Comprobar la caché
-2. Esperar en `event.preloadResponse`, que se pasa como `preloadResponsePromise` a la función `cacheFirst`.
-   Guardar en caché el resultado si regresa.
-3. Si ninguno de estos está definido, vamos a la red.
+1. Verificar la caché.
+2. Esperar `event.preloadResponse`, que se pasa como `preloadResponsePromise` a la función `cacheFirst()`. Almacenar en caché el resultado si se obtiene.
+3. Si ninguno de estos está definido, se recurre a la red.
 
 ```js
 const addResourcesToCache = async (resources) => {
@@ -363,28 +312,33 @@ const putInCache = async (request, response) => {
   await cache.put(request, response);
 };
 
-const cacheFirst = async ({ request, preloadResponsePromise, fallbackUrl }) => {
-  // Primero intenta obtener el recurso desde caché
+const cacheFirst = async ({
+  request,
+  preloadResponsePromise,
+  fallbackUrl,
+  event,
+}) => {
+  // Primero intentar obtener el recurso de la caché
   const responseFromCache = await caches.match(request);
   if (responseFromCache) {
     return responseFromCache;
   }
 
-  // A continuación, intenta usar (y almacenar en caché) la respuesta precargada, si está allí
+  // Luego intentar usar (y almacenar en caché) la respuesta precargada, si está disponible
   const preloadResponse = await preloadResponsePromise;
   if (preloadResponse) {
     console.info("using preload response", preloadResponse);
-    putInCache(request, preloadResponse.clone());
+    event.waitUntil(putInCache(request, preloadResponse.clone()));
     return preloadResponse;
   }
 
-  // A continuación, intenta obtener el recurso desde la red
+  // Luego intentar obtener el recurso de la red
   try {
     const responseFromNetwork = await fetch(request);
     // la respuesta solo se puede usar una vez
-    // necesitamos guardar el clon para poner una copia en caché
-    // y servir el segundo
-    putInCache(request, responseFromNetwork.clone());
+    // se necesita guardar el clon para poner una copia en caché
+    // y servir la segunda
+    event.waitUntil(putInCache(request, responseFromNetwork.clone()));
     return responseFromNetwork;
   } catch (error) {
     const fallbackResponse = await caches.match(fallbackUrl);
@@ -392,7 +346,7 @@ const cacheFirst = async ({ request, preloadResponsePromise, fallbackUrl }) => {
       return fallbackResponse;
     }
     // cuando incluso la respuesta alternativa no está disponible,
-    // no hay nada que podamos hacer, pero siempre debemos
+    // no hay nada que se pueda hacer, pero siempre se debe
     // devolver un objeto Response
     return new Response("Ocurrió un error de red", {
       status: 408,
@@ -401,10 +355,9 @@ const cacheFirst = async ({ request, preloadResponsePromise, fallbackUrl }) => {
   }
 };
 
-// Habilita la precarga de navegación
+// Habilitar precarga de navegación
 const enableNavigationPreload = async () => {
   if (self.registration.navigationPreload) {
-    // ¡Habilitar precargas de navegación!
     await self.registration.navigationPreload.enable();
   }
 };
@@ -435,20 +388,22 @@ self.addEventListener("fetch", (event) => {
       request: event.request,
       preloadResponsePromise: event.preloadResponse,
       fallbackUrl: "/gallery/myLittleVader.jpg",
+      event,
     }),
   );
 });
 ```
 
-Ten en cuenta que en este ejemplo descargamos y almacenamos en caché los mismos datos para el recurso, ya sea que se descargue "normalmente" o se precargue.
-En su lugar, puedes optar por descargar y almacenar en caché un recurso diferente en la precarga.
-Para obtener más información, consulta [NavigationPreloadManager > Respuestas personalizadas](/es/docs/Web/API/NavigationPreloadManager#custom_responses).
+Nótese que en este ejemplo se descargan y almacenan en caché los mismos datos para el recurso, ya sea que se descargue "normalmente" o se precargue. En su lugar, se puede optar por descargar y almacenar en caché un recurso diferente en la precarga. Para más información, consulte [`NavigationPreloadManager` > Respuestas personalizadas](/es/docs/Web/API/NavigationPreloadManager#custom_responses).
 
-## Actualizar tu service worker
+## Actualizar el service worker
 
-Si tu _service worker_ se instaló anteriormente, pero luego está disponible una nueva versión del trabajador al actualizar o cargar la página, la nueva versión se instala en segundo plano, pero aún no está activada. Solo se activa cuando ya no hay páginas cargadas que todavía estén usando el antiguo _service worker_. Tan pronto como no queden más páginas cargadas, se activa el nuevo _service worker_.
+Si el service worker se instaló previamente, pero luego hay una nueva versión del worker disponible al refrescar o cargar la página, la nueva versión se instala en segundo plano, pero aún no se activa. Solo se activa cuando ya no hay páginas cargadas que aún usen el service worker antiguo. Tan pronto como no queden más páginas cargadas de este tipo, el nuevo service worker se activa.
 
-Querrás actualizar tu escucha de eventos `install` en el nuevo _service worker_ a algo como esto (observa el nuevo número de versión):
+> [!NOTE]
+> Es posible evitar esto usando [`Clients.claim()`](/es/docs/Web/API/Clients/claim).
+
+Se querrá actualizar el detector de eventos `install` en el nuevo service worker a algo como esto (nótese el nuevo número de versión):
 
 ```js
 const addResourcesToCache = async (resources) => {
@@ -465,7 +420,7 @@ self.addEventListener("install", (event) => {
       "/app.js",
       "/image-list.js",
 
-      // ...
+      // …
 
       // incluir otros nuevos recursos para la nueva versión…
     ]),
@@ -473,15 +428,15 @@ self.addEventListener("install", (event) => {
 });
 ```
 
-Mientras esto sucede, la versión anterior sigue siendo responsable de las recuperaciones. La nueva versión se está instalando en segundo plano. Estamos llamando al nuevo caché `v2`, por lo que el caché anterior `v1` no se ve afectado.
+Mientras el service worker se está instalando, la versión anterior sigue siendo responsable de los fetches. La nueva versión se está instalando en segundo plano. Se está llamando a la nueva caché `v2`, por lo que la caché anterior `v1` no se ve afectada.
 
-Cuando ninguna página está usando la versión actual, el nuevo trabajador se activa y se vuelve responsable de las recuperaciones.
+Cuando ninguna página está usando la versión anterior, el nuevo worker se activa y se vuelve responsable de los fetches.
 
-### Eliminar cachés antiguos
+### Eliminar cachés antiguas
 
-También obtienes un evento `activate`. Esto generalmente se usa para hacer cosas que habrían roto la versión anterior mientras aún se estaba ejecutando, por ejemplo, deshacerse de los cachés antiguos. Esto también es útil para eliminar datos que ya no se necesitan para evitar llenar demasiado espacio en disco: cada navegador tiene un límite estricto en la cantidad de almacenamiento en caché que puede usar un determinado _service worker_. El navegador hace todo lo posible para administrar el espacio en disco, pero puede eliminar el almacenamiento en caché de un origen. El navegador, generalmente, eliminará todos los datos de un origen o ninguno de los datos de un origen.
+Como se vio en la sección anterior, cuando se actualiza un service worker a una nueva versión, se crea una nueva caché en el controlador de eventos `install`. Mientras haya páginas abiertas controladas por la versión anterior del worker, es necesario mantener ambas cachés, porque la versión anterior necesita su versión de la caché. Se puede usar el evento `activate` para eliminar datos de las cachés anteriores.
 
-Las promesas pasadas a `waitUntil()` bloquearán otros eventos hasta que se completen, por lo que puedes estar seguro de que tu operación de limpieza se habrá completado cuando obtengas tu primer evento `fetch` en el nuevo _service worker_.
+Las promesas pasadas a `waitUntil()` bloquearán otros eventos hasta completarse, por lo que se puede estar seguro de que la operación de limpieza se habrá completado para cuando se reciba el primer evento `fetch` en el nuevo service worker.
 
 ```js
 const deleteCache = async (key) => {
@@ -502,21 +457,13 @@ self.addEventListener("activate", (event) => {
 
 ## Herramientas de desarrollo
 
-Chrome tiene `chrome://inspect/#service-workers`, que muestra la actividad actual de los _service workers_ y el almacenamiento en un dispositivo, y `chrome://serviceworker-internals`, que muestra más detalles y te permite iniciar/detener/depurar el proceso del trabajador. En el futuro, tendrán modos de limitación/desconexión para simular conexiones defectuosas o inexistentes, lo que será algo realmente bueno.
-
-Firefox también ha comenzado a implementar algunas herramientas útiles relacionadas con los _service workers_:
-
-- Puedes navegar a [`about:debugging`](https://firefox-source-docs.mozilla.org/devtools-user/about_colon_debugging/index.html) para ver qué <abbr title="Service Workers">SW</abbr>s están registrados y actualizarlos/eliminarlos.
-- Al realizar pruebas, puedes sortear la restricción de HTTPS marcando la opción "Habilitar _service worker_ a través de HTTP (cuando la caja de herramientas está abierta)" en la [Configuración de herramientas de desarrollo de Firefox](https://firefox-source-docs.mozilla.org/devtools-user/settings/index.html).
-- El botón "Olvidar", disponible en las opciones de personalización de Firefox, se puede usar para borrar los _service workers_ y sus cachés ([Error 1252998 en Firefox](https://bugzil.la/1252998)).
-
-> [!NOTE]
-> Puedes servir tu aplicación desde `http://localhost` (por ejemplo, usando `me@localhost:/my/app$ python -m SimpleHTTPServer`) para el desarrollo local. Ve [Consideraciones de seguridad](https://www.w3.org/TR/service-workers/#security-considerations)
+- [Chrome](https://www.chromium.org/blink/serviceworker/service-worker-faq/)
+- [Firefox](https://firefox-source-docs.mozilla.org/devtools-user/application/service_workers/index.html)
+  - El botón "Olvidar este sitio", disponible en las [opciones de personalización de la barra de herramientas de Firefox](https://support.mozilla.org/en-US/kb/customize-firefox-controls-buttons-and-toolbars), se puede usar para limpiar los service workers y sus cachés.
+- [Edge](https://learn.microsoft.com/en-us/microsoft-edge/devtools/progressive-web-apps/#service-workers)
 
 ## Véase también
 
-- [El manual del _service worker_](https://github.com/mdn/serviceworker-cookbook)
-- [¿Está listo ServiceWorker?](https://jakearchibald.github.io/isserviceworkerready/)
-- Descarga la [hoja de trucos de _service worker_ 101](sw101.png).
 - [Promesas](/es/docs/Web/JavaScript/Reference/Global_Objects/Promise)
-- [Usar _web workers_](/es/docs/Web/API/Web_Workers_API/Using_web_workers)
+- [Uso de web workers](/es/docs/Web/API/Web_Workers_API/Using_web_workers)
+- {{HTTPHeader("Service-Worker-Allowed")}} encabezado HTTP


### PR DESCRIPTION
## Summary

- Updated `Web/API/Service_Worker_API` overview to match latest English source
- Updated `Web/API/Service_Worker_API/Using_Service_Workers` guide to match latest English source
- Added missing sections (static routing, navigation preload improvements)
- Removed deprecated interfaces no longer in English source (NotificationEvent, SyncEvent, SyncManager, ServiceWorkerMessageEvent)
- Updated macros to use current format (DOMxRef, event links)
- Fixed terminology consistency and improved translation quality