### PR TITLE
chore(sync-fr): css at-rules descriptor pages use backticks on title

### DIFF
--- a/files/fr/web/css/reference/at-rules/@counter-style/additive-symbols/index.md
+++ b/files/fr/web/css/reference/at-rules/@counter-style/additive-symbols/index.md
@@ -1,8 +1,9 @@
 ---
-title: additive-symbols
+title: Descripteur de règle CSS `additive-symbols`
+short-title: additive-symbols
 slug: Web/CSS/Reference/At-rules/@counter-style/additive-symbols
 l10n:
-  sourceCommit: 6ad108adad746bd7ed79b5b32d8d3e05e5ec685a
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`additive-symbols`** de la règle {{CSSxRef('@counter-style')}} est utilisé pour définir les symboles du compteur lorsque la valeur du descripteur {{CSSxRef('@counter-style/system', 'system')}} de `@counter-style` est définie sur `additive`. Le système additif permet de construire des systèmes de numérotation à valeur de signe (<i lang="en">sign-value numbering</i>) comme les chiffres romains.

--- a/files/fr/web/css/reference/at-rules/@counter-style/fallback/index.md
+++ b/files/fr/web/css/reference/at-rules/@counter-style/fallback/index.md
@@ -1,8 +1,9 @@
 ---
-title: fallback
+title: Descripteur de règle CSS `fallback`
+short-title: fallback
 slug: Web/CSS/Reference/At-rules/@counter-style/fallback
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`fallback`** de la règle {{CSSxRef("@counter-style")}} permet de définir un style de compteur de repli si le style de compteur défini ne peut pas créer de représentation pour une certaine valeur du compteur.

--- a/files/fr/web/css/reference/at-rules/@counter-style/negative/index.md
+++ b/files/fr/web/css/reference/at-rules/@counter-style/negative/index.md
@@ -1,8 +1,9 @@
 ---
-title: negative
+title: Descripteur de règle CSS `negative`
+short-title: negative
 slug: Web/CSS/Reference/At-rules/@counter-style/negative
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`negative`** de la règle {{CSSxRef("@counter-style")}} permet de définir comment les valeurs négatives du compteur sont représentées lors de la création de styles de compteur personnalisés. La valeur du descripteur `negative` définit les symboles à ajouter avant et après la représentation du compteur lorsque la valeur du compteur est négative.

--- a/files/fr/web/css/reference/at-rules/@counter-style/pad/index.md
+++ b/files/fr/web/css/reference/at-rules/@counter-style/pad/index.md
@@ -1,8 +1,9 @@
 ---
-title: pad
+title: Descripteur de règle CSS `pad`
+short-title: pad
 slug: Web/CSS/Reference/At-rules/@counter-style/pad
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`pad`** de la règle {{CSSxRef("@counter-style")}} permet de définir une longueur minimale pour les représentations des marqueurs.

--- a/files/fr/web/css/reference/at-rules/@counter-style/prefix/index.md
+++ b/files/fr/web/css/reference/at-rules/@counter-style/prefix/index.md
@@ -1,8 +1,9 @@
 ---
-title: prefix
+title: Descripteur de règle CSS `prefix`
+short-title: prefix
 slug: Web/CSS/Reference/At-rules/@counter-style/prefix
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`prefix`** de la règle {{CSSxRef('@counter-style')}} permet de définir le contenu qui sera ajouté au début de la représentation du marqueur du compteur.

--- a/files/fr/web/css/reference/at-rules/@counter-style/range/index.md
+++ b/files/fr/web/css/reference/at-rules/@counter-style/range/index.md
@@ -1,8 +1,9 @@
 ---
-title: range
+title: Descripteur de règle CSS `range`
+short-title: range
 slug: Web/CSS/Reference/At-rules/@counter-style/range
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`range`** de la règle {{CSSxRef("@counter-style")}} permet à l'auteur·ice de définir une ou plusieurs plages de valeurs du compteur pour lesquelles le style est appliqué lors de la définition de styles de compteur personnalisés. Lorsque le descripteur `range` est inclus, le compteur défini ne sera utilisé que pour les valeurs comprises dans les plages définies. Si la valeur du compteur est en dehors de la plage définie, le style de repli sera utilisé pour construire la représentation de ce marqueur.

