### PR TITLE
chore(fr): mise à jour de l'élément SVG `<feBlend>`

### DIFF
--- a/files/fr/web/svg/reference/element/feblend/index.md
+++ b/files/fr/web/svg/reference/element/feblend/index.md
@@ -2,7 +2,7 @@
 title: <feBlend>
 slug: Web/SVG/Reference/Element/feBlend
 l10n:
-  sourceCommit: 48afb4da7957efe672d7fd837413ee1a69a842fd
+  sourceCommit: 62476ac3c21417ad3a07e12c9f8eaf92cea8311d
 ---
 
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feBlend>`** permet de composer deux objets ensemble selon un mode de fusion donné, à la manière de ce que proposent les logiciels de retouche d'image pour fusionner deux calques. Le mode utilisé est défini par l'attribut {{SVGAttr("mode")}}.
@@ -24,7 +24,7 @@ Comme les autres primitives de filtres, elle traite les composantes colorimétri
 
 Cet élément implémente l'interface {{DOMxRef("SVGFEBlendElement")}}.
 
-## Exemple
+## Exemples
 
 ### SVG
 
@@ -60,7 +60,7 @@ Cet élément implémente l'interface {{DOMxRef("SVGFEBlendElement")}}.
 
 ### Résultat
 
-{{EmbedLiveSample("Exemple", "", 200)}}
+{{EmbedLiveSample("Exemples", "", 200)}}
 
 ## Spécifications
 

--- a/files/fr/web/svg/reference/element/feblend/index.md
+++ b/files/fr/web/svg/reference/element/feblend/index.md
@@ -22,7 +22,7 @@ Comme les autres primitives de filtres, elle traite les composantes colorimétri
 
 ## Interface DOM
 
-Cet élément implémente l'interface {{domxref("SVGFEBlendElement")}}.
+Cet élément implémente l'interface {{DOMxRef("SVGFEBlendElement")}}.
 
 ## Exemple
 
@@ -73,22 +73,22 @@ Cet élément implémente l'interface {{domxref("SVGFEBlendElement")}}.
 ## Voir aussi
 
 - [Attributs des primitives de filtres SVG](/fr/docs/Web/SVG/Reference/Attribute#attributs_pour_les_primitives_de_filtre)
-- {{SVGElement("filter")}}
-- {{SVGElement("animate")}}
-- {{SVGElement("set")}}
-- {{SVGElement("feColorMatrix")}}
-- {{SVGElement("feComponentTransfer")}}
-- {{SVGElement("feComposite")}}
-- {{SVGElement("feConvolveMatrix")}}
-- {{SVGElement("feDiffuseLighting")}}
-- {{SVGElement("feDisplacementMap")}}
-- {{SVGElement("feFlood")}}
-- {{SVGElement("feGaussianBlur")}}
-- {{SVGElement("feImage")}}
-- {{SVGElement("feMerge")}}
-- {{SVGElement("feMorphology")}}
-- {{SVGElement("feOffset")}}
-- {{SVGElement("feSpecularLighting")}}
-- {{SVGElement("feTile")}}
-- {{SVGElement("feTurbulence")}}
+- L'élément {{SVGElement("filter")}}
+- L'élément {{SVGElement("animate")}}
+- L'élément {{SVGElement("set")}}
+- L'élément {{SVGElement("feColorMatrix")}}
+- L'élément {{SVGElement("feComponentTransfer")}}
+- L'élément {{SVGElement("feComposite")}}
+- L'élément {{SVGElement("feConvolveMatrix")}}
+- L'élément {{SVGElement("feDiffuseLighting")}}
+- L'élément {{SVGElement("feDisplacementMap")}}
+- L'élément {{SVGElement("feFlood")}}
+- L'élément {{SVGElement("feGaussianBlur")}}
+- L'élément {{SVGElement("feImage")}}
+- L'élément {{SVGElement("feMerge")}}
+- L'élément {{SVGElement("feMorphology")}}
+- L'élément {{SVGElement("feOffset")}}
+- L'élément {{SVGElement("feSpecularLighting")}}
+- L'élément {{SVGElement("feTile")}}
+- L'élément {{SVGElement("feTurbulence")}}
 - [Tutoriel SVG&nbsp;: Effets de filtre](/fr/docs/Web/SVG/Tutorials/SVG_from_scratch/Filter_effects)

--- a/files/fr/web/svg/reference/element/feblend/index.md
+++ b/files/fr/web/svg/reference/element/feblend/index.md
@@ -1,32 +1,24 @@
 ---
 title: <feBlend>
 slug: Web/SVG/Reference/Element/feBlend
-original_slug: Web/SVG/Element/feBlend
+l10n:
+  sourceCommit: 48afb4da7957efe672d7fd837413ee1a69a842fd
 ---
 
-{{SVGRef}}
+La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feBlend>`** permet de composer deux objets ensemble selon un mode de fusion donné, à la manière de ce que proposent les logiciels de retouche d'image pour fusionner deux calques. Le mode utilisé est défini par l'attribut {{SVGAttr("mode")}}.
 
