### PR TITLE
chore(fr): remove remnent `XsltSidebar` macros

### DIFF
--- a/files/fr/web/xml/xpath/guides/comparison_with_css_selectors/index.md
+++ b/files/fr/web/xml/xpath/guides/comparison_with_css_selectors/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Guides/Comparison_with_CSS_selectors
 original_slug: Web/XPath/Comparison_with_CSS_selectors
 ---
 
-{{XsltSidebar}}
-
 Dans cet article, nous listerons les différences entre les sélecteurs CSS et les fonctionnalités XPath afin que les développeurs web puissent choisir l'outil le plus pertinent.
 
 | [Fonctionnalité XPath](/fr/docs/Web/XML/XPath)                                                                                                                                                               | [Équivalent CSS](/fr/docs/Web/CSS/Guides/Selectors)                                                                                                                                             |

--- a/files/fr/web/xml/xpath/guides/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/fr/web/xml/xpath/guides/introduction_to_using_xpath_in_javascript/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Guides/Introduction_to_using_XPath_in_JavaScript
 original_slug: Web/XPath/Introduction_to_using_XPath_in_JavaScript
 ---
 
-{{XsltSidebar}}
-
 Ce document décrit l'interface pour utiliser [XPath](/fr/docs/Web/XML/XPath) dans JavaScript, que ce soit en interne, dans les extensions et depuis les sites Web. Mozilla implémente une partie importante de [DOM 3 XPath (en)](https://www.w3.org/TR/2004/NOTE-DOM-Level-3-XPath-20040226/). Cela signifie que les expressions XPath peuvent être utilisées sur des documents HTML et XML.
 
 La principale interface pour l'utilisation de XPath est la fonction [`evaluate()`](/fr/docs/Web/API/Document/evaluate) de l'objet [`document`](/fr/docs/Web/API/Document).

--- a/files/fr/web/xml/xpath/reference/axes/index.md
+++ b/files/fr/web/xml/xpath/reference/axes/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Axes
 original_slug: Web/XPath/Axes
 ---
 
-{{XsltSidebar}}
-
 Il existe treize axes différents dans la spécification [XPath](XPath). Un axe représente une relation au nœud de contexte, et il est utilisé pour situer dans l'arbre les autres nœuds par rapport à celui-ci. La liste suivante présente très brièvement les treize axes disponibles et le niveau de leur support dans [Gecko](Gecko).
 
 Pour plus d'informations sur l'utilisation des expressions XPath, veuillez vous reportez à la section [Autres ressources](Transformations_XML_avec_XSLT/Autres_ressources) à la fin du document [Transformations XML avec XSLT](Transformations_XML_avec_XSLT).

--- a/files/fr/web/xml/xpath/reference/functions/boolean/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/boolean/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/boolean
 original_slug: Web/XPath/Functions/boolean
 ---
 
-{{XsltSidebar}}
-
 la fonction `boolean` évalue une expression et retourne `true` ou `false`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/ceiling/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/ceiling/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/ceiling
 original_slug: Web/XPath/Functions/ceiling
 ---
 
-{{XsltSidebar}}
-
 La fonction `ceiling` évalue un nombre décimal et retourne le plus petit nombre entier supérieur ou égal au nombre évalué.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/concat/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/concat/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/concat
 original_slug: Web/XPath/Functions/concat
 ---
 
-{{XsltSidebar}}
-
 La fonction `concat` concatène deux ou plusieurs chaînes et retourne la chaîne résultante.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/contains/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/contains/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/contains
 original_slug: Web/XPath/Functions/contains
 ---
 
-{{XsltSidebar}}
-
 La fonction `contains` détermine si la chaîne passée en premier argument contient la chaîne passée en second argument et retourne le booléen `true` ou `false`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/count/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/count/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/count
 original_slug: Web/XPath/Functions/count
 ---
 
-{{XsltSidebar}}
-
 La fonction `count` compte le nombre de nœuds dans un ensemble de nœuds et retourne un entier.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/current/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/current/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/current
 original_slug: Web/XPath/Functions/current
 ---
 
-{{XsltSidebar}}
-
 La fonction `current` peut être utilisée pour obtenir le nœud courant dans une instruction XSLT.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/document/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/document/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/document
 original_slug: Web/XPath/Functions/document
 ---
 