--- a/files/fr/web/css/reference/at-rules/@counter-style/speak-as/index.md
+++ b/files/fr/web/css/reference/at-rules/@counter-style/speak-as/index.md
@@ -1,8 +1,9 @@
 ---
-title: speak-as
+title: Descripteur de règle CSS `speak-as`
+short-title: speak-as
 slug: Web/CSS/Reference/At-rules/@counter-style/speak-as
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`speak-as`** permet de définir comment un symbole de compteur construit avec une règle {{CSSxRef('@counter-style')}} sera représenté à l'oral. Par exemple, l'auteur·ice peut indiquer qu'un symbole de compteur doit être prononcé comme sa valeur numérique ou simplement représenté par une indication sonore.

--- a/files/fr/web/css/reference/at-rules/@counter-style/suffix/index.md
+++ b/files/fr/web/css/reference/at-rules/@counter-style/suffix/index.md
@@ -1,8 +1,9 @@
 ---
-title: suffix
+title: Descripteur de règle CSS `suffix`
+short-title: suffix
 slug: Web/CSS/Reference/At-rules/@counter-style/suffix
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`suffix`** de la règle {{CSSxRef("@counter-style")}} permet de définir le contenu qui sera ajouté à la fin de la représentation du marqueur.

--- a/files/fr/web/css/reference/at-rules/@counter-style/symbols/index.md
+++ b/files/fr/web/css/reference/at-rules/@counter-style/symbols/index.md
@@ -1,8 +1,9 @@
 ---
-title: symbols
+title: Descripteur de règle CSS `symbols`
+short-title: symbols
 slug: Web/CSS/Reference/At-rules/@counter-style/symbols
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`symbols`** de la règle {{CSSxRef("@counter-style")}} est utilisé pour définir les symboles servant à créer les représentations du compteur dans le système de compteur indiqué. Ce descripteur est obligatoire lorsque la valeur du descripteur {{CSSxRef('@counter-style/system', 'system')}} est `cyclic`, `numeric`, `alphabetic`, `symbolic` ou `fixed`.

--- a/files/fr/web/css/reference/at-rules/@counter-style/system/index.md
+++ b/files/fr/web/css/reference/at-rules/@counter-style/system/index.md
@@ -1,8 +1,9 @@
 ---
-title: system
+title: Descripteur de règle CSS `system`
+short-title: system
 slug: Web/CSS/Reference/At-rules/@counter-style/system
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`system`** permet de définir l'algorithme à utiliser pour convertir la valeur entière d'un compteur en une représentation sous forme de chaîne de caractères. Il est utilisé dans une règle {{CSSxRef("@counter-style")}} pour définir le comportement du style défini.

--- a/files/fr/web/css/reference/at-rules/@font-face/ascent-override/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/ascent-override/index.md
@@ -1,8 +1,9 @@
 ---
