### PR TITLE
docs(es): corrige la afirmación sobre el respaldo en inglés y la guía de anclas [es]

### DIFF
--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -130,7 +130,21 @@ Ejemplo en video: <https://youtu.be/pFeW0vUYbkg>
 4. Cambia los enlaces internos de `/en-US/` a `/es/`.
 
    **¿Por qué `/es/` aunque la página no exista en español?**
-   Por consistencia de idioma, no por respaldo. **MDN no muestra la versión en inglés cuando falta la traducción**: si no existe `files/es/<ruta>/index.md`, la URL `/es/docs/<Ruta>` devuelve `404`. Tampoco hay respaldo por secciones: una página en español muestra únicamente los encabezados que su propio archivo contiene, y las secciones que aún no se han traducido simplemente no aparecen.
+   Por consistencia de idioma, no porque MDN rellene el hueco con el inglés.
+
+   Es una confusión muy común, y tiene una razón de ser. Lo que ocurre realmente cuando falta la traducción es esto:
+   1. Si no existe `files/es/<ruta>/index.md`, la URL `/es/docs/<Ruta>` devuelve **HTTP `404`** con la página «Page not found». El contenido en inglés **no** se renderiza en esa URL.
+   2. Acto seguido, ya en el navegador, MDN comprueba si la página existe en inglés y, si existe, muestra un aviso: _«**Good news!** The page you requested doesn't exist in **Spanish** but it exists in **English**»_ con un **enlace** a `/en-US/docs/<Ruta>`.
+
+   Es decir: hay un **enlace** de respaldo, no un renderizado de respaldo. La URL sigue siendo `/es/`, el estado sigue siendo `404` y hay que hacer clic para llegar al inglés. Puedes comprobarlo con cualquier página que exista en inglés y no en español:
+
+   ```bash
+   curl -s -o /dev/null -w '%{http_code}\n' \
+     "https://developer.mozilla.org/es/docs/Learn_web_development/Core/Scripting/Functions"
+   # 404
+   ```
+
+   Tampoco hay respaldo por secciones: una página en español muestra únicamente los encabezados que su propio archivo contiene, y las secciones que aún no se han traducido simplemente no aparecen (no se rellenan con el texto en inglés).
 
    Aun así, la regla es: **usa siempre `/es/` en los enlaces internos absolutos de MDN**, sin excepción. Los motivos son dos:
    - Un enlace en `/en-US/` saca al lector del contexto de su idioma preferido, incluso cuando la traducción sí existe.
@@ -150,6 +164,8 @@ Ejemplo en video: <https://youtu.be/pFeW0vUYbkg>
    | Enlace dentro de la misma página                                                | Usa el ID del encabezado tal como lo tradujiste (`## Cómo funciona` → `#cómo_funciona`) |
 
    **No conserves la ancla en inglés "para que funcione mientras tanto".** No va a resolverse sola: cuando la página destino se traduzca, ese encabezado también se traducirá, así que el ID pasará a ser, por ejemplo, `#índice_de_eventos` y nunca `#event_index`. Como una ancla inexistente equivale a no poner ancla, lo correcto es dejar sólo el enlace a la página y añadir el fragmento cuando el destino esté traducido.
+
+   Y si la página destino todavía no existe en español, el fragmento se pierde de todos modos: el enlace de respaldo que ofrece la página `404` apunta a la página en inglés **sin** conservar el `#fragmento`.
 
    **Ejemplo del problema frecuente:** el inglés tiene `/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated`. Al traducir se cambia la URL a `/es/`, y el fragmento se copia tal cual porque la página existe y el enlace "se ve bien". Pero los encabezados de esa página en español se renderizan como `experimental`, `obsoleto` y `en_desuso`: no hay ningún ID `deprecated`, así que el lector aterriza al inicio de la página.
 

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -130,29 +130,42 @@ Ejemplo en video: <https://youtu.be/pFeW0vUYbkg>
 4. Cambia los enlaces internos de `/en-US/` a `/es/`.
 
    **¿Por qué `/es/` aunque la página no exista en español?**
