### PR TITLE
chore(fr): replacing jsxref macros on webassembly by links

### DIFF
--- a/files/fr/webassembly/reference/javascript_interface/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/index.md
@@ -1,68 +1,75 @@
 ---
 title: WebAssembly
 slug: WebAssembly/Reference/JavaScript_interface
-original_slug: WebAssembly/JavaScript_interface
+l10n:
+  sourceCommit: 006c05b688814b45a01ad965bbe4ebfc15513e74
 ---
 
-{{WebAssemblySidebar}}
+L'objet JavaScript **`WebAssembly`** sert d'espace de noms pour toutes les fonctionnalités liées à [WebAssembly](/fr/docs/WebAssembly).
 
-L'objet JavaScript **`WebAssembly`** est un objet global qui agit comme un espace de noms (_namespace_) pour les différentes fonctionnalités JavaScript relatives à [WebAssembly](/fr/docs/WebAssembly).
-
-À la différence des autres objets globaux, `WebAssembly` n'est pas un constructeur (au même titre que {{jsxref("Math")}} qui agit comme un espace de noms pour les constantes et fonctions mathématiques ou comme {{jsxref("Intl")}} qui centralise les constructeurs et les opérations relatives à l'internationalisation).
+À la différence des autres objets globaux, `WebAssembly` n'est pas un constructeur (ce n'est pas un objet fonction). Vous pouvez le comparer à {{JSxRef("Math")}}, qui est également un objet espace de noms pour les constantes et fonctions mathématiques, ou à {{JSxRef("Intl")}}, qui est l'objet espace de noms pour les constructeurs d'internationalisation et autres fonctions sensibles à la langue.
 
 ## Description
 
-L'objet `WebAssembly` est notamment utilisé pour :
+L'objet `WebAssembly` est notamment utilisé pour&nbsp;:
 
-- Charger du code WebAssembly grâce à la fonction {{jsxref("WebAssembly.instantiate()")}}
-- Créer des zones mémoires et des instances de tableaux grâce aux constructeurs {{jsxref("WebAssembly.Memory()")}}/{{jsxref("WebAssembly.Table()")}}.
-- Fournir des outils de gestion d'erreur WebAssembly grâce aux constructeurs {{jsxref("WebAssembly.CompileError()")}}/{{jsxref("WebAssembly.LinkError()")}}/{{jsxref("WebAssembly.RuntimeError()")}}.
+- Charger du code WebAssembly grâce à la fonction [`WebAssembly.instantiate()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/instantiate_static).
+- Créer de nouvelles instances de mémoire et de tableau avec les constructeurs [`WebAssembly.Memory()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Memory)/[`WebAssembly.Table()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table).
+- Fournir des outils pour gérer les erreurs survenant dans WebAssembly avec les constructeurs [`WebAssembly.CompileError()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/CompileError)/[`WebAssembly.LinkError()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/LinkError)/[`WebAssembly.RuntimeError()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/RuntimeError).
 
-## Méthodes
+## Interfaces
 
