### PR TITLE
fix(fr): correction du nom de propriété attribLocations dans Using textures in WebGL

### DIFF
--- a/files/fr/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -252,14 +252,14 @@ Tout d'abord, le code pour spécifier le tampon de couleurs a disparu, remplacé
   const offset = 0; // à combien d'octets du début faut-il commencer
   gl.bindBuffer(gl.ARRAY_BUFFER, buffers.textureCoord);
   gl.vertexAttribPointer(
-    programInfo.attributeLocations.textureCoord,
+    programInfo.attribLocations.textureCoord,
     num,
     type,
     normalize,
     stride,
     offset,
   );
-  gl.enableVertexAttribArray(programInfo.attributeLocations.textureCoord);
+  gl.enableVertexAttribArray(programInfo.attribLocations.textureCoord);
 }
 ```
 


### PR DESCRIPTION
### Description
Le code utilise `programInfo.attributeLocations.textureCoord`, alors que la propriété définie sur l'objet `programInfo` est `attribLocations` (sans le "ute"). En suivant le tutoriel tel quel, le code ne fonctionne donc pas.

### Additional details

J'ai aligné la traduction française sur la version anglaise source, qui utilise bien `attribLocations`. Les autres pages du même tutoriel en français (Adding 2D content, Creating 3D objects) utilisent déjà la forme correcte.

Fixes #35737
