### PR TITLE
chore(fr): remove remnant `{{WebAssemblySidebar}}` macros

### DIFF
--- a/files/fr/webassembly/guides/c_to_wasm/index.md
+++ b/files/fr/webassembly/guides/c_to_wasm/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Guides/C_to_Wasm
 original_slug: WebAssembly/C_to_Wasm
 ---
 
-{{WebAssemblySidebar}}
-
 Quand vous avez écrit un module de code dans un langage comme le C/C++, vous pouvez ensuite le compiler en WebAssembly en utilisant un outil comme [Emscripten](/fr/docs/Mozilla/Projects/Emscripten). Regardons comment cela fonctionne.
 
 ## Mise en place de l'environnement Emscripten

--- a/files/fr/webassembly/reference/javascript_interface/compile_static/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/compile_static/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 292e29ec89933d06416419f8403241b7e34f6555
 ---
 
-{{WebAssemblySidebar}}
-
 La méthode statique **`WebAssembly.compile()`**, permet de compiler un module ([`WebAssembly.Module`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Module)) à partir d'un code binaire WebAssembly. Cette fonction est utile lorsqu'il est nécessaire de compiler un module avant de l'instancier (dans les autres cas, la méthode [`WebAssembly.instantiate()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/instantiate_static) sera plus pertinente).
 
 > [!NOTE]

--- a/files/fr/webassembly/reference/javascript_interface/compileerror/compileerror/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/compileerror/compileerror/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/CompileError/CompileError
 original_slug: WebAssembly/JavaScript_interface/CompileError/CompileError
 ---
 
-{{WebAssemblySidebar}}
-
 Le constructeur **`WebAssembly.CompileError()`** crée un nouvel objet `CompileError` WebAssembly qui représente une erreur qui se produit lors du décodage ou de la validation du code WebAssembly.
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/compileerror/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/compileerror/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/CompileError
 original_slug: WebAssembly/JavaScript_interface/CompileError
 ---
 
-{{WebAssemblySidebar}}
-
 Le constructeur **`WebAssembly.CompileError()`** permet de créer une nouvelle instance de `CompileError` qui indique qu'une erreur s'est produite lors du décodage du code WebAssembly ou lors de sa validation.
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/compilestreaming_static/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/compilestreaming_static/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 292e29ec89933d06416419f8403241b7e34f6555
 ---
 
