### PR TITLE
Sync page_types/aria_page_template [es]

### DIFF
--- a/files/es/mdn/writing_guidelines/page_structures/page_types/aria_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/aria_page_template/index.md
@@ -1,35 +1,53 @@
 ---
-title: "ARIA: Plantilla de página"
+title: Plantilla de página ARIA
 slug: MDN/Writing_guidelines/Page_structures/Page_types/ARIA_Page_Template
 l10n:
-  sourceCommit: dad6b0e057cd37b4408cdede8b9f568c56df9a82
+  sourceCommit: da12dd76d4c9863ce4f9c436f5e2373fe541e1c7
 ---
 
-{{MDNSidebar}}
+## Front matter de la página
 
-## Metadatos de la página
+Los metadatos de la página se describen en el front matter, como en el siguiente ejemplo:
 
-### Title y slug
+```md
+---
+title: aria-labelledby
+slug: Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby
+page-type: aria-attribute
+spec-urls: https://w3c.github.io/aria/#aria-labelledby
+sidebar: accessibilitysidebar
+---
+```
 
-Una página de rol de ARIA debe tener un `title` y un `slug` de `ARIA: Nombre del rol`. Por ejemplo, el [rol de botón](/es/docs/Web/Accessibility/ARIA/Roles/button_role) tiene un `title` y `slug` de `ARIA/NameOfTheRole_role` y el atributo [aria-labelledby](/es/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) tiene un `title` de `aria-labelledby`.
+### Título y slug
 
-### Principales macros
+Una página de rol ARIA debe tener un `title` y un `slug` de `ARIA: Nombre del rol`. Por ejemplo, el [rol de botón](/es/docs/Web/Accessibility/ARIA/Reference/Roles/button_role) tiene un `title` y un `slug` de `ARIA/NameOfTheRole_role`, y el atributo [aria-labelledby](/es/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) tiene un `title` de `aria-labelledby`.
 
-Aparecen varias llamadas a macros en la parte superior de la sección de contenido. Debes actualizarlos o eliminarlos de acuerdo con los siguientes consejos:
+### Barra lateral
 
-- \\{{deprecated_header}}: genera un banner de **Obsoleto** que indica que la tecnología está [obsoleta](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated). Si no es así, puede eliminar la llamada de macro.
-- \\{{ariaref}}: genera un menú lateral ARIA adecuado, dependiendo de las etiquetas que se incluyan en la página.
+El valor `accessibilitysidebar` puede usarse en todas las páginas bajo `/Web/Accessibility`:
 
-### Etiquetas
+```yaml
+sidebar: accessibilitysidebar
+```
 
