### PR TITLE
fix: remove obsolete numeric args from InheritanceDiagram macro

### DIFF
--- a/files/ru/web/api/htmlbuttonelement/index.md
+++ b/files/ru/web/api/htmlbuttonelement/index.md
@@ -7,7 +7,7 @@ slug: Web/API/HTMLButtonElement
 
 Интерфейс HTMLButtonElement предоставляет свойства и методы для управления элементами {{HTMLElement("button")}} (помимо обычного интерфейса {{domxref("HTMLElement")}}, он также доступен - по наследованию) .
 
-{{InheritanceDiagram(600, 120)}}
+{{InheritanceDiagram}}
 
 ## Свойства
 

--- a/files/ru/web/api/htmlscriptelement/index.md
+++ b/files/ru/web/api/htmlscriptelement/index.md
@@ -9,7 +9,7 @@ HTML-элементы {{HTMLElement("script")}} предоставляют **`HT
 
 JavaScript файлы должны обслуживаться с `application/javascript` [MIME type](/ru/docs/Web/HTTP/Guides/MIME_types), но браузеры снисходительны и блокируют их только, если скрипты обслуживаются с типом изображение (`image/*`), типом видео (`video/*`), типом аудио (`audio/*`), или `text/csv`. Если скрипт заблокирован, его элемент получает событие [`error`](/ru/docs/Web/API/HTMLElement/error_event); в противном случае, он получает событие [`success`](/ru/docs/Web/API/IDBRequest/success_event).
 
-{{InheritanceDiagram(600, 120)}}
+{{InheritanceDiagram}}
 
 ## Свойства
 

--- a/files/zh-cn/web/api/htmlmediaelement/index.md
+++ b/files/zh-cn/web/api/htmlmediaelement/index.md
@@ -7,7 +7,7 @@ slug: Web/API/HTMLMediaElement
 
 HTML 媒体元素接口在属性和方法中添加了 {{domxref("HTMLElement", "HTML 元素", "", 1)}}来支持基础的媒体相关的能力，就像音频和视频一样。{{domxref("HTMLVideoElement", "HTML 视频元素", "", 1)}}和{{domxref("HTMLAudioElement", "HTML 音频元素", "", 1)}}元素都继承自此接口。
 
-{{InheritanceDiagram(600, 180)}}
+{{InheritanceDiagram}}
 
 ## 特性
 


### PR DESCRIPTION
### Description

Fix `{{InheritanceDiagram}}` macro calls that passed obsolete `width, height` numeric arguments, causing content build validation to fail with "must be a string":

- `ru/web/api/htmlbuttonelement`
- `ru/web/api/htmlscriptelement`
- `zh-cn/web/api/htmlmediaelement`

### Motivation

Ensure these pages pass content validation; the macro no longer accepts numeric width/height arguments.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.