### PR TITLE
Fix `ListSubpages` macro paths in es and pt-BR

### DIFF
--- a/files/es/web/accessibility/aria/guides/techniques/index.md
+++ b/files/es/web/accessibility/aria/guides/techniques/index.md
@@ -17,12 +17,12 @@ l10n:
     <li><a href="/es/docs/Web/Accessibility/ARIA/How_to_file_ARIA-related_bugs">Cómo registrar errores relacionados con ARIA</a></li>
     <li class="toggle">
       <details><summary>Estados y propiedades de ARIA</summary>
-        {{ListSubpagesForSidebar("Web/Accessibility/ARIA/Attributes", 1)}}
+        {{ListSubpagesForSidebar("/es/docs/Web/Accessibility/ARIA/Attributes", 1)}}
       </details>
     </li>
     <li class="toggle">
       <details><summary>Roles WAI-ARIA</summary>
-        {{ListSubpagesForSidebar("Web/Accessibility/ARIA/Roles", 1)}}
+        {{ListSubpagesForSidebar("/es/docs/Web/Accessibility/ARIA/Roles", 1)}}
       </details>
     </li>
   </ol>

--- a/files/pt-br/mozilla/add-ons/webextensions/index.md
+++ b/files/pt-br/mozilla/add-ons/webextensions/index.md
@@ -101,4 +101,4 @@ Se você tem dúvidas ou sugestões, ou precisa de ajuda para migrar um compleme
 - [Visão geral do manifest.json](/docs/Mozilla/Add-ons/WebExtensions/manifest.json)
 - [Compatibilidade de navegadores com manifest.json](/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json)
 
-{{ ListSubpages ("/Add-ons/WebExtensions/manifest.json") }}{{AddonSidebar}}
+{{ ListSubpages ("/pt-BR/docs/Mozilla/Add-ons/WebExtensions/manifest.json") }}{{AddonSidebar}}


### PR DESCRIPTION
### Description

Fully qualify the path parameter of `ListSubpagesForSidebar` / `ListSubpages` in two pages:

- `files/es/web/accessibility/aria/guides/techniques/index.md`: `Web/Accessibility/ARIA/{Attributes,Roles}` -> `/es/docs/Web/Accessibility/ARIA/{Attributes,Roles}`
- `files/pt-br/mozilla/add-ons/webextensions/index.md`: `/Add-ons/WebExtensions/manifest.json` -> `/pt-BR/docs/Mozilla/Add-ons/WebExtensions/manifest.json`

### Motivation

Fix "invalid locale" macro flaws: the first path segment was interpreted as the locale.

### Additional details

The pt-BR path was also missing the `Mozilla/` segment, which is restored here.

### Related issues and pull requests

Part of mdn/fred#1462.