### PR TITLE
[es] Sync sourceCommit on MDN writing guidelines pages

### DIFF
--- a/files/es/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/es/mdn/writing_guidelines/howto/images_media/index.md
@@ -3,7 +3,7 @@ title: Cómo añadir imágenes, medios y recursos
 short-title: Añadir medios
 slug: MDN/Writing_guidelines/Howto/Images_media
 l10n:
-  sourceCommit: 0ff7ba5177bf2e66214bd90b58590c6bf3acb758
+  sourceCommit: c655f38c10ba17b853b0e66b43cf4cf2b176e424
 ---
 
 Esta página describe cómo añadir imágenes y medios a las páginas de documentación de MDN.

--- a/files/es/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
@@ -2,7 +2,7 @@
 title: Banners y avisos
 slug: MDN/Writing_guidelines/Page_structures/Banners_and_notices
 l10n:
-  sourceCommit: ca26363fcc6fc861103d40ac0205e5c5b79eb2fa
+  sourceCommit: 793bcbe2dd88fc553d2c4c918c4dec4899704022
 ---
 
 Los banners y avisos se muestran en algunas páginas, en particular en la referencia de la API, para destacar factores importantes que afectarán el uso del contenido descrito.

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
@@ -2,7 +2,7 @@
 title: Plantilla de página de selector CSS
 slug: MDN/Writing_guidelines/Page_structures/Page_types/CSS_selector_page_template
 l10n:
-  sourceCommit: d2fb8cdc9422dd2b68ff23f616d70811729f1fbd
+  sourceCommit: 8d9cda4e9080e9c324a521f40c7e0704ef94ce07
 ---
 
 > [!NOTE]

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/html_attribute_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/html_attribute_page_template/index.md
@@ -2,7 +2,7 @@
 title: Plantilla de página de atributo HTML
 slug: MDN/Writing_guidelines/Page_structures/Page_types/HTML_attribute_page_template
 l10n:
-  sourceCommit: a84b606ffd77c40a7306be6c932a74ab9ce6ab96
+  sourceCommit: 8d9cda4e9080e9c324a521f40c7e0704ef94ce07
 ---
 
 Los atributos HTML se dividen en dos categorías: **atributos específicos de elementos**, que se aplican solo a ciertos elementos (p. ej., el atributo `accept` en `<input type="file">`), y **atributos globales**, que pueden usarse en cualquier elemento HTML (p. ej., `class`, `id`). Los primeros deben ubicarse en `HTML/Reference/Attributes`, mientras que los segundos deben ir en `HTML/Reference/Global_attributes`.

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
@@ -2,7 +2,7 @@
 title: Plantilla de página de encabezado HTTP
 slug: MDN/Writing_guidelines/Page_structures/Page_types/HTTP_header_page_template
 l10n:
-  sourceCommit: ad5b5e31f81795d692e66dadb7818ba8b220ad15
+  sourceCommit: 8d9cda4e9080e9c324a521f40c7e0704ef94ce07
 ---
 
 > [!NOTE]

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/index.md
@@ -2,7 +2,7 @@
 title: Tipos de página
 slug: MDN/Writing_guidelines/Page_structures/Page_types
 l10n:
-  sourceCommit: e0a2b683c4ddaeecdc4ddebf16e4a72c2dda17ac
+  sourceCommit: 7ed7b730bf88307cc6cf34b82bb1d735b9a1aa1f
 ---
 
 MDN utiliza repetidamente varios tipos de páginas.

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -2,7 +2,7 @@
 title: La clave page-type de front matter
 slug: MDN/Writing_guidelines/Page_structures/Page_types/Page_type_key
 l10n:
-  sourceCommit: bd8f07e677d3bf6d5ebb0bccec3afb48f52921b5
+  sourceCommit: 87ca9db1ebe56eb20c1f20b91fca43955d8f0e26
 ---
 
 La clave `page-type` de front matter describe el tipo de una página de MDN.

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
@@ -2,7 +2,7 @@
 title: Plantilla de página de elemento SVG
 slug: MDN/Writing_guidelines/Page_structures/Page_types/SVG_element_page_template
 l10n:
