### PR TITLE
chore(fr): remove remnant `{{PWASidebar}}` macros

### DIFF
--- a/files/fr/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/fr/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -3,8 +3,6 @@ title: Ajouter à l'écran d'accueil
 slug: Web/Progressive_web_apps/Guides/Making_PWAs_installable
 ---
 
-{{PWASidebar}}
-
 Ajouter à l'écran d'accueil (A2HS en abrégé) est une fonctionnalité disponible dans les navigateurs pour smartphones modernes qui permet aux développeurs d'ajouter facilement et rapidement un raccourci à leur écran d'accueil, représentant leur application Web. Ce guide explique comment utiliser A2HS et ce que vous devez faire en tant que développeur pour permettre à vos utilisateurs d'en tirer parti.
 
 ## Pourquoi A2HS?

--- a/files/fr/web/progressive_web_apps/tutorials/cycletracker/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/cycletracker/index.md
@@ -7,8 +7,6 @@ l10n:
 
 {{NextMenu("Web/Progressive_web_apps/Tutorials/CycleTracker/HTML_and_CSS")}}
 
-{{PWASidebar}}
-
 Dans ce tutoriel introductif, nous aborderons les différentes étapes pour construire une application web progressive (<i lang="en">PWA</i> pour <i lang="en">Progressive Web App</i> en anglais). Nous utiliserons ici les technologies web&nbsp;: HTML, CSS et JavaScript, afin de construire une application de suivi menstruel, appelée «&nbsp;CycleTracker&nbsp;». Comme toutes les applications web, CycleTracker sera conçue pour fonctionner sur l'ensemble des navigateurs et l'ensemble des appareils qui accèdent au Web.
 
 Nous commencerons par les étapes pour construire une application web complètement fonctionnelle, puis nous améliorerons CycleTracker afin qu'elle soit installable, et qu'elle fonctionne même lorsque la personne est hors-ligne.

--- a/files/fr/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 3c0315d7898d2a5bc21784002c9cdc9dddcf559d
 ---
 
