### PR TITLE
chore(fr): translation of `MDN/Writing_guidelines/Howto/Retiring_content/Retired_content`

### DIFF
--- a/files/fr/mdn/writing_guidelines/howto/retiring_content/retired_content/index.md
+++ b/files/fr/mdn/writing_guidelines/howto/retiring_content/retired_content/index.md
@@ -1,0 +1,34 @@
+---
+title: Contenu retiré
+slug: MDN/Writing_guidelines/Howto/Retiring_content/Retired_content
+l10n:
+  sourceCommit: ca0b474bb2e153ce72718cb304306e540065a888
+---
+
+Cette page répertorie les sections de MDN Web Docs qui ont été retirées. Chaque entrée inclut un lien vers le contenu archivé dans le [dépôt MDN Museum <sup>(angl.)</sup>](https://github.com/mdn/museum) et vers le problème ou la discussion GitHub où la décision de retrait a été prise.
+
+Pour plus de détails sur le processus de retrait, consultez le guide [Retirer du contenu](/fr/docs/MDN/Writing_guidelines/Howto/Retiring_content).
+
+## Sections retirées
+
+### Canvas Raycaster
+
+- **Retiré&nbsp;:** juin 2022
+- **Contenu archivé&nbsp;:** [museum/canvas-raycaster <sup>(angl.)</sup>](https://github.com/mdn/museum/tree/main/canvas-raycaster)
+- **Problème sur GitHub&nbsp;:** [Move canvas-raycaster into mdn/museum <sup>(angl.)</sup>](https://github.com/mdn/mdn/issues/193)
+
+Une démonstration de l'API Canvas Raycaster et sa page de documentation associée. Le contenu a été déplacé vers le musée dans le cadre des travaux de maintenance du dépôt.
+
+> [!NOTE]
+> Ce retrait a précédé le processus de [Retrait de contenu](/fr/docs/MDN/Writing_guidelines/Howto/Retiring_content). Il n'y a plus de discussion disponible.
+
+### WebVR
+
+- **Retiré&nbsp;:** septembre 2022
+- **Contenu archivé&nbsp;:** [museum/webvr <sup>(angl.)</sup>](https://github.com/mdn/museum/tree/main/webvr)
+- **PR sur GitHub&nbsp;:** [Import webvr tests <sup>(angl.)</sup>](https://github.com/mdn/museum/pull/6)
+
+Une collection d'exemples de tests de l'API WebVR, incluant des informations d'affichage de base, des paramètres de scène, du WebGL brut, des démonstrations de contrôleurs VR et une démonstration A-Frame. L'API WebVR a été dépréciée au profit de [l'API WebXR Device](/fr/docs/Web/API/WebXR_Device_API).
+
+> [!NOTE]
+> Ce retrait a précédé le processus de [Retrait de contenu](/fr/docs/MDN/Writing_guidelines/Howto/Retiring_content). Il n'y a plus de discussion disponible.


### PR DESCRIPTION
### Description

Create translation of pages without french version: `MDN/Writing_guidelines/Howto/Retiring_content/Retired_content`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

Related to #16686