### PR TITLE
chore(fr): update of `Mozilla/Firefox/Releases/40`

### DIFF
--- a/files/fr/mozilla/firefox/releases/40/index.md
+++ b/files/fr/mozilla/firefox/releases/40/index.md
@@ -1,159 +1,165 @@
 ---
-title: Firefox 40 pour développeurs
+title: Firefox 40 note de version pour les développeurs
+short-title: Firefox 40
 slug: Mozilla/Firefox/Releases/40
+l10n:
+  sourceCommit: 1ddd95504b4507beeda0f08bd772eb167922b86a
 ---
 
-## Changements pour les développeurs Web
+[Pour tester les dernières fonctionnalités pour les développeur·euse·s de Firefox, installez Firefox Developer Edition <sup>(angl.)</sup>](https://www.firefox.com/en-US/channel/desktop/developer/)
+Firefox 40 est sorti le 11 août 2015. Cet article répertorie les modifications clés qui sont utiles non seulement pour les développeur·euse·s Web, mais également pour les développeur·euse·s Firefox et Gecko ainsi que pour les développeur·euse·s d'add-on.
 
-### Outils pour Développeurs
+## Changements pour les développeur·euse·s Web
 
-Nouveautés:
+### Outils de développement
 
-- [Amélioration des vues Animation](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/work_with_animations/index.html#firefox_40)
-- [Obtenir de l'aide MDN pour la syntaxe des propriétés CSS](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_css/index.html#get_help_for_css_properties)
-- [Editer les filtres depuis la page Inspecteur](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_css_filters/index.html)
-- [Affichage dans la Console Web des messages workers](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html#console_api_messages)
-- [Filtrer les requetes par URL dans le moniteur réseau](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html#filtering_by_url)
-- [Nouvelles options dans le menu contextuel du moniteur réseau](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html#context_menu)
-- [Montrer quand les ressources réseau sont récupérées du cache du navigateur](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html#network_request_fields)
-- [Filtrer les règles dans la page Inspecteur](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_css/index.html#filtering_rules)
+Points forts&nbsp;:
 
-More:
+- [Améliorations de la vue Animations <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/work_with_animations/index.html#firefox-40)
+- [Obtenez de l'aide sur la syntaxe des propriétés CSS depuis MDN <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_css/index.html#get-help-for-css-properties)
+- [Modifier les filtres dans l'inspecteur de page <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_css_filters/index.html)
+- [La console Web affiche désormais les messages des workers <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html#console-api-messages)
+- [Filtrer les requêtes par URL dans le moniteur réseau <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html#filtering-by-url)
+- [De nombreuses nouvelles options de menu contextuel dans le moniteur réseau <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html#context-menu)
+- [Afficher quand les ressources réseau sont récupérées depuis le cache du navigateur <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html#network-request-fields)
+- [Filtrer les règles dans l'inspecteur de page <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_css/index.html#filtering-rules)
 
-- [Point d'arret au niveau debugger ; expressions dans l'évaluation des sources non nommés](https://firefox-source-docs.mozilla.org/devtools-user/debugger/ui_tour/index.html#source_list_pane)
-- [Copy URL/Open in New Tab context menu items for Debugger source list pane](https://firefox-source-docs.mozilla.org/devtools-user/debugger/ui_tour/index.html#source_list_pane)
-- [Support de console.dirxml dans la Console Web](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html#log_messages)
-- [Editeur de Style : "Ouverture d'un lien dans un nouvel onglet" item added to stylesheet list](https://firefox-source-docs.mozilla.org/devtools-user/style_editor/index.html#the_style_sheet_pane)
-- [La recherche par sélecteur dans l'Inspecteur inclus dorénavant dans les résultats le class/id meme si celui ci n'a pas de préfix css](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_the_box_model/index.html#the_box_model_view)
-- [Indication de quelle règle CSS est a l'origine du Tooltips dans le modèle de vue 'boite'](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/inspect_and_select_colors/index.html)
-- [Basculement entre les format de couleur dans l'inspecteur en utilisant Shift+click](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to#element_popup_menu)
-- [Implement "Scroll Into View" menu item for the Inspector](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to#element_popup_menu)
-- [transformer un attribut url/id/resource en lien dans l'inspecteur](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html#network_request_fields)
-- [Infobulle de l'adresse IP dans le moniteur réseau](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html#network_request_fields)
+Plus de changements&nbsp;:
 
-Autres: [Tous les bugs devtools corrigés depuis Firefox 39 et Firefox 40](https://bugzilla.mozilla.org/buglist.cgi?resolution=FIXED&classification=Client%20Software&chfieldto=2015-05-11&query_format=advanced&chfield=resolution&chfieldfrom=2015-03-31&chfieldvalue=FIXED&bug_status=RESOLVED&bug_status=VERIFIED&component=Developer%20Tools&component=Developer%20Tools%3A%203D%20View&component=Developer%20Tools%3A%20Canvas%20Debugger&component=Developer%20Tools%3A%20Console&component=Developer%20Tools%3A%20Debugger&component=Developer%20Tools%3A%20Framework&component=Developer%20Tools%3A%20Graphic%20Commandline%20and%20Toolbar&component=Developer%20Tools%3A%20Inspector&component=Developer%20Tools%3A%20Memory&component=Developer%20Tools%3A%20Netmonitor&component=Developer%20Tools%3A%20Object%20Inspector&component=Developer%20Tools%3A%20Performance%20Tools%20%28Profiler%2FTimeline%29&component=Developer%20Tools%3A%20Responsive%20Mode&component=Developer%20Tools%3A%20Scratchpad&component=Developer%20Tools%3A%20Source%20Editor&component=Developer%20Tools%3A%20Storage%20Inspector&component=Developer%20Tools%3A%20Style%20Editor&component=Developer%20Tools%3A%20User%20Stories&component=Developer%20Tools%3A%20Web%20Audio%20Editor&component=Developer%20Tools%3A%20WebGL%20Shader%20Editor&component=Developer%20Tools%3A%20WebIDE&product=Firefox&list_id=12283503).
+- [Les «&nbsp;Break&nbsp;» dans le débogueur&nbsp;; instructions dans les sources d'évaluation non nommées <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/debug_eval_sources/index.html)
+- [Copier l'URL/Ouvrir dans un nouvel onglet dans le menu contextuel pour le volet de la liste des sources du débogueur <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/debugger/ui_tour/index.html#source-list-pane)
+- [Support de console.dirxml dans la console Web <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html#log-messages)
+- [Éditeur de style&nbsp;: élément "Ouvrir le lien dans un nouvel onglet" ajouté à la liste des feuilles de style <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/style_editor/index.html#the-style-sheet-pane)
+- [La recherche de sélecteurs dans l'inspecteur inclut désormais les résultats de classe/id même sans préfixe CSS <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_html/index.html#searching)
+- [Info-bulles dans la vue du modèle de boîte indiquant quelle règle CSS a causé la valeur <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_the_box_model/index.html#the-box-model-view)
+- [Changer le format de l'unité de couleur dans l'inspecteur en utilisant Shift+click <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/inspect_and_select_colors/index.html)
+- [Implémenter l'élément de menu «&nbsp;Défiler dans la vue&nbsp;» pour l'inspecteur <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_html/index.html#element-popup-menu)
+- [Lier les attributs url/id/resource dans l'inspecteur <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_html/index.html#element-popup-menu)
+- [Info-bulle pour l'adresse IP dans le moniteur réseau <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html#network-request-fields)
+
+Tous les changements&nbsp;: [tous les bogues des outils de développement corrigés entre Firefox 39 et Firefox 40 <sup>(angl.)</sup>](https://bugzilla.mozilla.org/buglist.cgi?resolution=FIXED&classification=Client%20Software&chfieldto=2015-05-11&query_format=advanced&chfield=resolution&chfieldfrom=2015-03-31&chfieldvalue=FIXED&bug_status=RESOLVED&bug_status=VERIFIED&component=Developer%20Tools&component=Developer%20Tools%3A%203D%20View&component=Developer%20Tools%3A%20Canvas%20Debugger&component=Developer%20Tools%3A%20Console&component=Developer%20Tools%3A%20Debugger&component=Developer%20Tools%3A%20Framework&component=Developer%20Tools%3A%20Graphic%20Commandline%20and%20Toolbar&component=Developer%20Tools%3A%20Inspector&component=Developer%20Tools%3A%20Memory&component=Developer%20Tools%3A%20Netmonitor&component=Developer%20Tools%3A%20Object%20Inspector&component=Developer%20Tools%3A%20Performance%20Tools%20%28Profiler%2FTimeline%29&component=Developer%20Tools%3A%20Responsive%20Mode&component=Developer%20Tools%3A%20Scratchpad&component=Developer%20Tools%3A%20Source%20Editor&component=Developer%20Tools%3A%20Storage%20Inspector&component=Developer%20Tools%3A%20Style%20Editor&component=Developer%20Tools%3A%20User%20Stories&component=Developer%20Tools%3A%20Web%20Audio%20Editor&component=Developer%20Tools%3A%20WebGL%20Shader%20Editor&component=Developer%20Tools%3A%20WebIDE&product=Firefox&list_id=12283503).
 
 ### CSS
 
-- Règles de préfixe (`-moz-`) pour {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-line")}}, et {{cssxref("text-decoration-style")}} ont été supprimé ([bug Firefox 1097922](https://bugzil.la/1097922)).
-- La propriété {{cssxref("text-align")}} supporte dorénavant la valeur `match-parent` ([bug Firefox 645642](https://bugzil.la/645642)).
-- Dans le mode Quirks, {{cssxref("empty-cells")}} a pour valeur par défaut `show`, comme dans le mode standard ([bug Firefox 1020400](https://bugzil.la/1020400)).
-- La propriété non standard {{cssxref("-moz-orient")}}, utilisée pour faire un rendu sur les éléments {{HTMLElement('meter')}} et {{HTMLElement('progress')}} a été adaptée pour les modes d'écriture verticales: la valeur `auto` a été supprimée et les valeurs `inline` et `block` ajoutées, avec `inline` comme nouvelle valeur par défaut ([bug Firefox 1028716](https://bugzil.la/1028716)).
+- Les règles avec un préfixe (`-moz-`) pour {{CSSxRef("text-decoration-color")}}, {{CSSxRef("text-decoration-line")}} et {{CSSxRef("text-decoration-style")}} ont été supprimées ([bogue Firefox 1097922 <sup>(angl.)</sup>](https://bugzil.la/1097922)).
+- La propriété {{CSSxRef("text-align")}} prend désormais en charge la valeur `match-parent` ([bogue Firefox 645642 <sup>(angl.)</sup>](https://bugzil.la/645642)).
+- En mode Quirks, {{CSSxRef("empty-cells")}} est désormais par défaut à `show`, comme en mode standard ([bogue Firefox 1020400 <sup>(angl.)</sup>](https://bugzil.la/1020400)).
+- La propriété non standard {{CSSxRef("-moz-orient")}}, utilisée pour mettre en forme les éléments {{HTMLElement('meter')}} et {{HTMLElement('progress')}}, a été adaptée pour les modes d'écriture verticale&nbsp;: la valeur `auto` a été supprimée et les valeurs `inline` et `block` ont été ajoutées, `inline` étant la nouvelle valeur par défaut ([bogue Firefox 1028716 <sup>(angl.)</sup>](https://bugzil.la/1028716)).
+- La propriété {{CSSxRef("font-size-adjust")}} a été corrigée afin que `0` soit traité comme un multiplicateur (ce qui entraîne une hauteur de police de `0`, donc la cache) au lieu de la valeur `none` (ce qui entraîne aucune ajustement, ou une valeur de `1.0`) ([bogue Firefox 1144885 <sup>(angl.)</sup>](https://bugzil.la/1144885)).
+- Correction du problème où `text-overflow` ne fonctionnait pas en mode d'écriture verticale ([bogue Firefox 1117227 <sup>(angl.)</sup>](https://bugzil.la/1117227)).
 
 ### HTML
 
-_pas de changement._
+_Pas de changement._
 
 ### JavaScript
 
-- Unreachable code after {{jsxref("Statements/return", "return")}} statement (including unreachable expression after {{jsxref("Statements/return", "semicolon-less return statements", "#Automatic_semicolon_insertion", 1)}}) will now show a warning in the console ([bug Firefox 1005110](https://bugzil.la/1005110), [bug Firefox 1151931](https://bugzil.la/1151931)).
-- {{jsxref("Symbol.match")}} a été ajouté ([bug Firefox 1054755](https://bugzil.la/1054755)).
-- Passing an object which has a property named {{jsxref("Symbol.match")}} with a {{Glossary("truthy")}} value to {{jsxref("String.prototype.startsWith")}}, {{jsxref("String.prototype.endsWith")}}, and `String.prototype.contains` now throws a {{jsxref("TypeError")}} ([bug Firefox 1054755](https://bugzil.la/1054755)).
-- {{jsxref("RegExp")}} function returns pattern itself if called without {{jsxref("new")}} and pattern object has a property named {{jsxref("Symbol.match")}} with a {{Glossary("truthy")}} value, and the pattern object's `constructor` property equals to {{jsxref("RegExp")}} function. ([bug Firefox 1147817](https://bugzil.la/1147817)).
-- Support for the non-standard JS1.7 destructuring for-in has been dropped ([bug Firefox 1083498](https://bugzil.la/1083498)).
-- [Les initialiseurs d'expression non-standard](/fr/docs/Web/JavaScript/Reference/Statements/for...in#firefox-specific_notes) dans les boucles [for...in](/fr/docs/Web/JavaScript/Reference/Statements/for...in) sont dorénavant ignorés et seront indiqués par un avertissement dans la console. ([bug Firefox 748550](https://bugzil.la/748550) et [bug Firefox 1164741](https://bugzil.la/1164741)).
-- [`\u{xxxxxx}`](/fr/docs/Web/JavaScript/Reference/Lexical_grammar#unicode_code_point_escapes) Unicode code point escapes have been added ([bug Firefox 320500](https://bugzil.la/320500)).
-- {{jsxref("String.prototype.includes", "String.prototype.contains", "#String.prototype.contains")}} has been replaced with {{jsxref("String.prototype.includes")}}, `String.prototype.contains` is kept as an alias ([bug Firefox 1102219](https://bugzil.la/1102219)).
-- If the {{jsxref("DataView")}} constructor is called as a function without the {{ jsxref("new") }} operator, a {{jsxref("TypeError")}} is now thrown as per the ES6 specification.
-- An issue regressed in Firefox 21, where proxyfied arrays without the `get` trap were not working properly, has been fixed. If the `get` trap in a {{jsxref("Proxy")}} was not defined, {{jsxref("Array.length")}} returned `0` and the `set` trap didn't get called. A workaround was to add the `get` trap even if was not necessary in your code. This issue has been fixed now ([bug Firefox 895223](https://bugzil.la/895223)).
-- {{jsxref("WeakMap")}} and {{jsxref("WeakSet")}} have been updated to be just ordinary objects, per ES6 specification ([bug Firefox 1055473](https://bugzil.la/1055473)).
-- The {{jsxref("RegExp.prototype.source")}} property is now prototype accessor property rather than own data property of `RegExp` instances ([bug Firefox 1120169](https://bugzil.la/1120169), [bug Firefox 1150297](https://bugzil.la/1150297)).
+- Le code inatteignable après une instruction {{JSxRef("Statements/return", "return")}} (comprenant les expressions inatteignables après les instructions {{JSxRef("Statements/return#ajout_automatique_de_point-virgule", "return sans point-virgule", "", 1)}}) affiche désormais un avertissement dans la console ([bogue Firefox 1005110 <sup>(angl.)</sup>](https://bugzil.la/1005110), [bogue Firefox 1151931 <sup>(angl.)</sup>](https://bugzil.la/1151931)).
+- {{JSxRef("Symbol.match")}} a été ajouté ([bogue Firefox 1054755 <sup>(angl.)</sup>](https://bugzil.la/1054755)).
+- Passer un objet qui a une propriété nommée {{JSxRef("Symbol.match")}} avec une valeur {{Glossary("truthy", "équivalente à vrai")}} à {{JSxRef("String.prototype.startsWith")}}, {{JSxRef("String.prototype.endsWith")}} et `String.prototype.contains` lance désormais une {{JSxRef("TypeError")}} ([bogue Firefox 1054755 <sup>(angl.)</sup>](https://bugzil.la/1054755)).
+- La fonction {{JSxRef("RegExp")}} retourne le motif lui-même si elle est appelée sans {{JSxRef("new")}} et que l'objet motif a une propriété nommée {{JSxRef("Symbol.match")}} avec une valeur {{Glossary("truthy", "équivalente à vrai")}}, et que la propriété `constructor` de l'objet motif est égale à la fonction {{JSxRef("RegExp")}}. ([bogue Firefox 1147817 <sup>(angl.)</sup>](https://bugzil.la/1147817)).
+- La prise en charge de la déstructuration non standard JS1.7 pour-in a été supprimée ([bogue Firefox 1083498 <sup>(angl.)</sup>](https://bugzil.la/1083498)).
+- Les [expressions d'initialisation non standard](/fr/docs/Web/JavaScript/Reference/Errors/Invalid_for-in_initializer) dans les boucles [`for...in`](/fr/docs/Web/JavaScript/Reference/Statements/for...in) sont désormais ignorées et affichent un avertissement dans la console. ([bogue Firefox 748550 <sup>(angl.)</sup>](https://bugzil.la/748550) et [bogue Firefox 1164741 <sup>(angl.)</sup>](https://bugzil.la/1164741)).
+- Les échappements de points de code Unicode [`\u{xxxxxx}`](/fr/docs/Web/JavaScript/Reference/Lexical_grammar#échappement_de_points_de_code_unicode) ont été ajoutés ([bogue Firefox 320500 <sup>(angl.)</sup>](https://bugzil.la/320500)).
+- `String.prototype.contains` a été remplacé par {{JSxRef("String.prototype.includes")}}, `String.prototype.contains` étant conservé comme alias ([bogue Firefox 1102219 <sup>(angl.)</sup>](https://bugzil.la/1102219)).
+- Si le constructeur {{JSxRef("DataView")}} est appelé comme une fonction sans l'opérateur {{JSxRef("Operators/new", "new")}}, une {{JSxRef("TypeError")}} est désormais levée conformément à la spécification ES2015.
+- Un problème régressé dans Firefox 21, où les tableaux mandataires sans le piège `get` ne fonctionnaient pas correctement, a été corrigé. Si le piège `get` dans un {{JSxRef("Proxy")}} n'était pas défini, {{JSxRef("Array.length")}} retournait `0` et le piège `set` n'était pas appelé. Une solution consistait à ajouter le piège `get` même s'il n'était pas nécessaire dans votre code. Ce problème est désormais corrigé ([bogue Firefox 895223 <sup>(angl.)</sup>](https://bugzil.la/895223)).
+- `WeakMap.prototype` et `WeakSet.prototype` ont été mis à jour pour être de simples objets ordinaires, conformément à la spécification ES2015 ([bogue Firefox 1055473 <sup>(angl.)</sup>](https://bugzil.la/1055473)).
 
 ### Interfaces/APIs/DOM
 
-#### Nouvelles APIs
+#### Nouvelles API
 
-- Implementation de [l'API Push](/fr/docs/Web/API/Push_API) ([bug Firefox 1038811](https://bugzil.la/1038811)).
+- [L'API Push](/fr/docs/Web/API/Push_API) a été mise en œuvre de manière expérimentale ([bogue Firefox 1038811 <sup>(angl.)</sup>](https://bugzil.la/1038811)). Contrôlée par la préférence `services.push.enabled`, elle est désactivée par défaut.
 
-#### Web Animations API
+#### API Web Animations
 
-Amélioration de notre implémentation des animations Web expérimentales, principalement mostley to match latest spec changes:
+Amélioration de notre implémentation expérimentale des animations Web, principalement pour correspondre aux dernières modifications de la spécification&nbsp;:
 
-- {{domxref("AnimationPlayer.currentTime")}} now can also be set ([bug Firefox 1072037](https://bugzil.la/1072037)).
-- `Animatable.getAnimationPlayers()`, available on {{domxref("Element")}} has been renamed to {{domxref("Element.getAnimations()")}} ([bug Firefox 1145246](https://bugzil.la/1145246)).
-- `Animation` and `AnimationEffect` have been merged into the newly created {{domxref("KeyframeEffectReadOnly")}} ([bug Firefox 1153734](https://bugzil.la/1153734)).
-- `AnimationPlayer` has been renamed to {{domxref("Animation")}} ([bug Firefox 1154615](https://bugzil.la/1154615)).
-- {{domxref("AnimationTimeline")}} is now an abstract class, with {{domxref("DocumentTimeline")}} its only implementation ([bug Firefox 1152171](https://bugzil.la/1152171)).
+- {{DOMxRef("Animation/currentTime", "AnimationPlayer.currentTime")}} peut désormais également être défini ([bogue Firefox 1072037 <sup>(angl.)</sup>](https://bugzil.la/1072037)).
+- `Animatable.getAnimationPlayers()`, disponible sur {{DOMxRef("Element")}}, a été renommé en {{DOMxRef("Element.getAnimations()")}} ([bogue Firefox 1145246 <sup>(angl.)</sup>](https://bugzil.la/1145246)).
+- `Animation` et `AnimationEffect` ont été fusionnés dans le nouveau `KeyframeEffectReadOnly` ([bogue Firefox 1153734 <sup>(angl.)</sup>](https://bugzil.la/1153734)).
+- `AnimationPlayer` a été renommé en {{DOMxRef("Animation")}} ([bogue Firefox 1154615 <sup>(angl.)</sup>](https://bugzil.la/1154615)).
+- {{DOMxRef("AnimationTimeline")}} est désormais une classe abstraite, avec {{DOMxRef("DocumentTimeline")}} comme seule implémentation ([bogue Firefox 1152171 <sup>(angl.)</sup>](https://bugzil.la/1152171)).
 
 #### CSSOM
 
-- The CSS Font Loading API is now enabled by default in Nightly and Developer Edition releases ([bug Firefox 1088437](https://bugzil.la/1088437)). It is still deactivated by default in Beta and Release browsers.
-- The `CSSCharsetRule` interface has been removed and such objects are no longer available in CSSOM ([bug Firefox 1148694](https://bugzil.la/1148694)). This matches the spec (recently adapted) and Chrome behavior.
+- L'API CSS Font Loading est désormais activée par défaut dans les versions Nightly et Developer Edition ([bogue Firefox 1088437 <sup>(angl.)</sup>](https://bugzil.la/1088437)). Elle reste désactivée par défaut dans les navigateurs Beta et Release.
+- L'interface `CSSCharsetRule` a été supprimée et de tels objets ne sont plus disponibles dans CSSOM ([bogue Firefox 1148694 <sup>(angl.)</sup>](https://bugzil.la/1148694)). Cela correspond à la spécification (récemment adaptée) et au comportement de Chrome.
 
 #### WebRTC
 
-- WebRTC: the [`negotiationneeded`](/fr/docs/Web/API/RTCPeerConnection/negotiationneeded_event) event is now also sent for initial negotiations, not only for re-negotiations ([bug Firefox 1149838](https://bugzil.la/1149838)).
+- WebRT&nbsp;: l'évènement {{DOMxRef("RTCPeerConnection.negotiationneeded_event", "negotiationneeded")}} est désormais également envoyé pour les négociations initiales, et pas seulement pour les renégociations ([bogue Firefox 1149838 <sup>(angl.)</sup>](https://bugzil.la/1149838)).
 
-#### DOM & HTML DOM
+#### DOM et HTML DOM
 
-- When unable to parse the [`srcset`](/fr/docs/Web/HTML/Reference/Elements/img#srcset), the {{domxref("HTMLImageElement.currentSrc")}} method doesn't return `null` anymore but `""`, as requested by the latest specification ([bug Firefox 1139560](https://bugzil.la/1139560)).
-- Like for images, Firefox now throttle {{domxref("Window.requestAnimationFrame()")}} for non-visible {{HTMLElement("iframe")}} ([bug Firefox 1145439](https://bugzil.la/1145439)).
-- {{domxref("Navigator.taintEnabled")}} is no longer available for Web workers ([bug Firefox 1154878](https://bugzil.la/1154878)).
-- The read-only properties {{domxref("MouseEvent.offsetX")}} and {{domxref("MouseEvent.offsetY")}} have been implemented [bug Firefox 69787](https://bugzil.la/69787).
+- Lorsque le [`srcset`](/fr/docs/Web/HTML/Reference/Elements/img#srcset) ne peut pas être analysé, la méthode {{DOMxRef("HTMLImageElement.currentSrc")}} ne retourne plus `null` mais `""`, comme demandé par la dernière spécification ([bogue Firefox 1139560 <sup>(angl.)</sup>](https://bugzil.la/1139560)).
+- Comme pour les images, Firefox limite désormais {{DOMxRef("Window.requestAnimationFrame()")}} pour les {{HTMLElement("iframe")}} non visibles ([bogue Firefox 1145439 <sup>(angl.)</sup>](https://bugzil.la/1145439)).
+- {{DOMxRef("Navigator.taintEnabled")}} n'est plus disponible pour les Web workers ([bogue Firefox 1154878 <sup>(angl.)</sup>](https://bugzil.la/1154878)).
 
-#### Web Audio API
+#### API Web Audio
 
-Nouvelles extensions pour l'[API Web Audio](/fr/docs/Web/API/Web_Audio_API):
+Nouvelles extensions à [l'API Web Audio](/fr/docs/Web/API/Web_Audio_API)&nbsp;:
 
-- The {{domxref("AudioContext.state")}} and {{domxref("AudioContext.onstatechange")}} properties as well as the methods {{domxref("AudioContext.suspend()")}}, {{domxref("AudioContext.resume()")}}, and {{domxref("AudioContext.close()")}} have been added ([bug Firefox 1094764](https://bugzil.la/1094764)).
-- {{domxref("AudioBufferSourceNode")}} now implements the {{domxref("AudioBufferSourceNode.detune")}} [k-rate](/fr/docs/Web/API/AudioParam#k-rate) attribute ([bug Firefox 1153783](https://bugzil.la/1153783)).
+- Les propriétés {{DOMxRef("BaseAudioContext/state", "AudioContext.state")}} et {{DOMxRef("BaseAudioContext/statechange_event", "AudioContext.onstatechange")}}, ainsi que les méthodes {{DOMxRef("AudioContext.suspend()")}}, {{DOMxRef("AudioContext.resume()")}} et {{DOMxRef("AudioContext.close()")}} ont été ajoutées ([bogue Firefox 1094764 <sup>(angl.)</sup>](https://bugzil.la/1094764)).
+- {{DOMxRef("AudioBufferSourceNode")}} implémente désormais l'attribut {{DOMxRef("AudioBufferSourceNode.detune")}} [k-rate](/fr/docs/Web/API/AudioParam#k-rate) ([bogue Firefox 1153783 <sup>(angl.)</sup>](https://bugzil.la/1153783)).
 
 #### Web Workers
 
-- Légère amélioration dans notre [API Service Worker](/fr/docs/Web/API/Service_Worker_API) : la méthode {{domxref("ServiceWorkerRegistration.update()", "update()")}} a été changée de {{domxref("ServiceWorkerGlobalScope")}} vers {{domxref("ServiceWorkerRegistration")}} ([bug Firefox 1131350](https://bugzil.la/1131350)).
-- {{domxref("ServiceWorkerRegistration")}} est maintenant disponible dans les Web workers ([bug Firefox 1131327](https://bugzil.la/1131327)).
-- {{domxref("DataStore")}} est maintenant disponible dans les Web workers ([bug Firefox 916196](https://bugzil.la/916196)).
+- Légère amélioration de notre [API Service Worker](/fr/docs/Web/API/Service_Worker_API)&nbsp;: la méthode {{DOMxRef("ServiceWorkerRegistration.update()", "update()")}} a été déplacée de {{DOMxRef("ServiceWorkerGlobalScope")}} vers {{DOMxRef("ServiceWorkerRegistration")}} ([bogue Firefox 1131350 <sup>(angl.)</sup>](https://bugzil.la/1131350)).
+- {{DOMxRef("ServiceWorkerRegistration")}} est désormais disponible dans les Web workers ([bogue Firefox 1131327 <sup>(angl.)</sup>](https://bugzil.la/1131327)).
+- `DataStore` est désormais disponible dans les Web workers ([bogue Firefox 916196 <sup>(angl.)</sup>](https://bugzil.la/916196)).
 
 #### IndexedDB
 
-- {{domxref("IDBTransaction")}} sont maintenant temporaire par default. ([bug Firefox 1112702](https://bugzil.la/1112702)). Cela privilegie les performances par rapport a la fiabilité et est en phase les autres navigateurs. Pour plus d'information, lire notre [durability definition](/fr/docs/Web/API/IndexedDB_API/Basic_Terminology#durable).
+- {{DOMxRef("IDBTransaction")}} sont désormais non durables par défaut ([bogue Firefox 1112702 <sup>(angl.)</sup>](https://bugzil.la/1112702)). Cela favorise les performances par rapport à la fiabilité et correspond à ce que font les autres navigateurs. Pour plus d'informations, consultez notre [définition de la durabilité](/fr/docs/Web/API/IndexedDB_API/Basic_Terminology#durable).
 
-#### Dev Tools
+#### Outils de développement
 
-- La propriété {{domxref("Console.timeStamp")}} a été ajoutée ([bug Firefox 922221](https://bugzil.la/922221)).
+- La propriété {{DOMxRef("console/timeStamp_static", "console.timeStamp()")}} a été ajoutée ([bogue Firefox 922221 <sup>(angl.)</sup>](https://bugzil.la/922221)).
 
 ### MathML
 
-_pas de changement._
+_Pas de changement._
 
 ### SVG
 
-_pas de changement._
+_Pas de changement._
 
 ### Audio/Video
 
-_pas de changement._
+_Pas de changement._
 
-## Networking
+## Réseau
 
-_pas de changement._
+_Pas de changement._
 
-## Security
+## Sécurité
 
-- L'utilisation d'un asterisk (`*`) dans {{Glossary("CSP")}} n'inclus plus le schema `data:`, `blob:` or `:filesystem` lors de la comparaison des expressions sources. Ces schemas doivent dorénavant etre définis explicitement dans l'entete concernée afin de correspondre au CSP ([bug Firefox 1086999](https://bugzil.la/1086999)).
+- L'utilisation d'un astérisque (`*`) dans une {{Glossary("CSP")}} n'inclut plus les schémas `data:`, `blob:` ou `:filesystem` lors de la correspondance des expressions source. Ces schémas doivent désormais être définis explicitement dans l'en-tête correspondant pour correspondre à la CSP ([bogue Firefox 1086999 <sup>(angl.)</sup>](https://bugzil.la/1086999)).
 
-## Changes for add-on and Mozilla developers
+## Changements pour les développeur·euse·s de Mozilla et d'extensions
 
 ### XUL
 
-_pas de changement._
+- Il n'est plus possible de créer des fenêtres de niveau supérieur transparentes ([bogue Firefox 1162649 <sup>(angl.)</sup>](https://bugzil.la/1162649)).
 
-### JavaScript code modules
+### Modules de code JavaScript
 
-- Dict.jsm a été supprimé [bug Firefox 1123309](https://bugzil.la/1123309). Veuillez utiliser {{jsxref("Map")}} en remplacement.
+- Dict.jsm a été supprimé ([bogue Firefox 1123309 <sup>(angl.)</sup>](https://bugzil.la/1123309)). Utilisez {{JSxRef("Map")}} à la place.
 
 ### XPCOM
 
-_No change._
+- L'attribut `nsIClassInfo.implementationLanguage` a été supprimé, ainsi que la fonction `nsClassInfo::GetImplementationLanguage()`.
+- Les interfaces XPCOM suivantes ont été supprimées&nbsp;; vous devez utiliser les interfaces HTML standard à la place&nbsp;:
+  - `nsIDOMHTMLBRElement`
+  - `nsIDOMDivElement`
+  - `nsIDOMHTMLHeadingElement`
+  - `nsIDOMHTMLTableCaptionElement`
+  - `nsIDOMHTMLTableElement`
+  - `nsIDOMHTMLTitleElement`
 
-### Other
+### Autres
 
-- Places Keywords API has been deprecated and will be removed soon ([bug Firefox 1140395](https://bugzil.la/1140395)).
-
-## Voir aussi
-
-- [Site Compatibility for Firefox 40](/fr/docs/Mozilla/Firefox/Releases/40/Site_Compatibility)
-
-## Older versions
-
-{{Firefox_for_developers('39')}}
+- L'API Places Keywords a été dépréciée et sera bientôt supprimée ([bogue Firefox 1140395 <sup>(angl.)</sup>](https://bugzil.la/1140395)).
+- Le système de test automatisé prend désormais en charge l'ignorance des fonctions de test individuelles. Voir [exécution de tests conditionnels <sup>(angl.)</sup>](https://firefox-source-docs.mozilla.org/testing/xpcshell/index.html#conditionally-running-a-test) dans les tests XPCShell.


### PR DESCRIPTION
### Description

Update translation of pages without french version: `Mozilla/Firefox/Releases/40`

### Motivation

Update access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_