### PR TITLE
fix(fr): fixed poisoned hash commit by parity detection

### DIFF
--- a/files/fr/web/api/element/hasattribute/index.md
+++ b/files/fr/web/api/element/hasattribute/index.md
@@ -1,13 +1,14 @@
 ---
 title: "Element : méthode hasAttribute()"
+short-title: hasAttribute()
 slug: Web/API/Element/hasAttribute
 l10n:
-  sourceCommit: 7eed0e1e4ab478d78dc7ca23c19ae77406776e4e
+  sourceCommit: 990ab6637bb4d44f059597262cbf3c51abae79eb
 ---
 
 {{APIRef("DOM")}}
 
-La méthode **`hasAttribute()`**, associée à l'interface [`Element`](/fr/docs/Web/API/Element), renvoie une **valeur booléenne** indiquant si l'élément courant possède l'attribut spécifié ou non.
+La méthode **`hasAttribute()`** de l'interface {{DOMxRef("Element")}} retourne une valeur **booléenne** indiquant si l'élément courant possède l'attribut défini ou non.
 
 ## Syntaxe
 
@@ -18,11 +19,11 @@ hasAttribute(name)
 ### Paramètres
 
 - `name`
-  - : Une chaine de caractères représentant le nom de l'attribut recherché.
+  - : Une chaîne de caractères représentant le nom de l'attribut recherché.
 
 ### Valeur de retour
 
-Un booléen indiquant la présence de l'attribut.
+Un booléen.
 
 ## Exemples
 