-{{WebAssemblySidebar}}
-
 La méthode statique **`WebAssembly.compileStreaming()`** permet de compiler un module WebAssembly (c'est-à-dire un objet [`WebAssembly.Module`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Module)) depuis un flux source. Cette fonction est utile si on doit compiler un module avant de l'instancier séparement, sinon on utilisera plutôt [`WebAssembly.instantiateStreaming()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static).
 
 > [!NOTE]

--- a/files/fr/webassembly/reference/javascript_interface/exception/exception/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/exception/exception/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Exception/Exception
 original_slug: WebAssembly/JavaScript_interface/Exception/Exception
 ---
 
-{{WebAssemblySidebar}}
-
 Le constructeur **`WebAssembly.Exception()`** permet de créer des objets [`WebAssembly.Exception`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Exception).
 
 Le constructeur prend comme arguments une balise [`Tag`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Exception) et un tableau `payload` de champs de données. Les types de données pour chaque élément du tableau `payload` doivent correspondre aux types de données définis par la balise `Tag`.

--- a/files/fr/webassembly/reference/javascript_interface/exception/getarg/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/exception/getarg/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Exception/getArg
 original_slug: WebAssembly/JavaScript_interface/Exception/getArg
 ---
 
-{{WebAssemblySidebar}}
-
 La méthode **`getArg()`**, rattachée au prototype d'un objet [`Exception`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Exception), permet d'obtenir la valeur d'un élément spécifique parmi les arguments de donnée d'une exception.
 
 Cette méthode prend comme argument une balise [`WebAssembly.Tag`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Tag) et fonctionnera uniquement si l'exception levée a été créée avec cette même balise. Dans le cas contraire, la méthode déclenchera une exception `TypeError`. On s'assure ainsi que l'exception puisse être lue seulement si le code appelant a accès à la balise. Les balies qui ne sont ni importées ni exportées dans/depuis le code WebAssembly sont internes et les exceptions correspondantes ne peuvent pas être inspectées avec cette méthode&nbsp;!

--- a/files/fr/webassembly/reference/javascript_interface/exception/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/exception/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Exception
 original_slug: WebAssembly/JavaScript_interface/Exception
 ---
 
-{{WebAssemblySidebar}}
-
 Un objet **`WebAssembly.Exception`** représente une exception d'exécution levée depuis WebAssembly vers JavaScript ou levée depuis JavaScript vers un gestionnaire d'exception WebAssembly.
 
 Le [constructeur](/fr/docs/WebAssembly/Reference/JavaScript_interface/Exception/Exception) prend comme arguments un objet [`WebAssembly.Tag`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Tag), un tableau de valeurs et un objet `options`.

--- a/files/fr/webassembly/reference/javascript_interface/exception/is/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/exception/is/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Exception/is
 original_slug: WebAssembly/JavaScript_interface/Exception/is
 ---
 
-{{WebAssemblySidebar}}
-
 La méthode **`is()`**, rattachée au prototype d'un objet [`Exception`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Exception), peut être utilisée afin de déterminer si l'objet `Exception` correspond à une balise donnée.
 
 La méthode peut être utilisée afin de tester si une balise est correcte avant de la passer à [`Exception.prototype.getArg()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Exception/getArg) pour obtenir les valeurs passées à l'exception. Elle peut être utilisée pour les balises créées côté JavaScript ou créées dans du code WebAssembly qui les exporte en JavaScript.

--- a/files/fr/webassembly/reference/javascript_interface/exception/stack/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/exception/stack/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Exception/stack
 original_slug: WebAssembly/JavaScript_interface/Exception/stack
 ---
 
-{{WebAssemblySidebar}}
-
 La propriété en lecture seule **`stack`**, rattachée à une instance d'[`Exception`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Exception) _peut_ contenir une trace de pile d'appels pour une exception levée par du code WebAssembly.
 
 Par défaut, les exceptions levées par du code WebAssembly n'incluent pas la pile d'appels. Si le code WebAssembly doit fournir une pile d'appels, il doit appeler une fonction JavaScript pour créer l'exception et passer le paramètre `options.traceStack=true` au [constructeur](/fr/docs/WebAssembly/Reference/JavaScript_interface/Exception/Exception). La machine virtuelle peut ensuite attacher la pile d'appels à l'exception lorsqu'elle est levée.

--- a/files/fr/webassembly/reference/javascript_interface/global/global/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/global/global/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Global/Global
 original_slug: WebAssembly/JavaScript_interface/Global/Global
 ---
 
-{{WebAssemblySidebar}}
-
 Le constructeur **`WebAssembly.Global()`** permet de créer un nouvel objet `Global` représentant une instance d'une variable globale, accessible depuis le code JavaScript et importable/exportable dans plusieurs instances de [`WebAssembly.Module`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Module). Cela permet la liaison dynamique de plusieurs modules.
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/global/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/global/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Global
 original_slug: WebAssembly/JavaScript_interface/Global
 ---
 
-{{WebAssemblySidebar}}
-
 Un objet **`WebAssembly.Global`** représente une instance d'une variable globale, accessible depuis le code JavaScript et importable/exportable pour un ou plusieurs modules WebAssembly ([`WebAssembly.Module`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Module)). Cela permet de lier dynamiquement plusieurs modules.
 
 ## Constructeur

--- a/files/fr/webassembly/reference/javascript_interface/instance/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/instance/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Instance
 original_slug: WebAssembly/JavaScript_interface/Instance
 ---
 
-{{WebAssemblySidebar}}
-
 Un objet **`WebAssembly.Instance`** représente un objet exécutable, avec un état, qui est une instance d'un [module WebAssembly](/fr/docs/WebAssembly/Reference/JavaScript_interface/Module). Un objet `Instance` contient l'ensemble [des fonctions WebAssembly exportées](/fr/docs/WebAssembly/Guides/Exported_functions) qui permettent d'invoquer du code WebAssembly depuis du code JavaScript.
 
 ## Constructeur

--- a/files/fr/webassembly/reference/javascript_interface/instance/instance/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/instance/instance/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Instance/Instance
 original_slug: WebAssembly/JavaScript_interface/Instance/Instance
 ---
 
-{{WebAssemblySidebar}}
-
 Le constructeur **`WebAssembly.Instance()`** crée un nouvel objet `Instance` qui représente une instance sans état et exécutable d'un [`WebAssembly.Module`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Module).
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/instantiate_static/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/instantiate_static/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 292e29ec89933d06416419f8403241b7e34f6555
 ---
 
-{{WebAssemblySidebar}}
-
 La méthode statique **`WebAssembly.instantiate()`** permet de compiler et d'instancier du code WebAssembly. Cette fonction possède deux formes&nbsp;:
 
 - La première forme prend un code binaire WebAssembly sous forme d'un [tableau typé](/fr/docs/Web/JavaScript/Guide/Typed_arrays) ou d'un [`ArrayBuffer`](/fr/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) et effectue les étapes de compilation et d'instanciation en une fois. La valeur de résolution de la promesse renvoyée se compose d'un module [`WebAssembly.Module`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Module) compilé et de sa première instance [`WebAssembly.Instance`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Instance).

--- a/files/fr/webassembly/reference/javascript_interface/instantiatestreaming_static/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/instantiatestreaming_static/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 292e29ec89933d06416419f8403241b7e34f6555
 ---
 
-{{WebAssemblySidebar}}
-
 La méthode statique **`WebAssembly.instantiateStreaming()`** permet de compiler et d'instancier un module WebAssembly depuis un flux source. C'est la méthode la plus efficace, et la plus optimisée, permettant de charger du code WebAssembly.
 
 > [!NOTE]

--- a/files/fr/webassembly/reference/javascript_interface/linkerror/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/linkerror/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/LinkError
 original_slug: WebAssembly/JavaScript_interface/LinkError
 ---
 
-{{WebAssemblySidebar}}
-
 Le constructeur **`WebAssembly.LinkError()`** permet de créer un nouvel objet WebAssembly `LinkError` qui indique qu'une erreur s'est produite lors de l'instanciation du module (en plus [des trappes](http://webassembly.org/docs/semantics/#traps) provenant de la fonction initiale).
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/linkerror/linkerror/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/linkerror/linkerror/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/LinkError/LinkError
 original_slug: WebAssembly/JavaScript_interface/LinkError/LinkError
 ---
 
-{{WebAssemblySidebar}}
-
 Le constructeur **`WebAssembly.LinkError()`** crée un nouvel objet `LinkError` WebAssembly qui indique une erreur lors de l'instanciation du module (en dehors des [trapoess](https://webassembly.org/docs/semantics/#traps) de la fonction de départ).
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/memory/grow/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/memory/grow/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Memory/grow
 original_slug: WebAssembly/JavaScript_interface/Memory/grow
 ---
 
-{{WebAssemblySidebar}}
-
 La méthode **`grow()`**, rattachée au prototype de l'objet [`Memory`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Memory), permet d'augmenter la taille de l'espace mémoire correspondant d'un nombre de pages WebAssembly.
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/memory/memory/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/memory/memory/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Memory/Memory
 original_slug: WebAssembly/JavaScript_interface/Memory/Memory
 ---
 
-{{WebAssemblySidebar}}
-
 Le constructeur **`WebAssembly.Memory()`** permet de créer un nouvel objet `Memory` dont la propriété [`buffer`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer) est un tableau tampon [`ArrayBuffer`](/fr/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) redimensionnable ou un `SharedArrayBuffer` contenant les octets bruts de mémoire à laquelle accède une `Instance` WebAssembly.
 
 Une mémoire créée par du code JavaScript ou WebAssembly sera accessible et modifiable depuis JavaScript ou WebAssembly.

--- a/files/fr/webassembly/reference/javascript_interface/module/customsections_static/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/module/customsections_static/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 292e29ec89933d06416419f8403241b7e34f6555
 ---
 
-{{WebAssemblySidebar}}
-
 La méthode statique **`WebAssembly.Module.customSections()`** renvoie un tableau qui contient les sections personnalisées (<i lang="en">custom sections</i>) disponibles dans un module WebAssembly et qui ont un nom donné.
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/module/exports_static/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/module/exports_static/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 292e29ec89933d06416419f8403241b7e34f6555
 ---
 
-{{WebAssemblySidebar}}
-
 La méthode statique **`WebAssembly.Module.exports()`** renvoie un tableau qui contient les descriptions des exports déclarés pour un module donné.
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/module/imports_static/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/module/imports_static/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 292e29ec89933d06416419f8403241b7e34f6555
 ---
 
-{{WebAssemblySidebar}}
-
 La méthode statique **`WebAssembly.Module.imports()`** renvoie un tableau qui contient les références des fonctions importées qui sont disponibles dans un module WebAssembly donné.
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/module/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/module/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Module
 original_slug: WebAssembly/JavaScript_interface/Module
 ---
 
-{{WebAssemblySidebar}}
-
 Un objet **`WebAssembly.Module`** contient du code WebAssembly, sans état et qui a déjà été compilé par le navigateur. Ce code peut être [partagé avec des <i lang="en">web workers</i>](/fr/docs/Web/API/Worker/postMessage) et être instancié à plusieurs reprises.
 
 ## Constructeur

--- a/files/fr/webassembly/reference/javascript_interface/module/module/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/module/module/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Module/Module
 original_slug: WebAssembly/JavaScript_interface/Module/Module
 ---
 
-{{WebAssemblySidebar}}
-
 Le constructeur **`WebAssembly.Module()`** crée un nouvel objet `Module` contenant du code WebAssembly sans état qui a déjà été compilé par le navigateur et qui peut efficacement [être partagé avec des workers](/fr/docs/Web/API/Worker/postMessage) et être instancié plusieurs fois.
 
 Le constructeur `WebAssembly.Module()` peut être appelé de façon synchrone afin de compiler le code binaire WebAssembly correspondant. Toutefois, la méthode principale pour obtenir un `Module` consiste à utiliser une fonction de compilation asynchrone comme [`WebAssembly.compile()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/compile_static).

--- a/files/fr/webassembly/reference/javascript_interface/runtimeerror/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/runtimeerror/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/RuntimeError
 original_slug: WebAssembly/JavaScript_interface/RuntimeError
 ---
 
-{{WebAssemblySidebar}}
-
 Le constructeur **`WebAssembly.RuntimeError()`** permet de créer un nouvel objet WebAssembly `RuntimeError`. C'est ce type d'exception qui est déclenchée lorsque WebAssembly définit [une trappe](http://webassembly.org/docs/semantics/#traps).
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/runtimeerror/runtimeerror/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/runtimeerror/runtimeerror/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/RuntimeError/RuntimeError
 original_slug: WebAssembly/JavaScript_interface/RuntimeError/RuntimeError
 ---
 
-{{WebAssemblySidebar}}
-
 Le constructeur **`WebAssembly.RuntimeError()`** crée un nouvel objet `RuntimeError` WebAssembly, une erreur levée quand WebAssembly définit une [trappe](https://webassembly.org/docs/semantics/#traps).
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/table/table/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/table/table/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Table/Table
 original_slug: WebAssembly/JavaScript_interface/Table/Table
 ---
 
-{{WebAssemblySidebar}}
-
 Le constructeur **`WebAssembly.Table()`** crée un nouvel objet `Table` de la taille et du type d'élément donné.
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/tag/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/tag/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Tag
 original_slug: WebAssembly/JavaScript_interface/Tag
 ---
 
-{{WebAssemblySidebar}}
-
 L'objet **`WebAssembly.Tag`** définit un _type_ d'exception WebAssembly qui peut être levée depuis ou vers du code WebAssembly.
 
 Lorsqu'on crée un objet [`WebAssembly.Exception`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Exception), la balise (<i lang="en">tag</i>) définit les types de données et l'ordre des valeurs portées par l'exception. La même instance de cette balise doit être utilisée ensuite afin d'accéder aux valeurs portées par les exceptions déclenchées (par exemple, en utilisant la méthode [`Exception.prototype.getArg()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Exception/getArg)).

