### PR TITLE
[ja] 加算演算子の長整数と文字列の加算の説明を更新し、長整数と数値の混在に関する注意点を追加

### DIFF
--- a/files/ja/web/javascript/reference/operators/addition/index.md
+++ b/files/ja/web/javascript/reference/operators/addition/index.md
@@ -69,7 +69,7 @@ false + false; // 0
 1n + 2n; // 3n
 ```
 
-加算で長整数と数値のオペランドを混在させることはできません。 `null` 、 `undefined` および真偽値は数値に強制変換されるため、使用することはできません。
+加算で長整数と数値のオペランドを混在させることはできません。`null`、`undefined` および真偽値は数値に強制変換されるため、使用することはできません。
 
 ```js example-bad
 1n + 2; // TypeError: Cannot mix BigInt and other types, use explicit conversions

--- a/files/ja/web/javascript/reference/operators/addition/index.md
+++ b/files/ja/web/javascript/reference/operators/addition/index.md
@@ -69,12 +69,17 @@ false + false; // 0
 1n + 2n; // 3n
 ```
 
-加算で長整数と数値のオペランドを混在させることはできません。
+加算で長整数と数値のオペランドを混在させることはできません。 `null` 、 `undefined` および真偽値は数値に強制変換されるため、使用することはできません。
 
 ```js example-bad
 1n + 2; // TypeError: Cannot mix BigInt and other types, use explicit conversions
 2 + 1n; // TypeError: Cannot mix BigInt and other types, use explicit conversions
-"1" + 2n; // TypeError: Cannot mix BigInt and other types, use explicit conversions
+```
+
+文字列は他の型よりも優先されるため、文字列と長整数を加算すると `TypeError` ではなく文字列連結が行われます。
+
+```js
+"1" + 2n; // "12"
 ```
 
 長整数と長整数以外で加算を行うには、どちらかのオペランドを変換してください。


### PR DESCRIPTION
### Description

日本語版の [加算演算子](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Addition) の「長整数を使用した加算」の例で `"1" + 2n` が `TypeError` になるという記載がありますが、実際には文字列連結がされます。

英語版の [Addition (+)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Addition) では、文字列連結がされる旨の記述に変更されています。

そのため、英語版に合わせて修正をしました。

ご確認、よろしくお願いします。

### Related issues and pull requests

- https://github.com/mdn/content/issues/43807
- https://github.com/mdn/content/pull/43812
