### PR TITLE
docs(es): add mariomorillo to the Spanish (es) review team

### DIFF
--- a/PEERS_GUIDELINES.md
+++ b/PEERS_GUIDELINES.md
@@ -55,6 +55,7 @@ The review teams for each locale are:
 - Spanish (`es`) content - the [es-content](https://github.com/orgs/mdn/teams/es-content) team, which consists of:
   - [JuanVqz](https://github.com/JuanVqz)
   - [Graywolf9](https://github.com/Graywolf9)
+  - [mariomorillo](https://github.com/mariomorillo)
 
 ---
 

--- a/files/es/mdn/community/translated_content/index.md
+++ b/files/es/mdn/community/translated_content/index.md
@@ -50,7 +50,7 @@ Hemos _congelado_ todo el contenido localizado (lo que significa que no aceptare
 ### Español (es)
 
 - Discusiones: [Telegram (`MDN l10n ES`)](https://t.me/+Dr6qKQCAepw4MjFj), [Discord (`#spanish`)](/discord)
-- Colaboradores actuales: [Graywolf9](https://github.com/Graywolf9), [JuanVqz](https://github.com/JuanVqz)
+- Colaboradores actuales: [Graywolf9](https://github.com/Graywolf9), [JuanVqz](https://github.com/JuanVqz), [mariomorillo](https://github.com/mariomorillo)
 
 > [!NOTE]
 > Si quiere hablar sobre la posibilidad de _descongelar_ una localización, las [directrices sobre lo que se requiere se pueden encontrar aquí](https://github.com/mdn/translated-content/blob/main/PEERS_GUIDELINES.md#activating-a-locale)


### PR DESCRIPTION
### Description

Adds [mariomorillo](https://github.com/mariomorillo) (Mario Morillo) to the Spanish (`es`) review team.

Updates the two in-repo places that list the individual `es` maintainers:

- `PEERS_GUIDELINES.md` — the `es-content` review-team roster.
- `files/es/mdn/community/translated_content/index.md` — the public "Colaboradores actuales" list.

### Motivation

Mario has been contributing high-quality reviews on Spanish translation PRs and is joining the maintainer team.

### Additional details

CODEOWNERS already routes `/files/es/` and `/docs/es/` to the `@mdn/es-content` team handle, so no CODEOWNERS change is needed. Adding Mario to the `@mdn/es-content` GitHub team (org-level) is handled separately.
