### PR TITLE
chore(fr): remove remnant `{{QuickLinksWithSubpages}}` macros

### DIFF
--- a/files/fr/mdn/writing_guidelines/page_structures/macros/other/index.md
+++ b/files/fr/mdn/writing_guidelines/page_structures/macros/other/index.md
@@ -11,7 +11,7 @@ Contrairement aux macros listées dans [Macros couramment utilisées](/fr/docs/M
 
 Cette macro n'est utilisée que dans des contextes particuliers, comme une référence d'API spécifique.
 
-- [`RFC`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/rfc.rs) crée un lien vers le RFC spécifié, à partir de son numéro. La syntaxe est `\{{RFC(numéro)}}`. Par exemple, `\{{RFC(2616)}}` donne {{ RFC(2616) }}.
+- [`RFC`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/links/rfc.rs) crée un lien vers le RFC définit, à partir de son numéro. La syntaxe est `\{{RFC(numéro)}}`. Par exemple, `\{{RFC(2616)}}` donne {{ RFC(2616) }}.
 
 ### Composants de page d'accueil
 
@@ -27,4 +27,4 @@ Il existe plusieurs macros permettant de générer automatiquement le contenu de
 
 Une macro est spécialement conçue pour créer des [listes de liens](/fr/docs/MDN/Writing_guidelines/Page_structures/Sidebars) dans le contenu&nbsp;:
 
-- [`QuickLinksWithSubpages`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/quick_links_with_subpages.rs) crée une liste de liens composée des pages situées sous la page courante (ou une page spécifiée). Jusqu'à deux niveaux de profondeur sont générés.
+- [`QuickLinksWithSubpages`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/quick_links_with_subpages.rs) crée une liste de liens composée des pages situées sous la page courante (ou une page définie). Jusqu'à deux niveaux de profondeur sont générés.

--- a/files/fr/web/media/guides/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
+++ b/files/fr/web/media/guides/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
@@ -4,8 +4,6 @@ slug: Web/Media/Guides/Audio_and_video_delivery/buffering_seeking_time_ranges
 original_slug: Web/Media/Audio_and_video_delivery/buffering_seeking_time_ranges
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/Media")}}
-
 Il est parfois utile de savoir combien d'{{htmlelement("audio") }} ou {{htmlelement("video") }} a été téléchargé ou peut être joué sans délai — par exemple pour afficher la barre de progression du tampon dans un lecteur audio ou vidéo. Cet article explique comment construire une barre de progrès de mise en mémoire tampon en utilisant [TimeRanges](/fr/docs/Web/API/TimeRanges), et d'autres fonctionnalités de l'API Media.
 
 ## Buffered

--- a/files/fr/web/media/guides/audio_and_video_delivery/index.md
+++ b/files/fr/web/media/guides/audio_and_video_delivery/index.md
@@ -4,8 +4,6 @@ slug: Web/Media/Guides/Audio_and_video_delivery
 original_slug: Web/Media/Audio_and_video_delivery
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/Media")}}
-
 On peut distribuer de l'audio et de la vidéo sur le web de plusieurs manières, du fichier média statique au <i lang="en">live stream</i> (flux en direct) adaptatif. Cet article se veut être le point de départ pour explorer les différents mécanismes de diffusion de média sur le web et la compatiblité avec les navigateurs populaires.
 
 ## Les éléments audio et vidéo

--- a/files/fr/web/media/guides/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
+++ b/files/fr/web/media/guides/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
@@ -4,8 +4,6 @@ slug: Web/Media/Guides/Audio_and_video_delivery/Live_streaming_web_audio_and_vid
 original_slug: Web/Media/Audio_and_video_delivery/Live_streaming_web_audio_and_video
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/Media")}}
-
 La technologie de _live streaming_ (diffusion en direct) est souvent utilisée pour relayer des événements en direct, tels que le sport, les concerts, ou de manière plus générale les programmes TV et radio en direct. Souvent raccourci au simple terme de _streaming_, le live streaming est le processus de transmissions d'un média _live_ (c'est à dire dynamique et non statique) aux ordinateurs et aux périphériques. C'est un sujet assez complexe et nouveau avec beaucoup de variables à prendre en considération, dans cet article nous allons vous introduire le sujet et vous donner des clés pour démarrer.
 
 La première chose à avoir en tête quand on diffuse un live stream à un navigateur est le fait que, plutôt que de jouer un fichier fini, on relaie un fichier qui est créé à la volée et qui n'a pas de début ou de fin prédéterminé.

