### PR TITLE
chore(sync-fr): css at-rules pages use backticks on title

### DIFF
--- a/files/fr/web/css/reference/at-rules/@charset/index.md
+++ b/files/fr/web/css/reference/at-rules/@charset/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@charset"
+title: "Règle CSS `@charset`"
+short-title: "@charset"
 slug: Web/CSS/Reference/At-rules/@charset
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@charset`** définit l'encodage des caractères utilisé dans la feuille de style. Cette syntaxe est utile lorsque vous utilisez des caractères non-{{Glossary("ASCII")}} dans certaines propriétés CSS, comme {{CSSxRef("content")}}. Bien que le premier caractère de `@charset` soit le symbole `@`, il ne s'agit pas d'une [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules). C'est une séquence d'octets spécifique qui ne peut être placée qu'au tout début d'une feuille de style. Aucun autre caractère, à l'exception du marqueur d'ordre des octets Unicode, n'est autorisé avant. Elle ne suit pas non plus les règles habituelles de syntaxe CSS, comme l'utilisation de guillemets ou d'espaces.

--- a/files/fr/web/css/reference/at-rules/@charset/index.md
+++ b/files/fr/web/css/reference/at-rules/@charset/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@charset`"
+title: Règle CSS `@charset`
 short-title: "@charset"
 slug: Web/CSS/Reference/At-rules/@charset
 l10n:

--- a/files/fr/web/css/reference/at-rules/@color-profile/index.md
+++ b/files/fr/web/css/reference/at-rules/@color-profile/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@color-profile`"
+title: Règle CSS `@color-profile`
 short-title: "@color-profile"
 slug: Web/CSS/Reference/At-rules/@color-profile
 l10n:

--- a/files/fr/web/css/reference/at-rules/@color-profile/index.md
+++ b/files/fr/web/css/reference/at-rules/@color-profile/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@color-profile"
+title: "Règle CSS `@color-profile`"
+short-title: "@color-profile"
 slug: Web/CSS/Reference/At-rules/@color-profile
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@color-profile`** définit et nomme un profil de couleur qui peut être utilisé ensuite avec la fonction {{CSSxRef("color_value/color", "color()")}} afin d'indiquer une couleur.

--- a/files/fr/web/css/reference/at-rules/@container/index.md
+++ b/files/fr/web/css/reference/at-rules/@container/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@container`"
+title: Règle CSS `@container`
 short-title: "@container"
 slug: Web/CSS/Reference/At-rules/@container
 l10n:

--- a/files/fr/web/css/reference/at-rules/@container/index.md
+++ b/files/fr/web/css/reference/at-rules/@container/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@container"
+title: "Règle CSS `@container`"
+short-title: "@container"
 slug: Web/CSS/Reference/At-rules/@container
 l10n:
-  sourceCommit: 51872f3d8311c3c071cbfea613da40036911e4d7
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@container`** est une règle conditionnelle de groupe qui applique des styles à un [contexte de conteneur](/fr/docs/Web/CSS/Guides/Containment/Container_queries#nommer_les_contextes_de_conteneur).
@@ -76,6 +77,23 @@ Si aucun `<container-query>` n'est défini, les conteneurs nommés sont sélecti
   h2 {
     font-size: 1.5em;
   }
+}
+
+/* Requêtes de style() booléennes */
+@container style(--theme: one) or style(--theme: two) {
+  /* styles de conteneur correspondants */
+}
+@container style((--theme: one) or (--theme: two)) {
+  /* styles de conteneur correspondants */
+}
+@container style(--theme: one) and style(--theme: two) {
+  /* styles de conteneur correspondants */
+}
+@container style((--theme: one) and (--theme: two)) {
+  /* styles de conteneur correspondants */
+}
+@container not style(--theme: one) {
+  /* styles de conteneur correspondants */
 }
 ```
 

--- a/files/fr/web/css/reference/at-rules/@counter-style/index.md
+++ b/files/fr/web/css/reference/at-rules/@counter-style/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@counter-style`"
+title: Règle CSS `@counter-style`
 short-title: "@counter-style"
 slug: Web/CSS/Reference/At-rules/@counter-style
 l10n:

