### PR TITLE
fix(fr): broken macros, links causing `page(Doc)` flaws

### DIFF
--- a/files/fr/learn_web_development/core/css_layout/introduction/index.md
+++ b/files/fr/learn_web_development/core/css_layout/introduction/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Core/CSS_layout/Introduction
 original_slug: Learn/CSS/CSS_layout/Introduction
 ---
 
-{{LearnSidebar}}{{NextMenu("Apprendre/CSS/CSS_layout/Normal_Flow", "Apprendre/CSS/CSS_layout")}}
+{{NextMenu("Learn_web_development/Core/CSS_layout/Floats", "Learn_web_development/Core/CSS_layout")}}
 
 Cet article récapitule quelques fonctionnalités de mise en page CSS que l'on a déjà côtoyées dans les modules précédents — telles que les différentes valeurs de {{cssxref("display")}} — et en introduit de nouveaux que nous aborderons dans ce module.
 
@@ -13,12 +13,11 @@ Cet article récapitule quelques fonctionnalités de mise en page CSS que l'on a
     <tr>
       <th scope="row">Prérequis&nbsp;:</th>
       <td>
-        Les fondamentaux du HTML (étudiez
-        <a href="/fr/Apprendre/HTML/Introduction_à_HTML"
-          >Introduction au HTML</a
-        >) et avoir une idée de la manière dont la CSS fonctionne (étudiez
-        <a href="/fr/Apprendre/CSS/Introduction_à_CSS">Introduction aux CSS</a
-        >).
+        <a href="/fr/docs/Learn_web_development/Core/Structuring_content"
+          >Structurer le contenu avec HTML</a
+        >,
+        <a href="/fr/docs/Learn_web_development/Core/Styling_basics">Mises en forme CSS de base</a>,
+        <a href="/fr/docs/Learn_web_development/Core/Text_styling/Fundamentals">Mise en forme de base du texte et de la police</a>.
       </td>
     </tr>
     <tr>
@@ -776,4 +775,4 @@ body {
 
 Cet article donne un bref résumé de toutes les techniques de mise en page à connaître. Poursuivez la lecture pour en savoir plus à propos de chaque technique !
 
-{{NextMenu("Apprendre/CSS/CSS_layout/Floats", "Apprendre/CSS/CSS_layout")}}
+{{NextMenu("Learn_web_development/Core/CSS_layout/Floats", "Learn_web_development/Core/CSS_layout")}}

--- a/files/fr/learn_web_development/extensions/performance/css/index.md
+++ b/files/fr/learn_web_development/extensions/performance/css/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Extensions/Performance/CSS
 original_slug: Learn/Performance/CSS
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Extensions/Performance/HTML", "Learn/Performance/fonts", "Learn_web_development/Extensions/Performance")}}
+{{PreviousMenuNext("Learn_web_development/Extensions/Performance/HTML", "Learn_web_development/Extensions/Performance/business_case_for_performance", "Learn_web_development/Extensions/Performance")}}
 
 Peindre une page non stylisée, puis la repeindre une fois les styles analysés constituerait une mauvaise expérience pour l'utilisateur. C'est pourquoi les feuilles de style CSS bloquent le rendu, sauf si le navigateur sait que les feuilles de style CSS ne sont pas nécessaires. Le navigateur peut peindre la page une fois qu'il a téléchargé le CSS et construit le modèle objet CSS. Les navigateurs suivent un chemin de rendu spécifique : la peinture n'intervient qu'après la mise en page, qui intervient après la création de l'arbre de rendu, qui nécessite à son tour les arbres DOM et CSSOM. Pour optimiser la construction du CSSOM, il faut supprimer les styles inutiles, les minifier, les compresser et les mettre en cache, et répartir les CSS qui ne sont pas nécessaires au chargement de la page dans des fichiers supplémentaires afin de réduire le blocage du rendu CSS.
 
@@ -67,8 +67,8 @@ Optimiser les performances en CSS revient ainsi à améliorer deux étapes cruci
 
 Enfin, les outils de développement du navigateur sont à votre disposition pour vous aider à cibler les étapes chronophages qui ralentissent le rendu de vos pages et gagner encore en efficacité, au prix parfois de quelques compromis.
 
-{{PreviousMenuNext("Learn_web_development/Extensions/Performance/HTML", "Learn/Performance/fonts", "Learn_web_development/Extensions/Performance")}}
-
 ## Voir aussi
 
 - [CSS animation performance](/fr/docs/Web/Performance/CSS_JavaScript_animation_performance)
+
+{{PreviousMenuNext("Learn_web_development/Extensions/Performance/HTML", "Learn_web_development/Extensions/Performance/business_case_for_performance", "Learn_web_development/Extensions/Performance")}}

--- a/files/fr/web/api/canvas_api/tutorial/optimizing_canvas/index.md
+++ b/files/fr/web/api/canvas_api/tutorial/optimizing_canvas/index.md
@@ -3,7 +3,7 @@ title: Optimiser les Canvas
 slug: Web/API/Canvas_API/Tutorial/Optimizing_canvas
 ---
 
-{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility", "Web/API/Canvas_API/Tutorial/Finale")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas", "Web/API/Canvas_API/Tutorial/Finale")}}
 
 L'élément {{HTMLElement("canvas")}} est l'un des standards les plus utilisés pour le rendu graphique 2D sur le web. Il est surtout utilisé dans les jeux et les visualisations complexes. Cependant, les sites et applications web poussent les canvas à leurs limites, et les performances commencent à en pâtir. Cet article propose des suggestions pour optimiser votre utilisation de l'élément canvas, et pour être certain que votre site ou application web fonctionne bien.
 
