### PR TITLE
fix(es): plantilla de página de encabezado HTTP — bloque [!NOTE], macros Glossary y encabezados

### DIFF
--- a/files/es/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
@@ -1,144 +1,162 @@
 ---
-title: Plantilla de página de cabecera HTTP
+title: Plantilla de página de encabezado HTTP
 slug: MDN/Writing_guidelines/Page_structures/Page_types/HTTP_header_page_template
 l10n:
-  sourceCommit: cb1c745168764c4646631e7c4289319d782cc83b
+  sourceCommit: ad5b5e31f81795d692e66dadb7818ba8b220ad15
 ---
 
-{{MDNSidebar}}
-
 > [!NOTE]
-> _Elimina toda esta nota explicativa antes de publicar_
+> _Elimina toda esta nota explicativa antes de publicar._
 >
 > ---
 >
-> **Metadatos de la página:**
+> **Front matter de la página:**
 >
-> Los metadatos en la parte superior de la página se utilizan para definir "metadatos de la página".
-> Los valores deben actualizarse adecuadamente para el elemento en particular.
+> El front matter al principio de la página se usa para definir los "metadatos de la página".
+> Los valores deben actualizarse adecuadamente para el encabezado en cuestión.
 >
 > ```md
 > ---
-> title: NombreDeLaCabecera
-> slug: Web/HTTP/Headers/NameOfTheHeader
+> title: Encabezado NombreDelEncabezado
+> short-title: NombreDelEncabezado
+> slug: Web/HTTP/Reference/Headers/NombreDelEncabezado
 > page-type: http-header
 > status:
->   - experimental
 >   - deprecated
+>   - experimental
 >   - non-standard
-> browser-compat: path.to.feature.NameOfTheHeader
+> browser-compat: path.to.feature.NombreDelEncabezado
+> sidebar: http
 > ---
 > ```
 >
 > - **title**
->   - : El título que se muestra en la parte superior de la página. Debe tener el formato _NombreDeLaCabecera_. Por ejemplo, la cabecera [Cache-Control](/es/docs/Web/HTTP/Reference/Headers/Cache-Control) tiene un _título_ de `Cache-Control`.
+>   - : Encabezado del título que se muestra en la parte superior de la página. Formato: _Encabezado NombreDelEncabezado_. Por ejemplo, el encabezado [Cache-Control](/es/docs/Web/HTTP/Reference/Headers/Cache-Control) tiene un _title_ de `Cache-Control header`.
+> - **short-title**
+>   - : Título abreviado que se usa en migas de pan y barras laterales. Formato: _NombreDelEncabezado_. Por ejemplo, el encabezado [Cache-Control](/es/docs/Web/HTTP/Reference/Headers/Cache-Control) tiene un _short-title_ de `Cache-Control`.
 > - **slug**
->   - : El final de la ruta de URL después de `https://developer.mozilla.org/es/docs/`.
->     Esto se formateará como `Web/HTTP/Headers/NameOfTheHeader`. Por ejemplo, el de [Cache-Control](/es/docs/Web/HTTP/Reference/Headers/Cache-Control) es Web/HTTP/Headers/Cache-Control.
+>   - : El final de la ruta URL después de `https://developer.mozilla.org/es/docs/`. Tendrá el formato `Web/HTTP/Reference/Headers/NombreDelEncabezado`. Por ejemplo, el slug de [Cache-Control](/es/docs/Web/HTTP/Reference/Headers/Cache-Control) es `Web/HTTP/Reference/Headers/Cache-Control`.
 > - **page-type**
