### PR TITLE
[ja] docs(html): a要素ページの文言を調整

### DIFF
--- a/files/ja/web/html/reference/elements/a/index.md
+++ b/files/ja/web/html/reference/elements/a/index.md
@@ -36,7 +36,7 @@ li {
 - `attributionsrc` {{experimental_inline}}
   - : ブラウザーが {{httpheader("Attribution-Reporting-Eligible")}} ヘッダーを送信することを指定します。サーバー側では、これはレスポンスで {{httpheader("Attribution-Reporting-Register-Source")}} ヘッダーの送信を開始し、[ナビゲーションベースのアトリビューションソース](/ja/docs/Web/API/Attribution_Reporting_API/Registering_sources#navigation-based_attribution_sources)を登録するために使用します。
 
-    ブラウザーは、ユーザーがリンクをクリックすると、ナビゲーションベースのアトリビューションソース（{{httpheader("Attribution-Reporting-Register-Source")}} レスポンスヘッダーで指定された）に関連付けられたソースデータを格納されます。詳細は[アトリビューション報告 API](/ja/docs/Web/API/Attribution_Reporting_API) を参照してください。
+    ブラウザーは、ユーザーがリンクをクリックすると、ナビゲーションベースのアトリビューションソース（{{httpheader("Attribution-Reporting-Register-Source")}} レスポンスヘッダーで指定された）に関連付けられたソースデータを格納します。詳細は[アトリビューション報告 API](/ja/docs/Web/API/Attribution_Reporting_API) を参照してください。
 
     この属性には設定することができる 2 つのバージョンがあります：
     - 論理値、つまり `attributionsrc` の名前だけです。これは、{{httpheader("Attribution-Reporting-Eligible")}} ヘッダーを、`href` 属性がこの点を指すのと同じサーバーに送ることを指定します。同じサーバーでアトリビューションソースの登録を処理している場合は、これで問題ありません。


### PR DESCRIPTION
### Description
英語原文を正として、`attributionsrc` 属性の説明で、ブラウザーが主語であるにもかかわらず受け身形になっていた `を格納されます` を、能動形 `を格納します` に調整しました。

英語原文: "The browser stores the source data associated with..."

### Motivation

### Additional details
関連ページ
- 英語: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a
- 日本語: https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Elements/a

### Related issues and pull requests
なし