--- a/files/fr/web/media/guides/audio_and_video_manipulation/index.md
+++ b/files/fr/web/media/guides/audio_and_video_manipulation/index.md
@@ -4,8 +4,6 @@ slug: Web/Media/Guides/Audio_and_video_manipulation
 original_slug: Web/Media/Audio_and_video_manipulation
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/Media")}}
-
 La beauté du web est qu'on peut combiner différentes technologies pour en créer de nouvelles. Avoir de l'audio et vidéo nativement dans le navigateur nous donne la possibilité d'utiliser ces flux de données avec d'autres technologies comme {{htmlelement("canvas")}}, [WebGL](/fr/docs/Web/API/WebGL_API) ou [Web Audio API](/fr/docs/Web/API/Web_Audio_API) pour modifier le média — par exemple ajouter des effets de réverbération ou de compression à l'audio, ou encore des filtres noir & blanc/sépia aux vidéos. Cet article fournit une référence pour expliquer ce que vous pouvez faire.
 
 ## Manipulation Vidéo

--- a/files/fr/web/media/guides/formats/image_types/index.md
+++ b/files/fr/web/media/guides/formats/image_types/index.md
@@ -4,8 +4,6 @@ slug: Web/Media/Guides/Formats/Image_types
 original_slug: Web/Media/Formats/Image_types
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/Media")}}
-
 Dans ce guide, nous aborderons les types de fichiers d'images généralement pris en charge par les navigateurs web, et nous vous donnerons des indications qui vous aideront à sélectionner les formats les plus appropriés pour l'imagerie de votre site.
 
 ## Types de fichiers d'images communs

--- a/files/fr/web/media/guides/formats/index.md
+++ b/files/fr/web/media/guides/formats/index.md
@@ -4,8 +4,6 @@ slug: Web/Media/Guides/Formats
 original_slug: Web/Media/Formats
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/Media")}}
-
 Depuis presque ses débuts, le web a inclus un support pour une certaine forme de présentation visuelle des médias. À l'origine, ces capacités étaient limitées et ont été développées de manière organique, les différents navigateurs trouvant leurs propres solutions aux problèmes liés à l'inclusion d'images fixes et vidéo sur le web. Le web moderne dispose de puissantes fonctionnalités pour prendre en charge la présentation et la manipulation des médias, avec plusieurs API liées aux médias prenant en charge divers types de contenu. En général, les formats de médias pris en charge par un navigateur sont entièrement laissés à la discrétion des créateurs du navigateur, ce qui peut compliquer le travail d'un développeur web.
 
 Ce guide donne un aperçu des types de fichiers médias, {{Glossary("codec", "codecs")}}, et des algorithmes qui peuvent comprendre des médias utilisés sur le web. Il fournit également des informations sur la prise en charge des navigateurs pour diverses combinaisons de ceux-ci, et des suggestions pour la hiérarchisation des formats, ainsi que sur les formats qui excellent pour des types de contenu spécifiques.