-La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feBlend>`** permet de combiner deux objets en utilisant un mode de fusion définit, un peu de la même manière que les logiciels de retouche d'image permettent de fusionner deux calques. Le mode à utiliser est définit par l'attribut {{SVGAttr("mode")}}.
+Comme les autres primitives de filtres, elle traite les composantes colorimétriques dans {{Glossary("color space", "l'espace colorimétrique")}} `linearRGB` par défaut. L'attribut {{SVGAttr("color-interpolation-filters")}} permet d'utiliser `sRGB` à la place.
 
 ## Contexte d'utilisation
 
-{{svginfo}}
+{{SVGInfo}}
 
 ## Attributs
-
-### Attributs globaux
-
-- [Attributs de base](/fr/docs/Web/SVG/Reference/Attribute#attributs_de_base)
-- [Attributs de présentation](/fr/docs/Web/SVG/Reference/Attribute#attributs_de_présentation)
-- [Attributs de primitive de filtre](/fr/docs/Web/SVG/Reference/Attribute#attributs_de_primitives_de_filtre)
-- {{SVGAttr("class")}}
-- {{SVGAttr("style")}}
-
-### Attributs spécifiques
 
 - {{SVGAttr("in")}}
 - {{SVGAttr("in2")}}
 - {{SVGAttr("mode")}}
+- [Attributs des primitives de filtres](/fr/docs/Web/SVG/Reference/Attribute#attributs_pour_les_primitives_de_filtre)&nbsp;: {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## Interface DOM
 
@@ -57,18 +49,18 @@ Cet élément implémente l'interface {{domxref("SVGFEBlendElement")}}.
   </defs>
 
   <image
-    xlink:href="/files/6457/mdn_logo_only_color.png"
+    href="mdn_logo_only_color.png"
     x="10%"
     y="10%"
     width="80%"
     height="80%"
-    style="filter:url(#spotlight);" />
+    filter="url(#spotlight)" />
 </svg>
 ```
 
 ### Résultat
 
-{{EmbedLiveSample("Exemple", 200, 200)}}
+{{EmbedLiveSample("Exemple", "", 200)}}
 
 ## Spécifications
 
@@ -80,6 +72,7 @@ Cet élément implémente l'interface {{domxref("SVGFEBlendElement")}}.
 
 ## Voir aussi
 
+- [Attributs des primitives de filtres SVG](/fr/docs/Web/SVG/Reference/Attribute#attributs_pour_les_primitives_de_filtre)
 - {{SVGElement("filter")}}
 - {{SVGElement("animate")}}
 - {{SVGElement("set")}}
@@ -98,4 +91,4 @@ Cet élément implémente l'interface {{domxref("SVGFEBlendElement")}}.
 - {{SVGElement("feSpecularLighting")}}
 - {{SVGElement("feTile")}}
 - {{SVGElement("feTurbulence")}}
-- [Tutoriel SVG: Filtres](/fr/docs/Web/SVG/Tutorials/SVG_from_scratch/Filter_effects)
+- [Tutoriel SVG&nbsp;: Effets de filtre](/fr/docs/Web/SVG/Tutorials/SVG_from_scratch/Filter_effects)


### PR DESCRIPTION
## Description

Mise à jour de la page `/fr/docs/Web/SVG/Reference/Element/feBlend` pour aligner sur la version EN courante (`l10n.sourceCommit: 48afb4da7957efe672d7fd837413ee1a69a842fd`).

## Motivation

Part of #34956 — chantier collaboratif MDN-FR section SVG, éléments.

## Changements

**Frontmatter modernisé** :
- `original_slug` retiré (legacy Yari)
- `l10n.sourceCommit` ajouté (40 caractères, valide sur `mdn/content`)

**Corps** :
- Macro `{{SVGRef}}` retirée (obsolète, gérée par `sidebar: svgref` côté EN — convention FR = simple suppression)
- Macros passées en PascalCase strict (`{{SVGInfo}}`, `{{SVGAttr}}`, `{{SVGElement}}`, `{{Glossary}}`)
- Typo historique « définit » corrigée en « défini » (×2 dans le premier paragraphe)
- Paragraphe sur `linearRGB` / `sRGB` ajouté — présent côté EN, manquait FR (cohérent avec la mise à jour `<feGaussianBlur>` #36114)
- Exemple modernisé :
  - `xlink:href` → `href` (xlink déprécié)
  - `style="filter:url(#spotlight);"` → `filter="url(#spotlight)"` (attribut SVG plutôt que style inline)
  - Source image relative (alignement EN)
- Liste d'attributs simplifiée : suppression de la double section globaux/spécifiques au profit d'un lien vers la section [primitives de filtres](/fr/docs/Web/SVG/Reference/Attribute#attributs_pour_les_primitives_de_filtre)
- `{{EmbedLiveSample}}` au format compact : titre humain `"Exemple"`, width vide `""`, height en number `200`
- Section « Voir aussi » : ajout du lien vers les attributs des primitives de filtres SVG (parité EN)
- Espaces insécables `&nbsp;` explicites (avant `:` et entre `SVG` + `:` dans le lien tutoriel)

**Diff** : +11 / -18 lignes.

## Additional details

Cette PR applique la checklist d'audit pré-push interne validée in-vivo sur la PR #36114 (mergée sans nouvelle correction). Audit one-liner exécuté localement avant push : 23/23 PASS sur les catégories applicables (Frontmatter, Macros, Liens internes, EmbedLiveSample, Typographie FR, Diff/commit, Métadonnées PR).

## Related

Part of #34956
Précédente PR de la série : #36114 (`<feGaussianBlur>`, mergée).