### PR TITLE
[es] Sincroniza Debugging_HTML con la fuente en inglés

### DIFF
--- a/files/es/learn_web_development/core/structuring_content/debugging_html/index.md
+++ b/files/es/learn_web_development/core/structuring_content/debugging_html/index.md
@@ -1,174 +1,234 @@
 ---
-title: Depurar el HTML
+title: Depuración de HTML
 slug: Learn_web_development/Core/Structuring_content/Debugging_HTML
-original_slug: Learn/HTML/Introduction_to_HTML/Debugging_HTML
+l10n:
+  sourceCommit: b5ee197a87ea18acbc4dd9544efa8c0e46253785
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Structuring_documents", "Learn_web_development/Core/Structuring_content/Marking_up_a_letter", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Forms_challenge", "Learn_web_development/Core/Styling_basics", "Learn_web_development/Core/Structuring_content")}}
 
-Escribir HTML es fácil, pero ¿qué pasa si algo va mal y desconocemos dónde está el error de codificación? En este artículo veremos varias herramientas que nos ayudarán a arreglar errores en HTML.
+Escribir HTML está bien, pero ¿qué pasa si algo sale mal y no puedes descubrir dónde está el error en el código? Este artículo te presentará algunas herramientas que pueden ayudarte a encontrar y corregir errores en HTML.
 
 <table>
   <tbody>
     <tr>
-      <th scope="row">Prerrequisitos:</th>
+      <th scope="row">Requisitos previos:</th>
       <td>
-        Estar familiarizado con los principios básicos de HTML, como los vistos
-        en el apartado
+        Familiaridad básica con HTML, tal como se describe en
         <a href="/es/docs/Learn_web_development/Core/Structuring_content/Basic_HTML_syntax"
-          >Empezar con el HTML</a
-        >,
-        <a href="/es/docs/Learn_web_development/Core/Structuring_content/Headings_and_paragraphs"
-          >Conocimientos básicos de aplicación de formato a textos con HTML</a
-        >
-        y
-        <a href="/es/docs/Learn_web_development/Core/Structuring_content/Creating_links"
-          >Creación de hiperenlaces</a
-        >.
+          >Sintaxis básica de HTML</a
+        >. Semántica a nivel de texto como <a href="/es/docs/Learn_web_development/Core/Structuring_content/Headings_and_paragraphs"
+          >encabezados y párrafos</a
+        > y <a href="/es/docs/Learn_web_development/Core/Structuring_content/Lists"
+          >listas</a
+        >. <a href="/es/docs/Learn_web_development/Core/Structuring_content/Structuring_documents"
+          >HTML estructural</a>.
       </td>
     </tr>
     <tr>
-      <th scope="row">Objetivo:</th>
+      <th scope="row">Resultados de aprendizaje:</th>
       <td>
-        Aprender el funcionamiento básico de las herramientas de depuración de
-        problemas de código en HTML.
+        <ul>
+          <li>El contexto clave sobre la depuración de HTML.</li>
+          <li>Usar el inspector del DOM en las herramientas de desarrollo de tu navegador para profundizar en tu código HTML.</li>
+          <li>Explorar los tipos de errores comunes en HTML.</li>
+          <li>Usar el <a href="https://validator.w3.org/">validador de HTML</a> para detectar errores en HTML.</li>
+        </ul>
       </td>
     </tr>
   </tbody>
 </table>
 
-## Depurar no debe asustarnos
+## Depurar no da miedo
 
