### PR TITLE
fix(es): remove `{{deprecated_header}}` macro calls

### DIFF
--- a/files/es/mdn/writing_guidelines/page_structures/feature_status/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/feature_status/index.md
@@ -56,7 +56,6 @@ Las siguientes macros se utilizan para renderizar los banners de estado en los e
 
 - `\{{Deprecated_Header}}`
   - : Para el estado `deprecated`. Genera un banner de **Estado obsoleto**:
-    {{deprecated_header}}
 
 - `\{{SeeCompatTable}}`
   - : Para el estado `experimental`. Genera un banner de **Estado experimental**:

--- a/files/es/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -233,7 +233,7 @@ También puedes usarlas para marcar una sección en una página.
 - [`Non-standard_Header`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs): `\{{Non-standard_Header}}` {{Non-standard_Header}}
 - [`SeeCompatTable`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs) se usa en páginas que documentan [características experimentales](/es/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
   Ejemplo: `\{{SeeCompatTable}}` {{SeeCompatTable}}
-- [`Deprecated_Header`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs): `\{{Deprecated_Header}}` {{Deprecated_Header}}
+- [`Deprecated_Header`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs): `\{{Deprecated_Header}}`
 - [`SecureContext_Header`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs).
   Debe usarse en páginas principales, como páginas de interfaz, páginas de descripción general de la API y puntos de entrada de la API (por ejemplo, `navigator.xyz`), pero normalmente no en subpáginas como páginas de métodos y propiedades.
   Ejemplo: `\{{SecureContext_Header}}` {{SecureContext_Header}}

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
@@ -79,7 +79,7 @@ l10n:
 >
 > _Recuerde eliminar toda esta nota explicativa antes de publicar._
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 Comience el contenido en la página con un párrafo introductorio — comience nombrando el constructor y diciendo qué hace.
 Idealmente, esto debería ser una o dos frases cortas.

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
@@ -88,7 +88,7 @@ l10n:
 >
 > _Recuerda eliminar toda esta nota explicativa antes de publicar._
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 Comienza el contenido de la página con un párrafo introductorio: empieza nombrando el evento, indicando a qué interfaz pertenece y explicando qué hace.
 Lo ideal es que sean una o dos frases breves.

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
@@ -94,7 +94,7 @@ l10n:
 >
 > _Recuerda eliminar toda esta nota explicativa antes de publicar_
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 Comienza el contenido de la página con un párrafo introductorio: comienza nombrando la API y explicando qué hace. Idealmente, debería ser de una o dos oraciones breves.
 

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
@@ -82,7 +82,7 @@ l10n:
 >
 > _Recuerda eliminar toda esta nota explicativa antes de publicar._
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 Comienza el contenido de la página con un párrafo introductorio: empieza nombrando el método, indicando a qué interfaz pertenece y explicando qué hace.
 Lo ideal es que sean una o dos frases breves. Puedes copiar la mayor parte de este texto del resumen del método en la página de referencia de la API correspondiente.

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -83,7 +83,7 @@ l10n:
 >
 > _Recuerda eliminar toda esta nota explicativa antes de publicarla._
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 La propiedad **`NameOfTheProperty`** [de solo lectura] de la interfaz \{{domxref("NameOfTheParentInterface")}} _\<proporciona un resumen conciso del comportamiento\>_.
 

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
@@ -67,7 +67,7 @@ l10n:
 >
 > _Recuerda eliminar toda esta nota explicativa antes de publicar._
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 El párrafo de resumen: comienza nombrando la interfaz, indicando a qué API pertenece y qué hace. Idealmente debería ser una o dos frases cortas. Puedes copiar gran parte de esto desde el resumen de la interfaz en la página de aterrizaje de la API correspondiente.
 

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
@@ -73,7 +73,7 @@ l10n:
 >
 > _Recuerda eliminar este bloque de notas antes de publicar._
 
-{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SeeCompatTable}}{{Non-standard_Header}}
 
 Comienza el contenido de la página con un párrafo introductorio que nombre la función y explique qué hace. Idealmente, debería ser una o dos frases cortas.
 

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -76,7 +76,7 @@ l10n:
 >
 > _Recuerda eliminar este bloque de notas antes de publicar._
 
