### PR TITLE
fix(fr): broken html attribute title and subtitle of type number

### DIFF
--- a/files/fr/web/html/reference/elements/input/number/index.md
+++ b/files/fr/web/html/reference/elements/input/number/index.md
@@ -1,6 +1,6 @@
 ---
-title: Valeur d'attribut HTML `Valeur d'attribut HTML `<input type="number">``
-short-title: Valeur d'attribut HTML `<input type="number">`
+title: Valeur d'attribut HTML `<input type="number">`
+short-title: <input type="number">
 slug: Web/HTML/Reference/Elements/input/number
 l10n:
   sourceCommit: 3944506d4afeeed774687cf3fd950878c6229bbc


### PR DESCRIPTION
### Description

Title broken during the backtick update of the titles, duplicata of title in the title and subtitle.

### Motivation

MDN cleanup update.

### Additional details

_none_

### Related issues and pull requests

_none_
