### PR TITLE
Sync Attribution and copyright licensing with English version [es]

### DIFF
--- a/files/es/mdn/writing_guidelines/attrib_copyright_license/index.md
+++ b/files/es/mdn/writing_guidelines/attrib_copyright_license/index.md
@@ -2,74 +2,69 @@
 title: Atribución y licencia de derechos de autor
 slug: MDN/Writing_guidelines/Attrib_copyright_license
 l10n:
-  sourceCommit: 6aa3327d5e4251de82ba7d3bc5355aabf00d1e72
+  sourceCommit: 24b4a3d9e5488d5c5600cf8eb278484d47bca07e
 ---
 
-{{MDNSidebar}}
-
-El contenido de MDN Web Docs está disponible de forma gratuita y está disponible bajo varias licencias de código abierto.
+El contenido de MDN Web Docs está disponible de forma gratuita y bajo varias licencias de código abierto.
 
 ## Uso del contenido de MDN Web Docs
 
-Esta sección cubre los tipos de contenido que proporcionamos y los derechos de autor y las licencias vigentes para cada tipo si elige reutilizar alguno de ellos.
+Esta sección cubre los tipos de contenido que proporcionamos y los derechos de autor y las licencias vigentes para cada tipo si eliges reutilizar alguno de ellos.
 
 ### Documentación
 
 > [!NOTE]
 > El contenido de MDN Web Docs ha sido preparado con las contribuciones de autores tanto dentro como fuera de Mozilla. A menos que se indique lo contrario, el contenido está disponible según los términos de la [licencia Creative Commons Attribution-ShareAlike](https://creativecommons.org/licenses/by-sa/2.5/) (CC-BY-SA), v2.5 o cualquier versión posterior.
 
-Su reutilización del contenido aquí se publica bajo la misma licencia que el contenido original: CC-BY-SA v2.5 o cualquier versión posterior. Al reutilizar el contenido en MDN Web Docs, debe asegurarse de que la atribución se dé al contenido original, así como a los "Colaboradores de Mozilla". Incluya un hipervínculo (en línea) o URL (impreso) a la página específica del contenido que se está obteniendo. Por ejemplo, para proporcionar la atribución de _este_ artículo, puede escribir:
+Tu reutilización del contenido aquí se publica bajo la misma licencia que el contenido original: CC-BY-SA v2.5 o cualquier versión posterior. Al reutilizar el contenido en MDN Web Docs, debes asegurarte de que se otorgue [atribución](https://creativecommons.org/licenses/by/2.5/deed.es) al material, así como a los "Colaboradores de Mozilla". Una buena atribución incluye el **título** del documento, con un hipervínculo (en línea) o URL (impreso) a la página específica del contenido que se está obteniendo, y una breve descripción de cualquier modificación que hayas realizado. Por ejemplo, para proporcionar la atribución de esta página, puedes escribir:
 
-> [Atribuciones y licencias de copyright](/es/docs/MDN/Writing_guidelines/Attrib_copyright_license) de [Colaboradores de Mozilla](/es/docs/MDN/Community/Roles_teams#contributor) tiene licencia bajo [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/). <!--necesita volver a visitar el enlace contributors.txt -->
+> ["Atribución y licencia de derechos de autor"](/es/docs/MDN/Writing_guidelines/Attrib_copyright_license) por Colaboradores de Mozilla, bajo licencia [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
 
-En el ejemplo anterior, "Colaboradores de Mozilla" enlaza con el historial de la página citada. Consulte [Prácticas recomendadas para la atribución](https://wiki.creativecommons.org/wiki/Recommended_practices_for_attribution) para obtener una explicación más detallada.
+También es recomendable enlazar "Colaboradores de Mozilla" a un archivo `contributors.txt` en el pie de página de la página que estás referenciando para obtener una lista de autores, si es razonable. Consulta las [Prácticas recomendadas para la atribución](https://wiki.creativecommons.org/wiki/Recommended_practices_for_attribution) para más detalles.
 
 ### Ejemplos de código
 
-Los ejemplos de código agregados a partir del 20 de agosto de 2010 se encuentran en el [dominio público CC0](https://creativecommons.org/publicdomain/zero/1.0/). No es necesario un aviso de licencia, pero si lo necesita, puede usar: `Todos los derechos de autor están dedicados al dominio público: https://creativecommons.org/publicdomain/zero/1.0/`
+Los ejemplos de código agregados a partir del 20 de agosto de 2010 se encuentran en el [dominio público CC0](https://creativecommons.org/publicdomain/zero/1.0/). No es necesario un aviso de licencia, pero si lo necesitas, puedes usar: `Todos los derechos de autor están dedicados al dominio público: https://creativecommons.org/publicdomain/zero/1.0/`
 
-Los ejemplos de código agregados antes del 20 de agosto de 2010 están disponibles bajo la [licencia MIT](https://opensource.org/license/mit/); debe insertar la siguiente información de atribución en la plantilla MIT: "© \<fecha de la última revisión de la página wiki> \<nombre de la persona que la puso en el wiki>".
+Los ejemplos de código agregados antes del 20 de agosto de 2010 están disponibles bajo la [licencia MIT](https://opensource.org/license/mit/); debes insertar la siguiente información de atribución en la plantilla MIT: "© \<fecha de la última revisión de la página wiki> \<nombre de la persona que la puso en el wiki>".
 
-Desde el lanzamiento de la nueva plataforma Yari de MDN el 14 de diciembre de 2020, actualmente no hay forma de determinar cuál necesita. Estamos trabajando en esto y actualizaremos este contenido pronto. <!--¿Todavía necesitamos esto aquí?-->
+Desde el lanzamiento de la nueva plataforma Yari de MDN el 14 de diciembre de 2020, actualmente no hay forma de determinar cuál necesitas. Estamos trabajando en esto y actualizaremos este contenido pronto.
 
 ### Tus contribuciones
 
-Si desea contribuir a MDN Web Docs, acepta que su documentación esté disponible bajo la licencia Attribution-ShareAlike (u ocasionalmente una licencia alternativa ya especificada por la página que está editando) y que sus muestras de código estén disponibles bajo [Creative Commons CC -0](https://creativecommons.org/publicdomain/zero/1.0/) (una dedicación de dominio público).
+Si deseas contribuir a MDN Web Docs, aceptas que tu documentación esté disponible bajo la licencia Attribution-ShareAlike (u ocasionalmente una licencia alternativa ya especificada por la página que estés editando) y que tus ejemplos de código están disponibles bajo [Creative Commons CC0](https://creativecommons.org/publicdomain/zero/1.0/) (una dedicación de dominio público).
 
 > [!WARNING]
 > No se pueden crear nuevas páginas utilizando licencias alternativas.
 
 **Los derechos de autor de los materiales aportados permanecen con el autor a menos que el autor los asigne a otra persona.**
 
-Si tiene alguna pregunta o inquietud sobre cualquier tema tratado aquí, comuníquese con el [equipo de MDN Web Docs](/es/docs/MDN/Community/Communication_channels).
+Si tienes alguna pregunta o inquietud sobre cualquier tema tratado aquí, comunícate con el [equipo de MDN Web Docs](/es/docs/MDN/Community/Communication_channels).
 
-## Logotipos, marcas comerciales, marcas de servicio y marcas denominativas
+### Logotipos, marcas comerciales, marcas de servicio y marcas denominativas
 
-Los derechos sobre los logotipos, las marcas comerciales y las marcas de servicio de la Fundación Mozilla, así como la apariencia de este sitio web, no están sujetos a la licencia Creative Commons y, en la medida en que sean trabajos de autoría (como logotipos y diseños gráficos), no están incluidos en el trabajo que se licencia bajo esos términos. Si usa el texto de los documentos y también desea usar cualquiera de estos derechos, o si tiene alguna otra pregunta sobre el cumplimiento de nuestros términos de licencia para esta colección, debe comunicarse con la Fundación Mozilla aquí: [licensing@mozilla.org](mailto:licensing@mozilla.org).
+Los derechos sobre los logotipos, las marcas comerciales y las marcas de servicio de la Fundación Mozilla, así como la apariencia de este sitio web, no están sujetos a la licencia Creative Commons y, en la medida en que sean trabajos de autoría (como logotipos y diseños gráficos), no están incluidos en el trabajo que se licencia bajo esos términos. Si usas el texto de los documentos y también deseas usar cualquiera de estos derechos, o si tienes alguna otra pregunta sobre el cumplimiento de nuestros términos de licencia para esta colección, debes comunicarte con la Fundación Mozilla aquí: [licensing@mozilla.org](mailto:licensing@mozilla.org).
 
 ## Usar contenido de otro lugar en MDN Web Docs
 
-En general, no aprobamos copiar contenido de otras fuentes y ponerlo en MDN.
-MDN debe estar compuesto de contenido original siempre que sea posible.
-Si recibimos una solicitud de extracción y descubrimos que contiene contenido plagiado, la cerraremos y solicitaremos que el remitente vuelva a enviar el cambio con el contenido reescrito en sus propias palabras.
+En general, no aprobamos copiar contenido de otras fuentes y ponerlo en MDN. MDN debe estar compuesto de contenido original siempre que sea posible. Si recibimos un pull request y descubrimos que contiene contenido plagiado, lo cerraremos y solicitaremos que el remitente vuelva a enviar el cambio con el contenido reescrito en sus propias palabras.
 
-## Si desea reutilizar o volver a publicar contenido
+### Reutilizar o volver a publicar tu contenido en MDN
 
 > [!NOTE]
-> A menos que haya una buena razón para volver a publicar el contenido, probablemente diremos "no".
-> La decisión del equipo de redacción de MDN es definitiva.
+> A menos que haya una buena razón para volver a publicar el contenido, probablemente diremos "no". La decisión del equipo de redacción de MDN es definitiva.
 
-Si alguien quiere donar un artículo a MDN que publicó previamente en su blog o tiene sentido copiar una hoja de referencia compleja a MDN, puede haber una justificación para volver a publicarlo. Para estos casos, discuta su plan con el equipo de MDN antes de eso:
+Si alguien quiere donar un artículo a MDN que publicó previamente en su blog o tiene sentido copiar una hoja de referencia compleja a MDN, puede haber una justificación para volver a publicarlo. Para estos casos, discute tu plan con el equipo de MDN antes de hacerlo:
 
-- [Cree un _issue_ de GitHub](https://github.com/mdn/mdn/issues/new/choose) que explique su intención.
-  - Describa lo que le gustaría copiar o volver a publicar.
-  - Proporcione una URL al recurso.
+- [Crea un issue en GitHub](https://github.com/mdn/mdn/issues/new/choose) que explique tu intención.
+  - Describe lo que le gustaría copiar o volver a publicar.
+  - Proporciona una URL al recurso.
   - Explica por qué crees que es apropiado.
 
 **Si el contenido se publica bajo una licencia cerrada:**
 
-- Si posee los derechos sobre el contenido, indíquelo y su acuerdo expreso para volver a publicarlo en MDN.
-- Si no posee los derechos sobre el contenido, incluya al autor/editor en el _issue_ si es posible, o incluya detalles sobre cómo se puede contactar con ellos para que podamos pedirles permiso para volver a publicar el contenido.
+- Si posees los derechos sobre el contenido, indícalo junto con tu consentimiento expreso para volver a publicarlo en MDN.
+- Si no posees los derechos sobre el contenido, incluye al autor/editor en el issue si es posible, o incluye detalles sobre cómo se puede contactar con ellos para que podamos pedirles permiso para volver a publicar el contenido.
 
 **Si el contenido se publica bajo una licencia abierta:**
 
@@ -77,4 +72,4 @@ Si alguien quiere donar un artículo a MDN que publicó previamente en su blog o
 
 ## Vinculación a artículos de MDN Web Docs
 
-Regularmente recibimos usuarios que nos hacen preguntas sobre cómo vincular a MDN Web Docs y si está permitido o no. La respuesta corta es: **sí, ¡puede vincular a MDN Web Docs!** El enlace de hipertexto no solo es la esencia de la web, sino que también es una forma de señalar a sus usuarios recursos valiosos y una muestra de confianza hacia el trabajo que hace nuestra comunidad.
+Regularmente recibimos usuarios que nos hacen preguntas sobre cómo vincular a MDN Web Docs y si está permitido o no. La respuesta corta es: **¡sí, puedes vincular a MDN Web Docs!** El enlace de hipertexto no solo es la esencia de la web, sino que también es una forma de señalar a sus usuarios recursos valiosos y una muestra de confianza hacia el trabajo que hace nuestra comunidad.


### PR DESCRIPTION
## Description

Synchronized `files/es/mdn/writing_guidelines/attrib_copyright_license/index.md` with its English source.

- Updated content to align with the latest upstream documentation.
- Cleaned up front matter by removing obsolete properties (`page-type`, `sidebar`, `tags`).
- Updated `l10n.sourceCommit` to `24b4a3d9e5488d5c5600cf8eb278484d47bca07e`.
- Adjusted internal links to point to the `/es/` locale.

## Related Issues

Fixes #35374
Part of #35373