### PR TITLE
Fix `QuickLinksWithSubPages` macro paths in es

### DIFF
--- a/files/es/web/performance/guides/fundamentals/index.md
+++ b/files/es/web/performance/guides/fundamentals/index.md
@@ -4,7 +4,7 @@ slug: Web/Performance/Guides/Fundamentals
 original_slug: Web/Performance/Fundamentals
 ---
 
-{{QuickLinksWithSubPages("Web/Performance")}}
+{{QuickLinksWithSubPages("/es/docs/Web/Performance")}}
 
 Performance significa eficiencia. En el contexto de Open Web Apps, este documento explica en general qué es performance, cómo la plataforma del navegador ayuda a mejorarlo y qué herramientas y procesos puede usar para probarlo y mejorarlo.
 

--- a/files/es/web/performance/guides/optimizing_startup_performance/index.md
+++ b/files/es/web/performance/guides/optimizing_startup_performance/index.md
@@ -4,7 +4,7 @@ slug: Web/Performance/Guides/Optimizing_startup_performance
 original_slug: Web/Performance/Optimizing_startup_performance
 ---
 
-{{QuickLinksWithSubPages("Web/Performance")}}
+{{QuickLinksWithSubPages("/es/docs/Web/Performance")}}
 
 Un aspecto que a menudo se pasa por alto en el desarrollo de software de aplicaciones, incluso entre aquellos enfocados en la optimización del rendimiento, es el rendimiento inicial. ¿Cuánto tiempo demora su aplicación en iniciarse? ¿Parece que se bloquea el dispositivo o el navegador del usuario no responde mientras se carga la aplicación? Eso hace que los usuarios se preocupen de que su aplicación haya fallado, o de que algo anda mal. Siempre es una buena idea invertir tiempo para asegurarse de que la aplicación se inicie de manera correcta. Este artículo ofrece consejos y sugerencias para ayudar a lograr ese objetivo, tanto al escribir una nueva aplicación como al migrar una aplicación de otra plataforma a la Web.
 


### PR DESCRIPTION
### Description

Fully qualify the path parameter of `QuickLinksWithSubPages` in 2 `Web/Performance/Guides/*` pages: `Web/Performance` -> `/es/docs/Web/Performance`.

### Motivation

Fix "fixed legacy url" macro flaws: the first path segment was interpreted as the locale.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of mdn/fred#1462.