### PR TITLE
[zh-cn]: update the translation of Element wheel_event

### DIFF
--- a/files/zh-cn/web/api/element/wheel_event/index.md
+++ b/files/zh-cn/web/api/element/wheel_event/index.md
@@ -1,22 +1,32 @@
 ---
 title: Element：滚轮事件
+short-title: wheel
 slug: Web/API/Element/wheel_event
+l10n:
+  sourceCommit: ac7f589f2471fde8e5ee910a7fbd8a4bff931140
 ---
 
-{{APIRef}}
+{{APIRef("UI Events")}}
 
-**滚轮**（**`wheel`**）事件会在滚动鼠标滚轮或操作其他类似输入设备时触发。
+**`wheel`** 事件在用户旋转定点设备（通常是鼠标）上的滚轮按钮时触发。对于模拟滚轮操作的类似设备（例如触控板和滚球鼠标）也会触发该事件。
 
-滚轮事件取代了已被弃用的非标准 {{domxref("Element/mousewheel_event", "mousewheel")}} 事件。
+该事件取代了已被弃用的非标准 {{domxref("Element/mousewheel_event", "mousewheel")}} 事件。
 
-> [!NOTE]
-> 不要将滚轮事件与 [`scroll`](/zh-CN/docs/Web/API/Document/scroll_event) 事件混淆。滚轮事件的默认行为是取决于实现的，所以不一定会触发 `scroll` 事件。即便如此，滚轮事件的 `delta*` 值也不一定能反映文档内容的实际滚动方向。因此，请不要依赖滚轮事件的 `delta*` 值来获得滚动方向。请通过检测目标的 `scroll` 事件的 {{domxref("Element.scrollLeft", "scrollLeft")}} 和 {{domxref("Element.scrollTop", "scrollTop")}} 这两个值代替。
+不要将 `wheel` 事件与 {{domxref("Element/scroll_event", "scroll")}} 事件混淆：
+
+- `wheel` 事件不一定会触发 `scroll` 事件。例如，元素可能根本无法滚动。使用滚轮或触控板进行缩放操作时也会触发 `wheel` 事件（其中 {{domxref("MouseEvent/ctrlKey", "ctrlKey")}} 为 `true`）。
+- `scroll` 事件不一定是 `wheel` 事件触发的。元素也可以通过键盘、拖动滚动条或使用 JavaScript 来滚动。
+- 即使 `wheel` 事件确实触发了滚动，`wheel` 事件中的 `delta*` 值也不一定反映内容的滚动方向。
+
+因此，请不要依赖 `wheel` 事件的 `delta*` 属性来获得滚动方向。请改为在 `scroll` 事件中检测目标元素 {{domxref("Element.scrollLeft", "scrollLeft")}} 和 {{domxref("Element.scrollTop", "scrollTop")}} 值的变化。
+
+`wheel` 事件是可取消的。在某些浏览器中，只有序列中的第一个 `wheel` 事件是可取消的，后续事件不可取消。如果事件被取消，则不会执行滚动或缩放。这可能会导致性能问题，因为浏览器必须等待每个 `wheel` 事件处理完毕后才能实际滚动内容。可以通过在调用 {{domxref("EventTarget.addEventListener", "addEventListener()")}} 时设置 `passive: true` 来避免这种情况，这可能会使浏览器生成不可取消的 `wheel` 事件。
 
 ## 语法
 
-在 {{domxref("EventTarget.addEventListener", "addEventListener()")}} 方法中使用事件名称，或设置事件处理器属性。
+在类似 {{domxref("EventTarget.addEventListener", "addEventListener()")}} 的方法中使用事件名称，或设置事件处理器属性。
 
-```js
+```js-nolint
 addEventListener("wheel", (event) => {});
 
 onwheel = (event) => {};
@@ -24,35 +34,9 @@ onwheel = (event) => {};
 
 ## 事件类型
 
-{{domxref("WheelEvent")}}。继承自 {{domxref("Event")}}。
+一个 {{domxref("WheelEvent")}}。继承自 {{domxref("MouseEvent")}}、{{domxref("UIEvent")}} 和 {{domxref("Event")}}。
 
 {{InheritanceDiagram("WheelEvent")}}
