### PR TITLE
chore(fr): add notice banner for deprecated framework sections in leaning area

### DIFF
--- a/files/fr/learn_web_development/core/frameworks_libraries/index.md
+++ b/files/fr/learn_web_development/core/frameworks_libraries/index.md
@@ -2,7 +2,7 @@
 title: Comprendre les frameworks JavaScript côté client
 slug: Learn_web_development/Core/Frameworks_libraries
 l10n:
-  sourceCommit: 04158640487c17d515de8078c9307a2f906377d0
+  sourceCommit: f5be60d013af8bfa3ff9db9a12c3c72fc7eb3988
 ---
 
 {{NextMenu("Learn_web_development/Core/Frameworks_libraries/Introduction", "Learn_web_development/Core")}}
@@ -61,6 +61,9 @@ Votre code n'en sera que de meilleure qualité et plus professionnel, et vous se
   - : Notre dernier article vous fournit une liste de ressources sur React que vous pouvez utiliser pour aller plus loin dans votre apprentissage.
 
 ## Autres choix de frameworks
+
+> [!NOTE]
+> Cette section de MDN n'est plus maintenue et sera supprimée du site Web dans 2 mois (d'ici le 20 août 2026). Le contenu sera archivé dans le [MDN Museum <sup>(angl.)</sup>](https://github.com/mdn/museum). Voir [cette discussion <sup>(angl.)</sup>](https://github.com/orgs/mdn/discussions/827) pour plus d'informations.
 
 ### Tutoriels sur Ember
 

--- a/files/fr/learn_web_development/core/frameworks_libraries/vue_getting_started/index.md
+++ b/files/fr/learn_web_development/core/frameworks_libraries/vue_getting_started/index.md
@@ -1,12 +1,12 @@
 ---
 title: Prise en main de Vue
 slug: Learn_web_development/Core/Frameworks_libraries/Vue_getting_started
-original_slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_getting_started
 ---
 
-{{LearnSidebar}}
-
 {{PreviousMenuNext("Learn_web_development/Core/Frameworks_libraries/Ember_resources","Learn_web_development/Core/Frameworks_libraries/Vue_first_component", "Learn_web_development/Core/Frameworks_libraries")}}
+
+> [!NOTE]
+> Cette section de MDN n'est plus maintenue et sera supprimée du site Web dans 2 mois (d'ici le 20 août 2026). Le contenu sera archivé dans le [MDN Museum <sup>(angl.)</sup>](https://github.com/mdn/museum). Voir [cette discussion <sup>(angl.)</sup>](https://github.com/orgs/mdn/discussions/827) pour plus d'informations.
 
 Présentons Maintenant Vue, le troisième de nos cadres. Dans cet article, nous allons examiner un peu de fond Vue, apprendre à l'installer et créer un nouveau projet, étudier la structure de haut niveau de l'ensemble du projet et un composant individuel, voir comment exécuter le projet localement, et le préparer à commencer à construire notre exemple.
 


### PR DESCRIPTION
### Description

Attention, les framework Angular, Ember, Svelte et Vue ne seront plus pris en charge dans la section « Apprendre » du MDN à partir du 20 Août 2026 et seront déplacés dans le musée du MDN (uniquement en anglais).

De ce fait, nous ajoutons les bannière temporaires sur les quelques pages qui en ont besoin, cependant, la majorité n'ayant pas été traduites, nous ne créerons pas les pages de ces sections du fait que le contenu est déprécié ou daté par rapport aux versions actuelles de ces cadriciels et qu'ils ont déjà leur propre documentation.

Si vous souhaitez d'avantage vous informer sur ces derniers, nous ne pouvons que vous conseiller de lire les documentations officielles.

### Motivation

Follows deprecation warning in en-us for frameworks.

### Additional details

_none_

### Related issues and pull requests

_none_
