### PR TITLE
chore(sync-fr): html attribute value pages use backticks on title

### DIFF
--- a/files/fr/web/html/reference/elements/input/button/index.md
+++ b/files/fr/web/html/reference/elements/input/button/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="button">
+title: Valeur d'attribut HTML `<input type="button">`
+short-title: <input type="button">
 slug: Web/HTML/Reference/Elements/input/button
 l10n:
-  sourceCommit: a1765c2cad20118be0dad322d3548908787b5791
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`button`** sont affichés comme des boutons poussoirs qui peuvent être programmés afin de contrôler des fonctionnalités de la page via un gestionnaire d'évènement (la plupart du temps pour l'évènement {{DOMxRef("Element/click_event", "click")}}).

--- a/files/fr/web/html/reference/elements/input/checkbox/index.md
+++ b/files/fr/web/html/reference/elements/input/checkbox/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="checkbox">
+title: Valeur d'attribut HTML `<input type="checkbox">`
+short-title: <input type="checkbox">
 slug: Web/HTML/Reference/Elements/input/checkbox
 l10n:
-  sourceCommit: 539dea64b179cea3f12270fe2b5203a9d2d08795
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`checkbox`** sont affichés par défaut sous la forme de cases qui sont cochées lorsqu'elles sont activées, comme vous pourriez le voir sur un formulaire papier gouvernemental. L'apparence exacte dépend de la configuration du système d'exploitation sous lequel le navigateur fonctionne. Il s'agit généralement d'un carré, mais il peut avoir des coins arrondis. Une case à cocher permet de sélectionner des valeurs individuelles à soumettre dans un formulaire (ou pas).

--- a/files/fr/web/html/reference/elements/input/color/index.md
+++ b/files/fr/web/html/reference/elements/input/color/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="color">
+title: Valeur d'attribut HTML `<input type="color">`
+short-title: <input type="color">
 slug: Web/HTML/Reference/Elements/input/color
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`color`** fournissent un élément d'interface utilisateur permettant à l'utilisateur·ice de définir une couleur, soit en utilisant une interface visuelle de sélection de couleur, soit en saisissant la couleur dans un champ texte au format [valeur de couleur CSS](/fr/docs/Web/CSS/Reference/Values/color_value).

--- a/files/fr/web/html/reference/elements/input/date/index.md
+++ b/files/fr/web/html/reference/elements/input/date/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="date">
+title: Valeur d'attribut HTML `<input type="date">`
+short-title: <input type="date">
 slug: Web/HTML/Reference/Elements/input/date
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de **`type="date"`** créent des champs de saisie permettant à l'utilisateur·ice d'entrer une date. L'apparence de l'interface du sélecteur de date varie selon le navigateur et le système d'exploitation. La valeur est normalisée au format `yyyy-mm-dd`.

--- a/files/fr/web/html/reference/elements/input/datetime-local/index.md
+++ b/files/fr/web/html/reference/elements/input/datetime-local/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="datetime-local">
+title: Valeur d'attribut HTML `<input type="datetime-local">`
+short-title: <input type="datetime-local">
 slug: Web/HTML/Reference/Elements/input/datetime-local
 l10n:
-  sourceCommit: 991d9809b3ecd8e01b5be871a1f30581e55ee060
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} dont l'attribut `type` vaut **`"datetime-local"`** permettent de créer des champs destinés à saisir simplement une date (définie par une année, un mois, et un jour) et une heure (définie par une heure et une minute). Il n'y a pas de secondes dans ce contrôle.

--- a/files/fr/web/html/reference/elements/input/email/index.md
+++ b/files/fr/web/html/reference/elements/input/email/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="email">
+title: Valeur d'attribut HTML `<input type="email">`
+short-title: <input type="email">
 slug: Web/HTML/Reference/Elements/input/email
 l10n:
-  sourceCommit: 5c7a1a6c3ccd8d2b22771f5d2bea050a207ec0f1
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`email`** permettent à l'utilisateur·ice de saisir et d'éditer une adresse électronique ou, si l'attribut [`multiple`](/fr/docs/Web/HTML/Reference/Attributes/multiple) est indiqué, une liste d'adresses électroniques.

