### PR TITLE
chore(fr): mise à jour de l'élément SVG `<feGaussianBlur>`

### DIFF
--- a/files/fr/web/svg/reference/element/fegaussianblur/index.md
+++ b/files/fr/web/svg/reference/element/fegaussianblur/index.md
@@ -7,18 +7,18 @@ l10n:
 
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feGaussianBlur>`** applique un effet de flou à l'image en entrée. La quantité de flou est définie par l'attribut {{SVGAttr("stdDeviation")}}, qui décrit la courbe en cloche du flou gaussien.
 
-Comme les autres primitives de filtres, elle traite les composantes colorimétriques dans l'{{glossary("color space", "espace colorimétrique")}} `linearRGB` par défaut. L'attribut {{SVGAttr("color-interpolation-filters")}} permet d'utiliser `sRGB` à la place.
+Comme les autres primitives de filtres, elle traite les composantes colorimétriques dans {{Glossary("color space", "l'espace colorimétrique")}} `linearRGB` par défaut. L'attribut {{SVGAttr("color-interpolation-filters")}} permet d'utiliser `sRGB` à la place.
 
 ## Contexte d'utilisation
 
-{{svginfo}}
+{{SVGInfo}}
 
 ## Attributs
 
 - {{SVGAttr("in")}}
 - {{SVGAttr("stdDeviation")}}
 - {{SVGAttr("edgeMode")}}
-- [Attributs des primitives de filtres](/fr/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes) : {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
+- [Attributs des primitives de filtres](/fr/docs/Web/SVG/Reference/Attribute#attributs_pour_les_primitives_de_filtre)&nbsp;: {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## Interface DOM
 
@@ -48,7 +48,7 @@ Cet élément implémente l'interface {{domxref("SVGFEGaussianBlurElement")}}.
 
 #### Résultat
 
-{{EmbedLiveSample("Exemple_simple", "", "130")}}
+{{EmbedLiveSample("Exemple simple", "", 130)}}
 
 ### Exemple avec une ombre portée
 
@@ -75,7 +75,7 @@ Cet élément implémente l'interface {{domxref("SVGFEGaussianBlurElement")}}.
 
 #### Résultat
 
-{{EmbedLiveSample("Exemple_avec_une_ombre_portée", "", "130")}}
+{{EmbedLiveSample("Exemple avec une ombre portée", "", 130)}}
 
 ## Spécifications
 
@@ -87,7 +87,7 @@ Cet élément implémente l'interface {{domxref("SVGFEGaussianBlurElement")}}.
 
 ## Voir aussi
 
-- [Attributs SVG pour les primitives de filtres](/fr/docs/Web/SVG/Reference/Attribute#filters_attributes)
+- [Attributs SVG pour les primitives de filtres](/fr/docs/Web/SVG/Reference/Attribute#attributs_de_filtre)
 - {{SVGElement("filter")}}
 - {{SVGElement("feBlend")}}
 - {{SVGElement("feColorMatrix")}}
@@ -104,4 +104,4 @@ Cet élément implémente l'interface {{domxref("SVGFEGaussianBlurElement")}}.
 - {{SVGElement("feSpecularLighting")}}
 - {{SVGElement("feTile")}}
 - {{SVGElement("feTurbulence")}}
-- [Tutoriel SVG : Filtres](/fr/docs/Web/SVG/Tutorials/SVG_from_scratch/Filter_effects)
+- [Tutoriel SVG&nbsp;: Filtres](/fr/docs/Web/SVG/Tutorials/SVG_from_scratch/Filter_effects)

--- a/files/fr/web/svg/reference/element/fegaussianblur/index.md
+++ b/files/fr/web/svg/reference/element/fegaussianblur/index.md
@@ -1,12 +1,13 @@
 ---
 title: <feGaussianBlur>
 slug: Web/SVG/Reference/Element/feGaussianBlur
-original_slug: Web/SVG/Element/feGaussianBlur
+l10n:
+  sourceCommit: 62476ac3c21417ad3a07e12c9f8eaf92cea8311d
 ---
 
-{{SVGRef}}
+La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feGaussianBlur>`** applique un effet de flou à l'image en entrée. La quantité de flou est définie par l'attribut {{SVGAttr("stdDeviation")}}, qui décrit la courbe en cloche du flou gaussien.
 
-La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feGaussianBlur>`** applique un effet de flou à l'image en entrée. La quantité de flou est contrôlée par {{SVGAttr("stdDeviation")}}.
+Comme les autres primitives de filtres, elle traite les composantes colorimétriques dans l'{{glossary("color space", "espace colorimétrique")}} `linearRGB` par défaut. L'attribut {{SVGAttr("color-interpolation-filters")}} permet d'utiliser `sRGB` à la place.
 
 ## Contexte d'utilisation
 
@@ -14,19 +15,10 @@ La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feGaussianBlur>`** applique u
 
 ## Attributs
 