--- a/files/fr/web/media/guides/formats/support_issues/index.md
+++ b/files/fr/web/media/guides/formats/support_issues/index.md
@@ -4,8 +4,6 @@ slug: Web/Media/Guides/Formats/Support_issues
 original_slug: Web/Media/Formats/Support_issues
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/Media")}}
-
 L'une des réalités du travail avec la présentation et la manipulation audio et vidéo sur le web est qu'il existe un certain nombre de formats de médias disponibles, de degrés de popularité variables et avec des capacités variées. La possibilité de choisir est bonne pour l'utilisateur, dans la mesure où il peut choisir le format qui répond le mieux à ses besoins. Il y a cependant un inconvénient : comme il y a un grand choix, avec tant de types de licences et de principes de conception différents, chaque développeur de navigateur web est laissé à lui-même pour décider des types de fichiers média et des codecs à prendre en charge.
 
 Cela impose une charge légère, mais raisonnablement facile à surmonter, au développeur web : gérer correctement la situation lorsque le navigateur de l'utilisateur ne peut pas gérer un type de média particulier. Ce guide couvre les techniques que vous pouvez utiliser pour développer des contenus web qui répondent à vos besoins médiatiques tout en offrant l'expérience la plus largement compatible possible. Les sujets que nous examinerons sont les solutions de secours, les formats de base des médias et les pratiques de traitement des erreurs qui permettront à votre contenu de fonctionner dans le plus grand nombre de situations possible.

--- a/files/fr/web/progressive_web_apps/manifest/index.md
+++ b/files/fr/web/progressive_web_apps/manifest/index.md
@@ -4,8 +4,6 @@ slug: Web/Progressive_web_apps/Manifest
 original_slug: Web/Manifest
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/Manifest")}}
-
 Le manifeste d'une application web fournit des informations concernant celle-ci (comme son nom, son auteur, une icône et une description) dans un document texte JSON. Le but du manifeste est d'installer des applications sur l'écran d'accueil d'un appareil, offrant aux utilisateurs un accès plus rapide et une expérience plus riche.
 
 Les manifestes font partie d'un ensemble de technologies appelées les [applications web progressives](/fr/docs/Web/Progressive_web_apps) (_progressive web apps_). Il s'agit d'applications web qui peuvent être installées sur la page d'accueil d'un appareil sans que l'utilisateur ait à se rendre dans une boutique d'applications. De plus, une fois installées, elles peuvent être utilisées sans connexion internet et sont capables de recevoir des notifications _push._

--- a/files/fr/web/progressive_web_apps/manifest/reference/theme_color/index.md
+++ b/files/fr/web/progressive_web_apps/manifest/reference/theme_color/index.md
@@ -4,8 +4,6 @@ slug: Web/Progressive_web_apps/Manifest/Reference/theme_color
 original_slug: Web/Manifest/theme_color
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/Manifest")}}
-
 <table>
   <tbody>
     <tr>

--- a/files/fr/web/xml/exslt/reference/exsl/node-set/index.md
+++ b/files/fr/web/xml/exslt/reference/exsl/node-set/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/EXSLT/Reference/exsl/node-set
 original_slug: Web/EXSLT/exsl/node-set
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
-
 `exsl:node-set()` retourne un ensemble de nœuds d'un fragment d'arbre résultant, qui correspond à ce qu'on obtient en regardant [`xsl:variable`](/fr/XSLT/variable) plutôt que son attribut `select` pour récupérer la valeur d'une variable. Ceci permet de traiter le XML créé dans une variable pour de le traiter en plusieurs étapes.
 
 Vous pouvez également utiliser `exsl:node-set()` pour transformer des chaînes en nœuds texte.

--- a/files/fr/web/xml/exslt/reference/exsl/object-type/index.md
+++ b/files/fr/web/xml/exslt/reference/exsl/object-type/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/EXSLT/Reference/exsl/object-type
 original_slug: Web/EXSLT/exsl/object-type
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
-
 `exsl:object-type()` renvoie une chaîne de caractères indiquant le type de l'objet indiqué en paramètre.
 
 > [!NOTE]