-{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SeeCompatTable}}{{Non-standard_Header}}
 
 Comienza el contenido de la página con un párrafo introductorio que nombre la propiedad y explique qué hace. Idealmente, debería ser una o dos frases cortas.
 

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
@@ -76,7 +76,7 @@ l10n:
 >
 > _Recuerda eliminar toda esta nota explicativa antes de publicar_
 
-{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SeeCompatTable}}{{Non-standard_Header}}
 
 Párrafo de resumen: comienza nombrando el selector y explicando qué hace. Lo ideal es que sea una o dos frases cortas.
 

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/html_attribute_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/html_attribute_page_template/index.md
@@ -71,7 +71,7 @@ Ten en cuenta que la mayoría de los atributos específicos no necesitan artícu
 >
 > _Recuerda eliminar toda esta nota explicativa antes de publicar._
 >
-> {{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+> {{SeeCompatTable}}{{Non-standard_Header}}
 >
 > Comienza presentando al lector el atributo y su uso.
 > Por ejemplo: El **`nombre-del-atributo`** [atributo global](/es/docs/Web/HTML/Reference/Global_attributes) describe o manipula [insertar descripción de uso].

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
@@ -66,7 +66,7 @@ l10n:
 >
 > _Recuerda eliminar toda esta nota explicativa antes de publicar._
 
-{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SeeCompatTable}}{{Non-standard_Header}}
 
 El elemento [HTML](/es/docs/Web/HTML) **`<insertar_el_nombre_del_elemento>`** hace _(insertar un párrafo de resumen nombrando el elemento y diciendo qué hace, idealmente una o dos frases cortas)_.
 

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
@@ -68,7 +68,7 @@ l10n:
 >
 > _Recuerda eliminar toda esta nota explicativa antes de publicar._
 
-{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SeeCompatTable}}{{Non-standard_Header}}
 
 La primera frase de la página debe seguir este formato:
 

--- a/files/es/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
@@ -69,7 +69,7 @@ l10n:
 >
 > _Recuerda eliminar toda esta nota explicativa antes de publicar_
 
-{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SeeCompatTable}}{{Non-standard_Header}}
 
 Comienza el contenido de la página con un párrafo introductorio — empieza nombrando el elemento y explicando qué hace.
 Lo ideal sería que sea de una o dos oraciones cortas.

--- a/files/es/orphaned/web/api/window/applicationcache/index.md
+++ b/files/es/orphaned/web/api/window/applicationcache/index.md
@@ -4,7 +4,7 @@ slug: orphaned/Web/API/Window/applicationCache
 original_slug: Web/API/Window/applicationCache
 ---
 
-{{APIRef}}{{Deprecated_Header}}{{Non-standard_Header}}{{securecontext_header}}
+{{APIRef}}{{Non-standard_Header}}{{securecontext_header}}
 
 > **Advertencia**: La memoria caché de la aplicación se está eliminando de la plataforma web. Considere usar [service workers](/es/docs/Web/API/Service_Worker_API) en su lugar.
 

--- a/files/es/web/api/batterymanager/charging/index.md
+++ b/files/es/web/api/batterymanager/charging/index.md
@@ -3,7 +3,7 @@ title: BatteryManager.charging
 slug: Web/API/BatteryManager/charging
 ---
 
-{{deprecated_header}}{{APIRef("Battery API")}}
+{{APIRef("Battery API")}}
 
 Un valor boleano indicando si está cargando o no la batería del dispositivo (está conectado el cargador).
 

