### PR TITLE
fix(fr): `@mdn/dex` error on escaped `<` in macros

### DIFF
--- a/files/fr/web/api/node/baseuri/index.md
+++ b/files/fr/web/api/node/baseuri/index.md
@@ -26,7 +26,7 @@ Une chaîne de caractères représentant l'URL de base du nœud ({{DOMxRef("Node
 
 ## Exemples
 
-### Sans \<base>
+### Sans `<base>`
 
 ```html
 <output>Pas calculé</output>
@@ -37,9 +37,9 @@ const sortie = document.querySelector("output");
 sortie.value = sortie.baseURI;
 ```
 
-{{EmbedLiveSample("Sans \<base>", "100%", 40)}}
+{{EmbedLiveSample("Sans `<base>`", "100%", 40)}}
 
-### Avec \<base>
+### Avec `<base>`
 
 ```html
 <base href="https://developer.mozilla.org/modified_base_uri/" />
@@ -51,7 +51,7 @@ const sortie = document.querySelector("output");
 sortie.value = sortie.baseURI;
 ```
 
-{{EmbedLiveSample("Avec \<base>", "100%", 40)}}
+{{EmbedLiveSample("Avec `<base>`", "100%", 40)}}
 
 ## Spécifications
 


### PR DESCRIPTION
### Description

In objective to check sometimes all tools and get errors from updates and changes of this tools, i've detected this entries:

```bash
ERROR page{locale="fr" slug="Web/API/Node/baseURI" file="/home/runner/work/dex/dex/mdn/translated-content/files/fr/web/api/node/baseuri/index.md"}:page{locale="fr" slug="Web/API/Node/baseURI" file="/home/runner/work/dex/dex/mdn/translated-content/files/fr/web/api/node/baseuri/index.md"}: rari_doc::templ::parser: invalid char, '<' break at 6 source="templ_parser"
ERROR page{locale="fr" slug="Web/API/Node/baseURI" file="/home/runner/work/dex/dex/mdn/translated-content/files/fr/web/api/node/baseuri/index.md"}:page{locale="fr" slug="Web/API/Node/baseURI" file="/home/runner/work/dex/dex/mdn/translated-content/files/fr/web/api/node/baseuri/index.md"}: rari_doc::templ::parser: invalid char, '<' break at 6 source="templ_parser"
```

The error comes from `EmbedLiveSample` with escaped &lt;.

### Motivation

Fixing the errors reported in DEX and RARI by updating titles and macros args with backticked titles instead of escaped.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

https://github.com/mdn/dex/actions/runs/34070779851/job/101587598189
