### PR TITLE
fix(pt-br): update stale `jsxref` references

### DIFF
--- a/files/pt-br/web/javascript/guide/meta_programming/index.md
+++ b/files/pt-br/web/javascript/guide/meta_programming/index.md
@@ -290,12 +290,12 @@ A tabela a seguir resume as traps disponíveis aos objetos do tipo Proxy. Veja a
     </tr>
     <tr>
       <td>
-        {{jsxref("Proxy/Proxy/enumerate", "handler.enumerate()")}}
+        <code>handler.enumerate()</code>
       </td>
       <td>
         Property enumeration / for...in:
         <code>for (var name in proxy) {...}</code
-        ><br />{{jsxref("Reflect.enumerate()")}}
+        ><br /><code>Reflect.enumerate()</code>
       </td>
       <td>
         <p>O método <code>enumerate</code> deve retornar um objeto.</p>

--- a/files/pt-br/web/javascript/reference/deprecated_and_obsolete_features/index.md
+++ b/files/pt-br/web/javascript/reference/deprecated_and_obsolete_features/index.md
@@ -56,12 +56,12 @@ As propriedades a seguir pertencem a instâncias de um `RegExp`, não mais ao ob
 
 ### Iterador
 
-- {{jsxref("StopIteration")}} foi descontinuado.
+- `StopIteration` foi descontinuado.
 - {{jsxref("Iterator")}} foi descontinuado.
 
 ### Métodos de objeto
 
-- {{jsxref("Object.watch", "watch")}} e {{jsxref("Object.unwatch", "unwatch")}} foram descontinuados. No lugar deles, use {{jsxref("Proxy")}} .
+- `watch` e `unwatch` foram descontinuados. No lugar deles, use {{jsxref("Proxy")}} .
 - `__iterator__` foi descontinuado.
 - `Object.prototype.__noSuchMethod__` foi descontinuado. Use {{jsxref("Proxy")}} em seu lugar.
 
@@ -69,7 +69,7 @@ As propriedades a seguir pertencem a instâncias de um `RegExp`, não mais ao ob
 
 - {{jsxref("Date.getYear", "getYear")}} e {{jsxref("Date.setYear", "setYear")}} foram afetados pelo Bug do Milênio e foram reagrupados em {{jsxref("Date.getFullYear", "getFullYear")}} e {{jsxref("Date.setFullYear", "setFullYear")}}.
 - Deve-se usar {{jsxref("Date.toISOString", "toISOString")}} ao invés do método descontinuado {{jsxref("Date.toUTCString", "toGMTString")}} em códigos novos.
-- {{jsxref("Date.toLocaleFormat", "toLocaleFormat")}} foi descontinuado.
+- `toLocaleFormat` foi descontinuado.
 
 ### Funções
 
@@ -96,7 +96,7 @@ As propriedades a seguir pertencem a instâncias de um `RegExp`, não mais ao ob
 ### Métodos de _string_
 
 - [HTML wrapper methods](/pt-BR/docs/tag/HTML%20wrapper%20methods) como {{jsxref("String.prototype.fontsize")}} e {{jsxref("String.prototype.big")}}.
-- {{jsxref("String.prototype.quote")}} foi removido do Firefox 37.
+- `String.prototype.quote` foi removido do Firefox 37.
 - parâmetros flag não padrões em {{jsxref("String.prototype.search")}}, {{jsxref("String.prototype.match")}}, e {{jsxref("String.prototype.replace")}} foram depreciados.
 
 ## _Features_ obsoletas
@@ -110,28 +110,28 @@ Estas _features_ obsoletas foram totamente removidas do JavaScript e não podem 
 
 ### Function
 
-| Property                              | Description                 |
-| ------------------------------------- | --------------------------- |
-| {{jsxref("Function.arity", "arity")}} | Number of formal arguments. |
+| Property | Description                 |
+| -------- | --------------------------- |
+| `arity`  | Number of formal arguments. |
 
 ### Array
 