--- a/files/fr/web/css/reference/at-rules/@counter-style/index.md
+++ b/files/fr/web/css/reference/at-rules/@counter-style/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@counter-style"
+title: "Règle CSS `@counter-style`"
+short-title: "@counter-style"
 slug: Web/CSS/Reference/At-rules/@counter-style
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@counter-style`** vous permet d'étendre les styles de liste prédéfinis et de définir vos propres styles de compteurs qui ne font pas partie de l'ensemble des styles prédéfinis. La règle `@counter-style` contient des [descripteurs](#descripteurs) définissant comment la valeur du compteur est convertie en une représentation sous forme de chaîne de caractères.

--- a/files/fr/web/css/reference/at-rules/@custom-media/index.md
+++ b/files/fr/web/css/reference/at-rules/@custom-media/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@custom-media"
+title: "Règle CSS `@custom-media`"
+short-title: "@custom-media"
 slug: Web/CSS/Reference/At-rules/@custom-media
 l10n:
-  sourceCommit: ad20400adefa435897ee28e55cb8dfa7419e29f8
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/at-rules/@custom-media/index.md
+++ b/files/fr/web/css/reference/at-rules/@custom-media/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@custom-media`"
+title: Règle CSS `@custom-media`
 short-title: "@custom-media"
 slug: Web/CSS/Reference/At-rules/@custom-media
 l10n:

--- a/files/fr/web/css/reference/at-rules/@document/index.md
+++ b/files/fr/web/css/reference/at-rules/@document/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@document"
+title: "Règle CSS `@document`"
+short-title: "@document"
 slug: Web/CSS/Reference/At-rules/@document
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 {{Deprecated_Header}}{{Non-standard_Header}}

--- a/files/fr/web/css/reference/at-rules/@document/index.md
+++ b/files/fr/web/css/reference/at-rules/@document/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@document`"
+title: Règle CSS `@document`
 short-title: "@document"
 slug: Web/CSS/Reference/At-rules/@document
 l10n:

--- a/files/fr/web/css/reference/at-rules/@font-face/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@font-face`"
+title: Règle CSS `@font-face`
 short-title: "@font-face"
 slug: Web/CSS/Reference/At-rules/@font-face
 l10n:

--- a/files/fr/web/css/reference/at-rules/@font-face/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@font-face"
+title: "Règle CSS `@font-face`"
+short-title: "@font-face"
 slug: Web/CSS/Reference/At-rules/@font-face
 l10n:
-  sourceCommit: 7d6315943bf1032e19c65bca591e28d2117e9bec
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@font-face`** permet de définir une police d'écriture particulière à utiliser pour afficher le texte de pages web. Cette police peut être chargée depuis un serveur distant ou depuis l'ordinateur de l'utilisatrice ou l'utilisateur.

--- a/files/fr/web/css/reference/at-rules/@font-feature-values/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-feature-values/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@font-feature-values"
+title: "Règle CSS `@font-feature-values`"
+short-title: "@font-feature-values"
 slug: Web/CSS/Reference/At-rules/@font-feature-values
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@font-feature-values`** permet d'utiliser un nom commun dans la propriété {{CSSxRef("font-variant-alternates")}} pour des fonctionnalités activées différemment en OpenType. Cela peut simplifier votre CSS lorsque vous utilisez plusieurs polices.

--- a/files/fr/web/css/reference/at-rules/@font-feature-values/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-feature-values/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@font-feature-values`"
+title: Règle CSS `@font-feature-values`
 short-title: "@font-feature-values"
 slug: Web/CSS/Reference/At-rules/@font-feature-values
 l10n:

--- a/files/fr/web/css/reference/at-rules/@font-palette-values/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-palette-values/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@font-palette-values`"
+title: Règle CSS `@font-palette-values`
 short-title: "@font-palette-values"
 slug: Web/CSS/Reference/At-rules/@font-palette-values
 l10n:

--- a/files/fr/web/css/reference/at-rules/@font-palette-values/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-palette-values/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@font-palette-values"
+title: "Règle CSS `@font-palette-values`"
+short-title: "@font-palette-values"
 slug: Web/CSS/Reference/At-rules/@font-palette-values
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@font-palette-values`** permet de personnaliser les valeurs par défaut de la [palette de police](/fr/docs/Web/CSS/Reference/Properties/font-palette) créée par le·la créateur·ice de la police.

--- a/files/fr/web/css/reference/at-rules/@function/index.md
+++ b/files/fr/web/css/reference/at-rules/@function/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@function`"
+title: Règle CSS `@function`
 short-title: "@function"
 slug: Web/CSS/Reference/At-rules/@function
 l10n:

