### PR TITLE
chore(fr): remove remnant `{{SVGRef}}` macros

### DIFF
--- a/files/fr/web/svg/reference/attribute/clip-path/index.md
+++ b/files/fr/web/svg/reference/attribute/clip-path/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/clip-path
 original_slug: Web/SVG/Attribute/clip-path
 ---
 
-{{SVGRef}}
-
 L'attribut **`clip-path`** permet d'appliquer un détourage à un élément.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/attribute/color/index.md
+++ b/files/fr/web/svg/reference/attribute/color/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/color
 original_slug: Web/SVG/Attribute/color
 ---
 
-{{SVGRef}}
-
 L'attribut `color` est utilisé pour définir indirectement une valeur potentielle (`currentColor`) pour les attributs {{ SVGAttr("fill") }}, {{ SVGAttr("stroke") }}, {{ SvgAttr("stop-color") }}, {{ SVGAttr("flood-color") }} et {{ SVGAttr("lighting-color") }}.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/attribute/cx/index.md
+++ b/files/fr/web/svg/reference/attribute/cx/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/cx
 original_slug: Web/SVG/Attribute/cx
 ---
 
-{{SVGRef}}
-
 L'attribut **`cx`** définit la coordonnée de l'axe x pour le point central d'un élément.
 
 Trois éléments utilisent cet attribut: {{SVGElement("circle")}}, {{SVGElement("ellipse")}}, et {{SVGElement("radialGradient")}}

--- a/files/fr/web/svg/reference/attribute/d/index.md
+++ b/files/fr/web/svg/reference/attribute/d/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 1a26583f60bdceece64347bf967d0653fe8df288
 ---
 
-{{SVGRef}}
-
 L'attribut **`d`** définit un tracé à dessiner.
 
 La définition d'un tracé est une liste de [commandes de tracé](#commandes_de_tracé) où chaque commande est composée d'une lettre pour la commande, et de nombres qui représentent les paramètres de la commande. Les commandes sont détaillées [ci-dessous](#commandes_de_tracé).

--- a/files/fr/web/svg/reference/attribute/dx/index.md
+++ b/files/fr/web/svg/reference/attribute/dx/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/dx
 original_slug: Web/SVG/Attribute/dx
 ---
 
-{{SVGRef}}
-
 L'attribut **`dx`** indique un décalage sur l'axe x de la position d'un élément ou de son contenu.
 
 Sept éléments utilisent cet attribut: {{SVGElement('altGlyph')}}, {{SVGElement('feDropShadow')}}, {{SVGElement('feOffset')}}, {{SVGElement('glyphRef')}}, {{SVGElement('text')}}, {{SVGElement('tref')}}, et {{SVGElement('tspan')}}

--- a/files/fr/web/svg/reference/attribute/dy/index.md
+++ b/files/fr/web/svg/reference/attribute/dy/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/dy
 original_slug: Web/SVG/Attribute/dy
 ---
 
-{{SVGRef}}
-
 L'attribut **`dy`** indique un décalage sur l'axe y de la position d'un élément ou de son contenu.
 
 Sept éléments utilisent cet attribut: {{SVGElement('altGlyph')}}, {{SVGElement('feDropShadow')}}, {{SVGElement('feOffset')}}, {{SVGElement('glyphRef')}}, {{SVGElement('text')}}, {{SVGElement('tref')}}, et {{SVGElement('tspan')}}

--- a/files/fr/web/svg/reference/attribute/fill-opacity/index.md
+++ b/files/fr/web/svg/reference/attribute/fill-opacity/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/fill-opacity
 original_slug: Web/SVG/Attribute/fill-opacity
 ---
 
-{{SVGRef}}
-
 L'attribut **`fill-opacity`** définit l'opacité du remplissage (_couleur, dégradé, motif_, etc) appliqué à une forme.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/attribute/fill-rule/index.md
+++ b/files/fr/web/svg/reference/attribute/fill-rule/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/fill-rule
 original_slug: Web/SVG/Attribute/fill-rule
 ---
 
-{{SVGRef}}
-
 L'attribut **`fill-rule`** définit l'algorithme à utiliser pour déterminer les parties qui sont considérées _à l'intérieur_ de la forme.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/attribute/fill/index.md
+++ b/files/fr/web/svg/reference/attribute/fill/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/fill
 original_slug: Web/SVG/Attribute/fill
 ---
 
-{{SVGRef}}
-
 L'attribut **`fill`** a deux significations différentes: 1. pour les formes et le texte, il définit le remplissage (_couleur, dégradé, motif, etc_); 2. pour les animations, il définit l'état final.
 
 Cet attribut peut être appliqué à tous les éléments, en revanche il n'aura d'effet que sur les formes suivantes: {{SVGElement('altGlyph')}}, {{SVGElement('circle')}}, {{SVGElement('ellipse')}}, {{SVGElement('path')}}, {{SVGElement('polygon')}}, {{SVGElement('polyline')}}, {{SVGElement('rect')}}, {{SVGElement('text')}}, {{SVGElement('textPath')}}, {{SVGElement('tref')}}, et {{SVGElement('tspan')}}

--- a/files/fr/web/svg/reference/attribute/height/index.md
+++ b/files/fr/web/svg/reference/attribute/height/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/height
 original_slug: Web/SVG/Attribute/height
 ---
 
-{{SVGRef}}
-
 L'attribut **`height`** définit la longueur verticale d'un élément dans le système des coordonnées de l'utilisatrice ou l'utilisateur.
 
 Cet attribut peut être utilisé avec les éléments SVG suivants&nbsp;:

--- a/files/fr/web/svg/reference/attribute/in/index.md
+++ b/files/fr/web/svg/reference/attribute/in/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/in
 original_slug: Web/SVG/Attribute/in
 ---
 
-{{SVGRef}}
-
 « [SVG Attribute reference home](/fr/docs/Web/SVG/Reference/Attribute)
 
 L'attribut `in` identifie l'entrée pour la primitive de filtre donnée.

--- a/files/fr/web/svg/reference/attribute/mask/index.md
+++ b/files/fr/web/svg/reference/attribute/mask/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/mask
 original_slug: Web/SVG/Attribute/mask
 ---
 
-{{SVGRef}}
-
 L'attribut `mask` est un attribut de présentation principalement utilisé pour appliquer un trou (défini par un élément {{ SVGElement("mask") }}) sur l'élément qui possède cet attribut.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/attribute/points/index.md
+++ b/files/fr/web/svg/reference/attribute/points/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/points
 original_slug: Web/SVG/Attribute/points
 ---
 
-{{SVGRef}}
-
 L'attribut **`point`** défini une liste de points. Chaque point est défini par deux nombres représentant les coordonnées X et Y dans le système de coordonnées de l'utilisateur. Si une coordonnées est dépareillée elle sera ignorée.
 
 Les éléments {{SVGElement("polyline")}} et {{SVGElement("polygon")}} utilisent cet attribut.

--- a/files/fr/web/svg/reference/attribute/preserveaspectratio/index.md
+++ b/files/fr/web/svg/reference/attribute/preserveaspectratio/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/preserveAspectRatio
 original_slug: Web/SVG/Attribute/preserveAspectRatio
 ---
 
-{{SVGRef}}
-
 L'attribut **`preserveAspectRatio`** indique comment un élément est mis à l'échelle lorsque le ratio largeur:hauteur de la [`viewBox`](/fr/docs/Web/SVG/Reference/Attribute/viewBox) est différent du ratio de la zone d'affichage (défini par les attributs `width` et `height`).
 
 Parce que les proportions du SVG sont définies par l'attribut `viewBox`, si ce dernier n'est pas défini alors l'attribut `preserveAspectRatio` n'a aucun effet (_à l'exception près de l'élément [`<image>`](/fr/docs/Web/SVG/Reference/Element/image) comme décrit ci-dessous_).

--- a/files/fr/web/svg/reference/attribute/seed/index.md
+++ b/files/fr/web/svg/reference/attribute/seed/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/seed
 original_slug: Web/SVG/Attribute/seed
 ---
 
-{{SVGRef}}
-
 « [Page de référence des attributs SVG](/fr/docs/Web/SVG/Reference/Attribute)
 
 L'attribut `seed` représente le nombre palier pour la pseudo génération d'un nombre aléatoire via la primitive {{SVGElement("feTurbulence")}}.

--- a/files/fr/web/svg/reference/attribute/stroke-dasharray/index.md
+++ b/files/fr/web/svg/reference/attribute/stroke-dasharray/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/stroke-dasharray
 original_slug: Web/SVG/Attribute/stroke-dasharray
 ---
 
-{{SVGRef}}
-
 L'attribut **`stroke-dasharray`** est un attribut de présentation qui définit le motif des traits et des espaces utilisés pour dessiner le contour de la forme.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/attribute/stroke-dashoffset/index.md
+++ b/files/fr/web/svg/reference/attribute/stroke-dashoffset/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/stroke-dashoffset
 original_slug: Web/SVG/Attribute/stroke-dashoffset
 ---
 
-{{SVGRef}}
-
 L'attribut **`stroke-dashoffset`** décale la position de départ des pointillés sur les lignes SVG.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/attribute/stroke-linecap/index.md
+++ b/files/fr/web/svg/reference/attribute/stroke-linecap/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/stroke-linecap
 original_slug: Web/SVG/Attribute/stroke-linecap
 ---
 
-{{SVGRef}}
-
 L'attribut **`stroke-linecap`** définit la forme de la fin des lignes SVG.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/attribute/stroke-linejoin/index.md
+++ b/files/fr/web/svg/reference/attribute/stroke-linejoin/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/stroke-linejoin
 original_slug: Web/SVG/Attribute/stroke-linejoin
 ---
 
-{{SVGRef}}
-
 L'attribut **`stroke-linejoin`** définit la manière de dessiner la liaison entre deux segments de ligne.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/attribute/stroke-miterlimit/index.md
+++ b/files/fr/web/svg/reference/attribute/stroke-miterlimit/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/stroke-miterlimit
 original_slug: Web/SVG/Attribute/stroke-miterlimit
 ---
 
-{{SVGRef}}
-
 L'attribut **`stroke-miterlimit`** définit la limite du rapport entre la longueur du coin et la valeur de {{ SVGAttr("stroke-width") }} utilisée pour dessiner la [liaison entre deux segments de ligne](/fr/docs/Web/SVG/Reference/Attribute/stroke-linejoin). Quand la limite est dépassée, la liaison passe du type _miter_ (pointu) au type _bevel_ (biseauté).
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/attribute/stroke-opacity/index.md
+++ b/files/fr/web/svg/reference/attribute/stroke-opacity/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/stroke-opacity
 original_slug: Web/SVG/Attribute/stroke-opacity
 ---
 
-{{SVGRef}}
-
 L'attribut **`stroke-opacity`** définit l'opacité du contour (_couleur_, _dégradé_, _motif_, etc) appliqué à une forme SVG.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/attribute/stroke-width/index.md
+++ b/files/fr/web/svg/reference/attribute/stroke-width/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/stroke-width
 original_slug: Web/SVG/Attribute/stroke-width
 ---
 
-{{SVGRef}}
-
 L'attribut **`stroke-width`** définit l'épaisseur du contour à appliquer à une forme SVG.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/attribute/stroke/index.md
+++ b/files/fr/web/svg/reference/attribute/stroke/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/stroke
 original_slug: Web/SVG/Attribute/stroke
 ---
 
-{{SVGRef}}
-
 L'attribut **`stroke`** définit la couleur (ou n'importe quelle méthode de remplissage, comme un gradient ou motif) a utiliser pour dessiner le contour d'une forme SVG.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/attribute/style/index.md
