### PR TITLE
chore(zh-cn): un-ignore Prettier for exponentiation operator pages

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,5 +12,3 @@ build/
 
 # XXX Ignored until https://github.com/prettier/prettier/issues/11828 is fixed
 /files/ru/web/javascript/guide/expressions_and_operators/index.md
-/files/zh-cn/web/javascript/reference/operators/exponentiation/index.md
-/files/zh-cn/web/javascript/reference/operators/exponentiation_assignment/index.md

--- a/files/zh-cn/web/javascript/reference/operators/exponentiation/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/exponentiation/index.md
@@ -3,8 +3,6 @@ title: 幂（**）
 slug: Web/JavaScript/Reference/Operators/Exponentiation
 ---
 
-
-
 **幂**（**`**`**）运算符返回第一个操作数取第二个操作数的幂的结果。它等价于 {{jsxref("Math.pow()")}}，不同之处在于，它还接受 [BigInt](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/BigInt) 作为操作数。
 
 {{InteractiveExample("JavaScript Demo: Expressions - Exponentiation operator")}}

--- a/files/zh-cn/web/javascript/reference/operators/exponentiation_assignment/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/exponentiation_assignment/index.md
@@ -5,8 +5,6 @@ l10n:
   sourceCommit: 145e8c316fcdd8f67f3595fc52b0bbfacf7b949d
 ---
 
-
-
 **幂赋值**（**`**=`**）对两个操作数执行[幂运算](/zh-CN/docs/Web/JavaScript/Reference/Operators/Exponentiation)，并将结果赋给左操作数。
 
 {{InteractiveExample("JavaScript Demo: Expressions - Exponentiation assignment operator")}}
@@ -20,7 +18,7 @@ console.log((a **= 2));
 console.log((a **= 0));
 // Expected output: 1
 
-console.log((a **= 'hello'));
+console.log((a **= "hello"));
 // Expected output: NaN
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update `.prettierignore` to un-ignore the zh-cn `**` and `**=` operator pages and format them with Prettier.

### Motivation

Ensure these pages are formatted consistently now that prettier/prettier#11828 is resolved.

### Additional details

Only redundant blank lines after the front matter and quote style in one example code block change.

### Related issues and pull requests

**Depends on:** #38391

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