--- a/files/es/web/api/batterymanager/chargingchange_event/index.md
+++ b/files/es/web/api/batterymanager/chargingchange_event/index.md
@@ -3,8 +3,6 @@ title: BatteryManager.onchargingchange
 slug: Web/API/BatteryManager/chargingchange_event
 ---
 
-{{deprecated_header}}
-
 {{APIRef("Battery API")}}
 
 Especifica un evento que escucha para recibir eventos [`chargingchange`](/es/docs/Web/Reference/Events/chargingchange). Estos eventos se producen cuando se actualiza el estado de la batería {{domxref("BatteryManager.charging", "charging")}}.

--- a/files/es/web/api/batterymanager/chargingtime/index.md
+++ b/files/es/web/api/batterymanager/chargingtime/index.md
@@ -3,8 +3,6 @@ title: BatteryManager.chargingTime
 slug: Web/API/BatteryManager/chargingTime
 ---
 
-{{deprecated_header}}
-
 {{APIRef("Battery API")}}
 
 Indica la cantidad de tiempo, en segundos, que faltan para que la batería esté completamente cargada.

--- a/files/es/web/api/batterymanager/dischargingtime/index.md
+++ b/files/es/web/api/batterymanager/dischargingtime/index.md
@@ -3,7 +3,7 @@ title: BatteryManager.dischargingTime
 slug: Web/API/BatteryManager/dischargingTime
 ---
 
-{{deprecated_header}}{{APIRef("Battery API")}}
+{{APIRef("Battery API")}}
 
 Indíca la cantidad de tiempo, en segundos,
 que restan antes de que la batería se descargue completamente.

--- a/files/es/web/api/batterymanager/index.md
+++ b/files/es/web/api/batterymanager/index.md
@@ -3,7 +3,7 @@ title: BatteryManager
 slug: Web/API/BatteryManager
 ---
 
-{{APIRef}}{{deprecated_header}}
+{{APIRef}}
 
 La interfaz `BatteryManager` de la [API del Estado de la Batería](/es/docs/Web/API/Battery_Status_API) proporciona la información del nivel de carga de la bateria del sistema. El método {{domxref("navigator.getBattery()")}} regresa una promesa que resuelve con la interfaz de `BatteryManager`.
 

--- a/files/es/web/api/batterymanager/levelchange_event/index.md
+++ b/files/es/web/api/batterymanager/levelchange_event/index.md
@@ -3,7 +3,7 @@ title: BatteryManager.onlevelchange
 slug: Web/API/BatteryManager/levelchange_event
 ---
 
-{{deprecated_header}} {{APIRef("Battery API")}}
+{{APIRef("Battery API")}}
 
 La propiedad **`BatteryManager.onlevelchange`** especifica un detector
 de eventos para recibir eventos de [`levelchange`](/es/docs/Web/Reference/Events/levelchange). Estos eventos ocurren

--- a/files/es/web/api/document/alinkcolor/index.md
+++ b/files/es/web/api/document/alinkcolor/index.md
@@ -3,7 +3,7 @@ title: document.alinkColor
 slug: Web/API/Document/alinkColor
 ---
 
