### PR TITLE
Sync writing_guidelines/(root) [es]

### DIFF
--- a/files/es/mdn/writing_guidelines/index.md
+++ b/files/es/mdn/writing_guidelines/index.md
@@ -1,38 +1,43 @@
 ---
-title: Guías de escritura
+title: Pautas de redacción
 slug: MDN/Writing_guidelines
 l10n:
-  sourceCommit: dab1b3e38e8b58b64991218c682f41b236032a36
+  sourceCommit: ca0b474bb2e153ce72718cb304306e540065a888
 ---
 
-{{MDNSidebar}}
+MDN Web Docs es un proyecto de código abierto. Las secciones descritas a continuación detallan nuestras pautas sobre _qué_ documentamos y _cómo_ lo hacemos en MDN Web Docs. Para saber _cómo contribuir_, consulta nuestras [guías de contribución](/es/docs/MDN/Community).
 
-MDN Web Docs es un proyecto de código abierto. Las secciones que se describen a continuación describen nuestras pautas para lo _qué_ documentamos y _cómo_ lo hacemos en MDN Web Docs. Para conocer _cómo contribuir_ consulta nuestras [guías de contribución](/es/docs/MDN/Community).
+- [Qué escribimos](/es/docs/MDN/Writing_guidelines/What_we_write)
+  - : Esta sección cubre qué incluimos en MDN Web Docs y qué no, además de otras políticas: cuándo escribimos sobre nuevas tecnologías, el proceso para sugerir contenido y si aceptamos enlaces externos. Es un buen punto de partida si estás considerando escribir o actualizar contenido para nosotros.
 
-- [Lo que escribimos](/es/docs/MDN/Writing_guidelines/What_we_write)
-  - : Esta sección cubre lo que incluimos en MDN Web Docs y lo que no, así como una serie de otras políticas, como cuándo escribimos sobre nuevas tecnologías, el proceso de sugerencia de contenido y si aceptamos enlaces externos. Este es un buen lugar para comenzar si está considerando escribir o actualizar contenido para nosotros. Esta sección también incluye:
-    - [Criterios de inclusión](/es/docs/MDN/Writing_guidelines/Criteria_for_inclusion)
-      - : Proporciona criterios detallados para que el contenido se incluya en MDN Web Docs, el proceso de solicitud para agregar nueva documentación en MDN Web Docs y las expectativas y pautas para la parte que solicita.
+- [Criterios de inclusión](/es/docs/MDN/Writing_guidelines/Criteria_for_inclusion)
+  - : Este artículo describe en detalle los criterios para el contenido que se incluirá en MDN Web Docs, el proceso para solicitar la inclusión de nueva documentación y las expectativas y pautas para los solicitantes.
 
-- [Nuestra guía de estilo de escritura](/es/docs/MDN/Writing_guidelines/Writing_style_guide)
-  - : La guía de estilo de escritura cubre el idioma y el estilo que usamos para escribir en MDN Web Docs. También cubre cómo [formatear ejemplos de código](/es/docs/MDN/Writing_guidelines/Code_style_guide).
+- [Nuestra guía de estilo de redacción](/es/docs/MDN/Writing_guidelines/Writing_style_guide)
+  - : La guía de estilo de redacción cubre el lenguaje y el estilo que usamos al redactar en MDN Web Docs. También abarca cómo [formatear ejemplos de código](/es/docs/MDN/Writing_guidelines/Code_style_guide).
+
+- [Pautas de redacción para Aprende desarrollo web](/es/docs/MDN/Writing_guidelines/Learning_content)
+  - : La sección "Aprende desarrollo web" de MDN está dirigida específicamente a personas que están aprendiendo los fundamentos básicos del desarrollo web y, como tal, requiere un enfoque diferente al del resto del contenido de MDN. Este artículo ofrece pautas para redactar contenido de aprendizaje.
 
 - [Cómo escribir para MDN Web Docs](/es/docs/MDN/Writing_guidelines/Howto)
-  - : Esta sección cubre toda la información para crear y editar páginas, incluidos ciertos procesos y técnicas a los que nos adherimos. Esta sección proporciona información sobre cómo comenzar, una descripción general de cómo se estructuran las páginas y dónde encontrar instrucciones sobre tareas específicas. Esta sección incluye temas como:
+  - : Esta sección cubre toda la información necesaria para crear y editar páginas, incluidos ciertos procesos y técnicas que seguimos. Esta sección proporciona información sobre cómo empezar, una descripción general de cómo se estructuran las páginas y dónde encontrar tutoriales sobre tareas específicas. Esta sección incluye temas como:
     - [Cómo investigar una tecnología](/es/docs/MDN/Writing_guidelines/Howto/Research_technology)
