### PR TITLE
fix(zh-tw): remove `{{deprecated_header}}` macro calls

### DIFF
--- a/files/zh-tw/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/zh-tw/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
@@ -66,7 +66,7 @@ l10n:
 >
 > _發布前請記得移除此整個說明性註解。_
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 在頁面內容開始處，撰寫一段簡介文字——首先點名建構子並說明其用途。這通常應該是一到兩個簡短的句子。你可以從相應 API 參考頁面的建構子摘要中複製大部分內容。
 

--- a/files/zh-tw/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
+++ b/files/zh-tw/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
@@ -69,7 +69,7 @@ l10n:
 >
 > _請記得刪除這整段說明文字後再發布。_
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 請在頁面內容開頭添加一個簡介段落——首先命名該事件，說明它屬於哪個介面，並描述它的功能。這部分應該儘量用一到兩個簡短的句子來表達。你可以從對應 API 參考頁面中該屬性的摘要中擷取大部分內容。
 

--- a/files/zh-tw/web/api/canvas_api/tutorial/drawing_text/index.md
+++ b/files/zh-tw/web/api/canvas_api/tutorial/drawing_text/index.md
@@ -197,8 +197,6 @@ nsIDOMTextMetrics measureText(
 
 ### mozDrawText()
 
-{{ deprecated_header }}
-
 繪製文字使用由`mozTextStyle`屬性的文字樣式。文本當前的填充顏色被用來當做文字顏色。
 
 > [!NOTE]
@@ -226,8 +224,6 @@ ctx.mozDrawText("Sample String");
 這個範例將文字「Sample String」繪製到畫布（canvas）上。
 
 ### mozMeasureText()
-
-{{ deprecated_header }}
 
 返回寬度，像素值，指定文字
 

--- a/files/zh-tw/web/api/document/createevent/index.md
+++ b/files/zh-tw/web/api/document/createevent/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: 08e04f121ea7b3a55e6ef47782d2d82fb053ca88
 ---
 
-{{APIRef("DOM")}}{{deprecated_header}}
+{{APIRef("DOM")}}
 
 > [!WARNING]
 > 許多與 `createEvent` 一起使用的方法，例如 `initCustomEvent`，已被淘汰。請改用[事件建構子](/zh-TW/docs/Web/API/CustomEvent)。

--- a/files/zh-tw/web/api/document/execcommand/index.md
+++ b/files/zh-tw/web/api/document/execcommand/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: e593d32ad2a2fde33cfd4d4d71b152efdc371f8e
 ---
 
-{{ApiRef("DOM")}}{{deprecated_header}}
+{{ApiRef("DOM")}}
 
 > [!NOTE]
 > 雖然 `execCommand()` 方法已被棄用，但仍有一些有效的用例尚未有可行的替代方案。例如，與直接操作 DOM 不同，由 `execCommand()` 執行的修改會保留撤銷緩衝區（編輯歷史）。對於這些用例，你仍然可以使用此方法，但請進行測試以確保跨瀏覽器相容性，例如使用 {{domxref("document.queryCommandSupported()")}}。

--- a/files/zh-tw/web/api/element/clientwidth/index.md
+++ b/files/zh-tw/web/api/element/clientwidth/index.md
@@ -3,7 +3,7 @@ title: Document.width
 slug: Web/API/Element/clientWidth
 ---
 
-{{APIRef("DOM")}} {{deprecated_header}}
+{{APIRef("DOM")}}
 
 > [!NOTE]
 > 從 Gecko 6.0 開始， `document.width` 將不再被支援。取而代之的是 `document.body.clientWidth`。請參照：{{domxref("element.clientWidth")}}.

--- a/files/zh-tw/web/api/file/name/index.md
+++ b/files/zh-tw/web/api/file/name/index.md
@@ -5,8 +5,6 @@ slug: Web/API/File/name
 
 {{APIRef("File API")}}{{non-standard_header}}
 
-{{deprecated_header(7.0)}}
-
 ## 總覽
 
 回傳檔案名稱，基於安全因素，檔案路徑不包含這個屬性。

--- a/files/zh-tw/web/api/performance/timing/index.md
+++ b/files/zh-tw/web/api/performance/timing/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: b25d8774aa7bcc6a053e26cf804ad454f51e134b
 ---
 
-{{APIRef("Performance API")}}{{deprecated_header}}
+{{APIRef("Performance API")}}
 
 遺留的 **`Performance.timing`** 唯讀屬性傳回一個包含了效能與時間延遲相關的資訊的 {{domxref("PerformanceTiming")}} 物件。
 

--- a/files/zh-tw/web/api/window/orientationchange_event/index.md
+++ b/files/zh-tw/web/api/window/orientationchange_event/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: f5e710f5c620c8d3c8b179f3b062d6bbdc8389ec
 ---
 
-{{APIRef}}{{Deprecated_Header}}
+{{APIRef}}
 
 當裝置的方向改變時，會觸發 `orientationchange` 事件。
 

--- a/files/zh-tw/web/css/reference/properties/clip/index.md
+++ b/files/zh-tw/web/css/reference/properties/clip/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 758ddcdfb06f53955fa3c05dd32e7e4e53fd3009
 ---
 
-{{Deprecated_Header}}
-
 > [!WARNING]
 > 若有可能，建議作者使用較新的 {{cssxref("clip-path")}} 屬性來取代。
 

--- a/files/zh-tw/web/html/reference/elements/acronym/index.md
+++ b/files/zh-tw/web/html/reference/elements/acronym/index.md
@@ -3,8 +3,6 @@ title: <acronym>
 slug: Web/HTML/Reference/Elements/acronym
 ---
 
-{{deprecated_header}}
-
 **`<acronym>`** [HTML](/zh-TW/docs/Web/HTML) 元素允許作者清楚地指示一系列字元，這些字元構成一個詞的縮寫或簡稱。
 
 > [!WARNING]

--- a/files/zh-tw/web/html/reference/elements/big/index.md
+++ b/files/zh-tw/web/html/reference/elements/big/index.md
@@ -3,8 +3,6 @@ title: <big>：更大文字元素
 slug: Web/HTML/Reference/Elements/big
 ---
 
-{{deprecated_header}}
-
 **`<big>`** [HTML](/zh-TW/docs/Web/HTML) 廢棄的元素會將所包含的文字呈現為比周圍文字大一個級別的字體大小（例如 `medium` 變為 `large`）。該大小限制在瀏覽器允許的最大字體大小之內。
 
 > [!WARNING]

--- a/files/zh-tw/web/html/reference/elements/center/index.md
+++ b/files/zh-tw/web/html/reference/elements/center/index.md
@@ -3,8 +3,6 @@ title: <center>：中央對齊文字元素
 slug: Web/HTML/Reference/Elements/center
 ---
 
-{{deprecated_header}}
-
 **`<center>`** [HTML](/zh-TW/docs/Web/HTML) 元素是一個[區塊級元素](/zh-TW/docs/Glossary/Block-level_content)，它將其區塊級或內聯內容在其包含元素中水平居中顯示。通常，容器是 {{HTMLElement("body")}}，但不是必需的。
 
 在 HTML 4（和 XHTML 1）中，此標籤已被棄用，取而代之的是 [CSS](/zh-TW/docs/Web/CSS) 的 {{Cssxref("text-align")}} 屬性，可以應用於 {{HTMLElement("div")}} 元素或個別的 {{HTMLElement("p")}}。要將區塊居中，請使用其他 CSS 屬性，如 {{Cssxref("margin-left")}} 和 {{Cssxref("margin-right")}}，並將它們設置為 `auto`（或將 {{Cssxref("margin")}} 設置為 `0 auto`）。

--- a/files/zh-tw/web/html/reference/elements/dir/index.md
+++ b/files/zh-tw/web/html/reference/elements/dir/index.md
@@ -3,8 +3,6 @@ title: <dir>：目錄元素
 slug: Web/HTML/Reference/Elements/dir
 ---
 
-{{Deprecated_Header}}
-
 **`<dir>`** [HTML](/zh-TW/docs/Web/HTML) 元素被用來作為文件和/或資料夾的目錄容器，可能會由{{Glossary("user agent", "使用者代理")}}應用樣式和圖示。請不要使用這個已過時的元素；相反地，你應該使用 {{HTMLElement("ul")}} 元素來建立列表，包括文件列表。
 
 > [!WARNING]

--- a/files/zh-tw/web/html/reference/elements/font/index.md
+++ b/files/zh-tw/web/html/reference/elements/font/index.md
@@ -3,8 +3,6 @@ title: <font>
 slug: Web/HTML/Reference/Elements/font
 ---
 
-{{Deprecated_Header}}
-
 **`<font>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於定義其內容的字型大小、顏色和字型。
 
 > [!WARNING]

--- a/files/zh-tw/web/html/reference/elements/frame/index.md
+++ b/files/zh-tw/web/html/reference/elements/frame/index.md
@@ -3,8 +3,6 @@ title: <frame>：框架元素
 slug: Web/HTML/Reference/Elements/frame
 ---
 
-{{Deprecated_Header}}
-
 **`<frame>`** [HTML](/zh-TW/docs/Web/HTML) 元素定義了另一個 HTML 文件可以顯示的特定區域。框架應該在 {{HTMLElement("frameset")}} 元素內使用。
 
 由於某些缺點，例如性能問題和對螢幕閱讀器用戶的可訪問性不足，不建議使用 `<frame>` 元素。取而代之的是使用 {{HTMLElement("iframe")}}。

--- a/files/zh-tw/web/html/reference/elements/frameset/index.md
+++ b/files/zh-tw/web/html/reference/elements/frameset/index.md
@@ -3,8 +3,6 @@ title: <frameset>
 slug: Web/HTML/Reference/Elements/frameset
 ---
 
-{{Deprecated_header}}
-
 **`<frameset>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於包含 {{HTMLElement("frame")}} 元素。
 
 > [!NOTE]

--- a/files/zh-tw/web/html/reference/elements/marquee/index.md
+++ b/files/zh-tw/web/html/reference/elements/marquee/index.md
@@ -3,8 +3,6 @@ title: <marquee>：捲動元素（已過時）
 slug: Web/HTML/Reference/Elements/marquee
 ---
 
-{{Deprecated_Header}}
-
 HTML `<marquee>` 元素用作插入一段文字的捲動區域。你可以透過屬性，控制文字在到達邊緣後的應對動作。
 
 <table class="properties">

--- a/files/zh-tw/web/html/reference/elements/rb/index.md
+++ b/files/zh-tw/web/html/reference/elements/rb/index.md
@@ -3,8 +3,6 @@ title: <rb>：Ruby 基本元素
 slug: Web/HTML/Reference/Elements/rb
 ---
 
-{{deprecated_header}}
-
 **`<rb>`** [HTML](/zh-TW/docs/Web/HTML) 元素用於定義 {{HTMLElement("ruby")}} 注釋的基本文字組件，即正在注釋的文字。每個 `<rb>` 元素應該包裹基本文字的每個獨立原子部分。
 
 ## 屬性

--- a/files/zh-tw/web/html/reference/elements/tt/index.md
+++ b/files/zh-tw/web/html/reference/elements/tt/index.md
@@ -3,8 +3,6 @@ title: <tt>：電報文字元素
 slug: Web/HTML/Reference/Elements/tt
 ---
 
-{{deprecated_header}}
-
 **`<tt>`** [HTML](/zh-TW/docs/Web/HTML) 元素創建內嵌文本，使用{{Glossary("user agent", "使用者代理")}}預設的等寬字體呈現。此元素是為了渲染文本而創建的，就像在固定寬度顯示器上顯示的那樣，例如電報機、僅文字螢幕或列印機。
 
 **非比例**、**等寬**和**等寬字型**是可互換使用的術語，具有相同的一般含義：它們描述了所有字符寬度相同的字體。

--- a/files/zh-tw/web/html/reference/elements/xmp/index.md
+++ b/files/zh-tw/web/html/reference/elements/xmp/index.md
@@ -3,8 +3,6 @@ title: <xmp>
 slug: Web/HTML/Reference/Elements/xmp
 ---
 
-{{deprecated_header}}
-
 **`<xmp>`** [HTML](/zh-TW/docs/Web/HTML) 元素呈現開始和結束標籤之間的文本，而不解釋其中的 HTML，並使用等寬字體。HTML2 規範建議應該以足夠寬的方式呈現，以允許每行 80 個字符。
 
 > [!NOTE]

--- a/files/zh-tw/web/http/reference/status/102/index.md
+++ b/files/zh-tw/web/http/reference/status/102/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: ad5b5e31f81795d692e66dadb7818ba8b220ad15
 ---
 
-{{deprecated_header}}
-
 HTTP **`102 Processing`** [資訊回應](/zh-TW/docs/Web/HTTP/Reference/Status#資訊回應)狀態碼表示伺服器已收到完整請求，且正在處理中。只有當伺服器預期請求需要花費較長時間時，才會傳送此狀態碼。
 
 > [!NOTE]


### PR DESCRIPTION
### Description

Remove all `{{deprecated_header}}` macro calls from zh-tw (22 files).

### Motivation

The macro is being removed from en-US and will then be removed from Rari. Rari generates the banner itself when web-features marks the feature as discouraged, or when the source page has `status: deprecated` and a slug under `Web/` or `WebAssembly/`. Translated pages copy `status` and `browser-compat` from their en-US source page (`copy_meta_from_super`), so the banner survives.

### Additional details

Audited every file against web-features and its en-US source page: 16 keep the banner, and 6 have no banner but either show no deprecation in en-US either or already carry the translated note. None loses its deprecation signal.

Escaped mentions (`\{{Deprecated_Header}}`) under `mdn/writing_guidelines/` stay; rewriting that prose belongs to a re-sync with en-US, which dropped the macro from those pages entirely. The two `page_types` templates drop it from their banner line so contributors no longer copy it.

Worth a look:

- `web/api/canvas_api/tutorial/drawing_text`: the call flagged the `mozDrawText()` and `mozMeasureText()` sections, both long gone from en-US.
- `web/http/reference/status/102`: the banner depends on the `status: deprecated` that mdn/content#45500 adds to en-US.

### Related issues and pull requests

Related to mdn/content#45500, which removes the last calls from en-US.