--- a/files/fr/web/html/reference/elements/input/file/index.md
+++ b/files/fr/web/html/reference/elements/input/file/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="file">
+title: Valeur d'attribut HTML `<input type="file">`
+short-title: <input type="file">
 slug: Web/HTML/Reference/Elements/input/file
 l10n:
-  sourceCommit: a1765c2cad20118be0dad322d3548908787b5791
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`file"`** permettent à l'utilisateur·ice de choisir un ou plusieurs fichiers stockés sur son appareil. Une fois sélectionnés, les fichiers peuvent être téléversés vers un serveur à l'aide de [l'envoi de formulaire](/fr/docs/Learn_web_development/Extensions/Forms), ou manipulés à l'aide du code JavaScript et de [l'API File](/fr/docs/Web/API/File_API/Using_files_from_web_applications).

--- a/files/fr/web/html/reference/elements/input/hidden/index.md
+++ b/files/fr/web/html/reference/elements/input/hidden/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="hidden">
+title: Valeur d'attribut HTML `<input type="hidden">`
+short-title: <input type="hidden">
 slug: Web/HTML/Reference/Elements/input/hidden
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`"hidden"`** permettent aux développeur·euse·s web d'inclure des données qui ne peuvent pas être vues ni modifiées par les utilisateur·ice·s lors de l'envoi d'un formulaire. Par exemple, l'identifiant du contenu actuellement commandé ou modifié, ou un jeton de sécurité unique. Les champs masqués sont totalement invisibles dans la page rendue, et il n'existe aucun moyen de les rendre visibles dans le contenu de la page.

--- a/files/fr/web/html/reference/elements/input/image/index.md
+++ b/files/fr/web/html/reference/elements/input/image/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="image">
+title: Valeur d'attribut HTML `<input type="image">`
+short-title: <input type="image">
 slug: Web/HTML/Reference/Elements/input/image
 l10n:
-  sourceCommit: 2eab0bc09a2972fda0f760abd5cfe06201b23498
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`image`** sont utilisés pour créer des boutons d'envoi de formulaire graphiques. Autrement dit, il s'agit de boutons d'envoi qui affichent une image plutôt qu'un texte.

--- a/files/fr/web/html/reference/elements/input/month/index.md
+++ b/files/fr/web/html/reference/elements/input/month/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="month">
+title: Valeur d'attribut HTML `<input type="month">`
+short-title: <input type="month">
 slug: Web/HTML/Reference/Elements/input/month
 l10n:
-  sourceCommit: 13856107d2cab5bb9e40de608ee38a5770ef7c4d
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} dont l'attribut `type` vaut **`month`** permettent de créer des contrôles où l'utilisateur·ice peut saisir un mois et année.

--- a/files/fr/web/html/reference/elements/input/number/index.md
+++ b/files/fr/web/html/reference/elements/input/number/index.md
@@ -1,8 +1,9 @@
 ---
-title: Valeur d'attribut HTML `<input type="number">`
+title: Valeur d'attribut HTML `Valeur d'attribut HTML `<input type="number">``
+short-title: Valeur d'attribut HTML `<input type="number">`
 slug: Web/HTML/Reference/Elements/input/number
 l10n:
-  sourceCommit: 1bc1971a1265d1792c94b99b736c5accec1fec6d
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`number`** permettent à un·e utilisateur·ice de saisir des nombres dans un formulaire. De tels contrôles incluent des mécanismes de validation natifs afin de rejeter les valeurs qui ne sont pas numériques.

--- a/files/fr/web/html/reference/elements/input/password/index.md
+++ b/files/fr/web/html/reference/elements/input/password/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="password">
+title: Valeur d'attribut HTML `<input type="password">`
+short-title: <input type="password">
 slug: Web/HTML/Reference/Elements/input/password
 l10n:
-  sourceCommit: cc7f29133a331628d623e8cd705394b538d4368c
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments `<input>` de type **`password`** permettent à l'utilisateur·ice de saisir un mot de passe de manière sécurisée.

--- a/files/fr/web/html/reference/elements/input/radio/index.md
+++ b/files/fr/web/html/reference/elements/input/radio/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="radio">
+title: Valeur d'attribut HTML `<input type="radio">`
+short-title: <input type="radio">
 slug: Web/HTML/Reference/Elements/input/radio
 l10n:
-  sourceCommit: 6036cd414b2214f85901158bdf3e3a96123d4553
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`radio`** sont généralement utilisés dans des **groupes de boutons radio** — des ensembles de boutons radio décrivant un ensemble d'options liées.

--- a/files/fr/web/html/reference/elements/input/range/index.md
+++ b/files/fr/web/html/reference/elements/input/range/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="range">
+title: Valeur d'attribut HTML `<input type="range">`
+short-title: <input type="range">
 slug: Web/HTML/Reference/Elements/input/range
 l10n:
-  sourceCommit: 06e6e54baef7032c4e81ca93291fde0a0585de8b
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`range`** permettent à l'utilisatrice ou l'utilisateur d'indiquer une valeur numérique comprise entre deux bornes. La valeur précise n'est pas considérée comme importante. Ces éléments sont généralement représentés avec un curseur sur une ligne ou comme un bouton de potentiel et non pas comme un champ de saisie (à la façon de `{{HTMLElement("input/number", "number")}}` par exemple).

--- a/files/fr/web/html/reference/elements/input/reset/index.md
+++ b/files/fr/web/html/reference/elements/input/reset/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="reset">
+title: Valeur d'attribut HTML `<input type="reset">`
+short-title: <input type="reset">
 slug: Web/HTML/Reference/Elements/input/reset
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`"reset"`** sont affichés sous la forme de boutons permettant de réinitialiser l'ensemble des champs du formulaire avec leurs valeurs initiales.

--- a/files/fr/web/html/reference/elements/input/search/index.md
+++ b/files/fr/web/html/reference/elements/input/search/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="search">
+title: Valeur d'attribut HTML `<input type="search">`
+short-title: <input type="search">
 slug: Web/HTML/Reference/Elements/input/search
 l10n:
-  sourceCommit: 30eaa394709dfb8e1bd6ccc85239b432152aaf9b
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`search`** sont des champs de texte conçus pour que l'utilisateur puisse saisir des requêtes de recherche. Ils sont fonctionnellement identiques aux champs [`text`](/fr/docs/Web/HTML/Reference/Elements/input/text), mais peuvent être mis en forme différemment par {{Glossary("user agent", "l'agent utilisateur")}}.

--- a/files/fr/web/html/reference/elements/input/submit/index.md
+++ b/files/fr/web/html/reference/elements/input/submit/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="submit">
+title: Valeur d'attribut HTML `<input type="submit">`
+short-title: <input type="submit">
 slug: Web/HTML/Reference/Elements/input/submit
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`submit`** sont affichés comme des boutons. Lorsqu'un évènement {{DOMxRef("Element/click_event", "click")}} se produit (généralement parce que l'utilisateur·ice a cliqué sur le bouton), {{Glossary("user agent", "l'agent utilisateur")}} tente de soumettre le formulaire au serveur.

--- a/files/fr/web/html/reference/elements/input/tel/index.md
+++ b/files/fr/web/html/reference/elements/input/tel/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="tel">
+title: Valeur d'attribut HTML `<input type="tel">`
+short-title: <input type="tel">
 slug: Web/HTML/Reference/Elements/input/tel
 l10n:
-  sourceCommit: 6e3b5b1a28e717aedd42b5e27b61bd80664ae3af
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`tel`** permettent de saisir un numéro de téléphone. Contrairement aux contrôles utilisés pour [`<input type="email">`](/fr/docs/Web/HTML/Reference/Elements/input/email) et [`<input type="url">`](/fr/docs/Web/HTML/Reference/Elements/input/url), la valeur saisie n'est pas automatiquement validée selon un format donné, car les formats des numéros de téléphone varient à travers le monde.

--- a/files/fr/web/html/reference/elements/input/text/index.md
+++ b/files/fr/web/html/reference/elements/input/text/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="text">
+title: Valeur d'attribut HTML `<input type="text">`
+short-title: <input type="text">
 slug: Web/HTML/Reference/Elements/input/text
 l10n:
-  sourceCommit: 6e3b5b1a28e717aedd42b5e27b61bd80664ae3af
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`text`** permettent de créer des champs de saisie pour du texte sur une seule ligne.

--- a/files/fr/web/html/reference/elements/input/time/index.md
+++ b/files/fr/web/html/reference/elements/input/time/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="time">
+title: Valeur d'attribut HTML `<input type="time">`
+short-title: <input type="time">
 slug: Web/HTML/Reference/Elements/input/time
 l10n:
-  sourceCommit: 0c81cbce5f95a0be935724bcd936f5592774eb3a
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`time`** permettent de créer des contrôles où l'utilisateur·ice peut saisir une heure (avec des minutes et éventuellement des secondes).

--- a/files/fr/web/html/reference/elements/input/url/index.md
+++ b/files/fr/web/html/reference/elements/input/url/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="url">
+title: Valeur d'attribut HTML `<input type="url">`
+short-title: <input type="url">
 slug: Web/HTML/Reference/Elements/input/url
 l10n:
-  sourceCommit: 5ebca2edd6095fb3f61d442ed3146fa37fffbf7d
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`url`** sont employées afin de permettre à un·e utilisateur·ice de saisir ou d'éditer une URL.

--- a/files/fr/web/html/reference/elements/input/week/index.md
+++ b/files/fr/web/html/reference/elements/input/week/index.md
@@ -1,8 +1,9 @@
 ---
-title: <input type="week">
+title: Valeur d'attribut HTML `<input type="week">`
+short-title: <input type="week">
 slug: Web/HTML/Reference/Elements/input/week
 l10n:
-  sourceCommit: 13856107d2cab5bb9e40de608ee38a5770ef7c4d
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Les éléments {{HTMLElement("input")}} de type **`week`** créent des champs de saisie permettant de saisir facilement une année ainsi que le [numéro de semaine ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601#Semaine) correspondant à cette année (c'est-à-dire de la semaine 1 à la semaine [52 ou 53](https://fr.wikipedia.org/wiki/ISO_8601#Semaine)).

--- a/files/fr/web/html/reference/elements/meta/name/color-scheme/index.md
+++ b/files/fr/web/html/reference/elements/meta/name/color-scheme/index.md
@@ -1,9 +1,9 @@
 ---
-title: <meta name="color-scheme">
+title: Valeur d'attribut HTML `<meta name="color-scheme">`
 short-title: color-scheme
 slug: Web/HTML/Reference/Elements/meta/name/color-scheme
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 La valeur **`color-scheme`** pour l'attribut [`name`](/fr/docs/Web/HTML/Reference/Elements/meta/name) de l'élément HTML {{HTMLElement("meta")}} indique un schéma de couleurs suggéré que les agents utilisateur·ice·s doivent utiliser pour une page.

--- a/files/fr/web/html/reference/elements/meta/name/referrer/index.md
+++ b/files/fr/web/html/reference/elements/meta/name/referrer/index.md
@@ -1,9 +1,9 @@
 ---
-title: <meta name="referrer">
+title: Valeur d'attribut HTML `<meta name="referrer">`
 short-title: referrer
 slug: Web/HTML/Reference/Elements/meta/name/referrer
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 La valeur **`referrer`** pour l'attribut [`name`](/fr/docs/Web/HTML/Reference/Elements/meta/name) de l'élément HTML {{HTMLElement("meta")}} contrôle l'en-tête HTTP {{HTTPHeader("Referer")}} des requêtes envoyées depuis le document.

--- a/files/fr/web/html/reference/elements/meta/name/robots/index.md
+++ b/files/fr/web/html/reference/elements/meta/name/robots/index.md
@@ -1,9 +1,9 @@
 ---
-title: <meta name="robots">
+title: Valeur d'attribut HTML `<meta name="robots">`
 short-title: robots
 slug: Web/HTML/Reference/Elements/meta/name/robots
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 La valeur **`robots`** pour l'attribut [`name`](/fr/docs/Web/HTML/Reference/Elements/meta/name) de l'élément HTML {{HTMLElement("meta")}} (souvent appelée «&nbsp;balise robots&nbsp;») définit le comportement d'exploration et d'indexation que les {{Glossary("Crawler", "robots d'exploration")}} web doivent utiliser avec la page.

--- a/files/fr/web/html/reference/elements/meta/name/theme-color/index.md
+++ b/files/fr/web/html/reference/elements/meta/name/theme-color/index.md
@@ -1,9 +1,9 @@
 ---
-title: <meta name="theme-color">
+title: Valeur d'attribut HTML `<meta name="theme-color">`
 short-title: theme-color
 slug: Web/HTML/Reference/Elements/meta/name/theme-color
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 La valeur de **`theme-color`** comme attribut [`name`](/fr/docs/Web/HTML/Reference/Elements/meta#name) de l'élément HTML {{HTMLElement("meta")}}, indique une suggestion de couleur que les agents utilisateur devraient utiliser pour personnaliser l'affichage de la page ou l'interface utilisateur environnante. Si elle est utilisée, l'attribut [`content`](/fr/docs/Web/HTML/Reference/Elements/meta#content) devra avoir une valeur CSS de type {{CSSxRef("&lt;color&gt;")}}.

--- a/files/fr/web/html/reference/elements/meta/name/viewport/index.md
+++ b/files/fr/web/html/reference/elements/meta/name/viewport/index.md
@@ -1,9 +1,9 @@
 ---
-title: <meta name="viewport">
+title: Valeur d'attribut HTML `<meta name="viewport">`
 short-title: viewport
 slug: Web/HTML/Reference/Elements/meta/name/viewport
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 La valeur **`viewport`** pour l'attribut [`name`](/fr/docs/Web/HTML/Reference/Elements/meta/name) d'un élément HTML {{HTMLElement("meta")}} donne des indications sur la façon dont la {{Glossary("viewport", "zone d'affichage")}} doit être dimensionnée.

--- a/files/fr/web/html/reference/elements/script/type/importmap/index.md
+++ b/files/fr/web/html/reference/elements/script/type/importmap/index.md
@@ -1,9 +1,9 @@
 ---
-title: <script type="importmap">
+title: Valeur d'attribut HTML `<script type="importmap">`
 short-title: importmap
 slug: Web/HTML/Reference/Elements/script/type/importmap
 l10n:
-  sourceCommit: 16c2dc9c347065f648a0d6204b814657480ed25b
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 La valeur **`importmap`** de l'attribut [`type`](/fr/docs/Web/HTML/Reference/Elements/script/type) pour l'élément HTML {{HTMLElement("script")}} indique que le contenu de l'élément contient un tableau associatif d'import (<i lang="en">import map</i>).

--- a/files/fr/web/html/reference/elements/script/type/speculationrules/index.md
+++ b/files/fr/web/html/reference/elements/script/type/speculationrules/index.md
@@ -1,9 +1,9 @@
 ---
-title: <script type="speculationrules">
+title: Valeur d'attribut HTML `<script type="speculationrules">`
 short-title: speculationrules
 slug: Web/HTML/Reference/Elements/script/type/speculationrules
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 {{SeeCompatTable}}


### PR DESCRIPTION
### Description

The front-matter key `title` now accept backticks. Content has updated titles to display code in title using these backticks.

### Motivation

Keep translated-content sync for updated pages

### Additional details

_none_

### Related issues and pull requests

Sync from https://github.com/mdn/content/tree/bf5017c389132af39b50106cf1763fa7106e87b4
