### PR TITLE
fix(zh-cn): correct markdown formatting and translation in WebSocket.extensions doc

### DIFF
--- a/files/zh-cn/web/api/websocket/extensions/index.md
+++ b/files/zh-cn/web/api/websocket/extensions/index.md
@@ -5,9 +5,7 @@ slug: Web/API/WebSocket/extensions
 
 {{APIRef("Web Sockets API")}}
 
-**`WebSocket.extensions`**是只读属性，返回服务器已选择的扩展值。目前，链接可以协定的扩展值只有空字符串或者一个扩展列表。
-
-The **`WebSocket.extensions`** read-only property returns the extensions selected by the server. This is currently only the empty string or a list of extensions as negotiated by the connection.
+**`WebSocket.extensions`** 是只读属性，返回服务器已选择的扩展值。目前，链接可以协定的扩展值只有空字符串或者一个扩展列表。
 
 ## 语法
 
@@ -17,7 +15,7 @@ var extensions = aWebSocket.extensions;
 
 ## 返回值
 
-A {{jsxref("String")}}.
+一个 {{jsxref("String")}}.
 
 ## 规范
 

--- a/files/zh-cn/web/api/websocket/extensions/index.md
+++ b/files/zh-cn/web/api/websocket/extensions/index.md
@@ -1,21 +1,18 @@
 ---
-title: WebSocket.extensions
+title: WebSocket：extensions 属性
+short-title: extensions
 slug: Web/API/WebSocket/extensions
+l10n:
+  sourceCommit: fb311d7305937497570966f015d8cc0eb1a0c29c
 ---
 
-{{APIRef("Web Sockets API")}}
+{{APIRef("Web Sockets API")}}{{AvailableInWorkers}}
 
-**`WebSocket.extensions`** 是只读属性，返回服务器已选择的扩展值。目前，链接可以协定的扩展值只有空字符串或者一个扩展列表。
+**`WebSocket.extensions`** 只读属性返回服务器已选择的扩展。目前，该属性的值仅为空字符串或连接协商确定的扩展列表。
 
-## 语法
+## 值
 
-```plain
-var extensions = aWebSocket.extensions;
-```
-
-## 返回值
-
-一个 {{jsxref("String")}}.
+一个字符串。
 
 ## 规范
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
- Add a missing space after **`WebSocket.extensions`** to fix bold text rendering.
- Delete the original English text.
- Translate “A” into "一个“


<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
None.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
None.
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
None.
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
