### PR TITLE
[es] Update Code style guide translations

### DIFF
--- a/files/es/mdn/writing_guidelines/code_style_guide/index.md
+++ b/files/es/mdn/writing_guidelines/code_style_guide/index.md
@@ -1,73 +1,72 @@
 ---
 title: Directrices para escribir ejemplos de código
+short-title: Estilo de código
 slug: MDN/Writing_guidelines/Code_style_guide
-original_slug: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide
 l10n:
-  sourceCommit: f7c186696980fee97e72261370d7b5a8c1cd9302
+  sourceCommit: 7ff752fba26e0bb950998bb5476157ff96c7d314
 ---
 
-{{MDNSidebar}}
+Este artículo describe las directrices de estilo y formato para los ejemplos de código en MDN Web Docs, independientemente del lenguaje de programación.
+Para obtener directrices sobre la prosa y otros contenidos, consulta la [guía de estilo de escritura](/es/docs/MDN/Writing_guidelines/Writing_style_guide#code_examples).
 
-Las pautas descritas en este artículo se aplican al estilo y formato de los ejemplos de código, independientemente del lenguaje. Para obtener pautas sobre qué contenido incluir al escribir ejemplos de código, consulta la [guía de estilo de escritura](/es/docs/MDN/Writing_guidelines/Writing_style_guide#code_examples).
+Para obtener directrices específicas de tecnología, consulta los siguientes artículos:
 
-Para pautas específicas de tecnología, consulta los siguientes artículos:
-
-- [Directrices HTML](/es/docs/MDN/Writing_guidelines/Code_style_guide/HTML)
-- [Directrices CSS](/es/docs/MDN/Writing_guidelines/Code_style_guide/CSS)
+- [Directrices de HTML](/es/docs/MDN/Writing_guidelines/Code_style_guide/HTML)
+- [Directrices de CSS](/es/docs/MDN/Writing_guidelines/Code_style_guide/CSS)
 - [Directrices de JavaScript](/es/docs/MDN/Writing_guidelines/Code_style_guide/JavaScript)
-- [Directrices de la interfaz de línea de comandos (Shell)](/es/docs/MDN/Writing_guidelines/Code_style_guide/Shell)
+- [Directrices del indicador de Shell](/es/docs/MDN/Writing_guidelines/Code_style_guide/Shell)
 
-## Mejores prácticas generales
+## Principios generales para los ejemplos de código
 
-Esta sección proporciona las mejores prácticas para crear un ejemplo de código mínimo comprensible que demuestre el uso de una función o característica específica.
+Existe una consideración general que debes tener en cuenta: **Los lectores copiarán y pegarán ejemplos en su propio código y es posible que lo utilicen en producción.**
+Por lo tanto, debes asegurarte de que los ejemplos de código sean utilizables, sigan las mejores prácticas generalmente aceptadas y no hagan nada que pueda hacer que una aplicación sea insegura, ineficiente, abultada o inaccesible.
+Si el ejemplo de código no es ejecutable o no es apto para producción, incluye una advertencia en un comentario de código y en el texto explicativo; por ejemplo, si es solo un fragmento y no un ejemplo completo, deja esto claro. Esto también significa que debes proporcionar toda la información necesaria para ejecutar el ejemplo, incluidas las dependencias y la información de configuración.
 
-Los ejemplos de código que agregues a MDN Web Docs deben ser:
+Los ejemplos de código deben ser lo suficientemente sencillos para ser comprensibles, pero lo suficientemente complejos para hacer algo interesante y, preferiblemente, útiles.
+El objetivo no es necesariamente producir código eficiente e ingenioso que impresione a expertos y tenga una gran funcionalidad, sino más bien compartir ejemplos de trabajo reducidos que se puedan entender y aprender lo más rápido posible.
 
-- lo suficientemente simples como para ser comprensibles, pero
-- lo suficientemente complejos como para hacer algo interesante, y preferiblemente útiles.
+Algunas directrices más generales incluyen:
 
-Existe una consideración general que debes tener en cuenta: **Los lectores copiarán y pegarán el fragmento de código en su propio código y es posible que lo utilicen en producción.**
-
-Por lo tanto, debes asegurarte de que el ejemplo de código sea utilizable, siga las mejores prácticas generalmente aceptadas y **no** realice acciones que puedan hacer que una aplicación sea insegura, ineficiente, abultada o inaccesible. Si el ejemplo de código no es ejecutable o no es apto para producción, asegúrate de incluir una advertencia en un comentario de código y en el texto explicativo; por ejemplo, si es solo un fragmento y no un ejemplo completo, deja esto claro. Esto también significa que debes proporcionar **toda** la información necesaria para ejecutar el ejemplo, incluidas las dependencias e información de configuración.
-
-Los ejemplos de código deben ser lo más autosuficientes y comprensibles posible. El objetivo no es necesariamente producir código eficiente e ingenioso que impresione a expertos y tenga una gran funcionalidad, sino más bien producir ejemplos de trabajo reducidos que se puedan entender lo más rápido posible.
-
-Algunas mejores prácticas adicionales incluyen:
-
-- El ejemplo de código debe ser corto y mostrar idealmente solo la característica que te interesa de inmediato.
-- **Solo** incluye el código que es esencial para el ejemplo. Una gran cantidad de código no relevante puede distraer o confundir fácilmente al lector. Si deseas proporcionar un ejemplo completo y más extenso, colócalo en uno de nuestros [repositorios de GitHub](https://github.com/mdn/) (o en JSBin, Codepen u otro similar) y luego proporciona el enlace a la versión completa arriba o debajo del fragmento.
-- No incluyas código innecesario del lado del servidor, bibliotecas, marcos de trabajo (_frameworks_), preprocesadores y otras dependencias similares. Esto dificulta la portabilidad y la comprensión del código. Usa código simple siempre que sea posible.
-- No asumas el conocimiento de los lectores sobre bibliotecas, marcos, preprocesadores u otras características no nativas. Por ejemplo, utiliza nombres de clases que tengan sentido dentro del ejemplo en lugar de nombres de clases que tengan sentido para usuarios de BEM o Bootstrap.
-- Escribe tu código de manera limpia y comprensible, incluso si no es la forma más eficiente de escribirlo.
+- Los ejemplos de código deben ser cortos y, idealmente, mostrar solo la característica que te interesa de inmediato.
+- Escribe tu código para que sea lo más comprensible posible, incluso si no es la forma más eficiente de escribirlo.
+- No incluyas código innecesario del lado del servidor, bibliotecas, marcos de trabajo (_frameworks_), preprocesadores y otras dependencias similares. Hacen que el código sea menos portátil y más difícil de ejecutar y entender. Usa código simple siempre que sea posible.
+- No asumas el conocimiento de los lectores sobre bibliotecas, marcos de trabajo, preprocesadores u otras características no nativas. Por ejemplo, usa nombres de clases que tengan sentido dentro del ejemplo en lugar de nombres de clases que tengan sentido para usuarios de BEM o Bootstrap.
 - Sé inclusivo en tus ejemplos de código; considera que los lectores de MDN provienen de todo el mundo y son diversos en sus etnias, religiones, edades, géneros, etc. Asegúrate de que el texto en los ejemplos de código refleje esa diversidad y sea inclusivo para todas las personas.
-- No uses malas prácticas por brevedad (como elementos de presentación como {{HTMLElement("big")}} o {{domxref("Document.write", "document.write()")}}); hazlo correctamente.
-- En el caso de demostraciones de API, si estás utilizando múltiples API juntas, señala qué APIs se incluyen y qué características provienen de cada una.
+- No uses características obsoletas por brevedad (como elementos de presentación como {{HTMLElement("big")}} o {{domxref("Document.write", "document.write()")}}); hazlo correctamente.
+- En el caso de demostraciones de API, si estás utilizando múltiples API juntas, señala qué API se incluyen y qué características provienen de cada una.
 
-## Pautas para el formato
+### Compatibilidad con navegadores
 
-Las opiniones sobre la correcta indentación, espaciado y longitud de líneas siempre han sido controvertidas. Las discusiones sobre estos temas son una distracción para crear y mantener el contenido.
+Al crear ejemplos de código para una tecnología que aún no está disponible en todos los navegadores principales, considera usar la [detección de características](/es/docs/Learn_web_development/Extensions/Testing/Feature_detection) para recurrir a un comportamiento más simple o informar al usuario que su navegador aún no es compatible.
+No especifiques los navegadores compatibles y sus versiones en comentarios de código o prosa, ya que esta información queda obsoleta rápidamente.
 
-En MDN Web Docs, utilizamos [Prettier](https://prettier.io/) como formateador de código para mantener consistente el estilo de código (y evitar discusiones fuera de tema). Puedes consultar nuestro [archivo de configuración](https://github.com/mdn/content/blob/main/.prettierrc.json) para conocer las reglas actuales y leer la [documentación de Prettier](https://prettier.io/docs/en/index.html).
+## Estilo y formato de código de MDN
 
-Prettier formatea todo el código y mantiene el estilo consistente. Sin embargo, hay algunas reglas adicionales que debes seguir.
+Las opiniones sobre la indentación, el espacio en blanco y la longitud de línea correctos siempre han sido controvertidas. Las discusiones sobre estos temas son una distracción para crear y mantener el contenido.
+En MDN Web Docs, usamos [Prettier](https://prettier.io/) como formateador de código para mantener el estilo de código consistente y evitar discusiones fuera de tema. Puedes consultar nuestro [archivo de configuración](https://github.com/mdn/content/blob/main/.prettierrc.json) para conocer las reglas actuales y leer la [documentación de Prettier](https://prettier.io/docs/index.html).
 
-Estas pautas de MDN Web Docs para formatear ejemplos de código también son buenas prácticas cuando estás codificando.
+Además del formato automatizado, hay algunas otras reglas para los ejemplos de código en MDN para que el resultado se represente bien.
 
-### Elección de un lenguaje de sintaxis
+### Elige el lenguaje correcto
 
-Para garantizar el formato adecuado y el resaltado de sintaxis de los bloques de código, los escritores deben especificar el lenguaje del bloque de código que están escribiendo. Consulta [Bloques de código de ejemplo en el formato MDN Markdown](/es/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#example_code_blocks) para obtener una lista de los lenguajes admitidos por MDN, así como detalles sobre cómo solicitar un nuevo lenguaje.
+Para garantizar el formato adecuado y el resaltado de sintaxis de los bloques de código, especifica correctamente el lenguaje del bloque de código.
+Consulta [Bloques de código de ejemplo en Markdown de MDN](/es/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#example_code_blocks) para obtener una lista de los lenguajes compatibles con MDN, así como detalles sobre cómo solicitar un nuevo lenguaje.
 
-Si el bloque de código es pseudocódigo, la salida de un comando, o de alguna manera no es un lenguaje de programación, establece explícitamente el lenguaje como `plain`.
+Si el bloque de código es pseudocódigo, la salida de un comando o, de alguna manera, no es un lenguaje de programación, establece el lenguaje en `plain`:
+
+````md
+```plain
+StaleElementReferenceException: The element reference of ABD-123 is stale…
+```
+````
 
 > [!WARNING]
 > Si el lenguaje deseado aún no es compatible con MDN, **no** establezcas el lenguaje de un bloque de código en un lenguaje similar, ya que hacerlo puede tener efectos secundarios no deseados con el formato de Prettier y el resaltado de sintaxis.
 
 ### Longitud de línea de código
 
-- Las líneas de código no deben ser tan largas que requieran desplazamiento horizontal para leerlas.
-- Como práctica recomendada, mantiene las líneas de código hasta un máximo de 80 caracteres de longitud (64 para [ejemplos interactivos](https://github.com/mdn/interactive-examples)).
-- Divide las líneas largas en puntos naturales de ruptura por el bien de la legibilidad, pero no a expensas de las mejores prácticas.
-
+Las líneas de código no deben ser tan largas que requieran desplazamiento horizontal para leerlas.
+Divide las líneas largas en puntos naturales de ruptura por el bien de la legibilidad, pero no a expensas de las mejores prácticas.
 Por ejemplo, esto no es ideal:
 
 ```js example-bad
@@ -91,106 +90,70 @@ Incluso mejor es usar una plantilla literal:
 const tommyCat = `Dijo Tommy el Gato mientras retrocedía para limpiar cualquier materia extraña
   que pudiera haberse metido en su poderosa garganta. Más de una rata callejera gorda
   había encontrado su muerte mientras miraba fijamente el cavernoso cañón de esta
-  impresionante máquina merodeadora`";
-```
-
-```js example-good
-if (
-  obj.CONDITION ||
-  obj.OTHER_CONDITION ||
-  obj.SOME_OTHER_CONDITION ||
-  obj.YET_ANOTHER_CONDITION
-) {
-  /* algo */
-}
-
-const toolkitProfileService = Components.classes[
-  "@mozilla.org/toolkit/profile-service;1"
-].createInstance(Components.interfaces.nsIToolkitProfileService);
+  impresionante máquina merodeadora.`;
 ```
 
 ### Altura del bloque de código
 
-Los bloques de código deben ser tan largos como sea necesario, pero no más. Idealmente, apunta a algo corto, como 15-25 líneas. Si un bloque de código va a ser mucho más largo, considera mostrar solo el fragmento más útil y enlaza al ejemplo completo en un repositorio de GitHub o CodePen, por ejemplo.
+Los bloques de código deben ser tan largos como sea necesario, pero no más. Idealmente, apunta a algo corto, como 15-25 líneas. Si un bloque de código va a ser mucho más largo, considera mostrar la parte más útil y enlaza a un ejemplo completo en un repositorio de GitHub, Gist o CodePen, por ejemplo.
 
-#### Formato de código en línea
+### Formato de código en línea
 
-Utiliza la sintaxis de código en línea (\`) para marcar los nombres de funciones, nombres de variables y nombres de métodos. Por ejemplo: "la función `frenchText()`".
+Usa la sintaxis de código en línea para marcar nombres de funciones, nombres de variables y nombres de métodos. Por ejemplo: "la función `frenchText()`" se escribe en markdown como:
 
-**Los nombres de los métodos deben ir seguidos de un par de paréntesis**: por ejemplo, `doSomethingUseful()`. Los paréntesis ayudan a diferenciar los métodos de otros términos de código.
+```md
+la función `frenchText()`
+```
 
-## Pautas para una representación adecuada
+Los nombres de los métodos deben ir seguidos de un par de paréntesis: por ejemplo, `doSomethingUseful()`. Los paréntesis ayudan a diferenciar los métodos de otros términos de código.
 
-Estas pautas deben seguirse para asegurar que los ejemplos de código que escribas se visualicen correctamente en MDN Web Docs. También debes considerar la capacidad de respuesta al escribir ejemplos de código para que también sean útiles en dispositivos móviles.
+## Directrices para una representación adecuada
+
+Debes seguir estas directrices para asegurarte de que los ejemplos de código que escribas se muestren correctamente en MDN Web Docs. También debes considerar la capacidad de respuesta al escribir ejemplos de código para que también sean útiles en dispositivos móviles.
 
 ### Tamaño del ejemplo de código renderizado
 
-- **Establece el ancho al 100%**: El panel de contenido principal en MDN Web Docs tiene aproximadamente 700px de ancho en escritorio, por lo que los ejemplos de código incrustados deben lucir bien con ese ancho.
+- **Establece el ancho al 100%**: El panel de contenido principal en MDN Web Docs tiene aproximadamente 700px de ancho en el escritorio, por lo que los ejemplos de código incrustados deben verse bien con ese ancho.
 - **Establece la altura por debajo de los 700px**: Recomendamos mantener esta altura para el ancho del ejemplo de código renderizado para una legibilidad máxima en pantalla.
 
-### Color en el ejemplo de código renderizado
+### Resaltar ejemplos como buenos o malos
 
-- Usa palabras clave para los colores primarios y otros colores "básicos", por ejemplo:
+Notarás en esta página que los bloques de código que representan buenas prácticas a seguir se representan con una marca de verificación verde en la esquina derecha, y los bloques de código que demuestran malas prácticas se representan con una cruz blanca en un círculo rojo.
 
-  ```css example-good
-  color: black;
-  color: white;
-  color: red;
-  ```
+Puedes seguir el mismo estilo al escribir ejemplos de código. No es necesario que uses este estilo en todas partes, solo en lugares donde quieras destacar específicamente el buen y mal uso en los ejemplos de código.
 
-- Utiliza `rgb()` para colores más complejos (incluidos los semitransparentes):
+Un bloque de código se escribe en markdown usando "vallas de código" para delimitar el bloque de código, seguido del lenguaje en la cadena de información. Por ejemplo:
 
-  ```css example-good
-  color: rgb(0 0 0 / 50%);
-  color: rgb(248 242 230);
-  ```
-
-- Para colores hexadecimales, utiliza la forma corta cuando sea relevante:
-
-  ```css example-good
-  color: #058ed9;
-  color: #a39a92c1;
-  color: #ff0;
-  color: #fbfa;
-  ```
-
-  ```css-nolint example-bad
-  color: #ffff00;
-  color: #ffbbffaa;
-  ```
-
-### Marcar ejemplos renderizados como buenos o malos
-
-Notarás en esta página que los bloques de código que representan buenas prácticas están renderizados con una marca de verificación verde en la esquina derecha, y los bloques de código que demuestran malas prácticas están renderizados con una cruz blanca en un círculo rojo.
-
-Puedes seguir el mismo estilo al escribir ejemplos de código. No es necesario utilizar este estilo en todas partes, solo en páginas donde desees destacar específicamente buenas y malas prácticas en tus ejemplos de código.
-
-Para lograr esta representación, utiliza "vallas de código" para delimitar el bloque de código, seguido de la cadena de información del lenguaje. Por ejemplo:
-
+````md
 ```js
 function myFunc() {
   console.log("Hello!");
 }
 ```
+````
 
-Para representar el bloque de código como un ejemplo bueno o malo, agrega `example-good` o `example-bad` después de la cadena de información del lenguaje, de la siguiente manera:
+Para representar el bloque de código como un ejemplo bueno o malo, agrega `example-good` o `example-bad` después de la cadena del lenguaje, así:
 
 ````md
 ```html example-good
-<p></p>
+<p>Buen ejemplo</p>
 ```
 
 ```html example-bad
-<p></p>
+<p>Mal ejemplo</p>
 ```
 ````
 
 Estos se representarán como:
 
 ```html example-good
-<p class="brush: js example-good"></p>
+<p>Buen ejemplo</p>
 ```
 
 ```html example-bad
-<p class="brush: js example-bad"></p>
+<p>Mal ejemplo</p>
 ```
+
+## Directrices para usar texto de marcador de posición
+
+Usa el texto de marcador de posición lorem-ipsum generado desde [lipsum.com](https://www.lipsum.com/) o el complemento de VS Code [Lorem ipsum](https://marketplace.visualstudio.com/items?itemName=Tyriar.lorem-ipsum). El texto estándar de lorem-ipsum se incluye en nuestra configuración del verificador ortográfico, por lo que no se reportará como errores tipográficos en los IDE o en las pruebas durante la revisión de código. Usar un texto de marcador de posición consistente hace que el código de ejemplo sea más fácil de revisar, especialmente cuando aparece repetidamente. También ayuda a mantener los ejemplos claramente para fines de ilustración y evita distraer a los lectores con contenido irrelevante.

--- a/files/es/mdn/writing_guidelines/code_style_guide/javascript/index.md
+++ b/files/es/mdn/writing_guidelines/code_style_guide/javascript/index.md
@@ -1,98 +1,83 @@
 ---
-title: Pautas para dar estilos a ejemplos de código JavaScript
+title: Directrices para escribir ejemplos de código JavaScript
+short-title: Ejemplos de JavaScript
 slug: MDN/Writing_guidelines/Code_style_guide/JavaScript
-original_slug: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/JavaScript
+l10n:
+  sourceCommit: 359d3c9cea9b2caa691c63ed3b01714ad4416372
 ---
 
-{{MDNSidebar}}
+Las siguientes directrices cubren la escritura de código de ejemplo JavaScript para MDN Web Docs. Este artículo es una lista de reglas para escribir ejemplos concisos que sean comprensibles para la mayor cantidad de personas posible.
 
-Las siguientes pautas cubren la escritura de código de ejemplo JavaScript para los documentos web de MDN.
-Este artículo es una lista de reglas para escribir ejemplos concisos que sean comprensibles para la mayor cantidad de personas posible.
+## Directrices generales para ejemplos de código JavaScript
 
-## Pautas generales para ejemplos de código JavaScript
+Esta sección explica las directrices generales a tener en cuenta al escribir ejemplos de código JavaScript. Las secciones posteriores cubrirán detalles más específicos.
 
-Esta sección explica las pautas generales a tener en cuenta al escribir ejemplos de código JavaScript.
-Las secciones posteriores cubrirán detalles más específicos.
+### Elección de un formato
 
-### Eligiendo un formato
+Las opiniones sobre la sangría correcta, el espacio en blanco y las longitudes de línea siempre han sido controvertidas. Las discusiones sobre estos temas son una distracción para la creación y mantenimiento de contenido.
 
-Opiniones sobre la sangría correcta, espacio en blanco, y las longitudes de línea siempre han sido controvertidas.
-Las discusiones sobre estos temas son una distracción para la creación y mantenimiento de contenido.
+En MDN Web Docs, usamos [Prettier](https://prettier.io/) como formateador de código para mantener el estilo del código consistente (y para evitar discusiones fuera de tema). Puedes consultar nuestro [archivo de configuración](https://github.com/mdn/content/blob/main/.prettierrc.json) para conocer las reglas actuales, y leer la [documentación de Prettier](https://prettier.io/docs/index.html).
 
-En documentos web de MDN, usamos [Prettier](https://prettier.io/) como formateador de código para mantener la consistencia del estilo del código (y para evitar discusiones fuera del tema).
-Puedes consultar nuestro [Archivo de configuración](https://github.com/mdn/content/blob/main/.prettierrc.json) para conocer las normas vigentes, y leer la [Documentación Prettier](https://prettier.io/docs/en/index.html).
+Prettier formatea todo el código y mantiene el estilo consistente. Sin embargo, hay algunas reglas adicionales que debes seguir.
 
-Prettier formatea todo el código y mantiene el estilo consistente. Sin embargo, hay algunas reglas adicionales que usted debe seguir.
+### Usa características modernas de JavaScript cuando estén soportadas
 
-### Uso de características modernas de JavaScript
+Puedes usar nuevas características una vez que cada navegador principal — Chrome, Edge, Firefox y Safari — las soporte (también conocido como {{glossary("Baseline", "Línea de base")}}).
 
-Usted puede usar nuevas funciones una vez que cada navegador principal — Chrome, Edge, Firefox, y Safari — las soporte.
+Esta regla no se aplica a la característica de JavaScript que se está documentando en la página (que se dicta en su lugar por los [criterios de inclusión](/es/docs/MDN/Writing_guidelines/Criteria_for_inclusion)). Por ejemplo, puedes documentar características [no estándar o experimentales](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete) y escribir ejemplos completos que demuestren su comportamiento, pero debes abstente de usar estas características en las demostraciones para otras características no relacionadas, como una API web.
 
-### Espaciado y sangría
+## Arrays
 
-Marque la sangría con _2 espacios_. No use el carácter de tabulación. El carácter de fin de línea es `\n`, la convención de Unix.
-Para ayudarle, hemos incluido un archivo [`.editorconfig`](https://editorconfig.org/) en el repositorio.
-Muchos editores leen su contenido y lo utilizan para configurar su comportamiento.
+### Creación de arrays
 
-## Matrices
+Para crear arrays, usa literales y no constructores.
 
-### Creación de matrices
-
-Para crear matrices, use literales y no constructores.
-
-Crear matrices como esta:
+Crea arrays así:
 
 ```js example-good
-const ciudadesVisitadas = [];
+const visitedCities = [];
 ```
 
-No hacer esto al crear matrices:
+No hagas esto al crear arrays:
 
 ```js example-bad
-const ciudadesVisitadas = new Array(length);
+const visitedCities = new Array(length);
 ```
 
 ### Adición de elementos
 
-Al agregar elementos a una matriz, use [`push()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/push) y no asignación directa.
-Considere la siguiente matriz:
+Al agregar elementos a un array, usa [`push()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/push) y no asignación directa. Considera el siguiente array:
 
 ```js
-const mascotas = [];
+const pets = [];
 ```
 
-Adicione elementos a la matriz de esta forma:
+Agrega elementos al array así:
 
 ```js example-good
-mascotas.push("gato");
+pets.push("cat");
 ```
 
-No adicione elementos a la matriz de esta forma:
+No agregues elementos al array así:
 
 ```js example-bad
-mascotas[mascotas.length] = "gato";
+pets[pets.length] = "cat";
 ```
 
 ## Métodos asíncronos
 
-Escribir código asincrónico mejora el rendimiento y debe usarse cuando sea posible.
-En particular, puede utilizar:
+Escribir código asíncrono mejora el rendimiento y debe usarse cuando sea posible. En particular, puedes usar:
 
-- [Promise](/es/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+- [Promesas](/es/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 - [`async`](/es/docs/Web/JavaScript/Reference/Statements/async_function)/[`await`](/es/docs/Web/JavaScript/Reference/Operators/await)
 
-Cuando ambas técnicas son posibles, preferimos usar la sintaxis más simple `async`/`await`.
-Desafortunadamente, no se puede utilizar `await` en el nivel superior a menos que esté en un módulo ECMAScript.
-Los módulos CommonJS utilizados por Node.js no son módulos ES.
-Si su ejemplo está destinado a ser usado en todas partes, evite el nivel superior `await`.
+Cuando ambas técnicas son posibles, preferimos usar la sintaxis más simple `async`/`await`. Desafortunadamente, no puedes usar `await` en el nivel superior a menos que estés en un módulo ECMAScript. Los módulos CommonJS usados por Node.js no son módulos ES. Si tu ejemplo está destinado a ser usado en todas partes, evita el `await` de nivel superior.
 
 ## Comentarios
 
-Los comentarios son fundamentales para escribir buenos ejemplos de código.
-Aclaran la intención del código y ayudan a los desarrolladores a entenderlo.
-Préstale especial atención.
+Los comentarios son críticos para escribir buenos ejemplos de código. Aclaran la intención del código y ayudan a los desarrolladores a entenderlo. Presta especial atención a ellos.
 
-- Si el propósito o la lógica del código no es obvio, añade un comentario con tu intención, como se muestra debajo:
+- Si el propósito o la lógica del código no es obvio, añade un comentario con tu intención, como se muestra abajo:
 
   ```js example-good
   let total = 0;
@@ -110,121 +95,109 @@ Préstale especial atención.
 
   // Bucle de 1 a 4
   for (let i = 0; i < 4; i++) {
-    // Adicionar valor al total
+    // Agrega valor al total
     total += arr[i];
   }
   ```
 
-- Los comentarios tampoco son necesarios cuando las funciones tienen nombres explícitos que describen lo que están haciendo. Escriba:
+- Los comentarios tampoco son necesarios cuando las funciones tienen nombres explícitos que describen lo que están haciendo. Escribe:
 
   ```js example-good
   closeConnection();
   ```
 
-  No escriba:
+  No escribas:
 
   ```js example-bad
-  closeConnection(); // Cierra la conexión
+  closeConnection(); // Cerrando la conexión
   ```
 
-### Usar comentarios de una sola línea
+### Usa comentarios de una sola línea
 
 Los comentarios de una sola línea se marcan con `//`, a diferencia de los comentarios en bloque encerrados entre `/* … */`.
 
-En general, use comentarios de una sola línea para comentar el código.
-Los desarrolladores deben marcar cada línea del comentario con `//`, para que sea más fácil notar visualmente el código comentado.
-Además, esta convención permite comentar secciones de código utilizando `/* … */` mientras se depura.
+En general, usa comentarios de una sola línea para comentar el código. Los escritores deben marcar cada línea del comentario con `//`, para que sea más fácil notar visualmente el código comentado. Además, esta convención permite comentar secciones de código usando `/* … */` mientras se depura.
 
-- Deje un espacio entre las barras y el comentario.
-  Comienza con una letra mayúscula, como una oración, pero no termines el comentario con un punto.
+- Deja un espacio entre las barras y el comentario. Comienza con una letra mayúscula, como una oración, pero no termines el comentario con un punto.
 
   ```js example-good
-  // Este es un comentario de una sola línea bien escrito.
+  // Este es un comentario de una sola línea bien escrito
   ```
 
-- Si un comentario no comienza inmediatamente después de un nuevo nivel de sangría, agregue una línea vacía y luego agregue el comentario.
-  Creará un bloque de código, haciendo obvio a qué se refiere el comentario.
-  Además, coloque sus comentarios en líneas separadas antes del código al que se refieren.
-  Esto se muestra en el siguiente ejemplo:
+- Si un comentario no comienza inmediatamente después de un nuevo nivel de sangría, agrega una línea vacía y luego agrega el comentario. Creará un bloque de código, haciendo obvio a qué se refiere el comentario. Además, pon tus comentarios en líneas separadas antes del código al que se refieren. Esto se muestra en el siguiente ejemplo:
 
   ```js example-good
-  function verificar(precioMercancias, precioEnvio, impuestos) {
+  function checkout(goodsPrice, shipmentPrice, taxes) {
     // Calcula el precio total
-    const total = precioMercancias + precioEnvio + impuestos;
+    const total = goodsPrice + shipmentPrice + taxes;
 
-    // Crea y agrega un nuevo párrafo al documento
-    const parrafo = document.createElement("p");
-    parrafo.textContent = `El precio total es ${total}`;
-    document.body.appendChild(parrafo);
+    // Crea y añade un nuevo párrafo al documento
+    const para = document.createElement("p");
+    para.textContent = `El precio total es ${total}`;
+    document.body.appendChild(para);
   }
   ```
 
 ### Salida de registros
 
-- En el código destinado a ejecutarse en un entorno de producción, rara vez necesita comentar cuando registra algunos datos.
-  En ejemplos de código, a menudo usamos `console.log()`, `console.error()`, o funciones similares para mostrar valores importantes.
-  Para ayudar al lector a comprender lo que sucederá sin ejecutar el código, puede colocar un comentario _después_ de la función con el registro que se producirá. Escriba:
+- En el código destinado a ejecutarse en un entorno de producción, rara vez necesitas comentar cuando registras algunos datos. En ejemplos de código, a menudo usamos `console.log()`, `console.error()`, o funciones similares para mostrar valores importantes. Para ayudar al lector a comprender lo que sucederá sin ejecutar el código, puedes poner un comentario _después_ de la función con el registro que se producirá. Escribe:
 
   ```js example-good
-  function funcionEjemplo(canastaDeFrutas) {
-    console.log(canastaDeFrutas); // ['banana', 'mango', 'naranja']
+  function exampleFunc(fruitBasket) {
+    console.log(fruitBasket); // ['banana', 'mango', 'orange']
   }
   ```
 
-  No escriba:
+  No escribas:
 
   ```js example-bad
-  function funcionEjemplo(canastaDeFrutas) {
-    // Registro: ['banana', 'mango', 'naranja']
-    console.log(canastaDeFrutas);
+  function exampleFunc(fruitBasket) {
+    // Registros: ['banana', 'mango', 'orange']
+    console.log(fruitBasket);
   }
   ```
 
-- En caso de que la línea se vuelva demasiado larga, coloque el comentario _después_ de la función, así:
+- En caso de que la línea se vuelva demasiado larga, pon el comentario _después_ de la función, así:
 
   ```js example-good
-  function funcionEjemplo(canastaDeFrutas) {
-    console.log(canastaDeFrutas);
-    // ['banana', 'mango', 'naranja', 'manzana', 'pera', 'durian', 'limón']
+  function exampleFunc(fruitBasket) {
+    console.log(fruitBasket);
+    // ['banana', 'mango', 'orange', 'apple', 'pear', 'durian', 'lemon']
   }
   ```
 
 ### Comentarios de varias líneas
 
-Los comentarios cortos suelen ser mejores, así que trate de mantenerlos en una línea de 60 a 80 caracteres.
-Si esto no es posible, utilice `//` al principio de cada línea:
+Los comentarios cortos suelen ser mejores, así que trata de mantenerlos en una línea de 60 a 80 caracteres. Si esto no es posible, usa `//` al principio de cada línea:
 
 ```js example-good
 // Este es un ejemplo de un comentario de varias líneas.
-// La función imaginaria que sigue, tiene algo inusual.
-// Limitaciones que quiero llamar.
+// La función imaginaria que sigue tiene algunas inusuales
+// limitaciones que quiero señalar.
 // Limitación 1
 // Limitación 2
 ```
 
-No use `/* … */`:
+No uses `/* … */`:
 
 ```js example-bad
 /* Este es un ejemplo de un comentario de varias líneas.
-  La función imaginaria que sigue, tiene algo inusual.
-  Limitaciones que quiero llamar.
+  La función imaginaria que sigue tiene algunas inusuales
+  limitaciones que quiero señalar.
   Limitación 1
   Limitación 2 */
 ```
 
-### Usar comentarios para marcar puntos suspensivos
+### Usa comentarios para marcar puntos suspensivos
 
-Omitir código redundante usando puntos suspensivos (…) es necesario para mantener los ejemplos cortos.
-Aun así, los escritores deben hacerlo cuidadosamente, ya que los desarrolladores con frecuencia copian y pegan ejemplos en su código, y todas nuestras muestras de código JavaScript deben ser válidas.
+Omitir código redundante usando puntos suspensivos (…) es necesario para mantener los ejemplos cortos. Aun así, los escritores deben hacerlo con cuidado, ya que los desarrolladores con frecuencia copian y pegan ejemplos en su código, y todas nuestras muestras de código JavaScript deben ser válidas.
 
-En JavaScript, debes poner los puntos suspensivos (`…`) en un comentario.
-Cuando sea posible, indique qué acción se espera que agregue quien reutilice este fragmento.
+En JavaScript, debes poner los puntos suspensivos (`…`) en un comentario. Cuando sea posible, indica qué acción se espera que agregue quien reutilice este fragmento.
 
-Usar un comentario para los puntos suspensivos (…) es mas explícito, previene errores cuando un desarrollador copia y pega un código de muestra.
-Escriba:
+Usar un comentario para los puntos suspensivos (…) es más explícito, previniendo errores cuando un desarrollador copia y pega un código de muestra. Escribe:
 
 ```js example-good
-function funcionEjemplo() {
+function exampleFunc() {
   // Agrega tu código aquí
   // …
 }
@@ -233,21 +206,19 @@ function funcionEjemplo() {
 No uses puntos suspensivos (…) así:
 
 ```js example-bad
-function funcionEjemplo() {
+function exampleFunc() {
   …
 }
 ```
 
 ### Comentar parámetros
 
-Al escribir código, generalmente omite parámetros que no necesitas.
-Pero en algunos ejemplos de código, quieres demostrar que no utilizaste algunos posibles parámetros.
+Al escribir código, generalmente omites parámetros que no necesitas. Pero en algunos ejemplos de código, quieres demostrar que no usaste algunos posibles parámetros.
 
-Para hacerlo, utilice `/* … */` en la lista de parámetros.
-Esta es una excepción a la regla de usar solo comentarios de una sola línea. (`//`).
+Para hacerlo, usa `/* … */` en la lista de parámetros. Esta es una excepción a la regla de usar solo comentarios de una sola línea (`//`).
 
 ```js
-array.forEach((valor /* , índice, matriz */) => {
+array.forEach((value /* , index, array */) => {
   // …
 });
 ```
@@ -256,37 +227,36 @@ array.forEach((valor /* , índice, matriz */) => {
 
 ### Nombres de funciones
 
-Para nombres de funciones, use camelCase, comenzando con un carácter en minúscula.
-Utilice nombres concisos, legibles por humanos y semánticos cuando sea apropiado.
+Para nombres de funciones, usa {{Glossary("camel_case", "camel case")}}, comenzando con un carácter en minúscula. Usa nombres concisos, legibles y semánticos cuando sea apropiado.
 
 El siguiente es un ejemplo correcto de un nombre de función:
 
 ```js example-good
-function decirHola() {
-  console.log("Hola!");
+function sayHello() {
+  console.log("Hello!");
 }
 ```
 
-No use nombres de funciones como estos:
+No uses nombres de funciones como estos:
 
 ```js example-bad
-function DecirHola() {
-  console.log("Hola!");
+function SayHello() {
+  console.log("Hello!");
 }
 
-function hazlo() {
-  console.log("Hola!");
+function doIt() {
+  console.log("Hello!");
 }
 ```
 
-### Declaración de funciones
+### Declaraciones de funciones
 
-- Siempre que sea posible, use la declaración de función sobre expresiones de función para definir funciones.
+- Cuando sea posible, usa la declaración de función sobre expresiones de función para definir funciones.
 
   Esta es la forma recomendada de declarar una función:
 
   ```js example-good
-  function suma(a, b) {
+  function sum(a, b) {
     return a + b;
   }
   ```
@@ -294,32 +264,30 @@ function hazlo() {
   Esta no es una buena forma de declarar una función:
 
   ```js example-bad
-  let suma = function (a, b) {
+  let sum = function (a, b) {
     return a + b;
   };
   ```
 
-- Al usar funciones anónimas como callback (una función pasada a otra invocación de método), si no necesitas acceder a `this`, use una función de flecha para hacer el código más corto y limpio.
+- Al usar funciones anónimas como callback (una función pasada a otra invocación de método), si no necesitas acceder a `this`, usa una función de flecha para hacer el código más corto y limpio.
 
   Esta es la forma recomendada:
 
   ```js example-good
-  const numeros = [1, 2, 3, 4];
-  const suma = numeros.reduce((a, b) => a + b);
+  const array = [1, 2, 3, 4];
+  const sum = array.reduce((a, b) => a + b);
   ```
 
   En lugar de esto:
 
   ```js example-bad
-  const numeros = [1, 2, 3, 4];
-  const suma = numeros.reduce(function (a, b) {
+  const array = [1, 2, 3, 4];
+  const sum = array.reduce(function (a, b) {
     return a + b;
   });
   ```
 
-- Considere evitar usar la función de flecha para asignar una función a un identificador.
-  En particular, no utilice funciones flecha para los métodos.
-  Use declaración de funciones con la palabra clave `function`:
+- Considera evitar usar la función de flecha para asignar una función a un identificador. En particular, no uses funciones flecha para los métodos. Usa declaraciones de funciones con la palabra clave `function`:
 
   ```js example-good
   function x() {
@@ -327,7 +295,7 @@ function hazlo() {
   }
   ```
 
-  No lo hagas así:
+  No hagas:
 
   ```js example-bad
   const x = () => {
@@ -335,16 +303,16 @@ function hazlo() {
   };
   ```
 
-- Cuando utilice funciones flecha, utilice [retorno implícito](/es/docs/Web/JavaScript/Reference/Functions/Arrow_functions#cuerpo_de_función) (también conocido como _cuerpo conciso_) cuando sea posible:
+- Cuando uses funciones flecha, usa [retorno implícito](/es/docs/Web/JavaScript/Reference/Functions/Arrow_functions#cuerpo_de_función) (también conocido como _cuerpo de expresión_) cuando sea posible:
 
   ```js example-good
-  matriz.map((e) => e.id);
+  arr.map((e) => e.id);
   ```
 
   Y no:
 
   ```js example-bad
-  matriz.map((e) => {
+  arr.map((e) => {
     return e.id;
   });
   ```
@@ -353,47 +321,43 @@ function hazlo() {
 
 ### Inicialización de bucle
 
-Cuando los [bucles](/es/docs/Learn_web_development/Core/Scripting/Loops) son requeridos, elegir el apropiado entre [`for(;;)`](/es/docs/Web/JavaScript/Reference/Statements/for), [`for...of`](/es/docs/Web/JavaScript/Reference/Statements/for...of), [`while`](/es/docs/Web/JavaScript/Reference/Statements/while), etc.
+Cuando los [bucles](/es/docs/Learn_web_development/Core/Scripting/Loops) son necesarios, elige el apropiado entre [`for(;;)`](/es/docs/Web/JavaScript/Reference/Statements/for), [`for...of`](/es/docs/Web/JavaScript/Reference/Statements/for...of), [`while`](/es/docs/Web/JavaScript/Reference/Statements/while), etc.
 
-- Al iterar a través de todos los elementos de la colección, evite usar el clásico bucle `for (;;)`; es preferible `for...of` o `forEach()`.
-  Tenga en cuenta que si está utilizando una colección que no es un `Array`, tienes que comprobar que `for...of` es realmente compatible (requiere que la variable sea iterable), o que el método `forEach()` está realmente presente.
+- Al iterar a través de todos los elementos de la colección, evita usar el bucle clásico `for (;;)`; prefiere `for...of` o `forEach()`. Ten en cuenta que si estás usando una colección que no es un `Array`, tienes que comprobar que `for...of` realmente está soportado (requiere que la variable sea iterable), o que el método `forEach()` realmente está presente.
 
-  Use `for...of`:
+  Usa `for...of`:
 
   ```js example-good
-  const perros = ["Rex", "Lassie"];
-  for (const perro of perros) {
-    console.log(perro);
+  const dogs = ["Rex", "Lassie"];
+  for (const dog of dogs) {
+    console.log(dog);
   }
   ```
 
   O `forEach()`:
 
   ```js example-good
-  const perros = ["Rex", "Lassie"];
-  perros.forEach((perro) => {
-    console.log(perro);
+  const dogs = ["Rex", "Lassie"];
+  dogs.forEach((dog) => {
+    console.log(dog);
   });
   ```
 
-  No use `for (;;)` — no solo tienes que agregar un índice extra, `i`, sino que también tienes que rastrear la longitud de la matriz.
-  Esto puede ser propenso a errores para principiantes.
+  No uses `for (;;)` — no solo tienes que agregar un índice extra, `i`, sino que también tienes que rastrear la longitud del array. Esto puede ser propenso a errores para principiantes.
 
   ```js example-bad
-  const perros = ["Rex", "Lassie"];
-  for (let i = 0; i < perros.length; i++) {
-    console.log(perros[i]);
+  const dogs = ["Rex", "Lassie"];
+  for (let i = 0; i < dogs.length; i++) {
+    console.log(dogs[i]);
   }
   ```
 
-- Asegúrese de definir correctamente el inicializador utilizando la palabra clave `const` para `for...of` o `let` para los otros bucles.
-  No lo omitas.
-  Estos son ejemplos correctos:
+- Asegúrate de definir correctamente el inicializador usando la palabra clave `const` para `for...of` o `let` para los otros bucles. No lo omitas. Estos son ejemplos correctos:
 
   ```js example-good
-  const gatos = ["Athena", "Luna"];
-  for (const gato of gatos) {
-    console.log(gato);
+  const cats = ["Athena", "Luna"];
+  for (const cat of cats) {
+    console.log(cat);
   }
 
   for (let i = 0; i < 4; i++) {
@@ -401,16 +365,16 @@ Cuando los [bucles](/es/docs/Learn_web_development/Core/Scripting/Loops) son req
   }
   ```
 
-  El siguiente ejemplo no sigue las pautas recomendadas para la inicialización (implícitamente crea una variable global y fallará en modo estricto):
+  El siguiente ejemplo no sigue las directrices recomendadas para la inicialización (implícitamente crea una variable global y fallará en modo estricto):
 
   ```js example-bad
-  const gatos = ["Athena", "Luna"];
-  for (i of gatos) {
+  const cats = ["Athena", "Luna"];
+  for (i of cats) {
     console.log(i);
   }
   ```
 
-- Cuando necesite acceder tanto al valor como al índice, puede usar `.forEach()` en lugar de `for (;;)`. Escriba:
+- Cuando necesites acceder tanto al valor como al índice, puedes usar `.forEach()` en lugar de `for (;;)`. Escribe:
 
   ```js example-good
   const gerbils = ["Zoé", "Chloé"];
@@ -419,7 +383,7 @@ Cuando los [bucles](/es/docs/Learn_web_development/Core/Scripting/Loops) son req
   });
   ```
 
-  No escriba:
+  No escribas:
 
   ```js example-bad
   const gerbils = ["Zoé", "Chloé"];
@@ -429,87 +393,84 @@ Cuando los [bucles](/es/docs/Learn_web_development/Core/Scripting/Loops) son req
   ```
 
 > [!WARNING]
-> Nunca utilice `for...in` en matrices y cadenas.
+> Nunca uses `for...in` con arrays y cadenas.
 
 > [!NOTE]
-> Considere no usar un bucle `for` en absoluto. Si estás utilizando un [`Array`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array) (o un [`String`](/es/docs/Web/JavaScript/Reference/Global_Objects/String) para algunas operaciones), considere usar más métodos de iteración semántica en su lugar, como [`map()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/map), [`every()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/every), [`findIndex()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex), [`find()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/find), [`includes()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/includes), y muchos más.
+> Considera no usar un bucle `for` en absoluto. Si estás usando un [`Array`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array) (o un [`String`](/es/docs/Web/JavaScript/Reference/Global_Objects/String) para algunas operaciones), considera usar métodos de iteración más semánticos en su lugar, como [`map()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/map), [`every()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/every), [`findIndex()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex), [`find()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/find), [`includes()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Array/includes), y muchos más.
 
 ### Sentencias de control
 
-Hay un caso notable a tener en cuenta para las sentencias de control `if...else`.
-Si la declaración `if` termina con `return`, no agregue una declaración `else`.
+Hay un caso notable a tener en cuenta para las sentencias de control `if...else`. Si la sentencia `if` termina con `return`, no agregues una sentencia `else`.
 
-Continúe justo después de la instrucción `if`. Escriba:
+Continúa justo después de la sentencia `if`. Escribe:
 
 ```js example-good
-if (prueba) {
-  // Realizar algo si la prueba es verdadera
+if (test) {
+  // Realiza algo si test es verdadero
   // …
   return;
 }
 
-// Realizar algo si la prueba es falsa
+// Realiza algo si test es falso
 // …
 ```
 
-No escriba:
+No escribas:
 
 ```js example-bad
-if (prueba) {
-  // Realizar algo si la prueba es verdadera
+if (test) {
+  // Realiza algo si test es verdadero
   // …
   return;
 } else {
-  // Realizar algo si la prueba es falsa
+  // Realiza algo si test es falso
   // …
 }
 ```
 
-### Use llaves con sentencias de flujo de control y bucles
+### Usa llaves con sentencias de flujo de control y bucles
 
-Si bien las declaraciones de flujo de control como `if`, `for` y `while` no requieren el uso de llaves cuando el contenido se compone de una sola declaración, siempre debe usar llaves.
-Escriba:
+Aunque las sentencias de flujo de control como `if`, `for`, y `while` no requieren el uso de llaves cuando el contenido se compone de una sola sentencia, siempre debes usar llaves. Escribe:
 
 ```js example-good
-for (const carro of carrosAlmacenados) {
-  carro.pintar("rojo");
+for (const car of storedCars) {
+  car.paint("red");
 }
 ```
 
-No escriba:
+No escribas:
 
 ```js example-bad
-for (const carro of carrosAlmacenados) carro.pintar("rojo");
+for (const car of storedCars) car.paint("red");
 ```
 
-Esto evita olvidarse de agregar las llaves al agregar más declaraciones.
+Esto evita olvidarse de agregar las llaves al agregar más sentencias.
 
 ### Sentencias switch
 
-Las sentencias `switch` pueden ser un poco complicadas.
+Las sentencias switch pueden ser un poco complicadas.
 
-- No agregue una declaración `break` después de una declaración `return` en un caso específico.
-  En su lugar, escriba instrucciones `return` como esta:
+- No agregues una sentencia `break` después de una sentencia `return` en un caso específico. En su lugar, escribe sentencias `return` así:
 
   ```js example-good
-  switch (especies) {
-    case "pollo":
+  switch (species) {
+    case "chicken":
       return farm.shed;
-    case "caballo":
+    case "horse":
       return corral.entry;
     default:
       return "";
   }
   ```
 
-  Si agrega una declaración `break`, será inalcanzable. No escriba:
+  Si agregas una sentencia `break`, será inalcanzable. No escribas:
 
   ```js example-bad
-  switch (especies) {
-    case "pollo":
+  switch (species) {
+    case "chicken":
       return farm.shed;
       break;
-    case "caballo":
+    case "horse":
       return corral.entry;
       break;
     default:
@@ -517,21 +478,20 @@ Las sentencias `switch` pueden ser un poco complicadas.
   }
   ```
 
-- Use `default` como el último caso, y no lo termine con una declaración `break`.
-  Si necesita hacerlo de otra manera, agregue un comentario explicando por qué.
+- Usa `default` como el último caso, y no lo termines con una sentencia `break`. Si necesitas hacerlo de otra manera, agrega un comentario explicando por qué.
 
-- Recuerde que cuando declara una variable local para un caso, necesita usar llaves para definir un alcance:
+- Recuerda que cuando declaras una variable local para un caso, necesitas usar llaves para definir un alcance:
 
   ```js
-  switch (frutas) {
-    case "Naranja": {
-      const pedazo = frutas.cortar();
-      comer(pedazo);
+  switch (fruits) {
+    case "Orange": {
+      const slice = fruit.slice();
+      eat(slice);
       break;
     }
-    case "Manzana": {
-      const corazon = frutas.extraerCorazon();
-      reciclar(corazon);
+    case "Apple": {
+      const core = fruit.extractCore();
+      recycle(core);
       break;
     }
   }
@@ -539,38 +499,36 @@ Las sentencias `switch` pueden ser un poco complicadas.
 
 ### Manejo de errores
 
-- Si ciertos estados de su programa arrojan errores no detectados, detendrán la ejecución y reducirán potencialmente la utilidad del ejemplo.
-  Por lo tanto, debe detectar errores utilizando un bloque [`try...catch`](/es/docs/Web/JavaScript/Reference/Statements/try...catch), Como se muestra debajo:
+- Si ciertos estados de tu programa arrojan errores no detectados, detendrán la ejecución y reducirán potencialmente la utilidad del ejemplo. Por lo tanto, debes detectar errores usando un bloque [`try...catch`](/es/docs/Web/JavaScript/Reference/Statements/try...catch), como se muestra abajo:
 
   ```js example-good
   try {
-    console.log(obtenerResultado());
+    console.log(getResult());
   } catch (e) {
     console.error(e);
   }
   ```
 
-- Cuando no necesite el parámetro de la sentencia `catch`, omítalo:
+- Cuando no necesites el parámetro de la sentencia `catch`, omítelo:
 
   ```js example-good
   try {
-    console.log(obtenerResultado());
+    console.log(getResult());
   } catch {
     console.error("Ocurrió un error!");
   }
   ```
 
 > [!NOTE]
-> Tenga en cuenta que solo los errores _recuperables_ deben detectarse y manejarse.
-> Todos los errores no recuperables deben dejarse pasar y aumentar la pila de llamadas.
+> Ten en cuenta que solo los errores _recuperables_ deben detectarse y manejarse. Todos los errores no recuperables deben dejarse pasar y propagarse por la pila de llamadas.
 
 ## Objetos
 
-### Nombre de objetos
+### Nombres de objetos
 
-- Al definir una clase, use _PascalCase_ (comenzando con una letra mayúscula) para el nombre de la clase y _camelCase_ (comenzando con una letra minúscula) para la propiedad del objeto y los nombres de los métodos.
+- Al definir una clase, usa _PascalCase_ (comenzando con una letra mayúscula) para el nombre de la clase y _camelCase_ (comenzando con una letra minúscula) para la propiedad del objeto y los nombres de los métodos.
 
-- Al definir una instancia de objeto, ya sea un literal o mediante un constructor, use _camelCase_, comenzando con un carácter en minúsculas, para el nombre de la instancia. Por ejemplo:
+- Al definir una instancia de objeto, ya sea un literal o mediante un constructor, usa _camelCase_, comenzando con un carácter en minúscula, para el nombre de la instancia. Por ejemplo:
 
   ```js example-good
   const hanSolo = new Person("Han Solo", 25, "he/him");
@@ -584,51 +542,51 @@ Las sentencias `switch` pueden ser un poco complicadas.
 
 ### Creación de objetos
 
-Para crear objetos generales (es decir, cuando las clases no están involucradas), use literales y no constructores.
+Para crear objetos generales (es decir, cuando las clases no están involucradas), usa literales y no constructores.
 
 Por ejemplo, haz esto:
 
 ```js example-good
-const objeto = {};
+const object = {};
 ```
 
-No crees un objeto general como este:
+No crees un objeto general así:
 
 ```js example-bad
-const objeto = new Object();
+const object = new Object();
 ```
 
 ### Clases de objetos
 
-- Use la sintaxis de clase ES para objetos, no constructores de estilo antiguo.
+- Usa la sintaxis de clase ES para objetos, no constructores de estilo antiguo.
 
   Por ejemplo, esta es la forma recomendada:
 
   ```js example-good
-  class Persona {
-    constructor(nombre, edad, pronombres) {
-      this.nombre = nombre;
-      this.edad = edad;
-      this.pronombres = pronombres;
+  class Person {
+    constructor(name, age, pronouns) {
+      this.name = name;
+      this.age = age;
+      this.pronouns = pronouns;
     }
 
     greeting() {
-      console.log(`Hola! Yo soy ${this.nombre}`);
+      console.log(`Hi! I'm ${this.name}`);
     }
   }
   ```
 
-- Usar `extends` para la herencia:
+- Usa `extends` para la herencia:
 
   ```js example-good
-  class Profesor extends Persona {
+  class Teacher extends Person {
     // …
   }
   ```
 
 ### Métodos
 
-Para definir métodos, utilice la sintaxis de definición de métodos:
+Para definir métodos, usa la sintaxis de definición de métodos:
 
 ```js example-good
 const obj = {
@@ -657,19 +615,19 @@ const obj = {
 ### Propiedades del objeto
 
 - El método [`Object.prototype.hasOwnProperty()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) ha quedado obsoleto en favor de [`Object.hasOwn()`](/es/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn).
-- Cuando sea posible, use la abreviatura evitando la duplicación del identificador de la propiedad. Escriba:
+- Cuando sea posible, usa la forma abreviada evitando la duplicación del identificador de la propiedad. Escribe:
 
   ```js example-good
-  function crearObjeto(nombre, edad) {
-    return { nombre, edad };
+  function createObject(name, age) {
+    return { name, age };
   }
   ```
 
-  No escriba:
+  No escribas:
 
   ```js example-bad
-  function crearObjeto(nombre, edad) {
-    return { nombre: nombre, edad: edad };
+  function createObject(name, age) {
+    return { name: name, age: age };
   }
   ```
 
@@ -679,113 +637,95 @@ Esta sección enumera nuestras recomendaciones sobre qué operadores usar y cuá
 
 ### Operadores condicionales
 
-Cuando desee almacenar en una variable un valor literal dependiendo de una condición, use un [operador condicional (ternario)](/es/docs/Web/JavaScript/Reference/Operators/Conditional_operator) en lugar de una sentencia `if...else`.
-Esta regla también se aplica cuando se devuelve un valor. Escriba:
+Cuando quieras almacenar en una variable un valor literal dependiendo de una condición, usa un [operador condicional (ternario)](/es/docs/Web/JavaScript/Reference/Operators/Conditional_operator) en lugar de una sentencia `if...else`. Esta regla también se aplica cuando se devuelve un valor. Escribe:
 
 ```js example-good
-const x = condicion ? 1 : 2;
+const x = condition ? 1 : 2;
 ```
 
-No escriba:
+No escribas:
 
 ```js example-bad
 let x;
-if (condicion) {
+if (condition) {
   x = 1;
 } else {
   x = 2;
 }
 ```
 
-El operador condicional es útil al crear cadenas para registrar información.
-En tales casos, el uso de una instrucción regular `if...else` conduce a largos bloques de código para una operación secundaria como el registro, ofuscando el punto central del ejemplo.
+El operador condicional es útil al crear cadenas para registrar información. En tales casos, el uso de una sentencia regular `if...else` lleva a largos bloques de código para una operación secundaria como el registro, oscureciendo el punto central del ejemplo.
 
 ### Operador de igualdad estricta
 
-Preferir los operadores de [igualdad estricta](/es/docs/Web/JavaScript/Reference/Operators/Strict_equality) `===` y de desigualdad `!==` sobre los operadores de igualdad flexible `==` y de desigualdad `!=`.
+Prefiere los operadores de [igualdad estricta](/es/docs/Web/JavaScript/Reference/Operators/Strict_equality) (triple igual) y de desigualdad sobre los operadores de igualdad flexible (doble igual) y de desigualdad.
 
-Use los operadores estrictos de igualdad y desigualdad de esta forma:
+Usa los operadores de igualdad estricta y de desigualdad así:
 
 ```js example-good
-nombre === "Shilpa";
-edad !== 25;
+name === "Shilpa";
+age !== 25;
 ```
 
-No use los operadores sueltos de igualdad y desigualdad, como se muestra a continuación:
+No uses los operadores de igualdad y desigualdad flexibles, como se muestra abajo:
 
 ```js example-bad
-nombre == "Shilpa";
-edad != 25;
+name == "Shilpa";
+age != 25;
 ```
 
-Si necesita usar `==` o `!=`, recuerde que `== null` es el único caso aceptable.
-Como TypeScript fallará en todos los demás casos, no queremos tenerlos en nuestro código de ejemplo.
-Considere agregar un comentario para explicar por qué lo necesita.
+Si necesitas usar `==` o `!=`, recuerda que `== null` es el único caso aceptable. Como TypeScript fallará en todos los demás casos, no queremos tenerlos en nuestro código de ejemplo. Considera agregar un comentario para explicar por qué lo necesitas.
 
 ### Atajos para pruebas booleanas
 
-Prefiera atajos para las pruebas booleanas. Por ejemplo, use `if (x)` y `if (!x)`, no use `if (x === true)` y `if (x === false)`, a menos que diferentes tipos de valores verdaderos o falsos se manejen de forma diferente.
+Prefiere atajos para las pruebas booleanas. Por ejemplo, usa `if (x)` y `if (!x)`, no `if (x === true)` y `if (x === false)`, a menos que diferentes tipos de valores verdaderos o falsos se manejen de forma diferente.
 
 ## Cadenas
 
-Las cadenas literales se pueden encerrar entre comillas simples, como en `'Una cadena'`, o entre comillas dobles, como en `"Una cadena"`.
-No se preocupe por cuál usar, Prettier lo mantiene consistente.
+Las cadenas literales se pueden encerrar entre comillas simples, como en `'Una cadena'`, o entre comillas dobles, como en `"Una cadena"`. No te preocupes por cuál usar; Prettier lo mantiene consistente.
 
 ### Template literals
 
-Para insertar valores en cadenas, use [Plantillas literales](/es/docs/Web/JavaScript/Reference/Template_literals).
+Para insertar valores en cadenas, usa [plantillas literales](/es/docs/Web/JavaScript/Reference/Template_literals).
 
-- Aquí hay un ejemplo de la forma recomendada de usar plantillas literales.
-  Su uso evita muchos errores de espaciado.
+- Aquí hay un ejemplo de la forma recomendada de usar plantillas literales. Su uso evita muchos errores de espaciado.
 
   ```js example-good
-  const nombre = "Shilpa";
-  console.log(`¡Hola! Soy ${nombre}!`);
+  const name = "Shilpa";
+  console.log(`Hi! I'm ${name}!`);
   ```
 
   No concatenes cadenas así:
 
   ```js example-bad
-  const nombre = "Shilpa";
-  console.log("¡Hola! Soy" + nombre + "!"); // ¡Hola! SoyShilpa!
+  const name = "Shilpa";
+  console.log("Hi! I'm" + name + "!"); // Hi! I'mShilpa!
   ```
 
-- No abuses de las plantillas literales.
-  Si no hay sustituciones, use una cadena literal normal en su lugar.
+- No abuses de las plantillas literales. Si no hay sustituciones, usa una cadena literal normal en su lugar.
 
 ## Variables
 
-### Nombre de Variables
+### Nombres de variables
 
 Los buenos nombres de variables son esenciales para comprender el código.
 
-- Use identificadores cortos y evite abreviaturas no comunes.
-  Los buenos nombres de variables suelen tener entre 3 y 10 caracteres, pero solo como sugerencia.
-  Por ejemplo, 'acelerómetro' es más descriptivo que abreviar como 'aclmtr' por el bien de la longitud de los caracteres.
-- Trate de usar ejemplos relevantes del mundo real donde cada variable tenga una semántica clara.
-  Solo recurra a nombres de marcadores de posición como `foo` y `bar` cuando el ejemplo sea simple y artificial.
-- No utilice la convención de nomenclatura [Notación húngara](https://es.wikipedia.org/wiki/Notaci%C3%B3n_h%C3%BAngara).
-  No prefije el nombre de la variable con su tipo.
-  Por ejemplo, escriba `bought = car.buyer !== null` en lugar de `bBought = oCar.sBuyer != null` o `name = "John Doe"` en lugar de `sName = "John Doe"`.
-- Para colecciones, evite agregar el tipo como lista, matriz, cola en el nombre.
-  Use el nombre del contenido en plural.
-  Por ejemplo, para una matriz de autos, utilice `cars` y no `carArray` o `carList`.
-  Puede haber excepciones, como cuando desea mostrar la forma abstracta de una función sin el contexto de una aplicación en particular.
-- Para valores primitivos, use _camelCase_, comenzando con un carácter en minúscula.
-  No use `_`.
-  Utilice nombres concisos, legibles por humanos y semánticos cuando sea apropiado.
-  Por ejemplo, use `currencyName` en lugar de `currency_name`.
-- Evite el uso de artículos y posesivos.
-  Por ejemplo, utilice `car` en lugar de `myCar` o `aCar`.
-  Puede haber excepciones, como cuando se describe una característica en general sin un contexto práctico.
-- Use nombres de variables como se muestra aquí:
+<!-- cSpell:ignore acclmtr -->
+
+- Usa identificadores cortos y evita abreviaturas no comunes. Los buenos nombres de variables suelen tener entre 3 y 10 caracteres, pero solo como sugerencia. Por ejemplo, `accelerometer` es más descriptivo que abreviar como `acclmtr` por el bien de la longitud de los caracteres.
+- Trata de usar ejemplos relevantes del mundo real donde cada variable tenga una semántica clara. Solo recurre a nombres de marcadores de posición como `foo` y `bar` cuando el ejemplo sea simple y artificial.
+- No uses la convención de nomenclatura [notación húngara](https://es.wikipedia.org/wiki/Notaci%C3%B3n_h%C3%BAngara). No prefijes el nombre de la variable con su tipo. Por ejemplo, escribe `bought = car.buyer !== null` en lugar de `bBought = oCar.sBuyer != null` o `name = "Maria Sanchez"` en lugar de `sName = "Maria Sanchez"`.
+- Para colecciones, evita agregar el tipo como lista, array, cola en el nombre. Usa el nombre del contenido en plural. Por ejemplo, para un array de autos, usa `cars` y no `carArray` o `carList`. Puede haber excepciones, como cuando quieres mostrar la forma abstracta de una característica sin el contexto de una aplicación en particular.
+- Para valores primitivos, usa _camelCase_, comenzando con un carácter en minúscula. No uses `_`. Usa nombres concisos, legibles y semánticos cuando sea apropiado. Por ejemplo, usa `currencyName` en lugar de `currency_name`.
+- Evita el uso de artículos y posesivos. Por ejemplo, usa `car` en lugar de `myCar` o `aCar`. Puede haber excepciones, como cuando se describe una característica en general sin un contexto práctico.
+- Usa nombres de variables como se muestra aquí:
 
   ```js example-good
   const playerScore = 0;
   const speed = distance / time;
   ```
 
-  No nombre variables de esta forma:
+  No nombres variables así:
 
   ```js example-bad
   const thisIsaveryLONGVariableThatRecordsPlayerscore345654 = 0;
@@ -793,53 +733,50 @@ Los buenos nombres de variables son esenciales para comprender el código.
   ```
 
 > [!NOTE]
-> El único lugar donde está permitido no usar nombres semánticos legibles por humanos es donde existe una convención comúnmente reconocida, como usar `i` y `j` para iteradores de bucle.
+> El único lugar donde está permitido no usar nombres semánticos legibles es donde existe una convención comúnmente reconocida, como usar `i` y `j` para iteradores de bucle.
 
-### Declaración de Variables
+### Declaraciones de variables
 
-Al declarar variables y constantes, use las palabras clave [`let`](/es/docs/Web/JavaScript/Reference/Statements/let) y [`const`](/es/docs/Web/JavaScript/Reference/Statements/const), no [`var`](/es/docs/Web/JavaScript/Reference/Statements/var).
-Los siguientes ejemplos muestran lo que se recomienda y lo que no en los documentos web de MDN:
+Al declarar variables y constantes, usa las palabras clave [`let`](/es/docs/Web/JavaScript/Reference/Statements/let) y [`const`](/es/docs/Web/JavaScript/Reference/Statements/const), no [`var`](/es/docs/Web/JavaScript/Reference/Statements/var). Los siguientes ejemplos muestran lo que se recomienda y lo que no en MDN Web Docs:
 
-- Si una variable no se reasignará, prefiera `const`, así:
-
-  ```js example-good
-  const nombre = "Shilpa";
-  console.log(nombre);
-  ```
-
-- Si va a cambiar el valor de una variable, use `let` como se muestra a continuación:
+- Si una variable no se reasignará, prefiere `const`, así:
 
   ```js example-good
-  let edad = 40;
-  edad++;
-  console.log("¡Feliz cumpleaños!");
+  const name = "Shilpa";
+  console.log(name);
   ```
 
-- El siguiente ejemplo usa `let` donde debería ser `const`.
-  El código funcionará, pero queremos evitar este uso en los ejemplos de código de los documentos web de MDN.
+- Si vas a cambiar el valor de una variable, usa `let` como se muestra abajo:
 
-  ```js example-bad
-  let nombre = "Shilpa";
-  console.log(nombre);
+  ```js example-good
+  let age = 40;
+  age++;
+  console.log("Happy birthday!");
   ```
 
-- El siguiente ejemplo usa `const` para una variable que se reasigna.
-  La reasignación arrojará un error.
+- El siguiente ejemplo usa `let` donde debería ser `const`. El código funcionará, pero queremos evitar este uso en los ejemplos de código de MDN Web Docs.
 
   ```js example-bad
-  const edad = 40;
-  edad++;
-  console.log("¡Feliz cumpleaños!");
+  let name = "Shilpa";
+  console.log(name);
+  ```
+
+- El siguiente ejemplo usa `const` para una variable que se reasigna. La reasignación arrojará un error.
+
+  ```js example-bad
+  const age = 40;
+  age++;
+  console.log("Happy birthday!");
   ```
 
 - El siguiente ejemplo usa `var`, contaminando el alcance global:
 
   ```js example-bad
-  var edad = 40;
-  var nombre = "Shilpa";
+  var age = 40;
+  var name = "Shilpa";
   ```
 
-- Declare una variable por línea, así:
+- Declara una variable por línea, así:
 
   ```js example-good
   let var1;
@@ -848,8 +785,7 @@ Los siguientes ejemplos muestran lo que se recomienda y lo que no en los documen
   let var4 = var3;
   ```
 
-  No declare múltiples variables en una línea, separándolas con comas o usando declaraciones en cadena.
-  Evite declarar variables así:
+  No declares múltiples variables en una línea, separándolas con comas o usando declaraciones en cadena. Evita declarar variables así:
 
   ```js-nolint example-bad
   let var1, var2;
@@ -858,8 +794,7 @@ Los siguientes ejemplos muestran lo que se recomienda y lo que no en los documen
 
 ### Coerción de tipos
 
-Evite las coacciones de tipo implícito. En particular, evite `+val` para forzar un valor a un número y `"" + val` para forzarlo a una cadena.
-Utilice `Number()` y `String()`, sin `new`, en su lugar. Escriba:
+Evita las coerciones de tipo implícito. En particular, evita `+val` para forzar un valor a un número y `"" + val` para forzarlo a una cadena. Usa `Number()` y `String()`, sin `new`, en su lugar. Escribe:
 
 ```js example-good
 class Person {
@@ -873,7 +808,7 @@ class Person {
 }
 ```
 
-No escriba:
+No escribas:
 
 ```js example-bad
 class Person {
@@ -889,17 +824,17 @@ class Person {
 
 ## APIs web para evitar
 
-Además de estas características del lenguaje JavaScript, recomendamos tener en cuenta algunas pautas relacionadas con las API web.
+Además de estas características del lenguaje JavaScript, recomendamos tener en cuenta algunas directrices relacionadas con las APIs web.
 
-### Evite los prefijos del navegador
+### Evita los prefijos del navegador
 
-Si todos los principales navegadores (Chrome, Edge, Firefox y Safari) soportan una función, no agregue el prefijo de la función. Escriba:
+Si todos los navegadores principales (Chrome, Edge, Firefox y Safari) soportan una característica, no agregues el prefijo de la característica. Escribe:
 
 ```js example-good
 const context = new AudioContext();
 ```
 
-Evite la complejidad añadida de los prefijos. No escriba:
+Evita la complejidad añadida de los prefijos. No escribas:
 
 ```js example-bad
 const AudioContext = window.AudioContext || window.webkitAudioContext;
@@ -908,21 +843,18 @@ const context = new AudioContext();
 
 La misma regla se aplica a los prefijos CSS.
 
-### Evite las API en desuso
+### Evita las APIs obsoletas
 
-Cuando un método, una propiedad o una interfaz completa está en desuso, no lo use (fuera de su documentación).
-En su lugar, utilice la API moderna.
+Cuando un método, una propiedad o una interfaz completa está obsoleto, no lo uses (fuera de su documentación). En su lugar, usa la API moderna.
 
-Aquí hay una lista no exhaustiva de API web para evitar y con qué reemplazarlas:
+Aquí hay una lista no exhaustiva de APIs web para evitar y con qué reemplazarlas:
 
-- Use `fetch()` en lugar de XHR (`XMLHttpRequest`).
-- Use `AudioWorklet` en lugar de `ScriptProcessorNode`, en la API de Audio Web.
+- Usa `fetch()` en lugar de XHR (`XMLHttpRequest`).
+- Usa `AudioWorklet` en lugar de `ScriptProcessorNode`, en la Web Audio API.
 
-### Use API seguras y confiables
+### Usa APIs seguras y confiables
 
-- No utilice {{DOMxRef("Element.innerHTML")}} para insertar contenido puramente textual en un elemento; use {{DOMxRef("Node.textContent")}} en su lugar.
-  La propiedad `innerHTML` genera problemas de seguridad si un desarrollador no controla el parámetro.
-  Cuanto más evitamos usarlo como escritores, menos fallas de seguridad se crean cuando un desarrollador copia y pega nuestro código.
+- No uses {{DOMxRef("Element.innerHTML")}} para insertar contenido puramente textual en un elemento; usa {{DOMxRef("Node.textContent")}} en su lugar. La propiedad `innerHTML` genera problemas de seguridad si un desarrollador no controla el parámetro. Cuanto más evitemos usarlo como escritores, menos fallos de seguridad se crean cuando un desarrollador copia y pega nuestro código.
 
   El siguiente ejemplo demuestra el uso de `textContent`.
 
@@ -932,7 +864,7 @@ Aquí hay una lista no exhaustiva de API web para evitar y con qué reemplazarla
   para.textContent = text;
   ```
 
-  No use `innerHTML` para insertar _texto puro_ en los nodos DOM.
+  No uses `innerHTML` para insertar _texto puro_ en los nodos DOM.
 
   ```js example-bad
   const text = "Hello to all you good people";
@@ -940,18 +872,13 @@ Aquí hay una lista no exhaustiva de API web para evitar y con qué reemplazarla
   para.innerHTML = text;
   ```
 
-- La función `alert()` no es fiable.
-  No funciona en ejemplos en vivo en MDN Web Docs que están dentro de un {{HTMLElement("iframe")}}.
-  Además, es modal para toda la ventana, lo cual es molesto.
-  En ejemplos de código estático, use `console.log()` o `console.error()`.
-  En [ejemplos en vivo](/es/docs/MDN/Writing_guidelines/Page_structures/Live_samples), evite `console.log()` y `console.error()` porque no se muestran.
-  Utilice un elemento de interfaz de usuario dedicado.
+- La función `alert()` no es confiable. No funciona en ejemplos en vivo en MDN Web Docs que están dentro de un {{HTMLElement("iframe")}}. Además, es modal para toda la ventana, lo cual es molesto. En ejemplos de código estático, usa `console.log()` o `console.error()`. En [ejemplos en vivo](/es/docs/MDN/Writing_guidelines/Page_structures/Live_samples), evita `console.log()` y `console.error()` porque no se muestran. Usa un elemento de interfaz de usuario dedicado.
 
-### Utilice el método de registro adecuado
+### Usa el método de registro apropiado
 
-- Al registrar un mensaje, utilice `console.log()`.
-- Cuando registre un error, use `console.error()`.
+- Al registrar un mensaje, usa `console.log()`.
+- Al registrar un error, usa `console.error()`.
 
-## Vea también
+## Véase también
 
-[Referencia del lenguaje JavaScript](/es/docs/Web/JavaScript/Reference) - navegue a través de nuestras páginas de referencia de JavaScript para ver algunos fragmentos de JavaScript buenos, concisos y significativos.
+[Referencia del lenguaje JavaScript](/es/docs/Web/JavaScript/Reference) - navega a través de nuestras páginas de referencia de JavaScript para ver algunos fragmentos de JavaScript buenos, concisos y significativos.


### PR DESCRIPTION
This PR updates the Spanish translation of the Code style guide and JavaScript code style guide.

Changes:
- Complete translation of all sections from the current English source
- Updated front matter with correct l10n.sourceCommit SHA
- Translated terminology using MDN Spanish style guide
- Updated internal links to use /es/ prefix
- Preserved all Kumascript macros as-is
- Applied Prettier and markdownlint formatting

Closes: #35378, #35379