### PR TITLE
[zh-cn]: create the translation of Element `ariaValueNow` property

### DIFF
--- a/files/zh-cn/web/api/element/ariavaluenow/index.md
+++ b/files/zh-cn/web/api/element/ariavaluenow/index.md
@@ -7,7 +7,7 @@ l10n:
 
 {{APIRef("DOM")}}
 
-{{domxref("Element")}} 接口的 **`ariaValueNow`** 属性反映 [`aria-valuenow`](/zh-CN/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuenow) 属性的值，定义范围小部件的当前值。
+{{domxref("Element")}} 接口的 **`ariaValueNow`** 属性反映 [`aria-valuenow`](/zh-CN/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuenow) 属性的值，定义了范围微件的当前值。
 
 ## 值
 

--- a/files/zh-cn/web/api/element/ariavaluenow/index.md
+++ b/files/zh-cn/web/api/element/ariavaluenow/index.md
@@ -1,0 +1,22 @@
+---
+title: "Element：ariaValueNow 属性"
+slug: Web/API/Element/ariaValueNow
+l10n:
+  sourceCommit: f65f7f6e4fda2cb1bd0e7db17777e2cb20be7d27
+---
+
+{{APIRef("DOM")}}
+
+{{domxref("Element")}} 接口的 **`ariaValueNow`** 属性反映 [`aria-valuenow`](/zh-CN/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuenow) 属性的值，定义范围小部件当前值。
+
+## 值
+
+字符串。
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}

--- a/files/zh-cn/web/api/element/ariavaluenow/index.md
+++ b/files/zh-cn/web/api/element/ariavaluenow/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element：ariaValueNow 属性"
+title: Element：ariaValueNow 属性
 slug: Web/API/Element/ariaValueNow
 l10n:
   sourceCommit: f65f7f6e4fda2cb1bd0e7db17777e2cb20be7d27
@@ -7,11 +7,31 @@ l10n:
 
 {{APIRef("DOM")}}
 
-{{domxref("Element")}} 接口的 **`ariaValueNow`** 属性反映 [`aria-valuenow`](/zh-CN/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuenow) 属性的值，定义范围小部件当前值。
+{{domxref("Element")}} 接口的 **`ariaValueNow`** 属性反映 [`aria-valuenow`](/zh-CN/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuenow) 属性的值，定义范围小部件的当前值。
 
 ## 值
 
-字符串。
+包含数字的字符串。
+
+## 示例
+
+此示例中，ID 为 `slider` 的元素上的 [`aria-valuenow`](/zh-CN/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuenow) 属性设为 `"1"`。使用 `ariaValueNow` 将其更新为 `"2"`。
+
+```html
+<div
+  role="slider"
+  aria-valuenow="1"
+  aria-valuemin="1"
+  aria-valuemax="7"
+  aria-valuetext="Sunday"></div>
+```
+
+```js
+let el = document.getElementById("slider");
+console.log(el.ariaValueNow); // 1
+el.ariaValueNow = "2";
+console.log(el.ariaValueNow); // 2
+```
 
 ## 规范
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaValueNow
### Related issues and pull requests
parts of #37729
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/element/ariavaluenow/index.md
* Last commit: https://github.com/mdn/content/commit/f65f7f6e4fda2cb1bd0e7db17777e2cb20be7d27