-| Property                        | Description                                 |
-| ------------------------------- | ------------------------------------------- |
-| {{jsxref("Array.observe()")}}   | Asynchronously observing changes to Arrays. |
-| {{jsxref("Array.unobserve()")}} | Remove observers.                           |
+| Property            | Description                                 |
+| ------------------- | ------------------------------------------- |
+| `Array.observe()`   | Asynchronously observing changes to Arrays. |
+| `Array.unobserve()` | Remove observers.                           |
 
 ### Number
 
-- {{jsxref("Number.toInteger()")}}
+- `Number.toInteger()`
 
 ### ParallelArray
 
-- {{jsxref("ParallelArray")}}
+- `ParallelArray`
 
 ### Statements
 
-- {{jsxref("Statements/for_each...in", "for each...in")}} is deprecated. Use {{jsxref("Statements/for...of", "for...of")}} instead.
+- `for each...in` is deprecated. Use {{jsxref("Statements/for...of", "for...of")}} instead.
 - Destructuring {{jsxref("Statements/for...in", "for...in")}} is deprecated. Use {{jsxref("Statements/for...of", "for...of")}} instead.
 
 ### E4X

--- a/files/pt-br/web/javascript/reference/global_objects/float32array/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/float32array/index.md
@@ -84,7 +84,7 @@ Todos os objetos `Float32Array` herdam de {{jsxref("TypedArray", "%TypedArray%.p
   - : Retorna o último (maior) índex de um elemento dentro da array igual ao valor especificado, ou -1 se nenhum for encontrado. Veja também {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "Float32Array.prototype.map()")}}
   - : Cria uma nova array com os resultados da função chamada em cada elemento nesta array. Veja também {{jsxref("Array.prototype.map()")}}.
-- {{jsxref("TypedArray.move", "Float32Array.prototype.move()")}} {{non-standard_inline}}
+- `Float32Array.prototype.move()` {{non-standard_inline}}
   - : Versão antiga não padrão de {{jsxref("TypedArray.copyWithin", "Float32Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.reduce", "Float32Array.prototype.reduce()")}}
   - : Aplica uma função contra um acumulador e cada valor na array (da esquerda para a direita) com o intuito de reduzí-la a um único valor. Veja também {{jsxref("Array.prototype.reduce()")}}.

--- a/files/pt-br/web/javascript/reference/global_objects/generator/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/generator/index.md
@@ -55,7 +55,7 @@ Firefox (SpiderMonkey) também implementa a versão anterior do generator em [Ja
 - `Generator.prototype.next()` {{non-standard_inline}}
   - : Retorna o valor fornecido pela expressão {{jsxref("Operators/yield", "yield")}}. Isto corresponde ao `next()` do ES6.
 - `Generator.prototype.close()` {{non-standard_inline}}
-  - : Fecha o generator, então quando chamar `next()` um erro {{jsxref("StopIteration")}} será lançado. Isto corresponde ao método `return()` do ES6.
+  - : Fecha o generator, então quando chamar `next()` um erro `StopIteration` será lançado. Isto corresponde ao método `return()` do ES6.
 - `Generator.prototype.send()` {{non-standard_inline}}
   - : Usado para enviar um valor para o generator. Este valor é retordo pela expressão {{jsxref("Operators/yield", "yield")}}, e retorna o valor fornecido pelo pelo next {{jsxref("Operators/yield", "yield")}}. `send(x)` corresponde ao `next(x)` do ES6.
 - `Generator.prototype.throw()` {{non-standard_inline}}
@@ -91,7 +91,7 @@ console.log(it.next()); // throws StopIteration (Como o generator está fechado)
 
 - {{jsxref("Deprecated_and_obsolete_features", "The legacy generator function", "", 1)}}
 - {{jsxref("Deprecated_and_obsolete_features", "The legacy generator function expression", "", 1)}}
-- {{jsxref("StopIteration")}}
+- `StopIteration`
 - [The legacy Iterator protocol](/pt-BR/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features)
 
 ### ES6 generators

--- a/files/pt-br/web/javascript/reference/global_objects/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/index.md
@@ -54,7 +54,7 @@ Estes são objetos básicos e fundamentais nos quais todos os outros objetos sã
 - {{jsxref("InternalError")}}
 - {{jsxref("RangeError")}}
 - {{jsxref("ReferenceError")}}
-- {{jsxref("StopIteration")}}
+- `StopIteration`
 - {{jsxref("SyntaxError")}}
 - {{jsxref("TypeError")}}
 - {{jsxref("URIError")}}
@@ -88,7 +88,7 @@ Estes objetos representam coleções de dados que são ordenados pelo valor de u
 - [`Uint32Array`](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array)
 - [`Uint8Array`](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)
 - [`Uint8ClampedArray`](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray)
-- {{jsxref("ParallelArray")}} {{non-standard_inline()}}
+- `ParallelArray` {{non-standard_inline()}}
 
 ### Coleções chaveadas
 
@@ -130,8 +130,8 @@ Adições ao core do ECMAScript para funcionalidades sensíveis à linguagem.
 ### Objetos não-padrão
 
 - {{jsxref("Iterator")}} {{non-standard_inline}}
-- {{jsxref("ParallelArray")}} {{non-standard_inline}}
-- {{jsxref("StopIteration")}} {{non-standard_inline}}
+- `ParallelArray` {{non-standard_inline}}
+- `StopIteration` {{non-standard_inline}}
 
 ### Outros
 

--- a/files/pt-br/web/javascript/reference/global_objects/int16array/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/int16array/index.md
@@ -84,7 +84,7 @@ Todos `Int16Array` objetos herdam de {{jsxref("TypedArray", "%TypedArray%.protot
   - : Retorna o último (maior) índice de um elemento dentro da matriz igual ao valor especificado ou -1 se nenhum for encontrado. Veja também {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "Int16Array.prototype.map()")}}
   - : Cria uma nova matriz com os resultados da chamada de uma função fornecida em todos os elementos dessa matriz. Veja também {{jsxref("Array.prototype.map()")}}.
-- {{jsxref("TypedArray.move", "Int16Array.prototype.move()")}} {{non-standard_inline}}
+- `Int16Array.prototype.move()` {{non-standard_inline}}
   - : Versão não-padrão anterior de {{jsxref("TypedArray.copyWithin", "Int16Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.reduce", "Int16Array.prototype.reduce()")}}
   - : Aplique uma função contra um acumulador e cada valor da matriz (da esquerda para a direita) para reduzi-lo a um único valor. Veja também {{jsxref("Array.prototype.reduce()")}}.

--- a/files/pt-br/web/javascript/reference/global_objects/number/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/number/index.md
@@ -58,7 +58,7 @@ Os principais usos para o objeto `Number` são:
   - : Determina se o tipo do valor passado é inteiro.
 - {{jsxref("Number.isSafeInteger()")}} {{experimental_inline}}
   - : Determina se o tipo do valor passado é um inteiro seguro (número entre -(253 -1) e 253 -1).
-- ~~{{jsxref("Number.toInteger()")}}~~
+- ~~`Number.toInteger()`~~
   - : ~~Usado para avaliar o valor passado e convertê-lo a um inteiro (ou infinito), mas foi removido.~~
 - {{jsxref("Number.parseFloat()")}} {{experimental_inline}}
   - : O valor é o mesmo que {{jsxref("parseFloat")}} do objeto global.

--- a/files/pt-br/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -457,8 +457,8 @@ O Internet Explorer 8 implementa o método `Object.defineProperty()` para uso [a
 - {{jsxref("Object.defineProperties()")}}
 - {{jsxref("Object.propertyIsEnumerable()")}}
 - {{jsxref("Object.getOwnPropertyDescriptor()")}}
-- {{jsxref("Object.prototype.watch()")}}
-- {{jsxref("Object.prototype.unwatch()")}}
+- `Object.prototype.watch()`
+- `Object.prototype.unwatch()`
 - {{jsxref("Functions/get", "get")}}
 - {{jsxref("Functions/set", "set")}}
 - {{jsxref("Object.create()")}}

--- a/files/pt-br/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/proxy/index.md
@@ -386,7 +386,7 @@ console.log(docCookies.my_cookie1);
 - [ECMAScript Harmony Proxy proposal page](http://wiki.ecmascript.org/doku.php?id=harmony:proxies) e [ECMAScript página de semântica de proxy Harmony](http://wiki.ecmascript.org/doku.php?id=harmony:proxies_semantics)
 - [Tutorial em proxies](http://soft.vub.ac.be/~tvcutsem/proxies/)
 - [SpiderMonkey specific Old Proxy API](/pt-BR/docs/JavaScript/Old_Proxy_API)
-- {{jsxref("Object.watch()")}} É um recurso não padrão, mas foi suportado no Gecko há muito tempo.
+- `Object.watch()` É um recurso não padrão, mas foi suportado no Gecko há muito tempo.
 
 ## `Nota de licença`
 

--- a/files/pt-br/web/javascript/reference/statements/for...in/index.md
+++ b/files/pt-br/web/javascript/reference/statements/for...in/index.md
@@ -108,7 +108,7 @@ Este não é o comportamento padrão e atualmente é ignorado a partir da versã
 ## Veja também
 
 - {{jsxref("Statements/for...of", "for...of")}} - laço similar que iterage sobre os valores das propriedades.
-- {{jsxref("Statements/for_each...in", "for each in")}} - (deprecated).
+- `for each in` - (deprecated).
 - {{jsxref("Statements/for", "for")}}
 - [Generator expressions](/pt-BR/docs/Web/JavaScript/Guide/Iterators_and_generators) (uses the `for...in` syntax)
 - [Enumerability and ownership of properties](/pt-BR/docs/Web/JavaScript/Guide/Enumerability_and_ownership_of_properties)

--- a/files/pt-br/web/javascript/reference/statements/import/index.md
+++ b/files/pt-br/web/javascript/reference/statements/import/index.md
@@ -99,7 +99,7 @@ import '/modules/my-module.js';
 
 ### Importando Padrões
 
-É possível ter um padrão {{JSxRef ("Declarações / exportação", "exportação")}} (seja um objeto, uma função, uma classe etc.). A declaração de importação pode então ser usada para importar esses padrões.
+É possível ter um padrão {{jsxref("Statements/export", "exportação")}} (seja um objeto, uma função, uma classe etc.). A declaração de importação pode então ser usada para importar esses padrões.
 
 A versão mais simples importa diretamente o padrão:
 

--- a/files/pt-br/web/javascript/reference/statements/index.md
+++ b/files/pt-br/web/javascript/reference/statements/index.md
@@ -56,7 +56,7 @@ Para visualizar em ordem alfabética use a barra de rolagem à esquerda.
   - : Cria um loop que executa uma especifica instrução até que a condição de teste seja falsa. A condição é retornada depois da execução da instrução, resultando na instrução especificada executando ao menos uma vez.
 - {{jsxref("Statements/for", "for")}}
   - : Cria um loop que consiste em três opções de expressões, entre parenteses e separado por ponto e vírgula, seguido pela instrução executada no loop.
-- {{deprecated_inline}} {{non-standard_inline()}} {{jsxref("Statements/for_each...in", "for each...in")}}
+- {{deprecated_inline}} {{non-standard_inline()}} `for each...in`
   - : Itera uma variável especificada sobre todos os valores das propriedades do objeto. Para cada propriedade distinta, uma instrução especificada é executada.
 - {{jsxref("Statements/for...in", "for...in")}}
   - : Itera através de enumeráveis propriedades de um objeto, em ordem arbitrária. Para cada propriedade distinta, instruções podem ser executadas.


### PR DESCRIPTION
### Description

Update stale `jsxref` references in Portuguese, Brazilian (pt-BR) content:
- De-link removed JavaScript features (`StopIteration`, `ParallelArray`, `Object.watch`/`unwatch`/`prototype.watch()`, `Number.toInteger()`, `Reflect.enumerate()`, `for each...in`, `Function.arity`, `Date.toLocaleFormat`, `String.prototype.quote`, `Array.observe()`/`unobserve()`, `TypedArray.move`) to inline code.
- Point a translated slug at its canonical en-US sub-path (`Declarações / exportação` → `Statements/export`).

### Motivation

Ensure `jsxref` references keep resolving once rari resolves macro arguments against an index of the current `Web/JavaScript/Reference/*` pages (mdn/rari#715) instead of probing candidate URLs and silently following redirects — which will otherwise surface these stale references as broken links.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of #37059.
Related to mdn/rari#715.
