### PR TITLE
chore(fr): traduction de la page de l'élément SVG `<set>`

### DIFF
--- a/files/fr/web/svg/reference/element/set/index.md
+++ b/files/fr/web/svg/reference/element/set/index.md
@@ -5,26 +5,26 @@ l10n:
   sourceCommit: ac806e34aba086be141689c64dc4dd73636fbd62
 ---
 
-L'élément **`<set>`** [SVG](/fr/docs/Web/SVG) fournit une méthode permettant de définir la valeur d'un attribut pour une durée déterminée.
+L'élément [SVG](/fr/docs/Web/SVG) **`<set>`** fournit une méthode permettant de définir la valeur d'un attribut pour une durée déterminée.
 
-Il prend en charge tous les types d'attributs, y compris ceux qui ne peuvent pas raisonnablement être interpolés, comme les valeurs de type chaîne de caractères ou booléen. Pour les attributs qui peuvent raisonnablement être interpolés, l'élément {{SVGElement('animate')}} est généralement préféré.
+Il prend en charge tous les types d'attributs, y compris ceux qui ne peuvent pas raisonnablement être interpolés, comme les valeurs de type chaîne de caractères ou booléen. Pour les attributs qui peuvent raisonnablement être interpolés, l'élément {{SVGElement("animate")}} est généralement préféré.
 
 > [!NOTE]
-> L'élément `<set>` est non additif. Les attributs {{SVGAttr('additive')}} et {{SVGAttr('accumulate')}} ne sont pas autorisés et seront ignorés s'ils sont spécifiés.
+> L'élément `<set>` est non additif. Les attributs {{SVGAttr("additive")}} et {{SVGAttr("accumulate")}} ne sont pas autorisés et sont ignorés s'ils sont définis.
 
 ## Contexte d'utilisation
 
-{{svginfo}}
+{{SVGInfo}}
 
 ## Attributs
 
 - {{SVGAttr("to")}}
   - : Cet attribut définit la valeur à appliquer à l'attribut cible pendant la durée de l'animation. La valeur doit correspondre aux exigences de l'attribut cible.
-    _Type de valeur_&nbsp;: [**\<anything>**](/fr/docs/Web/SVG/Guides/Content_type#anything)&nbsp;; _Valeur par défaut_&nbsp;: aucune&nbsp;; _Animable_&nbsp;: **non**
+    _Type de valeur_&nbsp;: [**`<anything>`**](/fr/docs/Web/SVG/Guides/Content_type#anything)&nbsp;; _Valeur par défaut_&nbsp;: aucune&nbsp;; _Animable_&nbsp;: **non**
 
 ## Interface DOM
 
-Cet élément implémente l'interface {{domxref("SVGSetElement")}}.
+Cet élément implémente l'interface {{DOMxRef("SVGSetElement")}}.
 
 ## Exemple
 
@@ -54,7 +54,7 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample('Exemple', 150, '100%')}}
+{{EmbedLiveSample("Exemple", 150, "100%")}}
 
 ## Spécifications
 
