### PR TITLE
fix(fr): remove `XSLTRef` from the XSLT landing page

### DIFF
--- a/files/fr/web/xml/xslt/index.md
+++ b/files/fr/web/xml/xslt/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT
 original_slug: Web/XSLT
 ---
 
-{{XSLTRef}}
-
 <div id="Quick_links">
   <ol>
     <li><strong><a href="/fr/docs/Web/XML/XSLT">XSLT</a></strong></li>


### PR DESCRIPTION
### Description

Remove the `{{XSLTRef}}` macro call from the French `Web/XML/XSLT` landing page.

### Motivation

Prevent five unfixable `redirected-link` flaws on this page. The macro renders a hardcoded link bar pointing at pre-move slugs, and since those URLs live in the macro implementation rather than in the markdown, no content change or autofixer can repair them.

### Additional details

Its links duplicate the hand-written `Quick_links` block that directly follows it, so nothing is lost. Building the page locally reports 0 issues after the change, down from 5.

This page is the only call site of `XSLTRef` across `mdn/content` and `mdn/translated-content`, so the macro itself is being removed in mdn/rari#867.

### Related issues and pull requests

Relates to mdn/rari#867, which must be merged after this.
