### PR TITLE
chore(ja): Fix typo in "ruby-overhang CSS プロパティ"

### DIFF
--- a/files/ja/web/css/reference/properties/ruby-overhang/index.md
+++ b/files/ja/web/css/reference/properties/ruby-overhang/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: bcbb4bd6a80292c0663b723d5466759cfaaa8315
 ---
 
-**`ruby-overhang`** は [CSS](/ja/docs/Web/CSS) のプロアpティで、{{htmlelement("ruby")}} の注釈が周囲のテキストからはみ出すかどうかを指定します。
+**`ruby-overhang`** は [CSS](/ja/docs/Web/CSS) のプロパティで、{{htmlelement("ruby")}} の注釈が周囲のテキストからはみ出すかどうかを指定します。
 
 {{InteractiveExample("CSS Demo: ruby-overhang")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

「プロパティ」の誤植修正です。

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

正しい語となりより自然に読めます。

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
