### PR TITLE
chore(fr): adding `attributionSourceId` to `HTMLAnchorElement`

### DIFF
--- a/files/fr/web/api/htmlanchorelement/attributionsourceid/index.md
+++ b/files/fr/web/api/htmlanchorelement/attributionsourceid/index.md
@@ -1,0 +1,51 @@
+---
+title: "HTMLAnchorElement: attributionSourceId property"
+short-title: attributionSourceId
+slug: Web/API/HTMLAnchorElement/attributionSourceId
+l10n:
+  sourceCommit: af9a8ff87cfa6563c9a082162ce4ed7ba0b204e1
+---
+
+{{APIRef("HTML DOM")}}{{SeeCompatTable}}
+
+La propriété **`attributionSourceId`** de l'interface {{DOMxRef("HTMLAnchorElement")}} obtient et définit l'attribut HTML `attributionsourceid` sur un élément HTML {{HTMLElement("a")}}.
+
+La propriété `attributionSourceId` est utilisée dans le cadre de la spécification [mesure des clics privés <sup>(angl.)</sup>](https://privacycg.github.io/private-click-measurement/) pour identifier le contenu qui a été cliqué lors du suivi d'un lien vers un autre site.
+
+## Valeur
+
+Un nombre. Les valeurs valides pour la mesure des clics privés sont comprises entre `0` et `255`. La valeur par défaut est `0`. Les valeurs en dehors de cette plage ne provoqueront pas d'erreur lors de la définition de la propriété, mais seront ignorées par le navigateur à des fins d'attribution.
+
+## Exemples
+
+### Définir un identifiant de source d'attribution sur un lien
+
+```html
+<a
+  id="ad-link"
+  href="https://exemple.com"
+  attributiondestination="https://exemple.com">
+  Cliquez pour visiter notre boutique
+</a>
+```
+
+```js
+const adLink = document.getElementById("ad-link");
+adLink.attributionSourceId = 17;
+
+console.log(adLink.attributionSourceId); // 17
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'interface {{DOMxRef("HTMLAnchorElement")}}
+- L'élément HTML {{HTMLElement("a")}}
+- La spécification [de mesure des clics privés <sup>(angl.)</sup>](https://privacycg.github.io/private-click-measurement/)

--- a/files/fr/web/api/htmlanchorelement/index.md
+++ b/files/fr/web/api/htmlanchorelement/index.md
@@ -15,6 +15,8 @@ L'interface **`HTMLAnchorElement`** représente les éléments d'hyperlien et fo
 
 _Hérite des propriétés de son parent, {{DOMxRef("HTMLElement")}}._
 
+- {{DOMxRef("HTMLAnchorElement.attributionSourceId")}} {{Experimental_Inline}}
+  - : Un entier positif représentant l'identifiant de la source d'attribution utilisé pour la [mesure des clics privés <sup>(angl.)</sup>](https://privacycg.github.io/private-click-measurement/). Les valeurs valides vont de `0` à `255`.
 - {{DOMxRef("HTMLAnchorElement.attributionSrc")}} {{SecureContext_Inline}} {{Deprecated_Inline}}
   - : Obtient et définit l'attribut [`attributionsrc`](/fr/docs/Web/HTML/Reference/Elements/a#attributionsrc) sur un élément {{HTMLElement("a")}} de façon programmatique, reflétant la valeur de cet attribut. `attributionsrc` indique que vous souhaitez que le navigateur envoie un en-tête {{HTTPHeader("Attribution-Reporting-Eligible")}}. Côté serveur, cela sert à déclencher l'envoi d'un en-tête {{HTTPHeader("Attribution-Reporting-Register-Source")}} dans la réponse, afin d'enregistrer une source d'attribution basée sur la navigation.
 - {{DOMxRef("HTMLAnchorElement.download")}}


### PR DESCRIPTION
### Description

Adding page for experimental `attributionSourceId` of `HTMLAnchorElement`

### Motivation

Week patch theme update. See project.

### Additional details

_none_

### Related issues and pull requests

_none_