--- a/files/fr/web/css/reference/at-rules/@function/index.md
+++ b/files/fr/web/css/reference/at-rules/@function/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@function"
+title: "Règle CSS `@function`"
+short-title: "@function"
 slug: Web/CSS/Reference/At-rules/@function
 l10n:
-  sourceCommit: 6ad108adad746bd7ed79b5b32d8d3e05e5ec685a
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/at-rules/@import/index.md
+++ b/files/fr/web/css/reference/at-rules/@import/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@import"
+title: "Règle CSS `@import`"
+short-title: "@import"
 slug: Web/CSS/Reference/At-rules/@import
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@import`** est utilisée pour importer des règles de style depuis d'autres feuilles de style valides.

--- a/files/fr/web/css/reference/at-rules/@import/index.md
+++ b/files/fr/web/css/reference/at-rules/@import/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@import`"
+title: Règle CSS `@import`
 short-title: "@import"
 slug: Web/CSS/Reference/At-rules/@import
 l10n:

--- a/files/fr/web/css/reference/at-rules/@keyframes/index.md
+++ b/files/fr/web/css/reference/at-rules/@keyframes/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@keyframes`"
+title: Règle CSS `@keyframes`
 short-title: "@keyframes"
 slug: Web/CSS/Reference/At-rules/@keyframes
 l10n:

--- a/files/fr/web/css/reference/at-rules/@keyframes/index.md
+++ b/files/fr/web/css/reference/at-rules/@keyframes/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@keyframes"
+title: "Règle CSS `@keyframes`"
+short-title: "@keyframes"
 slug: Web/CSS/Reference/At-rules/@keyframes
 l10n:
-  sourceCommit: f94b7a0b06a0e32df81ec8197720d306fe50a4a0
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@keyframes`** permet aux auteurs de définir les étapes qui composent la séquence d'une animation CSS. Cela permet de contrôler une animation plus finement que ce qu'on pourrait obtenir avec [les transitions](/fr/docs/Web/CSS/Guides/Transitions).

--- a/files/fr/web/css/reference/at-rules/@layer/index.md
+++ b/files/fr/web/css/reference/at-rules/@layer/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@layer"
+title: "Règle CSS `@layer`"
+short-title: "@layer"
 slug: Web/CSS/Reference/At-rules/@layer
 l10n:
-  sourceCommit: 5005d73d35175d72a470c2285f1c3953a54e3688
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@layer`** est utilisée pour déclarer une couche de cascade et peut également être utilisée afin de définir l'ordre de précédence lorsqu'il y a plusieurs couches de cascade.

--- a/files/fr/web/css/reference/at-rules/@layer/index.md
+++ b/files/fr/web/css/reference/at-rules/@layer/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@layer`"
+title: Règle CSS `@layer`
 short-title: "@layer"
 slug: Web/CSS/Reference/At-rules/@layer
 l10n:

--- a/files/fr/web/css/reference/at-rules/@media/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@media`"
+title: Règle CSS `@media`
 short-title: "@media"
 slug: Web/CSS/Reference/At-rules/@media
 l10n:

--- a/files/fr/web/css/reference/at-rules/@media/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@media"
+title: "Règle CSS `@media`"
+short-title: "@media"
 slug: Web/CSS/Reference/At-rules/@media
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@media`** permet d'appliquer une partie d'une feuille de styles en fonction du résultat d'une ou plusieurs [requêtes média (<i lang="en">media queries</i>)](/fr/docs/Web/CSS/Guides/Media_queries). Grâce à cette règle, on peut indiquer une requête média et un ensemble de règles CSS qui s'appliquent uniquement si la requête média est vérifiée pour l'appareil, le contexte avec lequel le contenu est consulté.

--- a/files/fr/web/css/reference/at-rules/@namespace/index.md
+++ b/files/fr/web/css/reference/at-rules/@namespace/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@namespace"
+title: "Règle CSS `@namespace`"
+short-title: "@namespace"
 slug: Web/CSS/Reference/At-rules/@namespace
 l10n:
