### PR TITLE
chore(sync-fr): update or sync data types title/content to remove original_slug

### DIFF
--- a/files/fr/web/css/reference/values/absolute-size/index.md
+++ b/files/fr/web/css/reference/values/absolute-size/index.md
@@ -1,9 +1,9 @@
 ---
-title: <absolute-size>
+title: Type CSS `<absolute-size>`
+short-title: <absolute-size>
 slug: Web/CSS/Reference/Values/absolute-size
-original_slug: Web/CSS/absolute-size
 l10n:
-  sourceCommit: 2645539130f36327a0f2d6f1040c3945098da234
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<absolute-size>`** décrit les mots-clés de taille absolue. Ce type de donnée est utilisé dans les propriétés abrégées {{CSSxRef("font")}} et {{CSSxRef("font-size")}}.

--- a/files/fr/web/css/reference/values/angle-percentage/index.md
+++ b/files/fr/web/css/reference/values/angle-percentage/index.md
@@ -1,9 +1,9 @@
 ---
-title: <angle-percentage>
+title: Type CSS `<angle-percentage>`
+short-title: <angle-percentage>
 slug: Web/CSS/Reference/Values/angle-percentage
-original_slug: Web/CSS/angle-percentage
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<angle-percentage>`** représente une valeur qui peut être soit un {{CSSxRef("angle")}} soit un {{CSSxRef("percentage")}}.

--- a/files/fr/web/css/reference/values/angle/index.md
+++ b/files/fr/web/css/reference/values/angle/index.md
@@ -1,9 +1,9 @@
 ---
-title: <angle>
+title: Type CSS `<angle>`
+short-title: <angle>
 slug: Web/CSS/Reference/Values/angle
-original_slug: Web/CSS/angle
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<angle>`** représente une valeur d'angle exprimée en degrés, grades, radians ou tours. Il est utilisé, par exemple, dans les {{CSSxRef("&lt;gradient&gt;")}} et dans certaines fonctions {{CSSxRef("transform")}}.

--- a/files/fr/web/css/reference/values/baseline-position/index.md
+++ b/files/fr/web/css/reference/values/baseline-position/index.md
@@ -1,9 +1,9 @@
 ---
-title: <baseline-position>
+title: Type CSS `<baseline-position>`
+short-title: <baseline-position>
 slug: Web/CSS/Reference/Values/baseline-position
-original_slug: Web/CSS/baseline-position
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 La valeur {{Glossary("enumerated", "énumérée")}} **`<baseline-position>`** représente le type de valeur pour le mot-clé `baseline` ainsi que les modificateurs `first` et `last`, utilisés pour les propriétés {{CSSxRef("align-content")}}, {{CSSxRef("align-items")}}, {{CSSxRef("align-self")}}, {{CSSxRef("justify-items")}} et {{CSSxRef("justify-self")}}, ainsi que pour les propriétés raccourcies {{CSSxRef("place-content")}}, {{CSSxRef("place-items")}} et {{CSSxRef("place-self")}}.

--- a/files/fr/web/css/reference/values/basic-shape/index.md
+++ b/files/fr/web/css/reference/values/basic-shape/index.md
@@ -1,9 +1,9 @@
 ---
-title: <basic-shape>
+title: Type CSS `<basic-shape>`
+short-title: <basic-shape>
 slug: Web/CSS/Reference/Values/basic-shape
-original_slug: Web/CSS/basic-shape
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<basic-shape>`** représente une forme utilisée dans les propriétés {{CSSxRef("clip-path")}}, {{CSSxRef("shape-outside")}} et {{CSSxRef("offset-path")}}.

--- a/files/fr/web/css/reference/values/blend-mode/index.md
+++ b/files/fr/web/css/reference/values/blend-mode/index.md
@@ -1,9 +1,9 @@
 ---
-title: <blend-mode>
+title: Type CSS `<blend-mode>`
+short-title: <blend-mode>
 slug: Web/CSS/Reference/Values/blend-mode