@@ -66,6 +66,6 @@ svg {
 
 ## Voir aussi
 
-- Attribut {{SVGAttr("attributeName")}}
-- [Attributs de minutage d'animation](/fr/docs/Web/SVG/Reference/Attribute#animation_timing_attributes), dont {{SVGAttr("begin")}}, {{SVGAttr("dur")}}, {{SVGAttr("end")}}, {{SVGAttr("min")}}, {{SVGAttr("max")}}, {{SVGAttr("restart")}}, {{SVGAttr("repeatCount")}}, {{SVGAttr("repeatDur")}} et {{SVGAttr("fill")}}.
-- {{SVGElement("animate")}}
+- L'attribut {{SVGAttr("attributeName")}}
+- [Les attributs pour me minutage de l'animation](/fr/docs/Web/SVG/Reference/Attribute#attributs_pour_le_minutage_de_lanimation), tels que {{SVGAttr("begin")}}, {{SVGAttr("dur")}}, {{SVGAttr("end")}}, {{SVGAttr("min")}}, {{SVGAttr("max")}}, {{SVGAttr("restart")}}, {{SVGAttr("repeatCount")}}, {{SVGAttr("repeatDur")}} et {{SVGAttr("fill")}}.
+- L'élément {{SVGElement("animate")}}

--- a/files/fr/web/svg/reference/element/set/index.md
+++ b/files/fr/web/svg/reference/element/set/index.md
@@ -1,0 +1,74 @@
+---
+title: <set>
+slug: Web/SVG/Reference/Element/set
+page-type: svg-element
+browser-compat: svg.elements.set
+sidebar: svgref
+l10n:
+  sourceCommit: ac806e34aba086be141689c64dc4dd73636fbd62
+---
+
+L'élément **`<set>`** [SVG](/fr/docs/Web/SVG) fournit une méthode permettant de définir la valeur d'un attribut pour une durée déterminée.
+
+Il prend en charge tous les types d'attributs, y compris ceux qui ne peuvent pas raisonnablement être interpolés, comme les valeurs de type chaîne de caractères ou booléen. Pour les attributs qui peuvent raisonnablement être interpolés, l'élément {{SVGElement('animate')}} est généralement préféré.
+
+> [!NOTE]
+> L'élément `<set>` est non additif. Les attributs {{SVGAttr('additive')}} et {{SVGAttr('accumulate')}} ne sont pas autorisés et seront ignorés s'ils sont spécifiés.
+
+## Contexte d'utilisation
+
+{{svginfo}}
+
+## Attributs
+
+- {{SVGAttr("to")}}
+  - : Cet attribut définit la valeur à appliquer à l'attribut cible pendant la durée de l'animation. La valeur doit correspondre aux exigences de l'attribut cible.
+    _Type de valeur_&nbsp;: [**\<anything>**](/fr/docs/Web/SVG/Guides/Content_type#anything)&nbsp;; _Valeur par défaut_&nbsp;: aucune&nbsp;; _Animable_&nbsp;: **non**
+
+## Interface DOM
+
+Cet élément implémente l'interface {{domxref("SVGSetElement")}}.
+
+## Exemple
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    rect {
+      cursor: pointer;
+    }
+    .round {
+      rx: 5px;
+      fill: green;
+    }
+  </style>
+
+  <rect id="me" width="10" height="10">
+    <set attributeName="class" to="round" begin="me.click" dur="2s" />
+  </rect>
+</svg>
+```
+
+{{EmbedLiveSample('Exemple', 150, '100%')}}
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- Attribut {{SVGAttr("attributeName")}}
+- [Attributs de minutage d'animation](/fr/docs/Web/SVG/Reference/Attribute#animation_timing_attributes), dont {{SVGAttr("begin")}}, {{SVGAttr("dur")}}, {{SVGAttr("end")}}, {{SVGAttr("min")}}, {{SVGAttr("max")}}, {{SVGAttr("restart")}}, {{SVGAttr("repeatCount")}}, {{SVGAttr("repeatDur")}} et {{SVGAttr("fill")}}.
+- {{SVGElement("animate")}}

--- a/files/fr/web/svg/reference/element/set/index.md
+++ b/files/fr/web/svg/reference/element/set/index.md
@@ -1,9 +1,6 @@
 ---
 title: <set>
 slug: Web/SVG/Reference/Element/set
-page-type: svg-element
-browser-compat: svg.elements.set
-sidebar: svgref
 l10n:
   sourceCommit: ac806e34aba086be141689c64dc4dd73636fbd62
 ---


### PR DESCRIPTION
### Description
Création de la traduction française de la page `<set>`.
Cette page n'existait pas encore en français.

### Motivation
L'élément `<set>` est un élément d'animation SVG documenté en
anglais mais absent de la documentation française. Cette traduction
permet aux développeurs francophones d'accéder à cette référence
dans leur langue.

### Additional details
- Traduction complète à partir de la version anglaise
  (sourceCommit: ac806e3)
- Création du dossier `files/fr/web/svg/reference/element/set/`
- Tous les liens internes pointent vers `/fr/docs/`

### Related issues and pull requests
Part of #34956