### PR TITLE
fix(ja): Fix typo in Subtraction assignment page: changed `*=` to `-=`

### DIFF
--- a/files/ja/web/javascript/reference/operators/subtraction_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/subtraction_assignment/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: fad67be4431d8e6c2a89ac880735233aa76c41d4
 ---
 
-**減算代入演算子 (`*=`)** は、2 つのオペランドで[減算](/ja/docs/Web/JavaScript/Reference/Operators/Subtraction)を行い、結果を左オペランドに代入します。
+**減算代入演算子 (`-=`)** は、2 つのオペランドで[減算](/ja/docs/Web/JavaScript/Reference/Operators/Subtraction)を行い、結果を左オペランドに代入します。
 
 {{InteractiveExample("JavaScript デモ: 減算代入演算子 (-=)")}}
 


### PR DESCRIPTION
### Description

冒頭の「減算代入演算子 (`*=`)」を「減算代入演算子 (`-=`)」に修正しました。

### Motivation

### Additional details

以下のコミットを見る限り、コピーペーストの修正ミスが原因だと思われます。

https://github.com/mdn/translated-content/commit/86691c8931e417a962f1a6a6708c203af0e5f25a

### Related issues and pull requests
