### PR TITLE
chore(fr): translation of `Web/API/HTMLMediaElement/error_event`

### DIFF
--- a/files/fr/web/api/htmlmediaelement/error_event/index.md
+++ b/files/fr/web/api/htmlmediaelement/error_event/index.md
@@ -1,0 +1,55 @@
+---
+title: "HTMLMediaElement : évènement error"
+short-title: error
+slug: Web/API/HTMLMediaElement/error_event
+l10n:
+  sourceCommit: a7265fc3effa7c25b9997135104370c057a65293
+---
+
+{{APIRef("HTML DOM")}}
+
+L'évènement **`error`** est déclenché lorsque la ressource n'a pas pu être chargée en raison d'une erreur (par exemple, un problème de connexion réseau).
+
+Cet évènement n'est pas annulable et ne se propage pas.
+
+## Syntaxe
+
+Utilisez le nom de l'évènement dans des méthodes comme {{DOMxRef("EventTarget.addEventListener", "addEventListener()")}}, ou définissez une propriété de gestionnaire d'évènements.
+
+```js-nolint
+addEventListener("error", (event) => { })
+
+onerror = (event) => { }
+```
+
+## Type d'évènement
+
+Un objet {{DOMxRef("Event")}} générique.
+
+## Exemples
+
+```js
+const video = document.querySelector("video");
+const videoSrc = "https://path/to/video.webm";
+
+video.addEventListener("error", () => {
+  console.error(`Erreur de chargement : ${videoSrc}`);
+});
+
+video.setAttribute("src", videoSrc);
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- L'interface {{DOMxRef("HTMLAudioElement")}}
+- L'interface {{DOMxRef("HTMLVideoElement")}}
+- L'élément HTML {{HTMLElement("audio")}}
+- L'élément HTML {{HTMLElement("video")}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/HTMLMediaElement/error_event`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_