### PR TITLE
fix(zh-tw): macro syntax error in HTTP status page

### DIFF
--- a/files/zh-tw/web/http/reference/status/index.md
+++ b/files/zh-tw/web/http/reference/status/index.md
@@ -133,7 +133,7 @@ HTTP 回應狀態碼表示特定的 [HTTP](/zh-TW/docs/Web/HTTP) 請求是否已
 - {{HTTPStatus(428, "428 Precondition Required")}}
   - : 原始伺服器需要請求是[條件式的](/zh-TW/docs/Web/HTTP/Guides/Conditional_requests)。此回應旨在防止「丟失更新」問題，即當用戶端 {{HTTPMethod("GET")}} 資源的狀態、修改它並將其 {{HTTPMethod("PUT")}} 回伺服器時，同時第三方已在伺服器上修改了狀態，導致衝突。
 - {{HTTPStatus(429, "429 Too Many Requests")}}
-  - : 用戶在給定時間內發送了過多的請求（{{Glossary("Rate_limit","rate limiting", "速率限制"}}）。
+  - : 用戶在給定時間內發送了過多的請求（{{Glossary("Rate_limit", "速率限制")}}）。
 - {{HTTPStatus(431, "431 Request Header Fields Too Large")}}
   - : 伺服器不願處理該請求，因為其標頭欄位太大。減小請求標頭欄位的大小後，可以重新提交請求。
 - {{HTTPStatus(451, "451 Unavailable For Legal Reasons")}}


### PR DESCRIPTION
### Description

Fix a `Glossary` macro in Web/HTTP/Reference/Status that was missing its closing parenthesis and passed three arguments. The macro only accepts a term and a display name, so it now renders the Chinese display name.

### Motivation

Ensure the affected macros render as links instead of leaving a syntax error (and raw macro text) in the page.

### Additional details

These errors are newly flagged as `templ-syntax-error` by rari 0.2.34, since https://github.com/mdn/rari/pull/868.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->