-Cuando escribimos cualquier tipo de código, normalmente todo va bien, hasta ese fatídico momento en el que ocurre un error, hemos hecho algo mal y el código no funciona, o no funciona del todo, no lo suficientemente bien. Por ejemplo, el dibujo siguiente muestra un error de {{glossary("compile","compilación")}} de un programa sencillo escrito en lenguaje [Rust](https://www.rust-lang.org/).
+Cuando escribes código de algún tipo, todo va bien, hasta ese temido momento en el que ocurre un error: hiciste algo mal, así que tu código no funciona, ya sea que no funcione en absoluto, o no funcione exactamente como querías. Por ejemplo, a continuación se muestra un error reportado al intentar {{glossary("compile", "compilar")}} un programa simple escrito en el lenguaje [Rust](https://rust-lang.org/).
 
-![Una ventana de consola que muestra el resultado de intentar compilar un programa Rust al que le faltan comillas alrededor de una cadena en una declaración impresa. El mensaje de error informado es error: cadena de comillas dobles sin terminar.](error-message.png)En el ejemplo, el mensaje de error es fácilmente comprensible: "unterminated double quote string" (comillas sin cerrar en el texto). Si analizamos el listado de código, observamos que en `println!(Hello, world!");` faltan una comillas. Pero, los mensajes de error pueden complicarse con facilidad y su interpretación ser menos sencilla a medida que los programas aumentan en tamaño, e incluso casos sencillo pueden llegar a intimidar a alguien que no sabe nada de Rust.
+![A console window showing the result of trying to compile a rust program with a missing quote around a string in a print statement. The error message reported is error: unterminated double quote string.](error-message.png)
 
-Sin embargo, la depuración no nos debe asustar; la clave para sentirnos cómodos con la escritura y la depuración de cualquier lenguaje o código es la familiaridad, tanto con el lenguaje como con las herramientas.
+Aquí, el mensaje de error es relativamente fácil de entender: "cadena de comillas dobles sin terminar". Si observas el listado, probablemente puedas ver cómo a `println!(Hello, world!");` le podría faltar lógicamente una comilla doble. Sin embargo, los mensajes de error pueden volverse rápidamente más complicados y menos fáciles de interpretar a medida que los programas crecen, e incluso los casos simples pueden parecer un poco intimidantes para alguien que no sabe nada de Rust.
+
+Sin embargo, depurar no tiene por qué dar miedo: la clave para sentirte cómodo escribiendo y depurando cualquier código es la familiaridad tanto con el lenguaje como con las herramientas asociadas.
 
 ## HTML y depuración
 
-HTML no es tan complicado de entender como Rust; HTML no se compila por separado antes de que el navegador lo analice (se interpreta, no se compila). Y la sintaxis de los {{glossary("element","elementos")}} de HTML es mucho más sencilla de entender que la de cualquier lenguaje de programación real como Rust, {{glossary("JavaScript")}} o {{glossary("Python")}}. La forma en que los navegadores ejecutan HTML es más **permisiva** que la de los otros lenguajes, cosa que es buena y mala a la vez.
+HTML no es tan complicado de entender como Rust. HTML no se compila a una forma diferente antes de analizarse (se _interpreta_, no se _compila_). Y la sintaxis de {{glossary("element", "elemento")}} de HTML es, sin duda, mucho más fácil de entender que la de un "lenguaje de programación real" como Rust, {{glossary("JavaScript")}} o {{glossary("Python")}}.
 
-### Código permisivo
+La forma en que los navegadores analizan el HTML es mucho más **permisiva** que la manera en que se analizan la mayoría de los lenguajes de programación, lo cual es a la vez algo bueno y algo malo.
 
-¿Qué queremos decir con _permisivo_? Bien, normalmente cuando hacemos algo mal al codificar, suele haber dos tipos de error:
+Pero antes que nada, ¿qué queremos decir con permisiva? Bueno, por lo general, cuando haces algo mal en el código, hay dos tipos principales de errores con los que te puedes encontrar:
 
-- **Errores sintácticos**: Son errores de escritura en el código que impiden que el programa funcione, como el error en Rust de arriba. Suelen ser fáciles de arreglar si estamos familiarizados con las herramientas adecuadas y sabemos el significado de los mensajes de error.
-- **Errores lógicos**: En estos errores la sintaxis es correcta, pero el código no hace lo que debería, por lo que el programa funciona de forma incorrecta. Estos errores son, por lo general, más difíciles de solucionar que los sintácticos, porque no hay mensajes de error que nos avisen de ellos.
+- **Errores de sintaxis**: son erratas en tu código que hacen que el programa no se ejecute, como el error de Rust que se mostró anteriormente. Suelen ser fáciles de corregir siempre que estés familiarizado con la sintaxis del lenguaje y sepas qué significan los mensajes de error.
+- **Errores lógicos**: son errores en los que la sintaxis en realidad es correcta, pero el código no hace lo que pretendías, lo que significa que el programa se ejecuta de forma incorrecta. Suelen ser más difíciles de corregir que los errores de sintaxis, ya que no hay un mensaje de error que te dirija al origen del error.
 
-HTML en sí mismo no suele producir errores sintácticos porque los navegadores son permisivos con ellos; o sea, el código se sigue ejecutando ¡aun si hay errores! Los navegadores disponen de reglas internas para saber cómo interpretar los errores de marcado incorrecto que encuentran, y seguirán funcionando aunque no produzcan el resultado esperado. Esto puede también ser un problema, por supuesto.
+El HTML en sí no sufre de errores de sintaxis porque los navegadores lo analizan de forma permisiva, lo que significa que la página se sigue mostrando aunque haya errores de sintaxis en el código fuente. Los navegadores tienen reglas incorporadas que indican cómo interpretar el marcado HTML escrito incorrectamente (a menudo llamado marcado **inválido** o **mal formado**), cambiándolo automáticamente a un marcado válido.
+
+Por ejemplo, el siguiente fragmento de HTML contiene elementos anidados incorrectamente:
+
+```html example-bad
+<p>I didn't expect to find the <em>next-door neighbor's <strong>cat</em></strong> here!</p>
+```
+
+La etiqueta de cierre `</strong>` debería estar antes de la etiqueta de cierre `</em>`, pero no es así: está después.
+
+Si cargas este HTML en un navegador y luego observas el [DOM renderizado](/es/docs/Learn_web_development/Getting_started/Web_standards/How_browsers_load_websites#handling_html), verás que el navegador corrigió el anidamiento:
+
+```html example-good
+<p>
+  I didn't expect to find the
+  <em>next-door neighbor's <strong>cat</strong></em> here!
+</p>
+```
+
+Entonces, ¿por qué esto es a la vez bueno y malo? Bueno, en este caso el navegador creó el resultado esperado, pero como verás [más adelante](#tu_turno_estudiando_html_con_el_inspector_del_dom), esto no siempre es así. Siempre obtendrás _algo_ funcionando, pero el navegador no siempre lo interpreta correctamente, lo cual puede causar problemas. Es mejor escribir el marcado correcto desde el principio.
 
 > [!NOTE]
-> La ejecución de HTML es permisiva porque cuando se creó la web por primera vez, se decidió que el hecho de permitir que la gente publicara su contenido era más importante que el hecho de que la sintaxis fuera totalmente correcta. La web no sería tan popular como lo es hoy en día si se hubiera sido más estricto desde el primer momento.
+> El HTML se analiza de forma permisiva porque, cuando se creó la web por primera vez, se decidió que publicar contenido era más importante que garantizar que la sintaxis fuera absolutamente correcta. Probablemente la web no sería tan popular como lo es hoy si hubiera sido más estricta desde el principio.
 
-### Aprendizaje activo: Estudio del código permisivo
+Entonces, ¿cómo encuentras errores de marcado? Más adelante te mostraremos cómo encontrar errores en HTML usando una herramienta llamada el [validador de HTML](#validacion_html), pero primero te mostraremos cómo inspeccionar tu HTML manualmente usando un **inspector del DOM**, y luego exploraremos qué tipos de errores de marcado podrías buscar, y cómo el navegador podría interpretarlos.
 
-Es hora de estudiar la naturaleza permisiva del código HTML por nosotros mismos.
+## Usar el inspector del DOM
 
-1. En primer lugar, hagamos una copia de nuestro [ejemplo-demo a depurar](https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/debugging-html/debug-example.html) y guardémoslo de forma local. Está escrito para generar diversos errores que deberemos descubrir (se dice que el marcado de HTML está **mal formado**, en contraposición a un marcado **bien formado**).
-2. A continuación, abrámoslo en un navegador; veremos lo siguiente:![Un documento HTML simple con un título de ejemplos de depuración de HTML y cierta información sobre errores HTML comunes, como elementos no cerrados, elementos mal anidados y atributos no cerrados.](badly-formed-html.png)
-3. No parece que esté bien; veamos el código fuente para ver qué podemos hacer (solo mostramos el contenido del \<body>):
+Todos los navegadores modernos tienen incorporado un conjunto de [herramientas de desarrollo](/es/docs/Learn_web_development/Howto/Tools_and_setup/What_are_browser_developer_tools) (devtools), que ofrecen un conjunto de funcionalidades para examinar la página web cargada en la pestaña actual. Estas pueden mostrarte qué HTML se renderiza en la página, qué CSS se aplica a cada nodo del DOM, qué JavaScript se ejecuta en la página, y más. También te permiten editar el código en ejecución y ver el efecto en tiempo real en la página.
+
+Puedes abrir las devtools de forma similar en cada navegador; consulta [Cómo abrir las devtools en tu navegador](/es/docs/Learn_web_development/Howto/Tools_and_setup/What_are_browser_developer_tools#how_to_open_the_devtools_in_your_browser) para aprender cómo hacerlo.
+
+Para este artículo, la única función de las devtools que es relevante es el **inspector del DOM**, que muestra el DOM HTML renderizado actualmente y te permite editarlo. Veamos esto ahora:
+
+1. Abre las devtools en tu navegador.
+2. Abre el inspector del DOM. Está en el mismo lugar en cada navegador: la primera pestaña en las devtools, al inicio de la fila. En Firefox se llama _Inspector_, mientras que en Safari, Edge y Chrome se llama _Elements_. Esta debería ser la pestaña seleccionada por defecto cuando abres las devtools por primera vez, pero selecciónala si no lo es.
+3. Examina la estructura del árbol del DOM que se muestra en la pestaña, y observa cómo puedes hacer clic en las pequeñas flechas de expansión al inicio de cada nodo del DOM para expandirlos y contraerlos, y revelar sus nodos descendientes. También puedes usar las teclas de cursor arriba y abajo para moverte entre los nodos, y las teclas de cursor derecha e izquierda para expandirlos y contraerlos.
+4. También prueba a pasar el cursor sobre los nodos (o seleccionarlos con las teclas de cursor), y observa cómo el elemento sobre el que está el cursor (o el seleccionado) se resalta en el viewport.
+5. También puedes editar el DOM renderizado. No usaremos la funcionalidad de edición en este artículo, pero tómate un tiempo para investigar cómo hacerlo si tienes curiosidad.
+
+## Tu turno: estudiando HTML con el inspector del DOM
+
+En esta sección, estudiarás algo de código usando el inspector del DOM y verás cómo maneja el navegador los errores comunes de marcado.
+
+1. Primero, guarda el siguiente listado de archivo HTML como `debug-example.html`, en algún lugar de tu máquina local. Esta demostración está escrita deliberadamente con algunos errores incorporados para que los exploremos.
+
+   ```html-nolint
+   <!doctype html>
+   <html lang="en-US">
+    <head>
+      <meta charset="utf-8">
+      <title>HTML debugging examples</title>
+    </head>
+
+    <body>
+      <h1>HTML debugging examples</h1>
+      <p>What causes errors in HTML?
+      <ul>
+        <li>Unclosed elements: If an element is <strong>not closed properly,then its effect can spread to areas you didn't intend
+        <li>Badly nested elements: Nesting elements properly is also very important for code behaving correctly. <strong>strong <em>strong emphasized?</strong> what is this?</em>
+        <li>Unclosed attributes: Another common source of HTML problems. Let's look at an example: <a href="https://www.mozilla.org/>link to Mozilla homepage</a>
+      </ul>
+    </body>
+   </html>
+   ```
+
+2. A continuación, ábrelo en un navegador. Verás algo como esto: ![A simple HTML document with a title of HTML debugging examples, and some information about common HTML errors, such as unclosed elements, badly nested elements, and unclosed attributes.](badly-formed-html.png)
+3. Esto no se ve nada bien de inmediato; veamos el código fuente para tratar de entender por qué (solo se muestra el contenido del `body`):
 
    ```html
-   <h1>Ejemplos de depuración de HTML</h1>
+   <h1>HTML debugging examples</h1>
 
-   <p>¿Qué causa los errores en HTML?
+   <p>What causes errors in HTML?
 
    <ul>
-     <li>Elementos no cerrados: Si un elemento <strong>no está cerrado correctamente,
-         su efecto puede extenderse a áreas que no pretendía
+     <li>Unclosed elements: If an element is <strong>not closed properly,
+         then its effect can spread to areas you didn't intend
 
-     <li>Elementos mal anidados: anidar elementos correctamente también es muy importante
-         para que el código se comporte correctamente. <strong>negritas <em>negritas enfatizadas?</strong>
-         ¿qué es esto?</em>
+     <li>Badly nested elements: Nesting elements properly is also very important
+         for code behaving correctly. <strong>strong <em>strong emphasized?</strong>
+         what is this?</em>
 
-     <li>Atributos no cerrados: otra fuente común de problemas de HTML. Veamos
-         un ejemplo: <a href="https://www.mozilla.org/>enlace a la página
-         de inicio de Mozilla</a>
+     <li>Unclosed attributes: Another common source of HTML problems. Let's
+         look at an example: <a href="https://www.mozilla.org/>link to Mozilla
+         homepage</a>
    </ul>
    ```
 
-4. Veamos qué problemas podemos descubrir:
-   - El elemento {{htmlelement("p")}} y el {{htmlelement("li")}} no tienen etiquetas de cierre. Si comprobamos el resultado, no parece que haya generado un efecto grave en la representación del lenguaje de marcado, porque es fácil deducir que donde un elemento acaba, debería comenzar otro.
-   - El primer elemento {{htmlelement("strong")}} no tiene etiqueta de cierre. Este resulta ser un poco más problemático porque no es fácil deducir dónde se supone que termina el elemento. De hecho, el énfasis fuerte se ha aplicado al resto del texto.
-   - Esta sección está mal anidada: `<strong>negritas <em>negritas enfatizadas?</strong> ¿qué es esto?</em>`. No es fácil de explicar la forma en que ha sido interpretado, debido al problema anterior.
-   - Al valor del atributo [`href`](/es/docs/Web/HTML/Reference/Elements/a#href) le faltan las comillas de cierre. Esto parece haber causado el problema más grave: el enlace ha desaparecido totalmente.
+4. Repasemos los problemas:
+   - Los elementos {{htmlelement("p","párrafo")}} y {{htmlelement("li","elemento de lista")}} no tienen etiquetas de cierre. Mirando la imagen de arriba, esto no parece haber afectado demasiado el renderizado del marcado, ya que es fácil inferir dónde debería terminar un elemento y empezar otro.
+   - El primer elemento {{htmlelement("strong")}} no tiene etiqueta de cierre. Esto es un poco más problemático, ya que no es fácil saber dónde se supone que debe terminar el elemento. De hecho, todo el resto del texto se ha renderizado en negrita.
+   - Esta sección está mal anidada: `<strong>strong <em>strong emphasized?</strong> what is this?</em>`. No es fácil saber cómo se ha interpretado esto debido al problema anterior.
+   - Al valor del atributo [`href`](/es/docs/Web/HTML/Reference/Elements/a#href) le falta una comilla doble de cierre. Esto parece haber causado el mayor problema: el enlace no se renderizó en absoluto.
 
-5. Ahora veamos lo que el navegador ha mostrado en contraposición al código fuente. Para ello podemos usar las herramientas de desarrollo del navegador. Si no estamos familiarizados con el uso de estas herramientas, echemos un vistazo rápido a [Descubrir las herramientas de desarrollo del navegador](/es/docs/Learn_web_development/Howto/Tools_and_setup/What_are_browser_developer_tools), y luego continuaremos.
-6. En el inspector de objetos (DOM), puedes comprobar la apariencia de cada elemento: ![El inspector de HTML en Firefox, con el párrafo de nuestro ejemplo resaltado, muestra el texto "¿Qué causa los errores en HTML?" Aquí puede ver que el navegador ha cerrado el elemento de párrafo.](html-inspector.png)
-7. Vamos a explorar nuestro código en detalle con el inspector de objetos DOM para ver cómo el navegador ha arreglado nuestros errores de código HTML (lo hemos hecho con Firefox; otros navegadores modernos deberían conducir al mismo resultado):
-   - Se han añadido etiquetas de cierre a los párrafos y las líneas de las listas.
-   - Al no estar claro el final del elemento `<strong>`, el navegador lo ha aplicado individualmente a todos los bloques de texto siguientes, a cada uno le ha añadido su etiqueta `strong` propia, desde donde está ¡hasta el final del documento!
-   - El navegador ha arreglado el anidamiento incorrecto del modo siguiente:
+5. Ahora examinemos el DOM renderizado, en lugar del código fuente. Para hacer esto, abre el inspector del DOM de tu navegador. Verás una representación del marcado renderizado: ![The HTML inspector in Firefox, with our example's paragraph highlighted, showing the text "What causes errors in HTML?" Here you can see that the paragraph element has been closed by the browser.](html-inspector.png)
+6. Observa cómo el navegador intentó corregir nuestros errores de HTML (hicimos la revisión en Firefox; otros navegadores modernos _deberían_ dar el mismo resultado):
+   - A los párrafos y elementos de lista se les agregaron etiquetas de cierre.
+   - No queda claro dónde debería cerrarse el primer elemento `<strong>`, así que el navegador envolvió cada bloque de texto por separado en su propio elemento `<strong>`, ¡hasta el final del documento!
+   - El anidamiento incorrecto fue corregido por el navegador de la siguiente manera:
 
-     ```html
-     <strong
-       >negritas
-       <em>negritas enfatizadas</em>
+   ```html
+   <strong>
+     strong
+     <em>strong emphasized?</em>
+   </strong>
+   <em> what is this?</em>
+   ```
+
+   - El enlace con la comilla doble faltante fue eliminado por completo. El último elemento de la lista se ve así:
+
+   ```html
+   <li>
+     <strong>
+       Unclosed attributes: Another common source of HTML problems. Let's look
+       at an example:
      </strong>
-     <em>¿qué es esto?</em>
-     ```
+   </li>
+   ```
 
-   - El enlace a cuyo atributo le faltan las comillas del final ha sido ignorado. La última lista la ha dejado como sigue:
+## Validación HTML
 
-     ```html
-     <li>
-       <strong
-         >Atributos no cerrados: otra fuente común de problemas de HTML. Veamos
-         un ejemplo:
-       </strong>
-     </li>
-     ```
+Puedes ver por el ejemplo anterior que realmente quieres asegurarte de que tu HTML esté bien formado. Pero, ¿cómo? En un ejemplo pequeño como el que vimos arriba, es fácil revisar las líneas y encontrar los errores, pero ¿qué pasa con un documento HTML enorme y complejo?
 
-### Validación HTML
+La herramienta para esta tarea es el [Servicio de validación de marcado](https://validator.w3.org/) (o **validador de HTML**), creado y mantenido por el W3C (sobre el cual aprendiste en [El modelo de estándares web](/es/docs/Learn_web_development/Getting_started/Web_standards/The_web_standards_model)). El validador toma un documento HTML como entrada, lo revisa, y te entrega un informe que te indica qué está mal en tu HTML.
 
-Con el ejemplo anterior podemos asegurarnos de que nuestro HTML está bien formado, pero ¿cómo? En el ejemplo siguiente podemos comprobar que es bastante fácil buscar entre las líneas y encontrar los errores en documentos pequeños; pero, ¿qué pasa cuando trabajamos con documentos HTML grandes y complejos?
+![The HTML validator homepage](validator.png)
 
-La mejor estrategia es comenzar por pasar tu página HTML por el [servicio de validación de etiquetas](https://validator.w3.org/); fue creado y está mantenido por el W3C, organización que se encarga de definir las especificaciones de HTML, CSS y otras tecnologías web. Esta página web toma un documento HTML como entrada, lo procesa, y genera un informe de dónde están los errores en el documento.
+Para especificar el HTML que se va a validar, puedes proporcionar una dirección web, subir un archivo HTML, o ingresar directamente algo de código HTML.
 
-![La página de inicio del validador HTML](validator.png)
+## Validando un documento HTML
 
-Para validar el HTML, podemos proporcionar al validador una dirección web a la que apuntar, subirle un archivo HTML, o directamente introducirle el código HTML que queremos que revise.
+En esta tarea, te haremos probar el validador de HTML. Validarás nuestro [documento de ejemplo](https://github.com/mdn/learning-area/blob/main/html/introduction-to-html/debugging-html/debug-example.html) y verás qué resultados devuelve. Este ejemplo contiene el mismo HTML que estudiaste con el inspector del DOM anteriormente.
 
-### Aprendizaje activo: Validación de un documento HTML
+1. Primero, carga el [Servicio de validación de marcado](https://validator.w3.org/) en una nueva pestaña del navegador, si aún no está abierto.
+2. Cambia a la pestaña [Validar mediante entrada directa](https://validator.w3.org/#validate_by_input).
+3. Copia todo el código del documento de ejemplo (no solo el `body`) y pégalo en el área de texto grande que se muestra en el Servicio de validación de marcado.
+4. Presiona el botón _Check_.
 
-Vamos a probar de validar nuestro [documento ejemplo](https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/debugging-html/debug-example.html).
+Esto debería darte una lista de errores y otra información.
 
-1. Primero, cargamos el [servicio de validación](https://validator.w3.org/) en una pestaña del navegador, si no lo tenemos ya.
-2. Hacemos clic en la subpestaña [Validate by Direct Input](https://validator.w3.org/#validate_by_input).
-3. Copiamos el código del documento ejemplo (no solo el `body`) y lo pegamos en el cuadro de texto grande.
-4. Hacemos clic en el botón _Check_.
+![A list of HTML validation results from the W3C markup validation service](validation-results.png)
 
-Esto debería proporcionar una lista de errores y otras informaciones:
+### Interpretando los mensajes de error
 
-![Una lista de resultados de validación HTML del servicio de validación de marcado W3C](validation-results.png)
+Los mensajes de error suelen ser útiles, pero a veces no son tan fáciles de entender. Con un poco de práctica, puedes aprender a interpretarlos para corregir tu código. Repasemos los mensajes de error y veamos qué significan. Verás que cada mensaje viene con un número de línea y columna para ayudarte a ubicar el error fácilmente.
 
-#### Interpretación de los mensajes de error
+- "Etiqueta de cierre `li` implícita, pero había elementos abiertos" (2 casos): estos mensajes indican que hay un elemento abierto que debería cerrarse. La etiqueta de cierre está implícita, pero en realidad no está presente. La información de línea/columna apunta a la primera línea después de donde realmente debería estar la etiqueta de cierre, pero esta es una pista suficientemente buena para ver qué está mal.
+- "Elemento `strong` sin cerrar": esto es más fácil de entender: un elemento {{htmlelement("strong")}} no está cerrado, y la información de línea/columna apunta exactamente a dónde está.
+- "La etiqueta de cierre `strong` viola las reglas de anidamiento": esto señala los elementos mal anidados, y la información de línea/columna indica dónde están.
+- "Se alcanzó el final del archivo dentro del valor de un atributo. Ignorando la etiqueta": este es bastante críptico; se refiere a que hay un valor de atributo mal formado en algún lugar, posiblemente cerca del final del archivo, ya que el final del archivo aparece dentro del valor del atributo. El hecho de que el navegador no renderice el enlace debería darnos una buena pista sobre qué elemento tiene el problema.
+- "Se alcanzó el final del archivo y había elementos abiertos": esto es un poco ambiguo, pero básicamente se refiere a que hay elementos abiertos que necesitan cerrarse correctamente. Los números de línea apuntan a las últimas líneas del archivo, y este mensaje de error viene con una línea de código que señala un ejemplo de un elemento abierto:
 
-La lista de mensajes de error que nos presenta el validador suele ayudar, pero a veces, no resultan muy útiles; con un poco de práctica aprenderemos a interpretar la lista para arreglar nuestro código. Veamos los mensajes de error y su significado. Observamos que cada mensaje se presenta con un número de línea y de columna, para ayudar a localizar el error más fácilmente.
+```plain
+  example: <a href="https://www.mozilla.org/>link to Mozilla homepage</a> ↩ </ul>↩ </body>↩</html>
+```
 
-- "Consider adding a `lang` attribute to the `html` start tag to declare the language of this document.": No se trata de un error, sino de una advertencia (warning). La [recomendación](https://www.w3.org/International/questions/qa-html-language-declarations) es definir siempre un idioma, y este "warning" explica cómo hacerlo..
-- "End tag `li` implied, but there were open elements" (2 instancias): Estos mensajes indican que un elemento que ha sido abierto debe ser cerrado. La etiqueta de cierre se supone, pero no está ahí. La información de la línea/columna apunta a la primera línea después de donde debería estar la etiqueta de cierre; es una buena pista para ver qué pasa.
-- "Unclosed element `strong`": Un elemento {{htmlelement("strong")}} no ha sido cerrado, y la línea/columna apunta directamente al lugar del error.
-- "End tag `strong` violates nesting rules": Este apunta a elementos que están incorrectamente anidados, y la línea/columna nos indica donde están.
-- "End of file reached when inside an attribute value. Ignoring tag": Esta es bastante enigmática; se refiere al hecho de que el valor de un atributo no ha sido bien construido, posiblemente cerca del final del archivo porque el final aparece dentro del valor del atributo. El hecho de que el navegador no muestre el enlace nos debería dar una buena pista de qué elemento es el erróneo.
-- "End of file seen and there were open elements": Este es un poco ambiguo, pero básicamente se refiere al hecho de que hay elementos abiertos que necesitan ser cerrados adecuadamente. Los números de línea apuntan a las últimas líneas del archivo, y este mensaje de error viene con una línea de código que indica un ejemplo de un elemento abierto:
+> [!NOTE]
+> A un atributo al que le falta una comilla de cierre puede provocar un elemento abierto, porque el resto del documento se interpreta como el contenido del atributo.
 
-  ejemplo: `<a href="https://www.mozilla.org/>enlace a la página de inicio de Mozilla</a> ↩ </ul>↩ </body>↩</html>`
+- "Elemento `ul` sin cerrar": esto no es muy útil, ya que el elemento {{htmlelement("ul")}} _sí_ está cerrado correctamente. Este error ocurre porque el elemento {{htmlelement("a")}} no está cerrado, debido a que falta la comilla de cierre.
 
-  > [!NOTE]
-  > Un atributo al que le falten las comillas de cierre puede ser un elemento abierto, porque el resto del documento será interpretado como si fuera parte de este atributo.
+Si no logras entender qué significa cada mensaje de error, no te preocupes. Una buena estrategia es corregir unos pocos errores a la vez, y luego volver a validar tu HTML después de cada tanda de correcciones para ver qué errores quedan. A veces, corregir un error anterior también elimina otros mensajes de error, ya que un solo problema suele causar varios errores, en un efecto dominó.
 
-- Unclosed element `ul`: Este no ayuda mucho, porque el elemento {{htmlelement("ul")}} está cerrado correctamente. Este error se debe a que el elemento {{htmlelement("a")}} no ha sido cerrado, ya que faltan las comillas de cierre.
-
-No debemos preocuparnos si no podemos corregir todos los mensajes de error; es práctico tratar de arreglar unos pocos errores cada vez y volver a pasar el validador para ver los que quedan. A veces, al arreglar unos cuantos se arreglan automáticamente otros muchos; con frecuencia muchos errores los causa uno solo en un efecto dominó.
-
-Sabremos que todos los errores están arreglados cuando veamos el mensaje siguiente:
-
-![Banner que dice "El documento se valida de acuerdo con los esquemas especificados y con restricciones adicionales verificadas por el validador".](valid-html-banner.png)
+Sabrás que todos tus errores están corregidos cuando veas un pequeño y agradable banner verde que te indique que no hay errores que reportar. Al momento de escribir esto, decía "Verificación del documento completada. No hay errores ni advertencias que mostrar."
 
 ## Resumen
 
-Pues hasta aquí una introducción al depurado de HTML, que nos proporcionará habilidades para cuando comencemos a depurar CSS, JavaScript y otros lenguajes más adelante en nuestros trabajos. Este apartado también constituye el final de la introducción al módulo de artículos de aprendizaje de HTML; ahora podemos hacer los test de prueba: el primero de los cuales está en el enlace siguiente.
+Y así llegamos al final, una introducción a la depuración de HTML, que debería darte algunas habilidades útiles para tener en cuenta al depurar HTML, pero también CSS y JavaScript más adelante en el curso. Esto también marca el final del módulo _Estructurando contenido con HTML_.
 
-{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Structuring_documents", "Learn_web_development/Core/Structuring_content/Marking_up_a_letter", "conflicting/Learn_web_development/Core/Structuring_content")}}
+Tu siguiente paso es empezar a aprender sobre el estilo en la web en nuestro módulo de [Fundamentos de estilos CSS](/es/docs/Learn_web_development/Core/Styling_basics).
+
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Forms_challenge", "Learn_web_development/Core/Styling_basics", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/debugging_html/index.md
+++ b/files/es/learn_web_development/core/structuring_content/debugging_html/index.md
@@ -2,7 +2,7 @@
 title: Depuración de HTML
 slug: Learn_web_development/Core/Structuring_content/Debugging_HTML
 l10n:
-  sourceCommit: b5ee197a87ea18acbc4dd9544efa8c0e46253785
+  sourceCommit: 2066cc916dfdcbb782340bf0ce562b230e947cba
 ---
 
 {{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Forms_challenge", "Learn_web_development/Core/Styling_basics", "Learn_web_development/Core/Structuring_content")}}
@@ -84,7 +84,7 @@ Entonces, ¿por qué esto es a la vez bueno y malo? Bueno, en este caso el naveg
 > [!NOTE]
 > El HTML se analiza de forma permisiva porque, cuando se creó la web por primera vez, se decidió que publicar contenido era más importante que garantizar que la sintaxis fuera absolutamente correcta. Probablemente la web no sería tan popular como lo es hoy si hubiera sido más estricta desde el principio.
 
-Entonces, ¿cómo encuentras errores de marcado? Más adelante te mostraremos cómo encontrar errores en HTML usando una herramienta llamada el [validador de HTML](#validacion_html), pero primero te mostraremos cómo inspeccionar tu HTML manualmente usando un **inspector del DOM**, y luego exploraremos qué tipos de errores de marcado podrías buscar, y cómo el navegador podría interpretarlos.
+Entonces, ¿cómo encuentras errores de marcado? Más adelante te mostraremos cómo encontrar errores en HTML usando una herramienta llamada el [validador de HTML](#validación_html), pero primero te mostraremos cómo inspeccionar tu HTML manualmente usando un **inspector del DOM**, y luego exploraremos qué tipos de errores de marcado podrías buscar, y cómo el navegador podría interpretarlos.
 
 ## Usar el inspector del DOM
 
@@ -109,20 +109,20 @@ En esta sección, estudiarás algo de código usando el inspector del DOM y ver�
    ```html-nolint
    <!doctype html>
    <html lang="en-US">
-    <head>
-      <meta charset="utf-8">
-      <title>HTML debugging examples</title>
-    </head>
+     <head>
+       <meta charset="utf-8">
+       <title>HTML debugging examples</title>
+     </head>
 
-    <body>
-      <h1>HTML debugging examples</h1>
-      <p>What causes errors in HTML?
-      <ul>
-        <li>Unclosed elements: If an element is <strong>not closed properly,then its effect can spread to areas you didn't intend
-        <li>Badly nested elements: Nesting elements properly is also very important for code behaving correctly. <strong>strong <em>strong emphasized?</strong> what is this?</em>
-        <li>Unclosed attributes: Another common source of HTML problems. Let's look at an example: <a href="https://www.mozilla.org/>link to Mozilla homepage</a>
-      </ul>
-    </body>
+     <body>
+       <h1>HTML debugging examples</h1>
+       <p>What causes errors in HTML?
+       <ul>
+         <li>Unclosed elements: If an element is <strong>not closed properly,then its effect can spread to areas you didn't intend
+         <li>Badly nested elements: Nesting elements properly is also very important for code behaving correctly. <strong>strong <em>strong emphasized?</strong> what is this?</em>
+         <li>Unclosed attributes: Another common source of HTML problems. Let's look at an example: <a href="https://www.mozilla.org/>link to Mozilla homepage</a>
+       </ul>
+     </body>
    </html>
    ```
 
@@ -160,24 +160,24 @@ En esta sección, estudiarás algo de código usando el inspector del DOM y ver�
    - No queda claro dónde debería cerrarse el primer elemento `<strong>`, así que el navegador envolvió cada bloque de texto por separado en su propio elemento `<strong>`, ¡hasta el final del documento!
    - El anidamiento incorrecto fue corregido por el navegador de la siguiente manera:
 
-   ```html
-   <strong>
-     strong
-     <em>strong emphasized?</em>
-   </strong>
-   <em> what is this?</em>
-   ```
+     ```html
+     <strong>
+       strong
+       <em>strong emphasized?</em>
+     </strong>
+     <em> what is this?</em>
+     ```
 
    - El enlace con la comilla doble faltante fue eliminado por completo. El último elemento de la lista se ve así:
 
-   ```html
-   <li>
-     <strong>
-       Unclosed attributes: Another common source of HTML problems. Let's look
-       at an example:
-     </strong>
-   </li>
-   ```
+     ```html
+     <li>
+       <strong>
+         Unclosed attributes: Another common source of HTML problems. Let's look
+         at an example:
+       </strong>
+     </li>
+     ```
 
 ## Validación HTML
 
@@ -191,11 +191,11 @@ Para especificar el HTML que se va a validar, puedes proporcionar una dirección
 
 ## Validando un documento HTML
 
-En esta tarea, te haremos probar el validador de HTML. Validarás nuestro [documento de ejemplo](https://github.com/mdn/learning-area/blob/main/html/introduction-to-html/debugging-html/debug-example.html) y verás qué resultados devuelve. Este ejemplo contiene el mismo HTML que estudiaste con el inspector del DOM anteriormente.
+En esta tarea, te haremos probar el validador de HTML. Validarás el mismo HTML que estudiaste con el inspector del DOM anteriormente.
 
 1. Primero, carga el [Servicio de validación de marcado](https://validator.w3.org/) en una nueva pestaña del navegador, si aún no está abierto.
 2. Cambia a la pestaña [Validar mediante entrada directa](https://validator.w3.org/#validate_by_input).
-3. Copia todo el código del documento de ejemplo (no solo el `body`) y pégalo en el área de texto grande que se muestra en el Servicio de validación de marcado.
+3. Copia el [documento de ejemplo](#tu_turno_estudiando_html_con_el_inspector_del_dom) y pégalo en el área de texto grande que se muestra en el Servicio de validación de marcado. Pega la estructura completa del documento, no solo el contenido del `<body>`.
 4. Presiona el botón _Check_.
 
 Esto debería darte una lista de errores y otra información.
@@ -212,12 +212,12 @@ Los mensajes de error suelen ser útiles, pero a veces no son tan fáciles de en
 - "Se alcanzó el final del archivo dentro del valor de un atributo. Ignorando la etiqueta": este es bastante críptico; se refiere a que hay un valor de atributo mal formado en algún lugar, posiblemente cerca del final del archivo, ya que el final del archivo aparece dentro del valor del atributo. El hecho de que el navegador no renderice el enlace debería darnos una buena pista sobre qué elemento tiene el problema.
 - "Se alcanzó el final del archivo y había elementos abiertos": esto es un poco ambiguo, pero básicamente se refiere a que hay elementos abiertos que necesitan cerrarse correctamente. Los números de línea apuntan a las últimas líneas del archivo, y este mensaje de error viene con una línea de código que señala un ejemplo de un elemento abierto:
 
-```plain
+  ```plain
   example: <a href="https://www.mozilla.org/>link to Mozilla homepage</a> ↩ </ul>↩ </body>↩</html>
-```
+  ```
 
-> [!NOTE]
-> A un atributo al que le falta una comilla de cierre puede provocar un elemento abierto, porque el resto del documento se interpreta como el contenido del atributo.
+  > [!NOTE]
+  > A un atributo al que le falta una comilla de cierre puede provocar un elemento abierto, porque el resto del documento se interpreta como el contenido del atributo.
 
 - "Elemento `ul` sin cerrar": esto no es muy útil, ya que el elemento {{htmlelement("ul")}} _sí_ está cerrado correctamente. Este error ocurre porque el elemento {{htmlelement("a")}} no está cerrado, debido a que falta la comilla de cierre.
 


### PR DESCRIPTION
### Description
Sincroniza la página "Depuración de HTML" (Debugging_HTML) con la última versión en inglés. La traducción anterior nunca se había registrado para sincronización y estaba desactualizada: faltaba una sección completa, el front-matter tenía `original_slug` de más, y varios enlaces internos seguían apuntando a `/en-US/`.

### Motivation
Esta página lleva años sin actualizarse y forma parte del esfuerzo de sincronización rastreado en el issue padre #9638. Actualizarla ayuda a los lectores de habla hispana a tener contenido completo y al día en vez de una mezcla de español antiguo e inglés sin traducir.

### Additional details
- Front-matter reducido a solo `title`, `slug` y `l10n.sourceCommit`, apuntando al SHA `b5ee197a87ea18acbc4dd9544efa8c0e46253785`.
- Estructura, encabezados y orden de secciones alineados con la fuente en inglés (incluida la sección que faltaba).
- Enlaces internos actualizados de `/en-US/` a `/es/`.
- Los mensajes de error del validador HTML se tradujeron completos al español, sin dejar el texto original entre paréntesis.
- El bloque de código de ejemplo (`debug-example.html`) se dejó intencionalmente en inglés, ya que contiene errores de sintaxis deliberados que el lector debe identificar, y traducirlo podría alterar accidentalmente la posición de esos errores.
- No estoy 100% seguro de dos anclas dentro del mismo documento (`#tu_turno_estudiando_html_con_el_inspector_del_dom` y `#validacion_html`) ni de un ancla hacia otra página (`#handling_html` en How_browsers_load_websites). Las verifiqué lo mejor que pude, pero agradecería que el revisor las confirme o me indique si hace falta ajustarlas.

### AI disclosure
Utilicé un asistente de IA (Claude) como apoyo durante la traducción de este documento, principalmente para generar un primer borrador de cada sección según las convenciones descritas en la guía de estilo del equipo (docs/es/README.md). Revisé, ajusté y verifiqué manualmente todo el contenido, incluyendo la terminología técnica, los macros de Kumascript, los enlaces internos y la decisión de mantener el bloque de código de ejemplo sin traducir.

### Related issues and pull requests
Fixes #37244
Relates to #9638