### PR TITLE
[zh-cn]: update the translation of SVG `<desc>` element

### DIFF
--- a/files/zh-cn/web/svg/reference/element/desc/index.md
+++ b/files/zh-cn/web/svg/reference/element/desc/index.md
@@ -1,31 +1,53 @@
 ---
-title: desc
+title: <desc>
 slug: Web/SVG/Reference/Element/desc
+l10n:
+  sourceCommit: ac806e34aba086be141689c64dc4dd73636fbd62
 ---
 
-SVG 绘画中的每个容器元素或图形元素都可以提供一个`desc`描述性字符串，这些描述只是纯文本的。如果当前的 SVG 文档片段在视媒体中呈现，desc 元素不会呈现为图形的一部分。替代性提词既可以看到也可以听到，它显示了 desc 元素但是不会显示路径元素或者别的图形元素。`desc`元素提升了 SVG 文档的无障碍。
+**`<desc>`** [SVG](/zh-CN/docs/Web/SVG) 元素为任意 SVG [容器元素](/zh-CN/docs/Web/SVG/Reference/Element#容器元素)或[图形元素](/zh-CN/docs/Web/SVG/Reference/Element#图形元素)提供可访问的长文本描述。
+
+`<desc>` 元素中的文本不会作为图形的一部分被渲染。如果元素可以用可见文本来描述，则可以通过 [`aria-describedby`](/zh-CN/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) 属性引用该文本。如果使用了 `aria-describedby`，它将优先于 `<desc>`。
+
+也可以在 `aria-describedby` 值中使用多个 ID，将 `<desc>` 元素的隐藏文本与其他元素的可见文本拼接起来。在这种情况下，`<desc>` 元素必须提供一个供引用的 ID。
 
 ## 使用上下文
 
 {{svginfo}}
 
-## 示例
-
 ## 属性
 
-### 全局属性
-
-- [核心属性](/zh-CN/docs/Web/SVG/Reference/Attribute#core) »
-- {{ SVGAttr("class") }}
-- {{ SVGAttr("style") }}
-
-### 专有属性
-
-_没有专有属性。_
+此元素仅包含全局属性。
 
 ## DOM 接口
 
-该元素实现了 `SVGDescElement` 接口。
+该元素实现了 {{domxref("SVGDescElement")}} 接口。
+
+## 示例
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="5" cy="5" r="4">
+    <desc>
+      我是一个圆，这段描述用来演示如何描述我，但对于像我这样简单的圆，真的有必要描述吗？
+    </desc>
+  </circle>
+</svg>
+```
+
+{{EmbedLiveSample("示例", 150, "100%")}}
+
+## 规范
+
+{{Specifications}}
 
 ## 浏览器兼容性
 
@@ -33,4 +55,4 @@ _没有专有属性。_
 
 ## 参见
 
-- {{ SVGElement("title") }}
+- {{SVGElement("title")}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/desc
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/svg/reference/element/desc/index.md
* Last commit: https://github.com/mdn/content/commit/ac806e34aba086be141689c64dc4dd73636fbd62
