### PR TITLE
chore(sync-fr): css data type pages use backticks on title

### DIFF
--- a/files/fr/web/css/reference/values/alpha-value/index.md
+++ b/files/fr/web/css/reference/values/alpha-value/index.md
@@ -1,8 +1,9 @@
 ---
-title: <alpha-value>
+title: Type CSS `<alpha-value>`
+short-title: <alpha-value>
 slug: Web/CSS/Reference/Values/alpha-value
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<alpha-value>`** représente une valeur qui peut être soit un ({{CSSxRef("&lt;number&gt;")}}) soit un ({{CSSxRef("&lt;percentage&gt;")}}), et qui définit le **canal alpha** (<i lang="en">alpha channel</i>) ou la **transparence** d'une couleur.

--- a/files/fr/web/css/reference/values/axis/index.md
+++ b/files/fr/web/css/reference/values/axis/index.md
@@ -1,8 +1,9 @@
 ---
-title: <axis>
+title: Type CSS `<axis>`
+short-title: <axis>
 slug: Web/CSS/Reference/Values/axis
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le type de donnée {{Glossary("enumerated", "énuméré")}} **`<axis>`** définit l'axe de défilement du {{Glossary("scroll container", "conteneur de défilement")}} qui pilote une [timeline de défilement](/fr/docs/Web/CSS/Guides/Scroll-driven_animations/Timelines).

--- a/files/fr/web/css/reference/values/color_value/index.md
+++ b/files/fr/web/css/reference/values/color_value/index.md
@@ -1,8 +1,9 @@
 ---
-title: <color>
+title: Type CSS `<color>`
+short-title: <color>
 slug: Web/CSS/Reference/Values/color_value
 l10n:
-  sourceCommit: d35e3fd4bc6b80049899b45d74ed71dc996adfc7
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<color>`** représente une couleur.

--- a/files/fr/web/css/reference/values/overflow-position/index.md
+++ b/files/fr/web/css/reference/values/overflow-position/index.md
@@ -1,8 +1,9 @@
 ---
-title: <overflow-position>
+title: Type CSS `<overflow-position>`
+short-title: <overflow-position>
 slug: Web/CSS/Reference/Values/overflow-position
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) {{Glossary("enumerated", "énuméré")}} [CSS](/fr/docs/Web/CSS) **`<overflow-position>`** définit comment un sujet d'alignement (<i lang="en">alignment subject</i> en anglais) plus grand que son conteneur d'alignement (<i lang="en">alignment container</i> en anglais) déborde de ce dernier. Par exemple, si des éléments centrés sont plus larges que leur conteneur, le débordement peut s'afficher au‑delà du bord de début de la zone d'affichage (<i lang="en">viewport</i> en anglais), bord vers lequel il est impossible de défiler. La valeur `<overflow-position>` précise si le mode d'alignement doit être remplacé pour garantir que le contenu soit visible (`safe`) ou si le mode d'alignement doit être respecté (`unsafe`).

--- a/files/fr/web/css/reference/values/overflow_value/index.md
+++ b/files/fr/web/css/reference/values/overflow_value/index.md
@@ -1,8 +1,9 @@
 ---
-title: <overflow>
+title: Type CSS `<overflow>`
+short-title: <overflow>
 slug: Web/CSS/Reference/Values/overflow_value
 l10n:
-  sourceCommit: 1dbba9f7a2c2e35c6e01e8a63159e2aac64b601b
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) {{Glossary("enumerated", "énuméré")}} [CSS](/fr/docs/Web/CSS) **`<overflow>`** représente les mots-clés pour les propriétés {{CSSxRef("overflow-block")}}, {{CSSxRef("overflow-inline")}}, {{CSSxRef("overflow-x")}}, {{CSSxRef("overflow-y")}} et la propriété raccourcie {{CSSxRef("overflow")}}. Ces propriétés s'appliquent aux conteneurs de bloc, flex et grille.

--- a/files/fr/web/css/reference/values/percentage/index.md
+++ b/files/fr/web/css/reference/values/percentage/index.md
@@ -1,8 +1,9 @@
 ---
