### PR TITLE
[es] Add Spanish translation for retired content

### DIFF
--- a/files/es/mdn/writing_guidelines/howto/retiring_content/retired_content/index.md
+++ b/files/es/mdn/writing_guidelines/howto/retiring_content/retired_content/index.md
@@ -1,0 +1,59 @@
+---
+title: Contenido retirado
+slug: MDN/Writing_guidelines/Howto/Retiring_content/Retired_content
+page-type: mdn-writing-guide
+sidebar: mdnsidebar
+l10n:
+  sourceCommit: ca0b474bb2e153ce72718cb304306e540065a888
+---
+
+Esta página lista las secciones de MDN Web Docs que se han retirado. Cada
+entrada incluye un enlace al contenido archivado en el
+[repositorio MDN Museum](https://github.com/mdn/museum) y al issue o discusión
+de GitHub donde se tomó la decisión de retirarlo.
+
+Para más detalles sobre cómo funciona el retiro de contenido, consulta la guía
+[Retiro de contenido](/en-US/docs/MDN/Writing_guidelines/Howto/Retiring_content).
+
+## Secciones retiradas
+
+### Canvas Raycaster
+
+- **Retirado:** junio de 2022
+- **Contenido archivado:** [museum/canvas-raycaster](https://github.com/mdn/museum/tree/main/canvas-raycaster)
+- **Issue en GitHub:** [Move canvas-raycaster into mdn/museum](https://github.com/mdn/mdn/issues/193)
+
+Una demo de raycasting de Canvas API y su página de documentación
+acompañante. El contenido se movió al museo como parte de las tareas de
+mantenimiento del repositorio.
+
+> [!NOTE]
+> Este retiro fue anterior al proceso de
+> [Retiro de contenido](/en-US/docs/MDN/Writing_guidelines/Howto/Retiring_content).
+> No queda ninguna discusión al respecto.
+
+### WebVR
+
+- **Retirado:** septiembre de 2022
+- **Archivo en GitHub:** [museum/webvr](https://github.com/mdn/museum/tree/main/webvr)
+- **PR en GitHub:** [Import webvr tests](https://github.com/mdn/museum/pull/6)
+
+Una colección de ejemplos de pruebas de la API WebVR, que incluye información
+básica de pantalla, parámetros de escenario, WebGL sin procesar, demos de
+controladores de realidad virtual y una demo de A-Frame. La API WebVR quedó en
+desuso en favor de la [API WebXR Device](/es/docs/Web/API/WebXR_Device_API).
+
+> [!NOTE]
+> Este retiro fue anterior al proceso de
+> [Retiro de contenido](/en-US/docs/MDN/Writing_guidelines/Howto/Retiring_content).
+> No queda ninguna discusión al respecto.
+
+<!--
+### Nombre de la sección
+
+- **Retirado:** MES AÑO
+- **Contenido archivado:** [Nombre de la sección](https://github.com/mdn/museum/tree/main/nombre_de_la_seccion/)
+- **Discusión:** [Título de la discusión](https://github.com/orgs/mdn/discussions/XXXX)
+
+Breve descripción de qué cubría la sección y por qué se retiró.
+-->


### PR DESCRIPTION
Adds the Spanish translation for `mdn/writing_guidelines/howto/retiring_content/retired_content`.

Fixes #37428