### PR TITLE
[es] Sync Handling different text directions

### DIFF
--- a/files/es/learn_web_development/core/styling_basics/handling_different_text_directions/index.md
+++ b/files/es/learn_web_development/core/styling_basics/handling_different_text_directions/index.md
@@ -43,10 +43,10 @@ Un modo de escritura en CSS se refiere a si el texto se desplaza de forma horizo
 En el siguiente ejemplo tenemos un encabezado mostrado usando `writing-mode: vertical-rl`. El texto ahora se desplaza verticalmente. El texto vertical es común en el diseño gráfico, y puede ser una forma de darle un aspecto más interesante a tu diseño web.
 
 ```html live-sample___simple-vertical
-<h1>Play with writing modes</h1>
+<h1>Experimenta con los modos de escritura</h1>
 ```
 
-`css live-sample___simple-vertical
+```css live-sample___simple-vertical
 body {
   font-family: sans-serif;
   height: 300px;
@@ -57,7 +57,7 @@ h1 {
   background-color: black;
   padding: 10px;
 }
-`
+```
 
 {{EmbedLiveSample("simple-vertical", "", "350px")}}
 
@@ -78,12 +78,12 @@ Si observamos un ejemplo, esto quedará más claro. En el siguiente ejemplo teng
 ```html live-sample___block-inline
 <div class="wrapper">
   <div class="box horizontal">
-    <h2>Heading</h2>
-    <p>A paragraph demonstrating writing modes in CSS.</p>
+    <h2>Encabezado</h2>
+    <p>Un párrafo que muestra los modos de escritura en CSS.</p>
   </div>
   <div class="box vertical">
-    <h2>Heading</h2>
-    <p>A paragraph demonstrating writing modes in CSS.</p>
+    <h2>Encabezado</h2>
+    <p>Un párrafo que muestra los modos de escritura en CSS.</p>
   </div>
 </div>
 ```
@@ -201,26 +201,26 @@ La propiedad mapeada a `width` cuando estamos en un modo de escritura horizontal
 </div>
 ```
 
-````css live-sample___inline-size
+```css live-sample___inline-size
 .wrapper {
-display: flex;
+  display: flex;
 }
 
 .box {
-border: 1px solid #cccccc;
-padding: 0.5em;
-margin: 10px;
-inline-size: 100px;
+  border: 1px solid #cccccc;
+  padding: 0.5em;
+  margin: 10px;
+  inline-size: 100px;
 }
 
 .horizontal {
-writing-mode: horizontal-tb;
+  writing-mode: horizontal-tb;
 }
 
 .vertical {
-writing-mode: vertical-rl;
+  writing-mode: vertical-rl;
 }
-​```
+```
 
 {{EmbedLiveSample("inline-size", "", "300px")}}
 
@@ -238,18 +238,18 @@ Si cambias el modo de escritura de las cajas cambiando la propiedad `writing-mod
 
 También puedes ver que el {{htmlelement("Heading_Elements", "h2")}} tiene un `border-bottom` negro. ¿Puedes descubrir cómo hacer que ese borde inferior siempre quede debajo del texto en ambos modos de escritura?
 
-​```html live-sample___logical-mbp
+```html live-sample___logical-mbp
 <div class="wrapper">
   <div class="box physical">
-    <h2>Physical Properties</h2>
-    <p>A paragraph demonstrating logical properties in CSS.</p>
+    <h2>Propiedades físicas</h2>
+    <p>Un párrafo que muestra las propiedades lógicas en CSS.</p>
   </div>
   <div class="box logical">
-    <h2>Logical Properties</h2>
-    <p>A paragraph demonstrating logical properties in CSS.</p>
+    <h2>Propiedades lógicas</h2>
+    <p>Un párrafo que muestra las propiedades lógicas en CSS.</p>
   </div>
 </div>
-````
+```
 
 ```css live-sample___logical-mbp
 .wrapper {
@@ -314,25 +314,25 @@ Cambia el modo de escritura de este ejemplo a `vertical-rl` para ver qué le suc
 </div>
 ```
 
-````css live-sample___float
+```css live-sample___float
 .wrapper {
-display: flex;
+  display: flex;
 }
 
 .box {
-margin: 10px;
-padding: 0.5em;
-border: 1px solid #cccccc;
-inline-size: 200px;
-writing-mode: horizontal-tb;
+  margin: 10px;
+  padding: 0.5em;
+  border: 1px solid #cccccc;
+  inline-size: 200px;
+  writing-mode: horizontal-tb;
 }
 
 img {
-float: inline-start;
-margin-inline-end: 10px;
-margin-block-end: 10px;
+  float: inline-start;
+  margin-inline-end: 10px;
+  margin-block-end: 10px;
 }
-​```
+```
 
 {{EmbedLiveSample("float", "", "200px")}}
 
@@ -345,4 +345,3 @@ Las propiedades y valores lógicos son más recientes que sus equivalentes físi
 ## Resumen
 
 Los conceptos explicados en esta lección son cada vez más importantes en CSS. Entender la dirección de bloque y en línea — y cómo el flujo del texto cambia al cambiar el modo de escritura — te será muy útil de aquí en adelante. Te ayudará a entender CSS incluso si nunca usas un modo de escritura distinto al horizontal.
-````

--- a/files/es/learn_web_development/core/styling_basics/handling_different_text_directions/index.md
+++ b/files/es/learn_web_development/core/styling_basics/handling_different_text_directions/index.md
@@ -1,145 +1,348 @@
 ---
-title: Manejando diferentes direcciones de texto
+title: Cómo manejar diferentes direcciones de texto
+short-title: Múltiples direcciones de texto
 slug: Learn_web_development/Core/Styling_basics/Handling_different_text_directions
-original_slug: Learn/CSS/Building_blocks/Handling_different_text_directions
+l10n:
+  sourceCommit: 2b4a2ad5d9ba084a9eaa2f9204102655e7b575c4
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Styling_basics/Backgrounds_and_borders", "Learn_web_development/Core/Styling_basics/Overflow", "Learn_web_development/Core/Styling_basics")}}
+Muchas de las propiedades y valores que hemos visto hasta ahora en nuestro aprendizaje de CSS han estado ligadas a las dimensiones físicas de nuestra pantalla. Por ejemplo, creamos bordes en la parte superior, derecha, inferior e izquierda de una caja. Estas dimensiones físicas se ajustan muy bien al contenido que se visualiza horizontalmente, y por defecto la web tiende a soportar mejor los idiomas de izquierda a derecha (por ejemplo, inglés o francés) que los idiomas de derecha a izquierda (como el árabe).
 
-Muchas de las propiedades y valores que hemos encontrado hasta ahora en nuestro aprendizaje de CSS han estado ligadas a las dimensiones físicas de nuestra pantalla. Creamos bordes arriba, a la derecha, abajo y a la izquierda de una caja, por ejemplo. Estas dimensiones físicas se ajustan adecuadamente al contenido que se visualiza de forma horizontal, y por defecto, la web tiende a apoyar lenguajes de izquierda a derecha, como el castellano o el francés, mejor que aquellos que se escriben de derecha a izquierda, como el árabe.
-
-Sin embargo, en los últimos años, CSS ha evolucionado para soportar de mejor forma contenidos en diferente direccionalidad, incluyendo contenido de derecha a izquierda, pero también de arriba-abajo, como el japonés - Estas direccionalidades se llaman **modos de escritura**. En la medida que progresa tu estudio y comiences a trabajar con diseños, comprender los modos de escritura será de mucha utilidad para ti, por ello los explicaremos a continuación.
+Sin embargo, en los últimos años CSS ha evolucionado para dar mejor soporte a diferentes direccionalidades de contenido, incluyendo no solo de derecha a izquierda, sino también de arriba hacia abajo (como el japonés) — a estas diferentes direccionalidades se les llama **modos de escritura**. A medida que avances en tu aprendizaje y comiences a trabajar con maquetación, entender los modos de escritura te será de mucha ayuda, por lo que los presentaremos ahora.
 
 <table>
   <tbody>
     <tr>
       <th scope="row">Prerrequisitos:</th>
       <td>
-        Literatura computacional básica,
         <a
           href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software"
-          >software básico instalado</a
-        >, conocimiento básico de
-        <a href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
-          >manejo de archivos</a
-        >, HTML básico (<a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+          >Software básico instalado</a
+        >, conocimientos básicos de
+        <a
+          href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
+          >cómo trabajar con archivos</a
+        >, fundamentos de HTML (estudia
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción a HTML</a
-        >), y una idea de cómo funciona CSS (<a
-          href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics"
-          >Primeros pasos en CSS</a
-        >.)
+        >), y una idea de cómo funciona CSS (estudia
+        <a href="/es/docs/Learn_web_development/Core/Styling_basics">Fundamentos de estilos con CSS</a>.)
       </td>
     </tr>
     <tr>
       <th scope="row">Objetivo:</th>
-      <td>
-        Entender la importancia de los modos de escritura en el CSS moderno.
-      </td>
+      <td>Comprender la importancia de los modos de escritura en el CSS moderno.</td>
     </tr>
   </tbody>
 </table>
 
 ## ¿Qué son los modos de escritura?
 
-Un modo de escritura en CSS se refiere a si el texto está escrito horizontal o verticalmente. La propiedad {{cssxref("writing-mode")}} permite cambiar de un modo a otro. No necesitas estar trabajando en un lenguaje que use un modo de escritura vertical para querer hacer esto - Podrías cambiar el modo de escritura de partes de tu diseño por razones creativas.
+Un modo de escritura en CSS se refiere a si el texto se desplaza de forma horizontal o vertical. La propiedad {{cssxref("writing-mode")}} nos permite cambiar de un modo de escritura a otro. No es necesario que estés trabajando con un idioma que use un modo de escritura vertical para querer hacer esto — también puedes cambiar el modo de escritura de partes de tu maquetación con fines creativos.
 
-En el ejemplo siguiente existe un encabezado desplegado usando `writing-mode: vertical-rl`. El texto ahora aparece vertical. El texto vertical es común en diseño gráfico, y puede ser una forma de agregar un aspecto más interesante a tu diseño web.
+En el siguiente ejemplo tenemos un encabezado mostrado usando `writing-mode: vertical-rl`. El texto ahora se desplaza verticalmente. El texto vertical es común en el diseño gráfico, y puede ser una forma de darle un aspecto más interesante a tu diseño web.
 
-{{EmbedGHLiveSample("css-examples/learn/writing-modes/simple-vertical.html", '100%', 800)}}
+```html live-sample___simple-vertical
+<h1>Play with writing modes</h1>
+```
 
-Los tres valores posibles para la propiedad [`writing-mode`](/es/docs/Web/CSS/Reference/Properties/writing-mode) son:
+`css live-sample___simple-vertical
+body {
+  font-family: sans-serif;
+  height: 300px;
+}
+h1 {
+  writing-mode: vertical-rl;
+  color: white;
+  background-color: black;
+  padding: 10px;
+}
+`
 
-- `horizontal-tb`: Dirección de flujo de bloque de arriba abajo. Las frases aparecen horizontales.
-- `vertical-rl`: Dirección de flujo de bloque de derecha a izquierda. Las frases aparecen verticales.
-- `vertical-lr`: Dirección de flujo de bloque de izquierda a derecha. Las frases aparecen verticales.
+{{EmbedLiveSample("simple-vertical", "", "350px")}}
 
-Así, la propiedad `writing-mode` está configurando en realidad la direccion en que los elementos de nivel bloque son desplegados en la página - ya sea de arriba abajo, derecha a izquierda, o de izquierda a derecha. Luego señala la dirección del flujo de texto en las frases.
+Los tres valores posibles para la propiedad {{cssxref("writing-mode")}} son:
 
-## Modos de escritura y diseño en bloque y lineal
+- `horizontal-tb`: Dirección de flujo de bloque de arriba hacia abajo. Las oraciones se desplazan horizontalmente.
+- `vertical-rl`: Dirección de flujo de bloque de derecha a izquierda. Las oraciones se desplazan verticalmente.
+- `vertical-lr`: Dirección de flujo de bloque de izquierda a derecha. Las oraciones se desplazan verticalmente.
 
-Ya hemos visto el diseño en bloque y lineal, y el hecho de que algunas cosas se muestran como elementos de bloque y otras como elementos lineales. Ésto se encuentra ligado al modo de escritura del documento, y no de la pantalla física. Los bloques sólo se presentan desde la parte superior a la inferior de la página si estas usando un modo de escritura que presente el texto horizontalmente, como el español.
+Entonces, la propiedad `writing-mode` en realidad establece la dirección en la que se muestran los elementos de nivel de bloque en la página: ya sea de arriba hacia abajo, de derecha a izquierda, o de izquierda a derecha. Esto a su vez determina la dirección en la que fluye el texto en las oraciones.
 
-Con el siguiente ejemplo quedará más claro. Si tienes dos cajas que contengan un `heading` y un `paragraph`. La primera usa `writing-mode: horizontal-tb`, un modo de escritura horizontal y desde la parte superior de la página a la base. La segunda usa `writing-mode: vertical-rl`; este es un modo de escritura vertical y de derecha a izquierda.
+## Modos de escritura y la disposición de bloque y en línea
 
-{{EmbedGHLiveSample("css-examples/learn/writing-modes/block-inline.html", '100%', 1200)}}
+Ya hemos hablado de la [disposición de bloque y en línea](/es/docs/Web/CSS/Guides/Display/Block_and_inline_layout), y del hecho de que algunas cosas se muestran como elementos de bloque y otras como elementos en línea. Como hemos visto anteriormente, el comportamiento de bloque y en línea está ligado al modo de escritura del documento, y no a la pantalla física. Los bloques solo se muestran de arriba hacia abajo en la página si estás usando un modo de escritura que despliega el texto horizontalmente, como el inglés.
 
-Cuando cambiamos el modo de escritura, estamos cambiando que dirección es en bloque y cuál es lineal. En un modo de escritura `horizontal-tb` La direccion del bloque va de arriba abajo; en un modo de escritura `vertical-rl` el bloque corre de derecha a izquierda horizontalmente. De esta forma la **dimensión del bloque** es siempre la direccion en la que se muestran los bloques en el modo de escritura en uso. La **dimensión lineal**, es siempre la dirección en que fluye una frase.
+Si observamos un ejemplo, esto quedará más claro. En el siguiente ejemplo tengo dos cajas que contienen un encabezado y un párrafo. La primera usa `writing-mode: horizontal-tb` — un modo de escritura horizontal, de arriba hacia abajo. La segunda usa `writing-mode: vertical-rl` — un modo de escritura vertical, de derecha a izquierda.
 
-Este dibujo muestra las dos dimensiones en un modo de escritura horizontal.![Showing the block and inline axis for a horizontal writing mode.](horizontal-tb.png)
+```html live-sample___block-inline
+<div class="wrapper">
+  <div class="box horizontal">
+    <h2>Heading</h2>
+    <p>A paragraph demonstrating writing modes in CSS.</p>
+  </div>
+  <div class="box vertical">
+    <h2>Heading</h2>
+    <p>A paragraph demonstrating writing modes in CSS.</p>
+  </div>
+</div>
+```
 
-Este dibujo muestra las dos dimensiones en un modo de escritura vertical.
+```css live-sample___block-inline
+body {
+  font-family: sans-serif;
+  height: 300px;
+}
+.wrapper {
+  display: flex;
+}
 
-![Showing the block and inline axis for a vertical writing mode.](vertical.png)
+.box {
+  border: 1px solid #cccccc;
+  padding: 0.5em;
+  margin: 10px;
+}
 
-Una vez que empieces a observar el diseño CSS, y en particular los nuevos métodos de diseño, esta idea de bloque y lineal cobra mayor importancia. Será revisado más adelante.
+.horizontal {
+  writing-mode: horizontal-tb;
+}
+
+.vertical {
+  writing-mode: vertical-rl;
+}
+```
+
+{{EmbedLiveSample("block-inline", "", "350px")}}
+
+Cuando cambiamos el modo de escritura, estamos cambiando cuál dirección es de bloque y cuál es en línea. En un modo de escritura `horizontal-tb`, la dirección de bloque va de arriba hacia abajo; en un modo de escritura `vertical-rl`, la dirección de bloque va de derecha a izquierda horizontalmente. Entonces, la **dimensión de bloque** siempre es la dirección en la que se muestran los bloques en la página según el modo de escritura en uso. La **dimensión en línea** siempre es la dirección en la que fluye una oración.
+
+Esta figura muestra las dos dimensiones en un modo de escritura horizontal.
+
+![Mostrando el eje de bloque y en línea para un modo de escritura horizontal.](horizontal-tb.png)
+
+Esta figura muestra las dos dimensiones en un modo de escritura vertical.
+
+![Mostrando el eje de bloque y en línea para un modo de escritura vertical.](vertical.png)
+
+Una vez que empieces a estudiar la disposición en CSS, y en particular los métodos de disposición más nuevos, esta idea de bloque y en línea se vuelve muy importante. Volveremos a este tema más adelante.
 
 ### Dirección
 
-Además del modo de escritura también tenemos la dirección del texto. Como se mencionó antes, algunos idiomas como el Árabe se escriben horizontalmente, de derecha a izquierda. Esto no es algo que usarías en un sentido creativo. Si tu simplemente quieres alinear algún elemento a la derecha, existen otras formas de hacerlo. Sin embargo es importante entender esto como parte de la naturaleza del CSS. La web no es solo para lenguajes que son escritos de izquierda a derecha!
+Además del modo de escritura, también tenemos la dirección del texto. Como mencionamos antes, algunos idiomas como el árabe se escriben horizontalmente, pero de derecha a izquierda. Esto no es algo que probablemente uses con fines creativos — si quieres alinear algo a la derecha hay otras formas de hacerlo — sin embargo, es importante entender esto como parte de la naturaleza de CSS. ¡La web no es solo para idiomas que se muestran de izquierda a derecha!
 
-Debido al hecho de que el modo de escritura y la dirección del texto pueden cambiar, los nuevos métodos de diseño CSS no toman como referencia la izquierda y derecha, ni la parte superior e inferior. En su lugar, hablarán de inicio y fin junto con esta idea de en línea y bloque. No te preocupes mucho por eso en este momento, pero ten en cuenta estas ideas a medida que empiezas a mirar el diseño de una página web; va a ser de gran ayuda en tu entendimiento de CSS.
+Debido a que el modo de escritura y la dirección del texto pueden cambiar, los métodos de disposición más nuevos de CSS no se refieren a izquierda y derecha, ni a arriba y abajo. En su lugar, hablarán de _inicio_ y _fin_, junto con esta idea de bloque y en línea. No te preocupes demasiado por esto ahora, pero ten estas ideas en mente cuando empieces a estudiar la disposición; te resultará muy útil para entender CSS.
 
-## Valores y propiedades lógicas
+## Propiedades y valores lógicos
 
-La razón de hablar acerca de modos de escritura y dirección en este punto en tu aprendizaje, es por el hecho de que ya vimos muchas de estas propiedades que están atadas a las dimensiones físicas de la pantalla, y tienen más sentido cuando está en un modo de escritura horizontal.
+La razón para hablar de modos de escritura y dirección en este punto de tu aprendizaje es que ya hemos visto muchas propiedades que están ligadas a las dimensiones físicas de la pantalla, y estas tienen más sentido cuando estamos en un modo de escritura horizontal.
 
-Vamos a echarle un vistzo a nuestras dos cajas de nuevo, una con el modo escritura `horizontal-tb` y otro con `vertical-rl`. Le hemos dado a estas dos cajas un {{cssxref("width")}}. Puedes ver que cuando la caja está en el modo de escritura vertical, aún tiene una anchura, y esto está causando que el texto se desborde.
+Volvamos a ver nuestras dos cajas — una con un modo de escritura `horizontal-tb` y otra con `vertical-rl`. A ambas cajas les he asignado un {{cssxref("width")}}. Puedes ver que cuando la caja está en el modo de escritura vertical, sigue teniendo un ancho, y esto hace que el texto se desborde.
 
-{{EmbedGHLiveSample("css-examples/learn/writing-modes/width.html", '100%', 1200)}}
+```html live-sample___width
+<div class="wrapper">
+  <div class="box horizontal">
+    <h2>Heading</h2>
+    <p>A paragraph demonstrating writing modes in CSS.</p>
+    <p>These boxes have a width.</p>
+  </div>
+  <div class="box vertical">
+    <h2>Heading</h2>
+    <p>A paragraph demonstrating writing modes in CSS.</p>
+    <p>These boxes have a width.</p>
+  </div>
+</div>
+```
 
-Lo que nosotros realmente queremos en este escenario, es esencialmente intercambiar altura y anchura junto con el modo de escritura. Cuando estamos en el modo de escritura vertical, queremos que la caja se expanda en la dimensión del bloque así como lo hace en el modo horizontal.
+```css live-sample___width
+body {
+  font-family: sans-serif;
+  height: 300px;
+}
+.wrapper {
+  display: flex;
+}
 
-Para hacerlo más fácil, CSS ha desarrollado recientemente un conjunto de propiedades asignadas. Estas esencialmente reemplazan las propiedades físicas como `width` and `height`, con versiones **lógicas** o **relativas al flujo**.
+.box {
+  border: 1px solid #cccccc;
+  padding: 0.5em;
+  margin: 10px;
+  width: 100px;
+}
 
-La propiedad asignada a `width` cuando está en el modo de escritura horizontal se llama {{cssxref("inline-size")}}, se refiere al tamaño en la dimensión inline. La propiedad para `height` se llama {{cssxref("block-size")}} y es el tamaño en la dimensión de bloque. Puedes ver como funciona en el ejemplo de abajo, donde reemplazamos `width` con `inline-size`.
+.horizontal {
+  writing-mode: horizontal-tb;
+}
 
-{{EmbedGHLiveSample("css-examples/learn/writing-modes/inline-size.html", '100%', 1200)}}
+.vertical {
+  writing-mode: vertical-rl;
+}
+```
 
-### Propiedades lógicas `margin`, `border` y `padding`
+{{EmbedLiveSample("width", "", "350px")}}
 
-En las últimas dos lecciones aprendimos acerca del modelo de cajas con CSS, y los bordes CSS. En las propiedades margin, border y padding vas a encontrar varias instancias de propiedades físicas, por ejemplo {{cssxref("margin-top")}}, {{cssxref("padding-left")}}, y {{cssxref("border-bottom")}}. Del mismo modo que tenemos asignaciones para ancho y alto, hay asignaciones para estas propiedades.
+Lo que realmente queremos en este escenario es básicamente intercambiar la altura por el ancho según el modo de escritura. Cuando estamos en un modo de escritura vertical, queremos que la caja se expanda en la dimensión de bloque, tal como lo hace en el modo horizontal.
 
-La propiedad `margin-top` está asignada a {{cssxref("margin-block-start")}}, esto siempre se va a referir al margen al inicio de la dimensión del bloque.
+Para facilitar esto, CSS ha desarrollado recientemente un conjunto de propiedades mapeadas. Estas esencialmente reemplazan propiedades físicas — cosas como `width` y `height` — con versiones **lógicas**, o **relativas al flujo**.
 
-La propiedad {{cssxref("padding-left")}} se asigna a {{cssxref("padding-inline-start")}}, el padding que se aplica al inicio de la dirección inline. Aquí será donde las oraciones comienzan en ese modo de escritura. La propiedad {{cssxref("border-bottom")}} se asigna a {{cssxref("border-block-end")}}, que es el borde del final de la dimensión del bloque.
+La propiedad mapeada a `width` cuando estamos en un modo de escritura horizontal se llama {{cssxref("inline-size")}} — se refiere al tamaño en la dimensión en línea. La propiedad para `height` se llama {{cssxref("block-size")}} y es el tamaño en la dimensión de bloque. Puedes ver cómo funciona esto en el siguiente ejemplo, donde reemplazamos `width` por `inline-size`.
 
-Puedes ver una comparación entre las propiedades físicas y lógicas a continuación.
+```html live-sample___inline-size
+<div class="wrapper">
+  <div class="box horizontal">
+    <h2>Heading</h2>
+    <p>A paragraph demonstrating writing modes in CSS.</p>
+    <p>These boxes have inline-size.</p>
+  </div>
+  <div class="box vertical">
+    <h2>Heading</h2>
+    <p>A paragraph demonstrating writing modes in CSS.</p>
+    <p>These boxes have inline-size.</p>
+  </div>
+</div>
+```
 
-**Si cambias el modo de escritura de las cajas asignando a la propiedad `writing-mode` en `.box` a `vertical-rl`, vas a ver como las propiedades físicas se quedan ligadas a sus direcciones físicas, mientras que las propiedades lógicas cambian con el modo de escritura.**
+````css live-sample___inline-size
+.wrapper {
+display: flex;
+}
 
-**También puedes ver que el {{htmlelement("h2")}} tiene un `border-bottom` negro. ¿Puedes averiguar como hacer que el borde inferior siempre esté debajo del texto en ambos modos de escritura?**
+.box {
+border: 1px solid #cccccc;
+padding: 0.5em;
+margin: 10px;
+inline-size: 100px;
+}
 
-{{EmbedGHLiveSample("css-examples/learn/writing-modes/logical-mbp.html", '100%', 1200)}}
+.horizontal {
+writing-mode: horizontal-tb;
+}
 
-Existe un gran número de propiedades cuando consideras cada uno de los bordes que puedes hacer a mano, y puedes ver todas las propiedades asignadas en la página de MDN para [propiedades Lógicas y Valores](/es/docs/Web/CSS/Guides/Logical_properties_and_values)
+.vertical {
+writing-mode: vertical-rl;
+}
+​```
+
+{{EmbedLiveSample("inline-size", "", "300px")}}
+
+### Propiedades lógicas de margen, borde y relleno
+
+En las últimas dos lecciones aprendimos sobre el modelo de caja de CSS y los bordes en CSS. En las propiedades de margen, borde y relleno encontrarás muchos casos de propiedades físicas, por ejemplo {{cssxref("margin-top")}}, {{cssxref("padding-left")}}, y {{cssxref("border-bottom")}}. De la misma forma en que existen mapeos para `width` y `height`, existen mapeos para estas propiedades.
+
+La propiedad `margin-top` se mapea a {{cssxref("margin-block-start")}} — esta siempre se refiere al margen al inicio de la dimensión de bloque.
+
+La propiedad {{cssxref("padding-left")}} se mapea a {{cssxref("padding-inline-start")}}, el relleno que se aplica al inicio de la dirección en línea. Este será el lugar donde comienzan las oraciones en ese modo de escritura. La propiedad {{cssxref("border-bottom")}} se mapea a {{cssxref("border-block-end")}}, que es el borde al final de la dimensión de bloque.
+
+Puedes ver una comparación entre propiedades físicas y lógicas a continuación.
+
+Si cambias el modo de escritura de las cajas cambiando la propiedad `writing-mode` en `.box` a `vertical-rl`, verás cómo las propiedades físicas se mantienen ligadas a su dirección física, mientras que las propiedades lógicas cambian junto con el modo de escritura.
+
+También puedes ver que el {{htmlelement("Heading_Elements", "h2")}} tiene un `border-bottom` negro. ¿Puedes descubrir cómo hacer que ese borde inferior siempre quede debajo del texto en ambos modos de escritura?
+
+​```html live-sample___logical-mbp
+<div class="wrapper">
+  <div class="box physical">
+    <h2>Physical Properties</h2>
+    <p>A paragraph demonstrating logical properties in CSS.</p>
+  </div>
+  <div class="box logical">
+    <h2>Logical Properties</h2>
+    <p>A paragraph demonstrating logical properties in CSS.</p>
+  </div>
+</div>
+````
+
+```css live-sample___logical-mbp
+.wrapper {
+  display: flex;
+  border: 5px solid #cccccc;
+}
+
+.box {
+  margin-right: 30px;
+  inline-size: 200px;
+  writing-mode: horizontal-tb;
+}
+
+.logical {
+  margin-block-start: 20px;
+  padding-inline-end: 2em;
+  padding-block-start: 2px;
+  border-block-start: 5px solid pink;
+  border-inline-end: 10px dotted rebeccapurple;
+  border-block-end: 1em double orange;
+  border-inline-start: 1px solid black;
+}
+
+.physical {
+  margin-top: 20px;
+  padding-right: 2em;
+  padding-top: 2px;
+  border-top: 5px solid pink;
+  border-right: 10px dotted rebeccapurple;
+  border-bottom: 1em double orange;
+  border-left: 1px solid black;
+}
+
+h2 {
+  border-bottom: 5px solid black;
+}
+```
+
+{{EmbedLiveSample("logical-mbp", "", "200px")}}
+
+Hay una gran cantidad de propiedades si consideras todas las propiedades individuales de borde, y puedes ver todas las propiedades mapeadas en la página de MDN sobre [Propiedades y valores lógicos](/es/docs/Web/CSS/Guides/Logical_properties_and_values).
 
 ### Valores lógicos
 
-Hasta ahora hemos examinado los nombres de las propiedades lógicas. Existen también algunas propiedades que toman valores físicos de `top`, `right`, `bottom`, y `left`. Estos valores también tienen asignaciones a valores lógicos: `block-start`, `inline-end`, `block-end`, y `inline-start`.
+Hasta ahora hemos visto nombres de propiedades lógicas. También hay algunas propiedades que aceptan valores físicos como `top`, `right`, `bottom`, y `left`. Estos valores también tienen mapeos a valores lógicos — `block-start`, `inline-end`, `block-end`, e `inline-start`.
 
-Por ejemplo, puedes hacer que una imagen flote a la izquierda para hacer que el texto se ajuste alrededor de la imagen. Puedes reemplazar `left` con `inline-start` como se muestra en el ejemplo a continuación.
+Por ejemplo, puedes flotar una imagen a la izquierda para hacer que el texto la rodee. Podrías reemplazar `left` por `inline-start` como se muestra en el siguiente ejemplo.
 
-**Cambia el modo de escritura en este ejemplo a `vertical-rl` para ver que sucede con la imagen. Cambia `inline-start` por `inline-end` para cambiar el modo en que flota.**
+Cambia el modo de escritura de este ejemplo a `vertical-rl` para ver qué le sucede a la imagen. Cambia `inline-start` a `inline-end` para cambiar el flotado:
 
-{{EmbedGHLiveSample("css-examples/learn/writing-modes/float.html", '100%', 1200)}}
+```html live-sample___float
+<div class="wrapper">
+  <div class="box logical">
+    <img
+      alt="star"
+      src="https://mdn.github.io/shared-assets/images/examples/big-star.png" />
+    <p>
+      This box uses logical properties. The star image has been floated
+      inline-start, it also has a margin on the inline-end and block-end.
+    </p>
+  </div>
+</div>
+```
 
-Aquí también estamos usando valores lógicos de margen para asegurar que el margen está en el sitio correcto sin importar que modo de escritura es.
+````css live-sample___float
+.wrapper {
+display: flex;
+}
 
-> [!NOTE]
-> Actualmente, solo Firefox soporta valores relativos de flujo para `float`. Si estás usando **Google Chrome** o **Microsoft Edge**, deberías ver que la imagen no flota.
+.box {
+margin: 10px;
+padding: 0.5em;
+border: 1px solid #cccccc;
+inline-size: 200px;
+writing-mode: horizontal-tb;
+}
 
-### ¿Debería usar propiedades físicas o lógicas?
+img {
+float: inline-start;
+margin-inline-end: 10px;
+margin-block-end: 10px;
+}
+​```
 
-Las propiedades lógicas y los valores son más recientes que su equivalente físico, y por lo tanto se han implementado recientemente en los navegadores. Puedes revisar cualquier página de propiedades en MDN para ver hasta donde llega el soporte del navegador. Si no estás usando multiples modos de escritura, entonces, por ahora, deberías preferir usar las versiones físicas. Sin embargo, en última instancia, esperamos que la gente va a pasar a las versiones lógicas para la mayoría de las cosas, ya que tienen mucho sentido una vez que comienzas a tratar también con métodos de diseño como Flexbox y Grid.
+{{EmbedLiveSample("float", "", "200px")}}
 
-## ¡Prueba tus habilidades!
+Aquí también estamos usando valores lógicos de margen para asegurarnos de que el margen quede en el lugar correcto sin importar cuál sea el modo de escritura.
 
-Tenemos mucho terreno cubierto en este artículo, pero puedes recordad la información más importante? Puedes encontrar algunas pruebas adicionales para verificar que has retenido esta información antes de seguir adelante: [Prueba tus habilidades: modos de escritura.](/es/docs/Learn_web_development/Core/Styling_basics/Handling_different_text_directions)
+### ¿Deberías usar propiedades físicas o lógicas?
+
+Las propiedades y valores lógicos son más recientes que sus equivalentes físicos, y por lo tanto se han implementado en los navegadores solo desde hace poco tiempo. Puedes revisar cualquier página de propiedades en MDN para ver hasta dónde llega el soporte de navegadores. Si no estás usando múltiples modos de escritura, entonces por ahora podrías preferir usar las versiones físicas. Sin embargo, en última instancia esperamos que las personas transicionen hacia las versiones lógicas para la mayoría de los casos, ya que tienen mucho sentido una vez que empiezas a trabajar con métodos de disposición como flexbox y grid.
 
 ## Resumen
 
-Los conceptos explicados en esta lección son cada vez más importantes en CSS. Un entendimiento pleno de las direcciones en bloque y en línea, y como el flujo de texto cambia con la variación de los modos de escritura, van a ser de gran ayuda en el futuro. Te ayudará a entender CSS incluso si nunca usas un modo de escritura diferente al horizontal.
-
-En el módulo siguiente, vamos a echar un buen vistazo al desbordamiento en CSS
-
-{{PreviousMenuNext("Learn_web_development/Core/Styling_basics/Backgrounds_and_borders", "Learn_web_development/Core/Styling_basics/Overflow", "Learn_web_development/Core/Styling_basics")}}
+Los conceptos explicados en esta lección son cada vez más importantes en CSS. Entender la dirección de bloque y en línea — y cómo el flujo del texto cambia al cambiar el modo de escritura — te será muy útil de aquí en adelante. Te ayudará a entender CSS incluso si nunca usas un modo de escritura distinto al horizontal.
+````

--- a/files/es/learn_web_development/core/styling_basics/handling_different_text_directions/index.md
+++ b/files/es/learn_web_development/core/styling_basics/handling_different_text_directions/index.md
@@ -141,14 +141,14 @@ Volvamos a ver nuestras dos cajas — una con un modo de escritura `horizontal-t
 ```html live-sample___width
 <div class="wrapper">
   <div class="box horizontal">
-    <h2>Heading</h2>
-    <p>A paragraph demonstrating writing modes in CSS.</p>
-    <p>These boxes have a width.</p>
+    <h2>Encabezado</h2>
+    <p>Un párrafo que muestra los modos de escritura en CSS.</p>
+    <p>Estas cajas tienen un ancho definido.</p>
   </div>
   <div class="box vertical">
-    <h2>Heading</h2>
-    <p>A paragraph demonstrating writing modes in CSS.</p>
-    <p>These boxes have a width.</p>
+    <h2>Encabezado</h2>
+    <p>Un párrafo que muestra los modos de escritura en CSS.</p>
+    <p>Estas cajas tienen un ancho definido.</p>
   </div>
 </div>
 ```
@@ -189,14 +189,14 @@ La propiedad mapeada a `width` cuando estamos en un modo de escritura horizontal
 ```html live-sample___inline-size
 <div class="wrapper">
   <div class="box horizontal">
-    <h2>Heading</h2>
-    <p>A paragraph demonstrating writing modes in CSS.</p>
-    <p>These boxes have inline-size.</p>
+    <h2>Encabezado</h2>
+    <p>Un párrafo que muestra los modos de escritura en CSS.</p>
+    <p>Estas cajas tienen <code>inline-size</code>.</p>
   </div>
   <div class="box vertical">
-    <h2>Heading</h2>
-    <p>A paragraph demonstrating writing modes in CSS.</p>
-    <p>These boxes have inline-size.</p>
+    <h2>Encabezado</h2>
+    <p>Un párrafo que muestra los modos de escritura en CSS.</p>
+    <p>Estas cajas tienen <code>inline-size</code>.</p>
   </div>
 </div>
 ```
@@ -304,11 +304,12 @@ Cambia el modo de escritura de este ejemplo a `vertical-rl` para ver qué le suc
 <div class="wrapper">
   <div class="box logical">
     <img
-      alt="star"
+      alt="estrella"
       src="https://mdn.github.io/shared-assets/images/examples/big-star.png" />
     <p>
-      This box uses logical properties. The star image has been floated
-      inline-start, it also has a margin on the inline-end and block-end.
+      Esta caja usa propiedades lógicas. La imagen de la estrella se ha flotado
+      con <code>inline-start</code>, y además tiene un margen en
+      <code>inline-end</code> y <code>block-end</code>.
     </p>
   </div>
 </div>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->
### Description
<!-- ✍️ Summarize your changes in one or two sentences -->
Syncs the Spanish translation of "Handling different text directions" with the latest English source (commit `2b4a2ad5d9ba084a9eaa2f9204102655e7b575c4`). The page had no `l10n.sourceCommit` and had never been registered for sync, so the full document was compared against English and rewritten to match, including the missing `## Summary` section and the `{{EmbedLiveSample}}` macros that were absent from the previous version.

### Motivation
<!-- ❓ Why are you making these changes and how do they help readers? -->
The Spanish version was outdated and out of sync with the English source, missing a full section and several live code samples. This left Spanish-speaking readers with an incomplete lesson compared to the English version. Syncing it closes that gap and restores the interactive examples that help demonstrate writing modes and logical properties.

### Additional details
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
- Front-matter cleaned up to only include `title`, `short-title`, `slug`, and `l10n.sourceCommit`, removed `original_slug`, `page-type`, and `sidebar` per the `es` contribution guide.
- Internal links updated from `/en-US/` to `/es/`.
- All Kumascript macros (`{{cssxref}}`, `{{htmlelement}}`, `{{EmbedLiveSample}}`) and code blocks left untouched, matching the English source exactly.
- Live sample HTML/CSS content (headings, demo text) left in English, consistent with the source, since it's placeholder text inside code blocks rather than reader-facing prose.

### Related issues and pull requests
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Fixes #37240
Relates to #9638

---

### AI usage disclosure
Portions of this translation were drafted with AI assistance (Claude), working section by section from the English source under my direction. I reviewed, edited, and verified every section myself, including macro syntax, link targets, and adherence to the `es` contribution guide's terminology and style rules (tuteo, active voice, front-matter format). All final wording and decisions are my own.