### PR TITLE
fix(fr): typos for `XMLHttpRequest.open()` method page

### DIFF
--- a/files/fr/web/api/xmlhttprequest/open/index.md
+++ b/files/fr/web/api/xmlhttprequest/open/index.md
@@ -29,7 +29,7 @@ XMLHttpRequest.open(method, url, async, user, password);
   - : Un booléen optionnel par défaut à `true`, indiquant s'il faut, ou pas, traiter la requête en asynchrone. Si la valeur est à `false`, la méthode `send()` ne retourne rien tant qu'elle n'a pas reçu la réponse. Si la valeur est à `true`, une notification de transaction complétée est fournie en utilisant un gestionnaire d'évènements. Le paramètre doit être sur "true" si l'attribut `multipart` est sur "true" aussi ou une exception sera levée.
 
     > [!NOTE]
-    > Les requêtes asynchrones sur le "thread" principal peuvent facilement dérouter l'utilisateur et devraient être évitées; En fait, de nombreux navigateurs ont un support XHR obsolète sur la totalité du "thread" principal. Les requêtes synchrones sont acceptées dans {{domxref("Worker")}}.
+    > Les requêtes synchrones sur le "thread" principal peuvent facilement dérouter l'utilisateur et devraient être évitées; En fait, de nombreux navigateurs ont un support XHR obsolète sur la totalité du "thread" principal. Les requêtes synchrones sont acceptées dans {{domxref("Worker")}}.
 
 - `user` {{optional_inline}}
   - : Le nom de l'utilisateur, optionnel, à utiliser dans un but d'authentification. Sa valeur par défaut est `null`.


### PR DESCRIPTION
### Description

Replaced a use of "asynchrones" with "synchrones".

### Motivation

The original sentence said the opposite of what it should. The English version uses the word "synchronous".

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
