### PR TITLE
fix(pt-br): remove `{{deprecated_header}}` macro calls

### DIFF
--- a/files/pt-br/conflicting/web/api/htmlslotelement/index.md
+++ b/files/pt-br/conflicting/web/api/htmlslotelement/index.md
@@ -5,8 +5,6 @@ slug: conflicting/Web/API/HTMLSlotElement
 
 {{ APIRef("Web Components") }}
 
-{{Deprecated_header}}
-
 A interface do **`HTMLContentElement`** representa um {{HTMLElement("content")}} Element HTML, ao qual é usado em [Shadow DOM](/pt-BR/docs/Web/API/Web_components/Using_shadow_DOM).
 
 ## Propriedades

--- a/files/pt-br/conflicting/web/api/xmldocument/index.md
+++ b/files/pt-br/conflicting/web/api/xmldocument/index.md
@@ -3,7 +3,7 @@ title: Document.async
 slug: conflicting/Web/API/XMLDocument
 ---
 
-{{APIRef("DOM")}}{{Deprecated_header}} {{Non-standard_header}}
+{{APIRef("DOM")}} {{Non-standard_header}}
 
 `document.async` pode ser configurado para indicar se uma chamada {{domxref ("document.load")}} deve ser uma solicitação assíncrona ou síncrona. True é o valor padrão, indicando que os documentos devem ser carregados de forma assíncrona.
 

--- a/files/pt-br/conflicting/web/http/headers/expect-ct/index.md
+++ b/files/pt-br/conflicting/web/http/headers/expect-ct/index.md
@@ -3,8 +3,6 @@ title: Public-Key-Pins
 slug: conflicting/Web/HTTP/Headers/Expect-CT
 ---
 
-{{deprecated_header}}
-
 > [!NOTE]
 > O mecanismo de Fixação de Chaves Públicas (Public Key Pinning) foi depreciado em favor do [Certificado de Transparência](/pt-BR/docs/Web/Security/Certificate_Transparency) e do cabeçalho {{HTTPHeader("Expect-CT")}}.
 

--- a/files/pt-br/conflicting/web/http/headers/expect-ct_63e560324d2c47190db4456d746ba07b/index.md
+++ b/files/pt-br/conflicting/web/http/headers/expect-ct_63e560324d2c47190db4456d746ba07b/index.md
@@ -3,8 +3,6 @@ title: Public-Key-Pins-Report-Only
 slug: conflicting/Web/HTTP/Headers/Expect-CT_63e560324d2c47190db4456d746ba07b
 ---
 
-{{deprecated_header}}
-
 > [!NOTE]
 > O mecanismo de Fixação de Chave Pública (_Public Key Pinning_) foi depreciado em favor do [Certificado de Transparência (Certificate Transparency)](/pt-BR/docs/Web/Security/Certificate_Transparency) e do cabeçalho {{HTTPHeader("Expect-CT")}}.
 

--- a/files/pt-br/conflicting/web/javascript/reference/global_objects/date/toutcstring/index.md
+++ b/files/pt-br/conflicting/web/javascript/reference/global_objects/date/toutcstring/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.toGMTString()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Date/toUTCString
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método **`toGMTString()`** converte a data para uma cadeia de caracteres (_string)_, usando as convenções de Internet para o Horário de Greenwich (GMT). O formato exato do valor retornado por `toGMTString()` varia de acordo com plataforma e navegador, em geral ele deve representar uma _string_ legível para um ser humano.
 

--- a/files/pt-br/conflicting/web/svg/element/animate/index.md
+++ b/files/pt-br/conflicting/web/svg/element/animate/index.md
@@ -3,7 +3,7 @@ title: animateColor
 slug: conflicting/Web/SVG/Element/animate
 ---
 
-{{SVGRef}}{{deprecated_header}}
+{{SVGRef}}
 
 > [!WARNING]
 > Este elemento ficou obsoleto na Segunda Edição do SVG 1.1 e deverá ser removida das futuras versões do SVG. Este elemento fornece recursos ainda não disponíveis utilizando o elemento {{ SVGElement("animate") }} e não está implementado no Firefox e no Internet Explorer. Os autores devem utilizar o elemento {{ SVGElement("animate") }} em seu lugar.