@@ -43,9 +44,8 @@ if (toto.hasAttribute("truc")) {
 
 ## Voir aussi
 
-- [`Element.hasAttributes()`](/fr/docs/Web/API/Element/hasAttributes)
-- [`Element.hasAttributeNS()`](/fr/docs/Web/API/Element/hasAttributeNS)
-- [`Element.getAttribute()`](/fr/docs/Web/API/Element/getAttribute)
-- [`Element.setAttribute()`](/fr/docs/Web/API/Element/setAttribute)
-- [`Element.removeAttribute()`](/fr/docs/Web/API/Element/removeAttribute)
-- [`Element.toggleAttribute()`](/fr/docs/Web/API/Element/toggleAttribute)
+- La méthode {{DOMxRef("Element.hasAttributes()")}}
+- La méthode {{DOMxRef("Element.getAttribute()")}}
+- La méthode {{DOMxRef("Element.setAttribute()")}}
+- La méthode {{DOMxRef("Element.removeAttribute()")}}
+- La méthode {{DOMxRef("Element.toggleAttribute()")}}

--- a/files/fr/web/api/element/removeattribute/index.md
+++ b/files/fr/web/api/element/removeattribute/index.md
@@ -1,13 +1,14 @@
 ---
 title: "Element : méthode removeAttribute()"
+short-title: removeAttribute()
 slug: Web/API/Element/removeAttribute
 l10n:
-  sourceCommit: 7eed0e1e4ab478d78dc7ca23c19ae77406776e4e
+  sourceCommit: 990ab6637bb4d44f059597262cbf3c51abae79eb
 ---
 
 {{APIRef("DOM")}}
 
-La méthode **`removeAttribute()`**, rattachée à l'interface [`Element`](/fr/docs/Web/API/Element), supprime l'attribut ayant le nom indiqué de l'élément.
+La méthode **`removeAttribute()`** de l'interface {{DOMxRef("Element")}} supprime l'attribut ayant le nom indiqué de l'élément.
 
 ## Syntaxe
 
@@ -17,16 +18,17 @@ removeAttribute(attrName)
 
 ### Paramètres
 
-- `nomAttribut`
+- `attrName`
   - : Une chaîne de caractères qui indique le nom de l'attribut à supprimer de l'élément. Si l'attribut indiqué n'existe pas, `removeAttribute()` finit son exécution sans générer d'erreur.
 
 ### Valeur de retour
 
-Aucune ([`undefined`](/fr/docs/Web/JavaScript/Reference/Global_Objects/undefined)).
+Aucune ({{JSxRef("undefined")}}).
 
 ## Notes d'utilisation
 
-`removeAttribute()` devrait être utilisée plutôt que de passer la valeur de l'attribut à `null` (que ce soit directement ou en appelant [`setAttribute()`](/fr/docs/Web/API/Element/setAttribute). De nombreux attributs ne fonctionneront pas comme espéré si on les passe à `null`.
+`removeAttribute()` devrait être utilisée plutôt que de passer la valeur de l'attribut à `null` que ce soit directement ou en appelant {{DOMxRef("Element.setAttribute", "setAttribute()")}}.
+De nombreux attributs ne fonctionneront pas comme espéré si on les passe à `null`.
 
 ## Exemple
 
@@ -46,9 +48,7 @@ document.getElementById("div1").removeAttribute("disabled");
 
 ## Voir aussi
 
-- [`Element.hasAttribute()`](/fr/docs/Web/API/Element/hasAttribute)
-- [`Element.getAttribute()`](/fr/docs/Web/API/Element/getAttribute)
-- [`Element.setAttribute()`](/fr/docs/Web/API/Element/setAttribute)
-- [`Element.toggleAttribute()`](/fr/docs/Web/API/Element/toggleAttribute)
-- [`Element.removeAttributeNode()`](/fr/docs/Web/API/Element/removeAttributeNode)
-- [`Element.removeAttributeNS()`](/fr/docs/Web/API/Element/removeAttributeNS)
+- La méthode {{DOMxRef("Element.hasAttribute()")}}
+- La méthode {{DOMxRef("Element.getAttribute()")}}
+- La méthode {{DOMxRef("Element.setAttribute()")}}
+- La méthode {{DOMxRef("Element.toggleAttribute()")}}

--- a/files/fr/web/css/reference/properties/font-palette/palette-mix/index.md
+++ b/files/fr/web/css/reference/properties/font-palette/palette-mix/index.md
@@ -1,8 +1,9 @@
 ---
-title: palette-mix()
+title: Fonction CSS `palette-mix()`
+short-title: palette-mix()
 slug: Web/CSS/Reference/Properties/font-palette/palette-mix
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 {{SeeCompatTable}}

--- a/files/fr/web/css/reference/values/-moz-image-rect/index.md
+++ b/files/fr/web/css/reference/values/-moz-image-rect/index.md
@@ -1,8 +1,9 @@
 ---
-title: -moz-image-rect
+title: Fonction CSS `-moz-image-rect()`
+short-title: -moz-image-rect()
 slug: Web/CSS/Reference/Values/-moz-image-rect
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 {{Non-standard_Header}}{{Deprecated_Header}}

--- a/files/fr/web/css/reference/values/anchor/index.md
+++ b/files/fr/web/css/reference/values/anchor/index.md
@@ -1,8 +1,9 @@
 ---
-title: anchor()
+title: Fonction CSS `anchor()`
+short-title: anchor()
 slug: Web/CSS/Reference/Values/anchor
 l10n:
-  sourceCommit: 3e0ba995376cace7f08f0771635f86f0fb1753b3
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`anchor()`** peut être utilisée dans les valeurs d'une [propriété d'encart](#propriétés_acceptant_les_valeurs_de_la_fonction_anchor) d'un élément **positionné par ancre**, et retourne une valeur de longueur relative à la position des bords de l'élément d'ancre associé.

--- a/files/fr/web/css/reference/values/color_value/color-mix/index.md
+++ b/files/fr/web/css/reference/values/color_value/color-mix/index.md
@@ -1,8 +1,9 @@
 ---
-title: color-mix()
+title: Fonction CSS `color-mix()`
+short-title: color-mix()
 slug: Web/CSS/Reference/Values/color_value/color-mix
 l10n:
-  sourceCommit: b272f3e0aef3030a1370f1466fa59ee97243de7a
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`color-mix()`** prend une ou plusieurs valeurs de type {{CSSxRef("&lt;color&gt;")}} et retourne le résultat de leur mélange selon des proportions données, dans un espace de couleur donné.

--- a/files/fr/web/css/reference/values/color_value/color/index.md
+++ b/files/fr/web/css/reference/values/color_value/color/index.md
@@ -1,8 +1,9 @@
 ---
-title: color()
+title: Fonction CSS `color()`
+short-title: color()
 slug: Web/CSS/Reference/Values/color_value/color
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`color()`** permet de définir une couleur dans un {{Glossary("color space", "espace colorimétrique")}} particulier, au lieu de l'espace colorimétrique sRGB implicite utilisé par la plupart des autres fonctions de couleur.

--- a/files/fr/web/css/reference/values/color_value/contrast-color/index.md
+++ b/files/fr/web/css/reference/values/color_value/contrast-color/index.md
@@ -1,8 +1,9 @@
 ---
-title: contrast-color()
+title: Fonction CSS `contrast-color()`
+short-title: contrast-color()
 slug: Web/CSS/Reference/Values/color_value/contrast-color
 l10n:
-  sourceCommit: 7c78b2ffa0f08ac11e486884fa689ff08645dda7
+  sourceCommit: a8b7faffbd3fdeae5c0be97793d963d8a31cd1cf
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`contrast-color()`** prend une valeur de type {{CSSxRef("&lt;color&gt;")}} et retourne une couleur contrastée [garantie <sup>(angl.)</sup>](https://w3c.github.io/wcag/guidelines/22/#contrast-minimum).
@@ -78,12 +79,8 @@ button {
     content: "Votre navigateur ne prend pas en charge la fonction contrast-color().";
     background-color: wheat;
     display: block;
-    width: 100%;
+    padding: 1rem 0;
     text-align: center;
-  }
-
-  body > * {
-    display: none;
   }
 }
 ```
@@ -148,16 +145,8 @@ pre {
     content: "Votre navigateur ne prend pas en charge la fonction contrast-color().";
     background-color: wheat;
     display: block;
-    width: 100%;
+    padding: 1rem 0;
     text-align: center;
-  }
-
-  body {
-    background-color: white;
-  }
-
-  body > * {
-    display: none;
   }
 }
 ```

--- a/files/fr/web/css/reference/values/color_value/device-cmyk/index.md
+++ b/files/fr/web/css/reference/values/color_value/device-cmyk/index.md
@@ -1,8 +1,9 @@
 ---
-title: device-cmyk()
+title: Fonction CSS `device-cmyk()`
+short-title: device-cmyk()
 slug: Web/CSS/Reference/Values/color_value/device-cmyk
 l10n:
-  sourceCommit: 7d0031545bb606d2ff7fb033180f9cec451a6f8d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`device-cmyk()`** permet d'exprimer des couleurs dans l'espace de couleurs CMJN (CMYK en anglais), en indiquant les composantes de cyan, de magenta, de jaune et de noir.

--- a/files/fr/web/css/reference/values/color_value/hsl/index.md
+++ b/files/fr/web/css/reference/values/color_value/hsl/index.md
@@ -1,8 +1,9 @@
 ---
-title: hsl()
+title: Fonction CSS `hsl()`
+short-title: hsl()
 slug: Web/CSS/Reference/Values/color_value/hsl
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 > [!NOTE]

--- a/files/fr/web/css/reference/values/color_value/hwb/index.md
+++ b/files/fr/web/css/reference/values/color_value/hwb/index.md
@@ -1,8 +1,9 @@
 ---
-title: hwb()
+title: Fonction CSS `hwb()`
+short-title: hwb()
 slug: Web/CSS/Reference/Values/color_value/hwb
 l10n:
-  sourceCommit: db52e840c36da02f761984001bd25b603c84ee92
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`hwb()`** exprime un {{Glossary("color space", "espace de couleur")}} {{Glossary("RGB", "sRGB")}} donné selon sa teinte, sa blancheur et sa noirceur. Une composante alpha optionnelle représente l'opacité de la couleur.

--- a/files/fr/web/css/reference/values/color_value/lab/index.md
+++ b/files/fr/web/css/reference/values/color_value/lab/index.md
@@ -1,8 +1,9 @@
 ---
-title: lab()
+title: Fonction CSS `lab()`
+short-title: lab()
 slug: Web/CSS/Reference/Values/color_value/lab
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`lab()`** exprime une couleur donnée dans {{Glossary("color space", "l'espace de couleur")}} CIE L\*a\*b\*.

--- a/files/fr/web/css/reference/values/color_value/lch/index.md
+++ b/files/fr/web/css/reference/values/color_value/lch/index.md
@@ -1,8 +1,9 @@
 ---
-title: lch()
+title: Fonction CSS `lch()`
+short-title: lch()
 slug: Web/CSS/Reference/Values/color_value/lch
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`lch()`** exprime une couleur donnée dans {{Glossary("color space", "l'espace de couleur")}} LCH, qui utilise le même axe L (luminosité) que la fonction de couleur {{CSSxRef("color_value/lab","lab()")}} de l'[espace de couleur CIELab](/fr/docs/Glossary/Color_space#espaces_de_couleur_cielab), mais utilise des coordonnées polaires C (chroma) et H (pour la teinte, <i lang="en">hue</i> en anglais).

--- a/files/fr/web/css/reference/values/color_value/light-dark/index.md
+++ b/files/fr/web/css/reference/values/color_value/light-dark/index.md
@@ -1,8 +1,9 @@
 ---
-title: light-dark()
+title: Fonction CSS `light-dark()`
+short-title: light-dark()
 slug: Web/CSS/Reference/Values/color_value/light-dark
 l10n:
-  sourceCommit: f07826b83e8d2af50d69e3ff28c527d4ef572c19
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`light-dark()`** accepte deux couleurs ou deux images et retourne une couleur ou une image en fonction du schéma de couleurs actif, sans avoir besoin d'une [fonctionnalité média](/fr/docs/Web/CSS/Guides/Media_queries/Using#cibler_des_types_de_média) [`prefers-color-scheme`](/fr/docs/Web/CSS/Reference/At-rules/@media/prefers-color-scheme).

--- a/files/fr/web/css/reference/values/color_value/oklab/index.md
+++ b/files/fr/web/css/reference/values/color_value/oklab/index.md
@@ -1,8 +1,9 @@
 ---
-title: oklab()
+title: Fonction CSS `oklab()`
+short-title: oklab()
 slug: Web/CSS/Reference/Values/color_value/oklab
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`oklab()`** exprime une couleur donnée dans {{Glossary("color space", "l'espace de couleur")}} OKLab, qui essaie de se rapprocher de la perception de la couleur par l'œil humain.

--- a/files/fr/web/css/reference/values/color_value/oklch/index.md
+++ b/files/fr/web/css/reference/values/color_value/oklch/index.md
@@ -1,8 +1,9 @@
 ---
-title: oklch()
+title: Fonction CSS `oklch()`
+short-title: oklch()
 slug: Web/CSS/Reference/Values/color_value/oklch
 l10n:
-  sourceCommit: 33094d735e90b4dcae5733331b79c51fee997410
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction de type `<color>`](/fr/docs/Web/CSS/Reference/Values/Functions#les_fonctions_de_couleur) [CSS](/fr/docs/Web/CSS) **`oklch()`** exprime une couleur donnée dans {{Glossary("color space", "l'espace de couleur")}} OKLCH. `oklch()` est la forme cylindrique de {{CSSxRef("color_value/oklab", "oklab()")}}, utilisant le même axe `L`, mais avec des coordonnées polaires Chroma (`C`) et teinte (`h` pour <i lang="en">hue</i> en anglais).

--- a/files/fr/web/css/reference/values/color_value/rgb/index.md
+++ b/files/fr/web/css/reference/values/color_value/rgb/index.md
@@ -1,8 +1,9 @@
 ---
-title: rgb()
+title: Fonction CSS `rgb()`
+short-title: rgb()
 slug: Web/CSS/Reference/Values/color_value/rgb
 l10n:
-  sourceCommit: 8fd626a7b7f1fcb19193325bbac5b87e719f83ea
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 > [!NOTE]

--- a/files/fr/web/css/reference/values/easing-function/steps/index.md
+++ b/files/fr/web/css/reference/values/easing-function/steps/index.md
@@ -1,9 +1,9 @@
 ---
-title: steps()
+title: Fonction CSS `steps()`
+short-title: steps()
 slug: Web/CSS/Reference/Values/easing-function/steps
-original_slug: Web/CSS/easing-function/steps
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`steps()`** définit une transition qui divise le temps d'entrée en un nombre spécifié d'intervalles de même longueur. Cette sous-classe de fonctions en étapes est parfois aussi appelée _fonction en escalier_.

--- a/files/fr/web/css/reference/values/gradient/repeating-conic-gradient/index.md
+++ b/files/fr/web/css/reference/values/gradient/repeating-conic-gradient/index.md
@@ -1,8 +1,9 @@
 ---
-title: repeating-conic-gradient()
+title: Fonction CSS `repeating-conic-gradient()`
+short-title: repeating-conic-gradient()
 slug: Web/CSS/Reference/Values/gradient/repeating-conic-gradient
 l10n:
-  sourceCommit: b1bc04e2aedcaa50c55fb54686fb7855fdcbfc4e
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`repeating-conic-gradient()`** crée une image composée d'un dégradé conique répété (plutôt qu'un [dégradé unique](/fr/docs/Web/CSS/Reference/Values/gradient/conic-gradient)), avec des transitions de couleurs qui tournent autour d'un point central (plutôt que de [rayonner depuis le centre](/fr/docs/Web/CSS/Reference/Values/gradient/repeating-radial-gradient)).

