### PR TITLE
Sync writing_guidelines/page_structures [es]

### DIFF
--- a/files/es/mdn/writing_guidelines/page_structures/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/index.md
@@ -1,13 +1,16 @@
 ---
-title: Estructura de páginas
+title: Estructuras de página
 slug: MDN/Writing_guidelines/Page_structures
 l10n:
-  sourceCommit: 75767ee17cb5d731148a353be70fc13a7b0c6310
+  sourceCommit: 719645a32546d9e514ac530a5eb66aa4c26d4f51
 ---
 
-{{MDNSidebar}}
+En todo MDN existen estructuras de documentos que se utilizan para presentar la información de forma coherente en los artículos.
+Esta página enumera los artículos que describen estas estructuras para que puedas modificar el contenido de las páginas de manera adecuada en los documentos que escribas, edites o traduzcas.
 
-A lo largo de MDN existen estructuras de documentos que se utilizan para proporcionar una presentación coherente de la información en los artículos de MDN.
-Esta página enumera artículos que describen estas estructuras para que pueda modificar el contenido de la página de manera adecuada para los documentos que escribe, edita o traduce.
+{{SubpagesWithSummaries}}
 
-{{LandingPageListSubPages()}}
+## Véase también
+
+- [Plantillas de página](/es/docs/MDN/Writing_guidelines/Page_structures/Page_types#page_templates)
+- [Componentes de la página](/es/docs/MDN/Writing_guidelines/Writing_style_guide#page_components)


### PR DESCRIPTION
## Description

Syncs the Spanish translation of `Page structures` with the current English source in `mdn/content`.

## Changes

- `l10n.sourceCommit` updated to current EN HEAD SHA.
- Front-matter contains only allowed fields (`title`, `slug`, `l10n.sourceCommit`).
- Removed outdated `{{MDNSidebar}}` macro to match the upstream source.
- Updated all internal links from `/en-US/` to `/es/`.
- Added missing section.

## Related

Closes #35402
Part of #35373