-
-## 事件属性
-
-_此接口从父接口：{{DOMxRef("MouseEvent")}}、{{DOMxRef("UIEvent")}} 和 {{DOMxRef("Event")}} 继承属性。_
-
-- {{DOMxRef("WheelEvent.deltaX")}} {{ReadOnlyInline}}
-  - : 返回一个浮点数（`double`），表示水平方向的滚动量。
-- {{DOMxRef("WheelEvent.deltaY")}} {{ReadOnlyInline}}
-  - : 返回一个浮点数（`double`），表示垂直方向的滚动量。
-- {{DOMxRef("WheelEvent.deltaZ")}} {{ReadOnlyInline}}
-  - : 返回一个浮点数（`double`）表示 z 轴方向的滚动量。
-- {{DOMxRef("WheelEvent.deltaMode")}} {{ReadOnlyInline}}
-  - : 返回一个无符号长整型数（`unsigned long`），表示 `delta*` 值滚动量的单位。允许的值为：
-
-    | 常量                         | 值     | 描述                                                                                  |
-    | ---------------------------- | ------ | ------------------------------------------------------------------------------------- |
-    | `WheelEvent.DOM_DELTA_PIXEL` | `0x00` | `delta*` 值以像素为单位。                                                             |
-    | `WheelEvent.DOM_DELTA_LINE`  | `0x01` | `delta*` 值以行为单位。每次鼠标单击都会滚动一行内容，其中行高计算的方法取决于浏览器。 |
-    | `WheelEvent.DOM_DELTA_PAGE`  | `0x02` | `delta*` 值以页为单位。每次鼠标单击都会滚动一页内容。                                 |
-
-- {{DOMxRef("WheelEvent.wheelDelta")}} {{ReadOnlyInline}} {{deprecated_inline}}
-  - : 返回一个（32 位）整型数，表示像素距离。
-- {{DOMxRef("WheelEvent.wheelDeltaX")}} {{ReadOnlyInline}} {{deprecated_inline}}
-  - : 返回一个整型数，表示水平滚动量。
-- {{DOMxRef("WheelEvent.wheelDeltaY")}} {{ReadOnlyInline}} {{deprecated_inline}}
-  - : 返回一个整型数，表示垂直滚动量。
 
 ## 示例
 
@@ -76,12 +60,15 @@ body {
 div {
   width: 105px;
   height: 105px;
-  background: #cdf;
+  background: #ccddff;
   padding: 5px;
 }
 ```
 
 ```js
+let scale = 1;
+const el = document.querySelector("div");
+
 function zoom(event) {
   event.preventDefault();
 
@@ -94,8 +81,6 @@ function zoom(event) {
   el.style.transform = `scale(${scale})`;
 }
 
-let scale = 1;
-const el = document.querySelector("div");
 el.onwheel = zoom;
 ```
 
@@ -120,4 +105,3 @@ el.addEventListener("wheel", zoom, { passive: false });
 ## 参见
 
 - {{domxref("WheelEvent")}}
-- [Document：`wheel` 事件](/zh-CN/docs/Web/API/Element/wheel_event)

--- a/files/zh-cn/web/api/element/wheel_event/index.md
+++ b/files/zh-cn/web/api/element/wheel_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: Element：滚轮事件
+title: Element：wheel 事件
 short-title: wheel
 slug: Web/API/Element/wheel_event
 l10n:
@@ -27,9 +27,9 @@ l10n:
 在类似 {{domxref("EventTarget.addEventListener", "addEventListener()")}} 的方法中使用事件名称，或设置事件处理器属性。
 
 ```js-nolint
-addEventListener("wheel", (event) => {});
+addEventListener("wheel", (event) => { })
 
-onwheel = (event) => {};
+onwheel = (event) => { }
 ```
 
 ## 事件类型


### PR DESCRIPTION
Part of https://github.com/mdn/translated-content/issues/37729

Update the zh-CN translation of `Web/API/Element/wheel_event` to match the current English version.

## Changes

- Remove the `Event properties` section (removed upstream in [mdn/content#44423](https://github.com/mdn/content/pull/44423))
- Add `short-title: wheel` and `l10n.sourceCommit` (`ac7f589f24`) to the frontmatter
- Rewrite the intro as the upstream bulleted "wheel vs scroll" list and add the cancelable / `passive: true` paragraph
- Sync the event type inheritance, example CSS/JS, and `{{APIRef("UI Events")}}`

## Verification

- markdownlint / prettier / autocorrect / check-url-locale: all pass
- Rendered preview verified locally via the MDN content dev server