### PR TITLE
chore(sync-fr): add backticks to titles on rel values

### DIFF
--- a/files/fr/web/html/reference/attributes/rel/alternate_stylesheet/index.md
+++ b/files/fr/web/html/reference/attributes/rel/alternate_stylesheet/index.md
@@ -1,8 +1,9 @@
 ---
-title: rel="alternate stylesheet"
+title: Valeur d'attribut HTML `rel="alternate stylesheet"`
+short-title: alternate stylesheet
 slug: Web/HTML/Reference/Attributes/rel/alternate_stylesheet
 l10n:
-  sourceCommit: ad9776a6cf53eaf570ac0515402247e82ecefcfe
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 La paire de mots-clés **`alternate stylesheet`**, lorsqu'elle est utilisée comme valeur pour l'attribut [`rel`](/fr/docs/Web/HTML/Reference/Elements/link#rel) de l'élément {{HTMLElement("link")}}, indique que la ressource cible est une _feuille de style alternative_. Définir des **feuilles de style alternatives** dans une page web permet aux utilisateur·ice·s de voir plusieurs versions d'une page selon leurs besoins ou préférences.

--- a/files/fr/web/html/reference/attributes/rel/compression-dictionary/index.md
+++ b/files/fr/web/html/reference/attributes/rel/compression-dictionary/index.md
@@ -1,8 +1,9 @@
 ---
-title: rel="compression-dictionary"
+title: Valeur d'attribut HTML `rel="compression-dictionary"`
+short-title: compression-dictionary
 slug: Web/HTML/Reference/Attributes/rel/compression-dictionary
 l10n:
-  sourceCommit: 5d5ea57d7c00fac731b5ed6df9a2ccc4b7d76cb9
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/html/reference/attributes/rel/dns-prefetch/index.md
+++ b/files/fr/web/html/reference/attributes/rel/dns-prefetch/index.md
@@ -1,8 +1,9 @@
 ---
-title: rel="dns-prefetch"
+title: Valeur d'attribut HTML `rel="dns-prefetch"`
+short-title: dns-prefetch
 slug: Web/HTML/Reference/Attributes/rel/dns-prefetch
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Le mot-clé **`dns-prefetch`** pour l'attribut [`rel`](/fr/docs/Web/HTML/Reference/Elements/link#rel) de l'élément {{HTMLElement("link")}} indique aux navigateurs que l'utilisateur·ice est susceptible d'avoir besoin de ressources provenant de l'origine de la ressource cible, et que le navigateur peut donc améliorer l'expérience en effectuant de manière proactive la résolution DNS pour cette origine.

--- a/files/fr/web/html/reference/attributes/rel/manifest/index.md
+++ b/files/fr/web/html/reference/attributes/rel/manifest/index.md
@@ -1,8 +1,9 @@
 ---
-title: rel="manifest"
+title: Valeur d'attribut HTML `rel="manifest"`
+short-title: manifest
 slug: Web/HTML/Reference/Attributes/rel/manifest
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Le mot-clé **`manifest`** pour l'attribut [`rel`](/fr/docs/Web/HTML/Reference/Elements/link#rel) de l'élément {{HTMLElement("link")}} indique que la ressource cible est un [manifest d'application Web](/fr/docs/Web/Progressive_web_apps/Manifest).

--- a/files/fr/web/html/reference/attributes/rel/me/index.md
+++ b/files/fr/web/html/reference/attributes/rel/me/index.md
@@ -1,8 +1,9 @@
 ---
-title: rel="me"
+title: Valeur d'attribut HTML `rel="me"`
+short-title: me
 slug: Web/HTML/Reference/Attributes/rel/me
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Le mot-clé **`me`** pour l'attribut [`rel`](/fr/docs/Web/HTML/Reference/Elements/link#rel) des éléments {{HTMLElement("link")}} et {{HTMLElement("a")}} indique que la ressource courante est représentée par la partie liée. La valeur `me` a été introduite dans la [spécification XHTML Friends Network (XFN) <sup>(angl.)</sup>](https://gmpg.org/xfn/).

--- a/files/fr/web/html/reference/attributes/rel/modulepreload/index.md
+++ b/files/fr/web/html/reference/attributes/rel/modulepreload/index.md
@@ -1,8 +1,9 @@
 ---
-title: rel="modulepreload"
+title: Valeur d'attribut HTML `rel="modulepreload"`
+short-title: modulepreload
 slug: Web/HTML/Reference/Attributes/rel/modulepreload
 l10n:
-  sourceCommit: f529eadda54e8a3ed37b7c9d2182be61ce666b6a
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Le mot-clé **`modulepreload`** pour l'attribut [`rel`](/fr/docs/Web/HTML/Reference/Attributes/rel) de l'élément HTML {{HTMLElement("link")}} offre un moyen déclaratif de précharger un [module JavaScript](/fr/docs/Web/JavaScript/Guide/Modules), de l'analyser, de le compiler et de le stocker dans la carte des modules du document pour une exécution ultérieure.

--- a/files/fr/web/html/reference/attributes/rel/noopener/index.md
+++ b/files/fr/web/html/reference/attributes/rel/noopener/index.md
@@ -1,8 +1,9 @@
 ---
-title: rel="noopener"
+title: Valeur d'attribut HTML `rel="noopener"`
+short-title: noopener
 slug: Web/HTML/Reference/Attributes/rel/noopener
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Le mot-clé **`noopener`** pour l'attribut [`rel`](/fr/docs/Web/HTML/Reference/Attributes/rel) des éléments HTML {{HTMLElement("a")}}, {{HTMLElement("area")}} et {{HTMLElement("form")}} indique au navigateur de naviguer vers la ressource cible sans donner au nouveau contexte de navigation l'accès au document d'origine — en ne définissant pas la propriété {{DOMxRef("Window.opener")}} sur la fenêtre ouverte (elle retourne `null`).

--- a/files/fr/web/html/reference/attributes/rel/noreferrer/index.md
+++ b/files/fr/web/html/reference/attributes/rel/noreferrer/index.md
@@ -1,8 +1,9 @@
 ---
-title: rel="noreferrer"
+title: Valeur d'attribut HTML `rel="noreferrer"`
+short-title: noreferrer
 slug: Web/HTML/Reference/Attributes/rel/noreferrer
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Le mot-clé **`noreferrer`** pour l'attribut [`rel`](/fr/docs/Web/HTML/Reference/Attributes/rel) des éléments {{HTMLElement("a")}}, {{HTMLElement("area")}} et {{HTMLElement("form")}} indique au navigateur, lors de la navigation vers la ressource cible, de ne pas envoyer l'en-tête {{HTTPHeader("Referer")}} et de ne divulguer aucune information de provenance. Il impose également le même comportement que le mot-clé [`noopener`](/fr/docs/Web/HTML/Reference/Attributes/rel/noopener).

--- a/files/fr/web/html/reference/attributes/rel/preconnect/index.md
+++ b/files/fr/web/html/reference/attributes/rel/preconnect/index.md
@@ -1,8 +1,9 @@
 ---
-title: rel="preconnect"
+title: Valeur d'attribut HTML `rel="preconnect"`
+short-title: preconnect
 slug: Web/HTML/Reference/Attributes/rel/preconnect
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Le mot-clé **`preconnect`** pour l'attribut [`rel`](/fr/docs/Web/HTML/Reference/Elements/link#rel) de l'élément HTML {{HTMLElement("link")}} indique au navigateur que l'utilisateur·ice aura probablement besoin de ressources provenant de l'origine de la ressource cible. Le navigateur peut donc améliorer l'expérience en initiant de manière anticipée une connexion vers cette origine. Le préconnect permet d'accélérer les chargements futurs depuis une origine donnée en réalisant à l'avance tout ou partie de l'établissement de la connexion (DNS+TCP pour HTTP, et DNS+TCP+TLS pour les origines HTTPS).

--- a/files/fr/web/html/reference/attributes/rel/prefetch/index.md
+++ b/files/fr/web/html/reference/attributes/rel/prefetch/index.md
@@ -1,8 +1,9 @@
 ---
-title: rel="prefetch"
+title: Valeur d'attribut HTML `rel="prefetch"`
+short-title: prefetch
 slug: Web/HTML/Reference/Attributes/rel/prefetch
 l10n:
-  sourceCommit: 8799c26ef12a653ea2ab7d22a958fb46a649ca60
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 Le mot-clé **`prefetch`** pour l'attribut [`rel`](/fr/docs/Web/HTML/Reference/Elements/link#rel) de l'élément {{HTMLElement("link")}} indique au navigateur que l'utilisateur·ice aura probablement besoin de la ressource cible lors de navigations futures. Le navigateur peut donc améliorer l'expérience en récupérant et en mettant en cache la ressource de façon anticipée. `<link rel="prefetch">` est utilisé pour les ressources de navigation internes au site ou pour les sous-ressources utilisées par des pages du même site.

--- a/files/fr/web/html/reference/attributes/rel/preload/index.md
+++ b/files/fr/web/html/reference/attributes/rel/preload/index.md
@@ -1,8 +1,9 @@
 ---
-title: rel="preload"
+title: Valeur d'attribut HTML `rel="preload"`
+short-title: preload
 slug: Web/HTML/Reference/Attributes/rel/preload
 l10n:
-  sourceCommit: 8799c26ef12a653ea2ab7d22a958fb46a649ca60
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 La valeur `preload` de l'attribut [`rel`](/fr/docs/Web/HTML/Reference/Elements/link#rel) de l'élément HTML {{HTMLElement("link")}} permet de déclarer des requêtes à récupérer dans la partie {{HTMLElement("head")}} du HTML de la page, en spécifiant les ressources dont votre page va avoir besoin dans peu de temps, et qu'il serait souhaitable de charger le plus tôt possible, avant que le rendu de la page par le navigateur ne commence. Cela permet de s'assurer que les ressources sont disponibles plus tôt et qu'elles auront moins de chances de bloquer le rendu de la page, ce qui améliore les performances.

--- a/files/fr/web/html/reference/attributes/rel/prerender/index.md
+++ b/files/fr/web/html/reference/attributes/rel/prerender/index.md
@@ -1,8 +1,9 @@
 ---
-title: rel="prerender"
+title: Valeur d'attribut HTML `rel="prerender"`
+short-title: prerender
 slug: Web/HTML/Reference/Attributes/rel/prerender
 l10n:
-  sourceCommit: 8799c26ef12a653ea2ab7d22a958fb46a649ca60
+  sourceCommit: bf5017c389132af39b50106cf1763fa7106e87b4
 ---
 
 {{Deprecated_Header}}{{Non-standard_Header}}


### PR DESCRIPTION
### Description

The front-matter key `title` now accept backticks. Content has updated titles to display code in title using these backticks.

### Motivation

Keep translated-content sync for updated pages

### Additional details

_none_

### Related issues and pull requests

Sync from https://github.com/mdn/content/tree/bf5017c389132af39b50106cf1763fa7106e87b4
