### PR TITLE
chore(fr): remove remnant `{{CSSRef}}` macros

### DIFF
--- a/files/fr/web/api/web_animations_api/tips/index.md
+++ b/files/fr/web/api/web_animations_api/tips/index.md
@@ -4,8 +4,6 @@ slug: Web/API/Web_Animations_API/Tips
 original_slug: Web/CSS/CSS_animations/Tips
 ---
 
-{{CSSRef}}
-
 Les animations CSS permettent de réaliser réaliser des effets incroyables en mainpulant les éléments de vos documents et applications.. Cependant, il est parfois compliqué d'obtenir l'effet désiré. Dans cet article, on explorera différents conseils visant à simplifier la réalisation d'animations.
 
 ## Relancer une animation

--- a/files/fr/web/css/guides/display/block_formatting_context/index.md
+++ b/files/fr/web/css/guides/display/block_formatting_context/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Display/Block_formatting_context
 original_slug: Web/CSS/CSS_display/Block_formatting_context
 ---
 
-{{CSSRef}}
-
 Un **contexte de formatage de blocs** (_block formatting context_) est une partie du rendu visuel par le CSS, d'une page web. C'est la région qui délimite la mise en page des blocs et dans laquelle les éléments flottant interagissent les uns avec les autres.
 
 Un contexte de formatage de blocs est créé dans les situations suivantes :

--- a/files/fr/web/css/guides/display/containing_block/index.md
+++ b/files/fr/web/css/guides/display/containing_block/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Display/Containing_block
 original_slug: Web/CSS/CSS_display/Containing_block
 ---
 
-{{CSSRef}}
-
 Le **bloc englobant (_containing block_)** affecte souvent la taille et la position d'un élément. La plupart du temps, le bloc englobant est la [zone de contenu](/fr/docs/Learn_web_development/Core/Styling_basics/Box_model#les_propriétés_des_boîtes) de l'ancêtre de [bloc](/fr/docs/Glossary/Block-level_content) le plus proche mais cette règle n'est pas absolue. Dans cet article, nous verrons les différents facteurs qui participent à la définition du bloc englobant.
 
 Lorsqu'un agent utilisateur (un navigateur web par exemple) dispose un document, il génère une boîte pour chaque élément du document. Chaque boîte est divisée en quatre zones :

--- a/files/fr/web/css/guides/display/formatting_contexts/index.md
+++ b/files/fr/web/css/guides/display/formatting_contexts/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Display/Formatting_contexts
 original_slug: Web/CSS/CSS_display/Introduction_to_formatting_contexts
 ---
 
-{{CSSRef}}
-
 Dans cet article, nous aborderons le concept des contextes de formatage. Ceux-ci peuvent être de différents types : contextes de formatage de bloc, contextes de formatage en ligne, contextes de formatage flexibles. Nous verrons les bases de leur comportement et comment les utiliser.
 
 Sur une page web, tout s'inscrit dans un **contexte de formatage**, une zone qui a été définie pour être organisée d'une certaine façon. Un **contexte de formatage en bloc** (ou _block formatting context_ (BFC)) organisera ses éléments fils selon une disposition en bloc, un **contexte de formatage flexible** organisera ses éléments fils comme des objets flexibles, etc. Chaque contexte de formatage possède des règles spécifiques qui décrivent le comportement de la disposition pour ce contexte.

--- a/files/fr/web/css/guides/display/in_flow_and_out_of_flow/index.md
+++ b/files/fr/web/css/guides/display/in_flow_and_out_of_flow/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Display/In_flow_and_out_of_flow
 original_slug: Web/CSS/CSS_display/In_flow_and_out_of_flow
 ---
 
-{{CSSRef}}
-
 Dans [le précédent guide](/fr/docs/Web/CSS/Guides/Display/Block_and_inline_layout), nous avons vu le fonctionnement de la disposition en ligne et en bloc dans le flux normal. Tous les éléments qui sont « dans » le flux seront disposés grâce à cette méthode.
 
 Dans l'exemple qui suit, on a un titre, un paragraphe, une liste puis un paragraphe final qui contient un élément `strong`. Le titre et les paragraphes sont des éléments de blocs et l'élément `strong` est un élément en ligne. La liste est affichée en utilisant les boîtes flexibles afin d'avoir les éléments de la liste sur une même ligne mais cette liste contribue bien à la disposition en ligne et en bloc car le conteneur a un type `display` externe qui vaut `block`.

--- a/files/fr/web/css/guides/flexible_box_layout/aligning_items/index.md
+++ b/files/fr/web/css/guides/flexible_box_layout/aligning_items/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 3c7e928f332191b153c40a6ade88fb5815c92b99
 ---
 
