### PR TITLE
chore(fr): translation of Firefox 150 (for april 21th)

### DIFF
--- a/files/fr/mozilla/firefox/experimental_features/index.md
+++ b/files/fr/mozilla/firefox/experimental_features/index.md
@@ -3,7 +3,7 @@ title: Fonctionnalités expérimentales dans Firefox
 short-title: Fonctionnalités expérimentales
 slug: Mozilla/Firefox/Experimental_features
 l10n:
-  sourceCommit: fa3c5c29a9d186b9970860bff1f513d3fb4ca354
+  sourceCommit: 291993c57c245249cf27c80f33f3dd22f8dd140d
 ---
 
 Cette page répertorie les fonctionnalités expérimentales et partiellement implémentées de Firefox, y compris les standards de la plateforme web en évolution ou proposés.
@@ -133,7 +133,7 @@ Vous pouvez également utiliser la notation fonctionnelle {{CSSxRef("animation-t
 
 Pour plus d'informations, voir [le bogue Firefox 1807685 <sup>(angl.)</sup>](https://bugzil.la/1807685), [le bogue Firefox 1804573 <sup>(angl.)</sup>](https://bugzil.la/1804573), [le bogue Firefox 1809005 <sup>(angl.)</sup>](https://bugzil.la/1809005), [le bogue Firefox 1676791 <sup>(angl.)</sup>](https://bugzil.la/1676791), [le bogue Firefox 1754897 <sup>(angl.)</sup>](https://bugzil.la/1754897), [le bogue Firefox 1817303 <sup>(angl.)</sup>](https://bugzil.la/1817303) et [le bogue Firefox 1737918 <sup>(angl.)</sup>](https://bugzil.la/1737918).
 
-Les propriétés {{CSSxRef('timeline-scope')}}, {{CSSxRef('animation-range-start')}} et {{CSSxRef('animation-range-end')}} (ainsi que la propriété abrégée {{CSSxRef('animation-range')}}) ne sont pas encore prises en charge. Pour plus d'informations, voir [le bogue Firefox 1676779 <sup>(angl.)</sup>](https://bugzil.la/1676779).
+La propriété {{CSSxRef('timeline-scope')}} n'est pas encore prise en charge. Pour plus d'informations, voir [le bogue Firefox 1676779 <sup>(angl.)</sup>](https://bugzil.la/1676779).
 
 | Canal de parution | Ajouté dans la version | Activé par défaut ? |
 | ----------------- | ---------------------- | ------------------- |
@@ -161,7 +161,8 @@ La fonctionnalité média CSS {{CSSxRef("@media/prefers-reduced-transparency")}}
 
 ### Fonctionnalité média `inverted-colors`
 
-La fonctionnalité média CSS {{CSSxRef("@media/inverted-colors")}} permet de détecter si un agent utilisateur ou le système d'exploitation sous-jacent inverse les couleurs. (Voir [le bogue Firefox 1794628 <sup>(angl.)</sup>](https://bugzil.la/1794628) pour plus de détails.)
+La fonctionnalité média CSS {{CSSxRef("@media/inverted-colors")}} permet de détecter si un agent utilisateur ou le système d'exploitation sous-jacent inverse les couleurs.
+Voir [le bogue Firefox 1794628 <sup>(angl.)</sup>](https://bugzil.la/1794628) pour plus de détails.
 
 | Canal de parution | Ajouté dans la version | Activé par défaut ? |
 | ----------------- | ---------------------- | ------------------- |
@@ -191,7 +192,8 @@ Ce nom peut ensuite être assigné à `animation-timeline`, ce qui permet d'anim
 ### Fonction anonyme de progression de la vue
 
 La fonction CSS {{CSSxRef("animation-timeline/view")}} permet d'indiquer que la propriété `animation-timeline` d'un élément est une timeline de progression de la vue, ce qui animera l'élément lorsqu'il se déplace dans la zone visible de son élément de défilement ancêtre.
-La fonction définit l'axe de l'élément parent qui fournit la timeline, ainsi que l'encart dans la zone visible où l'animation commence et se termine. (Voir [le bogue Firefox 1808410 <sup>(angl.)</sup>](https://bugzil.la/1808410) pour plus de détails.)
+La fonction définit l'axe de l'élément parent qui fournit la timeline, ainsi que l'encart dans la zone visible où l'animation commence et se termine.
+Voir [le bogue Firefox 1808410 <sup>(angl.)</sup>](https://bugzil.la/1808410) pour plus de détails.
 
 | Canal de parution | Ajouté dans la version | Activé par défaut ? |
 | ----------------- | ---------------------- | ------------------- |
@@ -320,17 +322,17 @@ La règle CSS {{CSSxRef("@custom-media")}} permet de définir des alias pour des
 
 | Canal de parution | Ajouté dans la version | Activé par défaut ? |
 | ----------------- | ---------------------- | ------------------- |
-| Nightly           | 146                    | Non                 |
-| Developer Edition | 146                    | Non                 |
-| Beta              | 146                    | Non                 |
-| Release           | 146                    | Non                 |
+| Nightly           | 148                    | Non                 |
+| Developer Edition | 148                    | Non                 |
+| Beta              | 148                    | Non                 |
+| Release           | 148                    | Non                 |
 
 - `layout.css.custom-media.enabled`
   - : Mettre sur `true` pour activer.
 
 ### Valeurs `<attr-type>` dans la fonction CSS `attr()`
 
-La fonction CSS {{CSSxRef("attr")}} prend désormais en charge les valeurs [`<attr-type>`](/fr/docs/Web/CSS/Reference/Values/attr#attr-type). Cela vous permet de spécifier comment une valeur d'attribut est analysée en une valeur CSS et de prendre ces valeurs directement à partir de [`data-*`](/fr/docs/Web/HTML/How_to/Use_data_attributes). ([Bogue Firefox 1986631 <sup>(angl.)</sup>](https://bugzil.la/1986631), [bogue Firefox 1998245 <sup>(angl.)</sup>](https://bugzil.la/1998245))
+La fonction CSS {{CSSxRef("attr")}} prend désormais en charge les valeurs [`<attr-type>`](/fr/docs/Web/CSS/Reference/Values/attr#attr-type). Cela vous permet de spécifier comment une valeur d'attribut est analysée en une valeur CSS et de prendre ces valeurs directement à partir de [`data-*`](/fr/docs/Web/HTML/How_to/Use_data_attributes). ([bogue Firefox 1986631 <sup>(angl.)</sup>](https://bugzil.la/1986631), [bogue Firefox 1998245 <sup>(angl.)</sup>](https://bugzil.la/1998245).
 
 | Canal de parution | Ajouté dans la version | Activé par défaut ? |
 | ----------------- | ---------------------- | ------------------- |
@@ -342,32 +344,48 @@ La fonction CSS {{CSSxRef("attr")}} prend désormais en charge les valeurs [`<at
 - `layout.css.attr.enabled`
   - : Mettre sur `true` pour activer.
 
-### `color-mix()` accepte plusieurs arguments de couleur
+### Attributs avec espace de noms dans la fonction CSS `attr()`
 
-La fonction CSS [`color-mix()`](/fr/docs/Web/CSS/Reference/Values/color_value/color-mix) prend désormais en charge plusieurs valeurs [`<color>`](/fr/docs/Web/CSS/Reference/Values/color_value), et pas seulement deux. Cela vous permet de mélanger plusieurs couleurs et de définir les pourcentages de chacune. ([Bogues Firefox 2007772 <sup>(angl.)</sup>](https://bugzil.la/2007772)).
+La fonction CSS {{CSSxRef("attr")}} prend désormais en charge les [attributs avec espace de noms](/fr/docs/Web/CSS/Reference/Values/attr#namespaces). Cela vous permet de prendre des attributs d'éléments de langages basés sur [XML](/fr/docs/Web/XML), tels que [SVG](/fr/docs/Web/SVG), et de les mettre en forme en conséquence. ([bogue Firefox 2014060 <sup>(angl.)</sup>](https://bugzil.la/2014060))
 
 | Canal de parution | Ajouté dans la version | Activé par défaut ? |
 | ----------------- | ---------------------- | ------------------- |
-| Nightly           | 150                    | Oui                 |
-| Developer Edition | 149                    | Non                 |
-| Beta              | 149                    | Non                 |
-| Release           | 149                    | Non                 |
+| Nightly           | 150                    | Non                 |
+| Developer Edition | 150                    | Non                 |
+| Beta              | 150                    | Non                 |
+| Release           | 150                    | Non                 |
 
-- `layout.css.color-mix-multi-color.enabled`
+- `layout.css.attr.enabled`
   - : Mettre sur `true` pour activer.
 
-### Pseudo-classes basées sur les médias
+### Requêtes `@container style()`
 
-Les pseudo-classes basées sur les médias {{CSSxRef(":buffering")}}, {{CSSxRef(":muted")}}, {{CSSxRef(":paused")}}, {{CSSxRef(":playing")}}, {{CSSxRef(":seeking")}}, {{CSSxRef(":stalled")}}, et {{CSSxRef(":volume-locked")}} vous permettent de mettre en forme les éléments HTML {{HTMLElement("audio")}} et {{HTMLElement("video")}} en fonction de leur état actuel, comme en lecture ou en pause. ([Bogue Firefox 1707584](https://bugzil.la/1707584), [bogue Firefox 2014512](https://bugzil.la/2014512)).
+La règle CSS [`@container`](/fr/docs/Web/CSS/Reference/At-rules/@container) prend en charge les requêtes [`style()`](/fr/docs/Web/CSS/Guides/Containment/Container_size_and_style_queries#conteneurs_de_requêtes_de_style). Cela vous permet de vérifier si un conteneur possède une déclaration CSS valide, une propriété CSS ou une propriété personnalisée, et d'appliquer des styles à ses enfants en conséquence. ([bogue Firefox 2014404 <sup>(angl.)</sup>](https://bugzil.la/2014404)).
 
 | Canal de parution | Ajouté dans la version | Activé par défaut ? |
 | ----------------- | ---------------------- | ------------------- |
-| Nightly           | 150                    | Oui                 |
+| Nightly           | 149                    | Oui                 |
 | Developer Edition | 149                    | Non                 |
 | Beta              | 149                    | Non                 |
 | Release           | 149                    | Non                 |
 
-- `dom.media.pseudo-classes.enabled`
+- `layout.css.style-queries.enabled`
+  - : Mettre sur `true` pour activer.
+
+### Éléments positionnés en absolu dans des conteneurs multi-colonnes et lors de l'impression
+
+Les éléments positionnés en absolu à l'intérieur des [conteneurs multi-colonnes](/fr/docs/Web/CSS/Guides/Multicol_layout) et lors de l'impression sont désormais correctement positionnés et fragmentés.
+Cela améliore l'interopérabilité avec d'autres navigateurs et empêche les problèmes de mise en page tels que le chevauchement du texte ou la perte de contenu.
+([bogue Firefox 2018797 <sup>(angl.)</sup>](https://bugzil.la/2018797)).
+
+| Canal de parution | Ajouté dans la version | Activé par défaut ? |
+| ----------------- | ---------------------- | ------------------- |
+| Nightly           | 150                    | Oui                 |
+| Developer Edition | 150                    | Non                 |
+| Beta              | 150                    | Non                 |
+| Release           | 150                    | Non                 |
+
+- `layout.abspos.fragmentainer-aware-positioning.enabled`
   - : Mettre sur `true` pour activer.
 
 ## SVG
@@ -376,15 +394,50 @@ Les pseudo-classes basées sur les médias {{CSSxRef(":buffering")}}, {{CSSxRef(
 
 ## JavaScript
 
-**Aucune fonctionnalité expérimentale dans ce cycle de publication.**
+### Tableaux associatifs multiples d'import
+
+Support pour [les tableaux associatifs multiples d'import](/fr/docs/Web/HTML/Reference/Elements/script/type/importmap#fusion_de_plusieurs_tableaux_associatifs_dimport).
+Cela donne aux développeur·euse·s plus de flexibilité lors de la structuration et du chargement des modules JavaScript, car ils n'ont plus besoin de connaître toutes leurs correspondances de modules à l'avance et de les déclarer dans un seul tableau associatif d'importation chargeant tous les modules.
+([bogue Firefox 1916277 <sup>(angl.)</sup>](https://bugzil.la/1916277)).
+
+| Canal de parution | Ajouté dans la version | Activé par défaut ? |
+| ----------------- | ---------------------- | ------------------- |
+| Nightly           | 150                    | Non                 |
+| Developer Edition | 150                    | Non                 |
+| Beta              | 150                    | Non                 |
+| Release           | 150                    | Non                 |
+
+- `dom.multiple_import_maps.enabled`
+  - : Mettre sur `true` pour activer.
 
 ## Les API Web
+
+### Registres d'éléments personnalisés à portée limitée
+
+La prise en charge des [registres d'éléments personnalisés à portée limitée](/fr/docs/Web/API/Web_components/Using_custom_elements#registres_des_éléments_personnalisés_à_portée_limitée) est en cours d'implémentation.
+Les registres à portée permettent à un arbre d'ombre de créer un {{DOMxRef("CustomElementRegistry")}} indépendant dont les définitions ne s'appliquent qu'à ce sous-arbre DOM spécifique.
+Cela permet d'éviter les collisions lorsque plusieurs composants Web déclarent des éléments portant le même nom.
+
+L'implémentation inclut&nbsp;:
+
+- La propriété `customElementRegistry` sur {{DOMxRef("Document")}}, {{DOMxRef("Element")}} et {{DOMxRef("ShadowRoot")}}.
+  ([bogue Firefox 2018900 <sup>(angl.)</sup>](https://bugzil.la/2018900)).
+
+| Canal de parution | Ajouté dans la version | Activé par défaut ? |
+| ----------------- | ---------------------- | ------------------- |
+| Nightly           | 150                    | Non                 |
+| Developer Edition | 150                    | Non                 |
+| Beta              | 150                    | Non                 |
+| Release           | 150                    | Non                 |
+
+- `dom.scoped-custom-element-registries.enabled`
+  - : Mettre sur `true` pour activer.
 
 ### CSS Typed Object Model Level 1
 
 Le travail d'implémentation a commencé sur le [CSS Typed OM Level 1 <sup>(angl.)</sup>](https://drafts.css-houdini.org/css-typed-om/).
 Par exemple, la méthode {{DOMxRef("CSSNumericValue/to", "to()")}} de l'interface {{DOMxRef("CSSNumericValue")}} est prise en charge pour convertir une valeur numérique CSS d'une unité à une autre.
-([Bogue Firefox 1278697 <sup>(angl.)</sup>](https://bugzil.la/1278697)).
+([bogue Firefox 1278697 <sup>(angl.)</sup>](https://bugzil.la/1278697)).
 
 | Canal de parution | Ajouté dans la version | Activé par défaut ? |
 | ----------------- | ---------------------- | ------------------- |

--- a/files/fr/mozilla/firefox/releases/149/index.md
+++ b/files/fr/mozilla/firefox/releases/149/index.md
@@ -3,7 +3,7 @@ title: Firefox 149 note de version pour les développeurs
 short-title: Firefox 149
 slug: Mozilla/Firefox/Releases/149
 l10n:
-  sourceCommit: d1d2fb19fa649240ce6e25c4d79e21d9a5f6de37
+  sourceCommit: 1ad93c0731806b155441afe9e44e971d8b2b0e2a
 ---
 
 Cet article présente les informations concernant les changements de Firefox 149 qui concernent les développeur·euse·s.
@@ -22,7 +22,7 @@ Firefox 149 est sorti le [24 mars 2026 <sup>(angl.)</sup>](https://whattrainisit
 
 ### CSS
 
-- La propriété CSS {{CSSxRef("shape-outside")}} prend désormais en charge la fonction {{CSSxRef("basic-shape/xywh", "xywh()")}} comme valeur. Cela permet de définir une forme autour de laquelle le contenu en ligne peut s'enrouler, en utilisant les distances par rapport aux bords gauche (`x`) et supérieur (`y`) du bloc contenant, ainsi qu'une largeur (`w`) et une hauteur (`h`). ([bogue Firefox 1983187 <sup>(angl.)</sup>](https://bugzil.la/1983187)).
+- La propriété CSS {{CSSxRef("shape-outside")}} prend désormais en charge la fonction {{CSSxRef("basic-shape/xywh", "xywh()")}} et {{CSSxRef("basic-shape/rect", "rect()")}} comme valeurs. Ces fonctions étaient déjà implémentées pour les propriétés {{CSSxRef("clip-path")}} et {{CSSxRef("offset-path")}}, et sont maintenant également disponibles pour `shape-outside`. ([bogue Firefox 1983187 <sup>(angl.)</sup>](https://bugzil.la/1983187)).
 
 - La propriété CSS {{CSSxRef("vertical-align")}} est désormais une propriété raccourcie pour les propriétés {{CSSxRef("alignment-baseline")}}, {{CSSxRef("baseline-shift")}} et {{CSSxRef("baseline-source")}}. ([bogue Firefox 1830771 <sup>(angl.)</sup>](https://bugzil.la/1830771)).
 
@@ -47,7 +47,7 @@ Firefox 149 est sorti le [24 mars 2026 <sup>(angl.)</sup>](https://whattrainisit
   Une version sérialisée des objets de rapport peut également être envoyée à un serveur de rapport défini dans l'en-tête HTTP correspondant — les noms des points de terminaison et les URL correspondantes doivent d'abord être définis dans les en-têtes de réponse HTTP {{HTTPHeader('Reporting-Endpoints')}} ou {{HTTPHeader('Report-To')}}.
   ([bogue Firefox 1976074 <sup>(angl.)</sup>](https://bugzil.la/1976074), [bogue Firefox 2008916 <sup>(angl.)</sup>](https://bugzil.la/2008916)).
 
-- Jusqu'à Firefox 148, `structuredClone.call(iframe.contentWindow)` créait incorrectement des objets dans le [domaine d'exécution](/fr/docs/Web/JavaScript/Reference/Execution_model#domaine_dexécution_realm) de l'appelant au lieu du domaine d'exécution du cadre intégré (<i lang="en">iframe</i> en anglais). L'implémentation crée désormais des objets dans le domaine d'exécution de `this`, de sorte que le comportement de la méthode correspond davantage à la spécification.
+- Jusqu'à Firefox 148, `structuredClone.call(iframe.contentWindow)` créait incorrectement des objets dans le [domaine d'exécution](/fr/docs/Web/JavaScript/Reference/Execution_model#domaine_dexécution_realm) de l'appelant au lieu du domaine d'exécution du cadre intégré (<i lang="en">iframe</i> en anglais). L'implémentation crée désormais des objets dans le domaine d'exécution de `this`, de sorte que le comportement de la méthode correspond davantage à la spécification ([bogue Firefox 2017797 <sup>(angl.)</sup>](https://bugzil.la/2017797)).
 
 #### DOM
 
@@ -88,8 +88,7 @@ Firefox 149 est sorti le [24 mars 2026 <sup>(angl.)</sup>](https://whattrainisit
 - Ajout du support pour `tabId` en tant que paramètre de niveau supérieur dans {{WebExtAPIRef("action.isEnabled")}} et {{WebExtAPIRef("browserAction.isEnabled")}}. Ce changement assure la compatibilité avec l'implémentation Chrome de `action.isEnabled`. ([bogue Firefox 2013477 <sup>(angl.)</sup>](https://bugzil.la/2013477))
 - Un geste de l'utilisateur·ice n'est plus requis pour {{WebExtAPIRef("action.openPopup")}} et {{WebExtAPIRef("browserAction.openPopup")}} pour ouvrir une fenêtre affichée par dessus le contenu (<i lang="en">popup</i> en anglais). Cette fonctionnalité était disponible derrière la préférence `extensions.openPopupWithoutUserGesture.enabled` depuis Firefox 108. Ce changement aligne le comportement de Firefox avec Chrome et Safari. ([bogue Firefox 1799344 <sup>(angl.)</sup>](https://bugzil.la/1799344))
 - Si `windowId` est passé dans {{WebExtAPIRef("action.openPopup")}} ou {{WebExtAPIRef("browserAction.openPopup")}}, la fenêtre doit être sélectionnée (active) pour que l'élément affiché par dessus le contenu s'ouvre. Pour ouvrir un élément par dessus le contenu dans une fenêtre qui n'est pas sélectionnée, {{WebExtAPIRef("windows.update","windows.update(windowId, { focused: true })")}} doit être appelé en premier. Ce changement aligne le comportement de Firefox avec Chrome. ([bogue Firefox 2011516 <sup>(angl.)</sup>](https://bugzil.la/2011516))
-- L'implémentation de {{DOMxRef("structuredClone")}} a été modifiée pour instancier des objets dans le domaine d'exécution de `this` au lieu du domaine d'exécution de l'appelant. Pour des raisons de compatibilité, la portée globale des scripts de contenu inclut désormais sa propre méthode `structuredClone` qui masque la méthode `window.structuredClone`. Pour plus d'informations, voir [`structuredClone` dans Partage d'objets avec les scripts de page](/fr/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts#structuredclone).
-
+- L'implémentation de {{DOMxRef("structuredClone")}} a été modifiée pour instancier des objets dans le domaine d'exécution de `this` au lieu du domaine d'exécution de l'appelant. Pour des raisons de compatibilité, la portée globale des scripts de contenu inclut désormais sa propre méthode `structuredClone` qui masque la méthode `window.structuredClone`. Pour plus d'informations, voir [`structuredClone` dans Partage d'objets avec les scripts de page](/fr/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts#structuredclone) ([bogue Firefox 2017797 <sup>(angl.)</sup>](https://bugzil.la/2017797)).
 - La capacité des extensions à exécuter dynamiquement du code dans leurs documents `moz-extension:` avec {{WebExtAPIRef("tabs.executeScript")}}, {{WebExtAPIRef("tabs.insertCSS")}}, {{WebExtAPIRef("tabs.removeCSS")}}, {{WebExtAPIRef("scripting.executeScript")}}, {{WebExtAPIRef("scripting.insertCSS")}}, et {{WebExtAPIRef("scripting.removeCSS")}} est désormais obsolète. ([bogue Firefox 2011234 <sup>(angl.)</sup>](https://bugzil.la/2011234)) La fonctionnalité n'est plus disponible dans Firefox Nightly, et les versions bêta et release de Firefox affichent un avertissement dans la console de l'onglet. Cette restriction s'appliquera à toutes les versions de Firefox 152 et ultérieures. ([bogue Firefox 2015559 <sup>(angl.)</sup>](https://bugzil.la/2015559)) En alternative, une extension peut exécuter du code dans ses documents de manière dynamique en enregistrant un écouteur {{WebExtAPIRef("runtime.onMessage")}} dans le script du document, puis en envoyant un message pour déclencher l'exécution du code requis.
 - Le filtre CSS implicite appliqué aux icônes SVG des [actions de page](/fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions) sur les thèmes sombres est désactivé dans les versions Nightly ([bogue Firefox 2001318 <sup>(angl.)</sup>](https://bugzil.la/2001318)) et sera désactivé dans les autres éditions de Firefox à partir de la version 152 ([bogue Firefox 2016509 <sup>(angl.)</sup>](https://bugzil.la/2016509)). Vous pouvez tester les icônes SVG des actions de page avec le filtre CSS désactivé dans d'autres éditions de Firefox en créant une préférence booléenne `about:config` appelée `extensions.webextensions.pageActionIconDarkModeFilter.enabled` et en la définissant sur `false`.
 
@@ -111,7 +110,7 @@ Firefox 149 est sorti le [24 mars 2026 <sup>(angl.)</sup>](https://whattrainisit
 
 #### Marionette
 
-- Amélioration de plusieurs commandes WebDriver classiques pour gérer les délais d'attente `implicit` et `pageLoad` conformément au délai d'attente du script, permettant aux valeurs `null` de désactiver les délais d'attente. ([bogue Firefox 2008345](https://bugzil.la/2008345)).
+- Amélioration de plusieurs commandes WebDriver classiques pour gérer les délais d'attente `implicit` et `pageLoad` conformément au délai d'attente du script, permettant aux valeurs `null` de désactiver les délais d'attente. ([bogue Firefox 2008345 <sup>(angl.)</sup>](https://bugzil.la/2008345)).
 
 ## Fonctionnalités web expérimentales
 

--- a/files/fr/mozilla/firefox/releases/149/index.md
+++ b/files/fr/mozilla/firefox/releases/149/index.md
@@ -3,7 +3,7 @@ title: Firefox 149 note de version pour les développeurs
 short-title: Firefox 149
 slug: Mozilla/Firefox/Releases/149
 l10n:
-  sourceCommit: 1ad93c0731806b155441afe9e44e971d8b2b0e2a
+  sourceCommit: ce29b1c36065db92c2a59ba507a4941fbf0a5159
 ---
 
 Cet article présente les informations concernant les changements de Firefox 149 qui concernent les développeur·euse·s.

--- a/files/fr/mozilla/firefox/releases/150/index.md
+++ b/files/fr/mozilla/firefox/releases/150/index.md
@@ -3,7 +3,7 @@ title: Firefox 150 note de version pour les développeurs
 short-title: Firefox 150
 slug: Mozilla/Firefox/Releases/150
 l10n:
-  sourceCommit: 291993c57c245249cf27c80f33f3dd22f8dd140d
+  sourceCommit: ce29b1c36065db92c2a59ba507a4941fbf0a5159
 ---
 
 Cet article présente les informations concernant les changements de Firefox 150 qui concernent les développeur·euse·s.
@@ -15,6 +15,7 @@ Firefox 150 est sorti le [21 avril 2026 <sup>(angl.)</sup>](https://whattrainisi
 
 - Un message spécifique est désormais affiché dans [_l'onglet Réponse_ du panneau Réseau <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/request_details/index.html#response-tab) pour indiquer pourquoi il n'y a pas de données de réponse lorsqu'une requête a été redirigée.
   ([bogue Firefox 2016679 <sup>(angl.)</sup>](https://bugzil.la/2016679)).
+- Une nouvelle section «&nbsp;Pseudo-classes spécifiques aux éléments&nbsp;» a été ajoutée au [panneau de bascule des pseudo-classes <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_css/index.html#viewing-common-pseudo-classes), incluant une bascule pour la pseudo-classe {{CSSxRef(":open")}}, qui n'est disponible que pour les éléments ayant un état ouvert comme les éléments `<dialog>`. La bascule existante pour la pseudo-classe {{CSSxRef(":visited")}} a également été déplacée, car elle ne s'applique qu'aux éléments `<a>` et `<area>`. ([bogue Firefox 2014442 <sup>(angl.)</sup>](https://bugzil.la/2014442)).
 
 ### HTML
 
@@ -39,9 +40,7 @@ Firefox 150 est sorti le [21 avril 2026 <sup>(angl.)</sup>](https://whattrainisi
 
 ### JavaScript
 
-- Le [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#types_de_calendriers_pris_en_charge) `"islamic-umalqura"` est désormais pris en charge par {{JSxRef("Intl")}}.
-  Cette chaîne de caractères sera dans la liste des calendriers retournés par {{JSxRef("Intl.supportedValuesOf()")}}, et peut être définie comme paramètre [`options.calendar`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#calendar) dans le [constructeur `DateTimeFormat()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat).
-  ([bogue Firefox 2011505 <sup>(angl.)</sup>](https://bugzil.la/2011505)).
+Pas de changements notables.
 
 ### APIs
 

--- a/files/fr/mozilla/firefox/releases/150/index.md
+++ b/files/fr/mozilla/firefox/releases/150/index.md
@@ -1,0 +1,118 @@
+---
+title: Firefox 150 note de version pour les développeurs
+short-title: Firefox 150
+slug: Mozilla/Firefox/Releases/150
+l10n:
+  sourceCommit: 291993c57c245249cf27c80f33f3dd22f8dd140d
+---
+
+Cet article présente les informations concernant les changements de Firefox 150 qui concernent les développeur·euse·s.
+Firefox 150 est sorti le [21 avril 2026 <sup>(angl.)</sup>](https://whattrainisitnow.com/release/?version=150).
+
+## Changements pour les développeur·euse·s web
+
+### Outils de développement
+
+- Un message spécifique est désormais affiché dans [_l'onglet Réponse_ du panneau Réseau <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/request_details/index.html#response-tab) pour indiquer pourquoi il n'y a pas de données de réponse lorsqu'une requête a été redirigée.
+  ([bogue Firefox 2016679 <sup>(angl.)</sup>](https://bugzil.la/2016679)).
+
+### HTML
+
+- Le mot-clé `"auto"` est désormais pris en charge comme option pour l'attribut [`sizes`](/fr/docs/Web/HTML/Reference/Elements/img#sizes) des éléments `<img>` (et [`HTMLImageElement.sizes`](/fr/docs/Web/API/HTMLImageElement/sizes)).
+  Cela permet aux éléments `<img>` chargés paresseusement d'utiliser la taille de mise en page de l'image calculée, après l'application de tout CSS, pour sélectionner l'image à afficher à partir d'un [`srcset`](/fr/docs/Web/HTML/Reference/Elements/img#srcset).
+  Cela est plus simple que de définir des conditions de média et leurs tailles associées dans l'attribut, ce qui duplique probablement le comportement déjà capturé dans les requêtes média CSS.
+  ([bogue Firefox 1819581 <sup>(angl.)</sup>](https://bugzil.la/1819581)).
+
+### CSS
+
+- La fonction CSS [`color-mix()`](/fr/docs/Web/CSS/Reference/Values/color_value/color-mix) accepte désormais plusieurs valeurs [`<color>`](/fr/docs/Web/CSS/Reference/Values/color_value), et pas seulement deux. Cela permet de mélanger un nombre quelconque de couleurs. ([bogue Firefox 2024171 <sup>(angl.)</sup>](https://bugzil.la/2024171)).
+
+- La fonction CSS [`light-dark()`](/fr/docs/Web/CSS/Reference/Values/color_value/light-dark) accepte désormais des valeurs [`<image>`](/fr/docs/Web/CSS/Reference/Values/image). Cela permet d'utiliser des images, des dégradés, etc. pour différents schémas de couleurs. ([bogue Firefox 2023569 <sup>(angl.)</sup>](https://bugzil.la/2023569)).
+
+- Les pseudo-classes basées sur les médias {{CSSxRef(":buffering")}}, {{CSSxRef(":muted")}}, {{CSSxRef(":paused")}}, {{CSSxRef(":playing")}}, {{CSSxRef(":seeking")}}, {{CSSxRef(":stalled")}} et {{CSSxRef(":volume-locked")}} sont désormais prises en charge. Elles permettent de mettre en forme les éléments {{HTMLElement("audio")}} et {{HTMLElement("video")}} en fonction de leur état actuel, comme en lecture ou en pause. ([bogue Firefox 2020775 <sup>(angl.)</sup>](https://bugzil.la/2020775)).
+
+- Les propriétés {{CSSxRef("animation-range-start")}} et {{CSSxRef("animation-range-end")}} (ainsi que la propriété abrégée {{CSSxRef("animation-range")}}) sont désormais prises en charge. Ces propriétés définissent le début et la fin de la plage d'attachement d'une animation le long de sa chronologie, ce qui vous permet de contrôler à quel moment de la chronologie d'une [animation pilotée par le défilement](/fr/docs/Web/CSS/Guides/Scroll-driven_animations) va commencer et se terminer. ([bogue Firefox 1825427 <sup>(angl.)</sup>](https://bugzil.la/1825427)).
+
+- Le mot-clé CSS {{CSSxRef("revert-rule")}} est désormais pris en charge. Il permet de déterminer la valeur d'une propriété comme si la règle de style actuelle n'avait pas été présente, de sorte que la valeur d'une autre règle correspondante puisse s'appliquer à la place. ([bogue Firefox 2017307 <sup>(angl.)</sup>](https://bugzil.la/2017307)).
+
+- La propriété CSS {{CSSxRef("overscroll-behavior")}} (et ses propriétés longues {{CSSxRef("overscroll-behavior-x")}}, {{CSSxRef("overscroll-behavior-y")}}, {{CSSxRef("overscroll-behavior-block")}} et {{CSSxRef("overscroll-behavior-inline")}}) s'applique désormais correctement aux conteneurs de défilement qui n'ont pas de débordement défilable, comme les éléments avec `overflow: hidden`. Auparavant, la propriété était ignorée sur de tels éléments. ([bogue Firefox 1837436 <sup>(angl.)</sup>](https://bugzil.la/1837436)).
+
+### JavaScript
+
+- Le [calendrier](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#types_de_calendriers_pris_en_charge) `"islamic-umalqura"` est désormais pris en charge par {{JSxRef("Intl")}}.
+  Cette chaîne de caractères sera dans la liste des calendriers retournés par {{JSxRef("Intl.supportedValuesOf()")}}, et peut être définie comme paramètre [`options.calendar`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#calendar) dans le [constructeur `DateTimeFormat()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat).
+  ([bogue Firefox 2011505 <sup>(angl.)</sup>](https://bugzil.la/2011505)).
+
+### APIs
+
+- La méthode {{DOMxRef("Sanitizer.replaceElementWithChildren()")}} retourne désormais `false` si l'élément à remplacer est {{HTMLElement("html")}} dans [l'espace de noms HTML](/fr/docs/Web/API/Sanitizer/replaceElementWithChildren#namespace).
+  En d'autres termes, vous ne pouvez pas utiliser cette méthode pour créer un {{DOMxRef("Sanitizer")}} qui remplacera l'élément `<html>` par son contenu interne. ([bogue Firefox 2022176 <sup>(angl.)</sup>](https://bugzil.la/2022176)).
+
+#### DOM
+
+- L'argument [`options.shadowRoots`](/fr/docs/Web/API/Document/caretPositionFromPoint#shadowroots) de la méthode {{DOMxRef('Document.caretPositionFromPoint()')}} est désormais pris en charge.
+  Cela permet à la méthode de retourner le nœud contenant le curseur à l'intérieur d'un DOM d'ombre, à condition que son {{DOMxRef("ShadowRoot")}} associé ait été passé en option.
+  ([bogue Firefox 1914596 <sup>(angl.)</sup>](https://bugzil.la/1914596)).
+
+- L'interface {{DOMxRef("CSSFontFaceDescriptors")}} est désormais prise en charge, et une instance de ce type est retournée par la propriété {{DOMxRef("CSSFontFaceRule.style")}}. ([bogue Firefox 2019904 <sup>(angl.)</sup>](https://bugzil.la/2019904)).
+
+- La méthode non standard {{DOMxRef("Document/caretRangeFromPoint","caretRangeFromPoint()")}} de l'interface {{DOMxRef("Document")}} est désormais prise en charge. ([bogue Firefox 1550635 <sup>(angl.)</sup>](https://bugzil.la/1550635)).
+
+- La méthode `ariaNotify()` est désormais prise en charge sur les interfaces {{DOMxRef("Document/ariaNotify","Document")}} et {{DOMxRef("Element/ariaNotify","Element")}}.
+  Cela permet de mettre en file d'attente une chaîne de texte à annoncer par un {{Glossary("screen reader", "lecteur d'écran")}}, offrant une alternative plus ergonomique et fiable aux [régions ARIA dynamiques](/fr/docs/Web/Accessibility/ARIA/Guides/Live_regions).
+  ([bogue Firefox 2018095 <sup>(angl.)</sup>](https://bugzil.la/2018095)).
+
+### Conformité WebDriver (WebDriver BiDi, Marionette)
+
+#### Général
+
+- Correction d'un problème où la fermeture du navigateur avec des téléchargements en attente pouvait être bloquée par une invite. L'invite est désormais rejetée automatiquement. ([bogue Firefox 2003840 <sup>(angl.)</sup>](https://bugzil.la/2003840)).
+
+#### WebDriver BiDi
+
+- Ajout de la commande `emulation.setNetworkConditions`, qui prend en charge le type `offline` pour le moment. Cela permet d'émuler le mode hors ligne soit sur des contextes de navigation spécifiques, sur des contextes utilisateur (a.k.a. conteneurs) ou globalement. ([bogue Firefox 1993079 <sup>(angl.)</sup>](https://bugzil.la/1993079)).
+- Amélioration de la prise en charge des valeurs d'en-tête non UTF-8 dans toutes les commandes et évènements du module `network`. Elles sont désormais correctement sérialisées en `BytesValue`. ([bogue Firefox 1994996 <sup>(angl.)</sup>](https://bugzil.la/1994996)).
+- Correction d'un bogue pour les évènements de téléchargement déclenchés par une réponse avec l'en-tête "Content-Disposition". Ces évènements ne comportaient pas la propriété `navigation` si le téléchargement était initié par un lien avec `target="_blank"`. ([bogue Firefox 1999481 <sup>(angl.)</sup>](https://bugzil.la/1999481)).
+- Mise à jour de l'évènement `log.entryAdded` pour qu'il ne soit émis que pour les appels à l'API console qui affichent réellement un message dans les outils de développement du navigateur (voir également la spécification de la console&nbsp;: [utilisation de l'imprimante <sup>(angl.)</sup>](https://console.spec.whatwg.org/#printer)). Avec ce changement, l'utilisation de `console.clear` ou `console.time` ne déclenche plus d'évènement. ([bogue Firefox 1866749 <sup>(angl.)</sup>](https://bugzil.la/1866749)).
+- Correction d'une condition de concurrence avec la commande `browsingContext.setViewport` qui pouvait entraîner un dépassement de délai si plusieurs contextes étaient créés en parallèle. ([bogue Firefox 2019511 <sup>(angl.)</sup>](https://bugzil.la/2019511)).
+- Amélioration de la commande `browsingContext.locateNodes` pour permettre de récupérer l'élément HTML (`documentElement`) d'une page lors de l'utilisation du localisateur `css`. ([bogue Firefox 2020578 <sup>(angl.)</sup>](https://bugzil.la/2020578)).
+
+#### Marionette
+
+- Correction de la commande `WebDriver:getShadowRoot` pour qu'elle ne retourne plus les racines d'ombre spécifiques à l'agent utilisateur. ([bogue Firefox 2016741 <sup>(angl.)</sup>](https://bugzil.la/2016741)).
+
+## Changements pour les développeur·euse·s d'extensions
+
+- Le comportement de {{WebExtAPIRef("tabs.move")}} est mis à jour pour les vues fractionnées afin que&nbsp;:
+  - L'ordre des onglets dans une vue fractionnée puisse être échangé. ([bogue Firefox 2016762 <sup>(angl.)</sup>](https://bugzil.la/2016762))
+  - Lorsque la liste des onglets inclut à la fois des onglets de vue fractionnée et place un ou plusieurs onglets entre eux, les onglets sont déplacés et la vue fractionnée est fermée. ([bogue Firefox 2022549 <sup>(angl.)</sup>](https://bugzil.la/2022549))
+- Résolution d'un problème avec certains appels JavaScript [`import`](/fr/docs/Web/JavaScript/Reference/Statements/import) échouant à importer du CSS. ([bogue Firefox 2016369 <sup>(angl.)</sup>](https://bugzil.la/2016369))
+
+## Fonctionnalités web expérimentales
+
+Ces fonctionnalités sont livrées dans Firefox 150 mais sont désactivées par défaut.
+Pour les tester, recherchez la préférence appropriée dans la page `about:config` et définissez-la sur `true`.
+Vous pouvez en trouver d'autres sur la page [Fonctionnalités expérimentales](/fr/docs/Mozilla/Firefox/Experimental_features).
+
+- **Attributs avec espace de noms dans la fonction CSS `attr()`**&nbsp;: `layout.css.attr.enabled`
+
+  La fonction CSS {{CSSxRef("attr()")}} prend désormais en charge [les attributs avec espace de noms](/fr/docs/Web/CSS/Reference/Values/attr#namespaces). Cela vous permet de prendre des attributs d'éléments de langages basés sur [XML](/fr/docs/Web/XML), tels que [SVG](/fr/docs/Web/SVG) et de les mettre en forme en conséquence. ([bogue Firefox 2014060 <sup>(angl.)</sup>](https://bugzil.la/2014060))
+
+- **Requêtes `@container style()`** (Nightly)&nbsp;: `layout.css.style-queries.enabled`
+
+  La règle CSS [`@container`](/fr/docs/Web/CSS/Reference/At-rules/@container) prend en charge les requêtes [`style()`](/fr/docs/Web/CSS/Guides/Containment/Container_size_and_style_queries#conteneurs_de_requêtes_de_style). Cela a été mis à jour pour prendre en charge l'imbrication des requêtes `style()`. ([bogue Firefox 2014098 <sup>(angl.)</sup>](https://bugzil.la/2014098)).
+
+- **Les éléments positionnés en absolu dans les conteneurs à colonnes multiples et lors de l'impression**&nbsp;: `layout.abspos.fragmentainer-aware-positioning.enabled`
+
+  Les éléments positionnés en absolu à l'intérieur des [conteneurs à colonnes multiples](/fr/docs/Web/CSS/Guides/Multicol_layout) et lors de l'impression sont désormais correctement positionnés et fragmentés. Cela améliore l'interopérabilité avec d'autres navigateurs et empêche les problèmes de mise en page tels que le chevauchement du texte ou la perte de contenu. ([bogue Firefox 2018797 <sup>(angl.)</sup>](https://bugzil.la/2018797)).
+
+- **Registres d'éléments personnalisés à portée limitée**&nbsp;: `dom.scoped-custom-element-registries.enabled`
+
+  La propriété {{DOMxRef("CustomElementRegistry","customElementRegistry")}} est prise en charge sur {{DOMxRef("Document")}}, {{DOMxRef("Element")}} et {{DOMxRef("ShadowRoot")}}.
+  Cela permet la définition de [registres d'éléments personnalisés à portée limitée](/fr/docs/Web/API/Web_components/Using_custom_elements#registres_déléments_personnalisés_à_portée_limitée).
+  ([bogue Firefox 2018900 <sup>(angl.)</sup>](https://bugzil.la/2018900)).
+
+- **Tableaux associatifs d'importations multiples**&nbsp;: `dom.multiple_import_maps.enabled`
+
+  Les [tableaux associatifs d'importations multiples](/fr/docs/Web/HTML/Reference/Elements/script/type/importmap#fusion_de_plusieurs_tableaux_associatifs_dimport) offrent aux développeur·euse·s plus de flexibilité lors de la structuration et du chargement des modules JavaScript.
+  ([bogue Firefox 1916277 <sup>(angl.)</sup>](https://bugzil.la/1916277)).

--- a/files/fr/web/html/reference/elements/script/type/importmap/index.md
+++ b/files/fr/web/html/reference/elements/script/type/importmap/index.md
@@ -6,16 +6,16 @@ l10n:
   sourceCommit: 16c2dc9c347065f648a0d6204b814657480ed25b
 ---
 
-La valeur **`importmap`** de l'attribut [`type`](/fr/docs/Web/HTML/Reference/Elements/script/type) pour l'élément HTML {{HTMLElement("script")}} indique que le contenu de l'élément contient une carte d'import (<i lang="en">import map</i>).
+La valeur **`importmap`** de l'attribut [`type`](/fr/docs/Web/HTML/Reference/Elements/script/type) pour l'élément HTML {{HTMLElement("script")}} indique que le contenu de l'élément contient un tableau associatif d'import (<i lang="en">import map</i>).
 
-Une carte d'import est un objet JSON qui permet aux développeur·euse·s de contrôler la façon dont le navigateur résout les spécificateurs de modules lors de l'import [des modules JavaScript](/fr/docs/Web/JavaScript/Guide/Modules).
+Un tableau associatif d'import est un objet JSON qui permet aux développeur·euse·s de contrôler la façon dont le navigateur résout les spécificateurs de modules lors de l'import [des modules JavaScript](/fr/docs/Web/JavaScript/Guide/Modules).
 Elle fournit une correspondance entre le texte utilisé comme spécificateur de module dans [une instruction `import`](/fr/docs/Web/JavaScript/Reference/Statements/import) ou [un opérateur `import()`](/fr/docs/Web/JavaScript/Reference/Operators/import) et la valeur correspondante qui remplacera le texte lors de la résolution du spécificateur.
-L'objet JSON doit respecter [le format de représentation JSON des cartes d'import](#représentation_json_des_cartes_dimport).
+L'objet JSON doit respecter [le format de représentation JSON des tableaux associatifs d'import](#représentation_json_des_tableaux_associatifs_dimport).
 
-Une carte d'import est utilisée pour la résolution des spécificateurs de module, tant pour les imports statiques que pour les imports dynamiques. Elle doit donc être déclarée et traitée avant tout élément `<script>` important des modules utilisant des spécificateurs présents dans la carte.
-On notera que la carte d'import s'applique uniquement aux spécificateurs de module présents dans [l'instruction `import`](/fr/docs/Web/JavaScript/Reference/Statements/import) ou [l'opérateur `import()`](/fr/docs/Web/JavaScript/Reference/Operators/import)&nbsp;; elle ne s'applique pas au chemin fourni via l'attribut `src` d'un élément `<script>`.
+Un tableau associatif d'import est utilisée pour la résolution des spécificateurs de module, tant pour les imports statiques que pour les imports dynamiques. Elle doit donc être déclarée et traitée avant tout élément `<script>` important des modules utilisant des spécificateurs présents dans le tableau.
+On notera que la tableau associatif d'import s'applique uniquement aux spécificateurs de module présents dans [l'instruction `import`](/fr/docs/Web/JavaScript/Reference/Statements/import) ou [l'opérateur `import()`](/fr/docs/Web/JavaScript/Reference/Operators/import)&nbsp;; elle ne s'applique pas au chemin fourni via l'attribut `src` d'un élément `<script>`.
 
-Pour plus d'informations, voir [la section sur l'import de modules à l'aide des cartes d'import](/fr/docs/Web/JavaScript/Guide/Modules#importer_des_modules_avec_des_cartes_d_import) dans le guide sur les modules JavaScript.
+Pour plus d'informations, voir [la section sur l'import de modules à l'aide des tableaux associatifs d'import](/fr/docs/Web/JavaScript/Guide/Modules#importer_des_modules_avec_des_tableaux_associatifs_dimport) dans le guide sur les modules JavaScript.
 
 ## Syntaxe
 
@@ -30,9 +30,9 @@ Les attributs `src`, `async`, `nomodule`, `defer`, `crossorigin`, `integrity`, e
 ### Exceptions
 
 - `TypeError`
-  - : La définition de la carte d'import n'est pas un objet JSON ou la clé `importmap` est définie mais n'est pas un objet JSON, ou la clé `scopes` est définie mais n'est pas un objet JSON.
+  - : La définition de le tableau associatif d'import n'est pas un objet JSON ou la clé `importmap` est définie mais n'est pas un objet JSON, ou la clé `scopes` est définie mais n'est pas un objet JSON.
 
-Les navigateurs génèrent des avertissements dans la console au cas où la carte d'import JSON ne respecte pas [le schéma de représentation des cartes d'import](#représentation_json_des_cartes_d_import).
+Les navigateurs génèrent des avertissements dans la console au cas où le tableau associatif d'import JSON ne respecte pas [le schéma de représentation des tableaux associatifs d'import](#représentation_json_des_tableaux_associatifs_dimport).
 
 ## Description
 
@@ -46,11 +46,11 @@ import { nom as nomCercle } from "https://example.com/formes/cercle.js";
 import { nom as nomCarre, dessiner } from "./modules/formes/carre.js";
 ```
 
-Les cartes d'import permettent d'indiquer (presque) n'importe quel texte comme spécificateur de module, la carte fournit une correspondance qui remplacera le texte lors de la résolution du spécificateur.
+Les tableaux associatifs d'import permettent d'indiquer (presque) n'importe quel texte comme spécificateur de module, le tableau fournit une correspondance qui remplacera le texte lors de la résolution du spécificateur.
 
 ### Noms simples
 
-La carte d'import qui suit définit une clé `imports` doté d'une carte de correspondance pour les spécificateurs de module qui a les propriétés `carre` et `cercle`.
+Le tableau associatif d'import qui suit définit une clé `imports` doté d'un tableau associatif de correspondance pour les spécificateurs de module qui a les propriétés `carre` et `cercle`.
 
 ```html
 <script type="importmap">
@@ -63,7 +63,7 @@ La carte d'import qui suit définit une clé `imports` doté d'une carte de corr
 </script>
 ```
 
-Grâce à cette carte d'import, on peut réaliser le même import que précédemment, mais en utilisant des noms simples comme spécificateurs de modules&nbsp;:
+Grâce à ce tableau associatif d'import, on peut réaliser le même import que précédemment, mais en utilisant des noms simples comme spécificateurs de modules&nbsp;:
 
 ```js
 import { nom as nomCarre, dessiner } from "carre";
@@ -108,7 +108,7 @@ Elles peuvent contenir ou finir des séparateurs de chemin, être des URL absolu
 }
 ```
 
-Si plusieurs clés de spécificateur d'une carte peuvent correspondre, c'est la clé la plus spécifique qui est sélectionnée (celle avec la plus longue valeur).
+Si plusieurs clés de spécificateur d'un tableau associatif peuvent correspondre, c'est la clé la plus spécifique qui est sélectionnée (celle avec la plus longue valeur).
 
 Un spécificateur de module `./toto/../js/app.js` sera converti en `./js/app.js` avant la recherche de correspondance.
 Aussi, cela signifie que la clé `./js/app.js` correspondrait au spécificateur de module, même si ce ne sont pas exactement les mêmes.
@@ -119,7 +119,7 @@ La clé `scopes` permet de fournir des correspondances qui seront uniquement uti
 Si l'URL du script qui charge le module correspond au chemin indiqué, c'est la correspondance associée à cette portée qui sera utilisée.
 Cela permet d'avoir différentes versions du module qui peuvent être utilisées selon le code qui réalise l'import.
 
-Dans l'exemple qui suit, la carte utilisera uniquement la correspondance de la portée si l'URL du module qui fait le chargement contient le chemin&nbsp;: `"/modules/formesspecifiques/"`.
+Dans l'exemple qui suit, le tableau associatif utilisera uniquement la correspondance de la portée si l'URL du module qui fait le chargement contient le chemin&nbsp;: `"/modules/formesspecifiques/"`.
 
 ```html
 <script type="importmap">
@@ -139,16 +139,16 @@ Dans l'exemple qui suit, la carte utilisera uniquement la correspondance de la p
 Si plusieurs portées correspondent à l'URL du module, c'est la portée avec le chemin le plus spécifique qui est utilisée (autrement dit, celle pour laquelle la clé a le nom le plus long).
 Si cette portée ne contient aucun spécificateur correspondant à l'import, il passe à la prochaine portée la plus spécifique, et ainsi de suite. Le navigateur pourra finir par utiliser la correspondance de la clé `imports` si le spécificateur n'est présent dans aucune portée.
 
-### Carte des métadonnées d'intégrité
+### Tableau associatif des métadonnées d'intégrité
 
 Vous pouvez utiliser la clé `integrity` pour fournir une correspondance pour les [métadonnées d'intégrité](/fr/docs/Web/Security/Defenses/Subresource_Integrity#utilisation_de_subresource_integrity) des modules.
 Cela permet de garantir l'intégrité des modules importés dynamiquement ou statiquement.
 La clé `integrity` permet aussi de fournir une solution de repli pour les modules principaux ou préchargés, au cas où ils n'incluraient pas déjà un attribut `integrity`.
 
-Les clés de la carte représentent les URL des modules, qui peuvent être absolues ou relatives (commençant par `/`, `./` ou `../`).
-Les valeurs de la carte représentent les métadonnées d'intégrité, identiques à celles utilisées dans les valeurs de l'attribut [`integrity`](/fr/docs/Web/HTML/Reference/Elements/script#integrity).
+Les clés du tableau associatif représentent les URL des modules, qui peuvent être absolues ou relatives (commençant par `/`, `./` ou `../`).
+Les valeurs du tableau associatif représentent les métadonnées d'intégrité, identiques à celles utilisées dans les valeurs de l'attribut [`integrity`](/fr/docs/Web/HTML/Reference/Elements/script#integrity).
 
-Par exemple, la carte ci-dessous définit des métadonnées d'intégrité pour le module `square.js` (directement) et pour son spécificateur simple (de façon transitive, via la clé `imports`).
+Par exemple, le tableau associatif ci-dessous définit des métadonnées d'intégrité pour le module `square.js` (directement) et pour son spécificateur simple (de façon transitive, via la clé `imports`).
 
 ```html
 <script type="importmap">
@@ -163,13 +163,13 @@ Par exemple, la carte ci-dessous définit des métadonnées d'intégrité pour l
 </script>
 ```
 
-### Fusion de plusieurs cartes d'import
+### Fusion de plusieurs tableaux associatifs d'import
 
-Les navigateurs prenant en charge cette fonctionnalité peuvent déclarer une ou plusieurs cartes d'import n'importe où dans le document, à condition qu'elles soient définies avant tout module qui en dépend (certaines [versions de navigateurs](#compatibilité_des_navigateurs) n'autorisent qu'une seule déclaration de carte d'import, qui doit apparaître avant tout module chargé).
+Les navigateurs prenant en charge cette fonctionnalité peuvent déclarer une ou plusieurs tableaux associatifs d'import n'importe où dans le document, à condition qu'elles soient définies avant tout module qui en dépend (certaines [versions de navigateurs](#compatibilité_des_navigateurs) n'autorisent qu'une seule déclaration de tableau associatif d'import, qui doit apparaître avant tout module chargé).
 
-En interne, les navigateurs maintiennent une seule représentation globale de la carte d'import. Lorsque plusieurs cartes d'import sont incluses dans un document, leur contenu est fusionné dans la carte d'import globale lors de leur enregistrement.
+En interne, les navigateurs maintiennent une seule représentation globale du tableau associatif d'import. Lorsque plusieurs tableaux associatifs d'import sont incluses dans un document, leur contenu est fusionné dans le tableau associatif d'import global lors de leur enregistrement.
 
-Par exemple, considérons les deux cartes d'import suivantes&nbsp;:
+Par exemple, considérons les deux tableaux associatifs d'import suivantes&nbsp;:
 
 ```html
 <script type="importmap">
@@ -196,7 +196,7 @@ Par exemple, considérons les deux cartes d'import suivantes&nbsp;:
 </script>
 ```
 
-Celles-ci sont équivalentes à la carte d'import unique suivante&nbsp;:
+Celles-ci sont équivalentes au tableau associatif d'import unique suivant&nbsp;:
 
 ```html
 <script type="importmap">
@@ -214,9 +214,9 @@ Celles-ci sont équivalentes à la carte d'import unique suivante&nbsp;:
 </script>
 ```
 
-Les spécificateurs de module de chaque carte enregistrée qui étaient déjà résolus auparavant sont ignorés. Les résolutions ultérieures de ces spécificateurs donneront les mêmes résultats que leurs résolutions précédentes.
+Les spécificateurs de module de chaque tableau associatif enregistrée qui étaient déjà résolus auparavant sont ignorés. Les résolutions ultérieures de ces spécificateurs donneront les mêmes résultats que leurs résolutions précédentes.
 
-Par exemple, si le spécificateur de module `/app/helper.js` a déjà été résolu, la nouvelle carte d'import suivante&nbsp;:
+Par exemple, si le spécificateur de module `/app/helper.js` a déjà été résolu, le nouveau tableau associatif d'import suivant&nbsp;:
 
 ```html
 <script type="importmap">
@@ -241,11 +241,11 @@ Sera équivalente à&nbsp;:
 </script>
 ```
 
-La règle `/app/helper.js` a été ignorée et n'a pas été intégrée à la carte.
+La règle `/app/helper.js` a été ignorée et n'a pas été intégrée au tableau associatif.
 
-De même, les spécificateurs de module d'une carte enregistrée qui étaient déjà associés à des URL dans la carte globale sont ignorés&nbsp;; leur correspondance précédente prévaut.
+De même, les spécificateurs de module d'un tableau associatif enregistré qui étaient déjà associés à des URL dans le tableau associatif global sont ignorés&nbsp;; leur correspondance précédente prévaut.
 
-Par exemple, les deux cartes d'import suivantes&nbsp;:
+Par exemple, les deux tableaux associatifs d'import suivants&nbsp;:
 
 ```html
 <script type="importmap">
@@ -268,7 +268,7 @@ Par exemple, les deux cartes d'import suivantes&nbsp;:
 </script>
 ```
 
-Sont équivalentes à la carte d'import unique suivante&nbsp;:
+Sont équivalentes au tableau associatif d'import unique suivant&nbsp;:
 
 ```html
 <script type="importmap">
@@ -281,25 +281,25 @@ Sont équivalentes à la carte d'import unique suivante&nbsp;:
 </script>
 ```
 
-La règle `/app/helper/` a été ignorée dans la seconde carte.
+La règle `/app/helper/` a été ignorée dans le second tableau associatif.
 
 > [!NOTE]
 > Dans les navigateurs qui ne prennent pas en charge cette fonctionnalité (voir les [données de compatibilité](#compatibilité_des_navigateurs)), un [polyfill](https://github.com/guybedford/es-module-shims) peut être utilisé pour éviter les problèmes liés à la résolution des modules.
 
-## Représentation JSON des cartes d'import
+## Représentation JSON des tableaux associatifs d'import
 
-Ce qui suit est une définition «&nbsp;formelle&nbsp;» de la représentation JSON pour les cartes d'import.
+Ce qui suit est une définition «&nbsp;formelle&nbsp;» de la représentation JSON pour les tableaux associatifs d'import.
 
-La carte d'import doit être un objet JSON valide qui définit au plus deux clés optionnelles&nbsp;: `imports` et `scopes`. Les valeurs de ces clés doivent être un objet, potentiellement vide.
+Le tableau associatif d'import doit être un objet JSON valide qui définit au plus deux clés optionnelles&nbsp;: `imports` et `scopes`. Les valeurs de ces clés doivent être un objet, potentiellement vide.
 
 - `imports` {{Optional_Inline}}
-  - : La valeur doit être [une carte de spécificateur de module](#carte_des_métadonnées_dintégrité), qui fournit les correspondances entre les spécificateurs utilisés dans les instructions `import` ou les opérateurs `import()`, et le texte qui les remplacera lors de leur résolution.
+  - : La valeur doit être [un tableau associatif de spécificateur de module](#tableau_associatif_des_métadonnées_dintégrité), qui fournit les correspondances entre les spécificateurs utilisés dans les instructions `import` ou les opérateurs `import()`, et le texte qui les remplacera lors de leur résolution.
 
-    Il s'agit de la carte de correspondance qui est utilisée par défaut si les spécificateurs de module ne sont pas présents (via leur nom ou via leur chemin) dans les portées décrites via l'attribut `scopes`.
+    Il s'agit du tableau associatif de correspondance qui est utilisé par défaut si les spécificateurs de module ne sont pas présents (via leur nom ou via leur chemin) dans les portées décrites via l'attribut `scopes`.
     - `<module specifier map>`
-      - : Une carte de spécificateur de module est un objet JSON valide où les _clés_ correspondent au texte qui peut être présent dans le spécificateur de module lors de l'import et où les _valeurs_ correspondantes sont les URL ou les chemins qui remplaceront ce texte lorsque le spécificateur de module sera résolu en une adresse.
+      - : Un tableau associatif de spécificateur de module est un objet JSON valide où les _clés_ correspondent au texte qui peut être présent dans le spécificateur de module lors de l'import et où les _valeurs_ correspondantes sont les URL ou les chemins qui remplaceront ce texte lorsque le spécificateur de module sera résolu en une adresse.
 
-        L'objet JSON représentant une carte de spécificateur de module doit respecter les règles suivantes&nbsp;:
+        L'objet JSON représentant un tableau associatif de spécificateur de module doit respecter les règles suivantes&nbsp;:
         - Aucune des clés ne doit être vide.
         - Toutes les valeurs doivent être des chaînes de caractères, qui définissent soit une URL absolue valide, soit une chaîne d'URL valide commençant par `/`, `./`, ou `../`.
         - Si la clé finit par `/`, la valeur correspondante doit également finir par `/`. On pourra utiliser une clé se terminant par `/` comme préfixe lors de la correspondance entre les adresses de modules.
@@ -313,15 +313,15 @@ La carte d'import doit être un objet JSON valide qui définit au plus deux clé
     sauf si elles possèdent déjà des métadonnées d'intégrité.
 
 - `scopes` {{Optional_Inline}}
-  - : Les portées définissent des [cartes de spécificateur de module](#carte_des_métadonnées_dintégrité) pour des chemins spécifiques, permettant de choisir la correspondance à effectuer en fonction du chemin du code qui importe le module.
+  - : Les portées définissent des [tableaux associatifs de spécificateur de module](#tableau_associatif_des_métadonnées_dintégrité) pour des chemins spécifiques, permettant de choisir la correspondance à effectuer en fonction du chemin du code qui importe le module.
 
-    L'objet `scopes` est un objet JSON valide où chaque propriété est une clé de portée (représentée par une URL) avec une valeur correspondante qui est une carte de spécificateur de module.
+    L'objet `scopes` est un objet JSON valide où chaque propriété est une clé de portée (représentée par une URL) avec une valeur correspondante qui est un tableau associatif de spécificateur de module.
 
-    Si l'URL d'un script important un module correspond au chemin d'une clé d'une portée, c'est la carte de spécificateur de module correspondante qui est utilisée en première pour vérifier les correspondances de spécificateur.
+    Si l'URL d'un script important un module correspond au chemin d'une clé d'une portée, c'est le tableau associatif de spécificateur de module correspondant qui est utilisé en première pour vérifier les correspondances de spécificateur.
     S'il existe plusieurs clés de portées qui correspondent, c'est la valeur associée avec le chemin de portée le plus spécifique qui est utilisée en première pour vérifier les correspondances de spécificateur.
-    La carte de spécificateur de module décrite dans `imports` est utilisée en dernier recours s'il n'y a aucune correspondance pour le spécificateur de module dans les cartes des portées correspondantes.
+    Le tableau associatif de spécificateur de module décrit dans `imports` est utilisé en dernier recours s'il n'y a aucune correspondance pour le spécificateur de module dans les tableaux associatifs des portées correspondantes.
 
-    On notera que la portée ne modifie pas la façon dont une adresse est résolue. Les adresses relatives sont toujours résolues par rapport à l'URL de base de la carte d'import.
+    On notera que la portée ne modifie pas la façon dont une adresse est résolue. Les adresses relatives sont toujours résolues par rapport à l'URL de base du tableau associatif d'import.
 
 ## Spécifications
 
@@ -333,7 +333,7 @@ La carte d'import doit être un objet JSON valide qui définit au plus deux clé
 
 ## Voir aussi
 
-- [Guide des modules JavaScript > Importer des modules avec des cartes d'import](/fr/docs/Web/JavaScript/Guide/Modules#importer_des_modules_avec_des_cartes_d_import)
+- [Guide des modules JavaScript > Importer des modules avec des tableaux associatifs d'import](/fr/docs/Web/JavaScript/Guide/Modules#importer_des_modules_avec_des_tableaux_associatifs_dimport)
 - [L'attribut `type` des éléments HTML `<script>`](/fr/docs/Web/HTML/Reference/Elements/script#type)
 - [L'instruction `import`](/fr/docs/Web/JavaScript/Reference/Statements/import)
 - [L'opérateur `import()`](/fr/docs/Web/JavaScript/Reference/Operators/import)


### PR DESCRIPTION
### Description

<img width="1200" height="250" alt="mdn_linked_banner" src="https://github.com/user-attachments/assets/ccc0d0f9-d9b8-42fa-ae83-12dfd4ce9f68" />

- **added:** firefox 150 first iteration (last sync today@23:30)
- **updated:** firefox 149 is synced to prepare firefox 150
- **fixed:** wording of "map(s)" now use "tableau(x) associatif(s)" instead of "carte(s)" that a more accurate translation

### Motivation

_none_

### Additional details

_none_

### Related issues and pull requests

_none_
