### PR TITLE
chore(fr): translation of `Mozilla/Add-ons/Contact_us`

### DIFF
--- a/files/fr/mozilla/add-ons/contact_us/index.md
+++ b/files/fr/mozilla/add-ons/contact_us/index.md
@@ -1,0 +1,29 @@
+---
+title: Nous contacter
+slug: Mozilla/Add-ons/Contact_us
+l10n:
+  sourceCommit: 0c81cbce5f95a0be935724bcd936f5592774eb3a
+---
+
+Utilisez les liens ci-dessous pour obtenir de l'aide, pour vous tenir au courant des actualités sur les modules complémentaires et pour nous faire part de vos commentaires.
+
+## Forum des modules complémentaires
+
+Utilisez le [forum Discourse des modules complémentaires <sup>(angl.)</sup>](https://discourse.mozilla.org/c/add-ons/35) pour discuter de tous les aspects du développement des modules complémentaires et pour demander de l'aide.
+
+## Discussion instantanée
+
+[Matrix <sup>(angl.)</sup>](https://matrix.org/) est un protocole ouvert et léger pour les communications décentralisées en temps réel. Pour savoir comment rejoindre l'instance Matrix de Mozilla, consultez la [page de Matrix sur MozillaWiki <sup>(angl.)</sup>](https://wiki.mozilla.org/Matrix).
+
+- [Modules complémentaires <sup>(angl.)</sup>](https://chat.mozilla.org/#/room/#addons:mozilla.org) (assistance pour les extensions, les thèmes et l'API WebExtensions)
+- [AMO <sup>(angl.)</sup>](https://chat.mozilla.org/#/room/#amo:mozilla.org) (discussion autour de addons.mozilla.org)
+
+## Signaler des problèmes
+
+### Vulnérabilités de sécurité
+
+Si vous découvrez une vulnérabilité de sécurité dans un module complémentaire, même si le module complémentaire n'est pas hébergé sur un site de Mozilla, prévenez-nous. Nous travaillons avec la personne qui développe le module pour corriger le problème. Signalez les vulnérabilités de sécurité [de manière confidentielle <sup>(angl.)</sup>](https://www.mozilla.org/en-US/about/governance/policies/security-group/bugs/) dans [Bugzilla <sup>(angl.)</sup>](https://bugzilla.mozilla.org/enter_bug.cgi?product=addons.mozilla.org&component=Add-on%20Security&maketemplate=Add-on%20Security%20Bug&bit-23=1&rep_platform=All&op_sys=All).
+
+### Bogues sur addons.mozilla.org (AMO)
+
+Si vous trouvez un problème sur le site, nous souhaitons le corriger. Veuillez [signaler un bogue <sup>(angl.)</sup>](https://github.com/mozilla/addons/issues/new/choose) et inclure autant de détails que possible.


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Mozilla/Add-ons/Contact_us`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_