--- a/files/pt-br/web/api/document/alinkcolor/index.md
+++ b/files/pt-br/web/api/document/alinkcolor/index.md
@@ -3,7 +3,7 @@ title: Document.alinkColor
 slug: Web/API/Document/alinkColor
 ---
 
-{{APIRef("DOM")}}{{Deprecated_header}}
+{{APIRef("DOM")}}
 
 Retorna ou define a cor de um link ativo no corpo do documento. Um link está ativo durante o tempo entre os eventos `mousedown` e `mouseup`.
 

--- a/files/pt-br/web/api/document/anchors/index.md
+++ b/files/pt-br/web/api/document/anchors/index.md
@@ -5,8 +5,6 @@ slug: Web/API/Document/anchors
 
 {{APIRef("DOM")}}
 
-{{deprecated_header}}
-
 `anchors` retorna uma lista de todas as âncoras no documento.
 
 ## Sintaxe

--- a/files/pt-br/web/api/document/bgcolor/index.md
+++ b/files/pt-br/web/api/document/bgcolor/index.md
@@ -3,7 +3,7 @@ title: Document.bgColor
 slug: Web/API/Document/bgColor
 ---
 
-{{APIRef("DOM")}} {{ Deprecated_header }}
+{{APIRef("DOM")}}
 
 A propriedade obsoleta `bgColor` obtém ou atribue a cor de fundo do documento atual.
 

--- a/files/pt-br/web/api/document/fullscreen/index.md
+++ b/files/pt-br/web/api/document/fullscreen/index.md
@@ -3,7 +3,7 @@ title: Document.fullscreen
 slug: Web/API/Document/fullscreen
 ---
 
-{{APIRef("Fullscreen API")}}{{Deprecated_Header}}
+{{APIRef("Fullscreen API")}}
 
 A propriedade de somente leitura da interface **`fullscreen`** retorna se o documento correspondente está mostrando conteúdo em modo de tela cheia (full-screen).
 

--- a/files/pt-br/web/api/event/initevent/index.md
+++ b/files/pt-br/web/api/event/initevent/index.md
@@ -3,7 +3,7 @@ title: Event.initEvent()
 slug: Web/API/Event/initEvent
 ---
 
-{{ ApiRef("DOM") }}{{deprecated_header}}
+{{ ApiRef("DOM") }}
 
 O método **`Event.initEvent()`** é usado para inicializar o valor de um {{ domxref("event") }} criado usando {{ domxref("Document.createEvent()") }}.
 

--- a/files/pt-br/web/api/navigator/getusermedia/index.md
+++ b/files/pt-br/web/api/navigator/getusermedia/index.md
@@ -3,7 +3,7 @@ title: navigator.getUserMedia
 slug: Web/API/Navigator/getUserMedia
 ---
 
-{{APIRef("Media Capture and Streams")}}{{deprecated_header}}
+{{APIRef("Media Capture and Streams")}}
 
 O método Navigator.getUserMedia() atualmente esta _deprecated_ (obsoleto), ele é responsável por pedir a permissão do usuário para usar até 1 dispositivo de entrada de vídeo (como câmera, ou tela compartilhada) e até 1 dispositivo de entrada de áudio (como o microfone) como fonte para o stream de mídia (pode ser representado por uma instância `MediaStream`).
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/getyear/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/getyear/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.getYear()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getYear
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 ## Resumo
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/setyear/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/date/setyear/index.md
@@ -3,7 +3,7 @@ title: Date.prototype.setYear()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setYear
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método **`setYear()`** atribui o ano para a data especificada de acordo com o horário local. Devido `setYear()` não colocar o anos cheios ("problema do ano 2000"), ele não é mais utilizado e foi substituído pelo método {{jsxref("Date.prototype.setFullYear()", "setFullYear()")}}.
 

--- a/files/pt-br/web/javascript/reference/global_objects/function/arguments/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/function/arguments/index.md
@@ -3,7 +3,7 @@ title: Function.arguments
 slug: Web/JavaScript/Reference/Global_Objects/Function/arguments
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 A propriedade **`function.arguments`** diz respeito a um objeto tipo array (array-like object) correspondente aos argumentos passados para uma função. Use somente a variável {{jsxref("Functions/arguments", "arguments")}} em vez disso.
 

