### PR TITLE
[ru] Fix misleading comment in the `:target` example

### DIFF
--- a/files/ru/web/css/reference/selectors/_colon_target/index.md
+++ b/files/ru/web/css/reference/selectors/_colon_target/index.md
@@ -77,7 +77,7 @@ p:target::before {
   margin-right: 0.25em;
 }
 
-/* Стиль italic-элементов без target-элемента */
+/* Стилизация курсивных элементов внутри целевого элемента */
 p:target i {
   color: red;
 }


### PR DESCRIPTION
Fixes #27808

The CSS comment for `p:target i` said the rule styles italic elements *without* a target element, which is the opposite of what the selector does. Reworded to match the English source ("Style italic elements within the target element").