### PR TITLE
[zh-tw] Replace `{{domxref}}` with `{{jsxref}}` for `DOMString` and `USVString`

### DIFF
--- a/files/zh-tw/web/api/errorevent/index.md
+++ b/files/zh-tw/web/api/errorevent/index.md
@@ -12,9 +12,9 @@ slug: Web/API/ErrorEvent
 _此介面繼承了其父 {{domxref("Event")}} 的 properties 。_
 
 - {{domxref("ErrorEvent.message")}} {{readonlyInline}}
-  - : 一 {{domxref("DOMString")}} 提供具可讀性的關於問題的錯誤訊息。
+  - : 一 {{jsxref("String")}} 提供具可讀性的關於問題的錯誤訊息。
 - {{domxref("ErrorEvent.filename")}} {{readonlyInline}}
-  - : 一 {{domxref("DOMString")}} ，為發生錯誤的程式碼檔案的檔名。
+  - : 一 {{jsxref("String")}} ，為發生錯誤的程式碼檔案的檔名。
 - {{domxref("ErrorEvent.lineno")}} {{readonlyInline}}
   - : 一 `整數` ，為發生問題的程式的行數。
 - {{domxref("ErrorEvent.colno")}} {{readonlyInline}}

--- a/files/zh-tw/web/api/event/event/index.md
+++ b/files/zh-tw/web/api/event/event/index.md
@@ -16,7 +16,7 @@ event = new Event(typeArg, eventInit);
 ### 參數
 
 - _typeArg_
-  - : 為一 {{domxref("DOMString")}} ，用來表示事件名稱。
+  - : 為一 {{jsxref("String")}} ，用來表示事件名稱。
 - _eventInit_{{optional_inline}}
   - : 一個 `EventInit` object，包含以下欄位
 

--- a/files/zh-tw/web/api/file/file/index.md
+++ b/files/zh-tw/web/api/file/file/index.md
@@ -16,12 +16,12 @@ var myFile = new File(bits, name[, options]);
 ### 參數
 
 - _bits_
-  - : An {{jsxref("Array")}} of {{jsxref("ArrayBuffer")}}, {{domxref("ArrayBufferView")}}, {{domxref("Blob")}}, or {{domxref("DOMString")}} objects — 或是由這些物件組成的集合。這是以 UTF-8 編碼的檔案內容。
+  - : An {{jsxref("Array")}} of {{jsxref("ArrayBuffer")}}, {{domxref("ArrayBufferView")}}, {{domxref("Blob")}}, or {{jsxref("String")}} objects — 或是由這些物件組成的集合。這是以 UTF-8 編碼的檔案內容。
 - _name_
-  - : 檔案名稱或檔案的路徑（{{domxref("USVString")}}）。
+  - : 檔案名稱或檔案的路徑（{{jsxref("String")}}）。
 - _options_ {{optional_inline}}
   - : 物件選項，包含物件非必要的屬性，以下為可得到的屬性：
-    - `type`: 物件的 MIME 類型（{{domxref("DOMString")}} ）將被放進檔案中，預設為 ""（空值）。
+    - `type`: 物件的 MIME 類型（{{jsxref("String")}} ）將被放進檔案中，預設為 ""（空值）。
     - `lastModified`: 檔案最後修改時間，格式為毫秒，預設為 {{jsxref("Date.now()")}}.
 
 ## 範例

--- a/files/zh-tw/web/api/history/index.md
+++ b/files/zh-tw/web/api/history/index.md
@@ -14,11 +14,11 @@ _The `History`_ _interface doesn't inherit any property._
 - {{domxref("History.length")}} {{readOnlyInline}}
   - : Returns an `Integer` representing the number of elements in the session history, including the currently loaded page. For example, for a page loaded in a new tab this property returns `1`.
 - {{domxref("History.current")}} {{readOnlyInline}} {{ non-standard_inline() }} {{Deprecated_Inline}}
-  - : Returns a {{domxref("DOMString")}} representing the URL of the active item of the session history. This property was never available to web content and is no more supported by any browser. Use {{domxref("Location.href")}} instead.
+  - : Returns a {{jsxref("String")}} representing the URL of the active item of the session history. This property was never available to web content and is no more supported by any browser. Use {{domxref("Location.href")}} instead.
 - {{domxref("History.next")}} {{readOnlyInline}} {{ non-standard_inline() }} {{Deprecated_Inline}}
-  - : Returns a {{domxref("DOMString")}} representing the URL of the next item in the session history. This property was never available to web content and is not supported by other browsers.
+  - : Returns a {{jsxref("String")}} representing the URL of the next item in the session history. This property was never available to web content and is not supported by other browsers.
 - {{domxref("History.previous")}} {{readOnlyInline}} {{ non-standard_inline() }} {{Deprecated_Inline}}