--- a/files/pt-br/web/javascript/reference/global_objects/object/__lookupgetter__/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/object/__lookupgetter__/index.md
@@ -3,7 +3,7 @@ title: Object.prototype.__lookupGetter__()
 slug: Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método **`__lookupGetter__`** retorna a função limite como uma getter para a específica propriedade.
 

--- a/files/pt-br/web/javascript/reference/global_objects/object/__lookupsetter__/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/object/__lookupsetter__/index.md
@@ -3,7 +3,7 @@ title: Object.prototype.__lookupSetter__()
 slug: Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método **`__lookupSetter__`** retorna a função vinculada como _setter_ para a propriedade especificada.
 

--- a/files/pt-br/web/javascript/reference/global_objects/regexp/compile/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/regexp/compile/index.md
@@ -3,7 +3,7 @@ title: RegExp.prototype.compile()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/compile
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método **`compile()`** está depreciado, é usado para (re-)compilar uma expressão regular durante a execução de um script. É basicamente o mesmo que o construtor `RegExp`.
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/anchor/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/anchor/index.md
@@ -3,7 +3,7 @@ title: String.prototype.anchor()
 slug: Web/JavaScript/Reference/Global_Objects/String/anchor
 ---
 
-{{JSRef}} {{deprecated_header}}O método **`anchor()`** cria uma string começando com uma tag inicial `<a name="...">`, um texto e uma tag final `</a>`.
+{{JSRef}} O método **`anchor()`** cria uma string começando com uma tag inicial `<a name="...">`, um texto e uma tag final `</a>`.
 
 > [!WARNING]
 > Não use este método. Ao invés, use [DOM APIs](/pt-BR/docs/Web/API/Document_Object_Model). Além disso, a especificação HTML não permite mais que o elemento \<a> tenha um atributo **"name"**, portanto, esse método nem mesmo cria uma tag válida.

--- a/files/pt-br/web/javascript/reference/global_objects/string/big/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/big/index.md
@@ -3,7 +3,7 @@ title: String.prototype.big()
 slug: Web/JavaScript/Reference/Global_Objects/String/big
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método **big()** cria um elemento HTML [\<big>](/pt-BR/docs/Web/HTML/Reference/Elements/big) fazendo com que o texto dentro dele seja exibido uma uma fonte maior.
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/blink/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/blink/index.md
@@ -3,7 +3,7 @@ title: String.prototype.blink()
 slug: Web/JavaScript/Reference/Global_Objects/String/blink
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método **`blink()`** cria um elemento HTML [\<blink>](/pt-BR/docs/Web/HTML/Element/blink) que faz uma string piscar.
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/bold/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/bold/index.md
@@ -3,7 +3,7 @@ title: String.prototype.bold()
 slug: Web/JavaScript/Reference/Global_Objects/String/bold
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método **`bold()`** cria um elemento HTML [\<b>](/pt-BR/docs/Web/HTML/Reference/Elements/b) que faz com que uma string seja exibida em negrito.
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/fixed/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/fixed/index.md
@@ -3,7 +3,7 @@ title: String.prototype.fixed()
 slug: Web/JavaScript/Reference/Global_Objects/String/fixed
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método **`fixed()`** cria um elemento HTML [`<tt>`](/pt-BR/docs/Web/HTML/Element/tt) que faz com que uma string seja exibida em uma fonte de densidade fixa.
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/fontcolor/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/fontcolor/index.md
@@ -3,7 +3,7 @@ title: String.prototype.fontcolor()
 slug: Web/JavaScript/Reference/Global_Objects/String/fontcolor
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método `fontcolor()` cria um elemento HTML [\<font>](/pt-BR/docs/Web/HTML/Element/font) que faz com que uma string seja exibida na cor especificada.
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/fontsize/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/fontsize/index.md
@@ -3,7 +3,7 @@ title: String.prototype.fontsize()
 slug: Web/JavaScript/Reference/Global_Objects/String/fontsize
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método `fontsize()` cria um elemento HTML [\<font>](/pt-BR/docs/Web/HTML/Element/font) que faz com que uma string seja exibida no tamanho da fonte especificada.
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/italics/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/italics/index.md
@@ -3,7 +3,7 @@ title: String.prototype.italics()
 slug: Web/JavaScript/Reference/Global_Objects/String/italics
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método `italics()` cria um elemento HTML [`<i>`](/pt-BR/docs/Web/HTML/Reference/Elements/i) que faz com que uma string fique em itálico.
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/link/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/link/index.md
@@ -3,7 +3,7 @@ title: String.prototype.link()
 slug: Web/JavaScript/Reference/Global_Objects/String/link
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método `link()` cria uma string que representa o código para um elemento HTML [`<a>`](/pt-BR/docs/Web/HTML/Reference/Elements/a) a ser usado como um link de hipertexto para outro URL.
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/small/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/small/index.md
@@ -3,7 +3,7 @@ title: String.prototype.small()
 slug: Web/JavaScript/Reference/Global_Objects/String/small
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método `small()` cria um elemento HTML [`<small>`](/pt-BR/docs/Web/HTML/Element/small) que faz com que uma string seja exibida em uma fonte pequena.
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/strike/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/strike/index.md
@@ -3,7 +3,7 @@ title: String.prototype.strike()
 slug: Web/JavaScript/Reference/Global_Objects/String/strike
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método `strike()` cria um elemento HTML [`<strike>`](/pt-BR/docs/Web/HTML/Element/strike) que faz com que uma string seja exibida com o texto riscado.
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/sub/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/sub/index.md
@@ -3,7 +3,7 @@ title: String.prototype.sub()
 slug: Web/JavaScript/Reference/Global_Objects/String/sub
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método `sub()` cria um elemento HTML [`<sub>`](/pt-BR/docs/Web/HTML/Element/sub) que faz com que uma string seja exibida como subscrito (texto pequeno).
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/sup/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/sup/index.md
@@ -3,7 +3,7 @@ title: String.prototype.sup()
 slug: Web/JavaScript/Reference/Global_Objects/String/sup
 ---
 
