### PR TITLE
chore(fr): mise à jour de l'élément SVG `<desc>`

### DIFF
--- a/files/fr/web/svg/reference/element/desc/index.md
+++ b/files/fr/web/svg/reference/element/desc/index.md
@@ -5,25 +5,25 @@ l10n:
   sourceCommit: ac806e34aba086be141689c64dc4dd73636fbd62
 ---
 
-L'élément **`<desc>`** [SVG](/fr/docs/Web/SVG) fournit une description textuelle longue et accessible de tout [élément conteneur](/fr/docs/Web/SVG/Reference/Element#container_elements) ou [élément graphique](/fr/docs/Web/SVG/Reference/Element#graphics_elements) SVG.
+L'élément [SVG](/fr/docs/Web/SVG) **`<desc>`** fournit une description textuelle longue et accessible de tout [élément SVG conteneur](/fr/docs/Web/SVG/Reference/Element#éléments_conteneurs) ou [élément SVG graphique](/fr/docs/Web/SVG/Reference/Element#éléments_graphiques).
 
 Le texte d'un élément `<desc>` n'est pas affiché dans le rendu graphique. Si l'élément peut être décrit par du texte visible, il est possible de référencer ce texte avec l'attribut [`aria-describedby`](/fr/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby). Si `aria-describedby` est utilisé, il prendra le pas sur `<desc>`.
 
-Le texte masqué d'un élément `<desc>` peut également être concaténé avec le texte visible d'autres éléments en utilisant plusieurs ID dans une valeur `aria-describedby`. Dans ce cas, l'élément `<desc>` doit fournir un ID pour être référencé.
+Le texte masqué d'un élément `<desc>` peut également être concaténé avec le texte visible d'autres éléments en utilisant plusieurs ID dans la valeur de `aria-describedby`. Dans ce cas, l'élément `<desc>` doit fournir un ID pour être référencé.
 
 ## Contexte d'utilisation
 
-{{svginfo}}
+{{SVGInfo}}
 
 ## Attributs
 
-Cet élément n'inclut que les attributs globaux.
+Cet élément n'inclut que les attributs universels.
 
 ## Interface DOM
 
-Cet élément implémente l'interface {{domxref("SVGDescElement")}}.
+Cet élément implémente l'interface {{DOMxRef("SVGDescElement")}}.
 
-## Exemple
+## Exemples
 
 ```css hidden
 html,
@@ -45,7 +45,7 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample('Exemple', 150, '100%')}}
+{{EmbedLiveSample("Exemples", 150, "100%")}}
 
 ## Spécifications
 
@@ -57,4 +57,4 @@ svg {
 
 ## Voir aussi
 
-- {{SVGElement("title")}}
+- L'élément {{SVGElement("title")}}

--- a/files/fr/web/svg/reference/element/desc/index.md
+++ b/files/fr/web/svg/reference/element/desc/index.md
@@ -1,9 +1,6 @@
 ---
 title: <desc>
 slug: Web/SVG/Reference/Element/desc
-page-type: svg-element
-browser-compat: svg.elements.desc
-sidebar: svgref
 l10n:
   sourceCommit: ac806e34aba086be141689c64dc4dd73636fbd62
 ---

--- a/files/fr/web/svg/reference/element/desc/index.md
+++ b/files/fr/web/svg/reference/element/desc/index.md
@@ -1,14 +1,18 @@
 ---
-title: desc
+title: <desc>
 slug: Web/SVG/Reference/Element/desc
-original_slug: Web/SVG/Element/desc
+page-type: svg-element
+browser-compat: svg.elements.desc
+sidebar: svgref
+l10n:
+  sourceCommit: ac806e34aba086be141689c64dc4dd73636fbd62
 ---
 
-{{SVGRef}}
+L'élément **`<desc>`** [SVG](/fr/docs/Web/SVG) fournit une description textuelle longue et accessible de tout [élément conteneur](/fr/docs/Web/SVG/Reference/Element#container_elements) ou [élément graphique](/fr/docs/Web/SVG/Reference/Element#graphics_elements) SVG.
 
-Tout élément graphique ou conteneur dans un dessin SVG peut définir une description en utilisant l'élément **`<desc>`**, cette description ne peut contenir que du texte.
+Le texte d'un élément `<desc>` n'est pas affiché dans le rendu graphique. Si l'élément peut être décrit par du texte visible, il est possible de référencer ce texte avec l'attribut [`aria-describedby`](/fr/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby). Si `aria-describedby` est utilisé, il prendra le pas sur `<desc>`.
 
-Quand l'élément contenant une description apparaît à l'utilisateur sous forme d'image, l'élément `<desc>` n'est pas affiché. Néanmoins, quelques moteurs de rendu peuvent, par exemple, l'afficher sous forme d'infobulle. Des représentations alternatives sont possibles, visuelles ou auditives, en remplacement des éléments graphiques. De manière générale, cet élément améliore l'accessibilité des documents SVG.
+Le texte masqué d'un élément `<desc>` peut également être concaténé avec le texte visible d'autres éléments en utilisant plusieurs ID dans une valeur `aria-describedby`. Dans ce cas, l'élément `<desc>` doit fournir un ID pour être référencé.
 
 ## Contexte d'utilisation
 
@@ -16,19 +20,39 @@ Quand l'élément contenant une description apparaît à l'utilisateur sous form
 
 ## Attributs
 
-### Attributs globaux
-
-- [Attributs de base](/fr/docs/Web/SVG/Reference/Attribute#attributs_de_base)&nbsp;»
-- {{ SVGAttr("class") }}
-- {{ SVGAttr("style") }}
-
-### Attributs spécifiques
-
-_Aucun._
+Cet élément n'inclut que les attributs globaux.
 
 ## Interface DOM
 
-Cet élément implémente l'interface [`SVGDescElement`](/fr/docs/Web/API/SVGDescElement).
+Cet élément implémente l'interface {{domxref("SVGDescElement")}}.
+
+## Exemple
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="5" cy="5" r="4">
+    <desc>
+      Je suis un cercle, et cette description sert à montrer comment on peut me
+      décrire, mais est-il vraiment nécessaire de décrire un simple cercle comme
+      moi ?
+    </desc>
+  </circle>
+</svg>
+```
+
+{{EmbedLiveSample('Exemple', 150, '100%')}}
+
+## Spécifications
+
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
@@ -36,4 +60,4 @@ Cet élément implémente l'interface [`SVGDescElement`](/fr/docs/Web/API/SVGDes
 
 ## Voir aussi
 
-- {{ SVGElement("title") }}
+- {{SVGElement("title")}}


### PR DESCRIPTION
### Description
Mise à jour de la traduction française de la page `<desc>` pour l'aligner sur la version anglaise actuelle (commit ac806e3).

### Motivation
L'ancienne version française était très obsolète : elle ne mentionnait pas `aria-describedby`, utilisait une structure différente de la version anglaise, et contenait des informations inexactes (par exemple, elle indiquait que `<desc>` ne pouvait contenir que du texte). Cette mise à jour permet aux lecteurs francophones d'accéder à une documentation
conforme à la version de référence.

### Additional details
- Remplacement complet du contenu pour correspondre à la structure EN
- Ajout de la propriété `l10n.sourceCommit`
- Les liens internes pointent vers les pages `/fr/docs/`

### Related issues and pull requests
Part of #34956