### PR TITLE
[zh-cn]: update the translation of SVG `<title>` element

### DIFF
--- a/files/zh-cn/web/svg/reference/element/title/index.md
+++ b/files/zh-cn/web/svg/reference/element/title/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: ac806e34aba086be141689c64dc4dd73636fbd62
 ---
 
-**`<title>`** [SVG](/zh-CN/docs/Web/SVG) 元素为任意 SVG [容器元素](/zh-CN/docs/Web/SVG/Reference/Element#容器元素)或[图形元素](/zh-CN/docs/Web/SVG/Reference/Element#图形元素)提供可访问的短文本描述。
+**`<title>`** [SVG](/zh-CN/docs/Web/SVG) 元素为任意 SVG [容器元素](/zh-CN/docs/Web/SVG/Reference/Element#容器元素)或[图形元素](/zh-CN/docs/Web/SVG/Reference/Element#图形元素)提供无障碍的短文本描述。
 
 `<title>` 元素中的文本不会作为图形的一部分被渲染，但浏览器通常会将其显示为工具提示。如果元素可以用可见文本来描述，则建议使用 [`aria-labelledby`](/zh-CN/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) 属性引用该文本，而不是使用 `<title>` 元素。
 

--- a/files/zh-cn/web/svg/reference/element/title/index.md
+++ b/files/zh-cn/web/svg/reference/element/title/index.md
@@ -1,45 +1,56 @@
 ---
-title: title
+title: <title> — SVG 无障碍名称元素
 slug: Web/SVG/Reference/Element/title
+l10n:
+  sourceCommit: ac806e34aba086be141689c64dc4dd73636fbd62
 ---
 
-SVG 绘图中的每个窗口元素或图形元素都可以提供一个`title`描述性字符串，该描述只能是纯文本。如果当前的 SVG 文档片段在可视媒体中呈现为 SVG，title 元素不会呈现为绘图的一部分。然而，一些用户代理可能会，举个例子，把`title`显示为一个提示冒泡。替代性提词既可以看到也可以听到，它显示了 title 元素但是不会显示路径元素或者别的图形元素。`title`元素通常提升了 SVG 文档的无障碍。
+**`<title>`** [SVG](/zh-CN/docs/Web/SVG) 元素为任意 SVG [容器元素](/zh-CN/docs/Web/SVG/Reference/Element#容器元素)或[图形元素](/zh-CN/docs/Web/SVG/Reference/Element#图形元素)提供可访问的短文本描述。
 
-通常`title`元素必须是它的父元素的第一个子元素。注意，只有当`title`是它的父元素的第一个子元素的时候，那些编译器才会把`title`显示为一个提示冒泡。
+`<title>` 元素中的文本不会作为图形的一部分被渲染，但浏览器通常会将其显示为工具提示。如果元素可以用可见文本来描述，则建议使用 [`aria-labelledby`](/zh-CN/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) 属性引用该文本，而不是使用 `<title>` 元素。
+
+> [!NOTE]
+> 为与 SVG 1.1 保持向后兼容，`<title>` 元素应作为其父元素的第一个子元素。
 
 ## 使用上下文
 
 {{svginfo}}
 
-## 示例
-
-下面的代码片段显示了 SVG `<title>`标签的用法。
-
-```xml
-<svg width="500" height="300" xmlns="http://www.w3.org/2000/svg">
-  <g>
-    <title>SVG Title Demo example</title>
-    <rect x="10" y="10" width="200" height="50"
-    style="fill:none; stroke:blue; stroke-width:1px"/>
-  </g>
-</svg>
-```
-
 ## 属性
 
-### 全局属性
-
-- [核心属性](/zh-CN/docs/Web/SVG/Reference/Attribute#core) »
-- {{ SVGAttr("class") }}
-- {{ SVGAttr("style") }}
-
-### 专有属性
-
-_没有专有属性。_
+此元素仅包含全局属性。
 
 ## DOM 接口
 
-该元素实现了 [`SVGTitleElement`](/zh-CN/docs/DOM/SVGTitleElement) 接口。
+该元素实现了 {{domxref("SVGTitleElement")}} 接口。
+
+## 示例
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="5" cy="5" r="4">
+    <title>我是一个圆</title>
+  </circle>
+
+  <rect x="11" y="1" width="8" height="8">
+    <title>我是一个正方形</title>
+  </rect>
+</svg>
+```
+
+{{EmbedLiveSample("示例", 150, "100%")}}
+
+## 规范
+
+{{Specifications}}
 
 ## 浏览器兼容性
 
@@ -47,4 +58,4 @@ _没有专有属性。_
 
 ## 参见
 
-- {{ SVGElement("desc") }}
+- {{SVGElement("desc")}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/title
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/svg/reference/element/title/index.md
* Last commit: https://github.com/mdn/content/commit/ac806e34aba086be141689c64dc4dd73636fbd62