-{{XsltSidebar}}
-
 La fonction `document` recherche un ensemble de nœuds dans un ou des documents externes et retourne l'ensemble de nœuds résultant.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/element-available/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/element-available/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/element-available
 original_slug: Web/XPath/Functions/element-available
 ---
 
-{{XsltSidebar}}
-
 La fonction `element-available` détermine si un élément est disponible et retourne la valeur booléenne `true` ou `false`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/false/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/false/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/false
 original_slug: Web/XPath/Functions/false
 ---
 
-{{XsltSidebar}}
-
 La fonction `false` retourne le booléen `false`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/floor/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/floor/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/floor
 original_slug: Web/XPath/Functions/floor
 ---
 
-{{XsltSidebar}}
-
 La fonction `floor` évalue un nombre décimal et retourne le plus grand nombre entier inférieur ou égal au nombre évalué.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/format-number/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/format-number/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/format-number
 original_slug: Web/XPath/Functions/format-number
 ---
 
-{{XsltSidebar}}
-
 La fonction `format-number` évalue un nombre et retourne une chaîne représentant le nombre dans un format donné.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/function-available/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/function-available/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/function-available
 original_slug: Web/XPath/Functions/function-available
 ---
 
-{{XsltSidebar}}
-
 La fonction `function-available` détermine si une fonction donnée est disponible et retourne le booléen `true` ou `false`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/generate-id/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/generate-id/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/generate-id
 original_slug: Web/XPath/Functions/generate-id
 ---
 
-{{XsltSidebar}}
-
 La fonction `generate-id` génère un identifiant `id` unique pour le premier nœud d'un ensemble de nœuds donné et retourne une chaîne contenant cet `id`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/id/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/id/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/id
 original_slug: Web/XPath/Functions/id
 ---
 
-{{XsltSidebar}}
-
 La fonction `id` recherche les nœuds correspondant aux identifiants `id` donnés et retourne un ensemble de nœuds contenant les nœuds identifiés.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions
 original_slug: Web/XPath/Functions
 ---
 
-{{XsltSidebar}}
-
 La liste ci-dessous regroupe les principales fonctions de [XPath](/fr/docs/Web/XML/XPath) et les ajouts à XPath qui sont spécifiques à [XSLT](/fr/docs/Web/XML/XSLT). Chaque lien fournit pour la fonction correspondante description, syntaxe, liste d'arguments, types de résultats, description originelle dans les recommandations du W3C, et niveau de support actuel dans [Gecko](/fr/docs/Web_Gecko). Pour plus d'informations sur l'utilisation des fonctions XPath/XSLT, reportez-vous à la page [Autres ressources](/fr/docs/Web/XML/XSLT/Guides/Transforming_XML_with_XSLT).
 
 - [boolean()](Fonctions/boolean)

--- a/files/fr/web/xml/xpath/reference/functions/key/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/key/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/key
 original_slug: Web/XPath/Functions/key
 ---
 
-{{XsltSidebar}}
-
 La fonction `key` retourne un ensemble de nœuds ayant la valeur donnée pour la clef donnée.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/lang/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/lang/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/lang
 original_slug: Web/XPath/Functions/lang
 ---
 
-{{XsltSidebar}}
-
 La fonction `lang` détermine si le nœud de contexte correspond à la langue indiquée et retourne le booléen `true` ou `false`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/last/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/last/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/last
 original_slug: Web/XPath/Functions/last
 ---
 
-{{XsltSidebar}}
-
 La fonction `last` retourne un nombre égal à la taille du contexte dans le contexte d'évaluation d'expression.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/local-name/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/local-name/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/local-name
 original_slug: Web/XPath/Functions/local-name
 ---
 
-{{XsltSidebar}}
-
 La fonction `local-name` retourne une chaîne représentant le nom local du premier nœud d'un ensemble de nœuds donné.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/name/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/name/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/name
 original_slug: Web/XPath/Functions/name
 ---
 
-{{XsltSidebar}}
-
 La fonction `name` retourne une chaîne représentant le QName du premier nœud d'un ensemble de nœuds donné.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/namespace-uri/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/namespace-uri/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/namespace-uri
 original_slug: Web/XPath/Functions/namespace-uri
 ---
 
