### PR TITLE
[ja] docs(uri): javascript URLページの表記を調整

### DIFF
--- a/files/ja/web/uri/reference/schemes/javascript/index.md
+++ b/files/ja/web/uri/reference/schemes/javascript/index.md
@@ -28,7 +28,7 @@ javascript:<script>
 
 - `<a>` または `<area>` 要素の [`href`](/ja/docs/Web/HTML/Reference/Elements/a#href) 属性。
 - `<form>` 要素の [`action`](/ja/docs/Web/HTML/Reference/Elements/form#action) 属性。
-- `<iframe>`要素の [`src`](/ja/docs/Web/HTML/Reference/Elements/iframe#src) 属性。
+- `<iframe>` 要素の [`src`](/ja/docs/Web/HTML/Reference/Elements/iframe#src) 属性。
 - JavaScript の [`window.location`](/ja/docs/Web/API/Window/location) プロパティ。
 - ブラウザーのアドレスバー自体。
 


### PR DESCRIPTION
### Description
`javascript:` URL ページの説明リスト内で、`<iframe>` 要素の行だけ半角スペースが抜けていたため、前後の行と表記を揃えました。
他の行との整合を取る形で調整しています。

### Motivation

### Additional details
関連ページ

• 英語: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/javascript
• 日本語: https://developer.mozilla.org/ja/docs/Web/URI/Reference/Schemes/javascript

### Related issues and pull requests
なし