### PR TITLE
chore(sync-fr): html attributes pages use backticks on title

### DIFF
--- a/files/fr/web/html/reference/attributes/accept/index.md
+++ b/files/fr/web/html/reference/attributes/accept/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : accept"
+title: "Attribut HTML : `accept`"
 short-title: accept
 slug: Web/HTML/Reference/Attributes/accept
 l10n:
-  sourceCommit: 19a086b6076db59fcc42ee76a98ba183adb29f8c
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`accept`** prend comme valeur une liste, séparée par des virgules, d'un ou plusieurs types de fichiers ou de [spécificateurs de type de fichier unique](#spécification_de_type_de_fichier_unique), décrivant les types de fichiers autorisés.

--- a/files/fr/web/html/reference/attributes/autocomplete/index.md
+++ b/files/fr/web/html/reference/attributes/autocomplete/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : autocomplete"
+title: "Attribut HTML : `autocomplete`"
 short-title: autocomplete
 slug: Web/HTML/Reference/Attributes/autocomplete
 l10n:
-  sourceCommit: 2456adac96280a9c78696fa4a0a87810671c3a8d
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut `autocomplete` permet aux développeur·euse·s web de définir si, et dans quelle mesure, {{Glossary("user agent", "l'agent utilisateur")}} est autorisé à fournir une aide automatisée pour remplir les champs d'un formulaire, ainsi que d'indiquer au navigateur le type d'information attendu dans le champ.

--- a/files/fr/web/html/reference/attributes/capture/index.md
+++ b/files/fr/web/html/reference/attributes/capture/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : capture"
+title: "Attribut HTML : `capture`"
 short-title: capture
 slug: Web/HTML/Reference/Attributes/capture
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`capture`** indique, de façon optionnelle, qu'un nouveau fichier doit être capturé et quel appareil doit être utilisé pour capturer ce nouveau média, dont le type est défini par l'attribut [`accept`](/fr/docs/Web/HTML/Reference/Attributes/accept).

--- a/files/fr/web/html/reference/attributes/content/index.md
+++ b/files/fr/web/html/reference/attributes/content/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : content"
+title: "Attribut HTML : `content`"
 short-title: content
 slug: Web/HTML/Reference/Attributes/content
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`content`** définit la valeur d'un nom de métadonnée — défini par l'attribut [`name`](/fr/docs/Web/HTML/Reference/Elements/meta/name) — de l'élément HTML `<meta>`.

--- a/files/fr/web/html/reference/attributes/crossorigin/index.md
+++ b/files/fr/web/html/reference/attributes/crossorigin/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : crossorigin"
+title: "Attribut HTML : `crossorigin`"
 short-title: crossorigin
 slug: Web/HTML/Reference/Attributes/crossorigin
 l10n:
-  sourceCommit: 0c81cbce5f95a0be935724bcd936f5592774eb3a
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`crossorigin`** est valide sur les éléments HTML {{HTMLElement("audio")}}, {{HTMLElement("img")}}, {{HTMLElement("link")}}, {{HTMLElement("script")}} et {{HTMLElement("video")}}. Il permet de gérer le [CORS](/fr/docs/Web/HTTP/Guides/CORS), c'est-à-dire la façon dont l'élément traite les requêtes inter-origines, et donc de configurer les requêtes CORS pour les données récupérées par l'élément. Selon l'élément, l'attribut peut être un attribut de configuration CORS.

--- a/files/fr/web/html/reference/attributes/dirname/index.md
+++ b/files/fr/web/html/reference/attributes/dirname/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : dirname"
+title: "Attribut HTML : `dirname`"
 short-title: dirname
 slug: Web/HTML/Reference/Attributes/dirname
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`dirname`** peut être utilisé sur l'élément HTML {{HTMLElement("textarea")}} et sur plusieurs types d'éléments HTML {{HTMLElement("input")}}. Il permet d'indiquer la direction du texte saisi dans l'élément lors de la soumission du formulaire.

--- a/files/fr/web/html/reference/attributes/disabled/index.md
+++ b/files/fr/web/html/reference/attributes/disabled/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : disabled"
+title: "Attribut HTML : `disabled`"
 short-title: disabled
 slug: Web/HTML/Reference/Attributes/disabled
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut booléen **`disabled`**, lorsqu'il est présent, rend l'élément non modifiable, non sélectionnable, ou même non soumis avec le formulaire. L'utilisateur·rice ne peut ni modifier ni sélectionner le contrôle, ni les descendants du contrôle de formulaire. Si l'attribut `disabled` est défini sur un contrôle de formulaire, l'élément et ses descendants de contrôle de formulaire ne participent pas à la validation des contraintes. Souvent, les navigateurs grisent ces contrôles et ils ne reçoivent aucun événement de navigation, comme les clics de souris ou les événements liés à la sélection.

