### PR TITLE
Sincroniza la validación de formularios [es]

### DIFF
--- a/files/es/learn_web_development/extensions/forms/form_validation/index.md
+++ b/files/es/learn_web_development/extensions/forms/form_validation/index.md
@@ -1,140 +1,171 @@
 ---
-title: Validación de formularios de datos
+title: Validación de formularios en el lado del cliente
 slug: Learn_web_development/Extensions/Forms/Form_validation
-original_slug: Learn/Forms/Form_validation
+l10n:
+  sourceCommit: ce12c10364f35c64184dec44be85537b7e10d91f
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Extensions/Forms/UI_pseudo-classes", "Learn_web_development/Extensions/Forms/Sending_and_retrieving_form_data", "Learn_web_development/Extensions/Forms")}}
+{{PreviousMenuNext("Learn_web_development/Extensions/Forms/UI_pseudo-classes", "Learn_web_development/Extensions/Forms/Sending_and_retrieving_form_data", "Learn_web_development/Extensions/Forms")}}
 
-Antes de enviar datos al servidor, es importante asegurarse de que se completan todos los controles de formulario requeridos, y en el formato correcto. Esto se denomina **validación de formulario en el lado del cliente** y ayuda a garantizar que los datos que se envían coinciden con los requisitos establecidos en los diversos controles de formulario. Este artículo te guiará por los conceptos básicos y ejemplos de validación de formularios en el lado del cliente.
+Antes de enviar al servidor los datos introducidos por el usuario en un formulario, es importante asegurarse de que todos los controles de formulario obligatorios estén completos y tengan el formato correcto. Esta **validación de formularios en el lado del cliente** ayuda a garantizar que los datos introducidos cumplan los requisitos establecidos en los distintos controles de formulario.
+
+Este artículo te guía a través de los conceptos básicos y ejemplos de validación de formularios en el lado del cliente.
 
 <table>
   <tbody>
     <tr>
       <th scope="row">Prerrequisitos:</th>
       <td>
-        Conocimientos básicos de informática, y entender cómo funcionan el
-        <a href="/es/docs/Learn_web_development/Core/Structuring_content">HTML</a>, el
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics_b957eec7deaf1ea2b20721d6838ea6e1">CSS</a> y el
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Scripting_41cf930b8cfd2b83c76f8086a5e24792">JavaScript</a>.
+        Conocimientos básicos de informática y una comprensión razonable de
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">HTML</a>,
+        <a href="/es/docs/Learn_web_development/Core/Styling_basics">CSS</a> y
+        <a href="/es/docs/Learn_web_development/Core/Scripting">JavaScript</a>.
       </td>
     </tr>
     <tr>
       <th scope="row">Objetivo:</th>
       <td>
-        Entender qué es la validación de formularios en el lado del cliente,
-        porqué es importante y cómo aplicar diversas técnicas para
-        implementarla.
+        Entender qué es la validación de formularios en el lado del cliente, por
+        qué es importante y cómo aplicar distintas técnicas para implementarla.
       </td>
     </tr>
   </tbody>
 </table>
 
-La validación en el lado del cliente es una verificación inicial y una característica importante para garantizar una buena experiencia de usuario; mediante la detección de datos no válidos en el lado del cliente, el usuario puede corregirlos de inmediato. Si el servidor lo recibe y, a continuación, lo rechaza; se produce un retraso considerable en la comunicación entre el servidor y el cliente que insta al usuario a corregir sus datos.
+La validación en el lado del cliente es una comprobación inicial y una característica importante para ofrecer una buena experiencia de usuario; al detectar datos no válidos en el lado del cliente, el usuario puede corregirlos inmediatamente.
+Si los datos llegan al servidor y allí se rechazan, se produce un retraso perceptible debido al recorrido de ida y vuelta entre el cliente y el servidor antes de indicar al usuario que debe corregirlos.
 
-Sin embargo, ¡la validación en el lado del cliente _no debe considerarse_ una medida de seguridad exhaustiva! Tus aplicaciones siempre deben realizar comprobaciones de seguridad de los datos enviados por el formulario _en el lado del servidor_, **así como también** en el lado del cliente, porque la validación en el lado del cliente es demasiado fácil de evitar, por lo que los usuarios malintencionados pueden enviar fácilmente datos incorrectos a tu servidor. Lee [Seguridad en los sitios web](/es/docs/Learn_web_development/Extensions/Server-side/First_steps/Website_security) para ver qué _podría_ suceder. Cómo implementar la validación en el lado del servidor está fuera del alcance de este módulo, pero debes tenerlo en cuenta.
+Sin embargo, la validación en el lado del cliente _no debe considerarse_ una medida de seguridad exhaustiva. Tus aplicaciones siempre deben validar los datos enviados mediante formularios, incluidas las comprobaciones de seguridad, _en el lado del servidor_, **además de** hacerlo en el lado del cliente, ya que la validación en el lado del cliente es demasiado fácil de eludir y los usuarios malintencionados pueden enviar datos incorrectos al servidor.
+
+> [!NOTE]
+> Lee [Seguridad de sitios web](/es/docs/Learn_web_development/Extensions/Server-side/First_steps/Website_security) para hacerte una idea de lo que _podría_ ocurrir; implementar la validación en el lado del servidor queda en cierta medida fuera del alcance de este módulo, pero debes tenerla en cuenta.
 
 ## ¿Qué es la validación de formularios?
 
-Ve a cualquier sitio web popular que incluya un formulario de registro y observa que proporcionan comentarios cuando no introduces tus datos en el formato que se espera. Recibirás mensajes como:
+Ve a cualquier sitio web popular que tenga un formulario de registro y observarás que proporciona información cuando no introduces los datos en el formato esperado.
+Recibirás mensajes como los siguientes:
 
-- «Este campo es obligatorio» (No se puede dejar este campo en blanco).
-- «Introduzca su número de teléfono en el formato xxx-xxxx» (Se requiere un formato de datos específico para que se considere válido).
-- «Introduzca una dirección de correo electrónico válida» (los datos que introdujiste no están en el formato correcto).
-- «Su contraseña debe tener entre 8 y 30 caracteres y contener una letra mayúscula, un símbolo y un número». (Se requiere un formato de datos muy específico para tus datos).
+- «Este campo es obligatorio» (no puedes dejar este campo en blanco).
+- «Introduce tu número de teléfono con el formato xxx-xxxx» (se requiere un formato de datos específico para que se considere válido).
+- «Introduce una dirección de correo electrónico válida» (los datos introducidos no tienen el formato correcto).
+- «Tu contraseña debe tener entre 8 y 30 caracteres y contener una letra mayúscula, un símbolo y un número» (se requiere un formato de datos muy específico).
 
-Esto se llama **validación de formulario**. Cuando introduces los datos, el navegador y/o el servidor web verifican que estén en el formato correcto y dentro de las restricciones establecidas por la aplicación. La validación realizada en el navegador se denomina validación **en el lado del cliente**, mientras que la validación realizada en el servidor se denomina validación **en el lado del servidor**. En este capítulo nos centraremos en la validación en el lado del cliente.
+Esto se denomina **validación de formularios**.
+Cuando introduces datos, el navegador (y el servidor web) comprueba que tengan el formato correcto y que cumplan las restricciones establecidas por la aplicación. La validación realizada en el navegador se denomina validación **en el lado del cliente**, mientras que la realizada en el servidor se denomina validación **en el lado del servidor**.
+En este capítulo nos centraremos en la validación en el lado del cliente.
 
-Si la información está en el formato correcto, la aplicación permite que los datos se envíen al servidor y (en general) que se guarden en una base de datos; si la información no está en el formato correcto, da al usuario un mensaje de error que explica lo que debe corregir y le permite volver a intentarlo.
+Si la información tiene el formato correcto, la aplicación permite enviar los datos al servidor y, por lo general, guardarlos en una base de datos; si la información no tiene el formato correcto, muestra al usuario un mensaje de error que explica qué debe corregir y le permite intentarlo de nuevo.
 
-Queremos que completar formularios web sea lo más fácil posible. Entonces, ¿por qué insistimos en validar nuestros formularios? Hay tres razones principales:
+Queremos que completar formularios web sea lo más sencillo posible. Entonces, ¿por qué insistimos en validar nuestros formularios?
+Hay tres razones principales:
 
-- **Queremos obtener los datos correctos en el formato correcto.** Nuestras aplicaciones no funcionarán correctamente si los datos de nuestros usuarios se almacenan en el formato incorrecto, son incorrectos o se omiten por completo.
-- **Queremos proteger los datos de nuestros usuarios**. Obligar a nuestros usuarios a introducir contraseñas seguras facilita proteger la información de su cuenta.
-- **Queremos protegernos a nosotros mismo**. Hay muchas formas en que los usuarios maliciosos puedan usar mal los formularios desprotegidos y dañar la aplicación (consulta [Seguridad del sitio web](/es/docs/Learn_web_development/Extensions/Server-side/First_steps/Website_security)).
+- **Queremos obtener los datos correctos y en el formato correcto.** Nuestras aplicaciones no funcionarán correctamente si los datos de nuestros usuarios se almacenan en un formato incorrecto, son incorrectos o se omiten por completo.
+- **Queremos proteger los datos de nuestros usuarios.** Obligar a nuestros usuarios a introducir contraseñas seguras facilita la protección de la información de sus cuentas.
+- **Queremos protegernos.** Hay muchas formas en las que usuarios malintencionados pueden utilizar formularios desprotegidos para dañar la aplicación. Consulta [Seguridad de sitios web](/es/docs/Learn_web_development/Extensions/Server-side/First_steps/Website_security).
 
-> [!WARNING]
-> No confíes nunca en los datos que se pasan al servidor desde el cliente. Incluso si tu formulario se valida correctamente y evita la introducción de datos con formato incorrecto en el lado del cliente, un usuario malintencionado puede alterar la petición de red.
+  > [!WARNING]
+  > Nunca confíes en los datos enviados al servidor desde el cliente. Incluso si tu formulario valida correctamente y evita entradas con un formato incorrecto en el lado del cliente, un usuario malintencionado puede modificar la solicitud de red.
 
 ## Diferentes tipos de validación en el lado del cliente
 
-Hay dos tipos diferentes de validación por parte del cliente que encontrarás en la web:
+Hay dos tipos diferentes de validación en el lado del cliente que encontrarás en la web:
 
-- La **validación de formularios incorporada** utiliza características de validación de formularios HTML5, que hemos visto en muchos lugares a lo largo de este módulo. Esta validación generalmente no requiere mucho JavaScript. La validación de formularios incorporada tiene un mejor rendimiento que JavaScript, pero no es tan personalizable como la validación con JavaScript.
-- La **validación con JavaScript** se codifica utilizando JavaScript. Esta validación es completamente personalizable, pero debes crearlo todo (o usar una biblioteca).
+- **Validación de formularios HTML**: Los atributos de los formularios HTML pueden definir qué controles de formulario son obligatorios y qué formato deben tener los datos introducidos por el usuario para ser válidos.
+- **Validación de formularios con JavaScript**: Por lo general, se incluye JavaScript para mejorar o personalizar la validación de formularios HTML.
+
+La validación en el lado del cliente se puede realizar con poco o ningún JavaScript. La validación HTML es más rápida que JavaScript, pero es menos personalizable que la validación con JavaScript. Por lo general, se recomienda empezar los formularios con características HTML sólidas y, después, mejorar la experiencia de usuario con JavaScript según sea necesario.
 
 ## Usar la validación de formulario incorporada
 
