### PR TITLE
chore: Fix typo in Access-Control-Allow-Credentials page 

### DIFF
--- a/files/ja/web/http/reference/headers/access-control-allow-credentials/index.md
+++ b/files/ja/web/http/reference/headers/access-control-allow-credentials/index.md
@@ -19,7 +19,7 @@ HTTP の **`Access-Control-Allow-Credentials`** は{{Glossary("response header",
 
 資格情報が添付されるのは次の場合です。
 
-- {{glossary("Preflight_request", "プリフライト")}}のあるリクエストの場合、プリフラウとリクエストには資格情報を添付しません。
+- {{glossary("Preflight_request", "プリフライト")}}のあるリクエストの場合、プリフライトリクエストには資格情報を添付しません。
   プリフライトリクエストに対するサーバーのレスポンスで `Access-Control-Allow-Credentials` ヘッダーが `true` に設定されている場合、実際のリクエストには資格情報を添付します。そうでない場合、ブラウザーはネットワークエラーを報告します。
 - プリフライトのないリクエストの場合、リクエストには資格情報が添付されます。サーバーのレスポンスで `Access-Control-Allow-Credentials` ヘッダーが `true` に設定されていない場合、ブラウザーはネットワークエラーを報告します。
 


### PR DESCRIPTION

### Description
Fix typo in ```https://developer.mozilla.org/ja/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Credentials```

<img width="798" height="262" alt="スクリーンショット 2026-05-14 14 28 19" src="https://github.com/user-attachments/assets/2d9d6f83-3e95-4cea-9833-a3ce2f465bb7" />

typo: ```プリフラウとリクエスト```
corecct: ```プリフライトリクエスト```

### Motivation
none.

### Additional details
none. 


### Related issues and pull requests
none.