-  sourceCommit: 39d45a2e71cee2c107a026a59ba0d9229a511592
+  sourceCommit: 8d9cda4e9080e9c324a521f40c7e0704ef94ce07
 ---
 
 {{MDNSidebar}}

--- a/files/es/mdn/writing_guidelines/what_we_write/index.md
+++ b/files/es/mdn/writing_guidelines/what_we_write/index.md
@@ -2,7 +2,7 @@
 title: Qué escribimos
 slug: MDN/Writing_guidelines/What_we_write
 l10n:
-  sourceCommit: ca0b474bb2e153ce72718cb304306e540065a888
+  sourceCommit: de5b264fa7bf6bb49811bf79f8f28f10835bfb79
 ---
 
 MDN Web Docs contiene documentación _neutral respecto al navegador_ que permite a los desarrolladores web escribir código _agnóstico al navegador_. En este artículo, encontrarás información sobre si un tema o tipo de contenido determinado debe incluirse o no en MDN Web Docs.

--- a/files/es/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/es/mdn/writing_guidelines/writing_style_guide/index.md
@@ -3,7 +3,7 @@ title: Guía de estilo de redacción
 short-title: Guía de estilo
 slug: MDN/Writing_guidelines/Writing_style_guide
 l10n:
-  sourceCommit: a886ef3867e01df856ed9b49b3b6856232cc8c75
+  sourceCommit: c53bfa01f3bf436d486f4032c16f592855a2af2c
 ---
 
 Esta guía de estilo de redacción describe cómo debe escribirse, organizarse, deletrearse y formatearse el contenido en MDN Web Docs.


### PR DESCRIPTION
### Description

Bumps `l10n.sourceCommit` on the ten `files/es/mdn/writing_guidelines/` pages that were still tracking an older English commit. No prose changes: every upstream change since each tracked SHA was an English-only spelling or link chore with no Spanish counterpart.

| Page | Tracked → latest | Upstream change |
| --- | --- | --- |
| `howto/images_media` | `0ff7ba51` → `c655f38c` | GitHub docs URL shortened (see note below) |
| `page_structures/banners_and_notices` | `ca26363f` → `793bcbe2` | spelling fix |
| `page_structures/page_types` | `e0a2b683` → `7ed7b730` | "a HTTP" → "an HTTP" |
| `page_structures/page_types/page_type_key` | `bd8f07e6` → `87ca9db1` | spelling fix |
| `page_structures/page_types/css_selector_page_template` | `d2fb8cdc` → `8d9cda4e` | spelling fix |
| `page_structures/page_types/html_attribute_page_template` | `a84b606f` → `8d9cda4e` | spelling fix |
| `page_structures/page_types/http_header_page_template` | `ad5b5e31` → `8d9cda4e` | spelling fix |
| `page_structures/page_types/svg_element_page_template` | `39d45a2e` → `8d9cda4e` | spelling fix |
| `what_we_write` | `ca0b474b` → `de5b264f` | "fulfil" → "fulfill" |
| `writing_style_guide` | `a886ef38` → `c53bfa01` | CC0 link (already correct in the Spanish page) |

### Motivation

Closes out the last gap in #35373: with all 58 subtasks merged, every `files/es/mdn/writing_guidelines/` page now exists and matches the English source 1:1, but ten of them still pointed at an older SHA, which makes future sync checks report false staleness.

### Additional details

One upstream change was deliberately **not** carried over. In `howto/images_media`, `mdn/content` commit `c655f38c` rewrote the GitHub docs link to `https://docs.github.com/en/pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request`, which **returns 404**; the longer URL currently in the Spanish page (with `/collaborating-with-pull-requests/`) returns 200. Verified with `curl -L` today. The Spanish page keeps the working link, and the broken one should be reported upstream in `mdn/content`.

### Related issues and pull requests

Follow-up to #35373.