+++ b/files/fr/web/svg/reference/attribute/style/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/style
 original_slug: Web/SVG/Attribute/style
 ---
 
-{{SVGRef}}
-
 L'attribut **`style`** définit les [informations de style](/fr/docs/Web/CSS) pour son élément. Il fonctionne de manière identique à [l'attribut `style` en HTML](/fr/docs/Web/HTML/Reference/Global_attributes/style).
 
 ## Context d'utilisation

--- a/files/fr/web/svg/reference/attribute/text-anchor/index.md
+++ b/files/fr/web/svg/reference/attribute/text-anchor/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/text-anchor
 original_slug: Web/SVG/Attribute/text-anchor
 ---
 
-{{SVGRef}}
-
 L'attribut **`text-anchor`** est utilisé pour aligner (alignement de début, de milieu ou de fin) une chaîne de texte préformaté ou un texte auto-enveloppé dont la zone d'enveloppement est déterminée à partir de la propriété [`inline-size`](/fr/docs/Web/SVG/Attribute/inline-size) par rapport à un point donné. Elle ne s'applique pas aux autres types de texte auto-enveloppé. Pour ces cas, vous devez utiliser [`text-align`](/fr/docs/Web/CSS/Reference/Properties/text-align). Pour le texte à plusieurs lignes, l'alignement a lieu pour chaque ligne.
 
 L'attribut `text-anchor` est appliqué à chaque bloc de texte individuel dans un élément [`<text>`](/fr/docs/Web/SVG/Reference/Element/text) donné. Chaque fragment de texte a une position de texte actuelle initiale, qui représente le point du système de coordonnées de l'utilisateur résultant (selon le contexte) de l'application des attributs [`x`](/fr/docs/Web/SVG/Reference/Attribute/x) et [`y`](/fr/docs/Web/SVG/Attribute/y) sur l'élément `<text>`, toute valeur d'attribut `x` ou `y` sur un élément [`<tspan>`](/fr/docs/Web/SVG/Reference/Element/tspan), [`<tref>`](/fr/docs/Web/CSS/Reference/At-rules/@font-face) ou [`<altGlyph>`](/fr/docs/Web/SVG/Element/altGlyph) assigné explicitement au premier caractère rendu dans un fragment de texte, ou la détermination de la position initiale du texte actuel pour un élément [`<textPath>`](/fr/docs/Web/SVG/Element/textPath).