-title: <percentage>
+title: Type CSS `<percentage>`
+short-title: <percentage>
 slug: Web/CSS/Reference/Values/percentage
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<percentage>`** représente une valeur en pourcentage. Il est souvent utilisé pour définir une taille relative à l'objet parent d'un élément. De nombreuses propriétés peuvent utiliser des pourcentages, telles que {{CSSxRef("width")}}, {{CSSxRef("height")}}, {{CSSxRef("margin")}}, {{CSSxRef("padding")}} et {{CSSxRef("font-size")}}.

--- a/files/fr/web/css/reference/values/position-area_value/index.md
+++ b/files/fr/web/css/reference/values/position-area_value/index.md
@@ -1,8 +1,9 @@
 ---
-title: <position-area>
+title: Type CSS `<position-area>`
+short-title: <position-area>
 slug: Web/CSS/Reference/Values/position-area_value
 l10n:
-  sourceCommit: 3e0ba995376cace7f08f0771635f86f0fb1753b3
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<position-area>`** définit la cellule ou les cellules étendues d'une **grille de zones de position** (<i lang="en">position-area grid</i>), une grille 3×3 dont la cellule centrale est un élément ancre.

--- a/files/fr/web/css/reference/values/position_value/index.md
+++ b/files/fr/web/css/reference/values/position_value/index.md
@@ -1,8 +1,9 @@
 ---
-title: <position>
+title: Type CSS `<position>`
+short-title: <position>
 slug: Web/CSS/Reference/Values/position_value
 l10n:
-  sourceCommit: 8fd626a7b7f1fcb19193325bbac5b87e719f83ea
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<position>`** désigne une paire de coordonnées utilisée pour définir un emplacement par rapport à une boîte d'élément. Elle est utilisée dans les propriétés {{CSSxRef("background-position")}}, {{CSSxRef("object-position")}}, {{CSSxRef("mask-position")}}, {{CSSxRef("offset-position")}}, {{CSSxRef("offset-anchor")}} et {{CSSxRef("transform-origin")}}.

--- a/files/fr/web/css/reference/values/ratio/index.md
+++ b/files/fr/web/css/reference/values/ratio/index.md
@@ -1,8 +1,9 @@
 ---
-title: <ratio>
+title: Type CSS `<ratio>`
+short-title: <ratio>
 slug: Web/CSS/Reference/Values/ratio
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<ratio>`** décrit la relation proportionnelle entre deux valeurs. Il correspond essentiellement au rapport d'aspect (<i lang="en">aspect ratio</i> en anglais), qui met en relation la largeur et la hauteur. Par exemple, le `<ratio>` est utilisé comme valeur pour la caractéristique media `aspect-ratio` dans les media queries {{CSSxRef("@media")}}, pour la caractéristique de taille `aspect-ratio` dans les requêtes de conteneur {{CSSxRef("@container")}}, et comme valeur de la propriété CSS {{CSSxRef("aspect-ratio")}}.

--- a/files/fr/web/css/reference/values/relative-size/index.md
+++ b/files/fr/web/css/reference/values/relative-size/index.md
@@ -1,8 +1,9 @@
 ---
-title: <relative-size>
+title: Type CSS `<relative-size>`
+short-title: <relative-size>
 slug: Web/CSS/Reference/Values/relative-size
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<relative-size>`** décrit les mots‑clés de taille relative. Les mots‑clés `<relative-size>` définissent une taille relative à la taille calculée de l'élément parent. Ce type de donnée est utilisé dans les propriétés (raccourcie) {{CSSxRef("font")}} et (longue) {{CSSxRef("font-size")}}.

--- a/files/fr/web/css/reference/values/resolution/index.md
+++ b/files/fr/web/css/reference/values/resolution/index.md
@@ -1,8 +1,9 @@
 ---
-title: <resolution>
+title: Type CSS `<resolution>`
+short-title: <resolution>
 slug: Web/CSS/Reference/Values/resolution
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<resolution>`**, utilisé pour décrire les [résolutions](/fr/docs/Web/CSS/Reference/At-rules/@media/resolution) dans les [requêtes média](/fr/docs/Web/CSS/Guides/Media_queries), désigne la densité de pixels d'un périphérique de sortie, c'est‑à‑dire sa résolution.

--- a/files/fr/web/css/reference/values/rule-list/index.md
+++ b/files/fr/web/css/reference/values/rule-list/index.md
@@ -1,8 +1,9 @@
 ---
-title: <rule-list>
+title: Type CSS `<rule-list>`
+short-title: <rule-list>
 slug: Web/CSS/Reference/Values/rule-list
 l10n:
