### PR TITLE
fix(es): sync Our repositories with English source

### DIFF
--- a/files/es/mdn/community/our_repositories/index.md
+++ b/files/es/mdn/community/our_repositories/index.md
@@ -1,79 +1,70 @@
 ---
-title: Repositorios de documentación web de MDN
+title: Repositorios de GitHub de MDN
+short-title: Repositorios de GitHub
 slug: MDN/Community/Our_repositories
-original_slug: MDN/Community/Contributing/Our_repositories
+l10n:
+  sourceCommit: 405633ae1911
 ---
 
-{{MDNSidebar}}
-
-La [documentación web de MDN](/) (MDN Web Docs) es un proyecto complejo con muchas partes móviles. Es una buena idea familiarizarse con los diferentes repositorios de los proyectos. Este documento tiene la intención de ayudarlo a encontrar los diferentes repositorios (repos) que puede necesitar al contribuir a diferentes partes del proyecto de MDN Web Docs.
-
-## Niveles de repositorio
-
-### Nivel 1
-
-El código de estos repositorios es fundamental para el proyecto MDN Web Docs y se ejecuta en dominios propiedad de Mozilla.
-
-- [mdn/content](https://github.com/mdn/content)
-- [Yari](https://github.com/mdn/yari)
-- [rumba](https://github.com/mdn/rumba)
-- [browser-compat-data](https://github.com/mdn/browser-compat-data)
-- [interactive-examples](https://github.com/mdn/interactive-examples)
-- [bob](https://github.com/mdn/bob)
-
-Un proyecto de Nivel 1 debe tener al menos 3 miembros, incluidos al menos dos con permisos de administrador.
-
-### Nivel 2
-
-Estos repositorios se concentran principalmente en contenido de soporte, como ejemplos de código, el área de aprendizaje de MDN Web Docs, localización y ejemplos de proyectos. Ejemplos:
-
-- [dom-examples](https://github.com/mdn/dom-examples)
-- [translated-content](https://github.com/mdn/translated-content)
-- [learning-area](https://github.com/mdn/learning-area)
-
-Un proyecto de Nivel 2 debe tener al menos 2 miembros, incluido al menos uno con permisos de administrador.
-
-### Nivel 3
-
-Estos son repositorios utilizados para la planificación de proyectos, la documentación del proyecto en sí y la participación de la comunidad. Ejemplos:
-
-- [mdn-community](https://github.com/mdn/mdn-community)
-- [mdn/mdn](https://github.com/mdn/mdn)
-- [content-team-projects](https://github.com/mdn/content-team-projects).
-
-Un proyecto de nivel 3 necesita al menos 1 administrador.
+La [documentación web de MDN](/) (MDN Web Docs) es un proyecto complejo con muchas partes en movimiento.
+Es una buena idea familiarizarse con los diferentes repositorios de código.
+Este documento describe los repositorios (repos) que puede necesitar al contribuir a MDN Web Docs.
 
 ## Repositorios principales
 
-- **Contenido principal**: <https://github.com/mdn/content>. El repositorio más importante para el contenido de MDN Web Docs: Aquí es donde se almacena todo el contenido principal en inglés del sitio y donde realizará todos los cambios estándar en el contenido de la página.
-- **Plataforma de MDN Web Docs**: <https://github.com/mdn/yari>. Aquí es donde se almacena la plataforma de MDN Web Docs y a donde irá si desea realizar cambios en nuestra estructura base de la página o sistema de renderizado.
-- **Datos de compatibilidad del navegador**: <https://github.com/mdn/browser-compat-data>. Aquí es donde se almacenan los datos utilizados para generar las tablas de compatibilidad del navegador que se encuentran en nuestras páginas de referencia ([ejemplo](/es/docs/Web/HTML/Reference/Elements/progress#browser_compatibility)). Si tiene información sobre la compatibilidad del navegador con las funciones web, o está dispuesto y es capaz de investigar y/o experimentar, puede ayudar a actualizar los datos de [compatibilidad del navegador](https://github.com/mdn/browser-compat-data/blob/main/docs/contributing.md) de MDN.
-- **Ejemplos interactivos**: <https://github.com/mdn/interactive-examples>. Este repositorio almacena los bloques de código de ejemplo que se encuentran en la parte superior de muchas de nuestras páginas de referencia ([ejemplo](/es/docs/Web/JavaScript/Reference/Global_Objects/globalThis)). Edite esos ejemplos aquí.
-- **Bob**, también conocido como _Builder of Bits_: <https://github.com/mdn/bob> Este repositorio almacena el código de representación que produce los agradables ejemplos editables y copiables que se encuentran en la parte superior de muchas de nuestras páginas de referencia ([ejemplo](/es/docs/Web/JavaScript/Reference/Global_Objects/globalThis)).
-- **Contenido traducido/localizado**: <https://github.com/mdn/translated-content>. Aquí es donde se almacena el contenido localizado. Vaya aquí si desea ayudar a traducir páginas a cualquiera de nuestros [idiomas mantenidos activamente](https://github.com/mdn/translated-content#locales).
-- **Flujos de trabajo**: <https://github.com/mdn/workflows> Una colección creciente de GitHub Actions reutilizables para usar en los repositorios de MDN Web Docs.
+- [content](https://github.com/mdn/content)
+  - : Aquí se mantiene todo el contenido en inglés del sitio, y aquí realizará todos los cambios en el contenido de las páginas, el texto y los ejemplos de código incluidos en las páginas.
+
+- [rari](https://github.com/mdn/rari)
+  - : El **backend** de la plataforma MDN Web Docs, donde deberá acudir si desea realizar cambios en las estructuras de las páginas, las plantillas y la maquinaria de renderizado.
+
+- [fred](https://github.com/mdn/fred)
+  - : El **frontend** de MDN Web Docs, donde encontrará las funcionalidades relacionadas con los estilos, el diseño y la maquetación.
+
+- [browser-compat-data](https://github.com/mdn/browser-compat-data)
+  - : Datos utilizados para generar las tablas de compatibilidad de los navegadores que aparecen en nuestras páginas de referencia.
+    Si dispone de información sobre la compatibilidad de los navegadores con las funcionalidades web, o está dispuesto y capacitado para investigar y experimentar, puede ayudar a actualizar los [datos de compatibilidad de los navegadores](https://github.com/mdn/browser-compat-data/blob/main/docs/contributing.md) de MDN.
+
+- [translated-content](https://github.com/mdn/translated-content)
+  - : Aquí se encuentra el contenido localizado.
+    Acuda aquí si desea ayudar a traducir páginas a cualquiera de nuestros [idiomas mantenidos activamente](https://github.com/mdn/translated-content#locales).
+
+### Infraestructura
+
+- [rumba](https://github.com/mdn/rumba)
+  - : Un sistema de backend que proporciona la infraestructura de MDN Plus.
+
+- [workflows](https://github.com/mdn/workflows)
+  - : Una colección de GitHub Actions reutilizables para los repositorios de MDN Web Docs.
+
+### Planificación y coordinación
+
+Estos son repositorios utilizados para la planificación de proyectos, la documentación del propio proyecto y los proyectos de la comunidad.
+
+- https://github.com/mdn/mdn
+  - : Aquí se mantienen las propuestas de proyectos y los issues de planificación.
+
+- [mdn-community](https://github.com/mdn/mdn-community)
+  - : Este repositorio aloja las GitHub Discussions que utilizan escritores y colaboradores cuando necesitan decidir cómo proceder con decisiones de redacción o técnicas.
 
 ## Ejemplos de código
 
-### Ejemplos de código y demostraciones
+Estos repositorios contienen, por lo general, ejemplos de código independientes que son demasiado grandes o que no se pueden representar mediante la macro [`EmbedLiveSample`](/es/docs/MDN/Writing_guidelines/Page_structures/Live_samples#live_sample_macros).
 
-[//]: # "TODO: UPDATE WITH REPO TRIAGE"
+> [!NOTE]
+> Si está actualizando el código de una página determinada, compruebe si está referenciado en un repositorio de ejemplos correspondiente y, en ese caso, asegúrese de actualizar también dicho repositorio.
 
-La organización MDN Web Docs en GitHub contiene una gran cantidad de repositorios de ejemplo. Por lo general, contienen ejemplos de código independientes que a menudo están vinculados desde nuestras páginas, pero ocasionalmente encontrará uno de estos ejemplos incrustado en una página mediante una llamada de macro como esta: `\{{EmbedGHLiveSample("css-examples/learn/tasks/grid/grid1.html", '100%', 700)}}`.
-
-Recuerde siempre que si está actualizando el código en una página determinada, también deberá actualizar el repositorio de ejemplo correspondiente.
-
-- [**dom-examples**](https://github.com/mdn/dom-examples)
-- [**css-examples**](https://github.com/mdn/css-examples)
-- [**webaudio-examples**](https://github.com/mdn/webaudio-examples)
-- [**webassembly-examples**](https://github.com/mdn/webassembly-examples)
-- [**indexeddb-examples**](https://github.com/mdn/indexeddb-examples)
-- [**js-examples**](https://github.com/mdn/js-examples)
-- [**html-examples**](https://github.com/mdn/html-examples)
-- [**web-components-examples**](https://github.com/mdn/web-components-examples)
-- [**webextension-examples**](https://github.com/mdn/webextensions-examples)
-- [**pwa-examples**](https://github.com/mdn/pwa-examples)
-- [**houdini-examples**](https://github.com/mdn/houdini-examples)
-- [**headless-examples**](https://github.com/mdn/headless-examples)
-- [**perf-examples**](https://github.com/mdn/perf-examples)
-- [**devtools-examples**](https://github.com/mdn/devtools-examples)
+- [learning-area](https://github.com/mdn/learning-area)
+- [dom-examples](https://github.com/mdn/dom-examples)
+- [css-examples](https://github.com/mdn/css-examples)
+- [webaudio-examples](https://github.com/mdn/webaudio-examples)
+- [webassembly-examples](https://github.com/mdn/webassembly-examples)
+- [indexeddb-examples](https://github.com/mdn/indexeddb-examples)
+- [js-examples](https://github.com/mdn/js-examples)
+- [html-examples](https://github.com/mdn/html-examples)
+- [web-components-examples](https://github.com/mdn/web-components-examples)
+- [webextension-examples](https://github.com/mdn/webextensions-examples)
+- [pwa-examples](https://github.com/mdn/pwa-examples)
+- [houdini-examples](https://github.com/mdn/houdini-examples)
+- [headless-examples](https://github.com/mdn/headless-examples)
+- [perf-examples](https://github.com/mdn/perf-examples)

--- a/files/es/mdn/community/our_repositories/index.md
+++ b/files/es/mdn/community/our_repositories/index.md
@@ -2,32 +2,33 @@
 title: Repositorios de GitHub de MDN
 short-title: Repositorios de GitHub
 slug: MDN/Community/Our_repositories
-l10n:
+page-type: mdn-community-guide
+  sourceCommit: 405633ae19118004716a450d26ad3916b0cc86fa
   sourceCommit: 405633ae1911
 ---
 
-La [documentación web de MDN](/) (MDN Web Docs) es un proyecto complejo con muchas partes en movimiento.
+MDN Web Docs es un proyecto complejo con muchas partes en movimiento.
 Es una buena idea familiarizarse con los diferentes repositorios de código.
-Este documento describe los repositorios (repos) que puede necesitar al contribuir a MDN Web Docs.
+Este documento describe los repositorios (repos) que puedes necesitar al contribuir a MDN Web Docs.
 
 ## Repositorios principales
 
 - [content](https://github.com/mdn/content)
-  - : Aquí se mantiene todo el contenido en inglés del sitio, y aquí realizará todos los cambios en el contenido de las páginas, el texto y los ejemplos de código incluidos en las páginas.
+  - : Aquí se mantiene todo el contenido en inglés del sitio, y aquí harás todos los cambios en el contenido de las páginas, el texto y los ejemplos de código incluidos en las páginas.
 
 - [rari](https://github.com/mdn/rari)
-  - : El **backend** de la plataforma MDN Web Docs, donde deberá acudir si desea realizar cambios en las estructuras de las páginas, las plantillas y la maquinaria de renderizado.
+  - : El **backend** de la plataforma MDN Web Docs, donde tendrás que ir si quieres hacer cambios en las estructuras de las páginas, las plantillas y la maquinaria de renderizado.
 
 - [fred](https://github.com/mdn/fred)
-  - : El **frontend** de MDN Web Docs, donde encontrará las funcionalidades relacionadas con los estilos, el diseño y la maquetación.
+  - : El **frontend** de MDN Web Docs, donde encontrarás las funcionalidades relacionadas con los estilos, el diseño y la maquetación.
 
 - [browser-compat-data](https://github.com/mdn/browser-compat-data)
   - : Datos utilizados para generar las tablas de compatibilidad de los navegadores que aparecen en nuestras páginas de referencia.
-    Si dispone de información sobre la compatibilidad de los navegadores con las funcionalidades web, o está dispuesto y capacitado para investigar y experimentar, puede ayudar a actualizar los [datos de compatibilidad de los navegadores](https://github.com/mdn/browser-compat-data/blob/main/docs/contributing.md) de MDN.
+    Si tienes información sobre la compatibilidad de los navegadores con las funcionalidades web, o estás dispuesto y capacitado para investigar y experimentar, puedes ayudar a actualizar los [datos de compatibilidad de los navegadores](https://github.com/mdn/browser-compat-data/blob/main/docs/contributing.md) de MDN.
 
 - [translated-content](https://github.com/mdn/translated-content)
   - : Aquí se encuentra el contenido localizado.
-    Acuda aquí si desea ayudar a traducir páginas a cualquiera de nuestros [idiomas mantenidos activamente](https://github.com/mdn/translated-content#locales).
+    Ven aquí si quieres ayudar a traducir páginas a cualquiera de nuestros [idiomas mantenidos activamente](https://github.com/mdn/translated-content#locales).
 
 ### Infraestructura
 
@@ -41,7 +42,7 @@ Este documento describe los repositorios (repos) que puede necesitar al contribu
 
 Estos son repositorios utilizados para la planificación de proyectos, la documentación del propio proyecto y los proyectos de la comunidad.
 
-- https://github.com/mdn/mdn
+- [mdn/mdn](https://github.com/mdn/mdn)
   - : Aquí se mantienen las propuestas de proyectos y los issues de planificación.
 
 - [mdn-community](https://github.com/mdn/mdn-community)
@@ -49,10 +50,10 @@ Estos son repositorios utilizados para la planificación de proyectos, la docume
 
 ## Ejemplos de código
 
-Estos repositorios contienen, por lo general, ejemplos de código independientes que son demasiado grandes o que no se pueden representar mediante la macro [`EmbedLiveSample`](/es/docs/MDN/Writing_guidelines/Page_structures/Live_samples#live_sample_macros).
+Estos repositorios contienen, por lo general, ejemplos de código independientes que son demasiado grandes o que no se pueden representar mediante la macro [`EmbedLiveSample`](/es/docs/MDN/Writing_guidelines/Page_structures/Live_samples#macros_para_ejemplos_en_vivo).
 
 > [!NOTE]
-> Si está actualizando el código de una página determinada, compruebe si está referenciado en un repositorio de ejemplos correspondiente y, en ese caso, asegúrese de actualizar también dicho repositorio.
+> Si estás actualizando el código de una página determinada, comprueba si está referenciado en un repositorio de ejemplos correspondiente y, en ese caso, asegúrate de actualizar también dicho repositorio.
 
 - [learning-area](https://github.com/mdn/learning-area)
 - [dom-examples](https://github.com/mdn/dom-examples)

--- a/files/es/mdn/community/our_repositories/index.md
+++ b/files/es/mdn/community/our_repositories/index.md
@@ -2,7 +2,6 @@
 title: Repositorios de GitHub de MDN
 short-title: Repositorios de GitHub
 slug: MDN/Community/Our_repositories
-page-type: mdn-community-guide
 l10n:
   sourceCommit: 405633ae19118004716a450d26ad3916b0cc86fa
 ---

--- a/files/es/mdn/community/our_repositories/index.md
+++ b/files/es/mdn/community/our_repositories/index.md
@@ -3,8 +3,8 @@ title: Repositorios de GitHub de MDN
 short-title: Repositorios de GitHub
 slug: MDN/Community/Our_repositories
 page-type: mdn-community-guide
+l10n:
   sourceCommit: 405633ae19118004716a450d26ad3916b0cc86fa
-  sourceCommit: 405633ae1911
 ---
 
 MDN Web Docs es un proyecto complejo con muchas partes en movimiento.


### PR DESCRIPTION
### Description

Synchronized the Spanish translation of `MDN/Community/Our_repositories` with the current English source, updating the repository list, structure, descriptions, and code examples.

### Motivation

The Spanish page was outdated and no longer reflected the current English version. This update brings the Spanish documentation in line with the current source content.

### Additional details

Updated the `l10n.sourceCommit` metadata to `405633ae1911` and removed obsolete front matter and content.

### Related issues and pull requests

Fixes #38216