### PR TITLE
ci: run `pull_request` workflows on stacked PRs

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -2,8 +2,6 @@ name: Markdownlint (global)
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - .nvmrc
       - .markdownlint-cli2.jsonc

--- a/.github/workflows/pr-check_json.yml
+++ b/.github/workflows/pr-check_json.yml
@@ -2,8 +2,6 @@ name: JSON lint
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - .nvmrc
       - "**/*.json"

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -2,8 +2,6 @@ name: Check Redirects
 
 on:
   pull_request:
-    branches:
-      - main
 
 permissions: {}
 

--- a/.github/workflows/pr-check_yml.yml
+++ b/.github/workflows/pr-check_yml.yml
@@ -2,8 +2,6 @@ name: Lint YAML
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - .nvmrc
       - package-lock.json

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -8,8 +8,6 @@ name: PR Test
 
 on:
   pull_request:
-    branches:
-      - main
 
 jobs:
   tests:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update the `pull_request` triggers of PR Test, Markdownlint (global), JSON lint, Check Redirects and Lint YAML to drop the `branches: [main]` filter.

### Motivation

Ensure that these workflows also run for stacked PRs, i.e. PRs that target another PR branch instead of `main`.

### Additional details

Without this, PR Test does not run for stacked PRs, so the PR review companion cannot deploy preview pages (e.g. #38394). mdn/content's `pr-test.yml` already has no branch filter.

### Related issues and pull requests

Part of mdn/fred#1872.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