-{{CSSRef}}
-
 Une des raisons qui ont poussé à l'adoption des boîtes flexibles est la présence d'outils d'alignement enfin corrects pour le Web. On pouvait ainsi enfin centrer une boîte sur un axe vertical. Dans ce guide, nous verrons dans le détail comment fonctionnent les propriétés d'alignement et de justification relatives aux boîtes flexibles.
 
 Afin de centrer notre boîte, nous allons utiliser la propriété `align-items` afin d'aligner l'objet sur l'axe secondaire (<i lang="en">cross axis</i> en anglais). Dans notre exemple, cet axe est l'axe de bloc et est orienté verticalement. La propriété `justify-content` est quant à elle utilisée pour aligner l'objet sur l'axe principal (<i lang="en">main axis</i> en anglais) (ici l'axe principal est l'axe en ligne qui s'étend horizontalement).

--- a/files/fr/web/css/guides/flexible_box_layout/controlling_flex_item_ratios/index.md
+++ b/files/fr/web/css/guides/flexible_box_layout/controlling_flex_item_ratios/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Flexible_box_layout/Controlling_flex_item_ratios
 original_slug: Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the_main_axis
 ---
 
-{{CSSRef}}
-
 Dans ce guide, nous verrons les trois propriétés appliquées aux éléments flexibles qui permettent de contrôler leurs tailles et flexibilités le long de l'axe principal : {{cssxref("flex-grow")}}, {{cssxref("flex-shrink")}} et {{cssxref("flex-basis")}}. Comprendre le fonctionnement de ces propriétés est primordial pour maîtriser les boîtes flexibles.
 
 ## Un premier aperçu

--- a/files/fr/web/css/guides/flexible_box_layout/index.md
+++ b/files/fr/web/css/guides/flexible_box_layout/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Flexible_box_layout
 original_slug: Web/CSS/CSS_flexible_box_layout
 ---
 
-{{CSSRef}}
-
 **Le module de disposition des boîtes flexibles CSS** (_CSS Flexible Box Layout_) est un module de CSS qui définit un modèle de boîtes optimisé pour la conception des interfaces utilisateurs. En utilisant le modèle des boîtes flexibles, les éléments d'une conteneur flexible peuvent être disposés dans n'importe quelle direction et étendre leurs dimensions (pour remplir un espace vide) ou se réduire pour éviter de dépasser en dehors de l'élément parent. On peut facilement manipuler les alignements horizontal et vertical des éléments fils. On peut aussi imbriquer plusieurs niveaux de boîtes flexibles afin de construire des dispositions en deux dimensions..
 
 ## Exemple

--- a/files/fr/web/css/guides/flexible_box_layout/ordering_items/index.md
+++ b/files/fr/web/css/guides/flexible_box_layout/ordering_items/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 2a23f650d86d4f5d948614a607224a2bd52cca33
 ---
 
-{{CSSRef}}
-
 Les méthodes de disposition telles que les boîtes flexibles (<i lang="en">flexbox</i>) et les grilles CSS permettent de contrôler l'ordre du contenu. Dans cet article, nous verrons comment changer l'ordre visuel du contenu grâce aux boîtes flexibles. Nous examinerons également les conséquences de cette réorganisation du point de vue de l'accessibilité.
 
 ## Inverser l'affichage des éléments

--- a/files/fr/web/css/guides/flexible_box_layout/relationship_with_other_layout_methods/index.md
+++ b/files/fr/web/css/guides/flexible_box_layout/relationship_with_other_layout_methods/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Flexible_box_layout/Relationship_with_other_layout_methods
 original_slug: Web/CSS/CSS_flexible_box_layout/Relationship_of_flexbox_to_other_layout_methods
 ---
 
-{{CSSRef}}
-
 Dans cet article, nous verrons comment les boîtes flexibles interagissent avec les autres modules CSS. Nous verrons quelles sont les spécifications qui décrivent les boîtes flexibles et pourquoi les boîtes flexibles sont différentes des autres modules.
 
 > [!NOTE]

--- a/files/fr/web/css/guides/flexible_box_layout/use_cases/index.md
+++ b/files/fr/web/css/guides/flexible_box_layout/use_cases/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 39065429ffa608d6b486d599ce2ac9f156a32bd3
 ---
 
-{{CSSRef}}
-
 Dans ce guide, nous verrons quels sont les cas d'utilisation classiques pour les boîtes flexibles et lorsque cette méthode est plus pertinente qu'une autre méthode de disposition.
 
 ## Pourquoi choisir les boîtes flexibles ?

--- a/files/fr/web/css/guides/flexible_box_layout/wrapping_items/index.md
+++ b/files/fr/web/css/guides/flexible_box_layout/wrapping_items/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: ec9d2eb49c0916c394842d5caa923e1d86ed47ed
 ---
 
-{{CSSRef}}
-
 Les boîtes flexibles ont été conçues comme une méthode de disposition unidimensionnelle. Autrement dit, elles permettent de disposer des éléments en lignes ou en colonnes mais pas en lignes et en colonnes en même temps. Il existe toutefois la possibilité de passer des éléments flexibles à la ligne pour créer de nouvelles lignes horizontales si [`flex-direction`](/fr/docs/Web/CSS/Reference/Properties/flex-direction) vaut `row` ou de nouvelles colonnes si `flex-direction` vaut `column`. Dans ce guide, nous verrons comment cela fonctionne, les cas pour lesquels cela a été prévu et les situations qui nécessitent plutôt d'utiliser [une disposition en grille](/fr/docs/Web/CSS/Guides/Grid_layout).
 
 ## Créer des passages à la ligne

--- a/files/fr/web/css/guides/fonts/index.md
+++ b/files/fr/web/css/guides/fonts/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Fonts
 original_slug: Web/CSS/CSS_fonts
 ---
 
-{{CSSRef}}
-
 **CSS Fonts** est un module CSS qui définit des propriétés relatives aux polices de caractères et la façon dont les ressources des polices sont chargées. Il permet de définir le style d'une police, comme sa famille, sa taille ou sa graisse ainsi que la variante du glyphe à utiliser dans le cas des polices disposant de plusieurs glyphes par caractère. Il permet également de définir la hauteur d'une ligne.
 
 ## Exemple simple

--- a/files/fr/web/css/guides/fonts/opentype_fonts/index.md
+++ b/files/fr/web/css/guides/fonts/opentype_fonts/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Fonts/OpenType_fonts
 original_slug: Web/CSS/CSS_fonts/OpenType_fonts_guide
 ---
 
-{{CSSRef}}
-
 Les caractéristiques de police ou variantes font référence à différents glyphes ou styles de caractère contenus dans une police OpenType. Cela inclut notamment les ligatures (des caractères spéciaux qui permettent de combiner des caractères entre eux comme œ qui est la ligature entre o et e), le crénage (_kerning_ en anglais) qui définit l'espacement entre certaines lettres, les fractions et styles numériques, etc. Toutes ces caractéristiques sont des caractéristiques OpenType Features et peuvent être utilisées sur le Web grâce à certaines propriétés spécifiques qui permettent un contrôle de bas niveau comme {{cssxref("font-feature-settings")}}. Dans cet article, nous verrons tout ce qu'il faut savoir pour manipuler les caractéristiques OpenType avec CSS.
 
 Pour certaines polices, une ou plusieurs caractéristiques sont activées par défaut (le crénage et les ligatures classiques sont souvent activées par exemple). D'autres caractéristiques sont inactives et peuvent être activées par choix dans certaines situations.

--- a/files/fr/web/css/guides/fonts/variable_fonts/index.md
+++ b/files/fr/web/css/guides/fonts/variable_fonts/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Fonts/Variable_fonts
 original_slug: Web/CSS/CSS_fonts/Variable_fonts_guide
 ---
 
-{{CSSRef}}
-
 **Les polices variables** sont une évolution de la spécification OpenType et qui permet d'activer différentes variations d'une police dans un seul fichier plutôt que d'avoir différents fichiers pour chaque taille, graisse ou style. En CSS, on peut accéder à l'ensemble des variations en utilisant une seule référence {{cssxref("@font-face")}}. Dans cet article, nous verrons tout ce qu'il faut savoir pour commencer à utiliser les polices variables.
 
 > [!WARNING]

--- a/files/fr/web/css/guides/fragmentation/index.md
+++ b/files/fr/web/css/guides/fragmentation/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Fragmentation
 original_slug: Web/CSS/CSS_fragmentation
 ---
 
-{{cssref}}
-
 **_CSS Fragmentation_** est un module CSS qui décrit la façon dont le contenu est divisé (fragmenté) entre plusieurs [pages](/fr/docs/Web/CSS/Guides/Paged_media), régions ou [colonnes](/fr/docs/Web/CSS/Guides/Multicol_layout).
 
 La fragmentation se produit lorsqu'une boîte en ligne se retrouve sur plusieurs lignes ou lorsqu'un bloc s'étend sur plus d'une colonne au sein d'un conteneur de colonne ou sur un saut de page lorsque le document est imprimé. Chaque morceau de l'élément ainsi divisé est appelé un _fragment_.

--- a/files/fr/web/css/guides/generated_content/index.md
+++ b/files/fr/web/css/guides/generated_content/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Generated_content
 original_slug: Web/CSS/CSS_generated_content
 ---
 
-{{CSSRef}}
-
 **_CSS Generated Content_** est un module CSS qui définit comment ajouter du contenu à un élément.
 
 ## Référence

--- a/files/fr/web/css/guides/grid_layout/auto-placement/index.md
+++ b/files/fr/web/css/guides/grid_layout/auto-placement/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: b906098e63b1eb3512b4381fe7c105b67037aff1
 ---
 
-{{CSSRef}}
-
 En plus de pouvoir placer des objets de façon précise sur une grille, la spécification pour les grilles CSS définit le comportement obtenu lorsque certains (voire aucun) des objets ne sont pas placés sur la grille. Pour voir comment fonctionne le placement automatique, il suffit de créer une grille avec un ensemble d'objets.
 
 ## Placement automatique

--- a/files/fr/web/css/guides/grid_layout/basic_concepts/index.md
+++ b/files/fr/web/css/guides/grid_layout/basic_concepts/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 3a22bb59de072d368ad47cf36f8c385f1f3494fe
 ---
 
-{{CSSRef}}
-
 [Le module de spécification CSS pour les dispositions en grilles (<i lang="en">Grid Layout</i> en anglais)](/fr/docs/Web/CSS/Guides/Grid_layout) ajoute un système de grille en deux dimensions à CSS. Les grilles peuvent être utilisées pour agencer des pages entières ou de petits éléments d'interface. Cet article présente ce module de grille, et introduit la terminologie de la spécification de niveau 1 des grilles CSS. Les fonctionnalités évoquées dans cet aperçu seront expliquées plus en détails dans le reste du guide.
 
 ## Qu'est-ce qu'une grille&nbsp;?

--- a/files/fr/web/css/guides/grid_layout/box_alignment/index.md
+++ b/files/fr/web/css/guides/grid_layout/box_alignment/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Grid_layout/Box_alignment
 original_slug: Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout
 ---
 
-{{CSSRef}}
-
 {{PreviousMenuNext("Web/CSS/Guides/Grid_layout/Auto-placement", "Web/CSS/Guides/Grid_layout/Logical_values_and_writing_modes","Web/CSS/Guides/Grid_layout")}}
 
 Si vous connaissez [les boîtes flexibles (flexbox)](/fr/docs/Web/CSS/Guides/Flexible_box_layout) vous savez déjà comment aligner les éléments flexibles à l'intérieur d'un conteneur flexible. Ces propriétés d'alignement, initialement spécifiée dans la spécification des boîtes flexibles, sont désormais spécifiées dans une nouvelle spécification [Box Alignment Level 3](https://drafts.csswg.org/css-align/). Cette spécification détaille le fonctionnement de l'alignement pour les différentes méthodes de disposition.

--- a/files/fr/web/css/guides/grid_layout/common_grid_layouts/index.md
+++ b/files/fr/web/css/guides/grid_layout/common_grid_layouts/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 72304bf90ccd530ff9dc9e5ff12397b2600248ed
 ---
 
-{{CSSRef}}
-
 Pour clôturer ces différents guides, nous allons maintenant voir différentes dispositions sur lesquelles nous appliquerons des techniques avec les grilles CSS. Nous prendrons un exemple qui utilise [les zones nommées d'une grille](/fr/docs/Web/CSS/Guides/Grid_layout/Grid_template_areas), un système de grille flexible avec 12 colonnes, et aussi une liste de produits avec un placement automatique. Comme nous le verrons, il existe plusieurs méthodes pour obtenir chaque résultat. À vous de choisir la méthode qui vous paraît la plus pertinente et utile pour les problèmes que vous avez à résoudre et les dispositions que vous devez implémenter.
 
 ## Une disposition adaptative avec une à trois colonnes en utilisant `grid-template-areas`

--- a/files/fr/web/css/guides/grid_layout/grid_template_areas/index.md
+++ b/files/fr/web/css/guides/grid_layout/grid_template_areas/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Grid_layout/Grid_template_areas
 original_slug: Web/CSS/CSS_grid_layout/Grid_template_areas
 ---
 
-{{CSSRef}}
-
 {{PreviousMenuNext("Web/CSS/Guides/Grid_layout/Line-based_placement", "Web/CSS/Guides/Grid_layout/Named_grid_lines","Web/CSS/Guides/Grid_layout")}}
 
 Dans [le guide précédent](/fr/docs/Web/CSS/Guides/Grid_layout/Line-based_placement), on a étudié les lignes formées par une grille et comment positionner des objets sur ces lignes. Lorsqu'on utilise une grille CSS, on a toujours ces lignes et celles-ci permettent d'avoir une disposition simple. Toutefois, il existe une autre méthode de disposition avec les grilles, qu'on peut utiliser seule ou combinée avec les lignes. Avec cette méthode, on place les éléments sur des _zones_ de la grille. Nous allons voir dans ce guide comment cela fonctionne voire comment on peut faire de l'ASCII-art en CSS avec les grilles !

--- a/files/fr/web/css/guides/grid_layout/line-based_placement/index.md
+++ b/files/fr/web/css/guides/grid_layout/line-based_placement/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Grid_layout/Line-based_placement
 original_slug: Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement
 ---
 
-{{CSSRef}}
-
 {{PreviousMenuNext("Web/CSS/Guides/Grid_layout/Basic_concepts", "Web/CSS/Guides/Grid_layout/Grid_template_areas","Web/CSS/Guides/Grid_layout")}}
 
 Dans [l'article sur les concepts de base](/fr/docs/Web/CSS/Guides/Grid_layout/Basic_concepts), nous avons vu comment positionner des éléments en utilisant des numéros de lignes. Nous allons désormais étudier cette fonctionnalité de positionnement plus en détail.

--- a/files/fr/web/css/guides/grid_layout/logical_values_and_writing_modes/index.md
+++ b/files/fr/web/css/guides/grid_layout/logical_values_and_writing_modes/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: f224dbe80c60289cd8b7d2bf92871d091e0f5d0d
 ---
 
-{{CSSRef}}
-
 Dans les articles précédents, nous avons évoqué un aspect important de la disposition en grille&nbsp;: la prise en charge des différents modes d'écriture. Dans ce guide, nous nous intéresserons plus particulièrement à cette fonctionnalité ainsi qu'aux autres méthodes modernes de disposition. Cela sera également l'occasion d'en apprendre plus sur les modes d'écritures et la notion de propriété logique/physique.
 
 ## Les propriétés logiques, les propriétés physiques et les valeurs

--- a/files/fr/web/css/guides/grid_layout/named_grid_lines/index.md
+++ b/files/fr/web/css/guides/grid_layout/named_grid_lines/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Grid_layout/Named_grid_lines
 original_slug: Web/CSS/CSS_grid_layout/Grid_layout_using_named_grid_lines
 ---
 
-{{CSSRef}}
-
 {{PreviousMenuNext("Web/CSS/Guides/Grid_layout/Grid_template_areas", "Web/CSS/Guides/Grid_layout/Auto-placement","Web/CSS/Guides/Grid_layout")}}
 
 Dans les articles précédents, on a vu comment placer des objets sur les lignes définies par les pistes de la grilles. On a également vu comment placer des objets sur des zones nommées. Dans ce guide, nous allons combiner ces deux concepts et apprendre à placer les objets sur des lignes avec des noms. Le nommage des lignes peut s'avérer très utile mais un aspect encore plus intéressant consiste à combiner les noms et les tailles de pistes. Cela sera plus clair lorsque nous aurons vu les différents exemples.

--- a/files/fr/web/css/guides/grid_layout/relationship_with_other_layout_methods/index.md
+++ b/files/fr/web/css/guides/grid_layout/relationship_with_other_layout_methods/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Grid_layout/Relationship_with_other_layout_methods
 original_slug: Web/CSS/CSS_grid_layout/Relationship_of_grid_layout_with_other_layout_methods
 ---
 
-{{CSSRef}}
-
 Le mode de disposition en grille a été conçu afin de pouvoir fonctionner avec les autres composantes de CSS pour construire un système complet de disposition. Dans ce guide, nous expliquerons comment intégrer une grille CSS parmi d'autres techniques que vous pourriez déjà utiliser.
 
 ## Les grilles et les boîtes flexibles (_flexbox_)

--- a/files/fr/web/css/guides/grid_layout/subgrid/index.md
+++ b/files/fr/web/css/guides/grid_layout/subgrid/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Grid_layout/Subgrid
 original_slug: Web/CSS/CSS_grid_layout/Subgrid
 ---
 
-{{CSSRef}}
-
 La valeur **`subgrid`** a été ajoutée par le module de spécification _CSS Grid Layout_ de niveau 2 pour les propriétés {{cssxref("grid-template-columns")}} et {{cssxref("grid-template-rows")}}. Dans ce guide, nous verrons comment utiliser cette valeur ainsi que les cas d'utilisation ou patrons de conception qui peuvent en bénéficier.
 
 ## Une introduction à `subgrid`

--- a/files/fr/web/css/guides/images/implementing_image_sprites/index.md
+++ b/files/fr/web/css/guides/images/implementing_image_sprites/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Images/Implementing_image_sprites
 original_slug: Web/CSS/CSS_images/Implementing_image_sprites_in_CSS
 ---
 
-{{CSSRef}}
-
 Les _sprites_ sont utilisées dans de nombreuses applications web où de multiples images sont utilisées. Au lieu d'avoir une image par fichier, on économise de la bande passante et de la mémoire en les envoyant toute dans le même fichier, ainsi, le nombre de requêtes HTTP diminue. On utilise alors `background-position` pour choisir l'image qu'on souhaite utiliser.
 
 > [!NOTE]

--- a/files/fr/web/css/guides/images/index.md
+++ b/files/fr/web/css/guides/images/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Images
 original_slug: Web/CSS/CSS_images
 ---
 
-{{CSSRef}}
-
 **_CSS Images_** est un module CSS qui définit les types d'images qui peuvent être utilisés (le type {{cssxref("&lt;image&gt;")}}, les URLs qu'elles contiennent, les dégradés et autres types d'images), comment les redimensionner et comment elles, ainsi que le contenu remplacé, interagissent avec les différents modèles de mise en page.
 
 ## Référence

--- a/files/fr/web/css/guides/images/replaced_element_properties/index.md
+++ b/files/fr/web/css/guides/images/replaced_element_properties/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Images/Replaced_element_properties
 original_slug: Web/CSS/CSS_images/Replaced_element_properties
 ---
 
-{{CSSRef}}
-
 En CSS, un **élément remplacé** est un élément dont la représentation est en dehors du champ de CSS. Ce sont des objets externes dont la représentation sera indépendante de CSS.
 
 Autrement dit, ces éléments sont des éléments dont le contenu n'est pas impacté par les styles du document. La position de l'élément remplacé peut être modifiée avec CSS mais le contenu même de l'élément ne pourra pas être modifiée. Certains éléments remplacés comme {{HTMLElement("iframe")}} peuvent avoir leurs propres feuilles de styles mais ils n'héritent pas de celles du document parent.

--- a/files/fr/web/css/guides/images/using_gradients/index.md
+++ b/files/fr/web/css/guides/images/using_gradients/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: f79a491594ebb5634949ed31b26155973a39166e
 ---
 
-{{CSSRef}}
-
 Les **dégradés CSS** sont représentés par le type de donnée [`<gradient>`](/fr/docs/Web/CSS/Reference/Values/gradient) qui est un sous-ensemble du type [`<image>`](/fr/docs/Web/CSS/Reference/Values/image). L'utilisation de dégradés CSS permet d'afficher des transitions douces entre deux couleurs ou plus. Il existe trois sortes de dégradés&nbsp;:
 
 - Les dégradés linéaires (créés avec la fonction [`linear-gradient()`](/fr/docs/Web/CSS/Reference/Values/gradient/linear-gradient)),

--- a/files/fr/web/css/guides/inline_layout/inline_formatting_context/index.md
+++ b/files/fr/web/css/guides/inline_layout/inline_formatting_context/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Inline_layout/Inline_formatting_context
 original_slug: Web/CSS/CSS_inline_layout/Inline_formatting_context
 ---
 
-{{CSSRef}}
-
 Dans cet article, nous allons voir ce qu'est le contexte de formatage en ligne (_inline formatting context_).
 
 ## Concepts-clés

--- a/files/fr/web/css/guides/lists/indenting/index.md
+++ b/files/fr/web/css/guides/lists/indenting/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Lists/Indenting
 original_slug: Web/CSS/CSS_lists/Consistent_list_indentation
 ---
 
-{{CSSRef}}
-
 La modification la plus fréquemment apportée sur une liste concerne la distance d'indentation (autrement dit, la distance de laquelle les éléments sont décalés vers la droite). Ce point peut être source de frustration car les navigateurs se comportent différemment à ce sujet. Ainsi, si on déclare une liste sans marge à gauche, elles sont déplacées Internet Explorer mais restent obstinément à la même place dans les navigateurs Gecko.
 
 Pour comprendre pourquoi cela se produit ainsi, et surtout afin d'éviter ces problèmes, nous allons devoir examiner en détail la construction des listes.

--- a/files/fr/web/css/guides/lists/index.md
+++ b/files/fr/web/css/guides/lists/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Lists
 original_slug: Web/CSS/CSS_lists
 ---
 
-{{CSSRef}}
-
 **CSS Lists** (listes CSS) est un module CSS qui définit la façon dont les listes sont mises en forme, comment des styles peuvent être appliqués aux marqueurs.
 
 ## Référence

--- a/files/fr/web/css/guides/logical_properties_and_values/basic_concepts/index.md
+++ b/files/fr/web/css/guides/logical_properties_and_values/basic_concepts/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Logical_properties_and_values/Basic_concepts
 original_slug: Web/CSS/CSS_logical_properties_and_values/Basic_concepts_of_logical_properties_and_values
 ---
 
-{{CSSRef}}
-
 La spécification relative aux propriétés et valeurs logiques introduit une correspondance relative au flux pour de nombreuses propriétés et valeurs CSS. Dans cet article, nous verrons une introduction de cette spécification et expliquerons les propriétés et valeurs relatives au flux.
 
 ## Quel intérêt pour les propriétés logiques ?

--- a/files/fr/web/css/guides/logical_properties_and_values/floating_and_positioning/index.md
+++ b/files/fr/web/css/guides/logical_properties_and_values/floating_and_positioning/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Logical_properties_and_values/Floating_and_positioning
 original_slug: Web/CSS/CSS_logical_properties_and_values/Floating_and_positioning
 ---
 
-{{CSSRef}}
-
 [La spécification sur les propriétés et valeurs logiques](https://drafts.csswg.org/css-logical/) définit des valeurs logiques qui correspondent aux valeurs physiques utilisées pour {{cssxref("float")}} et {{cssxref("clear")}}. Elle définit aussi des propriétés logiques pour le positionnement lorsqu'on utilise une [disposition positionnée](/fr/docs/Web/CSS/Guides/Positioned_layout). Dans ce guide, nous verrons comment utiliser ces valeurs et ces propriétés logiques.
 
 ## Correspondance entre les propriétés et les valeurs

--- a/files/fr/web/css/guides/logical_properties_and_values/index.md
+++ b/files/fr/web/css/guides/logical_properties_and_values/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Logical_properties_and_values
 original_slug: Web/CSS/CSS_logical_properties_and_values
 ---
 
-{{CSSRef}}
-
 **_CSS Logical Properties_** (les propriétés logiques CSS) est un module CSS qui définit une correspondance logique vers les propriétés physiques de contrôle de la mise en page selon le sens de lecture et l'orientation du texte. On aura deux directions logiques : _block_ et _inline_, perpendiculaires, qui dépendent du sens de l'orientation du document.
 
 Ce module définit également les propriétés logiques et les valeurs pour les propriétés précédemment définies avec CSS 2.1. Les propriétés logiques sont des propriétés dont l'orientation est relative au mode d'écriture du document et possèdent des propriétés physiques équivalentes.

--- a/files/fr/web/css/guides/logical_properties_and_values/margins_borders_padding/index.md
+++ b/files/fr/web/css/guides/logical_properties_and_values/margins_borders_padding/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Logical_properties_and_values/Margins_borders_padding
 original_slug: Web/CSS/CSS_logical_properties_and_values/Margins_borders_padding
 ---
 
-{{CSSRef}}
-
 La spécification [sur les propriétés et valeurs logiques](https://drafts.csswg.org/css-logical/) définit des correspondances pour les propriétés servant à définir les marges, les bordures et les remplissages (_padding_) et les propriétés raccourcies associées. Dans ce guide, nous verrons comment utiliser ces propriétés logiques.
 
 Si vous avez consulté la page principale sur [les propriétés et valeurs logiques](/fr/docs/Web/CSS/Guides/Logical_properties_and_values), vous avez pu voir une grande quantité de propriétés. Cela est principalement du au fait que pour chaque marge, bordure et remplissage, il y a quatre propriétés détaillées et une propriété raccourcie.

--- a/files/fr/web/css/guides/logical_properties_and_values/sizing/index.md
+++ b/files/fr/web/css/guides/logical_properties_and_values/sizing/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Logical_properties_and_values/Sizing
 original_slug: Web/CSS/CSS_logical_properties_and_values/Sizing
 ---
 
-{{CSSRef}}
-
 Dans ce guide, nous verrons les correspondances entre les propriétés physiques et les propriétés logiques qui peuvent être utilisées afin de dimensionner des éléments au sein d'un document.
 
 Lorsqu'on définit la taille d'un objet, [la spécification sur les propriétés et les valeurs logiques](https://drafts.csswg.org/css-logical/) permet de définir le dimensionnement en fonction du flux du texte (le mode d'écriture et son orientation) plutôt que relativement aux dimensions physiques du support (haut / bas / gauche / droite). Bien que ce premier fonctionnement, utilisant des propriétés et des valeurs _logiques_, puisse devenir la méthode par défaut à l'avenir, on peut tout à fait avoir besoin d'utiliser des propriétés et des valeurs _physiques_ en combinaison avec ces propriétés et ces valeurs logiques.

--- a/files/fr/web/css/guides/masking/index.md
+++ b/files/fr/web/css/guides/masking/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Masking
 original_slug: Web/CSS/CSS_masking
 ---
 
-{{CSSRef}}
-
 **_CSS Masking_** (ou « masques CSS ») est un module CSS qui définit les moyens, dont les masques et le _clipping_, pour dissimuler des parties d'éléments visuels, partiellement ou en totalité.
 
 ## Référence

--- a/files/fr/web/css/guides/media_queries/index.md
+++ b/files/fr/web/css/guides/media_queries/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 50e215d730cd173d93b9bf75785c0d8ed2f67cb0
 ---
 
-{{CSSRef}}
-
 Les **requêtes média CSS**, plus souvent appelées **<i lang="en">media queries</i>**, sont un outil de [<i lang="en">responsive design</i>](/fr/docs/Learn_web_development/Core/CSS_layout/Responsive_Design) qui permet d'adapter la feuille de styles CSS en fonction de différents paramètres ou caractéristiques de l'appareil.
 
 Par exemple, on pourra appliquer différentes mises en forme selon la taille de [la zone d'affichage](/fr/docs/Glossary/Viewport) pour que la disposition soit correcte selon les tailles d'écran des appareils.

--- a/files/fr/web/css/guides/media_queries/testing/index.md
+++ b/files/fr/web/css/guides/media_queries/testing/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Media_queries/Testing
 original_slug: Web/CSS/CSS_media_queries/Testing_media_queries
 ---
 
-{{CSSRef}}
-
 Le {{Glossary("DOM")}} fournit un certain nombre de fonctionnalités qui permettent de tester les résultats d'une requête média (_media query_) avec un script. Pour cela, on utilise l'interface {{domxref("MediaQueryList")}} ainsi que ses méthodes et ses propriétés. Une fois qu'on a créé un objet {{domxref("MediaQueryList") }}, on peut vérifier le résultat de la requête ou également recevoir des notifications automatiques lorsque le résultat de la requête change.
 
 ## Créer une liste de requêtes média

--- a/files/fr/web/css/guides/media_queries/using/index.md
+++ b/files/fr/web/css/guides/media_queries/using/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Media_queries/Using
 original_slug: Web/CSS/CSS_media_queries/Using_media_queries
 ---
 
-{{CSSRef}}
-
 **Les requêtes média (_media queries_)** permettent de modifier l'apparence d'un site ou d'une application en fonction du type d'appareil (impression ou écran par exemple) et de ses caractéristiques (la résolution d'écran ou la largeur de la zone d'affichage (_viewport_) par exemple).
 
 Les requêtes média sont utilisées afin :

--- a/files/fr/web/css/guides/motion_path/index.md
+++ b/files/fr/web/css/guides/motion_path/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Motion_path
 original_slug: Web/CSS/CSS_motion_path
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
-
 **_Motion Path_** est un module de la spécification CSS qui permet aux auteurs d'animer des objets graphiques le long d'une ligne appelée _chemin_.
 
 ## Référence

--- a/files/fr/web/css/guides/multicol_layout/basic_concepts/index.md
+++ b/files/fr/web/css/guides/multicol_layout/basic_concepts/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Multicol_layout/Basic_concepts
 original_slug: Web/CSS/CSS_multicol_layout/Basic_concepts
 ---
 
-{{CSSRef}}
-
 La disposition sur plusieurs colonnes (« _Multiple-column Layout_ » ou « _multicol_ » en anglais) est un module de spécification pour organiser du contenu sur un ensemble de colonnes, à la façon des colonnes dans un journal imprimé. Dans ce guide, nous verrons comment fonctionne cette spécification et quelques cas d'exemples.
 
 ## Concepts et terminologie

--- a/files/fr/web/css/guides/multicol_layout/handling_content_breaks/index.md
+++ b/files/fr/web/css/guides/multicol_layout/handling_content_breaks/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Multicol_layout/Handling_content_breaks
 original_slug: Web/CSS/CSS_multicol_layout/Handling_content_breaks_in_multicol_layout
 ---
 
-{{CSSRef}}
-
 Le contenu est coupé entre les colonnes d'une disposition multi-colonnes de la même façon qu'il est coupé entre chaque page d'un média paginé. Dans ces deux contextes, la façon dont on contrôle l'emplacement et la coupure se paramètre grâce aux propriétés décrites dans le module de spécification _CSS Fragmentation_. Dans ce guide, nous verrons comment fonctionne la fragmentation en multi-colonnes.
 
 ## Quelques notions de bases sur la fragmentation

--- a/files/fr/web/css/guides/multicol_layout/handling_overflow/index.md
+++ b/files/fr/web/css/guides/multicol_layout/handling_overflow/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Multicol_layout/Handling_overflow
 original_slug: Web/CSS/CSS_multicol_layout/Handling_overflow_in_multicol_layout
 ---
 
-{{CSSRef}}
-
 Dans ce guide, nous verrons comment gérer le dépassement avec une disposition multi-colonnes. Le dépassement peut avoir lieu pour chaque boîte de colonne ou lorsqu'il y a plus de contenu que de place dans le conteneur.
 
 ## Le dépassement dans les boîtes des colonnes

--- a/files/fr/web/css/guides/multicol_layout/index.md
+++ b/files/fr/web/css/guides/multicol_layout/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Multicol_layout
 original_slug: Web/CSS/CSS_multicol_layout
 ---
 
-{{CSSRef}}
-
 **Les colonnes CSS** (_CSS Multi-column Layout_ en anglais) forment un module CSS qui définit le comportement d'une disposition en colonnes, qui permet de décrire comment le contenu doit être réparti entre les colonnes et qui détaille comment sont gérées les espaces et les règles entre les colonnes.
 
 ## Exemple simple

--- a/files/fr/web/css/guides/multicol_layout/spanning_balancing_columns/index.md
+++ b/files/fr/web/css/guides/multicol_layout/spanning_balancing_columns/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Multicol_layout/Spanning_balancing_columns
 original_slug: Web/CSS/CSS_multicol_layout/Spanning_balancing_columns
 ---
 
-{{CSSRef}}
-
 Dans ce guide, nous verrons comment répartir les éléments sur plusieurs colonnes et comment contrôler le remplissage des colonnes.
 
 > [!NOTE]

--- a/files/fr/web/css/guides/multicol_layout/styling_columns/index.md
+++ b/files/fr/web/css/guides/multicol_layout/styling_columns/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Multicol_layout/Styling_columns
 original_slug: Web/CSS/CSS_multicol_layout/Styling_columns
 ---
 
-{{CSSRef}}
-
 Les boîtes de colonne créées au sein des conteneurs multi-colonnes sont des boîtes anonymes et leur mise en forme est donc limitée. Elle n'est toutefois pas inexistante. Dans ce guide nous verrons comment modifier l'espace entre les colonnes et comment mettre en forme une ligne entre les colonnes.
 
 ## Peut-on mettre en forme les boîtes des colonnes ?

--- a/files/fr/web/css/guides/multicol_layout/using/index.md
+++ b/files/fr/web/css/guides/multicol_layout/using/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Multicol_layout/Using
 original_slug: Web/CSS/CSS_multicol_layout/Using_multicol_layouts
 ---
 
-{{CSSRef}}
-
 La **disposition multi-colonnes** étend _le mode de disposition en bloc_ et permet de définir simplement plusieurs colonnes de texte. Lorsqu'on lit un texte, si les lignes sont trop longues, il faudra trop de temps aux yeux pour revenir au début de la ligne et passer à la ligne suivante : on perdra alors la ligne sur laquelle on était. Ainsi, pour utiliser efficacement l'espace fourni par un grand écran, on préfèrera utiliser des colonnes de largeur fixe, disposée côte à côte, à la façon d'un journal.
 
 ## Utiliser les colonnes CSS

--- a/files/fr/web/css/guides/namespaces/index.md
+++ b/files/fr/web/css/guides/namespaces/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Namespaces
 original_slug: Web/CSS/CSS_namespaces
 ---
 
-{{CSSRef}}
-
 **_CSS Namespaces_** (ou « espaces de noms CSS ») est un module CSS qui permet aux auteurs de spécifier des [espaces de noms XML](/fr/docs/Namespaces) en CSS.
 
 ## Référence

--- a/files/fr/web/css/guides/overflow/index.md
+++ b/files/fr/web/css/guides/overflow/index.md
@@ -4,7 +4,6 @@ slug: Web/CSS/Guides/Overflow
 original_slug: Web/CSS/CSS_overflow
 ---
 
-{{CSSRef}}
 Le module de spécification **_CSS Overflow_** décrit les fonctionnalités CSS relatives au dépassement et au défilement du contenu pour les médias visuels. En CSS, le dépassement se produit lorsque le contenu d'une boîte s'étend au-delà des bords de la boîte.
 
 ## Dépassement au dessin (_ink overflow_) et dépassement défilable (_scrollable overflow_)

--- a/files/fr/web/css/guides/paged_media/index.md
+++ b/files/fr/web/css/guides/paged_media/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Paged_media
 original_slug: Web/CSS/CSS_paged_media
 ---
 
-{{CSSRef}}
-
 **Les média paginés CSS** (ou _CSS Paged Media_ en anglais) est un module CSS qui définit la façon dont sont gérés les sauts de page ainsi que les veuves et orphelines.
 
 ## Référence

--- a/files/fr/web/css/guides/positioned_layout/index.md
+++ b/files/fr/web/css/guides/positioned_layout/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Positioned_layout
 original_slug: Web/CSS/CSS_positioned_layout
 ---
 
-{{CSSRef}}
-
 **_CSS Positioned Layout_** (ou module CSS de disposition positionnée) est un module CSS qui définit comment positionner des éléments sur une page.
 
 ## Référence

--- a/files/fr/web/css/guides/positioned_layout/using_z-index/index.md
+++ b/files/fr/web/css/guides/positioned_layout/using_z-index/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/Guides/Positioned_layout/Using_z-index
 original_slug: Web/CSS/CSS_positioned_layout/Using_z-index
 ---
 
-{{CSSRef}}{{PreviousMenuNext("Web/CSS/Guides/Positioned_layout/Stacking_floating_elements","Web/CSS/Guides/Positioned_layout/Stacking_context", "Web/CSS/Guides/Positioned_layout/Understanding_z-index")}}
+{{PreviousMenuNext("Web/CSS/Guides/Positioned_layout/Stacking_floating_elements","Web/CSS/Guides/Positioned_layout/Stacking_context", "Web/CSS/Guides/Positioned_layout/Understanding_z-index")}}
 
 ## Ajouter `z-index`
 

--- a/files/fr/web/css/guides/ruby_layout/index.md
+++ b/files/fr/web/css/guides/ruby_layout/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Ruby_layout
 original_slug: Web/CSS/CSS_ruby_layout
 ---
 
-{{CSSRef}}
-
 **_CSS Ruby Layout_** est un module CSS qui fournit des propriétés de contrôle pour le rendu et la mise en forme [des annotations Ruby](<https://fr.wikipedia.org/wiki/Ruby_(linguistique)>) utilisées dans les documents d'Asie orientale afin d'indiquer la prononciation ou d'annoter le texte de base.
 
 ## Référence

--- a/files/fr/web/css/guides/scroll_anchoring/overview/index.md
+++ b/files/fr/web/css/guides/scroll_anchoring/overview/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Scroll_anchoring/Overview
 original_slug: Web/CSS/CSS_scroll_anchoring/Scroll_anchoring
 ---
 
-{{CSSRef}}
-
 Lorsque vous naviguez sur le Web avec une connexion plus ou moins performante, vous avez déjà pu rencontrer le problème suivant : vous faites défiler verticalement le contenu d'une page qui est en cours de chargement puis, au milieu de votre lecture, le contenu se décale brutalement plus bas (parce que des images au-dessus ou d'autres éléments ont fini de charger et s'affichent enfin).
 
 L'ancrage du défilement (ou _scroll anchoring_ en anglais) est une fonctionnalité des navigateurs qui vise à résoudre ce problème de « saut » (qui se produit lorsque l'utilisateur a déjà suffisamment fait défiler le contenu pour arriver sur une autre partie du document).

--- a/files/fr/web/css/guides/scroll_snap/basic_concepts/index.md
+++ b/files/fr/web/css/guides/scroll_snap/basic_concepts/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Scroll_snap/Basic_concepts
 original_slug: Web/CSS/CSS_scroll_snap/Basic_concepts
 ---
 
-{{CSSRef}}
-
 [Le module de spécification CSS _Scroll Snap_](https://drafts.csswg.org/css-scroll-snap-1/) fournit des outils pour «&nbsp;accrocher&nbsp;» sur certains points lors du défilement dans un document. Un tel comportement peut s'avérer utile pour obtenir un résultat analogue à certaines applications (qu'elles soient mobiles ou non).
 
 ## Principes fondamentaux

--- a/files/fr/web/css/guides/scroll_snap/index.md
+++ b/files/fr/web/css/guides/scroll_snap/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Scroll_snap
 original_slug: Web/CSS/CSS_scroll_snap
 ---
 
-{{CSSRef}}
-
 **_CSS Scroll Snap_** est un module de spécification CSS qui introduit les positions d'accroche lors du défilement. Cela permet de garantir la position sur laquelle on arrive après avoir fait défiler du contenu.
 
 > [!NOTE]

--- a/files/fr/web/css/guides/scrollbars_styling/index.md
+++ b/files/fr/web/css/guides/scrollbars_styling/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Scrollbars_styling
 original_slug: Web/CSS/CSS_scrollbars_styling
 ---
 
-{{CSSRef}} {{SeeCompatTable}}
-
 Le module de spécification _CSS Scrollbars_ standardise la mise en forme des barres de défilement (_scrollbar_) notamment introduite en 2000 avec Windows IE 5.5.
 
 ## Exemples

--- a/files/fr/web/css/guides/selectors/index.md
+++ b/files/fr/web/css/guides/selectors/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Selectors
 original_slug: Web/CSS/CSS_selectors
 ---
 
-{{CSSRef}}
-
 **Les sélecteurs** définissent les éléments sur lesquelles s'applique un ensemble de règles CSS.
 
 ## Les sélecteurs simples

--- a/files/fr/web/css/guides/selectors/privacy_and__colon_visited/index.md
+++ b/files/fr/web/css/guides/selectors/privacy_and__colon_visited/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Selectors/Privacy_and_:visited
 original_slug: Web/CSS/CSS_selectors/Privacy_and_the_visited_selector
 ---
 
-{{CSSRef}}
-
 Par le passé (avant 2010), le sélecteur CSS {{cssxref(":visited")}} permettait aux sites d'effectuer des requêtes sur l'historique de l'utilisateur grâce à la méthode {{domxref("window.getComputedStyle")}} ou à d'autre techniques, parcourant l'historique de l'utilisateur afin de connaître les sites qu'il avait visité. Cela pouvait effectué rapidement et permettait d'obtenir beaucoup d'informations sur l'identité d'un utilisateur.
 
 Afin de palier au problème, Gecko (Gecko 2) a été modifié afin de limiter la quantité d'informations qui peut être obtenue au travers des liens visités. Les autres navigateurs ont également été modifiés de façon semblable.

--- a/files/fr/web/css/guides/selectors/using__colon_target/index.md
+++ b/files/fr/web/css/guides/selectors/using__colon_target/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Selectors/Using_:target
 original_slug: Web/CSS/CSS_selectors/Using_the_:target_pseudo-class_in_selectors
 ---
 
-{{CSSRef}}
-
 Afin d'aider à identifier la destination d'un lien qui mène vers une portion spécifique du document, les [sélecteurs CSS3](https://www.w3.org/TR/css3-selectors/#target-pseudo) ont introduit [la pseudo-classe](/fr/docs/Web/CSS/Reference/Selectors/Pseudo-classes) {{cssxref(":target")}}.
 
 ## Choisir une cible

--- a/files/fr/web/css/guides/shapes/from_box_values/index.md
+++ b/files/fr/web/css/guides/shapes/from_box_values/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Shapes/From_box_values
 original_slug: Web/CSS/CSS_shapes/From_box_values
 ---
 
-{{CSSRef}}
-
 Une méthode permettant de créer des formes consiste à utiliser les valeurs provenant du modèle de boîte CSS. Dans cet article, nous verrons comment les utiliser.
 
 Les [valeurs de boîte](https://drafts.csswg.org/css-shapes-1/#shapes-from-box-values) qui sont autorisées pour les formes sont :

--- a/files/fr/web/css/guides/shapes/from_images/index.md
+++ b/files/fr/web/css/guides/shapes/from_images/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Shapes/From_images
 original_slug: Web/CSS/CSS_shapes/Shapes_from_images
 ---
 
-{{CSSRef}}
-
 Dans ce guide, nous allons voir comment créer une forme à partir d'une image, que ce soit un fichier avec un canal alpha ou un dégradé CSS. Grâce aux images, on peut suivre une forme complexe sans avoir à dessiner de polygone. On peut créer la forme à partir d'un éditeur graphique et utiliser le contour de cette image formé par la ligne des pixels moins opaques qu'un seuil donné.
 
 ## Générer une forme simple avec une image

--- a/files/fr/web/css/guides/shapes/index.md
+++ b/files/fr/web/css/guides/shapes/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Shapes
 original_slug: Web/CSS/CSS_shapes
 ---
 
-{{CSSRef}}
-
 **_CSS Shapes_** est un module de spécification CSS qui décrit les formes géométriques. [Selon le niveau 1 de cette spécification](https://drafts.csswg.org/css-shapes/), les formes CSS peuvent être appliquées aux éléments flottants. Cette spécification définit différentes façon permettant de définir la forme d'un élément flottant afin que les lignes « coulent » autour de la forme plutôt qu'autour du rectangle formé par la boîte de l'élément.
 
 ## Exemple simple

--- a/files/fr/web/css/guides/shapes/overview/index.md
+++ b/files/fr/web/css/guides/shapes/overview/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Shapes/Overview
 original_slug: Web/CSS/CSS_shapes/Overview_of_shapes
 ---
 
-{{CSSRef}}
-
 La spécification [CSS Shapes Level 1](https://www.w3.org/TR/css-shapes/) définit les formes géométriques en CSS. Pour ce module de niveau 1, ces formes s'appliquent aux éléments qui utilisent une disposition flottante. Dans cet article, nous verrons un aperçu de ce qu'il est possible de faire avec les formes en CSS.
 
 Si on fait flotter un élément à gauche d'un texte, on verra le texte écrit autour de cet élément en suivant un contour rectangulaire. Si on applique une forme circulaire à cet élément, le texte suivra alors le contour du cercle.

--- a/files/fr/web/css/guides/shapes/using_shape-outside/index.md
+++ b/files/fr/web/css/guides/shapes/using_shape-outside/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Shapes/Using_shape-outside
 original_slug: Web/CSS/CSS_shapes/Basic_shapes
 ---
 
-{{CSSRef}}
-
 Les formes CSS peuvent être définies grâce au type {{cssxref("&lt;basic-shape&gt;")}}. Dans ce guide, nous verrons les différentes valeurs utilisables avec ce type et leur fonctionnement. Ces formes peuvent par exemple décrire des cercles simples voire des polygones complexes.
 
 Avant d'étudier ces formes dans le détail, attardons nous sur deux notions qui permettent de construire les formes :

--- a/files/fr/web/css/guides/syntax/comments/index.md
+++ b/files/fr/web/css/guides/syntax/comments/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Syntax/Comments
 original_slug: Web/CSS/CSS_syntax/Comments
 ---
 
-{{CSSRef}}
-
 Les commentaires sont utilisés afin d'ajouter des notes explicatives ou pour empêcher le navigateur d'interpréter certaines parties de la feuille de style. Les commentaires n'ont donc aucun impact sur la disposition d'un document.
 
 ## Syntaxe

--- a/files/fr/web/css/guides/table/index.md
+++ b/files/fr/web/css/guides/table/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Table
 original_slug: Web/CSS/CSS_table
 ---
 
-{{CSSRef}}
-
 **_CSS Table_** (ou module des tableaux CSS) est un module CSS qui définit comment disposer les données de tableaux.
 
 ## Référence

--- a/files/fr/web/css/guides/text/index.md
+++ b/files/fr/web/css/guides/text/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Text
 original_slug: Web/CSS/CSS_text
 ---
 
-{{CSSRef}}
-
 **_CSS Text_** (ou module texte de CSS) est un module CSS qui définit comment effectuer des manipulations de texte, comme les coupures de mots, la justification et l'alignement, la gestion des espaces et les transformations de texte.
 
 ## Référence

--- a/files/fr/web/css/guides/text_decoration/index.md
+++ b/files/fr/web/css/guides/text_decoration/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Text_decoration
 original_slug: Web/CSS/CSS_text_decoration
 ---
 
-{{CSSRef}}
-
 **_CSS Text Decoration_** (ou module des décorations textuelles CSS) est un module CSS qui définit les caractéristiques relatives à la décoration du texte, comme le soulignage, les ombres et les marques d'emphase.
 
 ## Référence

--- a/files/fr/web/css/guides/transforms/index.md
+++ b/files/fr/web/css/guides/transforms/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Transforms
 original_slug: Web/CSS/CSS_transforms
 ---
 
-{{CSSRef}}
-
 Le module **_CSS Transforms_** (ou module des transformations CSS) est un module de la spécification CSS qui définit comment les éléments mis en forme avec CSS peuvent être transformés dans un espace à deux ou à trois dimensions.
 
 ## Référence

--- a/files/fr/web/css/guides/transforms/using/index.md
+++ b/files/fr/web/css/guides/transforms/using/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Transforms/Using
 original_slug: Web/CSS/CSS_transforms/Using_CSS_transforms
 ---
 
-{{CSSRef}}
-
 En modifiant l'espace des coordonnées, les **transformations CSS** permettent de changer la forme et la position d'un contenu donner sans perturber le flux normal du document.
 
 Elles sont implémentées en utilisant un ensemble de propriétés CSS qui permettent d'appliquer des transformations linéaires affines aux éléments HTML. Ces transformations incluent la rotation, l'inclinaison, l'homothétie, et la translation à la fois dans le plan (2D) et dans l'espace (3D).

--- a/files/fr/web/css/guides/transitions/index.md
+++ b/files/fr/web/css/guides/transitions/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Transitions
 original_slug: Web/CSS/CSS_transitions
 ---
 
-{{CSSRef}}
-
 Les **transitions CSS** permettent de créer des transitions harmonieuses entre les valeurs des propriétés CSS concernées. Elles permettent aussi de définir leur évolution (accélération/décélération), via les fonctions de minutage.
 
 ## Référence

--- a/files/fr/web/css/guides/values_and_units/value_definition_syntax/index.md
+++ b/files/fr/web/css/guides/values_and_units/value_definition_syntax/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Values_and_units/Value_definition_syntax
 original_slug: Web/CSS/CSS_values_and_units/Value_definition_syntax
 ---
 
-{{CSSRef}}
-
 **La syntaxe de définition des valeurs CSS** est une grammaire formelle qui définit les règles pour créer des règles CSS valides. En plus de ces règles, il peut y avoir des contraintes sémantiques (ex. un nombre doit être positif pour une propriété donnée).
 
 La syntaxe de définition décrit les valeurs qui sont permises et les interactions entre ces valeurs. Un composant peut-être un mot-clé, un littéral, une valeur d'un type donné ou une autre propriété CSS.

--- a/files/fr/web/css/guides/writing_modes/index.md
+++ b/files/fr/web/css/guides/writing_modes/index.md
@@ -4,8 +4,6 @@ slug: Web/CSS/Guides/Writing_modes
 original_slug: Web/CSS/CSS_writing_modes
 ---
 
-{{CSSRef}}
-
 **_CSS Writing Modes_** (ou modes d'écriture CSS) est un module qui définit différents modes d'écriture internationaux comme l'écriture de gauche à droite (e.g. utilisée par les langues latines et indiennes), de droite à gauche (e.g. utilisée par l'hébreu ou l'arabe), bidirectionnelle (utilisée quand il y a à la fois des écritures de gauche à droite et de droite à gauche sont ) et verticale (e.g. utilisée par certains écrits asiatiques).
 
 ## Référence


### PR DESCRIPTION
### Description

Dans l'objectif actuel de https://github.com/orgs/mdn/projects/44 d'effectuer le nettoyage des pages du MDN pour les 1 an de cycle de maintenance, et afin d'accélérer l'obsolescence des macros de barre latérale qui ne sont plus du tout utilisées sur le MDN anglais ; cette mise à jour à pour objectif de cibler une macro liée à un thème et la supprimer sur toutes les pages.

### Motivation

- Aligner les pages au MDN.
- Préparer la possible suppression de ces macros à l'avenir.
- Éviter de surcharger l'interpréteur de page avec des macros obsolètes.
- Gagner en lisibilité sur les pages Markdown pour les futur·e·s contributeur·ice·s.

### Additional details

_none_

### Related issues and pull requests

Related to https://github.com/mdn-fr/documentation/issues/88
