### PR TITLE
zh-cn: sync RegExp Symbol methods lastIndex behavior

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.match/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.match/index.md
@@ -39,7 +39,7 @@ match 方法会返回一个数组，它包括整个匹配结果，和通过捕�
 
 ## 描述
 
-这个方法在 {{jsxref("String.prototype.match()")}} 的内部调用。例如，下面的两个方法返回相同结果。
+此方法用于在 `RegExp` 子类中自定义匹配行为。它在内部被 {{jsxref("String.prototype.match()")}} 调用。例如，下面的两个方法返回相同结果。
 
 ```js
 "abc".match(/a/);
@@ -47,7 +47,34 @@ match 方法会返回一个数组，它包括整个匹配结果，和通过捕�
 /a/[Symbol.match]("abc");
 ```
 
-这个方法为自定义 `RegExp` 子类中的匹配行为而存在。
+如果正则表达式是全局的（带有 `g` 标志），其 [`lastIndex`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) 会先被设置为 0，因此匹配总是从字符串开头开始。然后会重复调用正则表达式的 [`exec()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) 方法，直到 `exec()` 返回 `null`。如果当前匹配为空字符串，`lastIndex` 仍会递增——如果正则表达式是[支持 Unicode](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode_感知模式)的，则递增一个 Unicode 码位；否则递增一个 UTF-16 码元。
+
+```js
+console.log("😄".match(/(?:)/g)); // [ '', '', '' ]
+console.log("😄".match(/(?:)/gu)); // [ '', '' ]
+```
+
+如果正则表达式不是全局的，则只会调用一次 `exec()`，其结果将成为 `[Symbol.match]()` 的返回值。
+
+`exec()` 方法会在最后一次匹配失败时自动将 `lastIndex` 重置为 0。因此，对于 `lastIndex` 从 0 开始的全局正则表达式，`[Symbol.match]()` 通常不会产生副作用。但是，对于非全局的[粘性](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky)正则表达式，只会调用一次 `exec()`，如果匹配成功，`lastIndex` 就不会被重置。在这种情况下，每次调用 `match()` 可能会返回不同的结果。
+
+```js
+const re = /[abc]/y;
+for (let i = 0; i < 5; i++) {
+  console.log("abc".match(re), re.lastIndex);
+}
+// [ 'a' ] 1
+// [ 'b' ] 2
+// [ 'c' ] 3
+// null 0
+// [ 'a' ] 1
+```
+
+当正则表达式同时具有粘性和全局标志时，仍会执行粘性匹配，也就是说不会匹配 `lastIndex` 之后的任何内容。
+
+```js
+console.log("ab-c".match(/[abc]/gy)); // [ 'a', 'b' ]
+```
 
 ## 示例
 

--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.matchall/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.matchall/index.md
@@ -54,7 +54,9 @@ regexp[Symbol.matchAll](str)
 const regexp = /[a-c]/g;
 regexp.lastIndex = 1;
 const str = "abc";
-console.log(Array.from(str.matchAll(regexp), (m) => `${regexp.lastIndex} ${m[0]}`));
+console.log(
+  Array.from(str.matchAll(regexp), (m) => `${regexp.lastIndex} ${m[0]}`),
+);
 // [ "1 b", "1 c" ]
 ```
 

--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.matchall/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.matchall/index.md
@@ -40,7 +40,7 @@ regexp[Symbol.matchAll](str)
 
 ## 描述
 
-本方法在{{jsxref("String.prototype.matchAll()")}}中被内部调用。例如，以下两个示例返回相同的结果。
+本方法用于在 `RegExp` 子类中自定义 `matchAll()` 的行为。它在内部被{{jsxref("String.prototype.matchAll()")}}调用。例如，以下两个示例返回相同的结果。
 
 ```js
 "abc".matchAll(/a/);
@@ -48,7 +48,33 @@ regexp[Symbol.matchAll](str)
 /a/[Symbol.matchAll]("abc");
 ```
 
-本方法用于自定义`RegExp`子类中的匹配行为。
+与 [`[Symbol.split]()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.split) 类似，[`[Symbol.matchAll]()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.matchAll) 首先使用 [`[Symbol.species]`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.species) 构造一个新的正则表达式，从而避免以任何方式修改原始正则表达式。构造函数接收 `this` 和原始标志。 [`lastIndex`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) 从原始正则表达式的值开始。
+
+```js
+const regexp = /[a-c]/g;
+regexp.lastIndex = 1;
+const str = "abc";
+console.log(Array.from(str.matchAll(regexp), (m) => `${regexp.lastIndex} ${m[0]}`));
+// [ "1 b", "1 c" ]
+```
+
+如果正则表达式是全局的（带有 `g` 标志），每次调用返回迭代器的 `next()` 方法时，都会调用正则表达式的 [`exec()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) 方法并返回结果。如果当前匹配为空字符串，[`lastIndex`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) 仍会递增。如果正则表达式带有 [`u`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode) 标志，则递增一个 Unicode 码位；否则递增一个 UTF-16 码元。
+
+```js
+console.log(Array.from("😄".matchAll(/(?:)/g)));
+// [ [ "" ], [ "" ], [ "" ] ]
+console.log(Array.from("😄".matchAll(/(?:)/gu)));
+// [ [ "" ], [ "" ] ]
+```
+
+如果正则表达式不是全局的，返回的迭代器会返回一次 [`exec()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) 的结果，然后结束。（输入是否为全局正则表达式由 [`String.prototype.matchAll()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll) 验证。`[Symbol.matchAll]()` 不会验证 `this` 的标志。）
+
+当正则表达式同时具有粘性和全局标志时，仍会执行粘性匹配，也就是说不会匹配 `lastIndex` 之后的任何内容。
+
+```js
+console.log(Array.from("ab-c".matchAll(/[abc]/gy)));
+// [ [ "a" ], [ "b" ] ]
+```
 
 ## 示例
 

--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.matchall/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.matchall/index.md
@@ -40,7 +40,7 @@ regexp[Symbol.matchAll](str)
 
 ## 描述
 
-本方法用于在 `RegExp` 子类中自定义 `matchAll()` 的行为。它在内部被{{jsxref("String.prototype.matchAll()")}}调用。例如，以下两个示例返回相同的结果。
+本方法用于在 `RegExp` 子类中自定义 `matchAll()` 的行为。它在内部被 {{jsxref("String.prototype.matchAll()")}} 调用。例如，以下两个示例返回相同的结果。
 
 ```js
 "abc".matchAll(/a/);

--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.replace/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.replace/index.md
@@ -39,7 +39,7 @@ regexp[Symbol.replace](str, replacement)
 
 ## 描述
 
-如果匹配模式也是 {{jsxref("RegExp")}} 对象，这个方法在 {{jsxref("String.prototype.replace()")}} 的内部调用。例如，下面的两个方法返回相同结果。
+该方法用于在 `RegExp` 子类中自定义替换行为。如果 `pattern` 参数是 {{jsxref("RegExp")}} 对象，它会在内部被 {{jsxref("String.prototype.replace()")}} 和 {{jsxref("String.prototype.replaceAll()")}} 调用。例如，下面的两个方法返回相同结果。
 
 ```js
 "abc".replace(/a/, "A");
@@ -47,7 +47,36 @@ regexp[Symbol.replace](str, replacement)
 /a/[Symbol.replace]("abc", "A");
 ```
 
-该方法是为了在 RegExp 子类中自定义匹配的替换模式。
+如果正则表达式是全局的（带有 `g` 标志），其 [`lastIndex`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) 会先被设置为 0，因此匹配总是从字符串开头开始。然后会重复调用正则表达式的 [`exec()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) 方法，直到 `exec()` 返回 `null`。如果当前匹配为空字符串，`lastIndex` 仍会递增——如果正则表达式是[支持 Unicode](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode_感知模式)的，则递增一个 Unicode 码位；否则递增一个 UTF-16 码元。
+
+```js
+console.log("😄".replace(/(?:)/g, " ")); // " \ud83d \ude04 "
+console.log("😄".replace(/(?:)/gu, " ")); // " 😄 "
+```
+
+如果正则表达式不是全局的，则只会调用一次 `exec()`。
+
+替换会在识别出所有匹配的子字符串后进行。对于每个成功的 `exec()` 结果，会根据 `replacement` 参数创建替换字符串，具体过程见 [`String.prototype.replace()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/String/replace#描述)。
+
+`exec()` 方法会在最后一次匹配失败时自动将 `lastIndex` 重置为 0。因此，对于 `lastIndex` 从 0 开始的全局正则表达式，`[Symbol.replace]()` 通常不会产生副作用。但是，对于非全局的[粘性](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky)正则表达式，只会调用一次 `exec()`，如果匹配成功，`lastIndex` 就不会被重置。在这种情况下，每次调用 `replace()` 可能会返回不同的结果。
+
+```js
+const re = /a/y;
+for (let i = 0; i < 5; i++) {
+  console.log("aaa".replace(re, "b"), re.lastIndex);
+}
+// baa 1
+// aba 2
+// aab 3
+// aaa 0
+// baa 1
+```
+
+当正则表达式同时具有粘性和全局标志时，仍会执行粘性匹配，也就是说不会匹配 `lastIndex` 之后的任何内容。
+
+```js
+console.log("aa-a".replace(/a/gy, "b")); // "bb-a"
+```
 
 如果匹配模式不是一个{{jsxref("RegExp")}} 对象，{{jsxref("String.prototype.replace()")}} 就不会调用该方法，也不会创建一个 {{jsxref("RegExp")}}对象。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.search/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.search/index.md
@@ -23,7 +23,7 @@ regexp[Symbol.search](str)
 
 ## 描述
 
-这个方法在 {{jsxref("String.prototype.search()")}} 的内部调用。例如，下面的两个方法返回相同结果。
+这个方法用于在 `RegExp` 子类中自定义搜索行为。它在内部被 {{jsxref("String.prototype.search()")}} 调用。例如，下面的两个方法返回相同结果。
 
 ```js
 "abc".search(/a/);
@@ -31,7 +31,20 @@ regexp[Symbol.search](str)
 /a/[Symbol.search]("abc");
 ```
 
-这个方法为自定义 `RegExp` 子类中的匹配行为而存在。
+`[Symbol.search]()` 总是恰好调用一次正则表达式的 [`exec()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) 方法，并返回结果的 `index` 属性；如果结果为 `null`，则返回 `-1`。`g` 标志对此方法没有影响。
+
+与 [`[Symbol.split]()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.split) 或 [`[Symbol.matchAll]()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.matchAll) 不同，此方法不会复制正则表达式。但是，与 [`[Symbol.match]()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.match) 或 [`[Symbol.replace]()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.replace) 不同，它总会在执行开始时将 [`lastIndex`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) 设置为 0，并在退出时恢复之前的值，因此通常不会产生副作用。这意味着即使 `lastIndex` 不为 0，它也总是返回字符串中的第一个匹配项，并且粘性正则表达式总是严格从字符串开头搜索。
+
+```js
+const re = /[abc]/g;
+re.lastIndex = 2;
+console.log("abc".search(re)); // 0
+
+const re2 = /[bc]/y;
+re2.lastIndex = 1;
+console.log("abc".search(re2)); // -1
+console.log("abc".match(re2)); // [ 'b' ]
+```
 
 ## 示例
 

--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.split/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.split/index.md
@@ -44,7 +44,7 @@ regexp[Symbol.split](str, limit)
 
 ## 描述
 
-此方法用于在自定义 `RegExp` 子类中自定义 `split()` 的行为。当 `RegExp` 作为分隔符传入时，{{jsxref("String.prototype.split()")}} 会在内部调用此方法。例如，下面的两个示例返回相同的结果。
+此方法用于在 `RegExp` 子类中自定义 `split()` 的行为。当 `RegExp` 作为分隔符传入时，{{jsxref("String.prototype.split()")}} 会在内部调用此方法。例如，下面的两个示例返回相同的结果。
 
 ```js
 "a-b-c".split(/-/);
@@ -56,7 +56,7 @@ regexp[Symbol.split](str, limit)
 
 如果目标字符串是空字符串，且正则表达式可以匹配空字符串（例如 `/a?/`），则返回空数组。否则，如果正则表达式无法匹配空字符串，则返回 `[""]`。
 
-正则表达式的 [`exec()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) 方法会被重复调用，每次调用都会推进 `lastIndex`，直到到达字符串末尾。如果当前匹配为空字符串，或者正则表达式（由于启用了粘性）在当前位置无法匹配，那么 `lastIndex` 仍会被推进——如果正则是[支持 Unicode](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode_感知模式)的，则推进一个 Unicode 码位；否则，推进一个 UTF-16 码元。
+正则表达式的 [`exec()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) 方法会被重复调用，每次调用都会推进 `lastIndex`，直到到达字符串末尾。如果当前匹配为空字符串，或者正则表达式（由于启用了粘性）在当前位置无法匹配，那么 `lastIndex` 仍会被推进——如果正则是[支持 Unicode](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode_感知模式) 的，则推进一个 Unicode 码位；否则，推进一个 UTF-16 码元。
 
 ```js
 console.log("😄".split(/(?:)/g)); // [ '\ud83d', '\ude04' ]

--- a/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.split/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/regexp/symbol.split/index.md
@@ -44,7 +44,7 @@ regexp[Symbol.split](str, limit)
 
 ## 描述
 
-当 `RegExp` 作为分隔符传入时，{{jsxref("String.prototype.split()")}} 会在内部调用此方法。例如，下面的两个示例返回相同的结果。
+此方法用于在自定义 `RegExp` 子类中自定义 `split()` 的行为。当 `RegExp` 作为分隔符传入时，{{jsxref("String.prototype.split()")}} 会在内部调用此方法。例如，下面的两个示例返回相同的结果。
 
 ```js
 "a-b-c".split(/-/);
@@ -52,18 +52,20 @@ regexp[Symbol.split](str, limit)
 /-/[Symbol.split]("a-b-c");
 ```
 
-此方法用于在自定义 `RegExp` 子类中 `split()` 方法的行为。
+与 [`[Symbol.matchAll]()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.matchAll) 类似，[`[Symbol.split]()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.split) 首先使用 [`[Symbol.species]`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.species) 构造一个新的正则表达式，从而避免以任何方式修改原始正则表达式。构造函数接收 `this` 和原始标志；如果原始标志中没有 `y`（“粘性”）标志，还会添加该标志。`g`（“全局”）标志与此方法的行为无关。由于 `RegExp()` 构造函数的行为，[`lastIndex`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) 默认从 0 开始。
 
-`RegExp.prototype[Symbol.split]()` 基础方法具有以下行为：
+如果目标字符串是空字符串，且正则表达式可以匹配空字符串（例如 `/a?/`），则返回空数组。否则，如果正则表达式无法匹配空字符串，则返回 `[""]`。
 
-- 它首先使用 [`[Symbol.species]`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.species) 构造一个新的正则表达式，从而避免对原始正则表达式进行任何修改。
-- 该正则表达式的 `g`（“全局”）标志会被忽略，而 `y`（“粘性”）标志则始终会被应用，即使它最初并未设置。
-- 如果目标字符串是空字符串，且正则表达式可以匹配空字符串（例如 `/a?/`），则返回空数组。否则，如果正则表达式无法匹配空字符串，则返回 `[""]`。
-- 匹配过程通过不断调用 `this.exec()`。由于正则表达式始终带有粘性标志，每次调用都会沿字符串向前推进，返回匹配的字符串、匹配位置索引以及任何捕获组。
-- 对于每一次匹配，首先将上一个匹配结束位置与当前匹配开始位置之间的子字符串添加到结果数组中。然后，将当前匹配中的捕获组值逐个添加进去。
-- 如果当前匹配是空字符串，或者正则表达式（由于启用了粘性）在当前位置无法匹配，那么 `lastIndex` 仍会被推进——如果正则是 [Unicode 感知](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode_感知模式)的，则推进一个 Unicode 码位；否则，推进一个 UTF-16 码元。
-- 如果正则表达式无法匹配目标字符串，则返回原始字符串本身，并将其包裹在一个数组中。
-- 返回的数组长度不会超过提供的 `limit` 参数（如果有的话），同时会尽可能接近该限制。因此，如果数组已满，最后一个匹配项及其捕获组可能不会全部出现在返回的数组中。
+正则表达式的 [`exec()`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) 方法会被重复调用，每次调用都会推进 `lastIndex`，直到到达字符串末尾。如果当前匹配为空字符串，或者正则表达式（由于启用了粘性）在当前位置无法匹配，那么 `lastIndex` 仍会被推进——如果正则是[支持 Unicode](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode_感知模式)的，则推进一个 Unicode 码位；否则，推进一个 UTF-16 码元。
+
+```js
+console.log("😄".split(/(?:)/g)); // [ '\ud83d', '\ude04' ]
+console.log("😄".split(/(?:)/gu)); // [ '😄' ]
+```
+
+对于每一次匹配，首先将上一个匹配结束位置与当前匹配开始位置之间的子字符串添加到结果数组中。然后，将当前匹配中的捕获组值逐个添加进去。返回的数组长度不会超过提供的 `limit` 参数（如果有的话），同时会尽可能接近该限制。因此，如果数组已满，最后一个匹配项及其捕获组可能不会全部出现在返回的数组中。
+
+如果整个字符串中没有成功匹配，则返回原始字符串本身，并将其包裹在一个数组中。
 
 ## 示例
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
sync https://github.com/mdn/content/pull/44957
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
