### PR TITLE
[zh-cn]: update the translation of BaseAudioContext `createChannelSplitter()` method

### DIFF
--- a/files/zh-cn/web/api/baseaudiocontext/createchannelsplitter/index.md
+++ b/files/zh-cn/web/api/baseaudiocontext/createchannelsplitter/index.md
@@ -1,61 +1,65 @@
 ---
-title: AudioContext.createChannelSplitter()
+title: BaseAudioContext：createChannelSplitter() 方法
 slug: Web/API/BaseAudioContext/createChannelSplitter
+l10n:
+  sourceCommit: be8f7f155a48e11b30c240f8731afb1845f85378
 ---
 
-{{ APIRef("Web Audio API") }}
+{{APIRef("Web Audio API")}}
 
-The `createChannelSplitter()` method of the {{ domxref("AudioContext") }} Interface is used to create a {{domxref("ChannelSplitterNode")}}, which is used to access the individual channels of an audio stream and process them separately.
+{{domxref("BaseAudioContext")}} 接口的 `createChannelSplitter()` 方法用于创建一个 {{domxref("ChannelSplitterNode")}}，该节点可用于访问音频流中的各个声道并分别处理它们。
 
-## Syntax
+> [!NOTE]
+> 推荐使用 {{domxref("ChannelSplitterNode.ChannelSplitterNode", "ChannelSplitterNode()")}} 构造函数来创建 {{domxref("ChannelSplitterNode")}}；请参见[创建 AudioNode](/zh-CN/docs/Web/API/AudioNode#创建_audionode)。
 
-```js
-var audioCtx = new AudioContext();
-var splitter = audioCtx.createChannelSplitter(2);
+## 语法
+
+```js-nolint
+createChannelSplitter(numberOfOutputs)
 ```
 
 ### 参数
 
-- numberOfOutputs
-  - : 你期待将输入音频分割成的声道道数目; 当不传入参数时，默认为 6
+- `numberOfOutputs`
+  - : 你希望分别输出的输入音频流中的声道数；如果未指定此参数，默认值为 6。
 
-### Returns
+### 返回值
 
-一个 {{domxref("ChannelSplitterNode")}}.
+一个 {{domxref("ChannelSplitterNode")}}。
 
-## Example
+## 示例
 
-下面这个简单的例子告诉你怎样分割一个双声道音轨 (或者说一段音乐), 以及对于左右声道不同的处理。要使用它们，你需要用到{{domxref("AudioNode.connect(AudioNode)") }}方法的第二个和第三个参数，他们会指定链接声道源的序号和链接到的声道序号。
+下面的简单示例展示了如何分离立体声音轨（例如一段音乐），并对左右声道进行不同处理。要使用它们，你需要使用 {{domxref("AudioNode/connect", "AudioNode.connect(AudioNode)")}} 方法的第二和第三个参数，这两个参数分别用于指定连接来源声道的索引以及连接目标声道的索引。
 
 ```js
-var ac = new AudioContext();
-ac.decodeAudioData(someStereoBuffer, function (data) {
-  var source = ac.createBufferSource();
+const ac = new AudioContext();
+ac.decodeAudioData(someStereoBuffer, (data) => {
+  const source = ac.createBufferSource();
   source.buffer = data;
-  var splitter = ac.createChannelSplitter(2);
+  const splitter = ac.createChannelSplitter(2);
   source.connect(splitter);
-  var merger = ac.createChannelMerger(2);
+  const merger = ac.createChannelMerger(2);
 
-  // Reduce the volume of the left channel only
-  var gainNode = ac.createGain();
-  gainNode.gain.value = 0.5;
+  // 仅降低左声道的音量
+  const gainNode = ac.createGain();
+  gainNode.gain.setValueAtTime(0.5, ac.currentTime);
   splitter.connect(gainNode, 0);
 
-  // Connect the splitter back to the second input of the merger: we
-  // effectively swap the channels, here, reversing the stereo image.
+  // 将分离器重新连接到合并器的第二个输入：
+  // 这里实际上交换了声道，从而反转了立体声声像。
   gainNode.connect(merger, 0, 1);
   splitter.connect(merger, 1, 0);
 
-  var dest = ac.createMediaStreamDestination();
+  const dest = ac.createMediaStreamDestination();
 
-  // Because we have used a ChannelMergerNode, we now have a stereo
-  // MediaStream we can use to pipe the Web Audio graph to WebRTC,
-  // MediaRecorder, etc.
+  // 因为我们使用了 ChannelMergerNode，现在得到了一个立体声
+  // MediaStream，可用于将 Web Audio 图管道传输到 WebRTC、
+  // MediaRecorder 等。
   merger.connect(dest);
 });
 ```
 
-## 规格
+## 规范
 
 {{Specifications}}
 
@@ -65,4 +69,4 @@ ac.decodeAudioData(someStereoBuffer, function (data) {
 
 ## 参见
 
-- [Using the Web Audio API](/zh-CN/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)
+- [Web 音频 API 的运用](/zh-CN/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/createChannelSplitter
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.md
* Last commit: https://github.com/mdn/content/commit/be8f7f155a48e11b30c240f8731afb1845f85378