-Una de las características más importantes de los [controles de formulario de HTML5](/es/docs/Learn_web_development/Extensions/Forms/HTML5_input_types) es la capacidad de validar la mayoría de los datos de usuario sin depender de JavaScript. Esto se realiza mediante el uso de atributos de validación en los elementos del formulario. Los hemos visto anteriormente en el curso, pero recapitulamos aquí:
+Una de las características más importantes de los [controles de formulario](/es/docs/Learn_web_development/Extensions/Forms/HTML5_input_types) es la capacidad de validar la mayoría de los datos de usuario sin depender de JavaScript. Esto se logra mediante el uso de atributos de validación en los elementos de formulario. Hemos visto muchos de ellos antes en el curso, pero para recapitular:
 
-- [`required`](/es/docs/Web/HTML/Attributes/required): Especifica si un campo de formulario debe completarse antes de que se pueda enviar el formulario.
-- [`minlength`](/es/docs/Web/HTML/Reference/Attributes/minlength) y [`maxlength`](/es/docs/Web/HTML/Attributes/maxlength): Especifican la longitud mínima y máxima de los datos de texto (cadenas).
-- [`min`](/es/docs/Web/HTML/Reference/Attributes/min) y [`max`](/es/docs/Web/HTML/Attributes/max): Especifican los valores mínimo y máximo de los tipos de entrada numéricos.
-- `type`: Especifica si los datos deben ser un número, una dirección de correo electrónico o algún otro tipo de preajuste específico.
-- [`pattern`](/es/docs/Web/HTML/Attributes/pattern): Especifica una [expresión regular](/es/docs/Web/JavaScript/Guide/Regular_expressions) que define un patrón que los datos que se introduzcan deben seguir.
+- [`required`](/es/docs/Web/HTML/Reference/Attributes/required): Especifica si un campo de formulario debe rellenarse antes de que se pueda enviar el formulario.
+- [`minlength`](/es/docs/Web/HTML/Reference/Attributes/minlength) y [`maxlength`](/es/docs/Web/HTML/Reference/Attributes/maxlength): Especifican la longitud mínima y máxima de los datos de texto (cadenas).
+- [`min`](/es/docs/Web/HTML/Reference/Attributes/min), [`max`](/es/docs/Web/HTML/Reference/Attributes/max) y [`step`](/es/docs/Web/HTML/Reference/Attributes/step): Especifican los valores mínimo y máximo de los tipos de entrada numéricos y el incremento o paso de los valores, a partir del mínimo.
+- [`type`](/es/docs/Web/HTML/Reference/Elements/input): Especifica si los datos deben ser un número, una dirección de correo electrónico u otro tipo predefinido específico.
+- [`pattern`](/es/docs/Web/HTML/Reference/Attributes/pattern): Especifica una [expresión regular](/es/docs/Web/JavaScript/Guide/Regular_expressions) que define un patrón que deben seguir los datos introducidos.
 
-Si los datos que se introducen en un campo de formulario siguen todas las reglas que especifican los atributos anteriores, se consideran válidos. Si no, se consideran no válidos.
+Si los datos introducidos en un campo de formulario siguen todas las reglas especificadas por los atributos aplicados al campo, se consideran válidos. De lo contrario, se consideran no válidos.
 
-Cuando un elemento es válido, se cumplen los aspectos siguientes:
+Cuando un elemento es válido, se cumple lo siguiente:
 
-- El elemento coincide con la pseudoclase {{cssxref(":valid")}} de CSS, lo que te permite aplicar un estilo específico a los elementos válidos.
-- Si el usuario intenta enviar los datos, el navegador envía el formulario siempre que no haya nada más que lo impida (por ejemplo, JavaScript).
+- El elemento coincide con la pseudoclase CSS {{cssxref(":valid")}}, que permite aplicar un estilo específico a los elementos válidos. El control también coincide con {{cssxref(":user-valid")}} si el usuario ha interactuado con él, y puede coincidir con otras pseudoclases de interfaz de usuario, como {{cssxref(":in-range")}}, según el tipo de entrada y sus atributos.
+- Si el usuario intenta enviar los datos, el navegador envía el formulario, siempre que nada más lo impida (por ejemplo, JavaScript).
 
-Cuando un elemento no es válido, se cumplen los aspectos siguientes:
+Cuando un elemento no es válido, se cumple lo siguiente:
 
