### PR TITLE
fix(zh-CN): correct node removal translation

### DIFF
--- a/files/zh-cn/learn_web_development/core/scripting/dom_scripting/index.md
+++ b/files/zh-cn/learn_web_development/core/scripting/dom_scripting/index.md
@@ -175,7 +175,7 @@ sect.appendChild(linkPara);
 sect.removeChild(linkPara);
 ```
 
-要删除一个仅基于自身引用的节点可能稍微有点复杂，这也是很常见的。你可以使用 {{domxref("Element.remove()")}}：
+当你想仅通过节点自身的引用来删除它时，这也是很常见的。你可以使用 {{domxref("Element.remove()")}}：
 
 ```js
 linkPara.remove();


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

删除原译文中， 英文原文不存在的“可能稍微有点复杂”

### Motivation

原文只说明“只有节点自身引用”是一种很常见的情况，并未评价删除操作的复杂程度。
当前译文额外加入了“可能稍微有点复杂”，容易使读者误以为使用节点自身引用删除节点是一项较复杂的操作。

### Additional details

N/A

### Related issues and pull requests

Fixes #37191
