### PR TITLE
[ja] docs(html): readonly属性ページの文言を調整

### DIFF
--- a/files/ja/web/html/reference/attributes/readonly/index.md
+++ b/files/ja/web/html/reference/attributes/readonly/index.md
@@ -39,7 +39,7 @@ textarea:read-only {
 
 `readonly` 属性が input 要素に指定された場合、その入力欄をユーザーが編集できないので、その要素は制約検証が行われません。
 
-`readonly` 属性は、次のようなテキストのフォームコントロールで対応してます。
+`readonly` 属性は、次のようなテキストのフォームコントロールで対応しています。
 
 - {{HTMLElement("input")}} 要素の型:
   - `{{HTMLElement("input/text","text")}}`


### PR DESCRIPTION
### Description
`対応してます` を `対応しています` に調整しました。

### Motivation

### Additional details
関連ページ
- 英語: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/readonly
- 日本語: https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Attributes/readonly

### Related issues and pull requests
なし