->   - : Para cabeceras HTTP, debe ser `http-header`. Para otros valores HTTP de `page-type`, consulte la [sección HTTP](/es/docs/MDN/Writing_guidelines/Page_structures/Page_types/Page_type_key#http_page_types) de la documentación para el metadato `page-type`.
+>   - : Para encabezados HTTP, debe ser `http-header`.
 > - **status**
->   - : Banderas que describen el estado de esta característica. Puede contener uno o más de los siguiente valores: `experimental`, `deprecated`, `non-standard` Este valor no debe configurarse manualmente: se configura automáticamente en función de los valores de los datos de compatibilidad del navegador para la característica. Consulte ["Cómo agregar o actualizar estados de funciones"](/es/docs/MDN/Writing_guidelines/Page_structures/Feature_status#how_to_add_or_update_feature_statuses).
+>   - : Indicadores que describen el estado de esta funcionalidad. Es un arreglo que puede contener uno o más de los siguientes valores: `experimental`, `deprecated`, `non-standard`. Esta clave no debe configurarse manualmente: se establece automáticamente según los valores en los datos de compatibilidad de navegadores. Consulta ["Cómo se añaden o actualizan los estados de las funcionalidades"](/es/docs/MDN/Writing_guidelines/Page_structures/Feature_status#how_feature_statuses_are_added_or_updated).
 > - **browser-compat**
->   - : Reemplaza el valor de marcador de posición `path.to.feature.NameOfTheHeader` con la cadena de consulta para el elemento en el [repositorio de datos de compatibilidad con navegadores](https://github.com/mdn/browser-compat-data).
->     La herramienta utiliza automáticamente la clave para completar la sección de compatibilidad (reemplazando la macro `\{{Compat}}`).
+>   - : Reemplaza el valor de marcador de posición `path.to.feature.NombreDelEncabezado` con la cadena de consulta para el encabezado en el <a href="https://github.com/mdn/browser-compat-data">repositorio de datos de compatibilidad de navegadores</a>.
+>     La cadena de herramientas usa automáticamente esta clave para rellenar la sección de compatibilidad (reemplazando la macro `\{{Compat}}`).
 >
->     Ten en cuenta que es posible que primero necesites crear/actualizar una entrada para la cabecera HTTP en nuestro [repositorio de datos de compatibilidad con navegadores](https://github.com/mdn/browser-compat-data), y la entrada debe incluir información de especificación.
->     Consulta nuestra [guía sobre cómo hacer esto](/es/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables).
+>     La compatibilidad con navegadores no aplica para encabezados HTTP sin implementación específica definida.
+>     En esos casos, elimina la clave `browser-compat` y su valor.
+>
+> - **sidebar**
+>   - : Siempre es `http`.
+>     Consulta [Estructuras de página: barras laterales](/es/docs/MDN/Writing_guidelines/Page_structures/Sidebars) para más detalles.
 >
 > ---
 >
-> **Macros en la parte superior de la página**
+> **Macros de la parte superior de la página**
 >
-> Aparecen varias llamadas a macros en la parte superior de la sección de contenido (inmediatamente debajo de los metadatos de la página).
-> Debes actualizarlos o eliminarlos según el consejo siguiente:
+> Varias macros aparecen en la parte superior de la sección de contenido inmediatamente después del front matter.
+> Estas macros se añaden automáticamente mediante la cadena de herramientas (no es necesario añadirlas ni eliminarlas):
 >
-> - `\{{SeeCompatTable}}` — esto genera un banner de **Esta es una tecnología experimental** que indica que la tecnología es [experimental](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
->   Si la tecnología que estás documentando no es experimental, debes eliminar esto.
->   Si es experimental, y la tecnología está oculta detrás de una preferencia en Firefox, también debes completar una entrada para ella en la página [Características experimentales en Firefox](/es/docs/Mozilla/Firefox/Experimental_features).
-> - `\{{Deprecated_Header}}` — esto genera un banner de **Obsoleto** que indica que el uso de la tecnología está [desaconsejado](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
->   Si no lo está, puedes eliminar la llamada a la macro.
-> - `\{{Non-standard_Header}}` — esto genera un banner de no estándar que indica que la función no forma parte de ninguna especificación.
+> - `\{{SeeCompatTable}}` — genera un banner de **Esta es una tecnología experimental** que indica que el encabezado es [experimental](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
+>   Si es experimental y está oculto detrás de una preferencia en Firefox, también debes completar una entrada en la página [Funcionalidades experimentales en Firefox](/es/docs/Mozilla/Firefox/Experimental_features).
+> - `\{{deprecated_header}}` — genera un banner de **Obsoleto** que indica que el uso del encabezado está [desaconsejado](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
+> - `\{{Non-standard_Header}}` — genera un banner de **No estándar** que indica que la funcionalidad no forma parte de ninguna especificación.
 >
->   No proporcione macros de encabezado de estado manualmente. Consulte ["Cómo agregar o actualizar estados de funciones"](/es/docs/MDN/Writing_guidelines/Page_structures/Feature_status#how_to_add_or_update_feature_statuses). para agregar estos estados a la página.
+> No proporciones macros de encabezado de estado manualmente. Consulta la sección ["Cómo se añaden o actualizan los estados de las funcionalidades"](/es/docs/MDN/Writing_guidelines/Page_structures/Feature_status#how_feature_statuses_are_added_or_updated) para añadir estos estados a la página.
 >
-> Se muestran muestras de los banners **Experimental** y **Obsoleto** justo después de este bloque de nota.
+> Justo después de este bloque de notas se muestran ejemplos de los banners **Experimental**, **Obsoleto** y **No estándar**.
 >
-> _Recuerda eliminar toda esta nota explicativa antes de publicar_
+> _Recuerda eliminar toda esta nota explicativa antes de publicar._
 
 {{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
 
-Comienza el contenido en la página con un párrafo introductorio — comienza nombrando la cabecera http y diciendo qué hace.
-Idealmente, esto debería ser una o dos oraciones cortas.
+La primera frase de la página debe seguir este formato:
+
+> El encabezado HTTP **`nombre-del-encabezado`** (tipo de encabezado) se utiliza para X en circunstancias Y.
+
+El "tipo de encabezado" debe indicar si es un {{Glossary("request header", "encabezado de solicitud")}}, un {{Glossary("response header", "encabezado de respuesta")}}, o si puede ser ambos.
+El párrafo de resumen debería ser idealmente una o dos frases cortas.
+
+Puedes mencionar advertencias notables o errores comunes en esta sección, enlazando a ejemplos o documentación más detallada (guías, etc.).
+Dos o tres párrafos son apropiados para esta sección; si hay notas de uso sustanciales que incluir, usa una sección de "Descripción" después de "Directivas".
 
 <table class="properties">
   <tbody>
     <tr>
-      <th scope="row">Tipo de cebera</th>
+      <th scope="row">Tipo de encabezado</th>
       <td>
-        Incluye la categoría de la cabecera (o categorías), por ejemplo,
-        {{Glossary("Request header", "Cabecera de solicitud")}},
-        {{Glossary("Response header", "Cabecera de respuesta")}},
-        <a href="/es/docs/Web/HTTP/Reference/Headers">Cabecera de pista del cliente</a>
+        Incluye la categoría (o categorías) del encabezado, p. ej.
+        {{Glossary("Request header", "Encabezado de solicitud")}},
+        {{Glossary("Response header", "Encabezado de respuesta")}},
+        <a href="/es/docs/Web/HTTP/Guides/Client_hints">Client hint (Indicio del cliente)</a>
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name", "Nombre de cabecera prohibido")}}</th>
-      <td>sí o no</td>
+      <th scope="row">{{Glossary("Forbidden request header", "Encabezado de solicitud prohibido")}}</th>
+      <td>"Sí" o "No"</td>
     </tr>
     <tr>
       <th scope="row">
-        {{Glossary("CORS-safelisted response header", "Cabecera de respuesta permitida por CORS")}}
+        {{Glossary("CORS-safelisted response header", "Encabezado de respuesta en lista blanca de CORS")}}
       </th>
-      <td>sí o no</td>
+      <td>"Sí" o "No"</td>
     </tr>
   </tbody>
 </table>
 
 ## Sintaxis
 
-Rellena un cuadro de sintaxis, como el siguiente, de acuerdo con la guía en nuestro artículo [secciones de sintaxis](/es/docs/MDN/Writing_guidelines/Page_structures/Syntax_sections).
-Si el encabezado tiene muchas directivas disponibles, siéntete libre de incluir múltiples cuadros de sintaxis, subsecciones y explicaciones según corresponda.
+Completa un bloque de sintaxis, como el de abajo, de acuerdo con la guía en nuestro artículo de [secciones de sintaxis](/es/docs/MDN/Writing_guidelines/Page_structures/Syntax_sections).
 
 ```http
-NombreDeLaCabecera: <directiva1>
-NombreDeLaCabecera: <directiva1>, <directiva2>, …
+NombreDelEncabezado: <directiva1>
+NombreDelEncabezado: <directiva1>, <directiva2>, …
 ```
 
-Las directivas no distinguen mayúsculas de minúsculas y tienen un argumento opcional, que puede usar tanto la sintaxis de token como la de cadena entre comillas.
-Las múltiples directivas están separadas por comas (elimina la información según corresponda).
+Si el encabezado tiene muchas directivas disponibles, no dudes en incluir múltiples bloques de sintaxis, subsecciones y explicaciones según sea necesario:
+
+```http
+NombreDelEncabezado: <directiva3>, …, <directivaN>
+```
+
+Las directivas no distinguen entre mayúsculas y minúsculas y tienen un argumento opcional que puede usar tanto la sintaxis de _token_ como la de cadena entrecomillada (_quoted-string_). Las múltiples directivas se separan por comas (elimina la información según corresponda).
 
 ## Directivas
 
 - `directiva1`
-  - : Incluye una breve descripción de la directiva y lo que hace aquí.
+  - : Incluye aquí una breve descripción de la directiva y lo que hace.
     Incluye un término y una definición para cada directiva.
 - `directiva2`
   - : etc.
 
-Si el encabezado tiene muchas directivas disponibles, siéntete libre de incluir múltiples listas de definiciones, subsecciones y explicaciones según corresponda.
+Si el encabezado tiene muchas directivas disponibles, puedes incluir múltiples listas de definiciones, subsecciones y explicaciones según sea necesario.
+
+## Descripción
+
+Si hay demasiado contenido para incluirlo en los párrafos iniciales, proporciona aquí todo el detalle necesario, como información de trasfondo, consejos de uso y enlaces a la documentación. Este es un buen lugar para señalar si los patrones del mundo real difieren de lo especificado, en caso de que las implementaciones ampliamente desplegadas se desvíen de lo descrito en las especificaciones.
 
 ## Ejemplos
 
-Nota que usamos el plural "Ejemplos" incluso si la página solo contiene un ejemplo.
+Ten en cuenta que usamos el plural "Ejemplos" incluso si la página solo contiene un ejemplo.
 
 ### Un encabezado descriptivo
 
-Cada ejemplo debe tener un encabezado H3 (###) que nombre el ejemplo. El encabezado debe ser descriptivo de lo que está haciendo el ejemplo. Por ejemplo, "Un ejemplo simple" no dice nada sobre el ejemplo y por lo tanto, no es un buen encabezado. El encabezado debe ser conciso. Para una descripción más larga, usa el párrafo después del encabezado.
+Cada ejemplo **debe** tener un encabezado H3 (`###`) que nombre el ejemplo. El encabezado debe ser descriptivo de lo que hace el ejemplo. Por ejemplo, "Un ejemplo simple" no dice nada sobre el ejemplo y, por lo tanto, no es un buen encabezado. El encabezado debe ser conciso. Para una descripción más larga, usa el párrafo después del encabezado.
 
-Consulta nuestra guía sobre cómo agregar [ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples) para obtener más información.
+Consulta nuestra guía sobre cómo añadir [ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples) para más información.
 
 > [!NOTE]
 > A veces querrás enlazar a ejemplos dados en otra página.
 >
 > **Escenario 1:** Si tienes algunos ejemplos en esta página y algunos más en otra página:
 >
-> Incluye un encabezado H3 (`###`) para cada ejemplo en esta página y luego un encabezado H3 (`###`) final con el texto "Más ejemplos", debajo del cual puedes enlazar a los ejemplos en otras páginas. Por ejemplo:
+> Incluye un encabezado H3 (`###`) para cada ejemplo en esta página y luego un encabezado H3 final (`###`) con el texto "Más ejemplos", bajo el cual puedes enlazar a los ejemplos en otras páginas. Por ejemplo:
 >
 > ```md
 > ## Ejemplos
 >
-> ### Usando la API fetch
+> ### Uso de la API fetch
 >
 > Ejemplo de Fetch
 >
@@ -147,14 +165,14 @@ Consulta nuestra guía sobre cómo agregar [ejemplos de código](/es/docs/MDN/Wr
 > Enlaces a más ejemplos en otras páginas
 > ```
 >
-> **Escenario 2:** Si solo tienes ejemplos en otra página y ninguno en esta página:
+> **Escenario 2:** Si _solo_ tienes ejemplos en otra página y ninguno en esta:
 >
-> No agregues ningún encabezado H3; simplemente agrega los enlaces directamente debajo del encabezado H2 "Ejemplos". Por ejemplo:
+> No añadas encabezados H3; simplemente añade los enlaces directamente bajo el encabezado H2 "Ejemplos". Por ejemplo:
 >
 > ```md
 > ## Ejemplos
 >
-> Para ejemplos de esta API, consulta [la página sobre fetch()](https://example.org).
+> Para ver ejemplos de esta API, consulta [la página sobre fetch()](https://example.org/).
 > ```
 
 ## Especificaciones
@@ -165,13 +183,20 @@ _Para usar esta macro, elimina las comillas invertidas y la barra invertida en e
 
 ## Compatibilidad con navegadores
 
+_Si el navegador no tiene un manejo específico para el encabezado, elimina la macro de abajo._
+_De lo contrario, para usar esta macro, elimina las comillas invertidas y la barra invertida en el archivo markdown._
+
 `\{{Compat}}`
 
-_Para usar esta macro, elimina las comillas invertidas y la barra invertida en el archivo markdown._
+_Si el navegador tiene un manejo específico para el encabezado, elimina el texto de abajo:_
+
+Este encabezado no tiene una integración con el agente de usuario definida por la especificación (la "compatibilidad con navegadores" no se aplica).
+Los desarrolladores pueden establecer y obtener encabezados HTTP usando `fetch()` para proporcionar un comportamiento de implementación específico de la aplicación.
 
 ## Véase también
 
-Incluye enlaces a páginas de referencia y guías relacionadas con el encabezado HTTP actual. Para obtener más pautas, consulta la [sección Ver también](/es/docs/MDN/Writing_guidelines/Writing_style_guide#see_also_section) en la _Guía de estilo de escritura_.
+Incluye enlaces a páginas de referencia y guías relacionadas con el encabezado HTTP actual. Para más pautas, consulta la [sección Véase también](/es/docs/MDN/Writing_guidelines/Writing_style_guide#seccion_vease_tambien) en la _Guía de estilo de escritura_.
+Puedes enlazar a estados de respuesta relevantes como `\{{HTTPStatus("123", "123 Motivo")}}` y encabezados como `\{{HTTPHeader("Nombre-Del-Encabezado")}}`. Puedes agrupar estados y encabezados relacionados en un solo elemento de la lista para mayor brevedad.
 
 - enlace1
 - enlace2


### PR DESCRIPTION
Fixes #35422

Toma el trabajo de #35548 (@GNUXDAR) y aplica las correcciones pendientes:

- Añade el bloque `[!NOTE]` explicativo (traducido del inglés), que faltaba en el archivo
- Corrige 4 macros `{{Glossary(...)}}` en la tabla de propiedades: el primer argumento debe ser el término en inglés (p. ej., `{{Glossary("Request header", "Encabezado de solicitud")}}`)
- `## Ver también` → `## Véase también` con la ancla correcta `#seccion_vease_tambien`