--- a/files/fr/web/xml/exslt/reference/math/highest/index.md
+++ b/files/fr/web/xml/exslt/reference/math/highest/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/EXSLT/Reference/math/highest
 original_slug: Web/EXSLT/math/highest
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
-
 `math:highest()` renvoie le nœud qui a la valeur maximale, parmi l'ensemble de nœuds passé en argument (la valeur maximale est calculée à l'aide de [`math:max()`](/fr/docs/Web/EXSLT/math/max)).
 
 Un nœud possède cette valeur maximale si la conversion de sa valeur qui est une chaîne de caractères en nombre est égale à la valeur maximale.

--- a/files/fr/web/xml/exslt/reference/math/lowest/index.md
+++ b/files/fr/web/xml/exslt/reference/math/lowest/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/EXSLT/Reference/math/lowest
 original_slug: Web/EXSLT/math/lowest
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
-
 `math:lowest()` renvoie le nœud qui a la valeur minimale, parmi l'ensemble de nœuds passé en argument (la valeur minimale est calculée à l'aide de [`math:min()`](/fr/docs/Web/XML/EXSLT/Reference/math/min)).
 
 Un nœud possède cette valeur minimale si la conversion de sa valeur qui est une chaîne de caractères en nombre est égale à la valeur minimale.

--- a/files/fr/web/xml/exslt/reference/math/min/index.md
+++ b/files/fr/web/xml/exslt/reference/math/min/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/EXSLT/Reference/math/min
 original_slug: Web/EXSLT/math/min
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
-
 `math:min()` renvoie la valeur minimale d'un ensemble de nœuds.
 
 Pour calculer la valeur minimale d'un ensemble de nœuds, l'ensemble est trié selon l'ordre croissant, comme on pourrait le faire avec [`xsl:sort()`](/fr/docs/Web/XML/XSLT/Reference/Element/sort) en utilisant un type de données `number`. La valeur minimale est ensuite construite avec la valeur du premier nœud de cette liste ordonnée, convertie en nombre.

--- a/files/fr/web/xml/exslt/reference/set/difference/index.md
+++ b/files/fr/web/xml/exslt/reference/set/difference/index.md
@@ -4,7 +4,6 @@ slug: Web/XML/EXSLT/Reference/set/difference
 original_slug: Web/EXSLT/set/difference
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
 `set:difference()` retourne la différence entre deux ensembles de nœuds. En d'autres termes, elle retourne un ensemble de nœuds qui sont dans un des ensembles mais par dans l'autre.
 
 La version*modèle* de `set:difference` applique des modèles à ces nœuds dans le mode `set:difference`, en copiant les nœuds afin de retourner un un fragment d'arbre résultant comprenant ces nœuds.

--- a/files/fr/web/xml/exslt/reference/set/distinct/index.md
+++ b/files/fr/web/xml/exslt/reference/set/distinct/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/EXSLT/Reference/set/distinct
 original_slug: Web/EXSLT/set/distinct
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
-
 `set:distinct()` retourne un sous-ensemble des nœuds appartenant à l'ensemble de nœuds spécifié, en ne retournant que les nœuds possédant une valeur de chaîne unique.
 
 ### Syntaxe

--- a/files/fr/web/xml/exslt/reference/set/has-same-node/index.md
+++ b/files/fr/web/xml/exslt/reference/set/has-same-node/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/EXSLT/Reference/set/has-same-node
 original_slug: Web/EXSLT/set/has-same-node
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
-
 `set:has-same-node()` détermine si deux ensembles de nœuds ont ou non des nœuds communs.
 
 ### Syntaxe

--- a/files/fr/web/xml/exslt/reference/set/intersection/index.md
+++ b/files/fr/web/xml/exslt/reference/set/intersection/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/EXSLT/Reference/set/intersection
 original_slug: Web/EXSLT/set/intersection
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
-
 `set:intersection()` retourne l'intersection de deux ensembles de nœuds. En d'autres termes, cette fonction retourne un ensemble de nœuds contenant tous les nœuds appartenant aux deux ensembles de nœuds.
 
 ### Syntaxe