-  sourceCommit: 3ee2355c3c90cf92c3119b82f8ebfa5d16c91c53
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<rule-list>`** représente une séquence de **zéro ou plusieurs règles CSS**. Il est utilisé pour définir les endroits du CSS où plusieurs règles peuvent apparaître, comme le niveau supérieur d'une feuille de style ou à l'intérieur des règles @ de regroupement telles que `@media` ou `@supports`.
@@ -94,6 +95,6 @@ body {
 
 ## Voir aussi
 
-- La règle @ {{CSSxRef("@supports")}}
-- La règle @ {{CSSxRef("@media")}}
-- La règle @ {{CSSxRef("@custom-media")}}
+- La règle {{CSSxRef("@supports")}}
+- La règle {{CSSxRef("@media")}}
+- La règle {{CSSxRef("@custom-media")}}

--- a/files/fr/web/css/reference/values/self-position/index.md
+++ b/files/fr/web/css/reference/values/self-position/index.md
@@ -1,8 +1,9 @@
 ---
-title: <self-position>
+title: Type CSS `<self-position>`
+short-title: <self-position>
 slug: Web/CSS/Reference/Values/self-position
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) {{Glossary("enumerated", "énuméré")}} [CSS](/fr/docs/Web/CSS) **`<self-position>`** est employé par les propriétés {{CSSxRef("justify-self")}} et {{CSSxRef("align-self")}}, ainsi que par le raccourci {{CSSxRef("place-self")}}, pour aligner la boîte dans son conteneur d'alignement. Il est également utilisé par les propriétés {{CSSxRef("justify-items")}} et {{CSSxRef("align-items")}}, ainsi que par le raccourci {{CSSxRef("place-items")}}, pour définir les valeurs par défaut de `justify-self` et `align-self`.

--- a/files/fr/web/css/reference/values/shape/index.md
+++ b/files/fr/web/css/reference/values/shape/index.md
@@ -1,8 +1,9 @@
 ---
-title: <shape>
+title: Type CSS `<shape>`
+short-title: <shape>
 slug: Web/CSS/Reference/Values/shape
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/css/reference/values/string/index.md
+++ b/files/fr/web/css/reference/values/string/index.md
@@ -1,8 +1,9 @@
 ---
-title: <string>
+title: Type CSS `<string>`
+short-title: <string>
 slug: Web/CSS/Reference/Values/string
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<string>`** représente une suite de caractères. Les chaînes de caractères sont utilisées dans de nombreuses propriétés CSS, telles que {{CSSxRef("content")}}, {{CSSxRef("font-family")}} et {{CSSxRef("quotes")}}.

--- a/files/fr/web/css/reference/values/system-color/index.md
+++ b/files/fr/web/css/reference/values/system-color/index.md
@@ -1,8 +1,9 @@
 ---
-title: <system-color>
+title: Type CSS `<system-color>`
+short-title: <system-color>
 slug: Web/CSS/Reference/Values/system-color
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<system-color>`** reflète généralement les choix de couleurs par défaut utilisés pour les différentes parties d'une page web.

--- a/files/fr/web/css/reference/values/text-edge/index.md
+++ b/files/fr/web/css/reference/values/text-edge/index.md
@@ -1,8 +1,9 @@
 ---
-title: <text-edge>
+title: Type CSS `<text-edge>`
+short-title: <text-edge>
 slug: Web/CSS/Reference/Values/text-edge
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) {{Glossary("enumerated", "énuméré")}} [CSS](/fr/docs/Web/CSS) **`<text-edge>`** définit des mots-clés qui définissent les métriques de police représentant des régions spécifiques sur le bord de début de bloc (block-start) et le bord de fin de bloc (block-end) d'une police. Chaque mot-clé définit une position du bord supérieur et/ou inférieur d'une police.

--- a/files/fr/web/css/reference/values/time-percentage/index.md
+++ b/files/fr/web/css/reference/values/time-percentage/index.md
@@ -1,8 +1,9 @@
 ---
-title: <time-percentage>
+title: Type CSS `<time-percentage>`
+short-title: <time-percentage>
 slug: Web/CSS/Reference/Values/time-percentage
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<time-percentage>`** représente une valeur qui peut être soit un {{CSSxRef("time")}}, soit un {{CSSxRef("percentage")}}.

--- a/files/fr/web/css/reference/values/time/index.md
+++ b/files/fr/web/css/reference/values/time/index.md
@@ -1,8 +1,9 @@
 ---
