### PR TITLE
fix(pt-br): correct `jsxref` arguments for property accessors

### DIFF
--- a/files/pt-br/orphaned/web/javascript/reference/errors/undefined_prop/index.md
+++ b/files/pt-br/orphaned/web/javascript/reference/errors/undefined_prop/index.md
@@ -18,7 +18,7 @@ ReferenceError: reference to undefined property "x" (Firefox)
 
 ## O que está errado?
 
-O script tentou acessar uma propriedade de objeto que não existe. Existem duas maneiras de acessar propriedades; veja a página de referência {{jsxref ("Operators / Property_Accessors", "property accessors", 0, 1)}} para saber mais sobre eles.
+O script tentou acessar uma propriedade de objeto que não existe. Existem duas maneiras de acessar propriedades; veja a página de referência {{jsxref("Operators/Property_accessors", "property accessors", "", 1)}} para saber mais sobre eles.
 
 ## Exemplos
 
@@ -52,4 +52,4 @@ if (foo.hasOwnProperty("bar")) {
 
 ## Veja também
 
-- {{jsxref("Operators/Property_accessors", "property accessors", 0, 1)}}
+- {{jsxref("Operators/Property_accessors", "property accessors", "", 1)}}


### PR DESCRIPTION
### Description

Fix the two `jsxref` calls on `orphaned/Web/JavaScript/Reference/Errors/Undefined_prop`:

- pass `""` instead of `0` as argument 3 (anchor)
- remove the stray spaces in `{{jsxref (` and `"Operators / Property_Accessors"`
- use the correct slug casing `Operators/Property_accessors`

### Motivation

Prevent a rendering error: `jsxref` argument 3 (anchor) must be a string.

### Additional details

Argument 4 (`1`, no code formatting) is unchanged, so the rendered link text stays plain text.

### Related issues and pull requests

Part of mdn/fred#1462.