-   MDN renderiza el contenido en inglés como respaldo (_fallback_) para las secciones o páginas que aún no han sido traducidas, pero siempre bajo la URL `/es/`. Un enlace como `/es/docs/Web/API/Fetch_API` funciona correctamente aunque la página no tenga traducción completa: el lector verá el contenido en inglés dentro del contexto de la interfaz en español.
+   Por consistencia de idioma, no por respaldo. **MDN no muestra la versión en inglés cuando falta la traducción**: si no existe `files/es/<ruta>/index.md`, la URL `/es/docs/<Ruta>` devuelve `404`. Tampoco hay respaldo por secciones: una página en español muestra únicamente los encabezados que su propio archivo contiene, y las secciones que aún no se han traducido simplemente no aparecen.
 
-   Por eso la regla general es: **usa siempre `/es/` en los enlaces internos absolutos de MDN**, sin excepción. Si la página de destino no existe en español, el sistema la muestra en inglés de forma transparente. No conserves `/en-US/` "para que funcione": un enlace en `/en-US/` saca al lector del contexto de su idioma preferido, incluso si la traducción sí existe.
+   Aun así, la regla es: **usa siempre `/es/` en los enlaces internos absolutos de MDN**, sin excepción. Los motivos son dos:
+   - Un enlace en `/en-US/` saca al lector del contexto de su idioma preferido, incluso cuando la traducción sí existe.
+   - Un enlace en `/es/` hacia una página todavía sin traducir empieza a funcionar solo en cuanto alguien la traduzca, sin tener que volver a editar la página que lo contiene. Las propias macros de MDN (`{{PreviousMenuNext}}`, `{{domxref}}`, `{{Glossary}}`) generan enlaces `/es/` con ese mismo criterio.
 
-   **Anclas (`#fragmento`): deben coincidir con el encabezado que se renderiza**
+   Es decir: un enlace `/es/` roto hoy es un enlace correcto que aún no tiene destino, y así lo tratamos.
 
-   Cuando un enlace incluye un fragmento (`#`), la ancla debe coincidir con el ID del encabezado **tal como se renderiza en la página destino**. No es simplemente "español si la URL es `/es/`": lo que importa es qué contenido sirve MDN en esa URL.
+   **Anclas (`#fragmento`): deben coincidir con un encabezado que exista en la página en español**
 
-   | Caso                    | URL de destino               | Página destino              | Ancla correcta                                      |
-   | ----------------------- | ---------------------------- | --------------------------- | --------------------------------------------------- |
-   | Página _sin_ traducción | `/es/docs/Web/API/Fetch_API` | MDN sirve inglés (fallback) | Ancla en inglés: `#browser_compatibility`           |
-   | Página _con_ traducción | `/es/docs/Web/API/Fetch_API` | MDN sirve español           | Ancla en español: `#compatibilidad_con_navegadores` |
-   | Misma página            | `#fragmento`                 | El archivo actual           | Ancla del encabezado traducido                      |
+   Una ancla que no corresponde a ningún ID no da error: el navegador se queda al inicio de la página, igual que si no hubiera fragmento. Por eso las anclas mal traducidas pasan desapercibidas con facilidad.
 
-   **Ejemplo del problema frecuente:** el inglés tiene `/en-US/docs/Web/API/Fetch_API#browser_compatibility`. Al traducir la página que contiene ese enlace, es tentador cambiar ambas partes a la vez: `/es/docs/Web/API/Fetch_API#compatibilidad_con_navegadores`. Pero si esa página no tiene traducción española, MDN la sirve en inglés y el encabezado `#compatibilidad_con_navegadores` no existe: el lector llega a la página pero sin desplazarse a la sección correcta.
+   | Caso                                                                            | Qué hacer                                                                               |
+   | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+   | La página destino está traducida y tiene ese encabezado                         | Usa la ancla en español: `#compatibilidad_con_navegadores`                              |
+   | La página destino está traducida pero le falta la sección (está desactualizada) | Quita el fragmento y deja sólo el enlace a la página                                    |
+   | La página destino todavía no existe en español                                  | Quita el fragmento y deja sólo el enlace a la página                                    |
+   | Enlace dentro de la misma página                                                | Usa el ID del encabezado tal como lo tradujiste (`## Cómo funciona` → `#cómo_funciona`) |
 
