### PR TITLE
fix(zh-cn): add missing deprecation notes

### DIFF
--- a/files/zh-cn/web/api/webvr_api/concepts/index.md
+++ b/files/zh-cn/web/api/webvr_api/concepts/index.md
@@ -5,6 +5,9 @@ slug: Web/API/WebVR_API/Concepts
 
 {{APIRef("WebVR API")}}
 
+> [!NOTE]
+> WebVR API 已被 [WebXR API](/zh-CN/docs/Web/API/WebXR_Device_API) 取代。WebVR 从未被批准为标准，仅有极少数浏览器实现并默认启用，且支持的设备数量很少。
+
 这篇文章探讨了一些关于虚拟现实（VR）的概念及其背后的理论基础。如果你是一个进入这个领域的新手，在你深入学习相关代码知识前，非常有必要对于以下的话题做一定的了解。
 
 ## 关于 VR 的历史

--- a/files/zh-cn/web/mathml/reference/values/index.md
+++ b/files/zh-cn/web/mathml/reference/values/index.md
@@ -14,6 +14,9 @@ l10n:
 
 ## 旧版 MathML 长度
 
+> [!WARNING]
+> 这些长度已弃用，不再推荐使用。
+
 在 {{cssxref("length-percentage")}} 之外，MathML 曾经定义了自己的[用于描述长度的类型](https://www.w3.org/TR/MathML3/chapter2.html#type.length)。接受的值包括非零无单位长度值（例如 `5` 表示 `500%`）、以点结尾的数字（例如 `34.px`）或命名空间（例如 `thinmathspace`）。出于兼容性考虑，建议将非零无单位长度值替换为等效的 {{cssxref("percentage")}} 值，删除数字中不必要的点，并使用以下替代方案替换具名长度：
 
 ```plain

--- a/files/zh-cn/web/mathml/reference/values/index.md
+++ b/files/zh-cn/web/mathml/reference/values/index.md
@@ -15,7 +15,7 @@ l10n:
 ## 旧版 MathML 长度
 
 > [!WARNING]
-> 这些长度已弃用，不再推荐使用。
+> 这些长度值已弃用，不再推荐使用。
 
 在 {{cssxref("length-percentage")}} 之外，MathML 曾经定义了自己的[用于描述长度的类型](https://www.w3.org/TR/MathML3/chapter2.html#type.length)。接受的值包括非零无单位长度值（例如 `5` 表示 `500%`）、以点结尾的数字（例如 `34.px`）或命名空间（例如 `thinmathspace`）。出于兼容性考虑，建议将非零无单位长度值替换为等效的 {{cssxref("percentage")}} 值，删除数字中不必要的点，并使用以下替代方案替换具名长度：
 


### PR DESCRIPTION
### Description

Add the deprecation notes that en-US carries in prose to two zh-CN pages.

- `web/api/webvr_api/concepts`: the WebVR API is replaced by the WebXR API.
- `web/mathml/reference/values`: the legacy MathML lengths are deprecated.

### Motivation

Removing `{{deprecated_header}}` in #38239 leaves these two pages with no deprecation signal: neither en-US source page has `status: deprecated`, and web-features does not mark either feature as discouraged, so Rari generates no banner. en-US conveys the status in prose instead, which the translations lacked.

### Additional details

The WebVR wording follows the note already translated on the `Navigator.activeVRDisplays` page.

Across all 216 files in #38239, these were the only two where the deprecation would otherwise become invisible.

### Related issues and pull requests

**Depends on:** #38239.
