### PR TITLE
[ko] word-break 문서 최신 원문과 동기화

### DIFF
--- a/files/ko/web/css/reference/properties/word-break/index.md
+++ b/files/ko/web/css/reference/properties/word-break/index.md
@@ -1,10 +1,12 @@
 ---
-title: word-break
+title: "`word-break` CSS 속성"
+short-title: word-break
 slug: Web/CSS/Reference/Properties/word-break
-original_slug: Web/CSS/word-break
+l10n:
+  sourceCommit: bcbb4bd6a80292c0663b723d5466759cfaaa8315
 ---
 
-[CSS](/ko/docs/Web/CSS) **`word-break`** 속성은 텍스트가 자신의 콘텐츠 박스 밖으로 오버플로 할 때 줄을 바꿀 지 지정합니다.
+[CSS](/ko/docs/Web/CSS) **`word-break`** 속성은 텍스트가 자신의 콘텐츠 박스 밖으로 오버플로 할 때 줄을 바꿀지 지정합니다.
 
 {{InteractiveExample("CSS Demo: word-break")}}
 
@@ -50,17 +52,20 @@ word-break: break-word;
 word-break: normal;
 word-break: break-all;
 word-break: keep-all;
-word-break: break-word; /* 사용 안함 */
+word-break: auto-phrase; /* 실험적 */
+word-break: break-word; /* 사용 중단 */
 
 /* 전역 값 */
 word-break: inherit;
 word-break: initial;
+word-break: revert;
+word-break: revert-layer;
 word-break: unset;
 ```
 
 `word-break` 속성은 아래의 값 중 하나를 선택해서 지정할 수 있습니다.
 
-<h3 class="brush:css" id="값">값</h3>
+### 값
 
 - `normal`
   - : 기본 줄 바꿈 규칙을 사용합니다.
@@ -68,15 +73,19 @@ word-break: unset;
   - : 오버플로를 방지하기 위해서는 어떠한 두 문자 사이에서도 줄 바꿈이 발생할 수 있습니다. (한중일 텍스트 제외)
 - `keep-all`
   - : 한중일(CJK) 텍스트에서는 줄을 바꿀 때 단어를 끊지 않습니다. 비 CJK 텍스트에서는 `normal`과 동일합니다.
-- `break-word` {{Deprecated_inline}}
+- `auto-phrase`
+  - : `word-break: normal`과 같은 효과를 내지만, 언어별 분석을 통해 자연스러운 구절 중간에서 줄을 바꾸지 않도록 줄 바꿈 위치를 개선합니다.
+- `break-word`
   - : 실제 {{cssxref("overflow-wrap")}} 속성에 상관하지 않고, `word-break: normal`과 `overflow-wrap: anywhere`를 설정한 것과 같은 효과를 냅니다.
 
 > [!NOTE]
 > `word-break: break-word`와 `overflow-wrap: break-word`({{cssxref("overflow-wrap")}} 참고)와 달리, `word-break: break-all`은 텍스트의 오버플로가 시작하는 정확한 지점에서 줄을 바꿉니다. 단어 전체를 다음 줄로 이동하면 중간을 끊지 않아도 될 상황에서도 마찬가지입니다.
 
+명세서에는 `manual`이라는 값도 있지만, 아직 이 값을 지원하는 브라우저는 없습니다. 구현된다면 `manual`은 `word-break: normal`과 같은 효과를 내되, 동남아시아 언어에서는 줄을 바꿀 위치를 자동으로 찾지 않습니다. 이런 언어에서는 사용자 에이전트가 적절하지 않은 위치에서 줄을 바꾸는 경우가 많아 이 값이 필요합니다. `manual`을 사용하면 적절한 위치에 직접 줄 바꿈을 넣을 수 있습니다.
+
 ## 형식 정의
 
-{{cssinfo}}
+{{CSSInfo}}
 
 ## 형식 구문
 
@@ -108,7 +117,21 @@ word-break: unset;
   グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉
 </p>
 
-<p>4. <code>word-break: break-word</code></p>
+<p>4. <code>word-break: manual</code></p>
+<p class="manual narrow">
+  This is a long and Honorificabilitudinitatibus califragilisticexpialidocious
+  Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu
+  グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉
+</p>
+
+<p>5. <code>word-break: auto-phrase</code></p>
+<p class="autoPhrase narrow">
+  This is a long and Honorificabilitudinitatibus califragilisticexpialidocious
+  Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu
+  グレートブリテンおよび北アイルランド連合王国という言葉は本当に長い言葉
+</p>
+
+<p>6. <code>word-break: break-word</code></p>
 <p class="breakWord narrow">
   This is a long and Honorificabilitudinitatibus califragilisticexpialidocious
   Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu
@@ -120,10 +143,13 @@ word-break: unset;
 
 ```css
 .narrow {
-  padding: 5px;
+  padding: 10px;
   border: 1px solid;
-  display: table;
-  max-width: 100%;
+  width: 500px;
+  margin: 0 auto;
+  font-size: 20px;
+  line-height: 1.5;
+  letter-spacing: 1px;
 }
 
 .normal {
@@ -138,6 +164,14 @@ word-break: unset;
   word-break: keep-all;
 }
 