--- a/files/fr/web/svg/reference/attribute/transform/index.md
+++ b/files/fr/web/svg/reference/attribute/transform/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/transform
 original_slug: Web/SVG/Attribute/transform
 ---
 
-{{SVGRef}}
-
 L'attribut **`transform`** définit une liste de définitions de transformation qui sont appliquées à l'élément ainsi qu'à ses éléments fils.
 
 ## Exemple

--- a/files/fr/web/svg/reference/attribute/viewbox/index.md
+++ b/files/fr/web/svg/reference/attribute/viewbox/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/viewBox
 original_slug: Web/SVG/Attribute/viewBox
 ---
 
-{{SVGRef}}
-
 « [Sommaire de la référence des attributs SVG](/fr/docs/Web/SVG/Reference/Attribute)
 
 L'attribut `viewBox` permet de spécifier qu'un groupe d'éléments graphiques s'étire afin de s'adapter à un élément conteneur.

--- a/files/fr/web/svg/reference/attribute/width/index.md
+++ b/files/fr/web/svg/reference/attribute/width/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/width
 original_slug: Web/SVG/Attribute/width
 ---
 
-{{SVGRef}}
-
 L'attribut **`width`** définit la longueur horizontale d'un élément dans le système des coordonnées de l'utilisatrice ou l'utilisateur.
 
 Cet attribut peut être utilisé avec les éléments SVG suivants&nbsp;:

--- a/files/fr/web/svg/reference/attribute/x/index.md
+++ b/files/fr/web/svg/reference/attribute/x/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Attribute/x
 original_slug: Web/SVG/Attribute/x
 ---
 
-{{SVGRef}}
-
 L'attribut **`x`** définit une coordonnée en abscisse dans le système de coordonnées de l'utilisatrice ou l'utilisateur.
 
 Cet attribut peut être utilisé avec les éléments SVG suivants&nbsp;:

--- a/files/fr/web/svg/reference/element/a/index.md
+++ b/files/fr/web/svg/reference/element/a/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/a
 original_slug: Web/SVG/Element/a
 ---
 
-{{SVGRef}}
-
 L'élément SVG **`<a>`** crée un hyperlien vers d'autres pages web, fichiers, emplacements dans la page en cours, adresses email, ou toute autre URL.
 
 En SVG, l'élément `<a>` est un conteneur, ce qui veut dire que vous pouvez créer un lien autour du texte comme en HTML, mais que vous pouvez aussi créer un lien autour de n'importe quelle forme.

--- a/files/fr/web/svg/reference/element/animate/index.md
+++ b/files/fr/web/svg/reference/element/animate/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/animate
 original_slug: Web/SVG/Element/animate
 ---
 
-{{SVGRef}}
-
 L'élément SVG **`<animate>`** permet d'animer un attribut d'un élément au fil du temps.
 
 ## Exemple

--- a/files/fr/web/svg/reference/element/animatemotion/index.md
+++ b/files/fr/web/svg/reference/element/animatemotion/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/animateMotion
 original_slug: Web/SVG/Element/animateMotion
 ---
 
-{{SVGRef}}
-
 L'élément **`<animateMotion>`** permet d'animer un élément le long d'un chemin donné.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/animatetransform/index.md
+++ b/files/fr/web/svg/reference/element/animatetransform/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/animateTransform
 original_slug: Web/SVG/Element/animateTransform
 ---
 
-{{SVGRef}}
-
 L'élément **`<animateTransform>`** permet d'animer un élement en appliquant une transformation: translation, mise à l'échelle, rotation et/ou inclinaison.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/circle/index.md
+++ b/files/fr/web/svg/reference/element/circle/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/circle
 original_slug: Web/SVG/Element/circle
 ---
 
-{{SVGRef}}
-
 L'élément `circle` est un élément de la catégorie des Formes simples, utilisé pour créer des cercles, en se basant sur un centre et un rayon.
 
 ## Usage

--- a/files/fr/web/svg/reference/element/clippath/index.md
+++ b/files/fr/web/svg/reference/element/clippath/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/clipPath
 original_slug: Web/SVG/Element/clipPath
 ---
 
-{{SVGRef}}
-
 L'élément [SVG](/fr/docs/Web/SVG) **`<clipPath>`** définit un détourage. Ce détourage peut par la suite être appliqué sur une forme en utilisant la propriété {{SVGAttr("clip-path")}}.
 
 Le détourage limite la zone dans laquelle l'élément sur lequel il est appliqué sera dessiné. Autrement dit, les parties de l'élément en dehors de la forme créée par le détourage ne seront pas affichées.

--- a/files/fr/web/svg/reference/element/defs/index.md
+++ b/files/fr/web/svg/reference/element/defs/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/defs
 original_slug: Web/SVG/Element/defs
 ---
 
-{{SVGRef}}
-
 SVG permet de définir des objets graphiques (génériques) pour une utilisation ultérieure. Autant qu'il est possible, cet usage est recommandé grâce aux propriétés offertes par l'élément `defs`.
 Ainsi définir ces éléments au sein de l'élément `defs` promeut une meilleure compréhension du contenu SVG par l'homme et donc son accessibilité.
 

--- a/files/fr/web/svg/reference/element/ellipse/index.md
+++ b/files/fr/web/svg/reference/element/ellipse/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/ellipse
 original_slug: Web/SVG/Element/ellipse
 ---
 
-{{SVGRef}}
-
 L'élément `ellipse` est une forme basique SVG,utilisé pour créer des ellipses basées sur un centre, et ses deux rayons x et y.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/element/fecolormatrix/index.md
+++ b/files/fr/web/svg/reference/element/fecolormatrix/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feColorMatrix
 original_slug: Web/SVG/Element/feColorMatrix
 ---
 
