### PR TITLE
fix(zh-cn): correct markdown formatting and translation in WebSocket()

### DIFF
--- a/files/zh-cn/web/api/websocket/websocket/index.md
+++ b/files/zh-cn/web/api/websocket/websocket/index.md
@@ -5,7 +5,7 @@ slug: Web/API/WebSocket/WebSocket
 
 {{APIRef("WebSockets API")}}{{AvailableInWorkers}}
 
-**`WebSocket()`**构造函器会返回一个 {{domxref("WebSocket")}} 对象。
+**`WebSocket()`** 构造函数会返回一个 {{domxref("WebSocket")}} 对象。
 
 ## 语法
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
- Add a missing space after **`WebSocket()`** to fix bold text rendering.
- Correct the translation of "constructor" from "构造函器" to "构造函数".
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
None.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
None.
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
None.
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
