### PR TITLE
fix(zh-tw): correct `EmbedLiveSample` arguments on `box-sizing`

### DIFF
--- a/files/zh-tw/web/css/reference/properties/box-sizing/index.md
+++ b/files/zh-tw/web/css/reference/properties/box-sizing/index.md
@@ -150,7 +150,7 @@ div {
 
 #### 結果
 
-{{EmbedLiveSample('Box_sizes_with_content-box_and_border-box', "使用 content-box 和 border-box 的盒子尺寸", 'auto', 300)}}
+{{EmbedLiveSample('使用 content-box 和 border-box 的盒子尺寸', 'auto', 300)}}
 
 ## 規範
 


### PR DESCRIPTION
### Description

Fix the `EmbedLiveSample` call on `Web/CSS/Reference/Properties/box-sizing` by dropping the leftover English sample ID and keeping only the translated heading as the ID.

### Motivation

Prevent a rendering error: `embedlivesample` argument 4 (`_deprecated_3`) must be a string.

### Additional details

Before: `{{EmbedLiveSample("Box_sizes_with_content-box_and_border-box", "使用 content-box 和 border-box 的盒子尺寸", "auto", 300)}}`

After: `{{EmbedLiveSample("使用 content-box 和 border-box 的盒子尺寸", "auto", 300)}}`

The section heading was translated, so the sample ID has to be the translated one for the example to resolve. The extra argument had shifted `auto` (width) and `300` (height) into arguments 3 and 4.

### Related issues and pull requests

Part of mdn/fred#1462.