-  sourceCommit: 1dcf976e9b654679c762568812562b1a2361c755
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@namespace`** définie [les espaces de noms XML](/fr/docs/Glossary/Namespace) utilisés dans une feuille de style CSS. Les espaces de noms définis sont alors utilisés pour restreindre les sélecteurs [universels](/fr/docs/Web/CSS/Reference/Selectors/Universal_selectors), [de type](/fr/docs/Web/CSS/Reference/Selectors/Type_selectors), et [d'attribut](/fr/docs/Web/CSS/Reference/Selectors/Attribute_selectors) afin que ceux-ci ne sélectionnent que les éléments contenus dans cet espace de nom. La règle `@namespace` est généralement utilisée lorsqu'on manipule des documents entremêlant différents espaces de noms (par exemple, un document HTML5 qui contient du SVG en ligne ou du MathML ou alors un fichier XML qui est composé de plusieurs vocabulaires).

--- a/files/fr/web/css/reference/at-rules/@namespace/index.md
+++ b/files/fr/web/css/reference/at-rules/@namespace/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@namespace`"
+title: Règle CSS `@namespace`
 short-title: "@namespace"
 slug: Web/CSS/Reference/At-rules/@namespace
 l10n:

--- a/files/fr/web/css/reference/at-rules/@page/index.md
+++ b/files/fr/web/css/reference/at-rules/@page/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@page`"
+title: Règle CSS `@page`
 short-title: "@page"
 slug: Web/CSS/Reference/At-rules/@page
 l10n:

--- a/files/fr/web/css/reference/at-rules/@page/index.md
+++ b/files/fr/web/css/reference/at-rules/@page/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@page"
+title: "Règle CSS `@page`"
+short-title: "@page"
 slug: Web/CSS/Reference/At-rules/@page
 l10n:
-  sourceCommit: 1dbba9f7a2c2e35c6e01e8a63159e2aac64b601b
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@page`** est utilisée pour modifier différents aspects des pages imprimées. Elle permet de cibler et de modifier les dimensions, l'orientation et les marges de la page. La règle `@page` peut s'appliquer à toutes les pages d'une impression ou à un sous-ensemble grâce à ses différentes pseudo-classes.

--- a/files/fr/web/css/reference/at-rules/@position-try/index.md
+++ b/files/fr/web/css/reference/at-rules/@position-try/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@position-try"
+title: "Règle CSS `@position-try`"
+short-title: "@position-try"
 slug: Web/CSS/Reference/At-rules/@position-try
 l10n:
-  sourceCommit: 3e0ba995376cace7f08f0771635f86f0fb1753b3
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@position-try`** permet de définir une option personnalisée de repli de position, utilisée pour définir le positionnement et l'alignement des éléments ancrés. Un ou plusieurs ensembles d'options de repli peuvent être appliqués à l'élément ancré via la propriété {{CSSxRef("position-try-fallbacks")}} ou le raccourci {{CSSxRef("position-try")}}. Lorsque l'élément positionné est déplacé à un endroit où il commence à déborder de son bloc conteneur ou de la zone d'affichage (<i lang="en">viewport</i> en anglais), le navigateur sélectionne la première option de repli qui permet de replacer l'élément entièrement à l'écran.

--- a/files/fr/web/css/reference/at-rules/@position-try/index.md
+++ b/files/fr/web/css/reference/at-rules/@position-try/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@position-try`"
+title: Règle CSS `@position-try`
 short-title: "@position-try"
 slug: Web/CSS/Reference/At-rules/@position-try
 l10n:

--- a/files/fr/web/css/reference/at-rules/@property/index.md
+++ b/files/fr/web/css/reference/at-rules/@property/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@property`"
+title: Règle CSS `@property`
 short-title: "@property"
 slug: Web/CSS/Reference/At-rules/@property
 l10n:

--- a/files/fr/web/css/reference/at-rules/@property/index.md
+++ b/files/fr/web/css/reference/at-rules/@property/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@property"
+title: "Règle CSS `@property`"
+short-title: "@property"
 slug: Web/CSS/Reference/At-rules/@property
 l10n:
-  sourceCommit: cd5ad7b2d4aa2596b19e6875fbe7736dde47ee82
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@property`** est utilisée pour définir explicitement des [propriétés CSS personnalisées](/fr/docs/Web/CSS/Reference/Properties/--*), avec vérification et contrainte de type, définition de valeurs par défaut et choix de l'héritage ou non de la propriété personnalisée.

