### PR TITLE
fix(fr): example in note don't explain ths shorten version properly

### DIFF
--- a/files/fr/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
+++ b/files/fr/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
@@ -84,12 +84,10 @@ const header = (
 > [!NOTE]
 > Les parenthèses dans l'extrait de code précédent ne sont pas propres à JSX et n'ont aucun effet sur votre application. Elles sont un signal pour vous (et votre ordinateur) que plusieurs lignes de code à l'intérieur font partie de la même expression. Vous pourriez tout aussi bien écrire l'expression d'en-tête comme ceci&nbsp;:
 >
-> ```js
-> const header = (
->   <header>
->     <h1>Mozilla Developer Network</h1>
->   </header>
-> );
+> ```jsx-nolint
+> const header = <header>
+>   <h1>Mozilla Developer Network</h1>
+> </header>;
 > ```
 >
 > Cependant, cela semble un peu gênant, car la balise [`<header>`](/fr/docs/Web/HTML/Reference/Elements/header) qui commence l'expression n'est pas indentée à la même position que sa balise de fermeture correspondante.


### PR DESCRIPTION
### Description

Correct the bad example so that it remains bad. Just like they do in [English](https://github.com/mdn/content/blob/52a81d8138473b6ac4bec77d0be4261cb0b76d41/files/en-us/learn_web_development/core/frameworks_libraries/react_getting_started/index.md?plain=1#L74-L78).

### Motivation

The note doesn't make sense, because the example is the same as the correct one.