### PR TITLE
Sync writing_guidelines/howto/document_web_errors [es]

### DIFF
--- a/files/es/mdn/writing_guidelines/howto/document_web_errors/index.md
+++ b/files/es/mdn/writing_guidelines/howto/document_web_errors/index.md
@@ -1,43 +1,41 @@
 ---
 title: Cómo documentar errores web
+short-title: Documentar errores
 slug: MDN/Writing_guidelines/Howto/Document_web_errors
 l10n:
-  sourceCommit: aa66311219951396e7305df61eb31831360d2c79
+  sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
 ---
 
-{{MDNSidebar}}
+La [Referencia de errores de JavaScript](/es/docs/Web/JavaScript/Reference/Errors) en MDN Web Docs es un proyecto destinado a ayudar a los desarrolladores web con los errores que aparecen en la [Consola de desarrollador](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html). Para este proyecto, necesitamos ampliar la documentación de errores en MDN Web Docs, para poder agregar más enlaces a las herramientas donde se generan los mensajes. Este artículo explica cómo documentar los errores web.
 
-La [Referencia de errores de JavaScript](/es/docs/Web/JavaScript/Reference/Errors) en MDN Web Docs es un proyecto para ayudar a los desarrolladores web con los errores que ocurren en la [Consola de desarrollador](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html). Para este proyecto, necesitamos escribir más documentación de errores en MDN Web Docs para que podamos agregar más enlaces a las herramientas donde se lanzan los mensajes. Este artículo explica cómo documentar los errores web.
+Los errores de JavaScript incluyen un enlace de "Más información" que dirige a la referencia de errores de JavaScript, donde se ofrece asesoramiento adicional para solucionar problemas. Para poder documentar los errores web, necesitarás conocer o ser capaz de profundizar en algunos conceptos de [JavaScript](/es/docs/Web/JavaScript).
 
-Los errores de JavaScript contienen un enlace de "Más información" que lo lleva a la referencia de errores de JavaScript que contiene consejos adicionales para solucionar problemas. Para poder documentar los errores de la web, necesitará saber o poder sumergirse algo en [JavaScript](/es/docs/Web/JavaScript).
-
-## Paso 1 – Determina el error a documentar
+## Paso 1 – Determinar el error a documentar
 
 - Mensajes de error de Firefox/Gecko: <https://github.com/mozilla/gecko-dev/blob/master/js/src/jsshell.msg>
-- Mensajes de error de Edge/Chakra: <https://github.com/Microsoft/ChakraCore/blob/master/lib/Parser/rterrors.h>
 - Mensajes de error de Chrome/v8: <https://chromium.googlesource.com/v8/v8.git/+/refs/heads/main/src/execution/messages.h>
 
-## Paso 2: Verifica la documentación del error existente
+## Paso 2 – Verificar la documentación de errores existente
 
-- Vea la [referencia de errores de JavaScript](/es/docs/Web/JavaScript/Reference/Errors) existentes y vea cómo se documentan los errores.
-- Según el tipo de error sobre el que desee escribir, puede echar un vistazo más de cerca a estas páginas.
-- Es posible que desee copiar el contenido de una página existente para iniciar su nueva página.
+- Revisa la [referencia de errores de JavaScript](/es/docs/Web/JavaScript/Reference/Errors) actual para ver cómo se documentan.
+- Dependiendo del tipo de error sobre el que quieras escribir, puedes analizar esas páginas detalladamente.
+- Puedes copiar el contenido de una página existente para utilizarlo como base para tu nueva página.
 
-## Paso 3: Crea la nueva página del error
+## Paso 3 – Crear la nueva página de error
 
-- Todas las páginas de error se encuentran bajo esta estructura: [/docs/Web/JavaScript/Reference/Errors](/es/docs/Web/JavaScript/Reference/Errors)
-- Para crear una nueva página, consulta las instrucciones en nuestra guía [cómo crear una página](/es/docs/MDN/Writing_guidelines/Howto/Creating_moving_deleting).
+- Todas las páginas de error se encuentran bajo este directorio: [/docs/Web/JavaScript/Reference/Errors](/es/docs/Web/JavaScript/Reference/Errors)
+- Para crear una nueva página, consulta las instrucciones en nuestra guía sobre [cómo crear una página](/es/docs/MDN/Writing_guidelines/Howto/Creating_moving_deleting).
 
-## Paso 4: Documenta el error
+## Paso 4 – Documentar el error
 
-- Utilice una estructura copiada de uno de los documentos de error existentes o comience desde cero. ¡Tu elección!
-- Deberías tener al menos:
-  - Un cuadro de sintaxis que contiene el mensaje tal como se lanza en diferentes navegadores.
+- Puedes usar una estructura copiada de uno de los documentos de error existentes o empezar desde cero. ¡Tú eliges!
+- El contenido debe incluir al menos:
+  - Un cuadro de sintaxis que contenga el mensaje tal como se lanza en diferentes navegadores.
   - El tipo de error.
-  - Un texto que explica por qué ocurrió este error y cuáles son sus consecuencias. Ir más allá del mensaje lanzado.
-  - Ejemplos que muestran el error (¡puede haber más de uno!) y un ejemplo que muestra cómo corregir el código.
+  - Un texto que explique por qué ocurrió este error y cuáles son sus consecuencias. Ve más allá del mensaje de error mostrado.
+  - Ejemplos que demuestren el error (¡puede haber más de uno!) y un ejemplo que muestre cómo corregir el código.
   - Enlaces a otro material de referencia en MDN Web Docs.
 
-## Paso 5: Conseguir que se revise el contenido
+## Paso 5 – Solicitar la revisión del contenido
 
-Una vez que haya creado la página del error, envíela como una solicitud de incorporación de cambios (Pull request en Inglés). Se asignará automáticamente a un miembro de nuestro equipo de revisión para que revise su página.
+Una vez que hayas creado la página de error, envíala mediante un _pull request_. Un miembro de nuestro equipo de revisión será asignado automáticamente para revisar tu página.


### PR DESCRIPTION
## Description

This PR synchronizes the page `How to document web errors` with its English upstream source.

### Changes made:

- Synced `l10n.sourceCommit` to the latest upstream hash.
- Cleaned up YAML front-matter (added `short-title`).
- Removed outdated `{{MDNSidebar}}` macro to match the upstream source.
- Validated all internal links are properly prefixed with `/es/`.

## Related Issues

Resolves #35386
Part of #35373