### PR TITLE
chore(sync-fr): global attributes pages use backticks on title

### DIFF
--- a/files/fr/web/html/reference/global_attributes/accesskey/index.md
+++ b/files/fr/web/html/reference/global_attributes/accesskey/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : accesskey"
+title: "Attribut HTML universel : `accesskey`"
 short-title: accesskey
 slug: Web/HTML/Reference/Global_attributes/accesskey
 l10n:
-  sourceCommit: 1696e3eadd2b142341a65a1cf6e9a4f3416412d1
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`accesskey`** indique un raccourci clavier possible pour l'élément courant. La valeur de l'attribut doit être un seul caractère imprimable (ce qui inclut les caractères accentués et autres caractères pouvant être générés par le clavier).

--- a/files/fr/web/html/reference/global_attributes/anchor/index.md
+++ b/files/fr/web/html/reference/global_attributes/anchor/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : anchor"
+title: "Attribut HTML universel : `anchor`"
 short-title: anchor
 slug: Web/HTML/Reference/Global_attributes/anchor
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 {{Non-standard_Header}}{{SeeCompatTable}}

--- a/files/fr/web/html/reference/global_attributes/autocapitalize/index.md
+++ b/files/fr/web/html/reference/global_attributes/autocapitalize/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : autocapitalize"
+title: "Attribut HTML universel : `autocapitalize`"
 short-title: autocapitalize
 slug: Web/HTML/Reference/Global_attributes/autocapitalize
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`autocapitalize`** est un attribut {{Glossary("Enumerated", "énuméré")}} qui contrôle si le texte saisi est automatiquement mis en majuscule et, le cas échéant, de quelle manière. Cela concerne&nbsp;:

--- a/files/fr/web/html/reference/global_attributes/autocorrect/index.md
+++ b/files/fr/web/html/reference/global_attributes/autocorrect/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : autocorrect"
+title: "Attribut HTML universel : `autocorrect`"
 short-title: autocorrect
 slug: Web/HTML/Reference/Global_attributes/autocorrect
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`autocorrect`** est un attribut {{Glossary("Enumerated", "énuméré")}} qui contrôle si la correction automatique du texte éditable est activée pour les erreurs d'orthographe et/ou de ponctuation.

--- a/files/fr/web/html/reference/global_attributes/autofocus/index.md
+++ b/files/fr/web/html/reference/global_attributes/autofocus/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : autofocus"
+title: "Attribut HTML universel : `autofocus`"
 short-title: autofocus
 slug: Web/HTML/Reference/Global_attributes/autofocus
 l10n:
-  sourceCommit: 01d5901fdbad83033fe1f86486f652d07db7ce2a
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`autofocus`** est un attribut booléen indiquant si l'élément doit recevoir la sélection (<i lang="en">focus</i> en anglais) au chargement de la page ou, s'il est imbriqué à l'intérieur d'un élément {{HTMLElement("dialog")}} ou [`popover`](/fr/docs/Web/HTML/Reference/Global_attributes/popover), lorsque le `<dialog>` ou la fenêtre contextuelle est affiché.

--- a/files/fr/web/html/reference/global_attributes/class/index.md
+++ b/files/fr/web/html/reference/global_attributes/class/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : class"
+title: "Attribut HTML universel : `class`"
 short-title: class
 slug: Web/HTML/Reference/Global_attributes/class
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`class`** est une liste des classes de l'élément, séparées par des [espaces ASCII](/fr/docs/Glossary/Whitespace#en_html).

--- a/files/fr/web/html/reference/global_attributes/contenteditable/index.md
+++ b/files/fr/web/html/reference/global_attributes/contenteditable/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : contenteditable"
+title: "Attribut HTML universel : `contenteditable`"
 short-title: contenteditable
 slug: Web/HTML/Reference/Global_attributes/contenteditable
 l10n:
-  sourceCommit: 9cfc2285428932f448a1747e347b1e35a3e0172b
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`contenteditable`** est un attribut énuméré qui indique si l'élément doit être éditable par l'utilisateur·ice. Si c'est le cas, le navigateur modifie son widget pour permettre l'édition.