-{{XsltSidebar}}
-
 La fonction `namespace-uri` retourne une chaîne représentant l'URI de l'espace de nommage du premier nœud d'un ensemble de nœuds donné.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/normalize-space/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/normalize-space/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/normalize-space
 original_slug: Web/XPath/Functions/normalize-space
 ---
 
-{{XsltSidebar}}
-
 La fonction `normalize-space` supprime les espaces de début et de fin d'une chaîne et remplace les successions d'espaces par une seule puis retourne la chaîne résultante.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/not/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/not/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/not
 original_slug: Web/XPath/Functions/not
 ---
 
-{{XsltSidebar}}
-
 La fonction `not` évalue une expression booléenne et retourne la valeur opposée.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/number/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/number/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/number
 original_slug: Web/XPath/Functions/number
 ---
 
-{{XsltSidebar}}
-
 La fonction `number` convertit un objet en un nombre et retourne ce nombre.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/position/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/position/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/position
 original_slug: Web/XPath/Functions/position
 ---
 
-{{XsltSidebar}}
-
 La fonction `position` retourne un nombre égal à la position du contexte dans le contexte d'évaluation d'expression.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/round/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/round/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/round
 original_slug: Web/XPath/Functions/round
 ---
 
-{{XsltSidebar}}
-
 La fonction `round` retourne le nombre entier le plus proche d'un nombre donné.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/starts-with/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/starts-with/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/starts-with
 original_slug: Web/XPath/Functions/starts-with
 ---
 
-{{XsltSidebar}}
-
 La fonction `starts-with` vérifie si la première chaîne débute par la seconde, et retourne `true` ou `false`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/string-length/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/string-length/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/string-length
 original_slug: Web/XPath/Functions/string-length
 ---
 
-{{XsltSidebar}}
-
 La fonction `string-length` retourne le nombre de caractères dans une chaîne donnée.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/string/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/string/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/string
 original_slug: Web/XPath/Functions/string
 ---
 
-{{XsltSidebar}}
-
 La fonction `string` convertit l'argument passé en une chaîne.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/substring-after/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/substring-after/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/substring-after
 original_slug: Web/XPath/Functions/substring-after
 ---
 
-{{XsltSidebar}}
-
 La fonction `substring-after()` retourne la partie d'une chaîne donnée suivant une sous-chaîne donnée.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/substring-before/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/substring-before/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/substring-before
 original_slug: Web/XPath/Functions/substring-before
 ---
 
-{{XsltSidebar}}
-
 La fonction `substring-before()` retourne retourne la partie d'une chaîne donnée précédant une sous-chaîne donnée.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/substring/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/substring/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/substring
 original_slug: Web/XPath/Functions/substring
 ---
 
-{{XsltSidebar}}
-
 La fonction `substring` retourne une partie d'une chaîne donnée.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/sum/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/sum/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/sum
 original_slug: Web/XPath/Functions/sum
 ---
 
-{{XsltSidebar}}
-
 La fonction `sum` retourne un nombre qui est la somme des valeurs numériques de chaque nœud d'un ensemble de nœuds donné.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/system-property/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/system-property/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/system-property
 original_slug: Web/XPath/Functions/system-property
 ---
 
-{{XsltSidebar}}
-
 La fonction `system-property()` retourne un objet représentant la propriété système donnée.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/translate/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/translate/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/translate
 original_slug: Web/XPath/Functions/translate
 ---
 
-{{XsltSidebar}}
-
 La fonction `translate` évalue une chaîne et un ensemble de caractères à traduire, et retourne la chaîne traduite.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/true/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/true/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/true
 original_slug: Web/XPath/Functions/true
 ---
 
-{{XsltSidebar}}
-
 La fonction `true` retourne la valeur booléenne `true`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xpath/reference/functions/unparsed-entity-url/index.md
+++ b/files/fr/web/xml/xpath/reference/functions/unparsed-entity-url/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XPath/Reference/Functions/unparsed-entity-url
 original_slug: Web/XPath/Functions/unparsed-entity-url
 ---
 
