### PR TITLE
[pt-br] Remove superfluous CSSxRef argument

### DIFF
--- a/files/pt-br/web/css/reference/properties/gap/index.md
+++ b/files/pt-br/web/css/reference/properties/gap/index.md
@@ -6,7 +6,7 @@ original_slug: Web/CSS/gap
 
 {{CSSRef}}
 
-A propriedade {{CSSxRef("", "CSS")}} **`gap`** define os espaços ({{glossary("gutters")}}) entre as linhas e colunas. É uma {{CSSxRef("Shorthand_properties", "propriedade shorthand")}} para {{CSSxRef("row-gap")}} e {{CSSxRef("column-gap")}}.
+A propriedade {{CSSxRef("CSS")}} **`gap`** define os espaços ({{glossary("gutters")}}) entre as linhas e colunas. É uma {{CSSxRef("Shorthand_properties", "propriedade shorthand")}} para {{CSSxRef("row-gap")}} e {{CSSxRef("column-gap")}}.
 
 {{InteractiveExample("CSS Demo: gap")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removes a superfluous CSSxRef argument.

### Motivation

Resolves a flaw reported by Rari.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.