--- a/files/fr/web/html/reference/attributes/elementtiming/index.md
+++ b/files/fr/web/html/reference/attributes/elementtiming/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : elementtiming"
+title: "Attribut HTML : `elementtiming`"
 short-title: elementtiming
 slug: Web/HTML/Reference/Attributes/elementtiming
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`elementtiming`** sert à indiquer qu'un élément doit être suivi par des objets {{domxref("PerformanceObserver")}} utilisant le type `"element"`. Pour plus de détails, voir l'interface {{domxref("PerformanceElementTiming")}}.

--- a/files/fr/web/html/reference/attributes/fetchpriority/index.md
+++ b/files/fr/web/html/reference/attributes/fetchpriority/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : fetchpriority"
+title: "Attribut HTML : `fetchpriority`"
 short-title: fetchpriority
 slug: Web/HTML/Reference/Attributes/fetchpriority
 l10n:
-  sourceCommit: 96a73163513476fe49bfba695acedb7622135354
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`fetchpriority`** permet au développeur·euse d'indiquer que le chargement anticipé d'une ressource (par exemple une image) a plus ou moins d'impact sur l'expérience utilisateur que ce que le navigateur peut raisonnablement déduire lorsqu'il assigne une priorité interne.

--- a/files/fr/web/html/reference/attributes/for/index.md
+++ b/files/fr/web/html/reference/attributes/for/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : for"
+title: "Attribut HTML : `for`"
 short-title: for
 slug: Web/HTML/Reference/Attributes/for
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`for`** est un attribut autorisé pour les éléments HTML {{HTMLElement("label")}} et {{HTMLElement("output")}}. Lorsqu'il est utilisé sur un élément `<label>`, il indique l'élément de formulaire que ce label décrit. Lorsqu'il est utilisé sur un élément `<output>`, il permet une relation explicite entre les éléments, qui représentent les valeurs, qui sont utilisées dans le résultat représenté par `<output>`.

--- a/files/fr/web/html/reference/attributes/form/index.md
+++ b/files/fr/web/html/reference/attributes/form/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : form"
+title: "Attribut HTML : `form`"
 short-title: form
 slug: Web/HTML/Reference/Attributes/form
 l10n:
-  sourceCommit: 6afda999d054c2ba12d13d129b13eb35952b4fbe
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`form`** associe un élément lié à un formulaire à un élément HTML {{HTMLElement("form")}} du même document. Cet attribut s'applique aux éléments HTML {{HTMLElement("button")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("input")}}, {{HTMLElement("object")}}, {{HTMLElement("output")}}, {{HTMLElement("select")}} et {{HTMLElement("textarea")}}.

--- a/files/fr/web/html/reference/attributes/max/index.md
+++ b/files/fr/web/html/reference/attributes/max/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : max"
+title: "Attribut HTML : `max`"
 short-title: max
 slug: Web/HTML/Reference/Attributes/max
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`max`** définit la valeur maximale acceptable et valide pour le champ de saisie contenant l'attribut. Si la [`valeur`](/fr/docs/Web/HTML/Reference/Elements/input#value) de l'élément est supérieure à cette valeur, l'élément échoue à [la validation des contraintes](/fr/docs/Web/HTML/Guides/Constraint_validation). Cette valeur doit être supérieure ou égale à la valeur de l'attribut [`min`](min). Si l'attribut `max` est présent mais n'est pas défini ou est invalide, aucune valeur `max` n'est appliquée. Si l'attribut `max` est valide et qu'une valeur non vide est supérieure au maximum autorisé par l'attribut `max`, la validation des contraintes empêchera la soumission du formulaire.

--- a/files/fr/web/html/reference/attributes/maxlength/index.md
+++ b/files/fr/web/html/reference/attributes/maxlength/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : maxlength"
+title: "Attribut HTML : `maxlength`"
 short-title: maxlength
 slug: Web/HTML/Reference/Attributes/maxlength
 l10n:
-  sourceCommit: 0c81cbce5f95a0be935724bcd936f5592774eb3a
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`maxlength`** définit la [longueur maximale de chaîne de caractères](/fr/docs/Web/JavaScript/Reference/Global_Objects/String/length) que l'utilisateur·rice peut saisir dans un élément HTML {{HTMLElement("input")}} ou un élément {{HTMLElement("textarea")}}. L'attribut doit avoir une valeur entière supérieure ou égale à 0.

