### PR TITLE
Sync page_structures/macros [es]

### DIFF
--- a/files/es/mdn/writing_guidelines/page_structures/macros/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/macros/index.md
@@ -1,38 +1,33 @@
 ---
-title: Utilizando macros
+title: Uso de macros
 slug: MDN/Writing_guidelines/Page_structures/Macros
 l10n:
-  sourceCommit: 92cbbdaf81325539eace880b5e78152e3cb8ba49
+  sourceCommit: 078deef4b52f337f2ef69e037ee80d1feae0d96a
 ---
 
-{{MDNSidebar}}
+El backend [rari](https://github.com/mdn/rari) es el sistema de compilación de MDN y proporciona una sintaxis de macros para tareas comunes.
 
-La plataforma [Yari](https://github.com/mdn/yari/tree/main/docs/what-yari-does.md) en la que se ejecuta MDN, proporciona un sistema de macros, [KumaScript](https://github.com/mdn/yari/tree/main/docs/kumascript) que permite automatizar ciertas tareas. Este artículo proporciona información sobre cómo invocar las macros de MDN dentro de los artículos.
+## Uso de una macro en el contenido
 
-La [guía de KumaScript](https://github.com/mdn/yari/blob/main/docs/kumascript/README.md) proporciona una visión en profundidad de cómo utilizar macros en MDN, por lo que esta sección es más bien una breve visión general.
-
-## Cómo se implementan las macros
-
-Las macros en MDN se implementan utilizando código [JavaScript](/es/docs/Web/JavaScript) ejecutado por el servidor e interpretado usando [Node.js](https://nodejs.org/es/). Sobre esto, hemos implementado una serie de bibliotecas que proporcionan servicios y funciones para que las macros interactúen con la plataforma y el contenido.
-
-## Utilizar una macro en el contenido
-
-Para utilizar una macro, encierre la llamada a la macro en un par de llaves dobles incluyendo sus parámetros, si los hay.
+Para usar una macro, encierra su nombre entre llaves dobles (`{{ }}`) junto con sus parámetros, si los hay:
 
 ```plain
-\{{nombredelamacro(lista-de-parámetros)}}
+\{{macroname(parameter-list)}}
 ```
 
-Algunos apuntes sobre la llamada a las macros
+Algunas notas sobre las llamadas a macros:
 
-- Los nombres de las macros son _case-sensitive_ (sensibles a mayúsculas), es decir distinguen entre minúsculas y mayúsculas, pero se intentan corregir los errores comunes de mayúsculas. Puede escribir el nombre completo de una macro en minúsculas incluso si el nombre de la macro utiliza mayúsculas en su interior. Del mismo modo, puede comenzar el nombre de una macro en mayúsculas,incluso cuando éstas generalmente suelen comenzar con una letra minúscula.
-- Los parámetros deben ir separados por comas.
-- Si no hay parámetros, puede omitir por completo los paréntesis. `\{{nombredelamacro()}}` y `\{{nombredelamacro}}` son idénticos.
-- Los parámetros numéricos puede ir entre comillas o no. Depende de ti (sin embargo, si tiene un número de versión con varios decimales, debe ir entre comillas).
-- Si obtienes errores, revisa tu código cuidadosamente. Si sigues sin poder averiguar qué está pasando, consulta [Solución de errores de KumaScript](https://github.com/mdn/yari/blob/main/docs/kumascript/troubleshooting-errors.md) para obtener ayuda.
+- Los nombres de las macros distinguen entre mayúsculas y minúsculas, pero se intenta corregir los errores comunes de mayúsculas; puedes usar solo minúsculas incluso si el nombre de la macro incluye mayúsculas, y puedes escribir con mayúscula una macro cuyo nombre normalmente comience con una letra minúscula.
+- Los parámetros están separados por comas.
+- Si no hay parámetros, puedes omitir los paréntesis por completo. Por ejemplo, las macros `\{{APIRef()}}` y `\{{APIRef}}` son equivalentes.
+- Los parámetros numéricos pueden escribirse con o sin comillas. Sin embargo, los números de versión con varios decimales deben ir entre comillas.
 
-Las macros son almacenadas en caché de forma considerable. Para cualquier conjunto de valores de entrada (tanto parámetros y valores de entorno como la URL para la que se ejecutó la macro), los resultados se almacenan y se reutilizan. Esto significa que la macro realmente sólo se ejecuta cuando las entradas cambian.
+Las macros pueden ser tan simples como insertar un bloque de texto extenso o sustituir contenido de otra parte de MDN, o tan complejas como construir un índice completo de contenido explorando secciones del sitio, aplicando estilos al resultado y añadiendo enlaces.
 
-Una macro puede ser algo tan sencillo como insertar un bloque de texto más grande, intercambiar contenidos de otra parte de MDN. Pero también puede ser algo complejo, como crear un índice de contenidos completo para buscar a través de las diferentes secciones del sitio, estilizando el resultado y añadiendo enlaces.
+## Véase también
 
-Puede consultar las macros más utilizadas en la página [Macros usadas comúnmente](/es/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros). También puede consultar las [Fuenetes completas para todas las macros](https://github.com/mdn/yari/tree/main/kumascript/macros). La mayoría de las fuentes de macros tienen documentación incorporada en forma de comentarios en la parte superior.
+- [Macros de uso común](/es/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros)
+- [Macros de enlace](/es/docs/MDN/Writing_guidelines/Page_structures/Links)
+- [Macros de barra lateral](/es/docs/MDN/Writing_guidelines/Page_structures/Sidebars)
+- [Macros de estado de características](/es/docs/MDN/Writing_guidelines/Page_structures/Feature_status)
+- [Otras macros](/es/docs/MDN/Writing_guidelines/Page_structures/Macros/Other) (macros poco usadas u obsoletas)


### PR DESCRIPTION
## Description

Syncs the Spanish translation of `Using macros` with the current English source in `mdn/content`.

## Changes

- `l10n.sourceCommit` updated to current EN HEAD SHA.
- Front-matter contains only allowed fields (`title`, `slug`, `l10n.sourceCommit`).
- Removed outdated `{{MDNSidebar}}` macro to match the upstream source.
- Updated all internal links from `/en-US/` to `/es/`.
- Added missing section.

## Related

Closes #35406
Part of #35373