### PR TITLE
chore(fr): update of `MDN/Writing_guidelines/Howto/Markdown_in_MDN`

### DIFF
--- a/files/fr/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -1,56 +1,49 @@
 ---
 title: Comment écrire du Markdown
+short-title: Écrire du Markdown
 slug: MDN/Writing_guidelines/Howto/Markdown_in_MDN
 l10n:
-  sourceCommit: 134cdabf5742ed1fd65b1c90ee19d8cc425ce999
+  sourceCommit: 49f3eb321cf6a491c3bcef1c3590f9bf6f90c9b8
 ---
 
-{{MDNSidebar}}
-
-Cette page décrit comment nous utilisons le Markdown pour écrire la documentation sur MDN Web Docs. Nous avons choisi le Markdown personnalisé de GitHub (GFM) comme base, et nous avons ajouté quelques extensions pour supporter certaines choses que nous devons faire sur MDN et qui ne sont pas supportées par GFM.
+Cette page décrit comment nous utilisons le Markdown pour écrire la documentation sur MDN Web Docs.
+Nous avons choisi le Markdown personnalisé de GitHub (GFM) comme base, et nous avons ajouté quelques extensions pour supporter certaines choses que nous devons faire sur MDN et qui ne sont pas supportées par GFM.
 
 ## Syntaxe basée sur GFM
 
-La syntaxe Markdown de MDN se base sur le format Markdown de GitHub (GFM)&nbsp;: <https://github.github.com/gfm/> (en anglais). Cela signifie que vous pouvez vous référer à la spécification GFM pour tout ce qui n'est pas explicitement spécifié sur cette page. GFM se base quant à lui sur <i lang="en">CommonMark</i> (<https://spec.commonmark.org> (en anglais)).
+La syntaxe Markdown de MDN se base sur le format Markdown de GitHub (GFM)&nbsp;: <https://github.github.com/gfm/> <sup>(angl.)</sup>. Cela signifie que vous pouvez vous référer à la spécification GFM pour tout ce qui n'est pas explicitement défini sur cette page. GFM se base quant à lui sur <i lang="en">CommonMark</i> (<https://spec.commonmark.org> <sup>(angl.)</sup>).
 
 ## Liens
 
 La spécification GFM définit deux types basiques de liens&nbsp;:
 
