### PR TITLE
chore(sync-fr): css at-rules function pages use backticks on title

### DIFF
--- a/files/fr/web/css/reference/at-rules/@import/layer_function/index.md
+++ b/files/fr/web/css/reference/at-rules/@import/layer_function/index.md
@@ -1,8 +1,9 @@
 ---
-title: layer()
+title: Fonction CSS `layer()`
+short-title: layer()
 slug: Web/CSS/Reference/At-rules/@import/layer_function
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`layer()`** est utilisée avec la [règle](/fr/docs/Web/CSS/Guides/Syntax/At-rules) {{CSSxRef("@import")}} pour placer la ressource importée dans une [couche de cascade](/fr/docs/Web/CSS/Reference/At-rules/@layer) nommée distincte.

--- a/files/fr/web/css/reference/at-rules/@media/-moz-device-pixel-ratio/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/-moz-device-pixel-ratio/index.md
@@ -1,8 +1,9 @@
 ---
-title: -moz-device-pixel-ratio
+title: Fonction CSS `-moz-device-pixel-ratio`
+short-title: -moz-device-pixel-ratio
 slug: Web/CSS/Reference/At-rules/@media/-moz-device-pixel-ratio
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 {{Non-standard_Header}}{{Deprecated_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/-webkit-animation/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/-webkit-animation/index.md
@@ -1,8 +1,9 @@
 ---
-title: -webkit-animation
+title: Fonction CSS `-webkit-animation`
+short-title: -webkit-animation
 slug: Web/CSS/Reference/At-rules/@media/-webkit-animation
 l10n:
-  sourceCommit: 09d8ff096be97b28ea415fc4c68fb1cff0ff8af9
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 {{Non-standard_Header}}{{Deprecated_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/-webkit-device-pixel-ratio/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/-webkit-device-pixel-ratio/index.md
@@ -1,8 +1,9 @@
 ---
-title: -webkit-device-pixel-ratio
+title: Fonction CSS `-webkit-device-pixel-ratio`
+short-title: -webkit-device-pixel-ratio
 slug: Web/CSS/Reference/At-rules/@media/-webkit-device-pixel-ratio
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 **`-webkit-device-pixel-ratio`** est une caractéristique média non-standard, alternative à la caractéristique média standard {{CSSxRef("@media/resolution", "resolution")}}.

--- a/files/fr/web/css/reference/at-rules/@media/-webkit-transform-2d/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/-webkit-transform-2d/index.md
@@ -1,8 +1,9 @@
 ---
-title: -webkit-transform-2d
+title: Fonction CSS `-webkit-transform-2d`
+short-title: -webkit-transform-2d
 slug: Web/CSS/Reference/At-rules/@media/-webkit-transform-2d
 l10n:
-  sourceCommit: 09d8ff096be97b28ea415fc4c68fb1cff0ff8af9
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/-webkit-transform-3d/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/-webkit-transform-3d/index.md
@@ -1,8 +1,9 @@
 ---
-title: -webkit-transform-3d
+title: Fonction CSS `-webkit-transform-3d`
+short-title: -webkit-transform-3d
 slug: Web/CSS/Reference/At-rules/@media/-webkit-transform-3d
 l10n:
-  sourceCommit: 09d8ff096be97b28ea415fc4c68fb1cff0ff8af9
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) booléenne [CSS](/fr/docs/Web/CSS) **`-webkit-transform-3d`** est une [extension WebKit](/fr/docs/Web/CSS/Reference/Webkit_extensions) qui vaut `true` si les transformations CSS 3D {{CSSxRef("transform")}} préfixées sont prises en charge.

--- a/files/fr/web/css/reference/at-rules/@media/-webkit-transition/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/-webkit-transition/index.md
@@ -1,8 +1,9 @@
 ---
-title: -webkit-transition
+title: Fonction CSS `-webkit-transition`
+short-title: -webkit-transition
 slug: Web/CSS/Reference/At-rules/@media/-webkit-transition
 l10n:
-  sourceCommit: 09d8ff096be97b28ea415fc4c68fb1cff0ff8af9
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 {{Deprecated_Header}}{{Non-standard_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/any-hover/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/any-hover/index.md
@@ -1,8 +1,9 @@
 ---
-title: any-hover
+title: Fonction CSS `any-hover`
+short-title: any-hover
 slug: Web/CSS/Reference/At-rules/@media/any-hover
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`any-hover`** est utilisée pour tester si _n'importe quel_ mécanisme d'entrée disponible peut survoler un élément.

--- a/files/fr/web/css/reference/at-rules/@media/any-pointer/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/any-pointer/index.md
@@ -1,8 +1,9 @@
 ---
-title: any-pointer
+title: Fonction CSS `any-pointer`
+short-title: any-pointer
 slug: Web/CSS/Reference/At-rules/@media/any-pointer
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`any-pointer`** vérifie si l'utilisateur dispose _d'un_ dispositif de pointage (comme une souris) et, le cas échéant, quelle est sa précision.

--- a/files/fr/web/css/reference/at-rules/@media/aspect-ratio/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/aspect-ratio/index.md
@@ -1,8 +1,9 @@
 ---
-title: aspect-ratio
+title: Fonction CSS `aspect-ratio`
+short-title: aspect-ratio
 slug: Web/CSS/Reference/At-rules/@media/aspect-ratio
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`aspect-ratio`** peut être utilisée pour tester le {{Glossary("aspect ratio", "rapport d'aspect")}} de la {{Glossary("viewport", "zone d'affichage")}}.

--- a/files/fr/web/css/reference/at-rules/@media/color-gamut/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/color-gamut/index.md
@@ -1,8 +1,9 @@
 ---
-title: color-gamut
+title: Fonction CSS `color-gamut`
+short-title: color-gamut
 slug: Web/CSS/Reference/At-rules/@media/color-gamut
 l10n:
-  sourceCommit: 423161782178b119c64cd0b41bff8df20dc84a56
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`color-gamut`** est utilisée pour appliquer des styles CSS en fonction de l'intervalle approximatif des couleurs {{Glossary("gamut")}} pris en charge par l'agent utilisateur et l'appareil de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/color-index/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/color-index/index.md
@@ -1,8 +1,9 @@
 ---
-title: color-index
+title: Fonction CSS `color-index`
+short-title: color-index
 slug: Web/CSS/Reference/At-rules/@media/color-index
 l10n:
-  sourceCommit: 6ef7bc04d63cf8b512bdbea149a6cb875cc063e3
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`color-index`** est utilisée pour tester le nombre d'entrées dans la table de recherche des couleurs du périphérique de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/color/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/color/index.md
@@ -1,8 +1,9 @@
 ---
-title: color
+title: Fonction CSS `color`
+short-title: color
 slug: Web/CSS/Reference/At-rules/@media/color
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`color`** est utilisée pour tester le nombre de bits par composante de couleur (rouge, vert, bleu) du périphérique de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/device-aspect-ratio/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/device-aspect-ratio/index.md
@@ -1,8 +1,9 @@
 ---
-title: device-aspect-ratio
+title: Fonction CSS `device-aspect-ratio`
+short-title: device-aspect-ratio
 slug: Web/CSS/Reference/At-rules/@media/device-aspect-ratio
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/device-height/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/device-height/index.md
@@ -1,8 +1,9 @@
 ---
-title: device-height
+title: Fonction CSS `device-height`
+short-title: device-height
 slug: Web/CSS/Reference/At-rules/@media/device-height
 l10n:
-  sourceCommit: 6ef7bc04d63cf8b512bdbea149a6cb875cc063e3
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/device-posture/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/device-posture/index.md
@@ -1,8 +1,9 @@
 ---
-title: device-posture
+title: Fonction CSS `device-posture`
+short-title: device-posture
 slug: Web/CSS/Reference/At-rules/@media/device-posture
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/at-rules/@media/device-width/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/device-width/index.md
@@ -1,8 +1,9 @@
 ---
-title: device-width
+title: Fonction CSS `device-width`
+short-title: device-width
 slug: Web/CSS/Reference/At-rules/@media/device-width
 l10n:
-  sourceCommit: 6ef7bc04d63cf8b512bdbea149a6cb875cc063e3
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/display-mode/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/display-mode/index.md
@@ -1,8 +1,9 @@
 ---
-title: display-mode
+title: Fonction CSS `display-mode`
+short-title: display-mode
 slug: Web/CSS/Reference/At-rules/@media/display-mode
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`display-mode`** permet de tester si une application web est affichée dans un onglet de navigateur classique ou d'une autre manière, comme une application autonome ou en mode plein écran.

--- a/files/fr/web/css/reference/at-rules/@media/dynamic-range/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/dynamic-range/index.md
@@ -1,8 +1,9 @@
 ---
-title: dynamic-range
+title: Fonction CSS `dynamic-range`
+short-title: dynamic-range
 slug: Web/CSS/Reference/At-rules/@media/dynamic-range
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`dynamic-range`** permet de tester la combinaison de la luminosité, du taux de contraste et de la profondeur de couleur pris en charge par l'{{Glossary("user agent", "agent utilisateur")}} et le périphérique de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/forced-colors/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/forced-colors/index.md
@@ -1,8 +1,9 @@
 ---
-title: forced-colors
+title: Fonction CSS `forced-colors`
+short-title: forced-colors
 slug: Web/CSS/Reference/At-rules/@media/forced-colors
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`forced-colors`** permet de détecter si l'{{Glossary("user agent", "agent utilisateur")}} a activé un mode couleurs forcées, dans lequel il impose une palette de couleurs limitée choisie par l'utilisateur·ice sur la page. Un exemple de mode couleurs forcées est le mode contraste élevé de Windows.

--- a/files/fr/web/css/reference/at-rules/@media/grid/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/grid/index.md
@@ -1,8 +1,9 @@
 ---
-title: grid
+title: Fonction CSS `grid`
+short-title: grid
 slug: Web/CSS/Reference/At-rules/@media/grid
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`grid`** permet de tester si le périphérique de sortie utilise un écran basé sur une grille.

--- a/files/fr/web/css/reference/at-rules/@media/height/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/height/index.md
@@ -1,8 +1,9 @@
 ---
-title: height
+title: Fonction CSS `height`
+short-title: height
 slug: Web/CSS/Reference/At-rules/@media/height
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`height`** permet d'appliquer des styles en fonction de la hauteur de la {{Glossary("viewport", "zone d'affichage")}} (ou de la boîte de page, pour les [médias paginés](/fr/docs/Web/CSS/Guides/Paged_media)).

--- a/files/fr/web/css/reference/at-rules/@media/horizontal-viewport-segments/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/horizontal-viewport-segments/index.md
@@ -1,8 +1,9 @@
 ---
-title: horizontal-viewport-segments
+title: Fonction CSS `horizontal-viewport-segments`
+short-title: horizontal-viewport-segments
 slug: Web/CSS/Reference/At-rules/@media/horizontal-viewport-segments
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`horizontal-viewport-segments`** permet de détecter si l'appareil possède un nombre spécifié de segments de zone d'affichage disposés horizontalement (côte à côte).

--- a/files/fr/web/css/reference/at-rules/@media/hover/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/hover/index.md
@@ -1,8 +1,9 @@
 ---
-title: hover
+title: Fonction CSS `hover`
+short-title: hover
 slug: Web/CSS/Reference/At-rules/@media/hover
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`hover`** est utilisée pour tester si le _mécanisme_ de saisie principal de l'utilisateur·ice peut survoler des éléments.

--- a/files/fr/web/css/reference/at-rules/@media/inverted-colors/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/inverted-colors/index.md
@@ -1,8 +1,9 @@
 ---
-title: inverted-colors
+title: Fonction CSS `inverted-colors`
+short-title: inverted-colors
 slug: Web/CSS/Reference/At-rules/@media/inverted-colors
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`inverted-colors`** permet de tester si l'{{Glossary("user agent", "agent utilisateur")}} ou le système d'exploitation sous-jacent a inversé toutes les couleurs.

--- a/files/fr/web/css/reference/at-rules/@media/monochrome/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/monochrome/index.md
@@ -1,8 +1,9 @@
 ---
-title: monochrome
+title: Fonction CSS `monochrome`
+short-title: monochrome
 slug: Web/CSS/Reference/At-rules/@media/monochrome
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`monochrome`** permet de tester le nombre de bits par pixel dans le tampon d'affichage monochrome de l'appareil de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/orientation/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/orientation/index.md
@@ -1,8 +1,9 @@
 ---
-title: orientation
+title: Fonction CSS `orientation`
+short-title: orientation
 slug: Web/CSS/Reference/At-rules/@media/orientation
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`orientation`** permet de tester l'orientation de la {{Glossary("viewport", "zone d'affichage")}} (ou de la boîte de page, pour les [médias paginés](/fr/docs/Web/CSS/Guides/Paged_media)).

--- a/files/fr/web/css/reference/at-rules/@media/overflow-block/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/overflow-block/index.md
@@ -1,8 +1,9 @@
 ---
-title: overflow-block
+title: Fonction CSS `overflow-block`
+short-title: overflow-block
 slug: Web/CSS/Reference/At-rules/@media/overflow-block
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`overflow-block`** permet de tester la façon dont l'appareil de sortie gère le contenu qui déborde du [bloc englobant](/fr/docs/Web/CSS/Guides/Display/Containing_block) initial selon l'axe du bloc.

--- a/files/fr/web/css/reference/at-rules/@media/overflow-inline/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/overflow-inline/index.md
@@ -1,8 +1,9 @@
 ---
-title: overflow-inline
+title: Fonction CSS `overflow-inline`
+short-title: overflow-inline
 slug: Web/CSS/Reference/At-rules/@media/overflow-inline
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`overflow-inline`** permet de tester la façon dont l'appareil de sortie gère le contenu qui déborde du [bloc englobant](/fr/docs/Web/CSS/Guides/Display/Containing_block) initial selon l'axe en ligne.

--- a/files/fr/web/css/reference/at-rules/@media/pointer/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/pointer/index.md
@@ -1,8 +1,9 @@
 ---
-title: pointer
+title: Fonction CSS `pointer`
+short-title: pointer
 slug: Web/CSS/Reference/At-rules/@media/pointer
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`pointer`** permet de tester si l'utilisateur·ice dispose d'un dispositif de pointage (comme une souris) et, le cas échéant, d'évaluer la précision du dispositif de pointage principal.

--- a/files/fr/web/css/reference/at-rules/@media/prefers-color-scheme/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/prefers-color-scheme/index.md
@@ -1,8 +1,9 @@
 ---
-title: prefers-color-scheme
+title: Fonction CSS `prefers-color-scheme`
+short-title: prefers-color-scheme
 slug: Web/CSS/Reference/At-rules/@media/prefers-color-scheme
 l10n:
-  sourceCommit: 1dbba9f7a2c2e35c6e01e8a63159e2aac64b601b
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`prefers-color-scheme`** permet de détecter si un·e utilisateur·ice a demandé un thème clair ou sombre.

--- a/files/fr/web/css/reference/at-rules/@media/prefers-contrast/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/prefers-contrast/index.md
@@ -1,8 +1,9 @@
 ---
-title: prefers-contrast
+title: Fonction CSS `prefers-contrast`
+short-title: prefers-contrast
 slug: Web/CSS/Reference/At-rules/@media/prefers-contrast
 l10n:
-  sourceCommit: c4d3b34b77fcfc28dd1d1a7ecb051ee912d9d3dd
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`prefers-contrast`** permet de détecter si un·e utilisateur·ice a demandé à ce que le contenu web soit présenté avec un contraste plus faible ou plus élevé.

--- a/files/fr/web/css/reference/at-rules/@media/prefers-reduced-data/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/prefers-reduced-data/index.md
@@ -1,8 +1,9 @@
 ---
-title: prefers-reduced-data
+title: Fonction CSS `prefers-reduced-data`
+short-title: prefers-reduced-data
 slug: Web/CSS/Reference/At-rules/@media/prefers-reduced-data
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/at-rules/@media/prefers-reduced-motion/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/prefers-reduced-motion/index.md
@@ -1,8 +1,9 @@
 ---
-title: prefers-reduced-motion
+title: Fonction CSS `prefers-reduced-motion`
+short-title: prefers-reduced-motion
 slug: Web/CSS/Reference/At-rules/@media/prefers-reduced-motion
 l10n:
-  sourceCommit: 77445f9812d0644dfe6975234f8ff3450efcf142
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 > [!WARNING]

--- a/files/fr/web/css/reference/at-rules/@media/prefers-reduced-transparency/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/prefers-reduced-transparency/index.md
@@ -1,8 +1,9 @@
 ---
-title: prefers-reduced-transparency
+title: Fonction CSS `prefers-reduced-transparency`
+short-title: prefers-reduced-transparency
 slug: Web/CSS/Reference/At-rules/@media/prefers-reduced-transparency
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/at-rules/@media/resolution/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/resolution/index.md
@@ -1,8 +1,9 @@
 ---
-title: resolution
+title: Fonction CSS `resolution`
+short-title: resolution
 slug: Web/CSS/Reference/At-rules/@media/resolution
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`resolution`** peut être utilisée pour tester la densité de pixels de l'appareil de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/scan/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/scan/index.md
@@ -1,8 +1,9 @@
 ---
-title: scan
+title: Fonction CSS `scan`
+short-title: scan
 slug: Web/CSS/Reference/At-rules/@media/scan
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`scan`** permet d'appliquer des styles CSS en fonction du procédé de balayage du périphérique de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/scripting/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/scripting/index.md
@@ -1,8 +1,9 @@
 ---
-title: scripting
+title: Fonction CSS `scripting`
+short-title: scripting
 slug: Web/CSS/Reference/At-rules/@media/scripting
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`scripting`** permet de tester si les scripts (comme JavaScript) sont disponibles.

--- a/files/fr/web/css/reference/at-rules/@media/shape/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/shape/index.md
@@ -1,8 +1,9 @@
 ---
-title: shape
+title: Fonction CSS `shape`
+short-title: shape
 slug: Web/CSS/Reference/At-rules/@media/shape
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/at-rules/@media/update/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/update/index.md
@@ -1,8 +1,9 @@
 ---
-title: update
+title: Fonction CSS `update`
+short-title: update
 slug: Web/CSS/Reference/At-rules/@media/update
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`update`** peut être utilisée pour tester la fréquence à laquelle (le cas échéant) l'appareil de sortie est capable de modifier l'apparence du contenu une fois rendu.

--- a/files/fr/web/css/reference/at-rules/@media/vertical-viewport-segments/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/vertical-viewport-segments/index.md
@@ -1,8 +1,9 @@
 ---
-title: vertical-viewport-segments
+title: Fonction CSS `vertical-viewport-segments`
+short-title: vertical-viewport-segments
 slug: Web/CSS/Reference/At-rules/@media/vertical-viewport-segments
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`vertical-viewport-segments`** permet de détecter si l'appareil possède un nombre spécifié de segments de zone d'affichage (<i lang="en">viewport</i>) disposés verticalement (de haut en bas).

--- a/files/fr/web/css/reference/at-rules/@media/video-dynamic-range/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/video-dynamic-range/index.md
@@ -1,8 +1,9 @@
 ---
-title: video-dynamic-range
+title: Fonction CSS `video-dynamic-range`
+short-title: video-dynamic-range
 slug: Web/CSS/Reference/At-rules/@media/video-dynamic-range
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`video-dynamic-range`** permet de tester la combinaison de la luminosité, du rapport de contraste et de la profondeur de couleur pris en charge par le plan vidéo de l'{{Glossary("user agent", "agent utilisateur")}} et le périphérique de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/width/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/width/index.md
@@ -1,8 +1,9 @@
 ---
-title: width
+title: Fonction CSS `width`
+short-title: width
 slug: Web/CSS/Reference/At-rules/@media/width
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`width`** peut être utilisée pour tester la largeur de la {{Glossary("viewport", "zone d'affichage")}} (ou de la boîte de page, pour [les médias paginés](/fr/docs/Web/CSS/Guides/Paged_media)).


### PR DESCRIPTION
### Description

The front-matter key `title` now accept backticks. Content has updated titles to display code in title using these backticks.

### Motivation

Keep translated-content sync for updated pages

### Additional details

_none_

### Related issues and pull requests

Sync from https://github.com/mdn/content/tree/b760560abe30bd69ca968dac38528102f423b5ea
