### PR TITLE
chore(sync-fr): pseudo-classes pages use backticks on title

### DIFF
--- a/files/fr/web/css/reference/selectors/_colon_-moz-broken/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-broken/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-broken
+title: Pseudo-classe CSS `:-moz-broken`
+short-title: :-moz-broken
 slug: Web/CSS/Reference/Selectors/:-moz-broken
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}{{Deprecated_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-drag-over/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-drag-over/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-drag-over
+title: Pseudo-classe CSS `:-moz-drag-over`
+short-title: :-moz-drag-over
 slug: Web/CSS/Reference/Selectors/:-moz-drag-over
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-first-node/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-first-node/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-first-node
+title: Pseudo-classe CSS `:-moz-first-node`
+short-title: :-moz-first-node
 slug: Web/CSS/Reference/Selectors/:-moz-first-node
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}{{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-handler-blocked/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-handler-blocked/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-handler-blocked
+title: Pseudo-classe CSS `:-moz-handler-blocked`
+short-title: :-moz-handler-blocked
 slug: Web/CSS/Reference/Selectors/:-moz-handler-blocked
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-handler-crashed/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-handler-crashed/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-handler-crashed
+title: Pseudo-classe CSS `:-moz-handler-crashed`
+short-title: :-moz-handler-crashed
 slug: Web/CSS/Reference/Selectors/:-moz-handler-crashed
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-handler-disabled/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-handler-disabled/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-handler-disabled
+title: Pseudo-classe CSS `:-moz-handler-disabled`
+short-title: :-moz-handler-disabled
 slug: Web/CSS/Reference/Selectors/:-moz-handler-disabled
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-last-node/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-last-node/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-last-node
+title: Pseudo-classe CSS `:-moz-last-node`
+short-title: :-moz-last-node
 slug: Web/CSS/Reference/Selectors/:-moz-last-node
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}{{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-loading/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-loading/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-loading
+title: Pseudo-classe CSS `:-moz-loading`
+short-title: :-moz-loading
 slug: Web/CSS/Reference/Selectors/:-moz-loading
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-locale-dir_ltr/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-locale-dir_ltr/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-locale-dir(ltr)
+title: Pseudo-classe CSS `:-moz-locale-dir(ltr)`
+short-title: :-moz-locale-dir(ltr)
 slug: Web/CSS/Reference/Selectors/:-moz-locale-dir_ltr
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-locale-dir_rtl/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-locale-dir_rtl/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-locale-dir(rtl)
+title: Pseudo-classe CSS `:-moz-locale-dir(rtl)`
+short-title: :-moz-locale-dir(rtl)
 slug: Web/CSS/Reference/Selectors/:-moz-locale-dir_rtl
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-only-whitespace/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-only-whitespace/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-only-whitespace
+title: Pseudo-classe CSS `:-moz-only-whitespace`
+short-title: :-moz-only-whitespace
 slug: Web/CSS/Reference/Selectors/:-moz-only-whitespace
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-submit-invalid/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-submit-invalid/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-submit-invalid
+title: Pseudo-classe CSS `:-moz-submit-invalid`
+short-title: :-moz-submit-invalid
 slug: Web/CSS/Reference/Selectors/:-moz-submit-invalid
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-suppressed/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-suppressed/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-suppressed
+title: Pseudo-classe CSS `:-moz-suppressed`
+short-title: :-moz-suppressed
 slug: Web/CSS/Reference/Selectors/:-moz-suppressed
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-user-disabled/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-user-disabled/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-user-disabled
+title: Pseudo-classe CSS `:-moz-user-disabled`
+short-title: :-moz-user-disabled
 slug: Web/CSS/Reference/Selectors/:-moz-user-disabled
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_-moz-window-inactive/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_-moz-window-inactive/index.md
@@ -1,8 +1,9 @@
 ---
-title: :-moz-window-inactive
+title: Pseudo-classe CSS `:-moz-window-inactive`
+short-title: :-moz-window-inactive
 slug: Web/CSS/Reference/Selectors/:-moz-window-inactive
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_active-view-transition-type/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_active-view-transition-type/index.md
@@ -1,8 +1,9 @@
 ---
-title: :active-view-transition-type()
+title: Pseudo-classe CSS `:active-view-transition-type()`
+short-title: :active-view-transition-type()
 slug: Web/CSS/Reference/Selectors/:active-view-transition-type
 l10n:
-  sourceCommit: 8f7fa9e7aef0399c7a7f8e5a20476a0c2f287640
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La fonction de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:active-view-transition-type()`** correspond aux éléments lorsqu'une transition de vue avec un ou plusieurs types spécifiques est en cours (est _active_) et cesse de correspondre une fois la transition de vue terminée.

--- a/files/fr/web/css/reference/selectors/_colon_active-view-transition/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_active-view-transition/index.md
@@ -1,8 +1,9 @@
 ---
-title: :active-view-transition
+title: Pseudo-classe CSS `:active-view-transition`
+short-title: :active-view-transition
 slug: Web/CSS/Reference/Selectors/:active-view-transition
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:active-view-transition`** correspond à l'élément racine d'un document lorsqu'une [transition de vue](/fr/docs/Web/API/View_Transition_API#concepts_et_utilisation) est en cours (_active_) et cesse de correspondre une fois la transition terminée.

--- a/files/fr/web/css/reference/selectors/_colon_active/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_active/index.md
@@ -1,8 +1,9 @@
 ---
-title: :active
+title: Pseudo-classe CSS `:active`
+short-title: :active
 slug: Web/CSS/Reference/Selectors/:active
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:active`** permet de cibler un élément lorsque celui-ci est activé par l'utilisateur. Elle permet de fournir un _feedback_ indiquant que l'activation a bien été détectée par le navigateur. Lorsqu'on a une interaction avec un pointeur, il s'agit généralement du moment entre l'appui sur le pointeur et le relâchement de celui-ci.

--- a/files/fr/web/css/reference/selectors/_colon_any-link/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_any-link/index.md
@@ -1,8 +1,9 @@
 ---
-title: :any-link
+title: Pseudo-classe CSS `:any-link`
+short-title: :any-link
 slug: Web/CSS/Reference/Selectors/:any-link
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:any-link`** permet de représenter un élément qui agit comme la source de l'ancre d'un hyperlien (qu'il ait été visité ou non). Elle permet donc de cibler les éléments {{HTMLElement("a")}}, {{HTMLElement("area")}} ou {{HTMLElement("link")}} avec un attribut `href`. Autrement dit, elle cible les éléments qui correspondent à {{CSSxRef(":link")}} ou à {{CSSxRef(":visited")}}.

--- a/files/fr/web/css/reference/selectors/_colon_autofill/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_autofill/index.md
@@ -1,8 +1,9 @@
 ---
-title: :autofill
+title: Pseudo-classe CSS `:autofill`
+short-title: :autofill
 slug: Web/CSS/Reference/Selectors/:autofill
 l10n:
-  sourceCommit: 1c68ccea9621d3b67d9e3bff8f9f2e948e4e7e54
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:autofill`** correspond à un élément {{HTMLElement("input")}} lorsque sa valeur est remplie automatiquement par le navigateur. La classe cesse la correspondance si l'utilisateur·ice modifie le champ.

--- a/files/fr/web/css/reference/selectors/_colon_blank/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_blank/index.md
@@ -1,8 +1,9 @@
 ---
-title: :blank
+title: Pseudo-classe CSS `:blank`
+short-title: :blank
 slug: Web/CSS/Reference/Selectors/:blank
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_colon_buffering/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_buffering/index.md
@@ -1,8 +1,9 @@
 ---
-title: :buffering
+title: Pseudo-classe CSS `:buffering`
+short-title: :buffering
 slug: Web/CSS/Reference/Selectors/:buffering
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:buffering`** correspond à un élément qui peut être lu, tel que {{HTMLElement("audio")}} ou {{HTMLElement("video")}}, lorsque l'élément lisible est en train de mettre en mémoire tampon une ressource multimédia.

--- a/files/fr/web/css/reference/selectors/_colon_checked/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_checked/index.md
@@ -1,8 +1,9 @@
 ---
-title: :checked
+title: Pseudo-classe CSS `:checked`
+short-title: :checked
 slug: Web/CSS/Reference/Selectors/:checked
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:checked`** représente n'importe quel **bouton radio** ([`<input type="radio">`](/fr/docs/Web/HTML/Reference/Elements/input/radio)), **case à cocher** ([`<input type="checkbox">`](/fr/docs/Web/HTML/Reference/Elements/input/checkbox)) ou **option** ({{HTMLElement("option")}} d'un élément {{HTMLElement("select")}}) qui est coché ou activé (`on`).

--- a/files/fr/web/css/reference/selectors/_colon_current/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_current/index.md
@@ -1,8 +1,9 @@
 ---
-title: :current
+title: Pseudo-classe CSS `:current`
+short-title: :current
 slug: Web/CSS/Reference/Selectors/:current
 l10n:
-  sourceCommit: 483ce811e1ea52cb2d9d2a5af0c4d1c4d591ea4a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_colon_default/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_default/index.md
@@ -1,8 +1,9 @@
 ---
-title: :default
+title: Pseudo-classe CSS `:default`
+short-title: :default
 slug: Web/CSS/Reference/Selectors/:default
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:default`** représente un élément de l'interface utilisateur qui est l'élément par défaut parmi d'autres éléments semblables (par exemple le bouton par défaut d'un groupe de boutons).

--- a/files/fr/web/css/reference/selectors/_colon_defined/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_defined/index.md
@@ -1,8 +1,9 @@
 ---
-title: :defined
+title: Pseudo-classe CSS `:defined`
+short-title: :defined
 slug: Web/CSS/Reference/Selectors/:defined
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:defined`** représente n'importe quel élément ayant été défini. Cela inclut les éléments standards provenant du navigateur, ainsi que les éléments personnalisés («&nbsp;_custom elements_&nbsp;») ayant correctement été définis (c'est-à-dire grâce à la méthode {{DOMxRef("CustomElementRegistry.define()")}}).

--- a/files/fr/web/css/reference/selectors/_colon_dir/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_dir/index.md
@@ -1,8 +1,9 @@
 ---
-title: :dir()
+title: Pseudo-classe CSS `:dir()`
+short-title: :dir()
 slug: Web/CSS/Reference/Selectors/:dir
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:dir()`** permet de cibler un élément selon la direction du texte qu'il contient.

--- a/files/fr/web/css/reference/selectors/_colon_disabled/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_disabled/index.md
@@ -1,8 +1,9 @@
 ---
-title: :disabled
+title: Pseudo-classe CSS `:disabled`
+short-title: :disabled
 slug: Web/CSS/Reference/Selectors/:disabled
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:disabled`** permet de cibler un élément désactivé. Un élément est désactivé s'il ne peut pas être activé (sélectionné, cliqué ou saisi) ou s'il ne peut pas recevoir le focus de l'utilisateur. L'élément possède également un état activé dans lequel il peut être sélectionné ou recevoir le focus.

--- a/files/fr/web/css/reference/selectors/_colon_empty/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_empty/index.md
@@ -1,8 +1,9 @@
 ---
-title: :empty
+title: Pseudo-classe CSS `:empty`
+short-title: :empty
 slug: Web/CSS/Reference/Selectors/:empty
 l10n:
-  sourceCommit: 5e815d522e796fb2209fa8470616b37e31c572b4
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:empty`** correspond à un élément qui n'a aucun enfant. Seules les feuilles de l'arbre et le texte (espaces inclus) sont pris en compte. Les commentaires, les attributs ou le contenu généré en CSS avec {{CSSxRef("content")}} n'ont pas d'influence sur le contenu de l'élément (autrement dit, si un élément ne contient que des commentaires, il sera considéré comme vide).

--- a/files/fr/web/css/reference/selectors/_colon_enabled/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_enabled/index.md
@@ -1,8 +1,9 @@
 ---
-title: :enabled
+title: Pseudo-classe CSS `:enabled`
+short-title: :enabled
 slug: Web/CSS/Reference/Selectors/:enabled
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:enabled`** permet de cibler un élément activé. Un élément est activé s'il peut être sélectionné, si on peut cliquer dessus ou si on peut y saisir du texte ou y passer le focus (un élément peut également être dans un état désactivé).

--- a/files/fr/web/css/reference/selectors/_colon_first-child/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_first-child/index.md
@@ -1,8 +1,9 @@
 ---
-title: :first-child
+title: Pseudo-classe CSS `:first-child`
+short-title: :first-child
 slug: Web/CSS/Reference/Selectors/:first-child
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:first-child`** permet de cibler un élément qui est le premier élément fils par rapport à son élément parent.

--- a/files/fr/web/css/reference/selectors/_colon_first-of-type/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_first-of-type/index.md
@@ -1,8 +1,9 @@
 ---
-title: :first-of-type
+title: Pseudo-classe CSS `:first-of-type`
+short-title: :first-of-type
 slug: Web/CSS/Reference/Selectors/:first-of-type
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:first-of-type`** permet de cibler le premier élément d'un type donné parmi ceux d'un même élément parent (et de même niveau).

--- a/files/fr/web/css/reference/selectors/_colon_first/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_first/index.md
@@ -1,8 +1,9 @@
 ---
-title: :first
+title: Pseudo-classe CSS `:first`
+short-title: :first
 slug: Web/CSS/Reference/Selectors/:first
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:first`**, liée à la règle @ {{CSSxRef("@page")}} décrit la mise en forme de la première page lors de l'impression d'un document. ( voir {{CSSxRef(":first-child")}} pour le premier élément d'un noeud )

--- a/files/fr/web/css/reference/selectors/_colon_focus-visible/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_focus-visible/index.md
@@ -1,8 +1,9 @@
 ---
-title: :focus-visible
+title: Pseudo-classe CSS `:focus-visible`
+short-title: :focus-visible
 slug: Web/CSS/Reference/Selectors/:focus-visible
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:focus-visible`** s'applique lorsqu'un élément correspond à la pseudo-classe {{CSSxRef(":focus")}} et que {{Glossary("User Agent", "l'agent utilisateur")}} détermine, via une heuristique, que le focus devrait être mis en évidence sur l'élément (la plupart des navigateurs affichent un contour en surbrillance par défaut).

--- a/files/fr/web/css/reference/selectors/_colon_focus-within/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_focus-within/index.md
@@ -1,8 +1,9 @@
 ---
-title: :focus-within
+title: Pseudo-classe CSS `:focus-within`
+short-title: :focus-within
 slug: Web/CSS/Reference/Selectors/:focus-within
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:focus-within`** correspond à un élément si celui-ci ou l'un de ses descendants est sélectionné. En d'autres termes, elle représente un élément qui est lui-même correspondant à la pseudo-classe {{CSSxRef(":focus")}} ou qui a un descendant correspondant à `:focus`. (Cela inclut les descendants dans le [DOM sombre (<i lang="en">shadow DOM</i>)](/fr/docs/Web/API/Web_components/Using_shadow_DOM)).

--- a/files/fr/web/css/reference/selectors/_colon_focus/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_focus/index.md
@@ -1,8 +1,9 @@
 ---
-title: :focus
+title: Pseudo-classe CSS `:focus`
+short-title: :focus
 slug: Web/CSS/Reference/Selectors/:focus
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:focus`** permet de cibler un élément lorsque celui-ci reçoit le focus (soit il est sélectionné à l'aide du clavier, soit il est activé avec la souris comme par exemple le champ d'un formulaire).

--- a/files/fr/web/css/reference/selectors/_colon_fullscreen/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_fullscreen/index.md
@@ -1,8 +1,9 @@
 ---
-title: :fullscreen
+title: Pseudo-classe CSS `:fullscreen`
+short-title: :fullscreen
 slug: Web/CSS/Reference/Selectors/:fullscreen
 l10n:
-  sourceCommit: 1dbba9f7a2c2e35c6e01e8a63159e2aac64b601b
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:fullscreen`** permet de cibler tout élément qui est en mode plein écran. Si plusieurs éléments ont été mis en plein écran, tous ces éléments seront ciblés.

--- a/files/fr/web/css/reference/selectors/_colon_future/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_future/index.md
@@ -1,8 +1,9 @@
 ---
-title: :future
+title: Pseudo-classe CSS `:future`
+short-title: :future
 slug: Web/CSS/Reference/Selectors/:future
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 Le sélecteur de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:future`** agit dans la dimension temporelle qui cible n'importe quel élément apparaissant entièrement après un élément correspondant à {{CSSxRef(":current")}}. Ce sélecteur peut par exemple servir dans le cas d'une vidéo ayant des sous-titres affichés à l'aide du format [WebVTT](/fr/docs/Web/API/WebVTT_API).

--- a/files/fr/web/css/reference/selectors/_colon_has-slotted/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_has-slotted/index.md
@@ -1,8 +1,9 @@
 ---
-title: :has-slotted
+title: Pseudo-classe CSS `:has-slotted`
+short-title: :has-slotted
 slug: Web/CSS/Reference/Selectors/:has-slotted
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:has-slotted`** correspond lorsque le contenu d'un élément {{HTMLElement("slot")}} n'est pas vide ou n'utilise pas la valeur par défaut (voir [Utilisation des modèles et des slots](/fr/docs/Web/API/Web_components/Using_templates_and_slots) pour plus d'informations).

--- a/files/fr/web/css/reference/selectors/_colon_has/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_has/index.md
@@ -1,8 +1,9 @@
 ---
-title: :has()
+title: Pseudo-classe CSS `:has()`
+short-title: :has()
 slug: Web/CSS/Reference/Selectors/:has
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La fonction de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:has()`** permet de cibler un élément si au moins un des sélecteurs passés en paramètre correspond à l'élément (selon la portée, {{CSSxRef(":scope")}}, de l'élément).

--- a/files/fr/web/css/reference/selectors/_colon_heading/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_heading/index.md
@@ -1,8 +1,9 @@
 ---
-title: :heading
+title: Pseudo-classe CSS `:heading`
+short-title: :heading
 slug: Web/CSS/Reference/Selectors/:heading
 l10n:
-  sourceCommit: 56d7fc5f9d1b010fc55d0384facd2b1477baee0c
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_colon_heading_function/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_heading_function/index.md
@@ -1,8 +1,9 @@
 ---
-title: :heading()
+title: Pseudo-classe CSS `:heading()`
+short-title: :heading()
 slug: Web/CSS/Reference/Selectors/:heading_function
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_colon_host-context/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_host-context/index.md
@@ -1,8 +1,9 @@
 ---
-title: :host-context()
+title: Pseudo-classe CSS `:host-context()`
+short-title: :host-context()
 slug: Web/CSS/Reference/Selectors/:host-context
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/css/reference/selectors/_colon_host/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_host/index.md
@@ -1,8 +1,9 @@
 ---
-title: :host
+title: Pseudo-classe CSS `:host`
+short-title: :host
 slug: Web/CSS/Reference/Selectors/:host
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:host`** permet de cibler l'hôte d'un _[DOM d'ombre (<i lang="en">shadow DOM</i>)](/fr/docs/Web/API/Web_components/Using_shadow_DOM)_ contenant le CSS à utiliser pour cet hôte. Autrement dit, elle permet de sélectionner un élément personnalisé (_custom element_) depuis l'intérieur du DOM d'ombre.

--- a/files/fr/web/css/reference/selectors/_colon_host_function/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_host_function/index.md
@@ -1,8 +1,9 @@
 ---
-title: :host()
+title: Pseudo-classe CSS `:host()`
+short-title: :host()
 slug: Web/CSS/Reference/Selectors/:host_function
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La fonction de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:host()`** sélectionne l'hôte du [DOM d'ombre](/fr/docs/Web/API/Web_components/Using_shadow_DOM) contenant le CSS à utiliser à l'intérieur (vous pouvez donc sélectionner un élément personnalisé depuis l'intérieur de son DOM d'ombre) — mais uniquement si le sélecteur donné en paramètre de la fonction correspond à l'hôte d'ombre. **`:host()`** n'a aucun effet lorsqu'il est utilisé en dehors d'un DOM d'ombre.

--- a/files/fr/web/css/reference/selectors/_colon_hover/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_hover/index.md
@@ -1,8 +1,9 @@
 ---
-title: :hover
+title: Pseudo-classe CSS `:hover`
+short-title: :hover
 slug: Web/CSS/Reference/Selectors/:hover
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:hover`** permet de spécifier l'apparence d'un élément au moment où l'utilisateur·ice le survole avec le pointeur, sans nécessairement l'activer.

--- a/files/fr/web/css/reference/selectors/_colon_in-range/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_in-range/index.md
@@ -1,8 +1,9 @@
 ---
-title: :in-range
+title: Pseudo-classe CSS `:in-range`
+short-title: :in-range
 slug: Web/CSS/Reference/Selectors/:in-range
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:in-range`** cible un élément HTML {{HTMLElement("input")}} lorsque sa valeur courante est comprise dans l'intervalle défini par les attributs [`min`](/fr/docs/Web/HTML/Reference/Elements/input#min) et [`max`](/fr/docs/Web/HTML/Reference/Elements/input#max).

--- a/files/fr/web/css/reference/selectors/_colon_indeterminate/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_indeterminate/index.md
@@ -1,8 +1,9 @@
 ---
-title: :indeterminate
+title: Pseudo-classe CSS `:indeterminate`
+short-title: :indeterminate
 slug: Web/CSS/Reference/Selectors/:indeterminate
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:indeterminate`** permet de cibler un élément de formulaire dont l'état est indéterminé.

--- a/files/fr/web/css/reference/selectors/_colon_interest-source/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_interest-source/index.md
@@ -1,8 +1,9 @@
 ---
-title: :interest-source
+title: Pseudo-classe CSS `:interest-source`
+short-title: :interest-source
 slug: Web/CSS/Reference/Selectors/:interest-source
 l10n:
-  sourceCommit: 423161782178b119c64cd0b41bff8df20dc84a56
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_colon_interest-target/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_interest-target/index.md
@@ -1,8 +1,9 @@
 ---
-title: :interest-target
+title: Pseudo-classe CSS `:interest-target`
+short-title: :interest-target
 slug: Web/CSS/Reference/Selectors/:interest-target
 l10n:
-  sourceCommit: 423161782178b119c64cd0b41bff8df20dc84a56
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_colon_invalid/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_invalid/index.md
@@ -1,8 +1,9 @@
 ---
-title: :invalid
+title: Pseudo-classe CSS `:invalid`
+short-title: :invalid
 slug: Web/CSS/Reference/Selectors/:invalid
 l10n:
-  sourceCommit: aff319cd81d10cfda31b13adb3263deafb284b20
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:invalid`** cible tout élément {{HTMLElement("input")}} pour lequel [la validation](/fr/docs/Web/HTML/Guides/Constraint_validation) du contenu échoue par rapport au type de donnée attendu. Ceci permet de mettre en forme les champs non valides pour aider l'utilisateur·ice à identifier et à corriger les erreurs.

--- a/files/fr/web/css/reference/selectors/_colon_is/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_is/index.md
@@ -1,8 +1,9 @@
 ---
-title: :is()
+title: Pseudo-classe CSS `:is()`
+short-title: :is()
 slug: Web/CSS/Reference/Selectors/:is
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La fonction de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:is()`** prend comme argument une liste de sélecteurs, et cible tous les éléments sélectionnés par chaque sélecteur de cette liste. Cela permet d'écrire des sélecteurs expansifs de façon plus concise.

--- a/files/fr/web/css/reference/selectors/_colon_lang/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_lang/index.md
@@ -1,8 +1,9 @@
 ---
-title: :lang()
+title: Pseudo-classe CSS `:lang()`
+short-title: :lang()
 slug: Web/CSS/Reference/Selectors/:lang
 l10n:
-  sourceCommit: 0ab262675372b83fc870accf3dc46d6a367c451c
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La fonction de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:lang()`** permet de définir la mise en forme d'un élément selon la langue dans laquelle il est écrit.

--- a/files/fr/web/css/reference/selectors/_colon_last-child/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_last-child/index.md
@@ -1,8 +1,9 @@
 ---
-title: :last-child
+title: Pseudo-classe CSS `:last-child`
+short-title: :last-child
 slug: Web/CSS/Reference/Selectors/:last-child
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:last-child`** permet de cibler un élément qui est le dernier enfant de son parent.

--- a/files/fr/web/css/reference/selectors/_colon_last-of-type/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_last-of-type/index.md
@@ -1,8 +1,9 @@
 ---
-title: :last-of-type
+title: Pseudo-classe CSS `:last-of-type`
+short-title: :last-of-type
 slug: Web/CSS/Reference/Selectors/:last-of-type
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:last-of-type`** cible un élément qui est le dernier enfant d'un type donné dans la liste des enfants de l'élément parent.

--- a/files/fr/web/css/reference/selectors/_colon_left/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_left/index.md
@@ -1,8 +1,9 @@
 ---
-title: :left
+title: Pseudo-classe CSS `:left`
+short-title: :left
 slug: Web/CSS/Reference/Selectors/:left
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:left`**, liée à la règle {{CSSxRef("@page")}}, permet de cibler les pages de gauche lors d'une impression.

--- a/files/fr/web/css/reference/selectors/_colon_link/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_link/index.md
@@ -1,8 +1,9 @@
 ---
-title: :link
+title: Pseudo-classe CSS `:link`
+short-title: :link
 slug: Web/CSS/Reference/Selectors/:link
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:link`** représente un élément qui n'a pas encore été visité. Il correspond à chaque élément {{HTMLElement('a')}} ou {{HTMLElement('area')}} non visité qui possède un attribut `href`.

--- a/files/fr/web/css/reference/selectors/_colon_local-link/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_local-link/index.md
@@ -1,8 +1,9 @@
 ---
-title: :local-link
+title: Pseudo-classe CSS `:local-link`
+short-title: :local-link
 slug: Web/CSS/Reference/Selectors/:local-link
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_colon_modal/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_modal/index.md
@@ -1,8 +1,9 @@
 ---
-title: :modal
+title: Pseudo-classe CSS `:modal`
+short-title: :modal
 slug: Web/CSS/Reference/Selectors/:modal
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:modal`** cible un élément qui est dans un état interdisant toute interaction avec les autres éléments situés en dehors jusqu'à ce que l'interaction soit terminée. Plusieurs éléments peuvent être ciblés par la pseudo-classe `:modal` à un même instant donné, mais un seul de ces éléments sera actif et permettra de recevoir une saisie.

--- a/files/fr/web/css/reference/selectors/_colon_muted/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_muted/index.md
@@ -1,8 +1,9 @@
 ---
-title: :muted
+title: Pseudo-classe CSS `:muted`
+short-title: :muted
 slug: Web/CSS/Reference/Selectors/:muted
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:muted`** représente un élément capable de produire du son, tel que {{HTMLElement("audio")}} ou {{HTMLElement("video")}}, mais qui est muet (silencieux de force).

--- a/files/fr/web/css/reference/selectors/_colon_not/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_not/index.md
@@ -1,8 +1,9 @@
 ---
-title: :not
+title: Pseudo-classe CSS `:not()`
+short-title: :not()
 slug: Web/CSS/Reference/Selectors/:not
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La fonction de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:not()`** représente les éléments qui ne correspondent pas à une liste de sélecteurs. Comme elle empêche la sélection d'éléments spécifiques, elle est connue sous le nom de _pseudo-classe de négation_.

--- a/files/fr/web/css/reference/selectors/_colon_nth-child/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_nth-child/index.md
@@ -1,8 +1,9 @@
 ---
-title: :nth-child
+title: Pseudo-classe CSS `:nth-child()`
+short-title: :nth-child()
 slug: Web/CSS/Reference/Selectors/:nth-child
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La fonction de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:nth-child()`** permet de cibler les éléments en se basant sur l'indice des éléments dans la liste des enfants de leur parent. Autrement dit, un sélecteur utilisant cette pseudo-classe ciblera les éléments selon leur position parmi leurs voisins appartenant à un même parent.

--- a/files/fr/web/css/reference/selectors/_colon_nth-last-child/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_nth-last-child/index.md
@@ -1,8 +1,9 @@
 ---
-title: :nth-last-child
+title: Pseudo-classe CSS `:nth-last-child()`
+short-title: :nth-last-child()
 slug: Web/CSS/Reference/Selectors/:nth-last-child
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La fonction de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:nth-last-child`** permet de cibler les éléments qui possèdent `an+b-1` nœud frères qui les suivent pour un même élément parent avec un indice n entier qui est incrémenté à partir de 0. Avec CSS3, il était nécessaire que l'élément ciblé ait un élément parent, cette restriction a été levée en CSS4.

--- a/files/fr/web/css/reference/selectors/_colon_nth-last-of-type/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_nth-last-of-type/index.md
@@ -1,8 +1,9 @@
 ---
-title: :nth-last-of-type
+title: Pseudo-classe CSS `:nth-last-of-type()`
+short-title: :nth-last-of-type()
 slug: Web/CSS/Reference/Selectors/:nth-last-of-type
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La fonction de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:nth-last-of-type`** permet de cibler les éléments selon leur position parmi les voisins qui sont du même type (les mêmes balises) en partant de la fin.

--- a/files/fr/web/css/reference/selectors/_colon_nth-of-type/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_nth-of-type/index.md
@@ -1,8 +1,9 @@
 ---
-title: :nth-of-type
+title: Pseudo-classe CSS `:nth-of-type()`
+short-title: :nth-of-type()
 slug: Web/CSS/Reference/Selectors/:nth-of-type
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La fonction de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:nth-of-type()`** permet de cibler les éléments selon leur position parmi les voisins du même type (les mêmes noms de balise).

--- a/files/fr/web/css/reference/selectors/_colon_only-child/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_only-child/index.md
@@ -1,8 +1,9 @@
 ---
-title: :only-child
+title: Pseudo-classe CSS `:only-child`
+short-title: :only-child
 slug: Web/CSS/Reference/Selectors/:only-child
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) **`:only-child`** représente n'importe quel élément qui est le seul enfant de son élément parent. Elle permet d'obtenir le même effet que `:first-child:last-child` ou `:nth-child(1):nth-last-child(1)`, mais avec une spécificité inférieure.

--- a/files/fr/web/css/reference/selectors/_colon_only-of-type/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_only-of-type/index.md
@@ -1,8 +1,9 @@
 ---
-title: :only-of-type
+title: Pseudo-classe CSS `:only-of-type`
+short-title: :only-of-type
 slug: Web/CSS/Reference/Selectors/:only-of-type
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:only-of-type`** permet de cibler un élément qui ne possède aucun nœud frère du même type.

--- a/files/fr/web/css/reference/selectors/_colon_open/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_open/index.md
@@ -1,8 +1,9 @@
 ---
-title: :open
+title: Pseudo-classe CSS `:open`
+short-title: :open
 slug: Web/CSS/Reference/Selectors/:open
 l10n:
-  sourceCommit: 20bccf73111b44f1424dbfa21f77b3a11b541cca
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:open`** représente un élément qui a des états ouverts et fermés, uniquement lorsqu'il est actuellement dans l'état ouvert.

--- a/files/fr/web/css/reference/selectors/_colon_optional/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_optional/index.md
@@ -1,8 +1,9 @@
 ---
-title: :optional
+title: Pseudo-classe CSS `:optional`
+short-title: :optional
 slug: Web/CSS/Reference/Selectors/:optional
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:optional`** permet de cibler les éléments {{HTMLElement("input")}} ou {{HTMLElement("textarea")}} pour lesquels l'attribut [`required`](/fr/docs/Web/HTML/Reference/Elements/input#required) n'est pas activé. Cela permet ainsi d'indiquer et de mettre en forme les champs facultatifs d'un formulaire.

--- a/files/fr/web/css/reference/selectors/_colon_out-of-range/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_out-of-range/index.md
@@ -1,8 +1,9 @@
 ---
-title: :out-of-range
+title: Pseudo-classe CSS `:out-of-range`
+short-title: :out-of-range
 slug: Web/CSS/Reference/Selectors/:out-of-range
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:out-of-range`** cible un élément {{HTMLElement("input")}} lorsque la valeur de son attribut `value` est en dehors de l'intervalle autorisé par les attributs [`min`](/fr/docs/Web/HTML/Reference/Elements/input#min) et [`max`](/fr/docs/Web/HTML/Reference/Elements/input#max). Ceci permet d'informer l'utilisateur·ice que la valeur actuellement renseignée dans l'élément est hors des limites acceptables.

--- a/files/fr/web/css/reference/selectors/_colon_past/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_past/index.md
@@ -1,8 +1,9 @@
 ---
-title: :past
+title: Pseudo-classe CSS `:past`
+short-title: :past
 slug: Web/CSS/Reference/Selectors/:past
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 Le sélecteur de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:past`** est une pseudo-classe temporelle qui correspondra à tout élément apparaissant entièrement avant un élément correspondant à {{CSSxRef(":current")}}. Par exemple, dans une vidéo avec des sous-titres affichés par [WebVTT](/fr/docs/Web/API/WebVTT_API).

--- a/files/fr/web/css/reference/selectors/_colon_paused/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_paused/index.md
@@ -1,8 +1,9 @@
 ---
-title: :paused
+title: Pseudo-classe CSS `:paused`
+short-title: :paused
 slug: Web/CSS/Reference/Selectors/:paused
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 Le sélecteur de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:paused`** représente un élément pouvant être lu, tel que {{HTMLElement("audio")}} ou {{HTMLElement("video")}}, lorsque cet élément est «&nbsp;en pause&nbsp;» (c'est-à-dire qu'il n'est pas «&nbsp;en cours de lecture&nbsp;»).

--- a/files/fr/web/css/reference/selectors/_colon_picture-in-picture/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_picture-in-picture/index.md
@@ -63,7 +63,6 @@ La magie opère dans le CSS.
 
 - L'[API <i lang="en">Picture-in-picture</i>](/fr/docs/Web/API/Picture-in-Picture_API)
 - La méthode API {{DOMxRef("HTMLVideoElement.requestPictureInPicture()")}}
-- La propriété API {{DOMxRef("HTMLVideoElement.autoPictureInPicture")}}
 - La propriété API {{DOMxRef("HTMLVideoElement.disablePictureInPicture")}}
 - La propriété API {{DOMxRef("Document.pictureInPictureEnabled")}}
 - La méthode API {{DOMxRef("Document.exitPictureInPicture()")}}

--- a/files/fr/web/css/reference/selectors/_colon_picture-in-picture/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_picture-in-picture/index.md
@@ -1,8 +1,9 @@
 ---
-title: :picture-in-picture
+title: Pseudo-classe CSS `:picture-in-picture`
+short-title: :picture-in-picture
 slug: Web/CSS/Reference/Selectors/:picture-in-picture
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:picture-in-picture`** cible les éléments qui sont présentement affichés en incrustation vidéo (<i lang="en">picture-in-picture</i>).

--- a/files/fr/web/css/reference/selectors/_colon_placeholder-shown/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_placeholder-shown/index.md
@@ -1,8 +1,9 @@
 ---
-title: :placeholder-shown
+title: Pseudo-classe CSS `:placeholder-shown`
+short-title: :placeholder-shown
 slug: Web/CSS/Reference/Selectors/:placeholder-shown
 l10n:
-  sourceCommit: aff319cd81d10cfda31b13adb3263deafb284b20
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:placeholder-shown`** représente n'importe quel élément {{HTMLElement("input")}} ou {{HTMLElement("textarea")}} affichant [un texte de substitution](/fr/docs/Web/HTML/Reference/Elements/input#placeholder).

--- a/files/fr/web/css/reference/selectors/_colon_playing/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_playing/index.md
@@ -1,8 +1,9 @@
 ---
-title: :playing
+title: Pseudo-classe CSS `:playing`
+short-title: :playing
 slug: Web/CSS/Reference/Selectors/:playing
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 Le sélecteur de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:playing`** est une pseudo-classe d'état d'une ressource audio, vidéo ou autre type de ressource capable d'être lue ou mise en pause lorsque cet élément est lu.

--- a/files/fr/web/css/reference/selectors/_colon_popover-open/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_popover-open/index.md
@@ -1,8 +1,9 @@
 ---
-title: :popover-open
+title: Pseudo-classe CSS `:popover-open`
+short-title: :popover-open
 slug: Web/CSS/Reference/Selectors/:popover-open
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:popover-open`** représente un élément [<i lang="en">popover</i>](/fr/docs/Web/API/Popover_API) (c'est-à-dire un élément avec un attribut [`popover`](/fr/docs/Web/HTML/Reference/Global_attributes/popover)) qui est dans l'état ouvert. Vous pouvez l'utiliser pour appliquer un style aux éléments <i lang="en">popovers</i> uniquement lorsqu'ils sont affichés.

--- a/files/fr/web/css/reference/selectors/_colon_read-only/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_read-only/index.md
@@ -1,8 +1,9 @@
 ---
-title: :read-only
+title: Pseudo-classe CSS `:read-only`
+short-title: :read-only
 slug: Web/CSS/Reference/Selectors/:read-only
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:read-only`** permet de cibler les éléments (tels que certains types de {{HTMLElement("input")}} et {{HTMLElement("textarea")}}) qui ne sont pas modifiables par l'utilisateur·ice. Les éléments sur lesquels l'attribut HTML [`readonly`](/fr/docs/Web/HTML/Reference/Attributes/readonly) n'a pas d'effet (tels que [`<input type="radio">`](/fr/docs/Web/HTML/Reference/Elements/input/radio), [`<input type="checkbox">`](/fr/docs/Web/HTML/Reference/Elements/input/checkbox) et tous les autres éléments non liés à un formulaire) sont également sélectionnés par la pseudo-classe `:read-only`. En fait, `:read-only` correspond à tout ce qui ne correspond pas à {{CSSxRef(":read-write")}}, ce qui le rend équivalent à `:not(:read-write)`.

--- a/files/fr/web/css/reference/selectors/_colon_read-write/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_read-write/index.md
@@ -1,8 +1,9 @@
 ---
-title: :read-write
+title: Pseudo-classe CSS `:read-write`
+short-title: :read-write
 slug: Web/CSS/Reference/Selectors/:read-write
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:read-write`** représente un élément (tel que `input` ou `textarea`) qui peut être modifié par l'utilisateur·ice.

--- a/files/fr/web/css/reference/selectors/_colon_required/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_required/index.md
@@ -1,8 +1,9 @@
 ---
-title: :required
+title: Pseudo-classe CSS `:required`
+short-title: :required
 slug: Web/CSS/Reference/Selectors/:required
 l10n:
-  sourceCommit: 4cb9d89a204a9532370693b982e8a3b274a874b1
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:required`** permet de cibler un élément {{HTMLElement("input")}} pour lequel l'attribut [`required`](/fr/docs/Web/HTML/Reference/Elements/input#required) est activé. Cela permet de mettre en forme les éléments obligatoires pour remplir correctement un formulaire.

--- a/files/fr/web/css/reference/selectors/_colon_right/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_right/index.md
@@ -1,8 +1,9 @@
 ---
-title: :right
+title: Pseudo-classe CSS `:right`
+short-title: :right
 slug: Web/CSS/Reference/Selectors/:right
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:right`**, liée à la règle {{CSSxRef("@page")}}, correspond aux pages de droite pour un média paginé. Ceci permet de mettre en forme les pages de droite.

--- a/files/fr/web/css/reference/selectors/_colon_root/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_root/index.md
@@ -1,8 +1,9 @@
 ---
-title: :root
+title: Pseudo-classe CSS `:root`
+short-title: :root
 slug: Web/CSS/Reference/Selectors/:root
 l10n:
-  sourceCommit: 35534a9827b883f755d6f429c230481496f9ead5
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:root`** permet de cibler la racine de l'arbre représentant le document. Pour un document HTML, `:root` ciblera donc l'élément {{HTMLElement("html")}} et aura le même comportement que le sélecteur `html` mais [sa spécificité](/fr/docs/Learn_web_development/Core/Styling_basics/Handling_conflicts#le_poids_des_sélecteurs) sera plus forte.

--- a/files/fr/web/css/reference/selectors/_colon_scope/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_scope/index.md
@@ -1,8 +1,9 @@
 ---
-title: :scope
+title: Pseudo-classe CSS `:scope`
+short-title: :scope
 slug: Web/CSS/Reference/Selectors/:scope
 l10n:
-  sourceCommit: 28e834cdc972a940d80a370f2fa15263a44c944b
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:scope`** représente les éléments qui sont des points de référence ou des portées auxquels faire correspondre les sélecteurs.

--- a/files/fr/web/css/reference/selectors/_colon_seeking/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_seeking/index.md
@@ -1,8 +1,9 @@
 ---
-title: :seeking
+title: Pseudo-classe CSS `:seeking`
+short-title: :seeking
 slug: Web/CSS/Reference/Selectors/:seeking
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:seeking`** représente un élément qui est lisible, tel que {{HTMLElement("audio")}} ou {{HTMLElement("video")}}, lorsque l'élément lisible recherche une position de lecture dans la ressource multimédia.

--- a/files/fr/web/css/reference/selectors/_colon_stalled/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_stalled/index.md
@@ -1,8 +1,9 @@
 ---
-title: :stalled
+title: Pseudo-classe CSS `:stalled`
+short-title: :stalled
 slug: Web/CSS/Reference/Selectors/:stalled
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:stalled`** représente un élément qui est lisible, tel que {{HTMLElement("audio")}} ou {{HTMLElement("video")}}, lorsque la lecture est bloquée.

--- a/files/fr/web/css/reference/selectors/_colon_state/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_state/index.md
@@ -1,8 +1,9 @@
 ---
-title: :state()
+title: Pseudo-classe CSS `:state()`
+short-title: :state()
 slug: Web/CSS/Reference/Selectors/:state
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La fonction de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:state()`** correspond aux [éléments personnalisés](/fr/docs/Web/API/Web_components/Using_custom_elements) qui ont l'état personnalisé spécifié.

--- a/files/fr/web/css/reference/selectors/_colon_target-after/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_target-after/index.md
@@ -1,8 +1,9 @@
 ---
-title: :target-after
+title: Pseudo-classe CSS `:target-after`
+short-title: :target-after
 slug: Web/CSS/Reference/Selectors/:target-after
 l10n:
-  sourceCommit: 9dbcd91284ec1ec64c4d8b343c3770880dd25129
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_colon_target-before/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_target-before/index.md
@@ -1,8 +1,9 @@
 ---
-title: :target-before
+title: Pseudo-classe CSS `:target-before`
+short-title: :target-before
 slug: Web/CSS/Reference/Selectors/:target-before
 l10n:
-  sourceCommit: 9dbcd91284ec1ec64c4d8b343c3770880dd25129
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_colon_target-current/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_target-current/index.md
@@ -1,8 +1,9 @@
 ---
-title: :target-current
+title: Pseudo-classe CSS `:target-current`
+short-title: :target-current
 slug: Web/CSS/Reference/Selectors/:target-current
 l10n:
-  sourceCommit: 9dbcd91284ec1ec64c4d8b343c3770880dd25129
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/selectors/_colon_target/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_target/index.md
@@ -1,8 +1,9 @@
 ---
-title: :target
+title: Pseudo-classe CSS `:target`
+short-title: :target
 slug: Web/CSS/Reference/Selectors/:target
 l10n:
-  sourceCommit: 11d748f9e217b6a9fd16291d7815a6f803f0136d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:target`** permet de cibler l'unique élément (s'il existe) dont l'attribut [`id`](/fr/docs/Web/HTML/Reference/Global_attributes#id) correspond au fragment d'identifiant de l'URI du document.

--- a/files/fr/web/css/reference/selectors/_colon_user-invalid/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_user-invalid/index.md
@@ -1,8 +1,9 @@
 ---
-title: :user-invalid
+title: Pseudo-classe CSS `:user-invalid`
+short-title: :user-invalid
 slug: Web/CSS/Reference/Selectors/:user-invalid
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:user-invalid`** représente tout élément de formulaire validé dont la valeur n'est pas valide selon ses [contraintes de validation](/fr/docs/Web/HTML/Guides/Constraint_validation), après que l'utilisateur·ice a interagi avec lui.

--- a/files/fr/web/css/reference/selectors/_colon_user-valid/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_user-valid/index.md
@@ -1,8 +1,9 @@
 ---
-title: :user-valid
+title: Pseudo-classe CSS `:user-valid`
+short-title: :user-valid
 slug: Web/CSS/Reference/Selectors/:user-valid
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:user-valid`** représente tout élément de formulaire validé donc la valeur respecte [la validation des contraintes](/fr/docs/Web/HTML/Guides/Constraint_validation). Toutefois, à la différence de {{CSSxRef(":valid")}}, cette pseudo-classe ne cible l'élément qu'après que la personne a interagi avec.

--- a/files/fr/web/css/reference/selectors/_colon_valid/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_valid/index.md
@@ -1,8 +1,9 @@
 ---
-title: :valid
+title: Pseudo-classe CSS `:valid`
+short-title: :valid
 slug: Web/CSS/Reference/Selectors/:valid
 l10n:
-  sourceCommit: f8ef875113a7d3e9952f41de68be1e3a3a1e6988
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:valid`** permet de cibler tout élément HTML {{HTMLElement("input")}} ou {{HTMLElement("form")}} dont la [validation](/fr/docs/Web/HTML/Guides/Constraint_validation) du contenu s'effectue correctement par rapport au type de donnée attendu. On peut ainsi facilement mettre en forme les champs correctement remplis par l'utilisateur·ice.

--- a/files/fr/web/css/reference/selectors/_colon_visited/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_visited/index.md
@@ -1,8 +1,9 @@
 ---
-title: :visited
+title: Pseudo-classe CSS `:visited`
+short-title: :visited
 slug: Web/CSS/Reference/Selectors/:visited
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:visited`** s'applique une fois que le lien a été visité par l'utilisateur·ice. Pour des raisons de vie privée, les styles pouvant être modifiés avec ce sélecteur sont très limités. La pseudo-classe `:visited` s'applique uniquement aux éléments HTML {{HTMLElement("a")}} et {{HTMLElement("area")}} qui possèdent un attribut `href`.

--- a/files/fr/web/css/reference/selectors/_colon_volume-locked/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_volume-locked/index.md
@@ -1,8 +1,9 @@
 ---
-title: :volume-locked
+title: Pseudo-classe CSS `:volume-locked`
+short-title: :volume-locked
 slug: Web/CSS/Reference/Selectors/:volume-locked
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 Le sélecteur de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:volume-locked`** représente un élément capable de produire du son, tel que {{HTMLElement("audio")}} ou {{HTMLElement("video")}}, mais pour lequel le volume de l'élément multimédia est actuellement «&nbsp;verrouillé&nbsp;» par l'utilisateur·ice.

--- a/files/fr/web/css/reference/selectors/_colon_where/index.md
+++ b/files/fr/web/css/reference/selectors/_colon_where/index.md
@@ -1,8 +1,9 @@
 ---
-title: :where()
+title: Pseudo-classe CSS `:where()`
+short-title: :where()
 slug: Web/CSS/Reference/Selectors/:where
 l10n:
-  sourceCommit: 235f91c4deeb3a62492fdc82565afc56c11ec153
+  sourceCommit: bf90d24ddf56e3f60df25fcbc0d4e3e084004794
 ---
 
 La fonction de [pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/fr/docs/Web/CSS) **`:where()`** prend une liste de sélecteurs en argument et cible tout élément qui peut être sélectionné par l'un des sélecteurs de la liste.


### PR DESCRIPTION
### Description

The front-matter key `title` now accept backticks. Content has updated titles to display code in title using these backticks.

### Motivation

Keep translated-content sync for updated pages

### Additional details

_none_

### Related issues and pull requests

Sync from https://github.com/mdn/content/tree/bf90d24ddf56e3f60df25fcbc0d4e3e084004794