-   La solución es verificar antes de cambiar la ancla:
-   - ¿Existe `files/es/…/Fetch_API/index.md` en el repositorio con ese encabezado ya traducido? → usa la ancla en español.
-   - ¿No existe o la sección puntual sigue en inglés? → cambia la URL a `/es/` pero **conserva la ancla en inglés**: `/es/docs/Web/API/Fetch_API#browser_compatibility`.
+   **No conserves la ancla en inglés "para que funcione mientras tanto".** No va a resolverse sola: cuando la página destino se traduzca, ese encabezado también se traducirá, así que el ID pasará a ser, por ejemplo, `#índice_de_eventos` y nunca `#event_index`. Como una ancla inexistente equivale a no poner ancla, lo correcto es dejar sólo el enlace a la página y añadir el fragmento cuando el destino esté traducido.
 
-   Para los **enlaces dentro de la misma página** (`[ver más](#cómo_funciona)`), la ancla debe coincidir con el ID generado por el encabezado traducido. Si tradujiste `## How it works` como `## Cómo funciona`, el enlace debe ser `#cómo_funciona`.
+   **Ejemplo del problema frecuente:** el inglés tiene `/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated`. Al traducir se cambia la URL a `/es/`, y el fragmento se copia tal cual porque la página existe y el enlace "se ve bien". Pero los encabezados de esa página en español se renderizan como `experimental`, `obsoleto` y `en_desuso`: no hay ningún ID `deprecated`, así que el lector aterriza al inicio de la página.
 
-   **Cómo verificar el ID real de un encabezado:** la forma exacta en que un encabezado se convierte en ID (si conserva tildes, mayúsculas, guiones bajos, etc.) depende de la versión actual del motor de _build_ (Rari), así que no conviene deducirlo a mano. Para confirmarlo, levanta el sitio localmente:
+   **Cómo verificar los IDs reales de una página en español:** cualquier página publicada expone su HTML ya renderizado en `index.json`, que es la forma más rápida de leer los IDs sin levantar nada:
+
+   ```bash
+   curl -sL "https://developer.mozilla.org/es/docs/<Ruta>/index.json" | grep -oE '"id":"[^"]*"'
+   ```
+
+   Para las páginas que estás modificando en un PR, el bot publica una URL de previsualización; sirve igual:
+
+   ```bash
+   curl -s "https://prNNNNN.review.mdn.allizom.net/es/docs/<Ruta>" | grep -oiE '<h[2-6][^>]*id="[^"]*"'
+   ```
+
+   No deduzcas el ID a mano: la forma exacta en que un encabezado se convierte en ID (si conserva tildes, mayúsculas, signos de apertura `¿`, etc.) la decide el motor de _build_ (Rari). Como alternativa, también puedes levantar el sitio localmente:
 
    ```bash
    # Desde tu clon de mdn/content, con CONTENT_TRANSLATED_ROOT apuntando a translated-content


### PR DESCRIPTION
> **Borrador.** Corrige una afirmación técnica de la guía; lo abro como _draft_ para que el equipo confirme la conclusión antes de fusionar.

## Problema

La guía de localización al español afirma que MDN muestra el contenido en inglés como respaldo (_fallback_) cuando falta la traducción:

> MDN renderiza el contenido en inglés como respaldo (_fallback_) para las secciones o páginas que aún no han sido traducidas, pero siempre bajo la URL `/es/`. Un enlace como `/es/docs/Web/API/Fetch_API` funciona correctamente aunque la página no tenga traducción completa.

Es una confusión entendible, porque **sí existe un respaldo, pero es un enlace, no un renderizado**. Lo que ocurre de verdad son dos pasos:

1. Si no existe `files/es/<ruta>/index.md`, la URL `/es/docs/<Ruta>` devuelve **HTTP `404`** con la página «Page not found» (`data-renderer="SpaNotFound"`, `<title>Page not found | MDN</title>`). En esa respuesta no viene nada del artículo en inglés.
2. Ya en el navegador, MDN consulta si la página existe en inglés y, si existe, muestra un aviso con un **enlace** a `/en-US/docs/<Ruta>`: _«**Good news!** The page you requested doesn't exist in **Spanish** but it exists in **English**»_. Es [`client/src/page-not-found/fallback-link.tsx`](https://github.com/mdn/yari/blob/main/client/src/page-not-found/fallback-link.tsx) en Yari.

La URL sigue siendo `/es/`, el estado sigue siendo `404`, y hay que hacer clic para llegar al inglés.

Se puede comprobar con cualquier página que exista en inglés y no en español:

```bash
for s in Functions Event_bubbling DOM_scripting Debugging_JavaScript; do
  echo "$s en=$(curl -s -o /dev/null -w '%{http_code}' "https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Scripting/$s")" \
       "es=$(curl -s -o /dev/null -w '%{http_code}' "https://developer.mozilla.org/es/docs/Learn_web_development/Core/Scripting/$s")"