-- {{jsxref("WebAssembly.instantiate()")}}
-  - : La méthode qu'on utilisera la plupart du temps pour compiler et instancier du code WebAssembly, elle renvoie une promesse qui est résolue en une `Instance` ou en une `Instance` et un `Module`.
-- {{jsxref("WebAssembly.instantiateStreaming()")}}
-  - : Cette méthode permet de compiler et d'instancier un module WebAssembly à partir d'un flux source (_streamed source_). Elle renvoie à la fois un objet `Module` et sa première `Instance`.
-- {{jsxref("WebAssembly.compile()")}}
-  - : Cette méthode permet de compiler un {{jsxref("WebAssembly.Module")}} à partir de _bytecode_ WebAssembly, l'instanciation doit alors être effectuée dans une autre étape.
-- {{jsxref("WebAssembly.compileStreaming()")}}
-  - : Cette méthode permet de compiler un module {{jsxref("WebAssembly.Module")}} à partir d'un flux source (_streamed source_). L'instanciation devra alors être réalisée avec une autre étape.
-- {{jsxref("WebAssembly.validate()")}}
-  - : Cette méthode permet de valider un tableau typé censé contenir du _bytecode_ WebAssembly : elle renvoie `true` si les octets forment un code WebAssembly valide ou `false` sinon.
+- [`WebAssembly.CompileError`](/fr/docs/WebAssembly/Reference/JavaScript_interface/CompileError)
+  - : Indique une erreur lors du décodage ou de la validation de WebAssembly.
+- [`WebAssembly.Global`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Global)
+  - : Représente une instance de variable globale, accessible à la fois depuis JavaScript et importable/exportable entre une ou plusieurs instances de [`WebAssembly.Module`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Module). Cela permet le lien dynamique de plusieurs modules.
+- [`WebAssembly.Instance`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Instance)
+  - : Est une instance exécutable et avec état d'un [`WebAssembly.Module`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Module)
+- [`WebAssembly.LinkError`](/fr/docs/WebAssembly/Reference/JavaScript_interface/LinkError)
+  - : Indique une erreur lors de l'instanciation d'un module (autre que les [pièges de capture <sup>(angl.)</sup>](https://webassembly.github.io/simd/core/intro/overview.html#trap) de la fonction de démarrage).
+- [`WebAssembly.Memory`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Memory)
+  - : Un objet dont la propriété [`buffer`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer) est un objet {{JSxRef("ArrayBuffer")}} redimensionnable qui contient les octets bruts de la mémoire accessible par une `Instance` WebAssembly.
+- [`WebAssembly.Module`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Module)
+  - : Contient du code WebAssembly sans état qui a déjà été compilé par le navigateur et peut être efficacement [partagé avec des Workers](/fr/docs/Web/API/Worker/postMessage), et instancié plusieurs fois.
+- [`WebAssembly.RuntimeError`](/fr/docs/WebAssembly/Reference/JavaScript_interface/RuntimeError)
+  - : Type d'erreur qui est levé chaque fois que WebAssembly définit un [piège <sup>(angl.)</sup>](https://webassembly.github.io/simd/core/intro/overview.html#trap).
+- [`WebAssembly.Table`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table)
+  - : Une structure de type tableau représentant une table WebAssembly, qui stocke des [références <sup>(angl.)</sup>](https://webassembly.github.io/spec/core/syntax/types.html#syntax-reftype), telles que des références de fonctions.
+- [`WebAssembly.Tag`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Tag)
+  - : Un objet qui représente un type d'exception WebAssembly.
+- [`WebAssembly.Exception`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Exception)
+  - : Un objet d'exception WebAssembly qui peut être levé, capturé et relancé à la fois à l'intérieur et à travers les frontières WebAssembly/JavaScript.
 
-## Constructeurs
+## Méthodes statiques
 
-- {{jsxref("WebAssembly.Global()")}}
-  - : Ce constructeur permet de créer un nouvel objet WebAssembly `Global`.
-- {{jsxref("WebAssembly.Module()")}}
-  - : Ce constructeur permet de créer un objet WebAssembly `Module`.
-- {{jsxref("WebAssembly.Instance()")}}
-  - : Ce constructeur permet de créer un objet WebAssembly `Instance`.
-- {{jsxref("WebAssembly.Memory()")}}
-  - : Ce constructeur permet de créer un objet WebAssembly `Memory`.
-- {{jsxref("WebAssembly.Table()")}}
-  - : Ce constructeur permet de créer un objet WebAssembly `Table`.
-- {{jsxref("WebAssembly.CompileError()")}}
-  - : Ce constructeur permet de créer un objet WebAssembly `CompileError`.
-- {{jsxref("WebAssembly.LinkError()")}}
-  - : Ce constructeur permet de créer un objet WebAssembly `LinkError`.
-- {{jsxref("WebAssembly.RuntimeError()")}}
-  - : Ce constructeur permet de créer un objet WebAssembly `RuntimeError`.
+- [`WebAssembly.compile()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/compile_static)
+  - : Compile un [`WebAssembly.Module`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Module) à partir de code binaire WebAssembly, laissant l'instanciation comme une étape séparée.
+- [`WebAssembly.compileStreaming()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/compileStreaming_static)
+  - : Compile un [`WebAssembly.Module`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Module) directement à partir d'une source sous-jacente en flux, laissant l'instanciation comme une étape séparée.
+- [`WebAssembly.instantiate()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/instantiate_static)
+  - : L'API principale pour compiler et instancier du code WebAssembly, retournant à la fois un `Module` et sa première `Instance`.
+- [`WebAssembly.instantiateStreaming()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static)
+  - : Compile et instancie directement un module WebAssembly à partir d'une source sous-jacente en flux, retournant à la fois un `Module` et sa première `Instance`.
+- [`WebAssembly.validate()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/validate_static)
+  - : Valide un tableau typé donné de code binaire WebAssembly, renvoyant `true` si les octets sont un code WebAssembly valide ou `false` sinon.
 
 ## Exemples
 
-L'exemple suivant (cf. le fichier [`instantiate-streaming.html`](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/instantiate-streaming.html) sur GitHub et [le résultat obtenu](https://mdn.github.io/webassembly-examples/js-api-examples/instantiate-streaming.html)) permet de récupérer le module WebAssembly via un flux depuis une source, de le compiler, puis de l'instancier. La promesse est résolue avec un objet `ResultObject`. La méthode `instantiateStreaming()` accepte une promesse pour l'argument {{domxref("Response")}}, on peut lui passer directement un appel à [`fetch()`](/fr/docs/Web/API/Window/fetch) qui passera ensuite la réponse à la fonction lors de la complétion de la promesse.
+### Diffuser un module WebAssembly puis le compiler et l'instancier
+
+L'exemple suivant (voir notre démonstration [instantiate-streaming.html <sup>(angl.)</sup>](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/instantiate-streaming.html) sur GitHub, et [la voir en direct <sup>(angl.)</sup>](https://mdn.github.io/webassembly-examples/js-api-examples/instantiate-streaming.html) également) diffuse directement un module WebAssembly depuis une source sous-jacente, puis le compile et l'instancie, la promesse étant résolue en un `ResultObject`. Comme la fonction `instantiateStreaming()` accepte une promesse pour un objet [`Response`](/fr/docs/Web/API/Response), vous pouvez lui passer directement un appel à [`fetch()`](/fr/docs/Web/API/Window/fetch), et elle transmettra la réponse à la fonction lorsque la promesse sera résolue.
 
 ```js
-var importObject = { imports: { imported_func: (arg) => console.log(arg) } };
+const importObject = {
+  my_namespace: { imported_func: (arg) => console.log(arg) },
+};
 
 WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject).then(
   (obj) => obj.instance.exports.exported_func(),
 );
 ```
 
-On accède alors à la propriété de l'instance `ResultObject` puis on appelle la fonction exportée.
+On accède ensuite à la propriété `.instance` du `ResultObject`, puis on invoque la fonction exportée qu'elle contient.
 
 ## Spécifications
 
@@ -74,6 +81,6 @@ On accède alors à la propriété de l'instance `ResultObject` puis on appelle 
 
 ## Voir aussi
 
-- [Le portail WebAssembly](/fr/docs/WebAssembly)
-- [Les concepts relatifs à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
+- Un aperçu de [WebAssembly](/fr/docs/WebAssembly)
+- [Les concepts associés à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
 - [Utiliser l'API JavaScript WebAssembly](/fr/docs/WebAssembly/Guides/Using_the_JavaScript_API)

--- a/files/fr/webassembly/reference/javascript_interface/instance/exports/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/instance/exports/index.md
@@ -1,36 +1,34 @@
 ---
 title: WebAssembly.Instance.prototype.exports
 slug: WebAssembly/Reference/JavaScript_interface/Instance/exports
-original_slug: WebAssembly/JavaScript_interface/Instance/exports
+l10n:
+  sourceCommit: 006c05b688814b45a01ad965bbe4ebfc15513e74
 ---
 
-{{WebAssemblySidebar}}
-
-La propriété **`exports`** du prototype de {{jsxref("WebAssembly.Instance")}} est une propriété en lecture seul qui renvoie un objet dont les propriétés sont les différentes fonctions exportées depuis l'instance du module WebAssembly. Cela permet d'y accéder et de les manipuler en JavaScript.
-
-```js
-instance.exports;
-```
+La propriété en lecture seule **`exports`** de l'objet [`WebAssembly.Instance`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Instance) retourne un objet contenant comme membres toutes les fonctions exportées depuis l'instance du module WebAssembly, permettant ainsi d'y accéder et de les utiliser en JavaScript.
 
 ## Exemples
 
-Après avoir récupéré le _bytecode_ WebAssembly grâce à la méthode `fetch()`, on le compile et on instancie le module grâce à la fonction {{jsxref("WebAssembly.instantiateStreaming()")}}. Lorsqu'on utilise cette fonction, on importe une fonction dans le module. Ensuite, on appelle [une fonction WebAssembly exportée](/fr/docs/WebAssembly/Guides/Exported_functions) qui est exposée via l'instance.
+### Utiliser la propriété `exports`
+
+Après avoir récupéré des octets WebAssembly en utilisant `fetch`, vous compilez et instanciez le module en utilisant la fonction [`WebAssembly.instantiateStreaming()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static), en important au passage une fonction JavaScript dans le module WebAssembly. Vous appelez ensuite une [fonction WebAssembly exportée](/fr/docs/WebAssembly/Guides/Exported_functions) qui est exportée par une `Instance`.
 
 ```js
-var importObject = {
-  imports: {
-    imported_func: function (arg) {
+const importObject = {
+  my_namespace: {
+    imported_func(arg) {
       console.log(arg);
     },
   },
 };
+
 WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject).then(
   (obj) => obj.instance.exports.exported_func(),
 );
 ```
 
 > [!NOTE]
-> Voir le fichier [index.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/index.html) sur GitHub (ainsi que [la démonstration](https://mdn.github.io/webassembly-examples/js-api-examples/)) pour un exemple.
+> Vous pouvez également trouver cet exemple dans [instantiate-streaming.html <sup>(angl.)</sup>](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/instantiate-streaming.html) sur GitHub ([la voir en direct <sup>(angl.)</sup>](https://mdn.github.io/webassembly-examples/js-api-examples/instantiate-streaming.html)).
 
 ## Spécifications
 
@@ -42,6 +40,6 @@ WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject).then(
 
 ## Voir aussi
 
-- [Le portail WebAssembly](/fr/docs/WebAssembly)
-- [Les concepts relatifs à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
+- Un aperçu de [WebAssembly](/fr/docs/WebAssembly)
+- [Les concepts associés à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
 - [Utiliser l'API JavaScript WebAssembly](/fr/docs/WebAssembly/Guides/Using_the_JavaScript_API)

--- a/files/fr/webassembly/reference/javascript_interface/memory/buffer/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/memory/buffer/index.md
@@ -1,32 +1,32 @@
 ---
 title: WebAssembly.Memory.prototype.buffer
 slug: WebAssembly/Reference/JavaScript_interface/Memory/buffer
-original_slug: WebAssembly/JavaScript_interface/Memory/buffer
+l10n:
+  sourceCommit: 006c05b688814b45a01ad965bbe4ebfc15513e74
 ---
 
-{{WebAssemblySidebar}}
-
-La propriété **`buffer`**, rattachée au prototype de l'objet [`Memory`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Memory), renvoie le tampon (_buffer_) contenu dans l'espace mémoire.
-
-## Syntaxe
-
-```js
-memory.buffer;
-```
+La propriété en lecture seule **`buffer`** de l'objet [`WebAssembly.Memory`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Memory) retourne le tampon contenu dans la mémoire. Selon que la mémoire a été construite avec `shared: true` ou non, le tampon est soit un {{JSxRef("ArrayBuffer")}}, soit un {{JSxRef("SharedArrayBuffer")}}.
 
 ## Exemples
 
-Dans l'exemple suivant (cf. le fichier [memory.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/memory.html) sur GitHub ainsi que [le résultat obtenu](https://mdn.github.io/webassembly-examples/js-api-examples/memory.html)), on récupère puis on instancie le _bytecode_ `memory.wasm` grâce à la méthode {{jsxref("WebAssembly.instantiateStreaming()")}} tout en important la mémoire créée à la ligne précédente. Ensuite, on enregistre certaines valeurs dans cette mémoire puis on exporte une fonction afin de l'utiliser pour additionner certaines valeurs.
+### Utiliser la propriété `buffer`
+
+L'exemple suivant (voir [memory.html <sup>(angl.)</sup>](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/memory.html) sur GitHub, et [la voir en direct <sup>(angl.)</sup>](https://mdn.github.io/webassembly-examples/js-api-examples/memory.html)) récupère et instancie le code binaire chargé «&nbsp;memory.wasm&nbsp;» en utilisant la fonction [`WebAssembly.instantiateStreaming()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static), tout en important la mémoire créée à la ligne ci-dessus. Il stocke ensuite des valeurs dans cette mémoire, exporte une fonction, et utilise la fonction exportée pour additionner ces valeurs.
 
 ```js
+const memory = new WebAssembly.Memory({
+  initial: 10,
+  maximum: 100,
+});
+
 WebAssembly.instantiateStreaming(fetch("memory.wasm"), {
   js: { mem: memory },
 }).then((obj) => {
-  var i32 = new Uint32Array(memory.buffer);
-  for (var i = 0; i < 10; i++) {
-    i32[i] = i;
+  const summands = new DataView(memory.buffer);
+  for (let i = 0; i < 10; i++) {
+    summands.setUint32(i * 4, i, true); // WebAssembly est petit boutiste
   }
-  var sum = obj.instance.exports.accumulate(0, 10);
+  const sum = obj.instance.exports.accumulate(0, 10);
   console.log(sum);
 });
 ```
@@ -41,6 +41,6 @@ WebAssembly.instantiateStreaming(fetch("memory.wasm"), {
 
 ## Voir aussi
 
-- [Le portail WebAssembly](/fr/docs/WebAssembly)
-- [Les concepts relatifs à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
+- Un aperçu de [WebAssembly](/fr/docs/WebAssembly)
+- [Les concepts associés à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
 - [Utiliser l'API JavaScript WebAssembly](/fr/docs/WebAssembly/Guides/Using_the_JavaScript_API)

--- a/files/fr/webassembly/reference/javascript_interface/memory/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/memory/index.md
@@ -1,80 +1,92 @@
 ---
 title: WebAssembly.Memory()
 slug: WebAssembly/Reference/JavaScript_interface/Memory
-original_slug: WebAssembly/JavaScript_interface/Memory
+l10n:
+  sourceCommit: 562051c4ad20e9ecb5faf905286cdfca545a340d
 ---
 
-{{WebAssemblySidebar}}
+L'objet **`WebAssembly.Memory`** est un {{JSxRef("ArrayBuffer")}} ou {{JSxRef("SharedArrayBuffer")}} redimensionnable qui contient des octets bruts de mémoire accessibles par un objet [`WebAssembly.Instance`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Instance).
 
-Le constructeur **`WebAssembly.Memory()`** crée un nouvel objet `Memory` dont la propriété {{jsxref("WebAssembly/Memory/buffer","buffer")}} est un {{jsxref("ArrayBuffer")}} redimensionnable qui contient les octets de mémoire bruts accessibles par une instance WebAssembly.
+WebAssembly et JavaScript permettent tous deux de créer des objets `Memory`.
+Si vous souhaitez accéder à la mémoire créée en JS depuis WebAssembly, ou inversement, vous pouvez exporter la mémoire du module vers JavaScript ou importer la mémoire de JavaScript vers le module lors de son [instanciation](/fr/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static).
 
-Un espace mémoire créé depuis du code JavaScript ou depuis du code WebAssembly sera accessible et modifiable (_mutable_) depuis JavaScript **et** depuis WebAssembly.
-
-## Syntaxe
-
-```js
-var maMemoire = new WebAssembly.Memory(descripteurMemoire);
-```
-
-### Paramètres
-
-- `descripteurMemoire`
-  - : Un objet qui contient les propriétés suivantes :
-    - `initial`
-      - : La taille initiale de cet espace mémoire WebAssembly, exprimée en nombre de pages WebAssembly.
-    - `maximum` {{optional_inline}}
-      - : La taille maximale autorisée pour cet espace mémoire WebAssembly, exprimée en nombre de pages WebAssembly. Lorsque ce paramètre est utilisé, il est fournit comme indication au moteur pour que celui-ci réserve l'espace mémoire correspondant. Toutefois, le moteur peut choisir d'ignorer cette indication. Dans la plupart des cas, il n'est pas nécessaire d'indiquer un maximum pour les modules WebAssembly.
+À l'origine, vous ne pouviez effectuer des opérations de mémoire que sur une seule mémoire dans le module Wasm, donc bien que plusieurs objets `Memory` puissent être créés, cela n'avait aucun intérêt.
+Les implémentations plus récentes permettent aux [instructions de mémoire](/fr/docs/WebAssembly/Reference/Memory) de WebAssembly d'opérer sur une mémoire définie.
+Pour plus d'informations, voir [Mémoires multiples](/fr/docs/WebAssembly/Guides/Understanding_the_text_format#multiple_memories) dans _Comprendre le format texte WebAssembly_.
 
 > [!NOTE]
-> Une page mémoire WebAssembly correspond à une taille fixe de 65 536 octets, soit environ 64 Ko.
+> La mémoire WebAssembly est toujours au format petit-boutiste, quel que soit la plateforme sur laquelle elle est exécutée. Par conséquent, pour des raisons de portabilité, vous devez lire et écrire des valeurs multi-octets en JavaScript en utilisant {{JSxRef("DataView")}}.
 
-### Exceptions
+## Constructeur
 
-- Si `descripteurMemoire` n'est pas un objet, une exception {{jsxref("TypeError")}} sera levée.
-- Si `maximum` est indiqué et qu'il est inférieur à `initial`, une exception {{jsxref("RangeError")}} sera levée.
+- [`WebAssembly.Memory()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Memory/Memory)
+  - : Crée un nouvel objet `Memory`.
 
-## Méthodes du constructeur `Memory`
+## Propriétés d'instance
 
-Aucune.
+- [`Memory.prototype.buffer`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer) {{ReadOnlyInline}}
+  - : Retourne le tampon contenu dans la mémoire.
 
-## Instances de `Memory`
+## Méthodes d'instance
 
-Toutes les instances de `Memory` héritent des propriétés du [prototype du constructeur](/fr/docs/WebAssembly/Reference/JavaScript_interface/Memory) `Memory()` qui peut être utilisé afin de modifier le comportement de l'ensemble des instances de `Memory`.
-
-### Propriétés
-
-- `Memory.prototype.constructor`
-  - : Renvoie la fonction qui a créé l'instance de l'objet. Par défaut, c'est le constructeur {{jsxref("WebAssembly.Memory()")}}.
-- {{jsxref("WebAssembly/Memory/buffer","Memory.prototype.buffer")}}
-  - : Une propriété d'accesseur qui renvoie le tampon contenu dans l'espace mémoire.
-
-### Méthodes
-
-- {{jsxref("WebAssembly/Memory/grow","Memory.prototype.grow()")}}
-  - : Cette méthode permet d'augmenter la taille de l'espace mémoire d'un nombre de pages donné (dont chacune mesure 64 Ko).
+- [`Memory.prototype.grow()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Memory/grow)
+  - : Augmente la taille de l'instance de mémoire d'un nombre défini de pages WebAssembly (chacune de 64 KiB). Détache le `buffer` précédent.
 
 ## Exemples
 
-Il existe deux façons de créer un objet `WebAssembly.Memory`. La première consiste à le créer explicitement en JavaScript. Avec l'instruction qui suit, on crée un espace mémoire avec une taille initiale de 10 pages (soit 640 Ko) et une taille maximale de 100 pages (soit 6,4 Mo).
+### Créer un nouvel objet `Memory`
+
+Il existe deux façons d'obtenir un objet `WebAssembly.Memory`. La première consiste à le construire à partir de JavaScript. L'extrait suivant crée une nouvelle instance de mémoire WebAssembly avec une taille initiale de 10 pages (640 KiB) et une taille maximale de 100 pages (6,4 MiB). Sa propriété [`buffer`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer) retourne un {{JSxRef("ArrayBuffer")}}.
 
 ```js
-var memoire = new WebAssembly.Memory({ initial: 10, maximum: 100 });
+const memory = new WebAssembly.Memory({
+  initial: 10,
+  maximum: 100,
+});
 ```
 
-La seconde méthode permettant d'obtenir un objet `WebAssembly.Memory` est de l'exporter depuis un module WebAssembly. Dans l'exemple suivant (cf. le fichier [memory.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/memory.html) sur GitHub ainsi que [le résultat obtenu](https://mdn.github.io/webassembly-examples/js-api-examples/memory.html)) on récupère et on instancie le _bytecode_ `memory.wasm` grâce à la méthode {{jsxref("WebAssembly.instantiateStreaming()")}} tout en important la mémoire créée à la ligne précédente. Ensuite, on enregistre des valeurs au sein de cette mémoire puis on exporte une fonction qu'on utilise pour additionner certaines valeurs.
+L'exemple suivant (voir [memory.html <sup>(angl.)</sup>](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/memory.html) sur GitHub, et [la voir en direct <sup>(angl.)</sup>](https://mdn.github.io/webassembly-examples/js-api-examples/memory.html)) récupère et instancie le code binaire chargé «&nbsp;memory.wasm&nbsp;» en utilisant la fonction [`WebAssembly.instantiateStreaming()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static), tout en important la mémoire créée à la ligne ci-dessus. Il stocke ensuite des valeurs dans cette mémoire, exporte une fonction, et utilise la fonction exportée pour additionner ces valeurs. Notez l'utilisation de {{JSxRef("DataView")}} pour accéder à la mémoire afin d'utiliser toujours le format petit-boutiste.
 
 ```js
+const memory = new WebAssembly.Memory({
+  initial: 10,
+  maximum: 100,
+});
+
 WebAssembly.instantiateStreaming(fetch("memory.wasm"), {
   js: { mem: memory },
 }).then((obj) => {
-  var i32 = new Uint32Array(memory.buffer);
-  for (var i = 0; i < 10; i++) {
-    i32[i] = i;
+  const summands = new DataView(memory.buffer);
+  for (let i = 0; i < 10; i++) {
+    summands.setUint32(i * 4, i, true); // WebAssembly est petit boutiste
   }
-  var sum = obj.instance.exports.accumulate(0, 10);
+  const sum = obj.instance.exports.accumulate(0, 10);
   console.log(sum);
 });
 ```
+
+Une autre façon d'obtenir un objet `WebAssembly.Memory` est de l'avoir exporté par un module WebAssembly. Cette mémoire peut être accédée dans la propriété `exports` de l'instance WebAssembly (après que la mémoire ait été exportée dans le module WebAssembly). L'exemple suivant importe une mémoire exportée depuis WebAssembly avec le nom `memory`, puis affiche le premier élément de la mémoire, interprété comme un {{JSxRef("Uint32Array")}}.
+
+```js
+WebAssembly.instantiateStreaming(fetch("memory.wasm")).then((obj) => {
+  const values = new DataView(obj.instance.exports.memory.buffer);
+  console.log(values.getUint32(0, true));
+});
+```
+
+### Créer une mémoire partagée
+
+Par défaut, les mémoires WebAssembly ne sont pas partagées. Vous pouvez créer une [mémoire partagée](/fr/docs/WebAssembly/Guides/Understanding_the_text_format#mémoires_partagées) depuis JavaScript en passant `shared: true` dans l'objet d'initialisation du constructeur&nbsp;:
+
+```js
+const memory = new WebAssembly.Memory({
+  initial: 10,
+  maximum: 100,
+  shared: true,
+});
+```
+
+La propriété `buffer` de cette mémoire retournera un objet {{JSxRef("SharedArrayBuffer")}}.
 
 ## Spécifications
 
@@ -86,6 +98,6 @@ WebAssembly.instantiateStreaming(fetch("memory.wasm"), {
 
 ## Voir aussi
 
-- [Le portail WebAssembly](/fr/docs/WebAssembly)
-- [Les concepts relatifs à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
+- Un aperçu de [WebAssembly](/fr/docs/WebAssembly)
+- [Les concepts associés à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
 - [Utiliser l'API JavaScript WebAssembly](/fr/docs/WebAssembly/Guides/Using_the_JavaScript_API)

--- a/files/fr/webassembly/reference/javascript_interface/table/get/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/table/get/index.md
@@ -1,17 +1,16 @@
 ---
 title: WebAssembly.Table.prototype.get()
 slug: WebAssembly/Reference/JavaScript_interface/Table/get
-original_slug: WebAssembly/JavaScript_interface/Table/get
+l10n:
+  sourceCommit: 006c05b688814b45a01ad965bbe4ebfc15513e74
 ---
 
-{{WebAssemblySidebar}}
-
-La méthode **`get()`**, rattachéee au prototype de {{jsxref("WebAssembly.Table()")}}, permet de récupérer une référence à une fonction stockée dans le tableau WebAssembly grâce à sa position. dans le tableau.
+La méthode **`get()`** du prototype de [`WebAssembly.Table()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table) permet de récupérer l'élément stocké à un index donné.
 
 ## Syntaxe
 
-```js
-var funcRef = table.get(index);
+```js-nolint
+get(index)
 ```
 
 ### Paramètres
@@ -21,25 +20,27 @@ var funcRef = table.get(index);
 
 ### Valeur de retour
 
-Une référence de fonction, c'est-à-dire [une fonction WebAssembly exportée](/fr/docs/WebAssembly/Guides/Exported_functions) qui est une enveloppe JavaScript pour manipuler la fonction WebAssembly sous-jacente.
+Selon le type d'élément du tableau, cela peut être une référence de fonction — il s'agit d'une [fonction WebAssembly exportée](/fr/docs/WebAssembly/Guides/Exported_functions), d'une enveloppe JavaScript pour une fonction Wasm sous-jacente, ou d'une référence d'hôte.
 
 ### Exceptions
 
-Si `index` est supérieur ou égal à {{jsxref("WebAssembly/Table/length","Table.prototype.length")}}, la méthode lèvera une exception {{jsxref("RangeError")}}.
+Si `index` est supérieur ou égal à [`Table.prototype.length`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table/length), la méthode lèvera une exception {{JSxRef("RangeError")}}.
 
 ## Exemples
 
-Dans l'exemple suivant (cf. le fichier [`table.html`](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table.html) sur GitHub ainsi que [le résultat obtenu](https://mdn.github.io/webassembly-examples/js-api-examples/table.html)), on compile et on instancie le _bytecode_ chargé, `table.wasm`, grâce à la méthode {{jsxref("WebAssembly.instantiateStreaming()")}}. On récupère ensuite les références stockées dans le tableau d'export.
+### Utiliser la méthode `get()`
+
+L'exemple suivant (voir [table.html <sup>(angl.)</sup>](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/table.html) sur GitHub, et [le voir en direct <sup>(angl.)</sup>](https://mdn.github.io/webassembly-examples/js-api-examples/table.html) également) compile et instancie le code binaire «&nbsp;table.wasm&nbsp;» chargé à l'aide de la méthode [`WebAssembly.instantiateStreaming()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static). Il récupère ensuite les références stockées dans le tableau exporté.
 
 ```js
-WebAssembly.instantiateStreaming(fetch("table.wasm")).then(function (obj) {
-  var tbl = obj.instance.exports.tbl;
+WebAssembly.instantiateStreaming(fetch("table.wasm")).then((obj) => {
+  const tbl = obj.instance.exports.tbl;
   console.log(tbl.get(0)()); // 13
   console.log(tbl.get(1)()); // 42
 });
 ```
 
-On note ici qu'il est nécessaire d'avoir un deuxième opérateur d'appel après l'accesseur pour récupérer le valeur stockée dans la référence (autrement dit, on utilise `get(0)()` plutôt que `get(0)`). La valeur exportée est une fonction plutôt qu'une valeur simple.
+Remarquez qu'il faut inclure un second opérateur d'appel de fonction à la fin de l'accesseur pour réellement obtenir la valeur stockée dans la référence (par exemple, `get(0)()` plutôt que `get(0)`) — il s'agit d'une fonction et non d'une simple valeur.
 
 ## Spécifications
 
@@ -51,6 +52,6 @@ On note ici qu'il est nécessaire d'avoir un deuxième opérateur d'appel après
 
 ## Voir aussi
 
-- [Le portail WebAssembly](/fr/docs/WebAssembly)
-- [Les concepts relatifs à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
+- Un aperçu de [WebAssembly](/fr/docs/WebAssembly)
+- [Les concepts associés à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
 - [Utiliser l'API JavaScript WebAssembly](/fr/docs/WebAssembly/Guides/Using_the_JavaScript_API)

--- a/files/fr/webassembly/reference/javascript_interface/table/grow/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/table/grow/index.md
@@ -1,23 +1,25 @@
 ---
 title: WebAssembly.Table.prototype.grow()
 slug: WebAssembly/Reference/JavaScript_interface/Table/grow
-original_slug: WebAssembly/JavaScript_interface/Table/grow
+l10n:
+  sourceCommit: 006c05b688814b45a01ad965bbe4ebfc15513e74
 ---
 
-{{WebAssemblySidebar}}
-
-La méthode **`grow()`**, rattachée au prototype de {{jsxref("WebAssembly.Table")}}, permet d'augmenter la taille du tableau WebAssembly d'un nombre d'éléments donné.
+La méthode **`grow()`** de l'objet [`WebAssembly.Table`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table) permet d'augmenter la taille de l'instance de `Table` d'un nombre défini d'éléments, remplis avec la valeur fournie.
 
 ## Syntaxe
 
-```js
-table.grow(nombre);
+```js-nolint
+grow(delta)
+grow(delta, value)
 ```
 
 ### Paramètres
 
-- `nombre`
+- `delta`
   - : Le nombre d'éléments qu'on souhaite ajouter au tableau.
+- `value` {{Optional_Inline}}
+  - : L'élément avec lequel remplir l'espace nouvellement alloué.
 
 ### Valeur de retour
 
@@ -25,26 +27,54 @@ La taille du tableau avant l'agrandissement.
 
 ### Exceptions
 
-Si l'opération `grow()` échoue, pour quelque raison que ce soit, une exception {{jsxref("RangeError")}} sera levée.
+- {{JSxRef("RangeError")}}
+  - : Levée dans l'un des cas suivants&nbsp;:
+    - Si la taille actuelle additionnée à `delta` dépasse la capacité maximale de l'instance de `Table`.
+    - Si le client n'a pas assez de mémoire pour l'allocation.
+- {{JSxRef("TypeError")}}
+  - : Levée si `value` n'est pas une valeur du type d'élément du tableau
 
 ## Exemples
 
-Dans l'exemple qui suit, on crée une instance de `Table` pour représenter un tableau WebAssembly avec une taille initiale de 2 et une taille maximale de 10.
+### Utiliser la méthode `grow()`
+
+L'exemple suivant crée une nouvelle instance du tableau WebAssembly avec une taille initiale de 2 et une taille maximale de 10&nbsp;:
 
 ```js
-var table = new WebAssembly.Table({
+const tableau = new WebAssembly.Table({
   element: "anyfunc",
   initial: 2,
   maximum: 10,
 });
 ```
 
-On étend ensuite le tableau d'une unité en utilisant la méthode `grow()` :
+On agrandit le tableau d'un élément en utilisant `Table.grow()`&nbsp;:
 
 ```js
-console.log(table.length); // "2"
-console.log(table.grow(1)); // "2"
-console.log(table.length); // "3"
+console.log(tableau.length); // 2
+tableau.grow(1);
+console.log(tableau.length); // 3
+```
+
+### Utiliser `grow()` avec une valeur
+
+L'exemple suivant crée une nouvelle instance de `Table` WebAssembly avec une taille initiale de 0 et une taille maximale de 4, en la remplissant avec un objet&nbsp;:
+
+```js
+const monObjet = { bonjour: "le monde" };
+
+const tableau = new WebAssembly.Table({
+  element: "externref",
+  initial: 0,
+  maximum: 4,
+});
+```
+
+On agrandit le tableau de 4 unités et on le remplit avec une valeur en utilisant `WebAssembly.grow()`&nbsp;:
+
+```js
+tableau.grow(4, monObjet);
+console.log(monObjet === tableau.get(2)); // true
 ```
 
 ## Spécifications
@@ -57,6 +87,6 @@ console.log(table.length); // "3"
 
 ## Voir aussi
 
-- [Le portail WebAssembly](/fr/docs/WebAssembly)
-- [Les concepts relatifs à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
+- Un aperçu de [WebAssembly](/fr/docs/WebAssembly)
+- [Les concepts associés à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
 - [Utiliser l'API JavaScript WebAssembly](/fr/docs/WebAssembly/Guides/Using_the_JavaScript_API)

--- a/files/fr/webassembly/reference/javascript_interface/table/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/table/index.md
@@ -1,96 +1,70 @@
 ---
-title: WebAssembly.Table()
+title: WebAssembly.Table
 slug: WebAssembly/Reference/JavaScript_interface/Table
-original_slug: WebAssembly/JavaScript_interface/Table
+l10n:
+  sourceCommit: 006c05b688814b45a01ad965bbe4ebfc15513e74
 ---
 
-{{WebAssemblySidebar}}
-
-Le constructeur **`WebAssembly.Table()`** permet de créer un nouvel objet `Table`.
-
-Cet objet est une enveloppe JavaScript qui représente un tableau WebAssembly et qui contient des références à des fonctions. Un tableau créé en JavaScript ou dans du code WebAssembly sera accessible et modifiable depuis du code JavaScript et depuis du code WebAssembly.
+L'objet **`WebAssembly.Table`** est un objet JavaScript qui agit comme une structure de type tableau représentant un tableau WebAssembly, lequel stocke des références homogènes. Un tableau créé en JavaScript ou dans du code WebAssembly sera accessible et modifiable depuis du code JavaScript et depuis du code WebAssembly.
 
 > [!NOTE]
-> Actuellement, les tableaux WebAssembly peuvent uniquement stocker des références à des fonctions. Cette fonctionnalité sera vraisemblablement étendue par la suite.
+> Actuellement, les tableaux WebAssembly peuvent uniquement stocker des références à des fonctions ou des références hôtes, mais cette fonctionnalité sera vraisemblablement étendue par la suite.
 
-## Syntaxe
+## Constructeur
 
-```js
-var monTableau = new WebAssembly.Table(descripteurTableau);
-```
+- [`WebAssembly.Table()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table/Table)
+  - : Crée un nouvel objet `Table`.
 
-### Paramètres
+## Propriétés d'instance
 
-- `descripteurTableau`
-  - : Un objet composé des propriétés qui suivent :
-    - `element`
-      - : Une chaîne de caractères qui représente le type de référence enregistrée dans le tableau. Actuellement, la seule valeur possible est `"anyfunc"` (pour indiquer des fonctions).
-    - `initial`
-      - : La longueur initiale du tableau WebAssembly. Cela correspond au nombre d'éléments contenus dans le tableau.
-    - `maximum {{optional_inline}}`
-      - : La taille maximale que pourra avoir tableau WebAssembly s'il est étendu.
+- [`Table.prototype.length`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table/length) {{ReadOnlyInline}}
+  - : Retourne la longueur du tableau, c'est-à-dire le nombre d'éléments dans le tableau.
 
-### Exceptions
+## Méthodes d'instance
 
-- Si `tableDescriptor` n'est pas un objet, une exception {{jsxref("TypeError")}} sera levée.
-- Si `maximum` est défini et est inférieur à `initial`, une exception {{jsxref("RangeError")}} sera levée.
-
-## Instances de `Table`
-
-Toutes les instances `Table` héritent des propriétés [du prototype du constructeur](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table) `Table()`. Ce dernier peut être utilisé afin de modifier l'ensemble des instances `Table`.
-
-### Propriétés
-
-- `Table.prototype.constructor`
-  - : Renvoie la fonction qui a créé l'instance. Par défaut, c'est le constructeur {{jsxref("WebAssembly.Table()")}}.
-- {{jsxref("WebAssembly/Table/length","Table.prototype.length")}}
-  - : Renvoie la longueur du tableau, c'est-à-dire le nombre de références qui sont enregistrées dans le tableau.
-
-### Méthodes
-
-- {{jsxref("WebAssembly/Table/get","Table.prototype.get()")}}
-  - : Une fonction d'accès qui permet d'obtenir l'élément du tableau situé à une position donnée.
-- {{jsxref("WebAssembly/Table/grow","Table.prototype.grow()")}}
-  - : Cette méthode permet d'augmenter la taille du tableau `Table` d'un incrément donné.
-- {{jsxref("WebAssembly/Table/set","Table.prototype.set()")}}
-  - : Cette méthode permet de modifier un élément du tableau situé à une position donnée.
+- [`Table.prototype.get()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table/get)
+  - : Fonction accesseur — obtient l'élément stocké à un index donné.
+- [`Table.prototype.grow()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table/grow)
+  - : Augmente la taille de l'instance `Table` d'un nombre défini d'éléments.
+- [`Table.prototype.set()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table/set)
+  - : Définit un élément stocké à un index donné avec une valeur donnée.
 
 ## Exemples
 
-Dans l'exemple qui suit (tiré du fichier [table2.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.html) et qui dispose [d'une démonstration](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)), on crée une nouvelle instance d'un tableau WebAssembly avec une taille initiale permettant de stocker 2 références. Ensuite, on imprime la longueur du tableau et le contenu des deux éléments (obtenus grâce à la méthode {{jsxref("WebAssembly/Table/get", "Table.prototype.get()")}} afin de montrer que la longueur vaut 2 et que le tableau ne contient encore aucune référence de fonction (pour les deux positions, on a la valeur {{jsxref("null")}}).
+### Créer une nouvelle instance de `Table` WebAssembly
+
+L'exemple suivant (voir table2.html [code source <sup>(angl.)</sup>](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/table2.html) et [version en ligne <sup>(angl.)</sup>](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)) crée une nouvelle instance de Table WebAssembly avec une taille initiale de 2 éléments. Nous affichons ensuite la longueur du tableau et le contenu des deux indices (obtenus avec [`Table.prototype.get()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table/get)) pour montrer que la longueur est de deux et que les deux éléments sont [`null`](/fr/docs/Web/JavaScript/Reference/Operators/null).
 
 ```js
-var tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });
-console.log(tbl.length);
-console.log(tbl.get(0));
-console.log(tbl.get(1));
+const tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });
+console.log(tbl.length); // "2"
+console.log(tbl.get(0)); // "null"
+console.log(tbl.get(1)); // "null"
 ```
 
-Ensuite, on crée un objet d'import qui contient une référence au tableau :
+Nous créons ensuite un objet d'importation qui contient le tableau&nbsp;:
 
 ```js
-var importObj = {
-  js: {
-    tbl: tbl,
-  },
+const importObj = {
+  js: { tbl },
 };
 ```
 
-Enfin, on charge et on instancie un module WebAssembly (table2.wasm) grâce à la fonction {{jsxref("WebAssembly.instantiateStreaming()")}}. Le module `table2.wasm` a ajouté deux références de fonctions (cf. [sa représentation textuelle](https://github.com/mdn/webassembly-examples/blob/0991effbbf2e2cce38a7dbadebd2f3495e3f4e07/js-api-examples/table2.wat)). Chacune de ces fonctions fournit une valeur simple :
+Enfin, nous chargeons et instancions un module Wasm (table2.wasm) en utilisant la méthode [`WebAssembly.instantiateStreaming()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static). Le module table2.wasm contient deux fonctions (une qui retourne 42 et une autre qui retourne 83) et les stocke dans les éléments 0 et 1 du tableau importé (voir [représentation textuelle <sup>(angl.)</sup>](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/table2.wat)). Ainsi, après l'instanciation, le tableau a toujours une longueur de 2, mais les éléments contiennent maintenant des [fonctions WebAssembly exportées](/fr/docs/WebAssembly/Guides/Exported_functions) appelables depuis JS.
 
 ```js
 WebAssembly.instantiateStreaming(fetch("table2.wasm"), importObject).then(
-  function (obj) {
-    console.log(tbl.length); // "2"
-    console.log(tbl.get(0)()); // "42"
-    console.log(tbl.get(1)()); // "83"
+  (obj) => {
+    console.log(tbl.length);
+    console.log(tbl.get(0)());
+    console.log(tbl.get(1)());
   },
 );
 ```
 
-On voit ici qu'il faut d'abord récupérer la fonction puis effectuer une invocation pour obtenir la valeur correspondante à partir de l'accesseur (autrement dit, on écrit `get(0)()` plutôt que `get(0)` pour obtenir le résultat de la fonction) .
+Notez qu'il faut inclure un second opérateur d'invocation de fonction à la fin de l'accesseur pour réellement invoquer la fonction référencée et enregistrer la valeur qu'elle contient (par exemple, `get(0)()` plutôt que `get(0)`).
 
-Dans cet exemple, on voit comment créer et manipuler le tableau depuis du code JavaScript mais ce même tableau est également accessible depuis l'instance WebAssembly.
+Cet exemple montre que nous créons et accédons au tableau depuis JavaScript, mais le même tableau est également visible et appelable à l'intérieur de l'instance Wasm.
 
 ## Spécifications
 
@@ -102,6 +76,6 @@ Dans cet exemple, on voit comment créer et manipuler le tableau depuis du code 
 
 ## Voir aussi
 
-- [Le portail WebAssembly](/fr/docs/WebAssembly)
-- [Les concepts relatifs à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
+- Un aperçu de [WebAssembly](/fr/docs/WebAssembly)
+- [Les concepts associés à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
 - [Utiliser l'API JavaScript WebAssembly](/fr/docs/WebAssembly/Guides/Using_the_JavaScript_API)

--- a/files/fr/webassembly/reference/javascript_interface/table/length/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/table/length/index.md
@@ -1,37 +1,32 @@
 ---
 title: WebAssembly.Table.prototype.length
 slug: WebAssembly/Reference/JavaScript_interface/Table/length
-original_slug: WebAssembly/JavaScript_interface/Table/length
+l10n:
+  sourceCommit: 006c05b688814b45a01ad965bbe4ebfc15513e74
 ---
 
-{{WebAssemblySidebar}}
-
-La propriété **`length`**, rattachée au prototype de l'objet {{jsxref("WebAssembly.Table")}}, renvoie la longueur du tableau WebAssembly, c'est-à-dire le nombre d'éléments qui y sont stockées.
-
-## Syntaxe
-
-```js
-table.length;
-```
+La propriété en lecture seule **`length`** de l'objet [`WebAssembly.Table`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table) retourne la longueur du tableau, c'est-à-dire le nombre d'éléments dans le tableau.
 
 ## Exemples
 
-Avec l'instruction qui suit, on crée un tableau WebAssembly avec une taille initiale de 2 éléments et avec une taille maximale de 10.
+### Utiliser la propriété `length`
+
+L'exemple suivant crée une nouvelle instance de tableau WebAssembly avec une taille initiale de 2 et une taille maximale de 10&nbsp;:
 
 ```js
-var table = new WebAssembly.Table({
+const tableau = new WebAssembly.Table({
   element: "anyfunc",
   initial: 2,
   maximum: 10,
 });
 ```
 
-On peut ensuite étendre le tableau d'un élément :
+On agrandit le tableau d'un élément en utilisant `WebAssembly.grow()`&nbsp;:
 
 ```js
-console.log(table.length); // "2"
-console.log(table.grow(1)); // "2"
-console.log(table.length); // "3"
+console.log(tableau.length); // 2
+tableau.grow(1);
+console.log(tableau.length); // 3
 ```
 
 ## Spécifications
@@ -44,6 +39,6 @@ console.log(table.length); // "3"
 
 ## Voir aussi
 
-- [Le portail WebAssembly](/fr/docs/WebAssembly)
-- [Les concepts relatifs à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
+- Un aperçu de [WebAssembly](/fr/docs/WebAssembly)
+- [Les concepts associés à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
 - [Utiliser l'API JavaScript WebAssembly](/fr/docs/WebAssembly/Guides/Using_the_JavaScript_API)

--- a/files/fr/webassembly/reference/javascript_interface/table/set/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/table/set/index.md
@@ -1,61 +1,60 @@
 ---
 title: WebAssembly.Table.prototype.set()
 slug: WebAssembly/Reference/JavaScript_interface/Table/set
-original_slug: WebAssembly/JavaScript_interface/Table/set
+l10n:
+  sourceCommit: 006c05b688814b45a01ad965bbe4ebfc15513e74
 ---
 
-{{WebAssemblySidebar}}
-
-La méthode **`set()`**, rattachée au prototype de {{jsxref("WebAssembly.Table")}}, permet de modifier une référence de fonction stockée dans un tableau WebAssembly.
+La méthode **`set()`** de l'objet [`WebAssembly.Table`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table) permet de modifier une référence stockée à un index donné par une valeur différente.
 
 ## Syntaxe
 
-```js
-table.set(index, valeur);
+```js-nolint
+set(index, value)
 ```
 
 ### Paramètres
 
 - `index`
   - : L'index de la référence de la fonction qu'on souhaite modifier.
-- `valeur`
-  - : La valeur par laquelle on souhaite remplacer la référence. Cette valeur doit être [une fonction exportée WebAssembly](/fr/docs/WebAssembly/Guides/Exported_functions) (c'est-à-dire une enveloppe JavaScript représentant une fonction WebAssembly sous-jacente).
+- `value`
+  - : La valeur par laquelle on souhaite remplacer la référence. Cette valeur doit être une valeur du type d'élément du tableau. Selon le type, il peut s'agir d'une [fonction WebAssembly exportée](/fr/docs/WebAssembly/Guides/Exported_functions), d'une enveloppe JavaScript pour une fonction Wasm sous-jacente, ou d'une référence hôte.
 
 ### Valeur de retour
 
-Aucune.
+Aucune ({{JSxRef("undefined")}}).
 
 ### Exceptions
 
-- Si `index` est supérieur ou égal à {{jsxref("WebAssembly/Table/length","Table.prototype.length")}}, une exception {{jsxref("RangeError")}} sera levée.
-- Si `valeur` n'est pas une fonction WebAssembly exportée ou la valeur {{jsxref("null")}}, une exception {{jsxref("TypeError")}} sera levée.
+- Si `index` est supérieur ou égal à [`Table.prototype.length`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table/length), une exception {{JSxRef("RangeError")}} est levée.
+- Si `value` n'est pas du type d'élément du tableau, une exception {{JSxRef("TypeError")}} est levée.
 
 ## Exemples
 
-Dans l'exemple qui suit (basé sur le [code source de `table2.html`](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.html) et qui dispose [d'une démonstration](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)), on crée ue nouvelle instance d'un tableau WebAssembly (`Table`) qui permet initialement de stocker 2 référence. On imprime alors la longueur du tableau dans la console ainsi que le contenu pour les deux premiers index (obtenus grâce à la méthode {{jsxref("WebAssembly/Table/get","Table.prototype.get()")}}) afin de montrer qu la longueur vaut 2 et qu'initialement, les deux éléments du tableau ne contiennent aucune référence (ils ont tous les deux la valeur {{jsxref("null")}}).
+### Utiliser la méthode `set()`
+
+L'exemple suivant (voir «&nbsp;table2.html&nbsp;» [code source <sup>(angl.)</sup>](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/table2.html) et [version en direct <sup>(angl.)</sup>](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)) crée une nouvelle instance de tableau WebAssembly avec une taille initiale de deux références. Nous affichons ensuite la longueur du tableau et le contenu des deux index (ces valeurs sont obtenues à l'aide de [`Table.prototype.get()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Table/get)) pour montrer que la longueur est de deux, et que les index ne contiennent actuellement aucune référence de fonction (ils retournent actuellement [`null`](/fr/docs/Web/JavaScript/Reference/Operators/null)).
 
 ```js
-var tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });
+const tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });
 console.log(tbl.length);
 console.log(tbl.get(0));
 console.log(tbl.get(1));
 ```
 
-On crée ensuite un objet d'import qui contient une référence au tableau :
+Nous créons ensuite un objet d'importation qui contient une référence au tableau&nbsp;:
 
 ```js
-var importObj = {
-  js: {
-    tbl: tbl,
-  },
+const importObj = {
+  js: { tbl },
 };
 ```
 
-Enfin, on charge et on instancie le module WebAssembly (`table2.wasm`) grâce à la méthode {{jsxref("WebAssembly.instantiateStreaming()")}}, on logge la longueur du tableau et on appelle les deux fonctions référencées qui sont désormais dans le tableau (le module `table2.wasm` (cf. [la représentation textuelle](https://github.com/mdn/webassembly-examples/blob/master/text-format-examples/table2.was)) ajoute deux références de fonctions au tableau et chacune affiche une valeur simple) :
+Enfin, nous chargeons et instancions un module Wasm (table2.wasm) en utilisant [`WebAssembly.instantiateStreaming()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static), affichons la longueur du tableau, et invoquons les deux fonctions référencées qui sont maintenant stockées dans le tableau. Le module «&nbsp;table2.wasm&nbsp;» ajoute deux références de fonction au tableau, qui affichent chacune une valeur simple (voir [représentation textuelle <sup>(angl.)</sup>](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/table2.wat))&nbsp;:
 
 ```js
 WebAssembly.instantiateStreaming(fetch("table2.wasm"), importObject).then(
-  function (obj) {
+  (obj) => {
     console.log(tbl.length);
     console.log(tbl.get(0)());
     console.log(tbl.get(1)());
@@ -63,9 +62,9 @@ WebAssembly.instantiateStreaming(fetch("table2.wasm"), importObject).then(
 );
 ```
 
-On voit ici qu'il faut appeler la fonction après avoir appeler l'opérateur sur l'accesseur (autrement dit, on écrit `get(0)()` plutôt que `get(0)`) .
+Notez qu'il faut inclure un second opérateur d'appel de fonction à la fin de l'accesseur pour réellement invoquer la fonction référencée et afficher la valeur stockée à l'intérieur (par exemple, `get(0)()` plutôt que `get(0)`).
 
-Dans cet exemple, on montre comment créer et manipuler un tableau en JavaScript mais ce tableau est également accessible et manipulable depuis l'instance WebAssembly.
+Cet exemple montre que nous créons et accédons au tableau depuis JavaScript, mais que le même tableau est visible et appelable à l'intérieur de l'instance Wasm aussi.
 
 ## Spécifications
 
@@ -77,6 +76,6 @@ Dans cet exemple, on montre comment créer et manipuler un tableau en JavaScript
 
 ## Voir aussi
 
-- [Le portail WebAssembly](/fr/docs/WebAssembly)
-- [Les concepts relatifs à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
+- Un aperçu de [WebAssembly](/fr/docs/WebAssembly)
+- [Les concepts associés à WebAssembly](/fr/docs/WebAssembly/Guides/Concepts)
 - [Utiliser l'API JavaScript WebAssembly](/fr/docs/WebAssembly/Guides/Using_the_JavaScript_API)


### PR DESCRIPTION
### Description

Cleaning all JSxRef used as Wasm links instead of valid links.

### Motivation

_none_

### Additional details

_none_

### Related issues and pull requests

Fix https://github.com/mdn/translated-content/issues/8657