--- a/files/fr/web/css/reference/at-rules/@scope/index.md
+++ b/files/fr/web/css/reference/at-rules/@scope/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@scope"
+title: "Règle CSS `@scope`"
+short-title: "@scope"
 slug: Web/CSS/Reference/At-rules/@scope
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@scope`** permet de sélectionner des éléments dans des sous-arbres spécifiques du DOM, en ciblant précisément les éléments sans écrire des sélecteurs trop spécifiques difficiles à surcharger, et sans lier vos sélecteurs de façon trop étroite à la structure du DOM.

--- a/files/fr/web/css/reference/at-rules/@scope/index.md
+++ b/files/fr/web/css/reference/at-rules/@scope/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@scope`"
+title: Règle CSS `@scope`
 short-title: "@scope"
 slug: Web/CSS/Reference/At-rules/@scope
 l10n:

--- a/files/fr/web/css/reference/at-rules/@starting-style/index.md
+++ b/files/fr/web/css/reference/at-rules/@starting-style/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@starting-style`"
+title: Règle CSS `@starting-style`
 short-title: "@starting-style"
 slug: Web/CSS/Reference/At-rules/@starting-style
 l10n:

--- a/files/fr/web/css/reference/at-rules/@starting-style/index.md
+++ b/files/fr/web/css/reference/at-rules/@starting-style/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@starting-style"
+title: "Règle CSS `@starting-style`"
+short-title: "@starting-style"
 slug: Web/CSS/Reference/At-rules/@starting-style
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@starting-style`** est utilisée pour définir les valeurs de départ des propriétés appliquées à un élément, à partir desquelles vous souhaitez effectuer une transition lors de la première mise à jour de style de l'élément, c'est-à-dire lorsqu'un élément est affiché pour la première fois sur une page déjà chargée.

--- a/files/fr/web/css/reference/at-rules/@supports/index.md
+++ b/files/fr/web/css/reference/at-rules/@supports/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@supports"
+title: "Règle CSS `@supports`"
+short-title: "@supports"
 slug: Web/CSS/Reference/At-rules/@supports
 l10n:
-  sourceCommit: 46a4425d4b7160129fd4c8d0f684ccd0617326b7
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@supports`** permet de définir des déclarations CSS qui dépendent du support de certaines fonctionnalités CSS par le navigateur.

--- a/files/fr/web/css/reference/at-rules/@supports/index.md
+++ b/files/fr/web/css/reference/at-rules/@supports/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@supports`"
+title: Règle CSS `@supports`
 short-title: "@supports"
 slug: Web/CSS/Reference/At-rules/@supports
 l10n:

--- a/files/fr/web/css/reference/at-rules/@view-transition/index.md
+++ b/files/fr/web/css/reference/at-rules/@view-transition/index.md
@@ -1,8 +1,9 @@
 ---
-title: "@view-transition"
+title: "Règle CSS `@view-transition`"
+short-title: "@view-transition"
 slug: Web/CSS/Reference/At-rules/@view-transition
 l10n:
-  sourceCommit: b88f711ce4944f97162d7f1a7bcb8283af06f690
+  sourceCommit: e328268bb418551ab451881845881b5837c9da83
 ---
 
 La [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) [CSS](/fr/docs/Web/CSS) **`@view-transition`** est utilisée pour choisir les documents actuels et de destination qui subiront [une transition d'affichage](/fr/docs/Web/API/View_Transition_API), dans le cas d'une navigation entre plusieurs documents.

--- a/files/fr/web/css/reference/at-rules/@view-transition/index.md
+++ b/files/fr/web/css/reference/at-rules/@view-transition/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Règle CSS `@view-transition`"
+title: Règle CSS `@view-transition`
 short-title: "@view-transition"
 slug: Web/CSS/Reference/At-rules/@view-transition
 l10n:


### PR DESCRIPTION
### Description

The front-matter key `title` now accept backticks. Content has updated titles to display code in title using these backticks.

### Motivation

Keep translated-content sync for updated pages

### Additional details

_none_

### Related issues and pull requests

Sync from https://github.com/mdn/content/tree/67d40334c8b90e4623f3b0d3aea466b9882d8236