done
# Functions             en=200 es=404
# Event_bubbling        en=200 es=404
# DOM_scripting         en=200 es=404
# Debugging_JavaScript  en=200 es=404
```

Tampoco hay respaldo por secciones. `files/es/web/api/fetch_api/index.md` tiene 61 líneas frente a 70 del original, y la página publicada expone exactamente los encabezados de su propio archivo (`conceptos_y_uso`, `abortar_una_petición`, `fetch_interfaces_o_métodos`, …): las secciones no traducidas simplemente no aparecen, no se rellenan con inglés.

Medido el 2026-08-03 contra producción.

## Por qué importa

La regla que se apoya en esa afirmación —**usar siempre `/es/`**— es correcta, pero por otra razón: consistencia de idioma, no respaldo. Lo que sí queda mal es la guía de anclas construida sobre la premisa equivocada:

> | Página _sin_ traducción | `/es/docs/Web/API/Fetch_API` | MDN sirve inglés (fallback) | Ancla en inglés: `#browser_compatibility` |

Siguiendo esa fila, quien traduce conserva el fragmento en inglés esperando que funcione mientras la página destino no esté traducida. Falla por dos lados:

- **Hoy no sirve de nada.** La página devuelve `404` y el enlace de respaldo apunta a `document.mdn_url`, es decir a la página en inglés **sin** conservar el `#fragmento`.
- **Mañana tampoco.** Cuando esa página se traduzca, el encabezado se traducirá con ella, así que el ID pasará a ser `#compatibilidad_con_navegadores` y nunca `#browser_compatibility`. El fragmento queda roto para siempre, y en silencio, porque una ancla inexistente no da error: el lector simplemente se queda al inicio de la página.

Es un caso real y recurrente en las revisiones (por ejemplo #37185, #37371 y #37500).

## Qué cambia este PR

Reescribe el bloque del paso 4 de «Traducir un documento»:

- **Corrige la afirmación del respaldo** explicando los dos pasos reales (404 + enlace en el cliente), en lugar de decir que el inglés se renderiza bajo la URL `/es/`. También aclara que no hay respaldo por secciones.
- **Incluye el comando `curl`** para que cualquiera pueda verificarlo sin creer en la guía a ciegas.
- **Conserva y refuerza la regla `/es/`** con sus motivos reales: no sacar al lector de su idioma, y que un enlace `/es/` hacia una página aún sin traducir empieza a funcionar solo en cuanto alguien la traduzca (mismo criterio que usan las macros `{{PreviousMenuNext}}`, `{{domxref}}`, `{{Glossary}}`).
- **Rehace la tabla de anclas** sobre el criterio correcto: la ancla debe corresponder a un encabezado que exista en la página en español. Si no existe (porque la página no está traducida o está desactualizada), se quita el fragmento y se deja sólo el enlace a la página.
- **Añade la advertencia explícita** de no conservar la ancla en inglés «mientras tanto», con las dos razones de por qué no se arregla sola.
- **Reemplaza el ejemplo** por uno verificable: `Experimental_deprecated_obsolete#deprecated`, cuya página en español renderiza `experimental`, `obsoleto` y `en_desuso`.
- **Agrega una forma rápida de verificar los IDs** con el `index.json` de la página publicada (o la URL de previsualización del PR), y mantiene la opción de levantar el sitio localmente como alternativa.

## Verificación

- `npm run lint:md` limpio (Prettier + markdownlint).
- Los comportamientos descritos se comprobaron contra producción con los comandos incluidos en la propia sección.

## Nota

Es independiente de #37506 (documentación sobre imágenes), aunque ambos toquen `docs/es/README.md`. Vale la pena señalar un matiz que podría parecer contradictorio entre los dos: **para imágenes sí existe respaldo real en el _build_** (el `src` se reescribe hacia `/en-US/` cuando el archivo no está en la carpeta del locale, y la imagen se muestra dentro de la página en español). El respaldo que no existe es el de páginas y secciones. Los dos PRs quedan redactados para no confundir ambos casos.
