### PR TITLE
sync: Introduction to events (Learn web development) [es]

### DIFF
--- a/files/es/learn_web_development/core/scripting/events/index.md
+++ b/files/es/learn_web_development/core/scripting/events/index.md
@@ -1,66 +1,60 @@
 ---
 title: Introducción a los eventos
+short-title: Eventos
 slug: Learn_web_development/Core/Scripting/Events
-original_slug: Learn/JavaScript/Building_blocks/Events
 l10n:
-  sourceCommit: ac5dfaa2f71a7381cd8fdd4cb554507f375ac19c
+  sourceCommit: 2b4a2ad5d9ba084a9eaa2f9204102655e7b575c4
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Scripting/Return_values","Learn_web_development/Core/Scripting/Image_gallery", "Learn_web_development/Core/Scripting")}}
+{{PreviousMenuNext("Learn_web_development/Core/Scripting/Test_your_skills/Functions","Learn_web_development/Core/Scripting/Event_bubbling", "Learn_web_development/Core/Scripting")}}
 
-Los eventos son cosas que pasan en el sistema que estás programando, el cual se encarga de avisarte para que tu código pueda hacer algo al respecto.
-
-Por ejemplo, si el usuario hace clic en el botón de una página web, puede que quieras reaccionar a esa acción y mostrar una tarjeta con información.
-En este artículo vamos a discutir algunos conceptos importantes sobre los eventos y cómo funcionan en el navegador.
-Este no será un estudio exhaustivo, solo veremos lo que necesitas saber en esta etapa.
+Los eventos son cosas que ocurren en el sistema que estás programando, y que el sistema te notifica para que tu código pueda reaccionar a ellos.
+Por ejemplo, si haces clic en un botón de una página web, podrías querer reaccionar a esa acción mostrando un cuadro de información.
+En este artículo veremos algunos conceptos importantes sobre los eventos, y analizaremos los fundamentos de cómo funcionan en los navegadores.
 
 <table>
   <tbody>
     <tr>
-      <th scope="row">Pre-requisitos:</th>
-      <td>
-  Conocimientos básicos de informática, entendimiento básico de HTML y CSS, <a href="/es/docs/conflicting/Learn_web_development/Core/Scripting"
-          >Primeros pasos con JavaScript</a
-        >.
-      </td>
+      <th scope="row">Requisitos previos:</th>
+      <td>Comprensión de <a href="/es/docs/Learn_web_development/Core/Structuring_content">HTML</a> y de los <a href="/es/docs/Learn_web_development/Core/Styling_basics">fundamentos de CSS</a>, además de familiaridad con los conceptos básicos de JavaScript vistos en lecciones anteriores.</td>
     </tr>
     <tr>
-      <th scope="row">Objetivo:</th>
+      <th scope="row">Resultados del aprendizaje:</th>
       <td>
-Entender la teoría fundamental sobre los eventos, cómo funcionan en el navegador y cómo los eventos son diferentes según el entorno de programación.</td>
+        <ul>
+          <li>Qué son los eventos: una señal que emite el navegador cuando ocurre algo importante, a la que el desarrollador puede responder ejecutando código.</li>
+          <li>Cómo configurar manejadores de eventos usando <code>addEventListener()</code> (y <code>removeEventListener()</code>) y mediante propiedades de manejador de eventos.</li>
+          <li>Los atributos de manejador de eventos en línea, y por qué no deberías usarlos.</li>
+          <li>Los objetos evento.</li>
+        </ul>
+      </td>
     </tr>
   </tbody>
 </table>
 
 ## ¿Qué es un evento?
 
-Los eventos son cosas que suceden en el sistema que estás programando. El sistema se encarga de producir una señal de cierto tipo cuando un evento ocurre, y proporciona un mecanismo para que una acción se lleve a cabo (ejecutar código) de forma automática cuando el evento ocurra.
-Los eventos se lanzan dentro de la ventana del navegador y usualmente están asociados a un elemento en específico dentro de dicha ventana. Esto puede ser un solo elemento, un grupo de elementos, el documento HTML cargado la pestaña actual, o la ventana del navegador en su totalidad.
-Existen distintos tipos de eventos que pueden ocurrir.
+Los eventos son cosas que suceden en el sistema que estás programando: el sistema produce (o "lanza") una señal de algún tipo cuando ocurre un evento, y ofrece un mecanismo para que una acción se ejecute automáticamente (es decir, ejecutar algún código) cuando ocurre el evento.
+Los eventos se lanzan dentro de la ventana del navegador y suelen estar asociados a un elemento específico dentro de ella. Puede tratarse de un solo elemento, un conjunto de elementos, el documento HTML cargado en la pestaña actual, o toda la ventana del navegador.
+Existen muchos tipos distintos de eventos que pueden ocurrir.
 
 Por ejemplo:
 
-- El usuario selecciona, hace clic o pasa el ratón por encima de cierto elemento.
+- El usuario selecciona, hace clic o pasa el cursor sobre un elemento determinado.
 - El usuario presiona una tecla del teclado.
-- El usuario redimensiona o cierra la ventana del navegador.
-- Una página web terminó de cargarse.
-- Un formulario fue enviado.
+- El usuario cambia el tamaño o cierra la ventana del navegador.
+- Una página web termina de cargarse.
+- Se envía un formulario.
 - Un vídeo se reproduce, se pausa o termina.
-- Ocurrió un error.
+- Ocurre un error.
 
