### PR TITLE
Sync writing_guidelines/howto [es]

### DIFF
--- a/files/es/mdn/writing_guidelines/howto/index.md
+++ b/files/es/mdn/writing_guidelines/howto/index.md
@@ -1,15 +1,18 @@
 ---
-title: Guías prácticas
+title: Guías prácticas para colaboradores de MDN
+short-title: Guías prácticas
 slug: MDN/Writing_guidelines/Howto
 l10n:
-  sourceCommit: aa66311219951396e7305df61eb31831360d2c79
+  sourceCommit: 719645a32546d9e514ac530a5eb66aa4c26d4f51
 ---
 
-{{MDNSidebar}}
+Esta sección de las guías de escritura de MDN Web Docs contiene los detalles
+paso a paso para realizar tareas específicas al contribuir a MDN Web Docs:
+cómo usamos Markdown, cómo añadimos una entrada al glosario, cómo movemos o
+eliminamos páginas y más.
+Para saber _cómo contribuir_, consulta nuestras
+[guías de contribución](/es/docs/MDN/Community).
+En estos documentos se asume que has leído las guías de contribución, que estás
+familiarizado con el repositorio `mdn/content` y que sabes usar Git y GitHub.
 
-Esta sección de las guías de escritura de MDN Web Docs contiene toda la información paso a paso para realizar tareas específicas al contribuir a MDN Web Docs: cómo usamos Markdown, cómo agregamos una entrada al glosario, cómo movemos o eliminamos páginas y más. Para saber más sobre _cómo contribuir_ (que se realiza a través de GitHub), consulta nuestras [guías de contribución](/es/docs/conflicting/MDN/Community).
-
-> [!NOTE]
-> A lo largo de esta sección, asumimos que ha leído las guías de contribución, está familiarizado con el repositorio `mdn/content` y sabe cómo usar git y GitHub.
-
-{{LandingPageListSubpages}}
+{{SubpagesWithSummaries}}


### PR DESCRIPTION
## Description

Syncs the Spanish translation of `How-to guides for MDN contributors` with the current English source in `mdn/content`.

## Changes

- Updated `l10n.sourceCommit` to the latest English commit SHA.
- Added `short-title` to front-matter.
- Replaced `{{LandingPageListSubpages}}` with `{{SubpagesWithSummaries}}` to match the English source macro.
- Removed outdated `{{MDNSidebar}}`.
- Synchronized content to exactly match the latest English version, removing outdated notes and text.
- Fixed internal link: `/es/docs/conflicting/MDN/Community` → `/es/docs/MDN/Community`.

## Related

Closes #35388
Parent issue: #35373