-- El elemento coincide con la pseudoclase {{cssxref(":invalid")}} de CSS, y a veces con otras pseudoclases de interfaz de usuario (UI) –por ejemplo, {{cssxref(":out-of-range")}}– dependiendo del error, que te permite aplicar un estilo específico a elementos no válidos.
-- Si el usuario intenta enviar los datos, el navegador bloquea el formulario y muestra un mensaje de error.
-
-> [!NOTE]
-> Hay varios errores que evitan que el formulario se envíe, incluidos {{domxref('validityState.badInput', 'badInput')}}, {{domxref('validityState.patternMismatch','patternMismatch')}}, {{domxref('validityState.rangeOverflow','rangeOverflow')}} o {{domxref('validityState.rangeUnderflow','rangeUnderflow')}}, {{domxref('validityState.stepMismatch','stepMismatch')}}, {{domxref('validityState.tooLong','tooLong')}} o {{domxref('validityState.tooShort','tooShort')}}, {{domxref('validityState.typeMismatch','typeMismatch')}}, {{domxref('validityState.valueMissing','valueMissing')}} o {{domxref('validityState.customError','customError')}}.
+- El elemento coincide con la pseudoclase CSS {{cssxref(":invalid")}}. Si el usuario ha interactuado con el control, también coincide con la pseudoclase CSS {{cssxref(":user-invalid")}}. También puede coincidir con otras pseudoclases de interfaz de usuario, como {{cssxref(":out-of-range")}}, según el error. Estas permiten aplicar un estilo específico a los elementos no válidos.
+- Si el usuario intenta enviar los datos, el navegador bloquea el envío del formulario y muestra un mensaje de error. El mensaje varía según el tipo de error. La [API de validación de restricciones](#la_api_de_validación_de_restricciones) se describe más adelante.
 
 ## Ejemplos de validación de formularios incorporados
 
 En esta sección probaremos algunos de los atributos que hemos comentado antes.
 
-### Archivo de inicio sencillo
+### Archivo de inicio básico
 
-Vamos a empezar con un ejemplo sencillo: una entrada que te permite elegir si prefieres un plátano o una cereza. Este ejemplo implica una simple entrada ({{HTMLElement("input")}}) de texto con una etiqueta ({{htmlelement("label")}}) asociada y un botón de envío ({{htmlelement ("button")}}). Puedes encontrar el código fuente en GitHub en [fruit-start.html](https://github.com/mdn/learning-area/blob/master/html/forms/form-validation/fruit-start.html) y el ejemplo en vivo a continuación.
+Comencemos con un ejemplo básico: una entrada que te permite elegir si prefieres un plátano o una cereza.
+Este ejemplo incluye una {{HTMLElement("input")}} de texto con una {{htmlelement("label")}} asociada y un {{htmlelement("button")}} de envío.
 
-```html
-<form>
-  <label for="choose">¿Prefieres un plátano o una cereza?</label>
-  <input id="choose" name="i_like" />
-  <button>Enviar</button>
-</form>
+```html live-sample___simple-start-file
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Fruta favorita inicial</title>
+    <style>
+      input:invalid {
+        border: 2px dashed red;
+      }
+
+      input:valid {
+        border: 2px solid black;
+      }
+    </style>
+  </head>
+
+  <body>
+    <form>
+      <label for="choose">¿Prefieres un plátano o una cereza?</label>
+      <input id="choose" name="i_like" />
+      <button>Enviar</button>
+    </form>
+  </body>
+</html>
 ```
 
-```css
-input:invalid {
-  border: 2px dashed red;
-}
+{{EmbedLiveSample("simple-start-file", "100%", 80)}}
 
-input:valid {
-  border: 2px solid black;
-}
-```
-
-{{EmbedLiveSample("Archivo_de_inicio_sencillo", "100%", 80)}}
-
-Para empezar, haz una copia de `fruit-start.html` en un nuevo directorio de tu disco duro.
+Para comenzar, crea una copia del código HTML anterior en un archivo `index.html` nuevo. Guárdalo en un directorio nuevo de tu disco duro.
 
 ### El atributo `required`
 
-La característica de validación de HTML5 más simple es el atributo [`required`](/es/docs/Web/HTML/Attributes/required). Añade este atributo al elemento para que una entrada sea obligatoria. Cuando se establece este atributo, el elemento coincide con la pseudoclase de la interfaz de usuario {{cssxref(':required')}} y el formulario no se envía; muestra un mensaje de error al enviarlo si la entrada está vacía. Si está vacía, la entrada también se considera inválida, coincidiendo con la pseudoclase de interfaz de usuario {{cssxref(':invalid')}}.
+Una característica común de validación de HTML es el atributo [`required`](/es/docs/Web/HTML/Reference/Attributes/required).
+Añade este atributo a una entrada para hacer obligatorio un elemento.
+Cuando se establece este atributo, el elemento coincide con la pseudoclase de interfaz de usuario {{cssxref(':required')}} y el formulario no se enviará si la entrada está vacía; al intentar enviarlo se mostrará un mensaje de error.
+Mientras está vacía, la entrada también se considerará no válida y coincidirá con la pseudoclase de interfaz de usuario {{cssxref(':invalid')}}.
+
+Si cualquier botón de opción de un grupo con el mismo nombre tiene el atributo `required`, debe seleccionarse uno de los botones de opción de ese grupo para que sea válido; el botón seleccionado no tiene que ser el que tiene el atributo establecido.
+
+> [!NOTE]
+> Solicita a los usuarios únicamente los datos que necesitas: por ejemplo, ¿es realmente necesario conocer el género o el tratamiento de alguien?
 
 Añade un atributo `required` a tu entrada, como se muestra a continuación.
 
-```html
+```html live-sample___the-required-attribute
 <form>
-  <label for="choose">¿Prefieres un plátano o una cereza? (requerido) </label>
-  <input id="choose" name="i_like" required />
+  <label for="choose">¿Prefieres un plátano o una cereza? *</label>
+  <input id="choose" name="i-like" required />
   <button>Enviar</button>
 </form>
 ```
 
-Ten en cuenta el CSS que en el archivo de ejemplo se ha incluido:
+> [!NOTE]
+> Es habitual colocar un asterisco (u otra marca) después de las etiquetas de los controles de formulario obligatorios para que destaquen para los usuarios videntes. Indicar cuándo son obligatorios los campos de un formulario no solo es una buena experiencia de usuario: también lo exigen las pautas de [accesibilidad](/es/docs/Learn_web_development/Core/Accessibility) de las WCAG.
 
-```css
+Incluimos estilos CSS que se aplican según si el elemento es obligatorio, válido o no válido:
+
+```css live-sample___the-required-attribute
 input:invalid {
   border: 2px dashed red;
 }
@@ -148,46 +179,46 @@ input:valid {
 }
 ```
 
-Este CSS da un borde discontinuo rojo cuando la entrada no es válida, y un borde negro sólido más sutil cuando es válida. También añadimos un gradiente de fondo cuando la entrada es obligatoria _y_ no válida. Prueba el nuevo comportamiento en el ejemplo siguiente:
+```js hidden live-sample___the-required-attribute live-sample___validate-regular-expression live-sample___constraining-values
+const form = document.querySelector("form");
+form.addEventListener("submit", (e) => {
+  e.preventDefault();
+});
+```
 
-{{EmbedLiveSample("El_atributo_required", "100%", 80)}}
+Este CSS hace que la entrada tenga un borde discontinuo rojo cuando no es válida y un borde negro sólido más sutil cuando es válida.
+También añadimos un degradado de fondo cuando la entrada es obligatoria _y_ no válida. Prueba el comportamiento nuevo en el ejemplo siguiente:
 
-> [!NOTE]
-> Puedes encontrar este ejemplo en vivo en GitHub como [fruit-validation.html](https://mdn.github.io/learning-area/html/forms/form-validation/fruit-required.html) (consulta también el [código fuente](https://github.com/mdn/learning-area/blob/master/html/forms/form-validation/fruit-required.html)).
+{{EmbedLiveSample("the-required-attribute", "100%", 80, , , , , "allow-forms")}}
 
-Intenta enviar el formulario sin introducir ningún valor. Observa que la entrada no válida recibe el cursor, aparece un mensaje de error predeterminado («Complete este campo») y el formulario no se puede enviar.
-
-La presencia del atributo `required` en cualquier elemento que admite este atributo significa que el elemento coincide con la pseudoclase {{cssxref(':required')}}, tenga o no un valor. Si en el elemento {{HTMLElement("input")}} no se ha introducido ningún valor, `input` coincidirá con la pseudoclase {{cssxref(':invalid')}}.
-
-> [!NOTE]
-> Para una buena experiencia de usuario, indica al usuario que campos de formulario se requieren. No solo es una buena experiencia de usuario, sino que lo exigen las pautas de [accesibilidad](/es/docs/Learn_web_development/Core/Accessibility) de WCAG. Además, solo requiere que los usuarios introduzcan los datos que realmente necesitas: Por ejemplo, ¿por qué realmente necesitas saber el género o el tratamiento de alguien?
+Intenta enviar el formulario sin introducir un valor. Observa cómo la entrada no válida recibe el foco y aparece un mensaje de error predeterminado («Completa este campo»). También se impide el envío del formulario (aunque, incluso cuando se introduce un valor, evitamos el envío para evitar un error debido a cómo MDN gestiona los formularios incrustados).
 
 ### Validación de una expresión regular
 
-Otra característica útil de validación es el atributo [`pattern`](/es/docs/Web/HTML/Attributes/pattern), que espera una [expresión regular](/es/docs/Web/JavaScript/Guide/Regular_expressions) como valor. Una expresión regular (_regex_) es un patrón que se puede usar para establecer combinaciones de caracteres en cadenas de texto, por lo que las expresiones regulares son ideales para la validación de formularios y sirven para una gran variedad de otros usos en JavaScript.
+Otra característica útil de validación es el atributo [`pattern`](/es/docs/Web/HTML/Reference/Attributes/pattern), que espera una [expresión regular](/es/docs/Web/JavaScript/Guide/Regular_expressions) como valor. Una expresión regular (_regex_) es un patrón que se puede usar para establecer combinaciones de caracteres en cadenas de texto, por lo que las expresiones regulares son ideales para la validación de formularios y sirven para una gran variedad de otros usos en JavaScript.
 
 Las expresiones regulares son bastante complejas y no vamos a exponerlas exhaustivamente en este artículo. A continuación hay algunos ejemplos para que te hagas una idea de cómo funcionan.
 
 - `a`: coincide con un carácter que es `a` (ni `b`, ni `aa`, etc.).
 - `abc`: coincide con `a`, seguido de `b`, seguido de `c`.
-- `ab?c`: coincide con `a`, seguida opcionalmente de una sola `b`, seguida de `c` (`ac` o `abc`).
+- `ab?c`: coincide con `a`, seguido opcionalmente de una sola `b`, seguido de `c` (`ac` o `abc`).
 - `ab*c`: coincide con `a`, seguido opcionalmente de cualquier número de `b`, seguido de `c`. (`ac`, `abc`, `abbbbbc`, etc.)
 - `a|b`: coincide con un carácter que es `a` o `b`.
-- `abc|xyz`: coincide exactamente con `abc` o `xyz` (pero no con `abcxyz` `a` o `y`, y así sucesivamente).
+- `abc|xyz`: coincide exactamente con `abc` o `xyz` (pero no con `abcxyz`, `a` o `y`, y así sucesivamente).
 
 Hay muchas más posibilidades que no exponemos aquí. Para obtener una lista completa y muchos ejemplos, consulta nuestro documento de [expresiones regulares](/es/docs/Web/JavaScript/Guide/Regular_expressions).
 
-Implementemos un ejemplo. Actualiza tu HTML para añadir un atributo [`pattern`](/es/docs/Web/HTML/Attributes/pattern) como este:
+Implementemos un ejemplo. Actualiza tu HTML para añadir un atributo [`pattern`](/es/docs/Web/HTML/Reference/Attributes/pattern) como este:
 
-```html
+```html live-sample___validate-regular-expression
 <form>
-  <label for="choose">¿Prefieres un plátano o una cereza?</label>
-  <input id="choose" name="i_like" required pattern="[Pp]látano|[Cc]ereza" />
+  <label for="choose">¿Prefieres un plátano o una cereza? *</label>
+  <input id="choose" name="i-like" required pattern="[Pp]látano|[Cc]ereza" />
   <button>Enviar</button>
 </form>
 ```
 
-```css hidden
+```css hidden live-sample___validate-regular-expression
 input:invalid {
   border: 2px dashed red;
 }
@@ -199,48 +230,49 @@ input:valid {
 
 Esto nos da la siguiente actualización; pruébalo:
 
-{{EmbedLiveSample("Validación de una expresión regular", "100%", 80)}}
+{{EmbedLiveSample("validate-regular-expression", "100%", 80, , , , , "allow-forms")}}
 
-> [!NOTE]
-> Puedes encontrar este ejemplo en vivo en GitHub como [fruit-pattern.html](https://mdn.github.io/learning-area/html/forms/form-validation/fruit-pattern.html) (consulta también su [código fuente](https://github.com/mdn/learning-area/blob/master/html/forms/form-validation/fruit-pattern.html)).
+También puedes pulsar el botón **Play** para abrir el ejemplo en MDN Playground y editar allí el código fuente.
 
 En este ejemplo, el elemento {{HTMLElement("input")}} acepta uno de los cuatro valores posibles: las cadenas «plátano», «Plátano», «cereza» o «Cereza». Las expresiones regulares distinguen entre mayúsculas y minúsculas, pero hemos hecho que admita versiones en mayúsculas y minúsculas utilizando un patrón «Aa» adicional anidado dentro de corchetes.
 
-En este punto, intenta cambiar el valor dentro del atributo [`pattern`](/es/docs/Web/HTML/Attributes/pattern) para que se vean iguales que algunos de los ejemplos vistos anteriormente, y observa que esto afecta a los valores que puedes añadir para que el valor de entrada sea válido. Intenta escribir algo por tu cuenta y mira cómo va. ¡Haz que estén relacionadas con la fruta siempre que sea posible para que tus ejemplos tengan sentido!
+En este punto, intenta cambiar el valor dentro del atributo [`pattern`](/es/docs/Web/HTML/Reference/Attributes/pattern) para que se vean iguales que algunos de los ejemplos vistos anteriormente, y observa que esto afecta a los valores que puedes añadir para que el valor de entrada sea válido. Intenta escribir algo por tu cuenta y mira cómo va. ¡Haz que estén relacionadas con la fruta siempre que sea posible para que tus ejemplos tengan sentido!
 
-Si un valor no vacío de {{HTMLElement("input")}} no coincide con el patrón de la expresión regular, `input` coincidirá con la pseudoclase {{cssxref(':invalid')}}.
+Si un valor no vacío de {{HTMLElement("input")}} no coincide con el patrón de la expresión regular, `input` coincidirá con la pseudoclase {{cssxref(':invalid')}}. Si está vacío y el elemento no es obligatorio, no se considera no válido.
+
+Algunos tipos de elementos {{HTMLElement("input")}} no necesitan un atributo [`pattern`](/es/docs/Web/HTML/Reference/Attributes/pattern) para validarse con una expresión regular. Por ejemplo, especificar el tipo `email` valida el valor de entrada con un patrón de dirección de correo electrónico bien formada o, si tiene el atributo [`multiple`](/es/docs/Web/HTML/Reference/Attributes/multiple), con un patrón que coincide con una lista de direcciones de correo electrónico separadas por comas.
 
 > [!NOTE]
-> Algunos tipos de elementos {{HTMLElement ("input")}} no necesitan validar una expresión regular con el atributo [`pattern`](/es/docs/Web/HTML/Attributes/pattern). Especificar el tipo de correo electrónico (`email`), por ejemplo, valida el valor de las entradas con un patrón de dirección de correo electrónico bien formado o un patrón que coincida con una lista de direcciones de correo electrónico separadas por comas si tiene el atributo [`multiple`](/es/docs/Web/HTML/Reference/Attributes/multiple).
+> El elemento {{HTMLElement("textarea")}} no admite el atributo [`pattern`](/es/docs/Web/HTML/Reference/Attributes/pattern).
+
+### Restringir la longitud de las entradas
+
+Puedes restringir la longitud de los caracteres de todos los campos de texto creados por {{HTMLElement("input")}} o {{HTMLElement("textarea")}} utilizando los atributos [`minlength`](/es/docs/Web/HTML/Reference/Attributes/minlength) y [`maxlength`](/es/docs/Web/HTML/Reference/Attributes/maxlength). Un campo no es válido si tiene un valor y ese valor tiene menos caracteres que el valor de longitud mínima ([`minlength`](/es/docs/Web/HTML/Reference/Attributes/minlength)), o más que el valor de longitud máxima ([`maxlength`](/es/docs/Web/HTML/Reference/Attributes/maxlength)).
+
+Los navegadores a menudo no permiten que el usuario escriba un valor más largo de lo esperado en los campos de texto. Una mejor experiencia de usuario que usar únicamente `maxlength` consiste en proporcionar información sobre el recuento de caracteres de forma accesible y permitir que los usuarios reduzcan el contenido hasta el tamaño permitido. Los límites de caracteres de las publicaciones en redes sociales son un ejemplo. Para ofrecerlo, puedes usar JavaScript, incluidas [soluciones que usan `maxlength`](https://github.com/mimo84/bootstrap-maxlength).
 
 > [!NOTE]
-> El elemento {{HTMLElement("textarea")}} no admite el atributo [`pattern`](/es/docs/Web/HTML/Attributes/pattern).
+> Las restricciones de longitud nunca se notifican si el valor se establece mediante programación. Solo se notifican para entradas proporcionadas por el usuario.
 
-### Restringir la longitud de tus entradas
+### Restringir los valores de las entradas
 
-Puedes restringir la longitud de los caracteres de todos los campos de texto creados por {{HTMLElement("input")}} o {{HTMLElement("textarea")}} utilizando los atributos [`minlength`](/es/docs/Web/HTML/Reference/Attributes/minlength) y [`maxlength`](/es/docs/Web/HTML/Attributes/maxlength). Un campo no es válido si tiene un valor y ese valor tiene menos caracteres que el valor de longitud mínima ([`minlength`](/es/docs/Web/HTML/Reference/Attributes/minlength)), o más que el valor de longitud máxima ([`maxlength`](/es/docs/Web/HTML/Attributes/maxlength)).
+Los atributos [`min`](/es/docs/Web/HTML/Reference/Attributes/min) y [`max`](/es/docs/Web/HTML/Reference/Attributes/max) se pueden usar para proporcionar a los campos numéricos (es decir, [`<input type="number">`](/es/docs/Web/HTML/Reference/Elements/input/number)) y a los distintos tipos de entrada de fecha un rango de valores válidos. El campo no será válido si contiene un valor fuera de este rango.
 
-Los navegadores a menudo no permiten que el usuario escriba un valor más largo de lo esperado en los campos de texto. Lo que otorga una mejor experiencia de usuario que `maxlength` es proporcionar comentarios de recuento de caracteres de manera accesible y permitirles editar su contenido a un tamaño más reducido. Un ejemplo de esto es el límite de caracteres de Twitter. JavaScript, incluidas las [soluciones que utilizan `maxlength`](https://github.com/mimo84/bootstrap-maxlength), se puede utilizar para proporcionar esta funcionalidad.
+Veamos otro ejemplo. Crea una nueva copia del [archivo de inicio básico](#archivo_de_inicio_básico) y guárdala en el mismo directorio como `index2.html`.
 
-### Restringir los valores de tus entradas
+Ahora elimina el contenido del elemento `<body>` y sustitúyelo por lo siguiente:
 
-Los atributos [`min`](/es/docs/Web/HTML/Reference/Attributes/min) y [`max`](/es/docs/Web/HTML/Attributes/max) se pueden usar para proporcionar a los campos numéricos (es decir, [`<input type="number">`](/es/docs/Web/HTML/Reference/Elements/input/number)) un rango de valores válidos. El campo no será válido si contiene un valor fuera de este rango.
-
-Veamos otro ejemplo. Crea una nueva copia del archivo [fruit-start.html](https://github.com/mdn/learning-area/blob/master/html/forms/form-validation/fruit-start.html).
-
-Ahora elimina el contenido del elemento `<body>` y reemplázalo con lo siguiente:
-
-```html
+```html live-sample___constraining-values
 <form>
   <div>
-    <label for="choose">¿Prefieres un plátano o una cereza?</label>
+    <label for="choose">¿Prefieres un plátano o una cereza? *</label>
     <input
       type="text"
       id="choose"
-      name="i_like"
+      name="i-like"
       required
       minlength="6"
-      maxlength="6" />
+      maxlength="7" />
   </div>
   <div>
     <label for="number">¿Cuántos te gustaría comer?</label>
@@ -252,10 +284,10 @@ Ahora elimina el contenido del elemento `<body>` y reemplázalo con lo siguiente
 </form>
 ```
 
-- Aquí verás que le hemos dado al campo de `text` unos valores `minlength` y `maxlength` de seis, que es la misma longitud que tienen el plátano y la cereza.
+- Aquí verás que le hemos dado al campo de `text` un valor `minlength` de seis y un valor `maxlength` de siete, que corresponden a las longitudes de «cereza» y «plátano», respectivamente.
 - También le hemos dado al campo `number` un `min` de uno y un `max` de diez. Los números introducidos que queden fuera de este rango se mostrarán como no válidos; los usuarios no podrán usar las flechas de incremento/decremento para mover el valor fuera de este rango. Si el usuario introduce un número desde el teclado fuera de este rango, los datos no serán válidos. El número no es obligatorio, por lo que eliminar el valor aún dará como resultado un valor válido.
 
-```css hidden
+```css hidden live-sample___constraining-values
 input:invalid {
   border: 2px dashed red;
 }
@@ -271,13 +303,11 @@ div {
 
 Aquí está el ejemplo que se ejecuta en vivo:
 
-{{EmbedLiveSample("Restringir_los_valores_de_tus_entradas", "100%", 100)}}
+{{EmbedLiveSample("constraining-values", "100%", 100)}}
 
-> [!NOTE]
-> Puedes encontrar este ejemplo en vivo en GitHub como [fruit-length.html](https://mdn.github.io/learning-area/html/forms/form-validation/fruit-length.html) (consulta también su [código fuente](https://github.com/mdn/learning-area/blob/master/html/forms/form-validation/fruit-length.html)).
+También puedes pulsar el botón **Play** para abrir el ejemplo en MDN Playground y editar allí el código fuente.
 
-> [!NOTE]
-> `<input type="number">` (y otros tipos, como `range` y `date`) también pueden tomar un atributo [`step`](/es/docs/Web/HTML/Attributes/step), que especifica en qué incremento aumenta o disminuye el valor cuando se utilizan los controles de entrada (como el botones numéricos arriba y abajo). En el ejemplo anterior no hemos incluido un atributo `step`, por lo que el valor predeterminado es `1`. Esto significa que los valores de coma flotante, como 3.2, también se mostrarán como no válidos.
+Los tipos de entrada numéricos, como `number`, `range` y `date`, también pueden usar el atributo [`step`](/es/docs/Web/HTML/Reference/Attributes/step). Este atributo especifica en qué incremento aumenta o disminuye el valor cuando se utilizan los controles de entrada (como los botones numéricos arriba y abajo o el control deslizante de los rangos). El atributo `step` se omite en nuestro ejemplo, por lo que el valor predeterminado es `1`. Esto significa que los números de coma flotante, como 3.2, también se mostrarán como no válidos.
 
 ### Ejemplo completo
 
@@ -285,30 +315,27 @@ Aquí hay un ejemplo completo que muestra el uso de las funciones de validación
 
 ```html
 <form>
-  <p>
-    <fieldset>
-      <legend>¿Tienes carné de conducir?<abbr title="Este campo es obligatorio" aria-label="required">*</abbr></legend>
-      <!-- Solo se puede seleccionar un botón de opción en un grupo con el mismo nombre,
-           y, por lo tanto, solo un botón de opción en un grupo con el mismo nombre que tiene marcado el atributo «requerido»
-           basta para hacer de una selección un requisito -->
-      <input type="radio" required name="driver" id="r1" value="yes"><label for="r1">Sí</label>
-      <input type="radio" required name="driver" id="r2" value="no"><label for="r2">No</label>
-    </fieldset>
-  </p>
+  <p>Completa todos los campos obligatorios (*).</p>
+  <fieldset>
+    <legend>¿Tienes permiso de conducir? *</legend>
+    <input type="radio" required name="driver" id="r1" value="yes" />
+    <label for="r1">Sí</label>
+    <input type="radio" required name="driver" id="r2" value="no" />
+    <label for="r2">No</label>
+  </fieldset>
   <p>
     <label for="n1">¿Qué edad tienes?</label>
-    <!-- El atributo pattern puede actuar como una alternativa para los navegadores que
-         no implementan el tipo de entrada de número, pero admiten el atributo pattern.
-         Ten en cuenta que los navegadores que admiten el atributo pattern lo harán
-         fallar silenciosamente cuando se use con un campo numérico.
-         Su uso aquí solo actúa como una alternativa -->
-     <input type="number" min="12" max="120" step="1" id="n1" name="age"
-           pattern="\d+">
+    <input type="number" min="12" max="120" step="1" id="n1" name="age" />
   </p>
   <p>
-    <label for="t1">¿Cuál es tu fruta favorita?<abbr title="Este campo es obligatorio" aria-label="required">*</abbr></label>
-    <input type="text" id="t1" name="fruit" list="l1" required
-           pattern="[Bb]anana|[Cc]herry|[Aa]pple|[Ss]trawberry|[Ll]emon|[Oo]range">
+    <label for="t1">¿Cuál es tu fruta favorita? *</label>
+    <input
+      type="text"
+      id="t1"
+      name="fruit"
+      list="l1"
+      required
+      pattern="[Pp]látano|[Cc]ereza|[Mm]anzana|[Ff]resa|[Ll]imón|[Nn]aranja" />
     <datalist id="l1">
       <option>Plátano</option>
       <option>Cereza</option>
@@ -316,14 +343,14 @@ Aquí hay un ejemplo completo que muestra el uso de las funciones de validación
       <option>Fresa</option>
       <option>Limón</option>
       <option>Naranja</option>
-     </datalist>
+    </datalist>
   </p>
   <p>
-    <label for="t2">¿Cuál es tu dirección de correo electrónico? </label>
-    <input type="email" id="t2" name="email">
+    <label for="t2">¿Cuál es tu dirección de correo electrónico?</label>
+    <input type="email" id="t2" name="email" />
   </p>
   <p>
-    <label for="t3">Deja un mensaje</label>
+    <label for="t3">Deja un mensaje breve</label>
     <textarea id="t3" name="msg" maxlength="140" rows="5"></textarea>
   </p>
   <p>
@@ -350,7 +377,7 @@ input[type="number"],
 textarea,
 fieldset {
   width: 100%;
-  border: 1px solid #333;
+  border: 1px solid #333333;
   box-sizing: border-box;
 }
 
@@ -363,101 +390,180 @@ input:focus:invalid {
 }
 ```
 
-Esto se traduce de la siguiente manera:
+El resultado se muestra a continuación:
 
-{{EmbedLiveSample("Ejemplo_completo", "100%", 420)}}
+{{EmbedLiveSample("Full_example", "100%", 420)}}
 
-Consulta [Atributos relacionados con la validación](/es/docs/HTML/HTML5/Validacion_de_restricciones#Atributos_relacionados_con_validaciones) para obtener una lista completa de los atributos que se pueden usar para restringir los valores de entrada y los tipos de entrada que los admiten.
+También puedes pulsar el botón **Play** para abrir el ejemplo en MDN Playground y editar allí el código fuente.
 
-> [!NOTE]
-> Puedes encontrar este ejemplo en vivo en GitHub como [full-example.html](https://mdn.github.io/learning-area/html/forms/form-validation/full-example.html) (consulta también su [código fuente](https://github.com/mdn/learning-area/blob/master/html/forms/form-validation/full-example.html)).
+Consulta [atributos relacionados con la validación](/es/docs/Web/HTML/Guides/Constraint_validation) para ver una lista completa de los atributos que pueden utilizarse para restringir valores de entrada y los tipos de entrada que los admiten.
 
-## Validar formularios utilizando JavaScript
+## Validar formularios con JavaScript
 
-Debes usar JavaScript si quieres controlar la apariencia de los mensajes de error nativos o tratar con navegadores heredados que no admiten la validación de formularios incorporados en HTML. En esta sección veremos las diferentes formas de hacer esto.
+Si quieres cambiar el texto de los mensajes de error nativos, necesitas JavaScript. En esta sección veremos las distintas formas de hacerlo.
 
 ### La API de validación de restricciones
 
-La mayoría de los navegadores admiten la [API de validación de restricciones](/es/docs/Learn_web_development/Extensions/Forms/Form_validation), que consta de un conjunto de métodos y propiedades disponibles en las interfaces DOM de elementos de formulario siguientes:
+La API de validación de restricciones consta de un conjunto de métodos y propiedades disponibles en las siguientes interfaces DOM de elementos de formulario:
 
 - [`HTMLButtonElement`](/es/docs/Web/API/HTMLButtonElement) (representa un elemento [`<button>`](/es/docs/Web/HTML/Reference/Elements/button))
 - [`HTMLFieldSetElement`](/es/docs/Web/API/HTMLFieldSetElement) (representa un elemento [`<fieldset>`](/es/docs/Web/HTML/Reference/Elements/fieldset))
 - [`HTMLInputElement`](/es/docs/Web/API/HTMLInputElement) (representa un elemento [`<input>`](/es/docs/Web/HTML/Reference/Elements/input))
-- [`HTMLOutputElement`](/es/docs/Web/API/HTMLOutputElement) (representa un elemento [`<output>`](/es/docs/Web/HTML/Element/output))
+- [`HTMLOutputElement`](/es/docs/Web/API/HTMLOutputElement) (representa un elemento [`<output>`](/es/docs/Web/HTML/Reference/Elements/output))
 - [`HTMLSelectElement`](/es/docs/Web/API/HTMLSelectElement) (representa un elemento [`<select>`](/es/docs/Web/HTML/Reference/Elements/select))
 - [`HTMLTextAreaElement`](/es/docs/Web/API/HTMLTextAreaElement) (representa un elemento [`<textarea>`](/es/docs/Web/HTML/Reference/Elements/textarea))
 
-La API de validación de restricciones hace que las propiedades siguientes estén disponibles en los elementos anteriores.
+La API de validación de restricciones pone las siguientes propiedades a disposición de estos elementos:
 
-- `validationMessage`: Devuelve un mensaje localizado que describe las restricciones de validación que el control no satisface (si corresponde). Si el control no es candidato para la validación de restricciones (`willValidate` es `false`) o el valor del elemento satisface sus restricciones (es válido), esto devolverá una cadena vacía.
-- `validity`: Devuelve un objeto `ValidityState` que contiene varias propiedades que describen el estado de validez del elemento. Puedes encontrar todos los detalles de todas las propiedades disponibles en la página de referencia {{domxref("ValidityState")}}; a continuación se enumeran algunos de los más comunes:
-  - {{domxref("ValidityState.patternMismatch", "patternMismatch")}}: Devuelve `true` si el valor no coincide con el [`pattern`](/es/docs/Web/HTML/Reference/Elements/input#pattern) especificado, y `false` si coincide. Si es verdadero, el elemento coincide con la pseudoclase {{cssxref(":invalid")}} de CSS.
-  - {{domxref("ValidityState.tooLong", "tooLong")}}: Devuelve `true` si el valor es mayor que la longitud máxima especificada por el atributo [`maxlength`](/es/docs/Web/HTML/Reference/Elements/input#maxlength), o `false` si es menor o igual al máximo. Si es verdadero, el elemento coincide con la pseudoclase {{cssxref(":invalid")}} de CSS.
-  - {{domxref("ValidityState.tooShort", "tooShort")}}: Devuelve `true` si el valor es menor que la longitud mínima especificada por el atributo [`minlength`](/es/docs/Web/HTML/Reference/Elements/input#minlength), o `false` si es mayor o igual al mínmo. Si es verdadero, el elemento coincide con la pseudoclase {{cssxref(":invalid")}} de CSS.
-  - {{domxref("ValidityState.rangeOverflow", "rangeOverflow")}}: Devuelve `true` si el valor es mayor que el máximo especificado por el atributo [`max`](/es/docs/Web/HTML/Reference/Elements/input#max), o `false` si es menor o igual que el máximo. Si es verdadero, el elemento coincide con las pseudoclases {{cssxref(":invalid")}} y {{cssxref(":out-of-range")}} de CSS.
-  - {{domxref("ValidityState.rangeUnderflow", "rangeUnderflow")}}: Devuelve `true` si el valor es menor que el mínimo especificado por el atributo [`min`](/es/docs/Web/HTML/Reference/Elements/input#min), o `false` si es mayor o igual que el mínimo. Si es verdadero, el elemento coincide con las pseudoclases {{cssxref(":invalid")}} y {{cssxref(":out-of-range")}} de CSS.
-  - {{domxref("ValidityState.typeMismatch", "typeMismatch")}}: Devuelve `true` si el valor no está en la sintaxis requerida (cuando [`type`](/es/docs/Web/HTML/Reference/Elements/input#type) es `email` o `url`), o `false` si la sintaxis es correcta. Si es verdadero, el elemento coincide con la pseudoclase {{cssxref(":invalid")}} de CSS.
-  - `valid`: Devuelve `true` si el elemento cumple con todas sus restricciones de validación y por lo tanto se considera válido, o `false` si falla alguna restricción. Si es verdadero, el elemento coincide con la pseudoclase {{cssxref(":valid")}} de CSS; o con la pseudoclase {{cssxref(":invalid")}} de CSS de lo contrario.
-  - `valueMissing`: Devuelve `true` si el elemento tiene un atributo [`required`](/es/docs/Web/HTML/Reference/Elements/input#required) pero no tiene valor, o `false` de lo contrario. Si es verdadero, el elemento coincide con la pseudoclase {{cssxref(":invalid")}} de CSS.
+- `validationMessage`: Devuelve un mensaje localizado que describe las restricciones de validación que el control no satisface (si las hay). Si el control no es candidato para la validación de restricciones (`willValidate` es `false`) o el valor del elemento satisface sus restricciones (es válido), devuelve una cadena vacía.
+- `validity`: Devuelve un objeto `ValidityState` que contiene varias propiedades que describen el estado de validez del elemento. Puedes consultar todos los detalles de las propiedades disponibles en la página de referencia de {{domxref("ValidityState")}}; a continuación se enumeran algunas de las más comunes:
+  - {{domxref("ValidityState.patternMismatch", "patternMismatch")}}: Devuelve `true` si el valor no coincide con el [`pattern`](/es/docs/Web/HTML/Reference/Elements/input#pattern) especificado, y `false` si coincide. Si es `true`, el elemento coincide con la pseudoclase CSS {{cssxref(":invalid")}}.
+  - {{domxref("ValidityState.tooLong", "tooLong")}}: Devuelve `true` si el valor supera la longitud máxima especificada por el atributo [`maxlength`](/es/docs/Web/HTML/Reference/Elements/input#maxlength), o `false` si es menor o igual que el máximo. Si es `true`, el elemento coincide con la pseudoclase CSS {{cssxref(":invalid")}}.
+  - {{domxref("ValidityState.tooShort", "tooShort")}}: Devuelve `true` si el valor es menor que la longitud mínima especificada por el atributo [`minlength`](/es/docs/Web/HTML/Reference/Elements/input#minlength), o `false` si es mayor o igual que el mínimo. Si es `true`, el elemento coincide con la pseudoclase CSS {{cssxref(":invalid")}}.
+  - {{domxref("ValidityState.rangeOverflow", "rangeOverflow")}}: Devuelve `true` si el valor es mayor que el máximo especificado por el atributo [`max`](/es/docs/Web/HTML/Reference/Elements/input#max), o `false` si es menor o igual que el máximo. Si es `true`, el elemento coincide con las pseudoclases CSS {{cssxref(":invalid")}} y {{cssxref(":out-of-range")}}.
+  - {{domxref("ValidityState.rangeUnderflow", "rangeUnderflow")}}: Devuelve `true` si el valor es menor que el mínimo especificado por el atributo [`min`](/es/docs/Web/HTML/Reference/Elements/input#min), o `false` si es mayor o igual que el mínimo. Si es `true`, el elemento coincide con las pseudoclases CSS {{cssxref(":invalid")}} y {{cssxref(":out-of-range")}}.
+  - {{domxref("ValidityState.typeMismatch", "typeMismatch")}}: Devuelve `true` si el valor no tiene la sintaxis requerida (cuando [`type`](/es/docs/Web/HTML/Reference/Elements/input#type) es `email` o `url`), o `false` si la sintaxis es correcta. Si es `true`, el elemento coincide con la pseudoclase CSS {{cssxref(":invalid")}}.
+  - `valid`: Devuelve `true` si el elemento cumple todas sus restricciones de validación y, por tanto, se considera válido, o `false` si incumple alguna. Si es `true`, el elemento coincide con la pseudoclase CSS {{cssxref(":valid")}}; de lo contrario, coincide con {{cssxref(":invalid")}}.
+  - `valueMissing`: Devuelve `true` si el elemento tiene un atributo [`required`](/es/docs/Web/HTML/Reference/Elements/input#required), pero no tiene valor, o `false` de lo contrario. Si es `true`, el elemento coincide con la pseudoclase CSS {{cssxref(":invalid")}}.
 
-- `willValidate`: Devuelve `true` si el elemento se valida cuando se envía el formulario; `false` de lo contrario.
+- `willValidate`: Devuelve `true` si el elemento se validará cuando se envíe el formulario; `false` de lo contrario.
 
-La API de validación de restricciones también pone a disposición los siguientes métodos en los elementos anteriores.
+La API de validación de restricciones también pone los siguientes métodos a disposición de los elementos anteriores y del elemento [`form`](/es/docs/Web/HTML/Reference/Elements/form):
 
-- `checkValidity()`: Devuelve `true` si el valor del elemento no tiene problemas de validez; `false` en caso contrario. Si el elemento no es válido, este método también activa un [evento `invalid`](/es/docs/Web/API/HTMLInputElement/invalid_event) en el elemento.
-- `setCustomValidity(message)`: Añade un mensaje de error personalizado al elemento; si configuras un mensaje de error personalizado, el elemento se considera no válido y se muestra el error especificado. Esto te permite utilizar el código JavaScript para establecer un fallo de validación distinto de los ofrecidos por las restricciones estándar de validación de HTML5. El mensaje se muestra al usuario cuando se informa del problema.
+- `checkValidity()`: Devuelve `true` si el valor del elemento no tiene problemas de validez; `false` de lo contrario. Si el elemento no es válido, este método también dispara un [evento `invalid`](/es/docs/Web/API/HTMLInputElement/invalid_event) en el elemento.
+- `reportValidity()`: Informa de los campos no válidos mediante eventos. Este método es útil junto con `preventDefault()` en un controlador de eventos `onSubmit`.
+- `setCustomValidity(message)`: Añade un mensaje de error personalizado al elemento; si estableces uno, el elemento se considera no válido y se muestra el error indicado. Esto te permite usar código JavaScript para establecer un fallo de validación distinto de los que ofrecen las restricciones estándar de validación HTML. El mensaje se muestra al usuario cuando se informa del problema.
 
 #### Implementar un mensaje de error personalizado
 
-Como has visto en los ejemplos de restricciones de validación de HTML5 anteriores, cada vez que un usuario intenta enviar un formulario no válido, el navegador muestra un mensaje de error. La forma en que se muestra este mensaje depende del navegador.
+Como viste en los ejemplos anteriores de restricciones de validación HTML, cada vez que un usuario intenta enviar un formulario no válido, el navegador muestra un mensaje de error. La forma en que se muestra depende del navegador.
 
-Estos mensajes automatizados tienen dos inconvenientes:
+Estos mensajes automáticos tienen dos inconvenientes:
 
-- No hay una forma estándar de cambiar su aspecto con CSS.
-- Dependen de la configuración regional del navegador, lo que significa que puedes tener una página en un idioma pero un mensaje de error en otro idioma, como se ve en la siguiente captura de pantalla de Firefox.
+- No hay una forma estándar de cambiar su apariencia con CSS.
+- Dependen de la configuración regional del navegador, lo que significa que puedes tener una página en un idioma, pero un mensaje de error en otro, como se ve en la siguiente captura de pantalla de Firefox.
 
-![Ejemplo de un mensaje de error en francés en una página de Firefox en inglés](error-firefox-win7.png)
+![Ejemplo de un mensaje de error con Firefox en francés en una página en inglés](error-firefox-win7.png)
 
-La personalización de estos mensajes de error es uno de los casos de uso más comunes de la [API de validación de restricciones](/es/docs/Learn_web_development/Extensions/Forms/Form_validation). Veamos un ejemplo simple de cómo hacer esto.
+Personalizar estos mensajes de error es uno de los casos de uso más habituales de la API de validación de restricciones. Veamos un ejemplo de cómo hacerlo.
 
-Comenzaremos con un HTML simple (siéntete libre de poner esto en un archivo HTML en blanco; usa una copia nueva de [fruit-start.html](https://github.com/mdn/learning-area/blob/master/html/forms/form-validation/fruit-start.html) como base, si lo deseas):
+Comenzaremos con algo de HTML. Si quieres, puedes ponerlo en otra copia del [archivo de inicio básico](#archivo_de_inicio_básico):
 
 ```html
 <form>
-  <label for="mail">Me gustaría que me proporcionara una dirección de correo electrónico:<label>
-  <input type="email" id="mail" name="mail">
+  <label for="mail">
+    Me gustaría que me proporcionaras una dirección de correo electrónico:
+  </label>
+  <input type="email" id="mail" name="mail" />
   <button>Enviar</button>
 </form>
 ```
 
-Y añade a la página el JavaScript siguiente:
+Añade el siguiente JavaScript a la página:
 
 ```js
 const email = document.getElementById("mail");
 
-email.addEventListener("input", function (event) {
+email.addEventListener("input", (event) => {
   if (email.validity.typeMismatch) {
-    email.setCustomValidity(
-      "¡Se esperaba una dirección de correo electrónico!",
-    );
+    email.setCustomValidity("Espero una dirección de correo electrónico.");
   } else {
     email.setCustomValidity("");
   }
 });
 ```
 
-Aquí guardamos una referencia para la entrada de la dirección de correo electrónico, luego le añadimos un detector de eventos que ejecuta el código de `content` cada vez que el valor de la entrada cambia.
+Aquí guardamos una referencia a la entrada de correo electrónico y, después, le añadimos un detector de eventos que ejecuta el código incluido cada vez que cambia el valor de la entrada.
 
-Dentro del código que contiene, verificamos si la propiedad `validity.typeMismatch` de la entrada de la dirección de correo electrónico devuelve `true`, lo que significa que el valor que contiene no coincide con el patrón para una dirección de correo electrónico bien formada. Si es así, llamamos al método [`setCustomValidity()`](/es/docs/HTML/HTML5/Validacion_de_restricciones) con un mensaje personalizado. Esto hace que la entrada no sea válida, de modo que cuando intentas enviar el formulario, el envío falla y se muestra el mensaje de error personalizado.
+Dentro de ese código, comprobamos si la propiedad `validity.typeMismatch` de la entrada de correo electrónico devuelve `true`, lo que significa que el valor no coincide con el patrón de una dirección de correo electrónico bien formada. Si es así, llamamos al método {{domxref("HTMLInputElement.setCustomValidity()", "setCustomValidity()")}} con un mensaje personalizado. Esto hace que la entrada no sea válida, por lo que al intentar enviar el formulario el envío falla y se muestra el mensaje de error personalizado.
 
-Si la propiedad `validity.typeMismatch` devuelve `false`, llamamos al método `setCustomValidity()` con una cadena vacía. Esto hace que la entrada sea válida, y el formulario se envía.
+Si la propiedad `validity.typeMismatch` devuelve `false`, llamamos al método `setCustomValidity()` con una cadena vacía. Esto hace que la entrada sea válida, de modo que el formulario se enviará. Durante la validación, si algún control del formulario tiene un `customError` que no sea una cadena vacía, se bloquea el envío del formulario.
 
-Puedes probarlo a continuación:
+Puedes probarlo a continuación (pulsa el botón **Play** para ejecutar el ejemplo en MDN Playground y editar el código fuente):
 
-{{EmbedGHLiveSample("learning-area/html/forms/form-validation/custom-error-message.html", '100%', 80)}}
+```html hidden live-sample___custom-error-message
+<form>
+  <label for="mail"
+    >Me gustaría que me proporcionaras una dirección de correo
+    electrónico:</label
+  >
+  <input type="email" id="mail" name="mail" />
+  <button>Enviar</button>
+</form>
+```
 
-> [!NOTE]
-> Puede encontrar este ejemplo vivo en GitHub como [custom-error-message.html](https://mdn.github.io/learning-area/html/forms/form-validation/custom-error-message.html) (véase también su [código fuente](https://github.com/mdn/learning-area/blob/master/html/forms/form-validation/custom-error-message.html)).
+```css hidden live-sample___custom-error-message
+input:invalid {
+  border: 2px dashed red;
+}
+
+input:valid {
+  border: 2px solid black;
+}
+form {
+  margin: 3rem 0;
+}
+```
+
+```js hidden live-sample___custom-error-message
+const email = document.getElementById("mail");
+
+email.addEventListener("input", (event) => {
+  if (email.validity.typeMismatch) {
+    email.setCustomValidity("Espero una dirección de correo electrónico.");
+  } else {
+    email.setCustomValidity("");
+  }
+});
+
+const form = document.querySelector("form");
+form.addEventListener("submit", (e) => {
+  e.preventDefault();
+});
+```
+
+{{EmbedLiveSample("custom-error-message", "100%", 120, , , , , "allow-forms")}}
+
+#### Ampliar la validación de formularios incorporada
+
+El ejemplo anterior mostró cómo puedes añadir un mensaje personalizado para un tipo de error concreto (`validity.typeMismatch`). También es posible usar toda la validación de formularios incorporada y, después, ampliarla con `setCustomValidity()`.
+
+Aquí mostramos cómo puedes ampliar la validación incorporada de [`<input type="email">`](/es/docs/Web/HTML/Reference/Elements/input/email) para aceptar únicamente direcciones con el dominio `@example.com`. Comenzamos con el {{htmlelement("form")}} HTML siguiente:
+
+```html
+<form>
+  <label for="mail">Dirección de correo electrónico (solo @example.com):</label>
+  <input type="email" id="mail" />
+  <button>Enviar</button>
+</form>
+```
+
+El código de validación se muestra a continuación. Ante cada entrada nueva, primero restablece el mensaje de validez personalizado mediante `setCustomValidity("")`. Después usa `email.validity.valid` para comprobar si la dirección introducida no es válida y, si lo es, sale del controlador de eventos. Esto garantiza que se ejecuten todas las comprobaciones normales de validación incorporada mientras el texto introducido no sea una dirección de correo electrónico válida.
+
+Una vez que la dirección de correo electrónico es válida, el código añade una restricción personalizada y llama a `setCustomValidity()` con un mensaje de error si la dirección no termina en `@example.com`.
+
+```js
+const email = document.getElementById("mail");
+
+email.addEventListener("input", (event) => {
+  // Validar con las restricciones incorporadas
+  email.setCustomValidity("");
+  if (!email.validity.valid) {
+    return;
+  }
+
+  // Ampliar con una restricción personalizada
+  if (!email.value.endsWith("@example.com")) {
+    email.setCustomValidity(
+      "Introduce una dirección de correo electrónico de @example.com",
+    );
+  }
+});
+```
+
+Intenta enviar una dirección de correo electrónico no válida, una dirección válida que no termine en `@example.com` y una que sí termine en `@example.com`.
+
+{{EmbedLiveSample("extending built-in form validation", "", 200, , , , , "allow-forms")}}
 
 #### Un ejemplo más detallado
 
@@ -469,7 +575,7 @@ En primer lugar, el código HTML. Una vez más, siéntete libre de construir est
 <form novalidate>
   <p>
     <label for="mail">
-      <span>Por favor, introduzca una dirección de correo electrónico: </span>
+      <span>Introduce una dirección de correo electrónico *:</span>
       <input type="email" id="mail" name="mail" required minlength="8" />
       <span class="error" aria-live="polite"></span>
     </label>
@@ -478,16 +584,16 @@ En primer lugar, el código HTML. Una vez más, siéntete libre de construir est
 </form>
 ```
 
-Este sencillo formulario usa el atributo [`novalidate`](/es/docs/Web/HTML/Attributes/novalidate) para desactivar la validación automática del navegador; esto permite que nuestra secuencia de comandos tome control sobre la validación. Sin embargo, esto no deshabilita la compatibilidad para la API de validación de restricciones ni la aplicación de pseudoclases de CSS como {{cssxref(":valid")}}, etc. Eso significa que, aunque el navegador no verifica automáticamente la validez del formulario antes de enviar los datos, puedes hacerlo tú mismo y diseñar el formulario en consecuencia.
+Este formulario usa el atributo [`novalidate`](/es/docs/Web/HTML/Reference/Elements/form#novalidate) para desactivar la validación automática del navegador. Establecer el atributo `novalidate` en el formulario impide que este muestre sus propios cuadros de mensaje de error y nos permite mostrar mensajes de error personalizados en el DOM de la manera que elijamos.
+Sin embargo, esto no deshabilita la API de validación de restricciones ni la aplicación de pseudoclases CSS como {{cssxref(":valid")}}, etc.
+Esto significa que, aunque el navegador no comprueba automáticamente la validez del formulario antes de enviar sus datos, puedes hacerlo tú mismo y aplicar estilos al formulario en consecuencia.
 
-Nuestra entrada para validar es [`<input type="email">`](/es/docs/Web/HTML/Reference/Elements/input/email), que es obligatoria y tiene una longitud mínima (`minlength`) de 8 caracteres. Vamos a verificar esto con nuestro propio código para que muestre un mensaje de error personalizado para cada elemento.
+Nuestra entrada para validar es [`<input type="email">`](/es/docs/Web/HTML/Reference/Elements/input/email), que es obligatoria y tiene un `minlength` de 8 caracteres. Vamos a comprobar estas condiciones con nuestro propio código y a mostrar un mensaje de error personalizado para cada una.
 
-Nuestro objetivo es mostrar los mensajes de error dentro de un elemento `<span>`. El atributo [`aria-live`](/es/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) se establece en ese `<span>` para asegurar que todo el mundo podrá ver nuestro mensaje de error personalizado, incluidos los usuarios de lectores de pantalla.
+Nuestro objetivo es mostrar los mensajes de error dentro de un elemento `<span>`.
+El atributo [`aria-live`](/es/docs/Web/Accessibility/ARIA/Guides/Live_regions) se establece en ese `<span>` para asegurar que nuestro mensaje de error personalizado se presente a todo el mundo, incluso que se lea a los usuarios de lectores de pantalla.
 
-> [!NOTE]
-> Un punto clave a tener en cuenta es que establecer el atributo `novalidate` en el formulario impide que el formulario muestre sus propios cuadros de diálogo de error, y nos permite mostrar los mensajes de error personalizados en el DOM de la manera que nosotros elijamos.
-
-Ahora aplicaremos algo de CSS básico para mejorar ligeramente el aspecto del formulario y proporcionar algunos comentarios visuales cuando los datos de entrada no sean válidos:
+Ahora aplicaremos algo de CSS básico para mejorar ligeramente el aspecto del formulario y proporcionar información visual cuando los datos de entrada no sean válidos:
 
 ```css
 body {
@@ -502,11 +608,10 @@ p * {
 }
 
 input[type="email"] {
-  -webkit-appearance: none;
   appearance: none;
 
   width: 100%;
-  border: 1px solid #333;
+  border: 1px solid #333333;
   margin: 0;
 
   font-family: inherit;
@@ -515,24 +620,24 @@ input[type="email"] {
   box-sizing: border-box;
 }
 
-/* Este es nuestro diseño para los campos no válidos */
+/* Campos no válidos */
 input:invalid {
-  border-color: #900;
-  background-color: #fdd;
+  border-color: #990000;
+  background-color: #ffdddd;
 }
 
 input:focus:invalid {
   outline: none;
 }
 
-/* Este es el diseño para nuestros mensajes de error */
+/* Estilos de los mensajes de error */
 .error {
   width: 100%;
   padding: 0;
 
   font-size: 80%;
   color: white;
-  background-color: #900;
+  background-color: #990000;
   border-radius: 0 0 5px 5px;
 
   box-sizing: border-box;
@@ -543,86 +648,158 @@ input:focus:invalid {
 }
 ```
 
-Vamos a ver el JavaScript que implementa la validación de error personalizada.
+Ahora veamos el JavaScript que implementa la validación de errores personalizada.
+Hay muchas formas de seleccionar un nodo DOM; aquí obtenemos el formulario, el campo de entrada de correo electrónico y el elemento `span` en el que colocaremos el mensaje de error.
+
+Mediante controladores de eventos, comprobamos si los campos del formulario son válidos cada vez que el usuario escribe algo. Si hay un error, lo mostramos. Si no lo hay, eliminamos cualquier mensaje de error.
 
 ```js
-// Hay muchas formas de elegir un nodo DOM; aquí obtenemos el formulario y, a continuación, el campo de entrada
-// del correo electrónico, así como el elemento span en el que colocaremos el mensaje de error.
-const form = document.getElementsByTagName("form")[0];
-
+const form = document.querySelector("form");
 const email = document.getElementById("mail");
 const emailError = document.querySelector("#mail + span.error");
 
-email.addEventListener("input", function (event) {
-  // Cada vez que el usuario escribe algo, verificamos si
-  // los campos del formulario son válidos.
-
+email.addEventListener("input", (event) => {
   if (email.validity.valid) {
-    // En caso de que haya un mensaje de error visible, si el campo
-    // es válido, eliminamos el mensaje de error.
-    emailError.innerHTML = ""; // Restablece el contenido del mensaje
-    emailError.className = "error"; // Restablece el estado visual del mensaje
+    emailError.textContent = ""; // Elimina el contenido del mensaje
+    emailError.className = "error"; // Elimina la clase `active`
   } else {
-    // Si todavía hay un error, muestra el error exacto
+    // Si aún hay un error, muestra el error correspondiente
     showError();
   }
 });
 
-form.addEventListener("submit", function (event) {
-  // si el campo de correo electrónico es válido, dejamos que el formulario se envíe
-
+form.addEventListener("submit", (event) => {
+  // Si el campo de correo electrónico no es válido
   if (!email.validity.valid) {
-    // Si no es así, mostramos un mensaje de error apropiado
+    // Muestra un mensaje de error apropiado
     showError();
-    // Luego evitamos que se envíe el formulario cancelando el evento
+    // Impide el envío del formulario
     event.preventDefault();
   }
 });
 
 function showError() {
   if (email.validity.valueMissing) {
-    // Si el campo está vacío
-    // muestra el mensaje de error siguiente.
+    // Si está vacío
     emailError.textContent =
-      "Debe introducir una dirección de correo electrónico.";
+      "Debes introducir una dirección de correo electrónico.";
   } else if (email.validity.typeMismatch) {
-    // Si el campo no contiene una dirección de correo electrónico
-    // muestra el mensaje de error siguiente.
+    // Si no es una dirección de correo electrónico
     emailError.textContent =
       "El valor introducido debe ser una dirección de correo electrónico.";
   } else if (email.validity.tooShort) {
-    // Si los datos son demasiado cortos
-    // muestra el mensaje de error siguiente.
-    emailError.textContent =
-      "El correo electrónico debe tener al menos ${ email.minLength } caracteres; ha introducido ${ email.value.length }.";
+    // Si el valor es demasiado corto
+    emailError.textContent = `El correo electrónico debe tener al menos ${email.minLength} caracteres; has introducido ${email.value.length}.`;
   }
-
-  // Establece el estilo apropiado
-  emailError.className = "error activo";
+  // Añade la clase `active`
+  emailError.className = "error active";
 }
 ```
 
-Los comentarios explican las cosas bastante bien, pero de una manera muy breve:
+Cada vez que cambiamos el valor de la entrada, comprobamos si contiene datos válidos. Si es así, eliminamos cualquier mensaje de error que se muestre. Si los datos no son válidos, ejecutamos `showError()` para mostrar el error correspondiente.
 
-- Cada vez que cambiamos el valor de la entrada, verificamos si contiene datos válidos. Si es así, eliminamos cualquier mensaje de error que se muestre. Si los datos no son válidos, ejecutamos `showError()` para mostrar el error correspondiente.
-- Cada vez que intentamos enviar el formulario, verificamos nuevamente si los datos son válidos. Si es así, dejamos que envíe el formulario. Si no, ejecutamos `showError()` para mostrar el error correspondiente y detenemos el envío del formulario con [`preventDefault()`](/es/docs/Web/API/Event/preventDefault).
-- La función `showError()` usa varias propiedades de la entrada `validity` para determinar cuál es el error y luego muestra un mensaje de error según corresponda.
+Cada vez que intentamos enviar el formulario, volvemos a comprobar si los datos son válidos. Si es así, permitimos que se envíe el formulario. Si no, ejecutamos `showError()` para mostrar el error correspondiente y detenemos el envío del formulario con [`preventDefault()`](/es/docs/Web/API/Event/preventDefault).
 
-Este es el resultado:
+La función `showError()` usa varias propiedades del objeto `validity` de la entrada para determinar cuál es el error y, a continuación, muestra el mensaje correspondiente.
 
-{{EmbedGHLiveSample("learning-area/html/forms/form-validation/detailed-custom-validation.html", '100%', 150)}}
+Este es el resultado en vivo (pulsa el botón **Play** para ejecutar el ejemplo en MDN Playground y editar el código fuente):
 
-> [!NOTE]
-> Puedes encontrar este ejemplo en vivo en GitHub como [detailed-custom-validation.html](https://mdn.github.io/learning-area/html/forms/form-validation/detailed-custom-validation.html) (consulta también su [código fuente](https://github.com/mdn/learning-area/blob/master/html/forms/form-validation/detailed-custom-validation.html)).
+```html hidden live-sample___detailed-custom-validation
+<form novalidate>
+  <p>
+    <label for="mail">
+      <span>Introduce una dirección de correo electrónico *:</span>
+      <input type="email" id="mail" name="mail" required minlength="8" />
+      <span class="error" aria-live="polite"></span>
+    </label>
+  </p>
+  <button>Enviar</button>
+</form>
+```
+
+```css hidden live-sample___detailed-custom-validation
+body {
+  font: 1em sans-serif;
+  width: 200px;
+  padding: 0;
+  margin: 0 auto;
+}
+p * {
+  display: block;
+}
+input[type="email"] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  border: 1px solid #333333;
+  margin: 0;
+  font-family: inherit;
+  font-size: 90%;
+  box-sizing: border-box;
+}
+input:invalid {
+  border-color: #990000;
+  background-color: #ffdddd;
+}
+input:focus:invalid {
+  outline: none;
+}
+.error {
+  width: 100%;
+  padding: 0;
+  font-size: 80%;
+  color: white;
+  background-color: #990000;
+  border-radius: 0 0 5px 5px;
+  box-sizing: border-box;
+}
+.error.active {
+  padding: 0.3em;
+}
+```
+
+```js hidden live-sample___detailed-custom-validation
+const form = document.getElementsByTagName("form")[0];
+const email = document.getElementById("mail");
+const emailError = document.querySelector("#mail + span.error");
+email.addEventListener("input", (event) => {
+  if (email.validity.valid) {
+    emailError.innerHTML = "";
+    emailError.className = "error";
+  } else {
+    showError();
+  }
+});
+form.addEventListener("submit", (event) => {
+  if (!email.validity.valid) {
+    showError();
+    event.preventDefault();
+  }
+});
+function showError() {
+  if (email.validity.valueMissing) {
+    emailError.textContent =
+      "Debes introducir una dirección de correo electrónico.";
+  } else if (email.validity.typeMismatch) {
+    emailError.textContent =
+      "El valor introducido debe ser una dirección de correo electrónico.";
+  } else if (email.validity.tooShort) {
+    emailError.textContent = `El correo electrónico debe tener al menos ${email.minLength} caracteres; has introducido ${email.value.length}.`;
+  }
+  emailError.className = "error active";
+}
+form.addEventListener("submit", (e) => {
+  e.preventDefault();
+});
+```
+
+{{EmbedLiveSample("detailed-custom-validation", "100%", 150, , , , , "allow-forms")}}
 
 La API de validación de restricciones te proporciona una herramienta poderosa para manejar la validación de formularios, y te permite tener un control enorme sobre la interfaz de usuario más allá de lo que puedas hacer solo con HTML y CSS.
 
-> [!NOTE]
-> Para obtener más información, consulta nuestra [guía de validación de restricciones](/es/docs/HTML/HTML5/Validacion_de_restricciones) y la referencia de [API de validación de restricciones](/es/docs/Learn_web_development/Extensions/Forms/Form_validation).
-
 ### Validar formularios sin una API incorporada
 
-En algunos casos, como la compatibilidad heredada del navegador o los [controles personalizados](/es/docs/Learn_web_development/Extensions/Forms/How_to_build_custom_form_controls), no podrás o no querrás usar la API de validación de restricciones. Todavía puedes usar JavaScript para validar tu formulario, pero vas a tener que escribirlo.
+En algunos casos, como los [controles personalizados](/es/docs/Learn_web_development/Extensions/Forms/How_to_build_custom_form_controls), no podrás o no querrás usar la API de validación de restricciones. Aun así puedes usar JavaScript para validar el formulario, pero tendrás que escribir la validación tú mismo.
 
 Antes de validar el formulario, hazte estas preguntas:
 
@@ -632,14 +809,13 @@ Antes de validar el formulario, hazte estas preguntas:
   - : Esto es claramente un problema de la interfaz de usuario. Tienes que decidir cómo se comportará el formulario. ¿El formulario va a enviar los datos de todos modos? ¿Deberías resaltar los campos que dan error? ¿Deberías mostrar mensajes de error?
 - ¿Cómo puedo ayudar al usuario a corregir datos no válidos?
   - : Para reducir la frustración del usuario, es muy importante proporcionar tanta información útil como sea posible para guiarlo a fin de que corrija sus entradas de datos. Debes ofrecer sugerencias por adelantado para que sepan lo que se espera de ellos, así como mensajes de error claros. Si deseas profundizar en los requisitos de interfaz de usuario para la validación de formularios, aquí hay algunos artículos útiles que debes leer:
-    - SmashingMagazine: [Validación de campo de formulario: El enfoque de solo errores](http://uxdesign.smashingmagazine.com/2012/06/27/form-field-validation-errors-only-approach/)
-    - SmashingMagazine: [Validación de formularios web: Buenas prácticas y tutoriales](http://www.smashingmagazine.com/2009/07/07/web-form-validation-best-practices-and-tutorials/)
-    - Six Revision: [Buenas prácticas para sugerencias y validación de formularios web](http://sixrevisions.com/user-interface/best-practices-for-hints-and-validation-in-web-forms/)
-    - A List Apart: [Validación en línea de formularios web](https://www.alistapart.com/articles/inline-validation-in-web-forms/)
+    - [Ayuda a los usuarios a introducir los datos correctos en los formularios](https://web.dev/learn/forms/form-fields)
+    - [Validar entradas](https://www.w3.org/WAI/tutorials/forms/validation/)
+    - [Cómo informar de errores en formularios: 10 pautas de diseño](https://www.nngroup.com/articles/errors-forms-design-guidelines/)
 
 #### Un ejemplo que no usa la API de validación de restricciones
 
-Para ilustrar esto, mostramos una versión simplificada del ejemplo anterior que funciona con navegadores con compatibilidad heredada.
+Para ilustrarlo, a continuación se muestra una versión simplificada del ejemplo anterior sin la API de validación de restricciones.
 
 El HTML es casi el mismo; solo hemos eliminado las funciones de validación de HTML.
 
@@ -647,18 +823,16 @@ El HTML es casi el mismo; solo hemos eliminado las funciones de validación de H
 <form>
   <p>
     <label for="mail">
-      <span>Por favor, introduzca una dirección de correo electrónico: </span>
-      <input type="text" class="mail" id="mail" name="mail" />
-      <span class="error" aria-live="polite"></span>
+      <span>Introduce una dirección de correo electrónico:</span>
     </label>
+    <input type="text" id="mail" name="mail" />
+    <span id="error" aria-live="polite"></span>
   </p>
-  <!-- Algunos navegadores con compatibilidad heredada deben tener el atributo «type»
-       establecido explícitamente en el elemento «button» de «submit»-->
-  <button type="submit">Enviar</button>
+  <button>Enviar</button>
 </form>
 ```
 
-Del mismo modo, no es necesario cambiar mucho el CSS; acabamos de convertir la pseudoclase {{cssxref(":invalid")}} de CSS en una clase real y evitamos usar el selector de atributos que no funciona en Internet Explorer 6.
+Del mismo modo, el CSS no necesita cambiar mucho; simplemente convertimos la pseudoclase CSS {{cssxref(":invalid")}} en una clase real y evitamos usar el selector de atributos.
 
 ```css
 body {
@@ -676,11 +850,10 @@ p * {
   display: block;
 }
 
-input.mail {
-  -webkit-appearance: none;
-
+input {
+  appearance: none;
   width: 100%;
-  border: 1px solid #333;
+  border: 1px solid #333333;
   margin: 0;
 
   font-family: inherit;
@@ -689,134 +862,104 @@ input.mail {
   box-sizing: border-box;
 }
 
-/* Este es nuestro diseño para los campos no válidos */
+/* Campos no válidos */
 input.invalid {
-  border-color: #900;
-  background-color: #fdd;
+  border: 2px solid #990000;
+  background-color: #ffdddd;
 }
 
 input:focus.invalid {
   outline: none;
+  /* Asegura que quienes usan solo teclado vean un cambio al enfocar */
+  border-style: dashed;
 }
 
-/* Este es el diseño para nuestros mensajes de error */
-.error {
+/* Mensajes de error */
+#error {
   width: 100%;
-  padding: 0;
-
   font-size: 80%;
   color: white;
-  background-color: #900;
+  background-color: #990000;
   border-radius: 0 0 5px 5px;
   box-sizing: border-box;
 }
 
-.error.active {
-  padding: 0.3em;
+.active {
+  padding: 0.3rem;
 }
 ```
 
 Los grandes cambios están en el código JavaScript, que necesita hacer mucho más trabajo pesado.
 
 ```js
-// Hay menos formas de elegir un nodo DOM con navegadores antiguos
-const form = document.getElementsByTagName("form")[0];
+const form = document.querySelector("form");
 const email = document.getElementById("mail");
+const error = document.getElementById("error");
 
-// Lo siguiente es un truco para llegar al siguiente nodo de elementos hermanos en el DOM
-// Esto es peligroso porque puedes construir fácilmente un bucle infinito.
-// En los navegadores modernos es mejor usar element.nextElementSibling
-let error = email;
-while ((error = error.nextSibling).nodeType != 1);
+// Expresión regular para validar correo electrónico según la especificación HTML
+const emailRegExp = /^[\w.!#$%&'*+/=?^`{|}~-]+@[a-z\d-]+(?:\.[a-z\d-]+)*$/i;
 
-// según la especificación HTML5
-const emailRegExp =
-  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+// Comprueba si el correo electrónico es válido
+const isValidEmail = () => {
+  const validity = email.value.length !== 0 && emailRegExp.test(email.value);
+  return validity;
+};
 
-// Muchos navegadores antiguos no son compatibles con el método addEventListener.
-// Aquí hay una manera simple de manejar esto; está lejos de ser la única.
-function addEvent(element, event, callback) {
-  let previousEventCallBack = element["on" + event];
-  element["on" + event] = function (e) {
-    const output = callback(e);
+// Actualiza la clase de la entrada de correo según su validez
+const setEmailClass = (isValid) => {
+  email.className = isValid ? "valid" : "invalid";
+};
 
-    // Una devolución de llamada que devuelve «false» detiene la cadena de devolución de llamada
-    // e interrumpe la ejecución de la devolución de llamada del evento.
-    if (output === false) return false;
-
-    if (typeof previousEventCallBack === "function") {
-      output = previousEventCallBack(e);
-      if (output === false) return false;
-    }
-  };
-}
-
-// Ahora podemos reconstruir nuestra restricción de validación
-// Debido a que no confiamos en la pseudoclase de CSS, tenemos que
-// establecer explícitamente la clase valid/invalid en nuestro campo de correo electrónico
-addEvent(window, "load", function () {
-  // Aquí probamos si el campo está vacío (recuerda, el campo no es obligatorio)
-  // Si no es así, verificamos si su contenido es una dirección de correo electrónico con el formato correcto.
-  const test = email.value.length === 0 || emailRegExp.test(email.value);
-
-  email.className = test ? "valid" : "invalid";
-});
-
-// Esto define lo que sucede cuando el usuario escribe en el campo
-addEvent(email, "input", function () {
-  const test = email.value.length === 0 || emailRegExp.test(email.value);
-  if (test) {
-    email.className = "valid";
-    error.innerHTML = "";
-    error.className = "error";
+// Actualiza el mensaje de error y su visibilidad
+const updateError = (isValid) => {
+  if (isValid) {
+    error.textContent = "";
+    error.removeAttribute("class");
   } else {
-    email.className = "invalid";
+    error.textContent = "Espero una dirección de correo electrónico.";
+    error.setAttribute("class", "active");
   }
-});
+};
 
-// Esto define lo que sucede cuando el usuario intenta enviar los datos.
-addEvent(form, "submit", function () {
-  const test = email.value.length === 0 || emailRegExp.test(email.value);
+// Gestiona el evento de entrada para actualizar la validez del correo
+const handleInput = () => {
+  const validity = isValidEmail();
+  setEmailClass(validity);
+  updateError(validity);
+};
 
-  if (!test) {
-    email.className = "invalid";
-    error.innerHTML = "Espero un correo electrónico, querido!";
-    error.className = "error active";
+// Gestiona el envío del formulario y muestra un error si el correo no es válido
+const handleSubmit = (event) => {
+  event.preventDefault();
 
-    // Algunos navegadores antiguos no son compatibles con el método event.preventDefault ()
-    return false;
-  } else {
-    email.className = "valid";
-    error.innerHTML = "";
-    error.className = "error";
-  }
-});
+  const validity = isValidEmail();
+  setEmailClass(validity);
+  updateError(validity);
+};
+
+// Ahora podemos reconstruir nuestra restricción de validación.
+// Como no usamos una pseudoclase CSS, tenemos que establecer explícitamente
+// la clase valid/invalid del campo de correo electrónico.
+const validity = isValidEmail();
+setEmailClass(validity);
+email.addEventListener("input", handleInput);
+form.addEventListener("submit", handleSubmit);
 ```
 
 El resultado es el siguiente:
 
-{{EmbedLiveSample("Validar_formularios_sin_una_API_incorporada", "100%", 130)}}
+{{EmbedLiveSample("An_example_that_doesnt_use_the_constraint_validation_API", "100%", 150)}}
 
-Como puedes ver, no es tan difícil construir un sistema de validación por tu cuenta. La parte difícil es hacer que sea lo suficientemente genérico para que se pueda usar en diferentes plataformas y en cualquier forma. Hay muchas bibliotecas de archivos disponibles para realizar la validación de formularios, como por ejemplo [Validate.js](http://rickharrison.github.com/validate.js/).
-
-## Prueba tus habilidades!
-
-Has llegado al final de este artículo pero ¿puedes recordar la información más importante?Puedes encontrar pruebas adicionales para comprovar que has comprendido la información antes de que continue — visita [Prueba tus habilidades: Validación de formularios](/es/docs/Learn_web_development/Extensions/Forms).
+Como puedes ver, no es tan difícil crear por tu cuenta un sistema de validación. La parte difícil es hacerlo lo suficientemente genérico para usarlo en distintas plataformas y en cualquier formulario que puedas crear. Hay muchas bibliotecas disponibles para realizar la validación de formularios, como [Validate.js](https://rickharrison.github.io/validate.js/).
 
 ## Resumen
 
-La validación de formularios en el lado del cliente a veces requiere JavaScript si deseas personalizar el estilo y los mensajes de error, pero _siempre_ requiere que pienses cuidadosamente en el usuario. Recuerda que siempre debes ayudar a tus usuarios a corregir los datos que proporcionan. Para ese fin, asegúrate de:
+La validación de formularios en el lado del cliente a veces requiere JavaScript si quieres personalizar los estilos y los mensajes de error, pero _siempre_ exige que pienses cuidadosamente en el usuario. Recuerda siempre ayudar a los usuarios a corregir los datos que proporcionan. Para ello, asegúrate de:
 
 - Mostrar mensajes de error explícitos.
-- Ser permisivo con el formato de entrada.
-- Señalar exactamente dónde se produce el error, especialmente en formularios extensos.
+- Ser flexible con el formato de entrada.
+- Señalar exactamente dónde se produce el error, especialmente en formularios grandes.
 
-Una vez que hayas verificado que el formulario se ha completado correctamente, puedes proceder a enviarlo. Vamos a exponer el [envío de los datos del formulario](/es/docs/Learn_web_development/Extensions/Forms/Sending_and_retrieving_form_data) en el próximo artículo.
+Una vez que hayas comprobado que el formulario se ha rellenado correctamente, puedes enviarlo. A continuación veremos el [envío de datos de formularios](/es/docs/Learn_web_development/Extensions/Forms/Sending_and_retrieving_form_data).
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Forms/UI_pseudo-classes", "Learn_web_development/Extensions/Forms/Sending_and_retrieving_form_data", "Learn_web_development/Extensions/Forms")}}
-
-### Temas avanzados
-
-- [Cómo construir controles de formulario personalizados](/es/docs/Learn_web_development/Extensions/Forms/How_to_build_custom_form_controls)
-- [Enviar formularios por JavaScript](/es/docs/Learn/Forms/Sending_forms_through_JavaScript)
-- [Tabla de compatibilidad de propiedades para controles de formulario](/es/docs/Learn_web_development/Extensions/Forms)

--- a/files/es/learn_web_development/extensions/forms/form_validation/index.md
+++ b/files/es/learn_web_development/extensions/forms/form_validation/index.md
@@ -82,7 +82,7 @@ Una de las características más importantes de los [controles de formulario](/e
 - [`required`](/es/docs/Web/HTML/Reference/Attributes/required): Especifica si un campo de formulario debe rellenarse antes de que se pueda enviar el formulario.
 - [`minlength`](/es/docs/Web/HTML/Reference/Attributes/minlength) y [`maxlength`](/es/docs/Web/HTML/Reference/Attributes/maxlength): Especifican la longitud mínima y máxima de los datos de texto (cadenas).
 - [`min`](/es/docs/Web/HTML/Reference/Attributes/min), [`max`](/es/docs/Web/HTML/Reference/Attributes/max) y [`step`](/es/docs/Web/HTML/Reference/Attributes/step): Especifican los valores mínimo y máximo de los tipos de entrada numéricos y el incremento o paso de los valores, a partir del mínimo.
-- [`type`](/es/docs/Web/HTML/Reference/Elements/input): Especifica si los datos deben ser un número, una dirección de correo electrónico u otro tipo predefinido específico.
+- [`type`](/es/docs/Web/HTML/Reference/Elements/input#tipos_de_input): Especifica si los datos deben ser un número, una dirección de correo electrónico u otro tipo predefinido específico.
 - [`pattern`](/es/docs/Web/HTML/Reference/Attributes/pattern): Especifica una [expresión regular](/es/docs/Web/JavaScript/Guide/Regular_expressions) que define un patrón que deben seguir los datos introducidos.
 
 Si los datos introducidos en un campo de formulario siguen todas las reglas especificadas por los atributos aplicados al campo, se consideran válidos. De lo contrario, se consideran no válidos.


### PR DESCRIPTION
## Resumen

Sincroniza la página en español **Validación de formularios en el lado del cliente** con la versión más reciente de la fuente en inglés.

Esta actualización:

- sincroniza la estructura y el contenido con el documento actual en inglés
- añade y actualiza `l10n.sourceCommit`
- elimina front matter obsoleto y secciones desactualizadas
- añade secciones faltantes y actualiza el contenido de la API de validación de restricciones
- actualiza los enlaces internos de MDN para usar `/es/`
- sincroniza los ejemplos de código con la fuente inglesa actual
- actualiza recursos externos obsoletos
- corrige traducciones y redacciones desactualizadas a lo largo del documento
- resuelve la inconsistencia del ejemplo de validación de frutas al sincronizar los valores del `datalist` y el `pattern` con la fuente inglesa

Esta sincronización también resuelve el problema de validación reportado en #38268, donde los valores de frutas traducidos en el `datalist` no coincidían con los valores en inglés aceptados por el `pattern`.

Fixes #37281  
Fixes #38268