--- a/files/fr/web/html/reference/global_attributes/data-_star_/index.md
+++ b/files/fr/web/html/reference/global_attributes/data-_star_/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : data-*"
+title: "Attribut HTML universel : `data-*`"
 short-title: data-*
 slug: Web/HTML/Reference/Global_attributes/data-*
 l10n:
-  sourceCommit: 0c81cbce5f95a0be935724bcd936f5592774eb3a
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [Les attributs universels](/fr/docs/Web/HTML/Reference/Global_attributes) **`data-*`** forment une classe d'attributs, appelés **attributs de données personnalisés** (<i lang="en">custom data attributes</i> en anglais), ils permettent d'échanger des données propriétaire entre le [HTML](/fr/docs/Web/HTML) et la représentation du [DOM](/fr/docs/Web/API/Document_Object_Model), qu'on peut manipuler avec des scripts.

--- a/files/fr/web/html/reference/global_attributes/dir/index.md
+++ b/files/fr/web/html/reference/global_attributes/dir/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : dir"
+title: "Attribut HTML universel : `dir`"
 short-title: dir
 slug: Web/HTML/Reference/Global_attributes/dir
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`dir`** est un attribut {{Glossary("Enumerated", "énuméré")}} qui permet d'indiquer la direction du texte d'un élément.

--- a/files/fr/web/html/reference/global_attributes/draggable/index.md
+++ b/files/fr/web/html/reference/global_attributes/draggable/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : draggable"
+title: "Attribut HTML universel : `draggable`"
 short-title: draggable
 slug: Web/HTML/Reference/Global_attributes/draggable
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`draggable`** est un attribut {{Glossary("Enumerated", "énuméré")}} qui indique si l'élément peut être déplacé, soit par le comportement natif du navigateur, soit via [l'API HTML Drag and Drop](/fr/docs/Web/API/HTML_Drag_and_Drop_API).

--- a/files/fr/web/html/reference/global_attributes/enterkeyhint/index.md
+++ b/files/fr/web/html/reference/global_attributes/enterkeyhint/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : enterkeyhint"
+title: "Attribut HTML universel : `enterkeyhint`"
 short-title: enterkeyhint
 slug: Web/HTML/Reference/Global_attributes/enterkeyhint
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`enterkeyhint`** est un attribut {{Glossary("Enumerated", "énuméré")}} définissant le libellé d'action (ou l'icône) à présenter pour la touche entrée sur le clavier virtuel.

--- a/files/fr/web/html/reference/global_attributes/exportparts/index.md
+++ b/files/fr/web/html/reference/global_attributes/exportparts/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : exportparts"
+title: "Attribut HTML universel : `exportparts`"
 short-title: exportparts
 slug: Web/HTML/Reference/Global_attributes/exportparts
 l10n:
-  sourceCommit: 730741c750cc299b85798f1adbaf7adbd6e2016d
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`exportparts`** permet de sélectionner et de mettre en forme des éléments présents dans des {{Glossary("shadow tree", "arbres d'ombre")}} imbriqués, en exportant leurs noms de `part`.

--- a/files/fr/web/html/reference/global_attributes/hidden/index.md
+++ b/files/fr/web/html/reference/global_attributes/hidden/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : hidden"
+title: "Attribut HTML universel : `hidden`"
 short-title: hidden
 slug: Web/HTML/Reference/Global_attributes/hidden
 l10n:
-  sourceCommit: 032373c0ec106ec2d57f6bd14e74e2cc9191907a
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`hidden`** est un attribut {{Glossary("Enumerated", "énuméré")}} qui indique que le navigateur ne doit pas rendre le contenu de l'élément. Par exemple, il peut être utilisé pour masquer des éléments de la page qui ne peuvent pas être utilisés tant que le processus de connexion n'est pas terminé.

--- a/files/fr/web/html/reference/global_attributes/id/index.md
+++ b/files/fr/web/html/reference/global_attributes/id/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : id"
+title: "Attribut HTML universel : `id`"
 short-title: id
 slug: Web/HTML/Reference/Global_attributes/id
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`id`** définit un identifiant qui doit être unique pour l'ensemble du document.