--- a/files/fr/web/css/reference/values/transform-function/matrix/index.md
+++ b/files/fr/web/css/reference/values/transform-function/matrix/index.md
@@ -1,8 +1,9 @@
 ---
-title: matrix()
+title: Fonction CSS `matrix()`
+short-title: matrix()
 slug: Web/CSS/Reference/Values/transform-function/matrix
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`matrix()`** définit une matrice de transformation homogène en 2D. Son résultat est un type de donnée {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/matrix3d/index.md
+++ b/files/fr/web/css/reference/values/transform-function/matrix3d/index.md
@@ -1,8 +1,9 @@
 ---
-title: matrix3d()
+title: Fonction CSS `matrix3d()`
+short-title: matrix3d()
 slug: Web/CSS/Reference/Values/transform-function/matrix3d
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`matrix3d()`** définit une transformation 3D sous forme de matrice homogène 4x4.

--- a/files/fr/web/css/reference/values/transform-function/perspective/index.md
+++ b/files/fr/web/css/reference/values/transform-function/perspective/index.md
@@ -1,8 +1,9 @@
 ---
-title: perspective()
+title: Fonction CSS `perspective()`
+short-title: perspective()
 slug: Web/CSS/Reference/Values/transform-function/perspective
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`perspective()`** définit une transformation qui fixe la distance entre l'utilisateur·ice et le plan z=0, soit la perspective depuis laquelle l'interface bidimensionnelle serait perçue comme tridimensionnelle. Son résultat est un type de donnée {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/rotate/index.md
+++ b/files/fr/web/css/reference/values/transform-function/rotate/index.md
@@ -1,8 +1,9 @@
 ---
-title: rotate()
+title: Fonction CSS `rotate()`
+short-title: rotate()
 slug: Web/CSS/Reference/Values/transform-function/rotate
 l10n:
-  sourceCommit: 8fd626a7b7f1fcb19193325bbac5b87e719f83ea
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`rotate()`** définit une transformation qui fait pivoter un élément autour d'un point fixe du plan 2D, sans le déformer. Son résultat est un type de donnée {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/rotate3d/index.md
+++ b/files/fr/web/css/reference/values/transform-function/rotate3d/index.md
@@ -1,8 +1,9 @@
 ---
-title: rotate3d()
+title: Fonction CSS `rotate3d()`
+short-title: rotate3d()
 slug: Web/CSS/Reference/Values/transform-function/rotate3d
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`rotate3d()`** définit une transformation qui fait pivoter un élément autour d'un axe fixe dans l'espace 3D, sans le déformer. Son résultat est un type de donnée {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/rotatex/index.md
+++ b/files/fr/web/css/reference/values/transform-function/rotatex/index.md
@@ -1,8 +1,9 @@
 ---
-title: rotateX()
+title: Fonction CSS `rotateX()`
+short-title: rotateX()
 slug: Web/CSS/Reference/Values/transform-function/rotateX
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`rotateX()`** définit une transformation qui fait pivoter un élément autour de l'axe x (horizontal) sans le déformer. Son résultat est un type de donnée {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/rotatey/index.md
+++ b/files/fr/web/css/reference/values/transform-function/rotatey/index.md
@@ -1,8 +1,9 @@
 ---
-title: rotateY()
+title: Fonction CSS `rotateY()`
+short-title: rotateY()
 slug: Web/CSS/Reference/Values/transform-function/rotateY
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`rotateY()`** définit une transformation qui fait pivoter un élément autour de l'axe y (vertical) sans le déformer. Son résultat est un type de donnée {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/rotatez/index.md
+++ b/files/fr/web/css/reference/values/transform-function/rotatez/index.md
@@ -1,8 +1,9 @@
 ---
-title: rotateZ()
+title: Fonction CSS `rotateZ()`
+short-title: rotateZ()
 slug: Web/CSS/Reference/Values/transform-function/rotateZ
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`rotateZ()`** définit une transformation qui fait pivoter un élément autour de l'axe z sans le déformer. Son résultat est un type de donnée {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/scale/index.md
+++ b/files/fr/web/css/reference/values/transform-function/scale/index.md
@@ -1,8 +1,9 @@
 ---
-title: scale()
+title: Fonction CSS `scale()`
+short-title: scale()
 slug: Web/CSS/Reference/Values/transform-function/scale
 l10n:
-  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`scale()`** définit une transformation qui redimensionne un élément dans le plan 2D. Comme la quantité de mise à l'échelle est définie par un vecteur [sx, sy], elle peut redimensionner les dimensions horizontale et verticale à des échelles différentes. Son résultat est un type de donnée {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/scale3d/index.md
+++ b/files/fr/web/css/reference/values/transform-function/scale3d/index.md
@@ -1,8 +1,9 @@
 ---
-title: scale3d()
+title: Fonction CSS `scale3d()`
+short-title: scale3d()
 slug: Web/CSS/Reference/Values/transform-function/scale3d
 l10n:
-  sourceCommit: 8fd626a7b7f1fcb19193325bbac5b87e719f83ea
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`scale3d()`** définit une transformation qui redimensionne un élément dans l'espace 3D.

--- a/files/fr/web/css/reference/values/transform-function/scalex/index.md
+++ b/files/fr/web/css/reference/values/transform-function/scalex/index.md
@@ -1,8 +1,9 @@
 ---
-title: scaleX()
+title: Fonction CSS `scaleX()`
+short-title: scaleX()
 slug: Web/CSS/Reference/Values/transform-function/scaleX
 l10n:
-  sourceCommit: 8fd626a7b7f1fcb19193325bbac5b87e719f83ea
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`scaleX()`** définit une transformation qui redimensionne un élément selon l'axe des abscisses (horizontalement). Son résultat est de type {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/scaley/index.md
+++ b/files/fr/web/css/reference/values/transform-function/scaley/index.md
@@ -1,8 +1,9 @@
 ---
-title: scaleY()
+title: Fonction CSS `scaleY()`
+short-title: scaleY()
 slug: Web/CSS/Reference/Values/transform-function/scaleY
 l10n:
-  sourceCommit: 8fd626a7b7f1fcb19193325bbac5b87e719f83ea
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`scaleY()`** définit une transformation qui redimensionne un élément selon l'axe des ordonnées (verticalement). Son résultat est de type {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/scalez/index.md
+++ b/files/fr/web/css/reference/values/transform-function/scalez/index.md
@@ -1,8 +1,9 @@
 ---
-title: scaleZ()
+title: Fonction CSS `scaleZ()`
+short-title: scaleZ()
 slug: Web/CSS/Reference/Values/transform-function/scaleZ
 l10n:
-  sourceCommit: 8fd626a7b7f1fcb19193325bbac5b87e719f83ea
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`scaleZ()`** définit une transformation qui redimensionne un élément selon l'axe des z. Son résultat est de type {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/skew/index.md
+++ b/files/fr/web/css/reference/values/transform-function/skew/index.md
@@ -1,8 +1,9 @@
 ---
-title: skew()
+title: Fonction CSS `skew()`
+short-title: skew()
 slug: Web/CSS/Reference/Values/transform-function/skew
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`skew()`** définit une transformation qui incline un élément dans le plan 2D. Son résultat est de type {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/skewx/index.md
+++ b/files/fr/web/css/reference/values/transform-function/skewx/index.md
@@ -1,8 +1,9 @@
 ---
-title: skewX()
+title: Fonction CSS `skewX()`
+short-title: skewX()
 slug: Web/CSS/Reference/Values/transform-function/skewX
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`skewX()`** définit une transformation qui incline un élément dans la direction horizontale sur le plan 2D. Son résultat est un type de donnée {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/skewy/index.md
+++ b/files/fr/web/css/reference/values/transform-function/skewy/index.md
@@ -1,8 +1,9 @@
 ---
-title: skewY()
+title: Fonction CSS `skewY()`
+short-title: skewY()
 slug: Web/CSS/Reference/Values/transform-function/skewY
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`skewY()`** définit une transformation qui incline un élément dans la direction verticale sur le plan 2D. Son résultat est un type de donnée {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/translate/index.md
+++ b/files/fr/web/css/reference/values/transform-function/translate/index.md
@@ -1,8 +1,9 @@
 ---
-title: translate()
+title: Fonction CSS `translate()`
+short-title: translate()
 slug: Web/CSS/Reference/Values/transform-function/translate
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`translate()`** repositionne un élément dans les directions horizontale et/ou verticale. Son résultat est de type {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/translate3d/index.md
+++ b/files/fr/web/css/reference/values/transform-function/translate3d/index.md
@@ -1,8 +1,9 @@
 ---
-title: translate3d()
+title: Fonction CSS `translate3d()`
+short-title: translate3d()
 slug: Web/CSS/Reference/Values/transform-function/translate3d
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`translate3d()`** repositionne un élément dans l'espace 3D. Son résultat est de type {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/translatex/index.md
+++ b/files/fr/web/css/reference/values/transform-function/translatex/index.md
@@ -1,8 +1,9 @@
 ---
-title: translateX()
+title: Fonction CSS `translateX()`
+short-title: translateX()
 slug: Web/CSS/Reference/Values/transform-function/translateX
 l10n:
-  sourceCommit: 8fd626a7b7f1fcb19193325bbac5b87e719f83ea
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`translateX()`** repositionne un élément horizontalement sur le plan 2D. Son résultat est de type {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/translatey/index.md
+++ b/files/fr/web/css/reference/values/transform-function/translatey/index.md
@@ -1,8 +1,9 @@
 ---
-title: translateY()
+title: Fonction CSS `translateY()`
+short-title: translateY()
 slug: Web/CSS/Reference/Values/transform-function/translateY
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`translateY()`** repositionne un élément verticalement sur le plan 2D. Son résultat est de type {{CSSxRef("&lt;transform-function&gt;")}}.

--- a/files/fr/web/css/reference/values/transform-function/translatez/index.md
+++ b/files/fr/web/css/reference/values/transform-function/translatez/index.md
@@ -1,8 +1,9 @@
 ---
-title: translateZ()
+title: Fonction CSS `translateZ()`
+short-title: translateZ()
 slug: Web/CSS/Reference/Values/transform-function/translateZ
 l10n:
-  sourceCommit: f69b6693212029ce4b9fa0c753729044577af548
+  sourceCommit: b760560abe30bd69ca968dac38528102f423b5ea
 ---
 
 La [fonction](/fr/docs/Web/CSS/Reference/Values/Functions) [CSS](/fr/docs/Web/CSS) **`translateZ()`** repositionne un élément le long de l'axe z dans l'espace 3D, c'est-à-dire plus près ou plus loin de l'utilisateur·ice. Son résultat est de type {{CSSxRef("&lt;transform-function&gt;")}}.


### PR DESCRIPTION
### Description

Fixing page detected as poisoned hask commit key with invalid parity.

Like : Parity 0 but diff in hash key
Like : Parity -1 (hash not existe on file history)

Detection made by https://tristantheb.github.io/history-content/?lang=fr parity filter (status)

### Motivation

Update access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_