### PR TITLE
chore(sync-fr): css `@media` descriptor pages use backticks on title

### DIFF
--- a/files/fr/web/css/reference/at-rules/@media/-moz-device-pixel-ratio/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/-moz-device-pixel-ratio/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `-moz-device-pixel-ratio`
+title: Caractéristique média CSS `-moz-device-pixel-ratio`
 short-title: -moz-device-pixel-ratio
 slug: Web/CSS/Reference/At-rules/@media/-moz-device-pixel-ratio
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 {{Non-standard_Header}}{{Deprecated_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/-webkit-animation/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/-webkit-animation/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `-webkit-animation`
+title: Caractéristique média CSS `-webkit-animation`
 short-title: -webkit-animation
 slug: Web/CSS/Reference/At-rules/@media/-webkit-animation
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 {{Non-standard_Header}}{{Deprecated_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/-webkit-device-pixel-ratio/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/-webkit-device-pixel-ratio/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `-webkit-device-pixel-ratio`
+title: Caractéristique média CSS `-webkit-device-pixel-ratio`
 short-title: -webkit-device-pixel-ratio
 slug: Web/CSS/Reference/At-rules/@media/-webkit-device-pixel-ratio
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 **`-webkit-device-pixel-ratio`** est une caractéristique média non-standard, alternative à la caractéristique média standard {{CSSxRef("@media/resolution", "resolution")}}.

--- a/files/fr/web/css/reference/at-rules/@media/-webkit-transform-2d/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/-webkit-transform-2d/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `-webkit-transform-2d`
+title: Caractéristique média CSS `-webkit-transform-2d`
 short-title: -webkit-transform-2d
 slug: Web/CSS/Reference/At-rules/@media/-webkit-transform-2d
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 {{Non-standard_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/-webkit-transform-3d/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/-webkit-transform-3d/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `-webkit-transform-3d`
+title: Caractéristique média CSS `-webkit-transform-3d`
 short-title: -webkit-transform-3d
 slug: Web/CSS/Reference/At-rules/@media/-webkit-transform-3d
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) booléenne [CSS](/fr/docs/Web/CSS) **`-webkit-transform-3d`** est une [extension WebKit](/fr/docs/Web/CSS/Reference/Webkit_extensions) qui vaut `true` si les transformations CSS 3D {{CSSxRef("transform")}} préfixées sont prises en charge.

--- a/files/fr/web/css/reference/at-rules/@media/-webkit-transition/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/-webkit-transition/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `-webkit-transition`
+title: Caractéristique média CSS `-webkit-transition`
 short-title: -webkit-transition
 slug: Web/CSS/Reference/At-rules/@media/-webkit-transition
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 {{Deprecated_Header}}{{Non-standard_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/any-hover/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/any-hover/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `any-hover`
+title: Caractéristique média CSS `any-hover`
 short-title: any-hover
 slug: Web/CSS/Reference/At-rules/@media/any-hover
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`any-hover`** est utilisée pour tester si _n'importe quel_ mécanisme d'entrée disponible peut survoler un élément.

--- a/files/fr/web/css/reference/at-rules/@media/any-pointer/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/any-pointer/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `any-pointer`
+title: Caractéristique média CSS `any-pointer`
 short-title: any-pointer
 slug: Web/CSS/Reference/At-rules/@media/any-pointer
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`any-pointer`** vérifie si l'utilisateur dispose _d'un_ dispositif de pointage (comme une souris) et, le cas échéant, quelle est sa précision.

--- a/files/fr/web/css/reference/at-rules/@media/aspect-ratio/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/aspect-ratio/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `aspect-ratio`
+title: Caractéristique média CSS `aspect-ratio`
 short-title: aspect-ratio
 slug: Web/CSS/Reference/At-rules/@media/aspect-ratio
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`aspect-ratio`** peut être utilisée pour tester le {{Glossary("aspect ratio", "rapport d'aspect")}} de la {{Glossary("viewport", "zone d'affichage")}}.

--- a/files/fr/web/css/reference/at-rules/@media/color-gamut/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/color-gamut/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `color-gamut`
+title: Caractéristique média CSS `color-gamut`
 short-title: color-gamut
 slug: Web/CSS/Reference/At-rules/@media/color-gamut
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`color-gamut`** est utilisée pour appliquer des styles CSS en fonction de l'intervalle approximatif des couleurs {{Glossary("gamut")}} pris en charge par l'agent utilisateur et l'appareil de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/color-index/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/color-index/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `color-index`
+title: Caractéristique média CSS `color-index`
 short-title: color-index
 slug: Web/CSS/Reference/At-rules/@media/color-index
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`color-index`** est utilisée pour tester le nombre d'entrées dans la table de recherche des couleurs du périphérique de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/color/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/color/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `color`
+title: Caractéristique média CSS `color`
 short-title: color
 slug: Web/CSS/Reference/At-rules/@media/color
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`color`** est utilisée pour tester le nombre de bits par composante de couleur (rouge, vert, bleu) du périphérique de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/device-aspect-ratio/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/device-aspect-ratio/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `device-aspect-ratio`
+title: Caractéristique média CSS `device-aspect-ratio`
 short-title: device-aspect-ratio
 slug: Web/CSS/Reference/At-rules/@media/device-aspect-ratio
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/device-height/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/device-height/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `device-height`
+title: Caractéristique média CSS `device-height`
 short-title: device-height
 slug: Web/CSS/Reference/At-rules/@media/device-height
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/device-posture/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/device-posture/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `device-posture`
+title: Caractéristique média CSS `device-posture`
 short-title: device-posture
 slug: Web/CSS/Reference/At-rules/@media/device-posture
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/at-rules/@media/device-width/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/device-width/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `device-width`
+title: Caractéristique média CSS `device-width`
 short-title: device-width
 slug: Web/CSS/Reference/At-rules/@media/device-width
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/css/reference/at-rules/@media/display-mode/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/display-mode/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `display-mode`
+title: Caractéristique média CSS `display-mode`
 short-title: display-mode
 slug: Web/CSS/Reference/At-rules/@media/display-mode
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`display-mode`** permet de tester si une application web est affichée dans un onglet de navigateur classique ou d'une autre manière, comme une application autonome ou en mode plein écran.

--- a/files/fr/web/css/reference/at-rules/@media/dynamic-range/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/dynamic-range/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `dynamic-range`
+title: Caractéristique média CSS `dynamic-range`
 short-title: dynamic-range
 slug: Web/CSS/Reference/At-rules/@media/dynamic-range
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`dynamic-range`** permet de tester la combinaison de la luminosité, du taux de contraste et de la profondeur de couleur pris en charge par l'{{Glossary("user agent", "agent utilisateur")}} et le périphérique de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/forced-colors/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/forced-colors/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `forced-colors`
+title: Caractéristique média CSS `forced-colors`
 short-title: forced-colors
 slug: Web/CSS/Reference/At-rules/@media/forced-colors
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`forced-colors`** permet de détecter si l'{{Glossary("user agent", "agent utilisateur")}} a activé un mode couleurs forcées, dans lequel il impose une palette de couleurs limitée choisie par l'utilisateur·ice sur la page. Un exemple de mode couleurs forcées est le mode contraste élevé de Windows.

--- a/files/fr/web/css/reference/at-rules/@media/grid/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/grid/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `grid`
+title: Caractéristique média CSS `grid`
 short-title: grid
 slug: Web/CSS/Reference/At-rules/@media/grid
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`grid`** permet de tester si le périphérique de sortie utilise un écran basé sur une grille.

--- a/files/fr/web/css/reference/at-rules/@media/height/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/height/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `height`
+title: Caractéristique média CSS `height`
 short-title: height
 slug: Web/CSS/Reference/At-rules/@media/height
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`height`** permet d'appliquer des styles en fonction de la hauteur de la {{Glossary("viewport", "zone d'affichage")}} (ou de la boîte de page, pour les [médias paginés](/fr/docs/Web/CSS/Guides/Paged_media)).

--- a/files/fr/web/css/reference/at-rules/@media/horizontal-viewport-segments/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/horizontal-viewport-segments/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `horizontal-viewport-segments`
+title: Caractéristique média CSS `horizontal-viewport-segments`
 short-title: horizontal-viewport-segments
 slug: Web/CSS/Reference/At-rules/@media/horizontal-viewport-segments
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`horizontal-viewport-segments`** permet de détecter si l'appareil possède un nombre spécifié de segments de zone d'affichage disposés horizontalement (côte à côte).

--- a/files/fr/web/css/reference/at-rules/@media/hover/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/hover/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `hover`
+title: Caractéristique média CSS `hover`
 short-title: hover
 slug: Web/CSS/Reference/At-rules/@media/hover
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`hover`** est utilisée pour tester si le _mécanisme_ de saisie principal de l'utilisateur·ice peut survoler des éléments.

--- a/files/fr/web/css/reference/at-rules/@media/inverted-colors/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/inverted-colors/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `inverted-colors`
+title: Caractéristique média CSS `inverted-colors`
 short-title: inverted-colors
 slug: Web/CSS/Reference/At-rules/@media/inverted-colors
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`inverted-colors`** permet de tester si l'{{Glossary("user agent", "agent utilisateur")}} ou le système d'exploitation sous-jacent a inversé toutes les couleurs.

--- a/files/fr/web/css/reference/at-rules/@media/monochrome/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/monochrome/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `monochrome`
+title: Caractéristique média CSS `monochrome`
 short-title: monochrome
 slug: Web/CSS/Reference/At-rules/@media/monochrome
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`monochrome`** permet de tester le nombre de bits par pixel dans le tampon d'affichage monochrome de l'appareil de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/orientation/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/orientation/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `orientation`
+title: Caractéristique média CSS `orientation`
 short-title: orientation
 slug: Web/CSS/Reference/At-rules/@media/orientation
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`orientation`** permet de tester l'orientation de la {{Glossary("viewport", "zone d'affichage")}} (ou de la boîte de page, pour les [médias paginés](/fr/docs/Web/CSS/Guides/Paged_media)).

--- a/files/fr/web/css/reference/at-rules/@media/overflow-block/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/overflow-block/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `overflow-block`
+title: Caractéristique média CSS `overflow-block`
 short-title: overflow-block
 slug: Web/CSS/Reference/At-rules/@media/overflow-block
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`overflow-block`** permet de tester la façon dont l'appareil de sortie gère le contenu qui déborde du [bloc englobant](/fr/docs/Web/CSS/Guides/Display/Containing_block) initial selon l'axe du bloc.

--- a/files/fr/web/css/reference/at-rules/@media/overflow-inline/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/overflow-inline/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `overflow-inline`
+title: Caractéristique média CSS `overflow-inline`
 short-title: overflow-inline
 slug: Web/CSS/Reference/At-rules/@media/overflow-inline
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`overflow-inline`** permet de tester la façon dont l'appareil de sortie gère le contenu qui déborde du [bloc englobant](/fr/docs/Web/CSS/Guides/Display/Containing_block) initial selon l'axe en ligne.

--- a/files/fr/web/css/reference/at-rules/@media/pointer/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/pointer/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `pointer`
+title: Caractéristique média CSS `pointer`
 short-title: pointer
 slug: Web/CSS/Reference/At-rules/@media/pointer
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`pointer`** permet de tester si l'utilisateur·ice dispose d'un dispositif de pointage (comme une souris) et, le cas échéant, d'évaluer la précision du dispositif de pointage principal.

--- a/files/fr/web/css/reference/at-rules/@media/prefers-color-scheme/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/prefers-color-scheme/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `prefers-color-scheme`
+title: Caractéristique média CSS `prefers-color-scheme`
 short-title: prefers-color-scheme
 slug: Web/CSS/Reference/At-rules/@media/prefers-color-scheme
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`prefers-color-scheme`** permet de détecter si un·e utilisateur·ice a demandé un thème clair ou sombre.

--- a/files/fr/web/css/reference/at-rules/@media/prefers-contrast/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/prefers-contrast/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `prefers-contrast`
+title: Caractéristique média CSS `prefers-contrast`
 short-title: prefers-contrast
 slug: Web/CSS/Reference/At-rules/@media/prefers-contrast
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`prefers-contrast`** permet de détecter si un·e utilisateur·ice a demandé à ce que le contenu web soit présenté avec un contraste plus faible ou plus élevé.

--- a/files/fr/web/css/reference/at-rules/@media/prefers-reduced-data/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/prefers-reduced-data/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `prefers-reduced-data`
+title: Caractéristique média CSS `prefers-reduced-data`
 short-title: prefers-reduced-data
 slug: Web/CSS/Reference/At-rules/@media/prefers-reduced-data
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/at-rules/@media/prefers-reduced-motion/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/prefers-reduced-motion/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `prefers-reduced-motion`
+title: Caractéristique média CSS `prefers-reduced-motion`
 short-title: prefers-reduced-motion
 slug: Web/CSS/Reference/At-rules/@media/prefers-reduced-motion
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 > [!WARNING]

--- a/files/fr/web/css/reference/at-rules/@media/prefers-reduced-transparency/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/prefers-reduced-transparency/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `prefers-reduced-transparency`
+title: Caractéristique média CSS `prefers-reduced-transparency`
 short-title: prefers-reduced-transparency
 slug: Web/CSS/Reference/At-rules/@media/prefers-reduced-transparency
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/at-rules/@media/resolution/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/resolution/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `resolution`
+title: Caractéristique média CSS `resolution`
 short-title: resolution
 slug: Web/CSS/Reference/At-rules/@media/resolution
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`resolution`** peut être utilisée pour tester la densité de pixels de l'appareil de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/scan/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/scan/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `scan`
+title: Caractéristique média CSS `scan`
 short-title: scan
 slug: Web/CSS/Reference/At-rules/@media/scan
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`scan`** permet d'appliquer des styles CSS en fonction du procédé de balayage du périphérique de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/scripting/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/scripting/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `scripting`
+title: Caractéristique média CSS `scripting`
 short-title: scripting
 slug: Web/CSS/Reference/At-rules/@media/scripting
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`scripting`** permet de tester si les scripts (comme JavaScript) sont disponibles.

--- a/files/fr/web/css/reference/at-rules/@media/shape/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/shape/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `shape`
+title: Caractéristique média CSS `shape`
 short-title: shape
 slug: Web/CSS/Reference/At-rules/@media/shape
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/at-rules/@media/update/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/update/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `update`
+title: Caractéristique média CSS `update`
 short-title: update
 slug: Web/CSS/Reference/At-rules/@media/update
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`update`** peut être utilisée pour tester la fréquence à laquelle (le cas échéant) l'appareil de sortie est capable de modifier l'apparence du contenu une fois rendu.

--- a/files/fr/web/css/reference/at-rules/@media/vertical-viewport-segments/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/vertical-viewport-segments/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `vertical-viewport-segments`
+title: Caractéristique média CSS `vertical-viewport-segments`
 short-title: vertical-viewport-segments
 slug: Web/CSS/Reference/At-rules/@media/vertical-viewport-segments
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`vertical-viewport-segments`** permet de détecter si l'appareil possède un nombre spécifié de segments de zone d'affichage (<i lang="en">viewport</i>) disposés verticalement (de haut en bas).

--- a/files/fr/web/css/reference/at-rules/@media/video-dynamic-range/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/video-dynamic-range/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `video-dynamic-range`
+title: Caractéristique média CSS `video-dynamic-range`
 short-title: video-dynamic-range
 slug: Web/CSS/Reference/At-rules/@media/video-dynamic-range
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`video-dynamic-range`** permet de tester la combinaison de la luminosité, du rapport de contraste et de la profondeur de couleur pris en charge par le plan vidéo de l'{{Glossary("user agent", "agent utilisateur")}} et le périphérique de sortie.

--- a/files/fr/web/css/reference/at-rules/@media/width/index.md
+++ b/files/fr/web/css/reference/at-rules/@media/width/index.md
@@ -1,9 +1,9 @@
 ---
-title: Fonction CSS `width`
+title: Caractéristique média CSS `width`
 short-title: width
 slug: Web/CSS/Reference/At-rules/@media/width
 l10n:
-  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
+  sourceCommit: 67d40334c8b90e4623f3b0d3aea466b9882d8236
 ---
 
 La [caractéristique média](/fr/docs/Web/CSS/Reference/At-rules/@media#caractéristiques_média) [CSS](/fr/docs/Web/CSS) **`width`** peut être utilisée pour tester la largeur de la {{Glossary("viewport", "zone d'affichage")}} (ou de la boîte de page, pour [les médias paginés](/fr/docs/Web/CSS/Guides/Paged_media)).


### PR DESCRIPTION
### Description

The front-matter key `title` now accept backticks. Content has updated titles to display code in title using these backticks.

### Motivation

Keep translated-content sync for updated pages

### Additional details

_none_

### Related issues and pull requests

_none_