### PR TITLE
docs(webassembly): replace `npm adduser` with `npm login`

### DIFF
--- a/files/ja/webassembly/guides/rust_to_wasm/index.md
+++ b/files/ja/webassembly/guides/rust_to_wasm/index.md
@@ -393,7 +393,7 @@ hello-wasm-0.1.0.tgz
 [INFO]: 🎒  packed up your package!
 ```
 
-npm に公開するには、[npm アカウント](https://www.npmjs.com/)が必要であり、 [`npm adduser`](https://docs.npmjs.com/cli/v10/commands/npm-adduser/) を使用してマシンを認証する必要があります。準備ができたら、内部で `npm publish` を呼び出す `wasm-pack` を使用して公開することができます。
+npm に公開するには、[npm アカウント](https://www.npmjs.com/)が必要であり、 [`npm login`](https://docs.npmjs.com/cli/v11/commands/npm-login/) を使用してマシンを認証する必要があります。準備ができたら、内部で `npm publish` を呼び出す `wasm-pack` を使用して公開することができます。
 
 ```bash
 wasm-pack publish

--- a/files/ko/webassembly/guides/rust_to_wasm/index.md
+++ b/files/ko/webassembly/guides/rust_to_wasm/index.md
@@ -46,10 +46,10 @@ Node.js와 npm을 설치하려면 [Get npm!](https://www.npmjs.com/get-npm) 페�
 
 npm 계정을 만드려면 [npm 가입 페이지](https://www.npmjs.com/signup) 에서 양식을 작성하시면 됩니다.
 
-그 다음은, 명령줄에서 `npm adduser` 명령을 실행합니다.
+그 다음은, 명령줄에서 `npm login` 명령을 실행합니다.
 
 ```bash
-    $ npm adduser
+    $ npm login
     Username: yournpmusername
     Password:
     Email: (this IS public) you@example.com

--- a/files/ru/webassembly/guides/rust_to_wasm/index.md
+++ b/files/ru/webassembly/guides/rust_to_wasm/index.md
@@ -45,10 +45,10 @@ cargo install wasm-pack
 
 Чтобы создать npm-аккаунт, посетите [npm signup](https://www.npmjs.com/signup) станицу и заполните форму.
 
-Дальше запустите в командой строке `npm adduser`:
+Дальше запустите в командой строке `npm login`:
 
 ```bash
-> npm adduser
+> npm login
 Username: yournpmusername
 Password:
 Email: (this IS public) you@example.com

--- a/files/zh-cn/webassembly/guides/rust_to_wasm/index.md
+++ b/files/zh-cn/webassembly/guides/rust_to_wasm/index.md
@@ -43,10 +43,10 @@ cargo install wasm-pack
 
 在 [npm signup page](https://www.npmjs.com/signup) 注册 npm 账户，并填写表格。
 
-接下来，在命令行中运行 `npm adduser`:
+接下来，在命令行中运行 `npm login`:
 
 ```bash
-> npm adduser
+> npm login
 Username: yournpmusername
 Password:
 Email: (this IS public) you@example.com


### PR DESCRIPTION
### Description

Update the Rust to Wasm guide to use `npm login` instead of `npm adduser`, in `ja`, `ko`, `ru` and `zh-cn`.

### Motivation

`npm adduser` was removed in npm 12, so readers are told to run a command that no longer exists.

### Additional details

- `npm login` has been the documented alias for years, so this is a rename rather than a change in instructions. In `ja`, the link now points at `npm-login` in the current (v11) CLI docs instead of `npm-adduser` in the v10 docs.
- `ko`, `ru` and `zh-cn` still show the legacy interactive prompts of a much older en-US revision. Only the command name is changed here, leaving the wider staleness for a proper re-translation.

### Related issues and pull requests

Ports https://github.com/mdn/content/pull/45568.

Part of mdn/fred#1868.
