### PR TITLE
[ja] fix: [Symbol.dispose]() か [Symbol.dispose]() → [Symbol.asyncDispose]() か [Symbol.dispose]()

### DIFF
--- a/files/ja/web/javascript/reference/statements/await_using/index.md
+++ b/files/ja/web/javascript/reference/statements/await_using/index.md
@@ -18,7 +18,7 @@ await using name1 = value1, name2 = value2, /* …, */ nameN = valueN;
 - `nameN`
   - : 宣言する変数の名前。各変数名は、 JavaScript で有効な[識別子](/ja/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers)でなければならず、[構造分解バインドパターン](/ja/docs/Web/JavaScript/Reference/Operators/Destructuring)であってはなりません。
 - `valueN`
-  - : 変数の初期値。有効な式であれば何でも指定可能ですが、その値は `null`、`undefined`、または `[Symbol.dispose]()` か [`[Symbol.dispose]()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Symbol/dispose) メソッドを持つオブジェクトのいずれかでなければなりません。
+  - : 変数の初期値。有効な式であれば何でも指定可能ですが、その値は `null`、`undefined`、または [`[Symbol.asyncDispose]()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncDispose) か [`[Symbol.dispose]()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Symbol/dispose) メソッドを持つオブジェクトのいずれかでなければなりません。
 
 ## 解説
 


### PR DESCRIPTION
`[Symbol.dispose]() か [Symbol.dispose]()` → `[Symbol.asyncDispose]() か [Symbol.dispose]()`

### Description

`[Symbol.asyncDispose]() か [Symbol.dispose]()` となるべきところが  `[Symbol.dispose]() か [Symbol.dispose]()` となっている

### Motivation

Fixed typos

### Additional details

none

### Related issues and pull requests

none
