### PR TITLE
ci: identify PR by head SHA in `workflow_run` workflows

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -43,7 +43,8 @@ jobs:
       - name: Identify PR
         id: identify-pr
         run: |
-          PR_NUMBER=$(gh api "repos/$HEAD_REPO/commits/$HEAD_SHA/pulls" --jq ".[] | select(.base.repo.full_name == \"$BASE_REPO\") | .number")
+          PR_NUMBER=$(gh api "repos/$HEAD_REPO/commits/$HEAD_SHA/pulls" \
+            --jq "[.[] | select(.base.repo.full_name == \"$BASE_REPO\" and .head.sha == \"$HEAD_SHA\") | .number] | first // empty")
           echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
         env:
           BASE_REPO: ${{ github.repository }}

--- a/.github/workflows/pr-reviewdog.yml
+++ b/.github/workflows/pr-reviewdog.yml
@@ -42,7 +42,7 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           PR_NUMBER=$(gh api "repos/$HEAD_REPO/commits/$HEAD_SHA/pulls" \
-            --jq ".[] | select(.base.repo.full_name == \"$BASE_REPO\") | .number")
+            --jq "[.[] | select(.base.repo.full_name == \"$BASE_REPO\" and .head.sha == \"$HEAD_SHA\") | .number] | first // empty")
           echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
       - name: Download artifact


### PR DESCRIPTION
### Description

Fix `pr-reviewdog.yml` and `pr-review-companion.yml` to identify the PR by head SHA, and to emit at most one PR number.

### Motivation

Prevent the workflows from failing on stacked PRs.

### Additional details

`repos/{repo}/commits/{sha}/pulls` returns every open PR a commit belongs to. For the head commit of a PR that another PR is stacked on, that is two PRs, both matching `base.repo.full_name`. `PR_NUMBER` then became a two-line value and `echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT` failed:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '38245'
```

That failed the job and made `Mark status as failure` post a red "PR Reviewdog / Failing" status on the PR, even though linting had passed. See https://github.com/mdn/translated-content/actions/runs/34161721256.

Adding `.head.sha == $HEAD_SHA` drops the stacked PR, and `first // empty` keeps the output single-line regardless.

### Related issues and pull requests

Unblocks https://github.com/mdn/translated-content/pull/38238.