-A partir de esto (y dando un vistazo a la [referencia de eventos](/es/docs/Web/API/Document_Object_Model/Events) de MDN) puedes observar que existen **muchos** eventos que pueden ser lanzados.
+A partir de esto (y echando un vistazo al [índice de eventos](/es/docs/Web/API/Document_Object_Model/Events#event_index)) puedes ver que existen **muchos** eventos que se pueden lanzar.
 
-Para reaccionar a un evento, puedes asociarle un **manejador de eventos**. Esto es un bloque de código (normalmente una función de JavaScript que tú como programador creas) que se ejecuta cuando el evento ocurre.
-Cuando uno de estos bloques de código se configura para ejecutarse en respuesta de un evento, decimos que estamos **registrando un manejador de eventos**.
-Nota: Los manejadores de eventos a veces son llamados **detectores de eventos**. Estos términos, para lo que nos concierne justo ahora, son intercambiables, aunque hablando de forma estricta, hacen referencia a dos mecanismos que trabajan juntos.
-Los detectores de eventos están pendientes a que ocurra un evento, mientras que el manejador es el código que se ejecuta en respuesta del evento.
+Para reaccionar a un evento, le asocias un **detector de eventos**. Se trata de una funcionalidad del código que detecta el evento que se lanza. Cuando el evento se lanza, se llama a una función **manejadora de eventos** (referenciada por el detector de eventos, o contenida dentro de él) para responder a dicho evento. Cuando configuramos un bloque de código de este tipo para que se ejecute en respuesta a un evento, decimos que estamos **registrando un manejador de eventos**.
 
-> [!NOTE]
-> Los eventos en la web no son parte del núcleo del lenguaje JavaScript, éstos están definidos como parte de las API del navegador.
+### Un ejemplo: manejar un evento de clic
 
-### Un ejemplo: manejando un evento de clic
-
-En el siguiente ejemplo, tenemos un único elemento {{htmlelement("button")}} en la página:
+En el siguiente ejemplo, tenemos un único {{htmlelement("button")}} en la página:
 
 ```html
 <button>Cambiar el color</button>
@@ -72,7 +66,7 @@ button {
 }
 ```
 
-Ahora tenemos algo de JavaScript. Veremos esto más a detalle en la siguiente sección pero, por ahora, nos basta decir que: agrega un manejador de evento al evento `"click"` del botón, y el manejador reacciona al evento estableciendo un color de fondo aleatorio en la página:
+Luego tenemos algo de JavaScript. Lo veremos con más detalle en la siguiente sección, pero por ahora basta con decir que: agrega un detector de eventos al evento `"click"` del botón, y la función manejadora de eventos contenida reacciona al evento estableciendo un color de fondo aleatorio en la página:
 
 ```js
 const btn = document.querySelector("button");
@@ -82,20 +76,20 @@ function random(number) {
 }
 
 btn.addEventListener("click", () => {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   document.body.style.backgroundColor = rndCol;
 });
 ```
 
-La salida del ejemplo es de la siguiente forma. Intenta hacer clic en el botón:
+El resultado del ejemplo es el siguiente. Intenta hacer clic en el botón:
 
 {{ EmbedLiveSample('An example: handling a click event', '100%', 200, "", "") }}
 
-## Utilizando addEventListener()
+## Uso de addEventListener()
 
-Como pudimos ver en el ejemplo anterior, los objetos que pueden lanzar eventos tienen el método {{domxref("EventTarget/addEventListener", "addEventListener()")}}, y este es el mecanismo recomendado para registrar manejadores de eventos.
+Como vimos en el ejemplo anterior, los objetos que pueden lanzar eventos tienen un método {{domxref("EventTarget/addEventListener", "addEventListener()")}}, y este es el mecanismo recomendado para agregar detectores de eventos.
 
-Ahora veamos más de cerca el código del ejemplo anterior:
+Veamos más de cerca el código del ejemplo anterior:
 
 ```js
 const btn = document.querySelector("button");
@@ -105,18 +99,17 @@ function random(number) {
 }
 
 btn.addEventListener("click", () => {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   document.body.style.backgroundColor = rndCol;
 });
 ```
 
-El elemento HTML {{HTMLElement("button")}} lanzará un evento cuando el usuario hace clic sobre él. Entonces define la función `addEventListener()` que estamos llamando aquí. Le estamos pasando dos parámetros:
+El elemento HTML {{HTMLElement("button")}} lanzará un evento `click` cuando el usuario haga clic en él. Llamamos al método `addEventListener()` sobre ese elemento para agregarle un detector de eventos; este método recibe dos parámetros:
 
-- la cadena `"click"`, para indicar que queremos detectar el evento de clic.
-  Los botones pueden lanzar muchos otros eventos, como [`"mouseover"`](/es/docs/Web/API/Element/mouseover_event) cuando el usuario mueve el ratón por encima del botón, o [`"keydown"`](/es/docs/Web/API/Element/keydown_event) cuando el usuario presiona una tecla y el botón está enfocado.
-- una función a llamar cuando el evento ocurra. En este caso, la función genera un color RGB aleatorio y establece el [`background-color`](/es/docs/Web/CSS/Reference/Properties/background-color) de la página [`<body>`](/es/docs/Web/HTML/Reference/Elements/body) a ese color.
+- la cadena `"click"`, para indicar que queremos detectar el evento `click`. Los botones pueden lanzar muchos otros eventos, como [`"mouseover"`](/es/docs/Web/API/Element/mouseover_event) cuando el usuario mueve el ratón sobre el botón, o [`"keydown"`](/es/docs/Web/API/Element/keydown_event) cuando el usuario presiona una tecla y el botón está enfocado.
+- una función que se llamará cuando ocurra el evento. En nuestro caso, la función anónima que definimos genera un color RGB aleatorio y establece el {{cssxref("background-color")}} de la página [`<body>`](/es/docs/Web/HTML/Reference/Elements/body) con ese color.
 
-Es válido crear una función manejador con su propio nombre, de la siguiente forma:
+También podrías crear una función independiente con nombre propio, y hacer referencia a ella en el segundo parámetro de `addEventListener()`, de esta forma:
 
 ```js
 const btn = document.querySelector("button");
@@ -126,89 +119,59 @@ function random(number) {
 }
 
 function changeBackground() {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   document.body.style.backgroundColor = rndCol;
 }
 
 btn.addEventListener("click", changeBackground);
 ```
 
-### Detectando otros eventos
+### Detectar otros eventos
 
-Existen distintos tipos de eventos que pueden ser lanzados por un elemento de tipo botón. Hagamos algunos experimentos.
+Existen muchos eventos diferentes que puede lanzar un elemento de tipo botón. Experimentemos.
 
-Primero, haz una copia local del archivo [random-color-addeventlistener.html](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/random-color-addeventlistener.html), y ábrelo en tu navegador.
-Se trata de una copia del ejemplo sencillo del color aleatorio con el que ya trabajamos anteriormente. Ahora intenta a cambiar `click` por cada uno de los siguientes valores y observa los resultados en el ejemplo:
+Primero, haz una copia local de [random-color-addeventlistener.html](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/random-color-addeventlistener.html) y ábrelo en tu navegador.
+Es solo una copia del ejemplo sencillo del color aleatorio con el que ya hemos trabajado antes. Ahora intenta cambiar `click` por cada uno de los siguientes valores, y observa los resultados en el ejemplo:
 
-- [`focus`](/es/docs/Web/API/Element/focus_event) y [`blur`](/es/docs/Web/API/Element/blur_event) — El color cambia cuando el botón es enfocado y desenfocado; Intenta presionar la tecla "Tabulador" para enfocar el botón y presionala de nuevo para desenfocarlo.
-  Estos eventos son normalmente utilizados para mostrar información a la hora de completar formularios, o incluso para mostrar un mensaje de error si un campo recibe un valor incorrecto.
-- [`dblclick`](/es/docs/Web/API/Element/dblclick_event) — El color cambia únicamente cuando se hace doble clic sobre el botón.
-- [`mouseover`](/es/docs/Web/API/Element/mouseover_event) y [`mouseout`](/es/docs/Web/API/Element/mouseout_event) — El color cambia cuando el puntero del ratón pasa por encima del botón, o cuando el puntero sale del botón, respectivamente.
+- [`focus`](/es/docs/Web/API/Element/focus_event) y [`blur`](/es/docs/Web/API/Element/blur_event) — El color cambia cuando el botón se enfoca y se desenfoca; intenta presionar la tecla Tabulador para enfocar el botón, y presiónala de nuevo para desenfocarlo.
+  Estos eventos se utilizan a menudo para mostrar información al completar campos de un formulario, o para mostrar un mensaje de error si un campo recibe un valor incorrecto.
+- [`dblclick`](/es/docs/Web/API/Element/dblclick_event) — El color cambia solo cuando se hace doble clic en el botón.
+- [`mouseover`](/es/docs/Web/API/Element/mouseover_event) y [`mouseout`](/es/docs/Web/API/Element/mouseout_event) — El color cambia cuando el puntero del ratón pasa por encima del botón, o cuando sale de él, respectivamente.
 
-Algunos eventos, como `click`, están disponibles prácticamente en cualquier elemento. Mientras que otros son más específicos y solo son útiles en ciertas situaciones: por ejemplo, el evento [`play`](/es/docs/Web/API/HTMLMediaElement/play_event) solo está disponible en algunos elementos, como {{htmlelement("video")}}.
+Algunos eventos, como `click`, están disponibles en prácticamente cualquier elemento, mientras que otros son más específicos y solo resultan útiles en ciertas situaciones: por ejemplo, el evento [`play`](/es/docs/Web/API/HTMLMediaElement/play_event) solo está disponible en elementos con funcionalidad de reproducción, como {{htmlelement("video")}}.
 
-### Removiendo detectores
+### Eliminar detectores
 
-Si has agregado un manejador de eventos usando `addEventListener()`, puedes removerlo utilizando el método [`removeEventListener()`](/es/docs/Web/API/EventTarget/removeEventListener). Por ejemplo, esto removería el manejador de evento `changeBackground()`:
+Si has agregado un detector de eventos con `addEventListener()`, puedes eliminarlo si lo deseas. La forma más común de hacerlo es mediante el método [`removeEventListener()`](/es/docs/Web/API/EventTarget/removeEventListener). Por ejemplo, la siguiente línea eliminaría el manejador del evento `click` que vimos antes:
 
 ```js
 btn.removeEventListener("click", changeBackground);
 ```
 
-Los manejadores de eventos también pueden ser removidos al pasarles una {{domxref("AbortSignal")}} al método {{domxref("EventTarget/addEventListener()", "addEventListener()")}} y después llamar al método {{domxref("AbortController/abort()", "abort()")}} sobre el control al que le pertenece la `AbortSignal`.
-Por ejemplo, para agregar un manejador de evento que podemos remover con una `AbortSignal`:
+Para programas pequeños y sencillos, no es necesario limpiar los manejadores de eventos que ya no se usan, pero en programas más grandes y complejos puede mejorar la eficiencia.
+Además, la posibilidad de eliminar manejadores de eventos permite que el mismo botón realice diferentes acciones en diferentes circunstancias: solo tienes que agregar o eliminar manejadores.
 
-```js
-const controller = new AbortController();
+### Agregar varios detectores para un solo evento
 
-btn.addEventListener(
-  "click",
-  () => {
-    const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
-    document.body.style.backgroundColor = rndCol;
-  },
-  { signal: controller.signal },
-); // se pasa una AbortSignal a este manejador
-```
-
-De esta forma, el manejador de evento creado por el código anterior puede ser removido de la siguiente manera:
-
-```js
-controller.abort(); // remueve cualquier manejador de evento asociado con este controlador.
-```
-
-Para programas pequeños y simples, limpiar los rastros de manejadores de eventos sin utilizar resulta innecesario. Sin embargo, para programas más complejos, puede traer mejoras de eficiencia.
-Además, la habilidad de remover manejadores de eventos te permite tener al mismo botón ejecutando diferentes acciones en diferentes circunstancias: todo lo que tienes que hacer es agregar o remover manejadores.
-
-### Agregando varios detectores para un solo evento
-
-Al realizar más de una llamada al método {{domxref("EventTarget/addEventListener()", "addEventListener()")}}, proporcionando distintos manejadores, puedes tener varios detectores para un solo evento:
+Al hacer más de una llamada a {{domxref("EventTarget/addEventListener()", "addEventListener()")}}, proporcionando diferentes manejadores, puedes tener varias funciones manejadoras ejecutándose en respuesta a un mismo evento:
 
 ```js
 myElement.addEventListener("click", functionA);
 myElement.addEventListener("click", functionB);
 ```
 
-Ambas functiones se ejecutarían cuando se hace clic en dicho elemento.
-
-### Conocer más
-
-Existen otras características y opciones poderosas disponibles para `addEventListener()`.
-
-Éstas se encuentran un poco fuera del alcance de este artículo, pero si quieres saber más de ellas, visita las páginas de referencia para [`addEventListener()`](/es/docs/Web/API/EventTarget/addEventListener) y [`removeEventListener()`](/es/docs/Web/API/EventTarget/removeEventListener).
+Ambas funciones se ejecutarían al hacer clic en el elemento.
 
 ## Otros mecanismos para detectar eventos
 
-Te recomendamos que utilices `addEventListener()` para registrar manejadores de eventos. Es el método más potente y que mejor escala para programas más complejos.
-No obstante, existen otras dos formas distintas para registrar manejadores de eventos que deberías conocer.
+Te recomendamos que utilices `addEventListener()` para registrar manejadores de eventos. Es el método más potente y el que mejor escala en programas más complejos. Sin embargo, existen otras dos formas de registrar manejadores de eventos que podrías encontrar: _propiedades de manejador de eventos_ y _manejadores de eventos en línea_.
 
-### Propiedades para manejar eventos
+### Propiedades de manejador de eventos
 
-Los objetos (como botones) que pueden lanzar eventos, normalmente tienen propiedades cuyo nombre es `on` seguido del nombre del evento. Por ejemplo, elementos con la propiedad `onclick`.
-A esto se le conoce como una propiedad para manejar eventos, o _event handler property_.
-Para detectar un evento, puedes asignar la función manejador a dicha propiedad.
+Los objetos que pueden lanzar eventos (como los botones) normalmente también tienen propiedades cuyo nombre es `on` seguido del nombre del evento. Por ejemplo, los elementos tienen una propiedad `onclick`.
+Esto se denomina **propiedad de manejador de eventos**. Para detectar el evento, puedes asignar la función manejadora de eventos a esa propiedad.
 
-Por ejemplo, podemos reescribir el ejemplo del color aleatorio de esta forma:
+Por ejemplo, podríamos reescribir el ejemplo del color aleatorio de esta forma:
 
 ```js
 const btn = document.querySelector("button");
@@ -218,12 +181,12 @@ function random(number) {
 }
 
 btn.onclick = () => {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   document.body.style.backgroundColor = rndCol;
 };
 ```
 
-También puedes establecer la propiedad manejador a una función con nombre:
+También puedes establecer la propiedad manejadora en una función con nombre:
 
 ```js
 const btn = document.querySelector("button");
@@ -233,60 +196,52 @@ function random(number) {
 }
 
 function bgChange() {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   document.body.style.backgroundColor = rndCol;
 }
 
 btn.onclick = bgChange;
 ```
 
-Al utilizar propiedades para manejar eventos, no es posible agregar más de un manejador para un solo evento.
-Por ejemplo, puedes llamar el método `addEventListener('click', handler)` en un elemento varias veces, pasando diferentes funciones al segundo argumento:
-
-```js
-element.addEventListener("click", function1);
-element.addEventListener("click", function2);
-```
-
-Esto es imposible de lograr con propiedades para manejar eventos debido a que cualquier intento subsecuente para establecer dicha propiedad, habrá sobreescrito las anteriores asignaciones.
+Las propiedades de manejador de eventos tienen desventajas en comparación con `addEventListener()`. Una de las más importantes es que no puedes [agregar más de un detector para un mismo evento](#agregar_varios_detectores_para_un_solo_evento). El siguiente patrón no funciona, porque cualquier intento posterior de establecer el valor de la propiedad sobrescribirá los anteriores:
 
 ```js
 element.onclick = function1;
 element.onclick = function2;
 ```
 
-### Manejadores de eventos en línea: No los utilices
+### Manejadores de eventos en línea: no utilices estos
 
-Quizá hayas visto un patrón como este en tu código:
+También podrías ver un patrón como este en tu código:
 
-```html
+```html example-bad
 <button onclick="bgChange()">Haz clic</button>
 ```
 
 ```js
 function bgChange() {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   document.body.style.backgroundColor = rndCol;
 }
 ```
 
-El primer método para el registro de manejadores de eventos en la Web, utilizaba [_atributos HTML para manejar eventos_](/es/docs/Web/HTML/Reference/Attributes#event_handler_attributes) (o _manejadores de eventos en línea_) como el que se mostró anteriormente. El valor del atributo es literalmente el código JavaScript que quieres ejecutar cuando el evento ocurra.
-El ejemplo anterior invoca a la función definida dentro de un elemento {{htmlelement("script")}} en la misma página, pero también pueden insertar JavaScript directamente en el atributo, por ejemplo:
+El método más antiguo para registrar manejadores de eventos que se encuentra en la Web implicaba [_atributos HTML de manejador de eventos_](/es/docs/Web/HTML/Reference/Attributes#event_handler_attributes)(o _manejadores de eventos en línea_), como el que se muestra arriba: el valor del atributo contiene el código JavaScript que quieres ejecutar cuando ocurre el evento.
+El ejemplo anterior invoca una función definida dentro de un elemento {{htmlelement("script")}} en la misma página, pero también podrías insertar JavaScript directamente dentro del atributo, por ejemplo:
 
-```html
+```html example-bad
 <button onclick="alert('¡Hola, este es un manejador de eventos anticuado!');">
-  Haz click
+  Haz clic
 </button>
 ```
 
-Puedes encontrar atributos HTML equivalentes para varias de las propiedades para manejar eventos. Sin embargo, no deberías utilizarlos, ya que se consideran una mala práctica.
-Puede parecer fácil utilizar un atributo para manejar un evento si estás haciendo sencillo de forma rápida, pero más adelante se puede volver ineficiente e imposible de manejar.
+Puedes encontrar atributos HTML equivalentes para muchas de las propiedades de manejador de eventos; sin embargo, no deberías usarlos, ya que se consideran una mala práctica.
+Puede parecer fácil usar un atributo de manejador de eventos cuando estás haciendo algo rápido y sencillo, pero pronto se vuelven inmanejables e ineficientes.
 
-Para empezar, no es buena idea mezclar tu código HTML y JavaScript, ya que se vuelve difícil de leer. Mantener tu código JavaScript por separado es una buena práctica, además de que si se encuentra en un archivo separado, puedes aplicarlo a distintos documentos HTML.
+Para empezar, no es buena idea mezclar tu HTML con tu JavaScript, ya que dificulta la lectura del código. Mantener tu JavaScript por separado es una buena práctica y, si está en un archivo aparte, puedes aplicarlo a varios documentos HTML.
 
-Incluso en un solo archivo, los manejadores de eventos en línea no son una buena idea.
-Un botón está bien, pero ¿qué tal si tuvieras 100 botones? Tendrías que agregar 100 atributos a ese archivo; de inmediato se convertiría en una pesadilla para mantener.
-Con JavaScript, fácilmente puedes agregar una función para manejar eventos en todos los botones de la página sin importar cuántos de ellos haya, usando algo como esto:
+Incluso en un solo archivo, los manejadores de eventos en línea no son buena idea.
+Un botón está bien, pero ¿qué pasaría si tuvieras 100 botones? Tendrías que agregar 100 atributos al archivo, y rápidamente se convertiría en una pesadilla de mantenimiento.
+Con JavaScript, puedes agregar fácilmente una función manejadora de eventos a todos los botones de la página sin importar cuántos haya, usando algo como esto:
 
 ```js
 const buttons = document.querySelectorAll("button");
@@ -296,16 +251,15 @@ for (const button of buttons) {
 }
 ```
 
-Finalmente, varias configuraciones comunes en servidores desactivan el código JavaScript en línea, como parte de una medida de seguridad.
+Por último, muchas configuraciones de servidor comunes deshabilitarán el JavaScript en línea, como medida de seguridad.
 
-**Nunca deberías utilizar atributos HTML para manejar eventos** — Estos están obsoletos y utilizarlos es mala práctica.
+**Nunca deberías usar los atributos de manejador de eventos HTML** — están obsoletos y usarlos es una mala práctica.
 
 ## Objetos evento
 
-A menudo, dentro de la función manejadora de eventos verás un parámetro especificado con el nombre de `event`, `evt`, or `e`.
-A este se le conoce como **objeto evento**,
-y es pasado automáticamente a los manejadores de eventos para proporcionar información y características extra.
-Por ejemplo, vamos a reestructurar ligeramente nuestro ejemplo de color aleatorio una vez más:
+A veces, dentro de una función manejadora de eventos, verás un parámetro especificado con un nombre como `event`, `evt` o `e`.
+A esto se le conoce como el **objeto evento**, y se pasa automáticamente a los manejadores de eventos para proporcionarles características e información adicionales.
+Por ejemplo, vamos a reescribir nuestro ejemplo de color aleatorio para incluir un objeto evento:
 
 ```js
 const btn = document.querySelector("button");
@@ -315,7 +269,7 @@ function random(number) {
 }
 
 function bgChange(e) {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   e.target.style.backgroundColor = rndCol;
   console.log(e);
 }
@@ -324,25 +278,22 @@ btn.addEventListener("click", bgChange);
 ```
 
 > [!NOTE]
-> Puedes encontrar el [código fuente completo](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/random-color-eventobject.html) de este ejemplo en Github (además [mira cómo se ejecuta en vivo](https://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-eventobject.html)).
+> Puedes encontrar el [código fuente completo](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/random-color-eventobject.html) de este ejemplo en GitHub (además, [verlo funcionando en vivo](https://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-eventobject.html)).
 
-Aquí puedes ver que estamos incluyendo un objeto evento **e** en la función, y dentro de nuestra función estamos cambiando el estilo de color de fondo sobre `e.target`, que es el botón como tal.
-La propiedad `target` del objeto evento siempre es una referencia al elemento sobre el cual ocurrió el evento.
-Por lo tanto, en este ejemplo, estamos estableciendo el color de fondo aleatorio en el botón, no la página.
-
-> [!NOTE]
-> Mira la sección de [delegación de Eventos](#event_delegation) más abajo para ver un ejemplo donde usamos `event.target`.
+Aquí puedes ver que estamos incluyendo un objeto evento, **e**, en la función, y en la función estamos estableciendo un estilo de color de fondo en `e.target`, que es el botón en sí.
+La propiedad `target` del objeto evento siempre es una referencia al elemento sobre el que se produjo el evento.
+Por lo tanto, en este ejemplo estamos estableciendo un color de fondo aleatorio en el botón, no en la página.
 
 > [!NOTE]
-> Puedes utilizar cualquier nombre para el objeto evento, simplemente debes elegir un nombre que puedas usar para hacer referencia a él dentro de la función manejadora.
-> `e`/`evt`/`event` son los nombres más comunes utilizados por desarrolladores porque son cortos y fáciles de recordar.
-> Siempre es bueno ser consistente, contigo mismo y los demás siempre que sea posible.
+> Puedes usar el nombre que prefieras para el objeto evento; solo debes elegir uno al que puedas hacer referencia dentro de la función manejadora de eventos.
+> `e`, `evt` y `event` son los nombres más utilizados por los desarrolladores porque son cortos y fáciles de recordar.
+> Siempre es recomendable ser consistente, tanto contigo mismo como, en la medida de lo posible, con los demás.
 
-### Propiedades extra en los objetos evento
+### Propiedades adicionales de los objetos evento
 
-La mayoría de objetos eventos tienen un conjunto estándar de propiedades y métodos disponibles en el objeto evento; visita la referencia del objeto {{domxref("Event")}} para una lista completa.
+La mayoría de los objetos evento tienen un conjunto estándar de propiedades y métodos disponibles; consulta la referencia del objeto {{domxref("Event")}} para ver la lista completa.
 
-Algunos objetos evento agregan propiedades extra que son relevantes para un tipo de evento en particular. Por ejemplo, el evento {{domxref("Element/keydown_event", "keydown")}} se lanza cuando el usuario presiona una tecla. Su objeto evento es un {{domxref("KeyboardEvent")}}, el cual es un objeto `Event` especializado con una propiedad `key` que nos indica la tecla que fue presionada.
+Algunos objetos evento agregan propiedades adicionales relevantes para ese tipo de evento en particular. Por ejemplo, el evento {{domxref("Element/keydown_event", "keydown")}} se lanza cuando el usuario presiona una tecla. Su objeto evento es un {{domxref("KeyboardEvent")}}, que es un objeto `Event` especializado con una propiedad `key` que indica qué tecla se presionó:
 
 ```html
 <input id="textBox" type="text" />
@@ -352,10 +303,9 @@ Algunos objetos evento agregan propiedades extra que son relevantes para un tipo
 ```js
 const textBox = document.querySelector("#textBox");
 const output = document.querySelector("#output");
-textBox.addEventListener(
-  "keydown",
-  (event) => (output.textContent = `Presionaste "${event.key}".`),
-);
+textBox.addEventListener("keydown", (event) => {
+  output.textContent = `Presionaste "${event.key}".`;
+});
 ```
 
 ```css hidden
@@ -364,24 +314,24 @@ div {
 }
 ```
 
-Intenta escribir en la caja de texto y mira el resultado:
+Intenta escribir en el cuadro de texto y observa el resultado:
 
 {{EmbedLiveSample("Extra_properties_of_event_objects", 100, 100)}}
 
-## Evitando el comportamiento por defecto
+## Evitar el comportamiento por defecto
 
-En algunas ocasiones, te encontrarás en una situación donde quieres evitar que un evento realice su acción por defecto.
-El escenario más común es el de un formulario web, por ejemplo, un formulario personalizado para un registro.
-Cuando llenas todos los campos y haces clic en el botón para enviar, el comportamiento normal es que la información sea enviada a un servidor para que sea procesada, mientras que el navegador se redirecciona a una página donde se muestra un mensaje de "envío exitoso" (o a la misma página si no se especifica otra).
+En ocasiones, te encontrarás con una situación en la que quieres evitar que un evento haga lo que hace por defecto.
+El ejemplo más común es el de un formulario web, por ejemplo, un formulario de registro personalizado.
+Cuando completas los campos y haces clic en el botón de envío, lo normal es que los datos se envíen a una página específica del servidor para su procesamiento, y que el navegador te redirija a una página de "mensaje de éxito" de algún tipo (o a la misma página, si no se especifica otra).
 
-El problema viene cuando el usuario no ha introducido sus datos correctamente. Como desarrollador, quieres evitar que la información sea enviada al servidor y, en su lugar, mostrar un mensaje de error que señale cuáles son los problemas y qué se necesita para corregirlos.
-Algunos navegadores tienen soporte para características de validación automática de formularios, pero tomando en cuenta que muchos otros no, se te recomienda que no confies en estos mecanismos e implementes tus propias pruebas de validación.
+El problema surge cuando el usuario no ha enviado los datos correctamente: como desarrollador, quieres evitar el envío al servidor y mostrar un mensaje de error que indique qué está mal y qué hay que hacer para corregirlo.
+Algunos navegadores admiten funciones de validación automática de datos de formularios, pero como muchos no lo hacen, te recomendamos no depender de ellas e implementar tus propias comprobaciones de validación.
 Veamos un ejemplo.
 
-Primero, un formulario HTML simple que requiere que introduzcas tu nombre y apellido:
+Primero, un formulario HTML sencillo que te pide que introduzcas tu nombre y tu apellido:
 
 ```html
-<form>
+<form action="#">
   <div>
     <label for="fname">Nombre: </label>
     <input id="fname" type="text" />
@@ -403,8 +353,8 @@ div {
 }
 ```
 
-Ahora un poco de JavaScript. Aquí vamos a implementar una simple prueba dentro del manejador del evento [`submit`](/es/docs/Web/API/HTMLFormElement/submit_event) (el evento _submit_ es lanzado en un formulario cuando este se envía) que determina si los campos de texto están vacíos o no.
-En caso de que lo estén, llamamos al método [`preventDefault()`](/es/docs/Web/API/Event/preventDefault) del objeto evento, el cual detiene el envío del formulario y muestra un mensaje de error en el párrafo debajo de nuestro formulario para hacerle saber al usuario cuál es el problema:
+Ahora un poco de JavaScript: aquí implementamos una comprobación básica dentro de un manejador para el evento [`submit`](/es/docs/Web/API/HTMLFormElement/submit_event) (el evento submit se lanza en un formulario cuando este se envía) que comprueba si los campos de texto están vacíos.
+Si lo están, llamamos a la función [`preventDefault()`](/es/docs/Web/API/Event/preventDefault) sobre el objeto evento —lo que detiene el envío del formulario— y mostramos un mensaje de error en el párrafo debajo del formulario para indicarle al usuario cuál es el problema:
 
 ```js
 const form = document.querySelector("form");
@@ -415,393 +365,34 @@ const para = document.querySelector("p");
 form.addEventListener("submit", (e) => {
   if (fname.value === "" || lname.value === "") {
     e.preventDefault();
-    para.textContent = "¡Necesitas completar ambos campos!";
+    para.textContent = "¡Debes completar ambos nombres!";
   }
 });
 ```
 
-Obviamente esta es una validación bastante débil, esto no detendría al usuario de, por ejemplo, llenar los campos del formulario con espacios en blanco o números, pero, es suficiente para los propósitos de nuestro ejemplo.
-El resultado es el siguiente:
+Obviamente, esta es una validación de formulario bastante débil —no evitaría, por ejemplo, que el usuario validara el formulario con espacios en blanco o números en los campos—, pero sirve a modo de ejemplo.
 
-{{ EmbedLiveSample('Preventing_default_behavior', '100%', 180, "", "") }}
+Puedes ver el ejemplo completo [funcionando en vivo](https://mdn.github.io/learning-area/javascript/building-blocks/events/preventdefault-validation.html); pruébalo ahí. Para consultar el código fuente completo, visita [preventdefault-validation.html](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/preventdefault-validation.html).
 
-> [!NOTE]
-> Para ver el código fuente completo, aquí tienes el archivo [preventdefault-validation.html](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/preventdefault-validation.html) (también puedes [verlo ejecutándose en vivo](https://mdn.github.io/learning-area/javascript/building-blocks/events/preventdefault-validation.html) aquí).
+## No es solo en páginas web
 
-## Burbujeo de eventos
+Los eventos no son exclusivos de JavaScript: la mayoría de los lenguajes de programación tienen algún tipo de modelo de eventos, y su funcionamiento suele ser distinto al de JavaScript.
+De hecho, el modelo de eventos de JavaScript en páginas web es diferente del modelo de eventos de JavaScript usado en otros entornos.
 
-El burbujeo de eventos (o _event bubbling_) describe como el navegador maneja eventos dirigidos a elementos anidados.
+Por ejemplo, [Node.js](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs) es un entorno de ejecución de JavaScript muy popular que permite a los desarrolladores crear aplicaciones de red y del lado del servidor.
+El [modelo de eventos de Node.js](https://nodejs.org/api/events.html) se basa en detectores que escuchan eventos y emisores que los emiten periódicamente; no suena tan distinto, pero el código es bastante diferente, ya que usa funciones como `on()` para registrar un detector de eventos, y `once()` para registrar uno que se elimina después de ejecutarse una vez.
+La [documentación sobre el evento connect de HTTP en Node.js](https://nodejs.org/api/http.html#event-connect) ofrece un buen ejemplo.
 
-### Estableciendo un detector de eventos en un elemento padre
+También puedes usar JavaScript para crear complementos multinavegador —mejoras de funcionalidad del navegador— utilizando una tecnología llamada [WebExtensions](/es/docs/Mozilla/Add-ons/WebExtensions).
+El modelo de eventos es similar al modelo de eventos web, pero un poco diferente: las propiedades de los detectores de eventos se escriben en {{Glossary("camel_case", "camel case")}} (por ejemplo, `onMessage` en lugar de `onmessage`), y deben combinarse con la función `addListener`.
+Consulta la página de [`runtime.onMessage`](/es/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#examples) para ver un ejemplo.
 
-Considera una página web como la siguiente:
+No necesitas entender nada sobre estos otros entornos en esta etapa de tu aprendizaje; solo queríamos dejar claro que los eventos pueden variar según el entorno de programación.
 
-```html
-<div id="container">
-  <button>¡Haz clic en mi!</button>
-</div>
-<pre id="output"></pre>
-```
+## Resumen
 
-Aquí el botón se encuentra dentro de otro elemento, de forma específica, un elemento {{HTMLElement("div")}}. En este caso, decimos que el elemento `<div>` es el **padre** del elemento que contiene. ¿Qué sucede si agregamos un manejador para el evento `click` en el padre y luego hacemos clic en el botón?
+En este capítulo hemos aprendido qué son los eventos, cómo detectarlos y cómo responder a ellos.
 
-```js
-const output = document.querySelector("#output");
-function handleClick(e) {
-  output.textContent += `Hiciste clic en un elemento ${e.currentTarget.tagName}\n`;
-}
+Ya habrás visto que los elementos de una página web pueden estar anidados dentro de otros elementos. Por ejemplo, en el ejemplo de [Evitar el comportamiento por defecto](#evitar_el_comportamiento_por_defecto), tenemos algunos campos de texto ubicados dentro de elementos {{htmlelement("div")}}, que a su vez están ubicados dentro de un elemento {{htmlelement("form")}}. ¿Qué ocurre cuando se asocia un detector del evento click al elemento `<form>` y el usuario haga clic dentro de uno de los campos de texto? La función manejadora de eventos asociada se sigue disparando gracias a un proceso llamado _burbujeo de eventos_ (_event bubbling_), que se tratará en la siguiente lección.
 
-const container = document.querySelector("#container");
-container.addEventListener("click", handleClick);
-```
-
-{{ EmbedLiveSample('Setting a listener on a parent element', '100%', 200, "", "") }}
-
-Como puedes ver, el padre lanza el evento `click` cuando el usuario hace clic en el botón:
-
-```
-Hiciste clic en un elemento DIV
-```
-
-Esto tiene sentido, el botón está dentro del elemento `<div>`, por lo tanto, cuando haces clic en el botón, de forma implícita estás haciendo clic en el elemento en el que se encuentra.
-
-### Ejemplo de burbujeo
-
-¿Qué sucede si agregamos un detector de eventos al botón _y_ al padre?
-
-```html
-<body>
-  <div id="container">
-    <button>¡Haz clic en mi!</button>
-  </div>
-  <pre id="output"></pre>
-</body>
-```
-
-Intentemos agregar un manejador de eventos al botón, a su padre (el `<div>`) y, además, al elemento {{HTMLElement("body")}} que contiene a ambos:
-
-```js
-const output = document.querySelector("#output");
-function handleClick(e) {
-  output.textContent += `Hiciste clic en un elemento ${e.currentTarget.tagName}\n`;
-}
-
-const container = document.querySelector("#container");
-const button = document.querySelector("button");
-
-document.body.addEventListener("click", handleClick);
-container.addEventListener("click", handleClick);
-button.addEventListener("click", handleClick);
-```
-
-{{ EmbedLiveSample('Bubbling example', '100%', 200, "", "") }}
-
-Te darás cuenta que los tres elementos lanzan un evento de clic cuando el usuario hace clic en el botón:
-
-```
-Hiciste clic en un elemento BUTTON
-Hiciste clic en un elemento DIV
-Hiciste clic en un elemento BODY
-```
-
-En este caso:
-
-- el clic en el botón se lanza primero
-- seguido del clic en el padre (el elemento `<div>`)
-- por último, se lanza en el padre del elemento `<div>` (el elemento `<body>`).
-
-Para describir esta situación, decimos que el evento **burbujea hacia arriba** (_bubbles up_, en inglés) desde el elemento más interno que recibió un clic.
-
-Este comportamiento puede ser útil a la par de causar problemas inesperados. En las siguientes secciones veremos los problemas que causa y econtraremos una solución.
-
-### Ejemplo de un reproductor de video
-
-En este ejemplo, nuestra página contiene un video, el cual se encuentra oculto inicialmente, y un botón con la etiqueta "Display video". Queremos lograr la siguiente interacción:
-
-- Cuando el usuario hace clic en el botón de "Display video", muestra la caja que contiene el video, pero sin iniciar la reproducción del video todavía.
-- Cuando el usuario hace clic en el video, inicia la reproducción del video.
-- Cuando el usuario hace clic en cualquier lugar fuera de la caja del video, oculta la caja nuevamente.
-
-El HTML se ve así:
-
-```html
-<button>Mostrar vídeo</button>
-
-<div class="hidden">
-  <video>
-    <source src="/shared-assets/videos/flower.webm" type="video/webm" />
-    <p>
-      Su navegador no es compatible con video HTML. Aquí hay un
-      <a href="rabbit320.mp4">enlace al video</a> en su lugar.
-    </p>
-  </video>
-</div>
-```
-
-Además incluye:
-
-- un element `<button>`
-- un elemento `<div>` que inicialmente tiene un atributo `class="hidden"`
-- un elemento `<video>` anidado dentro del elemento `<div>`.
-
-Estamos usando CSS para ocultar elementos con la clase `"hidden"`.
-
-```css hidden
-div {
-  width: 100%;
-  height: 100%;
-  background-color: #eee;
-}
-
-.hidden {
-  display: none;
-}
-
-div video {
-  padding: 40px;
-  display: block;
-  width: 400px;
-  margin: 40px auto;
-}
-```
-
-El código JavaScript se ve así:
-
-```js
-const btn = document.querySelector("button");
-const box = document.querySelector("div");
-const video = document.querySelector("video");
-
-btn.addEventListener("click", () => box.classList.remove("hidden"));
-video.addEventListener("click", () => video.play());
-box.addEventListener("click", () => box.classList.add("hidden"));
-```
-
-Éste añade tres manejadores para el evento `'click'`:
-
-- uno en el `<button>`, el cual muestra el `<div>` que contiene al `<video>`
-- uno en el `<video>`, el cual inicia la reproducción del video
-- uno en el `<div>`, el cual oculta el video.
-
-Veamos como funciona esto:
-
-{{ EmbedLiveSample('Video_player_example', '100%', 500) }}
-
-Deberías ver que cuando haces clic en el botón, la caja y el video que contiene son mostrados. Pero cuando haces clic en el video, éste empieza a reproducirse pero, ¡la caja se oculta de nuevo!
-
-El video se encuentra dentro del `<div>`, ya que es parte de él, por lo tanto, hacer clic en el video ejecuta ambos manejadores de eventos, ocasionando este comportamiento.
-
-### Resolviendo el problema con stopPropagation()
-
-Como pudimos ver en la anterior sección, a veces el _event bubbling_ puede ocasionar problemas, pero existe una manera de prevenirlos.
-El objeto [`Event`](/es/docs/Web/API/Event)
-contiene un método llamado [`stopPropagation()`](/es/docs/Web/API/Event/stopPropagation) que cuando es llamado dentro de un manejador de evento, evita que el evento burbujee hacia los elementos de más arriba.
-
-Podemos solucionar nuestro problema actual al cambiar el código JavaScript por lo siguiente:
-
-```js
-const btn = document.querySelector("button");
-const box = document.querySelector("div");
-const video = document.querySelector("video");
-
-btn.addEventListener("click", () => box.classList.remove("hidden"));
-
-video.addEventListener("click", (event) => {
-  event.stopPropagation();
-  video.play();
-});
-
-box.addEventListener("click", () => box.classList.add("hidden"));
-```
-
-Todo lo que estamos haciendo aquí es llamar al método `stopPropagation()` en el objeto evento dentro del manejador del evento `'click'` para el elemento `<video>`. Esto evitará que el evento burbujee hacia la caja de más arriba. Ahora intenta hacer clic en el botón y luego en el video:
-
-{{EmbedLiveSample("Fixing the problem with stopPropagation()", '100%', 500)}}
-
-```html hidden
-<button>Mostrar vídeo</button>
-
-<div class="hidden">
-  <video>
-    <source src="/shared-assets/videos/flower.webm" type="video/webm" />
-    <p>
-      Su navegador no es compatible con video HTML. Aquí hay un
-      <a href="rabbit320.mp4">enlace al video</a> en su lugar.
-    </p>
-  </video>
-</div>
-```
-
-```css hidden
-div {
-  width: 100%;
-  height: 100%;
-  background-color: #eee;
-}
-
-.hidden {
-  display: none;
-}
-
-div video {
-  padding: 40px;
-  display: block;
-  width: 400px;
-  margin: 40px auto;
-}
-```
-
-### Captura de eventos
-
-Una forma alternativa para la propagación de eventos es la _captura de eventos_ (_event capture_, en inglés). Esta es parecida al _bubbling_ pero el sentido está invertido: en vez de que el evento se lance primero en el elemento objetivo más anidado y, sucesivamente, en elementos menos anidados, el evento se lanza primero en el elemento _menos anidado_, y luego en los elementos más anidados, hasta que el objetivo es alcanzado.
-
-La captura de eventos está desactivada por defecto. Para activarla debes pasar la opción `capture` al método `addEventListener()`.
-
-Este ejemplo es parecido al [ejemplo de burbujeo](#bubbling_example) que vimos anteriormente, a excepción de que ahora hemos usado la opción `capture`:
-
-```html
-<body>
-  <div id="container">
-    <button>¡Haz clic en mi!</button>
-  </div>
-  <pre id="output"></pre>
-</body>
-```
-
-```js
-const output = document.querySelector("#output");
-function handleClick(e) {
-  output.textContent += `Hiciste clic en un elemento ${e.currentTarget.tagName}\n`;
-}
-
-const container = document.querySelector("#container");
-const button = document.querySelector("button");
-
-document.body.addEventListener("click", handleClick, { capture: true });
-container.addEventListener("click", handleClick, { capture: true });
-button.addEventListener("click", handleClick);
-```
-
-{{ EmbedLiveSample('Event capture', '100%', 200, "", "") }}
-
-En este caso, el orden de los mensajes está invertido: el manejador de evento del `<body>` se lanza primero, seguido del manejador del `<div>` y por el último el manejador del `<button>`:
-
-```
-Hiciste clic en un elemento BODY
-Hiciste clic en un elemento DIV
-Hiciste clic en un elemento BUTTON
-```
-
-¿Por qué molestarse con ambos métodos, captura y burbujeo? En los malos viejos tiempos, cuando los navegadores eran mucho menos compatibles entre sí, Netscape utilizaba solamente captura de eventos, mientras que Internet Explorer solo usaba burbujeo de eventos. Cuando W3C decidió tratar de estandarizar este comportamiento y llegar a un acuerdo, terminaron con este sistema que incluye ambos métodos, el cual está implementado por los navegadores modernos.
-
-Por defecto, casi todos los manejadores de eventos están registrados en la fase de burbujeo, lo cual tiene sentido la mayoría de veces.
-
-## Delegación de eventos
-
-En la sección anterior, vimos un problema ocasionado por el burbujeo de eventos y cómo solucionarlo.
-El burbujeo de eventos no simplemente es molesto, sino que puede resultar bastante útil. Particularmente, hace posible la **delegación de eventos**. En esta técnica, cuando queremos que cierto código se ejecute cuando el usuario interacciona con cualquiera de un gran número de elementos descendientes, establecemos el detector de eventos en el padre y dejamos que los eventos burbujeen hasta el padre, en vez de establecer el detector de eventos individualmente en cada descendiente.
-
-Regresemos a nuestro primer ejemplo, donde establecemos el color de toda la página cuando el usuario hace clic en un botón. Imagina que en su lugar, la página está dividida en 16 secciones, y queremos establecer un color de fondo aleatorio en cada sección cuando el usuario hace clic en una sección.
-
-Aquí está el HTML:
-
-```html
-<div id="container">
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-</div>
-```
-
-Estamos usando un poco de CSS para establecer el tamaño y posición de las secciones:
-
-```css
-.tile {
-  height: 100px;
-  width: 25%;
-  float: left;
-}
-```
-
-Ahora desde JavaScript podemos agregar un manejador del evento clic para cada sección.
-Pero una solución más sencilla y más eficiente sería agregar un solo detector de eventos en el padre, y aprovecharnos del burbujeo de eventos para asegurarnos de que el manejador se ejecuta cuando el usuario hace clic en una sección:
-
-```js
-function random(number) {
-  return Math.floor(Math.random() * number);
-}
-
-function bgChange() {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
-  return rndCol;
-}
-
-const container = document.querySelector("#container");
-
-container.addEventListener(
-  "click",
-  (event) => (event.target.style.backgroundColor = bgChange()),
-);
-```
-
-El resultado es de la siguiente forma (intenta hacer clic alreador):
-
-{{ EmbedLiveSample('Event delegation', '100%', 430, "", "") }}
-
-> [!NOTE]
-> En este ejemplo, estamos usando `event.target` para obtener el elemento objetivo del evento (es decir, el elemento más interno). Si queremos acceder al elemento que manejó el evento (en este caso, el contenedor), podemos usar `event.currentTarget`.
-
-> [!NOTE]
-> Ve el archivo [useful-eventtarget.html](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/useful-eventtarget.html) para el código completo; además velo [ejecutándose en vivo](https://mdn.github.io/learning-area/javascript/building-blocks/events/useful-eventtarget.html) aquí.
-
-## No es solamente en paǵinas web
-
-Los eventos no son exclusivos de JavaScript, la mayoría de lenguajes de programación poseen algún tipo de modelo de eventos. El funcionamiento de estos modelos puede ser diferente de lo que tenemos en JavaScript.
-De hecho, el modelo de eventos en JavaScript para páginas web es diferente del modelo de eventos de JavaScript cuando se usa en otros entornos.
-
-Por ejemplo, [Node.js](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs) es un entorno de ejecución (_runtime, en inglés_) bastante popular que le permite a los desarrolladores usar JavaScript para crear aplicaciones de redes y del lado del servidor.
-El [modelo de eventos de Node.js](https://nodejs.org/api/events.html) se basa en detectores para detectar eventos y emisores para emitir eventos periodicamente, esto no suena muy alejado de lo que conocemos pero, el código sí es bastante diferente. En este modelo, se usan funciones como `on()` para registrar un detector de eventos, y `once()` para registrar un detector de eventos que elimina su registro después de haber sido ejecutado una vez.
-
-La [documentación del evento HTTP connect](https://nodejs.org/api/http.html#event-connect) proporciona un buen ejemplo.
-
-También puedes utilizar JavaScript para construir extensiones multi-navegador (mejoras en la funcionalidad de los navegadores) usando una tecnología llamada [WebExtensions](/es/docs/Mozilla/Add-ons/WebExtensions).
-El modelo de eventos es similar al modelo de los eventos de la web, salvo por pequeñas diferencias. Por ejemplo, las propiedades para detectar eventos utilizan el estilo _camel-case_ (`onMessage` en vez de `onmessage`), y necesitan ser combinadas con la función `addListener`.
-Visita la página de [`runtime.onMessage`](/es/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#examples) para ver un ejemplo.
-
-No necesitas entender nada sobre otros entornos de ejecución en este punto en tu camino de aprendizaje, simplemente queriamos aclarar que los eventos suelen ser diferentes en distintos entornos de programación.
-
-## ¡Pon a prueba tus habilidades!
-
-Haz llegado al final de este artículo pero, ¿Recuerdas la información más importante? Para verificar que has retenido esta información antes de que continúes, visita la página de [Pon a prueba tus habilidades: Eventos](/es/docs/Learn/JavaScript/Building_blocks/Test_your_skills:_Events).
-
-## Conclusión
-
-Por ahora deberías saber todo lo que necesitas sobre eventos en la web. Como mencionamos anteriormente, los eventos en realidad no son parte del núcleo de JavaScript, ya que estos son definidos como parte de la API del navegador.
-
-De igual forma, es importante entender que los diferentes contextos en los que JavaScript se usa, tienen diferentes modelos de eventos, desde las API Web a otras áreas como WebExtensions y Node.js (JavaScript del lado del servidor).
-
-No estamos esperando que entiendas todas estás áreas justo ahora, pero sin duda mencionar estos temas te ayudará a entender los aspectos básicos de los eventos mientras sigues adelante en tu proceso de aprendizaje de desarrollo web.
-
-Si hay algo que no te quedó muy claro, tómate la libertad de leer de nuevo el artículo o [contáctanos](https://discourse.mozilla.org/c/mdn/learn/250) para pedir ayuda.
-
-## Véase también
-
-- [domevents.dev](https://domevents.dev/) — una aplicación interactiva bastante útil para aprender el comportamiento del sistema de eventos del DOM a través de la exploración.
-- [Referencia de eventos](/es/docs/Web/API/Document_Object_Model/Events)
-- [Orden de eventos](https://www.quirksmode.org/js/events_order.html) (debate sobre captura y burbujeo) - un excelente y detallado artículo por Peter-Paul Koch.
-- [Event accessing](https://www.quirksmode.org/js/events_access.html) (debate sobre el objeto evento) - otro excelente y detallado artículo por Peter-Paul Koch.
-
-{{PreviousMenuNext("Learn_web_development/Core/Scripting/Return_values","Learn_web_development/Core/Scripting/Image_gallery", "Learn_web_development/Core/Scripting")}}
+{{PreviousMenuNext("Learn_web_development/Core/Scripting/Test_your_skills/Functions","Learn_web_development/Core/Scripting/Event_bubbling", "Learn_web_development/Core/Scripting")}}

--- a/files/es/learn_web_development/core/scripting/events/index.md
+++ b/files/es/learn_web_development/core/scripting/events/index.md
@@ -1,66 +1,60 @@
 ---
 title: Introducción a los eventos
+short-title: Eventos
 slug: Learn_web_development/Core/Scripting/Events
-original_slug: Learn/JavaScript/Building_blocks/Events
 l10n:
-  sourceCommit: ac5dfaa2f71a7381cd8fdd4cb554507f375ac19c
+  sourceCommit: 2b4a2ad5d9ba084a9eaa2f9204102655e7b575c4
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Scripting/Return_values","Learn_web_development/Core/Scripting/Image_gallery", "Learn_web_development/Core/Scripting")}}
+{{PreviousMenuNext("Learn_web_development/Core/Scripting/Test_your_skills/Functions","Learn_web_development/Core/Scripting/Event_bubbling", "Learn_web_development/Core/Scripting")}}
 
-Los eventos son cosas que pasan en el sistema que estás programando, el cual se encarga de avisarte para que tu código pueda hacer algo al respecto.
-
-Por ejemplo, si el usuario hace clic en el botón de una página web, puede que quieras reaccionar a esa acción y mostrar una tarjeta con información.
-En este artículo vamos a discutir algunos conceptos importantes sobre los eventos y cómo funcionan en el navegador.
-Este no será un estudio exhaustivo, solo veremos lo que necesitas saber en esta etapa.
+Los eventos son cosas que ocurren en el sistema que estás programando, y que el sistema te notifica para que tu código pueda reaccionar a ellos.
+Por ejemplo, si haces clic en un botón de una página web, podrías querer reaccionar a esa acción mostrando un cuadro de información.
+En este artículo veremos algunos conceptos importantes sobre los eventos, y analizaremos los fundamentos de cómo funcionan en los navegadores.
 
 <table>
   <tbody>
     <tr>
-      <th scope="row">Pre-requisitos:</th>
-      <td>
-  Conocimientos básicos de informática, entendimiento básico de HTML y CSS, <a href="/es/docs/conflicting/Learn_web_development/Core/Scripting"
-          >Primeros pasos con JavaScript</a
-        >.
-      </td>
+      <th scope="row">Requisitos previos:</th>
+      <td>Comprensión de <a href="/es/docs/Learn_web_development/Core/Structuring_content">HTML</a> y de los <a href="/es/docs/Learn_web_development/Core/Styling_basics">fundamentos de CSS</a>, además de familiaridad con los conceptos básicos de JavaScript vistos en lecciones anteriores.</td>
     </tr>
     <tr>
-      <th scope="row">Objetivo:</th>
+      <th scope="row">Resultados del aprendizaje:</th>
       <td>
-Entender la teoría fundamental sobre los eventos, cómo funcionan en el navegador y cómo los eventos son diferentes según el entorno de programación.</td>
+        <ul>
+          <li>Qué son los eventos: una señal que emite el navegador cuando ocurre algo importante, a la que el desarrollador puede responder ejecutando código.</li>
+          <li>Cómo configurar manejadores de eventos usando <code>addEventListener()</code> (y <code>removeEventListener()</code>) y mediante propiedades de manejador de eventos.</li>
+          <li>Los atributos de manejador de eventos en línea, y por qué no deberías usarlos.</li>
+          <li>Los objetos evento.</li>
+        </ul>
+      </td>
     </tr>
   </tbody>
 </table>
 
 ## ¿Qué es un evento?
 
-Los eventos son cosas que suceden en el sistema que estás programando. El sistema se encarga de producir una señal de cierto tipo cuando un evento ocurre, y proporciona un mecanismo para que una acción se lleve a cabo (ejecutar código) de forma automática cuando el evento ocurra.
-Los eventos se lanzan dentro de la ventana del navegador y usualmente están asociados a un elemento en específico dentro de dicha ventana. Esto puede ser un solo elemento, un grupo de elementos, el documento HTML cargado la pestaña actual, o la ventana del navegador en su totalidad.
-Existen distintos tipos de eventos que pueden ocurrir.
+Los eventos son cosas que suceden en el sistema que estás programando: el sistema produce (o "lanza") una señal de algún tipo cuando ocurre un evento, y ofrece un mecanismo para que una acción se ejecute automáticamente (es decir, ejecutar algún código) cuando ocurre el evento.
+Los eventos se lanzan dentro de la ventana del navegador y suelen estar asociados a un elemento específico dentro de ella. Puede tratarse de un solo elemento, un conjunto de elementos, el documento HTML cargado en la pestaña actual, o toda la ventana del navegador.
+Existen muchos tipos distintos de eventos que pueden ocurrir.
 
 Por ejemplo:
 
-- El usuario selecciona, hace clic o pasa el ratón por encima de cierto elemento.
+- El usuario selecciona, hace clic o pasa el cursor sobre un elemento determinado.
 - El usuario presiona una tecla del teclado.
-- El usuario redimensiona o cierra la ventana del navegador.
-- Una página web terminó de cargarse.
-- Un formulario fue enviado.
+- El usuario cambia el tamaño o cierra la ventana del navegador.
+- Una página web termina de cargarse.
+- Se envía un formulario.
 - Un vídeo se reproduce, se pausa o termina.
-- Ocurrió un error.
+- Ocurre un error.
 
-A partir de esto (y dando un vistazo a la [referencia de eventos](/es/docs/Web/API/Document_Object_Model/Events) de MDN) puedes observar que existen **muchos** eventos que pueden ser lanzados.
+A partir de esto (y echando un vistazo al [índice de eventos](/es/docs/Web/API/Document_Object_Model/Events)) puedes ver que existen **muchos** eventos que se pueden lanzar.
 
-Para reaccionar a un evento, puedes asociarle un **manejador de eventos**. Esto es un bloque de código (normalmente una función de JavaScript que tú como programador creas) que se ejecuta cuando el evento ocurre.
-Cuando uno de estos bloques de código se configura para ejecutarse en respuesta de un evento, decimos que estamos **registrando un manejador de eventos**.
-Nota: Los manejadores de eventos a veces son llamados **detectores de eventos**. Estos términos, para lo que nos concierne justo ahora, son intercambiables, aunque hablando de forma estricta, hacen referencia a dos mecanismos que trabajan juntos.
-Los detectores de eventos están pendientes a que ocurra un evento, mientras que el manejador es el código que se ejecuta en respuesta del evento.
+Para reaccionar a un evento, le asocias un **detector de eventos**. Se trata de una funcionalidad del código que detecta el evento que se lanza. Cuando el evento se lanza, se llama a una función **manejadora de eventos** (referenciada por el detector de eventos, o contenida dentro de él) para responder a dicho evento. Cuando configuramos un bloque de código de este tipo para que se ejecute en respuesta a un evento, decimos que estamos **registrando un manejador de eventos**.
 
-> [!NOTE]
-> Los eventos en la web no son parte del núcleo del lenguaje JavaScript, éstos están definidos como parte de las API del navegador.
+### Un ejemplo: manejar un evento de clic
 
-### Un ejemplo: manejando un evento de clic
-
-En el siguiente ejemplo, tenemos un único elemento {{htmlelement("button")}} en la página:
+En el siguiente ejemplo, tenemos un único {{htmlelement("button")}} en la página:
 
 ```html
 <button>Cambiar el color</button>
@@ -72,7 +66,7 @@ button {
 }
 ```
 
-Ahora tenemos algo de JavaScript. Veremos esto más a detalle en la siguiente sección pero, por ahora, nos basta decir que: agrega un manejador de evento al evento `"click"` del botón, y el manejador reacciona al evento estableciendo un color de fondo aleatorio en la página:
+Luego tenemos algo de JavaScript. Lo veremos con más detalle en la siguiente sección, pero por ahora basta con decir que: agrega un detector de eventos al evento `"click"` del botón, y la función manejadora de eventos contenida reacciona al evento estableciendo un color de fondo aleatorio en la página:
 
 ```js
 const btn = document.querySelector("button");
@@ -82,20 +76,20 @@ function random(number) {
 }
 
 btn.addEventListener("click", () => {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   document.body.style.backgroundColor = rndCol;
 });
 ```
 
-La salida del ejemplo es de la siguiente forma. Intenta hacer clic en el botón:
+El resultado del ejemplo es el siguiente. Intenta hacer clic en el botón:
 
 {{ EmbedLiveSample('An example: handling a click event', '100%', 200, "", "") }}
 
-## Utilizando addEventListener()
+## Uso de addEventListener()
 
-Como pudimos ver en el ejemplo anterior, los objetos que pueden lanzar eventos tienen el método {{domxref("EventTarget/addEventListener", "addEventListener()")}}, y este es el mecanismo recomendado para registrar manejadores de eventos.
+Como vimos en el ejemplo anterior, los objetos que pueden lanzar eventos tienen un método {{domxref("EventTarget/addEventListener", "addEventListener()")}}, y este es el mecanismo recomendado para agregar detectores de eventos.
 
-Ahora veamos más de cerca el código del ejemplo anterior:
+Veamos más de cerca el código del ejemplo anterior:
 
 ```js
 const btn = document.querySelector("button");
@@ -105,18 +99,17 @@ function random(number) {
 }
 
 btn.addEventListener("click", () => {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   document.body.style.backgroundColor = rndCol;
 });
 ```
 
-El elemento HTML {{HTMLElement("button")}} lanzará un evento cuando el usuario hace clic sobre él. Entonces define la función `addEventListener()` que estamos llamando aquí. Le estamos pasando dos parámetros:
+El elemento HTML {{HTMLElement("button")}} lanzará un evento `click` cuando el usuario haga clic en él. Llamamos al método `addEventListener()` sobre ese elemento para agregarle un detector de eventos; este método recibe dos parámetros:
 
-- la cadena `"click"`, para indicar que queremos detectar el evento de clic.
-  Los botones pueden lanzar muchos otros eventos, como [`"mouseover"`](/es/docs/Web/API/Element/mouseover_event) cuando el usuario mueve el ratón por encima del botón, o [`"keydown"`](/es/docs/Web/API/Element/keydown_event) cuando el usuario presiona una tecla y el botón está enfocado.
-- una función a llamar cuando el evento ocurra. En este caso, la función genera un color RGB aleatorio y establece el [`background-color`](/es/docs/Web/CSS/Reference/Properties/background-color) de la página [`<body>`](/es/docs/Web/HTML/Reference/Elements/body) a ese color.
+- la cadena `"click"`, para indicar que queremos detectar el evento `click`. Los botones pueden lanzar muchos otros eventos, como [`"mouseover"`](/es/docs/Web/API/Element/mouseover_event) cuando el usuario mueve el ratón sobre el botón, o [`"keydown"`](/es/docs/Web/API/Element/keydown_event) cuando el usuario presiona una tecla y el botón está enfocado.
+- una función que se llamará cuando ocurra el evento. En nuestro caso, la función anónima que definimos genera un color RGB aleatorio y establece el {{cssxref("background-color")}} de la página [`<body>`](/es/docs/Web/HTML/Reference/Elements/body) con ese color.
 
-Es válido crear una función manejador con su propio nombre, de la siguiente forma:
+También podrías crear una función independiente con nombre propio, y hacer referencia a ella en el segundo parámetro de `addEventListener()`, de esta forma:
 
 ```js
 const btn = document.querySelector("button");
@@ -126,89 +119,59 @@ function random(number) {
 }
 
 function changeBackground() {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   document.body.style.backgroundColor = rndCol;
 }
 
 btn.addEventListener("click", changeBackground);
 ```
 
-### Detectando otros eventos
+### Detectar otros eventos
 
-Existen distintos tipos de eventos que pueden ser lanzados por un elemento de tipo botón. Hagamos algunos experimentos.
+Existen muchos eventos diferentes que puede lanzar un elemento de tipo botón. Experimentemos.
 
-Primero, haz una copia local del archivo [random-color-addeventlistener.html](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/random-color-addeventlistener.html), y ábrelo en tu navegador.
-Se trata de una copia del ejemplo sencillo del color aleatorio con el que ya trabajamos anteriormente. Ahora intenta a cambiar `click` por cada uno de los siguientes valores y observa los resultados en el ejemplo:
+Primero, haz una copia local de [random-color-addeventlistener.html](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/random-color-addeventlistener.html) y ábrelo en tu navegador.
+Es solo una copia del ejemplo sencillo del color aleatorio con el que ya hemos trabajado antes. Ahora intenta cambiar `click` por cada uno de los siguientes valores, y observa los resultados en el ejemplo:
 
-- [`focus`](/es/docs/Web/API/Element/focus_event) y [`blur`](/es/docs/Web/API/Element/blur_event) — El color cambia cuando el botón es enfocado y desenfocado; Intenta presionar la tecla "Tabulador" para enfocar el botón y presionala de nuevo para desenfocarlo.
-  Estos eventos son normalmente utilizados para mostrar información a la hora de completar formularios, o incluso para mostrar un mensaje de error si un campo recibe un valor incorrecto.
-- [`dblclick`](/es/docs/Web/API/Element/dblclick_event) — El color cambia únicamente cuando se hace doble clic sobre el botón.
-- [`mouseover`](/es/docs/Web/API/Element/mouseover_event) y [`mouseout`](/es/docs/Web/API/Element/mouseout_event) — El color cambia cuando el puntero del ratón pasa por encima del botón, o cuando el puntero sale del botón, respectivamente.
+- [`focus`](/es/docs/Web/API/Element/focus_event) y [`blur`](/es/docs/Web/API/Element/blur_event) — El color cambia cuando el botón se enfoca y se desenfoca; intenta presionar la tecla Tabulador para enfocar el botón, y presiónala de nuevo para desenfocarlo.
+  Estos eventos se utilizan a menudo para mostrar información al completar campos de un formulario, o para mostrar un mensaje de error si un campo recibe un valor incorrecto.
+- [`dblclick`](/es/docs/Web/API/Element/dblclick_event) — El color cambia solo cuando se hace doble clic en el botón.
+- [`mouseover`](/es/docs/Web/API/Element/mouseover_event) y [`mouseout`](/es/docs/Web/API/Element/mouseout_event) — El color cambia cuando el puntero del ratón pasa por encima del botón, o cuando sale de él, respectivamente.
 
-Algunos eventos, como `click`, están disponibles prácticamente en cualquier elemento. Mientras que otros son más específicos y solo son útiles en ciertas situaciones: por ejemplo, el evento [`play`](/es/docs/Web/API/HTMLMediaElement/play_event) solo está disponible en algunos elementos, como {{htmlelement("video")}}.
+Algunos eventos, como `click`, están disponibles en prácticamente cualquier elemento, mientras que otros son más específicos y solo resultan útiles en ciertas situaciones: por ejemplo, el evento [`play`](/es/docs/Web/API/HTMLMediaElement/play_event) solo está disponible en elementos con funcionalidad de reproducción, como {{htmlelement("video")}}.
 
-### Removiendo detectores
+### Eliminar detectores
 
-Si has agregado un manejador de eventos usando `addEventListener()`, puedes removerlo utilizando el método [`removeEventListener()`](/es/docs/Web/API/EventTarget/removeEventListener). Por ejemplo, esto removería el manejador de evento `changeBackground()`:
+Si has agregado un detector de eventos con `addEventListener()`, puedes eliminarlo si lo deseas. La forma más común de hacerlo es mediante el método [`removeEventListener()`](/es/docs/Web/API/EventTarget/removeEventListener). Por ejemplo, la siguiente línea eliminaría el manejador del evento `click` que vimos antes:
 
 ```js
 btn.removeEventListener("click", changeBackground);
 ```
 
-Los manejadores de eventos también pueden ser removidos al pasarles una {{domxref("AbortSignal")}} al método {{domxref("EventTarget/addEventListener()", "addEventListener()")}} y después llamar al método {{domxref("AbortController/abort()", "abort()")}} sobre el control al que le pertenece la `AbortSignal`.
-Por ejemplo, para agregar un manejador de evento que podemos remover con una `AbortSignal`:
+Para programas pequeños y sencillos, no es necesario limpiar los manejadores de eventos que ya no se usan, pero en programas más grandes y complejos puede mejorar la eficiencia.
+Además, la posibilidad de eliminar manejadores de eventos permite que el mismo botón realice diferentes acciones en diferentes circunstancias: solo tienes que agregar o eliminar manejadores.
 
-```js
-const controller = new AbortController();
+### Agregar varios detectores para un solo evento
 
-btn.addEventListener(
-  "click",
-  () => {
-    const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
-    document.body.style.backgroundColor = rndCol;
-  },
-  { signal: controller.signal },
-); // se pasa una AbortSignal a este manejador
-```
-
-De esta forma, el manejador de evento creado por el código anterior puede ser removido de la siguiente manera:
-
-```js
-controller.abort(); // remueve cualquier manejador de evento asociado con este controlador.
-```
-
-Para programas pequeños y simples, limpiar los rastros de manejadores de eventos sin utilizar resulta innecesario. Sin embargo, para programas más complejos, puede traer mejoras de eficiencia.
-Además, la habilidad de remover manejadores de eventos te permite tener al mismo botón ejecutando diferentes acciones en diferentes circunstancias: todo lo que tienes que hacer es agregar o remover manejadores.
-
-### Agregando varios detectores para un solo evento
-
-Al realizar más de una llamada al método {{domxref("EventTarget/addEventListener()", "addEventListener()")}}, proporcionando distintos manejadores, puedes tener varios detectores para un solo evento:
+Al hacer más de una llamada a {{domxref("EventTarget/addEventListener()", "addEventListener()")}}, proporcionando diferentes manejadores, puedes tener varias funciones manejadoras ejecutándose en respuesta a un mismo evento:
 
 ```js
 myElement.addEventListener("click", functionA);
 myElement.addEventListener("click", functionB);
 ```
 
-Ambas functiones se ejecutarían cuando se hace clic en dicho elemento.
-
-### Conocer más
-
-Existen otras características y opciones poderosas disponibles para `addEventListener()`.
-
-Éstas se encuentran un poco fuera del alcance de este artículo, pero si quieres saber más de ellas, visita las páginas de referencia para [`addEventListener()`](/es/docs/Web/API/EventTarget/addEventListener) y [`removeEventListener()`](/es/docs/Web/API/EventTarget/removeEventListener).
+Ambas funciones se ejecutarían al hacer clic en el elemento.
 
 ## Otros mecanismos para detectar eventos
 
-Te recomendamos que utilices `addEventListener()` para registrar manejadores de eventos. Es el método más potente y que mejor escala para programas más complejos.
-No obstante, existen otras dos formas distintas para registrar manejadores de eventos que deberías conocer.
+Te recomendamos que utilices `addEventListener()` para registrar manejadores de eventos. Es el método más potente y el que mejor escala en programas más complejos. Sin embargo, existen otras dos formas de registrar manejadores de eventos que podrías encontrar: _propiedades de manejador de eventos_ y _manejadores de eventos en línea_.
 
-### Propiedades para manejar eventos
+### Propiedades de manejador de eventos
 
-Los objetos (como botones) que pueden lanzar eventos, normalmente tienen propiedades cuyo nombre es `on` seguido del nombre del evento. Por ejemplo, elementos con la propiedad `onclick`.
-A esto se le conoce como una propiedad para manejar eventos, o _event handler property_.
-Para detectar un evento, puedes asignar la función manejador a dicha propiedad.
+Los objetos que pueden lanzar eventos (como los botones) normalmente también tienen propiedades cuyo nombre es `on` seguido del nombre del evento. Por ejemplo, los elementos tienen una propiedad `onclick`.
+Esto se denomina **propiedad de manejador de eventos**. Para detectar el evento, puedes asignar la función manejadora de eventos a esa propiedad.
 
-Por ejemplo, podemos reescribir el ejemplo del color aleatorio de esta forma:
+Por ejemplo, podríamos reescribir el ejemplo del color aleatorio de esta forma:
 
 ```js
 const btn = document.querySelector("button");
@@ -218,12 +181,12 @@ function random(number) {
 }
 
 btn.onclick = () => {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   document.body.style.backgroundColor = rndCol;
 };
 ```
 
-También puedes establecer la propiedad manejador a una función con nombre:
+También puedes establecer la propiedad manejadora en una función con nombre:
 
 ```js
 const btn = document.querySelector("button");
@@ -233,60 +196,52 @@ function random(number) {
 }
 
 function bgChange() {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   document.body.style.backgroundColor = rndCol;
 }
 
 btn.onclick = bgChange;
 ```
 
-Al utilizar propiedades para manejar eventos, no es posible agregar más de un manejador para un solo evento.
-Por ejemplo, puedes llamar el método `addEventListener('click', handler)` en un elemento varias veces, pasando diferentes funciones al segundo argumento:
-
-```js
-element.addEventListener("click", function1);
-element.addEventListener("click", function2);
-```
-
-Esto es imposible de lograr con propiedades para manejar eventos debido a que cualquier intento subsecuente para establecer dicha propiedad, habrá sobreescrito las anteriores asignaciones.
+Las propiedades de manejador de eventos tienen desventajas en comparación con `addEventListener()`. Una de las más importantes es que no puedes [agregar más de un detector para un mismo evento](#agregar_varios_detectores_para_un_solo_evento). El siguiente patrón no funciona, porque cualquier intento posterior de establecer el valor de la propiedad sobrescribirá los anteriores:
 
 ```js
 element.onclick = function1;
 element.onclick = function2;
 ```
 
-### Manejadores de eventos en línea: No los utilices
+### Manejadores de eventos en línea: no utilices estos
 
-Quizá hayas visto un patrón como este en tu código:
+También podrías ver un patrón como este en tu código:
 
-```html
+```html example-bad
 <button onclick="bgChange()">Haz clic</button>
 ```
 
 ```js
 function bgChange() {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   document.body.style.backgroundColor = rndCol;
 }
 ```
 
-El primer método para el registro de manejadores de eventos en la Web, utilizaba [_atributos HTML para manejar eventos_](/es/docs/Web/HTML/Reference/Attributes#event_handler_attributes) (o _manejadores de eventos en línea_) como el que se mostró anteriormente. El valor del atributo es literalmente el código JavaScript que quieres ejecutar cuando el evento ocurra.
-El ejemplo anterior invoca a la función definida dentro de un elemento {{htmlelement("script")}} en la misma página, pero también pueden insertar JavaScript directamente en el atributo, por ejemplo:
+El método más antiguo para registrar manejadores de eventos que se encuentra en la Web implicaba [_atributos HTML de manejador de eventos_](/es/docs/Web/HTML/Reference/Attributes) (o _manejadores de eventos en línea_), como el que se muestra arriba: el valor del atributo contiene el código JavaScript que quieres ejecutar cuando ocurre el evento.
+El ejemplo anterior invoca una función definida dentro de un elemento {{htmlelement("script")}} en la misma página, pero también podrías insertar JavaScript directamente dentro del atributo, por ejemplo:
 
-```html
+```html example-bad
 <button onclick="alert('¡Hola, este es un manejador de eventos anticuado!');">
-  Haz click
+  Haz clic
 </button>
 ```
 
-Puedes encontrar atributos HTML equivalentes para varias de las propiedades para manejar eventos. Sin embargo, no deberías utilizarlos, ya que se consideran una mala práctica.
-Puede parecer fácil utilizar un atributo para manejar un evento si estás haciendo sencillo de forma rápida, pero más adelante se puede volver ineficiente e imposible de manejar.
+Puedes encontrar atributos HTML equivalentes para muchas de las propiedades de manejador de eventos; sin embargo, no deberías usarlos, ya que se consideran una mala práctica.
+Puede parecer fácil usar un atributo de manejador de eventos cuando estás haciendo algo rápido y sencillo, pero pronto se vuelven inmanejables e ineficientes.
 
-Para empezar, no es buena idea mezclar tu código HTML y JavaScript, ya que se vuelve difícil de leer. Mantener tu código JavaScript por separado es una buena práctica, además de que si se encuentra en un archivo separado, puedes aplicarlo a distintos documentos HTML.
+Para empezar, no es buena idea mezclar tu HTML con tu JavaScript, ya que dificulta la lectura del código. Mantener tu JavaScript por separado es una buena práctica y, si está en un archivo aparte, puedes aplicarlo a varios documentos HTML.
 
-Incluso en un solo archivo, los manejadores de eventos en línea no son una buena idea.
-Un botón está bien, pero ¿qué tal si tuvieras 100 botones? Tendrías que agregar 100 atributos a ese archivo; de inmediato se convertiría en una pesadilla para mantener.
-Con JavaScript, fácilmente puedes agregar una función para manejar eventos en todos los botones de la página sin importar cuántos de ellos haya, usando algo como esto:
+Incluso en un solo archivo, los manejadores de eventos en línea no son buena idea.
+Un botón está bien, pero ¿qué pasaría si tuvieras 100 botones? Tendrías que agregar 100 atributos al archivo, y rápidamente se convertiría en una pesadilla de mantenimiento.
+Con JavaScript, puedes agregar fácilmente una función manejadora de eventos a todos los botones de la página sin importar cuántos haya, usando algo como esto:
 
 ```js
 const buttons = document.querySelectorAll("button");
@@ -296,16 +251,15 @@ for (const button of buttons) {
 }
 ```
 
-Finalmente, varias configuraciones comunes en servidores desactivan el código JavaScript en línea, como parte de una medida de seguridad.
+Por último, muchas configuraciones de servidor comunes deshabilitarán el JavaScript en línea, como medida de seguridad.
 
-**Nunca deberías utilizar atributos HTML para manejar eventos** — Estos están obsoletos y utilizarlos es mala práctica.
+**Nunca deberías usar los atributos de manejador de eventos HTML** — están obsoletos y usarlos es una mala práctica.
 
 ## Objetos evento
 
-A menudo, dentro de la función manejadora de eventos verás un parámetro especificado con el nombre de `event`, `evt`, or `e`.
-A este se le conoce como **objeto evento**,
-y es pasado automáticamente a los manejadores de eventos para proporcionar información y características extra.
-Por ejemplo, vamos a reestructurar ligeramente nuestro ejemplo de color aleatorio una vez más:
+A veces, dentro de una función manejadora de eventos, verás un parámetro especificado con un nombre como `event`, `evt` o `e`.
+A esto se le conoce como el **objeto evento**, y se pasa automáticamente a los manejadores de eventos para proporcionarles características e información adicionales.
+Por ejemplo, vamos a reescribir nuestro ejemplo de color aleatorio para incluir un objeto evento:
 
 ```js
 const btn = document.querySelector("button");
@@ -315,7 +269,7 @@ function random(number) {
 }
 
 function bgChange(e) {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
+  const rndCol = `rgb(${random(255)} ${random(255)} ${random(255)})`;
   e.target.style.backgroundColor = rndCol;
   console.log(e);
 }
@@ -324,25 +278,22 @@ btn.addEventListener("click", bgChange);
 ```
 
 > [!NOTE]
-> Puedes encontrar el [código fuente completo](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/random-color-eventobject.html) de este ejemplo en Github (además [mira cómo se ejecuta en vivo](https://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-eventobject.html)).
+> Puedes encontrar el [código fuente completo](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/random-color-eventobject.html) de este ejemplo en GitHub (además, [verlo funcionando en vivo](https://mdn.github.io/learning-area/javascript/building-blocks/events/random-color-eventobject.html)).
 
-Aquí puedes ver que estamos incluyendo un objeto evento **e** en la función, y dentro de nuestra función estamos cambiando el estilo de color de fondo sobre `e.target`, que es el botón como tal.
-La propiedad `target` del objeto evento siempre es una referencia al elemento sobre el cual ocurrió el evento.
-Por lo tanto, en este ejemplo, estamos estableciendo el color de fondo aleatorio en el botón, no la página.
-
-> [!NOTE]
-> Mira la sección de [delegación de Eventos](#event_delegation) más abajo para ver un ejemplo donde usamos `event.target`.
+Aquí puedes ver que estamos incluyendo un objeto evento, **e**, en la función, y en la función estamos estableciendo un estilo de color de fondo en `e.target`, que es el botón en sí.
+La propiedad `target` del objeto evento siempre es una referencia al elemento sobre el que se produjo el evento.
+Por lo tanto, en este ejemplo estamos estableciendo un color de fondo aleatorio en el botón, no en la página.
 
 > [!NOTE]
-> Puedes utilizar cualquier nombre para el objeto evento, simplemente debes elegir un nombre que puedas usar para hacer referencia a él dentro de la función manejadora.
-> `e`/`evt`/`event` son los nombres más comunes utilizados por desarrolladores porque son cortos y fáciles de recordar.
-> Siempre es bueno ser consistente, contigo mismo y los demás siempre que sea posible.
+> Puedes usar el nombre que prefieras para el objeto evento; solo debes elegir uno al que puedas hacer referencia dentro de la función manejadora de eventos.
+> `e`, `evt` y `event` son los nombres más utilizados por los desarrolladores porque son cortos y fáciles de recordar.
+> Siempre es recomendable ser consistente, tanto contigo mismo como, en la medida de lo posible, con los demás.
 
-### Propiedades extra en los objetos evento
+### Propiedades adicionales de los objetos evento
 
-La mayoría de objetos eventos tienen un conjunto estándar de propiedades y métodos disponibles en el objeto evento; visita la referencia del objeto {{domxref("Event")}} para una lista completa.
+La mayoría de los objetos evento tienen un conjunto estándar de propiedades y métodos disponibles; consulta la referencia del objeto {{domxref("Event")}} para ver la lista completa.
 
-Algunos objetos evento agregan propiedades extra que son relevantes para un tipo de evento en particular. Por ejemplo, el evento {{domxref("Element/keydown_event", "keydown")}} se lanza cuando el usuario presiona una tecla. Su objeto evento es un {{domxref("KeyboardEvent")}}, el cual es un objeto `Event` especializado con una propiedad `key` que nos indica la tecla que fue presionada.
+Algunos objetos evento agregan propiedades adicionales relevantes para ese tipo de evento en particular. Por ejemplo, el evento {{domxref("Element/keydown_event", "keydown")}} se lanza cuando el usuario presiona una tecla. Su objeto evento es un {{domxref("KeyboardEvent")}}, que es un objeto `Event` especializado con una propiedad `key` que indica qué tecla se presionó:
 
 ```html
 <input id="textBox" type="text" />
@@ -352,10 +303,9 @@ Algunos objetos evento agregan propiedades extra que son relevantes para un tipo
 ```js
 const textBox = document.querySelector("#textBox");
 const output = document.querySelector("#output");
-textBox.addEventListener(
-  "keydown",
-  (event) => (output.textContent = `Presionaste "${event.key}".`),
-);
+textBox.addEventListener("keydown", (event) => {
+  output.textContent = `Presionaste "${event.key}".`;
+});
 ```
 
 ```css hidden
@@ -364,24 +314,24 @@ div {
 }
 ```
 
-Intenta escribir en la caja de texto y mira el resultado:
+Intenta escribir en el cuadro de texto y observa el resultado:
 
 {{EmbedLiveSample("Extra_properties_of_event_objects", 100, 100)}}
 
-## Evitando el comportamiento por defecto
+## Evitar el comportamiento por defecto
 
-En algunas ocasiones, te encontrarás en una situación donde quieres evitar que un evento realice su acción por defecto.
-El escenario más común es el de un formulario web, por ejemplo, un formulario personalizado para un registro.
-Cuando llenas todos los campos y haces clic en el botón para enviar, el comportamiento normal es que la información sea enviada a un servidor para que sea procesada, mientras que el navegador se redirecciona a una página donde se muestra un mensaje de "envío exitoso" (o a la misma página si no se especifica otra).
+En ocasiones, te encontrarás con una situación en la que quieres evitar que un evento haga lo que hace por defecto.
+El ejemplo más común es el de un formulario web, por ejemplo, un formulario de registro personalizado.
+Cuando completas los campos y haces clic en el botón de envío, lo normal es que los datos se envíen a una página específica del servidor para su procesamiento, y que el navegador te redirija a una página de "mensaje de éxito" de algún tipo (o a la misma página, si no se especifica otra).
 
-El problema viene cuando el usuario no ha introducido sus datos correctamente. Como desarrollador, quieres evitar que la información sea enviada al servidor y, en su lugar, mostrar un mensaje de error que señale cuáles son los problemas y qué se necesita para corregirlos.
-Algunos navegadores tienen soporte para características de validación automática de formularios, pero tomando en cuenta que muchos otros no, se te recomienda que no confies en estos mecanismos e implementes tus propias pruebas de validación.
+El problema surge cuando el usuario no ha enviado los datos correctamente: como desarrollador, quieres evitar el envío al servidor y mostrar un mensaje de error que indique qué está mal y qué hay que hacer para corregirlo.
+Algunos navegadores admiten funciones de validación automática de datos de formularios, pero como muchos no lo hacen, te recomendamos no depender de ellas e implementar tus propias comprobaciones de validación.
 Veamos un ejemplo.
 
-Primero, un formulario HTML simple que requiere que introduzcas tu nombre y apellido:
+Primero, un formulario HTML sencillo que te pide que introduzcas tu nombre y tu apellido:
 
 ```html
-<form>
+<form action="#">
   <div>
     <label for="fname">Nombre: </label>
     <input id="fname" type="text" />
@@ -403,8 +353,8 @@ div {
 }
 ```
 
-Ahora un poco de JavaScript. Aquí vamos a implementar una simple prueba dentro del manejador del evento [`submit`](/es/docs/Web/API/HTMLFormElement/submit_event) (el evento _submit_ es lanzado en un formulario cuando este se envía) que determina si los campos de texto están vacíos o no.
-En caso de que lo estén, llamamos al método [`preventDefault()`](/es/docs/Web/API/Event/preventDefault) del objeto evento, el cual detiene el envío del formulario y muestra un mensaje de error en el párrafo debajo de nuestro formulario para hacerle saber al usuario cuál es el problema:
+Ahora un poco de JavaScript: aquí implementamos una comprobación básica dentro de un manejador para el evento [`submit`](/es/docs/Web/API/HTMLFormElement/submit_event) (el evento submit se lanza en un formulario cuando este se envía) que comprueba si los campos de texto están vacíos.
+Si lo están, llamamos a la función [`preventDefault()`](/es/docs/Web/API/Event/preventDefault) sobre el objeto evento —lo que detiene el envío del formulario— y mostramos un mensaje de error en el párrafo debajo del formulario para indicarle al usuario cuál es el problema:
 
 ```js
 const form = document.querySelector("form");
@@ -415,393 +365,34 @@ const para = document.querySelector("p");
 form.addEventListener("submit", (e) => {
   if (fname.value === "" || lname.value === "") {
     e.preventDefault();
-    para.textContent = "¡Necesitas completar ambos campos!";
+    para.textContent = "¡Debes completar ambos nombres!";
   }
 });
 ```
 
-Obviamente esta es una validación bastante débil, esto no detendría al usuario de, por ejemplo, llenar los campos del formulario con espacios en blanco o números, pero, es suficiente para los propósitos de nuestro ejemplo.
-El resultado es el siguiente:
+Obviamente, esta es una validación de formulario bastante débil —no evitaría, por ejemplo, que el usuario validara el formulario con espacios en blanco o números en los campos—, pero sirve a modo de ejemplo.
 
-{{ EmbedLiveSample('Preventing_default_behavior', '100%', 180, "", "") }}
+Puedes ver el ejemplo completo [funcionando en vivo](https://mdn.github.io/learning-area/javascript/building-blocks/events/preventdefault-validation.html); pruébalo ahí. Para consultar el código fuente completo, visita [preventdefault-validation.html](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/preventdefault-validation.html).
 
-> [!NOTE]
-> Para ver el código fuente completo, aquí tienes el archivo [preventdefault-validation.html](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/preventdefault-validation.html) (también puedes [verlo ejecutándose en vivo](https://mdn.github.io/learning-area/javascript/building-blocks/events/preventdefault-validation.html) aquí).
+## No es solo en páginas web
 
-## Burbujeo de eventos
+Los eventos no son exclusivos de JavaScript: la mayoría de los lenguajes de programación tienen algún tipo de modelo de eventos, y su funcionamiento suele ser distinto al de JavaScript.
+De hecho, el modelo de eventos de JavaScript en páginas web es diferente del modelo de eventos de JavaScript usado en otros entornos.
 
-El burbujeo de eventos (o _event bubbling_) describe como el navegador maneja eventos dirigidos a elementos anidados.
+Por ejemplo, [Node.js](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs) es un entorno de ejecución de JavaScript muy popular que permite a los desarrolladores crear aplicaciones de red y del lado del servidor.
+El [modelo de eventos de Node.js](https://nodejs.org/api/events.html) se basa en detectores que escuchan eventos y emisores que los emiten periódicamente; no suena tan distinto, pero el código es bastante diferente, ya que usa funciones como `on()` para registrar un detector de eventos, y `once()` para registrar uno que se elimina después de ejecutarse una vez.
+La [documentación sobre el evento connect de HTTP en Node.js](https://nodejs.org/api/http.html#event-connect) ofrece un buen ejemplo.
 
-### Estableciendo un detector de eventos en un elemento padre
+También puedes usar JavaScript para crear complementos multinavegador —mejoras de funcionalidad del navegador— utilizando una tecnología llamada [WebExtensions](/es/docs/Mozilla/Add-ons/WebExtensions).
+El modelo de eventos es similar al modelo de eventos web, pero un poco diferente: las propiedades de los detectores de eventos se escriben en {{Glossary("camel_case", "camel case")}} (por ejemplo, `onMessage` en lugar de `onmessage`), y deben combinarse con la función `addListener`.
+Consulta la página de [`runtime.onMessage`](/es/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#examples) para ver un ejemplo.
 
-Considera una página web como la siguiente:
+No necesitas entender nada sobre estos otros entornos en esta etapa de tu aprendizaje; solo queríamos dejar claro que los eventos pueden variar según el entorno de programación.
 
-```html
-<div id="container">
-  <button>¡Haz clic en mi!</button>
-</div>
-<pre id="output"></pre>
-```
+## Resumen
 
-Aquí el botón se encuentra dentro de otro elemento, de forma específica, un elemento {{HTMLElement("div")}}. En este caso, decimos que el elemento `<div>` es el **padre** del elemento que contiene. ¿Qué sucede si agregamos un manejador para el evento `click` en el padre y luego hacemos clic en el botón?
+En este capítulo hemos aprendido qué son los eventos, cómo detectarlos y cómo responder a ellos.
 
-```js
-const output = document.querySelector("#output");
-function handleClick(e) {
-  output.textContent += `Hiciste clic en un elemento ${e.currentTarget.tagName}\n`;
-}
+Ya habrás visto que los elementos de una página web pueden estar anidados dentro de otros elementos. Por ejemplo, en el ejemplo de [Evitar el comportamiento por defecto](#evitar_el_comportamiento_por_defecto), tenemos algunos campos de texto ubicados dentro de elementos {{htmlelement("div")}}, que a su vez están ubicados dentro de un elemento {{htmlelement("form")}}. ¿Qué ocurre cuando se asocia un detector del evento click al elemento `<form>` y el usuario haga clic dentro de uno de los campos de texto? La función manejadora de eventos asociada se sigue disparando gracias a un proceso llamado _burbujeo de eventos_ (_event bubbling_), que se tratará en la siguiente lección.
 
-const container = document.querySelector("#container");
-container.addEventListener("click", handleClick);
-```
-
-{{ EmbedLiveSample('Setting a listener on a parent element', '100%', 200, "", "") }}
-
-Como puedes ver, el padre lanza el evento `click` cuando el usuario hace clic en el botón:
-
-```
-Hiciste clic en un elemento DIV
-```
-
-Esto tiene sentido, el botón está dentro del elemento `<div>`, por lo tanto, cuando haces clic en el botón, de forma implícita estás haciendo clic en el elemento en el que se encuentra.
-
-### Ejemplo de burbujeo
-
-¿Qué sucede si agregamos un detector de eventos al botón _y_ al padre?
-
-```html
-<body>
-  <div id="container">
-    <button>¡Haz clic en mi!</button>
-  </div>
-  <pre id="output"></pre>
-</body>
-```
-
-Intentemos agregar un manejador de eventos al botón, a su padre (el `<div>`) y, además, al elemento {{HTMLElement("body")}} que contiene a ambos:
-
-```js
-const output = document.querySelector("#output");
-function handleClick(e) {
-  output.textContent += `Hiciste clic en un elemento ${e.currentTarget.tagName}\n`;
-}
-
-const container = document.querySelector("#container");
-const button = document.querySelector("button");
-
-document.body.addEventListener("click", handleClick);
-container.addEventListener("click", handleClick);
-button.addEventListener("click", handleClick);
-```
-
-{{ EmbedLiveSample('Bubbling example', '100%', 200, "", "") }}
-
-Te darás cuenta que los tres elementos lanzan un evento de clic cuando el usuario hace clic en el botón:
-
-```
-Hiciste clic en un elemento BUTTON
-Hiciste clic en un elemento DIV
-Hiciste clic en un elemento BODY
-```
-
-En este caso:
-
-- el clic en el botón se lanza primero
-- seguido del clic en el padre (el elemento `<div>`)
-- por último, se lanza en el padre del elemento `<div>` (el elemento `<body>`).
-
-Para describir esta situación, decimos que el evento **burbujea hacia arriba** (_bubbles up_, en inglés) desde el elemento más interno que recibió un clic.
-
-Este comportamiento puede ser útil a la par de causar problemas inesperados. En las siguientes secciones veremos los problemas que causa y econtraremos una solución.
-
-### Ejemplo de un reproductor de video
-
-En este ejemplo, nuestra página contiene un video, el cual se encuentra oculto inicialmente, y un botón con la etiqueta "Display video". Queremos lograr la siguiente interacción:
-
-- Cuando el usuario hace clic en el botón de "Display video", muestra la caja que contiene el video, pero sin iniciar la reproducción del video todavía.
-- Cuando el usuario hace clic en el video, inicia la reproducción del video.
-- Cuando el usuario hace clic en cualquier lugar fuera de la caja del video, oculta la caja nuevamente.
-
-El HTML se ve así:
-
-```html
-<button>Mostrar vídeo</button>
-
-<div class="hidden">
-  <video>
-    <source src="/shared-assets/videos/flower.webm" type="video/webm" />
-    <p>
-      Su navegador no es compatible con video HTML. Aquí hay un
-      <a href="rabbit320.mp4">enlace al video</a> en su lugar.
-    </p>
-  </video>
-</div>
-```
-
-Además incluye:
-
-- un element `<button>`
-- un elemento `<div>` que inicialmente tiene un atributo `class="hidden"`
-- un elemento `<video>` anidado dentro del elemento `<div>`.
-
-Estamos usando CSS para ocultar elementos con la clase `"hidden"`.
-
-```css hidden
-div {
-  width: 100%;
-  height: 100%;
-  background-color: #eee;
-}
-
-.hidden {
-  display: none;
-}
-
-div video {
-  padding: 40px;
-  display: block;
-  width: 400px;
-  margin: 40px auto;
-}
-```
-
-El código JavaScript se ve así:
-
-```js
-const btn = document.querySelector("button");
-const box = document.querySelector("div");
-const video = document.querySelector("video");
-
-btn.addEventListener("click", () => box.classList.remove("hidden"));
-video.addEventListener("click", () => video.play());
-box.addEventListener("click", () => box.classList.add("hidden"));
-```
-
-Éste añade tres manejadores para el evento `'click'`:
-
-- uno en el `<button>`, el cual muestra el `<div>` que contiene al `<video>`
-- uno en el `<video>`, el cual inicia la reproducción del video
-- uno en el `<div>`, el cual oculta el video.
-
-Veamos como funciona esto:
-
-{{ EmbedLiveSample('Video_player_example', '100%', 500) }}
-
-Deberías ver que cuando haces clic en el botón, la caja y el video que contiene son mostrados. Pero cuando haces clic en el video, éste empieza a reproducirse pero, ¡la caja se oculta de nuevo!
-
-El video se encuentra dentro del `<div>`, ya que es parte de él, por lo tanto, hacer clic en el video ejecuta ambos manejadores de eventos, ocasionando este comportamiento.
-
-### Resolviendo el problema con stopPropagation()
-
-Como pudimos ver en la anterior sección, a veces el _event bubbling_ puede ocasionar problemas, pero existe una manera de prevenirlos.
-El objeto [`Event`](/es/docs/Web/API/Event)
-contiene un método llamado [`stopPropagation()`](/es/docs/Web/API/Event/stopPropagation) que cuando es llamado dentro de un manejador de evento, evita que el evento burbujee hacia los elementos de más arriba.
-
-Podemos solucionar nuestro problema actual al cambiar el código JavaScript por lo siguiente:
-
-```js
-const btn = document.querySelector("button");
-const box = document.querySelector("div");
-const video = document.querySelector("video");
-
-btn.addEventListener("click", () => box.classList.remove("hidden"));
-
-video.addEventListener("click", (event) => {
-  event.stopPropagation();
-  video.play();
-});
-
-box.addEventListener("click", () => box.classList.add("hidden"));
-```
-
-Todo lo que estamos haciendo aquí es llamar al método `stopPropagation()` en el objeto evento dentro del manejador del evento `'click'` para el elemento `<video>`. Esto evitará que el evento burbujee hacia la caja de más arriba. Ahora intenta hacer clic en el botón y luego en el video:
-
-{{EmbedLiveSample("Fixing the problem with stopPropagation()", '100%', 500)}}
-
-```html hidden
-<button>Mostrar vídeo</button>
-
-<div class="hidden">
-  <video>
-    <source src="/shared-assets/videos/flower.webm" type="video/webm" />
-    <p>
-      Su navegador no es compatible con video HTML. Aquí hay un
-      <a href="rabbit320.mp4">enlace al video</a> en su lugar.
-    </p>
-  </video>
-</div>
-```
-
-```css hidden
-div {
-  width: 100%;
-  height: 100%;
-  background-color: #eee;
-}
-
-.hidden {
-  display: none;
-}
-
-div video {
-  padding: 40px;
-  display: block;
-  width: 400px;
-  margin: 40px auto;
-}
-```
-
-### Captura de eventos
-
-Una forma alternativa para la propagación de eventos es la _captura de eventos_ (_event capture_, en inglés). Esta es parecida al _bubbling_ pero el sentido está invertido: en vez de que el evento se lance primero en el elemento objetivo más anidado y, sucesivamente, en elementos menos anidados, el evento se lanza primero en el elemento _menos anidado_, y luego en los elementos más anidados, hasta que el objetivo es alcanzado.
-
-La captura de eventos está desactivada por defecto. Para activarla debes pasar la opción `capture` al método `addEventListener()`.
-
-Este ejemplo es parecido al [ejemplo de burbujeo](#bubbling_example) que vimos anteriormente, a excepción de que ahora hemos usado la opción `capture`:
-
-```html
-<body>
-  <div id="container">
-    <button>¡Haz clic en mi!</button>
-  </div>
-  <pre id="output"></pre>
-</body>
-```
-
-```js
-const output = document.querySelector("#output");
-function handleClick(e) {
-  output.textContent += `Hiciste clic en un elemento ${e.currentTarget.tagName}\n`;
-}
-
-const container = document.querySelector("#container");
-const button = document.querySelector("button");
-
-document.body.addEventListener("click", handleClick, { capture: true });
-container.addEventListener("click", handleClick, { capture: true });
-button.addEventListener("click", handleClick);
-```
-
-{{ EmbedLiveSample('Event capture', '100%', 200, "", "") }}
-
-En este caso, el orden de los mensajes está invertido: el manejador de evento del `<body>` se lanza primero, seguido del manejador del `<div>` y por el último el manejador del `<button>`:
-
-```
-Hiciste clic en un elemento BODY
-Hiciste clic en un elemento DIV
-Hiciste clic en un elemento BUTTON
-```
-
-¿Por qué molestarse con ambos métodos, captura y burbujeo? En los malos viejos tiempos, cuando los navegadores eran mucho menos compatibles entre sí, Netscape utilizaba solamente captura de eventos, mientras que Internet Explorer solo usaba burbujeo de eventos. Cuando W3C decidió tratar de estandarizar este comportamiento y llegar a un acuerdo, terminaron con este sistema que incluye ambos métodos, el cual está implementado por los navegadores modernos.
-
-Por defecto, casi todos los manejadores de eventos están registrados en la fase de burbujeo, lo cual tiene sentido la mayoría de veces.
-
-## Delegación de eventos
-
-En la sección anterior, vimos un problema ocasionado por el burbujeo de eventos y cómo solucionarlo.
-El burbujeo de eventos no simplemente es molesto, sino que puede resultar bastante útil. Particularmente, hace posible la **delegación de eventos**. En esta técnica, cuando queremos que cierto código se ejecute cuando el usuario interacciona con cualquiera de un gran número de elementos descendientes, establecemos el detector de eventos en el padre y dejamos que los eventos burbujeen hasta el padre, en vez de establecer el detector de eventos individualmente en cada descendiente.
-
-Regresemos a nuestro primer ejemplo, donde establecemos el color de toda la página cuando el usuario hace clic en un botón. Imagina que en su lugar, la página está dividida en 16 secciones, y queremos establecer un color de fondo aleatorio en cada sección cuando el usuario hace clic en una sección.
-
-Aquí está el HTML:
-
-```html
-<div id="container">
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-  <div class="tile"></div>
-</div>
-```
-
-Estamos usando un poco de CSS para establecer el tamaño y posición de las secciones:
-
-```css
-.tile {
-  height: 100px;
-  width: 25%;
-  float: left;
-}
-```
-
-Ahora desde JavaScript podemos agregar un manejador del evento clic para cada sección.
-Pero una solución más sencilla y más eficiente sería agregar un solo detector de eventos en el padre, y aprovecharnos del burbujeo de eventos para asegurarnos de que el manejador se ejecuta cuando el usuario hace clic en una sección:
-
-```js
-function random(number) {
-  return Math.floor(Math.random() * number);
-}
-
-function bgChange() {
-  const rndCol = `rgb(${random(255)}, ${random(255)}, ${random(255)})`;
-  return rndCol;
-}
-
-const container = document.querySelector("#container");
-
-container.addEventListener(
-  "click",
-  (event) => (event.target.style.backgroundColor = bgChange()),
-);
-```
-
-El resultado es de la siguiente forma (intenta hacer clic alreador):
-
-{{ EmbedLiveSample('Event delegation', '100%', 430, "", "") }}
-
-> [!NOTE]
-> En este ejemplo, estamos usando `event.target` para obtener el elemento objetivo del evento (es decir, el elemento más interno). Si queremos acceder al elemento que manejó el evento (en este caso, el contenedor), podemos usar `event.currentTarget`.
-
-> [!NOTE]
-> Ve el archivo [useful-eventtarget.html](https://github.com/mdn/learning-area/blob/main/javascript/building-blocks/events/useful-eventtarget.html) para el código completo; además velo [ejecutándose en vivo](https://mdn.github.io/learning-area/javascript/building-blocks/events/useful-eventtarget.html) aquí.
-
-## No es solamente en paǵinas web
-
-Los eventos no son exclusivos de JavaScript, la mayoría de lenguajes de programación poseen algún tipo de modelo de eventos. El funcionamiento de estos modelos puede ser diferente de lo que tenemos en JavaScript.
-De hecho, el modelo de eventos en JavaScript para páginas web es diferente del modelo de eventos de JavaScript cuando se usa en otros entornos.
-
-Por ejemplo, [Node.js](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs) es un entorno de ejecución (_runtime, en inglés_) bastante popular que le permite a los desarrolladores usar JavaScript para crear aplicaciones de redes y del lado del servidor.
-El [modelo de eventos de Node.js](https://nodejs.org/api/events.html) se basa en detectores para detectar eventos y emisores para emitir eventos periodicamente, esto no suena muy alejado de lo que conocemos pero, el código sí es bastante diferente. En este modelo, se usan funciones como `on()` para registrar un detector de eventos, y `once()` para registrar un detector de eventos que elimina su registro después de haber sido ejecutado una vez.
-
-La [documentación del evento HTTP connect](https://nodejs.org/api/http.html#event-connect) proporciona un buen ejemplo.
-
-También puedes utilizar JavaScript para construir extensiones multi-navegador (mejoras en la funcionalidad de los navegadores) usando una tecnología llamada [WebExtensions](/es/docs/Mozilla/Add-ons/WebExtensions).
-El modelo de eventos es similar al modelo de los eventos de la web, salvo por pequeñas diferencias. Por ejemplo, las propiedades para detectar eventos utilizan el estilo _camel-case_ (`onMessage` en vez de `onmessage`), y necesitan ser combinadas con la función `addListener`.
-Visita la página de [`runtime.onMessage`](/es/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#examples) para ver un ejemplo.
-
-No necesitas entender nada sobre otros entornos de ejecución en este punto en tu camino de aprendizaje, simplemente queriamos aclarar que los eventos suelen ser diferentes en distintos entornos de programación.
-
-## ¡Pon a prueba tus habilidades!
-
-Haz llegado al final de este artículo pero, ¿Recuerdas la información más importante? Para verificar que has retenido esta información antes de que continúes, visita la página de [Pon a prueba tus habilidades: Eventos](/es/docs/Learn/JavaScript/Building_blocks/Test_your_skills:_Events).
-
-## Conclusión
-
-Por ahora deberías saber todo lo que necesitas sobre eventos en la web. Como mencionamos anteriormente, los eventos en realidad no son parte del núcleo de JavaScript, ya que estos son definidos como parte de la API del navegador.
-
-De igual forma, es importante entender que los diferentes contextos en los que JavaScript se usa, tienen diferentes modelos de eventos, desde las API Web a otras áreas como WebExtensions y Node.js (JavaScript del lado del servidor).
-
-No estamos esperando que entiendas todas estás áreas justo ahora, pero sin duda mencionar estos temas te ayudará a entender los aspectos básicos de los eventos mientras sigues adelante en tu proceso de aprendizaje de desarrollo web.
-
-Si hay algo que no te quedó muy claro, tómate la libertad de leer de nuevo el artículo o [contáctanos](https://discourse.mozilla.org/c/mdn/learn/250) para pedir ayuda.
-
-## Véase también
-
-- [domevents.dev](https://domevents.dev/) — una aplicación interactiva bastante útil para aprender el comportamiento del sistema de eventos del DOM a través de la exploración.
-- [Referencia de eventos](/es/docs/Web/API/Document_Object_Model/Events)
-- [Orden de eventos](https://www.quirksmode.org/js/events_order.html) (debate sobre captura y burbujeo) - un excelente y detallado artículo por Peter-Paul Koch.
-- [Event accessing](https://www.quirksmode.org/js/events_access.html) (debate sobre el objeto evento) - otro excelente y detallado artículo por Peter-Paul Koch.
-
-{{PreviousMenuNext("Learn_web_development/Core/Scripting/Return_values","Learn_web_development/Core/Scripting/Image_gallery", "Learn_web_development/Core/Scripting")}}
+{{PreviousMenuNext("Learn_web_development/Core/Scripting/Test_your_skills/Functions","Learn_web_development/Core/Scripting/Event_bubbling", "Learn_web_development/Core/Scripting")}}


### PR DESCRIPTION
## Description

Synchronizes the Spanish translation of `Introduction to events` with the current English source in `mdn/content`.

## Changes

- `l10n.sourceCommit` updated to current EN HEAD SHA.
- Added `short-title` to front-matter.
- Moved all bubbling/capture/delegation content to a new `Event_bubbling` page (confirmed by the updated `{{PreviousMenuNext}}` "next" target).
- Dropped "Test your skills", "Conclusion", and "See also".
- Replaced the old "Conclusion" with a short new "Summary" section.
- Reworked the intro table (`Prerequisites` / `Learning outcomes` instead of `Prerequisites` / `Objective`).
- Restructured a few code samples (modern space-separated `rgb()` syntax, `<form action="#">`, block-bodied `keydown` handler).
- Synchronized content to exactly match the latest English version.