### PR TITLE
fix(ja): use `APIRef` instead of empty `DefaultAPISidebar`

### DIFF
--- a/files/ja/web/api/vttcue/line/index.md
+++ b/files/ja/web/api/vttcue/line/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: 532ecbca7b68e7defa4612bc7b00885a13163641
 ---
 
-{{DefaultAPISidebar("")}}
+{{APIRef("WebVTT")}}
 
 **`line`** は {{domxref("VTTCue")}} インターフェイスのプロパティで、この WebVTT キューのキュー行を表します。
 


### PR DESCRIPTION
### Description

Fix the sidebar macro on `Web/API/VTTCue/line` by replacing `{{DefaultAPISidebar("")}}` with `{{APIRef("WebVTT")}}`.

### Motivation

Prevent a rendering error: `DefaultAPISidebar` argument 1 (group) must not be empty.

### Additional details

All other `VTTCue` pages in `files/ja/web/api/vttcue/` already use `{{APIRef("WebVTT")}}`, matching the en-US source.

### Related issues and pull requests

Part of mdn/fred#1462.