-{{XsltSidebar}}
-
 La fonction `unparsed-entity-url()` retourne l'URI d'une entité non analysée avec le nom donné. C'est une donnée non-XML référencée dans le DTD du document source.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/guides/pi_parameters/index.md
+++ b/files/fr/web/xml/xslt/guides/pi_parameters/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Guides/PI_Parameters
 original_slug: Web/XSLT/PI_Parameters
 ---
 
-{{XsltSidebar}}
-
 ### Présentation
 
 XSLT permet de passer des paramètres à une feuille de style lors de son exécution. C'était déjà possible depuis quelques temps dans l'[XSLTProcessor](/fr/XSLTProcessor) sous JavaScript, mais pas lors de l'utilisation de l'instruction de traitement (_PI_, pour Processing Instruction) `<?xml-stylesheet?>`.

--- a/files/fr/web/xml/xslt/guides/transforming_xml_with_xslt/index.md
+++ b/files/fr/web/xml/xslt/guides/transforming_xml_with_xslt/index.md
@@ -6,8 +6,6 @@ l10n:
   sourceCommit: e14e4830bcd43de164623aaf787fbd695be31d91
 ---
 
-{{XsltSidebar}}
-
 [Transformations XML avec XSLT](/fr/docs/Web/XML/XSLT/Guides/Transforming_XML_with_XSLT)
 
 ## Publications

