### PR TITLE
fix(fr): remove ExperimentalBadge macros

### DIFF
--- a/files/fr/web/api/performanceeventtiming/index.md
+++ b/files/fr/web/api/performanceeventtiming/index.md
@@ -46,18 +46,18 @@ L'interface `PerformanceEventTiming` des événements de l'`Event Timing API` fo
 
 ## Propriétés
 
-- [`PerformanceEventTiming.processingStart`](/fr/docs/Web/API/PerformanceEventTiming/processingStart) _lecture seule_ {{ExperimentalBadge}}
+- [`PerformanceEventTiming.processingStart`](/fr/docs/Web/API/PerformanceEventTiming/processingStart) _lecture seule_
   - : Retourne un [`DOMHighResTimeStamp`](/fr/docs/Web/API/DOMHighResTimeStamp) représentant l'heure à laquelle la diffusion des événements a commencé.
-- [`PerformanceEventTiming.processingEnd`](/fr/docs/Web/API/PerformanceEventTiming/processingEnd) _lecture seule_ {{ExperimentalBadge}}
+- [`PerformanceEventTiming.processingEnd`](/fr/docs/Web/API/PerformanceEventTiming/processingEnd) _lecture seule_
   - : Retourne un [`DOMHighResTimeStamp`](/fr/docs/Web/API/DOMHighResTimeStamp) représentant l'heure à laquelle la diffusion de l'événement s'est terminée.
-- [`PerformanceEventTiming.cancelable`](/fr/docs/Web/API/PerformanceEventTiming/cancelable) _lecture seule_ {{ExperimentalBadge}}
+- [`PerformanceEventTiming.cancelable`](/fr/docs/Web/API/PerformanceEventTiming/cancelable) _lecture seule_
   - : Retourne un [`Boolean`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Boolean) représentant l'attribut annulable de l'événement associé.
 - [`PerformanceEventTiming.target`](/fr/docs/Web/API/PerformanceEventTiming/target) _lecture seule_ {{Non-standard_Inline}}
   - : Retourne un [`Node`](/fr/docs/Web/API/Node) représentant la dernière cible de l'événement associé, si elle n'est pas supprimée.
 
 ## Méthodes
 
-- [`PerformanceEventTiming.toJSON()`](</fr/docs/Web/API/PerformanceEventTiming/toJSON()>) {{ExperimentalBadge}}
+- [`PerformanceEventTiming.toJSON()`](</fr/docs/Web/API/PerformanceEventTiming/toJSON()>)
   - : Convertit l'objet [`PerformanceEventTiming`](/fr/docs/Web/API/PerformanceEventTiming) en JSON.
 
 ## Exemples

--- a/files/fr/web/api/performancelongtasktiming/index.md
+++ b/files/fr/web/api/performancelongtasktiming/index.md
@@ -11,7 +11,7 @@ L'interface **`PerformanceLongTaskTiming`** de [l'API _Long Tasks_](/fr/docs/Web
 
 ## Propriétés
 
-- [`PerformanceLongTaskTiming`](/fr/docs/Web/API/PerformanceLongTaskTiming) _lecture seule_ {{ExperimentalBadge}}
+- [`PerformanceLongTaskTiming`](/fr/docs/Web/API/PerformanceLongTaskTiming) _lecture seule_
   - : Retourne une séquence d'instances [`TaskAttributionTiming`](/fr/docs/Web/API/TaskAttributionTiming).
 
 ## Spécifications


### PR DESCRIPTION
### Description

Fix French API documentation by removing `{{ExperimentalBadge}}` macros from properties that are not marked as experimental in the English source.

### Motivation

Align the French translation with the en-US documentation to ensure consistent experimental status across language versions. The properties `processingStart`, `processingEnd`, and `cancelable` are not experimental in the English source.

### Additional details

Removed `{{ExperimentalBadge}}` from:
- PerformanceLongTaskTiming interface property
- PerformanceEventTiming.processingStart
- PerformanceEventTiming.processingEnd
- PerformanceEventTiming.cancelable
- PerformanceEventTiming.toJSON()
### Related issues and pull requests

<!-- No related issues -->