### PR TITLE
chore(fr): translation of `Web/API/AbstractRange/startContainer`

### DIFF
--- a/files/fr/web/api/abstractrange/startcontainer/index.md
+++ b/files/fr/web/api/abstractrange/startcontainer/index.md
@@ -1,0 +1,35 @@
+---
+title: "AbstractRange : propriété startContainer"
+short-title: startContainer
+slug: Web/API/AbstractRange/startContainer
+l10n:
+  sourceCommit: f314991b236fce81b712a6df59e4643de0f98449
+---
+
+{{APIRef("DOM")}}
+
+La propriété en lecture seule **`startContainer`** de l'interface {{DOMxRef("AbstractRange")}} retourne le {{DOMxRef("Node")}} dans lequel se trouve le début de la plage.
+
+Pour modifier la position de début, utilisez la méthode {{DOMxRef("Range.setStart()")}} ou une méthode similaire.
+
+## Valeur
+
+L'objet {{DOMxRef("Node")}} dans lequel se trouve le début de la plage.
+
+## Exemples
+
+```js
+const plage = document.createRange();
+plage.setStart(startNode, startOffset);
+plage.setEnd(endNode, endOffset);
+
+const noeudDebutPlage = plage.startContainer;
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/AbstractRange/startContainer`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_