### PR TITLE
fix(fr): update csssyntax with "could not find syntax for this item" flaws

### DIFF
--- a/files/fr/web/css/reference/properties/box-direction/index.md
+++ b/files/fr/web/css/reference/properties/box-direction/index.md
@@ -54,7 +54,7 @@ Si la direction de l'élément est définie grâce à l'attribut `dir`, la décl
 
 ## Syntaxe formelle
 
-{{CSSSyntax}}
+{{CSSSyntaxRaw(`box-direction = normal | reverse`)}}
 
 ## Exemples
 

--- a/files/fr/web/css/reference/values/repeat/index.md
+++ b/files/fr/web/css/reference/values/repeat/index.md
@@ -163,7 +163,7 @@ Il existe une quatrième forme, `<name-repeat>`, qui est utilisée pour ajouter 
 
 ## Syntaxe formelle
 
-{{CSSSyntax}}
+{{CSSSyntaxRaw(`<track-repeat> <auto-repeat> <fixed-repeat> <name-repeat>`)}}
 
 ## Exemples
 


### PR DESCRIPTION
### Description

Fixing macros and links of pages affected by `could not find syntax for this item` flaws to prevent future errors.

### Motivation

Bug hunting for better documentation!

### Additional details

_none_

### Related issues and pull requests

_none_
