### PR TITLE
chore(fr): update of `/mozilla/add-ons/webextensions/api/runtime/geturl`

### DIFF
--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
@@ -3,7 +3,7 @@ title: runtime.getURL()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/getURL
 ---
 
-{{AddonSidebar}}Etant donné un chemin relatif de [manifest.json](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json) à une ressource empaquetée avec l'extension, renvoyez une URL complète.Cette fonction ne vérifie pas que la ressource existe réellement à cette URL.
+{{AddonSidebar}}Reçoit en argument un chemin relatif à [manifest.json](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json) et renvoie l'URL complète correspondante. Il s'agit du chemin d'une ressource empaquetée dans l'extension. La fonction ne vérifie pas l'existance de la ressource.
 
 ## Syntaxe
 


### PR DESCRIPTION
Change in 1 file in french : files/fr/mozilla/add-ons/webextensions/api/runtime/geturl/index.md

### Description

Dans le fichier files/fr/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
Changé le texte d'introduction avant #Syntaxe, j'essaie d'être plus clair en faisant plus court.
élimine une faute

### Motivation

Il y avait une faute, "renvoyez une URL complète" alors que le sujet est la fonction.
+ Le texte d'intro concerné m'a paru un peu alambiqué, j'ai préféré reformuler un peu.