### PR TITLE
zh-cn: correct `tabindex` default value description

### DIFF
--- a/files/zh-cn/web/html/reference/global_attributes/tabindex/index.md
+++ b/files/zh-cn/web/html/reference/global_attributes/tabindex/index.md
@@ -48,7 +48,7 @@ div:focus {
 如果我们在 {{htmlelement("div")}} 上设置了 `tabindex` 属性，它的子元素内容不能使用箭头键来滚动，除非我们在内容上也设置 `tabindex`。[查看这篇 fiddle 来理解 tabindex 的滚动影响](https://jsfiddle.net/jainakshay/0b2q4Lgv/)。
 
 > [!NOTE]
-> tabindex 的最大值不应超过 32767。如果没有指定，它的默认值为 0。
+> tabindex 的最大值不应超过 32767。如果没有指定，一些可聚焦的 HTML 元素的默认值为 0。
 
 ## 规范
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Refer to https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:~:text=Return%200%20if%20this%20is%20an%20a%2C%20area%2C%20button%2C%20frame%2C%20iframe%2C%20input%2C%20object%2C%20select%2C%20textarea%2C%20or%20SVG%20a%20element%2C%20or%20MathML%20a%20element%2C%20or%20is%20a%20summary%20element%20that%20is%20a%20summary%20for%20its%20parent%20details%3B%20otherwise%20%E2%88%921.

The current description may lead readers to believe that the default `tabindex` value is `0` for all elements. In fact, only certain focusable elements have a default value of `0`.