-### Attributs globaux
-
-- [Attributs de base](/fr/docs/Web/SVG/Reference/Attribute#attributs_de_base)
-- [Attributs de présentation](/fr/docs/Web/SVG/Reference/Attribute#attributs_de_présentation)
-- [Attributs de primitives de filtres](/fr/docs/Web/SVG/Reference/Attribute#attributs_de_primitives_de_filtre)
-- {{SVGAttr("class")}}
-- {{SVGAttr("style")}}
-
-### Attributs spécifiques
-
 - {{SVGAttr("in")}}
 - {{SVGAttr("stdDeviation")}}
 - {{SVGAttr("edgeMode")}}
+- [Attributs des primitives de filtres](/fr/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes) : {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## Interface DOM
 
@@ -56,7 +48,7 @@ Cet élément implémente l'interface {{domxref("SVGFEGaussianBlurElement")}}.
 
 #### Résultat
 
-{{EmbedLiveSample("Exemple_simple",232,124)}}
+{{EmbedLiveSample("Exemple_simple", "", "130")}}
 
 ### Exemple avec une ombre portée
 
@@ -83,7 +75,7 @@ Cet élément implémente l'interface {{domxref("SVGFEGaussianBlurElement")}}.
 
 #### Résultat
 
-{{EmbedLiveSample("Exemple_avec_une_ombre_portée",125,124)}}
+{{EmbedLiveSample("Exemple_avec_une_ombre_portée", "", "130")}}
 
 ## Spécifications
 
@@ -95,6 +87,7 @@ Cet élément implémente l'interface {{domxref("SVGFEGaussianBlurElement")}}.
 
 ## Voir aussi
 
+- [Attributs SVG pour les primitives de filtres](/fr/docs/Web/SVG/Reference/Attribute#filters_attributes)
 - {{SVGElement("filter")}}
 - {{SVGElement("feBlend")}}
 - {{SVGElement("feColorMatrix")}}
@@ -111,4 +104,4 @@ Cet élément implémente l'interface {{domxref("SVGFEGaussianBlurElement")}}.
 - {{SVGElement("feSpecularLighting")}}
 - {{SVGElement("feTile")}}
 - {{SVGElement("feTurbulence")}}
-- [Tutoriel SVG: Filtres](/fr/docs/Web/SVG/Tutorials/SVG_from_scratch/Filter_effects)
+- [Tutoriel SVG : Filtres](/fr/docs/Web/SVG/Tutorials/SVG_from_scratch/Filter_effects)

--- a/files/fr/web/svg/reference/element/fegaussianblur/index.md
+++ b/files/fr/web/svg/reference/element/fegaussianblur/index.md
@@ -22,7 +22,7 @@ Comme les autres primitives de filtres, elle traite les composantes colorimétri
 
 ## Interface DOM
 
-Cet élément implémente l'interface {{domxref("SVGFEGaussianBlurElement")}}.
+Cet élément implémente l'interface {{DOMxRef("SVGFEGaussianBlurElement")}}.
 
 ## Exemple
 
@@ -88,20 +88,20 @@ Cet élément implémente l'interface {{domxref("SVGFEGaussianBlurElement")}}.
 ## Voir aussi
 
 - [Attributs SVG pour les primitives de filtres](/fr/docs/Web/SVG/Reference/Attribute#attributs_de_filtre)
-- {{SVGElement("filter")}}
-- {{SVGElement("feBlend")}}
-- {{SVGElement("feColorMatrix")}}
-- {{SVGElement("feComponentTransfer")}}
-- {{SVGElement("feComposite")}}
-- {{SVGElement("feConvolveMatrix")}}
-- {{SVGElement("feDiffuseLighting")}}
-- {{SVGElement("feDisplacementMap")}}
-- {{SVGElement("feFlood")}}
-- {{SVGElement("feImage")}}
-- {{SVGElement("feMerge")}}
-- {{SVGElement("feMorphology")}}
-- {{SVGElement("feOffset")}}
-- {{SVGElement("feSpecularLighting")}}
-- {{SVGElement("feTile")}}
-- {{SVGElement("feTurbulence")}}
+- L'élément {{SVGElement("filter")}}
+- L'élément {{SVGElement("feBlend")}}
+- L'élément {{SVGElement("feColorMatrix")}}
+- L'élément {{SVGElement("feComponentTransfer")}}
+- L'élément {{SVGElement("feComposite")}}
+- L'élément {{SVGElement("feConvolveMatrix")}}
+- L'élément {{SVGElement("feDiffuseLighting")}}
+- L'élément {{SVGElement("feDisplacementMap")}}
+- L'élément {{SVGElement("feFlood")}}
+- L'élément {{SVGElement("feImage")}}
+- L'élément {{SVGElement("feMerge")}}
+- L'élément {{SVGElement("feMorphology")}}
+- L'élément {{SVGElement("feOffset")}}
+- L'élément {{SVGElement("feSpecularLighting")}}
+- L'élément {{SVGElement("feTile")}}
+- L'élément {{SVGElement("feTurbulence")}}
 - [Tutoriel SVG&nbsp;: Filtres](/fr/docs/Web/SVG/Tutorials/SVG_from_scratch/Filter_effects)


### PR DESCRIPTION
### Description
Mise à jour de la traduction française de la page `<feGaussianBlur>` pour l'aligner sur la version anglaise actuelle (commit `62476ac`).

### Motivation
L'ancienne version française était figée sur un import legacy (champ `original_slug` historique, macro `{{SVGRef}}` obsolète) et avait pris ~5 ans de retard sur la version anglaise. En particulier, elle ne mentionnait pas le traitement des composantes colorimétriques dans l'espace `linearRGB` par défaut ni la possibilité d'utiliser `sRGB` via `color-interpolation-filters` — une information technique importante pour les développeurs qui travaillent sur des filtres SVG.

### Additional details
- Frontmatter modernisé : retrait de `original_slug`, ajout de `l10n.sourceCommit: 62476ac3c21417ad3a07e12c9f8eaf92cea8311d`
- Retrait de la macro obsolète `{{SVGRef}}`
- Ajout du paragraphe sur `linearRGB` / `sRGB`
- Section Attributs aplatie pour suivre la nouvelle structure EN
- Dimensions des `EmbedLiveSample` alignées sur la version EN
- Ajout du lien « Attributs SVG pour les primitives de filtres » en tête de la section « Voir aussi »
- Petite correction typographique FR (espace insécable avant les deux-points dans « Tutoriel SVG : Filtres »)

### Related issues and pull requests
Part of #34956