### PR TITLE
Fix broken internal anchors in writing guidelines [es]

### DIFF
--- a/files/es/mdn/writing_guidelines/page_structures/feature_status/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/feature_status/index.md
@@ -15,7 +15,7 @@ Es uno de los siguientes:
 
 > [!WARNING]
 > No actualices manualmente los estados de las características en el repositorio `mdn/content`.
-> La documentación se [actualiza automáticamente](#how_feature_statuses_are_added_or_updated) a partir de la información del repositorio `mdn/browser-compat-data` en GitHub.
+> La documentación se [actualiza automáticamente](#¿cómo_se_agregan_o_actualizan_los_estados_de_las_características) a partir de la información del repositorio `mdn/browser-compat-data` en GitHub.
 
 Si no se aplica ninguno de los estados anteriores, la característica se considera _estable y estándar_.
 Para más información sobre estos términos, consulta la página ["Experimental, obsoleta y en desuso"](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete).

--- a/files/es/mdn/writing_guidelines/page_structures/links/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/links/index.md
@@ -20,7 +20,7 @@ MDN ofrece macros que crean una lista de enlaces:
 - [`\{{QuickLinksWithSubpages()}}`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/quick_links_with_subpages.rs)
   - : Crea un conjunto de enlaces rápidos usando las páginas secundarias de la página actual (o de la página especificada) como destinos. Esto crea listas jerárquicas de hasta dos niveles de profundidad. Los títulos de las páginas se utilizan como texto del enlace y sus resúmenes como información emergente (tooltips).
 
-Por ejemplo, para incluir una lista ordenada de enlaces que incluya esta página y sus páginas relacionadas, escribe lo siguiente:
+Por ejemplo, para incluir una lista ordenada de enlaces que incluya esta página y sus páginas hermanas, escribe lo siguiente:
 
 ```md
 \{{ListSubpagesForSidebar("/es/docs/MDN/Writing_guidelines/Page_structures/Macros", 1)}}
@@ -53,7 +53,7 @@ Por eso, usar macros para agregar enlaces es rápido y fácil.
 
 ### Personalizar el texto visible
 
-Por defecto, el texto visible del enlace es el primer parámetro que se pasa a la macro. Para mostrar un texto diferente, usa el segundo parámetro. Por ejemplo, `\{{JSxRef("Array")}}` genera {{JSxRef("Array")}}. Para mostrar una variación de ese texto, usa `\{{JSxRef("Array", "JavaScript arrays")}}`, que genera {{JSxRef("Array", "JavaScript arrays")}}. Notarás que el enlace resultante tiene formato de código debido al comportamiento por defecto de la macro. Consulta la sección [Desactivar el formato de código](#disabling_code_formatting) para ver cómo omitir el estilo de código.
+Por defecto, el texto visible del enlace es el primer parámetro que se pasa a la macro. Para mostrar un texto diferente, usa el segundo parámetro. Por ejemplo, `\{{JSxRef("Array")}}` genera {{JSxRef("Array")}}. Para mostrar una variación de ese texto, usa `\{{JSxRef("Array", "JavaScript arrays")}}`, que genera {{JSxRef("Array", "JavaScript arrays")}}. Notarás que el enlace resultante tiene formato de código debido al comportamiento por defecto de la macro. Consulta la sección [Desactivar el formato de código](#desactivar_el_formato_de_código) para ver cómo omitir el estilo de código.
 
 ### Enlazar a páginas anidadas
 

--- a/files/es/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -12,7 +12,7 @@ Esta característica permite a los lectores comprender exactamente qué producir
 El sistema de ejemplos en vivo puede procesar bloques de código escritos en HTML, CSS y JavaScript, sin importar el orden en el que estén escritos en la página.
 Esto garantiza que la salida corresponda al código fuente combinado, ya que el sistema ejecuta el código directamente dentro de la página.
 
-A diferencia de los [Ejemplos interactivos](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples#what_types_of_code_example_are_on_mdn), los ejemplos en vivo no proporcionan soporte integrado para capturar registros de consola o restablecer ejemplos que han sido modificados por la entrada del usuario.
+A diferencia de los [Ejemplos interactivos](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples#¿qué_tipos_de_ejemplos_de_código_hay_en_mdn), los ejemplos en vivo no proporcionan soporte integrado para capturar registros de consola o restablecer ejemplos que han sido modificados por la entrada del usuario.
 La sección [Ejemplos](#ejemplos) muestra cómo puedes implementar estas y otras características útiles.
 
 ## ¿Cómo funcionan los ejemplos en vivo?


### PR DESCRIPTION
## Description
Applies review feedback that was left unresolved when the original PRs were merged.

## Changes
- Fix broken internal anchor in `live_samples/index.md` — unresolved review comment from the PR for #35404.
- Fix broken internal anchor in `feature_status/index.md` — unresolved review comment from the PR for #35401.
- Fix broken internal anchor in `links/index.md` — unresolved review comment from the PR for #35403.

## Related
Follow-up to #35404, #35401, #35403. Part of #35373.