### PR TITLE
fix(fr): typo in 101 switching protocols title

### DIFF
--- a/files/fr/web/http/reference/status/101/index.md
+++ b/files/fr/web/http/reference/status/101/index.md
@@ -1,5 +1,5 @@
 ---
-title: 101 Switching Protocol
+title: 101 Switching Protocols
 slug: Web/HTTP/Reference/Status/101
 l10n:
   sourceCommit: ad5b5e31f81795d692e66dadb7818ba8b220ad15


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add a missing `s` on the title of the french HTTP reference 101 switching protocols.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

I'm making this change to fix a typo that can lead to a confusion.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

To have the same title as:
- [english](https://github.com/mdn/content/blob/main/files/en-us/web/http/reference/status/101/index.md)
- [spanish](https://github.com/mdn/translated-content/blob/main/files/es/web/http/reference/status/101/index.md)
- [japanese](https://github.com/mdn/translated-content/blob/main/files/ja/web/http/reference/status/101/index.md)
- etc...
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

No issues or dependencies.
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
