### PR TITLE
chore(fr): update of `Mozilla/Firefox/Releases/23`

### DIFF
--- a/files/fr/mozilla/firefox/releases/23/index.md
+++ b/files/fr/mozilla/firefox/releases/23/index.md
@@ -1,69 +1,69 @@
 ---
-title: Firefox 23 pour les développeurs
+title: Firefox 23 note de version pour les développeurs
+short-title: Firefox 23
 slug: Mozilla/Firefox/Releases/23
+l10n:
+  sourceCommit: 83f4e64da466670c3700110da364546253eae127
 ---
 
-##### Changements pour les développeurs Web
-
-### Sécurité
-
-- Blocage des contenus mixte. Firefox ne charge plus les ressources non-sécurisées (http) sur une page sécurisée (https). ([bug Firefox 834836](https://bugzil.la/834836))
-- La syntaxe standard de [CSP](/fr/docs/Sécurité/CSP) 1.0 a été implémentée et appliquée par défaut.
+## Changements pour les développeur·euse·s Web
 
 ### Outils de développement
 
-- Un panneau Réseau a été ajouté aux outils de développement. C'est une vue plus détaillée que la vue "Réseau" présente dans la console Web.
-- La console Web a été renommée en "Console", et inclus une option pour filtrer les erreurs/avertissement de sécruité.
-- Les nouvelles options des outils vous permettent de désactiver des fonctionnalités, de changer de thème (sombre ou clair), ou d'activer le débogage du Chrome.
+- Un panneau Réseau a été ajouté aux outils de développement. C'est une vue plus détaillée que la vue «&nbsp;Réseau&nbsp;» présente dans la console Web.
+- La console Web a été renommée en «&nbsp;Console&nbsp;», et inclut une option pour filtrer les erreurs/avertissements de sécurité.
+- Les nouvelles options des outils vous permettent de désactiver des fonctionnalités, de changer de thème (sombre ou clair), ou d'activer le débogage du Chrome/à distance.
 
 ### HTML
 
-- Le support de l'élément `<blink>` a désormais été abandonné. La balise `<blink>` fait désormais partie de l'interface {{domxref("HTMLUnknownElement")}} ([bug Firefox 857820](https://bugzil.la/857820).)
-- Le type `range` de l'élément {{HTMLElement("input")}} (`<input type="range">`) a été activé par défaut ([bug Firefox 841950](https://bugzil.la/841950)).
+- Le support de l'élément `<blink>` a désormais été abandonné. La balise `<blink>` fait désormais partie de l'interface {{DOMxRef("HTMLUnknownElement")}} ([bogue Firefox 857820 <sup>(angl.)</sup>](https://bugzil.la/857820).)
+- Le type `range` de l'élément {{HTMLElement("input")}} (`<input type="range">`) a été activé par défaut ([bogue Firefox 841950 <sup>(angl.)</sup>](https://bugzil.la/841950)).
 
 ### JavaScript
 
-- La méthode [`Object.defineProperty`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) peut désormais être utilisée pour redéfinir la propriété `length` d'un objet [`Array`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Array).
-- L'option pour désactiver JavaScript, incluant les options pour permettre de déplacer une fenêtre/remplacer le menu contextuel, a été retirée. Vous pouvez toujours désactiver JavaScript en double-cliquant sur l'option "javascript.enabled" dans about:config.
+- La méthode {{JSxRef("Object.defineProperty()")}} peut désormais être utilisée pour redéfinir la propriété `length` d'un objet {{JSxRef("Array")}}.
+- L'option pour désactiver JavaScript, incluant les options pour permettre de déplacer une fenêtre/remplacer le menu contextuel, a été retirée. Vous pouvez toujours désactiver JavaScript en double-cliquant sur l'option «&nbsp;javascript.enabled&nbsp;» dans about:config.
 
 ### DOM
 
-- D3E [`KeyboardEvent.key`](/fr/docs/Web/API/KeyboardEvent) est désormais supporté, mais seulement pour les éléments non-imprimables ([bug Firefox 842927](https://bugzil.la/842927)).
-- L'attribut `title` de {{domxref("DOMImplementation.createHTMLDocument")}} est désormais optionnel, d'après la mise à jour de la spécification DOM.
-- La possibilité d'ajouter un panneau latéral (`window.sidebar.addPanel`) a été abandonnée ([bug Firefox 691647](https://bugzil.la/691647)).
-- Les méthodes {{domxref("Window.requestAnimationFrame")}} et {{domxref("Window.cancelAnimationFrame")}} sans préfixe ont été ajoutées ([bug Firefox 704063](https://bugzil.la/704063)).
-- Le rappel pour {{domxref("Window.requestAnimationFrame")}} reçoit désormais {{domxref("DOMHighResTimeStamp")}} comme argument à la place de {{domxref("DOMTimeStamp")}}, moins précis, qui est utilisé dans la version sans préfixe ([bug Firefox 753453](https://bugzil.la/753453)).
-- L'argument text pour {{domxref("window.alert")}} et {{domxref("window.confirm")}} est désormais optionnel ([bug Firefox 861605](https://bugzil.la/861605)).
-- La propriété {{domxref("HTMLMediaElement.initialTime")}}, retirée de la spécification, n'est plus supportée ([bug Firefox 742537](https://bugzil.la/742537)).
-- Le constructeur {{domxref("AnimationEvent.AnimationEvent", "AnimationEvent()")}} a été ajoutée ([bug Firefox 848293](https://bugzil.la/848293)).
-- La propriété {{domxref("AnimationEvent.pseudoElement")}} a été implémentée ([bug Firefox 848293](https://bugzil.la/848293)).
-- Le constructeur {{domxref("TransitionEvent.TransitionEvent", "TransitionEvent()")}} a été ajoutée ([bug Firefox 848291](https://bugzil.la/848291)).
-- La propriété {{domxref("TransitionEvent.pseudoElement")}} a été implémentée ([bug Firefox 848291](https://bugzil.la/848291)).
-- {{domxref("TransitionEvent.initTransitionEvent()")}} et {{domxref("AnimationEvent.initAnimationEvent()")}} qui ne sont pas standardisées ont été retirées ([bug Firefox 868751](https://bugzil.la/868751)).
+- D3E {{DOMxRef("KeyboardEvent.key")}} est désormais pris en charge, mais seulement pour les éléments non-imprimables ([bogue Firefox 842927 <sup>(angl.)</sup>](https://bugzil.la/842927)).
+- L'attribut `title` de {{DOMxRef("DOMImplementation.createHTMLDocument")}} est désormais optionnel, d'après la mise à jour de la spécification DOM.
+- La possibilité d'ajouter un panneau latéral (`window.sidebar.addPanel`) a été abandonnée ([bogue Firefox 691647 <sup>(angl.)</sup>](https://bugzil.la/691647)).
+- Les méthodes {{DOMxRef("Window.requestAnimationFrame")}} et {{DOMxRef("Window.cancelAnimationFrame")}} sans préfixe ont été ajoutées ([bogue Firefox 704063 <sup>(angl.)</sup>](https://bugzil.la/704063)). La version sans préfixe de {{DOMxRef("Window.requestAnimationFrame")}} reçoit un {{DOMxRef("DOMHighResTimeStamp")}} comme argument&nbsp;; la version avec préfixe reçoit un timestamp en millisecondes ([bogue Firefox 753453 <sup>(angl.)</sup>](https://bugzil.la/753453)).
+- L'argument text pour {{DOMxRef("window.alert")}} et {{DOMxRef("window.confirm")}} est désormais optionnel ([bogue Firefox 861605 <sup>(angl.)</sup>](https://bugzil.la/861605)).
+- La propriété `HTMLMediaElement.initialTime`, retirée de la spécification, n'est plus prise en charge ([bogue Firefox 742537 <sup>(angl.)</sup>](https://bugzil.la/742537)).
+- Le constructeur {{DOMxRef("AnimationEvent.AnimationEvent", "AnimationEvent()")}} a été ajouté ([bogue Firefox 848293 <sup>(angl.)</sup>](https://bugzil.la/848293)).
+- La propriété {{DOMxRef("AnimationEvent.pseudoElement")}} a été implémentée ([bogue Firefox 848293 <sup>(angl.)</sup>](https://bugzil.la/848293)).
+- Le constructeur {{DOMxRef("TransitionEvent.TransitionEvent", "TransitionEvent()")}} a été ajouté ([bogue Firefox 848291 <sup>(angl.)</sup>](https://bugzil.la/848291)).
+- La propriété {{DOMxRef("TransitionEvent.pseudoElement")}} a été implémentée ([bogue Firefox 848291 <sup>(angl.)</sup>](https://bugzil.la/848291)).
+- `TransitionEvent.initTransitionEvent()` et `AnimationEvent.initAnimationEvent()` qui ne sont pas standardisées ont été retirées ([bogue Firefox 868751 <sup>(angl.)</sup>](https://bugzil.la/868751)).
+
+### WebRTC
+
+- Au lieu d'inclure des noms d'utilisateur·ice dans la propriété `RTCIceServer.url` (comme `stun:username@stunserver.example.com`), vous devez maintenant utiliser la nouvelle propriété `RTCIceServer.username`.
 
 ### CSS
 
-- L'effet blink pour `text-decoration: blink;` n'a plus d'effet, mais c'est encore une valeur valide ([bug Firefox 857820](https://bugzil.la/857820)).
-- Les pseudo-éléments {{cssxref("::after")}} et {{cssxref("::before")}} sont désormais des objets flexibles ([bug Firefox 867454](https://bugzil.la/867454)).
-- La façon de calculer les [unités viewport](/fr/docs/Web/CSS/Reference/Values/length#longueurs_liées_au_viewport) a été changée. en liaison avec `overflow:auto`, l'espace occupé par d'éventuelles barres de défilement n'est pas soustrait de la fenêtre, alors que dans le cas de `overflow:scroll`, ça l'est ([bug Firefox 811403](https://bugzil.la/811403)).
+- L'effet clignotant pour `text-decoration: blink;` n'a plus d'effet, mais c'est encore une valeur valide ([bogue Firefox 857820 <sup>(angl.)</sup>](https://bugzil.la/857820)).
+- Les pseudo-éléments {{CSSxRef("::after")}} et {{CSSxRef("::before")}} sont désormais des objets flexibles ([bogue Firefox 867454 <sup>(angl.)</sup>](https://bugzil.la/867454)).
+- La façon de calculer les [unités de la zone d'affichage](/fr/docs/Web/CSS/Reference/Values/length#unités_de_longueur_relatives_à_la_zone_daffichage) a été changée. en liaison avec `overflow:auto`, l'espace occupé par d'éventuelles barres de défilement n'est pas soustrait de la fenêtre, alors que dans le cas de `overflow:scroll`, ça l'est ([bogue Firefox 811403 <sup>(angl.)</sup>](https://bugzil.la/811403)).
 
 ### MathML
 
-- Les largeurs négatives pour l'élément {{MathMLElement("mspace")}} ont été implémentées ([bug Firefox 717546](https://bugzil.la/717546)).
+- Les largeurs négatives pour l'élément {{MathMLElement("mspace")}} ont été implémentées ([bogue Firefox 717546 <sup>(angl.)</sup>](https://bugzil.la/717546)).
 - L'élément {{MathMLElement("semantics")}} détermine désormais l'enfant visible comme décrit dans la spécification MathML3.
 
-## Changements pour les développeurs Mozilla et développeurs d'add-on
+### Sécurité
 
-### Outils pour développeurs de Firefox
+- Blocage des contenus mixte. Firefox ne charge plus les ressources non-sécurisées (http) sur une page sécurisée (https). ([bogue Firefox 834836 <sup>(angl.)</sup>](https://bugzil.la/834836))
+- La syntaxe standard de [CSP](/fr/docs/Web/HTTP/Guides/CSP 1.0 a été implémentée et appliquée par défaut.
+
+## Changements pour les développeur·euse·s Mozilla et d'extensions
+
+### Outils de développement Firefox
 
 Les add-ons qui ont recourt à chrome://browser/content/debugger.xul doivent désormais utiliser chrome://browser/content/devtools/debugger.xul. Vous pouvez ajouter des références à ces deux fichiers dans chrome.manifest pour la compatibilité.
 
 ## Voir aussi
 
-- [Notes de version de Firefox 23](https://www.mozilla.org/en-US/firefox/23.0/releasenotes/)
-- [Compatibilité des sites avec Firefox 23](/fr/docs/Site_Compatibility_for_Firefox_23)
-- [Compatibilité des add-ons avec Firefox 23](https://blog.mozilla.org/addons/2013/07/24/compatibility-for-firefox-23/)
-
-### Anciennes versions
-
-{{Firefox_for_developers('22')}}
+- [Notes de version de Firefox 23 Aurora <sup>(angl.)</sup>](https://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-us/firefox/23.0a2/auroranotes/)


### PR DESCRIPTION
### Description

Update translation of pages without french version: `Mozilla/Firefox/Releases/23`

### Motivation

Update access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_