### PR TITLE
fix(es): sync CSS property page template translation [es]

### DIFF
--- a/files/es/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -2,97 +2,98 @@
 title: Plantilla de página de propiedad CSS
 slug: MDN/Writing_guidelines/Page_structures/Page_types/CSS_property_page_template
 l10n:
-  sourceCommit: fcf868352a45840521813dbfea87fe2120f9c015
+  sourceCommit: d2fb8cdc9422dd2b68ff23f616d70811729f1fbd
 ---
 
-{{MDNSidebar}}
-
 > [!NOTE]
-> _Elimina este bloque de nota antes de publicar._
+> _Elimina este bloque de notas antes de publicar._
 >
 > ---
 >
-> **Metadatos de la página:**
+> **Front matter de la página:**
 >
-> La información al inicio de la página se utiliza para definir "metadatos de la página".
-> Los valores deben actualizarse apropiadamente para la propiedad particular.
+> El front matter en la parte superior de la página se utiliza para definir los "metadatos de la página".
+> Los valores deben actualizarse adecuadamente para la propiedad en particular.
 >
 > ```md
 > ---
-> title: NombreDeLaPropiedad
-> slug: Web/CSS/NombreDeLaPropiedad
+> title: name-of-the-property
+> slug: Web/CSS/Reference/Properties/name-of-the-property
 > page-type: css-property O css-shorthand-property
 > status:
->   - experimental
 >   - deprecated
+>   - experimental
 >   - non-standard
-> browser-compat: css.properties.NombreDeLaPropiedad
+> browser-compat: css.properties.name-of-the-property
+> sidebar: cssref
 > ---
 > ```
 >
 > - **title**
->   - : El valor de `title` se muestra en la parte superior de la página. El formato del título es _NombreDeLaPropiedad_.
->     Por ejemplo, la propiedad [`background-color`](/es/docs/Web/CSS/Reference/Properties/background-color) tiene un título de _background-color_.
+>   - : El valor de `title` se muestra en la parte superior de la página. El formato del título es _nombre-de-la-propiedad_.
+>     Por ejemplo, la propiedad {{cssxref("background-color")}} tiene el título _background-color_.
 > - **slug**
->   - : El valor de `slug` es el final de la ruta URL después de `https://developer.mozilla.org/es/docs/`. Esto se formateará como `Web/CSS/NombreDeLaPropiedad`.
->     Por ejemplo, el slug para la propiedad [`background-color`](/es/docs/Web/CSS/Reference/Properties/background-color) es `Web/CSS/background-color`. Para un componente de varias palabras como `Getting_started` en un slug, el slug debería usar un guión bajo como en `/es/docs/Learn/HTML/Getting_started`.
+>   - : El valor de `slug` es el final de la ruta de la URL después de `https://developer.mozilla.org/en-US/docs/`. Esto tendrá el formato `Web/CSS/Reference/Properties/nombre-de-la-propiedad`.
+>     Por ejemplo, el slug para la propiedad {{cssxref("background-color")}} es `Web/CSS/Reference/Properties/background-color`. Para un componente de varias palabras como `Getting_started` en un slug, este debe usar un guion bajo, como en `/en-US/docs/Learn_web_development/Core/Structuring_content`.
 > - **page-type**
->   - : El valor de `page-type` para las propiedades CSS es `css-property`. Para una propiedad CSS abreviada, el valor es `css-shorthand-property`. Por ejemplo, el valor de `page-type` para la propiedad [animation](/es/docs/Web/CSS/Reference/Properties/animation) es `css-shorthand-property` porque es una propiedad abreviada, mientras que el valor de `page-type` para la propiedad [animation-delay](/es/docs/Web/CSS/Reference/Properties/animation-delay) es `css-property`.
+>   - : El valor de `page-type` para las propiedades CSS es `css-property`. Para una propiedad CSS abreviada (shorthand), el valor es `css-shorthand-property`. Por ejemplo, el valor de `page-type` para la propiedad [animation](/es/docs/Web/CSS/Reference/Properties/animation) es `css-shorthand-property` porque es una propiedad abreviada, mientras que el valor de `page-type` para la propiedad [animation-delay](/es/docs/Web/CSS/Reference/Properties/animation-delay) es `css-property`.
 > - **status**