--- a/files/fr/web/html/reference/attributes/min/index.md
+++ b/files/fr/web/html/reference/attributes/min/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : min"
+title: "Attribut HTML : `min`"
 short-title: min
 slug: Web/HTML/Reference/Attributes/min
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`min`** définit la valeur minimale acceptable et valide pour le champ de saisie qui contient cet attribut. Si la [valeur](/fr/docs/Web/HTML/Reference/Elements/input#value) de l'élément est inférieure à cette valeur, le champ échoue lors de la [validation](/fr/docs/Learn_web_development/Extensions/Forms/Form_validation). Cette valeur doit être inférieure ou égale à la valeur de l'attribut `max`.

--- a/files/fr/web/html/reference/attributes/minlength/index.md
+++ b/files/fr/web/html/reference/attributes/minlength/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : minlength"
+title: "Attribut HTML : `minlength`"
 short-title: minlength
 slug: Web/HTML/Reference/Attributes/minlength
 l10n:
-  sourceCommit: 635820782735cd00f71ce3929ff9377b091f8995
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`minlength`** définit la [longueur minimale de chaîne de caractères](/fr/docs/Web/JavaScript/Reference/Global_Objects/String/length) que l'utilisateur·ice peut saisir dans un élément HTML {{HTMLElement("input")}} ou un élément {{HTMLElement("textarea")}}. L'attribut doit avoir une valeur entière supérieure ou égale à 0.

--- a/files/fr/web/html/reference/attributes/multiple/index.md
+++ b/files/fr/web/html/reference/attributes/multiple/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : multiple"
+title: "Attribut HTML : `multiple`"
 short-title: multiple
 slug: Web/HTML/Reference/Attributes/multiple
 l10n:
-  sourceCommit: 7fdf1972da2094ecf91427a578685670c2fbdb17
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut booléen **`multiple`**, s'il est défini, signifie que le contrôle de formulaire accepte une ou plusieurs valeurs. Valable pour les types de saisie [`email`](/fr/docs/Web/HTML/Reference/Elements/input/email) et [`file`](/fr/docs/Web/HTML/Reference/Elements/input/file) et l'élément {{HTMLElement("select")}}, la manière dont l'utilisateur·ice opte pour plusieurs valeurs dépend du contrôle de formulaire.

--- a/files/fr/web/html/reference/attributes/pattern/index.md
+++ b/files/fr/web/html/reference/attributes/pattern/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : pattern"
+title: "Attribut HTML : `pattern`"
 short-title: pattern
 slug: Web/HTML/Reference/Attributes/pattern
 l10n:
-  sourceCommit: 06e6e54baef7032c4e81ca93291fde0a0585de8b
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`pattern`** indique une [expression rationnelle](/fr/docs/Web/JavaScript/Guide/Regular_expressions) que doit respecter la valeur du contrôle du formulaire. Si une valeur non nulle (qui n'est pas `null`) ne respecte pas les contraintes portées par `pattern`, la propriété {{DOMxRef("ValidityState.patternMismatch", "patternMismatch")}} en lecture seule, rattachée à l'objet {{DOMxRef("ValidityState")}}, vaudra `true`.

--- a/files/fr/web/html/reference/attributes/placeholder/index.md
+++ b/files/fr/web/html/reference/attributes/placeholder/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : placeholder"
+title: "Attribut HTML : `placeholder`"
 short-title: placeholder
 slug: Web/HTML/Reference/Attributes/placeholder
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`placeholder`** définit le texte affiché dans un contrôle de formulaire lorsque celui-ci n'a pas de valeur. Le texte d'exemple doit fournir un indice bref à l'utilisateur·ice sur le type de donnée attendu dans le contrôle.

--- a/files/fr/web/html/reference/attributes/readonly/index.md
+++ b/files/fr/web/html/reference/attributes/readonly/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : readonly"
+title: "Attribut HTML : `readonly`"
 short-title: readonly
 slug: Web/HTML/Reference/Attributes/readonly
 l10n:
-  sourceCommit: aff319cd81d10cfda31b13adb3263deafb284b20
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut booléen **`readonly`**, lorsqu'il est présent, rend l'élément non mutable, ce qui signifie que l'utilisateur·ice ne peut pas modifier le contrôle.

--- a/files/fr/web/html/reference/attributes/rel/index.md
+++ b/files/fr/web/html/reference/attributes/rel/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : rel"
+title: "Attribut HTML : `rel`"
 short-title: rel
 slug: Web/HTML/Reference/Attributes/rel
 l10n:
-  sourceCommit: a4fcf79b60471db6f148fa4ba36f2cdeafbbeb70
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`rel`** définit la relation entre une ressource liée et le document courant. Il est valide sur {{HTMLElement("link")}}, {{HTMLElement("a")}}, {{HTMLElement("area")}} et {{HTMLElement("form")}}. Les valeurs acceptées dépendent de l'élément sur lequel l'attribut est utilisé.

--- a/files/fr/web/html/reference/attributes/required/index.md
+++ b/files/fr/web/html/reference/attributes/required/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : required"
+title: "Attribut HTML : `required`"
 short-title: required
 slug: Web/HTML/Reference/Attributes/required
 l10n:
-  sourceCommit: 0c81cbce5f95a0be935724bcd936f5592774eb3a
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut {{Glossary("Boolean/HTML", "booléen")}} **`required`**, s'il est présent, indique que l'utilisateur·ice doit définir une valeur avant que le formulaire propriétaire puisse être envoyé.

--- a/files/fr/web/html/reference/attributes/size/index.md
+++ b/files/fr/web/html/reference/attributes/size/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : size"
+title: "Attribut HTML : `size`"
 short-title: size
 slug: Web/HTML/Reference/Attributes/size
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`size`** définit la largeur de l'élément HTML {{HTMLElement("input")}} et la hauteur de l'élément {{HTMLElement("select")}}. Pour un élément `input`, il définit le nombre de caractères que l'agent utilisateur permet à l'utilisateur·ice de voir lors de la modification de la valeur. Pour un élément `select`, il définit le nombre d'options qui doivent être affichées à l'utilisateur·ice. Il doit s'agir d'un entier non négatif valide supérieur à zéro.

--- a/files/fr/web/html/reference/attributes/step/index.md
+++ b/files/fr/web/html/reference/attributes/step/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Attribut HTML : step"
+title: "Attribut HTML : `step`"
 short-title: step
 slug: Web/HTML/Reference/Attributes/step
 l10n:
-  sourceCommit: 13856107d2cab5bb9e40de608ee38a5770ef7c4d
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`step`** est un nombre qui définit la granularité à laquelle la valeur doit adhérer ou le mot-clé `any`. Il est valide pour les types d'entrée numériques, y compris les types `{{HTMLElement("input/date", "date")}}`, `{{HTMLElement("input/month", "month")}}`, `{{HTMLElement("input/week", "week")}}`, `{{HTMLElement("input/time", "time")}}`, `{{HTMLElement("input/datetime-local", "datetime-local")}}`, `{{HTMLElement("input/number", "number")}}` et `{{HTMLElement("input/range", "range")}}`.

--- a/files/fr/web/html/reference/elements/meta/http-equiv/index.md
+++ b/files/fr/web/html/reference/elements/meta/http-equiv/index.md
@@ -1,9 +1,9 @@
 ---
-title: Attribut <meta> http-equiv
-short-title: <meta> http-equiv
+title: "Attribut HTML : `<meta http-equiv>`"
+short-title: <meta http-equiv>
 slug: Web/HTML/Reference/Elements/meta/http-equiv
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`http-equiv`** de l'élément {{HTMLElement("meta")}} permet de fournir des instructions de traitement au navigateur, comme si la réponse ayant retourné le document incluait certains en-têtes HTTP.

--- a/files/fr/web/html/reference/elements/meta/name/index.md
+++ b/files/fr/web/html/reference/elements/meta/name/index.md
@@ -1,10 +1,9 @@
 ---
-title: Attribut <meta> name
-short-title: <meta> name
+title: "Attribut HTML : `<meta name>`"
+short-title: <meta name>
 slug: Web/HTML/Reference/Elements/meta/name
-original_slug: Web/HTML/Element/meta/name
 l10n:
-  sourceCommit: c7a8b2584452bcd5d2c135b637f4ec659ff74b99
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`name`** de l'élément {{HTMLElement("meta")}} fournit des métadonnées sous forme de paires nom-valeur.

--- a/files/fr/web/html/reference/elements/script/type/index.md
+++ b/files/fr/web/html/reference/elements/script/type/index.md
@@ -1,9 +1,9 @@
 ---
-title: Attribut <script> type
+title: "Attribut HTML : `<script type>`"
+short-title: <script type>
 slug: Web/HTML/Reference/Elements/script/type
-original_slug: Web/HTML/Element/script/type
 l10n:
-  sourceCommit: 11e09e7c584658fbfbecd2f00ae66e546cd54cc0
+  sourceCommit: b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
 ---
 
 L'attribut **`type`** de l'élément {{HTMLElement("script")}} indique le _type_ de script représenté par l'élément&nbsp;: un script classique, un module JavaScript, une carte (<i lang="en">map</i>) d'import, ou un bloc de données.


### PR DESCRIPTION
### Description

The front-matter key `title` now accept backticks. Content has updated titles to display code in title using these backticks.

### Motivation

Keep translated-content sync for updated pages

### Additional details

_none_

### Related issues and pull requests

Sync from https://github.com/mdn/content/tree/b50ed7ac1c2ca21b4b5cfb594474a17da3f2e6c2
