### PR TITLE
[ja] Glossary/Fragmentainer の翻訳

### DIFF
--- a/files/ja/glossary/fragmentainer/index.md
+++ b/files/ja/glossary/fragmentainer/index.md
@@ -1,0 +1,18 @@
+---
+title: Fragmentainer (断片化コンテナー)
+slug: Glossary/Fragmentainer
+l10n:
+  sourceCommit: 84673e170bd930bb92a0a271855e3d68b605e000
+---
+
+{{GlossarySidebar}}
+
+**断片化コンテナー** (fragmentainer) は、[CSS 断片化](https://drafts.csswg.org/css-break/) 仕様で次のように定義されています。
+
+> ページボックス、段ボックス、領域など、断片化されたフローの一部 (またはすべて) を格納するボックスです。断片化コンテナーは事前に定義することも、必要に応じて生成することもできます。分割可能なコンテンツがブロック軸方向で断片化コンテナーからはみ出すことになる場合、そのコンテンツははみ出さず、断片化コンテキスト内の次のコンテナーへ分割されます。
+
+断片化コンテキストは [CSS ページメディア](/ja/docs/Web/CSS/Guides/Paged_media) で見られ、ここでは断片化コンテナーがページを定義するボックスになります。[CSS 段組みレイアウト](/ja/docs/Web/CSS/Guides/Multicol_layout) では、段組みコンテナーに段が定義されたときに作成される段ボックスが断片化コンテナーになります。
+
+## 関連情報
+
+- [CSS 断片化](/ja/docs/Web/CSS/Guides/Fragmentation) モジュール


### PR DESCRIPTION
### 概要

`Glossary/Fragmentainer` を日本語に翻訳しました。

### 関連情報

- 原文: https://developer.mozilla.org/en-US/docs/Glossary/Fragmentainer
- 翻訳先: https://developer.mozilla.org/ja/docs/Glossary/Fragmentainer