### PR TITLE
chore(fr): un-ignore Prettier for `Array.includes()` + `Intl.DisplayNames.of()`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,8 +11,6 @@ build/
 /files/**/orphaned/**/*.md
 
 # XXX Ignored until https://github.com/prettier/prettier/issues/11828 is fixed
-/files/fr/web/javascript/reference/global_objects/array/includes/index.md
-/files/fr/web/javascript/reference/global_objects/intl/displaynames/of/index.md
 /files/ja/web/api/audiobuffer/audiobuffer/index.md
 /files/ru/web/javascript/guide/expressions_and_operators/index.md
 /files/zh-cn/web/javascript/reference/operators/exponentiation/index.md

--- a/files/fr/web/javascript/reference/global_objects/array/includes/index.md
+++ b/files/fr/web/javascript/reference/global_objects/array/includes/index.md
@@ -16,12 +16,12 @@ const array1 = [1, 2, 3];
 console.log(array1.includes(2));
 // Résultat attendu : true
 
-const pets = ['chat', 'chien', 'chauve-souris'];
+const pets = ["chat", "chien", "chauve-souris"];
 
-console.log(pets.includes('chat'));
+console.log(pets.includes("chat"));
 // Résultat attendu : true
 
-console.log(pets.includes('at'));
+console.log(pets.includes("at"));
 // Résultat attendu : false
 ```
 

--- a/files/fr/web/javascript/reference/global_objects/intl/displaynames/of/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/displaynames/of/index.md
@@ -11,15 +11,15 @@ La méthode **`of()`** des instances de {{JSxRef("Intl.DisplayNames")}} reçoit 
 {{InteractiveExample("Démonstration JavaScript&nbsp;: Intl.DisplayNames.prototype.of()")}}
 
 ```js interactive-example
-const regionNamesInEnglish = new Intl.DisplayNames(['en'], { type: 'region' });
-const regionNamesInTraditionalChinese = new Intl.DisplayNames(['zh-Hant'], {
-  type: 'region',
+const regionNamesInEnglish = new Intl.DisplayNames(["en"], { type: "region" });
+const regionNamesInTraditionalChinese = new Intl.DisplayNames(["zh-Hant"], {
+  type: "region",
 });
 
-console.log(regionNamesInEnglish.of('US'));
+console.log(regionNamesInEnglish.of("US"));
 // Résultat attendu : "United States"
 
-console.log(regionNamesInTraditionalChinese.of('US'));
+console.log(regionNamesInTraditionalChinese.of("US"));
 // Résultat attendu : "美國"
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update `.prettierignore` to un-ignore two fr pages and format them with Prettier.

### Motivation

Ensure these pages are formatted consistently now that prettier/prettier#11828 is resolved.

### Additional details

Only quote style in the interactive example code blocks changes (single to double quotes).

### Related issues and pull requests

**Depends on:** #38389

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