-title: <time>
+title: Type CSS `<time>`
+short-title: <time>
 slug: Web/CSS/Reference/Values/time
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<time>`** représente une valeur temporelle exprimée en secondes ou en millisecondes. Il est utilisé dans {{CSSxRef("animation")}}, {{CSSxRef("transition")}} et les propriétés associées.

--- a/files/fr/web/css/reference/values/timeline-range-name/index.md
+++ b/files/fr/web/css/reference/values/timeline-range-name/index.md
@@ -1,8 +1,9 @@
 ---
-title: <timeline-range-name>
+title: Type CSS `<timeline-range-name>`
+short-title: <timeline-range-name>
 slug: Web/CSS/Reference/Values/timeline-range-name
 l10n:
-  sourceCommit: 0cc0da86bf55acce9f83eca7bbed9508fda98375
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) {{Glossary("enumerated", "énuméré")}} [CSS](/fr/docs/Web/CSS) **`<timeline-range-name>`** est un identifiant représentant l'une des plages de chronologie nommées prédéfinies à l'intérieur d'une [chronologie de progression de vue](/fr/docs/Web/CSS/Guides/Scroll-driven_animations/Timelines).
@@ -37,9 +38,12 @@ Valeurs valides pour `<timeline-range-name>`&nbsp;:
 - `exit-crossing`
   - : Représente la plage où la boîte principale franchit le bord de début. Le début de la plage (0% de progression) se produit lorsque le bord de début de la boîte principale de l'élément coïncide avec le bord de début de sa plage de visibilité de progression de vue. La fin de la plage (100% de progression) est le point où le bord de fin de la boîte principale de l'élément coïncide avec le bord de début de sa plage de visibilité de progression de vue. La taille de la plage correspond à la taille de la boîte principale de l'élément dans la direction du défilement.
 
+- `scroll`
+  - : Représente la plage complète du {{Glossary("scroll container", "conteneur de défilement")}} sur lequel la chronologie de progression de vue est définie. Le début de la plage (0% de progression) et la fin de la plage (100% de progression) se produisent aux positions de début et de fin du conteneur de défilement sous-jacent à la chronologie de progression de vue.
+
 ## Syntaxe formelle
 
-{{CSSSyntaxRaw(`<timeline-range-name> = cover | contain | entry | exit | entry-crossing | exit-crossing`)}}
+{{CSSSyntaxRaw(`<timeline-range-name> = cover | contain | entry | exit | entry-crossing | exit-crossing | scroll`)}}
 
 ## Exemples
 
@@ -55,10 +59,11 @@ Voir le [visualiseur de plage de chronologie de vue <sup>(angl.)</sup>](https://
 
 ## Voir aussi
 
-- {{CSSxRef("animation-range-start")}}, {{CSSxRef("animation-range-end")}}, {{CSSxRef("animation-range")}}
+- Les propriétés {{CSSxRef("animation-range-start")}}, {{CSSxRef("animation-range-end")}}, {{CSSxRef("animation-range")}}
 - La propriété {{CSSxRef("animation-timeline")}}
 - La propriété {{CSSxRef("scroll-timeline")}}
 - La propriété {{CSSxRef("view-timeline-inset")}}
+- [Comprendre les noms de plage de chronologie](/fr/docs/Web/CSS/Guides/Scroll-driven_animations/Timeline_range_names)
 - [Chronologies d'animation pilotées par le défilement](/fr/docs/Web/CSS/Guides/Scroll-driven_animations/Timelines)
 - Le module [des animations pilotées par le défilement CSS](/fr/docs/Web/CSS/Guides/Scroll-driven_animations)
 - [Visualiseur de plage de chronologie de vue <sup>(angl.)</sup>](https://scroll-driven-animations.style/tools/view-timeline/ranges/)

--- a/files/fr/web/css/reference/values/transform-function/index.md
+++ b/files/fr/web/css/reference/values/transform-function/index.md
@@ -1,8 +1,9 @@
 ---
-title: <transform-function>
+title: Type CSS `<transform-function>`
+short-title: <transform-function>
 slug: Web/CSS/Reference/Values/transform-function
 l10n:
-  sourceCommit: 8fd626a7b7f1fcb19193325bbac5b87e719f83ea
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<transform-function>`** représente une transformation qui affecte l'apparence d'un élément. Les [fonctions](/fr/docs/Web/CSS/Reference/Values/Functions) de transformation peuvent faire pivoter, redimensionner, déformer ou déplacer un élément en 2D ou 3D. Ce type est utilisé dans la propriété {{CSSxRef("transform")}}.

--- a/files/fr/web/css/reference/values/url_value/index.md
+++ b/files/fr/web/css/reference/values/url_value/index.md
@@ -1,27 +1,77 @@
 ---
