### PR TITLE
fix(pt-br): replace unsupported `{{CSSSyntax}}` invocations

### DIFF
--- a/files/pt-br/web/css/reference/selectors/_colon_blank/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_blank/index.md
@@ -15,7 +15,11 @@ A [pseudo-classe](/pt-BR/docs/Web/CSS/Reference/Selectors/Pseudo-classes) [CSS](
 
 ## Sintaxe
 
-{{CSSSyntax}}
+```css
+:blank {
+  /* ... */
+}
+```
 
 ## Especificações
 

--- a/files/pt-br/web/css/reference/selectors/_colon_disabled/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_disabled/index.md
@@ -17,7 +17,11 @@ input:disabled {
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+:disabled {
+  /* ... */
+}
+```
 
 ## Exemplo
 

--- a/files/pt-br/web/css/reference/selectors/_colon_empty/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_empty/index.md
@@ -17,7 +17,11 @@ div:empty {
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+:empty {
+  /* ... */
+}
+```
 
 ## Exemplos
 

--- a/files/pt-br/web/css/reference/selectors/_colon_enabled/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_enabled/index.md
@@ -17,7 +17,11 @@ input:enabled {
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+:enabled {
+  /* ... */
+}
+```
 
 ## Exemplo
 

--- a/files/pt-br/web/css/reference/selectors/_colon_first-of-type/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_first-of-type/index.md
@@ -21,7 +21,11 @@ p:first-of-type {
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+:first-of-type {
+  /* ... */
+}
+```
 
 ## Exemplos
 

--- a/files/pt-br/web/css/reference/selectors/_colon_focus-within/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_focus-within/index.md
@@ -19,7 +19,11 @@ Este seletor é útil, pegando um exemplo comum, para destacar um todo {{htmlEle
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+:focus-within {
+  /* ... */
+}
+```
 
 ## Exemplo
 

--- a/files/pt-br/web/css/reference/selectors/_colon_invalid/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_invalid/index.md
@@ -19,7 +19,11 @@ Essa pseudo-classe é útil para usuário identificar quais campos foram preench
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+:invalid {
+  /* ... */
+}
+```
 
 ## Exemplo
 

--- a/files/pt-br/web/css/reference/selectors/_colon_nth-child/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_nth-child/index.md
@@ -35,7 +35,11 @@ A pseudo-classe **`nth-child`** é usada com apenas um argumento, que representa
 
 ### Sintaxe formal
 
-{{csssyntax}}
+```css-nolint
+:nth-child([ <An+B> | even | odd ] [of <complex-selector-list>]?) {
+  /* ... */
+}
+```
 
 ## Exemplos
 

--- a/files/pt-br/web/css/reference/selectors/_colon_nth-last-child/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_nth-last-child/index.md
@@ -38,7 +38,11 @@ A pseudo-classe `nth-last-child` é especificada com um único argumento, que re
 
 ### Sintaxe formal
 
-{{csssyntax}}
+```css-nolint
+:nth-last-child(<nth> [of <complex-selector-list>]?) {
+  /* ... */
+}
+```
 
 ## Exemplos
 

--- a/files/pt-br/web/css/reference/selectors/_colon_nth-of-type/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_nth-of-type/index.md
@@ -24,7 +24,11 @@ Veja {{Cssxref(":nth-child")}} para uma explicação mais detalhada de sua sinta
 
 ### Sintaxe formal
 
-{{csssyntax}}
+```css-nolint
+:nth-of-type(<An+B> | even | odd) {
+  /* ... */
+}
+```
 
 ## Exemplos
 

--- a/files/pt-br/web/css/reference/selectors/_colon_only-child/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_only-child/index.md
@@ -21,7 +21,11 @@ p:only-child {
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+:only-child {
+  /* ... */
+}
+```
 
 ## Exemplos
 

--- a/files/pt-br/web/css/reference/selectors/_colon_optional/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_optional/index.md
@@ -22,7 +22,11 @@ Esta pseudo-classe é utilizada para estilizar campos do formulário que não s�
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+:optional {
+  /* ... */
+}
+```
 
 ## Exemplos
 

--- a/files/pt-br/web/css/reference/selectors/_colon_out-of-range/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_out-of-range/index.md
@@ -23,7 +23,11 @@ Essa pseudo classe é muito útil por dar ao usuario uma indicacão visual de qu
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+:out-of-range {
+  /* ... */
+}
+```
 
 ## Exemplo
 

--- a/files/pt-br/web/css/reference/selectors/_colon_read-write/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_read-write/index.md
@@ -21,7 +21,11 @@ p:read-write {
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+:read-write {
+  /* ... */
+}
+```
 
 ## Exemplos
 

--- a/files/pt-br/web/css/reference/selectors/_colon_required/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_required/index.md
@@ -22,7 +22,11 @@ Esta pseudo-classe é utilizada para destacar campos que devem ter dados válido
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+:required {
+  /* ... */
+}
+```
 
 ## Exemplos
 

--- a/files/pt-br/web/css/reference/selectors/_colon_target/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_target/index.md
@@ -29,7 +29,11 @@ O seguinte elemento será selecionado pelo seletor `:target` quando a URL for ig
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+:target {
+  /* ... */
+}
+```
 
 ## Exemplos
 

--- a/files/pt-br/web/css/reference/selectors/_colon_valid/index.md
+++ b/files/pt-br/web/css/reference/selectors/_colon_valid/index.md
@@ -19,7 +19,11 @@ Essa pseudo-classe é útil para realçar os campos válidos para o usuário.
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+:valid {
+  /* ... */
+}
+```
 
 ## Exemplos
 

--- a/files/pt-br/web/css/reference/selectors/_doublecolon_after/index.md
+++ b/files/pt-br/web/css/reference/selectors/_doublecolon_after/index.md
@@ -17,7 +17,12 @@ a::after {
 
 ## Sintaxe
 
-{{csssyntax}}
+```css-nolint
+::after {
+  content: /* value */;
+  /* properties */
+}
+```
 
 > [!NOTE]
 > O CSS3 introduziu a notação `::after` (com dois sinais de dois pontos) para distinguir [pseudo-classes](/pt-BR/docs/Web/CSS/Reference/Selectors/Pseudo-classes) dos [pseudo-elementos](/pt-BR/docs/Web/CSS/Reference/Selectors/Pseudo-elements). Os navegadores também aceitam `:after`, introduzido no CSS2.

--- a/files/pt-br/web/css/reference/selectors/_doublecolon_before/index.md
+++ b/files/pt-br/web/css/reference/selectors/_doublecolon_before/index.md
@@ -12,7 +12,12 @@ original_slug: Web/CSS/::before
 
 ## Sintaxe
 
-{{csssyntax}}
+```css-nolint
+::before {
+  content: /* value */;
+  /* properties */
+}
+```
 
 A notação `::before` (com dois dois-pontos) foi introduzida no CSS3 afim de diferenciar [pseudo-classes](/pt-BR/docs/Web/CSS/Reference/Selectors/Pseudo-classes) de [pseudo-elementos](/pt-BR/docs/Web/CSS/Reference/Selectors/Pseudo-elements). Navegadores também aceitam a notação `:before` introduzida no CSS 2.
 

--- a/files/pt-br/web/css/reference/selectors/_doublecolon_first-line/index.md
+++ b/files/pt-br/web/css/reference/selectors/_doublecolon_first-line/index.md
@@ -30,7 +30,11 @@ Somente um pequeno subconjunto de propriedades CSS pode ser usado com o`::first-
 
 ## Sintaxe
 
-{{csssyntax}}
+```css
+::first-line {
+  /* ... */
+}
+```
 
 ## Exemplos
 

--- a/files/pt-br/web/css/reference/selectors/_doublecolon_selection/index.md
+++ b/files/pt-br/web/css/reference/selectors/_doublecolon_selection/index.md
@@ -35,8 +35,12 @@ Apenas certas propriedades podem ser usadas com o `::selection`:
 ```
 /* Sintaxe legado do Firefox (até a versão 61) */
 ::-moz-selection
+```
 
-{{CSSSyntax}}
+```css
+::selection {
+  /* ... */
+}
 ```
 
 ## Exemplo


### PR DESCRIPTION
### Description

Fix 21 pages in `pt-br` that call `{{CSSSyntax}}` on CSS pseudo-class, pseudo-element and keyword pages:

- Replace each invocation with the corresponding code block from the en-US page.
- Close a stray code fence on `::selection` that swallowed the invocation.

### Motivation

Ensure the syntax section renders, instead of failing with "CSS syntax not supported".

### Additional details

The `CSSSyntax` macro only has syntax data for properties, functions and at-rules. For the other page types, en-US spells the syntax out in a code block, which this copies over verbatim, leaving the translated prose around it untouched.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.