-original_slug: Web/CSS/blend-mode
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<blend-mode>`** définit la façon dont les couleurs doivent apparaître lorsque des éléments se superposent. Il est utilisé dans les propriétés {{CSSxRef("background-blend-mode")}} et {{CSSxRef("mix-blend-mode")}}.

--- a/files/fr/web/css/reference/values/box-edge/index.md
+++ b/files/fr/web/css/reference/values/box-edge/index.md
@@ -1,9 +1,9 @@
 ---
-title: <box-edge>
+title: Type CSS `<box-edge>`
+short-title: <box-edge>
 slug: Web/CSS/Reference/Values/box-edge
-original_slug: Web/CSS/box-edge
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<box-edge>`** représentent un mot-clé de [bord de boîte](/fr/docs/Web/CSS/Guides/Box_model/Introduction), comme [`content-box`](#content-box) et [`border-box`](#border-box). Les mots-clés de bord de boîte servent à définir différents aspects du modèle de boîte d'un element et la façon dont les elements sont positionnés et affichés à l'écran.

--- a/files/fr/web/css/reference/values/calc-keyword/index.md
+++ b/files/fr/web/css/reference/values/calc-keyword/index.md
@@ -1,9 +1,9 @@
 ---
-title: <calc-keyword>
+title: Type CSS `<calc-keyword>`
+short-title: <calc-keyword>
 slug: Web/CSS/Reference/Values/calc-keyword
-original_slug: Web/CSS/calc-keyword
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<calc-keyword>`** représente des constantes bien définies comme `e` et `pi`. Plutôt que d'obliger les auteur·ice·s à saisir manuellement plusieurs chiffres de ces constantes mathématiques ou à les calculer, certaines d'entre elles sont directement fournies par CSS pour plus de commodité.

--- a/files/fr/web/css/reference/values/calc-sum/index.md
+++ b/files/fr/web/css/reference/values/calc-sum/index.md
@@ -1,9 +1,9 @@
 ---
-title: <calc-sum>
+title: Type CSS `<calc-sum>`
+short-title: <calc-sum>
 slug: Web/CSS/Reference/Values/calc-sum
-original_slug: Web/CSS/calc-sum
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<calc-sum>`** représente une expression qui effectue un calcul dans n'importe quelle [fonction mathématique CSS](/fr/docs/Web/CSS/Reference/Values/Functions#les_fonctions_mathématiques). L'expression réalise une opération arithmétique d'addition ou de soustraction entre deux valeurs.

--- a/files/fr/web/css/reference/values/color-interpolation-method/index.md
+++ b/files/fr/web/css/reference/values/color-interpolation-method/index.md
@@ -1,9 +1,9 @@
 ---
-title: <color-interpolation-method>
+title: Type CSS `<color-interpolation-method>`
+short-title: <color-interpolation-method>
 slug: Web/CSS/Reference/Values/color-interpolation-method
-original_slug: Web/CSS/color-interpolation-method
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<color-interpolation-method>`** représente l'espace colorimétrique utilisé pour l'interpolation entre des valeurs {{CSSxRef("&lt;color&gt;")}}. Il peut être utilisé pour remplacer l'espace colorimétrique d'interpolation par défaut dans les notations fonctionnelles liées à la couleur comme {{CSSxRef("color_value/color-mix", "color-mix()")}} et {{CSSxRef("gradient/linear-gradient", "linear-gradient()")}}.

--- a/files/fr/web/css/reference/values/content-distribution/index.md
+++ b/files/fr/web/css/reference/values/content-distribution/index.md
@@ -1,9 +1,9 @@
 ---
-title: <content-distribution>
+title: Type CSS `<content-distribution>`
+short-title: <content-distribution>
 slug: Web/CSS/Reference/Values/content-distribution
-original_slug: Web/CSS/content-distribution
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) {{Glossary("enumerated", "énuméré")}} [CSS](/fr/docs/Web/CSS) **`<content-distribution>`** est utilisé par les propriétés {{CSSxRef("justify-content")}} et {{CSSxRef("align-content")}}, ainsi que par le raccourci {{CSSxRef("place-content")}}, pour répartir l'espace supplémentaire d'un conteneur entre ses {{Glossary("alignment subject", "sujets d'alignement")}}.

--- a/files/fr/web/css/reference/values/content-position/index.md
+++ b/files/fr/web/css/reference/values/content-position/index.md
@@ -1,9 +1,9 @@
 ---
-title: <content-position>
+title: Type CSS `<content-position>`
+short-title: <content-position>
 slug: Web/CSS/Reference/Values/content-position
-original_slug: Web/CSS/content-position
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) {{Glossary("enumerated", "énuméré")}} [CSS](/fr/docs/Web/CSS) **`<content-position>`** est utilisé par les propriétés {{CSSxRef("justify-content")}} et {{CSSxRef("align-content")}}, ainsi que par le raccourci {{CSSxRef("place-content")}}, pour aligner le contenu de la boîte à l'intérieur de celle-ci.

--- a/files/fr/web/css/reference/values/corner-shape-value/index.md
+++ b/files/fr/web/css/reference/values/corner-shape-value/index.md
@@ -1,9 +1,9 @@
 ---
-title: <corner-shape-value>
+title: Type CSS `<corner-shape-value>`
+short-title: <corner-shape-value>
 slug: Web/CSS/Reference/Values/corner-shape-value
-original_slug: Web/CSS/corner-shape-value
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/values/custom-ident/index.md
+++ b/files/fr/web/css/reference/values/custom-ident/index.md
@@ -1,9 +1,9 @@
 ---
-title: <custom-ident>
+title: Type CSS `<custom-ident>`
+short-title: <custom-ident>
 slug: Web/CSS/Reference/Values/custom-ident
-original_slug: Web/CSS/custom-ident
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<custom-ident>`** désigne une chaîne de caractères arbitraire définie par l'utilisateur·ice et utilisée comme {{Glossary("identifier", "identifiant")}}. Elle est sensible à la casse et certaines valeurs sont interdites dans divers contextes pour éviter toute ambiguïté.

--- a/files/fr/web/css/reference/values/dashed-ident/index.md
+++ b/files/fr/web/css/reference/values/dashed-ident/index.md
@@ -1,26 +1,26 @@
 ---
-title: <dashed-ident>
+title: Type CSS `<dashed-ident>`
+short-title: <dashed-ident>
 slug: Web/CSS/Reference/Values/dashed-ident
-original_slug: Web/CSS/dashed-ident
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
-Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<dashed-ident>`** désigne une chaîne de caractères arbitraire utilisée comme {{Glossary("identifier", "identifiant")}}.
+Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<dashed-ident>`** est un {{CSSxRef("&lt;custom-ident&gt;")}} sensible à la casse commençant par deux tirets et désigne une chaîne de caractères arbitraire utilisée comme {{Glossary("identifier", "identifiant")}}.
 
 ## Syntaxe
 
-La syntaxe de `<dashed-ident>` est similaire à celle des identifiants CSS (comme les noms de propriétés), à l'exception près qu'elle est [sensible à la casse](https://fr.wikipedia.org/wiki/Sensibilit%C3%A9_%C3%A0_la_casse). Elle commence par deux tirets, suivis de l'identifiant défini par l'utilisateur·ice.
+La syntaxe de `<dashed-ident>` est similaire à celle des identifiants CSS (comme les noms de propriétés), à l'exception près qu'elle est sensible à la casse. Il s'agit d'un identifiant défini par l'utilisateur·ice précédé de deux tirets (`--`).
 
 Le double tiret au début permet de les identifier facilement lors de la lecture d'un bloc de code CSS et aide à éviter les conflits de noms avec les mots-clés CSS standards.
 
-Comme pour {{CSSxRef("&lt;custom-ident&gt;")}}, les `<dashed-ident>` sont définis par l'utilisateur·ice, mais contrairement à `<custom-ident>`, [CSS](/fr/docs/Web/CSS) ne définira jamais de `<dashed-ident>`.
+Comme pour {{CSSxRef("&lt;custom-ident&gt;")}}, les `<dashed-ident>` sont définis par l'utilisateur·ice. Cependant, certains `<custom-ident>` sont définis par le langage CSS lui-même&nbsp;; les `<dashed-ident>` ne seront jamais définis dans CSS.
 
 ## Exemples
 
 ### Utiliser les propriétés personnalisées CSS
 
-Lorsque `<dashed-ident>` est utilisé avec les [propriétés personnalisées CSS](/fr/docs/Web/CSS/Guides/Cascading_variables/Using_custom_properties), la propriété est d'abord déclarée puis utilisée dans une [fonction CSS `var()`](/fr/docs/Web/CSS/Reference/Values/var).
+Lorsqu'un `<dashed-ident>` est utilisé comme une [propriété personnalisée CSS](/fr/docs/Web/CSS/Guides/Cascading_variables/Using_custom_properties), la propriété est d'abord déclarée, puis le `<dashed-ident>` est utilisé dans une [fonction CSS `var()`](/fr/docs/Web/CSS/Reference/Values/var).
 
 ```css
 html {
@@ -47,7 +47,7 @@ h6 {
 
 ### Utiliser `@color-profile`
 
-Lorsque `<dashed-ident>` est utilisé avec la règle at {{CSSxRef("@color-profile")}}, la règle est d'abord déclarée puis utilisée dans une [fonction CSS `color()`](/fr/docs/Web/CSS/Reference/Values/color_value/color).
+Lorsqu'un `<dashed-ident>` est utilisé avec la règle {{CSSxRef("@color-profile")}}, la règle est d'abord déclarée, puis le `<dashed-ident>` est utilisé dans une [fonction CSS `color()`](/fr/docs/Web/CSS/Reference/Values/color_value/color).
 
 ```css
 @color-profile --my-color-profile {
@@ -61,7 +61,7 @@ Lorsque `<dashed-ident>` est utilisé avec la règle at {{CSSxRef("@color-profil
 
 ### Utiliser `@font-palette-values`
 
-Lorsque `<dashed-ident>` est utilisé avec la règle at {{CSSxRef("@font-palette-values")}}, la règle est d'abord déclarée puis utilisée comme valeur pour la propriété {{CSSxRef("font-palette")}}.
+Lorsqu'un `<dashed-ident>` est utilisé avec la règle {{CSSxRef("@font-palette-values")}}, la règle est d'abord déclarée, puis le `<dashed-ident>` est utilisé comme valeur pour la propriété {{CSSxRef("font-palette")}}.
 
 ```css
 @font-palette-values --my-palette {

--- a/files/fr/web/css/reference/values/dimension/index.md
+++ b/files/fr/web/css/reference/values/dimension/index.md
@@ -1,9 +1,9 @@
 ---
-title: <dimension>
+title: Type CSS `<dimension>`
+short-title: <dimension>
 slug: Web/CSS/Reference/Values/dimension
-original_slug: Web/CSS/dimension
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<dimension>`** représente une valeur de type {{CSSxRef("&lt;number&gt;")}} directement suivie d'une unité&nbsp;: par exemple `10px`.

--- a/files/fr/web/css/reference/values/display-box/index.md
+++ b/files/fr/web/css/reference/values/display-box/index.md
@@ -1,9 +1,9 @@
 ---
-title: <display-box>
+title: Type CSS `<display-box>`
+short-title: <display-box>
 slug: Web/CSS/Reference/Values/display-box
-original_slug: Web/CSS/display-box
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<display-box>`** définit si un élément génère des boîtes d'affichage ou aucune.

--- a/files/fr/web/css/reference/values/display-inside/index.md
+++ b/files/fr/web/css/reference/values/display-inside/index.md
@@ -1,9 +1,9 @@
 ---
-title: <display-inside>
+title: Type CSS `<display-inside>`
+short-title: <display-inside>
 slug: Web/CSS/Reference/Values/display-inside
-original_slug: Web/CSS/display-inside
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<display-inside>`** définit le type d'affichage ({{CSSxRef("display")}}) pour l'intérieur de l'élément. Ce type servira à la disposition du contenu de l'élément (si ce contenu n'est pas un élément remplacé). Ces mots-clés sont des valeurs de la propriété `display` et peuvent, historiquement être utilisé seul, ou plus récemment (cf. la spécification de niveau 3), être utilisé en combinaison avec un mot-clé {{CSSxRef("&lt;display-outside&gt;")}}.

--- a/files/fr/web/css/reference/values/display-internal/index.md
+++ b/files/fr/web/css/reference/values/display-internal/index.md
@@ -1,9 +1,9 @@
 ---
-title: <display-internal>
+title: Type CSS `<display-internal>`
+short-title: <display-internal>
 slug: Web/CSS/Reference/Values/display-internal
-original_slug: Web/CSS/display-internal
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<display-internal>`** définit les modes de disposition tels que `table` et `ruby` possèdent une structure interne complexe avec différents roles pour les éléments enfants et descendants. Cette page décrit ces valeurs «&nbsp;internes&nbsp;» pour `display` et qui s'appliquent dans un mode donné.

--- a/files/fr/web/css/reference/values/display-legacy/index.md
+++ b/files/fr/web/css/reference/values/display-legacy/index.md
@@ -1,9 +1,9 @@
 ---
-title: <display-legacy>
+title: Type CSS `<display-legacy>`
+short-title: <display-legacy>
 slug: Web/CSS/Reference/Values/display-legacy
-original_slug: Web/CSS/display-legacy
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<display-legacy>`** décrit les valeurs de la propriété `display` dans CSS 2. Utilisant une syntaxe avec un seul mot-clé comme valeur pour la propriété `display`, il fallait plusieurs mots-clés pour les différentes variantes bloc/en ligne d'un même mode. Cette page décrit ces valeurs.

--- a/files/fr/web/css/reference/values/display-listitem/index.md
+++ b/files/fr/web/css/reference/values/display-listitem/index.md
@@ -1,9 +1,9 @@
 ---
-title: <display-listitem>
+title: Type CSS `<display-listitem>`
+short-title: <display-listitem>
 slug: Web/CSS/Reference/Values/display-listitem
-original_slug: Web/CSS/display-listitem
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le mot-clé `list-item` permet à un élément de générer un pseudo-élément `::marker` dont le contenu est défini par les propriétés {{CSSxRef("list-style")}} (pour afficher une puce par exemple) avec une boîte principale du type indiquée pour organiser le contenu de l'élément.

--- a/files/fr/web/css/reference/values/display-outside/index.md
+++ b/files/fr/web/css/reference/values/display-outside/index.md
@@ -1,9 +1,9 @@
 ---
-title: <display-outside>
+title: Type CSS `<display-outside>`
+short-title: <display-outside>
 slug: Web/CSS/Reference/Values/display-outside
-original_slug: Web/CSS/display-outside
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<display-outside>`** définit le type d'affichage externe ({{CSSxRef("display")}}) d'un élément, c'est-à-dire son rôle dans le flux de mise en page. Ces mots-clés sont utilisés comme valeurs de la propriété `display` et peuvent, pour des raisons historiques, être utilisés seuls ou, comme défini dans la spécification de niveau 3, en combinaison avec une valeur parmi les mots-clés {{CSSxRef("&lt;display-inside&gt;")}}.

--- a/files/fr/web/css/reference/values/easing-function/index.md
+++ b/files/fr/web/css/reference/values/easing-function/index.md
@@ -1,9 +1,9 @@
 ---
-title: <easing-function>
+title: Type CSS `<easing-function>`
+short-title: <easing-function>
 slug: Web/CSS/Reference/Values/easing-function
-original_slug: Web/CSS/easing-function
 l10n:
-  sourceCommit: ed2725c99c6011da9d4afa5e47546fe0722ee814
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<easing-function>`** représente une fonction mathématique décrivant la vitesse à laquelle la valeur change.

--- a/files/fr/web/css/reference/values/filter-function/index.md
+++ b/files/fr/web/css/reference/values/filter-function/index.md
@@ -1,9 +1,9 @@
 ---
-title: <filter-function>
+title: Type CSS `<filter-function>`
+short-title: <filter-function>
 slug: Web/CSS/Reference/Values/filter-function
-original_slug: Web/CSS/filter-function
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<filter-function>`** représente un effet graphique qui peut modifier l'apparence d'une image. Il est notamment utilisé avec les propriétés {{CSSxRef("filter")}} et {{CSSxRef("backdrop-filter")}}.

--- a/files/fr/web/css/reference/values/flex_value/index.md
+++ b/files/fr/web/css/reference/values/flex_value/index.md
@@ -1,9 +1,9 @@
 ---
-title: <flex>
+title: Type CSS `<flex>`
+short-title: <flex>
 slug: Web/CSS/Reference/Values/flex_value
-original_slug: Web/CSS/flex_value
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<flex>`** permet de représenter une longueur flexible à l'intérieur d'un conteneur en grille, qui est déclarée comme une dimension d'unité `fr`. Il est notamment utilisé pour les propriétés {{CSSxRef("grid-template-columns")}}, {{CSSxRef("grid-template-rows")}} ainsi que d'autres.

--- a/files/fr/web/css/reference/values/frequency-percentage/index.md
+++ b/files/fr/web/css/reference/values/frequency-percentage/index.md
@@ -1,9 +1,9 @@
 ---
-title: <frequency-percentage>
+title: Type CSS `<frequency-percentage>`
+short-title: <frequency-percentage>
 slug: Web/CSS/Reference/Values/frequency-percentage
-original_slug: Web/CSS/frequency-percentage
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<frequency-percentage>`** représente une valeur qui peut être une valeur de type {{CSSxRef("frequency")}} ou une valeur de type {{CSSxRef("percentage")}}. Les valeurs de fréquence, par exemple, la hauteur d'une voix parlante, ne sont actuellement utilisées dans aucune propriété CSS.

--- a/files/fr/web/css/reference/values/frequency/index.md
+++ b/files/fr/web/css/reference/values/frequency/index.md
@@ -1,9 +1,9 @@
 ---
-title: <frequency>
+title: Type CSS `<frequency>`
+short-title: <frequency>
 slug: Web/CSS/Reference/Values/frequency
-original_slug: Web/CSS/frequency
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<frequency>`** permet de représenter des fréquences (par exemple la hauteur d'une voix). Ce type n'est actuellement utilisé pour aucune propriété CSS.

--- a/files/fr/web/css/reference/values/generic-family/index.md
+++ b/files/fr/web/css/reference/values/generic-family/index.md
@@ -1,9 +1,9 @@
 ---
-title: <generic-family>
+title: Type CSS `<generic-family>`
+short-title: <generic-family>
 slug: Web/CSS/Reference/Values/generic-family
-original_slug: Web/CSS/generic-family
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<generic-family>`** représente les mots-clés des familles de polices génériques utilisés dans la propriété abrégée {{CSSxRef("font")}} et la propriété longue {{CSSxRef("font-family")}}. Le `<generic-family>` désigne une ou plusieurs polices installées localement appartenant à cette catégorie.

--- a/files/fr/web/css/reference/values/gradient/index.md
+++ b/files/fr/web/css/reference/values/gradient/index.md
@@ -1,9 +1,9 @@
 ---
-title: <gradient>
+title: Type CSS `<gradient>`
+short-title: <gradient>
 slug: Web/CSS/Reference/Values/gradient
-original_slug: Web/CSS/gradient
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<gradient>`** permet de représenter une {{CSSxRef("&lt;image&gt;")}} contenant un dégradé entre deux ou plusieurs couleurs. Un dégradé CSS n'est pas une couleur CSS (type {{CSSxRef("&lt;color&gt;")}}) mais une image [sans dimension intrinsèque](/fr/docs/Web/CSS/Reference/Values/image) (elle n'a aucune taille naturelle ou ratio), sa taille réelle sera celle de l'élément auquel elle est appliquée.

--- a/files/fr/web/css/reference/values/hex-color/index.md
+++ b/files/fr/web/css/reference/values/hex-color/index.md
@@ -1,9 +1,9 @@
 ---
-title: <hex-color>
+title: Type CSS `<hex-color>`
+short-title: <hex-color>
 slug: Web/CSS/Reference/Values/hex-color
-original_slug: Web/CSS/hex-color
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<hex-color>`** est une notation permettant de décrire la _syntaxe de couleur hexadécimale_ d'une couleur [sRGB](/fr/docs/Glossary/RGB) en utilisant ses composantes principales (rouge, vert, bleu) écrites sous forme de nombres hexadécimaux, ainsi que sa transparence.

--- a/files/fr/web/css/reference/values/hue-interpolation-method/index.md
+++ b/files/fr/web/css/reference/values/hue-interpolation-method/index.md
@@ -1,9 +1,9 @@
 ---
-title: <hue-interpolation-method>
+title: Type CSS `<hue-interpolation-method>`
+short-title: <hue-interpolation-method>
 slug: Web/CSS/Reference/Values/hue-interpolation-method
-original_slug: Web/CSS/hue-interpolation-method
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<hue-interpolation-method>`** représente l'algorithme utilisé pour l'interpolation entre des valeurs de type {{CSSxRef("&lt;hue&gt;")}}.

--- a/files/fr/web/css/reference/values/hue/index.md
+++ b/files/fr/web/css/reference/values/hue/index.md
@@ -1,9 +1,9 @@
 ---
-title: <hue>
+title: Type CSS `<hue>`
+short-title: <hue>
 slug: Web/CSS/Reference/Values/hue
-original_slug: Web/CSS/hue
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<hue>`** représente l'angle de teinte d'une couleur.

--- a/files/fr/web/css/reference/values/ident/index.md
+++ b/files/fr/web/css/reference/values/ident/index.md
@@ -1,9 +1,9 @@
 ---
-title: <ident>
+title: Type CSS `<ident>`
+short-title: <ident>
 slug: Web/CSS/Reference/Values/ident
-original_slug: Web/CSS/ident
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de donnée](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<ident>`** désigne une chaîne de caractères arbitraire utilisée comme {{Glossary("identifier", "identifiant")}}.

--- a/files/fr/web/css/reference/values/image/index.md
+++ b/files/fr/web/css/reference/values/image/index.md
@@ -1,9 +1,9 @@
 ---
-title: <image>
+title: Type CSS `<image>`
+short-title: <image>
 slug: Web/CSS/Reference/Values/image
-original_slug: Web/CSS/image
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<image>`** représente une image en deux dimensions.
@@ -29,7 +29,9 @@ CSS peut gérer ces différents types d'images&nbsp;:
 - Les images sans dimension intrinsèque, mais avec _des proportions intrinsèques_ entre la hauteur et la largeur, comme un fichier SVG ou une image dans [un format vectoriel](https://fr.wikipedia.org/wiki/Image_vectorielle).
 - Les images _sans dimension ou proportion intrinsèques_, comme les dégradés CSS.
 
-Le moteur CSS détermine la _taille effective_ d'un objet en utilisant&nbsp;: (1) ses _dimensions intrinsèques_&nbsp;; (2) sa _taille indiquée_, définie par des propriétés CSS comme {{CSSxRef("width")}}, {{CSSxRef("height")}} ou {{CSSxRef("background-size")}}&nbsp;; et (3) sa _taille par défaut_, déterminée selon la propriété avec laquelle l'image est utilisée&nbsp;:
+### Taille concrète
+
+Le moteur CSS détermine la _taille concrète_ d'un objet en utilisant&nbsp;: (1) ses _dimensions intrinsèques_&nbsp;; (2) sa _taille indiquée_, définie par des propriétés CSS comme {{CSSxRef("width")}}, {{CSSxRef("height")}} ou {{CSSxRef("background-size")}}&nbsp;; et (3) sa _taille par défaut_, déterminée selon la propriété avec laquelle l'image est utilisée&nbsp;:
 
 | Type d'objet (propriété CSS)                                                                   | Taille par défaut de l'objet                                                                  |
 | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |

--- a/files/fr/web/css/reference/values/integer/index.md
+++ b/files/fr/web/css/reference/values/integer/index.md
@@ -1,9 +1,9 @@
 ---
-title: <integer>
+title: Type CSS `<integer>`
+short-title: <integer>
 slug: Web/CSS/Reference/Values/integer
-original_slug: Web/CSS/integer
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<integer>`** est un type particulier de {{CSSxRef("number")}} qui représente un nombre entier positif ou négatif. Les entiers peuvent être utilisés dans de nombreuses propriétés et descripteurs CSS, comme les propriétés {{CSSxRef("column-count")}}, {{CSSxRef("counter-increment")}}, {{CSSxRef("grid-column")}}, {{CSSxRef("grid-row")}}, {{CSSxRef("z-index")}} et le descripteur {{CSSxRef("@counter-style/range", "range")}}.

--- a/files/fr/web/css/reference/values/length-percentage/index.md
+++ b/files/fr/web/css/reference/values/length-percentage/index.md
@@ -1,9 +1,9 @@
 ---
-title: <length-percentage>
+title: Type CSS `<length-percentage>`
+short-title: <length-percentage>
 slug: Web/CSS/Reference/Values/length-percentage
-original_slug: Web/CSS/length-percentage
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<length-percentage>`** représente une valeur qui peut être une valeur de type {{CSSxRef("length")}} ou une valeur de type {{CSSxRef("percentage")}}.

--- a/files/fr/web/css/reference/values/length/index.md
+++ b/files/fr/web/css/reference/values/length/index.md
@@ -1,9 +1,9 @@
 ---
-title: <length>
+title: Type CSS `<length>`
+short-title: <length>
 slug: Web/CSS/Reference/Values/length
-original_slug: Web/CSS/length
 l10n:
-  sourceCommit: 81e6735431b50ded681b760b702e68b80000b58c
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<length>`** correspond à une mesure de distance. Les longueurs peuvent être utilisées dans de nombreuses propriétés CSS, comme {{CSSxRef("width")}}, {{CSSxRef("height")}}, {{CSSxRef("margin")}}, {{CSSxRef("padding")}}, {{CSSxRef("border-width")}}, {{CSSxRef("font-size")}} et {{CSSxRef("text-shadow")}}.

--- a/files/fr/web/css/reference/values/line-style/index.md
+++ b/files/fr/web/css/reference/values/line-style/index.md
@@ -1,9 +1,9 @@
 ---
-title: <line-style>
+title: Type CSS `<line-style>`
+short-title: <line-style>
 slug: Web/CSS/Reference/Values/line-style
-original_slug: Web/CSS/line-style
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) {{Glossary("enumerated", "énuméré")}} [CSS](/fr/docs/Web/CSS) **`<line-style>`** représente des mots-clés qui définissent le style d'une ligne, ou l'absence de ligne. Les valeurs de mot-clé `<line-style>` sont utilisées dans les propriétés [border](/fr/docs/Web/CSS/Guides/Backgrounds_and_borders) et [column](/fr/docs/Web/CSS/Guides/Multicol_layout), aussi bien en version longue qu'en version abrégée&nbsp;:

--- a/files/fr/web/css/reference/values/named-color/index.md
+++ b/files/fr/web/css/reference/values/named-color/index.md
@@ -1,9 +1,9 @@
 ---
-title: <named-color>
+title: Type CSS `<named-color>`
+short-title: <named-color>
 slug: Web/CSS/Reference/Values/named-color
-original_slug: Web/CSS/named-color
 l10n:
-  sourceCommit: 865da9174c0ef94d65378a97e2e890f28613bdf1
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<named-color>`** correspond au nom d'une couleur, comme `red`, `blue`, `black` ou `lightseagreen`. Syntaxiquement, un `<named-color>` est équivalent à un {{CSSxRef("&lt;ident&gt;")}}.

--- a/files/fr/web/css/reference/values/number/index.md
+++ b/files/fr/web/css/reference/values/number/index.md
@@ -1,9 +1,9 @@
 ---
-title: <number>
+title: Type CSS `<number>`
+short-title: <number>
 slug: Web/CSS/Reference/Values/number
-original_slug: Web/CSS/number
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: c88e03530319b73272fd4f9a9f6ebe878f026004
 ---
 
 Le [type de données](/fr/docs/Web/CSS/Reference/Values/Data_types) [CSS](/fr/docs/Web/CSS) **`<number>`** représente un nombre, qu'il s'agisse d'un entier, d'un nombre avec une partie fractionnaire ou d'un exposant en base dix en notation scientifique.


### PR DESCRIPTION
### Description

The front-matter key `title` now accept backticks. Content has updated titles to display code in title using these backticks.

### Motivation

Keep translated-content sync for updated pages

### Additional details

_none_

### Related issues and pull requests

Synced from https://github.com/mdn/content/tree/c88e03530319b73272fd4f9a9f6ebe878f026004