--- a/files/fr/web/xml/xslt/reference/element/apply-imports/index.md
+++ b/files/fr/web/xml/xslt/reference/element/apply-imports/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/apply-imports
 original_slug: Web/XSLT/Element/apply-imports
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:apply-imports>`, utilisé la plupart du temps dans les feuilles de styles complexes, est assez mystérieux. Les règles de priorité de l'importation imposent que les règles de modèles des feuilles de styles principales aient une priorité supérieure aux règles de modèles des feuilles de styles importées. Cependant, il est parfois utile de forcer le processeur à utiliser une règle de modèle de la feuille de styles importée (de priorité plus basse) plutôt que la règle équivalente de la feuille de styles principale.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/apply-templates/index.md
+++ b/files/fr/web/xml/xslt/reference/element/apply-templates/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/apply-templates
 original_slug: Web/XSLT/Element/apply-templates
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:apply-templates>` sélectionne un ensemble de nœuds dans l'arbre d'entrée et demande au processeur de leur appliquer les modèles appropriés.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/attribute-set/index.md
+++ b/files/fr/web/xml/xslt/reference/element/attribute-set/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/attribute-set
 original_slug: Web/XSLT/Element/attribute-set
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:attribute-set>` crée un ensemble nommé d'attributs, qui peut être appliqué dans son intégralité au document de sortie, de façon similaire aux styles CSS nommés.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/attribute/index.md
+++ b/files/fr/web/xml/xslt/reference/element/attribute/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/attribute
 original_slug: Web/XSLT/Element/attribute
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:attribute>` crée un attribut dans le document de sortie, en utilisant n'importe quelle donnée accessible depuis la feuille de styles. L'élément **doit** être la première chose définie dans l'élément du document de sortie pour lequel il détermine les valeurs d'attributs.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/call-template/index.md
+++ b/files/fr/web/xml/xslt/reference/element/call-template/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/call-template
 original_slug: Web/XSLT/Element/call-template
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:call-template>` invoque un modèle nommé.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/choose/index.md
+++ b/files/fr/web/xml/xslt/reference/element/choose/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/choose
 original_slug: Web/XSLT/Element/choose
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:choose>` définit un choix parmi un certain nombre d'alternatives. Il se comporte comme l'instruction switch d'un langage procédural.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/comment/index.md
+++ b/files/fr/web/xml/xslt/reference/element/comment/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/comment
 original_slug: Web/XSLT/Element/comment
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:comment>` écrit un commentaire dans le document de sortie. Il ne doit contenir que du texte.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/copy-of/index.md
+++ b/files/fr/web/xml/xslt/reference/element/copy-of/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/copy-of
 original_slug: Web/XSLT/Element/copy-of
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:copy-of>` fait une copie complète dans le document de sortie (incluant les nœuds enfants) de tout ce que l'élément sélectionné spécifie.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/copy/index.md
+++ b/files/fr/web/xml/xslt/reference/element/copy/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/copy
 original_slug: Web/XSLT/Element/copy
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:copy>` transfert une copie limitée (le nœud et tous les nœuds d'espace de nommage associés) du nœud courant vers le document de sortie. Il ne copie aucun enfant ni attribut du nœud courant.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/decimal-format/index.md
+++ b/files/fr/web/xml/xslt/reference/element/decimal-format/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/decimal-format
 original_slug: Web/XSLT/Element/decimal-format
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:decimal-format>` définit les caractères et symboles à utiliser lors de la conversion de nombres en chaînes à l'aide de la fonction `format-number( )`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/element/index.md
+++ b/files/fr/web/xml/xslt/reference/element/element/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/element
 original_slug: Web/XSLT/Element/element
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:element>` crée un élément dans le document de sortie.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/fallback/index.md
+++ b/files/fr/web/xml/xslt/reference/element/fallback/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/fallback
 original_slug: Web/XSLT/Element/fallback
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:fallback>` définit le modèle à utiliser si un élément d'extension donné (ou, éventuellement, une nouvelle version) n'est pas supporté.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/for-each/index.md
+++ b/files/fr/web/xml/xslt/reference/element/for-each/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/for-each
 original_slug: Web/XSLT/Element/for-each
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:for-each>` sélectionne un ensemble de nœuds et traite chacun d'eux de la même façon. Il est souvent utilisé pour des itérations sur un ensemble de nœuds ou pour changer le nœud courant. Si un ou plusieurs éléments `<xsl:sort>` apparaissent comme enfants de cet élément, le tri est effectué avant le traitement. Autrement, les nœuds sont traités dans l'ordre d'apparition dans le document.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/if/index.md
+++ b/files/fr/web/xml/xslt/reference/element/if/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/if
 original_slug: Web/XSLT/Element/if
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:if>` regroupe un attribut test et un modèle. Si le test renvoie `true`, le modèle est appliqué. En cela, il est très semblable à l'instruction `if` d'autres langages. Cependant, pour simuler un `if-then-else`, vous devrez utilisez l'élément `<xsl:choose>` avec un descendant `<xsl:when>` et un `<xsl:otherwise>`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/import/index.md
+++ b/files/fr/web/xml/xslt/reference/element/import/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/import
 original_slug: Web/XSLT/Element/import
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:import>` est un élément de haut niveau qui sert à importer le contenu d'une feuille de styles dans une autre. Généralement, le contenu importé a une priorité inférieure à celui de la feuille qui effectue l'importation. Ceci contraste avec [\<xsl:include>](/fr/docs/Web/XML/XSLT/Reference/Element/include) où les contenus des deux feuilles ont exactement la même priorité.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/include/index.md
+++ b/files/fr/web/xml/xslt/reference/element/include/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/include
 original_slug: Web/XSLT/Element/include
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:include>` fusionne les contenus de deux feuilles de styles. Contrairement à l'élément [\<xsl:import>](/fr/XSLT/import), les contenus des deux feuilles de styles fusionnées ont la même priorité.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/index.md
+++ b/files/fr/web/xml/xslt/reference/element/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element
 original_slug: Web/XSLT/Element
 ---
 
-{{XsltSidebar}}
-
 Ce document traite de deux types d'éléments&nbsp;: les éléments de haut niveau, et les instructions. Un élément de haut niveau doit toujours apparaître en tant qu'enfant de `<xsl:stylesheet>` ou de `<xsl:transform>`. Une instruction, de son côté, est associée à un modèle. Une feuille de style peut comporter plusieurs modèles. Un troisième type d'élément, que nous n'aborderons pas ici, est le «&nbsp;Literal Result Element (LRE)&nbsp;». Un LRE appartient également à un modèle. Le terme regroupe tout ce qui n'est pas une instruction et qui doit être recopié tel-quel dans le document de sortie, par exemple, un élément `<hr>` dans feuille de style de conversion HTML.
 
 A ce propos, tous les attributs d'un LRE et certains attributs d'un nombre limité d'éléments XSLT peuvent inclure ce que l'on appelle un modèle de valeur d'attribut. Un modèle de valeur d'attribut est simplement une chaîne qui intègre une expression XPath utilisée pour spécifier la valeur de l'attribut. Lors de l'exécution, l'expression est évaluée et le résultat de cette évaluation est substitué à l'expression XPath. Par exemple, considérons que variable «&nbsp;`image-dir`&nbsp;» est définie comme ci-dessous&nbsp;:

