### PR TITLE
[zh-cn]: update the translation of SVG `clip-path` attribute

### DIFF
--- a/files/zh-cn/web/svg/reference/attribute/clip-path/index.md
+++ b/files/zh-cn/web/svg/reference/attribute/clip-path/index.md
@@ -1,13 +1,35 @@
 ---
 title: clip-path
 slug: Web/SVG/Reference/Attribute/clip-path
+l10n:
+  sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d
 ---
 
-元素的表现属性 **`clip-path`** 为其定义或关联一条剪切路径。
+**`clip-path`** 表现属性为其相关元素定义或关联一条裁剪路径。
 
-**注意：**`clip-path` 是一个表现属性，可以作为 CSS 属性使用。
+> [!NOTE]
+> 作为一个表现属性，`clip-path` 也有对应的 CSS 属性：{{cssxref("clip-path")}}。两者同时指定时，CSS 属性优先。
 
-作为一种表现属性，`clip-path` 可以用于任何元素，不过效果最明显的是下列十九种元素：{{SVGElement('a')}}, {{SVGElement('circle')}}, {{SVGElement('clipPath')}}, {{SVGElement('ellipse')}}, {{SVGElement('g')}}, {{SVGElement('image')}}, {{SVGElement('line')}}, {{SVGElement('marker')}}, {{SVGElement('mask')}}, {{SVGElement('path')}}, {{SVGElement('pattern')}}, {{SVGElement('polygon')}}, {{SVGElement('polyline')}}, {{SVGElement('rect')}}, {{SVGElement('svg')}}, {{SVGElement('symbol')}}, {{SVGElement('text')}}, {{SVGElement('use')}}
+你可以和下面的 SVG 元素一起使用该属性：
+
+- {{SVGElement('a')}}
+- {{SVGElement('circle')}}
+- {{SVGElement('clipPath')}}
+- {{SVGElement('ellipse')}}
+- {{SVGElement('g')}}
+- {{SVGElement('image')}}
+- {{SVGElement('line')}}
+- {{SVGElement('marker')}}
+- {{SVGElement('mask')}}
+- {{SVGElement('path')}}
+- {{SVGElement('pattern')}}
+- {{SVGElement('polygon')}}
+- {{SVGElement('polyline')}}
+- {{SVGElement('rect')}}
+- {{SVGElement('svg')}}
+- {{SVGElement('symbol')}}
+- {{SVGElement('text')}}
+- {{SVGElement('use')}}
 
 ## 示例
 
@@ -25,7 +47,7 @@ svg {
     <circle cx=".5" cy=".5" r=".5" />
   </clipPath>
 
-  <!-- 左上：应用自定义的剪切路径 -->
+  <!-- 左上：应用自定义的裁剪路径 -->
   <rect
     x="1"
     y="1"
@@ -34,9 +56,9 @@ svg {
     stroke="green"
     clip-path="url(#myClip)" />
 
-  <!-- 右上：应用 CSS 基本形状和 fill-box 几何。
-       实质上和自定义剪切路径并把 clipPathUnits
-       设成 objectBoundingBox 一样 -->
+  <!-- 右上：在 fill-box 几何上应用 CSS 基本形状。
+       这等同于使用自定义裁剪路径，并将 clipPathUnits
+       设为 objectBoundingBox -->
   <rect
     x="11"
     y="1"
@@ -54,9 +76,9 @@ svg {
     stroke="green"
     clip-path="circle() stroke-box" />
 
-  <!-- 右下：应用 CSS 基本形状和 view-box 几何。
-       实质上和自定义剪切路径并把 clipPathUnits
-       设成 userSpaceOnUse 一样 -->
+  <!-- 右下：在 view-box 几何上应用 CSS 基本形状。
+       这等同于使用自定义裁剪路径，并将 clipPathUnits
+       设为 userSpaceOnUse -->
   <rect
     x="11"
     y="11"
@@ -67,20 +89,35 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample('示例', '100%', 200)}}
+{{EmbedLiveSample("示例", '100%', 200)}}
 
-## Usage notes
+## 使用说明
 
-| 值         | {{cssxref('url')}} \| [ {{cssxref('basic-shape')}} \|\| `<geometry-box>` ] \| `none` |
-| ---------- | ------------------------------------------------------------------------------------ |
-| 默认值     | `none`                                                                               |
-| Animatable | 是                                                                                   |
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">值</th>
+      <td>
+        {{CSSXref("url_value", "&lt;url&gt;")}} | [ {{cssxref('basic-shape')}} ||
+        <code>&#x3C;geometry-box></code> ] | <code>none</code>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">默认值</th>
+      <td><code>none</code></td>
+    </tr>
+    <tr>
+      <th scope="row">动画性</th>
+      <td>是</td>
+    </tr>
+  </tbody>
+</table>
 
 - \<geometry-box>
-  - : geometry-box 是应用 {{cssxref('basic-shape')}} 的额外信息，用于区分 CSS 基本形状如何应用于元素上：`fill-box` 表示将对象的包围框作为参照框；`stroke-box` 表示将对象的包围框加上描边的范围作为参照框；`view-box` 表示使用最近的 SVG 视窗作为参照框。
+  - : 用于说明如何将 {{cssxref('basic-shape')}} 应用于元素的额外信息：`fill-box` 表示使用对象包围盒；`stroke-box` 表示使用扩展了描边的对象包围盒；`view-box` 表示使用最近的 SVG 视口作为参照框。
 
 > [!NOTE]
-> `clip-path` 语法的更多细节可参考 CSS 属性 {{cssxref('clip-path')}} 的参考页面。
+> 有关 clip-path 语法的更多详情，请参阅 CSS 属性 {{cssxref('clip-path')}} 参考页。
 
 ## 规范
 
@@ -90,6 +127,7 @@ svg {
 
 {{Compat}}
 
-## See also
+## 参见
 
-- The CSS {{cssxref("clip-path")}} property
+- CSS {{cssxref("clip-path")}} 属性
+- [CSS 裁剪简介](/zh-CN/docs/Web/CSS/Guides/Masking/Clipping)


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/clip-path
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/svg/reference/attribute/clip-path/index.md
* Last commit: https://github.com/mdn/content/commit/85fccefc8066bd49af4ddafc12c77f35265c7e2d