### PR TITLE
fix(zh-CN): correct exponentiation example result

### DIFF
--- a/files/zh-cn/learn_web_development/core/scripting/math/index.md
+++ b/files/zh-cn/learn_web_development/core/scripting/math/index.md
@@ -175,7 +175,7 @@ myNumber = Number(myNumber) + 3;
         </p>
       </td>
       <td>
-        <code>5 ** 2</code>（返回 <code>3125</code>，相当于
+        <code>5 ** 2</code>（返回 <code>25</code>，相当于
         <code>5 * 5</code> 。）
       </td>
     </tr>

--- a/files/zh-cn/learn_web_development/core/scripting/math/index.md
+++ b/files/zh-cn/learn_web_development/core/scripting/math/index.md
@@ -15,7 +15,7 @@ l10n:
     <tr>
       <th scope="row">前提：</th>
       <td>
-        初步了解 <a href="/zh-CN/docs/Learn_web_development/Core/Structuring_content">HTML</a> 和 <a href="/zh-CN/docs/Learn_web_development/Core/Styling_basics">CSS</a>。</td>。
+        初步了解 <a href="/zh-CN/docs/Learn_web_development/Core/Structuring_content">HTML</a> 和 <a href="/zh-CN/docs/Learn_web_development/Core/Styling_basics">CSS</a>。
       </td>
     </tr>
     <tr>
@@ -162,9 +162,9 @@ myNumber = Number(myNumber) + 3;
       <td><code>%</code></td>
       <td>求余（有时候也叫取模）</td>
       <td>
-        <p>在你将左边的数分成同右边数字相同的若干整数部分后，返回剩下的余数</p>
+        <p>在将左边的数分成同右边数字相同的若干整数部分后，返回剩下的余数</p>
       </td>
-      <td><code>8 % 3</code>（返回 2，因为 3 可以被 8 整除两次，还剩余 2。）</td>
+      <td><code>8 % 3</code>（返回 2，因为 3 可以被 8 整除两次，还剩余 2）。</td>
     </tr>
     <tr>
       <td><code>**</code></td>
@@ -176,7 +176,7 @@ myNumber = Number(myNumber) + 3;
       </td>
       <td>
         <code>5 ** 2</code>（返回 <code>25</code>，相当于
-        <code>5 * 5</code> 。）
+        <code>5 * 5</code> ）。
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Corrects the result of `5 ** 2` from `3125` to `25` in the zh-CN JavaScript Math article.

### Motivation

The current example shows an incorrect result and may confuse readers learning the exponentiation operator.

### Additional details

None

### Related issues and pull requests

Fixes #37012
