### PR TITLE
fix: remove `{{deprecated_header}}` with parameter

### DIFF
--- a/files/es/web/api/idbcursor/index.md
+++ b/files/es/web/api/idbcursor/index.md
@@ -42,8 +42,6 @@ Puede tener un número ilimitado de cursores al mismo tiempo. Siempre se obtiene
 
 ## Constants
 
-{{ deprecated_header(13) }}
-
 > [!WARNING]
 > These constants are no longer available — they were removed in Gecko 25. You should use the string constants directly instead. ([Error 891944 en Firefox](https://bugzil.la/891944))
 

--- a/files/ja/web/api/idbtransaction/index.md
+++ b/files/ja/web/api/idbtransaction/index.md
@@ -79,8 +79,6 @@ Firefox 40 以降、IndexedDB のトランザクションはパフォーマン�
 
 ## モード定数
 
-{{ deprecated_header(13) }}
-
 > [!WARNING]
 > これらの定数はもう利用可能ではありません。Gecko 25 で削除されました。かわりに、これらの文字列定数を直接使用するべきです。([Firefox バグ 888598](https://bugzil.la/888598))
 

--- a/files/zh-tw/web/api/file/name/index.md
+++ b/files/zh-tw/web/api/file/name/index.md
@@ -5,8 +5,6 @@ slug: Web/API/File/name
 
 {{APIRef("File API")}}{{non-standard_header}}
 
-{{deprecated_header(7.0)}}
-
 ## 總覽
 
 回傳檔案名稱，基於安全因素，檔案路徑不包含這個屬性。


### PR DESCRIPTION
### Description

Remove the remaining `{{deprecated_header(...)}}` calls, which pass a version parameter that the macro no longer supports:

- `es`: `Web/API/IDBCursor`
- `ja`: `Web/API/IDBTransaction`
- `zh-TW`: `Web/API/File/name`

### Motivation

Prevent flaws from a deprecated macro signature.

### Additional details

In all three cases the macro call is dropped entirely rather than just the parameter:

- The `IDBCursor` and `IDBTransaction` constants sections already carry a warning about the constants being removed in Gecko 25, and en-US has no `{{deprecated_header}}` there.
- `File.name` is no longer deprecated in en-US.

Note: `files/ru/web/javascript/reference/global_objects/date/getyear/index.md` still calls `{{deprecated_header("")}}` with an empty parameter, which is apparently not flagged; left untouched.

### Related issues and pull requests

Follows up on #35902.