### PR TITLE
[ja] docs(uri): blob URL例の表記を調整

### DIFF
--- a/files/ja/web/uri/reference/schemes/blob/index.md
+++ b/files/ja/web/uri/reference/schemes/blob/index.md
@@ -65,7 +65,7 @@ blob:https://example.org/40a5fb5a-d56d-4a33-b4e2-0acf6a8e5f64
 
 ### blob URL の作成
 
-この例では、まず {{domxref("Blob")}} を {{HTMLElement("canvas")}} から作成し、それに　blob URL を作成し、最後にその URL を {{HTMLElement("img")}} 要素に添付します。
+この例では、まず {{domxref("Blob")}} を {{HTMLElement("canvas")}} から作成し、それに blob URL を作成し、最後にその URL を {{HTMLElement("img")}} 要素に添付します。
 
 ```js
 const canvas = document.querySelector("canvas");


### PR DESCRIPTION
### Description
全角・半角の空白表記を調整しました。

### Motivation

### Additional details
関連ページ

• 英語: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/blob
• 日本語: https://developer.mozilla.org/ja/docs/Web/URI/Reference/Schemes/blob

### Related issues and pull requests
なし