### PR TITLE
zh-cn: update mismatched screenshot for `console.group` example

### DIFF
--- a/files/zh-cn/web/api/console/index.md
+++ b/files/zh-cn/web/api/console/index.md
@@ -180,13 +180,13 @@ console.log(
 
 ```js
 console.log("This is the outer level");
-console.group();
-console.log("Level 2");
-console.group();
-console.log("Level 3");
-console.warn("More of level 3");
+console.group("First group");
+console.log("In the first group");
+console.group("Second group");
+console.log("In the second group");
+console.warn("Still in the second group");
 console.groupEnd();
-console.log("Back to level 2");
+console.log("Back to the first group");
 console.groupEnd();
 console.debug("Back to the outer level");
 ```

--- a/files/zh-cn/web/api/console/index.md
+++ b/files/zh-cn/web/api/console/index.md
@@ -176,7 +176,7 @@ console.log(
 
 可以使用嵌套组来把视觉上相关的元素合并，以协助组织你的输出。使用`console.group()`创建新的嵌套块，或者用`console.groupCollapsed()` 创建默认折叠的块，这种块需要点击闭合按钮来展开才能读到。
 
-直接调用 `console.groupEnd()`.就可以退出当前组。比如下面的代码：
+直接调用 `console.groupEnd()` 就可以退出当前组。比如下面的代码：
 
 ```js
 console.log("This is the outer level");


### PR DESCRIPTION
### Description

Fixed the mismatch between the example code and the output screenshot in the `console.group()` documentation.

---

<img width="1008" height="863" alt="屏幕截图 2026-05-09 154714" src="https://github.com/user-attachments/assets/5f99ca11-5e7f-4ba5-859e-cef797b4a2e2" />

---

<img width="995" height="811" alt="屏幕截图 2026-05-09 154722" src="https://github.com/user-attachments/assets/8b62768a-0fde-4b94-80f3-cae6fbd69edd" />
