### PR TITLE
chore(fr): translation of `Web/API/AbstractRange/endContainer`

### DIFF
--- a/files/fr/web/api/abstractrange/endcontainer/index.md
+++ b/files/fr/web/api/abstractrange/endcontainer/index.md
@@ -1,0 +1,35 @@
+---
+title: "AbstractRange : propriété endContainer"
+short-title: endContainer
+slug: Web/API/AbstractRange/endContainer
+l10n:
+  sourceCommit: f314991b236fce81b712a6df59e4643de0f98449
+---
+
+{{APIRef("DOM")}}
+
+La propriété en lecture seule **`endContainer`** de l'interface {{DOMxRef("AbstractRange")}} retourne le {{DOMxRef("Node")}} dans lequel se trouve la fin de la plage.
+
+Pour modifier la position de fin, utilisez la méthode {{DOMxRef("Range.setEnd()")}} ou une méthode similaire.
+
+## Valeur
+
+L'objet {{DOMxRef("Node")}} qui contient le dernier caractère de la plage.
+
+## Exemples
+
+```js
+const plage = document.createRange();
+plage.setStart(startNode, startOffset);
+plage.setEnd(endNode, endOffset);
+
+const noeudFinPlage = plage.endContainer;
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/AbstractRange/endContainer`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_