### PR TITLE
l10n(es): update SubtleCrypto and fix encrypt redirect

### DIFF
--- a/files/es/_redirects.txt
+++ b/files/es/_redirects.txt
@@ -1932,7 +1932,6 @@
 /es/docs/Web/API/PushManager/supportedContentEncodings	/es/docs/Web/API/PushManager/supportedContentEncodings_static
 /es/docs/Web/API/RandomSource/Obtenervaloresaleatorios	/es/docs/Web/API/Crypto/getRandomValues
 /es/docs/Web/API/Range/collapsed	/es/docs/Web/API/AbstractRange/collapsed
-/es/docs/Web/API/SubtleCrypto/encrypt	/es/docs/Web/HTTP/Reference/Headers/Content-Digest
 /es/docs/Web/API/UIEvent/pageX	/es/docs/Web/API/MouseEvent/pageX
 /es/docs/Web/API/URL/createObjectURL	/es/docs/Web/API/URL/createObjectURL_static
 /es/docs/Web/API/WebGL_API/Getting_started_with_WebGL	/es/docs/Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL

--- a/files/es/web/api/subtlecrypto/index.md
+++ b/files/es/web/api/subtlecrypto/index.md
@@ -1,87 +1,32 @@
 ---
 title: SubtleCrypto
 slug: Web/API/SubtleCrypto
+l10n:
+  sourceCommit: 44b15fff6c156ec81c2290e252e20c4519089688
 ---
 
-{{APIRef("Web Crypto API")}}
+{{APIRef("Web Crypto API")}}{{SecureContext_header}}{{AvailableInWorkers}}
 
-La interfaz **`SubtleCrypto`** de la [Web Crypto API](/es/docs/Web/API/Web_Crypto_API) provee una serie de funciones criptográficas de bajo nivel. Se accede a ella a través de las propiedades {{domxref("Crypto.subtle")}} disponible en un contexto de la ventana (via {{domxref("Window.crypto")}}).
+La interfaz **`SubtleCrypto`** de la [Web Crypto API](/es/docs/Web/API/Web_Crypto_API) proporciona una serie de funciones criptográficas de bajo nivel.
+
+El nombre de la interfaz incluye el término "subtle" (sutil) para indicar que muchos de sus algoritmos tienen requisitos de uso sutiles y que, por lo tanto, debe utilizarse con cuidado para ofrecer garantías de seguridad adecuadas.
+
+Una instancia de `SubtleCrypto` está disponible a través de la propiedad {{domxref("Crypto.subtle", "subtle")}} de la interfaz {{domxref("Crypto")}}, la cual se encuentra disponible en ventanas mediante {{domxref("Window.crypto")}} y en _workers_ a través de la propiedad {{domxref("WorkerGlobalScope.crypto")}}.
 
 > [!WARNING]
-> Esta API proporciona una serie de primitivos criptográficos de bajo nivel. Es muy fácil hacer un mal uso de ellos, y las trampas involucradas pueden ser muy sutiles.
+> Esta API proporciona una serie de primitivas criptográficas de bajo nivel. Es muy fácil hacer un mal uso de ellas, y los riesgos que conlleva pueden ser muy sutiles.
 >
-> Incluso suponiendo que se utilicen correctamente las funciones criptográficas básicas, la gestión segura de las claves y el diseño general del sistema de seguridad son extremadamente difíciles de conseguir correctamente, y generalmente son el dominio de expertos en seguridad especializados.
+> Incluso suponiendo que las funciones criptográficas básicas se utilicen correctamente, la gestión segura de las claves y el diseño general del sistema de seguridad son extremadamente difíciles de implementar de forma adecuada y, por lo general, son competencia de expertos especializados en seguridad.
 >
 > Los errores en el diseño e implementación del sistema de seguridad pueden hacer que la seguridad del sistema sea completamente ineficaz.
 >
