### PR TITLE
fix(zh-cn): update stale `jsxref` references

### DIFF
--- a/files/zh-cn/mozilla/firefox/releases/33/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/33/index.md
@@ -21,7 +21,7 @@ _No change._
 
 ### JavaScript
 
-- 移除了非标准的 {{jsxref("Number.toInteger()")}} 方法（[Firefox bug 1022396](https://bugzil.la/1022396)）。
+- 移除了非标准的 `Number.toInteger()` 方法（[Firefox bug 1022396](https://bugzil.la/1022396)）。
 
 ### Interfaces/APIs/DOM
 

--- a/files/zh-cn/web/javascript/reference/errors/not_a_constructor/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/not_a_constructor/index.md
@@ -25,7 +25,7 @@ TypeError: Atomics is not a constructor
 
 是因为尝试将不是构造器的对象或者变量来作为构造器使用。参考 {{Glossary("constructor")}} 或者 [`new` operator](/zh-CN/docs/Web/JavaScript/Reference/Operators/new) 来了解什么是构造器。
 
-有很多的全局对象比如 {{jsxref("String")}}、{{jsxref("Array")}} 等等都是可以使用 `new` 操作符的构造器。但是有一些全局对象并不是，且其属性和方法都是[静态](<https://en.wikipedia.org/wiki/Method_(computer_programming)#Static_methods>) 的。下面的 JavaScript 标准内置对象都不是构造器：{{jsxref("Math")}}，{{jsxref("JSON")}}，{{jsxref("Symbol")}}，{{jsxref("Reflect")}}，{{jsxref("Intl")}}，`SIMD`，{{jsxref("Atomics")}}。
+有很多的全局对象比如 {{jsxref("String")}}、{{jsxref("Array")}} 等等都是可以使用 `new` 操作符的构造器。但是有一些全局对象并不是，且其属性和方法都是[静态](<https://zh.wikipedia.org/wiki/方法_(電腦科學)#靜態（共享/類別）方法>) 的。下面的 JavaScript 标准内置对象都不是构造函数：{{jsxref("Math")}}、{{jsxref("JSON")}}、{{jsxref("Symbol")}}、{{jsxref("Reflect")}}、{{jsxref("Intl")}}、`SIMD`、{{jsxref("Atomics")}}。
 
 [Generator functions](/zh-CN/docs/Web/JavaScript/Reference/Statements/function*) 也不能作为构造器来使用。
 

--- a/files/zh-cn/web/javascript/reference/errors/not_a_constructor/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/not_a_constructor/index.md
@@ -25,7 +25,7 @@ TypeError: Atomics is not a constructor
 
 是因为尝试将不是构造器的对象或者变量来作为构造器使用。参考 {{Glossary("constructor")}} 或者 [`new` operator](/zh-CN/docs/Web/JavaScript/Reference/Operators/new) 来了解什么是构造器。
 
-有很多的全局对象比如 {{jsxref("String")}}、{{jsxref("Array")}} 等等都是可以使用 `new` 操作符的构造器。但是有一些全局对象并不是，且其属性和方法都是[静态](<https://en.wikipedia.org/wiki/Method_(computer_programming)#Static_methods>) 的。下面的 JavaScript 标准内置对象都不是构造器：{{jsxref("Math")}}，{{jsxref("JSON")}}，{{jsxref("Symbol")}}，{{jsxref("Reflect")}}，{{jsxref("Intl")}}，{{jsxref("SIMD")}}，{{jsxref("Atomics")}}。
+有很多的全局对象比如 {{jsxref("String")}}、{{jsxref("Array")}} 等等都是可以使用 `new` 操作符的构造器。但是有一些全局对象并不是，且其属性和方法都是[静态](<https://en.wikipedia.org/wiki/Method_(computer_programming)#Static_methods>) 的。下面的 JavaScript 标准内置对象都不是构造器：{{jsxref("Math")}}，{{jsxref("JSON")}}，{{jsxref("Symbol")}}，{{jsxref("Reflect")}}，{{jsxref("Intl")}}，`SIMD`，{{jsxref("Atomics")}}。
 
 [Generator functions](/zh-CN/docs/Web/JavaScript/Reference/Statements/function*) 也不能作为构造器来使用。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/typedarray/copywithin/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/typedarray/copywithin/index.md
@@ -28,7 +28,7 @@ typedarray.copyWithin(target, start[, end = this.length])
 
 更多信息请见 {{jsxref("Array.prototype.copyWithin")}}。
 
-这个方法取代了实验性的 {{jsxref("TypedArray.prototype.move()")}}。
+这个方法取代了实验性的 `TypedArray.prototype.move()`。
 
 ## 示例
 

--- a/files/zh-cn/web/javascript/reference/iteration_protocols/index.md
+++ b/files/zh-cn/web/javascript/reference/iteration_protocols/index.md
@@ -116,7 +116,7 @@ JavaScript 语言指定了产生或使用可迭代对象和迭代器的 API。
 
 ### 内置的可迭代对象
 
-{{jsxref("String")}}、{{jsxref("Array")}}、{{jsxref("TypedArray")}}、{{jsxref("Map")}}、{{jsxref("Set")}} 以及 {{jsxref("Intl/Segmenter/Segments", "Intl.Segments")}} 都是内置的可迭代对象，因为它们的每个 `prototype` 对象都实现了 `[Symbol.iterator]()` 方法。此外，[`arguments`](/zh-CN/docs/Web/JavaScript/Reference/Functions/arguments) 对象和一些 DOM 集合类型，如 {{domxref("NodeList")}} 也是可迭代的。目前，没有内置的异步可迭代对象。
+{{jsxref("String")}}、{{jsxref("Array")}}、{{jsxref("TypedArray")}}、{{jsxref("Map")}}、{{jsxref("Set")}} 以及 {{jsxref("Intl/Segmenter/segment/Segments", "Intl.Segments")}} 都是内置的可迭代对象，因为它们的每个 `prototype` 对象都实现了 `[Symbol.iterator]()` 方法。此外，[`arguments`](/zh-CN/docs/Web/JavaScript/Reference/Functions/arguments) 对象和一些 DOM 集合类型，如 {{domxref("NodeList")}} 也是可迭代的。目前，没有内置的异步可迭代对象。
 
 [生成器函数](/zh-CN/docs/Web/JavaScript/Reference/Statements/function*)返回[生成器对象](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Generator)，它们是可迭代的迭代器。[异步生成器函数](/zh-CN/docs/Web/JavaScript/Reference/Statements/async_function*)返回[异步生成器对象](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator)，它们是异步可迭代的迭代器。
 


### PR DESCRIPTION
### Description

Update stale `jsxref` references in Chinese, Simplified (zh-CN) content:
- De-link removed JavaScript features (`Number.toInteger()`, `SIMD`, `TypedArray.prototype.move()`) to inline code.
- Fix a stale `Intl/Segmenter/Segments` argument to point at `Intl/Segmenter/segment/Segments`.

### Motivation

Ensure `jsxref` references keep resolving once rari resolves macro arguments against an index of the current `Web/JavaScript/Reference/*` pages (mdn/rari#715) instead of probing candidate URLs and silently following redirects — which will otherwise surface these stale references as broken links.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of #37059.
Related to mdn/rari#715.
