### PR TITLE
fix(fr): remove outdated macros creating legacy url flaws

### DIFF
--- a/files/fr/web/performance/guides/how_browsers_work/index.md
+++ b/files/fr/web/performance/guides/how_browsers_work/index.md
@@ -4,8 +4,6 @@ slug: Web/Performance/Guides/How_browsers_work
 original_slug: Web/Performance/How_browsers_work
 ---
 
-{{QuickLinksWithSubPages("Web/Performance")}}
-
 Les utilisateurs veulent des expériences Web avec un contenu rapide à charger et une interaction fluide. Par conséquent, un développeur doit s'efforcer d'atteindre ces deux objectifs.
 
 Pour comprendre comment améliorer les performances et les performances perçues, il est utile de comprendre le fonctionnement du navigateur.

--- a/files/fr/web/performance/guides/how_long_is_too_long/index.md
+++ b/files/fr/web/performance/guides/how_long_is_too_long/index.md
@@ -4,8 +4,6 @@ slug: Web/Performance/Guides/How_long_is_too_long
 original_slug: Web/Performance/How_long_is_too_long
 ---
 
-{{QuickLinksWithSubPages("Web/Performance")}}
-
 Il n'y a pas de règle stricte définissant ce qui constitue un site trop long à charger, mais il y a des bonnes pratiques spécifiques pour définir un bon temps de chargement du contenu (1 seconde), de fonctionnement au ralenti (50 millisecondes), d'animation (16,7 secondes) ou encore de réponse à la saisie d'un visiteur (50 à 200 millisecondes).
 
 ## Objectifs de chargement

--- a/files/fr/web/performance/guides/lazy_loading/index.md
+++ b/files/fr/web/performance/guides/lazy_loading/index.md
@@ -4,8 +4,6 @@ slug: Web/Performance/Guides/Lazy_loading
 original_slug: Web/Performance/Lazy_loading
 ---
 
-{{QuickLinksWithSubPages("Web/Performance")}}
-
 Le **chargement différé** (<i lang="en">lazy loading</i> en anglais) est une stratégie d'identification des ressources non bloquantes (non critiques) afin de ne les charger qu'au moment où elles sont utiles. C'est une façon de raccourcir le [chemin critique de rendu](/fr/docs/Web/Performance/Critical_rendering_path), ce qui se traduit par une réduction du temps de chargement de la page.
 
 Le chargement différé peut se dérouler à plusieurs moments du chargement d'une application, mais il se déroule typiquement lorsque l'internaute interagit avec la page, notamment lors du défilement de la page ou de la navigation.

--- a/files/fr/web/performance/guides/performance_budgets/index.md
+++ b/files/fr/web/performance/guides/performance_budgets/index.md
@@ -4,8 +4,6 @@ slug: Web/Performance/Guides/Performance_budgets
 original_slug: Web/Performance/Performance_budgets
 ---
 
-{{QuickLinksWithSubPages("Web/Performance")}}
-
 Un budget de performance est une limite pour éviter les régressions. Il peut s'appliquer à un fichier, un type de fichier, tous les fichiers chargés sur une page, une métrique spécifique (par exemple, [Time to Interactive](/fr/docs/Glossary/Time_to_interactive)), une métrique personnalisée (par exemple, Time to Hero Element), ou un seuil sur une période de temps.
 
 ## Pourquoi ai-je besoin d'un budget de performance?


### PR DESCRIPTION
### Description

Fixing macros and links of pages affected by `fixed legacy url` flaws to prevent future errors.

### Motivation

Bug hunting for better documentation!

### Additional details

_none_

### Related issues and pull requests

_none_