--- a/files/fr/web/html/reference/global_attributes/inert/index.md
+++ b/files/fr/web/html/reference/global_attributes/inert/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : inert"
+title: "Attribut HTML universel : `inert`"
 short-title: inert
 slug: Web/HTML/Reference/Global_attributes/inert
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`inert`** est un attribut booléen qui indique que l'élément et tous ses descendants dans l'arbre plat deviennent _inertes_. L'attribut `inert` peut être ajouté à des sections de contenu qui ne doivent pas être interactives. Lorsqu'un élément est inerte, lui et tous ses descendants, y compris les éléments normalement interactifs comme les liens, boutons et contrôles de formulaire, sont désactivés car ils ne peuvent pas recevoir la sélection ni être cliqués. L'attribut `inert` peut aussi être ajouté à des éléments qui doivent être hors écran ou masqués. Un élément inerte, ainsi que ses descendants, est retiré de l'ordre de tabulation et de l'arbre d'accessibilité.

--- a/files/fr/web/html/reference/global_attributes/inputmode/index.md
+++ b/files/fr/web/html/reference/global_attributes/inputmode/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : inputmode"
+title: "Attribut HTML universel : `inputmode`"
 short-title: inputmode
 slug: Web/HTML/Reference/Global_attributes/inputmode
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`inputmode`** est un attribut {{Glossary("Enumerated", "énuméré")}} qui suggère le type de données qui pourrait être saisi par l'utilisateur·ice lors de la modification de l'élément ou de son contenu.

--- a/files/fr/web/html/reference/global_attributes/is/index.md
+++ b/files/fr/web/html/reference/global_attributes/is/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : is"
+title: "Attribut HTML universel : `is`"
 short-title: is
 slug: Web/HTML/Reference/Global_attributes/is
 l10n:
-  sourceCommit: 56f5609d323467cd08eeaddc57e4490a02be1889
+  sourceCommit: 1bc1971a1265d1792c94b99b736c5accec1fec6d
 ---
 
 > [!NOTE]

--- a/files/fr/web/html/reference/global_attributes/itemid/index.md
+++ b/files/fr/web/html/reference/global_attributes/itemid/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : itemid"
+title: "Attribut HTML universel : `itemid`"
 short-title: itemid
 slug: Web/HTML/Reference/Global_attributes/itemid
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`itemid`** fournit des microdonnées sous la forme d'un identifiant global unique pour un élément.

--- a/files/fr/web/html/reference/global_attributes/itemprop/index.md
+++ b/files/fr/web/html/reference/global_attributes/itemprop/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : itemprop"
+title: "Attribut HTML universel : `itemprop`"
 short-title: itemprop
 slug: Web/HTML/Reference/Global_attributes/itemprop
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`itemprop`** est utilisé pour ajouter des propriétés à un objet. Chaque élément HTML peut avoir un attribut `itemprop` défini, et un `itemprop` consiste en une paire nom-valeur. Chaque paire nom-valeur est appelée une **propriété**, et un groupe d'une ou plusieurs propriétés forme un **objet**. Les valeurs des propriétés sont soit une chaîne de caractères, soit une URL, et peuvent être associées à un très large éventail d'éléments, y compris {{HTMLElement("audio")}}, {{HTMLElement("embed")}}, {{HTMLElement("iframe")}}, {{HTMLElement("img")}}, {{HTMLElement("link")}}, {{HTMLElement("object")}}, {{HTMLElement("source")}}, {{HTMLElement("track")}}, et {{HTMLElement("video")}}.

--- a/files/fr/web/html/reference/global_attributes/itemref/index.md
+++ b/files/fr/web/html/reference/global_attributes/itemref/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : itemref"
+title: "Attribut HTML universel : `itemref`"
 short-title: itemref
 slug: Web/HTML/Reference/Global_attributes/itemref
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`itemref`** permet d'associer des propriétés qui ne sont pas des descendants d'un élément avec l'attribut [`itemscope`](/fr/docs/Web/HTML/Reference/Global_attributes/itemscope).

--- a/files/fr/web/html/reference/global_attributes/itemscope/index.md
+++ b/files/fr/web/html/reference/global_attributes/itemscope/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : itemscope"
+title: "Attribut HTML universel : `itemscope`"
 short-title: itemscope
 slug: Web/HTML/Reference/Global_attributes/itemscope
 l10n:
-  sourceCommit: 0c81cbce5f95a0be935724bcd936f5592774eb3a
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`itemscope`** est un booléen qui définit la portée des métadonnées associées. La spécification de l'attribut **`itemscope`** pour un élément crée un nouvel élément, ce qui entraîne un certain nombre de paires nom-valeur associées à l'élément.