-title: ascent-override
+title: Descripteur de règle CSS `ascent-override`
+short-title: ascent-override
 slug: Web/CSS/Reference/At-rules/@font-face/ascent-override
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`ascent-override`** pour la [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@font-face")}} définit la mesure du jambage supérieur pour la police. La mesure du jambage supérieur est la hauteur au-dessus de la ligne de base que CSS utilise pour disposer les boîtes de ligne dans un contexte de mise en forme en ligne.

--- a/files/fr/web/css/reference/at-rules/@font-face/descent-override/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/descent-override/index.md
@@ -1,8 +1,9 @@
 ---
-title: descent-override
+title: Descripteur de règle CSS `descent-override`
+short-title: descent-override
 slug: Web/CSS/Reference/At-rules/@font-face/descent-override
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`descent-override`** pour la [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@font-face")}} définit la mesure du jambage inférieur pour la police. La mesure du jambage inférieur est la hauteur en dessous de la ligne de base que CSS utilise pour disposer les boîtes de ligne dans un contexte de mise en forme en ligne.

--- a/files/fr/web/css/reference/at-rules/@font-face/font-display/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/font-display/index.md
@@ -1,8 +1,9 @@
 ---
-title: font-display
+title: Descripteur de règle CSS `font-display`
+short-title: font-display
 slug: Web/CSS/Reference/At-rules/@font-face/font-display
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`font-display`** pour la [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@font-face")}} détermine comment une police est affichée en fonction de son état de téléchargement et de disponibilité.

--- a/files/fr/web/css/reference/at-rules/@font-face/font-family/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/font-family/index.md
@@ -1,8 +1,9 @@
 ---
-title: font-family
+title: Descripteur de règle CSS `font-family`
+short-title: font-family
 slug: Web/CSS/Reference/At-rules/@font-face/font-family
 l10n:
-  sourceCommit: 1dbba9f7a2c2e35c6e01e8a63159e2aac64b601b
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`font-family`** définit la famille de polices pour une police spécifiée dans une [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@font-face")}}.

--- a/files/fr/web/css/reference/at-rules/@font-face/font-feature-settings/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/font-feature-settings/index.md
@@ -1,8 +1,9 @@
 ---
-title: font-feature-settings
+title: Descripteur de règle CSS `font-feature-settings`
+short-title: font-feature-settings
 slug: Web/CSS/Reference/At-rules/@font-face/font-feature-settings
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`font-feature-settings`** permet de définir les réglages initiaux à utiliser pour la police définie par la [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@font-face")}}. Vous pouvez également utiliser ce descripteur pour contrôler les fonctionnalités typographiques de la police, telles que les ligatures, petites capitales et ornements, pour la police définie par `@font-face`. Les valeurs de ce descripteur sont identiques à celles de la propriété {{CSSxRef("font-feature-settings")}}, à l'exception des mots-clés globaux.

--- a/files/fr/web/css/reference/at-rules/@font-face/font-stretch/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/font-stretch/index.md
@@ -1,8 +1,9 @@
 ---
-title: font-stretch
+title: Descripteur de règle CSS `font-stretch`
+short-title: font-stretch
 slug: Web/CSS/Reference/At-rules/@font-face/font-stretch
 l10n:
-  sourceCommit: 3c91c067a4d36b532a4bce72e5d8a2c5a9279db5
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 > [!NOTE]

--- a/files/fr/web/css/reference/at-rules/@font-face/font-style/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/font-style/index.md
@@ -1,8 +1,9 @@
 ---
-title: font-style
+title: Descripteur de règle CSS `font-style`
+short-title: font-style
 slug: Web/CSS/Reference/At-rules/@font-face/font-style
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`font-style`**, associé à [la règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@font-face")}}, permet d'indiquer le style de police pour la police définie via la règle.

--- a/files/fr/web/css/reference/at-rules/@font-face/font-variation-settings/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/font-variation-settings/index.md
@@ -1,8 +1,9 @@
 ---
-title: font-variation-settings
+title: Descripteur de règle CSS `font-variation-settings`
+short-title: font-variation-settings
 slug: Web/CSS/Reference/At-rules/@font-face/font-variation-settings
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`font-variation-settings`**, associé à la [la règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@font-face")}} permet d'indiquer les variations de police de bas niveau pour les polices OpenType ou TrueType.

--- a/files/fr/web/css/reference/at-rules/@font-face/font-weight/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/font-weight/index.md
@@ -1,8 +1,9 @@
 ---
-title: font-weight
+title: Descripteur de règle CSS `font-weight`
+short-title: font-weight
 slug: Web/CSS/Reference/At-rules/@font-face/font-weight
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`font-weight`** permet aux auteur·ice·s d'indiquer les graisses pour les polices fournies dans une [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@font-face")}}. La propriété {{CSSxRef("font-weight")}} peut être utilisée séparément pour indiquer la graisse des caractères d'un texte (c'est-à-dire s'ils sont en gras, normaux ou plus fins).

--- a/files/fr/web/css/reference/at-rules/@font-face/font-width/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/font-width/index.md
@@ -1,8 +1,9 @@
 ---
-title: font-width
+title: Descripteur de règle CSS `font-width`
+short-title: font-width
 slug: Web/CSS/Reference/At-rules/@font-face/font-width
 l10n:
-  sourceCommit: de5b557883e8eff2514f0fe6eeb180db782575b1
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/at-rules/@font-face/line-gap-override/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/line-gap-override/index.md
@@ -1,8 +1,9 @@
 ---
-title: line-gap-override
+title: Descripteur de règle CSS `line-gap-override`
+short-title: line-gap-override
 slug: Web/CSS/Reference/At-rules/@font-face/line-gap-override
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`line-gap-override`** pour la [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@font-face")}} définit la mesure de l'écart de lignes de la police. La mesure de l'écart de lignes est l'écart recommandé par la police ou l'écart externe.

--- a/files/fr/web/css/reference/at-rules/@font-face/size-adjust/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/size-adjust/index.md
@@ -1,8 +1,9 @@
 ---
-title: size-adjust
+title: Descripteur de règle CSS `size-adjust`
+short-title: size-adjust
 slug: Web/CSS/Reference/At-rules/@font-face/size-adjust
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`size-adjust`** CSS définit un multiplicateur destiné aux contours des glyphes et aux mesures associées à la police. Cela facilite l'harmonisation de l'apparence des polices lorsqu'elles sont rendues avec la même taille.

--- a/files/fr/web/css/reference/at-rules/@font-face/src/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/src/index.md
@@ -1,8 +1,9 @@
 ---
-title: src
+title: Descripteur de règle CSS `src`
+short-title: src
 slug: Web/CSS/Reference/At-rules/@font-face/src
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`src`** pour la règle {{CSSxRef("@font-face")}} spécifie la ressource contenant les données de la police. Il est obligatoire pour que la règle `@font-face` soit valide.

--- a/files/fr/web/css/reference/at-rules/@font-face/unicode-range/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-face/unicode-range/index.md
@@ -1,8 +1,9 @@
 ---
-title: unicode-range
+title: Descripteur de règle CSS `unicode-range`
+short-title: unicode-range
 slug: Web/CSS/Reference/At-rules/@font-face/unicode-range
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`unicode-range`** pour à la [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@font-face")}}, définit l'intervalle de caractères qui peuvent être représentés par cette police pour la page. Si la page n'utilise aucun caractère de cet intervalle, la police n'est pas téléchargée. Si, au contraire, elle utilise au moins un caractère appartenant à cet intervalle, toute la police est téléchargée.

--- a/files/fr/web/css/reference/at-rules/@font-feature-values/font-display/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-feature-values/font-display/index.md
@@ -1,8 +1,9 @@
 ---
-title: font-display
+title: Descripteur de règle CSS `font-display`
+short-title: font-display
 slug: Web/CSS/Reference/At-rules/@font-feature-values/font-display
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le descripteur **`font-display`** pour la règle {{CSSxRef("@font-feature-values")}} définit la valeur par défaut indiquant comment une police est affichée, en fonction de son téléchargement et du moment où il a lieu. Définir une valeur pour le descripteur `font-display` dans un bloc `@font-feature-values` fixe la valeur par défaut du descripteur `font-display` pour la règle {{CSSxRef("@font-face")}} pour toutes les polices partageant la même valeur de {{CSSxRef("@font-face/font-family", "font-family")}}.

--- a/files/fr/web/css/reference/at-rules/@font-palette-values/base-palette/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-palette-values/base-palette/index.md
@@ -1,8 +1,9 @@
 ---
-title: base-palette
+title: Descripteur de règle CSS `base-palette`
+short-title: base-palette
 slug: Web/CSS/Reference/At-rules/@font-palette-values/base-palette
 l10n:
-  sourceCommit: 0b926fc3e79782401461d389fc9f17d522b39ed3
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`base-palette`** de la [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@font-palette-values")}} est utilisé pour spécifier le nom ou l'index d'une palette prédéfinie à utiliser pour créer une nouvelle palette. Si la `base-palette` indiquée n'existe pas, alors la palette définie à l'index 0 sera utilisée.

--- a/files/fr/web/css/reference/at-rules/@font-palette-values/font-family/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-palette-values/font-family/index.md
@@ -1,8 +1,9 @@
 ---
-title: font-family
+title: Descripteur de règle CSS `font-family`
+short-title: font-family
 slug: Web/CSS/Reference/At-rules/@font-palette-values/font-family
 l10n:
-  sourceCommit: 0b926fc3e79782401461d389fc9f17d522b39ed3
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`font-family`** de la [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@font-palette-values")}} est utilisé pour spécifier à quelle famille de police les valeurs de palette doivent s'appliquer. Cette valeur doit correspondre exactement à celle utilisée lors de la définition de la propriété CSS {{CSSxRef("font-family")}}.

--- a/files/fr/web/css/reference/at-rules/@font-palette-values/override-colors/index.md
+++ b/files/fr/web/css/reference/at-rules/@font-palette-values/override-colors/index.md
@@ -1,8 +1,9 @@
 ---
-title: override-colors
+title: Descripteur de règle CSS `override-colors`
+short-title: override-colors
 slug: Web/CSS/Reference/At-rules/@font-palette-values/override-colors
 l10n:
-  sourceCommit: 0b926fc3e79782401461d389fc9f17d522b39ed3
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`override-colors`** de la [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@font-palette-values")}} est utilisé pour remplacer les couleurs de la [palette de base](/fr/docs/Web/CSS/Reference/At-rules/@font-palette-values/base-palette) choisie pour une police couleur.

--- a/files/fr/web/css/reference/at-rules/@page/page-orientation/index.md
+++ b/files/fr/web/css/reference/at-rules/@page/page-orientation/index.md
@@ -1,8 +1,9 @@
 ---
-title: page-orientation
+title: Descripteur de règle CSS `page-orientation`
+short-title: page-orientation
 slug: Web/CSS/Reference/At-rules/@page/page-orientation
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`page-orientation`** pour la [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@page")}} contrôle la rotation d'une page imprimée. Il gère le flux du contenu d'une page à l'autre lorsque l'orientation de la page est modifiée. Ce comportement diffère du descripteur [`size`](/fr/docs/Web/CSS/Reference/At-rules/@page/size) car l'utilisateur·rice peut définir la direction de rotation de la page.

--- a/files/fr/web/css/reference/at-rules/@page/size/index.md
+++ b/files/fr/web/css/reference/at-rules/@page/size/index.md
@@ -1,8 +1,9 @@
 ---
-title: size
+title: Descripteur de règle CSS `size`
+short-title: size
 slug: Web/CSS/Reference/At-rules/@page/size
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`size`** associé à la [règle](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@page")}}, permet de définir les dimensions et l'orientation de la boîte utilisée pour représenter une page. La plupart du temps, cette taille correspondra à la totalité de la taille de la page imprimée.

--- a/files/fr/web/css/reference/at-rules/@property/inherits/index.md
+++ b/files/fr/web/css/reference/at-rules/@property/inherits/index.md
@@ -1,8 +1,9 @@
 ---
-title: inherits
+title: Descripteur de règle CSS `inherits`
+short-title: inherits
 slug: Web/CSS/Reference/At-rules/@property/inherits
 l10n:
-  sourceCommit: 98bbdcd90e5487539cebe19b12fe3d731fb5a03e
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`inherits`** de la [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@property")}} contrôle si la [propriété personnalisée CSS](/fr/docs/Web/CSS/Reference/Properties/--*) enregistrée hérite ou non de sa valeur par défaut.

--- a/files/fr/web/css/reference/at-rules/@property/initial-value/index.md
+++ b/files/fr/web/css/reference/at-rules/@property/initial-value/index.md
@@ -1,8 +1,9 @@
 ---
-title: initial-value
+title: Descripteur de règle CSS `initial-value`
+short-title: initial-value
 slug: Web/CSS/Reference/At-rules/@property/initial-value
 l10n:
-  sourceCommit: 98bbdcd90e5487539cebe19b12fe3d731fb5a03e
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`initial-value`** de la [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@property")}} définit la valeur initiale pour la [propriété personnalisée CSS](/fr/docs/Web/CSS/Reference/Properties/--*) enregistrée.

--- a/files/fr/web/css/reference/at-rules/@property/syntax/index.md
+++ b/files/fr/web/css/reference/at-rules/@property/syntax/index.md
@@ -1,8 +1,9 @@
 ---
-title: syntax
+title: Descripteur de règle CSS `syntax`
+short-title: syntax
 slug: Web/CSS/Reference/At-rules/@property/syntax
 l10n:
-  sourceCommit: 98bbdcd90e5487539cebe19b12fe3d731fb5a03e
+  sourceCommit: f0094356d3acb19475dde45508dfeac6abf596db
 ---
 
 Le {{Glossary("CSS_Descriptor", "descripteur")}} [CSS](/fr/docs/Web/CSS) **`syntax`** de la [règle @](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@property")}} définit les types de valeurs autorisées pour la [propriété personnalisée CSS](/fr/docs/Web/CSS/Reference/Properties/--*) enregistrée.


### PR DESCRIPTION
### Description

The front-matter key `title` now accept backticks. Content has updated titles to display code in title using these backticks.

### Motivation

Keep translated-content sync for updated pages

### Additional details

_none_

### Related issues and pull requests

Sync from https://github.com/mdn/content/tree/f0094356d3acb19475dde45508dfeac6abf596db