--- a/files/fr/webassembly/reference/javascript_interface/tag/tag/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/tag/tag/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Tag/Tag
 original_slug: WebAssembly/JavaScript_interface/Tag/Tag
 ---
 
-{{WebAssemblySidebar}}
-
 Le constructeur **`WebAssembly.Tag()`** crée un nouvel objet [`WebAssembly.Tag`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Tag).
 
 ## Syntaxe

--- a/files/fr/webassembly/reference/javascript_interface/tag/type/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/tag/type/index.md
@@ -4,8 +4,6 @@ slug: WebAssembly/Reference/JavaScript_interface/Tag/type
 original_slug: WebAssembly/JavaScript_interface/Tag/type
 ---
 
-{{WebAssemblySidebar}}
-
 La méthode **`type()`**, rattachée au prototype d'un objet [`Tag`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Tag), permet d'accéder à la séquence des types de données associés à la balise.
 
 L'objet renvoyé par la méthode sera le même que celui initialement passé au [constructeur `Tag()`](/fr/docs/WebAssembly/Reference/JavaScript_interface/Tag/Tag).

--- a/files/fr/webassembly/reference/javascript_interface/validate_static/index.md
+++ b/files/fr/webassembly/reference/javascript_interface/validate_static/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: 292e29ec89933d06416419f8403241b7e34f6555
 ---
 
-{{WebAssemblySidebar}}
-
 La méthode statique **`WebAssembly.validate()`** permet de valider un [tableau typé](/fr/docs/Web/JavaScript/Guide/Typed_arrays) de <i lang="en">bytecode</i> WebAssembly et renvoie un booléen qui indique si le contenu du tableau forme un module WebAssembly valide (`true`) ou non (`false`).
 
 ## Syntaxe


### PR DESCRIPTION
### Description

Dans l'objectif actuel de https://github.com/orgs/mdn/projects/44 d'effectuer le nettoyage des pages du MDN pour les 1 an de cycle de maintenance, et afin d'accélérer l'obsolescence des macros de barre latérale qui ne sont plus du tout utilisées sur le MDN anglais ; cette mise à jour à pour objectif de cibler une macro liée à un thème et la supprimer sur toutes les pages.

### Motivation

- Aligner les pages au MDN.
- Préparer la possible suppression de ces macros à l'avenir.
- Éviter de surcharger l'interpréteur de page avec des macros obsolètes.
- Gagner en lisibilité sur les pages Markdown pour les futur·e·s contributeur·ice·s.

### Additional details

_none_

### Related issues and pull requests

Related to https://github.com/mdn-fr/documentation/issues/88
