### PR TITLE
[ja] Glossary/Snap_positions の翻訳

### DIFF
--- a/files/ja/glossary/snap_positions/index.md
+++ b/files/ja/glossary/snap_positions/index.md
@@ -1,0 +1,16 @@
+---
+title: Snap positions (スナップ位置)
+slug: Glossary/Snap_positions
+l10n:
+  sourceCommit: 84673e170bd930bb92a0a271855e3d68b605e000
+---
+
+{{GlossarySidebar}}
+
+**スナップ位置**とは、スクロール操作が完了した後に{{Glossary("scroll container", "スクロールポート")}}の移動が停止する位置のことです。スナップ位置を設定すると、コンテンツを表示領域内までドラッグしなくても、ページをめくるようなスクロール操作を実現できます。
+
+スナップ位置は{{Glossary("scroll container", "スクロールコンテナー")}}に設定します。[CSS スクロールスナップ](/ja/docs/Web/CSS/Guides/Scroll_snap)のプロパティを参照してください。
+
+## 関連情報
+
+- {{glossary("Scroll snap", "スクロールスナップ")}}


### PR DESCRIPTION
### 概要

`Glossary/Snap_positions` を日本語に翻訳しました。

### 関連情報

- 原文: https://developer.mozilla.org/en-US/docs/Glossary/Snap_positions
- 翻訳先: https://developer.mozilla.org/ja/docs/Glossary/Snap_positions