### PR TITLE
fix(es): replace unsupported `{{CSSSyntax}}` invocations

### DIFF
--- a/files/es/web/css/reference/selectors/_colon_active/index.md
+++ b/files/es/web/css/reference/selectors/_colon_active/index.md
@@ -20,7 +20,11 @@ Los estilos definidos por la pseudoclase `:active` serán anulados por cualquier
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:active {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_any-link/index.md
+++ b/files/es/web/css/reference/selectors/_colon_any-link/index.md
@@ -15,7 +15,11 @@ original_slug: Web/CSS/:any-link
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:any-link {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_blank/index.md
+++ b/files/es/web/css/reference/selectors/_colon_blank/index.md
@@ -13,7 +13,11 @@ La [pseudo-clase CSS](/es/docs/Web/CSS) **`:blank`** selecciona elementos de ent
 
 ## Sintáxis
 
-{{CSSSyntax}}
+```css
+:blank {
+  /* ... */
+}
+```
 
 ## Especificaciones
 

--- a/files/es/web/css/reference/selectors/_colon_checked/index.md
+++ b/files/es/web/css/reference/selectors/_colon_checked/index.md
@@ -23,7 +23,11 @@ El usuario puede activar este estado marcando/seleccionando un elemento, o desac
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:checked {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_default/index.md
+++ b/files/es/web/css/reference/selectors/_colon_default/index.md
@@ -21,7 +21,11 @@ Los elementos agrupados que permiten selecciones múltiples también pueden tene
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:default {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_defined/index.md
+++ b/files/es/web/css/reference/selectors/_colon_defined/index.md
@@ -20,7 +20,11 @@ simple-custom:defined {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:defined {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_dir/index.md
+++ b/files/es/web/css/reference/selectors/_colon_dir/index.md
@@ -36,7 +36,11 @@ La pseudoclase `:dir()` requiere un parámetro, que representa la direccionalida
 
 ### Sintaxis formal
 
-{{csssyntax}}
+```css-nolint
+:dir([ltr | rtl]) {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_disabled/index.md
+++ b/files/es/web/css/reference/selectors/_colon_disabled/index.md
@@ -15,7 +15,11 @@ input:disabled {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:disabled {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_empty/index.md
+++ b/files/es/web/css/reference/selectors/_colon_empty/index.md
@@ -20,7 +20,11 @@ div:empty {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:empty {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_enabled/index.md
+++ b/files/es/web/css/reference/selectors/_colon_enabled/index.md
@@ -15,7 +15,11 @@ input:enabled {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:enabled {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_first-child/index.md
+++ b/files/es/web/css/reference/selectors/_colon_first-child/index.md
@@ -19,7 +19,11 @@ p:first-child {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:first-child {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_first-of-type/index.md
+++ b/files/es/web/css/reference/selectors/_colon_first-of-type/index.md
@@ -19,7 +19,11 @@ p:first-of-type {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:first-of-type {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_first/index.md
+++ b/files/es/web/css/reference/selectors/_colon_first/index.md
@@ -19,7 +19,11 @@ La [pseudo-clase](/es/docs/Web/CSS/Reference/Selectors/Pseudo-classes) `:first` 
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:first {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_focus-visible/index.md
+++ b/files/es/web/css/reference/selectors/_colon_focus-visible/index.md
@@ -12,7 +12,11 @@ Nótese que Firefox soporta una funcionalidad similar a través de una pseudo-cl
 
 ## Sintaxis
 
-{{CSSSyntax}}
+```css
+:focus-visible {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_focus-within/index.md
+++ b/files/es/web/css/reference/selectors/_colon_focus-within/index.md
@@ -17,7 +17,11 @@ Este selector es útil, por tomar un ejemplo común, para resaltar un contenedor
 
 ## Sintaxis
 
-{{CSSSyntax}}
+```css
+:focus-within {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_focus/index.md
+++ b/files/es/web/css/reference/selectors/_colon_focus/index.md
@@ -18,7 +18,11 @@ input:focus {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:focus {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_fullscreen/index.md
+++ b/files/es/web/css/reference/selectors/_colon_fullscreen/index.md
@@ -30,7 +30,11 @@ div:fullscreen {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:fullscreen {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_host/index.md
+++ b/files/es/web/css/reference/selectors/_colon_host/index.md
@@ -18,7 +18,11 @@ La [pseudo-clase](/es/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](/es
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:host {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_hover/index.md
+++ b/files/es/web/css/reference/selectors/_colon_hover/index.md
@@ -20,7 +20,11 @@ Los estilos definidos por la pseudoclase `:active` serán anulados por cualquier
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:hover {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_in-range/index.md
+++ b/files/es/web/css/reference/selectors/_colon_in-range/index.md
@@ -21,7 +21,11 @@ Esta pseudo-clase es útil para dar al usuario una indicación visual de que el 
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:in-range {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_indeterminate/index.md
+++ b/files/es/web/css/reference/selectors/_colon_indeterminate/index.md
@@ -21,7 +21,11 @@ Los elementos seleccionados por este selector son:
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:indeterminate {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_invalid/index.md
+++ b/files/es/web/css/reference/selectors/_colon_invalid/index.md
@@ -17,7 +17,11 @@ Esta pseudo-clase es útil para resaltar errores de campo para el usuario.
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:invalid {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_lang/index.md
+++ b/files/es/web/css/reference/selectors/_colon_lang/index.md
@@ -20,7 +20,11 @@ p:lang(en) {
 
 ### Sintaxis formal
 
-{{csssyntax}}
+```plain
+:lang(<language-code> [,<language-code> ]*) {
+  /* ... */
+}
+```
 
 ### Parámetro
 

--- a/files/es/web/css/reference/selectors/_colon_last-child/index.md
+++ b/files/es/web/css/reference/selectors/_colon_last-child/index.md
@@ -19,7 +19,11 @@ p:last-child {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:last-child {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_last-of-type/index.md
+++ b/files/es/web/css/reference/selectors/_colon_last-of-type/index.md
@@ -19,7 +19,11 @@ p:last-of-type {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:last-of-type {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_left/index.md
+++ b/files/es/web/css/reference/selectors/_colon_left/index.md
@@ -22,7 +22,11 @@ La dirección principal de escritura del documento determina si una página es "
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:left {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_link/index.md
+++ b/files/es/web/css/reference/selectors/_colon_link/index.md
@@ -20,7 +20,11 @@ Los estilos definidos por la pseudo-clase `:link` serán anulados por cualquier 
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:link {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_not/index.md
+++ b/files/es/web/css/reference/selectors/_colon_not/index.md
@@ -27,7 +27,11 @@ La pseudoclase `:not()` requiere una lista separada por comas de uno o más sele
 > [!WARNING]
 > La capacidad de enumerar más de un selector es experimental y aún no es ampliamente compatible.
 
-{{csssyntax}}
+```css-nolint
+:not(<complex-selector-list>) {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_nth-child/index.md
+++ b/files/es/web/css/reference/selectors/_colon_nth-child/index.md
@@ -32,7 +32,11 @@ La pseudo-clase `nth-child` se especifica con un único argumento, que represent
 
 ### Sintaxis formal
 
-{{csssyntax}}
+```css-nolint
+:nth-child([ <An+B> | even | odd ] [of <complex-selector-list>]?) {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_nth-last-child/index.md
+++ b/files/es/web/css/reference/selectors/_colon_nth-last-child/index.md
@@ -36,7 +36,11 @@ La pseudo-clase `nth-last-child` se especifica con un solo argumento, que repres
 
 ### Sintaxis formal
 
-{{csssyntax}}
+```css-nolint
+:nth-last-child(<nth> [of <complex-selector-list>]?) {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_nth-last-of-type/index.md
+++ b/files/es/web/css/reference/selectors/_colon_nth-last-of-type/index.md
@@ -26,7 +26,11 @@ Ver {{Cssxref(":nth-last-child")}} para una explicación más detallada de su si
 
 ### Sintaxis formal
 
-{{csssyntax}}
+```css-nolint
+:nth-last-of-type(<An+B> | even | odd) {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_nth-of-type/index.md
+++ b/files/es/web/css/reference/selectors/_colon_nth-of-type/index.md
@@ -22,7 +22,11 @@ Ver {{Cssxref(":nth-child")}} para una explicación más detallada de su sintaxi
 
 ### Sintaxis formal
 
-{{csssyntax}}
+```css-nolint
+:nth-of-type(<An+B> | even | odd) {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_only-child/index.md
+++ b/files/es/web/css/reference/selectors/_colon_only-child/index.md
@@ -19,7 +19,11 @@ p:only-child {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:only-child {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_only-of-type/index.md
+++ b/files/es/web/css/reference/selectors/_colon_only-of-type/index.md
@@ -19,7 +19,11 @@ p:only-of-type {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:only-of-type {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_optional/index.md
+++ b/files/es/web/css/reference/selectors/_colon_optional/index.md
@@ -20,7 +20,11 @@ Esta pseudo-clase es útil para diseñar campos que no son necesarios para envia
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:optional {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_out-of-range/index.md
+++ b/files/es/web/css/reference/selectors/_colon_out-of-range/index.md
@@ -21,7 +21,11 @@ Esta pseudo-clase es útil para dar al usuario una indicación visual de que el 
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:out-of-range {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_placeholder-shown/index.md
+++ b/files/es/web/css/reference/selectors/_colon_placeholder-shown/index.md
@@ -17,7 +17,11 @@ La [pseudo-clase](/es/docs/Web/CSS/Reference/Selectors/Pseudo-classes) **`:place
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:placeholder-shown {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_read-write/index.md
+++ b/files/es/web/css/reference/selectors/_colon_read-write/index.md
@@ -24,7 +24,11 @@ input:read-write {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:read-write {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_required/index.md
+++ b/files/es/web/css/reference/selectors/_colon_required/index.md
@@ -20,7 +20,11 @@ Esta pseudo-clase es útil para resaltar campos que deben tener datos válidos a
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:required {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_right/index.md
+++ b/files/es/web/css/reference/selectors/_colon_right/index.md
@@ -22,7 +22,11 @@ Que una página dada sea "izquierda" o "derecha" está determinada por la direcc
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:right {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_root/index.md
+++ b/files/es/web/css/reference/selectors/_colon_root/index.md
@@ -16,7 +16,11 @@ La [pseudo-clase](/es/docs/Web/CSS/Reference/Selectors/Pseudo-classes) **`:root`
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:root {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_colon_target/index.md
+++ b/files/es/web/css/reference/selectors/_colon_target/index.md
@@ -27,7 +27,11 @@ El siguiente elemento sería seleccionado por un selector `:target` cuando la UR
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:target {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_valid/index.md
+++ b/files/es/web/css/reference/selectors/_colon_valid/index.md
@@ -17,7 +17,11 @@ Esta pseudo-clase es útil para resaltar los campos correctos para el usuario.
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:valid {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_colon_visited/index.md
+++ b/files/es/web/css/reference/selectors/_colon_visited/index.md
@@ -29,7 +29,11 @@ Por motivos de privacidad, los navegadores limitan estrictamente los estilos que
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+:visited {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_doublecolon_-moz-color-swatch/index.md
+++ b/files/es/web/css/reference/selectors/_doublecolon_-moz-color-swatch/index.md
@@ -13,7 +13,11 @@ El **`::-moz-color-swatch`** [pdseudo-elemento CSS](/es/docs/Web/CSS) es una [ex
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+::-moz-color-swatch {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_doublecolon_-moz-progress-bar/index.md
+++ b/files/es/web/css/reference/selectors/_doublecolon_-moz-progress-bar/index.md
@@ -10,7 +10,11 @@ El [pseudo-elemento](/es/docs/Web/CSS/Reference/Selectors/Pseudo-elements) **`::
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+::-moz-progress-bar {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/selectors/_doublecolon_-moz-range-progress/index.md
+++ b/files/es/web/css/reference/selectors/_doublecolon_-moz-range-progress/index.md
@@ -15,7 +15,11 @@ El [pseudo-elemento](/es/docs/Web/CSS/Reference/Selectors/Pseudo-elements) [CSS]
 
 ## Síntaxis
 
-{{csssyntax}}
+```css
+::-moz-range-progress {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_doublecolon_-moz-range-thumb/index.md
+++ b/files/es/web/css/reference/selectors/_doublecolon_-moz-range-thumb/index.md
@@ -15,7 +15,11 @@ El [pseudo-elemento](/es/docs/Web/CSS/Reference/Selectors/Pseudo-elements) CSS *
 
 ## Syntax
 
-{{csssyntax}}
+```css
+::-moz-range-thumb {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_doublecolon_-moz-range-track/index.md
+++ b/files/es/web/css/reference/selectors/_doublecolon_-moz-range-track/index.md
@@ -15,7 +15,11 @@ El [pseudo-elemento](/es/docs/Web/CSS/Reference/Selectors/Pseudo-elements) CSS *
 
 ## Síntaxis
 
-{{csssyntax}}
+```css
+::-moz-range-track {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_doublecolon_before/index.md
+++ b/files/es/web/css/reference/selectors/_doublecolon_before/index.md
@@ -18,7 +18,12 @@ a::before {
 
 ## Sintaxis
 
-{{csssyntax}}
+```css-nolint
+::before {
+  content: /* value */;
+  /* properties */
+}
+```
 
 > [!NOTE]
 > CSS3 introdujo la notación `::before` (con doble dos puntos) para diferenciar [pseudo-clases](/es/docs/Web/CSS/Reference/Selectors/Pseudo-classes) con [pseudo-elementos](/es/docs/Web/CSS/Reference/Selectors/Pseudo-elements). Los navegadores aceptan `:before`, añadido en CSS2.

--- a/files/es/web/css/reference/selectors/_doublecolon_cue/index.md
+++ b/files/es/web/css/reference/selectors/_doublecolon_cue/index.md
@@ -17,7 +17,11 @@ Las propiedades son aplicadas al cojunto completo de anotaciones como si fuesen 
 
 ## Sintaxis
 
-{{CSSSyntax}}
+```css-nolint
+::cue | ::cue(<selector>) {
+  /* ... */
+}
+```
 
 ## Propiedades permitidas
 

--- a/files/es/web/css/reference/selectors/_doublecolon_first-letter/index.md
+++ b/files/es/web/css/reference/selectors/_doublecolon_first-letter/index.md
@@ -36,7 +36,11 @@ Sólo unas pocas propiedades de CSS se pueden usar con el pseudoelemento `::firs
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+::first-letter {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_doublecolon_first-line/index.md
+++ b/files/es/web/css/reference/selectors/_doublecolon_first-line/index.md
@@ -28,7 +28,11 @@ Sólo unas pocas propiedades de CSS se pueden usar con el pseudoelemento `::firs
 
 ## Sintaxis
 
-{{csssyntax}}
+```css
+::first-line {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_doublecolon_marker/index.md
+++ b/files/es/web/css/reference/selectors/_doublecolon_marker/index.md
@@ -29,7 +29,11 @@ Sólo ciertas propiedades CSS puedes utilizarse en una regla con `::marker` como
 
 ## Sintaxis
 
-{{CSSSyntax}}
+```css
+::marker {
+  /* ... */
+}
+```
 
 ## Ejemplo
 

--- a/files/es/web/css/reference/selectors/_doublecolon_placeholder/index.md
+++ b/files/es/web/css/reference/selectors/_doublecolon_placeholder/index.md
@@ -20,7 +20,11 @@ Solo el subconjuto de las propiedades CSS que aplican al pseudo-elemento {{cssxr
 
 ## Sintáxis
 
-{{csssyntax}}
+```css
+::placeholder {
+  /* ... */
+}
+```
 
 ## Ejemplos
 

--- a/files/es/web/css/reference/values/fit-content/index.md
+++ b/files/es/web/css/reference/values/fit-content/index.md
@@ -38,7 +38,13 @@ Función que acepta un `<length>` o un `<percentage>` como un argumento.
 
 ### Formal syntax
 
-{{csssyntax}}
+```css
+/* Used in sizing properties */
+width: fit-content;
+height: fit-content;
+inline-size: fit-content;
+block-size: fit-content;
+```
 
 ## Ejemplo
 


### PR DESCRIPTION
### Description

Fix 56 pages in `es` that call `{{CSSSyntax}}` on CSS pseudo-class, pseudo-element and keyword pages:

- Replace each invocation with the corresponding code block from the en-US page.

### Motivation

Ensure the syntax section renders, instead of failing with "CSS syntax not supported".

### Additional details

The `CSSSyntax` macro only has syntax data for properties, functions and at-rules. For the other page types, en-US spells the syntax out in a code block, which this copies over verbatim, leaving the translated prose around it untouched.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.
