### PR TITLE
docs(es): documenta cómo tratar imágenes en las traducciones [es]

### DIFF
--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -12,6 +12,7 @@ Guía para colaborar traduciendo y manteniendo el contenido de MDN Web Docs al e
   - [Opción A: Desde GitHub (sin instalar nada)](#opción-a-desde-github-sin-instalar-nada)
   - [Opción B: Desde tu computadora (recomendada para cambios grandes)](#opción-b-desde-tu-computadora-recomendada-para-cambios-grandes)
 - [Traducir un documento](#traducir-un-documento)
+- [Imágenes y otros archivos](#imágenes-y-otros-archivos)
 - [Mantener el `l10n.sourceCommit` al día](#mantener-el-l10nsourcecommit-al-día)
 - [Convención de traducciones](#convención-de-traducciones)
   - [Estilo de escritura](#estilo-de-escritura)
@@ -163,6 +164,63 @@ Ejemplo en video: <https://youtu.be/pFeW0vUYbkg>
    Abre la página en `http://localhost:5042/es/docs/...`, inspecciona el encabezado con las herramientas de desarrollo del navegador y copia el `id` real generado por el _build_. Ese es el único valor confiable; no lo derives manualmente del texto del encabezado.
 
 5. Revisa el _front-matter_ YAML (`title`, `slug`, `l10n.sourceCommit`) como se describe en la siguiente sección.
+
+---
+
+## Imágenes y otros archivos
+
+**Regla corta: no copies a `files/es/` las imágenes que ya existen en `mdn/content`.**
+
+Cuando una página en español referencia una imagen que sólo existe en la carpeta en inglés, el _build_ resuelve automáticamente el `src` hacia la ruta de `en-US`. Basta con conservar en el Markdown la misma referencia relativa que usa el original:
+
+```md
+![Descripción de la imagen traducida al español](default-vite.png)
+```
+
+Y el HTML publicado en la página en español queda así:
+
+```html
+<img
+  src="/en-US/docs/Learn_web_development/Core/Frameworks_libraries/React_getting_started/default-vite.png"
+  alt="Descripción de la imagen traducida al español" />
+```
+
+Es decir: **traduce el texto del `alt`, pero no subas el archivo binario.**
+
+### ¿Por qué no duplicarlas?
+
+- **Tamaño del repositorio.** Git no puede calcular diferencias (_diff_) sobre un `.png` o un `.jpg`: cada commit que toque el archivo suma su peso completo al historial, para siempre.
+- **Desincronización silenciosa.** Si la imagen en inglés se actualiza o se renombra, la copia en español queda obsoleta sin que nada falle en CI. Es un problema real: la versión anterior de [Primeros pasos en React][react-getting-started] seguía mostrando una captura de `create-react-app` mucho después de que el original en inglés cambiara a Vite.
+- **No aporta nada.** Una copia idéntica byte por byte se renderiza exactamente igual que la referencia al original.
+
+De hecho, en todo `files/es/` hay apenas un puñado de imágenes, y casi todas son capturas propias que no existen en inglés.
+
+### ¿Cuándo sí se agrega una imagen a `files/es/`?
+
+Sólo cuando el **contenido de la imagen** es específico del idioma, por ejemplo:
+
+- Una captura de pantalla de una interfaz en español (el navegador, un formulario, un panel de herramientas de desarrollo).
+- Un diagrama cuyas etiquetas están en inglés en el original y aportan al lector verlas en español.
+
+En ese caso, colócala en la misma carpeta del documento (`files/es/<ruta>/mi-imagen.png`), usa el mismo nombre de archivo que el original para que sea evidente qué está reemplazando, y comprímela antes de subirla:
+
+```bash
+# Desde tu clon de mdn/content
+npm run filecheck ../translated-content/files/es/<ruta>/mi-imagen.png --save-compression
+```
+
+### Cómo verificar cómo quedó resuelta una imagen
+
+Cualquier página de MDN expone su HTML ya renderizado en `index.json`, lo que permite comprobar el `src` final sin levantar el sitio:
+
+```bash
+curl -sL "https://developer.mozilla.org/es/docs/<Slug>/index.json" | grep -oE '<img[^>]{0,140}'
+```
+
+Si el resultado apunta a `/en-US/...`, el respaldo funcionó correctamente y no hace falta hacer nada más.
+
+> [!NOTE]
+> Antes de agregar una imagen nueva, revisa el repositorio [mdn/shared-assets](https://github.com/mdn/shared-assets): funciona como biblioteca de recursos compartidos y quizá ya exista algo que puedas reutilizar. Los detalles generales están en [Cómo agregar imágenes y medios][guia-imagenes].
 
 ---
 
@@ -349,3 +407,5 @@ Al ejecutar `npm start` en tu clon de `mdn/content` puedes previsualizar localme
 Más información en [la discusión general de la comunidad de español](https://github.com/mdn/translated-content/discussions/4029).
 
 [guia-contribucion]: https://developer.mozilla.org/es/docs/MDN/Contribute
+[guia-imagenes]: https://developer.mozilla.org/es/docs/MDN/Writing_guidelines/Howto/Images_media
+[react-getting-started]: https://developer.mozilla.org/es/docs/Learn_web_development/Core/Frameworks_libraries/React_getting_started


### PR DESCRIPTION
## Resumen

Agrega a la guía de localización al español una sección sobre cómo tratar las imágenes en las páginas traducidas.

La regla, hasta ahora no documentada, es **no copiar a `files/es/` las imágenes que ya existen en `mdn/content`**: cuando la imagen no está en la carpeta del locale, el _build_ resuelve automáticamente el `src` hacia la ruta de `en-US`. Basta con traducir el `alt` y conservar la referencia relativa del original.

Comprobado en una página cuyas imágenes sólo viven en `mdn/content`:

```bash
curl -sL "https://developer.mozilla.org/es/docs/Web/CSS/Guides/Flexible_box_layout/Basic_concepts/index.json" | grep -oE '<img[^>]{0,120}'
# <img src="/en-US/docs/Web/CSS/Guides/Flexible_box_layout/Basic_concepts/basics1.svg" ...
```

El Markdown en `files/es/` escribe `![...](basics1.svg)` y el HTML publicado sirve la ruta de `en-US`.

## Qué incluye la sección

- La regla corta, con un ejemplo del Markdown de entrada y del HTML resultante.
- Por qué no duplicar: los binarios no se pueden _diff_ear (cada commit que los toca suma su peso completo al historial) y la copia en español se desincroniza en silencio cuando la imagen en inglés cambia.
- Los casos en los que **sí** corresponde agregar una imagen a `files/es/`: cuando su contenido es específico del idioma (una captura de una interfaz en español, un diagrama con etiquetas traducidas), junto con el comando de compresión.
- Cómo verificar el `src` final de una imagen leyendo el `index.json` de la página publicada, sin necesidad de levantar el sitio localmente.
- Un recordatorio de revisar [mdn/shared-assets](https://github.com/mdn/shared-assets) antes de agregar una imagen nueva, con enlace a la guía general de imágenes.

## Motivación

Salió de la revisión de #37500, donde una contribución que por lo demás estaba muy bien hecha añadió una copia byte por byte (`sha1 381f5aef…`) de la imagen en inglés. La guía no decía nada al respecto, así que la duda era razonable. En todo `files/es/` hay apenas 7 imágenes y 2 de ellas son duplicados innecesarios de este tipo.

De paso, la versión anterior de esa misma página en español ilustra el problema de la desincronización: seguía mostrando una captura de `create-react-app` mucho después de que el original en inglés cambiara a Vite.

## Verificación

- `npm run lint:md` limpio (Prettier + markdownlint).
- Los dos enlaces a `developer.mozilla.org` usan definiciones de referencia para no activar la regla `fqdn-moz-links`.
- Entrada añadida a la tabla de contenido.
