### PR TITLE
chore(fr): remove `{{JsRef}}` and cleanup `()` in others

### DIFF
--- a/files/fr/web/api/batterymanager/index.md
+++ b/files/fr/web/api/batterymanager/index.md
@@ -3,7 +3,7 @@ title: BatteryManager
 slug: Web/API/BatteryManager
 ---
 
-{{APIRef()}}
+{{APIRef}}
 
 L'interface `BatteryManager` fournit des moyens pour obtenir des informations sur le niveau de charge de la batterie du système. La méthode [`navigator.getBattery()`](/fr/docs/Web/API/Navigator/getBattery) renvoie un objet `Promise` dont la valeur de résolution est une interface `BatteryManager`.
 

--- a/files/fr/web/api/credentialscontainer/get/index.md
+++ b/files/fr/web/api/credentialscontainer/get/index.md
@@ -31,7 +31,7 @@ var promise = CredentialsContainer.get([options]);
 
     - `publicKey` : un objet {{domxref("PublicKeyCredentialRequestOptions")}} contenant les conditions que doivent respecter les informations d'authentification [WebAuthn](/fr/docs/Web/API/Web_Authentication_API) qui seront renvoyées.
     - `mediation` : une chaîne de caractères {{jsxref("String")}} qui indique si l'utilisateur devra se reconnecter à chaque visite sur le site. Les valeurs valides sont `"silent"`, `"optional"` ou `"required"`.
-    - `unmediated` : {{deprecated_inline()}} un booléen ({{jsxref("Boolean")}}) qui indique que l'instance {{domxref("Credential")}} renvoyée ne devrait pas nécessiter de médiation avec l'utilisateur.
+    - `unmediated` : {{deprecated_inline}} un booléen ({{jsxref("Boolean")}}) qui indique que l'instance {{domxref("Credential")}} renvoyée ne devrait pas nécessiter de médiation avec l'utilisateur.
 
 ### Valeur de retour
 

--- a/files/fr/web/api/file_and_directory_entries_api/index.md
+++ b/files/fr/web/api/file_and_directory_entries_api/index.md
@@ -3,7 +3,7 @@ title: API fichier système
 slug: Web/API/File_and_Directory_Entries_API
 ---
 
-{{DefaultAPISidebar("File System API")}}{{Non-standard_header()}}
+{{DefaultAPISidebar("File System API")}}{{Non-standard_header}}
 
 L'API fichier système simule un fichier système en local que les applications web peuvent utiliser. Vous pouvez développer des applications qui lisent, écrivent, et créent des fichiers et/ou des dossiers dans un espace virtuel.
 

--- a/files/fr/web/api/force_touch_events/index.md
+++ b/files/fr/web/api/force_touch_events/index.md
@@ -22,7 +22,7 @@ slug: Web/API/Force_Touch_events
 
 La propriété suivante est connue pour être disponible sur les objets évènement [`webkitmouseforcewillbegin`](/fr/docs/Web/API/Element/webkitmouseforcewillbegin_event), [`mousedown`](/fr/docs/Web/API/Element/mousedown_event), [`webkitmouseforcechanged`](/fr/docs/Web/API/Element/webkitmouseforcechanged_event), [`webkitmouseforcedown`](/fr/docs/Web/API/Element/webkitmouseforcedown_event), [`webkitmouseforceup`](/fr/docs/Web/API/Element/webkitmouseforceup_event), [`mousemove`](/fr/docs/Web/API/Element/mousemove_event) et [`mouseup`](/fr/docs/Web/API/Element/mouseup_event):
 
-- {{domxref("MouseEvent.webkitForce")}} {{non-standard_inline()}} {{readonlyinline}}
+- {{domxref("MouseEvent.webkitForce")}} {{non-standard_inline}} {{readonlyinline}}
   - : La quantité de pression actuellement appliquée sur le trackpad / écran tactile.
 
 ## Constantes

