### PR TITLE
fix(fr): update stale `jsxref` references

### DIFF
--- a/files/fr/web/javascript/guide/meta_programming/index.md
+++ b/files/fr/web/javascript/guide/meta_programming/index.md
@@ -292,13 +292,13 @@ Le tableau suivant résume les différentes trappes disponibles pour les objets 
     </tr>
     <tr>
       <td>
-        {{jsxref("Proxy/Proxy/enumerate", "handler.enumerate()")}}
+        <code>handler.enumerate()</code>
       </td>
       <td>
         <p>
           Lister les propriétés avec <code>for...in</code> :
           <code>for (var nom in proxy) {...}</code
-          ><br /><br />{{jsxref("Reflect.enumerate()")}}
+          ><br /><br /><code>Reflect.enumerate()</code>
         </p>
       </td>
       <td>La méthode <code>enumerate</code> doit renvoyer un objet.</td>

--- a/files/fr/web/javascript/reference/errors/not_a_constructor/index.md
+++ b/files/fr/web/javascript/reference/errors/not_a_constructor/index.md
@@ -28,7 +28,7 @@ TypeError: Atomics is not a constructor
 
 Une variable ou un objet a été utilisé comme un constructeur alors que cet objet ou cette variable n'est pas un constructeur. Pour plus d'informations sur les constructeurs, voir la page sur [l'opérateur `new`](/fr/docs/Web/JavaScript/Reference/Operators/new).
 
-De nombreux objets globaux tels que {{jsxref("String")}} ou {{jsxref("Array")}}, sont constructibles avec `new`. Cependant, d'autres objets globaux ne le sont pas (leurs propriétés et méthodes sont statiques). Les objets standards natifs suivants ne sont pas des constructeur : {{jsxref("Math")}}, {{jsxref("JSON")}}, {{jsxref("Symbol")}}, {{jsxref("Reflect")}}, {{jsxref("Intl")}}, {{jsxref("SIMD")}}, {{jsxref("Atomics")}}.
+De nombreux objets globaux tels que {{jsxref("String")}} ou {{jsxref("Array")}}, sont constructibles avec `new`. Cependant, d'autres objets globaux ne le sont pas (leurs propriétés et méthodes sont statiques). Les objets standards natifs suivants ne sont pas des constructeur : {{jsxref("Math")}}, {{jsxref("JSON")}}, {{jsxref("Symbol")}}, {{jsxref("Reflect")}}, {{jsxref("Intl")}}, `SIMD`, {{jsxref("Atomics")}}.
 
 [Les fonctions génératrices](/fr/docs/Web/JavaScript/Reference/Statements/function*) ne peuvent pas non plus être utilisées comme des constructeurs.
 

--- a/files/fr/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/fr/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -382,8 +382,8 @@ arc.getArchive(); // [{val: 11}, {val: 13}]
 - {{jsxref("Object.defineProperties()")}}
 - {{jsxref("Object.propertyIsEnumerable()")}}
 - {{jsxref("Object.getOwnPropertyDescriptor()")}}
-- {{jsxref("Object.prototype.watch()")}}
-- {{jsxref("Object.prototype.unwatch()")}}
+- `Object.prototype.watch()`
+- `Object.prototype.unwatch()`
 - {{jsxref("Functions/get", "get")}}
 - {{jsxref("Functions/set", "set")}}
 - {{jsxref("Object.create()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/copywithin/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/copywithin/index.md
@@ -42,7 +42,7 @@ Le tableau typé, modifié par la fonction.
 
 Voir la page {{jsxref("Array.prototype.copyWithin")}} pour plus d'informations.
 
-Cette méthode remplace la méthode expérimentale {{jsxref("TypedArray.prototype.move()")}}.
+Cette méthode remplace la méthode expérimentale `TypedArray.prototype.move()`.
 
 ## Exemples
 

--- a/files/fr/web/javascript/reference/global_objects/uint16array/index.md
+++ b/files/fr/web/javascript/reference/global_objects/uint16array/index.md
@@ -84,7 +84,7 @@ Tous les objets `Uint16Array` héritent de {{jsxref("TypedArray", "%TypedArray%.
   - : Renvoie le dernier indice (le plus élevé) d'un élément du tableau qui est égal à la valeur fournie. Si aucun élément ne correspond, la valeur -1 sera renvoyée. Voir également {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "Uint16Array.prototype.map()")}}
   - : Crée un nouveau tableau dont les éléments sont les images des éléments du tableau courant par une fonction donnée. Voir également {{jsxref("Array.prototype.map()")}}.
-- {{jsxref("TypedArray.move", "Uint16Array.prototype.move()")}} {{non-standard_inline}}
+- `Uint16Array.prototype.move()` {{non-standard_inline}}
   - : Ancienne version, non-standard, de {{jsxref("TypedArray.copyWithin", "Uint16Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.reduce", "Uint16Array.prototype.reduce()")}}
   - : Applique une fonction sur un accumulateur et chaque élément du tableau (de gauche à droite) afin de réduire le tableau en une seule valeur. Voir également {{jsxref("Array.prototype.reduce()")}}.

--- a/files/fr/web/javascript/reference/global_objects/uint32array/index.md
+++ b/files/fr/web/javascript/reference/global_objects/uint32array/index.md
@@ -84,7 +84,7 @@ Tous les objets `Uint32Array` héritent de {{jsxref("TypedArray", "%TypedArray%.
   - : Renvoie le dernier indice (le plus élevé) d'un élément du tableau qui est égal à la valeur fournie. Si aucun élément ne correspond, la valeur -1 sera renvoyée. Voir également {{jsxref("Array.prototype.lastIndexOf()")}}.
 - {{jsxref("TypedArray.map", "Uint32Array.prototype.map()")}}
   - : Crée un nouveau tableau dont les éléments sont les images des éléments du tableau courant par une fonction donnée. Voir également {{jsxref("Array.prototype.map()")}}.
-- {{jsxref("TypedArray.move", "Uint32Array.prototype.move()")}} {{non-standard_inline}}
+- `Uint32Array.prototype.move()` {{non-standard_inline}}
   - : Ancienne version, non-standard, de {{jsxref("TypedArray.copyWithin", "Uint32Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.reduce", "Uint32Array.prototype.reduce()")}}
   - : Applique une fonction sur un accumulateur et chaque élément du tableau (de gauche à droite) afin de réduire le tableau en une seule valeur. Voir également {{jsxref("Array.prototype.reduce()")}}.

--- a/files/fr/web/javascript/reference/global_objects/weakset/delete/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakset/delete/index.md
@@ -64,4 +64,4 @@ ws.has(window); // Renvoie false, window n'appartient plus au WeakSet.
 ## Voir aussi
 
 - {{jsxref("WeakSet")}}
-- {{jsxref("WeakSet.prototype.clear()")}}
+- `WeakSet.prototype.clear()`


### PR DESCRIPTION
### Description

Update stale `jsxref` references in French (fr) content:
- De-link removed JavaScript features (`SIMD`, `Object.prototype.watch()`/`unwatch()`, `Reflect.enumerate()`, `WeakSet.prototype.clear()`, `TypedArray.move`) to inline code.

### Motivation

Ensure `jsxref` references keep resolving once rari resolves macro arguments against an index of the current `Web/JavaScript/Reference/*` pages (mdn/rari#715) instead of probing candidate URLs and silently following redirects — which will otherwise surface these stale references as broken links.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of #37059.
Related to mdn/rari#715.
