### PR TITLE
fix(ko): fully qualify `QuickLinksWithSubPages` path

### DIFF
--- a/files/ko/web/performance/guides/animation_performance_and_frame_rate/index.md
+++ b/files/ko/web/performance/guides/animation_performance_and_frame_rate/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: 5f76b99045f87349ed030bbd6a3c2e43badb3c22
 ---
 
-{{QuickLinksWithSubPages("Web/Performance")}}
+{{QuickLinksWithSubPages("/ko/docs/Web/Performance")}}
 
 웹에서 애니메이션은 {{htmlelement('canvas')}} 와 {{domxref('WebGL_API', 'WebGL')}}, CSS {{cssxref('animation')}}, {{htmlelement('video')}}, 애니메이션 GIF, 그리고 애니메이션 PNG 및 기타 이미지 유형과 {{domxref('SVGAnimationElement', 'SVG')}}, {{domxref('window.requestAnimationFrame','JavaScript')}}를 통해 구현할 수 있습니다. CSS 속성을 애니메이션화하는 데 드는 성능 비용은 각 속성에 따라 다를 수 있으며, 비용이 높은 CSS 속성을 애니메이션화하면 브라우저가 부드러운 {{glossary("FPS", "프레임 속도")}}를 유지하는 것이 어려워지기 때문에 {{glossary('jank', '버벅거림')}} 현상이 발생할 수 있습니다.
 

--- a/files/ko/web/performance/guides/critical_rendering_path/index.md
+++ b/files/ko/web/performance/guides/critical_rendering_path/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: 5b20f5f4265f988f80f513db0e4b35c7e0cd70dc
 ---
 
-{{QuickLinksWithSubPages("Web/Performance")}}
+{{QuickLinksWithSubPages("/ko/docs/Web/Performance")}}
 
 중요 렌더링 경로 (_Critical Rendering Path_)는 브라우저가 HTML, CSS, Javascript를 화면에 픽셀로 전환되는 일련의 단계를 말하며 이를 최적화 하는 것은 렌더링 성능을 향상시킵니다. 중요 렌더링 경로는 [Document Object Model](/ko/docs/Web/API/Document_Object_Model) (DOM), [CSS Object Model](/ko/docs/Web/API/CSS_Object_Model) (CSSOM), 렌더 트리 그리고 레이아웃을 포함합니다.
 

--- a/files/ko/web/performance/guides/how_browsers_work/index.md
+++ b/files/ko/web/performance/guides/how_browsers_work/index.md
@@ -4,7 +4,7 @@ slug: Web/Performance/Guides/How_browsers_work
 original_slug: Web/Performance/How_browsers_work
 ---
 
-{{QuickLinksWithSubPages("Web/Performance")}}
+{{QuickLinksWithSubPages("/ko/docs/Web/Performance")}}
 
 사용자는 로드가 빠르고 상호작용이 원활한 컨텐츠로 이루어진 웹 경험을 원합니다. 따라서 개발자는 이 두 가지 목표를 달성하기 위해서 부단히 노력해야합니다.
 

--- a/files/ko/web/performance/guides/lazy_loading/index.md
+++ b/files/ko/web/performance/guides/lazy_loading/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: 0c45d0d3ec3e3eeb80fcf2101a30704dae7c8ee9
 ---
 
-{{QuickLinksWithSubPages("Web/Performance")}}
+{{QuickLinksWithSubPages("/ko/docs/Web/Performance")}}
 
 **지연 로딩**은 리소스를 논 블로킹(중요하지 않음)으로 식별하여 필요할 때만 로드하는 전략입니다. 이는 [중요 렌더링 경로](/ko/docs/Web/Performance/Guides/Critical_rendering_path)의 길이를 단축하는 방법으로, 페이지 로드 시간을 감소시킬 수 있습니다.
 

--- a/files/ko/web/performance/guides/performance_budgets/index.md
+++ b/files/ko/web/performance/guides/performance_budgets/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: 5b20f5f4265f988f80f513db0e4b35c7e0cd70dc
 ---
 
-{{QuickLinksWithSubPages("Web/Performance")}}
+{{QuickLinksWithSubPages("/ko/docs/Web/Performance")}}
 
 성능 예산은 성능 저하를 방지하기 위한 제한입니다. 이는 특정 파일, 확장자, 페이지에서 로드되는 모든 파일, [Time to Interactive](/ko/docs/Glossary/Time_to_interactive) 같은 특정 지표, Time to Hero Element 같은 사용자 정의 지표, 또는 일정 기간 동안의 걸친 임계값에 적용할 수 있습니다.
 

--- a/files/ko/web/performance/guides/understanding_latency/index.md
+++ b/files/ko/web/performance/guides/understanding_latency/index.md
@@ -4,7 +4,7 @@ slug: Web/Performance/Guides/Understanding_latency
 original_slug: Web/Performance/Understanding_latency
 ---
 
-{{QuickLinksWithSubPages("Web/Performance")}}
+{{QuickLinksWithSubPages("/ko/docs/Web/Performance")}}
 
 **대기 시간(Latency)** 이란 하나의 데이터 패킷이 출발지에서 도착지까지 가는 데 걸리는 시간을 뜻합니다. 성능 최적화에 있어서 대기 시간의 원인을 줄이는 것과 연결 상태가 좋지 않은 사용자를 고려하여 대기 시간이 긴 환경에서 사이트 성능을 테스트하는 것은 중요합니다. 이 글에서 대기 시간이 무엇인지, 대기 시간이 성능에 어떤 영향을 주는지, 이를 어떻게 측정하고 어떤 방법으로 줄일 수 있을지에 관해 설명합니다.
 


### PR DESCRIPTION
### Description

Fully qualify the path parameter of `QuickLinksWithSubPages` in 6 `Web/Performance/Guides/*` pages: `Web/Performance` -> `/ko/docs/Web/Performance`.

### Motivation

Fix "fixed legacy url" macro flaws: the first path segment was interpreted as the locale.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of mdn/fred#1462.