### PR TITLE
chore: drop stale + already-clean entries from `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,37 +11,9 @@ build/
 /files/**/orphaned/**/*.md
 
 # XXX Ignored until https://github.com/prettier/prettier/issues/11828 is fixed
-/files/es/learn/css/howto/css_faq/index.md
-/files/fr/glossary/cross_axis/index.md
-/files/fr/glossary/flex/index.md
-/files/fr/glossary/flex_container/index.md
-/files/fr/glossary/flexbox/index.md
-/files/fr/glossary/grid_axis/index.md
-/files/fr/glossary/grid_lines/index.md
-/files/fr/glossary/main_axis/index.md
-/files/fr/learn/server-side/django/forms/index.md
-/files/fr/web/css/align-self/index.md
-/files/fr/web/css/justify-content/index.md
-/files/fr/web/css/place-items/index.md
-/files/fr/web/css/place-self/index.md
 /files/fr/web/javascript/reference/global_objects/array/includes/index.md
 /files/fr/web/javascript/reference/global_objects/intl/displaynames/of/index.md
 /files/ja/web/api/audiobuffer/audiobuffer/index.md
-/files/ja/web/api/history_api/working_with_the_history_api/index.md
-/files/ja/web/javascript/reference/global_objects/intl/displaynames/of/index.md
-/files/ja/web/javascript/reference/regular_expressions/character_class_escape/index.md
-/files/ja/web/svg/content_type/index.md
-/files/ko/web/css/css_flow_layout/block_and_inline_layout_in_normal_flow/index.md
-/files/pt-br/learn/server-side/django/forms/index.md
-/files/pt-br/web/svg/content_type/index.md
-/files/ru/learn/server-side/django/forms/index.md
-/files/ru/learn/server-side/django/introduction/index.md
-/files/ru/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
-/files/ru/web/css/computed_value/index.md
-/files/ru/web/css/justify-content/index.md
-/files/ru/web/css/margin-top/index.md
-/files/ru/web/html/element/abbr/index.md
 /files/ru/web/javascript/guide/expressions_and_operators/index.md
-/files/zh-cn/learn/server-side/django/forms/index.md
 /files/zh-cn/web/javascript/reference/operators/exponentiation/index.md
 /files/zh-cn/web/javascript/reference/operators/exponentiation_assignment/index.md


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update `.prettierignore` to drop 28 entries from the block ignored pending prettier/prettier#11828:

- 18 paths that no longer exist in the repository.
- 10 files (7 fr glossary pages, 3 ja pages) whose Prettier output is already identical to the file.

### Motivation

Prevent stale ignore entries from accumulating now that the upstream issue is resolved.

### Additional details

No content files change. `npx prettier --check` passes for the 10 un-ignored files. The 6 remaining entries in the block are handled in follow-up PRs, one per locale, stacked on this one.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
