### PR TITLE
[es] Sincronizar writing_guidelines/code_style_guide

### DIFF
--- a/files/es/mdn/writing_guidelines/code_style_guide/index.md
+++ b/files/es/mdn/writing_guidelines/code_style_guide/index.md
@@ -1,73 +1,72 @@
 ---
 title: Directrices para escribir ejemplos de código
+short-title: Estilo de código
 slug: MDN/Writing_guidelines/Code_style_guide
-original_slug: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide
 l10n:
-  sourceCommit: f7c186696980fee97e72261370d7b5a8c1cd9302
+  sourceCommit: 7ff752fba26e0bb950998bb5476157ff96c7d314
 ---
 
-{{MDNSidebar}}
+Este artículo describe las directrices de estilo y formato para los ejemplos de código en MDN Web Docs, independientemente del lenguaje de programación.
+Para obtener directrices sobre la prosa y otros contenidos, consulta la [guía de estilo de escritura](/es/docs/MDN/Writing_guidelines/Writing_style_guide#code_examples).
 
-Las pautas descritas en este artículo se aplican al estilo y formato de los ejemplos de código, independientemente del lenguaje. Para obtener pautas sobre qué contenido incluir al escribir ejemplos de código, consulta la [guía de estilo de escritura](/es/docs/MDN/Writing_guidelines/Writing_style_guide#code_examples).
+Para obtener directrices específicas de tecnología, consulta los siguientes artículos:
 
-Para pautas específicas de tecnología, consulta los siguientes artículos:
-
-- [Directrices HTML](/es/docs/MDN/Writing_guidelines/Code_style_guide/HTML)
-- [Directrices CSS](/es/docs/MDN/Writing_guidelines/Code_style_guide/CSS)
+- [Directrices de HTML](/es/docs/MDN/Writing_guidelines/Code_style_guide/HTML)
+- [Directrices de CSS](/es/docs/MDN/Writing_guidelines/Code_style_guide/CSS)
 - [Directrices de JavaScript](/es/docs/MDN/Writing_guidelines/Code_style_guide/JavaScript)
-- [Directrices de la interfaz de línea de comandos (Shell)](/es/docs/MDN/Writing_guidelines/Code_style_guide/Shell)
+- [Directrices del indicador de Shell](/es/docs/MDN/Writing_guidelines/Code_style_guide/Shell)
 
-## Mejores prácticas generales
+## Principios generales para los ejemplos de código
 
-Esta sección proporciona las mejores prácticas para crear un ejemplo de código mínimo comprensible que demuestre el uso de una función o característica específica.
+Existe una consideración general que debes tener en cuenta: **Los lectores copiarán y pegarán ejemplos en su propio código y es posible que lo utilicen en producción.**
+Por lo tanto, debes asegurarte de que los ejemplos de código sean utilizables, sigan las mejores prácticas generalmente aceptadas y no hagan nada que pueda hacer que una aplicación sea insegura, ineficiente, abultada o inaccesible.
+Si el ejemplo de código no es ejecutable o no es apto para producción, incluye una advertencia en un comentario de código y en el texto explicativo; por ejemplo, si es solo un fragmento y no un ejemplo completo, deja esto claro. Esto también significa que debes proporcionar toda la información necesaria para ejecutar el ejemplo, incluidas las dependencias y la información de configuración.
 
-Los ejemplos de código que agregues a MDN Web Docs deben ser:
+Los ejemplos de código deben ser lo suficientemente sencillos para ser comprensibles, pero lo suficientemente complejos para hacer algo interesante y, preferiblemente, útiles.
+El objetivo no es necesariamente producir código eficiente e ingenioso que impresione a expertos y tenga una gran funcionalidad, sino más bien compartir ejemplos de trabajo reducidos que se puedan entender y aprender lo más rápido posible.
 
-- lo suficientemente simples como para ser comprensibles, pero
-- lo suficientemente complejos como para hacer algo interesante, y preferiblemente útiles.
+Algunas directrices más generales incluyen:
 
-Existe una consideración general que debes tener en cuenta: **Los lectores copiarán y pegarán el fragmento de código en su propio código y es posible que lo utilicen en producción.**
-
-Por lo tanto, debes asegurarte de que el ejemplo de código sea utilizable, siga las mejores prácticas generalmente aceptadas y **no** realice acciones que puedan hacer que una aplicación sea insegura, ineficiente, abultada o inaccesible. Si el ejemplo de código no es ejecutable o no es apto para producción, asegúrate de incluir una advertencia en un comentario de código y en el texto explicativo; por ejemplo, si es solo un fragmento y no un ejemplo completo, deja esto claro. Esto también significa que debes proporcionar **toda** la información necesaria para ejecutar el ejemplo, incluidas las dependencias e información de configuración.
-
-Los ejemplos de código deben ser lo más autosuficientes y comprensibles posible. El objetivo no es necesariamente producir código eficiente e ingenioso que impresione a expertos y tenga una gran funcionalidad, sino más bien producir ejemplos de trabajo reducidos que se puedan entender lo más rápido posible.
-
-Algunas mejores prácticas adicionales incluyen:
-
-- El ejemplo de código debe ser corto y mostrar idealmente solo la característica que te interesa de inmediato.
-- **Solo** incluye el código que es esencial para el ejemplo. Una gran cantidad de código no relevante puede distraer o confundir fácilmente al lector. Si deseas proporcionar un ejemplo completo y más extenso, colócalo en uno de nuestros [repositorios de GitHub](https://github.com/mdn/) (o en JSBin, Codepen u otro similar) y luego proporciona el enlace a la versión completa arriba o debajo del fragmento.
-- No incluyas código innecesario del lado del servidor, bibliotecas, marcos de trabajo (_frameworks_), preprocesadores y otras dependencias similares. Esto dificulta la portabilidad y la comprensión del código. Usa código simple siempre que sea posible.
-- No asumas el conocimiento de los lectores sobre bibliotecas, marcos, preprocesadores u otras características no nativas. Por ejemplo, utiliza nombres de clases que tengan sentido dentro del ejemplo en lugar de nombres de clases que tengan sentido para usuarios de BEM o Bootstrap.
-- Escribe tu código de manera limpia y comprensible, incluso si no es la forma más eficiente de escribirlo.
+- Los ejemplos de código deben ser cortos y, idealmente, mostrar solo la característica que te interesa de inmediato.
+- Escribe tu código para que sea lo más comprensible posible, incluso si no es la forma más eficiente de escribirlo.
+- No incluyas código innecesario del lado del servidor, bibliotecas, marcos de trabajo (_frameworks_), preprocesadores y otras dependencias similares. Hacen que el código sea menos portátil y más difícil de ejecutar y entender. Usa código simple siempre que sea posible.
+- No asumas el conocimiento de los lectores sobre bibliotecas, marcos de trabajo, preprocesadores u otras características no nativas. Por ejemplo, usa nombres de clases que tengan sentido dentro del ejemplo en lugar de nombres de clases que tengan sentido para usuarios de BEM o Bootstrap.
 - Sé inclusivo en tus ejemplos de código; considera que los lectores de MDN provienen de todo el mundo y son diversos en sus etnias, religiones, edades, géneros, etc. Asegúrate de que el texto en los ejemplos de código refleje esa diversidad y sea inclusivo para todas las personas.
-- No uses malas prácticas por brevedad (como elementos de presentación como {{HTMLElement("big")}} o {{domxref("Document.write", "document.write()")}}); hazlo correctamente.
-- En el caso de demostraciones de API, si estás utilizando múltiples API juntas, señala qué APIs se incluyen y qué características provienen de cada una.
+- No uses características obsoletas por brevedad (como elementos de presentación como {{HTMLElement("big")}} o {{domxref("Document.write", "document.write()")}}); hazlo correctamente.
+- En el caso de demostraciones de API, si estás utilizando múltiples API juntas, señala qué API se incluyen y qué características provienen de cada una.
 
-## Pautas para el formato
+### Compatibilidad con navegadores
 
-Las opiniones sobre la correcta indentación, espaciado y longitud de líneas siempre han sido controvertidas. Las discusiones sobre estos temas son una distracción para crear y mantener el contenido.
+Al crear ejemplos de código para una tecnología que aún no está disponible en todos los navegadores principales, considera usar la [detección de características](/es/docs/Learn_web_development/Extensions/Testing/Feature_detection) para recurrir a un comportamiento más simple o informar al usuario que su navegador aún no es compatible.
+No especifiques los navegadores compatibles y sus versiones en comentarios de código o prosa, ya que esta información queda obsoleta rápidamente.
 
-En MDN Web Docs, utilizamos [Prettier](https://prettier.io/) como formateador de código para mantener consistente el estilo de código (y evitar discusiones fuera de tema). Puedes consultar nuestro [archivo de configuración](https://github.com/mdn/content/blob/main/.prettierrc.json) para conocer las reglas actuales y leer la [documentación de Prettier](https://prettier.io/docs/en/index.html).
+## Estilo y formato de código de MDN
 
-Prettier formatea todo el código y mantiene el estilo consistente. Sin embargo, hay algunas reglas adicionales que debes seguir.
+Las opiniones sobre la indentación, el espacio en blanco y la longitud de línea correctos siempre han sido controvertidas. Las discusiones sobre estos temas son una distracción para crear y mantener el contenido.
+En MDN Web Docs, usamos [Prettier](https://prettier.io/) como formateador de código para mantener el estilo de código consistente y evitar discusiones fuera de tema. Puedes consultar nuestro [archivo de configuración](https://github.com/mdn/content/blob/main/.prettierrc.json) para conocer las reglas actuales y leer la [documentación de Prettier](https://prettier.io/docs/index.html).
 
-Estas pautas de MDN Web Docs para formatear ejemplos de código también son buenas prácticas cuando estás codificando.
+Además del formato automatizado, hay algunas otras reglas para los ejemplos de código en MDN para que el resultado se represente bien.
 
-### Elección de un lenguaje de sintaxis
+### Elige el lenguaje correcto
 
-Para garantizar el formato adecuado y el resaltado de sintaxis de los bloques de código, los escritores deben especificar el lenguaje del bloque de código que están escribiendo. Consulta [Bloques de código de ejemplo en el formato MDN Markdown](/es/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#example_code_blocks) para obtener una lista de los lenguajes admitidos por MDN, así como detalles sobre cómo solicitar un nuevo lenguaje.
+Para garantizar el formato adecuado y el resaltado de sintaxis de los bloques de código, especifica correctamente el lenguaje del bloque de código.
+Consulta [Bloques de código de ejemplo en Markdown de MDN](/es/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#example_code_blocks) para obtener una lista de los lenguajes compatibles con MDN, así como detalles sobre cómo solicitar un nuevo lenguaje.
 
-Si el bloque de código es pseudocódigo, la salida de un comando, o de alguna manera no es un lenguaje de programación, establece explícitamente el lenguaje como `plain`.
+Si el bloque de código es pseudocódigo, la salida de un comando o, de alguna manera, no es un lenguaje de programación, establece el lenguaje en `plain`:
+
+````md
+```plain
+StaleElementReferenceException: The element reference of ABD-123 is stale…
+```
+````
 
 > [!WARNING]
 > Si el lenguaje deseado aún no es compatible con MDN, **no** establezcas el lenguaje de un bloque de código en un lenguaje similar, ya que hacerlo puede tener efectos secundarios no deseados con el formato de Prettier y el resaltado de sintaxis.
 
 ### Longitud de línea de código
 
-- Las líneas de código no deben ser tan largas que requieran desplazamiento horizontal para leerlas.
-- Como práctica recomendada, mantiene las líneas de código hasta un máximo de 80 caracteres de longitud (64 para [ejemplos interactivos](https://github.com/mdn/interactive-examples)).
-- Divide las líneas largas en puntos naturales de ruptura por el bien de la legibilidad, pero no a expensas de las mejores prácticas.
-
+Las líneas de código no deben ser tan largas que requieran desplazamiento horizontal para leerlas.
+Divide las líneas largas en puntos naturales de ruptura por el bien de la legibilidad, pero no a expensas de las mejores prácticas.
 Por ejemplo, esto no es ideal:
 
 ```js example-bad
@@ -91,106 +90,70 @@ Incluso mejor es usar una plantilla literal:
 const tommyCat = `Dijo Tommy el Gato mientras retrocedía para limpiar cualquier materia extraña
   que pudiera haberse metido en su poderosa garganta. Más de una rata callejera gorda
   había encontrado su muerte mientras miraba fijamente el cavernoso cañón de esta
-  impresionante máquina merodeadora`";
-```
-
-```js example-good
-if (
-  obj.CONDITION ||
-  obj.OTHER_CONDITION ||
-  obj.SOME_OTHER_CONDITION ||
-  obj.YET_ANOTHER_CONDITION
-) {
-  /* algo */
-}
-
-const toolkitProfileService = Components.classes[
-  "@mozilla.org/toolkit/profile-service;1"
-].createInstance(Components.interfaces.nsIToolkitProfileService);
+  impresionante máquina merodeadora.`;
 ```
 
 ### Altura del bloque de código
 
-Los bloques de código deben ser tan largos como sea necesario, pero no más. Idealmente, apunta a algo corto, como 15-25 líneas. Si un bloque de código va a ser mucho más largo, considera mostrar solo el fragmento más útil y enlaza al ejemplo completo en un repositorio de GitHub o CodePen, por ejemplo.
+Los bloques de código deben ser tan largos como sea necesario, pero no más. Idealmente, apunta a algo corto, como 15-25 líneas. Si un bloque de código va a ser mucho más largo, considera mostrar la parte más útil y enlaza a un ejemplo completo en un repositorio de GitHub, Gist o CodePen, por ejemplo.
 
-#### Formato de código en línea
+### Formato de código en línea
 
-Utiliza la sintaxis de código en línea (\`) para marcar los nombres de funciones, nombres de variables y nombres de métodos. Por ejemplo: "la función `frenchText()`".
+Usa la sintaxis de código en línea para marcar nombres de funciones, nombres de variables y nombres de métodos. Por ejemplo: "la función `frenchText()`" se escribe en markdown como:
 
-**Los nombres de los métodos deben ir seguidos de un par de paréntesis**: por ejemplo, `doSomethingUseful()`. Los paréntesis ayudan a diferenciar los métodos de otros términos de código.
+```md
+la función `frenchText()`
+```
 
-## Pautas para una representación adecuada
+Los nombres de los métodos deben ir seguidos de un par de paréntesis: por ejemplo, `doSomethingUseful()`. Los paréntesis ayudan a diferenciar los métodos de otros términos de código.
 
-Estas pautas deben seguirse para asegurar que los ejemplos de código que escribas se visualicen correctamente en MDN Web Docs. También debes considerar la capacidad de respuesta al escribir ejemplos de código para que también sean útiles en dispositivos móviles.
+## Directrices para una representación adecuada
+
+Debes seguir estas directrices para asegurarte de que los ejemplos de código que escribas se muestren correctamente en MDN Web Docs. También debes considerar la capacidad de respuesta al escribir ejemplos de código para que también sean útiles en dispositivos móviles.
 
 ### Tamaño del ejemplo de código renderizado
 
-- **Establece el ancho al 100%**: El panel de contenido principal en MDN Web Docs tiene aproximadamente 700px de ancho en escritorio, por lo que los ejemplos de código incrustados deben lucir bien con ese ancho.
+- **Establece el ancho al 100%**: El panel de contenido principal en MDN Web Docs tiene aproximadamente 700px de ancho en el escritorio, por lo que los ejemplos de código incrustados deben verse bien con ese ancho.
 - **Establece la altura por debajo de los 700px**: Recomendamos mantener esta altura para el ancho del ejemplo de código renderizado para una legibilidad máxima en pantalla.
 
-### Color en el ejemplo de código renderizado
+### Resaltar ejemplos como buenos o malos
 
-- Usa palabras clave para los colores primarios y otros colores "básicos", por ejemplo:
+Notarás en esta página que los bloques de código que representan buenas prácticas a seguir se representan con una marca de verificación verde en la esquina derecha, y los bloques de código que demuestran malas prácticas se representan con una cruz blanca en un círculo rojo.
 
-  ```css example-good
-  color: black;
-  color: white;
-  color: red;
-  ```
+Puedes seguir el mismo estilo al escribir ejemplos de código. No es necesario que uses este estilo en todas partes, solo en lugares donde quieras destacar específicamente el buen y mal uso en los ejemplos de código.
 
-- Utiliza `rgb()` para colores más complejos (incluidos los semitransparentes):
+Un bloque de código se escribe en markdown usando "vallas de código" para delimitar el bloque de código, seguido del lenguaje en la cadena de información. Por ejemplo:
 
-  ```css example-good
-  color: rgb(0 0 0 / 50%);
-  color: rgb(248 242 230);
-  ```
-
-- Para colores hexadecimales, utiliza la forma corta cuando sea relevante:
-
-  ```css example-good
-  color: #058ed9;
-  color: #a39a92c1;
-  color: #ff0;
-  color: #fbfa;
-  ```
-
-  ```css-nolint example-bad
-  color: #ffff00;
-  color: #ffbbffaa;
-  ```
-
-### Marcar ejemplos renderizados como buenos o malos
-
-Notarás en esta página que los bloques de código que representan buenas prácticas están renderizados con una marca de verificación verde en la esquina derecha, y los bloques de código que demuestran malas prácticas están renderizados con una cruz blanca en un círculo rojo.
-
-Puedes seguir el mismo estilo al escribir ejemplos de código. No es necesario utilizar este estilo en todas partes, solo en páginas donde desees destacar específicamente buenas y malas prácticas en tus ejemplos de código.
-
-Para lograr esta representación, utiliza "vallas de código" para delimitar el bloque de código, seguido de la cadena de información del lenguaje. Por ejemplo:
-
+````md
 ```js
 function myFunc() {
   console.log("Hello!");
 }
 ```
+````
 
-Para representar el bloque de código como un ejemplo bueno o malo, agrega `example-good` o `example-bad` después de la cadena de información del lenguaje, de la siguiente manera:
+Para representar el bloque de código como un ejemplo bueno o malo, agrega `example-good` o `example-bad` después de la cadena del lenguaje, así:
 
 ````md
 ```html example-good
-<p></p>
+<p>Buen ejemplo</p>
 ```
 
 ```html example-bad
-<p></p>
+<p>Mal ejemplo</p>
 ```
 ````
 
 Estos se representarán como:
 
 ```html example-good
-<p class="brush: js example-good"></p>
+<p>Buen ejemplo</p>
 ```
 
 ```html example-bad
-<p class="brush: js example-bad"></p>
+<p>Mal ejemplo</p>
 ```
+
+## Directrices para usar texto de marcador de posición
+
+Usa el texto de marcador de posición lorem-ipsum generado desde [lipsum.com](https://www.lipsum.com/) o el complemento de VS Code [Lorem ipsum](https://marketplace.visualstudio.com/items?itemName=Tyriar.lorem-ipsum). El texto estándar de lorem-ipsum se incluye en nuestra configuración del verificador ortográfico, por lo que no se reportará como errores tipográficos en los IDE o en las pruebas durante la revisión de código. Usar un texto de marcador de posición consistente hace que el código de ejemplo sea más fácil de revisar, especialmente cuando aparece repetidamente. También ayuda a mantener los ejemplos claramente para fines de ilustración y evita distraer a los lectores con contenido irrelevante.

--- a/files/es/mdn/writing_guidelines/code_style_guide/javascript/index.md
+++ b/files/es/mdn/writing_guidelines/code_style_guide/javascript/index.md
@@ -1,98 +1,83 @@
 ---
-title: Pautas para dar estilos a ejemplos de código JavaScript
+title: Directrices para escribir ejemplos de código JavaScript
+short-title: Ejemplos de JavaScript
 slug: MDN/Writing_guidelines/Code_style_guide/JavaScript
-original_slug: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/JavaScript
+l10n:
+  sourceCommit: 359d3c9cea9b2caa691c63ed3b01714ad4416372
 ---
 
-{{MDNSidebar}}
+Las siguientes directrices cubren la escritura de código de ejemplo JavaScript para MDN Web Docs. Este artículo es una lista de reglas para escribir ejemplos concisos que sean comprensibles para la mayor cantidad de personas posible.
 
-Las siguientes pautas cubren la escritura de código de ejemplo JavaScript para los documentos web de MDN.
-Este artículo es una lista de reglas para escribir ejemplos concisos que sean comprensibles para la mayor cantidad de personas posible.
+## Directrices generales para ejemplos de código JavaScript
 
-## Pautas generales para ejemplos de código JavaScript
+Esta sección explica las directrices generales a tener en cuenta al escribir ejemplos de código JavaScript. Las secciones posteriores cubrirán detalles más específicos.
 
-Esta sección explica las pautas generales a tener en cuenta al escribir ejemplos de código JavaScript.
-Las secciones posteriores cubrirán detalles más específicos.
+### Elección de un formato
 
-### Eligiendo un formato
+Las opiniones sobre la sangría correcta, el espacio en blanco y las longitudes de línea siempre han sido controvertidas. Las discusiones sobre estos temas son una distracción para la creación y mantenimiento de contenido.
 
-Opiniones sobre la sangría correcta, espacio en blanco, y las longitudes de línea siempre han sido controvertidas.
-Las discusiones sobre estos temas son una distracción para la creación y mantenimiento de contenido.
+En MDN Web Docs, usamos [Prettier](https://prettier.io/) como formateador de código para mantener el estilo del código consistente (y para evitar discusiones fuera de tema). Puedes consultar nuestro [archivo de configuración](https://github.com/mdn/content/blob/main/.prettierrc.json) para conocer las reglas actuales, y leer la [documentación de Prettier](https://prettier.io/docs/index.html).
 
-En documentos web de MDN, usamos [Prettier](https://prettier.io/) como formateador de código para mantener la consistencia del estilo del código (y para evitar discusiones fuera del tema).
-Puedes consultar nuestro [Archivo de configuración](https://github.com/mdn/content/blob/main/.prettierrc.json) para conocer las normas vigentes, y leer la [Documentación Prettier](https://prettier.io/docs/en/index.html).
+Prettier formatea todo el código y mantiene el estilo consistente. Sin embargo, hay algunas reglas adicionales que debes seguir.
 
-Prettier formatea todo el código y mantiene el estilo consistente. Sin embargo, hay algunas reglas adicionales que usted debe seguir.
+### Usa características modernas de JavaScript cuando estén soportadas
 
-### Uso de características modernas de JavaScript
+Puedes usar nuevas características una vez que cada navegador principal — Chrome, Edge, Firefox y Safari — las soporte (también conocido como {{glossary("Baseline", "Línea de base")}}).
 
-Usted puede usar nuevas funciones una vez que cada navegador principal — Chrome, Edge, Firefox, y Safari — las soporte.
+Esta regla no se aplica a la característica de JavaScript que se está documentando en la página (que se dicta en su lugar por los [criterios de inclusión](/es/docs/MDN/Writing_guidelines/Criteria_for_inclusion)). Por ejemplo, puedes documentar características [no estándar o experimentales](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete) y escribir ejemplos completos que demuestren su comportamiento, pero debes abstente de usar estas características en las demostraciones para otras características no relacionadas, como una API web.
 
-### Espaciado y sangría
+## Arrays
 
-Marque la sangría con _2 espacios_. No use el carácter de tabulación. El carácter de fin de línea es `\n`, la convención de Unix.
-Para ayudarle, hemos incluido un archivo [`.editorconfig`](https://editorconfig.org/) en el repositorio.
-Muchos editores leen su contenido y lo utilizan para configurar su comportamiento.
+### Creación de arrays
 
-## Matrices
+Para crear arrays, usa literales y no constructores.
 
-### Creación de matrices
-
-Para crear matrices, use literales y no constructores.
-
-Crear matrices como esta:
+Crea arrays así:
 
 ```js example-good
-const ciudadesVisitadas = [];
+const visitedCities = [];
 ```
 
-No hacer esto al crear matrices:
+No hagas esto al crear arrays:
 
 ```js example-bad
-const ciudadesVisitadas = new Array(length);
+const visitedCities = new Array(length);
 ```
 
 ### Adición de elementos
 
-Al agregar elementos a una matriz, use [`push()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/push) y no asignación directa.
-Considere la siguiente matriz:
+Al agregar elementos a un array, usa [`push()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/push) y no asignación directa. Considera el siguiente array:
 
 ```js
-const mascotas = [];
+const pets = [];
 ```
 
-Adicione elementos a la matriz de esta forma:
+Agrega elementos al array así:
 
 ```js example-good
-mascotas.push("gato");
+pets.push("cat");
 ```
 
-No adicione elementos a la matriz de esta forma:
+No agregues elementos al array así:
 
 ```js example-bad
-mascotas[mascotas.length] = "gato";
+pets[pets.length] = "cat";
 ```
 
 ## Métodos asíncronos
 
-Escribir código asincrónico mejora el rendimiento y debe usarse cuando sea posible.
-En particular, puede utilizar:
+Escribir código asíncrono mejora el rendimiento y debe usarse cuando sea posible. En particular, puedes usar:
 
-- [Promise](/es/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+- [Promesas](/es/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 - [`async`](/es/docs/Web/JavaScript/Reference/Statements/async_function)/[`await`](/es/docs/Web/JavaScript/Reference/Operators/await)
 
-Cuando ambas técnicas son posibles, preferimos usar la sintaxis más simple `async`/`await`.
-Desafortunadamente, no se puede utilizar `await` en el nivel superior a menos que esté en un módulo ECMAScript.
-Los módulos CommonJS utilizados por Node.js no son módulos ES.
-Si su ejemplo está destinado a ser usado en todas partes, evite el nivel superior `await`.
+Cuando ambas técnicas son posibles, preferimos usar la sintaxis más simple `async`/`await`. Desafortunadamente, no puedes usar `await` en el nivel superior a menos que estés en un módulo ECMAScript. Los módulos CommonJS usados por Node.js no son módulos ES. Si tu ejemplo está destinado a ser usado en todas partes, evita el `await` de nivel superior.
 
 ## Comentarios
 
-Los comentarios son fundamentales para escribir buenos ejemplos de código.
-Aclaran la intención del código y ayudan a los desarrolladores a entenderlo.
-Préstale especial atención.
+Los comentarios son críticos para escribir buenos ejemplos de código. Aclaran la intención del código y ayudan a los desarrolladores a entenderlo. Presta especial atención a ellos.
 
-- Si el propósito o la lógica del código no es obvio, añade un comentario con tu intención, como se muestra debajo:
+- Si el propósito o la lógica del código no es obvio, añade un comentario con tu intención, como se muestra abajo:
 
   ```js example-good
   let total = 0;
@@ -110,121 +95,109 @@ Préstale especial atención.
 
   // Bucle de 1 a 4
   for (let i = 0; i < 4; i++) {
-    // Adicionar valor al total
+    // Agrega valor al total
     total += arr[i];
   }
   ```
 
-- Los comentarios tampoco son necesarios cuando las funciones tienen nombres explícitos que describen lo que están haciendo. Escriba:
+- Los comentarios tampoco son necesarios cuando las funciones tienen nombres explícitos que describen lo que están haciendo. Escribe:
 
   ```js example-good
   closeConnection();
   ```
 
-  No escriba:
+  No escribas:
 
   ```js example-bad
-  closeConnection(); // Cierra la conexión
+  closeConnection(); // Cerrando la conexión
   ```
 
-### Usar comentarios de una sola línea
+### Usa comentarios de una sola línea
 
 Los comentarios de una sola línea se marcan con `//`, a diferencia de los comentarios en bloque encerrados entre `/* … */`.
 
-En general, use comentarios de una sola línea para comentar el código.
-Los desarrolladores deben marcar cada línea del comentario con `//`, para que sea más fácil notar visualmente el código comentado.
-Además, esta convención permite comentar secciones de código utilizando `/* … */` mientras se depura.
+En general, usa comentarios de una sola línea para comentar el código. Los escritores deben marcar cada línea del comentario con `//`, para que sea más fácil notar visualmente el código comentado. Además, esta convención permite comentar secciones de código usando `/* … */` mientras se depura.
 
-- Deje un espacio entre las barras y el comentario.
-  Comienza con una letra mayúscula, como una oración, pero no termines el comentario con un punto.
+- Deja un espacio entre las barras y el comentario. Comienza con una letra mayúscula, como una oración, pero no termines el comentario con un punto.
 
   ```js example-good
-  // Este es un comentario de una sola línea bien escrito.
+  // Este es un comentario de una sola línea bien escrito
   ```
 
-- Si un comentario no comienza inmediatamente después de un nuevo nivel de sangría, agregue una línea vacía y luego agregue el comentario.
-  Creará un bloque de código, haciendo obvio a qué se refiere el comentario.
-  Además, coloque sus comentarios en líneas separadas antes del código al que se refieren.
-  Esto se muestra en el siguiente ejemplo:
+- Si un comentario no comienza inmediatamente después de un nuevo nivel de sangría, agrega una línea vacía y luego agrega el comentario. Creará un bloque de código, haciendo obvio a qué se refiere el comentario. Además, pon tus comentarios en líneas separadas antes del código al que se refieren. Esto se muestra en el siguiente ejemplo:
 
   ```js example-good
-  function verificar(precioMercancias, precioEnvio, impuestos) {
+  function checkout(goodsPrice, shipmentPrice, taxes) {
     // Calcula el precio total
-    const total = precioMercancias + precioEnvio + impuestos;
+    const total = goodsPrice + shipmentPrice + taxes;
 
-    // Crea y agrega un nuevo párrafo al documento
-    const parrafo = document.createElement("p");
-    parrafo.textContent = `El precio total es ${total}`;
-    document.body.appendChild(parrafo);
+    // Crea y añade un nuevo párrafo al documento
+    const para = document.createElement("p");
+    para.textContent = `El precio total es ${total}`;
+    document.body.appendChild(para);
   }
   ```
 
 ### Salida de registros
 
-- En el código destinado a ejecutarse en un entorno de producción, rara vez necesita comentar cuando registra algunos datos.
-  En ejemplos de código, a menudo usamos `console.log()`, `console.error()`, o funciones similares para mostrar valores importantes.
-  Para ayudar al lector a comprender lo que sucederá sin ejecutar el código, puede colocar un comentario _después_ de la función con el registro que se producirá. Escriba:
+- En el código destinado a ejecutarse en un entorno de producción, rara vez necesitas comentar cuando registras algunos datos. En ejemplos de código, a menudo usamos `console.log()`, `console.error()`, o funciones similares para mostrar valores importantes. Para ayudar al lector a comprender lo que sucederá sin ejecutar el código, puedes poner un comentario _después_ de la función con el registro que se producirá. Escribe:
 
   ```js example-good
-  function funcionEjemplo(canastaDeFrutas) {
-    console.log(canastaDeFrutas); // ['banana', 'mango', 'naranja']
+  function exampleFunc(fruitBasket) {
+    console.log(fruitBasket); // ['banana', 'mango', 'orange']
   }
   ```
 
-  No escriba:
+  No escribas:
 
   ```js example-bad
-  function funcionEjemplo(canastaDeFrutas) {
-    // Registro: ['banana', 'mango', 'naranja']
-    console.log(canastaDeFrutas);
+  function exampleFunc(fruitBasket) {
+    // Registros: ['banana', 'mango', 'orange']
+    console.log(fruitBasket);
   }
   ```
 
-- En caso de que la línea se vuelva demasiado larga, coloque el comentario _después_ de la función, así:
+- En caso de que la línea se vuelva demasiado larga, pon el comentario _después_ de la función, así:
 
   ```js example-good
-  function funcionEjemplo(canastaDeFrutas) {
-    console.log(canastaDeFrutas);
-    // ['banana', 'mango', 'naranja', 'manzana', 'pera', 'durian', 'limón']
+  function exampleFunc(fruitBasket) {
+    console.log(fruitBasket);
+    // ['banana', 'mango', 'orange', 'apple', 'pear', 'durian', 'lemon']
   }
   ```
 
 ### Comentarios de varias líneas
 
-Los comentarios cortos suelen ser mejores, así que trate de mantenerlos en una línea de 60 a 80 caracteres.
-Si esto no es posible, utilice `//` al principio de cada línea:
+Los comentarios cortos suelen ser mejores, así que trata de mantenerlos en una línea de 60 a 80 caracteres. Si esto no es posible, usa `//` al principio de cada línea:
 
 ```js example-good
 // Este es un ejemplo de un comentario de varias líneas.
-// La función imaginaria que sigue, tiene algo inusual.
-// Limitaciones que quiero llamar.
+// La función imaginaria que sigue tiene algunas inusuales
+// limitaciones que quiero señalar.
 // Limitación 1
 // Limitación 2
 ```
 
-No use `/* … */`:
+No uses `/* … */`:
 
 ```js example-bad
 /* Este es un ejemplo de un comentario de varias líneas.
-  La función imaginaria que sigue, tiene algo inusual.
-  Limitaciones que quiero llamar.
+  La función imaginaria que sigue tiene algunas inusuales
+  limitaciones que quiero señalar.
   Limitación 1
   Limitación 2 */
 ```
 
-### Usar comentarios para marcar puntos suspensivos
+### Usa comentarios para marcar puntos suspensivos
 
-Omitir código redundante usando puntos suspensivos (…) es necesario para mantener los ejemplos cortos.
-Aun así, los escritores deben hacerlo cuidadosamente, ya que los desarrolladores con frecuencia copian y pegan ejemplos en su código, y todas nuestras muestras de código JavaScript deben ser válidas.
+Omitir código redundante usando puntos suspensivos (…) es necesario para mantener los ejemplos cortos. Aun así, los escritores deben hacerlo con cuidado, ya que los desarrolladores con frecuencia copian y pegan ejemplos en su código, y todas nuestras muestras de código JavaScript deben ser válidas.
 
-En JavaScript, debes poner los puntos suspensivos (`…`) en un comentario.
-Cuando sea posible, indique qué acción se espera que agregue quien reutilice este fragmento.
+En JavaScript, debes poner los puntos suspensivos (`…`) en un comentario. Cuando sea posible, indica qué acción se espera que agregue quien reutilice este fragmento.
 
-Usar un comentario para los puntos suspensivos (…) es mas explícito, previene errores cuando un desarrollador copia y pega un código de muestra.
-Escriba:
+Usar un comentario para los puntos suspensivos (…) es más explícito, previniendo errores cuando un desarrollador copia y pega un código de muestra. Escribe:
 
 ```js example-good
-function funcionEjemplo() {
+function exampleFunc() {
   // Agrega tu código aquí
   // …
 }
@@ -233,21 +206,19 @@ function funcionEjemplo() {
 No uses puntos suspensivos (…) así:
 
 ```js example-bad
-function funcionEjemplo() {
+function exampleFunc() {
   …
 }
 ```
 
 ### Comentar parámetros
 
-Al escribir código, generalmente omite parámetros que no necesitas.
-Pero en algunos ejemplos de código, quieres demostrar que no utilizaste algunos posibles parámetros.
+Al escribir código, generalmente omites parámetros que no necesitas. Pero en algunos ejemplos de código, quieres demostrar que no usaste algunos posibles parámetros.
 
-Para hacerlo, utilice `/* … */` en la lista de parámetros.
-Esta es una excepción a la regla de usar solo comentarios de una sola línea. (`//`).
+Para hacerlo, usa `/* … */` en la lista de parámetros. Esta es una excepción a la regla de usar solo comentarios de una sola línea (`//`).
 
 ```js
-array.forEach((valor /* , índice, matriz */) => {
+array.forEach((value /* , index, array */) => {
   // …
 });
 ```
@@ -256,37 +227,36 @@ array.forEach((valor /* , índice, matriz */) => {
 
 ### Nombres de funciones
 
-Para nombres de funciones, use camelCase, comenzando con un carácter en minúscula.
-Utilice nombres concisos, legibles por humanos y semánticos cuando sea apropiado.
+Para nombres de funciones, usa {{Glossary("camel_case", "camel case")}}, comenzando con un carácter en minúscula. Usa nombres concisos, legibles y semánticos cuando sea apropiado.
 
 El siguiente es un ejemplo correcto de un nombre de función:
 
 ```js example-good
-function decirHola() {
-  console.log("Hola!");
+function sayHello() {
+  console.log("Hello!");
 }
 ```
 
-No use nombres de funciones como estos:
+No uses nombres de funciones como estos:
 
 ```js example-bad
-function DecirHola() {
-  console.log("Hola!");
+function SayHello() {
+  console.log("Hello!");
 }
 
-function hazlo() {
-  console.log("Hola!");
+function doIt() {
+  console.log("Hello!");
 }
 ```
 
-### Declaración de funciones
+### Declaraciones de funciones
 
-- Siempre que sea posible, use la declaración de función sobre expresiones de función para definir funciones.
+- Cuando sea posible, usa la declaración de función sobre expresiones de función para definir funciones.
 
   Esta es la forma recomendada de declarar una función:
 
   ```js example-good
-  function suma(a, b) {
+  function sum(a, b) {
     return a + b;
   }
   ```
@@ -294,32 +264,30 @@ function hazlo() {
   Esta no es una buena forma de declarar una función:
 
   ```js example-bad
-  let suma = function (a, b) {
+  let sum = function (a, b) {
     return a + b;
   };
   ```
 
-- Al usar funciones anónimas como callback (una función pasada a otra invocación de método), si no necesitas acceder a `this`, use una función de flecha para hacer el código más corto y limpio.
+- Al usar funciones anónimas como callback (una función pasada a otra invocación de método), si no necesitas acceder a `this`, usa una función de flecha para hacer el código más corto y limpio.
 
   Esta es la forma recomendada:
 
   ```js example-good
-  const numeros = [1, 2, 3, 4];
-  const suma = numeros.reduce((a, b) => a + b);
+  const array = [1, 2, 3, 4];
+  const sum = array.reduce((a, b) => a + b);
   ```
 
   En lugar de esto:
 
   ```js example-bad
-  const numeros = [1, 2, 3, 4];
-  const suma = numeros.reduce(function (a, b) {
+  const array = [1, 2, 3, 4];
+  const sum = array.reduce(function (a, b) {
     return a + b;
   });
   ```
 
-- Considere evitar usar la función de flecha para asignar una función a un identificador.
-  En particular, no utilice funciones flecha para los métodos.
-  Use declaración de funciones con la palabra clave `function`:
+- Considera evitar usar la función de flecha para asignar una función a un identificador. En particular, no uses funciones flecha para los métodos. Usa declaraciones de funciones con la palabra clave `function`:
 
   ```js example-good
   function x() {
@@ -327,7 +295,7 @@ function hazlo() {
   }
   ```
 
-  No lo hagas así:
+  No hagas:
 
   ```js example-bad
   const x = () => {
@@ -335,16 +303,16 @@ function hazlo() {
   };
   ```
 
-- Cuando utilice funciones flecha, utilice [retorno implícito](/es/docs/Web/JavaScript/Reference/Functions/Arrow_functions#cuerpo_de_función) (también conocido como _cuerpo conciso_) cuando sea posible:
+- Cuando uses funciones flecha, usa [retorno implícito](/es/docs/Web/JavaScript/Reference/Functions/Arrow_functions#cuerpo_de_función) (también conocido como _cuerpo de expresión_) cuando sea posible:
 
   ```js example-good
-  matriz.map((e) => e.id);
+  arr.map((e) => e.id);
   ```
 
   Y no:
 
   ```js example-bad
-  matriz.map((e) => {
+  arr.map((e) => {
     return e.id;
   });
   ```
@@ -353,47 +321,43 @@ function hazlo() {
 
 ### Inicialización de bucle
 
-Cuando los [bucles](/es/docs/Learn_web_development/Core/Scripting/Loops) son requeridos, elegir el apropiado entre [`for(;;)`](/es/docs/Web/JavaScript/Reference/Statements/for), [`for...of`](/es/docs/Web/JavaScript/Reference/Statements/for...of), [`while`](/es/docs/Web/JavaScript/Reference/Statements/while), etc.
+Cuando los [bucles](/es/docs/Learn_web_development/Core/Scripting/Loops) son necesarios, elige el apropiado entre [`for(;;)`](/es/docs/Web/JavaScript/Reference/Statements/for), [`for...of`](/es/docs/Web/JavaScript/Reference/Statements/for...of), [`while`](/es/docs/Web/JavaScript/Reference/Statements/while), etc.
 
-- Al iterar a través de todos los elementos de la colección, evite usar el clásico bucle `for (;;)`; es preferible `for...of` o `forEach()`.
-  Tenga en cuenta que si está utilizando una colección que no es un `Array`, tienes que comprobar que `for...of` es realmente compatible (requiere que la variable sea iterable), o que el método `forEach()` está realmente presente.
+- Al iterar a través de todos los elementos de la colección, evita usar el bucle clásico `for (;;)`; prefiere `for...of` o `forEach()`. Ten en cuenta que si estás usando una colección que no es un `Array`, tienes que comprobar que `for...of` realmente está soportado (requiere que la variable sea iterable), o que el método `forEach()` realmente está presente.
 
-  Use `for...of`:
+  Usa `for...of`:
 
   ```js example-good
-  const perros = ["Rex", "Lassie"];
-  for (const perro of perros) {
-    console.log(perro);
+  const dogs = ["Rex", "Lassie"];
+  for (const dog of dogs) {
+    console.log(dog);
   }
   ```
 
   O `forEach()`:
 
   ```js example-good
-  const perros = ["Rex", "Lassie"];
-  perros.forEach((perro) => {
-    console.log(perro);
+  const dogs = ["Rex", "Lassie"];
+  dogs.forEach((dog) => {
+    console.log(dog);
   });
   ```
 
-  No use `for (;;)` — no solo tienes que agregar un índice extra, `i`, sino que también tienes que rastrear la longitud de la matriz.
-  Esto puede ser propenso a errores para principiantes.
+  No uses `for (;;)` — no solo tienes que agregar un índice extra, `i`, sino que también tienes que rastrear la longitud del array. Esto puede ser propenso a errores para principiantes.
 
   ```js example-bad
-  const perros = ["Rex", "Lassie"];
-  for (let i = 0; i < perros.length; i++) {
-    console.log(perros[i]);
+  const dogs = ["Rex", "Lassie"];
+  for (let i = 0; i < dogs.length; i++) {
+    console.log(dogs[i]);
   }
   ```
 
-- Asegúrese de definir correctamente el inicializador utilizando la palabra clave `const` para `for...of` o `let` para los otros bucles.
-  No lo omitas.
-  Estos son ejemplos correctos:
+- Asegúrate de definir correctamente el inicializador usando la palabra clave `const` para `for...of` o `let` para los otros bucles. No lo omitas. Estos son ejemplos correctos:
 
   ```js example-good
-  const gatos = ["Athena", "Luna"];
-  for (const gato of gatos) {
-    console.log(gato);
+  const cats = ["Athena", "Luna"];
+  for (const cat of cats) {
+    console.log(cat);
   }
 
   for (let i = 0; i < 4; i++) {
@@ -401,16 +365,16 @@ Cuando los [bucles](/es/docs/Learn_web_development/Core/Scripting/Loops) son req
   }
   ```
 
-  El siguiente ejemplo no sigue las pautas recomendadas para la inicialización (implícitamente crea una variable global y fallará en modo estricto):
+  El siguiente ejemplo no sigue las directrices recomendadas para la inicialización (implícitamente crea una variable global y fallará en modo estricto):
 
   ```js example-bad
-  const gatos = ["Athena", "Luna"];
-  for (i of gatos) {
+  const cats = ["Athena", "Luna"];
+  for (i of cats) {
     console.log(i);
   }
   ```
 
-- Cuando necesite acceder tanto al valor como al índice, puede usar `.forEach()` en lugar de `for (;;)`. Escriba:
+- Cuando necesites acceder tanto al valor como al índice, puedes usar `.forEach()` en lugar de `for (;;)`. Escribe:
 
   ```js example-good
   const gerbils = ["Zoé", "Chloé"];
@@ -419,7 +383,7 @@ Cuando los [bucles](/es/docs/Learn_web_development/Core/Scripting/Loops) son req
   });
   ```
 
-  No escriba:
+  No escribas:
 
   ```js example-bad
   const gerbils = ["Zoé", "Chloé"];
@@ -429,87 +393,84 @@ Cuando los [bucles](/es/docs/Learn_web_development/Core/Scripting/Loops) son req
   ```
 
 > [!WARNING]
-> Nunca utilice `for...in` en matrices y cadenas.
+> Nunca uses `for...in` con arrays y cadenas.
 
 > [!NOTE]
-> Considere no usar un bucle `for` en absoluto. Si estás utilizando un [`Array`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array) (o un [`String`](/es/docs/Web/JavaScript/Reference/Global_Objects/String) para algunas operaciones), considere usar más métodos de iteración semántica en su lugar, como [`map()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/map), [`every()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/every), [`findIndex()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex), [`find()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/find), [`includes()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/includes), y muchos más.
+> Considera no usar un bucle `for` en absoluto. Si estás usando un [`Array`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array) (o un [`String`](/es/docs/Web/JavaScript/Reference/Global_Objects/String) para algunas operaciones), considera usar métodos de iteración más semánticos en su lugar, como [`map()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/map), [`every()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/every), [`findIndex()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex), [`find()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/find), [`includes()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/includes), y muchos más.
 
 ### Sentencias de control
 
-Hay un caso notable a tener en cuenta para las sentencias de control `if...else`.
-Si la declaración `if` termina con `return`, no agregue una declaración `else`.
+Hay un caso notable a tener en cuenta para las sentencias de control `if...else`. Si la sentencia `if` termina con `return`, no agregues una sentencia `else`.
 
-Continúe justo después de la instrucción `if`. Escriba:
+Continúa justo después de la sentencia `if`. Escribe:
 
 ```js example-good
-if (prueba) {
-  // Realizar algo si la prueba es verdadera
+if (test) {
+  // Realiza algo si test es verdadero
   // …
   return;
 }
 
-// Realizar algo si la prueba es falsa
+// Realiza algo si test es falso
 // …
 ```
 
-No escriba:
+No escribas:
 
 ```js example-bad
-if (prueba) {
-  // Realizar algo si la prueba es verdadera
+if (test) {
+  // Realiza algo si test es verdadero
   // …
   return;
 } else {
-  // Realizar algo si la prueba es falsa
+  // Realiza algo si test es falso
   // …
 }
 ```
 
-### Use llaves con sentencias de flujo de control y bucles
+### Usa llaves con sentencias de flujo de control y bucles
 
-Si bien las declaraciones de flujo de control como `if`, `for` y `while` no requieren el uso de llaves cuando el contenido se compone de una sola declaración, siempre debe usar llaves.
-Escriba:
+Aunque las sentencias de flujo de control como `if`, `for`, y `while` no requieren el uso de llaves cuando el contenido se compone de una sola sentencia, siempre debes usar llaves. Escribe:
 
 ```js example-good
-for (const carro of carrosAlmacenados) {
-  carro.pintar("rojo");
+for (const car of storedCars) {
+  car.paint("red");
 }
 ```
 
-No escriba:
+No escribas:
 
 ```js example-bad
-for (const carro of carrosAlmacenados) carro.pintar("rojo");
+for (const car of storedCars) car.paint("red");
 ```
 
-Esto evita olvidarse de agregar las llaves al agregar más declaraciones.
+Esto evita olvidarse de agregar las llaves al agregar más sentencias.
 
 ### Sentencias switch
 
-Las sentencias `switch` pueden ser un poco complicadas.
+Las sentencias switch pueden ser un poco complicadas.
 
-- No agregue una declaración `break` después de una declaración `return` en un caso específico.
-  En su lugar, escriba instrucciones `return` como esta:
+- No agregues una sentencia `break` después de una sentencia `return` en un caso específico. En su lugar, escribe sentencias `return` así:
 
   ```js example-good
-  switch (especies) {
-    case "pollo":
+  switch (species) {
+    case "chicken":
       return farm.shed;
-    case "caballo":
+    case "horse":
       return corral.entry;
     default:
       return "";
   }
   ```
 
-  Si agrega una declaración `break`, será inalcanzable. No escriba:
+  Si agregas una sentencia `break`, será inalcanzable. No escribas:
 
   ```js example-bad
-  switch (especies) {
-    case "pollo":
+  switch (species) {
+    case "chicken":
       return farm.shed;
       break;
-    case "caballo":
+    case "horse":
       return corral.entry;
       break;
     default:
@@ -517,21 +478,20 @@ Las sentencias `switch` pueden ser un poco complicadas.
   }
   ```
 
-- Use `default` como el último caso, y no lo termine con una declaración `break`.
-  Si necesita hacerlo de otra manera, agregue un comentario explicando por qué.
+- Usa `default` como el último caso, y no lo termines con una sentencia `break`. Si necesitas hacerlo de otra manera, agrega un comentario explicando por qué.
 
-- Recuerde que cuando declara una variable local para un caso, necesita usar llaves para definir un alcance:
+- Recuerda que cuando declaras una variable local para un caso, necesitas usar llaves para definir un alcance:
 
   ```js
-  switch (frutas) {
-    case "Naranja": {
-      const pedazo = frutas.cortar();
-      comer(pedazo);
+  switch (fruits) {
+    case "Orange": {
+      const slice = fruit.slice();
+      eat(slice);
       break;
     }
-    case "Manzana": {
-      const corazon = frutas.extraerCorazon();
-      reciclar(corazon);
+    case "Apple": {
+      const core = fruit.extractCore();
+      recycle(core);
       break;
     }
   }
@@ -539,38 +499,36 @@ Las sentencias `switch` pueden ser un poco complicadas.
 
 ### Manejo de errores
 
-- Si ciertos estados de su programa arrojan errores no detectados, detendrán la ejecución y reducirán potencialmente la utilidad del ejemplo.
-  Por lo tanto, debe detectar errores utilizando un bloque [`try...catch`](/es/docs/Web/JavaScript/Reference/Statements/try...catch), Como se muestra debajo:
+- Si ciertos estados de tu programa arrojan errores no detectados, detendrán la ejecución y reducirán potencialmente la utilidad del ejemplo. Por lo tanto, debes detectar errores usando un bloque [`try...catch`](/es/docs/Web/JavaScript/Reference/Statements/try...catch), como se muestra abajo:
 
   ```js example-good
   try {
-    console.log(obtenerResultado());
+    console.log(getResult());
   } catch (e) {
     console.error(e);
   }
   ```
 
-- Cuando no necesite el parámetro de la sentencia `catch`, omítalo:
+- Cuando no necesites el parámetro de la sentencia `catch`, omítelo:
 
   ```js example-good
   try {
-    console.log(obtenerResultado());
+    console.log(getResult());
   } catch {
     console.error("Ocurrió un error!");
   }
   ```
 
 > [!NOTE]
-> Tenga en cuenta que solo los errores _recuperables_ deben detectarse y manejarse.
-> Todos los errores no recuperables deben dejarse pasar y aumentar la pila de llamadas.
+> Ten en cuenta que solo los errores _recuperables_ deben detectarse y manejarse. Todos los errores no recuperables deben dejarse pasar y propagarse por la pila de llamadas.
 
 ## Objetos
 
-### Nombre de objetos
+### Nombres de objetos
 
-- Al definir una clase, use _PascalCase_ (comenzando con una letra mayúscula) para el nombre de la clase y _camelCase_ (comenzando con una letra minúscula) para la propiedad del objeto y los nombres de los métodos.
+- Al definir una clase, usa _PascalCase_ (comenzando con una letra mayúscula) para el nombre de la clase y _camelCase_ (comenzando con una letra minúscula) para la propiedad del objeto y los nombres de los métodos.
 
-- Al definir una instancia de objeto, ya sea un literal o mediante un constructor, use _camelCase_, comenzando con un carácter en minúsculas, para el nombre de la instancia. Por ejemplo:
+- Al definir una instancia de objeto, ya sea un literal o mediante un constructor, usa _camelCase_, comenzando con un carácter en minúscula, para el nombre de la instancia. Por ejemplo:
 
   ```js example-good
   const hanSolo = new Person("Han Solo", 25, "he/him");
@@ -584,51 +542,51 @@ Las sentencias `switch` pueden ser un poco complicadas.
 
 ### Creación de objetos
 
-Para crear objetos generales (es decir, cuando las clases no están involucradas), use literales y no constructores.
+Para crear objetos generales (es decir, cuando las clases no están involucradas), usa literales y no constructores.
 
 Por ejemplo, haz esto:
 
 ```js example-good
-const objeto = {};
+const object = {};
 ```
 
-No crees un objeto general como este:
+No crees un objeto general así:
 
 ```js example-bad
-const objeto = new Object();
+const object = new Object();
 ```
 
 ### Clases de objetos
 
-- Use la sintaxis de clase ES para objetos, no constructores de estilo antiguo.
+- Usa la sintaxis de clase ES para objetos, no constructores de estilo antiguo.
 
   Por ejemplo, esta es la forma recomendada:
 
   ```js example-good
-  class Persona {
-    constructor(nombre, edad, pronombres) {
-      this.nombre = nombre;
-      this.edad = edad;
-      this.pronombres = pronombres;
+  class Person {
+    constructor(name, age, pronouns) {
+      this.name = name;
+      this.age = age;
+      this.pronouns = pronouns;
     }
 
     greeting() {
-      console.log(`Hola! Yo soy ${this.nombre}`);
+      console.log(`Hi! I'm ${this.name}`);
     }
   }
   ```
 
-- Usar `extends` para la herencia:
+- Usa `extends` para la herencia:
 
   ```js example-good
-  class Profesor extends Persona {
+  class Teacher extends Person {
     // …
   }
   ```
 
 ### Métodos
 
-Para definir métodos, utilice la sintaxis de definición de métodos:
+Para definir métodos, usa la sintaxis de definición de métodos:
 
 ```js example-good
 const obj = {
@@ -657,19 +615,19 @@ const obj = {
 ### Propiedades del objeto
 
 - El método [`Object.prototype.hasOwnProperty()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) ha quedado obsoleto en favor de [`Object.hasOwn()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn).
-- Cuando sea posible, use la abreviatura evitando la duplicación del identificador de la propiedad. Escriba:
+- Cuando sea posible, usa la forma abreviada evitando la duplicación del identificador de la propiedad. Escribe:
 
   ```js example-good
-  function crearObjeto(nombre, edad) {
-    return { nombre, edad };
+  function createObject(name, age) {
+    return { name, age };
   }
   ```
 
-  No escriba:
+  No escribas:
 
   ```js example-bad
-  function crearObjeto(nombre, edad) {
-    return { nombre: nombre, edad: edad };
+  function createObject(name, age) {
+    return { name: name, age: age };
   }
   ```
 
@@ -679,113 +637,95 @@ Esta sección enumera nuestras recomendaciones sobre qué operadores usar y cuá
 
 ### Operadores condicionales
 
-Cuando desee almacenar en una variable un valor literal dependiendo de una condición, use un [operador condicional (ternario)](/es/docs/Web/JavaScript/Reference/Operators/Conditional_operator) en lugar de una sentencia `if...else`.
-Esta regla también se aplica cuando se devuelve un valor. Escriba:
+Cuando quieras almacenar en una variable un valor literal dependiendo de una condición, usa un [operador condicional (ternario)](/es/docs/Web/JavaScript/Reference/Operators/Conditional_operator) en lugar de una sentencia `if...else`. Esta regla también se aplica cuando se devuelve un valor. Escribe:
 
 ```js example-good
-const x = condicion ? 1 : 2;
+const x = condition ? 1 : 2;
 ```
 
-No escriba:
+No escribas:
 
 ```js example-bad
 let x;
-if (condicion) {
+if (condition) {
   x = 1;
 } else {
   x = 2;
 }
 ```
 
-El operador condicional es útil al crear cadenas para registrar información.
-En tales casos, el uso de una instrucción regular `if...else` conduce a largos bloques de código para una operación secundaria como el registro, ofuscando el punto central del ejemplo.
+El operador condicional es útil al crear cadenas para registrar información. En tales casos, el uso de una sentencia regular `if...else` lleva a largos bloques de código para una operación secundaria como el registro, oscureciendo el punto central del ejemplo.
 
 ### Operador de igualdad estricta
 
-Preferir los operadores de [igualdad estricta](/es/docs/Web/JavaScript/Reference/Operators/Strict_equality) `===` y de desigualdad `!==` sobre los operadores de igualdad flexible `==` y de desigualdad `!=`.
+Prefiere los operadores de [igualdad estricta](/es/docs/Web/JavaScript/Reference/Operators/Strict_equality) (triple igual) y de desigualdad sobre los operadores de igualdad flexible (doble igual) y de desigualdad.
 
-Use los operadores estrictos de igualdad y desigualdad de esta forma:
+Usa los operadores de igualdad estricta y de desigualdad así:
 
 ```js example-good
-nombre === "Shilpa";
-edad !== 25;
+name === "Shilpa";
+age !== 25;
 ```
 
-No use los operadores sueltos de igualdad y desigualdad, como se muestra a continuación:
+No uses los operadores de igualdad y desigualdad flexibles, como se muestra abajo:
 
 ```js example-bad
-nombre == "Shilpa";
-edad != 25;
+name == "Shilpa";
+age != 25;
 ```
 
-Si necesita usar `==` o `!=`, recuerde que `== null` es el único caso aceptable.
-Como TypeScript fallará en todos los demás casos, no queremos tenerlos en nuestro código de ejemplo.
-Considere agregar un comentario para explicar por qué lo necesita.
+Si necesitas usar `==` o `!=`, recuerda que `== null` es el único caso aceptable. Como TypeScript fallará en todos los demás casos, no queremos tenerlos en nuestro código de ejemplo. Considera agregar un comentario para explicar por qué lo necesitas.
 
 ### Atajos para pruebas booleanas
 
-Prefiera atajos para las pruebas booleanas. Por ejemplo, use `if (x)` y `if (!x)`, no use `if (x === true)` y `if (x === false)`, a menos que diferentes tipos de valores verdaderos o falsos se manejen de forma diferente.
+Prefiere atajos para las pruebas booleanas. Por ejemplo, usa `if (x)` y `if (!x)`, no `if (x === true)` y `if (x === false)`, a menos que diferentes tipos de valores verdaderos o falsos se manejen de forma diferente.
 
 ## Cadenas
 
-Las cadenas literales se pueden encerrar entre comillas simples, como en `'Una cadena'`, o entre comillas dobles, como en `"Una cadena"`.
-No se preocupe por cuál usar, Prettier lo mantiene consistente.
+Las cadenas literales se pueden encerrar entre comillas simples, como en `'Una cadena'`, o entre comillas dobles, como en `"Una cadena"`. No te preocupes por cuál usar; Prettier lo mantiene consistente.
 
 ### Template literals
 
-Para insertar valores en cadenas, use [Plantillas literales](/es/docs/Web/JavaScript/Reference/Template_literals).
+Para insertar valores en cadenas, usa [plantillas literales](/es/docs/Web/JavaScript/Reference/Template_literals).
 
-- Aquí hay un ejemplo de la forma recomendada de usar plantillas literales.
-  Su uso evita muchos errores de espaciado.
+- Aquí hay un ejemplo de la forma recomendada de usar plantillas literales. Su uso evita muchos errores de espaciado.
 
   ```js example-good
-  const nombre = "Shilpa";
-  console.log(`¡Hola! Soy ${nombre}!`);
+  const name = "Shilpa";
+  console.log(`Hi! I'm ${name}!`);
   ```
 
   No concatenes cadenas así:
 
   ```js example-bad
-  const nombre = "Shilpa";
-  console.log("¡Hola! Soy" + nombre + "!"); // ¡Hola! SoyShilpa!
+  const name = "Shilpa";
+  console.log("Hi! I'm" + name + "!"); // Hi! I'mShilpa!
   ```
 
-- No abuses de las plantillas literales.
-  Si no hay sustituciones, use una cadena literal normal en su lugar.
+- No abuses de las plantillas literales. Si no hay sustituciones, usa una cadena literal normal en su lugar.
 
 ## Variables
 
-### Nombre de Variables
+### Nombres de variables
 
 Los buenos nombres de variables son esenciales para comprender el código.
 
-- Use identificadores cortos y evite abreviaturas no comunes.
-  Los buenos nombres de variables suelen tener entre 3 y 10 caracteres, pero solo como sugerencia.
-  Por ejemplo, 'acelerómetro' es más descriptivo que abreviar como 'aclmtr' por el bien de la longitud de los caracteres.
-- Trate de usar ejemplos relevantes del mundo real donde cada variable tenga una semántica clara.
-  Solo recurra a nombres de marcadores de posición como `foo` y `bar` cuando el ejemplo sea simple y artificial.
-- No utilice la convención de nomenclatura [Notación húngara](https://es.wikipedia.org/wiki/Notaci%C3%B3n_h%C3%BAngara).
-  No prefije el nombre de la variable con su tipo.
-  Por ejemplo, escriba `bought = car.buyer !== null` en lugar de `bBought = oCar.sBuyer != null` o `name = "John Doe"` en lugar de `sName = "John Doe"`.
-- Para colecciones, evite agregar el tipo como lista, matriz, cola en el nombre.
-  Use el nombre del contenido en plural.
-  Por ejemplo, para una matriz de autos, utilice `cars` y no `carArray` o `carList`.
-  Puede haber excepciones, como cuando desea mostrar la forma abstracta de una función sin el contexto de una aplicación en particular.
-- Para valores primitivos, use _camelCase_, comenzando con un carácter en minúscula.
-  No use `_`.
-  Utilice nombres concisos, legibles por humanos y semánticos cuando sea apropiado.
-  Por ejemplo, use `currencyName` en lugar de `currency_name`.
-- Evite el uso de artículos y posesivos.
-  Por ejemplo, utilice `car` en lugar de `myCar` o `aCar`.
-  Puede haber excepciones, como cuando se describe una característica en general sin un contexto práctico.
-- Use nombres de variables como se muestra aquí:
+<!-- cSpell:ignore acclmtr -->
+
+- Usa identificadores cortos y evita abreviaturas no comunes. Los buenos nombres de variables suelen tener entre 3 y 10 caracteres, pero solo como sugerencia. Por ejemplo, `accelerometer` es más descriptivo que abreviar como `acclmtr` por el bien de la longitud de los caracteres.
+- Trata de usar ejemplos relevantes del mundo real donde cada variable tenga una semántica clara. Solo recurre a nombres de marcadores de posición como `foo` y `bar` cuando el ejemplo sea simple y artificial.
+- No uses la convención de nomenclatura [notación húngara](https://es.wikipedia.org/wiki/Notaci%C3%B3n_h%C3%BAngara). No prefijes el nombre de la variable con su tipo. Por ejemplo, escribe `bought = car.buyer !== null` en lugar de `bBought = oCar.sBuyer != null` o `name = "Maria Sanchez"` en lugar de `sName = "Maria Sanchez"`.
+- Para colecciones, evita agregar el tipo como lista, array, cola en el nombre. Usa el nombre del contenido en plural. Por ejemplo, para un array de autos, usa `cars` y no `carArray` o `carList`. Puede haber excepciones, como cuando quieres mostrar la forma abstracta de una característica sin el contexto de una aplicación en particular.
+- Para valores primitivos, usa _camelCase_, comenzando con un carácter en minúscula. No uses `_`. Usa nombres concisos, legibles y semánticos cuando sea apropiado. Por ejemplo, usa `currencyName` en lugar de `currency_name`.
+- Evita el uso de artículos y posesivos. Por ejemplo, usa `car` en lugar de `myCar` o `aCar`. Puede haber excepciones, como cuando se describe una característica en general sin un contexto práctico.
+- Usa nombres de variables como se muestra aquí:
 
   ```js example-good
   const playerScore = 0;
   const speed = distance / time;
   ```
 
-  No nombre variables de esta forma:
+  No nombres variables así:
 
   ```js example-bad
   const thisIsaveryLONGVariableThatRecordsPlayerscore345654 = 0;
@@ -793,53 +733,50 @@ Los buenos nombres de variables son esenciales para comprender el código.
   ```
 
 > [!NOTE]
-> El único lugar donde está permitido no usar nombres semánticos legibles por humanos es donde existe una convención comúnmente reconocida, como usar `i` y `j` para iteradores de bucle.
+> El único lugar donde está permitido no usar nombres semánticos legibles es donde existe una convención comúnmente reconocida, como usar `i` y `j` para iteradores de bucle.
 
-### Declaración de Variables
+### Declaraciones de variables
 
-Al declarar variables y constantes, use las palabras clave [`let`](/es/docs/Web/JavaScript/Reference/Statements/let) y [`const`](/es/docs/Web/JavaScript/Reference/Statements/const), no [`var`](/es/docs/Web/JavaScript/Reference/Statements/var).
-Los siguientes ejemplos muestran lo que se recomienda y lo que no en los documentos web de MDN:
+Al declarar variables y constantes, usa las palabras clave [`let`](/es/docs/Web/JavaScript/Reference/Statements/let) y [`const`](/es/docs/Web/JavaScript/Reference/Statements/const), no [`var`](/es/docs/Web/JavaScript/Reference/Statements/var). Los siguientes ejemplos muestran lo que se recomienda y lo que no en MDN Web Docs:
 
-- Si una variable no se reasignará, prefiera `const`, así:
-
-  ```js example-good
-  const nombre = "Shilpa";
-  console.log(nombre);
-  ```
-
-- Si va a cambiar el valor de una variable, use `let` como se muestra a continuación:
+- Si una variable no se reasignará, prefiere `const`, así:
 
   ```js example-good
-  let edad = 40;
-  edad++;
-  console.log("¡Feliz cumpleaños!");
+  const name = "Shilpa";
+  console.log(name);
   ```
 
-- El siguiente ejemplo usa `let` donde debería ser `const`.
-  El código funcionará, pero queremos evitar este uso en los ejemplos de código de los documentos web de MDN.
+- Si vas a cambiar el valor de una variable, usa `let` como se muestra abajo:
 
-  ```js example-bad
-  let nombre = "Shilpa";
-  console.log(nombre);
+  ```js example-good
+  let age = 40;
+  age++;
+  console.log("Happy birthday!");
   ```
 
-- El siguiente ejemplo usa `const` para una variable que se reasigna.
-  La reasignación arrojará un error.
+- El siguiente ejemplo usa `let` donde debería ser `const`. El código funcionará, pero queremos evitar este uso en los ejemplos de código de MDN Web Docs.
 
   ```js example-bad
-  const edad = 40;
-  edad++;
-  console.log("¡Feliz cumpleaños!");
+  let name = "Shilpa";
+  console.log(name);
+  ```
+
+- El siguiente ejemplo usa `const` para una variable que se reasigna. La reasignación arrojará un error.
+
+  ```js example-bad
+  const age = 40;
+  age++;
+  console.log("Happy birthday!");
   ```
 
 - El siguiente ejemplo usa `var`, contaminando el alcance global:
 
   ```js example-bad
-  var edad = 40;
-  var nombre = "Shilpa";
+  var age = 40;
+  var name = "Shilpa";
   ```
 
-- Declare una variable por línea, así:
+- Declara una variable por línea, así:
 
   ```js example-good
   let var1;
@@ -848,8 +785,7 @@ Los siguientes ejemplos muestran lo que se recomienda y lo que no en los documen
   let var4 = var3;
   ```
 
-  No declare múltiples variables en una línea, separándolas con comas o usando declaraciones en cadena.
-  Evite declarar variables así:
+  No declares múltiples variables en una línea, separándolas con comas o usando declaraciones en cadena. Evita declarar variables así:
 
   ```js-nolint example-bad
   let var1, var2;
@@ -858,8 +794,7 @@ Los siguientes ejemplos muestran lo que se recomienda y lo que no en los documen
 
 ### Coerción de tipos
 
-Evite las coacciones de tipo implícito. En particular, evite `+val` para forzar un valor a un número y `"" + val` para forzarlo a una cadena.
-Utilice `Number()` y `String()`, sin `new`, en su lugar. Escriba:
+Evita las coerciones de tipo implícito. En particular, evita `+val` para forzar un valor a un número y `"" + val` para forzarlo a una cadena. Usa `Number()` y `String()`, sin `new`, en su lugar. Escribe:
 
 ```js example-good
 class Person {
@@ -873,7 +808,7 @@ class Person {
 }
 ```
 
-No escriba:
+No escribas:
 
 ```js example-bad
 class Person {
@@ -889,17 +824,17 @@ class Person {
 
 ## APIs web para evitar
 
-Además de estas características del lenguaje JavaScript, recomendamos tener en cuenta algunas pautas relacionadas con las API web.
+Además de estas características del lenguaje JavaScript, recomendamos tener en cuenta algunas directrices relacionadas con las APIs web.
 
-### Evite los prefijos del navegador
+### Evita los prefijos del navegador
 
-Si todos los principales navegadores (Chrome, Edge, Firefox y Safari) soportan una función, no agregue el prefijo de la función. Escriba:
+Si todos los navegadores principales (Chrome, Edge, Firefox y Safari) soportan una característica, no agregues el prefijo de la característica. Escribe:
 
 ```js example-good
 const context = new AudioContext();
 ```
 
-Evite la complejidad añadida de los prefijos. No escriba:
+Evita la complejidad añadida de los prefijos. No escribas:
 
 ```js example-bad
 const AudioContext = window.AudioContext || window.webkitAudioContext;
@@ -908,21 +843,18 @@ const context = new AudioContext();
 
 La misma regla se aplica a los prefijos CSS.
 
-### Evite las API en desuso
+### Evita las APIs obsoletas
 
-Cuando un método, una propiedad o una interfaz completa está en desuso, no lo use (fuera de su documentación).
-En su lugar, utilice la API moderna.
+Cuando un método, una propiedad o una interfaz completa está obsoleto, no lo uses (fuera de su documentación). En su lugar, usa la API moderna.
 
-Aquí hay una lista no exhaustiva de API web para evitar y con qué reemplazarlas:
+Aquí hay una lista no exhaustiva de APIs web para evitar y con qué reemplazarlas:
 
-- Use `fetch()` en lugar de XHR (`XMLHttpRequest`).
-- Use `AudioWorklet` en lugar de `ScriptProcessorNode`, en la API de Audio Web.
+- Usa `fetch()` en lugar de XHR (`XMLHttpRequest`).
+- Usa `AudioWorklet` en lugar de `ScriptProcessorNode`, en la Web Audio API.
 
-### Use API seguras y confiables
+### Usa APIs seguras y confiables
 
-- No utilice {{DOMxRef("Element.innerHTML")}} para insertar contenido puramente textual en un elemento; use {{DOMxRef("Node.textContent")}} en su lugar.
-  La propiedad `innerHTML` genera problemas de seguridad si un desarrollador no controla el parámetro.
-  Cuanto más evitamos usarlo como escritores, menos fallas de seguridad se crean cuando un desarrollador copia y pega nuestro código.
+- No uses {{DOMxRef("Element.innerHTML")}} para insertar contenido puramente textual en un elemento; usa {{DOMxRef("Node.textContent")}} en su lugar. La propiedad `innerHTML` genera problemas de seguridad si un desarrollador no controla el parámetro. Cuanto más evitemos usarlo como escritores, menos fallos de seguridad se crean cuando un desarrollador copia y pega nuestro código.
 
   El siguiente ejemplo demuestra el uso de `textContent`.
 
@@ -932,7 +864,7 @@ Aquí hay una lista no exhaustiva de API web para evitar y con qué reemplazarla
   para.textContent = text;
   ```
 
-  No use `innerHTML` para insertar _texto puro_ en los nodos DOM.
+  No uses `innerHTML` para insertar _texto puro_ en los nodos DOM.
 
   ```js example-bad
   const text = "Hello to all you good people";
@@ -940,18 +872,13 @@ Aquí hay una lista no exhaustiva de API web para evitar y con qué reemplazarla
   para.innerHTML = text;
   ```
 
-- La función `alert()` no es fiable.
-  No funciona en ejemplos en vivo en MDN Web Docs que están dentro de un {{HTMLElement("iframe")}}.
-  Además, es modal para toda la ventana, lo cual es molesto.
-  En ejemplos de código estático, use `console.log()` o `console.error()`.
-  En [ejemplos en vivo](/es/docs/MDN/Writing_guidelines/Page_structures/Live_samples), evite `console.log()` y `console.error()` porque no se muestran.
-  Utilice un elemento de interfaz de usuario dedicado.
+- La función `alert()` no es confiable. No funciona en ejemplos en vivo en MDN Web Docs que están dentro de un {{HTMLElement("iframe")}}. Además, es modal para toda la ventana, lo cual es molesto. En ejemplos de código estático, usa `console.log()` o `console.error()`. En [ejemplos en vivo](/es/docs/MDN/Writing_guidelines/Page_structures/Live_samples), evita `console.log()` y `console.error()` porque no se muestran. Usa un elemento de interfaz de usuario dedicado.
 
-### Utilice el método de registro adecuado
+### Usa el método de registro apropiado
 
-- Al registrar un mensaje, utilice `console.log()`.
-- Cuando registre un error, use `console.error()`.
+- Al registrar un mensaje, usa `console.log()`.
+- Al registrar un error, usa `console.error()`.
 
-## Vea también
+## Véase también
 
-[Referencia del lenguaje JavaScript](/es/docs/Web/JavaScript/Reference) - navegue a través de nuestras páginas de referencia de JavaScript para ver algunos fragmentos de JavaScript buenos, concisos y significativos.
+[Referencia del lenguaje JavaScript](/es/docs/Web/JavaScript/Reference) - navega a través de nuestras páginas de referencia de JavaScript para ver algunos fragmentos de JavaScript buenos, concisos y significativos.

--- a/files/es/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/es/mdn/writing_guidelines/writing_style_guide/index.md
@@ -1,97 +1,706 @@
 ---
-title: Guía de estilo
+title: Guía de estilo de redacción
+short-title: Guía de estilo
 slug: MDN/Writing_guidelines/Writing_style_guide
+l10n:
+  sourceCommit: a886ef3867e01df856ed9b49b3b6856232cc8c75
 ---
 
-{{MDNSidebar}}
+Esta guía de estilo de redacción describe cómo debe escribirse, organizarse, deletrearse y formatearse el contenido en MDN Web Docs.
 
-Para mostrar la documentación de forma organizada, estandarizada y fácil de leer, la guía de estilos de MDN describe cómo debe organizarse, escribirse y formatearse el texto. Se trata de pautas más que de reglas estrictas. Interesa más el contenido que el formato, así que no te sientas obligado a aprenderte la guía de estilos antes de colaborar. No te enojes ni te sorprendas si después un voluntario edita tu trabajo para que quede de acuerdo con esta guía.
+Estas pautas aseguran la coherencia del lenguaje y el estilo en todo el sitio web. Dicho esto, nos interesa más el contenido que su formato, así que no te sientas obligado a aprender la guía de estilo de redacción completa antes de colaborar. Sin embargo, no te sorprendas si otro colaborador edita tu trabajo más tarde para que se ajuste a esta guía. Los revisores también pueden remitirte a esta guía de estilo cuando envíes una solicitud de incorporación de cambios de contenido.
 
-Los aspectos lingüísticos de esta guía se refieren principalmente a la documentación en idioma inglés.Se pueden (y se anima a) crear guías de estilo en otros idiomas. Estas deben publicarse como subpáginas de la página del equipo de localización.
+> [!NOTE]
+> Los aspectos lingüísticos de esta guía se aplican principalmente a la documentación en inglés. Otros idiomas pueden tener (y se les invita a crear) sus propias guías de estilo. Estas deben publicarse como subpáginas de la página del respectivo equipo de localización. Sin embargo, esta guía aún debe consultarse para formatear y organizar el contenido.
 
-Si buscas especificaciones de cómo debe estructurarse un determinado tipo de página, mira la [guía de diseño de MDN](/es/docs/MDN/Contribute/Content/Layout).
+Después de enumerar las pautas generales de redacción, esta guía describe el estilo de redacción recomendado para MDN Web Docs y luego cómo formatear diferentes componentes en una página, como listas y títulos.
 
-Aquí se enumeran los usos y costumbres recomendados a la hora de editar los artículos de este wiki. Si ves que falta contenido o crees que deberíamos mejorar o corregir algo, por favor coméntalo en la página de discusión.
+## Pautas generales de redacción
 
-## Uso de mayúsculas en el nombre de las páginas y los encabezados
+El objetivo es escribir páginas que incluyan toda la información que los lectores puedan necesitar para comprender el tema en cuestión.
 
-- Cuando escribas los nombres de las páginas y de los encabezados, recuerda que sólo debe empezar con mayúscula la primera palabra de la frase.
-  - **Correcto**: "Guía de estilo"
-  - **Incorrecto**: "Guía de Estilo"
+Las siguientes subsecciones proporcionan las recomendaciones para lograr esto:
 
-## Infinitivos y gerundios
+- [Considera tu público objetivo](#considera_tu_publico_objetivo)
+- [Considera las tres C de la redacción](#considera_las_tres_c_de_la_redaccion)
+- [Incluye ejemplos relevantes](#incluye_ejemplos_relevantes)
+- [Proporciona una introducción descriptiva](#proporciona_una_introduccion_descriptiva)
+- [Usa un lenguaje inclusivo](#usa_un_lenguaje_inclusivo)
+- [Escribe pensando en SEO](#escribe_pensando_en_seo)
 
-- En inglés, una práctica muy habitual es la de utilizar verbos acabados en "-ing" en los títulos: "Configuring Firefox", por ejemplo. En estos casos la traducción correcta al español consiste en utilizar el infinitivo del verbo y no el gerundio.
-  - **Correcto**: Configurar Firefox
-  - **Incorrecto**: Configurando Firefox
+### Considera tu público objetivo
 
-## Siglas y abreviaturas
+Ten en cuenta el público objetivo del contenido que estás escribiendo. Por ejemplo, una página sobre técnicas avanzadas de red probablemente no necesita entrar en tantos detalles sobre conceptos básicos de redes como la página típica sobre redes. Ten en cuenta que estas son pautas. Algunos de estos consejos pueden no aplicarse en todos los casos.
 
-### Mayúsculas y espacios
+### Considera las tres C de la redacción
 
-- Escribe las siglas en mayúsculas y sin puntos.
+Las tres C de una buena redacción son escribir con claridad, concisión y coherencia.
+
+- **Claro**: Asegúrate de que tu redacción sea clara y sencilla. En general, usa la voz activa y pronombres inequívocos. Escribe oraciones cortas, manteniendo una idea por oración. Define los nuevos términos, teniendo en cuenta el público objetivo, antes de usarlos.
+- **Conciso**: Al escribir cualquier documento, es importante saber cuánto decir. Si proporcionas detalles excesivos, la página se vuelve tediosa de leer y rara vez se utilizará.
+- **Coherente**: Asegúrate de usar el mismo vocabulario de manera coherente en toda la página y entre varias páginas.
+
+### Incluye ejemplos relevantes
+
+En general, agrega ejemplos o escenarios de la vida real para explicar mejor el contenido que estás escribiendo. Esto ayuda a los lectores a comprender la información conceptual y procedimental de una manera más tangible y práctica.
+
+Debes usar ejemplos para aclarar para qué se usa cada parámetro y para aclarar cualquier caso límite que pueda existir.
+También puedes usar ejemplos para demostrar soluciones para tareas comunes y soluciones para problemas que puedan surgir.
+
+### Proporciona una introducción descriptiva
+
+Asegúrate de que el(os) párrafo(s) de apertura antes del primer encabezado resuman adecuadamente la información que cubrirá la página y quizás lo que los lectores podrán lograr después de pasar por el contenido. De esta manera, un lector puede determinar rápidamente si la página es relevante para sus preocupaciones y resultados de aprendizaje deseados.
+
+En una guía o tutorial, el(los) párrafo(s) introductorio(s) debe(n) informar al lector sobre los temas que se cubrirán, así como sobre los conocimientos previos que se espera que el lector tenga, si los hubiera. El párrafo de apertura debe mencionar las tecnologías y/o APIs que se están documentando o discutiendo, con enlaces a la información relacionada, y debe ofrecer pistas sobre situaciones en las que el contenido del artículo podría ser útil.
+
+- **Ejemplo de introducción corta**: Este ejemplo de una introducción es demasiado corto. Omite demasiada información, como qué significa exactamente "trazar" texto, dónde se dibuja el texto, etc.
+
+  > **`CanvasRenderingContext2D.strokeText()`** dibuja una cadena.
+
+- **Ejemplo de introducción larga**: Este ejemplo tiene una introducción actualizada, pero ahora es demasiado larga.
+  Se incluyen demasiados detalles y el texto profundiza demasiado en la descripción de otros métodos y propiedades.
+  En su lugar, la introducción debe centrarse en el método `strokeText()` y debe hacer referencia a las guías apropiadas donde se describen los otros detalles.
+
+  > Cuando se llama, el método de la API Canvas 2D **`CanvasRenderingContext2D.strokeText()`** traza los caracteres de la cadena especificada comenzando en las coordenadas especificadas, usando el color de pluma actual.
+  > En la terminología de los gráficos por computadora, "trazar" texto significa dibujar los contornos de los glifos en la cadena sin rellenar el contenido de cada carácter con color.
+  >
+  > El texto se dibuja usando la fuente actual del contexto como se especifica en la propiedad {{domxref("CanvasRenderingContext2D.font", "font")}} del contexto.
+  >
+  > La colocación del texto relativa a las coordenadas especificadas se determina por las propiedades `textAlign`, `textBaseline` y `direction` del contexto.
+  > `textAlign` controla la colocación de la cadena relativa a la coordenada X especificada; si el valor es `"center"`, entonces la cadena se dibuja comenzando en `x - (stringWidth / 2)`, colocando la coordenada X especificada en el medio de la cadena.
+  > Si el valor es `"left"`, la cadena se dibuja comenzando en el valor especificado de `x`.
+  > Y si `textAlign` es `"right"`, el texto se dibuja de tal manera que termina en la coordenada X especificada.
+  >
+  > (...)
+  >
+  > Opcionalmente, puedes proporcionar un cuarto parámetro que te permite especificar un ancho máximo para la cadena, en píxeles.
+  > Si proporcionas este parámetro, el texto se comprime horizontalmente o escala (o se ajusta de otra manera) para caber dentro de un espacio de ese ancho al dibujarse.
+  >
+  > Puedes llamar al método **`fillText()`** para dibujar los caracteres de una cadena rellenos de color en lugar de solo dibujar los contornos de los caracteres.
+
+- **Ejemplo de una introducción apropiada**: La siguiente sección proporciona una visión general mucho mejor para el método `strokeText()`.
+
+  > El método **`strokeText()`** de {{domxref("CanvasRenderingContext2D")}}, parte de la [API Canvas 2D](/es/docs/Web/API/Canvas_API), traza (dibuja los contornos de) los caracteres de una cadena especificada, anclada en la posición indicada por las coordenadas X e Y dadas.
+  > El texto se dibuja usando la {{domxref("CanvasRenderingContext2D.font", "fuente")}} actual del contexto, y se justifica y alinea de acuerdo con las propiedades {{domxref("CanvasRenderingContext2D.textAlign", "textAlign")}}, {{domxref("CanvasRenderingContext2D.textBaseline", "textBaseline")}} y {{domxref("CanvasRenderingContext2D.direction", "direction")}}.
+  >
+  > Para obtener más detalles y ejemplos, consulta la sección [Texto](/es/docs/Learn_web_development/Extensions/Client-side_APIs/Drawing_graphics#texto) en la página Dibujo de gráficos, así como nuestro artículo principal sobre el tema, [Dibujo de texto](/es/docs/Web/API/Canvas_API/Tutorial/Drawing_text).
+
+### Usa un lenguaje inclusivo
+
+MDN tiene un público amplio y diverso.
+Animamos encarecidamente a mantener el texto lo más inclusivo posible.
+Algunos términos, aunque no pretenden ser ofensivos, pueden alejar a los lectores de ciertos antecedentes, tales como:
+
+- Evita usar los términos **master** y **slave** y en su lugar usa **main** y **replica**.
+- Reemplaza **whitelist** y **blacklist** con **allowlist** y **denylist**.
+- **Sanity** debe reemplazarse con **coherence**.
+- En lugar de **dummy**, usa **placeholder**.
+- No deberías necesitar usar los términos **crazy** y **insane** en la documentación; sin embargo, si surge el caso, considera usar **fantastic** en su lugar.
+
+Evita los modismos figurados con representaciones de violencia o crueldad, que desencadenan a ciertos públicos y establecen el tono incorrecto para la documentación. Por ejemplo:
+
+- En lugar de "matar dos pájaros de un tiro", usa "resolver dos problemas a la vez".
+- En lugar de "azotar un caballo muerto", usa "insistir en el punto" o "dar vueltas en círculos".
+- En lugar de "hay más de una forma de despellejar un gato", usa "hay más de una forma de hacer esto".
+
+Es mejor usar un lenguaje neutral en cuanto al género en cualquier redacción donde el género sea irrelevante para el tema.
+Por ejemplo, si estás hablando de las acciones de un hombre específico, usar "él"/"su" está bien; pero si el sujeto es una persona de cualquier género, "él"/"su" no es apropiado.
+
+Veamos los siguientes ejemplos:
+
+- **Incorrecto**: "Un cuadro de diálogo de confirmación pregunta al usuario si él quiere permitir que la página web haga uso de su cámara web."
+- **Incorrecto**: "Un cuadro de diálogo de confirmación pregunta al usuario si ella quiere permitir que la página web haga uso de su cámara web."
+
+Ambas versiones son específicas de género. Para corregir esto, usa pronombres neutrales en cuanto al género de la siguiente manera:
+
+- **Correcto**: "Un cuadro de diálogo de confirmación pregunta al usuario si quieren permitir que la página web haga uso de su cámara web."
+
+> [!NOTE]
+> MDN Web Docs permite el uso del plural de tercera persona, comúnmente conocido como "'ellos' singular". Los pronombres neutrales en cuanto al género incluyen "ellos", "los", "su" y "suyo".
+
+Otra opción es hacer que los usuarios sean plurales, así:
+
+- **Correcto**: "Un cuadro de diálogo de confirmación pregunta a los usuarios si quieren permitir que la página web haga uso de sus cámaras web."
+
+La mejor solución, por supuesto, es reescribir y eliminar los pronombres:
+
+- **Correcto**: "Aparece un cuadro de diálogo de confirmación que solicita el permiso del usuario para acceder a la cámara web."
+- **Correcto**: "Aparece un cuadro de diálogo de confirmación que pide al usuario permiso para usar la cámara web."
+
+Este último ejemplo de cómo lidiar con el problema es posiblemente mejor.
+No solo es gramaticalmente más correcto, sino que elimina parte de la complejidad asociada con lidiar con los géneros en diferentes idiomas que pueden tener reglas de género muy diferentes.
+Esta solución puede facilitar la traducción tanto para los lectores como para los traductores.
+
+### Usa un lenguaje accesible
+
+Evita usar palabras espaciales y direccionales, como "arriba", "abajo", "izquierda", "derecha" o "aquí". Estos términos asumen un diseño visual específico, que puede no aplicarse a todos los usuarios. También pueden ser poco claros o engañosos, especialmente para los usuarios que dependen de lectores de pantalla o aquellos que leen contenido traducido, donde el lenguaje direccional puede ser ambiguo o difícil de traducir con precisión. En diseños responsivos, donde la posición del contenido puede cambiar según el tamaño de la pantalla, estas referencias direccionales pueden volverse inexactas. Este tipo de lenguaje puede obstaculizar la accesibilidad y dificultar que todos los usuarios naveguen o comprendan el contenido.
+
+En su lugar, usa frases descriptivas que identifiquen claramente la sección, concepto o elemento al que se hace referencia. Haz referencia a las secciones por sus títulos o encabezados, y haz referencia a ejemplos o fragmentos de código por lo que demuestran o contienen.
+
+Por ejemplo:
+
+- **Correcto**: "Consulta la sección [Accesibilidad](/es/docs/Web/CSS/Reference/Values/gradient/repeating-conic-gradient#accesibilidad) más adelante en esta página."
+- **Incorrecto**: "Consulta la sección de Accesibilidad a continuación."
+
+- **Correcto**: "En el siguiente ejemplo de código, animamos un círculo usando transiciones de CSS."
+- **Incorrecto**: "En el ejemplo de código a continuación, animamos un círculo usando transiciones de CSS."
+
+- **Correcto**: "Este concepto se explica en la sección anterior titulada Crear una consulta de medios."
+- **Incorrecto**: "Este concepto se explica en la sección de arriba."
+
+Además, evita usar texto de enlace vago como "Haz clic aquí" o "Lee este artículo". El texto de enlace descriptivo proporciona un mejor contexto para todos los lectores y mejora la experiencia para los usuarios de tecnologías de asistencia.
+
+<!-- markdownlint-disable descriptive-link-text -->
+
+- **Correcto**: "Aprende más sobre [cómo ordenar elementos flex](/es/docs/Web/CSS/Guides/Flexible_box_layout/Ordering_items)."
+- **Incorrecto**: "Haz clic [aquí](/es/docs/Web/CSS/Guides/Flexible_box_layout/Ordering_items) para aprender más."
+- **Incorrecto**: "Lee [este artículo](/es/docs/Web/CSS/Guides/Flexible_box_layout/Ordering_items) para aprender más."
+
+<!-- markdownlint-enable descriptive-link-text -->
+
+Al seguir estas pautas, ayudas a que la documentación de MDN sea accesible, clara y utilizable para todos, independientemente de cómo accedan a la página.
+
+### Escribe pensando en SEO
+
+Si bien el objetivo principal de cualquier redacción en MDN Web Docs siempre debe ser explicar e informar sobre tecnología web abierta para que los desarrolladores puedan aprender rápidamente a hacer lo que quieren o encontrar los pequeños detalles que necesitan saber para perfeccionar su código, es importante que puedan _encontrar_ el material que escribimos. Podemos lograr esto manteniendo la Optimización de Motores de Búsqueda ({{Glossary("SEO")}}) en mente al escribir.
+
+Esta sección cubre las prácticas estándar, las recomendaciones y los requisitos para el contenido para ayudar a garantizar que los motores de búsqueda puedan categorizar e indexar fácilmente nuestro material para asegurar que los lectores puedan encontrar fácilmente lo que necesitan. Las pautas de SEO incluyen asegurar que cada página en la que trabajan los escritores y editores esté razonablemente bien diseñada, escrita y marcada para dar a los motores de búsqueda el contexto y las pistas que necesitan para indexar correctamente los artículos.
+
+La siguiente lista de verificación es buena para tener en cuenta al escribir y revisar contenido para ayudar a garantizar que la página y sus vecinas se indexarán correctamente por los motores de búsqueda:
+
+- **Asegúrate de que las páginas no sean demasiado similares**: Si el contenido en diferentes páginas es similar textualmente, los motores de búsqueda asumirán que las páginas tratan sobre lo mismo incluso si no lo están.
+  Por ejemplo, si una interfaz tiene las propiedades `width` y `height`, es fácil que el texto sea sorprendentemente similar en las dos páginas que documentan estas dos propiedades, con solo unas pocas palabras intercambiadas y usando el mismo ejemplo. Esto hace difícil que los motores de búsqueda sepan cuál es cuál, y terminan compartiendo el rango de página, lo que resulta que ambas sean más difíciles de encontrar de lo que deberían ser.
+
+  Es importante, entonces, asegurar que cada página tenga su propio contenido. Las siguientes sugerencias pueden ayudarte a lograr esto:
+  - **Explica más conceptos únicos**: Considera casos de uso donde podría haber más diferencias de lo que uno pensaría. Por ejemplo, en el caso de documentar las propiedades `width` y `height`, quizás podrías escribir sobre las formas en que el espacio horizontal y el espacio vertical se usan de manera diferente, y proporcionar una discusión sobre los conceptos apropiados. Quizás podrías mencionar el uso de `width` en términos de hacer espacio para una barra lateral, mientras usas `height` para manejar el desplazamiento vertical o los pies de página. Incluir información sobre problemas de accesibilidad también es una idea útil e importante.
+  - **Usa ejemplos diferentes**: Los ejemplos en estas situaciones son a menudo incluso más similares que el texto del cuerpo porque los ejemplos pueden usar ambos (o todos) de los métodos o propiedades similares desde el principio, por lo que no requieren cambios reales cuando se reutilizan. Así que descarta el ejemplo y escribe uno nuevo, o al menos proporciona múltiples ejemplos, con al menos algunos de ellos diferentes.
+  - **Agrega descripciones para los ejemplos**: Se debe incluir tanto una descripción general de lo que hace el ejemplo como una cobertura de cómo funciona, en un nivel apropiado de detalle dada la complejidad del tema y el público objetivo.
+  - La forma más fácil de evitar ser demasiado similar es, por supuesto, escribir cada artículo desde cero si el tiempo lo permite.
+
+- **Asegúrate de que las páginas no sean demasiado cortas**: Si el contenido en una página es demasiado poco (llamado "páginas delgadas" en la jerga de SEO), los motores de búsqueda no catalogarán dichas páginas con precisión (o en absoluto). Las páginas de contenido excesivamente cortas son difíciles de encontrar. Como principio rector, asegúrate de que las páginas en MDN Web Docs no sean más cortas de alrededor de 300 palabras más o menos. No inflames artificialmente una página, pero trata esta pauta como una longitud objetivo mínima cuando sea posible.
+
+  Estas pautas básicas pueden ayudarte a crear páginas que tengan suficiente contenido para ser correctamente buscables sin recurrir a saturarlas con texto innecesario:
+  - **Evita los esbozos**: Obviamente, si el artículo es un esbozo o falta contenido, agrégalo. Tratamos de evitar páginas de "esbozo" absolutas en MDN Web Docs, aunque existen, pero hay muchas páginas a las que les faltan grandes porciones de su contenido.
+  - **Revisa la estructura de la página**: Revisa la página para asegurar que esté estructurada apropiadamente para su [tipo de página](/es/docs/MDN/Writing_guidelines/Page_structures/Page_types). Asegúrate de que todas las secciones estén presentes y tengan contenido apropiado.
+  - **Asegura la completitud**: Revisa las secciones para asegurar que no falte información. Asegúrate de que todos los parámetros estén listados y explicados. Asegúrate de que cualquier excepción esté cubierta; este es un lugar particularmente común donde falta contenido.
+  - **Asegúrate de que todos los conceptos estén completamente desarrollados**: Es fácil dar una explicación rápida de algo, pero asegúrate de que se cubran todos los matices. ¿Hay casos especiales? ¿Hay restricciones conocidas que el lector podría necesitar saber?
+  - **Agrega ejemplos**: Debe haber ejemplos que cubran todos los parámetros o al menos los parámetros (o propiedades, o atributos) que es probable que los usuarios del rango de principiante a intermedio usen, así como cualquiera avanzada que requiera explicación adicional. Cada ejemplo debe ir precedido de una descripción general de lo que hará el ejemplo, qué conocimiento adicional podría ser necesario para entenderlo, etc. Después del ejemplo (o intercalado entre partes del ejemplo) debe haber texto que explique cómo funciona el código. No escatimes en los detalles ni en el manejo de errores en los ejemplos. Ten en cuenta que los usuarios _copiarán y pegarán_ tu ejemplo para usarlo en sus propios proyectos, y tu código _terminará_ siendo usado en sitios de producción. Consulta nuestras [pautas de ejemplo de código](/es/docs/MDN/Writing_guidelines/Code_style_guide) para más información útil.
+  - **Explica casos de uso**: Si hay casos de uso particularmente comunes para la característica que se está describiendo, ¡habla de ellos! En lugar de asumir que un usuario descubrirá que el método que se está documentando se puede usar para resolver un problema común de desarrollo, agrega realmente una sección sobre ese caso de uso con un ejemplo y texto que explique cómo funciona el ejemplo.
+  - **Agrega información de imágenes**: Incluye texto `alt` apropiado en todas las imágenes y diagramas. Este texto, así como los títulos en las tablas y otras figuras, cuenta porque los robots no pueden rastrear imágenes, por lo que el texto `alt` le dice a los rastreadores de motores de búsqueda qué contenido contiene el medio incrustado.
+    > [!NOTE]
+    > No se recomienda incluir demasiadas palabras clave o palabras clave no relacionadas con la característica en un intento de manipular los rankings de los motores de búsqueda; este tipo de comportamiento es fácil de detectar y tiende a ser penalizado.
+    > Del mismo modo, **no** agregues material repetitivo e inútil o blobs de palabras clave dentro de la página real, en un intento de mejorar el tamaño y el ranking de búsqueda de la página. Esto hace más daño que bien, tanto para la legibilidad del contenido como para nuestros resultados de búsqueda.
+
+- **Enfócate en el contenido del tema**: Es mucho mejor escribir contenido en torno al tema de la página que una palabra clave específica. Es muy probable que haya muchas palabras clave que podrías incluir para un tema dado; de hecho, muchos expertos en SEO compilan una lista de 5-100 palabras clave diferentes (variando entre palabras clave cortas, medianas y de cola larga) para incluir dentro de su artículo, dependiendo de la longitud. Hacerlo diversificará tu redacción, lo que llevará a menos repetición.
+
+## Estilo de redacción
+
+Además de escribir oraciones gramaticalmente correctas en inglés, te recomendamos que sigas estas pautas para mantener el contenido coherente en MDN Web Docs.
+
+- [Abreviaturas y acrónimos](#abreviaturas_y_acronimos)
+- [Uso de mayúsculas](#uso_de_mayusculas)
+- [Contracciones](#contracciones)
+- [Números y numerales](#numeros_y_numerales)
+- [Pluralización](#pluralizacion)
+- [Apóstrofos y comillas](#apostrofos_y_comillas)
+- [Comas](#comas)
+- [Guiones](#guiones)
+- [Ortografía](#ortografia)
+- [Terminología](#terminologia)
+- [Voz](#voz)
+
+### Abreviaturas y acrónimos
+
+Una abreviatura es una versión acortada de una palabra más larga, mientras que un acrónimo es una nueva palabra creada usando la primera letra de cada palabra de una frase. Esta sección describe las pautas para abreviaturas y acrónimos.
+
+- **Expansiones**: En la primera mención de un término en una página, expande los acrónimos que es probable que los usuarios desconozcan. En caso de duda, expande el término. Aún mejor, vincúlalo al artículo o la entrada del [glosario](/es/docs/Glossary) que describe la tecnología.
+  - **Correcto**: "XUL (XML User Interface Language) es el lenguaje basado en XML de Mozilla..."
+  - **Incorrecto**: "XUL es el lenguaje basado en XML de Mozilla..."
+
+- **Uso de mayúsculas y puntos**: Usa mayúsculas completas y elimina los puntos en todas las abreviaturas y acrónimos, incluyendo organizaciones como "US" y "UN".
   - **Correcto**: XUL
   - **Incorrecto**: X.U.L.; Xul
 
-### Expansión
+- **Abreviaturas latinas**: Puedes usar abreviaturas latinas comunes (etc., i.e., e.g.) en expresiones entre paréntesis y notas. Usa puntos en estas abreviaturas, seguidos de una coma u otra puntuación apropiada.
 
-- Siempre que sea posible, cuando uses siglas deberás expandirlas, es decir, explicar su significado. Recuerda que esto es necesario sólo la primera vez que dicha sigla aparezca en tu artículo.
-  - **Correcto**: "SVG (Gráficos vectoriales escalables) es un lenguaje de marcado XML..."
-  - **Incorrecto**: "SVG es un lenguaje de marcado XML..."
+  <!-- markdownlint-disable search-replace -->
+  - **Correcto**: Los navegadores web (p.ej., Firefox) pueden ser usados ...
+  - **Incorrecto**: Los navegadores web p.ej. Firefox pueden ser usados ...
+  - **Incorrecto**: Los navegadores web, p.ej. Firefox, pueden ser usados ...
+  - **Incorrecto**: Los navegadores web, (ej: Firefox) pueden ser usados ...
 
-- También existe la opción de usar el elemento abbr:
-  - El siguiente código: `<abbr title='Gráficos vectoriales escalables'>SVG</abbr>`
-  - Se muestra de la siguiente forma: SVG
+  <!-- markdownlint-enable search-replace -->
 
-### Plurales
+  En el texto regular (es decir, texto fuera de notas o paréntesis), usa el equivalente en inglés de la abreviatura.
+  - **Correcto**: ... navegadores web, y así sucesivamente.
+  - **Incorrecto**: ... navegadores web, etc.
 
-- Para indicar el plural de una sigla usas "s".
+  - **Correcto**: Los navegadores web como Firefox pueden ser usados ...
+  - **Incorrecto**: Los navegadores web p.ej., Firefox pueden ser usados ...
+
+  La siguiente tabla resume los significados y equivalentes en inglés de las abreviaturas latinas:
+
+  <!-- markdownlint-disable search-replace -->
+
+  | Abreviatura | Latino           | Español                      |
+  | ----------- | ---------------- | ---------------------------- |
+  | cf.         | _confer_         | compara                      |
+  | e.g.        | _exempli gratia_ | por ejemplo                  |
+  | et al.      | _et alii_        | y otros                      |
+  | etc.        | _et cetera_      | y así sucesivamente, y demás |
+  | i.e.        | _id est_         | es decir, en otras palabras  |
+  | N.B.        | _nota bene_      | nota bien                    |
+  | P.S.        | _post scriptum_  | posdata                      |
+
+  <!-- markdownlint-enable search-replace -->
+
+  > [!NOTE]
+  > Considera siempre si es verdaderamente beneficioso usar una abreviatura latina. Algunas de estas se usan tan raramente que muchos lectores las confundirán o no entenderán sus significados.
+  >
+  > Además, asegúrate de que _tú_ las uses correctamente si decides hacerlo. Por ejemplo, ten cuidado de no confundir "e.g." con "i.e.", lo cual es un error común.
+
+- **Plurales de abreviaturas y acrónimos**: Para los plurales de abreviaturas y acrónimos, agrega _s_. No uses un apóstrofo. Nunca. Por favor.
   - **Correcto**: CD-ROMs
   - **Incorrecto**: CD-ROM's
 
-## Números
+- **"Versus", "vs." y "v."**: Si usas la contracción, "vs." se prefiere sobre "v." y se puede usar en encabezados. En el resto del texto, usa la forma escrita "versus".
+  - **Correcto**: esto vs. aquello
+  - **Incorrecto**: esto v. aquello
+  - **Correcto**: esto versus aquello
 
-### Fechas
+### Uso de mayúsculas
 
-- Para las fechas usa el formato: día mes año.
-  - **Correcto**: 1 de enero de 2006
-  - **Incorrecto**: 01/02/06
+Usa las reglas estándar de mayúsculas en inglés en el texto del cuerpo, y usa mayúsculas en "World Wide Web". Es aceptable usar minúsculas para "web" (usado solo o como modificador) e "internet".
 
-### Cantidades
+> [!NOTE]
+> Esta pauta es un cambio de una versión anterior de esta guía, por lo que puedes encontrar muchas instancias de "Web" e "Internet" en MDN.
+> Siéntete libre de cambiarlas mientras haces otros cambios, pero editar un artículo solo para cambiar las mayúsculas no es necesario.
 
-- Usa coma para separar los decimales y punto para indicar miles:
-  - **Correcto**: 1,5 GB son 1.536 MB
-  - **Incorrecto**: 1.5 GB son 1536 MB
+Las teclas del teclado deben usar mayúsculas estilo oración, no mayúsculas completas.
+Por ejemplo, "<kbd>Enter</kbd>" no "<kbd>ENTER</kbd>".
+La única excepción es que puedes usar "<kbd>ESC</kbd>" para abreviar la tecla "<kbd>Escape</kbd>".
 
-Esta regla tiene una excepción: en un documento que trate del lenguaje 'X', las cantidades deben expresarse del modo definido por ese lenguaje.
+Ciertas palabras siempre deben usar mayúsculas, como las marcas comerciales que incluyen letras mayúsculas o palabras que derivan del nombre de una persona (a menos que la palabra se esté usando dentro del código y la sintaxis del código requiera minúsculas).
+Algunos ejemplos incluyen:
 
-## Usted, tú y yo
+- Boolean (llamado así por el matemático y lógico inglés [George Boole](https://en.wikipedia.org/wiki/George_Boole))
+- JavaScript (una marca comercial de Oracle Corporation, siempre debe escribirse como marca comercial)
+- Python, TypeScript, Django y otros nombres de lenguajes de programación y frameworks
 
-### El tuteo
+Algunos nombres de herramientas y proyectos tienen sus propias reglas de mayúsculas de marca. Estos pueden requerir nombres que están todos en minúsculas ("npm" o "webpack"), todos en mayúsculas ("UNIX", "GNOME", "VIM"), o en mayúsculas y minúsculas ("TypeScript", "macOS" o "jQuery").
 
-Este es un problema complejo, puede que no exista la solución perfecta a gusto de todos. Pero sería interesante ponernos de acuerdo.
+Las mayúsculas de marca del sitio web oficial o la documentación siempre deben usarse, incluso al principio de una oración. Si no te sientes cómodo con una oración que comienza con una letra minúscula, recomendamos reformular para evitar el problema. Por ejemplo, podrías decir "Puedes usar el gestor de paquetes npm para..." en lugar de "npm te permite...".
 
-Por lo pronto, hemos decidido usar el tú y evitar regionalismos en nuestras traducciones. Te invitamos a comentar tus opiniones en nuestra lista de correo.
+### Contracciones
 
-### La 1ª persona
+Nuestro estilo de redacción tiende a ser informal, así que debes sentirte libre de usar contracciones (p.ej., "don't", "can't", "shouldn't"), si prefieres.
 
-Salvo rarísimas excepciones, nunca debe usarse.
+### Números y numerales
 
-- **Correcto**: es recomendable...
-- **Incorrecto**: te recomiendo...
+- **Comas**: En el texto en ejecución, usa comas solo en números de cinco dígitos y más grandes.
+  - **Correcto**: 4000; 54,000
+  - **Incorrecto**: 4,000; 54000
 
-## Otras guías de estilo recomendadas
+- **Fechas**: Para las fechas (sin incluir fechas en muestras de código), usa el formato "1 de enero de 1900".
+  - **Correcto**: 24 de febrero de 1906
+  - **Incorrecto**: 24 de febrero de 1906; 24 de febrero de 1906; 24/02/1906
 
-Si tienes dudas sobre usos y estilos que no sean tratados en este documento, te recomendamos consultar:
+  Alternativamente, puedes usar el formato AAAA/MM/DD.
+  - **Correcto**: 1906/02/24
+  - **Incorrecto**: 02/24/1906; 24/02/1906; 02/24/06
 
-- [Manual de estilo del CICESE](http://usuario.cicese.mx/~mechevar/manual/) Sobre como escribir documentación técnica.
-- [Manual de estilo de Wikipedia](http://es.wikipedia.org/wiki/Manual_de_estilo) Sobre como escribir en un wiki.
+- **Décadas**: Usa el formato "1990s". No uses un apóstrofe.
+  - **Correcto**: 1920s
+  - **Incorrecto**: 1920's
 
-Los traductores también deberían consultar [Writer's guide](/Project:en/Writer%27s_guide) para conocer el estilo usado en la edición inglesa.
+- **Plurales de numerales**: Agrega "s". No uses un apóstrofe.
+  - **Correcto**: 486s
+  - **Incorrecto**: 486's
 
-## Diccionarios recomendados
+### Pluralización
 
-Si tienes dudas sobre gramática y ortografía, puedes visitar:
+Usa plurales estilo inglés, no las formas influenciadas por el latín o el griego.
 
-- [Diccionario de la Real Academia Española](http://www.rae.es/rae.html)
-- [Diccionario Panhispánico de Dudas](http://www.rae.es/rae.html)
+- **Correcto**: syllabuses, octopuses
+- **Incorrecto**: syllabi, octopi
+
+### Apóstrofos y comillas
+
+No uses comillas y apóstrofos "curvos". En MDN Web Docs, solo usamos comillas y apóstrofos rectos. Esto se debe a que necesitamos elegir uno u otro para mantener la coherencia. Si las comillas curvas o los apóstrofos llegan a los fragmentos de código, incluso los en línea, los lectores pueden copiarlos y pegarlos, esperando que funcionen (lo cual no harán).
+
+- **Correcto**: Please don't use "curly quotes."
+- **Incorrecto**: Please don&rsquo;t use &ldquo;curly quotes.&rdquo;
+
+### Comas
+
+La siguiente lista describe algunas de las situaciones comunes donde necesitamos estar conscientes de las reglas de uso de la coma:
+
+- **Después de cláusulas introductorias**: Una cláusula introductoria es una cláusula dependiente, generalmente encontrada al principio de una oración. Usa una coma después de una cláusula introductoria para separarla de la siguiente cláusula independiente.
+  - Ejemplo 1:
+    - **Correcto**: "In this example, you will learn how to use a comma."
+    - **Incorrecto**: "In this example you will learn how to use a comma."
+  - Ejemplo 2:
+    - **Correcto**: "If you are looking for guidelines, refer to our writing style guide."
+    - **Incorrecto**: "If you are looking for guidelines refer to our writing style guide."
+  - Ejemplo 3:
+    - **Correcto**: "On mobile platforms, you tend to get a numeric keypad for entering data."
+    - **Incorrecto**: "On mobile platforms you tend to get a numeric keypad for entering data."
+
+- **Antes de conjunciones**: La coma en serie (también conocida como "coma Oxford") es la coma que aparece antes de la conjunción en una serie de tres o más elementos. En MDN Web Docs, usamos la coma en serie. Las comas también separan cada elemento de la lista.
+  - **Correcto**: "I will travel on trains, planes, and automobiles."
+  - **Incorrecto**: "I will travel on trains, planes and automobiles."
+
+  No uses coma antes de "and" y "or" en una lista que contiene dos elementos.
+  - **Correcto**: "My dog is cute and smart."
+  - **Incorrecto**: "My dog is cute, and smart."
+
+  Usa coma antes de las conjunciones "and", "but" y "or" si unen dos cláusulas independientes. Sin embargo, si la oración se está volviendo muy larga o compleja con la conjunción, considera reescribirla como dos oraciones.
+  - Ejemplo 1:
+    - **Correcto**: "You can perform this step, but you need to pay attention to the file setting."
+    - **Incorrecto**: "You can perform this step but you need to pay attention to the file setting."
+  - Ejemplo 2:
+    - **Correcto**: "My father is strict but loving."
+    - **Incorrecto**: "My father is strict, but loving."
+
+- **Antes de "that" y "which"**: Una cláusula restrictiva es esencial para el significado de la oración y no necesita comas para separarse del resto de la oración. Una cláusula restrictiva generalmente se introduce por "that" y **no debe** ir precedida de una coma.
+  - **Correcto**: "We have put together a course that includes all the essential information you need to work towards your goal."
+  - **Incorrecto**: "We have put together a course, that includes all the essential information you need to work towards your goal."
+
+  Una cláusula no restrictiva proporciona información adicional y no es esencial para el significado de la oración. Una cláusula no restrictiva generalmente se introduce por "which" y debe ir precedida de una coma.
+  - **Correcto**: "You write a policy, which is an allowed list of origins for each feature."
+  - **Incorrecto**: "You write a policy which is an allowed list of origins for each feature."
+
+- **Antes de "such as"**: Si "such as" es parte de una cláusula no restrictiva y el resto de la oración es una cláusula independiente, usa coma antes de "such as".
+  - **Correcto**: "The Array object has methods for manipulating arrays in various ways, such as joining, reversing, and sorting them."
+  - **Incorrecto**: "The Array object has methods for manipulating arrays in various ways such as joining, reversing, and sorting them."
+
+  El siguiente ejemplo muestra cuándo no usar una coma con "such as". En este caso, la cláusula que contiene "such as" es esencial para el significado de la oración.
+  - **Correcto**: "Web applications are becoming more powerful by adding features such as audio and video manipulation and allowing access to raw data using WebSockets."
+  - **Incorrecto**: "Web applications are becoming more powerful by adding features, such as audio and video manipulation, and allowing access to raw data using WebSockets."
+
+### Guiones
+
+Las palabras compuestas solo deben llevar guión cuando la última letra del prefijo es una vocal y es la misma que la primera letra de la raíz.
+
+- **Correcto**: re-elect, co-op, email
+- **Incorrecto**: reelect, coop, e&#45;mail
+
+### Ortografía
+
+Usa la ortografía del inglés americano.
+
+En general, usa la primera entrada en [Dictionary.com](https://www.dictionary.com/), a menos que esa entrada esté listada como una variante ortográfica o como usada principalmente en una forma no americana del inglés.
+Por ejemplo, si [buscas "behaviour"](https://www.dictionary.com/browse/behaviour) (con una _u_ adicional agregada a la forma estándar americana), encontrarás la frase "Chiefly British" seguida de un enlace a la forma estándar americana, ["behavior"](https://www.dictionary.com/browse/behavior).
+No uses la ortografía variante.
+
+<!-- cSpell:ignore localise behaviour colour -->
+
+- **Correcto**: localize, behavior, color
+- **Incorrecto**: localise, behaviour, colour
+
+Tenemos [cSpell](https://cspell.org/) instalado para detectar errores ortográficos. Se ejecuta cada semana y genera [un informe de errores ortográficos](https://github.com/mdn/content/issues?q=Weekly+spelling+check+is%3Aissue+in%3Atitle) en el repositorio. También puedes ejecutarlo localmente usando el siguiente comando:
+
+```bash
+npm run lint:typos
+```
+
+En el repositorio, mantenemos varias listas de palabras, ubicadas en [`.vscode/dictionaries`](https://github.com/mdn/content/tree/main/.vscode/dictionaries), que contienen palabras sancionadas que no están en los diccionarios predeterminados. Puedes agregar más palabras a estas listas si son válidas pero reportadas por el corrector ortográfico. Lee [`.vscode/cspell.json`](https://github.com/mdn/content/blob/main/.vscode/cspell.json) para entender qué contiene cada diccionario y los detalles de nuestra configuración de verificación ortográfica.
+
+### Terminología
+
+Estas son nuestras recomendaciones para usar ciertos términos técnicos:
+
+- **Elementos HTML**: Usa el término "elemento" para referirte a los elementos HTML y XML, en lugar de "etiqueta". Además, el elemento debe estar envuelto en corchetes angulares "<>" y debe estar estilizado usando comillas inversas (`` ` ``). Por ejemplo, usar \<input\> dentro de comillas inversas lo estilizará como `<input>` como se espera.
+  - **Correcto**: el elemento `<span>`
+  - **Incorrecto**: la etiqueta span
+
+  En MDN, opcionalmente puedes especificar el elemento HTML en el [`HTMLElement` macro](/es/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros#linking_to_reference_pages), que lo estilizará, agregará los corchetes angulares "<>", así como agregará un enlace a su página de referencia.
+  - **Usando comillas inversas**: `<span>`
+  - **Usando la macro**: {{HTMLElement("span")}} (fuente en markdown: `\{{HTMLElement("span")}}`)
+
+- **Parámetros vs. argumentos**: El término preferido en MDN Web Docs es **parámetros**. Por favor, evita el término "argumentos" para mantener la coherencia siempre que sea posible.
+
+- **Acciones de la interfaz de usuario**: En secuencias de tareas, describe las acciones de la interfaz de usuario usando el modo imperativo. Identifica el elemento de la interfaz de usuario por su etiqueta y tipo.
+  - **Correcto**: "Click the Edit button."
+  - **Incorrecto**: "Click Edit."
+
+### Voz
+
+Aunque se prefiere la voz activa, la voz pasiva también es aceptable, dado el carácter informal de nuestro contenido.
+Intenta ser coherente, sin embargo.
+
+## Componentes de la página
+
+Esta sección enumera las pautas a seguir para diferentes partes de cada página, como encabezados, notas, enlaces y ejemplos.
+
+- [Ejemplos de código](#ejemplos_de_codigo)
+- [Referencias cruzadas (vinculación)](#referencias_cruzadas_vinculacion)
+- [Enlaces externos](#enlaces_externos)
+- [URL acortadas (enlaces cortos)](#url_acortadas_enlaces_cortos)
+- [Niveles de encabezado](#niveles_de_encabezado)
+- [Imágenes y otros medios](#imagenes_y_otros_medios)
+- [Listas](#listas)
+- [Sección Véase también](#seccion_vease_tambien)
+- [Subpáginas](#subpaginas)
+- [Slugs](#slugs)
+- [Títulos](#titulos)
+
+### Ejemplos de código
+
+Una página en MDN Web Docs puede contener más de un ejemplo de código. La siguiente lista presenta algunas prácticas recomendadas al escribir un ejemplo de código para MDN Web Docs:
+
+- Cada pieza de código de ejemplo debe incluir:
+  - **Encabezado**: Un encabezado corto `###` (`<h3>`) para describir el escenario que se demuestra a través del ejemplo de código. Por ejemplo, "Using offset printing" y "Reverting to style in previous layer".
+  - **Descripción**: Una descripción corta que precede al código de ejemplo que indica las especificidades del ejemplo al que deseas llamar la atención del lector. Por ejemplo, "In the following example, two cascade layers are defined in the CSS, `base` and `special`."
+  - **Explicación del resultado**: Una explicación después del código de ejemplo que describe el resultado y cómo funciona el código.
+- En general, el ejemplo de código no solo debe demostrar la sintaxis de la característica y cómo se usa, sino también resaltar el propósito y las situaciones en las que un desarrollador web podría querer o necesitar usar la característica.
+- Si estás trabajando con una pieza grande de código de ejemplo, puede tener sentido dividirla en partes lógicas más pequeñas para que puedan describirse individualmente.
+- Al agregar [ejemplos en vivo](/es/docs/MDN/Writing_guidelines/Page_structures/Live_samples), es útil estar consciente de que todos los bloques de código del ejemplo que tienen el mismo tipo (HTML, CSS y JavaScript) se concatenan antes de ejecutar el ejemplo. Esto te permite dividir el código en múltiples segmentos, cada uno opcionalmente con sus propias descripciones, encabezados, etc. Esto hace que documentar el código sea increíblemente potente y flexible.
+
+Para aprender cómo estilizar o formatear ejemplos de código para MDN Web Docs, consulta nuestras [Pautas para estilizar ejemplos de código](/es/docs/MDN/Writing_guidelines/Code_style_guide).
+
+### Referencias cruzadas (vinculación)
+
+Al hacer referencia a otra página o sección de una página en MDN por su título, sigue el uso de mayúsculas estilo oración en el texto del enlace (coincide con el título de la página o sección). Usa el uso de mayúsculas estilo oración en el texto del enlace incluso si es diferente del título de la página o sección vinculada (podría ser que el uso de mayúsculas en el título de la página o sección sea incorrecto). No uses comillas alrededor del texto del enlace. Para referirte a una página en MDN por su título, usa el siguiente estilo:
+
+- **Correcto**: "Refer to the [Ordering flex items](/es/docs/Web/CSS/Guides/Flexible_box_layout/Ordering_items) guide."
+- **Incorrecto**: "Refer to the "[Ordering flex items](/es/docs/Web/CSS/Guides/Flexible_box_layout/Ordering_items)" guide."
+
+Sigue un estilo coherente al vincular a secciones dentro de una página:
+
+- **Correcto**: "For more information, refer to the [Allocation in JavaScript](/es/docs/Web/JavaScript/Guide/Memory_management#allocation_in_javascript) section in the _Memory management_ guide."
+
+Si la sección a la que te estás vinculando está en la misma página, puedes sugerir la ubicación de la sección usando frases descriptivas.
+
+- **Correcto**: "This concept is described in more detail in the [Accessibility](/es/docs/Web/CSS/Reference/Values/gradient/repeating-conic-gradient#accesibilidad) section of this document."
+- **Incorrecto**: "This concept is described in more detail in the [Accessibility](/es/docs/Web/CSS/Reference/Values/gradient/repeating-conic-gradient#accesibilidad) section below."
+
+En MDN, otra forma de vincular a una página de referencia es usando una macro. Estas macros se describen en la página [Macros de uso común](/es/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros#linking_to_reference_pages). Por ejemplo, para vincular a la página de referencia de un elemento HTML, usa la macro `HTMLElement`, y para vincular a la página de referencia de una propiedad de CSS, usa la macro `CSSxRef`.
+
+Seguimos pautas similares de referencia cruzada en las secciones [Véase también](#seccion_vease_tambien) al final de las páginas de referencia, páginas del glosario y guías.
+
+### Enlaces externos
+
+Los enlaces externos están permitidos en MDN Web Docs en situaciones específicas. Usa las pautas descritas en esta sección para decidir si es o no aceptable incluir un enlace externo en MDN Web Docs. Las solicitudes de incorporación de cambios que agreguen enlaces externos serán rechazadas si no siguen estas pautas.
+
+Si estás considerando agregar un enlace externo al contenido [Aprender desarrollo web](/es/docs/Learn_web_development) de MDN, por favor también lee [Pautas de redacción de contenido de aprendizaje > Enlaces y recursos asociados](/es/docs/MDN/Writing_guidelines/Learning_content#partner_links_and_embeds).
+
+En general, si estás considerando agregar un enlace externo, necesitas asegurar que haya un riesgo mínimo de lo siguiente:
+
+- Enlaces rotos o desactualizados
+- Apariencia de respaldo, especialmente para productos o servicios comerciales
+- Intento de usar MDN Web Docs para distribuir spam
+- Enlaces cortos que ofuscan el destino del enlace
+
+> [!NOTE]
+> Antes de agregar un enlace externo, considera hacer referencias cruzadas dentro de MDN Web Docs. Los enlaces internos son más fáciles de mantener y hacen que la totalidad de MDN Web Docs sea más valiosa para los lectores.
+
+- **Buenos enlaces externos**: Los buenos enlaces externos llevan a los lectores a recursos que son relevantes, duraderos y ampliamente confiables. Debes preferir agregar enlaces a contenido externo que sea:
+  - Único o indispensable (p.ej., un IETF RFC)
+  - Necesario para la atribución, cita o reconocimiento (p.ej., como parte de una atribución de Creative Commons)
+  - Más probable que se mantenga para el tema que incorporar dicho contenido en MDN Web Docs mismo (p.ej., las notas de lanzamiento de un proveedor)
+  - Código abierto o impulsado por la comunidad, como MDN Web Docs mismo
+
+- **Malos enlaces externos**: Los malos enlaces externos carecen de relevancia, capacidad de mantenimiento, accesibilidad, o de otra manera ponen barreras a los lectores. Evita agregar enlaces a contenido externo que sea:
+  - Genérico o no específico (p.ej., la página de inicio de un proveedor, en lugar de la documentación relacionada)
+  - Efímero o no mantenido (p.ej., un anuncio de una sola vez)
+  - Autovinculación o autopromoción (p.ej., el propio trabajo del autor fuera de MDN Web Docs)
+  - De pago (p.ej., un curso costoso fuera del alcance de aficionados, estudiantes o lectores que viven en países de bajos ingresos)
+  - Inaccesible (p.ej., un video sin subtítulos)
+
+- **Enlaces que son autopromocionales o spam**: Si bien una publicación de blog personal, una charla de conferencia o un repositorio de GitHub tienen valor, vincular a tus propios recursos puede crear la apariencia de un conflicto de intereses. Piénsalo dos veces antes de vincular a recursos con los que tienes una relación comercial o personal.
+
+  > [!NOTE]
+  > Si tienes una relación comercial o personal con el destino de un enlace, debes divulgar esa relación en tu solicitud de incorporación de cambios. No hacerlo puede poner en peligro tu participación continua con MDN Web Docs.
+
+  A veces dichos enlaces son relevantes y apropiados. Por ejemplo, si eres el editor de una especificación y estás contribuyendo a la documentación relacionada con esa especificación, entonces vincular a esa especificación se espera y es aceptable. Pero debes divulgar la relación entre tú y el enlace.
+
+### URL acortadas (enlaces cortos)
+
+Un acortador de URL (como TinyURL o Bitly) puede ser excelente para acortar enlaces largos en URL pequeñas y más fáciles de recordar (también conocidas como "enlaces cortos"). Sin embargo, también ofuscan el destino de la URL. Además, con ciertos acortadores, el destino puede cambiarse después de su creación, una característica que podría usarse para fines maliciosos.
+
+No uses enlaces creados a través de acortadores de URL de terceros (generables por el usuario). Por ejemplo, si `https://myshort.link/foobar` es una URL corta generada por un usuario aleatorio y redirige a `https://example.com/somelongURL/details/show?page_id=foobar`, usa la URL más larga de `example.com`.
+
+<!-- markdownlint-disable search-replace -->
+
+Por otro lado, se fomentan los acortadores de primera parte que son mantenidos por las organizaciones que también mantienen las URL de destino. `https://bugzil.la` es propiedad y está operado por Mozilla y es un acortador de URL que redirige a `https://bugzilla.mozilla.org/`, que también es un dominio propiedad de Mozilla. En este caso, usa la URL más corta. Por ejemplo, usa `https://bugzil.la/1682349` en lugar de `https://bugzilla.mozilla.org/show_bug.cgi?id=1682349`.
+
+<!-- markdownlint-enable search-replace -->
+
+### Niveles de encabezado
+
+Cuando un nuevo párrafo comienza una nueva sección, se debe agregar un encabezado.
+Usa estos niveles de encabezado markdown en orden descendente sin saltar niveles: `##`, luego `###`, y luego `####`; estos se traducen a las [etiquetas de encabezado HTML](/es/docs/Web/HTML/Reference/Elements/Heading_Elements) `<h2>`, `<h3>` y `<h4>`, respectivamente.
+
+`##` es el nivel más alto permitido porque `#` está reservado para el título de la página.
+Recomendamos no agregar más de tres niveles de encabezados. Si sientes la necesidad de agregar el cuarto nivel de encabezado, considera dividir el artículo en varios artículos más pequeños con una página de aterrizaje. Alternativamente, considera presentar la información como puntos con viñetas para evitar usar un encabezado de nivel cuatro.
+
+Ten en cuenta los siguientes "hacer" y "no hacer" mientras creas encabezados para subsecciones:
+
+- **No crees subsecciones individuales.** No subdividas un tema en un solo subtema.
+  O son dos subencabezados o más, o ninguno en absoluto.
+- **No uses estilos en línea, clases o macros dentro de los encabezados.** Sin embargo, puedes usar comillas inversas para indicar términos de código (p.ej., "Using `FooBar` interface").
+- **No crees "cabezas que chocan".** Estos son encabezados seguidos inmediatamente por un subencabezado, sin texto de contenido entre ellos.
+  Esto no se ve bien y deja a los lectores sin ningún texto explicativo al comienzo de la sección externa.
+
+### Imágenes y otros medios
+
+Si incluyes imágenes u otros medios en una página, sigue estas pautas:
+
+- Asegúrate de que la licencia del medio te permita usarlos. Intenta usar medios que tengan una licencia muy permisiva como [CC0](https://creativecommons.org/public-domain/cc0/) o al menos una que sea compatible con nuestra licencia de contenido general — [Licencia Creative Commons Atribución-CompartirIgual](https://creativecommons.org/licenses/by-sa/2.5/) (CC-BY-SA).
+- Para las imágenes, pásalas por <https://tinypng.com> o <https://imageoptim.com> para reducir el peso de la página.
+- Para `SVG`, pasa el código por [SVGOMG](https://jakearchibald.github.io/svgomg/), y asegúrate de que el archivo `SVG` tenga una línea vacía al final del archivo.
+- Cada imagen debe [incluir texto `alt` descriptivo](/es/docs/MDN/Writing_guidelines/Howto/Images_media#adding_alternative_text_to_images).
+
+### Listas
+
+Las listas deben formatearse y estructurarse de manera coherente en todas las páginas.
+Los elementos individuales de la lista deben escribirse con puntuación adecuada, independientemente del formato de la lista.
+Sin embargo, dependiendo del tipo de lista que estés creando, querrás ajustar tu redacción como se describe en las secciones que siguen. En ambos casos, incluye una oración introductoria que describa la información en la lista.
+
+- **Listas con viñetas**: Las listas con viñetas deben usarse para agrupar piezas relacionadas de información concisa. Cada elemento de la lista debe seguir una estructura de oración similar. Las oraciones y frases (es decir, fragmentos de oración que carecen de un verbo o un sujeto o ambos) en las listas con viñetas deben incluir puntuación estándar; las oraciones terminan con puntos, las frases no.
+
+  Si hay múltiples oraciones en un elemento de lista, debe aparecer un punto al final de cada oración, incluida la oración final del elemento, tal como se esperaría en un párrafo. Este es un ejemplo de una lista con viñetas correctamente estructurada:
+
+  > En este ejemplo, debemos incluir:
+  >
+  > - Una condición, con una breve explicación.
+  > - Una condición similar, con una breve explicación.
+  > - Otra condición más, con alguna explicación adicional.
+
+  Observa cómo la misma estructura de oración se repite de viñeta en viñeta. En este ejemplo, cada punto de viñeta establece una condición seguida de una coma y una breve explicación, y cada elemento de la lista termina con un punto.
+
+  Si los elementos de la lista incluyen oraciones incompletas, no se requiere un punto al final. Por ejemplo:
+
+  > Las siguientes propiedades relacionadas con el color serán útiles en este escenario:
+  >
+  > - propiedadA: Establece el color de fondo
+  > - propiedadB: Agrega sombra al texto
+
+  Si uno o más elementos de la lista son oraciones completas, usa un punto después de cada elemento de la lista, incluso si un elemento de la lista contiene tres o menos palabras. Sin embargo, en la medida de lo posible, sigue la misma estructura para todos los elementos de una lista; asegúrate de que todos los elementos de la lista sean oraciones completas o frases.
+
+- **Listas numeradas**: Las listas numeradas se usan principalmente para enumerar pasos en un conjunto de instrucciones. Dado que las instrucciones pueden ser complejas, la claridad es una prioridad, especialmente si el texto en cada elemento de la lista es extenso. Al igual que con las listas con viñetas, sigue el uso estándar de puntuación. Este es un ejemplo de una lista numerada correctamente estructurada:
+
+  > Para estructurar correctamente una lista numerada, debes:
+  >
+  > 1. Abrir con un encabezado o párrafo breve para introducir las instrucciones. Es importante proporcionar al usuario el contexto antes de comenzar las instrucciones.
+  > 2. Comenzar a crear tus instrucciones, y mantener cada paso en su propio elemento numerado.
+  >    Tus instrucciones pueden ser bastante extensas, por lo que es importante escribir con claridad y usar la puntuación correcta.
+  > 3. Después de terminar tus instrucciones, sigue la lista numerada con un breve resumen de cierre o explicación sobre el resultado esperado al completar.
+
+  Lo siguiente es un ejemplo de cómo escribir una explicación de cierre para la lista anterior:
+
+  > Hemos creado una lista numerada corta que proporciona pasos instructivos para producir una lista numerada con el formato correcto.
+
+  Observa cómo los elementos en las listas numeradas se leen como párrafos cortos. Dado que las listas numeradas se usan rutinariamente para fines instruccionales o para guiar a alguien a través de un procedimiento ordenado, asegúrate de mantener cada elemento enfocado: un elemento numerado por paso.
+
+### Sección Véase también
+
+La mayoría de las guías, páginas de referencia e incluso páginas del glosario en MDN Web Docs contienen una sección _Véase también_ al final del artículo. Esta sección contiene [referencias cruzadas](#referencias_cruzadas_vinculacion) a temas relacionados dentro de MDN y, a veces, enlaces a artículos externos relacionados. Por ejemplo, esta es la [sección Véase también](/es/docs/Web/CSS/Reference/At-rules/@layer#see_also) para la página `@layer`.
+
+En general, presenta los enlaces en una sección Véase también en formato de [lista con viñetas](#listas) con cada elemento de la lista como una frase. Sin embargo, en la sección [Aprender desarrollo web](/es/docs/Learn_web_development) de MDN, la sección Véase también sigue el formato de [lista de definiciones](/es/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#definition_lists).
+
+Para mantener la coherencia en MDN Web Docs, ten en cuenta las siguientes pautas al agregar o actualizar una sección Véase también.
+
+#### Texto del enlace
+
+- El texto del enlace debe ser el mismo que el título de la página o la sección a la que se está vinculando. Por ejemplo, el texto del enlace a esta página [ARIA](/es/docs/Web/Accessibility/ARIA/Reference/Attributes) con el título de página "ARIA states and properties" será:
+  - **Correcto**: [ARIA states and properties](/es/docs/Web/Accessibility/ARIA/Reference/Attributes)
+- Usa el uso de mayúsculas estilo oración en el texto del enlace incluso si es diferente del título de la página o sección vinculada. Podría ser que el uso de mayúsculas en el título de la página o sección sea incorrecto. Por ejemplo, el texto del enlace a la página [Quirks Mode](/es/docs/Web/HTML/Guides/Quirks_mode_and_standards_mode) en mayúsculas de oración correctas será:
+  - **Correcto**: [Quirks mode](/es/docs/Web/HTML/Guides/Quirks_mode_and_standards_mode)
+- Para los enlaces externos también, usa mayúsculas de oración incluso si el uso de mayúsculas en la página del artículo de destino es diferente. Esto es para asegurar la coherencia en MDN Web Docs. Las excepciones incluyen nombres de libros.
+- En MDN, opcionalmente puedes usar una macro para vincular a una página, como se explica en la sección [Vincular a páginas de referencia](/es/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros#linking_to_reference_pages) en la página _Macros de uso común_. El uso de la macro agregará formato de código a la palabra clave en el texto del enlace, como se muestra en el siguiente ejemplo.
+- No se necesita ningún artículo ("Un", "Una", "El", "La") al comienzo del elemento de la lista de enlaces. No se requiere puntuación al final del elemento de la lista porque invariablemente será un término o una frase.
+  - **Correcto**: {{cssxref("revert-layer")}}
+  - **Incorrecto**: The {{cssxref("revert-layer")}} keyword.
+  - **Correcto**: [HTML DOM API](/es/docs/Web/API/HTML_DOM_API)
+  - **Incorrecto**: The [HTML DOM API](/es/docs/Web/API/HTML_DOM_API)
+- Como se muestra en los ejemplos anteriores, agrega formato de código usando comillas inversas (`` ` ``) a las palabras clave y literales en el texto del enlace, aunque el formato no se use en los títulos de página y sección. Por ejemplo, para el título de página "Array() constructor", el texto del enlace será [`Array()` constructor](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/Array).
+
+#### Texto descriptivo
+
+- Mantén el texto descriptivo que rodea el enlace al mínimo. En caso de una descripción, agrégala después del texto del enlace y dos puntos. Redacta la descripción como una frase sin puntuación final. Mantén todo el texto vinculado al principio para ayudar a escanear la lista de enlaces.
+  - **Correcto**: {{cssxref(":checked")}}, {{cssxref(":indeterminate")}}: Selectores CSS para estilizar casillas de verificación
+- No uses la conjunción "y" antes del último elemento de la serie.
+  - **Correcto**: {{cssxref("background-color")}}, {{cssxref("border-color")}}, {{cssxref("color")}}, {{cssxref("caret-color")}}, {{cssxref("column-rule-color")}}, {{cssxref("outline-color")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-emphasis-color")}}, {{cssxref("text-shadow")}}: Otras propiedades relacionadas con el color
+- Para los enlaces externos, trata de especificar el sitio web de origen y el año de publicación o última actualización (entre paréntesis) siempre que sea factible y apropiado. Proporcionar esta información por adelantado da a los lectores una idea clara del destino que alcanzarán al hacer clic en el enlace. La fecha de publicación o última actualización guía a los lectores para evaluar la relevancia del artículo vinculado y también ayuda a los mantenedores de MDN a revisar los enlaces a artículos que no se han actualizado en mucho tiempo. Si proporcionas un enlace a un artículo en Wikipedia, por ejemplo, puedes ignorar la fecha de publicación/actualización. El siguiente elemento de la lista es un ejemplo de agregar un enlace al artículo externo [Top-level await](https://v8.dev/features/top-level-await) en la sección Véase también, junto con la información de origen y año:
+  - **Correcto**: [Top-level await](https://v8.dev/features/top-level-await) en v8.dev (2019)
+- Para los enlaces externos a libros, también puedes proporcionar los nombres de los autores. Se enumeran algunos ejemplos en la sección [Lectura adicional](#idioma_gramatica_y_ortografia). Abstente de agregar nombres de autores para publicaciones de blog o repositorios de GitHub a los que puedas vincular.
+
+#### Orden de los enlaces
+
+- Lista los enlaces a las páginas de MDN en el orden de páginas de referencia primero, seguidos de enlaces a las guías y páginas de tutoriales relacionados. Este orden sugerido es principalmente para ayudar en la capacidad de escaneo de los elementos de la lista.
+- Si la lista es una mezcla de enlaces internos y externos, primero lista los enlaces internos y luego los externos.
+- Dentro de cada grupo de enlaces internos y externos, sigue el orden alfabético o de simple a avanzado, lo que tenga más sentido para el contexto.
+
+### Subpáginas
+
+Cuando necesites agregar algunos artículos sobre un tema o área temática, generalmente lo harás creando una página de aterrizaje, luego agregando subpáginas para cada uno de los artículos individuales.
+La página de aterrizaje debe abrirse con un párrafo o dos que describan el tema o la tecnología, luego proporcionar una lista de las subpáginas con descripciones de cada página.
+Puedes automatizar la inserción de páginas en la lista usando algunas macros que hemos creado.
+
+Por ejemplo, considera la guía [JavaScript](/es/docs/Web/JavaScript), que está estructurada de la siguiente manera:
+
+- [JavaScript/Guide](/es/docs/Web/JavaScript/Guide) – Página principal de la tabla de contenidos
+- [JavaScript/Guide/JavaScript Overview](/es/docs/Web/JavaScript/Guide/Introduction)
+- [JavaScript/Guide/Functions](/es/docs/Web/JavaScript/Guide/Functions)
+- [JavaScript/Guide/Details of the Object Model](/es/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain)
+
+Intenta evitar poner tu artículo en la parte superior de la jerarquía, lo que ralentiza el sitio y hace que la búsqueda y la navegación por el sitio sean menos efectivas.
+
+### Slugs
+
+El título de la página, que se muestra en la parte superior de la página, puede ser diferente del "slug" de la página, que es la porción de la URL de la página que sigue a `<locale>/docs/`. Ten en cuenta las siguientes pautas al definir un slug:
+
+- Los slugs deben mantenerse cortos. Al crear un nuevo nivel de jerarquía, el componente del nuevo nivel en el slug debe ser solo una o dos palabras.
+- Los slugs deben usar un guión bajo para un componente de varias palabras, como `Basic_HTML_syntax` en `/es/docs/Learn_web_development/Core/Structuring_content/Basic_HTML_syntax`.
+- Sigue el uso de mayúsculas estilo oración en los slugs también para cada componente, como `Basic_HTML_syntax` en el ejemplo anterior.
+
+### Títulos
+
+Los títulos de página se usan en los resultados de búsqueda y también se usan para estructurar la jerarquía de la página en la lista de migas de pan en la parte superior de la página. Un título de página puede ser diferente del "slug" de la página, como se explica en la sección [Slugs](#slugs).
+
+Ten en cuenta las siguientes pautas al escribir títulos:
+
+- **Estilo de mayúsculas**: En MDN Web Docs, los títulos de página y los encabezados de sección deben usar mayúsculas estilo oración (solo poner en mayúscula la primera palabra y los sustantivos propios) en lugar de mayúsculas estilo titular:
+  - **Correcto**: "A new method for creating JavaScript rollovers"
+  - **Incorrecto**: "A New Method for Creating JavaScript Rollovers"
+
+  Tenemos muchas páginas antiguas que se escribieron antes de que se estableciera esta regla de estilo. Siéntete libre de actualizarlas según sea necesario si lo deseas. Gradualmente estamos llegando a ellas.
+
+- **Pautas generales**: Decidir qué quieres documentar y cómo estructurarás ese contenido es uno de los primeros pasos en la redacción. Escribir una tabla de contenidos puede ayudarte a decidir cómo quieres ordenar la información. Cubre conceptos simples primero y luego pasa a conceptos más complicados y avanzados. Cubre información conceptual primero y luego pasa a temas orientados a la acción.
+
+  Ten en cuenta las siguientes pautas al escribir títulos para una página y secciones o subsecciones:
+  - **Ve de mayor a menor**: Como se indica en la sección [Niveles de encabezado](#niveles_de_encabezado), ve de `##` más alto a `####` más bajo, sin saltar niveles. Usa encabezados de nivel más alto para títulos introductorios más amplios, y usa títulos más específicos a medida que avanzas a encabezados de nivel más bajo.
+  - **Agrupa lógicamente**: Asegúrate de que todas las subsecciones relacionadas se agrupen lógicamente bajo un encabezado de nivel más alto. Nombrar los títulos de varias secciones puede ayudarte en este ejercicio.
+  - **Mantén los títulos cortos**: Los títulos más cortos son más fáciles de escanear en el texto y en la tabla de contenidos.
+  - **Mantén los títulos específicos**: Usa el título para transmitir la información específica que se cubrirá en la sección. Por ejemplo, para una sección que introduce elementos HTML, usa el título "HTML elements" en lugar de "Introduction" o "Overview".
+  - **Mantén los títulos enfocados**: Usa el título para transmitir un objetivo: una sola idea o concepto que se cubrirá en esa sección. Para ese propósito, en la medida de lo posible, intenta no usar la conjunción "y" en un título.
+  - **Usa construcción paralela**: Usa un lenguaje similar para los títulos en el mismo nivel de encabezado. Por ejemplo, si un título de nivel de encabezado `###` usa gerundios, es decir, palabras que terminan en "-ing", como "Installing", entonces intenta escribir todos los títulos en ese nivel de encabezado usando gerundios. Si un título comienza con un verbo imperativo, como "Use", "Configure", entonces escribe todos los títulos en ese nivel de encabezado comenzando con un verbo imperativo.
+  - **Evita el término común en el encabezado de nivel inferior**: No repitas el texto en el título de un encabezado de nivel superior en los títulos de nivel inferior. Por ejemplo, en una sección titulada "Commas", nombra el título de una subsección "After introductory clauses" en lugar de "Commas after introductory clauses".
+  - **No comiences con artículo**: Evita comenzar títulos con artículos "a", "an" o "the".
+  - **Agrega información introductoria**: Después de un título, agrega algo de texto introductorio para explicar lo que se cubrirá en la sección.
+
+## Véase también
+
+- [Pautas para escribir ejemplos de código](/es/docs/MDN/Writing_guidelines/Code_style_guide)
+- [Pautas para escribir ejemplos de código HTML](/es/docs/MDN/Writing_guidelines/Code_style_guide/HTML)
+- [Pautas para escribir ejemplos de código CSS](/es/docs/MDN/Writing_guidelines/Code_style_guide/CSS)
+- [Pautas para escribir ejemplos de código JavaScript](/es/docs/MDN/Writing_guidelines/Code_style_guide/JavaScript)
+- [Pautas para escribir ejemplos de código de línea de comandos](/es/docs/MDN/Writing_guidelines/Code_style_guide/Shell)
+
+## Lectura adicional
+
+### Otras guías de estilo
+
+Si tienes preguntas sobre el uso y el estilo no cubiertos en esta guía, recomendamos consultar la [Guía de estilo de redacción de Microsoft](https://learn.microsoft.com/en-us/style-guide/welcome/) o el [Manual de estilo de Chicago](https://www.chicagomanualofstyle.org/).
+
+### Idioma, gramática y ortografía
+
+Si estás interesado en mejorar tus habilidades de redacción y edición, puedes encontrar los siguientes recursos útiles.
+
+- [Common errors in English usage](https://brians.wsu.edu/common-errors-in-english-usage/) en brians.wsu.edu
+- [English language and usage](https://english.stackexchange.com/) en english.stackexchange.com: Sitio de preguntas y respuestas sobre el uso del idioma inglés
+- [Merriam-Webster's Concise Dictionary of English Usage](https://books.google.com/books?id=UDIjAQAAIAAJ) en google.com/books (publicado 2002): Consejos basados en evidencia, académicos pero fáciles de usar; muy buenos para hablantes no nativos, especialmente para el uso de preposiciones
+- [On Writing Well](https://www.harpercollins.com/products/on-writing-well-william-zinsser) por William Zinsser en harpercollins.com (publicado 2016)
+- [Style: Lessons in Clarity and Grace](https://books.google.com/books?id=QjskvgEACAAJ) por Joseph Williams y Gregory Colomb en google.com/books (publicado 2019)


### PR DESCRIPTION
Sincroniza la guía de estilo de código con la fuente en inglés, actualizando el contenido, estructura y front-matter.

Closes #35378

Cambios principales:
- Actualiza el front-matter con el sourceCommit correcto
- Actualiza el contenido para coincidir con la fuente en inglés
- Actualiza la estructura de secciones
- Mantiene las traducciones válidas donde el inglés no ha cambiado
- Corrige enlaces internos para usar /es/
- Usa el informal "tú" de forma consistente

El archivo ha sido linted y formateado con Prettier.