-En las subpáginas de roles o atributos de ARIA, debes incluir las siguientes etiquetas (consulta la sección _Etiquetas_ en la parte inferior de la interfaz de usuario del editor): **ARIA**, **Reference**, **ARIA Role** o **ARIA Attribute**, _el nombre del Rol oo Atributo_ (por ejemplo **ARIA button** or **aria-labelledby**), **ARIA widget,** **Experimental** (si el atributo del rol es [experimental](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental)), y **Obsoleto** (si es [obsoleto](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated)).
+Consulta [Estructuras de página: Barras laterales](/es/docs/MDN/Writing_guidelines/Page_structures/Sidebars) para más información.
+
+### Macros principales
+
+En la parte superior de la sección de contenido aparecen varias llamadas a macros. Debes actualizarlas o eliminarlas según las indicaciones detalladas a continuación.
+
+### Estados
+
+No añadas ni edites las claves de estado manualmente.
+Para incluir la clave de estado de la característica que corresponda —[**experimental**](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental), [**obsoleto**](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated) o **no estándar**—, consulta la sección ["Cómo se agregan o actualizan los estados de las características"](/es/docs/MDN/Writing_guidelines/Page_structures/Feature_status#¿cómo_se_agregan_o_actualizan_los_estados_de_las_características).
 
 ### Especificaciones
 
-En el valor de la clave de metadatos `spec_urls`, actualice las URL para que apunten a los ID de url para las secciones correctas de las siguientes especificaciones:
+En el valor de la clave de metadatos del front matter `spec-urls`, actualiza las URL para que apunten a los ID de fragmento de las secciones correctas de las siguientes especificaciones:
 
 - [ARIA](https://w3c.github.io/aria/)
-- [Prácticas de autoría de ARIA](https://w3c.github.io/aria-practices/)
+- [Prácticas de autoría de ARIA](https://www.w3.org/WAI/ARIA/apg/)
 
 Recursos adicionales:
 
@@ -38,28 +56,28 @@ Recursos adicionales:
 
 ## Plantilla de página
 
-El párrafo de resumen comienza nombrando el rol o atributo y diciendo lo que hace. Idealmente, esto debería consistir en 1 o 2 oraciones cortas. Este contenido aparece como una sugerencia de herramienta en los enlaces a esta página, así que elabóralo bien.
+Comienza el párrafo de resumen nombrando el rol o atributo y describiendo qué hace. Idealmente, debería constar de una o dos frases cortas. Este contenido aparece como información emergente (tooltip) en los enlaces a esta página, así que redáctalo con cuidado.
 
 ```html
-<!-- Insertar bloque de código que muestre casos de uso comunes-->
+<!-- Insertar bloque de código que muestre casos de uso comunes -->
 ```
 
-(Opcional) Incluya una breve descripción del ejemplo anterior.
+(Opcional) Incluye una breve descripción del ejemplo anterior.
 
 ## Descripción
 
-Incluya una descripción completa del atributo o rol.
+Incluye una descripción completa del atributo o rol.
 
 ### Roles, estados y propiedades de ARIA asociados
 
 - Nombre de los roles asociados
-  - : Explicación de requerimientos, enlace a páginas de características.
+  - : Explicación del requisito, enlace a las páginas de características.
 - Nombre de los atributos asociados
   - : Explicación del requisito, enlace a las páginas del atributo, junto con el enlace a JS requerido para cambiar el valor, si corresponde.
 
 ### Interacciones con el teclado
 
-### Funciones de JavaScript requeridas
+### Características de JavaScript requeridas
 
 - Manejadores de eventos requeridos
   - : Explicación de cada uno
@@ -67,24 +85,24 @@ Incluya una descripción completa del atributo o rol.
   - : Explicación de cada uno
 
 > [!NOTE]
-> Incluye una nota sobre alternativas semánticas al uso de este rol o atributo. La primera regla de uso de ARIA es que puedes usar una función nativa con la semántica y el comportamiento que requieres ya incorporados, en lugar de reutilizar un elemento y **agregar** un rol, estado o propiedad de ARIA para hacerlo accesible, y luego hacerlo. Luego publique todos los detalles en la sección de mejores prácticas a continuación.
+> Incluye una nota sobre alternativas semánticas al uso de este rol o atributo. La primera regla de uso de ARIA es que, si puedes usar una característica nativa que ya incorpora la semántica y el comportamiento que necesitas, en lugar de reutilizar un elemento y **añadir** un rol, estado o propiedad de ARIA para hacerlo accesible, hazlo. Luego publica todos los detalles en la sección de mejores prácticas más abajo.
 
 ## Ejemplos
 
-Tenga en cuenta que usamos el plural "Ejemplos" incluso si la página solo contiene un ejemplo.
+Ten en cuenta que usamos el plural "Ejemplos" incluso si la página solo contiene un ejemplo.
 
 ### Un encabezado descriptivo
 
-Cada ejemplo debe tener un encabezado H3 (`###`) que nombre el ejemplo. El encabezado debe ser descriptivo de lo que está haciendo el ejemplo. Por ejemplo, "Un ejemplo simple" no dice nada sobre el ejemplo y, por lo tanto, no es un buen encabezado. El encabezado debe ser conciso. Para una descripción más larga, use el párrafo después del encabezado.
+Cada ejemplo debe tener un encabezado H3 (`###`) que nombre el ejemplo. El encabezado debe describir lo que hace el ejemplo. Por ejemplo, "Un ejemplo simple" no dice nada sobre el ejemplo y, por lo tanto, no es un buen encabezado. El encabezado debe ser conciso. Para una descripción más larga, usa el párrafo que sigue al encabezado.
 
-Consulta nuestra guía sobre cómo añadir [ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples) para obtener más información.
+Consulta nuestra guía sobre cómo añadir [ejemplos de código](/es/docs/MDN/Writing_guidelines/Page_structures/Code_examples) para más información.
 
 > [!NOTE]
-> A veces querrás enlazar a ejemplos dados en otra página.
+> A veces querrás enlazar a ejemplos que aparecen en otra página.
 >
-> **Escenario 1:** Si tiene algunos ejemplos en esta página y algunos ejemplos más en otra página:
+> **Escenario 1:** Si tienes algunos ejemplos en esta página y otros más en otra página:
 >
-> Incluya un encabezado H3 (`###`) para cada ejemplo en esta página y luego un encabezado H3 final (`###`) con el texto "Más ejemplos", bajo el cual puede vincular los ejemplos en otras páginas. Por ejemplo:
+> Incluye un encabezado H3 (`###`) para cada ejemplo de esta página y, después, un encabezado H3 final (`###`) con el texto "Más ejemplos", bajo el cual puedes enlazar los ejemplos de otras páginas. Por ejemplo:
 >
 > ```md
 > ## Ejemplos
@@ -100,34 +118,34 @@ Consulta nuestra guía sobre cómo añadir [ejemplos de código](/es/docs/MDN/Wr
 >
 > **Escenario 2:** Si _solo_ tienes ejemplos en otra página y ninguno en esta página:
 >
-> No añada ningún encabezado H3; solo añada los enlaces directamente debajo del encabezado H2 "Ejemplos". Por ejemplo:
+> No añadas ningún encabezado H3; simplemente añade los enlaces directamente debajo del encabezado H2 "Ejemplos". Por ejemplo:
 >
 > ```md
 > ## Ejemplos
 >
-> Para ver ejemplos de esta API, consulte [la página en fetch()](https://example.org).
+> Para ver ejemplos de esta API, consulta [la página en fetch()](https://example.org/).
 > ```
 
 ## Problemas de accesibilidad
 
-Opcionalmente, advierte sobre cualquier posible problema de accesibilidad que exista con el uso de esta propiedad y cómo solucionarlos. Elimine esta sección si no hay ninguna para enumerar.
+Opcionalmente, advierte sobre cualquier posible problema de accesibilidad que exista con el uso de esta propiedad, y cómo solucionarlo. Elimina esta sección si no hay ninguno que enumerar.
 
 ## Mejores prácticas
 
-Opcionalmente, enumere las mejores prácticas que existen para este rol. Elimine la sección si no existe.
+Opcionalmente, enumera las mejores prácticas que existan para este rol. Elimina la sección si no existe ninguna.
 
 ### Beneficios añadidos
 
 - Rol asociado
-  - : Si ese rol es un padre, hijo o hermano requerido, y lo que hace.
+  - : Si ese rol es un padre, hijo o hermano requerido, y qué hace.
 
-Cualquier beneficio adicional que esta función tenga para los usuarios no típicos de lectores de pantalla, como el reconocimiento de voz de Google o móvil.
+Cualquier beneficio adicional que esta característica aporte a usuarios de lectores de pantalla no habituales, como el reconocimiento de voz de Google o el de dispositivos móviles.
 
 ## Especificaciones
 
 `\{{Specifications}}`
 
-_Recuerde eliminar las comillas invertidas y la barra invertida para usar esta macro._
+_Recuerda eliminar las comillas invertidas y la barra invertida para usar esta macro._
 
 ## Orden de precedencia
 
@@ -135,9 +153,9 @@ _Recuerde eliminar las comillas invertidas y la barra invertida para usar esta m
 
 ## Compatibilidad con lectores de pantalla
 
-## Vease también
+## Véase también
 
-Incluya enlaces a páginas de referencia y guías relacionadas con el rol o atributo actual. Para obtener más pautas, consulta la [sección Véase también](/es/docs/MDN/Writing_guidelines/Writing_style_guide#see_also_section) en la _Guía de estilo_.
+Incluye enlaces a páginas de referencia y guías relacionadas con el rol o atributo actual. Para más pautas, consulta la [sección Véase también](/es/docs/MDN/Writing_guidelines/Writing_style_guide#sección_véase_también) en la _Guía de estilo_.
 
 - link1
 - link2


### PR DESCRIPTION
## Description

Syncs the Spanish translation of `ARIA page template` with the current English source in `mdn/content`.

## Changes

- `l10n.sourceCommit` updated to current EN HEAD SHA.
- Front-matter contains only allowed fields (`title`, `slug`, `l10n.sourceCommit`).
- Removed outdated `{{MDNSidebar}}` macro to match the upstream source.
- Updated all internal links from `/en-US/` to `/es/`.
- Added missing section.

## Related

Closes #35414
Part of #35373