--- a/files/fr/web/xml/xslt/reference/element/key/index.md
+++ b/files/fr/web/xml/xslt/reference/element/key/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/key
 original_slug: Web/XSLT/Element/key
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:key>` déclare une clef nommée qui peut être utilisée dans toute la feuille de styles à l'aide de la fonction `key( )`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/message/index.md
+++ b/files/fr/web/xml/xslt/reference/element/message/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/message
 original_slug: Web/XSLT/Element/message
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:message>` écrit un message de sortie (dans la console JavaScript) et, éventuellement, met fin à l'exécution de la feuille de styles. Il peut être utile pour le débogage.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/namespace-alias/index.md
+++ b/files/fr/web/xml/xslt/reference/element/namespace-alias/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/namespace-alias
 original_slug: Web/XSLT/Element/namespace-alias
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:namespace-alias>` est un dispositif rarement utilisé qui établit une équivalence entre un espace de nommage d'une feuille de styles et un espace de nommage différent dans l'arbre de sortie. L'utilisation la plus courante de cet élément est la génération d'une feuille de styles depuis une autre feuille de styles. Pour éviter qu'un élément résultat correctement préfixé par `xsl:` (qui doit être copié tel quel dans l'arbre résultant) soit interprêté à tort par le processeur, il lui est assigné un espace de nommage temporaire qui est convenablement reconverti en l'espace de nommage XSLT dans l'arbre de sortie.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/number/index.md
+++ b/files/fr/web/xml/xslt/reference/element/number/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/number
 original_slug: Web/XSLT/Element/number
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:number>` compte des éléments de façon séquentielle. Il peut également être utilisé
 pour formater rapidement un nombre.
 

--- a/files/fr/web/xml/xslt/reference/element/otherwise/index.md
+++ b/files/fr/web/xml/xslt/reference/element/otherwise/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/otherwise
 original_slug: Web/XSLT/Element/otherwise
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:otherwise>` est utilisé pour définir une action qui doit être exécutée lorsqu'aucune condition `<xsl:when>` ne s'applique. Elle est comparable aux instructions `else` ou `default` d'autres langages de programmation.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/output/index.md
+++ b/files/fr/web/xml/xslt/reference/element/output/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/output
 original_slug: Web/XSLT/Element/output
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:output>` contrôle les caractéristiques du document de sortie. Pour fonctionner correctement dans Netscape, cet élément doit être utilisé, avec l'attribut `method`. À partir de Netscape 7.0, `method="text"` fonctionne comme prévu.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/param/index.md
+++ b/files/fr/web/xml/xslt/reference/element/param/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/param
 original_slug: Web/XSLT/Element/param
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:param>` définit un paramètre par son nom et, éventuellement, lui attribue une valeur par défaut. Lorsqu'il est utilisé comme élément de premier niveau, le paramètre est global. Utilisé dans un élément `<xsl:template>`, le paramètre est local à ce modèle. Dans ce dernier cas, il doit être le premier élément enfant du modèle.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/preserve-space/index.md
+++ b/files/fr/web/xml/xslt/reference/element/preserve-space/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/preserve-space
 original_slug: Web/XSLT/Element/preserve-space
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:preserve-space>` définit les éléments du document source pour lesquels les espaces doivent être préservées. Si il y a plus d'un élément, leurs noms doivent être séparés par des espaces. La politique par défaut est de conserver les espaces, cet élément n'est donc utile que pour contrer l'effet de `<xsl:strip-space>`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/processing-instruction/index.md
+++ b/files/fr/web/xml/xslt/reference/element/processing-instruction/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/processing-instruction
 original_slug: Web/XSLT/Element/processing-instruction
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:processing-instruction>` écrit une instruction de traitement dans le document de sortie.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/sort/index.md
+++ b/files/fr/web/xml/xslt/reference/element/sort/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/sort
 original_slug: Web/XSLT/Element/sort
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:sort>` définit les paramètres de tri pour des nœuds sélectionnés par `<xsl:apply-templates>` ou par `<xsl:for-each>`.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/strip-space/index.md
+++ b/files/fr/web/xml/xslt/reference/element/strip-space/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/strip-space
 original_slug: Web/XSLT/Element/strip-space
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:strip-space>` définit les éléments du document source dont les noeuds descendants ne contenant que des espaces doivent être supprimés.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/stylesheet/index.md
+++ b/files/fr/web/xml/xslt/reference/element/stylesheet/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/stylesheet
 original_slug: Web/XSLT/Element/stylesheet
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:stylesheet>` (ou son équivalent `<xsl:transform>`) est l'élément le plus externe d'une feuille de style, celui qui contient tout les autres éléments.
 
 ### Déclaration de l'espace de nommage