-      - : Esta sección proporciona algunos consejos útiles para investigar una tecnología que está documentando.
+      - : Esta sección ofrece algunos consejos útiles para investigar una tecnología que estás documentando.
 
     - [Cómo crear, mover y eliminar páginas](/es/docs/MDN/Writing_guidelines/Howto/Creating_moving_deleting)
-      - : Esta sección explica cómo creamos, movemos o eliminamos una página en MDN Web Docs. También explica cómo redirigimos una página al mover o eliminar la página.
+      - : Esta sección explica cómo creamos, movemos o eliminamos una página en MDN Web Docs. También explica cómo redirigimos una página cuando la movemos o eliminamos.
+
+    - [Cómo retirar una sección de contenido](/es/docs/MDN/Writing_guidelines/Howto/Retiring_content)
+      - : Esta sección explica el proceso para retirar secciones completas del contenido de MDN Web Docs de manera planificada y transparente, incluyendo la toma de decisiones, los períodos de aviso, el archivado y la eliminación.
 
     - [Cómo usar markdown](/es/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN)
-      - : El formato _markdown_ que usamos se deriva de [la versión _markdown_ de GitHub (GFM, por sus siglas en inglés)](https://github.github.com/gfm/). Esta sección es una guía de la versión _markdown_ que usamos en MDN Web Docs, incluidos los formatos para componentes específicos en la página, como notas y listas de definiciones.
+      - : El formato markdown que usamos deriva de [GitHub Flavored Markdown (GFM)](https://github.github.com/gfm/). Esta sección es una guía del markdown que usamos en MDN Web Docs, con los formatos para componentes específicos de la página, como notas y listas de definición.
 
-    - [Añadiendo imágenes y medios](/es/docs/MDN/Writing_guidelines/Howto/Images_media)
-      - : En esta sección se describen los requisitos para incluir contenido multimedia en las páginas, como imágenes.
+    - [Añadir imágenes y medios](/es/docs/MDN/Writing_guidelines/Howto/Images_media)
+      - : Esta sección describe los requisitos para incluir contenido multimedia en las páginas, como imágenes.
 
     - [Cómo documentar una propiedad CSS](/es/docs/MDN/Writing_guidelines/Howto/Document_a_CSS_property)
-      - : Este artículo explica cómo escribir una página de propiedades CSS, incluido el diseño y el contenido.
+      - : Este artículo explica cómo escribir una página de propiedad CSS, incluyendo el diseño y el contenido.
 
     - [Cómo documentar una referencia de API](/es/docs/MDN/Writing_guidelines/Howto/Write_an_api_reference)
       - : Esta sección explica cómo abordar la documentación de una API web.
@@ -40,34 +45,34 @@ MDN Web Docs es un proyecto de código abierto. Las secciones que se describen a
     - [Cómo documentar una cabecera HTTP](/es/docs/MDN/Writing_guidelines/Howto/Document_an_HTTP_header)
       - : Este artículo explica cómo crear una nueva página de referencia para una cabecera HTTP.
 
-    - [Cómo agregar una entrada al glosario](/es/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary)
-      - : Este artículo explica cómo agregar y vincular entradas en el glosario de MDN Web Docs. También proporciona pautas sobre el diseño y el contenido de las entradas del glosario.
+    - [Cómo añadir una entrada al glosario](/es/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary)
+      - : Este artículo explica cómo añadir y vincular entradas en el glosario de MDN Web Docs. También ofrece pautas sobre el diseño y el contenido de las entradas del glosario.
 
 - [Tipos de página en MDN Web Docs](/es/docs/MDN/Writing_guidelines/Page_structures/Page_types)
-  - : Cada página de MDN Web Docs tiene un tipo de página específico, ya sea una página de referencia de CSS o una página de guía de JavaScript. Esta sección enumera los diferentes tipos de página y proporciona plantillas para cada tipo. Es una buena idea examinarlos para comprender qué tipo de página está escribiendo.
+  - : Cada página de MDN Web Docs tiene un tipo de página específico, ya sea una página de referencia de CSS o una guía de JavaScript. Esta sección enumera los distintos tipos de página y ofrece plantillas para cada uno. Es una buena idea revisarlos para entender qué tipo de página estás redactando.
 
 - [Estructuras de página en MDN Web Docs](/es/docs/MDN/Writing_guidelines/Page_structures)
-  - : Esta sección cubre las diversas estructuras de página que usamos para proporcionar una presentación coherente de la información en MDN Web Docs. Esto incluye:
+  - : Esta sección cubre las distintas estructuras de página que usamos para presentar la información de manera coherente en MDN Web Docs. Incluye:
     - [Secciones de sintaxis](/es/docs/MDN/Writing_guidelines/Page_structures/Syntax_sections)
-      - : La sección de sintaxis de una página de referencia en MDN Web Docs contiene un cuadro de sintaxis que define la sintaxis exacta de una característica. Este artículo explica cómo escribir cuadros de sintaxis para artículos de referencia.
+      - : La sección de sintaxis de una página de referencia en MDN Web Docs contiene un bloque específico que define la sintaxis exacta de una característica. Este artículo explica cómo redactar estos bloques de sintaxis para los artículos de referencia.
 
     - [Ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples)
-      - : Hay muchas maneras diferentes de incluir ejemplos de código en las páginas. Esta sección los describe y proporciona pautas de sintaxis para los diferentes lenguajes.
+      - : Hay muchas formas distintas de incluir ejemplos de código en las páginas. Esta sección las describe y ofrece pautas de sintaxis para los diferentes lenguajes.
 
     - [Banners y avisos](/es/docs/MDN/Writing_guidelines/Page_structures/Banners_and_notices)
-      - : A veces, un artículo necesita que se le agregue un aviso especial. Esto podría suceder si la página cubre tecnología obsoleta u otro material que no debería usarse en el código de producción. Este artículo cubre los casos más comunes y cómo manejarlos.
+      - : A veces, un artículo necesita que se le añada un aviso especial. Esto puede ocurrir si la página trata sobre tecnología obsoleta u otro material que no debería usarse en código de producción. Este artículo cubre los casos más comunes y cómo gestionarlos.
 
     - [Tablas de especificaciones](/es/docs/MDN/Writing_guidelines/Page_structures/Specification_tables)
-      - : Cada página de referencia en MDN Web Docs debe proporcionar información sobre la especificación o especificaciones en las que se definió esa API o tecnología. Este artículo muestra el aspecto de estas tablas y explica cómo agregarlas.
+      - : Cada página de referencia en MDN Web Docs debe proporcionar información sobre la especificación o especificaciones en las que se definió esa API o tecnología. Este artículo muestra el aspecto de estas tablas y explica cómo añadirlas.
 
     - [Tablas de compatibilidad](/es/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables)
-      - : MDN Web Docs tiene un formato estándar para tablas de compatibilidad para nuestra documentación web abierta. Este artículo explica cómo agregar y mantener la base de datos que se utiliza para generar las tablas de compatibilidad y cómo integrar las tablas en los artículos.
+      - : MDN Web Docs tiene un formato estándar para las tablas de compatibilidad de nuestra documentación web abierta. Este artículo explica cómo añadir entradas a la base de datos que genera dichas tablas, cómo mantenerla y cómo integrar las tablas en los artículos.
 
     - [Macros](/es/docs/MDN/Writing_guidelines/Page_structures/Macros)
-      - : Las macros son accesos directos que se utilizan en las páginas para generar contenido, como los menús laterales. Esta sección enumera las macros que usamos y lo que hacen.
+      - : Las macros son atajos que se utilizan en las páginas para generar contenido, como barras laterales. Esta sección enumera las macros que usamos y lo que hacen.
 
-- [Atribuciones e información sobre licencias de derechos de autor](/es/docs/MDN/Writing_guidelines/Attrib_copyright_license)
-  - : Describe nuestra política sobre el uso de contenido de MDN Web Docs en otros lugares de la web, cómo obtener permiso para volver a publicar contenido en MDN y sugerencias para vincular contenido de MDN.
+- [Atribución y licencia de derechos de autor](/es/docs/MDN/Writing_guidelines/Attrib_copyright_license)
+  - : Describe nuestra política sobre el uso de contenido de MDN Web Docs en otros lugares de la web, cómo obtener permiso para volver a publicar contenido en MDN y sugerencias para enlazar contenido de MDN.
 
 - [Cómo etiquetar una tecnología](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete)
-  - : Esta sección cubre nuestras definiciones de los términos obsoleto, en desuso y experimental y proporciona pautas sobre cómo etiquetar una tecnología con ellos y cuándo eliminamos contenido de MDN Web Docs.
+  - : Esta sección cubre nuestras definiciones de los términos "en desuso", "obsoleto" y "experimental", y ofrece pautas sobre cómo etiquetar una tecnología con ellos y cuándo eliminamos contenido de MDN Web Docs.


### PR DESCRIPTION
## Description

Syncs `files/es/mdn/writing_guidelines/index.md` with the current EN source in `mdn/content`.

## Changes

- `l10n.sourceCommit` updated to current EN HEAD SHA.
- Removed outdated `{{MDNSidebar}}` macro to match the upstream source.
- Updated all internal links from `/en-US/` to `/es/`.
- Content matches the EN source.
- Added "Pautas de redacción para Aprende desarrollo web" top-level entry.
- Restructured "Criterios de inclusión" was nested as a sub-item of "Qué escribimos".

## Related

Closes #35396
Part of #35373