-> **Si no estás seguro de saber lo que estás haciendo, probablemente no deberías usar esta API.**
+> Por favor, aprende y experimenta, pero no garantices ni insinúes la seguridad de tu trabajo antes de que una persona con conocimientos en esta materia lo revise exhaustivamente. El [curso Crypto 101](https://www.crypto101.io/) puede ser un excelente punto de partida para aprender sobre el diseño e implementación de sistemas seguros.
 
-## Descripción general
-
-Podemos dividir las funciones implementadas por esta API en dos grupos: funciones criptográficas y funciones de administración de claves.
-
-### Funciones criptográficas
-
-Estas son las funciones que puedes utilizar para implementar características de seguridad como la privacidad y la autenticación en un sistema. El API de `SubtleCrypto` proporciona las siguientes funciones criptográficas:
-
-- {{DOMxRef("SubtleCrypto.sign","sign()")}} y {{DOMxRef("SubtleCrypto.verify","verify()")}}: crea y verifica las firmas digitales.
-- {{DOMxRef("SubtleCrypto.encrypt","encrypt()")}} y {{DOMxRef("SubtleCrypto.decrypt","decrypt()")}}: encripta y desencripta datos.
-- {{DOMxRef("SubtleCrypto.digest","digest()")}}: crea un digest de longitud fija y resistente a colisiones de algunos datos.
-
-### Funciones de gestión clave
-
-Excepto para {{DOMxRef("SubtleCrypto.digest","digest()")}}, todas las funciones de criptografía de la API utilizan claves criptográficas. En la API `SubtleCrypto` una clave criptográfica se representa usando un objeto {{DOMxRef("CryptoKey","CryptoKey")}}. Para realizar operaciones como firmado y encriptación, provee un objeto {{DOMxRef("CryptoKey","CryptoKey")}} a la función {{DOMxRef("SubtleCrypto.sign","sign()")}} o {{DOMxRef("SubtleCrypto.encrypt","encrypt()")}}.
-
-#### Generando y derivando claves
-
-Las funciones {{DOMxRef("SubtleCrypto.generateKey","generateKey()")}} y {{DOMxRef("SubtleCrypto.deriveKey","deriveKey()")}} ambos crean un nuevo objeto {{DOMxRef("CryptoKey")}}.
-
-La diferencia es que `generateKey()` generará un nuevo valor clave distinto cada vez que lo llames, mientras que `deriveKey()` deriva una llave de algún material inicial de claves. Si proporcionas el mismo material de claves a dos llamadas separadas a `deriveKey()`, obtendrás dos objetos `CryptoKey` que tienen el mismo valor de base. Esto es útil si, por ejemplo, se quiere derivar una clave de cifrado de una contraseña y luego derivar la misma clave de la misma contraseña para descifrar los datos.
-
-#### Importación y exportación de claves
-
-Para hacer que las claves estén disponibles fuera de tu aplicación, necesitas exportar la clave, y para eso sirve {{DOMxRef("SubtleCrypto.exportKey","exportKey()")}}.Puedes elegir uno de varios formatos de exportación.
-
-El inverso de `exportKey()` es {{DOMxRef("SubtleCrypto.importKey","importKey()")}}. Puedes importar claves de otros sistemas, y la compatibilidad con formatos estándar como [PKCS #8](https://tools.ietf.org/html/rfc5208) y [JSON Web Key](https://tools.ietf.org/html/rfc7517) te ayudan a hacer esto. La función `exportKey()` exporta la clave en un formato no codificado.
-
-Si la clave es sensible, deberías usar {{DOMxRef("SubtleCrypto.wrapKey","wrapKey()")}}, que exporta la clave y luego la encripta usando otra clave; el API llama a una "llave de envoltura".
-
-El inverso de `wrapKey()` es {{DOMxRef("SubtleCrypto.unwrapKey","unwrapKey()")}}, que descifra y luego importa la llave.
-
-#### Almacenamiento de claves
-
-Epecification objetos `CryptoKey` pueden ser almacenados usando el [structured clone algorithm](/es/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), lo que significa que puedes almacenarlos y recuperarlos usando las API de almacenamiento web estándar. La especificación espera que la mayoría de los desarrolladores usen el [IndexedDB API](/es/docs/Web/API/IndexedDB_API) para almacenar objetos `CryptoKey`.
-
-### Algoritmos Suportados
-
-Las funciones criptográficas que proporciona la Web Crypto API pueden ser realizadas por uno o más _algoritmos criptográficos_ diferentes: El argumento `algorithm` de la función indica el algoritmo a utilizar. Algunos algoritmos necesitan parámetros adicionales: en estos casos el argumento `algorithm` es un objeto de diccionario que incluye los parámetros adicionales.
-
-En el cuadro que figura a continuación se resume qué algoritmos son adecuados para cada operación criptográfica:
-
-|                   | [sign()](/es/docs/Web/API/SubtleCrypto/sign)[verify()](/es/docs/Web/API/SubtleCrypto/verify) | [encrypt()](/es/docs/Web/HTTP/Reference/Headers/Content-Digest)[decrypt()](/es/docs/Web/API/SubtleCrypto/decrypt) | [digest()](/es/docs/Web/API/SubtleCrypto/digest) | [deriveBits()](/es/docs/Web/API/SubtleCrypto/deriveBits)[deriveKey()](/es/docs/Web/API/SubtleCrypto/deriveKey) | [wrapKey()](/es/docs/Web/API/SubtleCrypto/wrapKey)[unwrapKey()](/es/docs/Web/API/SubtleCrypto/unwrapKey) |
-| ----------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| RSASSA-PKCS1-v1_5 | ✓                                                                                            |                                                                                                                   |                                                  |                                                                                                                |                                                                                                          |
-| RSA-PSS           | ✓                                                                                            |                                                                                                                   |                                                  |                                                                                                                |                                                                                                          |
-| ECDSA             | ✓                                                                                            |                                                                                                                   |                                                  |                                                                                                                |                                                                                                          |
-| HMAC              | ✓                                                                                            |                                                                                                                   |                                                  |                                                                                                                |                                                                                                          |
-| RSA-OAEP          |                                                                                              | ✓                                                                                                                 |                                                  |                                                                                                                | ✓                                                                                                        |
-| AES-CTR           |                                                                                              | ✓                                                                                                                 |                                                  |                                                                                                                | ✓                                                                                                        |
-| AES-CBC           |                                                                                              | ✓                                                                                                                 |                                                  |                                                                                                                | ✓                                                                                                        |
-| AES-GCM           |                                                                                              | ✓                                                                                                                 |                                                  |                                                                                                                | ✓                                                                                                        |
-| SHA-1             |                                                                                              |                                                                                                                   | ✓                                                |                                                                                                                |                                                                                                          |
-| SHA-256           |                                                                                              |                                                                                                                   | ✓                                                |                                                                                                                |                                                                                                          |
-| SHA-384           |                                                                                              |                                                                                                                   | ✓                                                |                                                                                                                |                                                                                                          |
-| SHA-512           |                                                                                              |                                                                                                                   | ✓                                                |                                                                                                                |                                                                                                          |
-| ECDH              |                                                                                              |                                                                                                                   |                                                  | ✓                                                                                                              |                                                                                                          |
-| HKDF              |                                                                                              |                                                                                                                   |                                                  | ✓                                                                                                              |                                                                                                          |
-| PBKDF2            |                                                                                              |                                                                                                                   |                                                  | ✓                                                                                                              |                                                                                                          |
-| AES-KW            |                                                                                              |                                                                                                                   |                                                  |                                                                                                                | ✓                                                                                                        |
-
-## Propiedades
+## Propiedades de instancia
 
 _Esta interfaz no hereda ni implementa ninguna propiedad._
 
-## Métodos
+## Métodos de instancia
 
 _Esta interfaz no hereda ningún método._
 
@@ -94,7 +39,7 @@ _Esta interfaz no hereda ningún método._
 - {{domxref("SubtleCrypto.verify()")}}
   - : Retorna un {{jsxref("Promise")}} que se completa con un valor {{jsxref("Boolean")}} indicando si la firma dada como parámetro coincide con el texto, el algoritmo y la clave que también se dan como parámetros.
 - {{domxref("SubtleCrypto.digest()")}}
-  - : Retorna un {{jsxref("Promise")}} que se completa con digest generado a partir del algoritmo y el texto dados como parámetros.
+  - : Retorna un {{jsxref("Promise")}} que se completa con el digest generado a partir del algoritmo y el texto dados como parámetros.
 - {{domxref("SubtleCrypto.generateKey()")}}
   - : Retorna un {{jsxref("Promise")}} que se completa con un recién generado {{domxref("CryptoKey")}}, para algoritmos simétricos, o un {{domxref("CryptoKeyPair")}}, que contiene dos claves recién generadas, para algoritmos asimétricos. Estas coincidirán con el algoritmo, usos y extraíbles dados como parámetros.
 - {{domxref("SubtleCrypto.deriveKey()")}}
@@ -106,9 +51,265 @@ _Esta interfaz no hereda ningún método._
 - {{domxref("SubtleCrypto.exportKey()")}}
   - : Retorna un {{jsxref("Promise")}} que se completa con un buffer que contiene la clave en el formato solicitado.
 - {{domxref("SubtleCrypto.wrapKey()")}}
-  - : Retorna un {{jsxref("Promise")}} que se completa con una llave simétrica envuelta para su uso (transferencia y almacenamiento) en entornos inseguros. La llave envuelta coincide con el formato especificado en los parámetros dados, y la envoltura se hace con la llave envuelta dada, usando el algoritmo especificado.
+  - : Retorna un {{jsxref("Promise")}} que se completa con una clave simétrica envuelta para su uso (transferencia y almacenamiento) en entornos inseguros. La clave envuelta coincide con el formato especificado en los parámetros dados, y la envoltura se hace con la clave envuelta dada, usando el algoritmo especificado.
 - {{domxref("SubtleCrypto.unwrapKey()")}}
-  - : Retorna un {{jsxref("Promise")}} que se completa con un {{domxref("CryptoKey")}} correspondiente a la llave envuelta dada en el parámetro.
+  - : Retorna un {{jsxref("Promise")}} que se completa con un {{domxref("CryptoKey")}} correspondiente a la clave envuelta dada en el parámetro.
+
+## Uso de SubtleCrypto
+
+Podemos dividir las funciones implementadas por esta API en dos grupos: funciones criptográficas y funciones de administración de claves.
+
+### Funciones criptográficas
+
+Estas son las funciones que puedes utilizar para implementar características de seguridad como la privacidad y la autenticación en un sistema. El API de `SubtleCrypto` proporciona las siguientes funciones criptográficas:
+
+- {{domxref("SubtleCrypto.sign","sign()")}} y {{domxref("SubtleCrypto.verify","verify()")}}: crea y verifica las firmas digitales.
+- {{domxref("SubtleCrypto.encrypt","encrypt()")}} y {{domxref("SubtleCrypto.decrypt","decrypt()")}}: encripta y desencripta datos.
+- {{domxref("SubtleCrypto.digest","digest()")}}: crea un digest de longitud fija y resistente a colisiones de algunos datos.
+
+### Funciones de gestión de claves
+
+Excepto para {{domxref("SubtleCrypto.digest","digest()")}}, todas las funciones de criptografía de la API utilizan claves criptográficas. En la API `SubtleCrypto` una clave criptográfica se representa usando un objeto {{domxref("CryptoKey","CryptoKey")}}. Para realizar operaciones como firmado y encriptación, provee un objeto {{domxref("CryptoKey","CryptoKey")}} a la función {{domxref("SubtleCrypto.sign","sign()")}} o {{domxref("SubtleCrypto.encrypt","encrypt()")}}.
+
+#### Generando y derivando claves
+
+Las funciones {{domxref("SubtleCrypto.generateKey","generateKey()")}} y {{domxref("SubtleCrypto.deriveKey","deriveKey()")}} ambas crean un nuevo objeto {{domxref("CryptoKey")}}.
+
+La diferencia es que `generateKey()` generará un nuevo valor clave distinto cada vez que lo llames, mientras que `deriveKey()` deriva una clave de algún material inicial de claves. Si proporcionas el mismo material de claves a dos llamadas separadas a `deriveKey()`, obtendrás dos objetos `CryptoKey` que tienen el mismo valor de base. Esto es útil si, por ejemplo, se quiere derivar una clave de cifrado de una contraseña y luego derivar la misma clave de la misma contraseña para descifrar los datos.
+
+#### Importación y exportación de claves
+
+Para hacer que las claves estén disponibles fuera de tu aplicación, necesitas exportar la clave, y para eso sirve {{domxref("SubtleCrypto.exportKey","exportKey()")}}. Puedes elegir uno de varios formatos de exportación.
+
+El inverso de `exportKey()` es {{domxref("SubtleCrypto.importKey","importKey()")}}. Puedes importar claves de otros sistemas, y la compatibilidad con formatos estándar como [PKCS #8](https://tools.ietf.org/html/rfc5208) y [JSON Web Key](https://tools.ietf.org/html/rfc7517) te ayudan a hacer esto. La función `exportKey()` exporta la clave en un formato no codificado.
+
+Si la clave es sensible, deberías usar {{domxref("SubtleCrypto.wrapKey","wrapKey()")}}, que exporta la clave y luego la encripta usando otra clave; la API la llama "clave de envoltura".
+
+El inverso de `wrapKey()` es {{domxref("SubtleCrypto.unwrapKey","unwrapKey()")}}, que descifra y luego importa la clave.
+
+#### Almacenamiento de claves
+
+`CryptoKey` es un {{glossary("serializable object", "objeto serializable")}}, lo que permite que las claves se almacenen y recuperen utilizando las API de almacenamiento web estándar.
+
+La especificación espera que la mayoría de los desarrolladores utilicen la [API IndexedDB](/es/docs/Web/API/IndexedDB_API), almacenando los objetos `CryptoKey` asociados a algún identificador de cadena clave que sea significativo para la aplicación, junto con cualquier otro metadato que consideren útil.
+Esto permite el almacenamiento y la recuperación de la `CryptoKey` sin tener que exponer su material de clave subyacente a la aplicación o al entorno de JavaScript.
+
+### Algoritmos soportados
+
+Las funciones criptográficas que proporciona la Web Crypto API pueden ser realizadas por uno o más _algoritmos criptográficos_ diferentes: El argumento `algorithm` de la función indica el algoritmo a utilizar. Algunos algoritmos necesitan parámetros adicionales: en estos casos el argumento `algorithm` es un objeto de diccionario que incluye los parámetros adicionales.
+
+En el cuadro que figura a continuación se resume qué algoritmos son adecuados para cada operación criptográfica:
+
+<table class="standard-table">
+  <thead>
+    <tr>
+      <th scope="row"></th>
+      <th scope="col">
+        <a href="/es/docs/Web/API/SubtleCrypto/sign">sign</a><br /><a href="/es/docs/Web/API/SubtleCrypto/verify">verify</a>
+      </th>
+      <th scope="col">
+        <a href="/es/docs/Web/API/SubtleCrypto/encrypt">encrypt</a><br /><a href="/es/docs/Web/API/SubtleCrypto/decrypt">decrypt</a>
+      </th>
+      <th scope="col">
+        <a href="/es/docs/Web/API/SubtleCrypto/digest">digest</a>
+      </th>
+      <th scope="col">
+        <a href="/es/docs/Web/API/SubtleCrypto/deriveBits">deriveBits</a><br /><a href="/es/docs/Web/API/SubtleCrypto/deriveKey">deriveKey</a>
+      </th>
+      <th scope="col">
+        <a href="/es/docs/Web/API/SubtleCrypto/wrapKey">wrapKey</a><br /><a href="/es/docs/Web/API/SubtleCrypto/unwrapKey">unwrapKey</a>
+      </th>
+      <th scope="col">
+        <a href="/es/docs/Web/API/SubtleCrypto/generateKey">generateKey</a><br /><a href="/es/docs/Web/API/SubtleCrypto/exportKey">exportKey</a>
+      </th>
+      <th scope="col">
+        <a href="/es/docs/Web/API/SubtleCrypto/importKey">importKey</a>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/sign#rsassa-pkcs1-v1_5">RSASSA-PKCS1-v1_5</a></th>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/sign#rsa-pss">RSA-PSS</a></th>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/sign#ecdsa">ECDSA</a></th>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/sign#ed25519">Ed25519</a></th>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/sign#hmac">HMAC</a></th>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep">RSA-OAEP</a></th>
+      <td></td>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td>✓</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/encrypt#aes-ctr">AES-CTR</a></th>
+      <td></td>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td>✓</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/encrypt#aes-cbc">AES-CBC</a></th>
+      <td></td>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td>✓</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/encrypt#aes-gcm">AES-GCM</a></th>
+      <td></td>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td>✓</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/wrapKey#aes-kw">AES-KW</a></th>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td>✓</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/digest#supported_algorithms">SHA-1</a></th>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/digest#supported_algorithms">SHA-256</a></th>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/digest#supported_algorithms">SHA-384</a></th>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/digest#supported_algorithms">SHA-512</a></th>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/deriveKey#ecdh">ECDH</a></th>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td></td>
+      <td>✓</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/deriveKey#x25519">X25519</a></th>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td></td>
+      <td>✓</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/deriveKey#hkdf">HKDF</a></th>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href="/es/docs/Web/API/SubtleCrypto/deriveKey#pbkdf2">PBKDF2</a></th>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+      <td></td>
+      <td></td>
+      <td>✓</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Especificaciones
 
@@ -118,7 +319,11 @@ _Esta interfaz no hereda ningún método._
 
 {{Compat}}
 
-## Ver también
+## Véase también
 
-- {{domxref("Crypto")}} and {{domxref("Crypto.subtle")}}.
+- [Web Crypto API](/es/docs/Web/API/Web_Crypto_API)
+- [Usos no criptográficos de SubtleCrypto](/es/docs/Web/API/Web_Crypto_API/Non-cryptographic_uses_of_subtle_crypto)
+- [Seguridad web](/es/docs/Web/Security)
+- [Privacidad, permisos y seguridad de la información](/es/docs/Web/Privacy)
+- {{domxref("Crypto")}} y {{domxref("Crypto.subtle")}}.
 - [Crypto 101](https://www.crypto101.io/): un curso de introducción a la criptografía (en inglés).


### PR DESCRIPTION
### Description
This PR synchronizes the Spanish version of the `SubtleCrypto` interface with the English source and fixes a critical redirect error.

### Motivation
The `SubtleCrypto.encrypt` redirect was incorrectly pointing to the `Content-Digest` header, breaking navigation for readers. Additionally, the Spanish documentation for `SubtleCrypto` was out of sync with the upstream English content, missing key interface properties, and using outdated terminology and formatting.

### Additional details
**Specific changes:**
- Updated `files/es/_redirects.txt` to point `SubtleCrypto.encrypt` to the correct API page.
- Updated `files/es/web/api/subtlecrypto/index.md` to match English source commit `44b15ff`.
- Replaced the text list of algorithms with the standard HTML matrix table.
- Standardized terminology (using "clave" instead of "llave").
- Added the `SecureContext_header` and `AvailableInWorkers` macros.
- Verified changes locally using Yari.

### Related issues and pull requests
Fixes #34274