### PR TITLE
ci(pr-reviewdog): pin reviewdog_version

### DIFF
--- a/.github/workflows/pr-reviewdog.yml
+++ b/.github/workflows/pr-reviewdog.yml
@@ -72,7 +72,7 @@ jobs:
         if: steps.check.outputs.HAS_ARTIFACT == 'true'
         uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1.5.0
         with:
-          reviewdog_version: latest
+          reviewdog_version: v0.21.0
 
       - name: Add PR review with suggested changes using `git diff` output
         if: steps.check.outputs.HAS_ARTIFACT == 'true' && hashFiles('lint-results/lint.diff') != ''


### PR DESCRIPTION
### Description

Updates the `pr-reviewdog` workflow, pinning the `reviewdog_version`.

### Motivation

Apply best practices, similar to pinning the action itself.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1565.

Same as:

- https://github.com/mdn/content/pull/44112
- https://github.com/mdn/translated-content-de/pull/252