### PR TITLE
zh-cn: fix translation of example code

### DIFF
--- a/files/zh-cn/web/javascript/reference/statements/switch/index.md
+++ b/files/zh-cn/web/javascript/reference/statements/switch/index.md
@@ -286,7 +286,7 @@ switch (true) {
 switch (true) {
   case isSquare(shape):
     console.log("该形状是一个正方形。");
-  // 失败，因为正方形也是矩形的一种！
+  // 穿透，因为正方形也是矩形的一种！
   case isRectangle(shape):
     console.log("该形状是一个矩形。");
   case isQuadrilateral(shape):


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

`switch`语句示例代码注释翻译有误

### Motivation

https://github.com/mdn/translated-content/blob/be04af198427daed31b1613af02eb74733061eed/files/zh-cn/web/javascript/reference/statements/switch/index.md?plain=1#L285-L299
原文：https://github.com/mdn/content/blob/0985f662bf6c2351278ddb6c6629827d00ff6755/files/en-us/web/javascript/reference/statements/switch/index.md?plain=1#L290
```js
switch (true) {
  case isSquare(shape):
    console.log("This shape is a square.");
  // Fall-through, since a square is a rectangle as well!
  case isRectangle(shape):
    console.log("This shape is a rectangle.");
  case isQuadrilateral(shape):
    console.log("This shape is a quadrilateral.");
    break;
  case isCircle(shape):
    console.log("This shape is a circle.");
    break;
}
```
根据上下文，Fall-through为“穿透”

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Statements/switch

示例章节最后一段

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Indepenent

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
