### PR TITLE
Prettierで行の折り返しを保持するよう設定変更

### DIFF
--- a/files/ja/.prettierrc.json
+++ b/files/ja/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "proseWrap": "preserve",
+  "bracketSameLine": true
+}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Since Japanese does not include spaces between words, applying Prettier’s rule to wrap long lines with spaces makes the source code very difficult to read. Therefore, I would like to preserve the line break positions in Japanese articles.

日本語では単語間にスペースが含まれないため、長い行をスペースで折り返すPrettierのルールを適用すると、ソースが大変読みにくくなります。そのため、日本語記事では折り返し位置を保存するようにしたいと思います。

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