-{{SVGRef}}
-
 La primitive de filtre SVG **`<feColorMatrix>`** change les couleurs d'un élément en fonction d'une matrice de transformation. Chaque pixel (représenté par un vecteur \[R,G,B,A]) est [multiplié par matrice](https://fr.wikipedia.org/wiki/Produit_matriciel) pour créer une nouvelle couleur:
 
 ```

--- a/files/fr/web/svg/reference/element/fecomponenttransfer/index.md
+++ b/files/fr/web/svg/reference/element/fecomponenttransfer/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feComponentTransfer
 original_slug: Web/SVG/Element/feComponentTransfer
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feComponentTransfer>`** permet d'effectuer un remappage des composantes de couleur (rouge, bleu, vert et alpha) de chaque pixel. Cela permet notamment de régler la luminosité, le constraste, la balance des couleurs ou encore le seuillage.
 
 Les calculs sont effectués sur les valeurs de couleur non prémultipliées. Chaque canal de couleur est modifié en utilisant le résultat des éléments {{SVGElement("feFuncR")}}, {{SVGElement("feFuncB")}}, {{SVGElement("feFuncG")}}, et {{SVGElement("feFuncA")}} placés à l'intérieur de la balise.

--- a/files/fr/web/svg/reference/element/fecomposite/index.md
+++ b/files/fr/web/svg/reference/element/fecomposite/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feComposite
 original_slug: Web/SVG/Element/feComposite
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feComposite>`** effectue la combinaison de deux images en entrée, pixel par pixel, en utilisant une des opérations de composition de Porter-Duff: `over`_,_ `in`_,_ `atop`_,_ `out`_,_ `xor`, et `lighter`. Il est également possible d'appliquer une opération de type `arithmetic` (avec un résultat borné entre \[0..1]).
 
 L'opération `arithmetic` est utile pour combiner le résultat de {{SVGElement("feDiffuseLighting")}} et {{SVGElement("feSpecularLighting")}} avec des textures. Si l'opération `arithmetic` est choisie, chaque pixel est calculé à l'aide de la formule suivante:

--- a/files/fr/web/svg/reference/element/feconvolvematrix/index.md
+++ b/files/fr/web/svg/reference/element/feconvolvematrix/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feConvolveMatrix
 original_slug: Web/SVG/Element/feConvolveMatrix
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feConvolveMatrix>`** applique une matrice de convolution d'effet de filtre. Une convolution combine les pixels de l'image en entrée avec ceux voisins pour donner une image résultante. On peut obtenir une grande variété d'opérations d'imagerie à l'aide de convolutions, dont le flou, la détection de bord, la netteté, l'estampage et le chanfreinage.
 
 Une convolution de matrice se fonde sur une matrice n par m (le noyau de convolution), qui décrit la façon dont une valeur de pixel donné de l'image en entrée est combinée avec celles des pixels de son voisinage pour aboutir à une valeur de pixel résultante. Chaque pixel du résultat est déterminé par l'application de la matrice noyau sur le pixel source correspondant et ses pixels voisins. La formule de convolution de base, appliquée à chaque valeur de couleur d'un pixel donné, est :

--- a/files/fr/web/svg/reference/element/fediffuselighting/index.md
+++ b/files/fr/web/svg/reference/element/fediffuselighting/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feDiffuseLighting
 original_slug: Web/SVG/Element/feDiffuseLighting
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feDiffuseLighting>`** éclaire une image en utilisant son canal alpha en tant que relief. L'image résultante, qui est une image RGBA opaque, dépend de la couleur de la lumière, de sa position et du relief de l'image en entrée.
 
 La lumière crée par cette primitive de filtre peut être combinée avec une image de texture à l'aide de l'opérateur `arithmetic` de la primitive de filtre {{SVGElement("feComposite")}}. De multiples sources lumineuses peuvent être simulées en ajoutant plusieurs éléments à la texture.

--- a/files/fr/web/svg/reference/element/fedisplacementmap/index.md
+++ b/files/fr/web/svg/reference/element/fedisplacementmap/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feDisplacementMap
 original_slug: Web/SVG/Element/feDisplacementMap
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feDisplacementMap>`** utilise les valeurs de pixel de l'image de {{SVGAttr("in2")}} pour déplacer spatialement l'image de {{SVGAttr("in")}}.
 
 La formule utilisée pour la transformation est comme suit:

--- a/files/fr/web/svg/reference/element/fedistantlight/index.md
+++ b/files/fr/web/svg/reference/element/fedistantlight/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feDistantLight
 original_slug: Web/SVG/Element/feDistantLight
 ---
 
-{{SVGRef}}
-
 La primitive de filtre **`<feDistantLight>`** définit une source de lumière distante, que l'on place dans une primitive de filtre d'éclairage:{{SVGElement("feDiffuseLighting")}} ou {{SVGElement("feSpecularLighting")}}.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/fedropshadow/index.md
+++ b/files/fr/web/svg/reference/element/fedropshadow/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feDropShadow
 original_slug: Web/SVG/Element/feDropShadow
 ---
 
-{{SVGRef}}
-
 La primitive de filtre **`<feDropShadow>`** crée une ombre portée pour l'image en entrée. Il s'agit d'un raccourci, le résultat du filtre `<feDropShadow>` revient à appliquer les primitives suivantes:
 
 ```xml

--- a/files/fr/web/svg/reference/element/feflood/index.md
+++ b/files/fr/web/svg/reference/element/feflood/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feFlood
 original_slug: Web/SVG/Element/feFlood
 ---
 
-{{SVGRef}}
-
 La primitive de filtre SVG **`<feFlood>`** remplit la région du filtre avec la couleur et l'opacité définies par {{SVGAttr("flood-color")}} et {{SVGAttr("flood-opacity")}}.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/fefunca/index.md
+++ b/files/fr/web/svg/reference/element/fefunca/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feFuncA
 original_slug: Web/SVG/Element/feFuncA
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feFuncA>`** doit être placée dans une balise {{SVGElement("feComponentTransfer")}} et elle définit la fonction de transfert pour le canal alpha (opacité) de l'image en entrée.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/fefuncb/index.md
+++ b/files/fr/web/svg/reference/element/fefuncb/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feFuncB
 original_slug: Web/SVG/Element/feFuncB
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feFuncB>`** doit être placée dans une balise {{SVGElement("feComponentTransfer")}} et elle définit la fonction de transfert pour le canal bleu de l'image en entrée.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/fefuncg/index.md
+++ b/files/fr/web/svg/reference/element/fefuncg/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feFuncG
 original_slug: Web/SVG/Element/feFuncG
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feFuncG>`** doit être placée dans une balise {{SVGElement("feComponentTransfer")}} et elle définit la fonction de transfert pour le canal vert de l'image en entrée.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/fefuncr/index.md
+++ b/files/fr/web/svg/reference/element/fefuncr/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feFuncR
 original_slug: Web/SVG/Element/feFuncR
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feFuncR>`** doit être placée dans une balise {{SVGElement("feComponentTransfer")}} et elle définit la fonction de transfert pour le canal rouge de l'image en entrée.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/feimage/index.md
+++ b/files/fr/web/svg/reference/element/feimage/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feImage
 original_slug: Web/SVG/Element/feImage
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feImage>`** extrait les données d'une image d'une source externe et retourne les pixels récupérés en sortie (autrement dit, si l'image récupérée est une image SVG, elle sortira comme raster)
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/femerge/index.md
+++ b/files/fr/web/svg/reference/element/femerge/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feMerge
 original_slug: Web/SVG/Element/feMerge
 ---
 
-{{SVGRef}}
-
 La primitive de filtre SVG **`<feMerge>`** permet d'empiler les résultats de différentes opérations de filtre les uns par dessus les autres. La liste des images à empiler est définit par une liste d'élément {{ SVGElement("feMergeNode") }} à l'intérieur de la balise. Pour y parvenir, stocker au préalable les résultats des filtres voulus dans un buffer temporaire grâce à l'attribut {{ SVGAttr("result") }}.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/femergenode/index.md
+++ b/files/fr/web/svg/reference/element/femergenode/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feMergeNode
 original_slug: Web/SVG/Element/feMergeNode
 ---
 
-{{SVGRef}}
-
 L'élément SVG `feMergeNode` se place à l'intérieur d'un élément {{ SVGElement("feMerge") }}. Il prend en entrée le résultat d'un filtre afin qu'il soit traité par son parent.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/femorphology/index.md
+++ b/files/fr/web/svg/reference/element/femorphology/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feMorphology
 original_slug: Web/SVG/Element/feMorphology
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feMorphology>`** est utilisée pour éroder ou dilater l'image en entrée. Cela permet d'appliquer des effets de mise en gras ou d'amincissement.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/fepointlight/index.md
+++ b/files/fr/web/svg/reference/element/fepointlight/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/fePointLight
 original_slug: Web/SVG/Element/fePointLight
 ---
 
-{{SVGRef}}
-
 La primitive de filtre **`<fePointLight>`** définit une source de lumière qui permet de créer un point lumineux. On la place dans une primitive de filtre d'éclairage: {{SVGElement("feDiffuseLighting")}} or {{SVGElement("feSpecularLighting")}}.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/fespecularlighting/index.md
+++ b/files/fr/web/svg/reference/element/fespecularlighting/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feSpecularLighting
 original_slug: Web/SVG/Element/feSpecularLighting
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feSpecularLighting>`** éclaire une image en utilisant son canal alpha en tant que relief. L'image résultante est une image RGBA qui dépend de la couleur de la lumière, de sa position et du relief de l'image en entrée. Le calcul de l'éclairage se fait suivant le [modèle d'illumination de Phong](https://fr.wikipedia.org/wiki/Ombrage_de_Phong).
 
 La lumière crée par cette primitive de filtre peut être combinée avec une image de texture à l'aide de l'opérateur `arithmetic` de la primitive de filtre {{SVGElement("feComposite")}}. De multiples sources lumineuses peuvent être simulées en ajoutant plusieurs éléments à la texture.

--- a/files/fr/web/svg/reference/element/fespotlight/index.md
+++ b/files/fr/web/svg/reference/element/fespotlight/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feSpotLight
 original_slug: Web/SVG/Element/feSpotLight
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feSpotLight>`** définit une source de lumière qui permet de créer un feu de projecteur. On la place dans une primitive de filtre d'éclairage: {{SVGElement("feDiffuseLighting")}} ou {{SVGElement("feSpecularLighting")}}.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/fetile/index.md
+++ b/files/fr/web/svg/reference/element/fetile/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feTile
 original_slug: Web/SVG/Element/feTile
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feTile>`** permet de remplir un rectangle cible avec un motif en mosaïque qui répète une image en entrée. L'effet est similaire à ce que l'on obtient avec {{SVGElement("pattern")}}.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/feturbulence/index.md
+++ b/files/fr/web/svg/reference/element/feturbulence/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/feTurbulence
 original_slug: Web/SVG/Element/feTurbulence
 ---
 
-{{SVGRef}}
-
 La primitive de filtre [SVG](/fr/docs/Web/SVG) **`<feTurbulence>`** crée une image en utilisant la [fonction de turbulence de Perlin](https://fr.wikipedia.org/wiki/Bruit_de_Perlin). Cela permet de créer des textures artificielles comme des nuages, du marbre, etc.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/filter/index.md
+++ b/files/fr/web/svg/reference/element/filter/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/filter
 original_slug: Web/SVG/Element/filter
 ---
 
-{{SVGRef}}
-
 L'élément [SVG](/fr/docs/Web/SVG) **`<filter>`** sert de conteneur pour définir des opérations de filtre. Il n'est jamais affiché par lui-même, il est référencé en utilisant l'attribut {{SVGAttr("filter")}} sur un élément SVG ou via la propriété {{Glossary("CSS")}} {{cssxref("filter")}}.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/image/index.md
+++ b/files/fr/web/svg/reference/element/image/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/image
 original_slug: Web/SVG/Element/image
 ---
 
-{{SVGRef}}
-
 L'élément Image SVG (\<image>) permet d'inclure une image matricielle dans un document SVG.
 
 ## Contexte d'Utilisation

--- a/files/fr/web/svg/reference/element/lineargradient/index.md
+++ b/files/fr/web/svg/reference/element/lineargradient/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/linearGradient
 original_slug: Web/SVG/Element/linearGradient
 ---
 
-{{SVGRef}}
-
 L'élément **`<linearGradient>`** permet de définir des dégradés linéaires, qui pourront être utilisés comme remplissage ou contour des éléments SVG.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/marker/index.md
+++ b/files/fr/web/svg/reference/element/marker/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/marker
 original_slug: Web/SVG/Element/marker
 ---
 
-{{SVGRef}}
-
 L'élément **`<marker>`** définit un élément graphique qui pourra être utilisé pour dessiner des pointes de flèches ou des polymarqueurs sur un élément {{SVGElement("path")}}, {{SVGElement("line")}}, {{SVGElement("polyline")}} ou {{SVGElement("polygon")}}.
 
 Les marqueurs sont attachés aux formes à l'aide des propriétés {{SVGAttr("marker-start")}}, {{SVGAttr("marker-mid")}}, et {{SVGAttr("marker-end")}}.

--- a/files/fr/web/svg/reference/element/mask/index.md
+++ b/files/fr/web/svg/reference/element/mask/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/mask
 original_slug: Web/SVG/Element/mask
 ---
 
-{{SVGRef}}
-
 L'élément **`<mask>`** définit un masque alpha. Ce masque peut par la suite être appliqué sur une forme en utilisant la propriété {{SVGAttr("mask")}}.
 
 Le masque permet de rendre des zones de l'élément sur lequel est appliqué (semi-)transparentes. On peut par exemple créer un effet de fondu en utilisant un dégradé, ce que le détourage ({{SVGElement('clipPath')}}) ne permet pas.

--- a/files/fr/web/svg/reference/element/metadata/index.md
+++ b/files/fr/web/svg/reference/element/metadata/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/metadata
 original_slug: Web/SVG/Element/metadata
 ---
 
-{{SVGRef}}
-
 L'élément [SVG](/fr/docs/Web/SVG) **`<metadata>`** permet d'ajouter des metadonnées au contenu SVG. Des metadonnées sont des données structurées qui donnent des informations sur le contenu du document. La balise `<metadata>` doit contenir des éléments d'un autre {{Glossary("namespace", "namespaces")}} {{Glossary("XML")}} tel que {{Glossary("RDF")}}, [FOAF](https://fr.wikipedia.org/wiki/FOAF), etc.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/mpath/index.md
+++ b/files/fr/web/svg/reference/element/mpath/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/mpath
 original_slug: Web/SVG/Element/mpath
 ---
 
-{{SVGRef}}
-
 L'élément **`<mpath>`** se place dans un élément {{SVGElement("animateMotion")}}, il permet de référencer un élément {{SVGElement("path")}} pour définir le chemin utilisé par l'animation.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/path/index.md
+++ b/files/fr/web/svg/reference/element/path/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/path
 original_slug: Web/SVG/Element/path
 ---
 
-{{SVGRef}}
-
 L'élément `path` est l'élément générique pour définir une forme. Toutes les formes basiques peuvent aussi être faites à partir de `path`.
 
 ## Usage

--- a/files/fr/web/svg/reference/element/pattern/index.md
+++ b/files/fr/web/svg/reference/element/pattern/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/pattern
 original_slug: Web/SVG/Element/pattern
 ---
 
-{{SVGRef}}
-
 L'élément **`<pattern>`** définit un objet graphique qui peut être redessiné à des intervalles de coordonnées x et y répétés ("en mosaïque") pour couvrir une surface.
 
 Le **`<pattern>`** est référéne par les attributs {{SVGAttr("fill")}} et {{SVGAttr("stroke")}} sur les autres éléments graphiques, pour appliquer un remplissage ou une bordure sur ces éléments avec le motif référencé.

--- a/files/fr/web/svg/reference/element/polygon/index.md
+++ b/files/fr/web/svg/reference/element/polygon/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/polygon
 original_slug: Web/SVG/Element/polygon
 ---
 
-{{SVGRef}}
-
 L'élément **`<polygon>`** délimite une forme close composée d'un groupe de plusieurs segments de droites. Le dernier point est relié au premier afin de fermer la forme et de relier les traits entre deux. Pour créer une forme ouverte, voir l'élément {{SVGElement("polyline")}}.
 
 ## Exemple

--- a/files/fr/web/svg/reference/element/polyline/index.md
+++ b/files/fr/web/svg/reference/element/polyline/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/polyline
 original_slug: Web/SVG/Element/polyline
 ---
 
-{{SVGRef}}
-
 L'élément SVG **`<polyline>`** est une forme SVG basique qui crée des lignes entre plusieurs points. Un élément `polyline` est généralement utilisé pour créer des tracés ouverts car le dernier point n'est pas nécessairement connecté avec le premier. Lorsqu'on désire réaliser des formes fermées, on privilégiera l'élément {{SVGElement("polygon")}}.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/radialgradient/index.md
+++ b/files/fr/web/svg/reference/element/radialgradient/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/radialGradient
 original_slug: Web/SVG/Element/radialGradient
 ---
 
-{{SVGRef}}
-
 L'élément SVG **`<radialGradient>`** permet de définir des dégradés radiaux qui peuvent être appliqués aux éléments de remplissage ou de contour des éléments graphiques.
 
 > [!NOTE]

--- a/files/fr/web/svg/reference/element/rect/index.md
+++ b/files/fr/web/svg/reference/element/rect/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/rect
 original_slug: Web/SVG/Element/rect
 ---
 
-{{SVGRef}}
-
 L'élément `rect` est un élément de Formes basiques, utilisé pour dessiner des rectangles à partir de la position d'un angle, de largeur et de la hauteur. Il peut aussi être utilisé avec des arrondis.
 
 ## Usage

--- a/files/fr/web/svg/reference/element/stop/index.md
+++ b/files/fr/web/svg/reference/element/stop/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/stop
 original_slug: Web/SVG/Element/stop
 ---
 
-{{SVGRef}}
-
 L'élément [SVG](/fr/docs/Web/SVG) **`<stop>`** définit une couleur supplémentaire dans une palette à utiliser pour un dégradé, et est contenu dans un élément {{SVGElement("linearGradient")}} ou {{SVGElement("radialGradient")}}.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/style/index.md
+++ b/files/fr/web/svg/reference/element/style/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/style
 original_slug: Web/SVG/Element/style
 ---
 
-{{SVGRef}}
-
 L'élément `style` permet d'intégrer directement des feuilles de style dans un contenu SVG. L'élément style de SVG possède les mêmes attributs que l'élément correspondant au format HTML (voir l'élément HTML {{HTMLElement("style")}}).
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/svg/index.md
+++ b/files/fr/web/svg/reference/element/svg/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/svg
 original_slug: Web/SVG/Element/svg
 ---
 
-{{SVGRef}}
-
 L'élément `svg` peut être utilisé pour intégrer des fragments de code SVG à l'intérieur d'un document (par exemple, un document HTML). Ce fragment de code SVG dispose de ses propres [viewport](/fr/docs/Web) et système de coordonnée.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/switch/index.md
+++ b/files/fr/web/svg/reference/element/switch/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/switch
 original_slug: Web/SVG/Element/switch
 ---
 
-{{SVGRef}}
-
 L'élément `switch` évalue les attributs {{ SVGAttr("requiredFeatures") }}, {{ SVGAttr("requiredExtensions") }} et {{ SVGAttr("systemLanguage") }} de ses éléments enfants directs, dans l'ordre, puis affiche le premier élément pour lequel les attributs renvoient `true`. Tous les autres seront ignorés et donc non affichés. Si l'élément enfant est un élément conteneur tel que {{ SVGElement("g") }}, alors l'intégralité du contenu de cet enfant est soit traité/rendu soit ignoré/non rendu.
 
 Notez que la valeur des propriétés `display` et `visibility` n'ont aucun effet sur le traitement du `switch`. En particulier, appliquer une propriété `display` à `none` sur l'élément enfant d'un `switch` n'a aucun effet sur le résultat du test `true/false` associé au traitement des éléments par le `switch`.

--- a/files/fr/web/svg/reference/element/text/index.md
+++ b/files/fr/web/svg/reference/element/text/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/text
 original_slug: Web/SVG/Element/text
 ---
 
-{{SVGRef}}
-
 L'élément SVG `text` définit un élément graphique contenant du texte. Notez qu'il est possible d'y appliquer un dégradé, un motif, un tracé spécifique (clipping path), un masque ou un filtre.
 
 Si du texte est écrit dans le SVG sans être intégré dans un balise \<text>, il ne sera pas affiché. Le texte n'est pas _caché_ par défaut, la propriété display ne le montre simplement pas.

--- a/files/fr/web/svg/reference/element/title/index.md
+++ b/files/fr/web/svg/reference/element/title/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/title
 original_slug: Web/SVG/Element/title
 ---
 
-{{SVGRef}}
-
 Tout élément graphique ou conteneur dans un dessin SVG peut définir un titre en utilisant un élément **`<title>`**, ce titre ne peut contenir que du texte.
 
 Quand l'élément contenant un titre apparaît à l'utilisateur sous forme d'image, l'élément `<title>` n'est pas affiché. Néanmoins, quelques moteurs de rendu peuvent, par exemple, l'afficher sous forme d'infobulle. Des représentations alternatives sont possibles, visuelles ou auditives, en renplacement des éléments graphiques. De manière générale, cet élément améliore l'accessibilité des documents SVG.

--- a/files/fr/web/svg/reference/element/tspan/index.md
+++ b/files/fr/web/svg/reference/element/tspan/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/tspan
 original_slug: Web/SVG/Element/tspan
 ---
 
-{{SVGRef}}
-
 A l'intérieur d'un élément {{SVGElement("text")}}, les propriétés du texte et des polices, ainsi que la position actuelle du texte, peuvent être ajustées de façon absolue ou relative à partir des coodonnées précisées dans un élément `tspan`.
 
 ## Contexte d'utilisation

--- a/files/fr/web/svg/reference/element/use/index.md
+++ b/files/fr/web/svg/reference/element/use/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Reference/Element/use
 original_slug: Web/SVG/Element/use
 ---
 
-{{SVGRef}}
-
 L'élement **`<use>`** permet la duplication de _nodes_ (noeuds du DOM, NDR) définis par [\<defs>](/fr/docs/Web/SVG/Reference/Element/defs) afin de les insérer par ailleurs. L'effet est le même que si les noeuds étaient créés dans une partie non-rendue (au sens de non-affichée) au sein du DOM puis "clonés" là où est utilisé l'élément `use` tel que le permet les [éléments de gabarit](/fr/docs/Web/HTML/Reference/Elements/template) grâce à HTML5.
 
 Puisque les noeuds clonés par `use` ne sont pas exposés, vous devez être attentif lorsque vous utilisez des règles de style [CSS](/fr/docs/Web/CSS) sur l'élément `use` et ses enfants "cachés". En effet les attributs CSS ne sont pas garantis d'être hérités lorsqu'ils seront clonés si vous n'explicitez pas correctement les [héritages CSS](/fr/docs/Web/CSS/Guides/Cascade/Inheritance).

--- a/files/fr/web/svg/tutorials/svg_from_scratch/basic_transformations/index.md
+++ b/files/fr/web/svg/tutorials/svg_from_scratch/basic_transformations/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/Basic_transformations
 original_slug: Web/SVG/Tutorial/Basic_Transformations
 ---
 
-{{SVGRef}}
-
 {{ PreviousNext("Web/SVG/Tutorials/SVG_from_scratch/Texts", "Web/SVG/Tutorials/SVG_from_scratch/Clipping_and_masking") }}
 
 Maintenant, nous sommes prêts à tordre nos images dans tous les sens. Mais avant toute chose, il faut vous présenter l'élément `<g>`. Cet assistant va vous permettre d'assigner des attributs à un ensemble d'éléments. En fait, c'est bien son seul rôle. Par exemple :

--- a/files/fr/web/svg/tutorials/svg_from_scratch/clipping_and_masking/index.md
+++ b/files/fr/web/svg/tutorials/svg_from_scratch/clipping_and_masking/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/Clipping_and_masking
 original_slug: Web/SVG/Tutorial/Clipping_and_masking
 ---
 
-{{SVGRef}}
-
 {{ PreviousNext("Web/SVG/Tutorials/SVG_from_scratch/Basic_transformations", "Web/SVG/Tutorials/SVG_from_scratch/Other_content_in_SVG") }}
 
 Effacer une partie de ce que l'on a créé précédemment peut paraître maladroit, voire totalement contradictoire. Mais cela peut se révéler très utile, par exemple quand vous essayez de dessiner un demi-cercle.

--- a/files/fr/web/svg/tutorials/svg_from_scratch/fills_and_strokes/index.md
+++ b/files/fr/web/svg/tutorials/svg_from_scratch/fills_and_strokes/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/Fills_and_strokes
 original_slug: Web/SVG/Tutorial/Fills_and_Strokes
 ---
 
-{{SVGRef}}
-
 {{ PreviousNext("Web/SVG/Tutorials/SVG_from_scratch/Paths", "Web/SVG/Tutorials/SVG_from_scratch/Gradients") }}
 
 Il y a différentes manières de colorer des formes: utiliser différents attributs SVG sur l'objet, utiliser du {{glossary("CSS")}} en ligne, une section CSS ou un fichier CSS externe. La plupart des {{glossary("SVG")}} que vous trouverez sur le Web utilisent du CSS en ligne, mais il y a des avantages et inconvénients pour chaque manière.

--- a/files/fr/web/svg/tutorials/svg_from_scratch/filter_effects/index.md
+++ b/files/fr/web/svg/tutorials/svg_from_scratch/filter_effects/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/Filter_effects
 original_slug: Web/SVG/Tutorial/Filter_effects
 ---
 
-{{SVGRef}}
-
 {{ PreviousNext("Web/SVG/Tutorials/SVG_from_scratch/Other_content_in_SVG", "Web/SVG/Tutorials/SVG_from_scratch/Using_fonts") }}
 
 Dans certaines situations, les formes de base n'offrent pas la flexibilité nécessaire pour obtenir un certain effet. Par exemple, les ombres portées ne peuvent raisonnablement pas être crées avec des gradients. Les filtres sont des mécanismes SVG qui permettent de créer effets plus sophistiqués.

--- a/files/fr/web/svg/tutorials/svg_from_scratch/gradients/index.md
+++ b/files/fr/web/svg/tutorials/svg_from_scratch/gradients/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/Gradients
 original_slug: Web/SVG/Tutorial/Gradients
 ---
 
-{{SVGRef}}
-
 {{ PreviousNext("Web/SVG/Tutorials/SVG_from_scratch/Fills_and_strokes", "Web/SVG/Tutorials/SVG_from_scratch/Patterns") }}
 
 Probablement plus excitant qu'un simple remplissage et contour, est le fait de pouvoir créer et appliquer des dégradés comme remplissage ou contour.

--- a/files/fr/web/svg/tutorials/svg_from_scratch/image_element/index.md
+++ b/files/fr/web/svg/tutorials/svg_from_scratch/image_element/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/Image_element
 original_slug: Web/SVG/Tutorial/SVG_Image_Tag
 ---
 
-{{SVGRef}}
-
 {{ PreviousNext("Web/SVG/Tutorials/SVG_from_scratch/Using_fonts", "Web/SVG/Tutorials/SVG_from_scratch/Tools_for_SVG") }}
 
 L'élément SVG {{ SVGElement("image") }} permet d'afficher des images pixélisées au sein d'un objet SVG.

--- a/files/fr/web/svg/tutorials/svg_from_scratch/other_content_in_svg/index.md
+++ b/files/fr/web/svg/tutorials/svg_from_scratch/other_content_in_svg/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/Other_content_in_SVG
 original_slug: Web/SVG/Tutorial/Other_content_in_SVG
 ---
 
-{{SVGRef}}
-
 {{ PreviousNext("Web/SVG/Tutorials/SVG_from_scratch/Clipping_and_masking", "Web/SVG/Tutorials/SVG_from_scratch/Filter_effects") }}
 
 En plus des formes graphiques simples comme les rectangles et les cercles, le format SVG permet d'ajouter d'autres types de contenu aux images.

--- a/files/fr/web/svg/tutorials/svg_from_scratch/paths/index.md
+++ b/files/fr/web/svg/tutorials/svg_from_scratch/paths/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/Paths
 original_slug: Web/SVG/Tutorial/Paths
 ---
 
-{{SVGRef}}
-
 {{ PreviousNext("Web/SVG/Tutorials/SVG_from_scratch/Basic_shapes", "Web/SVG/Tutorials/SVG_from_scratch/Fills_and_strokes") }}
 
 L'élément [`<path>`](/fr/docs/Web/SVG/Reference/Element/path) (_chemin_ en français) est le plus versatile des éléments de la bibliothèque SVG parmi les [formes basiques](/fr/docs/Web/SVG/Tutorials/SVG_from_scratch/Basic_shapes). Vous pouvez l'utiliser pour créer des lignes, des courbes, des arcs et autres.

--- a/files/fr/web/svg/tutorials/svg_from_scratch/patterns/index.md
+++ b/files/fr/web/svg/tutorials/svg_from_scratch/patterns/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/Patterns
 original_slug: Web/SVG/Tutorial/Patterns
 ---
 
-{{SVGRef}}
-
 {{ PreviousNext("Web/SVG/Tutorials/SVG_from_scratch/Gradients", "Web/SVG/Tutorials/SVG_from_scratch/Texts") }}
 
 Les motifs (_patterns_ en anglais) sont sans aucun doute les types de remplissages les plus complexes à utiliser en SVG. Ce sont également des outils très puissants, ils méritent donc d'être abordés pour que vous en connaissiez les fondamentaux. Comme les dégradés, l'élément {{SVGElement('pattern')}} doit être placé dans la section `<defs>` du fichier SVG.

--- a/files/fr/web/svg/tutorials/svg_from_scratch/svg_and_css/index.md
+++ b/files/fr/web/svg/tutorials/svg_from_scratch/svg_and_css/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/SVG_and_CSS
 original_slug: Web/SVG/Tutorial/SVG_and_CSS
 ---
 
-{{SVGRef}}
-
 {{ PreviousNext("Web/SVG/Tutorials/SVG_from_scratch/Tools_for_SVG") }}
 
 Cette page illustre l'application de CSS sur des documents [SVG](/fr/docs/Web/SVG), le langage spécialisé dans la création d'éléments graphiques vectoriels.

--- a/files/fr/web/svg/tutorials/svg_from_scratch/texts/index.md
+++ b/files/fr/web/svg/tutorials/svg_from_scratch/texts/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/Texts
 original_slug: Web/SVG/Tutorial/Texts
 ---
 
-{{SVGRef}}
-
 {{PreviousNext("Web/SVG/Tutorials/SVG_from_scratch/Patterns", "Web/SVG/Tutorials/SVG_from_scratch/Basic_transformations")}}
 
 Lorsqu'on parle de texte en SVG, on doit différencier deux choses pratiquement complètement séparées: 1. l'inclusion et l'affichage de texte dans une image, 2. les polices SVG. Un article séparé sera dédié aux polices SVG, celui-ci se concentrera uniquement sur le fait d'insérer du texte.

--- a/files/fr/web/svg/tutorials/svg_from_scratch/tools_for_svg/index.md
+++ b/files/fr/web/svg/tutorials/svg_from_scratch/tools_for_svg/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/Tools_for_SVG
 original_slug: Web/SVG/Tutorial/Tools_for_SVG
 ---
 
-{{SVGRef}}
-
 {{ PreviousNext("Web/SVG/Tutorials/SVG_from_scratch/Image_element", "Web/SVG/Tutorials/SVG_from_scratch/SVG_and_CSS") }}
 
 Maintenant que nous avons vu les notions de base en SVG, nous allons nous intéresser à quelques outils qui permettent d'éditer des fichiers SVG.

--- a/files/fr/web/svg/tutorials/svg_from_scratch/using_fonts/index.md
+++ b/files/fr/web/svg/tutorials/svg_from_scratch/using_fonts/index.md
@@ -4,8 +4,6 @@ slug: Web/SVG/Tutorials/SVG_from_scratch/Using_fonts
 original_slug: Web/SVG/Tutorial/SVG_fonts
 ---
 
-{{SVGRef}}
-
 {{ PreviousNext("Web/SVG/Tutorials/SVG_from_scratch/Filter_effects","Web/SVG/Tutorials/SVG_from_scratch/Image_element") }}
 
 Lorsque SVG a été spécifié, le support des polices d'écriture pour le web n'était pas répandu dans les navigateurs. Comme l'accès au fichier de la police adéquate est cependant crucial pour afficher correctement le texte, une technologie de description des polices a été ajoutée à SVG pour offrir cette capacité. Elle n'a pas été conçue pour la compatibilité avec d'autres formats tels que le PostScript ou OTF, mais plutôt comme un moyen simple d'intégration des informations des glyphes en SVG lors de l'affichage.


### PR DESCRIPTION
### Description

Dans l'objectif actuel de https://github.com/orgs/mdn/projects/44 d'effectuer le nettoyage des pages du MDN pour les 1 an de cycle de maintenance, et afin d'accélérer l'obsolescence des macros de barre latérale qui ne sont plus du tout utilisées sur le MDN anglais ; cette mise à jour à pour objectif de cibler une macro liée à un thème et la supprimer sur toutes les pages.

### Motivation

- Aligner les pages au MDN.
- Préparer la possible suppression de ces macros à l'avenir.
- Éviter de surcharger l'interpréteur de page avec des macros obsolètes.
- Gagner en lisibilité sur les pages Markdown pour les futur·e·s contributeur·ice·s.

### Additional details

_none_

### Related issues and pull requests

Related to https://github.com/mdn-fr/documentation/issues/88
