### PR TITLE
chore(sync-fr): add backticks to titles on html elements

### DIFF
--- a/files/fr/web/html/reference/elements/a/index.md
+++ b/files/fr/web/html/reference/elements/a/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<a> : l'élément d'ancre"
+title: "Élément HTML `<a>` : l'élément d'ancre"
+short-title: <a>
 slug: Web/HTML/Reference/Elements/a
 l10n:
-  sourceCommit: e936e7271df947f25184a5ba8a21445bbd4d056c
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<a>`** (ou élément d'_ancre_), avec [son attribut `href`](#href), crée un hyperlien vers des pages web, des fichiers, des adresses e-mail, des emplacements dans la même page ou toute autre ressource accessible par une URL.

--- a/files/fr/web/html/reference/elements/abbr/index.md
+++ b/files/fr/web/html/reference/elements/abbr/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<abbr> : l'élément d'abréviation"
+title: "Élément HTML `<abbr>` : l'élément d'abréviation"
+short-title: <abbr>
 slug: Web/HTML/Reference/Elements/abbr
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<abbr>`** représente une abréviation ou un acronyme.

--- a/files/fr/web/html/reference/elements/acronym/index.md
+++ b/files/fr/web/html/reference/elements/acronym/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<acronym> : l'élément d'acronyme"
+title: "Élément HTML `<acronym>` : l'élément d'acronyme"
+short-title: <acronym>
 slug: Web/HTML/Reference/Elements/acronym
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/address/index.md
+++ b/files/fr/web/html/reference/elements/address/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<address> : l'élément d'adresse de contact"
+title: "Élément HTML `<address>` : l'élément d'adresse de contact"
+short-title: <address>
 slug: Web/HTML/Reference/Elements/address
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<address>`** indique que le HTML inclus fournit des informations de contact pour une personne, des personnes ou une organisation.

--- a/files/fr/web/html/reference/elements/area/index.md
+++ b/files/fr/web/html/reference/elements/area/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<area> : l'élément de zone"
+title: "Élément HTML `<area>` : l'élément de zone"
+short-title: <area>
 slug: Web/HTML/Reference/Elements/area
 l10n:
-  sourceCommit: 995f8bcede5aa8ca40921b030deef7524ce9e1a3
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<area>`** définit une zone à l'intérieur d'une image qui possède des zones cliquables prédéfinies. Une _image_ permet d'associer des zones géométriques d'une image à des {{Glossary("Hyperlink", "liens hypertextes")}}.

--- a/files/fr/web/html/reference/elements/article/index.md
+++ b/files/fr/web/html/reference/elements/article/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<article> : l'élément de contenu d'un article"
+title: "Élément HTML `<article>` : l'élément de contenu d'un article"
+short-title: <article>
 slug: Web/HTML/Reference/Elements/article
 l10n:
-  sourceCommit: a1765c2cad20118be0dad322d3548908787b5791
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<article>`** représente une composition autonome dans un document, une page, une application ou un site, destinée à être distribuée ou réutilisée indépendamment (par exemple dans une syndication). Les exemples incluent&nbsp;: un message de forum, un article de magazine ou de journal, une entrée de blog, une fiche produit, un commentaire soumis par un·e utilisateur·ice, un widget ou gadget interactif, ou tout autre élément de contenu indépendant.

--- a/files/fr/web/html/reference/elements/aside/index.md
+++ b/files/fr/web/html/reference/elements/aside/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<aside> : l'élément aparté"
+title: "Élément HTML `<aside>` : l'élément aparté"
+short-title: <aside>
 slug: Web/HTML/Reference/Elements/aside
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<aside>`** représente une partie d'un document dont le contenu n'est lié que de façon indirecte au contenu principal du document. Les apartés sont fréquemment présentés sous forme de barres latérales ou d'encadrés.

--- a/files/fr/web/html/reference/elements/audio/index.md
+++ b/files/fr/web/html/reference/elements/audio/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<audio> : l'élément audio embarqué"
+title: "Élément HTML `<audio>` : l'élément audio embarqué"
+short-title: <audio>
 slug: Web/HTML/Reference/Elements/audio
 l10n:
-  sourceCommit: 743ba8b257cd06449b192818df120e609f6e16d2
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<audio>`** est utilisé pour intégrer du contenu sonore dans des documents. Il peut contenir une ou plusieurs sources audio, représentées à l'aide de l'attribut `src` ou de l'élément {{HTMLElement("source")}}&nbsp;: le navigateur choisira la plus appropriée.

--- a/files/fr/web/html/reference/elements/b/index.md
+++ b/files/fr/web/html/reference/elements/b/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<b> : l'élément portant à l'attention"
+title: "Élément HTML `<b>` : l'élément portant à l'attention"
+short-title: <b>
 slug: Web/HTML/Reference/Elements/b
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<b>`** est utilisé pour attirer l'attention du·de la lecteur·ice sur le contenu de l'élément, qui n'a pas d'importance particulière par ailleurs. Il était auparavant connu sous le nom d'élément «&nbsp;Boldface&nbsp;», et la plupart des navigateurs affichent encore le texte en gras. Cependant, il ne faut pas utiliser `<b>` pour la mise en forme du texte ou pour indiquer une importance. Pour créer un texte en gras, il faut utiliser la propriété CSS {{CSSxRef("font-weight")}}. Pour indiquer qu'un élément a une importance particulière, il faut utiliser l'élément {{HTMLElement("strong")}}.

--- a/files/fr/web/html/reference/elements/base/index.md
+++ b/files/fr/web/html/reference/elements/base/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<base> : l'élément pour l'URL de base du document"
+title: "Élément HTML `<base>` : l'élément pour l'URL de base du document"
+short-title: <base>
 slug: Web/HTML/Reference/Elements/base
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<base>`** définit l'URL de base à utiliser pour toutes les URL _relatives_ d'un document. Il ne peut y avoir qu'un seul élément `<base>` dans un document.

--- a/files/fr/web/html/reference/elements/bdi/index.md
+++ b/files/fr/web/html/reference/elements/bdi/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<bdi> : l'élément d'isolation bidirectionnelle"
+title: "Élément HTML `<bdi>` : l'élément d'isolation bidirectionnelle"
+short-title: <bdi>
 slug: Web/HTML/Reference/Elements/bdi
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<bdi>`** indique à l'algorithme bidirectionnel du navigateur de traiter le texte qu'il contient indépendamment du texte qui l'entoure. Il est particulièrement utile lorsqu'un site insère dynamiquement du texte sans connaître la direction du texte inséré.

