### PR TITLE
feat(ja): add translation for Web/Security/Attacks/Supply_chain_attacks

### DIFF
--- a/files/ja/web/security/attacks/supply_chain_attacks/index.md
+++ b/files/ja/web/security/attacks/supply_chain_attacks/index.md
@@ -1,0 +1,79 @@
+---
+title: サプライチェーン攻撃
+slug: Web/Security/Attacks/Supply_chain_attacks
+l10n:
+  sourceCommit: afcdfa050626bb7eb05ee693df8997020db9ff2e
+---
+
+_ソフトウェアサプライチェーン_ とは、ソフトウェア製品の作成と保守に使用されるすべてのソフトウェアとツールのことです。これには、製品そのもののために開発されたソフトウェアだけでなく、その製造過程で使用されるすべてのソフトウェアとツールが含まれます。
+
+サプライチェーン攻撃では、攻撃者は製品そのものを侵害するために、その製品のサプライチェーンの一部を標的とします。
+
+もっとも分かりやすい例は、サードパーティーのライブラリーです。例えば、サードパーティーが開発した [npm](https://www.npmjs.com/) パッケージを使用している場合、そのパッケージはあなたのサイトを侵害することができます。それが悪意のあるものであれば意図的に、それ自体に意図しない脆弱性が含まれていれば偶発的に、侵害が起こる可能性があります。要するに、サードパーティーの依存関係は、自分自身のコードと同じくらい信頼できるものでなければなりません。
+
+これはあまり意識されませんが、同じ原理は、ソフトウェアの作成に使用するすべてのツールにも当てはまります。コードエディター、エディターのプラグイン、バージョン管理システム、ビルドツールなどが該当します。これらのツールはいずれも、変換処理を適用する過程で、最終的なソフトウェア製品に悪意のあるコードや脆弱性のあるコードを挿入する可能性があります。
+
+この文書では、ソフトウェアサプライチェーンを保護するために従うべき慣行の概要を説明します。内容は主に 2 つの節に分かれています。
+
+- [開発環境の保護](#開発環境の保護): 自分自身のコードが侵害されないようにするための慣行です。
+- [サードパーティーの依存関係の管理](#サードパーティーの依存関係の管理): 依存関係が侵害されないようにするための慣行です。
+
+## 開発環境の保護
+
+サプライチェーン攻撃の経路の 1 つは、攻撃者が自分自身の製品に脆弱性や悪意のあるコードを直接混入させることです。一般的に、攻撃者はプロジェクトのメンテナーのアカウントを侵害するか、メンテナーが使用している開発者向けツールの弱点を悪用することで、これを行います。
+
+[運用上のセキュリティ](/ja/docs/Web/Security/Defenses/Operational_security#securing_your_development_environment)のガイドでは、これらの脅威に対抗するための慣行を説明しています。以下のものが含まれます。
+
+- [プロジェクトのメンテナーに強力な認証を要求する](/ja/docs/Web/Security/Defenses/Operational_security#requiring_strong_authentication_for_project_maintainers)
+- [プロジェクトのメンテナーにロールベースのアクセス制御を実装する](/ja/docs/Web/Security/Defenses/Operational_security#implementing_role-based_access_control_for_project_maintainers)
+- [使用するツールを評価する](/ja/docs/Web/Security/Defenses/Operational_security#evaluating_the_tools_you_use)
+- [設定を保護する](/ja/docs/Web/Security/Defenses/Operational_security#securing_your_configuration)
+
+## サードパーティーの依存関係の管理
+
+サードパーティーの依存関係には、コードが使用するライブラリーやフレームワークだけでなく、開発工程に関わるすべてのサードパーティー製ツールが含まれます。エディター、IDE、ソース管理システム、パッケージマネージャー、ビルドツールなどが該当します。
+
+攻撃者は、これらの依存関係の弱点を悪用してプロジェクトを侵害することができます。[運用上のセキュリティ](/ja/docs/Web/Security/Defenses/Operational_security#managing_third-party_dependencies)のガイドでは、これらの脅威に対抗するための慣行を説明しています。以下のものが含まれます。
+
+- [新しい依存関係を評価する](/ja/docs/Web/Security/Defenses/Operational_security#evaluating_new_dependencies)
+- [既存の依存関係を更新する](/ja/docs/Web/Security/Defenses/Operational_security#updating_dependencies)
+- [_ソフトウェア部品表_ (SBOM) を維持する](/ja/docs/Web/Security/Defenses/Operational_security#maintaining_a_software_bill_of_materials)
+
+さらに、サードパーティーのサイトによってホストされているスクリプトやスタイルシートについては、[サブリソース完全性を使用する](#サブリソース完全性の使用)べきです。
+
+### サブリソース完全性の使用
+
+多くのウェブサイトは、外部でホストされているスクリプトを取り込んでいます。もっとも代表的なのは {{glossary("CDN", "コンテンツ配信ネットワーク (CDN)")}} から配信されるスクリプトですが、それに限りません。
+
+```html
+<script src="https://cdn.example.org/library.js"></script>
+```
+
+これはサプライチェーンにとってのリスクとなります。攻撃者が `cdn.example.org` ドメインを掌握できた場合、攻撃者はそのスクリプトを悪意のあるスクリプトに置き換えることができ、それによってサイトを侵害できるからです。
+
+外部のスクリプトは、他のソフトウェアの依存関係と同様に SBOM に含めるべきですが、さらなる防御策として、スクリプトの [`integrity`](/ja/docs/Web/HTML/Reference/Elements/script#integrity) 属性を設定する方法があります。
+
+```html
+<script
+  src="https://cdn.example.org/library.js"
+  integrity="sha256-d5f450f7ce715d827de27ca569e183f819d33c1e7601875fd61eccbc98f56c5b"></script>
+```
+
+この属性の値には、スクリプトの内容の{{glossary("hash_function", "暗号学的ハッシュ")}}が含まれます。スクリプトが攻撃者によって改変されていた場合、ブラウザーはそのスクリプトの読み込みを拒否するため、保護されることになります。
+
+ただし、これは保守の手間を増やすことになります。配信元が変更されるたびに（例えば、新しいバージョンがリリースされるたびに）、コード内の属性値を更新する必要があります。
+
+{{htmlelement("link")}} 要素も `integrity` 属性に対応しているため、スクリプトだけでなく CSS のスタイルシートにも使用することができます（そして使用するべきです）。
+
+詳細は[サブリソース完全性](/ja/docs/Web/Security/Defenses/Subresource_Integrity)を参照してください。
+
+## 防御のまとめチェックリスト
+
+- 運用上のセキュリティの慣行に従い、以下を行う。
+  - [自分自身の開発環境を保護する](/ja/docs/Web/Security/Defenses/Operational_security#securing_your_development_environment)。
+  - [サードパーティーの依存関係のリスクを抑える](/ja/docs/Web/Security/Defenses/Operational_security#managing_third-party_dependencies)。
+- 外部から参照するスクリプトやスタイルシートには[サブリソース完全性](#サブリソース完全性の使用)を使用する。
+
+## 関連情報
+
+- [owasp.org](https://owasp.org/) の [Software Supply Chain Security](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)


### PR DESCRIPTION
### 概要

`Web/Security/Attacks/Supply_chain_attacks` を新規に日本語訳しました。

このページは、翻訳済みの [`<script>` 要素のリファレンス](https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Elements/script)（`integrity` 属性の説明）から「サプライチェーン攻撃」という表記でリンクされていますが、これまで日本語版が存在しなかったため、リンク先が未翻訳の状態になっていました。タイトルは、そのリンクで既に使われている表記に合わせています。

### 翻訳方針

- 用語は既存の日本語版セキュリティページ（[攻撃](https://developer.mozilla.org/ja/docs/Web/Security/Attacks)、[IDOR](https://developer.mozilla.org/ja/docs/Web/Security/Attacks/IDOR)、[XSS](https://developer.mozilla.org/ja/docs/Web/Security/Attacks/XSS)）に合わせました（ブラウザー、サードパーティー、脆弱性 など）。
- ページ内アンカーは、既存の日本語版ページの慣習にならって日本語の見出しに合わせています。
- `Web/Security/Defenses/Operational_security` は日本語版が未作成のため、そのページへのリンクのアンカーのみ英語の ID を維持しています（日本語のアンカーでは解決できないため）。同ページが翻訳された際に追随が必要です。
- コードブロック、マクロ（`glossary` / `htmlelement`）、`integrity` 属性の値は原文のままにしています。

### 確認したこと

- 英語版原文（`afcdfa050626bb7eb05ee693df8997020db9ff2e`）と、見出し数・箇条書き数・コードブロック・マクロの種類と順序が一致することを確認しました。
- リンク先ページの存在を確認しました（`Subresource_Integrity` の日本語版、`script#integrity` のアンカー）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
