### PR TITLE
fix(zh-cn): correct markdown formatting and translation in WebSocket.url doc

### DIFF
--- a/files/zh-cn/web/api/websocket/url/index.md
+++ b/files/zh-cn/web/api/websocket/url/index.md
@@ -1,21 +1,18 @@
 ---
-title: WebSocket.url
+title: WebSocket：url 属性
+short-title: url
 slug: Web/API/WebSocket/url
+l10n:
+  sourceCommit: fb311d7305937497570966f015d8cc0eb1a0c29c
 ---
 
 {{APIRef("Web Sockets API")}}
 
-**`WebSocket.url`** 是一个只读属性，返回值为当构造函数创建{{domxref("WebSocket")}}实例对象时 URL 的绝对路径。
+**`WebSocket.url`** 只读属性返回由构造函数解析出的 {{domxref("WebSocket")}} 的绝对 URL。
 
-## 语法
+## 值
 
-```plain
-var url = aWebSocket.url;
-```
-
-## 返回值
-
-一个 [`DOMString`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/String)。
+一个字符串。
 
 ## 规范
 

--- a/files/zh-cn/web/api/websocket/url/index.md
+++ b/files/zh-cn/web/api/websocket/url/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: fb311d7305937497570966f015d8cc0eb1a0c29c
 ---
 
-{{APIRef("Web Sockets API")}}
+{{APIRef("WebSockets API")}}{{AvailableInWorkers}}
 
 **`WebSocket.url`** 只读属性返回由构造函数解析出的 {{domxref("WebSocket")}} 的绝对 URL。
 

--- a/files/zh-cn/web/api/websocket/url/index.md
+++ b/files/zh-cn/web/api/websocket/url/index.md
@@ -5,9 +5,7 @@ slug: Web/API/WebSocket/url
 
 {{APIRef("Web Sockets API")}}
 
-The **`WebSocket.url`** read-only property returns the absolute URL of the {{domxref("WebSocket")}} as resolved by the constructor.
-
-**`WebSocket.url`**是一个只读属性，返回值为当构造函数创建{{domxref("WebSocket")}}实例对象时 URL 的绝对路径。
+**`WebSocket.url`** 是一个只读属性，返回值为当构造函数创建{{domxref("WebSocket")}}实例对象时 URL 的绝对路径。
 
 ## 语法
 
@@ -17,7 +15,7 @@ var url = aWebSocket.url;
 
 ## 返回值
 
-A [`DOMString`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/String).
+一个 [`DOMString`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/String)。
 
 ## 规范
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
- Add a missing space after `WebSocket.url` to fix bold text rendering.
- Delete the original English text.
- Translate “A” into "一个“.
- Fix punctuation.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
