### PR TITLE
chore(fr): update of `Web/API/Element/copy_event`

### DIFF
--- a/files/fr/web/api/element/copy_event/index.md
+++ b/files/fr/web/api/element/copy_event/index.md
@@ -1,54 +1,78 @@
 ---
-title: copy
+title: "Element : évènement copy"
+short-title: copy
 slug: Web/API/Element/copy_event
+l10n:
+  sourceCommit: a7265fc3effa7c25b9997135104370c057a65293
 ---
 
-{{APIRef}}
+{{APIRef("Clipboard API")}}
 
-L'événement **copy** est déclenché lorsque l'utilisateur initie une copie par le biais de l'interface du navigateur (par exemple, Ctrl/Cmd+C ou "copier" du menu contextuel) et en réponse d'un appel de {{domxref("Document.execCommand", "document.execCommand('copy')")}} autorisé.
+L'évènement **`copy`** de [l'API Clipboard](/fr/docs/Web/API/Clipboard_API) se déclenche lorsque l'utilisateur·ice initie une action de copie avec l'interface utilisateur du navigateur.
 
-## Informations générales
+L'action par défaut de l'évènement est de copier la sélection (le cas échéant) dans le presse-papiers.
 
-- Spécification
-  - : [Clipboard](https://www.w3.org/TR/clipboard-apis/#the-copy-action)
-- Interface
-  - : {{domxref("ClipboardEvent")}}
-- Propagation
-  - : Oui
-- Annulable
-  - : Oui
-- Cible
-  - : {{domxref("Element")}}: L'élément ayant le focus (pour les éléments {{domxref("HTMLElement.contentEditable", "contentEditable")}} - l'élément contenant le début de la sélection), ou l'élément {{HTMLElement("body")}}
-- Action par défaut
-  - : Voir ce-dessous
+Un gestionnaire d'évènement peut _modifier_ le contenu du presse-papiers en appelant {{DOMxRef("DataTransfer.setData", "setData(format, data)")}} sur la propriété {{DOMxRef("ClipboardEvent.clipboardData")}} de l'évènement, et en annulant l'action par défaut de l'évènement en utilisant {{DOMxRef("Event/preventDefault", "event.preventDefault()")}}.
 
-Un gestionnaire de cet événement peut modifier l'objet {{domxref("ClipboardEvent.clipboardData")}} en appellant {{domxref("DataTransfer.setData", "setData(format, data)")}}:
+Cependant, le gestionnaire ne peut pas _lire_ les données du presse-papiers.
+
+Il est possible de construire et de déclencher un évènement [synthétique](/fr/docs/Web/API/Document_Object_Model/Events#créer_et_diffuser_des_évènements) `copy`, mais cela n'affecte pas le presse-papiers du système.
+
+Cet évènement [se propage](/fr/docs/Learn_web_development/Core/Scripting/Event_bubbling) dans l'arborescence DOM, jusqu'à {{DOMxRef("Document")}} et {{DOMxRef("Window")}}, est [annulable](/fr/docs/Web/API/Event/cancelable) et est [composé](/fr/docs/Web/API/Event/composed).
+
+## Syntaxe
+
+Utilisez le nom de l'évènement dans des méthodes comme {{DOMxRef("EventTarget.addEventListener", "addEventListener()")}}, ou définissez une propriété de gestionnaire d'évènement.
+
+```js-nolint
+addEventListener("copy", (event) => { })
+
+oncopy = (event) => { }
+```
+
+## Type d'évènement
+
+Un objet {{DOMxRef("ClipboardEvent")}}. Hérite de {{DOMxRef("Event")}}.
+
+{{InheritanceDiagram("ClipboardEvent")}}
+
+## Exemples
+
+### Exemple interactif
+
+#### HTML
+
+```html
+<div class="source" contenteditable="true">Copiez le texte de cette zone.</div>
+<div class="cible" contenteditable="true">Et collez-le dans celle-ci.</div>
+```
+
+```css hidden
+div.source,
+div.cible {
+  border: 1px solid gray;
+  margin: 0.5rem;
+  padding: 0.5rem;
+  height: 1rem;
+  background-color: #e9eef1;
+}
+```
+
+#### JavaScript
 
 ```js
-document.addEventListener("copy", function (e) {
-  e.clipboardData.setData("text/plain", "Hello, world!");
-  e.clipboardData.setData("text/html", "<b>Hello, world!</b>");
-  e.preventDefault(); // We want our data, not data from any selection, to be written to the clipboard
+const source = document.querySelector("div.source");
+
+source.addEventListener("copy", (event) => {
+  const selection = document.getSelection();
+  event.clipboardData.setData("text/plain", selection.toString().toUpperCase());
+  event.preventDefault();
 });
 ```
 
-Un gestionnaire de cet événement ne peut pas lire les données du presse-papiers en utilisant {{domxref("DataTransfer.getData", "clipboardData.getData()")}}.
+#### Résultat
 
-L'action par défaut de l'événement dépend de la source de celui-ci et du comportement du gestionnaire:
-
-- Un événement de copie [synthétique](/fr/docs/Web/API/Document_Object_Model/Events) n'a pas d'action par défaut;
-- Si l'événement n'a pas été annulé: Copie de la sélection (s'il y a) dans le presse-papiers;
-- Si le gestionnaire a annulé l'événement et appelé setData(): Copie le contenu de _clipboardData_ de {{domxref("ClipboardEvent")}};
-- Si le gestionnaire a annulé l'événement sans appelé setData(): Aucune action.
-
-## Propriétés
-
-| Property                        | Type                       | Description                                            |
-| ------------------------------- | -------------------------- | ------------------------------------------------------ |
-| `target` {{readonlyInline}}     | {{domxref("EventTarget")}} | The event target (the topmost target in the DOM tree). |
-| `type` {{readonlyInline}}       | {{jsxref("String")}}       | The type of event.                                     |
-| `bubbles` {{readonlyInline}}    | {{jsxref("Boolean")}}      | Whether the event normally bubbles or not.             |
-| `cancelable` {{readonlyInline}} | {{jsxref("Boolean")}}      | Whether the event is cancellable or not.               |
+{{EmbedLiveSample("Exemple interactif", "100%", 120)}}
 
 ## Spécifications
 
@@ -60,6 +84,5 @@ L'action par défaut de l'événement dépend de la source de celui-ci et du com
 
 ## Voir aussi
 
-- Événements relatifs : {{domxref("Element/cut_event", "cut")}}, {{domxref("Element/paste_event", "paste")}}
-- Cet événement sur {{domxref("Document")}} cible : {{domxref("Document/copy_event", "copy")}}
-- Cet événement sur {{domxref("Window")}} cible : {{domxref("Window/copy_event", "copy")}}
+- L'évènement {{DOMxRef("Element/cut_event", "cut")}}
+- L'évènement {{DOMxRef("Element/paste_event", "paste")}}


### PR DESCRIPTION
### Description

Update translation of pages without french version: `Web/API/Element/copy_event`

### Motivation

Update access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_