### PR TITLE
Web/JavaScript/Reference/Errors/Deprecated_octal_escape_sequence を新規翻訳

### DIFF
--- a/files/ja/web/javascript/reference/errors/deprecated_octal_escape_sequence/index.md
+++ b/files/ja/web/javascript/reference/errors/deprecated_octal_escape_sequence/index.md
@@ -1,0 +1,60 @@
+---
+title: "SyntaxError: octal escape sequences can't be used in untagged template literals or in strict mode code"
+slug: Web/JavaScript/Reference/Errors/Deprecated_octal_escape_sequence
+l10n:
+  sourceCommit: fad67be4431d8e6c2a89ac880735233aa76c41d4
+---
+
+JavaScript 例外 "octal escape sequences can't be used in untagged template literals or in strict mode code" は、[厳格モード](/ja/docs/Web/JavaScript/Reference/Strict_mode)の文字列リテラルやタグなしテンプレートリテラル内で 8 進エスケープシーケンスが使用された場合に発生します。
+
+## エラーメッセージ
+
+```plain
+SyntaxError: Octal escape sequences are not allowed in strict mode. (V8-based)
+SyntaxError: \8 and \9 are not allowed in strict mode. (V8-based)
+SyntaxError: Octal escape sequences are not allowed in template strings. (V8-based)
+SyntaxError: \8 and \9 are not allowed in template strings. (V8-based)
+SyntaxError: octal escape sequences can't be used in untagged template literals or in strict mode code (Firefox)
+SyntaxError: the escapes \8 and \9 can't be used in untagged template literals or in strict mode code (Firefox)
+SyntaxError: The only valid numeric escape in strict mode is '\0' (Safari)
+```
+
+## エラーの種類
+
+{{jsxref("SyntaxError")}}
+
+## エラーの原因
+
+`\` に続いて、単一の `0` 以外の任意の数値が続く形式の [文字列エスケープシーケンス](/ja/docs/Web/JavaScript/Reference/Lexical_grammar#escape_sequences) は、非推奨となっています。文字をコードポイント値で表したい場合は、代わりに `\x` または `\u` エスケープシーケンスを使用しましょう。例えば、`\1` の代わりに `\x01` や `\u0001` を使用します。
+
+[タグなしのテンプレートリテラル](/ja/docs/Web/JavaScript/Reference/Template_literals)には、厳格モードであるかどうかにかかわらず、8 進数のエスケープシーケンスを含めることはできません。一方、タグ付きのテンプレートリテラルには、どの形のエスケープシーケンスでも含めることができ、その場合、タグ関数が受け取るテンプレート配列には `undefined` が格納されます。
+
+## 例
+
+### 8 進エスケープシーケンス
+
+```js-nolint example-bad
+"use strict";
+
+"\251";
+
+// SyntaxError: octal escape sequences can't be used in untagged template literals or in strict mode code
+```
+
+### 有効な 8 進数の数値
+
+8進数のエスケープシーケンスについては、代わりに16進数のエスケープシーケンスを使用することができます。
+
+```js example-good
+"\xA9";
+```
+
+エスケープシーケンスを解釈せずにソーステキストをそのまま表したい場合は、{{jsxref("String.raw")}} を使用してください。
+
+```js example-good
+String.raw`\251`; // 4 文字から成る文字列
+```
+
+## 関連情報
+
+- [字句文法](/ja/docs/Web/JavaScript/Reference/Lexical_grammar#エスケープシーケンス)

--- a/files/ja/web/javascript/reference/errors/import_decl_module_top_level/index.md
+++ b/files/ja/web/javascript/reference/errors/import_decl_module_top_level/index.md
@@ -1,0 +1,80 @@
+---
+title: "SyntaxError: import declarations may only appear at top level of a module"
+slug: Web/JavaScript/Reference/Errors/import_decl_module_top_level
+l10n:
+  sourceCommit: fad67be4431d8e6c2a89ac880735233aa76c41d4
+---
+
+JavaScript 例外 "import declarations may only appear at top level of a module" は、import 宣言がモジュールの最上位レベルにない場合に発生します。これは、import 宣言が他の構文（関数やブロックなど）を含むか、多くの場合で言えば、現在のファイルがモジュールとして扱われていないことが原因である可能性があります。
+
+## エラーメッセージ
+
+```plain
+SyntaxError: Cannot use import statement outside a module (V8-based)
+SyntaxError: import declarations may only appear at top level of a module (Firefox)
+SyntaxError: Unexpected identifier 'x'. import call expects one or two arguments. (Safari)
+```
+
+## エラーの種類
+
+{{jsxref("SyntaxError")}}
+
+## エラーの原因
+
+関数やブロックなど、`import` 宣言が別の構造の中に含まれている場合が考えられます。`import` 宣言は、モジュールの最上位に記述する必要があります。モジュールを条件付きでインポートしたり、必要に応じて遅延インポートしたりしたい場合は、代わりに [動的インポート](/ja/docs/Web/JavaScript/Reference/Operators/import) を使用してください。
+
+もし `import` がすでにコードの最上位にある場合は、そのファイルがモジュールとして解釈されていない可能性があります。ランタイムは、ファイルがモジュールであるかどうかを判断するために外部からのヒントを要求します。そのようなヒントを提供する方法はいくつかあります。
+
+- ファイルを HTML から直接読み込む場合は、[`<script>`](/ja/docs/Web/HTML/Reference/Elements/script) タグに `type="module"` 属性が設定されていることを確認してください。
+- ノードでファイルを実行する場合は、ファイルの拡張子が `.mjs` であるか、あるいは最も近い `package.json` ファイルに `"type": "module"` フィールドが含まれていることを確認してください。
+- ファイルを [ワーカー](/ja/docs/Web/API/Web_Workers_API/Using_web_workers)として実行する場合は、`Worker()` コンストラクターを `type: "module"` オプションをつけて呼び出すようにしてください。
+- このファイルを別のモジュールからインポートしてください。
+
+それ以外にも、原因として考えられるのは、コンパイラー（TypeScript など）をつけて `import` を記述している際に、誤ってソースファイルを実行してしまった場合です。`import` 宣言は通常、プログラムの先頭に現れるため、パーサーがまずこれを検知し、エラーを報告してしまうのです。必ずソースファイルをコンパイルし、コンパイルされたファイルを実行するようにしてください。
+
+## 例
+
+### 条件付きインポート
+
+Python と同様に、他の構文の内部で `import` を使用することはできません。
+
+```js example-bad
+if (writeOutput) {
+  import fs from "fs"; // SyntaxError
+}
+```
+
+`import` を最上位に移動するか、動的インポートを使用するかしてください。
+
+```js example-good
+if (writeOutput) {
+  import("fs").then((fs) => {
+    // use fs
+  });
+}
+```
+
+### モジュールではないスクリプトでのインポート
+
+HTML からスクリプトを読み込む場合は、必ず `<script>` タグに `type="module"` 属性を追加してください。
+
+```html
+<script type="module" src="main.js"></script>
+```
+
+何らかの理由でスクリプトをモジュールに移行できない場合は、動的インポートを使用することができます。
+
+```js example-good
+async function main() {
+  const myModule = await import("./my-module.js");
+  // use myModule
+}
+
+main();
+```
+
+## 関連情報
+
+- [モジュールの使用](/ja/docs/Web/JavaScript/Guide/Modules)
+- {{jsxref("Statements/import", "import")}}
+- {{jsxref("Operators/import", "import()")}}

--- a/files/ja/web/javascript/reference/errors/regex_invalid_char_in_class/index.md
+++ b/files/ja/web/javascript/reference/errors/regex_invalid_char_in_class/index.md
@@ -1,0 +1,45 @@
+---
+title: "SyntaxError: invalid character in class in regular expression"
+slug: Web/JavaScript/Reference/Errors/Regex_invalid_char_in_class
+l10n:
+  sourceCommit: fad67be4431d8e6c2a89ac880735233aa76c41d4
+---
+
+JavaScript の例外 "invalid character in class in regular expression" は、[`v`モードの文字クラス](/ja/docs/Web/JavaScript/Reference/Regular_expressions/Character_class#v_モード文字クラス)内に文字が現れるにもかかわらず、その文字をリテラルとして記述することができることが許可されていない場合に発生します。
+
+## エラーメッセージ
+
+```plain
+SyntaxError: Invalid regular expression: /[|]/v: Invalid character in character class (V8-based)
+SyntaxError: invalid character in class in regular expression (Firefox)
+SyntaxError: Invalid regular expression: invalid class set character (Safari)
+```
+
+## エラーの種類
+
+{{jsxref("SyntaxError")}}
+
+## エラーの原因
+
+通常、文字クラスには、ほぼすべての文字がリテラルとして含まれています。しかし、`v` モードでは文字クラスの構文がより洗練されたものとなり、将来の構文拡張に備えるため、一部の構文文字が文字クラス内でリテラルとして現れることを禁止しています。これには、`(`、`)`、`[`、`]`、`{`、`}`、`/`、`-`、`|` が含まれます。これらのリテラル文字を照合したい場合は、エスケープしてください。例えば、`/[\|]/v` のようにします。
+
+## 例
+
+### 無効な場合
+
+```js example-bad
+/[(){}]/v;
+```
+
+### 有効な場合
+
+<!-- メモ: {} は二重にエスケープする必要がある。1 つは Yari 用 -->
+
+```js example-good
+/[\(\)\\{\\}]/v;
+```
+
+## 関連情報
+
+- [正規表現](/ja/docs/Web/JavaScript/Reference/Regular_expressions)
+- [文字クラス: `[...]`, `[^...]`](/ja/docs/Web/JavaScript/Reference/Regular_expressions/Character_class)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
