### PR TITLE
chore(sync-fr): pseudo-elements pages use backticks on title

### DIFF
--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-color-swatch/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-color-swatch/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-moz-color-swatch`"
+title: Pseudo-élément CSS `::-moz-color-swatch`
 short-title: ::-moz-color-swatch
 slug: Web/CSS/Reference/Selectors/::-moz-color-swatch
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-color-swatch/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-color-swatch/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-moz-color-swatch
+title: "Pseudo-élément CSS `::-moz-color-swatch`"
+short-title: ::-moz-color-swatch
 slug: Web/CSS/Reference/Selectors/::-moz-color-swatch
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-focus-inner/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-focus-inner/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-moz-focus-inner`"
+title: Pseudo-élément CSS `::-moz-focus-inner`
 short-title: ::-moz-focus-inner
 slug: Web/CSS/Reference/Selectors/::-moz-focus-inner
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-focus-inner/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-focus-inner/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-moz-focus-inner
+title: "Pseudo-élément CSS `::-moz-focus-inner`"
+short-title: ::-moz-focus-inner
 slug: Web/CSS/Reference/Selectors/::-moz-focus-inner
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}{{Deprecated_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-list-bullet/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-list-bullet/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-moz-list-bullet`"
+title: Pseudo-élément CSS `::-moz-list-bullet`
 short-title: ::-moz-list-bullet
 slug: Web/CSS/Reference/Selectors/::-moz-list-bullet
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-list-bullet/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-list-bullet/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-moz-list-bullet
+title: "Pseudo-élément CSS `::-moz-list-bullet`"
+short-title: ::-moz-list-bullet
 slug: Web/CSS/Reference/Selectors/::-moz-list-bullet
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}{{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-list-number/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-list-number/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-moz-list-number`"
+title: Pseudo-élément CSS `::-moz-list-number`
 short-title: ::-moz-list-number
 slug: Web/CSS/Reference/Selectors/::-moz-list-number
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-list-number/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-list-number/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-moz-list-number
+title: "Pseudo-élément CSS `::-moz-list-number`"
+short-title: ::-moz-list-number
 slug: Web/CSS/Reference/Selectors/::-moz-list-number
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}{{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-meter-bar/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-meter-bar/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-moz-meter-bar
+title: "Pseudo-élément CSS `::-moz-meter-bar`"
+short-title: ::-moz-meter-bar
 slug: Web/CSS/Reference/Selectors/::-moz-meter-bar
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-meter-bar/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-meter-bar/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-moz-meter-bar`"
+title: Pseudo-élément CSS `::-moz-meter-bar`
 short-title: ::-moz-meter-bar
 slug: Web/CSS/Reference/Selectors/::-moz-meter-bar
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-progress-bar/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-progress-bar/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-moz-progress-bar`"
+title: Pseudo-élément CSS `::-moz-progress-bar`
 short-title: ::-moz-progress-bar
 slug: Web/CSS/Reference/Selectors/::-moz-progress-bar
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-progress-bar/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-progress-bar/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-moz-progress-bar
+title: "Pseudo-élément CSS `::-moz-progress-bar`"
+short-title: ::-moz-progress-bar
 slug: Web/CSS/Reference/Selectors/::-moz-progress-bar
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}{{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-range-progress/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-range-progress/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-moz-range-progress
+title: "Pseudo-élément CSS `::-moz-range-progress`"
+short-title: ::-moz-range-progress
 slug: Web/CSS/Reference/Selectors/::-moz-range-progress
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-range-progress/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-range-progress/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-moz-range-progress`"
+title: Pseudo-élément CSS `::-moz-range-progress`
 short-title: ::-moz-range-progress
 slug: Web/CSS/Reference/Selectors/::-moz-range-progress
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-range-thumb/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-range-thumb/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-moz-range-thumb
+title: "Pseudo-élément CSS `::-moz-range-thumb`"
+short-title: ::-moz-range-thumb
 slug: Web/CSS/Reference/Selectors/::-moz-range-thumb
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-range-thumb/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-range-thumb/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-moz-range-thumb`"
+title: Pseudo-élément CSS `::-moz-range-thumb`
 short-title: ::-moz-range-thumb
 slug: Web/CSS/Reference/Selectors/::-moz-range-thumb
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-range-track/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-range-track/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-moz-range-track
+title: "Pseudo-élément CSS `::-moz-range-track`"
+short-title: ::-moz-range-track
 slug: Web/CSS/Reference/Selectors/::-moz-range-track
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-moz-range-track/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-moz-range-track/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-moz-range-track`"
+title: Pseudo-élément CSS `::-moz-range-track`
 short-title: ::-moz-range-track
 slug: Web/CSS/Reference/Selectors/::-moz-range-track
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-inner-spin-button/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-inner-spin-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-inner-spin-button`"
+title: Pseudo-élément CSS `::-webkit-inner-spin-button`
 short-title: ::-webkit-inner-spin-button
 slug: Web/CSS/Reference/Selectors/::-webkit-inner-spin-button
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-inner-spin-button/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-inner-spin-button/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-inner-spin-button
+title: "Pseudo-élément CSS `::-webkit-inner-spin-button`"
+short-title: ::-webkit-inner-spin-button
 slug: Web/CSS/Reference/Selectors/::-webkit-inner-spin-button
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-bar/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-bar/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-meter-bar`"
+title: Pseudo-élément CSS `::-webkit-meter-bar`
 short-title: ::-webkit-meter-bar
 slug: Web/CSS/Reference/Selectors/::-webkit-meter-bar
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-bar/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-bar/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-meter-bar
+title: "Pseudo-élément CSS `::-webkit-meter-bar`"
+short-title: ::-webkit-meter-bar
 slug: Web/CSS/Reference/Selectors/::-webkit-meter-bar
 l10n:
-  sourceCommit: f336c5b6795a562c64fe859aa9ee2becf223ad8a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}{{Deprecated_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-even-less-good-value/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-even-less-good-value/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-meter-even-less-good-value`"
+title: Pseudo-élément CSS `::-webkit-meter-even-less-good-value`
 short-title: ::-webkit-meter-even-less-good-value
 slug: Web/CSS/Reference/Selectors/::-webkit-meter-even-less-good-value
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-even-less-good-value/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-even-less-good-value/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-meter-even-less-good-value
+title: "Pseudo-élément CSS `::-webkit-meter-even-less-good-value`"
+short-title: ::-webkit-meter-even-less-good-value
 slug: Web/CSS/Reference/Selectors/::-webkit-meter-even-less-good-value
 l10n:
-  sourceCommit: f336c5b6795a562c64fe859aa9ee2becf223ad8a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-inner-element/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-meter-inner-element`"
+title: Pseudo-élément CSS `::-webkit-meter-inner-element`
 short-title: ::-webkit-meter-inner-element
 slug: Web/CSS/Reference/Selectors/::-webkit-meter-inner-element
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-inner-element/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-meter-inner-element
+title: "Pseudo-élément CSS `::-webkit-meter-inner-element`"
+short-title: ::-webkit-meter-inner-element
 slug: Web/CSS/Reference/Selectors/::-webkit-meter-inner-element
 l10n:
-  sourceCommit: f336c5b6795a562c64fe859aa9ee2becf223ad8a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-optimum-value/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-optimum-value/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-meter-optimum-value
+title: "Pseudo-élément CSS `::-webkit-meter-optimum-value`"
+short-title: ::-webkit-meter-optimum-value
 slug: Web/CSS/Reference/Selectors/::-webkit-meter-optimum-value
 l10n:
-  sourceCommit: f336c5b6795a562c64fe859aa9ee2becf223ad8a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-optimum-value/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-optimum-value/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-meter-optimum-value`"
+title: Pseudo-élément CSS `::-webkit-meter-optimum-value`
 short-title: ::-webkit-meter-optimum-value
 slug: Web/CSS/Reference/Selectors/::-webkit-meter-optimum-value
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-suboptimum-value/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-suboptimum-value/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-meter-suboptimum-value
+title: "Pseudo-élément CSS `::-webkit-meter-suboptimum-value`"
+short-title: ::-webkit-meter-suboptimum-value
 slug: Web/CSS/Reference/Selectors/::-webkit-meter-suboptimum-value
 l10n:
-  sourceCommit: f336c5b6795a562c64fe859aa9ee2becf223ad8a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-suboptimum-value/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-meter-suboptimum-value/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-meter-suboptimum-value`"
+title: Pseudo-élément CSS `::-webkit-meter-suboptimum-value`
 short-title: ::-webkit-meter-suboptimum-value
 slug: Web/CSS/Reference/Selectors/::-webkit-meter-suboptimum-value
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-progress-bar/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-progress-bar
+title: "Pseudo-élément CSS `::-webkit-progress-bar`"
+short-title: ::-webkit-progress-bar
 slug: Web/CSS/Reference/Selectors/::-webkit-progress-bar
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-progress-bar/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-progress-bar`"
+title: Pseudo-élément CSS `::-webkit-progress-bar`
 short-title: ::-webkit-progress-bar
 slug: Web/CSS/Reference/Selectors/::-webkit-progress-bar
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-progress-inner-element/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-progress-inner-element
+title: "Pseudo-élément CSS `::-webkit-progress-inner-element`"
+short-title: ::-webkit-progress-inner-element
 slug: Web/CSS/Reference/Selectors/::-webkit-progress-inner-element
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-progress-inner-element/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-progress-inner-element`"
+title: Pseudo-élément CSS `::-webkit-progress-inner-element`
 short-title: ::-webkit-progress-inner-element
 slug: Web/CSS/Reference/Selectors/::-webkit-progress-inner-element
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-progress-value/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-progress-value/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-progress-value`"
+title: Pseudo-élément CSS `::-webkit-progress-value`
 short-title: ::-webkit-progress-value
 slug: Web/CSS/Reference/Selectors/::-webkit-progress-value
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-progress-value/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-progress-value/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-progress-value
+title: "Pseudo-élément CSS `::-webkit-progress-value`"
+short-title: ::-webkit-progress-value
 slug: Web/CSS/Reference/Selectors/::-webkit-progress-value
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-scrollbar/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-scrollbar`"
+title: Pseudo-élément CSS `::-webkit-scrollbar`
 short-title: ::-webkit-scrollbar
 slug: Web/CSS/Reference/Selectors/::-webkit-scrollbar
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-scrollbar/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-scrollbar
+title: "Pseudo-élément CSS `::-webkit-scrollbar`"
+short-title: ::-webkit-scrollbar
 slug: Web/CSS/Reference/Selectors/::-webkit-scrollbar
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-search-cancel-button/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-search-cancel-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-search-cancel-button`"
+title: Pseudo-élément CSS `::-webkit-search-cancel-button`
 short-title: ::-webkit-search-cancel-button
 slug: Web/CSS/Reference/Selectors/::-webkit-search-cancel-button
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-search-cancel-button/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-search-cancel-button/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-search-cancel-button
+title: "Pseudo-élément CSS `::-webkit-search-cancel-button`"
+short-title: ::-webkit-search-cancel-button
 slug: Web/CSS/Reference/Selectors/::-webkit-search-cancel-button
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-search-results-button/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-search-results-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-search-results-button`"
+title: Pseudo-élément CSS `::-webkit-search-results-button`
 short-title: ::-webkit-search-results-button
 slug: Web/CSS/Reference/Selectors/::-webkit-search-results-button
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-search-results-button/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-search-results-button/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-search-results-button
+title: "Pseudo-élément CSS `::-webkit-search-results-button`"
+short-title: ::-webkit-search-results-button
 slug: Web/CSS/Reference/Selectors/::-webkit-search-results-button
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-slider-runnable-track/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-slider-runnable-track/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-slider-runnable-track
+title: "Pseudo-élément CSS `::-webkit-slider-runnable-track`"
+short-title: ::-webkit-slider-runnable-track
 slug: Web/CSS/Reference/Selectors/::-webkit-slider-runnable-track
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-slider-runnable-track/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-slider-runnable-track/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-slider-runnable-track`"
+title: Pseudo-élément CSS `::-webkit-slider-runnable-track`
 short-title: ::-webkit-slider-runnable-track
 slug: Web/CSS/Reference/Selectors/::-webkit-slider-runnable-track
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-slider-thumb/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-slider-thumb/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::-webkit-slider-thumb`"
+title: Pseudo-élément CSS `::-webkit-slider-thumb`
 short-title: ::-webkit-slider-thumb
 slug: Web/CSS/Reference/Selectors/::-webkit-slider-thumb
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_-webkit-slider-thumb/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_-webkit-slider-thumb/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::-webkit-slider-thumb
+title: "Pseudo-élément CSS `::-webkit-slider-thumb`"
+short-title: ::-webkit-slider-thumb
 slug: Web/CSS/Reference/Selectors/::-webkit-slider-thumb
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_after/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_after/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::after
+title: "Pseudo-élément CSS `::after`"
+short-title: ::after
 slug: Web/CSS/Reference/Selectors/::after
 l10n:
-  sourceCommit: ed2725c99c6011da9d4afa5e47546fe0722ee814
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::after`** crée un pseudo-élément qui sera le dernier enfant de l'élément ciblé. Généralement utilisé pour ajouter du contenu esthétique à un élément via la propriété CSS {{CSSxRef("content")}}. Par défaut, l'élément créé est de type en-ligne (<i lang="en">inline</i> en anglais).

--- a/files/fr/web/css/reference/selectors/_doublecolon_after/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_after/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::after`"
+title: Pseudo-élément CSS `::after`
 short-title: ::after
 slug: Web/CSS/Reference/Selectors/::after
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_backdrop/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_backdrop/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::backdrop`"
+title: Pseudo-élément CSS `::backdrop`
 short-title: ::backdrop
 slug: Web/CSS/Reference/Selectors/::backdrop
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_backdrop/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_backdrop/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::backdrop
+title: "Pseudo-élément CSS `::backdrop`"
+short-title: ::backdrop
 slug: Web/CSS/Reference/Selectors/::backdrop
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::backdrop`** est une boîte de la taille de la {{Glossary("viewport", "zone d'affichage")}}, qui est rendue immédiatement sous tout élément présenté dans la {{Glossary("top layer", "couche supérieure")}}.

--- a/files/fr/web/css/reference/selectors/_doublecolon_before/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_before/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::before
+title: "Pseudo-élément CSS `::before`"
+short-title: ::before
 slug: Web/CSS/Reference/Selectors/::before
 l10n:
-  sourceCommit: 1dbba9f7a2c2e35c6e01e8a63159e2aac64b601b
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::before`** crée un pseudo-élément qui sera le premier enfant de l'élément ciblé. Généralement utilisé pour ajouter du contenu esthétique à un élément via la propriété CSS {{CSSxRef("content")}}. Par défaut, l'élément créé est de type en-ligne (<i lang="en">inline</i> en anglais).

--- a/files/fr/web/css/reference/selectors/_doublecolon_before/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_before/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::before`"
+title: Pseudo-élément CSS `::before`
 short-title: ::before
 slug: Web/CSS/Reference/Selectors/::before
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_checkmark/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_checkmark/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::checkmark
+title: "Pseudo-élément CSS `::checkmark`"
+short-title: ::checkmark
 slug: Web/CSS/Reference/Selectors/::checkmark
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_checkmark/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_checkmark/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::checkmark`"
+title: Pseudo-élément CSS `::checkmark`
 short-title: ::checkmark
 slug: Web/CSS/Reference/Selectors/::checkmark
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_column/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_column/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::column
+title: "Pseudo-élément CSS `::column`"
+short-title: ::column
 slug: Web/CSS/Reference/Selectors/::column
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_column/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_column/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::column`"
+title: Pseudo-élément CSS `::column`
 short-title: ::column
 slug: Web/CSS/Reference/Selectors/::column
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_cue/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_cue/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::cue
+title: "Pseudo-élément CSS `::cue`"
+short-title: ::cue
 slug: Web/CSS/Reference/Selectors/::cue
 l10n:
-  sourceCommit: 1dbba9f7a2c2e35c6e01e8a63159e2aac64b601b
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::cue`** permet de cibler les indications textuelles [WebVTT](/fr/docs/Web/API/WebVTT_API) d'un élément. Ce pseudo-élément peut être utilisé afin de mettre en forme [les légendes et autres indications textuelles](/fr/docs/Web/API/WebVTT_API#styling_webtt_cues) pour les médias avec des pistes VTT.

--- a/files/fr/web/css/reference/selectors/_doublecolon_cue/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_cue/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::cue`"
+title: Pseudo-élément CSS `::cue`
 short-title: ::cue
 slug: Web/CSS/Reference/Selectors/::cue
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_details-content/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_details-content/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::details-content`"
+title: Pseudo-élément CSS `::details-content`
 short-title: ::details-content
 slug: Web/CSS/Reference/Selectors/::details-content
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_details-content/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_details-content/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::details-content
+title: "Pseudo-élément CSS `::details-content`"
+short-title: ::details-content
 slug: Web/CSS/Reference/Selectors/::details-content
 l10n:
-  sourceCommit: 6aa7c99917d9d6209baca3310a139cb9536da7a7
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::details-content`** représente le contenu extensible/collapsible d'un élément {{HTMLElement("details")}}.

--- a/files/fr/web/css/reference/selectors/_doublecolon_file-selector-button/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_file-selector-button/index.md
@@ -1,11 +1,12 @@
 ---
-title: ::file-selector-button
+title: "Pseudo-élément CSS `::file-selector-button`"
+short-title: ::file-selector-button
 slug: Web/CSS/Reference/Selectors/::file-selector-button
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
-Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::file-upload-button`** représente le bouton d'un élément {{HTMLElement("input")}} de type `file`.
+Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::file-selector-button`** représente le bouton d'un élément {{HTMLElement("input")}} de type `file`.
 
 {{InteractiveExample("Démonstration CSS&nbsp;: ::file-selector-button", "tabbed-shorter")}}
 

--- a/files/fr/web/css/reference/selectors/_doublecolon_file-selector-button/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_file-selector-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::file-selector-button`"
+title: Pseudo-élément CSS `::file-selector-button`
 short-title: ::file-selector-button
 slug: Web/CSS/Reference/Selectors/::file-selector-button
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_first-letter/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_first-letter/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::first-letter`"
+title: Pseudo-élément CSS `::first-letter`
 short-title: ::first-letter
 slug: Web/CSS/Reference/Selectors/::first-letter
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_first-letter/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_first-letter/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::first-letter
+title: "Pseudo-élément CSS `::first-letter`"
+short-title: ::first-letter
 slug: Web/CSS/Reference/Selectors/::first-letter
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::first-letter`** sélectionne la première lettre de la première ligne d'un bloc, si elle n'est pas précédée par un quelconque autre contenu (comme une image ou un tableau en ligne) sur sa ligne.

--- a/files/fr/web/css/reference/selectors/_doublecolon_first-line/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_first-line/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::first-line`"
+title: Pseudo-élément CSS `::first-line`
 short-title: ::first-line
 slug: Web/CSS/Reference/Selectors/::first-line
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_first-line/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_first-line/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::first-line
+title: "Pseudo-élément CSS `::first-line`"
+short-title: ::first-line
 slug: Web/CSS/Reference/Selectors/::first-line
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::first-line`** applique la décoration à la première ligne d'un élément. La quantité de texte sur la première ligne dépend de nombreux facteurs, comme la largeur des éléments ou du document, mais aussi de la taille du texte. Comme tous les pseudo-éléments, les sélecteurs contenant `::first-line` ne ciblent pas un élément HTML réel.

--- a/files/fr/web/css/reference/selectors/_doublecolon_grammar-error/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_grammar-error/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::grammar-error`"
+title: Pseudo-élément CSS `::grammar-error`
 short-title: ::grammar-error
 slug: Web/CSS/Reference/Selectors/::grammar-error
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_grammar-error/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_grammar-error/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::grammar-error
+title: "Pseudo-élément CSS `::grammar-error`"
+short-title: ::grammar-error
 slug: Web/CSS/Reference/Selectors/::grammar-error
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::grammar-error`** représente une portion de texte que le navigateur signale comme contenant une ou plusieurs erreurs de grammaire.

--- a/files/fr/web/css/reference/selectors/_doublecolon_highlight/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_highlight/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::highlight()`"
+title: Pseudo-élément CSS `::highlight()`
 short-title: ::highlight()
 slug: Web/CSS/Reference/Selectors/::highlight
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_highlight/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_highlight/index.md
@@ -1,13 +1,14 @@
 ---
-title: ::highlight()
+title: "Pseudo-élément CSS `::highlight()`"
+short-title: ::highlight()
 slug: Web/CSS/Reference/Selectors/::highlight
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::highlight()`** applique des styles à une mise en évidence personnalisée.
 
-Une mise en évidence personnalisée est une collection d'objets {{DOMxRef("Range")}} et est enregistrée sur une page Web à l'aide de {{DOMxRef("HighlightRegistry")}}.
+Une mise en évidence personnalisée est une collection d'objets {{DOMxRef("AbstractRange")}} et est enregistrée sur une page Web à l'aide de {{DOMxRef("HighlightRegistry")}}.
 
 Le pseudo-élément `::highlight()` suit un modèle d'héritage spécial commun à tous les pseudo-éléments de mise en évidence. Pour plus de détails sur le fonctionnement de cet héritage, consultez la section [Héritage des pseudo-éléments mise en évidence](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements#héritage_des_pseudo-éléments_de_mise_en_évidence).
 
@@ -31,7 +32,7 @@ En particulier, {{CSSxRef("background-image")}} est ignoré.
 
 ## Exemples
 
-### Mise en évidence des caractères
+### Mettre en évidence des caractères
 
 #### HTML
 
@@ -116,7 +117,7 @@ for (let i = 0; i < textNode.textContent.length; i++) {
 
 #### Résultat
 
-{{ EmbedLiveSample("mise_en_évidence_des_caractères") }}
+{{EmbedLiveSample("Mettre en évidence des caractères")}}
 
 ## Spécifications
 
@@ -129,5 +130,5 @@ for (let i = 0; i < textNode.textContent.length; i++) {
 ## Voir aussi
 
 - Le module CSS de [Mise en évidence personnalisée](/fr/docs/Web/CSS/CSS_custom_highlight_API)
-- L'[API CSS de mise en évidence personnalisée](/fr/docs/Web/API/CSS_Custom_Highlight_API)
+- [L'API CSS de mise en évidence personnalisée](/fr/docs/Web/API/CSS_Custom_Highlight_API)
 - Le module de [pseudo-éléments CSS](/fr/docs/Web/CSS/CSS_pseudo-elements)

--- a/files/fr/web/css/reference/selectors/_doublecolon_marker/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_marker/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::marker`"
+title: Pseudo-élément CSS `::marker`
 short-title: ::marker
 slug: Web/CSS/Reference/Selectors/::marker
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_marker/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_marker/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::marker
+title: "Pseudo-élément CSS `::marker`"
+short-title: ::marker
 slug: Web/CSS/Reference/Selectors/::marker
 l10n:
-  sourceCommit: 618d480ec934c834d8a37796dc691061c401ed5d
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::marker`** représente le marqueur d'un élément d'une liste à puces ou numérotée. Il fonctionne sur tout élément ou pseudo-élément défini avec [`display: list-item`](/fr/docs/Web/CSS/Reference/Properties/display), tel que les éléments {{HTMLElement("li")}} et {{HTMLElement("summary")}}.

--- a/files/fr/web/css/reference/selectors/_doublecolon_part/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_part/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::part()`"
+title: Pseudo-élément CSS `::part()`
 short-title: ::part()
 slug: Web/CSS/Reference/Selectors/::part
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_part/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_part/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::part()
+title: "Pseudo-élément CSS `::part()`"
+short-title: ::part()
 slug: Web/CSS/Reference/Selectors/::part
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::part()`** représente n'importe quel élément dans un [arbre fantôme (<i lang="en">shadow tree</i>)](/fr/docs/Web/API/Web_components/Using_shadow_DOM) qui a un attribut [`part`](/fr/docs/Web/HTML/Reference/Global_attributes#part) correspondant.

--- a/files/fr/web/css/reference/selectors/_doublecolon_picker-icon/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_picker-icon/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::picker-icon
+title: "Pseudo-élément CSS `::picker-icon`"
+short-title: ::picker-icon
 slug: Web/CSS/Reference/Selectors/::picker-icon
 l10n:
-  sourceCommit: 9af64ef430ad722b9cc3f75ccabeb8989c23b988
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::picker-icon`** cible l'icône de sélection à l'intérieur des contrôles de formulaire qui ont une icône associée. Dans le cas d'un [élément `<select>` personnalisable](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select), il sélectionne l'icône de flèche affichée sur l'élément `<select>` qui pointe vers le bas lorsqu'il est fermé.

--- a/files/fr/web/css/reference/selectors/_doublecolon_picker-icon/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_picker-icon/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::picker-icon`"
+title: Pseudo-élément CSS `::picker-icon`
 short-title: ::picker-icon
 slug: Web/CSS/Reference/Selectors/::picker-icon
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_picker/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_picker/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::picker()
+title: "Pseudo-élément CSS `::picker()`"
+short-title: ::picker()
 slug: Web/CSS/Reference/Selectors/::picker
 l10n:
-  sourceCommit: 9af64ef430ad722b9cc3f75ccabeb8989c23b988
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::picker()`** cible la partie sélecteur (<i lang="en">picker</i>) d'un élément, par exemple la liste déroulante d'un [élément `<select>` personnalisable](/fr/docs/Learn_web_development/Extensions/Forms/Customizable_select).

--- a/files/fr/web/css/reference/selectors/_doublecolon_picker/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_picker/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::picker()`"
+title: Pseudo-élément CSS `::picker()`
 short-title: ::picker()
 slug: Web/CSS/Reference/Selectors/::picker
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_placeholder/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_placeholder/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::placeholder
+title: "Pseudo-élément CSS `::placeholder`"
+short-title: ::placeholder
 slug: Web/CSS/Reference/Selectors/::placeholder
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::placeholder`** représente [le texte de substitution](/fr/docs/Web/HTML/Reference/Elements/input#placeholder) pour un élément {{HTMLElement("input")}} ou {{HTMLElement("textarea")}}.

--- a/files/fr/web/css/reference/selectors/_doublecolon_placeholder/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_placeholder/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::placeholder`"
+title: Pseudo-élément CSS `::placeholder`
 short-title: ::placeholder
 slug: Web/CSS/Reference/Selectors/::placeholder
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_scroll-button/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_scroll-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::scroll-button()`"
+title: Pseudo-élément CSS `::scroll-button()`
 short-title: ::scroll-button()
 slug: Web/CSS/Reference/Selectors/::scroll-button
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_scroll-button/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_scroll-button/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::scroll-button()
+title: "Pseudo-élément CSS `::scroll-button()`"
+short-title: ::scroll-button()
 slug: Web/CSS/Reference/Selectors/::scroll-button
 l10n:
-  sourceCommit: 5ebca2edd6095fb3f61d442ed3146fa37fffbf7d
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_scroll-marker-group/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_scroll-marker-group/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::scroll-marker-group`"
+title: Pseudo-élément CSS `::scroll-marker-group`
 short-title: ::scroll-marker-group
 slug: Web/CSS/Reference/Selectors/::scroll-marker-group
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_scroll-marker-group/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_scroll-marker-group/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::scroll-marker-group
+title: "Pseudo-élément CSS `::scroll-marker-group`"
+short-title: ::scroll-marker-group
 slug: Web/CSS/Reference/Selectors/::scroll-marker-group
 l10n:
-  sourceCommit: 9dbcd91284ec1ec64c4d8b343c3770880dd25129
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_scroll-marker/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_scroll-marker/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::scroll-marker`"
+title: Pseudo-élément CSS `::scroll-marker`
 short-title: ::scroll-marker
 slug: Web/CSS/Reference/Selectors/::scroll-marker
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_scroll-marker/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_scroll-marker/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::scroll-marker
+title: "Pseudo-élément CSS `::scroll-marker`"
+short-title: ::scroll-marker
 slug: Web/CSS/Reference/Selectors/::scroll-marker
 l10n:
-  sourceCommit: 9dbcd91284ec1ec64c4d8b343c3770880dd25129
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_search-text/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_search-text/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::search-text`"
+title: Pseudo-élément CSS `::search-text`
 short-title: ::search-text
 slug: Web/CSS/Reference/Selectors/::search-text
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_search-text/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_search-text/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::search-text
+title: "Pseudo-élément CSS `::search-text`"
+short-title: ::search-text
 slug: Web/CSS/Reference/Selectors/::search-text
 l10n:
-  sourceCommit: 483ce811e1ea52cb2d9d2a5af0c4d1c4d591ea4a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_doublecolon_selection/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_selection/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::selection`"
+title: Pseudo-élément CSS `::selection`
 short-title: ::selection
 slug: Web/CSS/Reference/Selectors/::selection
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_selection/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_selection/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::selection
+title: "Pseudo-élément CSS `::selection`"
+short-title: ::selection
 slug: Web/CSS/Reference/Selectors/::selection
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::selection`** permet d'appliquer des règles CSS à une portion du document qui a été sélectionnée par l'utilisateur·ice (par exemple en cliquant et en faisant glisser la souris sur le texte).

--- a/files/fr/web/css/reference/selectors/_doublecolon_slotted/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_slotted/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::slotted()
+title: "Pseudo-élément CSS `::slotted()`"
+short-title: ::slotted()
 slug: Web/CSS/Reference/Selectors/::slotted
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 La [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::slotted()`** représente n'importe quel élément ayant été placé à l'intérieur d'un emplacement (_slot_) au sein d'un gabarit (_template_) HTML (voir [Utiliser les gabarits et les emplacements](/fr/docs/Web/API/Web_components/Using_templates_and_slots) pour plus d'informations).

--- a/files/fr/web/css/reference/selectors/_doublecolon_slotted/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_slotted/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::slotted()`"
+title: Pseudo-élément CSS `::slotted()`
 short-title: ::slotted()
 slug: Web/CSS/Reference/Selectors/::slotted
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_spelling-error/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_spelling-error/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::spelling-error
+title: "Pseudo-élément CSS `::spelling-error`"
+short-title: ::spelling-error
 slug: Web/CSS/Reference/Selectors/::spelling-error
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::spelling-error`** représente une portion de texte que l'{{Glossary("user agent", "agent utilisateur")}} signale comme étant mal orthographiée.

--- a/files/fr/web/css/reference/selectors/_doublecolon_spelling-error/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_spelling-error/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::spelling-error`"
+title: Pseudo-élément CSS `::spelling-error`
 short-title: ::spelling-error
 slug: Web/CSS/Reference/Selectors/::spelling-error
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_target-text/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_target-text/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::target-text
+title: "Pseudo-élément CSS `::target-text`"
+short-title: ::target-text
 slug: Web/CSS/Reference/Selectors/::target-text
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::target-text`** représente le texte vers lequel l'écran vient de défiler, dans le cas où le navigateur prend en charge les [fragments de texte](/fr/docs/Web/URI/Reference/Fragment/Text_fragments). Il permet aux auteur·ice·s de mettre en évidence cette section de texte.

--- a/files/fr/web/css/reference/selectors/_doublecolon_target-text/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_target-text/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::target-text`"
+title: Pseudo-élément CSS `::target-text`
 short-title: ::target-text
 slug: Web/CSS/Reference/Selectors/::target-text
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_view-transition-group/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_view-transition-group/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::view-transition-group()`"
+title: Pseudo-élément CSS `::view-transition-group()`
 short-title: ::view-transition-group()
 slug: Web/CSS/Reference/Selectors/::view-transition-group
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_view-transition-group/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_view-transition-group/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::view-transition-group()
+title: "Pseudo-élément CSS `::view-transition-group()`"
+short-title: ::view-transition-group()
 slug: Web/CSS/Reference/Selectors/::view-transition-group
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::view-transition-group()`** représente un groupe instantané de transition de vue.

--- a/files/fr/web/css/reference/selectors/_doublecolon_view-transition-image-pair/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_view-transition-image-pair/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::view-transition-image-pair()
+title: "Pseudo-élément CSS `::view-transition-image-pair()`"
+short-title: ::view-transition-image-pair()
 slug: Web/CSS/Reference/Selectors/::view-transition-image-pair
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::view-transition-image-pair()`** représente un conteneur pour les états de vue «&nbsp;<i lang="en">old</i>&nbsp;» et «&nbsp;<i lang="en">new</i>&nbsp;» d'une [transition de vue](/fr/docs/Web/API/View_Transition_API) — avant et après la transition.

--- a/files/fr/web/css/reference/selectors/_doublecolon_view-transition-image-pair/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_view-transition-image-pair/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::view-transition-image-pair()`"
+title: Pseudo-élément CSS `::view-transition-image-pair()`
 short-title: ::view-transition-image-pair()
 slug: Web/CSS/Reference/Selectors/::view-transition-image-pair
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_view-transition-new/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_view-transition-new/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::view-transition-new()
+title: "Pseudo-élément CSS `::view-transition-new()`"
+short-title: ::view-transition-new()
 slug: Web/CSS/Reference/Selectors/::view-transition-new
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::view-transition-new()`** représente l'état de vue «&nbsp;<i lang="en">new</i>&nbsp;» d'une transition de vue — une représentation instantanée en direct de l'état après la transition.

--- a/files/fr/web/css/reference/selectors/_doublecolon_view-transition-new/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_view-transition-new/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::view-transition-new()`"
+title: Pseudo-élément CSS `::view-transition-new()`
 short-title: ::view-transition-new()
 slug: Web/CSS/Reference/Selectors/::view-transition-new
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_view-transition-old/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_view-transition-old/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::view-transition-old()
+title: "Pseudo-élément CSS `::view-transition-old()`"
+short-title: ::view-transition-old()
 slug: Web/CSS/Reference/Selectors/::view-transition-old
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::view-transition-old()`** représente l'état de vue «&nbsp;<i lang="en">old</i>&nbsp;» d'une transition de vue — une représentation instantanée de l'état avant la transition.

--- a/files/fr/web/css/reference/selectors/_doublecolon_view-transition-old/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_view-transition-old/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::view-transition-old()`"
+title: Pseudo-élément CSS `::view-transition-old()`
 short-title: ::view-transition-old()
 slug: Web/CSS/Reference/Selectors/::view-transition-old
 l10n:

--- a/files/fr/web/css/reference/selectors/_doublecolon_view-transition/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_view-transition/index.md
@@ -1,8 +1,9 @@
 ---
-title: ::view-transition
+title: "Pseudo-élément CSS `::view-transition`"
+short-title: ::view-transition
 slug: Web/CSS/Reference/Selectors/::view-transition
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 6cf697a8965ecdc4967258cc0282fe789b60318e
 ---
 
 Le [pseudo-élément](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS](/fr/docs/Web/CSS) **`::view-transition`** représente la racine de la superposition des [transitions de vue](/fr/docs/Web/API/View_Transition_API), qui contient tous les groupes de vue instantanées de transition de vue et se trouve au-dessus de tout le reste du contenu de la page.

--- a/files/fr/web/css/reference/selectors/_doublecolon_view-transition/index.md
+++ b/files/fr/web/css/reference/selectors/_doublecolon_view-transition/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Pseudo-élément CSS `::view-transition`"
+title: Pseudo-élément CSS `::view-transition`
 short-title: ::view-transition
 slug: Web/CSS/Reference/Selectors/::view-transition
 l10n:


### PR DESCRIPTION
### Description

The front-matter key `title` now accept backticks. Content has updated titles to display code in title using these backticks.

### Motivation

Keep translated-content sync for updated pages

### Additional details

_none_

### Related issues and pull requests

Sync from https://github.com/mdn/content/tree/6cf697a8965ecdc4967258cc0282fe789b60318e