-  - : Returns a {{domxref("DOMString")}} representing the URL of the previous item in the session history. This property was never available to web content and is not supported by other browsers.
+  - : Returns a {{jsxref("String")}} representing the URL of the previous item in the session history. This property was never available to web content and is not supported by other browsers.
 - {{domxref("History.scrollRestoration")}} {{experimental_inline}}
   - : Allows web applications to explicitly set default scroll restoration behavior on history navigation. This property can be either `auto` or `manual`.
 - {{domxref("History.state")}} {{readOnlyInline}}

--- a/files/zh-tw/web/api/html_drag_and_drop_api/drag_operations/index.md
+++ b/files/zh-tw/web/api/html_drag_and_drop_api/drag_operations/index.md
@@ -213,7 +213,7 @@ function doDragOver(event) {
 
 ### Updates to DataTransfer.types
 
-Note that the latest spec now dictates that {{domxref("DataTransfer.types")}} should return a frozen array of {{domxref("DOMString")}}s rather than a {{domxref("DOMStringList")}} (this is supported in Firefox 52 and above).
+Note that the latest spec now dictates that {{domxref("DataTransfer.types")}} should return a frozen array of {{jsxref("String")}}s rather than a {{domxref("DOMStringList")}} (this is supported in Firefox 52 and above).
 
 As a result, the [contains](/zh-TW/docs/Web/API/Node/contains) method no longer works on the property; the [includes](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Array/includes) method should be used instead to check if a specific type of data is provided, using code like the following:
 

--- a/files/zh-tw/web/api/html_drag_and_drop_api/index.md
+++ b/files/zh-tw/web/api/html_drag_and_drop_api/index.md
@@ -73,7 +73,7 @@ See the [draggable attribute reference](/zh-TW/docs/Web/HTML/Reference/Global_at
 
 ### Define the drag's data
 
-The application is free to include any number of data items in a drag operation. Each data item is a {{domxref("DOMString","string")}} of a particular `type`, typically a MIME type such as `text/html`.
+The application is free to include any number of data items in a drag operation. Each data item is a {{jsxref("String","string")}} of a particular `type`, typically a MIME type such as `text/html`.
 
 Each {{domxref("DragEvent","drag event")}} has a {{domxref("DragEvent.dataTransfer","dataTransfer")}} property that _holds_ the event's data. This property (which is a {{domxref("DataTransfer")}} object) also has methods to _manage_ drag data. The {{domxref("DataTransfer.setData","setData()")}} method is used to add an item to the drag data, as shown in the following example.
 

--- a/files/zh-tw/web/api/keyboardevent/index.md
+++ b/files/zh-tw/web/api/keyboardevent/index.md
@@ -33,7 +33,7 @@ _本介面（ interface）亦繼承其父，{{domxref("UIEvent")}} 和 {{domxref
 - {{domxref("KeyboardEvent.altKey")}} {{Readonlyinline}}
   - : 一個 {{jsxref("Boolean")}} 。用來表示在事件建立時， <kbd>Alt</kbd> （OS X 中是 <kbd>Option</kbd> 或 <kbd>⌥</kbd> ） 鍵是否執行中。
 - {{domxref("KeyboardEvent.char")}} {{Non-standard_inline}}{{Deprecated_inline}}{{Readonlyinline}}
-  - : 一個 {{domxref("DOMString")}} ，返回鍵盤對應的字符。若是該鍵對應一個實際的字符，則其值為對應該字符的一個非空的 Unicode 字串；若沒對應的話，則返回一個空字串。
+  - : 一個 {{jsxref("String")}} ，返回鍵盤對應的字符。若是該鍵對應一個實際的字符，則其值為對應該字符的一個非空的 Unicode 字串；若沒對應的話，則返回一個空字串。
 
     > [!NOTE]
     > If the key is used as a macro that inserts multiple characters, this attribute's value is the entire string, not just the first character.
@@ -48,13 +48,13 @@ _本介面（ interface）亦繼承其父，{{domxref("UIEvent")}} 和 {{domxref
     > 此 attribute 已被淘汰。如果可以，建議使用 {{domxref("KeyboardEvent.key")}}。
 
 - {{domxref("KeyboardEvent.code")}} {{Readonlyinline}}
-  - : 一個 {{domxref("DOMString")}} 。返回事件對應的按鍵的代碼。
+  - : 一個 {{jsxref("String")}} 。返回事件對應的按鍵的代碼。
 - {{domxref("KeyboardEvent.ctrlKey")}} {{Readonlyinline}}
   - : 一個 {{jsxref("Boolean")}} 。用來表示在事件建立時， <kbd>Ctrl</kbd> 鍵是否執行中。
 - {{domxref("KeyboardEvent.isComposing")}} {{Readonlyinline}}
   - : 一個 {{jsxref("Boolean")}} 。用來表示其觸發時間是否在 `compositionstart` 和 `compositionend` 之間。
 - {{domxref("KeyboardEvent.key")}} {{Readonlyinline}}
-  - : 一個 {{domxref("DOMString")}} ，用來事件對應的按鍵的值（key value）。
+  - : 一個 {{jsxref("String")}} ，用來事件對應的按鍵的值（key value）。
 - {{domxref("KeyboardEvent.keyCode")}} {{deprecated_inline}}{{Readonlyinline}}
   - : Returns a {{jsxref("Number")}} representing a system and implementation dependent numerical code identifying the unmodified value of the pressed key.
 
@@ -62,7 +62,7 @@ _本介面（ interface）亦繼承其父，{{domxref("UIEvent")}} 和 {{domxref
     > 此 attribute 已被淘汰。如果可以，建議使用{{domxref("KeyboardEvent.key")}}。
 
 - {{domxref("KeyboardEvent.locale")}} {{Readonlyinline}}
-  - : Returns a {{domxref("DOMString")}} representing a locale string indicating the locale the keyboard is configured for. This may be the empty string if the browser or device doesn't know the keyboard's locale.
+  - : Returns a {{jsxref("String")}} representing a locale string indicating the locale the keyboard is configured for. This may be the empty string if the browser or device doesn't know the keyboard's locale.
 
     > [!NOTE]
     > This does not describe the locale of the data being entered. A user may be using one keyboard layout while typing text in a different language.

--- a/files/zh-tw/web/api/keyboardevent/keyboardevent/index.md
+++ b/files/zh-tw/web/api/keyboardevent/keyboardevent/index.md
@@ -16,7 +16,7 @@ slug: Web/API/KeyboardEvent/KeyboardEvent
 ### 參數
 
 - `type`
-  - : 一 {{domxref("DOMString")}} 用來表示事件名稱。
+  - : 一 {{jsxref("String")}} 用來表示事件名稱。
 - `options` {{optional_inline}}
   - : 一個 `KeyboardEventInit` dictionary，能接受以下參數：
     - `key` {{optional_inline}}

--- a/files/zh-tw/web/api/mediasource/readystate/index.md
+++ b/files/zh-tw/web/api/mediasource/readystate/index.md
@@ -19,7 +19,7 @@ var myReadyState = mediaSource.readyState;
 
 ### 回傳值
 
-一個 {{domxref("DOMString")}}。
+一個 {{jsxref("String")}}。
 
 ## 範例
 

--- a/files/zh-tw/web/api/messageevent/index.md
+++ b/files/zh-tw/web/api/messageevent/index.md
@@ -9,9 +9,9 @@ slug: Web/API/MessageEvent
 
 ## 屬性
 
-| 屬性   | 形態                                                                                                                                    | 描述               |
-| ------ | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `data` | {{ domxref("DOMString") }} \| {{ domxref("Blob") }} \| [`ArrayBuffer`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) | 伺服器傳來的資料。 |
+| 屬性   | 形態                                                                                                                                | 描述               |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `data` | {{ jsxref("String") }} \| {{ domxref("Blob") }} \| [`ArrayBuffer`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) | 伺服器傳來的資料。 |
 
 ## 規範
 

--- a/files/zh-tw/web/api/navigator/language/index.md
+++ b/files/zh-tw/web/api/navigator/language/index.md
@@ -15,7 +15,7 @@ const lang = navigator.language
 
 ### 值
 
-一個 {{domxref("DOMString")}}. `lang` 儲存一個代表此語言的字串。定義在[BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)。範例: 合法的語言代碼 "en", "en-US", "fr", "fr-FR", "es-ES", etc.
+一個 {{jsxref("String")}}. `lang` 儲存一個代表此語言的字串。定義在[BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)。範例: 合法的語言代碼 "en", "en-US", "fr", "fr-FR", "es-ES", etc.
 
 在 iOS 小於 10.2 的 Safari 國碼是回傳小寫的喲！
 "en-us", "fr-fr" etc.

--- a/files/zh-tw/web/api/response/index.md
+++ b/files/zh-tw/web/api/response/index.md
@@ -60,7 +60,7 @@ slug: Web/API/Response
 - {{domxref("Body.json()")}}
   - : Takes a {{domxref("Response")}} stream and reads it to completion. It returns a promise that resolves with the result of parsing the body text as {{jsxref("JSON")}}.
 - {{domxref("Body.text()")}}
-  - : Takes a {{domxref("Response")}} stream and reads it to completion. It returns a promise that resolves with a {{domxref("USVString")}} (text).
+  - : Takes a {{domxref("Response")}} stream and reads it to completion. It returns a promise that resolves with a {{jsxref("String")}} (text).
 
 ## 範例
 

--- a/files/zh-tw/web/api/uievent/uievent/index.md
+++ b/files/zh-tw/web/api/uievent/uievent/index.md
@@ -16,7 +16,7 @@ slug: Web/API/UIEvent/UIEvent
 ### 參數
 
 - _typeArg_
-  - : 一個 {{domxref("DOMString")}} ，用來表示事件名稱
+  - : 一個 {{jsxref("String")}} ，用來表示事件名稱
 - _UIEventInit_{{optional_inline}}
   - : 一個 `UIEventInit` dictionary ，能接受以下參數：
     - `detail`

--- a/files/zh-tw/web/api/url/createobjecturl_static/index.md
+++ b/files/zh-tw/web/api/url/createobjecturl_static/index.md
@@ -7,7 +7,7 @@ slug: Web/API/URL/createObjectURL_static
 
 ## 摘要
 
-靜態方法 **`URL.createObjectURL()`** 用於建立一個帶有 URL 的 {{domxref("DOMString")}} 以代表參數中所傳入的物件. 該 URL 的生命週期與創造它的 window 中的 {{domxref("document")}}一致. 這個新的物件 URL 代表了所指定的 {{domxref("File")}} 物件 或是 {{domxref("Blob")}} 物件。
+靜態方法 **`URL.createObjectURL()`** 用於建立一個帶有 URL 的 {{jsxref("String")}} 以代表參數中所傳入的物件. 該 URL 的生命週期與創造它的 window 中的 {{domxref("document")}}一致. 這個新的物件 URL 代表了所指定的 {{domxref("File")}} 物件 或是 {{domxref("Blob")}} 物件。
 
 {{AvailableInWorkers}}
 

--- a/files/zh-tw/web/api/websocket/index.md
+++ b/files/zh-tw/web/api/websocket/index.md
@@ -17,16 +17,16 @@ slug: Web/API/WebSocket
 
 | 屬性             | 形態                                      | 描述                                                                                                                                                                                             |
 | ---------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `binaryType`     | {{ DOMXref("DOMString") }}                | 表示連線傳輸的二進制資料形態的字串，若使用 {{ domxref("Blob") }} 物件則為 "blob"，使用 [`ArrayBuffer`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) 物件則為 "arraybuffer"。 |
+| `binaryType`     | {{ jsxref("String") }}                    | 表示連線傳輸的二進制資料形態的字串，若使用 {{ domxref("Blob") }} 物件則為 "blob"，使用 [`ArrayBuffer`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) 物件則為 "arraybuffer"。 |
 | `bufferedAmount` | [`unsigned long`](/zh-TW/unsigned_long)   | 呼叫 [`send()`](#send) 隊列但尚未傳輸至網路上資料的位元數。連線關閉時此值不會重設為零。連續呼叫 [`send()`](#send) 會讓此值不斷上升。**唯讀**                                                     |
-| `extensions`     | {{ DOMXref("DOMString") }}                | 伺服器選擇的擴展。目前僅有空字串或表示資料經過壓縮的 "deflate-stream"。**唯讀**                                                                                                                  |
+| `extensions`     | {{ jsxref("String") }}                    | 伺服器選擇的擴展。目前僅有空字串或表示資料經過壓縮的 "deflate-stream"。**唯讀**                                                                                                                  |
 | `onclose`        | {{ domxref("EventListener") }}            | 當 WebSocket 連線的 `readyState` 切換至 `CLOSED` 時呼叫的事件監聽器。監聽器接收命名為 "close" 的 [`CloseEvent`](/zh-TW/WebSockets/WebSockets_reference/CloseEvent)。                             |
 | `onerror`        | {{ domxref("EventListener") }}            | 當錯誤發生時呼叫的事件監聽器。事件為命名 "error" 的簡單事件。                                                                                                                                    |
 | `onmessage`      | {{ domxref("EventListener") }}            | 當瀏覽器接收伺服器的訊息時呼叫的事件監聽器。監聽器接收命名為 "message" 的 [`MessageEvent`](/zh-TW/WebSockets/WebSockets_reference/MessageEvent)。                                                |
 | `onopen`         | {{ domxref("EventListener") }}            | 當 WebSocket 連線的 `readyState` 切換至 `OPEN` 時呼叫的事件監聽器，表示連線已準備傳送、接收資料。事件為命名 "open" 的簡單事件。                                                                  |
-| `protocol`       | {{ DOMXref("DOMString") }}                | 伺服器選擇的子協定，這是建立 WebSocket 物件時 `protocols` 參數裡的其中一個字串。                                                                                                                 |
+| `protocol`       | {{ jsxref("String") }}                    | 伺服器選擇的子協定，這是建立 WebSocket 物件時 `protocols` 參數裡的其中一個字串。                                                                                                                 |
 | `readyState`     | [`unsigned short`](/zh-TW/unsigned_short) | 連線的目前狀態，是就緒狀態常數的其中一個。**唯讀**                                                                                                                                               |
-| `url`            | {{ DOMXref("DOMString") }}                | 建構方法解析出來的 URL，總是絕對 URL。**唯讀**                                                                                                                                                   |
+| `url`            | {{ jsxref("String") }}                    | 建構方法解析出來的 URL，總是絕對 URL。**唯讀**                                                                                                                                                   |
 
 ## 常數
 

--- a/files/zh-tw/web/html/reference/elements/input/submit/index.md
+++ b/files/zh-tw/web/html/reference/elements/input/submit/index.md
@@ -5,7 +5,7 @@ slug: Web/HTML/Reference/Elements/input/submit
 
 {{HTMLElement("input")}} 元素的 **`"submit"`** 類型會被視為提交按鈕（submit button）——點選的話就能把表單提交到伺服器。
 
-| **[值](#值)**      | 用作按鈕 label 的 {{domxref("DOMString")}}                                                                                     |
+| **[值](#值)**      | 用作按鈕 label 的 {{jsxref("String")}}                                                                                         |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
 | **事件**           | [`click`](/zh-TW/docs/Web/API/Element/click_event)                                                                             |
 | **常見的支援屬性** | [`type`](/zh-TW/docs/Web/HTML/Reference/Elements/input#type) 與 [`value`](/zh-TW/docs/Web/HTML/Reference/Elements/input#value) |
@@ -14,7 +14,7 @@ slug: Web/HTML/Reference/Elements/input/submit
 
 ## 值
 
-`<input type="submit">` 元素的 [`value`](/zh-TW/docs/Web/HTML/Reference/Elements/input#value) 屬性會包含用作按鈕 label 的 {{domxref("DOMString")}}。
+`<input type="submit">` 元素的 [`value`](/zh-TW/docs/Web/HTML/Reference/Elements/input#value) 屬性會包含用作按鈕 label 的 {{jsxref("String")}}。
 
 ```html hidden
 <input type="submit" value="Submit to me" />

--- a/files/zh-tw/web/javascript/reference/global_objects/string/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/string/index.md
@@ -358,6 +358,6 @@ for (let i = 0, n = inputValues.length; i < n; ++i) {
 
 ## 參見
 
-- {{domxref("DOMString")}}
+- {{jsxref("String")}}
 - [`StringView` — a C-like representation of strings based on typed arrays](/zh-TW/docs/Mozilla/Add-ons/Code_snippets/StringView)
 - [Binary strings](/zh-TW/docs/Web/API/DOMString/Binary)


### PR DESCRIPTION
### Description

Replace `{{domxref("DOMString")}}` and `{{domxref("USVString")}}` (and case variants like `DOMxRef`, `DOMXref`) with `{{jsxref("String")}}` across the `zh-tw` locale, preserving any translated display text.

### Motivation

Make the `zh-tw` translated content match the English convention — `content/` has 0 remaining `{{domxref("DOMString")}}` / `{{domxref("USVString")}}` calls and uses `{{jsxref("String")}}` (180 occurrences) instead.

Avoid emitting `templ-redirected-link` / `templ-broken-link` flaws for these macros: the `Web/API/DOMString` and `Web/API/USVString` pages either redirect to the JavaScript `String` page (or a `conflicting/` stub of it) or are missing entirely in some locales.

### Additional details

17 files changed.

Measured against https://github.com/mdn/rari/pull/715, `domxref`-attributed flaws in `zh-tw` drop from **237** → **208** (Δ −29).

The substitution preserves translated display text: e.g. `{{domxref("DOMString", "<translated label>")}}` → `{{jsxref("String", "<translated label>")}}`.

### Related issues and pull requests

Part of a per-locale split; see also the sibling PRs for the other 6 locales.

Related to https://github.com/mdn/rari/pull/715.