### PR TITLE
fix(fr): sidebar using wrong slug are not properly displayed

### DIFF
--- a/files/fr/learn_web_development/core/scripting/event_bubbling/index.md
+++ b/files/fr/learn_web_development/core/scripting/event_bubbling/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: 95b52aa7aeabbd2670f762da4fb7c0b0133f4d9f
 ---
 
-{{APIRef}}
+{{PreviousMenuNext("Learn_web_development/Core/Scripting/Events","Learn_web_development/Core/Scripting/Test_your_skills/Events", "Learn_web_development/Core/Scripting")}}
 
 On peut facilement confondre les différentes cibles d'évènements lorsqu'on écrit un gestionnaire d'évènement. Cet article devrait vous aider à y voir plus clair dans l'utilisation des propriétés relatives aux cibles.
 
@@ -187,3 +187,5 @@ inner.addEventListener("mouseout", handleMouseOut);
 Déplacez votre pointeur dans le carré noir et en dehors.
 
 {{EmbedLiveSample("","",200)}}
+
+{{PreviousMenuNext("Learn_web_development/Core/Scripting/Events","Learn_web_development/Core/Scripting/Test_your_skills/Events", "Learn_web_development/Core/Scripting")}}

--- a/files/fr/mdn/writing_guidelines/page_structures/sidebars/index.md
+++ b/files/fr/mdn/writing_guidelines/page_structures/sidebars/index.md
@@ -271,9 +271,9 @@ Si une locale MDN n'a pas de valeur définie pour un espace réservé, la versio
 
 Certaines barres latérales sur MDN n'utilisent pas le système standard décrit ci-dessus. Ce sont des macros plus complexes nécessitant un traitement particulier&nbsp;:
 
-- `{{APIRef("<API>")}}`
+- `\{{APIRef("<API>")}}`
   - : La barre latérale API affichée sur les [pages de référence d'API](/fr/docs/Web/API#interfaces). Pour chaque interface, la macro génère automatiquement des liens vers les membres définis sur l'interface — propriétés, méthodes, événements, etc. Le paramètre unique est le nom du groupe d'API défini dans le fichier [`GroupData.json` <sup>(angl.)</sup>](https://github.com/mdn/content/blob/main/files/jsondata/GroupData.json). Pour modifier les pages associées affichées en bas de la barre latérale, modifiez l'entrée GroupData de cette API.
-- `{{DefaultAPISidebar("<API>")}}`
+- `\{{DefaultAPISidebar("<API>")}}`
   - : La barre latérale API affichée sur les [pages d'accueil d'API](/fr/docs/Web/API#spécifications). Le paramètre unique est le nom du groupe d'API défini dans le fichier [`GroupData.json` <sup>(angl.)</sup>](https://github.com/mdn/content/blob/main/files/jsondata/GroupData.json). Pour modifier les guides, interfaces, etc. liés dans la barre latérale d'une API, modifiez l'entrée GroupData de cette API.
 - `sidebar: jsref`
   - : La barre latérale sur les [pages de référence JavaScript](/fr/docs/Web/JavaScript/Reference) incluse via le front-matter.

--- a/files/fr/web/api/force_touch_events/index.md
+++ b/files/fr/web/api/force_touch_events/index.md
@@ -3,9 +3,7 @@ title: Force Touch events
 slug: Web/API/Force_Touch_events
 ---
 
-{{DefaultAPISidebar("Force Touch events")}}
-
-{{Non-standard_header()}}
+{{DefaultAPISidebar("Force Touch Events")}}{{Non-standard_Header}}
 
 **Force Touch events** est une fonctionnalité propriétaire propre à Apple et qui rend possibles (si supporté par le matériel d'entrée) de nouvelles interactions basées sur le fait que l'utilisateur clique ou appuie sur l'écran tactile ou sur le trackpad.
 


### PR DESCRIPTION
### Description

Fixing macros and links of pages affected by `Invalid slug for templ/sidebar` flaws to prevent future errors.

### Motivation

Bug hunting for better documentation!

### Additional details

_none_

### Related issues and pull requests

_none_