### PR TITLE
fix(fr): add missing indentation

### DIFF
--- a/files/fr/web/html/reference/elements/dialog/index.md
+++ b/files/fr/web/html/reference/elements/dialog/index.md
@@ -26,7 +26,7 @@ Cet élément inclut les [attributs universels](/fr/docs/Web/HTML/Reference/Glob
     - `closerequest`
       - : Le dialogue peut être fermé par une action spécifique à la plateforme ou un mécanisme défini par le·la développeur·euse.
     - `none`
-    - : Le dialogue ne peut être fermé que par un mécanisme défini par le·la développeur·euse.
+      - : Le dialogue ne peut être fermé que par un mécanisme défini par le·la développeur·euse.
 
     Si l'élément `<dialog>` ne possède pas de valeur `closedby` valide&nbsp;:
     - s'il a été ouvert avec {{DOMxRef("HTMLDialogElement.showModal()", "showModal()")}}, il se comporte comme si la valeur était `"closerequest"`


### PR DESCRIPTION
### Description

There is a missing indentation in [the dialog docs](https://developer.mozilla.org/fr/docs/Web/HTML/Reference/Elements/dialog#attributs) in french language.

<img width="603" height="413" alt="Capture d’écran 2026-04-17 à 09 27 42" src="https://github.com/user-attachments/assets/35213175-d34c-4df9-b7e9-301d704dbd20" />

### Motivation

Fix indentation so the possible values are displayed correctly.

### Additional details

N/A

### Related issues and pull requests

N/A
