### PR TITLE
[ja] fix: サイズを指定しで → サイズを指定して

### DIFF
--- a/files/ja/web/api/canvasrenderingcontext2d/fillrect/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/fillrect/index.md
@@ -18,7 +18,7 @@ l10n:
 fillRect(x, y, width, height)
 ```
 
-`fillRect()` メソッドは塗りつぶした矩形を、 `(x, y)` を始点とし、 `width` と `height` でサイズを指定しで描画します。塗りつぶしのスタイルは、現在の `fillStyle` 属性によって決定されます。
+`fillRect()` メソッドは塗りつぶした矩形を、 `(x, y)` を始点とし、 `width` と `height` でサイズを指定して描画します。塗りつぶしのスタイルは、現在の `fillStyle` 属性によって決定されます。
 
 ### 引数
 


### PR DESCRIPTION
### Description

Fix a typo ("指定しで" → "指定して") in the Japanese translation of the CanvasRenderingContext2D.fillRect() page.

### Motivation

The sentence had a kana typo ("しで" instead of "して"), which made the description read incorrectly. This fixes it for Japanese readers.

### Additional details

- File: files/ja/web/api/canvasrenderingcontext2d/fillrect/index.md
- Changed the method description: 「…サイズを指定しで描画します。」→「…サイズを指定して描画します。」
- The original English source did not have this issue; it was a typo introduced only in the Japanese translation.
- Translation-only fix; no change to the English source or page structure.