### PR TITLE
Sync page_structures/compatibility_tables [es]

### DIFF
--- a/files/es/mdn/writing_guidelines/page_structures/compatibility_tables/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/compatibility_tables/index.md
@@ -1,31 +1,30 @@
 ---
-title: Tablas de compatibilidad y repositorio de datos de compatibilidad con navegadores (BCD)
+title: Tablas y datos de compatibilidad de navegadores (BCD)
+short-title: Tablas de compatibilidad y BCD
 slug: MDN/Writing_guidelines/Page_structures/Compatibility_tables
 l10n:
-  sourceCommit: b8f5e2a73b0a410fe5508fc674f1ad463deeffb1
+  sourceCommit: 2e427c5c185433c5a6612c63bf877753a5fedc99
 ---
 
-{{MDNSidebar}}
+MDN tiene un formato estándar para las tablas que ilustran la compatibilidad de tecnologías web compartidas en todos los navegadores: DOM, HTML, CSS, JavaScript, SVG, etc.
+Para que estos datos estén disponibles en múltiples proyectos de forma programática, se crea un paquete de Node.js a partir del [repositorio `browser-compat-data`](https://github.com/mdn/browser-compat-data) y se publica en npm.
 
-MDN tiene un formato estándar para tablas que ilustran la compatibilidad de tecnologías compartidas en todos los navegadores, como DOM, HTML, CSS, JavaScript, SVG, etc.
-Para que estos datos estén disponibles en varios proyectos mediante programación, se crea un paquete de Node.js desde el [repositorio `browser-compat-data`](https://github.com/mdn/browser-compat-data) y se publica en npm.
+Para modificar los datos dentro de estas tablas, puedes encontrar documentación completa junto con los detalles más recientes de las convenciones y esquemas JSON utilizados para representar los datos en la [guía de contribución](https://github.com/mdn/browser-compat-data/blob/main/docs/contributing.md) del repositorio, así como en la [guía de pautas de datos](https://github.com/mdn/browser-compat-data/tree/main/docs/data-guidelines).
+Si tienes dudas o encuentras algún problema, puedes [pedir ayuda](/es/docs/MDN/Community/Communication_channels).
 
-Para modificar los datos dentro de estas tablas, la documentación completa junto con los detalles más recientes de las convenciones y los esquemas JSON utilizados para representar los datos se pueden encontrar en la [guía de contribución](https://github.com/mdn/browser-compat-data/blob/main/docs/contributing.md) del repositorio, así como la [guía de pautas de datos](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md).
-Si tienes dudas o descubres problemas, te invitamos a [pedir ayuda](/es/docs/MDN/Community/Communication_channels).
+## Uso de datos de BCD en las páginas de MDN
 
-## Uso de los datos de BCD en páginas MDN
+Una vez que los datos se hayan incluido en el repositorio [`browser-compat-data`](https://github.com/mdn/browser-compat-data), puedes comenzar a incluir dinámicamente las tablas de compatibilidad y especificaciones de navegadores basadas en esos datos dentro de las páginas de MDN.
 
-Una vez que se han incluido los datos en el repositorio [`browser-compat-data`](https://github.com/mdn/browser-compat-data), puede comenzar a incluir dinámicamente las tablas de especificación y compatibilidad con los navegadores basadas en esos datos dentro de páginas MDN.
-
-Para comenzar con los datos de BCD en páginas MDN, use la cadena de consulta especificada en el archivo fuente de BCD para los datos relevantes que desea incluir.
+Para comenzar a usar datos de BCD en las páginas de MDN, utiliza la cadena de consulta especificada en el archivo fuente de BCD para los datos relevantes que deseas incluir.
 Por ejemplo:
 
-- {{domxref("AbortController")}} los datos de compatibilidad se definen en [api/AbortController.json](https://github.com/mdn/browser-compat-data/blob/main/api/AbortController.json) y se puede consultar usando `api.AbortController`.
-- {{HTTPHeader("Content-Type")}} Los datos de compatibilidad de la cabecera HTTP se definen en [http/headers/content-type.json](https://github.com/mdn/browser-compat-data/blob/main/http/headers/content-type.json) y se puede consultar usando `http.headers.Content-Type`.
-- {{domxref("VRDisplay.capabilities")}} los datos de compatibilidad de propiedades se definen en [api/VRDisplay.json](https://github.com/mdn/browser-compat-data/blob/main/api/VRDisplay.json) y se puede consultar usando `api.VRDisplay.capabilities`.
+- Los datos de compatibilidad de {{domxref("AbortController")}} están definidos en [api/AbortController.json](https://github.com/mdn/browser-compat-data/blob/main/api/AbortController.json) y la consulta es `api.AbortController`.
+- Los datos de compatibilidad de la cabecera HTTP {{HTTPHeader("Content-Type")}} están definidos en [http/headers/content-type.json](https://github.com/mdn/browser-compat-data/blob/main/http/headers/Content-Type.json) y la consulta es `http.headers.Content-Type`.
+- Los datos de compatibilidad de la propiedad {{domxref("VRDisplay.capabilities")}} están definidos en [api/VRDisplay.json](https://github.com/mdn/browser-compat-data/blob/main/api/VRDisplay.json) y la consulta es `api.VRDisplay.capabilities`.
 
-La consulta de datos de compatibilidad debe especificarse en los metadatos de la página en la clave `browser-compat`.
-Por ejemplo, {{domxref("AbortController")}} se agregaría como se muestra a continuación:
+La consulta de datos de compatibilidad debe especificarse en el _front-matter_ de la página, en la clave `browser-compat`.
+Por ejemplo, {{domxref("AbortController")}} se añadiría como se muestra a continuación:
 
 ```md
 ---
@@ -36,9 +35,9 @@ browser-compat: api.AbortController
 ---
 ```
 
-Las tablas de compatibilidad y especificación correspondientes a la clave se representan automáticamente en lugar de las macros `\{{Compat}}` y `\{{Specifications}}` en el código fuente.
+Las tablas de compatibilidad y especificaciones correspondientes a la clave se renderizan automáticamente en lugar de las macros `\{{Compat}}` y `\{{Specifications}}` en el código fuente.
 
-Si se requieren varias tablas de compatibilidad/especificaciones en la misma página, puede especificar el valor de `browser-compat` como una matriz. Por ejemplo, para la [API de mensajería de canal](/es/docs/Web/API/Channel_Messaging_API) esto se agregaría como se muestra a continuación:
+Si se requieren múltiples tablas de compatibilidad o especificaciones en la misma página, puedes especificar el valor de `browser-compat` como un arreglo. Por ejemplo, para la [Channel Messaging API](/es/docs/Web/API/Channel_Messaging_API) se añadiría así:
 
 ```md
 ---
@@ -51,7 +50,7 @@ browser-compat:
 ---
 ```
 
-Las llamadas a las macros generan las siguientes tablas (y el correspondiente conjunto de notas):
+Las llamadas a las macros generan las siguientes tablas (y el conjunto correspondiente de notas):
 
 ### Ejemplo de tabla de compatibilidad
 
@@ -60,6 +59,3 @@ Las llamadas a las macros generan las siguientes tablas (y el correspondiente co
 ### Ejemplos de tablas de especificaciones
 
 {{Specifications}}
-
-> [!NOTE]
-> El metadato `browser-compat` solo es utilizado en el contenido en Inglés.


### PR DESCRIPTION
## Description

Syncs the Spanish translation of `Browser Compatibility tables and Browser Compatibility Data (BCD)` with the current English source in `mdn/content`.

## Changes

- `l10n.sourceCommit` updated to current EN HEAD SHA.
- Updated `title` and added `short-title` to front-matter.
- Removed outdated `{{MDNSidebar}}` macro to match the upstream source.
- Updated all internal links from `/en-US/` to `/es/`.
- Removed obsolete content.

## Related

Closes #35400
Part of #35373