--- a/files/fr/web/xml/xslt/reference/element/template/index.md
+++ b/files/fr/web/xml/xslt/reference/element/template/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/template
 original_slug: Web/XSLT/Element/template
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:template>` définit un modèle produisant une sortie. Au moins l'un des atttributs match et set doit posséder une valeur.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/text/index.md
+++ b/files/fr/web/xml/xslt/reference/element/text/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/text
 original_slug: Web/XSLT/Element/text
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:text>` écrit un texte littéral dans l'arbre de sortie. Il peut contenir des `#PCDATA`, du texte littéral, et des références aux entités.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/transform/index.md
+++ b/files/fr/web/xml/xslt/reference/element/transform/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/transform
 original_slug: Web/XSLT/Element/transform
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:transform>` est l'équivalent exact de l'élément [`<xsl:stylesheet>`](/fr/XSLT/stylesheet).
 
 ### Support Gecko

--- a/files/fr/web/xml/xslt/reference/element/value-of/index.md
+++ b/files/fr/web/xml/xslt/reference/element/value-of/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/value-of
 original_slug: Web/XSLT/Element/value-of
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:value-of>` évalue une expression XPath, la convertit en chaîne et écrit cette chaîne dans l'arbre de sortie.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/variable/index.md
+++ b/files/fr/web/xml/xslt/reference/element/variable/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/variable
 original_slug: Web/XSLT/Element/variable
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:variable>` déclare une variable globale ou locale dans une feuille de style et lui attribue une valeur. Comme XSLT ne permet pas d'effet de bord, une fois que la valeur de la variable est établie, elle reste la même jusqu'à ce que la variable soit hors de portée.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/when/index.md
+++ b/files/fr/web/xml/xslt/reference/element/when/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/when
 original_slug: Web/XSLT/Element/when
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:when>` apparaît toujours dans un élément `<xsl:choose>`, et se comporte comme une structure conditionelle 'case'.
 
 ### Syntaxe

--- a/files/fr/web/xml/xslt/reference/element/with-param/index.md
+++ b/files/fr/web/xml/xslt/reference/element/with-param/index.md
@@ -4,8 +4,6 @@ slug: Web/XML/XSLT/Reference/Element/with-param
 original_slug: Web/XSLT/Element/with-param
 ---
 
-{{XsltSidebar}}
-
 L'élément `<xsl:with-param>` définit la valeur d'un paramètre à passer à un modèle.
 
 ### Syntaxe


### PR DESCRIPTION
### Description

Dans l'objectif actuel de https://github.com/orgs/mdn/projects/44 d'effectuer le nettoyage des pages du MDN pour les 1 an de cycle de maintenance, et afin d'accélérer l'obsolescence des macros de barre latérale qui ne sont plus du tout utilisées sur le MDN anglais ; cette mise à jour à pour objectif de cibler une macro liée à un thème et la supprimer sur toutes les pages.

### Motivation

- Aligner les pages au MDN.
- Préparer la possible suppression de ces macros à l'avenir.
- Éviter de surcharger l'interpréteur de page avec des macros obsolètes.
- Gagner en lisibilité sur les pages Markdown pour les futur·e·s contributeur·ice·s.

### Additional details

_none_

### Related issues and pull requests

Related to https://github.com/mdn-fr/documentation/issues/88