--- a/files/fr/web/html/reference/global_attributes/itemtype/index.md
+++ b/files/fr/web/html/reference/global_attributes/itemtype/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : itemtype"
+title: "Attribut HTML universel : `itemtype`"
 short-title: itemtype
 slug: Web/HTML/Reference/Global_attributes/itemtype
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`itemtype`** définit l'URL du vocabulaire qui sera utilisé pour définir les `itemprop` (propriétés d'élément) dans la structure de données.

--- a/files/fr/web/html/reference/global_attributes/lang/index.md
+++ b/files/fr/web/html/reference/global_attributes/lang/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : lang"
+title: "Attribut HTML universel : `lang`"
 short-title: lang
 slug: Web/HTML/Reference/Global_attributes/lang
 l10n:
-  sourceCommit: a2a094e0c6b051595a6d33c06650c5faca202d14
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`lang`** aide à définir la langue d'un élément&nbsp;: la langue dans laquelle les éléments non modifiables sont écrits, ou la langue dans laquelle les éléments modifiables doivent être écrits par l'utilisateur·ice. L'attribut contient une seule {{Glossary("BCP 47 language tag", "balise de langue BCP 47")}}.

--- a/files/fr/web/html/reference/global_attributes/nonce/index.md
+++ b/files/fr/web/html/reference/global_attributes/nonce/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : nonce"
+title: "Attribut HTML universel : `nonce`"
 short-title: nonce
 slug: Web/HTML/Reference/Global_attributes/nonce
 l10n:
-  sourceCommit: dc788bf0ea36cb1ebe809c82aaae2c77cb3e18c0
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`nonce`** est un attribut de contenu qui définit un {{Glossary("Nonce", "nonce")}} cryptographique («&nbsp;nombre utilisé une fois&nbsp;») pouvant être utilisé par une [règle de sécurité du contenu (CSP)](/fr/docs/Web/HTTP/Guides/CSP) afin de déterminer si la récupération d'un élément sera autorisée ou non.

--- a/files/fr/web/html/reference/global_attributes/part/index.md
+++ b/files/fr/web/html/reference/global_attributes/part/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : part"
+title: "Attribut HTML universel : `part`"
 short-title: part
 slug: Web/HTML/Reference/Global_attributes/part
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`part`** contient une liste espacée des noms de parties de l'élément. Les noms de parties permettent au CSS de sélectionner et de mettre en forme des éléments spécifiques dans un arbre d'ombre avec le pseudo-élément CSS {{CSSxRef("::part")}}.

--- a/files/fr/web/html/reference/global_attributes/popover/index.md
+++ b/files/fr/web/html/reference/global_attributes/popover/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : popover"
+title: "Attribut HTML universel : `popover`"
 short-title: popover
 slug: Web/HTML/Reference/Global_attributes/popover
 l10n:
-  sourceCommit: d35f07a74f76374a6d98aa07b0b42e79322b02ec
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`popover`** permet de désigner un élément qui sera affiché par-dessus le contenu actuel.

