### PR TITLE
beforeinput event の title を 'HTMLElement' から 'Element' に変更

### DIFF
--- a/files/ja/web/api/element/beforeinput_event/index.md
+++ b/files/ja/web/api/element/beforeinput_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTMLElement: beforeinput イベント"
+title: "Element: beforeinput イベント"
 short-title: beforeinput
 slug: Web/API/Element/beforeinput_event
 l10n:


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

英語版との違いが発生していたのを修正しました。本来はHTMLElementではなくElementだと思います。