-{{PWASidebar}}
-
 {{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/CycleTracker/Secure_connection", "Web/Progressive_web_apps/Tutorials/CycleTracker", "Web/Progressive_web_apps/Tutorials/CycleTracker")}}
 
 Dans la section précédente, nous avons écrit le code HTML et CSS de CycleTracker, et ainsi obtenu une version statique de notre application web. Dans cette section, nous écrirons le code JavaScript qui permettra de convertir le HTML statique en une application web fonctionnelle.

--- a/files/fr/web/progressive_web_apps/tutorials/cycletracker/manifest_file/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/cycletracker/manifest_file/index.md
@@ -8,8 +8,6 @@ l10n:
 
 {{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/CycleTracker/JavaScript_functionality", "Web/Progressive_web_apps/Tutorials/CycleTracker/Service_workers", "Web/Progressive_web_apps/Tutorials/CycleTracker")}}
 
-{{PWASidebar}}
-
 Le manifeste d'une PWA est un fichier JSON qui fournit des informations à propos des caractéristiques de l'application afin qu'elle puisse ressembler et se comporter comme une application native une fois installée sur un appareil. Le manifeste contient des métadonnées à propos de l'application comme son nom, ses icônes, ainsi que des directives d'affichage.
 
 Bien que la spécification considère l'ensemble des champs du manifeste comme facultatifs, certains navigateurs, systèmes d'exploitation ou outils de distribution imposent [certains champs obligatoires](/fr/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#required_manifest_members) pour qu'une application web soit une PWA. En incluant un nom ou un nom court, l'URL initiale, une icône respectant certains critères, le type de zone d'affichage dans laquelle l'application devrait être vue, votre application respectera les critères liés au manifeste pour être une PWA.

--- a/files/fr/web/progressive_web_apps/tutorials/cycletracker/secure_connection/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/cycletracker/secure_connection/index.md
@@ -8,8 +8,6 @@ l10n:
 
 {{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/CycleTracker/HTML_and_CSS", "Web/Progressive_web_apps/Tutorials/CycleTracker/JavaScript_functionality", "Web/Progressive_web_apps/Tutorials/CycleTracker")}}
 
-{{PWASidebar}}
-
 Les <i lang="en">service workers</i>, et par extension les PWA, sont [restreints aux contextes sécurisés](/fr/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts). Les contextes sécurisés incluent notamment les contextes TLS servis avec le protocole `https://` et les ressources servies localement (par exemple les URL avec l'hôte `127.0.0.1` ou `localhost`, servies avec le protocole `http://`). Dans cette section, nous aborderons les façons de servir une application localement et à distance avec une connexion sécurisée.
 
 Dans l'article précédent, nous avons utilisé HTML et CSS pour créer le squelette de notre application. Dans ce chapitre, nous ouvrirons le contenu statique de CycleTracker dans un navigateur, nous en verrons le contenu depuis un environnement de développement local, mais aussi depuis un serveur distant, avec une connexion sécurisée.

--- a/files/fr/web/progressive_web_apps/tutorials/cycletracker/service_workers/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/cycletracker/service_workers/index.md
@@ -4,8 +4,6 @@ short-title: Service workers
 slug: Web/Progressive_web_apps/Tutorials/CycleTracker/Service_workers
 ---
 
-{{PWASidebar}}
-
 {{PreviousMenu("Web/Progressive_web_apps/Tutorials/CycleTracker/Manifest_file", "Web/Progressive_web_apps/Tutorials/CycleTracker")}}
 
 Jusqu'à présent, nous avons écrit le HTML, le CSS et le JavaScript de l'application CycleTracker. Nous avons ajouté un fichier de manifeste qui définit les couleurs, icônes, URL et d'autres fonctionnalités de l'application. Notre application web est fonctionnelle&nbsp;! Toutefois, ce n'est pas encore une application web progressive. Dans cette section, nous écrirons le JavaScript nécessaire pour que notre application web devienne une PWA qui puisse être distribuée comme une application à part entière et qui fonctionne hors-ligne.

--- a/files/fr/web/progressive_web_apps/tutorials/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 8d202854ade7328f827da2951bc714455f78674f
 ---
 
-{{PWASidebar}}
-
 Cette page répertorie les tutoriels permettant d'apprendre à développer des applications web progressives (abbrégé <abbr title="Progressive Web Apps">PWA</abbr> en anglais pour «&nbsp;<i lang="en">Progressive Web Apps</i>&nbsp;»). Les tutoriels décrivent les étapes de la création d'une application, du début à la fin, en expliquant comment les différentes fonctionnalités de l'application sont mises en œuvre.
 
 - [Créer votre première PWA](/fr/docs/Web/Progressive_web_apps/Tutorials/CycleTracker)

--- a/files/fr/web/progressive_web_apps/tutorials/js13kgames/app_structure/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/js13kgames/app_structure/index.md
@@ -7,8 +7,6 @@ l10n:
 
 {{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/js13kGames", "Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers", "Web/Progressive_web_apps/Tutorials/js13kGames")}}
 
-{{PWASidebar}}
-
 Dans cet article, nous analyserons l'application [js13kPWA](https://mdn.github.io/pwa-examples/js13kpwa/), verrons pourquoi elle est construite de cette façon et les avantages que cela apporte.
 
 La structure du site web [js13kPWA](https://mdn.github.io/pwa-examples/js13kpwa/) est plutôt simple&nbsp;: elle consiste en un simple fichier HTML ([`index.html`](https://github.com/mdn/pwa-examples/blob/master/js13kpwa/index.html)) avec un style CSS basique ([`style.css`](https://github.com/mdn/pwa-examples/blob/master/js13kpwa/style.css)) et quelques images, scripts et polices de caractères. La structure du répertoire ressemble à ceci&nbsp;:

--- a/files/fr/web/progressive_web_apps/tutorials/js13kgames/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/js13kgames/index.md
@@ -7,8 +7,6 @@ l10n:
 
 {{NextMenu("Web/Progressive_web_apps/Tutorials/js13kGames/App_structure", "Web/Progressive_web_apps/Tutorials/js13kGames")}}
 
-{{PWASidebar}}
-
 Dans ce tutoriel, nous allons examiner le code source d'un site web qui répertorie des informations sur les jeux soumis dans la catégorie _A-Frame_ du concours [js13kGames 2017](https://2017.js13kgames.com/). Vous n'avez pas besoin de vous soucier du contenu même de ce site web&nbsp;; l'essentiel est d'apprendre à utiliser les fonctionnalités des PWA dans vos propres projets.
 
 Vous pouvez [voir cette application en ligne](https://mdn.github.io/pwa-examples/js13kpwa/), et le code source est [disponible sur GitHub](https://github.com/mdn/pwa-examples/tree/master/js13kpwa). Dans ce tutoriel, nous allons examiner attentivement ce code.

--- a/files/fr/web/progressive_web_apps/tutorials/js13kgames/installable_pwas/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/js13kgames/installable_pwas/index.md
@@ -7,8 +7,6 @@ l10n:
 
 {{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers", "Web/Progressive_web_apps/Tutorials/js13kGames/Re-engageable_Notifications_Push", "Web/Progressive_web_apps/Tutorials/js13kGames")}}
 
-{{PWASidebar}}
-
 Dans l'article précédent, nous avons vu comment [js13kPWA](https://mdn.github.io/pwa-examples/js13kpwa/) fonctionne en mode hors connexion grâce à son [<i lang="en">service worker</i>](/fr/docs/Web/API/Service_Worker_API), mais nous pouvons aller encore plus loin et permettre aux utilisatrices et utilisateurs d'installer l'application web sur leur appareil. L'application web installée peut ensuite être lancée comme s'il s'agissait d'une application native du système d'exploitation. Cet article explique comment y parvenir à l'aide du manifeste de l'application web.
 
 Ces technologies permettent à l'application d'être directement lancée depuis l'écran d'accueil, la barre de tâche, ou le dock de l'appareil, plutôt que d'ouvrir le navigateur, puis d'accéder au site en utilisant un marque-page ou en tapant l'URL. Votre application web peut être placée à côté d'applications natives, ce qui en facilite l'accès. De plus, vous pouvez spécifier que l'application soit lancée en mode plein écran ou autonome, supprimant ainsi l'interface utilisateur du navigateur par défaut qui serait autrement présente, créant ainsi une sensation encore plus transparente et native.

--- a/files/fr/web/progressive_web_apps/tutorials/js13kgames/loading/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/js13kgames/loading/index.md
@@ -7,8 +7,6 @@ l10n:
 
 {{PreviousMenu("Web/Progressive_web_apps/Tutorials/js13kGames/Re-engageable_Notifications_Push", "Web/Progressive_web_apps/Tutorials/js13kGames")}}
 
-{{PWASidebar}}
-
 Dans les articles précédents, nous avons abordé les API qui permettent que [js13kPWA](https://mdn.github.io/pwa-examples/js13kpwa/) soit une application web progressive&nbsp;:
 
 - [Les <i lang="en">service workers</i>](/fr/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers)

--- a/files/fr/web/progressive_web_apps/tutorials/js13kgames/offline_service_workers/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/js13kgames/offline_service_workers/index.md
@@ -7,8 +7,6 @@ l10n:
 
 {{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/js13kGames/App_structure", "Web/Progressive_web_apps/Tutorials/js13kGames/Installable_PWAs", "Web/Progressive_web_apps/Tutorials/js13kGames")}}
 
-{{PWASidebar}}
-
 Maintenant que nous avons vu la structure de notre application js13kPWA, que nous avons configuré et fait fonctionner le squelette de base, voyons comment implémenter un mode hors connexion à l'aide des <i lang="en">service workers</i>. Dans cet article, nous examinerons comment ils sont utilisés dans notre [exemple js13kPWA](https://mdn.github.io/pwa-examples/js13kpwa/) ([voir également le code source](https://github.com/mdn/pwa-examples/tree/master/js13kpwa)).
 
 ## Explication des service workers

--- a/files/fr/web/progressive_web_apps/tutorials/js13kgames/re-engageable_notifications_push/index.md
+++ b/files/fr/web/progressive_web_apps/tutorials/js13kgames/re-engageable_notifications_push/index.md
@@ -7,8 +7,6 @@ l10n:
 
 {{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/js13kGames/Installable_PWAs", "Web/Progressive_web_apps/Tutorials/js13kGames/Loading", "Web/Progressive_web_apps/Tutorials/js13kGames")}}
 
-{{PWASidebar}}
-
 Mettre en cache le contenu d'une application pour travailler en mode déconnecté est une fonctionnalité appréciable, tout comme l'installation d'une application web sur son écran d'accueil. Toutefois, nous pouvons aller plus loin que les utilisations initiées par la personne. En effet, grâce aux messages poussés (<i lang="en">push messages</i>) et aux notifications, nous pouvons informer l'utilisatrice ou l'utilisateur que de nouvelles informations sont disponibles.
 
 ## Deux API, un seul but


### PR DESCRIPTION
### Description

Dans l'objectif actuel de https://github.com/orgs/mdn/projects/44 d'effectuer le nettoyage des pages du MDN pour les 1 an de cycle de maintenance, et afin d'accélérer l'obsolescence des macros de barre latérale qui ne sont plus du tout utilisées sur le MDN anglais ; cette mise à jour à pour objectif de cibler une macro liée à un thème et la supprimer sur toutes les pages.

### Motivation

- Aligner les pages au MDN.
- Préparer la possible suppression de ces macros à l'avenir.
- Éviter de surcharger l'interpréteur de page avec des macros obsolètes.
- Gagner en lisibilité sur les pages Markdown pour les futur·e·s contributeur·ice·s.

### Additional details

_none_

### Related issues and pull requests

Related to https://github.com/mdn-fr/documentation/issues/88