--- a/files/fr/web/html/reference/global_attributes/slot/index.md
+++ b/files/fr/web/html/reference/global_attributes/slot/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : slot"
+title: "Attribut HTML universel : `slot`"
 short-title: slot
 slug: Web/HTML/Reference/Global_attributes/slot
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`slot`** assigne un emplacement dans un [DOM d'ombre](/fr/docs/Web/API/Web_components/Using_shadow_DOM) de l'arbe d'ombre d'un élément&nbsp;: Un élément avec un attribut `slot` est assigné à un emplacement créé par l'élément {{HTMLElement("slot")}} dont la valeur de l'attribut [`name`](/fr/docs/Web/HTML/Reference/Elements/slot#name) correspond à celle de l'attribut `slot`. Vous pouvez avoir plusieurs éléments assignés au même emplacement en utilisant le même nom de slot. Les éléments sans attribut `slot` sont assignés à l'emplacement non nommé, si celui-ci existe.

--- a/files/fr/web/html/reference/global_attributes/spellcheck/index.md
+++ b/files/fr/web/html/reference/global_attributes/spellcheck/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : spellcheck"
+title: "Attribut HTML universel : `spellcheck`"
 short-title: spellcheck
 slug: Web/HTML/Reference/Global_attributes/spellcheck
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`spellcheck`** est un attribut [énuméré](/fr/docs/Glossary/Enumerated) qui définit si l'élément peut être vérifié pour les erreurs d'orthographe.

--- a/files/fr/web/html/reference/global_attributes/style/index.md
+++ b/files/fr/web/html/reference/global_attributes/style/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : style"
+title: "Attribut HTML universel : `style`"
 short-title: style
 slug: Web/HTML/Reference/Global_attributes/style
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`style`** contient des déclarations [CSS](/fr/docs/Web/CSS) afin de mettre en forme l'élément. Notez qu'il est recommandé de définir les règles de mise en forme dans un ou plusieurs fichiers séparés. Cet attribut, ainsi que l'élément {{HTMLElement("style")}} ont simplement pour but de permettre une mise en forme rapide, notamment pour tester.

--- a/files/fr/web/html/reference/global_attributes/tabindex/index.md
+++ b/files/fr/web/html/reference/global_attributes/tabindex/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : tabindex"
+title: "Attribut HTML universel : `tabindex`"
 short-title: tabindex
 slug: Web/HTML/Reference/Global_attributes/tabindex
 l10n:
-  sourceCommit: 5e815d522e796fb2209fa8470616b37e31c572b4
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`tabindex`** permet aux développeur·euse·s de créer des éléments HTML sélectionnables, de permettre ou d'empêcher leur sélection séquentielle (généralement avec la touche <kbd>Tab</kbd>, d'où le nom) et de déterminer leur ordre relatif pour la navigation séquentielle.

--- a/files/fr/web/html/reference/global_attributes/title/index.md
+++ b/files/fr/web/html/reference/global_attributes/title/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : title"
+title: "Attribut HTML universel : `title`"
 short-title: title
 slug: Web/HTML/Reference/Global_attributes/title
 l10n:
-  sourceCommit: 5e815d522e796fb2209fa8470616b37e31c572b4
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`title`** contient un texte d'information relatif à l'élément auquel il est rattaché.

--- a/files/fr/web/html/reference/global_attributes/translate/index.md
+++ b/files/fr/web/html/reference/global_attributes/translate/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : translate"
+title: "Attribut HTML universel : `translate`"
 short-title: translate
 slug: Web/HTML/Reference/Global_attributes/translate
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) **`translate`** est un attribut [énuméré](/fr/docs/Glossary/Enumerated) utilisé pour définir si les valeurs _des attributs traduisibles_ d'un élément et ses nœuds enfants {{DOMxRef("Text")}} doivent être traduits lors de la localisation de la page, ou laissés inchangés.

--- a/files/fr/web/html/reference/global_attributes/virtualkeyboardpolicy/index.md
+++ b/files/fr/web/html/reference/global_attributes/virtualkeyboardpolicy/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : virtualkeyboardpolicy"
+title: "Attribut HTML universel : `virtualkeyboardpolicy`"
 short-title: virtualkeyboardpolicy
 slug: Web/HTML/Reference/Global_attributes/virtualkeyboardpolicy
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/html/reference/global_attributes/writingsuggestions/index.md
+++ b/files/fr/web/html/reference/global_attributes/writingsuggestions/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML universel : writingsuggestions"
+title: "Attribut HTML universel : `writingsuggestions`"
 short-title: writingsuggestions
 slug: Web/HTML/Reference/Global_attributes/writingsuggestions
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 9c70c6ff09189cad43d40e241fbd2fe67349c3c2
 ---
 
 [L'attribut universel](/fr/docs/Web/HTML/Reference/Global_attributes) {{Glossary("enumerated", "énuméré")}} **`writingsuggestions`** indique si les suggestions d'écriture fournies par le navigateur doivent être activées dans le cadre de l'élément ou non.


### PR DESCRIPTION
### Description

The front-matter key `title` now accept backticks. Content has updated titles to display code in title using these backticks.

### Motivation

Keep translated-content sync for updated pages

### Additional details

_none_

### Related issues and pull requests

Sync from https://github.com/mdn/content/tree/9c70c6ff09189cad43d40e241fbd2fe67349c3c2