@@ -117,4 +117,4 @@ Si le canvas n'a pas besoin de transparence, ajouter l'attribut `moz-opaque` dan
 - [Improving HTML5 Canvas Performance – HTML5 Rocks](https://www.html5rocks.com/en/tutorials/canvas/performance/#toc-ref)
 - [Optimizing your JavaScript game for Firefox OS – Mozilla Hacks](https://hacks.mozilla.org/2013/05/optimizing-your-javascript-game-for-firefox-os/)
 
-{{PreviousNext("Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility", "Web/API/Canvas_API/Tutorial/Finale")}}
+{{PreviousNext("Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas", "Web/API/Canvas_API/Tutorial/Finale")}}

--- a/files/fr/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/fr/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -3,7 +3,7 @@ title: Manipulation de pixels avec canvas
 slug: Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas
 ---
 
-{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Advanced_animations", "Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Advanced_animations", "Web/API/Canvas_API/Tutorial/Optimizing_canvas")}}
 
 Jusqu'à présent, nous n'avons pas examiné dans le détail les pixels réels de notre canevas. Avec l'objet ImageData, vous pouvez directement lire et écrire dans le tableau de données de l'image, pour manipuler les pixels un par un. Nous verrons également comment le lissage (anticrénelage) de l'image peut être contrôlé et comment sauvegarder des images depuis votre canevas.
 
@@ -267,9 +267,9 @@ L' {{domxref ("HTMLCanvasElement")}} fournit une méthode `toDataURL ()`, utile 
 - {{domxref("HTMLCanvasElement.toDataURL", "canvas.toDataURL('image/jpeg', quality)")}}
   - : Crée une image JPG. En option, vous pouvez fournir une qualité comprise entre 0 et 1, 1 étant de la meilleure qualité et 0 presque non reconnaissable mais de petite taille.
 
-Une fois que vous avez généré un URI de données à partir de votre canevas, vous pouvez l'utiliser comme source de {{HTMLElement ("image")}} ou le mettre dans un lien hypertexte avec un attribut de téléchargement pour l'enregistrer sur le disque par exemple.
+Une fois que vous avez généré un URI de données à partir de votre canevas, vous pouvez l'utiliser comme source de {{HTMLElement("img")}} ou le mettre dans un lien hypertexte avec un attribut de téléchargement pour l'enregistrer sur le disque par exemple.
 
-Vous pouvez également créer un {{domxref ("Blob")}} à partir du canevas.
+Vous pouvez également créer un {{domxref("Blob")}} à partir du canevas.
 
 - {{domxref("HTMLCanvasElement.toBlob", "canvas.toBlob(callback, type, encoderOptions)")}}
   - : Crée un objet `Blob` représentant l'image contenue dans le canevas.
@@ -280,4 +280,4 @@ Vous pouvez également créer un {{domxref ("Blob")}} à partir du canevas.
 - [Manipulating video using canvas](/fr/docs/Web/API/Canvas_API/Manipulating_video_using_canvas)
 - [Canevas, images et pixels – par Christian Heilmann (en)](https://codepo8.github.io/canvas-images-and-pixels/)
 
-{{PreviousNext("Web/API/Canvas_API/Tutorial/Advanced_animations", "Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility")}}
+{{PreviousNext("Web/API/Canvas_API/Tutorial/Advanced_animations", "Web/API/Canvas_API/Tutorial/Optimizing_canvas")}}

--- a/files/fr/web/api/canvas_api/tutorial/transformations/index.md
+++ b/files/fr/web/api/canvas_api/tutorial/transformations/index.md
@@ -3,7 +3,7 @@ title: Transformations
 slug: Web/API/Canvas_API/Tutorial/Transformations
 ---
 
-{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Using_images", " Web/API/Canvas_API/Tutorial/Compositing ")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Using_images", "Web/API/Canvas_API/Tutorial/Compositing")}}
 
 Précédemment dans ce tutoriel, nous avons étudié la [grille du canevas](/fr/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes) et le **système de coordonnées**. Jusqu'à maintenant, nous avons uniquement utilisé la grille par défaut et modifié la taille de la globalité du canevas afin de répondre à nos besoins. Les transformations que nous allons aborder dans la suite vont nous permettre, de manière plus puissante, d'effectuer des déplacements et des rotations sur la grille et même d'effectuer des mises à l'échelle.
 

--- a/files/fr/web/api/webgl_api/by_example/index.md
+++ b/files/fr/web/api/webgl_api/by_example/index.md
@@ -3,7 +3,7 @@ title: WebGL par l'exemple
 slug: Web/API/WebGL_API/By_example
 ---
 
-{{Next("Apprendre/WebGL/Par_exemple/Détecter_WebGL")}}
+{{DefaultAPISidebar("WebGL")}}{{Next("Web/API/WebGL_API/By_example/Detect_WebGL")}}
 
 _WebGL par l'exemple_ est une série d'articles illustrant les concepts et les possibilités offertes par WebGL. Chaque exemple est accompagné d'explications. Ces démonstrations sont triés par sujet et par niveau de difficulté. Les concepts abordés sont, entre autres, le contexte de rendu, la programmation avec les _shaders_, les textures, la géométrie et l'interaction avec les utilisateurs.
 
@@ -52,4 +52,4 @@ Les exemples sont expliqués, avec des commentaires dans le code et des paragrap
 - [Les textures vidéos](/fr/docs/Web/API/WebGL_API/By_example/Video_textures)
   - : Dans cet exemple, on voit comment utiliser des fichiers vidéos comme des textures.
 
-{{Next("Apprendre/WebGL/Par_exemple/Détecter_WebGL")}}
+{{Next("Web/API/WebGL_API/By_example/Detect_WebGL")}}

--- a/files/fr/web/css/guides/display/flow_layout_and_overflow/index.md
+++ b/files/fr/web/css/guides/display/flow_layout_and_overflow/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Display/Flow_layout_and_overflow
 original_slug: Web/CSS/CSS_display/Flow_layout_and_overflow
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/CSS/CSS_Flow_Layout/")}}
-
 Lorsque le conteneur est trop petit pour son contenu, on obtient une situation de dépassement. Le comportement du dépassement est importante dès qu'on manipule des objets CSS dont la taille est contrainte. Dans ce guide, nous verrons le fonctionnement du dépassement avec le flux normal.
 
 ## Qu'est-ce que le dépassement ?

--- a/files/fr/web/css/guides/display/flow_layout_and_writing_modes/index.md
+++ b/files/fr/web/css/guides/display/flow_layout_and_writing_modes/index.md
@@ -77,5 +77,3 @@ Dans la plupart des cas, la disposition de flux fonctionne comme on s'y attend l
 ## Ressources externes
 
 - _[CSS Writing Modes (en anglais)](https://24ways.org/2016/css-writing-modes/)_ par Jen Simmons sur _24 Ways_
-
-{{QuickLinksWithSubpages("/fr/docs/Web/CSS/CSS_Flow_Layout/")}}

--- a/files/fr/web/css/guides/display/formatting_contexts/index.md
+++ b/files/fr/web/css/guides/display/formatting_contexts/index.md
@@ -78,5 +78,3 @@ Dans ce guide, nous avons approfondi les notions relatives aux contextes de form
 - [Contexte de formatage de bloc (ou _Block Formatting Context_ (BFC) en anglais)](/fr/docs/Web/CSS/Guides/Display/Block_formatting_context)
 - [Modèle de formatage visuel](/fr/docs/Web/CSS/Guides/Display/Visual_formatting_model)
 - [Modèle de boîte CSS](/fr/docs/Web/CSS/Guides/Box_model)
-
-{{QuickLinksWithSubpages("/fr/docs/Web/CSS/CSS_Flow_Layout/")}}

--- a/files/fr/web/css/guides/grid_layout/accessibility/index.md
+++ b/files/fr/web/css/guides/grid_layout/accessibility/index.md
@@ -4,10 +4,6 @@ slug: Web/CSS/Guides/Grid_layout/Accessibility
 original_slug: Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility
 ---
 
-{{CSSRef}}
-
-{{PreviousMenuNext("Web/CSS/Guides/Grid_layout/Logical_values_and_writing_modes", "Web/CSS/CSS_Grid_Layout/Les_grilles_CSS_et_l_amélioration_progressive","Web/CSS/Guides/Grid_layout")}}
-
 Pour celles et ceux qui étaient présents aux premières lueurs du Web, les grilles CSS peuvent rappeler l'âge sombre où les tableaux HTML étaient utilisés pour la mise en forme des pages et où les cellules étaient utilisées pour diviser le contenu. Cette approche avait quelques avantages par rapport au positionnement CSS apparu après : on pouvait tirer parti de l'alignement et des colonnes créées dans un tableau. Il y a toutefois un inconvénient majeur : la mise en forme est fortement couplée à la structure du document, entraînant certains problèmes d'accessibilité. On pouvait par exemple découper le contenu dans le tableau afin d'obtenir la mise en forme souhaitée mais la structure de la page n'avait plus aucun sens lorsqu'elle était lue par un lecteur d'écran.
 
 Aux débuts de CSS, on évoquait souvent CSS comme un outil pour séparer distinctement la mise en forme d'une part et le contenu du document d'autre part. L'objectif ultime était alors de pouvoir créer un document sémantique et structuré correctement puis appliquer une feuille de style CSS afin de créer la disposition voulue. Des sites tels que [CSS Zen Garden](https://www.csszengarden.com/) montrent comment obtenir différents styles grâce à CSS à partir d'un même document HTML.
@@ -109,5 +105,3 @@ Il n'existe pas encore beaucoup de contenu relatif à l'accessibilité et au mod
 Le concept selon lequel l'ordre d'affichage des éléments doit suivre l'ordre des éléments dans le document est décrit dans _WCAG Techniques for Success Criteria – [Technique C27](https://www.w3.org/TR/WCAG20-TECHS/C27.html)_ (en anglais).
 
 Pour construire votre réflexion sur ce sujet, je vous invite à lire _[Flexbox & the Keyboard Navigation Disconnect](https://tink.uk/flexbox-the-keyboard-navigation-disconnect/)_ écrit par Léonie Watson. [La vidéo de la présentation de Léonie à ffconf](https://www.youtube.com/watch?v=spxT2CmHoPk) est aussi utile pour mieux comprendre comment les lecteurs d'écran utilisent la représentation visuelle des objets en CSS. Adrian Roselli a également publié [un article sur l'ordre de la navigation au clavier dans les différents navigateurs](https://adrianroselli.com/2015/10/html-source-order-vs-css-display-order.html) bien que cet article ait été rédigé avant l'implémentation des grilles CSS dans Firefox.
-
-{{PreviousMenuNext("Web/CSS/Guides/Grid_layout/Logical_values_and_writing_modes", "Web/CSS/CSS_Grid_Layout/Les_grilles_CSS_et_l_amélioration_progressive","Web/CSS/Guides/Grid_layout")}}

--- a/files/fr/web/css/guides/media_queries/using_for_accessibility/index.md
+++ b/files/fr/web/css/guides/media_queries/using_for_accessibility/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Media_queries/Using_for_accessibility
 original_slug: Web/CSS/CSS_media_queries/Using_media_queries_for_accessibility
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/CSS/Requêtes_média/")}}
-
 **Les requêtes média (_media queries_)** peuvent être utilisées afin d'améliorer l'accessibilité d'un site web.
 
 ## Réduction de mouvement - `prefers-reduced-motion`

--- a/files/fr/web/css/guides/positioned_layout/stacking_context/example_1/index.md
+++ b/files/fr/web/css/guides/positioned_layout/stacking_context/example_1/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Positioned_layout/Stacking_context/Example_1
 original_slug: Web/CSS/CSS_positioned_layout/Stacking_context/Stacking_context_example_1
 ---
 
-{{CSSRef}}{{PreviousMenuNext("Web/CSS/Comprendre_z-index/L'empilement_de_couches","Web/CSS/Comprendre_z-index/Exemple_2", "Web/CSS/Comprendre_z-index")}}
-
 ## Premier exemple
 
 Commençons par un exemple simple, dans le contexte d'empilement racine nous avons deux blocs _DIV_ (_DIV #1_ et _DIV #3_), tout deux positionnés relativement, mais sans propriété {{ cssxref("z-index") }}. Dans le bloc _DIV #1_ il y a un bloc _DIV #2_ en position absolue, alors que dans le bloc _DIV #3_ il y a un bloc _DIV #4_ en position absolue, tout deux également sans propriété `z-index`.
@@ -106,5 +104,3 @@ Dans le contexte d'empilement, les blocs _DIV #1_ et _DIV #3_ sont simplement as
 ### Résultat
 
 {{EmbedLiveSample('Exemple')}}
-
-{{PreviousMenuNext("Web/CSS/Comprendre_z-index/L'empilement_de_couches","Web/CSS/Comprendre_z-index/Exemple_2", "Web/CSS/Comprendre_z-index")}}


### PR DESCRIPTION
### Description

Fixing macros and links of pages affected by `page(doc)` flaws to prevent future errors.

### Motivation

Bug hunting for better documentation!

### Additional details

_none_

### Related issues and pull requests

Fixes #36021 (thanks @caugner)
