### PR TITLE
[ko] Fix HTTP header macro link

### DIFF
--- a/files/ko/web/http/reference/headers/content-type/index.md
+++ b/files/ko/web/http/reference/headers/content-type/index.md
@@ -86,4 +86,4 @@ Content-Type: text/plain
 - {{HTTPHeader("Accept")}}과 {{HTTPHeader("Accept-Charset")}}
 - {{HTTPHeader("Content-Disposition")}}
 - {{HTTPStatus("206")}} Partial Content
-- {{HTTPStatus("X-Content-Type-Options")}}
+- {{HTTPHeader("X-Content-Type-Options")}}


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updates a broken HTTP Header link to use the `{{HTTPHeader}}` macro instead of `{{HTTPStatus}}`.

### Motivation

Fixes the link, and resolves a flaw: 

[1 issues — live view](https://caugner.github.io/mdn-flawless/#templ=httpstatus)

**Filters:**
- templ: `httpstatus`

| Category | File | Slug | Message |
|---|---|---|---|
| templ-broken-link | [translated-content/files/ko/web/http/reference/headers/content-type/index.md:88:2](https://github.com/mdn/translated-content/blob/main/files/ko/web/http/reference/headers/content-type/index.md?plain=1#L89C3-L89C43) | [Web/HTTP/Reference/Headers/Content-Type](https://developer.mozilla.org/ko/docs/Web/HTTP/Reference/Headers/Content-Type) | /ko/docs/Web/HTTP/Reference/Status/X-Content-Type-Options |

### Additional details



### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.