### PR TITLE
search イベントの説明を明確化

### DIFF
--- a/files/ja/web/api/htmlinputelement/search_event/index.md
+++ b/files/ja/web/api/htmlinputelement/search_event/index.md
@@ -10,7 +10,7 @@ l10n:
 
 **`search`** イベントは、 {{HTMLElement("input")}} 要素の `type="search"` にて検索が開始されたときに発生します。
 
-検索を開始する方法はいくつかあり、例えば、 {{HTMLElement("input")}} にフォーカスがある時に <kbd>Enter</kbd> を押したり、[`incremental`](/ja/docs/Web/HTML/Reference/Elements/input#attr-incremental) 属性が存在すれば、最も新しいキー入力から UA 定義のタイムアウト時間が経過してから検索が開始されます（新しくキー入力をするとタイムアウトがリセットされるので、イベントが繰り返して発生します）。
+検索を開始する方法はいくつかあり、例えば、 {{HTMLElement("input")}} にフォーカスがある時に <kbd>Enter</kbd> を押したり、[`incremental`](/ja/docs/Web/HTML/Reference/Elements/input#attr-incremental) 属性が存在すれば、最も新しいキー入力から UA 定義のタイムアウト時間が経過してから検索が開始されます（新しくキー入力をするたびにタイムアウトがリセットされ、そのタイムアウト時間が経過するまでイベントは発生しません）。
 
 現在 UA が `<input type="search">` を実装している方法では、フィールド内をクリアするために追加のコントロールを置きます。このコントロールを使用しても `search` イベントが発生します。この場合、 {{HTMLElement("input")}} 要素の `value` は空文字列になります。
 


### PR DESCRIPTION
## Summary

`incremental` 属性がある場合の `search` イベントについて、キー入力のたびにイベントが繰り返し発生するようにも読める説明を修正しました。

新しいキー入力でタイムアウトがリセットされ、タイムアウト時間が経過するまでイベントが発生しないことを明記しています。

Fixes #30141

## Validation

- 英語版の説明およびIssueの提案内容と照合
- `git diff --check` 実行済み
- 文書のみの変更