--- a/files/fr/web/html/reference/elements/bdo/index.md
+++ b/files/fr/web/html/reference/elements/bdo/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<bdo> : l'élément de remplacement bidirectionnelle"
+title: "Élément HTML `<bdo>` : l'élément de remplacement bidirectionnelle"
+short-title: <bdo>
 slug: Web/HTML/Reference/Elements/bdo
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<bdo>`** force la direction courante du texte, de sorte que le texte à l'intérieur est affiché dans une direction différente.

--- a/files/fr/web/html/reference/elements/big/index.md
+++ b/files/fr/web/html/reference/elements/big/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<big> : l'élément d'agrandissement de texte"
+title: "Élément HTML `<big>` : l'élément d'agrandissement de texte"
+short-title: <big>
 slug: Web/HTML/Reference/Elements/big
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/blockquote/index.md
+++ b/files/fr/web/html/reference/elements/blockquote/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<blockquote> : l'élément de bloc de citation"
+title: "Élément HTML `<blockquote>` : l'élément de bloc de citation"
+short-title: <blockquote>
 slug: Web/HTML/Reference/Elements/blockquote
 l10n:
-  sourceCommit: 0ab262675372b83fc870accf3dc46d6a367c451c
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<blockquote>`** indique que le texte qu'il contient est une citation longue. Habituellement, cela s'affiche visuellement par une indentation (voir [Notes](#notes_dutilisation) pour savoir comment la modifier). Une URL pour la source de la citation peut être donnée avec l'attribut `cite`, tandis qu'une représentation textuelle de la source peut être donnée avec l'élément HTML {{HTMLElement("cite")}}.

--- a/files/fr/web/html/reference/elements/body/index.md
+++ b/files/fr/web/html/reference/elements/body/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<body> : l'élément pour le corps du document"
+title: "Élément HTML `<body>` : l'élément pour le corps du document"
+short-title: <body>
 slug: Web/HTML/Reference/Elements/body
 l10n:
-  sourceCommit: 2a7d7d219c2ed31fbeec632d0b3f5e8a320a050a
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<body>`** représente le contenu principal du document HTML. Il ne peut y avoir qu'un élément `<body>` par document.

--- a/files/fr/web/html/reference/elements/br/index.md
+++ b/files/fr/web/html/reference/elements/br/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<br> : l'élément de saut de ligne"
+title: "Élément HTML `<br>` : l'élément de saut de ligne"
+short-title: <br>
 slug: Web/HTML/Reference/Elements/br
 l10n:
-  sourceCommit: 0ab262675372b83fc870accf3dc46d6a367c451c
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<br>`** crée un saut de ligne dans le texte (retour à la ligne). Il est utile pour écrire un poème ou une adresse, lorsque la division des lignes est significative.

--- a/files/fr/web/html/reference/elements/button/index.md
+++ b/files/fr/web/html/reference/elements/button/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<button> : l'élément représentant un bouton"
+title: "Élément HTML `<button>` : l'élément représentant un bouton"
+short-title: <button>
 slug: Web/HTML/Reference/Elements/button
 l10n:
-  sourceCommit: 5e815d522e796fb2209fa8470616b37e31c572b4
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<button>`** est un élément interactif qui peut être activé avec une souris, un clavier, un doigt, une commande vocale ou tout autre technologie d'assistance. Une fois activé, il peut déclencher une action tel qu'envoyer un [formulaire](/fr/docs/Learn_web_development/Extensions/Forms) ou ouvrir une boite de dialogue.

--- a/files/fr/web/html/reference/elements/canvas/index.md
+++ b/files/fr/web/html/reference/elements/canvas/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<canvas> : l'élément de canevas graphique"
+title: "Élément HTML `<canvas>` : l'élément de canevas graphique"
+short-title: <canvas>
 slug: Web/HTML/Reference/Elements/canvas
 l10n:
-  sourceCommit: 5e815d522e796fb2209fa8470616b37e31c572b4
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 Utilisez l'élément HTML **`<canvas>`** avec soit l'[API de script Canvas](/fr/docs/Web/API/Canvas_API), soit l'[API WebGL](/fr/docs/Web/API/WebGL_API) pour dessiner des graphiques et des animations.

--- a/files/fr/web/html/reference/elements/caption/index.md
+++ b/files/fr/web/html/reference/elements/caption/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<caption> : l'élément de légende d'un tableau"
+title: "Élément HTML `<caption>` : l'élément de légende d'un tableau"
+short-title: <caption>
 slug: Web/HTML/Reference/Elements/caption
 l10n:
-  sourceCommit: 0b5859108411e47d228a4bb9f30a5556ab17f63c
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<caption>`** définit la légende (ou le titre) d'un tableau, fournissant à ce dernier un {{Glossary("accessible name", "nom accessible")}} ou une {{Glossary("accessible description", "description accessible")}}.

--- a/files/fr/web/html/reference/elements/center/index.md
+++ b/files/fr/web/html/reference/elements/center/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<center> : l'élément de texte centré"
+title: "Élément HTML `<center>` : l'élément de texte centré"
+short-title: <center>
 slug: Web/HTML/Reference/Elements/center
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/cite/index.md
+++ b/files/fr/web/html/reference/elements/cite/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<cite> : l'élément de citation"
+title: "Élément HTML `<cite>` : l'élément de citation"
+short-title: <cite>
 slug: Web/HTML/Reference/Elements/cite
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<cite>`** est utilisé pour baliser le titre d'une œuvre créative. La référence peut être sous forme abrégée selon les conventions appropriées au contexte liées aux métadonnées de citation.

--- a/files/fr/web/html/reference/elements/code/index.md
+++ b/files/fr/web/html/reference/elements/code/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<code> : l'élément de code en ligne"
+title: "Élément HTML `<code>` : l'élément de code en ligne"
+short-title: <code>
 slug: Web/HTML/Reference/Elements/code
 l10n:
-  sourceCommit: 9cfc2285428932f448a1747e347b1e35a3e0172b
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<code>`** affiche son contenu avec une mise en forme destinée à indiquer qu'il s'agit d'un court fragment de code informatique. Par défaut, le texte est affiché avec la police monospace par défaut de {{Glossary("user agent", "l'agent utilisateur")}}.

--- a/files/fr/web/html/reference/elements/col/index.md
+++ b/files/fr/web/html/reference/elements/col/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<col> : l'élément représentant une colonne"
+title: "Élément HTML `<col>` : l'élément représentant une colonne"
+short-title: <col>
 slug: Web/HTML/Reference/Elements/col
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<col>`** définit une ou plusieurs colonnes dans un groupe de colonnes représenté par son élément parent {{HTMLElement("colgroup")}}. L'élément `<col>` n'est valide qu'en tant qu'enfant d'un élément {{HTMLElement("colgroup")}} qui n'a pas d'attribut [`span`](/fr/docs/Web/HTML/Reference/Elements/colgroup#span) défini.

--- a/files/fr/web/html/reference/elements/colgroup/index.md
+++ b/files/fr/web/html/reference/elements/colgroup/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<colgroup> : l'élément regroupant des colonnes"
+title: "Élément HTML `<colgroup>` : l'élément regroupant des colonnes"
+short-title: <colgroup>
 slug: Web/HTML/Reference/Elements/colgroup
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<colgroup>`** définit un groupe de colonnes au sein d'un tableau.

--- a/files/fr/web/html/reference/elements/data/index.md
+++ b/files/fr/web/html/reference/elements/data/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<data> : l'élément de données"
+title: "Élément HTML `<data>` : l'élément de données"
+short-title: <data>
 slug: Web/HTML/Reference/Elements/data
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<data>`** associe un contenu donné à une version interprétable par une machine. Si le contenu concerne une date ou une heure, il faut utiliser l'élément HTML {{HTMLElement("time")}}.

--- a/files/fr/web/html/reference/elements/datalist/index.md
+++ b/files/fr/web/html/reference/elements/datalist/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<datalist> : l'élément de liste des données"
+title: "Élément HTML `<datalist>` : l'élément de liste des données"
+short-title: <datalist>
 slug: Web/HTML/Reference/Elements/datalist
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<datalist>`** contient un ensemble d'éléments HTML {{HTMLElement("option")}} qui représentent les options permises ou recommandées à choisir dans d'autres contrôles.

--- a/files/fr/web/html/reference/elements/dd/index.md
+++ b/files/fr/web/html/reference/elements/dd/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<dd> : l'élément de détail d'une description"
+title: "Élément HTML `<dd>` : l'élément de détail d'une description"
+short-title: <dd>
 slug: Web/HTML/Reference/Elements/dd
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<dd>`** fournit la description, la définition ou la valeur du terme précédent ({{HTMLElement("dt")}}) dans une liste de description ({{HTMLElement("dl")}}).

--- a/files/fr/web/html/reference/elements/del/index.md
+++ b/files/fr/web/html/reference/elements/del/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<del> : l'élément de texte supprimé"
+title: "Élément HTML `<del>` : l'élément de texte supprimé"
+short-title: <del>
 slug: Web/HTML/Reference/Elements/del
 l10n:
-  sourceCommit: 5e815d522e796fb2209fa8470616b37e31c572b4
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<del>`** représente une portion de texte qui a été supprimée d'un document. Cela peut être utilisé, par exemple, pour afficher le «&nbsp;suivi des modifications&nbsp;» ou des informations sur les différences dans le code source. L'élément HTML {{HTMLElement("ins")}} peut être utilisé pour l'effet inverse&nbsp;: indiquer le texte qui a été ajouté au document.

--- a/files/fr/web/html/reference/elements/details/index.md
+++ b/files/fr/web/html/reference/elements/details/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<details> : l'élément de divulgation des détails"
+title: "Élément HTML `<details>` : l'élément de divulgation des détails"
+short-title: <details>
 slug: Web/HTML/Reference/Elements/details
 l10n:
-  sourceCommit: 7615562a3689a3e23a2b6b623597f4391740a53e
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<details>`** crée un composant de divulgation dans lequel l'information n'est visible que lorsque le composant est ouvert. Un résumé ou une étiquette doit être fourni·e à l'aide de l'élément HTML {{HTMLElement("summary")}}.

--- a/files/fr/web/html/reference/elements/dfn/index.md
+++ b/files/fr/web/html/reference/elements/dfn/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<dfn> : l'élément de définition"
+title: "Élément HTML `<dfn>` : l'élément de définition"
+short-title: <dfn>
 slug: Web/HTML/Reference/Elements/dfn
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<dfn>`** indique un terme à définir. L'élément `<dfn>` doit être utilisé dans une phrase de définition complète, où la définition du terme peut être l'une des suivantes&nbsp;:

--- a/files/fr/web/html/reference/elements/dialog/index.md
+++ b/files/fr/web/html/reference/elements/dialog/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<dialog> : l'élément de boîte de dialogue"
+title: "Élément HTML `<dialog>` : l'élément de boîte de dialogue"
+short-title: <dialog>
 slug: Web/HTML/Reference/Elements/dialog
 l10n:
-  sourceCommit: 483ce811e1ea52cb2d9d2a5af0c4d1c4d591ea4a
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<dialog>`** représente une boite de dialogue ou un composant interactif (par exemple un inspecteur ou une fenêtre).

--- a/files/fr/web/html/reference/elements/dir/index.md
+++ b/files/fr/web/html/reference/elements/dir/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<dir> : l'élément de répertoire"
+title: "Élément HTML `<dir>` : l'élément de répertoire"
+short-title: <dir>
 slug: Web/HTML/Reference/Elements/dir
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/div/index.md
+++ b/files/fr/web/html/reference/elements/div/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<div> : l'élément de division du contenu"
+title: "Élément HTML `<div>` : l'élément de division du contenu"
+short-title: <div>
 slug: Web/HTML/Reference/Elements/div
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<div>`** est le conteneur générique du contenu de flux. Il n'a aucun effet sur le contenu ou la mise en page tant qu'il n'est pas mis en forme d'une manière quelconque à l'aide de {{Glossary("CSS")}} (par exemple, si la mise en forme lui est appliquée directement, ou si un modèle de mise en page tel que [Flexbox](/fr/docs/Web/CSS/Guides/Flexible_box_layout) est appliqué à son élément parent).

--- a/files/fr/web/html/reference/elements/dl/index.md
+++ b/files/fr/web/html/reference/elements/dl/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<dl> : l'élément de liste de descriptions"
+title: "Élément HTML `<dl>` : l'élément de liste de descriptions"
+short-title: <dl>
 slug: Web/HTML/Reference/Elements/dl
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément HTML **`<dl>`** représente une liste de descriptions sous la forme d'une liste de paires associant des termes (fournis par des éléments [`<dt>`](/fr/docs/Web/HTML/Reference/Elements/dt)) et leurs descriptions ou définitions (fournies par des éléments [`<dd>`](/fr/docs/Web/HTML/Reference/Elements/dd)). On utilisera par exemple cet élément pour implémenter un glossaire.

--- a/files/fr/web/html/reference/elements/dt/index.md
+++ b/files/fr/web/html/reference/elements/dt/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<dt> : l'élément pour le terme d'une description"
+title: "Élément HTML `<dt>` : l'élément pour le terme d'une description"
+short-title: <dt>
 slug: Web/HTML/Reference/Elements/dt
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<dt>`** identifie un terme dans une liste de descriptions ou de définitions et, de ce fait, doit être utilisé à l'intérieur d'un élément HTML {{HTMLElement("dl")}}. Il est généralement suivi d'un élément {{HTMLElement("dd")}}&nbsp;; toutefois, plusieurs éléments `<dt>` successifs indiquent plusieurs termes qui sont tous définis par le {{HTMLElement("dd")}} immédiatement suivant.

--- a/files/fr/web/html/reference/elements/em/index.md
+++ b/files/fr/web/html/reference/elements/em/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<em> : l'élément d'emphase"
+title: "Élément HTML `<em>` : l'élément d'emphase"
+short-title: <em>
 slug: Web/HTML/Reference/Elements/em
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<em>`** marque le texte qui reçoit une emphase. L'élément `<em>` peut être imbriqué, chaque niveau d'imbrication indiquant un degré d'emphase plus élevé.

--- a/files/fr/web/html/reference/elements/embed/index.md
+++ b/files/fr/web/html/reference/elements/embed/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<embed> : l'élément de contenu externe embarqué"
+title: "Élément HTML `<embed>` : l'élément de contenu externe embarqué"
+short-title: <embed>
 slug: Web/HTML/Reference/Elements/embed
 l10n:
-  sourceCommit: 5dc9a1731aec0c04cebb4fdfa436b01cd30a20ae
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<embed>`** intègre du contenu externe au point défini dans le document. Ce contenu est fourni par une application externe ou une autre source de contenu interactif, comme un plugin de navigateur.

--- a/files/fr/web/html/reference/elements/fencedframe/index.md
+++ b/files/fr/web/html/reference/elements/fencedframe/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<fencedframe> : l'élément de cadre protégé"
+title: "Élément HTML `<fencedframe>` : l'élément de cadre protégé"
+short-title: <fencedframe>
 slug: Web/HTML/Reference/Elements/fencedframe
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/html/reference/elements/fieldset/index.md
+++ b/files/fr/web/html/reference/elements/fieldset/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<fieldset> : l'élément pour les ensembles de champs"
+title: "Élément HTML `<fieldset>` : l'élément pour les ensembles de champs"
+short-title: <fieldset>
 slug: Web/HTML/Reference/Elements/fieldset
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<fieldset>`** est utilisé afin de regrouper plusieurs contrôles interactifs ainsi que des étiquettes ({{HTMLElement("label")}}) dans un formulaire.

--- a/files/fr/web/html/reference/elements/figcaption/index.md
+++ b/files/fr/web/html/reference/elements/figcaption/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<figcaption> : l'élément de légende d'une figure"
+title: "Élément HTML `<figcaption>` : l'élément de légende d'une figure"
+short-title: <figcaption>
 slug: Web/HTML/Reference/Elements/figcaption
 l10n:
-  sourceCommit: c403dd32f627cd972048db05db04ef76f3ab84fe
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<figcaption>`** représente une légende ou une description du reste du contenu de son élément parent {{HTMLElement("figure")}}, fournissant à `<figure>` un {{Glossary("accessible name", "nom accessible")}}.

--- a/files/fr/web/html/reference/elements/figure/index.md
+++ b/files/fr/web/html/reference/elements/figure/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<figure> : l'élément de figure avec légende facultative"
+title: "Élément HTML `<figure>` : l'élément de figure avec légende facultative"
+short-title: <figure>
 slug: Web/HTML/Reference/Elements/figure
 l10n:
-  sourceCommit: a1765c2cad20118be0dad322d3548908787b5791
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<figure>`** représente un contenu autonome, éventuellement accompagné d'une légende facultative, qui est définie à l'aide de l'élément {{HTMLElement("figcaption")}}. La figure, sa légende et son contenu sont référencés comme une seule unité.

--- a/files/fr/web/html/reference/elements/font/index.md
+++ b/files/fr/web/html/reference/elements/font/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<font> : l'élément de police"
+title: "Élément HTML `<font>` : l'élément de police"
+short-title: <font>
 slug: Web/HTML/Reference/Elements/font
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/footer/index.md
+++ b/files/fr/web/html/reference/elements/footer/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<footer> : l'élément de pied de page"
+title: "Élément HTML `<footer>` : l'élément de pied de page"
+short-title: <footer>
 slug: Web/HTML/Reference/Elements/footer
 l10n:
-  sourceCommit: f2d281d86396bcd2dcecfdabd5837b1590132aa6
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<footer>`** représente un pied de page pour sa [section de contenu](/fr/docs/Web/HTML/Guides/Content_categories#contenu_sectionnant) ou [racine de sectionnement](/fr/docs/Web/HTML/Reference/Elements/Heading_Elements#libeller_le_contenu_des_sections) la plus proche. Un `<footer>` contient généralement des informations sur l'auteur·ice de la section, des données de droit d'auteur ou des liens vers des documents associés.

--- a/files/fr/web/html/reference/elements/form/index.md
+++ b/files/fr/web/html/reference/elements/form/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<form> : l'élément représentant un formulaire"
+title: "Élément HTML `<form>` : l'élément représentant un formulaire"
+short-title: <form>
 slug: Web/HTML/Reference/Elements/form
 l10n:
-  sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<form>`** représente une section du document contenant des contrôles interactifs permettant de soumettre des informations.

--- a/files/fr/web/html/reference/elements/frame/index.md
+++ b/files/fr/web/html/reference/elements/frame/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<frame> : l'élément de cadre"
+title: "Élément HTML `<frame>` : l'élément de cadre"
+short-title: <frame>
 slug: Web/HTML/Reference/Elements/frame
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/frameset/index.md
+++ b/files/fr/web/html/reference/elements/frameset/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<frameset> : l'élément contenant des frames"
+title: "Élément HTML `<frameset>` : l'élément contenant des frames"
+short-title: <frameset>
 slug: Web/HTML/Reference/Elements/frameset
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/geolocation/index.md
+++ b/files/fr/web/html/reference/elements/geolocation/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<geolocation> : l'élément de géolocalisation"
+title: "Élément HTML `<geolocation>` : l'élément de géolocalisation"
+short-title: <geolocation>
 slug: Web/HTML/Reference/Elements/geolocation
 l10n:
-  sourceCommit: 483ce811e1ea52cb2d9d2a5af0c4d1c4d591ea4a
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/html/reference/elements/head/index.md
+++ b/files/fr/web/html/reference/elements/head/index.md
@@ -1,9 +1,9 @@
 ---
-title: "<head> : l'élément de métadonnées (en-tête) du document"
+title: "Élément HTML `<head>` : l'élément de métadonnées (en-tête) du document"
+short-title: <head>
 slug: Web/HTML/Reference/Elements/head
-original_slug: Web/HTML/Element/head
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<head>`** fournit des informations générales ({{Glossary("metadata", "métadonnées")}}) sur le document, incluant son [titre](/fr/docs/Web/HTML/Reference/Elements/title), [scripts](/fr/docs/Web/HTML/Reference/Elements/script), et [feuilles de style](/fr/docs/Web/HTML/Reference/Elements/style). Il ne peut y avoir qu'un seul élément `<head>` dans un document HTML.

--- a/files/fr/web/html/reference/elements/header/index.md
+++ b/files/fr/web/html/reference/elements/header/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<header> : l'élément d'en-tête"
+title: "Élément HTML `<header>` : l'élément d'en-tête"
+short-title: <header>
 slug: Web/HTML/Reference/Elements/header
 l10n:
-  sourceCommit: 0ab262675372b83fc870accf3dc46d6a367c451c
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<header>`** représente du contenu introductif, généralement un groupe d'éléments d'introduction ou d'aides à la navigation. Il peut contenir des éléments de titre mais aussi un logo, un formulaire de recherche, le nom d'un·e auteur·ice et d'autres éléments.

--- a/files/fr/web/html/reference/elements/heading_elements/index.md
+++ b/files/fr/web/html/reference/elements/heading_elements/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<h1>-<h6> : les éléments de titre de section"
+title: "Élément HTML `<h1>-<h6>` : les éléments de titre de section"
+short-title: <h1>-<h6>
 slug: Web/HTML/Reference/Elements/Heading_Elements
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 Les éléments [HTML](/fr/docs/Web/HTML) **`<h1>`** à **`<h6>`** représentent les six niveaux de titre de section. `<h1>` correspond au niveau de section le plus haut et `<h6>` correspond au niveau le plus faible. Par défaut, tous les éléments de titre créent une boîte de [niveau bloc](/fr/docs/Glossary/Block-level_content) dans la mise en page, commençant sur une nouvelle ligne et prenant toute la largeur disponible dans leur bloc conteneur.

--- a/files/fr/web/html/reference/elements/hgroup/index.md
+++ b/files/fr/web/html/reference/elements/hgroup/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<hgroup> : l'élément de regroupement de titres"
+title: "Élément HTML `<hgroup>` : l'élément de regroupement de titres"
+short-title: <hgroup>
 slug: Web/HTML/Reference/Elements/hgroup
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<hgroup>`** représente un titre et son contenu associé. Il regroupe un seul élément [`<h1>—<h6>`](/fr/docs/Web/HTML/Reference/Elements/Heading_Elements) avec un ou plusieurs éléments {{HTMLElement("p")}}.

--- a/files/fr/web/html/reference/elements/hr/index.md
+++ b/files/fr/web/html/reference/elements/hr/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<hr> : l'élément de rupture thématique (règle horizontale)"
+title: "Élément HTML `<hr>` : l'élément de rupture thématique (règle horizontale)"
+short-title: <hr>
 slug: Web/HTML/Reference/Elements/hr
 l10n:
-  sourceCommit: 479f72f9279246685bcf6eec93527ac3f470f93e
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<hr>`** représente une rupture thématique entre des éléments de niveau paragraphe&nbsp;: par exemple, un changement de décor dans un récit ou un changement de sujet au sein d'une section.

--- a/files/fr/web/html/reference/elements/html/index.md
+++ b/files/fr/web/html/reference/elements/html/index.md
@@ -1,9 +1,9 @@
 ---
-title: "<html> : l'élément de racine du document HTML"
+title: "Élément HTML `<html>` : l'élément de racine du document HTML"
+short-title: <html>
 slug: Web/HTML/Reference/Elements/html
-original_slug: Web/HTML/Element/html
 l10n:
-  sourceCommit: e7bc0ed5466f5834641d75d416fa81886cf6b37e
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément HTML **`<html>`** représente la racine d'un document HTML ou XHTML. Tout autre élément du document doit être un descendant de cet élément.

--- a/files/fr/web/html/reference/elements/i/index.md
+++ b/files/fr/web/html/reference/elements/i/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<i> : l'élément de texte idiomatic"
+title: "Élément HTML `<i>` : l'élément de texte idiomatic"
+short-title: <i>
 slug: Web/HTML/Reference/Elements/i
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<i>`** représente une portion de texte mise à part du texte normal pour une raison donnée, comme du texte idiomatique, des termes techniques ou des désignations taxonomiques, entre autres. Historiquement, ces contenus étaient présentés en italique, ce qui explique la désignation `<i>` de cet élément.

--- a/files/fr/web/html/reference/elements/iframe/index.md
+++ b/files/fr/web/html/reference/elements/iframe/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<iframe> : l'élément de cadre intégré"
+title: "Élément HTML `<iframe>` : l'élément de cadre intégré"
+short-title: <iframe>
 slug: Web/HTML/Reference/Elements/iframe
 l10n:
-  sourceCommit: 743ba8b257cd06449b192818df120e609f6e16d2
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<iframe>`** représente un {{Glossary("Browsing context", "contexte de navigation")}} imbriqué, intégrant une autre page HTML dans la page courante.

--- a/files/fr/web/html/reference/elements/img/index.md
+++ b/files/fr/web/html/reference/elements/img/index.md
@@ -1,9 +1,9 @@
 ---
-title: "<img> : l'élément d'image embarquée"
+title: "Élément HTML `<img>` : l'élément d'image embarquée"
+short-title: <img>
 slug: Web/HTML/Reference/Elements/img
-original_slug: Web/HTML/Element/img
 l10n:
-  sourceCommit: 3111c5a49047a966a63b66f8634a1713c2568011
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<img>`** permet d'intégrer une image dans un document.

--- a/files/fr/web/html/reference/elements/input/index.md
+++ b/files/fr/web/html/reference/elements/input/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<input> : l'élément de saisie dans un formulaire"
+title: "Élément HTML `<input>` : l'élément de saisie dans un formulaire"
+short-title: <input>
 slug: Web/HTML/Reference/Elements/input
 l10n:
-  sourceCommit: 3712f845b54b2754b2b550c7d7dca18f0277c0ad
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<input>`** permet de créer des contrôles interactifs pour les formulaires web afin d'accepter des données de la part de l'utilisateur·ice&nbsp;; une grande variété de types de données d'entrée et de widgets de contrôle est disponible, selon l'appareil et {{Glossary("user agent", "agent utilisateur")}}. L'élément `<input>` est l'un des éléments HTML les plus puissants et les plus complexes en raison du grand nombre de combinaisons possibles de types d'entrée et d'attributs.

--- a/files/fr/web/html/reference/elements/ins/index.md
+++ b/files/fr/web/html/reference/elements/ins/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<ins> : l'élément de texte inséré"
+title: "Élément HTML `<ins>` : l'élément de texte inséré"
+short-title: <ins>
 slug: Web/HTML/Reference/Elements/ins
 l10n:
-  sourceCommit: 5e815d522e796fb2209fa8470616b37e31c572b4
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<ins>`** représente une portion de texte qui a été ajoutée à un document. Vous pouvez utiliser l'élément {{HTMLElement("del")}} de la même manière pour indiquer une portion de texte qui a été supprimée du document.

--- a/files/fr/web/html/reference/elements/kbd/index.md
+++ b/files/fr/web/html/reference/elements/kbd/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<kbd> : l'élément de saisie clavier"
+title: "Élément HTML `<kbd>` : l'élément de saisie clavier"
+short-title: <kbd>
 slug: Web/HTML/Reference/Elements/kbd
 l10n:
-  sourceCommit: 6ed02a2b0e0d891f7d3b4c2a6b1d9cc05c90ed9c
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<kbd>`** représente une portion de texte en ligne désignant une saisie de texte de l'utilisateur·ice à partir d'un clavier, d'une commande vocale ou de tout autre dispositif de saisie de texte. Par convention, {{Glossary("user agent", "l'agent utilisateur")}} affiche le contenu d'un élément `<kbd>` en utilisant sa police monospace par défaut, bien que cela ne soit pas imposé par la norme HTML.

--- a/files/fr/web/html/reference/elements/label/index.md
+++ b/files/fr/web/html/reference/elements/label/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<label> : l'élément de libellé"
+title: "Élément HTML `<label>` : l'élément de libellé"
+short-title: <label>
 slug: Web/HTML/Reference/Elements/label
 l10n:
-  sourceCommit: 7b8768d410a281446b0b95627c531d852e624353
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<label>`** représente une légende pour un élément d'une interface utilisateur.

--- a/files/fr/web/html/reference/elements/legend/index.md
+++ b/files/fr/web/html/reference/elements/legend/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<legend> : l'élément de légende de groupe de champs"
+title: "Élément HTML `<legend>` : l'élément de légende de groupe de champs"
+short-title: <legend>
 slug: Web/HTML/Reference/Elements/legend
 l10n:
-  sourceCommit: f2d281d86396bcd2dcecfdabd5837b1590132aa6
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<legend>`** représente une légende pour le contenu de son parent {{HTMLElement("fieldset")}}.

--- a/files/fr/web/html/reference/elements/li/index.md
+++ b/files/fr/web/html/reference/elements/li/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<li> : l'élément dans une liste"
+title: "Élément HTML `<li>` : l'élément dans une liste"
+short-title: <li>
 slug: Web/HTML/Reference/Elements/li
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<li>`** est utilisé pour représenter un élément dans une liste. Il doit être contenu dans un élément parent&nbsp;: une liste ordonnée ({{HTMLElement("ol")}}), une liste non ordonnée ({{HTMLElement("ul")}}) ou un menu ({{HTMLElement("menu")}}). Dans les menus et les listes non ordonnées, les éléments de liste sont habituellement affichés avec des puces. Dans les listes ordonnées, ils sont habituellement affichés avec un compteur croissant à gauche, tel qu'un nombre ou une lettre.

--- a/files/fr/web/html/reference/elements/link/index.md
+++ b/files/fr/web/html/reference/elements/link/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<link> : l'élément de lien vers des ressources externes"
+title: "Élément HTML `<link>` : l'élément de lien vers des ressources externes"
+short-title: <link>
 slug: Web/HTML/Reference/Elements/link
 l10n:
-  sourceCommit: fef6630e9b90f9794d3194ea8389ff70599c6884
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<link>`** définit la relation entre le document courant et une ressource externe. Cet élément peut être utilisé pour définir un lien vers {{Glossary("CSS", "une feuille de style")}}, vers les icônes utilisées en barre de titre ou comme icône d'application sur les appareils mobiles.

--- a/files/fr/web/html/reference/elements/main/index.md
+++ b/files/fr/web/html/reference/elements/main/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<main> : l'élément de contenu principal"
+title: "Élément HTML `<main>` : l'élément de contenu principal"
+short-title: <main>
 slug: Web/HTML/Reference/Elements/main
 l10n:
-  sourceCommit: 7615562a3689a3e23a2b6b623597f4391740a53e
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<main>`** représente le contenu principal du corps ({{HTMLElement("body")}}) d'un document. La zone de contenu principal se compose de contenu directement lié ou qui développe le sujet central d'un document, ou la fonctionnalité centrale d'une application.

--- a/files/fr/web/html/reference/elements/map/index.md
+++ b/files/fr/web/html/reference/elements/map/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<map> : l'élément de carte d'image"
+title: "Élément HTML `<map>` : l'élément de carte d'image"
+short-title: <map>
 slug: Web/HTML/Reference/Elements/map
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<map>`** est utilisé avec des éléments {{HTMLElement("area")}} pour définir une carte d'image (une zone de lien cliquable).

--- a/files/fr/web/html/reference/elements/mark/index.md
+++ b/files/fr/web/html/reference/elements/mark/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<mark> : l'élément de marquage du texte"
+title: "Élément HTML `<mark>` : l'élément de marquage du texte"
+short-title: <mark>
 slug: Web/HTML/Reference/Elements/mark
 l10n:
-  sourceCommit: 17813cceb76950fea2acc1a39eb64ae3c57f038c
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<mark>`** représente du texte qui est **marqué** ou **surligné** à des fins de référence ou de notation, en raison de la pertinence du passage marqué dans le contexte qui l'entoure.

--- a/files/fr/web/html/reference/elements/marquee/index.md
+++ b/files/fr/web/html/reference/elements/marquee/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<marquee> : l'élément de texte défilant"
+title: "Élément HTML `<marquee>` : l'élément de texte défilant"
+short-title: <marquee>
 slug: Web/HTML/Reference/Elements/marquee
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/menu/index.md
+++ b/files/fr/web/html/reference/elements/menu/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<menu> : l'élément de menu"
+title: "Élément HTML `<menu>` : l'élément de menu"
+short-title: <menu>
 slug: Web/HTML/Reference/Elements/menu
 l10n:
-  sourceCommit: 0ab262675372b83fc870accf3dc46d6a367c451c
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<menu>`** est une alternative sémantique à {{HTMLElement("ul")}}, mais il est traité par les navigateurs (et exposé dans l'arbre d'accessibilité) comme identique à {{HTMLElement("ul")}}. Il représente une liste non ordonnée d'éléments (représentés par des éléments {{HTMLElement("li")}}).

--- a/files/fr/web/html/reference/elements/meta/index.md
+++ b/files/fr/web/html/reference/elements/meta/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<meta> : l'élément de métadonnées"
+title: "Élément HTML `<meta>` : l'élément de métadonnées"
+short-title: <meta>
 slug: Web/HTML/Reference/Elements/meta
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<meta>`** représente toute information de {{Glossary("Metadata","métadonnées")}} qui ne peut pas être représentée par un des autres éléments de métadonnées, tels que {{HTMLElement("base")}}, {{HTMLElement("link")}}, {{HTMLElement("script")}}, {{HTMLElement("style")}} ou {{HTMLElement("title")}}.

--- a/files/fr/web/html/reference/elements/meter/index.md
+++ b/files/fr/web/html/reference/elements/meter/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<meter> : l'élément de mesure"
+title: "Élément HTML `<meter>` : l'élément de mesure"
+short-title: <meter>
 slug: Web/HTML/Reference/Elements/meter
 l10n:
-  sourceCommit: 877e5882a590ade070954ee37e64fea5144f31db
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<meter>`** représente une valeur scalaire dans un intervalle donné ou une valeur fractionnaire.

--- a/files/fr/web/html/reference/elements/nav/index.md
+++ b/files/fr/web/html/reference/elements/nav/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<nav> : l'élément de section de navigation"
+title: "Élément HTML `<nav>` : l'élément de section de navigation"
+short-title: <nav>
 slug: Web/HTML/Reference/Elements/nav
 l10n:
-  sourceCommit: f2d281d86396bcd2dcecfdabd5837b1590132aa6
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<nav>`** représente une section d'une page dont le but est de fournir des liens de navigation, soit au sein du document courant, soit vers d'autres documents. Des exemples courants de sections de navigation sont les menus, les tables des matières et les index.

--- a/files/fr/web/html/reference/elements/nobr/index.md
+++ b/files/fr/web/html/reference/elements/nobr/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<nobr> : l'élément de non-rupture de texte"
+title: "Élément HTML `<nobr>` : l'élément de non-rupture de texte"
+short-title: <nobr>
 slug: Web/HTML/Reference/Elements/nobr
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/noembed/index.md
+++ b/files/fr/web/html/reference/elements/noembed/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<noembed> : l'élément de repli au contenu embarqué"
+title: "Élément HTML `<noembed>` : l'élément de repli au contenu embarqué"
+short-title: <noembed>
 slug: Web/HTML/Reference/Elements/noembed
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/noframes/index.md
+++ b/files/fr/web/html/reference/elements/noframes/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<noframes> : l'élément de repli des cadres"
+title: "Élément HTML `<noframes>` : l'élément de repli des cadres"
+short-title: <noframes>
 slug: Web/HTML/Reference/Elements/noframes
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/noscript/index.md
+++ b/files/fr/web/html/reference/elements/noscript/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<noscript> : l'élément de repli des scripts"
+title: "Élément HTML `<noscript>` : l'élément de repli des scripts"
+short-title: <noscript>
 slug: Web/HTML/Reference/Elements/noscript
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<noscript>`** définit une section HTML à insérer si un type de script sur la page n'est pas pris en charge ou si l'exécution des scripts est actuellement désactivée dans le navigateur.

--- a/files/fr/web/html/reference/elements/object/index.md
+++ b/files/fr/web/html/reference/elements/object/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<object> : l'élément d'objet externe"
+title: "Élément HTML `<object>` : l'élément d'objet externe"
+short-title: <object>
 slug: Web/HTML/Reference/Elements/object
 l10n:
-  sourceCommit: f29e825161ee6776a395cd846f8570686f784341
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<object>`** représente une ressource externe, qui peut être traitée comme une image, un contexte de navigation imbriqué ou une ressource à gérer par un module externe.

--- a/files/fr/web/html/reference/elements/ol/index.md
+++ b/files/fr/web/html/reference/elements/ol/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<ol> : l'élément de liste ordonnée"
+title: "Élément HTML `<ol>` : l'élément de liste ordonnée"
+short-title: <ol>
 slug: Web/HTML/Reference/Elements/ol
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<ol>`** représente une liste ordonnée, généralement affichée sous forme de liste numérotée.

--- a/files/fr/web/html/reference/elements/optgroup/index.md
+++ b/files/fr/web/html/reference/elements/optgroup/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<optgroup> : l'élément de groupe d'options"
+title: "Élément HTML `<optgroup>` : l'élément de groupe d'options"
+short-title: <optgroup>
 slug: Web/HTML/Reference/Elements/optgroup
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<optgroup>`** crée un regroupement d'options à l'intérieur d'un élément HTML {{HTMLElement("select")}}.

--- a/files/fr/web/html/reference/elements/option/index.md
+++ b/files/fr/web/html/reference/elements/option/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<option> : l'élément d'option"
+title: "Élément HTML `<option>` : l'élément d'option"
+short-title: <option>
 slug: Web/HTML/Reference/Elements/option
 l10n:
-  sourceCommit: c10cfb6daba8fe6fc5366f2e1ca1bd32de8a537f
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<option>`** est utilisé pour définir un élément contenu dans un élément {{HTMLElement("select")}}, {{HTMLElement("optgroup")}} ou {{HTMLElement("datalist")}}. Ainsi, `<option>` peut représenter des éléments de menu dans des fenêtres contextuelles et d'autres listes d'éléments dans un document HTML.

--- a/files/fr/web/html/reference/elements/output/index.md
+++ b/files/fr/web/html/reference/elements/output/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<output> : l'élément de sortie"
+title: "Élément HTML `<output>` : l'élément de sortie"
+short-title: <output>
 slug: Web/HTML/Reference/Elements/output
 l10n:
-  sourceCommit: f29e825161ee6776a395cd846f8570686f784341
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<output>`** est un élément conteneur dans lequel un site ou une application peut injecter les résultats d'un calcul ou le résultat d'une action utilisateur.

--- a/files/fr/web/html/reference/elements/p/index.md
+++ b/files/fr/web/html/reference/elements/p/index.md
@@ -1,9 +1,9 @@
 ---
-title: "<p> : l'élément paragraphe"
+title: "Élément HTML `<p>` : l'élément paragraphe"
+short-title: <p>
 slug: Web/HTML/Reference/Elements/p
-original_slug: Web/HTML/Element/p
 l10n:
-  sourceCommit: a1765c2cad20118be0dad322d3548908787b5791
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<p>`** représente un paragraphe. Les paragraphes sont généralement représentés dans les médias visuels comme des blocs de texte séparés des blocs adjacents par des lignes vides et/ou une indentation de première ligne, mais les paragraphes HTML peuvent être tout regroupement structurel de contenu lié, comme des images ou des champs de formulaire.

--- a/files/fr/web/html/reference/elements/param/index.md
+++ b/files/fr/web/html/reference/elements/param/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<param> : l'élément paramètre d'un objet"
+title: "Élément HTML `<param>` : l'élément paramètre d'un objet"
+short-title: <param>
 slug: Web/HTML/Reference/Elements/param
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/picture/index.md
+++ b/files/fr/web/html/reference/elements/picture/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<picture> : l'élément d'image adaptative"
+title: "Élément HTML `<picture>` : l'élément d'image adaptative"
+short-title: <picture>
 slug: Web/HTML/Reference/Elements/picture
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<picture>`** contient zéro ou plusieurs éléments {{HTMLElement("source")}} et un élément {{HTMLElement("img")}} pour proposer des versions alternatives d'une image selon les scénarios d'affichage ou d'appareil.

--- a/files/fr/web/html/reference/elements/plaintext/index.md
+++ b/files/fr/web/html/reference/elements/plaintext/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<plaintext> : l'élément de texte brut"
+title: "Élément HTML `<plaintext>` : l'élément de texte brut"
+short-title: <plaintext>
 slug: Web/HTML/Reference/Elements/plaintext
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/pre/index.md
+++ b/files/fr/web/html/reference/elements/pre/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<pre> : l'élément de texte préformaté"
+title: "Élément HTML `<pre>` : l'élément de texte préformaté"
+short-title: <pre>
 slug: Web/HTML/Reference/Elements/pre
 l10n:
-  sourceCommit: d534b22334554896f3c2c83e469f9b9eb3f9188a
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<pre>`** représente du texte préformaté qui est présenté exactement comme écrit dans le fichier HTML. Le texte est généralement affiché avec une police non proportionnelle, ou [à chasse fixe](https://fr.wikipedia.org/wiki/Police_de_caract%C3%A8res_%C3%A0_chasse_fixe).

--- a/files/fr/web/html/reference/elements/progress/index.md
+++ b/files/fr/web/html/reference/elements/progress/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<progress> : l'élément d'indicateur de progression"
+title: "Élément HTML `<progress>` : l'élément d'indicateur de progression"
+short-title: <progress>
 slug: Web/HTML/Reference/Elements/progress
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<progress>`** indique l'état de complétion d'une tâche et est généralement représenté par une barre de progression.

--- a/files/fr/web/html/reference/elements/q/index.md
+++ b/files/fr/web/html/reference/elements/q/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<q> : l'élément de citation en incise"
+title: "Élément HTML `<q>` : l'élément de citation en incise"
+short-title: <q>
 slug: Web/HTML/Reference/Elements/q
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<q>`** indique que le texte qu'il contient est une citation en incise. La plupart des navigateurs modernes entoure le texte de cet élément avec des marques de citation. Cet élément est destiné aux citations courtes qui ne nécessitent pas de sauts de paragraphe. Pour les plus grandes citations, on utilisera l'élément {{HTMLElement("blockquote")}}.

--- a/files/fr/web/html/reference/elements/rb/index.md
+++ b/files/fr/web/html/reference/elements/rb/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<rb> : l'élément de base ruby"
+title: "Élément HTML `<rb>` : l'élément de base ruby"
+short-title: <rb>
 slug: Web/HTML/Reference/Elements/rb
 l10n:
-  sourceCommit: 038bda33048810c222cc32b71f52f14d53495a1d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/rp/index.md
+++ b/files/fr/web/html/reference/elements/rp/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<rp> : l'élément de parenthèses alternatif aux annotations Ruby"
+title: "Élément HTML `<rp>` : l'élément de parenthèses alternatif aux annotations Ruby"
+short-title: <rp>
 slug: Web/HTML/Reference/Elements/rp
 l10n:
-  sourceCommit: 038bda33048810c222cc32b71f52f14d53495a1d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<rp>`** est utilisé pour fournir des parenthèses de repli pour les navigateurs qui ne prennent pas en charge l'affichage des annotations ruby avec l'élément {{HTMLElement("ruby")}}. Un élément `<rp>` doit entourer chacune des parenthèses ouvrantes et fermantes qui encadrent l'élément {{HTMLElement("rt")}} contenant le texte de l'annotation.

--- a/files/fr/web/html/reference/elements/rt/index.md
+++ b/files/fr/web/html/reference/elements/rt/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<rt> : l'élément de texte Ruby"
+title: "Élément HTML `<rt>` : l'élément de texte Ruby"
+short-title: <rt>
 slug: Web/HTML/Reference/Elements/rt
 l10n:
-  sourceCommit: 038bda33048810c222cc32b71f52f14d53495a1d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<rt>`** indique la composante texte d'une annotation Ruby, il est notamment utilisé pour la prononciation, la traduction ou la translitération des caractères d'Asie orientale. Cet élément est toujours contenu dans un élément {{HTMLElement("ruby")}}.

--- a/files/fr/web/html/reference/elements/rtc/index.md
+++ b/files/fr/web/html/reference/elements/rtc/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<rtc> : l'élément de conteneur de texte Ruby"
+title: "Élément HTML `<rtc>` : l'élément de conteneur de texte Ruby"
+short-title: <rtc>
 slug: Web/HTML/Reference/Elements/rtc
 l10n:
-  sourceCommit: 038bda33048810c222cc32b71f52f14d53495a1d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/ruby/index.md
+++ b/files/fr/web/html/reference/elements/ruby/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<ruby> : l'élément d'annotation de Ruby"
+title: "Élément HTML `<ruby>` : l'élément d'annotation de Ruby"
+short-title: <ruby>
 slug: Web/HTML/Reference/Elements/ruby
 l10n:
-  sourceCommit: 038bda33048810c222cc32b71f52f14d53495a1d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<ruby>`** représente de petites annotations affichées au-dessus, en dessous ou à côté du texte de base, généralement utilisées pour indiquer la prononciation des caractères d'Asie orientale. Il peut aussi servir à annoter d'autres types de texte, mais cet usage est moins courant.

--- a/files/fr/web/html/reference/elements/s/index.md
+++ b/files/fr/web/html/reference/elements/s/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<s> : l'élément de texte barré"
+title: "Élément HTML `<s>` : l'élément de texte barré"
+short-title: <s>
 slug: Web/HTML/Reference/Elements/s
 l10n:
-  sourceCommit: 5e815d522e796fb2209fa8470616b37e31c572b4
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<s>`** affiche du texte barré. Utilisez l'élément `<s>` pour représenter des choses qui ne sont plus pertinentes ou plus exactes. Cependant, `<s>` n'est pas approprié pour indiquer les modifications d'un document&nbsp;; pour cela, utilisez les éléments {{HTMLElement("del")}} et {{HTMLElement("ins")}}, selon le cas.

--- a/files/fr/web/html/reference/elements/samp/index.md
+++ b/files/fr/web/html/reference/elements/samp/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<samp> : l'élément d'échantillon en sortie"
+title: "Élément HTML `<samp>` : l'élément d'échantillon en sortie"
+short-title: <samp>
 slug: Web/HTML/Reference/Elements/samp
 l10n:
-  sourceCommit: a1765c2cad20118be0dad322d3548908787b5791
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<samp>`** est un élément qui permet de représenter un résultat produit par un programme informatique en incise dans du texte. Il est généralement affiché avec la police à chasse fixe du navigateur (par exemple en [Courier](<https://fr.wikipedia.org/wiki/Courier_(police_d'écriture)>) ou en Lucida Console).

--- a/files/fr/web/html/reference/elements/script/index.md
+++ b/files/fr/web/html/reference/elements/script/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<script> : l'élément de script"
+title: "Élément HTML `<script>` : l'élément de script"
+short-title: <script>
 slug: Web/HTML/Reference/Elements/script
 l10n:
-  sourceCommit: fef6630e9b90f9794d3194ea8389ff70599c6884
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<script>`** est utilisé pour intégrer du code ou des données exécutables&nbsp;: il sert généralement à intégrer ou référencer du code JavaScript. L'élément `<script>` peut aussi être utilisé avec d'autres langages, comme le langage de programmation GLSL de [WebGL](/fr/docs/Web/API/WebGL_API) ou {{Glossary("JSON")}}.

--- a/files/fr/web/html/reference/elements/search/index.md
+++ b/files/fr/web/html/reference/elements/search/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<search>: l'élément de recherche"
+title: "Élément HTML `<search>` : l'élément de recherche"
+short-title: <search>
 slug: Web/HTML/Reference/Elements/search
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<search>`** est un conteneur représentant les parties du document ou de l'application avec des contrôles de formulaire ou d'autres contenus liés à l'exécution d'une opération de recherche ou de filtrage. L'élément `<search>` identifie sémantiquement le but du contenu de l'élément comme ayant des capacités de recherche ou de filtrage. La fonctionnalité de recherche ou de filtrage peut concerner le site Web ou l'application, la page Web ou le document actuel, ou l'ensemble d'Internet ou une sous-section de celui-ci.

--- a/files/fr/web/html/reference/elements/section/index.md
+++ b/files/fr/web/html/reference/elements/section/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<section> : l'élément de section générique"
+title: "Élément HTML `<section>` : l'élément de section générique"
+short-title: <section>
 slug: Web/HTML/Reference/Elements/section
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<section>`** représente une section générique et autonome d'un document, qui n'a pas d'élément sémantique plus spécifique pour la représenter. Les sections doivent toujours comporter un titre, sauf très rares exceptions.

--- a/files/fr/web/html/reference/elements/select/index.md
+++ b/files/fr/web/html/reference/elements/select/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<select> : l'élément de liste déroulante"
+title: "Élément HTML `<select>` : l'élément de liste déroulante"
+short-title: <select>
 slug: Web/HTML/Reference/Elements/select
 l10n:
-  sourceCommit: dea6ca35b4cba685b7353a92b77f55e3fd6937c1
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<select>`** représente un contrôle qui propose un menu d'options.

--- a/files/fr/web/html/reference/elements/selectedcontent/index.md
+++ b/files/fr/web/html/reference/elements/selectedcontent/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<selectedcontent> : l'élément d'affichage de l'option sélectionnée"
+title: "Élément HTML `<selectedcontent>` : l'élément d'affichage de l'option sélectionnée"
+short-title: <selectedcontent>
 slug: Web/HTML/Reference/Elements/selectedcontent
 l10n:
-  sourceCommit: 6eae35bc64a49865a469ca29bc40e6993b9cb8cc
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/html/reference/elements/slot/index.md
+++ b/files/fr/web/html/reference/elements/slot/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<slot> : l'élément d'emplacement de composant web"
+title: "Élément HTML `<slot>` : l'élément d'emplacement de composant web"
+short-title: <slot>
 slug: Web/HTML/Reference/Elements/slot
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<slot>`** — qui fait partie de la suite technologique [des Composants Web](/fr/docs/Web/API/Web_components) — est un emplacement à l'intérieur d'un composant web que vous pouvez remplir avec votre propre balisage, ce qui permet de créer des arbres DOM distincts et de les présenter ensemble.

--- a/files/fr/web/html/reference/elements/small/index.md
+++ b/files/fr/web/html/reference/elements/small/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<small> : l'élément de commentaire en marge"
+title: "Élément HTML `<small>` : l'élément de commentaire en marge"
+short-title: <small>
 slug: Web/HTML/Reference/Elements/small
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<small>`** représente des commentaires en marge et des mentions en petits caractères, comme les textes de droits d'auteur et les mentions légales, indépendamment de sa présentation visuelle. Par défaut, il affiche le texte qu'il contient avec une taille de police inférieure, par exemple de `small` à `x-small`.

--- a/files/fr/web/html/reference/elements/source/index.md
+++ b/files/fr/web/html/reference/elements/source/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<source> : l'élément de source d'image et média"
+title: "Élément HTML `<source>` : l'élément de source d'image et média"
+short-title: <source>
 slug: Web/HTML/Reference/Elements/source
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<source>`** définit une ou plusieurs ressources média pour les éléments {{HTMLElement("picture")}}, {{HTMLElement("audio")}} et {{HTMLElement("video")}}. C'est un {{Glossary("void element", "élément vide")}}, ce qui signifie qu'il n'a pas de contenu et ne nécessite pas de balise fermante. Cet élément est couramment utilisé pour proposer le même contenu média dans plusieurs formats de fichiers afin d'assurer la compatibilité avec un large éventail de navigateurs, compte tenu de leur prise en charge différente des [formats de fichiers image](/fr/docs/Web/Media/Guides/Formats/Image_types) et des [formats de fichiers média](/fr/docs/Web/Media/Guides/Formats).

--- a/files/fr/web/html/reference/elements/span/index.md
+++ b/files/fr/web/html/reference/elements/span/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<span> : l'élément de contenu en ligne générique"
+title: "Élément HTML `<span>` : l'élément de contenu en ligne générique"
+short-title: <span>
 slug: Web/HTML/Reference/Elements/span
 l10n:
-  sourceCommit: f2d281d86396bcd2dcecfdabd5837b1590132aa6
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<span>`** est un conteneur générique en ligne (<i lang="en">inline</i> en anglais) pour les contenus phrasés. Il ne représente rien de particulier. Il peut être utilisé pour grouper des éléments afin de les mettre en forme (grâce aux attributs [`class`](/fr/docs/Web/HTML/Reference/Global_attributes/class) ou [`id`](/fr/docs/Web/HTML/Reference/Global_attributes/id) et aux règles [CSS](/fr/docs/Web/CSS)) ou parce qu'ils partagent certaines valeurs d'attribut comme [`lang`](/fr/docs/Web/HTML/Reference/Global_attributes/lang). Il doit uniquement être utilisé lorsqu'aucun autre élément sémantique n'est approprié. `<span>` est très proche de l'élément {{HTMLElement("div")}}, mais l'élément {{HTMLElement("div")}} est [un élément de bloc](/fr/docs/Glossary/Block-level_content), alors que `<span>` est {{Glossary("Inline-level_content", "un élément en ligne")}}.

--- a/files/fr/web/html/reference/elements/strike/index.md
+++ b/files/fr/web/html/reference/elements/strike/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<strike> : l'élément obsolète de texte barré"
+title: "Élément HTML `<strike>` : l'élément obsolète de texte barré"
+short-title: <strike>
 slug: Web/HTML/Reference/Elements/strike
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/strong/index.md
+++ b/files/fr/web/html/reference/elements/strong/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<strong> : l'élément de haute importance"
+title: "Élément HTML `<strong>` : l'élément de haute importance"
+short-title: <strong>
 slug: Web/HTML/Reference/Elements/strong
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<strong>`** indique que le texte a une importance particulière ou un certain sérieux voire un caractère urgent. Cela se traduit généralement par un affichage en gras.

--- a/files/fr/web/html/reference/elements/style/index.md
+++ b/files/fr/web/html/reference/elements/style/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<style> : l'élément d'information de style"
+title: "Élément HTML `<style>` : l'élément d'information de style"
+short-title: <style>
 slug: Web/HTML/Reference/Elements/style
 l10n:
-  sourceCommit: dc788bf0ea36cb1ebe809c82aaae2c77cb3e18c0
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<style>`** contient des informations de mise en forme pour un document ou une partie d'un document. Il contient du CSS, qui est appliqué au contenu du document contenant l'élément `<style>`.

--- a/files/fr/web/html/reference/elements/sub/index.md
+++ b/files/fr/web/html/reference/elements/sub/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<sub> : l'élément de mise en indice"
+title: "Élément HTML `<sub>` : l'élément de mise en indice"
+short-title: <sub>
 slug: Web/HTML/Reference/Elements/sub
 l10n:
-  sourceCommit: b9acb5397cf8e07966b1757a857e5000a009b04e
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<sub>`** définit du texte en ligne qui doit être affiché en indice pour des raisons strictement typographiques. Les indices sont généralement rendus avec une ligne de base abaissée et un texte de plus petite taille.

--- a/files/fr/web/html/reference/elements/summary/index.md
+++ b/files/fr/web/html/reference/elements/summary/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<summary> : l'élément de révélation d'un résumé"
+title: "Élément HTML `<summary>` : l'élément de révélation d'un résumé"
+short-title: <summary>
 slug: Web/HTML/Reference/Elements/summary
 l10n:
-  sourceCommit: 0ab262675372b83fc870accf3dc46d6a367c451c
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<summary>`** représente une boîte permettant de révéler le contenu d'un résumé ou d'une légende pour le contenu d'un élément {{HTMLElement("details")}}. En cliquant sur l'élément `<summary>`, on passe de l'état affiché à l'état masqué (et vice versa) de l'élément `<details>` parent.

--- a/files/fr/web/html/reference/elements/sup/index.md
+++ b/files/fr/web/html/reference/elements/sup/index.md
@@ -1,9 +1,9 @@
 ---
-title: "<sup> : l'élément de mise en exposant"
+title: "Élément HTML `<sup>` : l'élément de mise en exposant"
+short-title: <sup>
 slug: Web/HTML/Reference/Elements/sup
-original_slug: Web/HTML/Element/sup
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément HTML **`<sup>`** permet d'afficher du texte en exposant, uniquement pour des raisons typographiques. Le texte est alors positionné plus haut que la ligne de base et généralement en plus petit.

--- a/files/fr/web/html/reference/elements/table/index.md
+++ b/files/fr/web/html/reference/elements/table/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<table> : l'élément de tableau"
+title: "Élément HTML `<table>` : l'élément de tableau"
+short-title: <table>
 slug: Web/HTML/Reference/Elements/table
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<table>`** représente des données tabulaires, c'est-à-dire des informations présentées dans un tableau à deux dimensions composé de lignes et de colonnes de cellules contenant des données.

--- a/files/fr/web/html/reference/elements/tbody/index.md
+++ b/files/fr/web/html/reference/elements/tbody/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<tbody> : l'élément de corps d'un tableau"
+title: "Élément HTML `<tbody>` : l'élément de corps d'un tableau"
+short-title: <tbody>
 slug: Web/HTML/Reference/Elements/tbody
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<tbody>`** permet de regrouper une ou plusieurs lignes du tableau (éléments {{HTMLElement("tr")}}), indiquant qu'elles constituent le corps (principal) des données d'un tableau.

--- a/files/fr/web/html/reference/elements/td/index.md
+++ b/files/fr/web/html/reference/elements/td/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<td> : l'élément de cellule de tableau"
+title: "Élément HTML `<td>` : l'élément de cellule de tableau"
+short-title: <td>
 slug: Web/HTML/Reference/Elements/td
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<td>`** définit une cellule d'un tableau qui contient des données et peut être utilisé comme enfant de l'élément {{HTMLElement("tr")}}.

--- a/files/fr/web/html/reference/elements/template/index.md
+++ b/files/fr/web/html/reference/elements/template/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<template> : l'élément de modèle de contenu"
+title: "Élément HTML `<template>` : l'élément de modèle de contenu"
+short-title: <template>
 slug: Web/HTML/Reference/Elements/template
 l10n:
-  sourceCommit: 9c4d4cb78a55340b46855e47aba76729a59e11ce
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<template>`** sert de mécanisme pour contenir des fragments {{Glossary("HTML")}}, qui peuvent être utilisés plus tard via JavaScript ou générés immédiatement dans le DOM d'ombre.

--- a/files/fr/web/html/reference/elements/textarea/index.md
+++ b/files/fr/web/html/reference/elements/textarea/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<textarea> : l'élément de zone de texte"
+title: "Élément HTML `<textarea>` : l'élément de zone de texte"
+short-title: <textarea>
 slug: Web/HTML/Reference/Elements/textarea
 l10n:
-  sourceCommit: f29e825161ee6776a395cd846f8570686f784341
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<textarea>`** représente un contrôle d'édition de texte brut sur plusieurs lignes, utile lorsque vous souhaitez permettre aux utilisateur·ice·s de saisir une quantité importante de texte libre, par exemple un commentaire sur un avis ou un formulaire de retour.

--- a/files/fr/web/html/reference/elements/tfoot/index.md
+++ b/files/fr/web/html/reference/elements/tfoot/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<tfoot> : l'élément de pied de tableau"
+title: "Élément HTML `<tfoot>` : l'élément de pied de tableau"
+short-title: <tfoot>
 slug: Web/HTML/Reference/Elements/tfoot
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<tfoot>`** encapsule un ensemble de lignes de tableau (éléments {{HTMLElement("tr")}}), indiquant qu'elles constituent le pied d'un tableau avec des informations sur les colonnes du tableau. Il s'agit généralement d'un récapitulatif des colonnes, par exemple une somme des nombres présents dans une colonne.

--- a/files/fr/web/html/reference/elements/th/index.md
+++ b/files/fr/web/html/reference/elements/th/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<th> : l'élément d'en-tête de tableau"
+title: "Élément HTML `<th>` : l'élément d'en-tête de tableau"
+short-title: <th>
 slug: Web/HTML/Reference/Elements/th
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<th>`** définit une cellule comme l'en-tête d'un groupe de cellules de tableau et peut être utilisé comme enfant de l'élément {{HTMLElement("tr")}}. La nature exacte de ce groupe est définie par les attributs [`scope`](#scope) et [`headers`](#headers).

--- a/files/fr/web/html/reference/elements/thead/index.md
+++ b/files/fr/web/html/reference/elements/thead/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<thead> : l'élément d'en-tête du tableau"
+title: "Élément HTML `<thead>` : l'élément d'en-tête du tableau"
+short-title: <thead>
 slug: Web/HTML/Reference/Elements/thead
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<thead>`** encapsule un ensemble de lignes de tableau (éléments {{HTMLElement("tr")}}), indiquant qu'elles constituent l'en-tête d'un tableau contenant des informations sur les colonnes du tableau. Il s'agit généralement d'en-têtes de colonnes (éléments {{HTMLElement("th")}}).

--- a/files/fr/web/html/reference/elements/time/index.md
+++ b/files/fr/web/html/reference/elements/time/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<time> : l'élément de temps (date)"
+title: "Élément HTML `<time>` : l'élément de temps (date)"
+short-title: <time>
 slug: Web/HTML/Reference/Elements/time
 l10n:
-  sourceCommit: eb9034ead504af00b27a7da3ff9d4f641ade5e59
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<time>`** représente une période précise dans le temps. Il peut inclure l'attribut `datetime` pour traduire les dates dans un format lisible par une machine, permettant d'améliorer les résultats des moteurs de recherche ou d'activer des fonctionnalités personnalisées comme des rappels.

--- a/files/fr/web/html/reference/elements/title/index.md
+++ b/files/fr/web/html/reference/elements/title/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<title> : l'élément de titre du document"
+title: "Élément HTML `<title>` : l'élément de titre du document"
+short-title: <title>
 slug: Web/HTML/Reference/Elements/title
 l10n:
-  sourceCommit: 96a73163513476fe49bfba695acedb7622135354
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<title>`** définit le titre du document (qui est affiché dans la barre de titre du {{Glossary("Browser", "navigateur")}} ou dans l'onglet de la page). Il ne contient que du texte&nbsp;; les balises HTML présentes dans l'élément, le cas échéant, sont également traitées comme du texte brut.

--- a/files/fr/web/html/reference/elements/tr/index.md
+++ b/files/fr/web/html/reference/elements/tr/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<tr> : l'élément de ligne d'un tableau"
+title: "Élément HTML `<tr>` : l'élément de ligne d'un tableau"
+short-title: <tr>
 slug: Web/HTML/Reference/Elements/tr
 l10n:
-  sourceCommit: 7c28cd21b705e7b7664d53b4d7822469ea8e6e15
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<tr>`** définit une ligne de cellules dans un tableau. Les cellules de la ligne peuvent ensuite être créées à l'aide d'une combinaison d'éléments {{HTMLElement("td")}} (cellule de données) et {{HTMLElement("th")}} (cellule d'en-tête).

--- a/files/fr/web/html/reference/elements/track/index.md
+++ b/files/fr/web/html/reference/elements/track/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<track> : l'élément de piste texte embarquée"
+title: "Élément HTML `<track>` : l'élément de piste texte embarquée"
+short-title: <track>
 slug: Web/HTML/Reference/Elements/track
 l10n:
-  sourceCommit: 41db8c95b49ec2ca65776ef5c2eafed616b1510b
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<track>`** est utilisé comme enfant des éléments média, {{HTMLElement("audio")}} et {{HTMLElement("video")}}.

--- a/files/fr/web/html/reference/elements/tt/index.md
+++ b/files/fr/web/html/reference/elements/tt/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<tt> : l'élément de texte de téléscripteur"
+title: "Élément HTML `<tt>` : l'élément de texte de téléscripteur"
+short-title: <tt>
 slug: Web/HTML/Reference/Elements/tt
 l10n:
-  sourceCommit: 9cfc2285428932f448a1747e347b1e35a3e0172b
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}

--- a/files/fr/web/html/reference/elements/u/index.md
+++ b/files/fr/web/html/reference/elements/u/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<u> : l'élément d'annotation non textuelle"
+title: "Élément HTML `<u>` : l'élément d'annotation non textuelle"
+short-title: <u>
 slug: Web/HTML/Reference/Elements/u
 l10n:
-  sourceCommit: f2d281d86396bcd2dcecfdabd5837b1590132aa6
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<u>`** représente une portion de texte en ligne devant être rendue de manière à indiquer qu'elle comporte une annotation non textuelle. Par défaut, il est affiché avec un unique soulignement continu, mais cela peut être modifié via CSS.

--- a/files/fr/web/html/reference/elements/ul/index.md
+++ b/files/fr/web/html/reference/elements/ul/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<ul> : l'élément de liste non ordonnée"
+title: "Élément HTML `<ul>` : l'élément de liste non ordonnée"
+short-title: <ul>
 slug: Web/HTML/Reference/Elements/ul
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<ul>`** représente une liste d'éléments sans ordre particulier. Il est souvent représenté par une liste à puces.

--- a/files/fr/web/html/reference/elements/var/index.md
+++ b/files/fr/web/html/reference/elements/var/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<var> : l'élément de variable"
+title: "Élément HTML `<var>` : l'élément de variable"
+short-title: <var>
 slug: Web/HTML/Reference/Elements/var
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<var>`** représente une variable dans une expression mathématique ou un texte lié à la programmation. Son contenu est généralement représenté avec une version italique de la police environnante utilisée, toutefois, ce comportement peut dépendre du navigateur utilisé.

--- a/files/fr/web/html/reference/elements/video/index.md
+++ b/files/fr/web/html/reference/elements/video/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<video> : l'élément d'intégration vidéo"
+title: "Élément HTML `<video>` : l'élément d'intégration vidéo"
+short-title: <video>
 slug: Web/HTML/Reference/Elements/video
 l10n:
-  sourceCommit: 743ba8b257cd06449b192818df120e609f6e16d2
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<video>`** intègre un lecteur de média qui prend en charge la lecture vidéo dans le document. Vous pouvez également utiliser `<video>` pour le contenu audio, mais l'élément {{HTMLElement("audio")}} peut fournir une expérience utilisateur plus appropriée.

--- a/files/fr/web/html/reference/elements/wbr/index.md
+++ b/files/fr/web/html/reference/elements/wbr/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<wbr> : l'élément d'opportunité de saut de ligne"
+title: "Élément HTML `<wbr>` : l'élément d'opportunité de saut de ligne"
+short-title: <wbr>
 slug: Web/HTML/Reference/Elements/wbr
 l10n:
-  sourceCommit: a1765c2cad20118be0dad322d3548908787b5791
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<wbr>`** permet de représenter un emplacement où casser la ligne si nécessaire. Le navigateur pourra alors utiliser cet emplacement pour effectuer un saut de ligne si le texte est trop long et qu'en temps normal, une règle empêche le saut de ligne.

--- a/files/fr/web/html/reference/elements/xmp/index.md
+++ b/files/fr/web/html/reference/elements/xmp/index.md
@@ -1,8 +1,9 @@
 ---
-title: "<xmp> : l'élément de texte préformaté"
+title: "Élément HTML `<xmp>` : l'élément de texte préformaté"
+short-title: <xmp>
 slug: Web/HTML/Reference/Elements/xmp
 l10n:
-  sourceCommit: 0754cd805a8e010d2e3a2a065f634a3bcf358252
+  sourceCommit: 599ae8b7ad414e91df473d91983f4ffc5cafabb3
 ---
 
 {{Deprecated_Header}}


### PR DESCRIPTION
### Description

The front-matter key `title` now accept backticks. Content has updated titles to display code in title using these backticks.

### Motivation

Keep translated-content sync for updated pages

### Additional details

_none_

### Related issues and pull requests

Sync from https://github.com/mdn/content/tree/599ae8b7ad414e91df473d91983f4ffc5cafabb3
