### PR TITLE
[ja] docs(http): MIME タイプの文言を調整

### DIFF
--- a/files/ja/web/http/index.md
+++ b/files/ja/web/http/index.md
@@ -32,8 +32,8 @@ HTTP は拡張可能なプロトコルであり、リソースや統一リソー
     この記事では、この一般的な構造、その目的、およびさまざまな種類のメッセージについて説明します。
 - [MIME タイプ](/ja/docs/Web/HTTP/Guides/MIME_types)
   - : HTTP/1.0 以降、さまざまな種類のコンテンツを送信することが可能になりました。
-    この記事では、{{HTTPHeader("Content-Type")}} ヘッダーと MIME 標準を用いて、これがどのように実現されるかを説明します。
-    ウェブ開発者がよく使用する一般的な MIME タイプのリストは、[一般的な MIME タイプ](/ja/docs/Web/HTTP/Guides/MIME_types/Common_types)でご覧いただけます。
+    この記事では、これが {{HTTPHeader("Content-Type")}} ヘッダーと MIME 標準を用いてどのように実現されているかを説明します。
+    ウェブ開発者がよく使用する MIME タイプの一覧は、[一般的な MIME タイプ](/ja/docs/Web/HTTP/Guides/MIME_types/Common_types)でご覧いただけます。
 - [HTTP の圧縮](/ja/docs/Web/HTTP/Guides/Compression)
   - : ブラウザーやサーバーは、ネットワーク経由でメッセージを送信する前に圧縮を行い、送信する必要があるデータを縮小することで、転送速度と帯域幅の利用効率を改善します。
 - [HTTP キャッシュ](/ja/docs/Web/HTTP/Guides/Caching)


### PR DESCRIPTION
### Description

1. 指示語「これが」の位置を調整し、指示語が指すもの「さまざまな種類のコンテンツの送信」が明確に伝わるよう調整しました。
2. `A shortlist of common types used by web developers` を「ウェブ開発者がよく使用する（MIME）タイプの一覧」と翻訳しました。

### Motivation

### Additional details

該当部分の原文:
`Since HTTP/1.0, different types of content can be transmitted. This article explains how this is accomplished using the Content-Type header and the MIME standard. A shortlist of common types used by web developers can be found in Common MIME types.`

- `A shortlist of common types used by web developers` は直訳すると「ウェブ開発者に使用される代表的な（MIME）タイプの一覧」になると思いますが、日本語の読みやすさを優先して「ウェブ開発者がよく使用する（MIME）タイプの一覧」と翻訳しました。

### Related issues and pull requests
なし