-{{JSRef}} {{deprecated_header}}
+{{JSRef}}
 
 O método `sup()` cria um elemento HTML [`<sup>`](/pt-BR/docs/Web/HTML/Element/sup) que faz com que uma string seja exibida como sobrescrito.
 

--- a/files/pt-br/web/javascript/reference/global_objects/unescape/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/unescape/index.md
@@ -3,7 +3,7 @@ title: unescape()
 slug: Web/JavaScript/Reference/Global_Objects/unescape
 ---
 
-{{jsSidebar("Objects")}}{{Deprecated_header}}A função **unescape()** obsolta computa uma nova string na qual as sequencias hexadecimal são esquecidas com o caractere que representa. As sequências de escape podem ser introduzidas como funções {{jsxref("escape")}}. Porque a função 'unescape' está obsoleta, ao invez disso, use {{jsxref("decodeURI")}} ou {{jsxref("decodeURIComponent")}}.
+{{jsSidebar("Objects")}}A função **unescape()** obsolta computa uma nova string na qual as sequencias hexadecimal são esquecidas com o caractere que representa. As sequências de escape podem ser introduzidas como funções {{jsxref("escape")}}. Porque a função 'unescape' está obsoleta, ao invez disso, use {{jsxref("decodeURI")}} ou {{jsxref("decodeURIComponent")}}.
 
 > [!NOTE]
 > Não use `unescape` para decodificar URIs, use `decodeURI` ao invez disso.


### PR DESCRIPTION
### Description

Remove all `{{deprecated_header}}` macro calls from pt-br (32 files).

### Motivation

The macro is being removed from en-US and will then be removed from Rari. Rari generates the banner itself when web-features marks the feature as discouraged, or when the source page has `status: deprecated` and a slug under `Web/` or `WebAssembly/`. Translated pages copy `status` and `browser-compat` from their en-US source page (`copy_meta_from_super`), so the banner survives.

### Additional details

Audited every file against web-features and its en-US source page: 26 keep the banner, and 6 have no en-US counterpart. None loses its deprecation signal.

The six files without a counterpart live under `conflicting/` and are not published; the calls are removed there for consistency.

Worth a look:

- `web/javascript/reference/global_objects/string/anchor` and `web/javascript/reference/global_objects/unescape`: the call sat between the sidebar macro and the intro text; both keep prose saying the feature is obsolete.

### Related issues and pull requests

Related to mdn/content#45500, which removes the last calls from en-US.