-{{APIRef("DOM")}}{{ Deprecated_header }}
+{{APIRef("DOM")}}
 
 Devuelve o define el color que tendrán los vínculos activos en el cuerpo (elemento `body` del documento. Un vínculo está activo durante el tiempo entre los eventos `mousedown` (cuando se presiona el botón izquierdo del "mouse" sobre el vínculo) y `mouseup` (cuando se deja de presionar el vínculo al soltar el botón izquierdo del "mouse").
 

--- a/files/es/web/api/document/anchors/index.md
+++ b/files/es/web/api/document/anchors/index.md
@@ -3,7 +3,7 @@ title: document.anchors
 slug: Web/API/Document/anchors
 ---
 
-{{APIRef("DOM")}}{{deprecated_header}}La propiedad de solo lectura **`anchors`** de la interfaz {{domxref("Document")}} devuelve una lista de todas las anclas (anchors) del documento.
+{{APIRef("DOM")}}La propiedad de solo lectura **`anchors`** de la interfaz {{domxref("Document")}} devuelve una lista de todas las anclas (anchors) del documento.
 
 ## Sintaxis
 

--- a/files/es/web/api/document/applets/index.md
+++ b/files/es/web/api/document/applets/index.md
@@ -3,7 +3,7 @@ title: document.applets
 slug: Web/API/Document/applets
 ---
 
-{{APIRef("DOM")}}{{ Deprecated_header }}
+{{APIRef("DOM")}}
 
 ### Resumen
 

--- a/files/es/web/api/document/bgcolor/index.md
+++ b/files/es/web/api/document/bgcolor/index.md
@@ -3,7 +3,7 @@ title: document.bgColor
 slug: Web/API/Document/bgColor
 ---
 
-{{APIRef("DOM")}}{{ Deprecated_header }}
+{{APIRef("DOM")}}
 
 `bgColor` da/define el color de fondo (bgColor) del documento actual.
 

--- a/files/es/web/api/document/clear/index.md
+++ b/files/es/web/api/document/clear/index.md
@@ -3,7 +3,7 @@ title: Document.clear()
 slug: Web/API/Document/clear
 ---
 
-{{APIRef("DOM")}}{{ Deprecated_header }}
+{{APIRef("DOM")}}
 
 Método que se usa en versiones anterior a las 1.0 de Mozilla para para limpiar el documento completo.
 

--- a/files/es/web/api/document/execcommand/index.md
+++ b/files/es/web/api/document/execcommand/index.md
@@ -3,7 +3,7 @@ title: Document.execCommand()
 slug: Web/API/Document/execCommand
 ---
 
-{{ApiRef("DOM")}}{{ Deprecated_header }}
+{{ApiRef("DOM")}}
 
 ## Resumen
 

--- a/files/es/web/api/event/initevent/index.md
+++ b/files/es/web/api/event/initevent/index.md
@@ -3,7 +3,7 @@ title: event.initEvent
 slug: Web/API/Event/initEvent
 ---
 
-{{ ApiRef("DOM") }}{{deprecated_header}}
+{{ ApiRef("DOM") }}
 
 ### Resumen
 

--- a/files/es/web/api/file/lastmodifieddate/index.md
+++ b/files/es/web/api/file/lastmodifieddate/index.md
@@ -3,7 +3,7 @@ title: File.lastModifiedDate
 slug: Web/API/File/lastModifiedDate
 ---
 
-{{APIRef("File API") }} {{deprecated_header}}
+{{APIRef("File API") }}
 
 La propiedad de solo lectura **`File.lastModifiedDate`** retorna la fecha de ultima modificación del archivo. Archivos sin una ultima fecha de modificación conocida retornan la fecha actual.
 

--- a/files/es/web/api/htmldialogelement/showmodal/index.md
+++ b/files/es/web/api/htmldialogelement/showmodal/index.md
@@ -4,7 +4,7 @@ slug: Web/API/HTMLDialogElement/showModal
 original_slug: Web/API/Window/showModalDialog
 ---
 
-{{ deprecated_header }}{{APIRef}}
+{{APIRef}}
 
 El método **`Window.showModalDialog()`** crea y visualiza una caja de diálogo modal, conteniendo el documento HTML especificado.
 

--- a/files/es/web/api/htmltableelement/align/index.md
+++ b/files/es/web/api/htmltableelement/align/index.md
@@ -3,7 +3,7 @@ title: HTMLTableElement.align
 slug: Web/API/HTMLTableElement/align
 ---
 
-{{APIRef("HTML DOM")}}{{deprecated_header}}
+{{APIRef("HTML DOM")}}
 
 La propiedad **`HTMLTableElement.align`** representa la alineación de la tabla.
 

--- a/files/es/web/api/idbcursor/index.md
+++ b/files/es/web/api/idbcursor/index.md
@@ -42,8 +42,6 @@ Puede tener un número ilimitado de cursores al mismo tiempo. Siempre se obtiene
 
 ## Constants
 
-{{ deprecated_header(13) }}
-
 > [!WARNING]
 > These constants are no longer available — they were removed in Gecko 25. You should use the string constants directly instead. ([Error 891944 en Firefox](https://bugzil.la/891944))
 

--- a/files/es/web/api/mouseevent/initmouseevent/index.md
+++ b/files/es/web/api/mouseevent/initmouseevent/index.md
@@ -3,8 +3,6 @@ title: event.initMouseEvent
 slug: Web/API/MouseEvent/initMouseEvent
 ---
 
-{{Deprecated_Header}}
-
 {{APIRef("UI Events")}}
 
 > [!NOTE]

--- a/files/es/web/api/node/issamenode/index.md
+++ b/files/es/web/api/node/issamenode/index.md
@@ -3,7 +3,7 @@ title: Node.isSameNode()
 slug: Web/API/Node/isSameNode
 ---
 
-{{APIRef("DOM")}} {{Deprecated_Header}}
+{{APIRef("DOM")}}
 **`Node.isSameNode()`** comprueba si dos nodos son iguales, es decir si hacen referencia al mismo objecto.
 
 > [!WARNING]

--- a/files/es/web/api/performance/timing/index.md
+++ b/files/es/web/api/performance/timing/index.md
@@ -3,7 +3,7 @@ title: Performance.timing
 slug: Web/API/Performance/timing
 ---
 
-{{APIRef("Navigation Timing")}}{{deprecated_header}}
+{{APIRef("Navigation Timing")}}
 
 > [!WARNING]
 > Esta propiedad está deprecada en [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Por favor usa {{domxref("Performance.timeOrigin")}} en vez esta..

--- a/files/es/web/css/reference/properties/clip/index.md
+++ b/files/es/web/css/reference/properties/clip/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Reference/Properties/clip
 original_slug: Web/CSS/clip
 ---
 
-{{deprecated_header}}
-
 ## Resumen
 
 La propiedad de CSS `clip` define qué porción de un elemento es visible. La propiedad `clip` se aplica solamente sobre elementos con {{ cssxref("position","position:absolute") }} o {{cssxref("position", "position:fixed")}}.

--- a/files/es/web/html/reference/elements/center/index.md
+++ b/files/es/web/html/reference/elements/center/index.md
@@ -4,7 +4,7 @@ slug: Web/HTML/Reference/Elements/center
 original_slug: Web/HTML/Element/center
 ---
 
-{{HTMLSidebar}}{{Deprecated_Header}}
+{{HTMLSidebar}}
 
 ### Definición
 

--- a/files/es/web/html/reference/elements/marquee/index.md
+++ b/files/es/web/html/reference/elements/marquee/index.md
@@ -4,7 +4,7 @@ slug: Web/HTML/Reference/Elements/marquee
 original_slug: Web/HTML/Element/marquee
 ---
 
-{{HTMLSidebar}}{{Deprecated_Header}}
+{{HTMLSidebar}}
 
 ## Resumen
 

--- a/files/es/web/html/reference/elements/param/index.md
+++ b/files/es/web/html/reference/elements/param/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: 942a529383ee7ee3996fb234187641c08935f3ff
 ---
 
-{{HTMLSidebar}}{{Deprecated_Header}}
+{{HTMLSidebar}}
 
 El elemento [HTML](/es/docs/Web/HTML) **`<param>`** define los parámetros para un elemento {{HTMLElement("object")}}.
 

--- a/files/es/web/html/reference/elements/xmp/index.md
+++ b/files/es/web/html/reference/elements/xmp/index.md
@@ -4,8 +4,6 @@ slug: Web/HTML/Reference/Elements/xmp
 original_slug: Web/HTML/Element/xmp
 ---
 
-{{Deprecated_Header}}
-
 ## Resumen
 
 El elemento HTML example element \<xmp> dibuja texto entre las etiquetas de inicio y fin sin interpretar el HTML que se encuentra en medio y lo muestra usando un tipo de letra monoespaciada . La especificación de HTML2 recomendaba que que esta debería de ser dibujada suficientemente amplia para permitir 80 caracteres por línea .

--- a/files/es/web/javascript/reference/global_objects/escape/index.md
+++ b/files/es/web/javascript/reference/global_objects/escape/index.md
@@ -3,7 +3,7 @@ title: escape()
 slug: Web/JavaScript/Reference/Global_Objects/escape
 ---
 
-{{jsSidebar("Objects")}}{{Deprecated_header}}
+{{jsSidebar("Objects")}}
 
 > [!WARNING]
 > `escape()` no esta estrictamente en desuso("eliminada por los estándares Web"), esta definida en [Anexo B](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-additional-ecmascript-features-for-web-browsers) El estándar ECMA-262 , cuya introducción establece:

--- a/files/es/web/javascript/reference/global_objects/function/arguments/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/arguments/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: 70f09675ddcfc75a3bb66d2dce4cf82738948a37
 ---
 
-{{JSRef}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{JSRef}}{{Non-standard_Header}}
 
 > [!NOTE]
 > La propiedad `arguments` de los objetos {{jsxref("Function")}} está en desuso. La forma recomendada de acceder al objeto `arguments` es hacer referencia a la variable {{jsxref("Functions/arguments", "arguments") }} disponible dentro de las funciones.

--- a/files/es/web/javascript/reference/global_objects/regexp/compile/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/compile/index.md
@@ -3,7 +3,7 @@ title: RegExp.prototype.compile()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/compile
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 El método obsoleto **`compile()`** es usado para (re-)compilar una expresión regular durante la ejecución del script. Es básicamente lo mismo que el constructor `RegExp`.
 

--- a/files/es/web/javascript/reference/global_objects/string/big/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/big/index.md
@@ -5,8 +5,6 @@ slug: Web/JavaScript/Reference/Global_Objects/String/big
 
 {{JSRef}}
 
-{{deprecated_header}}
-
 ## Resumen
 
 Provoca que una cadena sea mostrada con un tamaño de fuente grade, como si estuviese en una etiqueta {{HTMLElement("big")}}.

--- a/files/es/web/javascript/reference/global_objects/string/blink/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/blink/index.md
@@ -5,8 +5,6 @@ slug: Web/JavaScript/Reference/Global_Objects/String/blink
 
 {{JSRef}}
 
-{{deprecated_header}}
-
 ## Resumen
 
 Causa que una cadena parpadee como si estuviese en una etiqueta `<blink>`.

--- a/files/es/web/javascript/reference/global_objects/string/bold/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/bold/index.md
@@ -5,8 +5,6 @@ slug: Web/JavaScript/Reference/Global_Objects/String/bold
 
 {{JSRef}}
 
-{{Deprecated_header}}
-
 ## Resumen
 
 Provoca que una cadena se muestre en negrita como si estuviera en una etiqueta {{HTMLElement("b")}}.

--- a/files/es/web/javascript/reference/global_objects/string/fixed/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fixed/index.md
@@ -5,8 +5,6 @@ slug: Web/JavaScript/Reference/Global_Objects/String/fixed
 
 {{JSRef}}
 
-{{deprecated_header}}
-
 ## Resumen
 
 Causa que una cadena se muestre con una fuente de ancho fijo, como si estuviesde dentro de una etiqueta {{HTMLElement("tt")}}.

--- a/files/es/web/javascript/reference/global_objects/string/fontcolor/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fontcolor/index.md
@@ -3,7 +3,7 @@ title: String.prototype.fontcolor()
 slug: Web/JavaScript/Reference/Global_Objects/String/fontcolor
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 El método **`fontcolor()`** crea {{HTMLElement("font")}} elemento HTML que cambia el color de la cadena.
 

--- a/files/es/web/javascript/reference/global_objects/string/fontsize/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fontsize/index.md
@@ -3,7 +3,7 @@ title: String.prototype.fontsize()
 slug: Web/JavaScript/Reference/Global_Objects/String/fontsize
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 El método **`fontsize()`** crea {{HTMLElement("font")}} elemento HTML que muestra una cadena con el tamaño especificado.
 

--- a/files/es/web/javascript/reference/global_objects/string/italics/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/italics/index.md
@@ -5,8 +5,6 @@ slug: Web/JavaScript/Reference/Global_Objects/String/italics
 
 {{JSRef}}
 
-{{deprecated_header}}
-
 ## Resumen
 
 Provoca que una cadena ponga en cursiva, como si estuviese dentro de una etiqueta {{HTMLElement("i")}}.

--- a/files/es/web/javascript/reference/global_objects/string/small/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/small/index.md
@@ -5,8 +5,6 @@ slug: Web/JavaScript/Reference/Global_Objects/String/small
 
 {{JSRef}}
 
-{{deprecated_header}}
-
 ## Resumen
 
 Causa que una cadena se muestra con una fuente pequeña, como si estuviese dentro de una etiqueta {{HTMLElement("small")}}.

--- a/files/es/web/javascript/reference/global_objects/string/strike/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/strike/index.md
@@ -5,8 +5,6 @@ slug: Web/JavaScript/Reference/Global_Objects/String/strike
 
 {{JSRef}}
 
-{{deprecated_header}}
-
 ## Resumen
 
 Causa que una cadena se muestre como texto tachado, como si estuviese dentro de una etiqueta {{HTMLElement("strike")}}.

--- a/files/es/web/javascript/reference/global_objects/unescape/index.md
+++ b/files/es/web/javascript/reference/global_objects/unescape/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: c4e3558ee1045803df4a685f11f94dca273cd5fe
 ---
 
-{{jsSidebar("Objects")}}{{Deprecated_Header}}
+{{jsSidebar("Objects")}}
 
 > [!NOTE]
 > `unescape()` no es una función estándar implementada por los navegadores y solo se estandarizó para la compatibilidad entre motores. No es necesario que todos los motores de JavaScript lo implementen y es posible que no funcione en todas partes. Use {{jsxref("decodeURIComponent()")}} o {{jsxref("decodeURI()")}} si es posible.


### PR DESCRIPTION
### Description

Remove all `{{deprecated_header}}` macro calls from es (54 files).

### Motivation

The macro is being removed from en-US and will then be removed from Rari. Rari generates the banner itself when web-features marks the feature as discouraged, or when the source page has `status: deprecated` and a slug under `Web/` or `WebAssembly/`. Translated pages copy `status` and `browser-compat` from their en-US source page (`copy_meta_from_super`), so the banner survives.

### Additional details

Audited every file against web-features and its en-US source page: 29 keep the banner, 24 have no banner but either show no deprecation in en-US either (stale calls, for example `web/api/batterymanager/*` and `web/api/htmldialogelement/showmodal`) or already carry the translated note, and 1 has no en-US counterpart. None loses its deprecation signal.

Escaped mentions (`\{{Deprecated_Header}}`) under `mdn/writing_guidelines/` stay; rewriting that prose belongs to a re-sync with en-US, which dropped the macro from those pages entirely. The 13 `page_structures/page_types/*` templates drop it from their banner line so contributors no longer copy it.

Worth a look:

- `orphaned/web/api/window/applicationcache` has no en-US counterpart and so no metadata to fall back on; removed for consistency.
- `web/api/document/anchors`: the call sat between `{{APIRef("DOM")}}` and the intro text.
- `web/api/idbcursor` passed an obsolete `(13)` argument.

### Related issues and pull requests

Related to mdn/content#45500, which removes the last calls from en-US.