-- [Les liens en ligne (en anglais)](https://github.github.com/gfm/#inline-link), dans lesquels la destination est donnée directement après le texte du lien.
-- [Les liens de référence (en anglais)](https://github.github.com/gfm/#reference-link), dans lesquels la destination est définie ailleurs dans le document.
+- [Les liens en ligne <sup>(angl.)</sup>](https://github.github.com/gfm/#inline-link), dans lesquels la destination est donnée directement après le texte du lien.
+- [Les liens de référence <sup>(angl.)</sup>](https://github.github.com/gfm/#reference-link), dans lesquels la destination est définie ailleurs dans le document.
 
-Sur MDN, nous autorisons uniquement les liens en ligne.
+Sur MDN, nous préférons utiliser des liens en ligne, car ils sont plus faciles à lire et à maintenir sans perdre le contexte. C'est la manière recommandée d'écrire des liens sur MDN&nbsp;:
 
-Voici la manière correcte d'écrire des liens GFM sur MDN&nbsp;:
-
-```md example-good
+```md
 Les [macarons](https://fr.wikipedia.org/wiki/Macaron) sont délicieux mais difficiles à faire.
 ```
 
-Ceci est une manière incorrecte d'écrire des liens sur MDN&nbsp;:
+Dans certaines situations, cependant, les liens de référence sont plus appropriés en raison de leur compacité.
+Par exemple, réduire la largeur des tableaux larges peut les rendre plus faciles à examiner et à modifier.
 
-```md example-bad
-Les [macarons][macaron] sont délicieux mais difficiles à faire.
+```md
+| Nom                  | Fonctionnalité                                                                                                       |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| [Macarons][macarons] | Délicieux mais difficiles à faire. Apporte plus de classe à un goûter que presque n'importe quelle autre pâtisserie. |
+| [Biscotti][biscotti] | Croquants et plus faciles à faire.                                                                                   |
 
-[macaron]: https://fr.wikipedia.org/wiki/Macaron
+[macarons]: https://fr.wikipedia.org/wiki/Macaron
+[biscotti]: https://fr.wikipedia.org/wiki/Biscotti
 ```
+
+Dans de rares cas où il est nécessaire d'utiliser des liens de référence, veuillez vous assurer qu'ils suivent immédiatement le contexte dans lequel ils sont utilisés.
 
 ## Blocs de code d'exemple
 
 Dans GFM et CommonMark, on peut utiliser des «&nbsp;blocs de code&nbsp;» pour délimiter les blocs `<pre>`. Le bloc de code ouvrant peut être suivi par du texte appelé «&nbsp;texte d'information&nbsp;». La spécification établit ceci&nbsp;:
-
-> Le premier mot du texte d'information est généralement utilisé pour spécifier le langage de l'exemple de code, et est rendu dans l'attribut de classe de la balise de code.
-
-Il est possible pour le texte d'information de contenir plusieurs mots&nbsp;:
-
-````md
-```fee fi fo fum
-// code d'exemple
-```
-````
-
-Sur MDN, la rédaction utilise les blocs de code pour les exemples de code. Elle doit spécifier le langage de l'échantillon de code dès le premier mot de la chaîne de caractères, et cela fourni de la coloration syntaxique pour le bloc. Les mots suivant sont supportés&nbsp;:
 
 - Langages de programmation
   - JavaScript
@@ -99,7 +92,7 @@ Sur MDN, la rédaction utilise les blocs de code pour les exemples de code. Elle
   - `django` — Modèles Django
   - `svelte` — Modèles Svelte
   - `handlebars` — Modèles Handlebars
-  - `pug` — [Modèles Pug (en anglais)](https://pugjs.org/api/getting-started.html) (peuvent être utilisés par [Express](/fr/docs/Learn/Server-side/Express_Nodejs/Displaying_data/Template_primer))
+  - `pug` — [Modèles Pug <sup>(angl.)</sup>](https://pugjs.org/api/getting-started.html) (peuvent être utilisés par [Express](/fr/docs/Learn/Server-side/Express_Nodejs/Displaying_data/Template_primer))
 - Autres
   - `plain` — Texte brut
   - `diff` — Fichier de différence
@@ -115,7 +108,10 @@ const salutation = "Je possède la coloration syntaxique du JavaScript";
 ```
 ````
 
-Si la coloration syntaxique que vous souhaitez utiliser n'est pas listée au-dessus, vous devriez marquer le bloc de code comme du texte brut (`plain`). D'autres langages peuvent être demandés grâce au processus [expliqué sur GitHub (en anglais)](https://github.com/orgs/mdn/discussions/170#discussioncomment-3404366).
+Si la coloration syntaxique que vous souhaitez utiliser n'est pas listée au-dessus, vous devez marquer le bloc de code comme du texte brut (`plain`). D'autres langages peuvent être demandés grâce au processus [expliqué sur GitHub <sup>(angl.)</sup>](https://github.com/orgs/mdn/discussions/170#discussioncomment-3404366).
+
+> [!NOTE]
+> Utilisez l'identificateur de langage exactement comme indiqué ci-dessus. Par exemple, `javascript` n'est pas autorisé, vous devez écrire `js`.
 
 ### Suppression du formatage
 
@@ -124,16 +120,16 @@ On peut ajouter le suffixe `-nolint` à n'importe quel identificateur de langage
 ````md-nolint
 ```html-nolint
 <p>
-Je ne suis pas formatté.
+Je ne suis pas formaté.
 </p>
 ```
 ````
 
-Ces blocs de code auront bien la coloration syntaxique et seront reconnus par le système d'exemple en direct, mais seront ignorés par les outils de formatage comme <i lang="en">Prettier</i>. Il faut utiliser ce suffixe pour montrer du code invalide ou d'autres manières de formater que les outils de formatage ne devraient pas corriger.
+Ces blocs de code ont bien la coloration syntaxique et sont reconnus par le système d'exemple en direct, mais sont ignorés par les outils de formatage comme <i lang="en">Prettier</i>. Il faut utiliser ce suffixe pour montrer du code invalide ou d'autres manières de formater que les outils de formatage ne devraient pas corriger.
 
 ### Classes supplémentaires (textes d'information)
 
-GFM supporte les [textes d'information (en anglais)](https://github.github.com/gfm/#info-string), qui permettent d'ajouter des informations additionnelles à propos d'un bloc de code. Sur MDN, les textes d'information sont convertis en noms de classe.
+GFM supporte les [textes d'information <sup>(angl.)</sup>](https://github.github.com/gfm/#info-string), qui permettent d'ajouter des informations additionnelles à propos d'un bloc de code. Sur MDN, les textes d'information sont convertis en noms de classe.
 
 On peut ajouter l'un des textes d'information suivant&nbsp;:
 
@@ -157,7 +153,7 @@ const salutation = "Je suis une salutation secrète";
 ```
 ````
 
-Ces exemples seront affichés comme suit&nbsp;:
+Ces exemples sont affichés comme suit&nbsp;:
 
 ```js example-good
 const salutation = "Je suis un bon exemple";
@@ -171,20 +167,23 @@ const salutation = "Je suis un mauvais exemple";
 
 Ce sujet a été discuté et a fait l'objet d'un consensus dans&nbsp;:
 
-- <https://github.com/mdn/content/issues/3512> (en anglais)
-- <https://github.com/mdn/yari/pull/7017> (en anglais)
+- <https://github.com/mdn/content/issues/3512> <sup>(angl.)</sup>
+- <https://github.com/mdn/yari/pull/7017> <sup>(angl.)</sup>
 
 ## Notes, avertissements, et remarques
 
-Parfois, nous devons attirer l'attention sur une partie du contenu. Pour réaliser cela, on utilise un bloc de code GFM avec un premier paragraphe spécial. Il en existe trois types&nbsp;: les notes, les avertissements et les remarques.
+Les rédacteur·ice·s peuvent utiliser la [syntaxe des alertes GFM <sup>(angl.)</sup>](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) pour attirer l'attention sur un contenu particulier. Il existe trois types d'alertes&nbsp;: notes, avertissements et encadrés.
 
-- Pour ajouter une note, créez un bloc de citation dont le premier paragraphe commence par `**Note :**`.
-- Pour ajouter un avertissement, créez un bloc de citation dont le premier paragraphe commence par `**Attention :**`.
-- Pour ajouter un encadré, créez un bloc de citation dont le premier paragraphe commence par `**Remarque :**`.
+> [!NOTE]
+> MDN Web Docs prend en charge les alertes avec sa propre syntaxe avant la prise en charge des alertes GFM, et les appelait «&nbsp;blocs de notes&nbsp;».
+> MDN ne prend pas en charge les alertes GFM suivantes&nbsp;: `[!TIP]`, `[!CAUTION]`, `[!IMPORTANT]`.
+> GFM ne prend pas en charge `[!CALLOUT]`.
 
-Les notes et les avertissements afficheront le texte **Note :** ou **Attention :** dans la sortie, tandis que les remarques n'ajoutent pas de texte particulier. Cela en fait un bon choix lorsqu'on souhaite utiliser un titre personnalisé.
+- Pour ajouter une note, créez un bloc de citation dont le premier paragraphe commence par `[!NOTE]`.
+- Pour ajouter un avertissement, créez un bloc de citation dont le premier paragraphe commence par `[!WARNING]`.
+- Pour ajouter un encadré, créez un bloc de citation dont le premier paragraphe commence par `[!CALLOUT]`.
 
-Le traitement des mots de balisage fonctionne sur l'ASA (Arbre de syntaxe abstraite) produit, pas sur les caractères exacts fournis en entrée. Cela signifie que fournir `<strong>Note :</strong>` génère aussi une note. Cependant, la syntaxe Markdown est requise par souci de style.
+Les notes et les avertissements affichent le texte **Note :** ou **Attention :** dans la sortie, tandis que les remarques n'ajoutent pas de texte particulier. Cela en fait un bon choix lorsqu'on souhaite utiliser un titre personnalisé.
 
 Plusieurs lignes sont produites par un bloc de code vide de la même manière que pour les paragraphes normaux. De plus, plusieurs lignes sans espace sont aussi traitées comme une ligne de Markdown normale, et sont donc concaténées.
 
@@ -201,7 +200,7 @@ Le bloc de code peut contenir d'autres éléments de type bloc.
 > Elle peut avoir plusieurs lignes.
 ```
 
-Cela produira le HTML suivant&nbsp;:
+Cela produit le HTML suivant&nbsp;:
 
 ```html
 <div class="notecard note">
@@ -210,7 +209,7 @@ Cela produira le HTML suivant&nbsp;:
 </div>
 ```
 
-Ce HTML sera affiché comme une boîte mise en valeur&nbsp;:
+Ce HTML est affiché comme une boîte mise en valeur&nbsp;:
 
 > [!NOTE]
 > Voici comment écrire une note.
@@ -226,7 +225,7 @@ Ce HTML sera affiché comme une boîte mise en valeur&nbsp;:
 > Il peut avoir plusieurs paragraphes.
 ```
 
-Cela produira le HTML suivant&nbsp;:
+Cela produit le HTML suivant&nbsp;:
 
 ```html
 <div class="notecard warning">
@@ -235,7 +234,7 @@ Cela produira le HTML suivant&nbsp;:
 </div>
 ```
 
-Ce HTML sera affiché comme une boîte mise en valeur&nbsp;:
+Ce HTML est affiché comme une boîte mise en valeur&nbsp;:
 
 > [!WARNING]
 > Voici comment écrire un avertissement.
@@ -251,7 +250,7 @@ Ce HTML sera affiché comme une boîte mise en valeur&nbsp;:
 > Il peut avoir plusieurs paragraphes.
 ```
 
-Cela produira le HTML suivant&nbsp;:
+Cela produit le HTML suivant&nbsp;:
 
 ```html
 <div class="callout">
@@ -260,34 +259,13 @@ Cela produira le HTML suivant&nbsp;:
 </div>
 ```
 
-Ce HTML sera affiché comme une remarque&nbsp;:
+Ce HTML est affiché comme une remarque&nbsp;:
 
 > [!CALLOUT]
 >
 > **Voici comment écrire un encadré.**
 >
 > Il peut avoir plusieurs paragraphes.
-
-#### Traduction des titres pour les notes et avertissements
-
-Comme les textes «&nbsp;Note :&nbsp;» ou «&nbsp;Attention :&nbsp;» apparaissent aussi dans la sortie affichée, ils doivent être traduits selon la langue de la page. En pratique, cela signifie que chaque locale prise en charge par MDN doit fournir ses propres traductions pour ces textes, et que la plateforme doit les reconnaître comme indiquant que la construction à besoin d'un traitement spécial.
-
-Les locales sont stockées dans [Yari (dépôt GitHub en anglais)](https://github.com/mdn/yari/tree/main/markdown/localizations) en tant que fichier JSON dans le format [gettext (en anglais)](https://www.gnu.org/software/gettext/). Référez-vous à ces fichiers pour déterminer quel texte devrait être utilisé à la place de «&nbsp;Note:&nbsp;» ou «&nbsp;Warning:&nbsp;» pour cette locale. Si un fichier de locales n'est pas défini, l'anglais sera utilisé en dernier recours.
-
-Par exemple, si nous voulons utiliser «&nbsp;Warnung&nbsp;» pour «&nbsp;Warning&nbsp;» en allemand, alors dans la page allemande nous écririons&nbsp;:
-
-```md
-> [!WARNING]
-> So schreibt man eine Warnung.
-```
-
-Et cela produira&nbsp;:
-
-```html
-<div class="notecard warning">
-  <p><strong>Warnung:</strong> So schreibt man eine Warnung.</p>
-</div>
-```
 
 #### Note contenant un bloc de code
 
@@ -306,7 +284,7 @@ Cet exemple contient un bloc de code.
 > Comme cela.
 ````
 
-Cela produira le HTML suivant&nbsp;:
+Cela produit le HTML suivant&nbsp;:
 
 ```html
 <div class="notecard note">
@@ -317,7 +295,7 @@ Cela produira le HTML suivant&nbsp;:
 </div>
 ```
 
-Ce HTML sera affiché comme un bloc de code&nbsp;:
+Ce HTML est affiché comme un bloc de code&nbsp;:
 
 > [!NOTE]
 > Voici comment écrire une note.
@@ -332,20 +310,20 @@ Ce HTML sera affiché comme un bloc de code&nbsp;:
 
 ### Référence de la discussion
 
-Voir la discussion et le consensus à ce sujet dans <https://github.com/mdn/content/issues/3483> (en anglais).
+Voir la discussion et le consensus à ce sujet dans <https://github.com/mdn/content/issues/3483> <sup>(angl.)</sup>.
 
 ## Listes de définitions
 
-Les listes de définitions sont souvent utilisées sur MDN, mais ne sont pas supportées par GFM. MDN introduit un format personnalisé pour les listes de définitions, qui est une forme modifiée des listes non-ordonnées de GFM ([`<ul>`](/fr/docs/Web/HTML/Reference/Elements/ul)). Dans ce format&nbsp;:
+Les listes de définitions sont souvent utilisées sur MDN, mais ne sont pas supportées par GFM. MDN introduit un format personnalisé pour les listes de définitions, qui est une forme modifiée des listes non-ordonnées de GFM ({{HTMLElement("ul")}})). Dans ce format&nbsp;:
 
 - La liste `<ul>` de GFM contient n'importe quel nombre d'éléments GFM `<li>` de premier niveau.
 - Chacun de ces éléments GFM `<li>` de premier niveau doivent contenir un élément GFM `<ul>` en tant que dernier élément.
 - Le dernier `<ul>` imbriqué doit contenir un unique élément GFM `<li>`, dont le contenu textuel doit commencer par «&nbsp;:&nbsp;&nbsp;» (deux points suivis par un espace). Cet élément peut contenir des éléments de type bloc, dont des paragraphes, des blocs de code, des listes incrustées et des notes.
 
-Chacun de ces éléments GFM `<li>` de premier niveau sera transformé en une paire de `<dt>`/`<dd>` comme suit&nbsp;:
+Chacun de ces éléments GFM `<li>` de premier niveau est transformé en une paire de `<dt>`/`<dd>` comme suit&nbsp;:
 
-- L'élément GFM `<li>` de premier niveau sera analysé comme un élément GFM `<li>` et son contenu comprendra le contenu du `<dt>`, excepté pour le dernier `<ul>` imbriqué qui ne sera pas inclus dans le `<dt>`.
-- L'élément `<li>` dans le dernier `<ul>` imbriqué sera analysé comme un élément GFM `<li>` et son contenu sera compris dans le contenu du `<dd>`, excepté le premier «&nbsp;:&nbsp;&nbsp;» qui sera rejeté.
+- L'élément GFM `<li>` de premier niveau est analysé comme un élément GFM `<li>` et son contenu comprend le contenu du `<dt>`, excepté pour le dernier `<ul>` imbriqué qui ne est pas inclus dans le `<dt>`.
+- L'élément `<li>` dans le dernier `<ul>` imbriqué est analysé comme un élément GFM `<li>` et son contenu est compris dans le contenu du `<dd>`, excepté le premier «&nbsp;:&nbsp;&nbsp;» qui est rejeté.
 
 Par exemple, voici un `<dl>`&nbsp;:
 
@@ -363,7 +341,7 @@ Par exemple, voici un `<dl>`&nbsp;:
     ```
 ````
 
-Dans GFM/CommonMark, cela aurait produit le HTML suivant&nbsp;:
+Dans GFM/CommonMark, cela produit le HTML suivant&nbsp;:
 
 ```html
 <ul>
@@ -390,7 +368,7 @@ Dans GFM/CommonMark, cela aurait produit le HTML suivant&nbsp;:
 </ul>
 ```
 
-Sur MDN, cela produirait le HTML suivant&nbsp;:
+Sur MDN, cela produit le HTML suivant&nbsp;:
 
 ```html
 <dl>
@@ -413,7 +391,7 @@ Sur MDN, cela produirait le HTML suivant&nbsp;:
 </dl>
 ```
 
-Les listes de définitions écrite avec cette syntaxe doivent être composées de paires d'éléments `<dt>`/`<dd>`. Avec cette syntaxe, il n'est pas possible d'écrire une liste avec plus d'un élément `<dt>` consécutif ou plus d'un élément `<dd>` consécutif&nbsp;: l'analyseur traitera cela comme une erreur. Nous nous attendons à ce que presque toutes les listes de définitions sur MDN fonctionnent avec cette limitation, et pour celles qui ne fonctionnent pas, il est toujours possible d'utiliser du HTML pur.
+Les listes de définitions écrites avec cette syntaxe doivent être composées de paires d'éléments `<dt>`/`<dd>`. Avec cette syntaxe, il n'est pas possible d'écrire une liste avec plus d'un élément `<dt>` consécutif ou plus d'un élément `<dd>` consécutif&nbsp;: l'analyseur traite cela comme une erreur. Nous nous attendons à ce que presque toutes les listes de définitions sur MDN fonctionnent avec cette limitation, et pour celles qui ne fonctionnent pas, il est toujours possible d'utiliser du HTML pur.
 
 Ceci n'est pas permis&nbsp;:
 
@@ -435,11 +413,11 @@ La syntaxe décrite ici a été choisie parce qu'elle fonctionne assez bien avec
 
 ### Référence de la discussion
 
-La discussion et le consensus sur ce sujet sont sur <https://github.com/mdn/content/issues/4367> (en anglais).
+La discussion et le consensus sur ce sujet sont sur <https://github.com/mdn/content/issues/4367> <sup>(angl.)</sup>.
 
 ## Tableaux
 
-GFM fournit une syntaxe pour créer des [tableaux (en anglais)](https://github.github.com/gfm/#tables-extension-) que nous utilisons dans MDN. Cependant, il existe certains cas dans lesquels les tableaux de GFM ne nous conviennent pas&nbsp;:
+GFM fournit une syntaxe pour créer des [tableaux <sup>(angl.)</sup>](https://github.github.com/gfm/#tables-extension-) que nous utilisons dans MDN. Cependant, il existe certains cas dans lesquels les tableaux de GFM ne nous conviennent pas&nbsp;:
 
 - La syntaxe GFM ne supporte qu'un sous-ensemble des fonctionnalités disponibles dans HTML. Si vous avez besoin d'utiliser des fonctionnalités de tableau qui ne sont pas disponibles dans GFM, utilisez HTML pour le tableau.
 - Si la représentation GFM du tableau fait plus de 150 caractères de large, utilisez HTML pour le tableau.
@@ -449,7 +427,7 @@ Le principe général est qu'il faut utiliser la syntaxe Markdown GFM si possibl
 
 ### Style pour la syntaxe des tableaux GFM
 
-Dans la syntaxe GFM, il est possible d'omettre les premières et dernières barres verticales («&nbsp;|&nbsp;») pour les lignes. Cependant, dans un souci de lisibilité, on veillera sur MDN à inclure ces barres verticales. De plus, on veillera à compléter les lignes par des espaces de manière à ce que les cellules d'une colonne fassent toutes la même longueur sous la forme du texte brut.
+Dans la syntaxe GFM, il est possible d'omettre les premières et dernières barres verticales («&nbsp;|&nbsp;») pour les lignes. Cependant, dans un souci de lisibilité, on veille sur MDN à inclure ces barres verticales. De plus, on veille à compléter les lignes par des espaces de manière à ce que les cellules d'une colonne fassent toutes la même longueur sous la forme du texte brut.
 
 En résumé, il faut viser ce style&nbsp;:
 
@@ -476,7 +454,7 @@ Heureusement, le formatage des tableaux est traité automatiquement par <i lang=
 Il y a trois principales circonstances dans lesquelles il convient d'utiliser les tableaux HTML plutôt que la syntaxe GFM&nbsp;:
 
 1. Le tableau utilise des fonctionnalités non prises en charge par GFM (voir ci-après).
-2. Le tableau GFM serait trop large pour être lisible.
+2. Le tableau GFM est trop large pour être lisible.
 3. On souhaite afficher un tableau de propriétés.
 
 #### Fonctionnalités de tableau non prise en charge par GFM
@@ -485,7 +463,7 @@ Les principales limitations de la syntaxe des tableaux GFM sont&nbsp;:
 
 - Les tableaux GFM doivent avoir une ligne d'en-tête.
 - Les tableaux GFM peuvent ne pas avoir de colonne d'en-tête.
-- GFM n'analysera pas les éléments de type bloc dans les cellules de tableau. Par exemple, vous ne pouvez pas avoir de liste dans une cellule de tableau.
+- GFM n'analyse pas les éléments de type bloc dans les cellules de tableau. Par exemple, vous ne pouvez pas avoir de liste dans une cellule de tableau.
 - Les tableaux GFM ne peuvent pas avoir de classes assignées.
 - GFM ne supporte aucun élément de tableau à part `<table>`, `<tr>`, `<th>` et `<td>`.
 - GFM ne supporte pas les attributs de tableau comme `<colspan>`, `<rowspan>` ou `<scope>`.
@@ -496,7 +474,7 @@ Notez que nous ne recommandons pas l'usage général des éléments `<caption>` 
 
 #### Largeur maximum des tableaux GFM
 
-Même quand un tableau peut être écris en GFM, il est certaines fois mieux d'utiliser HTML, car GFM utilise une forme «&nbsp;d'art [ASCII](/fr/docs/Glossary/ASCII)&nbsp;» pour les tableaux qui n'est pas lisible lorsque les lignes deviennent trop longues. Examinez les tableaux suivant&nbsp;:
+Même quand un tableau peut être écris en GFM, il est certaines fois mieux d'utiliser HTML, car GFM utilise une forme «&nbsp;d'art {{Glossary("ASCII")}}&nbsp;» pour les tableaux qui n'est pas lisible lorsque les lignes deviennent trop longues. Examinez les tableaux suivant&nbsp;:
 
 ```html
 <table>
@@ -568,7 +546,7 @@ Les tableaux de propriétés sont un type de tableau spécifique utilisés pour 
   </tbody>
 </table>
 
-Ces pages ne peuvent pas être représentées en GFM car elles possèdent une colonne en-tête, et il faut donc utiliser HTML dans ce cas. Pour obtenir la mise en forme spéciale correspondante, on applique la classe `"properties"` au tableau&nbsp;:
+Ces pages ne peuvent pas être représentées en GFM, car elles possèdent une colonne en-tête, et il faut donc utiliser HTML dans ce cas. Pour obtenir la mise en forme spéciale correspondante, on applique la classe `"properties"` au tableau&nbsp;:
 
 ```html
 <table class="properties"></table>
@@ -576,27 +554,42 @@ Ces pages ne peuvent pas être représentées en GFM car elles possèdent une co
 
 ### Référence de la discussion
 
-Voir les discussions et consensus sur les <i lang="en">issues</i> GitHub suivantes <https://github.com/mdn/content/issues/4325> (en anglais), <https://github.com/mdn/content/issues/7342> (en anglais) et <https://github.com/mdn/content/issues/7898#issuecomment-913265900> (en anglais).
+Voir les discussions et consensus sur les <i lang="en">issues</i> GitHub suivantes <https://github.com/mdn/content/issues/4325> <sup>(angl.)</sup>, <https://github.com/mdn/content/issues/7342> <sup>(angl.)</sup> et <https://github.com/mdn/content/issues/7898#issuecomment-913265900> <sup>(angl.)</sup>.
 
 ## Exposant et indice
 
-On peut utiliser les éléments HTML [`<sup>`](/fr/docs/Web/HTML/Reference/Elements/sup) et [`<sub>`](/fr/docs/Web/HTML/Reference/Elements/sub) si nécessaire, mais on veillera à utiliser des formes alternatives dans les cas suivants&nbsp;:
+On peut utiliser les éléments HTML {{HTMLElement("sup")}} et {{HTMLElement("sub")}} si nécessaire, mais on veille à utiliser des formes alternatives dans les cas suivants&nbsp;:
 
 - Pour l'exponentiation, utilisez le circonflexe&nbsp;: `2^53`.
 - Pour des expressions ordinales comme 1<sup>er</sup>, préférez des mots comme «&nbsp;premier&nbsp;».
 - Pour les notes de bas de page, ne pas marquer les références des notes, par exemple&nbsp;: `<sup>[1]</sup>`.
 
+> [!NOTE]
+> Pour les pages françaises, un lien menant vers **une page externe écrite en anglais** est annoté avec l'indicateur correspondant&nbsp;: `<sup>(angl.)</sup>`.
+
 ### Référence de la discussion
 
-Voir l'<i lang="en">issue</i> GitHub suivante pour la discussion et le consensus <https://github.com/mdn/content/issues/4578> (en anglais).
+Voir le problème (<i lang="en">issue</i> en anglais) GitHub suivante pour la discussion et le consensus <https://github.com/mdn/content/issues/4578> <sup>(angl.)</sup>.
 
 ## Résumé de la page
 
-Le résumé de la page est le premier paragraphe de contenu dans une page — le premier texte qui apparaît après l'en-tête de la page et la [barre latérale](/fr/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros#barres-laterales-de-navigation) ou la [bannière de la page](/fr/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros#indicateurs-pour-les-pages-ou-les-sections).
+Le résumé de la page est le premier paragraphe de contenu dans une page — le premier texte qui apparaît après l'en-tête de la page et la [barre latérale](/fr/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros#barres_latérales_de_navigation) ou la [bannière de la page](/fr/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros#indicateurs_pour_les_pages_ou_les_sections).
 
 Ce résumé est utilisé pour l'optimisation pour les moteurs de recherche (SEO) et est automatiquement inclus à côté des listes de pages par certaines macros.
-Le premier paragraphe devrait donc être à la fois bref et informatif.
+Le premier paragraphe doit donc être à la fois bref et informatif.
 
 ### Référence de la discussion
 
-Voir l'<i lang="en">issue</i> GitHub suivante pour la discussion et le consensus <https://github.com/mdn/content/issues/3923> (en anglais).
+Voir l'<i lang="en">issue</i> GitHub suivante pour la discussion et le consensus <https://github.com/mdn/content/issues/3923> <sup>(angl.)</sup>.
+
+## Macros
+
+Les rédacteur·ice·s utilisent des macros dans le texte pour modéliser des schémas de liens courants ou pour inclure des blocs spécifiques de code ou de texte&nbsp;:
+
+```md
+La propriété [CSS](/fr/docs/Web/CSS) **`margin`** définit la zone de marge sur les quatre côtés d'un élément.
+Il s'agit d'un raccourci pour \{{CSSxRef("margin-top")}}, \{{CSSxRef("margin-right")}}, \{{CSSxRef("margin-bottom")}} et \{{CSSxRef("margin-left")}}.
+…
+```
+
+Voir [Utiliser les macros](/fr/docs/MDN/Writing_guidelines/Page_structures/Macros) pour plus d'informations.


### PR DESCRIPTION
### Description

Update translation of pages without french version: `MDN/Writing_guidelines/Howto/Markdown_in_MDN`

### Motivation

Update access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

Related to #16686