### PR TITLE
[ja] link Hello world to Japanese Wikipedia

### DIFF
--- a/files/ja/learn_web_development/getting_started/your_first_website/adding_interactivity/index.md
+++ b/files/ja/learn_web_development/getting_started/your_first_website/adding_interactivity/index.md
@@ -88,7 +88,7 @@ listItems.forEach((item) => {
 
 ## "Hello world!" の手順を追って説明
 
-JavaScript で記述を始めるにあたって、サンプルウェブサイトに _Hello world!_ の例を追加する手順を順を追って追ってみましょう。（[_Hello world!_](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program) は、プログラミング入門の標準例です。）
+JavaScript で記述を始めるにあたって、サンプルウェブサイトに _Hello world!_ の例を追加する手順を順を追って追ってみましょう。（[_Hello world!_](https://ja.wikipedia.org/wiki/Hello_world) は、プログラミング入門の標準例です。）
 
 > [!WARNING]
 > これまでこのコースに沿って進めてきていない場合は、[このサンプルコードをダウンロードして](https://codeload.github.com/mdn/beginner-html-site-styled/zip/refs/heads/main)作業を進めてください。


### PR DESCRIPTION
### Description

日本語訳内の Hello world に対する Wikipedia リンクを、日本語版の記事へ変更しました。

### Motivation

日本語の読者が、英語版 Wikipedia を経由せずに関連情報を参照できるようにするためです。

### Additional details

ありません。

### Related issues and pull requests

ありません。