### PR TITLE
fix(zh-cn): sync min-width auto description with upstream

### DIFF
--- a/files/zh-cn/web/css/reference/properties/min-width/index.md
+++ b/files/zh-cn/web/css/reference/properties/min-width/index.md
@@ -2,7 +2,7 @@
 title: min-width
 slug: Web/CSS/Reference/Properties/min-width
 l10n:
-  sourceCommit: 925b2bd8beeae6ce8237863637bcd28ccbb8d47f
+  sourceCommit: bcbb4bd6a80292c0663b723d5466759cfaaa8315
 ---
 
 `min-width` [CSS](/zh-CN/docs/Web/CSS) 属性为给定元素设置最小宽度。它可以阻止 {{cssxref("width")}} 属性的[应用值](/zh-CN/docs/Web/CSS/Guides/Cascade/Property_value_processing#应用值)小于 `min-width` 指定的值。
@@ -76,7 +76,12 @@ min-width: unset;
 - `<percentage>`
   - : 以包含区块的宽度百分比定义 `min-width`。
 - `auto`
-  - : 浏览器将计算并选择指定元素的 `min-width`。
+  - : 默认值。对于指定元素，`auto` 值的具体来源取决于其 `display` 属性。对于块级盒子、行内盒子、行内块以及所有表格布局盒子，`auto` 会解析为 `0`。
+
+    对于 [flex item](/zh-CN/docs/Glossary/Flex_Item) 和 grid item，最小宽度值会按以下优先级确定：首先取指定的建议尺寸（如 `width` 属性的值）；其次取传递尺寸（当元素设置了 `aspect-ratio` 且高度为确定尺寸时，会据此计算）；否则使用 `min-content` 尺寸。
+
+    此外，如果 flex item 或 grid item 是{{glossary("scroll container")}}，或者 grid item 跨越了多个弹性列轨道，则自动最小尺寸为 `0`。
+
 - `max-content` {{ experimental_inline() }}
   - : 固有首选 `min-width`。
 - `min-content` {{ experimental_inline() }}

--- a/files/zh-cn/web/css/reference/properties/min-width/index.md
+++ b/files/zh-cn/web/css/reference/properties/min-width/index.md
@@ -1,5 +1,6 @@
 ---
-title: min-width
+title: "`min-width` CSS 属性"
+short-title: min-width
 slug: Web/CSS/Reference/Properties/min-width
 l10n:
   sourceCommit: bcbb4bd6a80292c0663b723d5466759cfaaa8315
@@ -7,7 +8,7 @@ l10n:
 
 `min-width` [CSS](/zh-CN/docs/Web/CSS) 属性为给定元素设置最小宽度。它可以阻止 {{cssxref("width")}} 属性的[应用值](/zh-CN/docs/Web/CSS/Guides/Cascade/Property_value_processing#应用值)小于 `min-width` 指定的值。
 
-{{InteractiveExample("CSS Demo: min-width")}}
+{{InteractiveExample("CSS 演示：min-width")}}
 
 ```css interactive-example-choice
 min-width: 150px;
@@ -28,7 +29,7 @@ min-width: 40ch;
 ```html interactive-example
 <section class="default-example" id="default-example">
   <div class="transition-all" id="example-element">
-    Change the minimum width.
+    改变最小宽度。
   </div>
 </section>
 ```
@@ -76,11 +77,9 @@ min-width: unset;
 - `<percentage>`
   - : 以包含区块的宽度百分比定义 `min-width`。
 - `auto`
-  - : 默认值。对于指定元素，`auto` 值的具体来源取决于其 `display` 属性。对于块级盒子、行内盒子、行内块以及所有表格布局盒子，`auto` 会解析为 `0`。
+  - : 默认值。对于指定元素，自动（auto）值的来源取决于其 display 的值。对于块级盒子、行内盒子、行内块以及所有表格布局盒子，`auto` 会解析为 `0`。
 
-    对于 [flex item](/zh-CN/docs/Glossary/Flex_Item) 和 grid item，最小宽度值会按以下优先级确定：首先取指定的建议尺寸（如 `width` 属性的值）；其次取传递尺寸（当元素设置了 `aspect-ratio` 且高度为确定尺寸时，会据此计算）；否则使用 `min-content` 尺寸。
-
-    此外，如果 flex item 或 grid item 是{{glossary("scroll container")}}，或者 grid item 跨越了多个弹性列轨道，则自动最小尺寸为 `0`。
+    对于[弹性项目](/zh-CN/docs/Glossary/Flex_Item)和网格项目，最小宽度值会按以下优先级确定：首先取指定的建议尺寸（如 `width` 属性的值），其次取传递尺寸（当元素设置了 `aspect-ratio` 且高度为确定尺寸时，会据此计算），否则使用 `min-content` 尺寸。此外，如果弹性项目或网格项目是{{glossary("scroll container", "滚动容器")}}，或者网格项目跨越了多个弹性列轨道，则自动最小尺寸为 `0`。
 
 - `max-content` {{ experimental_inline() }}
   - : 固有首选 `min-width`。
@@ -88,8 +87,13 @@ min-width: unset;
   - : 固有最小 `min-width`。
 - `fit-content`
   - : 使用可用空间，但不得超过 [max-content](/zh-CN/docs/Web/CSS/Reference/Values/max-content)，即 `min(max-content,max(min-content,stretch))`。
-- `fit-content({{cssxref("&lt;length-percentage&gt;")}})` {{Experimental_Inline}}
+- [`fit-content(<length-percentage>)`](/zh-CN/docs/Web/CSS/Reference/Values/fit-content_function)
   - : 使用 `fit-content` 公式，用指定参数替换可用空间，即 `min(max-content, max(min-content, argument))`。
+- `stretch`
+  - : 限制元素的[外边距盒子](/zh-CN/docs/Learn_web_development/Core/Styling_basics/Box_model#盒模型的各个部分)的最小宽度，使其等于其[包含区块](/zh-CN/docs/Web/CSS/Guides/Display/Containing_block#确定包含块)的宽度。它会尝试使外边距盒子填充包含区块中的可用空间，因此在某种程度上类似于`100%`，但将结果大小应用于外边距盒子，而不是由 [box-sizing](/en-US/docs/Web/CSS/Reference/Properties/box-sizing) 确定的盒子。
+
+    > [!NOTE]
+    > 要查看浏览器对 `stretch` 值使用的别名及其实现状态，请参阅[浏览器兼容性](#浏览器兼容性)部分。
 
 ## 形式定义
 
@@ -124,4 +128,10 @@ form {
 ## 参见
 
 - {{ Cssxref("width") }}、{{ Cssxref("max-width") }}
-- [盒模型](/zh-CN/docs/Web/CSS/Guides/Box_model/Introduction)，{{ Cssxref("box-sizing") }}
+- {{Cssxref("max-width")}}
+- {{Cssxref("width")}}
+- {{cssxref("min-inline-size")}}
+- {{cssxref("min-block-size")}}
+- {{cssxref("box-sizing")}}
+- [CSS 盒子模型介绍](/zh-CN/docs/Web/CSS/Guides/Box_model/Introduction)指南
+- [CSS 盒子模型](/zh-CN/docs/Web/CSS/Guides/Box_model)模块

--- a/files/zh-cn/web/css/reference/properties/min-width/index.md
+++ b/files/zh-cn/web/css/reference/properties/min-width/index.md
@@ -28,9 +28,7 @@ min-width: 40ch;
 
 ```html interactive-example
 <section class="default-example" id="default-example">
-  <div class="transition-all" id="example-element">
-    改变最小宽度。
-  </div>
+  <div class="transition-all" id="example-element">改变最小宽度。</div>
 </section>
 ```
 
@@ -90,7 +88,7 @@ min-width: unset;
 - [`fit-content(<length-percentage>)`](/zh-CN/docs/Web/CSS/Reference/Values/fit-content_function)
   - : 使用 `fit-content` 公式，用指定参数替换可用空间，即 `min(max-content, max(min-content, argument))`。
 - `stretch`
-  - : 限制元素的[外边距盒子](/zh-CN/docs/Learn_web_development/Core/Styling_basics/Box_model#盒模型的各个部分)的最小宽度，使其等于其[包含区块](/zh-CN/docs/Web/CSS/Guides/Display/Containing_block#确定包含块)的宽度。它会尝试使外边距盒子填充包含区块中的可用空间，因此在某种程度上类似于`100%`，但将结果大小应用于外边距盒子，而不是由 [box-sizing](/en-US/docs/Web/CSS/Reference/Properties/box-sizing) 确定的盒子。
+  - : 限制元素的[外边距盒子](/zh-CN/docs/Learn_web_development/Core/Styling_basics/Box_model#盒模型的各个部分)的最小宽度，使其等于其[包含区块](/zh-CN/docs/Web/CSS/Guides/Display/Containing_block#确定包含块)的宽度。它会尝试使外边距盒子填充包含区块中的可用空间，因此在某种程度上类似于`100%`，但将结果大小应用于外边距盒子，而不是由 [box-sizing](/zh-CN/docs/Web/CSS/Reference/Properties/box-sizing) 确定的盒子。
 
     > [!NOTE]
     > 要查看浏览器对 `stretch` 值使用的别名及其实现状态，请参阅[浏览器兼容性](#浏览器兼容性)部分。


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

同步 `min-width` 属性中 `auto` 值的中文翻译，补充了 flex 和 grid 子项自动最小尺寸的完整说明。

更新内容：
- `auto` 值的基础行为（块级、行内、表格布局等解析为 `0`）
- flex item 和 grid item 的自动最小尺寸计算规则：
  - 首选使用指定的建议尺寸（如 `width`）
  - 其次使用通过 `aspect-ratio` 传递的尺寸
  - 否则使用 `min-content` 尺寸
- 特殊情况的处理：滚动容器（scroll container）或多列轨道中的 grid item 自动最小尺寸为 `0`

### Motivation
开发时查阅文档发现，`min-width: auto`  值的中文说明较为简略，且与英文原版文档存在较大差异，因此对其进行了更新。

英文原版文档中对 `min-width: auto` 在 flex/grid 上下文中的行为有详细说明，但当前中文翻译缺失了以下关键信息：
- flex/grid 子项的自动最小尺寸计算逻辑
- `aspect-ratio` 传递尺寸的说明
- 滚动容器的特殊规则

这些内容对于理解现代 CSS 布局（尤其是 flex 和 grid 防止溢出的行为）非常重要。此 PR 旨在补全翻译，使中文文档与英文文档保持同步，帮助中文开发者准确理解 `min-width: auto` 在不同布局上下文中的表现。

### Additional details

参考英文原文：
- 源文件路径：`files/en-us/web/css/reference/properties/min-width/index.md`
- `auto` 值说明中的 flex/grid 行为部分

相关 CSS 规范：
- [CSS Flexible Box Layout Module Level 1 - Automatic Minimum Size of Flex Items](https://www.w3.org/TR/css-flexbox-1/#min-size-auto)
- [CSS Grid Layout Module Level 1 - Automatic Minimum Size of Grid Items](https://www.w3.org/TR/css-grid-1/#min-size-auto)

### Related issues and pull requests

Relates to: #sync-min-width-auto（当前同步分支）

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->