+.manual {
+  word-break: manual;
+}
+
+.autoPhrase {
+  word-break: auto-phrase;
+}
+
 .breakWord {
   word-break: break-word;
 }
@@ -145,7 +179,7 @@ word-break: unset;
 
 {{EmbedLiveSample('예제', '100%', 600)}}
 
-## 명세
+## 명세서
 
 {{Specifications}}
 
@@ -156,3 +190,7 @@ word-break: unset;
 ## 같이 보기
 
 - {{cssxref("overflow-wrap")}}
+- {{cssxref("white-space")}}
+- {{cssxref("hyphens")}}
+- {{cssxref("line-break")}}
+- [텍스트 줄 바꿈 안내서](/ko/docs/Web/CSS/Guides/Text/Wrapping_breaking_text)


### PR DESCRIPTION
### Description

한국어 `word-break` 문서를 최신 영문 문서에 맞춰 동기화합니다.

- 구문에 `auto-phrase`, `revert`, `revert-layer` 반영
- `auto-phrase`의 동작과 명세서에만 있는 `manual`에 관한 설명 번역
- `manual`, `auto-phrase` 예제 추가 및 예제 CSS를 원문과 동기화
- 제목과 헤딩을 원문 구조에 맞추고 `{{CSSInfo}}` 매크로 표기 정리
- 같이 보기에 빠져 있던 `white-space`, `hyphens`, `line-break`, 텍스트 줄 바꿈 안내서 링크 추가
- 번역 기준 커밋을 `l10n.sourceCommit`에 기록

변경 대상은 `files/ko/web/css/reference/properties/word-break/index.md` 한 파일입니다. 줄 바꿈 동작을 비교하는 예제의 다국어 텍스트는 비교 목적이 훼손되지 않도록 원문을 그대로 두었습니다.

`original_slug`는 함께 제거했습니다. 저장소의 `.front-matter-config.json`은 이 키를 `/conflicting`과 `/orphaned` 문서에만 두도록 설명하고 있는데, 이 문서는 두 경우에 해당하지 않습니다.

### Motivation

`word-break: auto-phrase`의 브라우저 호환성 정보를 수정하는 기여를 하면서 한국어 문서에 해당 값의 설명과 예제가 통째로 빠져 있는 것을 확인했습니다. 한국어 독자도 영문 문서와 같은 설명과 예제를 볼 수 있도록 번역을 갱신합니다.

### Additional details

번역 기준 영문 커밋: https://github.com/mdn/content/commit/bcbb4bd6a80292c0663b723d5466759cfaaa8315 (이 문서를 마지막으로 수정한 커밋)

검증:

- `markdownlint-cli2`, `check-url-locale`, `prettier -c`, `autocorrect --lint` 모두 통과
- 프런트매터를 `.front-matter-config.json` 스키마와 대조: 허용되지 않은 키 없음, 키 순서와 길이 제한 충족
- 코드 블록 9개를 원문과 대조: 번역한 주석 3줄을 빼면 모두 동일
- 문서 구조(헤딩·매크로·값 목록·같이 보기 항목) 34개 항목을 원문과 1:1 대조
- Rari로 변경 문서를 빌드: `No issues found in 101 files`(변경 문서 1개 + SPA 100개)
- 렌더링 결과에서 제목, 헤딩 8개, 예제 임베드, 호환성 컴포넌트, 추가한 문장 확인
- 브라우저에서 예제를 실제로 실행해 보는 확인은 하지 않았습니다

### Related issues and pull requests

Fixes #38333

관련 BCD 기여: https://github.com/mdn/browser-compat-data/pull/30360