-title: <url>
+title: Type CSS `<url>`
+short-title: <url>
 slug: Web/CSS/Reference/Values/url_value
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
-Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<url>`** est un pointeur vers une ressource. La ressource peut être une image, une vidéo, un fichier CSS, un fichier de police, une fonctionnalité SVG, etc.
+Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<url>`** est un pointeur vers une ressource.
 
 ## Syntaxe
 
 ```plain
-<url> = <url()>
+<url> = url()
 ```
 
 ### Valeurs
 
-La valeur est l'une des suivantes&nbsp;:
+La valeur peut être une URL absolue ou relative.
 
 - {{CSSxRef("url_function", "url()")}}
-  - : La fonction `url()` n'accepte qu'une chaîne d'URL littérale (avec ou sans guillemets).
+  - : La fonction `url()` accepte une URL, qui peut être écrite sous forme de chaîne de caractères entre guillemets ou sous forme de jeton URL sans guillemets.
 
 > [!NOTE]
-> La spécification définit une fonction alternative appelée `src()` qui accepte une chaîne d'URL ou une [variable CSS](/fr/docs/Web/CSS/Reference/Values/var). Mais aucun navigateur web ne l'a encore implémentée.
+> Le [module sur les valeurs et unités CSS](/fr/docs/Web/CSS/Guides/Values_and_units) introduit également la fonction `src()` en tant que valeur `<url>`. Actuellement, aucun navigateur ne prend en charge cette fonctionnalité.
+
+## Description
+
+Le type de données `<url>`, écrit avec la fonction {{CSSxRef("url_function", "url()")}}, représente une `URL`, qui est un pointeur vers une ressource interne ou externe. La ressource peut être une image, une vidéo, un fichier CSS, un fichier de police, une fonctionnalité SVG, etc. L'URL peut être absolue ou relative.
+
+```css
+/* URL relative */
+url("styles.css")
+url("assets/icon.svg")
+url("../assets/image.png")
+
+/* URL absolue */
+url("http://example.com/fonts/myFont.ttf")
+url("https://example.com/images/background.jpg")
+
+/* URL de données */
+url("data:image/svg+xml,%3Csvg'%3E%3Cpath d='M10 10h60' stroke='%2300F' stroke-width='5'/%3E%3Cpath d='M10 20h60' stroke='%230F0' stroke-width='5'/%3E%3C/svg%3E")
+url("data:image/png;base64,iVBORw0KGgoAAA...")
+```
+
+### Ressources externes et CORS
+
+La capacité d'importer des ressources externes avec la valeur `<url>` est définie par l'implémentation et souvent restreinte pour des raisons de sécurité.
+
+Selon la propriété CSS sur laquelle une `<url>` faisant référence à des ressources externes est appliquée, la ressource peut être soumise à des restrictions de [Partage de ressources entre origines (CORS)](/fr/docs/Web/HTTP/Guides/CORS).
+
+Certaines propriétés CSS, y compris {{CSSxRef("mask-image")}}, {{CSSxRef("filter")}}, ainsi que {{CSSxRef("clip-path")}} et quelques autres lorsqu'elles font référence à des éléments d'image {{SVGElement("svg")}}, peuvent nécessiter une validation CORS réussie lorsqu'elles provoquent la récupération de ressources externes et inter-origines en mode CORS. Si la validation CORS échoue, la ressource peut être bloquée et donc non utilisée pour le rendu.
+
+Notez que le type de valeur `<url>` n'impose pas lui-même la validation CORS, mais les propriétés CSS individuelles le font.
+
+Lors de l'ouverture d'un fichier HTML directement avec `file://`, les ressources peuvent échouer car les règles CORS s'appliquent localement. Les navigateurs modernes traitent `file://` comme une origine unique, ce qui signifie que les ressources croisées peuvent être bloquées. Dans ce cas, un [serveur HTTP](/fr/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server) peut être hébergé pour éviter les erreurs CORS. Le comportement de sécurité des URL `file://` varie également en fonction du navigateur et des permissions de fichiers du système d'exploitation.
+
+## Exemples
+
+URL relative
+
+```css
+body {
+  background-image: url("images/background.jpg");
+}
+```
+
+URL absolue
+
+```css
+body {
+  background-image: url("https://example.com/images/background.jpg");
+}
+```
 
 ## Spécifications
 


### PR DESCRIPTION
### Description

The front-matter key `title` now accept backticks. Content has updated titles to display code in title using these backticks.

### Motivation

Keep translated-content sync for updated pages

### Additional details

_none_

### Related issues and pull requests

Synced from https://github.com/mdn/content/tree/c88e03530319b73272fd4f9a9f6ebe878f026004