--- a/files/fr/web/api/mouseevent/index.md
+++ b/files/fr/web/api/mouseevent/index.md
@@ -78,11 +78,11 @@ _Cette interface hérite aussi des propriétés de ses parents_ _{{domxref("UIEv
 
 - {{domxref("MouseEvent.which")}} {{readonlyinline}}
   - : Le bouton qui est pressé alors que l'événement est lancé.
-- MouseEvent.mozPressure {{non-standard_inline()}} {{readonlyinline}}
+- MouseEvent.mozPressure {{non-standard_inline}} {{readonlyinline}}
   - : La quantité de pression appliquée à un appareil tactile ou tablette lors de la génération de l'événement ; l'amplitude de cette valeur se situe entre 0.0 (pression minimum) et 1.0 (pression maximum).
-- MouseEvent.mozInputSource {{non-standard_inline()}} {{readonlyinline}}
+- MouseEvent.mozInputSource {{non-standard_inline}} {{readonlyinline}}
   - : Le type d'appareil qui a généré l'événement (une des constantes `MOZ_SOURCE_*` listées ci-dessous). Ceci permet, par exemple, de déterminer si un événement de pointeur est généré par une souris ou par un événement tactile (qui pourrait affecter le degré de précision avec lequel il est possible d'interpréter les coordonnées associées à l'événement).
-- {{domxref("MouseEvent.webkitForce")}} {{non-standard_inline()}} {{readonlyinline}}
+- {{domxref("MouseEvent.webkitForce")}} {{non-standard_inline}} {{readonlyinline}}
   - : La quantité de pression appliquée en cliquant.
 - {{domxref("MouseEvent.x")}} {{experimental_inline}}{{readonlyinline}}
   - : Alias pour {{domxref("MouseEvent.clientX")}}.

--- a/files/fr/web/api/passwordcredential/index.md
+++ b/files/fr/web/api/passwordcredential/index.md
@@ -16,17 +16,17 @@ L'interface **`PasswordCredential`**, rattachée à l'[API Credential Management
 
 _Hérite des propriétés de l'interface parente, {{domxref("Credential")}}._
 
-- {{domxref("PasswordCredential.additionalData")}} {{deprecated_inline()}}
+- {{domxref("PasswordCredential.additionalData")}} {{deprecated_inline}}
   - : Une instance {{domxref("FormData")}} ou une instance {{domxref("URLSearchParams")}} ou {{jsxref("null")}}. Les données de cet objet seront ajoutées au corps de la requête et envoyées au point distant avec les informations d'authentification.
 - {{domxref("PasswordCredential.iconURL")}} {{readonlyinline}}
   - : Une chaîne de caractères {{jsxref("String")}} contenant une URL qui pointe vers une image servant d'icône. Cette image est destinée à être utilisée dans le sélecteur d'informations d'authentification. L'URL doit être accessible sans authentification.
-- {{domxref("PasswordCredential.idName")}} {{deprecated_inline()}}
+- {{domxref("PasswordCredential.idName")}} {{deprecated_inline}}
   - : Une chaîne de caractères {{jsxref("String")}} contenant le nom qui sera uitlisé pour le champ d'identifiant lorsque l'objet courant sera envoyé au point distant grâce à {{domxref("fetch")}}. La valeur par défaut correspond à `"username"` mais il est possible de surcharger cette valeur afin qu'elle corresponde à ce qui est attendu par le service distant.
 - {{domxref("PasswordCredential.name")}} {{readonlyinline}}
   - : Une chaîne de caractères {{jsxref("String")}} qui contient un nom public, lisible par un humain et qui sera affiché dans le sélecteur d'informations d'authentification.
 - {{domxref("PasswordCredential.password")}} {{readonlyinline}}
   - : Une chaîne de caractères {{jsxref("String")}} qui contient le mot de passe associé aux informations d'authentification.
-- {{domxref("PasswordCredential.passwordName")}} {{deprecated_inline()}}
+- {{domxref("PasswordCredential.passwordName")}} {{deprecated_inline}}
   - : Une chaîne de caractères {{jsxref("String")}} qui représente le nom utilisé pour le mot de passe lorsque l'objet courant est envoyé au point distant avec {{domxref("fetch")}}. Par défaut, cette propriété vaut `"password"` mais elle peut être surchargée afin que sa valeur corresponde à ce qui est attendu par le service distant.
 
 ### Gestionnaires d'évènement

--- a/files/fr/web/api/publickeycredential/index.md
+++ b/files/fr/web/api/publickeycredential/index.md
@@ -16,13 +16,13 @@ Les autres interfaces qui héritent de {{domxref("Credential")}} sont :
 
 ## Propriétés
 
-- {{domxref("PublicKeyCredential.type")}} {{ReadOnlyInline()}}
+- {{domxref("PublicKeyCredential.type")}} {{ReadOnlyInline}}
   - : Propriété héritée depuis {{domxref("Credential")}}. Dans le cas de `PublicKeyCredentials`, cette propriété vaut toujours `"public-key"`.
-- {{domxref("PublicKeyCredential.id")}} {{ReadOnlyInline()}}
+- {{domxref("PublicKeyCredential.id")}} {{ReadOnlyInline}}
   - : Propriété héritée depuis {{domxref("Credential")}} et surchargée afin de correspondre à l'[encodage en base64url](/fr/docs/Glossary/Base64) de `PublicKeyCredential.rawId`.
-- {{domxref("PublicKeyCredential.rawId")}} {{ReadOnlyInline()}}
+- {{domxref("PublicKeyCredential.rawId")}} {{ReadOnlyInline}}
   - : Un objet {{domxref("ArrayBuffer")}} qui contient l'identifiant unique global/universel pour cette instance `PublicKeyCredential`. Cet identifiant peut être utilisé afin de rechercher les informations d'authentification avec les futurs appels à {{domxref("CredentialsContainer.get")}}.
-- {{domxref("PublicKeyCredential.response")}} {{ReadOnlyInline()}}
+- {{domxref("PublicKeyCredential.response")}} {{ReadOnlyInline}}
   - : Une instance {{domxref("AuthenticatorResponse")}}. Cette instance est de type :
     - {{domxref("AuthenticatorAttestationResponse")}} si l'objet `PublicKeyCredential` a été créé grâce à un appel à [`create()`](/fr/docs/Web/API/CredentialsContainer/create)
     - {{domxref("AuthenticatorAssertionResponse")}} si l'objet `PublicKeyCredential` a été créé grâce à un appel à [`get()`](/fr/docs/Web/API/CredentialsContainer/get).

--- a/files/fr/web/api/pushevent/index.md
+++ b/files/fr/web/api/pushevent/index.md
@@ -3,7 +3,7 @@ title: PushEvent
 slug: Web/API/PushEvent
 ---
 
-{{APIRef("Push API")}}{{SeeCompatTable()}}
+{{APIRef("Push API")}}{{SeeCompatTable}}
 
 L'interface **`PushEvent`** de l'[API Push](/fr/docs/Web/API/Push_API) représente un message Push qui a été reçu. Cet événement est envoyé au [scope global](/fr/docs/Web/API/ServiceWorkerGlobalScope) d'un {{domxref("ServiceWorker")}}. Il contient les informations transmises de l'application serveur vers un {{domxref("PushSubscription")}}.
 

--- a/files/fr/web/api/storage/key/index.md
+++ b/files/fr/web/api/storage/key/index.md
@@ -3,7 +3,7 @@ title: Storage.key()
 slug: Web/API/Storage/key
 ---
 
-{{APIRef()}}
+{{APIRef}}
 
 La méthode `key()` de l'interface {{domxref("Storage")}} prend un nombre n en argument et retourne la n-ième clé contenue dans storage. L'ordre des clés étant définie par le navigateur, il est recommandé de ne pas s'y référer .
 

--- a/files/fr/web/api/window/scrollbars/index.md
+++ b/files/fr/web/api/window/scrollbars/index.md
@@ -3,7 +3,7 @@ title: Window.scrollbars
 slug: Web/API/Window/scrollbars
 ---
 
-{{APIRef()}}
+{{APIRef}}
 
 La propriété **`Window.scrollbars`** renvoie l'objet `scrollbars`, dont la visibilité peut être vérifié.
 

--- a/files/fr/web/javascript/reference/global_objects/iterator/zip/index.md
+++ b/files/fr/web/javascript/reference/global_objects/iterator/zip/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: 38c09bffe4654e74bfd225d28575afe42d4fe344
 ---
 
-{{JSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La méthode statique **`Iterator.zip()`** crée un nouvel objet {{JSxRef("Iterator")}} qui agrège plusieurs éléments à partir de plusieurs objets itérables en retournant des tableaux contenant les éléments à la même position. Elle permet essentiellement de "zipper" les itérables d'entrée, permettant une itération simultanée sur eux.
 

--- a/files/fr/web/javascript/reference/global_objects/iterator/zipkeyed/index.md
+++ b/files/fr/web/javascript/reference/global_objects/iterator/zipkeyed/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: c534ba0cb925657de5e99ab8c540eae31afd9382
 ---
 
-{{JSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 La méthode statique **`Iterator.zipKeyed()`** crée un nouvel objet {{JSxRef("Iterator")}} qui agrège des éléments à partir de plusieurs objets itérables en produisant des objets contenant les éléments à la même position, avec des clés définies par l'entrée. Elle permet essentiellement de «&nbsp;zipper&nbsp;» les itérables d'entrée, autorisant une itération simultanée sur eux.
 

--- a/files/fr/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/index.md
@@ -3,8 +3,6 @@ title: Proxy
 slug: Web/JavaScript/Reference/Global_Objects/Proxy
 ---
 
-{{JSRef}}
-
 Un objet **Proxy** permet de créer un intermédiaire pour un autre objet et qui peut intercepter et redéfinir certaines opérations fondamentales pour lui.
 
 ## Description

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/apply/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/apply/index.md
@@ -3,8 +3,6 @@ title: handler.apply()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/apply
 ---
 
-{{JSRef}}
-
 La méthode **`handler.apply()`** représente une trappe pour un appel de fonctions.
 
 {{InteractiveExample("JavaScript Demo: handler.apply()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
@@ -3,8 +3,6 @@ title: handler.construct()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/construct
 ---
 
-{{JSRef}}
-
 La méthode **`handler.construct()`** est une trappe pour l'opérateur {{jsxref("new")}}. Afin que l'opération `new` puisse être valide sur le proxy correspondant, la cible utilisée doit avoir une méthode interne `[[Construct]]` (autrement dit, l'instruction `new cible` doit être valide).
 
 {{InteractiveExample("JavaScript Demo: handler.construct()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
@@ -3,8 +3,6 @@ title: handler.defineProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/defineProperty
 ---
 
-{{JSRef}}
-
 La méthode **`handler.defineProperty()`** est une trappe pour {{jsxref("Object.defineProperty()")}}.
 
 {{InteractiveExample("JavaScript Demo: handler.defineProperty()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.md
@@ -3,8 +3,6 @@ title: handler.deleteProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/deleteProperty
 ---
 
-{{JSRef}}
-
 La méthode **`handler.deleteProperty()`** est une trappe pour l'opérateur {{jsxref("delete")}}.
 
 {{InteractiveExample("JavaScript Demo: handler.deleteProperty()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/get/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/get/index.md
@@ -3,8 +3,6 @@ title: handler.get()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/get
 ---
 
-{{JSRef}}
-
 La méthode **`handler.get()`** est une trappe pour intercepter l'accès à la valeur d'une propriété.
 
 {{InteractiveExample("JavaScript Demo: handler.get()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
@@ -3,8 +3,6 @@ title: handler.getOwnPropertyDescriptor()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getOwnPropertyDescriptor
 ---
 
-{{JSRef}}
-
 La méthode **`handler.getOwnPropertyDescriptor()`** est une trappe pour intercepter {{jsxref("Object.getOwnPropertyDescriptor()")}}.
 
 {{InteractiveExample("JavaScript Demo: handler.getOwnPropertyDescriptor()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
@@ -3,8 +3,6 @@ title: handler.getPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getPrototypeOf
 ---
 
-{{JSRef}}
-
 La méthode **`handler.getPrototypeOf()`** représente une trappe pour la méthode interne `[[GetPrototypeOf]]`.
 
 {{InteractiveExample("JavaScript Demo: handler.getPrototypeOf()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/has/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/has/index.md
@@ -3,8 +3,6 @@ title: handler.has()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/has
 ---
 
-{{JSRef}}
-
 La méthode **`handler.has()`** est une trappe pour l'opérateur {{jsxref("Operators/in", "in")}}.
 
 {{InteractiveExample("JavaScript Demo: handler.has()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/index.md
@@ -3,8 +3,6 @@ title: Gestionnaire de Proxy (handler)
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy
 ---
 
-{{JSRef}}
-
 L'objet gestionnaire d'un proxy est un objet qui contient les trappes de captures (_traps_) pour le {{jsxref("Proxy", "proxy", "", 1)}}.
 
 ## Méthodes

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
@@ -3,8 +3,6 @@ title: handler.isExtensible()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/isExtensible
 ---
 
-{{JSRef}}
-
 La méthode **`handler.isExtensible()`** est une trappe pour intercepter les opérations de {{jsxref("Object.isExtensible()")}}.
 
 {{InteractiveExample("JavaScript Demo: handler.isExtensible()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.md
@@ -3,8 +3,6 @@ title: handler.ownKeys()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/ownKeys
 ---
 
-{{JSRef}}
-
 La méthode **`handler.ownKeys()`** est une trappe pour {{jsxref("Object.getOwnPropertyNames()")}}.
 
 {{InteractiveExample("JavaScript Demo: handler.ownKeys()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.md
@@ -3,8 +3,6 @@ title: handler.preventExtensions()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/preventExtensions
 ---
 
-{{JSRef}}
-
 La méthode **`handler.preventExtensions()`** est une trappe pour {{jsxref("Object.preventExtensions()")}}.
 
 {{InteractiveExample("JavaScript Demo: handler.preventExtensions()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/set/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/set/index.md
@@ -3,8 +3,6 @@ title: handler.set()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set
 ---
 
-{{JSRef}}
-
 La méthode **`handler.set()`** est une trappe permettant d'intercepter les opérations visant à définir ou modifier la valeur d'une propriété.
 
 {{InteractiveExample("JavaScript Demo: handler.set()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.md
@@ -3,8 +3,6 @@ title: handler.setPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/setPrototypeOf
 ---
 
-{{JSRef}}
-
 La méthode **`handler.setPrototypeOf()`** est une trappe pour intercepter {{jsxref("Object.setPrototypeOf()")}}.
 
 {{InteractiveExample("JavaScript Demo: handler.setPrototypeOf()", "taller", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/proxy/revocable/index.md
+++ b/files/fr/web/javascript/reference/global_objects/proxy/revocable/index.md
@@ -3,8 +3,6 @@ title: Proxy.revocable()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/revocable
 ---
 
-{{JSRef}}
-
 La méthode **`Proxy.revocable()`** est utilisée afin de créer un objet [`Proxy`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Proxy) révocable.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/rangeerror/index.md
+++ b/files/fr/web/javascript/reference/global_objects/rangeerror/index.md
@@ -3,8 +3,6 @@ title: RangeError
 slug: Web/JavaScript/Reference/Global_Objects/RangeError
 ---
 
-{{JSRef}}
-
 L'objet **`RangeError`** permet d'indiquer une erreur lorsqu'une valeur fournie n'appartient pas à l'intervalle ou à l'ensemble de valeurs autorisées.
 
 ## Description

--- a/files/fr/web/javascript/reference/global_objects/rangeerror/rangeerror/index.md
+++ b/files/fr/web/javascript/reference/global_objects/rangeerror/rangeerror/index.md
@@ -3,8 +3,6 @@ title: Constructeur RangeError()
 slug: Web/JavaScript/Reference/Global_Objects/RangeError/RangeError
 ---
 
-{{JSRef}}
-
 Le constructeur **`RangeError()`** permet de créer une erreur lorsqu'une valeur n'appartient pas à l'intervalle ou à l'ensemble des valeurs autorisées.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/referenceerror/index.md
+++ b/files/fr/web/javascript/reference/global_objects/referenceerror/index.md
@@ -3,8 +3,6 @@ title: ReferenceError
 slug: Web/JavaScript/Reference/Global_Objects/ReferenceError
 ---
 
-{{JSRef}}
-
 L'objet **`ReferenceError`** représente une erreur qui se produit lorsqu'il fait référence à une variable qui n'existe pas (ou qui n'a pas encore été initialisée) dans la portée courante.
 
 ## Constructeur

--- a/files/fr/web/javascript/reference/global_objects/referenceerror/referenceerror/index.md
+++ b/files/fr/web/javascript/reference/global_objects/referenceerror/referenceerror/index.md
@@ -3,8 +3,6 @@ title: Constructeur ReferenceError()
 slug: Web/JavaScript/Reference/Global_Objects/ReferenceError/ReferenceError
 ---
 
-{{JSRef}}
-
 Le constructeur **`ReferenceError()`** permet de créer des objets représentant une erreur qui se produit lorsque le code fait référence à une variable qui n'existe pas.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/reflect/apply/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/apply/index.md
@@ -3,8 +3,6 @@ title: Reflect.apply()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/apply
 ---
 
-{{JSRef}}
-
 La méthode statique **`Reflect.apply()`** permet d'appeler une fonction cible avec des arguments donnés.
 
 {{InteractiveExample("JavaScript Demo: Reflect.apply()")}}

--- a/files/fr/web/javascript/reference/global_objects/reflect/construct/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/construct/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 488e1953f44909cbeb419f0e2133cc28ca069f84
 ---
 
-{{JSRef}}
-
 La méthode statique **`Reflect.construct()`** agit comme l'opérateur [`new`](/fr/docs/Web/JavaScript/Reference/Operators/new) sous la forme d'une fonction. Elle est équivalente à `new cible(...args)` et permet d'indiquer une valeur différente pour [`new.target`](/fr/docs/Web/JavaScript/Reference/Operators/new.target).
 
 {{InteractiveExample("JavaScript Demo: Reflect.construct()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/reflect/defineproperty/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/defineproperty/index.md
@@ -3,8 +3,6 @@ title: Reflect.defineProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/defineProperty
 ---
 
-{{JSRef}}
-
 La méthode statique **`Reflect.defineProperty()`** est semblable à {{jsxref("Object.defineProperty()")}} mais renvoie un {{jsxref("Boolean")}}.
 
 {{InteractiveExample("JavaScript Demo: Reflect.defineProperty()")}}

--- a/files/fr/web/javascript/reference/global_objects/reflect/deleteproperty/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/deleteproperty/index.md
@@ -3,8 +3,6 @@ title: Reflect.deleteProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/deleteProperty
 ---
 
-{{JSRef}}
-
 La méthode statique **`Reflect.deleteProperty()`** permet de supprimer des propriétés. Il agit comme l'opérateur [`delete`](/fr/docs/Web/JavaScript/Reference/Operators/delete).
 
 {{InteractiveExample("JavaScript Demo: Reflect.deleteProperty()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/reflect/get/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/get/index.md
@@ -3,8 +3,6 @@ title: Reflect.get()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/get
 ---
 
-{{JSRef}}
-
 La méthode statique **`Reflect.get()`** est une fonction qui permet d'obtenir une propriété d'un objet cible. Elle fonctionne comme (`cible[cléPropriété]`) mais sous la forme d'une fonction.
 
 {{InteractiveExample("JavaScript Demo: Reflect.get()")}}

--- a/files/fr/web/javascript/reference/global_objects/reflect/getownpropertydescriptor/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/getownpropertydescriptor/index.md
@@ -3,8 +3,6 @@ title: Reflect.getOwnPropertyDescriptor()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/getOwnPropertyDescriptor
 ---
 
-{{JSRef}}
-
 La méthode statique **`Reflect.getOwnPropertyDescriptor()`** est similaire à {{jsxref("Object.getOwnPropertyDescriptor()")}}. Elle renvoie un descripteur de propriété pour la propriété visée si elle existe sur l'objet, sinon, elle renvoie {{jsxref("undefined")}}.
 
 {{InteractiveExample("JavaScript Demo: Reflect.getOwnPropertyDescriptor()")}}

--- a/files/fr/web/javascript/reference/global_objects/reflect/getprototypeof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/getprototypeof/index.md
@@ -3,8 +3,6 @@ title: Reflect.getPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/getPrototypeOf
 ---
 
-{{JSRef}}
-
 La méthode statique **`Reflect.getPrototypeOf()`** est semblable à la méthode {{jsxref("Object.getPrototypeOf()")}}. Elle renvoie le prototype (c'est-à-dire la valeur de la propriété interne `[[Prototype]]`) de l'objet donné.
 
 {{InteractiveExample("JavaScript Demo: Reflect.getPrototypeOf()")}}

--- a/files/fr/web/javascript/reference/global_objects/reflect/has/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/has/index.md
@@ -3,8 +3,6 @@ title: Reflect.has()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/has
 ---
 
-{{JSRef}}
-
 La méthode statique **`Reflect.has()`** fonctionne comme [l'opérateur `in`](/fr/docs/Web/JavaScript/Reference/Operators/in) mais sous forme d'une fonction.
 
 {{InteractiveExample("JavaScript Demo: Reflect.has()")}}

--- a/files/fr/web/javascript/reference/global_objects/reflect/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/index.md
@@ -3,8 +3,6 @@ title: Reflect
 slug: Web/JavaScript/Reference/Global_Objects/Reflect
 ---
 
-{{JSRef}}
-
 **`Reflect`** est un objet natif qui fournit des méthodes pour les opérations qui peuvent être interceptées en JavaScript (via les proxies). Les méthodes de cet objet sont les mêmes que celles des [gestionnaires de proxy](/fr/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy). `Reflect` n'est pas une fonction (y compris pour construire un objet).
 
 ## Description

--- a/files/fr/web/javascript/reference/global_objects/reflect/isextensible/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/isextensible/index.md
@@ -3,8 +3,6 @@ title: Reflect.isExtensible()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/isExtensible
 ---
 
-{{JSRef}}
-
 La méthode statique **`Reflect.isExtensible()`** permet de déterminer si un objet est extensible (i.e. si on peut lui ajouter de nouvelles propriétés). Elle est semblable à la méthode {{jsxref("Object.isExtensible()")}} (modulo [quelques différences](#diffs)).
 
 {{InteractiveExample("JavaScript Demo: Reflect.isExtensible()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/reflect/ownkeys/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/ownkeys/index.md
@@ -3,8 +3,6 @@ title: Reflect.ownKeys()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys
 ---
 
-{{JSRef}}
-
 La méthode statique **`Reflect.ownKeys()`** renvoie un tableau qui contient les clés des propriétés propres (non héritées) de l'objet `cible`.
 
 {{InteractiveExample("JavaScript Demo: Reflect.ownKeys()")}}

--- a/files/fr/web/javascript/reference/global_objects/reflect/preventextensions/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/preventextensions/index.md
@@ -3,8 +3,6 @@ title: Reflect.preventExtensions()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/preventExtensions
 ---
 
-{{JSRef}}
-
 La méthode statique **`Reflect.preventExtensions()`** permet d'empêcher d'ajouter de nouvelles propriétés à un objet. Cette méthode est semblable à la méthode {{jsxref("Object.preventExtensions()")}} (modulo [quelques différences](#diffs)).
 
 {{InteractiveExample("JavaScript Demo: Reflect.preventExtensions()")}}

--- a/files/fr/web/javascript/reference/global_objects/reflect/set/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/set/index.md
@@ -3,8 +3,6 @@ title: Reflect.set()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/set
 ---
 
-{{JSRef}}
-
 La méthode statique **`Reflect.set()`** permet de définir ou de modifier une propriété sur un objet.
 
 {{InteractiveExample("JavaScript Demo: Reflect.set()")}}

--- a/files/fr/web/javascript/reference/global_objects/reflect/setprototypeof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/reflect/setprototypeof/index.md
@@ -3,8 +3,6 @@ title: Reflect.setPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/setPrototypeOf
 ---
 
-{{JSRef}}
-
 la méthode statique **`Reflect.setPrototypeOf()`** est semblable à la méthode {{jsxref("Object.setPrototypeOf()")}} (exception faite de la valeur de retour). Elle permet de définir le prototype (c'est-à-dire la propriété interne `[[Prototype]]`) d'un objet donné avec un autre objet ou {{jsxref("null")}}. Cette méthode renvoie `true` si l'opération a réussi et `false` sinon.
 
 {{InteractiveExample("JavaScript Demo: Reflect.setPrototypeOf()")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/compile/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/compile/index.md
@@ -3,8 +3,6 @@ title: RegExp.prototype.compile()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/compile
 ---
 
-{{JSRef}}
-
 La méthode dépréciée **`compile()`** est utilisée afin de (re)compiler une expression rationnelle lors de l'exécution d'un script. Cette méthode effectue essentiellement les mêmes actions que le constructeur `RegExp`.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/regexp/dotall/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/dotall/index.md
@@ -3,8 +3,6 @@ title: RegExp.prototype.dotAll
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/dotAll
 ---
 
-{{JSRef}}
-
 La propriété **`dotAll`** indique si le marqueur "`s`" est utilisé pour l'expression rationnelle. `dotAll` est une propriété en lecture seule et qui renseigne à propos de l'expression rationnelle courante.
 
 {{JS_Property_Attributes(0, 0, 1)}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/exec/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/exec/index.md
@@ -3,8 +3,6 @@ title: RegExp.prototype.exec()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/exec
 ---
 
-{{JSRef}}
-
 La méthode **`exec()`** exécute la recherche d'une correspondance sur une chaîne de caractères donnée. Elle renvoie un tableau contenant les résultats ou {{jsxref("null")}}.
 
 Si on souhaite uniquement savoir s'il y a une correspondance, on utilisera la méthode {{jsxref("RegExp.prototype.test()")}} ou la méthode {{jsxref("String.prototype.search()")}}.

--- a/files/fr/web/javascript/reference/global_objects/regexp/flags/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/flags/index.md
@@ -3,8 +3,6 @@ title: RegExp.prototype.flags
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/flags
 ---
 
-{{JSRef}}
-
 La propriété **`flags`** renvoie une chaîne de caractères contenant les [drapeaux (_flags_)](</fr/docs/Web/JavaScript/Guide/Regular_expressions#Effectuer_des_recherches_avancées_en_utilisant_les_drapeaux_(flags)>) de l'objet {{jsxref("RegExp")}} auquel elle appartient.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.flags")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/global/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/global/index.md
@@ -3,8 +3,6 @@ title: RegExp.prototype.global
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/global
 ---
 
-{{JSRef}}
-
 La propriété **`global`** indique si le marqueur (_flag_) "`g`" est utilisé pour l'expression rationnelle. `global` est une propriété accessible en lecture seule pour une expression rationnelle donnée.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.global")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/hasindices/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/hasindices/index.md
@@ -3,8 +3,6 @@ title: RegExp.prototype.hasIndices
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices
 ---
 
-{{JSRef}}
-
 La propriété **`hasIndices`** indique si le marqueur "`d`" a été utilisé ou non avec l'expression rationnelle. `hasIndices` est une propriété en lecture seule, rattachée à une instance d'expression rationnelle.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.hasIndices")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/ignorecase/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/ignorecase/index.md
@@ -3,8 +3,6 @@ title: RegExp.prototype.ignoreCase
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase
 ---
 
-{{JSRef}}
-
 La propriété **`ignoreCase`** indique si le drapeau (_flag_) "`i`" est utilisé ou non pour cette expression rationnelle. `ignoreCase` est une propriété accessible en lecture seule d'une instance d'expression rationnelle donnée.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.ignoreCase")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/index.md
@@ -3,8 +3,6 @@ title: RegExp
 slug: Web/JavaScript/Reference/Global_Objects/RegExp
 ---
 
-{{JSRef}}
-
 Un objet **RegExp** est utilisé pour étudier les correspondances d'un texte avec un motif donné.
 
 Pour une introduction aux expressions rationnelles, lire [le chapitre Expressions rationnelles](/fr/docs/Web/JavaScript/Guide/Regular_expressions) dans [le Guide JavaScript](/fr/docs/Web/JavaScript/Guide/Regular_expressions).

--- a/files/fr/web/javascript/reference/global_objects/regexp/input/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/input/index.md
@@ -3,7 +3,7 @@ title: RegExp.input ($_)
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/input
 ---
 
-{{JSRef}} {{non-standard_header}}
+{{non-standard_header}}
 
 La propriété non-standard **`input`** est une propriété statique de l'expression rationnelle qui contient la chaîne de caractères sur laquelle est effectuée la recherche de correspondances. `RegExp.$_` est un alias de cette propriété.
 

--- a/files/fr/web/javascript/reference/global_objects/regexp/lastindex/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/lastindex/index.md
@@ -3,8 +3,6 @@ title: regExp.lastIndex
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex
 ---
 
-{{JSRef}}
-
 La propriété **`lastIndex`** est un entier en lecture/écriture qui permet de définir l'indice (position) à partir duquel chercher la prochaine correspondance pour une instance d'expression rationnelle donnée.
 
 {{InteractiveExample("JavaScript Demo: RegExp.lastIndex")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/lastmatch/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/lastmatch/index.md
@@ -3,7 +3,7 @@ title: RegExp.lastMatch ($&)
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch
 ---
 
-{{JSRef}} {{non-standard_header}}
+{{non-standard_header}}
 
 La propriété non-standard **`lastMatch`** est une propriété statique en lecture seule pour les expressions rationnelles qui contient les caractères de la dernière correspondance. `RegExp.$&` est un alias pour cette propriété.
 

--- a/files/fr/web/javascript/reference/global_objects/regexp/lastparen/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/lastparen/index.md
@@ -3,7 +3,7 @@ title: RegExp.lastParen ($+)
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/lastParen
 ---
 
-{{JSRef}} {{non-standard_header}}
+{{non-standard_header}}
 
 La propriété **`lastParen`** est une propriété statique accessible en lecture seule qui contient la dernière correspondance enregistrée dans un groupe (entre parenthèse) si jamais elle existe. `RegExp.$+` est un alias pour cette propriété.
 

--- a/files/fr/web/javascript/reference/global_objects/regexp/leftcontext/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/leftcontext/index.md
@@ -3,7 +3,7 @@ title: RegExp.leftContext ($`)
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/leftContext
 ---
 
-{{JSRef}} {{non-standard_header}}
+{{non-standard_header}}
 
 La propriété non-standard **`leftContext`** est une propriété statique accessible uniquement en lecture. Cette propriété liée aux expressions rationnelles contient la sous-chaîne qui précède la correspondance la plus récente. `` RegExp.$` `` est un alias pour cette propriété.
 

--- a/files/fr/web/javascript/reference/global_objects/regexp/multiline/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/multiline/index.md
@@ -3,8 +3,6 @@ title: RegExp.prototype.multiline
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/multiline
 ---
 
-{{JSRef}}
-
 La propriété **`multiline`** indique si le drapeau (_flag_) "`m`" a été utilisé ou non pour l'expression rationnelle. `multiline` est une propriété liée à l'instance, accessible en lecture seule.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.multiline", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/n/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/n/index.md
@@ -3,7 +3,7 @@ title: RegExp.$1-$9
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/n
 ---
 
-{{JSRef}} {{non-standard_header}}
+{{non-standard_header}}
 
 Les propriétés non-standard **$1, $2, $3, $4, $5, $6, $7, $8, $9** sont des propriétés statiques accessibles en lecture qui contiennent les différents groupes capturés par une expression rationnelle.
 

--- a/files/fr/web/javascript/reference/global_objects/regexp/regexp/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/regexp/index.md
@@ -3,8 +3,6 @@ title: Constructeur RegExp()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/RegExp
 ---
 
-{{JSRef}}
-
 Le constructeur **`RegExp`** crée une expression rationnelle pour manipuler les correspondances trouvées dans un texte par rapport à un motif.
 
 Pour une introduction au sujet des expressions rationnelles, nous vous conseillons de lire [le chapitre sur les expressions rationnelles](/fr/docs/Web/JavaScript/Guide/Regular_expressions) du [Guide JavaScript](/fr/docs/Web/JavaScript/Guide).

--- a/files/fr/web/javascript/reference/global_objects/regexp/rightcontext/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/rightcontext/index.md
@@ -3,7 +3,7 @@ title: RegExp.rightContext ($')
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/rightContext
 ---
 
-{{JSRef}} {{non-standard_header}}
+{{non-standard_header}}
 
 La propriété non-standard **`rightContext`** est une propriété statique, accessible uniquement en lecture, qui contient la sous-chaîne suivant la correspondance la plus récente. `RegExp.$'` est un alias pour cette propriété.
 

--- a/files/fr/web/javascript/reference/global_objects/regexp/source/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/source/index.md
@@ -3,8 +3,6 @@ title: RegExp.prototype.source
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/source
 ---
 
-{{JSRef}}
-
 La propriété **`source`** renvoie une chaîne de caractères qui contient le texte du motif à rechercher (_pattern_), sans les barres obliques (_slashes_). C'est une propriété en lecture seule liée à l'instance. **`source`** ne contient aucun des options ou drapeaux (_flags_) (tels que "g", "i" ou "m") de l'expression rationnelle.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.source")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/sticky/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/sticky/index.md
@@ -3,8 +3,6 @@ title: RegExp.prototype.sticky
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/sticky
 ---
 
-{{JSRef}}
-
 La propriété **`sticky`** (adhérante) permet de déterminer si la recherche s'effectue uniquement à partir de l'indice {{jsxref("RegExp.lastIndex", "lastIndex")}} lié à l'expression rationnelle ou non). `sticky` est une propriété accessible en lecture seule, rattachée à l'instance.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.sticky")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/symbol.match/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/symbol.match/index.md
@@ -4,8 +4,6 @@ slug: Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.match
 original_slug: Web/JavaScript/Reference/Global_Objects/RegExp/@@match
 ---
 
-{{JSRef}}
-
 La méthode **`[@@match]()`** permet de récupérer les correspondances obtenues lorsqu'on teste une chaîne de caractères par rapport à une expression rationnelle (_regexp_).
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype[Symbol.match]()")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/symbol.matchall/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/symbol.matchall/index.md
@@ -4,8 +4,6 @@ slug: Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.matchAll
 original_slug: Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll
 ---
 
-{{JSRef}}
-
 La méthode **`[@@matchAll]`** renvoie l'ensemble des correspondances d'une expression rationnelle sur une chaîne de caractères.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype[Symbol.matchAll]()")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/symbol.replace/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/symbol.replace/index.md
@@ -4,8 +4,6 @@ slug: Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.replace
 original_slug: Web/JavaScript/Reference/Global_Objects/RegExp/@@replace
 ---
 
-{{JSRef}}
-
 La méthode **`[@@replace]()`** remplace toutes ou certaines correspondances d'un motif `this` dans une chaîne de caractère avec un outil de remplacement. La valeur renvoyée est la nouvelle chaîne ainsi créée. Cet outil de remplacement peut être une chaîne de caractère ou une fonction appelée pour chacune des correspondances.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype[SYmbol.replace]()")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/symbol.search/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/symbol.search/index.md
@@ -4,8 +4,6 @@ slug: Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.search
 original_slug: Web/JavaScript/Reference/Global_Objects/RegExp/@@search
 ---
 
-{{JSRef}}
-
 La méthode **`[@@search]()`** recherche une correspondance entre une expression rationnelle décrite par `this` et une chaîne de caractères donnée.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype[Symbol.search]()")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/symbol.species/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/symbol.species/index.md
@@ -4,8 +4,6 @@ slug: Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.species
 original_slug: Web/JavaScript/Reference/Global_Objects/RegExp/@@species
 ---
 
-{{JSRef}}
-
 La propriété accesseur **`RegExp[@@species]`** renvoie le constructeur `RegExp`.
 
 {{InteractiveExample("JavaScript Demo: RegExp[Symbol.species]")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/symbol.split/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/symbol.split/index.md
@@ -4,8 +4,6 @@ slug: Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.split
 original_slug: Web/JavaScript/Reference/Global_Objects/RegExp/@@split
 ---
 
-{{JSRef}}
-
 La méthode **`[@@split]()`** permet de découper une chaîne de caractères ({{jsxref("String")}}) en un tableau de sous-chaînes.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype[Symbol.split]()")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/test/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/test/index.md
@@ -3,8 +3,6 @@ title: RegExp.prototype.test()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/test
 ---
 
-{{JSRef}}
-
 La méthode **`test()`** vérifie s'il y a une correspondance entre un texte et une expression rationnelle. Elle retourne `true` en cas de succès et `false` dans le cas contraire.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.test", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/tostring/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/tostring/index.md
@@ -3,8 +3,6 @@ title: RegExp.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/toString
 ---
 
-{{JSRef}}
-
 La méthode **`toString()`** renvoie une chaîne de caractères représentant l'expression rationnelle.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.toString()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/regexp/unicode/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/unicode/index.md
@@ -3,8 +3,6 @@ title: RegExp.prototype.unicode
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/unicode
 ---
 
-{{JSRef}}
-
 La propriété **`unicode`** indique si le drapeau "`u`" a été utilisé avec l'expression rationnelle. `unicode` est une propriété en lecture seule et liée à une instance d'expression rationnelle.
 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.unicode", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/set/add/index.md
+++ b/files/fr/web/javascript/reference/global_objects/set/add/index.md
@@ -3,8 +3,6 @@ title: Set.prototype.add()
 slug: Web/JavaScript/Reference/Global_Objects/Set/add
 ---
 
-{{JSRef}}
-
 La méthode **`add()`** permet d'ajouter un nouvel élément ayant une valeur donnée à un ensemble `Set`. Cette valeur sera ajoutée à la fin de l'objet `Set`.
 
 {{InteractiveExample("JavaScript Demo: Set.prototype.add()")}}

--- a/files/fr/web/javascript/reference/global_objects/set/clear/index.md
+++ b/files/fr/web/javascript/reference/global_objects/set/clear/index.md
@@ -3,8 +3,6 @@ title: Set.prototype.clear()
 slug: Web/JavaScript/Reference/Global_Objects/Set/clear
 ---
 
-{{JSRef}}
-
 La méthode **`clear()`** permet de retirer tous les éléments d'un ensemble `Set`.
 
 {{InteractiveExample("JavaScript Demo: Set.prototype.clear()")}}

--- a/files/fr/web/javascript/reference/global_objects/set/delete/index.md
+++ b/files/fr/web/javascript/reference/global_objects/set/delete/index.md
@@ -3,8 +3,6 @@ title: Set.prototype.delete()
 slug: Web/JavaScript/Reference/Global_Objects/Set/delete
 ---
 
-{{JSRef}}
-
 La méthode **`delete()`** permet de retirer un élément donné d'un objet `Set`.
 
 {{InteractiveExample("JavaScript Demo: Set.prototype.delete()")}}

--- a/files/fr/web/javascript/reference/global_objects/set/entries/index.md
+++ b/files/fr/web/javascript/reference/global_objects/set/entries/index.md
@@ -3,8 +3,6 @@ title: Set.prototype.entries()
 slug: Web/JavaScript/Reference/Global_Objects/Set/entries
 ---
 
-{{JSRef}}
-
 La méthode **`entries()`** renvoie un nouvel objet [`Iterator`](/fr/docs/Web/JavaScript/Guide/Iterators_and_generators#itérateurs) qui contient un tableau composé de **`[valeur, valeur]`** pour chaque élément de l'objet `Set`, dans leur ordre d'insertion. En raison de leur structure, les objets `Set` n'ont pas de clé (`key`), à la différence des objets `Map`. Pour garder une structure et une API sembables à celle d'un objet `Map`, chaque entrée (_entry_) aura la même valeur pour la _clé_ (_key_) et pour la _valeur_ (_value_), c'est pourquoi un tableau de `[valeur, valeur]` est renvoyé.
 
 {{InteractiveExample("JavaScript Demo: Set.prototype.entries()")}}

--- a/files/fr/web/javascript/reference/global_objects/set/foreach/index.md
+++ b/files/fr/web/javascript/reference/global_objects/set/foreach/index.md
@@ -3,8 +3,6 @@ title: Set.prototype.forEach()
 slug: Web/JavaScript/Reference/Global_Objects/Set/forEach
 ---
 
-{{JSRef}}
-
 La méthode **`forEach()`** permet d'exécuter une fonction donnée, une fois pour chaque valeur de l'ensemble `Set`. L'ordre appliqué est celui dans lequel les valeurs ont été ajoutées à l'ensemble.
 
 {{InteractiveExample("JavaScript Demo: Set.prototype.forEach()")}}

--- a/files/fr/web/javascript/reference/global_objects/set/has/index.md
+++ b/files/fr/web/javascript/reference/global_objects/set/has/index.md
@@ -3,8 +3,6 @@ title: Set.prototype.has()
 slug: Web/JavaScript/Reference/Global_Objects/Set/has
 ---
 
-{{JSRef}}
-
 La méthode **`has()`** renvoie un booléen qui indique s'il existe un élément de l'ensemble `Set` avec une certaine valeur.
 
 {{InteractiveExample("JavaScript Demo: Set.prototype.has()")}}

--- a/files/fr/web/javascript/reference/global_objects/set/index.md
+++ b/files/fr/web/javascript/reference/global_objects/set/index.md
@@ -3,8 +3,6 @@ title: Set
 slug: Web/JavaScript/Reference/Global_Objects/Set
 ---
 
-{{JSRef}}
-
 Un objet **`Set`** permet de stocker un ensemble de valeurs uniques de n'importe quel type, qu'il s'agisse de [valeurs primitives](/fr/docs/Glossary/Primitive) ou d'objets.
 
 ## Description

--- a/files/fr/web/javascript/reference/global_objects/set/set/index.md
+++ b/files/fr/web/javascript/reference/global_objects/set/set/index.md
@@ -3,8 +3,6 @@ title: Constructeur Set()
 slug: Web/JavaScript/Reference/Global_Objects/Set/Set
 ---
 
-{{JSRef}}
-
 Le **constructeur `Set()`** permet de créer des objets `Set` qui sont des ensembles de valeurs uniques de n'importe quel type ([des valeurs primitives](/fr/docs/Glossary/Primitive) ou des objets).
 
 {{InteractiveExample("JavaScript Demo: Set.prototype Constructor")}}

--- a/files/fr/web/javascript/reference/global_objects/set/size/index.md
+++ b/files/fr/web/javascript/reference/global_objects/set/size/index.md
@@ -3,8 +3,6 @@ title: Set.prototype.size
 slug: Web/JavaScript/Reference/Global_Objects/Set/size
 ---
 
-{{JSRef}}
-
 L'accesseur **`size`** est une propriété qui renvoie le nombre d'éléments contenus dans un objet {{jsxref("Set")}}. Un objet `Set` correspondant à un ensemble, chaque élément qu'il contient y est unique.
 
 {{InteractiveExample("JavaScript Demo: Set.prototype.size")}}

--- a/files/fr/web/javascript/reference/global_objects/set/symbol.iterator/index.md
+++ b/files/fr/web/javascript/reference/global_objects/set/symbol.iterator/index.md
@@ -4,8 +4,6 @@ slug: Web/JavaScript/Reference/Global_Objects/Set/Symbol.iterator
 original_slug: Web/JavaScript/Reference/Global_Objects/Set/@@iterator
 ---
 
-{{JSRef}}
-
 La valeur initiale de la propriété **`@@iterator`** est le même objet fonction que la valeur initiale de la propriété {{jsxref("Set.prototype.values()", "Set.prototype.values")}}.
 
 {{InteractiveExample("JavaScript Demo: Set.prototype[Symbol.iterator]()")}}

--- a/files/fr/web/javascript/reference/global_objects/set/symbol.species/index.md
+++ b/files/fr/web/javascript/reference/global_objects/set/symbol.species/index.md
@@ -4,8 +4,6 @@ slug: Web/JavaScript/Reference/Global_Objects/Set/Symbol.species
 original_slug: Web/JavaScript/Reference/Global_Objects/Set/@@species
 ---
 
-{{JSRef}}
-
 **`Set[@@species]`** renvoie le constructeur `Set`.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/set/values/index.md
+++ b/files/fr/web/javascript/reference/global_objects/set/values/index.md
@@ -3,8 +3,6 @@ title: Set.prototype.values()
 slug: Web/JavaScript/Reference/Global_Objects/Set/values
 ---
 
-{{JSRef}}
-
 La méthode **`values()`** renvoie un nouvel objet {{jsxref("Iterator")}} qui contient les valeurs de chaque élément de l'objet `Set`, dans leur ordre d'insertion.
 
 La méthode **`keys()`** est un alias pour cette méthode (afin de conserver une certaine similarité avec les objets {{jsxref("Map")}}) et se comportera exactement de la même façon en renvoyant les **valeurs** des éléments du `Set`.

--- a/files/fr/web/javascript/reference/global_objects/sharedarraybuffer/bytelength/index.md
+++ b/files/fr/web/javascript/reference/global_objects/sharedarraybuffer/bytelength/index.md
@@ -3,8 +3,6 @@ title: SharedArrayBuffer.prototype.byteLength
 slug: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength
 ---
 
-{{JSRef}}
-
 La propriété d'accesseur **`byteLength`** représente la longueur d'un {{jsxref("SharedArrayBuffer")}} exprimée en octets.
 
 {{InteractiveExample("JavaScript Demo: SharedArrayBuffer.byteLength")}}

--- a/files/fr/web/javascript/reference/global_objects/sharedarraybuffer/index.md
+++ b/files/fr/web/javascript/reference/global_objects/sharedarraybuffer/index.md
@@ -3,8 +3,6 @@ title: SharedArrayBuffer
 slug: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
 ---
 
-{{JSRef}}
-
 L'objet **`SharedArrayBuffer`** est utilisé afin de représenter un tampon de données binaires brutes générique de longueur fixe. Il est semblable à l'objet [`ArrayBuffer`](/fr/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), mais peut ici être utilisé pour créer différentes vues sur une même mémoire partagée. À la différence d'un `ArrayBuffer`, un `SharedArrayBuffer` n'est pas [un objet transférable](/fr/docs/Web/API/Web_Workers_API/Transferable_objects).
 
 ## Description

--- a/files/fr/web/javascript/reference/global_objects/sharedarraybuffer/sharedarraybuffer/index.md
+++ b/files/fr/web/javascript/reference/global_objects/sharedarraybuffer/sharedarraybuffer/index.md
@@ -3,8 +3,6 @@ title: Constructeur SharedArrayBuffer()
 slug: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/SharedArrayBuffer
 ---
 
-{{JSRef}}
-
 > [!NOTE]
 > `SharedArrayBuffer` a été désactivé par défaut pour l'ensemble des navigateurs principaux le 5 janvier 2018 en réponse à la faille [Spectre](https://meltdownattack.com/). Chrome [a réactivé cette fonctionnalité à partir de la version 67](https://bugs.chromium.org/p/chromium/issues/detail?id=821270) sur les plateformes où la fonctionnalité d'isolation des sites est activée et protège des vulnérabilités analogues à Spectre.
 

--- a/files/fr/web/javascript/reference/global_objects/sharedarraybuffer/slice/index.md
+++ b/files/fr/web/javascript/reference/global_objects/sharedarraybuffer/slice/index.md
@@ -3,8 +3,6 @@ title: SharedArrayBuffer.prototype.slice()
 slug: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice
 ---
 
-{{JSRef}}
-
 La méthode **`SharedArrayBuffer.prototype.slice()`** renvoie un nouvel objet {{jsxref("SharedArrayBuffer")}} dont le contenu est une copie des octets de l'objet `SharedArrayBuffer` courant entre un indice de début (inclus) et un indice de fin (exclus) (autrement dit, on copie une « tranche » du tampon courant). Si l'indice de début ou de fin est négatif, la position sera comptée à partir de la fin du tableau plutôt qu'à partir du début. L'algorithme appliqué est le même que {{jsxref("Array.prototype.slice()")}}_._
 
 {{InteractiveExample("JavaScript Demo: SharedArrayBuffer.slice()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/anchor/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/anchor/index.md
@@ -3,8 +3,6 @@ title: String.prototype.anchor()
 slug: Web/JavaScript/Reference/Global_Objects/String/anchor
 ---
 
-{{JSRef}}
-
 La méthode **`anchor()`** permet de créer une ancre HTML {{HTMLElement("a")}} qui est utilisé comme cible hypertexte.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/string/at/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/at/index.md
@@ -3,8 +3,6 @@ title: String.prototype.at()
 slug: Web/JavaScript/Reference/Global_Objects/String/at
 ---
 
-{{JSRef}}
-
 La méthode **`at()`** prend un entier en argument et renvoie une nouvelle chaîne de caractères ([`String`](/fr/docs/Web/JavaScript/Reference/Global_Objects/String)) contenant le codet UTF-16 présent dans la chaîne courante à l'emplacement indiqué en argument. Cette méthode permet d'utiliser des arguments positifs ou négatifs. Lorsque le paramètre passé est un entier négatif, la recherche s'effectue depuis la fin de la chaîne de caractères.
 
 {{InteractiveExample("JavaScript Demo: String.at()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/big/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/big/index.md
@@ -3,8 +3,6 @@ title: String.prototype.big()
 slug: Web/JavaScript/Reference/Global_Objects/String/big
 ---
 
-{{JSRef}}
-
 La méthode **`big()`** crée un élément HTML {{HTMLElement("big")}} qui affichera la chaine de caractères avec une taille de police importante.
 
 > [!NOTE]

--- a/files/fr/web/javascript/reference/global_objects/string/blink/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/blink/index.md
@@ -3,8 +3,6 @@ title: String.prototype.blink()
 slug: Web/JavaScript/Reference/Global_Objects/String/blink
 ---
 
-{{JSRef}}
-
 La méthode **`blink()`** crée un élément HTML `<blink>` qui affiche la chaine de caractères en clignotant.
 
 > [!WARNING]

--- a/files/fr/web/javascript/reference/global_objects/string/bold/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/bold/index.md
@@ -3,8 +3,6 @@ title: String.prototype.bold()
 slug: Web/JavaScript/Reference/Global_Objects/String/bold
 ---
 
-{{JSRef}}
-
 La méthode **`bold()`** crée un élément HTML {{HTMLElement("b")}} qui affiche la chaine de caractères en gras.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/string/charat/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/charat/index.md
@@ -3,8 +3,6 @@ title: String.prototype.charAt()
 slug: Web/JavaScript/Reference/Global_Objects/String/charAt
 ---
 
-{{JSRef}}
-
 La méthode **`charAt()`** renvoie une nouvelle chaîne contenant le caractère (ou, plus précisément, le point de code UTF-16) à la position indiquée en argument.
 
 {{InteractiveExample("JavaScript Demo: String.charAt()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/charcodeat/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/charcodeat/index.md
@@ -3,8 +3,6 @@ title: String.prototype.charCodeAt()
 slug: Web/JavaScript/Reference/Global_Objects/String/charCodeAt
 ---
 
-{{JSRef}}
-
 La méthode **`charCodeAt()`** retourne un entier compris entre 0 et 65535 qui correspond au code UTF-16 d'un caractère de la chaîne situé à une position donnée.
 
 {{InteractiveExample("JavaScript Demo: String.charCodeAt()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/codepointat/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/codepointat/index.md
@@ -3,8 +3,6 @@ title: String.prototype.codePointAt()
 slug: Web/JavaScript/Reference/Global_Objects/String/codePointAt
 ---
 
-{{JSRef}}
-
 La méthode **`codePointAt()`** renvoie un entier positif qui correspond au code Unicode (_code point_) du caractère de la chaîne à la position donnée.
 
 {{InteractiveExample("JavaScript Demo: String.codePointAt()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/concat/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/concat/index.md
@@ -3,8 +3,6 @@ title: String.prototype.concat()
 slug: Web/JavaScript/Reference/Global_Objects/String/concat
 ---
 
-{{JSRef}}
-
 La méthode **`concat()`** combine le texte de plusieurs chaînes avec la chaîne appelante et renvoie la nouvelle chaîne ainsi formée.
 
 {{InteractiveExample("JavaScript Demo: String.concat()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/endswith/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/endswith/index.md
@@ -3,8 +3,6 @@ title: String.prototype.endsWith()
 slug: Web/JavaScript/Reference/Global_Objects/String/endsWith
 ---
 
-{{JSRef}}
-
 La méthode **`endsWith()`** renvoie un booléen indiquant si la chaine de caractères se termine par la chaine de caractères fournie en argument.
 
 {{InteractiveExample("JavaScript Demo: String.endsWith()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/fixed/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/fixed/index.md
@@ -3,8 +3,6 @@ title: String.prototype.fixed()
 slug: Web/JavaScript/Reference/Global_Objects/String/fixed
 ---
 
-{{JSRef}}
-
 La méthode **`fixed()`** permet de créer un élément HTML {{HTMLElement("tt")}}, ce qui permet d'afficher le texte de la chaîne de caractère dans une fonte à chasse fixe.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/string/fontcolor/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/fontcolor/index.md
@@ -3,8 +3,6 @@ title: String.prototype.fontcolor()
 slug: Web/JavaScript/Reference/Global_Objects/String/fontcolor
 ---
 
-{{JSRef}}
-
 La méthode **`fontcolor()`** permet de créer un élément {{HTMLElement("font")}} qui permet d'afficher la chaine de caractères dans une fonte utilisant la couleur donnée.
 
 > [!NOTE]

--- a/files/fr/web/javascript/reference/global_objects/string/fontsize/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/fontsize/index.md
@@ -3,8 +3,6 @@ title: String.prototype.fontsize()
 slug: Web/JavaScript/Reference/Global_Objects/String/fontsize
 ---
 
-{{JSRef}}
-
 La propriété **`fontsize()`** permet de créer un élément HTML {{HTMLElement("font")}} qui permet d'afficher la chaîne de caractères dans une fonte de taille donnée.
 
 > [!NOTE]

--- a/files/fr/web/javascript/reference/global_objects/string/fromcharcode/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/fromcharcode/index.md
@@ -3,8 +3,6 @@ title: String.fromCharCode()
 slug: Web/JavaScript/Reference/Global_Objects/String/fromCharCode
 ---
 
-{{JSRef}}
-
 La méthode statique **`String.fromCharCode()`** renvoie une chaîne de caractères créée à partir de points de code UTF-16.
 
 {{InteractiveExample("JavaScript Demo: String.fromCharCode()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/fromcodepoint/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/fromcodepoint/index.md
@@ -3,8 +3,6 @@ title: String.fromCodePoint()
 slug: Web/JavaScript/Reference/Global_Objects/String/fromCodePoint
 ---
 
-{{JSRef}}
-
 La méthode statique **`String.fromCodePoint()`** renvoie une chaîne de caractères créée à partir d'un suite de codets.
 
 {{InteractiveExample("JavaScript Demo: String.fromCodePoint()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/includes/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/includes/index.md
@@ -3,8 +3,6 @@ title: String.prototype.includes()
 slug: Web/JavaScript/Reference/Global_Objects/String/includes
 ---
 
-{{JSRef}}
-
 La méthode **`includes()`** détermine si une chaîne de caractères est contenue dans une autre et renvoie `true` ou `false` selon le cas de figure.
 
 {{InteractiveExample("JavaScript Demo: String.includes()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/index.md
@@ -3,8 +3,6 @@ title: String
 slug: Web/JavaScript/Reference/Global_Objects/String
 ---
 
-{{JSRef}}
-
 Un objet **`String`** est utilisé afin de représenter et de manipuler une chaîne de caractères.
 
 ## Description

--- a/files/fr/web/javascript/reference/global_objects/string/indexof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/indexof/index.md
@@ -3,8 +3,6 @@ title: String.prototype.indexOf()
 slug: Web/JavaScript/Reference/Global_Objects/String/indexOf
 ---
 
-{{JSRef}}
-
 La méthode **`indexOf()`** renvoie l'indice de la première occurence de la valeur cherchée au sein de la chaîne courante (à partir de `indexDébut`). Elle renvoie -1 si la valeur cherchée n'est pas trouvée.
 
 {{InteractiveExample("JavaScript Demo: String.indexOf()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/italics/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/italics/index.md
@@ -3,8 +3,6 @@ title: String.prototype.italics()
 slug: Web/JavaScript/Reference/Global_Objects/String/italics
 ---
 
-{{JSRef}}
-
 La méthode **`italics()`** permet de créer un élément HTML {{HTMLElement("i")}} qui permet de représenter la chaîne courante en italique.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/string/lastindexof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/lastindexof/index.md
@@ -3,8 +3,6 @@ title: String.prototype.lastIndexOf()
 slug: Web/JavaScript/Reference/Global_Objects/String/lastIndexOf
 ---
 
-{{JSRef}}
-
 La méthode **`lastIndexOf()`** renvoie l'indice, dans la chaîne courante, de la dernière occurence de la valeur donnée en argument. Si cette sous-chaîne n'est pas trouvée, la méthode renvoie -1. La recherche s'effectue de la fin vers le début de la chaîne, à partir de `indiceDébut`.
 
 {{InteractiveExample("JavaScript Demo: String.lastIndexOf()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/length/index.md
@@ -3,8 +3,6 @@ title: String.length
 slug: Web/JavaScript/Reference/Global_Objects/String/length
 ---
 
-{{JSRef}}
-
 La propriété **`length`** représente la longueur d'une chaine de caractères, exprimée en nombre de points de code UTF-16. C'est une propriété accessible en lecture seule.
 
 {{InteractiveExample("JavaScript Demo: String.length")}}

--- a/files/fr/web/javascript/reference/global_objects/string/link/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/link/index.md
@@ -3,8 +3,6 @@ title: String.prototype.link()
 slug: Web/JavaScript/Reference/Global_Objects/String/link
 ---
 
-{{JSRef}}
-
 La méthode **`link()`** permet de créer une chaîne de caractères représentant un élément HTML {{HTMLElement("a")}}, ce qui permet d'afficher la chaîne de caractères comme un lien hypertexte vers une URL donnée.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/string/localecompare/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/localecompare/index.md
@@ -3,8 +3,6 @@ title: String.prototype.localeCompare()
 slug: Web/JavaScript/Reference/Global_Objects/String/localeCompare
 ---
 
-{{JSRef}}
-
 La méthode **`localeCompare()`** renvoie un nombre indiquant si la chaîne de caractères courante se situe avant, après ou est la même que la chaîne passée en paramètre, selon l'ordre lexicographique de la locale.
 
 {{InteractiveExample("JavaScript Demo: String.localeCompare()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/match/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/match/index.md
@@ -3,8 +3,6 @@ title: String.prototype.match()
 slug: Web/JavaScript/Reference/Global_Objects/String/match
 ---
 
-{{JSRef}}
-
 La méthode **`match()`** permet d'obtenir le tableau des correspondances entre la chaîne courante et une expression rationnelle.
 
 {{InteractiveExample("JavaScript Demo: String.match()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/matchall/index.md
@@ -3,8 +3,6 @@ title: String.prototype.matchAll()
 slug: Web/JavaScript/Reference/Global_Objects/String/matchAll
 ---
 
-{{JSRef}}
-
 La méthode **`matchAll()`** renvoie un itérateur contenant l'ensemble des correspondances entre une chaîne de caractères d'une part et une expression rationnelle d'autre part (y compris les groupes capturants).
 
 {{InteractiveExample("JavaScript Demo: String.matchAll()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/normalize/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/normalize/index.md
@@ -3,8 +3,6 @@ title: String.prototype.normalize()
 slug: Web/JavaScript/Reference/Global_Objects/String/normalize
 ---
 
-{{JSRef}}
-
 La méthode **`normalize()`** permet de renvoyer la forme normalisée Unicode d'une chaîne de caractères.
 
 {{InteractiveExample("JavaScript Demo: String.normalize()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/padend/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/padend/index.md
@@ -3,8 +3,6 @@ title: String.prototype.padEnd()
 slug: Web/JavaScript/Reference/Global_Objects/String/padEnd
 ---
 
-{{JSRef}}
-
 La méthode **`padEnd()`** permet de compléter la chaîne courante avec une chaîne de caractères donnée afin d'obtenir une chaîne de longueur fixée. Pour atteindre cette longueur, la chaîne complémentaire peut être répétée. La chaîne courante est complétée depuis la fin.
 
 {{InteractiveExample("JavaScript Demo: String.padEnd()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/padstart/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/padstart/index.md
@@ -3,8 +3,6 @@ title: String.prototype.padStart()
 slug: Web/JavaScript/Reference/Global_Objects/String/padStart
 ---
 
-{{JSRef}}
-
 La méthode **`padStart()`** permet de compléter la chaîne courante avec une chaîne de caractères donnée afin d'obtenir une chaîne de longueur fixée. Pour atteindre cette longueur, la chaîne complémentaire peut être répétée. La chaîne courante est complétée depuis le début.
 
 {{InteractiveExample("JavaScript Demo: String.padStart()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/raw/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/raw/index.md
@@ -3,8 +3,6 @@ title: String.raw()
 slug: Web/JavaScript/Reference/Global_Objects/String/raw
 ---
 
-{{JSRef}}
-
 La méthode statique **`String.raw()`** est une fonction d'étiquetage (_tag function_) pour les [gabarits de chaînes de caractères](/fr/docs/Web/JavaScript/Reference/Template_literals#les_gabarits_étiquetés) (elle est [semblable](https://bugs.chromium.org/p/v8/issues/detail?id=5016) au préfixe `r` en Python ou au préfixe `@` en C#). Cette fonction permet d'obtenir la chaîne brute pour un gabarit (les caractères spéciaux ne sont pas pris en compte mais retranscrits tels quels, les séquences d'échappement ne sont pas interprétées et les emplacements (ex. `${toto}`) sont traités).
 
 {{InteractiveExample("JavaScript Demo: String.raw()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/repeat/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/repeat/index.md
@@ -3,8 +3,6 @@ title: String.prototype.repeat()
 slug: Web/JavaScript/Reference/Global_Objects/String/repeat
 ---
 
-{{JSRef}}
-
 La méthode **`repeat()`** construit et renvoie une nouvelle chaine de caractères qui contient le nombre de copie demandée de la chaine de caractères sur laquelle la méthode a été appelée, concaténées les unes aux autres.
 
 {{InteractiveExample("JavaScript Demo: String.repeat()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/replace/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/replace/index.md
@@ -3,8 +3,6 @@ title: String.prototype.replace()
 slug: Web/JavaScript/Reference/Global_Objects/String/replace
 ---
 
-{{JSRef}}
-
 La méthode **`replace()`** renvoie une nouvelle chaîne de caractères dans laquelle tout ou partie des correspondances à un `modèle` sont remplacées par un `remplacement`. Le `modèle` utilisé peut être une {{jsxref("RegExp")}} et le remplacement peut être une chaîne ou une fonction à appeler pour chaque correspondance. Si `modèle` est une chaîne de caractères, seule la première correspondance sera remplacée.
 
 La chaîne de caractère originale reste inchangée.

--- a/files/fr/web/javascript/reference/global_objects/string/replaceall/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/replaceall/index.md
@@ -3,8 +3,6 @@ title: String.prototype.replaceAll()
 slug: Web/JavaScript/Reference/Global_Objects/String/replaceAll
 ---
 
-{{JSRef}}
-
 La méthode **`replaceAll()`** retourne une nouvelle chaîne de caractères dans laquelle toutes les occurrences d'un motif donné ont été remplacées par une chaîne de remplacement. L'argument `pattern` fournit pour décrire le motif peut être une chaîne de caractères ou une expression rationnelle ([`RegExp`](/fr/docs/Web/JavaScript/Reference/Global_Objects/RegExp)), l'argument `replacement` peut être une chaîne de caractères ou une fonction qui sera appelée pour chaque correspondance.
 
 La chaîne de caractères initiale restera inchangée.

--- a/files/fr/web/javascript/reference/global_objects/string/search/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/search/index.md
@@ -3,8 +3,6 @@ title: String.prototype.search()
 slug: Web/JavaScript/Reference/Global_Objects/String/search
 ---
 
-{{JSRef}}
-
 La méthode **`search()`** éxecute une recherche dans une chaine de caractères grâce à une expression rationnelle appliquée sur la chaîne courante.
 
 {{InteractiveExample("JavaScript Demo: String.search()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/slice/index.md
@@ -3,8 +3,6 @@ title: String.prototype.slice()
 slug: Web/JavaScript/Reference/Global_Objects/String/slice
 ---
 
-{{JSRef}}
-
 La méthode **`slice()`** extrait une section d'une chaine de caractères et la retourne comme une nouvelle chaine de caractères. La chaîne de caractères courante n'est pas modifiée.
 
 {{InteractiveExample("JavaScript Demo: String.slice()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/small/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/small/index.md
@@ -3,8 +3,6 @@ title: String.prototype.small()
 slug: Web/JavaScript/Reference/Global_Objects/String/small
 ---
 
-{{JSRef}}
-
 La méthode **`small()`** permet de créer un élément HTML {{HTMLElement("small")}}, ce qui permet d'afficher la chaîne de caractères dans une fonte de petite taille.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/split/index.md
@@ -3,8 +3,6 @@ title: String.prototype.split()
 slug: Web/JavaScript/Reference/Global_Objects/String/split
 ---
 
-{{JSRef}}
-
 La méthode **`split()`** divise une [chaîne de caractères](/fr/docs/Web/JavaScript/Reference/Global_Objects/String) en une liste ordonnée de sous-chaînes, place ces sous-chaînes dans un tableau et retourne le tableau. La division est effectuée en recherchant un motif ; où le motif est fourni comme premier paramètre dans l'appel de la méthode.
 
 {{InteractiveExample("JavaScript Demo: String.split()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/string/startswith/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/startswith/index.md
@@ -3,8 +3,6 @@ title: String.prototype.startsWith()
 slug: Web/JavaScript/Reference/Global_Objects/String/startsWith
 ---
 
-{{JSRef}}
-
 La méthode **`startsWith()`** renvoie un booléen indiquant si la chaine de caractères commence par la deuxième chaine de caractères fournie en argument.
 
 {{InteractiveExample("JavaScript Demo: String.startsWith()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/strike/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/strike/index.md
@@ -3,8 +3,6 @@ title: String.prototype.strike()
 slug: Web/JavaScript/Reference/Global_Objects/String/strike
 ---
 
-{{JSRef}}
-
 La méthode **`strike()`** permet de créer un élément HTML {{HTMLElement("strike")}} qui permet d'afficher la chaîne comme un texte barré.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/string/string/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/string/index.md
@@ -3,8 +3,6 @@ title: Constructeur String()
 slug: Web/JavaScript/Reference/Global_Objects/String/String
 ---
 
-{{JSRef}}
-
 Le constructeur **`String`** est utilisé afin de créer un nouvel objet [`String`](/fr/docs/Web/JavaScript/Reference/Global_Objects/String) qui représente une chaîne de caractères. Lorsqu'il est appelé comme une fonction (et pas comme un constructeur, c'est-à-dire sans être précédé du mot-clé `new`), il effectue une conversion de la valeur fournie en argument en une chaîne de caractères primitive, ce qui peut être plus utile.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/string/sub/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/sub/index.md
@@ -3,8 +3,6 @@ title: String.prototype.sub()
 slug: Web/JavaScript/Reference/Global_Objects/String/sub
 ---
 
-{{JSRef}}
-
 La méthode **`sub()`** crée un élément HTML {{HTMLElement("sub")}} qui entraîne l'affichage de la chaîne en indice.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/string/substr/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/substr/index.md
@@ -3,8 +3,6 @@ title: String.prototype.substr()
 slug: Web/JavaScript/Reference/Global_Objects/String/substr
 ---
 
-{{JSRef}}
-
 > [!WARNING]
 > Bien que `String.prototype.substr(…)` ne soit pas strictement obsolète (au sens où elle n'a pas été retirée des standards), elle est définie au sein de [l'Annexe B](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-additional-ecmascript-features-for-web-browsers) du standard ECMA-262 qui définit l'ensemble des fonctionnalités historiques qui doivent être évitées autant que possible. On utilisera la méthode {{jsxref("String.prototype.substring()")}} à la place.
 

--- a/files/fr/web/javascript/reference/global_objects/string/substring/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/substring/index.md
@@ -3,8 +3,6 @@ title: String.prototype.substring()
 slug: Web/JavaScript/Reference/Global_Objects/String/substring
 ---
 
-{{JSRef}}
-
 La méthode **`substring()`** retourne une sous-chaîne de la chaîne courante, entre un indice de début et un indice de fin.
 
 {{InteractiveExample("JavaScript Demo: String.substring()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/sup/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/sup/index.md
@@ -3,8 +3,6 @@ title: String.prototype.sup()
 slug: Web/JavaScript/Reference/Global_Objects/String/sup
 ---
 
-{{JSRef}}
-
 La méthode **`sup()`** crée un élément HTML {{HTMLElement("sup")}} qui entraîne l'affichage de la chaîne en exposant.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/string/symbol.iterator/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/symbol.iterator/index.md
@@ -4,8 +4,6 @@ slug: Web/JavaScript/Reference/Global_Objects/String/Symbol.iterator
 original_slug: Web/JavaScript/Reference/Global_Objects/String/@@iterator
 ---
 
-{{JSRef}}
-
 La méthode **`[@@iterator]()`** renvoie un nouvel objet [`Iterator`](/fr/docs/Web/JavaScript/Reference/Iteration_protocols) qui itère sur les points de code (codets) d'une chaîne de caractères, en renvoyant chaque point de code sous forme d'une chaîne de caractères.
 
 {{InteractiveExample("JavaScript Demo: Symbol.iterator")}}

--- a/files/fr/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
@@ -3,8 +3,6 @@ title: String.prototype.toLocaleLowerCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase
 ---
 
-{{JSRef}}
-
 La méthode **`toLocaleLowerCase()`** renvoie la chaîne de caractères qui appelle la méthode en une chaîne de caractères représentées en minuscules, en tenant compte des correspondances de caractères propres aux différentes locales.
 
 {{InteractiveExample("JavaScript Demo: String.toLocaleLowerCase()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
@@ -3,8 +3,6 @@ title: String.prototype.toLocaleUpperCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase
 ---
 
-{{JSRef}}
-
 La méthode **`toLocaleUpperCase()`** renvoie la chaîne de caractères qui appelle la méthode en caractères majuscules, selon les correspondances de caractères propres aux différentes locales.
 
 {{InteractiveExample("JavaScript Demo: String.toLocaleUpperCase()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/tolowercase/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/tolowercase/index.md
@@ -3,8 +3,6 @@ title: String.prototype.toLowerCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toLowerCase
 ---
 
-{{JSRef}}
-
 La méthode **`toLowerCase()`** retourne la chaîne de caractères courante en minuscules.
 
 {{InteractiveExample("JavaScript Demo: String.toLowerCase()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/tostring/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/tostring/index.md
@@ -3,8 +3,6 @@ title: String.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/String/toString
 ---
 
-{{JSRef}}
-
 La méthode **`toString()`** renvoie une chaine de caractères représentant l'objet renseigné.
 
 {{InteractiveExample("JavaScript Demo: String.toString()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/touppercase/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/touppercase/index.md
@@ -3,8 +3,6 @@ title: String.prototype.toUpperCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toUpperCase
 ---
 
-{{JSRef}}
-
 La méthode **`toUpperCase()`** retourne la valeur de la chaîne courante, convertie en majuscules.
 
 {{InteractiveExample("JavaScript Demo: String.toUpperCase()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/trim/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/trim/index.md
@@ -3,8 +3,6 @@ title: String.prototype.trim()
 slug: Web/JavaScript/Reference/Global_Objects/String/trim
 ---
 
-{{JSRef}}
-
 La méthode **`trim()`** permet de retirer les blancs en début et fin de chaîne. Les blancs considérés sont les caractères d'espacement (espace, tabulation, espace insécable, etc.) ainsi que les caractères de fin de ligne (LF, CR, etc.).
 
 {{InteractiveExample("JavaScript Demo: String.trim()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/trimend/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/trimend/index.md
@@ -3,8 +3,6 @@ title: String.prototype.trimEnd()
 slug: Web/JavaScript/Reference/Global_Objects/String/trimEnd
 ---
 
-{{JSRef}}
-
 La méthode **`trimEnd()`** permet de retirer les blancs situés à la fin d'une chaîne de caractères. `trimRight()` est un synonyme pour cette méthode.
 
 {{InteractiveExample("JavaScript Demo: String.trimEnd()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/trimstart/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/trimstart/index.md
@@ -3,8 +3,6 @@ title: String.prototype.trimStart()
 slug: Web/JavaScript/Reference/Global_Objects/String/trimStart
 ---
 
-{{JSRef}}
-
 La méthode **`trimStart()`** permet de retirer les blancs au début de la chaîne de caractères. `trimLeft()` est un synonyme pour cette méthode.
 
 {{InteractiveExample("JavaScript Demo: String.trimStart()")}}

--- a/files/fr/web/javascript/reference/global_objects/string/valueof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/valueof/index.md
@@ -3,8 +3,6 @@ title: String.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/String/valueOf
 ---
 
-{{JSRef}}
-
 La méthode **`valueOf()`** renvoie la valeur primitive de l'objet {{jsxref("String")}}.
 
 {{InteractiveExample("JavaScript Demo: String.valueOf()")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/asynciterator/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/asynciterator/index.md
@@ -3,8 +3,6 @@ title: Symbol.asyncIterator
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator
 ---
 
-{{JSRef}}
-
 Le symbole connu **`Symbol.asyncIterator`** définit l'itérateur asynchrone par défaut d'un objet. Si cette propriété est définie sur un objet, celui-ci est un itérable asynchrone et peut être utilisé avec une boucle [`for await...of`](/fr/docs/Web/JavaScript/Reference/Statements/for-await...of).
 
 {{js_property_attributes(0,0,0)}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/description/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/description/index.md
@@ -3,8 +3,6 @@ title: Symbol.prototype.description
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/description
 ---
 
-{{JSRef}}
-
 La propriété en lecture seule **`description`** est une chaîne de caractères qui renvoie la description optionnelle de l'objet {{jsxref("Symbol")}}.
 
 {{InteractiveExample("JavaScript Demo: Symbol.prototype.description")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/for/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/for/index.md
@@ -3,8 +3,6 @@ title: Symbol.for()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/for
 ---
 
-{{JSRef}}
-
 La méthode **`Symbol.for(clé)`** permet de chercher parmi les symboles existants enregistrés dans le registre global de l'environnement d'exécution. Si un symbole associé à la clé donnée existe, il est renvoyé par la fonction, sinon un nouveau symbole associé à cette clé est créé dans le registre.
 
 {{InteractiveExample("JavaScript Demo: Symbol.for()")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/hasinstance/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/hasinstance/index.md
@@ -3,8 +3,6 @@ title: Symbol.hasInstance
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance
 ---
 
-{{JSRef}}
-
 Le symbole « connu » **`Symbol.hasInstance`** est utilisé afin de déterminer si un objet constructeur reconnaît un objet comme une de ses instances. On peut donc adapter/personnaliser le comportement de l'opérateur {{jsxref("instanceof")}} grâce à ce symbole.
 
 {{InteractiveExample("JavaScript Demo: Symbol.hasInstance")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/index.md
@@ -3,8 +3,6 @@ title: Symbol
 slug: Web/JavaScript/Reference/Global_Objects/Symbol
 ---
 
-{{JSRef}}
-
 Un objet **`Symbol`** est un objet natif dont le constructeur renvoie une valeur [primitive](/fr/docs/Glossary/Primitive) de type `symbol`. On parle de **valeur symbole** ou de **symbole**&nbsp;: il s'agit d'une valeur dont l'unicité est garantie. Les symboles sont souvent utilisés pour ajouter des clés de propriétés uniques à un objet afin que celles-ci ne rentrent pas en conflit avec des clés ajoutées par un autre code. Les symboles sont masqués des mécanismes habituellement utilisés pour parcourir les propriétés d'un objet. Cela permet une sorte d'[encapsulation](/fr/docs/Glossary/Encapsulation) faible, ou une forme faible de [masquage de l'information](https://fr.wikipedia.org/wiki/Masquage_de_l'information).
 
 Chaque appel à `Symbol()` garantit le renvoi d'un symbole unique. Chaque appel à `Symbol.for("cle")` renverra toujours le même symbole correspondant à la valeur `"cle"`. Lorsque `Symbol.for("cle")` est appelé, si un symbole existe avec cette clé dans le registre global des symboles, il est renvoyé. Sinon, un nouveau symbole est créé et est ajouté au registre global des symboles avec cette clé puis est renvoyé.

--- a/files/fr/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
@@ -3,8 +3,6 @@ title: Symbol.isConcatSpreadable
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable
 ---
 
-{{JSRef}}
-
 Le symbole connu **`Symbol.isConcatSpreadable`** est utilisé pour configurer la façon dont un tableau est aplati lors d'une concaténation via la méthode {{jsxref("Array.prototype.concat()")}}.
 
 {{InteractiveExample("JavaScript Demo: Symbol.isConcatSpreadable")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/iterator/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/iterator/index.md
@@ -3,8 +3,6 @@ title: Symbol.iterator
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/iterator
 ---
 
-{{JSRef}}
-
 Le symbole **`Symbol.iterator`** définit l'itérateur par défaut d'un objet. C'est l'itérateur qui sera utilisé par [`for...of`](/fr/docs/Web/JavaScript/Reference/Statements/for...of).
 
 {{InteractiveExample("JavaScript Demo: Symbol.iterator")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/keyfor/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/keyfor/index.md
@@ -3,8 +3,6 @@ title: Symbol.keyFor()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/keyFor
 ---
 
-{{JSRef}}
-
 La méthode **`Symbol.keyFor(sym)`** permet de récupérer la clé d'un symbole donné qui est partagé via le registre global des symboles.
 
 {{InteractiveExample("JavaScript Demo: Symbol.keyFor()")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/match/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/match/index.md
@@ -3,8 +3,6 @@ title: Symbol.match
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/match
 ---
 
-{{JSRef}}
-
 Le symbole **`Symbol.match`** définit la correspondance d'une expression rationnelle par rapport à une chaîne de caractères. Cette fonction est appelée par la méthode {{jsxref("String.prototype.match()")}}.
 
 {{InteractiveExample("JavaScript Demo: Symbol.match")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/matchall/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/matchall/index.md
@@ -3,8 +3,6 @@ title: Symbol.matchAll
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/matchAll
 ---
 
-{{JSRef}}
-
 Le symbole connu **`Symbol.matchAll`** renvoie un itérateur qui fournit l'ensemble des correspondances entre une expression rationnelle et une chaîne de caractères. Cette fonction est implicitement appelée par la méthode {{jsxref("String.prototype.matchAll()")}}.
 
 {{InteractiveExample("JavaScript Demo: Symbol.matchAll")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -3,8 +3,6 @@ title: Symbol.replace
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/replace
 ---
 
-{{JSRef}}
-
 Le symbole connu **`Symbol.replace`** définit la méthode utilisée pour remplacer les correspondances trouvées dans une chaîne de caractères. Cette fonction est appelée par la méthode {{jsxref("String.prototype.replace()")}}.
 
 Pour plus d'informations, se référer aux pages sur {{jsxref("RegExp/Symbol.replace", "RegExp.prototype[@@replace]()")}} et {{jsxref("String.prototype.replace()")}}.

--- a/files/fr/web/javascript/reference/global_objects/symbol/search/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/search/index.md
@@ -3,8 +3,6 @@ title: Symbol.search
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/search
 ---
 
-{{JSRef}}
-
 Le symbole connu **`Symbol.search`** définit la méthode qui renvoie l'indice indiquant la position d'une correspondance trouvée dans une chaîne de caractères grâce à une expression rationnelle. Cette fonction est appelée par la méthode {{jsxref("String.prototype.search()")}}.
 
 Pour plus d'informations, se référer aux pages sur {{jsxref("RegExp/Symbol.search", "RegExp.prototype[@@search]()")}} et {{jsxref("String.prototype.search()")}}.

--- a/files/fr/web/javascript/reference/global_objects/symbol/species/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/species/index.md
@@ -3,8 +3,6 @@ title: Symbol.species
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/species
 ---
 
-{{JSRef}}
-
 Le symbole **`Symbol.species`** correspond à une fonction utilisée comme constructeur pour créer des objets dérivés.
 
 {{InteractiveExample("JavaScript Demo: Symbol.species")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/split/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/split/index.md
@@ -3,8 +3,6 @@ title: Symbol.split
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/split
 ---
 
-{{JSRef}}
-
 Le symbole connu **`Symbol.split`** définit la méthode qui est utilisée pour découper une chaîne de caractères à l'emplacement où une correspondance a été trouvée grâce à une expression rationnelle. Cette fonction est appelée par la méthode {{jsxref("String.prototype.split()")}}.
 
 Pour plus d'informations, se référer aux pages sur {{jsxref("RegExp/Symbol.split", "RegExp.prototype[@@split]()")}} et {{jsxref("String.prototype.split()")}}.

--- a/files/fr/web/javascript/reference/global_objects/symbol/symbol.toprimitive/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/symbol.toprimitive/index.md
@@ -4,8 +4,6 @@ slug: Web/JavaScript/Reference/Global_Objects/Symbol/Symbol.toPrimitive
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive
 ---
 
-{{JSRef}}
-
 La méthode **`[@@toPrimitive]()`** permet de convertir un objet symbole en une valeur primitive.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/symbol/symbol/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/symbol/index.md
@@ -3,8 +3,6 @@ title: Constructeur Symbol()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/Symbol
 ---
 
-{{JSRef}}
-
 Le constructeur `Symbol()` renvoie une valeur de type **`symbol`**. Ce n'est pas à proprement parler un constructeur, car il n'accepte pas la syntaxe `new Symbol()` et qu'il n'est pas prévu pour créer des sous-classes. On pourra l'utiliser comme valeur pour la clause [`extends`](/fr/docs/Web/JavaScript/Reference/Classes/extends) d'une définition de classe, mais on ne pourra pas l'utiliser avec un appel [`super`](/fr/docs/Web/JavaScript/Reference/Operators/super), cela entraînera une exception.
 
 {{InteractiveExample("JavaScript Demo: Symbol - Constructor", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/toprimitive/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/toprimitive/index.md
@@ -3,8 +3,6 @@ title: Symbol.toPrimitive
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive
 ---
 
-{{JSRef}}
-
 Le symbole « connu » **`Symbol.toPrimitive`** définit une fonction qui est appelée pour convertir un objet en une valeur primitive.
 
 {{InteractiveExample("JavaScript Demo: Symbol.toPrimitive")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/tostring/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/tostring/index.md
@@ -3,8 +3,6 @@ title: Symbol.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/toString
 ---
 
-{{JSRef}}
-
 La méthode **`toString()`** renvoie une chaîne de caractères représentant l'objet `Symbol`.
 
 {{InteractiveExample("JavaScript Demo: Symbol.prototype.toString()")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/tostringtag/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/tostringtag/index.md
@@ -3,8 +3,6 @@ title: Symbol.toStringTag
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag
 ---
 
-{{JSRef}}
-
 Le symbole connu **`Symbol.toStringTag`** est une propriété qui est une chaîne de caractères qui est utilisée pour la description textuelle par défaut d'un objet. Ce symbole est utilisé par le moteur JavaScript via la méthode {{jsxref("Object.prototype.toString()")}}.
 
 {{InteractiveExample("JavaScript Demo: Symbol.toStringTag")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/unscopables/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/unscopables/index.md
@@ -3,8 +3,6 @@ title: Symbol.unscopables
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/unscopables
 ---
 
-{{JSRef}}
-
 Le symbole connu **`Symbol.unscopables`** est utilisé afin de définir les noms des propriétés propres et héritées qui sont exclues de l'objet lors de l'utilisation de [`with`](/fr/docs/Web/JavaScript/Reference/Statements/with) sur l'objet en question.
 
 {{InteractiveExample("JavaScript Demo: Symbol.unscopables")}}

--- a/files/fr/web/javascript/reference/global_objects/symbol/valueof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/valueof/index.md
@@ -3,8 +3,6 @@ title: Symbol.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/valueOf
 ---
 
-{{JSRef}}
-
 La méthode **`valueOf()`** renvoie la valeur primitive correspondant à l'objet `Symbol`.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/syntaxerror/index.md
+++ b/files/fr/web/javascript/reference/global_objects/syntaxerror/index.md
@@ -3,8 +3,6 @@ title: SyntaxError
 slug: Web/JavaScript/Reference/Global_Objects/SyntaxError
 ---
 
-{{JSRef}}
-
 L'objet **`SyntaxError`** représente une erreur qui se produit lors de l'interprétation d'un code dont la syntaxe est invalide. Une telle exception est déclenchée lorsque le moteur JavaScript rencontre des entités lexicales invalides ou dans un ordre invalide par rapport à la grammaire du langage.
 
 ## Constructeur

--- a/files/fr/web/javascript/reference/global_objects/syntaxerror/syntaxerror/index.md
+++ b/files/fr/web/javascript/reference/global_objects/syntaxerror/syntaxerror/index.md
@@ -3,8 +3,6 @@ title: Constructeur SyntaxError()
 slug: Web/JavaScript/Reference/Global_Objects/SyntaxError/SyntaxError
 ---
 
-{{JSRef}}
-
 Le constructeur **`SyntaxError()`** permet de créer un objet représentant une erreur qui se produit lorsqu'on essaie d'interpréter du code dont la syntaxe est invalide.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/typedarray/at/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/at/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.at()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/at
 ---
 
-{{JSRef}}
-
 La méthode **`at()`** prend comme argument un entier et renvoie l'élément du tableau typé situé à cette position. Il est possible d'utiliser des entiers positifs et négatifs. Si l'argument est négatif, la position est relative à la fin du tableau.
 
 L'accès aux éléments d'un tableau typé en utilisant les crochets ne permet que d'utiliser des indices positifs&nbsp;: `typedarray[0]` renverra le premier élément, `typedarray[typedarray.length-1]` renverra le dernier. Avec `typedarray.at(-1)`, on peut avoir une écriture plus concise pour accéder au dernier élément. Voir les exemples ci-après.

--- a/files/fr/web/javascript/reference/global_objects/typedarray/buffer/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/buffer/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.buffer
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/buffer
 ---
 
-{{JSRef}}
-
 La propriété **`buffer`** est un accesseur représentant l'{{jsxref("ArrayBuffer")}} représenté par le _TypedArray_ lors de la construction de l'objet.
 
 {{InteractiveExample("JavaScript Demo: TypedArray.buffer")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/bytelength/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/bytelength/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.byteLength
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/byteLength
 ---
 
-{{JSRef}}
-
 La propriété **`byteLength`** est un accesseur qui représente la longueur, exprimée en octets, du tableau typé à partir du début de l'{{jsxref("ArrayBuffer")}} correspondant.
 
 {{InteractiveExample("JavaScript Demo: TypedArray.byteLength")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/byteoffset/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/byteoffset/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.byteOffset
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/byteOffset
 ---
 
-{{JSRef}}
-
 La propriété **`byteOffset`** est un accesseur qui représente le décalage, exprimé en octets, entre le début du tableau typé par rapport au début du {{jsxref("ArrayBuffer")}} correspondant.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/typedarray/bytes_per_element/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/bytes_per_element/index.md
@@ -3,8 +3,6 @@ title: TypedArray.BYTES_PER_ELEMENT
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/BYTES_PER_ELEMENT
 ---
 
-{{JSRef}}
-
 La propriété **`TypedArray.BYTES_PER_ELEMENT`** représente la taille, exprimée en octets, de chaque élément du tableau typé.
 
 {{InteractiveExample("JavaScript Demo: TypedArray.BYTES_PER_ELEMENT")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/copywithin/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/copywithin/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.copyWithin()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin
 ---
 
-{{JSRef}}
-
 La méthode **`copyWithin()`** permet de copier des éléments d'un tableau dans le tableau typé à partir de la position `cible`. Les éléments copiés sont ceux contenus entre les index `début` et `fin`. L'argument `fin` est optionnel, sa valeur par défaut correspondra à la longueur du tableau dont on souhaite copier les éléments. Cette méthode utilise le même algorithme que {{jsxref("Array.prototype.copyWithin")}}_._ _TypedArray_ est l'un des types de [tableaux typés](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.copyWithin()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/entries/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/entries/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.entries()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/entries
 ---
 
-{{JSRef}}
-
 La méthode **`entries()`** renvoie un nouvel objet `Array Iterator` qui contient les paires clé/valeur pour chaque indice du tableau.
 
 {{InteractiveExample("JavaScript Demo: TypedArray.entries()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/every/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/every/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.every()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/every
 ---
 
-{{JSRef}}
-
 La méthode **`every()`** teste si tous les éléments du tableau typé satisfont une condition implémentée par la fonction de test fournie. Cette méthode utilise le même algorithme {{jsxref("Array.prototype.every()")}}. Pour le reste de cet article, _TypedArray_ correspond à un des [types de tableaux typés](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.every()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/fill/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/fill/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.fill()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/fill
 ---
 
-{{JSRef}}
-
 La méthode **`fill()`** remplit les éléments d'un tableau typé contenu entre un indice de début et un indice de fin avec une valeur statique. Cette méthode utilise le même algorithme que {{jsxref("Array.prototype.fill()")}}. Dans le reste de cet article, _TypedArray_ correspond à l'un des [types de tableaux typés](/fr/docs/Web/JavaScript/Guide/Typed_arrays#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.fill()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/filter/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/filter/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.filter()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/filter
 ---
 
-{{JSRef}}
-
 La méthode **`filter()`** crée un nouveau tableau qui contient l'ensemble des éléments qui remplissent une condition fournie par la fonction de test passée en argument. Cette méthode utilise le même algorithme que {{jsxref("Array.prototype.filter()")}}_._ _TypedArray_ est utilisé ici de façon générique pour représenter [l'un des types de tableaux typés possibles](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.filter()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/find/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/find/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.find()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/find
 ---
 
-{{JSRef}}
-
 La méthode **`find()`** renvoie une **valeur** du tableau typé si un élément du tableau remplit la condition définie par la fonction de test fournie. Si aucun élément ne remplit la condition, la valeur {{jsxref("undefined")}} sera renvoyée. Pour la suite de cet article _TypedArray_ correspond à l'un des [types de tableaux typés](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 Voir également la page sur la méthohde {{jsxref("TypedArray.findIndex", "findIndex()")}} qui renvoie l'**indice** de l'élément trouvé (et non sa valeur).

--- a/files/fr/web/javascript/reference/global_objects/typedarray/findindex/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/findindex/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.findIndex()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/findIndex
 ---
 
-{{JSRef}}
-
 La méthode **`findIndex()`** renvoie un **indice** d'un élément d'un tableau typé si cet élément remplit une condition définie par une fonction de test donnée. S'il n'y a aucun élément satisfaisant, -1 sera renvoyé.
 
 Voir aussi la méthode {{jsxref("TypedArray.find", "find()")}} qui renvoie la **valeur** de l'élément trouvé (au lieu de son indice).

--- a/files/fr/web/javascript/reference/global_objects/typedarray/foreach/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/foreach/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.forEach()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/forEach
 ---
 
-{{JSRef}}
-
 La méthode **`forEach()`** permet d'exécuter une fonction donnée sur chaque élément du tableau. Cette méthode implémente le même algorithme que {{jsxref("Array.prototype.forEach()")}}.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/typedarray/from/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/from/index.md
@@ -3,8 +3,6 @@ title: TypedArray.from()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/from
 ---
 
-{{JSRef}}
-
 La méthode **`TypedArray.from()`** crée un nouvel objet {{jsxref("TypedArray", "TypedArray", "#Les_objets_TypedArray")}} à partir d'un objet itérable ou d'un objet semblable à un tableau. Cette méthode est similaire à {{jsxref("Array.from()")}}.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/typedarray/includes/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/includes/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.includes()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/includes
 ---
 
-{{JSRef}}
-
 La méthode **`includes()`** détermine si un tableau typé possède un certain élément et renvoie `true` ou `false` selon le cas de figure. Cette méthode utilise le même algorithme que la méthode {{jsxref("Array.prototype.includes()")}}. Dans le reste de l'article _TypedArray_ fait référence à un des [types de tableau typé](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.includes()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/index.md
@@ -3,8 +3,6 @@ title: TypedArray
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray
 ---
 
-{{JSRef}}
-
 Un objet **_TypedArray_** décrit une vue organisée à la façon d'un tableau pour manipuler [un tampon (_buffer_) de données binaires](/fr/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer). `TypedArray` n'est pas une propriété globale, il n'existe pas non plus de constructeur `TypedArray`. En revanche, plusieurs propriétés globales existent et leurs valeurs permettent de construire des tableaux typés (<i lang="en">typed arrays</i>) avec différents types de données. Ceux-ci sont listés ci-après. Les pages suivantes permettent de décrire les propriétés et méthodes qui peuvent être utilisées sur les différents tableaux typés.
 
 {{InteractiveExample("JavaScript Demo: TypedArray Constructor")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/indexof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/indexof/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.indexOf()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/indexOf
 ---
 
-{{JSRef}}
-
 La méthode **`indexOf()`** renvoie le premier indice (le plus petit) auquel on peut trouver un élément donné dans le tableau typé. Si l'élément n'est pas trouvé, la valeur de retour sera -1. L'algorithme utilisé pour cette méthode est le même que celui pour {{jsxref("Array.prototype.indexOf()")}}. Pour le reste de l'article _TypedArray_ correspond à l'un des [types de tableau typé](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.indexOf()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/join/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/join/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.join()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/join
 ---
 
-{{JSRef}}
-
 La méthode **`join()`** fusionne l'ensemble des éléments d'un tableau en une chaîne de caractères. Cette méthode utilise le même algorithme que {{jsxref("Array.prototype.join()")}}. Dans le reste de cet article _TypedArray_ fait référence à l'un des [types de tableaux typés](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.join()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/keys/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/keys/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.keys()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/keys
 ---
 
-{{JSRef}}
-
 La méthode **`keys()`** renvoie un nouvel objet `Array Iterator` contenant les clés pour chaque indice du tableau typé.
 
 {{InteractiveExample("JavaScript Demo: TypedArray.keys()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/lastindexof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/lastindexof/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.lastIndexOf()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/lastIndexOf
 ---
 
-{{JSRef}}
-
 La méthode **`lastIndexOf()`** renvoie le dernier indice (le plus grand) pour lequel un élément donné est trouvé. Si l'élément cherché n'est pas trouvé, la valeur de retour sera -1. Le tableau typé est parcouru dans l'ordre des indices décroissants (de la fin vers le début) à partir de `indexDépart`. Cette méthode utilise le même algorithme que {{jsxref("Array.prototype.lastIndexOf()")}}. Dans le reste de l'article, _TypedArray_ correspond à l'un des [types de tableaux typés](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.lastIndexOf()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/length/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/length/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.length
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/length
 ---
 
-{{JSRef}}
-
 La propriété **`length`** est un accesseur qui permet de représenter la longueur, en nombre d'éléments, d'un tableau typé.
 
 {{InteractiveExample("JavaScript Demo: TypedArray.length")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/map/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/map/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.map()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/map
 ---
 
-{{JSRef}}
-
 La méthode **`map()`** crée un nouveau tableau typé dont les éléments sont les images des éléments du tableau typé courant par une fonction donnée. Cette méthode utilise le même algorithme que {{jsxref("Array.prototype.map()")}}_._ _TypedArray_ est utilisé ici de façon générique pour représenter [l'un des types de tableaux typés possibles](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.map()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/of/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/of/index.md
@@ -3,8 +3,6 @@ title: TypedArray.of()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/of
 ---
 
-{{JSRef}}
-
 La méthode **`TypedArray.of()`** crée un nouvel objet {{jsxref("TypedArray", "TypedArray", "#Les_objets_TypedArray")}} à partir d'un nombre variable d'arguments. Cette méthode est similaire à {{jsxref("Array.of()")}}.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/typedarray/reduce/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/reduce/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.reduce()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/reduce
 ---
 
-{{JSRef}}
-
 La méthode **`reduce()`** applique une fonction sur un accumulateur et chaque valeur du tableau typé (de la gauche vers la droite) afin de réduire le tableau en une seule valeur. Cette méthode utilise le même algorithme que {{jsxref("Array.prototype.reduce()")}}. Dans le reste de cet article _TypedArray_ correspond à un des [types de tableaux typés](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.reduce()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/reduceright/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/reduceright/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.reduceRight()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/reduceRight
 ---
 
-{{JSRef}}
-
 La méthode **`reduceRight()`** applique une fonction sur un accumulateur et chaque valeur du tableau typé (de la droite vers la gauche) afin de réduire le tableau en une seule valeur. Cette méthode utilise le même algorithme que {{jsxref("Array.prototype.reduceRight()")}}. Dans le reste de cet article _TypedArray_ correspond à un des [types de tableaux typés](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/typedarray/reverse/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/reverse/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.reverse()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/reverse
 ---
 
-{{JSRef}}
-
 La méthode **`reverse()`** inverse les éléments d'un tableau. Le premier élément du tableau typé devient le dernier, le dernier élément devient le premier et ainsi de suite. Cette méthode utilise le même algorithme que {{jsxref("Array.prototype.reverse()")}}_._ Dans le reste de cet article _TypedArray_ correspond à un des [types de tableaux typés](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.reverse()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/set/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/set/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.set()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/set
 ---
 
-{{JSRef}}
-
 La méthode **`set()`** permet d'enregistrer plusieurs valeurs dans le tableau typé à partir d'un tableau donné.
 
 {{InteractiveExample("JavaScript Demo: TypedArray.set()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/slice/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/slice/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: b2a5f62d66b4e3d71704017d0fab7ad710e68057
 ---
 
-{{JSRef}}
-
 La méthode **`slice()`** des instances de [`TypedArray`](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) renvoie une copie d'un fragment du tableau typé courant dans un nouveau tableau typé. La portion est prise entre les paramètres `début` (inclus) et `fin` (non-inclus) qui correspondent aux indices des éléments du tableau typé courant. Le tableau typé original ne sera pas modifié. Cette méthode utilise le même algorithme que [`Array.prototype.slice()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Array/slice)
 
 {{InteractiveExample("JavaScript Demo: TypedArray.slice()", "shorter")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/some/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/some/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.some()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/some
 ---
 
-{{JSRef}}
-
 La méthode **`some()`** teste si certains éléments du tableau typé remplissent une condition décrite par la fonction de test donnée. Cette méthode utilise le même algorithme que {{jsxref("Array.prototype.some()")}}_._ Dans le reste de cet article _TypedArray_ correspond à un des [types de tableaux typés](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.some()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/sort/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/sort/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.sort()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/sort
 ---
 
-{{JSRef}}
-
 La méthode **`sort()`** permet de trier numériquement les éléments d'un tableau typé, à même ce tableau. Cette méthode utilise le même algorithme que {{jsxref("Array.prototype.sort()")}} en triant les valeurs par ordre numérique plutôt que par ordre lexicographique*.* Par la suite, _TypedArray_ désigne l'un des [types de tableau typé](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray) here.
 
 {{InteractiveExample("JavaScript Demo: TypedArray.sort()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/subarray/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/subarray/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.subarray()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/subarray
 ---
 
-{{JSRef}}
-
 La méthode `subarray()` permet de renvoyer un nouvel objet _TypedArray_ basé sur le même {{jsxref("ArrayBuffer")}} et dont les éléments sont du même type que l'objet _TypedArray_ courant. Le paramètre `début` est à considérer au sens large et le paramètre `end` est à considérer au sens strict. _TypedArray_ est l'un des types de [tableaux typés](/fr/docs/Web/JavaScript/Guide/Typed_arrays#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.subarray()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/symbol.iterator/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/symbol.iterator/index.md
@@ -4,8 +4,6 @@ slug: Web/JavaScript/Reference/Global_Objects/TypedArray/Symbol.iterator
 original_slug: Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator
 ---
 
-{{JSRef}}
-
 La valeur initiale de la propriété @@iterator est le même objet fonction que la valeur initiale de {{jsxref("TypedArray.prototype.values()", "values")}}.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/typedarray/symbol.species/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/symbol.species/index.md
@@ -4,8 +4,6 @@ slug: Web/JavaScript/Reference/Global_Objects/TypedArray/Symbol.species
 original_slug: Web/JavaScript/Reference/Global_Objects/TypedArray/@@species
 ---
 
-{{JSRef}}
-
 La propriété d'accesseur **`TypedArray[@@species]`** renvoie le constructeur [du tableau typé](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/typedarray/tolocalestring/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/tolocalestring/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.toLocaleString()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/toLocaleString
 ---
 
-{{JSRef}}
-
 La méthode **`toLocaleString()`** renvoie une chaîne de caractères qui représente les éléments du tableau typé. Les éléments sont convertis en chaînes de caractères et séparés par une chaîne de caractères qui est fonction de la locale (la virgule `,` par exemple). Cette méthode utilise le même algorithme que [`Array.prototype.toLocaleString()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Array/toLocaleString) et vu que les éléments d'un tableau typé sont des nombres, elle utilise le même algorithme que [`Number.prototype.toLocaleString()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) pour chaque élément. Dans la suite de cet article, `TypedArray` fait référence à [l'un des types de tableau typé listés ici](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/typedarray/tostring/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/tostring/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/toString
 ---
 
-{{JSRef}}
-
 La méthode **`toString()`** renvoie une chaîne de caractères qui représente le tableau typé et ses éléments. Cette méthode utilise le même algorithme que {{jsxref("Array.prototype.toString()")}}_._ Dans la suite de cet article, _TypedArray_ fait référence à [l'un des types de tableau typé listés ici](/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#les_objets_typedarray).
 
 {{InteractiveExample("JavaScript Demo: TypedArray.toString()")}}

--- a/files/fr/web/javascript/reference/global_objects/typedarray/values/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/values/index.md
@@ -3,8 +3,6 @@ title: TypedArray.prototype.values()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/values
 ---
 
-{{JSRef}}
-
 La méthode **`values()`** renvoie un nouvel objet `Array Iterator` qui contient les valeurs pour chaque indice du tableau.
 
 {{InteractiveExample("JavaScript Demo: TypedArray.values()")}}

--- a/files/fr/web/javascript/reference/global_objects/typeerror/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typeerror/index.md
@@ -3,8 +3,6 @@ title: TypeError
 slug: Web/JavaScript/Reference/Global_Objects/TypeError
 ---
 
-{{JSRef}}
-
 Un objet **`TypeError`** représente une erreur qui se produit généralement (mais pas toujours) lorsqu'une opération n'a pu avoir lieu parce qu'une valeur n'a pas le type attendu.
 
 Une exception `TypeError` peut être levée lorsque&nbsp;:

--- a/files/fr/web/javascript/reference/global_objects/typeerror/typeerror/index.md
+++ b/files/fr/web/javascript/reference/global_objects/typeerror/typeerror/index.md
@@ -3,8 +3,6 @@ title: Constructeur TypeError()
 slug: Web/JavaScript/Reference/Global_Objects/TypeError/TypeError
 ---
 
-{{JSRef}}
-
 Le constructeur **`TypeError()`** permet de créer un objet représentant une erreur qui se produit lorsqu'une opération n'a pu être réalisée, généralement (mais pas toujours) parce qu'une valeur n'était pas du type attendu.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/uint16array/index.md
+++ b/files/fr/web/javascript/reference/global_objects/uint16array/index.md
@@ -3,8 +3,6 @@ title: Uint16Array
 slug: Web/JavaScript/Reference/Global_Objects/Uint16Array
 ---
 
-{{JSRef}}
-
 Le tableau typé **`Uint16Array`** permet de représenter un tableau d'entiers non signés représentés sur 16 bits, où l'ordre des octets correspond à celui de la plateforme utilisée. Si on souhaite contrôler l'ordre des octets utilisé (le « boutisme »), on utilisera un objet {{jsxref("DataView")}} à la place. Les éléments du tableau sont initialisés à `0`. Une fois que le tableau est construit, on peut manipuler ses différents éléments grâce aux méthodes de l'objet ou grâce à la notation usuelle (avec les crochets).
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/uint16array/uint16array/index.md
+++ b/files/fr/web/javascript/reference/global_objects/uint16array/uint16array/index.md
@@ -3,8 +3,6 @@ title: Constructeur Uint16Array()
 slug: Web/JavaScript/Reference/Global_Objects/Uint16Array/Uint16Array
 ---
 
-{{JSRef}}
-
 Le **constructeur `Uint16Array()`** permet de créer un nouveau tableau typé [`Uint16Array`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array) dont les éléments sont des nombres entiers non-signés, représentés sur 16 bits et utilisant le boutisme de la plateforme.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/uint32array/index.md
+++ b/files/fr/web/javascript/reference/global_objects/uint32array/index.md
@@ -3,8 +3,6 @@ title: Uint32Array
 slug: Web/JavaScript/Reference/Global_Objects/Uint32Array
 ---
 
-{{JSRef}}
-
 Le tableau typé **`Uint32Array`** permet de représenter un tableau d'entiers non signés représentés sur 32 bits, où l'ordre des octets correspond à celui de la plateforme utilisée. Si on souhaite contrôler l'ordre des octets utilisé (le « boutisme »), on utilisera un objet {{jsxref("DataView")}} à la place. Les éléments du tableau sont initialisés à `0`. Une fois que le tableau est construit, on peut manipuler ses différents éléments grâce aux méthodes de l'objet ou grâce à la notation usuelle (avec les crochets).
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/uint32array/uint32array/index.md
+++ b/files/fr/web/javascript/reference/global_objects/uint32array/uint32array/index.md
@@ -3,8 +3,6 @@ title: Constructeur Uint32Array()
 slug: Web/JavaScript/Reference/Global_Objects/Uint32Array/Uint32Array
 ---
 
-{{JSRef}}
-
 Le **constructeur `Uint32Array()`** permet de créer un nouveau tableau typé [`Uint32Array`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array) dont les éléments sont des nombres entiers non-signés, représentés sur 32 bits et utilisant le boutisme de la plateforme. S'il est nécessaire de contrôler l'ordre des octets, on utilisera un objet [`DataView`](/fr/docs/Web/JavaScript/Reference/Global_Objects/DataView) à la place. Lors de la construction, les éléments du tableau sont initialisés avec la valeur `0`. Une fois le tableau construit, on peut faire référence aux éléments du tableau à l'aide des méthodes de l'objet ou en utilisant la notation avec les crochets et l'indice voulu.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/uint8array/index.md
+++ b/files/fr/web/javascript/reference/global_objects/uint8array/index.md
@@ -3,8 +3,6 @@ title: Uint8Array
 slug: Web/JavaScript/Reference/Global_Objects/Uint8Array
 ---
 
-{{JSRef}}
-
 Le tableau typé **`Uint8Array`** représente un tableau d'entiers non signés, représentés sur 8 bits. Les éléments du tableau sont initialisés à `0`. Une fois que le tableau est construit, on peut manipuler ses différents éléments grâce aux méthodes de l'objet ou grâce à la notation usuelle (avec les crochets).
 
 ## Constructeur

--- a/files/fr/web/javascript/reference/global_objects/uint8array/uint8array/index.md
+++ b/files/fr/web/javascript/reference/global_objects/uint8array/uint8array/index.md
@@ -3,8 +3,6 @@ title: Constructeur Uint8Array()
 slug: Web/JavaScript/Reference/Global_Objects/Uint8Array/Uint8Array
 ---
 
-{{JSRef}}
-
 Le constructeur **`Uint8Array()`** crée un tableau typé contenant des entiers non-signés sur 8 bits. Le contenu de ces éléments est initialisé à `0`. Une fois le tableau construit, on peut faire référence aux éléments du tableau à l'aide des méthodes de l'objet ou en utilisant la notation usuelle pour les tableaux avec les crochets.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/uint8clampedarray/index.md
+++ b/files/fr/web/javascript/reference/global_objects/uint8clampedarray/index.md
@@ -3,8 +3,6 @@ title: Uint8ClampedArray
 slug: Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray
 ---
 
-{{JSRef}}
-
 Le tableau typé **`Uint8ClampedArray`** permet de représenter un tableau d'entiers non signés représentés sur 8 bits, dont les valeurs sont ramenées entre 0 et 255. Si une valeur non-entière est fournie, elle sera arrondie à l'entier le plus proche. Les éléments du tableau sont initialisés à `0`. Une fois que le tableau est construit, on peut manipuler ses différents éléments grâce aux méthodes de l'objet ou grâce à la notation usuelle (avec les crochets).
 
 ## Constructeur

--- a/files/fr/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
+++ b/files/fr/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
@@ -3,8 +3,6 @@ title: Constructeur Uint8ClampedArray()
 slug: Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray/Uint8ClampedArray
 ---
 
-{{JSRef}}
-
 Le constructeur **`Uint8ClampedArray()`** permet de créer un tableau typé contenant des entiers non-signés sur 8 bits, dont la valeur est ramenée entre 0 et 255. Une valeur indiquée, en dehors de cet intervalle, sera écrêtée. Une valeur non entière sera arrondie à l'entier le plus proche. Le contenu d'un tel tableau est initialisé avec des `0`. Une fois le tableau construit, on peut faire référence aux éléments du tableau à l'aide des méthodes de l'objet ou en utilisant la notation usuelle pour les tableaux avec les crochets.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/urierror/index.md
+++ b/files/fr/web/javascript/reference/global_objects/urierror/index.md
@@ -3,8 +3,6 @@ title: URIError
 slug: Web/JavaScript/Reference/Global_Objects/URIError
 ---
 
-{{JSRef}}
-
 L'objet **`URIError`** représente une erreur renvoyée lorsqu'une fonction de manipulation d'URI a été utilisée de façon inappropriée.
 
 ## Constructeur

--- a/files/fr/web/javascript/reference/global_objects/urierror/urierror/index.md
+++ b/files/fr/web/javascript/reference/global_objects/urierror/urierror/index.md
@@ -3,8 +3,6 @@ title: Constructeur URIError()
 slug: Web/JavaScript/Reference/Global_Objects/URIError/URIError
 ---
 
-{{JSRef}}
-
 Le constructeur **`URIError()`** permet de créer une erreur lorsqu'une fonction de gestion d'un URI a été utilisée de façon incorrecte.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/weakmap/delete/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakmap/delete/index.md
@@ -3,8 +3,6 @@ title: WeakMap.prototype.delete()
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/delete
 ---
 
-{{JSRef}}
-
 La méthode **`delete()`** retire un élément donné de l'objet {{jsxref("WeakMap")}}.
 
 {{InteractiveExample("JavaScript Demo: WeakMap.prototype.delete()")}}

--- a/files/fr/web/javascript/reference/global_objects/weakmap/get/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakmap/get/index.md
@@ -3,8 +3,6 @@ title: WeakMap.prototype.get()
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/get
 ---
 
-{{JSRef}}
-
 La méthode **`get()`** permet de renvoyer un élément donné d'un objet `WeakMap`.
 
 {{InteractiveExample("JavaScript Demo: WeakMap.prototype.get()")}}

--- a/files/fr/web/javascript/reference/global_objects/weakmap/has/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakmap/has/index.md
@@ -3,8 +3,6 @@ title: WeakMap.prototype.has()
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/has
 ---
 
-{{JSRef}}
-
 La méthode **`has()`** renvoie un booléen qui indique s'il existe (ou non) un élément avec une clé donnée au sein de l'objet `WeakMap`.
 
 {{InteractiveExample("JavaScript Demo: WeakMap.prototype.has()")}}

--- a/files/fr/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakmap/index.md
@@ -3,8 +3,6 @@ title: WeakMap
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap
 ---
 
-{{JSRef}}
-
 L'objet **`WeakMap`** représente une collection de paires clé-valeur dont les clés sont des objets et pour lesquelles les références sont « faibles » et les valeurs des valeurs quelconques.
 
 Vous pouvez en savoir plus sur les `WeakMap` en lisant l'article sur [les collections à clé](/fr/docs/Web/JavaScript/Guide/Keyed_collections).

--- a/files/fr/web/javascript/reference/global_objects/weakmap/set/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakmap/set/index.md
@@ -3,8 +3,6 @@ title: WeakMap.prototype.set()
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/set
 ---
 
-s{{JSRef}}
-
 La méthode **`set()`** permet d'ajouter un nouvel élément avec une `clé` et une `valeur` à un objet `WeakMap`.
 
 {{InteractiveExample("JavaScript Demo: WeakMap.prototype.set()")}}

--- a/files/fr/web/javascript/reference/global_objects/weakmap/weakmap/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakmap/weakmap/index.md
@@ -3,8 +3,6 @@ title: Constructeur WeakMap()
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/WeakMap
 ---
 
-{{JSRef}}
-
 Le **constructeur `WeakMap()`** permet de créer un nouvel objet [`WeakMap`](/fr/docs/Web/JavaScript/Reference/Global_Objects/WeakMap) éventuellement basé sur un autre objet itérable fourni en argument (par exemple, [un tableau](/fr/docs/Web/JavaScript/Reference/Global_Objects/Array)).
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/weakref/deref/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakref/deref/index.md
@@ -3,8 +3,6 @@ title: WeakRef.prototype.deref()
 slug: Web/JavaScript/Reference/Global_Objects/WeakRef/deref
 ---
 
-{{JSRef}}
-
 La méthode `deref` renvoie l'objet cible associé à l'objet [`WeakRef`](/fr/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) courant ou `undefined` si l'objet cible a été récupéré par le ramasse-miettes.
 
 ## Syntaxe

--- a/files/fr/web/javascript/reference/global_objects/weakref/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakref/index.md
@@ -3,8 +3,6 @@ title: WeakRef
 slug: Web/JavaScript/Reference/Global_Objects/WeakRef
 ---
 
-{{JSRef}}
-
 Un objet **`WeakRef`** permet de tenir une référence faible vers un autre objet, sans empêcher que ce dernier puisse être récupéré par le ramasse-miettes.
 
 ## Description

--- a/files/fr/web/javascript/reference/global_objects/weakref/weakref/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakref/weakref/index.md
@@ -3,8 +3,6 @@ title: Constructeur WeakRef()
 slug: Web/JavaScript/Reference/Global_Objects/WeakRef/WeakRef
 ---
 
-{{JSRef}}
-
 Le constructeur **`WeakRef`** crée un objet [`WeakRef`](/fr/docs/Web/JavaScript/Reference/Global_Objects/WeakRef)
 qui représente une référence faible vers un objet cible.
 

--- a/files/fr/web/javascript/reference/global_objects/weakset/add/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakset/add/index.md
@@ -3,8 +3,6 @@ title: WeakSet.prototype.add()
 slug: Web/JavaScript/Reference/Global_Objects/WeakSet/add
 ---
 
-{{JSRef}}
-
 La méthode **`add()`** permet d'ajouter un nouvel objet à un objet `WeakSet`.
 
 {{InteractiveExample("JavaScript Demo: WeakSet.Prototype.add()", "taller")}}

--- a/files/fr/web/javascript/reference/global_objects/weakset/delete/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakset/delete/index.md
@@ -3,8 +3,6 @@ title: WeakSet.prototype.delete()
 slug: Web/JavaScript/Reference/Global_Objects/WeakSet/delete
 ---
 
-{{JSRef}}
-
 La méthode **`delete()`** permet de retirer un élément donné d'un objet `WeakSet`.
 
 {{InteractiveExample("JavaScript Demo: WeakSet.Prototype.delete()")}}

--- a/files/fr/web/javascript/reference/global_objects/weakset/has/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakset/has/index.md
@@ -3,8 +3,6 @@ title: WeakSet.prototype.has()
 slug: Web/JavaScript/Reference/Global_Objects/WeakSet/has
 ---
 
-{{JSRef}}
-
 La méthode **`has()`** renvoie un booléen indiquant si un objet donné est contenu dans l'ensemble `WeakSet`.
 
 {{InteractiveExample("JavaScript Demo: WeakSet.Prototype.has()")}}

--- a/files/fr/web/javascript/reference/global_objects/weakset/weakset/index.md
+++ b/files/fr/web/javascript/reference/global_objects/weakset/weakset/index.md
@@ -3,8 +3,6 @@ title: Constructeur WeakSet()
 slug: Web/JavaScript/Reference/Global_Objects/WeakSet/WeakSet
 ---
 
-{{JSRef}}
-
 Le **constructeur `WeakSet()`** permet de créer des objets `WeakSet` qui stockent, avec des références faibles, des _objets_ dans un ensemble.
 
 ## Syntaxe

--- a/files/fr/web/mathml/reference/element/mfenced/index.md
+++ b/files/fr/web/mathml/reference/element/mfenced/index.md
@@ -15,11 +15,11 @@ L'élément MathML `<mfenced>` offre la possibilité d'ajouter des parenthèses 
   - : Afin d'être utilisés avec les [feuilles de styles](/fr/docs/Web/CSS).
 - close
   - : Une chaîne de caractère pour le délimiteur fermant. La valeur par défaut est «&nbsp;`)`&nbsp;» et tous les blancs sont tronqués.
-- href {{Deprecated_Inline()}}
+- href {{Deprecated_Inline}}
   - : Un hyperlien pointant vers un URI donné.
-- mathbackground {{Deprecated_Inline()}}
+- mathbackground {{Deprecated_Inline}}
   - : La couleur de fond. Il est possible d'utiliser les codes au format `#rgb`, `#rrggbb` et les [noms de couleurs HTML](/fr/docs/Web/CSS/Reference/Values/color_value#mots-clés).
-- mathcolor {{Deprecated_Inline()}}
+- mathcolor {{Deprecated_Inline}}
   - : La couleur du texte. Il est possible d'utiliser les codes au format `#rgb`, `#rrggbb` et les [noms de couleurs HTML](/fr/docs/Web/CSS/Reference/Values/color_value#mots-clés).
 
 <!---->


### PR DESCRIPTION
### Description

Dans l'objectif actuel de https://github.com/orgs/mdn/projects/44 d'effectuer le nettoyage des pages du MDN pour les 1 an de cycle de maintenance, et afin d'accélérer l'obsolescence des macros de barre latérale qui ne sont plus du tout utilisées sur le MDN anglais ; cette mise à jour à pour objectif de cibler une macro liée à un thème et la supprimer sur toutes les pages.

### Motivation

- Aligner les pages au MDN.
- Préparer la possible suppression de ces macros à l'avenir.
- Éviter de surcharger l'interpréteur de page avec des macros obsolètes.
- Gagner en lisibilité sur les pages Markdown pour les futur·e·s contributeur·ice·s.

### Additional details

- Bonus : Nettoyage des macros qui ont des parenthèses vides alors qu'elle ne prennent pas d'argument.

### Related issues and pull requests

Related to https://github.com/mdn-fr/documentation/issues/88
