### PR TITLE
Sync macros/commonly_used_macros [es]

### DIFF
--- a/files/es/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -1,84 +1,192 @@
 ---
-title: Macros usadas comunmente
+title: Macros de uso común
 slug: MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros
+l10n:
+  sourceCommit: 078deef4b52f337f2ef69e037ee80d1feae0d96a
 ---
 
-{{MDNSidebar}}
-
-Esta página enumera muchas de las macros de propósito general creadas para usarlas en MDN. Para obtener información sobre cómo usar estas macros, consulta [Uso de macros](/es/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros) y [Usar macros de enlaces](/es/docs/MDN/Contribute/Editor/Links#Usar_macros_de_enlaces). Consulta [Otras macros](/es/docs/MDN/Writing_guidelines/Page_structures/Macros/Other) para obtener información sobre las macros que se utilizan con poca frecuencia, que se utilizan solo en contextos especiales o, están en desuso. También hay una [lista completa de todas las macros en MDN](/es/dashboards/macros).
-
-Consulta también la [guía de estilo CSS](/es/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN) para conocer los estilos disponibles para usarlos.
+Esta página enumera muchas de las macros de propósito general que el sistema de compilación de MDN, [rari](https://github.com/mdn/rari), proporciona para su uso en MDN.
+Para obtener información general sobre cómo usarlas en el contenido de MDN, consulta [Uso de macros](/es/docs/MDN/Writing_guidelines/Page_structures/Macros).
 
 ## Enlaces
 
-### Creando un solo hipervínculo
+MDN ofrece una serie de macros de enlace para facilitar la creación de vínculos a entradas del glosario, páginas de referencia y otros temas.
 
-En general, no es necesario utilizar macros para crear enlaces arbitrarios. Utiliza el botón **Enlace** en la interfaz del editor para crear enlaces.
+Se recomiendan las macros de enlace en lugar de los enlaces normales de Markdown porque son concisas y fáciles de traducir.
+Por ejemplo, un enlace de glosario o de referencia creado con una macro no necesita ser traducido: en otros idiomas se vinculará automáticamente a la versión correcta del archivo.
 
-- La macro [`Glossary`](https://github.com/mdn/yari/tree/main/kumascript/macros/Glossary.ejs) crea un vínculo a la entrada de un término específico en el [glosario](/es/docs/Glossary) de MDN. Esta macro acepta un parámetro obligatorio y dos opcionales:
+Estas macros también se describen con más detalle en la página de [Macros de enlace](/es/docs/MDN/Writing_guidelines/Page_structures/Links).
 
-  Ejemplos:
-  1. El nombre del término (tal como "HTML").
-  2. El texto que se mostrará en el artículo en lugar del nombre del término (esto se debe usar con poca frecuencia).{{Optional_Inline}}
-  3. Si se especifica este parámetro y no es cero, no se aplica el estilo personalizado que normalmente se aplica a los enlaces del glosario.{{Optional_Inline}}
-  - `\{{Glossary("HTML")}}` produce {{Glossary("HTML")}}
-  - `\{{Glossary("CSS", "Hojas de estilo en cascada")}}` produce {{Glossary("CSS", "Hojas de estilo en cascada")}}
-  - `\{{Glossary("HTML", "", 1)}}` produce {{Glossary("HTML", "", 1)}}
+### Enlaces a términos del glosario
 
-### Enlace a páginas en referencias
+La macro [`Glossary`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/glossary.rs) crea un enlace a la página del término indicado en el [Glosario de MDN](/es/docs/Glossary).
+Esta macro acepta un parámetro obligatorio y uno opcional.
 
-Hay varias macros para vincular páginas en áreas de referencia específicas de MDN.
+- El término es un parámetro obligatorio. Por ejemplo, para enlazar a la página del glosario de "HTML", la macro será `\{{Glossary("HTML")}}`, y esto generará el enlace {{Glossary("HTML")}}.
+- El texto a mostrar es un parámetro opcional. Por ejemplo, puedes escribir el enlace del ejemplo anterior como `\{{Glossary("HTML", "HyperText Markup Language")}}`, lo que generará el enlace {{Glossary("HTML", "HyperText Markup Language")}}.
 
-- [`cssxref`](https://github.com/mdn/yari/tree/main/kumascript/macros/cssxref.ejs) links to a page in the [CSS Reference](/es/docs/Web/CSS/Reference).
-  Ejemplo: `\{{CSSxRef("cursor")}}`, da como resultado: {{CSSxRef("cursor")}}.
-- [`DOMxRef`](https://github.com/mdn/yari/tree/main/kumascript/macros/DOMxRef.ejs) enlaces a páginas en la referencia DOM; si incluyes paréntesis al final, la plantilla sabe que debe mostrar el enlace para que aparezca el nombre de una función. Por ejemplo, `\{{DOMxRef("document.getElementsByName()")}}` da como resultado: {{DOMxRef("document.getElementsByName()")}} mientras que `\{{DOMxRef("Node")}}` da como resultado: {{DOMxRef("Node")}}.
-- [`HTMLElement`](https://github.com/mdn/yari/tree/main/kumascript/macros/HTMLElement.ejs) enlaza a un elemento HTML en la Referencia HTML.
-- [`jsxref`](https://github.com/mdn/yari/tree/main/kumascript/macros/jsxref.ejs) enlaza a una página en la {{JSxRef("Referencia", "Referencia de JavaScript")}}.
-- [`SVGAttr`](https://github.com/mdn/yari/tree/main/kumascript/macros/SVGAttr.ejs) enlaza a un atributo SVG específico. Por ejemplo, `\{{SVGAttr("d")}}` crea este enlace: {{SVGAttr("d")}}.
-- [`SVGElement`](https://github.com/mdn/yari/tree/main/kumascript/macros/SVGElement.ejs) enlaza a un elemento SVG en la Referencia SVG.
-- [`httpheader`](https://github.com/mdn/yari/tree/main/kumascript/macros/httpheader.ejs) enlaza a un [header de HTTP](/es/docs/Web/HTTP/Reference/Headers).
-- [`HTTPMethod`](https://github.com/mdn/yari/tree/main/kumascript/macros/HTTPMethod.ejs) enlaza a un [método de solicitud HTTP](/es/docs/Web/HTTP/Reference/Methods).
-- [`HTTPStatus`](https://github.com/mdn/yari/tree/main/kumascript/macros/HTTPStatus.ejs) enlaces a un [código de estado de respuesta HTTP](/es/docs/Web/HTTP/Reference/Status).
+### Enlaces a páginas de referencia
 
-### Ayuda a la navegación para guías multipágina
+Existen macros para enlazar de forma independiente del idioma a páginas en áreas de referencia específicas de MDN, como HTML, CSS, JavaScript, SVG y HTTP.
 
-[`Previous`](https://github.com/mdn/yari/tree/main/kumascript/macros/Previous.ejs), [`Next`](https://github.com/mdn/yari/tree/main/kumascript/macros/Next.ejs) y [`PreviousNext`](https://github.com/mdn/yari/tree/main/kumascript/macros/PreviousNext.ejs) proporcionan controles de navegación para artículos que forman parte de secuencias. Para las plantillas unidireccionales, el único parámetro necesario es la ubicación wiki del artículo anterior o siguiente de la secuencia. Para [`PreviousNext`](https://github.com/mdn/yari/tree/main/kumascript/macros/PreviousNext.ejs), los dos parámetros necesarios son las ubicaciones wiki de los artículos correspondientes. El primer parámetro es para el artículo anterior y el segundo es para el artículo siguiente.
+Las macros son fáciles de usar.
+Lo único que tienes que hacer es especificar el nombre del elemento al que quieres enlazar en el primer parámetro.
+Al igual que la macro del glosario, la mayoría de las macros de referencia también aceptan un segundo parámetro para cambiar el texto que se muestra.
 
-## Ejemplos de código
+Consulta los archivos fuente enlazados en la primera columna de la siguiente tabla para obtener más detalles.
+
+<table class="standard-table">
+  <thead>
+    <tr>
+      <th>Macro</th>
+      <th>Enlaza a páginas bajo</th>
+      <th>Ejemplo</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/cssxref.rs">CSSxRef</a>
+      </td>
+      <td>
+        <a href="/es/docs/Web/CSS/Reference">Referencia CSS</a> (/Web/CSS/Reference)
+      </td>
+      <td>
+        <code>\{{CSSxRef("cursor")}}</code> da como resultado {{CSSxRef("cursor")}}.<br />
+        <code>\{{CSSxRef(":hover")}}</code> da como resultado {{CSSxRef(":hover")}}.<br />
+        <code>\{{CSSxRef("@media")}}</code> da como resultado {{CSSxRef("@media")}}.<br />
+        <code>\{{CSSxRef("pow")}}</code> da como resultado {{CSSxRef("pow")}}.<br /><br />
+        Consulta los detalles en <a href="/es/docs/MDN/Writing_guidelines/Page_structures/Links#using_cssxref_with_the_css_reference">Uso de <code>cssxref</code> con la referencia CSS</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/domxref.rs">DOMxRef</a>
+      </td>
+      <td><a href="/es/docs/Web/API">Referencia DOM</a> (/Web/API)</td>
+      <td>
+        <code>\{{DOMxRef("document")}}</code> da como resultado {{DOMxRef("Document")}}.<br />
+        <code>\{{DOMxRef("document.getElementsByName()")}}</code> da como resultado {{DOMxRef("document.getElementsByName()")}}.<br />
+        <code>\{{DOMxRef("Node")}}</code> da como resultado {{DOMxRef("Node")}}.<br />
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/htmlxref.rs">HTMLElement</a>
+      </td>
+      <td>
+        <a href="/es/docs/Web/HTML/Reference/Elements">Referencia de elementos HTML</a> (/Web/HTML/Reference/Elements)
+      </td>
+      <td>
+        <code>\{{HTMLElement("select")}}</code> da como resultado {{HTMLElement("select")}}.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/jsxref.rs">JSxRef</a>
+      </td>
+      <td>
+        <a href="/es/docs/Web/JavaScript/Reference">Referencia JavaScript</a> (/Web/JavaScript/Reference)
+      </td>
+      <td>
+        <code>\{{JSxRef("Promise")}}</code> da como resultado {{JSxRef("Promise")}}.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/svgattr.rs">SVGAttr</a>
+      </td>
+      <td>
+        <a href="/es/docs/Web/SVG/Reference/Attribute">Referencia de atributos SVG</a> (/Web/SVG/Reference/Attribute)
+      </td>
+      <td>
+        <code>\{{SVGAttr("d")}}</code> da como resultado {{SVGAttr("d")}}.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a
+          href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/svgxref.rs">SVGElement</a>
+      </td>
+      <td>
+        <a href="/es/docs/Web/SVG/Reference/Element">Referencia de elementos SVG</a> (/Web/SVG/Reference/Element)
+      </td>
+      <td>
+        <code>\{{SVGElement("view")}}</code> da como resultado {{SVGElement("view")}}.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code><a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/http.rs">HTTPHeader</a></code>
+      </td>
+      <td>
+        <a href="/es/docs/Web/HTTP/Reference/Headers">Cabeceras HTTP</a> (/Web/HTTP/Reference/Headers)
+      </td>
+      <td>
+        <code>\{{HTTPHeader("ACCEPT")}}</code> da como resultado {{HTTPHeader("ACCEPT")}}.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/http.rs">HTTPMethod</a>
+      </td>
+      <td>
+        <a href="/es/docs/Web/HTTP/Reference/Methods">Métodos de petición HTTP</a> (/Web/HTTP/Reference/Methods)
+      </td>
+      <td>
+        <code>\{{HTTPMethod("HEAD")}}</code> da como resultado {{HTTPMethod("HEAD")}}.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/http.rs">HTTPStatus</a>
+      </td>
+      <td>
+        <a href="/es/docs/Web/HTTP/Reference/Status">Códigos de estado de respuesta HTTP</a> (/Web/HTTP/Reference/Status)
+      </td>
+      <td>
+        <code>\{{HTTPStatus("404")}}</code> da como resultado {{HTTPStatus("404")}}.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### Añadir ayudas de navegación para guías multipágina
+
+Las macros [`Previous`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/previous_menu_next.rs), [`Next`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/previous_menu_next.rs) y [`PreviousNext`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/previous_menu_next.rs) ofrecen controles de navegación para artículos que forman parte de una secuencia.
+Para las plantillas unidireccionales, el único parámetro necesario es el slug del artículo anterior o siguiente en la secuencia.
+La macro [`PreviousNext`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/previous_menu_next.rs) requiere dos parámetros: el primero es el slug del artículo anterior y el segundo es el slug del artículo siguiente.
+
+## Generar ejemplos de código
 
 ### Ejemplos en vivo
 
-- [`EmbedLiveSample`](https://github.com/mdn/yari/tree/main/kumascript/macros/EmbedLiveSample.ejs) te permite insertar la salida de un ejemplo de código en una página, como se describe en [Ejemplos en vivo](/es/docs/MDN/Writing_guidelines/Page_structures/Live_samples).
-- [`LiveSampleLink`](https://github.com/mdn/yari/tree/main/kumascript/macros/LiveSampleLink.ejs) crea un vínculo a una página que contiene el resultado de un ejemplo de código en una página, como se describe en [Ejemplos en vivo](/es/docs/MDN/Writing_guidelines/Page_structures/Live_samples).
+- [`EmbedLiveSample`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/embeds/embed_live_sample.rs) te permite incrustar el resultado de un ejemplo de código en una página, como se describe en [Ejemplos en vivo](/es/docs/MDN/Writing_guidelines/Page_structures/Live_samples).
+- [`LiveSampleLink`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/embeds/live_sample_link.rs) crea un enlace a una página que contiene el resultado de un ejemplo de código, tal como se describe en [Ejemplos en vivo](/es/docs/MDN/Writing_guidelines/Page_structures/Live_samples).
+- [`EmbedGHLiveSample`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/embeds/embed_gh_live_sample.rs) permite incrustar ejemplos en vivo desde páginas de GitHub.
+  Puedes obtener más información en [Ejemplos en vivo de GitHub](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples#github_live_samples).
 
-## Generar la barra lateral
+## Añadir formato de propósito general
 
-Hay plantillas para casi todas las grandes colecciones de páginas. Por lo general, enlazan a la página principal de `reference/guide/tutorial` (esto, a menudo es necesario porque nuestras rutas de navegación a veces no lo pueden hacer) y colocan el artículo en la categoría apropiada.
+### Añadir indicadores en línea para la documentación de la API
 
-- [`CSSRef`](https://github.com/mdn/yari/tree/main/kumascript/macros/CSSRef.ejs) genera la barra lateral para las páginas de referencia CSS.
-- [`HTMLSidebar`](https://github.com/mdn/yari/tree/main/kumascript/macros/HTMLSidebar.ejs) genera la barra lateral para las páginas de referencia HTML.
-- [`APIRef`](https://github.com/mdn/yari/tree/main/kumascript/macros/APIRef.ejs) genera la barra lateral para las páginas de referencia de la API web.
+[`Optional_Inline`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/badges.rs) y [`ReadOnlyInline`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/badges.rs) se usan en la documentación de la API, generalmente al describir la lista de propiedades de un objeto o los parámetros de una función.
 
-## Formato de propósito general
+Uso: `\{{Optional_Inline}}` o `\{{ReadOnlyInline}}`.
+Ejemplo:
 
-### Indicadores en línea para documentación de APIs
+- `isCustomObject` {{ReadOnlyInline}}
+  - : Indica, si es `true`, que el objeto es personalizado.
+- `parameterX` {{optional_inline}}
+  - : Indica…
 
-[`optional_inline`](https://github.com/mdn/yari/tree/main/kumascript/macros/optional_inline.ejs) y [`ReadOnlyInline`](https://github.com/mdn/yari/tree/main/kumascript/macros/ReadOnlyInline.ejs) se utilizan en la documentación de la API, normalmente cuando se describe la lista de propiedades de un objeto o parámetros de una función.
+## Añadir indicadores de estado y compatibilidad
 
-Uso: `\{{Optional_Inline}}` o `\{{ReadOnlyInline}}`. Ejemplo:
+### Añadir indicadores en línea sin parámetros adicionales
 
-- `isCustomObject`{{ReadOnlyInline}}
-  - Indica, si es `true`, que el objeto es personalizado.
-- `parameterX`{{Optional_Inline}}
-  - : Blah blah blah...
+#### No estándar
 
-## Indicadores de estado y compatibilidad
-
-### Indicadores en línea sin parámetros adicionales
-
-#### `Non-standard`
-
-[`Non-standard_Inline`](https://github.com/mdn/yari/tree/main/kumascript/macros/Non-standard_Inline.ejs) inserta una marca en línea que indica que la API no se ha estandarizado y no está en un seguimiento de estándares.
+[`Non-standard_Inline`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/badges.rs) inserta una marca en línea que indica que la API no ha sido estandarizada y no está en vías de estandarización.
 
 ##### Sintaxis
 
@@ -90,7 +198,8 @@ Uso: `\{{Optional_Inline}}` o `\{{ReadOnlyInline}}`. Ejemplo:
 
 #### Experimental
 
-[`experimental_inline`](https://github.com/mdn/yari/tree/main/kumascript/macros/experimental_inline.ejs) inserta una marca en línea que indica que la API no está ampliamente implementada y puede cambiar en el futuro.
+[`Experimental_Inline`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/badges.rs) inserta una marca en línea que indica que la API no está ampliamente implementada y puede cambiar en el futuro.
+Para obtener más información sobre la definición de **experimental**, consulta la documentación sobre [Experimental, obsoleto y en desuso](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete).
 
 ##### Sintaxis
 
@@ -98,41 +207,68 @@ Uso: `\{{Optional_Inline}}` o `\{{ReadOnlyInline}}`. Ejemplo:
 
 ##### Ejemplos
 
-- Icon: {{Experimental_Inline}}
+- Icono: {{Experimental_Inline}}
 
-### Indicadores en línea que apoyan la especificación de la tecnología
+### Añadir indicadores en línea que permiten especificar la tecnología
 
-En estas macros, el parámetro (cuando se especifica) debe ser una de las cadenas "html", "js", "css" o "gecko", seguida del número de versión.
+#### Obsoleto
 
-#### Desaprobado
-
-[`Deprecated_Inline`](https://github.com/mdn/yari/tree/main/kumascript/macros/Deprecated_Inline.ejs) inserta una marca desaprobado en línea (`Deprecated_Inline`) para desalentar el uso de una API que oficialmente está en desuso. **Nota**: "Desaprobado" significa que el elemento ya no se debe utilizar, pero sigue funcionando. Si quieres decir que ya no funciona, utiliza el término "obsoleto".
-
-No utilices el parámetro en ningún área independiente del navegador (HTML, API, JS, CSS, …).
+[`Deprecated_Inline`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/badges.rs) inserta una marca de obsoleto en línea ({{Deprecated_Inline}}) para desalentar el uso de una API que está oficialmente obsoleta (o que ha sido eliminada).
+Para obtener más información sobre la definición de **obsoleto**, consulta la documentación sobre [Experimental, obsoleto y en desuso](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete).
 
 ##### Sintaxis
 
 `\{{Deprecated_Inline}}`
 
-##### Ejemplo
+##### Ejemplos
 
-- Icon: {{Deprecated_Inline}}
-
-### Plantilla de insignias
-
-Estas macros se utilizan principalmente en la página [WebAPI](/es/docs/Web/API). Consulta [Creación de nuevas insignias](#creación_de_nuevas_insignias) para obtener información sobre cómo crear una nueva insignia (`Badge`).
+- Icono: {{Deprecated_Inline}}
 
 ### Indicadores de encabezado de página o sección
 
-Estas plantillas tienen la misma semántica que sus contrapartes en línea descritas anteriormente. Las plantillas se deben colocar directamente debajo del título de la página principal (o la ruta de navegación si está disponible) en la página de referencia. También se pueden utilizar para marcar una sección en una página.
+Estas plantillas tienen la misma semántica que sus equivalentes en línea descritas anteriormente.
+Debes colocar las plantillas directamente debajo del título principal de la página (o de la ruta de navegación, si está disponible) en la página de referencia.
+También puedes usarlas para marcar una sección en una página.
 
-- [`Non-standard_Header`](https://github.com/mdn/yari/tree/main/kumascript/macros/Non-standard_Header.ejs): `\{{Non-standard_Header}}` {{Non-standard_Header}}
-- [`SeeCompatTable`](https://github.com/mdn/yari/tree/main/kumascript/macros/SeeCompatTable.ejs) se debe usar en páginas que documentan [características experimentales](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental). Ejemplo: `\{{SeeCompatTable}}` {{SeeCompatTable}}
-- [`Deprecated_Header`](https://github.com/mdn/yari/tree/main/kumascript/macros/Deprecated_Header.ejs): `\{{Deprecated_Header}}` {{Deprecated_Header}}
-- [`secureContext_header`](https://github.com/mdn/yari/tree/main/kumascript/macros/secureContext_header.ejs): `\{{SecureContext_Header}}` {{SecureContext_Header}}
+- [`Non-standard_Header`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs): `\{{Non-standard_Header}}` {{Non-standard_Header}}
+- [`SeeCompatTable`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs) se usa en páginas que documentan [características experimentales](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
+  Ejemplo: `\{{SeeCompatTable}}` {{SeeCompatTable}}
+- [`Deprecated_Header`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs): `\{{Deprecated_Header}}` {{Deprecated_Header}}
+- [`SecureContext_Header`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs).
+  Debe usarse en páginas principales, como páginas de interfaz, páginas de descripción general de la API y puntos de entrada de la API (por ejemplo, `navigator.xyz`), pero normalmente no en subpáginas como páginas de métodos y propiedades.
+  Ejemplo: `\{{SecureContext_Header}}` {{SecureContext_Header}}
 
-### Indica que una función está disponible en `workers` web
+#### Indicar que una característica está disponible en web workers
 
-La macro [`AvailableInWorkers`](https://github.com/mdn/yari/tree/main/kumascript/macros/AvailableInWorkers.ejs) inserta un cuadro de nota localizado que indica que una función está disponible en el contexto de [workers web](/es/docs/Web/API/Web_Workers_API).
+La macro [`AvailableInWorkers`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs) inserta un cuadro de nota localizado que indica que una característica está disponible en un [contexto de worker](/es/docs/Web/API/Web_Workers_API).
+También puedes pasar algunos argumentos para indicar que la característica funciona en un contexto de worker específico.
+
+##### Sintaxis
+
+```plain
+\{{AvailableInWorkers}}
+\{{AvailableInWorkers("window_and_worker_except_service")}}
+```
+
+##### Ejemplos
 
 {{AvailableInWorkers}}
+{{AvailableInWorkers("window_and_worker_except_service")}}
+
+## Enlaces a la compatibilidad con navegadores y especificaciones
+
+Las siguientes macros se incluyen en todas las páginas de referencia, pero también son compatibles con todos los tipos de página:
+
+- `\{{Compat}}`
+  - : Genera una [tabla de compatibilidad](/es/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables) para las características definidas por `browser-compat` en el frontmatter.
+- `\{{Specifications}}`
+  - : Incluye una [tabla de especificaciones](/es/docs/MDN/Writing_guidelines/Page_structures/Specification_tables) para las características definidas por `spec-urls` en el frontmatter, si está presente, o a partir de la especificación incluida en los datos de compatibilidad con navegadores definidos por `browser-compat` en el frontmatter.
+
+## Véase también
+
+- [Macros de enlace](/es/docs/MDN/Writing_guidelines/Page_structures/Links)
+- [Macros de barra lateral](/es/docs/MDN/Writing_guidelines/Page_structures/Sidebars)
+- [Macros de estado de características](/es/docs/MDN/Writing_guidelines/Page_structures/Feature_status)
+- [Otras macros](/es/docs/MDN/Writing_guidelines/Page_structures/Macros/Other) (macros poco usadas u obsoletas)
+- [Plantillas de página](/es/docs/MDN/Writing_guidelines/Page_structures/Page_types#page_templates)
+- [Componentes de página](/es/docs/MDN/Writing_guidelines/Writing_style_guide#page_components)


### PR DESCRIPTION
## Description

Syncs the Spanish translation of `Commonly-used macros` with the current English source in `mdn/content`.

## Changes

- `l10n.sourceCommit` updated to current EN HEAD SHA.
- Front-matter contains only allowed fields (`title`, `slug`, `l10n.sourceCommit`).
- Removed outdated `{{MDNSidebar}}` macro to match the upstream source.
- Updated all internal links from `/en-US/` to `/es/`.
- Added missing section.

## Related

Closes #35405
Part of #35373