### PR TITLE
[es] Fix pattern example in form validation page

### DIFF
--- a/files/es/learn_web_development/extensions/forms/form_validation/index.md
+++ b/files/es/learn_web_development/extensions/forms/form_validation/index.md
@@ -308,7 +308,7 @@ Aquí hay un ejemplo completo que muestra el uso de las funciones de validación
   <p>
     <label for="t1">¿Cuál es tu fruta favorita?<abbr title="Este campo es obligatorio" aria-label="required">*</abbr></label>
     <input type="text" id="t1" name="fruit" list="l1" required
-           pattern="[Bb]anana|[Cc]herry|[Aa]pple|[Ss]trawberry|[Ll]emon|[Oo]range ">
+           pattern="[Bb]anana|[Cc]herry|[Aa]pple|[Ss]trawberry|[Ll]emon|[Oo]range">
     <datalist id="l1">
       <option>Plátano</option>
       <option>Cereza</option>

--- a/files/es/learn_web_development/extensions/forms/form_validation/index.md
+++ b/files/es/learn_web_development/extensions/forms/form_validation/index.md
@@ -182,7 +182,7 @@ Implementemos un ejemplo. Actualiza tu HTML para añadir un atributo [`pattern`]
 ```html
 <form>
   <label for="choose">¿Prefieres un plátano o una cereza?</label>
-  <input id="choose" name="i_like" required pattern="[Pp]látano|[Cc]ereza " />
+  <input id="choose" name="i_like" required pattern="[Pp]látano|[Cc]ereza" />
   <button>Enviar</button>
 </form>
 ```


### PR DESCRIPTION
## Summary

Removes an unintended trailing space from the `pattern` attribute in the Spanish **Form validation** page.

The current pattern is:

```html
pattern="[Pp]látano|[Cc]ereza "
```

Because of the trailing space, entering `Cereza` fails validation unless the user also types a space at the end.

This PR changes it to:

```html
pattern="[Pp]látano|[Cc]ereza"
```

Fixes #38263