--- a/files/fr/web/xml/exslt/reference/set/leading/index.md
+++ b/files/fr/web/xml/exslt/reference/set/leading/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/EXSLT/Reference/set/leading
 original_slug: Web/EXSLT/set/leading
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
-
 `set:leading()` renvoie les nœuds d'un premier ensemble de nœuds qui viennent avant le premier nœud d'un deuxième ensemble.
 
 ## Syntaxe

--- a/files/fr/web/xml/exslt/reference/set/trailing/index.md
+++ b/files/fr/web/xml/exslt/reference/set/trailing/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/EXSLT/Reference/set/trailing
 original_slug: Web/EXSLT/set/trailing
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
-
 `set:trailing()` renvoie les nœuds d'un premier ensemble de nœuds qui viennent après le premier nœud d'un deuxième ensemble.
 
 ## Syntaxe

--- a/files/fr/web/xml/exslt/reference/str/concat/index.md
+++ b/files/fr/web/xml/exslt/reference/str/concat/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/EXSLT/Reference/str/concat
 original_slug: Web/EXSLT/str/concat
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
-
 `str:concat()` retourne une chaîne contenant toutes les valeurs de chaînes d'un ensemble de nœuds concaténées ensembles.
 
 ### Syntaxe

--- a/files/fr/web/xml/exslt/reference/str/split/index.md
+++ b/files/fr/web/xml/exslt/reference/str/split/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/EXSLT/Reference/str/split
 original_slug: Web/EXSLT/str/split
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
-
 `str:split()` divise une chaîne en utilisation un motif pour déterminer où doivent être fait les séparations, en retournant un ensemble de nœuds contenant les chaînes résultantes.
 
 ### Syntaxe

--- a/files/fr/web/xml/exslt/reference/str/tokenize/index.md
+++ b/files/fr/web/xml/exslt/reference/str/tokenize/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/EXSLT/Reference/str/tokenize
 original_slug: Web/EXSLT/str/tokenize
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
-
 `str:tokenize()` divise une chaîne en utilisant un ensemble de caractère comme délimiteur qui détermine l'endroit où doivent être fait les séparations, en retournant un ensemble de nœuds contenant les chaînes résultantes.
 
 ### Syntaxe

--- a/files/fr/web/xml/guides/xml_introduction/index.md
+++ b/files/fr/web/xml/guides/xml_introduction/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/Guides/XML_introduction
 original_slug: Web/XML/XML_introduction
 ---
 
-{{QuickLinksWithSubpages("/fr/docs/Web/XML")}}
-
 ### Définition
 
 XML, pour _e**X**tensible **M**arkup **L**anguage_ (langage de balisage extensible), est un langage de balisage généraliste [recommandé par le W3C](https://www.w3.org/) comme l'est HTML. XML est un sous-ensemble du langage SGML. Cela signifie que contrairement aux autres langages de balisages, XML n'est pas prédéfini, vous devez définir vos propres balises. Le but principal de ce langage est le partage de données entre différents systèmes, tel qu'Internet.


### PR DESCRIPTION
### Description

Dans l'objectif actuel de https://github.com/orgs/mdn/projects/44 d'effectuer le nettoyage des pages du MDN pour les 1 an de cycle de maintenance, et afin d'accélérer l'obsolescence des macros qui ne sont plus du tout utilisées sur le MDN anglais ; cette mise à jour à pour objectif de retirer la macro `QuickLinksWithSubpages`.

### Motivation

- Aligner les pages au MDN.
- Préparer la possible suppression de ces macros à l'avenir.
- Éviter de surcharger l'interpréteur de page avec des macros obsolètes.
- Gagner en lisibilité sur les pages Markdown pour les futur·e·s contributeur·ice·s.

### Additional details

_none_

### Related issues and pull requests

_none_