->   - : Si corresponde, el valor de la clave de tecnología `status` puede ser [**experimental**](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental), [**deprecated**](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated) y/o **non-standard** (si no está en una pista de estándares).
+>   - : Etiquetas (flags) que describen el estado de esta característica. Es un arreglo (array) que puede contener uno o más de los siguientes valores: `experimental`, `deprecated`, `non-standard`. Esta clave no debe configurarse manualmente: se establece automáticamente según los valores en los datos de compatibilidad del navegador para la característica. Consulta ["Cómo se añaden o actualizan los estados de las características"](/es/docs/MDN/Writing_guidelines/Page_structures/Feature_status#how_feature_statuses_are_added_or_updated).
 > - **browser-compat**
->   - : Reemplace el valor de marcador de posición <code>css.properties.NombreDeLaPropiedad</code> con la cadena de consulta para la propiedad en el [repositorio de datos de compatibilidad del navegador](https://github.com/mdn/browser-compat-data/tree/main/css/properties). Consulte la sección _Otros macros en la página_ de este bloque de nota para ver cómo se utiliza esta clave-valor para generar contenido para las secciones _Especificaciones_ y _Compatibilidad con el navegador_.
+>   - : Reemplaza el valor de marcador de posición <code>css.properties.NameOfTheProperty</code> con la cadena de consulta (query string) para la propiedad en el [repositorio de datos de compatibilidad de navegadores (Browser compat data repo)](https://github.com/mdn/browser-compat-data/tree/main/css/properties). Revisa la sección _Otras macros en la página_ de este bloque de notas para ver cómo se utiliza este par clave-valor para generar contenido para las secciones _Especificaciones_ y _Compatibilidad con navegadores_.
+> - **sidebar**
+>   - : Esto es `cssref` para todas las páginas de guía y referencia de CSS.
+>     Consulta [Estructuras de página: Barras laterales](/es/docs/MDN/Writing_guidelines/Page_structures/Sidebars) para más detalles.
 >
 > ---
 >
-> **Macros en la parte superior de la página**
+> **Macros de la parte superior de la página**
 >
-> Aparecen varias llamadas de macros en la sección de contenido (inmediatamente debajo de los metadatos de la página).
-> Debe actualizarlos o eliminarlos según el consejo a continuación:
+> Varias llamadas a macros aparecen en la parte superior de la sección de contenido (inmediatamente debajo del front matter de la página).
+> El conjunto de herramientas (toolchain) añade automáticamente estas macros (no es necesario añadirlas ni eliminarlas):
 >
-> - `\{{SeeCompatTable}}`: Esta macro genera un banner **Experimental**, que indica que la tecnología está [experimental](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
->   Si la tecnología que está documentando no es experimental, puede eliminar esta macro.
->   Si la tecnología es experimental y está oculta detrás de una preferencia en Firefox, también debe completar una entrada para ella en la página [Características experimentales en Firefox](/es/docs/Mozilla/Firefox/Experimental_features).
-> - `\{{Deprecated_Header}}`: Esta macro genera un banner **Deprecated**, que indica que el uso de la tecnología está [desaconsejado](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
->   Si no lo está, entonces puede eliminar la llamada a la macro.
-> - `\{{CSSRef}}`: Esta macro debe estar presente en cada página de propiedad de CSS. Genera una barra lateral de CSS adecuada, dependiendo de las etiquetas incluidas en la página.
->   Recuerde eliminar la macro `\{{MDNSidebar}}` cuando use esta plantilla.
+> - `\{{SeeCompatTable}}`: Esta macro genera un banner de **Experimental**, que indica que la tecnología es [experimental](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
+>   Si la tecnología es experimental y está oculta detrás de una preferencia en Firefox, también debes completar una entrada para ella en la página [Características experimentales en Firefox](/es/docs/Mozilla/Firefox/Experimental_features).
+> - `\{{Deprecated_Header}}`: Esta macro genera un banner de **Obsoleto (Deprecated)**, que indica que el uso de la tecnología está [desaconsejado](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
+> - `\{{Non-standard_Header}}` — esto genera un banner de **No estándar (Non-standard)** que indica que la característica no forma parte de ninguna especificación.
 >
-> Se muestran ejemplos de los banners **Experimental** y **Deprecated** justo después de este bloque de nota.
+> Debes actualizar o eliminar las siguientes macros de acuerdo con los consejos a continuación:
+
+> No proporciones macros de encabezado de estado manualmente. Consulta la sección ["Cómo se añaden o actualizan los estados de las características"](/es/docs/MDN/Writing_guidelines/Page_structures/Feature_status#how_feature_statuses_are_added_or_updated) para añadir estos estados a la página.
+>
+> Justo después de este bloque de notas se muestran ejemplos de los banners **Experimental**, **Obsoleto** y **No estándar**.
 >
 > ---
 >
 > **Otras macros en la página**
 >
-> - Sección de sintaxis formal: El contenido de la sección _Sintaxis formal_ se genera utilizando la macro `\{{CSSSyntax}}`. Esta macro obtiene datos de las especificaciones utilizando el paquete npm [@webref/css](https://www.npmjs.com/package/@webref/css).
-> - Sección de definición formal: El contenido de la sección _Definición formal_ se genera utilizando la macro `\{{CSSInfo}}`. Para que esta sección tenga datos, debe asegurarse de que se haya completado una entrada adecuada para la propiedad correspondiente en el archivo de datos [properties.json](https://github.com/mdn/data/blob/main/css/properties.json) en el repositorio `mdn/data`. Consulte la página [Properties](https://github.com/mdn/data/blob/main/css/properties.md) para obtener más información.
-> - Secciones de Especificaciones y Compatibilidad con el navegador: La herramienta de compilación utiliza automáticamente el par clave-valor `browser-compat` de los metadatos de la página para insertar datos en las secciones _Especificaciones_ y _Compatibilidad con el navegador_ (reemplazando las macros `\{{Specifications}}` y `\{{Compat}}` en esas secciones, respectivamente).
+> - Sección de sintaxis formal: El contenido para la sección _Sintaxis formal_ se genera utilizando la macro `\{{CSSSyntax}}`. Esta macro obtiene datos de las especificaciones utilizando el [paquete npm @webref/css](https://www.npmjs.com/package/@webref/css).
+> - Sección de definición formal: El contenido para la sección _Definición formal_ se genera utilizando la macro `\{{CSSInfo}}`. Para que esta sección tenga datos, debes asegurarte de que se haya completado una entrada adecuada para la propiedad correspondiente en el archivo de datos [properties.json](https://github.com/mdn/data/blob/main/css/properties.json) en el repositorio `mdn/data`. Consulta la página de [Propiedades](https://github.com/mdn/data/blob/main/css/properties.md) para obtener más información.
+> - Secciones de Especificaciones y Compatibilidad con navegadores: La herramienta de compilación utiliza automáticamente el par clave-valor `browser-compat` del front matter de la página para insertar datos en las secciones _Especificaciones_ y _Compatibilidad con navegadores_ (reemplazando las macros `\{{Specifications}}` y `\{{Compat}}` en esas secciones, respectivamente).
 >
->   Tenga en cuenta que puede que primero necesite crear/actualizar una entrada para la propiedad y su especificación en nuestro <a href="https://github.com/mdn/browser-compat-data">repositorio de datos de compatibilidad con navegadores</a>.
->   Consulte nuestra [guía de tablas de compatibilidad](/es/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables) para obtener información sobre cómo agregar o editar entradas.
+>   Ten en cuenta que es posible que primero debas crear o actualizar una entrada para la propiedad y su especificación en nuestro <a href="https://github.com/mdn/browser-compat-data">repositorio de datos de compatibilidad de navegadores</a>.
+>   Consulta nuestra [guía de tablas de compatibilidad](/es/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables) para obtener información sobre cómo añadir o editar entradas.
 >
-> _Recuerde eliminar este bloque de nota antes de publicar._
+> _Recuerda eliminar este bloque de notas antes de publicar._
 
-{{SeeCompatTable}}{{deprecated_header}}
+{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
 
-Comienza el contenido de la página con un párrafo introductorio que nombre la propiedad y diga qué hace. Idealmente, esto debería ser una o dos frases cortas.
+Comienza el contenido de la página con un párrafo introductorio que nombre la propiedad y explique qué hace. Idealmente, debería ser una o dos frases cortas.
 
 ## Pruébalo
 
-_Este título es generado automáticamente por la macro `\{{EmbedInteractiveExample}}`._
-
-Esta sección es para ejemplos interactivos agregados usando la macro `\{{EmbedInteractiveExample}}`. Puedes crear estos ejemplos en el [repositorio mdn/interactive-examples](https://github.com/mdn/interactive-examples/blob/main/CONTRIBUTING.md). Consulta la sección [Ejemplos interactivos](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples#ejemplos_interactivos) en nuestras _Guías de escritura_ para obtener más información.
+Esta sección es generada por la macro `InteractiveExample`. Incluye el título de la sección "Try it" y el editor de código. Consulta la sección de [Ejemplos interactivos](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples#interactive_examples) en nuestras _Directrices de escritura_ para más información.
 
 ## Propiedades constituyentes
 
-Agrega esta sección solo para propiedades abreviadas, como [animation](/es/docs/Web/CSS/Reference/Properties/animation), para listar todas las propiedades con descripción completa relacionadas.
+Añade esta sección solo para propiedades abreviadas (shorthand), como [animation](/es/docs/Web/CSS/Reference/Properties/animation), para enumerar todas las propiedades completas (longhand) relacionadas.
 
 ## Sintaxis
 
-Incluye los casos de uso comunes como un bloque de código y describe los subvalores del componente que forman un valor completo.
+Incluye los casos de uso comunes como un bloque de código y describe los subvalores de los componentes que forman un valor completo.
 
 ```css
-/* Insertar bloque de código mostrando casos de uso comunes */
+/* Inserta el bloque de código que muestra los casos de uso comunes */
 /* o categorías de valores */
 ```
 
@@ -101,13 +102,16 @@ Incluye los casos de uso comunes como un bloque de código y describe los subval
 Incluye un término y una definición para cada subvalor.
 
 - `subvalor1`
-  - : Incluye una descripción del subvalor, su tipo de datos y lo que representa.
+  - : Incluye una descripción del subvalor, su tipo de datos y qué representa.
 - `subvalor2`
-  - : Incluye una descripción del subvalor, su tipo de datos y lo que representa.
+  - : Incluye una descripción del subvalor, su tipo de datos y qué representa.
+
+> [!WARNING]
+> No añadas [macros de estado en línea](/es/docs/MDN/Writing_guidelines/Page_structures/Feature_status#feature_status_icons_in_definition_lists) en las páginas de CSS.
 
 ## Descripción
 
-Esta es una sección opcional para incluir una descripción de la propiedad y explicar cómo funciona. Usa esta sección para explicar términos relacionados y agregar casos de uso para la propiedad.
+Esta es una sección opcional para incluir una descripción de la propiedad y explicar cómo funciona. Usa esta sección para explicar términos relacionados y añadir casos de uso para la propiedad.
 
 ## Definición formal
 
@@ -117,31 +121,35 @@ _Para usar esta macro, elimina las comillas invertidas y la barra invertida en e
 
 ## Sintaxis formal
 
-`\{CSSSyntax}}`
+`\{{CSSSyntax}}`
 
 _Para usar esta macro, elimina las comillas invertidas y la barra invertida en el archivo markdown._
 
+## Accesibilidad
+
+Esta es una sección opcional. Incluye pautas de accesibilidad, mejores prácticas y posibles preocupaciones que los desarrolladores deben tener en cuenta al usar esta propiedad. También puedes incluir alternativas o soluciones cuando corresponda.
+
 ## Ejemplos
 
-Nota que usamos el plural "Ejemplos" incluso si la página solo contiene un ejemplo.
+Ten en cuenta que usamos el plural "Ejemplos" incluso si la página solo contiene un ejemplo.
 
-### Agregar un título descriptivo
+### Añade un encabezado descriptivo
 
-Cada ejemplo debe tener un título H3 (`###`) que nombre el ejemplo. El título debe ser descriptivo de lo que está haciendo el ejemplo. Por ejemplo, "Un ejemplo simple" no dice nada sobre el ejemplo y por lo tanto, no es un buen título. El título debe ser conciso. Para una descripción más larga, usa el párrafo después del título.
+Cada ejemplo debe tener un encabezado H3 (`###`) que nombre el ejemplo. El encabezado debe ser descriptivo de lo que hace el ejemplo. Por ejemplo, "Un ejemplo simple" no dice nada sobre el ejemplo y, por lo tanto, no es un buen encabezado. El encabezado debe ser conciso. Para una descripción más larga, usa el párrafo después del encabezado.
 
-Consulta nuestra guía sobre cómo agregar [ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples) para obtener más información.
+Consulta nuestra guía sobre cómo añadir [ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples) para más información.
 
 > [!NOTE]
 > A veces querrás enlazar a ejemplos dados en otra página.
 >
 > **Escenario 1:** Si tienes algunos ejemplos en esta página y algunos más en otra página:
 >
-> Incluye un título H3 (`###`) para cada ejemplo en esta página y luego un título H3 (`###`) final con el texto "Más ejemplos", debajo del cual puedes enlazar a los ejemplos en otras páginas. Por ejemplo:
+> Incluye un encabezado H3 (`###`) para cada ejemplo en esta página y luego un encabezado H3 final (`###`) con el texto "Más ejemplos", bajo el cual puedes enlazar a los ejemplos en otras páginas. Por ejemplo:
 >
 > ```md
 > ## Ejemplos
 >
-> ### Usando la API fetch
+> ### Uso de la API fetch
 >
 > Ejemplo de Fetch
 >
@@ -150,36 +158,32 @@ Consulta nuestra guía sobre cómo agregar [ejemplos de código](/es/docs/MDN/Wr
 > Enlaces a más ejemplos en otras páginas
 > ```
 >
-> **Escenario 2:** Si _solo_ tienes ejemplos en otra página y ninguno en esta página:
+> **Escenario 2:** Si _solo_ tienes ejemplos en otra página y ninguno en esta:
 >
-> No agregues ningún título H3; simplemente agrega los enlaces directamente debajo del título H2 "Ejemplos". Por ejemplo:
+> No añadas encabezados H3; simplemente añade los enlaces directamente bajo el encabezado H2 "Ejemplos". Por ejemplo:
 >
 > ```md
 > ## Ejemplos
 >
-> Para ejemplos de esta API, consulta [la página sobre fetch()](https://example.org).
+> Para ver ejemplos de esta API, consulta [la página sobre fetch()](https://example.org/).
 > ```
-
-## Preocupaciones de accesibilidad
-
-Esta es una sección opcional. Puedes incluir cualquier advertencia aquí para las preocupaciones de accesibilidad que los desarrolladores deben tener en cuenta al usar esta propiedad. También puedes incluir soluciones alternativas para estas preocupaciones de accesibilidad si las hay.
 
 ## Especificaciones
 
-`\{{Especificaciones}}`
+`\{{Specifications}}`
 
 _Para usar esta macro, elimina las comillas invertidas y la barra invertida en el archivo markdown._
 
-## Compatibilidad con el navegador
+## Compatibilidad con navegadores
 
-`\{{Compatibilidad}}`
+`\{{Compat}}`
 
 _Para usar esta macro, elimina las comillas invertidas y la barra invertida en el archivo markdown._
 
-## Veáse también
+## Véase también
 
-Incluye enlaces a páginas de referencia y guías relacionadas con la propiedad actual. Para obtener más pautas, consulta la [sección Véase también](/es/docs/MDN/Writing_guidelines/Writing_style_guide#see_also_section) en la _Guía de estilo de escritura_.
+Incluye enlaces a páginas de referencia y guías relacionadas con la propiedad actual. Para más pautas, consulta la [sección Véase también](/es/docs/MDN/Writing_guidelines/Writing_style_guide#see_also_section) en la _Guía de estilo de escritura_.
 
 - enlace1
 - enlace2
-- external_link (año)
+- enlace_externo (año)


### PR DESCRIPTION
## Summary

Syncs the Spanish translation of the CSS property page template with the English source, fixing four issues identified during review:

- **Line 36**: Removed Markdown link syntax inside backtick code span (`[url](url)` → plain URL)
- **Line 74**: Removed Markdown link syntax inside `href` HTML attribute (`[url](url)` → plain URL)
- **Line 79**: Fixed macro casing `{{deprecated_header}}` → `{{Deprecated_Header}}` (Yari is case-sensitive)
- **Line 185**: Aligned link text `[sección Ver también]` → `[sección Véase también]` to match the section heading

Based on @GNUXDAR's work in #35499.

Closes #35417

## Test plan

- [ ] Lint passes (markdownlint, Prettier, URL locale checker)
- [ ] Template renders correctly on the MDN preview URL