### PR TITLE
chore(ja): un-ignore Prettier for `AudioBuffer()` constructor page

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,7 +11,6 @@ build/
 /files/**/orphaned/**/*.md
 
 # XXX Ignored until https://github.com/prettier/prettier/issues/11828 is fixed
-/files/ja/web/api/audiobuffer/audiobuffer/index.md
 /files/ru/web/javascript/guide/expressions_and_operators/index.md
 /files/zh-cn/web/javascript/reference/operators/exponentiation/index.md
 /files/zh-cn/web/javascript/reference/operators/exponentiation_assignment/index.md

--- a/files/ja/web/api/audiobuffer/audiobuffer/index.md
+++ b/files/ja/web/api/audiobuffer/audiobuffer/index.md
@@ -30,12 +30,12 @@ new AudioBuffer(options)
       - : バッファーのサンプリングレート（単位: Hz）。既定では、このオブジェクトを作成する際に使用した `context` のサンプリングレートになります。ユーザーエージェントは 8,000 Hz から 96,000 Hz までのサンプリングレートに対応する必要があります（ただし、この範囲外でもかまいません）。
     - `channelCount`
       - : ノードへの任意の入力に[アップミキシングとダウンミキシング](/ja/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#アップミキシングとダウンミキシング)接続する際に使用するチャンネル数を決めるための整数を表します。
-      （詳しくは {{domxref("AudioNode.channelCount")}} を参照してください。）その使い方や正確な定義は `channelCountMode` の値に依存します。
+        （詳しくは {{domxref("AudioNode.channelCount")}} を参照してください。）その使い方や正確な定義は `channelCountMode` の値に依存します。
     - `channelCountMode`
       - : ノードの入力と出力の間でチャンネルを一致させる方法を記述する列挙型の値を表します。（既定値を含む詳細は {{domxref("AudioNode.channelCountMode")}} を参照してください。）
     - `channelInterpretation`
       - : チャンネルの意味を記述した列挙型の値を表します。この解釈により、音声の[アップミキシングとダウンミキシング](/ja/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#アップミキシングとダウンミキシング)がどのように行われるかが定義されることになります。
-      指定可能な値は `"speakers"` または `"discrete"` です。（既定値を含むより詳細な情報については {{domxref("AudioNode.channelCountMode")}} を参照してください。）
+        指定可能な値は `"speakers"` または `"discrete"` です。（既定値を含むより詳細な情報については {{domxref("AudioNode.channelCountMode")}} を参照してください。）
 
 #### 非推奨の引数
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update `.prettierignore` to un-ignore the ja `AudioBuffer()` constructor page and format it with Prettier.

### Motivation

Ensure this page is formatted consistently now that prettier/prettier#11828 is resolved.

### Additional details

Only the indentation of two continuation lines in the nested parameter list changes (6 to 8 spaces). Rendered output is unchanged.

### Related issues and pull requests

**Depends on:** #38390

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

