### PR TITLE
Sync writing_guidelines/howto/document_an_http_header [es]

### DIFF
--- a/files/es/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/es/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -1,57 +1,55 @@
 ---
 title: Cómo documentar una cabecera HTTP
+short-title: Documentar una cabecera HTTP
 slug: MDN/Writing_guidelines/Howto/Document_an_HTTP_header
 l10n:
-  sourceCommit: aa66311219951396e7305df61eb31831360d2c79
+  sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
 ---
 
-{{MDNSidebar}}
+La [referencia de cabeceras HTTP](/es/docs/Web/HTTP/Reference/Headers) documenta la sección de cabeceras de los mensajes de solicitud y respuesta en el Protocolo de Transferencia de Hipertexto ([HTTP](/es/docs/Web/HTTP)).
+Este artículo explica cómo crear una nueva página de referencia para una cabecera HTTP.
 
-La [referencia de cabeceras HTTP](/es/docs/Web/HTTP/Reference/Headers) en los campos de cabeceras HTTP de los documentos de MDN Web Docs. Son componentes de la sección de cabecera de los mensajes de solicitud y respuesta en el Protocolo de Transferencia de Hipertexto ([HTTP](/es/docs/Web/HTTP)). Definen los parámetros operativos de una transacción HTTP. Este artículo explica cómo crear una nueva página de referencia para una cabecera HTTP.
-
-Necesitarás saber o poder sumergirte en algo de [HTTP](/es/docs/Web/HTTP).
-
-## Paso 1: Determina la cabecera HTTP para documentar
+## Paso 1 – Determina la cabecera HTTP para documentar
 
 - Hay muchas cabeceras HTTP definidas en varios estándares IETF.
-- IANA mantiene un [registro de cabeceras](https://www.iana.org/assignments/message-headers/message-headers.xhtml) y Wikipedia enumera los [campos de cabeceras conocidos](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields), pero no todos son relevantes para los desarrolladores web o son parte de un estándar oficial.
+- IANA mantiene un [registro de campos de cabecera HTTP](https://www.iana.org/assignments/http-fields/http-fields.xhtml) y Wikipedia enumera los [campos de cabecera conocidos](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields), pero no todos son relevantes para los desarrolladores web o forman parte de un estándar oficial.
 - Si hay **enlaces rojos** en la [página de descripción general de referencia de cabeceras HTTP](/es/docs/Web/HTTP/Reference/Headers) actual, estas cabeceras son una buena opción para documentar.
-- En caso de duda, [pregunta al equipo de MDN Web Docs](/es/docs/MDN/Community/Communication_channels) si tiene o no sentido escribir sobre el encabezado que has elegido.
+- En caso de duda, [pregunta al equipo de MDN Web Docs](/es/docs/MDN/Community/Communication_channels) si tiene sentido o no escribir sobre la cabecera que has elegido.
 
-## Paso 2: Verifica las páginas de cabeceras HTTP existentes
+## Paso 2 – Verifica las páginas de cabeceras HTTP existentes
 
-- Las cabeceras HTTP existentes se documentan [aquí](/es/docs/Web/HTTP/Reference/Headers).
-- Hay diferentes categorías de cabeceras: {{Glossary("Request header")}}, {{Glossary("Response header")}} y {{Glossary("Representation header")}}.
-- Busque la categoría de la cabcera que está a punto de documentar (tenga en cuenta que algunas cabeceras pueden ser tanto de solicitud como de respuesta, según el contexto).
-- Vaya a una página de referencia de cabecera existente que tenga la misma categoría.
+- Las cabeceras HTTP existentes se documentan [en la referencia de HTTP](/es/docs/Web/HTTP/Reference/Headers).
+- Existen diferentes categorías de cabeceras: {{Glossary("Request header", "Cabecera de solicitud")}}, {{Glossary("Response header", "Cabecera de respuesta")}} y {{Glossary("Representation header", "Cabecera de representación")}}.
+- Busca la categoría de la cabecera que vas a documentar (ten en cuenta que algunas pueden ser tanto de solicitud como de respuesta, dependiendo del contexto).
+- Busca una página de referencia de cabecera existente que pertenezca a la misma categoría.
 
-## Paso 3: Crea la página de cabecera HTTP
+## Paso 3 – Crea la página de la cabecera HTTP
 
-- Todas las páginas de cabecera están bajo esta estructura: [/docs/Web/HTTP/Headers/](/es/docs/Web/HTTP/Reference/Headers)
-- Para crear una nueva página, consulta las instrucciones en nuestra guía [cómo crear una página](/es/docs/MDN/Writing_guidelines/Howto/Creating_moving_deleting).
+- Todas las páginas de cabeceras residen bajo este árbol: [`files/en-us/web/http/reference/headers`](https://github.com/mdn/content/tree/main/files/en-us/web/http/reference/headers).
+- Para crear una nueva página, consulta las instrucciones en nuestra guía sobre [cómo crear una página](/es/docs/MDN/Writing_guidelines/Howto/Creating_moving_deleting).
 
 ## Paso 4 – Escribe el contenido
 
-- Comienza desde nuestra [plantilla de página de cabecera HTTP](/es/docs/MDN/Writing_guidelines/Page_structures/Page_types#http_header_reference_page) o usa una estructura copiada de uno de los documentos de cabecera HTTP existentes que encontraste en el paso 2. Es tu elección.
-- Escriba sobre la nueva cabecera HTTP.
-- Asegúrate de tener estas secciones:
-  - Texto introductorio donde la primera oración menciona el nombre de la cabecera (negrita) y resume su propósito.
-  - Cuadro de información que contiene al menos el tipo de cabecera y si la cabecera es un {{Glossary("Forbidden header name","Nombre de cabecera prohibido")}}.
-  - Un cuadro de sintaxis que contiene todas las directivas/parámetros/valores posibles de la cabecera HTTP.
-  - Una sección que explica estas directivas/valores.
-  - Una sección de ejemplo que contiene un caso de uso práctico para esta cabecera o muestra dónde y cómo ocurre normalmente.
-  - Una sección de especificaciones que enumera los documentos estándar RFC relevantes.
-  - Una sección "Véase también" que enumera recursos relevantes.
+- Puedes comenzar desde nuestra [plantilla de página de cabecera HTTP](/es/docs/MDN/Writing_guidelines/Page_structures/Page_types#http_header_reference_page) o usar una estructura copiada de uno de los documentos de cabeceras existentes que encontraste en el paso 2. Tú eliges.
+- Escribe sobre la nueva cabecera HTTP.
+- Asegúrate de incluir estas secciones:
+  - Texto introductorio donde la primera oración mencione el nombre de la cabecera (en **negrita**) y resuma su propósito.
+  - Cuadro de información que contenga al menos el tipo de cabecera y si es una {{Glossary("Forbidden request header", "Cabecera de solicitud prohibida")}}.
+  - Un cuadro de sintaxis que contenga todas las directivas/parámetros/valores posibles de la cabecera HTTP.
+  - Una sección que explique estas directivas/valores.
+  - Una sección de ejemplos que contenga un caso de uso práctico para esta cabecera o muestre dónde y cómo ocurre normalmente.
+  - Una sección de especificaciones que enumere los documentos estándar RFC relevantes.
+  - Una sección "Véase también" con recursos relacionados.
 
-## Paso 5: Agrega información de compatibilidad con los navegadores
+## Paso 5 – Agrega información de compatibilidad con navegadores
 
-- Si has mirado otras páginas de cabecera HTTP, verás que hay una macro `\{{Compat}}` que completará una tabla del navegador por ti.
-- La página de la tabla de compatibilidad se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte las instrucciones en <https://github.com/mdn/browser-compat-data/blob/main/README.md> y envíenos una solicitud de incorporación de cambios (Pull request, en Inglés).
+- Si has observado otras páginas de cabeceras HTTP, verás que existe una macro `\{{Compat}}` que generará automáticamente una tabla de compatibilidad por ti.
+- La tabla de compatibilidad se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta las instrucciones en <https://github.com/mdn/browser-compat-data/blob/main/README.md> y envíanos un pull request.
 
-## Paso 6: Actualiza la lista de cabeceras HTTP
+## Paso 6 – Actualiza la lista de cabeceras HTTP
 
-Asegúrate de que tu cabecera está incluida en una categoría adecuada en la [página de resumen de referencia de cabeceras HTTP](/es/docs/Web/HTTP/Reference/Headers).
+Asegúrate de que tu cabecera aparezca en la categoría apropiada en la [página de descripción general de referencia de cabeceras HTTP](/es/docs/Web/HTTP/Reference/Headers).
 
-## Paso 7: Haz que se revise el contenido
+## Paso 7 – Solicita una revisión del contenido
 
-Una vez que hayas creado la página de cabecera, envíala como una solicitud de incorporación de cambios (Pull request). Se asignará automáticamente a un miembro de nuestro equipo de revisión para que revise su página.
+Después de crear la página de la cabecera, envíala mediante un pull request. Se asignará automáticamente a un miembro de nuestro equipo de revisión para que evalúe tu página.


### PR DESCRIPTION
## Description

This PR synchronizes the page `How to document an HTTP header` with its English upstream version.

### Changes made:

- Synced `l10n.sourceCommit` to the latest upstream hash.
- Cleaned up YAML front-matter (removed `page-type`, `sidebar` and added `short-title`).
- Removed outdated `{{MDNSidebar}}` macro to match the upstream source.
- Kumascript macros preserved.
- Validated all internal links are properly prefixed with `/es/`.

## Related Issues

Resolves #35385
Part of #35373